### PR TITLE
Use fade-out effect for workspace tab text overflow + make input more aesthetic

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/TopBar/WorkspaceTabs/WorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/TopBar/WorkspaceTabs/WorkspaceItem.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@superset/ui/button";
+import { Input } from "@superset/ui/input";
 import { cn } from "@superset/ui/utils";
 import { useState } from "react";
 import { useDrag, useDrop } from "react-dnd";
@@ -112,16 +113,16 @@ export function WorkspaceItem({
 						style={{ cursor: isDragging ? "grabbing" : "pointer" }}
 					>
 						{rename.isRenaming ? (
-							<input
+							<Input
 								ref={rename.inputRef}
-								type="text"
+								variant="ghost"
 								value={rename.renameValue}
 								onChange={(e) => rename.setRenameValue(e.target.value)}
 								onBlur={rename.submitRename}
 								onKeyDown={rename.handleKeyDown}
 								onClick={(e) => e.stopPropagation()}
 								onMouseDown={(e) => e.stopPropagation()}
-								className="flex-1 min-w-0 bg-muted border border-primary rounded px-1 py-0.5 text-sm outline-none"
+								className="flex-1 min-w-0 px-1 py-0.5"
 							/>
 						) : (
 							<>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/TabsView/TabItem/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/TabsView/TabItem/index.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@superset/ui/button";
+import { Input } from "@superset/ui/input";
 import { useState } from "react";
 import { HiChevronRight, HiMiniXMark } from "react-icons/hi2";
 import { trpc } from "renderer/lib/trpc";
@@ -132,15 +133,15 @@ export function TabItem({ tab, childTabs = [] }: TabItemProps) {
 							</button>
 						)}
 						{rename.isRenaming ? (
-							<input
+							<Input
 								ref={rename.inputRef}
-								type="text"
+								variant="ghost"
 								value={rename.renameValue}
 								onChange={(e) => rename.setRenameValue(e.target.value)}
 								onBlur={rename.submitRename}
 								onKeyDown={rename.handleKeyDown}
 								onClick={(e) => e.stopPropagation()}
-								className="flex-1 bg-tertiary-active border border-primary rounded px-1 py-0.5 text-sm outline-none"
+								className="flex-1 px-1 py-0.5"
 							/>
 						) : (
 							<>

--- a/packages/ui/src/components/input.tsx
+++ b/packages/ui/src/components/input.tsx
@@ -2,17 +2,25 @@ import type * as React from "react";
 
 import { cn } from "../lib/utils";
 
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+const inputVariants = {
+	default: [
+		"file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+		"focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+		"aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+	],
+	ghost: "bg-transparent outline-none text-sm",
+};
+
+interface InputProps extends React.ComponentProps<"input"> {
+	variant?: keyof typeof inputVariants;
+}
+
+function Input({ className, type, variant = "default", ...props }: InputProps) {
 	return (
 		<input
 			type={type}
 			data-slot="input"
-			className={cn(
-				"file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-				"focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
-				"aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-				className,
-			)}
+			className={cn(inputVariants[variant], className)}
 			{...props}
 		/>
 	);


### PR DESCRIPTION
## Summary
- Replace ellipsis truncation with gradient mask fade for workspace tab names
- Creates a cleaner visual effect when tab names overflow

## Test plan
- [ ] Open desktop app with multiple workspaces
- [ ] Verify long workspace names fade out smoothly instead of showing "..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rename fields now use an enhanced input with a lightweight "ghost" appearance for a cleaner edit experience.

* **Style**
  * Improved workspace title truncation using a subtle right-edge gradient mask for smoother visual fading and consistent layout.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->