### PR TITLE
feat(api): add advanced filters to list_tasks MCP tool

### DIFF
--- a/apps/api/src/lib/mcp/tools/tasks/list-tasks/list-tasks.ts
+++ b/apps/api/src/lib/mcp/tools/tasks/list-tasks/list-tasks.ts
@@ -1,7 +1,7 @@
 import { db } from "@superset/db/client";
 import { taskStatuses, tasks, users } from "@superset/db/schema";
 import type { SQL } from "drizzle-orm";
-import { and, desc, eq, ilike, isNull, or } from "drizzle-orm";
+import { and, desc, eq, ilike, isNull, or, sql } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { z } from "zod";
 import { registerTool } from "../../utils";
@@ -35,8 +35,21 @@ export const register = registerTool(
 				.boolean()
 				.optional()
 				.describe("Filter to tasks assigned to current user"),
+			creatorId: z.string().uuid().optional().describe("Filter by creator"),
+			createdByMe: z
+				.boolean()
+				.optional()
+				.describe("Filter to tasks created by current user"),
 			priority: z.enum(["urgent", "high", "medium", "low", "none"]).optional(),
+			labels: z
+				.array(z.string())
+				.optional()
+				.describe("Filter by labels (tasks must have ALL specified labels)"),
 			search: z.string().optional().describe("Search in title/description"),
+			includeDeleted: z
+				.boolean()
+				.optional()
+				.describe("Include deleted tasks in results"),
 			limit: z.number().int().min(1).max(100).default(50),
 			offset: z.number().int().min(0).default(0),
 		},
@@ -46,18 +59,26 @@ export const register = registerTool(
 		const statusType = params.statusType as TaskStatusType | undefined;
 		const assigneeId = params.assigneeId as string | undefined;
 		const assignedToMe = params.assignedToMe as boolean | undefined;
+		const creatorId = params.creatorId as string | undefined;
+		const createdByMe = params.createdByMe as boolean | undefined;
 		const priority = params.priority;
+		const labels = params.labels as string[] | undefined;
 		const search = params.search as string | undefined;
+		const includeDeleted = params.includeDeleted as boolean | undefined;
 		const limit = params.limit as number;
 		const offset = params.offset as number;
 
 		const assignee = alias(users, "assignee");
+		const creator = alias(users, "creator");
 		const status = alias(taskStatuses, "status");
 
 		const conditions: SQL<unknown>[] = [
 			eq(tasks.organizationId, ctx.organizationId),
-			isNull(tasks.deletedAt),
 		];
+
+		if (!includeDeleted) {
+			conditions.push(isNull(tasks.deletedAt));
+		}
 
 		if (statusId) {
 			conditions.push(eq(tasks.statusId, statusId));
@@ -69,8 +90,19 @@ export const register = registerTool(
 			conditions.push(eq(tasks.assigneeId, ctx.userId));
 		}
 
+		if (creatorId) {
+			conditions.push(eq(tasks.creatorId, creatorId));
+		} else if (createdByMe) {
+			conditions.push(eq(tasks.creatorId, ctx.userId));
+		}
+
 		if (isPriority(priority)) {
 			conditions.push(eq(tasks.priority, priority));
+		}
+
+		if (labels && labels.length > 0) {
+			// JSONB containment: tasks.labels must contain ALL specified labels
+			conditions.push(sql`${tasks.labels} @> ${JSON.stringify(labels)}::jsonb`);
 		}
 
 		if (search) {
@@ -129,13 +161,17 @@ export const register = registerTool(
 				statusType: status.type,
 				assigneeId: tasks.assigneeId,
 				assigneeName: assignee.name,
+				creatorId: tasks.creatorId,
+				creatorName: creator.name,
 				labels: tasks.labels,
 				dueDate: tasks.dueDate,
 				estimate: tasks.estimate,
 				createdAt: tasks.createdAt,
+				deletedAt: tasks.deletedAt,
 			})
 			.from(tasks)
 			.leftJoin(assignee, eq(tasks.assigneeId, assignee.id))
+			.leftJoin(creator, eq(tasks.creatorId, creator.id))
 			.leftJoin(status, eq(tasks.statusId, status.id))
 			.where(and(...conditions))
 			.orderBy(desc(tasks.createdAt))


### PR DESCRIPTION
## Summary

- Add `creatorId` and `createdByMe` filters to filter tasks by creator
- Add `labels` filter with JSONB containment (tasks must have ALL specified labels)
- Add `includeDeleted` filter to optionally include soft-deleted tasks
- Include `creatorId`, `creatorName`, and `deletedAt` in response

## Test plan

- [x] Tested `createdByMe=true` filter
- [x] Tested `labels=["Feature"]` filter with JSONB containment
- [x] Tested combined filters (statusType + priority)
- [x] Verified all existing filters still work (statusType, priority, assignedToMe, search)
- [x] Lint, typecheck, and tests pass