### PR TITLE
fix(web): allow Vercel Blob storage images in Next.js Image component to have Org logos show up properly

### DIFF
--- a/apps/admin/next.config.ts
+++ b/apps/admin/next.config.ts
@@ -12,6 +12,15 @@ const config: NextConfig = {
 	reactCompiler: true,
 	typescript: { ignoreBuildErrors: true },
 
+	images: {
+		remotePatterns: [
+			{
+				protocol: "https",
+				hostname: "*.public.blob.vercel-storage.com",
+			},
+		],
+	},
+
 	async rewrites() {
 		return [
 			{

--- a/apps/api/next.config.ts
+++ b/apps/api/next.config.ts
@@ -10,6 +10,15 @@ if (process.env.NODE_ENV !== "production") {
 const config: NextConfig = {
 	reactCompiler: true,
 	typescript: { ignoreBuildErrors: true },
+
+	images: {
+		remotePatterns: [
+			{
+				protocol: "https",
+				hostname: "*.public.blob.vercel-storage.com",
+			},
+		],
+	},
 };
 
 export default withSentryConfig(config, {

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -6,6 +6,14 @@ const withMDX = createMDX();
 /** @type {import('next').NextConfig} */
 const config = {
 	reactStrictMode: true,
+	images: {
+		remotePatterns: [
+			{
+				protocol: "https",
+				hostname: "*.public.blob.vercel-storage.com",
+			},
+		],
+	},
 	async redirects() {
 		return [
 			{

--- a/apps/marketing/next.config.ts
+++ b/apps/marketing/next.config.ts
@@ -13,6 +13,15 @@ const config: NextConfig = {
 	reactCompiler: true,
 	typescript: { ignoreBuildErrors: true },
 
+	images: {
+		remotePatterns: [
+			{
+				protocol: "https",
+				hostname: "*.public.blob.vercel-storage.com",
+			},
+		],
+	},
+
 	async rewrites() {
 		return [
 			{

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -12,6 +12,15 @@ const config: NextConfig = {
 	reactCompiler: true,
 	typescript: { ignoreBuildErrors: true },
 
+	images: {
+		remotePatterns: [
+			{
+				protocol: "https",
+				hostname: "*.public.blob.vercel-storage.com",
+			},
+		],
+	},
+
 	async rewrites() {
 		return [
 			{


### PR DESCRIPTION
## Summary
- Add `images.remotePatterns` config to all Next.js apps (web, admin, api, docs, marketing)
- Allows image optimization for files hosted on `*.public.blob.vercel-storage.com`
- Fixes 400 `INVALID_IMAGE_OPTIMIZE_REQUEST` errors when loading organization logos on invite accept page

## Test plan
- [x] Verified fix locally on invite accept page at `http://localhost:3000/accept-invitation/...`
- [ ] Organization logos should now display correctly on all Next.js apps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Next.js image configuration across all applications (admin, API, documentation, marketing, and web) to enable remote image loading from cloud storage services. This enhancement allows each application to seamlessly load and display images from cloud-based storage resources, improving flexibility in image management and delivery across the platform.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->