### PR TITLE
fix(desktop): include friendly-words module in packaged app

### DIFF
--- a/apps/desktop/electron-builder.ts
+++ b/apps/desktop/electron-builder.ts
@@ -92,6 +92,12 @@ const config: Configuration = {
 			to: "node_modules/node-pty",
 			filter: ["**/*"],
 		},
+		// friendly-words is a CommonJS module that Vite doesn't bundle
+		{
+			from: "node_modules/friendly-words",
+			to: "node_modules/friendly-words",
+			filter: ["**/*"],
+		},
 		"!**/.DS_Store",
 	],
 


### PR DESCRIPTION
## Summary
- Fix runtime error `Cannot find module 'friendly-words'` in packaged desktop app
- The module is imported via CommonJS require syntax in `git.ts` but Vite wasn't bundling it
- Added `friendly-words` to electron-builder files config so it gets included in app.asar

## Test plan
- [x] Build desktop app with `bun run build` 
- [x] Verified `friendly-words` is included in app.asar
- [ ] Test packaged app launches without module error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to ensure proper inclusion and availability of the friendly-words dependency in the packaged application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->