### PR TITLE
fix(desktop): preserve existing terminal presets during initialization

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/settings/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/index.ts
@@ -52,28 +52,33 @@ function initializeDefaultPresets() {
 	const row = getSettings();
 	if (row.terminalPresetsInitialized) return row.terminalPresets ?? [];
 
-	const presets: TerminalPreset[] = DEFAULT_PRESETS.map((p) => ({
-		id: crypto.randomUUID(),
-		...p,
-	}));
+	const existingPresets: TerminalPreset[] = row.terminalPresets ?? [];
+
+	const mergedPresets =
+		existingPresets.length > 0
+			? existingPresets
+			: DEFAULT_PRESETS.map((p) => ({
+					id: crypto.randomUUID(),
+					...p,
+				}));
 
 	localDb
 		.insert(settings)
 		.values({
 			id: 1,
-			terminalPresets: presets,
+			terminalPresets: mergedPresets,
 			terminalPresetsInitialized: true,
 		})
 		.onConflictDoUpdate({
 			target: settings.id,
 			set: {
-				terminalPresets: presets,
+				terminalPresets: mergedPresets,
 				terminalPresetsInitialized: true,
 			},
 		})
 		.run();
 
-	return presets;
+	return mergedPresets;
 }
 
 /** Get presets tagged with a given auto-apply field, falling back to the isDefault preset */


### PR DESCRIPTION
## Summary
- `initializeDefaultPresets()` was overwriting existing user terminal presets when `terminalPresetsInitialized` was null
- Now preserves existing presets and only applies defaults when no presets exist

## Changes
- **`apps/desktop/src/lib/trpc/routers/settings/index.ts`**: Changed `initializeDefaultPresets()` to check for existing `row.terminalPresets` before applying defaults. If presets already exist, they are kept as-is and only the `terminalPresetsInitialized` flag is set to `true`.

## Test Plan
- [ ] Verify existing user presets are preserved when `terminalPresetsInitialized` is null
- [ ] Verify default presets are still created for fresh installs (no existing presets)
- [ ] Verify the function still early-returns when `terminalPresetsInitialized` is already true

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced terminal preset initialization to properly preserve and merge existing presets, preventing unnecessary regeneration of preset identifiers during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->