### PR TITLE
feat: add Markdown reader mode for terminal output (Cmd+Shift+M)

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/MarkdownOverlay/MarkdownOverlay.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/MarkdownOverlay/MarkdownOverlay.tsx
@@ -1,0 +1,119 @@
+import type { Terminal as XTerm } from "@xterm/xterm";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { MarkdownRenderer } from "renderer/components/MarkdownRenderer/MarkdownRenderer";
+
+interface MarkdownOverlayProps {
+	xterm: XTerm | null;
+	onClose: () => void;
+}
+
+/**
+ * Extract all text from an xterm buffer, stripping ANSI escape codes.
+ * xterm.js already processes ANSI into styled cells, so translateToString()
+ * gives us clean text.
+ */
+function extractTextFromTerminal(xterm: XTerm): string {
+	const buffer = xterm.buffer.active;
+	const lines: string[] = [];
+
+	for (let i = 0; i < buffer.length; i++) {
+		const line = buffer.getLine(i);
+		if (line) {
+			lines.push(line.translateToString(true));
+		}
+	}
+
+	// Trim trailing empty lines
+	while (lines.length > 0 && lines[lines.length - 1]?.trim() === "") {
+		lines.pop();
+	}
+
+	return lines.join("\n");
+}
+
+export function MarkdownOverlay({ xterm, onClose }: MarkdownOverlayProps) {
+	const [content, setContent] = useState("");
+	const scrollRef = useRef<HTMLDivElement>(null);
+	const rafRef = useRef<number | null>(null);
+
+	const updateContent = useCallback(() => {
+		if (!xterm) return;
+		setContent(extractTextFromTerminal(xterm));
+	}, [xterm]);
+
+	// Initial content extraction
+	useEffect(() => {
+		updateContent();
+	}, [updateContent]);
+
+	// Poll for updates when terminal content changes (xterm doesn't expose
+	// a reliable content-change event, so we poll on a reasonable interval)
+	useEffect(() => {
+		if (!xterm) return;
+
+		const interval = setInterval(updateContent, 500);
+		return () => clearInterval(interval);
+	}, [xterm, updateContent]);
+
+	// Auto-scroll to bottom on content change
+	useEffect(() => {
+		if (rafRef.current !== null) {
+			cancelAnimationFrame(rafRef.current);
+		}
+		rafRef.current = requestAnimationFrame(() => {
+			rafRef.current = null;
+			const el = scrollRef.current;
+			if (el) {
+				el.scrollTop = el.scrollHeight;
+			}
+		});
+
+		return () => {
+			if (rafRef.current !== null) {
+				cancelAnimationFrame(rafRef.current);
+			}
+		};
+	}, [content]);
+
+	// Close on Escape
+	useEffect(() => {
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (e.key === "Escape") {
+				e.preventDefault();
+				e.stopPropagation();
+				onClose();
+			}
+		};
+
+		document.addEventListener("keydown", handleKeyDown, { capture: true });
+		return () =>
+			document.removeEventListener("keydown", handleKeyDown, {
+				capture: true,
+			});
+	}, [onClose]);
+
+	return (
+		<div className="absolute inset-0 z-10 flex flex-col bg-background">
+			<div className="flex items-center justify-between px-4 py-2 border-b border-border bg-muted/50">
+				<span className="text-sm font-medium text-muted-foreground">
+					Markdown View
+				</span>
+				<div className="flex items-center gap-3">
+					<span className="text-xs text-muted-foreground/60">
+						Press Esc or ⌘⇧M to close
+					</span>
+					<button
+						type="button"
+						onClick={onClose}
+						className="text-muted-foreground hover:text-foreground transition-colors text-sm px-2 py-0.5 rounded hover:bg-muted"
+					>
+						✕
+					</button>
+				</div>
+			</div>
+			<div ref={scrollRef} className="flex-1 overflow-y-auto">
+				<MarkdownRenderer content={content} />
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/MarkdownOverlay/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/MarkdownOverlay/index.ts
@@ -1,0 +1,1 @@
+export { MarkdownOverlay } from "./MarkdownOverlay";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -24,6 +24,7 @@ import {
 	useTerminalRestore,
 	useTerminalStream,
 } from "./hooks";
+import { MarkdownOverlay } from "./MarkdownOverlay";
 import { ScrollToBottomButton } from "./ScrollToBottomButton";
 import { TerminalSearch } from "./TerminalSearch";
 import type {
@@ -299,7 +300,12 @@ export const Terminal = ({ paneId, tabId, workspaceId }: TerminalProps) => {
 		return () => clearTimeout(timeout);
 	}, [connectionError, handleRetryConnection]);
 
-	const { isSearchOpen, setIsSearchOpen } = useTerminalHotkeys({
+	const {
+		isSearchOpen,
+		setIsSearchOpen,
+		isMarkdownViewOpen,
+		setIsMarkdownViewOpen,
+	} = useTerminalHotkeys({
 		isFocused,
 		xtermRef,
 	});
@@ -425,6 +431,12 @@ export const Terminal = ({ paneId, tabId, workspaceId }: TerminalProps) => {
 			<ScrollToBottomButton terminal={xtermInstance} />
 			{exitStatus === "killed" && !connectionError && !isRestoredMode && (
 				<SessionKilledOverlay onRestart={restartTerminal} />
+			)}
+			{isMarkdownViewOpen && (
+				<MarkdownOverlay
+					xterm={xtermRef.current}
+					onClose={() => setIsMarkdownViewOpen(false)}
+				/>
 			)}
 			<div ref={terminalRef} className="h-full w-full" />
 		</div>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalHotkeys.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalHotkeys.ts
@@ -12,6 +12,8 @@ export interface UseTerminalHotkeysOptions {
 export interface UseTerminalHotkeysReturn {
 	isSearchOpen: boolean;
 	setIsSearchOpen: Dispatch<SetStateAction<boolean>>;
+	isMarkdownViewOpen: boolean;
+	setIsMarkdownViewOpen: Dispatch<SetStateAction<boolean>>;
 }
 
 export function useTerminalHotkeys({
@@ -19,6 +21,7 @@ export function useTerminalHotkeys({
 	xtermRef,
 }: UseTerminalHotkeysOptions): UseTerminalHotkeysReturn {
 	const [isSearchOpen, setIsSearchOpen] = useState(false);
+	const [isMarkdownViewOpen, setIsMarkdownViewOpen] = useState(false);
 
 	useEffect(() => {
 		if (!isFocused) {
@@ -52,5 +55,17 @@ export function useTerminalHotkeys({
 		[isFocused],
 	);
 
-	return { isSearchOpen, setIsSearchOpen };
+	useAppHotkey(
+		"TOGGLE_MARKDOWN_VIEW",
+		() => setIsMarkdownViewOpen((prev) => !prev),
+		{ enabled: isFocused, preventDefault: true },
+		[isFocused],
+	);
+
+	return {
+		isSearchOpen,
+		setIsSearchOpen,
+		isMarkdownViewOpen,
+		setIsMarkdownViewOpen,
+	};
 }

--- a/apps/desktop/src/shared/hotkeys.ts
+++ b/apps/desktop/src/shared/hotkeys.ts
@@ -545,6 +545,13 @@ export const HOTKEYS = {
 		category: "Terminal",
 		description: "Scroll the active terminal to the bottom",
 	}),
+	TOGGLE_MARKDOWN_VIEW: defineHotkey({
+		keys: "meta+shift+m",
+		label: "Toggle Markdown View",
+		category: "Terminal",
+		description:
+			"Toggle rendered Markdown view of terminal output (useful for AI agent output)",
+	}),
 	PREV_TAB: defineHotkey({
 		keys: "meta+alt+left",
 		label: "Previous Tab",


### PR DESCRIPTION
## Summary

AI coding agents (Claude Code, Codex, OpenCode, etc.) output Markdown-formatted text through the terminal. Since xterm.js only renders ANSI escape codes, headers, tables, code blocks, and lists appear as raw text rather than properly formatted Markdown.

This adds a **toggleable Markdown overlay** that renders terminal output as rich Markdown:

- Extracts text from the xterm buffer (already ANSI-stripped by xterm.js via `translateToString()`)
- Renders it through the existing `MarkdownRenderer` component (react-markdown + remark-gfm)
- Toggles with **Cmd+Shift+M** (Ctrl+Shift+M on Win/Linux)
- Auto-scrolls to bottom as content updates
- Closes with **Escape** or the same hotkey

The overlay sits on top of the xterm canvas, which continues running underneath. Toggle back to see the raw terminal at any time.

## What changed

| File | Change |
|------|--------|
| `shared/hotkeys.ts` | Added `TOGGLE_MARKDOWN_VIEW` hotkey definition |
| `Terminal/hooks/useTerminalHotkeys.ts` | Wired hotkey to toggle state |
| `Terminal/MarkdownOverlay/MarkdownOverlay.tsx` | New overlay component |
| `Terminal/MarkdownOverlay/index.ts` | Barrel export |
| `Terminal/Terminal.tsx` | Render overlay when active |

**No new dependencies** — reuses existing `MarkdownRenderer` and the hotkey system.

## Demo

1. Open a terminal pane
2. Run any CLI agent (Claude Code, etc.) that outputs Markdown
3. Press `Cmd+Shift+M` to see the output rendered as rich Markdown
4. Press `Escape` or `Cmd+Shift+M` again to return to raw terminal

## Test plan

- [ ] Verify `Cmd+Shift+M` toggles the Markdown overlay on/off
- [ ] Verify overlay renders headers, code blocks, tables, and lists correctly
- [ ] Verify `Escape` closes the overlay
- [ ] Verify terminal continues running underneath (content updates reflected)
- [ ] Verify typecheck passes (`bun run typecheck` in `apps/desktop`)
- [ ] Verify formatting passes (`bun run format:check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Markdown View toggle (meta+shift+m) to render terminal output as formatted markdown
  * Enhances readability of complex text outputs with proper markdown formatting
  * Live-updating overlay syncs automatically with terminal changes, supports scrolling for navigation, and closes via Escape or button

<!-- end of auto-generated comment: release notes by coderabbit.ai -->