### PR TITLE
feat(desktop): add nested git repository support for monorepos

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/changes/security/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/security/index.ts
@@ -25,6 +25,7 @@ export {
 export {
 	assertRegisteredWorktree,
 	assertValidGitPath,
+	assertValidNestedRepo,
 	getRegisteredWorktree,
 	PathValidationError,
 	type PathValidationErrorCode,

--- a/apps/desktop/src/lib/trpc/routers/changes/staging.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/staging.ts
@@ -21,10 +21,11 @@ export const createStagingRouter = () => {
 				z.object({
 					worktreePath: z.string(),
 					filePath: z.string(),
+					repoPath: z.string().optional(),
 				}),
 			)
 			.mutation(async ({ input }): Promise<{ success: boolean }> => {
-				await gitStageFile(input.worktreePath, input.filePath);
+				await gitStageFile(input.worktreePath, input.filePath, input.repoPath);
 				return { success: true };
 			}),
 
@@ -33,10 +34,15 @@ export const createStagingRouter = () => {
 				z.object({
 					worktreePath: z.string(),
 					filePath: z.string(),
+					repoPath: z.string().optional(),
 				}),
 			)
 			.mutation(async ({ input }): Promise<{ success: boolean }> => {
-				await gitUnstageFile(input.worktreePath, input.filePath);
+				await gitUnstageFile(
+					input.worktreePath,
+					input.filePath,
+					input.repoPath,
+				);
 				return { success: true };
 			}),
 
@@ -45,24 +51,39 @@ export const createStagingRouter = () => {
 				z.object({
 					worktreePath: z.string(),
 					filePath: z.string(),
+					repoPath: z.string().optional(),
 				}),
 			)
 			.mutation(async ({ input }): Promise<{ success: boolean }> => {
-				await gitCheckoutFile(input.worktreePath, input.filePath);
+				await gitCheckoutFile(
+					input.worktreePath,
+					input.filePath,
+					input.repoPath,
+				);
 				return { success: true };
 			}),
 
 		stageAll: publicProcedure
-			.input(z.object({ worktreePath: z.string() }))
+			.input(
+				z.object({
+					worktreePath: z.string(),
+					repoPath: z.string().optional(),
+				}),
+			)
 			.mutation(async ({ input }): Promise<{ success: boolean }> => {
-				await gitStageAll(input.worktreePath);
+				await gitStageAll(input.worktreePath, input.repoPath);
 				return { success: true };
 			}),
 
 		unstageAll: publicProcedure
-			.input(z.object({ worktreePath: z.string() }))
+			.input(
+				z.object({
+					worktreePath: z.string(),
+					repoPath: z.string().optional(),
+				}),
+			)
 			.mutation(async ({ input }): Promise<{ success: boolean }> => {
-				await gitUnstageAll(input.worktreePath);
+				await gitUnstageAll(input.worktreePath, input.repoPath);
 				return { success: true };
 			}),
 
@@ -71,45 +92,77 @@ export const createStagingRouter = () => {
 				z.object({
 					worktreePath: z.string(),
 					filePath: z.string(),
+					repoPath: z.string().optional(),
 				}),
 			)
 			.mutation(async ({ input }): Promise<{ success: boolean }> => {
-				await secureFs.delete(input.worktreePath, input.filePath);
+				const targetRepoPath = input.repoPath || input.worktreePath;
+				// Use nested-repo-aware delete that validates both worktree and nested repo
+				await secureFs.deleteInNestedRepo(
+					input.worktreePath,
+					targetRepoPath,
+					input.filePath,
+				);
 				return { success: true };
 			}),
 
 		discardAllUnstaged: publicProcedure
-			.input(z.object({ worktreePath: z.string() }))
+			.input(
+				z.object({
+					worktreePath: z.string(),
+					repoPath: z.string().optional(),
+				}),
+			)
 			.mutation(async ({ input }): Promise<{ success: boolean }> => {
-				await gitDiscardAllUnstaged(input.worktreePath);
+				await gitDiscardAllUnstaged(input.worktreePath, input.repoPath);
 				return { success: true };
 			}),
 
 		discardAllStaged: publicProcedure
-			.input(z.object({ worktreePath: z.string() }))
+			.input(
+				z.object({
+					worktreePath: z.string(),
+					repoPath: z.string().optional(),
+				}),
+			)
 			.mutation(async ({ input }): Promise<{ success: boolean }> => {
-				await gitDiscardAllStaged(input.worktreePath);
+				await gitDiscardAllStaged(input.worktreePath, input.repoPath);
 				return { success: true };
 			}),
 
 		stash: publicProcedure
-			.input(z.object({ worktreePath: z.string() }))
+			.input(
+				z.object({
+					worktreePath: z.string(),
+					repoPath: z.string().optional(),
+				}),
+			)
 			.mutation(async ({ input }): Promise<{ success: boolean }> => {
-				await gitStash(input.worktreePath);
+				await gitStash(input.worktreePath, input.repoPath);
 				return { success: true };
 			}),
 
 		stashIncludeUntracked: publicProcedure
-			.input(z.object({ worktreePath: z.string() }))
+			.input(
+				z.object({
+					worktreePath: z.string(),
+					repoPath: z.string().optional(),
+				}),
+			)
 			.mutation(async ({ input }): Promise<{ success: boolean }> => {
-				await gitStashIncludeUntracked(input.worktreePath);
+				await gitStashIncludeUntracked(input.worktreePath, input.repoPath);
 				return { success: true };
 			}),
 
 		stashPop: publicProcedure
-			.input(z.object({ worktreePath: z.string() }))
+			.input(
+				z.object({
+					worktreePath: z.string(),
+					repoPath: z.string().optional(),
+				}),
+			)
 			.mutation(async ({ input }): Promise<{ success: boolean }> => {
-				await gitStashPop(input.worktreePath);
+				await gitStashPop(input.worktreePath, input.repoPath);
 				return { success: true };
 			}),
 	});

