### PR TITLE
fix(desktop): change default notifications port to avoid collisions

### DIFF
--- a/apps/desktop/src/shared/env.shared.ts
+++ b/apps/desktop/src/shared/env.shared.ts
@@ -18,7 +18,7 @@ const envSchema = z.object({
 		.default("development"),
 	// Port env vars (set in root .env or written by setup.sh for inner worktrees)
 	DESKTOP_VITE_PORT: z.coerce.number().default(5173),
-	DESKTOP_NOTIFICATIONS_PORT: z.coerce.number().default(5174),
+	DESKTOP_NOTIFICATIONS_PORT: z.coerce.number().default(51741),
 	ELECTRIC_PORT: z.coerce.number().default(5133),
 	DESKTOP_AUTOMATION_PORT: z.coerce.number().default(9223),
 	// Workspace name for instance isolation


### PR DESCRIPTION
## Summary
- The default `DESKTOP_NOTIFICATIONS_PORT` was `5174`, which sits in the Vite dev server range (5173, 5174, ...) and frequently collides during development
- Changed to `51741` in the IANA dynamic/private range (49152–65535) where collisions are unlikely

## Changes
- `apps/desktop/src/shared/env.shared.ts`: Update default from `5174` to `51741`

## Test Plan
- [ ] Verify desktop app starts and notifications server binds to port 51741
- [ ] Verify OAuth callback fallback still works on Linux/dev
- [ ] Verify agent notification hooks can POST to the new port

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default desktop notifications port configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->