### PR TITLE
feat(desktop): add keyboard shortcuts for workspace navigation

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/TopBar/WorkspaceTabs/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/TopBar/WorkspaceTabs/index.tsx
@@ -2,6 +2,7 @@ import { Fragment, useEffect, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { trpc } from "renderer/lib/trpc";
 import { useSetActiveWorkspace } from "renderer/react-query/workspaces";
+import { HOTKEYS } from "shared/hotkeys";
 import { WorkspaceDropdown } from "./WorkspaceDropdown";
 import { WorkspaceGroup } from "./WorkspaceGroup";
 
@@ -44,6 +45,28 @@ export function WorkspacesTabs() {
 		},
 		[allWorkspaces, setActiveWorkspace],
 	);
+
+	// Navigate to previous workspace (⌘+←)
+	useHotkeys(HOTKEYS.PREV_WORKSPACE.keys, () => {
+		if (!activeWorkspaceId) return;
+		const currentIndex = allWorkspaces.findIndex(
+			(w) => w.id === activeWorkspaceId,
+		);
+		if (currentIndex > 0) {
+			setActiveWorkspace.mutate({ id: allWorkspaces[currentIndex - 1].id });
+		}
+	}, [activeWorkspaceId, allWorkspaces, setActiveWorkspace]);
+
+	// Navigate to next workspace (⌘+→)
+	useHotkeys(HOTKEYS.NEXT_WORKSPACE.keys, () => {
+		if (!activeWorkspaceId) return;
+		const currentIndex = allWorkspaces.findIndex(
+			(w) => w.id === activeWorkspaceId,
+		);
+		if (currentIndex < allWorkspaces.length - 1) {
+			setActiveWorkspace.mutate({ id: allWorkspaces[currentIndex + 1].id });
+		}
+	}, [activeWorkspaceId, allWorkspaces, setActiveWorkspace]);
 
 	useEffect(() => {
 		const checkScroll = () => {

--- a/apps/desktop/src/shared/hotkeys.ts
+++ b/apps/desktop/src/shared/hotkeys.ts
@@ -72,6 +72,16 @@ export const HOTKEYS = {
 		label: "Switch to Workspace 9",
 		category: "Workspace",
 	},
+	PREV_WORKSPACE: {
+		keys: "meta+left",
+		label: "Previous Workspace",
+		category: "Workspace",
+	},
+	NEXT_WORKSPACE: {
+		keys: "meta+right",
+		label: "Next Workspace",
+		category: "Workspace",
+	},
 
 	// Layout
 	TOGGLE_SIDEBAR: {


### PR DESCRIPTION
## Summary
- Add ⌘+← hotkey to navigate to previous workspace
- Add ⌘+→ hotkey to navigate to next workspace
- Shortcuts automatically appear in the keyboard shortcuts modal (⌘+/)

## Test plan
- [ ] Open desktop app with multiple workspaces
- [ ] Press ⌘+→ to navigate to next workspace
- [ ] Press ⌘+← to navigate to previous workspace
- [ ] Verify shortcuts appear in hotkey modal (⌘+/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)