### PR TITLE
Add Neon, Linear, Sentry, and PostHog MCP servers

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -12,7 +12,7 @@
 			"command": "maestro",
 			"args": ["mcp"]
 		},
-		"Neon": {
+		"neon": {
 			"type": "http",
 			"url": "https://mcp.neon.tech/mcp"
 		},


### PR DESCRIPTION
## Summary
- Adds 4 MCP server configs to `.mcp.json` so all team members get access in Claude Code
- **Neon**, **Linear**, **Sentry**: native HTTP transport with OAuth (authenticate via `/mcp` in Claude Code)
- **PostHog**: uses `mcp-remote` bridge with Bearer token auth (requires `POSTHOG_API_KEY` env var)

## Test plan
- [ ] Run Claude Code and verify `/mcp` shows all new servers
- [ ] Authenticate with each OAuth-based server (Neon, Linear, Sentry)
- [ ] Set `POSTHOG_API_KEY` in `.env` and verify PostHog connects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added integrations with Neon, Linear, and Sentry services for improved connectivity.
  * Added PostHog analytics integration with authenticated remote connector to enable secure event reporting and configurable API-key based auth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->