### PR TITLE
docs: add missing Caddy setup to build-from-source instructions

### DIFF
--- a/Caddyfile.example
+++ b/Caddyfile.example
@@ -1,0 +1,15 @@
+# HTTP/2 reverse proxy for Electric SQL SSE streams.
+# Avoids browser's 6-connection limit when using 10+ Electric streams.
+#
+# Copy to Caddyfile:  cp Caddyfile.example Caddyfile
+# Install caddy:      brew install caddy  (macOS) / see https://caddyserver.com/docs/install
+
+{
+	auto_https disable_redirects
+}
+
+https://localhost:3010 {
+	reverse_proxy localhost:3001 {
+		flush_interval -1
+	}
+}

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ If it runs in a terminal, it runs on Superset
 | **Runtime** | [Bun](https://bun.sh/) v1.0+ |
 | **Version Control** | Git 2.20+ |
 | **GitHub CLI** | [gh](https://cli.github.com/) |
+| **Caddy** | [caddy](https://caddyserver.com/docs/install) (for dev server) |
 
 ## Getting Started
 
@@ -96,17 +97,25 @@ cp .env.example .env
 
 Option B: Skip env validation (for quick local testing)
 ```bash
-export SKIP_ENV_VALIDATION=1
+cp .env.example .env
+echo 'SKIP_ENV_VALIDATION=1' >> .env
 ```
 
-**3. Install dependencies and run**
+**3. Set up Caddy** (reverse proxy for Electric SQL streams):
+
+```bash
+# Install caddy: brew install caddy (macOS) or see https://caddyserver.com/docs/install
+cp Caddyfile.example Caddyfile
+```
+
+**4. Install dependencies and run**
 
 ```bash
 bun install
 bun run dev
 ```
 
-**4. Build the desktop app**
+**5. Build the desktop app**
 
 ```bash
 bun run build


### PR DESCRIPTION
## Summary

- Add `Caddyfile.example` so contributors can `cp Caddyfile.example Caddyfile` (matches template from `.superset/setup.sh`)
- Add Caddy to the Requirements table
- Add Caddy setup step to the build-from-source instructions
- Fix Option B (skip env validation) to also copy `.env.example` first

Without these, `bun run dev` fails immediately with `Error: spawn caddy ENOENT` or `open Caddyfile: no such file or directory`.

## Test plan

- [ ] Clone fresh repo, follow updated build-from-source instructions
- [ ] Verify `bun run dev` starts without errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added example Caddy configuration file for HTTP/2 reverse proxy setup
  * Updated Quick Start instructions with Caddy installation and configuration steps
  * Modified environment variable setup process
  * Reordered setup sequence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->