### PR TITLE
fix(desktop): ensure notify hook exits 0 on curl failure

### DIFF
--- a/apps/desktop/src/main/lib/agent-setup/templates/notify-hook.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/notify-hook.template.sh
@@ -44,3 +44,5 @@ curl -sG "http://127.0.0.1:${SUPERSET_PORT:-{{DEFAULT_PORT}}}/hook/complete" \
   --data-urlencode "env=$SUPERSET_ENV" \
   --data-urlencode "version=$SUPERSET_HOOK_VERSION" \
   > /dev/null 2>&1
+
+exit 0


### PR DESCRIPTION
## Summary
- Adds explicit `exit 0` at the end of the notify hook template so that a failed `curl` (e.g. notification server unreachable) doesn't propagate a non-zero exit code
- Fixes the intermittent "Stop hook error: Failed with non-blocking status code: No stderr output" warning in Claude Code

## Test plan
- [ ] Run Claude Code inside a Superset terminal — verify no more stop hook errors
- [ ] Kill the notification server port and confirm the hook still exits cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced notification hook reliability to ensure proper script termination and prevent potential hanging issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->