### PR TITLE
feat(desktop): fix some tooltips and gap

### DIFF
--- a/apps/desktop/src/renderer/components/OpenInButton/OpenInButton.tsx
+++ b/apps/desktop/src/renderer/components/OpenInButton/OpenInButton.tsx
@@ -7,6 +7,7 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import type { ExternalApp } from "main/lib/db/schemas";
 import { useState } from "react";
 import { HiChevronDown } from "react-icons/hi2";
@@ -87,17 +88,27 @@ export function OpenInButton({
 	return (
 		<ButtonGroup>
 			{label && (
-				<Button
-					variant="outline"
-					size="sm"
-					className="gap-1.5"
-					onClick={handleOpenLastUsed}
-					disabled={!path}
-					title={`Open in ${currentApp.label}${showShortcuts ? " (⌘O)" : ""}`}
-				>
-					<img src={currentApp.icon} alt="" className="size-4 object-contain" />
-					<span className="font-medium">{label}</span>
-				</Button>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							variant="outline"
+							size="sm"
+							className="gap-1.5"
+							onClick={handleOpenLastUsed}
+							disabled={!path}
+						>
+							<img
+								src={currentApp.icon}
+								alt=""
+								className="size-4 object-contain"
+							/>
+							<span className="font-medium">{label}</span>
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent side="bottom" showArrow={false}>
+						{`Open in ${currentApp.label}${showShortcuts ? " (⌘O)" : ""}`}
+					</TooltipContent>
+				</Tooltip>
 			)}
 			<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
 				<DropdownMenuTrigger asChild>

--- a/apps/desktop/src/renderer/screens/main/components/TopBar/HelpMenu/HelpMenu.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/TopBar/HelpMenu/HelpMenu.tsx
@@ -6,6 +6,7 @@ import {
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
 import { Kbd, KbdGroup } from "@superset/ui/kbd";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { FaDiscord } from "react-icons/fa";
 import {
 	HiOutlineBugAnt,
@@ -39,15 +40,22 @@ export function HelpMenu() {
 
 	return (
 		<DropdownMenu>
-			<DropdownMenuTrigger asChild>
-				<button
-					type="button"
-					className="no-drag flex h-8 w-8 items-center justify-center rounded-md text-accent-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
-					aria-label="Help menu"
-				>
-					<HiOutlineQuestionMarkCircle className="h-4 w-4" />
-				</button>
-			</DropdownMenuTrigger>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<DropdownMenuTrigger asChild>
+						<button
+							type="button"
+							className="no-drag flex h-8 w-8 items-center justify-center rounded-md text-accent-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+							aria-label="Help menu"
+						>
+							<HiOutlineQuestionMarkCircle className="h-4 w-4" />
+						</button>
+					</DropdownMenuTrigger>
+				</TooltipTrigger>
+				<TooltipContent side="bottom" showArrow={false}>
+					Help
+				</TooltipContent>
+			</Tooltip>
 			<DropdownMenuContent align="end" side="bottom" className="w-64">
 				<DropdownMenuItem onClick={handleContactUs}>
 					<HiOutlineEnvelope className="h-4 w-4" />

--- a/apps/desktop/src/renderer/screens/main/components/TopBar/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/TopBar/index.tsx
@@ -23,7 +23,7 @@ export function TopBar() {
 			<div className="flex items-center gap-2 flex-1 overflow-hidden h-full">
 				<WorkspacesTabs />
 			</div>
-			<div className="flex items-center gap-2 h-full pr-4">
+			<div className="flex items-center h-full pr-4">
 				<WorkspaceHeader worktreePath={activeWorkspace?.worktreePath} />
 				<SettingsButton />
 				<HelpMenu />


### PR DESCRIPTION
## Summary
- Replace native `title` attributes with `Tooltip` components in `OpenInButton` and `HelpMenu`
- Adjust TopBar spacing to accommodate tooltip changes
- Provides more polished, consistent tooltip UX across the desktop app

## Test plan
- [ ] Verify tooltips appear on hover for the "Open in" button
- [ ] Verify tooltip appears on hover for the Help menu icon
- [ ] Confirm tooltips display correct text including keyboard shortcuts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX Improvements**
  * Added interactive tooltips to the "Open in" button (displaying the current app name and keyboard shortcut) and Help menu trigger for enhanced user guidance on hover.
  * Refined spacing adjustments in the top bar for improved visual layout and better component alignment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->