### PR TITLE
chore: bump better auth version

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -23,7 +23,7 @@
 		"@trpc/client": "^11.7.1",
 		"@trpc/server": "^11.7.1",
 		"@trpc/tanstack-react-query": "^11.7.1",
-		"better-auth": "1.4.17",
+		"better-auth": "1.4.18",
 		"date-fns": "^4.1.0",
 		"drizzle-orm": "0.45.1",
 		"import-in-the-middle": "2.0.1",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -30,7 +30,7 @@
 		"@trpc/server": "^11.7.1",
 		"@upstash/qstash": "^2.8.4",
 		"@vercel/blob": "^2.0.0",
-		"better-auth": "1.4.17",
+		"better-auth": "1.4.18",
 		"date-fns": "^4.1.0",
 		"drizzle-orm": "0.45.1",
 		"import-in-the-middle": "2.0.1",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -36,7 +36,7 @@
 	},
 	"dependencies": {
 		"@anthropic-ai/claude-agent-sdk": "^0.2.19",
-		"@better-auth/stripe": "1.4.17",
+		"@better-auth/stripe": "1.4.18",
 		"@dnd-kit/core": "^6.3.1",
 		"@dnd-kit/sortable": "^10.0.0",
 		"@dnd-kit/utilities": "^3.2.2",
@@ -108,7 +108,7 @@
 		"@xterm/addon-webgl": "0.20.0-beta.147",
 		"@xterm/headless": "6.1.0-beta.148",
 		"@xterm/xterm": "6.1.0-beta.148",
-		"better-auth": "1.4.17",
+		"better-auth": "1.4.18",
 		"better-sqlite3": "12.6.2",
 		"bindings": "^1.5.0",
 		"clsx": "^2.1.1",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -12,7 +12,7 @@
 		"lint:fix": "biome check --write ."
 	},
 	"dependencies": {
-		"@better-auth/expo": "1.4.17",
+		"@better-auth/expo": "1.4.18",
 		"@electric-sql/client": "https://pkg.pr.new/@electric-sql/client@3724",
 		"@react-native-async-storage/async-storage": "2.2.0",
 		"@react-navigation/native": "^7.1.28",
@@ -48,7 +48,7 @@
 		"@tanstack/react-query": "^5.90.19",
 		"@trpc/client": "^11.7.1",
 		"@trpc/react-query": "^11.7.1",
-		"better-auth": "1.4.17",
+		"better-auth": "1.4.18",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
 		"dotenv": "^17.2.3",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,7 +24,7 @@
 		"@trpc/server": "^11.7.1",
 		"@trpc/tanstack-react-query": "^11.7.1",
 		"@uiw/react-md-editor": "^4.0.11",
-		"better-auth": "1.4.17",
+		"better-auth": "1.4.18",
 		"framer-motion": "^12.23.26",
 		"geist": "^1.7.0",
 		"import-in-the-middle": "2.0.1",

--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
         "@trpc/client": "^11.7.1",
         "@trpc/server": "^11.7.1",
         "@trpc/tanstack-react-query": "^11.7.1",
-        "better-auth": "1.4.17",
+        "better-auth": "1.4.18",
         "date-fns": "^4.1.0",
         "drizzle-orm": "0.45.1",
         "import-in-the-middle": "2.0.1",
@@ -77,7 +77,7 @@
         "@trpc/server": "^11.7.1",
         "@upstash/qstash": "^2.8.4",
         "@vercel/blob": "^2.0.0",
-        "better-auth": "1.4.17",
+        "better-auth": "1.4.18",
         "date-fns": "^4.1.0",
         "drizzle-orm": "0.45.1",
         "import-in-the-middle": "2.0.1",
@@ -134,7 +134,7 @@
       "version": "0.0.69",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.19",
-        "@better-auth/stripe": "1.4.17",
+        "@better-auth/stripe": "1.4.18",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
@@ -206,7 +206,7 @@
         "@xterm/addon-webgl": "0.20.0-beta.147",
         "@xterm/headless": "6.1.0-beta.148",
         "@xterm/xterm": "6.1.0-beta.148",
-        "better-auth": "1.4.17",
+        "better-auth": "1.4.18",
         "better-sqlite3": "12.6.2",
         "bindings": "^1.5.0",
         "clsx": "^2.1.1",
@@ -393,7 +393,7 @@
       "name": "@superset/mobile",
       "version": "1.0.0",
       "dependencies": {
-        "@better-auth/expo": "1.4.17",
+        "@better-auth/expo": "1.4.18",
         "@electric-sql/client": "https://pkg.pr.new/@electric-sql/client@3724",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-navigation/native": "^7.1.28",
@@ -429,7 +429,7 @@
         "@tanstack/react-query": "^5.90.19",
         "@trpc/client": "^11.7.1",
         "@trpc/react-query": "^11.7.1",
-        "better-auth": "1.4.17",
+        "better-auth": "1.4.18",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "dotenv": "^17.2.3",
@@ -514,7 +514,7 @@
         "@trpc/server": "^11.7.1",
         "@trpc/tanstack-react-query": "^11.7.1",
         "@uiw/react-md-editor": "^4.0.11",
-        "better-auth": "1.4.17",
+        "better-auth": "1.4.18",
         "framer-motion": "^12.23.26",
         "geist": "^1.7.0",
         "import-in-the-middle": "2.0.1",
@@ -548,8 +548,8 @@
       "name": "@superset/auth",
       "version": "0.1.0",
       "dependencies": {
-        "@better-auth/expo": "1.4.17",
-        "@better-auth/stripe": "1.4.17",
+        "@better-auth/expo": "1.4.18",
+        "@better-auth/stripe": "1.4.18",
         "@superset/db": "workspace:*",
         "@superset/email": "workspace:*",
         "@superset/shared": "workspace:*",
@@ -558,7 +558,7 @@
         "@upstash/qstash": "^2.8.4",
         "@upstash/ratelimit": "^2.0.4",
         "@upstash/redis": "^1.34.3",
-        "better-auth": "1.4.17",
+        "better-auth": "1.4.18",
         "dotenv": "^17.2.3",
         "drizzle-orm": "0.45.1",
         "resend": "^4.0.1",
@@ -999,13 +999,13 @@
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
-    "@better-auth/core": ["@better-auth/core@1.4.17", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "zod": "^4.3.5" }, "peerDependencies": { "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.21", "better-call": "1.1.8", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1" } }, "sha512-WSaEQDdUO6B1CzAmissN6j0lx9fM9lcslEYzlApB5UzFaBeAOHNUONTdglSyUs6/idiZBoRvt0t/qMXCgIU8ug=="],
+    "@better-auth/core": ["@better-auth/core@1.4.18", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "zod": "^4.3.5" }, "peerDependencies": { "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.21", "better-call": "1.1.8", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1" } }, "sha512-q+awYgC7nkLEBdx2sW0iJjkzgSHlIxGnOpsN1r/O1+a4m7osJNHtfK2mKJSL1I+GfNyIlxJF8WvD/NLuYMpmcg=="],
 
-    "@better-auth/expo": ["@better-auth/expo@1.4.17", "", { "dependencies": { "@better-fetch/fetch": "1.1.21", "better-call": "1.1.8", "zod": "^4.3.5" }, "peerDependencies": { "@better-auth/core": "1.4.17", "better-auth": "1.4.17", "expo-constants": ">=17.0.0", "expo-linking": ">=7.0.0", "expo-network": "^8.0.7", "expo-web-browser": ">=14.0.0" }, "optionalPeers": ["expo-constants", "expo-linking", "expo-web-browser"] }, "sha512-Yg39o9gVgBMu9/lClQmIjEFLhQ7wuE3RzmlNDnNarlmu1ckvjPBmWEqJNzid6PB/muq1qWcYD3FMd/5omd9/Bg=="],
+    "@better-auth/expo": ["@better-auth/expo@1.4.18", "", { "dependencies": { "@better-fetch/fetch": "1.1.21", "better-call": "1.1.8", "zod": "^4.3.5" }, "peerDependencies": { "@better-auth/core": "1.4.18", "better-auth": "1.4.18", "expo-constants": ">=17.0.0", "expo-linking": ">=7.0.0", "expo-network": "^8.0.7", "expo-web-browser": ">=14.0.0" }, "optionalPeers": ["expo-constants", "expo-linking", "expo-network", "expo-web-browser"] }, "sha512-hrAgqtwe5R1eVsdMtxU8iLMZTHKeww5xpdqqyVWYO5UAwit/pb97d8TBGDfSj/uq5ihklC/0RNYg9SQNVTHSsQ=="],
 
-    "@better-auth/stripe": ["@better-auth/stripe@1.4.17", "", { "dependencies": { "defu": "^6.1.4", "zod": "^4.3.5" }, "peerDependencies": { "@better-auth/core": "1.4.17", "better-auth": "1.4.17", "stripe": "^18 || ^19 || ^20" } }, "sha512-BQpd7BYkbusiBf1a5MGUXFFhLe8wZXx5CbKWu7osN2JU7z8KP1ZocQrLDV+dy6n5e5SioQiF5+EqCiDwqTL+7g=="],
+    "@better-auth/stripe": ["@better-auth/stripe@1.4.18", "", { "dependencies": { "defu": "^6.1.4", "zod": "^4.3.5" }, "peerDependencies": { "@better-auth/core": "1.4.18", "better-auth": "1.4.18", "stripe": "^18 || ^19 || ^20" } }, "sha512-T1vUPHEnzd3/gQH2e9BigfqcaOZ3W+jBVlfHpXZVGoat1oKFPtKnJ3OHmfU1MwSCjNSdIFllrN6U6DhsQlZoEQ=="],
 
-    "@better-auth/telemetry": ["@better-auth/telemetry@1.4.17", "", { "dependencies": { "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.21" }, "peerDependencies": { "@better-auth/core": "1.4.17" } }, "sha512-R1BC4e/bNjQbXu7lG6ubpgmsPj7IMqky5DvMlzAtnAJWJhh99pMh/n6w5gOHa0cqDZgEAuj75IPTxv+q3YiInA=="],
+    "@better-auth/telemetry": ["@better-auth/telemetry@1.4.18", "", { "dependencies": { "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.21" }, "peerDependencies": { "@better-auth/core": "1.4.18" } }, "sha512-e5rDF8S4j3Um/0LIVATL2in9dL4lfO2fr2v1Wio4qTMRbfxqnUDTa+6SZtwdeJrbc4O+a3c+IyIpjG9Q/6GpfQ=="],
 
     "@better-auth/utils": ["@better-auth/utils@0.3.0", "", {}, "sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw=="],
 
@@ -2643,7 +2643,7 @@
 
     "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
 
-    "better-auth": ["better-auth@1.4.17", "", { "dependencies": { "@better-auth/core": "1.4.17", "@better-auth/telemetry": "1.4.17", "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.21", "@noble/ciphers": "^2.0.0", "@noble/hashes": "^2.0.0", "better-call": "1.1.8", "defu": "^6.1.4", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1", "zod": "^4.3.5" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4", "drizzle-orm": ">=0.41.0", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-VmHGQyKsEahkEs37qguROKg/6ypYpNF13D7v/lkbO7w7Aivz0Bv2h+VyUkH4NzrGY0QBKXi1577mGhDCVwp0ew=="],
+    "better-auth": ["better-auth@1.4.18", "", { "dependencies": { "@better-auth/core": "1.4.18", "@better-auth/telemetry": "1.4.18", "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.21", "@noble/ciphers": "^2.0.0", "@noble/hashes": "^2.0.0", "better-call": "1.1.8", "defu": "^6.1.4", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1", "zod": "^4.3.5" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4", "drizzle-orm": ">=0.41.0", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-bnyifLWBPcYVltH3RhS7CM62MoelEqC6Q+GnZwfiDWNfepXoQZBjEvn4urcERC7NTKgKq5zNBM8rvPvRBa6xcg=="],
 
     "better-call": ["better-call@1.1.8", "", { "dependencies": { "@better-auth/utils": "^0.3.0", "@better-fetch/fetch": "^1.1.4", "rou3": "^0.7.10", "set-cookie-parser": "^2.7.1" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-XMQ2rs6FNXasGNfMjzbyroSwKwYbZ/T3IxruSS6U2MJRsSYh3wYtG3o6H00ZlKZ/C/UPOAD97tqgQJNsxyeTXw=="],
 

--- a/opencode.json
+++ b/opencode.json
@@ -2,5 +2,11 @@
 	"$schema": "https://opencode.ai/config.json",
 	"permission": {
 		"external_directory": "allow"
+	},
+	"mcp": {
+		"superset": {
+			"type": "remote",
+			"url": "https://api.superset.sh/api/agent/mcp"
+		}
 	}
 }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -26,8 +26,8 @@
 		"typecheck": "tsc --noEmit --emitDeclarationOnly false"
 	},
 	"dependencies": {
-		"@better-auth/expo": "1.4.17",
-		"@better-auth/stripe": "1.4.17",
+		"@better-auth/expo": "1.4.18",
+		"@better-auth/stripe": "1.4.18",
 		"@superset/db": "workspace:*",
 		"@superset/email": "workspace:*",
 		"@superset/shared": "workspace:*",
@@ -36,7 +36,7 @@
 		"@upstash/qstash": "^2.8.4",
 		"@upstash/ratelimit": "^2.0.4",
 		"@upstash/redis": "^1.34.3",
-		"better-auth": "1.4.17",
+		"better-auth": "1.4.18",
 		"dotenv": "^17.2.3",
 		"drizzle-orm": "0.45.1",
 		"resend": "^4.0.1",


### PR DESCRIPTION
## Summary
- Add opencode CLI configuration (`opencode.json`) with remote MCP server support pointing to `api.superset.sh`
- Bump `better-auth` from 1.4.17 to 1.4.18 across all packages (web, api, desktop, mobile, auth)
- Desktop app improvements: chat UI enhancements, agent hooks, file tagging with @ commands, edit mode toggle for diffs, file explorer state preservation, local session persistence, and various bug fixes
- Marketing site updates including Geist Pixel font for hero
- MCP package improvements including workspaceId requirement for claude sessions

## Test plan
- [ ] Verify opencode CLI can discover MCP server via `.well-known/oauth-authorization-server`
- [ ] Test MCP OAuth flow (register → authorize → consent → token exchange)
- [ ] Verify desktop app builds and runs correctly
- [ ] Test chat UI features (@ file tagging, edit mode toggle, agent hooks)
- [ ] Confirm better-auth 1.4.18 has no schema migration issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated better-auth and related authentication packages to v1.4.18 across all applications and packages.
  * Added remote MCP superset configuration to project settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->