### PR TITLE
feat(desktop): add daemon auto-restart and health check

### DIFF
--- a/apps/desktop/src/main/lib/terminal-host/types.ts
+++ b/apps/desktop/src/main/lib/terminal-host/types.ts
@@ -260,6 +260,23 @@ export interface ShutdownRequest {
 	killSessions?: boolean;
 }
 
+/**
+ * Ping request for health checks
+ */
+export interface PingRequest {
+	/** Optional timestamp from client for latency measurement */
+	timestamp?: number;
+}
+
+export interface PingResponse {
+	/** Echo back client timestamp if provided */
+	timestamp?: number;
+	/** Daemon uptime in milliseconds */
+	uptime: number;
+	/** Number of active sessions */
+	activeSessions: number;
+}
+
 // =============================================================================
 // IPC Message Framing
 // =============================================================================
@@ -362,4 +379,5 @@ export type RequestTypeMap = {
 	listSessions: { request: undefined; response: ListSessionsResponse };
 	clearScrollback: { request: ClearScrollbackRequest; response: EmptyResponse };
 	shutdown: { request: ShutdownRequest; response: EmptyResponse };
+	ping: { request: PingRequest; response: PingResponse };
 };


### PR DESCRIPTION
## Summary

- Add automatic daemon restart with exponential backoff when the terminal host daemon crashes or becomes unresponsive
- Add periodic health check (ping every 30s) to proactively detect stale daemons
- Add `ping` IPC command that returns daemon uptime and active session count
- Handle protocol version skew gracefully (older daemons without ping support)

## Changes

**Client (`client.ts`):**
- Auto-restart on disconnect with exponential backoff (500ms → 30s, max 10 attempts)
- Periodic health check via ping, triggers restart on timeout
- New `reconnected` event emitted on successful auto-restart
- `setAutoRestart()` and `setHealthCheck()` methods for runtime control

**Daemon (`index.ts`):**
- Add `ping` handler with role check (control only)
- Defensive socket write handling (`socket.writable` checks)
- Extract `removeStreamSocket()` helper to reduce duplication

**Types (`types.ts`):**
- Add `PingRequest` / `PingResponse` types

## Test plan

- [ ] Kill daemon manually (`kill -9 <pid>`) and verify auto-restart
- [ ] Verify health check detects frozen daemon
- [ ] Verify older daemon (without ping) disables health checks gracefully
- [ ] Verify `reconnected` event fires on successful restart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal daemon connections now auto-restart on disconnection using exponential backoff strategy
  * Health check mechanism monitors daemon responsiveness with automatic fallback for older systems
  * New reconnected event notifies when auto-restart succeeds

* **Improvements**
  * Enhanced server socket lifecycle and error handling robustness
  * Improved logging for unhandled exceptions and rejections

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->