### PR TITLE
feat(desktop): gate GitHub integration behind feature flag

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/integrations/components/IntegrationsSettings/IntegrationsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/integrations/components/IntegrationsSettings/IntegrationsSettings.tsx
@@ -1,3 +1,4 @@
+import { FEATURE_FLAGS } from "@superset/shared/constants";
 import { Badge } from "@superset/ui/badge";
 import { Button } from "@superset/ui/button";
 import {
@@ -8,6 +9,7 @@ import {
 } from "@superset/ui/card";
 import { Skeleton } from "@superset/ui/skeleton";
 import { useLiveQuery } from "@tanstack/react-db";
+import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useCallback, useEffect, useState } from "react";
 import { FaGithub } from "react-icons/fa";
 import { HiCheckCircle, HiOutlineArrowTopRightOnSquare } from "react-icons/hi2";
@@ -54,14 +56,17 @@ export function IntegrationsSettings({
 		useState<GithubInstallation | null>(null);
 	const [isLoadingGithub, setIsLoadingGithub] = useState(true);
 
+	const hasGithubAccess = useFeatureFlagEnabled(
+		FEATURE_FLAGS.GITHUB_INTEGRATION_ACCESS,
+	);
+
 	const showLinear = isItemVisible(
 		SETTING_ITEM_ID.INTEGRATIONS_LINEAR,
 		visibleItems,
 	);
-	const showGithub = isItemVisible(
-		SETTING_ITEM_ID.INTEGRATIONS_GITHUB,
-		visibleItems,
-	);
+	const showGithub =
+		hasGithubAccess &&
+		isItemVisible(SETTING_ITEM_ID.INTEGRATIONS_GITHUB, visibleItems);
 
 	const fetchGithubInstallation = useCallback(async () => {
 		if (!activeOrganizationId) {

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -52,4 +52,6 @@ export const FEATURE_FLAGS = {
 	BILLING_ENABLED: "billing-enabled",
 	/** Gates access to MCP agent commands (cloud-to-desktop sync). */
 	AGENT_COMMANDS_ACCESS: "agent-commands-access",
+	/** Gates access to GitHub integration (currently buggy, internal only). */
+	GITHUB_INTEGRATION_ACCESS: "github-integration-access",
 } as const;


### PR DESCRIPTION
## Summary
- Adds `github-integration-access` PostHog feature flag to gate the GitHub integration in desktop settings
- Only users with `@superset.sh` emails can see the GitHub integration (currently buggy)
- Feature flag created and enabled in Production and Preview PostHog environments

## Changes
- Added `GITHUB_INTEGRATION_ACCESS` constant to `packages/shared/src/constants.ts`
- Updated `IntegrationsSettings.tsx` to check feature flag before showing GitHub card

## Test plan
- [ ] Verify GitHub integration is hidden for non-superset.sh users
- [ ] Verify GitHub integration is visible for @superset.sh users