### PR TITLE
fix(desktop): ensure Electron quits when dev server stops

### DIFF
--- a/apps/desktop/src/main/lib/data-batcher.ts
+++ b/apps/desktop/src/main/lib/data-batcher.ts
@@ -47,6 +47,8 @@ export class DataBatcher {
 		// Schedule flush if not already scheduled
 		if (this.timeout === null) {
 			this.timeout = setTimeout(() => this.flush(), BATCH_DURATION_MS);
+			// Don't keep Electron alive just for terminal data batching
+			this.timeout.unref();
 		}
 	}
 

--- a/apps/desktop/src/main/lib/static-ports/watcher.ts
+++ b/apps/desktop/src/main/lib/static-ports/watcher.ts
@@ -110,10 +110,13 @@ class StaticPortsWatcher extends EventEmitter {
 						this.watch(workspaceId, worktreePath);
 					}
 				}, 100);
+				timer.unref();
 
 				this.debounceTimers.set(workspaceId, timer);
 			});
 
+			// Don't keep Electron alive just for file watching
+			watcher.unref();
 			this.watchers.set(workspaceId, watcher);
 		} catch (error) {
 			console.error(

--- a/apps/desktop/src/main/lib/terminal-host/client.ts
+++ b/apps/desktop/src/main/lib/terminal-host/client.ts
@@ -449,6 +449,8 @@ export class TerminalHostClient extends EventEmitter {
 					resolved = true;
 					clearTimeout(timeout);
 					this.controlSocket = socket;
+					// Don't keep Electron alive just for daemon connection
+					socket.unref();
 					this.setupControlSocketHandlers();
 					resolve(true);
 				}
@@ -496,6 +498,8 @@ export class TerminalHostClient extends EventEmitter {
 						this.handleDisconnect();
 					});
 					this.streamSocket = socket;
+					// Don't keep Electron alive just for daemon connection
+					socket.unref();
 					resolve(true);
 				}
 			});

--- a/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts
+++ b/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts
@@ -166,6 +166,7 @@ export class DaemonTerminalManager extends EventEmitter {
 					this.sessions.delete(paneId);
 					this.cleanupTimeouts.delete(paneId);
 				}, SESSION_CLEANUP_DELAY_MS);
+				timeoutId.unref();
 				this.cleanupTimeouts.set(paneId, timeoutId);
 			},
 		);

--- a/apps/desktop/src/main/lib/terminal/port-manager.ts
+++ b/apps/desktop/src/main/lib/terminal/port-manager.ts
@@ -125,6 +125,8 @@ class PortManager extends EventEmitter {
 			this.pendingHintScans.delete(paneId);
 			this.scanPane(paneId).catch(() => {});
 		}, HINT_SCAN_DELAY_MS);
+		// Don't keep Electron alive just for port scanning
+		timeout.unref();
 
 		this.pendingHintScans.set(paneId, timeout);
 	}

--- a/apps/desktop/src/main/lib/tray/index.ts
+++ b/apps/desktop/src/main/lib/tray/index.ts
@@ -341,6 +341,8 @@ export function initTray(): void {
 				console.error("[Tray] Failed to update menu:", error);
 			});
 		}, POLL_INTERVAL_MS);
