### PR TITLE
feat(api): add Slack image attachment support to Slack agent

### DIFF
--- a/apps/api/src/app/api/integrations/slack/connect/route.ts
+++ b/apps/api/src/app/api/integrations/slack/connect/route.ts
@@ -15,6 +15,7 @@ const SLACK_SCOPES = [
 	"im:write",
 	"mpim:history",
 	"users:read",
+	"files:read",
 	"assistant:write",
 	"links:read",
 	"links:write",

--- a/apps/api/src/app/api/integrations/slack/events/utils/run-agent/run-agent.ts
+++ b/apps/api/src/app/api/integrations/slack/events/utils/run-agent/run-agent.ts
@@ -4,6 +4,7 @@ import { WebClient } from "@slack/web-api";
 import { env } from "@/env";
 import { DEFAULT_SLACK_MODEL } from "../../../constants";
 import type { AgentAction } from "../slack-blocks";
+import type { SlackImageAsset } from "../slack-image-assets";
 import {
 	createSupersetMcpClient,
 	mcpToolToAnthropicTool,
@@ -113,6 +114,7 @@ interface RunSlackAgentParams {
 	userId: string;
 	slackToken: string;
 	model?: string;
+	images?: SlackImageAsset[];
 	onProgress?: (status: string) => void | Promise<void>;
 }
 
@@ -425,6 +427,42 @@ async function fetchAgentContext({
 	return sections.join("\n\n");
 }
 
+function buildUserMessageContent({
+	prompt,
+	threadContext,
+	images,
+}: {
+	prompt: string;
+	threadContext: string;
+	images: SlackImageAsset[] | undefined;
+}): string | Anthropic.ContentBlockParam[] {
+	const textContent = threadContext
+		? `${threadContext}\n\nCurrent message:\n${prompt}`
+		: prompt;
+
+	if (!images || images.length === 0) {
+		return textContent;
+	}
+
+	const content: Anthropic.ContentBlockParam[] = [];
+	if (textContent.trim().length > 0) {
+		content.push({ type: "text", text: textContent });
+	}
+
+	for (const image of images) {
+		content.push({
+			type: "image",
+			source: {
+				type: "base64",
+				media_type: image.mediaType,
+				data: image.base64Data,
+			},
+		});
+	}
+
+	return content;
+}
+
 export async function runSlackAgent(
 	params: RunSlackAgentParams,
 ): Promise<SlackAgentResult> {
@@ -481,9 +519,11 @@ Current context:
 
 ${agentContext}`;
 
-		const userContent = threadContext
-			? `${threadContext}\n\nCurrent message:\n${params.prompt}`
-			: params.prompt;
+		const userContent = buildUserMessageContent({
+			prompt: params.prompt,
+			threadContext,
+			images: params.images,
+		});
 
 		const messages: Anthropic.MessageParam[] = [
 			{

--- a/apps/api/src/app/api/integrations/slack/events/utils/slack-image-assets/index.ts
+++ b/apps/api/src/app/api/integrations/slack/events/utils/slack-image-assets/index.ts
@@ -1,0 +1,6 @@
+export type { SlackImageAsset } from "./slack-image-assets";
+export {
+	extractSlackImageAssets,
+	formatSlackImageAssetError,
+	SlackImageAssetError,
+} from "./slack-image-assets";

--- a/apps/api/src/app/api/integrations/slack/events/utils/slack-image-assets/slack-image-assets.ts
+++ b/apps/api/src/app/api/integrations/slack/events/utils/slack-image-assets/slack-image-assets.ts
@@ -1,0 +1,309 @@
+import type { WebClient } from "@slack/web-api";
+
+const SUPPORTED_IMAGE_MEDIA_TYPES = new Set([
+	"image/jpeg",
+	"image/png",
+	"image/gif",
+	"image/webp",
+] as const);
+
+const MAX_TOTAL_IMAGE_BYTES = 120 * 1024 * 1024; // 120MB safety ceiling
+
+type SupportedImageMediaType =
+	| "image/jpeg"
+	| "image/png"
+	| "image/gif"
+	| "image/webp";
+
+type SlackImageAssetErrorCode =
+	| "reauth_required"
+	| "invalid_file_metadata"
+	| "unsupported_image_type"
+	| "download_failed"
+	| "safety_limit_exceeded";
+
+interface SlackMessageFileInput {
+	id?: string;
+	name?: string;
+	mimetype?: string;
+	size?: number;
+	url_private?: string;
+	url_private_download?: string;
+}
+
+interface ExtractSlackImageAssetsParams {
+	eventFiles: unknown;
+	slack: WebClient;
+	slackToken: string;
+}
+
+export interface SlackImageAsset {
+	filename?: string;
+	mediaType: SupportedImageMediaType;
+	base64Data: string;
+}
+
+export class SlackImageAssetError extends Error {
+	public readonly code: SlackImageAssetErrorCode;
+
+	constructor(code: SlackImageAssetErrorCode, message: string) {
+		super(message);
+		this.name = "SlackImageAssetError";
+		this.code = code;
+	}
+}
+
+export function formatSlackImageAssetError(error: unknown): string {
+	if (!(error instanceof SlackImageAssetError)) {
+		return "I couldn't process the image attachment. Please try again.";
+	}
+
+	if (error.code === "reauth_required") {
+		return "I couldn't access one or more Slack images because this workspace needs updated Slack permissions (`files:read`). Please reconnect the Superset Slack integration and try again.";
+	}
+
+	return error.message;
+}
+
+export async function extractSlackImageAssets({
+	eventFiles,
+	slack,
+	slackToken,
+}: ExtractSlackImageAssetsParams): Promise<SlackImageAsset[]> {
+	const files = parseEventFiles(eventFiles);
+	if (files.length === 0) {
+		return [];
+	}
+
+	const assets: SlackImageAsset[] = [];
+	let totalBytes = 0;
+
+	for (const eventFile of files) {
+		const fileId = eventFile.id;
+		if (!fileId) {
+			throw new SlackImageAssetError(
+				"invalid_file_metadata",
+				"I couldn't process one of the attached images because its Slack file ID was missing.",
+			);
+		}
+
+		const metadata = await fetchSlackFileMetadata({
+			fileId,
+			slack,
+			fallback: eventFile,
+		});
+
+		const fileName = metadata.name ?? metadata.id ?? "image";
+		const mediaType = normalizeImageMediaType(metadata.mimetype);
+		if (!mediaType || !metadata.mimetype?.startsWith("image/")) {
+			// Non-image attachments are ignored; only image assets are ingested.
+			continue;
+		}
+
+		const downloadUrl = metadata.url_private_download ?? metadata.url_private;
+		if (!downloadUrl) {
+			throw new SlackImageAssetError(
+				"invalid_file_metadata",
+				`I couldn't download *${fileName}* because Slack did not return a private download URL.`,
+			);
+		}
+
+		const response = await fetch(downloadUrl, {
+			headers: {
+				Authorization: `Bearer ${slackToken}`,
+			},
+		});
+
+		if (response.status === 401 || response.status === 403) {
+			throw new SlackImageAssetError(
+				"reauth_required",
+				"Slack denied access while downloading image attachments. Please reconnect the Slack integration and try again.",
+			);
+		}
+
+		if (!response.ok) {
+			throw new SlackImageAssetError(
+				"download_failed",
+				`I couldn't download *${fileName}* from Slack (HTTP ${response.status}). Please try again.`,
+			);
+		}
+
+		const responseMediaType = normalizeImageMediaType(
+			extractContentType(response.headers.get("content-type")),
+		);
+		const resolvedMediaType = responseMediaType ?? mediaType;
+		if (!resolvedMediaType) {
+			throw new SlackImageAssetError(
+				"unsupported_image_type",
+				`I can't process *${fileName}* because its downloaded type is unsupported.`,
+			);
+		}
+
+		const bytes = await response.arrayBuffer();
+		totalBytes += bytes.byteLength;
+		if (totalBytes > MAX_TOTAL_IMAGE_BYTES) {
+			throw new SlackImageAssetError(
+				"safety_limit_exceeded",
+				"I couldn't process these images because the total attachment size is too large. Please retry with smaller images.",
+			);
+		}
+
+		assets.push({
+			filename: metadata.name,
+			mediaType: resolvedMediaType,
+			base64Data: Buffer.from(bytes).toString("base64"),
+		});
+	}
+
+	return assets;
+}
+
+async function fetchSlackFileMetadata({
+	fileId,
+	slack,
+	fallback,
+}: {
+	fileId: string;
+	slack: WebClient;
+	fallback: SlackMessageFileInput;
+}): Promise<SlackMessageFileInput> {
+	try {
+		const result = await slack.files.info({ file: fileId });
+		const file = toRecord(result.file);
+		if (!file) {
+			throw new SlackImageAssetError(
+				"invalid_file_metadata",
+				`I couldn't load metadata for Slack file ${fileId}.`,
+			);
+		}
+
+		return {
+			id: getString(file, "id") ?? fallback.id,
+			name: getString(file, "name") ?? fallback.name,
+			mimetype: getString(file, "mimetype") ?? fallback.mimetype,
+			size: getNumber(file, "size") ?? fallback.size,
+			url_private:
+				getString(file, "url_private") ??
+				getString(file, "url_private_download") ??
+				fallback.url_private,
+			url_private_download:
+				getString(file, "url_private_download") ??
+				fallback.url_private_download,
+		};
+	} catch (error) {
+		const slackErrorCode = extractSlackApiErrorCode(error);
+		if (isReauthSlackErrorCode(slackErrorCode)) {
+			throw new SlackImageAssetError(
+				"reauth_required",
+				"Slack file access is missing required permissions. Please reconnect the Slack integration.",
+			);
+		}
+
+		throw new SlackImageAssetError(
+			"download_failed",
+			`I couldn't read Slack metadata for file ${fileId}.`,
+		);
+	}
+}
+
+function parseEventFiles(eventFiles: unknown): SlackMessageFileInput[] {
+	if (!Array.isArray(eventFiles)) {
+		return [];
+	}
+
+	return eventFiles
+		.map((entry): SlackMessageFileInput | null => {
+			const file = toRecord(entry);
+			if (!file) return null;
+
+			return {
+				id: getString(file, "id") ?? undefined,
+				name: getString(file, "name") ?? undefined,
+				mimetype: getString(file, "mimetype") ?? undefined,
+				size: getNumber(file, "size") ?? undefined,
+				url_private: getString(file, "url_private") ?? undefined,
+				url_private_download:
+					getString(file, "url_private_download") ?? undefined,
+			};
+		})
+		.filter((file): file is SlackMessageFileInput => file !== null);
+}
+
+function normalizeImageMediaType(
+	mediaType: string | undefined,
+): SupportedImageMediaType | null {
+	if (!mediaType) {
+		return null;
+	}
+
+	const normalized = mediaType.trim().toLowerCase();
+	if (normalized === "image/jpg") {
+		return "image/jpeg";
+	}
+
+	if (SUPPORTED_IMAGE_MEDIA_TYPES.has(normalized as SupportedImageMediaType)) {
+		return normalized as SupportedImageMediaType;
+	}
+
+	return null;
+}
+
+function extractContentType(contentType: string | null): string | undefined {
+	if (!contentType) {
+		return undefined;
+	}
+
+	const [mediaType] = contentType.split(";");
+	return mediaType?.trim().toLowerCase();
+}
+
+function toRecord(value: unknown): Record<string, unknown> | null {
+	return typeof value === "object" && value !== null
+		? (value as Record<string, unknown>)
+		: null;
+}
+
+function getString(
+	record: Record<string, unknown>,
+	key: string,
+): string | undefined {
+	const value = record[key];
+	return typeof value === "string" ? value : undefined;
+}
+
+function getNumber(
+	record: Record<string, unknown>,
+	key: string,
+): number | undefined {
+	const value = record[key];
+	return typeof value === "number" ? value : undefined;
+}
+
+function extractSlackApiErrorCode(error: unknown): string | null {
+	const errorRecord = toRecord(error);
+	if (!errorRecord) {
+		return null;
+	}
+
+	const dataRecord = toRecord(errorRecord.data);
+	if (!dataRecord) {
+		return null;
+	}
+
+	const code = dataRecord.error;
+	return typeof code === "string" ? code : null;
+}
+
+function isReauthSlackErrorCode(code: string | null): boolean {
+	if (!code) {
+		return false;
+	}
+
+	return (
+		code === "missing_scope" ||
+		code === "not_authed" ||
+		code === "invalid_auth" ||
+		code === "token_revoked" ||
+		code === "account_inactive"
+	);
+}

