### PR TITLE
perf(desktop): optimize git status for large changesets

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -139,7 +139,6 @@ export function WorkspaceListItem({
 		worktreePath,
 		enabled: hasHovered && !!worktreePath,
 		staleTime: GITHUB_STATUS_STALE_TIME,
-		quickOnly: true,
 	});
 
 	const { data: aheadBehind } = electronTrpc.workspaces.getAheadBehind.useQuery(
@@ -167,9 +166,16 @@ export function WorkspaceListItem({
 						...localChanges.unstaged,
 						...localChanges.untracked,
 					];
+		if (allFiles.length === 0) return null;
 		const additions = allFiles.reduce((sum, f) => sum + (f.additions || 0), 0);
 		const deletions = allFiles.reduce((sum, f) => sum + (f.deletions || 0), 0);
-		if (additions === 0 && deletions === 0) return null;
+		if (additions === 0 && deletions === 0) {
+			if (localChanges.truncated) {
+				// Stats permanently unavailable due to large changeset — show file count
+				return { additions: allFiles.length, deletions: 0 };
+			}
+			return null;
+		}
 		return { additions, deletions };
 	}, [localChanges]);
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -139,6 +139,7 @@ export function WorkspaceListItem({
 		worktreePath,
 		enabled: hasHovered && !!worktreePath,
 		staleTime: GITHUB_STATUS_STALE_TIME,
+		quickOnly: true,
 	});
 
 	const { data: aheadBehind } = electronTrpc.workspaces.getAheadBehind.useQuery(

--- a/apps/desktop/src/renderer/screens/main/hooks/useGitChangesStatus/useGitChangesStatus.ts
+++ b/apps/desktop/src/renderer/screens/main/hooks/useGitChangesStatus/useGitChangesStatus.ts
@@ -55,6 +55,10 @@ export function useGitChangesStatus({
 	);
 
 	// Phase 2: Detailed status (slow — numstat, untracked line counts, against-base diff)
+	// Polls at 2x the quick interval to stay reasonably fresh without doubling load
+	const detailedRefetchInterval = refetchInterval
+		? refetchInterval * 2
+		: undefined;
 	const {
 		data: detailedStatus,
 		isLoading: isDetailedLoading,
@@ -67,6 +71,7 @@ export function useGitChangesStatus({
 		{
 			enabled:
 				!quickOnly && enabled && !!worktreePath && !!branchData && !!quickStatus,
+			refetchInterval: detailedRefetchInterval,
 			staleTime: staleTime ?? 10_000,
 			refetchOnWindowFocus,
 		},

--- a/apps/desktop/src/renderer/screens/main/hooks/useGitChangesStatus/useGitChangesStatus.ts
+++ b/apps/desktop/src/renderer/screens/main/hooks/useGitChangesStatus/useGitChangesStatus.ts
@@ -1,4 +1,5 @@
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import type { GitChangesStatus } from "shared/changes-types";
 
 interface UseGitChangesStatusOptions {
 	worktreePath: string | undefined;
@@ -6,6 +7,17 @@ interface UseGitChangesStatusOptions {
 	refetchInterval?: number;
 	refetchOnWindowFocus?: boolean;
 	staleTime?: number;
+	/** Only fetch quick status (no enrichment). Use for sidebar/hover contexts. */
+	quickOnly?: boolean;
+}
+
+interface UseGitChangesStatusResult {
+	status: GitChangesStatus | undefined;
+	isLoading: boolean;
+	/** Whether detailed enrichment (line counts, against-base) is still loading */
+	isEnriching: boolean;
+	effectiveBaseBranch: string;
+	refetch: () => void;
 }
 
 export function useGitChangesStatus({
@@ -14,7 +26,8 @@ export function useGitChangesStatus({
 	refetchInterval,
 	refetchOnWindowFocus,
 	staleTime,
-}: UseGitChangesStatusOptions) {
+	quickOnly = false,
+}: UseGitChangesStatusOptions): UseGitChangesStatusResult {
 	const { data: branchData } = electronTrpc.changes.getBranches.useQuery(
 		{ worktreePath: worktreePath || "" },
 		{ enabled: enabled && !!worktreePath },
@@ -23,11 +36,12 @@ export function useGitChangesStatus({
 	const effectiveBaseBranch =
 		branchData?.worktreeBaseBranch ?? branchData?.defaultBranch ?? "main";
 
+	// Phase 1: Quick status (fast — just file lists + ahead/behind)
 	const {
-		data: status,
-		isLoading,
-		refetch,
-	} = electronTrpc.changes.getStatus.useQuery(
+		data: quickStatus,
+		isLoading: isQuickLoading,
+		refetch: refetchQuick,
+	} = electronTrpc.changes.getStatusQuick.useQuery(
 		{
 			worktreePath: worktreePath || "",
 			defaultBranch: effectiveBaseBranch,
@@ -40,5 +54,38 @@ export function useGitChangesStatus({
 		},
 	);
 
-	return { status, isLoading, effectiveBaseBranch, refetch };
+	// Phase 2: Detailed status (slow — numstat, untracked line counts, against-base diff)
+	const {
+		data: detailedStatus,
+		isLoading: isDetailedLoading,
+		refetch: refetchDetailed,
+	} = electronTrpc.changes.getStatus.useQuery(
+		{
+			worktreePath: worktreePath || "",
+			defaultBranch: effectiveBaseBranch,
+		},
+		{
+			enabled:
+				!quickOnly && enabled && !!worktreePath && !!branchData && !!quickStatus,
+			staleTime: staleTime ?? 10_000,
+			refetchOnWindowFocus,
+		},
+	);
+
+	const refetch = () => {
+		refetchQuick();
+		if (!quickOnly) {
+			refetchDetailed();
+		}
+	};
+
+	// Return detailed when available, fall back to quick
+	const status = quickOnly
+		? quickStatus
+		: (detailedStatus ?? quickStatus);
+
+	const isLoading = isQuickLoading;
+	const isEnriching = !quickOnly && !detailedStatus && isDetailedLoading;
+
+	return { status, isLoading, isEnriching, effectiveBaseBranch, refetch };
 }

--- a/apps/desktop/src/shared/changes-types.ts
+++ b/apps/desktop/src/shared/changes-types.ts
@@ -37,6 +37,13 @@ export interface CommitInfo {
 	files: ChangedFile[];
 }
 
+/** Indicates which enrichment steps were skipped due to large changeset size */
+export interface TruncatedStatus {
+	numstat?: boolean;
+	untrackedLineCount?: boolean;
+	againstBase?: boolean;
+}
+
 /** Full git changes status for a worktree */
 export interface GitChangesStatus {
 	branch: string;
@@ -52,6 +59,7 @@ export interface GitChangesStatus {
 	pushCount: number; // Commits to push to tracking branch
 	pullCount: number; // Commits to pull from tracking branch
 	hasUpstream: boolean; // Whether branch has an upstream tracking branch
+	truncated?: TruncatedStatus; // Which enrichment steps were skipped
 }
 
 /** Whether a diff category supports editing (saving changes back to disk) */


### PR DESCRIPTION
## Summary
- Git status queries block the UI when a workspace has thousands of changed files because expensive operations (numstat, untracked line counts, against-base diffs) must all complete before any data is returned
- Adds a fast `getStatusQuick` tRPC procedure that returns file lists + ahead/behind immediately without enrichment
- Adds caps to `getStatus` to skip expensive operations when file counts exceed thresholds (500 files for numstat, 200 for untracked line counts, 200 commits for against-base diff)
- Implements progressive two-phase loading in the `useGitChangesStatus` hook so the UI shows file lists instantly and fills in line counts when the detailed query resolves

## Changes
**`apps/desktop/src/shared/changes-types.ts`**
- Add `TruncatedStatus` interface and optional `truncated` field to `GitChangesStatus`

**`apps/desktop/src/lib/trpc/routers/changes/status.ts`**
- Add `getStatusQuick` procedure — returns parsed git status + tracking info without numstat/line-count/against-base enrichment
- Add caps to `getStatus` — skips `applyNumstatToFiles` if >500 total files, `applyUntrackedLineCount` if >200 untracked files, against-base diff if >200 commits ahead
- Extract shared helpers: `parseWorktreeInput`, `getAheadBehind`, `statusInput` schema, `SimpleGit` type alias

**`apps/desktop/src/renderer/screens/main/hooks/useGitChangesStatus/useGitChangesStatus.ts`**
- Two-phase progressive loading: quick status polls on interval, detailed status loads once quick is available
- Add `quickOnly` option for sidebar/hover contexts that don't need enrichment
- Return `isEnriching` flag for consumers that want to show enrichment state

**`apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx`**
- Use `quickOnly: true` so sidebar hover never triggers expensive enrichment

## Test Plan
- [ ] Open a workspace with a very large number of changes (1000+ files) — ChangesView should show file lists within ~200ms, line counts fill in after
- [ ] Sidebar diff stats on hover should appear quickly without blocking
- [ ] Switching between workspaces should not block the UI
- [ ] Small changesets (<500 files) should still show full numstat/line counts as before
- [ ] `bun run typecheck` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quick status endpoint for fast, lightweight repo summaries in large repositories.
  * Progressive two-phase loading: show quick status first, then enrich with detailed changes (isEnriching/refetch support).
  * Truncation indicators in status to show which enrichments were skipped for large changesets.
  * UI now summarizes truncated local diffs by file count so large truncated changes still display a meaningful summary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->