### PR TITLE
fix(desktop): only show ports in sidebar when actively in use

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/hooks/usePortsData.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/hooks/usePortsData.ts
@@ -114,10 +114,10 @@ export function usePortsData() {
 			},
 		);
 
-		// Sort alphabetically by workspace name
-		groups.sort((a, b) => a.workspaceName.localeCompare(b.workspaceName));
-
-		return groups;
+		// Remove workspaces with no active ports and sort alphabetically
+		return groups
+			.filter((g) => g.ports.length > 0)
+			.sort((a, b) => a.workspaceName.localeCompare(b.workspaceName));
 	}, [allWorkspaceIds, allStaticPortsData?.ports, ports, workspaceNames]);
 
 	const totalPortCount = workspacePortGroups.reduce(

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/utils/merge-ports.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/utils/merge-ports.ts
@@ -4,9 +4,9 @@ import type { DetectedPort, MergedPort, StaticPort } from "shared/types";
  * Merge static port configuration with dynamically detected ports.
  *
  * Logic:
- * 1. Start with all static ports (always shown, even when inactive)
- * 2. For dynamic ports matching a static port number: merge process info, mark active
- * 3. For dynamic ports not in static config: add as dynamic-only entries
+ * 1. Only show ports that are actively in use (detected by the port scanner)
+ * 2. For active ports matching a static port number: apply the label from config
+ * 3. For active ports not in static config: show as dynamic-only entries
  * 4. Sort by port number
  */
 export function mergePorts({
@@ -22,39 +22,22 @@ export function mergePorts({
 		(p) => p.workspaceId === workspaceId,
 	);
 
-	const dynamicByPort = new Map(workspaceDynamicPorts.map((p) => [p.port, p]));
-	const staticPortNumbers = new Set(staticPorts.map((p) => p.port));
+	const staticByPort = new Map(staticPorts.map((p) => [p.port, p]));
 	const merged: MergedPort[] = [];
 
-	for (const staticPort of staticPorts) {
-		const dynamic = dynamicByPort.get(staticPort.port);
-		merged.push({
-			port: staticPort.port,
-			workspaceId,
-			label: staticPort.label,
-			isActive: !!dynamic,
-			pid: dynamic?.pid ?? null,
-			processName: dynamic?.processName ?? null,
-			paneId: dynamic?.paneId ?? null,
-			address: dynamic?.address ?? null,
-			detectedAt: dynamic?.detectedAt ?? null,
-		});
-	}
-
 	for (const dynamic of workspaceDynamicPorts) {
-		if (!staticPortNumbers.has(dynamic.port)) {
-			merged.push({
-				port: dynamic.port,
-				workspaceId,
-				label: null,
-				isActive: true,
-				pid: dynamic.pid,
-				processName: dynamic.processName,
-				paneId: dynamic.paneId,
-				address: dynamic.address,
-				detectedAt: dynamic.detectedAt,
-			});
-		}
+		const staticPort = staticByPort.get(dynamic.port);
+		merged.push({
+			port: dynamic.port,
+			workspaceId,
+			label: staticPort?.label ?? null,
+			isActive: true,
+			pid: dynamic.pid,
+			processName: dynamic.processName,
+			paneId: dynamic.paneId,
+			address: dynamic.address,
+			detectedAt: dynamic.detectedAt,
+		});
 	}
 
 	return merged.sort((a, b) => a.port - b.port);

--- a/bun.lock
+++ b/bun.lock
@@ -105,7 +105,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "0.0.73",
+      "version": "0.0.76",
       "dependencies": {
         "@better-auth/stripe": "1.4.18",
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Summary
- Static ports from `ports.json` were always displayed in the sidebar even when not running, adding visual clutter
- Now ports only appear when detected by the port scanner, with static config used solely as a label lookup for active ports
- Workspace groups with no active ports are filtered out entirely

## Changes
- **`merge-ports.ts`**: Simplified merge logic to iterate only over dynamically detected ports. Static ports serve as a label source rather than always being shown. Removed the two-pass approach (static-first, then dynamic-only) in favor of a single pass over active ports with static label lookup.
- **`usePortsData.ts`**: Added `.filter()` to remove workspace groups with zero active ports, preventing empty workspace sections in the sidebar.

## Test Plan
- [ ] Configure `ports.json` with static port entries — verify they do **not** appear in the sidebar when nothing is running on those ports
- [ ] Start a dev server on a port listed in `ports.json` — verify it appears with the configured label
- [ ] Start a dev server on a port **not** in `ports.json` — verify it still appears (dynamic-only, no label)
- [ ] Stop the dev server — verify the port disappears from the sidebar
- [ ] Verify workspaces with no active ports don't show an empty group header

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Port list now displays only workspaces containing active ports.
  * Improved port merging logic to correctly prioritize active ports.
  * Workspaces in the port list are sorted alphabetically by name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->