### PR TITLE
feat: automatic port management without env variable

### DIFF
--- a/apps/desktop/MULTIPLE_INSTANCES.md
+++ b/apps/desktop/MULTIPLE_INSTANCES.md
@@ -4,60 +4,59 @@ This guide explains how to run multiple Electron instances simultaneously for pa
 
 ## Quick Start
 
-### Method 1: Using Worktrees (Recommended)
+### Method 1: Automatic Port Management (Recommended)
 
-When you create a new worktree via the Superset app, it automatically runs `update-port.sh` which increments the port number in the root `.env`:
+The app automatically manages ports for you! Each instance will:
+- Try to use the last used port (stored in `~/.superset/dev-port.json`)
+- If that port is unavailable, automatically find the next available port in the range (4927-4999)
+- Save the chosen port for next time
 
-```bash
-# Worktree 1 - automatically uses port 4927
-# Worktree 2 - automatically uses port 4928
-# Worktree 3 - automatically uses port 4929
-```
-
-Each worktree reads the port from the root `.env` file, which gets incremented automatically during worktree setup.
-
-### Method 2: Manual Script Execution
-
-Run the port update script manually from the monorepo root:
+Simply run multiple instances:
 
 ```bash
-# Increment port in root .env
-./update-port.sh
+# Terminal 1 - Instance 1
+cd apps/desktop && bun dev
 
-# Then run dev in desktop app
+# Terminal 2 - Instance 2 (will automatically get next available port)
+cd apps/desktop && bun dev
+
+# Terminal 3 - Instance 3 (will automatically get next available port)
 cd apps/desktop && bun dev
 ```
 
-### Method 3: Helper Scripts (Advanced)
+Each instance will automatically select an available port without any configuration needed.
 
-Override the .env port using environment variables:
+### Method 2: Using Worktrees
+
+When you create a new worktree via the Superset app, each worktree will automatically get its own port:
 
 ```bash
-# Terminal 1 - Instance 1 on port 4927
-./dev-instance.sh instance1 4927
-
-# Terminal 2 - Instance 2 on port 4928
-./dev-instance.sh instance2 4928
-
-# Terminal 3 - Instance 3 on port 4929
-./dev-instance.sh instance3 4929
+# Worktree 1 - automatically finds available port
+# Worktree 2 - automatically finds available port
+# Worktree 3 - automatically finds available port
 ```
+
+Ports are managed automatically - no manual configuration needed!
 
 ### Windows
 
-```powershell
-# Terminal 1
-.\dev-instance.ps1 instance1 4927
+Ports are automatically managed on Windows too:
 
-# Terminal 2
-.\dev-instance.ps1 instance2 4928
+```powershell
+# Terminal 1 - Instance 1 (automatically gets available port)
+cd apps\desktop; bun dev
+
+# Terminal 2 - Instance 2 (automatically gets next available port)
+cd apps\desktop; bun dev
 ```
+
+Each instance will automatically select an available port without any configuration needed.
 
 ## How It Works
 
 Each instance runs with:
-- **Separate dev server port** - Configured via `VITE_DEV_SERVER_PORT`
-- **Separate user data directory** - Each instance stores settings, cache, and local storage in `~/.superset-dev-{instance-name}`
+- **Separate dev server port** - Automatically selected from available ports (4927-4999), persisted in `~/.superset/dev-port.json`
+- **Separate user data directory** - Each instance stores settings, cache, and local storage in `~/.superset-dev-{instance-name}` (optional)
 
 This allows you to:
 - Test different branches simultaneously
@@ -67,15 +66,14 @@ This allows you to:
 
 ## Manual Setup
 
-If you prefer not to use the helper scripts:
+If you want to use a custom user data directory:
 
 ```bash
