### PR TITLE
fix(desktop): update xterm CSS for 6.0.0 viewport changes

### DIFF
--- a/apps/desktop/src/renderer/globals.css
+++ b/apps/desktop/src/renderer/globals.css
@@ -167,8 +167,8 @@
 	.xterm .xterm-scrollable-element,
 	.xterm .xterm-viewport,
 	.xterm .xterm-screen {
-		height: 100% !important;
-		width: 100% !important;
+		height: 100%;
+		width: 100%;
 	}
 	.xterm .xterm-rows a {
 		color: inherit;


### PR DESCRIPTION
## Summary
- Fix terminal not filling full pane height after xterm.js 6.0.0 upgrade
- Add CSS rules for new `.xterm-scrollable-element` (VS Code scrollbar integration)
- Include `.xterm-viewport` for compatibility with both old and new DOM structures
- Use `!important` to ensure rules override xterm's CSS regardless of load order
- Fix CSS specificity for `.xterm-screen` to match xterm's selectors

## Context
xterm.js 6.0.0 introduced breaking changes to the viewport/scrollbar by integrating VS Code's `DomScrollableElement`. This changed the DOM structure and caused terminals to not fill their container height correctly.

## Test plan
- [ ] Launch desktop app and verify terminal fills the full pane height
- [ ] Test with split panes to ensure resizing works correctly
- [ ] Verify scrolling behavior is unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized CSS styling for terminal display components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->