### PR TITLE
fix(desktop): suppress notifications when viewing active pane

### DIFF
--- a/apps/desktop/src/main/lib/notifications/utils.test.ts
+++ b/apps/desktop/src/main/lib/notifications/utils.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "bun:test";
-import { extractWorkspaceIdFromUrl, isPaneVisible } from "./utils";
+import {
+	extractWorkspaceIdFromUrl,
+	getNotificationTitle,
+	getWorkspaceName,
+	isPaneVisible,
+} from "./utils";
 
 describe("extractWorkspaceIdFromUrl", () => {
 	it("extracts workspace ID from hash-routed URL", () => {
@@ -152,5 +157,75 @@ describe("isPaneVisible", () => {
 				pane,
 			}),
 		).toBe(false);
+	});
+});
+
+describe("getNotificationTitle", () => {
+	const tabs = [
+		{ id: "tab1", name: "Tab 1", userTitle: "My Custom Title" },
+		{ id: "tab2", name: "Tab 2" },
+	];
+	const panes = {
+		pane1: { name: "Pane 1" },
+		pane2: { name: "Pane 2" },
+	};
+
+	it("returns userTitle when available", () => {
+		expect(getNotificationTitle({ tabId: "tab1", tabs, panes })).toBe(
+			"My Custom Title",
+		);
+	});
+
+	it("returns tab.name when no userTitle", () => {
+		expect(getNotificationTitle({ tabId: "tab2", tabs, panes })).toBe("Tab 2");
+	});
+
+	it("returns pane.name when no tab found", () => {
+		expect(getNotificationTitle({ paneId: "pane1", tabs, panes })).toBe(
+			"Pane 1",
+		);
+	});
+
+	it("returns Terminal as fallback", () => {
+		expect(getNotificationTitle({})).toBe("Terminal");
+	});
+
+	it("trims whitespace from userTitle", () => {
+		const tabsWithWhitespace = [{ id: "t1", name: "Tab", userTitle: "  " }];
+		expect(
+			getNotificationTitle({ tabId: "t1", tabs: tabsWithWhitespace }),
+		).toBe("Tab");
+	});
+});
+
+describe("getWorkspaceName", () => {
+	it("returns workspace.name when available", () => {
+		expect(
+			getWorkspaceName({
+				workspace: { name: "My Workspace", worktreeId: null },
+			}),
+		).toBe("My Workspace");
+	});
+
+	it("returns worktree.branch when no workspace name", () => {
+		expect(
+			getWorkspaceName({
+				workspace: { name: null, worktreeId: "wt1" },
+				worktree: { branch: "feature/test" },
+			}),
+		).toBe("feature/test");
+	});
+
+	it("returns Workspace as fallback", () => {
+		expect(getWorkspaceName({})).toBe("Workspace");
+	});
+
+	it("returns Workspace when all values are null", () => {
+		expect(
+			getWorkspaceName({
+				workspace: { name: null, worktreeId: null },
+				worktree: { branch: null },
+			}),
+		).toBe("Workspace");
 	});
 });

--- a/apps/desktop/src/main/lib/notifications/utils.ts
+++ b/apps/desktop/src/main/lib/notifications/utils.ts
@@ -55,3 +55,55 @@ export function isPaneVisible({
 
 	return isViewingWorkspace && isActiveTab && isFocusedPane;
 }
+
+interface BaseTab {
+	id: string;
+	name: string;
+	userTitle?: string;
+}
+
+interface Pane {
+	name: string;
+}
+
+/**
+ * Derives a display title for a notification from tab/pane state.
+ * Priority: tab.userTitle > tab.name > pane.name > "Terminal"
+ */
+export function getNotificationTitle({
+	tabId,
+	paneId,
+	tabs,
+	panes,
+}: {
+	tabId?: string;
+	paneId?: string;
+	tabs?: BaseTab[];
+	panes?: Record<string, Pane>;
+}): string {
+	const tab = tabId ? tabs?.find((t) => t.id === tabId) : undefined;
+	const pane = paneId ? panes?.[paneId] : undefined;
+	return tab?.userTitle?.trim() || tab?.name || pane?.name || "Terminal";
+}
+
+interface Workspace {
+	name: string | null;
+	worktreeId: string | null;
+}
+
+interface Worktree {
+	branch: string | null;
+}
+
+/**
+ * Derives a display name for a workspace, falling back through available names.
+ */
+export function getWorkspaceName({
+	workspace,
+	worktree,
+}: {
+	workspace?: Workspace | null;
+	worktree?: Worktree | null;
+}): string {
+	return workspace?.name || worktree?.branch || "Workspace";
+}


### PR DESCRIPTION
## Summary
Implements Slack-pattern notification behavior - notifications and sounds are skipped when the user is already viewing the pane that triggered them.

## How it works
Parses `currentWorkspaceId` directly from the renderer URL via `window.webContents.getURL()` when a notification fires. No state sync needed.

Notifications are suppressed when ALL conditions are met:
1. Window is focused
2. User is viewing the workspace containing the pane (parsed from URL)
3. The tab is active in that workspace
4. The pane is focused in that tab

## Test plan
- [ ] Open a workspace and focus a terminal pane
- [ ] Trigger an agent event (e.g., permission request) in that pane
- [ ] Verify no notification sound or popup appears
- [ ] Switch to a different tab/pane and trigger event in original pane
- [ ] Verify notification now appears
- [ ] Minimize/unfocus the window and trigger event
- [ ] Verify notification appears

Closes #903

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated redundant notifications for content you're already viewing in your current workspace, tab, or pane. This reduces notification clutter and creates a cleaner, more focused user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->