### PR TITLE
feat(desktop): show Linear CTA in tasks view when not connected

### DIFF
--- a/apps/api/src/app/api/electric/[...path]/utils.ts
+++ b/apps/api/src/app/api/electric/[...path]/utils.ts
@@ -3,6 +3,7 @@ import {
 	agentCommands,
 	apikeys,
 	devicePresence,
+	integrationConnections,
 	invitations,
 	members,
 	organizations,
@@ -24,7 +25,8 @@ export type AllowedTable =
 	| "auth.invitations"
 	| "auth.apikeys"
 	| "device_presence"
-	| "agent_commands";
+	| "agent_commands"
+	| "integration_connections";
 
 interface WhereClause {
 	fragment: string;
@@ -107,6 +109,13 @@ export async function buildWhereClause(
 
 		case "auth.apikeys":
 			return build(apikeys, apikeys.userId, userId);
+
+		case "integration_connections":
+			return build(
+				integrationConnections,
+				integrationConnections.organizationId,
+				organizationId,
+			);
 
 		default:
 			return null;

--- a/apps/desktop/src/lib/trpc/routers/auth/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/auth/index.ts
@@ -4,6 +4,7 @@ import { AUTH_PROVIDERS } from "@superset/shared/constants";
 import { observable } from "@trpc/server/observable";
 import { shell } from "electron";
 import { env } from "main/env.main";
+import { getDeviceName, getHashedDeviceId } from "main/lib/device-info";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
 import {
@@ -17,6 +18,11 @@ import {
 export const createAuthRouter = () => {
 	return router({
 		getStoredToken: publicProcedure.query(() => loadToken()),
+
+		getDeviceInfo: publicProcedure.query(() => ({
+			deviceId: getHashedDeviceId(),
+			deviceName: getDeviceName(),
+		})),
 
 		persistToken: publicProcedure
 			.input(

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/TasksView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/TasksView.tsx
@@ -1,16 +1,34 @@
 import { ScrollArea } from "@superset/ui/scroll-area";
 import { Spinner } from "@superset/ui/spinner";
+import { eq } from "@tanstack/db";
+import { useLiveQuery } from "@tanstack/react-db";
 import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import { HiCheckCircle } from "react-icons/hi2";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { LinearCTA } from "./components/LinearCTA";
 import { TasksTableView } from "./components/TasksTableView";
 import { type TabValue, TasksTopBar } from "./components/TasksTopBar";
 import { type TaskWithStatus, useTasksTable } from "./hooks/useTasksTable";
 
 export function TasksView() {
 	const navigate = useNavigate();
+	const collections = useCollections();
 	const [currentTab, setCurrentTab] = useState<TabValue>("all");
 	const [searchQuery, setSearchQuery] = useState("");
+
+	const { data: integrations, isLoading: isCheckingLinear } = useLiveQuery(
+		(q) =>
+			q
+				.from({ integrationConnections: collections.integrationConnections })
+				.where(({ integrationConnections }) =>
+					eq(integrationConnections.provider, "linear"),
+				)
+				.select(({ integrationConnections }) => integrationConnections),
+		[collections],
+	);
+
+	const isLinearConnected = integrations && integrations.length > 0;
 
 	const { table, isLoading, slugColumnWidth } = useTasksTable({
 		filterTab: currentTab,
@@ -24,27 +42,38 @@ export function TasksView() {
 		});
 	};
 
+	const showLoading = isLoading || isCheckingLinear;
+	const showLinearCTA = !showLoading && !isLinearConnected;
+	const showEmptyState =
+		!showLoading && isLinearConnected && table.getRowModel().rows.length === 0;
+	const showTable =
+		!showLoading && isLinearConnected && table.getRowModel().rows.length > 0;
+
 	return (
 		<div className="flex-1 flex flex-col min-h-0">
-			<TasksTopBar
-				currentTab={currentTab}
-				onTabChange={setCurrentTab}
-				searchQuery={searchQuery}
-				onSearchChange={setSearchQuery}
-			/>
+			{!showLinearCTA && (
+				<TasksTopBar
+					currentTab={currentTab}
+					onTabChange={setCurrentTab}
+					searchQuery={searchQuery}
+					onSearchChange={setSearchQuery}
+				/>
+			)}
 
-			{isLoading ? (
+			{showLoading ? (
 				<div className="flex-1 flex items-center justify-center">
 					<Spinner className="size-5" />
 				</div>
-			) : table.getRowModel().rows.length === 0 ? (
+			) : showLinearCTA ? (
+				<LinearCTA />
+			) : showEmptyState ? (
 				<div className="flex-1 flex items-center justify-center">
 					<div className="flex flex-col items-center gap-2 text-muted-foreground">
 						<HiCheckCircle className="h-8 w-8" />
 						<span className="text-sm">No tasks found</span>
 					</div>
 				</div>
-			) : (
+			) : showTable ? (
 				<ScrollArea className="flex-1 min-h-0">
 					<TasksTableView
 						table={table}
@@ -52,7 +81,7 @@ export function TasksView() {
 						onTaskClick={handleTaskClick}
 					/>
 				</ScrollArea>
-			)}
+			) : null}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/LinearCTA/LinearCTA.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/LinearCTA/LinearCTA.tsx
@@ -1,0 +1,29 @@
+import { Button } from "@superset/ui/button";
+import { useNavigate } from "@tanstack/react-router";
+import { SiLinear } from "react-icons/si";
+
+export function LinearCTA() {
+	const navigate = useNavigate();
+
+	const handleConnectLinear = () => {
+		navigate({ to: "/settings/integrations" });
+	};
+
+	return (
+		<div className="flex-1 flex items-center justify-center p-6">
+			<div className="flex flex-col items-center gap-4 max-w-md text-center">
+				<div className="flex size-16 items-center justify-center rounded-xl border bg-muted/50">
+					<SiLinear className="size-8" />
+				</div>
+				<div className="space-y-2">
+					<h3 className="text-lg font-semibold">Connect Linear</h3>
+					<p className="text-sm text-muted-foreground">
+						Connect your Linear workspace to sync issues and manage tasks
+						directly from Superset.
+					</p>
+				</div>
+				<Button onClick={handleConnectLinear}>Connect Linear</Button>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/LinearCTA/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/LinearCTA/index.ts
@@ -1,0 +1,1 @@
+export { LinearCTA } from "./LinearCTA";

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
@@ -2,6 +2,7 @@ import { snakeCamelMapper } from "@electric-sql/client";
 import type {
 	SelectAgentCommand,
 	SelectDevicePresence,
+	SelectIntegrationConnection,
 	SelectInvitation,
 	SelectMember,
 	SelectOrganization,
@@ -32,6 +33,7 @@ interface OrgCollections {
 	invitations: Collection<SelectInvitation>;
 	agentCommands: Collection<SelectAgentCommand>;
 	devicePresence: Collection<SelectDevicePresence>;
+	integrationConnections: Collection<SelectIntegrationConnection>;
 }
 
 // Per-org collections cache
@@ -277,6 +279,22 @@ function createOrgCollections(organizationId: string): OrgCollections {
 		}),
 	);
 
+	const integrationConnections = createCollection(
+		electricCollectionOptions<SelectIntegrationConnection>({
+			id: `integration_connections-${organizationId}`,
+			shapeOptions: {
+				url: electricUrl,
+				params: {
+					table: "integration_connections",
+					organizationId,
+				},
+				headers,
+				columnMapper,
+			},
+			getKey: (item) => item.id,
+		}),
+	);
+
 	return {
 		tasks,
 		taskStatuses,
@@ -286,6 +304,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 		invitations,
 		agentCommands,
 		devicePresence,
+		integrationConnections,
 	};
 }
 


### PR DESCRIPTION
## Summary
- Display a call-to-action in the tasks view when users haven't connected Linear
- Shows Linear logo, description, and "Connect Linear" button instead of empty state
- Button navigates to the local integrations settings page

## Test plan
- [ ] Open the tasks view without Linear connected - should see the CTA
- [ ] Click "Connect Linear" button - should navigate to `/settings/integrations`
- [ ] Connect Linear and return to tasks view - should see the normal tasks view (empty state or tasks table)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects Linear connectivity in Tasks view and shows a "Connect Linear" prompt when not connected
  * Displays loading indicators while Linear connection status is being verified
  * Shows an empty-state when connected but no tasks exist; otherwise displays tasks list

* **Refactor**
  * Consolidated loading/connectivity checks to improve rendering logic and UI consistency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->