### PR TITLE
fix(electric): upgrade to latest image and increase VM resources

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -2,12 +2,12 @@ app = "superset-electric"
 primary_region = "iad"
 
 [build]
-image = "electricsql/electric:1.2.9"
+image = "electricsql/electric:latest"
 
 [[vm]]
-memory = "512mb"
+memory = "4096mb"
 cpu_kind = "shared"
-cpus = 1
+cpus = 2
 
 [env]
 ELECTRIC_DATABASE_USE_IPV6 = "true"


### PR DESCRIPTION
## Summary
- Upgrade Electric SQL from `1.2.9` to `latest` (resolved to `1.4.2`) for improved connection handling and reconnection logic
- Bump VM from 512MB / 1 shared CPU to 4GB / 2 shared CPUs to handle shape snapshot bursts

## Context
Production was hitting `Timeout waiting for Postgres lock acquisition: connection closed while talking to the database` and `Snapshot creation failed because of a connection pool queue timeout`. The version upgrade and larger VM have been deployed and verified — replication slot is active and health checks are passing.

## Test plan
- [x] Deployed to Fly.io production (`superset-electric`)
- [x] Verified replication slot `electric_slot_default` is active
- [x] Health check passing (`/v1/health` returns `{"status":"active"}`)
- [x] Verified DATABASE_URL secret is direct/unpooled Neon connection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment infrastructure configuration to allocate additional computational resources and upgrade the base image to the latest version, improving application performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->