### PR TITLE
feat(desktop): show hotkey in preset bar tooltip

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar/PresetsBar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar/PresetsBar.tsx
@@ -6,7 +6,9 @@ import {
 	getPresetIcon,
 	useIsDarkTheme,
 } from "renderer/assets/app-icons/preset-icons";
+import { HotkeyTooltipContent } from "renderer/components/HotkeyTooltipContent/HotkeyTooltipContent";
 import { usePresets } from "renderer/react-query/presets";
+import { PRESET_HOTKEY_IDS } from "renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/usePresetHotkeys";
 import { useTabsWithPresets } from "renderer/stores/tabs/useTabsWithPresets";
 
 export function PresetsBar() {
@@ -22,8 +24,10 @@ export function PresetsBar() {
 			className="flex items-center h-8 border-b border-border bg-background px-2 gap-0.5 overflow-x-auto shrink-0"
 			style={{ scrollbarWidth: "none" }}
 		>
-			{presets.map((preset) => {
+			{presets.map((preset, index) => {
 				const icon = getPresetIcon(preset.name, isDark);
+				const hotkeyId = PRESET_HOTKEY_IDS[index];
+				const label = preset.description || preset.name || "default";
 				return (
 					<Tooltip key={preset.id}>
 						<TooltipTrigger asChild>
@@ -47,11 +51,9 @@ export function PresetsBar() {
 								</span>
 							</Button>
 						</TooltipTrigger>
-						{preset.description && (
-							<TooltipContent side="bottom" sideOffset={4}>
-								{preset.description}
-							</TooltipContent>
-						)}
+						<TooltipContent side="bottom" sideOffset={4}>
+							<HotkeyTooltipContent label={label} hotkeyId={hotkeyId} />
+						</TooltipContent>
 					</Tooltip>
 				);
 			})}


### PR DESCRIPTION
## Summary
- Show the corresponding keyboard shortcut (e.g. `Ctrl+1`) in the preset bar tooltip
- Tooltip now always displays (previously only shown when preset had a description)
- Reuses `HotkeyTooltipContent` component for consistent hotkey rendering across the app

## Changes
- **`PresetsBar.tsx`**: Import `HotkeyTooltipContent` and `PRESET_HOTKEY_IDS`, use preset index to look up the hotkey, and render it alongside the preset label in the tooltip

## Test Plan
- [ ] Hover over preset bar items and verify the tooltip shows both the label and the hotkey (e.g. `Claude Code ⌃1`)
- [ ] Verify presets beyond index 9 show tooltip without a hotkey
- [ ] Verify presets with no description fall back to showing the preset name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hotkey information to preset tooltips, making keyboard shortcuts easily discoverable for faster preset access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->