### PR TITLE
fix(desktop): ensure NODE_ENV is set in t3-env runtimeEnv

### DIFF
--- a/apps/desktop/src/env.ts
+++ b/apps/desktop/src/env.ts
@@ -10,7 +10,11 @@ export const env = createEnv({
 		NEXT_PUBLIC_WEB_URL: z.url().default("https://app.superset.sh"),
 	},
 
-	runtimeEnv: process.env,
+	runtimeEnv: {
+		...process.env,
+		// Vite's define replaces this at build time, ensuring correct env in packaged apps
+		NODE_ENV: process.env.NODE_ENV,
+	},
 	emptyStringAsUndefined: true,
 
 	// Electron runs in a trusted environment - treat renderer as server context


### PR DESCRIPTION
## Summary
- Fix t3-env not receiving the build-time NODE_ENV value
- Explicitly set `NODE_ENV: process.env.NODE_ENV` in runtimeEnv so Vite's define can replace it

## Root cause  
Previous fix added Vite `define` for `process.env.NODE_ENV`, but t3-env uses `runtimeEnv: process.env` which passes the entire object. The spread doesn't trigger Vite's replacement - only direct property access does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined environment variable configuration in desktop app builds to ensure consistent behavior across packaged releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->