### PR TITLE
fix(desktop): replace useActiveOrganization with collections data

### DIFF
--- a/packages/auth/src/lib/accept-invitation-endpoint.ts
+++ b/packages/auth/src/lib/accept-invitation-endpoint.ts
@@ -71,8 +71,7 @@ export const acceptInvitationEndpoint = {
 				});
 
 				if (!user) {
-					const userName =
-						invitation.name || invitation.email.split("@")[0] || "User";
+					const userName = invitation.email;
 					const [newUser] = await db
 						.insert(users)
 						.values({

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -135,7 +135,6 @@ export const invitations = authSchema.table(
 			.notNull()
 			.references(() => organizations.id, { onDelete: "cascade" }),
 		email: text("email").notNull(),
-		name: text("name"),
 		role: text("role"),
 		status: text("status").default("pending").notNull(),
 		expiresAt: timestamp("expires_at").notNull(),

--- a/packages/trpc/src/router/organization/organization.ts
+++ b/packages/trpc/src/router/organization/organization.ts
@@ -75,7 +75,6 @@ export const organizationRouter = {
 		return {
 			id: invitation.id,
 			email: invitation.email,
-			name: invitation.name,
 			role: invitation.role,
 			status: invitation.status,
 			expiresAt: invitation.expiresAt,


### PR DESCRIPTION
## Summary
- Remove unused `name` field from invitations schema (was causing Better Auth query failures)
- Replace `useActiveOrganization()` with collections data in MembersSettings
- Use email directly for new user name when accepting invitations

## Test plan
- [x] Verify members settings page loads without errors
- [x] Verify pending invitations section shows correctly
- [x] Verify invite member dialog works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactoring**
  * Updated user account creation during invitation acceptance to use email-based naming.
  * Removed name field from invitations throughout the system and API responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->