### PR TITLE
fix(marketing): add missing canonicals, FAQPage schema, breadcrumbs, and sitemap entries

### DIFF
--- a/apps/marketing/src/app/blog/[slug]/page.tsx
+++ b/apps/marketing/src/app/blog/[slug]/page.tsx
@@ -2,7 +2,7 @@ import { COMPANY } from "@superset/shared/constants";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { MDXRemote } from "next-mdx-remote/rsc";
-import { ArticleJsonLd } from "@/components/JsonLd";
+import { ArticleJsonLd, BreadcrumbJsonLd } from "@/components/JsonLd";
 import {
 	extractToc,
 	getAllSlugs,
@@ -41,6 +41,13 @@ export default async function BlogPostPage({ params }: PageProps) {
 				publishedTime={new Date(post.date).toISOString()}
 				url={url}
 				image={post.image}
+			/>
+			<BreadcrumbJsonLd
+				items={[
+					{ name: "Home", url: COMPANY.MARKETING_URL },
+					{ name: "Blog", url: `${COMPANY.MARKETING_URL}/blog` },
+					{ name: post.title, url },
+				]}
 			/>
 			<BlogPostLayout post={post} toc={toc} relatedPosts={relatedPosts}>
 				<MDXRemote source={post.content} components={mdxComponents} />

--- a/apps/marketing/src/app/changelog/[slug]/page.tsx
+++ b/apps/marketing/src/app/changelog/[slug]/page.tsx
@@ -2,7 +2,7 @@ import { COMPANY } from "@superset/shared/constants";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { MDXRemote } from "next-mdx-remote/rsc";
-import { ArticleJsonLd } from "@/components/JsonLd";
+import { ArticleJsonLd, BreadcrumbJsonLd } from "@/components/JsonLd";
 import { getAllChangelogSlugs, getChangelogEntry } from "@/lib/changelog";
 import { changelogMdxComponents } from "../components/ChangelogEntry/changelog-mdx-components";
 import { ChangelogEntryLayout } from "./components/ChangelogEntryLayout";
@@ -30,6 +30,13 @@ export default async function ChangelogEntryPage({ params }: PageProps) {
 				publishedTime={new Date(entry.date).toISOString()}
 				url={url}
 				image={entry.image}
+			/>
+			<BreadcrumbJsonLd
+				items={[
+					{ name: "Home", url: COMPANY.MARKETING_URL },
+					{ name: "Changelog", url: `${COMPANY.MARKETING_URL}/changelog` },
+					{ name: entry.title, url },
+				]}
 			/>
 			<ChangelogEntryLayout entry={entry}>
 				<MDXRemote source={entry.content} components={changelogMdxComponents} />

--- a/apps/marketing/src/app/community/page.tsx
+++ b/apps/marketing/src/app/community/page.tsx
@@ -6,6 +6,9 @@ export const metadata: Metadata = {
 	title: "Community",
 	description:
 		"Join the Superset community to get help, share ideas, and stay up to date with the latest news and updates.",
+	alternates: {
+		canonical: `${COMPANY.MARKETING_URL}/community`,
+	},
 };
 
 interface GitHubRepoResponse {

--- a/apps/marketing/src/app/components/FAQSection/FAQSection.tsx
+++ b/apps/marketing/src/app/components/FAQSection/FAQSection.tsx
@@ -3,39 +3,8 @@
 import { AnimatePresence, motion } from "framer-motion";
 import { useState } from "react";
 import { HiPlus } from "react-icons/hi2";
-
-interface FAQItem {
-	question: string;
-	answer: string;
-}
-
-const FAQ_ITEMS: FAQItem[] = [
-	{
-		question: "I already use an IDE like Cursor, is this for me?",
-		answer:
-			"Superset is designed to work with your existing tool, we natively support deep-linking to IDEs like Cursor so you can open your workspaces and files in your IDE.",
-	},
-	{
-		question: "Which AI coding agents are supported?",
-		answer:
-			"Superset works with any CLI-based coding agent including Claude Code, OpenCode, OpenAI Codex, and more. If it runs in a terminal, it runs in Superset.",
-	},
-	{
-		question: "How does the parallel agent system work?",
-		answer:
-			"Each agent runs in its own isolated Git worktree, which means they can work on different branches or features simultaneously without conflicts. You can monitor all agents in real-time and switch between them instantly.",
-	},
-	{
-		question: "Is Superset free to use?",
-		answer:
-			"Yes, Superset is completely free and open source. You can self-host it, modify it, and use it however you like. The source code is available on GitHub under a permissive license.",
-	},
-	{
-		question: "Can I use my own API keys?",
-		answer:
-			"Absolutely. Superset doesn't proxy any API calls. You use your own API keys directly with whatever AI providers you choose. This means you have full control over costs and usage.",
-	},
-];
+import type { FAQItem } from "./constants";
+import { FAQ_ITEMS } from "./constants";
 
 function FAQAccordionItem({
 	item,

--- a/apps/marketing/src/app/components/FAQSection/constants.ts
+++ b/apps/marketing/src/app/components/FAQSection/constants.ts
@@ -1,0 +1,32 @@
+export interface FAQItem {
+	question: string;
+	answer: string;
+}
+
+export const FAQ_ITEMS: FAQItem[] = [
+	{
+		question: "I already use an IDE like Cursor, is this for me?",
+		answer:
+			"Superset is designed to work with your existing tool, we natively support deep-linking to IDEs like Cursor so you can open your workspaces and files in your IDE.",
+	},
+	{
+		question: "Which AI coding agents are supported?",
+		answer:
+			"Superset works with any CLI-based coding agent including Claude Code, OpenCode, OpenAI Codex, and more. If it runs in a terminal, it runs in Superset.",
+	},
+	{
+		question: "How does the parallel agent system work?",
+		answer:
+			"Each agent runs in its own isolated Git worktree, which means they can work on different branches or features simultaneously without conflicts. You can monitor all agents in real-time and switch between them instantly.",
+	},
+	{
+		question: "Is Superset free to use?",
+		answer:
+			"Yes, Superset is completely free and open source. You can self-host it, modify it, and use it however you like. The source code is available on GitHub under a permissive license.",
+	},
+	{
+		question: "Can I use my own API keys?",
+		answer:
+			"Absolutely. Superset doesn't proxy any API calls. You use your own API keys directly with whatever AI providers you choose. This means you have full control over costs and usage.",
+	},
+];

--- a/apps/marketing/src/app/components/FAQSection/index.ts
+++ b/apps/marketing/src/app/components/FAQSection/index.ts
@@ -1,1 +1,3 @@
+export type { FAQItem } from "./constants";
+export { FAQ_ITEMS } from "./constants";
 export { FAQSection } from "./FAQSection";

--- a/apps/marketing/src/app/page.tsx
+++ b/apps/marketing/src/app/page.tsx
@@ -1,7 +1,8 @@
-"use client";
-
+import { COMPANY } from "@superset/shared/constants";
+import type { Metadata } from "next";
 import dynamic from "next/dynamic";
-
+import { FAQPageJsonLd } from "@/components/JsonLd";
+import { FAQ_ITEMS } from "./components/FAQSection";
 import { HeroSection } from "./components/HeroSection";
 
 // Lazy load below-fold sections to reduce initial JS bundle (~304 KiB unused JS)
@@ -24,9 +25,16 @@ const CTASection = dynamic(() =>
 	import("./components/CTASection").then((mod) => mod.CTASection),
 );
 
+export const metadata: Metadata = {
+	alternates: {
+		canonical: COMPANY.MARKETING_URL,
+	},
+};
+
 export default function Home() {
 	return (
 		<main className="flex flex-col bg-background">
+			<FAQPageJsonLd items={FAQ_ITEMS} />
 			<HeroSection />
 			<VideoSection />
 			<TrustedBySection />

--- a/apps/marketing/src/app/sitemap.ts
+++ b/apps/marketing/src/app/sitemap.ts
@@ -26,6 +26,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
 			priority: 0.9,
 		},
 		{
+			url: `${baseUrl}/community`,
+			lastModified: new Date(),
+			changeFrequency: "monthly",
+			priority: 0.5,
+		},
+		{
 			url: `${baseUrl}/privacy`,
 			lastModified: new Date("2025-01-15"),
 			changeFrequency: "yearly",

--- a/apps/marketing/src/components/JsonLd/JsonLd.tsx
+++ b/apps/marketing/src/components/JsonLd/JsonLd.tsx
@@ -108,14 +108,58 @@ export function WebsiteJsonLd() {
 		"@type": "WebSite",
 		name: COMPANY.NAME,
 		url: COMPANY.MARKETING_URL,
-		potentialAction: {
-			"@type": "SearchAction",
-			target: {
-				"@type": "EntryPoint",
-				urlTemplate: `${COMPANY.MARKETING_URL}/blog?q={search_term_string}`,
+	};
+
+	return (
+		<script
+			type="application/ld+json"
+			// biome-ignore lint/security/noDangerouslySetInnerHtml: Safe for JSON-LD structured data
+			dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+		/>
+	);
+}
+
+interface FAQPageJsonLdProps {
+	items: Array<{ question: string; answer: string }>;
+}
+
+export function FAQPageJsonLd({ items }: FAQPageJsonLdProps) {
+	const schema = {
+		"@context": "https://schema.org",
+		"@type": "FAQPage",
+		mainEntity: items.map((item) => ({
+			"@type": "Question",
+			name: item.question,
+			acceptedAnswer: {
+				"@type": "Answer",
+				text: item.answer,
 			},
-			"query-input": "required name=search_term_string",
-		},
+		})),
+	};
+
+	return (
+		<script
+			type="application/ld+json"
+			// biome-ignore lint/security/noDangerouslySetInnerHtml: Safe for JSON-LD structured data
+			dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+		/>
+	);
+}
+
+interface BreadcrumbJsonLdProps {
+	items: Array<{ name: string; url: string }>;
+}
+
+export function BreadcrumbJsonLd({ items }: BreadcrumbJsonLdProps) {
+	const schema = {
+		"@context": "https://schema.org",
+		"@type": "BreadcrumbList",
+		itemListElement: items.map((item, index) => ({
+			"@type": "ListItem",
+			position: index + 1,
+			name: item.name,
+			item: item.url,
+		})),
 	};
 
 	return (

--- a/apps/marketing/src/components/JsonLd/index.ts
+++ b/apps/marketing/src/components/JsonLd/index.ts
@@ -1,5 +1,7 @@
 export {
 	ArticleJsonLd,
+	BreadcrumbJsonLd,
+	FAQPageJsonLd,
 	OrganizationJsonLd,
 	SoftwareApplicationJsonLd,
 	WebsiteJsonLd,


### PR DESCRIPTION
## Summary
- Add self-referencing `<link rel="canonical">` to homepage (`/`) and `/community`
- Add `/community` to `sitemap.ts`
- Add `FAQPage` JSON-LD structured data to homepage using existing FAQ Q&A content
- Add `BreadcrumbList` JSON-LD to blog post and changelog entry pages (Home > Section > Title)
- Remove invalid `SearchAction` from `WebSite` schema (no blog search exists)

## Test plan
- [ ] Verify homepage renders `<link rel="canonical" href="https://superset.sh">` in `<head>`
- [ ] Verify `/community` renders its canonical tag
- [ ] Verify `/sitemap.xml` includes `/community`
- [ ] Validate homepage FAQ JSON-LD at https://search.google.com/test/rich-results
- [ ] Validate breadcrumb JSON-LD on a blog post page
- [ ] Validate breadcrumb JSON-LD on a changelog entry page
- [ ] Confirm `WebSite` schema no longer contains `SearchAction`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Homepage expanded with new sections: video, trusted-by, features, testimonials, FAQ, and CTA.
  * Community page added to site navigation and sitemap.

* **SEO Improvements**
  * Breadcrumb structured data added to blog and changelog entries.
  * FAQ schema markup added site-wide and canonical alternates included for key pages.

* **Refactor**
  * FAQ content unified into a shared source for consistent display and schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->