### PR TITLE
fix(ci): add DATABASE_URL to deploy-api and parallelize deploys

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -68,6 +68,8 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_API_PROJECT_ID }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_URL_UNPOOLED: ${{ secrets.DATABASE_URL_UNPOOLED }}
           NEXT_PUBLIC_WEB_URL: ${{ secrets.NEXT_PUBLIC_WEB_URL }}
           NEXT_PUBLIC_ADMIN_URL: ${{ secrets.NEXT_PUBLIC_ADMIN_URL }}
           MOCK_USER_ID: ${{ secrets.MOCK_USER_ID }}
@@ -80,7 +82,7 @@ jobs:
     name: Deploy Web to Vercel
     runs-on: ubuntu-latest
     environment: production
-    needs: deploy-api
+    needs: deploy-database
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- Add missing `DATABASE_URL` and `DATABASE_URL_UNPOOLED` to deploy-api job
- Change deploy-web to depend on deploy-database instead of deploy-api (parallelize)

## Test plan

- [ ] Production deploy succeeds for all apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow configuration to enhance database integration and dependency management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->