### PR TITLE
fix(mcp): restrict device execution to user's own devices

### DIFF
--- a/packages/mcp/src/tools/devices/start-claude-session/start-claude-session.ts
+++ b/packages/mcp/src/tools/devices/start-claude-session/start-claude-session.ts
@@ -133,7 +133,7 @@ export function register(server: McpServer) {
 		"start_claude_session",
 		{
 			description:
-				"Start an autonomous Claude Code session for a task in an existing workspace. Launches Claude with the task context in the specified workspace.",
+				"Start an autonomous Claude Code session for a task in an existing workspace. Launches Claude with the task context in the specified workspace. The target device must belong to the current user.",
 			inputSchema: {
 				deviceId: z.string().describe("Target device ID"),
 				taskId: z.string().describe("Task ID to work on"),
@@ -172,7 +172,7 @@ export function register(server: McpServer) {
 		"start_claude_subagent",
 		{
 			description:
-				"Start a Claude Code subagent for a task in an existing workspace. Adds a new terminal pane to the active workspace instead of creating a new one. Use this when you want to run Claude alongside your current work.",
+				"Start a Claude Code subagent for a task in an existing workspace. Adds a new terminal pane to the active workspace instead of creating a new one. Use this when you want to run Claude alongside your current work. The target device must belong to the current user.",
 			inputSchema: {
 				deviceId: z.string().describe("Target device ID"),
 				taskId: z.string().describe("Task ID to work on"),

--- a/packages/mcp/src/tools/utils/utils.ts
+++ b/packages/mcp/src/tools/utils/utils.ts
@@ -70,6 +70,18 @@ export async function executeOnDevice({
 		};
 	}
 
+	if (device.userId !== ctx.userId) {
+		return {
+			content: [
+				{
+					type: "text" as const,
+					text: `Error: Device ${deviceId} does not belong to you. You can only execute commands on your own devices.`,
+				},
+			],
+			isError: true,
+		};
+	}
+
 	const [cmd] = await db
 		.insert(agentCommands)
 		.values({


### PR DESCRIPTION
## Summary

- Adds userId ownership check in `executeOnDevice()` so users can only target their own devices, not any device in the org
- Returns an explicit error ("Device X does not belong to you") instead of the misleading "not online" when targeting another user's device
- Updates `start_claude_session` and `start_claude_subagent` tool descriptions to note the ownership constraint

## Test plan

- [ ] `bun run typecheck` passes
- [ ] `bun test` passes
- [ ] Authenticate as User A, target User B's device → get "does not belong to you" error
- [ ] Authenticate as User A, target User A's own device → works as before
- [ ] Nonexistent/offline device → still returns "not online" error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added ownership validation so users can only operate devices that belong to them.

* **Documentation**
  * Updated tool descriptions to clarify device ownership requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->