### PR TITLE
feat(desktop): add extensible terminal output filter mechanism

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -14,7 +14,10 @@ import { authService, handleAuthDeepLink, isAuthDeepLink } from "./lib/auth";
 import { setupAutoUpdater } from "./lib/auto-updater";
 import { localDb } from "./lib/local-db";
 import { terminalManager } from "./lib/terminal";
+import { registerDefaultFilters } from "./lib/terminal-output-filters";
 import { MainWindow } from "./windows/main";
+
+registerDefaultFilters();
 
 // Initialize local SQLite database (runs migrations + legacy data migration on import)
 console.log("[main] Local database ready:", !!localDb);

--- a/apps/desktop/src/main/lib/terminal-output-filter.test.ts
+++ b/apps/desktop/src/main/lib/terminal-output-filter.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import {
+	type TerminalOutputFilter,
+	TerminalOutputFilterChain,
+} from "./terminal-output-filter";
+
+describe("TerminalOutputFilterChain", () => {
+	let chain: TerminalOutputFilterChain;
+
+	beforeEach(() => {
+		chain = new TerminalOutputFilterChain();
+	});
+
+	describe("register", () => {
+		it("should register a filter", () => {
+			const filter: TerminalOutputFilter = {
+				id: "test-filter",
+				description: "Test filter",
+				filter: (data) => data.replace("foo", "bar"),
+			};
+
+			chain.register(filter);
+
+			expect(chain.getRegisteredFilters()).toEqual(["test-filter"]);
+		});
+
+		it("should not register duplicate filters", () => {
+			const filter: TerminalOutputFilter = {
+				id: "test-filter",
+				description: "Test filter",
+				filter: (data) => data,
+			};
+
+			chain.register(filter);
+			chain.register(filter);
+
+			expect(chain.getRegisteredFilters()).toEqual(["test-filter"]);
+		});
+	});
+
+	describe("unregister", () => {
+		it("should unregister a filter", () => {
+			const filter: TerminalOutputFilter = {
+				id: "test-filter",
+				description: "Test filter",
+				filter: (data) => data,
+			};
+
+			chain.register(filter);
+			const result = chain.unregister("test-filter");
+
+			expect(result).toBe(true);
+			expect(chain.getRegisteredFilters()).toEqual([]);
+		});
+
+		it("should return false for non-existent filter", () => {
+			const result = chain.unregister("non-existent");
+			expect(result).toBe(false);
+		});
+	});
+
+	describe("apply", () => {
+		it("should apply filters in order", () => {
+			chain.register({
+				id: "filter-1",
+				description: "Add A",
+				filter: (data) => `${data}A`,
+			});
+			chain.register({
+				id: "filter-2",
+				description: "Add B",
+				filter: (data) => `${data}B`,
+			});
+
+			const result = chain.apply("X");
+			expect(result).toBe("XAB");
+		});
+
+		it("should stop early if data is empty", () => {
+			let secondFilterCalled = false;
+
+			chain.register({
+				id: "filter-1",
+				description: "Clear all",
+				filter: () => "",
+			});
+			chain.register({
+				id: "filter-2",
+				description: "Should not be called",
+				filter: (data) => {
+					secondFilterCalled = true;
+					return data;
+				},
+			});
+
+			const result = chain.apply("test");
+			expect(result).toBe("");
+			expect(secondFilterCalled).toBe(false);
+		});
+
+		it("should return original data with no filters", () => {
+			const result = chain.apply("test data");
+			expect(result).toBe("test data");
+		});
+	});
+
+	describe("clear", () => {
+		it("should remove all filters", () => {
+			chain.register({
+				id: "filter-1",
+				description: "Filter 1",
+				filter: (data) => data,
+			});
+			chain.register({
+				id: "filter-2",
+				description: "Filter 2",
+				filter: (data) => data,
+			});
+
+			chain.clear();
+
+			expect(chain.getRegisteredFilters()).toEqual([]);
+		});
+	});
+});

