### PR TITLE
fix(desktop): inject NODE_ENV into main and preload builds

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -54,6 +54,12 @@ export default defineConfig({
 	main: {
 		plugins: [tsconfigPaths, copyResourcesPlugin()],
 
+		define: {
+			"process.env.NODE_ENV": JSON.stringify(
+				process.env.NODE_ENV || "production",
+			),
+		},
+
 		build: {
 			rollupOptions: {
 				input: {
@@ -81,6 +87,12 @@ export default defineConfig({
 				exclude: ["trpc-electron"],
 			}),
 		],
+
+		define: {
+			"process.env.NODE_ENV": JSON.stringify(
+				process.env.NODE_ENV || "production",
+			),
+		},
 
 		build: {
 			outDir: resolve(devPath, "preload"),


### PR DESCRIPTION
## Summary
- Fix production builds using `.superset-dev` instead of `.superset`
- Inject `NODE_ENV` into main and preload process builds via Vite define
- Defaults to `"production"` when not set (matches expected behavior for packaged apps)

## Root cause
The renderer build had `NODE_ENV: "production"` injected via `injectProcessEnvPlugin`, but main/preload builds relied on `process.env.NODE_ENV` at runtime, which isn't set in packaged Electron apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to ensure consistent environment variable handling across build pipelines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->