### PR TITLE
perf(desktop): reduce terminal scrollback from 10k to 2k lines

### DIFF
--- a/apps/desktop/src/main/lib/terminal-host/headless-emulator.ts
+++ b/apps/desktop/src/main/lib/terminal-host/headless-emulator.ts
@@ -76,7 +76,7 @@ export class HeadlessEmulator {
 	private static readonly MAX_ESCAPE_BUFFER_SIZE = 1024;
 
 	constructor(options: HeadlessEmulatorOptions = {}) {
-		const { cols = 80, rows = 24, scrollback = 10000 } = options;
+		const { cols = 80, rows = 24, scrollback = 2000 } = options;
 
 		this.terminal = new Terminal({
 			cols,
@@ -225,7 +225,7 @@ export class HeadlessEmulator {
 	 */
 	getSnapshot(): TerminalSnapshot {
 		const snapshotAnsi = this.serializeAddon.serialize({
-			scrollback: this.terminal.options.scrollback ?? 10000,
+			scrollback: this.terminal.options.scrollback ?? 2000,
 		});
 
 		const rehydrateSequences = this.generateRehydrateSequences();

--- a/apps/desktop/src/main/lib/terminal/session.ts
+++ b/apps/desktop/src/main/lib/terminal/session.ts
@@ -15,7 +15,7 @@ import type { InternalCreateSessionParams, TerminalSession } from "./types";
 
 const DEFAULT_COLS = 80;
 const DEFAULT_ROWS = 24;
-const DEFAULT_SCROLLBACK = 10000;
+const DEFAULT_SCROLLBACK = 2000;
 /** Max time to wait for agent hooks before running initial commands */
 const AGENT_HOOKS_TIMEOUT_MS = 2000;
 const DEBUG_TERMINAL = process.env.SUPERSET_TERMINAL_DEBUG === "1";

--- a/apps/desktop/src/main/terminal-host/session.ts
+++ b/apps/desktop/src/main/terminal-host/session.ts
@@ -152,7 +152,7 @@ export class Session {
 		this.emulator = new HeadlessEmulator({
 			cols: options.cols,
 			rows: options.rows,
-			scrollback: options.scrollbackLines ?? 10000,
+			scrollback: options.scrollbackLines ?? 2000,
 		});
 
 		// Set initial CWD

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/config.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/config.ts
@@ -39,7 +39,7 @@ export const TERMINAL_OPTIONS: ITerminalOptions = {
 	fontFamily: DEFAULT_TERMINAL_FONT_FAMILY,
 	theme: TERMINAL_THEME,
 	allowProposedApi: true,
-	scrollback: 10000,
+	scrollback: 2000,
 	// Allow Option+key to type special characters on international keyboards (e.g., Option+2 = @)
 	macOptionIsMeta: false,
 	cursorStyle: "block",


### PR DESCRIPTION
## Summary
- Reduces the terminal scrollback buffer from 10,000 to 2,000 lines across all code paths (renderer xterm config, headless emulator, daemon session, non-daemon session)
- 10k was 5-10x the default of most terminals (iTerm2, Terminal.app, Kitty all default to 1-2k) and likely caused memory pressure and rendering lag in xterm.js, especially with multiple panes
- 2k lines matches Kitty's default and is still generous for normal terminal usage

## Test plan
- [x] `bun run lint:fix` — pass
- [x] `bun run typecheck` — pass
- [x] `bun test` — 1342/1342 pass
- [x] `bunx sherif --fix` — pass
- [ ] Manual: open multiple terminal panes, run long-output commands (`find /`, large builds), verify scrollback works and feels snappy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted default terminal scrollback retention from 10,000 to 2,000 lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->