### PR TITLE
always show change tab

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@superset/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useParams } from "@tanstack/react-router";
-import { useCallback, useEffect } from "react";
+import { useCallback } from "react";
 import {
 	LuExpand,
 	LuFile,
@@ -11,7 +11,6 @@ import {
 } from "react-icons/lu";
 import { HotkeyTooltipContent } from "renderer/components/HotkeyTooltipContent";
 import { electronTrpc } from "renderer/lib/electron-trpc";
-import { useChangesStore } from "renderer/stores/changes";
 import {
 	RightSidebarTab,
 	SidebarMode,
@@ -54,20 +53,6 @@ export function RightSidebar() {
 		{ enabled: !!workspaceId },
 	);
 	const worktreePath = workspace?.worktreePath;
-	const { baseBranch } = useChangesStore();
-	const { data: branchData } = electronTrpc.changes.getBranches.useQuery(
-		{ worktreePath: worktreePath || "" },
-		{ enabled: !!worktreePath },
-	);
-	const effectiveBaseBranch = baseBranch ?? branchData?.defaultBranch ?? "main";
-	const { data: status } = electronTrpc.changes.getStatus.useQuery(
-		{ worktreePath: worktreePath || "", defaultBranch: effectiveBaseBranch },
-		{
-			enabled: !!worktreePath,
-			refetchInterval: 2500,
-			refetchOnWindowFocus: true,
-		},
-	);
 	const {
 		currentMode,
 		rightSidebarTab,
@@ -76,20 +61,7 @@ export function RightSidebar() {
 		setMode,
 	} = useSidebarStore();
 	const isExpanded = currentMode === SidebarMode.Changes;
-	const hasChanges = status
-		? (status.againstBase?.length ?? 0) > 0 ||
-			(status.commits?.length ?? 0) > 0 ||
-			(status.staged?.length ?? 0) > 0 ||
-			(status.unstaged?.length ?? 0) > 0 ||
-			(status.untracked?.length ?? 0) > 0
-		: true;
-	const showChangesTab = !!worktreePath && hasChanges;
-
-	useEffect(() => {
-		if (!showChangesTab && rightSidebarTab === RightSidebarTab.Changes) {
-			setRightSidebarTab(RightSidebarTab.Files);
-		}
-	}, [rightSidebarTab, setRightSidebarTab, showChangesTab]);
+	const showChangesTab = !!worktreePath;
 
 	const handleExpandToggle = () => {
 		setMode(isExpanded ? SidebarMode.Tabs : SidebarMode.Changes);


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified right sidebar tab behavior by removing automatic switching logic that previously transitioned between tabs based on workspace changes status. The sidebar now displays tabs more directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->