### PR TITLE
feat(marketing): add GitHub releases link to changelog page

### DIFF
--- a/apps/marketing/src/app/changelog/page.tsx
+++ b/apps/marketing/src/app/changelog/page.tsx
@@ -1,4 +1,6 @@
+import { COMPANY } from "@superset/shared/constants";
 import type { Metadata } from "next";
+import { FaGithub } from "react-icons/fa";
 import { GridCross } from "@/app/blog/components/GridCross";
 import { getChangelogEntries } from "@/lib/changelog";
 import { ChangelogEntry } from "./components/ChangelogEntry";
@@ -59,6 +61,16 @@ export default async function ChangelogPage() {
 					<p className="text-muted-foreground mt-3 max-w-lg">
 						The latest updates, improvements, and new features in Superset.
 					</p>
+					<a
+						href={`${COMPANY.GITHUB_URL}/releases`}
+						target="_blank"
+						rel="noopener noreferrer"
+						className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mt-4"
+					>
+						<FaGithub className="size-4" />
+						View releases on GitHub
+						<span aria-hidden="true">&rarr;</span>
+					</a>
 
 					<GridCross className="bottom-0 left-0" />
 					<GridCross className="bottom-0 right-0" />


### PR DESCRIPTION
## Summary
- Adds a "View releases on GitHub →" link with GitHub icon to the changelog page header
- Users arriving from the desktop app's "See changes" update toast can now find detailed release notes on GitHub

## Test plan
- [x] Lint passes
- [x] Tests pass
- [x] Typecheck passes
- [ ] Verify link renders correctly on `/changelog` page
- [ ] Verify link opens GitHub releases in new tab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "View releases on GitHub" link in the changelog page header, enabling users to quickly access the latest project releases directly from the GitHub repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->