### PR TITLE
fix(desktop): show error toast when external URL fails to open

### DIFF
--- a/apps/desktop/src/lib/electron-app/factories/app/setup.ts
+++ b/apps/desktop/src/lib/electron-app/factories/app/setup.ts
@@ -58,7 +58,9 @@ export async function makeAppSetup(
 			// Always prevent in-app navigation for external URLs
 			if (url.startsWith("http://") || url.startsWith("https://")) {
 				event.preventDefault();
-				shell.openExternal(url);
+				shell.openExternal(url).catch((error) => {
+					console.error("[app] Failed to open external URL:", url, error);
+				});
 			}
 		}),
 	);

--- a/apps/desktop/src/lib/electron-app/factories/windows/create.ts
+++ b/apps/desktop/src/lib/electron-app/factories/windows/create.ts
@@ -9,7 +9,9 @@ export function createWindow({ id, ...settings }: WindowProps) {
 	// Open external URLs in the system browser instead of Electron
 	window.webContents.setWindowOpenHandler(({ url }) => {
 		if (url.startsWith("http://") || url.startsWith("https://")) {
-			shell.openExternal(url);
+			shell.openExternal(url).catch((error) => {
+				console.error("[window] Failed to open external URL:", url, error);
+			});
 			return { action: "deny" };
 		}
 		return { action: "deny" };

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -1,3 +1,4 @@
+import { toast } from "@superset/ui/sonner";
 import { CanvasAddon } from "@xterm/addon-canvas";
 import { ClipboardAddon } from "@xterm/addon-clipboard";
 import { FitAddon } from "@xterm/addon-fit";
@@ -135,6 +136,12 @@ export function createTerminalInstance(
 	const urlLinkProvider = new UrlLinkProvider(xterm, (_event, uri) => {
 		trpcClient.external.openUrl.mutate(uri).catch((error) => {
 			console.error("[Terminal] Failed to open URL:", uri, error);
+			toast.error("Failed to open URL", {
+				description:
+					error instanceof Error
+						? error.message
+						: "Could not open URL in browser",
+			});
 		});
 	});
 	xterm.registerLinkProvider(urlLinkProvider);


### PR DESCRIPTION
## Summary
- Fix silent failure when clicking "Navigate to..." to open external URLs in browser
- Add proper error handling and user feedback via toast notifications

## Changes
- `openUrl` tRPC mutation now returns `{ success, error }` instead of void
- Added `.catch()` handlers to fire-and-forget `shell.openExternal()` calls
- Terminal URL click handler shows toast notification on failure

Fixes #561

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and logging when opening external URLs; failures are now caught and reported.
  * Server-side call now returns structured errors on failure to open URLs.
  * Added user-facing notifications (toasts) to inform users when opening external URLs fails.
  * Existing navigation behavior for external http(s) links is preserved.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->