### PR TITLE
fix(scripts): append database URLs instead of sed replacement

### DIFF
--- a/.superset/setup.sh
+++ b/.superset/setup.sh
@@ -68,11 +68,15 @@ else
   POOLED_URL=$(neonctl connection-string "$BRANCH_ID" --project-id "$NEON_PROJECT_ID" --pooled)
 fi
 
-# Copy root .env and override with branch-specific values
+# Copy root .env and append branch-specific values
 cp "$SUPERSET_ROOT_PATH/.env" .env
-sed -i '' "s|^DATABASE_URL=.*|DATABASE_URL=$POOLED_URL|" .env
-sed -i '' "s|^DATABASE_URL_UNPOOLED=.*|DATABASE_URL_UNPOOLED=$DIRECT_URL|" .env
-echo "NEON_BRANCH_ID=$BRANCH_ID" >> .env
+cat >> .env << EOF
+
+# Workspace Database (Neon Branch)
+NEON_BRANCH_ID=$BRANCH_ID
+DATABASE_URL=$POOLED_URL
+DATABASE_URL_UNPOOLED=$DIRECT_URL
+EOF
 
 success "Neon branch created: $WORKSPACE_NAME"
 echo "✨ Done!"


### PR DESCRIPTION
## Summary
- Append branch-specific DATABASE_URL values at end of .env instead of sed replacement
- Simpler and more robust - doesn't depend on exact format of root .env
- Adds clear `# Workspace Database (Neon Branch)` header

## Test plan
- [x] Tested setup.sh - branch URLs appended at end of .env

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved environment variable initialization during the setup process for more reliable configuration management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->