### PR TITLE
feat(claude): add /task and /task-run slash commands

### DIFF
--- a/.claude/commands/task-run.md
+++ b/.claude/commands/task-run.md
@@ -1,6 +1,6 @@
 ---
 description: Create a task, workspace, and start a Claude Code session to work on it
-allowed-tools: mcp__superset__create_task, mcp__superset__list_task_statuses, mcp__superset__list_devices, mcp__superset__list_projects, mcp__superset__create_workspace, mcp__superset__start_claude_session
+allowed-tools: mcp__superset__create_task, mcp__superset__list_members, mcp__superset__list_devices, mcp__superset__list_projects, mcp__superset__create_workspace, mcp__superset__start_claude_session, Bash(git config user.email)
 ---
 
 Create a new task in Superset, spin up a workspace, and start a Claude Code session to work on it.
@@ -13,6 +13,13 @@ Parse `$ARGUMENTS` for:
 
 ## Steps
 
+### 0. Resolve current user and environment
+
+Run these in parallel:
+- Call `mcp__superset__list_members` and match against the git user email (`git config user.email`) to get the current user's member ID
+- Call `mcp__superset__list_devices` and select the device owned by the current user
+- Call `mcp__superset__list_projects` on the resolved device and select the project matching the current git repo
+
 ### 1. Create the task
 
 - Parse the arguments to extract the task description and optional priority
@@ -22,14 +29,19 @@ Parse `$ARGUMENTS` for:
   - `title`: The generated title
   - `description`: Expanded detail if provided, otherwise omit
   - `priority`: Parsed priority or `none`
-  - `assigneeId`: `2dacb80b-7af1-41c4-8611-1e1e425ef720`
+  - `assigneeId`: The resolved member ID from step 0
 
 ### 2. Create a workspace
 
-- Device ID: `2918d81578e8e4035a630f0eca401d7b` (Kiets-Macbook-Pro)
-- Project ID: `WfSZYEbP5ncqATcrE4Yin` (superset)
+- Use the device ID and project ID resolved in step 0
 - Generate a kebab-case workspace name from the task title (short, max 4-5 words)
-- Generate a branch name in the format `fix/...` for bugs or `feat/...` for features, based on the task type
+- Generate a branch name based on task type:
+  - `fix/...` for bugs and defects
+  - `feat/...` for new features
+  - `chore/...` for maintenance, dependency updates, or configuration changes
+  - `docs/...` for documentation-only changes
+  - `refactor/...` for code refactors with no behavior change
+  - Default to `feat/...` if the type is ambiguous
 - Create the workspace using `mcp__superset__create_workspace`
 
 ### 3. Start Claude Code session

--- a/.claude/commands/task.md
+++ b/.claude/commands/task.md
@@ -1,6 +1,6 @@
 ---
 description: Create a task and assign it to me via Superset MCP
-allowed-tools: mcp__superset__create_task, mcp__superset__list_task_statuses
+allowed-tools: mcp__superset__create_task, mcp__superset__list_members, Bash(git config user.email)
 ---
 
 Create a new task in Superset and assign it to me.
@@ -16,11 +16,12 @@ Parse `$ARGUMENTS` for:
 1. Parse the arguments to extract the task description and optional priority
 2. Generate a clear, concise task title from the description (imperative form, under 80 chars)
 3. If the user provided more detail beyond a short title, include it as a markdown description on the task
-4. Create the task using `mcp__superset__create_task` with:
+4. Resolve the current user's member ID by calling `mcp__superset__list_members` and matching against the git user (run `git config user.email` to get the current user's email)
+5. Create the task using `mcp__superset__create_task` with:
    - `title`: The generated title
    - `description`: Expanded detail if provided, otherwise omit
    - `priority`: Parsed priority or `none`
-   - `assigneeId`: `2dacb80b-7af1-41c4-8611-1e1e425ef720`
+   - `assigneeId`: The resolved member ID from step 4
 
 ## Output
 


### PR DESCRIPTION
## Summary
- Adds `/task` slash command for quick task creation and self-assignment via Superset MCP
- Adds `/task-run` slash command that creates a task, spins up a workspace, and starts a Claude Code session in one step

## Changes
- **`.claude/commands/task.md`**: New slash command that parses a description + optional priority, creates a Superset task, and assigns it to the current user
- **`.claude/commands/task-run.md`**: Extended version that also creates a workspace on the superset project and kicks off a Claude Code session to work on the task

## Test Plan
- [ ] Run `/task fix something broken` and verify task is created and assigned
- [ ] Run `/task high priority: urgent bug` and verify priority is set correctly
- [ ] Run `/task-run add dark mode toggle` and verify task, workspace, and Claude session are all created

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a workflow guide for creating tasks, provisioning workspaces, and launching development sessions, including required inputs and expected outputs.
  * Added a task-creation reference covering title/description rules, priority handling, assignee resolution, and confirmation output after task creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->