### PR TITLE
feat(desktop): per-project default IDE for Open in actions

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/settings/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/index.ts
@@ -100,10 +100,6 @@ export function getPresetsForTrigger(
 
 export const createSettingsRouter = () => {
 	return router({
-		getLastUsedApp: publicProcedure.query(() => {
-			const row = getSettings();
-			return row.lastUsedApp ?? "cursor";
-		}),
 		getTerminalPresets: publicProcedure.query(() => {
 			const row = getSettings();
 			if (!row.terminalPresetsInitialized) {

--- a/apps/desktop/src/renderer/components/ConfigFilePreview/ConfigFilePreview.tsx
+++ b/apps/desktop/src/renderer/components/ConfigFilePreview/ConfigFilePreview.tsx
@@ -49,7 +49,11 @@ export function ConfigFilePreview({
 					<span className="text-sm text-muted-foreground font-mono truncate">
 						{projectName}/{PROJECT_SUPERSET_DIR_NAME}/{CONFIG_FILE_NAME}
 					</span>
-					<OpenInButton path={configFilePath} label={CONFIG_FILE_NAME} />
+					<OpenInButton
+						path={configFilePath}
+						label={CONFIG_FILE_NAME}
+						projectId={projectId}
+					/>
 				</div>
 
 				<div className="p-4 bg-background/50">

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
@@ -52,6 +52,7 @@ export function TopBar() {
 					<OpenInMenuButton
 						worktreePath={workspace.worktreePath}
 						branch={workspace.worktree?.branch}
+						projectId={workspace.project?.id}
 					/>
 				)}
 				<OrganizationDropdown />

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/components/ClickablePath/ClickablePath.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/components/ClickablePath/ClickablePath.tsx
@@ -27,17 +27,12 @@ interface ClickablePathProps {
 	className?: string;
 }
 
+const defaultApp: ExternalApp = "cursor";
+
 export function ClickablePath({ path, className }: ClickablePathProps) {
 	const [isOpen, setIsOpen] = useState(false);
-	const utils = electronTrpc.useUtils();
-
-	const { data: lastUsedApp = "cursor" } =
-		electronTrpc.settings.getLastUsedApp.useQuery(undefined, {
-			staleTime: 30000,
-		});
 
 	const openInApp = electronTrpc.external.openInApp.useMutation({
-		onSuccess: () => utils.settings.getLastUsedApp.invalidate(),
 		onError: (error) => toast.error(`Failed to open: ${error.message}`),
 	});
 
@@ -81,7 +76,7 @@ export function ClickablePath({ path, className }: ClickablePathProps) {
 					>
 						<img src={app.icon} alt="" className="size-4 object-contain" />
 						<span>{app.label}</span>
-						{app.id === lastUsedApp && (
+						{app.id === defaultApp && (
 							<span className="ml-auto text-xs text-muted-foreground">
 								Default
 							</span>
@@ -106,7 +101,7 @@ export function ClickablePath({ path, className }: ClickablePathProps) {
 							>
 								<img src={app.icon} alt="" className="size-4 object-contain" />
 								<span>{app.label}</span>
-								{app.id === lastUsedApp && (
+								{app.id === defaultApp && (
 									<span className="ml-auto text-xs text-muted-foreground">
 										Default
 									</span>
@@ -133,7 +128,7 @@ export function ClickablePath({ path, className }: ClickablePathProps) {
 							>
 								<img src={app.icon} alt="" className="size-4 object-contain" />
 								<span>{app.label}</span>
-								{app.id === lastUsedApp && (
+								{app.id === defaultApp && (
 									<span className="ml-auto text-xs text-muted-foreground">
 										Default
 									</span>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
@@ -40,6 +40,7 @@ export function ChangesView({ onFileOpen, isExpandedView }: ChangesViewProps) {
 		{ enabled: !!workspaceId },
 	);
 	const worktreePath = workspace?.worktreePath;
+	const projectId = workspace?.projectId;
 
 	const { status, isLoading, effectiveBaseBranch, refetch } =
 		useGitChangesStatus({
@@ -366,6 +367,7 @@ export function ChangesView({ onFileOpen, isExpandedView }: ChangesViewProps) {
 							selectedCommitHash={selectedCommitHash}
 							onFileSelect={(file) => handleFileSelect(file, "against-base")}
 							worktreePath={worktreePath}
+							projectId={projectId}
 							category="against-base"
 							isExpandedView={isExpandedView}
 						/>
@@ -388,6 +390,7 @@ export function ChangesView({ onFileOpen, isExpandedView }: ChangesViewProps) {
 								onFileSelect={handleCommitFileSelect}
 								viewMode={fileListViewMode}
 								worktreePath={worktreePath}
+								projectId={projectId}
 								isExpandedView={isExpandedView}
 							/>
 						))}
@@ -451,6 +454,7 @@ export function ChangesView({ onFileOpen, isExpandedView }: ChangesViewProps) {
 							}
 							isActioning={unstageFileMutation.isPending}
 							worktreePath={worktreePath}
+							projectId={projectId}
 							category="staged"
 							isExpandedView={isExpandedView}
 						/>
@@ -518,6 +522,7 @@ export function ChangesView({ onFileOpen, isExpandedView }: ChangesViewProps) {
 								deleteUntrackedMutation.isPending
 							}
 							worktreePath={worktreePath}
+							projectId={projectId}
 							onDiscard={handleDiscard}
 							category="unstaged"
 							isExpandedView={isExpandedView}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/CommitItem/CommitItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/CommitItem/CommitItem.tsx
@@ -14,6 +14,7 @@ interface CommitItemProps {
 	viewMode: ChangesViewMode;
 	worktreePath: string;
 	isExpandedView?: boolean;
+	projectId?: string;
 }
 
 function CommitHeader({
@@ -48,6 +49,7 @@ export function CommitItem({
 	viewMode,
 	worktreePath,
 	isExpandedView,
+	projectId,
 }: CommitItemProps) {
 	const hasFiles = commit.files.length > 0;
 
@@ -79,6 +81,7 @@ export function CommitItem({
 					selectedCommitHash={selectedCommitHash}
 					onFileSelect={handleFileSelect}
 					worktreePath={worktreePath}
+					projectId={projectId}
 					category="committed"
 					commitHash={commit.hash}
 					isExpandedView={isExpandedView}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileItem/FileItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileItem/FileItem.tsx
@@ -47,6 +47,7 @@ interface FileItemProps {
 	commitHash?: string;
 	/** Expanded view uses scroll-sync highlighting; collapsed view uses selection highlighting */
 	isExpandedView?: boolean;
+	projectId?: string;
 }
 
 function LevelIndicators({ level }: { level: number }) {
@@ -80,6 +81,7 @@ export function FileItem({
 	category,
 	commitHash,
 	isExpandedView = false,
+	projectId,
 }: FileItemProps) {
 	const [showDiscardDialog, setShowDiscardDialog] = useState(false);
 	const { activeFileKey } = useScrollContext();
@@ -104,6 +106,7 @@ export function FileItem({
 			absolutePath,
 			relativePath: file.path,
 			cwd: worktreePath,
+			projectId,
 		});
 
 	const fileDragProps = useFileDrag({ absolutePath });

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileList/FileList.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileList/FileList.tsx
@@ -18,6 +18,7 @@ interface FileListProps {
 	category?: ChangeCategory;
 	commitHash?: string;
 	isExpandedView?: boolean;
+	projectId?: string;
 }
 
 export function FileList({
@@ -35,6 +36,7 @@ export function FileList({
 	category,
 	commitHash,
 	isExpandedView,
+	projectId,
 }: FileListProps) {
 	if (files.length === 0) {
 		return null;
@@ -56,6 +58,7 @@ export function FileList({
 				category={category}
 				commitHash={commitHash}
 				isExpandedView={isExpandedView}
+				projectId={projectId}
 			/>
 		);
 	}
@@ -75,6 +78,7 @@ export function FileList({
 			category={category}
 			commitHash={commitHash}
 			isExpandedView={isExpandedView}
+			projectId={projectId}
 		/>
 	);
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileList/FileListGrouped.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileList/FileListGrouped.tsx
@@ -17,6 +17,7 @@ interface FileListGroupedProps {
 	category?: ChangeCategory;
 	commitHash?: string;
 	isExpandedView?: boolean;
+	projectId?: string;
 }
 
 interface FolderGroup {
@@ -71,6 +72,7 @@ interface FolderGroupItemProps {
 	category?: ChangeCategory;
 	commitHash?: string;
 	isExpandedView?: boolean;
+	projectId?: string;
 }
 
 function FolderGroupItem({
@@ -86,6 +88,7 @@ function FolderGroupItem({
 	category,
 	commitHash,
 	isExpandedView,
+	projectId,
 }: FolderGroupItemProps) {
 	const [isExpanded, setIsExpanded] = useState(true);
 	const displayName = group.folderPath || "Root Path";
@@ -120,6 +123,7 @@ function FolderGroupItem({
 			variant="grouped"
 			folderPath={group.folderPath}
 			worktreePath={worktreePath}
+			projectId={projectId}
 			onStageAll={onStage ? handleStageAll : undefined}
 			onUnstageAll={onUnstage ? handleUnstageAll : undefined}
 			onDiscardAll={onDiscard ? handleDiscardAll : undefined}
@@ -136,6 +140,7 @@ function FolderGroupItem({
 					onUnstage={onUnstage ? () => onUnstage(file) : undefined}
 					isActioning={isActioning}
 					worktreePath={worktreePath}
+					projectId={projectId}
 					onDiscard={onDiscard ? () => onDiscard(file) : undefined}
 					category={category}
 					commitHash={commitHash}
@@ -159,6 +164,7 @@ export function FileListGrouped({
 	category,
 	commitHash,
 	isExpandedView,
+	projectId,
 }: FileListGroupedProps) {
 	const groups = groupFilesByFolder(files);
 
@@ -179,6 +185,7 @@ export function FileListGrouped({
 					category={category}
 					commitHash={commitHash}
 					isExpandedView={isExpandedView}
+					projectId={projectId}
 				/>
 			))}
 		</div>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileList/FileListTree.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileList/FileListTree.tsx
@@ -42,6 +42,7 @@ interface FileListTreeProps {
 	category?: ChangeCategory;
 	commitHash?: string;
 	isExpandedView?: boolean;
+	projectId?: string;
 }
 
 function buildFileTree(files: ChangedFile[]): FileTreeNode[] {
@@ -111,6 +112,7 @@ interface TreeNodeComponentProps {
 	category?: ChangeCategory;
 	commitHash?: string;
 	isExpandedView?: boolean;
+	projectId?: string;
 }
 
 function TreeNodeComponent({
@@ -128,6 +130,7 @@ function TreeNodeComponent({
 	category,
 	commitHash,
 	isExpandedView,
+	projectId,
 }: TreeNodeComponentProps) {
 	const [isExpanded, setIsExpanded] = useState(true);
 	const hasChildren = node.children && node.children.length > 0;
@@ -168,6 +171,7 @@ function TreeNodeComponent({
 				variant="tree"
 				folderPath={node.path}
 				worktreePath={worktreePath}
+				projectId={projectId}
 				onStageAll={onStage ? handleStageAll : undefined}
 				onUnstageAll={onUnstage ? handleUnstageAll : undefined}
 				onDiscardAll={onDiscard ? handleDiscardAll : undefined}
@@ -190,6 +194,7 @@ function TreeNodeComponent({
 						category={category}
 						commitHash={commitHash}
 						isExpandedView={isExpandedView}
+						projectId={projectId}
 					/>
 				))}
 			</FolderRow>
@@ -209,6 +214,7 @@ function TreeNodeComponent({
 				onUnstage={onUnstage ? () => onUnstage(file) : undefined}
 				isActioning={isActioning}
 				worktreePath={worktreePath}
+				projectId={projectId}
 				onDiscard={onDiscard ? () => onDiscard(file) : undefined}
 				category={category}
 				commitHash={commitHash}
@@ -234,6 +240,7 @@ export function FileListTree({
 	category,
 	commitHash,
 	isExpandedView,
+	projectId,
 }: FileListTreeProps) {
 	const tree = buildFileTree(files);
 
@@ -255,6 +262,7 @@ export function FileListTree({
 					category={category}
 					commitHash={commitHash}
 					isExpandedView={isExpandedView}
+					projectId={projectId}
 				/>
 			))}
 		</div>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FolderRow/FolderRow.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FolderRow/FolderRow.tsx
@@ -37,6 +37,7 @@ interface FolderRowProps {
 	onUnstageAll?: () => void;
 	onDiscardAll?: () => void;
 	isActioning?: boolean;
+	projectId?: string;
 }
 
 function LevelIndicators({ level }: { level: number }) {
@@ -112,6 +113,7 @@ export function FolderRow({
 	onUnstageAll,
 	onDiscardAll,
 	isActioning = false,
+	projectId,
 }: FolderRowProps) {
 	const isGrouped = variant === "grouped";
 	const isRoot = folderPath === "";
@@ -121,6 +123,7 @@ export function FolderRow({
 		usePathActions({
 			absolutePath,
 			relativePath: folderPath || undefined,
+			projectId,
 		});
 
 	const triggerContent = (

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
@@ -170,9 +170,13 @@ export function FilesView() {
 	const handleOpenInEditor = useCallback(
 		(entry: DirectoryEntry) => {
 			if (!worktreePath) return;
-			openFileInEditorMutation.mutate({ path: entry.path, cwd: worktreePath });
+			openFileInEditorMutation.mutate({
+				path: entry.path,
+				cwd: worktreePath,
+				projectId,
+			});
 		},
-		[worktreePath, openFileInEditorMutation],
+		[worktreePath, projectId, openFileInEditorMutation],
 	);
 
 	const handleNewFile = useCallback(
@@ -351,6 +355,7 @@ export function FilesView() {
 													key={entry.id}
 													entry={entry}
 													worktreePath={worktreePath}
+													projectId={projectId}
 													onActivate={handleFileActivate}
 													onOpenInEditor={handleOpenInEditor}
 													onNewFile={handleNewFile}
@@ -394,6 +399,7 @@ export function FilesView() {
 														rowHeight={ROW_HEIGHT}
 														indent={TREE_INDENT}
 														worktreePath={worktreePath}
+														projectId={projectId}
 														onActivate={handleFileActivate}
 														onOpenInEditor={handleOpenInEditor}
 														onNewFile={handleNewFile}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileSearchResultItem/FileSearchResultItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileSearchResultItem/FileSearchResultItem.tsx
@@ -24,6 +24,7 @@ import { getFileIcon } from "../../utils";
 interface FileSearchResultItemProps {
 	entry: DirectoryEntry;
 	worktreePath: string;
+	projectId?: string;
 	onActivate: (entry: DirectoryEntry) => void;
 	onOpenInEditor: (entry: DirectoryEntry) => void;
 	onNewFile: (parentPath: string) => void;
@@ -54,6 +55,7 @@ function truncatePathStart(value: string, maxLength: number): string {
 export function FileSearchResultItem({
 	entry,
 	worktreePath,
+	projectId,
 	onActivate,
 	onOpenInEditor,
 	onNewFile,
@@ -81,6 +83,7 @@ export function FileSearchResultItem({
 			absolutePath: entry.path,
 			relativePath: entry.relativePath,
 			cwd: worktreePath,
+			projectId,
 		});
 
 	const fileDragProps = useFileDrag({ absolutePath: entry.path });

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileTreeItem/FileTreeItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileTreeItem/FileTreeItem.tsx
@@ -29,6 +29,7 @@ interface FileTreeItemProps {
 	rowHeight: number;
 	indent: number;
 	worktreePath: string;
+	projectId?: string;
 	onActivate: (entry: DirectoryEntry) => void;
 	onOpenInEditor: (entry: DirectoryEntry) => void;
 	onNewFile: (parentPath: string) => void;
@@ -43,6 +44,7 @@ export function FileTreeItem({
 	rowHeight,
 	indent,
 	worktreePath,
+	projectId,
 	onActivate,
 	onOpenInEditor,
 	onNewFile,
@@ -64,6 +66,7 @@ export function FileTreeItem({
 			absolutePath: entry.path,
 			relativePath: entry.relativePath,
 			cwd: worktreePath,
+			projectId,
 		});
 
 	const fileDragProps = useFileDrag({ absolutePath: entry.path });

--- a/packages/local-db/drizzle/0027_per_project_default_app.sql
+++ b/packages/local-db/drizzle/0027_per_project_default_app.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `projects` ADD `default_app` text;--> statement-breakpoint
+ALTER TABLE `settings` DROP COLUMN `last_used_app`;

--- a/packages/local-db/drizzle/meta/0027_snapshot.json
+++ b/packages/local-db/drizzle/meta/0027_snapshot.json
@@ -1,0 +1,1210 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0a13d4fc-215b-41bb-9a42-29becaf02803",
+  "prevId": "f9a3301f-7c42-4e88-a95d-bca4ce39da98",
+  "tables": {
+    "browser_history": {
+      "name": "browser_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_visited_at": {
+          "name": "last_visited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visit_count": {
+          "name": "visit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "browser_history_url_unique": {
+          "name": "browser_history_url_unique",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "browser_history_url_idx": {
+          "name": "browser_history_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": false
+        },
+        "browser_history_last_visited_at_idx": {
+          "name": "browser_history_last_visited_at_idx",
+          "columns": [
+            "last_visited_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_organization_id_idx": {
+          "name": "organization_members_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_user_id_idx": {
+          "name": "organization_members_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_users_id_fk": {
+          "name": "organization_members_user_id_users_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_org": {
+          "name": "github_org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_clerk_org_id_unique": {
+          "name": "organizations_clerk_org_id_unique",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_idx": {
+          "name": "organizations_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "organizations_clerk_org_id_idx": {
+          "name": "organizations_clerk_org_id_idx",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "main_repo_path": {
+          "name": "main_repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_toast_dismissed": {
+          "name": "config_toast_dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_owner": {
+          "name": "github_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hide_image": {
+          "name": "hide_image",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_project_id": {
+          "name": "neon_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_app": {
+          "name": "default_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_main_repo_path_idx": {
+          "name": "projects_main_repo_path_idx",
+          "columns": [
+            "main_repo_path"
+          ],
+          "isUnique": false
+        },
+        "projects_last_opened_at_idx": {
+          "name": "projects_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_active_workspace_id": {
+          "name": "last_active_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets": {
+          "name": "terminal_presets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets_initialized": {
+          "name": "terminal_presets_initialized",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_ringtone_id": {
+          "name": "selected_ringtone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirm_on_quit": {
+          "name": "confirm_on_quit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_link_behavior": {
+          "name": "terminal_link_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "persist_terminal": {
+          "name": "persist_terminal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_apply_default_preset": {
+          "name": "auto_apply_default_preset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_sounds_muted": {
+          "name": "notification_sounds_muted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delete_local_branch": {
+          "name": "delete_local_branch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_open_mode": {
+          "name": "file_open_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_presets_bar": {
+          "name": "show_presets_bar",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_family": {
+          "name": "terminal_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_size": {
+          "name": "terminal_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_family": {
+          "name": "editor_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_size": {
+          "name": "editor_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_color": {
+          "name": "status_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_type": {
+          "name": "status_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_position": {
+          "name": "status_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "estimate": {
+          "name": "estimate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_provider": {
+          "name": "external_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tasks_slug_unique": {
+          "name": "tasks_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "tasks_slug_idx": {
+          "name": "tasks_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "tasks_organization_id_idx": {
+          "name": "tasks_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_assignee_id_idx": {
+          "name": "tasks_assignee_id_idx",
+          "columns": [
+            "assignee_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_status_idx": {
+          "name": "tasks_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "tasks_created_at_idx": {
+          "name": "tasks_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_organization_id_organizations_id_fk": {
+          "name": "tasks_organization_id_organizations_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_assignee_id_users_id_fk": {
+          "name": "tasks_assignee_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tasks_creator_id_users_id_fk": {
+          "name": "tasks_creator_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": true
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "users_clerk_id_idx": {
+          "name": "users_clerk_id_idx",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_id": {
+          "name": "worktree_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_unread": {
+          "name": "is_unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_unnamed": {
+          "name": "is_unnamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "deleting_at": {
+          "name": "deleting_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "port_base": {
+          "name": "port_base",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_project_id_idx": {
+          "name": "workspaces_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_worktree_id_idx": {
+          "name": "workspaces_worktree_id_idx",
+          "columns": [
+            "worktree_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_last_opened_at_idx": {
+          "name": "workspaces_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspaces_project_id_projects_id_fk": {
+          "name": "workspaces_project_id_projects_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_worktree_id_worktrees_id_fk": {
+          "name": "workspaces_worktree_id_worktrees_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "worktrees",
+          "columnsFrom": [
+            "worktree_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "worktrees": {
+      "name": "worktrees",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_status": {
+          "name": "git_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_status": {
+          "name": "github_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "worktrees_project_id_idx": {
+          "name": "worktrees_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "worktrees_branch_idx": {
+          "name": "worktrees_branch_idx",
+          "columns": [
+            "branch"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "worktrees_project_id_projects_id_fk": {
+          "name": "worktrees_project_id_projects_id_fk",
+          "tableFrom": "worktrees",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/local-db/drizzle/meta/_journal.json
+++ b/packages/local-db/drizzle/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1771214717763,
       "tag": "0026_browser_history",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "6",
+      "when": 1771524526706,
+      "tag": "0027_per_project_default_app",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/local-db/src/schema/schema.ts
+++ b/packages/local-db/src/schema/schema.ts
@@ -41,6 +41,7 @@ export const projects = sqliteTable(
 		hideImage: integer("hide_image", { mode: "boolean" }),
 		iconUrl: text("icon_url"),
 		neonProjectId: text("neon_project_id"),
+		defaultApp: text("default_app").$type<ExternalApp>(),
 	},
 	(table) => [
 		index("projects_main_repo_path_idx").on(table.mainRepoPath),
@@ -138,7 +139,6 @@ export type SelectWorkspace = typeof workspaces.$inferSelect;
 export const settings = sqliteTable("settings", {
 	id: integer("id").primaryKey().default(1),
 	lastActiveWorkspaceId: text("last_active_workspace_id"),
-	lastUsedApp: text("last_used_app").$type<ExternalApp>(),
 	terminalPresets: text("terminal_presets", { mode: "json" }).$type<
 		TerminalPreset[]
 	>(),


### PR DESCRIPTION
## Summary
- Move preferred IDE from global `settings.lastUsedApp` to per-project `projects.defaultApp` so each project remembers its own editor choice independently
- Add `defaultApp` column to `projects` table, remove `lastUsedApp` from `settings` table (migration `0027_per_project_default_app`)
- Thread `projectId` through all "Open in" UI consumers (TopBar, OpenInButton, ChangesView file tree, FilesView file tree, context menus) so the correct per-project default is resolved everywhere

## Test plan
- [ ] Open Project A → select Cursor from the Open dropdown. Open Project B → select VS Code. Switch between projects — Cmd+O remembers each project's choice independently
- [ ] Right-click a file in the file tree → "Open in Editor" uses the project's default app
- [ ] Double-click a file in the file tree opens in the project's default app
- [ ] Settings page ClickablePath still opens with "cursor" default (no project context)
- [ ] Fresh project with no default set falls back to Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Per-project default app configuration. Users can now set a preferred application for opening files for each project individually. Previously, the app used a global default setting. Project-specific preferences are automatically applied when opening files and fall back to cursor if no default is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->