### PR TITLE
fix(desktop): seed auth token in worktree setup to avoid re-authentication

### DIFF
--- a/.superset/lib/setup/main.sh
+++ b/.superset/lib/setup/main.sh
@@ -36,22 +36,27 @@ setup_main() {
     step_failed "Seed local DB"
   fi
 
-  # Step 5: Setup Neon branch
+  # Step 5: Seed auth token into superset-dev-data/
+  if ! step_seed_auth_token; then
+    step_failed "Seed auth token"
+  fi
+
+  # Step 6: Setup Neon branch
   if ! step_setup_neon_branch; then
     step_failed "Setup Neon branch"
   fi
 
-  # Step 6: Allocate port base (file-backed)
+  # Step 7: Allocate port base (file-backed)
   if ! allocate_port_base; then
     step_failed "Allocate port base"
   fi
 
-  # Step 7: Start Electric SQL
+  # Step 8: Start Electric SQL
   if ! step_start_electric; then
     step_failed "Start Electric SQL"
   fi
 
-  # Step 8: Write .env file
+  # Step 9: Write .env file
   if ! step_write_env; then
     step_failed "Write .env file"
   fi

--- a/.superset/lib/setup/steps.sh
+++ b/.superset/lib/setup/steps.sh
@@ -448,6 +448,38 @@ PORTSJSON
   return 0
 }
 
+step_seed_auth_token() {
+  echo "🔑 Seeding auth token into superset-dev-data/..."
+
+  local source_token="$HOME/.superset/auth-token.enc"
+  local dev_data_dir="superset-dev-data"
+  local dest_token="$dev_data_dir/auth-token.enc"
+
+  if [ ! -f "$source_token" ]; then
+    warn "No auth token found at $source_token — skipping (you'll need to sign in)"
+    step_skipped "Seed auth token (no source token)"
+    return 0
+  fi
+
+  mkdir -p "$dev_data_dir"
+  chmod 700 "$dev_data_dir"
+
+  if [ -f "$dest_token" ] && [ "$FORCE_OVERWRITE_DATA" != "1" ]; then
+    warn "Auth token already exists at $dest_token — skipping (use -f/--force)"
+    step_skipped "Seed auth token (already exists)"
+    return 0
+  fi
+
+  if ! cp "$source_token" "$dest_token"; then
+    error "Failed to copy auth token"
+    return 1
+  fi
+  chmod 600 "$dest_token"
+
+  success "Auth token seeded from $source_token"
+  return 0
+}
+
 step_seed_local_db() {
   echo "💾 Seeding local DB into superset-dev-data/..."
 


### PR DESCRIPTION
## Summary
- New worktrees require re-authentication because the setup script sets `SUPERSET_HOME_DIR` to a worktree-local `superset-dev-data/` directory, but never copies the auth token there
- The encrypted token at `~/.superset/auth-token.enc` uses the machine's hardware UUID for encryption, so it's portable across worktrees on the same machine
- Adds a `step_seed_auth_token` to the setup script that copies the token, matching the existing `step_seed_local_db` pattern

## Changes
- `.superset/lib/setup/steps.sh` — Added `step_seed_auth_token()` function that copies `~/.superset/auth-token.enc` to `superset-dev-data/auth-token.enc` with `0600` permissions
- `.superset/lib/setup/main.sh` — Added step 5 (seed auth token) after seeding the local DB, renumbered subsequent steps

## Test Plan
- [ ] Create a new workspace/worktree via the desktop app
- [ ] Verify setup output shows "Auth token seeded from ~/.superset/auth-token.enc"
- [ ] Confirm the new worktree starts authenticated without requiring sign-in
- [ ] Verify `-f/--force` flag overwrites an existing token
- [ ] Verify graceful skip when no source token exists (fresh machine)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced development environment setup process to include authentication token initialization during initial configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->