### PR TITLE
fix(desktop): nested hidden files not showing when toggle enabled

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
@@ -268,8 +268,20 @@ export function FilesView() {
 	}, [tree]);
 
 	const handleToggleHiddenFiles = useCallback(() => {
-		setShowHiddenFiles((v) => !v);
+		setShowHiddenFiles((prev) => {
+			const newValue = !prev;
+			// Update ref synchronously so invalidation uses correct value
+			showHiddenFilesRef.current = newValue;
+			return newValue;
+		});
+		// Invalidate root explicitly (getItems() may not include it)
 		tree.getItemInstance("root")?.invalidateChildrenIds();
+		// Also invalidate expanded directories so nested hidden files appear
+		for (const item of tree.getItems()) {
+			if (item.getItemData()?.isDirectory) {
+				item.invalidateChildrenIds();
+			}
+		}
 	}, [tree]);
 
 	const searchResultEntries = useMemo(() => {


### PR DESCRIPTION
## Summary

Fixes an issue where nested hidden folders/files don't appear when "Show Hidden Files" is enabled in the file browser.

**Root cause:** The toggle only invalidated the root directory's children cache, so nested expanded folders kept their stale children (fetched with `includeHidden: false`).

**Fix:**
- Update the ref synchronously before invalidation so `getChildren` uses the correct `includeHidden` value
- Invalidate all expanded directories on toggle, not just root

## Test plan

1. Open a workspace with nested folders containing hidden items (e.g., `.github/` inside a subfolder)
2. Expand the folder tree to show nested folders
3. Toggle "Show Hidden Files" on
4. Verify hidden folders/files appear at all levels, not just root

Closes #1193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hidden file visibility toggle to properly refresh all nested directories, ensuring hidden files within subdirectories display correctly when visibility settings are changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->