### PR TITLE
fix(desktop): suppress PostHog console debug logs

### DIFF
--- a/apps/desktop/src/renderer/lib/posthog.ts
+++ b/apps/desktop/src/renderer/lib/posthog.ts
@@ -15,7 +15,7 @@ export function initPostHog() {
 		capture_exceptions: true,
 		person_profiles: "identified_only",
 		persistence: "localStorage",
-		debug: import.meta.env.DEV,
+		debug: false,
 		loaded: (ph) => {
 			ph.register({
 				app_name: "desktop",
@@ -23,8 +23,6 @@ export function initPostHog() {
 			});
 		},
 	});
-
-	console.log("[posthog] Initialized");
 }
 
 export { posthog };


### PR DESCRIPTION
## Summary
- Disable PostHog debug mode to suppress verbose `[PostHog.js]` console logs in development
- Remove manual `[posthog] Initialized` console log

## Test plan
- [ ] Run the desktop app in development mode
- [ ] Verify PostHog debug logs no longer appear in the console

🤖 Generated with [Claude Code](https://claude.com/claude-code)