### PR TITLE
feat(desktop): open terminal URLs in system browser

### DIFF
--- a/apps/desktop/src/lib/electron-app/factories/app/setup.ts
+++ b/apps/desktop/src/lib/electron-app/factories/app/setup.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow } from "electron";
+import { app, BrowserWindow, shell } from "electron";
 
 import {
 	installExtension,
@@ -53,10 +53,13 @@ export async function makeAppSetup(
 	});
 
 	app.on("web-contents-created", (_, contents) =>
-		contents.on(
-			"will-navigate",
-			(event, _) => !ENVIRONMENT.IS_DEV && event.preventDefault(),
-		),
+		contents.on("will-navigate", (event, url) => {
+			// Always prevent in-app navigation for external URLs
+			if (url.startsWith("http://") || url.startsWith("https://")) {
+				event.preventDefault();
+				shell.openExternal(url);
+			}
+		}),
 	);
 
 	app.on("window-all-closed", () => !PLATFORM.IS_MAC && app.quit());

--- a/apps/desktop/src/lib/electron-app/factories/windows/create.ts
+++ b/apps/desktop/src/lib/electron-app/factories/windows/create.ts
@@ -1,10 +1,19 @@
 import { join } from "node:path";
-import { BrowserWindow } from "electron";
+import { BrowserWindow, shell } from "electron";
 import { registerRoute } from "lib/electron-router-dom";
 import type { WindowProps } from "shared/types";
 
 export function createWindow({ id, ...settings }: WindowProps) {
 	const window = new BrowserWindow(settings);
+
+	// Open external URLs in the system browser instead of Electron
+	window.webContents.setWindowOpenHandler(({ url }) => {
+		if (url.startsWith("http://") || url.startsWith("https://")) {
+			shell.openExternal(url);
+			return { action: "deny" };
+		}
+		return { action: "deny" };
+	});
 
 	registerRoute({
 		id,


### PR DESCRIPTION
## Summary
- External URLs (http/https) clicked in the terminal now open in the user's default system browser instead of within the Electron app
- Added `setWindowOpenHandler` to intercept new window opens and redirect to system browser
- Updated `will-navigate` handler to open external URLs externally instead of just preventing navigation

## Test plan
- [ ] Click an http/https URL in the terminal and verify it opens in the system browser
- [ ] Verify internal app navigation still works correctly
- [ ] Test on macOS (and Windows/Linux if available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)