### PR TITLE
fix(desktop): prevent implicit upstream tracking when creating worktrees

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
@@ -138,7 +138,10 @@ export async function createWorktree(
 				worktreePath,
 				"-b",
 				branch,
-				startPoint,
+				// Append ^{commit} to force Git to treat the startPoint as a commit,
+				// not a branch ref. This prevents implicit upstream tracking when
+				// creating a new branch from a remote branch like origin/main.
+				`${startPoint}^{commit}`,
 			],
 			{ env, timeout: 120_000 },
 		);


### PR DESCRIPTION
## Description
When creating a new branch from a remote branch (e.g., origin/main), Git implicitly sets upstream tracking to that remote branch. This causes git pull to pull from the base branch instead of the new branch's remote.

By appending ^{commit} to the startPoint, Git treats it as a commit object rather than a branch ref, preventing implicit upstream tracking. The new branch starts with no upstream, which matches the 'new branch' intent and allows push.autoSetupRemote to work correctly on first push.

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed git worktree creation to prevent unintended upstream branch tracking when creating worktrees from remote references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->