### PR TITLE
fix(desktop): revert migration 11 to simple ADD COLUMN

### DIFF
--- a/packages/local-db/drizzle/0011_add_terminal_persistence.sql
+++ b/packages/local-db/drizzle/0011_add_terminal_persistence.sql
@@ -1,6 +1,1 @@
--- Drop the column if it exists (to make migration idempotent for prod fix)
--- This handles cases where the column was partially added in previous migration attempts
-ALTER TABLE `settings` DROP COLUMN `terminal_persistence`;
---> statement-breakpoint
--- Add the column
 ALTER TABLE `settings` ADD `terminal_persistence` integer;


### PR DESCRIPTION
## Problem
The previous fix (#822) used `DROP COLUMN` which fails if the column doesn't exist (SQLite doesn't support `DROP COLUMN IF EXISTS`).

## Solution
Revert to simple `ALTER TABLE settings ADD terminal_persistence integer;`

The existing error handler in `apps/desktop/src/main/lib/local-db/index.ts:98-107` already catches "duplicate column name" errors and treats them as idempotent, so this handles both:
- Fresh installs (column doesn't exist) ✅
- Partial migrations (column already exists from failed migration) ✅

## Migration Change
```sql
-- Before (fails if column doesn't exist):
ALTER TABLE \`settings\` DROP COLUMN \`terminal_persistence\`;
ALTER TABLE \`settings\` ADD \`terminal_persistence\` integer;

-- After (idempotent via error handling):
ALTER TABLE \`settings\` ADD \`terminal_persistence\` integer;
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump and internal database metadata maintenance updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->