### PR TITLE
fix(desktop): select adjacent pane when closing a pane

### DIFF
--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -11,6 +11,7 @@ import {
 	createPane,
 	createTabWithPane,
 	extractPaneIdsFromLayout,
+	getAdjacentPaneId,
 	getFirstPaneId,
 	getPaneIdsForTab,
 	isLastPaneInTab,
@@ -509,6 +510,9 @@ export const useTabsStore = create<TabsStore>()(
 						return;
 					}
 
+					// Must get adjacent pane BEFORE removing from layout
+					const adjacentPaneId = getAdjacentPaneId(tab.layout, paneId);
+
 					// Only kill terminal sessions for terminal panes (avoids unnecessary IPC for file-viewers)
 					if (pane.type === "terminal") {
 						killTerminalForPane(paneId);
@@ -524,12 +528,11 @@ export const useTabsStore = create<TabsStore>()(
 					const newPanes = { ...state.panes };
 					delete newPanes[paneId];
 
-					// Update focused pane if needed
 					let newFocusedPaneIds = state.focusedPaneIds;
 					if (state.focusedPaneIds[tab.id] === paneId) {
 						newFocusedPaneIds = {
 							...state.focusedPaneIds,
-							[tab.id]: getFirstPaneId(newLayout),
+							[tab.id]: adjacentPaneId ?? getFirstPaneId(newLayout),
 						};
 					}
 

--- a/apps/desktop/src/renderer/stores/tabs/utils.test.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { MosaicNode } from "react-mosaic-component";
-import { findPanePath } from "./utils";
+import { findPanePath, getAdjacentPaneId } from "./utils";
 
 describe("findPanePath", () => {
 	it("returns empty array for single pane layout matching the id", () => {
@@ -97,5 +97,95 @@ describe("findPanePath", () => {
 			"second",
 		]);
 		expect(findPanePath(layout, "pane-4")).toEqual(["second", "second"]);
+	});
+});
+
+describe("getAdjacentPaneId", () => {
+	it("returns null for single pane layout", () => {
+		const layout: MosaicNode<string> = "pane-1";
+		const result = getAdjacentPaneId(layout, "pane-1");
+		expect(result).toBeNull();
+	});
+
+	it("returns next pane when closing first pane", () => {
+		const layout: MosaicNode<string> = {
+			direction: "row",
+			first: "pane-1",
+			second: "pane-2",
+		};
+		const result = getAdjacentPaneId(layout, "pane-1");
+		expect(result).toBe("pane-2");
+	});
+
+	it("returns previous pane when closing last pane", () => {
+		const layout: MosaicNode<string> = {
+			direction: "row",
+			first: "pane-1",
+			second: "pane-2",
+		};
+		const result = getAdjacentPaneId(layout, "pane-2");
+		expect(result).toBe("pane-1");
+	});
+
+	it("returns next pane when closing middle pane", () => {
+		const layout: MosaicNode<string> = {
+			direction: "row",
+			first: "pane-1",
+			second: {
+				direction: "row",
+				first: "pane-2",
+				second: "pane-3",
+			},
+		};
+		// Visual order: pane-1, pane-2, pane-3
+		const result = getAdjacentPaneId(layout, "pane-2");
+		expect(result).toBe("pane-3");
+	});
+
+	it("returns previous pane when closing last in multi-pane layout", () => {
+		const layout: MosaicNode<string> = {
+			direction: "row",
+			first: "pane-1",
+			second: {
+				direction: "row",
+				first: "pane-2",
+				second: "pane-3",
+			},
+		};
+		// Visual order: pane-1, pane-2, pane-3
+		const result = getAdjacentPaneId(layout, "pane-3");
+		expect(result).toBe("pane-2");
+	});
+
+	it("returns first pane when closing pane id not found", () => {
+		const layout: MosaicNode<string> = {
+			direction: "row",
+			first: "pane-1",
+			second: "pane-2",
+		};
+		const result = getAdjacentPaneId(layout, "pane-99");
+		expect(result).toBe("pane-1");
+	});
+
+	it("handles complex nested layouts", () => {
+		const layout: MosaicNode<string> = {
+			direction: "row",
+			first: {
+				direction: "column",
+				first: "pane-1",
+				second: "pane-2",
+			},
+			second: {
+				direction: "column",
+				first: "pane-3",
+				second: "pane-4",
+			},
+		};
+		// Visual order: pane-1, pane-2, pane-3, pane-4
+
+		expect(getAdjacentPaneId(layout, "pane-1")).toBe("pane-2");
+		expect(getAdjacentPaneId(layout, "pane-2")).toBe("pane-3");
+		expect(getAdjacentPaneId(layout, "pane-3")).toBe("pane-4");
+		expect(getAdjacentPaneId(layout, "pane-4")).toBe("pane-3"); // Last pane goes to previous
 	});
 });

--- a/apps/desktop/src/renderer/stores/tabs/utils.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils.ts
@@ -335,6 +335,27 @@ export const getPreviousPaneId = (
 };
 
 /**
+ * Gets the adjacent pane ID for focus fallback when a pane is closed.
+ * Prefers the next pane in visual order, falls back to previous if at the end.
+ * Returns null only if the pane is the only one in the layout.
+ */
+export const getAdjacentPaneId = (
+	layout: MosaicNode<string>,
+	closingPaneId: string,
+): string | null => {
+	const paneIds = getPaneIdsInVisualOrder(layout);
+	if (paneIds.length <= 1) return null;
+
+	const currentIndex = paneIds.indexOf(closingPaneId);
+	if (currentIndex === -1) return paneIds[0];
+
+	if (currentIndex < paneIds.length - 1) {
+		return paneIds[currentIndex + 1];
+	}
+	return paneIds[currentIndex - 1];
+};
+
+/**
  * Finds the path to a specific pane ID in a mosaic layout
  * Returns the path as an array of MosaicBranch ("first" | "second"), or null if not found
  */


### PR DESCRIPTION
## Summary
- Fix pane focus behavior when closing a pane to select the visually adjacent pane (next in order, or previous if closing the last) instead of always jumping to the first pane
- Add `getAdjacentPaneId` utility function with comprehensive tests