### PR TITLE
fix(desktop): prevent duplicate auto-update toast

### DIFF
--- a/apps/desktop/src/renderer/components/UpdateToast/useUpdateListener.tsx
+++ b/apps/desktop/src/renderer/components/UpdateToast/useUpdateListener.tsx
@@ -1,12 +1,11 @@
 import { toast } from "@superset/ui/sonner";
-import { useRef } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { AUTO_UPDATE_STATUS } from "shared/auto-update";
 import { UpdateToast } from "./UpdateToast";
 
-export function useUpdateListener() {
-	const toastIdRef = useRef<string | number | null>(null);
+const UPDATE_TOAST_ID = "auto-update";
 
+export function useUpdateListener() {
 	electronTrpc.autoUpdate.subscribe.useSubscription(undefined, {
 		onData: (event) => {
 			const { status, version, error } = event;
@@ -15,10 +14,7 @@ export function useUpdateListener() {
 				status === AUTO_UPDATE_STATUS.IDLE ||
 				status === AUTO_UPDATE_STATUS.CHECKING
 			) {
-				if (toastIdRef.current !== null) {
-					toast.dismiss(toastIdRef.current);
-					toastIdRef.current = null;
-				}
+				toast.dismiss(UPDATE_TOAST_ID);
 				return;
 			}
 
@@ -27,11 +23,7 @@ export function useUpdateListener() {
 				status === AUTO_UPDATE_STATUS.READY ||
 				status === AUTO_UPDATE_STATUS.ERROR
 			) {
-				if (toastIdRef.current !== null) {
-					toast.dismiss(toastIdRef.current);
-				}
-
-				const toastId = toast.custom(
+				toast.custom(
 					(id) => (
 						<UpdateToast
 							toastId={id}
@@ -41,13 +33,12 @@ export function useUpdateListener() {
 						/>
 					),
 					{
+						id: UPDATE_TOAST_ID,
 						duration: Number.POSITIVE_INFINITY,
 						position: "bottom-right",
 						unstyled: true,
 					},
 				);
-
-				toastIdRef.current = toastId;
 			}
 		},
 	});


### PR DESCRIPTION
## Summary
- Uses a stable toast ID (`"auto-update"`) so Sonner replaces the existing toast in-place rather than creating a duplicate
- The tRPC subscription can deliver the same `DOWNLOADING` status twice (once from the initial `getUpdateStatus()` emit, once from the EventEmitter listener), which caused two identical "Downloading update..." toasts to appear
- Removes the manual `useRef`-based toast tracking in favor of Sonner's built-in ID-based deduplication

## Test plan
- [x] Run desktop app in dev mode, use `simulateDownloading` mutation to trigger the downloading toast — verify only one toast appears
- [x] Call `simulateDownloading` multiple times rapidly — verify still only one toast
- [x] Verify toast transitions (downloading → ready) update in place
- [x] Verify dismiss (X button / "Later") still works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved update notification handling by streamlining internal toast management logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->