### PR TITLE
feat(desktop): enable push.autoSetupRemote on worktree creation

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
@@ -461,6 +461,14 @@ export async function createWorktree(
 			{ env, timeout: 120_000 },
 		);
 
+		// Enable autoSetupRemote so the first `git push` automatically creates
+		// the remote branch and sets upstream (like `git push -u origin <branch>`).
+		await execFileAsync(
+			"git",
+			["-C", worktreePath, "config", "--local", "push.autoSetupRemote", "true"],
+			{ env, timeout: 10_000 },
+		);
+
 		console.log(
 			`Created worktree at ${worktreePath} with branch ${branch} from ${startPoint}`,
 		);
@@ -576,6 +584,14 @@ export async function createWorktreeFromExistingBranch({
 				);
 			}
 		}
+
+		// Enable autoSetupRemote so the first `git push` automatically creates
+		// the remote branch and sets upstream (like `git push -u origin <branch>`).
+		await execFileAsync(
+			"git",
+			["-C", worktreePath, "config", "--local", "push.autoSetupRemote", "true"],
+			{ env, timeout: 10_000 },
+		);
 
 		console.log(
 			`Created worktree at ${worktreePath} using existing branch ${branch}`,
@@ -1699,6 +1715,13 @@ export async function createWorktreeFromPr({
 			args.push("-b", branchName, worktreePath, remoteRef);
 			await execFileAsync("git", args, { env, timeout: 120_000 });
 		}
+
+		// Enable autoSetupRemote so `git push` just works without -u flag.
+		await execFileAsync(
+			"git",
+			["-C", worktreePath, "config", "--local", "push.autoSetupRemote", "true"],
+			{ env, timeout: 10_000 },
+		);
 
 		console.log(
 			`[git] Created worktree at ${worktreePath} for PR #${prInfo.number}`,


### PR DESCRIPTION
## Summary
- Sets `push.autoSetupRemote=true` in each worktree's local git config after creation
- The first `git push` now automatically creates the remote branch and sets upstream tracking (like `git push -u origin <branch>`)
- Applied to all three worktree creation paths: new branch, existing branch, and PR checkout
- Works alongside the existing `^{commit}` trick which prevents the wrong upstream (origin/main) from being set

## Test plan
- [ ] Create a new workspace → verify `git config --local push.autoSetupRemote` returns `true` in the worktree
- [ ] Run `git push` from the worktree terminal → verify it pushes and sets upstream without needing `-u`
- [ ] Create workspace from existing remote branch → verify same behavior
- [ ] Open a PR workspace → verify same behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Git worktrees now automatically configure remote push settings, allowing the first push to set up tracking without requiring the `-u` flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->