### PR TITLE
feat(desktop): improve keyboard shortcut visibility on hover

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -467,7 +467,7 @@ export function WorkspaceListItem({
 							{/* Keyboard shortcut */}
 							{shortcutIndex !== undefined &&
 								shortcutIndex < MAX_KEYBOARD_SHORTCUT_INDEX && (
-									<span className="text-[10px] text-muted-foreground/50 opacity-0 group-hover:opacity-100 transition-opacity font-mono tabular-nums shrink-0">
+									<span className="text-[10px] text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity font-mono tabular-nums shrink-0">
 										⌘{shortcutIndex + 1}
 									</span>
 								)}


### PR DESCRIPTION
## Summary
- Improve visibility of keyboard shortcuts (⌘1-⌘9) when hovering over workspace items in the sidebar
- Changed text color from `text-muted-foreground/50` to `text-muted-foreground` for better readability

## Test plan
- [ ] Run the desktop app with `bun dev`
- [ ] Hover over workspace items in the sidebar
- [ ] Verify keyboard shortcuts are more visible on hover

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visibility of keyboard shortcut labels in the workspace sidebar.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->