### PR TITLE
fix: nested hidden folders not showing when 'Show Hidden Files' enabled

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/hooks/useFileTree.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/hooks/useFileTree.ts
@@ -56,6 +56,12 @@ export function useFileTree({
 		}));
 	}, [rootEntries]);
 
+	// Clear children cache when showHiddenFiles changes to ensure nested
+	// hidden files/folders are properly shown or hidden
+	useEffect(() => {
+		setChildrenCache({});
+	}, [showHiddenFiles]);
+
 	const buildTree = useCallback(
 		(nodes: FileTreeNode[]): FileTreeNode[] => {
 			return nodes.map((node) => {

--- a/bun.lock
+++ b/bun.lock
@@ -131,7 +131,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "0.0.67",
+      "version": "0.0.68",
       "dependencies": {
         "@better-auth/stripe": "1.4.17",
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Problem

Fixes #1193

When toggling 'Show Hidden Files' in the file browser, hidden folders at the root level would correctly appear, but nested hidden folders inside non-hidden directories would not show.

## Root Cause

The `useFileTree` hook caches children of expanded folders in `childrenCache`. When `showHiddenFiles` changed, the root directory query correctly re-fetched with `includeHidden: true`, but the cached children of expanded folders were not invalidated. This meant nested directories kept using stale cached data that was fetched without hidden files.

## Solution

Added a `useEffect` that clears `childrenCache` whenever `showHiddenFiles` changes. This ensures all nested directories will be re-fetched with the correct `includeHidden` setting when the toggle is changed.

## Testing

- Toggle 'Show Hidden Files' now correctly shows/hides hidden folders at all nesting levels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where nested hidden files and folders would not display correctly when toggling the show hidden files setting. The file tree now properly refreshes when this preference changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->