### PR TITLE
fix(desktop): clear auth token from memory on sign-out

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/auth/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/auth/index.ts
@@ -38,14 +38,20 @@ export const createAuthRouter = () => {
 					}
 				});
 
-				const handler = (data: { token: string; expiresAt: string }) => {
+				const handleSaved = (data: { token: string; expiresAt: string }) => {
 					emit.next(data);
 				};
 
-				authEvents.on("token-saved", handler);
+				const handleCleared = () => {
+					emit.next(null);
+				};
+
+				authEvents.on("token-saved", handleSaved);
+				authEvents.on("token-cleared", handleCleared);
 
 				return () => {
-					authEvents.off("token-saved", handler);
+					authEvents.off("token-saved", handleSaved);
+					authEvents.off("token-cleared", handleCleared);
 				};
 			});
 		}),
@@ -85,6 +91,7 @@ export const createAuthRouter = () => {
 
 		signOut: publicProcedure.mutation(async () => {
 			await fs.unlink(TOKEN_FILE).catch(() => {});
+			authEvents.emit("token-cleared");
 			return { success: true };
 		}),
 	});

--- a/apps/desktop/src/renderer/providers/AuthProvider/AuthProvider.tsx
+++ b/apps/desktop/src/renderer/providers/AuthProvider/AuthProvider.tsx
@@ -39,12 +39,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 		setIsHydrated(true);
 	}, [storedToken, isSuccess, isHydrated, refetchSession]);
 
-	// Listen for token changes from main process (OAuth callback)
+	// Listen for token changes from main process (OAuth callback or sign-out)
 	electronTrpc.auth.onTokenChanged.useSubscription(undefined, {
 		onData: (data) => {
 			if (data?.token && data?.expiresAt) {
 				setAuthToken(data.token);
 				setIsHydrated(true);
+				refetchSession();
+			} else if (data === null) {
+				// Token was cleared (sign-out)
+				setAuthToken(null);
 				refetchSession();
 			}
 		},


### PR DESCRIPTION
## Summary
- Fixes auth issue when switching worktrees/databases where the old token remained in memory after sign-out
- Sign-out now emits `token-cleared` event which clears the in-memory token via subscription

## Test plan
- [ ] Sign in to desktop app
- [ ] Sign out
- [ ] Verify session is null (not stale token)
- [ ] Re-auth with different database
- [ ] Verify new token is used