### PR TITLE
fix (desktop): ctrl-d fix to kill terminal pane

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -74,6 +74,7 @@ export const Terminal = ({ tabId, workspaceId }: TerminalProps) => {
 	);
 	const terminalTheme = useTerminalTheme();
 	const restartTerminalRef = useRef<() => void>(() => {});
+	const ctrlDSentRef = useRef(false);
 
 	// Terminal connection state and mutations
 	const {
@@ -235,6 +236,7 @@ export const Terminal = ({ tabId, workspaceId }: TerminalProps) => {
 			isExitedRef,
 			wasKilledByUserRef,
 			pendingEventsRef,
+			ctrlDSentRef,
 			setExitStatus,
 			setConnectionError,
 			updateModesFromData,
@@ -407,6 +409,10 @@ export const Terminal = ({ tabId, workspaceId }: TerminalProps) => {
 				if (!isFocusedRef.current || wasKilledByUserRef.current) return;
 				restartTerminal();
 				return;
+			}
+			// Track Ctrl+D (EOF character) for auto-close on exit
+			if (data === "\x04") {
+				ctrlDSentRef.current = true;
 			}
 			writeRef.current({ paneId, data });
 		};


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Terminal now properly detects and responds to Ctrl+D (EOF) input, automatically closing the session when a clean exit occurs. This improves compatibility with standard terminal workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/superset-sh/superset/pull/972">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
