### PR TITLE
feat(desktop): add project icon support with custom protocol

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/projects/projects.ts
+++ b/apps/desktop/src/lib/trpc/routers/projects/projects.ts
@@ -14,6 +14,10 @@ import type { BrowserWindow } from "electron";
 import { dialog } from "electron";
 import { track } from "main/lib/analytics";
 import { localDb } from "main/lib/local-db";
+import {
+	deleteProjectIcon,
+	saveProjectIconFromDataUrl,
+} from "main/lib/project-icons";
 import { getWorkspaceRuntimeRegistry } from "main/lib/workspace-runtime";
 import { PROJECT_COLOR_VALUES } from "shared/constants/project-colors";
 import simpleGit from "simple-git";
@@ -34,6 +38,7 @@ import {
 	sanitizeAuthorPrefix,
 } from "../workspaces/utils/git";
 import { getDefaultProjectColor } from "./utils/colors";
+import { discoverAndSaveProjectIcon } from "./utils/favicon-discovery";
 import { fetchGitHubOwner, getGitHubAvatarUrl } from "./utils/github";
 
 type Project = SelectProject;
@@ -1053,6 +1058,90 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 					name: authorName,
 					prefix: sanitizeAuthorPrefix(authorName),
 				};
+			}),
+
+		triggerFaviconDiscovery: publicProcedure
+			.input(z.object({ id: z.string() }))
+			.mutation(async ({ input }) => {
+				const project = localDb
+					.select()
+					.from(projects)
+					.where(eq(projects.id, input.id))
+					.get();
+
+				if (!project) {
+					throw new TRPCError({
+						code: "NOT_FOUND",
+						message: `Project ${input.id} not found`,
+					});
+				}
+
+				// Skip if the project already has an icon
+				if (project.iconUrl) {
+					return { iconUrl: project.iconUrl };
+				}
+
+				const iconUrl = await discoverAndSaveProjectIcon({
+					projectId: project.id,
+					repoPath: project.mainRepoPath,
+				});
+
+				if (iconUrl) {
+					localDb
+						.update(projects)
+						.set({ iconUrl })
+						.where(eq(projects.id, input.id))
+						.run();
+				}
+
+				return { iconUrl };
+			}),
+
+		setProjectIcon: publicProcedure
+			.input(
+				z.object({
+					id: z.string(),
+					icon: z.string().nullable(),
+				}),
+			)
+			.mutation(async ({ input }) => {
+				const project = localDb
+					.select()
+					.from(projects)
+					.where(eq(projects.id, input.id))
+					.get();
+
+				if (!project) {
+					throw new TRPCError({
+						code: "NOT_FOUND",
+						message: `Project ${input.id} not found`,
+					});
+				}
+
+				if (input.icon === null) {
+					// Remove icon
+					deleteProjectIcon(input.id);
+					localDb
+						.update(projects)
+						.set({ iconUrl: null })
+						.where(eq(projects.id, input.id))
+						.run();
+					return { iconUrl: null };
+				}
+
+				// Save icon from data URL
+				const iconUrl = await saveProjectIconFromDataUrl({
+					projectId: input.id,
+					dataUrl: input.icon,
+				});
+
+				localDb
+					.update(projects)
+					.set({ iconUrl })
+					.where(eq(projects.id, input.id))
+					.run();
+
+				return { iconUrl };
 			}),
 	});
 };

