### PR TITLE
feat(desktop): add elapsed time footer to assistant messages

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/ChatInterface.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/ChatInterface.tsx
@@ -245,6 +245,7 @@ export function ChatInterface({
 						: []),
 					...pending.files,
 				],
+				actorId: "user",
 				createdAt: pending.createdAt,
 			}));
 		const merged = [...chat.messages, ...optimisticMessages];

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/MessageList/MessageList.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/MessageList/MessageList.tsx
@@ -1,3 +1,4 @@
+import type { SupersetUIMessage } from "@superset/chat/client";
 import {
 	Conversation,
 	ConversationContent,
@@ -6,17 +7,18 @@ import {
 } from "@superset/ui/ai-elements/conversation";
 import { Message, MessageContent } from "@superset/ui/ai-elements/message";
 import { ShimmerLabel } from "@superset/ui/ai-elements/shimmer-label";
-import type { ChatStatus, UIMessage } from "ai";
+import type { ChatStatus } from "ai";
 import { FileIcon, FileTextIcon, ImageIcon } from "lucide-react";
 import { useCallback } from "react";
 import { HiMiniChatBubbleLeftRight } from "react-icons/hi2";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import type { InterruptedMessagePreview } from "../../types";
 import { MessagePartsRenderer } from "../MessagePartsRenderer";
+import { AgentMessageFooter } from "./components/AgentMessageFooter";
 import { MessageScrollbackRail } from "./components/MessageScrollbackRail";
 
 interface MessageListProps {
-	messages: UIMessage[];
+	messages: SupersetUIMessage[];
 	interruptedMessage?: InterruptedMessagePreview | null;
 	isStreaming: boolean;
 	submitStatus?: ChatStatus;
@@ -48,6 +50,44 @@ function FileChip({
 			<span className="max-w-[150px] truncate">{filename || "Attachment"}</span>
 		</div>
 	);
+}
+
+function extractTextContent(msg: SupersetUIMessage): string {
+	return msg.parts
+		.filter((p) => p.type === "text")
+		.map((p) => p.text)
+		.join("");
+}
+
+/** Epoch ms from a Date or date-like value, or undefined if missing. */
+function toEpochMs(value: Date | string | undefined): number | undefined {
+	if (!value) return undefined;
+	const ms =
+		value instanceof Date ? value.getTime() : new Date(value).getTime();
+	return Number.isNaN(ms) ? undefined : ms;
+}
+
+/** Find the preceding user message's createdAt as epoch ms. */
+function getPrecedingUserSendTime(
+	messages: SupersetUIMessage[],
+	index: number,
+): number | undefined {
+	for (let i = index - 1; i >= 0; i--) {
+		const ms = messages[i].role === "user" && toEpochMs(messages[i].createdAt);
+		if (ms) return ms;
+	}
+	return toEpochMs(messages[index]?.createdAt);
+}
+
+/** Get the last user message's createdAt as epoch ms. */
+function getLastUserSendTime(
+	messages: SupersetUIMessage[],
+): number | undefined {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const ms = messages[i].role === "user" && toEpochMs(messages[i].createdAt);
+		if (ms) return ms;
+	}
+	return undefined;
 }
 
 export function MessageList({
@@ -148,6 +188,7 @@ export function MessageList({
 							);
 						}
 
+						const startedAt = getPrecedingUserSendTime(messages, index);
 						return (
 							<Message key={msg.id} from={msg.role}>
 								<MessageContent>
@@ -165,6 +206,14 @@ export function MessageList({
 										/>
 									)}
 								</MessageContent>
+								{startedAt != null && (
+									<AgentMessageFooter
+										startedAt={startedAt}
+										metadata={msg.metadata}
+										isStreaming={shouldAnimateStreaming}
+										messageText={extractTextContent(msg)}
+									/>
+								)}
 							</Message>
 						);
 					})
@@ -195,6 +244,13 @@ export function MessageList({
 								Thinking...
 							</ShimmerLabel>
 						</MessageContent>
+						{getLastUserSendTime(messages) != null && (
+							<AgentMessageFooter
+								startedAt={getLastUserSendTime(messages) as number}
+								isStreaming
+								messageText=""
+							/>
+						)}
 					</Message>
 				)}
 			</ConversationContent>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/MessageList/components/AgentMessageFooter/AgentMessageFooter.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/MessageList/components/AgentMessageFooter/AgentMessageFooter.tsx
@@ -1,0 +1,80 @@
+import type { AssistantMessageMetadata } from "@superset/chat/client";
+import {
+	MessageAction,
+	MessageActions,
+} from "@superset/ui/ai-elements/message";
+import { CheckIcon, CopyIcon, GitForkIcon, RotateCcwIcon } from "lucide-react";
+import { useCallback, useState } from "react";
+import { AsciiSpinner } from "renderer/screens/main/components/AsciiSpinner";
+import { useElapsedTimer } from "./hooks/useElapsedTimer";
+
+interface AgentMessageFooterProps {
+	/** Epoch ms when the user sent the triggering message (timer start). */
+	startedAt: number;
+	metadata?: AssistantMessageMetadata;
+	isStreaming: boolean;
+	messageText: string;
+}
+
+export function AgentMessageFooter({
+	startedAt,
+	metadata,
+	isStreaming,
+	messageText,
+}: AgentMessageFooterProps) {
+	const elapsed = useElapsedTimer(startedAt, isStreaming);
+	const [isCopied, setIsCopied] = useState(false);
+
+	const handleCopy = useCallback(async () => {
+		try {
+			await navigator.clipboard.writeText(messageText);
+			setIsCopied(true);
+			setTimeout(() => setIsCopied(false), 2000);
+		} catch {
+			// clipboard API unavailable
+		}
+	}, [messageText]);
+
+	if (isStreaming) {
+		return (
+			<div className="flex items-center gap-1.5 text-xs text-muted-foreground font-mono">
+				<AsciiSpinner className="text-xs" />
+				<span>{elapsed.toFixed(1)}s</span>
+			</div>
+		);
+	}
+
+	// For completed messages, prefer finishedAt from stream metadata for accuracy
+	const finishedElapsed = metadata?.finishedAt
+		? (new Date(metadata.finishedAt).getTime() - startedAt) / 1000
+		: elapsed;
+	const displaySeconds = Math.round(finishedElapsed);
+
+	return (
+		<div className="flex items-center gap-1.5 text-xs text-muted-foreground font-mono">
+			<span>{displaySeconds}s</span>
+			<span className="select-none">&middot;</span>
+			<MessageActions>
+				<MessageAction
+					tooltip={isCopied ? "Copied" : "Copy"}
+					onClick={handleCopy}
+				>
+					<div className="relative size-3.5">
+						<CopyIcon
+							className={`absolute inset-0 size-3.5 transition-all duration-200 ${isCopied ? "scale-50 opacity-0" : "scale-100 opacity-100"}`}
+						/>
+						<CheckIcon
+							className={`absolute inset-0 size-3.5 transition-all duration-200 ${isCopied ? "scale-100 opacity-100" : "scale-50 opacity-0"}`}
+						/>
+					</div>
+				</MessageAction>
+				<MessageAction tooltip="Fork from here" onClick={() => {}}>
+					<GitForkIcon className="size-3.5" />
+				</MessageAction>
+				<MessageAction tooltip="Replay from here" onClick={() => {}}>
+					<RotateCcwIcon className="size-3.5" />
+				</MessageAction>
+			</MessageActions>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/MessageList/components/AgentMessageFooter/hooks/useElapsedTimer/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/MessageList/components/AgentMessageFooter/hooks/useElapsedTimer/index.ts
@@ -1,0 +1,1 @@
+export { useElapsedTimer } from "./useElapsedTimer";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/MessageList/components/AgentMessageFooter/hooks/useElapsedTimer/useElapsedTimer.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/MessageList/components/AgentMessageFooter/hooks/useElapsedTimer/useElapsedTimer.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Returns elapsed seconds since `startMs` (epoch milliseconds).
+ * When `isActive` is true, ticks every 100ms for a live timer.
+ * When `isActive` is false, returns a static snapshot (no interval).
+ */
+export function useElapsedTimer(startMs: number, isActive: boolean): number {
+	const [elapsed, setElapsed] = useState(() => (Date.now() - startMs) / 1000);
+
+	useEffect(() => {
+		if (!isActive) return;
+		const tick = () => setElapsed((Date.now() - startMs) / 1000);
+		tick();
+		const id = setInterval(tick, 100);
+		return () => clearInterval(id);
+	}, [startMs, isActive]);
+
+	// For inactive timers, compute once on startMs change without triggering re-renders via effect
+	useEffect(() => {
+		if (isActive) return;
+		setElapsed((Date.now() - startMs) / 1000);
+	}, [startMs, isActive]);
+
+	return elapsed;
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/MessageList/components/AgentMessageFooter/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/MessageList/components/AgentMessageFooter/index.ts
@@ -1,0 +1,1 @@
+export { AgentMessageFooter } from "./AgentMessageFooter";

--- a/packages/chat/src/client/index.ts
+++ b/packages/chat/src/client/index.ts
@@ -1,3 +1,7 @@
+export type {
+	AssistantMessageMetadata,
+	SupersetUIMessage,
+} from "../session-db/types";
 export { ChatServiceProvider, chatServiceTrpc } from "./provider";
 export type { UseChatOptions, UseChatReturn } from "./useChat";
 export { useChat } from "./useChat";

--- a/packages/chat/src/client/useChat/useChat.ts
+++ b/packages/chat/src/client/useChat/useChat.ts
@@ -10,10 +10,11 @@
  */
 
 import { createOptimisticAction } from "@durable-streams/state";
-import { type FileUIPart, isToolUIPart, type UIMessage } from "ai";
+import { type FileUIPart, isToolUIPart } from "ai";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ChunkRow } from "../../schema";
 import { messageRowToUIMessage } from "../../session-db/collections/messages/materialize";
+import type { SupersetUIMessage } from "../../session-db/types";
 import {
 	type UseChatMetadataReturn,
 	useChatMetadata,
@@ -55,7 +56,7 @@ export type AddToolOutputOptions =
 
 export interface UseChatReturn {
 	ready: boolean;
-	messages: (UIMessage & { actorId: string; createdAt: Date })[];
+	messages: SupersetUIMessage[];
 	isLoading: boolean;
 	sendMessage: (
 		text: string,
@@ -127,9 +128,9 @@ function parseToolOutputs(rows: ChunkRow[]): Map<string, ToolOutputSnapshot> {
 }
 
 function applyToolOutputs(
-	messages: (UIMessage & { actorId: string; createdAt: Date })[],
+	messages: SupersetUIMessage[],
 	toolOutputs: Map<string, ToolOutputSnapshot>,
-): (UIMessage & { actorId: string; createdAt: Date })[] {
+): SupersetUIMessage[] {
 	if (toolOutputs.size === 0) return messages;
 
 	return messages.map((message) => {

--- a/packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/run-agent.ts
+++ b/packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/run-agent.ts
@@ -409,8 +409,13 @@ async function writeToDurableStream(
 	options?: { runId?: string },
 ) {
 	const messageId = crypto.randomUUID();
+	const startedAt = new Date().toISOString();
 	const aiStream = toAISdkStream(stream, {
 		from: "agent",
+		messageMetadata: () => ({
+			startedAt,
+			finishedAt: new Date().toISOString(),
+		}),
 	}) as unknown as ReadableStream<UIMessageChunk>;
 	const streamWithMetadata =
 		typeof options?.runId === "string" && options.runId.length > 0

--- a/packages/chat/src/session-db/collections/messages/materialize.ts
+++ b/packages/chat/src/session-db/collections/messages/materialize.ts
@@ -9,13 +9,15 @@
  * following the AI SDK v6 chunk protocol.
  */
 
-import type { UIMessage, UIMessageChunk } from "ai";
+import type { UIMessageChunk } from "ai";
 import type { ChunkRow } from "../../../schema";
 import type {
 	AnyUIMessagePart,
+	AssistantMessageMetadata,
 	DurableStreamChunk,
 	MessageRole,
 	MessageRow,
+	SupersetUIMessage,
 	WholeMessageChunk,
 } from "../../types";
 
@@ -99,6 +101,7 @@ function materializeStreamedMessage(rows: ChunkRow[]): MessageRow {
 	const toolInputText = new Map<string, string>();
 
 	let isComplete = false;
+	let metadata: AssistantMessageMetadata | undefined;
 	let currentTextId: string | null = null;
 	let currentReasoningId: string | null = null;
 
@@ -345,10 +348,27 @@ function materializeStreamedMessage(rows: ChunkRow[]): MessageRow {
 
 			// --- Stream lifecycle ---
 			case "start":
-				// No-op — metadata only
+				if (
+					(c as { messageMetadata?: AssistantMessageMetadata }).messageMetadata
+				) {
+					metadata = {
+						...metadata,
+						...(c as { messageMetadata: AssistantMessageMetadata })
+							.messageMetadata,
+					};
+				}
 				break;
 			case "finish":
 				isComplete = true;
+				if (
+					(c as { messageMetadata?: AssistantMessageMetadata }).messageMetadata
+				) {
+					metadata = {
+						...metadata,
+						...(c as { messageMetadata: AssistantMessageMetadata })
+							.messageMetadata,
+					};
+				}
 				break;
 			case "abort":
 				isComplete = true;
@@ -360,7 +380,15 @@ function materializeStreamedMessage(rows: ChunkRow[]): MessageRow {
 				} as unknown as AnyUIMessagePart);
 				break;
 			case "message-metadata":
-				// No-op
+				if (
+					(c as { messageMetadata?: AssistantMessageMetadata }).messageMetadata
+				) {
+					metadata = {
+						...metadata,
+						...(c as { messageMetadata: AssistantMessageMetadata })
+							.messageMetadata,
+					};
+				}
 				break;
 
 			default:
@@ -378,6 +406,7 @@ function materializeStreamedMessage(rows: ChunkRow[]): MessageRow {
 		isComplete,
 		createdAt: new Date(first.createdAt),
 		lastChunkAt: new Date(lastRow.createdAt),
+		metadata,
 	};
 }
 
@@ -444,14 +473,13 @@ export function isAssistantMessage(row: MessageRow): boolean {
 /**
  * Convert a MessageRow to an AI SDK UIMessage.
  */
-export function messageRowToUIMessage(
-	row: MessageRow,
-): UIMessage & { actorId: string; createdAt: Date } {
+export function messageRowToUIMessage(row: MessageRow): SupersetUIMessage {
 	return {
 		id: row.id,
 		role: row.role as "user" | "assistant",
 		parts: row.parts,
 		createdAt: row.createdAt,
 		actorId: row.actorId,
-	} as UIMessage & { actorId: string; createdAt: Date };
+		metadata: row.metadata,
+	} as SupersetUIMessage;
 }

--- a/packages/chat/src/session-db/types/index.ts
+++ b/packages/chat/src/session-db/types/index.ts
@@ -1,7 +1,9 @@
 export type {
 	AnyUIMessagePart,
+	AssistantMessageMetadata,
 	DurableStreamChunk,
 	MessageRole,
 	MessageRow,
+	SupersetUIMessage,
 	WholeMessageChunk,
 } from "./types";

--- a/packages/chat/src/session-db/types/types.ts
+++ b/packages/chat/src/session-db/types/types.ts
@@ -3,6 +3,18 @@ import type { UIMessage, UIMessageChunk } from "ai";
 /** Convenience alias — UIMessagePart is generic; this uses defaults. */
 export type AnyUIMessagePart = UIMessage["parts"][number];
 
+/** Metadata attached to assistant messages via AI SDK messageMetadata. */
+export interface AssistantMessageMetadata {
+	startedAt?: string; // ISO timestamp
+	finishedAt?: string; // ISO timestamp
+}
+
+/** UIMessage parameterized with our metadata + session fields. */
+export type SupersetUIMessage = UIMessage<AssistantMessageMetadata> & {
+	actorId: string;
+	createdAt: Date;
+};
+
 /**
  * Whole message chunk — stored as single row in stream.
  * Used for messages that are complete when written (user input, cached messages).
@@ -43,4 +55,6 @@ export interface MessageRow {
 	createdAt: Date;
 	/** Timestamp of the most recent chunk (for staleness detection) */
 	lastChunkAt: Date;
+	/** Optional timing metadata from AI SDK messageMetadata */
+	metadata?: AssistantMessageMetadata;
 }


### PR DESCRIPTION
**Links**
- Linear: SUPER-291

## Summary
- Add a footer below every assistant message showing elapsed time and action buttons
- While streaming: animated braille spinner + live timer (e.g., `⠋ 1.4s`)
- When complete: final elapsed time (e.g., `47s`) + copy/fork/replay action buttons

## Why / Context
Inspired by Claude Code's message footer UX. Gives users timing feedback while the agent is working and quick actions (copy, fork, replay) once it finishes. Fork and replay are stubs for now.

## How It Works

**Server (packages/chat):**
- `writeToDurableStream` injects `startedAt`/`finishedAt` ISO timestamps into the AI SDK stream via `messageMetadata` callback on `toAISdkStream`
- `materializeStreamedMessage` extracts metadata from `start`, `finish`, and `message-metadata` chunk types into a new `metadata` field on `MessageRow`
- `messageRowToUIMessage` threads metadata through to the client

**Client (apps/desktop):**
- `AgentMessageFooter` component renders below each assistant message
- `useElapsedTimer` hook ticks every 100ms during streaming, returns static value when complete
- Timer start uses the **preceding user message's `createdAt`** (from optimistic sends) so the timer begins the instant the user hits send
- Completed messages compute elapsed from `metadata.finishedAt - userSendTime` for accuracy

**Key design choices:**
- Timer input is `number` (epoch ms) not `Date` to avoid object identity issues causing React re-render loops
- Helper functions return `undefined` instead of `Date.now()` fallback to prevent infinite re-renders during message queue transitions

## Manual QA Checklist

### Streaming State
- [ ] Send a message → braille spinner + live timer appears immediately (e.g., `⠋ 1.4s`)
- [ ] Timer starts from when user hits send, not when first chunk arrives
- [ ] Timer ticks smoothly at ~100ms intervals

### Completed State
- [ ] After completion → static elapsed time (e.g., `47s`) + `·` + copy/fork/replay icons
- [ ] Click copy → clipboard has message text, icon shows checkmark for 2s
- [ ] Click fork → no crash (stub)
- [ ] Click replay → no crash (stub)

### Edge Cases
- [ ] Scroll to older messages → all show elapsed + actions
- [ ] Queued messages don't cause render loops
- [ ] Pre-metadata messages (before this change) degrade gracefully

## Testing
- `bun run typecheck`
- `bun run lint:fix`
- Manual testing in desktop dev mode

## Known Limitations
- Fork and replay buttons are no-op stubs (future work)
- Messages created before this change will lack `finishedAt` metadata; footer falls back to computing elapsed from `Date.now() - startedAt` (slightly less accurate but functional)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent message footer: shows spinner and elapsed time during AI streaming and final elapsed after completion.
  * Copy-to-clipboard with temporary "copied" confirmation.
  * Fork and Replay action buttons added to message controls (placeholders).

* **Behavior Changes**
  * Messages now include timing metadata so agent footers can display start/finish context and show footers for appropriate messages/thinking state.

* **Public API**
  * Message list accepts additional props and updated message shape to support these features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->