### PR TITLE
feat(web): add organization switcher to avatar dropdown

### DIFF
--- a/apps/web/src/app/(dashboard)/components/Header/Header.tsx
+++ b/apps/web/src/app/(dashboard)/components/Header/Header.tsx
@@ -87,7 +87,7 @@ export function Header() {
 						<DropdownMenuSeparator />
 						{organizations && organizations.length === 1 && (
 							<>
-								<DropdownMenuItem disabled className="opacity-100">
+								<div className="flex items-center px-2 py-1.5 text-sm">
 									<Avatar className="mr-2 size-4">
 										<AvatarFallback className="text-[8px]">
 											{activeOrganization?.name?.charAt(0) ?? "O"}
@@ -96,7 +96,7 @@ export function Header() {
 									<span className="truncate">
 										{activeOrganization?.name ?? "Organization"}
 									</span>
-								</DropdownMenuItem>
+								</div>
 								<DropdownMenuSeparator />
 							</>
 						)}


### PR DESCRIPTION
## Summary
- Add organization switcher submenu to the header avatar dropdown in the web app
- Fetches user's organizations via tRPC `user.myOrganizations` query
- Only displays the switcher when user belongs to multiple organizations
- Switches active organization using `authClient.organization.setActive()` and refreshes the page

## Test plan
- [ ] Log in with a user that belongs to multiple organizations
- [ ] Click on the avatar in the header to open the dropdown
- [ ] Verify the organization switcher submenu appears
- [ ] Click on a different organization and verify it switches
- [ ] Log in with a user that belongs to only one organization
- [ ] Verify the organization switcher submenu does NOT appear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the header dropdown to support organization switching. Users with multiple organizations can now easily switch between them using a dedicated submenu where the active organization is highlighted with a check icon. Single-organization users see a compact display showing the organization name and avatar.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->