### PR TITLE
docs(mcp): add API key auth, multi-client setup, and missing tools

### DIFF
--- a/apps/docs/content/docs/mcp.mdx
+++ b/apps/docs/content/docs/mcp.mdx
@@ -12,82 +12,122 @@ Superset provides an [MCP (Model Context Protocol)](https://modelcontextprotocol
 | Category | Tools |
 |----------|-------|
 | **Tasks** | Create, update, list, get, delete tasks |
-| **Workspaces** | Create, switch, delete, list workspaces |
+| **Workspaces** | Create, update, switch, delete, list, navigate workspaces |
 | **Devices** | List devices, projects, and app context |
 | **Organization** | List members and task statuses |
+| **AI Sessions** | Start autonomous Claude sessions and subagents |
 
 ## Setup
 
-Superset supports two MCP transports: **SSE** (Server-Sent Events) and **Streamable HTTP**. Both work identically—choose based on your client's preference.
+### CLI Options
 
-### Claude Desktop
-
-Add to your `claude_desktop_config.json`:
-
-<Tabs items={["SSE", "HTTP"]}>
-<Tab value="SSE">
-```json
-{
-  "mcpServers": {
-    "superset": {
-      "url": "https://api.superset.sh/api/agent/sse"
-    }
-  }
-}
-```
-</Tab>
-<Tab value="HTTP">
-```json
-{
-  "mcpServers": {
-    "superset": {
-      "type": "http",
-      "url": "https://api.superset.sh/api/agent/mcp"
-    }
-  }
-}
-```
-</Tab>
-</Tabs>
-
-### Claude Code
-
-<Tabs items={["SSE", "HTTP"]}>
-<Tab value="SSE">
-```bash
-claude mcp add superset --transport sse https://api.superset.sh/api/agent/sse
-```
-</Tab>
-<Tab value="HTTP">
-```bash
+<Tabs items={["Claude Code", "Codex", "Gemini CLI", "Open Code"]}>
+<Tab value="Claude Code">
+```bash title="terminal"
 claude mcp add superset --transport http https://api.superset.sh/api/agent/mcp
 ```
 </Tab>
+<Tab value="Codex">
+```bash title="terminal"
+codex mcp add superset --url https://api.superset.sh/api/agent/mcp
+```
+</Tab>
+<Tab value="Gemini CLI">
+```bash title="terminal"
+gemini mcp add --transport http superset https://api.superset.sh/api/agent/mcp
+```
+</Tab>
+<Tab value="Open Code">
+```bash title="terminal"
+opencode mcp add
+```
+</Tab>
 </Tabs>
 
-### Cursor
+### Manual Configuration
 
-Add to your Cursor MCP settings:
+Alternatively, you can manually configure the MCP server for each client:
 
-<Tabs items={["SSE", "HTTP"]}>
-<Tab value="SSE">
-```json
+<Tabs items={["Claude Code", "Claude Desktop", "Cursor", "Codex", "Gemini CLI", "Open Code"]}>
+<Tab value="Claude Code">
+Add a `.mcp.json` to your project root. Claude Code auto-discovers this file and handles OAuth authentication.
+
+```json title=".mcp.json"
 {
   "mcpServers": {
     "superset": {
-      "url": "https://api.superset.sh/api/agent/sse"
+      "type": "http",
+      "url": "https://api.superset.sh/api/agent/mcp",
+      "oauth": {
+        "clientId": "claude-code",
+        "authorizationUrl": "https://api.superset.sh/api/auth/mcp/authorize",
+        "tokenUrl": "https://api.superset.sh/api/auth/mcp/token",
+        "scopes": ["openid", "profile", "email"]
+      }
     }
   }
 }
 ```
 </Tab>
-<Tab value="HTTP">
-```json
+<Tab value="Claude Desktop">
+Add to your `claude_desktop_config.json`:
+
+```json title="claude_desktop_config.json"
 {
   "mcpServers": {
     "superset": {
       "type": "http",
       "url": "https://api.superset.sh/api/agent/mcp"
+    }
+  }
+}
+```
+</Tab>
+<Tab value="Cursor">
+Add to `.cursor/mcp.json` in your project root:
+
+```json title=".cursor/mcp.json"
+{
+  "mcpServers": {
+    "superset": {
+      "url": "https://api.superset.sh/api/agent/mcp"
+    }
+  }
+}
+```
+</Tab>
+<Tab value="Codex">
+Add to your `~/.codex/config.toml`:
+
+```toml title="config.toml"
+[mcp_servers.superset]
+url = "https://api.superset.sh/api/agent/mcp"
+```
+</Tab>
+<Tab value="Gemini CLI">
+Add to your `.gemini/settings.json`:
+
+```json title="settings.json"
+{
+  "mcpServers": {
+    "superset": {
+      "httpUrl": "https://api.superset.sh/api/agent/mcp"
+    }
+  }
+}
+```
+</Tab>
+<Tab value="Open Code">
+Add to your `opencode.json`:
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "superset": {
+      "type": "remote",
+      "url": "https://api.superset.sh/api/agent/mcp",
+      "enabled": true
     }
   }
 }
@@ -98,6 +138,52 @@ Add to your Cursor MCP settings:
 ## Authentication
 
 The MCP server uses OAuth 2.1. When you first connect, you'll be prompted to authorize the connection in your browser. The token is scoped to your active organization.
+
+### API Key Authentication
+
+For headless environments, CI/CD pipelines, or scripts where browser-based OAuth isn't practical, you can authenticate with an API key instead.
+
+**Generating an API key:**
+
+1. Open the Superset desktop app
+2. Go to **Settings > API Keys**
+3. Click **Create API Key**
+4. Copy the key (it starts with `sk_live_`)—you won't be able to see it again
+
+**Using the API key:**
+
+Pass the API key as a Bearer token in the `Authorization` header:
+
+```
+Authorization: Bearer sk_live_your_api_key_here
+```
+
+MCP clients that support custom headers can use this directly. For Claude Code, set the header in your `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "superset": {
+      "type": "http",
+      "url": "https://api.superset.sh/api/agent/mcp",
+      "headers": {
+        "Authorization": "Bearer sk_live_your_api_key_here"
+      }
+    }
+  }
+}
+```
+
+<Callout type="warn">
+API keys grant full access to your organization. Keep them secret and never commit them to version control. Use environment variables or secrets managers for CI/CD.
+</Callout>
+
+**When to use which method:**
+
+| Method | Best for |
+|--------|----------|
+| OAuth 2.1 | Interactive use — Claude Desktop, Claude Code, Cursor |
+| API Key | Headless/CI — scripts, automation, pipelines |
 
 ## Available Tools
 
@@ -117,6 +203,7 @@ The MCP server uses OAuth 2.1. When you first connect, you'll be prompted to aut
 | Tool | Description |
 |------|-------------|
 | `create_workspace` | Create a new git worktree workspace |
+| `update_workspace` | Update workspaces (rename) |
 | `switch_workspace` | Switch to a different workspace |
 | `delete_workspace` | Delete a workspace |
 | `list_workspaces` | List all workspaces on a device |
@@ -131,6 +218,13 @@ The MCP server uses OAuth 2.1. When you first connect, you'll be prompted to aut
 | `get_app_context` | Get current app state (active workspace, pathname) |
 | `list_members` | List organization members |
 
+### AI Sessions
+
+| Tool | Description |
+|------|-------------|
+| `start_claude_session` | Start an autonomous Claude Code session for a task. Creates a new workspace with its own git branch and launches Claude with the task context. |
+| `start_claude_subagent` | Start a Claude Code subagent in an existing workspace. Adds a new terminal pane instead of creating a new workspace. |
+
 ## Example Usage
 
 Once connected, you can ask your AI agent to:
@@ -139,3 +233,5 @@ Once connected, you can ask your AI agent to:
 - "List all my assigned tasks"
 - "Create a new workspace for the auth feature"
 - "Show me who's online in my team"
+- "Start a Claude session on my MacBook to work on the auth task"
+- "Spin up a subagent to fix the failing tests"


### PR DESCRIPTION
## Summary

- Restructured Setup section into **CLI Options** (Claude Code, Codex, Gemini CLI, Open Code) and **Manual Configuration** (6 client tabs) — verified against each client's official docs
- Added **API Key authentication** section with generation steps and usage examples
- Added 3 missing tools: `update_workspace`, `start_claude_session`, `start_claude_subagent`
- Added **AI Sessions** category to capabilities and tools tables

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun test` passes (1193 pass, 0 fail)
- [x] Lint errors are pre-existing, not from this change
- [x] All 18 MCP tools documented
- [ ] Visual review of rendered docs page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded MCP capabilities including workspace update and navigation options.
  * Added AI Sessions category with support for Claude sessions and subagents.
  * Introduced multi-client setup UI for Claude Code, Codex, Gemini CLI, and Open Code.
  * Added comprehensive configuration examples and API Key Authentication section with OAuth comparison.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->