### PR TITLE
fix(db): enable env validation for DATABASE_URL

### DIFF
--- a/packages/db/src/env.ts
+++ b/packages/db/src/env.ts
@@ -19,5 +19,5 @@ export const env = createEnv({
 	runtimeEnv: process.env,
 
 	emptyStringAsUndefined: true,
-	skipValidation: true,
+	skipValidation: !!process.env.SKIP_ENV_VALIDATION,
 });


### PR DESCRIPTION
## Summary
- The `@superset/db` package had `skipValidation: true` which **unconditionally disabled** all t3-env validation for `DATABASE_URL` and `DATABASE_URL_UNPOOLED`
- This allowed undefined database connection strings to silently pass through to `neon()`, causing a cryptic runtime crash in the desktop app: `"No database connection string was provided to neon()"`
- Aligns with every other package in the repo which uses `!!process.env.SKIP_ENV_VALIDATION`

## Changes
- `packages/db/src/env.ts`: Change `skipValidation: true` → `skipValidation: !!process.env.SKIP_ENV_VALIDATION`

## Test Plan
- [ ] Verify apps with `DATABASE_URL` set (web, api, admin) continue to work normally
- [ ] Verify desktop app now fails with a clear t3-env validation error instead of a cryptic `neon()` crash
- [ ] Verify `SKIP_ENV_VALIDATION=1` still bypasses validation when needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Environment validation behavior can now be controlled at runtime through configuration settings, enabling or disabling validation as needed rather than being unconditionally disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->