### PR TITLE
fix: prevent postinstall infinite loop on bun install

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"format:check": "biome format .",
 		"typecheck": "turbo typecheck",
 		"ui-add": "turbo run ui-add",
-		"postinstall": "sherif; bun run --filter=@superset/desktop install:deps",
+		"postinstall": "./scripts/postinstall.sh",
 		"clean": "git clean -xdf node_modules",
 		"clean:workspaces": "turbo clean",
 		"release:desktop": "./apps/desktop/create-release.sh",

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Prevent infinite recursion during postinstall
+# electron-builder install-app-deps can trigger nested bun installs
+# which would re-run postinstall, spawning hundreds of processes
+
+if [ -n "$SUPERSET_POSTINSTALL_RUNNING" ]; then
+  exit 0
+fi
+
+export SUPERSET_POSTINSTALL_RUNNING=1
+
+# Run sherif for workspace validation
+sherif
+
+# Install native dependencies for desktop app
+bun run --filter=@superset/desktop install:deps


### PR DESCRIPTION
## Summary

- Fixes the infinite process spawn loop during `bun install`
- Adds environment variable guard to prevent recursive postinstall invocations

## Problem

When running `bun install`, the postinstall script spawns 370+ `electron-builder install-app-deps` processes in an infinite loop, causing the install to never complete.

**Root cause:** `electron-builder install-app-deps` triggers nested bun installs which re-run postinstall, creating a recursive loop.

## Solution

Created a `scripts/postinstall.sh` wrapper that:
1. Checks for `SUPERSET_POSTINSTALL_RUNNING` environment variable
2. Exits early if already in a postinstall run
3. Sets the guard variable before running the actual postinstall commands

## Test plan

- [ ] Run `bun install` from a clean clone - should complete without hanging
- [ ] Run `bun run build` - should build the desktop app successfully
- [ ] Verify native modules (better-sqlite3, node-pty) are properly compiled

Fixes #1063

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed postinstall script to prevent recursive execution, ensuring installation runs exactly once and completes reliably.

* **Chores**
  * Reorganized installation script structure for improved maintainability and clarity during the package setup process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->