### PR TITLE
fix(desktop): remove double border on first workspace tab

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupStrip.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupStrip.tsx
@@ -182,7 +182,7 @@ export function GroupStrip() {
 			style={{ scrollbarWidth: "none" }}
 		>
 			{tabs.length > 0 && (
-				<div className="flex items-center h-full shrink-0 border-l border-border">
+				<div className="flex items-center h-full shrink-0">
 					{tabs.map((tab, index) => {
 						const isPrevOfActive = index === activeTabIndex - 1;
 						const isNextOfActive = index === activeTabIndex + 1;


### PR DESCRIPTION
## Summary
- The left sidebar's right border and the GroupStrip tabs container's `border-l` were stacking, creating a double border on the left side of the first workspace tab
- Removed `border-l border-border` from the GroupStrip container since the sidebar already provides the left edge border

Closes #1581

## Test plan
- [ ] Verify the first tab no longer shows a double border on the left when the sidebar is open
- [ ] Verify tab separators between tabs still look correct
- [ ] Verify appearance when sidebar is closed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the left border from the tab strip in the workspace view for a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->