### PR TITLE
fix(desktop): align FileItem filename to start

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/components/FileItem/FileItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/components/FileItem/FileItem.tsx
@@ -75,7 +75,7 @@ export function FileItem({
 				<span className={cn("shrink-0 flex items-center", statusBadgeColor)}>
 					{statusIndicator}
 				</span>
-				<span className="flex-1 min-w-0 text-xs truncate overflow-hidden text-ellipsis">
+				<span className="flex-1 min-w-0 text-xs text-start truncate overflow-hidden text-ellipsis">
 					{fileName}
 				</span>
 


### PR DESCRIPTION
## Summary
- Adds `text-start` class to FileItem filename span to align text to start instead of center

## Test plan
- [ ] Open the Changes view in the desktop app
- [ ] Verify file names are aligned to the start

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved text alignment of filenames in the changes view sidebar for better visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->