### PR TITLE
fix(desktop): refresh git index before release script dirty check

### DIFF
--- a/apps/desktop/create-release.sh
+++ b/apps/desktop/create-release.sh
@@ -197,6 +197,8 @@ cd "${DESKTOP_DIR}"
 
 # 1. Check for uncommitted changes
 info "Checking for uncommitted changes..."
+# Refresh index to avoid false positives from stat cache mismatches
+git update-index --refresh > /dev/null 2>&1 || true
 if ! git diff-index --quiet HEAD --; then
     error "You have uncommitted changes. Please commit or stash them first."
 fi


### PR DESCRIPTION
## Summary
- Adds `git update-index --refresh` before the uncommitted changes check in the release script
- Fixes false positives when `git diff-index` reports changes due to stat cache mismatches (e.g., file timestamps changed by build processes, IDEs, or file sync but content is identical)

## Test plan
- [ ] Run `bun run release:desktop` after a build or IDE activity that touches files without changing content