### PR TITLE
fix(desktop): surface per-item errors in command watcher failure reporting

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/useCommandWatcher.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/useCommandWatcher.ts
@@ -109,12 +109,26 @@ export function useCommandWatcher() {
 						draft.executedAt = new Date();
 					});
 				} else {
+					// Include per-item errors from bulk operations in the error message
+					const itemErrors = (
+						result.data?.errors as Array<{ error: string }> | undefined
+					)
+						?.map((e) => e.error)
+						.join("; ");
+					const fullError = itemErrors
+						? `${result.error ?? "Unknown error"}: ${itemErrors}`
+						: (result.error ?? "Unknown error");
+
 					collections.agentCommands.update(commandId, (draft) => {
 						draft.status = "failed";
-						draft.error = result.error ?? "Unknown error";
+						draft.error = fullError;
 						draft.executedAt = new Date();
 					});
-					console.error(`[command-watcher] Failed: ${commandId}`, result.error);
+					console.error(
+						`[command-watcher] Failed: ${commandId}`,
+						fullError,
+						result.data,
+					);
 				}
 			} catch (error) {
 				console.error(`[command-watcher] Error: ${commandId}`, error);


### PR DESCRIPTION
## Summary
- When bulk operations like `create_workspace` failed, the per-item error details (e.g., "Project X not found") were captured in `buildBulkResult` but never stored or logged — only the generic "All workspace creations failed" message was visible in the console and MCP response
- Now the individual error messages are concatenated into the command's `error` field and logged to console with full `result.data` context, so both the desktop console and MCP agent responses show the actual failure reason

## Test plan
- [ ] Trigger a `create_workspace` via MCP with an invalid project ID — verify the console now shows the specific error (e.g., "All workspace creations failed: Project abc not found")
- [ ] Verify the MCP response includes the detailed error message
- [ ] Confirm successful workspace creation still works normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for failed bulk operations by including detailed per-item error information in error messages, providing users with more specific feedback when commands fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->