### PR TITLE
feat(desktop): agent screen composition with TanStack DB local collections

### DIFF
--- a/apps/api/src/lib/mcp/tools.ts
+++ b/apps/api/src/lib/mcp/tools.ts
@@ -954,6 +954,501 @@ export function registerMcpTools(server: McpServer, ctx: McpContext) {
 			});
 		},
 	);
+
+	// ========================================
+	// AGENT SCREEN TOOLS (Routed to Desktop)
+	// ========================================
+
+	server.tool(
+		"create_screen",
+		"Create a new agent screen for composing content to show the user",
+		{
+			deviceId: z.string().optional(),
+			workspaceId: z.string().uuid().describe("Workspace ID for context"),
+			title: z.string().describe("Screen title"),
+			description: z.string().optional().describe("Screen description"),
+		},
+		async (params) => {
+			const targetDeviceId = params.deviceId ?? ctx.defaultDeviceId;
+
+			if (!targetDeviceId) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: "Error: No device specified and no default device configured",
+						},
+					],
+					isError: true,
+				};
+			}
+
+			return executeOnDevice({
+				ctx,
+				deviceId: targetDeviceId,
+				tool: "create_screen",
+				params: {
+					workspaceId: params.workspaceId,
+					organizationId: ctx.organizationId,
+					title: params.title,
+					description: params.description,
+				},
+			});
+		},
+	);
+
+	server.tool(
+		"update_screen",
+		"Update an existing agent screen",
+		{
+			deviceId: z.string().optional(),
+			screenId: z.string().describe("Screen ID to update"),
+			title: z.string().optional().describe("New title"),
+			description: z.string().optional().describe("New description"),
+			status: z
+				.enum(["composing", "ready", "viewed", "dismissed"])
+				.optional()
+				.describe("New status"),
+		},
+		async (params) => {
+			const targetDeviceId = params.deviceId ?? ctx.defaultDeviceId;
+
+			if (!targetDeviceId) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: "Error: No device specified and no default device configured",
+						},
+					],
+					isError: true,
+				};
+			}
+
+			return executeOnDevice({
+				ctx,
+				deviceId: targetDeviceId,
+				tool: "update_screen",
+				params: {
+					screenId: params.screenId,
+					title: params.title,
+					description: params.description,
+					status: params.status,
+				},
+			});
+		},
+	);
+
+	server.tool(
+		"set_screen_layout",
+		"Set the pane layout for an agent screen using a mosaic tree structure",
+		{
+			deviceId: z.string().optional(),
+			screenId: z.string().describe("Screen ID"),
+			layout: z
+				.any()
+				.describe(
+					"Mosaic layout: either a pane ID string, or an object with { direction: 'row' | 'column', first: layout, second: layout, splitPercentage?: number }",
+				),
+		},
+		async (params) => {
+			const targetDeviceId = params.deviceId ?? ctx.defaultDeviceId;
+
+			if (!targetDeviceId) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: "Error: No device specified and no default device configured",
+						},
+					],
+					isError: true,
+				};
+			}
+
+			return executeOnDevice({
+				ctx,
+				deviceId: targetDeviceId,
+				tool: "set_screen_layout",
+				params: {
+					screenId: params.screenId,
+					layout: params.layout,
+				},
+			});
+		},
+	);
+
+	server.tool(
+		"delete_screen",
+		"Delete an agent screen",
+		{
+			deviceId: z.string().optional(),
+			screenId: z.string().describe("Screen ID to delete"),
+		},
+		async (params) => {
+			const targetDeviceId = params.deviceId ?? ctx.defaultDeviceId;
+
+			if (!targetDeviceId) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: "Error: No device specified and no default device configured",
+						},
+					],
+					isError: true,
+				};
+			}
+
+			return executeOnDevice({
+				ctx,
+				deviceId: targetDeviceId,
+				tool: "delete_screen",
+				params: {
+					screenId: params.screenId,
+				},
+			});
+		},
+	);
+
+	// Pane management tools
+
+	server.tool(
+		"add_browser_pane",
+		"Add a browser pane to an agent screen",
+		{
+			deviceId: z.string().optional(),
+			screenId: z.string().describe("Screen ID"),
+			paneId: z.string().describe("Unique pane ID within the screen"),
+			url: z.string().url().describe("URL to display"),
+			title: z.string().optional().describe("Pane title"),
+		},
+		async (params) => {
+			const targetDeviceId = params.deviceId ?? ctx.defaultDeviceId;
+
+			if (!targetDeviceId) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: "Error: No device specified and no default device configured",
+						},
+					],
+					isError: true,
+				};
+			}
+
+			return executeOnDevice({
+				ctx,
+				deviceId: targetDeviceId,
+				tool: "add_browser_pane",
+				params: {
+					screenId: params.screenId,
+					paneId: params.paneId,
+					url: params.url,
+					title: params.title,
+				},
+			});
+		},
+	);
+
+	server.tool(
+		"navigate_browser",
+		"Navigate a browser pane to a new URL",
+		{
+			deviceId: z.string().optional(),
+			screenId: z.string().describe("Screen ID"),
+			paneId: z.string().describe("Pane ID"),
+			url: z.string().url().describe("URL to navigate to"),
+		},
+		async (params) => {
+			const targetDeviceId = params.deviceId ?? ctx.defaultDeviceId;
+
+			if (!targetDeviceId) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: "Error: No device specified and no default device configured",
+						},
+					],
+					isError: true,
+				};
+			}
+
+			return executeOnDevice({
+				ctx,
+				deviceId: targetDeviceId,
+				tool: "navigate_browser",
+				params: {
+					screenId: params.screenId,
+					paneId: params.paneId,
+					url: params.url,
+				},
+			});
+		},
+	);
+
+	server.tool(
+		"add_terminal_pane",
+		"Add a terminal pane to an agent screen",
+		{
+			deviceId: z.string().optional(),
+			screenId: z.string().describe("Screen ID"),
+			paneId: z.string().describe("Unique pane ID within the screen"),
+		},
+		async (params) => {
+			const targetDeviceId = params.deviceId ?? ctx.defaultDeviceId;
+
+			if (!targetDeviceId) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: "Error: No device specified and no default device configured",
+						},
+					],
+					isError: true,
+				};
+			}
+
+			return executeOnDevice({
+				ctx,
+				deviceId: targetDeviceId,
+				tool: "add_terminal_pane",
+				params: {
+					screenId: params.screenId,
+					paneId: params.paneId,
+				},
+			});
+		},
+	);
+
+	server.tool(
+		"write_terminal",
+		"Write data to a terminal pane",
+		{
+			deviceId: z.string().optional(),
+			screenId: z.string().describe("Screen ID"),
+			paneId: z.string().describe("Pane ID"),
+			data: z.string().describe("Data to write to the terminal"),
+		},
+		async (params) => {
+			const targetDeviceId = params.deviceId ?? ctx.defaultDeviceId;
+
+			if (!targetDeviceId) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: "Error: No device specified and no default device configured",
+						},
+					],
+					isError: true,
+				};
+			}
+
+			return executeOnDevice({
+				ctx,
+				deviceId: targetDeviceId,
+				tool: "write_terminal",
+				params: {
+					screenId: params.screenId,
+					paneId: params.paneId,
+					data: params.data,
+				},
+			});
+		},
+	);
+
+	server.tool(
+		"add_summary_pane",
+		"Add a markdown summary pane to an agent screen",
+		{
+			deviceId: z.string().optional(),
+			screenId: z.string().describe("Screen ID"),
+			paneId: z.string().describe("Unique pane ID within the screen"),
+			content: z.string().describe("Markdown content"),
+			title: z.string().optional().describe("Pane title"),
+		},
+		async (params) => {
+			const targetDeviceId = params.deviceId ?? ctx.defaultDeviceId;
+
+			if (!targetDeviceId) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: "Error: No device specified and no default device configured",
+						},
+					],
+					isError: true,
+				};
+			}
+
+			return executeOnDevice({
+				ctx,
+				deviceId: targetDeviceId,
+				tool: "add_summary_pane",
+				params: {
+					screenId: params.screenId,
+					paneId: params.paneId,
+					content: params.content,
+					title: params.title,
+				},
+			});
+		},
+	);
+
+	server.tool(
+		"update_summary",
+		"Update the content of a summary pane",
+		{
+			deviceId: z.string().optional(),
+			screenId: z.string().describe("Screen ID"),
+			paneId: z.string().describe("Pane ID"),
+			content: z.string().describe("New markdown content"),
+		},
+		async (params) => {
+			const targetDeviceId = params.deviceId ?? ctx.defaultDeviceId;
+
+			if (!targetDeviceId) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: "Error: No device specified and no default device configured",
+						},
+					],
+					isError: true,
+				};
+			}
+
+			return executeOnDevice({
+				ctx,
+				deviceId: targetDeviceId,
+				tool: "update_summary",
+				params: {
+					screenId: params.screenId,
+					paneId: params.paneId,
+					content: params.content,
+				},
+			});
+		},
+	);
+
+	server.tool(
+		"remove_pane",
+		"Remove a pane from an agent screen",
+		{
+			deviceId: z.string().optional(),
+			screenId: z.string().describe("Screen ID"),
+			paneId: z.string().describe("Pane ID to remove"),
+		},
+		async (params) => {
+			const targetDeviceId = params.deviceId ?? ctx.defaultDeviceId;
+
+			if (!targetDeviceId) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: "Error: No device specified and no default device configured",
+						},
+					],
+					isError: true,
+				};
+			}
+
+			return executeOnDevice({
+				ctx,
+				deviceId: targetDeviceId,
+				tool: "remove_pane",
+				params: {
+					screenId: params.screenId,
+					paneId: params.paneId,
+				},
+			});
+		},
+	);
+
+	// Notification tools
+
+	server.tool(
+		"notify_user",
+		"Send a notification to the user with a link to an agent screen",
+		{
+			deviceId: z.string().optional(),
+			screenId: z.string().describe("Screen ID to link to"),
+			title: z.string().describe("Notification title"),
+			body: z.string().optional().describe("Notification body text"),
+			priority: z
+				.enum(["normal", "high", "urgent"])
+				.default("normal")
+				.describe("Notification priority"),
+		},
+		async (params) => {
+			const targetDeviceId = params.deviceId ?? ctx.defaultDeviceId;
+
+			if (!targetDeviceId) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: "Error: No device specified and no default device configured",
+						},
+					],
+					isError: true,
+				};
+			}
+
+			return executeOnDevice({
+				ctx,
+				deviceId: targetDeviceId,
+				tool: "notify_user",
+				params: {
+					screenId: params.screenId,
+					organizationId: ctx.organizationId,
+					title: params.title,
+					body: params.body,
+					priority: params.priority,
+				},
+			});
+		},
+	);
+
+	server.tool(
+		"cancel_notification",
+		"Cancel/dismiss a pending notification",
+		{
+			deviceId: z.string().optional(),
+			notificationId: z.string().describe("Notification ID to cancel"),
+		},
+		async (params) => {
+			const targetDeviceId = params.deviceId ?? ctx.defaultDeviceId;
+
+			if (!targetDeviceId) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: "Error: No device specified and no default device configured",
+						},
+					],
+					isError: true,
+				};
+			}
+
+			return executeOnDevice({
+				ctx,
+				deviceId: targetDeviceId,
+				tool: "cancel_notification",
+				params: {
+					notificationId: params.notificationId,
+				},
+			});
+		},
+	);
 }
 
 // ========================================

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -5,11 +5,13 @@ import {
 	useNavigate,
 } from "@tanstack/react-router";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { NotificationSidebar } from "renderer/screens/main/components/NotificationSidebar";
 import { ResizablePanel } from "renderer/screens/main/components/ResizablePanel";
 import { TopBar } from "renderer/screens/main/components/TopBar";
 import { WorkspaceSidebar } from "renderer/screens/main/components/WorkspaceSidebar";
 import { useAppHotkey } from "renderer/stores/hotkeys";
 import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
