### PR TITLE
fix(mcp): don't navigate to workspace in start_claude_session

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/start-claude-session.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/start-claude-session.ts
@@ -53,9 +53,6 @@ async function execute(
 			defaultPreset: pending?.defaultPreset ?? null,
 		});
 
-		// 4. Navigate
-		await ctx.navigateToWorkspace(result.workspace.id);
-
 		return {
 			success: true,
 			data: {


### PR DESCRIPTION
## Summary

- Remove the automatic `navigateToWorkspace` call from the `start_claude_session` desktop tool handler
- `create_workspace` already didn't navigate — `useCreateWorkspace({ skipNavigation: true })` handles that
- `start_claude_session` was the only MCP workspace-creation path that explicitly navigated
- Agents can use `navigate_to_workspace` separately if needed

## Test plan

- [ ] `start_claude_session` via MCP — workspace is created but active view does not switch
- [ ] `create_workspace` via MCP — still works as before (no navigation)
- [ ] Desktop UI workspace creation — still navigates to new workspace