### PR TITLE
Add tooltips with keyboard shortcuts to topbar buttons

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/TopBar/SettingsButton/SettingsButton.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/TopBar/SettingsButton/SettingsButton.tsx
@@ -1,17 +1,35 @@
+import { Kbd, KbdGroup } from "@superset/ui/kbd";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { HiOutlineCog6Tooth } from "react-icons/hi2";
 import { useOpenSettings } from "renderer/stores";
+import { formatKeysForDisplay, HOTKEYS } from "shared/hotkeys";
 
 export function SettingsButton() {
 	const openSettings = useOpenSettings();
+	const keys = formatKeysForDisplay(HOTKEYS.SHOW_HOTKEYS.keys);
 
 	return (
-		<button
-			type="button"
-			onClick={() => openSettings()}
-			className="no-drag flex h-8 w-8 items-center justify-center rounded-md text-accent-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
-			aria-label="Open settings"
-		>
-			<HiOutlineCog6Tooth className="h-4 w-4" />
-		</button>
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<button
+					type="button"
+					onClick={() => openSettings()}
+					className="no-drag flex h-8 w-8 items-center justify-center rounded-md text-accent-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+					aria-label="Open settings"
+				>
+					<HiOutlineCog6Tooth className="h-4 w-4" />
+				</button>
+			</TooltipTrigger>
+			<TooltipContent side="bottom" showArrow={false}>
+				<span className="flex items-center gap-2">
+					Settings
+					<KbdGroup>
+						{keys.map((key) => (
+							<Kbd key={key}>{key}</Kbd>
+						))}
+					</KbdGroup>
+				</span>
+			</TooltipContent>
+		</Tooltip>
 	);
 }

--- a/apps/desktop/src/renderer/screens/main/components/TopBar/SidebarControl.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/TopBar/SidebarControl.tsx
@@ -1,23 +1,41 @@
 import { Button } from "@superset/ui/button";
+import { Kbd, KbdGroup } from "@superset/ui/kbd";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { HiMiniBars3, HiMiniBars3BottomLeft } from "react-icons/hi2";
 import { useSidebarStore } from "renderer/stores";
+import { formatKeysForDisplay, HOTKEYS } from "shared/hotkeys";
 
 export function SidebarControl() {
 	const { isSidebarOpen, toggleSidebar } = useSidebarStore();
+	const keys = formatKeysForDisplay(HOTKEYS.TOGGLE_SIDEBAR.keys);
 
 	return (
-		<Button
-			variant="ghost"
-			size="icon"
-			onClick={toggleSidebar}
-			aria-label="Toggle sidebar"
-			className="no-drag"
-		>
-			{isSidebarOpen ? (
-				<HiMiniBars3BottomLeft className="size-4" />
-			) : (
-				<HiMiniBars3 className="size-4" />
-			)}
-		</Button>
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<Button
+					variant="ghost"
+					size="icon"
+					onClick={toggleSidebar}
+					aria-label="Toggle sidebar"
+					className="no-drag"
+				>
+					{isSidebarOpen ? (
+						<HiMiniBars3BottomLeft className="size-4" />
+					) : (
+						<HiMiniBars3 className="size-4" />
+					)}
+				</Button>
+			</TooltipTrigger>
+			<TooltipContent side="bottom" showArrow={false}>
+				<span className="flex items-center gap-2">
+					Toggle sidebar
+					<KbdGroup>
+						{keys.map((key) => (
+							<Kbd key={key}>{key}</Kbd>
+						))}
+					</KbdGroup>
+				</span>
+			</TooltipContent>
+		</Tooltip>
 	);
 }


### PR DESCRIPTION
Add tooltips to the settings and sidebar toggle buttons in the topbar, displaying the action name alongside the keyboard shortcut using styled Kbd components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings button and sidebar toggle now display keyboard shortcuts in tooltips. Hovering over these controls reveals the associated hotkeys, improving discoverability of available keyboard navigation options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->