### PR TITLE
fix(desktop): inline STREAMS_URL at build time to fix packaged app crash

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -70,6 +70,10 @@ export default defineConfig({
 			"process.env.NEXT_PUBLIC_POSTHOG_HOST": defineEnv(
 				process.env.NEXT_PUBLIC_POSTHOG_HOST,
 			),
+			"process.env.STREAMS_URL": defineEnv(
+				process.env.STREAMS_URL,
+				"https://superset-stream.fly.dev",
+			),
 		},
 
 		build: {

--- a/apps/desktop/src/main/env.main.ts
+++ b/apps/desktop/src/main/env.main.ts
@@ -19,7 +19,7 @@ export const env = createEnv({
 		NEXT_PUBLIC_POSTHOG_KEY: z.string().optional(),
 		NEXT_PUBLIC_POSTHOG_HOST: z.string().default("https://us.i.posthog.com"),
 		SENTRY_DSN_DESKTOP: z.string().optional(),
-		STREAMS_URL: z.url(),
+		STREAMS_URL: z.url().default("https://superset-stream.fly.dev"),
 	},
 
 	runtimeEnv: {


### PR DESCRIPTION
## Summary
- `STREAMS_URL` was missing from the Vite `define` block in `electron.vite.config.ts`, so the bundled `.asar` still contained a raw `process.env.STREAMS_URL` reference that resolves to `undefined` at runtime on users' machines
- The build succeeded because dotenv loads the var at build time and the Zod validation import passes — but Vite only inlines values explicitly listed in `define`
- Follows up on #1364 which added the env var to CI but didn't address the bundling gap

## Changes
- **`electron.vite.config.ts`** — Add `process.env.STREAMS_URL` to the `main.define` block with production fallback
- **`env.main.ts`** — Add `.default()` to the Zod schema as a safety net

## Test Plan
- [ ] Build desktop app (`bun run build --filter=@superset/desktop`)
- [ ] Launch packaged Canary — should no longer crash with "Invalid environment variables"
- [ ] Verify streams/AI chat functionality works with the inlined URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified configuration by providing a default streaming service endpoint, eliminating the need for manual setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->