### PR TITLE
fix(desktop): filter empty values in SelectItem components

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -217,11 +217,13 @@ export function NewWorkspaceModal() {
 							<SelectValue placeholder="Select project" />
 						</SelectTrigger>
 						<SelectContent>
-							{recentProjects.map((project) => (
-								<SelectItem key={project.id} value={project.id}>
-									{project.name}
-								</SelectItem>
-							))}
+							{recentProjects
+								.filter((project) => project.id)
+								.map((project) => (
+									<SelectItem key={project.id} value={project.id}>
+										{project.name}
+									</SelectItem>
+								))}
 						</SelectContent>
 					</Select>
 				</div>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/components/BaseBranchSelector/BaseBranchSelector.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/components/BaseBranchSelector/BaseBranchSelector.tsx
@@ -49,14 +49,16 @@ export function BaseBranchSelector({ worktreePath }: BaseBranchSelectorProps) {
 					<SelectValue />
 				</SelectTrigger>
 				<SelectContent align="start">
-					{availableBranches.map((branch) => (
-						<SelectItem key={branch} value={branch} className="text-xs">
-							{branch}
-							{branch === branchData.defaultBranch && (
-								<span className="ml-1 text-muted-foreground">(default)</span>
-							)}
-						</SelectItem>
-					))}
+					{availableBranches
+						.filter((branch) => branch)
+						.map((branch) => (
+							<SelectItem key={branch} value={branch} className="text-xs">
+								{branch}
+								{branch === branchData.defaultBranch && (
+									<span className="ml-1 text-muted-foreground">(default)</span>
+								)}
+							</SelectItem>
+						))}
 				</SelectContent>
 			</Select>
 		</div>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/components/ChangesHeader/ChangesHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/components/ChangesHeader/ChangesHeader.tsx
@@ -74,16 +74,18 @@ export function ChangesHeader({
 								</SelectTrigger>
 							</TooltipTrigger>
 							<SelectContent align="start">
-								{sortedBranches.map((branch) => (
-									<SelectItem key={branch} value={branch} className="text-xs">
-										{branch}
-										{branch === branchData.defaultBranch && (
-											<span className="ml-1 text-muted-foreground">
-												(default)
-											</span>
-										)}
-									</SelectItem>
-								))}
+								{sortedBranches
+									.filter((branch) => branch)
+									.map((branch) => (
+										<SelectItem key={branch} value={branch} className="text-xs">
+											{branch}
+											{branch === branchData.defaultBranch && (
+												<span className="ml-1 text-muted-foreground">
+													(default)
+												</span>
+											)}
+										</SelectItem>
+									))}
 							</SelectContent>
 						</Select>
 						<TooltipContent side="bottom" showArrow={false}>


### PR DESCRIPTION
## Summary
- Fix runtime error when `SelectItem` receives empty string value in New Workspace modal and branch selectors
- Add defensive `.filter()` before `.map()` to prevent Radix UI Select crash