### PR TITLE
fix(desktop): allow spaces in workspace rename input

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -379,7 +379,10 @@ export function WorkspaceListItem({
 						value={rename.renameValue}
 						onChange={(e) => rename.setRenameValue(e.target.value)}
 						onBlur={rename.submitRename}
-						onKeyDown={rename.handleKeyDown}
+						onKeyDown={(e) => {
+							e.stopPropagation();
+							rename.handleKeyDown(e);
+						}}
 						onClick={(e) => e.stopPropagation()}
 						onMouseDown={(e) => e.stopPropagation()}
 						className="h-6 px-1 py-0 text-sm -ml-1"


### PR DESCRIPTION
## Summary
- Fix workspace rename input not accepting space characters
- Skip keyboard navigation handling (Enter/Space to activate) when rename mode is active

## Test plan
- [ ] Double-click a workspace to enter rename mode
- [ ] Type a name with spaces (e.g., "My Workspace")
- [ ] Verify spaces are typed correctly instead of activating the workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented keydown events from bubbling during workspace item renaming, avoiding unintended actions or shortcuts interfering with the rename flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->