### PR TITLE
feat(desktop): persist show hidden files setting per-project

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
@@ -15,10 +15,7 @@ import { useParams } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { LuFile, LuFolder } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
-import {
-	LEGACY_SHOW_HIDDEN_KEY,
-	useFileExplorerStore,
-} from "renderer/stores/file-explorer";
+import { useFileExplorerStore } from "renderer/stores/file-explorer";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import type { DirectoryEntry } from "shared/file-tree-types";
 import { DeleteConfirmDialog } from "./components/DeleteConfirmDialog";
@@ -43,10 +40,7 @@ export function FilesView() {
 	const [searchTerm, setSearchTerm] = useState("");
 	const projectId = workspace?.project?.id;
 	const showHiddenFiles = useFileExplorerStore(
-		(s) =>
-			s.showHiddenFiles[projectId ?? LEGACY_SHOW_HIDDEN_KEY] ??
-			s.showHiddenFiles[LEGACY_SHOW_HIDDEN_KEY] ??
-			false,
+		(s) => (projectId ? (s.showHiddenFiles[projectId] ?? false) : false),
 	);
 	const toggleHiddenFiles = useFileExplorerStore((s) => s.toggleHiddenFiles);
 

--- a/apps/desktop/src/renderer/stores/file-explorer.ts
+++ b/apps/desktop/src/renderer/stores/file-explorer.ts
@@ -1,8 +1,6 @@
 import { create } from "zustand";
 import { devtools, persist } from "zustand/middleware";
 
-export const LEGACY_SHOW_HIDDEN_KEY = "__legacy__";
-
 export type SortBy = "name" | "type" | "modified";
 export type SortDirection = "asc" | "desc";
 
@@ -142,10 +140,7 @@ export const useFileExplorerStore = create<FileExplorerState>()(
 				},
 
 				toggleHiddenFiles: (projectId) => {
-					const current =
-						get().showHiddenFiles[projectId] ??
-						get().showHiddenFiles[LEGACY_SHOW_HIDDEN_KEY] ??
-						false;
+					const current = get().showHiddenFiles[projectId] ?? false;
 					set({
 						showHiddenFiles: {
 							...get().showHiddenFiles,
@@ -164,17 +159,6 @@ export const useFileExplorerStore = create<FileExplorerState>()(
 			}),
 			{
 				name: "file-explorer-store",
-				version: 1,
-				migrate: (persisted, version) => {
-					const state = persisted as Record<string, unknown>;
-					// v0 -> v1: showHiddenFiles changed from boolean to Record<string, boolean>
-					// Preserve legacy value so users don't lose their preference
-					if (version === 0 && typeof state.showHiddenFiles === "boolean") {
-						const legacyValue = state.showHiddenFiles;
-						state.showHiddenFiles = { [LEGACY_SHOW_HIDDEN_KEY]: legacyValue };
-					}
-					return state as FileExplorerState;
-				},
 				partialize: (state) => ({
 					showHiddenFiles: state.showHiddenFiles,
 					sortBy: state.sortBy,


### PR DESCRIPTION
Fixes #1232

## Summary

Persists the "Show Hidden Files" setting per-project, so each project remembers its own preference across app restarts.

**Changes:**
- Convert `showHiddenFiles` from `boolean` to `Record<string, boolean>` keyed by `project.id`
- Add Zustand migration for users with legacy boolean value in localStorage
- Setting shared across all worktrees of the same project (not per-worktree)

## Test plan

1. Toggle "Show Hidden Files" in a project
2. Switch to a different project - should have its own independent setting
3. Restart the app - settings should persist
4. Switch between worktrees of the same project - setting should be shared

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hidden files visibility is now scoped per project, allowing users to independently control hidden file display settings for each project instead of applying a global setting across all projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->