### PR TITLE
fix(docs): remove unused billing env vars that break search API

### DIFF
--- a/apps/docs/src/env.ts
+++ b/apps/docs/src/env.ts
@@ -11,11 +11,6 @@ export const env = createEnv({
 	},
 
 	server: {
-		STRIPE_SECRET_KEY: z.string().optional(),
-		STRIPE_WEBHOOK_SECRET: z.string().optional(),
-		STRIPE_PRO_MONTHLY_PRICE_ID: z.string().optional(),
-		STRIPE_PRO_YEARLY_PRICE_ID: z.string().optional(),
-		SLACK_BILLING_WEBHOOK_URL: z.string().url(),
 		SENTRY_AUTH_TOKEN: z.string().optional(),
 	},
 


### PR DESCRIPTION
## Summary
- Removed unused billing env vars (`SLACK_BILLING_WEBHOOK_URL`, Stripe keys) from the docs app's `env.ts`
- `SLACK_BILLING_WEBHOOK_URL` was **required** (non-optional) but never set in the Vercel deployment, causing the Sentry instrumentation hook to crash on startup
- This made all server-rendered routes — including `/api/search` — return 500, completely breaking docs search

## Test plan
- [ ] Deploy to Vercel preview and verify `/api/search?query=workspace` returns results instead of 500
- [ ] Verify search dialog works on docs site

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed five server environment variables related to payments and billing, simplifying deployment and reducing required configuration.
* **Tests**
  * Stabilized terminal-related tests by consolidating mocks to avoid duplicate registrations and flaky CI.
  * Added test setup stubs for database/ORM imports to prevent runtime crashes during test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->