### PR TITLE
feat(marketing): add Discord to header and make mobile nav collapsible

### DIFF
--- a/apps/marketing/src/app/components/CTAButtons/CTAButtons.tsx
+++ b/apps/marketing/src/app/components/CTAButtons/CTAButtons.tsx
@@ -9,42 +9,39 @@ export async function CTAButtons() {
 
 	if (userId) {
 		return (
-			<div className="flex items-center gap-2 sm:gap-3">
+			<>
 				<a
 					href={env.NEXT_PUBLIC_WEB_URL}
-					className="px-2 sm:px-4 py-2 text-sm font-normal text-muted-foreground hover:text-foreground transition-colors"
+					className="px-4 py-2 text-sm font-normal text-muted-foreground hover:text-foreground transition-colors text-center"
 				>
-					<span className="hidden sm:inline">Dashboard</span>
-					<span className="sm:hidden">Dash</span>
+					Dashboard
 				</a>
 				<a
 					href={DOWNLOAD_URL_MAC_ARM64}
-					className="px-2 sm:px-4 py-2 text-sm font-normal bg-foreground text-background hover:bg-foreground/90 transition-colors flex items-center gap-1.5 sm:gap-2"
+					className="px-4 py-2 text-sm font-normal bg-foreground text-background hover:bg-foreground/90 transition-colors flex items-center justify-center gap-2"
 				>
-					<span className="hidden sm:inline">Download for macOS</span>
-					<span className="sm:hidden">Download</span>
+					Download for macOS
 					<Download className="size-4" aria-hidden="true" />
 				</a>
-			</div>
+			</>
 		);
 	}
 
 	return (
-		<div className="flex items-center gap-2 sm:gap-3">
+		<>
 			<a
 				href={`${env.NEXT_PUBLIC_WEB_URL}/sign-in`}
-				className="px-2 sm:px-4 py-2 text-sm font-normal text-muted-foreground hover:text-foreground transition-colors"
+				className="px-4 py-2 text-sm font-normal text-muted-foreground hover:text-foreground transition-colors text-center"
 			>
 				Sign In
 			</a>
 			<a
 				href={DOWNLOAD_URL_MAC_ARM64}
-				className="px-2 sm:px-4 py-2 text-sm font-normal bg-foreground text-background hover:bg-foreground/90 transition-colors flex items-center gap-1.5 sm:gap-2"
+				className="px-4 py-2 text-sm font-normal bg-foreground text-background hover:bg-foreground/90 transition-colors flex items-center justify-center gap-2"
 			>
-				<span className="hidden sm:inline">Download for macOS</span>
-				<span className="sm:hidden">Download</span>
+				Download for macOS
 				<Download className="size-4" aria-hidden="true" />
 			</a>
-		</div>
+		</>
 	);
 }

