### PR TITLE
fix(desktop): make addFileViewerPane respect file open mode setting

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -49,10 +49,7 @@ import {
 	useNewWorkspaceModalOpen,
 	usePreSelectedProjectId,
 } from "renderer/stores/new-workspace-modal";
-import {
-	resolveBranchPrefix,
-	sanitizeBranchName,
-} from "shared/utils/branch";
+import { resolveBranchPrefix, sanitizeBranchName } from "shared/utils/branch";
 import { ExistingWorktreesList } from "./components/ExistingWorktreesList";
 
 function generateSlugFromTitle(title: string): string {

--- a/apps/desktop/src/renderer/hooks/useFileOpenMode/index.ts
+++ b/apps/desktop/src/renderer/hooks/useFileOpenMode/index.ts
@@ -1,1 +1,1 @@
-export { useFileOpenMode } from "./useFileOpenMode";
+export { getFileOpenMode, useFileOpenMode } from "./useFileOpenMode";

--- a/apps/desktop/src/renderer/hooks/useFileOpenMode/useFileOpenMode.ts
+++ b/apps/desktop/src/renderer/hooks/useFileOpenMode/useFileOpenMode.ts
@@ -1,6 +1,17 @@
+import type { FileOpenMode } from "@superset/local-db";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { DEFAULT_FILE_OPEN_MODE } from "shared/constants";
 
-export function useFileOpenMode() {
+let cachedFileOpenMode: FileOpenMode = DEFAULT_FILE_OPEN_MODE;
+
+/** Non-React getter, kept in sync by useFileOpenMode(). */
+export function getFileOpenMode(): FileOpenMode {
+	return cachedFileOpenMode;
+}
+
+export function useFileOpenMode(): FileOpenMode {
 	const { data } = electronTrpc.settings.getFileOpenMode.useQuery();
-	return data ?? "split-pane";
+	const mode = data ?? DEFAULT_FILE_OPEN_MODE;
+	cachedFileOpenMode = mode;
+	return mode;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -1,6 +1,7 @@
 import { toast } from "@superset/ui/sonner";
 import { createFileRoute, notFound, useNavigate } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo } from "react";
+import { useFileOpenMode } from "renderer/hooks/useFileOpenMode";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { electronTrpcClient as trpcClient } from "renderer/lib/trpc-client";
 import { usePresets } from "renderer/react-query/presets";
@@ -73,6 +74,9 @@ function WorkspacePage() {
 	const navigate = useNavigate();
 	const routeNavigate = Route.useNavigate();
 	const { tabId: searchTabId, paneId: searchPaneId } = Route.useSearch();
+
+	// Keep the file open mode cache warm for addFileViewerPane
+	useFileOpenMode();
 
 	// Handle search-param-driven tab/pane activation (e.g. from notification clicks)
 	useEffect(() => {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useFileLinkClick.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useFileLinkClick.ts
@@ -1,6 +1,5 @@
 import { toast } from "@superset/ui/sonner";
 import { useCallback } from "react";
-import { useFileOpenMode } from "renderer/hooks/useFileOpenMode";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { electronTrpcClient as trpcClient } from "renderer/lib/trpc-client";
 import { useTabsStore } from "renderer/stores/tabs/store";
@@ -26,7 +25,6 @@ export function useFileLinkClick({
 	workspaceCwd,
 }: UseFileLinkClickOptions): UseFileLinkClickReturn {
 	const addFileViewerPane = useTabsStore((s) => s.addFileViewerPane);
-	const fileOpenMode = useFileOpenMode();
 
 	// Query terminal link behavior setting
 	const { data: terminalLinkBehavior } =
@@ -91,19 +89,12 @@ export function useFileLinkClick({
 					filePath,
 					line,
 					column,
-					openInNewTab: fileOpenMode === "new-tab",
 				});
 			} else {
 				openInExternalEditor();
 			}
 		},
-		[
-			terminalLinkBehavior,
-			workspaceId,
-			workspaceCwd,
-			addFileViewerPane,
-			fileOpenMode,
-		],
+		[terminalLinkBehavior, workspaceId, workspaceCwd, addFileViewerPane],
 	);
 
 	return {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
@@ -14,7 +14,6 @@ import {
 import { useParams } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { LuFile, LuFolder } from "react-icons/lu";
-import { useFileOpenMode } from "renderer/hooks/useFileOpenMode";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useFileExplorerStore } from "renderer/stores/file-explorer";
 import { useTabsStore } from "renderer/stores/tabs/store";
@@ -149,7 +148,6 @@ export function FilesView() {
 	});
 
 	const addFileViewerPane = useTabsStore((s) => s.addFileViewerPane);
-	const fileOpenMode = useFileOpenMode();
 	const openFileInEditorMutation =
 		electronTrpc.external.openFileInEditor.useMutation();
 
@@ -164,10 +162,9 @@ export function FilesView() {
 			if (!workspaceId || !worktreePath || entry.isDirectory) return;
 			addFileViewerPane(workspaceId, {
 				filePath: entry.relativePath,
-				openInNewTab: fileOpenMode === "new-tab",
 			});
 		},
-		[workspaceId, worktreePath, addFileViewerPane, fileOpenMode],
+		[workspaceId, worktreePath, addFileViewerPane],
 	);
 
 	const handleOpenInEditor = useCallback(

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
@@ -11,7 +11,6 @@ import {
 	LuX,
 } from "react-icons/lu";
 import { HotkeyTooltipContent } from "renderer/components/HotkeyTooltipContent";
-import { useFileOpenMode } from "renderer/hooks/useFileOpenMode";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
 	RightSidebarTab,
@@ -102,7 +101,6 @@ export function RightSidebar() {
 	};
 
 	const addFileViewerPane = useTabsStore((s) => s.addFileViewerPane);
-	const fileOpenMode = useFileOpenMode();
 	const trpcUtils = electronTrpc.useUtils();
 	const { scrollToFile } = useScrollContext();
 
@@ -137,17 +135,10 @@ export function RightSidebar() {
 				diffCategory: category,
 				commitHash,
 				oldPath: file.oldPath,
-				openInNewTab: fileOpenMode === "new-tab",
 			});
 			invalidateFileContent(file.path);
 		},
-		[
-			workspaceId,
-			worktreePath,
-			addFileViewerPane,
-			invalidateFileContent,
-			fileOpenMode,
-		],
+		[workspaceId, worktreePath, addFileViewerPane, invalidateFileContent],
 	);
 
 	const handleFileScrollTo = useCallback(

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -1,5 +1,6 @@
 import type { MosaicNode } from "react-mosaic-component";
 import { updateTree } from "react-mosaic-component";
+import { getFileOpenMode } from "renderer/hooks/useFileOpenMode";
 import { trpcTabsStorage } from "renderer/lib/trpc-storage";
 import { acknowledgedStatus } from "shared/tabs-types";
 import { create } from "zustand";
@@ -530,6 +531,13 @@ export const useTabsStore = create<TabsStore>()(
 					workspaceId: string,
 					options: AddFileViewerPaneOptions,
 				) => {
+					if (options.openInNewTab === undefined) {
+						options = {
+							...options,
+							openInNewTab: getFileOpenMode() === "new-tab",
+						};
+					}
+
 					const state = get();
 					const resolvedActiveTabId = resolveActiveTabIdForWorkspace({
 						workspaceId,

--- a/bun.lock
+++ b/bun.lock
@@ -104,7 +104,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "0.0.78",
+      "version": "0.0.80",
       "dependencies": {
         "@better-auth/stripe": "1.4.18",
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Summary
- CMD+P (and other file-open callers) always opened files as split panes, ignoring the user's "File open mode" setting
- Centralized the tab-vs-split logic inside `addFileViewerPane` so it reads user config by default when `openInNewTab` is not explicitly passed

## Changes
- **`useFileOpenMode.ts`** — Added `getFileOpenMode()` imperative getter backed by a module-level cache, so the Zustand store can read the setting synchronously
- **`tabs/store.ts`** — `addFileViewerPane` now defaults `openInNewTab` from user config via `getFileOpenMode()` when not explicitly set
- **`page.tsx`** (workspace) — Calls `useFileOpenMode()` to keep the cache warm while a workspace is mounted
- **Removed redundant `useFileOpenMode()` + `openInNewTab` passing** from `FilesView.tsx`, `useFileLinkClick.ts`, `RightSidebar/index.tsx`

## Test Plan
- [ ] Set file open mode to "New tab" in Settings > Features, open a file via CMD+P — should open in a new tab
- [ ] Set file open mode to "Split pane", open a file via CMD+P — should open as a split
- [ ] Verify file clicks in the sidebar and terminal links also respect the setting
- [ ] Verify that explicitly passing `openInNewTab` still overrides the default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Refactor**
- Enhanced file open mode initialization by moving cache warming earlier in the application lifecycle and implementing module-level caching.
- Consolidated file opening behavior logic across components, removing redundant hook invocations from multiple UI paths.
- Simplified dependencies and cleaned up imports in related components.
- Optimized control flow for file viewer pane operations with improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->