### PR TITLE
fix(analytics): use rolling 7-day window for WAU calculation

### DIFF
--- a/apps/admin/src/app/(dashboard)/components/WAUTrendChart/WAUTrendChart.tsx
+++ b/apps/admin/src/app/(dashboard)/components/WAUTrendChart/WAUTrendChart.tsx
@@ -18,7 +18,7 @@ import type { ReactNode } from "react";
 import { Area, AreaChart, XAxis, YAxis } from "recharts";
 
 interface WAUData {
-	week: string;
+	date: string;
 	count: number;
 }
 
@@ -74,7 +74,7 @@ export function WAUTrendChart({
 					<ChartContainer config={chartConfig} className="h-[200px] w-full">
 						<AreaChart data={data} margin={{ left: 0, right: 0 }}>
 							<XAxis
-								dataKey="week"
+								dataKey="date"
 								tickLine={false}
 								axisLine={false}
 								tickFormatter={(v) =>


### PR DESCRIPTION
## Summary

- Fix WAU calculation to use a proper rolling 7-day window per day
- Previously used non-overlapping weekly buckets which didn't show day-over-day changes
- Now returns daily data points, each showing users active 3+ days in the preceding 7 days

## Before vs After

**Before:** Weekly buckets (e.g., Week 1: days 0-7, Week 2: days 8-14)
**After:** Rolling window per day (e.g., Dec 23: days 17-23, Dec 22: days 16-22)

## Definition

WAU = Users who had `workspace_created` events on **3+ distinct days** within a rolling 7-day window.

## Test plan

- [ ] Verify WAU chart shows daily data points
- [ ] Confirm numbers reflect rolling 7-day windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated WAU Trend Chart to use rolling 7-day calculation methodology instead of weekly aggregation for improved accuracy.
  * Chart now displays daily data points with automatic zero-filling for missing dates to ensure complete trend visibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->