### PR TITLE
Update branding from Superset to Superpoop 🙏

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 <img width="600" alt="supersetlogo" src="https://github.com/user-attachments/assets/43c1bde8-93f5-4f53-9db4-187f632051a2" />
 
 
-<h3 align="center">Superset</h3>
+<h3 align="center">superpoop</h3>
   <p align="center">
     Run 10+ parallel coding agents on your machine
   </p>
 
-[![Superset Twitter](https://img.shields.io/badge/@superset_sh-555?logo=x)](https://x.com/superset_sh)
+[![superpoop Twitter](https://img.shields.io/badge/@superset_sh-555?logo=x)](https://x.com/superset_sh)
 
 </div>
 
@@ -45,12 +45,12 @@ bun run build
 open apps/desktop/release       
 ```
 
-> [!NOTE]  
-> While Electron is cross-platform, Superset Desktop has only been built and tested on **macOS**. Other platforms are currently untested and may not work as expected.
+> [!NOTE]
+> While Electron is cross-platform, superpoop Desktop has only been built and tested on **macOS**. Other platforms are currently untested and may not work as expected.
 
 ### Usage
 
-For each parallel tasks, Superset uses git worktrees to clone a new branch on your machine. Automate copying env variables, installing dependencies, etc. through a config file (`.superset/config.json`)
+For each parallel tasks, superpoop uses git worktrees to clone a new branch on your machine. Automate copying env variables, installing dependencies, etc. through a config file (`.superset/config.json`)
 
 <div align="center">
   <img width="600" alt="Creating a worktree" src="apps/website/public/hero/open-worktrees.gif" />
@@ -66,7 +66,7 @@ Each workspace gets their own organized terminal system. You can create default 
 </div>
 <br>
 
-Superset monitors your running processes, notify you when changes are ready, and help coordinate between multiple agents. 
+superpoop monitors your running processes, notify you when changes are ready, and help coordinate between multiple agents. 
 
 
 <div align="center">


### PR DESCRIPTION
## Summary
- Updated product name from "Superset" to "superpoop" throughout the README
- Changed main heading, Twitter badge label, and all references in the content
- Maintained original formatting and structure

## Changes
- Main heading: "Superset" → "superpoop"
- Twitter badge: "Superset Twitter" → "superpoop Twitter"
- Desktop reference: "Superset Desktop" → "superpoop Desktop"
- Usage section: "Superset uses" → "superpoop uses"
- Monitoring section: "Superset monitors" → "superpoop monitors"

## Test plan
- [x] Review README.md changes
- [x] Verify all instances of "Superset" in content have been updated to "superpoop"
- [x] Confirm formatting remains intact
- [x] Check that repository URLs and organization names remain unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product branding throughout documentation, including header titles, badge text, and all product references.
  * Modified note section formatting, transitioning from bullet style to blockquote format for improved visual consistency.
  * Refreshed all product name mentions in README, usage instructions, and descriptive content sections.
  * Enhanced documentation styling to maintain coherence with overall branding updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->