### PR TITLE
fix(clerk): remove unnecessary domain and isSatellite props

### DIFF
--- a/apps/admin/src/app/layout.tsx
+++ b/apps/admin/src/app/layout.tsx
@@ -4,8 +4,6 @@ import { cn } from "@superset/ui/utils";
 import type { Metadata, Viewport } from "next";
 import { IBM_Plex_Mono, Inter } from "next/font/google";
 
-import { env } from "@/env";
-
 import "./globals.css";
 
 import { Providers } from "./providers";
@@ -40,7 +38,7 @@ export default function RootLayout({
 	children: React.ReactNode;
 }) {
 	return (
-		<ClerkProvider domain={env.NEXT_PUBLIC_COOKIE_DOMAIN} isSatellite={false}>
+		<ClerkProvider>
 			<html lang="en" suppressHydrationWarning>
 				<body
 					className={cn(

--- a/apps/marketing/src/app/layout.tsx
+++ b/apps/marketing/src/app/layout.tsx
@@ -5,8 +5,6 @@ import { IBM_Plex_Mono, Inter } from "next/font/google";
 import Script from "next/script";
 import { ThemeProvider } from "next-themes";
 
-import { env } from "@/env";
-
 import { CTAButtons } from "./components/CTAButtons";
 import { Footer } from "./components/Footer";
 import { Header } from "./components/Header";
@@ -36,7 +34,7 @@ export default function RootLayout({
 	children: React.ReactNode;
 }>) {
 	return (
-		<ClerkProvider domain={env.NEXT_PUBLIC_COOKIE_DOMAIN} isSatellite={false}>
+		<ClerkProvider>
 			<html
 				lang="en"
 				className={`overscroll-none ${ibmPlexMono.variable} ${inter.variable}`}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -4,8 +4,6 @@ import { cn } from "@superset/ui/utils";
 import type { Metadata, Viewport } from "next";
 import { IBM_Plex_Mono, Inter } from "next/font/google";
 
-import { env } from "@/env";
-
 import "./globals.css";
 
 import { Providers } from "./providers";
@@ -41,8 +39,6 @@ export default function RootLayout({
 }) {
 	return (
 		<ClerkProvider
-			domain={env.NEXT_PUBLIC_COOKIE_DOMAIN}
-			isSatellite={false}
 			signInUrl="/sign-in"
 			signUpUrl="/sign-up"
 			signInFallbackRedirectUrl="/"


### PR DESCRIPTION
## Summary
- Removes `domain` and `isSatellite` props from ClerkProvider in web, marketing, and admin apps
- Fixes malformed Clerk URL (`clerk..superset.sh`) that was causing sign-in page to fail in production
- These props are only needed for satellite domain setups, which we don't use

## Test plan
- [ ] Verify sign-in page loads without errors on web app
- [ ] Verify marketing site auth still works
- [ ] Verify admin dashboard auth still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified authentication provider configuration across multiple applications by removing unnecessary environment variable dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->