### PR TITLE
fix(web): org switching now updates sidebar and improve dropdown UX

### DIFF
--- a/apps/web/src/app/(dashboard)/components/Header/Header.tsx
+++ b/apps/web/src/app/(dashboard)/components/Header/Header.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { authClient } from "@superset/auth/client";
-import { getInitials } from "@superset/shared/names";
 import { Avatar, AvatarFallback, AvatarImage } from "@superset/ui/avatar";
 import {
 	DropdownMenu,
@@ -15,7 +14,7 @@ import {
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Check, LogOut } from "lucide-react";
+import { Check, ChevronDown, LogOut } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -33,11 +32,12 @@ export function Header() {
 	);
 
 	const user = session?.user;
-	const initials = getInitials(user?.name, user?.email);
 	const activeOrganizationId = session?.session?.activeOrganizationId;
 	const activeOrganization = organizations?.find(
 		(org) => org.id === activeOrganizationId,
 	);
+
+	const displayName = activeOrganization?.name ?? "Organization";
 
 	const handleSignOut = async () => {
 		await authClient.signOut();
@@ -66,15 +66,22 @@ export function Header() {
 					<DropdownMenuTrigger asChild>
 						<button
 							type="button"
-							className="cursor-pointer rounded-full outline-none focus-visible:ring-2 focus-visible:ring-ring"
+							className="flex cursor-pointer items-center gap-2 rounded-md border border-border/60 bg-secondary/50 px-3 py-1.5 transition-all duration-150 hover:border-border hover:bg-secondary focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+							aria-label="Organization menu"
 						>
-							<Avatar className="size-8">
+							<Avatar className="size-5">
 								<AvatarImage
-									src={user?.image ?? undefined}
-									alt={user?.name ?? ""}
+									src={activeOrganization?.logo ?? undefined}
+									alt={displayName}
 								/>
-								<AvatarFallback className="text-xs">{initials}</AvatarFallback>
+								<AvatarFallback className="text-[10px]">
+									{displayName.charAt(0)}
+								</AvatarFallback>
 							</Avatar>
+							<span className="max-w-32 truncate text-sm font-medium">
+								{displayName}
+							</span>
+							<ChevronDown className="size-4 text-muted-foreground" />
 						</button>
 					</DropdownMenuTrigger>
 					<DropdownMenuContent align="end" className="min-w-56">
@@ -85,52 +92,34 @@ export function Header() {
 							</div>
 						</DropdownMenuLabel>
 						<DropdownMenuSeparator />
-						{organizations && organizations.length === 1 && (
-							<>
-								<div className="flex items-center px-2 py-1.5 text-sm">
-									<Avatar className="mr-2 size-4">
-										<AvatarFallback className="text-[8px]">
-											{activeOrganization?.name?.charAt(0) ?? "O"}
-										</AvatarFallback>
-									</Avatar>
-									<span className="truncate">
-										{activeOrganization?.name ?? "Organization"}
-									</span>
-								</div>
-								<DropdownMenuSeparator />
-							</>
-						)}
 						{organizations && organizations.length > 1 && (
 							<>
 								<DropdownMenuSub>
 									<DropdownMenuSubTrigger className="cursor-pointer">
-										<Avatar className="mr-2 size-4">
-											<AvatarFallback className="text-[8px]">
-												{activeOrganization?.name?.charAt(0) ?? "O"}
-											</AvatarFallback>
-										</Avatar>
-										<span className="truncate">
-											{activeOrganization?.name ?? "Organization"}
-										</span>
+										<span>Switch organization</span>
 									</DropdownMenuSubTrigger>
 									<DropdownMenuSubContent>
 										<DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
-											Switch organization
+											{user?.email}
 										</DropdownMenuLabel>
 										{organizations.map((org) => (
 											<DropdownMenuItem
 												key={org.id}
-												className="cursor-pointer"
+												className="cursor-pointer gap-2"
 												onClick={() => handleSwitchOrganization(org.id)}
 											>
-												<Avatar className="mr-2 size-4">
+												<Avatar className="size-4">
+													<AvatarImage
+														src={org.logo ?? undefined}
+														alt={org.name ?? "Organization"}
+													/>
 													<AvatarFallback className="text-[8px]">
 														{org.name?.charAt(0) ?? "O"}
 													</AvatarFallback>
 												</Avatar>
 												<span className="flex-1 truncate">{org.name}</span>
 												{org.id === activeOrganizationId && (
-													<Check className="ml-2 size-4 text-primary" />
+													<Check className="size-4 text-primary" />
 												)}
 											</DropdownMenuItem>
 										))}
@@ -140,11 +129,11 @@ export function Header() {
 							</>
 						)}
 						<DropdownMenuItem
-							className="cursor-pointer"
+							className="cursor-pointer gap-2"
 							onClick={handleSignOut}
 						>
-							<LogOut className="mr-2 size-4" />
-							Logout
+							<LogOut className="size-4" />
+							<span>Log out</span>
 						</DropdownMenuItem>
 					</DropdownMenuContent>
 				</DropdownMenu>


### PR DESCRIPTION
## Summary
- Fix `myOrganization` tRPC procedure to filter by `activeOrganizationId` from session instead of returning first membership found - this was causing the sidebar to not update when switching orgs
- Update Header dropdown trigger to show org name + avatar (matching desktop app UX) with chevron icon
- Simplify dropdown to show org switcher submenu and log out button

## Test plan
- [ ] Switch between organizations and verify the sidebar org name updates
- [ ] Verify the dropdown trigger shows the current org name and avatar
- [ ] Verify org switcher submenu works correctly
- [ ] Verify log out works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced organization switcher in the header with organization logos and names displayed
  * Improved multi-organization support with a dropdown menu for seamless switching between organizations with visual indicators

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->