### PR TITLE
fix(desktop): bake OAuth client IDs into main process at build time

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -58,6 +58,13 @@ export default defineConfig({
 			"process.env.NODE_ENV": JSON.stringify(
 				process.env.NODE_ENV || "production",
 			),
+			// API URLs - baked in at build time for main process
+			"process.env.NEXT_PUBLIC_API_URL": JSON.stringify(
+				process.env.NEXT_PUBLIC_API_URL || "https://api.superset.sh",
+			),
+			"process.env.NEXT_PUBLIC_WEB_URL": JSON.stringify(
+				process.env.NEXT_PUBLIC_WEB_URL || "https://app.superset.sh",
+			),
 			// OAuth client IDs - baked in at build time for main process
 			"process.env.GOOGLE_CLIENT_ID": JSON.stringify(
 				process.env.GOOGLE_CLIENT_ID,

--- a/apps/desktop/src/main/env.main.ts
+++ b/apps/desktop/src/main/env.main.ts
@@ -22,7 +22,13 @@ export const env = createEnv({
 
 	runtimeEnv: {
 		...process.env,
+		// Explicitly list env vars so Vite can replace them at build time
+		// (spreading process.env only works at runtime, not for bundled apps)
 		NODE_ENV: process.env.NODE_ENV,
+		NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
+		NEXT_PUBLIC_WEB_URL: process.env.NEXT_PUBLIC_WEB_URL,
+		GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
+		GH_CLIENT_ID: process.env.GH_CLIENT_ID,
 	},
 	emptyStringAsUndefined: true,
 


### PR DESCRIPTION
## Summary
- Fixed desktop app build failing due to missing OAuth client IDs at runtime
- Added `GOOGLE_CLIENT_ID` and `GH_CLIENT_ID` to the vite `define` block for main process
- These are now baked into the bundle at build time instead of read from `process.env` at runtime

## Test plan
- [ ] Trigger desktop build workflow on this branch
- [ ] Download and test the auth flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop app now supports Google and GitHub sign-in.
  * Build-time configurable API/web endpoints and OAuth client IDs, allowing the desktop app to be pointed to custom backends and enable third‑party authentication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->