### PR TITLE
feat(desktop): add CMD+P quick open file command palette

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -8,6 +8,10 @@ import type { WorkspaceSearchParams } from "renderer/routes/_authenticated/_dash
 import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { usePresetHotkeys } from "renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/usePresetHotkeys";
 import { NotFound } from "renderer/routes/not-found";
+import {
+	CommandPalette,
+	useCommandPalette,
+} from "renderer/screens/main/components/CommandPalette";
 import { WorkspaceInitializingView } from "renderer/screens/main/components/WorkspaceView/WorkspaceInitializingView";
 import { WorkspaceLayout } from "renderer/screens/main/components/WorkspaceView/WorkspaceLayout";
 import { usePRStatus } from "renderer/screens/main/hooks";
@@ -333,6 +337,14 @@ function WorkspacePage() {
 		[pr?.url, workspace?.worktreePath],
 	);
 
+	const commandPalette = useCommandPalette({
+		workspaceId,
+		worktreePath: workspace?.worktreePath,
+	});
+	useAppHotkey("QUICK_OPEN", () => commandPalette.toggle(), undefined, [
+		commandPalette.toggle,
+	]);
+
 	// Toggle changes sidebar (⌘L)
 	useAppHotkey("TOGGLE_SIDEBAR", () => toggleSidebar(), undefined, [
 		toggleSidebar,
@@ -483,6 +495,14 @@ function WorkspacePage() {
 					<WorkspaceLayout />
 				)}
 			</div>
+			<CommandPalette
+				open={commandPalette.open}
+				onOpenChange={commandPalette.handleOpenChange}
+				query={commandPalette.query}
+				onQueryChange={commandPalette.setQuery}
+				searchResults={commandPalette.searchResults}
+				onSelectFile={commandPalette.selectFile}
+			/>
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/screens/main/components/CommandPalette/CommandPalette.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/CommandPalette/CommandPalette.tsx
@@ -1,0 +1,70 @@
+import {
+	CommandDialog,
+	CommandEmpty,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from "@superset/ui/command";
+import { getFileIcon } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils/file-icons";
+
+interface CommandPaletteProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	query: string;
+	onQueryChange: (query: string) => void;
+	searchResults: Array<{
+		id: string;
+		name: string;
+		relativePath: string;
+		path: string;
+		isDirectory: boolean;
+		score: number;
+	}>;
+	onSelectFile: (filePath: string) => void;
+}
+
+export function CommandPalette({
+	open,
+	onOpenChange,
+	query,
+	onQueryChange,
+	searchResults,
+	onSelectFile,
+}: CommandPaletteProps) {
+	return (
+		<CommandDialog
+			open={open}
+			onOpenChange={onOpenChange}
+			title="Quick Open"
+			description="Search for files in your workspace"
+			showCloseButton={false}
+		>
+			<CommandInput
+				placeholder="Search files..."
+				value={query}
+				onValueChange={onQueryChange}
+			/>
+			<CommandList>
+				{query.trim().length > 0 && searchResults.length === 0 && (
+					<CommandEmpty>No files found.</CommandEmpty>
+				)}
+				{searchResults.map((file) => {
+					const { icon: Icon, color } = getFileIcon(file.name, false);
+					return (
+						<CommandItem
+							key={file.id}
+							value={file.path}
+							onSelect={() => onSelectFile(file.relativePath)}
+						>
+							<Icon className={`size-3.5 shrink-0 ${color}`} />
+							<span className="truncate font-medium">{file.name}</span>
+							<span className="truncate text-muted-foreground text-xs ml-auto">
+								{file.relativePath}
+							</span>
+						</CommandItem>
+					);
+				})}
+			</CommandList>
+		</CommandDialog>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/CommandPalette/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/CommandPalette/index.ts
@@ -1,0 +1,2 @@
+export { CommandPalette } from "./CommandPalette";
+export { useCommandPalette } from "./useCommandPalette";

--- a/apps/desktop/src/renderer/screens/main/components/CommandPalette/useCommandPalette.ts
+++ b/apps/desktop/src/renderer/screens/main/components/CommandPalette/useCommandPalette.ts
@@ -1,0 +1,60 @@
+import { useCallback, useState } from "react";
+import { useFileSearch } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/hooks/useFileSearch/useFileSearch";
+import { useTabsStore } from "renderer/stores/tabs/store";
+
+const SEARCH_LIMIT = 50;
+
+interface UseCommandPaletteParams {
+	workspaceId: string;
+	worktreePath: string | undefined;
+}
+
+export function useCommandPalette({
+	workspaceId,
+	worktreePath,
+}: UseCommandPaletteParams) {
+	const [open, setOpen] = useState(false);
+	const [query, setQuery] = useState("");
+
+	const { searchResults, isFetching } = useFileSearch({
+		worktreePath: open ? worktreePath : undefined,
+		searchTerm: query,
+		includeHidden: false,
+		limit: SEARCH_LIMIT,
+	});
+
+	const handleOpenChange = useCallback((nextOpen: boolean) => {
+		setOpen(nextOpen);
+		if (!nextOpen) {
+			setQuery("");
+		}
+	}, []);
+
+	const toggle = useCallback(() => {
+		setOpen((prev) => {
+			if (prev) {
+				setQuery("");
+			}
+			return !prev;
+		});
+	}, []);
+
+	const selectFile = useCallback(
+		(filePath: string) => {
+			useTabsStore.getState().addFileViewerPane(workspaceId, { filePath });
+			handleOpenChange(false);
+		},
+		[workspaceId, handleOpenChange],
+	);
+
+	return {
+		open,
+		query,
+		setQuery,
+		handleOpenChange,
+		toggle,
+		selectFile,
+		searchResults,
+		isFetching,
+	};
+}

--- a/apps/desktop/src/shared/hotkeys.ts
+++ b/apps/desktop/src/shared/hotkeys.ts
@@ -719,6 +719,13 @@ export const HOTKEYS = {
 		description: "Copy the workspace path to the clipboard",
 	}),
 
+	QUICK_OPEN: defineHotkey({
+		keys: "meta+p",
+		label: "Quick Open File",
+		category: "Navigation",
+		description: "Search and open files in the current workspace",
+	}),
+
 	// Help
 	OPEN_SETTINGS: defineHotkey({
 		keys: "meta+,",


### PR DESCRIPTION
## Summary
- Adds a VS Code-style CMD+P (Ctrl+Shift+P on Windows/Linux) command palette for fuzzy-searching and opening files in the current workspace worktree
- Reuses existing `useFileSearch` hook (Fuse.js backend) and `CommandDialog` from `@superset/ui`
- Selecting a file opens it via `addFileViewerPane` using `relativePath`, matching sidebar behavior

## Test plan
- [x] Press CMD+P in a workspace — dialog opens
- [ ] Type a filename — results appear with fuzzy matching and file icons
- [ ] Arrow keys to navigate, Enter to select — file opens in a viewer pane
- [ ] Escape to close — dialog closes, query resets
- [ ] Press CMD+P again — dialog opens fresh (no stale query)
- [ ] Verify Ctrl+Shift+P works on Linux/Windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Command Palette for quickly searching and opening files within the workspace. Access it using Cmd+P (Mac) or Ctrl+P (Windows/Linux). Results display file icons and paths for easy identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->