### PR TITLE
fix(desktop): remove double-click to lock file behavior in changes sidebar

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/ChangesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/ChangesView.tsx
@@ -28,19 +28,10 @@ interface ChangesViewProps {
 		category: ChangeCategory,
 		commitHash?: string,
 	) => void;
-	onFileOpenPinned?: (
-		file: ChangedFile,
-		category: ChangeCategory,
-		commitHash?: string,
-	) => void;
 	isExpandedView?: boolean;
 }
 
-export function ChangesView({
-	onFileOpen,
-	onFileOpenPinned,
-	isExpandedView,
-}: ChangesViewProps) {
+export function ChangesView({ onFileOpen, isExpandedView }: ChangesViewProps) {
 	const { workspaceId } = useParams({ strict: false });
 	const { data: workspace } = electronTrpc.workspaces.get.useQuery(
 		{ id: workspaceId ?? "" },
@@ -262,36 +253,16 @@ export function ChangesView({
 		[status?.unstaged, status?.untracked],
 	);
 
-	// Single click - opens in preview mode
 	const handleFileSelect = (file: ChangedFile, category: ChangeCategory) => {
 		if (!worktreePath) return;
 		selectFile(worktreePath, file, category, null);
 		onFileOpen?.(file, category);
 	};
 
-	// Double click - opens pinned (permanent)
-	const handleFileDoubleClick = (
-		file: ChangedFile,
-		category: ChangeCategory,
-	) => {
-		if (!worktreePath) return;
-		selectFile(worktreePath, file, category, null);
-		onFileOpenPinned?.(file, category);
-	};
-
 	const handleCommitFileSelect = (file: ChangedFile, commitHash: string) => {
 		if (!worktreePath) return;
 		selectFile(worktreePath, file, "committed", commitHash);
 		onFileOpen?.(file, "committed", commitHash);
-	};
-
-	const handleCommitFileDoubleClick = (
-		file: ChangedFile,
-		commitHash: string,
-	) => {
-		if (!worktreePath) return;
-		selectFile(worktreePath, file, "committed", commitHash);
-		onFileOpenPinned?.(file, "committed", commitHash);
 	};
 
 	const handleCommitToggle = (hash: string) => {
@@ -402,9 +373,6 @@ export function ChangesView({
 							selectedFile={selectedFile}
 							selectedCommitHash={selectedCommitHash}
 							onFileSelect={(file) => handleFileSelect(file, "against-base")}
-							onFileDoubleClick={(file) =>
-								handleFileDoubleClick(file, "against-base")
-							}
 							worktreePath={worktreePath}
 							category="against-base"
 							isExpandedView={isExpandedView}
@@ -426,7 +394,6 @@ export function ChangesView({
 								selectedFile={selectedFile}
 								selectedCommitHash={selectedCommitHash}
 								onFileSelect={handleCommitFileSelect}
-								onFileDoubleClick={handleCommitFileDoubleClick}
 								viewMode={fileListViewMode}
 								worktreePath={worktreePath}
 								isExpandedView={isExpandedView}
@@ -484,9 +451,6 @@ export function ChangesView({
 							selectedFile={selectedFile}
 							selectedCommitHash={selectedCommitHash}
 							onFileSelect={(file) => handleFileSelect(file, "staged")}
-							onFileDoubleClick={(file) =>
-								handleFileDoubleClick(file, "staged")
-							}
 							onUnstage={(file) =>
 								unstageFileMutation.mutate({
 									worktreePath: worktreePath || "",
@@ -550,9 +514,6 @@ export function ChangesView({
 							selectedFile={selectedFile}
 							selectedCommitHash={selectedCommitHash}
 							onFileSelect={(file) => handleFileSelect(file, "unstaged")}
-							onFileDoubleClick={(file) =>
-								handleFileDoubleClick(file, "unstaged")
-							}
 							onStage={(file) =>
 								stageFileMutation.mutate({
 									worktreePath: worktreePath || "",

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/components/CommitItem/CommitItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/components/CommitItem/CommitItem.tsx
@@ -11,7 +11,6 @@ interface CommitItemProps {
 	selectedFile: ChangedFile | null;
 	selectedCommitHash: string | null;
 	onFileSelect: (file: ChangedFile, commitHash: string) => void;
-	onFileDoubleClick?: (file: ChangedFile, commitHash: string) => void;
 	viewMode: ChangesViewMode;
 	worktreePath?: string;
 	isExpandedView?: boolean;
@@ -46,7 +45,6 @@ export function CommitItem({
 	selectedFile,
 	selectedCommitHash,
 	onFileSelect,
-	onFileDoubleClick,
 	viewMode,
 	worktreePath,
 	isExpandedView,
@@ -55,10 +53,6 @@ export function CommitItem({
 
 	const handleFileSelect = (file: ChangedFile) => {
 		onFileSelect(file, commit.hash);
-	};
-
-	const handleFileDoubleClick = (file: ChangedFile) => {
-		onFileDoubleClick?.(file, commit.hash);
 	};
 
 	const isCommitSelected = selectedCommitHash === commit.hash;
@@ -84,7 +78,6 @@ export function CommitItem({
 					selectedFile={isCommitSelected ? selectedFile : null}
 					selectedCommitHash={selectedCommitHash}
 					onFileSelect={handleFileSelect}
-					onFileDoubleClick={handleFileDoubleClick}
 					worktreePath={worktreePath}
 					category="committed"
 					commitHash={commit.hash}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/components/FileItem/FileItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/components/FileItem/FileItem.tsx
@@ -36,7 +36,6 @@ interface FileItemProps {
 	file: ChangedFile;
 	isSelected: boolean;
 	onClick: () => void;
-	onDoubleClick?: () => void;
 	showStats?: boolean;
 	level?: number;
 	onStage?: () => void;
@@ -71,7 +70,6 @@ export function FileItem({
 	file,
 	isSelected,
 	onClick,
-	onDoubleClick,
 	showStats = true,
 	level = 0,
 	onStage,
@@ -156,7 +154,6 @@ export function FileItem({
 			<button
 				type="button"
 				onClick={onClick}
-				onDoubleClick={onDoubleClick}
 				className={cn(
 					"flex items-center gap-1.5 flex-1 min-w-0",
 					hasIndent ? "py-0.5" : "py-1",

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/components/FileList/FileList.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/components/FileList/FileList.tsx
@@ -9,7 +9,6 @@ interface FileListProps {
 	selectedFile: ChangedFile | null;
 	selectedCommitHash: string | null;
 	onFileSelect: (file: ChangedFile) => void;
-	onFileDoubleClick?: (file: ChangedFile) => void;
 	showStats?: boolean;
 	onStage?: (file: ChangedFile) => void;
 	onUnstage?: (file: ChangedFile) => void;
@@ -27,7 +26,6 @@ export function FileList({
 	selectedFile,
 	selectedCommitHash,
 	onFileSelect,
-	onFileDoubleClick,
 	showStats = true,
 	onStage,
 	onUnstage,
@@ -49,7 +47,6 @@ export function FileList({
 				selectedFile={selectedFile}
 				selectedCommitHash={selectedCommitHash}
 				onFileSelect={onFileSelect}
-				onFileDoubleClick={onFileDoubleClick}
 				showStats={showStats}
 				onStage={onStage}
 				onUnstage={onUnstage}
@@ -69,7 +66,6 @@ export function FileList({
 			selectedFile={selectedFile}
 			selectedCommitHash={selectedCommitHash}
 			onFileSelect={onFileSelect}
-			onFileDoubleClick={onFileDoubleClick}
 			showStats={showStats}
 			onStage={onStage}
 			onUnstage={onUnstage}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/components/FileList/FileListGrouped.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/components/FileList/FileListGrouped.tsx
@@ -8,7 +8,6 @@ interface FileListGroupedProps {
 	selectedFile: ChangedFile | null;
 	selectedCommitHash: string | null;
 	onFileSelect: (file: ChangedFile) => void;
-	onFileDoubleClick?: (file: ChangedFile) => void;
 	showStats?: boolean;
 	onStage?: (file: ChangedFile) => void;
 	onUnstage?: (file: ChangedFile) => void;
@@ -63,7 +62,6 @@ interface FolderGroupItemProps {
 	group: FolderGroup;
 	selectedFile: ChangedFile | null;
 	onFileSelect: (file: ChangedFile) => void;
-	onFileDoubleClick?: (file: ChangedFile) => void;
 	showStats?: boolean;
 	onStage?: (file: ChangedFile) => void;
 	onUnstage?: (file: ChangedFile) => void;
@@ -79,7 +77,6 @@ function FolderGroupItem({
 	group,
 	selectedFile,
 	onFileSelect,
-	onFileDoubleClick,
 	showStats,
 	onStage,
 	onUnstage,
@@ -108,9 +105,6 @@ function FolderGroupItem({
 					file={file}
 					isSelected={selectedFile?.path === file.path}
 					onClick={() => onFileSelect(file)}
-					onDoubleClick={
-						onFileDoubleClick ? () => onFileDoubleClick(file) : undefined
-					}
 					showStats={showStats}
 					onStage={onStage ? () => onStage(file) : undefined}
 					onUnstage={onUnstage ? () => onUnstage(file) : undefined}
@@ -130,7 +124,6 @@ export function FileListGrouped({
 	files,
 	selectedFile,
 	onFileSelect,
-	onFileDoubleClick,
 	showStats = true,
 	onStage,
 	onUnstage,
@@ -151,7 +144,6 @@ export function FileListGrouped({
 					group={group}
 					selectedFile={selectedFile}
 					onFileSelect={onFileSelect}
-					onFileDoubleClick={onFileDoubleClick}
 					showStats={showStats}
 					onStage={onStage}
 					onUnstage={onUnstage}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/components/FileList/FileListTree.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/components/FileList/FileListTree.tsx
@@ -8,7 +8,6 @@ interface FileListTreeProps {
 	selectedFile: ChangedFile | null;
 	selectedCommitHash: string | null;
 	onFileSelect: (file: ChangedFile) => void;
-	onFileDoubleClick?: (file: ChangedFile) => void;
 	showStats?: boolean;
 	onStage?: (file: ChangedFile) => void;
 	onUnstage?: (file: ChangedFile) => void;
@@ -87,7 +86,6 @@ interface TreeNodeComponentProps {
 	selectedPath: string | null;
 	selectedCommitHash: string | null;
 	onFileSelect: (file: ChangedFile) => void;
-	onFileDoubleClick?: (file: ChangedFile) => void;
 	showStats?: boolean;
 	onStage?: (file: ChangedFile) => void;
 	onUnstage?: (file: ChangedFile) => void;
@@ -105,7 +103,6 @@ function TreeNodeComponent({
 	selectedPath,
 	selectedCommitHash,
 	onFileSelect,
-	onFileDoubleClick,
 	showStats,
 	onStage,
 	onUnstage,
@@ -138,7 +135,6 @@ function TreeNodeComponent({
 						selectedPath={selectedPath}
 						selectedCommitHash={selectedCommitHash}
 						onFileSelect={onFileSelect}
-						onFileDoubleClick={onFileDoubleClick}
 						showStats={showStats}
 						onStage={onStage}
 						onUnstage={onUnstage}
@@ -161,9 +157,6 @@ function TreeNodeComponent({
 				file={file}
 				isSelected={isSelected}
 				onClick={() => onFileSelect(file)}
-				onDoubleClick={
-					onFileDoubleClick ? () => onFileDoubleClick(file) : undefined
-				}
 				showStats={showStats}
 				level={level}
 				onStage={onStage ? () => onStage(file) : undefined}
@@ -186,7 +179,6 @@ export function FileListTree({
 	selectedFile,
 	selectedCommitHash,
 	onFileSelect,
-	onFileDoubleClick,
 	showStats = true,
 	onStage,
 	onUnstage,
@@ -208,7 +200,6 @@ export function FileListTree({
 					selectedPath={selectedFile?.path ?? null}
 					selectedCommitHash={selectedCommitHash}
 					onFileSelect={onFileSelect}
-					onFileDoubleClick={onFileDoubleClick}
 					showStats={showStats}
 					onStage={onStage}
 					onUnstage={onUnstage}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/index.tsx
@@ -52,22 +52,6 @@ export function Sidebar() {
 				diffCategory: category,
 				commitHash,
 				oldPath: file.oldPath,
-				isPinned: false,
-			});
-			invalidateFileContent(file.path);
-		},
-		[workspaceId, worktreePath, addFileViewerPane, invalidateFileContent],
-	);
-
-	const handleFileOpenPinnedPane = useCallback(
-		(file: ChangedFile, category: ChangeCategory, commitHash?: string) => {
-			if (!workspaceId || !worktreePath) return;
-			addFileViewerPane(workspaceId, {
-				filePath: file.path,
-				diffCategory: category,
-				commitHash,
-				oldPath: file.oldPath,
-				isPinned: true,
 			});
 			invalidateFileContent(file.path);
 		},
@@ -88,20 +72,9 @@ export function Sidebar() {
 				: handleFileOpenPane
 			: undefined;
 
-	const handleFileOpenPinned =
-		workspaceId && worktreePath
-			? isExpanded
-				? handleFileScrollTo
-				: handleFileOpenPinnedPane
-			: undefined;
-
 	return (
 		<aside className="h-full flex flex-col overflow-hidden">
-			<ChangesView
-				onFileOpen={handleFileOpen}
-				onFileOpenPinned={handleFileOpenPinned}
-				isExpandedView={isExpanded}
-			/>
+			<ChangesView onFileOpen={handleFileOpen} isExpandedView={isExpanded} />
 		</aside>
 	);
 }

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -505,7 +505,7 @@ export const useTabsStore = create<TabsStore>()(
 								!p.fileViewer.isPinned,
 						);
 
-					// If we found an unpinned (preview) file-viewer pane, check if it's the same file
+					// If we found an unpinned (preview) file-viewer pane, reuse it
 					if (fileViewerPanes.length > 0) {
 						const paneToReuse = fileViewerPanes[0];
 						const existingFileViewer = paneToReuse.fileViewer;
@@ -514,25 +514,14 @@ export const useTabsStore = create<TabsStore>()(
 							return "";
 						}
 
-						// If clicking the same file that's already in preview, pin it
+						// If clicking the same file that's already in preview, just focus it
 						const isSameFile =
 							existingFileViewer.filePath === options.filePath &&
 							existingFileViewer.diffCategory === options.diffCategory &&
 							existingFileViewer.commitHash === options.commitHash;
 
 						if (isSameFile) {
-							// Pin the preview pane
 							set({
-								panes: {
-									...state.panes,
-									[paneToReuse.id]: {
-										...paneToReuse,
-										fileViewer: {
-											...existingFileViewer,
-											isPinned: true,
-										},
-									},
-								},
 								focusedPaneIds: {
 									...state.focusedPaneIds,
 									[activeTab.id]: paneToReuse.id,


### PR DESCRIPTION
## Summary
- Remove the unintuitive "click twice to lock" behavior that caused diff panels to open in new panes instead of replacing existing ones
- Files in the changes sidebar now always replace the current preview pane

## Test plan
- [ ] Click on a file in the changes sidebar to open it
- [ ] Click on a different file - verify it replaces the current diff panel instead of opening a new one
- [ ] Repeat clicking different files - verify the diff panel is always replaced, never duplicated

Closes #894

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified file opening behavior: removed double-click functionality and automatic pinning of files when reopened. Files now open with single-click only.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->