### PR TITLE
Replace CTA dropdown with device-specific CTA on marketing site

### DIFF
--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -36,6 +36,7 @@
 		"simplex-noise": "^4.0.3",
 		"stripe-gradient": "^1.0.1",
 		"three": "^0.181.2",
+		"ua-parser-js": "^2.0.8",
 		"zod": "^4.3.5"
 	},
 	"devDependencies": {
@@ -47,6 +48,7 @@
 		"@types/react": "~19.1.0",
 		"@types/react-dom": "^19.2.3",
 		"@types/three": "^0.181.0",
+		"@types/ua-parser-js": "^0.7.39",
 		"babel-plugin-react-compiler": "^1.0.0",
 		"dotenv": "^17.2.3",
 		"tailwindcss": "^4.1.18",

--- a/apps/marketing/src/app/components/CTAButtons/CTAButtons.tsx
+++ b/apps/marketing/src/app/components/CTAButtons/CTAButtons.tsx
@@ -1,9 +1,8 @@
 import { auth } from "@superset/auth/server";
-import { DOWNLOAD_URL_MAC_ARM64 } from "@superset/shared/constants";
-import { Download } from "lucide-react";
 import { headers } from "next/headers";
 
 import { env } from "@/env";
+import { HeaderCTA } from "./HeaderCTA";
 
 export async function CTAButtons() {
 	let session = null;
@@ -14,33 +13,7 @@ export async function CTAButtons() {
 		console.error("[marketing/CTAButtons] Failed to get session:", error);
 	}
 
-	if (session) {
-		return (
-			<>
-				<a
-					href={env.NEXT_PUBLIC_WEB_URL}
-					className="px-4 py-2 text-sm font-normal text-muted-foreground hover:text-foreground transition-colors text-center"
-				>
-					Dashboard
-				</a>
-				<a
-					href={DOWNLOAD_URL_MAC_ARM64}
-					className="px-4 py-2 text-sm font-normal bg-foreground text-background hover:bg-foreground/90 transition-colors flex items-center justify-center gap-2"
-				>
-					Download for macOS
-					<Download className="size-4" aria-hidden="true" />
-				</a>
-			</>
-		);
-	}
-
 	return (
-		<a
-			href={DOWNLOAD_URL_MAC_ARM64}
-			className="px-4 py-2 text-sm font-normal bg-foreground text-background hover:bg-foreground/90 transition-colors flex items-center justify-center gap-2"
-		>
-			Download for macOS
-			<Download className="size-4" aria-hidden="true" />
-		</a>
+		<HeaderCTA isLoggedIn={!!session} dashboardUrl={env.NEXT_PUBLIC_WEB_URL} />
 	);
 }

--- a/apps/marketing/src/app/components/CTAButtons/HeaderCTA.tsx
+++ b/apps/marketing/src/app/components/CTAButtons/HeaderCTA.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { DOWNLOAD_URL_MAC_ARM64 } from "@superset/shared/constants";
+import { Download } from "lucide-react";
+import posthog from "posthog-js";
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { HiMiniClock } from "react-icons/hi2";
+import { usePlatform } from "../../hooks/useOS";
+import { DownloadButton } from "../DownloadButton";
+import { WaitlistModal } from "../WaitlistModal";
+
+interface HeaderCTAProps {
+	isLoggedIn: boolean;
+	dashboardUrl: string;
+}
+
+export function HeaderCTA({ isLoggedIn, dashboardUrl }: HeaderCTAProps) {
+	const { os, isMobile } = usePlatform();
+	const [isWaitlistOpen, setIsWaitlistOpen] = useState(false);
+	const portalRef = useRef<HTMLElement | null>(null);
+
+	useEffect(() => {
+		portalRef.current = document.body;
+	}, []);
+
+	const showDownload = !isMobile && (os === "macos" || os === "unknown");
+
+	const dashboardLink = isLoggedIn && (
+		<a
+			href={dashboardUrl}
+			className="px-4 py-2 text-sm font-normal text-muted-foreground hover:text-foreground transition-colors text-center"
+		>
+			Dashboard
+		</a>
+	);
+
+	const waitlistModal = portalRef.current
+		? createPortal(
+				<WaitlistModal
+					isOpen={isWaitlistOpen}
+					onClose={() => setIsWaitlistOpen(false)}
+				/>,
+				portalRef.current,
+			)
+		: null;
+
+	if (isMobile) {
+		return (
+			<>
+				{dashboardLink}
+				<DownloadButton
+					size="sm"
+					onJoinWaitlist={() => setIsWaitlistOpen(true)}
+				/>
+				{waitlistModal}
+			</>
+		);
+	}
+
+	return (
+		<>
+			{dashboardLink}
+			{showDownload ? (
+				<a
+					href={DOWNLOAD_URL_MAC_ARM64}
+					className="px-4 py-2 text-sm font-normal bg-foreground text-background hover:bg-foreground/90 transition-colors flex items-center justify-center gap-2"
+					onClick={() => posthog.capture("download_clicked")}
+				>
+					Download for macOS
+					<Download className="size-4" aria-hidden="true" />
+				</a>
+			) : (
+				<button
+					type="button"
+					className="px-4 py-2 text-sm font-normal bg-foreground text-background hover:bg-foreground/90 transition-colors flex items-center justify-center gap-2"
+					onClick={() => {
+						posthog.capture("waitlist_clicked");
+						setIsWaitlistOpen(true);
+					}}
+				>
+					Join Waitlist
+					<HiMiniClock className="size-4" aria-hidden="true" />
+				</button>
+			)}
+			{waitlistModal}
+		</>
+	);
+}

--- a/apps/marketing/src/app/components/DownloadButton/DownloadButton.tsx
+++ b/apps/marketing/src/app/components/DownloadButton/DownloadButton.tsx
@@ -3,6 +3,7 @@
 import { COMPANY, DOWNLOAD_URL_MAC_ARM64 } from "@superset/shared/constants";
 import posthog from "posthog-js";
 import { HiMiniArrowDownTray, HiMiniClock } from "react-icons/hi2";
+import { usePlatform } from "../../hooks/useOS";
 import { type DropdownSection, PlatformDropdown } from "../PlatformDropdown";
 
 interface DownloadButtonProps {
@@ -16,93 +17,122 @@ export function DownloadButton({
 	className = "",
 	onJoinWaitlist,
 }: DownloadButtonProps) {
+	const { os, isMobile } = usePlatform();
+
 	const sizeClasses =
 		size === "sm"
 			? "px-2 sm:px-4 py-2 text-sm"
 			: "px-3 sm:px-6 py-2 sm:py-3 text-sm sm:text-base";
 
-	const handleAppleSiliconDownload = () => {
-		posthog.capture("download_clicked");
-		window.open(DOWNLOAD_URL_MAC_ARM64, "_blank");
-	};
+	const buttonClasses = `bg-foreground text-background ${sizeClasses} font-normal hover:bg-foreground/80 transition-colors flex items-center gap-2 ${className}`;
 
-	const handleBuildFromSource = () => {
-		window.open(COMPANY.GITHUB_URL, "_blank");
-	};
+	if (isMobile) {
+		const appleIcon = (
+			<svg
+				width="20"
+				height="20"
+				viewBox="0 0 24 24"
+				fill="currentColor"
+				xmlns="http://www.w3.org/2000/svg"
+				aria-label="Apple logo"
+			>
+				<title>Apple logo</title>
+				<path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
+			</svg>
+		);
 
-	const appleIcon = (
-		<svg
-			width="20"
-			height="20"
-			viewBox="0 0 24 24"
-			fill="currentColor"
-			xmlns="http://www.w3.org/2000/svg"
-			aria-label="Apple logo"
-		>
-			<title>Apple logo</title>
-			<path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
-		</svg>
-	);
+		const githubIcon = (
+			<svg
+				width="16"
+				height="16"
+				viewBox="0 0 24 24"
+				fill="currentColor"
+				xmlns="http://www.w3.org/2000/svg"
+				aria-label="GitHub logo"
+			>
+				<title>GitHub logo</title>
+				<path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z" />
+			</svg>
+		);
 
-	const githubIcon = (
-		<svg
-			width="16"
-			height="16"
-			viewBox="0 0 24 24"
-			fill="currentColor"
-			xmlns="http://www.w3.org/2000/svg"
-			aria-label="GitHub logo"
-		>
-			<title>GitHub logo</title>
-			<path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z" />
-		</svg>
-	);
-
-	const sections: DropdownSection[] = [
-		{
-			items: [
-				{
-					id: "mac-download",
-					label: "Download for Mac",
-					description: "APPLE SILICON",
-					icon: appleIcon,
-					onClick: handleAppleSiliconDownload,
-					variant: "primary",
-				},
-			],
-		},
-		{
-			title: "Other platforms",
-			items: [
-				{
-					id: "waitlist",
-					label: "Join waitlist for Windows & Linux",
-					icon: <HiMiniClock className="size-4" />,
-					onClick: () => {
-						posthog.capture("waitlist_clicked");
-						onJoinWaitlist?.();
+		const sections: DropdownSection[] = [
+			{
+				items: [
+					{
+						id: "mac-download",
+						label: "Download for Mac",
+						description: "APPLE SILICON",
+						icon: appleIcon,
+						onClick: () => {
+							posthog.capture("download_clicked");
+							window.open(DOWNLOAD_URL_MAC_ARM64, "_blank");
+						},
+						variant: "primary",
 					},
-				},
-				{
-					id: "build-from-source",
-					label: "Build from source on GitHub",
-					icon: githubIcon,
-					onClick: handleBuildFromSource,
-				},
-			],
-		},
-	];
+				],
+			},
+			{
+				title: "Other platforms",
+				items: [
+					{
+						id: "waitlist",
+						label: "Join waitlist for Windows & Linux",
+						icon: <HiMiniClock className="size-4" />,
+						onClick: () => {
+							posthog.capture("waitlist_clicked");
+							onJoinWaitlist?.();
+						},
+					},
+					{
+						id: "build-from-source",
+						label: "Build from source on GitHub",
+						icon: githubIcon,
+						onClick: () => window.open(COMPANY.GITHUB_URL, "_blank"),
+					},
+				],
+			},
+		];
 
-	const trigger = (
+		const trigger = (
+			<button type="button" className={buttonClasses}>
+				Download
+				<HiMiniArrowDownTray className="size-4" />
+			</button>
+		);
+
+		return (
+			<PlatformDropdown trigger={trigger} sections={sections} align="end" />
+		);
+	}
+
+	if (os === "macos" || os === "unknown") {
+		return (
+			<button
+				type="button"
+				className={buttonClasses}
+				onClick={() => {
+					posthog.capture("download_clicked");
+					window.open(DOWNLOAD_URL_MAC_ARM64, "_blank");
+				}}
+			>
+				<span className="hidden sm:inline">Download for macOS</span>
+				<span className="sm:hidden">Download</span>
+				<HiMiniArrowDownTray className="size-4" />
+			</button>
+		);
+	}
+
+	return (
 		<button
 			type="button"
-			className={`bg-foreground text-background ${sizeClasses} font-normal hover:bg-foreground/80 transition-colors flex items-center gap-2 ${className}`}
+			className={buttonClasses}
+			onClick={() => {
+				posthog.capture("waitlist_clicked");
+				onJoinWaitlist?.();
+			}}
 		>
-			<span className="hidden sm:inline">Download for macOS</span>
-			<span className="sm:hidden">Download</span>
-			<HiMiniArrowDownTray className="size-4" />
+			Join Waitlist
+			<HiMiniClock className="size-4" />
 		</button>
 	);
-
-	return <PlatformDropdown trigger={trigger} sections={sections} align="end" />;
 }

--- a/apps/marketing/src/app/hooks/useOS/index.ts
+++ b/apps/marketing/src/app/hooks/useOS/index.ts
@@ -1,0 +1,1 @@
+export { type OS, type PlatformInfo, usePlatform } from "./useOS";

--- a/apps/marketing/src/app/hooks/useOS/useOS.ts
+++ b/apps/marketing/src/app/hooks/useOS/useOS.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+import { UAParser } from "ua-parser-js";
+
+export type OS = "macos" | "windows" | "linux" | "unknown";
+
+export interface PlatformInfo {
+	os: OS;
+	isMobile: boolean;
+}
+
+function detectPlatform(): PlatformInfo {
+	if (typeof navigator === "undefined") {
+		return { os: "unknown", isMobile: false };
+	}
+
+	const parser = new UAParser(navigator.userAgent);
+	const osName = parser.getOS().name?.toLowerCase() ?? "";
+	const deviceType = parser.getDevice().type;
+
+	const isMobile = deviceType === "mobile" || deviceType === "tablet";
+
+	let os: OS = "unknown";
+	if (osName.includes("mac")) os = "macos";
+	else if (osName.includes("windows")) os = "windows";
+	else if (osName.includes("linux")) os = "linux";
+
+	return { os, isMobile };
+}
+
+const DEFAULT_PLATFORM: PlatformInfo = { os: "unknown", isMobile: false };
+
+export function usePlatform(): PlatformInfo {
+	const [platform, setPlatform] = useState<PlatformInfo>(DEFAULT_PLATFORM);
+
+	useEffect(() => {
+		setPlatform(detectPlatform());
+	}, []);
+
+	return platform;
+}

--- a/bun.lock
+++ b/bun.lock
@@ -363,6 +363,7 @@
         "simplex-noise": "^4.0.3",
         "stripe-gradient": "^1.0.1",
         "three": "^0.181.2",
+        "ua-parser-js": "^2.0.8",
         "zod": "^4.3.5",
       },
       "devDependencies": {
@@ -374,6 +375,7 @@
         "@types/react": "~19.1.0",
         "@types/react-dom": "^19.2.3",
         "@types/three": "^0.181.0",
+        "@types/ua-parser-js": "^0.7.39",
         "babel-plugin-react-compiler": "^1.0.0",
         "dotenv": "^17.2.3",
         "tailwindcss": "^4.1.18",
@@ -588,17 +590,6 @@
     "packages/scripts": {
       "name": "@superset/scripts",
       "version": "0.1.0",
-      "dependencies": {
-        "@superset/db": "workspace:*",
-        "dotenv": "^17.2.3",
-        "drizzle-orm": "0.45.1",
-        "stripe": "^20.2.0",
-      },
-      "devDependencies": {
-        "@superset/typescript": "workspace:*",
-        "@types/node": "^24.9.1",
-        "typescript": "^5.9.3",
-      },
     },
     "packages/shared": {
       "name": "@superset/shared",
@@ -2201,6 +2192,8 @@
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
+    "@types/ua-parser-js": ["@types/ua-parser-js@0.7.39", "", {}, "sha512-P/oDfpofrdtF5xw433SPALpdSchtJmY7nsJItf8h3KXqOslkbySh8zq4dSWXH2oTjRvJ5PczVEoCZPow6GicLg=="],
+
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
@@ -2825,6 +2818,8 @@
 
     "destroy": ["destroy@1.2.0", "", {}, "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="],
 
+    "detect-europe-js": ["detect-europe-js@0.1.2", "", {}, "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow=="],
+
     "detect-gpu": ["detect-gpu@5.0.70", "", { "dependencies": { "webgl-constants": "^1.1.1" } }, "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
@@ -3424,6 +3419,8 @@
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "is-reference": ["is-reference@1.2.1", "", { "dependencies": { "@types/estree": "*" } }, "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ=="],
+
+    "is-standalone-pwa": ["is-standalone-pwa@0.1.1", "", {}, "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g=="],
 
     "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
 
@@ -4795,7 +4792,9 @@
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "ua-parser-js": ["ua-parser-js@0.7.41", "", { "bin": { "ua-parser-js": "script/cli.js" } }, "sha512-O3oYyCMPYgNNHuO7Jjk3uacJWZF8loBgwrfd/5LE/HyZ3lUIOdniQ7DNXJcIgZbwioZxk0fLfI4EVnetdiX5jg=="],
+    "ua-is-frozen": ["ua-is-frozen@0.1.2", "", {}, "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw=="],
+
+    "ua-parser-js": ["ua-parser-js@2.0.8", "", { "dependencies": { "detect-europe-js": "^0.1.2", "is-standalone-pwa": "^0.1.1", "ua-is-frozen": "^0.1.2" }, "bin": { "ua-parser-js": "script/cli.js" } }, "sha512-BdnBM5waFormdrOFBU+cA90R689V0tWUWlIG2i30UXxElHjuCu5+dOV2Etw3547jcQ/yaLtPm9wrqIuOY2bSJg=="],
 
     "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
@@ -5396,6 +5395,8 @@
     "execa/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "expo/react-refresh": ["react-refresh@0.14.2", "", {}, "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA=="],
+
+    "expo-device/ua-parser-js": ["ua-parser-js@0.7.41", "", { "bin": { "ua-parser-js": "script/cli.js" } }, "sha512-O3oYyCMPYgNNHuO7Jjk3uacJWZF8loBgwrfd/5LE/HyZ3lUIOdniQ7DNXJcIgZbwioZxk0fLfI4EVnetdiX5jg=="],
 
     "expo-modules-autolinking/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 


### PR DESCRIPTION
## Summary
- Detect user's OS via `ua-parser-js` and render a single CTA button instead of a dropdown menu
- **macOS**: direct "Download for macOS" button linking to ARM64 DMG
- **Windows/Linux**: "Join Waitlist" button opening the Tally waitlist modal
- **Mobile** (any OS): original dropdown with all platform options preserved
- Header CTA uses `createPortal` to render the waitlist modal outside the sticky header's stacking context

## Changes
- **New**: `usePlatform` hook (`apps/marketing/src/app/hooks/useOS/`) — uses `ua-parser-js` for reliable OS and device type detection (correctly distinguishes iOS from macOS, Android from Linux)
- **New**: `HeaderCTA` client component — handles platform-aware CTA rendering in the header, with portaled waitlist modal
- **Modified**: `DownloadButton` — removed dropdown for desktop, kept dropdown for mobile
- **Modified**: `CTAButtons` — thin server component delegates to `HeaderCTA`

## Test plan
- [ ] Visit marketing site on macOS — should see "Download for macOS" button (no dropdown)
- [ ] Test `?os=windows` — should see "Join Waitlist" button
- [ ] Test `?os=linux` — should see "Join Waitlist" button
- [ ] Test `?mobile=true` — should see dropdown with all options
- [ ] Test `?os=windows&mobile=true` — should see dropdown
- [ ] Verify waitlist modal opens correctly from both header and hero/CTA sections
- [ ] Verify PostHog events fire (`download_clicked`, `waitlist_clicked`)