### PR TITLE
Remove PostHog MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -23,19 +23,6 @@
 		"sentry": {
 			"type": "http",
 			"url": "https://mcp.sentry.dev/mcp"
-		},
-		"posthog": {
-			"command": "npx",
-			"args": [
-				"-y",
-				"mcp-remote@latest",
-				"https://mcp.posthog.com/mcp",
-				"--header",
-				"Authorization:${POSTHOG_AUTH_HEADER}"
-			],
-			"env": {
-				"POSTHOG_AUTH_HEADER": "Bearer ${POSTHOG_API_KEY}"
-			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Removes the PostHog MCP server configuration from `.mcp.json`

## Test plan
- [x] Verify `.mcp.json` is valid JSON after removal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the Posthog integration configuration from the system settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->