### PR TITLE
feat(setup): clone local SQLite database when creating new worktree

### DIFF
--- a/.superset/setup.sh
+++ b/.superset/setup.sh
@@ -159,14 +159,14 @@ step_clone_local_db() {
   local sanitized
   sanitized=$(echo "$WORKSPACE_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | cut -c1-32)
 
-  # "superset" is the default (production) — no suffix, so no clone needed
-  if [ -z "$sanitized" ] || [ "$sanitized" = "superset" ]; then
-    warn "Default workspace — skipping local DB clone"
+  # "superset" is the default (production), "dev" is the dev workspace — skip cloning from self
+  if [ -z "$sanitized" ] || [ "$sanitized" = "superset" ] || [ "$sanitized" = "dev" ]; then
+    warn "Default/dev workspace — skipping local DB clone"
     step_skipped "Clone local database"
     return 0
   fi
 
-  local source_db="$HOME/.superset/local.db"
+  local source_db="$HOME/.superset-dev/local.db"
   local dest_dir="$HOME/.superset-${sanitized}"
   local dest_db="$dest_dir/local.db"
 


### PR DESCRIPTION
## Summary
- When creating a new worktree, the setup script now copies `~/.superset/local.db` to `~/.superset-<workspace>/local.db`
- New worktrees start with existing data (projects, settings, synced tables) instead of an empty database
- Each dev worktree gets its own isolated SQLite home dir via `SUPERSET_DIR_NAME` (e.g., `~/.superset-my-branch/`)

## Changes
- `.superset/setup.sh`: Added `step_clone_local_db()` function (new Step 4) that:
  - Sanitizes workspace name matching `env.shared.ts` `getWorkspaceName()` logic
  - Copies `local.db` + WAL/SHM files with secure permissions (700/600)
  - Skips if destination already exists, source is missing, or workspace is default
  - Renumbered subsequent steps (5-7)

## Test Plan
- [ ] Create a new workspace and verify `~/.superset-<name>/local.db` is copied from `~/.superset/local.db`
- [ ] Verify existing worktrees with an existing `local.db` are not overwritten
- [ ] Verify the default "superset" workspace skips the clone step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Setup now automatically clones a local SQLite database into each workspace during initialization, including handling of auxiliary DB files and secure permissions for created files/directories.
  * The setup sequence has been reordered so local DB cloning occurs earlier; subsequent setup steps (branch setup, service start, and environment file write) run after the clone.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->