### PR TITLE
fix(desktop): handle empty repos in workspace creation

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/projects/projects.ts
+++ b/apps/desktop/src/lib/trpc/routers/projects/projects.ts
@@ -31,6 +31,7 @@ import {
 	touchWorkspace,
 } from "../workspaces/utils/db-helpers";
 import {
+	createInitialCommit,
 	getCurrentBranch,
 	getDefaultBranch,
 	getGitAuthorName,
@@ -73,23 +74,7 @@ async function initGitRepo(path: string): Promise<{ defaultBranch: string }> {
 		await git.init();
 	}
 
-	try {
-		await git.raw(["commit", "--allow-empty", "-m", "Initial commit"]);
-	} catch (err) {
-		const errorMessage = err instanceof Error ? err.message : String(err);
-		if (
-			errorMessage.includes("empty ident") ||
-			errorMessage.includes("user.email") ||
-			errorMessage.includes("user.name")
-		) {
-			throw new Error(
-				"Git user not configured. Please run:\n" +
-					'  git config --global user.name "Your Name"\n' +
-					'  git config --global user.email "you@example.com"',
-			);
-		}
-		throw new Error(`Failed to create initial commit: ${errorMessage}`);
-	}
+	await createInitialCommit(path);
 
 	const defaultBranch = (await getCurrentBranch(path)) || "main";
 	return { defaultBranch };
@@ -136,13 +121,13 @@ async function ensureMainWorkspace(project: Project): Promise<void> {
 		return;
 	}
 
-	const branch = await getCurrentBranch(project.mainRepoPath);
-	if (!branch) {
-		console.warn(
-			`[ensureMainWorkspace] Could not determine current branch for project ${project.id}`,
-		);
-		return;
-	}
+	// getCurrentBranch fails on empty repos (HEAD is unborn), so fall back
+	// to the project's default branch. This ensures cloned empty repos still
+	// get a workspace that opens the repo directory.
+	const branch =
+		(await getCurrentBranch(project.mainRepoPath)) ||
+		project.defaultBranch ||
+		"main";
 
 	// Unique partial index (projectId WHERE type='branch') prevents duplicates
 	const insertResult = localDb

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.test.ts
@@ -9,7 +9,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createWorktree } from "./git";
+import { createInitialCommit, createWorktree, isRepoEmpty } from "./git";
 
 const TEST_DIR = join(
 	realpathSync(tmpdir()),
@@ -307,5 +307,106 @@ describe("createWorktree hook tolerance", () => {
 		await expect(
 			createWorktree(repoPath, "feature/existing-path", worktreePath, "HEAD"),
 		).rejects.toThrow("already exists");
+	});
+});
+
+describe("isRepoEmpty", () => {
+	beforeEach(() => {
+		mkdirSync(TEST_DIR, { recursive: true });
+	});
+
+	afterEach(() => {
+		if (existsSync(TEST_DIR)) {
+			rmSync(TEST_DIR, { recursive: true, force: true });
+		}
+	});
+
+	test("returns true for a repo with no commits", async () => {
+		const repoPath = createTestRepo("empty-repo");
+		expect(await isRepoEmpty(repoPath)).toBe(true);
+	});
+
+	test("returns false for a repo with commits", async () => {
+		const repoPath = createTestRepo("non-empty-repo");
+		seedCommit(repoPath);
+		expect(await isRepoEmpty(repoPath)).toBe(false);
+	});
+
+	test("returns true for a cloned empty repo", async () => {
+		const barePath = join(TEST_DIR, "bare-remote.git");
+		mkdirSync(barePath, { recursive: true });
+		execSync("git init --bare", { cwd: barePath, stdio: "ignore" });
+
+		const clonePath = join(TEST_DIR, "cloned-empty");
+		execSync(`git clone "${barePath}" "${clonePath}"`, { stdio: "pipe" });
+
+		expect(await isRepoEmpty(clonePath)).toBe(true);
+	});
+});
+
+describe("createInitialCommit", () => {
+	beforeEach(() => {
+		mkdirSync(TEST_DIR, { recursive: true });
+	});
+
+	afterEach(() => {
+		if (existsSync(TEST_DIR)) {
+			rmSync(TEST_DIR, { recursive: true, force: true });
+		}
+	});
+
+	test("creates an initial commit in an empty repo", async () => {
+		const repoPath = createTestRepo("init-commit");
+		expect(await isRepoEmpty(repoPath)).toBe(true);
+
+		await createInitialCommit(repoPath);
+
+		expect(await isRepoEmpty(repoPath)).toBe(false);
+		const log = execSync("git log --oneline", { cwd: repoPath })
+			.toString()
+			.trim();
+		expect(log).toContain("Initial commit");
+	});
+
+	test("allows worktree creation after bootstrapping empty repo", async () => {
+		const repoPath = createTestRepo("bootstrap-worktree");
+		await createInitialCommit(repoPath);
+
+		const worktreePath = join(TEST_DIR, "bootstrap-worktree-wt");
+		await createWorktree(repoPath, "feature/test", worktreePath, "HEAD");
+
+		expect(existsSync(worktreePath)).toBe(true);
+		const currentBranch = execSync("git rev-parse --abbrev-ref HEAD", {
+			cwd: worktreePath,
+		})
+			.toString()
+			.trim();
+		expect(currentBranch).toBe("feature/test");
+	});
+
+	test("allows worktree creation for cloned empty repo after bootstrap", async () => {
+		const barePath = join(TEST_DIR, "bare-for-wt.git");
+		mkdirSync(barePath, { recursive: true });
+		execSync("git init --bare", { cwd: barePath, stdio: "ignore" });
+
+		const clonePath = join(TEST_DIR, "cloned-for-wt");
+		execSync(`git clone "${barePath}" "${clonePath}"`, { stdio: "pipe" });
+		execSync("git config user.email 'test@test.com'", {
+			cwd: clonePath,
+			stdio: "ignore",
+		});
+		execSync("git config user.name 'Test'", {
+			cwd: clonePath,
+			stdio: "ignore",
+		});
+
+		expect(await isRepoEmpty(clonePath)).toBe(true);
+		await createInitialCommit(clonePath);
+		expect(await isRepoEmpty(clonePath)).toBe(false);
+
+		const worktreePath = join(TEST_DIR, "cloned-for-wt-worktree");
+		await createWorktree(clonePath, "feature/empty-repo", worktreePath, "HEAD");
+
+		expect(existsSync(worktreePath)).toBe(true);
 	});
 });

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
@@ -1434,6 +1434,46 @@ export async function checkoutBranch(
  * @throws Error if safety checks fail or checkout fails
  */
 /**
+ * Checks if a repository is empty (has no commits).
+ * An empty repo is one that has been initialized or cloned but has no commits yet.
+ */
+export async function isRepoEmpty(repoPath: string): Promise<boolean> {
+	const git = simpleGit(repoPath);
+	try {
+		await git.raw(["rev-parse", "HEAD"]);
+		return false;
+	} catch {
+		return true;
+	}
+}
+
+/**
+ * Creates an initial empty commit in a repository that has no commits.
+ * This is needed to bootstrap empty repos so that git worktree can work.
+ * @throws Error if git user is not configured or commit fails
+ */
+export async function createInitialCommit(repoPath: string): Promise<void> {
+	const git = simpleGit(repoPath);
+	try {
+		await git.raw(["commit", "--allow-empty", "-m", "Initial commit"]);
+	} catch (err) {
+		const errorMessage = err instanceof Error ? err.message : String(err);
+		if (
+			errorMessage.includes("empty ident") ||
+			errorMessage.includes("user.email") ||
+			errorMessage.includes("user.name")
+		) {
+			throw new Error(
+				"Git user not configured. Please run:\n" +
+					'  git config --global user.name "Your Name"\n' +
+					'  git config --global user.email "you@example.com"',
+			);
+		}
+		throw new Error(`Failed to create initial commit: ${errorMessage}`);
+	}
+}
+
+/**
  * Checks if a git ref exists locally (without network access).
  * Uses --verify --quiet to only check exit code without output.
  * @param repoPath - Path to the repository

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/workspace-init.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/workspace-init.ts
@@ -12,6 +12,7 @@ import {
 	createWorktreeFromExistingBranch,
 	fetchDefaultBranch,
 	hasOriginRemote,
+	isRepoEmpty,
 	refExistsLocally,
 	refreshDefaultBranch,
 	removeWorktree,
@@ -151,6 +152,18 @@ export async function initializeWorkspaceWorktree({
 				use_existing_branch: true,
 			});
 
+			return;
+		}
+
+		// Empty repos (no commits) can't create worktrees — fail early with
+		// a clear message instead of a cryptic git error later.
+		if (await isRepoEmpty(mainRepoPath)) {
+			manager.updateProgress(
+				workspaceId,
+				"failed",
+				"Repository has no commits",
+				"This repository has no commits yet. Make your first commit, then try creating a workspace.",
+			);
 			return;
 		}
 


### PR DESCRIPTION
## Summary

Fixes #1663 — cloning an empty repo (no commits) caused workspace creation to fail because `git worktree` requires at least one commit.

**Root cause:** `ensureMainWorkspace` called `getCurrentBranch()` which runs `git rev-parse --abbrev-ref HEAD` — this fails on empty repos (unborn HEAD) and returned `null`. The function then silently returned without creating a "branch" workspace, forcing the user into the worktree creation path which also failed with a cryptic error.

**Changes:**
- **Fix `ensureMainWorkspace`** to fall back to `project.defaultBranch || "main"` when `getCurrentBranch` returns null — empty repos now get a branch workspace that opens the repo directory directly
- **Add early empty-repo detection** in `workspace-init.ts` with a clear error message ("Repository has no commits yet") instead of the cryptic "No local reference available"
- **Extract `isRepoEmpty` / `createInitialCommit`** utilities into `git.ts` and refactor `initGitRepo` to use the shared helper (reduces duplication)

## Test plan

- [x] Added unit tests for `isRepoEmpty` (empty repo, non-empty repo, cloned empty repo)
- [x] Added unit tests for `createInitialCommit` (creates commit, enables worktree creation, works with cloned empty repos)
- [x] All 15 tests in `git.test.ts` pass
- [x] Typecheck passes
- [x] Lint passes
- [ ] Manual: clone an empty repo → open project → verify workspace opens at repo directory
- [ ] Manual: clone a normal repo → verify workspace creation still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for empty Git repositories with clearer configuration guidance.

* **Refactor**
  * Streamlined Git initialization workflow with safer branch detection and fallback behavior.

* **Tests**
  * Added comprehensive test coverage for repository initialization and empty repository scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->