### PR TITLE
feat(desktop): allow renaming projects in sidebar

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/RenameInput/RenameInput.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/RenameInput/RenameInput.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef } from "react";
+
+interface RenameInputProps {
+	value: string;
+	onChange: (value: string) => void;
+	onSubmit: () => void;
+	onCancel: () => void;
+	className?: string;
+}
+
+export function RenameInput({
+	value,
+	onChange,
+	onSubmit,
+	onCancel,
+	className,
+}: RenameInputProps) {
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	useEffect(() => {
+		// Delay to allow context menu to fully close
+		const timer = setTimeout(() => {
+			if (inputRef.current) {
+				inputRef.current.focus();
+				inputRef.current.select();
+			}
+		}, 100);
+		return () => clearTimeout(timer);
+	}, []);
+
+	const handleKeyDown = (e: React.KeyboardEvent) => {
+		e.stopPropagation();
+		if (e.key === "Enter") {
+			e.preventDefault();
+			onSubmit();
+		} else if (e.key === "Escape") {
+			e.preventDefault();
+			onCancel();
+		}
+	};
+
+	return (
+		<input
+			ref={inputRef}
+			type="text"
+			value={value}
+			onChange={(e) => onChange(e.target.value)}
+			onBlur={onSubmit}
+			onKeyDown={handleKeyDown}
+			onClick={(e) => e.stopPropagation()}
+			onMouseDown={(e) => e.stopPropagation()}
+			className={className}
+		/>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/RenameInput/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/RenameInput/index.ts
@@ -1,0 +1,1 @@
+export { RenameInput } from "./RenameInput";

--- a/apps/desktop/src/renderer/screens/main/hooks/useProjectRename/index.ts
+++ b/apps/desktop/src/renderer/screens/main/hooks/useProjectRename/index.ts
@@ -1,0 +1,1 @@
+export { useProjectRename } from "./useProjectRename";

--- a/apps/desktop/src/renderer/screens/main/hooks/useProjectRename/useProjectRename.ts
+++ b/apps/desktop/src/renderer/screens/main/hooks/useProjectRename/useProjectRename.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from "react";
+import { useUpdateProject } from "renderer/react-query/projects/useUpdateProject";
+
+export function useProjectRename(projectId: string, projectName: string) {
+	const [isRenaming, setIsRenaming] = useState(false);
+	const [renameValue, setRenameValue] = useState(projectName);
+	const updateProject = useUpdateProject();
+
+	useEffect(() => {
+		setRenameValue(projectName);
+	}, [projectName]);
+
+	const startRename = () => {
+		setIsRenaming(true);
+	};
+
+	const submitRename = () => {
+		const trimmedValue = renameValue.trim();
+		if (trimmedValue && trimmedValue !== projectName) {
+			updateProject.mutate({
+				id: projectId,
+				patch: { name: trimmedValue },
+			});
+		} else {
+			setRenameValue(projectName);
+		}
+		setIsRenaming(false);
+	};
+
+	const cancelRename = () => {
+		setRenameValue(projectName);
+		setIsRenaming(false);
+	};
+
+	const handleKeyDown = (e: React.KeyboardEvent) => {
+		if (e.key === "Enter") {
+			e.preventDefault();
+			submitRename();
+		} else if (e.key === "Escape") {
+			e.preventDefault();
+			cancelRename();
+		}
+	};
+
+	return {
+		isRenaming,
+		renameValue,
+		setRenameValue,
+		startRename,
+		submitRename,
+		cancelRename,
+		handleKeyDown,
+	};
+}


### PR DESCRIPTION
## Summary
- Add ability to rename projects via right-click context menu in the sidebar
- Support double-click to rename in the expanded sidebar view
- Create reusable `RenameInput` component with auto-focus and text selection

## Test plan
- [ ] Right-click on a project in the sidebar and select "Rename"
- [ ] Verify the input field appears with the project name selected
- [ ] Enter a new name and press Enter or click away to save
- [ ] Press Escape to cancel renaming
- [ ] Double-click on a project name in the expanded sidebar to rename

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline project renaming capability: double-click project name or select "Rename" from context menu
  * Supports keyboard shortcuts: Enter to confirm, Escape to cancel
  * Auto-focuses input field with text pre-selected for quick editing
  * Input validation ensures non-empty, changed names are saved

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->