### PR TITLE
fix(desktop): make scroll to bottom instant by default

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/ScrollToBottomButton/ScrollToBottomButton.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/ScrollToBottomButton/ScrollToBottomButton.tsx
@@ -4,7 +4,7 @@ import type { Terminal } from "@xterm/xterm";
 import { useCallback, useEffect, useState } from "react";
 import { HiArrowDown } from "react-icons/hi2";
 import { useHotkeyText } from "renderer/stores/hotkeys";
-import { smoothScrollToBottom } from "../utils";
+import { scrollToBottom } from "../utils";
 
 interface ScrollToBottomButtonProps {
 	terminal: Terminal | null;
@@ -42,7 +42,7 @@ export function ScrollToBottomButton({ terminal }: ScrollToBottomButtonProps) {
 
 	const handleClick = () => {
 		if (terminal) {
-			smoothScrollToBottom(terminal);
+			scrollToBottom(terminal);
 		}
 	};
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -38,8 +38,8 @@ import { TerminalSearch } from "./TerminalSearch";
 import type { TerminalProps, TerminalStreamEvent } from "./types";
 import {
 	getScrollOffsetFromBottom,
+	scrollToBottom,
 	shellEscapePaths,
-	smoothScrollToBottom,
 } from "./utils";
 
 const FIRST_RENDER_RESTORE_FALLBACK_MS = 250;
@@ -934,7 +934,7 @@ export const Terminal = ({ tabId, workspaceId }: TerminalProps) => {
 		"SCROLL_TO_BOTTOM",
 		() => {
 			if (xtermRef.current) {
-				smoothScrollToBottom(xtermRef.current);
+				scrollToBottom(xtermRef.current);
 			}
 		},
 		{ enabled: isFocused, preventDefault: true },
@@ -1266,7 +1266,7 @@ export const Terminal = ({ tabId, workspaceId }: TerminalProps) => {
 		};
 
 		const handleScrollToBottom = () => {
-			smoothScrollToBottom(xterm);
+			scrollToBottom(xterm);
 		};
 
 		const handleWrite = (data: string) => {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/utils.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/utils.ts
@@ -5,12 +5,15 @@ export function shellEscapePaths(paths: string[]): string {
 	return quote(paths);
 }
 
-export function smoothScrollToBottom(terminal: Terminal): void {
+export function scrollToBottom(
+	terminal: Terminal,
+	behavior: ScrollBehavior = "instant",
+): void {
 	const viewport = terminal.element?.querySelector(".xterm-viewport");
 	if (viewport) {
 		viewport.scrollTo({
 			top: viewport.scrollHeight,
-			behavior: "smooth",
+			behavior,
 		});
 	} else {
 		terminal.scrollToBottom();


### PR DESCRIPTION
## Summary
- Change terminal scroll to bottom behavior from smooth to instant for immediate navigation
- Make the scroll behavior configurable via a parameter that defaults to "instant"
- Rename `smoothScrollToBottom` to `scrollToBottom` to reflect the new default behavior

## Test plan
- [ ] Open a terminal with content scrolled up
- [ ] Click the scroll to bottom button and verify it jumps instantly (no animation)
- [ ] Use the keyboard shortcut for scroll to bottom and verify instant behavior