### PR TITLE
fix(db): add IF EXISTS to constraint drop in migration 0018

### DIFF
--- a/packages/db/drizzle/0018_sandbox_and_slack_users.sql
+++ b/packages/db/drizzle/0018_sandbox_and_slack_users.sql
@@ -64,7 +64,7 @@ CREATE TABLE "workspaces" (
 --> statement-breakpoint
 ALTER TABLE "repositories" DISABLE ROW LEVEL SECURITY;--> statement-breakpoint
 DROP TABLE "repositories" CASCADE;--> statement-breakpoint
-ALTER TABLE "tasks" DROP CONSTRAINT "tasks_repository_id_repositories_id_fk";
+ALTER TABLE "tasks" DROP CONSTRAINT IF EXISTS "tasks_repository_id_repositories_id_fk";
 --> statement-breakpoint
 DROP INDEX "tasks_repository_id_idx";--> statement-breakpoint
 ALTER TABLE "projects" ADD CONSTRAINT "projects_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "auth"."organizations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint


### PR DESCRIPTION
## Summary
- Migration `0018_sandbox_and_slack_users.sql` runs `DROP TABLE "repositories" CASCADE` which already removes the FK constraint via cascade
- The subsequent `ALTER TABLE "tasks" DROP CONSTRAINT "tasks_repository_id_repositories_id_fk"` then fails because the constraint no longer exists
- Adding `IF EXISTS` makes the migration idempotent and unblocks fresh DB setups

## Test plan
- [ ] Run `bun run --cwd packages/db migrate` on a fresh Neon branch — migrations should apply cleanly through all 20 migrations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced database migration process to gracefully handle scenarios where expected database constraints may not exist, preventing potential migration failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->