### PR TITLE
fix(docs): brand OG image with Superset logo and colors

### DIFF
--- a/apps/docs/src/app/og/docs/[...slug]/route.tsx
+++ b/apps/docs/src/app/og/docs/[...slug]/route.tsx
@@ -1,3 +1,4 @@
+import { COMPANY } from "@superset/shared/constants";
 import { generate as DefaultImage } from "fumadocs-ui/og";
 import { notFound } from "next/navigation";
 import { ImageResponse } from "next/og";
@@ -17,7 +18,18 @@ export async function GET(
 		<DefaultImage
 			title={page.data.title}
 			description={page.data.description}
-			site="My App"
+			site={COMPANY.NAME}
+			icon={
+				// biome-ignore lint/performance/noImgElement: Satori requires plain HTML elements
+				<img
+					src={`${COMPANY.DOCS_URL}/logo.png`}
+					alt=""
+					width={40}
+					height={40}
+				/>
+			}
+			primaryColor="rgba(255,255,255,0.15)"
+			primaryTextColor="rgb(255,255,255)"
 		/>,
 		{
 			width: 1200,


### PR DESCRIPTION
## Summary
- Replace boilerplate "My App" site name with `COMPANY.NAME` constant
- Add Superset logo icon to OG images
- Apply white-themed brand colors (`primaryColor`, `primaryTextColor`)

## Test plan
- [ ] Run docs dev server and visit `/og/docs/getting-started/image.png`
- [ ] Verify logo, site name, and colors render correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved documentation page previews for social media sharing with company branding, logo display, and customizable primary colors for enhanced brand consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->