### PR TITLE
fix(desktop): Persist command deletions in terminal presets

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/TerminalSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/TerminalSettings.tsx
@@ -176,9 +176,20 @@ export function TerminalSettings({ visibleItems }: TerminalSettingsProps) {
 	};
 
 	const handleCommandsChange = (rowIndex: number, commands: string[]) => {
+		const preset = localPresets[rowIndex];
+		const isDelete = preset && commands.length < preset.commands.length;
+
 		setLocalPresets((prev) =>
 			prev.map((p, i) => (i === rowIndex ? { ...p, commands } : p)),
 		);
+
+		// Save immediately on delete since onBlur won't have the updated state yet
+		if (isDelete) {
+			updatePreset.mutate({
+				id: preset.id,
+				patch: { commands },
+			});
+		}
 	};
 
 	const handleCommandsBlur = (rowIndex: number) => {

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetRow/components/CommandsEditor/CommandsEditor.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetRow/components/CommandsEditor/CommandsEditor.tsx
@@ -58,7 +58,6 @@ export function CommandsEditor({
 			e.preventDefault();
 			const updated = commands.filter((_, i) => i !== index);
 			onChange(updated);
-			onBlur?.();
 		}
 	};
 
@@ -66,7 +65,6 @@ export function CommandsEditor({
 		if (commands.length > 1) {
 			const updated = commands.filter((_, i) => i !== index);
 			onChange(updated);
-			onBlur?.();
 		}
 	};
 


### PR DESCRIPTION
## Description
Fix command deletions not persisting in terminal presets. Delete operations weren't saving because `onChange` updates state asynchronously, but `onBlur` was called immediately after and read stale state. Fixed by detecting deletes in `handleCommandsChange` and saving immediately with the new value.

## Related Issues
None

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing
- [x] Open terminal settings and edit a preset's commands
- [x] Remove a command using backspace on an empty input field
- [x] Verify the change persists after navigating away and back
- [x] Remove a command using the delete button
- [x] Verify the change persists

## Screenshots (if applicable)
N/A

## Additional Notes
Resolves #846