### PR TITLE
fix(slack): add missing /integrations/slack/linked page

### DIFF
--- a/apps/web/src/app/(dashboard)/integrations/slack/linked/page.tsx
+++ b/apps/web/src/app/(dashboard)/integrations/slack/linked/page.tsx
@@ -1,0 +1,27 @@
+import { CheckCircle2 } from "lucide-react";
+import Link from "next/link";
+
+export default function SlackLinkedPage() {
+	return (
+		<div className="flex min-h-[60vh] flex-col items-center justify-center p-4">
+			<div className="flex flex-col items-center gap-6">
+				<div className="flex size-16 items-center justify-center rounded-full bg-emerald-500/10">
+					<CheckCircle2 className="size-8 text-emerald-500" />
+				</div>
+				<div className="flex flex-col items-center gap-2 text-center">
+					<h1 className="text-2xl font-semibold">Slack Account Linked</h1>
+					<p className="max-w-sm text-muted-foreground">
+						Your Slack account has been linked to Superset. You can close this
+						tab and return to Slack.
+					</p>
+				</div>
+				<Link
+					href="/integrations/slack"
+					className="text-sm text-muted-foreground/70 underline decoration-muted-foreground/40 underline-offset-4 transition-colors hover:text-muted-foreground"
+				>
+					Go to Slack integration settings
+				</Link>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
- The Slack account linking API (`/api/integrations/slack/link`) redirects to `/integrations/slack/linked` after successfully linking a user's Slack account, but this page didn't exist — resulting in a 404.
- Adds a simple success page with a checkmark, confirmation message, and link back to Slack integration settings.

## Test plan
- [ ] Trigger the Slack account linking flow from the Slack Home tab
- [ ] After linking, verify the redirect lands on the new page instead of a 404
- [ ] Verify the "Go to Slack integration settings" link works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confirmation page displayed after successfully linking a Slack account, featuring visual confirmation with a check icon and direct access to integration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->