+import { useNotificationSidebarStore } from "renderer/stores/notification-sidebar-state";
 import {
 	COLLAPSED_WORKSPACE_SIDEBAR_WIDTH,
 	MAX_WORKSPACE_SIDEBAR_WIDTH,
@@ -49,6 +51,11 @@ function DashboardLayout() {
 		isCollapsed: isWorkspaceSidebarCollapsed,
 	} = useWorkspaceSidebarStore();
 
+	const {
+		isOpen: isNotificationSidebarOpen,
+		toggleOpen: toggleNotificationSidebar,
+	} = useNotificationSidebarStore();
+
 	// Global hotkeys for dashboard
 	useAppHotkey(
 		"SHOW_HOTKEYS",
@@ -81,6 +88,14 @@ function DashboardLayout() {
 		[openNewWorkspaceModal, currentWorkspace?.projectId],
 	);
 
+	// Toggle notification sidebar with Cmd/Ctrl+Shift+N
+	useAppHotkey(
+		"TOGGLE_NOTIFICATION_SIDEBAR",
+		toggleNotificationSidebar,
+		undefined,
+		[toggleNotificationSidebar],
+	);
+
 	return (
 		<div className="flex flex-col h-full w-full">
 			<TopBar />
@@ -100,6 +115,7 @@ function DashboardLayout() {
 					</ResizablePanel>
 				)}
 				<Outlet />
+				{isNotificationSidebarOpen && <NotificationSidebar />}
 			</div>
 		</div>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/screen/$screenId/components/AgentScreenView/AgentScreenView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/screen/$screenId/components/AgentScreenView/AgentScreenView.tsx
@@ -1,0 +1,139 @@
+import "react-mosaic-component/react-mosaic-component.css";
+import "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/mosaic-theme.css";
+
+import { useCallback, useMemo } from "react";
+import {
+	Mosaic,
+	type MosaicBranch,
+	type MosaicNode,
+} from "react-mosaic-component";
+import { dragDropManager } from "renderer/lib/dnd";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider/CollectionsProvider";
+import {
+	type AgentScreen,
+	agentScreenOperations,
+} from "renderer/stores/agent-screens";
+import { BrowserPane } from "./components/BrowserPane";
+import { SummaryPane } from "./components/SummaryPane";
+import { TerminalPane } from "./components/TerminalPane";
+
+interface AgentScreenViewProps {
+	screen: AgentScreen;
+}
+
+export function AgentScreenView({ screen }: AgentScreenViewProps) {
+	const collections = useCollections();
+
+	const paneIds = useMemo(() => Object.keys(screen.panes), [screen.panes]);
+
+	const handleLayoutChange = useCallback(
+		(newLayout: MosaicNode<string> | null) => {
+			if (newLayout) {
+				agentScreenOperations.setScreenLayout(
+					collections.agentScreens,
+					screen.id,
+					newLayout,
+				);
+			}
+		},
+		[screen.id, collections.agentScreens],
+	);
+
+	const renderPane = useCallback(
+		(paneId: string, _path: MosaicBranch[]) => {
+			const pane = screen.panes[paneId];
+
+			if (!pane) {
+				return (
+					<div className="w-full h-full flex items-center justify-center text-muted-foreground bg-background">
+						Pane not found: {paneId}
+					</div>
+				);
+			}
+
+			switch (pane.type) {
+				case "browser":
+					return (
+						<BrowserPane pane={pane} screenId={screen.id} paneId={paneId} />
+					);
+				case "terminal":
+					return (
+						<TerminalPane
+							pane={pane}
+							screenId={screen.id}
+							paneId={paneId}
+							workspaceId={screen.workspaceId}
+						/>
+					);
+				case "summary":
+					return (
+						<SummaryPane pane={pane} screenId={screen.id} paneId={paneId} />
+					);
+				default:
+					return (
+						<div className="w-full h-full flex items-center justify-center text-muted-foreground bg-background">
+							Unknown pane type
+						</div>
+					);
+			}
+		},
+		[screen.panes, screen.id, screen.workspaceId],
+	);
+
+	// No panes or no layout
+	if (paneIds.length === 0 || !screen.layout) {
+		return (
+			<div className="w-full h-full flex items-center justify-center bg-background">
+				<div className="text-center">
+					<h2 className="text-lg font-medium text-foreground mb-2">
+						{screen.title}
+					</h2>
+					{screen.description && (
+						<p className="text-sm text-muted-foreground mb-4">
+							{screen.description}
+						</p>
+					)}
+					<p className="text-sm text-muted-foreground">
+						{screen.status === "composing"
+							? "Agent is composing this screen..."
+							: "No content to display"}
+					</p>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="w-full h-full flex flex-col">
+			{/* Header */}
+			<div className="shrink-0 h-10 px-4 flex items-center justify-between border-b border-border bg-background">
+				<div className="flex items-center gap-2">
+					<h1 className="text-sm font-medium text-foreground">
+						{screen.title}
+					</h1>
+					{screen.status === "composing" && (
+						<span className="text-xs text-muted-foreground">
+							(composing...)
+						</span>
+					)}
+				</div>
+				{screen.description && (
+					<p className="text-xs text-muted-foreground truncate max-w-[300px]">
+						{screen.description}
+					</p>
+				)}
+			</div>
+
+			{/* Mosaic layout */}
+			<div className="flex-1 mosaic-container">
+				<Mosaic<string>
+					renderTile={renderPane}
+					value={screen.layout}
+					onChange={handleLayoutChange}
+					className="mosaic-theme-dark"
+					dragAndDropManager={dragDropManager}
+				/>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/screen/$screenId/components/AgentScreenView/components/BrowserPane/BrowserPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/screen/$screenId/components/AgentScreenView/components/BrowserPane/BrowserPane.tsx
@@ -1,0 +1,137 @@
+import { Button } from "@superset/ui/button";
+import { Input } from "@superset/ui/input";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { HiArrowPath, HiGlobeAlt, HiXMark } from "react-icons/hi2";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider/CollectionsProvider";
+import {
+	agentScreenOperations,
+	type BrowserPane as BrowserPaneType,
+} from "renderer/stores/agent-screens";
+
+interface BrowserPaneProps {
+	pane: BrowserPaneType;
+	screenId: string;
+	paneId: string;
+}
+
+export function BrowserPane({ pane, screenId, paneId }: BrowserPaneProps) {
+	const webviewRef = useRef<HTMLWebViewElement | null>(null);
+	const [currentUrl, setCurrentUrl] = useState(pane.url);
+	const [isLoading, setIsLoading] = useState(true);
+	const collections = useCollections();
+
+	// Set up webview event listeners
+	useEffect(() => {
+		const webview = webviewRef.current;
+		if (!webview) return;
+
+		const handleStartLoading = () => setIsLoading(true);
+		const handleStopLoading = () => setIsLoading(false);
+		const handleNavigate = (event: Event) => {
+			const e = event as CustomEvent<{ url: string }>;
+			if (e.detail?.url) {
+				setCurrentUrl(e.detail.url);
+			}
+		};
+
+		// Electron webview uses custom events
+		webview.addEventListener("did-start-loading", handleStartLoading);
+		webview.addEventListener("did-stop-loading", handleStopLoading);
+		webview.addEventListener("did-navigate", handleNavigate);
+		webview.addEventListener("did-navigate-in-page", handleNavigate);
+
+		return () => {
+			webview.removeEventListener("did-start-loading", handleStartLoading);
+			webview.removeEventListener("did-stop-loading", handleStopLoading);
+			webview.removeEventListener("did-navigate", handleNavigate);
+			webview.removeEventListener("did-navigate-in-page", handleNavigate);
+		};
+	}, []);
+
+	const handleNavigate = useCallback(
+		(url: string) => {
+			const webview = webviewRef.current as Electron.WebviewTag | null;
+			if (webview) {
+				webview.src = url;
+				setCurrentUrl(url);
+				agentScreenOperations.updatePane(
+					collections.agentScreens,
+					screenId,
+					paneId,
+					{ url },
+				);
+			}
+		},
+		[screenId, paneId, collections.agentScreens],
+	);
+
+	const handleRefresh = useCallback(() => {
+		const webview = webviewRef.current as Electron.WebviewTag | null;
+		webview?.reload();
+	}, []);
+
+	const handleClose = useCallback(() => {
+		agentScreenOperations.removePane(
+			collections.agentScreens,
+			screenId,
+			paneId,
+		);
+	}, [screenId, paneId, collections.agentScreens]);
+
+	const handleKeyDown = useCallback(
+		(e: React.KeyboardEvent<HTMLInputElement>) => {
+			if (e.key === "Enter") {
+				handleNavigate(currentUrl);
+			}
+		},
+		[currentUrl, handleNavigate],
+	);
+
+	return (
+		<div className="w-full h-full flex flex-col bg-background">
+			{/* Browser toolbar */}
+			<div className="shrink-0 h-10 px-2 flex items-center gap-2 border-b border-border bg-muted/30">
+				<HiGlobeAlt className="w-4 h-4 text-muted-foreground shrink-0" />
+				<Input
+					value={currentUrl}
+					onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+						setCurrentUrl(e.target.value)
+					}
+					onKeyDown={handleKeyDown}
+					className="h-7 text-xs flex-1"
+					placeholder="Enter URL..."
+				/>
+				<Button
+					variant="ghost"
+					size="icon"
+					className="h-7 w-7"
+					onClick={handleRefresh}
+					title="Refresh"
+				>
+					<HiArrowPath
+						className={`w-3.5 h-3.5 ${isLoading ? "animate-spin" : ""}`}
+					/>
+				</Button>
+				<Button
+					variant="ghost"
+					size="icon"
+					className="h-7 w-7"
+					onClick={handleClose}
+					title="Close pane"
+				>
+					<HiXMark className="w-3.5 h-3.5" />
+				</Button>
+			</div>
+
+			{/* Webview */}
+			<div className="flex-1 relative">
+				<webview ref={webviewRef} src={pane.url} className="w-full h-full" />
+				{isLoading && (
+					<div className="absolute inset-0 flex items-center justify-center bg-background/80">
+						<HiArrowPath className="w-6 h-6 animate-spin text-muted-foreground" />
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/screen/$screenId/components/AgentScreenView/components/BrowserPane/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/screen/$screenId/components/AgentScreenView/components/BrowserPane/index.ts
@@ -1,0 +1,1 @@
+export { BrowserPane } from "./BrowserPane";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/screen/$screenId/components/AgentScreenView/components/SummaryPane/SummaryPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/screen/$screenId/components/AgentScreenView/components/SummaryPane/SummaryPane.tsx
@@ -1,0 +1,137 @@
+import { Button } from "@superset/ui/button";
+import { useCallback, useMemo } from "react";
+import { HiDocumentText, HiXMark } from "react-icons/hi2";
+import ReactMarkdown from "react-markdown";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider/CollectionsProvider";
+import {
+	agentScreenOperations,
+	type SummaryPane as SummaryPaneType,
+} from "renderer/stores/agent-screens";
+
+interface SummaryPaneProps {
+	pane: SummaryPaneType;
+	screenId: string;
+	paneId: string;
+}
+
+export function SummaryPane({ pane, screenId, paneId }: SummaryPaneProps) {
+	const collections = useCollections();
+
+	const handleClose = useCallback(() => {
+		agentScreenOperations.removePane(
+			collections.agentScreens,
+			screenId,
+			paneId,
+		);
+	}, [screenId, paneId, collections.agentScreens]);
+
+	// Memoize markdown content to avoid re-parsing
+	const markdownContent = useMemo(() => pane.content, [pane.content]);
+
+	return (
+		<div className="w-full h-full flex flex-col bg-background">
+			{/* Summary toolbar */}
+			<div className="shrink-0 h-8 px-2 flex items-center justify-between border-b border-border bg-muted/30">
+				<div className="flex items-center gap-2">
+					<HiDocumentText className="w-3.5 h-3.5 text-muted-foreground" />
+					<span className="text-xs text-muted-foreground">
+						{pane.title ?? "Summary"}
+					</span>
+				</div>
+				<Button
+					variant="ghost"
+					size="icon"
+					className="h-6 w-6"
+					onClick={handleClose}
+					title="Close pane"
+				>
+					<HiXMark className="w-3 h-3" />
+				</Button>
+			</div>
+
+			{/* Markdown content */}
+			<div className="flex-1 overflow-auto p-4">
+				<article className="prose prose-sm prose-invert max-w-none">
+					<ReactMarkdown
+						components={{
+							// Custom rendering for code blocks
+							code({ className, children, ...props }) {
+								const match = /language-(\w+)/.exec(className || "");
+								const isInline = !match;
+
+								if (isInline) {
+									return (
+										<code
+											className="bg-muted px-1.5 py-0.5 rounded text-sm font-mono"
+											{...props}
+										>
+											{children}
+										</code>
+									);
+								}
+
+								return (
+									<pre className="bg-muted p-3 rounded-md overflow-x-auto">
+										<code
+											className={`${className} text-sm font-mono`}
+											{...props}
+										>
+											{children}
+										</code>
+									</pre>
+								);
+							},
+							// Style headings
+							h1: ({ children }) => (
+								<h1 className="text-xl font-bold text-foreground mb-4">
+									{children}
+								</h1>
+							),
+							h2: ({ children }) => (
+								<h2 className="text-lg font-semibold text-foreground mt-6 mb-3">
+									{children}
+								</h2>
+							),
+							h3: ({ children }) => (
+								<h3 className="text-base font-medium text-foreground mt-4 mb-2">
+									{children}
+								</h3>
+							),
+							// Style paragraphs
+							p: ({ children }) => (
+								<p className="text-sm text-foreground/90 mb-3 leading-relaxed">
+									{children}
+								</p>
+							),
+							// Style lists
+							ul: ({ children }) => (
+								<ul className="list-disc list-inside mb-3 text-sm text-foreground/90">
+									{children}
+								</ul>
+							),
+							ol: ({ children }) => (
+								<ol className="list-decimal list-inside mb-3 text-sm text-foreground/90">
+									{children}
+								</ol>
+							),
+							li: ({ children }) => <li className="mb-1">{children}</li>,
+							// Style links
+							a: ({ href, children }) => (
+								<a
+									href={href}
+									className="text-primary hover:underline"
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									{children}
+								</a>
+							),
+						}}
+					>
+						{markdownContent}
+					</ReactMarkdown>
+				</article>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/screen/$screenId/components/AgentScreenView/components/SummaryPane/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/screen/$screenId/components/AgentScreenView/components/SummaryPane/index.ts
@@ -1,0 +1,1 @@
+export { SummaryPane } from "./SummaryPane";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/screen/$screenId/components/AgentScreenView/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/screen/$screenId/components/AgentScreenView/components/TerminalPane/TerminalPane.tsx
@@ -1,0 +1,182 @@
+import { Button } from "@superset/ui/button";
+import { useCallback, useEffect, useRef } from "react";
+import { HiXMark } from "react-icons/hi2";
+import { LuTerminal } from "react-icons/lu";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider/CollectionsProvider";
+import {
+	agentScreenOperations,
+	type TerminalPane as TerminalPaneType,
+} from "renderer/stores/agent-screens";
+
+interface TerminalPaneProps {
+	pane: TerminalPaneType;
+	screenId: string;
+	paneId: string;
+	workspaceId: string;
+}
+
+export function TerminalPane({
+	pane,
+	screenId,
+	paneId,
+	workspaceId,
+}: TerminalPaneProps) {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const xtermRef = useRef<import("@xterm/xterm").Terminal | null>(null);
+	const fitAddonRef = useRef<import("@xterm/addon-fit").FitAddon | null>(null);
+	const collections = useCollections();
+
+	// Use the screen's paneId prefixed with "screen-" to avoid collision with workspace terminal panes
+	const sessionId = pane.sessionId ?? `screen-${screenId}-${paneId}`;
+
+	// Create or attach to terminal session
+	const createOrAttach = electronTrpc.terminal.createOrAttach.useMutation();
+	const write = electronTrpc.terminal.write.useMutation();
+	const resize = electronTrpc.terminal.resize.useMutation();
+
+	// Subscribe to terminal data stream
+	electronTrpc.terminal.stream.useSubscription(sessionId, {
+		onData: (event) => {
+			if (event.type === "data" && xtermRef.current) {
+				xtermRef.current.write(event.data);
+			}
+		},
+	});
+
+	// Initialize terminal
+	useEffect(() => {
+		if (!containerRef.current) return;
+
+		let isMounted = true;
+
+		const initTerminal = async () => {
+			// Dynamically import xterm to avoid SSR issues
+			const { Terminal } = await import("@xterm/xterm");
+			const { FitAddon } = await import("@xterm/addon-fit");
+			await import("@xterm/xterm/css/xterm.css");
+
+			if (!isMounted || !containerRef.current) return;
+
+			// Create xterm instance
+			const xterm = new Terminal({
+				cursorBlink: true,
+				fontSize: 13,
+				fontFamily: "JetBrains Mono, Menlo, Monaco, Consolas, monospace",
+				theme: {
+					background: "#1a1a1a",
+					foreground: "#e5e5e5",
+					cursor: "#e5e5e5",
+				},
+			});
+
+			const fitAddon = new FitAddon();
+			xterm.loadAddon(fitAddon);
+
+			xterm.open(containerRef.current);
+			fitAddon.fit();
+
+			xtermRef.current = xterm;
+			fitAddonRef.current = fitAddon;
+
+			// Handle input
+			xterm.onData((data) => {
+				write.mutate({ paneId: sessionId, data });
+			});
+
+			// Create or attach to session
+			try {
+				const result = await createOrAttach.mutateAsync({
+					paneId: sessionId,
+					tabId: screenId,
+					workspaceId,
+					cols: xterm.cols,
+					rows: xterm.rows,
+					allowKilled: true,
+				});
+
+				// Write scrollback if available
+				if (result.scrollback) {
+					xterm.write(result.scrollback);
+				}
+
+				// Save session ID to pane
+				agentScreenOperations.updatePane(
+					collections.agentScreens,
+					screenId,
+					paneId,
+					{ sessionId },
+				);
+			} catch (error) {
+				console.error("[TerminalPane] Failed to create session:", error);
+			}
+		};
+
+		initTerminal();
+
+		// Handle resize
+		const resizeObserver = new ResizeObserver(() => {
+			if (fitAddonRef.current && xtermRef.current) {
+				fitAddonRef.current.fit();
+				resize.mutate({
+					paneId: sessionId,
+					cols: xtermRef.current.cols,
+					rows: xtermRef.current.rows,
+				});
+			}
+		});
+
+		if (containerRef.current) {
+			resizeObserver.observe(containerRef.current);
+		}
+
+		return () => {
+			isMounted = false;
+			resizeObserver.disconnect();
+			xtermRef.current?.dispose();
+			xtermRef.current = null;
+			fitAddonRef.current = null;
+		};
+	}, [
+		sessionId,
+		screenId,
+		paneId,
+		workspaceId,
+		createOrAttach,
+		write,
+		resize,
+		collections.agentScreens,
+	]);
+
+	const handleClose = useCallback(() => {
+		agentScreenOperations.removePane(
+			collections.agentScreens,
+			screenId,
+			paneId,
+		);
+	}, [screenId, paneId, collections.agentScreens]);
+
+	return (
+		<div className="w-full h-full flex flex-col bg-[#1a1a1a]">
+			{/* Terminal toolbar */}
+			<div className="shrink-0 h-8 px-2 flex items-center justify-between border-b border-border/30 bg-[#1a1a1a]">
+				<div className="flex items-center gap-2">
+					<LuTerminal className="w-3.5 h-3.5 text-muted-foreground" />
+					<span className="text-xs text-muted-foreground">Terminal</span>
+				</div>
+				<Button
+					variant="ghost"
+					size="icon"
+					className="h-6 w-6"
+					onClick={handleClose}
+					title="Close pane"
+				>
+					<HiXMark className="w-3 h-3" />
+				</Button>
+			</div>
+
+			{/* Terminal container */}
+			<div ref={containerRef} className="flex-1 overflow-hidden" />
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/screen/$screenId/components/AgentScreenView/components/TerminalPane/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/screen/$screenId/components/AgentScreenView/components/TerminalPane/index.ts
@@ -1,0 +1,1 @@
+export { TerminalPane } from "./TerminalPane";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/screen/$screenId/components/AgentScreenView/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/screen/$screenId/components/AgentScreenView/index.ts
@@ -1,0 +1,1 @@
+export { AgentScreenView } from "./AgentScreenView";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/screen/$screenId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/screen/$screenId/page.tsx
@@ -1,0 +1,113 @@
+import { eq } from "@tanstack/db";
+import { useLiveQuery } from "@tanstack/react-db";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useEffect } from "react";
+import { env } from "renderer/env.renderer";
+import { authClient } from "renderer/lib/auth-client";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider/CollectionsProvider";
+import { agentNotificationOperations } from "renderer/stores/agent-screens";
+import { MOCK_ORG_ID } from "shared/constants";
+import { AgentScreenView } from "./components/AgentScreenView";
+
+export const Route = createFileRoute(
+	"/_authenticated/_dashboard/screen/$screenId/",
+)({
+	component: ScreenPage,
+});
+
+function ScreenPage() {
+	const { screenId } = Route.useParams();
+	const navigate = useNavigate();
+	const { data: session } = authClient.useSession();
+	const organizationId = env.SKIP_ENV_VALIDATION
+		? MOCK_ORG_ID
+		: session?.session?.activeOrganizationId;
+	const collections = useCollections();
+
+	// Get screen from collection
+	const { data: screens } = useLiveQuery(
+		(q) =>
+			q
+				.from({ screens: collections.agentScreens })
+				.where(({ screens }) => eq(screens.id, screenId))
+				.select(({ screens }) => ({ ...screens })),
+		[collections.agentScreens, screenId],
+	);
+
+	const screen = screens?.[0];
+
+	// Get pending notification for this screen
+	const { data: pendingNotifications } = useLiveQuery(
+		(q) =>
+			q
+				.from({ notifications: collections.agentNotifications })
+				.where(({ notifications }) => eq(notifications.screenId, screenId))
+				.where(({ notifications }) => eq(notifications.status, "pending"))
+				.select(({ notifications }) => ({ id: notifications.id })),
+		[collections.agentNotifications, screenId],
+	);
+
+	const pendingNotificationId = pendingNotifications?.[0]?.id;
+
+	// Mark associated notification as viewed when screen is opened
+	useEffect(() => {
+		if (pendingNotificationId) {
+			agentNotificationOperations.markNotificationViewed(
+				collections.agentNotifications,
+				pendingNotificationId,
+			);
+		}
+	}, [pendingNotificationId, collections.agentNotifications]);
+
+	// Screen not found
+	if (!screen) {
+		return (
+			<div className="flex-1 h-full flex items-center justify-center">
+				<div className="text-center">
+					<h2 className="text-lg font-medium text-foreground mb-2">
+						Screen Not Found
+					</h2>
+					<p className="text-sm text-muted-foreground mb-4">
+						The requested screen does not exist or has been dismissed.
+					</p>
+					<button
+						type="button"
+						onClick={() => navigate({ to: "/" })}
+						className="text-sm text-primary hover:underline"
+					>
+						Go back to workspaces
+					</button>
+				</div>
+			</div>
+		);
+	}
+
+	// Check organization match
+	if (screen.organizationId !== organizationId) {
+		return (
+			<div className="flex-1 h-full flex items-center justify-center">
+				<div className="text-center">
+					<h2 className="text-lg font-medium text-foreground mb-2">
+						Access Denied
+					</h2>
+					<p className="text-sm text-muted-foreground mb-4">
+						This screen belongs to a different organization.
+					</p>
+					<button
+						type="button"
+						onClick={() => navigate({ to: "/" })}
+						className="text-sm text-primary hover:underline"
+					>
+						Go back to workspaces
+					</button>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex-1 h-full flex flex-col overflow-hidden">
+			<AgentScreenView screen={screen} />
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/agent-screens.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/agent-screens.ts
@@ -1,0 +1,428 @@
+import {
+	agentNotificationOperations,
+	agentScreenOperations,
+} from "renderer/stores/agent-screens";
+import { z } from "zod";
+import type { CommandResult, ToolDefinition } from "./types";
+
+// Schema definitions for each tool
+const createScreenSchema = z.object({
+	workspaceId: z.string(),
+	organizationId: z.string(),
+	title: z.string(),
+	description: z.string().optional(),
+});
+
+const updateScreenSchema = z.object({
+	screenId: z.string(),
+	title: z.string().optional(),
+	description: z.string().optional(),
+	status: z.enum(["composing", "ready", "viewed", "dismissed"]).optional(),
+});
+
+const setScreenLayoutSchema = z.object({
+	screenId: z.string(),
+	layout: z.any(), // MosaicNode is complex, validate at runtime
+});
+
+const deleteScreenSchema = z.object({
+	screenId: z.string(),
+});
+
+const addBrowserPaneSchema = z.object({
+	screenId: z.string(),
+	paneId: z.string(),
+	url: z.string(),
+	title: z.string().optional(),
+});
+
+const navigateBrowserSchema = z.object({
+	screenId: z.string(),
+	paneId: z.string(),
+	url: z.string(),
+});
+
+const addTerminalPaneSchema = z.object({
+	screenId: z.string(),
+	paneId: z.string(),
+});
+
+const writeTerminalSchema = z.object({
+	screenId: z.string(),
+	paneId: z.string(),
+	data: z.string(),
+});
+
+const addSummaryPaneSchema = z.object({
+	screenId: z.string(),
+	paneId: z.string(),
+	content: z.string(),
+	title: z.string().optional(),
+});
+
+const updateSummarySchema = z.object({
+	screenId: z.string(),
+	paneId: z.string(),
+	content: z.string(),
+});
+
+const removePaneSchema = z.object({
+	screenId: z.string(),
+	paneId: z.string(),
+});
+
+const notifyUserSchema = z.object({
+	screenId: z.string(),
+	organizationId: z.string(),
+	title: z.string(),
+	body: z.string().optional(),
+	priority: z.enum(["normal", "high", "urgent"]).optional(),
+});
+
+const cancelNotificationSchema = z.object({
+	notificationId: z.string(),
+});
+
+// Tool definitions
+export const createScreen: ToolDefinition<typeof createScreenSchema> = {
+	name: "create_screen",
+	schema: createScreenSchema,
+	execute: async (params, ctx): Promise<CommandResult> => {
+		try {
+			const screenId = agentScreenOperations.createScreen(ctx.agentScreens, {
+				workspaceId: params.workspaceId,
+				organizationId: params.organizationId,
+				title: params.title,
+				description: params.description,
+			});
+			return { success: true, data: { screenId } };
+		} catch (error) {
+			return {
+				success: false,
+				error:
+					error instanceof Error ? error.message : "Failed to create screen",
+			};
+		}
+	},
+};
+
+export const updateScreen: ToolDefinition<typeof updateScreenSchema> = {
+	name: "update_screen",
+	schema: updateScreenSchema,
+	execute: async (params, ctx): Promise<CommandResult> => {
+		try {
+			const updates: Partial<
+				Pick<
+					import("renderer/stores/agent-screens").AgentScreen,
+					"title" | "description" | "status"
+				>
+			> = {};
+			if (params.title !== undefined) updates.title = params.title;
+			if (params.description !== undefined)
+				updates.description = params.description;
+			if (params.status !== undefined)
+				updates.status =
+					params.status as import("renderer/stores/agent-screens").AgentScreen["status"];
+
+			agentScreenOperations.updateScreen(
+				ctx.agentScreens,
+				params.screenId,
+				updates,
+			);
+			return { success: true, data: { screenId: params.screenId } };
+		} catch (error) {
+			return {
+				success: false,
+				error:
+					error instanceof Error ? error.message : "Failed to update screen",
+			};
+		}
+	},
+};
+
+export const setScreenLayout: ToolDefinition<typeof setScreenLayoutSchema> = {
+	name: "set_screen_layout",
+	schema: setScreenLayoutSchema,
+	execute: async (params, ctx): Promise<CommandResult> => {
+		try {
+			agentScreenOperations.setScreenLayout(
+				ctx.agentScreens,
+				params.screenId,
+				params.layout,
+			);
+			return { success: true, data: { screenId: params.screenId } };
+		} catch (error) {
+			return {
+				success: false,
+				error: error instanceof Error ? error.message : "Failed to set layout",
+			};
+		}
+	},
+};
+
+export const deleteScreen: ToolDefinition<typeof deleteScreenSchema> = {
+	name: "delete_screen",
+	schema: deleteScreenSchema,
+	execute: async (params, ctx): Promise<CommandResult> => {
+		try {
+			agentScreenOperations.deleteScreen(
+				ctx.agentScreens,
+				ctx.agentNotifications,
+				params.screenId,
+			);
+			return { success: true, data: { deleted: true } };
+		} catch (error) {
+			return {
+				success: false,
+				error:
+					error instanceof Error ? error.message : "Failed to delete screen",
+			};
+		}
+	},
+};
+
+export const addBrowserPane: ToolDefinition<typeof addBrowserPaneSchema> = {
+	name: "add_browser_pane",
+	schema: addBrowserPaneSchema,
+	execute: async (params, ctx): Promise<CommandResult> => {
+		try {
+			agentScreenOperations.addBrowserPane(ctx.agentScreens, {
+				screenId: params.screenId,
+				paneId: params.paneId,
+				url: params.url,
+				title: params.title,
+			});
+			return { success: true, data: { paneId: params.paneId } };
+		} catch (error) {
+			return {
+				success: false,
+				error:
+					error instanceof Error ? error.message : "Failed to add browser pane",
+			};
+		}
+	},
+};
+
+export const navigateBrowser: ToolDefinition<typeof navigateBrowserSchema> = {
+	name: "navigate_browser",
+	schema: navigateBrowserSchema,
+	execute: async (params, ctx): Promise<CommandResult> => {
+		try {
+			agentScreenOperations.updatePane(
+				ctx.agentScreens,
+				params.screenId,
+				params.paneId,
+				{ url: params.url },
+			);
+			return { success: true, data: { url: params.url } };
+		} catch (error) {
+			return {
+				success: false,
+				error:
+					error instanceof Error ? error.message : "Failed to navigate browser",
+			};
+		}
+	},
+};
+
+export const addTerminalPane: ToolDefinition<typeof addTerminalPaneSchema> = {
+	name: "add_terminal_pane",
+	schema: addTerminalPaneSchema,
+	execute: async (params, ctx): Promise<CommandResult> => {
+		try {
+			agentScreenOperations.addTerminalPane(ctx.agentScreens, {
+				screenId: params.screenId,
+				paneId: params.paneId,
+			});
+			return { success: true, data: { paneId: params.paneId } };
+		} catch (error) {
+			return {
+				success: false,
+				error:
+					error instanceof Error
+						? error.message
+						: "Failed to add terminal pane",
+			};
+		}
+	},
+};
+
+export const writeTerminal: ToolDefinition<typeof writeTerminalSchema> = {
+	name: "write_terminal",
+	schema: writeTerminalSchema,
+	execute: async (params, ctx): Promise<CommandResult> => {
+		// Writing to terminal requires accessing the terminal manager via IPC
+		// The terminal pane component will handle data streaming via its subscription
+		// For now, we need to send via IPC to the terminal session
+		try {
+			const screen = ctx.agentScreens.get(params.screenId);
+			if (!screen) {
+				return { success: false, error: "Screen not found" };
+			}
+			const pane = screen.panes[params.paneId];
+			if (!pane || pane.type !== "terminal") {
+				return { success: false, error: "Terminal pane not found" };
+			}
+
+			// The session ID follows the pattern: screen-{screenId}-{paneId}
+			const sessionId =
+				pane.sessionId ?? `screen-${params.screenId}-${params.paneId}`;
+
+			// Send write command via IPC - this requires window.ipcRenderer
+			if (typeof window === "undefined" || !window.ipcRenderer) {
+				return { success: false, error: "IPC not available" };
+			}
+
+			await window.ipcRenderer.invoke("terminal:write", {
+				paneId: sessionId,
+				data: params.data,
+			});
+
+			return { success: true, data: { written: params.data.length } };
+		} catch (error) {
+			return {
+				success: false,
+				error:
+					error instanceof Error
+						? error.message
+						: "Failed to write to terminal",
+			};
+		}
+	},
+};
+
+export const addSummaryPane: ToolDefinition<typeof addSummaryPaneSchema> = {
+	name: "add_summary_pane",
+	schema: addSummaryPaneSchema,
+	execute: async (params, ctx): Promise<CommandResult> => {
+		try {
+			agentScreenOperations.addSummaryPane(ctx.agentScreens, {
+				screenId: params.screenId,
+				paneId: params.paneId,
+				content: params.content,
+				title: params.title,
+			});
+			return { success: true, data: { paneId: params.paneId } };
+		} catch (error) {
+			return {
+				success: false,
+				error:
+					error instanceof Error ? error.message : "Failed to add summary pane",
+			};
+		}
+	},
+};
+
+export const updateSummary: ToolDefinition<typeof updateSummarySchema> = {
+	name: "update_summary",
+	schema: updateSummarySchema,
+	execute: async (params, ctx): Promise<CommandResult> => {
+		try {
+			agentScreenOperations.updatePane(
+				ctx.agentScreens,
+				params.screenId,
+				params.paneId,
+				{
+					content: params.content,
+				},
+			);
+			return { success: true, data: { paneId: params.paneId } };
+		} catch (error) {
+			return {
+				success: false,
+				error:
+					error instanceof Error ? error.message : "Failed to update summary",
+			};
+		}
+	},
+};
+
+export const removePane: ToolDefinition<typeof removePaneSchema> = {
+	name: "remove_pane",
+	schema: removePaneSchema,
+	execute: async (params, ctx): Promise<CommandResult> => {
+		try {
+			agentScreenOperations.removePane(
+				ctx.agentScreens,
+				params.screenId,
+				params.paneId,
+			);
+			return { success: true, data: { removed: true } };
+		} catch (error) {
+			return {
+				success: false,
+				error: error instanceof Error ? error.message : "Failed to remove pane",
+			};
+		}
+	},
+};
+
+export const notifyUser: ToolDefinition<typeof notifyUserSchema> = {
+	name: "notify_user",
+	schema: notifyUserSchema,
+	execute: async (params, ctx): Promise<CommandResult> => {
+		try {
+			const notificationId = agentNotificationOperations.notifyUser(
+				ctx.agentScreens,
+				ctx.agentNotifications,
+				{
+					screenId: params.screenId,
+					organizationId: params.organizationId,
+					title: params.title,
+					body: params.body,
+					priority: params.priority,
+				},
+			);
+			if (notificationId === null) {
+				return { success: false, error: "Screen not found" };
+			}
+			return { success: true, data: { notificationId } };
+		} catch (error) {
+			return {
+				success: false,
+				error: error instanceof Error ? error.message : "Failed to notify user",
+			};
+		}
+	},
+};
+
+export const cancelNotification: ToolDefinition<
+	typeof cancelNotificationSchema
+> = {
+	name: "cancel_notification",
+	schema: cancelNotificationSchema,
+	execute: async (params, ctx): Promise<CommandResult> => {
+		try {
+			agentNotificationOperations.dismissNotification(
+				ctx.agentNotifications,
+				params.notificationId,
+			);
+			return { success: true, data: { dismissed: true } };
+		} catch (error) {
+			return {
+				success: false,
+				error:
+					error instanceof Error
+						? error.message
+						: "Failed to cancel notification",
+			};
+		}
+	},
+};
+
+// Export all tools as an array for registration
+export const agentScreenTools = [
+	createScreen,
+	updateScreen,
+	setScreenLayout,
+	deleteScreen,
+	addBrowserPane,
+	navigateBrowser,
+	addTerminalPane,
+	writeTerminal,
+	addSummaryPane,
+	updateSummary,
+	removePane,
+	notifyUser,
+	cancelNotification,
+];

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/index.ts
@@ -1,3 +1,4 @@
+import { agentScreenTools } from "./agent-screens";
 import { createWorkspace } from "./create-worktree";
 import { deleteWorkspace } from "./delete-workspace";
 import { getAppContext } from "./get-app-context";
@@ -17,6 +18,7 @@ const tools: ToolDefinition<any>[] = [
 	listWorkspaces,
 	navigateToWorkspace,
 	switchWorkspace,
+	...agentScreenTools,
 ];
 
 // Map for O(1) lookup by name

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/types.ts
@@ -1,5 +1,10 @@
 import type { SelectProject, SelectWorkspace } from "@superset/local-db";
+import type { Collection } from "@tanstack/react-db";
 import type { electronTrpc } from "renderer/lib/electron-trpc";
+import type {
+	AgentNotification,
+	AgentScreen,
+} from "renderer/stores/agent-screens";
 import type { z } from "zod";
 
 export interface CommandResult {
@@ -23,6 +28,9 @@ export interface ToolContext {
 	getActiveWorkspaceId: () => string | null;
 	// Navigation
 	navigateToWorkspace: (workspaceId: string) => Promise<void>;
+	// Agent screen collections
+	agentScreens: Collection<AgentScreen>;
+	agentNotifications: Collection<AgentNotification>;
 }
 
 // Tool definition with schema and execute function

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/useCommandWatcher.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/useCommandWatcher.ts
@@ -50,6 +50,8 @@ export function useCommandWatcher() {
 			getActiveWorkspaceId: getCurrentWorkspaceIdFromRoute,
 			navigateToWorkspace: (workspaceId: string) =>
 				navigateToWorkspace(workspaceId, navigate),
+			agentScreens: collections.agentScreens,
+			agentNotifications: collections.agentNotifications,
 		}),
 		[
 			createWorktree,
@@ -60,6 +62,8 @@ export function useCommandWatcher() {
 			projects,
 			getCurrentWorkspaceIdFromRoute,
 			navigate,
+			collections.agentScreens,
+			collections.agentNotifications,
 		],
 	);
 

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
@@ -11,12 +11,17 @@ import type {
 	SelectUser,
 } from "@superset/db/schema";
 import type { AppRouter } from "@superset/trpc";
+import { localStorageCollectionOptions } from "@tanstack/db";
 import { electricCollectionOptions } from "@tanstack/electric-db-collection";
 import type { Collection } from "@tanstack/react-db";
 import { createCollection } from "@tanstack/react-db";
 import { createTRPCProxyClient, httpBatchLink } from "@trpc/client";
 import { env } from "renderer/env.renderer";
 import { getAuthToken } from "renderer/lib/auth-client";
+import type {
+	AgentNotification,
+	AgentScreen,
+} from "renderer/stores/agent-screens/types";
 import superjson from "superjson";
 
 const columnMapper = snakeCamelMapper();
@@ -31,6 +36,9 @@ interface OrgCollections {
 	invitations: Collection<SelectInvitation>;
 	agentCommands: Collection<SelectAgentCommand>;
 	devicePresence: Collection<SelectDevicePresence>;
+	// Local-only collections (persisted to localStorage, not synced to backend)
+	agentScreens: Collection<AgentScreen>;
+	agentNotifications: Collection<AgentNotification>;
 }
 
 // Per-org collections cache
@@ -248,6 +256,21 @@ function createOrgCollections(organizationId: string): OrgCollections {
 		}),
 	);
 
+	// Local-only collections (persisted to localStorage, not synced to backend)
+	const agentScreens = createCollection(
+		localStorageCollectionOptions<AgentScreen>({
+			storageKey: `agent-screens-${organizationId}`,
+			getKey: (item) => item.id,
+		}),
+	);
+
+	const agentNotifications = createCollection(
+		localStorageCollectionOptions<AgentNotification>({
+			storageKey: `agent-notifications-${organizationId}`,
+			getKey: (item) => item.id,
+		}),
+	);
+
 	return {
 		tasks,
 		taskStatuses,
@@ -257,6 +280,8 @@ function createOrgCollections(organizationId: string): OrgCollections {
 		invitations,
 		agentCommands,
 		devicePresence,
+		agentScreens,
+		agentNotifications,
 	};
 }
 

--- a/apps/desktop/src/renderer/screens/main/components/NotificationSidebar/NotificationSidebar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/NotificationSidebar/NotificationSidebar.tsx
@@ -1,0 +1,77 @@
+import { Button } from "@superset/ui/button";
+import { eq, not } from "@tanstack/db";
+import { useLiveQuery } from "@tanstack/react-db";
+import { HiXMark } from "react-icons/hi2";
+import { env } from "renderer/env.renderer";
+import { authClient } from "renderer/lib/auth-client";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider/CollectionsProvider";
+import { useNotificationSidebarStore } from "renderer/stores/notification-sidebar-state";
+import { MOCK_ORG_ID } from "shared/constants";
+import { NotificationList } from "./components/NotificationList";
+
+export function NotificationSidebar() {
+	const { data: session } = authClient.useSession();
+	const organizationId = env.SKIP_ENV_VALIDATION
+		? MOCK_ORG_ID
+		: session?.session?.activeOrganizationId;
+
+	const { isOpen, width, setOpen } = useNotificationSidebarStore();
+	const collections = useCollections();
+
+	const { data: notifications } = useLiveQuery(
+		(q) =>
+			q
+				.from({ notifications: collections.agentNotifications })
+				.where(({ notifications }) =>
+					not(eq(notifications.status, "dismissed")),
+				)
+				.select(({ notifications }) => ({ ...notifications })),
+		[collections.agentNotifications],
+	);
+
+	// Sort by createdAt descending
+	const sortedNotifications = [...(notifications ?? [])].sort(
+		(a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+	);
+
+	if (!isOpen || !organizationId) {
+		return null;
+	}
+
+	return (
+		<div
+			className="h-full border-l border-border bg-background flex flex-col shrink-0"
+			style={{ width }}
+		>
+			{/* Header */}
+			<div className="h-12 px-4 flex items-center justify-between border-b border-border shrink-0">
+				<h2 className="text-sm font-medium text-foreground">Notifications</h2>
+				<Button
+					variant="ghost"
+					size="icon"
+					className="h-7 w-7"
+					onClick={() => setOpen(false)}
+					title="Close notifications"
+				>
+					<HiXMark className="w-4 h-4" />
+				</Button>
+			</div>
+
+			{/* Notification list */}
+			<div className="flex-1 overflow-auto">
+				{sortedNotifications.length === 0 ? (
+					<div className="p-4 text-center">
+						<p className="text-sm text-muted-foreground">
+							No notifications yet
+						</p>
+						<p className="text-xs text-muted-foreground/70 mt-1">
+							Agent screens will appear here
+						</p>
+					</div>
+				) : (
+					<NotificationList notifications={sortedNotifications} />
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/NotificationSidebar/components/NotificationCard/NotificationCard.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/NotificationSidebar/components/NotificationCard/NotificationCard.tsx
@@ -1,0 +1,109 @@
+import { Button } from "@superset/ui/button";
+import { useNavigate } from "@tanstack/react-router";
+import { formatDistanceToNow } from "date-fns";
+import { useCallback } from "react";
+import { HiExclamationCircle, HiOutlineBell, HiXMark } from "react-icons/hi2";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider/CollectionsProvider";
+import {
+	type AgentNotification,
+	agentNotificationOperations,
+} from "renderer/stores/agent-screens";
+import { useNotificationSidebarStore } from "renderer/stores/notification-sidebar-state";
+
+interface NotificationCardProps {
+	notification: AgentNotification;
+}
+
+export function NotificationCard({ notification }: NotificationCardProps) {
+	const navigate = useNavigate();
+	const collections = useCollections();
+	const setOpen = useNotificationSidebarStore((s) => s.setOpen);
+
+	const handleClick = useCallback(() => {
+		agentNotificationOperations.markNotificationViewed(
+			collections.agentNotifications,
+			notification.id,
+		);
+		setOpen(false);
+		navigate({ to: `/screen/${notification.screenId}` });
+	}, [
+		notification.id,
+		notification.screenId,
+		collections.agentNotifications,
+		setOpen,
+		navigate,
+	]);
+
+	const handleDismiss = useCallback(
+		(e: React.MouseEvent) => {
+			e.stopPropagation();
+			agentNotificationOperations.dismissNotification(
+				collections.agentNotifications,
+				notification.id,
+			);
+		},
+		[notification.id, collections.agentNotifications],
+	);
+
+	const getPriorityIcon = () => {
+		switch (notification.priority) {
+			case "urgent":
+				return <HiExclamationCircle className="w-4 h-4 text-destructive" />;
+			case "high":
+				return <HiExclamationCircle className="w-4 h-4 text-warning" />;
+			default:
+				return <HiOutlineBell className="w-4 h-4 text-muted-foreground" />;
+		}
+	};
+
+	const isNew = notification.status === "pending";
+	const timeAgo = formatDistanceToNow(new Date(notification.createdAt), {
+		addSuffix: true,
+	});
+
+	return (
+		<button
+			type="button"
+			onClick={handleClick}
+			className={`
+				relative p-3 rounded-lg cursor-pointer transition-colors text-left w-full
+				${isNew ? "bg-primary/5 hover:bg-primary/10" : "bg-muted/30 hover:bg-muted/50"}
+				border ${isNew ? "border-primary/20" : "border-border/50"}
+			`}
+		>
+			{/* Dismiss button */}
+			<Button
+				variant="ghost"
+				size="icon"
+				className="absolute top-1 right-1 h-6 w-6 opacity-0 group-hover:opacity-100 hover:opacity-100"
+				onClick={handleDismiss}
+				title="Dismiss"
+			>
+				<HiXMark className="w-3 h-3" />
+			</Button>
+
+			{/* Content */}
+			<div className="flex items-start gap-2">
+				<div className="shrink-0 mt-0.5">{getPriorityIcon()}</div>
+				<div className="flex-1 min-w-0">
+					<div className="flex items-center gap-2">
+						<h3
+							className={`text-sm font-medium truncate ${isNew ? "text-foreground" : "text-foreground/80"}`}
+						>
+							{notification.title}
+						</h3>
+						{isNew && (
+							<span className="shrink-0 w-2 h-2 rounded-full bg-primary" />
+						)}
+					</div>
+					{notification.body && (
+						<p className="text-xs text-muted-foreground mt-1 line-clamp-2">
+							{notification.body}
+						</p>
+					)}
+					<p className="text-xs text-muted-foreground/70 mt-2">{timeAgo}</p>
+				</div>
+			</div>
+		</button>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/NotificationSidebar/components/NotificationCard/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/NotificationSidebar/components/NotificationCard/index.ts
@@ -1,0 +1,1 @@
+export { NotificationCard } from "./NotificationCard";

--- a/apps/desktop/src/renderer/screens/main/components/NotificationSidebar/components/NotificationList/NotificationList.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/NotificationSidebar/components/NotificationList/NotificationList.tsx
@@ -1,0 +1,48 @@
+import type { AgentNotification } from "renderer/stores/agent-screens";
+import { NotificationCard } from "../NotificationCard";
+
+interface NotificationListProps {
+	notifications: AgentNotification[];
+}
+
+export function NotificationList({ notifications }: NotificationListProps) {
+	// Group notifications by status
+	const pendingNotifications = notifications.filter(
+		(n) => n.status === "pending",
+	);
+	const viewedNotifications = notifications.filter(
+		(n) => n.status === "viewed",
+	);
+
+	return (
+		<div className="flex flex-col">
+			{/* Pending notifications */}
+			{pendingNotifications.length > 0 && (
+				<div className="p-2 space-y-2">
+					<p className="text-xs font-medium text-muted-foreground px-2">New</p>
+					{pendingNotifications.map((notification) => (
+						<NotificationCard
+							key={notification.id}
+							notification={notification}
+						/>
+					))}
+				</div>
+			)}
+
+			{/* Viewed notifications */}
+			{viewedNotifications.length > 0 && (
+				<div className="p-2 space-y-2">
+					<p className="text-xs font-medium text-muted-foreground px-2">
+						Earlier
+					</p>
+					{viewedNotifications.map((notification) => (
+						<NotificationCard
+							key={notification.id}
+							notification={notification}
+						/>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/NotificationSidebar/components/NotificationList/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/NotificationSidebar/components/NotificationList/index.ts
@@ -1,0 +1,1 @@
+export { NotificationList } from "./NotificationList";

--- a/apps/desktop/src/renderer/screens/main/components/NotificationSidebar/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/NotificationSidebar/index.ts
@@ -1,0 +1,1 @@
+export { NotificationSidebar } from "./NotificationSidebar";

--- a/apps/desktop/src/renderer/screens/main/components/TopBar/NotificationBadge/NotificationBadge.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/TopBar/NotificationBadge/NotificationBadge.tsx
@@ -1,0 +1,52 @@
+import { Button } from "@superset/ui/button";
+import { eq } from "@tanstack/db";
+import { useLiveQuery } from "@tanstack/react-db";
+import { HiOutlineBell } from "react-icons/hi2";
+import { env } from "renderer/env.renderer";
+import { authClient } from "renderer/lib/auth-client";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider/CollectionsProvider";
+import { useNotificationSidebarStore } from "renderer/stores/notification-sidebar-state";
+import { MOCK_ORG_ID } from "shared/constants";
+
+export function NotificationBadge() {
+	const { data: session } = authClient.useSession();
+	const organizationId = env.SKIP_ENV_VALIDATION
+		? MOCK_ORG_ID
+		: session?.session?.activeOrganizationId;
+
+	const toggleOpen = useNotificationSidebarStore((s) => s.toggleOpen);
+	const isOpen = useNotificationSidebarStore((s) => s.isOpen);
+	const collections = useCollections();
+
+	const { data: pendingNotifications } = useLiveQuery(
+		(q) =>
+			q
+				.from({ notifications: collections.agentNotifications })
+				.where(({ notifications }) => eq(notifications.status, "pending"))
+				.select(({ notifications }) => ({ id: notifications.id })),
+		[collections.agentNotifications],
+	);
+
+	const pendingCount = pendingNotifications?.length ?? 0;
+
+	if (!organizationId) {
+		return null;
+	}
+
+	return (
+		<Button
+			variant="ghost"
+			size="icon"
+			className="relative h-8 w-8 no-drag"
+			onClick={toggleOpen}
+			title={isOpen ? "Hide notifications" : "Show notifications"}
+		>
+			<HiOutlineBell className="w-4 h-4" />
+			{pendingCount > 0 && (
+				<span className="absolute -top-0.5 -right-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-medium text-primary-foreground">
+					{pendingCount > 99 ? "99+" : pendingCount}
+				</span>
+			)}
+		</Button>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/TopBar/NotificationBadge/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/TopBar/NotificationBadge/index.ts
@@ -1,0 +1,1 @@
+export { NotificationBadge } from "./NotificationBadge";

--- a/apps/desktop/src/renderer/screens/main/components/TopBar/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/TopBar/index.tsx
@@ -1,5 +1,6 @@
 import { useParams } from "@tanstack/react-router";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { NotificationBadge } from "./NotificationBadge";
 import { OpenInMenuButton } from "./OpenInMenuButton";
 import { OrganizationDropdown } from "./OrganizationDropdown";
 import { WindowControls } from "./WindowControls";
@@ -32,6 +33,7 @@ export function TopBar() {
 						branch={workspace.worktree?.branch}
 					/>
 				)}
+				<NotificationBadge />
 				<OrganizationDropdown />
 				{!isMac && <WindowControls />}
 			</div>

--- a/apps/desktop/src/renderer/stores/agent-screens/index.ts
+++ b/apps/desktop/src/renderer/stores/agent-screens/index.ts
@@ -1,0 +1,17 @@
+export {
+	agentNotificationOperations,
+	agentScreenOperations,
+} from "./store";
+export type {
+	AddBrowserPaneParams,
+	AddSummaryPaneParams,
+	AddTerminalPaneParams,
+	AgentNotification,
+	AgentPane,
+	AgentScreen,
+	BrowserPane,
+	CreateScreenParams,
+	NotifyUserParams,
+	SummaryPane,
+	TerminalPane,
+} from "./types";

--- a/apps/desktop/src/renderer/stores/agent-screens/store.ts
+++ b/apps/desktop/src/renderer/stores/agent-screens/store.ts
@@ -1,0 +1,317 @@
+import type { Collection } from "@tanstack/react-db";
+import type { MosaicNode } from "react-mosaic-component";
+import type {
+	AddBrowserPaneParams,
+	AddSummaryPaneParams,
+	AddTerminalPaneParams,
+	AgentNotification,
+	AgentScreen,
+	CreateScreenParams,
+	NotifyUserParams,
+} from "./types";
+
+function generateId(): string {
+	return `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+}
+
+/**
+ * Recursively removes a pane ID from a MosaicNode layout tree.
+ * Returns the new layout, or null if the entire tree should be removed.
+ */
+function removePaneFromLayout(
+	layout: MosaicNode<string> | null,
+	paneId: string,
+): MosaicNode<string> | null {
+	if (layout === null) {
+		return null;
+	}
+
+	// If it's a leaf node (string), check if it matches
+	if (typeof layout === "string") {
+		return layout === paneId ? null : layout;
+	}
+
+	// It's a branch node with first/second
+	const newFirst = removePaneFromLayout(layout.first, paneId);
+	const newSecond = removePaneFromLayout(layout.second, paneId);
+
+	// If both children are gone, return null
+	if (newFirst === null && newSecond === null) {
+		return null;
+	}
+
+	// If one child is gone, return the other (collapse the branch)
+	if (newFirst === null) {
+		return newSecond;
+	}
+	if (newSecond === null) {
+		return newFirst;
+	}
+
+	// Both children still exist, return updated branch
+	return {
+		...layout,
+		first: newFirst,
+		second: newSecond,
+	};
+}
+
+/**
+ * Helper functions for agent screen operations using TanStack DB collections.
+ * These functions work with the collections from CollectionsProvider.
+ */
+export const agentScreenOperations = {
+	createScreen: (
+		collection: Collection<AgentScreen>,
+		params: CreateScreenParams,
+	): string => {
+		const id = generateId();
+		const screen: AgentScreen = {
+			id,
+			workspaceId: params.workspaceId,
+			organizationId: params.organizationId,
+			title: params.title,
+			description: params.description,
+			layout: null,
+			panes: {},
+			createdAt: new Date().toISOString(),
+			status: "composing",
+		};
+		collection.insert(screen);
+		return id;
+	},
+
+	updateScreen: (
+		collection: Collection<AgentScreen>,
+		screenId: string,
+		updates: Partial<Pick<AgentScreen, "title" | "description" | "status">>,
+	): void => {
+		const screen = collection.get(screenId);
+		if (!screen) {
+			console.warn(`[agent-screens] Screen not found: ${screenId}`);
+			return;
+		}
+		collection.update(screenId, (draft) => {
+			if (updates.title !== undefined) draft.title = updates.title;
+			if (updates.description !== undefined)
+				draft.description = updates.description;
+			if (updates.status !== undefined) draft.status = updates.status;
+		});
+	},
+
+	setScreenLayout: (
+		collection: Collection<AgentScreen>,
+		screenId: string,
+		layout: MosaicNode<string>,
+	): void => {
+		const screen = collection.get(screenId);
+		if (!screen) {
+			console.warn(`[agent-screens] Screen not found: ${screenId}`);
+			return;
+		}
+		collection.update(screenId, (draft) => {
+			draft.layout = layout;
+		});
+	},
+
+	deleteScreen: (
+		screensCollection: Collection<AgentScreen>,
+		notificationsCollection: Collection<AgentNotification>,
+		screenId: string,
+	): void => {
+		// Collect notification IDs first to avoid mutating while iterating
+		const notificationIdsToDelete: string[] = [];
+		for (const [id, notification] of notificationsCollection.entries()) {
+			if (notification.screenId === screenId) {
+				notificationIdsToDelete.push(String(id));
+			}
+		}
+		// Delete notifications
+		for (const id of notificationIdsToDelete) {
+			notificationsCollection.delete(id);
+		}
+		// Delete screen
+		screensCollection.delete(screenId);
+	},
+
+	addBrowserPane: (
+		collection: Collection<AgentScreen>,
+		params: AddBrowserPaneParams,
+	): void => {
+		const screen = collection.get(params.screenId);
+		if (!screen) {
+			console.warn(`[agent-screens] Screen not found: ${params.screenId}`);
+			return;
+		}
+		collection.update(params.screenId, (draft) => {
+			draft.panes[params.paneId] = {
+				type: "browser",
+				id: params.paneId,
+				url: params.url,
+				title: params.title,
+			};
+		});
+	},
+
+	addTerminalPane: (
+		collection: Collection<AgentScreen>,
+		params: AddTerminalPaneParams,
+	): void => {
+		const screen = collection.get(params.screenId);
+		if (!screen) {
+			console.warn(`[agent-screens] Screen not found: ${params.screenId}`);
+			return;
+		}
+		collection.update(params.screenId, (draft) => {
+			draft.panes[params.paneId] = {
+				type: "terminal",
+				id: params.paneId,
+				sessionId: params.sessionId,
+			};
+		});
+	},
+
+	addSummaryPane: (
+		collection: Collection<AgentScreen>,
+		params: AddSummaryPaneParams,
+	): void => {
+		const screen = collection.get(params.screenId);
+		if (!screen) {
+			console.warn(`[agent-screens] Screen not found: ${params.screenId}`);
+			return;
+		}
+		collection.update(params.screenId, (draft) => {
+			draft.panes[params.paneId] = {
+				type: "summary",
+				id: params.paneId,
+				content: params.content,
+				title: params.title,
+			};
+		});
+	},
+
+	/**
+	 * Updates a pane with type-safe property updates.
+	 * Only properties valid for the pane's type are applied.
+	 */
+	updatePane: (
+		collection: Collection<AgentScreen>,
+		screenId: string,
+		paneId: string,
+		updates: {
+			url?: string;
+			title?: string;
+			content?: string;
+			sessionId?: string;
+		},
+	): void => {
+		const screen = collection.get(screenId);
+		if (!screen) {
+			console.warn(`[agent-screens] Screen not found: ${screenId}`);
+			return;
+		}
+		const pane = screen.panes[paneId];
+		if (!pane) {
+			console.warn(`[agent-screens] Pane not found: ${paneId}`);
+			return;
+		}
+		collection.update(screenId, (draft) => {
+			const draftPane = draft.panes[paneId];
+			if (!draftPane) return;
+
+			// Type-safe updates based on pane type
+			switch (draftPane.type) {
+				case "browser":
+					if (updates.url !== undefined) draftPane.url = updates.url;
+					if (updates.title !== undefined) draftPane.title = updates.title;
+					break;
+				case "terminal":
+					if (updates.sessionId !== undefined)
+						draftPane.sessionId = updates.sessionId;
+					break;
+				case "summary":
+					if (updates.content !== undefined)
+						draftPane.content = updates.content;
+					if (updates.title !== undefined) draftPane.title = updates.title;
+					break;
+			}
+		});
+	},
+
+	removePane: (
+		collection: Collection<AgentScreen>,
+		screenId: string,
+		paneId: string,
+	): void => {
+		const screen = collection.get(screenId);
+		if (!screen) {
+			console.warn(`[agent-screens] Screen not found: ${screenId}`);
+			return;
+		}
+		collection.update(screenId, (draft) => {
+			delete draft.panes[paneId];
+			// Remove pane from nested layout tree
+			draft.layout = removePaneFromLayout(draft.layout, paneId);
+		});
+	},
+};
+
+export const agentNotificationOperations = {
+	/**
+	 * Creates a notification for a screen and marks the screen as ready.
+	 * Returns the notification ID, or null if the screen doesn't exist.
+	 */
+	notifyUser: (
+		screensCollection: Collection<AgentScreen>,
+		notificationsCollection: Collection<AgentNotification>,
+		params: NotifyUserParams,
+	): string | null => {
+		// Validate screen exists to prevent orphan notifications
+		const screen = screensCollection.get(params.screenId);
+		if (!screen) {
+			console.warn(
+				`[agent-screens] Cannot notify: screen not found: ${params.screenId}`,
+			);
+			return null;
+		}
+
+		const id = generateId();
+		const notification: AgentNotification = {
+			id,
+			screenId: params.screenId,
+			organizationId: params.organizationId,
+			title: params.title,
+			body: params.body,
+			priority: params.priority ?? "normal",
+			status: "pending",
+			createdAt: new Date().toISOString(),
+		};
+		notificationsCollection.insert(notification);
+
+		// Mark screen as ready when notifying
+		if (screen.status === "composing") {
+			screensCollection.update(params.screenId, (draft) => {
+				draft.status = "ready";
+			});
+		}
+		return id;
+	},
+
+	markNotificationViewed: (
+		collection: Collection<AgentNotification>,
+		notificationId: string,
+	): void => {
+		collection.update(notificationId, (draft) => {
+			draft.status = "viewed";
+		});
+	},
+
+	dismissNotification: (
+		collection: Collection<AgentNotification>,
+		notificationId: string,
+	): void => {
+		collection.update(notificationId, (draft) => {
+			draft.status = "dismissed";
+		});
+	},
+};

--- a/apps/desktop/src/renderer/stores/agent-screens/types.ts
+++ b/apps/desktop/src/renderer/stores/agent-screens/types.ts
@@ -1,0 +1,90 @@
+import type { MosaicNode } from "react-mosaic-component";
+
+// Screen - workspace-bound, contains panes
+export interface AgentScreen {
+	id: string;
+	workspaceId: string; // Tied to a workspace for terminal cwd/env
+	organizationId: string;
+	title: string;
+	description?: string;
+	layout: MosaicNode<string> | null; // Same as existing Tab.layout
+	panes: Record<string, AgentPane>;
+	createdAt: string;
+	status: "composing" | "ready" | "viewed" | "dismissed";
+}
+
+// Pane types - extensible for future agent interactions
+export type AgentPane = BrowserPane | TerminalPane | SummaryPane;
+
+export interface BrowserPane {
+	type: "browser";
+	id: string;
+	url: string;
+	title?: string;
+	// Future: canNavigate, canClick, canScroll, domSnapshot
+}
+
+export interface TerminalPane {
+	type: "terminal";
+	id: string;
+	sessionId?: string; // Links to daemon terminal session
+	// Future: canWrite, canResize, processInfo
+}
+
+export interface SummaryPane {
+	type: "summary";
+	id: string;
+	content: string; // Markdown
+	title?: string;
+	// Future: canEdit, liveUpdate
+}
+
+// Notification card
+export interface AgentNotification {
+	id: string;
+	screenId: string;
+	organizationId: string;
+	title: string;
+	body?: string;
+	priority: "normal" | "high" | "urgent";
+	status: "pending" | "viewed" | "dismissed";
+	createdAt: string;
+}
+
+// Create screen params
+export interface CreateScreenParams {
+	workspaceId: string;
+	organizationId: string;
+	title: string;
+	description?: string;
+}
+
+// Add pane params
+export interface AddBrowserPaneParams {
+	screenId: string;
+	paneId: string;
+	url: string;
+	title?: string;
+}
+
+export interface AddTerminalPaneParams {
+	screenId: string;
+	paneId: string;
+	sessionId?: string;
+}
+
+export interface AddSummaryPaneParams {
+	screenId: string;
+	paneId: string;
+	content: string;
+	title?: string;
+}
+
+// Notify user params
+export interface NotifyUserParams {
+	screenId: string;
+	organizationId: string;
+	title: string;
+	body?: string;
+	priority?: "normal" | "high" | "urgent";
+}

--- a/apps/desktop/src/renderer/stores/notification-sidebar-state.ts
+++ b/apps/desktop/src/renderer/stores/notification-sidebar-state.ts
@@ -1,0 +1,60 @@
+import { create } from "zustand";
+import { devtools, persist } from "zustand/middleware";
+
+const DEFAULT_NOTIFICATION_SIDEBAR_WIDTH = 320;
+const MIN_NOTIFICATION_SIDEBAR_WIDTH = 280;
+const MAX_NOTIFICATION_SIDEBAR_WIDTH = 480;
+
+interface NotificationSidebarState {
+	isOpen: boolean;
+	width: number;
+	isResizing: boolean;
+
+	toggleOpen: () => void;
+	setOpen: (open: boolean) => void;
+	setWidth: (width: number) => void;
+	setIsResizing: (isResizing: boolean) => void;
+}
+
+export const useNotificationSidebarStore = create<NotificationSidebarState>()(
+	devtools(
+		persist(
+			(set) => ({
+				isOpen: false,
+				width: DEFAULT_NOTIFICATION_SIDEBAR_WIDTH,
+				isResizing: false,
+
+				toggleOpen: () => {
+					set((state) => ({ isOpen: !state.isOpen }));
+				},
+
+				setOpen: (open) => {
+					set({ isOpen: open });
+				},
+
+				setWidth: (width) => {
+					const clampedWidth = Math.max(
+						MIN_NOTIFICATION_SIDEBAR_WIDTH,
+						Math.min(MAX_NOTIFICATION_SIDEBAR_WIDTH, width),
+					);
+					set({ width: clampedWidth });
+				},
+
+				setIsResizing: (isResizing) => {
+					set({ isResizing });
+				},
+			}),
+			{
+				name: "notification-sidebar-store",
+				version: 1,
+				partialize: (state) => ({
+					isOpen: state.isOpen,
+					width: state.width,
+				}),
+			},
+		),
+		{ name: "NotificationSidebarStore" },
+	),
+);
+
+export { MAX_NOTIFICATION_SIDEBAR_WIDTH, MIN_NOTIFICATION_SIDEBAR_WIDTH };

--- a/apps/desktop/src/shared/hotkeys.ts
+++ b/apps/desktop/src/shared/hotkeys.ts
@@ -436,6 +436,12 @@ export const HOTKEYS = {
 		label: "Toggle Workspaces Sidebar",
 		category: "Layout",
 	}),
+	TOGGLE_NOTIFICATION_SIDEBAR: defineHotkey({
+		keys: "meta+shift+b",
+		label: "Toggle Notifications",
+		category: "Layout",
+		description: "Show or hide the notification sidebar",
+	}),
 	SPLIT_RIGHT: defineHotkey({
 		keys: "meta+d",
 		label: "Split Right",


### PR DESCRIPTION
## Summary
- Adds agent screen composition system with Browser, Terminal, and Summary pane types rendered via react-mosaic layout
- Notification sidebar with badge, cards, and auto-mark-as-viewed on screen navigation
- 13 MCP tools for agents to create/manage screens, panes, and notifications
- Uses TanStack DB local storage collections (not Zustand) for persistence, scoped per organization
- Includes validation (screen existence checks, safe iteration, type-safe pane updates, recursive layout removal)

## Test plan
- [ ] Verify agent screen creation via MCP tools
- [ ] Verify notification badge shows pending count
- [ ] Verify clicking notification navigates to screen and marks as viewed
- [ ] Verify pane removal properly collapses mosaic layout
- [ ] Verify data persists across page refreshes via localStorage
- [ ] Verify organization scoping isolates data between orgs