### PR TITLE
feat(desktop): allow force delete when teardown fails

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/TeardownLogsDialog/TeardownLogsDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/TeardownLogsDialog/TeardownLogsDialog.tsx
@@ -2,12 +2,15 @@ import {
 	CodeBlock,
 	CodeBlockCopyButton,
 } from "@superset/ui/ai-elements/code-block";
+import { Button } from "@superset/ui/button";
 import {
 	Dialog,
 	DialogContent,
+	DialogFooter,
 	DialogHeader,
 	DialogTitle,
 } from "@superset/ui/dialog";
+import { toast } from "@superset/ui/sonner";
 import { useState } from "react";
 
 // biome-ignore lint/suspicious/noControlCharactersInRegex: matching ANSI escape sequences
@@ -17,24 +20,79 @@ function stripAnsi(text: string): string {
 	return text.replace(ANSI_REGEX, "");
 }
 
-let showLogsFn: ((logs: string) => void) | null = null;
+let showLogsFn:
+	| ((logs: string, options?: { onDeleteAnyway?: () => void }) => void)
+	| null = null;
 
-export const showTeardownLogs = (logs: string) => {
+export const showTeardownLogs = (
+	logs: string,
+	options?: { onDeleteAnyway?: () => void },
+) => {
 	if (!showLogsFn) {
 		console.error(
 			"[teardown-logs] TeardownLogsDialog not mounted. Make sure to render <TeardownLogsDialog /> in your app",
 		);
 		return;
 	}
-	showLogsFn(logs);
+	showLogsFn(logs, options);
 };
+
+export function showTeardownFailedToast({
+	toastId,
+	output,
+	onForceDelete,
+}: {
+	toastId: string | number;
+	output: string;
+	onForceDelete: () => void;
+}) {
+	toast.error("Teardown failed", {
+		id: toastId,
+		action: {
+			label: "Delete Anyway",
+			onClick: onForceDelete,
+		},
+		cancel: {
+			label: "View Logs",
+			onClick: () =>
+				showTeardownLogs(output, { onDeleteAnyway: onForceDelete }),
+		},
+	});
+}
+
+export async function forceDeleteWithToast({
+	name,
+	deleteFn,
+}: {
+	name: string;
+	deleteFn: () => Promise<{ success: boolean; error?: string }>;
+}) {
+	const toastId = toast.loading(`Deleting "${name}" (skipping teardown)...`);
+
+	try {
+		const result = await deleteFn();
+		if (result.success) {
+			toast.success(`Deleted "${name}"`, { id: toastId });
+		} else {
+			toast.error(result.error ?? "Failed to delete", { id: toastId });
+		}
+	} catch (error) {
+		toast.error(error instanceof Error ? error.message : "Failed to delete", {
+			id: toastId,
+		});
+	}
+}
 
 export function TeardownLogsDialog() {
 	const [logs, setLogs] = useState<string | null>(null);
 	const [isOpen, setIsOpen] = useState(false);
+	const [onDeleteAnyway, setOnDeleteAnyway] = useState<(() => void) | null>(
+		null,
+	);
 
-	showLogsFn = (newLogs) => {
+	showLogsFn = (newLogs, options) => {
 		setLogs(newLogs);
+		setOnDeleteAnyway(() => options?.onDeleteAnyway ?? null);
 		setIsOpen(true);
 	};
 
@@ -42,6 +100,12 @@ export function TeardownLogsDialog() {
 
 	const handleClose = () => {
 		setIsOpen(false);
+		setOnDeleteAnyway(null);
+	};
+
+	const handleDeleteAnyway = () => {
+		handleClose();
+		onDeleteAnyway?.();
 	};
 
 	return (
@@ -63,6 +127,18 @@ export function TeardownLogsDialog() {
 						<CodeBlockCopyButton />
 					</CodeBlock>
 				</div>
+				{onDeleteAnyway && (
+					<DialogFooter className="px-4 pb-4 pt-0">
+						<Button
+							variant="destructive"
+							size="sm"
+							className="h-7 px-3 text-xs"
+							onClick={handleDeleteAnyway}
+						>
+							Delete Anyway
+						</Button>
+					</DialogFooter>
+				)}
 			</DialogContent>
 		</Dialog>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/components/TeardownLogsDialog/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/TeardownLogsDialog/index.ts
@@ -1,1 +1,6 @@
-export { showTeardownLogs, TeardownLogsDialog } from "./TeardownLogsDialog";
+export {
+	forceDeleteWithToast,
+	showTeardownFailedToast,
+	showTeardownLogs,
+	TeardownLogsDialog,
+} from "./TeardownLogsDialog";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/DeleteWorkspaceDialog/DeleteWorkspaceDialog.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/DeleteWorkspaceDialog/DeleteWorkspaceDialog.tsx
@@ -17,7 +17,10 @@ import {
 	useCloseWorkspace,
 	useDeleteWorkspace,
 } from "renderer/react-query/workspaces";
-import { showTeardownLogs } from "renderer/routes/_authenticated/components/TeardownLogsDialog";
+import {
+	forceDeleteWithToast,
+	showTeardownFailedToast,
+} from "renderer/routes/_authenticated/components/TeardownLogsDialog";
 
 interface DeleteWorkspaceDialogProps {
 	workspaceId: string;
@@ -98,6 +101,17 @@ export function DeleteWorkspaceDialog({
 		});
 	};
 
+	const handleForceDelete = () =>
+		forceDeleteWithToast({
+			name: workspaceName,
+			deleteFn: () =>
+				deleteWorkspace.mutateAsync({
+					id: workspaceId,
+					deleteLocalBranch: deleteLocalBranchChecked,
+					force: true,
+				}),
+		});
+
 	const handleDelete = async () => {
 		onOpenChange(false);
 
@@ -116,12 +130,10 @@ export function DeleteWorkspaceDialog({
 			if (!result.success) {
 				const { output } = result;
 				if (output) {
-					toast.error("Teardown failed", {
-						id: toastId,
-						action: {
-							label: "View Logs",
-							onClick: () => showTeardownLogs(output),
-						},
+					showTeardownFailedToast({
+						toastId,
+						output,
+						onForceDelete: handleForceDelete,
 					});
 				} else {
 					toast.error(result.error ?? "Failed to delete", { id: toastId });

--- a/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/DeleteWorktreeDialog.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/DeleteWorktreeDialog.tsx
@@ -11,7 +11,10 @@ import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useDeleteWorktree } from "renderer/react-query/workspaces/useDeleteWorktree";
-import { showTeardownLogs } from "renderer/routes/_authenticated/components/TeardownLogsDialog";
+import {
+	forceDeleteWithToast,
+	showTeardownFailedToast,
+} from "renderer/routes/_authenticated/components/TeardownLogsDialog";
 
 interface DeleteWorktreeDialogProps {
 	worktreeId: string;
@@ -37,6 +40,12 @@ export function DeleteWorktreeDialog({
 			},
 		);
 
+	const handleForceDelete = () =>
+		forceDeleteWithToast({
+			name: worktreeName,
+			deleteFn: () => deleteWorktree.mutateAsync({ worktreeId, force: true }),
+		});
+
 	const handleDelete = async () => {
 		onOpenChange(false);
 
@@ -48,12 +57,10 @@ export function DeleteWorktreeDialog({
 			if (!result.success) {
 				const { output } = result;
 				if (output) {
-					toast.error("Teardown failed", {
-						id: toastId,
-						action: {
-							label: "View Logs",
-							onClick: () => showTeardownLogs(output),
-						},
+					showTeardownFailedToast({
+						toastId,
+						output,
+						onForceDelete: handleForceDelete,
 					});
 				} else {
 					toast.error(result.error ?? "Failed to delete", { id: toastId });


### PR DESCRIPTION
## Summary
- When teardown scripts fail during workspace/worktree deletion, users were previously blocked with no way to proceed
- Now users can choose "Delete Anyway" to force-delete, skipping the failed teardown and continuing with cleanup

## Changes
- **Backend** (`delete.ts`): Added `force` parameter to both `delete` and `deleteWorktree` procedures — when `true`, logs the teardown failure as a warning and continues deletion
- **TeardownLogsDialog**: Extended `showTeardownLogs` to accept an `onDeleteAnyway` callback; renders a "Delete Anyway" button in the dialog footer
- **DeleteWorkspaceDialog**: Error toast now shows "Delete Anyway" (primary action) and "View Logs" (secondary) buttons
- **DeleteWorktreeDialog**: Same force-delete flow for worktree deletion

## Test Plan
- [ ] Trigger a teardown failure during workspace deletion — verify toast shows both "Delete Anyway" and "View Logs" buttons
- [ ] Click "Delete Anyway" on toast — verify workspace is force-deleted successfully
- [ ] Click "View Logs" on toast — verify logs dialog opens with "Delete Anyway" button in footer
- [ ] Click "Delete Anyway" in logs dialog — verify workspace is force-deleted and dialog closes
- [ ] Repeat above for worktree deletion flow
- [ ] Verify normal (non-failing teardown) deletion still works as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Delete Anyway" / force-delete option when workspace or worktree teardown fails.
  * Improved teardown failure UI: view logs, a dedicated failure toast, and an inline force-delete flow with progress/result feedback.

* **Bug Fixes**
  * Teardown errors can now be bypassed when forcing deletion; non-forced behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->