### PR TITLE
fix(desktop): improve auth token handling on re-authentication

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/auth/utils/auth-functions.ts
+++ b/apps/desktop/src/lib/trpc/routers/auth/utils/auth-functions.ts
@@ -16,6 +16,10 @@ export const stateStore = new Map<string, number>();
 /**
  * Event emitter for auth-related events.
  * Used by tRPC subscription to notify renderer of token changes.
+ *
+ * Events:
+ * - "token-saved": { token, expiresAt } - New token saved (OAuth callback)
+ * - "token-cleared": (no data) - Token deleted (sign-out)
  */
 export const authEvents = new EventEmitter();
 

--- a/apps/desktop/src/renderer/providers/AuthProvider/AuthProvider.tsx
+++ b/apps/desktop/src/renderer/providers/AuthProvider/AuthProvider.tsx
@@ -39,15 +39,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 		setIsHydrated(true);
 	}, [storedToken, isSuccess, isHydrated, refetchSession]);
 
-	// Listen for token changes from main process (OAuth callback or sign-out)
+	// Listen for auth events from main process (new auth or sign-out only, not hydration)
 	electronTrpc.auth.onTokenChanged.useSubscription(undefined, {
-		onData: (data) => {
+		onData: async (data) => {
 			if (data?.token && data?.expiresAt) {
+				// New authentication - clear old session state first, then set new token
+				setAuthToken(null);
+				await authClient.signOut({ fetchOptions: { throw: false } });
 				setAuthToken(data.token);
 				setIsHydrated(true);
 				refetchSession();
 			} else if (data === null) {
-				// Token was cleared (sign-out)
+				// Sign-out
 				setAuthToken(null);
 				refetchSession();
 			}


### PR DESCRIPTION
## Summary

Fixes an issue where re-authenticating (e.g., switching accounts) could leave stale session state, causing data inconsistencies.

## Changes

- **Subscription no longer emits on subscribe** - Use `getStoredToken` query for initial hydration instead of relying on subscription's initial emit
- **Clear old session before setting new token** - AuthProvider now explicitly clears old session state before applying new auth token
- **Documentation** - Added docs for auth event emitter

## Root Cause

The `onTokenChanged` subscription was emitting the current token on subscribe, which worked for initial load but caused issues on re-authentication. When a new OAuth callback came in, the subscription would fire with the new token, but the old session state wasn't cleared first.

## Test Plan

- [ ] Sign in with account A
- [ ] Sign out
- [ ] Sign in with account B
- [ ] Verify no stale data from account A appears
- [ ] Refresh app, verify session persists correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time token change subscription for immediate authentication state updates.

* **Improvements**
  * Enhanced token refresh handling to clear prior session state before establishing new tokens, ensuring more reliable authentication state management.

* **Removals**
  * Removed device information query.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->