### PR TITLE
fix(mcp): use dynamic heredoc delimiter in start-claude-session

### DIFF
--- a/packages/mcp/src/tools/devices/start-claude-session/start-claude-session.ts
+++ b/packages/mcp/src/tools/devices/start-claude-session/start-claude-session.ts
@@ -39,10 +39,12 @@ You are running fully autonomously. Do not ask questions or wait for user feedba
 4. Verify your changes work correctly (run relevant tests, typecheck, lint)
 5. When done, use the Superset MCP \`update_task\` tool to update task "${task.id}" with a summary of what was done`;
 
+	const delimiter = `SUPERSET_PROMPT_${crypto.randomUUID().replaceAll("-", "")}`;
+
 	return [
-		"claude --dangerously-skip-permissions \"$(cat <<'SUPERSET_PROMPT'",
+		`claude --dangerously-skip-permissions "$(cat <<'${delimiter}'`,
 		prompt,
-		"SUPERSET_PROMPT",
+		delimiter,
 		')"',
 	].join("\n");
 }


### PR DESCRIPTION
## Summary
- Uses a UUID-based heredoc delimiter (`SUPERSET_PROMPT_<uuid>`) instead of a static `SUPERSET_PROMPT` delimiter when passing prompts to the Claude CLI
- Prevents task descriptions containing the literal delimiter string from prematurely terminating the heredoc

## Test plan
- [ ] Verify `start_claude_session` MCP tool launches Claude with correct prompt
- [ ] Verify `start_claude_subagent` MCP tool launches Claude with correct prompt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Claude session initialization by using dynamic session identifiers instead of fixed markers, preventing potential conflicts with prompt content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->