### PR TITLE
fix(desktop): skip self-copy in canary Linux updater manifest step

### DIFF
--- a/.github/workflows/release-desktop-canary.yml
+++ b/.github/workflows/release-desktop-canary.yml
@@ -108,10 +108,10 @@ jobs:
           done
           # Prerelease builds may request canary-linux.yml; keep latest-linux.yml as fallback.
           for file in *-linux.yml; do
-            if [[ -f "$file" ]]; then
+            if [[ -f "$file" && "$file" != "canary-linux.yml" && "$file" != "latest-linux.yml" ]]; then
               cp "$file" "canary-linux.yml"
               cp "$file" "latest-linux.yml"
-              echo "Created canary manifests: canary-linux.yml, latest-linux.yml"
+              echo "Created canary manifests: canary-linux.yml, latest-linux.yml from $file"
               break
             fi
           done


### PR DESCRIPTION
## Summary
- Fix canary release workflow failing on Linux with `cp: 'latest-linux.yml' and 'latest-linux.yml' are the same file`
- The `*-linux.yml` glob matched `latest-linux.yml` itself, then tried to copy it to itself

## Changes
- Add guards to skip `canary-linux.yml` and `latest-linux.yml` in the glob loop so only the versioned source file (e.g. `Superset-0.0.1-canary.20260214-linux.yml`) gets copied
- Matches the pattern already used in `release-desktop.yml`

## Test Plan
- [ ] Trigger a canary release via `workflow_dispatch` and verify the "Create canary-named copies" step passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release workflow configuration to prevent redundant operations and better document file origins during the canary release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->