### PR TITLE
feat(desktop): add ctrl+tab tab navigation

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -174,6 +174,31 @@ function WorkspacePage() {
 		[workspaceId, activeTabId, tabs, setActiveTab],
 	);
 
+	useAppHotkey(
+		"PREV_TAB_ALT",
+		() => {
+			if (!activeTabId || tabs.length === 0) return;
+			const index = tabs.findIndex((t) => t.id === activeTabId);
+			const prevIndex = index <= 0 ? tabs.length - 1 : index - 1;
+			setActiveTab(workspaceId, tabs[prevIndex].id);
+		},
+		undefined,
+		[workspaceId, activeTabId, tabs, setActiveTab],
+	);
+
+	useAppHotkey(
+		"NEXT_TAB_ALT",
+		() => {
+			if (!activeTabId || tabs.length === 0) return;
+			const index = tabs.findIndex((t) => t.id === activeTabId);
+			const nextIndex =
+				index >= tabs.length - 1 || index === -1 ? 0 : index + 1;
+			setActiveTab(workspaceId, tabs[nextIndex].id);
+		},
+		undefined,
+		[workspaceId, activeTabId, tabs, setActiveTab],
+	);
+
 	const switchToTab = useCallback(
 		(index: number) => {
 			const tab = tabs[index];

--- a/apps/desktop/src/shared/hotkeys.ts
+++ b/apps/desktop/src/shared/hotkeys.ts
@@ -503,6 +503,16 @@ export const HOTKEYS = {
 		label: "Next Tab",
 		category: "Terminal",
 	}),
+	PREV_TAB_ALT: defineHotkey({
+		keys: "ctrl+shift+tab",
+		label: "Previous Tab (Alt)",
+		category: "Terminal",
+	}),
+	NEXT_TAB_ALT: defineHotkey({
+		keys: "ctrl+tab",
+		label: "Next Tab (Alt)",
+		category: "Terminal",
+	}),
 	PREV_PANE: defineHotkey({
 		keys: "meta+shift+left",
 		label: "Previous Pane",

--- a/bun.lock
+++ b/bun.lock
@@ -131,7 +131,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "0.0.64",
+      "version": "0.0.65",
       "dependencies": {
         "@better-auth/stripe": "1.4.17",
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Description

Adds alternate tab navigation hotkeys in the desktop app:

Ctrl+Tab → next tab
Ctrl+Shift+Tab → previous tab

These are standard shortcuts used across most apps (terminal apps, browsers, IDEs), so adding them provides a familiar, universal way for users to move between tabs quickly and efficiently.

## Related Issues

\-

## Type of Change

- [-] Bug fix
- [x] New feature
- [-] Documentation
- [-] Refactor
- [-] Other (please describe):

## Testing

* Start the desktop app `cd apps/desktop && SKIP_ENV_VALIDATION=1 bun run dev`
* Create new workspace
* Open several terminal tabs (preferably 3+)
* Use ctrl+tab / ctrl+shift+tab to navigate across terminal tabs

## Screenshots (if applicable)

\-

## Additional Notes

\-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added alternative keyboard shortcuts for terminal tab navigation: Ctrl+Tab to move to the next tab and Ctrl+Shift+Tab to move to the previous tab, with wrap-around support for seamless switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->