### PR TITLE
Use Neon SVG favicon in PR comment templates

### DIFF
--- a/.github/templates/cleanup-comment.md
+++ b/.github/templates/cleanup-comment.md
@@ -8,7 +8,7 @@ The following preview resources have been cleaned up:
 <th align="center">Status</th>
 </tr>
 <tr>
-<td><img src="https://neon.com/favicon.ico" width="20" height="20" alt="Neon"> <strong>Database (Neon)</strong></td>
+<td><img src="https://neon.com/favicon/favicon.svg" width="20" height="20" alt="Neon"> <strong>Database (Neon)</strong></td>
 <td align="center">$NEON_STATUS</td>
 </tr>
 </table>

--- a/.github/templates/preview-comment.md
+++ b/.github/templates/preview-comment.md
@@ -9,7 +9,7 @@
 <th align="left">Link</th>
 </tr>
 <tr>
-<td><img src="https://neon.com/favicon.ico" width="20" height="20" alt="Neon"> <strong>Database (Neon)</strong></td>
+<td><img src="https://neon.com/favicon/favicon.svg" width="20" height="20" alt="Neon"> <strong>Database (Neon)</strong></td>
 <td align="center">$DATABASE_STATUS</td>
 <td>$DATABASE_LINK</td>
 </tr>


### PR DESCRIPTION
## Summary

- Swap `favicon.ico` for `favicon.svg` in the Neon icon URLs used in preview and cleanup PR comment templates

## Test plan
- [ ] Verify icon renders in a preview deployment comment