### PR TITLE
feat(desktop): open new files in raw/rendered mode instead of diff view

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
@@ -133,6 +133,7 @@ export function RightSidebar() {
 			addFileViewerPane(workspaceId, {
 				filePath: file.path,
 				diffCategory: category,
+				fileStatus: file.status,
 				commitHash,
 				oldPath: file.oldPath,
 			});

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -656,6 +656,7 @@ export const useTabsStore = create<TabsStore>()(
 							filePath: options.filePath,
 							diffCategory: options.diffCategory,
 							viewMode: options.viewMode,
+							fileStatus: options.fileStatus,
 						});
 
 						set({

--- a/apps/desktop/src/renderer/stores/tabs/types.ts
+++ b/apps/desktop/src/renderer/stores/tabs/types.ts
@@ -1,5 +1,5 @@
 import type { MosaicBranch, MosaicNode } from "react-mosaic-component";
-import type { ChangeCategory } from "shared/changes-types";
+import type { ChangeCategory, FileStatus } from "shared/changes-types";
 import type {
 	BaseTab,
 	BaseTabsState,
@@ -51,6 +51,8 @@ export interface AddFileViewerPaneOptions {
 	/** Override default view mode (raw/diff/rendered) */
 	viewMode?: FileViewerMode;
 	diffCategory?: ChangeCategory;
+	/** File status from git — used to determine default view mode for new files */
+	fileStatus?: FileStatus;
 	commitHash?: string;
 	oldPath?: string;
 	/** Line to scroll to (raw mode only) */

--- a/apps/desktop/src/renderer/stores/tabs/utils.test.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "bun:test";
 import type { MosaicNode } from "react-mosaic-component";
+import type { FileStatus } from "shared/changes-types";
 import type { Tab } from "./types";
 import {
 	buildMultiPaneLayout,
 	findPanePath,
 	getAdjacentPaneId,
 	resolveActiveTabIdForWorkspace,
+	resolveFileViewerMode,
 } from "./utils";
 
 describe("findPanePath", () => {
@@ -398,5 +400,123 @@ describe("buildMultiPaneLayout", () => {
 			second: "pane-3",
 			splitPercentage: 50,
 		});
+	});
+});
+
+describe("resolveFileViewerMode", () => {
+	it("returns diff for modified file with diffCategory", () => {
+		expect(
+			resolveFileViewerMode({
+				filePath: "src/app.ts",
+				diffCategory: "unstaged",
+				fileStatus: "modified",
+			}),
+		).toBe("diff");
+	});
+
+	it("returns raw for added file with diffCategory", () => {
+		expect(
+			resolveFileViewerMode({
+				filePath: "src/new-file.ts",
+				diffCategory: "staged",
+				fileStatus: "added",
+			}),
+		).toBe("raw");
+	});
+
+	it("returns raw for untracked file with diffCategory", () => {
+		expect(
+			resolveFileViewerMode({
+				filePath: "src/untracked.ts",
+				diffCategory: "unstaged",
+				fileStatus: "untracked",
+			}),
+		).toBe("raw");
+	});
+
+	it("returns rendered for added markdown with diffCategory", () => {
+		expect(
+			resolveFileViewerMode({
+				filePath: "docs/README.md",
+				diffCategory: "staged",
+				fileStatus: "added",
+			}),
+		).toBe("rendered");
+	});
+
+	it("returns diff for renamed file with diffCategory", () => {
+		expect(
+			resolveFileViewerMode({
+				filePath: "src/renamed.ts",
+				diffCategory: "committed",
+				fileStatus: "renamed",
+			}),
+		).toBe("diff");
+	});
+
+	it("returns diff for copied file with diffCategory", () => {
+		expect(
+			resolveFileViewerMode({
+				filePath: "src/copied.ts",
+				diffCategory: "committed",
+				fileStatus: "copied",
+			}),
+		).toBe("diff");
+	});
+
+	it("returns diff for deleted file with diffCategory", () => {
+		expect(
+			resolveFileViewerMode({
+				filePath: "src/removed.ts",
+				diffCategory: "staged",
+				fileStatus: "deleted",
+			}),
+		).toBe("diff");
+	});
+
+	it("returns diff when fileStatus is undefined (backward compat)", () => {
+		expect(
+			resolveFileViewerMode({
+				filePath: "src/file.ts",
+				diffCategory: "unstaged",
+			}),
+		).toBe("diff");
+	});
+
+	it("returns raw when no diffCategory and not renderable", () => {
+		expect(
+			resolveFileViewerMode({
+				filePath: "src/file.ts",
+			}),
+		).toBe("raw");
+	});
+
+	it("returns rendered when no diffCategory and file is markdown", () => {
+		expect(
+			resolveFileViewerMode({
+				filePath: "README.md",
+			}),
+		).toBe("rendered");
+	});
+
+	it("returns rendered for image files regardless of other options", () => {
+		expect(
+			resolveFileViewerMode({
+				filePath: "assets/logo.png",
+				diffCategory: "unstaged",
+				fileStatus: "modified",
+			}),
+		).toBe("rendered");
+	});
+
+	it("respects explicit viewMode override", () => {
+		expect(
+			resolveFileViewerMode({
+				filePath: "src/file.ts",
+				diffCategory: "unstaged",
+				fileStatus: "added",
+				viewMode: "diff",
+			}),
+		).toBe("diff");
 	});
 });

--- a/apps/desktop/src/shared/changes-types.ts
+++ b/apps/desktop/src/shared/changes-types.ts
@@ -54,6 +54,11 @@ export interface GitChangesStatus {
 	hasUpstream: boolean; // Whether branch has an upstream tracking branch
 }
 
+/** Whether a file status represents a brand-new file (no previous version to diff against) */
+export function isNewFile(status: FileStatus): boolean {
+	return status === "added" || status === "untracked";
+}
+
 /** Whether a diff category supports editing (saving changes back to disk) */
 export function isDiffEditable(category: ChangeCategory): boolean {
 	return category === "staged" || category === "unstaged";


### PR DESCRIPTION
## Summary
- When opening brand-new files (`added`/`untracked`) from the Changes sidebar, show them in raw view (or rendered for markdown) instead of diff view, since an all-green diff provides no useful information
- Modified, deleted, renamed, and copied files continue to open in diff view as before
- Backward compatible — callers that don't pass `fileStatus` get the existing diff behavior

## Test plan
- [x] `bun test apps/desktop/src/renderer/stores/tabs/utils.test.ts` — 12 new tests covering all file status + diffCategory combinations
- [x] `bun run typecheck` — passes across all 18 packages
- [x] Manual: open a brand-new `.ts` file from Changes sidebar → opens in raw view
- [x] Manual: open a brand-new `.md` file from Changes sidebar → opens in rendered view
- [x] Manual: open a modified file from Changes sidebar → opens in diff view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced file viewer to intelligently select the appropriate display mode based on Git file status. New and untracked files now display in rendered preview or raw view instead of diff mode by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->