### PR TITLE
feat: gate Slack integration behind feature flag

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/integrations/components/IntegrationsSettings/IntegrationsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/integrations/components/IntegrationsSettings/IntegrationsSettings.tsx
@@ -64,6 +64,9 @@ export function IntegrationsSettings({
 	const hasGithubAccess = useFeatureFlagEnabled(
 		FEATURE_FLAGS.GITHUB_INTEGRATION_ACCESS,
 	);
+	const hasSlackAccess = useFeatureFlagEnabled(
+		FEATURE_FLAGS.SLACK_INTEGRATION_ACCESS,
+	);
 
 	const showLinear = isItemVisible(
 		SETTING_ITEM_ID.INTEGRATIONS_LINEAR,
@@ -104,10 +107,9 @@ export function IntegrationsSettings({
 		!!githubInstallation && !githubInstallation.suspended;
 	const isLoading = isLoadingIntegrations || isLoadingGithub;
 
-	const showSlack = isItemVisible(
-		SETTING_ITEM_ID.INTEGRATIONS_SLACK,
-		visibleItems,
-	);
+	const showSlack =
+		hasSlackAccess &&
+		isItemVisible(SETTING_ITEM_ID.INTEGRATIONS_SLACK, visibleItems);
 
 	const handleOpenWeb = (path: string) => {
 		window.open(`${env.NEXT_PUBLIC_WEB_URL}${path}`, "_blank");

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,6 +33,7 @@
 		"next": "^16.0.10",
 		"next-themes": "^0.4.6",
 		"posthog-js": "1.310.1",
+		"posthog-node": "^5.24.7",
 		"react": "19.1.0",
 		"react-dom": "19.1.0",
 		"react-icons": "^5.5.0",

--- a/apps/web/src/app/(dashboard)/integrations/page.tsx
+++ b/apps/web/src/app/(dashboard)/integrations/page.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { FEATURE_FLAGS } from "@superset/shared/constants";
+import { useFeatureFlagEnabled } from "posthog-js/react";
+import { useMemo } from "react";
 import { FaGithub, FaSlack } from "react-icons/fa";
 import { SiLinear } from "react-icons/si";
 import {
@@ -35,6 +38,23 @@ const integrations: IntegrationCardProps[] = [
 ];
 
 export default function IntegrationsPage() {
+	const hasGithubAccess = useFeatureFlagEnabled(
+		FEATURE_FLAGS.GITHUB_INTEGRATION_ACCESS,
+	);
+	const hasSlackAccess = useFeatureFlagEnabled(
+		FEATURE_FLAGS.SLACK_INTEGRATION_ACCESS,
+	);
+
+	const visibleIntegrations = useMemo(
+		() =>
+			integrations.filter((i) => {
+				if (i.id === "github") return hasGithubAccess;
+				if (i.id === "slack") return hasSlackAccess;
+				return true;
+			}),
+		[hasGithubAccess, hasSlackAccess],
+	);
+
 	return (
 		<div className="space-y-8">
 			<section>
@@ -44,7 +64,7 @@ export default function IntegrationsPage() {
 				</p>
 
 				<div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-					{integrations.map((integration) => (
+					{visibleIntegrations.map((integration) => (
 						<IntegrationCard key={integration.id} {...integration} />
 					))}
 				</div>

--- a/apps/web/src/app/(dashboard)/integrations/slack/layout.tsx
+++ b/apps/web/src/app/(dashboard)/integrations/slack/layout.tsx
@@ -1,0 +1,38 @@
+import { auth } from "@superset/auth/server";
+import { FEATURE_FLAGS } from "@superset/shared/constants";
+import { headers } from "next/headers";
+import { notFound } from "next/navigation";
+import { PostHog } from "posthog-node";
+
+import { env } from "@/env";
+
+const posthog = new PostHog(env.NEXT_PUBLIC_POSTHOG_KEY, {
+	host: env.NEXT_PUBLIC_POSTHOG_HOST,
+	flushAt: 1,
+	flushInterval: 0,
+});
+
+export default async function SlackIntegrationLayout({
+	children,
+}: {
+	children: React.ReactNode;
+}) {
+	const session = await auth.api.getSession({
+		headers: await headers(),
+	});
+
+	if (!session?.user) {
+		notFound();
+	}
+
+	const hasAccess = await posthog.getFeatureFlag(
+		FEATURE_FLAGS.SLACK_INTEGRATION_ACCESS,
+		session.user.id,
+	);
+
+	if (!hasAccess) {
+		notFound();
+	}
+
+	return <>{children}</>;
+}

--- a/bun.lock
+++ b/bun.lock
@@ -471,6 +471,7 @@
         "next": "^16.0.10",
         "next-themes": "^0.4.6",
         "posthog-js": "1.310.1",
+        "posthog-node": "^5.24.7",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-icons": "^5.5.0",
@@ -5239,6 +5240,8 @@
 
     "@slack/web-api/eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
+    "@superset/web/posthog-node": ["posthog-node@5.24.7", "", { "dependencies": { "@posthog/core": "1.17.0" } }, "sha512-IJ0Zj+v+eg/JQMZ75n0Hcp4NzuQzWcZjqFjcUQs6RhW2l5FiQIq09sKJMleXX33hYxD6sfjFsDTqugJlgeAohg=="],
+
     "@tailwindcss/node/jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
@@ -5990,6 +5993,8 @@
     "@sentry/react/@sentry/browser/@sentry-internal/replay": ["@sentry-internal/replay@10.36.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.36.0", "@sentry/core": "10.36.0" } }, "sha512-nLMkJgvHq+uCCrQKV2KgSdVHxTsmDk0r2hsAoTcKCbzUpXyW5UhCziMRS6ULjBlzt5sbxoIIplE25ZpmIEeNgg=="],
 
     "@sentry/react/@sentry/browser/@sentry-internal/replay-canvas": ["@sentry-internal/replay-canvas@10.36.0", "", { "dependencies": { "@sentry-internal/replay": "10.36.0", "@sentry/core": "10.36.0" } }, "sha512-DLGIwmT2LX+O6TyYPtOQL5GiTm2rN0taJPDJ/Lzg2KEJZrdd5sKkzTckhh2x+vr4JQyeaLmnb8M40Ch1hvG/vQ=="],
+
+    "@superset/web/posthog-node/@posthog/core": ["@posthog/core@1.17.0", "", { "dependencies": { "cross-spawn": "^7.0.6" } }, "sha512-8pDNL+/u9ojzXloA5wILVDXBCV5daJ7w2ipCALQlEEZmL752cCKhRpbyiHn3tjKXh3Hy6aOboJneYa1JdlVHrQ=="],
 
     "@tanstack/router-plugin/unplugin/webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -55,4 +55,6 @@ export const FEATURE_FLAGS = {
 	BILLING_ENABLED: "billing-enabled",
 	/** Gates access to GitHub integration (currently buggy, internal only). */
 	GITHUB_INTEGRATION_ACCESS: "github-integration-access",
+	/** Gates access to Slack integration (internal only). */
+	SLACK_INTEGRATION_ACCESS: "slack-integration-access",
 } as const;


### PR DESCRIPTION
## Summary
- Adds `slack-integration-access` PostHog feature flag (created in all 3 envs: Production, Preview, Local Development)
- Hides the Slack integration card from the web and desktop integrations pages when the flag is off
- Adds a client layout on `/integrations/slack` to redirect users without access back to `/integrations`
- Only `@superset.sh` email users have the flag enabled

## Test plan
- [ ] Verify Slack card is hidden on web `/integrations` page for non-@superset.sh users
- [ ] Verify Slack card is visible for @superset.sh users
- [ ] Verify navigating directly to `/integrations/slack` redirects non-@superset.sh users
- [ ] Verify Slack card is hidden in desktop app Settings → Integrations for non-@superset.sh users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slack access is now controlled per user via a feature flag; Slack options are hidden unless enabled.
  * Integrations page and desktop settings respect the per-user Slack access flag.
  * Integrations list also respects GitHub access flags, showing only enabled integrations.
  * Slack integration pages return not found for users without enabled access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->