### PR TITLE
fix(desktop): use bundle IDs for multi-edition JetBrains IDEs

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/external/helpers.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/helpers.test.ts
@@ -8,118 +8,124 @@ describe("getAppCommand", () => {
 		expect(getAppCommand("finder", "/path/to/file")).toBeNull();
 	});
 
-	test("returns correct command for cursor", () => {
+	test("returns single-element array for cursor", () => {
 		const result = getAppCommand("cursor", "/path/to/file");
-		expect(result).toEqual({
-			command: "open",
-			args: ["-a", "Cursor", "/path/to/file"],
-		});
+		expect(result).toEqual([
+			{ command: "open", args: ["-a", "Cursor", "/path/to/file"] },
+		]);
 	});
 
-	test("returns correct command for vscode", () => {
+	test("returns single-element array for vscode", () => {
 		const result = getAppCommand("vscode", "/path/to/file");
-		expect(result).toEqual({
-			command: "open",
-			args: ["-a", "Visual Studio Code", "/path/to/file"],
-		});
+		expect(result).toEqual([
+			{
+				command: "open",
+				args: ["-a", "Visual Studio Code", "/path/to/file"],
+			},
+		]);
 	});
 
-	test("returns correct command for sublime", () => {
+	test("returns single-element array for sublime", () => {
 		const result = getAppCommand("sublime", "/path/to/file");
-		expect(result).toEqual({
-			command: "open",
-			args: ["-a", "Sublime Text", "/path/to/file"],
-		});
+		expect(result).toEqual([
+			{ command: "open", args: ["-a", "Sublime Text", "/path/to/file"] },
+		]);
 	});
 
-	test("returns correct command for xcode", () => {
+	test("returns single-element array for xcode", () => {
 		const result = getAppCommand("xcode", "/path/to/file");
-		expect(result).toEqual({
-			command: "open",
-			args: ["-a", "Xcode", "/path/to/file"],
-		});
+		expect(result).toEqual([
+			{ command: "open", args: ["-a", "Xcode", "/path/to/file"] },
+		]);
 	});
 
-	test("returns correct command for iterm", () => {
+	test("returns single-element array for iterm", () => {
 		const result = getAppCommand("iterm", "/path/to/file");
-		expect(result).toEqual({
-			command: "open",
-			args: ["-a", "iTerm", "/path/to/file"],
-		});
+		expect(result).toEqual([
+			{ command: "open", args: ["-a", "iTerm", "/path/to/file"] },
+		]);
 	});
 
-	test("returns correct command for warp", () => {
+	test("returns single-element array for warp", () => {
 		const result = getAppCommand("warp", "/path/to/file");
-		expect(result).toEqual({
-			command: "open",
-			args: ["-a", "Warp", "/path/to/file"],
-		});
+		expect(result).toEqual([
+			{ command: "open", args: ["-a", "Warp", "/path/to/file"] },
+		]);
 	});
 
-	test("returns correct command for terminal", () => {
+	test("returns single-element array for terminal", () => {
 		const result = getAppCommand("terminal", "/path/to/file");
-		expect(result).toEqual({
-			command: "open",
-			args: ["-a", "Terminal", "/path/to/file"],
-		});
+		expect(result).toEqual([
+			{ command: "open", args: ["-a", "Terminal", "/path/to/file"] },
+		]);
 	});
 
-	test("returns correct command for ghostty", () => {
+	test("returns single-element array for ghostty", () => {
 		const result = getAppCommand("ghostty", "/path/to/file");
-		expect(result).toEqual({
-			command: "open",
-			args: ["-a", "Ghostty", "/path/to/file"],
-		});
+		expect(result).toEqual([
+			{ command: "open", args: ["-a", "Ghostty", "/path/to/file"] },
+		]);
 	});
 
 	describe("JetBrains IDEs", () => {
-		test("returns correct command for intellij", () => {
+		test("returns bundle ID candidates for intellij (multi-edition)", () => {
 			const result = getAppCommand("intellij", "/path/to/file");
-			expect(result).toEqual({
-				command: "open",
-				args: ["-a", "IntelliJ IDEA", "/path/to/file"],
-			});
+			expect(result).toEqual([
+				{
+					command: "open",
+					args: ["-b", "com.jetbrains.intellij", "/path/to/file"],
+				},
+				{
+					command: "open",
+					args: ["-b", "com.jetbrains.intellij.ce", "/path/to/file"],
+				},
+			]);
 		});
 
-		test("returns correct command for webstorm", () => {
-			const result = getAppCommand("webstorm", "/path/to/file");
-			expect(result).toEqual({
-				command: "open",
-				args: ["-a", "WebStorm", "/path/to/file"],
-			});
-		});
-
-		test("returns correct command for pycharm", () => {
+		test("returns bundle ID candidates for pycharm (multi-edition)", () => {
 			const result = getAppCommand("pycharm", "/path/to/file");
-			expect(result).toEqual({
-				command: "open",
-				args: ["-a", "PyCharm", "/path/to/file"],
-			});
+			expect(result).toEqual([
+				{
+					command: "open",
+					args: ["-b", "com.jetbrains.pycharm", "/path/to/file"],
+				},
+				{
+					command: "open",
+					args: ["-b", "com.jetbrains.pycharm.ce", "/path/to/file"],
+				},
+			]);
 		});
 
-		test("returns correct command for goland", () => {
+		test("returns single-element array for webstorm (single-edition)", () => {
+			const result = getAppCommand("webstorm", "/path/to/file");
+			expect(result).toEqual([
+				{ command: "open", args: ["-a", "WebStorm", "/path/to/file"] },
+			]);
+		});
+
+		test("returns single-element array for goland (single-edition)", () => {
 			const result = getAppCommand("goland", "/path/to/file");
-			expect(result).toEqual({
-				command: "open",
-				args: ["-a", "GoLand", "/path/to/file"],
-			});
+			expect(result).toEqual([
+				{ command: "open", args: ["-a", "GoLand", "/path/to/file"] },
+			]);
 		});
 
-		test("returns correct command for rustrover", () => {
+		test("returns single-element array for rustrover (single-edition)", () => {
 			const result = getAppCommand("rustrover", "/path/to/file");
-			expect(result).toEqual({
-				command: "open",
-				args: ["-a", "RustRover", "/path/to/file"],
-			});
+			expect(result).toEqual([
+				{ command: "open", args: ["-a", "RustRover", "/path/to/file"] },
+			]);
 		});
 	});
 
 	test("preserves paths with spaces", () => {
 		const result = getAppCommand("cursor", "/path/with spaces/file.ts");
-		expect(result).toEqual({
-			command: "open",
-			args: ["-a", "Cursor", "/path/with spaces/file.ts"],
-		});
+		expect(result).toEqual([
+			{
+				command: "open",
+				args: ["-a", "Cursor", "/path/with spaces/file.ts"],
+			},
+		]);
 	});
 });
 

--- a/apps/desktop/src/lib/trpc/routers/external/helpers.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/helpers.ts
@@ -15,9 +15,9 @@ const APP_NAMES: Record<ExternalApp, string | null> = {
 	terminal: "Terminal",
 	ghostty: "Ghostty",
 	sublime: "Sublime Text",
-	intellij: "IntelliJ IDEA",
+	intellij: null, // Multi-edition, uses bundle IDs
 	webstorm: "WebStorm",
-	pycharm: "PyCharm",
+	pycharm: null, // Multi-edition, uses bundle IDs
 	phpstorm: "PhpStorm",
 	rubymine: "RubyMine",
 	goland: "GoLand",
@@ -30,16 +30,36 @@ const APP_NAMES: Record<ExternalApp, string | null> = {
 };
 
 /**
- * Get the command and args to open a path in the specified app.
- * Uses `open -a` for macOS apps to avoid PATH issues in production builds.
+ * Bundle ID candidates for JetBrains IDEs with multiple editions.
+ * `open -b <bundleId>` works regardless of the .app display name,
+ * so "IntelliJ IDEA Ultimate.app" and "IntelliJ IDEA CE.app" both resolve correctly.
+ */
+const BUNDLE_ID_CANDIDATES: Partial<Record<ExternalApp, string[]>> = {
+	intellij: ["com.jetbrains.intellij", "com.jetbrains.intellij.ce"],
+	pycharm: ["com.jetbrains.pycharm", "com.jetbrains.pycharm.ce"],
+};
+
+/**
+ * Get candidate commands to open a path in the specified app.
+ * Returns an array of commands to try in order — for multi-edition apps (IntelliJ, PyCharm),
+ * multiple bundle IDs are returned so the caller can fall back if one isn't installed.
+ * Uses `open -b` (bundle ID) for multi-edition apps and `open -a` (app name) for others.
  */
 export function getAppCommand(
 	app: ExternalApp,
 	targetPath: string,
-): { command: string; args: string[] } | null {
+): { command: string; args: string[] }[] | null {
+	const bundleIds = BUNDLE_ID_CANDIDATES[app];
+	if (bundleIds) {
+		return bundleIds.map((id) => ({
+			command: "open",
+			args: ["-b", id, targetPath],
+		}));
+	}
+
 	const appName = APP_NAMES[app];
 	if (!appName) return null;
-	return { command: "open", args: ["-a", appName, targetPath] };
+	return [{ command: "open", args: ["-a", appName, targetPath] }];
 }
 
 /**


### PR DESCRIPTION
## Summary

- Uses `open -b <bundleId>` instead of `open -a <appName>` for IntelliJ and PyCharm, which have multiple editions (Ultimate/Professional vs Community)
- Bundle IDs are stable regardless of `.app` display name, so "IntelliJ IDEA Ultimate.app", "IntelliJ IDEA CE.app", etc. all resolve correctly
- Tries candidates in order (e.g. Ultimate first, then Community), falling back on failure
- Single-edition JetBrains IDEs (WebStorm, GoLand, etc.) are unchanged

Closes #1314

## Test plan

- [x] All 1205 tests pass (`bun test`)
- [x] Typecheck passes (17/17 packages)
- [x] Lint passes (`bun run lint:fix`)
- [x] Sherif passes
- [ ] Manual: verify `open -b com.jetbrains.intellij` opens IntelliJ on a machine with Ultimate installed
- [ ] Manual: verify fallback to `com.jetbrains.intellij.ce` works when only Community is installed
- [ ] Manual: verify PyCharm works similarly with Professional/Community editions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added enhanced support for multiple editions of JetBrains IDEs (IntelliJ IDEA, PyCharm) with improved launch compatibility.

* **Improvements**
  * Refined file opening logic with multi-candidate resolution, allowing graceful fallback attempts when primary methods fail, increasing success rates when opening files in external applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->