### PR TITLE
ci(electric): pin image, disable auto-stop, add CI deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -424,6 +424,33 @@ jobs:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: flyctl deploy . --config apps/streams/fly.toml --remote-only
 
+  deploy-electric:
+    name: Deploy Electric to Fly.io
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Fly CLI
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Stage secrets
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          flyctl secrets set \
+            DATABASE_URL="${{ secrets.DATABASE_URL_UNPOOLED }}" \
+            ELECTRIC_SECRET="${{ secrets.ELECTRIC_SECRET }}" \
+            --app superset-electric \
+            --stage
+
+      - name: Deploy to Fly.io
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: flyctl deploy . --config fly.toml --remote-only
+
   deploy-docs:
     name: Deploy Docs to Vercel
     runs-on: ubuntu-latest

--- a/fly.toml
+++ b/fly.toml
@@ -2,7 +2,7 @@ app = "superset-electric"
 primary_region = "iad"
 
 [build]
-image = "electricsql/electric:latest"
+image = "electricsql/electric:1.4.3"
 
 [[vm]]
 memory = "4096mb"
@@ -15,6 +15,9 @@ ELECTRIC_DATABASE_USE_IPV6 = "true"
 [http_service]
 internal_port = 3000
 force_https = true
+auto_stop_machines = "off"
+auto_start_machines = true
+min_machines_running = 1
 
 [[http_service.checks]]
 interval = "10s"


### PR DESCRIPTION
## Summary
- Pin Electric Docker image to `1.4.3` instead of `latest` for reproducible deploys
- Disable `auto_stop_machines` so the Electric streamer stays always-on
- Add `deploy-electric` job to `deploy-production.yml` so Electric redeploys on merge to main

## Test plan
- [ ] Verify Electric Fly machine stays running after deploy
- [ ] Confirm deploy-production workflow includes the new Electric job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Electric service to version 1.4.3.
  * Enhanced deployment automation and configured automatic machine scaling for improved infrastructure reliability and resource optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->