### PR TITLE
ci(api): add STREAMS_URL to turbo globalEnv

### DIFF
--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -16,7 +16,8 @@
 		"POSTHOG_API_KEY",
 		"POSTHOG_PROJECT_ID",
 		"KV_REST_API_URL",
-		"KV_REST_API_TOKEN"
+		"KV_REST_API_TOKEN",
+		"STREAMS_URL"
 	],
 	"globalPassThroughEnv": [
 		"NODE_ENV",


### PR DESCRIPTION
## Summary
- Add `STREAMS_URL` to Turbo's `globalEnv` so it is available during API builds in CI
- Without this, the API build fails because the env var is defined in `apps/api/src/env.ts` but not passed through by Turbo

## Changes
- `turbo.jsonc`: Added `STREAMS_URL` to the `globalEnv` array

## Test Plan
- [ ] Verify API builds successfully in CI with `STREAMS_URL` available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added STREAMS_URL as a globally available environment variable for enhanced application configuration flexibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->