### PR TITLE
feat(desktop): add SKIP_ENV_VALIDATION flag for dev mode

### DIFF
--- a/apps/desktop/BUILDING.md
+++ b/apps/desktop/BUILDING.md
@@ -1,1 +1,13 @@
-when building for release, make sure node-pty is built for the correct architecture with `bun install:deps` and then run `bun release`
+# Development
+
+Run the dev server without env validation or auth:
+
+```bash
+SKIP_ENV_VALIDATION=1 bun run dev
+```
+
+This skips environment variable validation and the sign-in screen, useful for local development without credentials.
+
+# Release
+
+When building for release, make sure node-pty is built for the correct architecture with `bun install:deps` and then run `bun release`

--- a/apps/desktop/bunfig.toml
+++ b/apps/desktop/bunfig.toml
@@ -4,3 +4,4 @@ preload = ["./test-setup.ts"]
 
 [test.env]
 NODE_ENV = "test"
+SKIP_ENV_VALIDATION = "1"

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -58,6 +58,9 @@ export default defineConfig({
 			"process.env.NODE_ENV": JSON.stringify(
 				process.env.NODE_ENV || "production",
 			),
+			"process.env.SKIP_ENV_VALIDATION": JSON.stringify(
+				process.env.SKIP_ENV_VALIDATION || "",
+			),
 			// API URLs - baked in at build time for main process
 			"process.env.NEXT_PUBLIC_API_URL": JSON.stringify(
 				process.env.NEXT_PUBLIC_API_URL || "https://api.superset.sh",
@@ -104,6 +107,9 @@ export default defineConfig({
 			"process.env.NODE_ENV": JSON.stringify(
 				process.env.NODE_ENV || "production",
 			),
+			"process.env.SKIP_ENV_VALIDATION": JSON.stringify(
+				process.env.SKIP_ENV_VALIDATION || "",
+			),
 		},
 
 		build: {
@@ -120,6 +126,9 @@ export default defineConfig({
 		define: {
 			// Core env vars - Vite replaces these at build time
 			"process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
+			"process.env.SKIP_ENV_VALIDATION": JSON.stringify(
+				process.env.SKIP_ENV_VALIDATION || "",
+			),
 			"process.platform": JSON.stringify(process.platform),
 			// API URLs - available in renderer if needed
 			"process.env.NEXT_PUBLIC_API_URL": JSON.stringify(

--- a/apps/desktop/src/main/env.main.ts
+++ b/apps/desktop/src/main/env.main.ts
@@ -31,6 +31,7 @@ export const env = createEnv({
 		GH_CLIENT_ID: process.env.GH_CLIENT_ID,
 	},
 	emptyStringAsUndefined: true,
+	skipValidation: !!process.env.SKIP_ENV_VALIDATION,
 
 	// Main process runs in trusted Node.js environment
 	isServer: true,

--- a/apps/desktop/src/renderer/env.renderer.ts
+++ b/apps/desktop/src/renderer/env.renderer.ts
@@ -40,4 +40,6 @@ const rawEnv = {
 		| undefined,
 };
 
-export const env = envSchema.parse(rawEnv);
+export const env = process.env.SKIP_ENV_VALIDATION
+	? (rawEnv as z.infer<typeof envSchema>)
+	: envSchema.parse(rawEnv);

--- a/apps/desktop/src/renderer/screens/main/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/index.tsx
@@ -32,8 +32,9 @@ function LoadingSpinner() {
 export function MainScreen() {
 	const utils = trpc.useUtils();
 	const { data: authState } = trpc.auth.getState.useQuery();
-	const isSignedIn = authState?.isSignedIn ?? false;
-	const isAuthLoading = !authState;
+	const isSignedIn =
+		!!process.env.SKIP_ENV_VALIDATION || (authState?.isSignedIn ?? false);
+	const isAuthLoading = !process.env.SKIP_ENV_VALIDATION && !authState;
 
 	// Subscribe to auth state changes
 	trpc.auth.onStateChange.useSubscription(undefined, {

--- a/apps/desktop/test-setup.ts
+++ b/apps/desktop/test-setup.ts
@@ -14,6 +14,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 process.env.NODE_ENV = "test";
+process.env.SKIP_ENV_VALIDATION = "1";
 process.env.GOOGLE_CLIENT_ID = "test-google-client-id";
 process.env.GH_CLIENT_ID = "test-github-client-id";
 

--- a/packages/trpc/src/env.ts
+++ b/packages/trpc/src/env.ts
@@ -10,4 +10,5 @@ export const env = createEnv({
 	client: {},
 	runtimeEnv: process.env,
 	emptyStringAsUndefined: true,
+	skipValidation: !!process.env.SKIP_ENV_VALIDATION,
 });


### PR DESCRIPTION
## Summary
- Add `SKIP_ENV_VALIDATION=1` flag to skip env validation and auth screen in dev mode
- Useful for local development without credentials configured
- Add to Vite define blocks to ensure proper bundling in prod (empty string = falsy = validation runs)

## Usage
```bash
SKIP_ENV_VALIDATION=1 bun run dev
```

## Test plan
- [ ] Run `SKIP_ENV_VALIDATION=1 bun run dev` from `apps/desktop/` - should skip auth screen
- [ ] Run `bun run dev` normally - should show auth screen as before
- [ ] Build for production and verify env validation still runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Development section with simplified instructions for running the app locally without external credentials.

* **Chores**
  * Introduced an option to bypass environment validation for streamlined local development and tests.
  * Ensured this bypass is propagated across build configurations.
  * Adjusted local auth handling to allow skipping the sign-in flow during development.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->