### PR TITLE
Fix desktop app notifications for Claude Code hooks

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -8,7 +8,7 @@ import injectProcessEnvPlugin from "rollup-plugin-inject-process-env";
 import tsconfigPathsPlugin from "vite-tsconfig-paths";
 import { main, resources } from "./package.json";
 
-// Dev server port - this is just the starting point, Vite will find next available if taken
+// Dev server port - must match PORTS.VITE_DEV_SERVER in src/shared/constants.ts
 const DEV_SERVER_PORT = 5927;
 
 // Load .env from monorepo root

--- a/apps/desktop/src/lib/electron-router-dom.ts
+++ b/apps/desktop/src/lib/electron-router-dom.ts
@@ -1,12 +1,8 @@
 import { createElectronRouter } from "electron-router-dom";
-
-// Dev server port - must match electron.vite.config.ts DEV_SERVER_PORT
-// This file is shared between main/renderer and can't import Node.js modules,
-// so we hardcode the dev port here. In production, renderer loads from bundled files.
-const DEV_SERVER_PORT = 5927;
+import { PORTS } from "shared/constants";
 
 export const { Router, registerRoute, settings } = createElectronRouter({
-	port: DEV_SERVER_PORT,
+	port: PORTS.VITE_DEV_SERVER,
 	types: {
 		ids: ["main", "about"],
 	},

--- a/apps/desktop/src/main/lib/agent-setup.ts
+++ b/apps/desktop/src/main/lib/agent-setup.ts
@@ -1,11 +1,8 @@
 import { execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import {
-	NOTIFICATIONS_PORT,
-	SUPERSET_DIR_NAME,
-	SUPERSET_HOME_DIR,
-} from "./app-environment";
+import { PORTS, SUPERSET_DIR_NAME } from "shared/constants";
+import { SUPERSET_HOME_DIR } from "./app-environment";
 
 const BIN_DIR = path.join(SUPERSET_HOME_DIR, "bin");
 const HOOKS_DIR = path.join(SUPERSET_HOME_DIR, "hooks");
@@ -48,7 +45,7 @@ EVENT_TYPE=$(echo "$INPUT" | grep -o '"hook_event_name":"[^"]*"' | cut -d'"' -f4
 # Default to "Stop" if not found
 [ -z "$EVENT_TYPE" ] && EVENT_TYPE="Stop"
 
-curl -sG "http://127.0.0.1:\${SUPERSET_PORT:-${NOTIFICATIONS_PORT}}/hook/complete" \\
+curl -sG "http://127.0.0.1:\${SUPERSET_PORT:-${PORTS.NOTIFICATIONS}}/hook/complete" \\
   --data-urlencode "tabId=$SUPERSET_TAB_ID" \\
   --data-urlencode "tabTitle=$SUPERSET_TAB_TITLE" \\
   --data-urlencode "workspaceName=$SUPERSET_WORKSPACE_NAME" \\

--- a/apps/desktop/src/main/lib/app-environment.ts
+++ b/apps/desktop/src/main/lib/app-environment.ts
@@ -1,16 +1,11 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { app } from "electron";
+import { ENVIRONMENT, SUPERSET_DIR_NAME } from "shared/constants";
 
-export const IS_DEV = !app.isPackaged;
+export const IS_DEV = ENVIRONMENT.IS_DEV;
 export const IS_TEST = process.env.NODE_ENV === "test";
 
-export const SUPERSET_DIR_NAME = IS_DEV ? ".superset-dev" : ".superset";
 export const SUPERSET_HOME_DIR = join(homedir(), SUPERSET_DIR_NAME);
-
-export const NOTIFICATIONS_PORT = IS_DEV ? 31416 : 31415;
-export const VITE_PORT_START = IS_DEV ? 5927 : 4927;
-export const VITE_PORT_END = IS_DEV ? 5999 : 4999;
 
 // For lowdb - use our own path instead of app.getPath("userData")
 export const DB_PATH = join(SUPERSET_HOME_DIR, "db.json");

--- a/apps/desktop/src/main/lib/notifications/server.ts
+++ b/apps/desktop/src/main/lib/notifications/server.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "node:events";
 import express from "express";
-import { NOTIFICATIONS_PORT } from "../app-environment";
+import { PORTS } from "shared/constants";
 
 export interface AgentCompleteEvent {
 	tabId: string;
@@ -56,4 +56,3 @@ app.use((req, res) => {
 });
 
 export const notificationsApp = app;
-export { NOTIFICATIONS_PORT };

--- a/apps/desktop/src/main/lib/terminal-manager.ts
+++ b/apps/desktop/src/main/lib/terminal-manager.ts
@@ -1,8 +1,8 @@
 import { EventEmitter } from "node:events";
 import os from "node:os";
 import * as pty from "node-pty";
+import { PORTS } from "shared/constants";
 import { getSupersetPath } from "./agent-setup";
-import { NOTIFICATIONS_PORT } from "./app-environment";
 import { TerminalEscapeFilter } from "./terminal-escape-filter";
 import { HistoryReader, HistoryWriter } from "./terminal-history";
 
@@ -85,7 +85,7 @@ export class TerminalManager extends EventEmitter {
 			SUPERSET_TAB_TITLE: tabTitle,
 			SUPERSET_WORKSPACE_NAME: workspaceName,
 			SUPERSET_WORKSPACE_ID: workspaceId,
-			SUPERSET_PORT: String(NOTIFICATIONS_PORT),
+			SUPERSET_PORT: String(PORTS.NOTIFICATIONS),
 		};
 
 		// Recover scrollback from in-memory dead session or disk

--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -2,12 +2,12 @@ import { join } from "node:path";
 import { Notification, screen } from "electron";
 import { createWindow } from "lib/electron-app/factories/windows/create";
 import { createAppRouter } from "lib/trpc/routers";
+import { PORTS } from "shared/constants";
 import { createIPCHandler } from "trpc-electron/main";
 import { productName } from "~/package.json";
 import { createApplicationMenu } from "../lib/menu";
 import {
 	type AgentCompleteEvent,
-	NOTIFICATIONS_PORT,
 	notificationsApp,
 	notificationsEmitter,
 } from "../lib/notifications/server";
@@ -46,11 +46,11 @@ export async function MainWindow() {
 
 	// Start notifications HTTP server
 	const server = notificationsApp.listen(
-		NOTIFICATIONS_PORT,
+		PORTS.NOTIFICATIONS,
 		"127.0.0.1",
 		() => {
 			console.log(
-				`[notifications] Listening on http://127.0.0.1:${NOTIFICATIONS_PORT}`,
+				`[notifications] Listening on http://127.0.0.1:${PORTS.NOTIFICATIONS}`,
 			);
 		},
 	);

--- a/apps/desktop/src/shared/constants.ts
+++ b/apps/desktop/src/shared/constants.ts
@@ -8,7 +8,15 @@ export const PLATFORM = {
 	IS_LINUX: process.platform === "linux",
 };
 
-// Note: For environment-aware paths and ports, use main/lib/app-environment.ts instead.
-// These constants are for code that runs in both main and renderer processes.
-export const SUPERSET_DIR_NAME = ".superset";
+// Ports - different for dev vs prod to allow running both simultaneously
+export const PORTS = {
+	// Vite dev server port
+	VITE_DEV_SERVER: ENVIRONMENT.IS_DEV ? 5927 : 4927,
+	// Notification HTTP server port
+	NOTIFICATIONS: ENVIRONMENT.IS_DEV ? 31416 : 31415,
+};
+
+// Note: For environment-aware paths, use main/lib/app-environment.ts instead.
+// Paths require Node.js/Electron APIs that aren't available in renderer.
+export const SUPERSET_DIR_NAME = ENVIRONMENT.IS_DEV ? ".superset-dev" : ".superset";
 export const WORKTREES_DIR_NAME = "worktrees";


### PR DESCRIPTION
## Summary

- Fixed Claude Code hook configuration format (removed invalid `matcher` field from `Stop` hook)
- Added `PermissionRequest` hook to notify when Claude needs user input
- Updated notify.sh script to pass event type to HTTP endpoint
- Updated notification messages to differentiate between "Agent Complete" and "Input Needed"

## Changes

| Hook Event | Notification Title | Notification Body |
|------------|-------------------|-------------------|
| Stop | "Agent Complete" | "{tab} has finished its task" |
| PermissionRequest | "Input Needed" | "{tab} needs your attention" |

## Test plan

- [ ] Restart desktop app (regenerates wrapper scripts at `~/.superset/bin/claude`)
- [ ] Open terminal in Superset, run `claude`
- [ ] Let Claude complete a task → verify "Agent Complete" notification appears
- [ ] Have Claude try to edit a file → verify "Input Needed" notification when permission dialog appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notifications now distinguish "Input Needed" (permission requests) from "Agent Complete", making required user actions clearer.
  * Notification system accepts and propagates an event type so external hooks can trigger permission-request notifications.

* **Chores**
  * CLI/notification integration updated so hook completions include the event type for accurate messaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->