### PR TITLE
fix(mcp): serialize Date objects to ISO strings in tool responses

### DIFF
--- a/packages/mcp/src/tools/devices/list-devices/list-devices.ts
+++ b/packages/mcp/src/tools/devices/list-devices/list-devices.ts
@@ -66,6 +66,7 @@ export function register(server: McpServer) {
 
 			const devicesWithStatus = devices.map((d) => ({
 				...d,
+				lastSeenAt: d.lastSeenAt.toISOString(),
 				isOnline: d.lastSeenAt > threshold,
 			}));
 

--- a/packages/mcp/src/tools/tasks/get-task/get-task.ts
+++ b/packages/mcp/src/tools/tasks/get-task/get-task.ts
@@ -93,9 +93,20 @@ export function register(server: McpServer) {
 				};
 			}
 
+			const serializedTask = {
+				...task,
+				dueDate: task.dueDate?.toISOString() ?? null,
+				createdAt: task.createdAt.toISOString(),
+				updatedAt: task.updatedAt.toISOString(),
+			};
 			return {
-				structuredContent: { task },
-				content: [{ type: "text", text: JSON.stringify({ task }, null, 2) }],
+				structuredContent: { task: serializedTask },
+				content: [
+					{
+						type: "text",
+						text: JSON.stringify({ task: serializedTask }, null, 2),
+					},
+				],
 			};
 		},
 	);

--- a/packages/mcp/src/tools/tasks/list-tasks/list-tasks.ts
+++ b/packages/mcp/src/tools/tasks/list-tasks/list-tasks.ts
@@ -208,7 +208,12 @@ export function register(server: McpServer) {
 				.offset(offset);
 
 			const data = {
-				tasks: tasksList,
+				tasks: tasksList.map((t) => ({
+					...t,
+					dueDate: t.dueDate?.toISOString() ?? null,
+					createdAt: t.createdAt.toISOString(),
+					deletedAt: t.deletedAt?.toISOString() ?? null,
+				})),
 				count: tasksList.length,
 				hasMore: tasksList.length === limit,
 			};


### PR DESCRIPTION
## Summary
- MCP tools `list_tasks`, `get_task`, and `list_devices` returned raw Drizzle `Date` objects in `structuredContent`, but their output schemas declared `z.string()`
- The MCP SDK validates structured content against the schema — `Date !== string` → validation failure
- This caused the Slack agent to fail when trying to list or retrieve tasks ("technical issue retrieving tasks")
- Fixed by calling `.toISOString()` on all Date fields before returning

## Affected tools
| Tool | Fields |
|------|--------|
| `list_tasks` | `dueDate`, `createdAt`, `deletedAt` |
| `get_task` | `dueDate`, `createdAt`, `updatedAt` |
| `list_devices` | `lastSeenAt` |

## Test plan
- [ ] Slack agent can list tasks without error
- [ ] Slack agent can get a specific task by slug
- [ ] Desktop app device listing still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Standardized date field formatting across device and task management endpoints to use ISO string format for consistent API responses and improved interoperability.
  * Updated last-seen timestamps, due dates, creation dates, and deletion date fields to use ISO string representation for better API consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->