### PR TITLE
fix(desktop): improve workspace removal dialog copy

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/projects/projects.ts
+++ b/apps/desktop/src/lib/trpc/routers/projects/projects.ts
@@ -395,8 +395,10 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 								});
 							} else {
 								// Update isLocal flag for branches that exist both locally and remotely
-								const existing = branchMap.get(branch)!;
-								existing.isLocal = true;
+								const existing = branchMap.get(branch);
+								if (existing) {
+									existing.isLocal = true;
+								}
 							}
 						}
 					} catch {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/DeleteWorkspaceDialog/DeleteWorkspaceDialog.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/DeleteWorkspaceDialog/DeleteWorkspaceDialog.tsx
@@ -66,7 +66,7 @@ export function DeleteWorkspaceDialog({
 		onOpenChange(false);
 
 		toast.promise(closeWorkspace.mutateAsync({ id: workspaceId }), {
-			loading: "Closing...",
+			loading: "Hiding...",
 			success: (result) => {
 				if (result.terminalWarning) {
 					setTimeout(() => {
@@ -75,10 +75,10 @@ export function DeleteWorkspaceDialog({
 						});
 					}, 100);
 				}
-				return "Workspace closed";
+				return "Workspace hidden";
 			},
 			error: (error) =>
-				error instanceof Error ? error.message : "Failed to close",
+				error instanceof Error ? error.message : "Failed to hide",
 		});
 	};
 
@@ -165,8 +165,8 @@ export function DeleteWorkspaceDialog({
 								<span className="text-destructive">{reason}</span>
 							) : (
 								<span className="block">
-									Close to hide from tabs (keeps files). Delete to permanently
-									remove worktree from disk.
+									Deleting will permanently remove the worktree. You can hide
+									instead to keep files on disk.
 								</span>
 							)}
 						</div>
@@ -194,22 +194,15 @@ export function DeleteWorkspaceDialog({
 					>
 						Cancel
 					</Button>
-					<Tooltip delayDuration={400}>
-						<TooltipTrigger asChild>
-							<Button
-								variant="secondary"
-								size="sm"
-								className="h-7 px-3 text-xs"
-								onClick={handleClose}
-								disabled={isLoading}
-							>
-								Close
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent side="top" className="text-xs max-w-[200px]">
-							Hide from tabs. Worktree stays on disk and can be reopened later.
-						</TooltipContent>
-					</Tooltip>
+					<Button
+						variant="secondary"
+						size="sm"
+						className="h-7 px-3 text-xs"
+						onClick={handleClose}
+						disabled={isLoading}
+					>
+						Hide
+					</Button>
 					<Tooltip delayDuration={400}>
 						<TooltipTrigger asChild>
 							<Button


### PR DESCRIPTION
## Summary
- Change "Close" button to "Hide" for clarity
- Update description to warn about deletion first, then offer hiding as an alternative
- Update toast messages to use "Hiding"/"hidden" terminology

## Test plan
- [ ] Open a workspace removal dialog
- [ ] Verify the description reads: "Deleting will permanently remove the worktree. You can hide instead to keep files on disk."
- [ ] Verify buttons are: Cancel, Hide, Delete
- [ ] Click Hide and verify toast says "Workspace hidden"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified dialog messaging: "Hiding..." loading state, success "Workspace hidden", and error "Failed to hide".
  * Non-branch dialog now explains that deleting permanently removes the worktree and that hiding preserves files.
  * Replaced secondary "Close" with "Hide" (same action) and aligned button labels/tooltips; branch workspaces still offer "Close".

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->