### PR TITLE
fix(desktop): fallback to worktree branch name in notifications

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/terminal/terminal.ts
+++ b/apps/desktop/src/lib/trpc/routers/terminal/terminal.ts
@@ -47,7 +47,11 @@ export const createTerminalRouter = () => {
 
 				// Get workspace to determine cwd and workspace name
 				const workspace = db.data.workspaces.find((w) => w.id === workspaceId);
-				const workspaceName = workspace?.name || "Workspace";
+				const worktree = workspace
+					? db.data.worktrees.find((wt) => wt.id === workspace.worktreeId)
+					: undefined;
+				const workspaceName =
+					workspace?.name || worktree?.branch || "Workspace";
 				const cwd =
 					cwdOverride ||
 					(workspace ? getWorktreePath(workspace.worktreeId) : undefined);


### PR DESCRIPTION
When workspace name is not set, notifications now fall back to the worktree's branch name instead of a generic "Workspace" label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved terminal workspace naming resolution to better identify workspace context in terminal sessions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->