### PR TITLE
feat(dx): add /create-pr and /respond-to-pr-comments slash commands

### DIFF
--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -14,14 +14,16 @@ Create a pull request for the current branch.
 ## Step 2: Analyze Changes
 
 Run in parallel:
-- `git log main..HEAD --oneline`
-- `git diff main...HEAD`
+- `git log main..HEAD --oneline` — commit history
+- `git log main..HEAD --format="%B---"` — full commit messages for context
+- `git diff main...HEAD --stat` — file change overview
+- `git diff main...HEAD` — full diff
 
 Read the diff carefully to understand what changed and why.
 
 ## Step 3: Generate PR
 
-Based on the actual diff, draft:
+Based on the actual diff and commit messages, draft:
 
 **Title**: `<type>(<scope>): <description>` (under 72 chars)
 - Types: feat, fix, chore, refactor, docs, test, perf, ci
@@ -30,6 +32,9 @@ Based on the actual diff, draft:
 ```markdown
 ## Summary
 <2-4 bullets: what changed and WHY>
+
+## Changes
+<Bulleted list of specific changes — group by area if touching multiple packages>
 
 ## Test Plan
 - [ ] <specific verification steps>

--- a/.claude/commands/respond-to-pr-comments.md
+++ b/.claude/commands/respond-to-pr-comments.md
@@ -16,16 +16,20 @@ Stop if no PR exists or it's closed/merged.
 
 List each comment with: reviewer, file/line (if inline), and the comment text.
 
-Mark as **BLOCKER** if it requests a required change or flags a bug. Everything else is lower priority.
+Categorize each:
+- **BLOCKER** — requests a required change or flags a bug/security issue
+- **QUESTION** — asks for clarification (needs a reply)
+- **SUGGESTION** — optional improvement (may ignore or adopt)
+- **NITPICK** — minor style issue (fix quickly or ignore)
 
-Address BLOCKERs first.
+Address BLOCKERs first, then QUESTIONs.
 
 ## Step 3: Address Each
 
 For each comment:
 1. Read the relevant code for context
 2. Either make the fix, or draft a reply if it needs discussion
-3. For BLOCKERs, confirm with user before making changes
+3. **For BLOCKERs: show the user what you plan to change before editing**
 
 Summarize what you changed and any replies needed.
 


### PR DESCRIPTION
## Summary
- Add custom Claude Code slash commands for common PR workflows to `.claude/commands/`
- `/create-pr` analyzes actual git log/diff, generates a structured PR with title, summary, changes, and test plan, then asks for approval before creating
- `/respond-to-pr-comments` fetches all review comments via `gh` CLI, categorizes them by priority (blocker → nitpick), and addresses each systematically
- Both commands follow best practices: context validation first, structured output, human-in-the-loop gates, reality-grounded content

## Changes
- Added `.claude/commands/create-pr.md` — 5-step workflow: validate context → gather diff → generate PR content → approval gate → create PR
- Added `.claude/commands/respond-to-pr-comments.md` — 6-step workflow: validate context → fetch comments → categorize → present summary → address comments → final summary

## Test Plan
- [ ] Run `/create-pr` on a feature branch and verify it generates a structured PR description based on actual diff
- [ ] Run `/respond-to-pr-comments` on a branch with an open PR that has review comments
- [ ] Verify context validation catches: wrong branch (main), missing `gh` auth, no open PR
- [ ] Verify human approval gate in `/create-pr` blocks until explicit approval

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added step-by-step workflow documentation for pull request creation and for responding to PR review comments, covering validation, context gathering, prioritization, and approval steps.

* **Chores**
  * Added templates and procedural guides to standardize PR handling and review-feedback workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->