### PR TITLE
ci: move Linux workflows to Blacksmith runners

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -53,9 +53,7 @@ jobs:
         with:
           path: |
             ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-bun-
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
         run: bun install --frozen
@@ -142,7 +140,7 @@ jobs:
 
   build-linux:
     name: Build - Linux (x64)
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     environment: production
 
     steps:
@@ -159,9 +157,7 @@ jobs:
         with:
           path: |
             ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-bun-
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
         run: bun install --frozen

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   sherif:
     name: Sherif
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -33,7 +33,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -57,7 +57,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -81,7 +81,7 @@ jobs:
 
   typecheck:
     name: Typecheck
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -105,7 +105,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   cleanup:
     name: Cleanup Preview Resources
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   deploy-database:
     name: Deploy Database (Neon)
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
       - name: Checkout repository
@@ -77,7 +77,7 @@ jobs:
 
   deploy-electric:
     name: Deploy Electric (Fly.io)
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: deploy-database
 
     steps:
@@ -122,7 +122,7 @@ jobs:
 
   deploy-api:
     name: Deploy API
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     environment: preview
     needs: deploy-database
 
@@ -278,7 +278,7 @@ jobs:
 
   deploy-web:
     name: Deploy Web
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     environment: preview
     needs: deploy-database
 
@@ -391,7 +391,7 @@ jobs:
 
   deploy-marketing:
     name: Deploy Marketing
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     environment: preview
     needs: deploy-database
 
@@ -487,7 +487,7 @@ jobs:
 
   deploy-admin:
     name: Deploy Admin
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     environment: preview
     needs: deploy-database
 
@@ -602,7 +602,7 @@ jobs:
 
   deploy-docs:
     name: Deploy Docs
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     environment: preview
     needs: deploy-database
 
@@ -669,7 +669,7 @@ jobs:
 
   post-final-comment:
     name: Post Deployment Comment
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     if: always()
     needs: [deploy-database, deploy-electric, deploy-api, deploy-web, deploy-marketing, deploy-admin, deploy-docs]
     permissions:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   deploy-database:
     name: Deploy Database Migrations
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     environment: production
 
     steps:
@@ -38,7 +38,7 @@ jobs:
 
   deploy-api:
     name: Deploy API to Vercel
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     environment: production
     needs: deploy-database
 
@@ -166,7 +166,7 @@ jobs:
 
   deploy-web:
     name: Deploy Web to Vercel
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     environment: production
     needs: deploy-database
 
@@ -252,7 +252,7 @@ jobs:
 
   deploy-marketing:
     name: Deploy Marketing to Vercel
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     environment: production
     needs: deploy-database
 
@@ -332,7 +332,7 @@ jobs:
 
   deploy-admin:
     name: Deploy Admin to Vercel
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     environment: production
     needs: deploy-database
 
@@ -420,7 +420,7 @@ jobs:
 
   deploy-electric:
     name: Deploy Electric to Fly.io
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     environment: production
 
     steps:
@@ -447,7 +447,7 @@ jobs:
 
   deploy-docs:
     name: Deploy Docs to Vercel
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     environment: production
     needs: deploy-database
 

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   generate-changelog:
     name: Generate Changelog
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release-desktop-canary.yml
+++ b/.github/workflows/release-desktop-canary.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   check-changes:
     name: Check for changes
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       should_build: ${{ steps.check.outputs.should_build }}
       short_sha: ${{ steps.check.outputs.short_sha }}
@@ -83,7 +83,7 @@ jobs:
     name: Update Canary Release
     needs: [check-changes, build]
     if: needs.check-changes.outputs.should_build == 'true'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -27,7 +27,7 @@ jobs:
   release:
     name: Create GitHub Release
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     if: startsWith(github.ref, 'refs/tags/desktop-v')
 
     steps:

--- a/.github/workflows/triage-issue.yml
+++ b/.github/workflows/triage-issue.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   triage:
     name: Triage Issue
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     permissions:
       contents: write

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   update-docs:
     name: Update Docs
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- switch all GitHub Actions Linux jobs from `ubuntu-latest` to `blacksmith-4vcpu-ubuntu-2404`
- keep macOS desktop build on `macos-latest`
- normalize `build-desktop` Bun cache keys from commit SHA to `hashFiles('bun.lock')` for cache reuse

## Why
- route CI Linux workloads through Blacksmith workers
- keep dependency caching stable and reusable across commits

## Validation
- verified no `ubuntu-latest` remains in workflow YAML
- parsed all workflow YAML files successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD infrastructure configurations across multiple workflows.

---

**Note:** This release contains no end-user visible changes. Updates are infrastructure-related only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->