### PR TITLE
fix(desktop): optimize terminal rendering to prevent re-render loops

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/TabPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/TabPane.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { memo, useEffect, useRef } from "react";
 import type { MosaicBranch } from "react-mosaic-component";
 import {
 	registerPaneRef,
@@ -41,7 +41,7 @@ interface TabPaneProps {
 	onMoveToNewTab: () => void;
 }
 
-export function TabPane({
+export const TabPane = memo(function TabPane({
 	paneId,
 	path,
 	isActive,
@@ -128,4 +128,4 @@ export function TabPane({
 			</TabContentContextMenu>
 		</BasePaneWindow>
 	);
-}
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
@@ -34,7 +34,6 @@ export function TabView({ tab }: TabViewProps) {
 	const movePaneToTab = useTabsStore((s) => s.movePaneToTab);
 	const movePaneToNewTab = useTabsStore((s) => s.movePaneToNewTab);
 	const allTabs = useTabsStore((s) => s.tabs);
-	const allPanes = useTabsStore((s) => s.panes);
 
 	// Get worktree path for file viewer panes
 	const { data: activeWorkspace } = trpc.workspaces.getActive.useQuery();
@@ -45,23 +44,15 @@ export function TabView({ tab }: TabViewProps) {
 		(t) => t.workspaceId === tab.workspaceId,
 	);
 
-	// Extract pane IDs from layout
-	const layoutPaneIds = useMemo(
-		() => extractPaneIdsFromLayout(tab.layout),
-		[tab.layout],
+	// Get all panes belonging to this tab
+	const allPanes = useTabsStore((s) => s.panes);
+	const tabPanes = useMemo(
+		() =>
+			Object.fromEntries(
+				Object.entries(allPanes).filter(([_, pane]) => pane.tabId === tab.id),
+			),
+		[allPanes, tab.id],
 	);
-
-	// Memoize the filtered panes to avoid creating new objects on every render
-	const tabPanes = useMemo(() => {
-		const result: Record<string, { tabId: string; type: string }> = {};
-		for (const paneId of layoutPaneIds) {
-			const pane = allPanes[paneId];
-			if (pane?.tabId === tab.id) {
-				result[paneId] = { tabId: pane.tabId, type: pane.type };
-			}
-		}
-		return result;
-	}, [layoutPaneIds, allPanes, tab.id]);
 
 	const validPaneIds = new Set(Object.keys(tabPanes));
 	const cleanedLayout = cleanLayout(tab.layout, validPaneIds);


### PR DESCRIPTION
## Summary
- Wrap Terminal and TabPane components in React.memo to prevent cascading re-renders from parent components
- Use granular Zustand selectors in Terminal to subscribe only to specific pane properties (initialCommands, initialCwd, tabId) instead of the full pane object
- Break circular dependency where Terminal updates pane.cwd → store notifies Terminal (which subscribed to pane) → Terminal re-renders
- Use stable callback pattern for tRPC subscription to prevent subscription re-initialization on every render

## Problem
When typing in the terminal, there were dropped frames and noticeable slowness. Investigation revealed:
1. Terminal subscribed to the full `pane` object from Zustand store
2. Terminal updates `pane.cwd` via `updatePaneCwd` when parsing OSC-7 sequences
3. This triggered store notifications, causing Terminal to re-render
4. The re-render created new callback references, potentially reinitializing the tRPC subscription
5. This created a circular re-render loop causing poor frame rates

## Test plan
- [ ] Open the desktop app and navigate to a terminal
- [ ] Type rapidly in the terminal
- [ ] Verify smooth rendering without dropped frames
- [ ] Verify cwd updates still work correctly (directory navigator shows current path)
- [ ] Verify terminal focus/blur behavior works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced rendering performance in tab and terminal components through strategic component memoization to reduce unnecessary re-renders and improve overall UI responsiveness.
  * Optimized terminal state management with granular data selectors and stabilized callback handling for better performance consistency.
  * Refined workspace tab pane visibility logic for more efficient tab content management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->