### PR TITLE
fix(desktop): validate branch name for git ref path conflicts

### DIFF
--- a/apps/desktop/src/shared/utils/branch.ts
+++ b/apps/desktop/src/shared/utils/branch.ts
@@ -20,3 +20,41 @@ export function sanitizeBranchName(name: string): string {
 		.filter(Boolean)
 		.join("/");
 }
+
+/**
+ * Checks if a new branch name would conflict with existing branches due to
+ * Git's ref storage using file/directory structure.
+ *
+ * Git stores branches as files in .git/refs/heads/. This means:
+ * - If "release" exists as a branch (file at refs/heads/release), you cannot
+ *   create "release/v1" (which would need refs/heads/release/ as a directory)
+ * - If "release/v1" exists, you cannot create "release" (same conflict)
+ *
+ * @param newBranch - The branch name to create
+ * @param existingBranches - List of existing branch names
+ * @returns The conflicting branch name if found, null otherwise
+ */
+export function findBranchPathConflict(
+	newBranch: string,
+	existingBranches: string[],
+): string | null {
+	const newBranchLower = newBranch.toLowerCase();
+
+	for (const existing of existingBranches) {
+		const existingLower = existing.toLowerCase();
+
+		// Check if the new branch would be a "child" of an existing branch
+		// e.g., creating "release/v61" when "release" exists
+		if (newBranchLower.startsWith(`${existingLower}/`)) {
+			return existing;
+		}
+
+		// Check if the new branch would be a "parent" of an existing branch
+		// e.g., creating "release" when "release/v61" exists
+		if (existingLower.startsWith(`${newBranchLower}/`)) {
+			return existing;
+		}
+	}
+
+	return null;
+}


### PR DESCRIPTION
## Summary
- Adds early validation to detect when a new branch name would conflict with existing branches due to Git's ref storage structure
- Provides a clear error message with a suggested alternative (e.g., "Try using release-v61 instead")
- Validation happens before any database writes or background jobs start, so MCP and UI both get immediate feedback

## Problem
When creating a workspace with branch name `release/v61`, if a branch `release` already exists, Git fails with a cryptic error:
```
fatal: 'refs/heads/release' exists; cannot create 'refs/heads/release/v61'
```

This happened during background initialization, so the MCP got no useful feedback and the UI showed a generic "Workspace setup failed" dialog.

## Solution
Added `findBranchPathConflict()` function that checks if a new branch name would conflict with existing branches. Now users see:
```
Cannot create branch "release/v61" because branch "release" already exists. 
Git cannot have branches where one is a path prefix of another. 
Try using "release-v61" instead.
```

## Test plan
- [x] Added unit tests for `findBranchPathConflict()` function
- [ ] Try creating a workspace with branch name that conflicts with existing branch
- [ ] Verify error shows up immediately in UI and MCP response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch creation to detect and prevent naming conflicts with existing branches. Users now receive helpful error messages with suggestions for alternative names when conflicts occur.

* **Tests**
  * Added test coverage for branch conflict detection scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->