### PR TITLE
fix(desktop): update scroll-to-bottom for xterm.js 6.0

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/ScrollToBottomButton/ScrollToBottomButton.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/ScrollToBottomButton/ScrollToBottomButton.tsx
@@ -28,15 +28,11 @@ export function ScrollToBottomButton({ terminal }: ScrollToBottomButtonProps) {
 		checkScrollPosition();
 
 		const writeDisposable = terminal.onWriteParsed(checkScrollPosition);
-		const viewport = terminal.element?.querySelector(".xterm-viewport");
-
-		if (viewport) {
-			viewport.addEventListener("scroll", checkScrollPosition);
-		}
+		const scrollDisposable = terminal.onScroll(checkScrollPosition);
 
 		return () => {
 			writeDisposable.dispose();
-			viewport?.removeEventListener("scroll", checkScrollPosition);
+			scrollDisposable.dispose();
 		};
 	}, [terminal, checkScrollPosition]);
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/utils.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/utils.ts
@@ -5,17 +5,6 @@ export function shellEscapePaths(paths: string[]): string {
 	return quote(paths);
 }
 
-export function scrollToBottom(
-	terminal: Terminal,
-	behavior: ScrollBehavior = "instant",
-): void {
-	const viewport = terminal.element?.querySelector(".xterm-viewport");
-	if (viewport) {
-		viewport.scrollTo({
-			top: viewport.scrollHeight,
-			behavior,
-		});
-	} else {
-		terminal.scrollToBottom();
-	}
+export function scrollToBottom(terminal: Terminal): void {
+	terminal.scrollToBottom();
 }


### PR DESCRIPTION
## Summary
- Fix scroll-to-bottom hotkey and button for xterm.js 6.0 compatibility
- Use `terminal.scrollToBottom()` instead of manually scrolling `.xterm-viewport` DOM element
- Use `terminal.onScroll` event instead of viewport scroll listener for detecting scroll position

## Test plan
- [ ] Open a terminal with scrollback history
- [ ] Scroll up in the terminal
- [ ] Press the scroll-to-bottom hotkey - should scroll to bottom
- [ ] Click the scroll-to-bottom button - should scroll to bottom
- [ ] Verify the button visibility updates correctly when scrolling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to terminal component handling for enhanced code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->