### PR TITLE
fix(desktop): source shell profile in teardown via wrappers

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/teardown.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/teardown.ts
@@ -84,7 +84,7 @@ export async function runTeardown({
 				fn();
 			};
 
-			// Listen on "exit" not "close" — background children may hold stdio open
+			// "exit" not "close" — background children may hold stdio open
 			child.on("exit", (code) => {
 				settle(() => {
 					if (code === 0) resolve(combined);

--- a/apps/desktop/src/main/lib/agent-setup/index.ts
+++ b/apps/desktop/src/main/lib/agent-setup/index.ts
@@ -22,40 +22,29 @@ import {
 	getShellEnv,
 } from "./shell-wrappers";
 
-/**
- * Sets up the ~/.superset directory structure and agent wrappers
- * Called on app startup
- */
 export function setupAgentHooks(): void {
 	console.log("[agent-setup] Initializing agent hooks...");
 
-	// Create directories
 	fs.mkdirSync(BIN_DIR, { recursive: true });
 	fs.mkdirSync(HOOKS_DIR, { recursive: true });
 	fs.mkdirSync(ZSH_DIR, { recursive: true });
 	fs.mkdirSync(BASH_DIR, { recursive: true });
 	fs.mkdirSync(OPENCODE_PLUGIN_DIR, { recursive: true });
 
-	// Clean up stale global plugins that may cause dev/prod conflicts
 	cleanupGlobalOpenCodePlugin();
 
-	// Create scripts
 	createNotifyScript();
 	createClaudeWrapper();
 	createCodexWrapper();
 	createOpenCodePlugin();
 	createOpenCodeWrapper();
 
-	// Create shell initialization wrappers
 	createZshWrapper();
 	createBashWrapper();
 
 	console.log("[agent-setup] Agent hooks initialized");
 }
 
-/**
- * Returns the bin directory path
- */
 export function getSupersetBinDir(): string {
 	return BIN_DIR;
 }


### PR DESCRIPTION
## Summary
- Teardown scripts bypassed the shell wrapper system (ZDOTDIR/rcfile), so they didn't get `~/.superset/bin` in PATH or source profiles the same way the terminal does
- Now uses `buildSafeEnv` + `getShellEnv` + new `getCommandShellArgs` to match the terminal's profile sourcing

## Changes
- **`shell-wrappers.ts`**: Added `getCommandShellArgs(shell, command)` for non-interactive command execution that sources wrapper profiles inline (needed because `--rcfile` is ignored with `-c` in bash, and `.zshrc` is skipped in non-interactive zsh)
- **`teardown.ts`**: Replaced `getShellEnvironment()` (spawned a separate login shell) with the shell wrapper approach — `buildSafeEnv` + `getShellEnv` for env, `getCommandShellArgs` for args
- **`index.ts`**: Re-exports `getCommandShellArgs`

## Test Plan
- [x] All 11 teardown tests pass
- [x] No type errors
- [ ] Verify teardown scripts can access tools in `~/.superset/bin` (e.g. agent wrappers)
- [ ] Verify teardown works on both zsh and bash shells

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More reliable shell environment handling and command argument construction for workspace operations.
  * Better RC-file sourcing behavior so user shell commands run with expected initialization.
  * Refined process event handling to accommodate background processes that may keep resources open.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->