### PR TITLE
feat(desktop): extend discard all to delete untracked/new files

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
@@ -542,8 +542,8 @@ export function ChangesView({ onFileOpen, isExpandedView }: ChangesViewProps) {
 							Discard all unstaged changes?
 						</AlertDialogTitle>
 						<AlertDialogDescription>
-							This will revert all unstaged modifications. Untracked files will
-							not be affected. This action cannot be undone.
+							This will revert all unstaged modifications and delete untracked
+							files. This action cannot be undone.
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter className="px-4 pb-4 pt-2 flex-row justify-end gap-2">
@@ -582,8 +582,8 @@ export function ChangesView({ onFileOpen, isExpandedView }: ChangesViewProps) {
 							Discard all staged changes?
 						</AlertDialogTitle>
 						<AlertDialogDescription>
-							This will unstage and revert all staged changes. Untracked files
-							will not be affected. This action cannot be undone.
+							This will unstage and revert all staged changes. Staged new files
+							will be deleted. This action cannot be undone.
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter className="px-4 pb-4 pt-2 flex-row justify-end gap-2">


### PR DESCRIPTION
## Summary

- **Discard All Unstaged** now also deletes untracked files after reverting tracked file modifications
- **Discard All Staged** now also deletes staged new files (files with status "added") after unstaging
- Updated dialog text to reflect the new behavior

Previously, "Discard All" only ran `git checkout -- .` which left untracked files untouched. This extends the functionality to provide a cleaner "discard everything" experience.

## Test plan

- [ ] Create a new file (untracked), then click "Discard all unstaged" → file should be deleted
- [ ] Stage a new file, then click "Discard all staged" → file should be deleted
- [ ] Modify an existing file, then "Discard all unstaged" → changes should be reverted
- [ ] Stage modifications to an existing file, then "Discard all staged" → changes should be reverted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Discarding unstaged changes now also deletes untracked files that were captured before discard.
  * Discarding staged changes now removes newly staged files after un-staging.

* **Documentation**
  * Confirmation dialogs updated to clearly state that untracked files (unstaged) or newly staged files (staged) will be deleted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->