### PR TITLE
fix(desktop): restore OpenInMenuButton to TopBar

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/TopBar/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/TopBar/index.tsx
@@ -1,9 +1,16 @@
+import { useParams } from "@tanstack/react-router";
 import { trpc } from "renderer/lib/trpc";
+import { OpenInMenuButton } from "./OpenInMenuButton";
 import { SupportMenu } from "./SupportMenu";
 import { WindowControls } from "./WindowControls";
 
 export function TopBar() {
 	const { data: platform } = trpc.window.getPlatform.useQuery();
+	const { workspaceId } = useParams({ strict: false });
+	const { data: workspace } = trpc.workspaces.get.useQuery(
+		{ id: workspaceId ?? "" },
+		{ enabled: !!workspaceId },
+	);
 	// Default to Mac layout while loading to avoid overlap with traffic lights
 	const isMac = platform === undefined || platform === "darwin";
 
@@ -19,6 +26,12 @@ export function TopBar() {
 			<div className="flex-1" />
 
 			<div className="flex items-center gap-3 h-full pr-4 shrink-0">
+				{workspace?.worktreePath && (
+					<OpenInMenuButton
+						worktreePath={workspace.worktreePath}
+						branch={workspace.worktree?.branch}
+					/>
+				)}
 				<SupportMenu />
 				{!isMac && <WindowControls />}
 			</div>


### PR DESCRIPTION
## Summary
- Restores the "Open In" button that was accidentally removed in #740 (Router Part 3)
- Updates the component to use the new workspace query pattern with `useParams` instead of the removed `getActive` query

## Test plan
- [ ] Verify the "Open In" button appears in the TopBar when viewing a workspace
- [ ] Verify clicking the button opens the project in the last used editor
- [ ] Verify the dropdown menu shows all editor options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Open In" menu button to the TopBar that appears when workspace configuration is available, enabling quick access to workspace-specific actions with branch information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->