### PR TITLE
feat(desktop): add dropdown menu to Add repository button

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarFooter.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarFooter.tsx
@@ -1,9 +1,17 @@
 import { Button } from "@superset/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
 import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
-import { LuFolderOpen } from "react-icons/lu";
+import { useState } from "react";
+import { LuFolderGit, LuFolderOpen, LuFolderPlus } from "react-icons/lu";
 import { useOpenNew } from "renderer/react-query/projects";
 import { useCreateBranchWorkspace } from "renderer/react-query/workspaces";
+import { CloneRepoDialog } from "../StartView/CloneRepoDialog";
 import { STROKE_WIDTH } from "./constants";
 
 interface WorkspaceSidebarFooterProps {
@@ -15,8 +23,9 @@ export function WorkspaceSidebarFooter({
 }: WorkspaceSidebarFooterProps) {
 	const openNew = useOpenNew();
 	const createBranchWorkspace = useCreateBranchWorkspace();
+	const [isCloneDialogOpen, setIsCloneDialogOpen] = useState(false);
 
-	const handleOpenNewProject = async () => {
+	const handleOpenProject = async () => {
 		try {
 			const result = await openNew.mutateAsync(undefined);
 			if (result.canceled) {
@@ -53,39 +62,99 @@ export function WorkspaceSidebarFooter({
 		}
 	};
 
+	const handleCloneError = (error: string) => {
+		toast.error("Failed to clone repository", {
+			description: error,
+		});
+	};
+
+	const isLoading = openNew.isPending || createBranchWorkspace.isPending;
+
 	if (isCollapsed) {
 		return (
-			<div className="border-t border-border p-2 flex justify-center">
-				<Tooltip delayDuration={300}>
-					<TooltipTrigger asChild>
-						<Button
-							variant="ghost"
-							size="icon"
-							className="size-8 text-muted-foreground hover:text-foreground"
-							onClick={handleOpenNewProject}
-							disabled={openNew.isPending || createBranchWorkspace.isPending}
-						>
-							<LuFolderOpen className="size-4" strokeWidth={STROKE_WIDTH} />
-						</Button>
-					</TooltipTrigger>
-					<TooltipContent side="right">Add repository</TooltipContent>
-				</Tooltip>
-			</div>
+			<>
+				<div className="border-t border-border p-2 flex justify-center">
+					<DropdownMenu>
+						<Tooltip delayDuration={300}>
+							<TooltipTrigger asChild>
+								<DropdownMenuTrigger asChild>
+									<Button
+										variant="ghost"
+										size="icon"
+										className="size-8 text-muted-foreground hover:text-foreground"
+										disabled={isLoading}
+									>
+										<LuFolderPlus
+											className="size-4"
+											strokeWidth={STROKE_WIDTH}
+										/>
+									</Button>
+								</DropdownMenuTrigger>
+							</TooltipTrigger>
+							<TooltipContent side="right">Add repository</TooltipContent>
+						</Tooltip>
+						<DropdownMenuContent side="top" align="start">
+							<DropdownMenuItem
+								onClick={handleOpenProject}
+								disabled={isLoading}
+							>
+								<LuFolderOpen className="size-4" strokeWidth={STROKE_WIDTH} />
+								Open project
+							</DropdownMenuItem>
+							<DropdownMenuItem
+								onClick={() => setIsCloneDialogOpen(true)}
+								disabled={isLoading}
+							>
+								<LuFolderGit className="size-4" strokeWidth={STROKE_WIDTH} />
+								Clone repo
+							</DropdownMenuItem>
+						</DropdownMenuContent>
+					</DropdownMenu>
+				</div>
+				<CloneRepoDialog
+					isOpen={isCloneDialogOpen}
+					onClose={() => setIsCloneDialogOpen(false)}
+					onError={handleCloneError}
+				/>
+			</>
 		);
 	}
 
 	return (
-		<div className="border-t border-border p-2">
-			<Button
-				variant="ghost"
-				size="sm"
-				className="w-full justify-start gap-2 text-muted-foreground hover:text-foreground"
-				onClick={handleOpenNewProject}
-				disabled={openNew.isPending || createBranchWorkspace.isPending}
-			>
-				<LuFolderOpen className="w-4 h-4" strokeWidth={STROKE_WIDTH} />
-				<span>Add repository</span>
-			</Button>
-		</div>
+		<>
+			<div className="border-t border-border p-2">
+				<DropdownMenu>
+					<DropdownMenuTrigger asChild>
+						<Button
+							variant="ghost"
+							size="sm"
+							className="w-full justify-start gap-2 text-muted-foreground hover:text-foreground"
+							disabled={isLoading}
+						>
+							<LuFolderPlus className="w-4 h-4" strokeWidth={STROKE_WIDTH} />
+							<span>Add repository</span>
+						</Button>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent side="top" align="start">
+						<DropdownMenuItem onClick={handleOpenProject} disabled={isLoading}>
+							<LuFolderOpen className="size-4" strokeWidth={STROKE_WIDTH} />
+							Open project
+						</DropdownMenuItem>
+						<DropdownMenuItem
+							onClick={() => setIsCloneDialogOpen(true)}
+							disabled={isLoading}
+						>
+							<LuFolderGit className="size-4" strokeWidth={STROKE_WIDTH} />
+							Clone repo
+						</DropdownMenuItem>
+					</DropdownMenuContent>
+				</DropdownMenu>
+			</div>
+			<CloneRepoDialog
+				isOpen={isCloneDialogOpen}
+				onClose={() => setIsCloneDialogOpen(false)}
+				onError={handleCloneError}
+			/>
+		</>
 	);
 }


### PR DESCRIPTION
## Summary
- Convert the sidebar "Add repository" button to a dropdown menu with two options
- **Open project**: opens a folder picker to select an existing local repo
- **Clone repo**: opens the clone dialog to clone from a URL
- Dropdown opens upward with folder-plus icon

## Test plan
- [ ] Click "Add repository" button in sidebar (expanded and collapsed states)
- [ ] Verify dropdown appears above the button
- [ ] Click "Open project" and verify folder picker opens
- [ ] Click "Clone repo" and verify clone dialog opens
- [ ] Test both options complete their flows successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Redesigned the workspace sidebar footer with a dropdown-based interface featuring quick actions to open existing projects and clone repositories
* Added dedicated repository cloning capability with dialog support and error handling to streamline repository management workflows
* Enhanced sidebar interactions with loading state management for better user feedback during operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->