### PR TITLE
chore: downgrade useExhaustiveDependencies to warning

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -110,7 +110,6 @@ export function NewWorkspaceModal() {
 	const effectiveBaseBranch = baseBranch ?? branchData?.defaultBranch ?? null;
 
 	// Reset base branch when project changes
-	// biome-ignore lint/correctness/useExhaustiveDependencies: intentionally reset when project changes
 	useEffect(() => {
 		setBaseBranch(null);
 	}, [selectedProjectId]);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/ChangesContent/components/DiffViewer/DiffViewer.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/ChangesContent/components/DiffViewer/DiffViewer.tsx
@@ -75,7 +75,6 @@ export function DiffViewer({
 	const [isEditorMounted, setIsEditorMounted] = useState(false);
 	const hasScrolledToFirstDiffRef = useRef(false);
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: Reset on file change only
 	useEffect(() => {
 		hasScrolledToFirstDiffRef.current = false;
 	}, [filePath]);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
@@ -114,7 +114,6 @@ export function FileViewerPane({
 		setIsDirty(value !== originalContentRef.current);
 	}, []);
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: Reset on file change only
 	useEffect(() => {
 		setIsDirty(false);
 		originalContentRef.current = "";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
@@ -97,12 +97,10 @@ export function FileViewerContent({
 	const isMonacoReady = useMonacoReady();
 	const hasAppliedInitialLocationRef = useRef(false);
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: Reset on file change only
 	useEffect(() => {
 		hasAppliedInitialLocationRef.current = false;
 	}, [filePath]);
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: Only reset when coordinates change
 	useEffect(() => {
 		hasAppliedInitialLocationRef.current = false;
 	}, [initialLine, initialColumn]);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/hooks/useFileContent/useFileContent.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/hooks/useFileContent/useFileContent.ts
@@ -56,14 +56,12 @@ export function useFileContent({
 			},
 		);
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: Only update baseline when content loads
 	useEffect(() => {
 		if (rawFileData?.ok === true && !isDirty) {
 			originalContentRef.current = rawFileData.content;
 		}
 	}, [rawFileData]);
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: Only update baseline when diff loads
 	useEffect(() => {
 		if (diffData?.modified && !isDirty) {
 			originalDiffContentRef.current = diffData.modified;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/ChangesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/ChangesView.tsx
@@ -121,7 +121,6 @@ export function ChangesView({
 
 	// Reset expanded commits when workspace changes to avoid querying
 	// old commit hashes against the new worktree
-	// biome-ignore lint/correctness/useExhaustiveDependencies: intentionally resets on worktreePath change
 	useEffect(() => {
 		setExpandedCommits(new Set());
 	}, [worktreePath]);

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -19,7 +19,10 @@
 	},
 	"linter": {
 		"rules": {
-			"recommended": true
+			"recommended": true,
+			"correctness": {
+				"useExhaustiveDependencies": "warn"
+			}
 		}
 	}
 }

--- a/packages/ui/src/components/ai-elements/prompt-input.tsx
+++ b/packages/ui/src/components/ai-elements/prompt-input.tsx
@@ -666,7 +666,6 @@ export const PromptInput = ({
 				}
 			}
 		},
-		// eslint-disable-next-line react-hooks/exhaustive-deps -- cleanup only on unmount; filesRef always current
 		[usingProvider],
 	);
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
-# Wrapper for biome check that fails on ANY diagnostic (info, warn, or error)
+# Wrapper for biome check that fails on errors (warnings are allowed)
 
 output=$(bunx biome check "$@" 2>&1)
 exit_code=$?
 
 echo "$output"
 
-# Check if there are any diagnostics (errors, warnings, or infos)
-if echo "$output" | grep -qE "Found [0-9]+ (error|info|warning)"; then
+# Fail only on errors, not warnings
+if echo "$output" | grep -qE "Found [0-9]+ error"; then
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Downgrade biome's `useExhaustiveDependencies` rule from error to warning
- Update lint script to only fail on errors (warnings are allowed to pass)
- Remove 9 `biome-ignore` and `eslint-disable` comments that were suppressing this rule

This allows the codebase to pass lint while still surfacing potential dependency array issues as warnings for developers to review.