### PR TITLE
refactor(desktop): remove dropdown from add workspace button in sidebar

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectHeader.tsx
@@ -8,16 +8,10 @@ import {
 	ContextMenuSubTrigger,
 	ContextMenuTrigger,
 } from "@superset/ui/context-menu";
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuTrigger,
-} from "@superset/ui/dropdown-menu";
 import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
-import { HiChevronRight, HiMiniPlus, HiOutlineBolt } from "react-icons/hi2";
+import { HiChevronRight, HiMiniPlus } from "react-icons/hi2";
 import { LuFolderOpen, LuPalette, LuSettings, LuX } from "react-icons/lu";
 import { trpc } from "renderer/lib/trpc";
 import { useUpdateProject } from "renderer/react-query/projects/useUpdateProject";
@@ -42,10 +36,6 @@ interface ProjectHeaderProps {
 	onToggleCollapse: () => void;
 	workspaceCount: number;
 	onNewWorkspace: () => void;
-	onQuickCreate: () => void;
-	isCreating: boolean;
-	dropdownOpen: boolean;
-	onDropdownOpenChange: (open: boolean) => void;
 }
 
 export function ProjectHeader({
@@ -59,10 +49,6 @@ export function ProjectHeader({
 	onToggleCollapse,
 	workspaceCount,
 	onNewWorkspace,
-	onQuickCreate,
-	isCreating,
-	dropdownOpen,
-	onDropdownOpenChange,
 }: ProjectHeaderProps) {
 	const utils = trpc.useUtils();
 	const openSettings = useOpenSettings();
@@ -222,56 +208,24 @@ export function ProjectHeader({
 					</button>
 
 					{/* Add workspace button */}
-					<div className="relative shrink-0 ml-1">
-						<DropdownMenu
-							open={dropdownOpen}
-							onOpenChange={onDropdownOpenChange}
-						>
-							<Tooltip delayDuration={500}>
-								<TooltipTrigger asChild>
-									<DropdownMenuTrigger asChild>
-										<button
-											type="button"
-											disabled={isCreating}
-											onClick={(e) => e.stopPropagation()}
-											onContextMenu={(e) => e.stopPropagation()}
-											className={cn(
-												"p-1 rounded hover:bg-muted transition-colors",
-												dropdownOpen && "bg-muted",
-											)}
-										>
-											<HiMiniPlus className="size-4 text-muted-foreground" />
-										</button>
-									</DropdownMenuTrigger>
-								</TooltipTrigger>
-								<TooltipContent side="bottom" sideOffset={4}>
-									Add workspace
-								</TooltipContent>
-							</Tooltip>
-							<DropdownMenuContent
-								align="end"
-								sideOffset={4}
-								className="w-44 rounded-lg border-border/40 bg-popover/95 p-1 shadow-lg backdrop-blur-sm"
-								onClick={(e) => e.stopPropagation()}
+					<Tooltip delayDuration={500}>
+						<TooltipTrigger asChild>
+							<button
+								type="button"
+								onClick={(e) => {
+									e.stopPropagation();
+									onNewWorkspace();
+								}}
+								onContextMenu={(e) => e.stopPropagation()}
+								className="p-1 rounded hover:bg-muted transition-colors shrink-0 ml-1"
 							>
-								<DropdownMenuItem
-									onClick={onNewWorkspace}
-									className="rounded-md text-[13px]"
-								>
-									<HiMiniPlus className="size-[14px] opacity-60" />
-									New Workspace
-								</DropdownMenuItem>
-								<DropdownMenuItem
-									onClick={onQuickCreate}
-									disabled={isCreating}
-									className="rounded-md text-[13px]"
-								>
-									<HiOutlineBolt className="size-[14px] opacity-60" />
-									Quick Create
-								</DropdownMenuItem>
-							</DropdownMenuContent>
-						</DropdownMenu>
-					</div>
+								<HiMiniPlus className="size-4 text-muted-foreground" />
+							</button>
+						</TooltipTrigger>
+						<TooltipContent side="bottom" sideOffset={4}>
+							New workspace
+						</TooltipContent>
+					</Tooltip>
 
 					{/* Collapse chevron */}
 					<button

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectSection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectSection.tsx
@@ -1,7 +1,4 @@
-import { toast } from "@superset/ui/sonner";
 import { AnimatePresence, motion } from "framer-motion";
-import { useState } from "react";
-import { useCreateWorkspace } from "renderer/react-query/workspaces";
 import { useWorkspaceSidebarStore } from "renderer/stores";
 import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
 import { WorkspaceListItem } from "../WorkspaceListItem";
@@ -43,26 +40,13 @@ export function ProjectSection({
 	shortcutBaseIndex,
 	isCollapsed: isSidebarCollapsed = false,
 }: ProjectSectionProps) {
-	const [dropdownOpen, setDropdownOpen] = useState(false);
 	const { isProjectCollapsed, toggleProjectCollapsed } =
 		useWorkspaceSidebarStore();
-	const createWorkspace = useCreateWorkspace();
 	const openModal = useOpenNewWorkspaceModal();
 
 	const isCollapsed = isProjectCollapsed(projectId);
 
-	const handleQuickCreate = () => {
-		setDropdownOpen(false);
-		toast.promise(createWorkspace.mutateAsync({ projectId }), {
-			loading: "Creating workspace...",
-			success: "Workspace created",
-			error: (err) =>
-				err instanceof Error ? err.message : "Failed to create workspace",
-		});
-	};
-
 	const handleNewWorkspace = () => {
-		setDropdownOpen(false);
 		openModal(projectId);
 	};
 
@@ -81,10 +65,6 @@ export function ProjectSection({
 					onToggleCollapse={() => toggleProjectCollapsed(projectId)}
 					workspaceCount={workspaces.length}
 					onNewWorkspace={handleNewWorkspace}
-					onQuickCreate={handleQuickCreate}
-					isCreating={createWorkspace.isPending}
-					dropdownOpen={dropdownOpen}
-					onDropdownOpenChange={setDropdownOpen}
 				/>
 				<AnimatePresence initial={false}>
 					{!isCollapsed && (
@@ -133,10 +113,6 @@ export function ProjectSection({
 				onToggleCollapse={() => toggleProjectCollapsed(projectId)}
 				workspaceCount={workspaces.length}
 				onNewWorkspace={handleNewWorkspace}
-				onQuickCreate={handleQuickCreate}
-				isCreating={createWorkspace.isPending}
-				dropdownOpen={dropdownOpen}
-				onDropdownOpenChange={setDropdownOpen}
 			/>
 
 			<AnimatePresence initial={false}>


### PR DESCRIPTION
## Summary
- Simplify the "Add Workspace" button in the sidebar by removing the dropdown menu
- Clicking the "+" button now directly opens the New Workspace modal instead of showing a dropdown with "New Workspace" and "Quick Create" options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified workspace creation interface by replacing the dropdown menu with a straightforward button and tooltip
  * Removed Quick Create feature; workspace creation now exclusively uses the dedicated modal for a more direct workflow

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->