### PR TITLE
Remove internal timestamps from MCP API responses

### DIFF
--- a/packages/mcp/src/tools/tasks/get-task/get-task.ts
+++ b/packages/mcp/src/tools/tasks/get-task/get-task.ts
@@ -35,8 +35,6 @@ export function register(server: McpServer) {
 					estimate: z.number().nullable(),
 					branch: z.string().nullable(),
 					prUrl: z.string().nullable(),
-					createdAt: z.string(),
-					updatedAt: z.string(),
 				}),
 			},
 		},
@@ -70,8 +68,6 @@ export function register(server: McpServer) {
 					estimate: tasks.estimate,
 					branch: tasks.branch,
 					prUrl: tasks.prUrl,
-					createdAt: tasks.createdAt,
-					updatedAt: tasks.updatedAt,
 				})
 				.from(tasks)
 				.leftJoin(assignee, eq(tasks.assigneeId, assignee.id))
@@ -96,8 +92,6 @@ export function register(server: McpServer) {
 			const serializedTask = {
 				...task,
 				dueDate: task.dueDate?.toISOString() ?? null,
-				createdAt: task.createdAt.toISOString(),
-				updatedAt: task.updatedAt.toISOString(),
 			};
 			return {
 				structuredContent: { task: serializedTask },

--- a/packages/mcp/src/tools/tasks/list-tasks/list-tasks.ts
+++ b/packages/mcp/src/tools/tasks/list-tasks/list-tasks.ts
@@ -75,7 +75,6 @@ export function register(server: McpServer) {
 						labels: z.array(z.string()),
 						dueDate: z.string().nullable(),
 						estimate: z.number().nullable(),
-						createdAt: z.string(),
 						deletedAt: z.string().nullable(),
 					}),
 				),
@@ -195,7 +194,6 @@ export function register(server: McpServer) {
 					labels: tasks.labels,
 					dueDate: tasks.dueDate,
 					estimate: tasks.estimate,
-					createdAt: tasks.createdAt,
 					deletedAt: tasks.deletedAt,
 				})
 				.from(tasks)
@@ -211,7 +209,6 @@ export function register(server: McpServer) {
 				tasks: tasksList.map((t) => ({
 					...t,
 					dueDate: t.dueDate?.toISOString() ?? null,
-					createdAt: t.createdAt.toISOString(),
 					deletedAt: t.deletedAt?.toISOString() ?? null,
 				})),
 				count: tasksList.length,


### PR DESCRIPTION
## Summary
- Remove `createdAt` from `list_tasks` MCP tool output schema, DB select, and serialization
- Remove `createdAt` and `updatedAt` from `get_task` MCP tool output schema, DB select, and serialization
- Internal sorting by `createdAt` in `list_tasks` is preserved (not exposed in response)

## Test plan
- [x] TypeScript typecheck passes (`bun run typecheck --filter=@superset/mcp`)
- [x] Biome lint passes on both modified files
- [ ] Verify `list_tasks` and `get_task` MCP tool responses no longer include timestamp fields