### PR TITLE
feat(desktop): add command menu (⌘P)

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/CommandMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/CommandMenu.tsx
@@ -1,0 +1,100 @@
+import {
+	CommandDialog,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+	CommandShortcut,
+} from "@superset/ui/command";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useHotkeyText } from "renderer/stores/hotkeys";
+import type { HotkeyId } from "shared/hotkeys";
+import {
+	actionsCommands,
+	contextualCommands,
+	navigationCommands,
+	type WorkspaceItem,
+	workspacesCommands,
+} from "./generators";
+import { useCommandActions } from "./hooks/useCommandActions";
+import { useCommandContext } from "./hooks/useCommandContext";
+import type { Command, CommandGroup as CommandGroupType } from "./types";
+
+interface CommandMenuProps {
+	isOpen: boolean;
+	onOpenChange: (open: boolean) => void;
+}
+
+function HotkeyShortcut({ hotkeyId }: { hotkeyId: HotkeyId }) {
+	const hotkeyText = useHotkeyText(hotkeyId);
+	if (hotkeyText === "Unassigned") return null;
+	return <CommandShortcut>{hotkeyText}</CommandShortcut>;
+}
+
+function CommandItemContent({ command }: { command: Command }) {
+	return (
+		<>
+			<span>{command.label}</span>
+			{command.hotkeyId && <HotkeyShortcut hotkeyId={command.hotkeyId} />}
+		</>
+	);
+}
+
+export function CommandMenu({ isOpen, onOpenChange }: CommandMenuProps) {
+	const ctx = useCommandContext();
+	const { executeCommand } = useCommandActions(ctx, () => onOpenChange(false));
+
+	// Fetch workspaces for the workspace list
+	const { data: workspaceGroups } =
+		electronTrpc.workspaces.getAllGrouped.useQuery();
+	const allWorkspaces: WorkspaceItem[] =
+		workspaceGroups?.flatMap((g) =>
+			g.workspaces.map((ws) => ({
+				id: ws.id,
+				name: ws.name,
+				branch: ws.branch,
+			})),
+		) ?? [];
+
+	// Generate all command groups
+	const groups: CommandGroupType[] = [
+		contextualCommands(ctx),
+		workspacesCommands(ctx, allWorkspaces),
+		actionsCommands(ctx),
+		navigationCommands(ctx),
+	].filter((g): g is CommandGroupType => g !== null);
+
+	const handleSelect = (commandId: string) => {
+		executeCommand(commandId);
+	};
+
+	return (
+		<CommandDialog
+			open={isOpen}
+			onOpenChange={onOpenChange}
+			title="Command Menu"
+			description="Search for commands and workspaces"
+			showCloseButton={false}
+		>
+			<CommandInput placeholder="Type a command or search..." />
+			<CommandList>
+				<CommandEmpty>No results found.</CommandEmpty>
+				{groups.map((group) => (
+					<CommandGroup key={group.displayName} heading={group.displayName}>
+						{group.commands.map((command) => (
+							<CommandItem
+								key={command.id}
+								value={command.id}
+								keywords={command.keywords}
+								onSelect={handleSelect}
+							>
+								<CommandItemContent command={command} />
+							</CommandItem>
+						))}
+					</CommandGroup>
+				))}
+			</CommandList>
+		</CommandDialog>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/generators.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/generators.ts
@@ -1,0 +1,151 @@
+import type { HotkeyId } from "shared/hotkeys";
+import type {
+	CommandContext,
+	CommandGroup,
+	CommandGroupGenerator,
+} from "./types";
+
+export interface WorkspaceItem {
+	id: string;
+	name: string;
+	branch: string;
+}
+
+const WORKSPACE_HOTKEY_IDS: HotkeyId[] = [
+	"JUMP_TO_WORKSPACE_1",
+	"JUMP_TO_WORKSPACE_2",
+	"JUMP_TO_WORKSPACE_3",
+	"JUMP_TO_WORKSPACE_4",
+	"JUMP_TO_WORKSPACE_5",
+	"JUMP_TO_WORKSPACE_6",
+	"JUMP_TO_WORKSPACE_7",
+	"JUMP_TO_WORKSPACE_8",
+	"JUMP_TO_WORKSPACE_9",
+];
+
+// Only shown when in a workspace
+export const contextualCommands: CommandGroupGenerator = (ctx) => {
+	if (!ctx.isInWorkspace) return null;
+
+	return {
+		displayName: "Workspace Actions",
+		commands: [
+			{
+				id: "close-workspace",
+				label: `Close ${ctx.workspaceName || "Workspace"}`,
+			},
+			{
+				id: "workspace-settings",
+				label: `${ctx.workspaceName || "Workspace"} Settings`,
+			},
+			{
+				id: "new-terminal-tab",
+				label: "New Terminal Tab",
+				hotkeyId: "NEW_GROUP",
+			},
+			{
+				id: "split-pane-right",
+				label: "Split Pane Right",
+				hotkeyId: "SPLIT_RIGHT",
+			},
+			{
+				id: "split-pane-down",
+				label: "Split Pane Down",
+				hotkeyId: "SPLIT_DOWN",
+			},
+			{
+				id: "clear-terminal",
+				label: "Clear Terminal",
+				hotkeyId: "CLEAR_TERMINAL",
+			},
+		],
+	};
+};
+
+// Dynamic workspace list (requires workspace data)
+export const workspacesCommands = (
+	_ctx: CommandContext,
+	workspaces: WorkspaceItem[],
+): CommandGroup | null => {
+	if (workspaces.length === 0) return null;
+
+	return {
+		displayName: "Workspaces",
+		commands: workspaces.map((ws, index) => ({
+			id: `switch-workspace-${ws.id}`,
+			label: ws.name || ws.branch,
+			keywords: [ws.branch, ws.name].filter(Boolean),
+			hotkeyId: index < 9 ? WORKSPACE_HOTKEY_IDS[index] : undefined,
+		})),
+	};
+};
+
+// Always shown
+export const actionsCommands: CommandGroupGenerator = () => ({
+	displayName: "Actions",
+	commands: [
+		{ id: "new-workspace", label: "New Workspace", hotkeyId: "NEW_WORKSPACE" },
+		{
+			id: "quick-create-workspace",
+			label: "Quick Create Workspace",
+			hotkeyId: "QUICK_CREATE_WORKSPACE",
+		},
+		{
+			id: "open-project",
+			label: "Open Project",
+			keywords: ["folder", "repo"],
+			hotkeyId: "OPEN_PROJECT",
+		},
+		{
+			id: "change-theme",
+			label: "Change Theme",
+			keywords: ["dark", "light", "mode", "toggle"],
+		},
+		{
+			id: "toggle-workspace-sidebar",
+			label: "Toggle Sidebar",
+			hotkeyId: "TOGGLE_WORKSPACE_SIDEBAR",
+		},
+	],
+});
+
+// Always shown
+export const navigationCommands: CommandGroupGenerator = () => ({
+	displayName: "Navigation",
+	commands: [
+		{
+			id: "settings-appearance",
+			label: "Appearance Settings",
+			keywords: ["theme"],
+		},
+		{
+			id: "settings-keyboard",
+			label: "Keyboard Shortcuts",
+			hotkeyId: "SHOW_HOTKEYS",
+		},
+		{
+			id: "settings-terminal",
+			label: "Terminal Settings",
+			keywords: ["shell", "presets"],
+		},
+		{
+			id: "settings-integrations",
+			label: "Integrations",
+			keywords: ["github"],
+		},
+		{
+			id: "contact-us",
+			label: "Contact Us",
+			keywords: ["support", "feedback"],
+		},
+		{
+			id: "join-discord",
+			label: "Join Discord",
+			keywords: ["community"],
+		},
+		{
+			id: "check-updates",
+			label: "Check for Updates",
+		},
+	],
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/hooks/useCommandActions/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/hooks/useCommandActions/index.ts
@@ -1,0 +1,1 @@
+export { useCommandActions } from "./useCommandActions";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/hooks/useCommandActions/useCommandActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/hooks/useCommandActions/useCommandActions.ts
@@ -1,0 +1,235 @@
+import { COMPANY } from "@superset/shared/constants";
+import { toast } from "@superset/ui/sonner";
+import { useNavigate } from "@tanstack/react-router";
+import { useCallback, useMemo } from "react";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useOpenNew } from "renderer/react-query/projects";
+import { useCloseWorkspace } from "renderer/react-query/workspaces";
+import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
+import { useTabsStore } from "renderer/stores/tabs";
+import {
+	SYSTEM_THEME_ID,
+	useSetTheme,
+	useThemeId,
+} from "renderer/stores/theme";
+import { useWorkspaceSidebarStore } from "renderer/stores/workspace-sidebar-state";
+import type { CommandContext } from "../../types";
+
+type ActionHandler = () => void | Promise<void>;
+
+export function useCommandActions(ctx: CommandContext, closeMenu: () => void) {
+	const navigate = useNavigate();
+	const openNewWorkspaceModal = useOpenNewWorkspaceModal();
+	const openNew = useOpenNew();
+	const closeWorkspace = useCloseWorkspace();
+	const checkForUpdates = electronTrpc.autoUpdate.check.useMutation();
+
+	// Theme
+	const setTheme = useSetTheme();
+	const themeId = useThemeId();
+
+	// Sidebar
+	const {
+		isOpen: isWorkspaceSidebarOpen,
+		toggleCollapsed: toggleWorkspaceSidebarCollapsed,
+		setOpen: setWorkspaceSidebarOpen,
+	} = useWorkspaceSidebarStore();
+
+	// Tabs/panes
+	const addTab = useTabsStore((s) => s.addTab);
+	const splitPaneVertical = useTabsStore((s) => s.splitPaneVertical);
+	const splitPaneHorizontal = useTabsStore((s) => s.splitPaneHorizontal);
+	const activeTabIds = useTabsStore((s) => s.activeTabIds);
+	const focusedPaneIds = useTabsStore((s) => s.focusedPaneIds);
+
+	// Helper to get active tab and focused pane for current workspace
+	const getActiveTabAndPane = useCallback(() => {
+		if (!ctx.workspaceId) return { tabId: null, paneId: null };
+		const tabId = activeTabIds[ctx.workspaceId] ?? null;
+		const paneId = tabId ? (focusedPaneIds[tabId] ?? null) : null;
+		return { tabId, paneId };
+	}, [ctx.workspaceId, activeTabIds, focusedPaneIds]);
+
+	const actions = useMemo<Record<string, ActionHandler>>(() => {
+		const handlers: Record<string, ActionHandler> = {
+			// Workspace actions
+			"close-workspace": async () => {
+				if (!ctx.workspaceId) return;
+				closeMenu();
+				try {
+					await closeWorkspace.mutateAsync({ id: ctx.workspaceId });
+					navigate({ to: "/" });
+				} catch (err) {
+					toast.error(
+						err instanceof Error ? err.message : "Failed to close workspace",
+					);
+				}
+			},
+			"workspace-settings": () => {
+				if (!ctx.projectId) return;
+				closeMenu();
+				navigate({
+					to: "/settings/project/$projectId",
+					params: { projectId: ctx.projectId },
+				});
+			},
+			"new-terminal-tab": () => {
+				if (!ctx.workspaceId) return;
+				closeMenu();
+				addTab(ctx.workspaceId);
+			},
+			"split-pane-right": () => {
+				const { tabId, paneId } = getActiveTabAndPane();
+				if (!tabId || !paneId) return;
+				closeMenu();
+				splitPaneVertical(tabId, paneId);
+			},
+			"split-pane-down": () => {
+				const { tabId, paneId } = getActiveTabAndPane();
+				if (!tabId || !paneId) return;
+				closeMenu();
+				splitPaneHorizontal(tabId, paneId);
+			},
+			"clear-terminal": () => {
+				// Clear terminal is handled by the terminal component's hotkey handler
+				// We dispatch the keyboard event to trigger it
+				closeMenu();
+				// Note: This won't work directly - clear terminal needs direct terminal access
+				// Users should use the keyboard shortcut instead
+				toast.info("Use keyboard shortcut to clear terminal");
+			},
+
+			// Global actions
+			"new-workspace": () => {
+				closeMenu();
+				openNewWorkspaceModal(ctx.projectId ?? undefined);
+			},
+			"quick-create-workspace": () => {
+				closeMenu();
+				// Quick create just opens the modal pre-filled
+				openNewWorkspaceModal(ctx.projectId ?? undefined);
+			},
+			"open-project": async () => {
+				closeMenu();
+				try {
+					const result = await openNew.mutateAsync(undefined);
+					if (result.canceled) return;
+					if ("error" in result) {
+						toast.error("Failed to open project", {
+							description: result.error,
+						});
+						return;
+					}
+					if ("needsGitInit" in result) {
+						toast.error("Selected folder is not a git repository");
+						return;
+					}
+					toast.success("Project opened", { description: result.project.name });
+				} catch (err) {
+					toast.error(
+						err instanceof Error ? err.message : "Failed to open project",
+					);
+				}
+			},
+			"change-theme": () => {
+				closeMenu();
+				// Toggle between dark and light, or toggle from system
+				if (themeId === "dark") {
+					setTheme("light");
+				} else if (themeId === "light") {
+					setTheme("dark");
+				} else {
+					// If using system or custom theme, toggle based on current appearance
+					setTheme(themeId === SYSTEM_THEME_ID ? "dark" : "light");
+				}
+			},
+			"toggle-workspace-sidebar": () => {
+				closeMenu();
+				if (!isWorkspaceSidebarOpen) {
+					setWorkspaceSidebarOpen(true);
+				} else {
+					toggleWorkspaceSidebarCollapsed();
+				}
+			},
+
+			// Navigation
+			"settings-appearance": () => {
+				closeMenu();
+				navigate({ to: "/settings/appearance" });
+			},
+			"settings-keyboard": () => {
+				closeMenu();
+				navigate({ to: "/settings/keyboard" });
+			},
+			"settings-terminal": () => {
+				closeMenu();
+				navigate({ to: "/settings/terminal" });
+			},
+			"settings-integrations": () => {
+				closeMenu();
+				navigate({ to: "/settings/integrations" });
+			},
+			"contact-us": () => {
+				closeMenu();
+				window.open(COMPANY.MAIL_TO, "_blank");
+			},
+			"join-discord": () => {
+				closeMenu();
+				window.open(COMPANY.DISCORD_URL, "_blank");
+			},
+			"check-updates": () => {
+				closeMenu();
+				checkForUpdates.mutate();
+				toast.info("Checking for updates...");
+			},
+		};
+
+		return handlers;
+	}, [
+		ctx.workspaceId,
+		ctx.projectId,
+		closeMenu,
+		closeWorkspace,
+		navigate,
+		openNewWorkspaceModal,
+		openNew,
+		addTab,
+		splitPaneVertical,
+		splitPaneHorizontal,
+		getActiveTabAndPane,
+		themeId,
+		setTheme,
+		isWorkspaceSidebarOpen,
+		setWorkspaceSidebarOpen,
+		toggleWorkspaceSidebarCollapsed,
+		checkForUpdates,
+	]);
+
+	// Handle workspace switching
+	const handleWorkspaceSwitch = useCallback(
+		(workspaceId: string) => {
+			closeMenu();
+			navigate({ to: "/workspace/$workspaceId", params: { workspaceId } });
+		},
+		[closeMenu, navigate],
+	);
+
+	const executeCommand = useCallback(
+		(commandId: string) => {
+			// Check if it's a workspace switch command
+			if (commandId.startsWith("switch-workspace-")) {
+				const workspaceId = commandId.replace("switch-workspace-", "");
+				handleWorkspaceSwitch(workspaceId);
+				return;
+			}
+
+			const handler = actions[commandId];
+			if (handler) {
+				handler();
+			}
+		},
+		[actions, handleWorkspaceSwitch],
+	);
+
+	return { executeCommand };
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/hooks/useCommandContext/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/hooks/useCommandContext/index.ts
@@ -1,0 +1,1 @@
+export { useCommandContext } from "./useCommandContext";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/hooks/useCommandContext/useCommandContext.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/hooks/useCommandContext/useCommandContext.ts
@@ -1,0 +1,29 @@
+import { useMatchRoute } from "@tanstack/react-router";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import type { CommandContext } from "../../types";
+
+export function useCommandContext(): CommandContext {
+	const matchRoute = useMatchRoute();
+
+	const workspaceMatch = matchRoute({
+		to: "/workspace/$workspaceId",
+		fuzzy: true,
+	});
+	const settingsMatch = matchRoute({ to: "/settings", fuzzy: true });
+	const workspaceId =
+		workspaceMatch !== false ? workspaceMatch.workspaceId : null;
+
+	const { data: workspace } = electronTrpc.workspaces.get.useQuery(
+		{ id: workspaceId ?? "" },
+		{ enabled: !!workspaceId },
+	);
+
+	return {
+		workspaceId,
+		workspaceName: workspace?.name ?? null,
+		workspaceBranch: workspace?.branch ?? null,
+		projectId: workspace?.projectId ?? null,
+		isInWorkspace: !!workspaceId,
+		isInSettings: !!settingsMatch,
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/index.ts
@@ -1,0 +1,1 @@
+export { CommandMenu } from "./CommandMenu";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/types.ts
@@ -1,0 +1,26 @@
+import type { HotkeyId } from "shared/hotkeys";
+
+export interface CommandContext {
+	workspaceId: string | null;
+	workspaceName: string | null;
+	workspaceBranch: string | null;
+	projectId: string | null;
+	isInWorkspace: boolean;
+	isInSettings: boolean;
+}
+
+export interface Command {
+	id: string;
+	label: string;
+	keywords?: string[];
+	hotkeyId?: HotkeyId;
+}
+
+export interface CommandGroup {
+	displayName: string;
+	commands: Command[];
+}
+
+export type CommandGroupGenerator<T = void> = T extends void
+	? (ctx: CommandContext) => CommandGroup | null
+	: (ctx: CommandContext, data: T) => CommandGroup | null;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -4,6 +4,7 @@ import {
 	useMatchRoute,
 	useNavigate,
 } from "@tanstack/react-router";
+import { useState } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { ResizablePanel } from "renderer/screens/main/components/ResizablePanel";
 import { TopBar } from "renderer/screens/main/components/TopBar";
@@ -15,6 +16,7 @@ import {
 	MAX_WORKSPACE_SIDEBAR_WIDTH,
 	useWorkspaceSidebarStore,
 } from "renderer/stores/workspace-sidebar-state";
+import { CommandMenu } from "./components/CommandMenu";
 
 export const Route = createFileRoute("/_authenticated/_dashboard")({
 	component: DashboardLayout,
@@ -23,6 +25,7 @@ export const Route = createFileRoute("/_authenticated/_dashboard")({
 function DashboardLayout() {
 	const navigate = useNavigate();
 	const openNewWorkspaceModal = useOpenNewWorkspaceModal();
+	const [isCommandMenuOpen, setCommandMenuOpen] = useState(false);
 
 	// Get current workspace from route to pre-select project in new workspace modal
 	const matchRoute = useMatchRoute();
@@ -81,26 +84,39 @@ function DashboardLayout() {
 		[openNewWorkspaceModal, currentWorkspace?.projectId],
 	);
 
+	useAppHotkey(
+		"OPEN_COMMAND_MENU",
+		() => setCommandMenuOpen((open) => !open),
+		undefined,
+		[],
+	);
+
 	return (
-		<div className="flex flex-col h-full w-full">
-			<TopBar />
-			<div className="flex flex-1 overflow-hidden">
-				{isWorkspaceSidebarOpen && (
-					<ResizablePanel
-						width={workspaceSidebarWidth}
-						onWidthChange={setWorkspaceSidebarWidth}
-						isResizing={isWorkspaceSidebarResizing}
-						onResizingChange={setWorkspaceSidebarIsResizing}
-						minWidth={COLLAPSED_WORKSPACE_SIDEBAR_WIDTH}
-						maxWidth={MAX_WORKSPACE_SIDEBAR_WIDTH}
-						handleSide="right"
-						clampWidth={false}
-					>
-						<WorkspaceSidebar isCollapsed={isWorkspaceSidebarCollapsed()} />
-					</ResizablePanel>
-				)}
-				<Outlet />
+		<>
+			<div className="flex flex-col h-full w-full">
+				<TopBar />
+				<div className="flex flex-1 overflow-hidden">
+					{isWorkspaceSidebarOpen && (
+						<ResizablePanel
+							width={workspaceSidebarWidth}
+							onWidthChange={setWorkspaceSidebarWidth}
+							isResizing={isWorkspaceSidebarResizing}
+							onResizingChange={setWorkspaceSidebarIsResizing}
+							minWidth={COLLAPSED_WORKSPACE_SIDEBAR_WIDTH}
+							maxWidth={MAX_WORKSPACE_SIDEBAR_WIDTH}
+							handleSide="right"
+							clampWidth={false}
+						>
+							<WorkspaceSidebar isCollapsed={isWorkspaceSidebarCollapsed()} />
+						</ResizablePanel>
+					)}
+					<Outlet />
+				</div>
 			</div>
-		</div>
+			<CommandMenu
+				isOpen={isCommandMenuOpen}
+				onOpenChange={setCommandMenuOpen}
+			/>
+		</>
 	);
 }

--- a/apps/desktop/src/shared/hotkeys.ts
+++ b/apps/desktop/src/shared/hotkeys.ts
@@ -608,6 +608,12 @@ export const HOTKEYS = {
 		label: "Show Keyboard Shortcuts",
 		category: "Help",
 	}),
+	OPEN_COMMAND_MENU: defineHotkey({
+		keys: "meta+p",
+		label: "Open Command Menu",
+		category: "Help",
+		description: "Search for commands and workspaces",
+	}),
 } as const satisfies Record<string, HotkeyDefinition>;
 
 export function getVisibleHotkeys(): HotkeyId[] {


### PR DESCRIPTION
## Summary
- Add command menu (`⌘P`) to desktop app for quick access to commands and navigation
- Context-aware: shows workspace-specific actions only when in a workspace
- Displays workspace hotkeys (⌘1-9) next to first 9 workspaces
- Includes navigation, actions, and workspace switching

## Features
- **Workspace Actions**: Close workspace, settings, terminal commands (new tab, split pane, clear)
- **Workspaces**: Quick switch between workspaces with hotkey display
- **Actions**: New workspace, open project, change theme, toggle sidebar
- **Navigation**: Settings pages, contact/discord links, check for updates

## Test plan
- [ ] Press `⌘P` to open command menu
- [ ] Verify workspace actions only show when in a workspace
- [ ] Verify workspace hotkeys (⌘1-9) display correctly
- [ ] Test command execution (navigation, theme toggle, etc.)
- [ ] Verify ESC closes the menu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a command palette accessible via Meta+P for searching and executing commands
  * Added quick workspace switching and management commands
  * Integrated contextual workspace actions including settings, terminal operations, and pane management
  * Navigation and settings shortcuts now accessible through the unified command menu

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->