### PR TITLE
fix(desktop): prevent env var leak in persistent terminal subprocess

### DIFF
--- a/apps/desktop/src/main/terminal-host/session.ts
+++ b/apps/desktop/src/main/terminal-host/session.ts
@@ -180,14 +180,11 @@ export class Session {
 		const shellArgs = this.getShellArgs(this.shell);
 		const subprocessPath = path.join(__dirname, "pty-subprocess.js");
 
-		// Use electron as node to run the subprocess
+		// Spawn subprocess with filtered env to prevent leaking NODE_ENV etc.
 		const electronPath = process.execPath;
 		this.subprocess = spawn(electronPath, [subprocessPath], {
-			stdio: ["pipe", "pipe", "inherit"], // pipe stdin/stdout, inherit stderr
-			env: {
-				...process.env,
-				ELECTRON_RUN_AS_NODE: "1",
-			},
+			stdio: ["pipe", "pipe", "inherit"],
+			env: { ...processEnv, ELECTRON_RUN_AS_NODE: "1" },
 		});
 
 		// Read framed messages from subprocess stdout


### PR DESCRIPTION
## Summary

Fixes environment variable leak in persistent terminal sessions that was causing `bun dev` to fail with `NODE_ENV=production`.

## Change

The subprocess (pty-subprocess.js) was spawned with raw `process.env`, which includes `NODE_ENV` and other vars that should be filtered. Now uses the same filtered `processEnv` for both the subprocess and PTY shell.

```diff
-env: { ...process.env, ELECTRON_RUN_AS_NODE: "1" }
+env: { ...processEnv, ELECTRON_RUN_AS_NODE: "1" }
```

## Test Plan

- [ ] Rebuild desktop app
- [ ] Kill existing daemon or restart app  
- [ ] Open persistent terminal
- [ ] Verify `echo $NODE_ENV` returns empty
- [ ] Run `bun dev` - should work without env validation errors