### PR TITLE
ci: fix preview Neon branch creation secret scoping

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -23,6 +23,7 @@ jobs:
   deploy-database:
     name: Deploy Database (Neon)
     runs-on: ubuntu-latest
+    environment: preview
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- set the preview database deployment job to run in the `preview` environment
- ensure environment-scoped secrets (including `NEON_API_KEY`) are available to `neondatabase/create-branch-action@v6`

## Why
The preview workflow already passed `api_key`, but the job was not bound to the `preview` environment, which can cause the action to see a missing `api_key` at runtime.

## Changes
- `.github/workflows/deploy-preview.yml`: added `environment: preview` to `deploy-database`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow configuration to explicitly specify the preview environment, improving deployment management processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->