### PR TITLE
fix(desktop): prevent StartView flash when deleting active workspace

### DIFF
--- a/apps/desktop/src/renderer/react-query/workspaces/useDeleteWorkspace.ts
+++ b/apps/desktop/src/renderer/react-query/workspaces/useDeleteWorkspace.ts
@@ -66,22 +66,33 @@ export function useDeleteWorkspace(
 					.sort((a, b) => b.lastOpenedAt - a.lastOpenedAt);
 
 				if (remainingWorkspaces && remainingWorkspaces.length > 0) {
-					const nextWorkspace = remainingWorkspaces[0];
-					const projectGroup = previousGrouped?.find((g) =>
-						g.workspaces.some((w) => w.id === nextWorkspace.id),
-					);
-					const workspaceFromGrouped = projectGroup?.workspaces.find(
-						(w) => w.id === nextWorkspace.id,
-					);
+					// Find a workspace with full data available in previousGrouped
+					let selectedWorkspace = null;
+					let projectGroup = null;
+					let workspaceFromGrouped = null;
 
-					if (projectGroup && workspaceFromGrouped) {
+					for (const candidate of remainingWorkspaces) {
+						const group = previousGrouped?.find((g) =>
+							g.workspaces.some((w) => w.id === candidate.id),
+						);
+						if (group) {
+							selectedWorkspace = candidate;
+							projectGroup = group;
+							workspaceFromGrouped = group.workspaces.find(
+								(w) => w.id === candidate.id,
+							);
+							break;
+						}
+					}
+
+					if (selectedWorkspace && projectGroup && workspaceFromGrouped) {
 						const worktreeData =
 							workspaceFromGrouped.type === "worktree"
 								? {
-										branch: nextWorkspace.branch,
+										branch: selectedWorkspace.branch,
 										baseBranch: null,
 										gitStatus: {
-											branch: nextWorkspace.branch,
+											branch: selectedWorkspace.branch,
 											needsRebase: false,
 											lastRefreshed: Date.now(),
 										},
@@ -89,7 +100,7 @@ export function useDeleteWorkspace(
 								: null;
 
 						utils.workspaces.getActive.setData(undefined, {
-							...nextWorkspace,
+							...selectedWorkspace,
 							type: workspaceFromGrouped.type,
 							worktreePath: workspaceFromGrouped.worktreePath,
 							project: {
@@ -100,7 +111,15 @@ export function useDeleteWorkspace(
 							worktree: worktreeData,
 						});
 					} else {
-						utils.workspaces.getActive.setData(undefined, null);
+						// Fallback: set minimal data to prevent StartView flash (refetch will populate full data)
+						const fallback = remainingWorkspaces[0];
+						utils.workspaces.getActive.setData(undefined, {
+							...fallback,
+							type: fallback.type === "branch" ? "branch" : "worktree",
+							worktreePath: "",
+							project: null,
+							worktree: null,
+						});
 					}
 				} else {
 					utils.workspaces.getActive.setData(undefined, null);


### PR DESCRIPTION
## Summary

- Fixed bug where deleting the active workspace would sometimes cause the StartView ("select project" screen) to appear even when other workspaces exist
- Root cause: mismatch between backend workspace selection (all workspaces) and frontend cache (only visible projects)

## Changes

**Backend (`db-helpers.ts`):**
- `selectNextActiveWorkspace()` now only selects from visible projects by joining with the projects table and filtering by `tabOrder != null`

**Frontend (`useDeleteWorkspace.ts`, `useCloseWorkspace.ts`):**
- Iterate through all remaining workspaces to find one with full data in `previousGrouped`, instead of only checking the first one
- Add fallback that sets minimal workspace data instead of `null` when cache is missing, preventing StartView flash

## Test plan

- [ ] Delete the active workspace when multiple workspaces exist in the same project
- [ ] Delete the active workspace when workspaces exist in different projects
- [ ] Verify no StartView flash occurs during workspace deletion
- [ ] Verify the next workspace becomes active correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns next-workspace selection to visible projects and hardens optimistic switching to avoid StartView flashes when closing/deleting the active workspace.
> 
> - Backend: `selectNextActiveWorkspace()` now joins `projects` and filters by `projects.tabOrder != null`, selecting most-recent from visible projects only
> - Frontend (close/delete hooks): iterate remaining workspaces to find one present in `getAllGrouped` and optimistically set it active; add minimal-data fallback instead of `null` to prevent StartView flash; keep caches in sync and invalidate after ops (plus recents on close)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 975f461b56a1fb52477a14cda2c5e0729419a376. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace selection when closing or deleting a workspace—now correctly filters to visible workspaces only.
  * Enhanced data consistency during workspace transitions to reduce UI flashing and provide a smoother experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->