### PR TITLE
fix(desktop): collapse sidebar tab buttons to icons when narrow

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
@@ -27,12 +27,34 @@ function TabButton({
 	onClick,
 	icon,
 	label,
+	compact,
 }: {
 	isActive: boolean;
 	onClick: () => void;
 	icon: React.ReactNode;
 	label: string;
+	compact?: boolean;
 }) {
+	if (compact) {
+		return (
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<Button
+						variant="ghost"
+						size="icon"
+						onClick={onClick}
+						className={`size-6 p-0 ${isActive ? "bg-muted" : ""}`}
+					>
+						{icon}
+					</Button>
+				</TooltipTrigger>
+				<TooltipContent side="bottom" showArrow={false}>
+					{label}
+				</TooltipContent>
+			</Tooltip>
+		);
+	}
+
 	return (
 		<Button
 			variant="ghost"
@@ -59,8 +81,10 @@ export function RightSidebar() {
 		setRightSidebarTab,
 		toggleSidebar,
 		setMode,
+		sidebarWidth,
 	} = useSidebarStore();
 	const isExpanded = currentMode === SidebarMode.Changes;
+	const compactTabs = sidebarWidth < 250;
 	const showChangesTab = !!worktreePath;
 
 	const handleExpandToggle = () => {
@@ -124,13 +148,14 @@ export function RightSidebar() {
 
 	return (
 		<aside className="h-full flex flex-col overflow-hidden">
-			<div className="flex flex-wrap items-center gap-1 px-2 py-1.5 border-b border-border">
+			<div className="flex items-center gap-1 px-2 py-1.5 border-b border-border">
 				{showChangesTab && (
 					<TabButton
 						isActive={rightSidebarTab === RightSidebarTab.Changes}
 						onClick={() => setRightSidebarTab(RightSidebarTab.Changes)}
 						icon={<LuGitCompareArrows className="size-3.5" />}
 						label="Changes"
+						compact={compactTabs}
 					/>
 				)}
 				<TabButton
@@ -138,6 +163,7 @@ export function RightSidebar() {
 					onClick={() => setRightSidebarTab(RightSidebarTab.Files)}
 					icon={<LuFile className="size-3.5" />}
 					label="Files"
+					compact={compactTabs}
 				/>
 				<div className="flex-1" />
 				<Tooltip>


### PR DESCRIPTION
## Summary
- Fix the right sidebar header buttons wrapping to a second row when the sidebar is resized to a narrow width
- Tab buttons ("Changes", "Files") now collapse to icon-only mode with tooltips when sidebar width is below 250px

## Changes
- Add `compact` prop to `TabButton` — renders as icon-only button with tooltip when true
- Derive `compactTabs` from `sidebarWidth < 250` via the sidebar store
- Remove `flex-wrap` from the header row so expand/close buttons always stay inline

## Test Plan
- [x] Resize the right sidebar to its minimum width (200px) — "Changes" and "Files" should show as icons only
- [x] Hover over the icon-only buttons — tooltips should show "Changes" / "Files"
- [x] Widen the sidebar past 250px — buttons should show full text labels again
- [x] Verify the expand and close buttons never wrap to a second row

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added compact tab display mode for the right sidebar that automatically activates when the sidebar width drops below 250 pixels, displaying tab buttons as icons with helpful tooltips instead of full labels to optimize space usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->