### PR TITLE
feat(desktop): rework account settings with editable profile

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/account/components/AccountSettings/components/ProfileSkeleton/ProfileSkeleton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/account/components/AccountSettings/components/ProfileSkeleton/ProfileSkeleton.tsx
@@ -1,0 +1,28 @@
+import { Card, CardContent } from "@superset/ui/card";
+import { Skeleton } from "@superset/ui/skeleton";
+
+export function ProfileSkeleton() {
+	return (
+		<Card>
+			<CardContent>
+				<ul className="space-y-6">
+					<li className="flex items-center justify-between gap-8 pb-6 border-b border-border">
+						<div className="flex-1">
+							<Skeleton className="h-4 w-16 mb-2" />
+							<Skeleton className="h-3 w-40" />
+						</div>
+						<Skeleton className="h-8 w-8 rounded-full" />
+					</li>
+					<li className="flex items-center justify-between gap-8 pb-6 border-b border-border">
+						<Skeleton className="h-4 w-12" />
+						<Skeleton className="h-10 flex-1" />
+					</li>
+					<li className="flex items-center justify-between gap-8">
+						<Skeleton className="h-4 w-12" />
+						<Skeleton className="h-10 flex-1" />
+					</li>
+				</ul>
+			</CardContent>
+		</Card>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/account/components/AccountSettings/components/ProfileSkeleton/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/account/components/AccountSettings/components/ProfileSkeleton/index.ts
@@ -1,0 +1,1 @@
+export { ProfileSkeleton } from "./ProfileSkeleton";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -2,7 +2,6 @@ import type { SettingsSection } from "renderer/stores/settings-state";
 
 export const SETTING_ITEM_ID = {
 	ACCOUNT_PROFILE: "account-profile",
-	ACCOUNT_VERSION: "account-version",
 	ACCOUNT_SIGNOUT: "account-signout",
 
 	ORGANIZATION_LOGO: "organization-logo",
@@ -76,22 +75,6 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"picture",
 			"photo",
 			"me",
-		],
-	},
-	{
-		id: SETTING_ITEM_ID.ACCOUNT_VERSION,
-		section: "account",
-		title: "Version",
-		description: "App version and updates",
-		keywords: [
-			"account",
-			"version",
-			"update",
-			"check for updates",
-			"app version",
-			"release",
-			"about",
-			"upgrade",
 		],
 	},
 	{

--- a/packages/trpc/src/router/user/user.ts
+++ b/packages/trpc/src/router/user/user.ts
@@ -1,7 +1,9 @@
 import { db } from "@superset/db/client";
-import { members } from "@superset/db/schema";
-import type { TRPCRouterRecord } from "@trpc/server";
+import { members, users } from "@superset/db/schema";
+import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
+import { del, put } from "@vercel/blob";
 import { eq } from "drizzle-orm";
+import { z } from "zod";
 
 import { protectedProcedure } from "../../trpc";
 
@@ -29,4 +31,96 @@ export const userRouter = {
 
 		return memberships.map((m) => m.organization);
 	}),
+
+	updateProfile: protectedProcedure
+		.input(z.object({ name: z.string().min(1).max(100) }))
+		.mutation(async ({ ctx, input }) => {
+			const [updatedUser] = await db
+				.update(users)
+				.set({ name: input.name })
+				.where(eq(users.id, ctx.session.user.id))
+				.returning();
+			return updatedUser;
+		}),
+
+	uploadAvatar: protectedProcedure
+		.input(
+			z.object({
+				fileData: z.string(),
+				fileName: z.string(),
+				mimeType: z.string(),
+			}),
+		)
+		.mutation(async ({ ctx, input }) => {
+			const userId = ctx.session.user.id;
+
+			const user = await db.query.users.findFirst({
+				where: eq(users.id, userId),
+			});
+
+			if (!user) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "User not found",
+				});
+			}
+
+			const allowedMimeTypes = ["image/png", "image/jpeg", "image/webp"];
+			if (!allowedMimeTypes.includes(input.mimeType)) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "Invalid image type. Only PNG, JPEG, and WebP are allowed",
+				});
+			}
+
+			const base64Data = input.fileData.includes("base64,")
+				? input.fileData.split("base64,")[1] || input.fileData
+				: input.fileData;
+			const buffer = Buffer.from(base64Data, "base64");
+
+			const sizeInMB = buffer.length / (1024 * 1024);
+			if (sizeInMB > 4.5) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `File too large (${sizeInMB.toFixed(2)}MB). Maximum size is 4.5MB`,
+				});
+			}
+
+			if (user.image) {
+				try {
+					await del(user.image);
+				} catch {
+					// Old avatar doesn't exist or isn't in blob storage - that's fine
+				}
+			}
+
+			const ext = input.mimeType.split("/")[1]?.replace("jpeg", "jpg") || "png";
+			const randomId = Math.random().toString(36).substring(2, 15);
+			const pathname = `user/${userId}/avatar/${randomId}.${ext}`;
+
+			try {
+				const blob = await put(pathname, buffer, {
+					access: "public",
+					contentType: input.mimeType,
+				});
+
+				const [updatedUser] = await db
+					.update(users)
+					.set({ image: blob.url })
+					.where(eq(users.id, userId))
+					.returning();
+
+				return {
+					success: true,
+					url: blob.url,
+					user: updatedUser,
+				};
+			} catch (error) {
+				console.error("[user/uploadAvatar] Upload failed:", error);
+				throw new TRPCError({
+					code: "INTERNAL_SERVER_ERROR",
+					message: "Failed to upload avatar",
+				});
+			}
+		}),
 } satisfies TRPCRouterRecord;


### PR DESCRIPTION
## Summary
- Add `updateProfile` and `uploadAvatar` mutations to user router for editing user profile
- Remove version section from account settings page
- Add editable name field with onBlur save functionality
- Add avatar upload with hover edit overlay (matches organization settings pattern)
- Use Electric SQL collections for real-time data sync instead of session refetch

## Test plan
- [ ] Navigate to Settings → Account
- [ ] Verify version section is removed
- [ ] Click avatar → file picker opens → select image → avatar updates
- [ ] Edit name field → blur → name persists (doesn't revert)
- [ ] Sign out and back in → changes persist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added avatar upload functionality with file picker and live preview.
  * Added editable name field in account settings.
  * Added email display in user profile.

* **Improvements**
  * Improved loading state UI during account data fetch.
  * Enhanced error handling with toast notifications for profile updates.

* **Removed**
  * Removed version information from account settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->