### PR TITLE
fix(desktop): prevent sidebar overflow when empty

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ModeCarousel/ModeContent.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ModeCarousel/ModeContent.tsx
@@ -11,14 +11,14 @@ interface ModeContentProps {
 export function ModeContent({ mode, children }: ModeContentProps) {
 	return (
 		<div
-			className="overflow-y-auto h-full"
+			className="overflow-y-auto flex flex-col h-full"
 			style={{
 				scrollSnapAlign: "start",
 				scrollSnapStop: "always",
 			}}
 		>
 			<ModeHeader mode={mode} />
-			<div className="px-1 h-full">{children}</div>
+			<div className="px-1 flex-1 min-h-0">{children}</div>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary
- Fixed sidebar showing scrollbar when empty due to incorrect height calculation
- Changed inner content wrapper from `h-full` to `flex-1 min-h-0` so it fills remaining space instead of 100% + header height

## Root Cause
In `ModeContent.tsx`, the structure was:
```tsx
<div className="overflow-y-auto h-full">
  <ModeHeader />           // Takes 8px (tabs) or ~40px (changes)
  <div className="h-full"> // ❌ 100% of parent
```
Total height = header + 100% > 100% → overflow

## Fix
Use flexbox to properly distribute space:
```tsx
<div className="overflow-y-auto flex flex-col h-full">
  <ModeHeader />
  <div className="flex-1 min-h-0"> // ✅ fills remaining space
```

## Test plan
- [x] Lint passes
- [x] Typecheck passes
- [ ] Verify sidebar has no scroll when empty
- [ ] Verify sidebar scrolls correctly when content overflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined sidebar layout structure and improved flex positioning for better content display and alignment in the workspace view.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->