### PR TITLE
feat(desktop): Allow dragging files into terminal

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -283,9 +283,17 @@ export const Terminal = ({ paneId, tabId, workspaceId }: TerminalProps) => {
 	const handleDrop = (event: React.DragEvent) => {
 		event.preventDefault();
 		const files = Array.from(event.dataTransfer.files);
-		if (files.length === 0) return;
-		const paths = files.map((file) => window.webUtils.getPathForFile(file));
-		const text = shellEscapePaths(paths);
+		let text: string;
+		if (files.length > 0) {
+			// Native file drop (from Finder, etc.)
+			const paths = files.map((file) => window.webUtils.getPathForFile(file));
+			text = shellEscapePaths(paths);
+		} else {
+			// Internal drag (from file tree) - path is in text/plain
+			const plainText = event.dataTransfer.getData("text/plain");
+			if (!plainText) return;
+			text = shellEscapePaths([plainText]);
+		}
 		if (!isExitedRef.current) {
 			writeRef.current({ paneId, data: text });
 		}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileItem/FileItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileItem/FileItem.tsx
@@ -29,7 +29,7 @@ import {
 } from "react-icons/lu";
 import type { ChangeCategory, ChangedFile } from "shared/changes-types";
 import { createFileKey, useScrollContext } from "../../../../ChangesContent";
-import { usePathActions } from "../../hooks";
+import { useFileDrag, usePathActions } from "../../hooks";
 import { getStatusColor, getStatusIndicator } from "../../utils";
 
 interface FileItemProps {
@@ -106,6 +106,8 @@ export function FileItem({
 			cwd: worktreePath,
 		});
 
+	const fileDragProps = useFileDrag({ absolutePath });
+
 	const handleClick = useCallback(() => {
 		if (clickTimeoutRef.current) {
 			clearTimeout(clickTimeoutRef.current);
@@ -161,6 +163,7 @@ export function FileItem({
 
 	const fileContent = (
 		<div
+			{...fileDragProps}
 			className={cn(
 				"group w-full flex items-stretch gap-1 px-1.5 text-left rounded-sm",
 				"hover:bg-accent/50 cursor-pointer transition-colors overflow-hidden",

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/hooks/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/hooks/index.ts
@@ -1,1 +1,2 @@
+export { useFileDrag } from "./useFileDrag";
 export { usePathActions } from "./usePathActions";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/hooks/useFileDrag.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/hooks/useFileDrag.ts
@@ -1,0 +1,24 @@
+import { useCallback } from "react";
+
+interface UseFileDragProps {
+	absolutePath: string | null;
+}
+
+export function useFileDrag({ absolutePath }: UseFileDragProps) {
+	const handleDragStart = useCallback(
+		(e: React.DragEvent) => {
+			if (!absolutePath) {
+				e.preventDefault();
+				return;
+			}
+			e.dataTransfer.setData("text/plain", absolutePath);
+			e.dataTransfer.effectAllowed = "copy";
+		},
+		[absolutePath],
+	);
+
+	return {
+		draggable: Boolean(absolutePath),
+		onDragStart: handleDragStart,
+	};
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileSearchResultItem/FileSearchResultItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileSearchResultItem/FileSearchResultItem.tsx
@@ -17,7 +17,7 @@ import {
 	LuTrash2,
 } from "react-icons/lu";
 import type { DirectoryEntry } from "shared/file-tree-types";
-import { usePathActions } from "../../../ChangesView/hooks";
+import { useFileDrag, usePathActions } from "../../../ChangesView/hooks";
 import { SEARCH_RESULT_ROW_HEIGHT } from "../../constants";
 import { getFileIcon } from "../../utils";
 
@@ -83,6 +83,8 @@ export function FileSearchResultItem({
 			cwd: worktreePath,
 		});
 
+	const fileDragProps = useFileDrag({ absolutePath: entry.path });
+
 	const handleClick = () => {
 		if (!entry.isDirectory) {
 			onActivate(entry);
@@ -104,6 +106,7 @@ export function FileSearchResultItem({
 
 	const itemContent = (
 		<div
+			{...fileDragProps}
 			role="treeitem"
 			tabIndex={0}
 			style={{ height: SEARCH_RESULT_ROW_HEIGHT }}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileTreeItem/FileTreeItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileTreeItem/FileTreeItem.tsx
@@ -20,7 +20,7 @@ import {
 	LuTrash2,
 } from "react-icons/lu";
 import type { DirectoryEntry } from "shared/file-tree-types";
-import { usePathActions } from "../../../ChangesView/hooks";
+import { useFileDrag, usePathActions } from "../../../ChangesView/hooks";
 import { getFileIcon } from "../../utils";
 
 interface FileTreeItemProps {
@@ -66,6 +66,8 @@ export function FileTreeItem({
 			cwd: worktreePath,
 		});
 
+	const fileDragProps = useFileDrag({ absolutePath: entry.path });
+
 	const handleClick = (e: React.MouseEvent) => {
 		e.stopPropagation();
 		if (isFolder) {
@@ -102,6 +104,7 @@ export function FileTreeItem({
 	const itemContent = (
 		<div
 			{...item.getProps()}
+			{...fileDragProps}
 			data-item-id={item.getId()}
 			style={{
 				height: rowHeight,

--- a/bun.lock
+++ b/bun.lock
@@ -131,7 +131,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "0.0.64",
+      "version": "0.0.65",
       "dependencies": {
         "@better-auth/stripe": "1.4.17",
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Description

Add drag-and-drop support to the terminal for files from the file tree, search results, and changes tabs. When files are dragged into the terminal, their paths are automatically shell-escaped for safe terminal use.

## Type of Change

- [x] New feature
- [x] Refactor

## Implementation

- Created reusable `useFileDrag` hook to eliminate duplication
- Terminal now accepts both native file drops (from Finder) and internal file drags
- Paths are shell-escaped in both cases for consistency

## Testing

Drag files from:
- Files tab (tree view)
- Files tab (search results)  
- Changes tab (staged/unstaged files)

Drop into any terminal pane to insert the shell-escaped path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Files can now be dragged from file views for use in external applications
  * Enhanced terminal drop handling to better distinguish between file and text input operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->