-# Set the port
-export VITE_DEV_SERVER_PORT=4928
-
 # Run with custom user data directory
 bun dev -- --user-data-dir="$HOME/.superset-dev-custom"
 ```
+
+The port will still be automatically selected - no need to configure it manually!
 
 ## User Data Directories
 
@@ -105,9 +103,10 @@ Remove-Item -Recurse -Force "$env:USERPROFILE\.superset-dev-instance1"
 ## Troubleshooting
 
 ### Port already in use
-If you see "Port 4927 is already in use", either:
-1. Stop the other instance using that port
-2. Choose a different port number (4928, 4929, etc.)
+The app automatically handles port conflicts by finding the next available port. If you see port-related issues:
+1. The app will automatically switch to an available port
+2. Check `~/.superset/dev-port.json` to see which port is being used
+3. If needed, delete the config file to reset port selection
 
 ### Instances share the same data
 Make sure each instance uses a different user data directory. Check that the `--user-data-dir` flag is being passed correctly.

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -7,6 +7,7 @@ import { defineConfig, externalizeDepsPlugin } from "electron-vite";
 import injectProcessEnvPlugin from "rollup-plugin-inject-process-env";
 import tsconfigPathsPlugin from "vite-tsconfig-paths";
 import { main, resources } from "./package.json";
+import { getPortSync } from "./src/lib/port-manager";
 import { settings } from "./src/lib/electron-router-dom";
 
 // Load .env from monorepo root
@@ -52,8 +53,8 @@ export default defineConfig({
 		},
 
 		server: {
-			port: Number(process.env.VITE_DEV_SERVER_PORT) || settings.port,
-			strictPort: true, // Fail if port is already in use
+			port: getPortSync(),
+			strictPort: false, // Allow fallback to next available port
 		},
 
 		plugins: [

--- a/apps/desktop/src/lib/electron-router-dom.ts
+++ b/apps/desktop/src/lib/electron-router-dom.ts
@@ -1,10 +1,14 @@
 import { createElectronRouter } from "electron-router-dom";
+import { getPortSync } from "./port-manager";
 
 // Note: Environment variables are loaded in main/index.ts before any imports
-// The port value comes from VITE_DEV_SERVER_PORT in the monorepo root .env file
+// The port value comes from:
+// 1. Last used port from ~/.superset/dev-port.json
+// 2. Default port 4927
+// The port will automatically switch if unavailable (handled by getPort() async function)
 // This module can be safely imported in both main and renderer processes
 export const { Router, registerRoute, settings } = createElectronRouter({
-	port: Number(process.env.VITE_DEV_SERVER_PORT) || 4927,
+	port: getPortSync(),
 	types: {
 		ids: ["main", "about"],
 	},

--- a/apps/desktop/src/lib/port-manager.ts
+++ b/apps/desktop/src/lib/port-manager.ts
@@ -1,0 +1,184 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const DEFAULT_PORT = 4927;
+const PORT_RANGE_START = 4927;
+const PORT_RANGE_END = 4999;
+const CONFIG_DIR = join(homedir(), ".superset");
+const PORT_CONFIG_FILE = join(CONFIG_DIR, "dev-port.json");
+
+interface PortConfig {
+	port: number;
+	lastUsed: string;
+	workspaceId?: string;
+}
+
+/**
+ * Check if a port is available
+ */
+async function isPortAvailable(port: number): Promise<boolean> {
+	return new Promise((resolve) => {
+		const server = createServer();
+
+		server.once("error", (err: NodeJS.ErrnoException) => {
+			if (err.code === "EADDRINUSE") {
+				resolve(false);
+			} else {
+				resolve(false);
+			}
+		});
+
+		server.once("listening", () => {
+			server.close();
+			resolve(true);
+		});
+
+		server.listen(port, "127.0.0.1");
+	});
+}
+
+/**
+ * Find the next available port in the range
+ */
+async function findAvailablePort(startPort: number): Promise<number> {
+	for (let port = startPort; port <= PORT_RANGE_END; port++) {
+		if (await isPortAvailable(port)) {
+			return port;
+		}
+	}
+
+	// If no port is available in the range, start from the beginning
+	for (let port = PORT_RANGE_START; port < startPort; port++) {
+		if (await isPortAvailable(port)) {
+			return port;
+		}
+	}
+
+	throw new Error(
+		`No available ports found in range ${PORT_RANGE_START}-${PORT_RANGE_END}`,
+	);
+}
+
+/**
+ * Load port configuration from disk
+ */
+function loadPortConfig(): PortConfig | null {
+	try {
+		if (!existsSync(PORT_CONFIG_FILE)) {
+			return null;
+		}
+		const data = readFileSync(PORT_CONFIG_FILE, "utf-8");
+		return JSON.parse(data);
+	} catch (error) {
+		console.warn("Failed to load port config:", error);
+		return null;
+	}
+}
+
+/**
+ * Save port configuration to disk
+ */
+function savePortConfig(config: PortConfig): void {
+	try {
+		if (!existsSync(CONFIG_DIR)) {
+			mkdirSync(CONFIG_DIR, { recursive: true });
+		}
+		writeFileSync(PORT_CONFIG_FILE, JSON.stringify(config, null, 2), "utf-8");
+	} catch (error) {
+		console.warn("Failed to save port config:", error);
+	}
+}
+
+/**
+ * Get a workspace identifier based on current working directory
+ */
+function getWorkspaceId(): string {
+	// Use the current working directory as a unique identifier
+	return process.cwd();
+}
+
+/**
+ * Get the port for this workspace/instance
+ * - First tries the last used port from config file (if available)
+ * - If that port is not available, automatically finds the first available port in the range
+ * - If no config exists, finds the first available port starting from the beginning of the range
+ * - Persists the chosen port for next time
+ */
+export async function getPort(): Promise<number> {
+	const workspaceId = getWorkspaceId();
+
+	// 1. Check last used port from config
+	const config = loadPortConfig();
+	if (config?.port) {
+		// Try the last used port first
+		if (await isPortAvailable(config.port)) {
+			// Update last used timestamp
+			savePortConfig({
+				...config,
+				lastUsed: new Date().toISOString(),
+				workspaceId,
+			});
+			return config.port;
+		}
+		console.log(
+			`Port ${config.port} is not available, searching for alternative...`,
+		);
+	}
+
+	// 2. Find the first available port
+	// If we had a config but the port wasn't available, start searching from that port
+	// Otherwise, start from the beginning of the range to find the first available port
+	const startPort = config?.port || PORT_RANGE_START;
+	const availablePort = await findAvailablePort(startPort);
+
+	// Save the new port
+	savePortConfig({
+		port: availablePort,
+		lastUsed: new Date().toISOString(),
+		workspaceId,
+	});
+
+	return availablePort;
+}
+
+/**
+ * Synchronous version for use in config files
+ * Returns the last known port or default, without availability checking
+ * The async version should be called during app initialization to ensure correctness
+ */
+export function getPortSync(): number {
+	// 1. Check config file
+	const config = loadPortConfig();
+	if (config?.port) {
+		return config.port;
+	}
+
+	// 2. Return default
+	return DEFAULT_PORT;
+}
+
+/**
+ * Reset the port configuration (useful for testing or cleanup)
+ */
+export function resetPortConfig(): void {
+	try {
+		if (existsSync(PORT_CONFIG_FILE)) {
+			writeFileSync(
+				PORT_CONFIG_FILE,
+				JSON.stringify(
+					{
+						port: DEFAULT_PORT,
+						lastUsed: new Date().toISOString(),
+					},
+					null,
+					2,
+				),
+				"utf-8",
+			);
+		}
+	} catch (error) {
+		console.warn("Failed to reset port config:", error);
+	}
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -6,6 +6,7 @@ import { config } from "dotenv";
 config({ path: resolve(__dirname, "../../../../.env"), override: true });
 
 import { app } from "electron";
+import { getPort } from "lib/port-manager";
 import { makeAppSetup } from "lib/electron-app/factories/app/setup";
 import { MainWindow } from "./windows/main";
 
@@ -13,6 +14,11 @@ import { MainWindow } from "./windows/main";
 // Each instance will use the same default user data directory
 // To use separate data directories, launch with: --user-data-dir=/path/to/custom/dir
 (async () => {
+	// Initialize port selection before app starts
+	// This ensures we get a consistent available port for this workspace
+	const port = await getPort();
+	console.log(`Using dev server port: ${port}`);
+
 	await app.whenReady();
 	await makeAppSetup(MainWindow);
 })();

--- a/update-port.sh
+++ b/update-port.sh
@@ -1,50 +1,13 @@
 #!/bin/bash
-# Script to create or increment VITE_DEV_SERVER_PORT in .env file
-# Used for running multiple Electron instances with different ports
+# DEPRECATED: This script is no longer needed for port management.
+# Ports are now automatically managed by the Electron app.
+# This script is kept for backward compatibility but does nothing useful.
+# 
+# The app automatically finds available ports (4927-4999) and persists
+# them in ~/.superset/dev-port.json
 
 set -e
 
-ENV_FILE=".env"
-DEFAULT_PORT=4927
-
-# Function to get next available port
-get_next_port() {
-    local current_port=$1
-    local next_port=$((current_port + 1))
-    echo $next_port
-}
-
-# Check if .env exists
-if [ ! -f "$ENV_FILE" ]; then
-    # Create .env from .env.example if it exists, otherwise create new
-    if [ -f ".env.example" ]; then
-        cp .env.example "$ENV_FILE"
-        echo "✓ Created $ENV_FILE from .env.example with default port: $DEFAULT_PORT"
-    else
-        echo "VITE_DEV_SERVER_PORT=$DEFAULT_PORT" > "$ENV_FILE"
-        echo "✓ Created $ENV_FILE with default port: $DEFAULT_PORT"
-    fi
-else
-    # .env exists, check if VITE_DEV_SERVER_PORT is set
-    if grep -q "^VITE_DEV_SERVER_PORT=" "$ENV_FILE"; then
-        # Extract current port
-        current_port=$(grep "^VITE_DEV_SERVER_PORT=" "$ENV_FILE" | cut -d'=' -f2)
-        next_port=$(get_next_port $current_port)
-
-        # Update the port
-        if [[ "$OSTYPE" == "darwin"* ]]; then
-            # macOS
-            sed -i '' "s/^VITE_DEV_SERVER_PORT=.*/VITE_DEV_SERVER_PORT=$next_port/" "$ENV_FILE"
-        else
-            # Linux
-            sed -i "s/^VITE_DEV_SERVER_PORT=.*/VITE_DEV_SERVER_PORT=$next_port/" "$ENV_FILE"
-        fi
-
-        echo "✓ Updated port: $current_port → $next_port"
-    else
-        # VITE_DEV_SERVER_PORT not in .env, append it
-        echo "" >> "$ENV_FILE"
-        echo "VITE_DEV_SERVER_PORT=$DEFAULT_PORT" >> "$ENV_FILE"
-        echo "✓ Added VITE_DEV_SERVER_PORT=$DEFAULT_PORT to $ENV_FILE"
-    fi
-fi
+echo "⚠️  Note: Port management is now automatic. This script is deprecated."
+echo "   The app will automatically select an available port when started."
+echo "   No manual port configuration is needed."


### PR DESCRIPTION
- Remove dependency on VITE_DEV_SERVER_PORT environment variable
- Add automatic port detection and selection (4927-4999 range)
- Ports are persisted in ~/.superset/dev-port.json
- Automatically finds next available port if preferred port is busy
- Update documentation to reflect automatic port management
- Deprecate update-port.sh script (ports now managed automatically)

This allows multiple Electron instances to run simultaneously without manual port configuration. Each instance automatically selects an available port and persists it for future use.

## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->
