### PR TITLE
fix(desktop): fix browser pane not loading images

### DIFF
--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -12,10 +12,12 @@
       - script-src 'self' 'wasm-unsafe-eval' https://*.posthog.com: Allow scripts from same origin + WebAssembly (for xterm ImageAddon) + PostHog
       - style-src 'self' 'unsafe-inline': Allow styles from same origin + inline (needed for CSS-in-JS)
       - connect-src 'self' ws: wss: %NEXT_PUBLIC_API_URL% %NEXT_PUBLIC_ELECTRIC_URL% %NEXT_PUBLIC_STREAMS_URL% https://*.posthog.com https://*.sentry.io sentry-ipc:: Allow WebSocket + API + Electric proxy + Streams server + PostHog + Sentry
-      - img-src 'self' data: https: Allow images from same origin + data URIs + any HTTPS source (needed for favicons from arbitrary sites in browser history)
+      - img-src 'self' data: https: http: blob:: Allow images from any source (needed for favicons and browser pane webview content)
       - font-src 'self': Allow fonts from same origin
+      - frame-src https: http: data: blob:: Allow webview browser pane to load any URL
+      - child-src 'self' blob:: Allow workers from same origin + blob workers
     -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://*.posthog.com; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss: %NEXT_PUBLIC_API_URL% %NEXT_PUBLIC_ELECTRIC_URL% %NEXT_PUBLIC_STREAMS_URL% https://*.posthog.com https://*.sentry.io sentry-ipc:; img-src 'self' data: https:; font-src 'self';" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://*.posthog.com; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss: %NEXT_PUBLIC_API_URL% %NEXT_PUBLIC_ELECTRIC_URL% %NEXT_PUBLIC_STREAMS_URL% https://*.posthog.com https://*.sentry.io sentry-ipc:; img-src 'self' data: https: http: blob:; font-src 'self'; frame-src https: http: data: blob:; child-src 'self' blob:;" />
   </head>
 
   <body>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
@@ -140,6 +140,8 @@ export function usePersistentWebview({
 			webview = document.createElement("webview") as Electron.WebviewTag;
 			webview.setAttribute("partition", "persist:superset");
 			webview.setAttribute("allowpopups", "");
+			webview.style.display = "flex";
+			webview.style.flex = "1";
 			webview.style.width = "100%";
 			webview.style.height = "100%";
 			webview.style.border = "none";


### PR DESCRIPTION
## Summary
- The persistent webview refactor (#1535) switched from JSX-rendered `<webview>` to programmatic `createElement`, but lost the `display: flex; flex: 1` styling needed for proper element sizing
- The renderer's CSP lacked explicit `frame-src` (falling back to restrictive `default-src 'self'`) and was missing `http:`/`blob:` in `img-src`, which could block the webview from loading external content and images

## Changes
- **`usePersistentWebview.ts`**: Added `display: flex` and `flex: 1` to the programmatically-created webview element, matching the old JSX implementation
- **`index.html` (CSP)**: Added `http:` and `blob:` to `img-src` for full image source compatibility; added explicit `frame-src https: http: data: blob:` to allow the webview browser pane to load any URL; added `child-src 'self' blob:` for worker compatibility

## Test Plan
- [ ] Open a browser pane and navigate to an image-heavy site (e.g. google images)
- [ ] Verify images render correctly within the browser pane
- [ ] Switch tabs and return — verify images persist after webview reparenting
- [ ] Test both HTTP and HTTPS sites load images correctly
- [ ] Verify URL suggestion favicons load in the address bar dropdown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
- Expanded security policy directives to permit loading of images, frames, web worker content, and blob-based resources from additional sources, improving system resource compatibility.

**Style**
- Enhanced webview component layout and rendering by applying flexbox CSS styling properties for improved display consistency and visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->