### PR TITLE
fix(desktop): prevent browser default behavior for terminal shortcuts

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -464,6 +464,7 @@ export function setupKeyboardHandler(
 
 		if (isShiftEnter) {
 			if (event.type === "keydown" && options.onShiftEnter) {
+				event.preventDefault();
 				options.onShiftEnter();
 			}
 			return false;
@@ -478,6 +479,7 @@ export function setupKeyboardHandler(
 
 		if (isCmdBackspace) {
 			if (event.type === "keydown" && options.onWrite) {
+				event.preventDefault();
 				options.onWrite("\x15\x1b[D"); // Ctrl+U + left arrow
 			}
 			return false;
@@ -493,6 +495,7 @@ export function setupKeyboardHandler(
 
 		if (isCmdLeft) {
 			if (event.type === "keydown" && options.onWrite) {
+				event.preventDefault();
 				options.onWrite("\x01"); // Ctrl+A - beginning of line
 			}
 			return false;
@@ -508,6 +511,7 @@ export function setupKeyboardHandler(
 
 		if (isCmdRight) {
 			if (event.type === "keydown" && options.onWrite) {
+				event.preventDefault();
 				options.onWrite("\x05"); // Ctrl+E - end of line
 			}
 			return false;


### PR DESCRIPTION
## Summary

Fix IME (Input Method Editor) input corruption after using `Cmd+Left`, `Cmd+Right`, `Cmd+Backspace`, or `Shift+Enter` shortcuts in the terminal.

## Problem

When using IME to input CJK characters (Chinese, Japanese, Korean) in the terminal:

1. Type some characters, e.g., "一二三四五" (Chinese for 1-2-3-4-5)
2. Press `Cmd+Left` to move cursor to the beginning of the line
3. Try to type any new character
4. **Bug**: The input becomes corrupted - in this case, any input would result in just "五" (the last character)

### As is

https://github.com/user-attachments/assets/8cfc4729-efc9-4cb6-b31d-4f959e4af24a

### To be


https://github.com/user-attachments/assets/4dc33aad-a5f3-486b-a306-5a3ae17f02aa


### More detail

This issue does **not** occur when:
- Using `Ctrl+A` directly (instead of `Cmd+Left`)
- Typing non-IME characters (English, numbers)
- Using arrow keys to move cursor character by character

## Root Cause

This bug was introduced in #926 (`feat(terminal): add Cmd+Arrow for cursor line navigation`), which remapped shortcuts to match macOS conventions:

| Shortcut | Before #926 | After #926 |
|----------|-------------|------------|
| Terminal switching | `Cmd+Left/Right` | `Cmd+Option+Left/Right` |
| Pane switching | `Cmd+Option+Left/Right` | `Cmd+Shift+Left/Right` |
| Cursor line navigation | (none) | `Cmd+Left/Right` |

xterm.js uses a hidden `<textarea>` element to capture keyboard input and IME composition. When handling custom shortcuts via `attachCustomKeyEventHandler`:

- Returning `false` tells xterm to skip its default key handling
- However, it does **not** call `event.preventDefault()`, so browser default behavior still occurs
- `Cmd+Left` in browsers moves the textarea cursor to the beginning of the text
- This cursor movement in the hidden textarea interferes with IME's internal composition state

## Solution

Add `event.preventDefault()` before handling the following shortcuts:
- `Cmd+Left` (move to line beginning)
- `Cmd+Right` (move to line end)
- `Cmd+Backspace` (delete to line beginning)
- `Shift+Enter` (line continuation)

This prevents the browser from manipulating the hidden textarea's cursor position while we send the appropriate control sequences to the PTY.

## Testing

1. Open terminal in Superset desktop app
2. Switch to an IME (e.g., Chinese Pinyin, Japanese)
3. Type some CJK characters
4. Press `Cmd+Left` to jump to line beginning
6. Type more characters
7. **Expected**: New characters appear at cursor position normally
8. **Before fix**: Input is corrupted

## Additional Notes

A video demonstration can be provided if needed to illustrate the bug and the fix.
