### PR TITLE
feat(desktop): show existing worktrees banner on create workspace page

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/project/$projectId/components/ExternalWorktreesBanner/ExternalWorktreesBanner.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/project/$projectId/components/ExternalWorktreesBanner/ExternalWorktreesBanner.tsx
@@ -1,0 +1,111 @@
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from "@superset/ui/alert-dialog";
+import { Button } from "@superset/ui/button";
+import { toast } from "@superset/ui/sonner";
+import { motion } from "framer-motion";
+import { GoGitBranch } from "react-icons/go";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useImportAllWorktrees } from "renderer/react-query/workspaces/useImportAllWorktrees";
+
+const MAX_VISIBLE_BRANCHES = 5;
+
+export function ExternalWorktreesBanner({ projectId }: { projectId: string }) {
+	const { data: externalWorktrees = [], isLoading } =
+		electronTrpc.workspaces.getExternalWorktrees.useQuery({ projectId });
+
+	const importAllWorktrees = useImportAllWorktrees();
+
+	if (isLoading || externalWorktrees.length === 0) {
+		return null;
+	}
+
+	const handleImportAll = async () => {
+		try {
+			const result = await importAllWorktrees.mutateAsync({ projectId });
+			toast.success(
+				`Imported ${result.imported} workspace${result.imported === 1 ? "" : "s"}`,
+			);
+		} catch (err) {
+			toast.error(
+				err instanceof Error ? err.message : "Failed to import worktrees",
+			);
+		}
+	};
+
+	const visibleBranches = externalWorktrees.slice(0, MAX_VISIBLE_BRANCHES);
+	const remainingCount = externalWorktrees.length - visibleBranches.length;
+
+	return (
+		<motion.div
+			initial={{ opacity: 0, y: 8 }}
+			animate={{ opacity: 1, y: 0 }}
+			exit={{ opacity: 0, y: 8 }}
+			transition={{ duration: 0.2, ease: "easeOut" }}
+			className="mx-6 mt-6 rounded-lg border border-border/60 bg-card/50 p-4"
+		>
+			<div className="flex items-start justify-between gap-4">
+				<div className="space-y-2 min-w-0">
+					<p className="text-sm font-medium text-foreground">
+						{externalWorktrees.length} existing worktree
+						{externalWorktrees.length === 1 ? "" : "s"} found
+					</p>
+					<div className="flex flex-wrap gap-1.5">
+						{visibleBranches.map((wt) => (
+							<span
+								key={wt.path}
+								className="inline-flex items-center gap-1 rounded-md bg-muted px-2 py-0.5 text-xs font-mono text-muted-foreground"
+							>
+								<GoGitBranch className="size-3 shrink-0" />
+								<span className="truncate max-w-[180px]">{wt.branch}</span>
+							</span>
+						))}
+						{remainingCount > 0 && (
+							<span className="inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+								+{remainingCount} more
+							</span>
+						)}
+					</div>
+				</div>
+
+				<AlertDialog>
+					<AlertDialogTrigger asChild>
+						<Button
+							size="sm"
+							variant="outline"
+							className="shrink-0"
+							disabled={importAllWorktrees.isPending}
+						>
+							{importAllWorktrees.isPending ? "Importing..." : "Import all"}
+						</Button>
+					</AlertDialogTrigger>
+					<AlertDialogContent>
+						<AlertDialogHeader>
+							<AlertDialogTitle>Import all worktrees</AlertDialogTitle>
+							<AlertDialogDescription>
+								This will import {externalWorktrees.length} existing worktree
+								{externalWorktrees.length === 1 ? "" : "s"} into Superset as
+								workspaces. Each worktree on disk will be tracked and appear in
+								your sidebar. No files will be modified.
+							</AlertDialogDescription>
+						</AlertDialogHeader>
+						<AlertDialogFooter>
+							<AlertDialogCancel>Cancel</AlertDialogCancel>
+							<AlertDialogAction onClick={handleImportAll}>
+								Import all
+							</AlertDialogAction>
+						</AlertDialogFooter>
+					</AlertDialogContent>
+				</AlertDialog>
+			</div>
+		</motion.div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/project/$projectId/components/ExternalWorktreesBanner/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/project/$projectId/components/ExternalWorktreesBanner/index.ts
@@ -1,0 +1,1 @@
+export { ExternalWorktreesBanner } from "./ExternalWorktreesBanner";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/project/$projectId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/project/$projectId/page.tsx
@@ -21,6 +21,7 @@ import { electronTrpcClient as trpcClient } from "renderer/lib/trpc-client";
 import { useCreateWorkspace } from "renderer/react-query/workspaces";
 import { NotFound } from "renderer/routes/not-found";
 import { sanitizeSegment } from "shared/utils/branch";
+import { ExternalWorktreesBanner } from "./components/ExternalWorktreesBanner";
 
 export const Route = createFileRoute(
 	"/_authenticated/_dashboard/project/$projectId/",
@@ -148,25 +149,18 @@ function ProjectPage() {
 
 	return (
 		<div className="flex-1 h-full flex flex-col overflow-hidden bg-background">
+			<AnimatePresence>
+				<ExternalWorktreesBanner projectId={projectId} />
+			</AnimatePresence>
+
 			<div className="flex-1 flex overflow-y-auto">
 				{/* Main content */}
 				<div className="flex-1 flex items-center justify-center">
 					{/* biome-ignore lint/a11y/noStaticElementInteractions: Form container handles Enter key for submission */}
-					<div className="w-full max-w-xl mx-6" onKeyDown={handleKeyDown}>
-						{/* Project context */}
-						<div className="flex items-center gap-1.5 mb-8">
-							<span className="text-xs text-muted-foreground/70">
-								{project.name}
-							</span>
-							<span className="text-muted-foreground/30">·</span>
-							<span className="text-xs text-muted-foreground/50 font-mono">
-								{branchData?.defaultBranch ?? "main"}
-							</span>
-						</div>
-
+					<div className="w-full max-w-md mx-6" onKeyDown={handleKeyDown}>
 						{/* Headline */}
 						<h1 className="text-3xl font-semibold text-foreground tracking-tight mb-2">
-							What are you building?
+							Create your first workspace
 						</h1>
 
 						{/* Subtext */}
@@ -177,14 +171,8 @@ function ProjectPage() {
 						</p>
 
 						{/* Form */}
-						<div className="space-y-4 max-w-md">
+						<div className="space-y-4">
 							<div className="space-y-2">
-								<label
-									htmlFor="task-title"
-									className="text-xs font-medium text-muted-foreground"
-								>
-									Name your task
-								</label>
 								<Input
 									id="task-title"
 									ref={titleInputRef}
@@ -330,6 +318,7 @@ function ProjectPage() {
 								{createWorkspace.isPending ? "Creating..." : "Create workspace"}
 							</Button>
 						</div>
+
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
## Summary
- Adds a banner at the top of the project page that shows existing (untracked) worktrees and lets users import them all at once
- Simplifies the create workspace page: removes project name/branch header, "Name your task" label, and updates headline to "Create your first workspace"
- Narrows the form container from `max-w-xl` to `max-w-md` for a tighter layout

## Test plan
- [ ] Open a project that has external worktrees on disk — verify the banner appears at the top showing the count and branch names
- [ ] Click "Import all" and confirm the dialog imports worktrees correctly
- [ ] Open a project with no external worktrees — verify no banner is shown
- [ ] Verify the create workspace form layout looks correct at the narrower width

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a banner displaying external worktrees available for import with a one-click "Import all" action.
  * Shows branch information for available worktrees; displays count of additional items if exceeding visible limit.

* **UI Updates**
  * Updated workspace creation interface messaging and layout.
  * Refined content area width for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->