### PR TITLE
fix(desktop): prevent deleted workspace from temporarily reappearing

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/workspaces.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/workspaces.ts
@@ -75,8 +75,11 @@ async function initializeWorkspaceWorktree({
 		await manager.acquireProjectLock(projectId);
 
 		// Check cancellation before starting (use durable cancellation check)
+		// Note: We don't emit "failed" progress for cancellations because the workspace
+		// is being deleted. Emitting would trigger a refetch race condition where the
+		// workspace temporarily reappears. finalizeJob() in the finally block will
+		// still unblock waitForInit() callers.
 		if (manager.isCancellationRequested(workspaceId)) {
-			manager.updateProgress(workspaceId, "failed", "Cancelled");
 			return;
 		}
 
@@ -118,7 +121,6 @@ async function initializeWorkspaceWorktree({
 		}
 
 		if (manager.isCancellationRequested(workspaceId)) {
-			manager.updateProgress(workspaceId, "failed", "Cancelled");
 			return;
 		}
 
@@ -212,7 +214,6 @@ async function initializeWorkspaceWorktree({
 		}
 
 		if (manager.isCancellationRequested(workspaceId)) {
-			manager.updateProgress(workspaceId, "failed", "Cancelled");
 			return;
 		}
 
@@ -231,7 +232,6 @@ async function initializeWorkspaceWorktree({
 		}
 
 		if (manager.isCancellationRequested(workspaceId)) {
-			manager.updateProgress(workspaceId, "failed", "Cancelled");
 			return;
 		}
 
@@ -254,7 +254,6 @@ async function initializeWorkspaceWorktree({
 					e,
 				);
 			}
-			manager.updateProgress(workspaceId, "failed", "Cancelled");
 			return;
 		}
 
@@ -275,7 +274,6 @@ async function initializeWorkspaceWorktree({
 					e,
 				);
 			}
-			manager.updateProgress(workspaceId, "failed", "Cancelled");
 			return;
 		}
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/DeleteWorkspaceDialog/DeleteWorkspaceDialog.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/DeleteWorkspaceDialog/DeleteWorkspaceDialog.tsx
@@ -85,7 +85,7 @@ export function DeleteWorkspaceDialog({
 		onOpenChange(false);
 
 		toast.promise(deleteWorkspace.mutateAsync({ id: workspaceId }), {
-			loading: "Deleting...",
+			loading: `Deleting "${workspaceName}"...`,
 			success: (result) => {
 				if (result.terminalWarning) {
 					setTimeout(() => {
@@ -94,7 +94,7 @@ export function DeleteWorkspaceDialog({
 						});
 					}, 100);
 				}
-				return "Workspace deleted";
+				return `Deleted "${workspaceName}"`;
 			},
 			error: (error) =>
 				error instanceof Error ? error.message : "Failed to delete",


### PR DESCRIPTION
## Summary
- Fix race condition where deleted workspace temporarily reappears during deletion
- Remove unnecessary "Cancelled" progress events from init cancellation checks
- Improve delete toast to show workspace name

## Problem
When deleting a workspace during initialization:
1. Optimistic update removes workspace from UI
2. Backend cancels init, which emits `"failed"` progress event
3. Subscription sees `"failed"` and calls `invalidate()` 
4. Refetch returns stale data (workspace still in DB) → workspace reappears
5. Backend finally deletes from DB → workspace disappears

## Solution
Don't emit `"failed"` progress events for cancelled inits. The `finally` block still calls `finalizeJob()` to unblock `waitForInit()`, but we no longer trigger the race condition.

## Test plan
- [ ] Delete a workspace while it's initializing - should not flash/reappear
- [ ] Delete an already-initialized workspace - should work normally
- [ ] Toast should show workspace name during deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)