### PR TITLE
fix(desktop): add timeouts to git/GitHub network operations

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git-timeouts.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git-timeouts.ts
@@ -1,0 +1,28 @@
+/** 10s — config reads, rev-parse, local-only commands */
+export const GIT_TIMEOUT_LOCAL = 10_000;
+
+/** 30s — fetch single branch, ls-remote, gh API calls */
+export const GIT_TIMEOUT_NETWORK = 30_000;
+
+/** 60s — push, pull (significant data transfer) */
+export const GIT_TIMEOUT_NETWORK_HEAVY = 60_000;
+
+/** 120s — worktree creation, large fetches (e.g. fork PRs) */
+export const GIT_TIMEOUT_LONG = 120_000;
+
+export function isTimeoutError(error: unknown): boolean {
+	return (
+		error instanceof Error &&
+		"killed" in error &&
+		(error as any).killed === true
+	);
+}
+
+export function wrapTimeoutError(error: unknown, operation: string): Error {
+	if (isTimeoutError(error)) {
+		return new Error(
+			`${operation} timed out. Check your network connection and try again.`,
+		);
+	}
+	return error instanceof Error ? error : new Error(String(error));
+}

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.ts
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import type { CheckItem, GitHubStatus } from "@superset/local-db";
 import { branchExistsOnRemote } from "../git";
+import { GIT_TIMEOUT_LOCAL } from "../git-timeouts";
 import { execWithShellEnv } from "../shell-env";
 import {
 	type GHPRResponse,
@@ -145,7 +146,7 @@ async function findPRByHeadCommit(
 		const { stdout: headOutput } = await execFileAsync(
 			"git",
 			["-C", worktreePath, "rev-parse", "HEAD"],
-			{ timeout: 10_000 },
+			{ timeout: GIT_TIMEOUT_LOCAL },
 		);
 		const headSha = headOutput.trim();
 
@@ -234,7 +235,7 @@ async function sharesAncestry(
 		const { stdout: localHead } = await execFileAsync(
 			"git",
 			["-C", worktreePath, "rev-parse", "HEAD"],
-			{ timeout: 10_000 },
+			{ timeout: GIT_TIMEOUT_LOCAL },
 		);
 		const localOid = localHead.trim();
 
@@ -258,7 +259,7 @@ async function sharesAncestry(
 						ancestor,
 						descendant,
 					],
-					{ timeout: 10_000 },
+					{ timeout: GIT_TIMEOUT_LOCAL },
 				);
 				return true;
 			} catch {


### PR DESCRIPTION
## Summary
- The desktop app hangs indefinitely ("loading forever") when the network is slow or unavailable because `simple-git` has no timeout support for network operations (fetch, push, pull, ls-remote, remote set-head)
- Replaces all network-dependent `simple-git` calls with `execFileAsync` + explicit timeouts, and adds a default 30s timeout to `execWithShellEnv` (used by all `gh` CLI calls)
- Timeout errors now surface user-friendly messages (e.g. "Push timed out. Check your network connection.") instead of cryptic "process was killed"

## Changes
**New file: `git-timeouts.ts`**
- Shared timeout constants: `GIT_TIMEOUT_LOCAL` (10s), `GIT_TIMEOUT_NETWORK` (30s), `GIT_TIMEOUT_NETWORK_HEAVY` (60s), `GIT_TIMEOUT_LONG` (120s)
- `isTimeoutError()` / `wrapTimeoutError()` helpers for user-friendly error messages

**`shell-env.ts`**
- `execWithShellEnv` now applies `GIT_TIMEOUT_NETWORK` (30s) as default timeout — fixes all `gh` CLI calls in `github.ts` which previously had zero timeout

**`git-operations.ts`**
- Replaced `simpleGit` network calls in `fetchCurrentBranch`, `pushWithSetUpstream`, `push`, `pull`, `sync`, `createPR` with `execFileAsync` + timeout
- `fetchCurrentBranch` and `pushWithSetUpstream` refactored to accept `worktreePath: string` instead of `simpleGit` instance

**`git.ts`**
- Replaced `simpleGit` network calls in `fetchDefaultBranch`, `refreshDefaultBranch`, `getDefaultBranch` (ls-remote fallback), `listBranches`, `checkBranchCheckoutSafety` with `execFileAsync` + timeout

**Magic number cleanup**
- All inline timeout values (`10_000`, `30_000`, `120_000`) across `git.ts`, `github.ts`, `shell-env.ts` replaced with named constants

## Test Plan
- [ ] Push/pull/sync with network available (happy path works as before)
- [ ] Disconnect network → push/pull should error within 60s with "timed out" message
- [ ] Create workspace offline → should fall back to local refs, not hang
- [ ] `gh` CLI calls offline → should error within 30s
- [ ] Typecheck passes (`bun run typecheck`)
- [ ] Lint passes (`bun run lint:fix`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and detection for Git operation timeouts across network operations.
  * Enhanced timeout management for fetch, push, pull, and sync operations with consistent, operation-specific timeouts.

* **Refactor**
  * Centralized Git operation timeout configuration for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->