### PR TITLE
fix(desktop): fix sidebar workspace hover controls layout drift

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceDiffStats.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceDiffStats.tsx
@@ -1,55 +1,27 @@
-import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
-import { HiMiniXMark } from "react-icons/hi2";
 
 interface WorkspaceDiffStatsProps {
 	additions: number;
 	deletions: number;
-	onClose?: (e: React.MouseEvent) => void;
 	isActive?: boolean;
 }
 
 export function WorkspaceDiffStats({
 	additions,
 	deletions,
-	onClose,
 	isActive,
 }: WorkspaceDiffStatsProps) {
 	return (
 		<div
 			className={cn(
-				"group/diff relative flex h-5 shrink-0 items-center rounded px-1.5 text-[10px] font-mono tabular-nums cursor-pointer",
-				isActive
-					? "bg-foreground/10 group-hover:bg-transparent"
-					: "bg-muted/50 group-hover:bg-transparent",
+				"flex h-5 shrink-0 items-center rounded px-1.5 text-[10px] font-mono tabular-nums transition-opacity group-hover:opacity-0",
+				isActive ? "bg-foreground/10" : "bg-muted/50",
 			)}
 		>
-			<div
-				className={cn(
-					"flex items-center gap-1.5 leading-none transition-opacity",
-					onClose && "group-hover:opacity-0",
-				)}
-			>
+			<div className="flex items-center gap-1.5 leading-none">
 				<span className="text-emerald-500/90">+{additions}</span>
 				<span className="text-red-400/90">−{deletions}</span>
 			</div>
-			{onClose && (
-				<Tooltip delayDuration={300}>
-					<TooltipTrigger asChild>
-						<button
-							type="button"
-							onClick={onClose}
-							className="absolute inset-0 flex items-center justify-center text-muted-foreground leading-none opacity-0 pointer-events-none transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 hover:text-foreground"
-							aria-label="Close workspace"
-						>
-							<HiMiniXMark className="size-3.5" />
-						</button>
-					</TooltipTrigger>
-					<TooltipContent side="top" sideOffset={4}>
-						Close workspace
-					</TooltipContent>
-				</Tooltip>
-			)}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -396,13 +396,6 @@ export function WorkspaceListItem({
 								{isBranchWorkspace ? "local" : name || branch}
 							</span>
 
-							{shortcutIndex !== undefined &&
-								shortcutIndex < MAX_KEYBOARD_SHORTCUT_INDEX && (
-									<span className="text-[10px] text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity font-mono tabular-nums shrink-0">
-										⌘{shortcutIndex + 1}
-									</span>
-								)}
-
 							{isBranchWorkspace && aheadBehind && (
 								<WorkspaceAheadBehind
 									ahead={aheadBehind.ahead}
@@ -410,45 +403,43 @@ export function WorkspaceListItem({
 								/>
 							)}
 
-							{isBranchWorkspace && diffStats && (
-								<WorkspaceDiffStats
-									additions={diffStats.additions}
-									deletions={diffStats.deletions}
-									isActive={isActive}
-								/>
-							)}
-
-							{!isBranchWorkspace &&
-								(diffStats ? (
+							<div className="grid shrink-0 h-5 [&>*]:col-start-1 [&>*]:row-start-1 items-center">
+								{diffStats && (
 									<WorkspaceDiffStats
 										additions={diffStats.additions}
 										deletions={diffStats.deletions}
 										isActive={isActive}
-										onClose={(e) => {
-											e.stopPropagation();
-											handleDeleteClick();
-										}}
 									/>
-								) : (
-									<Tooltip delayDuration={300}>
-										<TooltipTrigger asChild>
-											<button
-												type="button"
-												onClick={(e) => {
-													e.stopPropagation();
-													handleDeleteClick();
-												}}
-												className="opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center text-muted-foreground hover:text-foreground"
-												aria-label="Close workspace"
-											>
-												<HiMiniXMark className="size-3.5" />
-											</button>
-										</TooltipTrigger>
-										<TooltipContent side="top" sideOffset={4}>
-											Close workspace
-										</TooltipContent>
-									</Tooltip>
-								))}
+								)}
+								<div className="flex items-center justify-end gap-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
+									{shortcutIndex !== undefined &&
+										shortcutIndex < MAX_KEYBOARD_SHORTCUT_INDEX && (
+											<span className="text-[10px] text-muted-foreground font-mono tabular-nums shrink-0">
+												⌘{shortcutIndex + 1}
+											</span>
+										)}
+									{!isBranchWorkspace && (
+										<Tooltip delayDuration={300}>
+											<TooltipTrigger asChild>
+												<button
+													type="button"
+													onClick={(e) => {
+														e.stopPropagation();
+														handleDeleteClick();
+													}}
+													className="flex items-center justify-center text-muted-foreground hover:text-foreground"
+													aria-label="Close workspace"
+												>
+													<HiMiniXMark className="size-3.5" />
+												</button>
+											</TooltipTrigger>
+											<TooltipContent side="top" sideOffset={4}>
+												Close workspace
+											</TooltipContent>
+										</Tooltip>
+									)}
+								</div>
+							</div>
 						</div>
 
 						{(showBranchSubtitle || pr) && (


### PR DESCRIPTION
## Summary
- Decoupled diff stats badge from the close (X) button in sidebar workspace items — the `⌘N` shortcut and X now always render in a consistent position using a grid overlay that crossfades with the diff badge on hover
- Simplified `WorkspaceDiffStats` to a pure display component (removed embedded X button and `onClose` prop)
- Local branch item no longer shows an X button, only the `⌘N` shortcut on hover
- Reserved `h-5` height on the grid container to prevent layout shift when diff stats load in

## Test plan
- [ ] Hover over workspace items with diff stats — badge should fade out, `⌘N` + X should fade in
- [ ] Hover over workspace items without diff stats — `⌘N` + X should fade in with no layout shift
- [ ] Hover over the local branch item — only `⌘N` should appear, no X button
- [ ] Verify no height jump when diff stats load after first hover

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified workspace diff statistics display with streamlined styling
  * Reorganized close workspace action to appear on hover for non-branch workspaces
  * Restructured layout with improved organization of diff stats and controls
  * Keyboard shortcut badges now display alongside workspace actions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->