### PR TITLE
feat(ui): make toast notifications copyable

### DIFF
--- a/packages/ui/src/components/ui/sonner.tsx
+++ b/packages/ui/src/components/ui/sonner.tsx
@@ -24,6 +24,12 @@ const Toaster = ({ ...props }: ToasterProps) => {
 				error: <OctagonXIcon className="size-4" />,
 				loading: <Loader2Icon className="size-4 animate-spin" />,
 			}}
+			toastOptions={{
+				style: {
+					userSelect: "text",
+					WebkitUserSelect: "text",
+				},
+			}}
 			style={
 				{
 					"--normal-bg": "var(--popover)",


### PR DESCRIPTION
## Summary
- Add `userSelect: text` styles to `toastOptions` in the Sonner Toaster component
- Allows users to select and copy text from toast notifications

## Test plan
- [ ] Trigger a toast notification (success, error, etc.)
- [ ] Verify text in the toast can be selected with cursor
- [ ] Verify selected text can be copied to clipboard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced toast notifications with text selection support, allowing users to copy content directly from toast messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->