### PR TITLE
fix(desktop): fix sidebar workspace close button not clickable

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceDiffStats.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceDiffStats.tsx
@@ -14,7 +14,7 @@ export function WorkspaceDiffStats({
 	return (
 		<div
 			className={cn(
-				"flex h-5 shrink-0 items-center rounded px-1.5 text-[10px] font-mono tabular-nums transition-opacity group-hover:opacity-0",
+				"flex h-5 shrink-0 items-center rounded px-1.5 text-[10px] font-mono tabular-nums transition-[opacity,visibility] group-hover:opacity-0 group-hover:invisible",
 				isActive ? "bg-foreground/10" : "bg-muted/50",
 			)}
 		>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -411,7 +411,7 @@ export function WorkspaceListItem({
 										isActive={isActive}
 									/>
 								)}
-								<div className="flex items-center justify-end gap-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
+								<div className="flex items-center justify-end gap-1.5 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-[opacity,visibility]">
 									{shortcutIndex !== undefined &&
 										shortcutIndex < MAX_KEYBOARD_SHORTCUT_INDEX && (
 											<span className="text-[10px] text-muted-foreground font-mono tabular-nums shrink-0">


### PR DESCRIPTION
## Summary
- The close button on sidebar workspace items was unclickable after #1676 introduced a CSS grid overlay for hover swapping between diff stats and close controls
- Root cause: `opacity: 0` hides elements visually but still captures pointer events, so the invisible close button container was blocking clicks
- Replaced the opacity-only approach with `opacity + visibility` — `visibility: hidden` naturally prevents pointer events without needing `pointer-events` hacks

## Changes
- **WorkspaceListItem.tsx**: Use `invisible`/`group-hover:visible` alongside opacity toggling for the hover controls container
- **WorkspaceDiffStats.tsx**: Add `group-hover:invisible` alongside existing `group-hover:opacity-0`, transition both properties

## Test Plan
- [ ] Hover over a workspace item in the sidebar — close button (X) and keyboard shortcut should fade in
- [ ] Click the close button — should trigger workspace close
- [ ] Verify diff stats (+N -N) still show when not hovered and fade out on hover
- [ ] Confirm no layout shift when hovering/unhovering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Refined the visual behavior of workspace sidebar controls during hover interactions, improving transitions for a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->