### PR TITLE
feat(desktop): persist task search query in URL and Zustand store

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/page.tsx
@@ -25,11 +25,17 @@ export const Route = createFileRoute(
 
 function TaskDetailPage() {
 	const { taskId } = Route.useParams();
-	const { tab } = TasksLayoutRoute.useSearch();
+	const { tab, assignee, search } = TasksLayoutRoute.useSearch();
 	const navigate = useNavigate();
 	const collections = useCollections();
 
-	const backSearch = useMemo(() => (tab ? { tab } : {}), [tab]);
+	const backSearch = useMemo(() => {
+		const s: Record<string, string> = {};
+		if (tab) s.tab = tab;
+		if (assignee) s.assignee = assignee;
+		if (search) s.search = search;
+		return s;
+	}, [tab, assignee, search]);
 	useEscapeToNavigate("/tasks", { search: backSearch });
 
 	// Support both UUID and slug lookups

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/layout.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, Outlet } from "@tanstack/react-router";
 export type TasksSearch = {
 	tab?: "all" | "active" | "backlog";
 	assignee?: string;
+	search?: string;
 };
 
 export const Route = createFileRoute("/_authenticated/_dashboard/tasks")({
@@ -12,6 +13,7 @@ export const Route = createFileRoute("/_authenticated/_dashboard/tasks")({
 			? (search.tab as TasksSearch["tab"])
 			: undefined,
 		assignee: typeof search.assignee === "string" ? search.assignee : undefined,
+		search: typeof search.search === "string" ? search.search : undefined,
 	}),
 });
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/page.tsx
@@ -7,6 +7,12 @@ export const Route = createFileRoute("/_authenticated/_dashboard/tasks/")({
 });
 
 function TasksPage() {
-	const { tab, assignee } = TasksLayoutRoute.useSearch();
-	return <TasksView initialTab={tab} initialAssignee={assignee} />;
+	const { tab, assignee, search } = TasksLayoutRoute.useSearch();
+	return (
+		<TasksView
+			initialTab={tab}
+			initialAssignee={assignee}
+			initialSearch={search}
+		/>
+	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/stores/tasks-filter-state.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/stores/tasks-filter-state.ts
@@ -3,13 +3,17 @@ import { create } from "zustand";
 interface TasksFilterState {
 	tab: "all" | "active" | "backlog";
 	assignee: string | null;
+	search: string;
 	setTab: (tab: "all" | "active" | "backlog") => void;
 	setAssignee: (assignee: string | null) => void;
+	setSearch: (search: string) => void;
 }
 
 export const useTasksFilterStore = create<TasksFilterState>()((set) => ({
 	tab: "all",
 	assignee: null,
+	search: "",
 	setTab: (tab) => set({ tab }),
 	setAssignee: (assignee) => set({ assignee }),
+	setSearch: (search) => set({ search }),
 }));

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarHeader/WorkspaceSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarHeader/WorkspaceSidebarHeader.tsx
@@ -31,13 +31,18 @@ export function WorkspaceSidebarHeader({
 		}
 	};
 
-	const { tab: lastTab, assignee: lastAssignee } = useTasksFilterStore();
+	const {
+		tab: lastTab,
+		assignee: lastAssignee,
+		search: lastSearch,
+	} = useTasksFilterStore();
 
 	const handleTasksClick = () => {
 		gateFeature(GATED_FEATURES.TASKS, () => {
 			const search: Record<string, string> = {};
 			if (lastTab !== "all") search.tab = lastTab;
 			if (lastAssignee) search.assignee = lastAssignee;
+			if (lastSearch) search.search = lastSearch;
 			navigate({ to: "/tasks", search });
 		});
 	};


### PR DESCRIPTION
## Summary
- Task search query was local React state only — lost on navigation and page refresh
- Task detail back navigation only preserved `tab`, dropping `assignee` and `search`
- Sidebar navigation to tasks now restores all three filters from the Zustand store

## Changes
- **`tasks/layout.tsx`**: Add `search` to `TasksSearch` type and `validateSearch`
- **`tasks/page.tsx`**: Pass `search` URL param as `initialSearch` to `TasksView`
- **`TasksView.tsx`**: Wire search input to URL with 300ms debounce, sync to Zustand store, carry `search` through all navigation handlers
- **`tasks-filter-state.ts`**: Add `search` field and `setSearch` action to Zustand store
- **`WorkspaceSidebarHeader.tsx`**: Include `search` when navigating to tasks from sidebar
- **`$taskId/page.tsx`**: Preserve `assignee` and `search` in back navigation (previously only `tab`)

## Test Plan
- [ ] Set tab, assignee filter, and search query → URL reflects all three params
- [ ] Click a task → detail URL carries `tab`, `assignee`, `search`
- [ ] Press back/Escape from task detail → tasks page restores all filters
- [ ] Navigate away, click "Tasks" in sidebar → filters restored from Zustand store
- [ ] Refresh page → filters restored from URL
- [ ] Typecheck passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search functionality to the tasks section with persistent query state across navigation.
  * Search queries now remain in the URL and navigation history for better context preservation.
  * Implemented debounced search input handling for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->