### PR TITLE
fix(api): normalize localhost/127.0.0.1 in OAuth redirect_uri

### DIFF
--- a/apps/api/src/app/api/auth/[...all]/route.ts
+++ b/apps/api/src/app/api/auth/[...all]/route.ts
@@ -1,80 +1,29 @@
 import { auth } from "@superset/auth/server";
-import { db } from "@superset/db/client";
-import { oauthClients } from "@superset/db/schema/auth";
 import { toNextJsHandler } from "better-auth/next-js";
-import { eq } from "drizzle-orm";
 
 const { GET: _GET, POST: _POST } = toNextJsHandler(auth);
+
+/**
+ * Normalize localhost variants in a URL so that `localhost` and `127.0.0.1`
+ * are treated as equivalent. OAuth 2.1 requires exact string matching on
+ * redirect_uri, but some MCP clients (e.g. OpenCode) register with
+ * `127.0.0.1` and then authorize with `localhost` (or vice-versa).
+ */
+function normalizeLocalhostUri(uri: string): string {
+	return uri.replace(/^(https?:\/\/)localhost(:\d+)/, "$1127.0.0.1$2");
+}
 
 const GET = async (req: Request) => {
 	const url = new URL(req.url);
 	if (url.pathname.endsWith("/oauth2/authorize")) {
-		const clientId = url.searchParams.get("client_id");
 		const redirectUri = url.searchParams.get("redirect_uri");
-		console.log("[oauth/authorize] --- DEBUG START ---");
-		console.log("[oauth/authorize] client_id:", clientId);
-		console.log("[oauth/authorize] redirect_uri:", JSON.stringify(redirectUri));
-		console.log("[oauth/authorize] redirect_uri type:", typeof redirectUri);
-		if (clientId) {
-			try {
-				const client = await db.query.oauthClients.findFirst({
-					where: eq(oauthClients.clientId, clientId),
-					columns: {
-						clientId: true,
-						redirectUris: true,
-						name: true,
-					},
-				});
-				console.log("[oauth/authorize] DB client found:", !!client);
-				console.log(
-					"[oauth/authorize] DB redirectUris raw:",
-					JSON.stringify(client?.redirectUris),
-				);
-				console.log(
-					"[oauth/authorize] DB redirectUris type:",
-					typeof client?.redirectUris,
-				);
-				console.log(
-					"[oauth/authorize] DB redirectUris isArray:",
-					Array.isArray(client?.redirectUris),
-				);
-				if (client?.redirectUris && redirectUri) {
-					console.log(
-						"[oauth/authorize] Exact match (.includes):",
-						client.redirectUris.includes(redirectUri),
-					);
-					console.log(
-						"[oauth/authorize] Exact match (.find):",
-						!!client.redirectUris.find((u: string) => u === redirectUri),
-					);
-					for (const [i, uri] of client.redirectUris.entries()) {
-						console.log(
-							`[oauth/authorize] URI[${i}]:`,
-							JSON.stringify(uri),
-							"type:",
-							typeof uri,
-							"match:",
-							uri === redirectUri,
-						);
-					}
-				}
-				// Also test via Better Auth adapter
-				const baClient = await auth.api.getOAuthClientPublic({
-					query: { client_id: clientId },
-				});
-				console.log(
-					"[oauth/authorize] BA client redirect_uris:",
-					JSON.stringify(
-						baClient && "redirect_uris" in baClient
-							? baClient.redirect_uris
-							: "N/A",
-					),
-				);
-			} catch (error) {
-				console.error("[oauth/authorize] Debug query failed:", error);
+		if (redirectUri) {
+			const normalized = normalizeLocalhostUri(redirectUri);
+			if (normalized !== redirectUri) {
+				url.searchParams.set("redirect_uri", normalized);
+				return _GET(new Request(url.toString(), req));
 			}
 		}
-		console.log("[oauth/authorize] --- DEBUG END ---");
 	}
 	return _GET(req);
 };
@@ -82,17 +31,17 @@ const GET = async (req: Request) => {
 const POST = async (req: Request) => {
 	const url = new URL(req.url);
 	if (url.pathname.endsWith("/oauth2/register")) {
-		const body = await req
-			.clone()
-			.json()
-			.catch(() => null);
-		console.log("[oauth/register] --- DEBUG START ---");
-		console.log(
-			"[oauth/register] redirect_uris:",
-			JSON.stringify(body?.redirect_uris),
-		);
-		console.log("[oauth/register] client_name:", body?.client_name);
-		console.log("[oauth/register] --- DEBUG END ---");
+		const body = await req.json().catch(() => null);
+		if (body?.redirect_uris && Array.isArray(body.redirect_uris)) {
+			body.redirect_uris = body.redirect_uris.map(normalizeLocalhostUri);
+			return _POST(
+				new Request(req.url, {
+					method: req.method,
+					headers: req.headers,
+					body: JSON.stringify(body),
+				}),
+			);
+		}
 	}
 	return _POST(req);
 };


### PR DESCRIPTION
## Summary
- Fixes `invalid_redirect` error when MCP clients (e.g. OpenCode) register with `127.0.0.1` but send `localhost` in the authorize request
- Normalizes `localhost` → `127.0.0.1` in both the authorize `redirect_uri` param and registration `redirect_uris` body before passing to Better Auth
- This is an OpenCode bug (inconsistent URLs), but we work around it defensively since OAuth 2.1 requires exact string matching

## Root cause
OpenCode registers: `http://127.0.0.1:19876/mcp/oauth/callback`
OpenCode authorizes: `http://localhost:19876/mcp/oauth/callback`

Better Auth does `client.redirectUris.find(url => url === query.redirect_uri)` — exact match fails.

## Test plan
- [x] Reproduced on production via debug logging
- [ ] Deploy, then `opencode mcp logout superset && opencode` to verify OAuth flow completes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth redirect URI normalization to consistently handle localhost and 127.0.0.1 variants in authentication flows.

* **Performance**
  * Streamlined authentication endpoints by removing debug logging and optimizing database operations for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->