### PR TITLE
fix terminal hotkeys doubling

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -268,21 +268,8 @@ export function setupKeyboardHandler(
 		if (!event.metaKey && !event.ctrlKey) return true;
 
 		if (isAppHotkeyEvent(event)) {
-			document.dispatchEvent(
-				new KeyboardEvent(event.type, {
-					key: event.key,
-					code: event.code,
-					keyCode: event.keyCode,
-					which: event.which,
-					ctrlKey: event.ctrlKey,
-					shiftKey: event.shiftKey,
-					altKey: event.altKey,
-					metaKey: event.metaKey,
-					repeat: event.repeat,
-					bubbles: true,
-					cancelable: true,
-				}),
-			);
+			// Return false to prevent xterm from processing the key.
+			// The original event bubbles to document where useAppHotkey handles it.
 			return false;
 		}
 


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed keyboard event handling in the terminal to ensure application hotkeys are properly recognized and executed as intended.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->