### PR TITLE
fix(desktop): show branch subtitle for main workspace list item when branch name differs

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -289,7 +289,7 @@ export function WorkspaceListItem({
 	const showDiffStats = !!diffStats;
 
 	// Determine if we should show the branch subtitle
-	const showBranchSubtitle = !isBranchWorkspace;
+	const showBranchSubtitle = !isBranchWorkspace || (!!name && name !== branch);
 
 	// Collapsed sidebar: show just the icon with hover card (worktree) or tooltip (branch)
 	if (isCollapsed) {
@@ -345,6 +345,11 @@ export function WorkspaceListItem({
 					<TooltipTrigger asChild>{collapsedButton}</TooltipTrigger>
 					<TooltipContent side="right" className="flex flex-col gap-0.5">
 						<span className="font-medium">{name || branch}</span>
+						{showBranchSubtitle && (
+							<span className="text-xs text-muted-foreground font-mono">
+								{branch}
+							</span>
+						)}
 						<span className="text-xs text-muted-foreground">
 							Local workspace
 						</span>


### PR DESCRIPTION
## Description

Show the branch subtitle for the **main (branch) workspace menu item** only when the workspace name differs from the branch, so we avoid duplicate labels while still exposing the current branch when a custom name is used.

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

- [x] Bug fix
- [-] New feature
- [-] Documentation
- [-] Refactor
- [-] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

| Before | After |
| --- | --- |
| <img width="942" height="433" alt="Screenshot 2026-02-04 at 21 28 40" src="https://github.com/user-attachments/assets/c4e71db1-6a0b-4d62-864d-b2560074223b" /> | <img width="868" height="414" alt="Screenshot 2026-02-04 at 21 25 19" src="https://github.com/user-attachments/assets/e1757db1-f86c-448d-b53a-3e950a985696" /> | 

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved branch name display logic in workspace sidebar to more accurately show branch information in tooltips when branch names differ from branch labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->