### PR TITLE
feat(marketing): Add redirect from /docs to docs.superset.sh

### DIFF
--- a/apps/marketing/next.config.ts
+++ b/apps/marketing/next.config.ts
@@ -30,6 +30,16 @@ const config: NextConfig = {
 		];
 	},
 
+	async redirects() {
+		return [
+			{
+				source: "/docs/:path*",
+				destination: "https://docs.superset.sh/:path*",
+				permanent: true,
+			},
+		];
+	},
+
 	skipTrailingSlashRedirect: true,
 };
 


### PR DESCRIPTION
## Summary
- Add permanent redirect from `superset.sh/docs/*` to `docs.superset.sh/*`
- Uses Next.js `redirects()` config for clean 301 redirects

## Why
Users may naturally try to access docs via the main marketing site at `superset.sh/docs`. This redirect ensures they reach the documentation site seamlessly.

## Implementation
- Added `redirects()` function in `apps/marketing/next.config.ts`
- Uses `:path*` wildcard to preserve subpaths (e.g., `/docs/getting-started` → `docs.superset.sh/getting-started`)
- `permanent: true` for SEO-friendly 301 redirects

## Test plan
- [ ] Verify redirect works in production
- [ ] Test subpath preservation (e.g., `/docs/installation` redirects properly)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation routing to redirect documentation paths to the external documentation site.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->