### PR TITLE
fix(electric): add backoff to reduce retry storm

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
@@ -23,6 +23,11 @@ import { z } from "zod";
 
 const columnMapper = snakeCamelMapper();
 const electricUrl = `${env.NEXT_PUBLIC_API_URL}/api/electric/v1/shape`;
+const backoffOptions = {
+	initialDelay: 1_000,
+	maxDelay: 30_000,
+	multiplier: 2,
+};
 
 interface OrgCollections {
 	tasks: Collection<SelectTask>;
@@ -66,6 +71,7 @@ const organizationsCollection = createCollection(
 				},
 			},
 			columnMapper,
+			backoffOptions,
 		},
 		getKey: (item) => item.id,
 	}),
@@ -94,6 +100,7 @@ const apiKeysCollection = createCollection(
 				},
 			},
 			columnMapper,
+			backoffOptions,
 		},
 		getKey: (item) => item.id,
 	}),
@@ -118,6 +125,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 				},
 				headers,
 				columnMapper,
+				backoffOptions,
 			},
 			getKey: (item) => item.id,
 			onInsert: async ({ transaction }) => {
@@ -152,6 +160,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 				},
 				headers,
 				columnMapper,
+				backoffOptions,
 			},
 			getKey: (item) => item.id,
 		}),
@@ -168,6 +177,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 				},
 				headers,
 				columnMapper,
+				backoffOptions,
 			},
 			getKey: (item) => item.id,
 			onInsert: async ({ transaction }) => {
@@ -194,6 +204,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 				},
 				headers,
 				columnMapper,
+				backoffOptions,
 			},
 			getKey: (item) => item.id,
 		}),
@@ -210,6 +221,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 				},
 				headers,
 				columnMapper,
+				backoffOptions,
 			},
 			getKey: (item) => item.id,
 		}),
@@ -226,6 +238,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 				},
 				headers,
 				columnMapper,
+				backoffOptions,
 			},
 			getKey: (item) => item.id,
 		}),
@@ -242,6 +255,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 				},
 				headers,
 				columnMapper,
+				backoffOptions,
 			},
 			getKey: (item) => item.id,
 			onUpdate: async ({ transaction }) => {
@@ -274,6 +288,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 				},
 				headers,
 				columnMapper,
+				backoffOptions,
 			},
 			getKey: (item) => item.id,
 		}),
@@ -290,6 +305,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 				},
 				headers,
 				columnMapper,
+				backoffOptions,
 			},
 			getKey: (item) => item.id,
 		}),

--- a/apps/mobile/lib/collections/collections.ts
+++ b/apps/mobile/lib/collections/collections.ts
@@ -17,6 +17,11 @@ import { apiClient } from "../trpc/client";
 
 const columnMapper = snakeCamelMapper();
 const electricUrl = `${env.EXPO_PUBLIC_API_URL}/api/electric/v1/shape`;
+const backoffOptions = {
+	initialDelay: 1_000,
+	maxDelay: 30_000,
+	multiplier: 2,
+};
 
 interface OrgCollections {
 	tasks: Collection<SelectTask>;
@@ -40,6 +45,7 @@ const organizationsCollection = createCollection(
 				Cookie: () => authClient.getCookie() || "",
 			},
 			columnMapper,
+			backoffOptions,
 		},
 		getKey: (item) => item.id,
 	}),
@@ -58,6 +64,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 				params: { table: "tasks", organizationId },
 				headers,
 				columnMapper,
+				backoffOptions,
 			},
 			getKey: (item) => item.id,
 			onInsert: async ({ transaction }) => {
@@ -89,6 +96,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 				params: { table: "task_statuses", organizationId },
 				headers,
 				columnMapper,
+				backoffOptions,
 			},
 			getKey: (item) => item.id,
 		}),
@@ -102,6 +110,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 				params: { table: "repositories", organizationId },
 				headers,
 				columnMapper,
+				backoffOptions,
 			},
 			getKey: (item) => item.id,
 			onInsert: async ({ transaction }) => {
@@ -125,6 +134,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 				params: { table: "auth.members", organizationId },
 				headers,
 				columnMapper,
+				backoffOptions,
 			},
 			getKey: (item) => item.id,
 		}),
@@ -138,6 +148,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 				params: { table: "auth.users", organizationId },
 				headers,
 				columnMapper,
+				backoffOptions,
 			},
 			getKey: (item) => item.id,
 		}),
@@ -151,6 +162,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 				params: { table: "auth.invitations", organizationId },
 				headers,
 				columnMapper,
+				backoffOptions,
 			},
 			getKey: (item) => item.id,
 		}),


### PR DESCRIPTION
## Summary
- Configures `backoffOptions` on all Electric shape subscriptions (desktop: 11 shapes, mobile: 7 shapes)
- Changes retry from default `100ms / 1.3x multiplier` to `1s / 2x multiplier`
- Retry sequence becomes `1s → 2s → 4s → 8s → 16s → 30s cap` instead of ~50+ retries before reaching 1s

## Context
We're seeing ~130k `TypeError: fetch failed` (`UND_ERR_SOCKET: other side closed`) errors on Vercel from the Electric proxy. When the upstream Electric server drops connections, every shape for every user retries almost instantly with the default backoff, creating a thundering herd.

## Test plan
- [ ] Verify desktop app syncs normally with new backoff
- [ ] Verify mobile app syncs normally with new backoff
- [ ] Monitor Vercel error volume after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced API request resilience with automatic exponential backoff retry behavior across all data collections in both desktop and mobile applications, providing improved stability during temporary service disruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->