### PR TITLE
fix(desktop): improve preset editing UX with auto-scroll and focus management

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/TerminalSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/TerminalSettings.tsx
@@ -19,7 +19,7 @@ import {
 import { toast } from "@superset/ui/sonner";
 import { Switch } from "@superset/ui/switch";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { HiOutlineCheck, HiOutlinePlus } from "react-icons/hi2";
 import {
 	getPresetIcon,
@@ -140,9 +140,21 @@ export function TerminalSettings({ visibleItems }: TerminalSettingsProps) {
 	} = usePresets();
 	const [localPresets, setLocalPresets] =
 		useState<TerminalPreset[]>(serverPresets);
+	const presetsContainerRef = useRef<HTMLDivElement>(null);
+	const prevPresetsCountRef = useRef(serverPresets.length);
 
 	useEffect(() => {
 		setLocalPresets(serverPresets);
+
+		if (serverPresets.length > prevPresetsCountRef.current) {
+			requestAnimationFrame(() => {
+				presetsContainerRef.current?.scrollTo({
+					top: presetsContainerRef.current.scrollHeight,
+					behavior: "smooth",
+				});
+			});
+		}
+		prevPresetsCountRef.current = serverPresets.length;
 	}, [serverPresets]);
 
 	const existingPresetNames = useMemo(
@@ -490,7 +502,10 @@ export function TerminalSettings({ visibleItems }: TerminalSettingsProps) {
 									</div>
 								</div>
 
-								<div className="max-h-[320px] overflow-y-auto">
+								<div
+									ref={presetsContainerRef}
+									className="max-h-[320px] overflow-y-auto"
+								>
 									{isLoadingPresets ? (
 										<div className="py-8 text-center text-sm text-muted-foreground">
 											Loading presets...

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetRow/components/CommandsEditor/CommandsEditor.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetRow/components/CommandsEditor/CommandsEditor.tsx
@@ -58,6 +58,7 @@ export function CommandsEditor({
 			e.preventDefault();
 			const updated = commands.filter((_, i) => i !== index);
 			onChange(updated);
+			setFocusIndex(Math.max(0, index - 1));
 		}
 	};
 
@@ -65,6 +66,7 @@ export function CommandsEditor({
 		if (commands.length > 1) {
 			const updated = commands.filter((_, i) => i !== index);
 			onChange(updated);
+			setFocusIndex(Math.max(0, index - 1));
 		}
 	};
 


### PR DESCRIPTION
## Summary
- Auto-scroll preset list to bottom when adding a new preset so the user can immediately see and edit it
- Focus the previous command input when removing a command (via backspace or delete button) for smoother editing flow

## Test plan
- [ ] Add a preset and verify the list scrolls to show the new preset
- [ ] Add multiple presets until the list overflows, then add another and verify it scrolls to show it
- [ ] In a preset with multiple commands, delete one using backspace (on empty input) and verify focus moves to the previous command
- [ ] In a preset with multiple commands, click the X button to delete and verify focus moves to the previous command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Terminal presets list now automatically scrolls to display newly added presets.
  * Focus automatically restores to the appropriate position when deleting commands in the editor.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->