### PR TITLE
feat(desktop): add plans comparison page with feature matrix

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/BillingOverview.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/BillingOverview.tsx
@@ -1,0 +1,70 @@
+import { Button } from "@superset/ui/button";
+import { Link } from "@tanstack/react-router";
+import { HiArrowRight } from "react-icons/hi2";
+import {
+	isItemVisible,
+	SETTING_ITEM_ID,
+	type SettingItemId,
+} from "../../../utils/settings-search";
+import { MOCK_BILLING_INFO } from "../../constants";
+import { CurrentPlanCard } from "./components/CurrentPlanCard";
+import { InvoicesSection } from "./components/InvoicesSection";
+import { UpgradeCard } from "./components/UpgradeCard";
+
+interface BillingOverviewProps {
+	visibleItems?: SettingItemId[] | null;
+}
+
+export function BillingOverview({ visibleItems }: BillingOverviewProps) {
+	const billingInfo = MOCK_BILLING_INFO;
+	const showOverview = isItemVisible(
+		SETTING_ITEM_ID.BILLING_OVERVIEW,
+		visibleItems,
+	);
+	const showInvoices = isItemVisible(
+		SETTING_ITEM_ID.BILLING_INVOICES,
+		visibleItems,
+	);
+
+	return (
+		<div className="p-6 max-w-4xl w-full">
+			<div className="mb-6">
+				<div className="flex items-center justify-between">
+					<div>
+						<h2 className="text-lg font-semibold">Billing</h2>
+						<p className="text-xs text-muted-foreground mt-0.5">
+							For questions about billing,{" "}
+							<a
+								href="mailto:founders@superset.sh"
+								className="text-primary hover:underline"
+							>
+								contact us
+							</a>
+						</p>
+					</div>
+					<Button variant="ghost" size="sm" asChild>
+						<Link to="/settings/billing/plans">
+							All plans
+							<HiArrowRight className="h-3 w-3" />
+						</Link>
+					</Button>
+				</div>
+			</div>
+
+			<div className="space-y-3">
+				{showOverview && (
+					<>
+						<CurrentPlanCard billingInfo={billingInfo} />
+						{billingInfo.currentPlan === "free" && <UpgradeCard />}
+					</>
+				)}
+
+				{showInvoices && (
+					<div className="mt-6">
+						<InvoicesSection />
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/CurrentPlanCard/CurrentPlanCard.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/CurrentPlanCard/CurrentPlanCard.tsx
@@ -1,0 +1,34 @@
+import { Badge } from "@superset/ui/badge";
+import { Card, CardContent } from "@superset/ui/card";
+import type { BillingInfo } from "../../../../constants";
+import { PLANS } from "../../../../constants";
+
+interface CurrentPlanCardProps {
+	billingInfo: BillingInfo;
+}
+
+export function CurrentPlanCard({ billingInfo }: CurrentPlanCardProps) {
+	const plan = PLANS[billingInfo.currentPlan];
+
+	return (
+		<Card className="gap-0 rounded-lg border-border/60 py-0 shadow-none">
+			<CardContent className="px-5 py-4">
+				<div className="flex items-center justify-between">
+					<div className="min-w-0 flex-1">
+						<div className="flex items-center gap-2 mb-1">
+							<span className="text-sm font-medium">{plan.name} plan</span>
+							<Badge variant="secondary">Current</Badge>
+						</div>
+						<p className="text-xs text-muted-foreground">{plan.description}</p>
+					</div>
+					<div className="ml-6 text-right flex-shrink-0">
+						<div className="text-[11px] text-muted-foreground mb-0.5">
+							Users
+						</div>
+						<div className="text-sm font-medium">{billingInfo.usage.users}</div>
+					</div>
+				</div>
+			</CardContent>
+		</Card>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/CurrentPlanCard/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/CurrentPlanCard/index.ts
@@ -1,0 +1,1 @@
+export { CurrentPlanCard } from "./CurrentPlanCard";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/InvoicesSection/InvoicesSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/InvoicesSection/InvoicesSection.tsx
@@ -1,0 +1,14 @@
+import { Card, CardContent } from "@superset/ui/card";
+
+export function InvoicesSection() {
+	return (
+		<div className="space-y-3">
+			<h3 className="text-sm font-medium">Recent invoices</h3>
+			<Card className="gap-0 rounded-lg border-border/60 py-0 shadow-none">
+				<CardContent className="px-5 py-4">
+					<p className="text-xs text-muted-foreground">No invoices yet</p>
+				</CardContent>
+			</Card>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/InvoicesSection/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/InvoicesSection/index.ts
@@ -1,0 +1,1 @@
+export { InvoicesSection } from "./InvoicesSection";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/UpgradeCard/UpgradeCard.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/UpgradeCard/UpgradeCard.tsx
@@ -1,0 +1,50 @@
+import { Button } from "@superset/ui/button";
+import { Card, CardContent } from "@superset/ui/card";
+import { toast } from "@superset/ui/sonner";
+import { Link } from "@tanstack/react-router";
+import { HiCheck } from "react-icons/hi2";
+import { PLANS } from "../../../../constants";
+
+export function UpgradeCard() {
+	const plan = PLANS.pro;
+
+	const handleUpgrade = () => {
+		toast.info("Stripe integration coming soon");
+	};
+
+	return (
+		<Card className="gap-0 rounded-lg border-border/60 py-0 shadow-none">
+			<CardContent className="px-5 py-4">
+				<div className="flex flex-wrap items-center justify-between gap-4">
+					<div>
+						<div className="text-sm font-medium">
+							Upgrade to {plan.name} plan
+						</div>
+						<p className="text-xs text-muted-foreground">
+							${plan.price?.monthly ? plan.price.monthly / 100 : 0} per user/mo
+						</p>
+					</div>
+					<div className="flex items-center gap-3">
+						<Button variant="ghost" size="sm" asChild>
+							<Link to="/settings/billing/plans">View all plans</Link>
+						</Button>
+						<Button onClick={handleUpgrade} size="sm">
+							Upgrade now
+						</Button>
+					</div>
+				</div>
+
+				<div className="my-3 h-px bg-border/60" />
+
+				<div className="grid gap-x-4 gap-y-2 text-xs sm:grid-cols-2 lg:grid-cols-3">
+					{plan.features.map((feature) => (
+						<div key={feature.id} className="flex items-center gap-2">
+							<HiCheck className="h-3.5 w-3.5 text-accent-foreground flex-shrink-0" />
+							<span className="leading-tight">{feature.name}</span>
+						</div>
+					))}
+				</div>
+			</CardContent>
+		</Card>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/UpgradeCard/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/UpgradeCard/index.ts
@@ -1,0 +1,1 @@
+export { UpgradeCard } from "./UpgradeCard";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/index.ts
@@ -1,0 +1,1 @@
+export { BillingOverview } from "./BillingOverview";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/PlansComparison/PlansComparison.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/PlansComparison/PlansComparison.tsx
@@ -1,0 +1,404 @@
+import { Button } from "@superset/ui/button";
+import { toast } from "@superset/ui/sonner";
+import { Switch } from "@superset/ui/switch";
+import { cn } from "@superset/ui/utils";
+import { Link } from "@tanstack/react-router";
+import { Fragment, useState } from "react";
+import { HiArrowLeft, HiArrowUpRight, HiCheck } from "react-icons/hi2";
+import { MOCK_BILLING_INFO, type PlanTier } from "../../constants";
+
+type PlanCardAction = "current" | "upgrade" | "contact";
+type PlanCardData = {
+	id: "free" | "pro" | "enterprise";
+	name: string;
+	price: { monthly: string; yearly: string } | string;
+	priceNote?: { monthly: string; yearly: string } | string;
+	billingText: { monthly: string; yearly: string } | string;
+	showBillingToggle?: boolean;
+	actions: Array<{
+		label: string;
+		action: PlanCardAction;
+		variant: "default" | "secondary" | "outline";
+		size?: "default" | "sm";
+		fullWidth?: boolean;
+		align?: "center" | "start";
+	}>;
+};
+
+type ComparisonValue = string | boolean | null;
+type ComparisonRow = {
+	label: string;
+	values: ComparisonValue[];
+};
+type ComparisonSection = {
+	title: string;
+	rows: ComparisonRow[];
+};
+
+const PLAN_CARDS: PlanCardData[] = [
+	{
+		id: "free",
+		name: "Free",
+		price: "$0",
+		priceNote: "per user/month",
+		billingText: "Free for everyone",
+		actions: [
+			{
+				label: "Current plan",
+				action: "current",
+				variant: "secondary",
+			},
+		],
+	},
+	{
+		id: "pro",
+		name: "Pro",
+		price: { monthly: "$20", yearly: "$180" },
+		priceNote: { monthly: "per user/month", yearly: "per user/year" },
+		billingText: { monthly: "Billed monthly", yearly: "Billed yearly" },
+		showBillingToggle: true,
+		actions: [
+			{
+				label: "Upgrade",
+				action: "upgrade",
+				variant: "default",
+			},
+		],
+	},
+	{
+		id: "enterprise",
+		name: "Enterprise",
+		price: "Custom pricing",
+		billingText: "Billed yearly",
+		actions: [
+			{
+				label: "Request a trial",
+				action: "contact",
+				variant: "outline",
+			},
+		],
+	},
+];
+
+const COMPARISON_SECTIONS: ComparisonSection[] = [
+	{
+		title: "Usage",
+		rows: [
+			{
+				label: "Team members",
+				values: ["1", "Unlimited", "Unlimited"],
+			},
+			{
+				label: "Workspaces",
+				values: ["5", "Unlimited", "Unlimited"],
+			},
+			{
+				label: "Projects",
+				values: ["3", "Unlimited", "Unlimited"],
+			},
+		],
+	},
+	{
+		title: "Features",
+		rows: [
+			{
+				label: "Desktop app",
+				values: [true, true, true],
+			},
+			{
+				label: "Local workspaces",
+				values: [true, true, true],
+			},
+			{
+				label: "GitHub integration",
+				values: [true, true, true],
+			},
+			{
+				label: "Cloud workspaces",
+				values: [null, true, true],
+			},
+			{
+				label: "Mobile app",
+				values: [null, true, true],
+			},
+			{
+				label: "Linear integration",
+				values: [null, true, true],
+			},
+			{
+				label: "Team collaboration",
+				values: [null, true, true],
+			},
+		],
+	},
+	{
+		title: "Support",
+		rows: [
+			{
+				label: "Priority support",
+				values: [null, true, true],
+			},
+			{
+				label: "Uptime SLA",
+				values: [null, null, true],
+			},
+			{
+				label: "Custom contracts",
+				values: [null, null, true],
+			},
+		],
+	},
+	{
+		title: "Security",
+		rows: [
+			{
+				label: "SSO/SAML",
+				values: [null, null, true],
+			},
+			{
+				label: "IP restrictions",
+				values: [null, null, true],
+			},
+			{
+				label: "SCIM provisioning",
+				values: [null, null, true],
+			},
+			{
+				label: "Audit log",
+				values: [null, null, true],
+			},
+		],
+	},
+];
+
+export function PlansComparison() {
+	const [isYearly, setIsYearly] = useState(true);
+	const billingInfo = MOCK_BILLING_INFO;
+	const currentPlanLabelByTier: Record<PlanTier, string> = {
+		free: "Free",
+		pro: "Pro",
+		enterprise: "Enterprise",
+	};
+	const currentPlanLabel = currentPlanLabelByTier[billingInfo.currentPlan];
+
+	const getValue = <T,>(value: T | { monthly: T; yearly: T }): T => {
+		if (typeof value === "object" && value !== null && "monthly" in value) {
+			return isYearly ? value.yearly : value.monthly;
+		}
+		return value as T;
+	};
+
+	const handlePlanAction = (action: PlanCardAction) => {
+		if (action === "current") {
+			return;
+		}
+
+		if (action === "contact") {
+			window.open("mailto:founders@superset.sh", "_blank");
+			return;
+		}
+
+		toast.info("Stripe integration coming soon");
+	};
+
+	const renderComparisonValue = (value: ComparisonValue) => {
+		if (value === null || value === false) {
+			return <span className="sr-only">Not included</span>;
+		}
+
+		if (value === true) {
+			return <HiCheck className="h-3.5 w-3.5 text-muted-foreground" />;
+		}
+
+		return (
+			<>
+				<HiCheck className="h-3.5 w-3.5 text-muted-foreground" />
+				<span className="text-sm">{value}</span>
+			</>
+		);
+	};
+
+	const highlightColumnIndex = 1;
+	const highlightColumnStart = highlightColumnIndex + 2;
+	const gridColumnsClass = "grid grid-cols-[180px_repeat(3,_1fr)]";
+
+	return (
+		<div className="p-6 max-w-7xl w-full">
+			<div className="mb-6 space-y-4">
+				<Button variant="ghost" size="sm" asChild>
+					<Link to="/settings/billing">
+						<HiArrowLeft className="h-4 w-4" />
+						Billing
+					</Link>
+				</Button>
+				<div>
+					<h2 className="text-xl font-semibold">Plans</h2>
+					<p className="text-sm text-muted-foreground mt-1">
+						You are on the{" "}
+						<span className="text-foreground font-medium">
+							{currentPlanLabel} plan
+						</span>
+						. If you have any questions or would like further support with your
+						plan,{" "}
+						<a
+							href="mailto:founders@superset.sh"
+							className="inline-flex items-center gap-1 text-primary hover:underline"
+						>
+							contact us
+							<HiArrowUpRight className="h-3 w-3" />
+						</a>
+						.
+					</p>
+				</div>
+			</div>
+
+			<div className="overflow-x-auto">
+				<div className="relative min-w-[720px]">
+					<div
+						className={cn(
+							gridColumnsClass,
+							"pointer-events-none absolute inset-0",
+						)}
+					>
+						<div
+							className="bg-accent/30 border border-border/60 rounded-lg"
+							style={{
+								gridColumn: `${highlightColumnStart} / ${highlightColumnStart + 1}`,
+								gridRow: "span 3",
+							}}
+						/>
+					</div>
+					<div className={cn(gridColumnsClass, "relative z-10 items-start")}>
+						{(["plan", "billing", "cta"] as const).map((rowKey, rowIndex) => (
+							<Fragment key={rowKey}>
+								<div
+									className={cn("px-2", rowKey === "cta" ? "py-3" : "py-2.5")}
+								/>
+								{PLAN_CARDS.map((plan) => {
+									const isCurrent = currentPlanLabel === plan.name;
+									const planActions = isCurrent
+										? [
+												{
+													label: "Current plan",
+													action: "current" as const,
+													variant: "secondary" as const,
+												},
+											]
+										: plan.actions;
+
+									if (rowKey === "plan") {
+										return (
+											<div key={plan.id} className="px-4 py-2.5">
+												<div className="space-y-0.5">
+													<div className="text-base font-medium">
+														{plan.name}
+													</div>
+													<div
+														className={cn(
+															plan.priceNote
+																? "text-xl font-semibold leading-tight"
+																: "text-base font-medium text-muted-foreground",
+														)}
+													>
+														{getValue(plan.price)}
+													</div>
+													{plan.priceNote && (
+														<div className="text-xs text-muted-foreground">
+															{getValue(plan.priceNote)}
+														</div>
+													)}
+												</div>
+											</div>
+										);
+									}
+
+									if (rowKey === "billing") {
+										return (
+											<div
+												key={plan.id}
+												className="flex items-center gap-2 px-4 py-2.5 text-xs text-muted-foreground"
+											>
+												{plan.showBillingToggle && (
+													<Switch
+														checked={isYearly}
+														onCheckedChange={setIsYearly}
+														aria-label="Billed yearly"
+													/>
+												)}
+												<span>{getValue(plan.billingText)}</span>
+											</div>
+										);
+									}
+
+									return (
+										<div key={plan.id} className="px-4 py-3">
+											<div className="flex flex-col gap-2">
+												{planActions.map((action) => (
+													<Button
+														key={action.label}
+														variant={action.variant}
+														size={action.size ?? "sm"}
+														className={cn(
+															action.fullWidth === false ? "w-fit" : "w-full",
+															action.align === "center" && "self-center",
+															action.align === "start" && "self-start",
+														)}
+														disabled={action.action === "current"}
+														onClick={() => handlePlanAction(action.action)}
+													>
+														{action.label}
+													</Button>
+												))}
+											</div>
+										</div>
+									);
+								})}
+
+								{rowIndex < 2 && (
+									<>
+										<div />
+										<div className="col-span-3 h-px bg-border/60" />
+									</>
+								)}
+							</Fragment>
+						))}
+
+						{COMPARISON_SECTIONS.map((section, sectionIndex) => (
+							<Fragment key={section.title}>
+								<div className="col-span-4 pt-6 pb-3 px-2">
+									<span className="text-sm font-semibold">{section.title}</span>
+								</div>
+								<div className="col-span-4 h-px bg-border/60" />
+
+								{section.rows.map((row, rowIndex) => {
+									const isLastRow =
+										sectionIndex === COMPARISON_SECTIONS.length - 1 &&
+										rowIndex === section.rows.length - 1;
+
+									return (
+										<Fragment key={row.label}>
+											<div className="flex items-center px-2 py-2.5 text-xs text-muted-foreground">
+												{row.label}
+											</div>
+											{row.values.map((value, valueIndex) => (
+												<div
+													key={`${row.label}-${valueIndex}`}
+													className="flex items-center justify-start gap-2 px-4 py-2.5"
+												>
+													{renderComparisonValue(value)}
+												</div>
+											))}
+											{!isLastRow && (
+												<div className="col-span-4 h-px bg-border/60" />
+											)}
+										</Fragment>
+									);
+								})}
+							</Fragment>
+						))}
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/PlansComparison/components/FeatureList/FeatureList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/PlansComparison/components/FeatureList/FeatureList.tsx
@@ -1,0 +1,26 @@
+import { HiCheck } from "react-icons/hi2";
+import type { PlanFeature } from "../../../../constants";
+
+interface FeatureListProps {
+	features: PlanFeature[];
+}
+
+export function FeatureList({ features }: FeatureListProps) {
+	return (
+		<ul className="space-y-3">
+			{features.map((feature) => (
+				<li key={feature.id} className="flex items-start gap-2">
+					<HiCheck className="h-5 w-5 text-green-600 flex-shrink-0 mt-0.5" />
+					<div className="flex-1">
+						<span className="text-sm">{feature.name}</span>
+						{feature.limit && (
+							<span className="text-xs text-muted-foreground ml-1">
+								({feature.limit})
+							</span>
+						)}
+					</div>
+				</li>
+			))}
+		</ul>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/PlansComparison/components/FeatureList/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/PlansComparison/components/FeatureList/index.ts
@@ -1,0 +1,1 @@
+export { FeatureList } from "./FeatureList";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/PlansComparison/components/PlanCard/PlanCard.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/PlansComparison/components/PlanCard/PlanCard.tsx
@@ -1,0 +1,94 @@
+import { Badge } from "@superset/ui/badge";
+import { Button } from "@superset/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardFooter,
+	CardHeader,
+	CardTitle,
+} from "@superset/ui/card";
+import { Separator } from "@superset/ui/separator";
+import { toast } from "@superset/ui/sonner";
+import { cn } from "@superset/ui/utils";
+import type { Plan, PlanTier } from "../../../../constants";
+import { FeatureList } from "../FeatureList";
+
+interface PlanCardProps {
+	plan: Plan;
+	currentPlan: PlanTier;
+}
+
+export function PlanCard({ plan, currentPlan }: PlanCardProps) {
+	const isCurrent = plan.id === currentPlan;
+
+	const handleCTA = () => {
+		if (plan.cta.action === "current") {
+			return;
+		}
+
+		if (plan.cta.action === "contact") {
+			window.open("mailto:founders@superset.sh", "_blank");
+		} else if (plan.cta.action === "upgrade") {
+			toast.info("Stripe integration coming soon");
+		}
+	};
+
+	return (
+		<Card
+			className={cn(
+				"flex flex-col h-full",
+				isCurrent && "border-primary ring-2 ring-primary/20",
+			)}
+		>
+			<CardHeader>
+				<div className="flex items-start justify-between">
+					<div className="space-y-1">
+						<div className="flex items-center gap-2">
+							<CardTitle>{plan.name}</CardTitle>
+							{isCurrent && <Badge variant="outline">Current</Badge>}
+						</div>
+						<CardDescription>{plan.description}</CardDescription>
+					</div>
+				</div>
+			</CardHeader>
+			<CardContent className="flex-1 space-y-6">
+				<div>
+					{plan.price === null ? (
+						<div className="text-2xl font-bold">
+							{plan.id === "free" ? "Free" : "Contact sales"}
+						</div>
+					) : (
+						<div>
+							<div className="flex items-baseline gap-1">
+								<span className="text-3xl font-bold">
+									${plan.price.monthly / 100}
+								</span>
+								<span className="text-muted-foreground">per user/month</span>
+							</div>
+							{plan.price.yearly && (
+								<div className="text-xs text-muted-foreground mt-1">
+									or ${plan.price.yearly / 100}/year (~$
+									{Math.round(plan.price.yearly / 12 / 100)}
+									/mo)
+								</div>
+							)}
+						</div>
+					)}
+				</div>
+				<Separator />
+				<FeatureList features={plan.features} />
+			</CardContent>
+			<CardFooter>
+				<Button
+					variant={isCurrent ? "outline" : "default"}
+					className="w-full"
+					disabled={plan.cta.disabled || isCurrent}
+					onClick={handleCTA}
+				>
+					{plan.cta.text}
+				</Button>
+			</CardFooter>
+		</Card>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/PlansComparison/components/PlanCard/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/PlansComparison/components/PlanCard/index.ts
@@ -1,0 +1,1 @@
+export { PlanCard } from "./PlanCard";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/PlansComparison/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/PlansComparison/index.ts
@@ -1,0 +1,1 @@
+export { PlansComparison } from "./PlansComparison";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/constants.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/constants.ts
@@ -1,0 +1,133 @@
+export const PLAN_TIERS = ["free", "pro", "enterprise"] as const;
+export type PlanTier = (typeof PLAN_TIERS)[number];
+
+export interface PlanFeature {
+	id: string;
+	name: string;
+	description?: string;
+	included: boolean;
+	limit?: string;
+}
+
+export interface Plan {
+	id: PlanTier;
+	name: string;
+	description: string;
+	price: {
+		monthly: number;
+		yearly?: number;
+	} | null;
+	limits: {
+		maxUsers: number | null;
+		maxWorkspaces: number | null;
+		cloudWorkspaces: boolean;
+		mobileApp: boolean;
+	};
+	features: PlanFeature[];
+	cta: {
+		text: string;
+		action: "current" | "upgrade" | "contact";
+		disabled?: boolean;
+	};
+}
+
+export const PLANS: Record<PlanTier, Plan> = {
+	free: {
+		id: "free",
+		name: "Free",
+		description: "For individuals getting started",
+		price: null,
+		limits: {
+			maxUsers: 1,
+			maxWorkspaces: 5,
+			cloudWorkspaces: false,
+			mobileApp: false,
+		},
+		features: [
+			{ id: "users", name: "1 user", included: true },
+			{ id: "workspaces", name: "Up to 5 workspaces", included: true },
+			{ id: "local-only", name: "Local workspaces only", included: true },
+			{ id: "desktop-app", name: "Desktop app", included: true },
+		],
+		cta: { text: "Current plan", action: "current", disabled: true },
+	},
+	pro: {
+		id: "pro",
+		name: "Pro",
+		description: "For teams that need more power",
+		price: { monthly: 2000, yearly: 18000 },
+		limits: {
+			maxUsers: null,
+			maxWorkspaces: null,
+			cloudWorkspaces: true,
+			mobileApp: true,
+		},
+		features: [
+			{
+				id: "users",
+				name: "Unlimited users",
+				included: true,
+				limit: "$20/seat",
+			},
+			{ id: "workspaces", name: "Unlimited workspaces", included: true },
+			{ id: "cloud", name: "Cloud workspaces", included: true },
+			{ id: "mobile", name: "Mobile app access", included: true },
+			{ id: "priority", name: "Priority support", included: true },
+			{ id: "roles", name: "Role-based permissions", included: true },
+		],
+		cta: { text: "Upgrade to Pro", action: "upgrade" },
+	},
+	enterprise: {
+		id: "enterprise",
+		name: "Enterprise",
+		description: "For organizations with advanced needs",
+		price: null,
+		limits: {
+			maxUsers: null,
+			maxWorkspaces: null,
+			cloudWorkspaces: true,
+			mobileApp: true,
+		},
+		features: [
+			{ id: "everything-pro", name: "Everything in Pro", included: true },
+			{
+				id: "sso",
+				name: "SSO & advanced security",
+				included: true,
+			},
+			{ id: "audit", name: "Audit logs", included: true },
+			{
+				id: "sla",
+				name: "SLA & dedicated support",
+				included: true,
+			},
+			{ id: "custom", name: "Custom integrations", included: true },
+		],
+		cta: { text: "Contact sales", action: "contact" },
+	},
+};
+
+export interface BillingInfo {
+	organizationId: string;
+	currentPlan: PlanTier;
+	seats: number;
+	usage: {
+		users: number;
+		workspaces: number;
+	};
+	billing?: {
+		stripeCustomerId: string;
+		nextBillingDate: string;
+		amount: number;
+	};
+}
+
+export const MOCK_BILLING_INFO: BillingInfo = {
+	organizationId: "mock-org",
+	currentPlan: "free",
+	seats: 1,
+	usage: {
+		users: 1,
+		workspaces: 3,
+	},
+};

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/page.tsx
@@ -1,0 +1,22 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useMemo } from "react";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
+import { getMatchingItemsForSection } from "../utils/settings-search";
+import { BillingOverview } from "./components/BillingOverview";
+
+export const Route = createFileRoute("/_authenticated/settings/billing/")({
+	component: BillingPage,
+});
+
+function BillingPage() {
+	const searchQuery = useSettingsSearchQuery();
+
+	const visibleItems = useMemo(() => {
+		if (!searchQuery) return null;
+		return getMatchingItemsForSection(searchQuery, "billing").map(
+			(item) => item.id,
+		);
+	}, [searchQuery]);
+
+	return <BillingOverview visibleItems={visibleItems} />;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/plans/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/plans/page.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { PlansComparison } from "../components/PlansComparison";
+
+export const Route = createFileRoute("/_authenticated/settings/billing/plans/")(
+	{
+		component: PlansPage,
+	},
+);
+
+function PlansPage() {
+	return <PlansComparison />;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/GeneralSettings.tsx
@@ -5,6 +5,7 @@ import {
 	HiOutlineBuildingOffice2,
 	HiOutlineCommandLine,
 	HiOutlineComputerDesktop,
+	HiOutlineCreditCard,
 	HiOutlinePaintBrush,
 	HiOutlineSparkles,
 	HiOutlineUser,
@@ -24,7 +25,8 @@ type SettingsRoute =
 	| "/settings/ringtones"
 	| "/settings/keyboard"
 	| "/settings/behavior"
-	| "/settings/terminal";
+	| "/settings/terminal"
+	| "/settings/billing";
 
 const GENERAL_SECTIONS: {
 	id: SettingsRoute;
@@ -79,6 +81,12 @@ const GENERAL_SECTIONS: {
 		section: "terminal",
 		label: "Terminal",
 		icon: <HiOutlineComputerDesktop className="h-4 w-4" />,
+	},
+	{
+		id: "/settings/billing",
+		section: "billing",
+		label: "Billing",
+		icon: <HiOutlineCreditCard className="h-4 w-4" />,
 	},
 ];
 

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -40,6 +40,12 @@ export const SETTING_ITEM_ID = {
 	TERMINAL_SESSIONS: "terminal-sessions",
 	TERMINAL_LINK_BEHAVIOR: "terminal-link-behavior",
 
+	// Billing
+	BILLING_OVERVIEW: "billing-overview",
+	BILLING_PLANS: "billing-plans",
+	BILLING_USAGE: "billing-usage",
+	BILLING_INVOICES: "billing-invoices",
+
 	// Project
 	PROJECT_NAME: "project-name",
 	PROJECT_PATH: "project-path",
@@ -416,6 +422,69 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"cmd",
 			"ctrl",
 			"browser",
+		],
+	},
+
+	// Billing
+	{
+		id: SETTING_ITEM_ID.BILLING_OVERVIEW,
+		section: "billing",
+		title: "Current plan",
+		description: "View your current subscription and usage",
+		keywords: [
+			"billing",
+			"plan",
+			"subscription",
+			"pro",
+			"free",
+			"enterprise",
+			"current",
+			"payment",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.BILLING_PLANS,
+		section: "billing",
+		title: "All plans",
+		description: "Compare and upgrade plans",
+		keywords: [
+			"billing",
+			"upgrade",
+			"pricing",
+			"plans",
+			"pro",
+			"enterprise",
+			"compare",
+			"features",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.BILLING_USAGE,
+		section: "billing",
+		title: "Usage limits",
+		description: "Track workspace and user limits",
+		keywords: [
+			"billing",
+			"usage",
+			"limits",
+			"workspaces",
+			"users",
+			"quota",
+			"seats",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.BILLING_INVOICES,
+		section: "billing",
+		title: "Invoices",
+		description: "View billing history and invoices",
+		keywords: [
+			"billing",
+			"invoices",
+			"payment",
+			"history",
+			"receipts",
+			"transactions",
 		],
 	},
 

--- a/apps/desktop/src/renderer/stores/settings-state.ts
+++ b/apps/desktop/src/renderer/stores/settings-state.ts
@@ -14,6 +14,7 @@ export type SettingsSection =
 	| "keyboard"
 	| "behavior"
 	| "terminal"
+	| "billing"
 	| "project"
 	| "workspace";
 


### PR DESCRIPTION
## Summary
- Add billing settings section with plans overview page
- Create PlansComparison component with Linear-inspired design
- Add feature comparison grid showing Usage, Features, Support, Security sections
- Support monthly/yearly billing toggle for Pro plan pricing
- Include Free ($0), Pro ($20/mo or $180/yr), and Enterprise tiers

## Test plan
- [ ] Navigate to Settings > Billing
- [ ] Click "All plans" to view plans comparison
- [ ] Toggle yearly/monthly billing and verify Pro price changes ($180/yr vs $20/mo)
- [ ] Verify feature matrix displays correctly with checkmarks and values
- [ ] Verify highlighted Pro column has subtle border and background

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Billing section to settings with plan overview dashboard
  * Current plan card displays active plan details and user count
  * Plans comparison page showcasing Free, Pro, and Enterprise tiers with features and pricing
  * Upgrade card for free plan users to view premium options
  * Invoices section for transaction history (placeholder)
  * Billing integration into settings sidebar for easy access

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->