### PR TITLE
fix(desktop): open terminal presets as pane instead of new tab

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/TabsView/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/TabsView/index.tsx
@@ -218,7 +218,7 @@ export function TabsView() {
 									>
 										<Button
 											variant="ghost"
-											onClick={() => handleSelectPreset(preset)}
+											onClick={() => handleSelectPresetAsPane(preset)}
 											disabled={!activeWorkspaceId}
 											className="w-full justify-start px-3 py-1.5 h-auto text-sm"
 										>
@@ -246,7 +246,7 @@ export function TabsView() {
 						onAddTab={handleAddTab}
 						onOpenPresetsSettings={handleOpenPresetsSettings}
 						presets={presets}
-						onSelectPreset={handleSelectPreset}
+						onSelectPreset={handleSelectPresetAsPane}
 					/>
 				</motion.div>
 				<div className="text-sm text-sidebar-foreground space-y-1 relative">


### PR DESCRIPTION
## Summary
- Change default behavior when selecting a terminal preset to add as a split pane in the current tab instead of creating a new tab
- Falls back to creating a new tab if no active tab exists
- Context menu still offers both "Open as New Tab" and "Open as Pane in Current Tab" options

## Test plan
- [ ] Click preset in sidebar with existing tab → should add pane (split)
- [ ] Click preset in sidebar with no tabs → should create new tab
- [ ] Use Cmd+K command dialog to select preset → should add pane
- [ ] Right-click context menu → should still offer both options

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preset activation now opens content as a pane within the active tab instead of creating a new tab, improving workflow efficiency. Previous behavior is preserved when no active workspace or tab exists.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->