### PR TITLE
fix(desktop): open Changes header tooltips above toolbar

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ChangesHeader/ChangesHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ChangesHeader/ChangesHeader.tsx
@@ -96,7 +96,7 @@ function BaseBranchSelector({ worktreePath }: { worktreePath: string }) {
 						</Button>
 					</PopoverTrigger>
 				</TooltipTrigger>
-				<TooltipContent side="bottom" showArrow={false}>
+				<TooltipContent side="top" showArrow={false}>
 					Change base branch
 				</TooltipContent>
 			</Tooltip>
@@ -162,7 +162,7 @@ function StashDropdown({
 						</Button>
 					</DropdownMenuTrigger>
 				</TooltipTrigger>
-				<TooltipContent side="bottom" showArrow={false}>
+				<TooltipContent side="top" showArrow={false}>
 					Stash operations
 				</TooltipContent>
 			</Tooltip>
@@ -217,7 +217,7 @@ function RefreshButton({ onRefresh }: { onRefresh: () => void }) {
 					/>
 				</Button>
 			</TooltipTrigger>
-			<TooltipContent side="bottom" showArrow={false}>
+			<TooltipContent side="top" showArrow={false}>
 				Refresh changes
 			</TooltipContent>
 		</Tooltip>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ChangesHeader/components/PRButton/PRButton.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ChangesHeader/components/PRButton/PRButton.tsx
@@ -72,7 +72,7 @@ export function PRButton({
 						)}
 					</button>
 				</TooltipTrigger>
-				<TooltipContent side="bottom">Create Pull Request</TooltipContent>
+				<TooltipContent side="top">Create Pull Request</TooltipContent>
 			</Tooltip>
 		);
 	}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ViewModeToggle/ViewModeToggle.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ViewModeToggle/ViewModeToggle.tsx
@@ -33,7 +33,7 @@ export function ViewModeToggle({
 					)}
 				</Button>
 			</TooltipTrigger>
-			<TooltipContent side="bottom" showArrow={false}>
+			<TooltipContent side="top" showArrow={false}>
 				{viewMode === "grouped"
 					? "Switch to tree view"
 					: "Switch to grouped view"}


### PR DESCRIPTION
## Description

Tooltips on the Changes panel toolbar (branch selector, stash, view mode, refresh, PR button) were opening downward, overlapping the commit message input and making them unreadable. Changed all five tooltips from `side="bottom"` to `side="top"`.

## Related Issues

Fixes #1586

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

Hover over each toolbar icon in the Changes header and verify tooltips appear above.