### PR TITLE
feat(slack): split responses into summary + side effects messages

### DIFF
--- a/apps/api/src/app/api/integrations/slack/events/utils/run-agent/index.ts
+++ b/apps/api/src/app/api/integrations/slack/events/utils/run-agent/index.ts
@@ -1,2 +1,2 @@
 export type { SlackAgentResult } from "./run-agent";
-export { runSlackAgent } from "./run-agent";
+export { formatErrorForSlack, runSlackAgent } from "./run-agent";

--- a/apps/api/src/app/api/integrations/slack/events/utils/slack-blocks/index.ts
+++ b/apps/api/src/app/api/integrations/slack/events/utils/slack-blocks/index.ts
@@ -1,2 +1,2 @@
 export type { AgentAction } from "./slack-blocks";
-export { formatActionsAsText } from "./slack-blocks";
+export { formatActionsAsText, formatSideEffectsMessage } from "./slack-blocks";

--- a/apps/api/src/app/api/integrations/slack/events/utils/slack-blocks/slack-blocks.ts
+++ b/apps/api/src/app/api/integrations/slack/events/utils/slack-blocks/slack-blocks.ts
@@ -58,3 +58,37 @@ export function formatActionsAsText(actions: AgentAction[]): string {
 
 	return lines.join("\n");
 }
+
+export function formatSideEffectsMessage(actions: AgentAction[]): string {
+	const lines: string[] = [];
+
+	for (const action of actions) {
+		if (action.type === "task_created") {
+			for (const task of action.tasks) {
+				const url = `${env.NEXT_PUBLIC_WEB_URL}/tasks/${task.slug}`;
+				lines.push(`• Created task <${url}|${task.slug}>`);
+			}
+		} else if (action.type === "task_updated") {
+			for (const task of action.tasks) {
+				const url = `${env.NEXT_PUBLIC_WEB_URL}/tasks/${task.slug}`;
+				lines.push(`• Updated task <${url}|${task.slug}>`);
+			}
+		} else if (action.type === "task_deleted") {
+			for (const task of action.tasks) {
+				lines.push(`• Deleted task ${task.slug}`);
+			}
+		} else if (action.type === "workspace_created") {
+			for (const ws of action.workspaces) {
+				lines.push(
+					`• Created workspace *${ws.name}*${ws.branch ? ` on branch \`${ws.branch}\`` : ""}`,
+				);
+			}
+		} else if (action.type === "workspace_switched") {
+			for (const ws of action.workspaces) {
+				lines.push(`• Switched to workspace *${ws.name}*`);
+			}
+		}
+	}
+
+	return `*Changes:*\n${lines.join("\n")}`;
+}


### PR DESCRIPTION
## Summary
- Post an initial "Thinking..." message that updates in-place (`chat.update`) with tool progress status ("Creating task...", "Searching tasks...", etc.) as the agent works, then finalizes with Claude's text response
- Side effects (task created/updated/deleted, workspace created) are posted as a separate second message with a `*Changes:*` header and bullet-pointed, unfurlable task links
- Previously, when side effects existed, Claude's conversational response was discarded entirely — now it's always shown

## Changes
- **`process-mention.ts`** / **`process-assistant-message.ts`** — Post initial message, update in-place during agent execution, post separate side effects message
- **`run-agent.ts`** — Added `onProgress` callback, `TOOL_PROGRESS_STATUS` lookup map, and `delete_task` action tracking
- **`slack-blocks.ts`** — Added `formatSideEffectsMessage()` with header + bullet formatting

## Test plan
- [ ] Mention bot in a channel with a task creation request → verify "Thinking..." appears, updates with progress, then shows Claude's response. Side effects message appears separately with unfurlable task links
- [ ] Send a DM to the bot with a question (no tool calls) → verify single message with Claude's response, no side effects message
- [ ] Mention bot to update multiple tasks → verify all updates appear as bullet items in the side effects message
- [ ] Verify error case: if agent fails, the initial message updates to show the error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Initial "Thinking..." message in Slack threads that is updated with live progress and final results.
  * Tool-specific progress messages shown during agent work.
  * Side effects posted as a separate, clearly formatted "Changes" message (includes task deletions).

* **Bug Fixes**
  * Improved error handling: errors update the in-thread message or post a clear threaded error message.
  * Progress updates are best-effort and won’t interrupt message flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->