### PR TITLE
fix(desktop): add visual gap between line number columns in inline diff

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/DiffViewer/DiffViewer.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/DiffViewer/DiffViewer.tsx
@@ -16,6 +16,7 @@ import {
 	registerCopyPathLineAction,
 	useEditorActions,
 } from "../../../ContentView/components/EditorContextMenu";
+import { getLineNumbersMinChars } from "./utils";
 
 function scrollToFirstDiff(
 	editor: Monaco.editor.IStandaloneDiffEditor,
@@ -33,14 +34,6 @@ function scrollToFirstDiff(
 	if (targetLine > 0) {
 		modifiedEditor.revealLineInCenter(targetLine);
 	}
-}
-
-function getLineNumbersMinChars(original: string, modified: string): number {
-	const originalLines = original.split("\n").length;
-	const modifiedLines = modified.split("\n").length;
-	const maxLines = Math.max(originalLines, modifiedLines);
-	const digits = maxLines > 0 ? Math.floor(Math.log10(maxLines)) + 1 : 1;
-	return digits + 1;
 }
 
 export interface DiffViewerContextMenuProps {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/DiffViewer/utils/getLineNumbersMinChars.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/DiffViewer/utils/getLineNumbersMinChars.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "bun:test";
+import { getLineNumbersMinChars } from "./getLineNumbersMinChars";
+
+describe("getLineNumbersMinChars", () => {
+	it("returns 2 for single line files (1 digit + 1 gap)", () => {
+		expect(getLineNumbersMinChars("line1", "line1")).toBe(2);
+	});
+
+	it("returns 2 for files with up to 9 lines", () => {
+		const nineLines = "1\n2\n3\n4\n5\n6\n7\n8\n9";
+		expect(getLineNumbersMinChars(nineLines, nineLines)).toBe(2);
+	});
+
+	it("returns 3 for files with 10-99 lines (2 digits + 1 gap)", () => {
+		const tenLines = Array(10).fill("line").join("\n");
+		expect(getLineNumbersMinChars(tenLines, tenLines)).toBe(3);
+
+		const ninetyNineLines = Array(99).fill("line").join("\n");
+		expect(getLineNumbersMinChars(ninetyNineLines, ninetyNineLines)).toBe(3);
+	});
+
+	it("returns 4 for files with 100-999 lines (3 digits + 1 gap)", () => {
+		const hundredLines = Array(100).fill("line").join("\n");
+		expect(getLineNumbersMinChars(hundredLines, hundredLines)).toBe(4);
+
+		const nineHundredNinetyNineLines = Array(999).fill("line").join("\n");
+		expect(
+			getLineNumbersMinChars(
+				nineHundredNinetyNineLines,
+				nineHundredNinetyNineLines,
+			),
+		).toBe(4);
+	});
+
+	it("returns 5 for files with 1000+ lines (4 digits + 1 gap)", () => {
+		const thousandLines = Array(1000).fill("line").join("\n");
+		expect(getLineNumbersMinChars(thousandLines, thousandLines)).toBe(5);
+	});
+
+	it("uses the larger of original or modified line count", () => {
+		const tenLines = Array(10).fill("line").join("\n");
+		const hundredLines = Array(100).fill("line").join("\n");
+
+		expect(getLineNumbersMinChars(tenLines, hundredLines)).toBe(4);
+		expect(getLineNumbersMinChars(hundredLines, tenLines)).toBe(4);
+	});
+
+	it("handles empty strings (counts as 1 line)", () => {
+		expect(getLineNumbersMinChars("", "")).toBe(2);
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/DiffViewer/utils/getLineNumbersMinChars.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/DiffViewer/utils/getLineNumbersMinChars.ts
@@ -1,0 +1,9 @@
+export function getLineNumbersMinChars(
+	original: string,
+	modified: string,
+): number {
+	const originalLines = original.split("\n").length;
+	const modifiedLines = modified.split("\n").length;
+	const maxLines = Math.max(originalLines, modifiedLines);
+	return String(maxLines).length + 1;
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/DiffViewer/utils/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/DiffViewer/utils/index.ts
@@ -1,0 +1,1 @@
+export { getLineNumbersMinChars } from "./getLineNumbersMinChars";


### PR DESCRIPTION
## Summary
- Add dynamic calculation of `lineNumbersMinChars` based on file content
- Calculates the digits needed for the max line count and adds 1 for visual spacing
- Creates a gap between original and modified line number columns in inline diff view

## Test plan
- [ ] Open a diff in inline view mode
- [ ] Verify there's visible spacing between the two line number columns
- [ ] Test with files of varying sizes (10 lines, 100 lines, 1000+ lines)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced diff viewer with improved line number column width that automatically adjusts based on the number of lines in the file being reviewed.

* **Tests**
  * Added comprehensive test coverage for line number formatting calculations across various file sizes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->