### PR TITLE
fix(desktop): close create workspace dialog immediately on submit

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -241,6 +241,8 @@ export function NewWorkspaceModal() {
 
 		const workspaceName = title.trim() || undefined;
 
+		handleClose();
+
 		try {
 			const result = await createWorkspace.mutateAsync({
 				projectId: selectedProjectId,
@@ -249,8 +251,6 @@ export function NewWorkspaceModal() {
 				baseBranch: effectiveBaseBranch || undefined,
 				applyPrefix,
 			});
-
-			handleClose();
 
 			if (result.isInitializing) {
 				toast.success("Workspace created", {


### PR DESCRIPTION
## Summary
- The "Create Workspace" dialog previously stayed open until the backend mutation resolved, causing a noticeable delay after clicking the button
- Move `handleClose()` before the async `createWorkspace.mutateAsync` call so the dialog dismisses instantly

## Changes
- `apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx`: Move `handleClose()` to run before the async workspace creation call instead of after it. Success/error toasts still fire when the operation completes.

## Test Plan
- [ ] Open the "Create Workspace" dialog, fill in details, and click "Create Workspace"
- [ ] Verify the dialog closes immediately upon clicking
- [ ] Verify the success toast still appears after workspace creation finishes
- [ ] Verify error toast appears if creation fails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved modal behavior in workspace creation by adjusting the timing of when the modal closes relative to the operation completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->