### PR TITLE
refactor(desktop): remove warm terminal tab logic and simplify env setup

### DIFF
--- a/apps/desktop/src/main/lib/terminal/env.test.ts
+++ b/apps/desktop/src/main/lib/terminal/env.test.ts
@@ -541,6 +541,7 @@ describe("env", () => {
 		// Store original env vars to restore after tests
 		const originalEnvVars: Record<string, string | undefined> = {};
 		const varsToTrack = [
+			"TERM",
 			"NODE_ENV",
 			"NODE_OPTIONS",
 			"NODE_PATH",
@@ -615,6 +616,18 @@ describe("env", () => {
 		});
 
 		describe("terminal metadata", () => {
+			it("should default TERM to xterm-256color when missing", () => {
+				delete process.env.TERM;
+				const result = buildTerminalEnv(baseParams);
+				expect(result.TERM).toBe("xterm-256color");
+			});
+
+			it("should preserve TERM when provided", () => {
+				process.env.TERM = "screen-256color";
+				const result = buildTerminalEnv(baseParams);
+				expect(result.TERM).toBe("screen-256color");
+			});
+
 			it("should set TERM_PROGRAM to Superset", () => {
 				const result = buildTerminalEnv(baseParams);
 				expect(result.TERM_PROGRAM).toBe("Superset");

--- a/apps/desktop/src/main/lib/terminal/env.ts
+++ b/apps/desktop/src/main/lib/terminal/env.ts
@@ -351,6 +351,7 @@ export function buildTerminalEnv(params: {
 	const terminalEnv: Record<string, string> = {
 		...baseEnv,
 		...shellEnv,
+		TERM: baseEnv.TERM || "xterm-256color",
 		TERM_PROGRAM: "Superset",
 		TERM_PROGRAM_VERSION: process.env.npm_package_version || "1.0.0",
 		COLORTERM: "truecolor",


### PR DESCRIPTION
## Summary
- Refactor terminal environment setup to use `buildTerminalEnv` at the `TerminalHost` level instead of inside `Session`, ensuring consistent env filtering for both subprocess and PTY shell
- Remove `isTabVisible` prop threading through `TabsContent` → `TabView` → `TabPane` → `Terminal`, simplifying the component hierarchy
- Remove persistence-mode complexity that kept terminal tabs mounted with visibility toggling (the warm terminal tab logic)

## Test plan
- [ ] Verify terminal sessions start correctly with proper environment variables
- [ ] Confirm TERM defaults to `xterm-256color` when not set
- [ ] Test tab switching works without the isTabVisible prop
- [ ] Verify DiffViewer layout renders correctly after monaco mount
- [ ] Run existing terminal lifecycle tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced terminal environment variable handling to ensure consistent behavior across session management.
  * Terminal now automatically defaults to "xterm-256color" when the TERM variable is not specified.

* **Tests**
  * Added test coverage for terminal environment variable handling and validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->