### PR TITLE
refactor(desktop): centralize workspace deletion toast logic

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/TeardownLogsDialog/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/TeardownLogsDialog/index.ts
@@ -1,6 +1,5 @@
 export {
-	forceDeleteWithToast,
-	showTeardownFailedToast,
+	deleteWithToast,
 	showTeardownLogs,
 	TeardownLogsDialog,
 } from "./TeardownLogsDialog";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/DeleteWorktreeDialog.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/DeleteWorktreeDialog.tsx
@@ -7,14 +7,10 @@ import {
 	AlertDialogTitle,
 } from "@superset/ui/alert-dialog";
 import { Button } from "@superset/ui/button";
-import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useDeleteWorktree } from "renderer/react-query/workspaces/useDeleteWorktree";
-import {
-	forceDeleteWithToast,
-	showTeardownFailedToast,
-} from "renderer/routes/_authenticated/components/TeardownLogsDialog";
+import { deleteWithToast } from "renderer/routes/_authenticated/components/TeardownLogsDialog";
 
 interface DeleteWorktreeDialogProps {
 	worktreeId: string;
@@ -40,40 +36,15 @@ export function DeleteWorktreeDialog({
 			},
 		);
 
-	const handleForceDelete = () =>
-		forceDeleteWithToast({
-			name: worktreeName,
-			deleteFn: () => deleteWorktree.mutateAsync({ worktreeId, force: true }),
-		});
-
 	const handleDelete = async () => {
 		onOpenChange(false);
 
-		const toastId = toast.loading(`Deleting "${worktreeName}"...`);
-
-		try {
-			const result = await deleteWorktree.mutateAsync({ worktreeId });
-
-			if (!result.success) {
-				const { output } = result;
-				if (output) {
-					showTeardownFailedToast({
-						toastId,
-						output,
-						onForceDelete: handleForceDelete,
-					});
-				} else {
-					toast.error(result.error ?? "Failed to delete", { id: toastId });
-				}
-				return;
-			}
-
-			toast.success(`Deleted "${worktreeName}"`, { id: toastId });
-		} catch (error) {
-			toast.error(error instanceof Error ? error.message : "Failed to delete", {
-				id: toastId,
-			});
-		}
+		await deleteWithToast({
+			name: worktreeName,
+			deleteFn: () => deleteWorktree.mutateAsync({ worktreeId }),
+			forceDeleteFn: () =>
+				deleteWorktree.mutateAsync({ worktreeId, force: true }),
+		});
 	};
 
 	const canDelete = canDeleteData?.canDelete ?? true;


### PR DESCRIPTION
## Summary
- Extracts the duplicated delete-with-toast pattern (loading → success/error/teardown-failure → force-delete fallback) into a single `deleteWithToast` helper
- Fixes `WorkspaceInitializingView` which was silently failing on delete errors with no user feedback
- Makes `showTeardownFailedToast` and `forceDeleteWithToast` internal to the module since they're now implementation details of `deleteWithToast`

## Changes
- **TeardownLogsDialog**: Added `deleteWithToast()` that handles the full deletion toast lifecycle; un-exported `showTeardownFailedToast` and `forceDeleteWithToast` (now internal)
- **DeleteWorkspaceDialog**: Replaced ~35 lines of inline toast logic with a single `deleteWithToast()` call
- **DeleteWorktreeDialog**: Replaced ~25 lines of inline toast logic with a single `deleteWithToast()` call
- **WorkspaceInitializingView**: Switched from raw `electronTrpc.workspaces.delete.useMutation()` to `useDeleteWorkspace()` hook (adds optimistic updates + rollback), and replaced silent-failure handler with `deleteWithToast()`

## Test Plan
- [ ] Delete a workspace from the sidebar — verify loading, success, and error toasts appear
- [ ] Delete a worktree from the worktrees list — verify same toast behavior
- [ ] Delete a workspace from the initializing/failed view — verify toasts now appear (previously silent)
- [ ] Trigger a teardown failure — verify "Delete Anyway" and "View Logs" actions work

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors user-facing deletion flows across multiple screens and changes mutation usage during workspace init; risk is mainly regressions in error/teardown handling and optimistic-update rollback behavior, not security-sensitive logic.
> 
> **Overview**
> Centralizes the repeated “delete + toast lifecycle + teardown-failure fallback” logic into a new `deleteWithToast` helper in `TeardownLogsDialog`, and makes `showTeardownFailedToast`/`forceDeleteWithToast` module-internal (no longer exported).
> 
> Updates workspace/worktree deletion dialogs to call `deleteWithToast` instead of duplicating toast/error handling, including showing teardown logs with a “Delete Anyway” force-delete path and surfacing `terminalWarning` toasts.
> 
> Fixes deletion from `WorkspaceInitializingView` by switching to the shared `useDeleteWorkspace` mutation and routing deletion through `deleteWithToast`, so failures now produce user-visible feedback instead of silently failing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2941d6054c74f5d128101938f9dbdaf7dc8354d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated workspace and worktree deletion flows to use a unified deletion handler, improving consistency across deletion operations and simplifying toast notification management throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->