### PR TITLE
fix(desktop): stale "has uncommitted changes" status in delete dialogs

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/DeleteWorkspaceDialog/DeleteWorkspaceDialog.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/DeleteWorkspaceDialog/DeleteWorkspaceDialog.tsx
@@ -55,7 +55,6 @@ export function DeleteWorkspaceDialog({
 			{ id: workspaceId },
 			{
 				enabled: open,
-				staleTime: Number.POSITIVE_INFINITY,
 			},
 		);
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/DeleteWorktreeDialog.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/DeleteWorktreeDialog.tsx
@@ -32,7 +32,6 @@ export function DeleteWorktreeDialog({
 			{ worktreeId },
 			{
 				enabled: open,
-				staleTime: Number.POSITIVE_INFINITY,
 			},
 		);
 


### PR DESCRIPTION
## Summary
- The "has uncommitted changes" warning in the delete workspace/worktree dialogs would get stuck showing stale data
- Once the status was fetched as `true`, it would never update even after changes were committed or discarded, because the query used `staleTime: Infinity`

## Changes
- **DeleteWorkspaceDialog**: Removed `staleTime: Number.POSITIVE_INFINITY` from the `canDelete` git status query
- **DeleteWorktreeDialog**: Removed `staleTime: Number.POSITIVE_INFINITY` from the `canDeleteWorktree` query
- Both queries already use `enabled: open`, so they only fire when the dialog is open and refetch on each new open with default `staleTime: 0`

## Test Plan
- [x] Open a workspace with uncommitted changes, open the delete dialog — should show "Has uncommitted changes"
- [x] Close the dialog, commit or discard the changes, reopen the dialog — warning should be gone
- [x] Verify no excessive git status calls while the dialog remains open

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data freshness for workspace and worktree deletion validation by adjusting cache refresh behavior to follow default timing instead of indefinite caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->