### PR TITLE
fix(desktop): ensure notification click switches to correct tab

### DIFF
--- a/apps/desktop/src/renderer/stores/tabs/useAgentHookListener.ts
+++ b/apps/desktop/src/renderer/stores/tabs/useAgentHookListener.ts
@@ -117,17 +117,20 @@ export function useAgentHookListener() {
 				// (router navigation is async, but state updates are immediate)
 				const freshState = useTabsStore.getState();
 				const freshTarget = resolveNotificationTarget(event.data, freshState);
-				if (!freshTarget?.tabId) return;
 
-				const freshTab = freshState.tabs.find(
-					(t) => t.id === freshTarget.tabId,
-				);
+				// Use resolved tabId, falling back to event's tabId directly
+				const tabIdToActivate = freshTarget?.tabId ?? event.data?.tabId;
+				if (!tabIdToActivate) return;
+
+				const freshTab = freshState.tabs.find((t) => t.id === tabIdToActivate);
 				if (!freshTab || freshTab.workspaceId !== workspaceId) return;
 
-				freshState.setActiveTab(workspaceId, freshTarget.tabId);
+				freshState.setActiveTab(workspaceId, tabIdToActivate);
 
-				if (freshTarget.paneId && freshState.panes[freshTarget.paneId]) {
-					freshState.setFocusedPane(freshTarget.tabId, freshTarget.paneId);
+				// Focus pane if available, using resolved or event's paneId
+				const paneIdToFocus = freshTarget?.paneId ?? event.data?.paneId;
+				if (paneIdToFocus && freshState.panes[paneIdToFocus]) {
+					freshState.setFocusedPane(tabIdToActivate, paneIdToFocus);
 				}
 			}
 		},


### PR DESCRIPTION
## Summary
- Fix notification click not switching to the correct tab when already on the right workspace
- Add fallback to use event's `tabId` directly when pane-based resolution fails
- Add debug logging to help diagnose future tab activation issues

## Test plan
- [ ] Click a notification while on the correct workspace but different tab
- [ ] Verify the app switches to the tab that triggered the notification
- [ ] Verify pane focus also works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reliability of tab and pane focus operations by implementing fallback mechanisms to handle missing or unresolved identifiers, ensuring graceful behavior in edge cases where expected data may not be available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->