### PR TITLE
feat(desktop): add copy/paste to terminal right-click context menu

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/TabPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/TabPane.tsx
@@ -64,6 +64,10 @@ export function TabPane({
 	const getScrollToBottomCallback = useTerminalCallbacksStore(
 		(s) => s.getScrollToBottomCallback,
 	);
+	const getGetSelectionCallback = useTerminalCallbacksStore(
+		(s) => s.getGetSelectionCallback,
+	);
+	const getPasteCallback = useTerminalCallbacksStore((s) => s.getPasteCallback);
 
 	useEffect(() => {
 		const container = terminalContainerRef.current;
@@ -117,6 +121,8 @@ export function TabPane({
 				onClosePane={() => removePane(paneId)}
 				onClearTerminal={handleClearTerminal}
 				onScrollToBottom={handleScrollToBottom}
+				getSelection={() => getGetSelectionCallback(paneId)?.() ?? ""}
+				onPaste={(text) => getPasteCallback(paneId)?.(text)}
 				currentTabId={tabId}
 				availableTabs={availableTabs}
 				onMoveToTab={onMoveToTab}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -149,6 +149,10 @@ export const Terminal = ({ paneId, tabId, workspaceId }: TerminalProps) => {
 		unregisterClearCallbackRef,
 		registerScrollToBottomCallbackRef,
 		unregisterScrollToBottomCallbackRef,
+		registerGetSelectionCallbackRef,
+		unregisterGetSelectionCallbackRef,
+		registerPasteCallbackRef,
+		unregisterPasteCallbackRef,
 	} = useTerminalRefs({
 		paneId,
 		tabId,
@@ -299,6 +303,10 @@ export const Terminal = ({ paneId, tabId, workspaceId }: TerminalProps) => {
 		unregisterClearCallbackRef,
 		registerScrollToBottomCallbackRef,
 		unregisterScrollToBottomCallbackRef,
+		registerGetSelectionCallbackRef,
+		unregisterGetSelectionCallbackRef,
+		registerPasteCallbackRef,
+		unregisterPasteCallbackRef,
 	});
 
 	useEffect(() => {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalRefs.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalRefs.ts
@@ -4,6 +4,14 @@ import { useRef } from "react";
 import { useTerminalCallbacksStore } from "renderer/stores/tabs/terminal-callbacks";
 
 type RegisterCallback = (paneId: string, callback: () => void) => void;
+type RegisterGetSelectionCallback = (
+	paneId: string,
+	callback: () => string,
+) => void;
+type RegisterPasteCallback = (
+	paneId: string,
+	callback: (text: string) => void,
+) => void;
 type UnregisterCallback = (paneId: string) => void;
 
 export interface UseTerminalRefsOptions {
@@ -37,6 +45,10 @@ export interface UseTerminalRefsReturn {
 	unregisterClearCallbackRef: MutableRefObject<UnregisterCallback>;
 	registerScrollToBottomCallbackRef: MutableRefObject<RegisterCallback>;
 	unregisterScrollToBottomCallbackRef: MutableRefObject<UnregisterCallback>;
+	registerGetSelectionCallbackRef: MutableRefObject<RegisterGetSelectionCallback>;
+	unregisterGetSelectionCallbackRef: MutableRefObject<UnregisterCallback>;
+	registerPasteCallbackRef: MutableRefObject<RegisterPasteCallback>;
+	unregisterPasteCallbackRef: MutableRefObject<UnregisterCallback>;
 }
 
 export function useTerminalRefs({
@@ -90,6 +102,18 @@ export function useTerminalRefs({
 	const unregisterScrollToBottomCallbackRef = useRef(
 		useTerminalCallbacksStore.getState().unregisterScrollToBottomCallback,
 	);
+	const registerGetSelectionCallbackRef = useRef(
+		useTerminalCallbacksStore.getState().registerGetSelectionCallback,
+	);
+	const unregisterGetSelectionCallbackRef = useRef(
+		useTerminalCallbacksStore.getState().unregisterGetSelectionCallback,
+	);
+	const registerPasteCallbackRef = useRef(
+		useTerminalCallbacksStore.getState().registerPasteCallback,
+	);
+	const unregisterPasteCallbackRef = useRef(
+		useTerminalCallbacksStore.getState().unregisterPasteCallback,
+	);
 
 	return {
 		isFocused,
@@ -106,5 +130,9 @@ export function useTerminalRefs({
 		unregisterClearCallbackRef,
 		registerScrollToBottomCallbackRef,
 		unregisterScrollToBottomCallbackRef,
+		registerGetSelectionCallbackRef,
+		unregisterGetSelectionCallbackRef,
+		registerPasteCallbackRef,
+		unregisterPasteCallbackRef,
 	};
 }

--- a/apps/desktop/src/renderer/stores/tabs/terminal-callbacks.ts
+++ b/apps/desktop/src/renderer/stores/tabs/terminal-callbacks.ts
@@ -3,6 +3,8 @@ import { create } from "zustand";
 interface TerminalCallbacksState {
 	clearCallbacks: Map<string, () => void>;
 	scrollToBottomCallbacks: Map<string, () => void>;
+	getSelectionCallbacks: Map<string, () => string>;
+	pasteCallbacks: Map<string, (text: string) => void>;
 	registerClearCallback: (paneId: string, callback: () => void) => void;
 	unregisterClearCallback: (paneId: string) => void;
 	getClearCallback: (paneId: string) => (() => void) | undefined;
@@ -12,12 +14,26 @@ interface TerminalCallbacksState {
 	) => void;
 	unregisterScrollToBottomCallback: (paneId: string) => void;
 	getScrollToBottomCallback: (paneId: string) => (() => void) | undefined;
+	registerGetSelectionCallback: (
+		paneId: string,
+		callback: () => string,
+	) => void;
+	unregisterGetSelectionCallback: (paneId: string) => void;
+	getGetSelectionCallback: (paneId: string) => (() => string) | undefined;
+	registerPasteCallback: (
+		paneId: string,
+		callback: (text: string) => void,
+	) => void;
+	unregisterPasteCallback: (paneId: string) => void;
+	getPasteCallback: (paneId: string) => ((text: string) => void) | undefined;
 }
 
 export const useTerminalCallbacksStore = create<TerminalCallbacksState>()(
 	(set, get) => ({
 		clearCallbacks: new Map(),
 		scrollToBottomCallbacks: new Map(),
+		getSelectionCallbacks: new Map(),
+		pasteCallbacks: new Map(),
 
 		registerClearCallback: (paneId, callback) => {
 			set((state) => {
@@ -57,6 +73,46 @@ export const useTerminalCallbacksStore = create<TerminalCallbacksState>()(
 
 		getScrollToBottomCallback: (paneId) => {
 			return get().scrollToBottomCallbacks.get(paneId);
+		},
+
+		registerGetSelectionCallback: (paneId, callback) => {
+			set((state) => {
+				const newCallbacks = new Map(state.getSelectionCallbacks);
+				newCallbacks.set(paneId, callback);
+				return { getSelectionCallbacks: newCallbacks };
+			});
+		},
+
+		unregisterGetSelectionCallback: (paneId) => {
+			set((state) => {
+				const newCallbacks = new Map(state.getSelectionCallbacks);
+				newCallbacks.delete(paneId);
+				return { getSelectionCallbacks: newCallbacks };
+			});
+		},
+
+		getGetSelectionCallback: (paneId) => {
+			return get().getSelectionCallbacks.get(paneId);
+		},
+
+		registerPasteCallback: (paneId, callback) => {
+			set((state) => {
+				const newCallbacks = new Map(state.pasteCallbacks);
+				newCallbacks.set(paneId, callback);
+				return { pasteCallbacks: newCallbacks };
+			});
+		},
+
+		unregisterPasteCallback: (paneId) => {
+			set((state) => {
+				const newCallbacks = new Map(state.pasteCallbacks);
+				newCallbacks.delete(paneId);
+				return { pasteCallbacks: newCallbacks };
+			});
+		},
+
+		getPasteCallback: (paneId) => {
+			return get().pasteCallbacks.get(paneId);
 		},
 	}),
 );


### PR DESCRIPTION
## Summary
- Add **Copy** and **Paste** items to the existing terminal right-click context menu
- Users can now right-click to copy selected terminal text or paste from clipboard without relying solely on keyboard shortcuts
- Copy trims trailing whitespace per line, consistent with existing Cmd+C behavior
- Paste uses `xterm.paste()` which handles newline normalization and bracketed paste mode for TUI apps

## Changes
- **`terminal-callbacks.ts`** — Add `getSelectionCallbacks` and `pasteCallbacks` maps to the terminal callbacks store
- **`useTerminalRefs.ts`** — Add refs for registering/unregistering the new callbacks
- **`useTerminalLifecycle.ts`** — Register `handleGetSelection` and `handlePaste` callbacks on mount, unregister on cleanup
- **`Terminal.tsx`** — Pass the new refs through to `useTerminalLifecycle`
- **`TabContentContextMenu.tsx`** — Add optional Copy/Paste menu items above existing items (Split, Clear, Move, Close)
- **`TabPane.tsx`** — Retrieve callbacks from the store and pass to `TabContentContextMenu`

## Test Plan
- [x] Right-click terminal with text selected → Copy is enabled, copies trimmed text to clipboard
- [x] Right-click terminal with no selection → Copy is disabled
- [x] Right-click terminal with clipboard content → Paste is enabled, pastes into terminal
- [x] Right-click terminal with empty clipboard → Paste is disabled
- [x] Existing context menu items (Split, Clear, Scroll to Bottom, Move to Tab, Close) still work
- [x] Paste works correctly in TUI apps (vim, etc.) with bracketed paste mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Copy and Paste menu items to the terminal context menu with platform-specific keyboard shortcuts (Cmd on macOS, Ctrl on Windows/Linux)
  * Copy option appears when text is selected; Paste option displays when clipboard content is available
  * Clipboard actions include icons and are visually separated from other menu options for improved usability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->