### PR TITLE
perf(desktop): narrow project lock scope for concurrent worktree operations

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/delete.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/delete.ts
@@ -398,8 +398,10 @@ export const createDeleteProcedures = () => {
 					return { success: false, error: "Project not found" };
 				}
 
-				// Check worktree existence and run teardown before acquiring lock
-				// (these are read-only git ops / user scripts, not git mutations)
+				// Check worktree existence and run teardown before acquiring lock.
+				// Note: teardown runs user-defined shell commands (.superset/config.json)
+				// which could include git operations, but not git worktree mutations
+				// (which is what the project lock protects).
 				const exists = await worktreeExists(
 					project.mainRepoPath,
 					worktree.path,


### PR DESCRIPTION
## Summary

- Narrows the per-project mutex in workspace init and delete to only wrap `git worktree add/remove` (~5s), instead of holding it for the entire init flow (~2-3 min of network I/O)
- Allows concurrent workspace creates/deletes for the same project to overlap their network fetches, teardown scripts, and config copies
- Adds `existsSync` guards in post-lock phases to handle the case where a concurrent delete removes the worktree between lock release and config copy
- Re-checks worktree existence inside the lock in `deleteWorktree` to eliminate TOCTOU window between pre-lock check and locked removal
- Uses `removeWorktreeFromDisk` wrapper (from main) for consistent error handling

## What changed

**`workspace-init.ts`** — The `initializeWorkspaceWorktree` function is restructured into three phases:
1. **No lock** — network I/O (`refreshDefaultBranch`, `branchExistsOnRemote`, `fetchDefaultBranch`)
2. **Lock held** — `createWorktree` / `createWorktreeFromExistingBranch` + cancellation cleanup
3. **No lock** — config copy, DB update, analytics (with `existsSync` guard for concurrent delete safety)

**`delete.ts`** — The `deleteWorktree` mutation moves teardown before the lock, then re-checks existence inside the lock before calling `removeWorktreeFromDisk`.

## Test plan

- [x] `bun test` — 684 pass, 0 fail
- [x] `bun run lint:fix` — no issues
- [x] `bun run typecheck` — passes (only pre-existing `ai-chat` missing-module errors)
- [ ] Manual: create two workspaces for the same project simultaneously — second should not block on first's network fetch
- [ ] Manual: delete a workspace while another is being created — delete should proceed without waiting for fetch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of workspace deletion and initialization operations
  * Enhanced handling of edge cases and concurrent operations during workspace setup
  * Better cleanup and cancellation handling to prevent partial or incomplete operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->