### PR TITLE
fix(setup): use real tabs in Caddyfile heredoc instead of literal \t

### DIFF
--- a/.superset/lib/setup/steps.sh
+++ b/.superset/lib/setup/steps.sh
@@ -423,13 +423,13 @@ step_write_env() {
   success "Electric proxy .dev.vars written"
 
   # Generate Caddyfile for HTTP/2 reverse proxy (avoids browser 6-connection limit with Electric SSE streams)
-  cat > Caddyfile <<CADDYEOF
-https://localhost:{\$CADDY_ELECTRIC_PORT} {
-\treverse_proxy localhost:{\$ELECTRIC_PROXY_PORT} {
-\t\tflush_interval -1
-\t}
-}
-CADDYEOF
+  cat > Caddyfile <<-CADDYEOF
+	https://localhost:{\$CADDY_ELECTRIC_PORT} {
+		reverse_proxy localhost:{\$ELECTRIC_PROXY_PORT} {
+			flush_interval -1
+		}
+	}
+	CADDYEOF
   success "Caddyfile written"
 
   # Generate .superset/ports.json for static port name mapping in the desktop app


### PR DESCRIPTION
## Summary
- The setup script's heredoc wrote literal `\t` strings into the Caddyfile instead of actual tab characters
- This caused Caddy to fail on startup with `unrecognized directive: \treverse_proxy`

## Changes
- `.superset/lib/setup/steps.sh`: Switch from `<<CADDYEOF` to `<<-CADDYEOF` heredoc syntax and use real tab indentation so the generated Caddyfile contains proper tabs

## Test Plan
- [ ] Run `bun dev` and verify Caddy starts without errors
- [ ] Inspect the generated `Caddyfile` and confirm it contains real tab characters (not `\t` literals)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved configuration file generation formatting and whitespace handling in the setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->