### PR TITLE
fix(desktop): prevent text overflow in discard changes dialog

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/ChangesContent/components/DiscardConfirmDialog/DiscardConfirmDialog.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/ChangesContent/components/DiscardConfirmDialog/DiscardConfirmDialog.tsx
@@ -32,30 +32,38 @@ export function DiscardConfirmDialog({
 
 	return (
 		<AlertDialog open={open} onOpenChange={onOpenChange}>
-			<AlertDialogContent>
+			<AlertDialogContent className="overflow-hidden">
 				<AlertDialogHeader>
 					<AlertDialogTitle>
 						{isUntracked ? "Delete File" : "Discard Changes"}
 					</AlertDialogTitle>
-					<AlertDialogDescription>
-						{isUntracked ? (
-							<>
-								Are you sure you want to permanently delete "{filePath}"?
-								<span className="block mt-2 text-destructive">
-									This will permanently delete this file from disk. This action
-									cannot be undone.
-								</span>
-							</>
-						) : (
-							<>
-								Are you sure you want to discard all changes to "{filePath}"?
-								<span className="block mt-2 text-destructive">
-									This will revert the file to its last committed state. All
-									uncommitted changes will be lost. This action cannot be
-									undone.
-								</span>
-							</>
-						)}
+					<AlertDialogDescription asChild>
+						<div className="text-muted-foreground text-sm">
+							{isUntracked ? (
+								<>
+									<p>Are you sure you want to permanently delete</p>
+									<p className="my-1 break-all font-mono text-xs">
+										"{filePath}"?
+									</p>
+									<p className="mt-2 text-destructive">
+										This will permanently delete this file from disk. This
+										action cannot be undone.
+									</p>
+								</>
+							) : (
+								<>
+									<p>Are you sure you want to discard all changes to</p>
+									<p className="my-1 break-all font-mono text-xs">
+										"{filePath}"?
+									</p>
+									<p className="mt-2 text-destructive">
+										This will revert the file to its last committed state. All
+										uncommitted changes will be lost. This action cannot be
+										undone.
+									</p>
+								</>
+							)}
+						</div>
 					</AlertDialogDescription>
 				</AlertDialogHeader>
 				<AlertDialogFooter>


### PR DESCRIPTION
## Summary
- Fixed long file paths causing text overflow in the "Discard Changes" dialog
- File paths now display on their own line with `break-all` wrapping
- Added `overflow-hidden` to dialog container to prevent content from escaping bounds

## Test plan
- [ ] Open the desktop app and make changes to a file with a long path
- [ ] Right-click and select "Discard Changes"
- [ ] Verify the dialog displays correctly without text overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the discard confirmation dialog's layout with improved text formatting, displaying messages in a structured multi-paragraph format for better readability.
  * Enhanced overflow handling in the dialog to prevent content spillover.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->