### PR TITLE
fix(desktop): ensure terminal scrolls to bottom after restore and resize

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -20,6 +20,7 @@ import {
 import { RESIZE_DEBOUNCE_MS, TERMINAL_OPTIONS } from "./config";
 import { FilePathLinkProvider, UrlLinkProvider } from "./link-providers";
 import { suppressQueryResponses } from "./suppressQueryResponses";
+import { scrollToBottom } from "./utils";
 
 /**
  * Get the default terminal theme from localStorage cache.
@@ -520,8 +521,13 @@ export function setupResizeHandlers(
 	onResize: (cols: number, rows: number) => void,
 ): () => void {
 	const debouncedHandleResize = debounce(() => {
+		const buffer = xterm.buffer.active;
+		const wasAtBottom = buffer.viewportY >= buffer.baseY;
 		fitAddon.fit();
 		onResize(xterm.cols, xterm.rows);
+		if (wasAtBottom) {
+			requestAnimationFrame(() => scrollToBottom(xterm));
+		}
 	}, RESIZE_DEBOUNCE_MS);
 
 	const resizeObserver = new ResizeObserver(debouncedHandleResize);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalColdRestore.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalColdRestore.ts
@@ -9,6 +9,7 @@ import type {
 	CreateOrAttachResult,
 	TerminalStreamEvent,
 } from "../types";
+import { scrollToBottom } from "../utils";
 
 export interface UseTerminalColdRestoreOptions {
 	paneId: string;
@@ -114,7 +115,12 @@ export function useTerminalColdRestore({
 
 						currentXterm.clear();
 						if (scrollback) {
-							currentXterm.write(scrollback);
+							currentXterm.write(scrollback, () => {
+								requestAnimationFrame(() => {
+									if (xtermRef.current !== currentXterm) return;
+									scrollToBottom(currentXterm);
+								});
+							});
 						}
 
 						didFirstRenderRef.current = true;


### PR DESCRIPTION
## Summary
- Uses `xterm.write()` callback with `requestAnimationFrame` to scroll to bottom only after content is fully rendered
- Fixes race condition where terminal viewport could remain scrolled up after cold restore, hot restore, or visibility/resize changes
- Preserves scroll position if user had manually scrolled up before resize

## Test plan
- [ ] Open a terminal with existing scrollback history, close and reopen app - terminal should scroll to bottom
- [ ] Switch tabs away from terminal and back - should maintain scroll position (or scroll to bottom if was at bottom)
- [ ] Resize terminal while it has scrollback - should scroll to bottom if was at bottom, otherwise preserve position
- [ ] Tab between terminals with different scroll positions - each should maintain its own scroll state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal scroll-to-bottom behavior during content restoration and session recovery
  * Fixed terminal scrolling position after resize events
  * Enhanced scroll handling to maintain bottom-of-view positioning during initialization
  * Optimized scroll behavior when toggling terminal visibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->