### PR TITLE
fix(desktop): match PRs by commit ancestry instead of branch name

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.ts
@@ -11,32 +11,27 @@ import {
 
 const execFileAsync = promisify(execFile);
 
-// Cache for GitHub status (10 second TTL)
 const cache = new Map<string, { data: GitHubStatus; timestamp: number }>();
 const CACHE_TTL_MS = 10_000;
 
 /**
  * Fetches GitHub PR status for a worktree using the `gh` CLI.
  * Returns null if `gh` is not installed, not authenticated, or on error.
- * Results are cached for 10 seconds.
  */
 export async function fetchGitHubPRStatus(
 	worktreePath: string,
 ): Promise<GitHubStatus | null> {
-	// Check cache first
 	const cached = cache.get(worktreePath);
 	if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
 		return cached.data;
 	}
 
 	try {
-		// First, get the repo URL
 		const repoUrl = await getRepoUrl(worktreePath);
 		if (!repoUrl) {
 			return null;
 		}
 
-		// Get current branch name
 		const { stdout: branchOutput } = await execFileAsync(
 			"git",
 			["rev-parse", "--abbrev-ref", "HEAD"],
@@ -44,29 +39,22 @@ export async function fetchGitHubPRStatus(
 		);
 		const branchName = branchOutput.trim();
 
-		// Check if branch exists on remote and get PR info in parallel
 		const [branchCheck, prInfo] = await Promise.all([
 			branchExistsOnRemote(worktreePath, branchName),
-			getPRForBranch(worktreePath, branchName),
+			getPRForBranch(worktreePath),
 		]);
-
-		// Convert result to boolean - only "exists" is true
-		// "not_found" and "error" both mean we can't confirm it exists
-		const existsOnRemote = branchCheck.status === "exists";
 
 		const result: GitHubStatus = {
 			pr: prInfo,
 			repoUrl,
-			branchExistsOnRemote: existsOnRemote,
+			branchExistsOnRemote: branchCheck.status === "exists",
 			lastRefreshed: Date.now(),
 		};
 
-		// Cache the result
 		cache.set(worktreePath, { data: result, timestamp: Date.now() });
 
 		return result;
 	} catch {
-		// Any error (gh not installed, not auth'd, etc.) - return null
 		return null;
 	}
 }
@@ -91,61 +79,200 @@ async function getRepoUrl(worktreePath: string): Promise<string | null> {
 	}
 }
 
