### PR TITLE
fix(desktop): scroll terminals to bottom by default

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -26,7 +26,7 @@ import { ScrollToBottomButton } from "./ScrollToBottomButton";
 import { TerminalSearch } from "./TerminalSearch";
 import type { TerminalProps, TerminalStreamEvent } from "./types";
 import {
-	getScrollPosition,
+	getScrollOffsetFromBottom,
 	restoreScrollPosition,
 	shellEscapePaths,
 	smoothScrollToBottom,
@@ -569,7 +569,10 @@ export const Terminal = ({ tabId, workspaceId }: TerminalProps) => {
 			unregisterClearCallbackRef.current(paneId);
 			unregisterScrollToBottomCallbackRef.current(paneId);
 			debouncedSetTabAutoTitleRef.current?.cancel?.();
-			detachRef.current({ paneId, viewportY: getScrollPosition(xterm) });
+			detachRef.current({
+				paneId,
+				viewportY: getScrollOffsetFromBottom(xterm),
+			});
 			setSubscriptionEnabled(false);
 			xterm.dispose();
 			xtermRef.current = null;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/utils.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/utils.ts
@@ -17,24 +17,20 @@ export function smoothScrollToBottom(terminal: Terminal): void {
 	}
 }
 
-/** Get scroll position to save (undefined = at bottom, number = absolute line) */
-export function getScrollPosition(terminal: Terminal): number | undefined {
+/** Get scroll offset from bottom (0 = at bottom, >0 = scrolled up N lines) */
+export function getScrollOffsetFromBottom(terminal: Terminal): number {
 	const { baseY, viewportY } = terminal.buffer.active;
-	// Only save if scrolled up from bottom and not at line 0
-	// (line 0 likely means content just loaded or race condition)
-	if (viewportY === 0 || viewportY >= baseY) {
-		return undefined;
-	}
-	return viewportY;
+	return baseY - viewportY;
 }
 
-/** Restore scroll position (undefined = bottom, number = absolute line) */
+/** Restore scroll position from offset (0 = bottom, >0 = N lines from bottom) */
 export function restoreScrollPosition(
 	terminal: Terminal,
-	savedPosition: number | undefined,
+	offsetFromBottom: number | undefined,
 ): void {
-	if (savedPosition !== undefined) {
-		terminal.scrollToLine(savedPosition);
+	if (offsetFromBottom && offsetFromBottom > 0) {
+		const targetLine = terminal.buffer.active.baseY - offsetFromBottom;
+		terminal.scrollToLine(Math.max(0, targetLine));
 	} else {
 		terminal.scrollToBottom();
 	}


### PR DESCRIPTION
## Summary
- Store scroll position as offset from bottom instead of absolute line number
- Terminals now default to bottom (offset 0) when no position saved or on re-render
- Fixes terminals appearing scrolled to top when switching workspaces or components re-render

## Test plan
- [ ] Open a new terminal - should be at bottom
- [ ] Switch workspaces and back - terminal should stay at bottom
- [ ] Scroll up in terminal, switch tabs, switch back - scroll position should be restored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Terminal Improvements**
  * Improved scroll-position handling when closing and reopening terminal sessions so your view is preserved more reliably (restores relative offset from the bottom or jumps to bottom as appropriate).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->