### PR TITLE
feat(desktop): drag file paths from sidebar into chat input

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/hooks/useFileDrag.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/hooks/useFileDrag.ts
@@ -1,5 +1,7 @@
 import { useCallback } from "react";
 
+const FILE_PATH_MIME = "application/x-superset-file-path";
+
 interface UseFileDragProps {
 	absolutePath: string | null;
 }
@@ -12,6 +14,7 @@ export function useFileDrag({ absolutePath }: UseFileDragProps) {
 				return;
 			}
 			e.dataTransfer.setData("text/plain", absolutePath);
+			e.dataTransfer.setData(FILE_PATH_MIME, absolutePath);
 			e.dataTransfer.effectAllowed = "copy";
 		},
 		[absolutePath],


### PR DESCRIPTION
## Summary
- Dragging files from the file tree or changes panel into the chat input now inserts the file path as text, matching the existing terminal drag-and-drop behavior
- Added a custom MIME type (`application/x-superset-file-path`) to `useFileDrag` to distinguish internal file path drags from native file drops
- Extended `useDocumentDrag` to detect both file drops (`"files"`) and path drops (`"path"`), showing an opacity change on the chat input for path drags
- Focuses the chat textarea after dropping a file path

## Test plan
- [ ] Drag a file from the file tree sidebar into the chat input — the file path should appear as text
- [ ] Drag a file from the changes panel into the chat input — same behavior
- [ ] Drag a native file (from Finder) into the chat input — should still show the "Drop files here" overlay and attach the file
- [ ] Drag a file from the sidebar to the terminal — terminal should still receive the path (existing behavior preserved)
- [ ] After dropping a file path into chat, the textarea should be focused
- [ ] Verify opacity dims on the chat input when hovering with a file path drag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added drag-and-drop support for file paths directly into the chat input area.
  * Enhanced visual feedback to distinguish between file and path drag operations.
  * Dropped paths are automatically inserted into the chat input field for quick reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->