### PR TITLE
Disable linting error in monaco

### DIFF
--- a/apps/desktop/src/renderer/contexts/MonacoProvider.tsx
+++ b/apps/desktop/src/renderer/contexts/MonacoProvider.tsx
@@ -40,12 +40,12 @@ async function initializeMonaco(): Promise<typeof monaco> {
 
 	await loader.init();
 
-	// Disable all diagnostics (lint errors, type errors, etc.)
-	monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
+	// Note: Disable all diagnostics (lint errors, type errors, etc.) since it's a diff viewer
+	monaco.typescript.typescriptDefaults.setDiagnosticsOptions({
 		noSemanticValidation: true,
 		noSyntaxValidation: true,
 	});
-	monaco.languages.typescript.javascriptDefaults.setDiagnosticsOptions({
+	monaco.typescript.javascriptDefaults.setDiagnosticsOptions({
 		noSemanticValidation: true,
 		noSyntaxValidation: true,
 	});


### PR DESCRIPTION

- **remove linting**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Editor Updates**
  * Disabled TypeScript and JavaScript syntax and semantic validation in the code editor. Error and warning diagnostics will no longer appear during code editing sessions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->