### PR TITLE
fix(desktop): add SF fonts for Apple tools symbol rendering

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/config.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/config.ts
@@ -25,6 +25,9 @@ const TERMINAL_FONT_FAMILY = [
 	"Menlo",
 	"Monaco",
 	'"Courier New"',
+	// SF fonts for Apple tools (swift, xcodebuild) that use SF Symbols private use area characters
+	"SF Mono",
+	"SF Pro",
 	"monospace",
 ].join(", ");
 


### PR DESCRIPTION
## Summary

Apple developer tools (`swift test`, `xcodebuild`) output symbols from SF Symbols font using Unicode private use area characters. Without SF fonts in the terminal font fallback chain, these characters render as placeholder boxes.

This PR adds `SF Mono` and `SF Pro` to the end of the terminal font family list to properly render symbols from Apple tools output while preserving the default font.

## Screenshots

### Before (without fix)
<img width="326" height="379" alt="SCR-20260126-plcr" src="https://github.com/user-attachments/assets/c33beb87-4013-48f7-bd9f-96d34b08e9bb" />


### After (with fix)
<img width="386" height="396" alt="SCR-20260126-pkxj" src="https://github.com/user-attachments/assets/3d480a14-11ff-4c29-8988-c4ac8363ad21" />


## Test Plan

1. Open Superset terminal
2. Run `swift test` in a Swift package directory
3. Verify that test result symbols (checkmarks/crosses) render correctly instead of showing placeholder boxes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal font selection expanded to include SF Mono and SF Pro font options, providing enhanced customization capabilities and improved cross-system font compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->