### PR TITLE
fix(desktop): use getAllGrouped as single source of truth for workspace queries

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/query.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/query.ts
@@ -21,15 +21,6 @@ export const createQueryProcedures = () => {
 				return workspace;
 			}),
 
-		getAll: publicProcedure.query(() => {
-			return localDb
-				.select()
-				.from(workspaces)
-				.where(isNull(workspaces.deletingAt))
-				.all()
-				.sort((a, b) => a.tabOrder - b.tabOrder);
-		}),
-
 		getAllGrouped: publicProcedure.query(() => {
 			const activeProjects = localDb
 				.select()

--- a/apps/desktop/src/lib/trpc/routers/workspaces/workspaces.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/workspaces.ts
@@ -13,7 +13,7 @@ import { createStatusProcedures } from "./procedures/status";
  * Procedures are organized into logical groups:
  * - create: create, createBranchWorkspace, openWorktree
  * - delete: delete, close, canDelete
- * - query: get, getAll, getAllGrouped, getActive
+ * - query: get, getAllGrouped, getActive
  * - branch: getBranches, switchBranchWorkspace
  * - git-status: refreshGitStatus, getGitHubStatus, getWorktreeInfo, getWorktreesByProject
  * - status: setActive, reorder, update, setUnread

--- a/apps/desktop/src/renderer/react-query/workspaces/useReorderWorkspaces.ts
+++ b/apps/desktop/src/renderer/react-query/workspaces/useReorderWorkspaces.ts
@@ -1,9 +1,5 @@
 import { trpc } from "renderer/lib/trpc";
 
-/**
- * Mutation hook for reordering workspaces
- * Automatically invalidates workspace queries on success
- */
 export function useReorderWorkspaces(
 	options?: Parameters<typeof trpc.workspaces.reorder.useMutation>[0],
 ) {
@@ -12,7 +8,6 @@ export function useReorderWorkspaces(
 	return trpc.workspaces.reorder.useMutation({
 		...options,
 		onSuccess: async (...args) => {
-			await utils.workspaces.getAll.invalidate();
 			await utils.workspaces.getAllGrouped.invalidate();
 			await options?.onSuccess?.(...args);
 		},

--- a/apps/desktop/src/renderer/react-query/workspaces/useSetActiveWorkspace.ts
+++ b/apps/desktop/src/renderer/react-query/workspaces/useSetActiveWorkspace.ts
@@ -2,9 +2,8 @@ import { toast } from "@superset/ui/sonner";
 import { trpc } from "renderer/lib/trpc";
 
 /**
- * Mutation hook for setting the active workspace
- * Automatically invalidates getActive and getAll queries on success
- * Shows undo toast if workspace was marked as unread (auto-cleared on switch)
+ * Sets the active workspace.
+ * Shows undo toast if workspace was marked as unread (auto-cleared on switch).
  */
 export function useSetActiveWorkspace(
 	options?: Parameters<typeof trpc.workspaces.setActive.useMutation>[0],
@@ -33,10 +32,8 @@ export function useSetActiveWorkspace(
 			options?.onError?.(error, variables, context, meta);
 		},
 		onSuccess: async (data, variables, ...rest) => {
-			// Auto-invalidate active workspace and all workspaces queries
 			await Promise.all([
 				utils.workspaces.getActive.invalidate(),
-				utils.workspaces.getAll.invalidate(),
 				utils.workspaces.getAllGrouped.invalidate(),
 			]);
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/hooks/usePortsData.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/hooks/usePortsData.ts
@@ -14,7 +14,12 @@ export interface MergedWorkspaceGroup {
 
 export function usePortsData() {
 	const { data: activeWorkspace } = trpc.workspaces.getActive.useQuery();
-	const { data: allWorkspaces } = trpc.workspaces.getAll.useQuery();
+	// Use getAllGrouped (always cached) instead of getAll to avoid cache sync issues
+	const { data: groupedWorkspaces } = trpc.workspaces.getAllGrouped.useQuery();
+	const allWorkspaces = useMemo(
+		() => groupedWorkspaces?.flatMap((g) => g.workspaces) ?? [],
+		[groupedWorkspaces],
+	);
 	const ports = usePortsStore((s) => s.ports);
 	const setPorts = usePortsStore((s) => s.setPorts);
 	const addPort = usePortsStore((s) => s.addPort);
@@ -53,7 +58,6 @@ export function usePortsData() {
 	});
 
 	const workspaceNames = useMemo(() => {
-		if (!allWorkspaces) return {};
 		return allWorkspaces.reduce(
 			(acc, ws) => {
 				acc[ws.id] = ws.name;


### PR DESCRIPTION
## Summary

- Fixes StartView flash when deleting/closing the active workspace
- Uses `getAllGrouped` as the single source of truth for workspace data (always cached by sidebar)
- Removes unused `getAll` query from frontend and backend

## Root Cause

The optimistic updates in `useDeleteWorkspace` and `useCloseWorkspace` relied on the `getAll` query cache to find the next workspace. However, `getAll` was rarely queried (only used by PortsList), so its cache was usually empty. When empty, the optimistic update would incorrectly set `activeWorkspace` to null, causing StartView to flash briefly.

## Changes

**Frontend:**
- `useDeleteWorkspace.ts` / `useCloseWorkspace.ts`: Use `getAllGrouped` as source of truth instead of `getAll`
- `usePortsData.ts`: Derive workspace list from `getAllGrouped` instead of querying `getAll`
- `useSetActiveWorkspace.ts` / `useReorderWorkspaces.ts`: Remove dead `getAll.invalidate()` calls

**Backend:**
- `procedures/query.ts`: Remove unused `getAll` procedure

## Test plan

- [ ] Delete active workspace with multiple workspaces open → should switch to next workspace without StartView flash
- [ ] Delete the only/last workspace → should show StartView
- [ ] Close active workspace → should switch to next workspace without flash
- [ ] Ports list should still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Consolidates workspace data fetching to a single query and improves optimistic updates to eliminate UI flicker on workspace changes.
> 
> - Backend: Remove unused `getAll` procedure; keep `get`, `getAllGrouped`, and `getActive`.
> - Frontend: Update `useCloseWorkspace` and `useDeleteWorkspace` to rely on `getAllGrouped` for optimistic next-workspace selection and avoid invalidating `getActive` to prevent flashes.
> - Frontend: Simplify invalidations in `useReorderWorkspaces` and `useSetActiveWorkspace` (drop `getAll`); keep `getAllGrouped`/`getActive` where needed.
> - Frontend: `usePortsData` derives flat workspace list from `getAllGrouped` instead of querying `getAll`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31f0ac009514f69139779d425ac6dc7c551296dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated workspace data handling to use grouped workspace data as the single source of truth.

* **Bug Fixes**
  * Reduced UI flashes and improved optimistic updates when closing, deleting, reordering, or switching workspaces; next-active selection logic simplified.

* **Documentation**
  * Updated inline docs to reflect the new data flow and behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->