### PR TITLE
fix(desktop): auto-scroll sidebar to active workspace on keyboard navigation

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -15,7 +15,7 @@ import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { useMatchRoute, useNavigate } from "@tanstack/react-router";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useDrag, useDrop } from "react-dnd";
 import { HiMiniXMark } from "react-icons/hi2";
 import {
@@ -103,6 +103,14 @@ export function WorkspaceListItem({
 		params: { workspaceId: id },
 		fuzzy: true,
 	});
+
+	const itemRef = useRef<HTMLElement | null>(null);
+	useEffect(() => {
+		if (isActive) {
+			itemRef.current?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+		}
+	}, [isActive]);
+
 	const openInFinder = electronTrpc.external.openInFinder.useMutation({
 		onError: (error) => toast.error(`Failed to open: ${error.message}`),
 	});
@@ -302,6 +310,7 @@ export function WorkspaceListItem({
 	if (isCollapsed) {
 		const collapsedButton = (
 			<button
+				ref={itemRef}
 				type="button"
 				onClick={handleClick}
 				onMouseEnter={handleMouseEnter}
@@ -409,6 +418,7 @@ export function WorkspaceListItem({
 			role="button"
 			tabIndex={0}
 			ref={(node) => {
+				itemRef.current = node;
 				drag(drop(node));
 			}}
 			onClick={handleClick}


### PR DESCRIPTION
## Summary
- When navigating workspaces via keyboard shortcuts (Cmd+1-9, Cmd+Alt+Up/Down), the active workspace could end up off-screen in the sidebar
- Adds `scrollIntoView({ block: "nearest", behavior: "smooth" })` to `WorkspaceListItem` when it becomes active
- `block: "nearest"` ensures no-op when already visible, and minimal scroll distance otherwise
- Works in both expanded and collapsed sidebar modes

## Test plan
- [x] Open app with enough workspaces to require scrolling in the sidebar
- [x] Use Cmd+1 through Cmd+9 to jump — sidebar should scroll to show the target
- [x] Use Cmd+Alt+Up/Down to cycle — sidebar should follow
- [x] Manually click a visible workspace — no jarring scroll should occur
- [x] Test in collapsed sidebar mode as well

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workspace sidebar items now automatically scroll into view when activated, improving navigation and visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->