+const PR_JSON_FIELDS =
+	"number,title,url,state,isDraft,mergedAt,additions,deletions,headRefOid,reviewDecision,statusCheckRollup";
+
 async function getPRForBranch(
 	worktreePath: string,
-	_branch: string,
 ): Promise<GitHubStatus["pr"]> {
+	// Try branch-based lookup first, then fall back to commit-based search.
+	// Branch-based is fast but fails when the branch was renamed after PR creation.
+	const branchResult = await getPRByBranchTracking(worktreePath);
+	if (branchResult !== undefined) {
+		return branchResult;
+	}
+
+	return findPRByHeadCommit(worktreePath);
+}
+
+/**
+ * Looks up a PR using `gh pr view` (no args), which matches via the branch's
+ * tracking ref. Essential for fork PRs that track refs/pull/XXX/head.
+ * Returns the PR, null (no match), or undefined (branch name mismatch — caller should try commit-based).
+ */
+async function getPRByBranchTracking(
+	worktreePath: string,
+): Promise<GitHubStatus["pr"] | undefined> {
 	try {
-		// Use execWithShellEnv to handle macOS GUI app PATH issues
-		// Important: Do NOT pass the branch name argument. When `gh pr view` is
-		// called without arguments, it uses the branch's tracking info to find
-		// the associated PR. This is essential for fork PRs checked out via
-		// `gh pr checkout`, where the branch tracks `refs/pull/XXX/head`.
-		// Passing the branch name explicitly would search by head branch name,
-		// which fails for fork PRs since the branch exists on the fork, not origin.
 		const { stdout } = await execWithShellEnv(
 			"gh",
-			[
-				"pr",
-				"view",
-				"--json",
-				"number,title,url,state,isDraft,mergedAt,additions,deletions,reviewDecision,statusCheckRollup",
-			],
+			["pr", "view", "--json", PR_JSON_FIELDS],
 			{ cwd: worktreePath },
 		);
-		const raw = JSON.parse(stdout);
-		const result = GHPRResponseSchema.safeParse(raw);
-		if (!result.success) {
-			console.error("[GitHub] PR schema validation failed:", result.error);
-			console.error("[GitHub] Raw data:", JSON.stringify(raw, null, 2));
-			throw new Error("PR schema validation failed");
+
+		const data = parsePRResponse(stdout);
+		if (!data) {
+			return null;
 		}
-		const data = result.data;
 
-		const checks = parseChecks(data.statusCheckRollup);
+		// `gh pr view` matches by branch name, which can find a stale PR if the
+		// branch was recreated. Verify shared commit ancestry to confirm the match.
+		if (!(await sharesAncestry(worktreePath, data.headRefOid))) {
+			return null;
+		}
 
-		return {
-			number: data.number,
-			title: data.title,
-			url: data.url,
-			state: mapPRState(data.state, data.isDraft),
-			mergedAt: data.mergedAt ? new Date(data.mergedAt).getTime() : undefined,
-			additions: data.additions,
-			deletions: data.deletions,
-			reviewDecision: mapReviewDecision(data.reviewDecision),
-			checksStatus: computeChecksStatus(data.statusCheckRollup),
-			checks,
-		};
+		return formatPRData(data);
 	} catch (error) {
-		// "no pull requests found" is not an error - just no PR
 		if (
 			error instanceof Error &&
 			error.message.includes("no pull requests found")
 		) {
+			// Branch name didn't match any PR — signal caller to try commit-based
+			return undefined;
+		}
+		throw error;
+	}
+}
+
+/**
+ * Finds a PR by searching GitHub for the local HEAD commit SHA.
+ * Handles cases where the branch was renamed after PR creation.
+ */
+async function findPRByHeadCommit(
+	worktreePath: string,
+): Promise<GitHubStatus["pr"]> {
+	try {
+		const { stdout: headOutput } = await execFileAsync(
+			"git",
+			["-C", worktreePath, "rev-parse", "HEAD"],
+			{ timeout: 10_000 },
+		);
+		const headSha = headOutput.trim();
+
+		const { stdout: searchOutput } = await execWithShellEnv(
+			"gh",
+			[
+				"api",
+				`search/issues?q=${headSha}+type:pr+repo:{owner}/{repo}`,
+				"--jq",
+				".items[].number",
+			],
+			{ cwd: worktreePath },
+		);
+
+		const prNumbers = searchOutput
+			.trim()
+			.split("\n")
+			.filter(Boolean)
+			.map(Number);
+		if (prNumbers.length === 0) {
 			return null;
 		}
-		// Re-throw other errors to be caught by parent
-		throw error;
+
+		// Check each candidate PR — prefer one whose headRefOid matches exactly
+		for (const prNumber of prNumbers) {
+			try {
+				const { stdout } = await execWithShellEnv(
+					"gh",
+					["pr", "view", String(prNumber), "--json", PR_JSON_FIELDS],
+					{ cwd: worktreePath },
+				);
+
+				const data = parsePRResponse(stdout);
+				if (!data) {
+					continue;
+				}
+
+				if (await sharesAncestry(worktreePath, data.headRefOid)) {
+					return formatPRData(data);
+				}
+			} catch {}
+		}
+
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+function parsePRResponse(stdout: string): GHPRResponse | null {
+	const raw = JSON.parse(stdout);
+	const result = GHPRResponseSchema.safeParse(raw);
+	if (!result.success) {
+		console.error("[GitHub] PR schema validation failed:", result.error);
+		console.error("[GitHub] Raw data:", JSON.stringify(raw, null, 2));
+		return null;
+	}
+	return result.data;
+}
+
+function formatPRData(data: GHPRResponse): NonNullable<GitHubStatus["pr"]> {
+	return {
+		number: data.number,
+		title: data.title,
+		url: data.url,
+		state: mapPRState(data.state, data.isDraft),
+		mergedAt: data.mergedAt ? new Date(data.mergedAt).getTime() : undefined,
+		additions: data.additions,
+		deletions: data.deletions,
+		reviewDecision: mapReviewDecision(data.reviewDecision),
+		checksStatus: computeChecksStatus(data.statusCheckRollup),
+		checks: parseChecks(data.statusCheckRollup),
+	};
+}
+
+/**
+ * Returns true if local HEAD and the given commit share ancestry
+ * (one is an ancestor of the other, or they are the same commit).
+ * Falls back to true when ancestry can't be verified (e.g., commit not fetched).
+ */
+async function sharesAncestry(
+	worktreePath: string,
+	prHeadOid: string,
+): Promise<boolean> {
+	try {
+		const { stdout: localHead } = await execFileAsync(
+			"git",
+			["-C", worktreePath, "rev-parse", "HEAD"],
+			{ timeout: 10_000 },
+		);
+		const localOid = localHead.trim();
+
+		if (localOid === prHeadOid) {
+			return true;
+		}
+
+		// Check both directions: local ahead of PR, and PR ahead of local
+		for (const [ancestor, descendant] of [
+			[prHeadOid, localOid],
+			[localOid, prHeadOid],
+		]) {
+			try {
+				await execFileAsync(
+					"git",
+					[
+						"-C",
+						worktreePath,
+						"merge-base",
+						"--is-ancestor",
+						ancestor,
+						descendant,
+					],
+					{ timeout: 10_000 },
+				);
+				return true;
+			} catch {
+				// Not an ancestor in this direction
+			}
+		}
+
+		return false;
+	} catch (error) {
+		console.warn(
+			"[GitHub] Could not verify PR commit ancestry:",
+			error instanceof Error ? error.message : String(error),
+		);
+		return true;
 	}
 }
 
@@ -172,12 +299,11 @@ function parseChecks(rollup: GHPRResponse["statusCheckRollup"]): CheckItem[] {
 		return [];
 	}
 
+	// GitHub returns two shapes: CheckRun (name/detailsUrl/conclusion) and
+	// StatusContext (context/targetUrl/state). Normalize both here.
 	return rollup.map((ctx) => {
-		// CheckRun uses 'name', StatusContext uses 'context'
 		const name = ctx.name || ctx.context || "Unknown check";
-		// CheckRun uses 'detailsUrl', StatusContext uses 'targetUrl'
 		const url = ctx.detailsUrl || ctx.targetUrl;
-		// StatusContext uses 'state', CheckRun uses 'conclusion'
 		const rawStatus = ctx.state || ctx.conclusion;
 
 		let status: CheckItem["status"];
@@ -212,7 +338,6 @@ function computeChecksStatus(
 	let hasPending = false;
 
 	for (const ctx of rollup) {
-		// StatusContext uses 'state', CheckRun uses 'conclusion'
 		const status = ctx.state || ctx.conclusion;
 
 		if (status === "FAILURE" || status === "ERROR" || status === "TIMED_OUT") {

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/types.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/types.ts
@@ -34,6 +34,7 @@ export const GHPRResponseSchema = z.object({
 	mergedAt: z.string().nullable(),
 	additions: z.number(),
 	deletions: z.number(),
+	headRefOid: z.string(),
 	reviewDecision: z
 		.enum(["APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED", ""])
 		.nullable(),


### PR DESCRIPTION
## Summary
- PR detection now uses commit ancestry verification instead of relying solely on branch name matching
- When `gh pr view` finds no PR by branch name, falls back to searching GitHub by HEAD commit SHA via the search API
- Prevents matching stale/unrelated PRs when branches are recreated, and finds the correct PR when branches are renamed after PR creation

## Test plan
- [ ] Verify PR status shows correctly for normal worktrees (branch name matches PR)
- [ ] Verify PR status shows correctly for renamed branches (branch name differs from PR head)
- [ ] Verify fork PRs still resolve correctly via tracking ref
- [ ] Verify worktrees with no PR show no PR status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub PR status detection reliability with enhanced fallback strategies for more robust PR identification

* **Refactor**
  * Optimized PR data handling and validation for more consistent and accurate status information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->