### PR TITLE
fix(desktop): respect preset execution mode when using hotkeys

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -81,8 +81,13 @@ function WorkspacePage() {
 	const activeTabIds = useTabsStore((s) => s.activeTabIds);
 	const tabHistoryStacks = useTabsStore((s) => s.tabHistoryStacks);
 	const focusedPaneIds = useTabsStore((s) => s.focusedPaneIds);
-	const { addTab, splitPaneAuto, splitPaneVertical, splitPaneHorizontal } =
-		useTabsWithPresets();
+	const {
+		addTab,
+		splitPaneAuto,
+		splitPaneVertical,
+		splitPaneHorizontal,
+		openPreset,
+	} = useTabsWithPresets();
 	const setActiveTab = useTabsStore((s) => s.setActiveTab);
 	const removePane = useTabsStore((s) => s.removePane);
 	const setFocusedPane = useTabsStore((s) => s.setFocusedPane);
@@ -114,36 +119,17 @@ function WorkspacePage() {
 	const focusedPaneId = activeTabId ? focusedPaneIds[activeTabId] : null;
 
 	const { presets } = usePresets();
-	const renameTab = useTabsStore((s) => s.renameTab);
-	const addTabWithMultiplePanes = useTabsStore(
-		(s) => s.addTabWithMultiplePanes,
-	);
 
 	const openTabWithPreset = useCallback(
 		(presetIndex: number) => {
 			const preset = presets[presetIndex];
 			if (preset) {
-				const isParallel =
-					preset.executionMode === "parallel" && preset.commands.length > 1;
-
-				const { tabId } = isParallel
-					? addTabWithMultiplePanes(workspaceId, {
-							commands: preset.commands,
-							initialCwd: preset.cwd || undefined,
-						})
-					: addTab(workspaceId, {
-							initialCommands: preset.commands,
-							initialCwd: preset.cwd || undefined,
-						});
-
-				if (preset.name) {
-					renameTab(tabId, preset.name);
-				}
+				openPreset(workspaceId, preset);
 			} else {
 				addTab(workspaceId);
 			}
 		},
-		[presets, workspaceId, addTab, addTabWithMultiplePanes, renameTab],
+		[presets, workspaceId, addTab, openPreset],
 	);
 
 	useAppHotkey("NEW_GROUP", () => addTab(workspaceId), undefined, [

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupStrip.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupStrip.tsx
@@ -1,4 +1,3 @@
-import type { TerminalPreset } from "@superset/local-db";
 import { Button } from "@superset/ui/button";
 import {
 	DropdownMenu,
@@ -41,7 +40,7 @@ export function GroupStrip() {
 	const panes = useTabsStore((s) => s.panes);
 	const activeTabIds = useTabsStore((s) => s.activeTabIds);
 	const tabHistoryStacks = useTabsStore((s) => s.tabHistoryStacks);
-	const { addTab } = useTabsWithPresets();
+	const { addTab, openPreset } = useTabsWithPresets();
 	const renameTab = useTabsStore((s) => s.renameTab);
 	const removeTab = useTabsStore((s) => s.removeTab);
 	const setActiveTab = useTabsStore((s) => s.setActiveTab);
@@ -90,30 +89,9 @@ export function GroupStrip() {
 		addTab(activeWorkspaceId);
 	};
 
-	const addTabWithMultiplePanes = useTabsStore(
-		(s) => s.addTabWithMultiplePanes,
-	);
-
-	const handleSelectPreset = (preset: TerminalPreset) => {
+	const handleSelectPreset = (preset: Parameters<typeof openPreset>[1]) => {
 		if (!activeWorkspaceId) return;
-
-		const isParallel =
-			preset.executionMode === "parallel" && preset.commands.length > 1;
-
-		const { tabId } = isParallel
-			? addTabWithMultiplePanes(activeWorkspaceId, {
-					commands: preset.commands,
-					initialCwd: preset.cwd || undefined,
-				})
-			: addTab(activeWorkspaceId, {
-					initialCommands: preset.commands,
-					initialCwd: preset.cwd || undefined,
-				});
-
-		if (preset.name) {
-			renameTab(tabId, preset.name);
-		}
-
+		openPreset(activeWorkspaceId, preset);
 		setDropdownOpen(false);
 	};
 

--- a/apps/desktop/src/renderer/stores/tabs/useTabsWithPresets.ts
+++ b/apps/desktop/src/renderer/stores/tabs/useTabsWithPresets.ts
@@ -1,3 +1,4 @@
+import type { TerminalPreset } from "@superset/local-db";
 import { useCallback, useMemo } from "react";
 import type { MosaicBranch } from "react-mosaic-component";
 import { usePresets } from "renderer/react-query/presets";
@@ -138,12 +139,37 @@ export function useTabsWithPresets() {
 		[storeSplitPaneAuto, defaultPresetOptions],
 	);
 
+	const openPreset = useCallback(
+		(workspaceId: string, preset: TerminalPreset) => {
+			const isParallel =
+				preset.executionMode === "parallel" && preset.commands.length > 1;
+
+			const { tabId } = isParallel
+				? storeAddTabWithMultiplePanes(workspaceId, {
+						commands: preset.commands,
+						initialCwd: preset.cwd || undefined,
+					})
+				: storeAddTab(workspaceId, {
+						initialCommands: preset.commands,
+						initialCwd: preset.cwd || undefined,
+					});
+
+			if (preset.name) {
+				renameTab(tabId, preset.name);
+			}
+
+			return { tabId };
+		},
+		[storeAddTab, storeAddTabWithMultiplePanes, renameTab],
+	);
+
 	return {
 		addTab,
 		addPane,
 		splitPaneVertical,
 		splitPaneHorizontal,
 		splitPaneAuto,
+		openPreset,
 		defaultPreset,
 	};
 }


### PR DESCRIPTION
## Summary

- Preset hotkeys (Ctrl+1-9) now correctly execute commands in parallel when the preset's `executionMode` is set to `"parallel"`, matching the behavior of the dropdown menu
- Extracted shared `openPreset` function into `useTabsWithPresets` hook to consolidate preset-opening logic

## Problem

The hotkey handler always called `addTab` which creates a single pane and joins commands with `&&` (sequential execution), ignoring the preset's `executionMode` setting. The dropdown menu correctly handled this by checking the execution mode and calling `addTabWithMultiplePanes` for parallel presets.

## Test plan

- [x] Create a preset with multiple commands and `executionMode: "parallel"`
- [x] Open via dropdown menu: commands execute in parallel (separate panes)
- [x] Open via hotkey (Ctrl+1): commands also execute in parallel (separate panes)
- [x] Verify sequential presets still work correctly via both paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Streamlined workspace preset operations with a unified preset-opening mechanism that consolidates multiple manual steps and conditional logic into a single, consistent action across all workspace components.

* **Refactor**
  * Simplified preset-handling code by eliminating redundant operations and reorganizing how workspace presets are created, opened, and managed throughout the application for improved consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->