### PR TITLE
fix(desktop): make error toast description readable in light mode

### DIFF
--- a/apps/desktop/src/renderer/components/ThemedToaster/ThemedToaster.tsx
+++ b/apps/desktop/src/renderer/components/ThemedToaster/ThemedToaster.tsx
@@ -1,0 +1,7 @@
+import { Toaster } from "@superset/ui/sonner";
+import { useTheme } from "renderer/stores/theme/store";
+
+export function ThemedToaster() {
+	const theme = useTheme();
+	return <Toaster theme={theme?.type ?? "dark"} />;
+}

--- a/apps/desktop/src/renderer/components/ThemedToaster/index.ts
+++ b/apps/desktop/src/renderer/components/ThemedToaster/index.ts
@@ -1,0 +1,1 @@
+export { ThemedToaster } from "./ThemedToaster";

--- a/apps/desktop/src/renderer/index.tsx
+++ b/apps/desktop/src/renderer/index.tsx
@@ -1,7 +1,7 @@
-import { Toaster } from "@superset/ui/sonner";
 import React from "react";
 import ReactDom from "react-dom/client";
 
+import { ThemedToaster } from "./components/ThemedToaster";
 import { AppProviders } from "./contexts";
 import { AppRoutes } from "./routes";
 
@@ -11,7 +11,7 @@ ReactDom.createRoot(document.querySelector("app") as HTMLElement).render(
 	<React.StrictMode>
 		<AppProviders>
 			<AppRoutes />
-			<Toaster />
+			<ThemedToaster />
 		</AppProviders>
 	</React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- Created `ThemedToaster` component that connects the app's theme store to sonner
- Error toast descriptions are now readable in light mode (previously had poor contrast with gray text on white background)

## Test plan
- [ ] Open the desktop app in light mode
- [ ] Trigger an error toast (e.g., try to open a folder that's not a git repository from the workspace dropdown)
- [ ] Verify the toast description text is readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Toast notifications now respect your app's theme preference, automatically adapting between light and dark modes for improved visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->