### PR TITLE
fix(desktop): synchronize emulator resize with PTY to fix autocomplete

### DIFF
--- a/apps/desktop/src/main/terminal-host/pty-subprocess-ipc.ts
+++ b/apps/desktop/src/main/terminal-host/pty-subprocess-ipc.ts
@@ -13,6 +13,7 @@ export enum PtySubprocessIpcType {
 	Data = 103,
 	Exit = 104,
 	Error = 105,
+	Resized = 106, // Acknowledgment after PTY resize completes
 }
 
 export interface PtySubprocessFrame {

--- a/apps/desktop/src/main/terminal-host/pty-subprocess.ts
+++ b/apps/desktop/src/main/terminal-host/pty-subprocess.ts
@@ -353,6 +353,13 @@ function handleResize(payload: Buffer): void {
 		const cols = payload.readUInt32LE(0);
 		const rows = payload.readUInt32LE(4);
 		ptyProcess.resize(cols, rows);
+
+		// Send acknowledgment with the applied dimensions
+		// This allows the daemon to synchronize emulator resize with PTY resize
+		const ackPayload = Buffer.allocUnsafe(8);
+		ackPayload.writeUInt32LE(cols, 0);
+		ackPayload.writeUInt32LE(rows, 4);
+		send(PtySubprocessIpcType.Resized, ackPayload);
 	} catch {
 		// Ignore resize errors
 	}


### PR DESCRIPTION
## Summary
- Fixes autocomplete cursor positioning bug in persisted (daemon) terminals where new line input would overwrite the wrong line
- Adds resize acknowledgment mechanism between PTY subprocess and daemon to synchronize dimensions
- Defers emulator resize until PTY confirms resize is complete, preventing race condition

## Problem
In daemon mode, when a terminal is resized:
1. Emulator was resized **immediately** (synchronous)
2. PTY resize was sent via IPC to subprocess (asynchronous)

This created a window where PTY data formatted for old dimensions was processed by an emulator with new dimensions, causing cursor position mismatches during autocomplete/line editing.

## Solution
Added `Resized` IPC acknowledgment:
1. Daemon sends resize to PTY subprocess
2. PTY subprocess resizes, then sends `Resized` ack back
3. Daemon receives ack and resizes emulator

This ensures dimensions stay synchronized between PTY and emulator.

## Test plan
- [ ] Test autocomplete in persisted terminal with multi-line commands
- [ ] Test terminal resize during active autocomplete
- [ ] Verify non-daemon terminals still work correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved terminal resize handling by introducing acknowledgment-based synchronization between the emulator and terminal layer. Resize operations now confirm dimension updates are complete before applying changes, preventing cursor-position misalignment issues that occurred during interactive terminal operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->