### PR TITLE
fix: load env vars in instrumentation before Sentry config

### DIFF
--- a/apps/admin/src/instrumentation.ts
+++ b/apps/admin/src/instrumentation.ts
@@ -2,6 +2,12 @@ import * as Sentry from "@sentry/nextjs";
 
 export async function register() {
 	if (process.env.NEXT_RUNTIME === "nodejs") {
+		// Load .env from monorepo root before importing modules that validate env vars
+		if (process.env.NODE_ENV !== "production") {
+			const { join } = await import("node:path");
+			const { config: dotenvConfig } = await import("dotenv");
+			dotenvConfig({ path: join(process.cwd(), "../../.env"), override: true });
+		}
 		await import("../sentry.server.config");
 	}
 

--- a/apps/api/src/instrumentation.ts
+++ b/apps/api/src/instrumentation.ts
@@ -2,6 +2,12 @@ import * as Sentry from "@sentry/nextjs";
 
 export async function register() {
 	if (process.env.NEXT_RUNTIME === "nodejs") {
+		// Load .env from monorepo root before importing modules that validate env vars
+		if (process.env.NODE_ENV !== "production") {
+			const { join } = await import("node:path");
+			const { config: dotenvConfig } = await import("dotenv");
+			dotenvConfig({ path: join(process.cwd(), "../../.env"), override: true });
+		}
 		await import("../sentry.server.config");
 	}
 

--- a/apps/docs/src/instrumentation.ts
+++ b/apps/docs/src/instrumentation.ts
@@ -2,6 +2,12 @@ import * as Sentry from "@sentry/nextjs";
 
 export async function register() {
 	if (process.env.NEXT_RUNTIME === "nodejs") {
+		// Load .env from monorepo root before importing modules that validate env vars
+		if (process.env.NODE_ENV !== "production") {
+			const { join } = await import("node:path");
+			const { config: dotenvConfig } = await import("dotenv");
+			dotenvConfig({ path: join(process.cwd(), "../../.env"), override: true });
+		}
 		await import("../sentry.server.config");
 	}
 

--- a/apps/marketing/src/instrumentation.ts
+++ b/apps/marketing/src/instrumentation.ts
@@ -2,6 +2,12 @@ import * as Sentry from "@sentry/nextjs";
 
 export async function register() {
 	if (process.env.NEXT_RUNTIME === "nodejs") {
+		// Load .env from monorepo root before importing modules that validate env vars
+		if (process.env.NODE_ENV !== "production") {
+			const { join } = await import("node:path");
+			const { config: dotenvConfig } = await import("dotenv");
+			dotenvConfig({ path: join(process.cwd(), "../../.env"), override: true });
+		}
 		await import("../sentry.server.config");
 	}
 

--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -2,6 +2,12 @@ import * as Sentry from "@sentry/nextjs";
 
 export async function register() {
 	if (process.env.NEXT_RUNTIME === "nodejs") {
+		// Load .env from monorepo root before importing modules that validate env vars
+		if (process.env.NODE_ENV !== "production") {
+			const { join } = await import("node:path");
+			const { config: dotenvConfig } = await import("dotenv");
+			dotenvConfig({ path: join(process.cwd(), "../../.env"), override: true });
+		}
 		await import("../sentry.server.config");
 	}
 


### PR DESCRIPTION
## Summary

- Fixes env validation errors during local development when running `bun dev`
- The instrumentation hook runs before `next.config.ts` can load dotenv, causing Sentry configs that import from `@/env` to fail validation
- Loads dotenv inside the `register()` function before importing Sentry configs

## Changes

- Updated all 5 Next.js app instrumentation files (web, api, admin, docs, marketing)
- Uses dynamic imports for `node:path` and `dotenv` to avoid Edge runtime issues
- Only loads env in Node.js runtime (not Edge) and only in development (not production)

## Test plan

- [x] Run `bun dev` and verify no env validation errors
- [ ] Verify apps start correctly in development mode
- [ ] Verify Sentry still initializes properly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures environment variables are available before Sentry initializes across all Next.js apps.
> 
> - In `apps/*/src/instrumentation.ts`, load `.env` from monorepo root inside `register()` when `NEXT_RUNTIME === "nodejs"` and not in production
> - Use dynamic imports for `node:path` and `dotenv`; call `dotenvConfig({ path: join(process.cwd(), "../../.env"), override: true })` before importing Sentry server config
> - Leave Edge runtime path unchanged, still importing `sentry.edge.config`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3b14d477243d71e3087710d48b6de25e9bd6080. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Enhanced environment configuration initialization during local development across multiple applications to ensure proper setup sequence and consistency across the platform.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->