### PR TITLE
fix(auth): bypass cookie cache in OAuth consent to prevent stale org context

### DIFF
--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -171,10 +171,16 @@ export const auth = betterAuth({
 				// Org selection is handled in the consent page, so never redirect to a separate page
 				page: `${env.NEXT_PUBLIC_WEB_URL}/oauth/consent`,
 				shouldRedirect: () => false,
-				consentReferenceId: ({ session }) => {
-					const activeOrganizationId = (
-						session as { activeOrganizationId?: string }
-					).activeOrganizationId;
+				consentReferenceId: async ({ session }) => {
+					// Bypass cookie cache by reading directly from DB.
+					// The consent page calls setActive() then consent() sequentially,
+					// but the cookie cache (5 min TTL) may serve a stale session
+					// without the updated activeOrganizationId.
+					const freshSession = await db.query.sessions.findFirst({
+						where: eq(authSchema.sessions.id, (session as { id: string }).id),
+						columns: { activeOrganizationId: true },
+					});
+					const activeOrganizationId = freshSession?.activeOrganizationId;
 					if (!activeOrganizationId) {
 						throw new Error("Organization must be selected before consent");
 					}


### PR DESCRIPTION
## Summary

- Fixes MCP OAuth authentication failures ("Authentication successful, but server reconnection failed") caused by a race condition between `setActive()` and `oauth2.consent()` in the consent flow
- The consent page calls `setActive(orgId)` to write the org to the session, then immediately calls `oauth2.consent()` which reads it back via `consentReferenceId`. With cookie caching enabled (5 min TTL), the consent endpoint may read a stale session without the updated `activeOrganizationId`, causing the JWT to be issued without the `organizationId` claim
- Fix: query the `sessions` table directly by session ID in `consentReferenceId` instead of trusting the potentially cached session object

## Test plan

- [ ] Connect an MCP client (e.g. Claude Code) to `https://api.superset.sh/api/agent/mcp` and complete the OAuth consent flow
- [ ] Verify the issued JWT contains the `organizationId` claim
- [ ] Verify MCP tools work after authorization (no 401)
- [ ] Verify normal session auth (login/logout) is unaffected
- [ ] Verify API key auth for MCP is unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures consent uses the current organization selection during OAuth login, preventing stale session data from causing incorrect or failed consent flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->