### PR TITLE
feat(slack-agent): prefetch context into system prompt

### DIFF
--- a/apps/api/src/app/api/integrations/slack/events/utils/run-agent/run-agent.ts
+++ b/apps/api/src/app/api/integrations/slack/events/utils/run-agent/run-agent.ts
@@ -338,7 +338,7 @@ async function fetchAgentContext({
 			(d) =>
 				`- ${d.deviceName ?? "Unknown"} (id: ${d.deviceId}, owner: ${d.ownerName ?? d.ownerEmail}, status: ${d.isOnline ? "online" : "offline"})`,
 		);
-		sections.push(`Online devices:\n${lines.join("\n")}`);
+		sections.push(`Devices:\n${lines.join("\n")}`);
 	}
 
 	return sections.join("\n\n");


### PR DESCRIPTION
## Summary
- Adds `fetchAgentContext()` that calls `list_members`, `list_task_statuses`, and `list_devices` via MCP at agent startup and formats the results into the system prompt
- Identifies the current user from the members list and includes it in the prompt context
- Removes those three tools from the agent's available toolset (added to `DENIED_SUPERSET_TOOLS`)
- Fixes the tool deny filter to apply before the `superset_` prefix transform so it actually matches

## Test plan
- [ ] Mention the Slack bot and ask it to create a task assigned to a team member by name — verify it uses the prefetched member ID without calling `list_members`
- [ ] Ask the bot about task statuses — verify it knows them without calling `list_task_statuses`
- [ ] Ask the bot about online devices — verify it knows them without calling `list_devices`
- [ ] Verify the bot correctly identifies who is talking to it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Slack agent now fetches members, task statuses, and devices in parallel for faster initialization.
  * Slack conversations gain broader contextual awareness using member lists, task statuses, and device info to improve relevance.
  * Certain tools are now excluded from Slack agent context to reduce noise and improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->