### PR TITLE
feat(api): migrate MCP task tools to array-native inputs

### DIFF
--- a/apps/api/src/lib/mcp/tools/tasks/update-task/update-task.ts
+++ b/apps/api/src/lib/mcp/tools/tasks/update-task/update-task.ts
@@ -5,91 +5,143 @@ import { and, eq, isNull } from "drizzle-orm";
 import { z } from "zod";
 import { registerTool } from "../../utils";
 
+const UUID_REGEX =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const updateSchema = z.object({
+	taskId: z.string().describe("Task ID (uuid) or slug"),
+	title: z.string().min(1).optional().describe("New title"),
+	description: z.string().optional().describe("New description"),
+	priority: z.enum(["urgent", "high", "medium", "low", "none"]).optional(),
+	assigneeId: z
+		.string()
+		.uuid()
+		.nullable()
+		.optional()
+		.describe("New assignee (null to unassign)"),
+	statusId: z.string().uuid().optional().describe("New status ID"),
+	labels: z.array(z.string()).optional().describe("Replace labels"),
+	dueDate: z
+		.string()
+		.datetime()
+		.nullable()
+		.optional()
+		.describe("New due date (null to clear)"),
+	estimate: z.number().int().positive().nullable().optional(),
+});
+
+type UpdateInput = z.infer<typeof updateSchema>;
+
 export const register = registerTool(
 	"update_task",
 	{
-		description: "Update an existing task",
+		description: "Update one or more existing tasks",
 		inputSchema: {
-			taskId: z.string().describe("Task ID (uuid) or slug"),
-			title: z.string().min(1).optional().describe("New title"),
-			description: z.string().optional().describe("New description"),
-			priority: z.enum(["urgent", "high", "medium", "low", "none"]).optional(),
-			assigneeId: z
-				.string()
-				.uuid()
-				.nullable()
-				.optional()
-				.describe("New assignee (null to unassign)"),
-			statusId: z.string().uuid().optional().describe("New status ID"),
-			labels: z.array(z.string()).optional().describe("Replace labels"),
-			dueDate: z
-				.string()
-				.datetime()
-				.nullable()
-				.optional()
-				.describe("New due date (null to clear)"),
-			estimate: z.number().int().positive().nullable().optional(),
+			updates: z
+				.array(updateSchema)
+				.min(1)
+				.max(25)
+				.describe("Array of task updates (1-25)"),
 		},
 	},
 	async (params, ctx) => {
-		const taskId = params.taskId as string;
-		const isUuid =
-			/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
-				taskId,
-			);
+		const updates = params.updates as UpdateInput[];
 
-		const [existingTask] = await db
-			.select()
-			.from(tasks)
-			.where(
-				and(
-					isUuid ? eq(tasks.id, taskId) : eq(tasks.slug, taskId),
-					eq(tasks.organizationId, ctx.organizationId),
-					isNull(tasks.deletedAt),
-				),
-			)
-			.limit(1);
+		// First pass: resolve all tasks and validate they exist
+		const resolvedUpdates: {
+			taskId: string;
+			updateData: Record<string, unknown>;
+		}[] = [];
 
-		if (!existingTask) {
-			return {
-				content: [{ type: "text", text: "Error: Task not found" }],
-				isError: true,
-			};
+		for (const [i, update] of updates.entries()) {
+			const taskId = update.taskId;
+			const isUuid = UUID_REGEX.test(taskId);
+
+			const [existingTask] = await db
+				.select({ id: tasks.id })
+				.from(tasks)
+				.where(
+					and(
+						isUuid ? eq(tasks.id, taskId) : eq(tasks.slug, taskId),
+						eq(tasks.organizationId, ctx.organizationId),
+						isNull(tasks.deletedAt),
+					),
+				)
+				.limit(1);
+
+			if (!existingTask) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: JSON.stringify(
+								{
+									error: `Task not found: ${taskId}`,
+									failedAt: { index: i, taskId },
+								},
+								null,
+								2,
+							),
+						},
+					],
+					isError: true,
+				};
+			}
+
+			// Build update data for this task
+			const updateData: Record<string, unknown> = {};
+			if (update.title !== undefined) updateData.title = update.title;
+			if (update.description !== undefined)
+				updateData.description = update.description;
+			if (update.priority !== undefined) updateData.priority = update.priority;
+			if (update.assigneeId !== undefined)
+				updateData.assigneeId = update.assigneeId;
+			if (update.statusId !== undefined) updateData.statusId = update.statusId;
+			if (update.labels !== undefined) updateData.labels = update.labels;
+			if (update.dueDate !== undefined)
+				updateData.dueDate = update.dueDate ? new Date(update.dueDate) : null;
+			if (update.estimate !== undefined) updateData.estimate = update.estimate;
+
+			if (Object.keys(updateData).length === 0) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: JSON.stringify(
+								{
+									error: `No updatable fields provided for task: ${taskId}`,
+									failedAt: { index: i, taskId },
+								},
+								null,
+								2,
+							),
+						},
+					],
+					isError: true,
+				};
+			}
+
+			resolvedUpdates.push({ taskId: existingTask.id, updateData });
 		}
 
