### PR TITLE
feat(desktop): support F1-F12 as hotkeys without modifiers

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -11,7 +11,12 @@ import { debounce } from "lodash";
 import { electronTrpcClient as trpcClient } from "renderer/lib/trpc-client";
 import { getHotkeyKeys, isAppHotkeyEvent } from "renderer/stores/hotkeys";
 import { toXtermTheme } from "renderer/stores/theme/utils";
-import { isTerminalReservedEvent, matchesHotkeyEvent } from "shared/hotkeys";
+import {
+	getCurrentPlatform,
+	hotkeyFromKeyboardEvent,
+	isTerminalReservedEvent,
+	matchesHotkeyEvent,
+} from "shared/hotkeys";
 import {
 	builtInThemes,
 	DEFAULT_THEME_ID,
@@ -527,7 +532,11 @@ export function setupKeyboardHandler(
 		}
 
 		if (event.type !== "keydown") return true;
-		if (!event.metaKey && !event.ctrlKey) return true;
+		const potentialHotkey = hotkeyFromKeyboardEvent(
+			event,
+			getCurrentPlatform(),
+		);
+		if (!potentialHotkey) return true;
 
 		if (isAppHotkeyEvent(event)) {
 			// Return false to prevent xterm from processing the key.

--- a/apps/desktop/src/renderer/stores/hotkeys/store.ts
+++ b/apps/desktop/src/renderer/stores/hotkeys/store.ts
@@ -20,7 +20,7 @@ import {
 	type HotkeyId,
 	type HotkeyPlatform,
 	type HotkeysState,
-	hasPrimaryModifier,
+	isValidAppHotkey,
 	hotkeyFromKeyboardEvent,
 	matchesHotkeyEvent,
 } from "shared/hotkeys";
@@ -77,8 +77,8 @@ export const useHotkeysStore = create<HotkeysStoreState>()(
 							? null
 							: canonicalizeHotkeyForPlatform(keys, platform);
 					if (keys !== null && !canonical) return;
-					// App hotkeys must include ctrl or meta to work in terminal
-					if (canonical !== null && !hasPrimaryModifier(canonical)) return;
+					// App hotkeys must include ctrl or meta (or be function keys) to work in terminal
+					if (canonical !== null && !isValidAppHotkey(canonical)) return;
 
 					const defaultValue = getDefaultHotkey(id, platform);
 					const overrides = getOverridesForPlatform(
@@ -117,8 +117,8 @@ export const useHotkeysStore = create<HotkeysStoreState>()(
 								? null
 								: canonicalizeHotkeyForPlatform(keys, platform);
 						if (keys !== null && !canonical) continue;
-						// App hotkeys must include ctrl or meta to work in terminal
-						if (canonical !== null && !hasPrimaryModifier(canonical)) continue;
+						// App hotkeys must include ctrl or meta (or be function keys) to work in terminal
+						if (canonical !== null && !isValidAppHotkey(canonical)) continue;
 						const defaultValue = getDefaultHotkey(hotkeyId, platform);
 						if (canonical === defaultValue) {
 							delete nextOverrides[hotkeyId];

--- a/apps/desktop/src/shared/hotkeys.ts
+++ b/apps/desktop/src/shared/hotkeys.ts
@@ -104,6 +104,18 @@ const ELECTRON_KEY_MAP: Record<string, string> = {
 	right: "Right",
 	space: "Space",
 	slash: "/",
+	f1: "F1",
+	f2: "F2",
+	f3: "F3",
+	f4: "F4",
+	f5: "F5",
+	f6: "F6",
+	f7: "F7",
+	f8: "F8",
+	f9: "F9",
+	f10: "F10",
+	f11: "F11",
+	f12: "F12",
 };
 
 const TERMINAL_RESERVED_CHORDS = new Set<string>([
@@ -114,6 +126,10 @@ const TERMINAL_RESERVED_CHORDS = new Set<string>([
 	"ctrl+q",
 	"ctrl+\\",
 ]);
+
+function isFunctionKey(key: string): boolean {
+	return /^f([1-9]|1[0-2])$/.test(key);
+}
 
 const OS_RESERVED_CHORDS: Record<HotkeyPlatform, string[]> = {
 	darwin: ["meta+q", "meta+space", "meta+tab"],
@@ -270,8 +286,9 @@ export function hotkeyFromKeyboardEvent(
 		return null;
 	}
 
-	// App hotkeys must include ctrl or meta to avoid conflicts with terminal input
-	if (!event.ctrlKey && !event.metaKey) {
+	// App hotkeys must include ctrl or meta (or be function keys F1-F12)
+	// to avoid conflicts with terminal input and ensure they work when the terminal is focused
+	if (!isFunctionKey(normalizedKey) && !event.ctrlKey && !event.metaKey) {
 		return null;
 	}
 
@@ -310,12 +327,16 @@ export function isOsReservedHotkey(
 }
 
 /**
- * Checks if a hotkey includes a primary modifier (ctrl or meta).
- * App hotkeys must include ctrl or meta to avoid conflicts with terminal input
- * and to ensure they work when the terminal is focused.
+ * Checks if a hotkey is valid for app-level use.
+ * App hotkeys must include ctrl or meta (or be function keys F1-F12)
+ * to avoid conflicts with terminal input and ensure they work when the terminal is focused.
  */
-export function hasPrimaryModifier(keys: string): boolean {
+export function isValidAppHotkey(keys: string): boolean {
 	const parsed = parseHotkeyString(keys);
+	// Function keys are allowed without modifiers
+	if (parsed.key && isFunctionKey(parsed.key)) {
+		return true;
+	}
 	return parsed.modifiers.has("ctrl") || parsed.modifiers.has("meta");
 }
 
@@ -685,8 +706,8 @@ export function buildOverridesFromBindings(
 		if (canonical === null && value !== null) {
 			continue;
 		}
-		// App hotkeys must include ctrl or meta to work in terminal
-		if (canonical !== null && !hasPrimaryModifier(canonical)) {
+		// App hotkeys must include ctrl or meta (or be function keys) to work in terminal
+		if (canonical !== null && !isValidAppHotkey(canonical)) {
 			continue;
 		}
 		const defaultValue = getDefaultHotkey(id, platform);


### PR DESCRIPTION
## Description

- Add F1-F12 to ELECTRON_KEY_MAP for hotkey recognition
- Allow function keys (F1-F12) as valid app hotkeys without requiring Cmd/Ctrl modifiers
- Update terminal keyboard handler to let unconfigured F1-F12 pass through to terminal apps
- Rename hasPrimaryModifier to isValidAppHotkey for better semantics

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<img width="855" height="485" alt="图片" src="https://github.com/user-attachments/assets/604e770e-0c31-47e3-84ac-9c0309d6ddc7" />

<img width="454" height="168" alt="图片" src="https://github.com/user-attachments/assets/b4dc57e9-453f-4966-8647-b7f4e78a473a" />

## Additional Notes

<!-- Add any other context about the PR here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Function keys (F1–F12) can now be assigned as app shortcuts without requiring modifier keys.
  * Enhanced keyboard event recognition for more reliable hotkey detection in the terminal.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->