### PR TITLE
fix(desktop): invalidate workspace nav queries after reorder

### DIFF
--- a/apps/desktop/src/renderer/react-query/projects/useReorderProjects.ts
+++ b/apps/desktop/src/renderer/react-query/projects/useReorderProjects.ts
@@ -13,6 +13,8 @@ export function useReorderProjects(
 		...options,
 		onSuccess: async (...args) => {
 			await utils.workspaces.getAllGrouped.invalidate();
+			await utils.workspaces.getPreviousWorkspace.invalidate();
+			await utils.workspaces.getNextWorkspace.invalidate();
 			await utils.projects.getRecents.invalidate();
 			await options?.onSuccess?.(...args);
 		},

--- a/apps/desktop/src/renderer/react-query/workspaces/useReorderWorkspaces.ts
+++ b/apps/desktop/src/renderer/react-query/workspaces/useReorderWorkspaces.ts
@@ -14,6 +14,8 @@ export function useReorderWorkspaces(
 		onSuccess: async (...args) => {
 			await utils.workspaces.getAll.invalidate();
 			await utils.workspaces.getAllGrouped.invalidate();
+			await utils.workspaces.getPreviousWorkspace.invalidate();
+			await utils.workspaces.getNextWorkspace.invalidate();
 			await options?.onSuccess?.(...args);
 		},
 	});


### PR DESCRIPTION
## Summary
- After dragging workspaces or projects to reorder in the sidebar, `getPreviousWorkspace` and `getNextWorkspace` tRPC queries were not invalidated
- This caused ⌘↑/⌘↓ keyboard navigation to use the stale (pre-drag) order
- Added cache invalidation for both navigation queries in `useReorderWorkspaces` and `useReorderProjects`

## Reproduction steps
1. Have 3+ workspaces in a project
2. Note which workspace is below the current one
3. Drag a workspace in the sidebar to reorder it (e.g. move the bottom one to the top)
4. Press ⌘↓ to navigate to the next workspace
5. **Before fix:** navigates based on the old order, not the new visual order
6. **After fix:** navigates to the correct next workspace per the new order

## Test plan
- [ ] Reorder workspaces via drag-and-drop, verify ⌘↑/⌘↓ navigates in the new order
- [ ] Reorder projects via drag-and-drop, verify ⌘↑/⌘↓ navigates in the new order

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved data consistency when reordering projects and workspaces by ensuring related caches are properly refreshed after reorder operations complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->