--- a/apps/desktop/src/lib/trpc/routers/projects/utils/favicon-discovery.ts
+++ b/apps/desktop/src/lib/trpc/routers/projects/utils/favicon-discovery.ts
@@ -1,0 +1,86 @@
+import { readFile, stat } from "node:fs/promises";
+import { extname } from "node:path";
+import fg from "fast-glob";
+import {
+	saveProjectIconFromBuffer,
+	saveProjectIconFromFile,
+} from "main/lib/project-icons";
+
+/** Common favicon file names to search for in project roots */
+const FAVICON_PATTERNS = [
+	"favicon.ico",
+	"favicon.png",
+	"favicon.svg",
+	"logo.png",
+	"logo.svg",
+	"icon.png",
+	"icon.svg",
+	".github/logo.png",
+	".github/logo.svg",
+	"public/favicon.ico",
+	"public/favicon.png",
+	"public/favicon.svg",
+	"public/logo.png",
+	"public/logo.svg",
+	"static/favicon.ico",
+	"static/favicon.png",
+	"static/favicon.svg",
+	"assets/favicon.ico",
+	"assets/favicon.png",
+	"assets/icon.png",
+];
+
+/** Max file size for discovered favicons: 256KB */
+const MAX_FAVICON_SIZE = 256 * 1024;
+
+/**
+ * Discovers a favicon/icon in the project directory and saves it to disk.
+ * Returns the protocol URL if found, or null if no icon was discovered.
+ */
+export async function discoverAndSaveProjectIcon({
+	projectId,
+	repoPath,
+}: {
+	projectId: string;
+	repoPath: string;
+}): Promise<string | null> {
+	try {
+		const matches = await fg(FAVICON_PATTERNS, {
+			cwd: repoPath,
+			absolute: true,
+			ignore: ["**/node_modules/**", "**/.git/**", "**/dist/**", "**/build/**"],
+			onlyFiles: true,
+		});
+
+		if (matches.length === 0) return null;
+
+		// Use the first match (ordered by FAVICON_PATTERNS priority)
+		const iconPath = matches[0];
+
+		// Check file size
+		const fileStat = await stat(iconPath);
+		if (fileStat.size > MAX_FAVICON_SIZE) {
+			console.log(
+				`[favicon-discovery] Icon too large (${Math.round(fileStat.size / 1024)}KB): ${iconPath}`,
+			);
+			return null;
+		}
+
+		const ext = extname(iconPath).replace(".", "") || "png";
+
+		// For .ico files, read as buffer since they may need special handling
+		if (ext === "ico") {
+			const buffer = await readFile(iconPath);
+			return await saveProjectIconFromBuffer({
+				projectId,
+				buffer: Buffer.from(buffer),
+				ext: "ico",
+			});
+		}
+
+		return await saveProjectIconFromFile({ projectId, sourcePath: iconPath });
+	} catch (error) {
+		console.error("[favicon-discovery] Error discovering icon:", error);
+		return null;
+	}
+}

--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/query.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/query.ts
@@ -160,6 +160,7 @@ export const createQueryProcedures = () => {
 						githubOwner: string | null;
 						mainRepoPath: string;
 						hideImage: boolean;
+						iconUrl: string | null;
 					};
 					workspaces: Array<{
 						id: string;
@@ -190,6 +191,7 @@ export const createQueryProcedures = () => {
 						githubOwner: project.githubOwner ?? null,
 						mainRepoPath: project.mainRepoPath,
 						hideImage: project.hideImage ?? false,
+						iconUrl: project.iconUrl ?? null,
 					},
 					workspaces: [],
 				});

