### PR TITLE
fix: disable LFS lock verification for external contributors

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,0 +1,2 @@
+[lfs]
+	locksverify = false


### PR DESCRIPTION
## Summary
- Adds `.lfsconfig` with `locksverify = false` to the repo root
- Fixes Git LFS lock verification errors that external contributors hit when pushing to their forks (LFS tries to verify locks against the upstream endpoint where they lack push access)
- The config file travels with the repo, so it requires zero action from contributors

## Test plan
- [ ] Verify `.lfsconfig` is present at repo root after merge
- [ ] Have an external contributor confirm they can push to their fork without LFS lock errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Git LFS configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->