### PR TITLE
fix(marketing): suppress expected session fetch errors from Sentry

### DIFF
--- a/apps/marketing/sentry.edge.config.ts
+++ b/apps/marketing/sentry.edge.config.ts
@@ -10,4 +10,17 @@ Sentry.init({
 		env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production" ? 0.1 : 1.0,
 	sendDefaultPii: true,
 	debug: false,
+	beforeSend(event) {
+		// Drop expected session fetch failures — visitors often have stale/invalid cookies
+		// and the marketing site doesn't require authentication (MARKETING-17)
+		if (
+			event.exception?.values?.some(
+				(e) =>
+					e.type === "APIError" && e.value?.includes("Failed to get session"),
+			)
+		) {
+			return null;
+		}
+		return event;
+	},
 });

--- a/apps/marketing/sentry.server.config.ts
+++ b/apps/marketing/sentry.server.config.ts
@@ -10,4 +10,17 @@ Sentry.init({
 		env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production" ? 0.1 : 1.0,
 	sendDefaultPii: true,
 	debug: false,
+	beforeSend(event) {
+		// Drop expected session fetch failures — visitors often have stale/invalid cookies
+		// and the marketing site doesn't require authentication (MARKETING-17)
+		if (
+			event.exception?.values?.some(
+				(e) =>
+					e.type === "APIError" && e.value?.includes("Failed to get session"),
+			)
+		) {
+			return null;
+		}
+		return event;
+	},
 });

--- a/apps/marketing/src/app/components/CTAButtons/CTAButtons.tsx
+++ b/apps/marketing/src/app/components/CTAButtons/CTAButtons.tsx
@@ -8,9 +8,10 @@ export async function CTAButtons() {
 	let session = null;
 	try {
 		session = await auth.api.getSession({ headers: await headers() });
-	} catch (error) {
-		// Handle errors from invalid/stale cookies (e.g., old Clerk cookies after migration to Better Auth)
-		console.error("[marketing/CTAButtons] Failed to get session:", error);
+	} catch {
+		// Expected when visitors have invalid/stale cookies (e.g., old Clerk cookies after migration to Better Auth).
+		// Session is optional on the marketing site — we just show the logged-out CTA.
+		console.warn("[marketing/CTAButtons] Failed to get session");
 	}
 
 	return (


### PR DESCRIPTION
## Summary
- Adds `beforeSend` filter in Sentry server and edge configs to drop `APIError: Failed to get session` events (MARKETING-17)
- Downgrades `console.error` to `console.warn` in `CTAButtons` since failed session fetch is expected behavior on the marketing site
- Removes unused `error` variable from catch block

## Context
The marketing site's `CTAButtons` component calls `auth.api.getSession()` on every page to show logged-in vs logged-out CTAs in the header. When visitors have stale or invalid cookies (e.g., leftover Clerk cookies from the auth migration), BetterAuth throws an `APIError("Failed to get session")`. This is expected and non-actionable — the component already gracefully falls back to showing logged-out CTAs — but it was generating Sentry noise (94 events).

## Test plan
- [x] Typecheck passes (`bun run typecheck --filter=@superset/marketing`)
- [x] Lint passes (`bun run lint:fix`)
- [ ] Verify in Sentry that MARKETING-17 stops receiving new events after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of session retrieval failures on the marketing site to prevent unnecessary disruptions.

* **Chores**
  * Refined error tracking to exclude expected session-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->