### PR TITLE
fix(desktop): ellipsis button goes directly to presets settings

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/TabsView/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/TabsView/index.tsx
@@ -151,9 +151,8 @@ export function TabsView() {
 						</Button>
 						<Button
 							variant="ghost"
-							onClick={() => setCommandOpen(true)}
+							onClick={handleOpenPresetsSettings}
 							className="px-3 py-2 rounded-md cursor-pointer"
-							disabled={!activeWorkspaceId}
 						>
 							<HiMiniEllipsisHorizontal className="size-4" />
 						</Button>


### PR DESCRIPTION
## Summary
- Changed the "..." button next to "New Terminal" to open presets settings directly instead of opening the command dialog

## Test plan
- [ ] Click the "..." button next to "New Terminal" in the sidebar
- [ ] Verify it opens the presets settings page directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)