### PR TITLE
fix(desktop): make dropdown button match commit button styling

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/components/CommitInput/CommitInput.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/components/CommitInput/CommitInput.tsx
@@ -246,7 +246,7 @@ export function CommitInput({
 				<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
 					<DropdownMenuTrigger asChild>
 						<Button
-							variant="default"
+							variant="secondary"
 							size="sm"
 							disabled={isPending}
 							className="h-7 px-1.5"


### PR DESCRIPTION
## Summary
- Fix visual inconsistency where the commit dropdown button had a different background color than the main "Commit" button by changing its variant from `default` to `secondary`