### PR TITLE
feat(desktop): implement cloud workspace type with UI and creation flow

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/query.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/query.ts
@@ -107,7 +107,7 @@ export const createQueryProcedures = () => {
 
 				return {
 					...workspace,
-					type: workspace.type as "worktree" | "branch",
+					type: workspace.type as "worktree" | "branch" | "cloud",
 					worktreePath: getWorkspacePath(workspace) ?? "",
 					project: project
 						? {
@@ -165,7 +165,7 @@ export const createQueryProcedures = () => {
 						projectId: string;
 						worktreeId: string | null;
 						worktreePath: string;
-						type: "worktree" | "branch";
+						type: "worktree" | "branch" | "cloud";
 						branch: string;
 						name: string;
 						tabOrder: number;
@@ -206,13 +206,16 @@ export const createQueryProcedures = () => {
 					let worktreePath = "";
 					if (workspace.type === "worktree" && workspace.worktreeId) {
 						worktreePath = worktreePathMap.get(workspace.worktreeId) ?? "";
-					} else if (workspace.type === "branch") {
+					} else if (
+						workspace.type === "branch" ||
+						workspace.type === "cloud"
+					) {
 						worktreePath = group.project.mainRepoPath;
 					}
 
 					group.workspaces.push({
 						...workspace,
-						type: workspace.type as "worktree" | "branch",
+						type: workspace.type as "worktree" | "branch" | "cloud",
 						worktreePath,
 						isUnread: workspace.isUnread ?? false,
 					});

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/worktree.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/worktree.ts
@@ -17,10 +17,10 @@ export function getWorktreePath(worktreeId: string): string | undefined {
 /**
  * Gets the working directory path for a workspace.
  * For worktree workspaces: returns the worktree path
- * For branch workspaces: returns the main repo path
+ * For branch/cloud workspaces: returns the main repo path
  */
 export function getWorkspacePath(workspace: SelectWorkspace): string | null {
-	if (workspace.type === "branch") {
+	if (workspace.type === "branch" || workspace.type === "cloud") {
 		const project = localDb
 			.select()
 			.from(projects)

--- a/apps/desktop/src/renderer/screens/main/components/TopBar/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/TopBar/index.tsx
@@ -1,4 +1,6 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useParams } from "@tanstack/react-router";
+import { LuCloud } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { OpenInMenuButton } from "./OpenInMenuButton";
 import { OrganizationDropdown } from "./OrganizationDropdown";
@@ -13,6 +15,7 @@ export function TopBar() {
 	);
 	// Default to Mac layout while loading to avoid overlap with traffic lights
 	const isMac = platform === undefined || platform === "darwin";
+	const isCloudWorkspace = workspace?.type === "cloud";
 
 	return (
 		<div className="drag gap-2 h-12 w-full flex items-center justify-between bg-background border-b border-border">
@@ -21,7 +24,21 @@ export function TopBar() {
 				style={{
 					paddingLeft: isMac ? "88px" : "16px",
 				}}
-			/>
+			>
+				{isCloudWorkspace && (
+					<Tooltip delayDuration={300}>
+						<TooltipTrigger asChild>
+							<div className="no-drag flex items-center gap-1.5 px-2 py-1 rounded-md bg-primary/10 text-primary text-xs font-medium">
+								<LuCloud className="size-3.5" />
+								<span>Cloud</span>
+							</div>
+						</TooltipTrigger>
+						<TooltipContent side="bottom">
+							<p className="text-xs">Cloud workspace - hosted remotely</p>
+						</TooltipContent>
+					</Tooltip>
+				)}
+			</div>
 
 			<div className="flex-1" />
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectSection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectSection.tsx
@@ -15,7 +15,7 @@ interface Workspace {
 	id: string;
 	projectId: string;
 	worktreePath: string;
-	type: "worktree" | "branch";
+	type: "worktree" | "branch" | "cloud";
 	branch: string;
 	name: string;
 	tabOrder: number;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -63,7 +63,7 @@ interface WorkspaceListItemProps {
 	worktreePath: string;
 	name: string;
 	branch: string;
-	type: "worktree" | "branch";
+	type: "worktree" | "branch" | "cloud";
 	isUnread?: boolean;
 	index: number;
 	shortcutIndex?: number;
@@ -84,6 +84,7 @@ export function WorkspaceListItem({
 	isCollapsed = false,
 }: WorkspaceListItemProps) {
 	const isBranchWorkspace = type === "branch";
+	const isCloudWorkspace = type === "cloud";
 	const navigate = useNavigate();
 	const matchRoute = useMatchRoute();
 	const reorderWorkspaces = useReorderWorkspaces();
@@ -308,6 +309,21 @@ export function WorkspaceListItem({
 			);
 		}
 
+		// Cloud workspaces get a simple tooltip
+		if (isCloudWorkspace) {
+			return (
+				<Tooltip delayDuration={300}>
+					<TooltipTrigger asChild>{collapsedButton}</TooltipTrigger>
+					<TooltipContent side="right" className="flex flex-col gap-0.5">
+						<span className="font-medium">{name || branch}</span>
+						<span className="text-xs text-muted-foreground">
+							Cloud workspace
+						</span>
+					</TooltipContent>
+				</Tooltip>
+			);
+		}
+
 		// Worktree workspaces get the full hover card with context menu
 		return (
 			<>
@@ -414,7 +430,14 @@ export function WorkspaceListItem({
 					</div>
 				</TooltipTrigger>
 				<TooltipContent side="right" sideOffset={8}>
-					{isBranchWorkspace ? (
+					{isCloudWorkspace ? (
+						<>
+							<p className="text-xs font-medium">Cloud workspace</p>
+							<p className="text-xs text-muted-foreground">
+								Hosted in the cloud for remote development
+							</p>
+						</>
+					) : isBranchWorkspace ? (
 						<>
 							<p className="text-xs font-medium">Local workspace</p>
 							<p className="text-xs text-muted-foreground">

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/DeleteWorkspaceDialog/DeleteWorkspaceDialog.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/DeleteWorkspaceDialog/DeleteWorkspaceDialog.tsx
@@ -18,7 +18,7 @@ import {
 interface DeleteWorkspaceDialogProps {
 	workspaceId: string;
 	workspaceName: string;
-	workspaceType?: "worktree" | "branch";
+	workspaceType?: "worktree" | "branch" | "cloud";
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 }
@@ -31,6 +31,7 @@ export function DeleteWorkspaceDialog({
 	onOpenChange,
 }: DeleteWorkspaceDialogProps) {
 	const isBranch = workspaceType === "branch";
+	const isCloud = workspaceType === "cloud";
 	const deleteWorkspace = useDeleteWorkspace();
 	const closeWorkspace = useCloseWorkspace();
 
@@ -108,8 +109,8 @@ export function DeleteWorkspaceDialog({
 	const hasUnpushedCommits = canDeleteData?.hasUnpushedCommits ?? false;
 	const hasWarnings = hasChanges || hasUnpushedCommits;
 
-	// For branch workspaces, use simplified dialog (only close option)
-	if (isBranch) {
+	// For branch/cloud workspaces, use simplified dialog (only close option)
+	if (isBranch || isCloud) {
 		return (
 			<AlertDialog open={open} onOpenChange={onOpenChange}>
 				<AlertDialogContent className="max-w-[340px] gap-0 p-0">
@@ -120,8 +121,9 @@ export function DeleteWorkspaceDialog({
 						<AlertDialogDescription asChild>
 							<div className="text-muted-foreground space-y-1.5">
 								<span className="block">
-									This will close the workspace and kill any active terminals.
-									Your branch and commits will remain in the repository.
+									{isCloud
+										? "This will disconnect from the cloud workspace and kill any active terminals."
+										: "This will close the workspace and kill any active terminals. Your branch and commits will remain in the repository."}
 								</span>
 							</div>
 						</AlertDialogDescription>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/WorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/WorkspaceRow.tsx
@@ -37,6 +37,7 @@ export function WorkspaceRow({
 	isOpening,
 }: WorkspaceRowProps) {
 	const isBranch = workspace.type === "branch";
+	const isCloud = workspace.type === "cloud";
 	const [hasHovered, setHasHovered] = useState(false);
 	const { showDeleteDialog, setShowDeleteDialog, handleDeleteClick } =
 		useWorkspaceDeleteHandler();
@@ -104,7 +105,14 @@ export function WorkspaceRow({
 					</div>
 				</TooltipTrigger>
 				<TooltipContent side="top" sideOffset={4}>
-					{isBranch ? (
+					{isCloud ? (
+						<>
+							<p className="text-xs font-medium">Cloud workspace</p>
+							<p className="text-xs text-muted-foreground">
+								Hosted in the cloud for remote development
+							</p>
+						</>
+					) : isBranch ? (
 						<>
 							<p className="text-xs font-medium">Local workspace</p>
 							<p className="text-xs text-muted-foreground">
@@ -181,11 +189,12 @@ export function WorkspaceRow({
 	// Determine the delete/close action label based on workspace type and state
 	const isOpenWorkspace = workspace.workspaceId !== null;
 	const isClosedWorktree = !isOpenWorkspace && workspace.worktreeId !== null;
-	const actionLabel = isBranch
-		? "Close workspace"
-		: isClosedWorktree
-			? "Delete worktree"
-			: "Delete workspace";
+	const actionLabel =
+		isBranch || isCloud
+			? "Close workspace"
+			: isClosedWorktree
+				? "Delete worktree"
+				: "Delete workspace";
 
 	// Can delete open workspaces or closed worktrees
 	const canDelete = isOpenWorkspace || isClosedWorktree;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/types.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/types.ts
@@ -8,7 +8,7 @@ export interface WorkspaceItem {
 	projectId: string;
 	projectName: string;
 	worktreePath: string;
-	type: "worktree" | "branch";
+	type: "worktree" | "branch" | "cloud";
 	branch: string;
 	name: string;
 	lastOpenedAt: number;

--- a/packages/local-db/src/schema/zod.ts
+++ b/packages/local-db/src/schema/zod.ts
@@ -63,8 +63,11 @@ export type TerminalPreset = z.infer<typeof terminalPresetSchema>;
 
 /**
  * Workspace type
+ * - worktree: Git worktree-based workspace (isolated copy)
+ * - branch: Branch-based workspace (main repo)
+ * - cloud: Cloud-hosted workspace
  */
-export const workspaceTypeSchema = z.enum(["worktree", "branch"]);
+export const workspaceTypeSchema = z.enum(["worktree", "branch", "cloud"]);
 
 export type WorkspaceType = z.infer<typeof workspaceTypeSchema>;
 


### PR DESCRIPTION
## Summary
- Add "cloud" as a new workspace type alongside "worktree" and "branch"
- Implement cloud workspace creation flow in NewWorkspaceModal
- Add cloud badge indicator in TopBar when viewing a cloud workspace
- Cloud workspaces use the project's main repo path (like branch workspaces)

## Changes
- **Schema**: Added "cloud" to `WorkspaceType` enum in `packages/local-db`
- **Backend**: Added `createCloudWorkspace` tRPC procedure
- **UI**: 
  - Cloud tab in NewWorkspaceModal with creation form
  - Cloud badge in TopBar for cloud workspaces
  - Updated tooltips to identify cloud workspaces
  - Updated delete dialog to handle cloud type

## Test plan
- [ ] Create a cloud workspace from the Cloud tab in New Workspace modal
- [ ] Verify cloud workspace appears in sidebar with correct icon
- [ ] Verify cloud badge appears in top bar when viewing cloud workspace
- [ ] Verify terminals work in cloud workspace
- [ ] Verify closing cloud workspace works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cloud workspace type alongside existing worktree and branch workspaces
  * New workspace creation modal with custom naming support for cloud workspaces
  * Cloud workspaces display with a visual indicator in the top bar
  * Dedicated disconnect option for cloud workspaces with updated messaging

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->