### PR TITLE
fix(mcp): use dynamic client registration for OAuth instead of hardcoded client ID

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,13 +2,7 @@
 	"mcpServers": {
 		"superset": {
 			"type": "http",
-			"url": "https://api.superset.sh/api/agent/mcp",
-			"oauth": {
-				"clientId": "claude-code",
-				"authorizationUrl": "https://api.superset.sh/api/auth/mcp/authorize",
-				"tokenUrl": "https://api.superset.sh/api/auth/mcp/token",
-				"scopes": ["openid", "profile", "email"]
-			}
+			"url": "https://api.superset.sh/api/agent/mcp"
 		},
 		"expo-mcp": {
 			"type": "http",

--- a/apps/web/src/app/oauth/consent/components/ConsentForm/ConsentForm.tsx
+++ b/apps/web/src/app/oauth/consent/components/ConsentForm/ConsentForm.tsx
@@ -26,6 +26,7 @@ interface Organization {
 interface ConsentFormProps {
 	consentCode: string;
 	clientId: string;
+	clientName?: string;
 	scopes: string[];
 	userName: string;
 	organizations: Organization[];
@@ -57,6 +58,7 @@ const SCOPE_DESCRIPTIONS: Record<
 export function ConsentForm({
 	consentCode,
 	clientId,
+	clientName,
 	scopes,
 	userName,
 	organizations,
@@ -134,16 +136,16 @@ export function ConsentForm({
 		}
 	};
 
-	const clientName = getClientDisplayName(clientId);
+	const displayName = clientName ?? getClientDisplayName(clientId);
 
 	return (
 		<div className="mx-auto flex w-full flex-col justify-center space-y-6 sm:w-[400px]">
 			<div className="flex flex-col space-y-2 text-center">
 				<h1 className="text-2xl font-semibold tracking-tight">
-					Authorize {clientName}
+					Authorize {displayName}
 				</h1>
 				<p className="text-muted-foreground text-sm">
-					<span className="font-medium text-foreground">{clientName}</span> is
+					<span className="font-medium text-foreground">{displayName}</span> is
 					requesting access to your Superset account
 				</p>
 			</div>

--- a/apps/web/src/app/oauth/consent/page.tsx
+++ b/apps/web/src/app/oauth/consent/page.tsx
@@ -1,4 +1,5 @@
 import { auth } from "@superset/auth/server";
+import { db } from "@superset/db/client";
 import { headers } from "next/headers";
 import Image from "next/image";
 import { redirect } from "next/navigation";
@@ -63,6 +64,11 @@ export default async function ConsentPage({ searchParams }: ConsentPageProps) {
 	const trpc = await api();
 	const userOrganizations = await trpc.user.myOrganizations.query();
 
+	const oauthApp = await db.query.oauthApplications.findFirst({
+		where: (table, { eq }) => eq(table.clientId, client_id),
+		columns: { name: true },
+	});
+
 	const extendedSession = session.session as typeof session.session & {
 		activeOrganizationId?: string | null;
 	};
@@ -86,6 +92,7 @@ export default async function ConsentPage({ searchParams }: ConsentPageProps) {
 				<ConsentForm
 					consentCode={consent_code}
 					clientId={client_id}
+					clientName={oauthApp?.name ?? undefined}
 					scopes={scopes}
 					userName={session.user.name}
 					organizations={userOrganizations.map((org) => ({


### PR DESCRIPTION
## Summary
- MCP OAuth authentication from Claude Code was failing with `invalid_client` because the hardcoded `clientId: "claude-code"` in `.mcp.json` was never registered in the `oauth_applications` database table
- Removed the hardcoded OAuth config so Claude Code uses the standard MCP OAuth discovery + dynamic client registration flow (which the API already supports via better-auth's MCP plugin)
- Updated the consent page to look up the application's registered name from the database, so dynamically registered clients display their proper name

## Changes
- **`.mcp.json`**: Removed `oauth` block (clientId, authorizationUrl, tokenUrl, scopes) — Claude Code will auto-discover these via `/.well-known/oauth-authorization-server`
- **`apps/web/src/app/oauth/consent/page.tsx`**: Query `oauth_applications` table for the client's `name` field and pass it as `clientName` prop
- **`apps/web/src/app/oauth/consent/components/ConsentForm/ConsentForm.tsx`**: Accept `clientName` prop and prefer it over the hardcoded `knownClients` fallback map

## Test Plan
- [ ] From Claude Code, run `/mcp` and authenticate the Superset MCP server — should complete OAuth flow without `invalid_client` error
- [ ] Verify the consent screen shows the application name correctly
- [ ] Verify existing `knownClients` fallback still works for clients without a DB name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth consent form now displays the actual application name in the authorization request, providing clearer identification of the service requesting access.

* **Chores**
  * Updated OAuth server configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->