### PR TITLE
fix: deduplicate task statuses from multi-team Linear syncs

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/StatusProperty/StatusProperty.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/StatusProperty/StatusProperty.tsx
@@ -14,7 +14,10 @@ import {
 } from "../../../../../components/TasksView/components/shared/StatusIcon";
 import { StatusMenuItems } from "../../../../../components/TasksView/components/shared/StatusMenuItems";
 import type { TaskWithStatus } from "../../../../../components/TasksView/hooks/useTasksTable";
-import { compareStatusesForDropdown } from "../../../../../components/TasksView/utils/sorting";
+import {
+	compareStatusesForDropdown,
+	deduplicateStatuses,
+} from "../../../../../components/TasksView/utils/sorting";
 
 interface StatusPropertyProps {
 	task: TaskWithStatus;
@@ -33,7 +36,7 @@ export function StatusProperty({ task }: StatusPropertyProps) {
 	const currentStatus = task.status;
 
 	const sortedStatuses = useMemo(() => {
-		return statuses.sort(compareStatusesForDropdown);
+		return deduplicateStatuses(statuses.sort(compareStatusesForDropdown));
 	}, [statuses]);
 
 	const handleSelectStatus = (newStatus: SelectTaskStatus) => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTableView/components/TaskContextMenu/TaskContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTableView/components/TaskContextMenu/TaskContextMenu.tsx
@@ -17,7 +17,10 @@ import {
 } from "react-icons/hi2";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { TaskWithStatus } from "../../../../hooks/useTasksTable";
-import { compareStatusesForDropdown } from "../../../../utils/sorting";
+import {
+	compareStatusesForDropdown,
+	deduplicateStatuses,
+} from "../../../../utils/sorting";
 import { AssigneeMenuItems } from "../../../shared/AssigneeMenuItems";
 import { ActiveIcon } from "../../../shared/icons/ActiveIcon";
 import { PriorityMenuIcon } from "../../../shared/icons/PriorityMenuIcon";
@@ -51,7 +54,9 @@ export function TaskContextMenu({
 
 	const sortedStatuses = useMemo(() => {
 		if (!allStatuses) return [];
-		return [...allStatuses].sort(compareStatusesForDropdown);
+		return deduplicateStatuses(
+			[...allStatuses].sort(compareStatusesForDropdown),
+		);
 	}, [allStatuses]);
 
 	const users = useMemo(() => allUsers || [], [allUsers]);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/hooks/useTasksTable/components/StatusCell/StatusCell.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/hooks/useTasksTable/components/StatusCell/StatusCell.tsx
@@ -13,7 +13,10 @@ import {
 	type StatusType,
 } from "../../../../components/shared/StatusIcon";
 import { StatusMenuItems } from "../../../../components/shared/StatusMenuItems";
-import { compareStatusesForDropdown } from "../../../../utils/sorting";
+import {
+	compareStatusesForDropdown,
+	deduplicateStatuses,
+} from "../../../../utils/sorting";
 import type { TaskWithStatus } from "../../useTasksTable";
 
 interface StatusCellProps {
@@ -33,7 +36,7 @@ export function StatusCell({ taskWithStatus }: StatusCellProps) {
 	const currentStatus = taskWithStatus.status;
 
 	const sortedStatuses = useMemo(() => {
-		return statuses.sort(compareStatusesForDropdown);
+		return deduplicateStatuses(statuses.sort(compareStatusesForDropdown));
 	}, [statuses]);
 
 	const handleSelectStatus = (newStatus: SelectTaskStatus) => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/utils/sorting/sorting.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/utils/sorting/sorting.ts
@@ -88,6 +88,19 @@ export function compareTasks(
 	return priorityOrderA - priorityOrderB;
 }
 
+/** Multiple Linear teams can create duplicate status entries with the same name and type */
+export function deduplicateStatuses(
+	statuses: SelectTaskStatus[],
+): SelectTaskStatus[] {
+	const seen = new Set<string>();
+	return statuses.filter((status) => {
+		const key = `${status.name}:${status.type}`;
+		if (seen.has(key)) return false;
+		seen.add(key);
+		return true;
+	});
+}
+
 /**
  * Compare two statuses for dropdown sorting.
  * Sort order: status type (workflow order) → status position

--- a/packages/mcp/src/tools/tasks/list-task-statuses/list-task-statuses.ts
+++ b/packages/mcp/src/tools/tasks/list-task-statuses/list-task-statuses.ts
@@ -26,7 +26,7 @@ export function register(server: McpServer) {
 		async (_args, extra) => {
 			const ctx = getMcpContext(extra);
 
-			const statuses = await db
+			const allStatuses = await db
 				.select({
 					id: taskStatuses.id,
 					name: taskStatuses.name,
@@ -37,6 +37,14 @@ export function register(server: McpServer) {
 				.from(taskStatuses)
 				.where(eq(taskStatuses.organizationId, ctx.organizationId))
 				.orderBy(taskStatuses.position);
+
+			const seen = new Set<string>();
+			const statuses = allStatuses.filter((s) => {
+				const key = `${s.name}:${s.type}`;
+				if (seen.has(key)) return false;
+				seen.add(key);
+				return true;
+			});
 
 			return {
 				structuredContent: { statuses },


### PR DESCRIPTION
## Summary
- When an org has multiple Linear teams, each team's workflow states (e.g., "Backlog", "Todo") were synced as separate DB rows, causing duplicate statuses in the task view dropdown
- Deduplicate states across teams by `(name, type)` during Linear sync so only one row per unique status is created
- Add `deduplicateStatuses` utility and apply it in all status dropdowns (StatusProperty, StatusCell, TaskContextMenu) and the MCP `list_task_statuses` tool to handle existing duplicate data

## Test plan
- [ ] Connect a Linear workspace with multiple teams that share status names
- [ ] Verify the task status dropdown shows each status only once
- [ ] Verify the context menu status submenu shows each status only once
- [ ] Verify `list_task_statuses` MCP tool returns deduplicated statuses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed duplicate statuses from appearing in status selection menus and dropdowns across the task management interface.
  * Ensured workflow states sync cleanly from Linear integrations without duplication across teams.
  * Deduplicated task statuses in list operations to prevent redundant entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->