### PR TITLE
fix: meta hotkey display in shortcuts table

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/SettingsView/KeyboardShortcutsSettings.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/SettingsView/KeyboardShortcutsSettings.tsx
@@ -1,21 +1,14 @@
 import { Input } from "@superset/ui/input";
 import { Kbd, KbdGroup } from "@superset/ui/kbd";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { HiMagnifyingGlass } from "react-icons/hi2";
 import {
 	formatKeysForDisplay,
 	getHotkeysByCategory,
 	type HotkeyCategory,
 	type HotkeyDefinition,
+	useIsMac
 } from "shared/hotkeys";
-
-function useIsMac(): boolean {
-	return useMemo(() => {
-		const platform = navigator.platform?.toUpperCase() ?? "";
-		const userAgent = navigator.userAgent?.toUpperCase() ?? "";
-		return platform.includes("MAC") || userAgent.includes("MAC");
-	}, []);
-}
 
 const CATEGORY_ORDER: HotkeyCategory[] = [
 	"Workspace",

--- a/apps/desktop/src/shared/hotkeys.ts
+++ b/apps/desktop/src/shared/hotkeys.ts
@@ -3,6 +3,30 @@
  * Used both for registering shortcuts and displaying in the hotkey modal.
  */
 
+import { useMemo } from "react";
+
+export function useIsMac(): boolean {
+	return useMemo(() => {
+		const platform = navigator.platform?.toUpperCase() ?? "";
+		const userAgent = navigator.userAgent?.toUpperCase() ?? "";
+		return platform.includes("MAC") || userAgent.includes("MAC");
+	}, []);
+}
+
+export function useIsWindows(): boolean {
+	return useMemo(() => {
+		const platform = navigator.platform?.toUpperCase() ?? "";
+		const userAgent = navigator.userAgent?.toUpperCase() ?? "";
+
+		return (
+			platform.includes("WIN") ||
+			userAgent.includes("WINDOWS") ||
+			userAgent.includes("WIN32") ||
+			userAgent.includes("WIN64")
+		);
+	}, []);
+}
+
 export type HotkeyCategory =
 	| "Workspace"
 	| "Layout"
@@ -192,14 +216,41 @@ export function getHotkeysByCategory(): Record<
 }
 
 /**
- * Format a key string for display (e.g., "meta+shift+d" -> ["⌘", "⇧", "D"])
+ * Format a key string for display
+ * (e.g., "meta+shift+d" -> ["⌘", "⇧", "D"] on Mac, or "meta+shift+d" -> ["Win", "⇧", "D"] on Windows)
  */
 export function formatKeysForDisplay(keys: string): string[] {
+	const isMac = useIsMac();
+	const isWindows = useIsWindows();
+
+	const metaKeyMaps = useMemo(() => {
+		if (isMac) {
+			return {
+				meta: "⌘",
+				ctrl: "⌃",
+				alt: "⌥",
+				shift: "⇧",
+			};
+		}
+		if (isWindows) {
+			return {
+				meta: "Win",
+				ctrl: "Ctrl",
+				alt: "Alt",
+				shift: "Shift",
+			};
+		}
+		// Linux / Other
+		return {
+			meta: "Super",
+			ctrl: "Ctrl",
+			alt: "Alt",
+			shift: "Shift",
+		};
+	}, [isMac, isWindows]);
+
 	const keyMap: Record<string, string> = {
-		meta: "⌘",
-		ctrl: "⌃",
-		alt: "⌥",
-		shift: "⇧",
+		...metaKeyMaps,
 		enter: "↵",
 		backspace: "⌫",
 		delete: "⌦",


### PR DESCRIPTION
## Description

Before, the hotkey table would display with the Mac meta key in the table even on Linux. This PR changes it to "Super" on Linux and "Win" on Windows.

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Other (please describe): Shortcut Formatting UI Change

## Testing

This PR is tested on Linux but not Mac or Windows. To test on Mac and Windows, navigate to the keyboard shortcuts page in settings and check that it displays the correct shortcut. That would look like `⌘ ⇧ D` on Mac for instance.

## Screenshots (if applicable)

<img width="1919" height="1079" alt="2025-12-12_16-15" src="https://github.com/user-attachments/assets/77967f3e-bf53-4a9b-ba26-43488ef84e5e" />

## Additional Notes

Typically on Linux, the super key is reserved for window manager specific key shortcuts and Ctrl is used for applications. Future changes can include changing the default meta on Linux to Ctrl instead of Super.

## Root Causing the issue

<img width="673" height="924" alt="image" src="https://github.com/user-attachments/assets/d8923930-62c9-45e5-9819-a42138731854" />

<img width="554" height="959" alt="image" src="https://github.com/user-attachments/assets/e35f7c24-0845-4ca4-bda7-26bc10b67173" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keyboard shortcuts now display with operating system-specific symbols and labels for improved clarity across different platforms
  * Mac users see ⌘/⌃/⌥/⇧, Windows users see Win/Ctrl/Alt/Shift, and Linux users see Super/Ctrl/Alt/Shift

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->