### PR TITLE
fix(desktop): enable notifications for permission prompts and questions

### DIFF
--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts
@@ -82,6 +82,15 @@ export function getClaudeSettingsContent(notifyPath: string): string {
 			PermissionRequest: [
 				{ matcher: "*", hooks: [{ type: "command", command: notifyPath }] },
 			],
+			// Notification hook fires when Claude Code needs user attention
+			// - permission_prompt: permission dialogs
+			// - elicitation_dialog: when Claude asks questions via MCP tool elicitation
+			Notification: [
+				{
+					matcher: "permission_prompt|elicitation_dialog",
+					hooks: [{ type: "command", command: notifyPath }],
+				},
+			],
 		},
 	};
 

--- a/apps/desktop/src/main/lib/agent-setup/notify-hook.ts
+++ b/apps/desktop/src/main/lib/agent-setup/notify-hook.ts
@@ -4,7 +4,7 @@ import { PORTS } from "shared/constants";
 import { HOOKS_DIR } from "./paths";
 
 export const NOTIFY_SCRIPT_NAME = "notify.sh";
-export const NOTIFY_SCRIPT_MARKER = "# Superset agent notification hook";
+export const NOTIFY_SCRIPT_MARKER = "# Superset agent notification hook v3";
 
 const NOTIFY_SCRIPT_TEMPLATE_PATH = path.join(
 	__dirname,

--- a/apps/desktop/src/main/lib/agent-setup/templates/notify-hook.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/notify-hook.template.sh
@@ -30,6 +30,21 @@ fi
 # Map UserPromptSubmit to Start for simpler handling
 [ "$EVENT_TYPE" = "UserPromptSubmit" ] && EVENT_TYPE="Start"
 
+# Handle Notification hook - check notification_type for user attention events
+if [ "$EVENT_TYPE" = "Notification" ]; then
+  NOTIFICATION_TYPE=$(echo "$INPUT" | grep -oE '"notification_type"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
+  case "$NOTIFICATION_TYPE" in
+    permission_prompt|elicitation_dialog)
+      # Both permission prompts and question dialogs need user attention
+      EVENT_TYPE="PermissionRequest"
+      ;;
+    *)
+      # Ignore other notification types
+      exit 0
+      ;;
+  esac
+fi
+
 # If no event type was found, skip the notification
 # This prevents parse failures from causing false completion notifications
 [ -z "$EVENT_TYPE" ] && exit 0


### PR DESCRIPTION
## Summary
- Fix notifications not showing for "needs attention" states (permission prompts, questions)
- Add `Notification` hook with `permission_prompt` and `elicitation_dialog` matchers to Claude Code settings
- Update notify shell script to handle Notification events and map them to PermissionRequest

## Root Cause
We were only using the `PermissionRequest` hook which is for decision control (auto-approve/deny), not for receiving notifications when dialogs appear. The `Notification` hook with specific matchers is what fires when Claude Code actually displays dialogs requiring user attention.

## Test plan
- [ ] Restart desktop app to regenerate hook scripts
- [ ] Start a Claude agent and trigger a permission request (e.g., run a bash command)
- [ ] Verify "Input Needed" notification appears
- [ ] Test that agent completion ("Agent Complete") notifications still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved notification handling for permission prompts and elicitation dialogs, enabling Claude to trigger notification scripts for these event types.

* **Chores**
  * Updated notification system version marker.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->