+		// Don't keep Electron alive just for tray updates
+		pollIntervalId.unref();
 
 		console.log("[Tray] Initialized successfully");
 	} catch (error) {

--- a/apps/desktop/src/main/lib/workspace-init-manager.ts
+++ b/apps/desktop/src/main/lib/workspace-init-manager.ts
@@ -133,11 +133,12 @@ class WorkspaceInitManager extends EventEmitter {
 
 		// Clean up ready jobs after a delay
 		if (step === "ready") {
-			setTimeout(() => {
+			const timer = setTimeout(() => {
 				if (this.jobs.get(workspaceId)?.progress.step === "ready") {
 					this.jobs.delete(workspaceId);
 				}
 			}, 2000);
+			timer.unref();
 		}
 	}
 

--- a/bun.lock
+++ b/bun.lock
@@ -338,11 +338,19 @@
       "version": "1.0.0",
       "dependencies": {
         "@better-auth/expo": "1.4.16",
+        "@electric-sql/client": "https://pkg.pr.new/@electric-sql/client@3724",
         "@react-navigation/native": "^7.1.28",
         "@rn-primitives/portal": "^1.3.0",
         "@rn-primitives/slot": "^1.2.0",
         "@rn-primitives/switch": "^1.2.0",
+        "@superset/db": "workspace:*",
+        "@superset/trpc": "workspace:*",
+        "@tanstack/db": "0.5.22",
+        "@tanstack/electric-db-collection": "0.2.27",
+        "@tanstack/react-db": "0.1.66",
         "@tanstack/react-query": "^5.90.19",
+        "@trpc/client": "^11.7.1",
+        "@trpc/react-query": "^11.7.1",
         "better-auth": "1.4.16",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -360,11 +368,13 @@
         "lucide-react-native": "^0.562.0",
         "react": "19.1.0",
         "react-native": "0.81.5",
+        "react-native-get-random-values": "^1.11.0",
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "^4.16.0",
         "react-native-svg": "^15.12.1",
         "react-native-worklets": "~0.5.0",
+        "superjson": "^2.2.5",
         "tailwind-merge": "^3.4.0",
         "tailwindcss": "^4.1.18",
         "tailwindcss-animate": "^1.0.7",
@@ -2839,6 +2849,8 @@
 
     "extsprintf": ["extsprintf@1.4.1", "", {}, "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA=="],
 
+    "fast-base64-decode": ["fast-base64-decode@1.0.0", "", {}, "sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q=="],
+
     "fast-content-type-parse": ["fast-content-type-parse@3.0.0", "", {}, "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
@@ -3904,6 +3916,8 @@
     "react-mosaic-component": ["react-mosaic-component@6.1.1", "", { "dependencies": { "classnames": "^2.3.2", "immutability-helper": "^3.1.1", "lodash": "^4.17.21", "prop-types": "^15.8.1", "rdndmb-html5-to-touch": "^8.0.0", "react-dnd": "^16.0.1", "react-dnd-html5-backend": "^16.0.1", "react-dnd-multi-backend": "^8.0.0", "react-dnd-touch-backend": "^16.0.1", "uuid": "^9.0.0" }, "peerDependencies": { "react": ">=16" } }, "sha512-Ivuj6AxRDlo/H8OiEDU1mdgivxuKbwGOa5Ub6Yf+bHcu0JWioT7ttlpCWF63/gKrJBlRMB6fW9/eNOXINg9+Gg=="],
 
     "react-native": ["react-native@0.81.5", "", { "dependencies": { "@jest/create-cache-key-function": "^29.7.0", "@react-native/assets-registry": "0.81.5", "@react-native/codegen": "0.81.5", "@react-native/community-cli-plugin": "0.81.5", "@react-native/gradle-plugin": "0.81.5", "@react-native/js-polyfills": "0.81.5", "@react-native/normalize-colors": "0.81.5", "@react-native/virtualized-lists": "0.81.5", "abort-controller": "^3.0.0", "anser": "^1.4.9", "ansi-regex": "^5.0.0", "babel-jest": "^29.7.0", "babel-plugin-syntax-hermes-parser": "0.29.1", "base64-js": "^1.5.1", "commander": "^12.0.0", "flow-enums-runtime": "^0.0.6", "glob": "^7.1.1", "invariant": "^2.2.4", "jest-environment-node": "^29.7.0", "memoize-one": "^5.0.0", "metro-runtime": "^0.83.1", "metro-source-map": "^0.83.1", "nullthrows": "^1.1.1", "pretty-format": "^29.7.0", "promise": "^8.3.0", "react-devtools-core": "^6.1.5", "react-refresh": "^0.14.0", "regenerator-runtime": "^0.13.2", "scheduler": "0.26.0", "semver": "^7.1.3", "stacktrace-parser": "^0.1.10", "whatwg-fetch": "^3.0.0", "ws": "^6.2.3", "yargs": "^17.6.2" }, "peerDependencies": { "@types/react": "^19.1.0", "react": "^19.1.0" }, "optionalPeers": ["@types/react"], "bin": { "react-native": "cli.js" } }, "sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw=="],
+
+    "react-native-get-random-values": ["react-native-get-random-values@1.11.0", "", { "dependencies": { "fast-base64-decode": "^1.0.0" }, "peerDependencies": { "react-native": ">=0.56" } }, "sha512-4BTbDbRmS7iPdhYLRcz3PGFIpFJBwNZg9g42iwa2P6FOv9vZj/xJc678RZXnLNZzd0qd7Q3CCF6Yd+CU2eoXKQ=="],
 
     "react-native-is-edge-to-edge": ["react-native-is-edge-to-edge@1.2.1", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q=="],
 


### PR DESCRIPTION
## Summary

- Fixes Electron staying open when dev server is stopped (Ctrl+C)
- Simplifies quit handling by removing complex state machine
- Adds parent process monitoring as reliable quit mechanism in dev mode

## Problem

When running `bun dev` and pressing Ctrl+C, the Electron app would remain open because:
1. electron-vite doesn't reliably propagate SIGINT/SIGTERM to child Electron process
2. The `before-quit` handler had async cleanup (`terminal.cleanup()`, `posthog.shutdown()`) that could hang

## Solution

1. **Parent process monitoring** (dev mode only): Poll every 1s to check if electron-vite is still running, quit if it dies
2. **SIGINT/SIGTERM handlers**: Defense in depth for signal propagation
3. **Simplified quit handling**: Remove state machine, use `app.exit(0)` instead of `app.quit()` to bypass hanging async cleanup
4. **`.unref()` on background timers**: Prevent timers/sockets from blocking exit

## Test plan

- [x] Run `bun dev` in desktop app
- [x] Wait for app to load
- [x] Press Ctrl+C
- [x] Verify Electron quits (should see `[main] Parent process exited, quitting...`)
- [x] Typecheck passes
- [x] Tests pass (603 pass, 0 fail)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed application hanging during shutdown in development mode
  * Streamlined quit confirmation flow for more reliable application exit

* **Performance**
  * Optimized process resource cleanup to ensure faster shutdown

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->