### PR TITLE
fix(desktop): persist zoom level across app restarts

### DIFF
--- a/apps/desktop/src/main/lib/window-state/window-state.test.ts
+++ b/apps/desktop/src/main/lib/window-state/window-state.test.ts
@@ -76,6 +76,57 @@ describe("isValidWindowState", () => {
 			).toBe(true);
 		});
 
+		it("should accept valid window state with zoomLevel", () => {
+			expect(
+				isValidWindowState({
+					x: 100,
+					y: 200,
+					width: 800,
+					height: 600,
+					isMaximized: false,
+					zoomLevel: 1.5,
+				}),
+			).toBe(true);
+		});
+
+		it("should accept valid window state with negative zoomLevel", () => {
+			expect(
+				isValidWindowState({
+					x: 100,
+					y: 200,
+					width: 800,
+					height: 600,
+					isMaximized: false,
+					zoomLevel: -2,
+				}),
+			).toBe(true);
+		});
+
+		it("should accept valid window state with zero zoomLevel", () => {
+			expect(
+				isValidWindowState({
+					x: 100,
+					y: 200,
+					width: 800,
+					height: 600,
+					isMaximized: false,
+					zoomLevel: 0,
+				}),
+			).toBe(true);
+		});
+
+		it("should accept valid window state without zoomLevel (optional)", () => {
+			expect(
+				isValidWindowState({
+					x: 100,
+					y: 200,
+					width: 800,
+					height: 600,
+					isMaximized: false,
+				}),
+			).toBe(true);
+		});
+
 		it("should accept MAX_SAFE_INTEGER dimensions", () => {
 			expect(
 				isValidWindowState({
@@ -160,6 +211,45 @@ describe("isValidWindowState", () => {
 					width: Number.NaN,
 					height: 600,
 					isMaximized: false,
+				}),
+			).toBe(false);
+		});
+
+		it("should reject NaN zoomLevel", () => {
+			expect(
+				isValidWindowState({
+					x: 0,
+					y: 0,
+					width: 800,
+					height: 600,
+					isMaximized: false,
+					zoomLevel: Number.NaN,
+				}),
+			).toBe(false);
+		});
+
+		it("should reject Infinity zoomLevel", () => {
+			expect(
+				isValidWindowState({
+					x: 0,
+					y: 0,
+					width: 800,
+					height: 600,
+					isMaximized: false,
+					zoomLevel: Number.POSITIVE_INFINITY,
+				}),
+			).toBe(false);
+		});
+
+		it("should reject string zoomLevel", () => {
+			expect(
+				isValidWindowState({
+					x: 0,
+					y: 0,
+					width: 800,
+					height: 600,
+					isMaximized: false,
+					zoomLevel: "1.5" as unknown as number,
 				}),
 			).toBe(false);
 		});

--- a/apps/desktop/src/main/lib/window-state/window-state.ts
+++ b/apps/desktop/src/main/lib/window-state/window-state.ts
@@ -14,6 +14,7 @@ export interface WindowState {
 	width: number;
 	height: number;
 	isMaximized: boolean;
+	zoomLevel?: number;
 }
 
 /**
@@ -68,6 +69,7 @@ export function isValidWindowState(value: unknown): value is WindowState {
 		(v.width as number) > 0 &&
 		Number.isFinite(v.height) &&
 		(v.height as number) > 0 &&
-		typeof v.isMaximized === "boolean"
+		typeof v.isMaximized === "boolean" &&
+		(v.zoomLevel === undefined || Number.isFinite(v.zoomLevel))
 	);
 }

--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -204,6 +204,10 @@ export async function MainWindow() {
 		if (initialBounds.isMaximized) {
 			window.maximize();
 		}
+		// Restore zoom level if it was saved
+		if (savedWindowState?.zoomLevel !== undefined) {
+			window.webContents.setZoomLevel(savedWindowState.zoomLevel);
+		}
 		window.show();
 	});
 
@@ -233,12 +237,14 @@ export async function MainWindow() {
 		// Save window state first, before any cleanup
 		const isMaximized = window.isMaximized();
 		const bounds = isMaximized ? window.getNormalBounds() : window.getBounds();
+		const zoomLevel = window.webContents.getZoomLevel();
 		saveWindowState({
 			x: bounds.x,
 			y: bounds.y,
 			width: bounds.width,
 			height: bounds.height,
 			isMaximized,
+			zoomLevel,
 		});
 
 		server.close();


### PR DESCRIPTION
## Summary
- Add `zoomLevel` to `WindowState` interface to persist user's zoom preference
- Save zoom level when window closes
- Restore zoom level when app starts

Addresses user-reported issue where zoom level would reset.

## Test plan
- [x] Zoom in/out using CMD+Plus/Minus
- [x] Close and reopen the app
- [x] Verify zoom level is preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Application now automatically saves and restores your window zoom level preference between sessions.

## Tests
* Added comprehensive validation tests for zoom level handling, covering numeric values and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->