--- a/apps/api/src/app/api/integrations/slack/jobs/process-assistant-message/route.ts
+++ b/apps/api/src/app/api/integrations/slack/jobs/process-assistant-message/route.ts
@@ -9,6 +9,15 @@ const receiver = new Receiver({
 	nextSigningKey: env.QSTASH_NEXT_SIGNING_KEY,
 });
 
+const slackFileSchema = z.object({
+	id: z.string(),
+	name: z.string().optional(),
+	mimetype: z.string().optional(),
+	size: z.number().optional(),
+	url_private: z.string().optional(),
+	url_private_download: z.string().optional(),
+});
+
 const payloadSchema = z.object({
 	event: z.object({
 		type: z.literal("message"),
@@ -19,6 +28,7 @@ const payloadSchema = z.object({
 		channel_type: z.literal("im"),
 		event_ts: z.string(),
 		thread_ts: z.string().optional(),
+		files: z.array(slackFileSchema).optional(),
 	}),
 	teamId: z.string(),
 	eventId: z.string(),
@@ -52,7 +62,7 @@ export async function POST(request: Request) {
 	}
 
 	await processAssistantMessage({
-		event: { ...parsed.data.event, subtype: undefined },
+		event: parsed.data.event,
 		teamId: parsed.data.teamId,
 		eventId: parsed.data.eventId,
 	});

--- a/apps/api/src/app/api/integrations/slack/jobs/process-mention/route.ts
+++ b/apps/api/src/app/api/integrations/slack/jobs/process-mention/route.ts
@@ -9,15 +9,25 @@ const receiver = new Receiver({
 	nextSigningKey: env.QSTASH_NEXT_SIGNING_KEY,
 });
 
+const slackFileSchema = z.object({
+	id: z.string(),
+	name: z.string().optional(),
+	mimetype: z.string().optional(),
+	size: z.number().optional(),
+	url_private: z.string().optional(),
+	url_private_download: z.string().optional(),
+});
+
 const payloadSchema = z.object({
 	event: z.object({
 		type: z.literal("app_mention"),
 		user: z.string(),
-		text: z.string(),
+		text: z.string().default(""),
 		ts: z.string(),
 		channel: z.string(),
 		event_ts: z.string(),
 		thread_ts: z.string().optional(),
+		files: z.array(slackFileSchema).optional(),
 	}),
 	teamId: z.string(),
 	eventId: z.string(),

--- a/apps/api/src/app/api/integrations/slack/manifest.json
+++ b/apps/api/src/app/api/integrations/slack/manifest.json
@@ -46,6 +46,7 @@
 				"im:write",
 				"mpim:history",
 				"users:read",
+				"files:read",
 				"assistant:write",
 				"links:read",
 				"links:write",


### PR DESCRIPTION
## Summary
- add Slack bot scope `files:read` to OAuth connect flow and manifest
- preserve Slack `event.files` metadata through QStash job payload validation
- add a Slack image asset utility that uses Slack SDK `files.info` and authenticated private downloads
- pass downloaded images into Anthropic as multimodal base64 image blocks for Slack mention and DM assistant flows
- return explicit reconnect guidance when Slack file access fails due to missing/expired scopes

## Validation
- `bun run lint`
- `bun test`
- `bun run typecheck`

## Rollout note
- existing Slack installs need re-auth to receive `files:read` scope (as discussed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Slack integration now supports image attachments in messages—the agent can process and analyze images shared in Slack conversations.
  * Added file reading permission to Slack OAuth scopes, enabling image file metadata access.

* **Bug Fixes**
  * Improved error handling for image-related issues with specific, user-friendly error messages including reauthentication guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->