### PR TITLE
refactor(desktop): remove auto-open first file when opening changes tab

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/SidebarControl/SidebarControl.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/SidebarControl/SidebarControl.tsx
@@ -1,121 +1,12 @@
 import { Button } from "@superset/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
-import { useParams } from "@tanstack/react-router";
-import { useCallback } from "react";
 import { LuDiff } from "react-icons/lu";
 import { HotkeyTooltipContent } from "renderer/components/HotkeyTooltipContent";
-import { useFileOpenMode } from "renderer/hooks/useFileOpenMode";
-import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useSidebarStore } from "renderer/stores";
-import { useChangesStore } from "renderer/stores/changes";
-import { useTabsStore } from "renderer/stores/tabs/store";
-import type { ChangeCategory, ChangedFile } from "shared/changes-types";
-
-/** Priority order for selecting the first file to open */
-const FILE_CATEGORIES: Array<{
-	key: "againstBase" | "staged" | "unstaged" | "untracked";
-	category: ChangeCategory;
-}> = [
-	{ key: "againstBase", category: "against-base" },
-	{ key: "staged", category: "staged" },
-	{ key: "unstaged", category: "unstaged" },
-	{ key: "untracked", category: "unstaged" },
-];
 
 export function SidebarControl() {
 	const { isSidebarOpen, toggleSidebar } = useSidebarStore();
-
-	const { workspaceId } = useParams({ strict: false });
-	const { data: workspace } = electronTrpc.workspaces.get.useQuery(
-		{ id: workspaceId ?? "" },
-		{ enabled: !!workspaceId },
-	);
-	const worktreePath = workspace?.worktreePath;
-
-	const { getBaseBranch, selectFile } = useChangesStore();
-	const baseBranch = getBaseBranch(worktreePath || "");
-	const { data: branchData } = electronTrpc.changes.getBranches.useQuery(
-		{ worktreePath: worktreePath || "" },
-		{ enabled: !!worktreePath && !isSidebarOpen },
-	);
-	const effectiveBaseBranch = baseBranch ?? branchData?.defaultBranch ?? "main";
-
-	const { data: status } = electronTrpc.changes.getStatus.useQuery(
-		{ worktreePath: worktreePath || "", defaultBranch: effectiveBaseBranch },
-		{ enabled: !!worktreePath && !isSidebarOpen },
-	);
-
-	const addFileViewerPane = useTabsStore((s) => s.addFileViewerPane);
-	const fileOpenMode = useFileOpenMode();
-	const trpcUtils = electronTrpc.useUtils();
-
-	const invalidateFileContent = useCallback(
-		(filePath: string) => {
-			if (!worktreePath) return;
-			Promise.all([
-				trpcUtils.changes.readWorkingFile.invalidate({
-					worktreePath,
-					filePath,
-				}),
-				trpcUtils.changes.getFileContents.invalidate({
-					worktreePath,
-					filePath,
-				}),
-			]).catch((error) => {
-				console.error(
-					"[SidebarControl/invalidateFileContent] Failed to invalidate:",
-					{ worktreePath, filePath, error },
-				);
-			});
-		},
-		[worktreePath, trpcUtils],
-	);
-
-	const openFirstFile = useCallback(() => {
-		if (!workspaceId || !worktreePath || !status) return;
-
-		let firstFile: ChangedFile | undefined;
-		let category: ChangeCategory | undefined;
-
-		for (const { key, category: cat } of FILE_CATEGORIES) {
-			const files = status[key];
-			if (files && files.length > 0) {
-				firstFile = files[0];
-				category = cat;
-				break;
-			}
-		}
-
-		if (firstFile && category) {
-			selectFile(worktreePath, firstFile, category, null);
-			addFileViewerPane(workspaceId, {
-				filePath: firstFile.path,
-				diffCategory: category,
-				oldPath: firstFile.oldPath,
-				isPinned: false,
-				openInNewTab: fileOpenMode === "new-tab",
-			});
-			invalidateFileContent(firstFile.path);
-		}
-	}, [
-		workspaceId,
-		worktreePath,
-		status,
-		selectFile,
-		addFileViewerPane,
-		invalidateFileContent,
-		fileOpenMode,
-	]);
-
-	const handleClick = useCallback(() => {
-		if (isSidebarOpen) {
-			toggleSidebar();
-		} else {
-			toggleSidebar();
-			openFirstFile();
-		}
-	}, [isSidebarOpen, toggleSidebar, openFirstFile]);
 
 	return (
 		<Tooltip>
@@ -123,7 +14,7 @@ export function SidebarControl() {
 				<Button
 					variant="ghost"
 					size="sm"
-					onClick={handleClick}
+					onClick={toggleSidebar}
 					aria-label={
 						isSidebarOpen ? "Hide Changes Sidebar" : "Show Changes Sidebar"
 					}


### PR DESCRIPTION
## Summary
- Remove the logic that automatically opens the first changed file when the Changes sidebar is toggled open
- The sidebar button now simply toggles visibility without side effects

## Changes
- **`apps/desktop/src/renderer/screens/main/components/SidebarControl/SidebarControl.tsx`**: Removed `openFirstFile` callback, `FILE_CATEGORIES` constant, `handleClick` wrapper, and all supporting code (workspace/branch/status queries, store access, file viewer pane logic). The button now calls `toggleSidebar` directly. (-110 lines)

## Test Plan
- [ ] Click the Changes button to open the sidebar — verify no file is auto-opened in the viewer
- [ ] Click the Changes button again to close the sidebar — verify it toggles correctly
- [ ] Manually click a file in the changes list — verify it still opens normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the sidebar control component by reducing internal complexity and removing unnecessary data operations. User-facing functionality and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->