### PR TITLE
fix(api): use linked Slack user identity for MCP auth

### DIFF
--- a/apps/api/src/app/api/integrations/slack/events/process-app-home-opened/process-app-home-opened.ts
+++ b/apps/api/src/app/api/integrations/slack/events/process-app-home-opened/process-app-home-opened.ts
@@ -1,8 +1,7 @@
-import { createHmac } from "node:crypto";
 import { db } from "@superset/db/client";
 import { integrationConnections, usersSlackUsers } from "@superset/db/schema";
 import { and, eq } from "drizzle-orm";
-import { env } from "@/env";
+import { generateConnectUrl } from "../utils/generate-connect-url";
 import { createSlackClient } from "../utils/slack-client";
 import { buildHomeView } from "./build-home-view";
 
@@ -10,25 +9,6 @@ interface ProcessAppHomeOpenedParams {
 	event: { user: string; tab: string };
 	teamId: string;
 	eventId: string;
-}
-
-function generateConnectUrl({
-	slackUserId,
-	teamId,
-}: {
-	slackUserId: string;
-	teamId: string;
-}): string {
-	const payload = JSON.stringify({
-		slackUserId,
-		teamId,
-		exp: Date.now() + 10 * 60 * 1000,
-	});
-	const signature = createHmac("sha256", env.SLACK_SIGNING_SECRET)
-		.update(payload)
-		.digest("hex");
-	const token = Buffer.from(payload).toString("base64url");
-	return `${env.NEXT_PUBLIC_API_URL}/api/integrations/slack/link?token=${token}&sig=${signature}`;
 }
 
 export async function processAppHomeOpened({

--- a/apps/api/src/app/api/integrations/slack/events/process-mention/process-mention.ts
+++ b/apps/api/src/app/api/integrations/slack/events/process-mention/process-mention.ts
@@ -1,7 +1,12 @@
 import type { AppMentionEvent } from "@slack/types";
 import { db } from "@superset/db/client";
-import { integrationConnections, usersSlackUsers } from "@superset/db/schema";
+import {
+	integrationConnections,
+	subscriptions,
+	usersSlackUsers,
+} from "@superset/db/schema";
 import { and, eq } from "drizzle-orm";
+import { generateConnectUrl } from "../utils/generate-connect-url";
 import {
 	formatErrorForSlack,
 	resolveUserMentions,
@@ -45,15 +50,91 @@ export async function processSlackMention({
 
 	const slack = createSlackClient(connection.accessToken);
 
-	const slackUserLink = event.user
-		? await db.query.usersSlackUsers.findFirst({
-				where: and(
-					eq(usersSlackUsers.slackUserId, event.user),
-					eq(usersSlackUsers.teamId, teamId),
-				),
-				columns: { modelPreference: true },
-			})
-		: undefined;
+	const [slackUserLink, activeSubscription] = await Promise.all([
+		event.user
+			? db.query.usersSlackUsers.findFirst({
+					where: and(
+						eq(usersSlackUsers.slackUserId, event.user),
+						eq(usersSlackUsers.teamId, teamId),
+					),
+					columns: { userId: true, modelPreference: true },
+				})
+			: undefined,
+		db.query.subscriptions.findFirst({
+			where: and(
+				eq(subscriptions.referenceId, connection.organizationId),
+				eq(subscriptions.status, "active"),
+			),
+			columns: { id: true },
+		}),
+	]);
+
+	if (!activeSubscription) {
+		await slack.chat.postMessage({
+			channel: event.channel,
+			thread_ts: event.thread_ts ?? event.ts,
+			text: "The Superset Slack integration requires a Pro plan.",
+			blocks: [
+				{
+					type: "section",
+					text: {
+						type: "mrkdwn",
+						text: "The Superset Slack integration requires a Pro plan.",
+					},
+				},
+				{
+					type: "actions",
+					elements: [
+						{
+							type: "button",
+							text: { type: "plain_text", text: "Upgrade to Pro", emoji: true },
+							url: "https://app.superset.sh/settings/billing",
+							style: "primary",
+						},
+					],
+				},
+			],
+		});
+		return;
+	}
+
+	if (!slackUserLink) {
+		if (!event.user) return;
+		const connectUrl = generateConnectUrl({
+			slackUserId: event.user,
+			teamId,
+		});
+		await slack.chat.postMessage({
+			channel: event.channel,
+			thread_ts: event.thread_ts ?? event.ts,
+			text: "To use Superset, you need to link your Slack account first.",
+			blocks: [
+				{
+					type: "section",
+					text: {
+						type: "mrkdwn",
+						text: "To use Superset, you need to link your Slack account first.",
+					},
+				},
+				{
+					type: "actions",
+					elements: [
+						{
+							type: "button",
+							text: {
+								type: "plain_text",
+								text: "Connect Account",
+								emoji: true,
+							},
+							url: connectUrl,
+							style: "primary",
+						},
+					],
+				},
+			],
+		});
+		return;
+	}
 
 	try {
 		await slack.reactions.add({
@@ -94,8 +175,9 @@ export async function processSlackMention({
 			channelId: event.channel,
 			threadTs,
 			organizationId: connection.organizationId,
+			userId: slackUserLink.userId,
 			slackToken: connection.accessToken,
-			model: slackUserLink?.modelPreference ?? undefined,
+			model: slackUserLink.modelPreference ?? undefined,
 			onProgress: messageTs
 				? async (status) => {
 						try {

--- a/apps/api/src/app/api/integrations/slack/events/utils/generate-connect-url/generate-connect-url.ts
+++ b/apps/api/src/app/api/integrations/slack/events/utils/generate-connect-url/generate-connect-url.ts
@@ -1,0 +1,21 @@
+import { createHmac } from "node:crypto";
+import { env } from "@/env";
+
+export function generateConnectUrl({
+	slackUserId,
+	teamId,
+}: {
+	slackUserId: string;
+	teamId: string;
+}): string {
+	const payload = JSON.stringify({
+		slackUserId,
+		teamId,
+		exp: Date.now() + 10 * 60 * 1000,
+	});
+	const signature = createHmac("sha256", env.SLACK_SIGNING_SECRET)
+		.update(payload)
+		.digest("hex");
+	const token = Buffer.from(payload).toString("base64url");
+	return `${env.NEXT_PUBLIC_API_URL}/api/integrations/slack/link?token=${token}&sig=${signature}`;
+}

--- a/apps/api/src/app/api/integrations/slack/events/utils/generate-connect-url/index.ts
+++ b/apps/api/src/app/api/integrations/slack/events/utils/generate-connect-url/index.ts
@@ -1,0 +1,1 @@
+export { generateConnectUrl } from "./generate-connect-url";

--- a/apps/web/src/app/(dashboard)/settings/billing/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/billing/page.tsx
@@ -1,3 +1,9 @@
+import {
+	DOWNLOAD_URL_MAC_ARM64,
+	PROTOCOL_SCHEMES,
+} from "@superset/shared/constants";
+import { Button } from "@superset/ui/button";
+import { Download, ExternalLink } from "lucide-react";
 import { HiCheckCircle } from "react-icons/hi2";
 
 export default async function BillingPage({
@@ -8,24 +14,41 @@ export default async function BillingPage({
 	const { success } = await searchParams;
 	const isSuccess = success === "true";
 
-	if (!isSuccess) {
+	if (isSuccess) {
 		return (
-			<div className="flex flex-col items-center justify-center py-16">
+			<div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
+				<HiCheckCircle className="h-12 w-12 text-green-500" />
+				<h1 className="text-2xl font-semibold">Payment Successful</h1>
 				<p className="text-muted-foreground">
-					Manage your billing in the desktop app.
+					Your subscription has been activated. You can now access all Pro
+					features.
 				</p>
 			</div>
 		);
 	}
 
 	return (
-		<div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
-			<HiCheckCircle className="h-12 w-12 text-green-500" />
-			<h1 className="text-2xl font-semibold">Payment Successful</h1>
-			<p className="text-muted-foreground">
-				Your subscription has been activated. You can now access all Pro
-				features.
-			</p>
+		<div className="flex flex-col items-center justify-center gap-6 py-16 text-center">
+			<div>
+				<h1 className="mb-2 text-2xl font-semibold">Billing</h1>
+				<p className="text-muted-foreground">
+					Manage your subscription and billing in the desktop app.
+				</p>
+			</div>
+			<div className="flex flex-wrap justify-center gap-3">
+				<Button size="lg" className="gap-2" asChild>
+					<a href={`${PROTOCOL_SCHEMES.PROD}://settings/billing`}>
+						Open in Desktop App
+						<ExternalLink className="size-4" />
+					</a>
+				</Button>
+				<Button variant="outline" size="lg" className="gap-2" asChild>
+					<a href={DOWNLOAD_URL_MAC_ARM64}>
+						Download for Mac
+						<Download className="size-4" />
+					</a>
+				</Button>
+			</div>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary

- **Fixes Slack impersonation vulnerability**: Previously, `runSlackAgent` always used `connectedByUserId` (the person who installed the integration) as the identity for MCP tool calls. Any Slack user in the workspace could act as that person. Now each request resolves the actual Superset user via the `usersSlackUsers` link table.
- **Gates Slack bot on Pro plan**: Both `process-mention` and `process-assistant-message` check for an active subscription before proceeding. Free orgs see an "Upgrade to Pro" button.
- **Requires account linking**: Unlinked Slack users see a "Connect Account" button (Block Kit) with an HMAC-signed connect URL instead of executing tools.
- **Extracts `generateConnectUrl` to shared utility**: Moved from `process-app-home-opened` to `utils/generate-connect-url/` so both entry points can reuse it.
- **Updates billing page**: Added deep link ("Open in Desktop App") and download buttons instead of just a text placeholder.

## Test plan

- [ ] Unlinked Slack user @mentions the bot → sees "Connect Account" button, no tools executed
- [ ] Free org user @mentions the bot → sees "Upgrade to Pro" button
- [ ] Linked Pro user @mentions the bot → works as before, using their own identity
- [ ] Same checks for DM (assistant message) flow
- [ ] Visit `/settings/billing` on web → see deep link + download buttons
- [ ] Visit `/settings/billing?success=true` → see payment success message (unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated Billing page: desktop app download, “Open in Desktop App” action, and refreshed payment success UI.

* **Improvements**
  * Slack interactions now require an active Pro subscription and prompt upgrades when absent.
  * Slack prompts users to connect their account when not linked and uses stored user preferences for agent interactions.

* **Refactor**
  * Connection URL generation and Slack agent invocation simplified and centralized for consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->