### PR TITLE
feat(desktop): make base branch tooltip hover-only

### DIFF
--- a/packages/ui/src/components/ui/tooltip.tsx
+++ b/packages/ui/src/components/ui/tooltip.tsx
@@ -20,12 +20,17 @@ function TooltipProvider({
 
 function Tooltip({
 	delayDuration,
+	disableHoverableContent,
 	...props
 }: React.ComponentProps<typeof TooltipPrimitive.Root> & {
 	delayDuration?: number;
+	disableHoverableContent?: boolean;
 }) {
 	return (
-		<TooltipProvider delayDuration={delayDuration}>
+		<TooltipProvider
+			delayDuration={delayDuration}
+			disableHoverableContent={disableHoverableContent}
+		>
 			<TooltipPrimitive.Root data-slot="tooltip" {...props} />
 		</TooltipProvider>
 	);


### PR DESCRIPTION
## Summary
- Makes the base branch selector tooltip close when leaving the trigger element, rather than staying open when hovering the tooltip bubble
- Adds a 100ms close delay so it doesn't feel too abrupt
- Adds `disableHoverableContent` prop to the shared Tooltip component for future use

## Problem
The "Change base branch" tooltip would remain open when moving the cursor toward the PR button, blocking clicks on the PR link.

## Test plan
- [x] Hover over the base branch selector in the Changes sidebar
- [x] Verify tooltip appears
- [x] Move cursor away from the selector toward the PR button
- [x] Verify tooltip closes and doesn't block clicking the PR link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new configuration option to Tooltip component for enhanced control over tooltip behavior.

* **Bug Fixes**
  * Improved hover interactions for the Base branch selector tooltip with better responsiveness and visibility management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->