### PR TITLE
fix(desktop): set SSL_CERT_FILE fallback on macOS to fix TLS verification in terminal

### DIFF
--- a/apps/desktop/src/main/lib/terminal/env.test.ts
+++ b/apps/desktop/src/main/lib/terminal/env.test.ts
@@ -550,6 +550,7 @@ describe("env", () => {
 			"NEXT_PUBLIC_TEST",
 			"DATABASE_URL",
 			"CLERK_SECRET_KEY",
+			"SSL_CERT_FILE",
 		];
 
 		beforeEach(() => {
@@ -676,6 +677,22 @@ describe("env", () => {
 			const result = buildTerminalEnv(baseParams);
 			expect(result.SUPERSET_HOOK_VERSION).toBeDefined();
 			expect(result.SUPERSET_HOOK_VERSION).toBe("2");
+		});
+
+		describe("SSL_CERT_FILE fallback on macOS", () => {
+			it("should set SSL_CERT_FILE to system cert bundle on macOS when not already set", () => {
+				delete process.env.SSL_CERT_FILE;
+				const result = buildTerminalEnv(baseParams);
+				if (process.platform === "darwin") {
+					expect(result.SSL_CERT_FILE).toBe("/etc/ssl/cert.pem");
+				}
+			});
+
+			it("should not override user-set SSL_CERT_FILE", () => {
+				process.env.SSL_CERT_FILE = "/custom/certs/ca-bundle.crt";
+				const result = buildTerminalEnv(baseParams);
+				expect(result.SSL_CERT_FILE).toBe("/custom/certs/ca-bundle.crt");
+			});
 		});
 
 		describe("COLORFGBG for light mode detection", () => {


### PR DESCRIPTION
## Summary
- Fixes TLS certificate verification error (`x509: OSStatus -26276`) when running tools like `gh auth login` inside the Superset terminal on macOS
- Go binaries use the macOS Security framework (Keychain) for cert verification, which fails when spawned from Electron's process tree
- Sets `SSL_CERT_FILE=/etc/ssl/cert.pem` as a file-based fallback when not already set by the user

## Changes
- **`apps/desktop/src/main/lib/terminal/env.ts`**: In `buildTerminalEnv`, proactively set `SSL_CERT_FILE` to the macOS system certificate bundle (`/etc/ssl/cert.pem`) when on macOS and the variable isn't already set. Includes an `fs.existsSync` guard.
- **`apps/desktop/src/main/lib/terminal/env.test.ts`**: Added tests verifying the fallback is set on macOS and that user-provided values are not overridden.

## Test Plan
- [ ] Open a Superset terminal on macOS and run `gh auth login -h github.com` — should no longer fail with TLS error
- [ ] Verify `echo $SSL_CERT_FILE` in Superset terminal shows `/etc/ssl/cert.pem`
- [ ] Set `SSL_CERT_FILE` in shell profile to a custom path, verify Superset terminal respects it
- [ ] Run `bun test apps/desktop/src/main/lib/terminal/env.test.ts` — all 72 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSL certificate handling on macOS: when not configured, SSL_CERT_FILE now defaults to the system certificate path; existing user settings are preserved.
* **Tests**
  * Added tests covering the macOS SSL_CERT_FILE fallback and ensuring user-set values are not overridden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->