### PR TITLE
Fix scripts package typecheck after script deletion

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -4,13 +4,6 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"clean": "git clean -xdf .cache .turbo dist node_modules",
-		"typecheck": "tsc --noEmit --emitDeclarationOnly false"
-	},
-	"dependencies": {},
-	"devDependencies": {
-		"@superset/typescript": "workspace:*",
-		"@types/node": "^24.9.1",
-		"typescript": "^5.9.3"
+		"clean": "git clean -xdf .cache .turbo dist node_modules"
 	}
 }


### PR DESCRIPTION
## Summary
- Removes the `typecheck` script and unused devDependencies from `packages/scripts` since all source files were deleted in #1095
- Without this, `tsc --noEmit` fails with "No inputs were found" because `src/` is empty

## Test plan
- [x] `bun run lint` — clean
- [x] `bun test` — 1195 pass, 0 fail
- [x] `bun run typecheck` — 16/16 successful