### PR TITLE
chore: disable PostHog debug logging in development

### DIFF
--- a/apps/admin/src/instrumentation-client.ts
+++ b/apps/admin/src/instrumentation-client.ts
@@ -11,7 +11,7 @@ posthog.init(env.NEXT_PUBLIC_POSTHOG_KEY, {
 	capture_pageview: "history_change",
 	capture_pageleave: true,
 	capture_exceptions: true,
-	debug: env.NODE_ENV === "development",
+	debug: false,
 	cross_subdomain_cookie: true,
 	persistence: "cookie",
 	persistence_name: POSTHOG_COOKIE_NAME,

--- a/apps/docs/src/instrumentation-client.ts
+++ b/apps/docs/src/instrumentation-client.ts
@@ -11,7 +11,7 @@ posthog.init(env.NEXT_PUBLIC_POSTHOG_KEY, {
 	capture_pageview: "history_change",
 	capture_pageleave: true,
 	capture_exceptions: true,
-	debug: env.NODE_ENV === "development",
+	debug: false,
 	cross_subdomain_cookie: true,
 	persistence: "cookie",
 	persistence_name: POSTHOG_COOKIE_NAME,

--- a/apps/marketing/src/instrumentation-client.ts
+++ b/apps/marketing/src/instrumentation-client.ts
@@ -12,7 +12,7 @@ posthog.init(env.NEXT_PUBLIC_POSTHOG_KEY, {
 	capture_pageview: "history_change",
 	capture_pageleave: true,
 	capture_exceptions: true,
-	debug: env.NODE_ENV === "development",
+	debug: false,
 	cross_subdomain_cookie: true,
 	persistence: "cookie",
 	persistence_name: POSTHOG_COOKIE_NAME,

--- a/apps/web/src/instrumentation-client.ts
+++ b/apps/web/src/instrumentation-client.ts
@@ -11,7 +11,7 @@ posthog.init(env.NEXT_PUBLIC_POSTHOG_KEY, {
 	capture_pageview: "history_change",
 	capture_pageleave: true,
 	capture_exceptions: true,
-	debug: env.NODE_ENV === "development",
+	debug: false,
 	cross_subdomain_cookie: true,
 	persistence: "cookie",
 	persistence_name: POSTHOG_COOKIE_NAME,


### PR DESCRIPTION
## Summary
- Disable PostHog debug logs in development mode across all apps (web, admin, marketing, docs)
- Removes verbose `[PostHog.js] send` console messages that clutter the browser dev tools
- Desktop app already had debug disabled

## Test plan
- [ ] Run any app locally and verify no PostHog debug logs appear in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)