### PR TITLE
fix(api): use authenticated user ID for organizations Electric sync

### DIFF
--- a/apps/api/src/app/api/electric/[...path]/route.ts
+++ b/apps/api/src/app/api/electric/[...path]/route.ts
@@ -31,7 +31,11 @@ export async function GET(request: Request): Promise<Response> {
 		return new Response("Missing table parameter", { status: 400 });
 	}
 
-	const whereClause = await buildWhereClause(tableName, organizationId);
+	const whereClause = await buildWhereClause(
+		tableName,
+		organizationId,
+		sessionData.user.id,
+	);
 	if (!whereClause) {
 		return new Response(`Unknown table: ${tableName}`, { status: 400 });
 	}


### PR DESCRIPTION
## Summary
- Fixed bug where Electric proxy used a random member from the active org to determine which organizations to sync
- Now correctly uses the authenticated user's ID to query their actual memberships
- This was causing users in shared orgs to see incorrect organization lists

## Test plan
- [x] Lint passes
- [x] Typecheck passes  
- [x] Tests pass (1114 pass, 0 fail)
- [x] Verified fix with Kiet's account - he can now see both orgs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced data filtering to ensure proper user access scoping
* **Chores**
  * Optimized user membership lookup and retrieval process

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->