--- a/apps/desktop/src/main/lib/terminal-output-filter.ts
+++ b/apps/desktop/src/main/lib/terminal-output-filter.ts
@@ -1,0 +1,50 @@
+/**
+ * Terminal output filter - transforms data before display (not storage).
+ * Implement this interface to add custom filters.
+ */
+export interface TerminalOutputFilter {
+	readonly id: string;
+	readonly description: string;
+	filter(data: string): string;
+}
+
+export class TerminalOutputFilterChain {
+	private filters: TerminalOutputFilter[] = [];
+
+	register(filter: TerminalOutputFilter): void {
+		if (this.filters.some((f) => f.id === filter.id)) {
+			return;
+		}
+		this.filters.push(filter);
+	}
+
+	unregister(filterId: string): boolean {
+		const index = this.filters.findIndex((f) => f.id === filterId);
+		if (index === -1) {
+			return false;
+		}
+		this.filters.splice(index, 1);
+		return true;
+	}
+
+	apply(data: string): string {
+		let result = data;
+		for (const filter of this.filters) {
+			result = filter.filter(result);
+			if (result.length === 0) {
+				break;
+			}
+		}
+		return result;
+	}
+
+	getRegisteredFilters(): string[] {
+		return this.filters.map((f) => f.id);
+	}
+
+	clear(): void {
+		this.filters = [];
+	}
+}
+
+export const terminalOutputFilterChain = new TerminalOutputFilterChain();

--- a/apps/desktop/src/main/lib/terminal-output-filters/index.ts
+++ b/apps/desktop/src/main/lib/terminal-output-filters/index.ts
@@ -1,0 +1,8 @@
+import { terminalOutputFilterChain } from "../terminal-output-filter";
+import { oscResponseFilter } from "./osc-response-filter";
+
+export function registerDefaultFilters(): void {
+	terminalOutputFilterChain.register(oscResponseFilter);
+}
+
+export { oscResponseFilter };

--- a/apps/desktop/src/main/lib/terminal-output-filters/osc-response-filter.test.ts
+++ b/apps/desktop/src/main/lib/terminal-output-filters/osc-response-filter.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "bun:test";
+import { oscResponseFilter } from "./osc-response-filter";
+
+const ESC = "\x1b";
+const BEL = "\x07";
+
+describe("oscResponseFilter", () => {
+	describe("OSC color responses", () => {
+		it("should filter OSC 11 background color response with BEL terminator", () => {
+			const response = `${ESC}]11;rgb:1a1a/1a1a/1a1a${BEL}`;
+			expect(oscResponseFilter.filter(response)).toBe("");
+		});
+
+		it("should filter OSC 11 background color response with ST terminator", () => {
+			const response = `${ESC}]11;rgb:1a1a/1a1a/1a1a${ESC}\\`;
+			expect(oscResponseFilter.filter(response)).toBe("");
+		});
+
+		it("should filter OSC 10 foreground color response", () => {
+			const response = `${ESC}]10;rgb:ffff/ffff/ffff${BEL}`;
+			expect(oscResponseFilter.filter(response)).toBe("");
+		});
+
+		it("should filter OSC 12 cursor color response", () => {
+			const response = `${ESC}]12;rgb:0000/ffff/0000${BEL}`;
+			expect(oscResponseFilter.filter(response)).toBe("");
+		});
+
+		it("should filter partial OSC response without ESC prefix", () => {
+			const response = "11;rgb:1a1a/1a1a/1a1a";
+			expect(oscResponseFilter.filter(response)).toBe("");
+		});
+
+		it("should filter partial OSC response with trailing 1R", () => {
+			const response = "11;rgb:1a1a/1a1a/1a1a1R";
+			expect(oscResponseFilter.filter(response)).toBe("");
+		});
+
+		it("should preserve normal text around OSC response", () => {
+			const data = `before${ESC}]11;rgb:1a1a/1a1a/1a1a${BEL}after`;
+			expect(oscResponseFilter.filter(data)).toBe("beforeafter");
+		});
+	});
+
+	describe("Device Attributes responses", () => {
+		it("should filter DA1 response", () => {
+			const response = `${ESC}[?1;2c`;
+			expect(oscResponseFilter.filter(response)).toBe("");
+		});
+
+		it("should filter DA2 response with more params", () => {
+			const response = `${ESC}[?65;1;9c`;
+			expect(oscResponseFilter.filter(response)).toBe("");
+		});
+	});
+
+	describe("Cursor Position Report", () => {
+		it("should filter CPR response", () => {
+			const response = `${ESC}[24;80R`;
+			expect(oscResponseFilter.filter(response)).toBe("");
+		});
+
+		it("should filter CPR with different positions", () => {
+			const response = `${ESC}[1;1R`;
+			expect(oscResponseFilter.filter(response)).toBe("");
+		});
+	});
+
+	describe("mixed content", () => {
+		it("should filter multiple response types", () => {
+			const data = `text${ESC}]11;rgb:1a1a/1a1a/1a1a${BEL}more${ESC}[?1;2c${ESC}[24;80Rend`;
+			expect(oscResponseFilter.filter(data)).toBe("textmoreend");
+		});
+
+		it("should preserve ANSI color codes", () => {
+			const data = `${ESC}[32mgreen text${ESC}[0m`;
+			expect(oscResponseFilter.filter(data)).toBe(data);
+		});
+
+		it("should preserve normal escape sequences", () => {
+			const data = `${ESC}[H${ESC}[2J`;
+			expect(oscResponseFilter.filter(data)).toBe(data);
+		});
+	});
+});

