### PR TITLE
fix(desktop): make collapse chevron point outward when collapsed

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectHeader.tsx
@@ -238,7 +238,7 @@ export function ProjectHeader({
 						<HiChevronRight
 							className={cn(
 								"size-3.5 text-muted-foreground transition-transform duration-150",
-								isCollapsed ? "rotate-180" : "rotate-90",
+								!isCollapsed && "rotate-90",
 							)}
 						/>
 					</button>


### PR DESCRIPTION
## Summary
- Change the ProjectHeader chevron to point right (outward) when the project is collapsed
- Previously pointed left (inward) with 180° rotation, now uses default orientation (0°)
- Provides better visual affordance for the expand action

## Test plan
- [ ] Open the desktop app
- [ ] Collapse a project in the sidebar
- [ ] Verify the chevron points outward (right) when collapsed
- [ ] Verify the chevron points down when expanded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted chevron icon rotation behavior in the project sidebar. The icon now displays with simplified rotation states when toggling between collapsed and expanded views.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->