### PR TITLE
fix: simplify tRPC headers and add image alt attributes

### DIFF
--- a/.github/templates/cleanup-comment.md
+++ b/.github/templates/cleanup-comment.md
@@ -8,7 +8,7 @@ The following preview resources have been cleaned up:
 <th align="center">Status</th>
 </tr>
 <tr>
-<td><img src="https://neon.com/favicon.ico" width="20" height="20"> <strong>Database (Neon)</strong></td>
+<td><img src="https://neon.com/favicon.ico" width="20" height="20" alt="Neon"> <strong>Database (Neon)</strong></td>
 <td align="center">$NEON_STATUS</td>
 </tr>
 </table>

--- a/.github/templates/preview-comment.md
+++ b/.github/templates/preview-comment.md
@@ -9,32 +9,32 @@
 <th align="left">Link</th>
 </tr>
 <tr>
-<td><img src="https://neon.com/favicon.ico" width="20" height="20"> <strong>Database (Neon)</strong></td>
+<td><img src="https://neon.com/favicon.ico" width="20" height="20" alt="Neon"> <strong>Database (Neon)</strong></td>
 <td align="center">$DATABASE_STATUS</td>
 <td>$DATABASE_LINK</td>
 </tr>
 <tr>
-<td><img src="https://vercel.com/favicon.ico" width="20" height="20"> <strong>API (Vercel)</strong></td>
+<td><img src="https://vercel.com/favicon.ico" width="20" height="20" alt="Vercel"> <strong>API (Vercel)</strong></td>
 <td align="center">$API_STATUS</td>
 <td>$API_LINK</td>
 </tr>
 <tr>
-<td><img src="https://vercel.com/favicon.ico" width="20" height="20"> <strong>Web (Vercel)</strong></td>
+<td><img src="https://vercel.com/favicon.ico" width="20" height="20" alt="Vercel"> <strong>Web (Vercel)</strong></td>
 <td align="center">$WEB_STATUS</td>
 <td>$WEB_LINK</td>
 </tr>
 <tr>
-<td><img src="https://vercel.com/favicon.ico" width="20" height="20"> <strong>Marketing (Vercel)</strong></td>
+<td><img src="https://vercel.com/favicon.ico" width="20" height="20" alt="Vercel"> <strong>Marketing (Vercel)</strong></td>
 <td align="center">$MARKETING_STATUS</td>
 <td>$MARKETING_LINK</td>
 </tr>
 <tr>
-<td><img src="https://vercel.com/favicon.ico" width="20" height="20"> <strong>Admin (Vercel)</strong></td>
+<td><img src="https://vercel.com/favicon.ico" width="20" height="20" alt="Vercel"> <strong>Admin (Vercel)</strong></td>
 <td align="center">$ADMIN_STATUS</td>
 <td>$ADMIN_LINK</td>
 </tr>
 <tr>
-<td><img src="https://vercel.com/favicon.ico" width="20" height="20"> <strong>Docs (Vercel)</strong></td>
+<td><img src="https://vercel.com/favicon.ico" width="20" height="20" alt="Vercel"> <strong>Docs (Vercel)</strong></td>
 <td align="center">$DOCS_STATUS</td>
 <td>$DOCS_LINK</td>
 </tr>

--- a/apps/admin/src/trpc/react.tsx
+++ b/apps/admin/src/trpc/react.tsx
@@ -45,9 +45,7 @@ export function TRPCReactProvider(props: { children: React.ReactNode }) {
 					transformer: SuperJSON,
 					url: `${env.NEXT_PUBLIC_API_URL}/api/trpc`,
 					headers() {
-						const headers = new Headers();
-						headers.set("x-trpc-source", "nextjs-react");
-						return headers;
+						return { "x-trpc-source": "nextjs-react" };
 					},
 				}),
 			],

--- a/apps/web/src/trpc/react.tsx
+++ b/apps/web/src/trpc/react.tsx
@@ -47,9 +47,7 @@ export function TRPCReactProvider(props: { children: React.ReactNode }) {
 					transformer: SuperJSON,
 					url: `${env.NEXT_PUBLIC_API_URL}/api/trpc`,
 					headers() {
-						const headers = new Headers();
-						headers.set("x-trpc-source", "nextjs-react");
-						return headers;
+						return { "x-trpc-source": "nextjs-react" };
 					},
 				}),
 			],


### PR DESCRIPTION
## Summary
- Simplify tRPC headers in web and admin apps to return plain objects instead of using `new Headers()` constructor
- Add alt attributes to `<img>` tags in preview and cleanup comment templates for accessibility (MD045)

## Test plan
- [x] Typecheck passes locally
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)