--- a/apps/desktop/src/main/lib/terminal-output-filters/osc-response-filter.ts
+++ b/apps/desktop/src/main/lib/terminal-output-filters/osc-response-filter.ts
@@ -1,0 +1,33 @@
+import type { TerminalOutputFilter } from "../terminal-output-filter";
+
+const ESC = "\\x1b";
+const BEL = "\\x07";
+
+// OSC 10/11/12 color responses: \e]1X;rgb:RRRR/GGGG/BBBB\a or \e]1X;rgb:RRRR/GGGG/BBBB\e\\
+const OSC_COLOR_RESPONSE = new RegExp(
+	`${ESC}\\]1[0-2];rgb:[0-9a-fA-F]{4}/[0-9a-fA-F]{4}/[0-9a-fA-F]{4}(?:${BEL}|${ESC}\\\\)`,
+	"g",
+);
+
+// Device Attributes response: \e[?...c
+const DA_RESPONSE = new RegExp(`${ESC}\\[\\?[0-9;]*c`, "g");
+
+// Cursor Position Report: \e[row;colR
+const CPR_RESPONSE = new RegExp(`${ESC}\\[[0-9]+;[0-9]+R`, "g");
+
+// Partial OSC responses without ESC prefix: 1X;rgb:XXXX/XXXX/XXXX...
+const PARTIAL_OSC_COLOR =
+	/1[0-2];rgb:[0-9a-fA-F]{4}\/[0-9a-fA-F]{4}\/[0-9a-fA-F]{4}(?:1R)?/g;
+
+export const oscResponseFilter: TerminalOutputFilter = {
+	id: "osc-response",
+	description: "Filters terminal query responses (OSC colors, DA, CPR)",
+
+	filter(data: string): string {
+		return data
+			.replace(OSC_COLOR_RESPONSE, "")
+			.replace(DA_RESPONSE, "")
+			.replace(CPR_RESPONSE, "")
+			.replace(PARTIAL_OSC_COLOR, "");
+	},
+};

--- a/apps/desktop/src/main/lib/terminal/session.ts
+++ b/apps/desktop/src/main/lib/terminal/session.ts
@@ -7,6 +7,7 @@ import {
 	extractContentAfterClear,
 } from "../terminal-escape-filter";
 import { HistoryReader, HistoryWriter } from "../terminal-history";
