### PR TITLE
refactor(auth): move oauth client_id to server-side only

### DIFF
--- a/apps/api/src/app/api/auth/github/route.ts
+++ b/apps/api/src/app/api/auth/github/route.ts
@@ -1,0 +1,30 @@
+import { redirect } from "next/navigation";
+import { env } from "@/env";
+
+/**
+ * Initiate GitHub OAuth flow for desktop app
+ *
+ * GET /api/auth/github?state=xxx
+ *
+ * This endpoint redirects to GitHub's OAuth page with the client_id,
+ * keeping credentials server-side only.
+ */
+export async function GET(request: Request) {
+	const url = new URL(request.url);
+	const state = url.searchParams.get("state");
+
+	if (!state) {
+		return Response.json({ error: "Missing state parameter" }, { status: 400 });
+	}
+
+	const authUrl = new URL("https://github.com/login/oauth/authorize");
+	authUrl.searchParams.set("client_id", env.GH_CLIENT_ID);
+	authUrl.searchParams.set(
+		"redirect_uri",
+		`${env.NEXT_PUBLIC_WEB_URL}/api/auth/desktop/github`,
+	);
+	authUrl.searchParams.set("scope", "user:email");
+	authUrl.searchParams.set("state", state);
+
+	redirect(authUrl.toString());
+}

--- a/apps/api/src/app/api/auth/google/route.ts
+++ b/apps/api/src/app/api/auth/google/route.ts
@@ -1,0 +1,33 @@
+import { redirect } from "next/navigation";
+import { env } from "@/env";
+
+/**
+ * Initiate Google OAuth flow for desktop app
+ *
+ * GET /api/auth/google?state=xxx
+ *
+ * This endpoint redirects to Google's OAuth page with the client_id,
+ * keeping credentials server-side only.
+ */
+export async function GET(request: Request) {
+	const url = new URL(request.url);
+	const state = url.searchParams.get("state");
+
+	if (!state) {
+		return Response.json({ error: "Missing state parameter" }, { status: 400 });
+	}
+
+	const authUrl = new URL("https://accounts.google.com/o/oauth2/v2/auth");
+	authUrl.searchParams.set("client_id", env.GOOGLE_CLIENT_ID);
+	authUrl.searchParams.set(
+		"redirect_uri",
+		`${env.NEXT_PUBLIC_WEB_URL}/api/auth/desktop/google`,
+	);
+	authUrl.searchParams.set("response_type", "code");
+	authUrl.searchParams.set("scope", "openid email profile");
+	authUrl.searchParams.set("state", state);
+	authUrl.searchParams.set("prompt", "select_account");
+	authUrl.searchParams.set("access_type", "online");
+
+	redirect(authUrl.toString());
+}

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -65,11 +65,6 @@ export default defineConfig({
 			"process.env.NEXT_PUBLIC_WEB_URL": JSON.stringify(
 				process.env.NEXT_PUBLIC_WEB_URL || "https://app.superset.sh",
 			),
-			// OAuth client IDs - baked in at build time for main process
-			"process.env.GOOGLE_CLIENT_ID": JSON.stringify(
-				process.env.GOOGLE_CLIENT_ID,
-			),
-			"process.env.GH_CLIENT_ID": JSON.stringify(process.env.GH_CLIENT_ID),
 		},
 
 		build: {

--- a/apps/desktop/src/main/env.main.ts
+++ b/apps/desktop/src/main/env.main.ts
@@ -16,8 +16,6 @@ export const env = createEnv({
 			.default("development"),
 		NEXT_PUBLIC_API_URL: z.url().default("https://api.superset.sh"),
 		NEXT_PUBLIC_WEB_URL: z.url().default("https://app.superset.sh"),
-		GOOGLE_CLIENT_ID: z.string().min(1),
-		GH_CLIENT_ID: z.string().min(1),
 	},
 
 	runtimeEnv: {
@@ -27,8 +25,6 @@ export const env = createEnv({
 		NODE_ENV: process.env.NODE_ENV,
 		NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
 		NEXT_PUBLIC_WEB_URL: process.env.NEXT_PUBLIC_WEB_URL,
-		GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
-		GH_CLIENT_ID: process.env.GH_CLIENT_ID,
 	},
 	emptyStringAsUndefined: true,
 


### PR DESCRIPTION
## Summary
- Moves OAuth client_id configuration from desktop app to server-side API routes
- Desktop now opens `/api/auth/github` or `/api/auth/google` which redirects to OAuth provider with client_id
- No OAuth secrets baked into the Electron build anymore

## Changes
- Add `/api/auth/github` and `/api/auth/google` routes in api app that redirect to OAuth providers
- Simplify desktop `auth-service.ts` to just open API URL instead of building full OAuth URL
- Remove `GOOGLE_CLIENT_ID` and `GH_CLIENT_ID` from electron build defines and env validation

## New Flow
```
desktop → api.superset.sh/api/auth/github?state=xxx
       → github.com/login/oauth/authorize?client_id=xxx&...
       → app.superset.sh/api/auth/desktop/github?code=xxx
       → desktop deep link with tokens
```