### PR TITLE
fix(desktop): include command output in teardown failure toast

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/terminal/terminal.ts
+++ b/apps/desktop/src/lib/trpc/routers/terminal/terminal.ts
@@ -168,13 +168,13 @@ export const createTerminalRouter = () => {
 			.query(async ({ input: workspaceId }) => {
 				const workspace = db.data.workspaces.find((w) => w.id === workspaceId);
 				if (!workspace) {
-					return undefined;
+					return null;
 				}
 
 				const worktree = db.data.worktrees.find(
 					(wt) => wt.id === workspace.worktreeId,
 				);
-				return worktree?.path;
+				return worktree?.path ?? null;
 			}),
 
 		/**

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/teardown.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/teardown.test.ts
@@ -121,6 +121,32 @@ describe("runTeardown", () => {
 		expect(result.error).toBeDefined();
 	});
 
+	test("captures stderr output in error message when teardown fails", () => {
+		writeFileSync(
+			join(MAIN_REPO, ".superset", "config.json"),
+			JSON.stringify({
+				teardown: ['echo "This is the error message" >&2 && exit 1'],
+			}),
+		);
+
+		const result = runTeardown(MAIN_REPO, WORKTREE, "test-workspace");
+		expect(result.success).toBe(false);
+		expect(result.error).toBe("This is the error message");
+	});
+
+	test("captures stdout output in error message when stderr is empty", () => {
+		writeFileSync(
+			join(MAIN_REPO, ".superset", "config.json"),
+			JSON.stringify({
+				teardown: ['echo "stdout error info" && exit 1'],
+			}),
+		);
+
+		const result = runTeardown(MAIN_REPO, WORKTREE, "test-workspace");
+		expect(result.success).toBe(false);
+		expect(result.error).toBe("stdout error info");
+	});
+
 	test("chains multiple teardown commands with &&", () => {
 		const testFile = join(WORKTREE, "teardown-test.txt");
 		writeFileSync(

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -200,7 +200,7 @@ export const Terminal = ({ tabId, workspaceId }: TerminalProps) => {
 			cleanup: cleanupQuerySuppression,
 		} = createTerminalInstance(
 			container,
-			workspaceCwd,
+			workspaceCwd ?? undefined,
 			initialThemeRef.current,
 		);
 		xtermRef.current = xterm;


### PR DESCRIPTION
## Summary
- Extract stderr/stdout from failed teardown commands and display actual error content in toast notifications
- Fix React Query warning by returning `null` instead of `undefined` from `getWorkspaceCwd` query
- Add tests for stderr/stdout capture in teardown errors

## Test plan
- [ ] Configure a teardown script that outputs to stderr and fails
- [ ] Delete a workspace and verify the toast shows the stderr content
- [ ] Verify no React Query console warnings appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when workspace teardown fails by capturing and displaying stderr or stdout output for more informative feedback.

* **Chores**
  * Refined workspace path handling in terminal initialization for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->