### PR TITLE
Sync Stripe customer name when organization name changes

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -15,6 +15,10 @@
 		"./env": {
 			"types": "./src/env.ts",
 			"default": "./src/env.ts"
+		},
+		"./stripe": {
+			"types": "./src/stripe.ts",
+			"default": "./src/stripe.ts"
 		}
 	},
 	"scripts": {

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -24,13 +24,14 @@ import {
 	organization,
 } from "better-auth/plugins";
 import { and, count, eq } from "drizzle-orm";
-import Stripe from "stripe";
+import type Stripe from "stripe";
 import { env } from "./env";
 import { acceptInvitationEndpoint } from "./lib/accept-invitation-endpoint";
 import { generateMagicTokenForInvite } from "./lib/generate-magic-token";
 import { oauthOrgScopeEndpoint } from "./lib/oauth-org-scope-endpoint";
 import { invitationRateLimit } from "./lib/rate-limit";
 import { resend } from "./lib/resend";
+import { stripeClient } from "./stripe";
 import {
 	formatPaymentFailed,
 	formatPaymentSucceeded,
@@ -41,7 +42,6 @@ import {
 	getOrganizationOwners,
 } from "./utils";
 
-const stripeClient = new Stripe(env.STRIPE_SECRET_KEY);
 const qstash = new Client({ token: env.QSTASH_TOKEN });
 
 const NOTIFY_SLACK_URL = `${env.NEXT_PUBLIC_API_URL}/api/integrations/stripe/jobs/notify-slack`;

--- a/packages/auth/src/stripe.ts
+++ b/packages/auth/src/stripe.ts
@@ -1,0 +1,4 @@
+import Stripe from "stripe";
+import { env } from "./env";
+
+export const stripeClient = new Stripe(env.STRIPE_SECRET_KEY);

--- a/packages/trpc/src/router/organization/organization.ts
+++ b/packages/trpc/src/router/organization/organization.ts
@@ -1,3 +1,4 @@
+import { stripeClient } from "@superset/auth/stripe";
 import { db } from "@superset/db/client";
 import { members, organizations } from "@superset/db/schema";
 import {
@@ -187,6 +188,20 @@ export const organizationRouter = {
 				.set(data)
 				.where(eq(organizations.id, id))
 				.returning();
+
+			if (organization?.stripeCustomerId && data.name) {
+				stripeClient.customers
+					.update(organization.stripeCustomerId, {
+						name: data.name,
+					})
+					.catch((error) => {
+						console.error(
+							"[org/update] Failed to sync Stripe customer info:",
+							error,
+						);
+					});
+			}
+
 			return organization;
 		}),
 


### PR DESCRIPTION
## Summary
- Extracts `stripeClient` into `packages/auth/src/stripe.ts` so it can be imported by other packages
- After the tRPC `organization.update` procedure writes to the DB, syncs the new name to the Stripe customer
- Uses fire-and-forget (`.catch()` with logging) so Stripe failures don't block the response

## Test plan
- [x] Lint passes
- [x] Tests pass (1195 pass, 0 fail)
- [x] Typecheck passes (16/16 packages)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization names are now automatically synchronized with your payment provider when updated.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->