### PR TITLE
fix(desktop): trim trailing whitespace when copying text from terminal

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
@@ -14,6 +14,7 @@ import { DEBUG_TERMINAL, FIRST_RENDER_RESTORE_FALLBACK_MS } from "../config";
 import {
 	createTerminalInstance,
 	setupClickToMoveCursor,
+	setupCopyHandler,
 	setupFocusListener,
 	setupKeyboardHandler,
 	setupPasteHandler,
@@ -518,6 +519,7 @@ export function useTerminalLifecycle({
 			onWrite: handleWrite,
 			isBracketedPasteEnabled: () => isBracketedPasteRef.current,
 		});
+		const cleanupCopy = setupCopyHandler(xterm);
 
 		const handleVisibilityChange = () => {
 			if (document.hidden || isUnmounted) return;
@@ -562,6 +564,7 @@ export function useTerminalLifecycle({
 			cleanupFocus?.();
 			cleanupResize();
 			cleanupPaste();
+			cleanupCopy();
 			cleanupQuerySuppression();
 			unregisterClearCallbackRef.current(paneId);
 			unregisterScrollToBottomCallbackRef.current(paneId);


### PR DESCRIPTION
## Summary
- Adds a copy handler that trims trailing whitespace from each line when copying text from the terminal
- This matches the default behavior of iTerm2 and other popular terminal emulators (iTerm2's `TrimWhitespaceOnCopy` defaults to `true`)

## Test plan
- [ ] Select text in terminal that spans multiple lines
- [ ] Copy with Cmd+C
- [ ] Paste into a text editor and verify no trailing spaces on each line
- [ ] Verify single-line copies still work correctly
- [ ] Verify intentional newlines are preserved

Fixes #1018

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced terminal copy functionality: When copying text from the terminal, trailing whitespace is automatically trimmed while preserving line breaks, resulting in cleaner copied content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->