### PR TITLE
fix(desktop): disable confirm-on-quit in development mode

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -142,7 +142,8 @@ app.on("before-quit", async (event) => {
 	// Skip confirmation in development mode to avoid interrupting hot-reload
 	if (quitState === "idle") {
 		const isDev = process.env.NODE_ENV === "development";
-		const shouldConfirm = !skipConfirmation && !isDev && getConfirmOnQuitSetting();
+		const shouldConfirm =
+			!skipConfirmation && !isDev && getConfirmOnQuitSetting();
 
 		if (shouldConfirm) {
 			event.preventDefault();


### PR DESCRIPTION
## Why

- The confirm-on-quit feature added in #524 triggers during hot-reload in development
- When the dev server restarts the Electron app after code changes, the quit confirmation dialog appears
- This interrupts the development workflow and requires manual dismissal each time

## What / How

Skip the quit confirmation dialog when `NODE_ENV === "development"`:

```typescript
const isDev = process.env.NODE_ENV === "development";
const shouldConfirm = !skipConfirmation && !isDev && getConfirmOnQuitSetting();
```

The setting continues to work normally in production builds.

## Files

- `apps/desktop/src/main/index.ts`

## Testing

- `bun run typecheck` ✓
- Manual: verified quit confirmation is skipped during dev hot-reload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Development mode no longer displays quit confirmation dialogs, streamlining the workflow and preventing interruptions during iterative development and automatic reloads. This keeps confirmation behavior unchanged in non-development environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->