### PR TITLE
fix(desktop): fix notification indicator not showing on hook events

### DIFF
--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -1,4 +1,43 @@
 # Implementation details
-For Electron interprocess communnication, ALWAYS use trpc as defined in `src/lib/trpc`
+For Electron interprocess communication, ALWAYS use trpc as defined in `src/lib/trpc`
 Please use alias as defined in `tsconfig.json` when possible
 Prefer zustand for state management if it makes sense. Do not use effect unless absolutely necessary.
+
+## tRPC Subscriptions (trpc-electron)
+
+**Important:** While standard tRPC recommends async generators for subscriptions, `trpc-electron` (used for Electron IPC) **only supports observables**. The library explicitly checks `isObservable(result)` and throws an error otherwise. Use the `observable` pattern:
+
+```typescript
+// CORRECT for trpc-electron - use observable pattern
+import { observable } from "@trpc/server/observable";
+
+export const createMyRouter = () => {
+  return router({
+    subscribe: publicProcedure.subscription(() => {
+      return observable<MyEvent>((emit) => {
+        const handler = (data: MyData) => {
+          emit.next({ type: "my-event", data });
+        };
+
+        myEmitter.on("my-event", handler);
+
+        return () => {
+          myEmitter.off("my-event", handler);
+        };
+      });
+    }),
+  });
+};
+
+// WRONG for trpc-electron - async generators don't work with IPC transport
+export const createMyRouter = () => {
+  return router({
+    subscribe: publicProcedure.subscription(async function* () {
+      // This will NOT work - the generator never gets invoked
+      while (true) {
+        yield await getNextEvent();
+      }
+    }),
+  });
+};
+```

--- a/apps/desktop/src/lib/trpc/routers/notifications.ts
+++ b/apps/desktop/src/lib/trpc/routers/notifications.ts
@@ -1,3 +1,4 @@
+import { observable } from "@trpc/server/observable";
 import {
 	type AgentCompleteEvent,
 	type NotificationIds,
@@ -15,36 +16,27 @@ type NotificationEvent =
 
 export const createNotificationsRouter = () => {
 	return router({
-		subscribe: publicProcedure.subscription(async function* () {
-			const queue: NotificationEvent[] = [];
+		subscribe: publicProcedure.subscription(() => {
+			return observable<NotificationEvent>((emit) => {
+				const onComplete = (data: AgentCompleteEvent) => {
+					emit.next({ type: NOTIFICATION_EVENTS.AGENT_COMPLETE, data });
+				};
 
-			const onComplete = (data: AgentCompleteEvent) => {
-				queue.push({ type: NOTIFICATION_EVENTS.AGENT_COMPLETE, data });
-			};
+				const onFocusTab = (data: NotificationIds) => {
+					emit.next({ type: NOTIFICATION_EVENTS.FOCUS_TAB, data });
+				};
 
-			const onFocusTab = (data: NotificationIds) => {
-				queue.push({ type: NOTIFICATION_EVENTS.FOCUS_TAB, data });
-			};
+				notificationsEmitter.on(NOTIFICATION_EVENTS.AGENT_COMPLETE, onComplete);
+				notificationsEmitter.on(NOTIFICATION_EVENTS.FOCUS_TAB, onFocusTab);
 
-			notificationsEmitter.on(NOTIFICATION_EVENTS.AGENT_COMPLETE, onComplete);
-			notificationsEmitter.on(NOTIFICATION_EVENTS.FOCUS_TAB, onFocusTab);
-
-			try {
-				while (true) {
-					const event = queue.shift();
-					if (event) {
-						yield event;
-					} else {
-						await new Promise((resolve) => setTimeout(resolve, 100));
-					}
-				}
-			} finally {
-				notificationsEmitter.off(
-					NOTIFICATION_EVENTS.AGENT_COMPLETE,
-					onComplete,
-				);
-				notificationsEmitter.off(NOTIFICATION_EVENTS.FOCUS_TAB, onFocusTab);
-			}
+				return () => {
+					notificationsEmitter.off(
+						NOTIFICATION_EVENTS.AGENT_COMPLETE,
+						onComplete,
+					);
+					notificationsEmitter.off(NOTIFICATION_EVENTS.FOCUS_TAB, onFocusTab);
+				};
+			});
 		}),
 	});
 };


### PR DESCRIPTION
## Summary
- Fix tRPC subscription using async generator pattern which doesn't work with trpc-electron IPC transport - changed to use `observable` pattern from `@trpc/server/observable`
- Fix stale closure issue in `useAgentHookListener` where `activeWorkspace` was captured at subscription creation time instead of using current value via ref
- Update AGENTS.md with tRPC subscription best practices to prevent this issue in the future

## Test plan
- [ ] Run Claude Code in a terminal pane and let it complete a task
- [ ] Verify the red notification indicator appears on the tab when the agent completes (if not viewing that pane)
- [ ] Verify clicking the native notification focuses the correct tab/pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed typo in interprocess communication terminology
  * Added tRPC Subscriptions implementation guidance with code examples

* **Bug Fixes**
  * Improved reliability of subscription event delivery in notifications
  * Fixed workspace context detection issue in agent hook listener

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->