### PR TITLE
fix: pass runtime env vars to Vercel deploy

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -123,10 +123,19 @@ jobs:
           NEXT_PUBLIC_ADMIN_URL: https://${{ env.ADMIN_ALIAS }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           CLERK_WEBHOOK_SECRET: ${{ secrets.CLERK_WEBHOOK_SECRET }}
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
         run: |
           vercel pull --yes --environment=preview --token=$VERCEL_TOKEN
           vercel build --token=$VERCEL_TOKEN
-          VERCEL_URL=$(vercel deploy --prebuilt --token=$VERCEL_TOKEN)
+          VERCEL_URL=$(vercel deploy --prebuilt --token=$VERCEL_TOKEN \
+            --env CLERK_SECRET_KEY=$CLERK_SECRET_KEY \
+            --env CLERK_WEBHOOK_SECRET=$CLERK_WEBHOOK_SECRET \
+            --env DATABASE_URL=$DATABASE_URL \
+            --env DATABASE_URL_UNPOOLED=$DATABASE_URL_UNPOOLED \
+            --env BLOB_READ_WRITE_TOKEN=$BLOB_READ_WRITE_TOKEN \
+            --env NEXT_PUBLIC_WEB_URL=$NEXT_PUBLIC_WEB_URL \
+            --env NEXT_PUBLIC_ADMIN_URL=$NEXT_PUBLIC_ADMIN_URL \
+            --env NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=$NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY)
           vercel alias $VERCEL_URL ${{ env.API_ALIAS }} --scope=$VERCEL_ORG_ID --token=$VERCEL_TOKEN
           echo "vercel_url=$VERCEL_URL" >> $GITHUB_OUTPUT
 
@@ -199,7 +208,10 @@ jobs:
         run: |
           vercel pull --yes --environment=preview --token=$VERCEL_TOKEN
           vercel build --token=$VERCEL_TOKEN
-          VERCEL_URL=$(vercel deploy --prebuilt --token=$VERCEL_TOKEN)
+          VERCEL_URL=$(vercel deploy --prebuilt --token=$VERCEL_TOKEN \
+            --env CLERK_SECRET_KEY=$CLERK_SECRET_KEY \
+            --env DATABASE_URL=$DATABASE_URL \
+            --env DATABASE_URL_UNPOOLED=$DATABASE_URL_UNPOOLED)
           vercel alias $VERCEL_URL ${{ env.WEB_ALIAS }} --scope=$VERCEL_ORG_ID --token=$VERCEL_TOKEN
           echo "vercel_url=$VERCEL_URL" >> $GITHUB_OUTPUT
 
@@ -257,7 +269,8 @@ jobs:
         run: |
           vercel pull --yes --environment=preview --token=$VERCEL_TOKEN
           vercel build --token=$VERCEL_TOKEN
-          VERCEL_URL=$(vercel deploy --prebuilt --token=$VERCEL_TOKEN)
+          VERCEL_URL=$(vercel deploy --prebuilt --token=$VERCEL_TOKEN \
+            --env CLERK_SECRET_KEY=$CLERK_SECRET_KEY)
           vercel alias $VERCEL_URL ${{ env.MARKETING_ALIAS }} --scope=$VERCEL_ORG_ID --token=$VERCEL_TOKEN
           echo "vercel_url=$VERCEL_URL" >> $GITHUB_OUTPUT
 
@@ -328,7 +341,10 @@ jobs:
         run: |
           vercel pull --yes --environment=preview --token=$VERCEL_TOKEN
           vercel build --token=$VERCEL_TOKEN
