### PR TITLE
fix(desktop): sanitize manually entered branch names in workspace modal

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -158,7 +158,7 @@ export function NewWorkspaceModal() {
 	};
 
 	const handleBranchNameChange = (value: string) => {
-		setBranchName(value);
+		setBranchName(generateBranchFromTitle(value));
 		setBranchNameEdited(true);
 	};
 


### PR DESCRIPTION
## Summary
- Apply the same branch name sanitization to manually entered branch names that was already applied to auto-generated names from titles
- Fixes bug where manually entering a branch name with spaces or special characters would cause worktree creation to fail (git rejects invalid branch names)

## Test plan
- [x] Open New Workspace modal
- [x] Expand "Advanced options" and manually enter a branch name with spaces (e.g., "my feature branch")
- [x] Verify it auto-sanitizes to "my-feature-branch" as you type