### PR TITLE
fix(slack): add missing QStash endpoint for DM messages

### DIFF
--- a/apps/api/src/app/api/integrations/slack/events/process-assistant-message/process-assistant-message.ts
+++ b/apps/api/src/app/api/integrations/slack/events/process-assistant-message/process-assistant-message.ts
@@ -2,7 +2,11 @@ import type { GenericMessageEvent } from "@slack/types";
 import { db } from "@superset/db/client";
 import { integrationConnections } from "@superset/db/schema";
 import { and, eq } from "drizzle-orm";
-import { formatErrorForSlack, runSlackAgent } from "../utils/run-agent";
+import {
+	formatErrorForSlack,
+	resolveUserMentions,
+	runSlackAgent,
+} from "../utils/run-agent";
 import { formatSideEffectsMessage } from "../utils/slack-blocks";
 import { createSlackClient } from "../utils/slack-client";
 
@@ -60,8 +64,13 @@ export async function processAssistantMessage({
 	}
 
 	try {
+		const resolve = await resolveUserMentions({
+			texts: [event.text ?? ""],
+			slack,
+		});
+
 		const result = await runSlackAgent({
-			prompt: event.text ?? "",
+			prompt: resolve(event.text ?? ""),
 			channelId: event.channel,
 			threadTs,
 			organizationId: connection.organizationId,

--- a/apps/api/src/app/api/integrations/slack/jobs/process-assistant-message/route.ts
+++ b/apps/api/src/app/api/integrations/slack/jobs/process-assistant-message/route.ts
@@ -1,0 +1,61 @@
+import { Receiver } from "@upstash/qstash";
+import { z } from "zod";
+
+import { env } from "@/env";
+import { processAssistantMessage } from "../../events/process-assistant-message";
+
+const receiver = new Receiver({
+	currentSigningKey: env.QSTASH_CURRENT_SIGNING_KEY,
+	nextSigningKey: env.QSTASH_NEXT_SIGNING_KEY,
+});
+
+const payloadSchema = z.object({
+	event: z.object({
+		type: z.literal("message"),
+		user: z.string(),
+		text: z.string().optional(),
+		ts: z.string(),
+		channel: z.string(),
+		channel_type: z.literal("im"),
+		event_ts: z.string(),
+		thread_ts: z.string().optional(),
+	}),
+	teamId: z.string(),
+	eventId: z.string(),
+});
+
+export async function POST(request: Request) {
+	const body = await request.text();
+	const signature = request.headers.get("upstash-signature");
+
+	if (!signature) {
+		return Response.json({ error: "Missing signature" }, { status: 401 });
+	}
+
+	const isValid = await receiver.verify({
+		body,
+		signature,
+		url: `${env.NEXT_PUBLIC_API_URL}/api/integrations/slack/jobs/process-assistant-message`,
+	});
+
+	if (!isValid) {
+		return Response.json({ error: "Invalid signature" }, { status: 401 });
+	}
+
+	const parsed = payloadSchema.safeParse(JSON.parse(body));
+	if (!parsed.success) {
+		console.error(
+			"[slack/process-assistant-message] Invalid payload:",
+			parsed.error,
+		);
+		return Response.json({ error: "Invalid payload" }, { status: 400 });
+	}
+
+	await processAssistantMessage({
+		event: { ...parsed.data.event, subtype: undefined },
+		teamId: parsed.data.teamId,
+		eventId: parsed.data.eventId,
+	});
+
+	return Response.json({ success: true });
+}


### PR DESCRIPTION
## Summary
- Adds the missing `jobs/process-assistant-message/route.ts` QStash handler — the event router was dispatching DM messages to this endpoint, but no route existed (404)
- Adds `resolveUserMentions` to the DM handler to match the mention handler pattern

## Test plan
- [ ] Send a DM to the Slack bot, verify it responds
- [ ] Reply in the DM thread, verify the agent sees prior thread context
- [ ] Send a DM with an `@mention`, verify the user's display name appears in the agent's prompt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Slack messages containing user mentions are now properly resolved before processing by the assistant, improving accuracy of responses in conversations with user references.

* **New Features**
  * Enhanced Slack integration with improved message processing validation and security verification for more reliable request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->