### PR TITLE
fix: update email domains from supersetlabs.com to superset.sh

### DIFF
--- a/apps/marketing/src/app/privacy/page.tsx
+++ b/apps/marketing/src/app/privacy/page.tsx
@@ -281,10 +281,10 @@ export default function PrivacyPolicyPage() {
 						<p className="text-foreground">
 							Email:{" "}
 							<a
-								href="mailto:privacy@supersetlabs.com"
+								href="mailto:privacy@superset.sh"
 								className="text-primary hover:text-primary/80 underline underline-offset-2"
 							>
-								privacy@supersetlabs.com
+								privacy@superset.sh
 							</a>
 						</p>
 					</section>

--- a/apps/marketing/src/app/terms/page.tsx
+++ b/apps/marketing/src/app/terms/page.tsx
@@ -344,10 +344,10 @@ export default function TermsOfServicePage() {
 						<p className="text-foreground">
 							Email:{" "}
 							<a
-								href="mailto:legal@supersetlabs.com"
+								href="mailto:legal@superset.sh"
 								className="text-primary hover:text-primary/80 underline underline-offset-2"
 							>
-								legal@supersetlabs.com
+								legal@superset.sh
 							</a>
 						</p>
 					</section>


### PR DESCRIPTION
## Summary
Fixed incorrect email domain references in Terms of Service and Privacy Policy pages.

## Changes
- **Terms page**: `legal@supersetlabs.com` → `legal@superset.sh`
- **Privacy page**: `privacy@supersetlabs.com` → `privacy@superset.sh`

## Why
The company domain is `superset.sh` (as defined in `packages/shared/src/constants.ts`), not `supersetlabs.com`. These email addresses now use the correct domain.

## Testing
- Verified no other instances of `supersetlabs` exist in the codebase
- Changes are text-only in marketing pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated contact email addresses in the Privacy Policy and Terms of Service pages to reflect new company email information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->