### PR TITLE
fix(desktop): fix file and changes view overflow clipping content

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
@@ -323,7 +323,7 @@ export function ChangesView({ onFileOpen, isExpandedView }: ChangesViewProps) {
 	const prUrl = githubStatus?.pr?.url;
 
 	return (
-		<div className="flex flex-col h-full">
+		<div className="flex flex-col flex-1 min-h-0">
 			<ChangesHeader
 				onRefresh={handleRefresh}
 				viewMode={fileListViewMode}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
@@ -279,7 +279,7 @@ export function FilesView() {
 	}
 
 	return (
-		<div className="flex flex-col h-full">
+		<div className="flex flex-col flex-1 min-h-0">
 			<FileTreeToolbar
 				searchTerm={searchTerm}
 				onSearchChange={setSearchTerm}
@@ -291,9 +291,10 @@ export function FilesView() {
 				onToggleHiddenFiles={handleToggleHiddenFiles}
 			/>
 
-			<ContextMenu>
-				<ContextMenuTrigger asChild className="flex-1 min-h-0">
-					<div className="flex-1 min-h-0 overflow-auto">
+			<div className="flex-1 min-h-0 overflow-hidden">
+				<ContextMenu>
+					<ContextMenuTrigger asChild className="h-full">
+						<div className="h-full overflow-auto">
 						{newItemMode && newItemParentPath === worktreePath && (
 							<NewItemInput
 								mode={newItemMode}
@@ -385,18 +386,19 @@ export function FilesView() {
 							</div>
 						)}
 					</div>
-				</ContextMenuTrigger>
-				<ContextMenuContent className="w-48">
-					<ContextMenuItem onClick={() => handleNewFile(worktreePath)}>
-						<LuFile className="mr-2 size-4" />
-						New File
-					</ContextMenuItem>
-					<ContextMenuItem onClick={() => handleNewFolder(worktreePath)}>
-						<LuFolder className="mr-2 size-4" />
-						New Folder
-					</ContextMenuItem>
-				</ContextMenuContent>
-			</ContextMenu>
+					</ContextMenuTrigger>
+					<ContextMenuContent className="w-48">
+						<ContextMenuItem onClick={() => handleNewFile(worktreePath)}>
+							<LuFile className="mr-2 size-4" />
+							New File
+						</ContextMenuItem>
+						<ContextMenuItem onClick={() => handleNewFolder(worktreePath)}>
+							<LuFolder className="mr-2 size-4" />
+							New Folder
+						</ContextMenuItem>
+					</ContextMenuContent>
+				</ContextMenu>
+			</div>
 
 			<DeleteConfirmDialog
 				entry={deleteEntry}


### PR DESCRIPTION
## Summary
- Fix file view and changes view overflow issue where expanded content was clipped
- Change `overflow-hidden` to `overflow-x-hidden` in nested components to allow vertical content to expand into parent scroll container

## Test plan
- [ ] Expand sections in Changes view with many files - should now be scrollable
- [ ] Expand file tree in Files view - content should not be clipped
- [ ] Verify horizontal text truncation still works for long file paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved layout responsiveness in the Changes and Files views with enhanced flex container sizing and overflow handling for better visual stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->