### PR TITLE
fix(desktop): support SSH URLs in clone repo dialog

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/projects/projects.ts
+++ b/apps/desktop/src/lib/trpc/routers/projects/projects.ts
@@ -180,6 +180,8 @@ async function ensureMainWorkspace(project: Project): Promise<void> {
 // Safe filename regex: letters, numbers, dots, underscores, hyphens, spaces, and common unicode
 // Allows most valid Git repo names while avoiding path traversal characters
 const SAFE_REPO_NAME_REGEX = /^[a-zA-Z0-9._\- ]+$/;
+const ALLOWED_URL_PROTOCOLS = new Set(["http:", "https:", "ssh:", "git:"]);
+const SSH_GIT_URL_REGEX = /^[\w.-]+@[\w.-]+:[\w./-]+$/;
 
 /**
  * Extracts and validates a repository name from a git URL.
@@ -608,7 +610,17 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 		cloneRepo: publicProcedure
 			.input(
 				z.object({
-					url: z.string().url(),
+					url: z.string().min(1).refine(
+						(val) => {
+							try {
+								const parsed = new URL(val);
+								return ALLOWED_URL_PROTOCOLS.has(parsed.protocol);
+							} catch {
+								return SSH_GIT_URL_REGEX.test(val);
+							}
+						},
+						{ message: "Must be a valid Git URL (HTTPS or SSH)" },
+					),
 					// Trim and convert empty/whitespace strings to undefined
 					targetDirectory: z
 						.string()

--- a/apps/desktop/src/renderer/screens/main/components/StartView/CloneRepoDialog.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/StartView/CloneRepoDialog.tsx
@@ -75,7 +75,7 @@ export function CloneRepoDialog({
 							type="text"
 							value={url}
 							onChange={(e) => setUrl(e.target.value)}
-							placeholder="https://github.com/user/repo.git"
+							placeholder="https:// or git@github.com:user/repo.git"
 							className="w-full px-3 py-2.5 bg-background border border-border rounded-md text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:border-ring transition-colors"
 							disabled={isLoading}
 							onKeyDown={(e) => {


### PR DESCRIPTION
## Summary
- `z.string().url()` in the `cloneRepo` input schema rejects SSH-style git URLs (`git@github.com:user/repo.git`) since they aren't valid URLs per the URL spec
- Replaced with a custom Zod `.refine()` validator that accepts both standard URLs (via `new URL()`) and SSH-style URLs (via regex)
- Updated placeholder text to indicate both formats are supported

## Test plan
- [ ] Clone a repo using an HTTPS URL (e.g. `https://github.com/user/repo.git`)
- [ ] Clone a repo using an SSH URL (e.g. `git@github.com:user/repo.git`)
- [ ] Verify invalid inputs still show validation errors
- [ ] Verify SSH clone without keys configured shows a proper git error (not a validation error)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Repository cloning now accepts SSH-style Git URLs (git@...) as well as HTTPS and rejects invalid inputs with a clear error message.
  * Improved handling when a repository already exists locally to avoid confusing failures.

* **Improvements**
  * Updated input placeholder to clarify both HTTPS and SSH URL formats are supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->