### PR TITLE
fix(desktop): run setup scripts when creating workspace from task

### DIFF
--- a/apps/desktop/src/renderer/react-query/workspaces/useCreateWorkspace.ts
+++ b/apps/desktop/src/renderer/react-query/workspaces/useCreateWorkspace.ts
@@ -11,6 +11,7 @@ type MutationOptions = Parameters<
 interface UseCreateWorkspaceOptions extends NonNullable<MutationOptions> {
 	skipNavigation?: boolean;
 	resolveInitialCommands?: (serverCommands: string[] | null) => string[] | null;
+	resolveAgentCommand?: () => string | undefined;
 }
 
 export function useCreateWorkspace(options?: UseCreateWorkspaceOptions) {
@@ -35,13 +36,16 @@ export function useCreateWorkspace(options?: UseCreateWorkspaceOptions) {
 				updateProgress(optimisticProgress);
 			}
 
-			if (!data.wasExisting) {
+			const resolvedCommands = options?.resolveInitialCommands
+					? options.resolveInitialCommands(data.initialCommands)
+					: data.initialCommands;
+			const agentCommand = options?.resolveAgentCommand?.();
+			if (!data.wasExisting || resolvedCommands || agentCommand) {
 				addPendingTerminalSetup({
 					workspaceId: data.workspace.id,
 					projectId: data.projectId,
-					initialCommands: options?.resolveInitialCommands
-						? options.resolveInitialCommands(data.initialCommands)
-						: data.initialCommands,
+					initialCommands: resolvedCommands,
+					agentCommand,
 				});
 			}
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/StartWorkingDialog/StartWorkingDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/StartWorkingDialog/StartWorkingDialog.tsx
@@ -57,24 +57,22 @@ export function StartWorkingDialog() {
 
 	// Single-task workspace creation (navigates after)
 	const createWorkspace = useCreateWorkspace({
-		resolveInitialCommands: () => {
-			if (!singleTask) return null;
-			const command = formatTaskContext({
+		resolveAgentCommand: () => {
+			if (!singleTask) return undefined;
+			return formatTaskContext({
 				task: singleTask,
 				additionalContext: additionalContext.trim() || undefined,
 			});
-			return [command];
 		},
 	});
 
 	// Batch workspace creation (skips navigation)
 	const createBatchWorkspace = useCreateWorkspace({
 		skipNavigation: true,
-		resolveInitialCommands: () => {
+		resolveAgentCommand: () => {
 			const task = currentBatchTaskRef.current;
-			if (!task) return null;
-			const command = formatTaskContext({ task });
-			return [command];
+			if (!task) return undefined;
+			return formatTaskContext({ task });
 		},
 	});
 

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/start-claude-session.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/start-claude-session.ts
@@ -29,11 +29,32 @@ async function execute(
 		// Append command to pending terminal setup for the existing workspace
 		const store = useWorkspaceInitStore.getState();
 		const pending = store.pendingTerminalSetups[workspace.id];
+
+		let initialCommands = pending?.initialCommands ?? null;
+		let defaultPresets = pending?.defaultPresets;
+
+		// When no pending setup exists (e.g. workspace was pre-existing),
+		// fetch setup commands from the server so setup scripts still run.
+		if (!initialCommands && ctx.fetchSetupCommands) {
+			try {
+				const setupData = await ctx.fetchSetupCommands(workspace.id);
+				if (setupData) {
+					initialCommands = setupData.initialCommands ?? null;
+					defaultPresets = defaultPresets ?? setupData.defaultPresets;
+				}
+			} catch (e) {
+				console.warn(
+					"[start_claude_session] Failed to fetch setup commands:",
+					e,
+				);
+			}
+		}
+
 		store.addPendingTerminalSetup({
 			workspaceId: workspace.id,
 			projectId: pending?.projectId ?? workspace.projectId,
-			initialCommands: pending?.initialCommands ?? null,
-			defaultPresets: pending?.defaultPresets,
+			initialCommands,
+			defaultPresets,
 			agentCommand: params.command,
 		});
 

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/types.ts
@@ -57,6 +57,12 @@ export interface ToolContext {
 	getActiveWorkspaceId: () => string | null;
 	// Navigation
 	navigateToWorkspace: (workspaceId: string) => Promise<void>;
+	// Setup commands
+	fetchSetupCommands: (workspaceId: string) => Promise<{
+		projectId: string;
+		initialCommands: string[] | null;
+		defaultPresets?: unknown[];
+	} | null>;
 }
 
 // Tool definition with schema and execute function

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/useCommandWatcher.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/useCommandWatcher.ts
@@ -39,6 +39,8 @@ export function useCommandWatcher() {
 		return match ? match[1] : null;
 	}, []);
 
+	const utils = electronTrpc.useUtils();
+
 	const toolContext: ToolContext = useMemo(
 		() => ({
 			createWorktree,
@@ -51,6 +53,8 @@ export function useCommandWatcher() {
 			getActiveWorkspaceId: getCurrentWorkspaceIdFromRoute,
 			navigateToWorkspace: (workspaceId: string) =>
 				navigateToWorkspace(workspaceId, navigate),
+			fetchSetupCommands: (workspaceId: string) =>
+				utils.workspaces.getSetupCommands.fetch({ workspaceId }),
 		}),
 		[
 			createWorktree,
@@ -62,6 +66,7 @@ export function useCommandWatcher() {
 			projects,
 			getCurrentWorkspaceIdFromRoute,
 			navigate,
+			utils,
 		],
 	);
 


### PR DESCRIPTION
## Summary

- Setup scripts from `.superset/config.json` were not running when creating a workspace from a task (via StartWorkingDialog)
- Root cause: `resolveInitialCommands` replaced setup scripts with the Claude task command instead of preserving them
- Added `resolveAgentCommand` option to `useCreateWorkspace` so setup scripts and the Claude command run in separate terminal panes

## Changes

**`useCreateWorkspace.ts`**
- Added `resolveAgentCommand` option that passes the task command as `agentCommand` (gets its own terminal pane)
- Fixed `wasExisting` gate: now queues pending setup when `initialCommands` or `agentCommand` is present, even for existing workspaces

**`StartWorkingDialog.tsx`**
- Switched from `resolveInitialCommands` (which replaced setup scripts) to `resolveAgentCommand` (which preserves them)

**`start-claude-session.ts`**
- When no pending setup exists (e.g. reopened workspace), fetches setup commands from the server via `getSetupCommands` instead of defaulting to `null`

**`useCommandWatcher.ts` + `types.ts`**
- Exposed `fetchSetupCommands` in the tool context so `start_claude_session` can query the backend

## Test plan

- [ ] Create a project with `.superset/config.json` setup scripts
- [ ] Create workspace manually → setup scripts run
- [ ] Create workspace from a single task → setup scripts run in "Workspace Setup" pane, Claude runs in separate "Agent" pane
- [ ] Create workspaces from batch tasks → same behavior for each
- [ ] Reopen an existing workspace from a task → setup scripts still run

Fixes #1594

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced workspace initialization to support agent-provided commands during creation.
  * Added server-provided setup commands fetching when initializing workspaces.

* **Refactor**
  * Improved command resolution mechanism in workspace setup flow for better initialization handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->