### PR TITLE
fix(desktop): shift+enter adding stray \ characters in Claude Code

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -355,7 +355,7 @@ export const Terminal = ({ tabId, workspaceId }: TerminalProps) => {
 		};
 
 		const cleanupKeyboard = setupKeyboardHandler(xterm, {
-			onShiftEnter: () => handleWrite("\n"),
+			onShiftEnter: () => handleWrite("\x1b\r"), // ESC + CR for line continuation without '\'
 			onClear: handleClear,
 		});
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -173,7 +173,7 @@ export function createTerminalInstance(
 }
 
 export interface KeyboardHandlerOptions {
-	/** Callback for Shift+Enter to create a line continuation (like iTerm) */
+	/** Callback for Shift+Enter (sends ESC+CR to avoid \ appearing in Claude Code while keeping line continuation behavior) */
 	onShiftEnter?: () => void;
 	/** Callback for Cmd+K to clear the terminal */
 	onClear?: () => void;
@@ -226,7 +226,7 @@ export function setupPasteHandler(
 /**
  * Setup keyboard handling for xterm including:
  * - Shortcut forwarding: App hotkeys are re-dispatched to document for react-hotkeys-hook
- * - Shift+Enter: Creates a line continuation (like iTerm) instead of executing
+ * - Shift+Enter: Sends ESC+CR sequence (sends ESC+CR to avoid \ appearing in Claude Code while keeping line continuation behavior)
  * - Cmd+K: Clears the terminal
  *
  * Returns a cleanup function to remove the handler.


### PR DESCRIPTION
## Description

Changed the Shift+Enter terminal behavior to send a plain newline (\n) instead of backslash-newline (\\n) to avoid adding unnecessary slash characters in cli tool input boxes.

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Other (please describe): Small UX tweak

## Testing

Verified that the change works well manually on codex, claude code, gemini-cli, opencode.

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

<img width="849" height="644" alt="2025-12-29_Superset_15-08-05" src="https://github.com/user-attachments/assets/c0530fa6-6c59-4223-87f1-99c557bb7ae9" />

<img width="849" height="644" alt="2025-12-29_Superset_15-09-05" src="https://github.com/user-attachments/assets/4a5a3741-b30b-4005-9697-0c0e110217e0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal input behavior: Shift+Enter now sends the correct continuation sequence to the backend to ensure proper line continuation.
* **Documentation**
  * Clarified docs/comments describing Shift+Enter behavior and the sequence used for line continuation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->