### PR TITLE
feat(desktop): simplify scripts editor UI

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/components/ScriptsEditor/ScriptsEditor.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/components/ScriptsEditor/ScriptsEditor.tsx
@@ -1,67 +1,51 @@
 import { Button } from "@superset/ui/button";
 import { cn } from "@superset/ui/utils";
 import { useCallback, useEffect, useState } from "react";
-import {
-	HiArrowTopRightOnSquare,
-	HiDocumentArrowUp,
-	HiPlus,
-	HiXMark,
-} from "react-icons/hi2";
+import { HiArrowTopRightOnSquare, HiDocumentArrowUp } from "react-icons/hi2";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { EXTERNAL_LINKS } from "shared/constants";
-
-interface ScriptEntry {
-	id: string;
-	content: string;
-}
 
 interface ScriptsEditorProps {
 	projectId: string;
 	className?: string;
 }
 
-function generateId(): string {
-	return Math.random().toString(36).substring(2, 9);
-}
-
-function parseScriptsFromConfig(content: string | null): {
-	setup: ScriptEntry[];
-	teardown: ScriptEntry[];
+function parseContentFromConfig(content: string | null): {
+	setup: string;
+	teardown: string;
 } {
 	if (!content) {
-		return { setup: [], teardown: [] };
+		return { setup: "", teardown: "" };
 	}
 
 	try {
 		const parsed = JSON.parse(content);
 		return {
-			setup: (parsed.setup ?? []).map((s: string) => ({
-				id: generateId(),
-				content: s,
-			})),
-			teardown: (parsed.teardown ?? []).map((s: string) => ({
-				id: generateId(),
-				content: s,
-			})),
+			setup: (parsed.setup ?? []).join("\n"),
+			teardown: (parsed.teardown ?? []).join("\n"),
 		};
 	} catch {
-		return { setup: [], teardown: [] };
+		return { setup: "", teardown: "" };
 	}
 }
 
-interface ScriptEntryRowProps {
-	script: ScriptEntry;
-	onChange: (id: string, content: string) => void;
-	onRemove: (id: string) => void;
-	onFileDrop: (id: string, content: string) => void;
+interface ScriptTextareaProps {
+	title: string;
+	description: string;
+	placeholder: string;
+	value: string;
+	onChange: (value: string) => void;
+	onImportFile: () => void;
 }
 
-function ScriptEntryRow({
-	script,
+function ScriptTextarea({
+	title,
+	description,
+	placeholder,
+	value,
 	onChange,
-	onRemove,
-	onFileDrop,
-}: ScriptEntryRowProps) {
+	onImportFile,
+}: ScriptTextareaProps) {
 	const [isDragOver, setIsDragOver] = useState(false);
 
 	const handleDragOver = useCallback((e: React.DragEvent) => {
@@ -96,116 +80,67 @@ function ScriptEntryRow({
 							filePath,
 						);
 						if (response && typeof response === "string") {
-							onFileDrop(script.id, response);
+							onChange(response);
 						}
 					} catch (error) {
-						console.error("Failed to read script file:", error);
+						console.error(
+							"[scripts/import] Failed to read dropped file:",
+							error,
+						);
 					}
 				}
 			}
 		},
-		[script.id, onFileDrop],
+		[onChange],
 	);
 
 	return (
-		// biome-ignore lint/a11y/useSemanticElements: Drop zone wrapper for drag-and-drop functionality
-		<div
-			role="region"
-			aria-label="Script editor with file drop support"
-			className={cn(
-				"relative group rounded-lg border transition-colors",
-				isDragOver
-					? "border-primary bg-primary/5"
-					: "border-border hover:border-border/80",
-			)}
-			onDragOver={handleDragOver}
-			onDragLeave={handleDragLeave}
-			onDrop={handleDrop}
-		>
-			<textarea
-				value={script.content}
-				onChange={(e) => onChange(script.id, e.target.value)}
-				placeholder="e.g. bun install && bun run dev"
-				className="w-full min-h-[60px] p-3 pr-10 text-sm font-mono bg-transparent resize-y focus:outline-none focus:ring-1 focus:ring-ring rounded-lg"
-				rows={2}
-			/>
-			<button
-				type="button"
-				onClick={() => onRemove(script.id)}
-				className="absolute top-2 right-2 p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent opacity-0 group-hover:opacity-100 transition-opacity"
-				title="Remove script"
-			>
-				<HiXMark className="h-4 w-4" />
-			</button>
-			{isDragOver && (
-				<div className="absolute inset-0 flex items-center justify-center bg-primary/10 rounded-lg pointer-events-none">
-					<div className="flex items-center gap-2 text-primary text-sm font-medium">
-						<HiDocumentArrowUp className="h-5 w-5" />
-						Drop to import
-					</div>
-				</div>
-			)}
-		</div>
-	);
-}
-
-interface ScriptsSectionProps {
-	title: string;
-	description: string;
-	scripts: ScriptEntry[];
-	onChange: (id: string, content: string) => void;
-	onAdd: () => void;
-	onRemove: (id: string) => void;
-	onFileDrop: (id: string, content: string) => void;
-	onImportFile: () => void;
-}
-
-function ScriptsSection({
-	title,
-	description,
-	scripts,
-	onChange,
-	onAdd,
-	onRemove,
-	onFileDrop,
-	onImportFile,
-}: ScriptsSectionProps) {
-	return (
-		<div className="space-y-3">
+		<div className="space-y-2">
 			<div>
 				<h4 className="text-sm font-medium">{title}</h4>
 				<p className="text-xs text-muted-foreground mt-0.5">{description}</p>
 			</div>
 
-			{scripts.length > 0 ? (
-				<div className="space-y-2">
-					{scripts.map((script) => (
-						<ScriptEntryRow
-							key={script.id}
-							script={script}
-							onChange={onChange}
-							onRemove={onRemove}
-							onFileDrop={onFileDrop}
-						/>
-					))}
-				</div>
-			) : null}
-
-			<div className="flex gap-2">
-				<Button variant="outline" size="sm" onClick={onAdd} className="gap-1.5">
-					<HiPlus className="h-3.5 w-3.5" />
-					Add
-				</Button>
-				<Button
-					variant="ghost"
-					size="sm"
-					onClick={onImportFile}
-					className="gap-1.5 text-muted-foreground"
-				>
-					<HiDocumentArrowUp className="h-3.5 w-3.5" />
-					Import file
-				</Button>
+			{/* biome-ignore lint/a11y/useSemanticElements: Drop zone wrapper for drag-and-drop functionality */}
+			<div
+				role="region"
+				aria-label={`${title} script editor with file drop support`}
+				className={cn(
+					"relative rounded-lg border transition-colors",
+					isDragOver
+						? "border-primary bg-primary/5"
+						: "border-border hover:border-border/80",
+				)}
+				onDragOver={handleDragOver}
+				onDragLeave={handleDragLeave}
+				onDrop={handleDrop}
+			>
+				<textarea
+					value={value}
+					onChange={(e) => onChange(e.target.value)}
+					placeholder={placeholder}
+					className="w-full min-h-[80px] p-3 text-sm font-mono bg-transparent resize-y focus:outline-none focus:ring-1 focus:ring-ring rounded-lg"
+					rows={3}
+				/>
+				{isDragOver && (
+					<div className="absolute inset-0 flex items-center justify-center bg-primary/10 rounded-lg pointer-events-none">
+						<div className="flex items-center gap-2 text-primary text-sm font-medium">
+							<HiDocumentArrowUp className="h-5 w-5" />
+							Drop to import
+						</div>
+					</div>
+				)}
 			</div>
+
+			<Button
+				variant="ghost"
+				size="sm"
+				onClick={onImportFile}
+				className="gap-1.5 text-muted-foreground"
+			>
+				<HiDocumentArrowUp className="h-3.5 w-3.5" />
+				Import file
+			</Button>
 		</div>
 	);
 }
@@ -219,16 +154,15 @@ export function ScriptsEditor({ projectId, className }: ScriptsEditorProps) {
 			{ enabled: !!projectId },
 		);
 
-	const [setupScripts, setSetupScripts] = useState<ScriptEntry[]>([]);
-	const [teardownScripts, setTeardownScripts] = useState<ScriptEntry[]>([]);
+	const [setupContent, setSetupContent] = useState("");
+	const [teardownContent, setTeardownContent] = useState("");
 	const [hasChanges, setHasChanges] = useState(false);
 
-	// Initialize scripts from config
 	useEffect(() => {
 		if (configData?.content) {
-			const parsed = parseScriptsFromConfig(configData.content);
-			setSetupScripts(parsed.setup);
-			setTeardownScripts(parsed.teardown);
+			const parsed = parseContentFromConfig(configData.content);
+			setSetupContent(parsed.setup);
+			setTeardownContent(parsed.teardown);
 			setHasChanges(false);
 		}
 	}, [configData?.content]);
@@ -241,111 +175,55 @@ export function ScriptsEditor({ projectId, className }: ScriptsEditorProps) {
 		},
 	});
 
