### PR TITLE
feat(terminal): add Cmd+Arrow for cursor line navigation

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -483,6 +483,36 @@ export function setupKeyboardHandler(
 			return false;
 		}
 
+		// Cmd+Left: Move cursor to beginning of line (sends Ctrl+A)
+		const isCmdLeft =
+			event.key === "ArrowLeft" &&
+			event.metaKey &&
+			!event.ctrlKey &&
+			!event.altKey &&
+			!event.shiftKey;
+
+		if (isCmdLeft) {
+			if (event.type === "keydown" && options.onWrite) {
+				options.onWrite("\x01"); // Ctrl+A - beginning of line
+			}
+			return false;
+		}
+
+		// Cmd+Right: Move cursor to end of line (sends Ctrl+E)
+		const isCmdRight =
+			event.key === "ArrowRight" &&
+			event.metaKey &&
+			!event.ctrlKey &&
+			!event.altKey &&
+			!event.shiftKey;
+
+		if (isCmdRight) {
+			if (event.type === "keydown" && options.onWrite) {
+				options.onWrite("\x05"); // Ctrl+E - end of line
+			}
+			return false;
+		}
+
 		if (isTerminalReservedEvent(event)) return true;
 
 		const clearKeys = getHotkeyKeys("CLEAR_TERMINAL");

--- a/apps/desktop/src/shared/hotkeys.ts
+++ b/apps/desktop/src/shared/hotkeys.ts
@@ -490,23 +490,23 @@ export const HOTKEYS = {
 		description: "Scroll the active terminal to the bottom",
 	}),
 	PREV_TERMINAL: defineHotkey({
-		keys: "meta+left",
+		keys: "meta+alt+left",
 		label: "Previous Terminal",
 		category: "Terminal",
 	}),
 	NEXT_TERMINAL: defineHotkey({
-		keys: "meta+right",
+		keys: "meta+alt+right",
 		label: "Next Terminal",
 		category: "Terminal",
 	}),
 	PREV_PANE: defineHotkey({
-		keys: "meta+alt+left",
+		keys: "meta+shift+left",
 		label: "Previous Pane",
 		category: "Terminal",
 		description: "Focus the previous pane in the current tab",
 	}),
 	NEXT_PANE: defineHotkey({
-		keys: "meta+alt+right",
+		keys: "meta+shift+right",
 		label: "Next Pane",
 		category: "Terminal",
 		description: "Focus the next pane in the current tab",


### PR DESCRIPTION
## Summary
- Frees up Cmd+Arrow for terminal cursor navigation (beginning/end of line)
- Remaps terminal tab switching to Cmd+Option+Left/Right
- Remaps pane switching to Cmd+Shift+Left/Right

## Changes
- `apps/desktop/src/shared/hotkeys.ts`: Updated keybindings for terminal/pane switching
- `apps/desktop/src/renderer/.../Terminal/helpers.ts`: Added Cmd+Left (Ctrl+A) and Cmd+Right (Ctrl+E) handlers

## Test plan
- [x] Open a workspace with a terminal
- [x] Type some text in the terminal
- [x] Press Cmd+Left → cursor jumps to beginning of line
- [x] Press Cmd+Right → cursor jumps to end of line
- [x] Verify Cmd+Option+Left/Right switches between terminal tabs
- [x] Verify Cmd+Shift+Left/Right switches between panes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cmd+Left and Cmd+Right in the terminal to jump to the start or end of the current line.

* **Changes**
  * Updated navigation shortcuts: terminal switching now uses Meta+Alt+Left/Right; pane switching now uses Meta+Shift+Left/Right.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->