### PR TITLE
feat(desktop): replace initial loading spinner with Superset logo

### DIFF
--- a/apps/desktop/src/renderer/providers/AuthProvider/AuthProvider.tsx
+++ b/apps/desktop/src/renderer/providers/AuthProvider/AuthProvider.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode, useEffect, useState } from "react";
-import { SupersetLogo } from "renderer/routes/sign-in/components/SupersetLogo/SupersetLogo";
 import { authClient, setAuthToken } from "renderer/lib/auth-client";
+import { SupersetLogo } from "renderer/routes/sign-in/components/SupersetLogo/SupersetLogo";
 import { electronTrpc } from "../../lib/electron-trpc";
 
 export function AuthProvider({ children }: { children: ReactNode }) {


### PR DESCRIPTION
## Summary
- Replace the generic loading spinner with the Superset logo on the initial app loading screen
- Matches the branding used on the onboarding/welcome screen for a more polished experience

## Changes
- **`apps/desktop/src/renderer/providers/AuthProvider/AuthProvider.tsx`**: Swapped `Spinner` component for `SupersetLogo` with `animate-pulse` animation and `opacity-80` styling while the auth session hydrates

## Test Plan
- [ ] Launch the desktop app and verify the Superset logo appears (with pulse animation) during initial load instead of a spinner
- [ ] Verify the logo disappears once the app finishes hydrating
- [ ] Confirm the onboarding/welcome screen still displays the logo correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style Changes**
  * Updated the loading indicator appearance during app initialization for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->