### PR TITLE
fix(desktop): change sidebar project dropdown to open downward

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectHeader.tsx
@@ -201,7 +201,7 @@ export function ProjectHeader({
 								</button>
 							</TooltipTrigger>
 						</ContextMenuTrigger>
-						<TooltipContent side="right" className="flex flex-col gap-0.5">
+						<TooltipContent className="flex flex-col gap-0.5">
 							<span className="font-medium">{projectName}</span>
 							<span className="text-xs text-muted-foreground">
 								{workspaceCount} workspace{workspaceCount !== 1 ? "s" : ""}


### PR DESCRIPTION
## Summary
- Converted the project header's `ContextMenu` (right-click triggered, opens at cursor position to the side) into a `DropdownMenu` (click-triggered on the chevron, opens downward below the trigger)
- Added `DropdownMenu` imports and a dropdown version of the color picker submenu using `DropdownMenuSub` components
- Positioned the dropdown with `side="bottom" align="end"` so it opens downward from the chevron trigger
- Collapsed sidebar view remains unchanged (still uses right-click `ContextMenu`)

## Test plan
- [ ] Click the chevron (v) next to a project name in the expanded sidebar — menu should open **downward** below the trigger
- [ ] Verify all menu items work: Rename, Open in Finder, Project Settings, Set Color, Close Project
- [ ] Verify the "Set Color" submenu opens correctly from within the dropdown
- [ ] Verify clicking the project name area still toggles collapse/expand
- [ ] Verify the collapsed sidebar thumbnail right-click context menu still works as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the project actions menu in the workspace sidebar to use a dropdown interface for improved accessibility and navigation.
  * Project actions (Rename, Open in Finder, Project Settings, Close Project) are now readily available through the dropdown menu.
  * Streamlined color selection to be directly accessible within the actions dropdown.

* **Bug Fix**
  * Fixed tooltip positioning in the collapsed workspace sidebar so tooltips appear in the correct location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->