-          VERCEL_URL=$(vercel deploy --prebuilt --token=$VERCEL_TOKEN)
+          VERCEL_URL=$(vercel deploy --prebuilt --token=$VERCEL_TOKEN \
+            --env CLERK_SECRET_KEY=$CLERK_SECRET_KEY \
+            --env DATABASE_URL=$DATABASE_URL \
+            --env DATABASE_URL_UNPOOLED=$DATABASE_URL_UNPOOLED)
           vercel alias $VERCEL_URL ${{ env.ADMIN_ALIAS }} --scope=$VERCEL_ORG_ID --token=$VERCEL_TOKEN
           echo "vercel_url=$VERCEL_URL" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -75,10 +75,19 @@ jobs:
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           CLERK_WEBHOOK_SECRET: ${{ secrets.CLERK_WEBHOOK_SECRET }}
           BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
         run: |
           vercel pull --yes --environment=production --token=$VERCEL_TOKEN
           vercel build --prod --token=$VERCEL_TOKEN
-          vercel deploy --prod --prebuilt --token=$VERCEL_TOKEN
+          vercel deploy --prod --prebuilt --token=$VERCEL_TOKEN \
+            --env CLERK_SECRET_KEY=$CLERK_SECRET_KEY \
+            --env CLERK_WEBHOOK_SECRET=$CLERK_WEBHOOK_SECRET \
+            --env DATABASE_URL=$DATABASE_URL \
+            --env DATABASE_URL_UNPOOLED=$DATABASE_URL_UNPOOLED \
+            --env BLOB_READ_WRITE_TOKEN=$BLOB_READ_WRITE_TOKEN \
+            --env NEXT_PUBLIC_WEB_URL=$NEXT_PUBLIC_WEB_URL \
+            --env NEXT_PUBLIC_ADMIN_URL=$NEXT_PUBLIC_ADMIN_URL \
+            --env NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=$NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
 
   deploy-web:
     name: Deploy Web to Vercel
@@ -123,7 +132,10 @@ jobs:
         run: |
           vercel pull --yes --environment=production --token=$VERCEL_TOKEN
           vercel build --prod --token=$VERCEL_TOKEN
-          vercel deploy --prod --prebuilt --token=$VERCEL_TOKEN
+          vercel deploy --prod --prebuilt --token=$VERCEL_TOKEN \
+            --env CLERK_SECRET_KEY=$CLERK_SECRET_KEY \
+            --env DATABASE_URL=$DATABASE_URL \
+            --env DATABASE_URL_UNPOOLED=$DATABASE_URL_UNPOOLED
 
   deploy-marketing:
     name: Deploy Marketing to Vercel
@@ -165,7 +177,8 @@ jobs:
         run: |
           vercel pull --yes --environment=production --token=$VERCEL_TOKEN
           vercel build --prod --token=$VERCEL_TOKEN
-          vercel deploy --prod --prebuilt --token=$VERCEL_TOKEN
+          vercel deploy --prod --prebuilt --token=$VERCEL_TOKEN \
+            --env CLERK_SECRET_KEY=$CLERK_SECRET_KEY
 
   deploy-admin:
     name: Deploy Admin to Vercel
@@ -209,7 +222,10 @@ jobs:
         run: |
           vercel pull --yes --environment=production --token=$VERCEL_TOKEN
           vercel build --prod --token=$VERCEL_TOKEN
-          vercel deploy --prod --prebuilt --token=$VERCEL_TOKEN
+          vercel deploy --prod --prebuilt --token=$VERCEL_TOKEN \
+            --env CLERK_SECRET_KEY=$CLERK_SECRET_KEY \
+            --env DATABASE_URL=$DATABASE_URL \
+            --env DATABASE_URL_UNPOOLED=$DATABASE_URL_UNPOOLED
 
   deploy-docs:
     name: Deploy Docs to Vercel


### PR DESCRIPTION
## Summary
- Fixes critical Clerk auth error in production (`Missing secretKey`)
- Server-side environment variables were only available at build time, not runtime
- Added `--env` flags to `vercel deploy` commands to pass runtime variables to serverless functions

## Test plan
- [ ] Verify marketing site loads without Clerk errors
- [ ] Verify auth works across all apps (web, api, admin, marketing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Ensure required environment variables are forwarded to production and preview deployments so deployed services receive runtime configuration consistently across jobs.
  * Expanded deployment commands to propagate additional runtime variables for web, API, marketing, and admin deployments; deployment behavior and error handling remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->