### PR TITLE
fix(ui): context menu sub-trigger text misaligned with regular items

### DIFF
--- a/packages/ui/src/components/ui/context-menu.tsx
+++ b/packages/ui/src/components/ui/context-menu.tsx
@@ -66,7 +66,7 @@ function ContextMenuSubTrigger({
 			data-slot="context-menu-sub-trigger"
 			data-inset={inset}
 			className={cn(
-				"focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				"focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 				className,
 			)}
 			{...props}


### PR DESCRIPTION
## Description

Adds the missing `gap-2` class to `ContextMenuSubTrigger` so that submenu trigger text (e.g. "Set Color") aligns with regular `ContextMenuItem` text.

`ContextMenuItem` has `gap-2` for icon-to-text spacing, but `ContextMenuSubTrigger` was missing it - a shadcn/ui component-level inconsistency.

## Screenshots

| Before | After |
|---|---|
| <img width="161" height="219" alt="image" src="https://github.com/user-attachments/assets/44528001-e1d2-4ac2-9f73-e014144cdc0e" /> | <img width="162" height="219" alt="image" src="https://github.com/user-attachments/assets/cadfdfb4-ef60-472a-8835-f0674be3d054" /> |

## Related Issues

Fixes #1293

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

Verified locally - right-click project context menu now has consistent text alignment across all items including the "Set Color" submenu trigger.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced spacing in context menu sub-trigger elements with improved horizontal gap, providing better visual separation and readability between inline items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->