### PR TITLE
fix(sentry): disable error tracking in dev and preview environments

### DIFF
--- a/apps/api/sentry.edge.config.ts
+++ b/apps/api/sentry.edge.config.ts
@@ -5,7 +5,7 @@ import { env } from "@/env";
 Sentry.init({
 	dsn: env.NEXT_PUBLIC_SENTRY_DSN_API,
 	environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
-	enabled: !!env.NEXT_PUBLIC_SENTRY_DSN_API,
+	enabled: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production",
 	tracesSampleRate:
 		env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production" ? 0.1 : 1.0,
 	sendDefaultPii: true,

--- a/apps/api/sentry.server.config.ts
+++ b/apps/api/sentry.server.config.ts
@@ -5,7 +5,7 @@ import { env } from "@/env";
 Sentry.init({
 	dsn: env.NEXT_PUBLIC_SENTRY_DSN_API,
 	environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
-	enabled: !!env.NEXT_PUBLIC_SENTRY_DSN_API,
+	enabled: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production",
 	tracesSampleRate:
 		env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production" ? 0.1 : 1.0,
 	sendDefaultPii: true,

--- a/apps/desktop/src/main/lib/sentry.ts
+++ b/apps/desktop/src/main/lib/sentry.ts
@@ -5,7 +5,7 @@ let sentryInitialized = false;
 export async function initSentry(): Promise<void> {
 	if (sentryInitialized) return;
 
-	if (!env.SENTRY_DSN_DESKTOP) {
+	if (!env.SENTRY_DSN_DESKTOP || env.NODE_ENV !== "production") {
 		return;
 	}
 
@@ -16,7 +16,7 @@ export async function initSentry(): Promise<void> {
 		Sentry.init({
 			dsn: env.SENTRY_DSN_DESKTOP,
 			environment: env.NODE_ENV,
-			tracesSampleRate: env.NODE_ENV === "development" ? 1.0 : 0.1,
+			tracesSampleRate: 0.1,
 			sendDefaultPii: false,
 		});
 

--- a/apps/desktop/src/renderer/lib/sentry.ts
+++ b/apps/desktop/src/renderer/lib/sentry.ts
@@ -5,7 +5,7 @@ let sentryInitialized = false;
 export async function initSentry(): Promise<void> {
 	if (sentryInitialized) return;
 
-	if (!env.SENTRY_DSN_DESKTOP) {
+	if (!env.SENTRY_DSN_DESKTOP || env.NODE_ENV !== "production") {
 		return;
 	}
 
@@ -16,7 +16,7 @@ export async function initSentry(): Promise<void> {
 		Sentry.init({
 			dsn: env.SENTRY_DSN_DESKTOP,
 			environment: env.NODE_ENV,
-			tracesSampleRate: env.NODE_ENV === "development" ? 1.0 : 0.1,
+			tracesSampleRate: 0.1,
 			replaysSessionSampleRate: 0.1,
 			replaysOnErrorSampleRate: 1.0,
 		});

--- a/apps/docs/sentry.edge.config.ts
+++ b/apps/docs/sentry.edge.config.ts
@@ -5,7 +5,7 @@ import { env } from "@/env";
 Sentry.init({
 	dsn: env.NEXT_PUBLIC_SENTRY_DSN_DOCS,
 	environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
-	enabled: !!env.NEXT_PUBLIC_SENTRY_DSN_DOCS,
+	enabled: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production",
 	tracesSampleRate:
 		env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production" ? 0.1 : 1.0,
 	sendDefaultPii: true,

--- a/apps/docs/sentry.server.config.ts
+++ b/apps/docs/sentry.server.config.ts
@@ -5,7 +5,7 @@ import { env } from "@/env";
 Sentry.init({
 	dsn: env.NEXT_PUBLIC_SENTRY_DSN_DOCS,
 	environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
-	enabled: !!env.NEXT_PUBLIC_SENTRY_DSN_DOCS,
+	enabled: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production",
 	tracesSampleRate:
 		env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production" ? 0.1 : 1.0,
 	sendDefaultPii: true,

--- a/apps/docs/src/instrumentation-client.ts
+++ b/apps/docs/src/instrumentation-client.ts
@@ -26,7 +26,7 @@ posthog.init(env.NEXT_PUBLIC_POSTHOG_KEY, {
 Sentry.init({
 	dsn: env.NEXT_PUBLIC_SENTRY_DSN_DOCS,
 	environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
-	enabled: !!env.NEXT_PUBLIC_SENTRY_DSN_DOCS,
+	enabled: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production",
 	tracesSampleRate:
 		env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production" ? 0.1 : 1.0,
 	sendDefaultPii: true,

--- a/apps/marketing/sentry.edge.config.ts
+++ b/apps/marketing/sentry.edge.config.ts
@@ -5,7 +5,7 @@ import { env } from "@/env";
 Sentry.init({
 	dsn: env.NEXT_PUBLIC_SENTRY_DSN_MARKETING,
 	environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
-	enabled: !!env.NEXT_PUBLIC_SENTRY_DSN_MARKETING,
+	enabled: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production",
 	tracesSampleRate:
 		env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production" ? 0.1 : 1.0,
 	sendDefaultPii: true,

--- a/apps/marketing/sentry.server.config.ts
+++ b/apps/marketing/sentry.server.config.ts
@@ -5,7 +5,7 @@ import { env } from "@/env";
 Sentry.init({
 	dsn: env.NEXT_PUBLIC_SENTRY_DSN_MARKETING,
 	environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
-	enabled: !!env.NEXT_PUBLIC_SENTRY_DSN_MARKETING,
+	enabled: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production",
 	tracesSampleRate:
 		env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production" ? 0.1 : 1.0,
 	sendDefaultPii: true,

--- a/apps/marketing/src/instrumentation-client.ts
+++ b/apps/marketing/src/instrumentation-client.ts
@@ -32,7 +32,7 @@ posthog.init(env.NEXT_PUBLIC_POSTHOG_KEY, {
 Sentry.init({
 	dsn: env.NEXT_PUBLIC_SENTRY_DSN_MARKETING,
 	environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
-	enabled: !!env.NEXT_PUBLIC_SENTRY_DSN_MARKETING,
+	enabled: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production",
 	tracesSampleRate:
 		env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production" ? 0.1 : 1.0,
 	sendDefaultPii: true,

--- a/apps/web/sentry.edge.config.ts
+++ b/apps/web/sentry.edge.config.ts
@@ -5,7 +5,7 @@ import { env } from "@/env";
 Sentry.init({
 	dsn: env.NEXT_PUBLIC_SENTRY_DSN_WEB,
 	environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
-	enabled: !!env.NEXT_PUBLIC_SENTRY_DSN_WEB,
+	enabled: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production",
 	tracesSampleRate:
 		env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production" ? 0.1 : 1.0,
 	sendDefaultPii: true,

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -5,7 +5,7 @@ import { env } from "@/env";
 Sentry.init({
 	dsn: env.NEXT_PUBLIC_SENTRY_DSN_WEB,
 	environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
-	enabled: !!env.NEXT_PUBLIC_SENTRY_DSN_WEB,
+	enabled: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production",
 	tracesSampleRate:
 		env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production" ? 0.1 : 1.0,
 	sendDefaultPii: true,

--- a/apps/web/src/instrumentation-client.ts
+++ b/apps/web/src/instrumentation-client.ts
@@ -26,7 +26,7 @@ posthog.init(env.NEXT_PUBLIC_POSTHOG_KEY, {
 Sentry.init({
 	dsn: env.NEXT_PUBLIC_SENTRY_DSN_WEB,
 	environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
-	enabled: !!env.NEXT_PUBLIC_SENTRY_DSN_WEB,
+	enabled: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production",
 	tracesSampleRate:
 		env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production" ? 0.1 : 1.0,
 	sendDefaultPii: true,


### PR DESCRIPTION
## Summary
- Disable Sentry in development and preview environments across all apps
- Only enable error tracking in production to reduce noise
- Simplify desktop Sentry config since it only runs in production now

## Test plan
- [ ] Verify Sentry is disabled when `NEXT_PUBLIC_SENTRY_ENVIRONMENT !== "production"`
- [ ] Verify Sentry still works correctly in production
- [ ] Confirm desktop app doesn't initialize Sentry in dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated error monitoring to activate only in production environments, ensuring tracking is consistently controlled by environment rather than configuration presence across all applications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->