### PR TITLE
chore: remove agent-commands-access feature flag

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/useCommandWatcher.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/useCommandWatcher.ts
@@ -1,8 +1,6 @@
-import { FEATURE_FLAGS } from "@superset/shared/constants";
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useNavigate } from "@tanstack/react-router";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useCallback, useEffect, useMemo } from "react";
 import { authClient } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
@@ -15,14 +13,13 @@ import { executeTool, type ToolContext } from "./tools";
 const processingCommands = new Set<string>();
 
 export function useCommandWatcher() {
-	const isEnabled = useFeatureFlagEnabled(FEATURE_FLAGS.AGENT_COMMANDS_ACCESS);
 	const { data: deviceInfo } = electronTrpc.auth.getDeviceInfo.useQuery();
 	const { data: session } = authClient.useSession();
 	const collections = useCollections();
 	const navigate = useNavigate();
 
 	const organizationId = session?.session?.activeOrganizationId;
-	const shouldWatch = isEnabled && !!deviceInfo && !!organizationId;
+	const shouldWatch = !!deviceInfo && !!organizationId;
 
 	const createWorktree = useCreateWorkspace({ skipNavigation: true });
 	const setActive = electronTrpc.workspaces.setActive.useMutation();
@@ -174,7 +171,6 @@ export function useCommandWatcher() {
 	]);
 
 	return {
-		isEnabled,
 		isWatching: shouldWatch && !!deviceInfo?.deviceId,
 		deviceId: deviceInfo?.deviceId,
 		pendingCount:

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/GeneralSettings.tsx
@@ -39,7 +39,6 @@ const GENERAL_SECTIONS: {
 	section: SettingsSection;
 	label: string;
 	icon: React.ReactNode;
-	requiresAgentCommands?: boolean;
 }[] = [
 	{
 		id: "/settings/account",
@@ -100,28 +99,22 @@ const GENERAL_SECTIONS: {
 		section: "devices",
 		label: "Devices",
 		icon: <HiOutlineDevicePhoneMobile className="h-4 w-4" />,
-		requiresAgentCommands: true,
 	},
 	{
 		id: "/settings/api-keys",
 		section: "apikeys",
 		label: "API Keys",
 		icon: <HiOutlineKey className="h-4 w-4" />,
-		requiresAgentCommands: true,
 	},
 ];
 
 export function GeneralSettings({ matchCounts }: GeneralSettingsProps) {
 	const matchRoute = useMatchRoute();
 	const billingEnabled = useFeatureFlagEnabled(FEATURE_FLAGS.BILLING_ENABLED);
-	const hasAgentCommandsAccess = useFeatureFlagEnabled(
-		FEATURE_FLAGS.AGENT_COMMANDS_ACCESS,
-	);
 
 	// Filter by feature flags first, then by search matches
 	const availableSections = GENERAL_SECTIONS.filter((section) => {
 		if (section.section === "billing" && !billingEnabled) return false;
-		if (section.requiresAgentCommands && !hasAgentCommandsAccess) return false;
 		return true;
 	});
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -53,8 +53,6 @@ export const FEATURE_FLAGS = {
 	ELECTRIC_TASKS_ACCESS: "electric-tasks-access",
 	/** Gates access to billing features. */
 	BILLING_ENABLED: "billing-enabled",
-	/** Gates access to MCP agent commands (cloud-to-desktop sync). */
-	AGENT_COMMANDS_ACCESS: "agent-commands-access",
 	/** Gates access to GitHub integration (currently buggy, internal only). */
 	GITHUB_INTEGRATION_ACCESS: "github-integration-access",
 } as const;


### PR DESCRIPTION
## Summary

- Removes the `agent-commands-access` feature flag since it's at 100% rollout for all users
- The command watcher and settings sections (Devices, API Keys) are now always enabled

## Changes

- Remove `AGENT_COMMANDS_ACCESS` constant from `packages/shared/src/constants.ts`
- Remove feature flag check in `useCommandWatcher` hook - now always enabled
- Remove `requiresAgentCommands` property from settings sections in `GeneralSettings.tsx`

## Test plan

- [ ] Verify Devices settings section is visible
- [ ] Verify API Keys settings section is visible
- [ ] Verify agent command watcher functionality works