### PR TITLE
feat(desktop): implement session refetch subscription and update billing success URLs

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/auth/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/auth/index.ts
@@ -66,6 +66,24 @@ export const createAuthRouter = () => {
 		}),
 
 		/**
+		 * Subscribe to session refetch requests.
+		 * Fires when the app needs to refetch the session (e.g. after Stripe checkout deeplink).
+		 */
+		onSessionRefetch: publicProcedure.subscription(() => {
+			return observable<true>((emit) => {
+				const handler = () => {
+					emit.next(true);
+				};
+
+				authEvents.on("session-refetch", handler);
+
+				return () => {
+					authEvents.off("session-refetch", handler);
+				};
+			});
+		}),
+
+		/**
 		 * Start OAuth sign-in flow.
 		 * Opens browser for OAuth, token delivered via deep link callback.
 		 */

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -12,6 +12,7 @@ import {
 } from "electron";
 import { makeAppSetup } from "lib/electron-app/factories/app/setup";
 import {
+	authEvents,
 	handleAuthCallback,
 	parseAuthDeepLink,
 } from "lib/trpc/routers/auth/utils/auth-functions";
@@ -71,6 +72,10 @@ async function processDeepLink(url: string): Promise<void> {
 	// e.g. superset://tasks/my-slug -> /tasks/my-slug
 	const path = `/${url.split("://")[1]}`;
 	focusMainWindow();
+
+	if (path.startsWith("/settings/billing") && path.includes("success=true")) {
+		authEvents.emit("session-refetch");
+	}
 
 	const windows = BrowserWindow.getAllWindows();
 	if (windows.length > 0) {

--- a/apps/desktop/src/renderer/components/Paywall/usePaywall.ts
+++ b/apps/desktop/src/renderer/components/Paywall/usePaywall.ts
@@ -9,10 +9,11 @@ type UserPlan = "free" | "pro";
 export function usePaywall() {
 	const { data: session } = authClient.useSession();
 	const collections = useCollections();
+	const subscriptions = collections.subscriptions;
 
 	const { data: subscriptionsData } = useLiveQuery(
-		(q) => q.from({ subscriptions: collections.subscriptions }),
-		[collections],
+		(q) => q.from({ subscriptions }),
+		[subscriptions],
 	);
 	const activeSubscription = subscriptionsData?.find(
 		(s) => s.status === "active",

--- a/apps/desktop/src/renderer/components/Paywall/usePaywall.ts
+++ b/apps/desktop/src/renderer/components/Paywall/usePaywall.ts
@@ -1,4 +1,6 @@
+import { useLiveQuery } from "@tanstack/react-db";
 import { authClient } from "renderer/lib/auth-client";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { GatedFeature } from "./constants";
 import { paywall } from "./Paywall";
 
@@ -6,8 +8,16 @@ type UserPlan = "free" | "pro";
 
 export function usePaywall() {
 	const { data: session } = authClient.useSession();
+	const collections = useCollections();
 
-	const userPlan: UserPlan = (session?.session?.plan as UserPlan) ?? "free";
+	const { data: subscriptionsData } = useLiveQuery(
+		(q) => q.from({ subscriptions: collections.subscriptions }),
+		[collections],
+	);
+	const activeSubscription = subscriptionsData?.find(
+		(s) => s.status === "active",
+	);
+	const userPlan: UserPlan = (activeSubscription?.plan as UserPlan) ?? "free";
 
 	function hasAccess(feature: GatedFeature): boolean {
 		void feature;

--- a/apps/desktop/src/renderer/components/Paywall/usePaywall.ts
+++ b/apps/desktop/src/renderer/components/Paywall/usePaywall.ts
@@ -1,6 +1,4 @@
-import { useLiveQuery } from "@tanstack/react-db";
 import { authClient } from "renderer/lib/auth-client";
-import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { GatedFeature } from "./constants";
 import { paywall } from "./Paywall";
 
@@ -8,18 +6,8 @@ type UserPlan = "free" | "pro";
 
 export function usePaywall() {
 	const { data: session } = authClient.useSession();
-	const collections = useCollections();
-	const subscriptions = collections.subscriptions;
 
-	const { data: subscriptionsData } = useLiveQuery(
-		(q) => q.from({ subscriptions }),
-		[subscriptions],
-	);
-	const activeSubscription = subscriptionsData?.find(
-		(s) => s.status === "active",
-	);
-	const rawPlan = activeSubscription?.plan;
-	const userPlan: UserPlan = rawPlan === "pro" ? "pro" : "free";
+	const userPlan: UserPlan = (session?.session?.plan as UserPlan) ?? "free";
 
 	function hasAccess(feature: GatedFeature): boolean {
 		void feature;

--- a/apps/desktop/src/renderer/components/Paywall/usePaywall.ts
+++ b/apps/desktop/src/renderer/components/Paywall/usePaywall.ts
@@ -17,7 +17,8 @@ export function usePaywall() {
 	const activeSubscription = subscriptionsData?.find(
 		(s) => s.status === "active",
 	);
-	const userPlan: UserPlan = (activeSubscription?.plan as UserPlan) ?? "free";
+	const rawPlan = activeSubscription?.plan;
+	const userPlan: UserPlan = rawPlan === "pro" ? "pro" : "free";
 
 	function hasAccess(feature: GatedFeature): boolean {
 		void feature;

--- a/apps/desktop/src/renderer/providers/AuthProvider/AuthProvider.tsx
+++ b/apps/desktop/src/renderer/providers/AuthProvider/AuthProvider.tsx
@@ -27,6 +27,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 		setIsHydrated(true);
 	}, [storedToken, isSuccess, isHydrated, refetchSession]);
 
+	electronTrpc.auth.onSessionRefetch.useSubscription(undefined, {
+		onData: () => {
+			refetchSession();
+		},
+	});
+
 	electronTrpc.auth.onTokenChanged.useSubscription(undefined, {
 		onData: async (data) => {
 			if (data?.token && data?.expiresAt) {

--- a/apps/desktop/src/renderer/providers/AuthProvider/AuthProvider.tsx
+++ b/apps/desktop/src/renderer/providers/AuthProvider/AuthProvider.tsx
@@ -29,7 +29,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
 	electronTrpc.auth.onSessionRefetch.useSubscription(undefined, {
 		onData: () => {
-			refetchSession();
+			refetchSession().catch(() => {});
 		},
 	});
 

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/BillingOverview.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/BillingOverview.tsx
@@ -7,6 +7,7 @@ import { HiArrowRight } from "react-icons/hi2";
 import { env } from "renderer/env.renderer";
 import { authClient } from "renderer/lib/auth-client";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { PROTOCOL_SCHEME } from "shared/constants";
 import {
 	isItemVisible,
 	SETTING_ITEM_ID,
@@ -67,7 +68,7 @@ export function BillingOverview({ visibleItems }: BillingOverviewProps) {
 					referenceId: activeOrgId,
 					annual,
 					seats: memberCount,
-					successUrl: `${env.NEXT_PUBLIC_WEB_URL}/settings/billing?success=true`,
+					successUrl: `${PROTOCOL_SCHEME}://settings/billing?success=true`,
 					cancelUrl: env.NEXT_PUBLIC_WEB_URL,
 					disableRedirect: true,
 				},

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/plans/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/plans/page.tsx
@@ -10,6 +10,7 @@ import { HiArrowLeft, HiArrowUpRight, HiCheck } from "react-icons/hi2";
 import { env } from "renderer/env.renderer";
 import { authClient } from "renderer/lib/auth-client";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { PROTOCOL_SCHEME } from "shared/constants";
 import type { PlanTier } from "../constants";
 
 export const Route = createFileRoute("/_authenticated/settings/billing/plans/")(
@@ -293,7 +294,7 @@ function PlansPage() {
 					referenceId: activeOrgId,
 					annual: isYearly,
 					seats: memberCount,
-					successUrl: `${env.NEXT_PUBLIC_WEB_URL}/settings/billing?success=true`,
+					successUrl: `${PROTOCOL_SCHEME}://settings/billing?success=true`,
 					cancelUrl: env.NEXT_PUBLIC_WEB_URL,
 					disableRedirect: true,
 				},


### PR DESCRIPTION
- Added a new subscription for session refetch requests in the auth router to handle session updates after specific events, such as Stripe checkout.
- Emitted a session refetch event upon successful billing deep link navigation.
- Updated success URLs in billing components to use a protocol scheme constant for consistency and improved link handling.
- Refactored the usePaywall hook to simplify user plan determination based on session data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a session-refetch subscription so the app can refresh session data in response to external events.
* **Improvements**
  * Billing success deep links now trigger an immediate session refresh, reflecting subscription and account updates without manual refresh.
  * Billing upgrade redirects use the app protocol scheme for more reliable in-app navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->