### PR TITLE
fix(local-db): correct migration 0011 timestamp ordering

### DIFF
--- a/packages/local-db/drizzle/meta/_journal.json
+++ b/packages/local-db/drizzle/meta/_journal.json
@@ -82,7 +82,7 @@
     {
       "idx": 11,
       "version": "6",
-      "when": 1767750000000,
+      "when": 1768100000000,
       "tag": "0011_add_terminal_persistence",
       "breakpoints": true
     }


### PR DESCRIPTION
## Summary
- Fix migration 0011 timestamp ordering in local-db journal
- Migration 0011 had timestamp `1767750000000` which was BEFORE migration 0010's `1768004449114`
- This caused Drizzle to skip migration 0011 during auto-migration on app startup

## Test plan
- [x] Rolled back migration 0011 from dev database
- [x] Started app with `bun dev`
- [x] Verified migration 0011 was automatically applied
- [x] Verified `terminal_persistence` column exists in settings table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal metadata timestamp updated.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->