### PR TITLE
feat(desktop): show diff highlights in scrollbar

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/ChangesContent/components/DiffViewer/DiffViewer.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/ChangesContent/components/DiffViewer/DiffViewer.tsx
@@ -192,7 +192,7 @@ export function DiffViewer({
 				renderSideBySide: viewMode === "side-by-side",
 				readOnly: !editable,
 				originalEditable: false,
-				renderOverviewRuler: false,
+				renderOverviewRuler: true,
 				diffWordWrap: "on",
 				contextmenu: !contextMenuProps, // Disable Monaco's context menu if we have custom props
 			}}


### PR DESCRIPTION
## Summary
- Enable Monaco's overview ruler in the diff viewer to show colored markers in the scrollbar
- Additions (green) and deletions (red) are now visible in the scrollbar for quick navigation

## Test plan
- [ ] Open a file with changes in the diff viewer
- [ ] Verify colored markers appear in the scrollbar indicating diff locations
- [ ] Click markers to navigate to corresponding changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)