### PR TITLE
feat(desktop): add mouse side button navigation

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/NavigationControls/NavigationControls.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/NavigationControls/NavigationControls.tsx
@@ -1,5 +1,6 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useLocation, useRouter } from "@tanstack/react-router";
+import { useEffect } from "react";
 import { LuArrowLeft, LuArrowRight } from "react-icons/lu";
 import { HotkeyTooltipContent } from "renderer/components/HotkeyTooltipContent";
 import { useAppHotkey } from "renderer/stores/hotkeys";
@@ -14,6 +15,21 @@ export function NavigationControls() {
 
 	useAppHotkey("NAVIGATE_BACK", () => router.history.back());
 	useAppHotkey("NAVIGATE_FORWARD", () => router.history.forward());
+
+	useEffect(() => {
+		const handleMouseUp = (event: MouseEvent) => {
+			if (event.button === 3) {
+				event.preventDefault();
+				router.history.back();
+			} else if (event.button === 4) {
+				event.preventDefault();
+				router.history.forward();
+			}
+		};
+
+		window.addEventListener("mouseup", handleMouseUp);
+		return () => window.removeEventListener("mouseup", handleMouseUp);
+	}, [router]);
 
 	return (
 		<div className="flex items-center">


### PR DESCRIPTION
## Summary
- Add mouse side button (back/forward) support for in-app navigation, matching Chrome's behavior
- Mouse button 3 (back) and button 4 (forward) now trigger `router.history.back()` / `router.history.forward()`

## Changes
- **NavigationControls.tsx**: Added a `useEffect` that listens for `mouseup` on `window` and handles button 3 (back) and button 4 (forward)

## Test Plan
- [ ] Run `bun dev` from the desktop app
- [ ] Press mouse back/forward buttons while cursor is over app chrome — should navigate the app router
- [ ] Confirm `bun run typecheck` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mouse button navigation support to the desktop application. Users can now use mouse side buttons for navigation: button 3 triggers back navigation and button 4 triggers forward navigation. This enhancement integrates seamlessly with existing keyboard shortcuts and button controls, providing an additional convenient navigation method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->