### PR TITLE
fix(slack): replace Slack MCP stdio client with direct web API

### DIFF
--- a/apps/api/src/app/api/integrations/slack/events/process-assistant-message/process-assistant-message.ts
+++ b/apps/api/src/app/api/integrations/slack/events/process-assistant-message/process-assistant-message.ts
@@ -63,7 +63,6 @@ export async function processAssistantMessage({
 			threadTs,
 			organizationId: connection.organizationId,
 			slackToken: connection.accessToken,
-			slackTeamId: teamId,
 		});
 
 		// Format actions as text with URLs (enables Slack unfurling)

--- a/apps/api/src/app/api/integrations/slack/events/process-mention/process-mention.ts
+++ b/apps/api/src/app/api/integrations/slack/events/process-mention/process-mention.ts
@@ -60,7 +60,6 @@ export async function processSlackMention({
 			threadTs,
 			organizationId: connection.organizationId,
 			slackToken: connection.accessToken,
-			slackTeamId: teamId,
 		});
 
 		// Format actions as text with URLs (enables Slack unfurling)

--- a/apps/api/src/app/api/integrations/slack/events/utils/run-agent/mcp-clients.ts
+++ b/apps/api/src/app/api/integrations/slack/events/utils/run-agent/mcp-clients.ts
@@ -1,6 +1,5 @@
 import type Anthropic from "@anthropic-ai/sdk";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { createInMemoryMcpClient } from "@superset/mcp/in-memory";
 
 interface McpTool {
@@ -18,32 +17,6 @@ export async function createSupersetMcpClient({
 	userId: string;
 }): Promise<{ client: Client; cleanup: () => Promise<void> }> {
 	return createInMemoryMcpClient({ organizationId, userId });
-}
-
-export async function createSlackMcpClient({
-	token,
-	teamId,
-}: {
-	token: string;
-	teamId: string;
-}): Promise<Client> {
-	const transport = new StdioClientTransport({
-		command: "npx",
-		args: ["-y", "@modelcontextprotocol/server-slack"],
-		env: {
-			...process.env,
-			SLACK_BOT_TOKEN: token,
-			SLACK_TEAM_ID: teamId,
-		},
-	});
-
-	const client = new Client({
-		name: "slack-agent-slack",
-		version: "1.0.0",
-	});
-
-	await client.connect(transport);
-	return client;
 }
 
 export function mcpToolToAnthropicTool(


### PR DESCRIPTION
## Summary
- The Slack MCP client spawned `npx @modelcontextprotocol/server-slack` via stdio transport, which fails on Vercel serverless (no writable home dir, npm can't cache packages, no persistent child processes)
- Replaced with a single `slack_get_channel_history` tool using `@slack/web-api` directly
- Superset MCP client (in-memory transport) is unchanged

## Test plan
- [ ] Deploy to preview and trigger a Slack mention — verify the agent responds without MCP connection errors
- [ ] Verify the agent can still use Superset tools (create task, list tasks, etc.)
- [ ] Verify channel history tool returns recent messages when the agent uses it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Slack integration now includes direct channel message retrieval, enabling access to recent messages for enhanced agent context awareness.

* **Bug Fixes**
  * Streamlined Slack agent parameter configuration and dependency handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->