--- a/apps/desktop/src/main/lib/project-icons.ts
+++ b/apps/desktop/src/main/lib/project-icons.ts
@@ -1,0 +1,145 @@
+import { existsSync, mkdirSync, readdirSync, unlinkSync } from "node:fs";
+import { copyFile, writeFile } from "node:fs/promises";
+import { extname, join } from "node:path";
+import { SUPERSET_HOME_DIR } from "./app-environment";
+
+export const PROJECT_ICONS_DIR = join(SUPERSET_HOME_DIR, "project-icons");
+
+/** Max icon file size: 512KB */
+const MAX_ICON_SIZE = 512 * 1024;
+
+/**
+ * Ensures the project icons directory exists.
+ * Call at startup.
+ */
+export function ensureProjectIconsDir(): void {
+	if (!existsSync(PROJECT_ICONS_DIR)) {
+		mkdirSync(PROJECT_ICONS_DIR, { recursive: true });
+	}
+}
+
+/**
+ * Finds the icon file for a project by globbing for any extension.
+ * Returns the full path or null if no icon exists.
+ */
+export function getProjectIconPath(projectId: string): string | null {
+	if (!existsSync(PROJECT_ICONS_DIR)) return null;
+
+	const files = readdirSync(PROJECT_ICONS_DIR);
+	const match = files.find((f) => {
+		const name = f.substring(0, f.lastIndexOf("."));
+		return name === projectId;
+	});
+
+	return match ? join(PROJECT_ICONS_DIR, match) : null;
+}
+
+/**
+ * Removes any existing icon file for a project (any extension).
+ */
+function removeExistingIcon(projectId: string): void {
+	const existing = getProjectIconPath(projectId);
+	if (existing) {
+		unlinkSync(existing);
+	}
+}
+
+/**
+ * Returns the protocol URL for a project icon.
+ */
+export function getProjectIconProtocolUrl(projectId: string): string {
+	return `superset-icon://projects/${projectId}`;
+}
+
+/**
+ * Saves an icon file for a project from a local file path.
+ * Copies the file to PROJECT_ICONS_DIR/{projectId}.{ext}.
+ * Returns the protocol URL.
+ */
+export async function saveProjectIconFromFile({
+	projectId,
+	sourcePath,
+}: {
+	projectId: string;
+	sourcePath: string;
+}): Promise<string> {
+	ensureProjectIconsDir();
+	removeExistingIcon(projectId);
+
+	const ext = extname(sourcePath) || ".png";
+	const destPath = join(PROJECT_ICONS_DIR, `${projectId}${ext}`);
+	await copyFile(sourcePath, destPath);
+
+	return getProjectIconProtocolUrl(projectId);
+}
+
+/**
+ * Saves an icon file for a project from a base64 data URL.
+ * Decodes and writes the file to PROJECT_ICONS_DIR/{projectId}.{ext}.
+ * Returns the protocol URL.
+ */
+export async function saveProjectIconFromDataUrl({
+	projectId,
+	dataUrl,
+}: {
+	projectId: string;
+	dataUrl: string;
+}): Promise<string> {
+	ensureProjectIconsDir();
+	removeExistingIcon(projectId);
+
+	// Parse data URL: data:image/png;base64,<data>
+	const match = dataUrl.match(/^data:image\/(\w+);base64,(.+)$/);
+	if (!match) {
+		throw new Error("Invalid data URL format");
+	}
+
+	const ext = match[1] === "jpeg" ? "jpg" : match[1];
+	const buffer = Buffer.from(match[2], "base64");
+
+	if (buffer.length > MAX_ICON_SIZE) {
+		throw new Error(
+			`Icon file too large (${Math.round(buffer.length / 1024)}KB). Maximum is ${MAX_ICON_SIZE / 1024}KB.`,
+		);
+	}
+
+	const destPath = join(PROJECT_ICONS_DIR, `${projectId}.${ext}`);
+	await writeFile(destPath, buffer);
+
+	return getProjectIconProtocolUrl(projectId);
+}
+
+/**
+ * Saves an icon from a Buffer with explicit extension.
+ * Returns the protocol URL.
+ */
+export async function saveProjectIconFromBuffer({
+	projectId,
+	buffer,
+	ext,
+}: {
+	projectId: string;
+	buffer: Buffer;
+	ext: string;
+}): Promise<string> {
+	ensureProjectIconsDir();
+	removeExistingIcon(projectId);
+
+	if (buffer.length > MAX_ICON_SIZE) {
+		throw new Error(
+			`Icon file too large (${Math.round(buffer.length / 1024)}KB). Maximum is ${MAX_ICON_SIZE / 1024}KB.`,
+		);
+	}
+
+	const destPath = join(PROJECT_ICONS_DIR, `${projectId}.${ext}`);
+	await writeFile(destPath, buffer);
+
+	return getProjectIconProtocolUrl(projectId);
+}
+
+/**
+ * Removes the icon file for a project from disk.
+ */
+export function deleteProjectIcon(projectId: string): void {
+	removeExistingIcon(projectId);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/ProjectSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/ProjectSettings.tsx
@@ -11,8 +11,9 @@ import {
 import { Switch } from "@superset/ui/switch";
 import { cn } from "@superset/ui/utils";
 import type { ReactNode } from "react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { HiOutlineCog6Tooth, HiOutlinePaintBrush } from "react-icons/hi2";
+import { LuImagePlus, LuTrash2 } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
 	PROJECT_COLOR_DEFAULT,
@@ -83,6 +84,44 @@ export function ProjectSettings({ projectId }: ProjectSettingsProps) {
 			utils.workspaces.getAllGrouped.invalidate();
 		},
 	});
