### PR TITLE
feat(desktop): add keyboard shortcuts option to help menu

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/TopBar/SupportMenu.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/TopBar/SupportMenu.tsx
@@ -3,7 +3,6 @@ import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
-	DropdownMenuSeparator,
 	DropdownMenuShortcut,
 	DropdownMenuSub,
 	DropdownMenuSubContent,
@@ -57,6 +56,10 @@ export function SupportMenu() {
 				</button>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent align="end" className="w-56">
+				<DropdownMenuItem onClick={handleReportIssue}>
+					<HiOutlineBugAnt className="h-4 w-4" />
+					Report Issue
+				</DropdownMenuItem>
 				<DropdownMenuItem onClick={handleKeyboardShortcuts}>
 					<LuKeyboard className="h-4 w-4" />
 					Keyboard Shortcuts
@@ -64,7 +67,6 @@ export function SupportMenu() {
 						<DropdownMenuShortcut>{shortcutsHotkey}</DropdownMenuShortcut>
 					)}
 				</DropdownMenuItem>
-				<DropdownMenuSeparator />
 				<DropdownMenuSub>
 					<DropdownMenuSubTrigger>
 						<LuLifeBuoy className="h-4 w-4" />
@@ -86,11 +88,6 @@ export function SupportMenu() {
 						</DropdownMenuItem>
 					</DropdownMenuSubContent>
 				</DropdownMenuSub>
-				<DropdownMenuSeparator />
-				<DropdownMenuItem onClick={handleReportIssue}>
-					<HiOutlineBugAnt className="h-4 w-4" />
-					Report Issue
-				</DropdownMenuItem>
 			</DropdownMenuContent>
 		</DropdownMenu>
 	);


### PR DESCRIPTION
## Summary
- Add "Keyboard Shortcuts" menu item to the SupportMenu (question mark button in the top bar)
- Display the hotkey (⌘/ on Mac, Ctrl+Shift+/ on Windows/Linux) using `DropdownMenuShortcut`
- Navigate to `/settings/keyboard` when clicked

## Test plan
- [ ] Click the question mark button in the top bar
- [ ] Verify "Keyboard Shortcuts" appears at the top with the hotkey displayed
- [ ] Click "Keyboard Shortcuts" and verify it navigates to the keyboard settings page
- [ ] Test on both Mac and Windows/Linux to verify correct hotkey display