### PR TITLE
feat(desktop): add Google Antigravity IDE to Open In dropdown

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/external/helpers.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/helpers.ts
@@ -8,6 +8,7 @@ const APP_NAMES: Record<ExternalApp, string | null> = {
 	vscode: "Visual Studio Code",
 	"vscode-insiders": "Visual Studio Code - Insiders",
 	cursor: "Cursor",
+	antigravity: "Antigravity",
 	zed: "Zed",
 	xcode: "Xcode",
 	iterm: "iTerm",

--- a/apps/desktop/src/renderer/assets/app-icons/antigravity.svg
+++ b/apps/desktop/src/renderer/assets/app-icons/antigravity.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 434 400" width="32" height="32">
+  <defs>
+    <linearGradient id="ag" x1="0" y1="0.5" x2="1" y2="0.5">
+      <stop offset="0%" stop-color="#4285F4"/>
+      <stop offset="33%" stop-color="#34A853"/>
+      <stop offset="66%" stop-color="#FBBC04"/>
+      <stop offset="100%" stop-color="#EA4335"/>
+    </linearGradient>
+  </defs>
+  <path d="M392.71,390.14c24.17,18.13,60.42,6.04,27.19-27.2C320.21,266.25,341.35.34,217.5.34S114.79,266.25,15.1,362.94c-36.25,36.26,3.02,45.33,27.19,27.2C135.93,326.68,129.89,214.88,217.5,214.88s81.56,111.8,175.21,175.26Z" fill="url(#ag)"/>
+</svg>

--- a/apps/desktop/src/renderer/components/OpenInButton/OpenInButton.tsx
+++ b/apps/desktop/src/renderer/components/OpenInButton/OpenInButton.tsx
@@ -15,6 +15,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useState } from "react";
 import { HiChevronDown } from "react-icons/hi2";
 import { LuCopy } from "react-icons/lu";
+import antigravityIcon from "renderer/assets/app-icons/antigravity.svg";
 import appcodeIcon from "renderer/assets/app-icons/appcode.svg";
 import clionIcon from "renderer/assets/app-icons/clion.svg";
 import cursorIcon from "renderer/assets/app-icons/cursor.svg";
@@ -52,6 +53,7 @@ interface AppOption {
 export const APP_OPTIONS: AppOption[] = [
 	{ id: "finder", label: "Finder", icon: finderIcon },
 	{ id: "cursor", label: "Cursor", icon: cursorIcon },
+	{ id: "antigravity", label: "Antigravity", icon: antigravityIcon },
 	{ id: "zed", label: "Zed", icon: zedIcon },
 	{ id: "sublime", label: "Sublime Text", icon: sublimeIcon },
 	{ id: "xcode", label: "Xcode", icon: xcodeIcon },

--- a/packages/local-db/src/schema/zod.ts
+++ b/packages/local-db/src/schema/zod.ts
@@ -85,6 +85,7 @@ export const EXTERNAL_APPS = [
 	"vscode",
 	"vscode-insiders",
 	"cursor",
+	"antigravity",
 	"zed",
 	"sublime",
 	"xcode",


### PR DESCRIPTION
## Summary
- Add Google Antigravity IDE as an external app option in the "Open in" dropdown menus
- Users can now open workspaces and files directly in Antigravity from the TopBar and OpenInButton components

## Changes
- **`packages/local-db/src/schema/zod.ts`** — Added `"antigravity"` to the `EXTERNAL_APPS` type union
- **`apps/desktop/src/lib/trpc/routers/external/helpers.ts`** — Added macOS app name mapping (`open -a Antigravity`)
- **`apps/desktop/src/renderer/components/OpenInButton/OpenInButton.tsx`** — Added icon import and menu entry (between Cursor and Zed)
- **`apps/desktop/src/renderer/assets/app-icons/antigravity.svg`** — Clean vector icon using the official Antigravity arc shape with Google brand gradient

## Test Plan
- [ ] Open a workspace and verify Antigravity appears in the "Open in" dropdown
- [ ] Click Antigravity and confirm it launches the app with the correct path
- [ ] Set Antigravity as last-used app and verify it persists across sessions
- [ ] Verify typecheck passes (`bun run typecheck`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for opening Antigravity as an external application. Users can now open files and projects directly in Antigravity from within the app's interface. The option appears in the "Open in" menu with a dedicated icon for easy identification and quick access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->