### PR TITLE
feat(desktop): add description for close vs delete workspace

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/TopBar/WorkspaceTabs/DeleteWorkspaceDialog.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/TopBar/WorkspaceTabs/DeleteWorkspaceDialog.tsx
@@ -136,7 +136,7 @@ export function DeleteWorkspaceDialog({
 
 				{!isLoading && canDelete && hasWarnings && (
 					<div className="px-4 pb-2">
-						<div className="text-sm text-amber-600 bg-amber-100/50 border border-amber-500 rounded px-2 py-1.5">
+						<div className="text-sm text-amber-600 dark:text-amber-400 bg-amber-100/50 dark:bg-amber-900/50 border border-amber-500 dark:border-amber-600 rounded px-2 py-1.5">
 							{hasChanges && hasUnpushedCommits
 								? "Has uncommitted changes and unpushed commits"
 								: hasChanges


### PR DESCRIPTION
## Summary
- Add explanatory text to the close workspace dialog clarifying the difference between Close and Delete actions
- Close: hides workspace from tabs but keeps files on disk (can be reopened later)
- Delete: permanently removes the git worktree from disk

## Test plan
- [ ] Open the close workspace dialog and verify the description text appears below the workspace name
- [ ] Hover over Close button to see tooltip
- [ ] Hover over Delete button to see tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)