### PR TITLE
fix(desktop): nested hidden files not showing when toggle enabled

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
@@ -40,7 +40,7 @@ export function FilesView() {
 	const [searchTerm, setSearchTerm] = useState("");
 	const { showHiddenFiles, toggleHiddenFiles } = useFileExplorerStore();
 
-	// Refs updated synchronously during render so dataLoader always reads current values
+	// Ref avoids stale closure in dataLoader callbacks
 	const worktreePathRef = useRef(worktreePath);
 	worktreePathRef.current = worktreePath;
 
@@ -99,7 +99,6 @@ export function FilesView() {
 		features: [asyncDataLoaderFeature, selectionFeature, expandAllFeature],
 	});
 
-	// Invalidate tree when workspace changes
 	const prevWorktreePathRef = useRef(worktreePath);
 	useEffect(() => {
 		if (
@@ -267,9 +266,8 @@ export function FilesView() {
 
 	const handleToggleHiddenFiles = useCallback(() => {
 		toggleHiddenFiles();
-		// Invalidate root explicitly (getItems() may not include it)
+		// invalidateChildrenIds doesn't cascade, so invalidate every directory
 		tree.getItemInstance("root")?.invalidateChildrenIds();
-		// Also invalidate expanded directories so nested hidden files appear
 		for (const item of tree.getItems()) {
 			if (item.getItemData()?.isDirectory) {
 				item.invalidateChildrenIds();


### PR DESCRIPTION
## Summary
- Invalidate all expanded directory nodes (not just root) when toggling "show hidden files", because `invalidateChildrenIds` doesn't cascade to child nodes
- Nested hidden files inside already-expanded directories now correctly appear/disappear when the toggle is changed

Based on the original work by @de1mat in #1220.

Closes #1193

## Test plan
- [ ] Expand a directory containing hidden subdirectories
- [ ] Toggle "show hidden files" on — verify hidden files appear at all levels, not just root
- [ ] Toggle off — verify they disappear again
- [ ] Toggle while no directories are expanded — verify root-level hidden files still toggle correctly