### PR TITLE
fix(desktop): refresh button not showing new files in nested folders

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
@@ -264,7 +264,14 @@ export function FilesView() {
 	}, [tree]);
 
 	const handleRefresh = useCallback(() => {
+		// Invalidate root explicitly (getItems() may not include it)
 		tree.getItemInstance("root")?.invalidateChildrenIds();
+		// Also invalidate all expanded directories so new files in nested folders appear
+		for (const item of tree.getItems()) {
+			if (item.getItemData()?.isDirectory) {
+				item.invalidateChildrenIds();
+			}
+		}
 	}, [tree]);
 
 	const handleToggleHiddenFiles = useCallback(() => {


### PR DESCRIPTION
Fixes #1227

## Summary

The refresh button only invalidated the root directory cache, causing new files in nested folders to remain invisible until the panel was reopened.

## Changes

Updated `handleRefresh` to invalidate all expanded directories, matching the pattern already used by `handleToggleHiddenFiles`.

## Test Plan

1. Open a workspace and expand a nested folder
2. Create a file externally in that folder
3. Click refresh - file should now appear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where newly added or moved files within subdirectories weren't properly reflected in the file view. The file display now correctly refreshes all directory contents during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->