### PR TITLE
fix(auth): sort org memberships by creation date

### DIFF
--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -23,7 +23,7 @@ import {
 	mcp,
 	organization,
 } from "better-auth/plugins";
-import { and, count, eq } from "drizzle-orm";
+import { and, count, desc, eq } from "drizzle-orm";
 import type Stripe from "stripe";
 import { env } from "./env";
 import { acceptInvitationEndpoint } from "./lib/accept-invitation-endpoint";
@@ -406,6 +406,7 @@ export const auth = betterAuth({
 							eq(members.organizationId, activeOrganizationId),
 						)
 					: eq(members.userId, session.userId ?? user.id),
+				orderBy: desc(members.createdAt),
 			});
 
 			if (!activeOrganizationId && membership?.organizationId) {

--- a/packages/trpc/src/router/user/user.ts
+++ b/packages/trpc/src/router/user/user.ts
@@ -2,7 +2,7 @@ import { db } from "@superset/db/client";
 import { members, users } from "@superset/db/schema";
 import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
 import { del, put } from "@vercel/blob";
-import { and, eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { protectedProcedure } from "../../trpc";
@@ -20,6 +20,7 @@ export const userRouter = {
 						eq(members.organizationId, activeOrganizationId),
 					)
 				: eq(members.userId, ctx.session.user.id),
+			orderBy: desc(members.createdAt),
 			with: {
 				organization: true,
 			},
@@ -31,6 +32,7 @@ export const userRouter = {
 	myOrganizations: protectedProcedure.query(async ({ ctx }) => {
 		const memberships = await db.query.members.findMany({
 			where: eq(members.userId, ctx.session.user.id),
+			orderBy: desc(members.createdAt),
 			with: {
 				organization: true,
 			},


### PR DESCRIPTION
## Summary
- Adds `orderBy: desc(members.createdAt)` to membership queries so the most recently created org is selected by default when no active org is set on the session
- Fixes the issue where users get signed into older test orgs instead of their primary org

## Changes
- `packages/auth/src/server.ts` — `customSession` plugin now picks newest membership first
- `packages/trpc/src/router/user/user.ts` — `myOrganization` and `myOrganizations` both return orgs newest-first

## Test plan
- [ ] Sign out and sign back in — should land on the most recently created org
- [ ] Org switcher list should show newest orgs first

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved membership selection consistency to reliably choose the most recently created record when multiple options are available, ensuring more predictable behavior across user account and organization features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->