### PR TITLE
Support arbitrary default branches in workspace creation

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/projects/projects.ts
+++ b/apps/desktop/src/lib/trpc/routers/projects/projects.ts
@@ -10,7 +10,7 @@ import { PROJECT_COLOR_VALUES } from "shared/constants/project-colors";
 import simpleGit from "simple-git";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
-import { getGitRoot } from "../workspaces/utils/git";
+import { getDefaultBranch, getGitRoot } from "../workspaces/utils/git";
 import { assignRandomColor } from "./utils/colors";
 
 // Safe filename regex: letters, numbers, dots, underscores, hyphens, spaces, and common unicode
@@ -127,6 +127,8 @@ export const createProjectsRouter = (window: BrowserWindow) => {
 					}
 				});
 			} else {
+				const defaultBranch = await getDefaultBranch(mainRepoPath);
+
 				project = {
 					id: nanoid(),
 					mainRepoPath,
@@ -135,6 +137,7 @@ export const createProjectsRouter = (window: BrowserWindow) => {
 					tabOrder: null,
 					lastOpenedAt: Date.now(),
 					createdAt: Date.now(),
+					defaultBranch,
 				};
 
 				await db.update((data) => {
@@ -242,6 +245,7 @@ export const createProjectsRouter = (window: BrowserWindow) => {
 
 					// Create new project
 					const name = basename(clonePath);
+					const defaultBranch = await getDefaultBranch(clonePath);
 					const project: Project = {
 						id: nanoid(),
 						mainRepoPath: clonePath,
@@ -250,6 +254,7 @@ export const createProjectsRouter = (window: BrowserWindow) => {
 						tabOrder: null,
 						lastOpenedAt: Date.now(),
 						createdAt: Date.now(),
+						defaultBranch,
 					};
 
 					await db.update((data) => {

--- a/apps/desktop/src/main/lib/db/schemas.ts
+++ b/apps/desktop/src/main/lib/db/schemas.ts
@@ -7,6 +7,7 @@ export interface Project {
 	lastOpenedAt: number;
 	createdAt: number;
 	configToastDismissed?: boolean;
+	defaultBranch?: string; // Detected default branch (e.g., 'main', 'master')
 }
 
 export interface GitStatus {

--- a/bun.lock
+++ b/bun.lock
@@ -122,7 +122,7 @@
         "shell-quote": "^1.8.3",
         "simple-git": "^3.30.0",
         "superjson": "^2.2.5",
-        "tailwind-merge": "^2.6.0",
+        "tailwind-merge": "^3.4.0",
         "trpc-electron": "^0.1.2",
         "zod": "^4.1.12",
         "zustand": "^5.0.8",
@@ -282,7 +282,7 @@
         "react-icons": "^5.5.0",
         "react-resizable-panels": "^3.0.6",
         "sonner": "^2.0.7",
-        "tailwind-merge": "^2.6.0",
+        "tailwind-merge": "^3.4.0",
       },
       "devDependencies": {
         "@superset/typescript": "workspace:*",
@@ -2647,7 +2647,7 @@
 
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 
-    "tailwind-merge": ["tailwind-merge@2.6.0", "", {}, "sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA=="],
+    "tailwind-merge": ["tailwind-merge@3.4.0", "", {}, "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g=="],
 
     "tailwindcss": ["tailwindcss@4.1.17", "", {}, "sha512-j9Ee2YjuQqYT9bbRTfTZht9W/ytp5H+jJpZKiYdP/bpnXARAuELt9ofP0lPnmHjbga7SNQIxdTAXCmtKVYjN+Q=="],
 


### PR DESCRIPTION
## Summary
- Adds `defaultBranch` field to Project schema for storing detected branch
- Adds `getDefaultBranch()` utility that detects branch via `origin/HEAD` symbolic ref, falling back to common names (main, master, develop, trunk)
- Updates `fetchDefaultBranch()` and `checkNeedsRebase()` to accept branch parameter
- Detects default branch when opening/cloning projects
- Lazy-migrates existing projects on first workspace creation or git status refresh

## Test plan
- [ ] Create workspace on repo with `main` as default branch
- [ ] Create workspace on repo with `master` as default branch
- [ ] Clone repo with `master` default branch, then create workspace
- [ ] Open existing project (without `defaultBranch` stored), create workspace - should detect and save
- [ ] Refresh git status on workspace from `master`-based repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)