### PR TITLE
Fix Cmd+K to clear terminal

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -185,6 +185,9 @@ export const Terminal = ({ tabId, workspaceId }: TerminalProps) => {
 					writeRef.current({ tabId, data: "\\\n" });
 				}
 			},
+			onClear: () => {
+				xterm.clear();
+			},
 		});
 
 		const cleanupFocus = setupFocusListener(

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -130,12 +130,15 @@ export function createTerminalInstance(
 export interface KeyboardHandlerOptions {
 	/** Callback for Shift+Enter to create a line continuation (like iTerm) */
 	onShiftEnter?: () => void;
+	/** Callback for Cmd+K to clear the terminal */
+	onClear?: () => void;
 }
 
 /**
  * Setup keyboard handling for xterm including:
  * - Shortcut forwarding: App hotkeys are re-dispatched to document for react-hotkeys-hook
  * - Shift+Enter: Creates a line continuation (like iTerm) instead of executing
+ * - Cmd+K: Clears the terminal
  */
 export function setupKeyboardHandler(
 	xterm: XTerm,
@@ -153,6 +156,21 @@ export function setupKeyboardHandler(
 			// Block both keydown and keyup to prevent Enter from leaking through
 			if (event.type === "keydown" && options.onShiftEnter) {
 				options.onShiftEnter();
+			}
+			return false;
+		}
+
+		// Handle Cmd+K to clear terminal (handle directly since it needs xterm access)
+		const isClearShortcut =
+			event.key.toLowerCase() === "k" &&
+			event.metaKey &&
+			!event.shiftKey &&
+			!event.ctrlKey &&
+			!event.altKey;
+
+		if (isClearShortcut) {
+			if (event.type === "keydown" && options.onClear) {
+				options.onClear();
 			}
 			return false;
 		}

--- a/apps/desktop/src/shared/hotkeys.ts
+++ b/apps/desktop/src/shared/hotkeys.ts
@@ -113,6 +113,11 @@ export const HOTKEYS = {
 		label: "Close Terminal",
 		category: "Terminal",
 	},
+	CLEAR_TERMINAL: {
+		keys: "meta+k",
+		label: "Clear Terminal",
+		category: "Terminal",
+	},
 	PREV_TERMINAL: {
 		keys: "meta+up",
 		label: "Previous Terminal",


### PR DESCRIPTION
Add CLEAR_TERMINAL hotkey (meta+k) and implement the keyboard handler to clear the terminal buffer when pressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cmd+K keyboard shortcut to clear the terminal in the desktop application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->