### PR TITLE
fix(desktop): prevent setFocusedPane from clearing loading state

### DIFF
--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -1,6 +1,7 @@
 import type { MosaicNode } from "react-mosaic-component";
 import { updateTree } from "react-mosaic-component";
 import { trpcTabsStorage } from "renderer/lib/trpc-storage";
+import { acknowledgedStatus } from "shared/tabs-types";
 import { create } from "zustand";
 import { devtools, persist } from "zustand/middleware";
 import { movePaneToNewTab, movePaneToTab } from "./actions/move-pane";
@@ -325,17 +326,11 @@ export const useTabsStore = create<TabsStore>()(
 					const newPanes = { ...state.panes };
 					let hasChanges = false;
 					for (const paneId of tabPaneIds) {
-						const currentStatus = newPanes[paneId]?.status;
-						if (currentStatus === "review") {
-							// User acknowledged completion
-							newPanes[paneId] = { ...newPanes[paneId], status: "idle" };
-							hasChanges = true;
-						} else if (currentStatus === "permission") {
-							// Assume permission granted, agent is now working
-							newPanes[paneId] = { ...newPanes[paneId], status: "working" };
+						const resolved = acknowledgedStatus(newPanes[paneId]?.status);
+						if (resolved !== (newPanes[paneId]?.status ?? "idle")) {
+							newPanes[paneId] = { ...newPanes[paneId], status: resolved };
 							hasChanges = true;
 						}
-						// "working" status is NOT cleared by click - persists until Stop
 					}
 
 					set({
@@ -811,7 +806,7 @@ export const useTabsStore = create<TabsStore>()(
 					set({
 						panes: {
 							...state.panes,
-							[paneId]: { ...pane, status: "idle" },
+							[paneId]: { ...pane, status: acknowledgedStatus(pane.status) },
 						},
 						focusedPaneIds: {
 							...state.focusedPaneIds,
@@ -881,17 +876,11 @@ export const useTabsStore = create<TabsStore>()(
 					const newPanes = { ...state.panes };
 					let hasChanges = false;
 					for (const paneId of workspacePaneIds) {
-						const currentStatus = newPanes[paneId]?.status;
-						if (currentStatus === "review") {
-							// User acknowledged completion
-							newPanes[paneId] = { ...newPanes[paneId], status: "idle" };
-							hasChanges = true;
-						} else if (currentStatus === "permission") {
-							// Assume permission granted, Claude is now working
-							newPanes[paneId] = { ...newPanes[paneId], status: "working" };
+						const resolved = acknowledgedStatus(newPanes[paneId]?.status);
+						if (resolved !== (newPanes[paneId]?.status ?? "idle")) {
+							newPanes[paneId] = { ...newPanes[paneId], status: resolved };
 							hasChanges = true;
 						}
-						// "working" status is NOT cleared by click - persists until Stop
 					}
 
 					if (hasChanges) {

--- a/apps/desktop/src/shared/tabs-types.ts
+++ b/apps/desktop/src/shared/tabs-types.ts
@@ -69,6 +69,21 @@ export function getHighestPriorityStatus(
 }
 
 /**
+ * Resolve what a pane's status should become when the user acknowledges it
+ * (e.g. clicking a tab, focusing a pane, selecting a workspace).
+ *
+ * - "review"     → "idle"    (user saw the completion)
+ * - "permission" → "working" (user saw the prompt; assume granted)
+ * - "working"    → unchanged (persists until agent stops)
+ * - "idle"       → unchanged
+ */
+export function acknowledgedStatus(status: PaneStatus | undefined): PaneStatus {
+	if (status === "review") return "idle";
+	if (status === "permission") return "working";
+	return status ?? "idle";
+}
+
+/**
  * File viewer display modes
  */
 export type FileViewerMode = "rendered" | "raw" | "diff";


### PR DESCRIPTION
## Summary
- `setFocusedPane` was unconditionally setting pane status to `"idle"`, which falsely cleared `"working"` state when clicking on an active pane
- Extracted `acknowledgedStatus()` helper to centralize status-acknowledgment logic and prevent future inconsistencies

## Changes
- **`apps/desktop/src/shared/tabs-types.ts`**: Added `acknowledgedStatus()` — resolves what a pane status should become when the user acknowledges it (`review→idle`, `permission→working`, `working`/`idle` unchanged)
- **`apps/desktop/src/renderer/stores/tabs/store.ts`**: Replaced inline status transition logic in `setActiveTab`, `setFocusedPane`, and `clearWorkspaceAttentionStatus` with the new helper

## Test Plan
- [ ] Start an agent task, click on the pane while it's working — status should remain `"working"`
- [ ] Let an agent finish on a background tab, switch to it — `"review"` status clears to `"idle"`
- [ ] Trigger a permission prompt on a background tab, switch to it — `"permission"` transitions to `"working"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency of tab and pane status transitions for more reliable state management during workspace interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->