+import { terminalOutputFilterChain } from "../terminal-output-filter";
 import { buildTerminalEnv, FALLBACK_SHELL, getDefaultShell } from "./env";
 import { portManager } from "./port-manager";
 import type { InternalCreateSessionParams, TerminalSession } from "./types";
@@ -166,10 +167,10 @@ export function setupDataHandler(
 		session.scrollback += dataToStore;
 		session.historyWriter?.write(dataToStore);
 
-		// Scan for port patterns in terminal output
 		portManager.scanOutput(dataToStore, session.paneId, session.workspaceId);
 
-		session.dataBatcher.write(data);
+		const dataToDisplay = terminalOutputFilterChain.apply(data);
+		session.dataBatcher.write(dataToDisplay);
 
 		if (initialCommandString && !commandsSent) {
 			commandsSent = true;


### PR DESCRIPTION
## Summary
- Add extensible `TerminalOutputFilterChain` mechanism for filtering terminal output before display
- Implement OSC response filter to remove unwanted terminal query responses (color queries, device attributes, cursor position reports)
- Filters apply to display only—scrollback history preserves raw data for accuracy

## Why / Context

Terminal emulators respond to certain escape sequences with response strings. For example, when a shell or program queries the background color with `\e]11;?\a`, xterm.js responds with `\e]11;rgb:RRRR/GGGG/BBBB\e\`. These responses were being echoed back to the display, showing noise like `11;rgb:1a1a/1a1a/1a1a1R` in the terminal output.

## How It Works

1. **Filter Interface** (`terminal-output-filter.ts`): Defines `TerminalOutputFilter` interface and `TerminalOutputFilterChain` class
2. **OSC Response Filter** (`terminal-output-filters/osc-response-filter.ts`): Filters:
   - OSC 10/11/12 color responses
   - Device Attributes (DA) responses  
   - Cursor Position Reports (CPR)
   - Partial/malformed OSC responses
3. **Integration** (`session.ts`): Applies filter chain before writing to `dataBatcher` (display), not before writing to scrollback

**Data flow:**
```
pty → session.onData → scrollback (unfiltered) → filterChain.apply() → dataBatcher → xterm (filtered)
```

## Manual QA Checklist
- [ ] Terminal displays normally without escape sequence noise
- [ ] Strings like `11;rgb:1a1a/1a1a/1a1a1R` no longer appear in terminal output
- [ ] Normal ANSI color codes still work (e.g., colored `ls` output)
- [ ] Scrollback history works correctly
- [ ] App starts without errors

## Testing
- `bun run typecheck` ✅
- `bun test apps/desktop/src/main/lib/terminal-output-filter.test.ts` ✅ (22 tests)
- `bun test apps/desktop/src/main/lib/terminal-output-filters/osc-response-filter.test.ts` ✅

## Extending

To add a new filter:

```typescript
import type { TerminalOutputFilter } from "../terminal-output-filter";

export const myFilter: TerminalOutputFilter = {
  id: "my-filter",
  description: "Filters X",
  filter(data: string): string {
    return data.replace(/pattern/g, "");
  },
};
```

Register in `terminal-output-filters/index.ts`:
```typescript
terminalOutputFilterChain.register(myFilter);
```

## New Files
- `apps/desktop/src/main/lib/terminal-output-filter.ts` - Core filter mechanism
- `apps/desktop/src/main/lib/terminal-output-filter.test.ts` - Tests
- `apps/desktop/src/main/lib/terminal-output-filters/index.ts` - Registration
- `apps/desktop/src/main/lib/terminal-output-filters/osc-response-filter.ts` - OSC filter
- `apps/desktop/src/main/lib/terminal-output-filters/osc-response-filter.test.ts` - OSC filter tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Terminal output is now automatically filtered to remove unnecessary escape sequences, improving readability of displayed terminal content in the desktop application.

* **Tests**
  * Added comprehensive unit tests for terminal output filtering functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->