### PR TITLE
fix(ui): remove double border on first/last tab in dark mode

### DIFF
--- a/packages/ui/src/components/ui/tabs.tsx
+++ b/packages/ui/src/components/ui/tabs.tsx
@@ -42,7 +42,7 @@ function TabsTrigger({
 		<TabsPrimitive.Trigger
 			data-slot="tabs-trigger"
 			className={cn(
-				"data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				"data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 dark:first:data-[state=active]:border-l-transparent dark:last:data-[state=active]:border-r-transparent",
 				className,
 			)}
 			{...props}


### PR DESCRIPTION
## Summary
- Fixes the double border visual bug on the first tab's left side (and last tab's right side) in dark mode
- In dark mode, active tabs get `border-input` on all sides. Combined with the `TabsList` container edge (`bg-muted` + `p-[3px]`), edge tabs showed two visible lines — the container boundary and the tab border
- Added `dark:first:data-[state=active]:border-l-transparent` and `dark:last:data-[state=active]:border-r-transparent` to keep edge borders transparent

Closes #1581

## Test plan
- [ ] Verify in dark mode that the first tab no longer shows a double border on the left
- [ ] Verify in dark mode that the last tab no longer shows a double border on the right
- [ ] Verify middle tabs still display borders correctly when active
- [ ] Verify light mode tabs are unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined dark mode styling for tab components with improved active state border handling in dark mode contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->