### PR TITLE
chore: add release:canary script

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
 		"postinstall": "sherif; bun run --filter=@superset/desktop install:deps",
 		"clean": "git clean -xdf node_modules",
 		"clean:workspaces": "turbo clean",
-		"release:desktop": "./apps/desktop/create-release.sh"
+		"release:desktop": "./apps/desktop/create-release.sh",
+		"release:canary": "gh workflow run release-desktop-canary.yml"
 	},
 	"type": "module",
 	"workspaces": [


### PR DESCRIPTION
## Summary
- Add `release:canary` script to trigger the canary release GitHub workflow

## Test plan
- Run `bun run release:canary` to trigger the workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added canary release workflow capability for the desktop application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->