### PR TITLE
fix(scripts): improve workspace setup/teardown reliability

### DIFF
--- a/.superset/setup.sh
+++ b/.superset/setup.sh
@@ -10,6 +10,13 @@ success() { echo -e "${GREEN}✓${NC} $1"; }
 
 echo "🚀 Setting up Superset workspace..."
 
+# Load root .env for this script (provides NEON_PROJECT_ID, etc.)
+if [ -n "$SUPERSET_ROOT_PATH" ] && [ -f "$SUPERSET_ROOT_PATH/.env" ]; then
+  set -a
+  source "$SUPERSET_ROOT_PATH/.env"
+  set +a
+fi
+
 # Check dependencies
 command -v bun &> /dev/null || error "Bun not installed. Install from https://bun.sh"
 command -v neonctl &> /dev/null || error "Neon CLI not installed. Run: npm install -g neonctl"
@@ -24,38 +31,48 @@ echo "📥 Installing dependencies..."
 bun install
 success "Dependencies installed"
 
-# Link direnv config from root repo if it exists
-if [ -n "$SUPERSET_ROOT_PATH" ] && [ -f "$SUPERSET_ROOT_PATH/.envrc" ]; then
-  echo "🔧 Linking .envrc..."
-  ln -sf "$SUPERSET_ROOT_PATH/.envrc" .envrc
+# Create .envrc for direnv
+if [ ! -f .envrc ]; then
+  echo "🔧 Creating .envrc..."
+  cat > .envrc << 'ENVRC'
+#!/usr/bin/env bash
+dotenv .env
+ENVRC
   if command -v direnv &> /dev/null; then
     direnv allow
   fi
   success "direnv configured"
 fi
 
-# Create Neon branch for this workspace
-echo "🗄️  Creating Neon branch..."
+# Create or get Neon branch for this workspace
 WORKSPACE_NAME="${SUPERSET_WORKSPACE_NAME:-$(basename "$PWD")}"
-NEON_OUTPUT=$(neonctl branches create \
-  --project-id "$NEON_PROJECT_ID" \
-  --name "$WORKSPACE_NAME" \
-  --output json)
 
-# Parse connection strings from create output
-BRANCH_ID=$(echo "$NEON_OUTPUT" | jq -r '.branch.id')
-DIRECT_URL=$(echo "$NEON_OUTPUT" | jq -r '.connection_uris[0].connection_uri')
-POOLER_HOST=$(echo "$NEON_OUTPUT" | jq -r '.connection_uris[0].connection_parameters.pooler_host')
-PASSWORD=$(echo "$NEON_OUTPUT" | jq -r '.connection_uris[0].connection_parameters.password')
-ROLE=$(echo "$NEON_OUTPUT" | jq -r '.connection_uris[0].connection_parameters.role')
-DATABASE=$(echo "$NEON_OUTPUT" | jq -r '.connection_uris[0].connection_parameters.database')
-POOLED_URL="postgresql://${ROLE}:${PASSWORD}@${POOLER_HOST}/${DATABASE}?sslmode=require"
+# Check if branch already exists
+EXISTING_BRANCH=$(neonctl branches list --project-id "$NEON_PROJECT_ID" --output json | jq -r ".[] | select(.name == \"$WORKSPACE_NAME\") | .id")
 
