### PR TITLE
fix(desktop): run preset commands after initialization script

### DIFF
--- a/apps/desktop/src/renderer/react-query/workspaces/useOpenWorktree.ts
+++ b/apps/desktop/src/renderer/react-query/workspaces/useOpenWorktree.ts
@@ -66,6 +66,7 @@ export function useOpenWorktree(
 				tabId,
 				workspaceId: data.workspace.id,
 				initialCommands,
+				cwd: initialCwd,
 			});
 
 			if (!initialCommands) {


### PR DESCRIPTION
## Description

When opening a workspace with a setup script configured, preset commands were not running after the initialization script completed. This was because `useOpenWorktree` bypassed the preset system entirely by using the raw `addTab` from the store instead of `useTabsWithPresets`.

This fix merges setup commands with preset commands so both run in sequence:
1. Initialization script commands run first
2. Preset commands run immediately after

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

1. Configure a workspace with a setup script in `.superset/config.json`
2. Set a default preset with commands (e.g., `echo "preset ran"`)
3. Open the workspace (first terminal boot)
4. Verify:
   - Setup script commands run first
   - Preset commands run immediately after
5. Open a second terminal (split) - verify preset commands still run
6. Open a workspace WITHOUT setup script - verify preset commands still run

## Screenshots (if applicable)

N/A

## Additional Notes

Resolves #834

The root cause was two-fold:
1. `useOpenWorktree` used `useTabsStore.addTab` directly, bypassing `useTabsWithPresets`
2. Even if it had used `useTabsWithPresets`, the logic was OR-based (options OR preset), not AND-based

The fix imports `useTabsWithPresets`, merges the command arrays (`[...setupCommands, ...presetCommands]`), and passes the combined commands explicitly to prevent double-application of presets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace terminals now apply preset configurations when opened.
  * Configuration prompt guides setup of workspaces without initial commands.

* **Bug Fixes**
  * Corrected terminal working directory initialization for workspace presets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->