### PR TITLE
Fix: persist sidebar reorder on drag end

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectSection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectSection.tsx
@@ -73,6 +73,7 @@ export function ProjectSection({
 						{
 							onError: (error) =>
 								toast.error(`Failed to reorder: ${error.message}`),
+							onSettled: () => utils.workspaces.getAllGrouped.invalidate(),
 						},
 					);
 				}
@@ -113,8 +114,10 @@ export function ProjectSection({
 					{
 						onError: (error) =>
 							toast.error(`Failed to reorder: ${error.message}`),
+						onSettled: () => utils.workspaces.getAllGrouped.invalidate(),
 					},
 				);
+				return { reordered: true };
 			}
 		},
 	});


### PR DESCRIPTION
Hi maintainers,

## Summary
- Sidebar reorder for project groups and workspace items could appear to work but reset after restart.
- Root cause: persistence only happened on React-DnD `drop`. When the mouse was released outside a registered drop target, `didDrop` was false, so the reorder never hit the database.
- Fix: persist reorders in the drag `end` handler when indices actually changed, while keeping the existing drop path intact.

## Reproduction steps
1. Open the desktop app with multiple projects/workspaces.
2. Drag a project group (or a workspace item) to a new position.
3. Release the mouse in the list area (not necessarily on another item).
4. Restart the app.

## Actual result
Order changes only in UI and resets after restart.

## Expected result
Order should be persisted and remain after restart.

## Testing
Not run (manual drag/drop verified locally).

Thank you for reviewing!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced drag-and-drop reordering for projects and workspaces with more reliable completion handling.
  * Added optimistic in-memory updates so index changes appear instantly during drag.
  * Ensures cache/state is refreshed after reorder operations settle.
* **Bug Fixes**
  * Guarded end-of-drag logic to avoid spurious reorders and prevent duplicate operations.
* **User-facing**
  * Preserves existing component interfaces; no public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->