### PR TITLE
fix(ui): prevent overflow in branch selection dropdown

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/ExistingWorktreesList/components/BranchesSection.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/ExistingWorktreesList/components/BranchesSection.tsx
@@ -53,13 +53,13 @@ export function BranchesSection({
 						className="w-full h-8 justify-between font-normal"
 						disabled={disabled}
 					>
-						<span className="flex items-center gap-2 truncate">
+						<span className="flex items-center gap-2 shrink-0 min-w-0">
 							<GoGitBranch className="size-3.5 shrink-0 text-muted-foreground" />
 							<span className="truncate text-sm text-muted-foreground">
 								Select branch...
 							</span>
 						</span>
-						<HiChevronUpDown className="size-4 shrink-0 text-muted-foreground" />
+						<HiChevronUpDown className="size-4 shrink-0 text-muted-foreground ml-2" />
 					</Button>
 				</PopoverTrigger>
 				<PopoverContent
@@ -82,22 +82,22 @@ export function BranchesSection({
 									onSelect={() => onSelectBranch(branch.name)}
 									className="flex items-center justify-between"
 								>
-									<span className="flex items-center gap-2 truncate">
+									<span className="flex items-center gap-2 truncate min-w-0">
 										<GoGitBranch className="size-3.5 shrink-0 text-muted-foreground" />
 										<span className="truncate">{branch.name}</span>
 										{branch.name === defaultBranch && (
-											<span className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+											<span className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded shrink-0">
 												default
 											</span>
 										)}
 										{!branch.isLocal && branch.isRemote && (
-											<span className="text-[10px] text-muted-foreground/60 bg-muted/50 px-1.5 py-0.5 rounded">
+											<span className="text-[10px] text-muted-foreground/60 bg-muted/50 px-1.5 py-0.5 rounded shrink-0">
 												remote
 											</span>
 										)}
 									</span>
 									{branch.lastCommitDate > 0 && (
-										<span className="text-xs text-muted-foreground shrink-0">
+										<span className="text-xs text-muted-foreground shrink-0 ml-2">
 											{formatRelativeTime(branch.lastCommitDate)}
 										</span>
 									)}


### PR DESCRIPTION
## Summary
- Adds `shrink-0` and `min-w-0` classes to prevent content overflow in branch selection dropdown

## Problem
When users click "Open workspace > existing" and long branch names are present, branch selection dropdown overflows. This happens because flex items were not constrained properly.

## Solution
- Added `shrink-0` to left content span in popover trigger button to prevent it from shrinking
- Added `min-w-0` to enable truncation within flex containers
- Added `shrink-0` to badges ("default", "remote") so they don't get squished
- Added `ml-2` to right-side elements for proper spacing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unwanted text truncation in the branches list, ensuring branch names, badges, and commit dates display properly without being cut off.
  * Improved spacing and alignment consistency across branch items for a cleaner visual presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->