### PR TITLE
fix(desktop): use BIN_DIR for agent hook PATH in worktree-local setups

### DIFF
--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts
@@ -23,14 +23,15 @@ const OPENCODE_PLUGIN_TEMPLATE_PATH = path.join(
 	"opencode-plugin.template.js",
 );
 
-const REAL_BINARY_RESOLVER = `find_real_binary() {
+function buildRealBinaryResolver(): string {
+	return `find_real_binary() {
   local name="$1"
   local IFS=:
   for dir in $PATH; do
     [ -z "$dir" ] && continue
     dir="\${dir%/}"
     case "$dir" in
-      "$HOME"/.superset/bin|"$HOME"/.superset-*/bin) continue ;;
+      "${BIN_DIR}"|"$HOME"/.superset/bin|"$HOME"/.superset-*/bin) continue ;;
     esac
     if [ -x "$dir/$name" ] && [ ! -d "$dir/$name" ]; then
       printf "%s\\n" "$dir/$name"
@@ -40,6 +41,7 @@ const REAL_BINARY_RESOLVER = `find_real_binary() {
   return 1
 }
 `;
+}
 
 function getMissingBinaryMessage(name: string): string {
 	return `Superset: ${name} not found in PATH. Install it and ensure it is on PATH, then retry.`;
@@ -94,7 +96,7 @@ ${WRAPPER_MARKER}
 # Superset wrapper for Claude Code
 # Injects notification hook settings
 
-${REAL_BINARY_RESOLVER}
+${buildRealBinaryResolver()}
 REAL_BIN="$(find_real_binary "claude")"
 if [ -z "$REAL_BIN" ]; then
   echo "${getMissingBinaryMessage("claude")}" >&2
@@ -111,7 +113,7 @@ ${WRAPPER_MARKER}
 # Superset wrapper for Codex
 # Injects notification hook settings
 
-${REAL_BINARY_RESOLVER}
+${buildRealBinaryResolver()}
 REAL_BIN="$(find_real_binary "codex")"
 if [ -z "$REAL_BIN" ]; then
   echo "${getMissingBinaryMessage("codex")}" >&2
@@ -128,7 +130,7 @@ ${WRAPPER_MARKER}
 # Superset wrapper for OpenCode
 # Injects OPENCODE_CONFIG_DIR for notification plugin
 
-${REAL_BINARY_RESOLVER}
+${buildRealBinaryResolver()}
 REAL_BIN="$(find_real_binary "opencode")"
 if [ -z "$REAL_BIN" ]; then
   echo "${getMissingBinaryMessage("opencode")}" >&2

--- a/apps/desktop/src/main/lib/agent-setup/shell-wrappers.ts
+++ b/apps/desktop/src/main/lib/agent-setup/shell-wrappers.ts
@@ -1,8 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { SUPERSET_DIR_NAME } from "shared/constants";
-import { BASH_DIR, ZSH_DIR } from "./paths";
+import { BASH_DIR, BIN_DIR, ZSH_DIR } from "./paths";
 
 const ZSH_RC = path.join(ZSH_DIR, ".zshrc");
 const BASH_RCFILE = path.join(BASH_DIR, "rcfile");
@@ -22,7 +21,7 @@ _superset_home="\${SUPERSET_ORIG_ZDOTDIR:-$HOME}"
 _superset_home="\${SUPERSET_ORIG_ZDOTDIR:-$HOME}"
 export ZDOTDIR="$_superset_home"
 [[ -f "$_superset_home/.zshrc" ]] && source "$_superset_home/.zshrc"
-export PATH="$HOME/${SUPERSET_DIR_NAME}/bin:$PATH"
+export PATH="${BIN_DIR}:$PATH"
 `;
 	fs.writeFileSync(zshrcPath, zshrcScript, { mode: 0o644 });
 	console.log("[agent-setup] Created zsh wrapper");
@@ -48,7 +47,7 @@ fi
 [[ -f "$HOME/.bashrc" ]] && source "$HOME/.bashrc"
 
 # Prepend superset bin to PATH
-export PATH="$HOME/${SUPERSET_DIR_NAME}/bin:$PATH"
+export PATH="${BIN_DIR}:$PATH"
 # Minimal prompt (path/env shown in toolbar) - emerald to match app theme
 export PS1=$'\\[\\e[1;38;2;52;211;153m\\]❯\\[\\e[0m\\] '
 `;


### PR DESCRIPTION
## Summary
- Agent hooks stopped working in dev because shell wrappers hardcoded the PATH from `SUPERSET_DIR_NAME` (`$HOME/.superset-<name>/bin`), which doesn't match when `SUPERSET_HOME_DIR` is overridden to a worktree-local path via `.env`
- `which claude` returned the real binary instead of the wrapper, so `--settings` was never passed and hooks never fired

## Changes
- **`shell-wrappers.ts`**: Use `BIN_DIR` (derived from `SUPERSET_HOME_DIR`) instead of reconstructing from `SUPERSET_DIR_NAME` for PATH prepend in both zsh and bash wrappers
- **`agent-wrappers.ts`**: Convert `REAL_BINARY_RESOLVER` from a static string to `buildRealBinaryResolver()` function that interpolates `BIN_DIR` into the case skip pattern, preventing infinite recursion when the wrapper lives at a worktree-local path

## Test Plan
- [ ] Start dev app from a worktree with `SUPERSET_HOME_DIR` set to a worktree-local path
- [ ] Open a terminal and verify `which claude` returns the wrapper binary path
- [ ] Run `claude` and confirm hooks fire (status indicator changes on Start/Stop)
- [ ] Verify existing `~/.superset/` (production) setup still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal agent setup and shell wrapper logic to improve code maintainability and path resolution handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->