### PR TITLE
Fix duplicate brand name in title tags

### DIFF
--- a/apps/marketing/src/app/blog/[slug]/page.tsx
+++ b/apps/marketing/src/app/blog/[slug]/page.tsx
@@ -57,7 +57,7 @@ export async function generateMetadata({
 	const url = `${COMPANY.MARKETING_URL}/blog/${slug}`;
 
 	return {
-		title: `${post.title} | ${COMPANY.NAME} Blog`,
+		title: post.title,
 		description: post.description,
 		alternates: {
 			canonical: url,

--- a/apps/marketing/src/app/blog/page.tsx
+++ b/apps/marketing/src/app/blog/page.tsx
@@ -4,7 +4,7 @@ import { BlogCard } from "./components/BlogCard";
 import { GridCross } from "./components/GridCross";
 
 export const metadata: Metadata = {
-	title: "Blog | Superset",
+	title: "Blog",
 	description:
 		"News, updates, and insights from the Superset team about parallel coding agents and developer productivity.",
 	alternates: {

--- a/apps/marketing/src/app/changelog/[slug]/page.tsx
+++ b/apps/marketing/src/app/changelog/[slug]/page.tsx
@@ -55,7 +55,7 @@ export async function generateMetadata({
 	const url = `${COMPANY.MARKETING_URL}/changelog/${slug}`;
 
 	return {
-		title: `${entry.title} | ${COMPANY.NAME} Changelog`,
+		title: entry.title,
 		description: entry.description,
 		alternates: {
 			canonical: url,

--- a/apps/marketing/src/app/changelog/page.tsx
+++ b/apps/marketing/src/app/changelog/page.tsx
@@ -4,7 +4,7 @@ import { getChangelogEntries } from "@/lib/changelog";
 import { ChangelogEntry } from "./components/ChangelogEntry";
 
 export const metadata: Metadata = {
-	title: "Changelog | Superset",
+	title: "Changelog",
 	description:
 		"The latest updates, improvements, and new features in Superset.",
 	alternates: {

--- a/apps/marketing/src/app/community/page.tsx
+++ b/apps/marketing/src/app/community/page.tsx
@@ -3,7 +3,7 @@ import { ArrowUpRight } from "lucide-react";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-	title: "Community - Superset",
+	title: "Community",
 	description:
 		"Join the Superset community to get help, share ideas, and stay up to date with the latest news and updates.",
 };


### PR DESCRIPTION
## Summary
- Removes redundant `" | Superset"` suffix from page-level `title` metadata in blog, changelog, and community pages
- The root layout already applies a `"%s | Superset"` template, so page titles only need the page name (e.g. `"Blog"` not `"Blog | Superset"`)
- Also fixes dynamic blog post and changelog entry pages which appended `" | Superset Blog"` / `" | Superset Changelog"`

**Before:** `Blog | Superset | Superset`, `Changelog | Superset | Superset`, `Community - Superset | Superset`
**After:** `Blog | Superset`, `Changelog | Superset`, `Community | Superset`

## Test plan
- [ ] Verify `/blog` title renders as `"Blog | Superset"`
- [ ] Verify `/changelog` title renders as `"Changelog | Superset"`
- [ ] Verify `/community` title renders as `"Community | Superset"`
- [ ] Verify individual blog post pages render as `"Post Title | Superset"`
- [ ] Verify individual changelog entry pages render as `"Entry Title | Superset"`
- [ ] Verify OpenGraph/Twitter meta titles are unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Simplified page titles across the marketing site. The following pages now display more concise titles in browser tabs and search engine results: individual blog posts, blog index page, changelog entry pages, changelog index page, and the community page. This creates a cleaner, more consistent presentation across the site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->