### PR TITLE
fix(desktop): create terminal instead of cloning diff editor on split

### DIFF
--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -625,19 +625,8 @@ export const useTabsStore = create<TabsStore>()(
 					const sourcePane = state.panes[sourcePaneId];
 					if (!sourcePane || sourcePane.tabId !== tabId) return;
 
-					// Clone file-viewer panes instead of creating a terminal
-					const newPane =
-						sourcePane.type === "file-viewer" && sourcePane.fileViewer
-							? createFileViewerPane(tabId, {
-									filePath: sourcePane.fileViewer.filePath,
-									viewMode: sourcePane.fileViewer.viewMode,
-									isLocked: true, // Lock the cloned pane
-									diffLayout: sourcePane.fileViewer.diffLayout,
-									diffCategory: sourcePane.fileViewer.diffCategory,
-									commitHash: sourcePane.fileViewer.commitHash,
-									oldPath: sourcePane.fileViewer.oldPath,
-								})
-							: createPane(tabId);
+					// Always create a new terminal when splitting
+					const newPane = createPane(tabId);
 
 					let newLayout: MosaicNode<string>;
 					if (path && path.length > 0) {
@@ -685,19 +674,8 @@ export const useTabsStore = create<TabsStore>()(
 					const sourcePane = state.panes[sourcePaneId];
 					if (!sourcePane || sourcePane.tabId !== tabId) return;
 
-					// Clone file-viewer panes instead of creating a terminal
-					const newPane =
-						sourcePane.type === "file-viewer" && sourcePane.fileViewer
-							? createFileViewerPane(tabId, {
-									filePath: sourcePane.fileViewer.filePath,
-									viewMode: sourcePane.fileViewer.viewMode,
-									isLocked: true, // Lock the cloned pane
-									diffLayout: sourcePane.fileViewer.diffLayout,
-									diffCategory: sourcePane.fileViewer.diffCategory,
-									commitHash: sourcePane.fileViewer.commitHash,
-									oldPath: sourcePane.fileViewer.oldPath,
-								})
-							: createPane(tabId);
+					// Always create a new terminal when splitting
+					const newPane = createPane(tabId);
 
 					let newLayout: MosaicNode<string>;
 					if (path && path.length > 0) {


### PR DESCRIPTION
## Summary
- When splitting a diff editor pane, create a new terminal instead of cloning the diff viewer
- This provides a better workflow as users typically want to run commands alongside viewing diffs rather than having duplicate diff views

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Splitting a pane now always opens a fresh terminal pane instead of cloning the source file-viewer; split behavior is consistent for vertical and horizontal splits.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->