### PR TITLE
fix(auth): use Bearer token auth for web app tRPC calls

### DIFF
--- a/apps/admin/src/trpc/react.tsx
+++ b/apps/admin/src/trpc/react.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useAuth } from "@clerk/nextjs";
 import type { AppRouter } from "@superset/trpc";
 import type { QueryClient } from "@tanstack/react-query";
 import { QueryClientProvider } from "@tanstack/react-query";
@@ -32,6 +33,7 @@ export type UseTRPC = typeof useTRPC;
 
 export function TRPCReactProvider(props: { children: React.ReactNode }) {
 	const queryClient = getQueryClient();
+	const { getToken } = useAuth();
 
 	const [trpcClient] = useState(() =>
 		createTRPCClient<AppRouter>({
@@ -44,14 +46,12 @@ export function TRPCReactProvider(props: { children: React.ReactNode }) {
 				httpBatchStreamLink({
 					transformer: SuperJSON,
 					url: `${env.NEXT_PUBLIC_API_URL}/api/trpc`,
-					headers() {
-						return { "x-trpc-source": "nextjs-react" };
-					},
-					fetch(url, options) {
-						return fetch(url, {
-							...options,
-							credentials: "include",
-						});
+					async headers() {
+						const token = await getToken();
+						return {
+							"x-trpc-source": "nextjs-react",
+							...(token ? { Authorization: `Bearer ${token}` } : {}),
+						};
 					},
 				}),
 			],

--- a/apps/web/src/trpc/react.tsx
+++ b/apps/web/src/trpc/react.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useAuth } from "@clerk/nextjs";
 import type { AppRouter } from "@superset/trpc";
 import type { QueryClient } from "@tanstack/react-query";
 import { QueryClientProvider } from "@tanstack/react-query";
@@ -32,6 +33,7 @@ export type UseTRPC = typeof useTRPC;
 
 export function TRPCReactProvider(props: { children: React.ReactNode }) {
 	const queryClient = getQueryClient();
+	const { getToken } = useAuth();
 
 	const [trpcClient] = useState(() =>
 		createTRPCClient<AppRouter>({
@@ -44,14 +46,12 @@ export function TRPCReactProvider(props: { children: React.ReactNode }) {
 				httpBatchStreamLink({
 					transformer: SuperJSON,
 					url: `${env.NEXT_PUBLIC_API_URL}/api/trpc`,
-					headers() {
-						return { "x-trpc-source": "nextjs-react" };
-					},
-					fetch(url, options) {
-						return fetch(url, {
-							...options,
-							credentials: "include",
-						});
+					async headers() {
+						const token = await getToken();
+						return {
+							"x-trpc-source": "nextjs-react",
+							...(token ? { Authorization: `Bearer ${token}` } : {}),
+						};
 					},
 				}),
 			],


### PR DESCRIPTION
## Summary
- Fixes authentication issue where users were stuck on sign-in page after signing in
- Root cause: cross-origin cookie restrictions (SameSite policy) prevented Clerk session cookies from being sent with tRPC requests from web app to API
- Web app now sends Clerk session tokens as `Authorization: Bearer <token>` headers instead of relying on cookies
- API now uses `clerkClient().authenticateRequest()` to validate Bearer tokens

## Test plan
- [ ] Sign in to web app - should redirect to dashboard instead of being stuck on sign-in page
- [ ] Verify tRPC calls work (user data loads, actions succeed)
- [ ] Verify desktop app auth still works (custom JWT flow unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated authentication infrastructure with improved token handling and request validation across API and web platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->