### PR TITLE
fix(api): bake org context into API keys via tRPC wrapper

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/api-keys/components/ApiKeysSettings/ApiKeysSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/api-keys/components/ApiKeysSettings/ApiKeysSettings.tsx
@@ -31,6 +31,7 @@ import {
 	HiOutlinePlus,
 	HiOutlineTrash,
 } from "react-icons/hi2";
+import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { authClient } from "renderer/lib/auth-client";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import {
@@ -71,11 +72,11 @@ export function ApiKeysSettings({ visibleItems }: ApiKeysSettingsProps) {
 
 		try {
 			setIsGenerating(true);
-			const result = await authClient.apiKey.create({
+			const result = await apiTrpcClient.apiKey.create.mutate({
 				name: newKeyName.trim(),
 			});
-			if (result.data?.key) {
-				setNewKeyValue(result.data.key);
+			if (result.key) {
+				setNewKeyValue(result.key);
 				setShowGenerateDialog(false);
 				setShowNewKeyDialog(true);
 				setNewKeyName("");

--- a/packages/trpc/src/root.ts
+++ b/packages/trpc/src/root.ts
@@ -3,6 +3,7 @@ import type { inferRouterInputs, inferRouterOutputs } from "@trpc/server";
 import { adminRouter } from "./router/admin";
 import { agentRouter } from "./router/agent";
 import { analyticsRouter } from "./router/analytics";
+import { apiKeyRouter } from "./router/api-key";
 import { deviceRouter } from "./router/device";
 import { integrationRouter } from "./router/integration";
 import { organizationRouter } from "./router/organization";
@@ -14,6 +15,7 @@ import { createCallerFactory, createTRPCRouter } from "./trpc";
 export const appRouter = createTRPCRouter({
 	admin: adminRouter,
 	agent: agentRouter,
+	apiKey: apiKeyRouter,
 	analytics: analyticsRouter,
 	device: deviceRouter,
 	integration: integrationRouter,

--- a/packages/trpc/src/router/api-key/api-key.ts
+++ b/packages/trpc/src/router/api-key/api-key.ts
@@ -1,0 +1,28 @@
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+
+import { protectedProcedure } from "../../trpc";
+
+export const apiKeyRouter = {
+	create: protectedProcedure
+		.input(z.object({ name: z.string().min(1) }))
+		.mutation(async ({ ctx, input }) => {
+			const organizationId = ctx.session.session.activeOrganizationId;
+			if (!organizationId) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "Active organization required to create an API key",
+				});
+			}
+
+			const result = await ctx.auth.api.createApiKey({
+				headers: ctx.headers,
+				body: {
+					name: input.name,
+					metadata: { organizationId },
+				},
+			});
+
+			return { key: result.key };
+		}),
+};

--- a/packages/trpc/src/router/api-key/index.ts
+++ b/packages/trpc/src/router/api-key/index.ts
@@ -1,0 +1,1 @@
+export { apiKeyRouter } from "./api-key";


### PR DESCRIPTION
## Summary
- Adds a `apiKey.create` tRPC procedure that injects `activeOrganizationId` from the session into the API key metadata server-side — no client-side org passing needed
- MCP endpoint now reads org from key metadata instead of querying the members table (fixes wrong-org bug for multi-org users)
- Stops leaking the raw API key secret in the `token` field (`"api-key"` sentinel instead)
- Adds `!userId` null guard on API key verification

## Changes
- **`packages/trpc/src/router/api-key/`** — new `apiKey.create` mutation wrapping `auth.api.createApiKey` with org metadata injection
- **`packages/trpc/src/root.ts`** — register `apiKeyRouter`
- **`apps/api/.../route.ts`** — read org from metadata, null guards, no secret leak
- **`apps/desktop/.../ApiKeysSettings.tsx`** — use `apiTrpcClient.apiKey.create.mutate()` instead of `authClient.apiKey.create()`

## Test plan
- [x] `bun run lint:fix` — clean
- [x] `bun run typecheck` — 18/18 pass
- [x] `bun test` — 1221 pass, 0 fail
- [ ] Manual: create API key in desktop settings, use in `.mcp.json`, confirm MCP tools respond with correct org context
- [ ] Manual: verify multi-org user gets the correct org baked into the key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Streamlined API key authentication process by removing database lookups and using metadata-based validation instead.
  * Reorganized API key management system through new router integration for improved consistency.
  * Updated API key creation workflow to use simplified internal infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->