### PR TITLE
fix(desktop): always show close all ports button in sidebar

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/components/WorkspacePortGroup/WorkspacePortGroup.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/components/WorkspacePortGroup/WorkspacePortGroup.tsx
@@ -41,7 +41,7 @@ export function WorkspacePortGroup({ group }: WorkspacePortGroupProps) {
 							<button
 								type="button"
 								onClick={handleCloseAll}
-								className="ml-auto opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-muted/50 transition-opacity text-muted-foreground hover:text-primary"
+								className="ml-auto p-0.5 rounded hover:bg-muted/50 text-muted-foreground hover:text-primary"
 							>
 								<LuX className="size-3" strokeWidth={STROKE_WIDTH} />
 							</button>


### PR DESCRIPTION
## Summary
- Makes the "close all ports" button always visible in the workspace sidebar ports list
- Removes hover-only visibility (`opacity-0 group-hover:opacity-100`) so users can see and access the button immediately

## Test plan
- [ ] Open a workspace with active ports
- [ ] Verify the close all ports (X) button is visible without hovering
- [ ] Verify clicking the button still closes all ports for that workspace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Close button in workspace port group is now permanently visible instead of appearing only on hover, improving accessibility and discoverability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->