### PR TITLE
fix(mcp): add worktree keyword to workspace tool descriptions

### DIFF
--- a/packages/mcp/src/tools/devices/create-workspace/create-workspace.ts
+++ b/packages/mcp/src/tools/devices/create-workspace/create-workspace.ts
@@ -21,7 +21,8 @@ export function register(server: McpServer) {
 	server.registerTool(
 		"create_workspace",
 		{
-			description: "Create one or more git worktree workspaces on a device",
+			description:
+				"Create one or more workspaces (git worktrees) on a device. Use this when the user asks to create worktrees or workspaces.",
 			inputSchema: {
 				deviceId: z.string().describe("Target device ID"),
 				workspaces: z

--- a/packages/mcp/src/tools/devices/delete-workspace/delete-workspace.ts
+++ b/packages/mcp/src/tools/devices/delete-workspace/delete-workspace.ts
@@ -6,7 +6,7 @@ export function register(server: McpServer) {
 	server.registerTool(
 		"delete_workspace",
 		{
-			description: "Delete one or more workspaces on a device",
+			description: "Delete one or more workspaces (git worktrees) on a device",
 			inputSchema: {
 				deviceId: z.string().describe("Target device ID"),
 				workspaceIds: z

--- a/packages/mcp/src/tools/devices/navigate-to-workspace/navigate-to-workspace.ts
+++ b/packages/mcp/src/tools/devices/navigate-to-workspace/navigate-to-workspace.ts
@@ -6,7 +6,8 @@ export function register(server: McpServer) {
 	server.registerTool(
 		"navigate_to_workspace",
 		{
-			description: "Navigate the desktop app to a specific workspace",
+			description:
+				"Navigate the desktop app to a specific workspace (git worktree)",
 			inputSchema: {
 				deviceId: z.string().describe("Target device ID"),
 				workspaceId: z

--- a/packages/mcp/src/tools/devices/switch-workspace/switch-workspace.ts
+++ b/packages/mcp/src/tools/devices/switch-workspace/switch-workspace.ts
@@ -6,7 +6,7 @@ export function register(server: McpServer) {
 	server.registerTool(
 		"switch_workspace",
 		{
-			description: "Switch to a different workspace",
+			description: "Switch to a different workspace (git worktree)",
 			inputSchema: {
 				deviceId: z.string().describe("Target device ID"),
 				workspaceId: z

--- a/packages/mcp/src/tools/devices/update-workspace/update-workspace.ts
+++ b/packages/mcp/src/tools/devices/update-workspace/update-workspace.ts
@@ -12,7 +12,7 @@ export function register(server: McpServer) {
 		"update_workspace",
 		{
 			description:
-				"Update one or more workspaces on a device. Currently supports renaming.",
+				"Update one or more workspaces (git worktrees) on a device. Currently supports renaming.",
 			inputSchema: {
 				deviceId: z.string().describe("Target device ID"),
 				updates: z


### PR DESCRIPTION
## Summary
- Adds "git worktree(s)" terminology to all workspace MCP tool descriptions so agents correctly route user requests about "worktrees" to workspace tools
- `create_workspace` gets an explicit hint: "Use this when the user asks to create worktrees or workspaces"
- Other workspace tools (`delete`, `switch`, `update`, `navigate_to`) get a consistent `(git worktree)` parenthetical

## Concern
Not 100% sure the extra hint on `create_workspace` won't confuse the agent in edge cases — open to tweaking the wording.

## Test plan
- [ ] Verify agents route "create worktrees" requests to `create_workspace`
- [ ] Verify normal "create workspace" requests still work
- [ ] Spot check that other workspace tools show updated descriptions in MCP tool listing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced workspace tool descriptions to improve clarity. The create, delete, navigate, switch, and update workspace tools now explicitly reference "git worktrees" in their descriptions, providing better context to users on the underlying technology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->