### PR TITLE
fix(desktop): preserve file explorer state when switching sidebar tabs

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
@@ -181,11 +181,29 @@ export function RightSidebar() {
 					</TooltipContent>
 				</Tooltip>
 			</div>
-			{rightSidebarTab === RightSidebarTab.Changes && showChangesTab ? (
-				<ChangesView onFileOpen={handleFileOpen} isExpandedView={isExpanded} />
-			) : (
-				<FilesView />
+			{showChangesTab && (
+				<div
+					className={
+						rightSidebarTab === RightSidebarTab.Changes
+							? "flex-1 min-h-0 flex flex-col overflow-hidden"
+							: "hidden"
+					}
+				>
+					<ChangesView
+						onFileOpen={handleFileOpen}
+						isExpandedView={isExpanded}
+					/>
+				</div>
 			)}
+			<div
+				className={
+					rightSidebarTab === RightSidebarTab.Changes && showChangesTab
+						? "hidden"
+						: "flex-1 min-h-0 flex flex-col overflow-hidden"
+				}
+			>
+				<FilesView />
+			</div>
 		</aside>
 	);
 }


### PR DESCRIPTION
## Summary

- Keep both `FilesView` and `ChangesView` mounted in the right sidebar, toggling visibility with CSS (`hidden` / `display: none`) instead of conditionally rendering only the active tab
- Preserves expanded folders, scroll position, and selection when switching between Changes and Files tabs

## Root cause

The `RightSidebar` component used a ternary to render either `<ChangesView />` or `<FilesView />`. Switching tabs unmounted the inactive component entirely, destroying the headless-tree's in-memory expansion state, scroll position, and selection.

## Fix

Both views are now always mounted. The inactive view gets `className="hidden"` (display: none), which removes it from layout without destroying its React state. This matches how VS Code handles panel switching.

Fixes #1296

## Test plan

- [x] Open a workspace, expand several nested folders in the Files tab, scroll down
- [x] Switch to Changes tab, then back to Files tab
- [x] Verify expanded folders, scroll position, and selection are preserved
- [x] Verify no flicker on tab switch
- [x] Verify Collapse All button still works
- [x] Verify Changes view also preserves its state when switching away and back
- [x] Verify switching workspaces still works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved sidebar view rendering performance and maintainability while preserving existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->