### PR TITLE
fix(desktop): backwards-compatible auth callback protocol

### DIFF
--- a/apps/web/src/app/auth/desktop/success/page.tsx
+++ b/apps/web/src/app/auth/desktop/success/page.tsx
@@ -10,9 +10,10 @@ export default async function DesktopSuccessPage({
 }: {
 	searchParams: Promise<{ desktop_state?: string; desktop_protocol?: string }>;
 }) {
-	const { desktop_state: state, desktop_protocol } = await searchParams;
+	const { desktop_state: state, desktop_protocol = "superset" } =
+		await searchParams;
 
-	if (!state || !desktop_protocol) {
+	if (!state) {
 		return (
 			<div className="flex min-h-screen flex-col items-center justify-center bg-background p-4">
 				<p className="text-xl text-muted-foreground">Missing auth state</p>


### PR DESCRIPTION
## Summary
- Default `desktop_protocol` to `"superset"` on the auth success page so older desktop clients that don't send the protocol param still complete OAuth successfully.

## Test plan
- [ ] Verify new desktop clients with multi-worktree support still send their workspace-specific protocol and it works
- [ ] Verify older desktop clients without the protocol param default to `superset://` and complete auth

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop authentication flow by providing a default protocol configuration and streamlining validation requirements for a more reliable user authentication experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->