### PR TITLE
fix(slack): resolve user mentions to display names

### DIFF
--- a/apps/api/src/app/api/integrations/slack/events/process-mention/process-mention.ts
+++ b/apps/api/src/app/api/integrations/slack/events/process-mention/process-mention.ts
@@ -2,7 +2,11 @@ import type { AppMentionEvent } from "@slack/types";
 import { db } from "@superset/db/client";
 import { integrationConnections } from "@superset/db/schema";
 import { and, eq } from "drizzle-orm";
-import { formatErrorForSlack, runSlackAgent } from "../utils/run-agent";
+import {
+	formatErrorForSlack,
+	resolveUserMentions,
+	runSlackAgent,
+} from "../utils/run-agent";
 import { formatSideEffectsMessage } from "../utils/slack-blocks";
 import { createSlackClient } from "../utils/slack-client";
 
@@ -70,8 +74,13 @@ export async function processSlackMention({
 	}
 
 	try {
+		const resolve = await resolveUserMentions({
+			texts: [event.text],
+			slack,
+		});
+
 		const result = await runSlackAgent({
-			prompt: event.text,
+			prompt: resolve(event.text),
 			channelId: event.channel,
 			threadTs,
 			organizationId: connection.organizationId,

--- a/apps/api/src/app/api/integrations/slack/events/utils/run-agent/index.ts
+++ b/apps/api/src/app/api/integrations/slack/events/utils/run-agent/index.ts
@@ -1,2 +1,6 @@
 export type { SlackAgentResult } from "./run-agent";
-export { formatErrorForSlack, runSlackAgent } from "./run-agent";
+export {
+	formatErrorForSlack,
+	resolveUserMentions,
+	runSlackAgent,
+} from "./run-agent";


### PR DESCRIPTION
## Summary
- The Slack agent was receiving raw user IDs (`<@U0A4BLQB04B>`) instead of human-readable names, so it couldn't identify who was being mentioned in threads or messages
- Added `resolveUserMentions()` helper that collects unique `<@U...>` IDs and resolves them in parallel via `slack.users.info()`
- Applied to all three places mentions appear: the prompt itself, thread context, and channel history

## Test plan
- [ ] Mention a user in a Slack thread with `@Superset` and verify the agent identifies them by name
- [ ] Verify thread context shows resolved names (e.g. `@John Smith: message`) instead of raw IDs
- [ ] Verify channel history tool returns resolved names
- [ ] Test with an unresolvable user ID (e.g. deactivated user) — should fall back to raw ID gracefully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Slack integration now resolves user mentions before processing messages, displaying actual usernames instead of user IDs for improved clarity and agent processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->