### PR TITLE
chore(ci): bump Neon GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Delete Neon branch
         id: delete-branch
-        uses: neondatabase/delete-branch-action@v3
+        uses: neondatabase/delete-branch-action@v3.2.0
         continue-on-error: true
         with:
           project_id: ${{ vars.NEON_PROJECT_ID }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Create Neon branch
         id: create-branch
-        uses: neondatabase/create-branch-action@v6
+        uses: neondatabase/create-branch-action@v6.1.1
         with:
           project_id: ${{ vars.NEON_PROJECT_ID }}
           branch_name: ${{ github.head_ref }}


### PR DESCRIPTION
## Summary

- Update `create-branch-action`: v6 → v6.1.1 (Sep 19, 2025)
- Update `delete-branch-action`: v3 → v3.2.0 (Oct 8, 2025)

These updates include dependency updates, security patches, and neonctl v2 support.

## Test plan

- [ ] CI workflows pass
- [ ] No functional changes, just version bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)