### PR TITLE
Workspace dropdown UX improvements

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/TopBar/WorkspaceTabs/WorkspaceDropdown.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/TopBar/WorkspaceTabs/WorkspaceDropdown.tsx
@@ -4,6 +4,7 @@ import {
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
 import { toast } from "@superset/ui/sonner";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useState } from "react";
 import { HiChevronDown, HiMiniFolderOpen, HiMiniPlus } from "react-icons/hi2";
 import { trpc } from "renderer/lib/trpc";
@@ -13,11 +14,15 @@ import { useCreateWorkspace } from "renderer/react-query/workspaces";
 export interface WorkspaceDropdownProps {
 	className?: string;
 	activeProjectId?: string | null;
+	activeProjectName?: string;
+	activeProjectColor?: string;
 }
 
 export function WorkspaceDropdown({
 	className,
 	activeProjectId,
+	activeProjectName,
+	activeProjectColor,
 }: WorkspaceDropdownProps) {
 	const [isOpen, setIsOpen] = useState(false);
 
@@ -60,68 +65,86 @@ export function WorkspaceDropdown({
 	};
 
 	return (
-		<div
-			className={`group/add flex items-center ml-2 rounded transition-colors hover:bg-accent/50 ${className ?? ""}`}
-		>
-			{/* Plus button - creates workspace in current project */}
-			<button
-				type="button"
-				aria-label="Add workspace to current project"
-				onClick={handleAddToCurrentProject}
-				disabled={!activeProjectId || createWorkspace.isPending}
-				className="flex items-center justify-center h-6 w-6 rounded-l-md transition-colors hover:bg-accent disabled:opacity-50 disabled:pointer-events-none"
-			>
-				<HiMiniPlus className="size-5" />
-			</button>
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<div
+					className={`group/add flex items-center h-6 ml-2 ${className ?? ""}`}
+				>
+					<div className="flex items-center h-6 rounded transition-colors hover:bg-accent/50">
+						{/* Plus button - creates workspace in current project */}
+						<button
+							type="button"
+							aria-label="Add workspace to current project"
+							onClick={handleAddToCurrentProject}
+							disabled={!activeProjectId || createWorkspace.isPending}
+							className="flex items-center justify-center h-6 w-6 rounded-l transition-colors hover:bg-accent disabled:opacity-50 disabled:pointer-events-none"
+						>
+							<HiMiniPlus className="size-5" />
+						</button>
 
-			{/* Dropdown for other options */}
-			<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
-				<DropdownMenuTrigger asChild>
-					<button
-						type="button"
-						aria-label="More workspace options"
-						className="flex items-center justify-center h-6 w-4 rounded-r-md transition-colors hover:bg-accent"
-					>
-						<HiChevronDown className="size-2.5" />
-					</button>
-				</DropdownMenuTrigger>
-				<DropdownMenuContent className="w-80 p-0" align="end">
-					<div className="py-2">
-						{recentProjects.length > 0 && (
-							<div className="px-2 pb-2 border-b">
-								<p className="text-xs text-muted-foreground px-2 py-1.5">
-									Recent Projects
-								</p>
-								{recentProjects.map((project) => (
-									<button
-										type="button"
-										key={project.id}
-										onClick={() => handleCreateWorkspace(project.id)}
-										disabled={createWorkspace.isPending}
-										className="w-full text-left px-2 py-1.5 text-sm rounded hover:bg-accent transition-colors"
-									>
-										<div className="font-medium">{project.name}</div>
-										<div className="text-xs text-muted-foreground truncate">
-											{project.mainRepoPath}
+						{/* Dropdown for other options */}
+						<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+							<DropdownMenuTrigger asChild>
+								<button
+									type="button"
+									aria-label="More workspace options"
+									className="flex items-center justify-center h-6 w-4 rounded-r transition-colors hover:bg-accent"
+								>
+									<HiChevronDown className="size-2.5" />
+								</button>
+							</DropdownMenuTrigger>
+							<DropdownMenuContent className="w-80 p-0" align="end">
+								<div className="py-2">
+									{recentProjects.length > 0 && (
+										<div className="px-2 pb-2 border-b">
+											<p className="text-xs text-muted-foreground px-2 py-1.5">
+												Recent Projects
+											</p>
+											{recentProjects.map((project) => (
+												<button
+													type="button"
+													key={project.id}
+													onClick={() => handleCreateWorkspace(project.id)}
+													disabled={createWorkspace.isPending}
+													className="w-full text-left px-2 py-1.5 text-sm rounded hover:bg-accent transition-colors"
+												>
+													<div className="font-medium">{project.name}</div>
+													<div className="text-xs text-muted-foreground truncate">
+														{project.mainRepoPath}
+													</div>
+												</button>
+											))}
 										</div>
-									</button>
-								))}
-							</div>
-						)}
-						<div className="px-2 pt-2">
-							<button
-								type="button"
-								onClick={handleOpenNewProject}
-								disabled={openNew.isPending || createWorkspace.isPending}
-								className="w-full text-left px-2 py-1.5 text-sm rounded hover:bg-accent transition-colors flex items-center gap-2"
-							>
-								<HiMiniFolderOpen className="h-4 w-4" />
-								<span>Open New Project...</span>
-							</button>
-						</div>
+									)}
+									<div className="px-2 pt-2">
+										<button
+											type="button"
+											onClick={handleOpenNewProject}
+											disabled={openNew.isPending || createWorkspace.isPending}
+											className="w-full text-left px-2 py-1.5 text-sm rounded hover:bg-accent transition-colors flex items-center gap-2"
+										>
+											<HiMiniFolderOpen className="h-4 w-4" />
+											<span>Open New Project...</span>
+										</button>
+									</div>
+								</div>
+							</DropdownMenuContent>
+						</DropdownMenu>
 					</div>
-				</DropdownMenuContent>
-			</DropdownMenu>
-		</div>
+				</div>
+			</TooltipTrigger>
+			<TooltipContent side="bottom">
+				{activeProjectName ? (
+					<>
+						New workspace in{" "}
+						<span style={{ color: activeProjectColor }}>
+							{activeProjectName}
+						</span>
+					</>
+				) : (
+					"New workspace"
+				)}
+			</TooltipContent>
+		</Tooltip>
 	);
 }

--- a/apps/desktop/src/renderer/screens/main/components/TopBar/WorkspaceTabs/WorkspaceGroup.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/TopBar/WorkspaceTabs/WorkspaceGroup.tsx
@@ -36,37 +36,37 @@ export function WorkspaceGroup({
 }: WorkspaceGroupProps) {
 	const [isCollapsed, setIsCollapsed] = useState(false);
 
+	const displayedWorkspaces = isCollapsed
+		? workspaces.filter((w) => w.id === activeWorkspaceId)
+		: workspaces;
+
+	const activeIndex = displayedWorkspaces.findIndex(
+		(w) => w.id === activeWorkspaceId,
+	);
+
 	return (
-		<div className="flex items-center h-full">
-			{/* Project group badge */}
+		<div className="flex items-center">
+			{/* Project group header with collapse control */}
 			<WorkspaceGroupHeader
 				projectId={projectId}
 				projectName={projectName}
 				projectColor={projectColor}
 				index={projectIndex}
 				isCollapsed={isCollapsed}
+				isBeforeActive={activeIndex === 0}
 				onToggleCollapse={() => setIsCollapsed(!isCollapsed)}
 			/>
 
-			{/* Workspaces with colored line (collapsed shows only active tab) */}
-			<div
-				className="flex items-end h-full gap-1"
-				style={{
-					borderBottom: `2px solid ${projectColor}`,
-				}}
-			>
+			{/* Workspaces - each tab handles its own border */}
+			<div className="flex items-center">
 				<AnimatePresence initial={false}>
-					{(isCollapsed
-						? workspaces.filter((w) => w.id === activeWorkspaceId)
-						: workspaces
-					).map((workspace, index) => (
+					{displayedWorkspaces.map((workspace, index) => (
 						<motion.div
 							key={workspace.id}
 							initial={{ width: 0, opacity: 0 }}
 							animate={{ width: "auto", opacity: 1 }}
 							exit={{ width: 0, opacity: 0 }}
 							transition={{ duration: 0.15, ease: "easeOut" }}
-							className="h-full"
 							style={{ overflow: "hidden" }}
 						>
 							<WorkspaceItem
@@ -75,8 +75,11 @@ export function WorkspaceGroup({
 								worktreePath={workspace.worktreePath}
 								title={workspace.name}
 								isActive={workspace.id === activeWorkspaceId}
+								isBeforeActive={index === activeIndex - 1}
+								isAfterActive={index === activeIndex + 1}
 								index={index}
 								width={workspaceWidth}
+								projectColor={projectColor}
 								onMouseEnter={() => onWorkspaceHover(workspace.id)}
 								onMouseLeave={() => onWorkspaceHover(null)}
 							/>

--- a/apps/desktop/src/renderer/screens/main/components/TopBar/WorkspaceTabs/WorkspaceGroupHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/TopBar/WorkspaceTabs/WorkspaceGroupHeader.tsx
@@ -1,4 +1,5 @@
 import { useDrag, useDrop } from "react-dnd";
+import { HiChevronRight } from "react-icons/hi2";
 import { useReorderProjects } from "renderer/react-query/projects";
 import { WorkspaceGroupContextMenu } from "./WorkspaceGroupContextMenu";
 
@@ -9,6 +10,7 @@ interface WorkspaceGroupHeaderProps {
 	projectName: string;
 	projectColor: string;
 	isCollapsed: boolean;
+	isBeforeActive: boolean;
 	index: number;
 	onToggleCollapse: () => void;
 }
@@ -18,6 +20,7 @@ export function WorkspaceGroupHeader({
 	projectName,
 	projectColor,
 	isCollapsed,
+	isBeforeActive,
 	index,
 	onToggleCollapse,
 }: WorkspaceGroupHeaderProps) {
@@ -59,13 +62,7 @@ export function WorkspaceGroupHeader({
 			projectName={projectName}
 			projectColor={projectColor}
 		>
-			<div
-				className="flex items-center h-full"
-				style={{
-					transition: "border-bottom 0.3s ease",
-					borderBottom: `2px solid ${isCollapsed ? "transparent" : projectColor}`,
-				}}
-			>
+			<div className="flex items-center h-7">
 				<button
 					type="button"
 					ref={(node) => {
@@ -73,19 +70,24 @@ export function WorkspaceGroupHeader({
 						drop(node);
 					}}
 					className={`
-					flex items-center justify-center mr-2
-					px-3 py-1 rounded-full
-					text-xs font-medium cursor-pointer select-none
-					transition-all shrink-0 no-drag
-					${isDragging ? "opacity-30" : "opacity-100"}
-					${isOver ? "ring-2 ring-white/20" : ""}
-				`}
-					onClick={onToggleCollapse}
+						flex items-center justify-center gap-1 h-6
+						px-2
+						text-xs font-medium cursor-pointer select-none
+						transition-all duration-150 shrink-0 no-drag
+						text-muted-foreground hover:text-foreground hover:bg-accent/40
+						${isDragging ? "opacity-30" : "opacity-100"}
+						${isOver ? "bg-accent/30" : ""}
+					`}
 					style={{
-						backgroundColor: projectColor,
-						color: "white",
+						borderBottom: `2px solid color-mix(in srgb, ${projectColor} 50%, transparent)`,
+						borderRadius: isBeforeActive ? "0 0 6px 0" : "0",
 					}}
+					onClick={onToggleCollapse}
 				>
+					<HiChevronRight
+						className={`size-3 transition-transform duration-150 ${isCollapsed ? "" : "rotate-90"}`}
+						style={{ color: projectColor }}
+					/>
 					<span className="truncate max-w-[100px]">{projectName}</span>
 				</button>
 			</div>

--- a/apps/desktop/src/renderer/screens/main/components/TopBar/WorkspaceTabs/WorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/TopBar/WorkspaceTabs/WorkspaceItem.tsx
@@ -20,8 +20,11 @@ interface WorkspaceItemProps {
 	worktreePath: string;
 	title: string;
 	isActive: boolean;
+	isBeforeActive: boolean;
+	isAfterActive: boolean;
 	index: number;
 	width: number;
+	projectColor: string;
 	onMouseEnter?: () => void;
 	onMouseLeave?: () => void;
 }
@@ -32,8 +35,11 @@ export function WorkspaceItem({
 	worktreePath,
 	title,
 	isActive,
+	isBeforeActive,
+	isAfterActive,
 	index,
 	width,
+	projectColor,
 	onMouseEnter,
 	onMouseLeave,
 }: WorkspaceItemProps) {
@@ -80,7 +86,7 @@ export function WorkspaceItem({
 				onRename={rename.startRename}
 			>
 				<div
-					className="group relative flex items-end shrink-0 h-full no-drag"
+					className="group relative flex items-center shrink-0 h-6 no-drag"
 					style={{ width: `${width}px` }}
 				>
 					{/* Main workspace button */}
@@ -93,16 +99,40 @@ export function WorkspaceItem({
 						onDoubleClick={rename.startRename}
 						onMouseEnter={onMouseEnter}
 						onMouseLeave={onMouseLeave}
-						className={`
-							flex items-center gap-0.5 rounded-t-md transition-all w-full shrink-0 pr-6 pl-3 h-[80%]
-							${
-								isActive
-									? "text-foreground bg-tertiary-active"
-									: "text-muted-foreground hover:text-foreground hover:bg-tertiary/30"
-							}
-							${isDragging ? "opacity-30" : "opacity-100"}
-						`}
-						style={{ cursor: isDragging ? "grabbing" : "pointer" }}
+						className={cn(
+							"flex items-center gap-1 w-full h-6 shrink-0 pr-6 pl-3 transition-all duration-150 m-0",
+							isActive
+								? "text-foreground bg-background"
+								: "text-muted-foreground hover:text-foreground hover:bg-accent/40",
+							isDragging ? "opacity-30" : "opacity-100",
+						)}
+						style={{
+							cursor: isDragging ? "grabbing" : "pointer",
+							// All tabs have 2px borders - just different colors
+							// Active: colored top/left/right, transparent bottom
+							// Inactive: transparent top/left/right, colored bottom
+							border: "2px solid transparent",
+							borderTopColor: isActive
+								? `color-mix(in srgb, ${projectColor} 60%, transparent)`
+								: "transparent",
+							borderLeftColor: isActive
+								? `color-mix(in srgb, ${projectColor} 60%, transparent)`
+								: "transparent",
+							borderRightColor: isActive
+								? `color-mix(in srgb, ${projectColor} 60%, transparent)`
+								: "transparent",
+							borderBottomColor: isActive
+								? "transparent"
+								: `color-mix(in srgb, ${projectColor} 50%, transparent)`,
+							// Border radius: active has top corners, adjacent tabs have corner touching active
+							borderRadius: isActive
+								? "6px 6px 0 0"
+								: isBeforeActive
+									? "0 0 6px 0"
+									: isAfterActive
+										? "0 0 0 6px"
+										: "0",
+						}}
 					>
 						{rename.isRenaming ? (
 							<input
@@ -140,7 +170,7 @@ export function WorkspaceItem({
 							setShowDeleteDialog(true);
 						}}
 						className={cn(
-							"mt-1 absolute right-1 top-1/2 -translate-y-1/2 cursor-pointer size-5 group-hover:opacity-100",
+							"absolute right-1 top-1/2 -translate-y-1/2 cursor-pointer size-4 group-hover:opacity-100",
 							isActive ? "opacity-90" : "opacity-0",
 						)}
 						aria-label="Close workspace"

--- a/apps/desktop/src/renderer/screens/main/components/TopBar/WorkspaceTabs/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/TopBar/WorkspaceTabs/index.tsx
@@ -110,12 +110,15 @@ export function WorkspacesTabs() {
 	}, [allWorkspaces]);
 
 	return (
-		<div ref={containerRef} className="flex items-center h-full w-full">
+		<div
+			ref={containerRef}
+			className="flex items-center h-full w-full border-b border-border"
+		>
 			{/* Scroll wrapper - shrinks to fit content, scrolls when overflow */}
-			<div className="relative h-full min-w-0 overflow-hidden">
+			<div className="relative h-full min-w-0 overflow-hidden flex items-center">
 				<div
 					ref={scrollRef}
-					className="flex h-full overflow-x-auto hide-scrollbar gap-4"
+					className="flex items-center overflow-x-auto hide-scrollbar gap-4"
 				>
 					{groups.map((group, groupIndex) => (
 						<Fragment key={group.project.id}>
@@ -131,8 +134,8 @@ export function WorkspacesTabs() {
 								onWorkspaceHover={setHoveredWorkspaceId}
 							/>
 							{groupIndex < groups.length - 1 && (
-								<div className="flex items-center h-full py-2">
-									<div className="w-px h-full bg-border" />
+								<div className="flex items-center h-6">
+									<div className="w-px h-4 bg-border/50" />
 								</div>
 							)}
 						</Fragment>
@@ -152,6 +155,14 @@ export function WorkspacesTabs() {
 			<WorkspaceDropdown
 				className="no-drag flex-shrink-0"
 				activeProjectId={activeWorkspace?.projectId}
+				activeProjectName={
+					groups.find((g) => g.project.id === activeWorkspace?.projectId)
+						?.project.name
+				}
+				activeProjectColor={
+					groups.find((g) => g.project.id === activeWorkspace?.projectId)
+						?.project.color
+				}
 			/>
 		</div>
 	);


### PR DESCRIPTION
## Summary
- Split workspace add button into plus icon + dropdown chevron (like Warp/Chrome tabs)
- Plus button creates workspace in current project instantly
- Dropdown shows recent projects and "Open New Project..." option
- Button stays visible outside scroll area but flows with tabs
- Added group hover effect with brighter highlight on specific button

## Test plan
- [ ] Click plus button - should create workspace in current project
- [ ] Click dropdown chevron - should show recent projects list
- [ ] Verify button doesn't scroll out of view when many tabs
- [ ] Test hover states (group hover + individual button hover)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)