### PR TITLE
fix(desktop): fix PR detection for fork PRs checked out via gh pr checkout

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.ts
@@ -93,16 +93,21 @@ async function getRepoUrl(worktreePath: string): Promise<string | null> {
 
 async function getPRForBranch(
 	worktreePath: string,
-	branch: string,
+	_branch: string,
 ): Promise<GitHubStatus["pr"]> {
 	try {
 		// Use execWithShellEnv to handle macOS GUI app PATH issues
+		// Important: Do NOT pass the branch name argument. When `gh pr view` is
+		// called without arguments, it uses the branch's tracking info to find
+		// the associated PR. This is essential for fork PRs checked out via
+		// `gh pr checkout`, where the branch tracks `refs/pull/XXX/head`.
+		// Passing the branch name explicitly would search by head branch name,
+		// which fails for fork PRs since the branch exists on the fork, not origin.
 		const { stdout } = await execWithShellEnv(
 			"gh",
 			[
 				"pr",
 				"view",
-				branch,
 				"--json",
 				"number,title,url,state,isDraft,mergedAt,additions,deletions,reviewDecision,statusCheckRollup",
 			],


### PR DESCRIPTION
## Summary
- Fixed PR scanning not working for PRs checked out from GitHub forks via `gh pr checkout`
- The root cause was that `gh pr view <branch>` only searches by head branch name on origin, which fails for fork PRs
- Now calling `gh pr view` without arguments, which uses the branch's tracking info (`refs/pull/XXX/head`) to find the associated PR

## Test plan
- [ ] Checkout a fork PR using `gh pr checkout <number>`
- [ ] Verify that PR info appears in the workspace sidebar/status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved pull request detection for users working with forked repositories, enhancing the reliability of tracking associated pull requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->