### PR TITLE
fix(desktop): await PTY ready in daemon to fix port detection

### DIFF
--- a/apps/desktop/src/main/terminal-host/terminal-host.ts
+++ b/apps/desktop/src/main/terminal-host/terminal-host.ts
@@ -130,7 +130,10 @@ export class TerminalHost {
 
 				// Wait for PTY ready to ensure PID is available for port scanning
 				try {
-					await promiseWithTimeout(session.waitForReady(), SPAWN_READY_TIMEOUT_MS);
+					await promiseWithTimeout(
+						session.waitForReady(),
+						SPAWN_READY_TIMEOUT_MS,
+					);
 				} catch {
 					console.warn(
 						`[TerminalHost] Timeout waiting for PTY ready for session ${sessionId}`,


### PR DESCRIPTION
## Summary
- Fix port detection not working for terminals when terminal persistence (daemon mode) is enabled
- The root cause was that `createOrAttach` returned before the PTY finished spawning, so `session.pid` was `null`
- The null PID was registered with the port manager, and sessions with null PIDs are skipped during port scanning

## Changes
- Await `session.waitForReady()` before returning from `createOrAttach` to ensure PID is available
- Simplify initial commands section since PTY is now guaranteed to be ready after the await

## Test plan
- [ ] Enable terminal persistence in settings
- [ ] Open a terminal and run a dev server (e.g., `npm run dev` or `python -m http.server 8000`)
- [ ] Verify that the port appears in the ports panel
- [ ] Test that port detection still works when terminal persistence is disabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal startup reliability by awaiting PTY readiness with a timeout and continuing safely when it times out.
  * Added timeout warnings to aid troubleshooting for slow terminal startups.
  * Ensured spawn permits/resources are always released to prevent leaks during launch.
  * Adjusted initial session command execution: commands run only if the session is alive and no extra readiness wait is performed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->