### PR TITLE
fix(desktop): update active workspace before slow delete operations

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/delete.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/delete.ts
@@ -158,8 +158,8 @@ export const createDeleteProcedures = () => {
 					return { success: false, error: "Workspace not found" };
 				}
 
-				// Hide from UI immediately to prevent reappearing during slow git operations
 				markWorkspaceAsDeleting(input.id);
+				updateActiveWorkspaceIfRemoved(input.id);
 
 				// Wait for any ongoing init to complete to avoid racing git operations
 				if (workspaceInitManager.isInitializing(input.id)) {
@@ -252,8 +252,6 @@ export const createDeleteProcedures = () => {
 				if (project) {
 					hideProjectIfNoWorkspaces(workspace.projectId);
 				}
-
-				updateActiveWorkspaceIfRemoved(input.id);
 
 				const terminalWarning =
 					terminalResult.failed > 0


### PR DESCRIPTION
## Summary
- Move `updateActiveWorkspaceIfRemoved` to run immediately after `markWorkspaceAsDeleting` instead of at the end of deletion
- Fixes StartView flash when deleting the active workspace

## Root Cause
When deleting a workspace, `markWorkspaceAsDeleting` was called at the start (hiding the workspace from queries), but `updateActiveWorkspaceIfRemoved` was called at the end (after slow git operations). During this window, any refetch of `getActive` would return `null` because `lastActiveWorkspaceId` still pointed to the hidden workspace.

## Test plan
- [ ] Delete the active workspace when other workspaces exist
- [ ] Verify no StartView flash occurs during deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the active workspace is updated promptly during deletion to prevent transient UI inconsistencies while git operations run.
> 
> - Move `updateActiveWorkspaceIfRemoved` to execute right after `markWorkspaceAsDeleting` in `workspaces/procedures/delete.ts`
> - Remove the later call after cleanup to avoid double updates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d578fee8ef89f415b98a071a452b7bfeec072bec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace deletion handling to correctly update UI state when removing a workspace.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->