### PR TITLE
fix(desktop): handle workspace creation for local-only repos

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceInitializingView/WorkspaceInitializingView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceInitializingView/WorkspaceInitializingView.tsx
@@ -194,7 +194,7 @@ export function WorkspaceInitializingView({
 							</h2>
 							<p className="text-sm text-muted-foreground">{workspaceName}</p>
 							{progress?.error && (
-								<p className="text-xs text-destructive/80 mt-2 bg-destructive/5 rounded-md px-3 py-2">
+								<p className="text-xs text-destructive/80 mt-2 bg-destructive/5 rounded-md px-3 py-2 select-text cursor-text break-words">
 									{progress.error}
 								</p>
 							)}


### PR DESCRIPTION
## Summary
- Fix worktree creation failing for repos without a remote configured
- Skip checking `origin/*` refs when no remote is configured
- Add fallback to common branch names (main, master, develop, trunk) when the requested base branch doesn't exist locally
- Only use fallback for auto-derived base branches, not explicit user-specified ones
- Update workspace metadata when a fallback branch is used
- Show user-friendly progress messages when using fallback branch
- Make error text selectable in workspace init failure view

## Problem
When creating a workspace for a local-only git repository (no remote configured), the workspace initialization would fail with:
```
fatal: invalid reference: origin/main^{commit}
```

This happened because the code was trying to use `origin/<branch>` as the start point even when no origin remote existed.

## Solution
- Added a `checkOriginRefs` parameter to `resolveLocalStartPoint()` to skip `origin/*` refs when there's no remote
- When no remote exists, directly use the local branch as the start point
- Fallback logic only triggers for auto-derived base branches to avoid silently changing explicitly user-specified branches

## Test plan
- [x] Create a local-only repo with `master` branch (no remote)
- [x] Import the repo and create a workspace
- [x] Verify workspace creates successfully using local `master` branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved workspace initialization with enhanced branch resolution and fallback handling to reduce setup failures.
  * Strengthened error handling for fetch failures during workspace setup.

* **UI/UX**
  * Error messages are now selectable and display with improved text wrapping for better readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->