### PR TITLE
fix(desktop): handle unsupported file types in chat attachments

### DIFF
--- a/apps/desktop/src/main/lib/agent-manager/utils/run-agent.ts
+++ b/apps/desktop/src/main/lib/agent-manager/utils/run-agent.ts
@@ -103,10 +103,19 @@ export async function runAgent(options: RunAgentOptions): Promise<void> {
 										mimeType: f.mediaType as `image/${string}`,
 									};
 								}
+								// Anthropic only supports text/plain, application/pdf, and
+								// image/* for file parts. Normalize other text-based types
+								// (e.g. text/markdown, text/csv, application/json) to
+								// text/plain so they don't throw
+								// AI_UnsupportedFunctionalityError.
+								const normalizedMimeType =
+									f.mediaType === "application/pdf"
+										? f.mediaType
+										: "text/plain";
 								return {
 									type: "file" as const,
 									data: new URL(f.url),
-									mimeType: f.mediaType,
+									mimeType: normalizedMimeType,
 								};
 							}),
 						],

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/MessagePartsRenderer/MessagePartsRenderer.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/MessagePartsRenderer/MessagePartsRenderer.tsx
@@ -3,6 +3,7 @@ import { MessageResponse } from "@superset/ui/ai-elements/message";
 import type { UIMessage } from "ai";
 import { getToolName, isToolUIPart } from "ai";
 import {
+	AlertCircleIcon,
 	FileIcon,
 	FileSearchIcon,
 	FolderTreeIcon,
@@ -64,6 +65,21 @@ export function MessagePartsRenderer({
 					>
 						{part.text}
 					</MessageResponse>,
+				);
+				i++;
+				continue;
+			}
+
+			if ((part as { type: string }).type === "error") {
+				const errorPart = part as unknown as { type: "error"; text: string };
+				nodes.push(
+					<div
+						key={i}
+						className="flex items-start gap-2 rounded-md border border-destructive/20 bg-destructive/10 px-4 py-2 text-sm text-destructive"
+					>
+						<AlertCircleIcon className="mt-0.5 h-4 w-4 shrink-0" />
+						<span className="select-text">{errorPart.text}</span>
+					</div>,
 				);
 				i++;
 				continue;

--- a/packages/durable-session/src/session-db/collections/messages/materialize.ts
+++ b/packages/durable-session/src/session-db/collections/messages/materialize.ts
@@ -305,7 +305,10 @@ function materializeStreamedMessage(rows: ChunkRow[]): MessageRow {
 				isComplete = true;
 				break;
 			case "error":
-				parts.push({ type: "text", text: `Error: ${c.errorText}` });
+				parts.push({
+					type: "error",
+					text: c.errorText ?? "An error occurred",
+				} as unknown as AnyUIMessagePart);
 				break;
 			case "message-metadata":
 				// No-op


### PR DESCRIPTION
## Summary
- Normalize non-image, non-PDF MIME types (e.g. `text/markdown`, `text/csv`, `application/json`) to `text/plain` before passing to the AI SDK, since Anthropic only supports `image/*`, `application/pdf`, and `text/plain` for file content parts
- Render agent stream errors in a styled error component (red destructive banner) instead of as raw text in chat output

Closes SUPER-315

## Test plan
- [ ] Attach a `.md` file to chat — should no longer throw `AI_UnsupportedFunctionalityError`
- [ ] Attach other text-based files (`.csv`, `.html`, `.json`) — should work without error
- [ ] Force an agent error (e.g. temporarily revert the MIME fix) — error should render in red error banner, not as plain text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Error messages now display with distinctive visual styling and icons for improved clarity

* **Bug Fixes**
  * Improved file type handling to better normalize and process different document formats
  * Enhanced error handling in message streaming to display errors more clearly and consistently

<!-- end of auto-generated comment: release notes by coderabbit.ai -->