### PR TITLE
fix(desktop): prevent sidebar workspace item height changes on hover

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceDiffStats.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceDiffStats.tsx
@@ -18,31 +18,30 @@ export function WorkspaceDiffStats({
 	return (
 		<div
 			className={cn(
-				"group/diff flex items-center text-[10px] font-mono tabular-nums px-1.5 py-0.5 rounded relative cursor-pointer",
+				"group/diff flex items-center justify-center text-[10px] font-mono tabular-nums px-1.5 py-0.5 rounded relative cursor-pointer",
 				isActive
 					? "bg-foreground/10 group-hover:bg-transparent"
 					: "bg-muted/50 group-hover:bg-transparent",
 			)}
 		>
-			{/* Diff stats - hidden on card hover when onClose provided */}
+			{/* Diff stats - fade out on hover when onClose provided */}
 			<div
-				className={
-					onClose
-						? "flex items-center gap-1.5 group-hover:hidden"
-						: "flex items-center gap-1.5"
-				}
+				className={cn(
+					"flex items-center gap-1.5 transition-opacity",
+					onClose && "group-hover:opacity-0",
+				)}
 			>
 				<span className="text-emerald-500/90">+{additions}</span>
 				<span className="text-red-400/90">−{deletions}</span>
 			</div>
-			{/* X icon - shown on card hover */}
+			{/* X icon - overlay on hover, positioned absolutely to avoid layout shift */}
 			{onClose && (
 				<Tooltip delayDuration={300}>
 					<TooltipTrigger asChild>
 						<button
 							type="button"
 							onClick={onClose}
-							className="hidden group-hover:flex items-center justify-center text-muted-foreground hover:text-foreground"
+							className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground hover:text-foreground"
 						>
 							<HiMiniXMark className="size-3.5" />
 						</button>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -366,8 +366,7 @@ export function WorkspaceListItem({
 			className={cn(
 				"flex items-center w-full pl-3 pr-2 text-sm",
 				"hover:bg-muted/50 transition-colors text-left cursor-pointer",
-				"group relative",
-				showBranchSubtitle ? "py-1.5" : "py-2",
+				"group relative py-1.5",
 				isActive && "bg-muted",
 				isDragging && "opacity-30",
 			)}
@@ -511,24 +510,22 @@ export function WorkspaceListItem({
 								))}
 						</div>
 
-						{/* Row 2: Git info (branch + PR badge) */}
-						{(showBranchSubtitle || pr) && (
-							<div className="flex items-center gap-2 text-[11px] w-full">
-								{showBranchSubtitle && (
-									<span className="text-muted-foreground/60 truncate font-mono leading-tight">
-										{branch}
-									</span>
-								)}
-								{pr && (
-									<WorkspaceStatusBadge
-										state={pr.state}
-										prNumber={pr.number}
-										prUrl={pr.url}
-										className="ml-auto"
-									/>
-								)}
-							</div>
-						)}
+						{/* Row 2: Git info (branch + PR badge) - always render for consistent height */}
+						<div className="flex items-center gap-2 text-[11px] w-full min-h-[18px]">
+							{showBranchSubtitle && (
+								<span className="text-muted-foreground/60 truncate font-mono leading-tight">
+									{branch}
+								</span>
+							)}
+							{pr && (
+								<WorkspaceStatusBadge
+									state={pr.state}
+									prNumber={pr.number}
+									prUrl={pr.url}
+									className="ml-auto"
+								/>
+							)}
+						</div>
 					</div>
 				)}
 			</div>


### PR DESCRIPTION
## Summary
- Use consistent `py-1.5` padding for all workspace items instead of conditional padding
- Always render Row 2 with `min-h-[18px]` to reserve space for PR badge, preventing height shift when badge loads on hover
- Change diff stats component to use opacity transitions and absolute positioning instead of `hidden`/`display` toggling to avoid content shift on hover

## Test plan
- [ ] Hover over workspace items in sidebar and verify no height/layout shift occurs
- [ ] Verify PR badge appearing on hover doesn't cause height change
- [ ] Verify diff stats transforming to X button on hover doesn't cause content shift

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined visual hover effects on workspace items with smooth fade transitions for diff stats and close button
  * Improved layout consistency by standardizing component alignment and ensuring fixed heights for git information display
  * Enhanced UI interactions to prevent layout shifts while maintaining responsive feedback during hover states

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->