### PR TITLE
fix(desktop): preserve permission status when tab is focused

### DIFF
--- a/apps/desktop/src/shared/tabs-types.ts
+++ b/apps/desktop/src/shared/tabs-types.ts
@@ -73,13 +73,12 @@ export function getHighestPriorityStatus(
  * (e.g. clicking a tab, focusing a pane, selecting a workspace).
  *
  * - "review"     → "idle"    (user saw the completion)
- * - "permission" → "working" (user saw the prompt; assume granted)
+ * - "permission" → unchanged (persists until agent resumes)
  * - "working"    → unchanged (persists until agent stops)
  * - "idle"       → unchanged
  */
 export function acknowledgedStatus(status: PaneStatus | undefined): PaneStatus {
 	if (status === "review") return "idle";
-	if (status === "permission") return "working";
 	return status ?? "idle";
 }
 


### PR DESCRIPTION
## Summary
- The "permission" pane status was being downgraded to "working" when the user clicked on or focused a tab
- This caused the red permission indicator to disappear prematurely, before the user actually granted/denied the permission
- Now the permission indicator persists until the agent resumes (Start event) or the terminal exits

## Changes
- **`apps/desktop/src/shared/tabs-types.ts`**: Removed the `"permission" → "working"` transition from `acknowledgedStatus()` so that focusing a tab no longer clears the permission indicator

## Test Plan
- [ ] Start an agent session that triggers a permission request
- [ ] Click away from the tab, then click back — verify the red permission indicator persists
- [ ] Grant or deny the permission — verify the indicator updates correctly (clears on agent resume or terminal exit)
- [ ] Verify "review" status still clears to "idle" when focusing the tab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed status handling to correctly preserve permission state during operations instead of converting it, ensuring proper state persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->