### PR TITLE
perf(desktop): convert port scanner from sync to async exec

### DIFF
--- a/apps/desktop/src/main/lib/terminal/port-manager.ts
+++ b/apps/desktop/src/main/lib/terminal/port-manager.ts
@@ -107,7 +107,7 @@ class PortManager extends EventEmitter {
 			}
 
 			for (const [paneId, { workspaceId, pids }] of panePortMap) {
-				const portInfos = getListeningPortsForPids(pids);
+				const portInfos = await getListeningPortsForPids(pids);
 				this.updatePortsForPane(paneId, workspaceId, portInfos);
 			}
 


### PR DESCRIPTION
## Summary

- Replace blocking `execSync` calls with async `exec` in `port-scanner.ts` to prevent the main process event loop from being blocked during periodic port scans (every 2.5 seconds)
- Add 5-second timeout to all shell commands to prevent hangs if `lsof`/`netstat` becomes unresponsive
- Improve Windows implementation to fetch process names in parallel using `Promise.all`

## Problem

The port scanner was using synchronous `execSync` for `lsof` (macOS/Linux) and `netstat` (Windows) commands. These blocking calls run every 2.5 seconds and can take 50-200ms+ each, causing periodic UI freezes in the Electron app.

## Solution

Convert all shell executions to async using `promisify(exec)`, allowing the Node.js event loop to continue processing IPC messages and other events while port scanning runs in the background.

## Test plan

- [ ] Verify port detection still works correctly on macOS/Linux
- [ ] Verify port detection still works correctly on Windows (if available)
- [ ] Confirm UI responsiveness improves (no periodic freezes every 2.5 seconds)
- [ ] Test with multiple terminal sessions running dev servers

🤖 Generated with [Claude Code](https://claude.com/claude-code)