### PR TITLE
fix(desktop): hide scrollbar in workspace sidebar list

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -31,7 +31,7 @@ export function WorkspaceSidebar({
 		<div className="flex flex-col h-full bg-background">
 			<WorkspaceSidebarHeader isCollapsed={isCollapsed} />
 
-			<div className="flex-1 overflow-y-auto">
+			<div className="flex-1 overflow-y-auto hide-scrollbar">
 				{groups.map((group, index) => (
 					<ProjectSection
 						key={group.project.id}


### PR DESCRIPTION
## Summary
- Add `hide-scrollbar` class to the workspace list container in WorkspaceSidebar
- Provides a cleaner UI by hiding the scrollbar while maintaining scroll functionality

## Test plan
- [ ] Open desktop app and verify workspace sidebar no longer shows scrollbar
- [ ] Verify scrolling still works with mouse wheel/trackpad
- [ ] Test with many workspaces to ensure scrolling functions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)