### PR TITLE
feat(desktop): add Cmd+Shift+P shortcut and always-visible PR button

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -1,3 +1,4 @@
+import { toast } from "@superset/ui/sonner";
 import { createFileRoute, notFound, useNavigate } from "@tanstack/react-router";
 import { useCallback, useMemo } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
@@ -8,6 +9,7 @@ import { usePresetHotkeys } from "renderer/routes/_authenticated/_dashboard/work
 import { NotFound } from "renderer/routes/not-found";
 import { WorkspaceInitializingView } from "renderer/screens/main/components/WorkspaceView/WorkspaceInitializingView";
 import { WorkspaceLayout } from "renderer/screens/main/components/WorkspaceView/WorkspaceLayout";
+import { usePRStatus } from "renderer/screens/main/hooks";
 import { useAppHotkey } from "renderer/stores/hotkeys";
 import { SidebarMode, useSidebarStore } from "renderer/stores/sidebar-state";
 import { getPaneDimensions } from "renderer/stores/tabs/pane-refs";
@@ -249,6 +251,25 @@ function WorkspacePage() {
 		},
 		undefined,
 		[workspace?.worktreePath],
+	);
+
+	// Open PR shortcut (⌘⇧P)
+	const { pr } = usePRStatus({ workspaceId });
+	const createPRMutation = electronTrpc.changes.createPR.useMutation({
+		onSuccess: () => toast.success("Opening GitHub..."),
+		onError: (error) => toast.error(`Failed: ${error.message}`),
+	});
+	useAppHotkey(
+		"OPEN_PR",
+		() => {
+			if (pr?.url) {
+				window.open(pr.url, "_blank");
+			} else if (workspace?.worktreePath) {
+				createPRMutation.mutate({ worktreePath: workspace.worktreePath });
+			}
+		},
+		undefined,
+		[pr?.url, workspace?.worktreePath],
 	);
 
 	// Toggle changes sidebar (⌘L)

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ChangesHeader/components/PRButton/PRButton.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ChangesHeader/components/PRButton/PRButton.tsx
@@ -6,8 +6,9 @@ import {
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
 import { toast } from "@superset/ui/sonner";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { HiChevronDown } from "react-icons/hi2";
-import { LuLoaderCircle } from "react-icons/lu";
+import { LuGitPullRequest, LuLoaderCircle } from "react-icons/lu";
 import { VscGitMerge } from "react-icons/vsc";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { PRIcon } from "renderer/screens/main/components/PRIcon";
@@ -37,6 +38,14 @@ export function PRButton({
 		onError: (error) => toast.error(`Merge failed: ${error.message}`),
 	});
 
+	const createPRMutation = electronTrpc.changes.createPR.useMutation({
+		onSuccess: () => {
+			toast.success("Opening GitHub...");
+			onRefresh();
+		},
+		onError: (error) => toast.error(`Failed: ${error.message}`),
+	});
+
 	const handleMergePR = (strategy: "merge" | "squash" | "rebase") =>
 		mergePRMutation.mutate({ worktreePath, strategy, deleteBranch: true });
 
@@ -46,7 +55,27 @@ export function PRButton({
 		);
 	}
 
-	if (!pr) return null;
+	if (!pr) {
+		return (
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<button
+						type="button"
+						className="flex items-center ml-auto hover:opacity-80 transition-opacity disabled:opacity-50"
+						onClick={() => createPRMutation.mutate({ worktreePath })}
+						disabled={createPRMutation.isPending}
+					>
+						{createPRMutation.isPending ? (
+							<LuLoaderCircle className="w-4 h-4 animate-spin text-muted-foreground" />
+						) : (
+							<LuGitPullRequest className="w-4 h-4 text-muted-foreground" />
+						)}
+					</button>
+				</TooltipTrigger>
+				<TooltipContent side="bottom">Create Pull Request</TooltipContent>
+			</Tooltip>
+		);
+	}
 
 	const canMerge = pr.state === "open";
 

--- a/apps/desktop/src/shared/hotkeys.ts
+++ b/apps/desktop/src/shared/hotkeys.ts
@@ -646,6 +646,12 @@ export const HOTKEYS = {
 		category: "Workspace",
 		description: "Open an existing project folder",
 	}),
+	OPEN_PR: defineHotkey({
+		keys: "meta+shift+p",
+		label: "Open Pull Request",
+		category: "Workspace",
+		description: "Open existing PR or create a new one on GitHub",
+	}),
 
 	// Window
 	NEW_WINDOW: defineHotkey({


### PR DESCRIPTION
## Summary

- Add `OPEN_PR` hotkey (`Cmd+Shift+P`) to the workspace hotkeys, registered in the workspace page
- Make the PR button in the changes header always visible — when no PR exists, it shows a muted pull request icon that creates a PR on click
- When a PR exists, `Cmd+Shift+P` opens the PR URL in the browser; when none exists, it triggers PR creation

## Test plan

- [ ] Workspace with existing PR: button shows PR icon + `#number`, `Cmd+Shift+P` opens the PR in browser
- [ ] Workspace without PR: button shows muted PR icon, clicking it or pressing `Cmd+Shift+P` creates the PR
- [ ] New shortcut appears in keyboard shortcuts settings under "Workspace" category
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added keyboard shortcut (Cmd/Ctrl+Shift+P) to open existing pull requests or create new ones directly
  * Added UI button to create pull requests from the workspace
  * Implemented toast notifications for user feedback on PR actions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->