### PR TITLE
feat(desktop): add PR status indicator to Changes view header

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/PRIcon/PRIcon.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/PRIcon/PRIcon.tsx
@@ -1,0 +1,38 @@
+import { cn } from "@superset/ui/utils";
+import { LuCircleDot, LuGitMerge, LuGitPullRequest } from "react-icons/lu";
+
+export type PRState = "open" | "merged" | "closed" | "draft";
+
+interface PRIconProps {
+	state: PRState;
+	className?: string;
+}
+
+const stateStyles: Record<PRState, string> = {
+	open: "text-emerald-500",
+	merged: "text-violet-500",
+	closed: "text-red-500",
+	draft: "text-muted-foreground",
+};
+
+/**
+ * Renders a PR icon with color based on state.
+ * - open: green pull request icon
+ * - merged: purple/violet merge icon
+ * - closed: red dot icon
+ * - draft: muted pull request icon
+ */
+export function PRIcon({ state, className }: PRIconProps) {
+	const baseClass = cn(stateStyles[state], className);
+
+	if (state === "merged") {
+		return <LuGitMerge className={baseClass} />;
+	}
+
+	if (state === "closed") {
+		return <LuCircleDot className={baseClass} />;
+	}
+
+	// open or draft
+	return <LuGitPullRequest className={baseClass} />;
+}

--- a/apps/desktop/src/renderer/screens/main/components/PRIcon/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/PRIcon/index.ts
@@ -1,0 +1,1 @@
+export { PRIcon, type PRState } from "./PRIcon";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/WorkspaceHoverCard.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/WorkspaceHoverCard.tsx
@@ -7,6 +7,7 @@ import {
 	LuTriangleAlert,
 } from "react-icons/lu";
 import { trpc } from "renderer/lib/trpc";
+import { usePRStatus } from "renderer/screens/main/hooks";
 import { ChecksList } from "./components/ChecksList";
 import { ChecksSummary } from "./components/ChecksSummary";
 import { PRStatusBadge } from "./components/PRStatusBadge";
