### PR TITLE
feat(desktop): make new workspace button more discoverable

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarHeader/NewWorkspaceButton.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarHeader/NewWorkspaceButton.tsx
@@ -51,7 +51,7 @@ export function NewWorkspaceButton({
 					<button
 						type="button"
 						onClick={handleClick}
-						className="group flex items-center justify-center size-8 rounded-md hover:bg-accent/50 transition-colors"
+						className="group flex items-center justify-center size-8 rounded-md bg-accent/40 hover:bg-accent/60 transition-colors"
 					>
 						<div className="flex items-center justify-center size-5 rounded bg-accent">
 							<LuPlus className="size-3" strokeWidth={STROKE_WIDTH_THICK} />
@@ -69,7 +69,7 @@ export function NewWorkspaceButton({
 		<button
 			type="button"
 			onClick={handleClick}
-			className="group flex items-center gap-2 px-2 py-1.5 w-full text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-accent/50 rounded-md transition-colors"
+			className="group flex items-center gap-2 px-2 py-1.5 w-full text-sm font-medium text-muted-foreground hover:text-foreground bg-accent/40 hover:bg-accent/60 rounded-md transition-colors"
 		>
 			<div className="flex items-center justify-center size-5 rounded bg-accent">
 				<LuPlus className="size-3" strokeWidth={STROKE_WIDTH_THICK} />


### PR DESCRIPTION
## Summary
- Add a persistent `bg-accent/40` background to the New Workspace button in the sidebar so it stands out from other nav items as a clear call-to-action
- Stronger hover state (`bg-accent/60`) to maintain visual feedback

## Test plan
- [x] Verify the button has a visible background in both collapsed and expanded sidebar states
- [x] Confirm hover state transitions smoothly
- [x] Check it looks consistent in both light and dark themes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the visual appearance of workspace sidebar buttons with improved background color styling and refined hover state transitions. These updates apply consistently across both collapsed and expanded sidebar layouts, providing users with clearer visual feedback and more responsive interactive states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->