### PR TITLE
fix(desktop): navigate to workspace after importing PR

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/ExistingWorktreesList/ExistingWorktreesList.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/ExistingWorktreesList/ExistingWorktreesList.tsx
@@ -2,6 +2,7 @@ import { toast } from "@superset/ui/sonner";
 import { useMemo, useState } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
+	useCreateFromPr,
 	useCreateWorkspace,
 	useOpenWorktree,
 } from "renderer/react-query/workspaces";
@@ -22,7 +23,7 @@ export function ExistingWorktreesList({
 		electronTrpc.projects.getBranches.useQuery({ projectId });
 	const openWorktree = useOpenWorktree();
 	const createWorkspace = useCreateWorkspace();
-	const createFromPr = electronTrpc.workspaces.createFromPr.useMutation();
+	const createFromPr = useCreateFromPr();
 
 	const [branchOpen, setBranchOpen] = useState(false);
 	const [branchSearch, setBranchSearch] = useState("");

--- a/apps/desktop/src/renderer/react-query/workspaces/index.ts
+++ b/apps/desktop/src/renderer/react-query/workspaces/index.ts
@@ -1,5 +1,6 @@
 export { useCloseWorkspace } from "./useCloseWorkspace";
 export { useCreateBranchWorkspace } from "./useCreateBranchWorkspace";
+export { useCreateFromPr } from "./useCreateFromPr";
 export { useCreateWorkspace } from "./useCreateWorkspace";
 export { useDeleteWorkspace } from "./useDeleteWorkspace";
 export { useDeleteWorktree } from "./useDeleteWorktree";

--- a/apps/desktop/src/renderer/react-query/workspaces/useCreateFromPr.ts
+++ b/apps/desktop/src/renderer/react-query/workspaces/useCreateFromPr.ts
@@ -1,0 +1,50 @@
+import { useNavigate } from "@tanstack/react-router";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
+import { useWorkspaceInitStore } from "renderer/stores/workspace-init";
+import type { WorkspaceInitProgress } from "shared/types/workspace-init";
+
+type MutationOptions = Parameters<
+	typeof electronTrpc.workspaces.createFromPr.useMutation
+>[0];
+
+export function useCreateFromPr(options?: MutationOptions) {
+	const navigate = useNavigate();
+	const utils = electronTrpc.useUtils();
+	const addPendingTerminalSetup = useWorkspaceInitStore(
+		(s) => s.addPendingTerminalSetup,
+	);
+	const updateProgress = useWorkspaceInitStore((s) => s.updateProgress);
+
+	return electronTrpc.workspaces.createFromPr.useMutation({
+		...options,
+		onSuccess: async (data, ...rest) => {
+			// Set optimistic progress before navigation for new workspaces
+			if (!data.wasExisting && data.initialCommands) {
+				const optimisticProgress: WorkspaceInitProgress = {
+					workspaceId: data.workspace.id,
+					projectId: data.projectId,
+					step: "pending",
+					message: "Preparing...",
+				};
+				updateProgress(optimisticProgress);
+			}
+
+			// Setup terminal if there are initial commands
+			if (data.initialCommands) {
+				addPendingTerminalSetup({
+					workspaceId: data.workspace.id,
+					projectId: data.projectId,
+					initialCommands: data.initialCommands,
+				});
+			}
+
+			await utils.workspaces.invalidate();
+
+			// Navigate to the workspace
+			navigateToWorkspace(data.workspace.id, navigate);
+
+			await options?.onSuccess?.(data, ...rest);
+		},
+	});
+}


### PR DESCRIPTION
## Summary
- Added `useCreateFromPr` hook that navigates to the workspace after creation via PR URL import
- Previously, importing a PR would create the workspace but leave the user on their current view
- Now follows the same pattern as `useOpenWorktree` and `useCreateWorkspace` hooks

## Test plan
- [ ] Open the New Workspace modal
- [ ] Select a project and go to the "Existing" tab
- [ ] Paste a valid PR URL and submit
- [ ] Verify the workspace is created AND the app navigates to the new workspace