### PR TITLE
fix(desktop): false positive LFS detection from .lfsconfig

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.test.ts
@@ -71,17 +71,17 @@ describe("LFS Detection", () => {
 		expect(content.includes("filter=lfs")).toBe(true);
 	});
 
-	test("detects LFS via .lfsconfig", async () => {
+	test("does not detect LFS from .lfsconfig alone", async () => {
 		const repoPath = createTestRepo("lfs-config-test");
 
-		// Create .lfsconfig
+		// .lfsconfig configures LFS behaviour but does not indicate file tracking
 		writeFileSync(
 			join(repoPath, ".lfsconfig"),
-			"[lfs]\n\turl = https://example.com/lfs\n",
+			"[lfs]\n\tlocksverify = false\n",
 		);
 
-		const content = await Bun.file(join(repoPath, ".lfsconfig")).text();
-		expect(content.includes("[lfs]")).toBe(true);
+		expect(existsSync(join(repoPath, ".git", "lfs"))).toBe(false);
+		expect(existsSync(join(repoPath, ".gitattributes"))).toBe(false);
 	});
 
 	test("no LFS detected in plain repo", async () => {

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
@@ -249,7 +249,6 @@ async function repoUsesLfs(repoPath: string): Promise<boolean> {
 	const attributeFiles = [
 		join(repoPath, ".gitattributes"),
 		join(repoPath, ".git", "info", "attributes"),
-		join(repoPath, ".lfsconfig"),
 	];
 
 	for (const filePath of attributeFiles) {


### PR DESCRIPTION
## Description

The `repoUsesLfs()` function checks `.lfsconfig` for the string `[lfs]` and treats it as evidence that the repo tracks files with LFS. However, `.lfsconfig` is a configuration file for LFS behaviour (server URLs, lock settings) - the `[lfs]` string is just an INI section header present in every `.lfsconfig` file.

The superset.sh repo itself has a `.lfsconfig` with only `locksverify = false`, which triggers a false positive. This blocks workspace creation with a "please install git-lfs" error even though no files are tracked with LFS.

Here is a screenshot of trying to create a new workspace using the superset repo:

<img width="566" height="455" alt="image" src="https://github.com/user-attachments/assets/c7dc3703-1d2b-44d7-9983-0228aefccd23" />

This PR removes `.lfsconfig` from the attribute file check. The remaining detection methods are sufficient:
- `.git/lfs/` directory (LFS objects present)
- `.gitattributes` with `filter=lfs` (files configured for LFS tracking)
- `.git/info/attributes` with `filter=lfs`
- `git check-attr filter` on sample files

## Related Issues

Fixes #1244

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

- Updated the "detects LFS via .lfsconfig" test to verify that `.lfsconfig` alone does **not** trigger LFS detection
- All 12 existing tests pass