### PR TITLE
feat(desktop): liquid glass sidebar on macOS

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -84,7 +84,12 @@ export default defineConfig({
 				output: {
 					dir: resolve(devPath, "main"),
 				},
-				external: ["electron", "better-sqlite3", "node-pty"],
+				external: [
+					"electron",
+					"better-sqlite3",
+					"node-pty",
+					"electron-liquid-glass",
+				],
 				plugins: [sentryPlugin].filter(Boolean),
 			},
 		},

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -112,6 +112,7 @@
 		"dnd-core": "^16.0.1",
 		"dotenv": "^17.2.3",
 		"drizzle-orm": "0.45.1",
+		"electron-liquid-glass": "^1.1.1",
 		"electron-updater": "6",
 		"execa": "^9.6.0",
 		"express": "^5.1.0",

--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -3,6 +3,7 @@ import { workspaces, worktrees } from "@superset/local-db";
 import { eq } from "drizzle-orm";
 import type { BrowserWindow } from "electron";
 import { Notification } from "electron";
+import liquidGlass from "electron-liquid-glass";
 import { createWindow } from "lib/electron-app/factories/windows/create";
 import { createAppRouter } from "lib/trpc/routers";
 import { localDb } from "main/lib/local-db";
@@ -83,6 +84,7 @@ export async function MainWindow() {
 		frame: false,
 		titleBarStyle: "hidden",
 		trafficLightPosition: { x: 16, y: 16 },
+		...(process.platform === "darwin" && { transparent: true }),
 		webPreferences: {
 			preload: join(__dirname, "../preload/index.js"),
 			webviewTag: true,
@@ -206,6 +208,10 @@ export async function MainWindow() {
 
 	window.webContents.on("did-finish-load", async () => {
 		console.log("[main-window] Renderer loaded successfully");
+		if (process.platform === "darwin") {
+			liquidGlass.addView(window.getNativeWindowHandle());
+			window.webContents.send("liquid-glass-active");
+		}
 		// Restore maximized state if it was saved
 		if (initialBounds.isMaximized) {
 			window.maximize();

--- a/apps/desktop/src/renderer/globals.css
+++ b/apps/desktop/src/renderer/globals.css
@@ -51,6 +51,20 @@
 	--sidebar-ring: oklch(0.439 0 0);
 }
 
+/* Liquid Glass: transparent body lets native NSGlassEffectView show through.
+   --background stays opaque so content areas are solid.
+   Only --sidebar gets transparency for the glass effect. */
+:root.liquid-glass {
+	--sidebar: oklch(0.145 0 0 / 0.4);
+	--sidebar-accent: oklch(0.269 0 0 / 0.5);
+	--sidebar-border: oklch(0.269 0 0 / 0.3);
+}
+:root.liquid-glass.light {
+	--sidebar: oklch(1 0 0 / 0.4);
+	--sidebar-accent: oklch(0.97 0 0 / 0.5);
+	--sidebar-border: oklch(0.922 0 0 / 0.3);
+}
+
 /* Light theme fallback values - applied before hydration if user has light theme saved */
 :root.light {
 	--background: oklch(1 0 0);
@@ -142,6 +156,12 @@
 
 	body {
 		@apply bg-background text-foreground;
+	}
+
+	/* Liquid glass: body must be fully transparent so the native glass shows.
+	   The <app> element paints bg-background instead so content areas are covered. */
+	.liquid-glass body {
+		background: transparent;
 	}
 
 	html,

--- a/apps/desktop/src/renderer/index.tsx
+++ b/apps/desktop/src/renderer/index.tsx
@@ -32,10 +32,21 @@ const handleDeepLink = (path: string) => {
 };
 window.ipcRenderer.on("deep-link-navigate", handleDeepLink);
 
+const handleLiquidGlass = () => {
+	const root = document.documentElement;
+	root.classList.add("liquid-glass");
+	// Remove inline styles that would override the semi-transparent CSS values
+	for (const v of ["--sidebar", "--sidebar-accent", "--sidebar-border"]) {
+		root.style.removeProperty(v);
+	}
+};
+window.ipcRenderer.on("liquid-glass-active", handleLiquidGlass);
+
 if (import.meta.hot) {
 	import.meta.hot.dispose(() => {
 		unsubscribe();
 		window.ipcRenderer.off("deep-link-navigate", handleDeepLink);
+		window.ipcRenderer.off("liquid-glass-active", handleLiquidGlass);
 	});
 }
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -105,7 +105,9 @@ function DashboardLayout() {
 						<WorkspaceSidebar isCollapsed={isWorkspaceSidebarCollapsed()} />
 					</ResizablePanel>
 				)}
-				<Outlet />
+				<div className="flex-1 overflow-hidden bg-background">
+					<Outlet />
+				</div>
 			</div>
 		</div>
 	);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -29,7 +29,7 @@ export function WorkspaceSidebar({
 	);
 
 	return (
-		<SidebarDropZone className="flex flex-col h-full bg-background">
+		<SidebarDropZone className="flex flex-col h-full bg-sidebar">
 			<WorkspaceSidebarHeader isCollapsed={isCollapsed} />
 
 			<div className="flex-1 overflow-y-auto hide-scrollbar">

--- a/apps/desktop/src/renderer/stores/theme/utils/css-variables.ts
+++ b/apps/desktop/src/renderer/stores/theme/utils/css-variables.ts
@@ -40,13 +40,25 @@ const UI_COLOR_TO_CSS_VAR: Record<keyof UIColors, string> = {
 	chart5: "--chart-5",
 };
 
+// Variables managed by liquid glass CSS — inline styles would override the
+// semi-transparent values needed for the native glass effect to show through.
+const LIQUID_GLASS_MANAGED_VARS = new Set([
+	"--sidebar",
+	"--sidebar-accent",
+	"--sidebar-border",
+]);
+
 /**
  * Apply UI colors to CSS variables on :root
  */
 export function applyUIColors(colors: UIColors): void {
 	const root = document.documentElement;
+	const isLiquidGlass = root.classList.contains("liquid-glass");
 
 	for (const [key, cssVar] of Object.entries(UI_COLOR_TO_CSS_VAR)) {
+		// Skip variables controlled by liquid glass CSS to preserve transparency
+		if (isLiquidGlass && LIQUID_GLASS_MANAGED_VARS.has(cssVar)) continue;
+
 		const value = colors[key as keyof UIColors];
 		if (value) {
 			root.style.setProperty(cssVar, value);

--- a/bun.lock
+++ b/bun.lock
@@ -131,7 +131,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "0.0.65",
+      "version": "0.0.67",
       "dependencies": {
         "@better-auth/stripe": "1.4.17",
         "@dnd-kit/core": "^6.3.1",
@@ -212,6 +212,7 @@
         "dnd-core": "^16.0.1",
         "dotenv": "^17.2.3",
         "drizzle-orm": "0.45.1",
+        "electron-liquid-glass": "^1.1.1",
         "electron-updater": "6",
         "execa": "^9.6.0",
         "express": "^5.1.0",
@@ -2890,6 +2891,8 @@
 
     "electron-extension-installer": ["electron-extension-installer@2.0.1", "", { "dependencies": { "jszip": "^3.10.1" }, "peerDependencies": { "electron": ">=36.0.0" } }, "sha512-pFdtmilltpZrjt568an4cwRZ0NPPLSiC0noZ3Bj9dE2O07jvDhFLNQZop4BudNJBhVSnlDHj4LznV3Y+9Q+tug=="],
 
+    "electron-liquid-glass": ["electron-liquid-glass@1.1.1", "", { "dependencies": { "bindings": "^1.5.0", "node-addon-api": "^8.4.0" }, "optionalDependencies": { "node-gyp-build": "^4" }, "os": "darwin" }, "sha512-AfPxcu6RJYxlsW2sjgjDEON0rVOjhh5QYM6ur5hsfILQmfY5ewHCWJZJZoDsQxhjeW1DAhbRbvB79IvgW4ansA=="],
+
     "electron-publish": ["electron-publish@26.3.4", "", { "dependencies": { "@types/fs-extra": "^9.0.11", "builder-util": "26.3.4", "builder-util-runtime": "9.5.1", "chalk": "^4.1.2", "form-data": "^4.0.0", "fs-extra": "^10.1.0", "lazy-val": "^1.0.5", "mime": "^2.5.2" } }, "sha512-5/ouDPb73SkKuay2EXisPG60LTFTMNHWo2WLrK5GDphnWK9UC+yzYrzVeydj078Yk4WUXi0+TaaZsNd6Zt5k/A=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.278", "", {}, "sha512-dQ0tM1svDRQOwxnXxm+twlGTjr9Upvt8UFWAgmLsxEzFQxhbti4VwxmMjsDxVC51Zo84swW7FVCXEV+VAkhuPw=="],
@@ -3897,6 +3900,8 @@
     "node-forge": ["node-forge@1.3.3", "", {}, "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg=="],
 
     "node-gyp": ["node-gyp@11.5.0", "", { "dependencies": { "env-paths": "^2.2.0", "exponential-backoff": "^3.1.1", "graceful-fs": "^4.2.6", "make-fetch-happen": "^14.0.3", "nopt": "^8.0.0", "proc-log": "^5.0.0", "semver": "^7.3.5", "tar": "^7.4.3", "tinyglobby": "^0.2.12", "which": "^5.0.0" }, "bin": { "node-gyp": "bin/node-gyp.js" } }, "sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ=="],
+
+    "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
 
     "node-int64": ["node-int64@0.4.0", "", {}, "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="],
 
@@ -5377,6 +5382,8 @@
     "electron/@types/node": ["@types/node@22.19.7", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw=="],
 
     "electron-builder/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "electron-liquid-glass/node-addon-api": ["node-addon-api@8.5.0", "", {}, "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A=="],
 
     "electron-publish/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 


### PR DESCRIPTION
## Summary
- Integrates `electron-liquid-glass` for native macOS Tahoe liquid glass effect
- Sidebar uses semi-transparent backgrounds so the native `NSGlassEffectView` shows through
- Content areas and TopBar remain fully opaque for readability
- Theme store skips overriding glass-managed CSS variables to preserve transparency
- Safe no-op on Windows/Linux — `transparent: true` only set on macOS

## Remaining work
- [ ] Glass tinting / `tintColor` tuning for better visual appearance
- [ ] TopBar glass integration
- [ ] Light theme tuning  
- [ ] Testing across macOS versions (Tahoe vs older fallback to `NSVisualEffectView`)
- [ ] Consider making glass a user preference / toggle
- [ ] Polish sidebar item hover/active states for glass context

## Test plan
- Build and run desktop app on macOS 26+ — sidebar should show glass effect
- Verify content area (terminals, changes panel) is fully opaque
- Verify Windows/Linux builds are unaffected
- Toggle light/dark theme and confirm sidebar stays glassy