### PR TITLE
fix(desktop): clear worktree status when tab is active, not just focused pane

### DIFF
--- a/apps/desktop/src/renderer/stores/tabs/useAgentHookListener.ts
+++ b/apps/desktop/src/renderer/stores/tabs/useAgentHookListener.ts
@@ -13,7 +13,7 @@ import { resolveNotificationTarget } from "./utils/resolve-notification-target";
  *
  * STATUS MAPPING:
  * - Start → "working" (amber pulsing indicator)
- * - Stop → "review" (green static) if pane not active, "idle" if active
+ * - Stop → "review" (green static) if pane's tab not active, "idle" if tab is active
  * - PermissionRequest → "permission" (red pulsing indicator)
  * - Terminal Exit → "idle" (handled in Terminal.tsx when mounted; also forwarded via notifications for unmounted panes)
  *
@@ -35,15 +35,10 @@ import { resolveNotificationTarget } from "./utils/resolve-notification-target";
 export function useAgentHookListener() {
 	const navigate = useNavigate();
 
-	// Track current workspace from router to avoid stale closure
+	// Ref avoids stale closure; parsed from URL since hook runs in _authenticated/layout
 	const currentWorkspaceIdRef = useRef<string | null>(null);
-
-	// We need to update this ref from the workspace page, but for now
-	// we'll use router state. This is called from _authenticated/layout
-	// so we check the current route
 	try {
-		const location = window.location;
-		const match = location.pathname.match(/\/workspace\/([^/]+)/);
+		const match = window.location.pathname.match(/\/workspace\/([^/]+)/);
 		currentWorkspaceIdRef.current = match ? match[1] : null;
 	} catch {
 		currentWorkspaceIdRef.current = null;
@@ -68,39 +63,28 @@ export function useAgentHookListener() {
 				const { eventType } = lifecycleEvent;
 
 				if (eventType === "Start") {
-					// Agent started working - always set to working
 					state.setPaneStatus(paneId, "working");
 				} else if (eventType === "PermissionRequest") {
-					// Agent needs permission - always set to permission (overrides working)
 					state.setPaneStatus(paneId, "permission");
 				} else if (eventType === "Stop") {
-					// Agent completed - only mark as review if not currently active
 					const activeTabId = state.activeTabIds[workspaceId];
-					const focusedPaneId =
-						activeTabId && state.focusedPaneIds[activeTabId];
-					const isAlreadyActive =
+					const pane = state.panes[paneId];
+					const isInActiveTab =
 						currentWorkspaceIdRef.current === workspaceId &&
-						focusedPaneId === paneId;
+						pane?.tabId === activeTabId;
 
 					debugLog("agent-hooks", "Stop event:", {
-						isAlreadyActive,
+						isInActiveTab,
 						activeTabId,
-						focusedPaneId,
+						paneTabId: pane?.tabId,
 						paneId,
-						willSetTo: isAlreadyActive ? "idle" : "review",
+						willSetTo: isInActiveTab ? "idle" : "review",
 					});
 
-					if (isAlreadyActive) {
-						// User is watching - go straight to idle
-						state.setPaneStatus(paneId, "idle");
-					} else {
-						// User not watching - mark for review
-						state.setPaneStatus(paneId, "review");
-					}
+					state.setPaneStatus(paneId, isInActiveTab ? "idle" : "review");
 				}
 			} else if (event.type === NOTIFICATION_EVENTS.TERMINAL_EXIT) {
-				// Correctness-only: clear transient status if the underlying process exited
-				// while the terminal pane was not mounted (no per-pane stream subscription).
+				// Clear transient status for unmounted panes (mounted panes handle this via stream subscription)
 				if (!paneId) return;
 				const currentPane = state.panes[paneId];
 				if (
@@ -110,15 +94,12 @@ export function useAgentHookListener() {
 					state.setPaneStatus(paneId, "idle");
 				}
 			} else if (event.type === NOTIFICATION_EVENTS.FOCUS_TAB) {
-				// Navigate to the workspace and focus the tab/pane
 				navigateToWorkspace(workspaceId, navigate);
 
-				// Set active tab and focused pane after navigation
-				// (router navigation is async, but state updates are immediate)
+				// Re-fetch state after navigation since router nav is async but state updates are immediate
 				const freshState = useTabsStore.getState();
 				const freshTarget = resolveNotificationTarget(event.data, freshState);
 
-				// Use resolved tabId, falling back to event's tabId directly
 				const tabIdToActivate = freshTarget?.tabId ?? event.data?.tabId;
 				if (!tabIdToActivate) return;
 
@@ -127,7 +108,6 @@ export function useAgentHookListener() {
 
 				freshState.setActiveTab(workspaceId, tabIdToActivate);
 
-				// Focus pane if available, using resolved or event's paneId
 				const paneIdToFocus = freshTarget?.paneId ?? event.data?.paneId;
 				if (paneIdToFocus && freshState.panes[paneIdToFocus]) {
 					freshState.setFocusedPane(tabIdToActivate, paneIdToFocus);


### PR DESCRIPTION
## Summary
- Fixed worktree status indicator showing incorrect state when switching between tabs and panes
- Status now clears to "idle" when the pane's tab is active, regardless of which pane within that tab has focus
- Previously required the specific pane to be focused, causing stale "review" indicators

## Test plan
- [ ] Open a workspace with multiple panes in a tab
- [ ] Run Claude in one pane, let it complete
- [ ] Verify status clears when viewing the tab (even if focused on a different pane)
- [ ] Switch to a different tab, verify status shows "review" for background tabs
- [ ] Switch back, verify status clears

Fixes SUPER-272