### PR TITLE
fix(desktop): preserve terminal history across re-renders

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -322,10 +322,9 @@ export const Terminal = ({ tabId, workspaceId }: TerminalProps) => {
 					if (initialCommands || initialCwd) {
 						clearPaneInitialDataRef.current(paneId);
 					}
-					const hasPendingEvents = pendingEventsRef.current.length > 0;
-					if (result.isNew || !hasPendingEvents) {
-						applyInitialState(result);
-					}
+					// Always apply initial state (scrollback) first, then flush pending events
+					// This ensures we don't lose terminal history when reattaching
+					applyInitialState(result);
 					setSubscriptionEnabled(true);
 					flushPendingEvents();
 				},


### PR DESCRIPTION
When reattaching to an existing terminal session, the previous logic skipped applying scrollback history if there were pending events queued. This caused terminal history loss when using fast-outputting processes like Claude Code, since data would queue during component unmount/remount cycles.

The fix always applies the initial scrollback state first, then flushes pending events, ensuring no history is lost on reattach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->
