### PR TITLE
feat(desktop): make workspace creation idempotent

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/db-helpers.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/db-helpers.ts
@@ -291,6 +291,71 @@ export function getBranchWorkspace(
 }
 
 /**
+ * Find a non-deleting worktree-type workspace by project + branch.
+ * Returns the workspace and its worktree, or null if not found.
+ */
+export function findWorktreeWorkspaceByBranch({
+	projectId,
+	branch,
+}: {
+	projectId: string;
+	branch: string;
+}): {
+	workspace: SelectWorkspace;
+	worktree: SelectWorktree;
+} | null {
+	const result = localDb
+		.select({ workspace: workspaces, worktree: worktrees })
+		.from(workspaces)
+		.innerJoin(worktrees, eq(workspaces.worktreeId, worktrees.id))
+		.where(
+			and(
+				eq(workspaces.projectId, projectId),
+				eq(workspaces.type, "worktree"),
+				eq(workspaces.branch, branch),
+				isNull(workspaces.deletingAt),
+			),
+		)
+		.get();
+
+	return result ?? null;
+}
+
+/**
+ * Find an orphaned worktree (has a worktree record but no active workspace) by project + branch.
+ */
+export function findOrphanedWorktreeByBranch({
+	projectId,
+	branch,
+}: {
+	projectId: string;
+	branch: string;
+}): SelectWorktree | null {
+	const worktree = localDb
+		.select()
+		.from(worktrees)
+		.where(
+			and(eq(worktrees.projectId, projectId), eq(worktrees.branch, branch)),
+		)
+		.get();
+
+	if (!worktree) return null;
+
+	const activeWorkspace = localDb
+		.select()
+		.from(workspaces)
+		.where(
+			and(
+				eq(workspaces.worktreeId, worktree.id),
+				isNull(workspaces.deletingAt),
+			),
+		)
+		.get();
+
+	return activeWorkspace ? null : worktree;
+}
+
+/**
  * Update a project's default branch.
  */
 export function updateProjectDefaultBranch(

--- a/apps/desktop/src/renderer/react-query/workspaces/useCreateWorkspace.ts
+++ b/apps/desktop/src/renderer/react-query/workspaces/useCreateWorkspace.ts
@@ -34,11 +34,13 @@ export function useCreateWorkspace(options?: UseCreateWorkspaceOptions) {
 				updateProgress(optimisticProgress);
 			}
 
-			addPendingTerminalSetup({
-				workspaceId: data.workspace.id,
-				projectId: data.projectId,
-				initialCommands: data.initialCommands,
-			});
+			if (!data.wasExisting) {
+				addPendingTerminalSetup({
+					workspaceId: data.workspace.id,
+					projectId: data.projectId,
+					initialCommands: data.initialCommands,
+				});
+			}
 
 			await utils.workspaces.invalidate();
 

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/create-worktree.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/create-worktree.ts
@@ -21,6 +21,7 @@ interface CreatedWorkspace {
 	workspaceId: string;
 	workspaceName: string;
 	branch: string;
+	wasExisting: boolean;
 }
 
 async function execute(
@@ -69,6 +70,7 @@ async function execute(
 				workspaceId: result.workspace.id,
 				workspaceName: result.workspace.name,
 				branch: result.workspace.branch,
+				wasExisting: result.wasExisting,
 			});
 		} catch (error) {
 			errors.push({


### PR DESCRIPTION
## Summary

- Add idempotency check to the `create` tRPC mutation for explicit branch names — if a workspace already exists on that branch, return it instead of creating duplicates
- Handle orphaned worktrees (worktree DB record exists but no active workspace) by attaching a new workspace to the existing worktree
- Surface `wasExisting` flag through the MCP tool response so agents know whether the workspace was reused
- Skip terminal setup scripts for existing workspaces to avoid re-running init

## Test plan

- [ ] Call `create_workspace` twice with the same `branchName` — second call should return existing workspace with `wasExisting: true`
- [ ] Call `create_workspace` without `branchName` — each call creates a new workspace (auto-generated branches skip idempotency check)
- [ ] Call `start_claude_session` twice for the same task — second call reuses workspace, Claude command still gets queued
- [ ] `bun run typecheck` passes in desktop app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace creation now reuses existing workspaces when initializing the same branch, reducing duplication
  * Automatic recovery and reuse of orphaned worktrees
  * Optimized setup process that runs only when necessary for new workspaces

<!-- end of auto-generated comment: release notes by coderabbit.ai -->