-	const handleSetupChange = useCallback((id: string, content: string) => {
-		setSetupScripts((prev) =>
-			prev.map((s) => (s.id === id ? { ...s, content } : s)),
-		);
+	const handleSetupChange = useCallback((value: string) => {
+		setSetupContent(value);
 		setHasChanges(true);
 	}, []);
 
-	const handleTeardownChange = useCallback((id: string, content: string) => {
-		setTeardownScripts((prev) =>
-			prev.map((s) => (s.id === id ? { ...s, content } : s)),
-		);
+	const handleTeardownChange = useCallback((value: string) => {
+		setTeardownContent(value);
 		setHasChanges(true);
 	}, []);
 
-	const handleAddSetup = useCallback(() => {
-		setSetupScripts((prev) => [...prev, { id: generateId(), content: "" }]);
-		setHasChanges(true);
-	}, []);
-
-	const handleAddTeardown = useCallback(() => {
-		setTeardownScripts((prev) => [...prev, { id: generateId(), content: "" }]);
-		setHasChanges(true);
-	}, []);
-
-	const handleRemoveSetup = useCallback((id: string) => {
-		setSetupScripts((prev) => prev.filter((s) => s.id !== id));
-		setHasChanges(true);
-	}, []);
-
-	const handleRemoveTeardown = useCallback((id: string) => {
-		setTeardownScripts((prev) => prev.filter((s) => s.id !== id));
-		setHasChanges(true);
-	}, []);
-
-	const handleFileDropSetup = useCallback((id: string, content: string) => {
-		setSetupScripts((prev) =>
-			prev.map((s) => (s.id === id ? { ...s, content } : s)),
-		);
-		setHasChanges(true);
-	}, []);
-
-	const handleFileDropTeardown = useCallback((id: string, content: string) => {
-		setTeardownScripts((prev) =>
-			prev.map((s) => (s.id === id ? { ...s, content } : s)),
-		);
-		setHasChanges(true);
-	}, []);
-
-	const handleImportSetupFile = useCallback(async () => {
-		try {
-			const result = await window.ipcRenderer.invoke("open-file-dialog", {
-				filters: [{ name: "Scripts", extensions: ["sh", "bash", "zsh"] }],
-			});
-			if (result && typeof result === "string") {
-				const content = await window.ipcRenderer.invoke(
-					"read-script-file",
-					result,
-				);
-				if (content && typeof content === "string") {
-					setSetupScripts((prev) => [...prev, { id: generateId(), content }]);
-					setHasChanges(true);
+	const handleImportFile = useCallback(
+		async (setter: (value: string) => void) => {
+			try {
+				const result = await window.ipcRenderer.invoke("open-file-dialog", {
+					filters: [{ name: "Scripts", extensions: ["sh", "bash", "zsh"] }],
+				});
+				if (result && typeof result === "string") {
+					const content = await window.ipcRenderer.invoke(
+						"read-script-file",
+						result,
+					);
+					if (content && typeof content === "string") {
+						setter(content);
+						setHasChanges(true);
+					}
 				}
+			} catch (error) {
+				console.error("[scripts/import] Failed to import file:", error);
 			}
-		} catch (error) {
-			console.error("Failed to import file:", error);
-		}
-	}, []);
+		},
+		[],
+	);
 
-	const handleImportTeardownFile = useCallback(async () => {
-		try {
-			const result = await window.ipcRenderer.invoke("open-file-dialog", {
-				filters: [{ name: "Scripts", extensions: ["sh", "bash", "zsh"] }],
-			});
-			if (result && typeof result === "string") {
-				const content = await window.ipcRenderer.invoke(
-					"read-script-file",
-					result,
-				);
-				if (content && typeof content === "string") {
-					setTeardownScripts((prev) => [
-						...prev,
-						{ id: generateId(), content },
-					]);
-					setHasChanges(true);
-				}
-			}
-		} catch (error) {
-			console.error("Failed to import file:", error);
-		}
-	}, []);
+	const handleImportSetupFile = useCallback(
+		() => handleImportFile(setSetupContent),
+		[handleImportFile],
+	);
+
+	const handleImportTeardownFile = useCallback(
+		() => handleImportFile(setTeardownContent),
+		[handleImportFile],
+	);
 
 	const handleSave = useCallback(() => {
-		const setup = setupScripts
-			.map((s) => s.content.trim())
-			.filter((s) => s.length > 0);
-		const teardown = teardownScripts
-			.map((s) => s.content.trim())
-			.filter((s) => s.length > 0);
+		const setup = setupContent.trim() ? [setupContent.trim()] : [];
+		const teardown = teardownContent.trim() ? [teardownContent.trim()] : [];
 
 		updateConfigMutation.mutate({ projectId, setup, teardown });
-	}, [projectId, setupScripts, teardownScripts, updateConfigMutation]);
-
-	const handleLearnMore = () => {
-		window.open(EXTERNAL_LINKS.SETUP_TEARDOWN_SCRIPTS, "_blank");
-	};
+	}, [projectId, setupContent, teardownContent, updateConfigMutation]);
 
 	if (isLoading) {
 		return (
@@ -361,19 +239,19 @@ export function ScriptsEditor({ projectId, className }: ScriptsEditorProps) {
 				<div className="space-y-1">
 					<h3 className="text-base font-semibold text-foreground">Scripts</h3>
 					<p className="text-sm text-muted-foreground">
-						Commands that run automatically when workspaces are created or
-						deleted.
+						Automate your workspace lifecycle with setup and teardown scripts.
 					</p>
 				</div>
 				<div className="flex gap-2 shrink-0">
-					<Button
-						variant="ghost"
-						size="sm"
-						onClick={handleLearnMore}
-						className="gap-1.5 text-muted-foreground"
-					>
-						Learn more
-						<HiArrowTopRightOnSquare className="h-3.5 w-3.5" />
+					<Button variant="outline" size="sm" asChild>
+						<a
+							href={EXTERNAL_LINKS.SETUP_TEARDOWN_SCRIPTS}
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							Get started with setup scripts
+							<HiArrowTopRightOnSquare className="h-3.5 w-3.5" />
+						</a>
 					</Button>
 					{hasChanges && (
 						<Button
@@ -387,25 +265,21 @@ export function ScriptsEditor({ projectId, className }: ScriptsEditorProps) {
 				</div>
 			</div>
 
-			<ScriptsSection
+			<ScriptTextarea
 				title="Setup"
-				description="Run when a new workspace is created"
-				scripts={setupScripts}
+				description="Runs when a new workspace is created."
+				placeholder="e.g. bun install && bun run dev"
+				value={setupContent}
 				onChange={handleSetupChange}
-				onAdd={handleAddSetup}
-				onRemove={handleRemoveSetup}
-				onFileDrop={handleFileDropSetup}
 				onImportFile={handleImportSetupFile}
 			/>
 
-			<ScriptsSection
+			<ScriptTextarea
 				title="Teardown"
-				description="Run when a workspace is deleted"
-				scripts={teardownScripts}
+				description="Runs when a workspace is deleted."
+				placeholder="e.g. docker compose down"
+				value={teardownContent}
 				onChange={handleTeardownChange}
-				onAdd={handleAddTeardown}
-				onRemove={handleRemoveTeardown}
-				onFileDrop={handleFileDropTeardown}
 				onImportFile={handleImportTeardownFile}
 			/>
 		</div>


### PR DESCRIPTION
## Summary
- Replace multi-entry add/remove script pattern with a single always-visible textarea per section (setup + teardown)
- Add prominent "Get started with setup scripts" outline button linking to docs
- Add "Import file" button and drag-and-drop support for `.sh` files on each textarea
- Net -126 lines — removes `ScriptEntry`, `ScriptEntryRow`, `ScriptsSection` components and all per-entry state management

## Test plan
- [x] Open desktop app → project settings → Scripts section
- [x] Confirm setup and teardown textareas are always visible (no add button)
- [x] Type content, verify Save appears, save + reload — content persists
- [ ] Click "Import file" — file dialog opens, `.sh` file contents appear in textarea
- [ ] Drag a `.sh` file onto textarea — content imports
- [ ] Click "Get started with setup scripts" — docs page opens
- [ ] Verify existing multi-entry configs load correctly (backward compat)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Simplified setup and teardown scripts editor with improved text input interface.
  * Enhanced drag-and-drop file import for scripts.
  * Updated UI text and navigation for better clarity on script functionality.
  * Streamlined script management workflow with consistent file import handling across setup and teardown sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->