### PR TITLE
fix(desktop): restore SUPERSET_ROOT_PATH and related env vars to terminal

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/terminal/terminal.ts
+++ b/apps/desktop/src/lib/trpc/routers/terminal/terminal.ts
@@ -15,6 +15,9 @@ import { resolveCwd } from "./utils";
  * - SUPERSET_PANE_ID: The pane ID (used by notification hooks, session key)
  * - SUPERSET_TAB_ID: The tab ID (parent of pane, used by notification hooks)
  * - SUPERSET_WORKSPACE_ID: The workspace ID (used by notification hooks)
+ * - SUPERSET_WORKSPACE_NAME: The workspace name (used by setup/teardown scripts)
+ * - SUPERSET_WORKSPACE_PATH: The worktree path (used by setup/teardown scripts)
+ * - SUPERSET_ROOT_PATH: The main repo path (used by setup/teardown scripts)
  * - SUPERSET_PORT: The hooks server port for agent completion notifications
  */
 export const createTerminalRouter = () => {
@@ -49,10 +52,18 @@ export const createTerminalRouter = () => {
 					: undefined;
 				const cwd = resolveCwd(cwdOverride, worktreePath);
 
+				// Get project info for environment variables
+				const project = workspace
+					? db.data.projects.find((p) => p.id === workspace.projectId)
+					: undefined;
+
 				const result = await terminalManager.createOrAttach({
 					paneId,
 					tabId,
 					workspaceId,
+					workspaceName: workspace?.name,
+					workspacePath: worktreePath,
+					rootPath: project?.mainRepoPath,
 					cwd,
 					cols,
 					rows,

--- a/apps/desktop/src/main/lib/terminal-manager.ts
+++ b/apps/desktop/src/main/lib/terminal-manager.ts
@@ -51,6 +51,9 @@ export class TerminalManager extends EventEmitter {
 		paneId: string;
 		tabId: string;
 		workspaceId: string;
+		workspaceName?: string;
+		workspacePath?: string;
+		rootPath?: string;
 		cwd?: string;
 		cols?: number;
 		rows?: number;
@@ -60,8 +63,18 @@ export class TerminalManager extends EventEmitter {
 		scrollback: string;
 		wasRecovered: boolean;
 	}> {
-		const { paneId, tabId, workspaceId, cwd, cols, rows, initialCommands } =
-			params;
+		const {
+			paneId,
+			tabId,
+			workspaceId,
+			workspaceName,
+			workspacePath,
+			rootPath,
+			cwd,
+			cols,
+			rows,
+			initialCommands,
+		} = params;
 
 		// Deduplicate concurrent calls for the same paneId (prevents race in React Strict Mode)
 		const pending = this.pendingSessions.get(paneId);
@@ -87,6 +100,9 @@ export class TerminalManager extends EventEmitter {
 			paneId,
 			tabId,
 			workspaceId,
+			workspaceName,
+			workspacePath,
+			rootPath,
 			cwd,
 			cols,
 			rows,
@@ -106,6 +122,9 @@ export class TerminalManager extends EventEmitter {
 		paneId: string;
 		tabId: string;
 		workspaceId: string;
+		workspaceName?: string;
+		workspacePath?: string;
+		rootPath?: string;
 		cwd?: string;
 		cols?: number;
 		rows?: number;
@@ -120,6 +139,9 @@ export class TerminalManager extends EventEmitter {
 			paneId,
 			tabId,
 			workspaceId,
+			workspaceName,
+			workspacePath,
+			rootPath,
 			cwd,
 			cols,
 			rows,
@@ -140,6 +162,9 @@ export class TerminalManager extends EventEmitter {
 			SUPERSET_PANE_ID: paneId,
 			SUPERSET_TAB_ID: tabId,
 			SUPERSET_WORKSPACE_ID: workspaceId,
+			SUPERSET_WORKSPACE_NAME: workspaceName || "",
+			SUPERSET_WORKSPACE_PATH: workspacePath || "",
+			SUPERSET_ROOT_PATH: rootPath || "",
 			SUPERSET_PORT: String(PORTS.NOTIFICATIONS),
 		};
 


### PR DESCRIPTION
## Summary
- Re-adds environment variables that were accidentally removed in #303
- Restores `SUPERSET_WORKSPACE_NAME`, `SUPERSET_WORKSPACE_PATH`, and `SUPERSET_ROOT_PATH` to terminal sessions
- These are needed by setup/teardown scripts that run in terminals

## Test plan
- [x] Open a terminal in a workspace
- [x] Run `env | grep SUPERSET` and verify all env vars are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminals now expose workspace context through environment variables (SUPERSET_WORKSPACE_NAME, SUPERSET_WORKSPACE_PATH, SUPERSET_ROOT_PATH), providing workspace and project information for terminal commands and scripts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->