### PR TITLE
fix(desktop): move desktop_opened event to app startup

### DIFF
--- a/apps/desktop/src/renderer/providers/PostHogProvider/PostHogProvider.tsx
+++ b/apps/desktop/src/renderer/providers/PostHogProvider/PostHogProvider.tsx
@@ -12,6 +12,7 @@ export function PostHogProvider({ children }: PostHogProviderProps) {
 
 	useEffect(() => {
 		initPostHog();
+		posthog.capture("desktop_opened");
 		setIsInitialized(true);
 	}, []);
 

--- a/apps/desktop/src/renderer/routes/sign-in/page.tsx
+++ b/apps/desktop/src/renderer/routes/sign-in/page.tsx
@@ -2,7 +2,6 @@ import { type AuthProvider, COMPANY } from "@superset/shared/constants";
 import { Button } from "@superset/ui/button";
 import { Spinner } from "@superset/ui/spinner";
 import { createFileRoute, Navigate } from "@tanstack/react-router";
-import { useEffect } from "react";
 import { FaGithub } from "react-icons/fa";
 import { FcGoogle } from "react-icons/fc";
 import { authClient } from "renderer/lib/auth-client";
@@ -17,10 +16,6 @@ export const Route = createFileRoute("/sign-in/")({
 function SignInPage() {
 	const { data: session, isPending } = authClient.useSession();
 	const signInMutation = electronTrpc.auth.signIn.useMutation();
-
-	useEffect(() => {
-		posthog.capture("desktop_opened");
-	}, []);
 
 	// Show loading while session is being fetched
 	if (isPending) {


### PR DESCRIPTION
## Summary
- Moved `desktop_opened` PostHog event from sign-in page to `PostHogProvider` initialization
- Previously, logged-in users who skip sign-in never triggered this event
- Now fires for all app launches regardless of auth state

## Test plan
- [ ] Open app while logged out → verify `desktop_opened` fires
- [ ] Open app while logged in → verify `desktop_opened` fires (previously didn't)
- [ ] Check PostHog dashboard for events

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted analytics event timing to be captured earlier during application initialization, replacing the previous collection point.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->