### PR TITLE
feat(desktop): add Cmd+F shortcut to focus search in Tasks view

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/TasksTopBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/TasksTopBar.tsx
@@ -1,6 +1,8 @@
 import { Input } from "@superset/ui/input";
 import { Tabs, TabsList, TabsTrigger } from "@superset/ui/tabs";
+import { useRef } from "react";
 import { HiOutlineMagnifyingGlass } from "react-icons/hi2";
+import { useAppHotkey } from "renderer/stores/hotkeys";
 import { ActiveIcon } from "../shared/icons/ActiveIcon";
 import { AllIssuesIcon } from "../shared/icons/AllIssuesIcon";
 import { BacklogIcon } from "../shared/icons/BacklogIcon";
@@ -43,6 +45,17 @@ export function TasksTopBar({
 	assigneeFilter,
 	onAssigneeFilterChange,
 }: TasksTopBarProps) {
+	const searchInputRef = useRef<HTMLInputElement>(null);
+
+	useAppHotkey(
+		"FOCUS_TASK_SEARCH",
+		() => {
+			searchInputRef.current?.focus();
+			searchInputRef.current?.select();
+		},
+		{ preventDefault: true },
+	);
+
 	return (
 		<div className="flex items-center justify-between border-b border-border px-4 h-11">
 			{/* Tabs and filters on the left */}
@@ -80,10 +93,17 @@ export function TasksTopBar({
 			<div className="relative w-64">
 				<HiOutlineMagnifyingGlass className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
 				<Input
+					ref={searchInputRef}
 					type="text"
 					placeholder="Search tasks..."
 					value={searchQuery}
 					onChange={(e) => onSearchChange(e.target.value)}
+					onKeyDown={(e) => {
+						if (e.key === "Escape") {
+							onSearchChange("");
+							searchInputRef.current?.blur();
+						}
+					}}
 					className="h-8 pl-9 pr-3 text-sm bg-muted/50 border-0 focus-visible:ring-1"
 				/>
 			</div>

--- a/apps/desktop/src/shared/hotkeys.ts
+++ b/apps/desktop/src/shared/hotkeys.ts
@@ -570,6 +570,12 @@ export const HOTKEYS = {
 		category: "Workspace",
 		description: "Quickly create a workspace in the current project",
 	}),
+	FOCUS_TASK_SEARCH: defineHotkey({
+		keys: "meta+f",
+		label: "Focus Task Search",
+		category: "Workspace",
+		description: "Focus the search input in the tasks view",
+	}),
 	OPEN_PROJECT: defineHotkey({
 		keys: "meta+shift+o",
 		label: "Open Project",


### PR DESCRIPTION
## Summary
- Adds `FOCUS_TASK_SEARCH` hotkey (`Cmd+F` / `Ctrl+Shift+F`) that focuses and selects the search input on the Tasks page
- Pressing `Escape` while focused clears the search query and blurs the input
- No conflict with `FIND_IN_TERMINAL` (also `meta+f`) since the terminal hotkey is gated by `enabled: isFocused` and the two views are on separate routes

## Test plan
- [ ] Navigate to Tasks page → press Cmd+F → search input focuses with text selected
- [ ] Press Escape → search clears and input blurs
- [ ] Navigate to a Workspace → press Cmd+F → terminal search opens (existing behavior preserved)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut (Cmd+F/Ctrl+F) to quickly focus the task search input
  * Press Escape to clear search and exit the search field

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->