### PR TITLE
fix(desktop): stop overriding OpenCode config with OPENCODE_CONFIG_DIR

### DIFF
--- a/apps/desktop/docs/EXTERNAL_FILES.md
+++ b/apps/desktop/docs/EXTERNAL_FILES.md
@@ -19,7 +19,7 @@ This separation prevents multiple instances from interfering with each other.
 |------|---------|
 | `claude` | Wrapper for Claude Code CLI that injects notification hooks |
 | `codex` | Wrapper for Codex CLI that injects notification hooks |
-| `opencode` | Wrapper for OpenCode CLI that sets `OPENCODE_CONFIG_DIR` |
+| `opencode` | Wrapper for OpenCode CLI that resolves real binary |
 
 These wrappers are added to `PATH` via shell integration, allowing them to intercept
 agent commands and inject Superset-specific configuration.
@@ -30,7 +30,6 @@ agent commands and inject Superset-specific configuration.
 |------|---------|
 | `notify.sh` | Shell script called by agents when they complete or need input |
 | `claude-settings.json` | Claude Code settings file with hook configuration |
-| `opencode/plugin/superset-notify.js` | OpenCode plugin for lifecycle events |
 
 ### `zsh/` and `bash/` - Shell Integration
 
@@ -39,21 +38,16 @@ agent commands and inject Superset-specific configuration.
 | `init.zsh` | Zsh initialization script (sources .zshrc, sets up PATH) |
 | `init.bash` | Bash initialization script (sources .bashrc, sets up PATH) |
 
-## Global Files (AVOID ADDING NEW ONES)
+## Global Files
 
-**DO NOT write to global locations** like `~/.config/`, `~/Library/`, etc.
-These cause dev/prod conflicts when both environments are running.
+| File | Purpose |
+|------|---------|
+| `~/.config/opencode/plugin/superset-notify.js` | OpenCode plugin for lifecycle events |
 
-### Known Issues with Global Files
-
-Previously, the OpenCode plugin was written to `~/.config/opencode/plugin/superset-notify.js`.
-This caused severe issues:
-1. Dev would overwrite prod's plugin with incompatible protocol
-2. Prod terminals would send events that dev's server couldn't handle
-3. Users received spam notifications for every agent message
-
-**Solution**: The global plugin is no longer written. On startup, any stale global plugin
-with our marker is deleted to prevent conflicts from older versions.
+The OpenCode plugin is installed at the global path so it doesn't interfere with user's
+OpenCode config (commands, skills, agents). The plugin reads `SUPERSET_NOTIFY_PATH` from
+the terminal environment at runtime, so the file content is identical across dev/prod — no
+conflicts when both are running.
 
 ## Shell RC File Modifications
 
@@ -79,6 +73,7 @@ Each terminal session receives these environment variables:
 | `SUPERSET_PORT` | Port for the notification server |
 | `SUPERSET_ENV` | Environment (`development` or `production`) |
 | `SUPERSET_HOOK_VERSION` | Hook protocol version for compatibility |
+| `SUPERSET_NOTIFY_PATH` | Path to the notification script for agent plugins |
 
 ## Adding New External Files
 
@@ -95,5 +90,5 @@ If you suspect dev/prod cross-talk:
 
 1. Check logs for "Environment mismatch" warnings
 2. Verify `SUPERSET_ENV` and `SUPERSET_PORT` are set correctly in terminal
-3. Delete stale global files: `rm -rf ~/.config/opencode/plugin/superset-notify.js`
+3. Verify `SUPERSET_NOTIFY_PATH` is set correctly in terminal
 4. Restart both dev and prod apps to regenerate hooks

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts
@@ -2,19 +2,14 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { getNotifyScriptPath } from "./notify-hook";
-import {
-	BIN_DIR,
-	HOOKS_DIR,
-	OPENCODE_CONFIG_DIR,
-	OPENCODE_PLUGIN_DIR,
-} from "./paths";
+import { BIN_DIR, HOOKS_DIR } from "./paths";
 
 export const WRAPPER_MARKER = "# Superset agent-wrapper v1";
 export const CLAUDE_SETTINGS_FILE = "claude-settings.json";
 export const OPENCODE_PLUGIN_FILE = "superset-notify.js";
 
 const OPENCODE_PLUGIN_SIGNATURE = "// Superset opencode plugin";
