### PR TITLE
fix(desktop): allow creating multiple terminal tabs per workspace

### DIFF
--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -83,29 +83,6 @@ export const useTabsStore = create<TabsStore>()(
 				addTab: (workspaceId, options?: CreatePaneOptions) => {
 					const state = get();
 
-					// Idempotency check: if a tab already exists for this workspace, just activate it
-					const existingTab = state.tabs.find(
-						(t) => t.workspaceId === workspaceId,
-					);
-					if (existingTab) {
-						const paneId =
-							state.focusedPaneIds[existingTab.id] ??
-							getFirstPaneId(existingTab.layout);
-
-						set({
-							activeTabIds: {
-								...state.activeTabIds,
-								[workspaceId]: existingTab.id,
-							},
-							focusedPaneIds: {
-								...state.focusedPaneIds,
-								[existingTab.id]: paneId,
-							},
-						});
-
-						return { tabId: existingTab.id, paneId };
-					}
-
 					const { tab, pane } = createTabWithPane(
 						workspaceId,
 						state.tabs,


### PR DESCRIPTION
## Summary
- Remove the idempotency check in `addTab` that prevented creating new terminal tabs
- This was a regression introduced in b2ecbc38 ("main terminal vs worktrees terminal")
- The "New Terminal" button now creates new tabs again instead of just activating existing ones

## Test plan
- [ ] Open a workspace that already has a terminal tab
- [ ] Click the "New Terminal" button
- [ ] Verify a new tab is created (not just activating the existing one)
- [ ] Verify multiple tabs can be created per workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified tab creation behavior: new tabs are now always created separately rather than reusing or restoring focus for existing workspace tabs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->