### PR TITLE
fix(desktop): improve workspace creation UI text

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -259,12 +259,13 @@ export function NewWorkspaceModal() {
 							<TooltipTrigger asChild>
 								<Button
 									variant="ghost"
-									size="icon"
-									className="h-8 w-8 shrink-0"
+									size="sm"
+									className="h-8 shrink-0 gap-1 text-xs"
 									onClick={handleOpenNewProject}
 									disabled={openNew.isPending}
 								>
 									<HiPlus className="h-4 w-4" />
+									Import
 								</Button>
 							</TooltipTrigger>
 							<TooltipContent side="bottom" sideOffset={4}>

--- a/apps/desktop/src/renderer/screens/main/components/TopBar/WorkspaceTabs/CreateWorkspaceButton.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/TopBar/WorkspaceTabs/CreateWorkspaceButton.tsx
@@ -111,7 +111,7 @@ export function CreateWorkspaceButton({
 					</Button>
 				</TooltipTrigger>
 				<TooltipContent side="bottom" sideOffset={4}>
-					New workspace
+					Create workspace or project
 				</TooltipContent>
 			</Tooltip>
 			<ButtonGroupSeparator />


### PR DESCRIPTION
## Summary
- Update tooltip on create workspace button from "New workspace" to "Create workspace or project"
- Change the "+" icon-only button to show "+ Import" text for better clarity

## Test plan
- [ ] Hover over the "New" button in the top bar workspace tabs - should show "Create workspace or project"
- [ ] Open the new workspace modal and verify the import button shows "+ Import"

🤖 Generated with [Claude Code](https://claude.com/claude-code)