-const OPENCODE_PLUGIN_VERSION = "v8";
+const OPENCODE_PLUGIN_VERSION = "v9";
 export const OPENCODE_PLUGIN_MARKER = `${OPENCODE_PLUGIN_SIGNATURE} ${OPENCODE_PLUGIN_VERSION}`;
 
 const OPENCODE_PLUGIN_TEMPLATE_PATH = path.join(
@@ -59,10 +54,6 @@ export function getOpenCodeWrapperPath(): string {
 
 export function getClaudeSettingsPath(): string {
 	return path.join(HOOKS_DIR, CLAUDE_SETTINGS_FILE);
-}
-
-export function getOpenCodePluginPath(): string {
-	return path.join(OPENCODE_PLUGIN_DIR, OPENCODE_PLUGIN_FILE);
 }
 
 /** @see https://opencode.ai/docs/plugins */
@@ -122,11 +113,10 @@ exec "$REAL_BIN" -c 'notify=["bash","${notifyPath}"]' "$@"
 `;
 }
 
-export function buildOpenCodeWrapperScript(opencodeConfigDir: string): string {
+export function buildOpenCodeWrapperScript(): string {
 	return `#!/bin/bash
 ${WRAPPER_MARKER}
 # Superset wrapper for OpenCode
-# Injects OPENCODE_CONFIG_DIR for notification plugin
 
 ${REAL_BINARY_RESOLVER}
 REAL_BIN="$(find_real_binary "opencode")"
@@ -135,23 +125,19 @@ if [ -z "$REAL_BIN" ]; then
   exit 127
 fi
 
-export OPENCODE_CONFIG_DIR="${opencodeConfigDir}"
 exec "$REAL_BIN" "$@"
 `;
 }
 
-export function getOpenCodePluginContent(notifyPath: string): string {
+export function getOpenCodePluginContent(): string {
 	const template = fs.readFileSync(OPENCODE_PLUGIN_TEMPLATE_PATH, "utf-8");
-	return template
-		.replace("{{MARKER}}", OPENCODE_PLUGIN_MARKER)
-		.replace("{{NOTIFY_PATH}}", notifyPath);
+	return template.replace("{{MARKER}}", OPENCODE_PLUGIN_MARKER);
 }
 
 function createClaudeSettings(): string {
 	const settingsPath = getClaudeSettingsPath();
 	const notifyPath = getNotifyScriptPath();
 	const settings = getClaudeSettingsContent(notifyPath);
-
 	fs.writeFileSync(settingsPath, settings, { mode: 0o644 });
 	return settingsPath;
 }
@@ -173,44 +159,21 @@ export function createCodexWrapper(): void {
 }
 
 /**
- * Writes to environment-specific path only, NOT the global path.
- * Global path causes dev/prod conflicts when both are running.
+ * Writes plugin to the global OpenCode config path (~/.config/opencode/plugin/).
+ * The plugin reads SUPERSET_NOTIFY_PATH from env at runtime, so the file content
+ * is identical across dev/prod — no conflicts when both are running.
  */
 export function createOpenCodePlugin(): void {
-	const pluginPath = getOpenCodePluginPath();
-	const notifyPath = getNotifyScriptPath();
-	const content = getOpenCodePluginContent(notifyPath);
+	const pluginPath = getOpenCodeGlobalPluginPath();
+	fs.mkdirSync(path.dirname(pluginPath), { recursive: true });
+	const content = getOpenCodePluginContent();
 	fs.writeFileSync(pluginPath, content, { mode: 0o644 });
 	console.log("[agent-setup] Created OpenCode plugin");
 }
 
-/**
- * Removes stale global plugin written by older versions.
- * Only removes if the file contains our signature to avoid deleting user plugins.
- */
-export function cleanupGlobalOpenCodePlugin(): void {
-	try {
-		const globalPluginPath = getOpenCodeGlobalPluginPath();
-		if (!fs.existsSync(globalPluginPath)) return;
-
-		const content = fs.readFileSync(globalPluginPath, "utf-8");
-		if (content.includes(OPENCODE_PLUGIN_SIGNATURE)) {
-			fs.unlinkSync(globalPluginPath);
-			console.log(
-				"[agent-setup] Removed stale global OpenCode plugin to prevent dev/prod conflicts",
-			);
-		}
-	} catch (error) {
-		console.warn(
-			"[agent-setup] Failed to cleanup global OpenCode plugin:",
-			error,
-		);
-	}
-}
-
 export function createOpenCodeWrapper(): void {
 	const wrapperPath = getOpenCodeWrapperPath();
-	const script = buildOpenCodeWrapperScript(OPENCODE_CONFIG_DIR);
+	const script = buildOpenCodeWrapperScript();
 	fs.writeFileSync(wrapperPath, script, { mode: 0o755 });
 	console.log("[agent-setup] Created OpenCode wrapper");
 }

--- a/apps/desktop/src/main/lib/agent-setup/ensure-agent-hooks.ts
+++ b/apps/desktop/src/main/lib/agent-setup/ensure-agent-hooks.ts
@@ -10,7 +10,6 @@ import {
 	getCodexWrapperPath,
 	getOpenCodeGlobalPluginPath,
 	getOpenCodePluginContent,
-	getOpenCodePluginPath,
 	getOpenCodeWrapperPath,
 	OPENCODE_PLUGIN_MARKER,
 	WRAPPER_MARKER,
@@ -20,12 +19,7 @@ import {
 	getNotifyScriptPath,
 	NOTIFY_SCRIPT_MARKER,
 } from "./notify-hook";
-import {
-	BIN_DIR,
-	HOOKS_DIR,
-	OPENCODE_CONFIG_DIR,
-	OPENCODE_PLUGIN_DIR,
-} from "./paths";
+import { BIN_DIR, HOOKS_DIR } from "./paths";
 
 let inFlight: Promise<void> | null = null;
 
@@ -100,8 +94,7 @@ export function ensureAgentHooks(): Promise<void> {
 
 		await fs.mkdir(BIN_DIR, { recursive: true });
 		await fs.mkdir(HOOKS_DIR, { recursive: true });
-		await fs.mkdir(OPENCODE_CONFIG_DIR, { recursive: true });
-		await fs.mkdir(OPENCODE_PLUGIN_DIR, { recursive: true });
+
 		const globalOpenCodePluginPath = getOpenCodeGlobalPluginPath();
 		try {
 			await fs.mkdir(path.dirname(globalOpenCodePluginPath), {
@@ -141,32 +134,24 @@ export function ensureAgentHooks(): Promise<void> {
 			logLabel: "Codex wrapper",
 		});
 
-		await ensureScriptFile({
-			filePath: getOpenCodePluginPath(),
-			content: getOpenCodePluginContent(notifyPath),
-			mode: 0o644,
-			marker: OPENCODE_PLUGIN_MARKER,
-			logLabel: "OpenCode plugin",
-		});
-
 		try {
 			await ensureScriptFile({
 				filePath: globalOpenCodePluginPath,
-				content: getOpenCodePluginContent(notifyPath),
+				content: getOpenCodePluginContent(),
 				mode: 0o644,
 				marker: OPENCODE_PLUGIN_MARKER,
-				logLabel: "OpenCode global plugin",
+				logLabel: "OpenCode plugin",
 			});
 		} catch (error) {
 			console.warn(
-				"[agent-setup] Failed to write global OpenCode plugin:",
+				"[agent-setup] Failed to write OpenCode plugin:",
 				error,
 			);
 		}
 
 		await ensureScriptFile({
 			filePath: getOpenCodeWrapperPath(),
-			content: buildOpenCodeWrapperScript(OPENCODE_CONFIG_DIR),
+			content: buildOpenCodeWrapperScript(),
 			mode: 0o755,
 			marker: WRAPPER_MARKER,
 			logLabel: "OpenCode wrapper",

--- a/apps/desktop/src/main/lib/agent-setup/index.ts
+++ b/apps/desktop/src/main/lib/agent-setup/index.ts
@@ -1,19 +1,12 @@
 import fs from "node:fs";
 import {
-	cleanupGlobalOpenCodePlugin,
 	createClaudeWrapper,
 	createCodexWrapper,
 	createOpenCodePlugin,
 	createOpenCodeWrapper,
 } from "./agent-wrappers";
 import { createNotifyScript } from "./notify-hook";
-import {
-	BASH_DIR,
-	BIN_DIR,
-	HOOKS_DIR,
-	OPENCODE_PLUGIN_DIR,
-	ZSH_DIR,
-} from "./paths";
+import { BASH_DIR, BIN_DIR, HOOKS_DIR, ZSH_DIR } from "./paths";
 import {
 	createBashWrapper,
 	createZshWrapper,
@@ -29,9 +22,6 @@ export function setupAgentHooks(): void {
 	fs.mkdirSync(HOOKS_DIR, { recursive: true });
 	fs.mkdirSync(ZSH_DIR, { recursive: true });
 	fs.mkdirSync(BASH_DIR, { recursive: true });
-	fs.mkdirSync(OPENCODE_PLUGIN_DIR, { recursive: true });
-
-	cleanupGlobalOpenCodePlugin();
 
 	createNotifyScript();
 	createClaudeWrapper();

--- a/apps/desktop/src/main/lib/agent-setup/paths.ts
+++ b/apps/desktop/src/main/lib/agent-setup/paths.ts
@@ -5,5 +5,3 @@ export const BIN_DIR = path.join(SUPERSET_HOME_DIR, "bin");
 export const HOOKS_DIR = path.join(SUPERSET_HOME_DIR, "hooks");
 export const ZSH_DIR = path.join(SUPERSET_HOME_DIR, "zsh");
 export const BASH_DIR = path.join(SUPERSET_HOME_DIR, "bash");
-export const OPENCODE_CONFIG_DIR = path.join(HOOKS_DIR, "opencode");
-export const OPENCODE_PLUGIN_DIR = path.join(OPENCODE_CONFIG_DIR, "plugin");

--- a/apps/desktop/src/main/lib/agent-setup/templates/opencode-plugin.template.js
+++ b/apps/desktop/src/main/lib/agent-setup/templates/opencode-plugin.template.js
@@ -5,7 +5,7 @@
  * This plugin sends desktop notifications when OpenCode sessions need attention.
  * It hooks into session.status (busy/idle), session.idle, session.error, and permission.ask events.
  *
- * ROBUSTNESS FEATURES (v8):
+ * ROBUSTNESS FEATURES (v9):
  * - Session-scoped: Tracks root sessionID, ignores events from other sessions
  * - Deduplication: Only sends Start on idle→busy, Stop on busy→idle transitions
  * - Safe defaults: On error, assumes child session to avoid false positives
@@ -23,13 +23,14 @@
  * @see https://github.com/sst/opencode/blob/dev/packages/app/src/context/notification.tsx
  */
 export const SupersetNotifyPlugin = async ({ $, client }) => {
-  if (globalThis.__supersetOpencodeNotifyPluginV8) return {};
-  globalThis.__supersetOpencodeNotifyPluginV8 = true;
+  if (globalThis.__supersetOpencodeNotifyPluginV9) return {};
+  globalThis.__supersetOpencodeNotifyPluginV9 = true;
 
   // Only run inside a Superset terminal session
   if (!process?.env?.SUPERSET_TAB_ID) return {};
 
-  const notifyPath = "{{NOTIFY_PATH}}";
+  const notifyPath = process?.env?.SUPERSET_NOTIFY_PATH;
+  if (!notifyPath) return {};
   const debug = process?.env?.SUPERSET_DEBUG === '1';
 
   // State tracking for deduplication and session-scoping

--- a/apps/desktop/src/main/lib/terminal/env.ts
+++ b/apps/desktop/src/main/lib/terminal/env.ts
@@ -2,6 +2,7 @@ import { execSync } from "node:child_process";
 import os from "node:os";
 import defaultShell from "default-shell";
 import { env } from "shared/env.shared";
+import { getNotifyScriptPath } from "../agent-setup/notify-hook";
 import { getShellEnv } from "../agent-setup/shell-wrappers";
 
 /**
@@ -371,6 +372,7 @@ export function buildTerminalEnv(params: {
 		SUPERSET_WORKSPACE_PATH: workspacePath || "",
 		SUPERSET_ROOT_PATH: rootPath || "",
 		SUPERSET_PORT: String(env.DESKTOP_NOTIFICATIONS_PORT),
+		SUPERSET_NOTIFY_PATH: getNotifyScriptPath(),
 		// Environment identifier for dev/prod separation
 		SUPERSET_ENV: env.NODE_ENV === "development" ? "development" : "production",
 		// Hook protocol version for forward compatibility


### PR DESCRIPTION
## Summary
- Users reported their OpenCode `/commands` and skills weren't showing up in Superset terminals
- The OpenCode wrapper was setting `OPENCODE_CONFIG_DIR` to a Superset-specific directory, which could interfere with user config discovery
- Move the plugin to the global OpenCode config path (`~/.config/opencode/plugin/`) and read the notify script path from `SUPERSET_NOTIFY_PATH` env var at runtime instead of baking it in

## Changes
- **Plugin template**: Reads `process.env.SUPERSET_NOTIFY_PATH` at runtime instead of hardcoded `{{NOTIFY_PATH}}`
- **OpenCode wrapper**: No longer sets `OPENCODE_CONFIG_DIR` — just resolves and execs the real binary
- **Plugin location**: Writes to global `~/.config/opencode/plugin/` instead of local `~/.superset/hooks/opencode/plugin/`
- **Terminal env**: Adds `SUPERSET_NOTIFY_PATH` to terminal environment (passes `SUPERSET_*` prefix allowlist)
- **Cleanup**: Removed `cleanupGlobalOpenCodePlugin`, `getOpenCodePluginPath`, `OPENCODE_CONFIG_DIR`/`OPENCODE_PLUGIN_DIR` constants
- Bumped plugin version to v9
- Updated `EXTERNAL_FILES.md` docs

## Test Plan
- [ ] Launch OpenCode in a Superset terminal — verify notifications still work (Start/Stop/PermissionRequest)
- [ ] Verify user's custom `/commands` and skills show up in OpenCode within Superset
- [ ] Run dev and prod simultaneously — verify no plugin conflicts
- [ ] Check `echo $SUPERSET_NOTIFY_PATH` in terminal points to correct notify script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated configuration documentation to reflect changes in OpenCode plugin setup and global path resolution.

* **Refactor**
  * Reorganized OpenCode integration to use a global plugin path instead of per-project configuration.
  * Updated OpenCode plugin version to v9.
  * Plugin now retrieves notification script path from environment variables at runtime rather than build-time configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->