### PR TITLE
feat(marketing): add custom 404 not-found page

### DIFF
--- a/apps/marketing/src/app/components/NotFoundGrid/NotFoundGrid.tsx
+++ b/apps/marketing/src/app/components/NotFoundGrid/NotFoundGrid.tsx
@@ -1,0 +1,44 @@
+export function NotFoundGrid() {
+	return (
+		<div className="absolute inset-0 pointer-events-none" aria-hidden="true">
+			<svg
+				className="absolute inset-0 w-full h-full"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<title>grid</title>
+				<defs>
+					<pattern
+						id="notfound-grid"
+						width="60"
+						height="60"
+						patternUnits="userSpaceOnUse"
+					>
+						<path
+							d="M 60 0 L 0 0 0 60"
+							fill="none"
+							stroke="rgba(255,255,255,0.06)"
+							strokeWidth="1"
+						/>
+					</pattern>
+					<radialGradient id="notfound-grid-fade" cx="50%" cy="50%" r="50%">
+						<stop offset="0%" stopColor="white" stopOpacity="1" />
+						<stop offset="75%" stopColor="white" stopOpacity="0.95" />
+						<stop offset="85%" stopColor="white" stopOpacity="0.7" />
+						<stop offset="92%" stopColor="white" stopOpacity="0.3" />
+						<stop offset="96%" stopColor="white" stopOpacity="0.1" />
+						<stop offset="100%" stopColor="white" stopOpacity="0" />
+					</radialGradient>
+					<mask id="notfound-grid-mask">
+						<rect width="100%" height="100%" fill="url(#notfound-grid-fade)" />
+					</mask>
+				</defs>
+				<rect
+					width="100%"
+					height="100%"
+					fill="url(#notfound-grid)"
+					mask="url(#notfound-grid-mask)"
+				/>
+			</svg>
+		</div>
+	);
+}

--- a/apps/marketing/src/app/components/NotFoundGrid/index.ts
+++ b/apps/marketing/src/app/components/NotFoundGrid/index.ts
@@ -1,0 +1,1 @@
+export { NotFoundGrid } from "./NotFoundGrid";

--- a/apps/marketing/src/app/components/Pixel404/Pixel404.tsx
+++ b/apps/marketing/src/app/components/Pixel404/Pixel404.tsx
@@ -1,0 +1,67 @@
+export function Pixel404() {
+	const s = 14;
+	const g = 16;
+
+	const d4a: [number, number][] = [
+		[0, 0],
+		[2, 0],
+		[0, 1],
+		[2, 1],
+		[0, 2],
+		[1, 2],
+		[2, 2],
+		[2, 3],
+		[2, 4],
+	];
+	const d0: [number, number][] = [
+		[4, 0],
+		[5, 0],
+		[6, 0],
+		[4, 1],
+		[6, 1],
+		[4, 2],
+		[6, 2],
+		[4, 3],
+		[6, 3],
+		[4, 4],
+		[5, 4],
+		[6, 4],
+	];
+	const d4b: [number, number][] = [
+		[8, 0],
+		[10, 0],
+		[8, 1],
+		[10, 1],
+		[8, 2],
+		[9, 2],
+		[10, 2],
+		[10, 3],
+		[10, 4],
+	];
+
+	const pixels = [...d4a, ...d0, ...d4b];
+
+	return (
+		<svg
+			viewBox={`0 0 ${10 * g + s} ${4 * g + s}`}
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			className="w-full max-w-[480px]"
+			aria-label="404"
+		>
+			<title>404</title>
+			{pixels.map(([col, row]) => (
+				<rect
+					key={`${col}-${row}`}
+					x={col * g}
+					y={row * g}
+					width={s}
+					height={s}
+					fill="rgba(255,255,255,0.04)"
+					stroke="rgba(255,255,255,0.1)"
+					strokeWidth="0.5"
+				/>
+			))}
+		</svg>
+	);
+}

--- a/apps/marketing/src/app/components/Pixel404/index.ts
+++ b/apps/marketing/src/app/components/Pixel404/index.ts
@@ -1,0 +1,1 @@
+export { Pixel404 } from "./Pixel404";

--- a/apps/marketing/src/app/not-found.tsx
+++ b/apps/marketing/src/app/not-found.tsx
@@ -1,0 +1,40 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { NotFoundGrid } from "./components/NotFoundGrid";
+import { Pixel404 } from "./components/Pixel404";
+
+export const metadata: Metadata = {
+	title: "Page Not Found",
+	robots: { index: false },
+};
+
+export default function NotFound() {
+	return (
+		<main className="relative bg-background min-h-[calc(100vh-3.5rem)] flex items-center overflow-hidden">
+			<NotFoundGrid />
+
+			<div className="relative z-10 w-full max-w-6xl mx-auto px-6 sm:px-8 lg:px-12 flex flex-col lg:flex-row items-center gap-12 lg:gap-20 py-24">
+				<div className="flex-1 flex items-center justify-center">
+					<Pixel404 />
+				</div>
+
+				<div className="flex-1 max-w-md space-y-6">
+					<h1 className="text-3xl sm:text-4xl font-medium text-foreground">
+						Page not found
+					</h1>
+					<p className="text-sm sm:text-base font-light text-muted-foreground leading-relaxed">
+						The page you&apos;re looking for doesn&apos;t exist or has been
+						moved.
+					</p>
+					<Link
+						href="/"
+						className="inline-flex items-center gap-2 mt-2 px-4 py-2.5 sm:px-6 sm:py-3 text-sm sm:text-base font-normal border border-border text-foreground hover:bg-muted transition-colors"
+					>
+						Take me home
+					</Link>
+				</div>
+			</div>
+		</main>
+	);
+}


### PR DESCRIPTION
## Summary
- Adds `apps/marketing/src/app/not-found.tsx` — custom 404 page with two-column layout
- Left side: pixel-art "404" SVG built from block squares matching the Superset logo aesthetic, over the hero grid background
- Right side: "Page not found" heading, description, and "Take me home" CTA button
- Follows brand styles: `font-medium` headings, `font-light` body, hero-style bordered button, grid background with radial fade
- `Pixel404` extracted into its own component folder per repo one-component-per-file convention
- Metadata includes `robots: { index: false }` to prevent search indexing of the 404

## Test plan
- [ ] Visit a non-existent route on the marketing site (e.g. `/asdf`) and verify the custom 404 renders
- [ ] Verify two-column layout on desktop, stacked on mobile
- [ ] Verify "Take me home" links to `/`
- [ ] Confirm grid background renders and fades at edges
- [ ] Check pixel-art "404" renders correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a custom 404 error page featuring a decorative grid overlay and pixel-style illustration when users encounter missing pages.
  * Added a home navigation link for easy return to the main site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->