### PR TITLE
fix(desktop): reset to branch name when workspace rename is cleared

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/status.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/status.ts
@@ -64,6 +64,7 @@ export const createStatusProcedures = () => {
 					patch: z.object({
 						name: z.string().optional(),
 						preserveUnnamedStatus: z.boolean().optional(),
+						isUnnamed: z.boolean().optional(),
 					}),
 				}),
 			)
@@ -75,12 +76,18 @@ export const createStatusProcedures = () => {
 					);
 				}
 
+				const resolveIsUnnamed = () => {
+					if (input.patch.isUnnamed !== undefined) return input.patch.isUnnamed;
+					if (input.patch.name !== undefined && !input.patch.preserveUnnamedStatus)
+						return false;
+					return undefined;
+				};
+
+				const isUnnamed = resolveIsUnnamed();
+
 				touchWorkspace(input.id, {
-					...(input.patch.name !== undefined && {
-						name: input.patch.name,
-						// Only mark as named if not preserving unnamed status
-						...(input.patch.preserveUnnamedStatus ? {} : { isUnnamed: false }),
-					}),
+					...(input.patch.name !== undefined && { name: input.patch.name }),
+					...(isUnnamed !== undefined && { isUnnamed }),
 				});
 
 				return { success: true };

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/workspace/$workspaceId/page.tsx
@@ -43,7 +43,11 @@ function WorkspaceSettingsPage() {
 		id: workspaceId,
 	});
 
-	const rename = useWorkspaceRename(workspace?.id ?? "", workspace?.name ?? "");
+	const rename = useWorkspaceRename(
+		workspace?.id ?? "",
+		workspace?.name ?? "",
+		workspace?.branch ?? "",
+	);
 
 	// Workspace is guaranteed to exist here because loader handles 404s
 	if (!workspace) {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -88,7 +88,7 @@ export function WorkspaceListItem({
 	const matchRoute = useMatchRoute();
 	const reorderWorkspaces = useReorderWorkspaces();
 	const [hasHovered, setHasHovered] = useState(false);
-	const rename = useWorkspaceRename(id, name);
+	const rename = useWorkspaceRename(id, name, branch);
 	const tabs = useTabsStore((s) => s.tabs);
 	const panes = useTabsStore((s) => s.panes);
 	const clearWorkspaceAttentionStatus = useTabsStore(

--- a/apps/desktop/src/renderer/screens/main/hooks/useWorkspaceRename/useWorkspaceRename.ts
+++ b/apps/desktop/src/renderer/screens/main/hooks/useWorkspaceRename/useWorkspaceRename.ts
@@ -1,20 +1,22 @@
 import { useEffect, useRef, useState } from "react";
 import { useUpdateWorkspace } from "renderer/react-query/workspaces/useUpdateWorkspace";
 
-export function useWorkspaceRename(workspaceId: string, workspaceName: string) {
+export function useWorkspaceRename(
+	workspaceId: string,
+	workspaceName: string,
+	branch: string,
+) {
 	const [isRenaming, setIsRenaming] = useState(false);
 	const [renameValue, setRenameValue] = useState(workspaceName);
 	const inputRef = useRef<HTMLInputElement | null>(null);
 	const updateWorkspace = useUpdateWorkspace();
 
-	// Select input text when rename mode is activated
 	useEffect(() => {
 		if (isRenaming && inputRef.current) {
 			inputRef.current.select();
 		}
 	}, [isRenaming]);
 
-	// Sync rename value when workspace name changes
 	useEffect(() => {
 		setRenameValue(workspaceName);
 	}, [workspaceName]);
@@ -25,7 +27,15 @@ export function useWorkspaceRename(workspaceId: string, workspaceName: string) {
 
 	const submitRename = () => {
 		const trimmedValue = renameValue.trim();
-		if (trimmedValue && trimmedValue !== workspaceName) {
+		const isCleared = !trimmedValue;
+
+		if (isCleared) {
+			updateWorkspace.mutate({
+				id: workspaceId,
+				patch: { name: branch, isUnnamed: true },
+			});
+			setRenameValue(branch);
+		} else if (trimmedValue !== workspaceName) {
 			updateWorkspace.mutate({
 				id: workspaceId,
 				patch: { name: trimmedValue },


### PR DESCRIPTION
## Summary
- When users clear the workspace name during rename (trim to empty), now resets to branch name instead of keeping empty
- Sets `isUnnamed=true` so the auto-rename feature can still prompt for a name
- Added `isUnnamed` field to workspace update patch schema for explicit control

## Test plan
- [ ] Open a workspace and double-click to rename it
- [ ] Clear the name field completely and press Enter
- [ ] Verify the workspace name resets to the branch name
- [ ] Verify the workspace is marked as unnamed (auto-rename prompt should appear)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace rename is branch-aware: the rename flow now uses the workspace branch; clearing the rename field reverts the name to the branch and marks the workspace as unnamed.

* **Bug Fixes**
  * Unnamed-status handling during renames is clarified with explicit precedence rules, removing prior implicit resets when names change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->