### PR TITLE
feat(desktop): sync app theme to Claude Code settings

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/settings/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/index.ts
@@ -1,4 +1,8 @@
 import { settings, type TerminalPreset } from "@superset/local-db";
+import {
+	updateClaudeSettingsTheme,
+	type ClaudeTheme,
+} from "main/lib/agent-setup";
 import { localDb } from "main/lib/local-db";
 import { DEFAULT_RINGTONE_ID, RINGTONES } from "shared/ringtones";
 import { z } from "zod";
@@ -163,6 +167,13 @@ export const createSettingsRouter = () => {
 					})
 					.run();
 
+				return { success: true };
+			}),
+
+		updateClaudeTheme: publicProcedure
+			.input(z.object({ theme: z.enum(["dark", "light"]) }))
+			.mutation(({ input }) => {
+				updateClaudeSettingsTheme(input.theme as ClaudeTheme);
 				return { success: true };
 			}),
 	});

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts
@@ -3,24 +3,62 @@ import path from "node:path";
 import { BIN_DIR, HOOKS_DIR } from "./paths";
 import { findRealBinary } from "./utils";
 
+export type ClaudeTheme = "dark" | "light";
+
+/** Current theme stored in memory for building settings */
+let currentTheme: ClaudeTheme = "dark";
+
 /**
- * Creates the Claude Code settings JSON file with notification hooks
+ * Gets the path to the Claude settings file
  */
-function createClaudeSettings(): string {
-	const settingsPath = path.join(HOOKS_DIR, "claude-settings.json");
+export function getClaudeSettingsPath(): string {
+	return path.join(HOOKS_DIR, "claude-settings.json");
+}
+
+/**
+ * Builds the Claude Code settings object with notification hooks and theme
+ */
+function buildClaudeSettings(): object {
 	const notifyPath = path.join(HOOKS_DIR, "notify.sh");
 
-	const settings = {
+	return {
 		hooks: {
 			Stop: [{ hooks: [{ type: "command", command: notifyPath }] }],
 			PermissionRequest: [
 				{ matcher: "*", hooks: [{ type: "command", command: notifyPath }] },
 			],
 		},
+		preferences: {
+			theme: currentTheme,
+		},
 	};
+}
+
+/**
+ * Creates the Claude Code settings JSON file with notification hooks
+ */
+function createClaudeSettings(): string {
+	const settingsPath = getClaudeSettingsPath();
+	const settings = buildClaudeSettings();
 
 	fs.writeFileSync(settingsPath, JSON.stringify(settings), { mode: 0o644 });
 	return settingsPath;
+}
+
+/**
+ * Updates the Claude Code settings with a new theme
+ * Called when the app theme changes
+ */
+export function updateClaudeSettingsTheme(theme: ClaudeTheme): void {
+	currentTheme = theme;
+	const settingsPath = getClaudeSettingsPath();
+
+	// Only update if settings file exists (wrapper was created)
+	if (fs.existsSync(settingsPath)) {
+		const settings = buildClaudeSettings();
+		fs.writeFileSync(settingsPath, JSON.stringify(settings), { mode: 0o644 });
+		console.log(`[agent-setup] Updated Claude settings theme to ${theme}`);
+	}
 }
 
 /**

--- a/apps/desktop/src/main/lib/agent-setup/index.ts
+++ b/apps/desktop/src/main/lib/agent-setup/index.ts
@@ -1,5 +1,10 @@
 import fs from "node:fs";
-import { createClaudeWrapper, createCodexWrapper } from "./agent-wrappers";
+import {
+	createClaudeWrapper,
+	createCodexWrapper,
+	updateClaudeSettingsTheme,
+	type ClaudeTheme,
+} from "./agent-wrappers";
 import { createNotifyScript } from "./notify-hook";
 import { BASH_DIR, BIN_DIR, HOOKS_DIR, ZSH_DIR } from "./paths";
 import {
@@ -43,3 +48,6 @@ export function getSupersetBinDir(): string {
 
 // Re-export shell utilities for terminal usage
 export { getShellArgs, getShellEnv };
+
+// Re-export Claude settings utilities for theme sync
+export { updateClaudeSettingsTheme, type ClaudeTheme };

--- a/apps/desktop/src/renderer/stores/theme/store.ts
+++ b/apps/desktop/src/renderer/stores/theme/store.ts
@@ -1,4 +1,5 @@
 import type { ITheme } from "@xterm/xterm";
+import { trpcClient } from "renderer/lib/trpc-client";
 import {
 	builtInThemes,
 	DEFAULT_THEME_ID,
@@ -78,6 +79,17 @@ function syncThemeToLocalStorage(theme: Theme): void {
 }
 
 /**
+ * Sync theme to Claude Code settings (fire-and-forget)
+ */
+function syncThemeToClaudeSettings(themeType: "dark" | "light"): void {
+	trpcClient.settings.updateClaudeTheme
+		.mutate({ theme: themeType })
+		.catch((error) => {
+			console.error("[theme] Failed to sync theme to Claude settings:", error);
+		});
+}
+
+/**
  * Apply a theme to the UI and terminal
  */
 function applyTheme(theme: Theme): {
@@ -91,6 +103,9 @@ function applyTheme(theme: Theme): {
 	updateThemeClass(theme.type);
 
 	syncThemeToLocalStorage(theme);
+
+	// Sync to Claude Code settings
+	syncThemeToClaudeSettings(theme.type);
 
 	// Convert to editor-specific formats
 	return {


### PR DESCRIPTION
## Summary
- Add theme preference sync from app to Claude Code settings.json
- When user changes theme (light/dark), the `~/.superset/hooks/claude-settings.json` file is updated with the new theme preference
- Adds tRPC endpoint `settings.updateClaudeTheme` to handle theme updates from renderer to main process

## Test plan
- [ ] Change theme in AppearanceSettings to dark mode
- [ ] Verify `~/.superset/hooks/claude-settings.json` contains `"preferences": { "theme": "dark" }`
- [ ] Change theme to light mode
- [ ] Verify settings file now contains `"preferences": { "theme": "light" }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added theme synchronization: Theme preferences now automatically sync with Claude Code settings when you switch between dark and light modes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->