### PR TITLE
fix(ci): add missing STREAMS_URL to desktop build workflow

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -93,6 +93,7 @@ jobs:
           NEXT_PUBLIC_DOCS_URL: ${{ secrets.NEXT_PUBLIC_DOCS_URL }}
           SENTRY_DSN_DESKTOP: ${{ secrets.SENTRY_DSN_DESKTOP }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          STREAMS_URL: ${{ secrets.STREAMS_URL }}
         run: bun run compile:app
 
       - name: Build Electron app


### PR DESCRIPTION
## Summary
- Adds `STREAMS_URL` secret to the `Compile app with electron-vite` step in `build-desktop.yml`
- This env var was added as required in `env.main.ts` (PR #1343) but was never passed through in the desktop build workflow, causing canary and stable builds to fail with `Invalid environment variables`

## Test plan
- [ ] Verify canary desktop build passes after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow configuration to support necessary environment variables.

---

**Note:** This release contains internal build infrastructure updates with no direct end-user impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->