### PR TITLE
fix: upgrade Electric VM to performance-4x

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -5,12 +5,13 @@ primary_region = "iad"
 image = "electricsql/electric:1.4.3"
 
 [[vm]]
-memory = "4096mb"
-cpu_kind = "shared"
-cpus = 2
+memory = "8192mb"
+cpu_kind = "performance"
+cpus = 4
 
 [env]
 ELECTRIC_DATABASE_USE_IPV6 = "true"
+ELECTRIC_MAX_CONCURRENT_REQUESTS = '{"initial": 3000, "existing": 10000}'
 
 [http_service]
 internal_port = 3000


### PR DESCRIPTION
## Summary
- Upgrade Electric VM from shared/2cpu/4GB to performance/4cpu/8GB
- Add `ELECTRIC_MAX_CONCURRENT_REQUESTS` config (3000 initial, 10000 existing)

The previous deploy-production run downgraded the machine back to the smaller size, causing degraded metrics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced infrastructure performance and capacity by scaling computational resources and upgrading system configurations for improved request handling and application responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->