### PR TITLE
fix(desktop): allow Option+key to type special characters on Mac

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/config.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/config.ts
@@ -38,7 +38,8 @@ export const TERMINAL_OPTIONS: ITerminalOptions = {
 	theme: TERMINAL_THEME,
 	allowProposedApi: true,
 	scrollback: 10000,
-	macOptionIsMeta: true,
+	// Allow Option+key to type special characters on international keyboards (e.g., Option+2 = @)
+	macOptionIsMeta: false,
 	cursorStyle: "block",
 	cursorInactiveStyle: "outline",
 	screenReaderMode: false,


### PR DESCRIPTION
## Summary
- Fix @ symbol typing with Option+2 keyboard shortcut for international keyboards
- Change `macOptionIsMeta` from `true` to `false` in terminal config

## Problem
International keyboard layouts (Portuguese, Spanish, UK, etc.) use Option+key combinations to type essential characters:
- Option+2 = `@` (Portuguese, Spanish, UK)
- Option+2 = `€` (some layouts)
- Option+2 = `™` (US)

With `macOptionIsMeta: true`, xterm.js treats Option as Meta, blocking these characters.

## Solution
Set `macOptionIsMeta: false` (which is xterm.js's default). This allows Option+key to produce special characters on international keyboards.

Users who relied on Option as Meta for terminal emacs shortcuts (Option+B, Option+F) can use Ctrl instead (Ctrl+B, Ctrl+F work in most shells by default).

## Test plan
- [ ] Test Option+2 on international keyboard layout produces `@`
- [ ] Test Option+key combinations on US keyboard produce special chars (™, £, etc.)
- [ ] Verify Cmd+Option hotkeys (like ⌘⌥↑ for Previous Workspace) still work