### PR TITLE
fix(desktop): reuse git init dialog when opening non-git project from dropdown

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/TopBar/WorkspaceTabs/CreateWorkspaceButton.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/TopBar/WorkspaceTabs/CreateWorkspaceButton.tsx
@@ -9,7 +9,6 @@ import {
 import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useCallback, useState } from "react";
-import { InitGitDialog } from "../../StartView/InitGitDialog";
 import {
 	HiChevronDown,
 	HiFolderOpen,
@@ -24,6 +23,7 @@ import {
 } from "renderer/react-query/workspaces";
 import { useAppHotkey, useHotkeyText } from "renderer/stores/hotkeys";
 import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
+import { InitGitDialog } from "../../StartView/InitGitDialog";
 
 export interface CreateWorkspaceButtonProps {
 	className?: string;


### PR DESCRIPTION
## Summary
- When opening a non-git folder from the workspace dropdown, show the same "Initialize Git Repository" dialog used on the start screen instead of a toast error telling users to go to the start screen
- Provides consistent UX for git initialization across both entry points

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Git initialization dialog that appears when repositories need to be initialized, replacing the previous error notification approach.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->