### PR TITLE
fix(desktop): remove focus ring outline from file tree items

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileTreeItem/FileTreeItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileTreeItem/FileTreeItem.tsx
@@ -117,8 +117,7 @@ export function FileTreeItem({
 				"flex items-center gap-1 px-1 cursor-pointer select-none",
 				"hover:bg-accent/50 transition-colors",
 				item.isSelected() && "bg-accent",
-				item.isFocused() && !item.isSelected() && "ring-1 ring-ring ring-inset",
-			)}
+				)}
 			onClick={handleClick}
 			onDoubleClick={handleDoubleClick}
 			onKeyDown={handleKeyDown}


### PR DESCRIPTION
## Summary
- Remove the black focus ring border that appears on focused file tree items
- The `ring-1 ring-ring ring-inset` styling was visually distracting

## Test plan
- [ ] Open the desktop app
- [ ] Navigate the file tree with keyboard or click on items
- [ ] Verify no black outline appears on focused items

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed visual focus ring from file tree items when focused but not selected, streamlining the interface appearance and reducing visual clutter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->