### PR TITLE
fix(desktop): register Sentry IPC protocol for custom session partition

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -97,7 +97,7 @@ export default defineConfig({
 		plugins: [
 			tsconfigPaths,
 			externalizeDepsPlugin({
-				exclude: ["trpc-electron"],
+				exclude: ["trpc-electron", "@sentry/electron"],
 			}),
 		],
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,7 +1,3 @@
-import { initSentry } from "./lib/sentry";
-
-initSentry();
-
 import path from "node:path";
 import { settings } from "@superset/local-db";
 import { app, BrowserWindow, dialog } from "electron";
@@ -15,6 +11,7 @@ import { setupAgentHooks } from "./lib/agent-setup";
 import { initAppState } from "./lib/app-state";
 import { setupAutoUpdater } from "./lib/auto-updater";
 import { localDb } from "./lib/local-db";
+import { initSentry } from "./lib/sentry";
 import {
 	reconcileDaemonSessions,
 	shutdownOrphanedDaemon,
@@ -215,6 +212,8 @@ if (!gotTheLock) {
 
 	(async () => {
 		await app.whenReady();
+
+		initSentry();
 
 		await initAppState();
 

--- a/apps/desktop/src/main/lib/sentry.ts
+++ b/apps/desktop/src/main/lib/sentry.ts
@@ -1,8 +1,11 @@
+import * as Sentry from "@sentry/electron/main";
+import { IPCMode } from "@sentry/electron/main";
+import { session } from "electron";
 import { env } from "../env.main";
 
 let sentryInitialized = false;
 
-export async function initSentry(): Promise<void> {
+export function initSentry(): void {
 	if (sentryInitialized) return;
 
 	if (!env.SENTRY_DSN_DESKTOP || env.NODE_ENV !== "production") {
@@ -10,19 +13,21 @@ export async function initSentry(): Promise<void> {
 	}
 
 	try {
-		// Dynamic import to avoid bundler issues
-		const Sentry = await import("@sentry/electron/main");
-
 		Sentry.init({
 			dsn: env.SENTRY_DSN_DESKTOP,
 			environment: env.NODE_ENV,
 			tracesSampleRate: 0.1,
 			sendDefaultPii: false,
+			ipcMode: IPCMode.Classic,
+			getSessions: () => [
+				session.defaultSession,
+				session.fromPartition("persist:superset"),
+			],
 		});
 
 		sentryInitialized = true;
 		console.log("[sentry] Initialized in main process");
 	} catch (error) {
-		console.error("[sentry] Failed to initialize:", error);
+		console.error("[sentry] Failed to initialize in main:", error);
 	}
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,3 +1,5 @@
+import "@sentry/electron/preload";
+
 import { contextBridge, ipcRenderer, webUtils } from "electron";
 import { exposeElectronTRPC } from "trpc-electron/main";
 


### PR DESCRIPTION
## Summary
- Fixes `net::ERR_UNKNOWN_URL_SCHEME` errors for `sentry-ipc://` in production
- The renderer uses a custom session partition (`persist:superset`) for isolation, but Sentry only registers its IPC protocol handler for `session.defaultSession` by default
- Added `getSessions` option to include the custom partition
- Moved `initSentry()` after `app.whenReady()` since `session.fromPartition()` requires the app to be ready

## Test plan
- [ ] Deploy to staging and verify Sentry errors are no longer appearing
- [ ] Check Sentry dashboard for successful event delivery from desktop app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Desktop startup now initializes error reporting after the app is ready and uses a more compatible renderer communication mode.
  * Preload and build configuration updated so the error-reporting integration is consistently included at startup.

* **Bug Fixes**
  * Improved reliability of error reporting during startup, with clearer diagnostics when initialization fails.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->