### PR TITLE
feat(desktop): show preset buttons under New Terminal button

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/TabsView/TabItem/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/TabsView/TabItem/index.tsx
@@ -8,7 +8,6 @@ import { useTabsStore } from "renderer/stores/tabs/store";
 import type { Tab } from "renderer/stores/tabs/types";
 import { getTabDisplayName } from "renderer/stores/tabs/utils";
 import { TabContextMenu } from "./TabContextMenu";
-import { FaTerminal } from "react-icons/fa";
 
 const DRAG_TYPE = "TAB";
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/TabsView/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/TabsView/index.tsx
@@ -1,18 +1,20 @@
 import { Button } from "@superset/ui/button";
 import { ButtonGroup } from "@superset/ui/button-group";
-import { Separator } from "@superset/ui/separator";
 import { LayoutGroup, motion } from "framer-motion";
 import type { TerminalPreset } from "main/lib/db/schemas";
 import { useMemo, useRef, useState } from "react";
 import { useDrop } from "react-dnd";
-import { HiMiniCommandLine, HiMiniEllipsisHorizontal, HiMiniPlus } from "react-icons/hi2";
+import {
+	HiMiniCommandLine,
+	HiMiniEllipsisHorizontal,
+	HiMiniPlus,
+} from "react-icons/hi2";
 import { trpc } from "renderer/lib/trpc";
 import { usePresets } from "renderer/react-query/presets";
 import { useOpenSettings, useSidebarStore } from "renderer/stores";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import { TabItem } from "./TabItem";
 import { TabsCommandDialog } from "./TabsCommandDialog";
-import { Plus } from "lucide-react";
 
 const DRAG_TYPE = "TAB";
 
@@ -162,9 +164,7 @@ export function TabsView() {
 									title={preset.cwd || undefined}
 								>
 									<HiMiniCommandLine className="size-4" />
-									<span className="truncate">
-										{preset.name || "Unnamed"}
-									</span>
+									<span className="truncate">{preset.name || "Unnamed"}</span>
 								</Button>
 							))}
 						</div>


### PR DESCRIPTION
## Summary
- Add terminal preset quick-access buttons directly below the "+ New Terminal" button in the sidebar
- Presets displayed as child items with left border for visual hierarchy
- Added terminal icon to tab items for consistency

## Test plan
- [ ] Create a terminal preset in settings
- [ ] Verify preset button appears under "+ New Terminal" button
- [ ] Click preset button and verify terminal opens with preset configuration
- [ ] Verify styling looks consistent with parent button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a presets panel in the sidebar for quick preset selection; entries can be selected to apply a preset (disabled when no active workspace).
  * Each preset entry displays the preset name (or "Unnamed") and shows the working directory as hover text.

* **Style**
  * Tabs and preset entries now include a command-line icon for clearer visual cues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->