### PR TITLE
feat(desktop): redesign branch workspace sidebar display

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -441,10 +441,12 @@ export function WorkspaceListItem({
 			{/* Icon with status indicator */}
 			<Tooltip delayDuration={500}>
 				<TooltipTrigger asChild>
-					<div className={cn(
-						"relative shrink-0 size-5 flex items-center justify-center mr-2.5",
-						showBranchSubtitle && "mt-0.5",
-					)}>
+					<div
+						className={cn(
+							"relative shrink-0 size-5 flex items-center justify-center mr-2.5",
+							showBranchSubtitle && "mt-0.5",
+						)}
+					>
 						{workspaceStatus === "working" ? (
 							<AsciiSpinner className="text-base" />
 						) : isBranchWorkspace ? (


### PR DESCRIPTION
## Summary
- Replace folder icon with laptop icon (`LuLaptop`) for branch workspaces in the sidebar
- Show "local" as the title with branch name displayed below for the default branch workspace
- Update collapsed tooltip to show "local" + branch name
- Adjust layout so single-line items (title matches branch) stay vertically centered, while two-line items top-align the icon

## Test plan
- [x] Verify the branch workspace shows a laptop icon in both collapsed and expanded sidebar
- [x] Verify the title reads "local" with the branch name below
- [x] Verify worktree workspaces are unaffected (still show `LuFolderGit2` icon and original title logic)
- [x] Verify collapsed sidebar tooltip shows "local" and the branch name
- [x] Verify single-line worktree items remain vertically centered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Replaced branch workspace icon from folder to laptop in collapsed view
  * Show "local" as the title for branch workspaces and display branch as subtitle when applicable
  * Simplified tooltip/hover content to a consistent local/branch presentation
  * Improved spacing and alignment in the workspace sidebar for better visual balance
  * Adjusted status indicator positioning for consistent alignment with subtitle changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->