### PR TITLE
fix(desktop): handle DrizzleError wrapping in migration error handler

### DIFF
--- a/apps/desktop/src/main/lib/local-db/index.ts
+++ b/apps/desktop/src/main/lib/local-db/index.ts
@@ -106,7 +106,8 @@ try {
 	const errorMessage =
 		`${sqliteError.message ?? ""} ${rootCause.message ?? ""}`.toLowerCase();
 
-	const isSqliteError = errorCode === "sqlite_error";
+	const isDrizzleError = sqliteError.constructor?.name === "DrizzleError";
+	const isSqliteError = errorCode === "sqlite_error" || isDrizzleError;
 	const isIdempotentMessage =
 		errorMessage.includes("duplicate column name") ||
 		errorMessage.includes("already exists") ||


### PR DESCRIPTION
## Summary
- DrizzleError wraps the original SQLite error in `error.cause`, but the migration error handler was only checking `.code` and `.message` on the outer DrizzleError — which has no `.code` and a generic `"Failed to run the query '...'"` message
- This caused idempotent migration errors (like `DROP COLUMN` on a non-existent column in migration 0018) to crash the app on startup instead of being caught and skipped
- Fix: also inspect `error.cause` to find the underlying SQLite error with its actual error code and message

## Test plan
- [ ] Verify app launches successfully after updating from a version before migration 0018
- [ ] Verify app launches successfully when local.db is in a partially-applied state (e.g. `delete_local_branch` column exists but `telemetry_enabled` was already dropped)
- [ ] Verify genuine migration errors (non-idempotent) are still re-thrown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit
<img width="1040" height="846" alt="Screenshot 2026-02-07 at 1 08 47 AM" src="https://github.com/user-attachments/assets/09a9e109-8356-44d1-8807-866f17ea5ace" />


* **Bug Fixes**
  * Improved database migration error handling to better surface underlying causes and produce clearer, normalized error codes.
  * Combines related error messages for more informative diagnostics.
  * Recognizes additional database error types to maintain idempotent migration behavior while improving failure reporting.
  * Added explanatory notes to clarify error unwrapping and classification for more consistent troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->