### PR TITLE
fix(desktop): center workspace initializing view horizontally

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceInitializingView/WorkspaceInitializingView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceInitializingView/WorkspaceInitializingView.tsx
@@ -89,7 +89,7 @@ export function WorkspaceInitializingView({
 	if (isInterrupted && !progress && showInterruptedUI) {
 		return (
 			<>
-				<div className="flex flex-col items-center justify-center h-full px-8">
+				<div className="flex flex-col items-center justify-center h-full w-full px-8">
 					<div className="flex flex-col items-center max-w-sm text-center space-y-6">
 						{/* Icon */}
 						<div className="flex items-center justify-center size-16 rounded-full bg-muted">
@@ -180,7 +180,7 @@ export function WorkspaceInitializingView({
 	if (hasFailed) {
 		return (
 			<>
-				<div className="flex flex-col items-center justify-center h-full px-8">
+				<div className="flex flex-col items-center justify-center h-full w-full px-8">
 					<div className="flex flex-col items-center max-w-sm text-center space-y-6">
 						{/* Error icon */}
 						<div className="flex items-center justify-center size-16 rounded-full bg-destructive/10">
@@ -271,7 +271,7 @@ export function WorkspaceInitializingView({
 
 	// Initializing state
 	return (
-		<div className="flex flex-col items-center justify-center h-full px-8">
+		<div className="flex flex-col items-center justify-center h-full w-full px-8">
 			<div className="flex flex-col items-center max-w-sm text-center space-y-6">
 				{/* Icon with pulse animation */}
 				<div className="relative">


### PR DESCRIPTION
## Summary
- Add `w-full` to root container divs in WorkspaceInitializingView
- Fixes horizontal centering in all three states: interrupted, failed, and initializing

## Test plan
- [ ] Create a new workspace and verify the "Setting up workspace" view is centered
- [ ] Verify interrupted state is centered (if applicable)
- [ ] Verify failed state is centered (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Expanded the workspace initializing view to span full available width across different screen states.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->