-cat >> .env << EOF
-NEON_BRANCH_ID=$BRANCH_ID
-DATABASE_URL=$POOLED_URL
-DATABASE_URL_UNPOOLED=$DIRECT_URL
-EOF
+if [ -n "$EXISTING_BRANCH" ]; then
+  echo "🗄️  Using existing Neon branch..."
+  BRANCH_ID="$EXISTING_BRANCH"
+  # Get connection strings for existing branch
+  DIRECT_URL=$(neonctl connection-string "$EXISTING_BRANCH" --project-id "$NEON_PROJECT_ID")
+  POOLED_URL=$(neonctl connection-string "$EXISTING_BRANCH" --project-id "$NEON_PROJECT_ID" --pooled)
+else
+  echo "🗄️  Creating Neon branch..."
+  NEON_OUTPUT=$(neonctl branches create \
+    --project-id "$NEON_PROJECT_ID" \
+    --name "$WORKSPACE_NAME" \
+    --output json)
+  BRANCH_ID=$(echo "$NEON_OUTPUT" | jq -r '.branch.id')
+  # Get connection strings for new branch
+  DIRECT_URL=$(neonctl connection-string "$BRANCH_ID" --project-id "$NEON_PROJECT_ID")
+  POOLED_URL=$(neonctl connection-string "$BRANCH_ID" --project-id "$NEON_PROJECT_ID" --pooled)
+fi
+
+# Copy root .env and override with branch-specific values
+cp "$SUPERSET_ROOT_PATH/.env" .env
+sed -i '' "s|^DATABASE_URL=.*|DATABASE_URL=$POOLED_URL|" .env
+sed -i '' "s|^DATABASE_URL_UNPOOLED=.*|DATABASE_URL_UNPOOLED=$DIRECT_URL|" .env
+echo "NEON_BRANCH_ID=$BRANCH_ID" >> .env
 
 success "Neon branch created: $WORKSPACE_NAME"
 echo "✨ Done!"

--- a/.superset/teardown.sh
+++ b/.superset/teardown.sh
@@ -10,6 +10,14 @@ success() { echo -e "${GREEN}✓${NC} $1"; }
 
 echo "🧹 Tearing down Superset workspace..."
 
+# Load local .env
+if [ -f ".env" ]; then
+  # shellcheck disable=SC1091
+  set -a
+  source .env
+  set +a
+fi
+
 # Check dependencies
 command -v neonctl &> /dev/null || error "Neon CLI not installed. Run: npm install -g neonctl"
 
@@ -17,16 +25,13 @@ command -v neonctl &> /dev/null || error "Neon CLI not installed. Run: npm insta
 NEON_PROJECT_ID="${NEON_PROJECT_ID:-}"
 [ -z "$NEON_PROJECT_ID" ] && error "NEON_PROJECT_ID environment variable is required"
 
-# Delete Neon branch for this workspace
-WORKSPACE_NAME="${SUPERSET_WORKSPACE_NAME:-$(basename "$PWD")}"
-if [ -f ".env" ]; then
-  # shellcheck disable=SC1091
-  source .env
-fi
 BRANCH_ID="${NEON_BRANCH_ID:-}"
 if [ -z "$BRANCH_ID" ]; then
   error "No NEON_BRANCH_ID found in .env; cannot delete branch"
 fi
+
+# Delete Neon branch for this workspace
+WORKSPACE_NAME="${SUPERSET_WORKSPACE_NAME:-$(basename "$PWD")}"
 
 echo "🗄️  Deleting Neon branch: $WORKSPACE_NAME ($BRANCH_ID)"
 if neonctl branches delete "$BRANCH_ID" --project-id "$NEON_PROJECT_ID" --force 2>/dev/null; then


### PR DESCRIPTION
## Summary
- Source root .env at start of setup to get NEON_PROJECT_ID
- Copy root .env to worktree and override DATABASE_URLs with branch-specific values  
- Create .envrc instead of symlinking to root
- Make setup idempotent by checking for existing Neon branches
- Make teardown idempotent by handling already-deleted branches gracefully

## Test plan
- [x] Tested setup.sh on fresh worktree
- [x] Tested setup.sh re-run (idempotent - uses existing branch)
- [x] Tested teardown.sh
- [x] Tested teardown.sh re-run (idempotent - graceful warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace setup now intelligently reuses existing database branches when available, eliminating unnecessary duplication.
  * Improved environment configuration handling with automatic population of database connection strings.

* **Bug Fixes**
  * Enhanced teardown process with improved error handling and informative messaging when database branch removal fails.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->