### PR TITLE
perf(desktop): batch port scans per interval

### DIFF
--- a/apps/desktop/src/main/lib/terminal/port-manager.ts
+++ b/apps/desktop/src/main/lib/terminal/port-manager.ts
@@ -369,17 +369,15 @@ class PortManager extends EventEmitter {
 		}
 	}
 
-	private updatePortsForPane(
-		{
-			paneId,
-			workspaceId,
-			portInfos,
-		}: {
-			paneId: string;
-			workspaceId: string;
-			portInfos: PortInfo[];
-		},
-	): void {
+	private updatePortsForPane({
+		paneId,
+		workspaceId,
+		portInfos,
+	}: {
+		paneId: string;
+		workspaceId: string;
+		portInfos: PortInfo[];
+	}): void {
 		const now = Date.now();
 
 		const validPortInfos = portInfos.filter(


### PR DESCRIPTION
## Summary\n- batch port scans into a single lsof/netstat call per interval\n- map port results back to panes via pid ownership\n- preserve existing hint-driven and per-pane update behavior\n\n## Testing\n- not run (not requested)\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Port scanning now runs as aggregated batches across terminal panes, improving speed and responsiveness and reducing redundant scans.

* **New Features**
  * Tracks PID ownership and builds pane-to-port mappings so listening ports are more accurately associated with panes; hint scans are now scheduled for coordinated updates.

* **Bug Fixes**
  * Self-healing removal of stale or orphaned ports and cleanup of empty panes keeps displayed port lists accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->