### PR TITLE
feat(desktop): show keyboard shortcut hint on View on GitHub button

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/WorkspaceHoverCard.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/WorkspaceHoverCard.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@superset/ui/button";
+import { Kbd, KbdGroup } from "@superset/ui/kbd";
 import { formatDistanceToNow } from "date-fns";
 import { FaGithub } from "react-icons/fa";
 import {
@@ -8,6 +9,7 @@ import {
 } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { usePRStatus } from "renderer/screens/main/hooks";
+import { useHotkeyDisplay } from "renderer/stores/hotkeys";
 import { STROKE_WIDTH } from "../../../constants";
 import { ChecksList } from "./components/ChecksList";
 import { ChecksSummary } from "./components/ChecksSummary";
@@ -35,6 +37,11 @@ export function WorkspaceHoverCardContent({
 		branchExistsOnRemote,
 		isLoading: isLoadingGithub,
 	} = usePRStatus({ workspaceId });
+
+	const openPRDisplay = useHotkeyDisplay("OPEN_PR");
+	const hasOpenPRShortcut = !(
+		openPRDisplay.length === 1 && openPRDisplay[0] === "Unassigned"
+	);
 
 	const needsRebase = worktreeInfo?.gitStatus?.needsRebase;
 
@@ -147,6 +154,15 @@ export function WorkspaceHoverCardContent({
 						<a href={pr.url} target="_blank" rel="noopener noreferrer">
 							<FaGithub className="size-3" />
 							View on GitHub
+							{hasOpenPRShortcut && (
+								<KbdGroup className="ml-auto">
+									{openPRDisplay.map((key) => (
+										<Kbd key={key} className="h-4 min-w-4 text-[10px]">
+											{key}
+										</Kbd>
+									))}
+								</KbdGroup>
+							)}
 						</a>
 					</Button>
 				</div>


### PR DESCRIPTION
## Summary
- Displays the configurable `OPEN_PR` keyboard shortcut (e.g. `⌘⇧P`) next to the "View on GitHub" button in the workspace hover card
- Uses `useHotkeyDisplay` so it respects user customizations; hides when the shortcut is unassigned

## Test plan
- [x] Hover over a workspace with a PR and verify the shortcut appears next to "View on GitHub"
- [x] Customize the OPEN_PR hotkey in settings and verify the hint updates
- [x] Unbind the OPEN_PR hotkey and verify the hint disappears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keyboard shortcut indicators now appear next to the "View on GitHub" / PR link, showing assigned hotkeys to users. If no shortcut is configured, the indicator is hidden to keep the workspace interface clean and uncluttered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->