### PR TITLE
fix(desktop): remove invalid -M flag from git status command

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
@@ -60,8 +60,8 @@ export async function getStatusNoLock(repoPath: string): Promise<StatusResult> {
 		// Run git status with --no-optional-locks to avoid holding locks
 		// Use porcelain=v1 for machine-parseable output, -b for branch info
 		// Use -z for NUL-terminated output (handles filenames with special chars)
-		// Use -M for rename detection (otherwise renames show as delete + add)
 		// Use -uall to show individual files in untracked directories (not just the directory)
+		// Note: porcelain=v1 already includes rename info (R/C status codes) without needing -M
 		const { stdout } = await execFileAsync(
 			"git",
 			[
@@ -72,7 +72,6 @@ export async function getStatusNoLock(repoPath: string): Promise<StatusResult> {
 				"--porcelain=v1",
 				"-b",
 				"-z",
-				"-M",
 				"-uall",
 			],
 			{ env, timeout: 30_000 },


### PR DESCRIPTION
## Summary

- Remove invalid `-M` flag from the `git status` command in `getStatusNoLock()`
- Update comments to clarify that `porcelain=v1` already includes rename detection

## Problem

When trying to remove a workspace, users saw:
```
Failed to check worktree status: Failed to get git status: Command failed:
git --no-optional-locks -C /path status --porcelain=v1 -b -z -M -uall
error: unknown switch `M'
```

## Root Cause

The `-M` flag is a `git diff` option for rename detection, not a `git status` option. The comment incorrectly stated it was needed for rename detection, but `git status --porcelain=v1` already includes rename information through `R` (rename) and `C` (copy) status codes.

## Test plan

- [ ] Open the desktop app
- [ ] Open a workspace in the sidebar
- [ ] Click the close/remove option
- [ ] Confirm no error appears and the removal dialog works correctly
- [ ] Test both "Hide" and "Delete" options work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized git status command handling for improved efficiency without affecting functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->