### PR TITLE
feat(desktop): open create PR link after publishing branch

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/components/CommitInput/CommitInput.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/components/CommitInput/CommitInput.tsx
@@ -102,8 +102,19 @@ export function CommitInput({
 		commitMutation.mutate({ worktreePath, message: commitMessage.trim() });
 	};
 
-	const handlePush = () =>
-		pushMutation.mutate({ worktreePath, setUpstream: true });
+	const handlePush = () => {
+		const isPublishing = !hasUpstream;
+		pushMutation.mutate(
+			{ worktreePath, setUpstream: true },
+			{
+				onSuccess: () => {
+					if (isPublishing) {
+						createPRMutation.mutate({ worktreePath });
+					}
+				},
+			},
+		);
+	};
 	const handlePull = () => pullMutation.mutate({ worktreePath });
 	const handleSync = () => syncMutation.mutate({ worktreePath });
 	const handleCreatePR = () => createPRMutation.mutate({ worktreePath });


### PR DESCRIPTION
## Summary
- Automatically opens the GitHub PR creation page when a user clicks "Publish Branch"
- Streamlines the workflow by eliminating the need to manually click "Create Pull Request" after publishing

## Test plan
- [ ] Create a new branch locally without an upstream
- [ ] Click "Publish Branch" in the Changes sidebar
- [ ] Verify the branch is pushed and GitHub's PR creation page opens automatically
- [ ] Verify regular "Push" operations (with existing upstream) do not open the PR page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pushing a branch now automatically initiates pull request creation for newly published branches.

* **Improvements**
  * Streamlined push workflow to reduce manual steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->