### PR TITLE
feat(desktop): wrap tab navigation hotkeys

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -152,11 +152,10 @@ function WorkspacePage() {
 	useAppHotkey(
 		"PREV_TAB",
 		() => {
-			if (!activeTabId) return;
+			if (!activeTabId || tabs.length === 0) return;
 			const index = tabs.findIndex((t) => t.id === activeTabId);
-			if (index > 0) {
-				setActiveTab(workspaceId, tabs[index - 1].id);
-			}
+			const prevIndex = index <= 0 ? tabs.length - 1 : index - 1;
+			setActiveTab(workspaceId, tabs[prevIndex].id);
 		},
 		undefined,
 		[workspaceId, activeTabId, tabs, setActiveTab],
@@ -165,11 +164,11 @@ function WorkspacePage() {
 	useAppHotkey(
 		"NEXT_TAB",
 		() => {
-			if (!activeTabId) return;
+			if (!activeTabId || tabs.length === 0) return;
 			const index = tabs.findIndex((t) => t.id === activeTabId);
-			if (index < tabs.length - 1) {
-				setActiveTab(workspaceId, tabs[index + 1].id);
-			}
+			const nextIndex =
+				index >= tabs.length - 1 || index === -1 ? 0 : index + 1;
+			setActiveTab(workspaceId, tabs[nextIndex].id);
 		},
 		undefined,
 		[workspaceId, activeTabId, tabs, setActiveTab],


### PR DESCRIPTION
## Summary
- PREV_TAB and NEXT_TAB hotkeys now wrap around at list boundaries instead of stopping at the first/last tab

## Test plan
- [ ] Open a workspace with multiple tabs
- [ ] Navigate to the last tab and press NEXT_TAB (⌘⌥→) — should wrap to the first tab
- [ ] Navigate to the first tab and press PREV_TAB (⌘⌥←) — should wrap to the last tab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tab navigation hotkeys now properly handle edge cases, including empty tab sets
  * Tab navigation now supports wrap-around behavior—moving from the last tab cycles to the first, and vice versa

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->