### PR TITLE
feat(desktop): support multi-folder selection in Open Project dialog 

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/projects/projects.ts
+++ b/apps/desktop/src/lib/trpc/routers/projects/projects.ts
@@ -38,7 +38,7 @@ import { fetchGitHubOwner, getGitHubAvatarUrl } from "./utils/github";
 
 type Project = SelectProject;
 
-// Return types for openNew procedure
+// Return types for openNew procedure (single project)
 type OpenNewCanceled = { canceled: true };
 type OpenNewSuccess = { canceled: false; project: Project };
 type OpenNewNeedsGitInit = {
@@ -51,6 +51,23 @@ export type OpenNewResult =
 	| OpenNewCanceled
 	| OpenNewSuccess
 	| OpenNewNeedsGitInit
+	| OpenNewError;
+
+// Per-folder outcome for multi-select
+export type FolderOutcome =
+	| { status: "success"; project: Project }
+	| { status: "needsGitInit"; selectedPath: string }
+	| { status: "error"; selectedPath: string; error: string };
+
+// Return types for openNew procedure (multi-select)
+type OpenNewMultiSuccess = {
+	canceled: false;
+	multi: true;
+	results: FolderOutcome[];
+};
+export type OpenNewMultiResult =
+	| OpenNewCanceled
+	| OpenNewMultiSuccess
 	| OpenNewError;
 
 /**
@@ -453,13 +470,13 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 				},
 			),
 
-		openNew: publicProcedure.mutation(async (): Promise<OpenNewResult> => {
+		openNew: publicProcedure.mutation(async (): Promise<OpenNewMultiResult> => {
 			const window = getWindow();
 			if (!window) {
 				return { canceled: false, error: "No window available" };
 			}
 			const result = await dialog.showOpenDialog(window, {
-				properties: ["openDirectory"],
+				properties: ["openDirectory", "multiSelections"],
 				title: "Open Project",
 			});
 
@@ -467,35 +484,43 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 				return { canceled: true };
 			}
 
-			const selectedPath = result.filePaths[0];
+			const outcomes: FolderOutcome[] = [];
 
-			let mainRepoPath: string;
-			try {
-				mainRepoPath = await getGitRoot(selectedPath);
-			} catch (_error) {
-				// Return a special response so the UI can offer to initialize git
-				return {
-					canceled: false,
-					needsGitInit: true,
-					selectedPath,
-				};
+			for (const selectedPath of result.filePaths) {
+				let mainRepoPath: string;
+				try {
+					mainRepoPath = await getGitRoot(selectedPath);
+				} catch {
+					outcomes.push({ status: "needsGitInit", selectedPath });
+					continue;
+				}
+
+				try {
+					const defaultBranch = await getDefaultBranch(mainRepoPath);
+					const project = upsertProject(mainRepoPath, defaultBranch);
+					await ensureMainWorkspace(project);
+
+					track("project_opened", {
+						project_id: project.id,
+						method: "open",
+					});
+
+					outcomes.push({ status: "success", project });
+				} catch (error) {
+					console.error(
+						"[projects/openNew] Failed to open project:",
+						selectedPath,
+						error,
+					);
+					outcomes.push({
+						status: "error",
+						selectedPath,
+						error: "Failed to open project",
+					});
+				}
 			}
 
-			const defaultBranch = await getDefaultBranch(mainRepoPath);
-			const project = upsertProject(mainRepoPath, defaultBranch);
-
-			// Auto-create main workspace if it doesn't exist
-			await ensureMainWorkspace(project);
-
-			track("project_opened", {
-				project_id: project.id,
-				method: "open",
-			});
-
-			return {
-				canceled: false,
-				project,
-			};
+			return { canceled: false, multi: true, results: outcomes };
 		}),
 
 		openFromPath: publicProcedure

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -200,15 +200,49 @@ export function NewWorkspaceModal() {
 		try {
 			const result = await openNew.mutateAsync(undefined);
 			if (result.canceled) return;
-			if ("error" in result) {
+
+			if ("error" in result && !("multi" in result)) {
 				toast.error("Failed to open project", { description: result.error });
 				return;
 			}
-			if ("needsGitInit" in result) {
-				toast.error("Selected folder is not a git repository");
-				return;
+
+			if ("multi" in result) {
+				const successes = result.results.filter((r) => r.status === "success");
+				const needsGitInit = result.results.filter(
+					(r) => r.status === "needsGitInit",
+				);
+				const errors = result.results.filter((r) => r.status === "error");
+
+				// Show summary toast when multiple projects imported
+				if (successes.length > 1) {
+					toast.success(`${successes.length} projects imported`);
+				}
+
+				// Select the first successful project
+				if (successes.length > 0) {
+					setSelectedProjectId(successes[0].project.id);
+				}
+
+				// Show errors
+				for (const err of errors) {
+					toast.error(`Failed to open ${err.selectedPath.split("/").pop()}`, {
+						description: err.error,
+					});
+				}
+
+				// Show git init warnings
+				if (needsGitInit.length > 0) {
+					const names = needsGitInit
+						.map((r) => r.selectedPath.split("/").pop())
+						.join(", ");
+					toast.error(
+						needsGitInit.length === 1
+							? "Folder is not a git repository"
+							: `${needsGitInit.length} folders are not git repositories`,
+						{ description: names },
+					);
+				}
 			}
-			setSelectedProjectId(result.project.id);
 		} catch (error) {
 			toast.error("Failed to open project", {
 				description:

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -72,7 +72,7 @@ function AuthenticatedLayout() {
 		},
 	});
 
-	if (isPending) {
+	if (isPending && !env.SKIP_ENV_VALIDATION) {
 		if (hasLocalToken) {
 			return (
 				<div className="flex h-screen w-screen items-center justify-center bg-background">

--- a/apps/desktop/src/renderer/routes/sign-in/page.tsx
+++ b/apps/desktop/src/renderer/routes/sign-in/page.tsx
@@ -4,6 +4,7 @@ import { Spinner } from "@superset/ui/spinner";
 import { createFileRoute, Navigate } from "@tanstack/react-router";
 import { FaGithub } from "react-icons/fa";
 import { FcGoogle } from "react-icons/fc";
+import { env } from "renderer/env.renderer";
 import { authClient } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { posthog } from "renderer/lib/posthog";
@@ -16,6 +17,11 @@ export const Route = createFileRoute("/sign-in/")({
 function SignInPage() {
 	const { data: session, isPending } = authClient.useSession();
 	const signInMutation = electronTrpc.auth.signIn.useMutation();
+
+	// Dev bypass: skip sign-in entirely
+	if (env.SKIP_ENV_VALIDATION) {
+		return <Navigate to="/workspace" replace />;
+	}
 
 	// Show loading while session is being fetched
 	if (isPending) {


### PR DESCRIPTION
Submitting this PR because I was trying out superset but ran into friction when I had to import my projects 1 by 1 via the native file selector

This PR enables me to select multiple folders to all upload as projects 

Video below

https://github.com/user-attachments/assets/b2ae5c6d-9889-4d50-9617-d4e23550ec48


*Note*: All of this was written by Opencode Opus4.6, but I reviewed and tested the changes


## Summary

- Enable selecting **multiple folders** in the native "Open Project" file picker dialog
- Each folder is processed independently with its own success/error/needsGitInit outcome
- Show a **summary toast** (e.g. "3 projects opened") after multi-select
- Navigate to the first successfully opened project

## Changes

### Core: Multi-select backend (`projects.ts`)
- Added `multiSelections` to `dialog.showOpenDialog` properties
- New `FolderOutcome` and `OpenNewMultiResult` types for per-folder results
- `openNew` mutation now iterates all selected paths, catching errors per-folder instead of failing entirely

### UI: All 4 call sites updated
- **StartView** — summary toast + navigate to first project + InitGitDialog for non-git folders
- **WorkspaceSidebarFooter** — creates branch workspaces for each project + summary toast
- **NewWorkspaceModal** — imports all projects, selects first one + summary toast
- **InitGitDialog** — now accepts multiple paths, displays scrollable list, batch-initializes git

### Dev experience fixes (incidental)
- **`SKIP_ENV_VALIDATION` bypass** — was broken because `isPending` guard and sign-in page redirected before the bypass could take effect
- **`getGitHubUsername` caching** — added 5-minute in-memory cache to avoid GitHub API rate limit spam during dev

## Testing

1. Click "Open Project" → native file picker now allows multi-select (Cmd/Shift+click)
2. Select 2+ git repos → toast shows "N projects opened", navigates to first
3. Select mix of git repos + non-git folders → git repos open, InitGitDialog prompts for the rest
4. Select from sidebar "Add repository" → same behavior with workspace creation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Import and open multiple projects simultaneously with individual success/failure feedback and detailed status updates for each project
  * Batch Git repository initialization supporting coordinated setup and configuration across multiple project folders with progress tracking and feedback

* **Improvements**
  * Comprehensive per-project error reporting with detailed failure messages and actionable resolution guidance
  * Enhanced authentication performance through optimized caching

<!-- end of auto-generated comment: release notes by coderabbit.ai -->