### PR TITLE
fix(terminal): sync PTY dimensions after restore to prevent autocomplete issues

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -189,6 +189,7 @@ export const Terminal = ({ tabId, workspaceId }: TerminalProps) => {
 		onErrorEvent: (event, xterm) => handleStreamErrorRef.current(event, xterm),
 		onDisconnectEvent: (reason) =>
 			setConnectionError(reason || "Connection to terminal daemon lost"),
+		onResize: (cols, rows) => resizeRef.current({ paneId, cols, rows }),
 	});
 
 	// Cold restore handling


### PR DESCRIPTION
## Problem

Terminal autocomplete from zsh was overwriting lines and there were positioning issues when reattaching terminals.

## Root Cause

When a terminal was attached/restored, `createOrAttach` was called with dimensions from an initial `fitAddon.fit()` that ran before the container was fully laid out by CSS. This resulted in wrong dimensions (e.g., 70 cols) being sent to the PTY. 

After the terminal rendered, the ResizeObserver would eventually send the correct dimensions (e.g., 74 cols), but there was a ~140ms window where the PTY had incorrect dimensions. During this window, shell operations (prompts, autocomplete) would use wrong column counts, causing line wrapping issues.

## Fix

Added an immediate resize call in `scheduleFitAndScroll` (in `useTerminalRestore.ts`) that sends the correct dimensions to the PTY right after `fitAddon.fit()` completes during restore. This ensures the PTY dimensions are synced with xterm.js dimensions before any user interaction can occur.

## Changes

- Add `onResize` callback parameter to the `useTerminalRestore` hook
- Call `onResize` after `fitAddon.fit()` in `scheduleFitAndScroll`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal restoration to synchronize terminal dimensions during session restore, preventing size/layout mismatches.
  * Maintains user scroll position for reattached sessions while ensuring new sessions scroll to the bottom after restoration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->