### PR TITLE
fix(desktop): stabilize workspace list item hover layout

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceDiffStats.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceDiffStats.tsx
@@ -18,7 +18,7 @@ export function WorkspaceDiffStats({
 	return (
 		<div
 			className={cn(
-				"group/diff flex items-center text-[10px] font-mono tabular-nums px-1.5 py-0.5 rounded relative cursor-pointer",
+				"group/diff relative flex h-5 shrink-0 items-center rounded px-1.5 text-[10px] font-mono tabular-nums cursor-pointer",
 				isActive
 					? "bg-foreground/10 group-hover:bg-transparent"
 					: "bg-muted/50 group-hover:bg-transparent",
@@ -26,8 +26,8 @@ export function WorkspaceDiffStats({
 		>
 			<div
 				className={cn(
-					"flex items-center gap-1.5",
-					onClose && "group-hover:hidden",
+					"flex items-center gap-1.5 leading-none transition-opacity",
+					onClose && "group-hover:opacity-0",
 				)}
 			>
 				<span className="text-emerald-500/90">+{additions}</span>
@@ -39,7 +39,8 @@ export function WorkspaceDiffStats({
 						<button
 							type="button"
 							onClick={onClose}
-							className="hidden group-hover:flex items-center justify-center text-muted-foreground hover:text-foreground"
+							className="absolute inset-0 flex items-center justify-center text-muted-foreground leading-none opacity-0 pointer-events-none transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 hover:text-foreground"
+							aria-label="Close workspace"
 						>
 							<HiMiniXMark className="size-3.5" />
 						</button>


### PR DESCRIPTION
## Description

Stabilizes workspace row height in the desktop sidebar to prevent hover-time layout shifts.
The diff stats badge now keeps a fixed height and swaps between stats/close affordance using opacity instead of display toggling, which avoids text and neighboring row movement.

Changed file:
- /Users/alexs/Dev/superset/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceDiffStats.tsx

## Related Issues

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

- `cd apps/desktop && SUPERSET_WORKSPACE_NAME=dev SKIP_ENV_VALIDATION=1 bun run dev`
- Hover workspace items with diff stats in sidebar
- Confirm row label no longer shifts vertically and neighboring items do not move

## Screenshots (if applicable)

| Before | After |
| --- | --- |
|![ScreenRecording2026-02-16at22 20 46-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/8ba945a6-4165-4f58-a185-e5a0245c518d) | ![ezgif-11296725922c1e08](https://github.com/user-attachments/assets/18b8ed69-264a-4c67-92ef-46b01e92569d) |


## Additional Notes

This is a focused UI stability fix with no intended behavior changes outside hover layout consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved workspace diff statistics display with refined layout and spacing
  * Enhanced close button interaction—now transitions smoothly with opacity-based hover visibility
  * Refined hover behavior for better visual feedback and accessibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->