### PR TITLE
feat(api): proxy STREAMS_URL through API for desktop

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -93,7 +93,6 @@ jobs:
           NEXT_PUBLIC_DOCS_URL: ${{ secrets.NEXT_PUBLIC_DOCS_URL }}
           SENTRY_DSN_DESKTOP: ${{ secrets.SENTRY_DSN_DESKTOP }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          STREAMS_URL: ${{ secrets.STREAMS_URL }}
         run: bun run compile:app
 
       - name: Build Electron app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,5 +126,3 @@ jobs:
 
       - name: Build CLI and Desktop
         run: bun turbo run build --filter=@superset/cli --filter=@superset/desktop
-        env:
-          STREAMS_URL: ${{ secrets.STREAMS_URL }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -18,7 +18,6 @@ env:
   ADMIN_ALIAS: admin-pr-${{ github.event.pull_request.number }}-superset.vercel.app
   DOCS_ALIAS: docs-pr-${{ github.event.pull_request.number }}-superset.vercel.app
   ELECTRIC_URL: https://superset-electric-pr-${{ github.event.pull_request.number }}.fly.dev/v1/shape
-  STREAMS_URL: https://superset-stream-pr-${{ github.event.pull_request.number }}.fly.dev
 
 jobs:
   deploy-database:

--- a/apps/api/src/app/api/streams/[...path]/route.ts
+++ b/apps/api/src/app/api/streams/[...path]/route.ts
@@ -1,0 +1,58 @@
+import { auth } from "@superset/auth/server";
+import { env } from "@/env";
+
+export const maxDuration = 300;
+
+const ALLOWED_HEADERS = [
+	"authorization",
+	"content-type",
+	"accept",
+	"x-actor-id",
+];
+
+function forwardHeaders(source: Headers): Headers {
+	const headers = new Headers();
+	for (const key of ALLOWED_HEADERS) {
+		const value = source.get(key);
+		if (value) {
+			headers.set(key, value);
+		}
+	}
+	return headers;
+}
+
+async function proxy(request: Request): Promise<Response> {
+	const sessionData = await auth.api.getSession({
+		headers: request.headers,
+	});
+	if (!sessionData?.user) {
+		return new Response("Unauthorized", { status: 401 });
+	}
+
+	const url = new URL(request.url);
+	const upstreamPath = url.pathname.replace(/^\/api\/streams/, "");
+	const upstream = new URL(`${env.STREAMS_URL}${upstreamPath}${url.search}`);
+
+	const headers = forwardHeaders(request.headers);
+
+	const hasBody = request.method !== "GET" && request.method !== "HEAD";
+
+	const response = await fetch(upstream, {
+		method: request.method,
+		headers,
+		body: hasBody ? request.body : undefined,
+		// @ts-expect-error -- Node fetch supports duplex for streaming request bodies
+		duplex: hasBody ? "half" : undefined,
+	});
+
+	return new Response(response.body, {
+		status: response.status,
+		statusText: response.statusText,
+		headers: response.headers,
+	});
+}
+
+export const GET = proxy;
+export const POST = proxy;
+export const PUT = proxy;
+export const DELETE = proxy;

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -40,6 +40,7 @@ export const env = createEnv({
 		STRIPE_PRO_MONTHLY_PRICE_ID: z.string(),
 		STRIPE_PRO_YEARLY_PRICE_ID: z.string(),
 		SLACK_BILLING_WEBHOOK_URL: z.string().url(),
+		STREAMS_URL: z.string().url(),
 		SENTRY_AUTH_TOKEN: z.string().optional(),
 	},
 	client: {

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -70,10 +70,6 @@ export default defineConfig({
 			"process.env.NEXT_PUBLIC_POSTHOG_HOST": defineEnv(
 				process.env.NEXT_PUBLIC_POSTHOG_HOST,
 			),
-			"process.env.STREAMS_URL": defineEnv(
-				process.env.STREAMS_URL,
-				"https://superset-stream.fly.dev",
-			),
 		},
 
 		build: {

--- a/apps/desktop/src/lib/trpc/routers/ai-chat/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/ai-chat/index.ts
@@ -59,7 +59,7 @@ export const createAiChatRouter = () => {
 		getConfig: publicProcedure.query(async () => {
 			const { token } = await loadToken();
 			return {
-				proxyUrl: env.STREAMS_URL,
+				proxyUrl: `${env.NEXT_PUBLIC_API_URL}/api/streams`,
 				authToken: token,
 			};
 		}),

--- a/apps/desktop/src/lib/trpc/routers/ai-chat/utils/session-manager/session-manager.ts
+++ b/apps/desktop/src/lib/trpc/routers/ai-chat/utils/session-manager/session-manager.ts
@@ -13,7 +13,7 @@ import { loadToken } from "../../../auth/utils/auth-functions";
 import { buildClaudeEnv } from "../auth";
 import type { SessionStore } from "../session-store";
 
-const PROXY_URL = env.STREAMS_URL;
+const PROXY_URL = `${env.NEXT_PUBLIC_API_URL}/api/streams`;
 
 function getClaudeBinaryPath(): string {
 	if (app.isPackaged) {

--- a/apps/desktop/src/main/env.main.ts
+++ b/apps/desktop/src/main/env.main.ts
@@ -19,7 +19,6 @@ export const env = createEnv({
 		NEXT_PUBLIC_POSTHOG_KEY: z.string().optional(),
 		NEXT_PUBLIC_POSTHOG_HOST: z.string().default("https://us.i.posthog.com"),
 		SENTRY_DSN_DESKTOP: z.string().optional(),
-		STREAMS_URL: z.url().default("https://superset-stream.fly.dev"),
 	},
 
 	runtimeEnv: {
@@ -32,7 +31,6 @@ export const env = createEnv({
 		NEXT_PUBLIC_POSTHOG_KEY: process.env.NEXT_PUBLIC_POSTHOG_KEY,
 		NEXT_PUBLIC_POSTHOG_HOST: process.env.NEXT_PUBLIC_POSTHOG_HOST,
 		SENTRY_DSN_DESKTOP: process.env.SENTRY_DSN_DESKTOP,
-		STREAMS_URL: process.env.STREAMS_URL,
 	},
 	emptyStringAsUndefined: true,
 	// Only allow skipping validation in development (never in production)

--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -11,11 +11,11 @@
       - default-src 'self': Only allow resources from same origin
       - script-src 'self' 'wasm-unsafe-eval' https://*.posthog.com: Allow scripts from same origin + WebAssembly (for xterm ImageAddon) + PostHog
       - style-src 'self' 'unsafe-inline': Allow styles from same origin + inline (needed for CSS-in-JS)
-      - connect-src 'self' ws: wss: %NEXT_PUBLIC_API_URL% %STREAMS_URL% https://*.posthog.com https://*.sentry.io sentry-ipc:: Allow WebSocket + API (includes Electric proxy) + Durable Streams proxy + PostHog + Sentry
+      - connect-src 'self' ws: wss: %NEXT_PUBLIC_API_URL% https://*.posthog.com https://*.sentry.io sentry-ipc:: Allow WebSocket + API (includes Electric proxy + Streams proxy) + PostHog + Sentry
       - img-src 'self' data: %NEXT_PUBLIC_API_URL% https://*.public.blob.vercel-storage.com https://github.com https://avatars.githubusercontent.com https://models.dev: Allow images from same origin + data URIs + API (Linear image proxy) + Vercel blob storage + GitHub avatars + model provider logos
       - font-src 'self': Allow fonts from same origin
     -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://*.posthog.com; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss: %NEXT_PUBLIC_API_URL% %STREAMS_URL% https://*.posthog.com https://*.sentry.io sentry-ipc:; img-src 'self' data: %NEXT_PUBLIC_API_URL% https://*.public.blob.vercel-storage.com https://github.com https://avatars.githubusercontent.com https://models.dev; font-src 'self';" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://*.posthog.com; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss: %NEXT_PUBLIC_API_URL% https://*.posthog.com https://*.sentry.io sentry-ipc:; img-src 'self' data: %NEXT_PUBLIC_API_URL% https://*.public.blob.vercel-storage.com https://github.com https://avatars.githubusercontent.com https://models.dev; font-src 'self';" />
   </head>
 
   <body>

--- a/apps/desktop/vite/helpers.ts
+++ b/apps/desktop/vite/helpers.ts
@@ -68,15 +68,10 @@ export function htmlEnvTransformPlugin(): Plugin {
 	return {
 		name: "html-env-transform",
 		transformIndexHtml(html) {
-			return html
-				.replace(
-					/%NEXT_PUBLIC_API_URL%/g,
-					process.env.NEXT_PUBLIC_API_URL || "https://api.superset.sh",
-				)
-				.replace(
-					/%STREAMS_URL%/g,
-					process.env.STREAMS_URL || "https://superset-stream.fly.dev",
-				);
+			return html.replace(
+				/%NEXT_PUBLIC_API_URL%/g,
+				process.env.NEXT_PUBLIC_API_URL || "https://api.superset.sh",
+			);
 		},
 	};
 }

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -16,8 +16,7 @@
 		"POSTHOG_API_KEY",
 		"POSTHOG_PROJECT_ID",
 		"KV_REST_API_URL",
-		"KV_REST_API_TOKEN",
-		"STREAMS_URL"
+		"KV_REST_API_TOKEN"
 	],
 	"globalPassThroughEnv": [
 		"NODE_ENV",


### PR DESCRIPTION
## Summary
- Route desktop streams traffic through the API (`/api/streams/...`) instead of connecting directly to the streams server
- Eliminates the need to bundle `STREAMS_URL` in desktop builds — the streams server URL can now be updated without shipping a new desktop release
- Follows the same proxy pattern already used by Electric SQL (`/api/electric/v1/shape`)

## Changes

### API (`apps/api`)
- Added `STREAMS_URL` to API env schema (`env.ts`)
- Created catch-all proxy route at `api/streams/[...path]/route.ts` — authenticates via session, forwards allowlisted headers, streams request/response bodies, sets `maxDuration = 300` for long-lived connections

### Desktop (`apps/desktop`)
- Updated `getConfig` and `session-manager` to use `${NEXT_PUBLIC_API_URL}/api/streams` instead of `STREAMS_URL`
- Removed `STREAMS_URL` from `env.main.ts`, CSP in `index.html`, `htmlEnvTransformPlugin`, and Vite `define` config

### CI & Build
- Removed `STREAMS_URL` from `build-desktop.yml`, `ci.yml`, `deploy-preview.yml` workflows
- Removed `STREAMS_URL` from `turbo.jsonc` `globalEnv`

## Test Plan
- [x] `bun run typecheck` — passes (18/18 packages)
- [x] `bun run lint:fix` — passes, no fixes needed
- [x] `bun test` — passes (1224 pass, 0 fail)
- [x] `bunx sherif --fix` — no issues found
- [ ] Local dev: start API + streams server, verify desktop chat connects through `localhost:3001/api/streams/v1/...`
- [ ] Verify session creation, message sending, streaming, and stop all work through the proxy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Streams proxy endpoint on the main API to enable authenticated streaming requests (GET/POST/PUT/DELETE) with preserved upstream responses.

* **Chores**
  * Switched desktop clients to route Streams traffic through the main API instead of a separate STREAMS_URL.
  * Removed STREAMS_URL from build/deploy configs and desktop CSP/placeholders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->