### PR TITLE
fix(desktop): use generated branch name from title when creating workspace

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -197,13 +197,12 @@ export function NewWorkspaceModal() {
 		if (!selectedProjectId) return;
 
 		const workspaceName = title.trim() || undefined;
-		const customBranchName = branchNameEdited ? branchName.trim() : undefined;
 
 		try {
 			const result = await createWorkspace.mutateAsync({
 				projectId: selectedProjectId,
 				name: workspaceName,
-				branchName: customBranchName || undefined,
+				branchName: branchNameToCreate || undefined,
 				baseBranch: effectiveBaseBranch || undefined,
 			});
 


### PR DESCRIPTION
## Summary
- Fix regression where workspace creation ignored the title-derived branch name
- Now correctly passes `branchNameToCreate` (which includes author prefix + slugified title) instead of only passing manually edited branch names
- Ensures branch names like `kiet-ho/my-feature` are used when user enters "My Feature" as the workspace title

## Test plan
- [ ] Create a new workspace with a title (e.g., "Test Feature")
- [ ] Verify the branch name is derived from the title with author prefix (e.g., `author/test-feature`)
- [ ] Verify manually editing the branch name still works as expected
- [ ] Verify leaving both title and branch name empty still falls back to random word generation