### PR TITLE
docs: add lint:fix and gh CLI preference to agent rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,8 @@ bun run clean:workspaces   # Clean all workspace node_modules
 2. **Follow existing patterns** - match the codebase style
 3. **Type safety** - avoid `any` unless necessary
 4. **Search narrowly** - avoid reading large files/assets
+5. **Lint = lint:fix** - when running lint, always use `bun run lint:fix` (not `bun run lint`) so issues are auto-fixed
+6. **Prefer `gh` CLI** - when performing git operations (PRs, issues, checkout, etc.), prefer the GitHub CLI (`gh`) over raw `git` commands where possible
 
 ---
 


### PR DESCRIPTION
## Summary
- Add agent rule to always use `bun run lint:fix` instead of `bun run lint` so issues are auto-fixed
- Add agent rule to prefer `gh` CLI over raw `git` commands where possible

## Test plan
- [ ] Verify AGENTS.md renders correctly on GitHub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated agent guidelines to include recommendations for linting procedures and GitHub CLI usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->