### PR TITLE
Fix setup script appearing 3 times when starting a worktree

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -161,7 +161,11 @@ export const Terminal = ({ tabId, workspaceId }: TerminalProps) => {
 			},
 			{
 				onSuccess: (result) => {
-					applyInitialScrollback(result);
+					// Avoid duplication when pending events already contain scrollback data
+					const hasPendingEvents = pendingEventsRef.current.length > 0;
+					if (result.isNew || !hasPendingEvents) {
+						applyInitialScrollback(result);
+					}
 					setSubscriptionEnabled(true);
 					flushPendingEvents();
 				},


### PR DESCRIPTION
## Summary
- Fix race condition where terminal scrollback and pending events both contained the same output
- Skip scrollback write when attaching to existing session if pending events already have the data

## Test plan
- [ ] Create a new worktree with a setup script configured
- [ ] Verify the setup script command appears only once in the terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal display issue where scrollback content could be duplicated when resuming previous sessions with pending data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->