### PR TITLE
fix: make NEXT_PUBLIC_OUTLIT_KEY optional in env schemas

### DIFF
--- a/apps/desktop/src/main/env.main.ts
+++ b/apps/desktop/src/main/env.main.ts
@@ -21,7 +21,7 @@ export const env = createEnv({
 		NEXT_PUBLIC_POSTHOG_HOST: z.string().default("https://us.i.posthog.com"),
 		SENTRY_DSN_DESKTOP: z.string().optional(),
 		STREAMS_URL: z.url().default("https://superset-stream.fly.dev"),
-		NEXT_PUBLIC_OUTLIT_KEY: z.string(),
+		NEXT_PUBLIC_OUTLIT_KEY: z.string().optional(),
 	},
 
 	runtimeEnv: {

--- a/apps/desktop/src/renderer/env.renderer.ts
+++ b/apps/desktop/src/renderer/env.renderer.ts
@@ -19,7 +19,7 @@ const envSchema = z.object({
 	NEXT_PUBLIC_WEB_URL: z.url().default("https://app.superset.sh"),
 	NEXT_PUBLIC_POSTHOG_KEY: z.string().optional(),
 	NEXT_PUBLIC_POSTHOG_HOST: z.string().default("https://us.i.posthog.com"),
-	NEXT_PUBLIC_OUTLIT_KEY: z.string(),
+	NEXT_PUBLIC_OUTLIT_KEY: z.string().optional(),
 	SENTRY_DSN_DESKTOP: z.string().optional(),
 });
 

--- a/apps/docs/src/env.ts
+++ b/apps/docs/src/env.ts
@@ -21,7 +21,7 @@ export const env = createEnv({
 
 	client: {
 		NEXT_PUBLIC_MARKETING_URL: z.string().url().optional(),
-		NEXT_PUBLIC_OUTLIT_KEY: z.string(),
+		NEXT_PUBLIC_OUTLIT_KEY: z.string().optional(),
 		NEXT_PUBLIC_POSTHOG_KEY: z.string().optional(),
 		NEXT_PUBLIC_POSTHOG_HOST: z.string().url().optional(),
 		NEXT_PUBLIC_SENTRY_DSN_DOCS: z.string().optional(),

--- a/apps/marketing/src/env.ts
+++ b/apps/marketing/src/env.ts
@@ -30,7 +30,7 @@ export const env = createEnv({
 		NEXT_PUBLIC_SENTRY_ENVIRONMENT: z
 			.enum(["development", "preview", "production"])
 			.optional(),
-		NEXT_PUBLIC_OUTLIT_KEY: z.string(),
+		NEXT_PUBLIC_OUTLIT_KEY: z.string().optional(),
 	},
 	experimental__runtimeEnv: {
 		NODE_ENV: process.env.NODE_ENV,

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -36,7 +36,7 @@ export const env = createEnv({
 		NEXT_PUBLIC_SENTRY_ENVIRONMENT: z
 			.enum(["development", "preview", "production"])
 			.optional(),
-		NEXT_PUBLIC_OUTLIT_KEY: z.string(),
+		NEXT_PUBLIC_OUTLIT_KEY: z.string().optional(),
 	},
 
 	experimental__runtimeEnv: {


### PR DESCRIPTION
## Summary
- Makes `NEXT_PUBLIC_OUTLIT_KEY` optional (`.optional()`) in all 5 env schemas, matching the existing pattern used for `NEXT_PUBLIC_POSTHOG_KEY` and `SENTRY_DSN_DESKTOP`

## Context
CI builds and tests run without secrets, so analytics keys need to be optional. This fixes the Build, Test, and Deploy Docs failures on #1374.