### PR TITLE
chore(shared): remove unused feature flags

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -51,8 +51,6 @@ export const POSTHOG_COOKIE_NAME = "superset";
 export const FEATURE_FLAGS = {
 	/** Gates access to experimental Electric SQL tasks feature. */
 	ELECTRIC_TASKS_ACCESS: "electric-tasks-access",
-	/** Gates access to billing features. */
-	BILLING_ENABLED: "billing-enabled",
 	/** Gates access to GitHub integration (currently buggy, internal only). */
 	GITHUB_INTEGRATION_ACCESS: "github-integration-access",
 	/** Gates access to AI chat (@superset.sh internal only). */


### PR DESCRIPTION
## Summary
- Remove the unused `billing-enabled` and `agent-commands-access` feature flags
- `BILLING_ENABLED` was defined in `FEATURE_FLAGS` but never referenced anywhere in the codebase
- `agent-commands-access` was already absent from code but still existed in PostHog
- Both flags have been deleted from PostHog

## Changes
- **`packages/shared/src/constants.ts`**: Removed `BILLING_ENABLED: "billing-enabled"` from the `FEATURE_FLAGS` constant

## Test Plan
- [x] `bun run lint:fix` — passed
- [x] `bun run typecheck` — all 18 packages passed
- [x] Searched entire codebase for any references to `billing-enabled`, `BILLING_ENABLED`, `agent-commands-access` — none found

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the billing-enabled feature flag from feature configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->