### PR TITLE
feat(desktop): add icons to terminal pane context menu

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabContentContextMenu.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabContentContextMenu.tsx
@@ -5,6 +5,7 @@ import {
 	ContextMenuSeparator,
 	ContextMenuTrigger,
 } from "@superset/ui/context-menu";
+import { Columns2, Rows2, X } from "lucide-react";
 import type { ReactNode } from "react";
 
 interface TabContentContextMenuProps {
@@ -25,13 +26,16 @@ export function TabContentContextMenu({
 			<ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
 			<ContextMenuContent>
 				<ContextMenuItem onSelect={onSplitHorizontal}>
+					<Rows2 className="size-4" />
 					Split Horizontally
 				</ContextMenuItem>
 				<ContextMenuItem onSelect={onSplitVertical}>
+					<Columns2 className="size-4" />
 					Split Vertically
 				</ContextMenuItem>
 				<ContextMenuSeparator />
 				<ContextMenuItem variant="destructive" onSelect={onClosePane}>
+					<X className="size-4" />
 					Close Pane
 				</ContextMenuItem>
 			</ContextMenuContent>


### PR DESCRIPTION
## Summary
- Add Lucide icons to the terminal pane context menu for better visual clarity
- Rows2 icon for "Split Horizontally" action
- Columns2 icon for "Split Vertically" action
- X icon for "Close Pane" action

## Test plan
- [ ] Right-click on a terminal pane to open the context menu
- [ ] Verify icons appear next to each menu item
- [ ] Verify icons are appropriately sized and aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added visual icons to context menu items for pane operations: Split Horizontally, Split Vertically, and Close Pane. This enhancement improves menu clarity and provides better visual guidance for workspace management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->