--- a/apps/marketing/src/app/components/Header/Header.tsx
+++ b/apps/marketing/src/app/components/Header/Header.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { motion } from "framer-motion";
+import { AnimatePresence, motion } from "framer-motion";
+import { Menu, X } from "lucide-react";
+import { useState } from "react";
 import { SocialLinks } from "../SocialLinks";
 
 function SupersetLogo() {
@@ -26,6 +28,8 @@ interface HeaderProps {
 }
 
 export function Header({ ctaButtons }: HeaderProps) {
+	const [isMenuOpen, setIsMenuOpen] = useState(false);
+
 	return (
 		<header className="fixed top-0 left-0 right-0 z-50">
 			<div className="absolute inset-0 h-24 pointer-events-none bg-gradient-to-b from-background via-background/90 to-transparent" />
@@ -42,17 +46,53 @@ export function Header({ ctaButtons }: HeaderProps) {
 						<SupersetLogo />
 					</motion.a>
 
-					{/* Right side */}
+					{/* Desktop: Right side */}
 					<motion.div
-						className="flex items-center gap-2 sm:gap-3 md:gap-4"
+						className="hidden sm:flex items-center gap-3 md:gap-4"
 						initial={{ opacity: 0, x: 10 }}
 						animate={{ opacity: 1, x: 0 }}
 						transition={{ duration: 0.3, delay: 0.1 }}
 					>
 						<SocialLinks />
-						{ctaButtons}
+						<div className="flex items-center gap-3">{ctaButtons}</div>
 					</motion.div>
+
+					{/* Mobile: Hamburger button */}
+					<motion.button
+						type="button"
+						className="sm:hidden p-2 text-muted-foreground hover:text-foreground transition-colors"
+						onClick={() => setIsMenuOpen(!isMenuOpen)}
+						aria-label={isMenuOpen ? "Close menu" : "Open menu"}
+						aria-expanded={isMenuOpen}
+						initial={{ opacity: 0, x: 10 }}
+						animate={{ opacity: 1, x: 0 }}
+						transition={{ duration: 0.3, delay: 0.1 }}
+					>
+						{isMenuOpen ? (
+							<X className="size-6" />
+						) : (
+							<Menu className="size-6" />
+						)}
+					</motion.button>
 				</div>
+
+				{/* Mobile menu */}
+				<AnimatePresence>
+					{isMenuOpen && (
+						<motion.div
+							className="sm:hidden absolute left-0 right-0 top-16 bg-background border-b border-border"
+							initial={{ opacity: 0, height: 0 }}
+							animate={{ opacity: 1, height: "auto" }}
+							exit={{ opacity: 0, height: 0 }}
+							transition={{ duration: 0.2 }}
+						>
+							<div className="px-4 py-4 flex flex-col gap-4">
+								<SocialLinks className="justify-center" />
+								<div className="flex flex-col gap-2">{ctaButtons}</div>
+							</div>
+						</motion.div>
+					)}
+				</AnimatePresence>
 			</nav>
 		</header>
 	);

--- a/apps/marketing/src/app/components/SocialLinks/SocialLinks.tsx
+++ b/apps/marketing/src/app/components/SocialLinks/SocialLinks.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { COMPANY } from "@superset/shared/constants";
+
 interface SocialLinksProps {
 	className?: string;
 }
@@ -8,7 +10,7 @@ export function SocialLinks({ className = "" }: SocialLinksProps) {
 	return (
 		<div className={`flex items-center gap-2 ${className}`}>
 			<a
-				href="https://github.com/superset-sh/superset"
+				href={COMPANY.GITHUB_URL}
 				target="_blank"
 				rel="noopener noreferrer"
 				className="text-muted-foreground hover:text-foreground transition-colors p-1 sm:p-2"
@@ -26,7 +28,25 @@ export function SocialLinks({ className = "" }: SocialLinksProps) {
 				</svg>
 			</a>
 			<a
-				href="https://x.com/superset_sh"
+				href={COMPANY.DISCORD_URL}
+				target="_blank"
+				rel="noopener noreferrer"
+				className="text-muted-foreground hover:text-foreground transition-colors p-1 sm:p-2"
+				aria-label="Join our Discord"
+			>
+				<svg
+					width="20"
+					height="20"
+					viewBox="0 0 24 24"
+					fill="currentColor"
+					xmlns="http://www.w3.org/2000/svg"
+				>
+					<title>Discord</title>
+					<path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
+				</svg>
+			</a>
+			<a
+				href={COMPANY.X_URL}
 				target="_blank"
 				rel="noopener noreferrer"
 				className="text-muted-foreground hover:text-foreground transition-colors p-1 sm:p-2"


### PR DESCRIPTION
## Summary
- Add Discord icon to marketing site header social links
- Centralize social URLs using `@superset/shared/constants` (COMPANY.GITHUB_URL, COMPANY.DISCORD_URL, COMPANY.X_URL)
- Add collapsible hamburger menu for mobile devices with animated dropdown

## Test plan
- [ ] Verify Discord icon appears in header between GitHub and X icons
- [ ] Test hamburger menu on mobile viewport (< 640px)
- [ ] Verify menu expands/collapses with animation
- [ ] Check all social links point to correct URLs from shared constants

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile hamburger menu now available on header for convenient access to navigation and social links.

* **UI/UX Improvements**
  * Refined button and padding styling for better visual alignment and consistency.
  * Added accessible aria labels to improve navigation for screen readers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->