### PR TITLE
fix(desktop): prevent webview from capturing drag events during pane rearrangement

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/BasePaneWindow.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/BasePaneWindow.tsx
@@ -56,6 +56,7 @@ export function BasePaneWindow({
 }: BasePaneWindowProps) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const splitOrientation = useSplitOrientation(containerRef);
+	const isDragging = useDragPaneStore((s) => s.draggingPaneId !== null);
 	const setDragging = useDragPaneStore((s) => s.setDragging);
 	const clearDragging = useDragPaneStore((s) => s.clearDragging);
 
@@ -105,6 +106,7 @@ export function BasePaneWindow({
 			<div
 				ref={containerRef}
 				className={contentClassName}
+				style={isDragging ? { pointerEvents: "none" } : undefined}
 				onClick={handleFocus}
 			>
 				{children}


### PR DESCRIPTION
## Summary
- Electron webviews render in a separate compositing layer and capture drag events, breaking React Mosaic pane drag-and-drop when the cursor moves over a browser pane
- Disables `pointer-events` on pane content during drag so mosaic drop targets receive events correctly

## Changes
- **BasePaneWindow**: Read `isDragging` from drag pane store; apply `pointer-events: none` on the content container while a pane drag is in progress

## Test Plan
- [ ] Open a browser pane alongside other panes
- [ ] Drag a pane and move the cursor over the browser pane — drop targets should appear correctly
- [ ] Verify normal pane interaction (clicking, typing) still works when not dragging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced pane drag functionality by preventing pointer events from interfering during drag operations, resulting in smoother and more responsive dragging behavior when managing workspace panes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->