### PR TITLE
feat(desktop): add default preset support for new terminals

### DIFF
--- a/apps/desktop/src/renderer/react-query/presets/index.ts
+++ b/apps/desktop/src/renderer/react-query/presets/index.ts
@@ -48,6 +48,21 @@ function useDeleteTerminalPreset(
 	});
 }
 
+function useSetDefaultPreset(
+	options?: Parameters<typeof trpc.settings.setDefaultPreset.useMutation>[0],
+) {
+	const utils = trpc.useUtils();
+
+	return trpc.settings.setDefaultPreset.useMutation({
+		...options,
+		onSuccess: async (...args) => {
+			await utils.settings.getTerminalPresets.invalidate();
+			await utils.settings.getDefaultPreset.invalidate();
+			await options?.onSuccess?.(...args);
+		},
+	});
+}
+
 /**
  * Combined hook for accessing terminal presets with all CRUD operations
  * Provides easy access to presets data and mutations from anywhere in the app
@@ -56,15 +71,20 @@ export function usePresets() {
 	const { data: presets = [], isLoading } =
 		trpc.settings.getTerminalPresets.useQuery();
 
+	const { data: defaultPreset } = trpc.settings.getDefaultPreset.useQuery();
+
 	const createPreset = useCreateTerminalPreset();
 	const updatePreset = useUpdateTerminalPreset();
 	const deletePreset = useDeleteTerminalPreset();
+	const setDefaultPreset = useSetDefaultPreset();
 
 	return {
 		presets,
+		defaultPreset,
 		isLoading,
 		createPreset,
 		updatePreset,
 		deletePreset,
+		setDefaultPreset,
 	};
 }

--- a/apps/desktop/src/renderer/screens/main/components/SettingsView/PresetsSettings/PresetRow/PresetRow.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/SettingsView/PresetsSettings/PresetRow/PresetRow.tsx
@@ -1,5 +1,7 @@
 import { Button } from "@superset/ui/button";
 import { Input } from "@superset/ui/input";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { HiOutlineStar, HiStar } from "react-icons/hi2";
 import { LuTrash } from "react-icons/lu";
 import { CommandsEditor } from "../CommandsEditor";
 import {
@@ -62,6 +64,7 @@ interface PresetRowProps {
 	onCommandsChange: (rowIndex: number, commands: string[]) => void;
 	onCommandsBlur: (rowIndex: number) => void;
 	onDelete: (rowIndex: number) => void;
+	onSetDefault: (presetId: string | null) => void;
 }
 
 export function PresetRow({
@@ -73,7 +76,13 @@ export function PresetRow({
 	onCommandsChange,
 	onCommandsBlur,
 	onDelete,
+	onSetDefault,
 }: PresetRowProps) {
+	const handleToggleDefault = () => {
+		// If already default, clear it; otherwise set this preset as default
+		onSetDefault(preset.isDefault ? null : preset.id);
+	};
+
 	return (
 		<div
 			className={`flex items-start gap-4 py-3 px-4 ${
@@ -93,7 +102,31 @@ export function PresetRow({
 					/>
 				</div>
 			))}
-			<div className="w-12 flex justify-center shrink-0 pt-1">
+			<div className="w-20 flex justify-center gap-1 shrink-0 pt-1">
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={handleToggleDefault}
+							className={`h-8 w-8 p-0 ${preset.isDefault ? "text-yellow-500 hover:text-yellow-600" : "text-muted-foreground hover:text-foreground"}`}
+							aria-label={
+								preset.isDefault ? "Remove default" : "Set as default"
+							}
+						>
+							{preset.isDefault ? (
+								<HiStar className="h-4 w-4" />
+							) : (
+								<HiOutlineStar className="h-4 w-4" />
+							)}
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent side="top">
+						{preset.isDefault
+							? "Remove as default"
+							: "Set as default for new terminals"}
+					</TooltipContent>
+				</Tooltip>
 				<Button
 					variant="ghost"
 					size="sm"

--- a/apps/desktop/src/renderer/screens/main/components/SettingsView/PresetsSettings/PresetsSettings.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/SettingsView/PresetsSettings/PresetsSettings.tsx
@@ -81,6 +81,7 @@ export function PresetsSettings() {
 		createPreset,
 		updatePreset,
 		deletePreset,
+		setDefaultPreset,
 	} = usePresets();
 	const [localPresets, setLocalPresets] =
 		useState<TerminalPreset[]>(serverPresets);
@@ -159,6 +160,10 @@ export function PresetsSettings() {
 		if (!preset) return;
 
 		deletePreset.mutate({ id: preset.id });
+	};
+
+	const handleSetDefault = (presetId: string | null) => {
+		setDefaultPreset.mutate({ id: presetId });
 	};
 
 	if (isLoading) {
@@ -241,7 +246,7 @@ export function PresetsSettings() {
 							{column.label}
 						</div>
 					))}
-					<div className="w-12 text-xs font-medium text-muted-foreground uppercase tracking-wider text-center shrink-0">
+					<div className="w-20 text-xs font-medium text-muted-foreground uppercase tracking-wider text-center shrink-0">
 						Actions
 					</div>
 				</div>
@@ -259,6 +264,7 @@ export function PresetsSettings() {
 								onCommandsChange={handleCommandsChange}
 								onCommandsBlur={handleCommandsBlur}
 								onDelete={handleDeleteRow}
+								onSetDefault={handleSetDefault}
 							/>
 						))
 					) : (

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupStrip.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupStrip.tsx
@@ -14,6 +14,7 @@ import {
 	HiMiniCog6Tooth,
 	HiMiniCommandLine,
 	HiMiniPlus,
+	HiStar,
 } from "react-icons/hi2";
 import {
 	getPresetIcon,
@@ -24,6 +25,7 @@ import { trpc } from "renderer/lib/trpc";
 import { usePresets } from "renderer/react-query/presets";
 import { useOpenSettings } from "renderer/stores";
 import { useTabsStore } from "renderer/stores/tabs/store";
+import { useTabsWithPresets } from "renderer/stores/tabs/useTabsWithPresets";
 import { type ActivePaneStatus, pickHigherStatus } from "shared/tabs-types";
 import { GroupItem } from "./GroupItem";
 
@@ -34,7 +36,7 @@ export function GroupStrip() {
 	const allTabs = useTabsStore((s) => s.tabs);
 	const panes = useTabsStore((s) => s.panes);
 	const activeTabIds = useTabsStore((s) => s.activeTabIds);
-	const addTab = useTabsStore((s) => s.addTab);
+	const { addTab } = useTabsWithPresets();
 	const renameTab = useTabsStore((s) => s.renameTab);
 	const removeTab = useTabsStore((s) => s.removeTab);
 	const setActiveTab = useTabsStore((s) => s.setActiveTab);
@@ -89,9 +91,8 @@ export function GroupStrip() {
 	}, [panes]);
 
 	const handleAddGroup = () => {
-		if (activeWorkspaceId) {
-			addTab(activeWorkspaceId);
-		}
+		if (!activeWorkspaceId) return;
+		addTab(activeWorkspaceId);
 	};
 
 	const handleSelectPreset = (preset: TerminalPreset) => {
@@ -208,6 +209,9 @@ export function GroupStrip() {
 											<HiMiniCommandLine className="size-4" />
 										)}
 										<span className="truncate">{preset.name || "default"}</span>
+										{preset.isDefault && (
+											<HiStar className="size-3 text-yellow-500 ml-auto flex-shrink-0" />
+										)}
 									</DropdownMenuItem>
 								);
 							})}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
@@ -11,6 +11,7 @@ import { dragDropManager } from "renderer/lib/dnd";
 import { trpc } from "renderer/lib/trpc";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import type { Pane, Tab } from "renderer/stores/tabs/types";
+import { useTabsWithPresets } from "renderer/stores/tabs/useTabsWithPresets";
 import {
 	cleanLayout,
 	extractPaneIdsFromLayout,
@@ -28,9 +29,8 @@ export function TabView({ tab, panes }: TabViewProps) {
 	const updateTabLayout = useTabsStore((s) => s.updateTabLayout);
 	const removePane = useTabsStore((s) => s.removePane);
 	const removeTab = useTabsStore((s) => s.removeTab);
-	const splitPaneAuto = useTabsStore((s) => s.splitPaneAuto);
-	const splitPaneHorizontal = useTabsStore((s) => s.splitPaneHorizontal);
-	const splitPaneVertical = useTabsStore((s) => s.splitPaneVertical);
+	const { splitPaneAuto, splitPaneHorizontal, splitPaneVertical } =
+		useTabsWithPresets();
 	const setFocusedPane = useTabsStore((s) => s.setFocusedPane);
 	const focusedPaneIds = useTabsStore((s) => s.focusedPaneIds);
 	const movePaneToTab = useTabsStore((s) => s.movePaneToTab);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/index.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { trpc } from "renderer/lib/trpc";
 import { useAppHotkey } from "renderer/stores/hotkeys";
 import { useTabsStore } from "renderer/stores/tabs/store";
+import { useTabsWithPresets } from "renderer/stores/tabs/useTabsWithPresets";
 import { getNextPaneId, getPreviousPaneId } from "renderer/stores/tabs/utils";
 import {
 	useHasWorkspaceFailed,
@@ -33,7 +34,7 @@ export function WorkspaceView() {
 	const allTabs = useTabsStore((s) => s.tabs);
 	const activeTabIds = useTabsStore((s) => s.activeTabIds);
 	const focusedPaneIds = useTabsStore((s) => s.focusedPaneIds);
-	const addTab = useTabsStore((s) => s.addTab);
+	const { addTab } = useTabsWithPresets();
 	const setActiveTab = useTabsStore((s) => s.setActiveTab);
 	const removePane = useTabsStore((s) => s.removePane);
 	const setFocusedPane = useTabsStore((s) => s.setFocusedPane);

--- a/apps/desktop/src/renderer/screens/main/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/index.tsx
@@ -18,6 +18,7 @@ import { getPaneDimensions } from "renderer/stores/tabs/pane-refs";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import type { Tab } from "renderer/stores/tabs/types";
 import { useAgentHookListener } from "renderer/stores/tabs/useAgentHookListener";
+import { useTabsWithPresets } from "renderer/stores/tabs/useTabsWithPresets";
 import { findPanePath, getFirstPaneId } from "renderer/stores/tabs/utils";
 import { useWorkspaceInitStore } from "renderer/stores/workspace-init";
 import { useWorkspaceSidebarStore } from "renderer/stores/workspace-sidebar-state";
@@ -94,9 +95,8 @@ export function MainScreen() {
 		enabled: isSignedIn,
 	});
 	const [isRetrying, setIsRetrying] = useState(false);
-	const splitPaneAuto = useTabsStore((s) => s.splitPaneAuto);
-	const splitPaneVertical = useTabsStore((s) => s.splitPaneVertical);
-	const splitPaneHorizontal = useTabsStore((s) => s.splitPaneHorizontal);
+	const { splitPaneAuto, splitPaneVertical, splitPaneHorizontal } =
+		useTabsWithPresets();
 	const setFocusedPane = useTabsStore((s) => s.setFocusedPane);
 	const activeTabIds = useTabsStore((s) => s.activeTabIds);
 	const focusedPaneIds = useTabsStore((s) => s.focusedPaneIds);

--- a/apps/desktop/src/renderer/stores/tabs/index.ts
+++ b/apps/desktop/src/renderer/stores/tabs/index.ts
@@ -1,4 +1,5 @@
 export * from "./store";
 export * from "./types";
 export * from "./useAgentHookListener";
+export * from "./useTabsWithPresets";
 export * from "./utils";

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -617,7 +617,7 @@ export const useTabsStore = create<TabsStore>()(
 				},
 
 				// Split operations
-				splitPaneVertical: (tabId, sourcePaneId, path) => {
+				splitPaneVertical: (tabId, sourcePaneId, path, options) => {
 					const state = get();
 					const tab = state.tabs.find((t) => t.id === tabId);
 					if (!tab) return;
@@ -626,7 +626,7 @@ export const useTabsStore = create<TabsStore>()(
 					if (!sourcePane || sourcePane.tabId !== tabId) return;
 
 					// Always create a new terminal when splitting
-					const newPane = createPane(tabId);
+					const newPane = createPane(tabId, "terminal", options);
 
 					let newLayout: MosaicNode<string>;
 					if (path && path.length > 0) {
@@ -666,7 +666,7 @@ export const useTabsStore = create<TabsStore>()(
 					});
 				},
 
-				splitPaneHorizontal: (tabId, sourcePaneId, path) => {
+				splitPaneHorizontal: (tabId, sourcePaneId, path, options) => {
 					const state = get();
 					const tab = state.tabs.find((t) => t.id === tabId);
 					if (!tab) return;
@@ -675,7 +675,7 @@ export const useTabsStore = create<TabsStore>()(
 					if (!sourcePane || sourcePane.tabId !== tabId) return;
 
 					// Always create a new terminal when splitting
-					const newPane = createPane(tabId);
+					const newPane = createPane(tabId, "terminal", options);
 
 					let newLayout: MosaicNode<string>;
 					if (path && path.length > 0) {
@@ -715,11 +715,11 @@ export const useTabsStore = create<TabsStore>()(
 					});
 				},
 
-				splitPaneAuto: (tabId, sourcePaneId, dimensions, path) => {
+				splitPaneAuto: (tabId, sourcePaneId, dimensions, path, options) => {
 					if (dimensions.width >= dimensions.height) {
-						get().splitPaneVertical(tabId, sourcePaneId, path);
+						get().splitPaneVertical(tabId, sourcePaneId, path, options);
 					} else {
-						get().splitPaneHorizontal(tabId, sourcePaneId, path);
+						get().splitPaneHorizontal(tabId, sourcePaneId, path, options);
 					}
 				},
 

--- a/apps/desktop/src/renderer/stores/tabs/types.ts
+++ b/apps/desktop/src/renderer/stores/tabs/types.ts
@@ -93,17 +93,20 @@ export interface TabsStore extends TabsState {
 		tabId: string,
 		sourcePaneId: string,
 		path?: MosaicBranch[],
+		options?: AddTabOptions,
 	) => void;
 	splitPaneHorizontal: (
 		tabId: string,
 		sourcePaneId: string,
 		path?: MosaicBranch[],
+		options?: AddTabOptions,
 	) => void;
 	splitPaneAuto: (
 		tabId: string,
 		sourcePaneId: string,
 		dimensions: { width: number; height: number },
 		path?: MosaicBranch[],
+		options?: AddTabOptions,
 	) => void;
 
 	// Move operations

--- a/apps/desktop/src/renderer/stores/tabs/useTabsWithPresets.ts
+++ b/apps/desktop/src/renderer/stores/tabs/useTabsWithPresets.ts
@@ -1,0 +1,124 @@
+import { useCallback, useMemo } from "react";
+import type { MosaicBranch } from "react-mosaic-component";
+import { usePresets } from "renderer/react-query/presets";
+import { useTabsStore } from "./store";
+import type { AddTabOptions } from "./types";
+
+/**
+ * Hook that wraps tab store actions with default preset support.
+ * When a default preset is configured, new terminals will automatically
+ * use that preset's commands and cwd.
+ */
+export function useTabsWithPresets() {
+	const { defaultPreset } = usePresets();
+
+	const storeAddTab = useTabsStore((s) => s.addTab);
+	const storeAddPane = useTabsStore((s) => s.addPane);
+	const storeSplitPaneVertical = useTabsStore((s) => s.splitPaneVertical);
+	const storeSplitPaneHorizontal = useTabsStore((s) => s.splitPaneHorizontal);
+	const storeSplitPaneAuto = useTabsStore((s) => s.splitPaneAuto);
+	const renameTab = useTabsStore((s) => s.renameTab);
+
+	// Get preset options if a default preset is set
+	const defaultPresetOptions: AddTabOptions | undefined = useMemo(() => {
+		if (!defaultPreset) return undefined;
+		return {
+			initialCommands: defaultPreset.commands,
+			initialCwd: defaultPreset.cwd || undefined,
+		};
+	}, [defaultPreset]);
+
+	// Wrapped addTab that applies default preset
+	const addTab = useCallback(
+		(workspaceId: string, options?: AddTabOptions) => {
+			// If explicit options are provided, use them; otherwise use default preset
+			const effectiveOptions = options ?? defaultPresetOptions;
+			const result = storeAddTab(workspaceId, effectiveOptions);
+
+			// If using default preset and it has a name, rename the tab
+			if (!options && defaultPreset?.name) {
+				renameTab(result.tabId, defaultPreset.name);
+			}
+
+			return result;
+		},
+		[storeAddTab, defaultPresetOptions, defaultPreset, renameTab],
+	);
+
+	// Wrapped addPane that applies default preset
+	const addPane = useCallback(
+		(tabId: string, options?: AddTabOptions) => {
+			const effectiveOptions = options ?? defaultPresetOptions;
+			return storeAddPane(tabId, effectiveOptions);
+		},
+		[storeAddPane, defaultPresetOptions],
+	);
+
+	// Wrapped splitPaneVertical that applies default preset
+	const splitPaneVertical = useCallback(
+		(
+			tabId: string,
+			sourcePaneId: string,
+			path?: MosaicBranch[],
+			options?: AddTabOptions,
+		) => {
+			const effectiveOptions = options ?? defaultPresetOptions;
+			return storeSplitPaneVertical(
+				tabId,
+				sourcePaneId,
+				path,
+				effectiveOptions,
+			);
+		},
+		[storeSplitPaneVertical, defaultPresetOptions],
+	);
+
+	// Wrapped splitPaneHorizontal that applies default preset
+	const splitPaneHorizontal = useCallback(
+		(
+			tabId: string,
+			sourcePaneId: string,
+			path?: MosaicBranch[],
+			options?: AddTabOptions,
+		) => {
+			const effectiveOptions = options ?? defaultPresetOptions;
+			return storeSplitPaneHorizontal(
+				tabId,
+				sourcePaneId,
+				path,
+				effectiveOptions,
+			);
+		},
+		[storeSplitPaneHorizontal, defaultPresetOptions],
+	);
+
+	// Wrapped splitPaneAuto that applies default preset
+	const splitPaneAuto = useCallback(
+		(
+			tabId: string,
+			sourcePaneId: string,
+			dimensions: { width: number; height: number },
+			path?: MosaicBranch[],
+			options?: AddTabOptions,
+		) => {
+			const effectiveOptions = options ?? defaultPresetOptions;
+			return storeSplitPaneAuto(
+				tabId,
+				sourcePaneId,
+				dimensions,
+				path,
+				effectiveOptions,
+			);
+		},
+		[storeSplitPaneAuto, defaultPresetOptions],
+	);
+
+	return {
+		addTab,
+		addPane,
+		splitPaneVertical,
+		splitPaneHorizontal,
+		splitPaneAuto,
+		defaultPreset,
+	};
+}

--- a/packages/local-db/src/schema/zod.ts
+++ b/packages/local-db/src/schema/zod.ts
@@ -56,6 +56,7 @@ export const terminalPresetSchema = z.object({
 	description: z.string().optional(),
 	cwd: z.string(),
 	commands: z.array(z.string()),
+	isDefault: z.boolean().optional(),
 });
 
 export type TerminalPreset = z.infer<typeof terminalPresetSchema>;


### PR DESCRIPTION
## Summary
- Add ability to mark a single terminal preset as default via a star toggle button in preset settings
- Default preset automatically applies when creating new terminals via Cmd+T, split panes (Cmd+D, Cmd+Shift+D, Cmd+E), and the plus button

## Changes
- Add `isDefault` field to TerminalPreset schema
- Add `setDefaultPreset` mutation and `getDefaultPreset` query to settings router
- Create `useTabsWithPresets` hook that wraps store actions with default preset support
- Update all terminal creation entry points to use the new hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Set a default terminal preset that automatically applies when creating new tabs and panes.
  * Visual star icon indicator in presets menu displaying the active default preset.
  * Toggle default status directly from preset settings with dedicated UI controls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->