### PR TITLE
feat(desktop): improve file tree icons with VS Code style icons

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils/file-icons.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils/file-icons.ts
@@ -1,22 +1,5 @@
 import type { IconType } from "react-icons";
 import {
-	VscFile,
-	VscFileCode,
-	VscFileMedia,
-	VscFilePdf,
-	VscFileZip,
-	VscFolder,
-	VscFolderOpened,
-	VscGear,
-	VscJson,
-	VscLock,
-	VscMarkdown,
-	VscPackage,
-	VscSourceControl,
-	VscSymbolMisc,
-	VscTerminalBash,
-} from "react-icons/vsc";
-import {
 	SiC,
 	SiCplusplus,
 	SiCss3,
@@ -36,6 +19,23 @@ import {
 	SiVuedotjs,
 	SiYaml,
 } from "react-icons/si";
+import {
+	VscFile,
+	VscFileCode,
+	VscFileMedia,
+	VscFilePdf,
+	VscFileZip,
+	VscFolder,
+	VscFolderOpened,
+	VscGear,
+	VscJson,
+	VscLock,
+	VscMarkdown,
+	VscPackage,
+	VscSourceControl,
+	VscSymbolMisc,
+	VscTerminalBash,
+} from "react-icons/vsc";
 
 interface FileIconConfig {
 	icon: IconType;
@@ -228,7 +228,7 @@ const FILENAME_ICONS: Record<string, FileIconConfig> = {
 	"requirements.txt": { icon: SiPython, color: "text-yellow-500" },
 	"pyproject.toml": { icon: SiPython, color: "text-yellow-500" },
 	"setup.py": { icon: SiPython, color: "text-yellow-500" },
-	"Pipfile": { icon: SiPython, color: "text-yellow-500" },
+	Pipfile: { icon: SiPython, color: "text-yellow-500" },
 	"Pipfile.lock": { icon: SiPython, color: "text-yellow-400" },
 	// GraphQL
 	"schema.graphql": { icon: SiGraphql, color: "text-pink-500" },

--- a/bun.lock
+++ b/bun.lock
@@ -131,7 +131,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "0.0.64",
+      "version": "0.0.65",
       "dependencies": {
         "@better-auth/stripe": "1.4.17",
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Summary
- Replace basic Lucide line icons with VS Code icons (`react-icons/vsc`) for a more polished look
- Use branded Simple Icons for language-specific files (TypeScript, JavaScript, React, Python, etc.)
- Add more folder icon mappings for common directories (app, apps, packages, config, scripts, etc.)
- Add support for additional config files (biome.json, turbo.json, .prettierrc, .eslintrc variants)

## Test plan
- [ ] Open the file tree sidebar in a workspace
- [ ] Verify folder icons look better (filled VS Code style instead of thin lines)
- [ ] Verify file icons are recognizable for common file types (.ts, .tsx, .js, .json, .md, etc.)
- [ ] Check that special folders (src, components, node_modules, .git) have distinct colors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Switched the file view to a new icon set and refreshed appearances for files, folders and folder states (open/closed/default).
  * Updated icons and colors across many languages, frameworks, config and build files, documentation, media types, archives and tooling.
  * Added and standardized language- and filename-specific icons (including language aliases) for clearer visual differentiation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->