### PR TITLE
fix(desktop): fix typecheck error in WorkspaceListItem

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -310,7 +310,9 @@ export function WorkspaceListItem({
 	if (isCollapsed) {
 		const collapsedButton = (
 			<button
-				ref={itemRef}
+				ref={(node) => {
+					itemRef.current = node;
+				}}
 				type="button"
 				onClick={handleClick}
 				onMouseEnter={handleMouseEnter}


### PR DESCRIPTION
## Summary
- Fixed a TypeScript error in `WorkspaceListItem` where a `RefObject<HTMLElement>` was being passed directly to a `<button>` element that expects `Ref<HTMLButtonElement>`
- Uses a ref callback instead, which safely widens `HTMLButtonElement` to `HTMLElement` on assignment — consistent with the pattern already used by the expanded view's `<div>` ref

## Test plan
- [x] `bun run typecheck` passes across all 17 packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-facing changes in this release. Internal code improvements have been made to enhance stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->