### PR TITLE
feat(desktop): add PR merge from sidebar

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
@@ -321,7 +321,6 @@ export function ChangesView({ onFileOpen, isExpandedView }: ChangesViewProps) {
 	const hasStagedChanges = status.staged.length > 0;
 	const hasExistingPR = !!githubStatus?.pr;
 	const prUrl = githubStatus?.pr?.url;
-	const prState = githubStatus?.pr?.state;
 
 	return (
 		<div className="flex flex-col h-full">
@@ -351,7 +350,6 @@ export function ChangesView({ onFileOpen, isExpandedView }: ChangesViewProps) {
 				hasUpstream={status.hasUpstream}
 				hasExistingPR={hasExistingPR}
 				prUrl={prUrl}
-				prState={prState}
 				onRefresh={handleRefresh}
 			/>
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ChangesHeader/ChangesHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ChangesHeader/ChangesHeader.tsx
@@ -10,14 +10,13 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useEffect, useRef, useState } from "react";
 import { HiArrowPath, HiCheck } from "react-icons/hi2";
-import { LuGitBranch, LuLoaderCircle } from "react-icons/lu";
+import { LuGitBranch } from "react-icons/lu";
 import { VscGitStash, VscGitStashApply } from "react-icons/vsc";
 import { electronTrpc } from "renderer/lib/electron-trpc";
-import { PRIcon } from "renderer/screens/main/components/PRIcon";
-import { usePRStatus } from "renderer/screens/main/hooks";
 import { useChangesStore } from "renderer/stores/changes";
 import type { ChangesViewMode } from "../../types";
 import { ViewModeToggle } from "../ViewModeToggle";
+import { PRButton } from "./components/PRButton";
 
 interface ChangesHeaderProps {
 	onRefresh: () => void;
@@ -187,35 +186,6 @@ function RefreshButton({ onRefresh }: { onRefresh: () => void }) {
 	);
 }
 
-function PRStatusLink({ workspaceId }: { workspaceId?: string }) {
-	const { pr, isLoading } = usePRStatus({
-		workspaceId,
-		refetchInterval: 10000,
-	});
-
-	if (isLoading) {
-		return (
-			<LuLoaderCircle className="w-4 h-4 animate-spin text-muted-foreground" />
-		);
-	}
-
-	if (!pr) return null;
-
-	return (
-		<a
-			href={pr.url}
-			target="_blank"
-			rel="noopener noreferrer"
-			className="flex items-center gap-1 hover:opacity-80 transition-opacity"
-		>
-			<PRIcon state={pr.state} className="w-4 h-4" />
-			<span className="text-xs text-muted-foreground font-mono">
-				#{pr.number}
-			</span>
-		</a>
-	);
-}
-
 export function ChangesHeader({
 	onRefresh,
 	viewMode,
@@ -238,7 +208,11 @@ export function ChangesHeader({
 			/>
 			<ViewModeToggle viewMode={viewMode} onViewModeChange={onViewModeChange} />
 			<RefreshButton onRefresh={onRefresh} />
-			<PRStatusLink workspaceId={workspaceId} />
+			<PRButton
+				workspaceId={workspaceId}
+				worktreePath={worktreePath}
+				onRefresh={onRefresh}
+			/>
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ChangesHeader/components/PRButton/PRButton.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ChangesHeader/components/PRButton/PRButton.tsx
@@ -1,0 +1,125 @@
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import { toast } from "@superset/ui/sonner";
+import { HiChevronDown } from "react-icons/hi2";
+import { LuLoaderCircle } from "react-icons/lu";
+import { VscGitMerge } from "react-icons/vsc";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { PRIcon } from "renderer/screens/main/components/PRIcon";
+import { usePRStatus } from "renderer/screens/main/hooks";
+
+interface PRButtonProps {
+	workspaceId?: string;
+	worktreePath: string;
+	onRefresh: () => void;
+}
+
+export function PRButton({
+	workspaceId,
+	worktreePath,
+	onRefresh,
+}: PRButtonProps) {
+	const { pr, isLoading } = usePRStatus({
+		workspaceId,
+		refetchInterval: 10000,
+	});
+
+	const mergePRMutation = electronTrpc.changes.mergePR.useMutation({
+		onSuccess: () => {
+			toast.success("PR merged successfully");
+			onRefresh();
+		},
+		onError: (error) => toast.error(`Merge failed: ${error.message}`),
+	});
+
+	const handleMergePR = (strategy: "merge" | "squash" | "rebase") =>
+		mergePRMutation.mutate({ worktreePath, strategy, deleteBranch: true });
+
+	if (isLoading) {
+		return (
+			<LuLoaderCircle className="w-4 h-4 animate-spin text-muted-foreground" />
+		);
+	}
+
+	if (!pr) return null;
+
+	const canMerge = pr.state === "open";
+
+	if (!canMerge) {
+		return (
+			<a
+				href={pr.url}
+				target="_blank"
+				rel="noopener noreferrer"
+				className="flex items-center gap-1 ml-auto hover:opacity-80 transition-opacity"
+			>
+				<PRIcon state={pr.state} className="w-4 h-4" />
+				<span className="text-xs text-muted-foreground font-mono">
+					#{pr.number}
+				</span>
+			</a>
+		);
+	}
+
+	return (
+		<div className="flex items-center ml-auto rounded border border-border overflow-hidden">
+			<a
+				href={pr.url}
+				target="_blank"
+				rel="noopener noreferrer"
+				className="flex items-center gap-1 px-1.5 py-0.5 hover:bg-accent transition-colors"
+			>
+				<PRIcon state={pr.state} className="w-4 h-4" />
+				<span className="text-xs text-muted-foreground font-mono">
+					#{pr.number}
+				</span>
+			</a>
+			<div className="w-px h-full bg-border" />
+			<DropdownMenu>
+				<DropdownMenuTrigger asChild>
+					<button
+						type="button"
+						className="flex items-center px-1 py-0.5 hover:bg-accent transition-colors"
+						disabled={mergePRMutation.isPending}
+					>
+						<HiChevronDown className="size-3 text-muted-foreground" />
+					</button>
+				</DropdownMenuTrigger>
+				<DropdownMenuContent align="end" className="w-44">
+					<DropdownMenuLabel className="text-xs text-muted-foreground font-normal">
+						Merge
+					</DropdownMenuLabel>
+					<DropdownMenuItem
+						onClick={() => handleMergePR("squash")}
+						className="text-xs"
+						disabled={mergePRMutation.isPending}
+					>
+						<VscGitMerge className="size-3.5" />
+						Squash and merge
+					</DropdownMenuItem>
+					<DropdownMenuItem
+						onClick={() => handleMergePR("merge")}
+						className="text-xs"
+						disabled={mergePRMutation.isPending}
+					>
+						<VscGitMerge className="size-3.5" />
+						Create merge commit
+					</DropdownMenuItem>
+					<DropdownMenuItem
+						onClick={() => handleMergePR("rebase")}
+						className="text-xs"
+						disabled={mergePRMutation.isPending}
+					>
+						<VscGitMerge className="size-3.5" />
+						Rebase and merge
+					</DropdownMenuItem>
+				</DropdownMenuContent>
+			</DropdownMenu>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ChangesHeader/components/PRButton/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ChangesHeader/components/PRButton/index.ts
@@ -1,0 +1,1 @@
+export { PRButton } from "./PRButton";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/CommitInput/CommitInput.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/CommitInput/CommitInput.tsx
@@ -5,9 +5,6 @@ import {
 	DropdownMenuContent,
 	DropdownMenuItem,
 	DropdownMenuSeparator,
-	DropdownMenuSub,
-	DropdownMenuSubContent,
-	DropdownMenuSubTrigger,
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
 import { toast } from "@superset/ui/sonner";
@@ -23,7 +20,6 @@ import {
 	HiCheck,
 	HiChevronDown,
 } from "react-icons/hi2";
-import { VscGitMerge } from "react-icons/vsc";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 
 interface CommitInputProps {
@@ -34,7 +30,6 @@ interface CommitInputProps {
 	hasUpstream: boolean;
 	hasExistingPR: boolean;
 	prUrl?: string;
-	prState?: "open" | "draft" | "merged" | "closed";
 	onRefresh: () => void;
 }
 
@@ -46,7 +41,6 @@ export function CommitInput({
 	hasUpstream,
 	hasExistingPR,
 	prUrl,
-	prState,
 	onRefresh,
 }: CommitInputProps) {
 	const [commitMessage, setCommitMessage] = useState("");
@@ -93,14 +87,6 @@ export function CommitInput({
 		onError: (error) => toast.error(`Failed: ${error.message}`),
 	});
 
-	const mergePRMutation = electronTrpc.changes.mergePR.useMutation({
-		onSuccess: () => {
-			toast.success("PR merged successfully");
-			onRefresh();
-		},
-		onError: (error) => toast.error(`Merge failed: ${error.message}`),
-	});
-
 	const fetchMutation = electronTrpc.changes.fetch.useMutation({
 		onSuccess: () => {
 			toast.success("Fetched");
@@ -115,8 +101,7 @@ export function CommitInput({
 		pullMutation.isPending ||
 		syncMutation.isPending ||
 		createPRMutation.isPending ||
-		fetchMutation.isPending ||
-		mergePRMutation.isPending;
+		fetchMutation.isPending;
 
 	const canCommit = hasStagedChanges && commitMessage.trim();
 
@@ -149,10 +134,6 @@ export function CommitInput({
 	};
 	const handleCreatePR = () => createPRMutation.mutate({ worktreePath });
 	const handleOpenPR = () => prUrl && window.open(prUrl, "_blank");
-	const handleMergePR = (strategy: "merge" | "squash" | "rebase") =>
-		mergePRMutation.mutate({ worktreePath, strategy, deleteBranch: true });
-
-	const canMergePR = hasExistingPR && prState === "open";
 
 	const handleCommitAndPush = () => {
 		if (!canCommit) return;
@@ -367,40 +348,10 @@ export function CommitInput({
 						<DropdownMenuSeparator />
 
 						{hasExistingPR ? (
-							<>
-								<DropdownMenuItem onClick={handleOpenPR} className="text-xs">
-									<HiArrowTopRightOnSquare className="size-3.5" />
-									Open Pull Request
-								</DropdownMenuItem>
-								{canMergePR && (
-									<DropdownMenuSub>
-										<DropdownMenuSubTrigger className="text-xs">
-											<VscGitMerge className="size-3.5" />
-											Merge Pull Request
-										</DropdownMenuSubTrigger>
-										<DropdownMenuSubContent className="w-40">
-											<DropdownMenuItem
-												onClick={() => handleMergePR("squash")}
-												className="text-xs"
-											>
-												Squash and merge
-											</DropdownMenuItem>
-											<DropdownMenuItem
-												onClick={() => handleMergePR("merge")}
-												className="text-xs"
-											>
-												Create merge commit
-											</DropdownMenuItem>
-											<DropdownMenuItem
-												onClick={() => handleMergePR("rebase")}
-												className="text-xs"
-											>
-												Rebase and merge
-											</DropdownMenuItem>
-										</DropdownMenuSubContent>
-									</DropdownMenuSub>
-								)}
-							</>
+							<DropdownMenuItem onClick={handleOpenPR} className="text-xs">
+								<HiArrowTopRightOnSquare className="size-3.5" />
+								Open Pull Request
+							</DropdownMenuItem>
 						) : (
 							<DropdownMenuItem onClick={handleCreatePR} className="text-xs">
 								<HiArrowTopRightOnSquare className="size-3.5" />


### PR DESCRIPTION
## Summary
- Adds ability to merge PRs directly from the sidebar changes tab dropdown menu
- Supports three merge strategies: squash and merge, create merge commit, and rebase and merge
- Uses GitHub CLI (`gh pr merge`) under the hood with automatic branch deletion

## Test plan
- [ ] Open the sidebar changes tab on a branch with an open PR
- [ ] Click the dropdown and verify "Merge Pull Request" submenu appears
- [ ] Test each merge strategy option
- [ ] Verify branch is deleted after merge
- [ ] Verify error handling when PR cannot be merged (conflicts, required checks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pull request merge capability with three merge strategies: squash, merge, and rebase.
  * Introduced a new merge button in the changes view displaying PR status with a dropdown menu for strategy selection.
  * Merge actions include automatic branch cleanup and error handling for merge conflicts or unmergeable PRs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->