### PR TITLE
fix(desktop): use consistent branch sanitization in NewWorkspaceModal

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -52,12 +52,11 @@ import {
 import {
 	resolveBranchPrefix,
 	sanitizeBranchName,
-	sanitizeSegment,
 } from "shared/utils/branch";
 import { ExistingWorktreesList } from "./components/ExistingWorktreesList";
 
 function generateSlugFromTitle(title: string): string {
-	return sanitizeSegment(title);
+	return sanitizeBranchName(title);
 }
 
 type Mode = "existing" | "new" | "cloud";


### PR DESCRIPTION
## Summary
- Aligns the title-to-branch auto-generation logic with the manual branch name input by using `sanitizeBranchName` instead of `sanitizeSegment`
- Both paths now apply the same linting/sanitization, preserving slash-separated segments (e.g. `feature/my feature` → `feature/my-feature`)

## Changes
- **`NewWorkspaceModal.tsx`**: Changed `generateSlugFromTitle` to use `sanitizeBranchName` instead of `sanitizeSegment`
- Removed unused `sanitizeSegment` import

## Test Plan
- [ ] Create a workspace with a title containing `/` (e.g. `feature/login fix`) — branch preview should show `feature/login-fix`
- [ ] Create a workspace with a simple title (e.g. `fix login bug`) — branch preview should show `fix-login-bug` (unchanged behavior)
- [ ] Manually edit the branch name — should still work as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated workspace slug generation logic to use an improved sanitization method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->