### PR TITLE
perf(desktop): parallelize git status checks and optimize file scanning

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/changes/status.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/status.ts
@@ -33,7 +33,6 @@ export const createStatusRouter = () => {
 				const [branchComparison, trackingStatus] = await Promise.all([
 					getBranchComparison(git, defaultBranch),
 					getTrackingBranchStatus(git),
-					// Run numstat operations in parallel too
 					applyNumstatToFiles(git, parsed.staged, [
 						"diff",
 						"--cached",


### PR DESCRIPTION
## Summary
- Parallelize independent git operations (branch comparison, tracking status, numstat) using `Promise.all()` instead of sequential `await`s
- Optimize untracked file line counting: limit to 50 files max, 100KB size limit, process in parallel batches of 10
- Add `staleTime` and disable background refetch on the client to prevent UI flicker and request overlap

## Context
The `getStatus` tRPC procedure runs every 2.5 seconds to poll for git changes. Previously it ran 7-9 git commands sequentially plus read all untracked files one at a time, which could cause UI lag especially with many files.

## Test plan
- [ ] Verify Changes panel still shows correct staged/unstaged/untracked files
- [ ] Verify commit counts and branch comparison work correctly
- [ ] Test with a repo that has many untracked files (>50) to confirm limiting works
- [ ] Monitor for UI responsiveness during polling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced performance of status calculations by optimizing Git operations processing.
  * Improved changes view UI stability by reducing unnecessary updates and preventing duplicate requests, resulting in a smoother user experience with less flickering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->