### PR TITLE
fix(desktop): simplify chat re-render fix

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/ChatInterface.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/ChatInterface.tsx
@@ -85,19 +85,15 @@ export function ChatInterface({ sessionId, cwd }: ChatInterfaceProps) {
 	});
 	const stopSession = electronTrpc.aiChat.stopSession.useMutation();
 
-	const startSessionRef = useRef(startSession);
-	startSessionRef.current = startSession;
-	const stopSessionRef = useRef(stopSession);
-	stopSessionRef.current = stopSession;
-
 	useEffect(() => {
 		if (!sessionId || !cwd) return;
 		hasConnected.current = false;
 		setSessionReady(false);
-		startSessionRef.current.mutate({ sessionId, cwd });
+		startSession.mutate({ sessionId, cwd });
 		return () => {
-			stopSessionRef.current.mutate({ sessionId });
+			stopSession.mutate({ sessionId });
 		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- mutations are stable transports, not reactive deps
 	}, [sessionId, cwd]);
 
 	// Connect once both session is ready and config has loaded


### PR DESCRIPTION
## Summary
- Removes the `startSessionRef` / `stopSessionRef` ref workaround from #1283 and replaces it with a simple `eslint-disable` on the dependency array
- tRPC mutation objects are stable transports (we only call `.mutate()`), so they don't need to be reactive deps — an eslint suppression is clearer than 4 lines of ref boilerplate
- Keeps the `sessionReady` state improvement from #1283

## Test plan
- [ ] Open the chat pane — should load without crashing (no infinite re-render)
- [ ] Switch sessions/workspaces and confirm chat reconnects correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-visible changes in this release. This update includes internal code optimizations to improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->