### PR TITLE
fix(desktop): register daemon sessions with port manager on startup

### DIFF
--- a/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts
+++ b/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts
@@ -92,6 +92,15 @@ export class DaemonTerminalManager extends EventEmitter {
 			);
 			this.daemonSessionIdsHydrated = true;
 
+			// Enable port scanning before user opens terminal tabs
+			for (const session of preservedSessions) {
+				portManager.upsertDaemonSession(
+					session.paneId,
+					session.workspaceId,
+					session.pid,
+				);
+			}
+
 			const preservedCount = response.sessions.length - orphanedCount;
 			if (preservedCount > 0) {
 				console.log(


### PR DESCRIPTION
## Summary
- Fix port scanning not working for terminals already running after app restart/update
- Register preserved daemon sessions with port manager during `reconcileOnStartup()`
- Enables immediate port detection without requiring user to open each terminal tab

## Test plan
- [ ] Start a dev server in a terminal (e.g., `bun dev`)
- [ ] Verify port appears in the ports panel
- [ ] Restart the desktop app (Cmd+R or quit and reopen)
- [ ] Verify port still appears in the ports panel without opening the terminal tab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of session restoration when the application restarts, ensuring all previously active connections are properly re-initialized and available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->