### PR TITLE
fix(desktop): prevent row click navigation on table cell dropdowns

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/hooks/useTasksTable/components/AssigneeCell/AssigneeCell.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/hooks/useTasksTable/components/AssigneeCell/AssigneeCell.tsx
@@ -46,7 +46,11 @@ export function AssigneeCell({ info }: AssigneeCellProps) {
 	return (
 		<DropdownMenu open={open} onOpenChange={setOpen}>
 			<DropdownMenuTrigger asChild>
-				<button type="button" className="cursor-pointer">
+				<button
+					type="button"
+					className="cursor-pointer"
+					onClick={(e) => e.stopPropagation()}
+				>
 					{task.assignee ? (
 						<Avatar
 							size="xs"
@@ -58,7 +62,11 @@ export function AssigneeCell({ info }: AssigneeCellProps) {
 					)}
 				</button>
 			</DropdownMenuTrigger>
-			<DropdownMenuContent align="start" className="w-56">
+			<DropdownMenuContent
+				align="start"
+				className="w-56"
+				onClick={(e) => e.stopPropagation()}
+			>
 				<div className="max-h-64 overflow-y-auto">
 					<DropdownMenuItem
 						onSelect={() => handleSelectUser(null)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/hooks/useTasksTable/components/PriorityCell/PriorityCell.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/hooks/useTasksTable/components/PriorityCell/PriorityCell.tsx
@@ -55,6 +55,7 @@ export function PriorityCell({ info }: PriorityCellProps) {
 					type="button"
 					className="group p-0 cursor-pointer border-0 transition-all"
 					title={PRIORITY_LABELS[currentPriority]}
+					onClick={(e) => e.stopPropagation()}
 				>
 					<PriorityIcon
 						priority={currentPriority}
@@ -63,7 +64,11 @@ export function PriorityCell({ info }: PriorityCellProps) {
 					/>
 				</button>
 			</DropdownMenuTrigger>
-			<DropdownMenuContent align="start" className="w-52 p-1">
+			<DropdownMenuContent
+				align="start"
+				className="w-52 p-1"
+				onClick={(e) => e.stopPropagation()}
+			>
 				{ALL_PRIORITIES.map((priority) => (
 					<DropdownMenuItem
 						key={priority}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/hooks/useTasksTable/components/StatusCell/StatusCell.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/hooks/useTasksTable/components/StatusCell/StatusCell.tsx
@@ -55,7 +55,11 @@ export function StatusCell({ taskWithStatus }: StatusCellProps) {
 	return (
 		<DropdownMenu open={open} onOpenChange={setOpen}>
 			<DropdownMenuTrigger asChild>
-				<button type="button" className="p-0 cursor-pointer border-0">
+				<button
+					type="button"
+					className="p-0 cursor-pointer border-0"
+					onClick={(e) => e.stopPropagation()}
+				>
 					<StatusIcon
 						type={currentStatus.type as StatusType}
 						color={currentStatus.color}
@@ -64,7 +68,11 @@ export function StatusCell({ taskWithStatus }: StatusCellProps) {
 					/>
 				</button>
 			</DropdownMenuTrigger>
-			<DropdownMenuContent align="start" className="w-48 p-1">
+			<DropdownMenuContent
+				align="start"
+				className="w-48 p-1"
+				onClick={(e) => e.stopPropagation()}
+			>
 				<div className="max-h-64 overflow-y-auto">
 					<StatusMenuItems
 						statuses={sortedStatuses}


### PR DESCRIPTION
## Summary
- Stop click events from propagating to the row's `onClick` (which navigates to task details) when interacting with status, priority, and assignee dropdown menus in the tasks table view
- Added `stopPropagation` on both dropdown triggers (for opening the menu) and `DropdownMenuContent` (for selecting items — needed because React portals bubble synthetic events through the React component tree, not the DOM tree)

## Test plan
- [ ] Click a status/priority/assignee dropdown trigger in the tasks table — dropdown opens without navigating
- [ ] Select an item from the dropdown — value updates without navigating to task details
- [ ] Click anywhere else on the row (title, slug, empty space) — still navigates to task details

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed dropdown menu behavior in the Tasks view where selections in Assignee, Priority, and Status fields no longer trigger unintended cascading actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->