### PR TITLE
fix(api): add sessionIdGenerator for MCP SDK v1.26.0 compatibility

### DIFF
--- a/apps/api/src/app/api/agent/[transport]/route.ts
+++ b/apps/api/src/app/api/agent/[transport]/route.ts
@@ -120,6 +120,8 @@ const baseHandler = createMcpHandler(
 		basePath: "/api/agent",
 		verboseLogs: env.NODE_ENV === "development",
 		maxDuration: 60,
+		// @ts-expect-error mcp-handler types sessionIdGenerator as undefined but runtime accepts it
+		sessionIdGenerator: () => crypto.randomUUID(),
 	},
 );
 


### PR DESCRIPTION
## Summary
- The `superagent` commit upgraded `@modelcontextprotocol/sdk` from v1.25.3 → v1.26.0, which added a check preventing stateless transports from being reused across requests
- `mcp-handler` creates a single module-level transport that gets reused — on warm Vercel instances this triggers `"Stateless transport cannot be reused across requests"`
- Adding `sessionIdGenerator` makes the transport stateful, allowing it to handle multiple requests

## Test plan
- [ ] Deploy to preview and test `/mcp` connection from Claude Code
- [ ] Verify MCP tools work (list_tasks, create_workspace, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented unique session identifier generation to improve session tracking and management within the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->