### PR TITLE
fix(desktop): rename sidebar button label from "Changes" to "Code"

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/SidebarControl/SidebarControl.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/SidebarControl/SidebarControl.tsx
@@ -15,9 +15,7 @@ export function SidebarControl() {
 					variant="ghost"
 					size="sm"
 					onClick={toggleSidebar}
-					aria-label={
-						isSidebarOpen ? "Hide Code Sidebar" : "Show Code Sidebar"
-					}
+					aria-label={isSidebarOpen ? "Hide Code Sidebar" : "Show Code Sidebar"}
 					aria-pressed={isSidebarOpen}
 					className={cn(
 						"no-drag gap-1.5 h-6 px-1.5 rounded",

--- a/bun.lock
+++ b/bun.lock
@@ -104,7 +104,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "0.0.77",
+      "version": "0.0.78",
       "dependencies": {
         "@better-auth/stripe": "1.4.18",
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Summary
- Renamed the sidebar toggle button from "Changes" to "Code" to better represent that the sidebar covers both files and changes

## Changes
- Updated button label text from "Changes" to "Code"
- Updated tooltip from "Open Changes Sidebar" to "Open Code Sidebar"
- Updated aria-labels from "Hide/Show Changes Sidebar" to "Hide/Show Code Sidebar"

## Test Plan
- [ ] Verify the sidebar button displays "Code" instead of "Changes"
- [ ] Verify the tooltip shows "Open Code Sidebar"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated sidebar interface text to use "Code Sidebar" instead of "Changes Sidebar" across button labels and tooltips for consistency.
* **Accessibility**
  * Updated accessible labels (aria-labels) to match the new "Code Sidebar" wording, improving clarity for assistive technologies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->