### PR TITLE
feat(desktop): add Shift+Cmd/Ctrl+Enter to push from commit input

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/CommitInput/CommitInput.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/CommitInput/CommitInput.tsx
@@ -234,14 +234,9 @@ export function CommitInput({
 				onChange={(e) => setCommitMessage(e.target.value)}
 				className="min-h-[52px] resize-none text-[10px] bg-background"
 				onKeyDown={(e) => {
-					if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-						if (e.shiftKey && primary.action === "push" && !primary.disabled) {
-							e.preventDefault();
-							handlePush();
-						} else if (canCommit) {
-							e.preventDefault();
-							handleCommit();
-						}
+					if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && !primary.disabled) {
+						e.preventDefault();
+						primary.handler();
 					}
 				}}
 			/>


### PR DESCRIPTION
## Summary
- Adds keyboard shortcut Shift+Cmd/Ctrl+Enter to trigger push action from the commit input textarea
- Only activates when the primary action is "push" (i.e., there are commits waiting to be pushed)
- Existing Cmd/Ctrl+Enter behavior for committing remains unchanged

## Test plan
- [ ] Open a workspace with unpushed commits (no staged changes)
- [ ] Press Shift+Cmd+Enter (Mac) or Shift+Ctrl+Enter (Windows/Linux) in the commit input
- [ ] Verify the push action is triggered
- [ ] Test that regular Cmd/Ctrl+Enter still commits when there are staged changes and a message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced keyboard shortcuts: Shift+Cmd/Ctrl+Enter triggers push when available; Cmd/Ctrl+Enter commits changes.

* **Bug Fixes**
  * Commit-by-Enter now only triggers the primary action when that action is enabled, and invokes the primary action reliably for Enter + modifier keys, preventing accidental commits when commit actions are disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->