### PR TITLE
feat(desktop): add editable Monaco diff view for uncommitted changes

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/changes/changes.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/changes.ts
@@ -1,4 +1,4 @@
-import { readFile, rm } from "node:fs/promises";
+import { readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type {
 	ChangedFile,
@@ -399,6 +399,26 @@ export const createChangesRouter = () => {
 					const message =
 						error instanceof Error ? error.message : String(error);
 					throw new Error(`Failed to delete untracked path: ${message}`);
+				}
+			}),
+
+		saveFile: publicProcedure
+			.input(
+				z.object({
+					worktreePath: z.string(),
+					filePath: z.string(),
+					content: z.string(),
+				}),
+			)
+			.mutation(async ({ input }): Promise<{ success: boolean }> => {
+				const fullPath = join(input.worktreePath, input.filePath);
+				try {
+					await writeFile(fullPath, input.content, "utf-8");
+					return { success: true };
+				} catch (error) {
+					const message =
+						error instanceof Error ? error.message : String(error);
+					throw new Error(`Failed to save file: ${message}`);
 				}
 			}),
 	});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/ChangesContent/components/DiffToolbar/DiffToolbar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/ChangesContent/components/DiffToolbar/DiffToolbar.tsx
@@ -1,9 +1,11 @@
+import { Badge } from "@superset/ui/badge";
 import { Button } from "@superset/ui/button";
 import { ToggleGroup, ToggleGroupItem } from "@superset/ui/toggle-group";
 import {
 	HiMiniArrowsRightLeft,
 	HiMiniListBullet,
 	HiMiniMinus,
+	HiMiniPencil,
 	HiMiniPlus,
 	HiMiniTrash,
 } from "react-icons/hi2";
@@ -17,6 +19,8 @@ interface DiffToolbarProps {
 	onUnstage?: () => void;
 	onDiscard?: () => void;
 	isActioning?: boolean;
+	isEditable?: boolean;
+	isSaving?: boolean;
 }
 
 export function DiffToolbar({
@@ -27,6 +31,8 @@ export function DiffToolbar({
 	onUnstage,
 	onDiscard,
 	isActioning = false,
+	isEditable = false,
+	isSaving = false,
 }: DiffToolbarProps) {
 	const canStage = category === "unstaged";
 	const canUnstage = category === "staged";
@@ -34,24 +40,34 @@ export function DiffToolbar({
 
 	return (
 		<div className="flex items-center justify-between px-3 py-2 border-b border-border bg-muted/30">
-			<ToggleGroup
-				type="single"
-				value={viewMode}
-				onValueChange={(value) => {
-					if (value) onViewModeChange(value as DiffViewMode);
-				}}
-				variant="outline"
-				size="sm"
-			>
-				<ToggleGroupItem value="side-by-side" aria-label="Side by side view">
-					<HiMiniArrowsRightLeft className="w-4 h-4 mr-1.5" />
-					Side by Side
-				</ToggleGroupItem>
-				<ToggleGroupItem value="inline" aria-label="Inline view">
-					<HiMiniListBullet className="w-4 h-4 mr-1.5" />
-					Inline
-				</ToggleGroupItem>
-			</ToggleGroup>
+			<div className="flex items-center gap-3">
+				<ToggleGroup
+					type="single"
+					value={viewMode}
+					onValueChange={(value) => {
+						if (value) onViewModeChange(value as DiffViewMode);
+					}}
+					variant="outline"
+					size="sm"
+				>
+					<ToggleGroupItem value="side-by-side" aria-label="Side by side view">
+						<HiMiniArrowsRightLeft className="w-4 h-4 mr-1.5" />
+						Side by Side
+					</ToggleGroupItem>
+					<ToggleGroupItem value="inline" aria-label="Inline view">
+						<HiMiniListBullet className="w-4 h-4 mr-1.5" />
+						Inline
+					</ToggleGroupItem>
+				</ToggleGroup>
+
+				{isEditable && (
+					<Badge variant="secondary" className="gap-1 text-xs">
+						<HiMiniPencil className="w-3 h-3" />
+						{isSaving ? "Saving..." : "Editable"}
+						<span className="text-muted-foreground ml-1">⌘S to save</span>
+					</Badge>
+				)}
+			</div>
 
 			<div className="flex items-center gap-2">
 				{canStage && onStage && (


### PR DESCRIPTION
## Summary
- Enable editing files directly in the Monaco diff view for unstaged and staged changes
- Added `saveFile` tRPC mutation to write file contents to disk
- Modified side of DiffEditor is now editable with `⌘S` / `Ctrl+S` to save
- Shows "Editable ⌘S to save" badge in the diff toolbar when editable
- When saving from staged view, automatically switches to unstaged view (since edits become new unstaged changes)

## Test plan
- [ ] Open a workspace with uncommitted changes
- [ ] Select an unstaged file - verify "Editable" badge appears and you can edit the right side
- [ ] Make changes and press ⌘S - verify file saves and diff updates
- [ ] Select a staged file - verify you can also edit it
- [ ] Save changes in staged view - verify it switches to unstaged view showing new changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-place file editing directly in the changes view.
  * Implemented save functionality to persist edited files to disk.
  * Added visual indicators for edit mode and saving status.
  * Introduced keyboard shortcut (Ctrl/Cmd+S) for quick saving.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->