### PR TITLE
chore(desktop): bump version to 0.0.19

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "@superset/desktop",
 	"productName": "Superset",
 	"description": "The last developer tool you'll ever need",
-	"version": "0.0.18",
+	"version": "0.0.19",
 	"main": "./dist/main/index.js",
 	"resources": "src/resources",
 	"repository": {


### PR DESCRIPTION
## Summary
- Bump desktop app version to 0.0.19 for release

## Changes included in 0.0.19
- fix(desktop): inject NODE_ENV into main and preload builds (#369)
- Fixes production builds using `.superset-dev` instead of `.superset`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Patch version bump for desktop application (0.0.19)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->