### PR TITLE
fix(desktop): enable bracketed paste mode for TUI apps

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -13,6 +13,7 @@ import {
 	getDefaultTerminalBg,
 	setupFocusListener,
 	setupKeyboardHandler,
+	setupPasteHandler,
 	setupResizeHandlers,
 } from "./helpers";
 import { TerminalSearch } from "./TerminalSearch";
@@ -271,6 +272,8 @@ export const Terminal = ({ tabId, workspaceId }: TerminalProps) => {
 				resizeRef.current({ tabId: paneId, cols, rows });
 			},
 		);
+		// Setup paste handler to ensure bracketed paste mode works for TUI apps like opencode
+		const cleanupPaste = setupPasteHandler(xterm);
 
 		return () => {
 			isUnmounted = true;
@@ -278,6 +281,7 @@ export const Terminal = ({ tabId, workspaceId }: TerminalProps) => {
 			cleanupKeyboard();
 			cleanupFocus?.();
 			cleanupResize();
+			cleanupPaste();
 			cleanupQuerySuppression();
 			// Keep PTY running for reattachment
 			detachRef.current({ tabId: paneId });


### PR DESCRIPTION
## Summary

- Add custom paste handler that uses xterm's `paste()` method to properly support bracketed paste mode
- Fixes pasting in TUI applications like opencode, vim, and ipython that expect paste content to be wrapped with escape sequences (`\x1b[200~` and `\x1b[201~`)

## Background

TUI applications built with frameworks like [Bubble Tea](https://github.com/charmbracelet/bubbletea) enable bracketed paste mode by default (sending `\x1b[?2004h`). When bracketed paste is enabled, terminals should wrap pasted content with escape sequences so applications can distinguish between typed and pasted input.

xterm.js supports this internally, but [there's no public API to customize paste handling](https://github.com/xtermjs/xterm.js/issues/3516). The recommended workaround from xterm.js maintainers is to intercept the paste event and call `xterm.paste()` directly, which is what this PR implements.

## Test plan

- [x] Paste works in regular shell (bash/zsh)
- [x] Paste works in opencode (Bubble Tea TUI app)
- [x] Paste works in vim
- [x] No double-paste occurs
- [x] Type check passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced terminal paste handling to properly support bracketed paste mode in terminal applications, ensuring clipboard paste operations function correctly across all environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->