### PR TITLE
fix(desktop): derive codex Start hooks from task_started session events

### DIFF
--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -141,6 +141,7 @@ describe("agent-wrappers copilot", () => {
 		const execLine = buildCodexWrapperExecLine(
 			path.join(TEST_HOOKS_DIR, "notify.sh"),
 		);
+		expect(execLine).not.toContain("{{NOTIFY_PATH}}");
 		expect(wrapper).toContain(execLine);
 	});
 

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts
@@ -23,6 +23,11 @@ const OPENCODE_PLUGIN_TEMPLATE_PATH = path.join(
 	"templates",
 	"opencode-plugin.template.js",
 );
+const CODEX_WRAPPER_EXEC_TEMPLATE_PATH = path.join(
+	__dirname,
+	"templates",
+	"codex-wrapper-exec.template.sh",
+);
 
 const SUPERSET_MANAGED_HOOK_PATH_PATTERN = /\/\.superset(?:-[^/'"\s\\]+)?\//;
 
@@ -183,53 +188,8 @@ export function createCodexWrapper(): void {
 }
 
 export function buildCodexWrapperExecLine(notifyPath: string): string {
-	return `# Codex exposes completion notifications via notify.
-# For per-prompt Start notifications, watch the TUI session log for task_started.
-if [ -n "$SUPERSET_TAB_ID" ] && [ -f "${notifyPath}" ]; then
-  export CODEX_TUI_RECORD_SESSION=1
-  if [ -z "$CODEX_TUI_SESSION_LOG_PATH" ]; then
-    _superset_codex_ts="$(date +%s 2>/dev/null || echo "$$")"
-    export CODEX_TUI_SESSION_LOG_PATH="\${TMPDIR:-/tmp}/superset-codex-session-$$_\${_superset_codex_ts}.jsonl"
-  fi
-
-  (
-    _superset_log="$CODEX_TUI_SESSION_LOG_PATH"
-    _superset_notify="${notifyPath}"
-    _superset_last_turn_id=""
-
-    # Wait briefly for codex to create the session log.
-    _superset_i=0
-    while [ ! -f "$_superset_log" ] && [ "$_superset_i" -lt 200 ]; do
-      _superset_i=$((_superset_i + 1))
-      sleep 0.05
-    done
-    [ -f "$_superset_log" ] || exit 0
-
-    tail -n 0 -F "$_superset_log" 2>/dev/null | while IFS= read -r _superset_line; do
-      case "$_superset_line" in
-        *'"dir":"to_tui"'*'"kind":"codex_event"'*'"type":"task_started"'*)
-          _superset_turn_id=$(printf '%s\n' "$_superset_line" | awk -F'"turn_id":"' 'NF > 1 { sub(/".*/, "", $2); print $2; exit }')
-          [ -n "$_superset_turn_id" ] || _superset_turn_id="task_started"
-          if [ "$_superset_turn_id" != "$_superset_last_turn_id" ]; then
-            _superset_last_turn_id="$_superset_turn_id"
-            bash "$_superset_notify" '{"hook_event_name":"Start"}' >/dev/null 2>&1 || true
-          fi
-          ;;
-      esac
-    done
-  ) &
-  SUPERSET_CODEX_START_WATCHER_PID=$!
-fi
-
-"$REAL_BIN" -c 'notify=["bash","${notifyPath}"]' "$@"
-SUPERSET_CODEX_STATUS=$?
-
-if [ -n "$SUPERSET_CODEX_START_WATCHER_PID" ]; then
-  kill "$SUPERSET_CODEX_START_WATCHER_PID" >/dev/null 2>&1 || true
-  wait "$SUPERSET_CODEX_START_WATCHER_PID" 2>/dev/null || true
-fi
-
-exit "$SUPERSET_CODEX_STATUS"`;
+	const template = fs.readFileSync(CODEX_WRAPPER_EXEC_TEMPLATE_PATH, "utf-8");
+	return template.replaceAll("{{NOTIFY_PATH}}", notifyPath);
 }
 
 /**

--- a/apps/desktop/src/main/lib/agent-setup/templates/codex-wrapper-exec.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/codex-wrapper-exec.template.sh
@@ -1,0 +1,47 @@
+# Codex exposes completion notifications via notify.
+# For per-prompt Start notifications, watch the TUI session log for task_started.
+if [ -n "$SUPERSET_TAB_ID" ] && [ -f "{{NOTIFY_PATH}}" ]; then
+  export CODEX_TUI_RECORD_SESSION=1
+  if [ -z "$CODEX_TUI_SESSION_LOG_PATH" ]; then
+    _superset_codex_ts="$(date +%s 2>/dev/null || echo "$$")"
+    export CODEX_TUI_SESSION_LOG_PATH="${TMPDIR:-/tmp}/superset-codex-session-$$_${_superset_codex_ts}.jsonl"
+  fi
+
+  (
+    _superset_log="$CODEX_TUI_SESSION_LOG_PATH"
+    _superset_notify="{{NOTIFY_PATH}}"
+    _superset_last_turn_id=""
+
+    # Wait briefly for codex to create the session log.
+    _superset_i=0
+    while [ ! -f "$_superset_log" ] && [ "$_superset_i" -lt 200 ]; do
+      _superset_i=$((_superset_i + 1))
+      sleep 0.05
+    done
+    [ -f "$_superset_log" ] || exit 0
+
+    tail -n 0 -F "$_superset_log" 2>/dev/null | while IFS= read -r _superset_line; do
+      case "$_superset_line" in
+        *'"dir":"to_tui"'*'"kind":"codex_event"'*'"type":"task_started"'*)
+          _superset_turn_id=$(printf '%s\n' "$_superset_line" | awk -F'"turn_id":"' 'NF > 1 { sub(/".*/, "", $2); print $2; exit }')
+          [ -n "$_superset_turn_id" ] || _superset_turn_id="task_started"
+          if [ "$_superset_turn_id" != "$_superset_last_turn_id" ]; then
+            _superset_last_turn_id="$_superset_turn_id"
+            bash "$_superset_notify" '{"hook_event_name":"Start"}' >/dev/null 2>&1 || true
+          fi
+          ;;
+      esac
+    done
+  ) &
+  SUPERSET_CODEX_START_WATCHER_PID=$!
+fi
+
+"$REAL_BIN" -c 'notify=["bash","{{NOTIFY_PATH}}"]' "$@"
+SUPERSET_CODEX_STATUS=$?
+
+if [ -n "$SUPERSET_CODEX_START_WATCHER_PID" ]; then
+  kill "$SUPERSET_CODEX_START_WATCHER_PID" >/dev/null 2>&1 || true
+  wait "$SUPERSET_CODEX_START_WATCHER_PID" 2>/dev/null || true
+fi
+
+exit "$SUPERSET_CODEX_STATUS"


### PR DESCRIPTION
## Summary
- refactor the Superset Codex wrapper to emit `Start` from Codex TUI session events instead of process launch
- enable `CODEX_TUI_RECORD_SESSION` in the wrapper and watch the session JSONL for `to_tui/codex_event/task_started`
- dedupe `Start` by `turn_id` to avoid duplicate lifecycle updates
- keep existing Codex completion hook behavior via `notify=["bash", "<notify.sh>"]`
- add focused wrapper test coverage for the new Codex start-watcher script shape

## Why
`notify` only emits completion (`agent-turn-complete`). We need `Start` when a user message begins processing, not when the `codex` process starts.

## Testing
- `bunx biome check apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts`
- `bun test apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Codex integration for wrapper executions: automatic session recording, background monitoring of Codex events, and notification triggering during runs.

* **Tests**
  * Introduced comprehensive tests validating Codex wrapper behavior, watcher/notification flows, session recording, and execution-line construction.

* **Refactor**
  * Improved wrapper execution architecture for clearer organization and more flexible dynamic configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->