### PR TITLE
fix(workspace): make teardown script resilient to missing deps and env vars

### DIFF
--- a/.superset/teardown.sh
+++ b/.superset/teardown.sh
@@ -77,8 +77,9 @@ step_load_env() {
   fi
 
   if [ "$sourced_any" = false ]; then
-    error "No .env file found (set SUPERSET_ROOT_PATH or run from a workspace with .env)"
-    return 1
+    warn "No .env file found (set SUPERSET_ROOT_PATH or run from a workspace with .env); using existing environment"
+    step_skipped "env sourcing (no .env files found)"
+    return 0
   fi
 
   success "Environment variables loaded"


### PR DESCRIPTION
## Summary
- Source root `.env` via `SUPERSET_ROOT_PATH` (like setup does) so `NEON_PROJECT_ID` is available during teardown
- Degrade gracefully when `neonctl` or `docker` are missing — skip steps with warnings instead of hard-failing
- Dependency check is now informational only (each step already guards itself)

Closes #1394

## Test plan
- [ ] Run teardown without `neonctl` installed — should warn and skip Neon branch deletion instead of failing
- [ ] Run teardown without `NEON_PROJECT_ID` in local `.env` but with it in root `.env` — should load it from root
- [ ] Run teardown with all deps present — should behave as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Teardown is now non-fatal: missing dependencies or external tools produce warnings and skip affected steps instead of failing.
  * Environment loading supports optional root and local env files with flexible fallback; teardown proceeds with warnings when none are found.
  * Summary output records warnings/skips for non-fatal conditions rather than halting the process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->