### PR TITLE
chore: add Neon MCP server configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/superset
 VITE_DEV_SERVER_PORT=4927
 WEBSITE_URL=http://localhost:3001
+
+# Neon MCP Server API key (for Claude Code integration)
+NEON_API_KEY=your_neon_api_key_here

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+	"mcpServers": {
+		"neon": {
+			"command": "npx",
+			"args": ["-y", "@neondatabase/mcp-server-neon@0.6.5", "start"],
+			"env": {
+				"NEON_API_KEY": "${NEON_API_KEY}"
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `.mcp.json` with Neon MCP server config for Claude Code
- Enables Claude Code to interact with Neon databases directly
- Developers need to set `NEON_API_KEY` environment variable

## Test plan
- [ ] Verify Claude Code picks up the MCP config
- [ ] Test Neon MCP tools work with API key set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Neon integration: a new MCP server entry to enable running the Neon service and reading NEON_API_KEY from the host environment to authenticate.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->