### PR TITLE
feat(desktop): middle-click to close workspace sidebar items

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/CollapsedWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/CollapsedWorkspaceItem.tsx
@@ -62,6 +62,12 @@ export function CollapsedWorkspaceItem({
 			}}
 			type="button"
 			onClick={onClick}
+			onAuxClick={(e) => {
+				if (e.button === 1) {
+					e.preventDefault();
+					onDeleteClick();
+				}
+			}}
 			onMouseEnter={onMouseEnter}
 			className={cn(
 				"relative flex items-center justify-center size-8 rounded-md",
@@ -81,15 +87,24 @@ export function CollapsedWorkspaceItem({
 
 	if (isBranchWorkspace) {
 		return (
-			<Tooltip delayDuration={300}>
-				<TooltipTrigger asChild>{collapsedButton}</TooltipTrigger>
-				<TooltipContent side="right" className="flex flex-col gap-0.5">
-					<span className="font-medium">local</span>
-					<span className="text-xs text-muted-foreground font-mono">
-						{branch}
-					</span>
-				</TooltipContent>
-			</Tooltip>
+			<>
+				<Tooltip delayDuration={300}>
+					<TooltipTrigger asChild>{collapsedButton}</TooltipTrigger>
+					<TooltipContent side="right" className="flex flex-col gap-0.5">
+						<span className="font-medium">local</span>
+						<span className="text-xs text-muted-foreground font-mono">
+							{branch}
+						</span>
+					</TooltipContent>
+				</Tooltip>
+				<DeleteWorkspaceDialog
+					workspaceId={id}
+					workspaceName={name}
+					workspaceType={type}
+					open={showDeleteDialog}
+					onOpenChange={setShowDeleteDialog}
+				/>
+			</>
 		);
 	}
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -306,6 +306,12 @@ export function WorkspaceListItem({
 					handleClick();
 				}
 			}}
+			onAuxClick={(e) => {
+				if (e.button === 1) {
+					e.preventDefault();
+					handleDeleteClick();
+				}
+			}}
 			onMouseEnter={handleMouseEnter}
 			onDoubleClick={isBranchWorkspace ? undefined : rename.startRename}
 			className={cn(


### PR DESCRIPTION
## Summary
- Add middle mouse button (auxclick, button === 1) to close workspace items in the sidebar, matching the existing pattern in GroupItem tab strip
- Works for both expanded and collapsed sidebar states
- All paths go through the existing `DeleteWorkspaceDialog` confirmation

Closes SUPER-298
## Test plan
- [ ] Middle-click a workspace in the expanded sidebar → delete confirmation dialog appears
- [ ] Middle-click a workspace in the collapsed sidebar → delete confirmation dialog appears
- [ ] Middle-click a branch workspace (collapsed) → delete confirmation dialog appears
- [ ] Left-click still navigates, right-click still shows context menu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now middle-click on workspace items in the sidebar to delete them directly, providing a quicker alternative to existing deletion methods.
  * Workspace deletion experience has been enhanced with an improved confirmation dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->