### PR TITLE
fix(desktop): add explicit mac artifactName for canary builds

### DIFF
--- a/apps/desktop/electron-builder.canary.ts
+++ b/apps/desktop/electron-builder.canary.ts
@@ -19,9 +19,6 @@ const config: Configuration = {
 	appId: "com.superset.desktop.canary",
 	productName,
 
-	// Use GitHub provider for prerelease
-	// Note: We override with setFeedURL in auto-updater.ts using generic provider,
-	// so the actual update URL is determined at runtime based on version suffix
 	publish: {
 		provider: "github",
 		owner: "superset-sh",
@@ -29,17 +26,16 @@ const config: Configuration = {
 		releaseType: "prerelease",
 	},
 
-	// macOS overrides
 	mac: {
 		...baseConfig.mac,
 		icon: join(pkg.resources, "build/icons/icon-canary.icns"),
+		artifactName: `Superset-Canary-\${version}-\${arch}.\${ext}`,
 		extendInfo: {
 			CFBundleName: productName,
 			CFBundleDisplayName: productName,
 		},
 	},
 
-	// Linux overrides
 	linux: {
 		...baseConfig.linux,
 		icon: join(pkg.resources, "build/icons/icon-canary.png"),
@@ -47,11 +43,10 @@ const config: Configuration = {
 		artifactName: `superset-canary-\${version}-\${arch}.\${ext}`,
 	},
 
-	// Windows overrides
 	win: {
 		...baseConfig.win,
 		icon: join(pkg.resources, "build/icons/icon-canary.ico"),
-		artifactName: `${productName}-${pkg.version}-\${arch}.\${ext}`,
+		artifactName: `Superset-Canary-\${version}-\${arch}.\${ext}`,
 	},
 };
 


### PR DESCRIPTION
## Summary

- Fixes 404 error during canary autoupdate
- electron-builder converts `"Superset Canary"` inconsistently:
  - Filenames: `Superset.Canary-...` (dot)
  - `latest-mac.yml`: `Superset-Canary-...` (dash)
- Adds explicit `artifactName` to ensure both match

## Test plan

- [ ] Merge and trigger canary build
- [ ] Verify filename in release matches URL in `latest-mac.yml`
- [ ] Test autoupdate downloads successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized file naming for macOS Canary releases to ensure consistent output filenames.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->