### PR TITLE
fix(desktop): show inline 'Taken' indicator for unavailable org slugs

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/organization/components/OrganizationSettings/components/SlugDialog/SlugDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/organization/components/OrganizationSettings/components/SlugDialog/SlugDialog.tsx
@@ -90,7 +90,7 @@ export function SlugDialog({
 					slug: slugValue,
 				});
 
-				setSlugAvailable(result.data?.status ?? null);
+				setSlugAvailable(result.data?.available ?? null);
 			} catch (error) {
 				console.error("[slug-dialog] Slug check failed:", error);
 				setSlugAvailable(null);
@@ -103,11 +103,6 @@ export function SlugDialog({
 	}, [slugValue, currentSlug, open]);
 
 	async function handleSlugUpdate(values: SlugFormValues): Promise<void> {
-		if (slugAvailable === false) {
-			toast.error("Slug is already taken");
-			return;
-		}
-
 		try {
 			await apiTrpcClient.organization.update.mutate({
 				id: organizationId,

--- a/apps/desktop/src/renderer/routes/create-organization/page.tsx
+++ b/apps/desktop/src/renderer/routes/create-organization/page.tsx
@@ -86,7 +86,7 @@ export function CreateOrganization() {
 					slug: slugValue,
 				});
 
-				setSlugAvailable(result.data?.status ?? null);
+				setSlugAvailable(result.data?.available ?? null);
 			} catch (error) {
 				console.error("[create-org] Slug check failed:", error);
 				setSlugAvailable(null);
@@ -129,11 +129,6 @@ export function CreateOrganization() {
 	}
 
 	async function onSubmit(values: FormValues): Promise<void> {
-		if (slugAvailable === false) {
-			toast.error("Slug is already taken");
-			return;
-		}
-
 		setIsSubmitting(true);
 		try {
 			const organization = await apiTrpcClient.organization.create.mutate({
@@ -234,7 +229,9 @@ export function CreateOrganization() {
 							<Button
 								type="submit"
 								className="w-full"
-								disabled={isSubmitting || slugAvailable === false}
+								disabled={
+									isSubmitting || isCheckingSlug || slugAvailable === false
+								}
 							>
 								{isSubmitting ? "Creating..." : "Create Organization"}
 							</Button>


### PR DESCRIPTION
## Summary
- Fixed org slug availability check to use `result.data?.available` instead of `result.data?.status` (Better Auth API returns `available`, not `status`)
- "Taken" indicator now shows inline in the input field when slug is unavailable
- Removed redundant toast.error fallback since inline indicator handles this
- Added `isCheckingSlug` to button disabled state in create-organization to prevent race condition

## Test plan
- [x] Create new organization with a slug that's already taken → should show "Taken" in red inside the input
- [x] Edit existing org slug to one that's taken → should show "Taken" in red inside the input
- [x] Verify no toast appears for taken slugs (toast should only appear for server errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined slug availability validation in organization settings to improve accuracy
  * Added loading state feedback while checking slug availability for better user experience

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->