### PR TITLE
feat(api): scope API keys to organization in Electric sync

### DIFF
--- a/apps/api/src/app/api/electric/[...path]/utils.ts
+++ b/apps/api/src/app/api/electric/[...path]/utils.ts
@@ -1,7 +1,6 @@
 import { db } from "@superset/db/client";
 import {
 	agentCommands,
-	apikeys,
 	devicePresence,
 	integrationConnections,
 	invitations,
@@ -109,8 +108,10 @@ export async function buildWhereClause(
 		case "agent_commands":
 			return build(agentCommands, agentCommands.organizationId, organizationId);
 
-		case "auth.apikeys":
-			return build(apikeys, apikeys.userId, userId);
+		case "auth.apikeys": {
+			const fragment = `"metadata"::jsonb->>'organizationId' = $1`;
+			return { fragment, params: [organizationId] };
+		}
 
 		case "integration_connections":
 			return build(


### PR DESCRIPTION
## Summary
- Filter Electric SQL apikeys shape by `organizationId` extracted from the metadata JSON field instead of `userId`
- Users now only see API keys belonging to the active organization, not all their keys across orgs

## Details
The `metadata` column already stores `organizationId` (set at key creation time via tRPC). This change uses Postgres JSON extraction (`metadata::jsonb->>'organizationId'`) in the Electric WHERE clause to filter server-side, matching the pattern used by all other org-scoped tables.

No schema migration needed — uses the existing metadata field.

## Test plan
- [ ] Create API keys in two different organizations
- [ ] Verify each org's settings page only shows its own keys
- [ ] Verify MCP auth still works (agent route reads organizationId from metadata independently)

Linear: SUPER-286

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-organization API key management and display: API keys are now surfaced and managed per organization.

* **Refactor**
  * Streamlined API key access filtering for improved organization-level access control and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->