### PR TITLE
fix(billing): route member creation through Better Auth hooks

### DIFF
--- a/packages/trpc/src/router/organization/organization.ts
+++ b/packages/trpc/src/router/organization/organization.ts
@@ -320,15 +320,15 @@ export const organizationRouter = {
 				userId: z.string().uuid(),
 			}),
 		)
-		.mutation(async ({ input }) => {
-			const [member] = await db
-				.insert(members)
-				.values({
+		.mutation(async ({ ctx, input }) => {
+			const member = await ctx.auth.api.addMember({
+				body: {
 					organizationId: input.organizationId,
 					userId: input.userId,
 					role: "member",
-				})
-				.returning();
+				},
+				headers: ctx.headers,
+			});
 			return member;
 		}),
 


### PR DESCRIPTION
## Summary

- Two codepaths were creating org members via raw `db.insert(members)`, bypassing `beforeAddMember` (free plan seat limit) and `afterAddMember` (Stripe seat quantity update + notification emails)
- **tRPC `addMember` mutation** — replaced with `ctx.auth.api.addMember()`, matching the pattern already used by `removeMember`, `leaveOrganization`, and `updateMemberRole`
- **Invitation acceptance endpoint** — replaced with `auth.api.addMember()` via dynamic import to avoid circular dependency (`server.ts` imports this file)

Seat quantities will self-correct on next member add/remove (the `afterAddMember` hook does a full member count, not an increment). Plan to email affected org owners ahead of time.

## Test plan

- [x] `bun run typecheck` — 17/17 pass
- [x] `bun run lint:fix` — clean
- [x] `bun test` — 1205 pass, 0 fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Member creation now goes through a centralized API, improving consistency and reliability for inviting and adding organization members.
  * Role assignment during invites is standardized (defaults to member), reducing ambiguity in new member permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->