### PR TITLE
feat(desktop): auto-update tab title from terminal

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -337,8 +337,6 @@ export const Terminal = ({ tabId, workspaceId }: TerminalProps) => {
 		const inputDisposable = xterm.onData(handleTerminalInput);
 		const keyDisposable = xterm.onKey(handleKeyPress);
 
-		// Listen for terminal title changes (OSC 0, 1, 2 sequences)
-		// Many shells and programs (vim, htop, etc.) set the terminal title via escape sequences
 		const titleDisposable = xterm.onTitleChange((title) => {
 			if (title && parentTabIdRef.current) {
 				debouncedSetTabAutoTitleRef.current(parentTabIdRef.current, title);


### PR DESCRIPTION
## Summary

- Listen for terminal title changes via OSC escape sequences (0, 1, 2)
- Automatically update the tab title when programs set the terminal title
- Update workspace name if it hasn't been customized (still using default branch name)

This allows shells and programs (vim, htop, ssh, etc.) that set the terminal title via escape sequences to have that reflected in the UI.

## Test plan

- [ ] Open a terminal and run a command that sets the title (e.g., `echo -e "\033]0;My Custom Title\007"`)
- [ ] Verify the tab title updates to "My Custom Title"
- [ ] Verify the workspace name updates if it was still using the default branch name
- [ ] Rename the workspace manually, then run the echo command again
- [ ] Verify the workspace name does NOT change (respects user customization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Terminal tab titles now automatically update to reflect the current state and active commands in real-time with smooth performance.

* **Bug Fixes**
  * Fixed memory leak where terminal event listeners were not properly disposed when closing or unmounting terminal components, preventing resource waste.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->