### PR TITLE
fix(test): fix failing materialize test and move test temp dirs to os.tmpdir()

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.test.ts
@@ -1,13 +1,20 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { execSync } from "node:child_process";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	realpathSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createWorktree } from "./git";
 
-// We need to test the internal functions, so we'll import the module
-// and test the exported functions that use them
-
-const TEST_DIR = join(__dirname, ".test-git-tmp");
+const TEST_DIR = join(
+	realpathSync(tmpdir()),
+	`superset-test-git-${process.pid}`,
+);
 
 function createTestRepo(name: string): string {
 	const repoPath = join(TEST_DIR, name);
@@ -73,8 +80,8 @@ describe("getDefaultBranch", () => {
 		cleanup: () => void;
 	} {
 		const testDir = join(
-			__dirname,
-			`.test-${testName}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+			realpathSync(tmpdir()),
+			`superset-test-${testName}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
 		);
 		mkdirSync(testDir, { recursive: true });
 		execSync("git init", { cwd: testDir, stdio: "ignore" });

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/setup.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/setup.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { PROJECTS_DIR_NAME, SUPERSET_DIR_NAME } from "shared/constants";
 import { loadSetupConfig } from "./setup";
 
-const TEST_DIR = join(__dirname, ".test-tmp");
+const TEST_DIR = join(tmpdir(), `superset-test-setup-${process.pid}`);
 const MAIN_REPO = join(TEST_DIR, "main-repo");
 const WORKTREE = join(TEST_DIR, "worktree");
 const PROJECT_ID = "test-project-id";

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/teardown.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/teardown.test.ts
@@ -6,12 +6,12 @@ import {
 	rmSync,
 	writeFileSync,
 } from "node:fs";
-import { homedir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { PROJECTS_DIR_NAME, SUPERSET_DIR_NAME } from "shared/constants";
 import { runTeardown } from "./teardown";
 
-const TEST_DIR = join(__dirname, ".test-tmp-teardown");
+const TEST_DIR = join(tmpdir(), `superset-test-teardown-${process.pid}`);
 const MAIN_REPO = join(TEST_DIR, "main-repo");
 const WORKTREE = join(TEST_DIR, "worktree");
 const PROJECT_ID = "test-teardown-project";

--- a/apps/desktop/src/main/lib/static-ports/loader.test.ts
+++ b/apps/desktop/src/main/lib/static-ports/loader.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { hasStaticPortsConfig, loadStaticPorts } from "./loader";
 
-const TEST_DIR = join(__dirname, ".test-tmp");
+const TEST_DIR = join(tmpdir(), `superset-test-loader-${process.pid}`);
 const WORKTREE_PATH = join(TEST_DIR, "worktree");
 const SUPERSET_DIR = join(WORKTREE_PATH, ".superset");
 const PORTS_FILE = join(SUPERSET_DIR, "ports.json");

--- a/packages/durable-session/src/session-db/collections/messages/materialize.test.ts
+++ b/packages/durable-session/src/session-db/collections/messages/materialize.test.ts
@@ -295,9 +295,7 @@ describe("materializeMessage", () => {
 		];
 
 		const result = materializeMessage(rows);
-		expect(result.parts).toEqual([
-			{ type: "text", text: "Error: something broke" },
-		]);
+		expect(result.parts).toEqual([{ type: "error", text: "something broke" }]);
 	});
 
 	it("skips custom chunk types (config, control)", () => {


### PR DESCRIPTION
## Summary
- Fix failing `materialize.test.ts` error chunk test that expected stale behavior
- Move 4 test files from `__dirname`-relative temp directories to `os.tmpdir()` to prevent committable artifacts from being left in the repo

## Changes
**packages/durable-session**
- `materialize.test.ts`: Update error chunk expectation from `{type: "text", text: "Error: ..."}` to `{type: "error", text: "..."}` to match implementation

**apps/desktop**
- `loader.test.ts`: Move temp dir from `__dirname/.test-tmp` to `tmpdir()/superset-test-loader-{pid}`
- `setup.test.ts`: Move temp dir from `__dirname/.test-tmp` to `tmpdir()/superset-test-setup-{pid}`
- `teardown.test.ts`: Move temp dir from `__dirname/.test-tmp-teardown` to `tmpdir()/superset-test-teardown-{pid}`
- `git.test.ts`: Move temp dirs from `__dirname/.test-git-tmp` to `tmpdir()/superset-test-git-{pid}` with `realpathSync` to handle macOS `/var` → `/private/var` symlink for git worktree path matching

## Test Plan
- [x] All 1227 tests pass, 0 failures
- [x] `git status` is clean after test run (no leftover artifacts)
- [x] Lint and typecheck pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to use system temporary directories for better artifact isolation and process-specific test environments.
  * Improved error handling in materialization tests to use dedicated error-type rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->