### PR TITLE
fix(desktop): break circular import in Paywall module

### DIFF
--- a/apps/desktop/src/renderer/components/Paywall/Paywall.tsx
+++ b/apps/desktop/src/renderer/components/Paywall/Paywall.tsx
@@ -5,8 +5,8 @@ import { useEffect, useRef, useState } from "react";
 import { posthog } from "../../lib/posthog";
 import { FeaturePreview } from "./components/FeaturePreview";
 import { FeatureSidebar } from "./components/FeatureSidebar";
+import type { GatedFeature } from "./constants";
 import { FEATURE_ID_MAP, PRO_FEATURES } from "./constants";
-import type { GatedFeature } from "./usePaywall";
 
 type PaywallOptions = {
 	feature: GatedFeature;

--- a/apps/desktop/src/renderer/components/Paywall/constants.ts
+++ b/apps/desktop/src/renderer/components/Paywall/constants.ts
@@ -6,8 +6,16 @@ import {
 	HiOutlinePuzzlePiece,
 	HiUsers,
 } from "react-icons/hi2";
-import type { GatedFeature } from "./usePaywall";
-import { GATED_FEATURES } from "./usePaywall";
+
+export const GATED_FEATURES = {
+	INVITE_MEMBERS: "invite-members",
+	INTEGRATIONS: "integrations",
+	TASKS: "tasks",
+	CLOUD_WORKSPACES: "cloud-workspaces",
+	MOBILE_APP: "mobile-app",
+} as const;
+
+export type GatedFeature = (typeof GATED_FEATURES)[keyof typeof GATED_FEATURES];
 
 export interface ProFeature {
 	id: string;

--- a/apps/desktop/src/renderer/components/Paywall/index.ts
+++ b/apps/desktop/src/renderer/components/Paywall/index.ts
@@ -1,3 +1,4 @@
+export type { GatedFeature } from "./constants";
+export { GATED_FEATURES } from "./constants";
 export { Paywall, paywall } from "./Paywall";
-export type { GatedFeature } from "./usePaywall";
-export { GATED_FEATURES, usePaywall } from "./usePaywall";
+export { usePaywall } from "./usePaywall";

--- a/apps/desktop/src/renderer/components/Paywall/usePaywall.ts
+++ b/apps/desktop/src/renderer/components/Paywall/usePaywall.ts
@@ -1,17 +1,8 @@
 import { authClient } from "renderer/lib/auth-client";
+import type { GatedFeature } from "./constants";
 import { paywall } from "./Paywall";
 
 type UserPlan = "free" | "pro";
-
-export const GATED_FEATURES = {
-	INVITE_MEMBERS: "invite-members",
-	INTEGRATIONS: "integrations",
-	TASKS: "tasks",
-	CLOUD_WORKSPACES: "cloud-workspaces",
-	MOBILE_APP: "mobile-app",
-} as const;
-
-export type GatedFeature = (typeof GATED_FEATURES)[keyof typeof GATED_FEATURES];
 
 export function usePaywall() {
 	const { data: session } = authClient.useSession();

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/integrations/components/IntegrationsSettings/IntegrationsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/integrations/components/IntegrationsSettings/IntegrationsSettings.tsx
@@ -14,10 +14,7 @@ import { useCallback, useEffect, useState } from "react";
 import { FaGithub, FaSlack } from "react-icons/fa";
 import { HiCheckCircle, HiOutlineArrowTopRightOnSquare } from "react-icons/hi2";
 import { SiLinear } from "react-icons/si";
-import {
-	GATED_FEATURES,
-	usePaywall,
-} from "renderer/components/Paywall/usePaywall";
+import { GATED_FEATURES, usePaywall } from "renderer/components/Paywall";
 import { env } from "renderer/env.renderer";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { authClient } from "renderer/lib/auth-client";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/members/components/MembersSettings/components/InviteMemberButton/InviteMemberButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/members/components/MembersSettings/components/InviteMemberButton/InviteMemberButton.tsx
@@ -6,10 +6,7 @@ import { alert } from "@superset/ui/atoms/Alert";
 import { Button } from "@superset/ui/button";
 import { useState } from "react";
 import { HiOutlinePlus } from "react-icons/hi2";
-import {
-	GATED_FEATURES,
-	usePaywall,
-} from "renderer/components/Paywall/usePaywall";
+import { GATED_FEATURES, usePaywall } from "renderer/components/Paywall";
 import { InviteMemberDialog } from "./components/InviteMemberDialog";
 
 interface InviteMemberButtonProps {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarHeader/WorkspaceSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarHeader/WorkspaceSidebarHeader.tsx
@@ -3,10 +3,7 @@ import { cn } from "@superset/ui/utils";
 import { useMatchRoute, useNavigate } from "@tanstack/react-router";
 import { HiOutlineClipboardDocumentList } from "react-icons/hi2";
 import { LuLayers } from "react-icons/lu";
-import {
-	GATED_FEATURES,
-	usePaywall,
-} from "renderer/components/Paywall/usePaywall";
+import { GATED_FEATURES, usePaywall } from "renderer/components/Paywall";
 import { STROKE_WIDTH } from "../constants";
 import { NewWorkspaceButton } from "./NewWorkspaceButton";
 


### PR DESCRIPTION
## Summary
- Moved `GATED_FEATURES` constant and `GatedFeature` type from `usePaywall.ts` into `constants.ts`, breaking the circular dependency: `usePaywall → Paywall → constants → usePaywall`
- Updated 3 consumer files to import from the barrel (`renderer/components/Paywall`) instead of directly from `usePaywall`

## Test plan
- [x] `bun run lint:fix` — passes
- [x] `bun run typecheck` — 17/17 packages pass
- [x] `bun test` — 1205 tests pass, 0 failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal module structure to improve code organization and maintainability without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->