### PR TITLE
feat(desktop): Add middle-click to close tabs

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupItem.tsx
@@ -88,6 +88,12 @@ export function GroupItem({
 							type="button"
 							onClick={onSelect}
 							onDoubleClick={startEditing}
+							onAuxClick={(e) => {
+								if (e.button === 1) {
+									e.preventDefault();
+									onClose();
+								}
+							}}
 							className={tabStyles}
 						>
 							<span className="text-sm whitespace-nowrap overflow-hidden flex-1 text-left">


### PR DESCRIPTION
## Summary
- Adds middle mouse button click support to close tabs in the desktop app
- Matches standard browser tab behavior (Chrome, Firefox, etc.)

## Test plan
- [x] Open the desktop app
- [x] Create multiple tabs
- [x] Middle-click on a tab to verify it closes
- [x] Verify left-click still switches tabs
- [x] Verify double-click still enables rename mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added middle-click support for group tabs—users can now close a group by middle-clicking on its tab for quicker navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->