### PR TITLE
feat(desktop): add clear status option to workspace context menu

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -19,6 +19,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useDrag, useDrop } from "react-dnd";
 import { HiMiniXMark } from "react-icons/hi2";
 import {
+	LuBellOff,
 	LuCopy,
 	LuEye,
 	LuEyeOff,
@@ -97,6 +98,7 @@ export function WorkspaceListItem({
 	const clearWorkspaceAttentionStatus = useTabsStore(
 		(s) => s.clearWorkspaceAttentionStatus,
 	);
+	const resetWorkspaceStatus = useTabsStore((s) => s.resetWorkspaceStatus);
 	const utils = electronTrpc.useUtils();
 
 	const isActive = !!matchRoute({
@@ -502,6 +504,12 @@ export function WorkspaceListItem({
 			</ContextMenuItem>
 			<ContextMenuSeparator />
 			{unreadMenuItem}
+			{workspaceStatus && (
+				<ContextMenuItem onSelect={() => resetWorkspaceStatus(id)}>
+					<LuBellOff className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />
+					Clear Status
+				</ContextMenuItem>
+			)}
 		</>
 	);
 

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -934,6 +934,36 @@ export const useTabsStore = create<TabsStore>()(
 					}
 				},
 
+				resetWorkspaceStatus: (workspaceId) => {
+					const state = get();
+					const workspaceTabs = state.tabs.filter(
+						(t) => t.workspaceId === workspaceId,
+					);
+					const workspacePaneIds = workspaceTabs.flatMap((t) =>
+						extractPaneIdsFromLayout(t.layout),
+					);
+
+					if (workspacePaneIds.length === 0) {
+						return;
+					}
+
+					const newPanes = { ...state.panes };
+					let hasChanges = false;
+					for (const paneId of workspacePaneIds) {
+						if (
+							newPanes[paneId]?.status &&
+							newPanes[paneId].status !== "idle"
+						) {
+							newPanes[paneId] = { ...newPanes[paneId], status: "idle" };
+							hasChanges = true;
+						}
+					}
+
+					if (hasChanges) {
+						set({ panes: newPanes });
+					}
+				},
+
 				updatePaneCwd: (paneId, cwd, confirmed) => {
 					set((state) => {
 						const pane = state.panes[paneId];

--- a/apps/desktop/src/renderer/stores/tabs/types.ts
+++ b/apps/desktop/src/renderer/stores/tabs/types.ts
@@ -115,6 +115,7 @@ export interface TabsStore extends TabsState {
 	setPaneStatus: (paneId: string, status: PaneStatus) => void;
 	setPaneName: (paneId: string, name: string) => void;
 	clearWorkspaceAttentionStatus: (workspaceId: string) => void;
+	resetWorkspaceStatus: (workspaceId: string) => void;
 	updatePaneCwd: (
 		paneId: string,
 		cwd: string | null,


### PR DESCRIPTION
## Summary
- Adds a "Clear Status" option to the workspace sidebar right-click context menu
- Allows users to forcefully reset all pane statuses (working, permission, review) to idle
- Only appears when the workspace has an active status indicator

## Changes
- **`stores/tabs/types.ts`** — Added `resetWorkspaceStatus` to the store interface
- **`stores/tabs/store.ts`** — Implemented `resetWorkspaceStatus` which forces all pane statuses to `idle` (unlike `clearWorkspaceAttentionStatus` which only acknowledges `review`)
- **`WorkspaceListItem.tsx`** — Added "Clear Status" context menu item with `LuBellOff` icon, conditionally rendered when `workspaceStatus` is non-null

## Test Plan
- [ ] Right-click a workspace with an active status (working/permission/review) → "Clear Status" appears
- [ ] Click "Clear Status" → all pane indicators reset to idle
- [ ] Right-click a workspace with no active status → "Clear Status" is not shown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Clear Status" context menu option for workspaces. This option appears when a workspace has an active status and allows users to reset the workspace status to idle with a single click.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->