### PR TITLE
feat(desktop): add Open in workspace button to task detail

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/PropertiesSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/PropertiesSidebar.tsx
@@ -2,6 +2,7 @@ import { Badge } from "@superset/ui/badge";
 import { ScrollArea } from "@superset/ui/scroll-area";
 import type { TaskWithStatus } from "../../../components/TasksView/hooks/useTasksTable";
 import { AssigneeProperty } from "./components/AssigneeProperty";
+import { OpenInWorkspace } from "./components/OpenInWorkspace";
 import { PriorityProperty } from "./components/PriorityProperty";
 import { StatusProperty } from "./components/StatusProperty";
 
@@ -41,6 +42,8 @@ export function PropertiesSidebar({ task }: PropertiesSidebarProps) {
 							<span className="text-sm text-muted-foreground">No labels</span>
 						)}
 					</div>
+
+					<OpenInWorkspace task={task} />
 				</div>
 			</ScrollArea>
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/OpenInWorkspace/OpenInWorkspace.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/OpenInWorkspace/OpenInWorkspace.tsx
@@ -1,0 +1,169 @@
+import { Button } from "@superset/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import { toast } from "@superset/ui/sonner";
+import { useEffect, useState } from "react";
+import { HiArrowRight, HiChevronDown } from "react-icons/hi2";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useCreateWorkspace } from "renderer/react-query/workspaces";
+import { ProjectThumbnail } from "renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectThumbnail";
+import { useWorkspaceInitStore } from "renderer/stores/workspace-init";
+import type { TaskWithStatus } from "../../../../../components/TasksView/hooks/useTasksTable";
+import { buildClaudeCommand } from "../../../../utils/buildClaudeCommand";
+import { deriveBranchName } from "../../../../utils/deriveBranchName";
+
+interface OpenInWorkspaceProps {
+	task: TaskWithStatus;
+}
+
+export function OpenInWorkspace({ task }: OpenInWorkspaceProps) {
+	const { data: recentProjects = [] } =
+		electronTrpc.projects.getRecents.useQuery();
+	const createWorkspace = useCreateWorkspace();
+	const [selectedProjectId, setSelectedProjectId] = useState<string | null>(
+		null,
+	);
+
+	// Default to the first recent project
+	const effectiveProjectId = selectedProjectId ?? recentProjects[0]?.id ?? null;
+	const selectedProject = recentProjects.find(
+		(p) => p.id === effectiveProjectId,
+	);
+
+	// Sync default once projects load
+	useEffect(() => {
+		if (!selectedProjectId && recentProjects.length > 0) {
+			setSelectedProjectId(recentProjects[0].id);
+		}
+	}, [selectedProjectId, recentProjects]);
+
+	const handleOpen = async () => {
+		if (!effectiveProjectId) return;
+		await handleSelectProject(effectiveProjectId);
+	};
+
+	const handleSelectProject = async (projectId: string) => {
+		const branchName = deriveBranchName({
+			slug: task.slug,
+			title: task.title,
+		});
+
+		try {
+			const result = await createWorkspace.mutateAsync({
+				projectId,
+				name: task.slug,
+				branchName,
+			});
+
+			if (!result.wasExisting) {
+				const command = buildClaudeCommand({
+					task: {
+						id: task.id,
+						slug: task.slug,
+						title: task.title,
+						description: task.description,
+						priority: task.priority,
+						statusName: task.status.name,
+						labels: task.labels,
+					},
+					randomId: window.crypto.randomUUID(),
+				});
+
+				const store = useWorkspaceInitStore.getState();
+				const pending = store.pendingTerminalSetups[result.workspace.id];
+				store.addPendingTerminalSetup({
+					workspaceId: result.workspace.id,
+					projectId: result.projectId,
+					initialCommands: [...(pending?.initialCommands ?? []), command],
+					defaultPresets: pending?.defaultPresets,
+				});
+			}
+
+			toast.success(
+				result.wasExisting ? "Opened existing workspace" : "Workspace created",
+			);
+		} catch (err) {
+			toast.error(
+				err instanceof Error ? err.message : "Failed to create workspace",
+			);
+		}
+	};
+
+	return (
+		<div className="flex flex-col gap-2">
+			<span className="text-xs text-muted-foreground">Open in workspace</span>
+			<div className="flex gap-1.5">
+				<DropdownMenu>
+					<DropdownMenuTrigger asChild>
+						<Button
+							variant="outline"
+							size="sm"
+							className="flex-1 justify-between font-normal h-8 min-w-0"
+						>
+							<span className="flex items-center gap-2 truncate">
+								{selectedProject ? (
+									<>
+										<ProjectThumbnail
+											projectId={selectedProject.id}
+											projectName={selectedProject.name}
+											projectColor={selectedProject.color}
+											githubOwner={selectedProject.githubOwner}
+											hideImage={selectedProject.hideImage ?? undefined}
+											iconUrl={selectedProject.iconUrl}
+											className="size-4"
+										/>
+										<span className="truncate">{selectedProject.name}</span>
+									</>
+								) : (
+									<span className="text-muted-foreground">Select project</span>
+								)}
+							</span>
+							<HiChevronDown className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+						</Button>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent
+						align="start"
+						className="w-[--radix-dropdown-menu-trigger-width]"
+					>
+						{recentProjects.length === 0 ? (
+							<DropdownMenuItem disabled>No projects found</DropdownMenuItem>
+						) : (
+							recentProjects
+								.filter((p) => p.id)
+								.map((project) => (
+									<DropdownMenuItem
+										key={project.id}
+										onClick={() => setSelectedProjectId(project.id)}
+										className="flex items-center gap-2"
+									>
+										<ProjectThumbnail
+											projectId={project.id}
+											projectName={project.name}
+											projectColor={project.color}
+											githubOwner={project.githubOwner}
+											hideImage={project.hideImage ?? undefined}
+											iconUrl={project.iconUrl}
+											className="size-4"
+										/>
+										{project.name}
+									</DropdownMenuItem>
+								))
+						)}
+					</DropdownMenuContent>
+				</DropdownMenu>
+				<Button
+					size="icon"
+					className="h-8 w-8 shrink-0"
+					disabled={!effectiveProjectId || createWorkspace.isPending}
+					onClick={handleOpen}
+				>
+					<HiArrowRight className="w-3.5 h-3.5" />
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/OpenInWorkspace/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/OpenInWorkspace/index.ts
@@ -1,0 +1,1 @@
+export { OpenInWorkspace } from "./OpenInWorkspace";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/utils/buildClaudeCommand.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/utils/buildClaudeCommand.ts
@@ -1,0 +1,1 @@
+export { buildClaudeCommand } from "@superset/shared/claude-command";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/utils/deriveBranchName.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/utils/deriveBranchName.ts
@@ -1,0 +1,13 @@
+import { sanitizeSegment } from "shared/utils/branch";
+
+export function deriveBranchName({
+	slug,
+	title,
+}: {
+	slug: string;
+	title: string;
+}): string {
+	const prefix = slug.toLowerCase();
+	const titleSegment = sanitizeSegment(title, 40);
+	return titleSegment ? `${prefix}-${titleSegment}` : prefix;
+}

--- a/bun.lock
+++ b/bun.lock
@@ -666,6 +666,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.3",
         "@superset/db": "workspace:*",
+        "@superset/shared": "workspace:*",
         "drizzle-orm": "0.45.1",
         "zod": "^4.3.5",
       },

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -23,6 +23,7 @@
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.25.3",
 		"@superset/db": "workspace:*",
+		"@superset/shared": "workspace:*",
 		"drizzle-orm": "0.45.1",
 		"zod": "^4.3.5"
 	},

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -19,6 +19,10 @@
 		"./auth": {
 			"types": "./src/auth/index.ts",
 			"default": "./src/auth/index.ts"
+		},
+		"./claude-command": {
+			"types": "./src/claude-command.ts",
+			"default": "./src/claude-command.ts"
 		}
 	},
 	"scripts": {

--- a/packages/shared/src/claude-command.ts
+++ b/packages/shared/src/claude-command.ts
@@ -1,0 +1,56 @@
+interface TaskInput {
+	id: string;
+	slug: string;
+	title: string;
+	description: string | null;
+	priority: string;
+	statusName: string | null;
+	labels: string[] | null;
+}
+
+export function buildClaudeCommand({
+	task,
+	randomId,
+}: {
+	task: TaskInput;
+	randomId: string;
+}): string {
+	const metadata = [
+		`Priority: ${task.priority}`,
+		task.statusName && `Status: ${task.statusName}`,
+		task.labels?.length && `Labels: ${task.labels.join(", ")}`,
+	]
+		.filter(Boolean)
+		.join("\n");
+
+	const prompt = `You are working on task "${task.title}" (${task.slug}).
+
+${metadata}
+
+## Task Description
+
+${task.description || "No description provided."}
+
+## Instructions
+
+You are running fully autonomously. Do not ask questions or wait for user feedback — make all decisions independently based on the codebase and task description.
+
+1. Explore the codebase to understand the relevant code and architecture
+2. Create a detailed execution plan for this task including:
+   - Purpose and scope of the changes
+   - Key assumptions
+   - Concrete implementation steps with specific files to modify
+   - How to validate the changes work correctly
+3. Implement the plan
+4. Verify your changes work correctly (run relevant tests, typecheck, lint)
+5. When done, use the Superset MCP \`update_task\` tool to update task "${task.id}" with a summary of what was done`;
+
+	const delimiter = `SUPERSET_PROMPT_${randomId.replaceAll("-", "")}`;
+
+	return [
+		`claude --dangerously-skip-permissions "$(cat <<'${delimiter}'`,
+		prompt,
+		delimiter,
+		')"',
+	].join("\n");
+}


### PR DESCRIPTION
## Summary
- Adds an "Open in workspace" control to the task detail properties sidebar — a project dropdown (defaults to most recent, shows project icons) plus a go button that creates a workspace and launches an autonomous Claude session with full task context
- Consolidates the Claude command prompt template into `@superset/shared/claude-command` so both the MCP server and desktop renderer share a single source of truth instead of duplicated copies

## Test plan
- [ ] Open desktop app, navigate to a task detail page
- [ ] Verify the "Open in workspace" section appears in the properties sidebar with a project dropdown defaulting to the most recent project
- [ ] Select a different project from the dropdown, verify project icons render
- [ ] Click the arrow button — verify a workspace is created, the app navigates to it, and Claude starts in the terminal with task context
- [ ] Verify `bun run typecheck` passes for both `@superset/mcp` and `@superset/desktop`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Open in Workspace" functionality in the task sidebar with project selection and workspace creation capabilities
  * Integrated Claude command execution support for task automation
  * Automatic branch name generation from task information
  * Enhanced workspace handling with success and error notifications
<!-- end of auto-generated comment: release notes by coderabbit.ai -->