### PR TITLE
fix(desktop): update workspace navigation shortcuts to use Option modifier

### DIFF
--- a/apps/desktop/src/shared/hotkeys.ts
+++ b/apps/desktop/src/shared/hotkeys.ts
@@ -410,12 +410,12 @@ export const HOTKEYS = {
 		category: "Workspace",
 	}),
 	PREV_WORKSPACE: defineHotkey({
-		keys: "meta+up",
+		keys: "meta+alt+up",
 		label: "Previous Workspace",
 		category: "Workspace",
 	}),
 	NEXT_WORKSPACE: defineHotkey({
-		keys: "meta+down",
+		keys: "meta+alt+down",
 		label: "Next Workspace",
 		category: "Workspace",
 	}),


### PR DESCRIPTION
## Summary
- Update `PREV_WORKSPACE` shortcut from `⌘↑` to `⌘⌥↑`
- Update `NEXT_WORKSPACE` shortcut from `⌘↓` to `⌘⌥↓`
- Aligns with terminal pane navigation pattern (`⌘⌥←` / `⌘⌥→`)

## Test plan
- [ ] Verify `⌘⌥↑` navigates to previous workspace
- [ ] Verify `⌘⌥↓` navigates to next workspace
- [ ] Confirm shortcuts display correctly in hotkey settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Workspace navigation hotkeys modified: previous and next workspace shortcuts now use meta+alt+up and meta+alt+down respectively (previously used meta+up and meta+down).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->