--- a/apps/desktop/src/lib/trpc/routers/changes/utils/nested-repos.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/utils/nested-repos.ts
@@ -1,0 +1,164 @@
+import { access, lstat, readdir } from "node:fs/promises";
+import { join, relative } from "node:path";
+
+/** Maximum depth to scan for nested repos */
+const MAX_SCAN_DEPTH = 5;
+
+/** Directories to exclude from scanning */
+const EXCLUDED_DIRS = new Set([
+	"node_modules",
+	"vendor",
+	"dist",
+	"build",
+	".git",
+	"__pycache__",
+	".venv",
+	"venv",
+	".next",
+	".turbo",
+	"target",
+	"coverage",
+]);
+
+/** Cache TTL in milliseconds (30 seconds) */
+const CACHE_TTL = 30_000;
+
+interface CacheEntry {
+	repos: string[];
+	timestamp: number;
+}
+
+const repoCache = new Map<string, CacheEntry>();
+
+/**
+ * Check if a directory contains a .git directory (is a git repo)
+ */
+async function isGitRepo(dirPath: string): Promise<boolean> {
+	try {
+		const gitPath = join(dirPath, ".git");
+		await access(gitPath);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Recursively find all nested git repositories within a directory.
+ * Uses breadth-first search with depth limiting.
+ */
+async function findNestedReposRecursive({
+	basePath,
+	currentPath,
+	depth,
+	results,
+}: {
+	basePath: string;
+	currentPath: string;
+	depth: number;
+	results: string[];
+}): Promise<void> {
+	if (depth > MAX_SCAN_DEPTH) return;
+
+	try {
+		const entries = await readdir(currentPath, { withFileTypes: true });
+
+		for (const entry of entries) {
+			if (!entry.isDirectory()) continue;
+			if (EXCLUDED_DIRS.has(entry.name)) continue;
+
+			const entryPath = join(currentPath, entry.name);
+
+			// Skip if it's a symlink (security: prevent escaping worktree)
+			try {
+				const stats = await lstat(entryPath);
+				if (stats.isSymbolicLink()) continue;
+			} catch {
+				continue;
+			}
+
+			// Check if this directory is a git repo
+			if (await isGitRepo(entryPath)) {
+				// Don't descend into nested repos, just record them
+				results.push(entryPath);
+			} else {
+				// Recurse into subdirectories
+				await findNestedReposRecursive({
+					basePath,
+					currentPath: entryPath,
+					depth: depth + 1,
+					results,
+				});
+			}
+		}
+	} catch {
+		// Silently skip directories we can't read
+	}
+}
+
+/**
+ * Detects nested git repositories within a worktree.
+ *
+ * @param worktreePath - The root worktree path
+ * @returns Array of absolute paths to git repositories, root first
+ */
+export async function detectNestedRepos(
+	worktreePath: string,
+): Promise<string[]> {
+	// Check cache first
+	const cached = repoCache.get(worktreePath);
+	if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
+		return cached.repos;
+	}
+
+	const repos: string[] = [];
+
+	// Always include root if it's a git repo
+	if (await isGitRepo(worktreePath)) {
+		repos.push(worktreePath);
+	}
+
+	// Find nested repos
+	await findNestedReposRecursive({
+		basePath: worktreePath,
+		currentPath: worktreePath,
+		depth: 1,
+		results: repos,
+	});
+
+	// Update cache
+	repoCache.set(worktreePath, {
+		repos,
+		timestamp: Date.now(),
+	});
+
+	return repos;
+}
+
+/**
+ * Get a display name for a nested repo relative to the worktree root.
+ *
+ * @param worktreePath - The root worktree path
+ * @param repoPath - The absolute path to the nested repo
+ * @returns Display name like "(root)" or "packages/submodule"
+ */
+export function getRepoDisplayName(
+	worktreePath: string,
+	repoPath: string,
+): string {
+	if (repoPath === worktreePath) {
+		return "(root)";
+	}
+	return relative(worktreePath, repoPath);
+}
+
+/**
+ * Clear the nested repos cache for a specific worktree or all worktrees.
+ */
+export function clearNestedReposCache(worktreePath?: string): void {
+	if (worktreePath) {
+		repoCache.delete(worktreePath);
+	} else {
+		repoCache.clear();
+	}
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
@@ -74,6 +74,7 @@ export function FileViewerPane({
 	const [showUnsavedDialog, setShowUnsavedDialog] = useState(false);
 	const [isSavingAndSwitching, setIsSavingAndSwitching] = useState(false);
 	const pendingModeRef = useRef<FileViewerMode | null>(null);
+	// Extract file viewer state from pane
 	const filePath = fileViewer?.filePath ?? "";
 	const viewMode = fileViewer?.viewMode ?? "raw";
 	const isPinned = fileViewer?.isPinned ?? false;
@@ -82,6 +83,8 @@ export function FileViewerPane({
 	const oldPath = fileViewer?.oldPath;
 	const initialLine = fileViewer?.initialLine;
 	const initialColumn = fileViewer?.initialColumn;
+	// repoPath is set when viewing files from nested repos (monorepo support)
+	const repoPath = fileViewer?.repoPath;
 
 	const pinPane = useTabsStore((s) => s.pinPane);
 
@@ -95,6 +98,7 @@ export function FileViewerPane({
 		originalDiffContentRef,
 		draftContentRef,
 		setIsDirty,
+		repoPath,
 	});
 
 	const { rawFileData, isLoadingRaw, diffData, isLoadingDiff } = useFileContent(
@@ -108,6 +112,7 @@ export function FileViewerPane({
 			isDirty,
 			originalContentRef,
 			originalDiffContentRef,
+			repoPath,
 		},
 	);
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/hooks/useFileContent/useFileContent.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/hooks/useFileContent/useFileContent.ts
@@ -12,6 +12,8 @@ interface UseFileContentParams {
 	isDirty: boolean;
 	originalContentRef: React.MutableRefObject<string>;
 	originalDiffContentRef: React.MutableRefObject<string>;
+	/** Nested repo path for multi-repo support (if different from worktreePath) */
+	repoPath?: string;
 }
 
 export function useFileContent({
@@ -24,6 +26,7 @@ export function useFileContent({
 	isDirty,
 	originalContentRef,
 	originalDiffContentRef,
+	repoPath,
 }: UseFileContentParams) {
 	const { data: branchData } = electronTrpc.changes.getBranches.useQuery(
 		{ worktreePath },
@@ -31,14 +34,18 @@ export function useFileContent({
 	);
 	const effectiveBaseBranch = branchData?.defaultBranch ?? "main";
 
+	// Query working file for raw/rendered modes
+	// repoPath tells the backend which nested repo to read from (if any)
 	const { data: rawFileData, isLoading: isLoadingRaw } =
 		electronTrpc.changes.readWorkingFile.useQuery(
-			{ worktreePath, filePath },
+			{ worktreePath, filePath, repoPath },
 			{
 				enabled: viewMode !== "diff" && !!filePath && !!worktreePath,
 			},
 		);
 
+	// Query file contents for diff mode (original vs modified)
+	// repoPath ensures we query the correct nested repo's git history
 	const { data: diffData, isLoading: isLoadingDiff } =
 		electronTrpc.changes.getFileContents.useQuery(
 			{
@@ -49,6 +56,7 @@ export function useFileContent({
 				commitHash,
 				defaultBranch:
 					diffCategory === "against-base" ? effectiveBaseBranch : undefined,
+				repoPath,
 			},
 			{
 				enabled:

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/hooks/useFileSave/useFileSave.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/hooks/useFileSave/useFileSave.ts
@@ -14,6 +14,8 @@ interface UseFileSaveParams {
 	originalDiffContentRef: MutableRefObject<string>;
 	draftContentRef: MutableRefObject<string | null>;
 	setIsDirty: (dirty: boolean) => void;
+	/** Nested repo path for multi-repo support (if different from worktreePath) */
+	repoPath?: string;
 }
 
 export function useFileSave({
@@ -26,6 +28,7 @@ export function useFileSave({
 	originalDiffContentRef,
 	draftContentRef,
 	setIsDirty,
+	repoPath,
 }: UseFileSaveParams) {
 	const savingFromRawRef = useRef(false);
 	const savingDiffContentRef = useRef<string | null>(null);
@@ -78,8 +81,9 @@ export function useFileSave({
 			worktreePath,
 			filePath,
 			content: editorRef.current.getValue(),
+			repoPath,
 		});
-	}, [worktreePath, filePath, saveFileMutation, editorRef]);
+	}, [worktreePath, filePath, saveFileMutation, editorRef, repoPath]);
 
 	const handleSaveDiff = useCallback(
 		async (content: string) => {
@@ -90,9 +94,10 @@ export function useFileSave({
 				worktreePath,
 				filePath,
 				content,
+				repoPath,
 			});
 		},
-		[worktreePath, filePath, saveFileMutation],
+		[worktreePath, filePath, saveFileMutation, repoPath],
 	);
 
 	return {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/RepoSection/RepoSection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/RepoSection/RepoSection.tsx
@@ -1,0 +1,222 @@
+import { Button } from "@superset/ui/button";
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "@superset/ui/collapsible";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { cn } from "@superset/ui/utils";
+import type { ReactNode } from "react";
+import { HiChevronRight, HiMiniMinus, HiMiniPlus } from "react-icons/hi2";
+import { LuGitBranch, LuUndo2 } from "react-icons/lu";
+import type {
+	ChangeCategory,
+	ChangedFile,
+	NestedRepoStatus,
+} from "shared/changes-types";
+import { CategorySection } from "../CategorySection";
+import { FileList } from "../FileList";
+
+interface RepoSectionProps {
+	repo: NestedRepoStatus;
+	worktreePath: string;
+	isExpanded: boolean;
+	onToggle: () => void;
+	selectedFile: ChangedFile | null;
+	selectedCommitHash: string | null;
+	fileListViewMode: "grouped" | "tree";
+	expandedSections: Record<ChangeCategory, boolean>;
+	onToggleSection: (section: ChangeCategory) => void;
+	onFileSelect: (
+		file: ChangedFile,
+		category: ChangeCategory,
+		repoPath: string,
+	) => void;
+	onStageFile: (file: ChangedFile, repoPath: string) => void;
+	onUnstageFile: (file: ChangedFile, repoPath: string) => void;
+	onDiscard: (file: ChangedFile, repoPath: string) => void;
+	onStageAll: (repoPath: string) => void;
+	onUnstageAll: (repoPath: string) => void;
+	onDiscardAllUnstaged: (repoPath: string) => void;
+	onDiscardAllStaged: (repoPath: string) => void;
+	isStaging: boolean;
+	isUnstaging: boolean;
+	isDiscarding: boolean;
+	isExpandedView?: boolean;
+	commitInput: ReactNode;
+}
+
+export function RepoSection({
+	repo,
+	worktreePath,
+	isExpanded,
+	onToggle,
+	selectedFile,
+	selectedCommitHash,
+	fileListViewMode,
+	expandedSections,
+	onToggleSection,
+	onFileSelect,
+	onStageFile,
+	onUnstageFile,
+	onDiscard,
+	onStageAll,
+	onUnstageAll,
+	onDiscardAllUnstaged,
+	onDiscardAllStaged,
+	isStaging,
+	isUnstaging,
+	isDiscarding,
+	isExpandedView,
+	commitInput,
+}: RepoSectionProps) {
+	const combinedUnstaged = [...repo.unstaged, ...repo.untracked];
+	const totalChanges =
+		repo.staged.length + repo.unstaged.length + repo.untracked.length;
+
+	return (
+		<Collapsible
+			open={isExpanded}
+			onOpenChange={onToggle}
+			className="border-b border-border last:border-b-0"
+		>
+			<div className="group flex items-center min-w-0 bg-muted/30">
+				<CollapsibleTrigger
+					className={cn(
+						"flex-1 flex items-center gap-1.5 px-2 py-2 text-left min-w-0",
+						"hover:bg-accent/30 cursor-pointer transition-colors",
+					)}
+				>
+					<HiChevronRight
+						className={cn(
+							"size-3.5 text-muted-foreground shrink-0 transition-transform duration-150",
+							isExpanded && "rotate-90",
+						)}
+					/>
+					<LuGitBranch className="size-3.5 text-muted-foreground shrink-0" />
+					<span className="text-xs font-medium truncate">{repo.repoName}</span>
+					{totalChanges > 0 && (
+						<span className="text-[10px] text-muted-foreground shrink-0 ml-auto">
+							{totalChanges} change{totalChanges !== 1 ? "s" : ""}
+						</span>
+					)}
+				</CollapsibleTrigger>
+			</div>
+
+			<CollapsibleContent className="min-w-0 overflow-hidden">
+				{commitInput}
+
+				<CategorySection
+					title="Staged"
+					count={repo.staged.length}
+					isExpanded={expandedSections.staged}
+					onToggle={() => onToggleSection("staged")}
+					actions={
+						<div className="flex items-center gap-0.5">
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<Button
+										variant="ghost"
+										size="icon"
+										className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity"
+										onClick={() => onDiscardAllStaged(repo.repoPath)}
+										disabled={isDiscarding}
+									>
+										<LuUndo2 className="w-3.5 h-3.5" />
+									</Button>
+								</TooltipTrigger>
+								<TooltipContent side="bottom">
+									Discard all staged
+								</TooltipContent>
+							</Tooltip>
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<Button
+										variant="ghost"
+										size="icon"
+										className="h-6 w-6"
+										onClick={() => onUnstageAll(repo.repoPath)}
+										disabled={isUnstaging}
+									>
+										<HiMiniMinus className="w-4 h-4" />
+									</Button>
+								</TooltipTrigger>
+								<TooltipContent side="bottom">Unstage all</TooltipContent>
+							</Tooltip>
+						</div>
+					}
+				>
+					<FileList
+						files={repo.staged}
+						viewMode={fileListViewMode}
+						selectedFile={selectedFile}
+						selectedCommitHash={selectedCommitHash}
+						onFileSelect={(file) => onFileSelect(file, "staged", repo.repoPath)}
+						onUnstage={(file) => onUnstageFile(file, repo.repoPath)}
+						isActioning={isUnstaging}
+						worktreePath={worktreePath}
+						category="staged"
+						isExpandedView={isExpandedView}
+					/>
+				</CategorySection>
+
+				<CategorySection
+					title="Unstaged"
+					count={combinedUnstaged.length}
+					isExpanded={expandedSections.unstaged}
+					onToggle={() => onToggleSection("unstaged")}
+					actions={
+						<div className="flex items-center gap-0.5">
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<Button
+										variant="ghost"
+										size="icon"
+										className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity"
+										onClick={() => onDiscardAllUnstaged(repo.repoPath)}
+										disabled={isDiscarding}
+									>
+										<LuUndo2 className="w-3.5 h-3.5" />
+									</Button>
+								</TooltipTrigger>
+								<TooltipContent side="bottom">
+									Discard all unstaged
+								</TooltipContent>
+							</Tooltip>
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<Button
+										variant="ghost"
+										size="icon"
+										className="h-6 w-6"
+										onClick={() => onStageAll(repo.repoPath)}
+										disabled={isStaging}
+									>
+										<HiMiniPlus className="w-4 h-4" />
+									</Button>
+								</TooltipTrigger>
+								<TooltipContent side="bottom">Stage all</TooltipContent>
+							</Tooltip>
+						</div>
+					}
+				>
+					<FileList
+						files={combinedUnstaged}
+						viewMode={fileListViewMode}
+						selectedFile={selectedFile}
+						selectedCommitHash={selectedCommitHash}
+						onFileSelect={(file) =>
+							onFileSelect(file, "unstaged", repo.repoPath)
+						}
+						onStage={(file) => onStageFile(file, repo.repoPath)}
+						isActioning={isStaging || isDiscarding}
+						worktreePath={worktreePath}
+						onDiscard={(file) => onDiscard(file, repo.repoPath)}
+						category="unstaged"
+						isExpandedView={isExpandedView}
+					/>
+				</CategorySection>
+			</CollapsibleContent>
+		</Collapsible>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/RepoSection/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/RepoSection/index.ts
@@ -1,0 +1,1 @@
+export { RepoSection } from "./RepoSection";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
@@ -94,14 +94,25 @@ export function RightSidebar() {
 		[worktreePath, trpcUtils],
 	);
 
+	/**
+	 * Opens a file in the diff viewer pane.
+	 * repoPath is passed for nested repo support - it tells the backend
+	 * which git repository to query for the file contents.
+	 */
 	const handleFileOpenPane = useCallback(
-		(file: ChangedFile, category: ChangeCategory, commitHash?: string) => {
+		(
+			file: ChangedFile,
+			category: ChangeCategory,
+			commitHash?: string,
+			repoPath?: string,
+		) => {
 			if (!workspaceId || !worktreePath) return;
 			addFileViewerPane(workspaceId, {
 				filePath: file.path,
 				diffCategory: category,
 				commitHash,
 				oldPath: file.oldPath,
+				repoPath,
 			});
 			invalidateFileContent(file.path);
 		},

--- a/apps/desktop/src/renderer/stores/changes/store.ts
+++ b/apps/desktop/src/renderer/stores/changes/store.ts
@@ -12,6 +12,7 @@ interface SelectedFileState {
 	file: ChangedFile;
 	category: ChangeCategory;
 	commitHash: string | null;
+	repoPath?: string;
 }
 
 interface ChangesState {
@@ -22,12 +23,14 @@ interface ChangesState {
 	baseBranch: string | null;
 	showRenderedMarkdown: Record<string, boolean>;
 	hideUnchangedRegions: boolean;
+	expandedRepos: Record<string, boolean>;
 
 	selectFile: (
 		worktreePath: string,
 		file: ChangedFile | null,
 		category?: ChangeCategory,
 		commitHash?: string | null,
+		repoPath?: string,
 	) => void;
 	getSelectedFile: (worktreePath: string) => SelectedFileState | null;
 	setViewMode: (mode: DiffViewMode) => void;
@@ -38,6 +41,8 @@ interface ChangesState {
 	toggleRenderedMarkdown: (worktreePath: string) => void;
 	getShowRenderedMarkdown: (worktreePath: string) => boolean;
 	toggleHideUnchangedRegions: () => void;
+	toggleRepoExpanded: (repoPath: string) => void;
+	isRepoExpanded: (repoPath: string) => boolean;
 	reset: (worktreePath: string) => void;
 }
 
@@ -54,6 +59,7 @@ const initialState = {
 	baseBranch: null,
 	showRenderedMarkdown: {} as Record<string, boolean>,
 	hideUnchangedRegions: false,
+	expandedRepos: {} as Record<string, boolean>,
 };
 
 export const useChangesStore = create<ChangesState>()(
@@ -62,7 +68,7 @@ export const useChangesStore = create<ChangesState>()(
 			(set, get) => ({
 				...initialState,
 
-				selectFile: (worktreePath, file, category, commitHash) => {
+				selectFile: (worktreePath, file, category, commitHash, repoPath) => {
 					const { selectedFiles } = get();
 					set({
 						selectedFiles: {
@@ -72,6 +78,7 @@ export const useChangesStore = create<ChangesState>()(
 										file,
 										category: category ?? "against-base",
 										commitHash: commitHash ?? null,
+										repoPath,
 									}
 								: null,
 						},
@@ -132,6 +139,21 @@ export const useChangesStore = create<ChangesState>()(
 					set({ hideUnchangedRegions: !get().hideUnchangedRegions });
 				},
 
+				toggleRepoExpanded: (repoPath) => {
+					const { expandedRepos } = get();
+					set({
+						expandedRepos: {
+							...expandedRepos,
+							[repoPath]: expandedRepos[repoPath] === false,
+						},
+					});
+				},
+
+				isRepoExpanded: (repoPath) => {
+					// Default to expanded (true) if not explicitly set
+					return get().expandedRepos[repoPath] !== false;
+				},
+
 				reset: (worktreePath) => {
 					const { selectedFiles } = get();
 					set({
@@ -152,6 +174,7 @@ export const useChangesStore = create<ChangesState>()(
 					baseBranch: state.baseBranch,
 					showRenderedMarkdown: state.showRenderedMarkdown,
 					hideUnchangedRegions: state.hideUnchangedRegions,
+					expandedRepos: state.expandedRepos,
 				}),
 			},
 		),

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -604,6 +604,9 @@ export const useTabsStore = create<TabsStore>()(
 							viewMode: options.viewMode,
 						});
 
+						// Update pane state with new file info
+						// repoPath is preserved for nested repo support - it tells
+						// the file content queries which git repo to read from
 						set({
 							panes: {
 								...state.panes,
@@ -620,6 +623,7 @@ export const useTabsStore = create<TabsStore>()(
 										oldPath: options.oldPath,
 										initialLine: options.line,
 										initialColumn: options.column,
+										repoPath: options.repoPath,
 									},
 								},
 							},

--- a/apps/desktop/src/renderer/stores/tabs/types.ts
+++ b/apps/desktop/src/renderer/stores/tabs/types.ts
@@ -57,6 +57,8 @@ export interface AddFileViewerPaneOptions {
 	column?: number;
 	/** If true, opens pinned (permanent). If false/undefined, opens in preview mode (can be replaced) */
 	isPinned?: boolean;
+	/** Nested repo path for multi-repo support (if different from worktreePath) */
+	repoPath?: string;
 }
 
 /**

--- a/apps/desktop/src/renderer/stores/tabs/utils.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils.ts
@@ -172,6 +172,8 @@ export interface CreateFileViewerPaneOptions {
 	line?: number;
 	/** Column to scroll to (raw mode only) */
 	column?: number;
+	/** Nested repo path for multi-repo support (if different from worktreePath) */
+	repoPath?: string;
 }
 
 /**
@@ -189,6 +191,9 @@ export const createFileViewerPane = (
 		viewMode: options.viewMode,
 	});
 
+	// Build file viewer state
+	// repoPath enables nested repo support - when set, file content queries
+	// will use this path instead of worktreePath to access the correct git repo
 	const fileViewer: FileViewerState = {
 		filePath: options.filePath,
 		viewMode: resolvedViewMode,
@@ -199,6 +204,7 @@ export const createFileViewerPane = (
 		oldPath: options.oldPath,
 		initialLine: options.line,
 		initialColumn: options.column,
+		repoPath: options.repoPath,
 	};
 
 	// Use filename for display name

--- a/apps/desktop/src/shared/changes-types.ts
+++ b/apps/desktop/src/shared/changes-types.ts
@@ -71,3 +71,18 @@ export interface FileContents {
 	modified: string; // Modified content (after changes)
 	language: string; // Detected language for syntax highlighting
 }
+
+/** Status for a nested repository within a worktree */
+export interface NestedRepoStatus extends GitChangesStatus {
+	repoPath: string; // Absolute path to the nested repo
+	repoName: string; // Display name (relative from worktree root, or "(root)")
+	isRoot: boolean; // true for main worktree repo
+}
+
+/** Multi-repo git changes status for a worktree with nested repos */
+export interface MultiRepoGitChangesStatus {
+	repos: NestedRepoStatus[];
+	totalStaged: number;
+	totalUnstaged: number;
+	totalUntracked: number;
+}

--- a/apps/desktop/src/shared/tabs-types.ts
+++ b/apps/desktop/src/shared/tabs-types.ts
@@ -100,6 +100,8 @@ export interface FileViewerState {
 	initialLine?: number;
 	/** Initial column to scroll to (raw mode only, transient - applied once) */
 	initialColumn?: number;
+	/** Nested repo path for multi-repo support (if different from worktreePath) */
+	repoPath?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds support for nested git repositories in the Source Control panel, enabling monorepo workflows where subdirectories contain separate `.git` directories.

Closes #1003

## Screenshot

<img width="263" height="863" alt="Screenshot 2026-02-02 at 11 23 02 AM" src="https://github.com/user-attachments/assets/2b59ce12-bf55-412e-b55e-9da307a82942" />

## What Changed

### Backend
- **Auto-detection**: Scans for nested `.git` directories (depth limit: 5, excludes `node_modules`, `vendor`, `dist`, etc.)
- **Multi-repo status**: New `getMultiRepoStatus` procedure returns status for all detected repos
- **Security**: Added `assertValidNestedRepo` validation and `secureFs` nested-repo-aware methods
- **Git operations**: All staging, commit, push, pull operations now accept optional `repoPath`

### Frontend
- **Multi-repo view**: Shows collapsible sections per repository with change counts
- **Per-repo commits**: Each nested repo has its own commit input and push/pull controls
- **Diff viewer**: Files from nested repos now display diffs correctly via `repoPath` threading

### New Files
- `src/lib/trpc/routers/changes/utils/nested-repos.ts` - Auto-detection logic with caching
- `src/renderer/.../RepoSection/RepoSection.tsx` - Per-repo UI section component

## How to Test

1. Create a test monorepo:
   ```bash
   mkdir -p /tmp/test-monorepo/nested-repo
   cd /tmp/test-monorepo && git init && echo "root" > root.txt && git add . && git commit -m "init"
   cd nested-repo && git init && echo "nested" > nested.txt && git add . && git commit -m "init nested"
   # Make changes in both
   echo "change" >> /tmp/test-monorepo/root.txt
   echo "change" >> /tmp/test-monorepo/nested-repo/nested.txt
   ```

2. Open `/tmp/test-monorepo` in Superset
3. Verify: Both repos appear in Source Control panel with collapsible headers
4. Test: Stage/unstage files in each repo independently
5. Test: Click a file in nested repo → diff should display correctly
6. Test: Commit to nested repo → commit goes to correct repo
7. Test: Push/pull works independently per repo

## Technical Notes

- Detection results are cached for 30 seconds to minimize filesystem scanning
- Security validation ensures nested repo paths cannot escape the parent worktree
- Single-repo workspaces render the same UI as before (backward compatible)

## Limitations (Future Work)

- "Against base" and "Commits" sections only shown for root repo currently
- No submodule-specific handling (treated as regular nested repos)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for nested repositories: perform Git operations, view file history, and manage changes across multiple repositories within a single workspace.
  * Multi-repository status view displaying aggregated changes and per-repository breakdowns.
  * Repository-aware file operations enabling targeted edits and interactions within nested repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->