### PR TITLE
fix(ci): update ci-check to fix warnings and auto-fix sherif

### DIFF
--- a/.claude/commands/ci-check.md
+++ b/.claude/commands/ci-check.md
@@ -12,7 +12,7 @@ Run these four commands **in parallel** and report all results:
 1. `bun run lint:fix` — Biome formatting + linting (auto-fixes)
 2. `bun run typecheck` — TypeScript type checking across all packages
 3. `bun test` — Run all tests
-4. `bunx sherif` — Monorepo dependency linting
+4. `bunx sherif --fix` — Monorepo dependency linting (auto-fixes)
 
 ## Output
 
@@ -26,5 +26,9 @@ After all commands complete, print a summary table:
 | sherif | pass/fail |
 
 If any check fails, show the relevant error output.
+
+## Fix Warnings
+
+After the initial run, if any check produced **warnings** (not just errors), fix them manually since warnings still fail CI. Re-run the failing check(s) to confirm they pass cleanly with zero warnings.
 
 $ARGUMENTS


### PR DESCRIPTION
## Summary
- CI checks were passing locally but warnings still caused CI failures
- The `ci-check` slash command now instructs the agent to fix remaining warnings after the initial run
- Changed `bunx sherif` to `bunx sherif --fix` to auto-fix dependency issues

## Changes
- `.claude/commands/ci-check.md`: Added `--fix` flag to sherif command
- `.claude/commands/ci-check.md`: Added "Fix Warnings" section instructing the agent to resolve warnings (not just errors) since they still fail CI

## Test Plan
- [ ] Run `/ci-check` and verify sherif runs with `--fix`
- [ ] Introduce a lint warning and verify the agent fixes it instead of just reporting it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CI-check documentation to clarify automated code quality fixes and added guidance for manually addressing any remaining warnings to ensure all checks pass with zero warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->