### PR TITLE
fix(desktop): resolve TypeScript errors in renderer and FilesView

### DIFF
--- a/apps/desktop/src/renderer/index.tsx
+++ b/apps/desktop/src/renderer/index.tsx
@@ -41,7 +41,7 @@ const handleDeepLink = (path: string) => {
 	console.log("[deep-link] Navigating to:", path);
 	router.navigate({ to: path });
 };
-if (window.ipcRenderer?.on && window.ipcRenderer?.off) {
+if (window.ipcRenderer) {
 	window.ipcRenderer.on("deep-link-navigate", handleDeepLink);
 } else {
 	reportBootError(

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
@@ -1,6 +1,7 @@
 import {
 	asyncDataLoaderFeature,
 	expandAllFeature,
+	type ItemInstance,
 	selectionFeature,
 } from "@headless-tree/core";
 import { useTree } from "@headless-tree/react";
@@ -49,8 +50,10 @@ export function FilesView() {
 
 	const tree = useTree<DirectoryEntry>({
 		rootItemId: "root",
-		getItemName: (item) => item.getItemData()?.name ?? "",
-		isItemFolder: (item) => item.getItemData()?.isDirectory ?? false,
+		getItemName: (item: ItemInstance<DirectoryEntry>) =>
+			item.getItemData()?.name ?? "",
+		isItemFolder: (item: ItemInstance<DirectoryEntry>) =>
+			item.getItemData()?.isDirectory ?? false,
 		dataLoader: {
 			getItem: async (itemId: string): Promise<DirectoryEntry> => {
 				if (itemId === "root") {
@@ -120,7 +123,10 @@ export function FilesView() {
 					? "root"
 					: tree
 							.getItems()
-							.find((item) => item.getItemData()?.path === parentPath)
+							.find(
+								(item: ItemInstance<DirectoryEntry>) =>
+									item.getItemData()?.path === parentPath,
+							)
 							?.getId();
 				if (itemId) {
 					await tree.getItemInstance(itemId)?.invalidateChildrenIds();
@@ -171,7 +177,10 @@ export function FilesView() {
 			if (parentPath !== worktreePath) {
 				const item = tree
 					.getItems()
-					.find((i) => i.getItemData()?.path === parentPath);
+					.find(
+						(i: ItemInstance<DirectoryEntry>) =>
+							i.getItemData()?.path === parentPath,
+					);
 				if (item && !item.isExpanded()) {
 					await item.expand();
 				}
@@ -187,7 +196,10 @@ export function FilesView() {
 			if (parentPath !== worktreePath) {
 				const item = tree
 					.getItems()
-					.find((i) => i.getItemData()?.path === parentPath);
+					.find(
+						(i: ItemInstance<DirectoryEntry>) =>
+							i.getItemData()?.path === parentPath,
+					);
 				if (item && !item.isExpanded()) {
 					await item.expand();
 				}
@@ -339,7 +351,7 @@ export function FilesView() {
 								)
 							) : (
 								<div {...tree.getContainerProps()} className="outline-none">
-									{tree.getItems().map((item) => {
+									{tree.getItems().map((item: ItemInstance<DirectoryEntry>) => {
 										const data = item.getItemData();
 										if (!data || item.getId() === "root") return null;
 										const showNewItemInput =


### PR DESCRIPTION
## Summary
- Fix `TS2774` in `index.tsx`: simplify `window.ipcRenderer?.on && window.ipcRenderer?.off` to `window.ipcRenderer` — the methods are always defined when the object exists
- Fix `TS7006` implicit `any` in `FilesView.tsx`: add explicit `ItemInstance<DirectoryEntry>` type annotations to callback parameters in `useTree` config and `.find()`/`.map()` calls

## Test plan
- [ ] Verify `bun run typecheck` passes for `@superset/desktop`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of deep-link listener initialization detection.

* **Refactor**
  * Enhanced type safety in file tree operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->