### PR TITLE
feat(desktop): add Homebrew distribution workflow

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -1,0 +1,70 @@
+name: Update Homebrew Cask
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-cask:
+    name: Update Homebrew Cask
+    runs-on: macos-latest
+    # Only run for desktop releases
+    if: startsWith(github.event.release.tag_name, 'desktop-v')
+
+    steps:
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#desktop-v}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION"
+
+      - name: Download DMG and calculate SHA256
+        id: sha256
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          DMG_URL="https://github.com/superset-sh/superset/releases/download/desktop-v${VERSION}/Superset-${VERSION}-arm64.dmg"
+
+          echo "Downloading from: $DMG_URL"
+          curl -L -o superset.dmg "$DMG_URL"
+
+          SHA256=$(shasum -a 256 superset.dmg | awk '{print $1}')
+          echo "sha256=$SHA256" >> $GITHUB_OUTPUT
+          echo "Calculated SHA256: $SHA256"
+
+      - name: Checkout homebrew tap
+        uses: actions/checkout@v4
+        with:
+          repository: superset-sh/homebrew-superset
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Update Cask formula
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          SHA256="${{ steps.sha256.outputs.sha256 }}"
+          CASK_FILE="homebrew-tap/Casks/superset.rb"
+
+          echo "Updating cask to version $VERSION with SHA256 $SHA256"
+
+          # Update version
+          sed -i '' "s/version \".*\"/version \"${VERSION}\"/" "$CASK_FILE"
+
+          # Update SHA256
+          sed -i '' "s/sha256 \".*\"/sha256 \"${SHA256}\"/" "$CASK_FILE"
+
+          echo "Updated cask file:"
+          cat "$CASK_FILE"
+
+      - name: Commit and push
+        run: |
+          cd homebrew-tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          VERSION="${{ steps.version.outputs.version }}"
+
+          git add Casks/superset.rb
+          git diff --staged --quiet || git commit -m "Update superset to ${VERSION}"
+          git push

--- a/apps/desktop/docs/HOMEBREW_DISTRIBUTION.md
+++ b/apps/desktop/docs/HOMEBREW_DISTRIBUTION.md
@@ -1,0 +1,123 @@
+# Homebrew Distribution
+
+Superset is distributed via Homebrew using a custom tap at [superset-sh/homebrew-superset](https://github.com/superset-sh/homebrew-superset).
+
+## User Installation
+
+Users can install Superset with:
+
+```bash
+brew tap superset-sh/superset
+brew install --cask superset
+```
+
+To update:
+
+```bash
+brew upgrade --cask superset
+```
+
+To uninstall:
+
+```bash
+brew uninstall --cask superset
+brew untap superset-sh/superset
+```
+
+## Automated Updates
+
+The Homebrew cask is automatically updated when a new desktop release is published via the `update-homebrew.yml` workflow.
+
+### Setup Requirements
+
+To enable automated updates, you need to configure a GitHub secret:
+
+#### 1. Create a Personal Access Token (PAT)
+
+1. Go to [GitHub Token Settings](https://github.com/settings/tokens?type=beta)
+2. Click **Generate new token** (fine-grained)
+3. Configure the token:
+   - **Token name**: `homebrew-tap-update`
+   - **Expiration**: Set as appropriate (recommend 1 year)
+   - **Repository access**: Select "Only select repositories" → `superset-sh/homebrew-superset`
+   - **Permissions**:
+     - Contents: **Read and write**
+4. Click **Generate token** and copy it
+
+#### 2. Add the Secret to the Main Repository
+
+Using the GitHub CLI:
+
+```bash
+gh secret set HOMEBREW_TAP_TOKEN --repo superset-sh/superset
+# Paste the token when prompted
+```
+
+Or via the GitHub UI:
+
+1. Go to [Repository Settings → Secrets](https://github.com/superset-sh/superset/settings/secrets/actions)
+2. Click **New repository secret**
+3. Name: `HOMEBREW_TAP_TOKEN`
+4. Value: Paste your PAT
+5. Click **Add secret**
+
+### How It Works
+
+1. When a release with tag `desktop-v*` is **published** (not drafted), the workflow triggers
+2. The workflow downloads the arm64 DMG from the release
+3. Calculates the SHA256 checksum
+4. Updates `Casks/superset.rb` in the homebrew-superset repo
+5. Commits and pushes the changes
+
+### Manual Updates
+
+If you need to manually update the cask:
+
+```bash
+# Clone the tap
+git clone https://github.com/superset-sh/homebrew-superset.git
+cd homebrew-superset
+
+# Download the DMG and get SHA256
+curl -L -o superset.dmg "https://github.com/superset-sh/superset/releases/download/desktop-v<VERSION>/Superset-<VERSION>-arm64.dmg"
+shasum -a 256 superset.dmg
+
+# Update Casks/superset.rb with new version and SHA256
+# Commit and push
+```
+
+## Adding Intel (x64) Support
+
+Currently the cask only supports Apple Silicon (arm64). To add Intel support:
+
+### 1. Update electron-builder.ts
+
+```typescript
+mac: {
+  target: [
+    {
+      target: "dmg",
+      arch: ["arm64", "x64"],  // Add x64
+    },
+  ],
+}
+```
+
+### 2. Update the Cask Formula
+
+```ruby
+cask "superset" do
+  arch arm: "arm64", intel: "x64"
+
+  version "0.0.56"
+  sha256 arm:   "ARM64_SHA256_HERE",
+         intel: "X64_SHA256_HERE"
+
+  url "https://github.com/superset-sh/superset/releases/download/desktop-v#{version}/Superset-#{version}-#{arch}.dmg"
+  # ... rest of cask
+end
+```
+
+### 3. Update the Workflow
+
+Modify `.github/workflows/update-homebrew.yml` to calculate SHA256 for both architectures and update both values in the cask.


### PR DESCRIPTION
## Summary
- Add automated Homebrew cask update workflow that triggers when desktop releases are published
- Add documentation for Homebrew distribution setup and maintenance

## Changes
- `.github/workflows/update-homebrew.yml` - Workflow that auto-updates the [homebrew-superset](https://github.com/superset-sh/homebrew-superset) tap when a `desktop-v*` release is published
- `apps/desktop/docs/HOMEBREW_DISTRIBUTION.md` - Setup instructions and documentation

## Setup Required
After merging, add the `HOMEBREW_TAP_TOKEN` secret to enable automated updates. See the [HOMEBREW_DISTRIBUTION.md](apps/desktop/docs/HOMEBREW_DISTRIBUTION.md) for instructions.

## User Installation
Once set up, users can install Superset via:
```bash
brew tap superset-sh/superset
brew install --cask superset
```

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Add `HOMEBREW_TAP_TOKEN` secret after merge
- [ ] Test by publishing a desktop release and verifying the cask updates