### PR TITLE
feat(desktop): show teardown logs in modal instead of error toast

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/delete.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/delete.ts
@@ -196,7 +196,7 @@ export const createDeleteProcedures = () => {
 					.terminal.killByWorkspaceId(input.id);
 
 				let teardownPromise:
-					| Promise<{ success: boolean; error?: string }>
+					| Promise<{ success: boolean; error?: string; output?: string }>
 					| undefined;
 				if (workspace.type === "worktree" && workspace.worktreeId) {
 					worktree = getWorktree(workspace.worktreeId);
@@ -233,6 +233,7 @@ export const createDeleteProcedures = () => {
 					return {
 						success: false,
 						error: `Teardown failed: ${teardownResult.error}`,
+						output: teardownResult.output,
 					};
 				}
 
@@ -435,6 +436,7 @@ export const createDeleteProcedures = () => {
 							return {
 								success: false,
 								error: `Teardown failed: ${teardownResult.error}`,
+								output: teardownResult.output,
 							};
 						}
 					}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/TeardownLogsDialog/TeardownLogsDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/TeardownLogsDialog/TeardownLogsDialog.tsx
@@ -1,0 +1,69 @@
+import {
+	CodeBlock,
+	CodeBlockCopyButton,
+} from "@superset/ui/ai-elements/code-block";
+import {
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+} from "@superset/ui/dialog";
+import { useState } from "react";
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: matching ANSI escape sequences
+const ANSI_REGEX = /\x1b\[[0-9;]*[a-zA-Z]/g;
+
+function stripAnsi(text: string): string {
+	return text.replace(ANSI_REGEX, "");
+}
+
+let showLogsFn: ((logs: string) => void) | null = null;
+
+export const showTeardownLogs = (logs: string) => {
+	if (!showLogsFn) {
+		console.error(
+			"[teardown-logs] TeardownLogsDialog not mounted. Make sure to render <TeardownLogsDialog /> in your app",
+		);
+		return;
+	}
+	showLogsFn(logs);
+};
+
+export function TeardownLogsDialog() {
+	const [logs, setLogs] = useState<string | null>(null);
+	const [isOpen, setIsOpen] = useState(false);
+
+	showLogsFn = (newLogs) => {
+		setLogs(newLogs);
+		setIsOpen(true);
+	};
+
+	const strippedLogs = logs ? stripAnsi(logs) : "";
+
+	const handleClose = () => {
+		setIsOpen(false);
+	};
+
+	return (
+		<Dialog
+			modal={true}
+			open={isOpen}
+			onOpenChange={(open) => !open && handleClose()}
+		>
+			<DialogContent className="flex !max-w-[60vw] flex-col gap-0 p-0">
+				<DialogHeader className="px-4 pt-4 pb-2">
+					<DialogTitle className="font-medium">Teardown Logs</DialogTitle>
+				</DialogHeader>
+				<div className="px-4 pb-4">
+					<CodeBlock
+						code={strippedLogs}
+						language="log"
+						className="max-h-[60vh] overflow-y-auto text-xs"
+					>
+						<CodeBlockCopyButton />
+					</CodeBlock>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/TeardownLogsDialog/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/TeardownLogsDialog/index.ts
@@ -1,0 +1,1 @@
+export { showTeardownLogs, TeardownLogsDialog } from "./TeardownLogsDialog";

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -22,6 +22,7 @@ import { useAgentHookListener } from "renderer/stores/tabs/useAgentHookListener"
 import { useWorkspaceInitStore } from "renderer/stores/workspace-init";
 import { MOCK_ORG_ID } from "shared/constants";
 import { AgentHooks } from "./components/AgentHooks";
+import { TeardownLogsDialog } from "./components/TeardownLogsDialog";
 import { CollectionsProvider } from "./providers/CollectionsProvider";
 
 export const Route = createFileRoute("/_authenticated")({
@@ -115,6 +116,7 @@ function AuthenticatedLayout() {
 				<Outlet />
 				<WorkspaceInitEffects />
 				<NewWorkspaceModal />
+				<TeardownLogsDialog />
 				<Paywall />
 			</CollectionsProvider>
 		</DndProvider>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -310,7 +310,9 @@ export function WorkspaceListItem({
 	if (isCollapsed) {
 		const collapsedButton = (
 			<button
-				ref={itemRef}
+				ref={(node) => {
+					itemRef.current = node;
+				}}
 				type="button"
 				onClick={handleClick}
 				onMouseEnter={handleMouseEnter}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/DeleteWorktreeDialog.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/DeleteWorktreeDialog.tsx
@@ -11,6 +11,7 @@ import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useDeleteWorktree } from "renderer/react-query/workspaces/useDeleteWorktree";
+import { showTeardownLogs } from "renderer/routes/_authenticated/components/TeardownLogsDialog";
 
 interface DeleteWorktreeDialogProps {
 	worktreeId: string;
@@ -36,23 +37,36 @@ export function DeleteWorktreeDialog({
 			},
 		);
 
-	const handleDelete = () => {
+	const handleDelete = async () => {
 		onOpenChange(false);
 
-		toast.promise(
-			deleteWorktree.mutateAsync({ worktreeId }).then((result) => {
-				if (!result.success) {
-					throw new Error(result.error ?? "Failed to delete");
+		const toastId = toast.loading(`Deleting "${worktreeName}"...`);
+
+		try {
+			const result = await deleteWorktree.mutateAsync({ worktreeId });
+
+			if (!result.success) {
+				const { output } = result;
+				if (output) {
+					toast.error("Teardown failed", {
+						id: toastId,
+						action: {
+							label: "View Logs",
+							onClick: () => showTeardownLogs(output),
+						},
+					});
+				} else {
+					toast.error(result.error ?? "Failed to delete", { id: toastId });
 				}
-				return result;
-			}),
-			{
-				loading: `Deleting "${worktreeName}"...`,
-				success: `Deleted "${worktreeName}"`,
-				error: (error) =>
-					error instanceof Error ? error.message : "Failed to delete",
-			},
-		);
+				return;
+			}
+
+			toast.success(`Deleted "${worktreeName}"`, { id: toastId });
+		} catch (error) {
+			toast.error(error instanceof Error ? error.message : "Failed to delete", {
+				id: toastId,
+			});
+		}
 	};
 
 	const canDelete = canDeleteData?.canDelete ?? true;


### PR DESCRIPTION
## Summary
- When a teardown script fails during workspace/worktree deletion, show a brief "Teardown failed" toast with a "View Logs" button instead of dumping raw terminal output into the toast
- Clicking "View Logs" opens a modal with the full output rendered in a CodeBlock (`language="log"`)
- Return `teardownResult.output` from both `delete` and `deleteWorktree` tRPC procedures
- Use `setImmediate` in teardown exit handler to let buffered stream data flush before reading combined output
- Replace native `<input type="checkbox">` with `Checkbox` + `Label` from `@superset/ui`

## Test plan
- [x] Configure a project with a failing teardown command (e.g., `exit 1` in `.superset/config.json`)
- [x] Delete a worktree workspace — error toast shows "Teardown failed" with "View Logs" button
- [x] Click "View Logs" — modal opens with full terminal output in a styled CodeBlock
- [x] Verify scrolling works for long output
- [x] Verify the modal can be closed and re-opened from the toast
- [x] Test worktree deletion from the WorkspacesListView
- [x] Verify successful deletions still show the normal success toast
- [x] Lint, typecheck, and tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Teardown Logs modal to view detailed logs when deletion fails.
  * Added a checkbox option in the deletion dialog to control deleting the local branch.

* **Bug Fixes**
  * Improved deletion feedback: clearer success/error notifications and an actionable "View Logs" button when teardown produces logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->