### PR TITLE
fix(desktop): resolve JetBrains IDE edition-specific app names

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/external/helpers.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/helpers.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import os from "node:os";
 import path from "node:path";
-import { getAppCommand, resolvePath, stripPathWrappers } from "./helpers";
+import {
+	getAppCandidates,
+	getAppCommand,
+	resolvePath,
+	stripPathWrappers,
+} from "./helpers";
 
 describe("getAppCommand", () => {
 	test("returns null for finder (handled specially)", () => {
@@ -73,11 +78,11 @@ describe("getAppCommand", () => {
 	});
 
 	describe("JetBrains IDEs", () => {
-		test("returns correct command for intellij", () => {
+		test("returns first candidate for intellij (Ultimate edition)", () => {
 			const result = getAppCommand("intellij", "/path/to/file");
 			expect(result).toEqual({
 				command: "open",
-				args: ["-a", "IntelliJ IDEA", "/path/to/file"],
+				args: ["-a", "IntelliJ IDEA Ultimate", "/path/to/file"],
 			});
 		});
 
@@ -89,11 +94,11 @@ describe("getAppCommand", () => {
 			});
 		});
 
-		test("returns correct command for pycharm", () => {
+		test("returns first candidate for pycharm (Professional edition)", () => {
 			const result = getAppCommand("pycharm", "/path/to/file");
 			expect(result).toEqual({
 				command: "open",
-				args: ["-a", "PyCharm", "/path/to/file"],
+				args: ["-a", "PyCharm Professional", "/path/to/file"],
 			});
 		});
 
@@ -120,6 +125,40 @@ describe("getAppCommand", () => {
 			command: "open",
 			args: ["-a", "Cursor", "/path/with spaces/file.ts"],
 		});
+	});
+});
+
+describe("getAppCandidates", () => {
+	test("returns empty array for finder", () => {
+		expect(getAppCandidates("finder", "/path/to/file")).toEqual([]);
+	});
+
+	test("returns single candidate for single-edition app", () => {
+		expect(getAppCandidates("webstorm", "/path/to/file")).toEqual([
+			{ command: "open", args: ["-a", "WebStorm", "/path/to/file"] },
+		]);
+	});
+
+	test("returns multiple candidates for intellij (edition variants)", () => {
+		expect(getAppCandidates("intellij", "/path/to/file")).toEqual([
+			{
+				command: "open",
+				args: ["-a", "IntelliJ IDEA Ultimate", "/path/to/file"],
+			},
+			{ command: "open", args: ["-a", "IntelliJ IDEA CE", "/path/to/file"] },
+			{ command: "open", args: ["-a", "IntelliJ IDEA", "/path/to/file"] },
+		]);
+	});
+
+	test("returns multiple candidates for pycharm (edition variants)", () => {
+		expect(getAppCandidates("pycharm", "/path/to/file")).toEqual([
+			{
+				command: "open",
+				args: ["-a", "PyCharm Professional", "/path/to/file"],
+			},
+			{ command: "open", args: ["-a", "PyCharm CE", "/path/to/file"] },
+			{ command: "open", args: ["-a", "PyCharm", "/path/to/file"] },
+		]);
 	});
 });
 


### PR DESCRIPTION
## Description

JetBrains IDEs with multiple editions (IntelliJ IDEA, PyCharm) have edition-specific macOS app names that vary by install method. The hardcoded single name never matches, causing "Open in" to fail.

This adds a candidate-based resolution: `APP_NAMES` supports arrays of names tried in order, falling back only on "app not found" errors. Other errors (bad path, permissions) are thrown immediately.

## Related Issues

Fixes #1314

## Type of Change

- [x] Bug fix

## Testing

- Updated unit tests for `getAppCommand` and new `getAppCandidates` function (103 tests pass)
- Typecheck passes
- Manually verified: "Open in IntelliJ IDEA" successfully opens IntelliJ IDEA Ultimate on macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple application editions when opening files in external IDEs (e.g., different IntelliJ IDEA and PyCharm versions).

* **Bug Fixes**
  * Improved error handling and fallback behavior when opening files in external applications; system default launcher is used if preferred app is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->