### PR TITLE
feat(desktop): add cloud workspace option placeholder

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -435,9 +435,7 @@ export function NewWorkspaceModal() {
 									<div className="text-sm font-medium text-foreground mb-1">
 										Cloud Workspaces
 									</div>
-									<p className="text-xs text-muted-foreground">
-										Coming soon
-									</p>
+									<p className="text-xs text-muted-foreground">Coming soon</p>
 								</div>
 							)}
 						</div>

--- a/apps/web/src/app/(dashboard)/integrations/components/IntegrationCard/IntegrationCard.tsx
+++ b/apps/web/src/app/(dashboard)/integrations/components/IntegrationCard/IntegrationCard.tsx
@@ -92,7 +92,7 @@ export function IntegrationCard({
 			</div>
 
 			{/* Bottom: Description */}
-			<div className="relative z-10 h-[2.6em] w-full text-sm leading-[1.3em] text-muted-foreground">
+			<div className="relative z-10 h-[2.6em] w-full text-sm leading-[1.3em] text-foreground/80">
 				{description}
 			</div>
 		</div>

--- a/apps/web/src/app/(dashboard)/integrations/page.tsx
+++ b/apps/web/src/app/(dashboard)/integrations/page.tsx
@@ -21,7 +21,7 @@ const integrations: IntegrationCardProps[] = [
 		name: "GitHub",
 		description: "Connect repos and sync pull requests.",
 		category: "Version Control",
-		accentColor: "#FFFFFF",
+		accentColor: "#238636",
 		icon: <FaGithub className="size-8" />,
 	},
 ];


### PR DESCRIPTION
## Summary
- Add a "Cloud" tab to the workspace creation modal
- Show placeholder content ("Coming soon") when Cloud tab is selected
- Prepares UI for future cloud workspace functionality

## Test plan
- [ ] Open the workspace creation modal
- [ ] Verify the "Cloud" tab appears alongside "New" and "Existing" tabs
- [ ] Click on the Cloud tab and verify placeholder text is shown
- [ ] Verify other tabs (New, Existing) still function correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a new "Cloud" tab to the workspace creation modal for accessing cloud workspace options
* Introduced a "Cloud Workspaces" section with "Coming soon" messaging

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->