### PR TITLE
chore: update .mcp.json to use production MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,11 +2,11 @@
 	"mcpServers": {
 		"superset": {
 			"type": "http",
-			"url": "http://localhost:3001/api/agent/mcp",
+			"url": "https://api.superset.sh/api/agent/mcp",
 			"oauth": {
 				"clientId": "claude-code",
-				"authorizationUrl": "http://localhost:3001/api/auth/mcp/authorize",
-				"tokenUrl": "http://localhost:3001/api/auth/mcp/token",
+				"authorizationUrl": "https://api.superset.sh/api/auth/mcp/authorize",
+				"tokenUrl": "https://api.superset.sh/api/auth/mcp/token",
 				"scopes": ["openid", "profile", "email"]
 			}
 		}


### PR DESCRIPTION
## Summary

- Update MCP server URLs from `localhost:3001` to `api.superset.sh` for production use

## Changes

```diff
- "url": "http://localhost:3001/api/agent/mcp"
+ "url": "https://api.superset.sh/api/agent/mcp"

- "authorizationUrl": "http://localhost:3001/api/auth/mcp/authorize"
+ "authorizationUrl": "https://api.superset.sh/api/auth/mcp/authorize"

- "tokenUrl": "http://localhost:3001/api/auth/mcp/token"
+ "tokenUrl": "https://api.superset.sh/api/auth/mcp/token"
```

## Test plan
- [x] `bun run lint:fix` - passes
- [x] `bun test` - 1181 pass, 7 skip
- [ ] Manual test: `/mcp` command connects to production server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication and API endpoints to production servers with enhanced security (HTTPS).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->