### PR TITLE
chore(electric-proxy): local dev setup and worker cleanup

### DIFF
--- a/apps/electric-proxy/src/env.ts
+++ b/apps/electric-proxy/src/env.ts
@@ -1,0 +1,7 @@
+export interface Env {
+	JWKS_URL: string;
+	JWT_ISSUER: string;
+	JWT_AUDIENCE: string;
+	ELECTRIC_URL: string;
+	ELECTRIC_SECRET?: string;
+}

--- a/apps/electric-proxy/src/index.ts
+++ b/apps/electric-proxy/src/index.ts
@@ -1,13 +1,8 @@
 import { verifyJWT } from "./auth";
+import type { Env } from "./env";
 import { buildWhereClause } from "./where-clauses";
 
-export interface Env {
-	JWKS_URL: string;
-	JWT_ISSUER: string;
-	JWT_AUDIENCE: string;
-	ELECTRIC_URL: string;
-	ELECTRIC_SECRET: string;
-}
+export type { Env } from "./env";
 
 const ELECTRIC_PROTOCOL_PARAMS = new Set([
 	"live",
@@ -100,8 +95,8 @@ export default {
 			return corsResponse(400, `Unknown table: ${table}`);
 		}
 
+		// Build Electric query params
 		const originUrl = new URL(env.ELECTRIC_URL);
-		originUrl.searchParams.set("secret", env.ELECTRIC_SECRET);
 		originUrl.searchParams.set("table", table);
 		originUrl.searchParams.set("where", whereClause.fragment);
 
@@ -117,6 +112,10 @@ export default {
 			if (ELECTRIC_PROTOCOL_PARAMS.has(key)) {
 				originUrl.searchParams.set(key, value);
 			}
+		}
+
+		if (env.ELECTRIC_SECRET) {
+			originUrl.searchParams.set("secret", env.ELECTRIC_SECRET);
 		}
 
 		const response = await fetch(originUrl.toString(), {

--- a/apps/electric-proxy/wrangler.jsonc
+++ b/apps/electric-proxy/wrangler.jsonc
@@ -2,10 +2,13 @@
 	"name": "electric-proxy",
 	"account_id": "6ac34a81594ea52ff7ed2f24b9108e41",
 	"main": "src/index.ts",
-	"compatibility_date": "2025-01-01",
+	"compatibility_date": "2026-02-12",
 	"vars": {
 		"JWKS_URL": "https://api.superset.sh/api/auth/jwks",
 		"JWT_ISSUER": "https://api.superset.sh",
 		"JWT_AUDIENCE": "https://api.superset.sh"
+	},
+	"observability": {
+		"enabled": true
 	}
 }


### PR DESCRIPTION
## Summary
- Wire up electric-proxy for local dev with `bun dev` (wrangler dev, Caddy HTTP/2 proxy, .dev.vars generation)
- Caddy now proxies electric-proxy (HTTP/2 for SSE multiplexing) instead of the API server
- Extract `Env` interface to dedicated file, enable Cloudflare observability
- Make `ELECTRIC_SECRET` optional for local dev

## Changes
- **`.superset/setup.sh`** — Generate `apps/electric-proxy/.dev.vars` with local Electric/auth URLs; Caddy now reverse-proxies wrangler dev instead of the API server; add `ELECTRIC_PROXY_PORT` and `CADDY_ELECTRIC_PORT`
- **`package.json`** — Include `@superset/electric-proxy` in `bun dev`
- **`turbo.jsonc`** — Add `NEXT_PUBLIC_ELECTRIC_URL` and `ELECTRIC_PROXY_PORT` to global env
- **`apps/electric-proxy/package.json`** — Dev script reads port from `.env` via dotenv
- **`apps/electric-proxy/src/env.ts`** — Extracted `Env` interface
- **`apps/electric-proxy/src/index.ts`** — Import from env.ts, make secret conditional
- **`apps/electric-proxy/wrangler.jsonc`** — Bump compat date, enable observability
- **`.gitignore`** — Ignore `.dev.vars`

## Test Plan
- [ ] Run `.superset/setup.sh` — verify `.dev.vars` generated in `apps/electric-proxy/`
- [ ] Run `bun dev` — verify electric-proxy starts alongside other services
- [ ] Desktop app connects to Electric via Caddy HTTPS proxy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Made the electric secret parameter optional, resolving configuration issues when the secret is not provided.

* **Chores**
  * Enabled observability for improved monitoring and diagnostics.
  * Updated platform compatibility to the latest version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->