### PR TITLE
feat(desktop): add hover state to workspace group header

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/TopBar/WorkspaceTabs/WorkspaceGroupHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/TopBar/WorkspaceTabs/WorkspaceGroupHeader.tsx
@@ -77,6 +77,7 @@ export function WorkspaceGroupHeader({
 					px-3 py-1 rounded-full
 					text-xs font-medium cursor-pointer select-none
 					transition-all shrink-0 no-drag
+					hover:brightness-110
 					${isDragging ? "opacity-30" : "opacity-100"}
 					${isOver ? "ring-2 ring-white/20" : ""}
 				`}


### PR DESCRIPTION
## Summary
- Add `hover:brightness-110` to workspace group header buttons for visual feedback on hover

## Test plan
- [ ] Hover over workspace group headers in the top bar
- [ ] Verify the button brightens slightly on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual feedback for workspace controls with improved hover effects on interactive buttons.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->