### PR TITLE
fix(desktop): reduce diff viewer gutter width

### DIFF
--- a/apps/desktop/src/renderer/providers/MonacoProvider/MonacoProvider.tsx
+++ b/apps/desktop/src/renderer/providers/MonacoProvider/MonacoProvider.tsx
@@ -110,6 +110,7 @@ export const MONACO_EDITOR_OPTIONS = {
 	wordWrap: "on" as const,
 	fontSize: 13,
 	lineHeight: 20,
+	lineNumbersMinChars: 3,
 	fontFamily:
 		"ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace",
 	padding: { top: 8, bottom: 8 },

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/DiffViewer/DiffViewer.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/DiffViewer/DiffViewer.tsx
@@ -209,6 +209,7 @@ export function DiffViewer({
 				readOnly: !editable,
 				originalEditable: false,
 				renderOverviewRuler: true,
+				renderGutterMenu: false,
 				diffWordWrap: "on",
 				contextmenu: !contextMenuProps, // Disable Monaco's context menu if we have custom props
 				hideUnchangedRegions: {


### PR DESCRIPTION
## Summary
- Reduces line number column width in Monaco editor by setting `lineNumbersMinChars: 3`
- Hides the gutter menu in diff viewer with `renderGutterMenu: false` to save horizontal space

before:
<img width="209" height="209" alt="Screenshot 2026-01-20 at 6 09 28 PM" src="https://github.com/user-attachments/assets/e90ab0c1-20b2-496d-bb8b-0f88ad8c8dc4" />


after:
<img width="189" height="133" alt="Screenshot 2026-01-20 at 6 08 40 PM" src="https://github.com/user-attachments/assets/d295037b-829a-4e94-b471-0fc70159887a" />

## Test plan
- [ ] Open the changes view in the desktop app
- [ ] Verify the line number gutter is narrower
- [ ] Verify the revert gutter menu is hidden

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced line number display width in the editor for improved visibility
  * Streamlined diff viewer by disabling the gutter context menu for a cleaner interface

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->