### PR TITLE
ci(desktop): verify app-update.yml in build pipeline

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -105,6 +105,15 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: bun run package -- --publish never --config ${{ inputs.electron_builder_config }}
 
+      - name: Verify app-update.yml exists
+        working-directory: apps/desktop
+        run: |
+          APP_DIR=$(ls -d release/mac-arm64/*.app | head -1)
+          test -f "$APP_DIR/Contents/Resources/app-update.yml" || {
+            echo "::error::app-update.yml missing from $APP_DIR/Contents/Resources/ — auto-update will be broken"
+            exit 1
+          }
+
       - name: Upload DMG artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- The split build change in #1372 (`--dir` + `--prepackaged`) caused `app-update.yml` to be missing from the app bundle, breaking auto-update for canary builds
- #1372 was reverted in #1393. This PR adds a CI guard so the same class of issue is caught before shipping

## Changes
- Add a verification step after `electron-builder` that fails the build if `app-update.yml` is missing from the `.app` bundle's Resources directory

## Test Plan
- [ ] Canary build passes with the verification step
- [ ] Verify auto-update works on next canary release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced macOS build process with stricter validation to ensure all required build artifacts are present before release, improving build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->