### PR TITLE
fix(desktop): fix git state mapping to wrong workspace in sidebar

### DIFF
--- a/.superset/setup.sh
+++ b/.superset/setup.sh
@@ -166,7 +166,7 @@ step_clone_local_db() {
     return 0
   fi
 
-  local source_db="$HOME/.superset-dev/local.db"
+  local source_db="$HOME/.superset/local.db"
   local dest_dir="$HOME/.superset-${sanitized}"
   local dest_db="$dest_dir/local.db"
 

--- a/apps/desktop/src/renderer/screens/main/hooks/useBranchSyncInvalidation/useBranchSyncInvalidation.ts
+++ b/apps/desktop/src/renderer/screens/main/hooks/useBranchSyncInvalidation/useBranchSyncInvalidation.ts
@@ -1,12 +1,6 @@
-import { useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 
-/**
- * Invalidates workspace-related caches when the git branch (from status polling)
- * diverges from the branch stored in the local DB workspace record.
- *
- * This keeps sidebar labels and hover cards in sync after external `git switch`.
- */
 export function useBranchSyncInvalidation({
 	gitBranch,
 	workspaceBranch,
@@ -17,13 +11,53 @@ export function useBranchSyncInvalidation({
 	workspaceId: string;
 }) {
 	const utils = electronTrpc.useUtils();
+	const { mutate } = electronTrpc.workspaces.syncBranch.useMutation();
+	const syncingRef = useRef<string | null>(null);
+
+	const doSync = useCallback(
+		(branch: string) => {
+			mutate(
+				{ workspaceId, branch },
+				{
+					onSuccess: (result) => {
+						if (!result.success || !("changed" in result) || !result.changed) {
+							syncingRef.current = null;
+							return;
+						}
+
+						utils.workspaces.getAllGrouped.setData(undefined, (oldData) => {
+							if (!oldData) return oldData;
+							return oldData.map((group) => ({
+								...group,
+								workspaces: group.workspaces.map((ws) =>
+									ws.id === workspaceId ? { ...ws, branch } : ws,
+								),
+							}));
+						});
+
+						utils.workspaces.get.invalidate({ id: workspaceId });
+						utils.workspaces.getWorktreeInfo.invalidate({
+							workspaceId,
+						});
+					},
+					onError: () => {
+						syncingRef.current = null;
+					},
+				},
+			);
+		},
+		[mutate, workspaceId, utils],
+	);
 
 	useEffect(() => {
 		if (!gitBranch || gitBranch === "HEAD" || !workspaceBranch) return;
-		if (gitBranch !== workspaceBranch) {
-			utils.workspaces.getAllGrouped.invalidate();
-			utils.workspaces.get.invalidate({ id: workspaceId });
-			utils.workspaces.getWorktreeInfo.invalidate({ workspaceId });
+		if (gitBranch === workspaceBranch) {
+			syncingRef.current = null;
+			return;
 		}
-	}, [gitBranch, workspaceBranch, workspaceId, utils]);
+		if (syncingRef.current === gitBranch) return;
+		syncingRef.current = gitBranch;
+
+		doSync(gitBranch);
+	}, [gitBranch, workspaceBranch, doSync]);
 }

--- a/bun.lock
+++ b/bun.lock
@@ -684,6 +684,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.3",
         "@superset/db": "workspace:*",
+        "@superset/shared": "workspace:*",
         "drizzle-orm": "0.45.1",
         "zod": "^4.3.5",
       },


### PR DESCRIPTION
## Summary
- **Root cause**: `syncWorkspaceBranch` inside the `getStatus` query used path-based worktree lookup instead of workspace ID, which could match the wrong DB record (no unique constraint on `worktrees.path`). This ran as a side effect on every 2.5s poll and every hover.
- **Cascade**: The mismatch triggered `useBranchSyncInvalidation` to call `invalidate(getAllGrouped)`, re-rendering all sidebar items and triggering accumulated queries in a loop — causing flickering diffs and wrong branch labels.
- **Fix**: Moved branch syncing to a dedicated `syncBranch` mutation using workspace ID, and replaced nuclear cache invalidation with in-place cache patching.

## Changes
- **`changes/status.ts`**: Removed `syncWorkspaceBranch` function and its call from `getStatus` — query is now a pure read with no DB side effects
- **`workspaces/procedures/status.ts`**: Added `syncBranch` mutation that looks up workspace by ID and updates both `workspaces.branch` and `worktrees.branch`
- **`useBranchSyncInvalidation.ts`**: Rewrote to call `syncBranch` mutation, patch `getAllGrouped` cache in-place via `setData`, and only invalidate the specific workspace's queries (with dedup guard via `syncingRef`)

## Test Plan
- [ ] Open app with multiple worktree workspaces for the same project
- [ ] Externally `git switch <branch>` in one worktree — sidebar branch label should update correctly
- [ ] Other workspaces should NOT change their branch labels
- [ ] Diff stats should stay stable (no flickering)
- [ ] Switch between workspaces — ChangesView should show correct data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an explicit branch sync action to reliably update workspace and worktree branch state when needed.

* **Refactor**
  * Removed implicit local-database side effects from status checks; status now proceeds without auto-syncing.
  * Sync now uses a guarded, mutation-driven flow that updates cached workspace state on change.

* **Bug Fixes**
  * Prevent duplicate concurrent branch syncs; only trigger sync when git and workspace branches differ.

* **Chores**
  * Adjusted default path for local Superset database clone.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->