+
+	const setProjectIcon = electronTrpc.projects.setProjectIcon.useMutation({
+		onError: (err) => {
+			console.error("[project-settings/setProjectIcon] Failed:", err);
+		},
+		onSettled: () => {
+			utils.projects.get.invalidate({ id: projectId });
+			utils.workspaces.getAllGrouped.invalidate();
+		},
+	});
+
+	const fileInputRef = useRef<HTMLInputElement>(null);
+
+	const handleIconUpload = useCallback(() => {
+		fileInputRef.current?.click();
+	}, []);
+
+	const handleFileChange = useCallback(
+		(e: React.ChangeEvent<HTMLInputElement>) => {
+			const file = e.target.files?.[0];
+			if (!file) return;
+
+			const reader = new FileReader();
+			reader.onload = () => {
+				const dataUrl = reader.result as string;
+				setProjectIcon.mutate({ id: projectId, icon: dataUrl });
+			};
+			reader.readAsDataURL(file);
+
+			// Reset input so the same file can be re-selected
+			e.target.value = "";
+		},
+		[projectId, setProjectIcon],
+	);
+
+	const handleRemoveIcon = useCallback(() => {
+		setProjectIcon.mutate({ id: projectId, icon: null });
+	}, [projectId, setProjectIcon]);
 
 	const handleBranchPrefixModeChange = (value: string) => {
 		if (value === "default") {
@@ -257,6 +296,58 @@ export function ProjectSettings({ projectId }: ProjectSettingsProps) {
 									})
 								}
 							/>
+						</div>
+					</div>
+
+					{/* Project Icon */}
+					<div className="flex items-center justify-between">
+						<div className="space-y-0.5">
+							<Label className="text-sm font-medium">Project Icon</Label>
+							<p className="text-xs text-muted-foreground">
+								Upload a custom icon for the sidebar.
+							</p>
+						</div>
+						<div className="flex items-center gap-2">
+							{project.iconUrl && (
+								<img
+									src={project.iconUrl}
+									alt="Project icon"
+									className="size-8 rounded object-cover border"
+								/>
+							)}
+							<input
+								ref={fileInputRef}
+								type="file"
+								accept="image/png,image/jpeg,image/svg+xml,image/x-icon"
+								className="hidden"
+								onChange={handleFileChange}
+							/>
+							<button
+								type="button"
+								onClick={handleIconUpload}
+								disabled={setProjectIcon.isPending}
+								className={cn(
+									"flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border",
+									"hover:bg-muted transition-colors",
+								)}
+							>
+								<LuImagePlus className="size-4" />
+								{project.iconUrl ? "Replace" : "Upload"}
+							</button>
+							{project.iconUrl && (
+								<button
+									type="button"
+									onClick={handleRemoveIcon}
+									disabled={setProjectIcon.isPending}
+									className={cn(
+										"flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border",
+										"hover:bg-destructive/10 text-destructive transition-colors",
+									)}
+								>
+									<LuTrash2 className="size-4" />
+									Remove
+								</button>
+							)}
 						</div>
 					</div>
 				</SettingsSection>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectHeader.tsx
