### PR TITLE
feat(desktop): output run URL after triggering canary release

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"clean": "git clean -xdf node_modules",
 		"clean:workspaces": "turbo clean",
 		"release:desktop": "./apps/desktop/create-release.sh",
-		"release:canary": "gh workflow run release-desktop-canary.yml"
+		"release:canary": "gh workflow run release-desktop-canary.yml && sleep 2 && gh run list --workflow=release-desktop-canary.yml --limit=1 --json url -q '.[0].url'"
 	},
 	"type": "module",
 	"workspaces": [


### PR DESCRIPTION
## Summary
- Updates `release:canary` script to output the GitHub Actions run URL after triggering the workflow
- Makes it easy to monitor the canary build progress

## Test plan
- [ ] Run `bun run release:canary` and verify the run URL is printed after triggering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Improved canary release workflow by adding verification that displays the release run details after successful trigger.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->