### PR TITLE
feat: add Electric Cloud managed service support

### DIFF
--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -12,6 +12,8 @@ export const env = createEnv({
 		DATABASE_URL_UNPOOLED: z.string(),
 		ELECTRIC_URL: z.string().url(),
 		ELECTRIC_SECRET: z.string().min(16),
+		ELECTRIC_SOURCE_ID: z.string().optional(),
+		ELECTRIC_SOURCE_SECRET: z.string().optional(),
 		BLOB_READ_WRITE_TOKEN: z.string(),
 		GOOGLE_CLIENT_ID: z.string().min(1),
 		GOOGLE_CLIENT_SECRET: z.string().min(1),

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
@@ -71,6 +71,7 @@ const electricHeaders = {
 		const token = getAuthToken();
 		return token ? `Bearer ${token}` : "";
 	},
+	"X-Electric-Backend": "cloud",
 };
 
 const organizationsCollection = createCollection(


### PR DESCRIPTION
## Summary
- Add header-based routing (`X-Electric-Backend: cloud`) in the API Electric proxy to support Electric Cloud alongside the existing self-hosted Fly.io backend
- Add `ELECTRIC_SOURCE_ID` and `ELECTRIC_SOURCE_SECRET` env vars (optional, already set in production)
- Desktop client sends the `cloud` header so new releases use Electric Cloud while older clients keep hitting Fly

## Test plan
- [ ] Deploy API — verify old clients without the header still route to Fly
- [ ] Ship desktop update — verify new clients with the header route to Electric Cloud
- [ ] Confirm shape sync works end-to-end through Electric Cloud (tasks, projects, members, etc.)
- [ ] Once stable, tear down `superset-electric` Fly app and remove old env vars

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Electric SQL cloud backend support, enabling seamless connection to the cloud-hosted Electric service as an alternative to self-hosted deployments.
  * Users can now configure the application to switch between cloud-backed and self-hosted Electric backends for real-time data synchronization based on infrastructure preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->