### PR TITLE
fix(desktop): use gh CLI to fetch GitHub username for branch prefix

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
@@ -312,14 +312,22 @@ export async function getGitAuthorName(
 }
 
 export async function getGitHubUsername(
-	repoPath?: string,
+	_repoPath?: string,
 ): Promise<string | null> {
+	const env = await getGitEnv();
+
 	try {
-		const git = repoPath ? simpleGit(repoPath) : simpleGit();
-		const username = await git.getConfig("github.user");
-		return username.value?.trim() || null;
+		const { stdout } = await execFileAsync(
+			"gh",
+			["api", "user", "--jq", ".login"],
+			{ env, timeout: 10_000 },
+		);
+		return stdout.trim() || null;
 	} catch (error) {
-		console.warn("[git/getGitHubUsername] Failed to get github.user:", error);
+		console.warn(
+			"[git/getGitHubUsername] Failed to get GitHub username:",
+			error instanceof Error ? error.message : String(error),
+		);
 		return null;
 	}
 }

--- a/bun.lock
+++ b/bun.lock
@@ -131,7 +131,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "0.0.62",
+      "version": "0.0.63",
       "dependencies": {
         "@better-auth/stripe": "1.4.17",
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Summary
- Changed `getGitHubUsername` to use `gh api user --jq .login` instead of reading `github.user` from git config
- The git config approach required users to manually set `github.user`, which most users don't do
- Now automatically retrieves the authenticated GitHub username from the gh CLI

## Test plan
- [ ] Set branch prefix mode to "GitHub username" in settings
- [ ] Create a new workspace
- [ ] Verify the branch is prefixed with your GitHub username (e.g., `username/branch-name`)
- [ ] Test fallback behavior when gh CLI is not installed or not authenticated