### PR TITLE
fix(desktop): wrap zsh and bash to enable claude and codex proxies instead of modifying users' paths

### DIFF
--- a/apps/desktop/src/main/lib/terminal-manager.ts
+++ b/apps/desktop/src/main/lib/terminal-manager.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from "node:events";
 import os from "node:os";
 import * as pty from "node-pty";
 import { PORTS } from "shared/constants";
-import { getSupersetPath } from "./agent-setup";
+import { getShellArgs, getShellEnv } from "./agent-setup";
 import { TerminalEscapeFilter } from "./terminal-escape-filter";
 import { HistoryReader, HistoryWriter } from "./terminal-history";
 
@@ -87,9 +87,10 @@ export class TerminalManager extends EventEmitter {
 		const terminalRows = rows || this.DEFAULT_ROWS;
 
 		const baseEnv = this.sanitizeEnv(process.env) || {};
+		const shellEnv = getShellEnv(shell);
 		const env = {
 			...baseEnv,
-			PATH: getSupersetPath(),
+			...shellEnv,
 			SUPERSET_TAB_ID: tabId,
 			SUPERSET_TAB_TITLE: tabTitle,
 			SUPERSET_WORKSPACE_NAME: workspaceName,
@@ -114,8 +115,7 @@ export class TerminalManager extends EventEmitter {
 			}
 		}
 
-		const shellArgs =
-			shell.includes("zsh") || shell.includes("bash") ? ["-l"] : [];
+		const shellArgs = getShellArgs(shell);
 
 		const ptyProcess = pty.spawn(shell, shellArgs, {
 			name: "xterm-256color",


### PR DESCRIPTION
…time

The wrapper scripts for Claude Code and Codex were hardcoding absolute paths to binaries when the app first launched. This caused notifications to fail for other users since paths like /Users/satyapatel/.nvm/... don't exist on their machines.

Now the wrappers use `which -a` at runtime to find the real binary, making them portable across different machines and Node.js installations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Terminal startup now respects the user’s shell environment and startup files, with added zsh/bash initialization wrappers.
  * Better handling of PATH and shell startup arguments for more reliable command execution.

* **Bug Fixes**
  * Improved logging around wrapper creation and more consistent environment propagation to spawned terminals.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->