### PR TITLE
ci(desktop): use macos-latest-xlarge runner for faster builds

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -102,11 +102,7 @@ jobs:
           bun run copy:native-modules
           bun run download:claude
 
-      - name: Build app bundle
-        working-directory: apps/desktop
-        run: npx electron-builder --dir --arm64 --config ${{ inputs.electron_builder_config }} -c.mac.identity=null
-
-      - name: Code sign, notarize & package
+      - name: Build & sign app bundle
         working-directory: apps/desktop
         env:
           CSC_LINK: ${{ secrets.MAC_CERTIFICATE }}
@@ -114,6 +110,10 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: npx electron-builder --dir --arm64 --config ${{ inputs.electron_builder_config }}
+
+      - name: Package (DMG & ZIP)
+        working-directory: apps/desktop
         run: npx electron-builder --prepackaged "release/mac-arm64/$(ls release/mac-arm64/)" --config ${{ inputs.electron_builder_config }} --publish never
 
       - name: Upload DMG artifact


### PR DESCRIPTION
## Summary
- Bumps the desktop build runner from `macos-latest` (3 cores, 7GB RAM) to `macos-latest-xlarge` (12 cores, 30GB RAM) for faster Electron builds

## Test plan
- [ ] Trigger a canary desktop build and verify it completes successfully on the larger runner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched macOS CI to a larger runner to improve build performance and reliability.
  * Reworked the desktop build workflow into distinct steps for preparing native resources, building app bundles, and packaging/notarization.
  * Kept artifact uploads for installer (DMG), archive (ZIP), and update manifest, preserving caching and retention behavior while adjusting step ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->