### PR TITLE
fix(desktop): scope base branch override per workspace

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/ChangesContent.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/ChangesContent.tsx
@@ -11,7 +11,8 @@ export function ChangesContent() {
 	);
 	const worktreePath = workspace?.worktreePath;
 
-	const { baseBranch } = useChangesStore();
+	const { getBaseBranch } = useChangesStore();
+	const baseBranch = getBaseBranch(worktreePath || "");
 	const { data: branchData } = electronTrpc.changes.getBranches.useQuery(
 		{ worktreePath: worktreePath || "" },
 		{ enabled: !!worktreePath },

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
@@ -40,7 +40,8 @@ export function ChangesView({ onFileOpen, isExpandedView }: ChangesViewProps) {
 	);
 	const worktreePath = workspace?.worktreePath;
 
-	const { baseBranch } = useChangesStore();
+	const { getBaseBranch } = useChangesStore();
+	const baseBranch = getBaseBranch(worktreePath || "");
 	const { data: branchData } = electronTrpc.changes.getBranches.useQuery(
 		{ worktreePath: worktreePath || "" },
 		{ enabled: !!worktreePath },

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ChangesHeader/ChangesHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ChangesHeader/ChangesHeader.tsx
@@ -31,7 +31,8 @@ interface ChangesHeaderProps {
 }
 
 function BaseBranchSelector({ worktreePath }: { worktreePath: string }) {
-	const { baseBranch, setBaseBranch } = useChangesStore();
+	const { getBaseBranch, setBaseBranch } = useChangesStore();
+	const baseBranch = getBaseBranch(worktreePath);
 	const { data: branchData, isLoading } =
 		electronTrpc.changes.getBranches.useQuery(
 			{ worktreePath },
@@ -46,8 +47,11 @@ function BaseBranchSelector({ worktreePath }: { worktreePath: string }) {
 	});
 
 	const handleBranchSelect = (branch: string) => {
-		if (branch === branchData?.defaultBranch && baseBranch === null) return;
-		setBaseBranch(branch);
+		if (branch === branchData?.defaultBranch) {
+			setBaseBranch(worktreePath, null);
+		} else {
+			setBaseBranch(worktreePath, branch);
+		}
 	};
 
 	return (

--- a/apps/desktop/src/renderer/stores/changes/store.ts
+++ b/apps/desktop/src/renderer/stores/changes/store.ts
@@ -19,7 +19,7 @@ interface ChangesState {
 	viewMode: DiffViewMode;
 	fileListViewMode: FileListViewMode;
 	expandedSections: Record<ChangeCategory, boolean>;
-	baseBranch: string | null;
+	baseBranch: Record<string, string | null>;
 	showRenderedMarkdown: Record<string, boolean>;
 	hideUnchangedRegions: boolean;
 
@@ -34,7 +34,8 @@ interface ChangesState {
 	setFileListViewMode: (mode: FileListViewMode) => void;
 	toggleSection: (section: ChangeCategory) => void;
 	setSectionExpanded: (section: ChangeCategory, expanded: boolean) => void;
-	setBaseBranch: (branch: string | null) => void;
+	setBaseBranch: (worktreePath: string, branch: string | null) => void;
+	getBaseBranch: (worktreePath: string) => string | null;
 	toggleRenderedMarkdown: (worktreePath: string) => void;
 	getShowRenderedMarkdown: (worktreePath: string) => boolean;
 	toggleHideUnchangedRegions: () => void;
@@ -51,7 +52,7 @@ const initialState = {
 		staged: true,
 		unstaged: true,
 	},
-	baseBranch: null,
+	baseBranch: {} as Record<string, string | null>,
 	showRenderedMarkdown: {} as Record<string, boolean>,
 	hideUnchangedRegions: false,
 };
@@ -110,8 +111,18 @@ export const useChangesStore = create<ChangesState>()(
 					});
 				},
 
-				setBaseBranch: (branch) => {
-					set({ baseBranch: branch });
+				setBaseBranch: (worktreePath, branch) => {
+					const { baseBranch } = get();
+					set({
+						baseBranch: {
+							...baseBranch,
+							[worktreePath]: branch,
+						},
+					});
+				},
+
+				getBaseBranch: (worktreePath) => {
+					return get().baseBranch[worktreePath] ?? null;
 				},
 
 				toggleRenderedMarkdown: (worktreePath) => {
@@ -144,6 +155,12 @@ export const useChangesStore = create<ChangesState>()(
 			}),
 			{
 				name: "changes-store",
+				version: 1,
+				migrate: (persisted) => {
+					const state = persisted as Record<string, unknown>;
+					state.baseBranch = {};
+					return state as unknown as ChangesState;
+				},
 				partialize: (state) => ({
 					selectedFiles: state.selectedFiles,
 					viewMode: state.viewMode,


### PR DESCRIPTION
## Summary
- The `baseBranch` in the changes Zustand store was a **global** `string | null` shared across all workspaces and persisted to localStorage
- When a user changed the base branch comparison in one workspace's Changes view, it silently affected every other workspace
- This caused new workspaces to show diff stats against the wrong branch, making it look like a WIP feature was accidentally merged
- Only reproducible for users who had previously changed the base branch selector — others had `null` which correctly fell back to the default

## Changes
- **`stores/changes/store.ts`**: Changed `baseBranch` from `string | null` to `Record<string, string | null>` keyed by `worktreePath`. Updated `setBaseBranch` to accept `(worktreePath, branch)`. Added `getBaseBranch(worktreePath)` helper.
- **`ChangesHeader.tsx`**: `BaseBranchSelector` now scopes overrides per worktree. Selecting the default branch resets to `null` instead of storing the literal string (fixes cross-project stickiness).
- **`ChangesView.tsx`**, **`ChangesContent.tsx`**, **`SidebarControl.tsx`**: Updated to use `getBaseBranch(worktreePath)` instead of the old global value.

## Test Plan
- [ ] Open workspace A, change base branch to a non-default branch in the Changes sidebar
- [ ] Open workspace B — verify it uses the project default branch, not workspace A's override
- [ ] Restart the app — verify workspace B still uses the default, workspace A retains its override
- [ ] Select the default branch in the base branch dropdown — verify it resets correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Base branch is now stored per workspace, improving multi-workspace behavior and reliability.
  * Branch selector persists workspace-specific base branch choices and allows clearing back to default.
  * Status, change lists, and related views now use the workspace-specific base branch for comparisons and listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->