### PR TITLE
fix(desktop): use consistent env for persistent terminal sessions

### DIFF
--- a/apps/desktop/src/main/terminal-host/session.ts
+++ b/apps/desktop/src/main/terminal-host/session.ts
@@ -169,16 +169,13 @@ export class Session {
 
 		const { cwd, cols, rows, env = {} } = options;
 
-		// Build environment - filter out undefined values and ELECTRON_RUN_AS_NODE
-		const processEnv: Record<string, string> = {};
-		for (const [key, value] of Object.entries(process.env)) {
-			if (key === "ELECTRON_RUN_AS_NODE") continue;
-			if (value !== undefined) {
-				processEnv[key] = value;
-			}
-		}
-		Object.assign(processEnv, env);
-		processEnv.TERM = "xterm-256color";
+		// Use the environment passed from the main process (already filtered by buildTerminalEnv).
+		// This matches the non-persistent mode behavior - only use the filtered env,
+		// not the daemon's process.env which may have stale or different values.
+		const processEnv: Record<string, string> = {
+			...env,
+			TERM: "xterm-256color",
+		};
 
 		// Get shell args
 		const shellArgs = this.getShellArgs(this.shell);


### PR DESCRIPTION
## Summary
- Persistent terminal mode was merging daemon's `process.env` with the filtered env from `buildTerminalEnv()`
- This caused inconsistent behavior vs non-persistent mode which uses only the filtered env
- The daemon's `process.env` could be stale or contain unexpected values, leading to unpredictable terminal environments
- Now both modes use only the filtered env from `buildTerminalEnv()`, ensuring consistent behavior

## Test plan
- [ ] Enable terminal persistence in settings
- [ ] Kill existing daemon: `pkill -f "terminal-host.js"`
- [ ] Open a new terminal in Superset
- [ ] Verify terminal environment matches non-persistent mode behavior
- [ ] Run `bun dev` inside a Superset terminal to verify env vars work correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures persistent terminal sessions use the same environment as non-persistent mode.
> 
> - In `session.ts` `spawn()`, build `processEnv` solely from the provided filtered `env` and set `TERM` to `xterm-256color`
> - Stop merging in the daemon's `process.env`, preventing stale or unexpected variables
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d1c2754981a703b66b835458e6e9849b4b41024. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized terminal session environment variable handling in the desktop application, simplifying internal environment construction while maintaining existing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->