### PR TITLE
fix(desktop): clear sidebar drop zone overlay when drag ends elsewhere

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/SidebarDropZone/SidebarDropZone.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/SidebarDropZone/SidebarDropZone.tsx
@@ -36,6 +36,25 @@ export function SidebarDropZone({ children, className }: SidebarDropZoneProps) {
 		return () => clearTimeout(timer);
 	}, [error]);
 
+	// Clear drag state when drag ends anywhere (e.g., drop outside this component)
+	useEffect(() => {
+		const handleWindowDragEnd = () => {
+			setIsDragOver(false);
+		};
+
+		const handleWindowDrop = () => {
+			setIsDragOver(false);
+		};
+
+		window.addEventListener("dragend", handleWindowDragEnd);
+		window.addEventListener("drop", handleWindowDrop);
+
+		return () => {
+			window.removeEventListener("dragend", handleWindowDragEnd);
+			window.removeEventListener("drop", handleWindowDrop);
+		};
+	}, []);
+
 	const handleDragOver = useCallback((e: React.DragEvent) => {
 		e.preventDefault();
 		e.stopPropagation();


### PR DESCRIPTION
## Summary
- Fixes the "Drop to add project" overlay getting stuck when dragging images into Claude chat
- Adds window-level `dragend` and `drop` event listeners to ensure the overlay clears when drag ends outside the component

Fixes #885

## Test plan
- [ ] Drag an image file from Finder over the sidebar (overlay should appear)
- [ ] Drop the image into the Claude chat area
- [ ] Verify the sidebar overlay dismisses correctly
- [ ] Drag an image and press Escape to cancel - overlay should dismiss
- [ ] Drag a folder and drop on sidebar - should still work as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag-and-drop behavior in the workspace sidebar. The application now properly clears drag state when dragging ends or when drops occur anywhere in the window, with appropriate event listener cleanup. This fixes visual inconsistencies and provides a more reliable drag-and-drop experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->