@@ -43,6 +43,7 @@ interface ProjectHeaderProps {
 	githubOwner: string | null;
 	mainRepoPath: string;
 	hideImage: boolean;
+	iconUrl: string | null;
 	/** Whether the project section is collapsed (workspaces hidden) */
 	isCollapsed: boolean;
 	/** Whether the sidebar is in collapsed mode (icon-only view) */
@@ -59,6 +60,7 @@ export function ProjectHeader({
 	githubOwner,
 	mainRepoPath,
 	hideImage,
+	iconUrl,
 	isCollapsed,
 	isSidebarCollapsed = false,
 	onToggleCollapse,
@@ -205,6 +207,7 @@ export function ProjectHeader({
 										projectName={projectName}
 										projectColor={projectColor}
 										githubOwner={githubOwner}
+										iconUrl={iconUrl}
 									/>
 								</button>
 							</TooltipTrigger>
@@ -279,6 +282,7 @@ export function ProjectHeader({
 									projectColor={projectColor}
 									githubOwner={githubOwner}
 									hideImage={hideImage}
+									iconUrl={iconUrl}
 								/>
 								<RenameInput
 									value={rename.renameValue}
@@ -301,6 +305,7 @@ export function ProjectHeader({
 									projectColor={projectColor}
 									githubOwner={githubOwner}
 									hideImage={hideImage}
+									iconUrl={iconUrl}
 								/>
 								<span className="truncate">{projectName}</span>
 								<span className="text-xs text-muted-foreground tabular-nums font-normal">

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectSection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectSection.tsx
@@ -29,6 +29,7 @@ interface ProjectSectionProps {
 	githubOwner: string | null;
 	mainRepoPath: string;
 	hideImage: boolean;
+	iconUrl: string | null;
 	workspaces: Workspace[];
 	/** Base index for keyboard shortcuts (0-based) */
 	shortcutBaseIndex: number;
@@ -45,6 +46,7 @@ export function ProjectSection({
 	githubOwner,
 	mainRepoPath,
 	hideImage,
+	iconUrl,
 	workspaces,
 	shortcutBaseIndex,
 	index,
@@ -143,6 +145,7 @@ export function ProjectSection({
 					githubOwner={githubOwner}
 					mainRepoPath={mainRepoPath}
 					hideImage={hideImage}
+					iconUrl={iconUrl}
 					isCollapsed={isCollapsed}
 					isSidebarCollapsed={isSidebarCollapsed}
 					onToggleCollapse={() => toggleProjectCollapsed(projectId)}
@@ -200,6 +203,7 @@ export function ProjectSection({
 				githubOwner={githubOwner}
 				mainRepoPath={mainRepoPath}
 				hideImage={hideImage}
+				iconUrl={iconUrl}
 				isCollapsed={isCollapsed}
 				isSidebarCollapsed={isSidebarCollapsed}
 				onToggleCollapse={() => toggleProjectCollapsed(projectId)}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectThumbnail/ProjectThumbnail.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectThumbnail/ProjectThumbnail.tsx
@@ -9,6 +9,7 @@ interface ProjectThumbnailProps {
 	projectColor: string;
 	githubOwner: string | null;
 	hideImage?: boolean;
+	iconUrl?: string | null;
 	className?: string;
 }
 
@@ -39,9 +40,11 @@ export function ProjectThumbnail({
 	projectColor,
 	githubOwner,
 	hideImage,
+	iconUrl,
 	className,
 }: ProjectThumbnailProps) {
 	const [imageError, setImageError] = useState(false);
+	const [iconError, setIconError] = useState(false);
 
 	const { data: avatarData } = electronTrpc.projects.getGitHubAvatar.useQuery(
 		{ id: projectId },
@@ -64,7 +67,28 @@ export function ProjectThumbnail({
 		? { borderColor: hexToRgba(projectColor, 0.6) }
 		: undefined;
 
-	// Show GitHub avatar if available and not hidden
+	// Priority 1: Show project icon if available (works for both superset-icon:// and https://)
+	if (iconUrl && !iconError) {
+		return (
+			<div
+				className={cn(
+					"relative size-6 rounded overflow-hidden flex-shrink-0 bg-muted",
+					borderClasses,
+					className,
+				)}
+				style={borderStyle}
+			>
+				<img
+					src={iconUrl}
+					alt={`${projectName} icon`}
+					className="size-full object-cover"
+					onError={() => setIconError(true)}
+				/>
+			</div>
+		);
+	}
+
+	// Priority 2: Show GitHub avatar if available and not hidden
 	if (owner && !imageError && !hideImage) {
 		return (
 			<div

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -47,6 +47,7 @@ export function WorkspaceSidebar({
 						githubOwner={group.project.githubOwner}
 						mainRepoPath={group.project.mainRepoPath}
 						hideImage={group.project.hideImage}
+						iconUrl={group.project.iconUrl}
 						workspaces={group.workspaces}
 						shortcutBaseIndex={projectShortcutIndices[index]}
 						index={index}

--- a/packages/local-db/drizzle/0020_add_icon_url_to_projects.sql
+++ b/packages/local-db/drizzle/0020_add_icon_url_to_projects.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `projects` ADD `icon_url` text;

--- a/packages/local-db/drizzle/meta/0020_snapshot.json
+++ b/packages/local-db/drizzle/meta/0020_snapshot.json
@@ -1,0 +1,1078 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "090422b5-9394-4b6f-b9c5-c4fb60f26063",
+  "prevId": "732c942c-5f01-451f-a6cf-92c38b434076",
+  "tables": {
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_organization_id_idx": {
+          "name": "organization_members_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_user_id_idx": {
+          "name": "organization_members_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_users_id_fk": {
+          "name": "organization_members_user_id_users_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_org": {
+          "name": "github_org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_clerk_org_id_unique": {
+          "name": "organizations_clerk_org_id_unique",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_idx": {
+          "name": "organizations_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "organizations_clerk_org_id_idx": {
+          "name": "organizations_clerk_org_id_idx",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "main_repo_path": {
+          "name": "main_repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_toast_dismissed": {
+          "name": "config_toast_dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_owner": {
+          "name": "github_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hide_image": {
+          "name": "hide_image",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_main_repo_path_idx": {
+          "name": "projects_main_repo_path_idx",
+          "columns": [
+            "main_repo_path"
+          ],
+          "isUnique": false
+        },
+        "projects_last_opened_at_idx": {
+          "name": "projects_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_active_workspace_id": {
+          "name": "last_active_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_app": {
+          "name": "last_used_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets": {
+          "name": "terminal_presets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets_initialized": {
+          "name": "terminal_presets_initialized",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_ringtone_id": {
+          "name": "selected_ringtone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirm_on_quit": {
+          "name": "confirm_on_quit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_link_behavior": {
+          "name": "terminal_link_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "persist_terminal": {
+          "name": "persist_terminal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_apply_default_preset": {
+          "name": "auto_apply_default_preset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_sounds_muted": {
+          "name": "notification_sounds_muted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delete_local_branch": {
+          "name": "delete_local_branch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_color": {
+          "name": "status_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_type": {
+          "name": "status_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_position": {
+          "name": "status_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "estimate": {
+          "name": "estimate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_provider": {
+          "name": "external_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tasks_slug_unique": {
+          "name": "tasks_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "tasks_slug_idx": {
+          "name": "tasks_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "tasks_organization_id_idx": {
+          "name": "tasks_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_assignee_id_idx": {
+          "name": "tasks_assignee_id_idx",
+          "columns": [
+            "assignee_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_status_idx": {
+          "name": "tasks_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "tasks_created_at_idx": {
+          "name": "tasks_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_organization_id_organizations_id_fk": {
+          "name": "tasks_organization_id_organizations_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_assignee_id_users_id_fk": {
+          "name": "tasks_assignee_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tasks_creator_id_users_id_fk": {
+          "name": "tasks_creator_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": true
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "users_clerk_id_idx": {
+          "name": "users_clerk_id_idx",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_id": {
+          "name": "worktree_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_unread": {
+          "name": "is_unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_unnamed": {
+          "name": "is_unnamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "deleting_at": {
+          "name": "deleting_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_project_id_idx": {
+          "name": "workspaces_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_worktree_id_idx": {
+          "name": "workspaces_worktree_id_idx",
+          "columns": [
+            "worktree_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_last_opened_at_idx": {
+          "name": "workspaces_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspaces_project_id_projects_id_fk": {
+          "name": "workspaces_project_id_projects_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_worktree_id_worktrees_id_fk": {
+          "name": "workspaces_worktree_id_worktrees_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "worktrees",
+          "columnsFrom": [
+            "worktree_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "worktrees": {
+      "name": "worktrees",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_status": {
+          "name": "git_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_status": {
+          "name": "github_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "worktrees_project_id_idx": {
+          "name": "worktrees_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "worktrees_branch_idx": {
+          "name": "worktrees_branch_idx",
+          "columns": [
+            "branch"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "worktrees_project_id_projects_id_fk": {
+          "name": "worktrees_project_id_projects_id_fk",
+          "tableFrom": "worktrees",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/local-db/drizzle/meta/_journal.json
+++ b/packages/local-db/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1770438863796,
       "tag": "0019_add_hide_image_to_projects",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "6",
+      "when": 1770681828456,
+      "tag": "0020_add_icon_url_to_projects",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/local-db/src/schema/schema.ts
+++ b/packages/local-db/src/schema/schema.ts
@@ -38,6 +38,7 @@ export const projects = sqliteTable(
 		branchPrefixMode: text("branch_prefix_mode").$type<BranchPrefixMode>(),
 		branchPrefixCustom: text("branch_prefix_custom"),
 		hideImage: integer("hide_image", { mode: "boolean" }),
+		iconUrl: text("icon_url"),
 	},
 	(table) => [
 		index("projects_main_repo_path_idx").on(table.mainRepoPath),


### PR DESCRIPTION
## Summary

- Store project icons on disk at `~/.superset/project-icons/{projectId}.{ext}` and serve them via a custom `superset-icon://` Electron protocol — making `<img src={project.iconUrl}>` work transparently
- Add automatic favicon discovery from project directories (searches for `favicon.ico`, `logo.png`, etc.)
- Add manual icon upload/remove in Project Settings UI
- Thread `iconUrl` through the sidebar component chain (`WorkspaceSidebar` → `ProjectSection` → `ProjectHeader` → `ProjectThumbnail`)

## Changes

**Backend (main process):**
- `project-icons.ts` — new utility for icon disk storage (save from file/data URL/buffer, delete, lookup)
- `favicon-discovery.ts` — auto-discovers favicons in project repos using `fast-glob` with sensible ignore patterns
- `main/index.ts` — registers `superset-icon://` protocol on both default and `persist:superset` sessions
- `projects.ts` — adds `triggerFaviconDiscovery` and `setProjectIcon` tRPC mutations

**Schema:**
- Adds single `icon_url` text column to projects table (migration 0020)

**Frontend:**
- `ProjectThumbnail` — renders icon with priority: `iconUrl` → GitHub avatar → first letter fallback
- `ProjectSettings` — adds "Project Icon" section with upload/replace/remove controls
- Props threaded through `WorkspaceSidebar` → `ProjectSection` → `ProjectHeader`

## Test plan

- [ ] Open a project with a `favicon.ico` in its root → triggers auto-discovery, icon appears in sidebar
- [ ] Upload a custom icon in Project Settings → replaces sidebar icon
- [ ] Remove the icon → falls back to GitHub avatar or letter
- [ ] Restart app → icons persist (served from disk via protocol)
- [ ] `bun run typecheck` passes (verified)
- [ ] `bun run test` passes (verified — 1205 pass, 0 fail)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project icons: Upload custom icons for projects or enable automatic discovery of project icons from repositories
  * Icon display: Project icons now appear in the sidebar and workspace lists for improved visual identification
  * Icon management: Upload, replace, or remove project icons at any time from project settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->