### PR TITLE
feat(desktop): add discard button to unstaged file rows

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileItem/FileItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileItem/FileItem.tsx
@@ -93,7 +93,7 @@ export function FileItem({
 	const showStatsDisplay =
 		showStats && (file.additions > 0 || file.deletions > 0);
 	const hasIndent = level > 0;
-	const hasAction = onStage || onUnstage;
+	const hasAction = onStage || onUnstage || onDiscard;
 
 	const isScrollSyncActive =
 		category && activeFileKey === createFileKey(file, category, commitHash);
@@ -216,6 +216,29 @@ export function FileItem({
 
 			{hasAction && (
 				<div className="flex items-center opacity-0 group-hover:opacity-100 transition-opacity">
+					{onDiscard && (
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									variant="ghost"
+									size="icon"
+									className="size-5 hover:bg-accent"
+									onClick={(e) => {
+										e.stopPropagation();
+										handleDiscardClick();
+									}}
+									disabled={isActioning}
+								>
+									{isDeleteAction ? (
+										<LuTrash2 className="size-3" />
+									) : (
+										<LuUndo2 className="size-3" />
+									)}
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent side="right">{discardLabel}</TooltipContent>
+						</Tooltip>
+					)}
 					{onStage && (
 						<Tooltip>
 							<TooltipTrigger asChild>


### PR DESCRIPTION
# feat(desktop): add discard button to unstaged file rows

## Summary
- Add a hover discard button (undo/trash icon) to the left of the stage (+) button on unstaged file rows
- Improves accessibility — previously discard was only available via right-click context menu
- Untracked/added files show trash icon, modified files show undo icon
- Clicking triggers the existing confirmation dialog before discarding

## View
<img width="251" height="368" alt="image" src="https://github.com/user-attachments/assets/61d84461-7d64-4b7a-a037-c798d9abad7c" />

## Test plan
- [x] Hover over an unstaged modified file → verify undo icon appears left of the + button
- [x] Hover over an unstaged untracked file → verify trash icon appears left of the + button
- [x] Click discard button → verify confirmation dialog appears and discard works
- [x] Hover over a staged file → verify no discard button is shown


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added discard functionality with an action button and context menu option for file items
  * Discard button displays dynamic icons based on file status (trash icon for deletions, undo icon for reversions)
  * Included confirmation dialog to prevent accidental discards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->