### PR TITLE
fix(ui): restore toast row layout broken by scrollable change

### DIFF
--- a/packages/ui/src/components/ui/sonner.tsx
+++ b/packages/ui/src/components/ui/sonner.tsx
@@ -30,8 +30,6 @@ const Toaster = ({ ...props }: ToasterProps) => {
 					WebkitUserSelect: "text",
 					maxHeight: "80dvh",
 					overflow: "hidden",
-					display: "flex",
-					flexDirection: "column",
 				},
 				classNames: {
 					description: "overflow-y-auto",


### PR DESCRIPTION
## Summary
- Removes `display: flex` and `flexDirection: column` overrides from toast styles that were causing the icon and content to stack vertically instead of side-by-side
- Scrollable behavior from #1238 is preserved — `maxHeight` + `overflow: hidden` on the toast and `overflow-y-auto` on the description still work correctly

## Test plan
- [ ] Verify toasts display with icon on the left and content on the right (row layout)
- [ ] Verify long toast descriptions are still scrollable and capped at 80dvh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted toaster layout rendering by removing forced flex display properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->