### PR TITLE
feat(desktop): resizable sidebar with persisted size

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/TabsView/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/TabsView/index.tsx
@@ -4,6 +4,7 @@ import { useMemo, useRef, useState } from "react";
 import { useDrop } from "react-dnd";
 import { HiMiniPlus } from "react-icons/hi2";
 import { trpc } from "renderer/lib/trpc";
+import { useSidebarStore } from "renderer/stores";
 import { useWindowsStore } from "renderer/stores/tabs/store";
 import { WindowItem } from "./WindowItem";
 
@@ -16,6 +17,7 @@ interface DragItem {
 }
 
 export function TabsView() {
+	const isResizing = useSidebarStore((s) => s.isResizing);
 	const { data: activeWorkspace } = trpc.workspaces.getActive.useQuery();
 	const activeWorkspaceId = activeWorkspace?.id;
 	const allWindows = useWindowsStore((s) => s.windows);
@@ -100,7 +102,7 @@ export function TabsView() {
 					{windows.map((window, index) => (
 						<motion.div
 							key={window.id}
-							layout
+							layout={!isResizing}
 							initial={false}
 							transition={{
 								layout: { duration: 0.2, ease: "easeInOut" },
@@ -128,7 +130,7 @@ export function TabsView() {
 					)}
 				</div>
 				<motion.div
-					layout
+					layout={!isResizing}
 					transition={{ layout: { duration: 0.2, ease: "easeInOut" } }}
 				>
 					<Button

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/index.tsx
@@ -1,4 +1,3 @@
-import { motion } from "framer-motion";
 import { useSidebarStore } from "renderer/stores";
 import { SidebarMode } from "renderer/stores/sidebar-state";
 import { ChangesView } from "./ChangesView";
@@ -6,50 +5,25 @@ import { ModeCarousel } from "./ModeCarousel";
 import { TabsView } from "./TabsView";
 
 export function Sidebar() {
-	const { isSidebarOpen, currentMode, setMode } = useSidebarStore();
+	const { currentMode, setMode } = useSidebarStore();
 
 	const modes: SidebarMode[] = [SidebarMode.Tabs, SidebarMode.Changes];
 
 	return (
-		<motion.aside
-			initial={false}
-			animate={{
-				width: isSidebarOpen ? 256 : 0,
-			}}
-			transition={{
-				duration: 0.2,
-				ease: "easeInOut",
-			}}
-			className="h-full flex flex-col overflow-hidden"
-			style={{
-				pointerEvents: isSidebarOpen ? "auto" : "none",
-			}}
-		>
-			<motion.div
-				initial={false}
-				animate={{
-					opacity: isSidebarOpen ? 1 : 0,
-				}}
-				transition={{
-					duration: 0.15,
-					ease: "easeInOut",
-				}}
-				className="flex-1 flex flex-col overflow-hidden"
+		<aside className="h-full flex flex-col overflow-hidden">
+			<ModeCarousel
+				modes={modes}
+				currentMode={currentMode}
+				onModeSelect={setMode}
 			>
-				<ModeCarousel
-					modes={modes}
-					currentMode={currentMode}
-					onModeSelect={setMode}
-				>
-					{(mode) => {
-						if (mode === SidebarMode.Changes) {
-							return <ChangesView />;
-						}
+				{(mode) => {
+					if (mode === SidebarMode.Changes) {
+						return <ChangesView />;
+					}
 
-						return <TabsView />;
-					}}
-				</ModeCarousel>
-			</motion.div>
-		</motion.aside>
+					return <TabsView />;
+				}}
+			</ModeCarousel>
+		</aside>
 	);
 }

--- a/apps/desktop/src/renderer/stores/sidebar-state.ts
+++ b/apps/desktop/src/renderer/stores/sidebar-state.ts
@@ -1,37 +1,73 @@
 import { create } from "zustand";
-import { devtools } from "zustand/middleware";
+import { devtools, persist } from "zustand/middleware";
 
 export enum SidebarMode {
 	Tabs = "tabs",
 	Changes = "changes",
 }
 
+const DEFAULT_SIDEBAR_SIZE = 15;
+
 interface SidebarState {
 	isSidebarOpen: boolean;
+	sidebarSize: number;
 	currentMode: SidebarMode;
+	isResizing: boolean;
 	toggleSidebar: () => void;
 	setSidebarOpen: (open: boolean) => void;
+	setSidebarSize: (size: number) => void;
 	setMode: (mode: SidebarMode) => void;
+	setIsResizing: (isResizing: boolean) => void;
 }
 
 export const useSidebarStore = create<SidebarState>()(
 	devtools(
-		(set) => ({
-			isSidebarOpen: true,
-			currentMode: "tabs",
+		persist(
+			(set, get) => ({
+				isSidebarOpen: true,
+				sidebarSize: DEFAULT_SIDEBAR_SIZE,
+				currentMode: SidebarMode.Tabs,
+				isResizing: false,
 
-			toggleSidebar: () => {
-				set((state) => ({ isSidebarOpen: !state.isSidebarOpen }));
-			},
+				toggleSidebar: () => {
+					const { isSidebarOpen, sidebarSize } = get();
+					if (isSidebarOpen) {
+						set({ isSidebarOpen: false });
+					} else {
+						set({
+							isSidebarOpen: true,
+							sidebarSize:
+								sidebarSize === 0 ? DEFAULT_SIDEBAR_SIZE : sidebarSize,
+						});
+					}
+				},
 
-			setSidebarOpen: (open) => {
-				set({ isSidebarOpen: open });
-			},
+				setSidebarOpen: (open) => {
+					const { sidebarSize } = get();
+					set({
+						isSidebarOpen: open,
+						sidebarSize:
+							open && sidebarSize === 0 ? DEFAULT_SIDEBAR_SIZE : sidebarSize,
+					});
+				},
 
-			setMode: (mode) => {
-				set({ currentMode: mode });
-			},
-		}),
+				setSidebarSize: (size) => {
+					set({
+						sidebarSize: size,
+						isSidebarOpen: size > 0,
+					});
+				},
+
+				setMode: (mode) => {
+					set({ currentMode: mode });
+				},
+
+				setIsResizing: (isResizing) => {
+					set({ isResizing });
+				},
+			}),
+			{ name: "sidebar-store" },
+		),
 		{ name: "SidebarStore" },
 	),
 );


### PR DESCRIPTION
## Summary
- Replace Framer Motion sidebar animation with ResizablePanel for drag-to-resize functionality
- Persist sidebar size in zustand store with localStorage
- Disable layout animations during resize to prevent jittery content

## Test plan
- [ ] Drag sidebar handle to resize - should be smooth
- [ ] Toggle sidebar with button - should collapse/expand
- [ ] Resize sidebar, close app, reopen - size should persist
- [ ] Drag items in tabs view - should still animate during reorder

🤖 Generated with [Claude Code](https://claude.com/claude-code)