### PR TITLE
fix(desktop): fix DevTools pane stuck at connecting

### DIFF
--- a/apps/desktop/src/lib/electron-app/factories/app/setup.ts
+++ b/apps/desktop/src/lib/electron-app/factories/app/setup.ts
@@ -84,9 +84,7 @@ PLATFORM.IS_WINDOWS &&
 
 app.commandLine.appendSwitch("force-color-profile", "srgb");
 
-// Enable CDP for desktop automation MCP (playwright-core connects via this port)
-if (env.NODE_ENV === "development") {
-	const cdpPort = String(process.env.DESKTOP_AUTOMATION_PORT || 9223);
-	app.commandLine.appendSwitch("remote-debugging-port", cdpPort);
-	app.commandLine.appendSwitch("remote-allow-origins", "*");
-}
+// Enable CDP for DevTools panes and desktop automation MCP
+const cdpPort = String(process.env.DESKTOP_AUTOMATION_PORT || 9223);
+app.commandLine.appendSwitch("remote-debugging-port", cdpPort);
+app.commandLine.appendSwitch("remote-allow-origins", "*");

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/DevToolsPane/DevToolsPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/DevToolsPane/DevToolsPane.tsx
@@ -28,10 +28,14 @@ export function DevToolsPane({
 	removePane,
 	setFocusedPane,
 }: DevToolsPaneProps) {
-	// Query the CDP debug server for the DevTools frontend URL
+	// Query the CDP debug server for the DevTools frontend URL.
+	// Retry every second until the URL is available (CDP target may not be ready immediately).
 	const { data } = electronTrpc.browser.getDevToolsUrl.useQuery(
 		{ browserPaneId: targetPaneId },
-		{ refetchOnWindowFocus: false },
+		{
+			refetchOnWindowFocus: false,
+			refetchInterval: (query) => (query.state.data?.url ? false : 1000),
+		},
 	);
 	const devToolsUrl = data?.url;
 


### PR DESCRIPTION
## Summary
- The DevTools browser pane was permanently stuck showing "Connecting to DevTools..." because the CDP remote debugging port was only enabled in development mode and the URL query had no retry logic.

## Changes
- **`setup.ts`**: Remove `NODE_ENV === "development"` guard around CDP port setup so DevTools panes work in all environments (listens on localhost only)
- **`browser-manager.ts`**: Improve CDP target matching — try exact URL match first, then fall back to matching by `webContentsId` in the WebSocket URL to handle redirects/URL mismatches
- **`DevToolsPane.tsx`**: Add `refetchInterval` that polls every 1s until a valid DevTools URL is returned, then stops — handles race conditions where the CDP target isn't registered yet

## Test Plan
- [ ] Open a browser pane, navigate to a URL, click "Open DevTools" — should connect successfully
- [ ] Verify DevTools connects even if the page redirects after loading
- [ ] Verify in both dev and packaged builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DevTools pane initialization reliability with retry logic for URL retrieval.
  * Enhanced CDP target detection with fallback matching for more robust DevTools inspector functionality.

* **Chores**
  * Updated desktop automation capabilities to always support remote debugging port configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->