### PR TITLE
ci(desktop): allow force building canary release

### DIFF
--- a/.github/workflows/release-desktop-canary.yml
+++ b/.github/workflows/release-desktop-canary.yml
@@ -4,7 +4,13 @@ on:
   schedule:
     # Every 12 hours at 12 AM and 12 PM UTC
     - cron: "0 0,12 * * *"
-  workflow_dispatch: # Manual trigger for testing
+  workflow_dispatch:
+    inputs:
+      force_build:
+        description: "Force build even if no changes detected"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -40,18 +46,25 @@ jobs:
           VERSION_TIMESTAMP=$(date -u +'%Y%m%d%H%M%S')
           echo "version_timestamp=$VERSION_TIMESTAMP" >> $GITHUB_OUTPUT
 
-          # Get the commit SHA of the last canary release
-          LAST_CANARY_SHA=$(git rev-parse desktop-canary 2>/dev/null || echo "")
+          FORCE_BUILD="${{ github.event.inputs.force_build }}"
 
-          if [ -z "$LAST_CANARY_SHA" ]; then
-            echo "No previous canary release found, building..."
+          if [ "$FORCE_BUILD" = "true" ]; then
+            echo "Force build requested, skipping change detection..."
             echo "should_build=true" >> $GITHUB_OUTPUT
-          elif [ "$LAST_CANARY_SHA" = "$(git rev-parse HEAD)" ]; then
-            echo "No changes since last canary release, skipping..."
-            echo "should_build=false" >> $GITHUB_OUTPUT
           else
-            echo "Changes detected since last canary, building..."
-            echo "should_build=true" >> $GITHUB_OUTPUT
+            # Get the commit SHA of the last canary release
+            LAST_CANARY_SHA=$(git rev-parse desktop-canary 2>/dev/null || echo "")
+
+            if [ -z "$LAST_CANARY_SHA" ]; then
+              echo "No previous canary release found, building..."
+              echo "should_build=true" >> $GITHUB_OUTPUT
+            elif [ "$LAST_CANARY_SHA" = "$(git rev-parse HEAD)" ]; then
+              echo "No changes since last canary release, skipping..."
+              echo "should_build=false" >> $GITHUB_OUTPUT
+            else
+              echo "Changes detected since last canary, building..."
+              echo "should_build=true" >> $GITHUB_OUTPUT
+            fi
           fi
 
   build:

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"clean": "git clean -xdf node_modules",
 		"clean:workspaces": "turbo clean",
 		"release:desktop": "./apps/desktop/create-release.sh",
-		"release:canary": "gh workflow run release-desktop-canary.yml && sleep 2 && gh run list --workflow=release-desktop-canary.yml --limit=1 --json url -q '.[0].url'"
+		"release:canary": "gh workflow run release-desktop-canary.yml -f force_build=true && sleep 2 && gh run list --workflow=release-desktop-canary.yml --limit=1 --json url -q '.[0].url'"
 	},
 	"type": "module",
 	"workspaces": [


### PR DESCRIPTION
## Summary
- Add a `force_build` input flag to the canary release workflow so manual dispatches can bypass change detection
- Update `release:canary` script to always pass `force_build=true`, ensuring manual triggers always build

## Changes
- `.github/workflows/release-desktop-canary.yml`: Add `force_build` boolean input to `workflow_dispatch`, wrap change detection in a conditional that skips it when force is enabled
- `package.json`: Update `release:canary` script to pass `-f force_build=true`

## Test Plan
- [ ] Trigger `bun run release:canary` and verify workflow starts without requiring new commits
- [ ] Verify scheduled runs still skip when no changes are detected (force_build defaults to false)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced the canary build release process to support manually forcing builds, providing greater flexibility in triggering releases independent of code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->