### PR TITLE
fix(mcp): clarify navigate_to_workspace tool description

### DIFF
--- a/packages/mcp/src/tools/devices/navigate-to-workspace/navigate-to-workspace.ts
+++ b/packages/mcp/src/tools/devices/navigate-to-workspace/navigate-to-workspace.ts
@@ -7,17 +7,17 @@ export function register(server: McpServer) {
 		"navigate_to_workspace",
 		{
 			description:
-				"Navigate the desktop app to a specific workspace (git worktree)",
+				"Open a workspace (git worktree) in the user's desktop app UI. This only changes what the user sees on screen — it does NOT change the agent's working directory, project context, or current workspace. Use switch_workspace to change the active workspace context.",
 			inputSchema: {
 				deviceId: z.string().describe("Target device ID"),
 				workspaceId: z
 					.string()
 					.optional()
-					.describe("Workspace ID to navigate to"),
+					.describe("Workspace ID to open in the desktop app UI"),
 				workspaceName: z
 					.string()
 					.optional()
-					.describe("Workspace name to navigate to"),
+					.describe("Workspace name to open in the desktop app UI"),
 			},
 		},
 		async (args, extra) => {


### PR DESCRIPTION
## Summary
- Updated the `navigate_to_workspace` MCP tool description to clearly state it only changes the user's desktop app UI view — it does **not** change the agent's working directory, project context, or current workspace.
- Updated parameter descriptions to use "open in the desktop app UI" instead of "navigate to".
- Points agents to `switch_workspace` when they need to actually change workspace context.

## Test plan
- [ ] Verify the MCP tool still functions correctly (navigates the desktop UI)
- [ ] Confirm agents no longer misinterpret this tool as changing their own context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified workspace navigation feature descriptions to emphasize that it opens workspaces in the desktop UI without affecting working directory or application context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->