### PR TITLE
fix(api): fix MCP OAuth connection through reverse proxy

### DIFF
--- a/apps/api/src/app/.well-known/oauth-protected-resource/[...path]/route.ts
+++ b/apps/api/src/app/.well-known/oauth-protected-resource/[...path]/route.ts
@@ -3,5 +3,4 @@ import { env } from "@/env";
 
 export const GET = protectedResourceHandler({
 	authServerUrls: [env.NEXT_PUBLIC_API_URL],
-	resourceUrl: env.NEXT_PUBLIC_API_URL,
 });

--- a/apps/api/src/app/.well-known/oauth-protected-resource/route.ts
+++ b/apps/api/src/app/.well-known/oauth-protected-resource/route.ts
@@ -3,5 +3,4 @@ import { env } from "@/env";
 
 export const GET = protectedResourceHandler({
 	authServerUrls: [env.NEXT_PUBLIC_API_URL],
-	resourceUrl: env.NEXT_PUBLIC_API_URL,
 });


### PR DESCRIPTION
## Summary
- Remove hardcoded `resourceUrl` from `protectedResourceHandler` in both `.well-known/oauth-protected-resource` routes so mcp-handler auto-derives it from `X-Forwarded-Host`/`X-Forwarded-Proto` headers — fixes URL mismatch when connecting through Caddy (`https://localhost:3050` vs `http://localhost:3041`)
- Add `sessionIdGenerator` to `createMcpHandler` config to fix `@modelcontextprotocol/sdk` v1.26.0 breaking change where stateless transports can no longer be reused across requests

## Test plan
- [x] Verified MCP OAuth connection works through Caddy in local dev (`/mcp` → "Authentication successful. Reconnected to superset")
- [x] Tested all MCP tools: `list_tasks`, `list_members`, `list_task_statuses`, `create_task`, `delete_task`, `list_devices`, `list_projects`, `list_workspaces`, `create_workspace`, `navigate_to_workspace`, `start_claude_session`, `delete_workspace`
- [x] Lint, typecheck, and tests all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified OAuth protected resource endpoint configuration by removing an unused parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->