### PR TITLE
fix(desktop): fix changes sidebar overflow and font sizing

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/ChangesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/ChangesView.tsx
@@ -1,5 +1,4 @@
 import { Button } from "@superset/ui/button";
-import { ScrollArea } from "@superset/ui/scroll-area";
 import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useEffect, useState } from "react";
@@ -225,7 +224,7 @@ export function ChangesView() {
 					No changes detected
 				</div>
 			) : (
-				<ScrollArea className="flex-1">
+				<div className="flex-1 overflow-y-auto">
 					{/* Against Main */}
 					<CategorySection
 						title="Against Main"
@@ -348,7 +347,7 @@ export function ChangesView() {
 							isActioning={stageFileMutation.isPending}
 						/>
 					</CategorySection>
-				</ScrollArea>
+				</div>
 			)}
 		</div>
 	);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/components/CommitItem/CommitItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/components/CommitItem/CommitItem.tsx
@@ -59,16 +59,16 @@ export function CommitItem({
 				)}
 			>
 				{isExpanded ? (
-					<HiChevronDown className="w-4 h-4 text-muted-foreground shrink-0" />
+					<HiChevronDown className="w-3 h-3 text-muted-foreground shrink-0" />
 				) : (
-					<HiChevronRight className="w-4 h-4 text-muted-foreground shrink-0" />
+					<HiChevronRight className="w-3 h-3 text-muted-foreground shrink-0" />
 				)}
 
 				<span className="text-xs font-mono text-muted-foreground shrink-0">
 					{commit.shortHash}
 				</span>
 
-				<span className="text-sm flex-1 truncate">{commit.message}</span>
+				<span className="text-xs flex-1 truncate">{commit.message}</span>
 
 				<span className="text-xs text-muted-foreground shrink-0">
 					{formatRelativeDate(commit.date)}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/components/FileList/FileListTree.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/components/FileList/FileListTree.tsx
@@ -162,7 +162,7 @@ export function FileListTree({
 	const tree = buildFileTree(files);
 
 	return (
-		<div className="flex flex-col min-w-0 overflow-hidden">
+		<div className="flex flex-col overflow-hidden">
 			{tree.map((node) => (
 				<TreeNodeComponent
 					key={node.id}


### PR DESCRIPTION
## Summary
- Replace `ScrollArea` with simple `div` + `overflow-y-auto` to fix horizontal overflow issues preventing text truncation
- Fix commit item font size to match file items (`text-xs` instead of `text-sm`)
- Fix commit item chevron size to match file items (`w-3 h-3` instead of `w-4 h-4`)

## Test plan
- [ ] Verify long commit messages truncate properly with ellipsis
- [ ] Verify stage/unstage all buttons are visible and right-aligned
- [ ] Verify commit items and file items have consistent font sizing

🤖 Generated with [Claude Code](https://claude.com/claude-code)