### PR TITLE
fix(desktop): auto-start shell on session restore without popup

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/workspace-init.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/workspace-init.ts
@@ -193,7 +193,6 @@ export async function initializeWorkspaceWorktree({
 			reason: string,
 			checkOriginRefs: boolean,
 		): Promise<LocalStartPointResult> => {
-			// Try origin tracking ref first (only if remote exists)
 			if (checkOriginRefs) {
 				const originRef = `origin/${effectiveBaseBranch}`;
 				if (await refExistsLocally(mainRepoPath, originRef)) {
@@ -204,7 +203,6 @@ export async function initializeWorkspaceWorktree({
 				}
 			}
 
-			// Try local branch
 			if (await refExistsLocally(mainRepoPath, effectiveBaseBranch)) {
 				console.log(
 					`[workspace-init] ${reason}. Using local branch: ${effectiveBaseBranch}`,
@@ -212,7 +210,6 @@ export async function initializeWorkspaceWorktree({
 				return { ref: effectiveBaseBranch };
 			}
 
-			// Only try fallback branches if the base branch was auto-derived
 			if (baseBranchWasExplicit) {
 				console.log(
 					`[workspace-init] ${reason}. Base branch "${effectiveBaseBranch}" was explicitly set, not using fallback.`,
@@ -220,11 +217,9 @@ export async function initializeWorkspaceWorktree({
 				return null;
 			}
 
-			// Fallback: try common default branch names
 			const commonBranches = ["main", "master", "develop", "trunk"];
 			for (const branch of commonBranches) {
-				if (branch === effectiveBaseBranch) continue; // Already tried
-				// Only check origin refs if remote exists
+				if (branch === effectiveBaseBranch) continue;
 				if (checkOriginRefs) {
 					const fallbackOriginRef = `origin/${branch}`;
 					if (await refExistsLocally(mainRepoPath, fallbackOriginRef)) {
@@ -245,7 +240,6 @@ export async function initializeWorkspaceWorktree({
 			return null;
 		};
 
-		// Helper to update baseBranch when fallback is used
 		const applyFallbackBranch = (fallbackBranch: string) => {
 			console.log(
 				`[workspace-init] Updating baseBranch from "${effectiveBaseBranch}" to "${fallbackBranch}" for workspace ${workspaceId}`,
@@ -355,7 +349,6 @@ export async function initializeWorkspaceWorktree({
 			try {
 				await fetchDefaultBranch(mainRepoPath, effectiveBaseBranch);
 			} catch (fetchError) {
-				// Fetch failed - verify local tracking ref exists before proceeding
 				const originRef = `origin/${effectiveBaseBranch}`;
 				if (!(await refExistsLocally(mainRepoPath, originRef))) {
 					console.warn(

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -71,7 +71,6 @@ export const Terminal = ({ tabId, workspaceId }: TerminalProps) => {
 	const terminalTheme = useTerminalTheme();
 	const restartTerminalRef = useRef<() => void>(() => {});
 
-	// Terminal connection state and mutations
 	const {
 		connectionError,
 		setConnectionError,
@@ -85,14 +84,12 @@ export const Terminal = ({ tabId, workspaceId }: TerminalProps) => {
 		},
 	} = useTerminalConnection({ workspaceId });
 
-	// Terminal CWD management
 	const { updateCwdFromData } = useTerminalCwd({
 		paneId,
 		initialCwd: paneInitialCwd,
 		workspaceCwd,
 	});
 
-	// Terminal modes tracking
 	const {
 		isAlternateScreenRef,
 		isBracketedPasteRef,
@@ -101,13 +98,11 @@ export const Terminal = ({ tabId, workspaceId }: TerminalProps) => {
 		resetModes,
 	} = useTerminalModes();
 
-	// File link click handler
 	const { handleFileLinkClick } = useFileLinkClick({
 		workspaceId,
 		workspaceCwd,
 	});
 
-	// Refs for stable identity
 	const initialThemeRef = useRef(terminalTheme);
 	const isFocused = focusedPaneId === paneId;
 	const isFocusedRef = useRef(isFocused);
@@ -126,8 +121,6 @@ export const Terminal = ({ tabId, workspaceId }: TerminalProps) => {
 	const handleFileLinkClickRef = useRef(handleFileLinkClick);
 	handleFileLinkClickRef.current = handleFileLinkClick;
 
-	// Refs for stream event handlers (populated after useTerminalStream)
-	// These allow flushPendingEvents to call the handlers via refs
 	const handleTerminalExitRef = useRef<
 		(exitCode: number, xterm: XTerm) => void
 	>(() => {});
@@ -163,7 +156,6 @@ export const Terminal = ({ tabId, workspaceId }: TerminalProps) => {
 		useTerminalCallbacksStore.getState().unregisterScrollToBottomCallback,
 	);
 
-	// Terminal restore logic
 	const {
 		isStreamReadyRef,
 		didFirstRenderRef,
@@ -187,7 +179,6 @@ export const Terminal = ({ tabId, workspaceId }: TerminalProps) => {
 			setConnectionError(reason || "Connection to terminal daemon lost"),
 	});
 
-	// Cold restore handling
 	const {
 		isRestoredMode,
 		setIsRestoredMode,
@@ -215,13 +206,11 @@ export const Terminal = ({ tabId, workspaceId }: TerminalProps) => {
 		resetModes,
 	});
 
-	// Avoid effect re-runs: track overlay states via refs for input gating
 	const isRestoredModeRef = useRef(isRestoredMode);
 	isRestoredModeRef.current = isRestoredMode;
 	const connectionErrorRef = useRef(connectionError);
 	connectionErrorRef.current = connectionError;
 
-	// Stream handling
 	const { handleTerminalExit, handleStreamError, handleStreamData } =
 		useTerminalStream({
 			paneId,
@@ -236,17 +225,14 @@ export const Terminal = ({ tabId, workspaceId }: TerminalProps) => {
 			updateCwdFromData,
 		});
 
-	// Populate handler refs for flushPendingEvents to use
 	handleTerminalExitRef.current = handleTerminalExit;
 	handleStreamErrorRef.current = handleStreamError;
 
-	// Stream subscription
 	electronTrpc.terminal.stream.useSubscription(paneId, {
 		onData: handleStreamData,
 		enabled: true,
 	});
 
-	// Focus handler ref
 	const handleTerminalFocusRef = useRef(() => {});
 	handleTerminalFocusRef.current = () => {
 		if (pane?.tabId) {
@@ -295,7 +281,6 @@ export const Terminal = ({ tabId, workspaceId }: TerminalProps) => {
 			console.log(`[Terminal] Mount: ${paneId}`);
 		}
 
-		// Cancel pending detach from previous unmount
 		const pendingDetach = pendingDetaches.get(paneId);
 		if (pendingDetach) {
 			clearTimeout(pendingDetach);
@@ -342,7 +327,6 @@ export const Terminal = ({ tabId, workspaceId }: TerminalProps) => {
 			searchAddonRef.current = searchAddon;
 		});
 
-		// Wait for first render before applying restoration
 		let renderDisposable: IDisposable | null = null;
 		let firstRenderFallback: ReturnType<typeof setTimeout> | null = null;
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalColdRestore.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalColdRestore.ts
@@ -72,11 +72,9 @@ export function useTerminalColdRestore({
 	const [isRestoredMode, setIsRestoredMode] = useState(false);
 	const [restoredCwd, setRestoredCwd] = useState<string | null>(null);
 
-	// Ref for restoredCwd to use in callbacks
 	const restoredCwdRef = useRef(restoredCwd);
 	restoredCwdRef.current = restoredCwd;
 
-	// Ref for handleStartShell to allow calling from handleRetryConnection
 	const handleStartShellRef = useRef<(cwd?: string | null) => void>(() => {});
 
 	const handleRetryConnection = useCallback(() => {
@@ -175,10 +173,8 @@ export function useTerminalColdRestore({
 			const fitAddon = fitAddonRef.current;
 			if (!xterm || !fitAddon) return;
 
-			// Drop any queued events from the pre-restore session
 			pendingEventsRef.current = [];
 
-			// Acknowledge cold restore to main process
 			trpcClient.terminal.ackColdRestore.mutate({ paneId }).catch((error) => {
 				console.warn("[Terminal] Failed to acknowledge cold restore:", {
 					paneId,
@@ -186,7 +182,6 @@ export function useTerminalColdRestore({
 				});
 			});
 
-			// Reset state for new session
 			isStreamReadyRef.current = false;
 			isExitedRef.current = false;
 			wasKilledByUserRef.current = false;
@@ -195,7 +190,6 @@ export function useTerminalColdRestore({
 			pendingInitialStateRef.current = null;
 			resetModes();
 
-			// Create new session with previous cwd (use passed cwd or fall back to ref)
 			createOrAttachRef.current(
 				{
 					paneId,
@@ -253,7 +247,6 @@ export function useTerminalColdRestore({
 		],
 	);
 
-	// Keep ref updated for use in handleRetryConnection
 	handleStartShellRef.current = handleStartShell;
 
 	return {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceInitializingView/WorkspaceInitializingView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceInitializingView/WorkspaceInitializingView.tsx
@@ -30,7 +30,6 @@ interface WorkspaceInitializingViewProps {
 	isInterrupted?: boolean;
 }
 
-// Steps to display in the progress view (skip pending and ready)
 const DISPLAY_STEPS: WorkspaceInitStep[] = INIT_STEP_ORDER.filter(
 	(step) => step !== "pending" && step !== "ready",
 );
@@ -84,8 +83,6 @@ export function WorkspaceInitializingView({
 
 	const currentStep = progress?.step ?? "pending";
 
-	// Interrupted state (app restart during init - no in-memory progress)
-	// Only show after delay to avoid flash during normal creation
 	if (isInterrupted && !progress && showInterruptedUI) {
 		return (
 			<>
@@ -176,7 +173,6 @@ export function WorkspaceInitializingView({
 		);
 	}
 
-	// Failed state
 	if (hasFailed) {
 		return (
 			<>
@@ -269,7 +265,6 @@ export function WorkspaceInitializingView({
 		);
 	}
 
-	// Initializing state
 	return (
 		<div className="flex flex-col items-center justify-center h-full w-full px-8">
 			<div className="flex flex-col items-center max-w-sm text-center space-y-6">


### PR DESCRIPTION
## Summary
- Remove the "Session restored" popup overlay that required user interaction
- Auto-start the shell immediately when a terminal session is cold-restored
- Preserve previous scrollback while starting the new shell in the background

## Test plan
- [ ] Restart the desktop app with terminal sessions open
- [ ] Verify no popup appears after restart
- [ ] Verify the terminal is immediately usable with the previous scrollback preserved
- [ ] Verify the shell starts automatically in the correct directory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined terminal cold-start restoration: the terminal now starts the shell directly with the appropriate working directory (when available) and no longer shows an intermediate restoration overlay, resulting in faster, smoother startup and focus behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->