### PR TITLE
fix(desktop): move new tab tooltip to top

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupStrip.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupStrip.tsx
@@ -173,7 +173,7 @@ export function GroupStrip() {
 								<HiMiniPlus className="size-4" />
 							</Button>
 						</TooltipTrigger>
-						<TooltipContent side="bottom" sideOffset={4}>
+						<TooltipContent side="top" sideOffset={4}>
 							<HotkeyTooltipContent label="New Tab" hotkeyId="NEW_GROUP" />
 						</TooltipContent>
 					</Tooltip>


### PR DESCRIPTION
## Summary
- Move the "New Tab" tooltip from bottom to top so it doesnt interfere with the dropdown

## Test plan
- [ ] Hover over the new tab button (+) in the tab strip
- [ ] Verify the tooltip appears above the button instead of below

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts tooltip placement for the “New Tab” (+) button in `GroupStrip.tsx`.
> 
> - Changes `TooltipContent` position from `side="bottom"` to `side="top"` for improved visibility in the tab strip
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45dc7de6e5431fb96db2f3ba1b90bfc9e51eec41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted tooltip positioning for the New Tab action to display above the button, improving visibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->