### PR TITLE
fix(ui): make toast notifications scrollable when content is too long

### DIFF
--- a/packages/ui/src/components/ui/sonner.tsx
+++ b/packages/ui/src/components/ui/sonner.tsx
@@ -28,6 +28,13 @@ const Toaster = ({ ...props }: ToasterProps) => {
 				style: {
 					userSelect: "text",
 					WebkitUserSelect: "text",
+					maxHeight: "80dvh",
+					overflow: "hidden",
+					display: "flex",
+					flexDirection: "column",
+				},
+				classNames: {
+					description: "overflow-y-auto",
 				},
 			}}
 			style={


### PR DESCRIPTION
## Summary
- Cap toast max height at `80dvh` and enable vertical scrolling on the description area
- Prevents long toast notifications from overflowing the viewport

## Test plan
- [ ] Trigger a toast with a long description and verify it scrolls instead of overflowing
- [ ] Verify normal-length toasts are unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved toast notification styling to better handle long-form content with enhanced scrollability and responsive layout adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->