-		const updateData: Record<string, unknown> = {};
-		if (params.title !== undefined) updateData.title = params.title;
-		if (params.description !== undefined)
-			updateData.description = params.description;
-		if (params.priority !== undefined) updateData.priority = params.priority;
-		if (params.assigneeId !== undefined)
-			updateData.assigneeId = params.assigneeId;
-		if (params.statusId !== undefined) updateData.statusId = params.statusId;
-		if (params.labels !== undefined) updateData.labels = params.labels;
-		if (params.dueDate !== undefined)
-			updateData.dueDate = params.dueDate
-				? new Date(params.dueDate as string)
-				: null;
-		if (params.estimate !== undefined) updateData.estimate = params.estimate;
-
-		if (Object.keys(updateData).length === 0) {
-			return {
-				content: [
-					{ type: "text", text: "Error: No updatable fields provided" },
-				],
-				isError: true,
-			};
-		}
-
+		// Second pass: apply all updates in a single transaction
 		const result = await dbWs.transaction(async (tx) => {
-			const [task] = await tx
-				.update(tasks)
-				.set(updateData)
-				.where(eq(tasks.id, existingTask.id))
-				.returning();
+			const updatedTasks: { id: string; slug: string; title: string }[] = [];
+
+			for (const { taskId, updateData } of resolvedUpdates) {
+				const [task] = await tx
+					.update(tasks)
+					.set(updateData)
+					.where(eq(tasks.id, taskId))
+					.returning({ id: tasks.id, slug: tasks.slug, title: tasks.title });
+
+				if (task) {
+					updatedTasks.push(task);
+				}
+			}
 
 			const txid = await getCurrentTxid(tx);
-			return { task, txid };
+			return { updatedTasks, txid };
 		});
 
 		return {
@@ -98,9 +150,7 @@ export const register = registerTool(
 					type: "text",
 					text: JSON.stringify(
 						{
-							id: result.task?.id,
-							slug: result.task?.slug,
-							title: result.task?.title,
+							updated: result.updatedTasks,
 							txid: result.txid,
 						},
 						null,


### PR DESCRIPTION
## Summary

- Migrate `create_task`, `update_task`, and `delete_task` MCP tools from single-item to array-native inputs
- All operations now accept arrays (1-25 items) and process them in a single transaction
- All-or-nothing semantics: entire batch fails if any item fails

## Changes

| Tool | Before | After |
|------|--------|-------|
| `create_task` | `{ title, description?, ... }` | `{ tasks: TaskInput[] }` |
| `update_task` | `{ taskId, title?, ... }` | `{ updates: UpdateInput[] }` |
| `delete_task` | `{ taskId }` | `{ taskIds: string[] }` |

## Test plan

- [x] Tested batch create (3 tasks in single call)
- [x] Tested batch update (3 tasks with different fields)
- [x] Tested batch delete (3 tasks by slug)
- [x] Verified deleted tasks are filtered from list
- [x] TypeScript compiles without errors
- [x] Linting passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **Bulk Task Creation**: Create multiple tasks (1-25) in a single operation
* **Bulk Task Deletion**: Delete multiple tasks (1-25) in a single operation
* **Bulk Task Updates**: Update multiple tasks (1-25) in a single operation
* **Transactional Processing**: All batch operations complete within a single database transaction
* **Granular Error Reporting**: Detailed feedback for each item when batch operations encounter issues

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->