### PR TITLE
fix(desktop): add postinstall script to rebuild native modules

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -25,7 +25,6 @@
 		"prepackage": "bun run copy:native-modules",
 		"package": "electron-builder --config electron-builder.ts",
 		"install:deps": "electron-builder install-app-deps",
-		"postinstall": "bun run install:deps",
 		"release": "electron-builder --publish always",
 		"clean:dev": "rimraf ./node_modules/.dev",
 		"typecheck": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"format:check": "biome format .",
 		"typecheck": "turbo typecheck",
 		"ui-add": "turbo run ui-add",
-		"postinstall": "sherif",
+		"postinstall": "sherif; bun run --filter=@superset/desktop install:deps",
 		"clean": "git clean -xdf node_modules",
 		"clean:workspaces": "turbo clean"
 	},


### PR DESCRIPTION
## Summary
- Adds a `postinstall` script that runs `install:deps` after each `bun install`
- Ensures native modules (better-sqlite3, node-pty) are automatically rebuilt for Electron

## Test plan
- [ ] Run `bun install` and verify `electron-builder install-app-deps` runs automatically
- [ ] Verify native modules work correctly after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the installation process to ensure all required dependencies are properly configured and installed during setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->