### PR TITLE
feat(desktop): add git fetch and fetch & pull actions

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/changes/git-operations.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/git-operations.ts
@@ -116,6 +116,15 @@ export const createGitOperationsRouter = () => {
 				return { success: true };
 			}),
 
+		fetch: publicProcedure
+			.input(z.object({ worktreePath: z.string() }))
+			.mutation(async ({ input }): Promise<{ success: boolean }> => {
+				assertRegisteredWorktree(input.worktreePath);
+				const git = simpleGit(input.worktreePath);
+				await git.fetch();
+				return { success: true };
+			}),
+
 		createPR: publicProcedure
 			.input(
 				z.object({

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/components/CommitInput/CommitInput.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/Sidebar/ChangesView/components/CommitInput/CommitInput.tsx
@@ -13,6 +13,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useState } from "react";
 import {
 	HiArrowDown,
+	HiArrowPath,
 	HiArrowsUpDown,
 	HiArrowTopRightOnSquare,
 	HiArrowUp,
@@ -88,12 +89,21 @@ export function CommitInput({
 		onError: (error) => toast.error(`Failed: ${error.message}`),
 	});
 
+	const fetchMutation = electronTrpc.changes.fetch.useMutation({
+		onSuccess: () => {
+			toast.success("Fetched");
+			onRefresh();
+		},
+		onError: (error) => toast.error(`Fetch failed: ${error.message}`),
+	});
+
 	const isPending =
 		commitMutation.isPending ||
 		pushMutation.isPending ||
 		pullMutation.isPending ||
 		syncMutation.isPending ||
-		createPRMutation.isPending;
+		createPRMutation.isPending ||
+		fetchMutation.isPending;
 
 	const canCommit = hasStagedChanges && commitMessage.trim();
 
@@ -117,6 +127,13 @@ export function CommitInput({
 	};
 	const handlePull = () => pullMutation.mutate({ worktreePath });
 	const handleSync = () => syncMutation.mutate({ worktreePath });
+	const handleFetch = () => fetchMutation.mutate({ worktreePath });
+	const handleFetchAndPull = () => {
+		fetchMutation.mutate(
+			{ worktreePath },
+			{ onSuccess: () => pullMutation.mutate({ worktreePath }) },
+		);
+	};
 	const handleCreatePR = () => createPRMutation.mutate({ worktreePath });
 	const handleOpenPR = () => prUrl && window.open(prUrl, "_blank");
 
@@ -331,6 +348,14 @@ export function CommitInput({
 						>
 							<HiArrowsUpDown className="size-3.5" />
 							Sync
+						</DropdownMenuItem>
+						<DropdownMenuItem onClick={handleFetch} className="text-xs">
+							<HiArrowPath className="size-3.5" />
+							Fetch
+						</DropdownMenuItem>
+						<DropdownMenuItem onClick={handleFetchAndPull} className="text-xs">
+							<HiArrowPath className="size-3.5" />
+							Fetch & Pull
 						</DropdownMenuItem>
 
 						<DropdownMenuSeparator />


### PR DESCRIPTION
## Summary
- Add standalone `fetch` tRPC procedure to git-operations router
- Add "Fetch" and "Fetch & Pull" menu items to the commit dropdown in ChangesView
- Allows users to fetch from remote without pulling, or to fetch then pull sequentially

## Test plan
- [x] Open desktop app with a git repository workspace
- [x] Click the commit dropdown menu
- [x] Verify "Fetch" and "Fetch & Pull" options appear between "Sync" and the PR separator
- [x] Click "Fetch" → verify "Fetched" toast appears
- [x] Click "Fetch & Pull" → verify fetch runs, then pull runs with "Pulled" toast

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Fetch action to retrieve remote updates.
  * Added Fetch & Pull action to retrieve and merge remote updates in one operation.
  * Success and error notifications display operation status.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->