### PR TITLE
fix(desktop): prevent terminal scroll jumping to top on resize/reattach

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/terminal/terminal.ts
+++ b/apps/desktop/src/lib/trpc/routers/terminal/terminal.ts
@@ -163,7 +163,6 @@ export const createTerminalRouter = () => {
 						isNew: result.isNew,
 						scrollback: result.scrollback,
 						wasRecovered: result.wasRecovered,
-						viewportY: result.viewportY,
 						// Cold restore fields (for reboot recovery)
 						isColdRestore: result.isColdRestore,
 						previousCwd: result.previousCwd,
@@ -265,7 +264,6 @@ export const createTerminalRouter = () => {
 			.input(
 				z.object({
 					paneId: z.string(),
-					viewportY: z.number().optional(),
 				}),
 			)
 			.mutation(async ({ input }) => {

--- a/apps/desktop/src/main/lib/terminal/daemon-manager.ts
+++ b/apps/desktop/src/main/lib/terminal/daemon-manager.ts
@@ -56,8 +56,6 @@ interface SessionInfo {
 	pid: number | null;
 	cols: number;
 	rows: number;
-	/** Saved viewport scroll position for restoration on reattach */
-	viewportY?: number;
 }
 
 // =============================================================================
@@ -747,7 +745,6 @@ export class DaemonTerminalManager extends EventEmitter {
 				// The renderer should prefer snapshot.snapshotAnsi when available.
 				scrollback: "",
 				wasRecovered: response.wasRecovered,
-				viewportY: this.sessions.get(paneId)?.viewportY,
 				snapshot: {
 					snapshotAnsi: response.snapshot.snapshotAnsi,
 					rehydrateSequences: response.snapshot.rehydrateSequences,
@@ -896,8 +893,8 @@ export class DaemonTerminalManager extends EventEmitter {
 		await this.client.kill({ sessionId: paneId, deleteHistory });
 	}
 
-	detach(params: { paneId: string; viewportY?: number }): void {
-		const { paneId, viewportY } = params;
+	detach(params: { paneId: string }): void {
+		const { paneId } = params;
 
 		const session = this.sessions.get(paneId);
 
@@ -912,9 +909,6 @@ export class DaemonTerminalManager extends EventEmitter {
 
 		if (session) {
 			session.lastActive = Date.now();
-			if (viewportY !== undefined) {
-				session.viewportY = viewportY;
-			}
 		}
 	}
 

--- a/apps/desktop/src/main/lib/terminal/manager.ts
+++ b/apps/desktop/src/main/lib/terminal/manager.ts
@@ -264,7 +264,7 @@ export class TerminalManager extends EventEmitter {
 		}
 	}
 
-	detach(params: { paneId: string; viewportY?: number }): void {
+	detach(params: { paneId: string }): void {
 		const { paneId } = params;
 		const session = this.sessions.get(paneId);
 

--- a/apps/desktop/src/main/lib/terminal/types.ts
+++ b/apps/desktop/src/main/lib/terminal/types.ts
@@ -46,8 +46,6 @@ export interface SessionResult {
 	 */
 	scrollback: string;
 	wasRecovered: boolean;
-	/** Saved viewport scroll position for restoration on reattach */
-	viewportY?: number;
 	/**
 	 * True if this is a cold restore from disk after reboot/crash.
 	 * The daemon didn't have this session, but we found scrollback on disk

--- a/apps/desktop/src/main/lib/workspace-runtime/types.ts
+++ b/apps/desktop/src/main/lib/workspace-runtime/types.ts
@@ -96,9 +96,8 @@ export interface TerminalSessionOperations {
 
 	/**
 	 * Detach from the terminal (keep session alive).
-	 * viewportY is saved for scroll restoration on reattach.
 	 */
-	detach(params: { paneId: string; viewportY?: number }): void;
+	detach(params: { paneId: string }): void;
 
 	/** Clear the scrollback buffer */
 	clearScrollback(params: { paneId: string }): void | Promise<void>;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -44,11 +44,7 @@ import { ScrollToBottomButton } from "./ScrollToBottomButton";
 import { coldRestoreState, pendingDetaches } from "./state";
 import { TerminalSearch } from "./TerminalSearch";
 import type { TerminalProps, TerminalStreamEvent } from "./types";
-import {
-	getScrollOffsetFromBottom,
-	scrollToBottom,
-	shellEscapePaths,
-} from "./utils";
+import { scrollToBottom, shellEscapePaths } from "./utils";
 
 export const Terminal = ({ tabId, workspaceId }: TerminalProps) => {
 	const paneId = tabId;
@@ -617,10 +613,7 @@ export const Terminal = ({ tabId, workspaceId }: TerminalProps) => {
 			debouncedSetTabAutoTitleRef.current?.cancel?.();
 
 			const detachTimeout = setTimeout(() => {
-				detachRef.current({
-					paneId,
-					viewportY: getScrollOffsetFromBottom(xterm),
-				});
+				detachRef.current({ paneId });
 				pendingDetaches.delete(paneId);
 				coldRestoreState.delete(paneId);
 			}, 50);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalRestore.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalRestore.ts
@@ -142,17 +142,6 @@ export function useTerminalRestore({
 				}
 			}
 
-			// Resize xterm to match snapshot dimensions before applying content
-			const snapshotCols = result.snapshot?.cols;
-			const snapshotRows = result.snapshot?.rows;
-			if (
-				snapshotCols &&
-				snapshotRows &&
-				(xterm.cols !== snapshotCols || xterm.rows !== snapshotRows)
-			) {
-				xterm.resize(snapshotCols, snapshotRows);
-			}
-
 			const isAltScreenReattach =
 				!result.isNew && result.snapshot?.modes.alternateScreen;
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/types.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/types.ts
@@ -13,7 +13,6 @@ export type CreateOrAttachResult = {
 	wasRecovered: boolean;
 	isNew: boolean;
 	scrollback: string;
-	viewportY?: number;
 	// Cold restore fields (for reboot recovery)
 	isColdRestore?: boolean;
 	previousCwd?: string;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/utils.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/utils.ts
@@ -19,22 +19,3 @@ export function scrollToBottom(
 		terminal.scrollToBottom();
 	}
 }
-
-/** Get scroll offset from bottom (0 = at bottom, >0 = scrolled up N lines) */
-export function getScrollOffsetFromBottom(terminal: Terminal): number {
-	const { baseY, viewportY } = terminal.buffer.active;
-	return baseY - viewportY;
-}
-
-/** Restore scroll position from offset (0 = bottom, >0 = N lines from bottom) */
-export function restoreScrollPosition(
-	terminal: Terminal,
-	offsetFromBottom: number | undefined,
-): void {
-	if (offsetFromBottom && offsetFromBottom > 0) {
-		const targetLine = terminal.buffer.active.baseY - offsetFromBottom;
-		terminal.scrollToLine(Math.max(0, targetLine));
-	} else {
-		terminal.scrollToBottom();
-	}
-}


### PR DESCRIPTION
## Summary
- Fix terminal scroll position jumping to top when resizing or reattaching
- Remove unused viewportY scroll restoration feature that was never working correctly
- Remove suspicious pre-content `xterm.resize()` call that caused double-resize during restore

## Changes
- Removed `viewportY` field from detach/createOrAttach flow across renderer and main process
- Removed unused `getScrollOffsetFromBottom` and `restoreScrollPosition` utils
- Removed pre-content resize in `useTerminalRestore` that resized terminal to snapshot dimensions before writing content, then resized again with `fitAddon.fit()` - this double-resize was confusing xterm's scroll handling

## Test plan
- [ ] Open terminal with long scrollback history
- [ ] Resize the window - scroll position should stay at bottom (or maintain position if scrolled up)
- [ ] Switch tabs and switch back - scroll position should be maintained
- [ ] Split panes and resize - scroll position should be maintained