### PR TITLE
fix(desktop): wrap right sidebar buttons when sidebar is narrow

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
@@ -124,7 +124,7 @@ export function RightSidebar() {
 
 	return (
 		<aside className="h-full flex flex-col overflow-hidden">
-			<div className="flex items-center gap-1 px-2 py-1.5 border-b border-border">
+			<div className="flex flex-wrap items-center gap-1 px-2 py-1.5 border-b border-border">
 				{showChangesTab && (
 					<TabButton
 						isActive={rightSidebarTab === RightSidebarTab.Changes}


### PR DESCRIPTION
## Summary
- Add `flex-wrap` to the right sidebar header so tab buttons and action buttons wrap to new rows instead of being hidden when the sidebar is too narrow

## Test plan
- [ ] Resize the right sidebar to a narrow width
- [ ] Verify that tab buttons (Changes, Files) and action buttons (expand, close) wrap to new rows instead of being clipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced right sidebar layout to allow child elements to wrap appropriately when space is constrained, improving the user interface in narrow viewing areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->