### PR TITLE
refactor(mcp): remove redundant runtime validation in device tools

### DIFF
--- a/packages/mcp/src/tools/devices/create-workspace/create-workspace.ts
+++ b/packages/mcp/src/tools/devices/create-workspace/create-workspace.ts
@@ -41,18 +41,6 @@ export function register(server: McpServer) {
 				typeof workspaceInputSchema
 			>[];
 
-			if (!deviceId || !projectId) {
-				return {
-					content: [
-						{
-							type: "text",
-							text: "Error: deviceId and projectId are required",
-						},
-					],
-					isError: true,
-				};
-			}
-
 			return executeOnDevice({
 				ctx,
 				deviceId,

--- a/packages/mcp/src/tools/devices/delete-workspace/delete-workspace.ts
+++ b/packages/mcp/src/tools/devices/delete-workspace/delete-workspace.ts
@@ -21,13 +21,6 @@ export function register(server: McpServer) {
 			const deviceId = args.deviceId as string;
 			const workspaceIds = args.workspaceIds as string[];
 
-			if (!deviceId) {
-				return {
-					content: [{ type: "text", text: "Error: deviceId is required" }],
-					isError: true,
-				};
-			}
-
 			return executeOnDevice({
 				ctx,
 				deviceId,

--- a/packages/mcp/src/tools/devices/get-app-context/get-app-context.ts
+++ b/packages/mcp/src/tools/devices/get-app-context/get-app-context.ts
@@ -16,13 +16,6 @@ export function register(server: McpServer) {
 			const ctx = getMcpContext(extra);
 			const deviceId = args.deviceId as string;
 
-			if (!deviceId) {
-				return {
-					content: [{ type: "text", text: "Error: deviceId is required" }],
-					isError: true,
-				};
-			}
-
 			return executeOnDevice({
 				ctx,
 				deviceId,

--- a/packages/mcp/src/tools/devices/list-projects/list-projects.ts
+++ b/packages/mcp/src/tools/devices/list-projects/list-projects.ts
@@ -15,13 +15,6 @@ export function register(server: McpServer) {
 			const ctx = getMcpContext(extra);
 			const deviceId = args.deviceId as string;
 
-			if (!deviceId) {
-				return {
-					content: [{ type: "text", text: "Error: deviceId is required" }],
-					isError: true,
-				};
-			}
-
 			return executeOnDevice({
 				ctx,
 				deviceId,

--- a/packages/mcp/src/tools/devices/list-workspaces/list-workspaces.ts
+++ b/packages/mcp/src/tools/devices/list-workspaces/list-workspaces.ts
@@ -15,13 +15,6 @@ export function register(server: McpServer) {
 			const ctx = getMcpContext(extra);
 			const deviceId = args.deviceId as string;
 
-			if (!deviceId) {
-				return {
-					content: [{ type: "text", text: "Error: deviceId is required" }],
-					isError: true,
-				};
-			}
-
 			return executeOnDevice({
 				ctx,
 				deviceId,

--- a/packages/mcp/src/tools/devices/navigate-to-workspace/navigate-to-workspace.ts
+++ b/packages/mcp/src/tools/devices/navigate-to-workspace/navigate-to-workspace.ts
@@ -26,13 +26,6 @@ export function register(server: McpServer) {
 			const workspaceId = args.workspaceId as string | undefined;
 			const workspaceName = args.workspaceName as string | undefined;
 
-			if (!deviceId) {
-				return {
-					content: [{ type: "text", text: "Error: deviceId is required" }],
-					isError: true,
-				};
-			}
-
 			if (!workspaceId && !workspaceName) {
 				return {
 					content: [

--- a/packages/mcp/src/tools/devices/switch-workspace/switch-workspace.ts
+++ b/packages/mcp/src/tools/devices/switch-workspace/switch-workspace.ts
@@ -26,13 +26,6 @@ export function register(server: McpServer) {
 			const workspaceId = args.workspaceId as string | undefined;
 			const workspaceName = args.workspaceName as string | undefined;
 
-			if (!deviceId) {
-				return {
-					content: [{ type: "text", text: "Error: deviceId is required" }],
-					isError: true,
-				};
-			}
-
 			if (!workspaceId && !workspaceName) {
 				return {
 					content: [

--- a/packages/mcp/src/tools/devices/update-workspace/update-workspace.ts
+++ b/packages/mcp/src/tools/devices/update-workspace/update-workspace.ts
@@ -27,13 +27,6 @@ export function register(server: McpServer) {
 			const deviceId = args.deviceId as string;
 			const updates = args.updates as z.infer<typeof workspaceUpdateSchema>[];
 
-			if (!deviceId) {
-				return {
-					content: [{ type: "text", text: "Error: deviceId is required" }],
-					isError: true,
-				};
-			}
-
 			return executeOnDevice({
 				ctx,
 				deviceId,


### PR DESCRIPTION
## Summary
- Removes manual `if (!deviceId)` runtime checks from 8 MCP device tools
- Zod schema validation already enforces required fields before handlers run, making these checks dead code
- Affected tools: `get_app_context`, `list_workspaces`, `list_projects`, `create_workspace`, `delete_workspace`, `navigate_to_workspace`, `switch_workspace`, `update_workspace`

## Test plan
- [x] Typecheck passes
- [x] Stress tested all MCP tools — all read/write paths working

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified input validation logic across device management tools for workspace and project operations. Removed redundant runtime validation checks that duplicate existing schema-level constraints, reducing code complexity and streamlining execution flow. System validation requirements remain enforced through the input schema, maintaining data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->