### PR TITLE
feat(desktop): add Copy Path option to worktree sidebar context menu

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -24,6 +24,9 @@ import {
 	LuEyeOff,
 	LuFolder,
 	LuFolderGit2,
+	LuFolderOpen,
+	LuPencil,
+	LuX,
 } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
@@ -323,6 +326,7 @@ export function WorkspaceListItem({
 							</ContextMenuItem>
 							<ContextMenuSeparator />
 							<ContextMenuItem onSelect={() => handleDeleteClick()}>
+								<LuX className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />
 								Close Worktree
 							</ContextMenuItem>
 						</ContextMenuContent>
@@ -555,6 +559,10 @@ export function WorkspaceListItem({
 					<ContextMenuTrigger asChild>{content}</ContextMenuTrigger>
 					<ContextMenuContent>
 						<ContextMenuItem onSelect={handleOpenInFinder}>
+							<LuFolderOpen
+								className="size-4 mr-2"
+								strokeWidth={STROKE_WIDTH}
+							/>
 							Open in Finder
 						</ContextMenuItem>
 						<ContextMenuItem onSelect={handleCopyPath}>
@@ -588,10 +596,15 @@ export function WorkspaceListItem({
 					</HoverCardTrigger>
 					<ContextMenuContent>
 						<ContextMenuItem onSelect={rename.startRename}>
+							<LuPencil className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />
 							Rename
 						</ContextMenuItem>
 						<ContextMenuSeparator />
 						<ContextMenuItem onSelect={handleOpenInFinder}>
+							<LuFolderOpen
+								className="size-4 mr-2"
+								strokeWidth={STROKE_WIDTH}
+							/>
 							Open in Finder
 						</ContextMenuItem>
 						<ContextMenuItem onSelect={handleCopyPath}>


### PR DESCRIPTION
## Summary
- Adds a new "Copy Path" context menu option to the worktree sidebar
- Copies the workspace path to clipboard when clicked
- Shows a toast notification on success/failure
- Available in all context menus: expanded worktree, collapsed worktree, and branch workspace views

## Test plan
- [ ] Right-click on a worktree in the expanded sidebar and verify "Copy Path" option appears
- [ ] Click "Copy Path" and verify the path is copied to clipboard with success toast
- [ ] Right-click on a worktree in the collapsed sidebar and verify "Copy Path" option appears
- [ ] Right-click on a branch workspace and verify "Copy Path" option appears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Copy Path" to workspace context menus (collapsed hover, branch workspace, and main content), letting users copy workspace paths to the clipboard. Toast notifications report success or failure of each copy operation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->