### PR TITLE
fix(desktop): show nested hidden files/folders when toggle is enabled

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
@@ -270,6 +270,9 @@ export function FilesView() {
 	const handleToggleHiddenFiles = useCallback(() => {
 		setShowHiddenFiles((v) => !v);
 		tree.getItemInstance("root")?.invalidateChildrenIds();
+		for (const itemId of tree.getState().expandedItems) {
+			tree.getItemInstance(itemId)?.invalidateChildrenIds();
+		}
 	}, [tree]);
 
 	const searchResultEntries = useMemo(() => {


### PR DESCRIPTION
## Summary
- Fixes #1193
- When toggling "Show Hidden Files" in the file browser, only root-level hidden items appeared. Nested hidden folders/files inside expanded directories remained invisible because only the root's children cache was invalidated.
- Now invalidates the headless-tree children cache for **all expanded items** (via `tree.getState().expandedItems`), not just root, so hidden entries appear at every directory level.

## Note on #1213
PR #1213 attempts to fix this by clearing `childrenCache` in the `useFileTree` hook, but that hook is **not imported or used** by `FilesView.tsx`. The active file tree uses `@headless-tree/react`'s `useTree` with `asyncDataLoaderFeature` directly, which has its own internal cache. This PR targets the correct code path.

## Test plan
- [ ] Enable "Show Hidden Files" toggle in file browser
- [ ] Expand a non-hidden folder that contains hidden subfolders/files (e.g. `folder/.hidden-subfolder`)
- [ ] Verify nested hidden items appear at all levels
- [ ] Toggle off — verify nested hidden items disappear at all levels
- [ ] Collapse a folder, toggle hidden files, re-expand — verify correct state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where toggling hidden files didn't update visibility across all expanded items in the file tree, ensuring consistent display throughout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->