### PR TITLE
feat(docs,marketing): move video above quickstart, hide blog link

### DIFF
--- a/apps/docs/content/docs/quick-start.mdx
+++ b/apps/docs/content/docs/quick-start.mdx
@@ -3,15 +3,6 @@ title: Quick Start
 description: Get up and running with Superset in minutes
 ---
 
-## Quick Start
-
-1. **Download** - Get Superset for macOS
-2. **Sign in** - Create an account or sign in
-3. **Add a repo** - From local folder or Git URL
-4. **Create workspace** - Pick a branch and start working
-
-<DownloadButton />
-
 <iframe
   width="100%"
   style={{ aspectRatio: '16/9' }}
@@ -21,6 +12,15 @@ description: Get up and running with Superset in minutes
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
   allowFullScreen
 />
+
+## Quick Start
+
+1. **Download** - Get Superset for macOS
+2. **Sign in** - Create an account or sign in
+3. **Add a repo** - From local folder or Git URL
+4. **Create workspace** - Pick a branch and start working
+
+<DownloadButton />
 
 ## Requirements
 

--- a/apps/marketing/src/app/components/Header/Header.tsx
+++ b/apps/marketing/src/app/components/Header/Header.tsx
@@ -26,7 +26,6 @@ function SupersetLogo() {
 
 const NAV_LINKS = [
 	{ href: COMPANY.DOCS_URL, label: "Docs", external: true },
-	{ href: "/blog", label: "Blog", external: false },
 	{ href: "/community", label: "Community", external: false },
 ];
 


### PR DESCRIPTION
## Summary
- Move demo video to top of quick-start docs page for better visibility
- Remove blog link from marketing site header navigation

## Test plan
- [ ] Verify video appears at top of https://docs.superset.sh/quick-start
- [ ] Verify blog link is no longer in marketing site header

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Restructured Quick Start guide with improved organization and flow
  * Added new "Next Steps" section with helpful navigation links
  * Expanded Requirements section to include Git installation and authentication setup details

* **UI Changes**
  * Removed Blog link from header navigation menu

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->