### PR TITLE
fix(desktop): persist task filters across navigation

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/TasksView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/TasksView.tsx
@@ -1,9 +1,10 @@
 import { Spinner } from "@superset/ui/spinner";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useNavigate } from "@tanstack/react-router";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { HiCheckCircle } from "react-icons/hi2";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useTasksFilterStore } from "../../stores/tasks-filter-state";
 import { LinearCTA } from "./components/LinearCTA";
 import { TasksTableView } from "./components/TasksTableView";
 import { type TabValue, TasksTopBar } from "./components/TasksTopBar";
@@ -11,14 +12,26 @@ import { type TaskWithStatus, useTasksTable } from "./hooks/useTasksTable";
 
 interface TasksViewProps {
 	initialTab?: "all" | "active" | "backlog";
+	initialAssignee?: string;
 }
 
-export function TasksView({ initialTab }: TasksViewProps) {
+export function TasksView({ initialTab, initialAssignee }: TasksViewProps) {
 	const navigate = useNavigate();
 	const collections = useCollections();
 	const currentTab: TabValue = initialTab ?? "all";
 	const [searchQuery, setSearchQuery] = useState("");
-	const [assigneeFilter, setAssigneeFilter] = useState<string | null>(null);
+	const assigneeFilter = initialAssignee ?? null;
+
+	const { setTab: storeSetTab, setAssignee: storeSetAssignee } =
+		useTasksFilterStore();
+
+	useEffect(() => {
+		storeSetTab(currentTab);
+	}, [currentTab, storeSetTab]);
+
+	useEffect(() => {
+		storeSetAssignee(assigneeFilter);
+	}, [assigneeFilter, storeSetAssignee]);
 
 	const { data: integrations, isLoading: isCheckingLinear } = useLiveQuery(
 		(q) =>
@@ -50,18 +63,35 @@ export function TasksView({ initialTab }: TasksViewProps) {
 	}, [rowSelection, table]);
 
 	const handleTabChange = (tab: TabValue) => {
+		const search: Record<string, string> = {};
+		if (tab !== "all") search.tab = tab;
+		if (assigneeFilter) search.assignee = assigneeFilter;
 		navigate({
 			to: "/tasks",
-			search: tab === "all" ? {} : { tab },
+			search,
+			replace: true,
+		});
+	};
+
+	const handleAssigneeFilterChange = (assignee: string | null) => {
+		const search: Record<string, string> = {};
+		if (currentTab !== "all") search.tab = currentTab;
+		if (assignee) search.assignee = assignee;
+		navigate({
+			to: "/tasks",
+			search,
 			replace: true,
 		});
 	};
 
 	const handleTaskClick = (task: TaskWithStatus) => {
+		const search: Record<string, string> = {};
+		if (currentTab !== "all") search.tab = currentTab;
+		if (assigneeFilter) search.assignee = assigneeFilter;
 		navigate({
 			to: "/tasks/$taskId",
 			params: { taskId: task.id },
-			search: currentTab === "all" ? {} : { tab: currentTab },
+			search,
 		});
 	};
 
@@ -85,7 +115,7 @@ export function TasksView({ initialTab }: TasksViewProps) {
 					searchQuery={searchQuery}
 					onSearchChange={setSearchQuery}
 					assigneeFilter={assigneeFilter}
-					onAssigneeFilterChange={setAssigneeFilter}
+					onAssigneeFilterChange={handleAssigneeFilterChange}
 					selectedCount={selectedTasks.length}
 					onClearSelection={handleClearSelection}
 				/>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/layout.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Outlet } from "@tanstack/react-router";
 
 export type TasksSearch = {
 	tab?: "all" | "active" | "backlog";
+	assignee?: string;
 };
 
 export const Route = createFileRoute("/_authenticated/_dashboard/tasks")({
@@ -10,6 +11,7 @@ export const Route = createFileRoute("/_authenticated/_dashboard/tasks")({
 		tab: ["all", "active", "backlog"].includes(search.tab as string)
 			? (search.tab as TasksSearch["tab"])
 			: undefined,
+		assignee: typeof search.assignee === "string" ? search.assignee : undefined,
 	}),
 });
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/page.tsx
@@ -7,6 +7,6 @@ export const Route = createFileRoute("/_authenticated/_dashboard/tasks/")({
 });
 
 function TasksPage() {
-	const { tab } = TasksLayoutRoute.useSearch();
-	return <TasksView initialTab={tab} />;
+	const { tab, assignee } = TasksLayoutRoute.useSearch();
+	return <TasksView initialTab={tab} initialAssignee={assignee} />;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/stores/tasks-filter-state.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/stores/tasks-filter-state.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+
+interface TasksFilterState {
+	tab: "all" | "active" | "backlog";
+	assignee: string | null;
+	setTab: (tab: "all" | "active" | "backlog") => void;
+	setAssignee: (assignee: string | null) => void;
+}
+
+export const useTasksFilterStore = create<TasksFilterState>()((set) => ({
+	tab: "all",
+	assignee: null,
+	setTab: (tab) => set({ tab }),
+	setAssignee: (assignee) => set({ assignee }),
+}));

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarHeader/WorkspaceSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarHeader/WorkspaceSidebarHeader.tsx
@@ -4,6 +4,7 @@ import { useMatchRoute, useNavigate } from "@tanstack/react-router";
 import { HiOutlineClipboardDocumentList } from "react-icons/hi2";
 import { LuLayers } from "react-icons/lu";
 import { GATED_FEATURES, usePaywall } from "renderer/components/Paywall";
+import { useTasksFilterStore } from "renderer/routes/_authenticated/_dashboard/tasks/stores/tasks-filter-state";
 import { STROKE_WIDTH } from "../constants";
 import { NewWorkspaceButton } from "./NewWorkspaceButton";
 
@@ -30,9 +31,14 @@ export function WorkspaceSidebarHeader({
 		}
 	};
 
+	const { tab: lastTab, assignee: lastAssignee } = useTasksFilterStore();
+
 	const handleTasksClick = () => {
 		gateFeature(GATED_FEATURES.TASKS, () => {
-			navigate({ to: "/tasks" });
+			const search: Record<string, string> = {};
+			if (lastTab !== "all") search.tab = lastTab;
+			if (lastAssignee) search.assignee = lastAssignee;
+			navigate({ to: "/tasks", search });
 		});
 	};
 


### PR DESCRIPTION
## Summary
- Task filters (tab, assignee) now persist when navigating away from the Tasks page and back
- Both filters are stored in URL search params as source of truth
- A lightweight zustand store syncs the last-used values so the sidebar Tasks button restores them
- Search query remains local state (intentionally resets on navigation)

## Test plan
- [ ] Open Tasks, switch to "Active" tab and filter by a specific assignee
- [ ] Navigate to a workspace tab, then click "Tasks" in sidebar — both filters should be preserved
- [ ] Verify URL shows `?tab=active&assignee=<userId>`
- [ ] Verify changing tab preserves assignee and vice versa
- [ ] Verify selecting "All assignees" clears only the assignee param
- [ ] Verify navigating to a task detail and back preserves filters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task filters are now preserved when navigating between tasks, including assignee and tab selection.
  * The Tasks sidebar button now remembers your last selected filters and automatically applies them when navigating back to the tasks view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->