@@ -26,13 +27,13 @@ export function WorkspaceHoverCardContent({
 		{ enabled: !!workspaceId },
 	);
 
-	const { data: githubStatus, isLoading: isLoadingGithub } =
-		trpc.workspaces.getGitHubStatus.useQuery(
-			{ workspaceId },
-			{ enabled: !!workspaceId },
-		);
+	const {
+		pr,
+		repoUrl,
+		branchExistsOnRemote,
+		isLoading: isLoadingGithub,
+	} = usePRStatus({ workspaceId });
 
-	const pr = githubStatus?.pr;
 	const needsRebase = worktreeInfo?.gitStatus?.needsRebase;
 
 	const worktreeName = worktreeInfo?.worktreeName;
@@ -51,9 +52,9 @@ export function WorkspaceHoverCardContent({
 						<span className="text-[10px] uppercase tracking-wide text-muted-foreground">
 							Branch
 						</span>
-						{githubStatus?.repoUrl && githubStatus.branchExistsOnRemote ? (
+						{repoUrl && branchExistsOnRemote ? (
 							<a
-								href={`${githubStatus.repoUrl}/tree/${worktreeName}`}
+								href={`${repoUrl}/tree/${worktreeName}`}
 								target="_blank"
 								rel="noopener noreferrer"
 								className={`flex items-center gap-1 font-mono break-all hover:underline ${hasCustomAlias ? "text-xs" : "text-sm"}`}
@@ -137,7 +138,7 @@ export function WorkspaceHoverCardContent({
 						</a>
 					</Button>
 				</div>
-			) : githubStatus ? (
+			) : repoUrl ? (
 				<div className="text-xs text-muted-foreground pt-2 border-t border-border">
 					No PR for this branch
 				</div>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/ChangesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/ChangesView.tsx
@@ -217,6 +217,7 @@ export function ChangesView({ onFileOpen }: ChangesViewProps) {
 				viewMode={fileListViewMode}
 				onViewModeChange={setFileListViewMode}
 				worktreePath={worktreePath}
+				workspaceId={activeWorkspace?.id}
 			/>
 
 			<CommitInput

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/components/ChangesHeader/ChangesHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/components/ChangesHeader/ChangesHeader.tsx
@@ -8,7 +8,10 @@ import {
 } from "@superset/ui/select";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { HiArrowPath } from "react-icons/hi2";
+import { LuLoaderCircle } from "react-icons/lu";
 import { trpc } from "renderer/lib/trpc";
+import { PRIcon } from "renderer/screens/main/components/PRIcon";
+import { usePRStatus } from "renderer/screens/main/hooks";
 import { useChangesStore } from "renderer/stores/changes";
 import type { ChangesViewMode } from "../../types";
 import { ViewModeToggle } from "../ViewModeToggle";
@@ -21,6 +24,7 @@ interface ChangesHeaderProps {
 	viewMode: ChangesViewMode;
 	onViewModeChange: (mode: ChangesViewMode) => void;
 	worktreePath: string;
+	workspaceId?: string;
 }
 
 export function ChangesHeader({
@@ -31,6 +35,7 @@ export function ChangesHeader({
 	viewMode,
 	onViewModeChange,
 	worktreePath,
+	workspaceId,
 }: ChangesHeaderProps) {
 	const { baseBranch, setBaseBranch } = useChangesStore();
 
@@ -38,6 +43,11 @@ export function ChangesHeader({
 		{ worktreePath },
 		{ enabled: !!worktreePath },
 	);
+
+	const { pr, isLoading: isPRLoading } = usePRStatus({
+		workspaceId,
+		refetchInterval: 10000,
+	});
 
 	const effectiveBaseBranch = baseBranch ?? branchData?.defaultBranch ?? "main";
 	const availableBranches = branchData?.remote ?? [];
@@ -115,6 +125,30 @@ export function ChangesHeader({
 						Refresh changes
 					</TooltipContent>
 				</Tooltip>
+
+				{/* PR Status Icon */}
+				{isPRLoading ? (
+					<LuLoaderCircle className="w-4 h-4 animate-spin text-muted-foreground shrink-0" />
+				) : pr ? (
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<a
+								href={pr.url}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="flex items-center gap-1 shrink-0 hover:opacity-80 transition-opacity"
+							>
+								<PRIcon state={pr.state} className="w-4 h-4" />
+								<span className="text-xs text-muted-foreground font-mono">
+									#{pr.number}
+								</span>
+							</a>
+						</TooltipTrigger>
+						<TooltipContent side="bottom" showArrow={false}>
+							View PR on GitHub
+						</TooltipContent>
+					</Tooltip>
+				) : null}
 			</div>
 		</div>
 	);

--- a/apps/desktop/src/renderer/screens/main/hooks/index.ts
+++ b/apps/desktop/src/renderer/screens/main/hooks/index.ts
@@ -1,1 +1,2 @@
+export { usePRStatus } from "./usePRStatus";
 export { useWorkspaceRename } from "./useWorkspaceRename";

--- a/apps/desktop/src/renderer/screens/main/hooks/usePRStatus/index.ts
+++ b/apps/desktop/src/renderer/screens/main/hooks/usePRStatus/index.ts
@@ -1,0 +1,1 @@
+export { usePRStatus } from "./usePRStatus";

--- a/apps/desktop/src/renderer/screens/main/hooks/usePRStatus/usePRStatus.ts
+++ b/apps/desktop/src/renderer/screens/main/hooks/usePRStatus/usePRStatus.ts
@@ -1,0 +1,46 @@
+import type { GitHubStatus } from "@superset/local-db";
+import { trpc } from "renderer/lib/trpc";
+
+interface UsePRStatusOptions {
+	workspaceId: string | undefined;
+	enabled?: boolean;
+	refetchInterval?: number;
+}
+
+interface UsePRStatusResult {
+	pr: GitHubStatus["pr"] | null;
+	repoUrl: string | null;
+	branchExistsOnRemote: boolean;
+	isLoading: boolean;
+	refetch: () => void;
+}
+
+/**
+ * Hook to fetch and manage GitHub PR status for a workspace.
+ * Returns PR info, loading state, and refetch function.
+ */
+export function usePRStatus({
+	workspaceId,
+	enabled = true,
+	refetchInterval,
+}: UsePRStatusOptions): UsePRStatusResult {
+	const {
+		data: githubStatus,
+		isLoading,
+		refetch,
+	} = trpc.workspaces.getGitHubStatus.useQuery(
+		{ workspaceId: workspaceId ?? "" },
+		{
+			enabled: enabled && !!workspaceId,
+			refetchInterval,
+		},
+	);
+
+	return {
+		pr: githubStatus?.pr ?? null,
+		repoUrl: githubStatus?.repoUrl ?? null,
+		branchExistsOnRemote: githubStatus?.branchExistsOnRemote ?? false,
+		isLoading,
+		refetch,
+	};
+}


### PR DESCRIPTION
## Summary
- Add a PR status indicator (icon + number) to the Changes view header that links to GitHub
- Create shared `usePRStatus` hook and `PRIcon` component for reuse, refactoring existing logic from WorkspaceHoverCard

## Changes
- **New `usePRStatus` hook**: Abstracts GitHub PR status fetching logic for reuse across components
- **New `PRIcon` component**: Color-coded PR icons based on state (green for open, violet for merged, red for closed, muted for draft)
- **Updated `ChangesHeader`**: Displays clickable PR icon with number when a PR exists
- **Refactored `WorkspaceHoverCard`**: Now uses the shared `usePRStatus` hook