### PR TITLE
fix(desktop): use execWithShellEnv for gh CLI in import from PR

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
@@ -9,7 +9,11 @@ import friendlyWords = require("friendly-words");
 import type { BranchPrefixMode } from "@superset/local-db";
 import simpleGit, { type StatusResult } from "simple-git";
 import { runWithPostCheckoutHookTolerance } from "../../utils/git-hook-tolerance";
-import { checkGitLfsAvailable, getShellEnvironment } from "./shell-env";
+import {
+	checkGitLfsAvailable,
+	execWithShellEnv,
+	getShellEnvironment,
+} from "./shell-env";
 
 const execFileAsync = promisify(execFile);
 
@@ -1681,10 +1685,8 @@ export async function getPrInfo({
 	repo: string;
 	prNumber: number;
 }): Promise<PullRequestInfo> {
-	const env = await getGitEnv();
-
 	try {
-		const { stdout } = await execFileAsync(
+		const { stdout } = await execWithShellEnv(
 			"gh",
 			[
 				"pr",
@@ -1695,7 +1697,7 @@ export async function getPrInfo({
 				"--json",
 				"number,title,headRefName,headRepository,headRepositoryOwner,isCrossRepository",
 			],
-			{ env, timeout: 30_000 },
+			{ timeout: 30_000 },
 		);
 
 		return JSON.parse(stdout) as PullRequestInfo;


### PR DESCRIPTION
## Summary
- Fix `gh` CLI not being found when importing a PR on macOS (app launched from Finder/Dock)
- `getPrInfo()` was the only `gh` call using raw `execFileAsync` + `getGitEnv()`, which lacks the ENOENT retry logic that resolves the user's shell PATH
- Switch to `execWithShellEnv`, matching the pattern used by all other `gh` calls in the codebase

## Changes
- **`apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts`**: Replace `execFileAsync("gh", ...)` with `execWithShellEnv("gh", ...)` in `getPrInfo()`, removing the now-unnecessary `getGitEnv()` call

## Test Plan
- [ ] Launch the desktop app from Finder (not terminal) on macOS
- [ ] Import a PR via URL — verify it resolves the `gh` CLI and fetches PR info successfully
- [ ] Verify existing worktree creation and PR import flows still work end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of Git operations for pull request information retrieval through enhanced environment variable management and simplified execution flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->