### PR TITLE
feat(desktop): add markdown syntax highlighting for Monaco editor

### DIFF
--- a/apps/desktop/src/renderer/stores/theme/utils/monaco-theme.ts
+++ b/apps/desktop/src/renderer/stores/theme/utils/monaco-theme.ts
@@ -61,12 +61,29 @@ function createEditorColors(theme: Theme): editor.IColors {
 	};
 }
 
+function createTokenRules(theme: Theme): editor.ITokenThemeRule[] {
+	const { terminal } = theme;
+	const hex = (color: string) => toHexAuto(color).slice(1);
+
+	return [
+		// Markdown
+		{ token: "keyword.md", foreground: hex(terminal.blue) },
+		{ token: "string.link.md", foreground: hex(terminal.cyan) },
+		{ token: "variable.md", foreground: hex(terminal.blue) },
+		{ token: "string.md", foreground: hex(terminal.green) },
+		{ token: "variable.source.md", foreground: hex(terminal.foreground) },
+		{ token: "markup.bold.md", fontStyle: "bold" },
+		{ token: "markup.italic.md", fontStyle: "italic" },
+		{ token: "markup.strikethrough.md", fontStyle: "strikethrough" },
+	];
+}
+
 export function toMonacoTheme(theme: Theme): MonacoTheme {
 	const isDark = theme.type === "dark";
 	return {
 		base: isDark ? "vs-dark" : "vs",
 		inherit: true,
-		rules: [], // Use VS Code default syntax highlighting
+		rules: createTokenRules(theme),
 		colors: createEditorColors(theme),
 	};
 }


### PR DESCRIPTION
## Summary
- Add token rules for markdown syntax highlighting in the Monaco diff viewer
- Headings and link text use blue, URLs use cyan, inline code uses green
- Bold, italic, and strikethrough get proper font styles

## Test plan
- [ ] Open a markdown file diff in the desktop app
- [ ] Verify headings, links, code blocks, and formatting are highlighted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Markdown syntax highlighting in the editor now properly applies custom theme colors to tokens, improving visual consistency with your selected theme.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->