### PR TITLE
fix(desktop): remove "View PR on GitHub" tooltip from ChangesHeader

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/components/ChangesHeader/ChangesHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/components/ChangesHeader/ChangesHeader.tsx
@@ -201,24 +201,17 @@ function PRStatusLink({ workspaceId }: { workspaceId?: string }) {
 	if (!pr) return null;
 
 	return (
-		<Tooltip>
-			<TooltipTrigger asChild>
-				<a
-					href={pr.url}
-					target="_blank"
-					rel="noopener noreferrer"
-					className="flex items-center gap-1 hover:opacity-80 transition-opacity"
-				>
-					<PRIcon state={pr.state} className="w-4 h-4" />
-					<span className="text-xs text-muted-foreground font-mono">
-						#{pr.number}
-					</span>
-				</a>
-			</TooltipTrigger>
-			<TooltipContent side="bottom" showArrow={false}>
-				View PR on GitHub
-			</TooltipContent>
-		</Tooltip>
+		<a
+			href={pr.url}
+			target="_blank"
+			rel="noopener noreferrer"
+			className="flex items-center gap-1 hover:opacity-80 transition-opacity"
+		>
+			<PRIcon state={pr.state} className="w-4 h-4" />
+			<span className="text-xs text-muted-foreground font-mono">
+				#{pr.number}
+			</span>
+		</a>
 	);
 }
 


### PR DESCRIPTION
## Summary
- Remove the "View PR on GitHub" tooltip from the PR status link in the ChangesHeader component
- The tooltip was overlapping with nearby buttons, making them difficult to click
- The PR icon and number are already intuitive, so the tooltip didn't add significant value

## Test plan
- [ ] Open a workspace with an associated PR
- [ ] Verify the PR number/icon link still opens GitHub when clicked
- [ ] Verify no tooltip appears on hover
- [ ] Verify nearby buttons (stash, view mode, refresh) are easier to click

Resolves #922 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed tooltip from PR status link in the Changes view.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->