### PR TITLE
fix(desktop): resolve gh CLI PATH issue when launched from Finder/Dock

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.ts
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import type { CheckItem, GitHubStatus } from "@superset/local-db";
 import { branchExistsOnRemote } from "../git";
+import { execWithShellEnv } from "../shell-env";
 import {
 	type GHPRResponse,
 	GHPRResponseSchema,
@@ -68,12 +69,10 @@ export async function fetchGitHubPRStatus(
 
 async function getRepoUrl(worktreePath: string): Promise<string | null> {
 	try {
-		const { stdout } = await execFileAsync(
+		const { stdout } = await execWithShellEnv(
 			"gh",
 			["repo", "view", "--json", "url"],
-			{
-				cwd: worktreePath,
-			},
+			{ cwd: worktreePath },
 		);
 		const raw = JSON.parse(stdout);
 		const result = GHRepoResponseSchema.safeParse(raw);
@@ -93,8 +92,8 @@ async function getPRForBranch(
 	branch: string,
 ): Promise<GitHubStatus["pr"]> {
 	try {
-		// Use execFile with args array to prevent command injection
-		const { stdout } = await execFileAsync(
+		// Use execWithShellEnv to handle macOS GUI app PATH issues
+		const { stdout } = await execWithShellEnv(
 			"gh",
 			[
 				"pr",


### PR DESCRIPTION
## Summary
- Fix GitHub PR status not loading when the desktop app is launched from Finder/Dock
- Add lazy PATH fix that derives user's shell environment on first ENOENT, then persists

## Why / Context
On macOS, GUI apps launched from Finder/Dock get a minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) that excludes homebrew (`/opt/homebrew/bin`) and other user-installed tools. This caused `gh` CLI calls to silently fail with ENOENT.

Terminal sessions worked because shell wrappers source user's `.zprofile`/`.zshrc` which configure PATH properly.

## How It Works
1. `execWithShellEnv()` wraps command execution with ENOENT retry logic
2. On first ENOENT (macOS only), derives shell environment via existing `getShellEnvironment()`
3. Persists `process.env.PATH` so all subsequent calls benefit (critical for multi-call flows like `fetchGitHubPRStatus` which calls both `gh repo view` and `gh pr view`)
4. Tracks `pathFixAttempted` vs `pathFixSucceeded` separately - if derivation fails transiently, future ENOENTs can retry

## Design Decisions
- **Why lazy fix instead of eager startup fix**: Avoids startup latency for users with heavy shell init. Only pays the cost when actually needed.
- **Why reuse getShellEnvironment()**: Already handles login shell spawn, caching, and fallback - no duplication.
- **Why /bin/zsh fallback on darwin**: Homebrew configures PATH in zsh; bash fallback would miss it for users without SHELL set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS reliability for running CLI commands by deriving and applying the user shell environment, caching PATH, and retrying once when commands are initially not found.

* **Refactor**
  * Replaced direct command execution with an environment-aware wrapper to ensure consistent behavior across platforms; no public API changes.

* **Documentation**
  * Added docs/comments describing the macOS PATH-fix and retry behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->