### PR TITLE
feat(chat): add provider-scoped OAuth reauth flow

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/ChatErrorMessage/ChatErrorMessage.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/ChatErrorMessage/ChatErrorMessage.tsx
@@ -1,0 +1,59 @@
+import { Button } from "@superset/ui/button";
+import { cn } from "@superset/ui/utils";
+import { AlertCircleIcon } from "lucide-react";
+import type React from "react";
+
+interface ChatErrorAction {
+	label: string;
+	onClick: () => void;
+}
+
+interface ChatErrorMessageProps {
+	message: React.ReactNode;
+	title?: React.ReactNode;
+	action?: ChatErrorAction;
+	showIcon?: boolean;
+	className?: string;
+}
+
+export function ChatErrorMessage({
+	message,
+	title,
+	action,
+	showIcon = true,
+	className,
+}: ChatErrorMessageProps) {
+	const hasDetailLayout = Boolean(title || action);
+
+	return (
+		<div
+			className={cn(
+				"rounded-md border bg-destructive/10 text-sm text-destructive",
+				hasDetailLayout
+					? "flex flex-col gap-3 border-destructive/30 px-4 py-3"
+					: "border-destructive/20 px-4 py-2",
+				!hasDetailLayout && showIcon && "flex items-start gap-2",
+				className,
+			)}
+		>
+			<div className={cn(showIcon && "flex items-start gap-2")}>
+				{showIcon ? (
+					<AlertCircleIcon className="mt-0.5 h-4 w-4 shrink-0" />
+				) : null}
+				<div className={cn(title && "space-y-1")}>
+					{title ? <div className="font-medium">{title}</div> : null}
+					<div className={cn("select-text", title && "text-destructive/90")}>
+						{message}
+					</div>
+				</div>
+			</div>
+			{action ? (
+				<div className={cn(showIcon && "pl-6")}>
+					<Button size="sm" variant="outline" onClick={action.onClick}>
+						{action.label}
+					</Button>
+				</div>
+			) : null}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/ChatErrorMessage/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/ChatErrorMessage/index.ts
@@ -1,0 +1,1 @@
+export { ChatErrorMessage } from "./ChatErrorMessage";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/ChatInputFooter/ChatInputFooter.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/ChatInputFooter/ChatInputFooter.tsx
@@ -17,6 +17,7 @@ import {
 } from "shared/hotkeys";
 import type { SlashCommand } from "../../hooks/useSlashCommands";
 import type { ModelOption, PermissionMode } from "../../types";
+import { ChatErrorMessage } from "../ChatErrorMessage";
 import { IssueLinkCommand } from "../IssueLinkCommand";
 import { MentionAnchor, MentionProvider } from "../MentionPopover";
 import { SlashCommandInput } from "../SlashCommandInput";
@@ -138,9 +139,11 @@ export function ChatInputFooter({
 			{(dragType) => (
 				<div className="mx-auto w-full max-w-[680px]">
 					{error && (
-						<div className="mb-3 select-text rounded-md border border-destructive/20 bg-destructive/10 px-4 py-2 text-sm text-destructive">
-							{error}
-						</div>
+						<ChatErrorMessage
+							className="mb-3"
+							message={error}
+							showIcon={false}
+						/>
 					)}
 					<SlashCommandInput
 						onCommandSend={onSlashCommandSend}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/MessagePartsRenderer/oauth-error.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/MessagePartsRenderer/oauth-error.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import {
+	ANTHROPIC_OAUTH_REAUTH_ERROR_CODE,
+	resolveOAuthReauthErrorUi,
+} from "./oauth-error";
+
+describe("resolveOAuthReauthErrorUi", () => {
+	it("matches structured oauth reauth error code", () => {
+		const result = resolveOAuthReauthErrorUi({
+			type: "error",
+			code: ANTHROPIC_OAUTH_REAUTH_ERROR_CODE,
+			text: "anything",
+		});
+
+		expect(result?.kind).toBe("oauth-reauth");
+		expect(result?.actionUrl).toBe("https://console.anthropic.com");
+	});
+
+	it("matches legacy oauth expiry text", () => {
+		const result = resolveOAuthReauthErrorUi({
+			type: "error",
+			text: "OAuth token has expired. Please obtain a new token or refresh your existing token.",
+		});
+
+		expect(result?.kind).toBe("oauth-reauth");
+	});
+
+	it("returns null for non-oauth errors", () => {
+		const result = resolveOAuthReauthErrorUi({
+			type: "error",
+			text: "network timeout",
+		});
+
+		expect(result).toBeNull();
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/MessagePartsRenderer/oauth-error.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/MessagePartsRenderer/oauth-error.ts
@@ -1,0 +1,54 @@
+export const ANTHROPIC_OAUTH_REAUTH_ERROR_CODE =
+	"anthropic_oauth_reauth_required";
+
+export const ANTHROPIC_CONSOLE_URL = "https://console.anthropic.com";
+
+export interface ErrorPartLike {
+	type: "error";
+	text: string;
+	code?: string;
+}
+
+export interface OAuthReauthErrorUi {
+	kind: "oauth-reauth";
+	title: string;
+	description: string;
+	actionLabel: string;
+	actionUrl: string;
+}
+
+export function resolveOAuthReauthErrorUi(
+	part: ErrorPartLike,
+): OAuthReauthErrorUi | null {
+	if (part.code === ANTHROPIC_OAUTH_REAUTH_ERROR_CODE) {
+		return {
+			kind: "oauth-reauth",
+			title: "Claude authentication required",
+			description:
+				"Your Anthropic OAuth session expired and could not be refreshed. Run `claude auth login` in your terminal, then retry.",
+			actionLabel: "Open Anthropic Console",
+			actionUrl: ANTHROPIC_CONSOLE_URL,
+		};
+	}
+
+	const normalized = part.text.toLowerCase();
+	const looksLikeOAuthReauthIssue =
+		normalized.includes("oauth token has expired") ||
+		normalized.includes("oauth token expired") ||
+		(normalized.includes("oauth") &&
+			normalized.includes("could not be refreshed")) ||
+		(normalized.includes("oauth") && normalized.includes("re-authenticate"));
+
+	if (!looksLikeOAuthReauthIssue) {
+		return null;
+	}
+
+	return {
+		kind: "oauth-reauth",
+		title: "Claude authentication required",
+		description:
+			"Your Anthropic OAuth session expired and could not be refreshed. Run `claude auth login` in your terminal, then retry.",
+		actionLabel: "Open Anthropic Console",
+		actionUrl: ANTHROPIC_CONSOLE_URL,
+	};
+}

--- a/packages/agent/src/superagent.ts
+++ b/packages/agent/src/superagent.ts
@@ -21,7 +21,7 @@ import { askUserQuestionTool, webFetchTool, webSearchTool } from "./tools";
  */
 let anthropicAuthToken: string | null = null;
 
-export function setAnthropicAuthToken(token: string) {
+export function setAnthropicAuthToken(token: string | null) {
 	anthropicAuthToken = token;
 }
 

--- a/packages/chat/src/host/auth/anthropic/anthropic.test.ts
+++ b/packages/chat/src/host/auth/anthropic/anthropic.test.ts
@@ -1,0 +1,378 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	clearAnthropicOAuthRefreshState,
+	getCredentialsFromConfig,
+	getOrRefreshAnthropicOAuthCredentials,
+} from "./anthropic";
+
+const tempDirs: string[] = [];
+
+function createConfigFile(config: Record<string, unknown>): string {
+	const dir = mkdtempSync(join(tmpdir(), "anthropic-auth-"));
+	tempDirs.push(dir);
+	const file = join(dir, "credentials.json");
+	writeFileSync(file, `${JSON.stringify(config, null, 2)}\n`);
+	return file;
+}
+
+afterEach(() => {
+	clearAnthropicOAuthRefreshState();
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("getCredentialsFromConfig", () => {
+	it("parses claudeAiOauth credentials", () => {
+		const configPath = createConfigFile({
+			claudeAiOauth: {
+				accessToken: "access-1",
+				refreshToken: "refresh-1",
+				expiresAt: 1_800_000_000,
+			},
+		});
+
+		const result = getCredentialsFromConfig({ configPaths: [configPath] });
+
+		expect(result?.kind).toBe("oauth");
+		if (result?.kind !== "oauth") return;
+		expect(result.apiKey).toBe("access-1");
+		expect(result.refreshToken).toBe("refresh-1");
+		expect(result.expiresAt).toBe(1_800_000_000_000);
+		expect(result.configPath).toBe(configPath);
+	});
+
+	it("parses api key credentials", () => {
+		const configPath = createConfigFile({
+			apiKey: "sk-ant-123",
+		});
+
+		const result = getCredentialsFromConfig({ configPaths: [configPath] });
+		expect(result).toEqual({
+			apiKey: "sk-ant-123",
+			source: "config",
+			kind: "apiKey",
+		});
+	});
+});
+
+describe("getOrRefreshAnthropicOAuthCredentials", () => {
+	it("does not refresh when token is still valid", async () => {
+		const now = 1_700_000_000_000;
+		const configPath = createConfigFile({
+			claudeAiOauth: {
+				accessToken: "still-valid",
+				refreshToken: "refresh-1",
+				expiresAt: now + 10 * 60 * 1000,
+			},
+		});
+		const fetchImpl = mock(async () => {
+			throw new Error("fetch should not be called");
+		});
+
+		const result = await getOrRefreshAnthropicOAuthCredentials({
+			configPaths: [configPath],
+			fetchImpl: fetchImpl as unknown as typeof fetch,
+			nowMs: () => now,
+		});
+
+		expect(fetchImpl).toHaveBeenCalledTimes(0);
+		expect(result?.apiKey).toBe("still-valid");
+	});
+
+	it("refreshes an expired token and persists updated credentials", async () => {
+		const now = 1_700_000_000_000;
+		const configPath = createConfigFile({
+			claudeAiOauth: {
+				accessToken: "expired-access",
+				refreshToken: "refresh-old",
+				expiresAt: now - 60_000,
+			},
+		});
+		const fetchImpl = mock(async () => {
+			return new Response(
+				JSON.stringify({
+					access_token: "access-new",
+					refresh_token: "refresh-new",
+					expires_in: 3600,
+				}),
+				{ status: 200 },
+			);
+		});
+
+		const result = await getOrRefreshAnthropicOAuthCredentials({
+			configPaths: [configPath],
+			fetchImpl: fetchImpl as unknown as typeof fetch,
+			nowMs: () => now,
+		});
+
+		expect(result?.apiKey).toBe("access-new");
+		expect(result?.refreshToken).toBe("refresh-new");
+		expect(result?.expiresAt).toBe(now + 3_600_000);
+		expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+		const saved = JSON.parse(readFileSync(configPath, "utf-8")) as {
+			claudeAiOauth?: {
+				accessToken?: string;
+				refreshToken?: string;
+				expiresAt?: number;
+			};
+		};
+		expect(saved.claudeAiOauth?.accessToken).toBe("access-new");
+		expect(saved.claudeAiOauth?.refreshToken).toBe("refresh-new");
+		expect(saved.claudeAiOauth?.expiresAt).toBe(now + 3_600_000);
+	});
+
+	it("uses a fresh fallback expiry when refresh response omits expires_in", async () => {
+		const now = 1_700_000_000_000;
+		const configPath = createConfigFile({
+			claudeAiOauth: {
+				accessToken: "expired-access",
+				refreshToken: "refresh-old",
+				expiresAt: now - 60_000,
+			},
+		});
+		const fetchImpl = mock(async () => {
+			return new Response(
+				JSON.stringify({
+					access_token: "access-new",
+					refresh_token: "refresh-new",
+				}),
+				{ status: 200 },
+			);
+		});
+
+		const result = await getOrRefreshAnthropicOAuthCredentials({
+			configPaths: [configPath],
+			fetchImpl: fetchImpl as unknown as typeof fetch,
+			nowMs: () => now,
+		});
+
+		expect(result?.apiKey).toBe("access-new");
+		expect(result?.refreshToken).toBe("refresh-new");
+		expect(result?.expiresAt).toBeGreaterThan(now);
+		expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+		const saved = JSON.parse(readFileSync(configPath, "utf-8")) as {
+			claudeAiOauth?: {
+				refreshToken?: string;
+				expiresAt?: number;
+			};
+		};
+		expect(saved.claudeAiOauth?.refreshToken).toBe("refresh-new");
+		expect(saved.claudeAiOauth?.expiresAt).toBeGreaterThan(now);
+	});
+
+	it("returns existing token when best-effort refresh fails but token is not expired", async () => {
+		const now = 1_700_000_000_000;
+		const configPath = createConfigFile({
+			oauth_access_token: "access-stale",
+			oauth_refresh_token: "refresh-old",
+			oauth_expires_at: now + 60_000,
+		});
+		const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+		const fetchImpl = mock(async () => {
+			return new Response("bad refresh", { status: 401 });
+		});
+
+		try {
+			const result = await getOrRefreshAnthropicOAuthCredentials({
+				configPaths: [configPath],
+				fetchImpl: fetchImpl as unknown as typeof fetch,
+				nowMs: () => now,
+			});
+
+			expect(result?.apiKey).toBe("access-stale");
+			expect(result?.refreshToken).toBe("refresh-old");
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+
+	it("returns null when forced refresh fails", async () => {
+		const now = 1_700_000_000_000;
+		const configPath = createConfigFile({
+			oauthAccessToken: "access-old",
+			oauthRefreshToken: "refresh-old",
+			oauthExpiresAt: now + 60_000,
+		});
+		const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+		const fetchImpl = mock(async () => {
+			return new Response("refresh failed", { status: 500 });
+		});
+
+		try {
+			const result = await getOrRefreshAnthropicOAuthCredentials({
+				forceRefresh: true,
+				configPaths: [configPath],
+				fetchImpl: fetchImpl as unknown as typeof fetch,
+				nowMs: () => now,
+			});
+			expect(result).toBeNull();
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+
+	it("returns null when forced refresh times out", async () => {
+		const now = 1_700_000_000_000;
+		const configPath = createConfigFile({
+			oauthAccessToken: "access-old",
+			oauthRefreshToken: "refresh-old",
+			oauthExpiresAt: now + 60_000,
+		});
+		const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+		const fetchImpl = mock(async () => {
+			const timeoutError = new Error("aborted");
+			timeoutError.name = "AbortError";
+			throw timeoutError;
+		});
+
+		try {
+			const result = await getOrRefreshAnthropicOAuthCredentials({
+				forceRefresh: true,
+				configPaths: [configPath],
+				fetchImpl: fetchImpl as unknown as typeof fetch,
+				nowMs: () => now,
+			});
+			expect(result).toBeNull();
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+
+	it("returns null when forced refresh is requested but refresh token is missing", async () => {
+		const now = 1_700_000_000_000;
+		const configPath = createConfigFile({
+			oauthAccessToken: "expired_access",
+			oauthExpiresAt: now - 60_000,
+		});
+		const fetchImpl = mock(async () => {
+			throw new Error("fetch should not be called without refresh token");
+		});
+
+		const result = await getOrRefreshAnthropicOAuthCredentials({
+			forceRefresh: true,
+			configPaths: [configPath],
+			fetchImpl: fetchImpl as unknown as typeof fetch,
+			nowMs: () => now,
+		});
+
+		expect(result).toBeNull();
+		expect(fetchImpl).toHaveBeenCalledTimes(0);
+	});
+
+	it("returns null when token is expired and refresh token is missing", async () => {
+		const now = 1_700_000_000_000;
+		const configPath = createConfigFile({
+			oauthAccessToken: "expired_access",
+			oauthExpiresAt: now - 60_000,
+		});
+		const fetchImpl = mock(async () => {
+			throw new Error("fetch should not be called without refresh token");
+		});
+
+		const result = await getOrRefreshAnthropicOAuthCredentials({
+			configPaths: [configPath],
+			fetchImpl: fetchImpl as unknown as typeof fetch,
+			nowMs: () => now,
+		});
+
+		expect(result).toBeNull();
+		expect(fetchImpl).toHaveBeenCalledTimes(0);
+	});
+
+	it("deduplicates concurrent refresh calls for the same config path", async () => {
+		const now = 1_700_000_000_000;
+		const configPath = createConfigFile({
+			claudeAiOauth: {
+				accessToken: "expired-access",
+				refreshToken: "refresh-old",
+				expiresAt: now - 60_000,
+			},
+		});
+		const fetchImpl = mock(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			return new Response(
+				JSON.stringify({
+					access_token: "access-new",
+					refresh_token: "refresh-new",
+					expires_in: 3600,
+				}),
+				{ status: 200 },
+			);
+		});
+
+		const [resultA, resultB] = await Promise.all([
+			getOrRefreshAnthropicOAuthCredentials({
+				configPaths: [configPath],
+				fetchImpl: fetchImpl as unknown as typeof fetch,
+				nowMs: () => now,
+			}),
+			getOrRefreshAnthropicOAuthCredentials({
+				configPaths: [configPath],
+				fetchImpl: fetchImpl as unknown as typeof fetch,
+				nowMs: () => now,
+			}),
+		]);
+
+		expect(fetchImpl).toHaveBeenCalledTimes(1);
+		expect(resultA?.apiKey).toBe("access-new");
+		expect(resultB?.apiKey).toBe("access-new");
+	});
+
+	it("does not share in-flight refreshes across different config paths", async () => {
+		const now = 1_700_000_000_000;
+		const configPathA = createConfigFile({
+			claudeAiOauth: {
+				accessToken: "expired-a",
+				refreshToken: "refresh-a",
+				expiresAt: now - 60_000,
+			},
+		});
+		const configPathB = createConfigFile({
+			claudeAiOauth: {
+				accessToken: "expired-b",
+				refreshToken: "refresh-b",
+				expiresAt: now - 60_000,
+			},
+		});
+		const fetchImpl = mock(
+			async (_input: RequestInfo | URL, init?: RequestInit) => {
+				const body =
+					typeof init?.body === "string"
+						? (JSON.parse(init.body) as { refresh_token?: string })
+						: {};
+				const refreshToken = body.refresh_token;
+				return new Response(
+					JSON.stringify({
+						access_token: `access-${refreshToken}`,
+						refresh_token: `refresh-next-${refreshToken}`,
+						expires_in: 3600,
+					}),
+					{ status: 200 },
+				);
+			},
+		);
+
+		const [resultA, resultB] = await Promise.all([
+			getOrRefreshAnthropicOAuthCredentials({
+				configPaths: [configPathA],
+				fetchImpl: fetchImpl as unknown as typeof fetch,
+				nowMs: () => now,
+			}),
+			getOrRefreshAnthropicOAuthCredentials({
+				configPaths: [configPathB],
+				fetchImpl: fetchImpl as unknown as typeof fetch,
+				nowMs: () => now,
+			}),
+		]);
+
+		expect(fetchImpl).toHaveBeenCalledTimes(2);
+		expect(resultA?.apiKey).toBe("access-refresh-a");
+		expect(resultB?.apiKey).toBe("access-refresh-b");
+	});
+});

--- a/packages/chat/src/host/auth/anthropic/anthropic.ts
+++ b/packages/chat/src/host/auth/anthropic/anthropic.ts
@@ -1,125 +1,20 @@
 /**
  * Claude Code authentication resolution.
  *
- * Reads Claude credentials from:
- * 1. Claude config file (~/.claude.json or ~/.config/claude/credentials.json)
- * 2. macOS Keychain (via security command)
+ * Backward-compatible export surface for Anthropic auth helpers.
  */
 
-import { execSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
-import { homedir, platform } from "node:os";
-import { join } from "node:path";
-
-interface ClaudeCredentials {
-	apiKey: string;
-	source: "config" | "keychain";
-	kind: "apiKey" | "oauth";
-}
-
-interface ClaudeConfigFile {
-	apiKey?: string;
-	api_key?: string;
-	oauthAccessToken?: string;
-	oauth_access_token?: string;
-	claudeAiOauth?: {
-		accessToken?: string;
-		refreshToken?: string;
-		expiresAt?: number;
-	};
-}
-
-export function getCredentialsFromConfig(): ClaudeCredentials | null {
-	const home = homedir();
-	const configPaths = [
-		join(home, ".claude", ".credentials.json"),
-		join(home, ".claude.json"),
-		join(home, ".config", "claude", "credentials.json"),
-		join(home, ".config", "claude", "config.json"),
-	];
-
-	for (const configPath of configPaths) {
-		if (existsSync(configPath)) {
-			try {
-				const content = readFileSync(configPath, "utf-8");
-				const config: ClaudeConfigFile = JSON.parse(content);
-
-				if (config.claudeAiOauth?.accessToken) {
-					console.log(
-						`[claude/auth] Found OAuth credentials in: ${configPath}`,
-					);
-					return {
-						apiKey: config.claudeAiOauth.accessToken,
-						source: "config",
-						kind: "oauth",
-					};
-				}
-
-				const apiKey = config.apiKey || config.api_key;
-				const oauthAccessToken =
-					config.oauthAccessToken || config.oauth_access_token;
-
-				if (apiKey) {
-					console.log(`[claude/auth] Found credentials in: ${configPath}`);
-					return { apiKey, source: "config", kind: "apiKey" };
-				}
-
-				if (oauthAccessToken) {
-					console.log(
-						`[claude/auth] Found OAuth credentials in: ${configPath}`,
-					);
-					return {
-						apiKey: oauthAccessToken,
-						source: "config",
-						kind: "oauth",
-					};
-				}
-			} catch (error) {
-				console.warn(
-					`[claude/auth] Failed to parse config at ${configPath}:`,
-					error,
-				);
-			}
-		}
-	}
-
-	return null;
-}
-
-export function getCredentialsFromKeychain(): ClaudeCredentials | null {
-	if (platform() !== "darwin") {
-		return null;
-	}
-
-	try {
-		const result = execSync(
-			'security find-generic-password -s "claude-cli" -a "api-key" -w 2>/dev/null',
-			{ encoding: "utf-8" },
-		).trim();
-
-		if (result) {
-			console.log("[claude/auth] Found credentials in macOS Keychain");
-			return { apiKey: result, source: "keychain", kind: "apiKey" };
-		}
-	} catch {
-		// Not found in keychain
-	}
-
-	try {
-		const result = execSync(
-			'security find-generic-password -s "anthropic-api-key" -w 2>/dev/null',
-			{ encoding: "utf-8" },
-		).trim();
-
-		if (result) {
-			console.log(
-				"[claude/auth] Found credentials in macOS Keychain (anthropic-api-key)",
-			);
-			return { apiKey: result, source: "keychain", kind: "apiKey" };
-		}
-	} catch {
-		// Not found in keychain
-	}
-
-	return null;
-}
+export {
+	getClaudeConfigPaths,
+	getCredentialsFromConfig,
+} from "./config-credentials";
+export { getCredentialsFromKeychain } from "./keychain-credentials";
+export {
+	clearAnthropicOAuthRefreshState,
+	getOrRefreshAnthropicOAuthCredentials,
+} from "./oauth-refresh";
+export type {
+	ClaudeApiKeyCredentials,
+	ClaudeCredentials,
+	ClaudeOAuthCredentials,
+} from "./types";

--- a/packages/chat/src/host/auth/anthropic/config-credentials.ts
+++ b/packages/chat/src/host/auth/anthropic/config-credentials.ts
@@ -1,0 +1,130 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type {
+	ClaudeConfigFile,
+	ClaudeCredentials,
+	ClaudeOAuthCredentials,
+	GetCredentialsFromConfigOptions,
+} from "./types";
+
+function normalizeExpiry(value: unknown): number | undefined {
+	if (typeof value !== "number" && typeof value !== "string") {
+		return undefined;
+	}
+	const numeric = Number(value);
+	if (!Number.isFinite(numeric) || numeric <= 0) {
+		return undefined;
+	}
+
+	// Handle both epoch seconds and epoch milliseconds.
+	return numeric < 1_000_000_000_000 ? numeric * 1000 : numeric;
+}
+
+function parseConfigCredentials(
+	configPath: string,
+	config: ClaudeConfigFile,
+): ClaudeCredentials | null {
+	if (config.claudeAiOauth?.accessToken) {
+		return {
+			apiKey: config.claudeAiOauth.accessToken,
+			source: "config",
+			kind: "oauth",
+			refreshToken: config.claudeAiOauth.refreshToken,
+			expiresAt: normalizeExpiry(config.claudeAiOauth.expiresAt),
+			configPath,
+		};
+	}
+
+	const apiKey = config.apiKey || config.api_key;
+	const oauthAccessToken = config.oauthAccessToken || config.oauth_access_token;
+	const oauthRefreshToken =
+		config.oauthRefreshToken || config.oauth_refresh_token;
+	const oauthExpiresAt = normalizeExpiry(
+		config.oauthExpiresAt || config.oauth_expires_at,
+	);
+
+	if (apiKey) {
+		return { apiKey, source: "config", kind: "apiKey" };
+	}
+
+	if (oauthAccessToken) {
+		return {
+			apiKey: oauthAccessToken,
+			source: "config",
+			kind: "oauth",
+			refreshToken: oauthRefreshToken,
+			expiresAt: oauthExpiresAt,
+			configPath,
+		};
+	}
+
+	return null;
+}
+
+export function getClaudeConfigPaths(home = homedir()): string[] {
+	return [
+		join(home, ".claude", ".credentials.json"),
+		join(home, ".claude.json"),
+		join(home, ".config", "claude", "credentials.json"),
+		join(home, ".config", "claude", "config.json"),
+	];
+}
+
+export function getCredentialsFromConfig(
+	options?: GetCredentialsFromConfigOptions,
+): ClaudeCredentials | null {
+	const configPaths = options?.configPaths ?? getClaudeConfigPaths();
+
+	for (const configPath of configPaths) {
+		if (existsSync(configPath)) {
+			try {
+				const content = readFileSync(configPath, "utf-8");
+				const config: ClaudeConfigFile = JSON.parse(content);
+				const credentials = parseConfigCredentials(configPath, config);
+				if (credentials) return credentials;
+			} catch (error) {
+				console.warn(
+					`[claude/auth] Failed to parse config at ${configPath}:`,
+					error,
+				);
+			}
+		}
+	}
+
+	return null;
+}
+
+export function saveOAuthCredentialsToConfig(
+	credentials: ClaudeOAuthCredentials,
+	refreshed: { accessToken: string; refreshToken: string; expiresAt: number },
+): void {
+	const content = readFileSync(credentials.configPath, "utf-8");
+	const config: ClaudeConfigFile = JSON.parse(content);
+
+	if (config.claudeAiOauth) {
+		config.claudeAiOauth = {
+			...config.claudeAiOauth,
+			accessToken: refreshed.accessToken,
+			refreshToken: refreshed.refreshToken,
+			expiresAt: refreshed.expiresAt,
+		};
+	} else {
+		const useSnakeCase =
+			typeof config.oauth_access_token === "string" ||
+			typeof config.oauth_refresh_token === "string" ||
+			typeof config.oauth_expires_at !== "undefined";
+
+		if (useSnakeCase) {
+			config.oauth_access_token = refreshed.accessToken;
+			config.oauth_refresh_token = refreshed.refreshToken;
+			config.oauth_expires_at = refreshed.expiresAt;
+		} else {
+			config.oauthAccessToken = refreshed.accessToken;
+			config.oauthRefreshToken = refreshed.refreshToken;
+			config.oauthExpiresAt = refreshed.expiresAt;
+		}
+	}
+
+	writeFileSync(credentials.configPath, `${JSON.stringify(config, null, 2)}\n`);
+}

--- a/packages/chat/src/host/auth/anthropic/constants.ts
+++ b/packages/chat/src/host/auth/anthropic/constants.ts
@@ -1,0 +1,10 @@
+export const ANTHROPIC_OAUTH_TOKEN_URL =
+	"https://console.anthropic.com/v1/oauth/token";
+
+export const ANTHROPIC_OAUTH_CLIENT_ID = Buffer.from(
+	"OWQxYzI1MGEtZTYxYi00NGQ5LTg4ZWQtNTk0NGQxOTYyZjVl",
+	"base64",
+).toString("utf8");
+
+export const REFRESH_BUFFER_MS = 5 * 60 * 1000;
+export const REFRESH_REQUEST_TIMEOUT_MS = 30_000;

--- a/packages/chat/src/host/auth/anthropic/index.ts
+++ b/packages/chat/src/host/auth/anthropic/index.ts
@@ -1,4 +1,5 @@
 export {
 	getCredentialsFromConfig,
 	getCredentialsFromKeychain,
+	getOrRefreshAnthropicOAuthCredentials,
 } from "./anthropic";

--- a/packages/chat/src/host/auth/anthropic/keychain-credentials.ts
+++ b/packages/chat/src/host/auth/anthropic/keychain-credentials.ts
@@ -1,0 +1,41 @@
+import { execSync } from "node:child_process";
+import { platform } from "node:os";
+import type { ClaudeCredentials } from "./types";
+
+export function getCredentialsFromKeychain(): ClaudeCredentials | null {
+	if (platform() !== "darwin") {
+		return null;
+	}
+
+	try {
+		const result = execSync(
+			'security find-generic-password -s "claude-cli" -a "api-key" -w 2>/dev/null',
+			{ encoding: "utf-8" },
+		).trim();
+
+		if (result) {
+			console.log("[claude/auth] Found credentials in macOS Keychain");
+			return { apiKey: result, source: "keychain", kind: "apiKey" };
+		}
+	} catch {
+		// Not found in keychain
+	}
+
+	try {
+		const result = execSync(
+			'security find-generic-password -s "anthropic-api-key" -w 2>/dev/null',
+			{ encoding: "utf-8" },
+		).trim();
+
+		if (result) {
+			console.log(
+				"[claude/auth] Found credentials in macOS Keychain (anthropic-api-key)",
+			);
+			return { apiKey: result, source: "keychain", kind: "apiKey" };
+		}
+	} catch {
+		// Not found in keychain
+	}
+
+	return null;
+}

--- a/packages/chat/src/host/auth/anthropic/oauth-refresh.ts
+++ b/packages/chat/src/host/auth/anthropic/oauth-refresh.ts
@@ -1,0 +1,187 @@
+import {
+	getCredentialsFromConfig,
+	saveOAuthCredentialsToConfig,
+} from "./config-credentials";
+import {
+	ANTHROPIC_OAUTH_CLIENT_ID,
+	ANTHROPIC_OAUTH_TOKEN_URL,
+	REFRESH_BUFFER_MS,
+	REFRESH_REQUEST_TIMEOUT_MS,
+} from "./constants";
+import type { ClaudeOAuthCredentials } from "./types";
+
+interface GetOrRefreshAnthropicOAuthCredentialsOptions {
+	forceRefresh?: boolean;
+	configPaths?: string[];
+	fetchImpl?: typeof fetch;
+	nowMs?: () => number;
+}
+
+const refreshInFlightByConfigPath = new Map<
+	string,
+	Promise<ClaudeOAuthCredentials | null>
+>();
+
+function isExpired(expiresAt: number | undefined, nowMs: number): boolean {
+	return typeof expiresAt === "number" && nowMs >= expiresAt;
+}
+
+function shouldRefresh(expiresAt: number | undefined, nowMs: number): boolean {
+	if (typeof expiresAt !== "number") {
+		return false;
+	}
+	return nowMs + REFRESH_BUFFER_MS >= expiresAt;
+}
+
+async function refreshAnthropicOAuthCredentials(
+	credentials: ClaudeOAuthCredentials,
+	deps: {
+		fetchImpl: typeof fetch;
+		nowMs: () => number;
+	},
+): Promise<ClaudeOAuthCredentials | null> {
+	if (!credentials.refreshToken) {
+		return null;
+	}
+
+	const abortController = new AbortController();
+	const timeout = setTimeout(() => {
+		abortController.abort();
+	}, REFRESH_REQUEST_TIMEOUT_MS);
+
+	let response: Response;
+	try {
+		response = await deps.fetchImpl(ANTHROPIC_OAUTH_TOKEN_URL, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				grant_type: "refresh_token",
+				client_id: ANTHROPIC_OAUTH_CLIENT_ID,
+				refresh_token: credentials.refreshToken,
+			}),
+			signal: abortController.signal,
+		});
+	} catch (error) {
+		if (
+			error instanceof Error &&
+			(error.name === "AbortError" || error.name === "TimeoutError")
+		) {
+			throw new Error(
+				`Anthropic OAuth refresh timed out after ${REFRESH_REQUEST_TIMEOUT_MS}ms`,
+			);
+		}
+		throw error;
+	} finally {
+		clearTimeout(timeout);
+	}
+
+	if (!response.ok) {
+		const errorText = await response.text();
+		throw new Error(
+			`Anthropic OAuth refresh failed (${response.status}): ${errorText}`,
+		);
+	}
+
+	const data = (await response.json()) as {
+		access_token?: string;
+		refresh_token?: string;
+		expires_in?: number;
+	};
+
+	if (!data.access_token) {
+		throw new Error("Anthropic OAuth refresh returned no access token");
+	}
+
+	const nextRefreshToken = data.refresh_token || credentials.refreshToken;
+	const now = deps.nowMs();
+	const nextExpiresAt =
+		typeof data.expires_in === "number"
+			? now + data.expires_in * 1000
+			: Math.max(now + 60 * 60 * 1000, credentials.expiresAt ?? 0);
+
+	saveOAuthCredentialsToConfig(credentials, {
+		accessToken: data.access_token,
+		refreshToken: nextRefreshToken,
+		expiresAt: nextExpiresAt,
+	});
+
+	return {
+		...credentials,
+		apiKey: data.access_token,
+		refreshToken: nextRefreshToken,
+		expiresAt: nextExpiresAt,
+	};
+}
+
+/**
+ * Resolve Claude OAuth credentials from config and refresh when needed.
+ *
+ * Returns null when OAuth is unavailable, or when a forced refresh fails.
+ */
+export async function getOrRefreshAnthropicOAuthCredentials(
+	options?: GetOrRefreshAnthropicOAuthCredentialsOptions,
+): Promise<ClaudeOAuthCredentials | null> {
+	const forceRefresh = options?.forceRefresh ?? false;
+	const nowMs = options?.nowMs ?? Date.now;
+	const fetchImpl = options?.fetchImpl ?? fetch;
+	const credentials = getCredentialsFromConfig({
+		configPaths: options?.configPaths,
+	});
+
+	if (!credentials || credentials.kind !== "oauth") {
+		return null;
+	}
+
+	if (!credentials.refreshToken) {
+		if (forceRefresh) {
+			return null;
+		}
+		const expired = isExpired(credentials.expiresAt, nowMs());
+		if (expired) {
+			return null;
+		}
+		// No refresh token available, keep using existing non-expired access token.
+		return credentials;
+	}
+
+	const expired = isExpired(credentials.expiresAt, nowMs());
+	const refreshNeeded =
+		forceRefresh || shouldRefresh(credentials.expiresAt, nowMs());
+
+	if (!refreshNeeded) {
+		return credentials;
+	}
+
+	const refreshKey = credentials.configPath;
+	let refreshInFlight = refreshInFlightByConfigPath.get(refreshKey);
+	if (!refreshInFlight) {
+		refreshInFlight = refreshAnthropicOAuthCredentials(credentials, {
+			fetchImpl,
+			nowMs,
+		})
+			.catch((error) => {
+				console.warn("[claude/auth] Failed to refresh OAuth token:", error);
+				return null;
+			})
+			.finally(() => {
+				refreshInFlightByConfigPath.delete(refreshKey);
+			});
+		refreshInFlightByConfigPath.set(refreshKey, refreshInFlight);
+	}
+
+	const refreshed = await refreshInFlight;
+	if (refreshed) {
+		return refreshed;
+	}
+
+	// If refresh failed and token is already expired, force caller to re-auth.
+	if (forceRefresh || expired) {
+		return null;
+	}
+
+	return credentials;
+}
+
+export function clearAnthropicOAuthRefreshState(): void {
+	refreshInFlightByConfigPath.clear();
+}

--- a/packages/chat/src/host/auth/anthropic/types.ts
+++ b/packages/chat/src/host/auth/anthropic/types.ts
@@ -1,0 +1,41 @@
+export interface ClaudeCredentialBase {
+	apiKey: string;
+	source: "config" | "keychain";
+	kind: "apiKey" | "oauth";
+}
+
+export interface ClaudeApiKeyCredentials extends ClaudeCredentialBase {
+	kind: "apiKey";
+}
+
+export interface ClaudeOAuthCredentials extends ClaudeCredentialBase {
+	kind: "oauth";
+	source: "config";
+	refreshToken?: string;
+	expiresAt?: number;
+	configPath: string;
+}
+
+export type ClaudeCredentials =
+	| ClaudeApiKeyCredentials
+	| ClaudeOAuthCredentials;
+
+export interface ClaudeConfigFile {
+	apiKey?: string;
+	api_key?: string;
+	oauthAccessToken?: string;
+	oauth_access_token?: string;
+	oauthRefreshToken?: string;
+	oauth_refresh_token?: string;
+	oauthExpiresAt?: number | string;
+	oauth_expires_at?: number | string;
+	claudeAiOauth?: {
+		accessToken?: string;
+		refreshToken?: string;
+		expiresAt?: number | string;
+	};
+}
+
+export interface GetCredentialsFromConfigOptions {
+	configPaths?: string[];
+}

--- a/packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/oauth-retry.test.ts
+++ b/packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/oauth-retry.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, mock } from "bun:test";
+import {
+	ANTHROPIC_OAUTH_REAUTH_REQUIRED_MESSAGE,
+	AnthropicOAuthReauthRequiredError,
+	isAnthropicOAuthExpiredError,
+	isAnthropicOAuthReauthRequiredError,
+	withAnthropicOAuthRetry,
+} from "./oauth-retry";
+
+describe("isAnthropicOAuthExpiredError", () => {
+	it("matches known Anthropic OAuth expiration signatures", () => {
+		expect(
+			isAnthropicOAuthExpiredError(
+				new Error(
+					"OAuth token has expired. Please obtain a new token or refresh your existing token.",
+				),
+			),
+		).toBe(true);
+		expect(
+			isAnthropicOAuthExpiredError(
+				new Error(
+					'{"type":"authentication_error","message":"oauth token expired"}',
+				),
+			),
+		).toBe(true);
+		expect(
+			isAnthropicOAuthExpiredError(
+				new Error("POST https://api.anthropic.com token is expired"),
+			),
+		).toBe(true);
+	});
+
+	it("does not match non-auth errors", () => {
+		expect(isAnthropicOAuthExpiredError(new Error("network timeout"))).toBe(
+			false,
+		);
+	});
+});
+
+describe("withAnthropicOAuthRetry", () => {
+	it("rethrows non-oauth errors without retry", async () => {
+		const syncToken = mock(async () => "synced" as const);
+
+		await expect(
+			withAnthropicOAuthRetry(
+				async () => {
+					throw new Error("unrelated failure");
+				},
+				{ syncToken },
+			),
+		).rejects.toThrow("unrelated failure");
+
+		expect(syncToken).toHaveBeenCalledTimes(1);
+	});
+
+	it("retries once when oauth token is expired and refresh succeeds", async () => {
+		const syncCalls: Array<{ forceRefresh?: boolean } | undefined> = [];
+		const syncToken = mock(async (options?: { forceRefresh?: boolean }) => {
+			syncCalls.push(options);
+			return "synced" as const;
+		});
+		const onRetry = mock(() => {});
+		let attempts = 0;
+
+		const result = await withAnthropicOAuthRetry(
+			async () => {
+				attempts++;
+				if (attempts === 1) {
+					throw new Error(
+						"OAuth token has expired. Please obtain a new token or refresh your existing token.",
+					);
+				}
+				return "ok";
+			},
+			{ syncToken, onRetry },
+		);
+
+		expect(result).toBe("ok");
+		expect(attempts).toBe(2);
+		expect(syncToken).toHaveBeenCalledTimes(2);
+		expect(syncCalls[0]).toBeUndefined();
+		expect(syncCalls[1]).toEqual({ forceRefresh: true });
+		expect(onRetry).toHaveBeenCalledTimes(1);
+	});
+
+	it("rethrows when refresh fails after oauth expiration", async () => {
+		const syncToken = mock(async (options?: { forceRefresh?: boolean }) =>
+			options?.forceRefresh
+				? ("reauth-required" as const)
+				: ("synced" as const),
+		);
+		let attempts = 0;
+
+		await expect(
+			withAnthropicOAuthRetry(
+				async () => {
+					attempts++;
+					throw new Error(
+						'{"type":"authentication_error","message":"oauth token expired"}',
+					);
+				},
+				{ syncToken },
+			),
+		).rejects.toThrow(ANTHROPIC_OAUTH_REAUTH_REQUIRED_MESSAGE);
+
+		expect(attempts).toBe(1);
+		expect(syncToken).toHaveBeenCalledTimes(2);
+	});
+
+	it("throws reauth-required before operation when preflight sync requires reauth", async () => {
+		const syncToken = mock(async () => "reauth-required" as const);
+		const operation = mock(async () => "ok");
+
+		await expect(
+			withAnthropicOAuthRetry(operation, { syncToken }),
+		).rejects.toThrow(ANTHROPIC_OAUTH_REAUTH_REQUIRED_MESSAGE);
+
+		expect(operation).toHaveBeenCalledTimes(0);
+		expect(syncToken).toHaveBeenCalledTimes(1);
+	});
+
+	it("identifies oauth reauth required errors", () => {
+		expect(
+			isAnthropicOAuthReauthRequiredError(
+				new AnthropicOAuthReauthRequiredError(),
+			),
+		).toBe(true);
+		expect(
+			isAnthropicOAuthReauthRequiredError(
+				new Error(ANTHROPIC_OAUTH_REAUTH_REQUIRED_MESSAGE),
+			),
+		).toBe(true);
+		expect(isAnthropicOAuthReauthRequiredError(new Error("unrelated"))).toBe(
+			false,
+		);
+	});
+});

--- a/packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/oauth-retry.ts
+++ b/packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/oauth-retry.ts
@@ -1,0 +1,84 @@
+export interface OAuthTokenSyncOptions {
+	forceRefresh?: boolean;
+}
+
+export type OAuthTokenSyncResult = "synced" | "reauth-required" | "unavailable";
+
+export const ANTHROPIC_OAUTH_REAUTH_REQUIRED_ERROR_CODE =
+	"anthropic_oauth_reauth_required";
+export const ANTHROPIC_OAUTH_REAUTH_REQUIRED_MESSAGE =
+	"Anthropic OAuth session expired and could not be refreshed. Re-authenticate Claude Code (run `claude auth login`) and try again.";
+
+export type SyncAnthropicOAuthToken = (
+	options?: OAuthTokenSyncOptions,
+) => Promise<OAuthTokenSyncResult>;
+
+export class AnthropicOAuthReauthRequiredError extends Error {
+	readonly code = ANTHROPIC_OAUTH_REAUTH_REQUIRED_ERROR_CODE;
+
+	constructor() {
+		super(ANTHROPIC_OAUTH_REAUTH_REQUIRED_MESSAGE);
+		this.name = "AnthropicOAuthReauthRequiredError";
+	}
+}
+
+export function isAnthropicOAuthExpiredError(error: unknown): boolean {
+	const message = error instanceof Error ? error.message : String(error);
+	const normalized = message.toLowerCase();
+
+	if (normalized.includes("oauth token has expired")) {
+		return true;
+	}
+	if (
+		normalized.includes("authentication_error") &&
+		normalized.includes("oauth")
+	) {
+		return true;
+	}
+	if (
+		normalized.includes("api.anthropic.com") &&
+		normalized.includes("token") &&
+		normalized.includes("expired")
+	) {
+		return true;
+	}
+
+	return false;
+}
+
+export function isAnthropicOAuthReauthRequiredError(error: unknown): boolean {
+	return (
+		error instanceof AnthropicOAuthReauthRequiredError ||
+		(error instanceof Error &&
+			error.message.includes(ANTHROPIC_OAUTH_REAUTH_REQUIRED_MESSAGE))
+	);
+}
+
+export async function withAnthropicOAuthRetry<T>(
+	operation: () => Promise<T>,
+	options: {
+		syncToken: SyncAnthropicOAuthToken;
+		onRetry?: () => void;
+	},
+): Promise<T> {
+	const preflightSyncResult = await options.syncToken();
+	if (preflightSyncResult === "reauth-required") {
+		throw new AnthropicOAuthReauthRequiredError();
+	}
+
+	try {
+		return await operation();
+	} catch (error) {
+		if (!isAnthropicOAuthExpiredError(error)) {
+			throw error;
+		}
+
+		const refreshResult = await options.syncToken({ forceRefresh: true });
+		if (refreshResult !== "synced") {
+			throw new AnthropicOAuthReauthRequiredError();
+		}
+
+		options.onRetry?.();
+		return operation();
+	}
+}

--- a/packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/provider-auth-retry.test.ts
+++ b/packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/provider-auth-retry.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const runWithAnthropicOAuthRetry = mock(
+	async <T>(operation: () => Promise<T>): Promise<T> => operation(),
+);
+
+mock.module("./run-agent-oauth", () => ({
+	runWithAnthropicOAuthRetry,
+}));
+
+const { resolveModelProvider, runWithProviderAuthRetry } = await import(
+	"./provider-auth-retry"
+);
+
+beforeEach(() => {
+	runWithAnthropicOAuthRetry.mockClear();
+});
+
+describe("resolveModelProvider", () => {
+	it("returns null for missing model IDs", () => {
+		expect(resolveModelProvider(undefined)).toBeNull();
+		expect(resolveModelProvider("")).toBeNull();
+		expect(resolveModelProvider("   ")).toBeNull();
+	});
+
+	it("extracts provider from namespaced model IDs", () => {
+		expect(resolveModelProvider("anthropic/claude-sonnet-4-6")).toBe(
+			"anthropic",
+		);
+		expect(resolveModelProvider("OPENAI/gpt-4.1")).toBe("openai");
+	});
+
+	it("defaults slash-less model IDs to anthropic", () => {
+		expect(resolveModelProvider("claude-sonnet-4-6")).toBe("anthropic");
+	});
+});
+
+describe("runWithProviderAuthRetry", () => {
+	it("uses the default anthropic retry handler", async () => {
+		const operation = mock(async () => "ok");
+
+		const result = await runWithProviderAuthRetry(operation, {
+			modelId: "anthropic/claude-sonnet-4-6",
+		});
+
+		expect(result).toBe("ok");
+		expect(runWithAnthropicOAuthRetry).toHaveBeenCalledTimes(1);
+		expect(operation).toHaveBeenCalledTimes(1);
+	});
+
+	it("falls back to direct execution when no handler exists", async () => {
+		const operation = mock(async () => "ok");
+
+		const result = await runWithProviderAuthRetry(operation, {
+			modelId: "openai/gpt-4.1",
+		});
+
+		expect(result).toBe("ok");
+		expect(runWithAnthropicOAuthRetry).toHaveBeenCalledTimes(0);
+		expect(operation).toHaveBeenCalledTimes(1);
+	});
+
+	it("supports injected provider handlers", async () => {
+		const operation = mock(async () => "ok");
+		const openaiHandler = mock(
+			async <T>(runner: () => Promise<T>): Promise<T> => runner(),
+		);
+
+		const result = await runWithProviderAuthRetry(operation, {
+			modelId: "openai/gpt-4.1",
+			handlers: { openai: openaiHandler },
+		});
+
+		expect(result).toBe("ok");
+		expect(openaiHandler).toHaveBeenCalledTimes(1);
+		expect(runWithAnthropicOAuthRetry).toHaveBeenCalledTimes(0);
+		expect(operation).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/provider-auth-retry.ts
+++ b/packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/provider-auth-retry.ts
@@ -1,0 +1,56 @@
+import { runWithAnthropicOAuthRetry } from "./run-agent-oauth";
+
+export type AuthRetryOperation<T> = () => Promise<T>;
+
+export type ProviderAuthRetryHandler = <T>(
+	operation: AuthRetryOperation<T>,
+) => Promise<T>;
+
+export interface RunWithProviderAuthRetryOptions {
+	modelId?: string;
+	handlers?: Partial<Record<string, ProviderAuthRetryHandler>>;
+}
+
+const defaultProviderAuthRetryHandlers: Record<
+	string,
+	ProviderAuthRetryHandler
+> = {
+	anthropic: runWithAnthropicOAuthRetry,
+};
+
+export function resolveModelProvider(modelId?: string): string | null {
+	if (!modelId) {
+		return null;
+	}
+
+	const normalizedModelId = modelId.trim().toLowerCase();
+	if (!normalizedModelId) {
+		return null;
+	}
+
+	const slashIndex = normalizedModelId.indexOf("/");
+	if (slashIndex > -1) {
+		return normalizedModelId.slice(0, slashIndex);
+	}
+
+	// Keep existing behavior: slash-less model IDs default to anthropic.
+	return "anthropic";
+}
+
+export async function runWithProviderAuthRetry<T>(
+	operation: AuthRetryOperation<T>,
+	options: RunWithProviderAuthRetryOptions,
+): Promise<T> {
+	const provider = resolveModelProvider(options.modelId);
+	if (!provider) {
+		return operation();
+	}
+
+	const handler =
+		options.handlers?.[provider] ?? defaultProviderAuthRetryHandlers[provider];
+	if (!handler) {
+		return operation();
+	}
+
+	return handler(operation);
+}

--- a/packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/run-agent-oauth.test.ts
+++ b/packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/run-agent-oauth.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const getCredentialsFromConfig = mock(() => null);
+const getOrRefreshAnthropicOAuthCredentials = mock(async () => null);
+
+mock.module("../../../../auth/anthropic", () => ({
+	getCredentialsFromConfig,
+	getOrRefreshAnthropicOAuthCredentials,
+}));
+
+const { syncAnthropicOAuthToken } = await import("./run-agent-oauth");
+
+beforeEach(() => {
+	getCredentialsFromConfig.mockClear();
+	getOrRefreshAnthropicOAuthCredentials.mockClear();
+});
+
+describe("syncAnthropicOAuthToken", () => {
+	it("returns synced and sets auth token when oauth credentials are available", async () => {
+		getCredentialsFromConfig.mockReturnValue({
+			kind: "oauth",
+			apiKey: "access-old",
+			source: "config",
+			configPath: "/tmp/credentials.json",
+		});
+		getOrRefreshAnthropicOAuthCredentials.mockResolvedValue({
+			kind: "oauth",
+			apiKey: "access-new",
+			source: "config",
+			configPath: "/tmp/credentials.json",
+		});
+
+		const result = await syncAnthropicOAuthToken();
+
+		expect(result).toBe("synced");
+	});
+
+	it("returns unavailable when oauth is not configured", async () => {
+		getCredentialsFromConfig.mockReturnValue(null);
+		getOrRefreshAnthropicOAuthCredentials.mockResolvedValue(null);
+
+		const result = await syncAnthropicOAuthToken();
+
+		expect(result).toBe("unavailable");
+	});
+
+	it("returns reauth-required when oauth is configured but refresh fails", async () => {
+		getCredentialsFromConfig.mockReturnValue({
+			kind: "oauth",
+			apiKey: "expired",
+			source: "config",
+			configPath: "/tmp/credentials.json",
+		});
+		getOrRefreshAnthropicOAuthCredentials.mockResolvedValue(null);
+
+		const result = await syncAnthropicOAuthToken();
+
+		expect(result).toBe("reauth-required");
+	});
+});

--- a/packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/run-agent-oauth.ts
+++ b/packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/run-agent-oauth.ts
@@ -1,0 +1,51 @@
+import { setAnthropicAuthToken } from "@superset/agent";
+import {
+	getCredentialsFromConfig,
+	getOrRefreshAnthropicOAuthCredentials,
+} from "../../../../auth/anthropic";
+import {
+	type OAuthTokenSyncOptions,
+	type OAuthTokenSyncResult,
+	withAnthropicOAuthRetry,
+} from "./oauth-retry";
+
+export async function syncAnthropicOAuthToken(
+	options?: OAuthTokenSyncOptions,
+): Promise<OAuthTokenSyncResult> {
+	const configuredCredentials = getCredentialsFromConfig();
+	const hasConfiguredOAuthCredentials = configuredCredentials?.kind === "oauth";
+
+	try {
+		const oauthCredentials = await getOrRefreshAnthropicOAuthCredentials({
+			forceRefresh: options?.forceRefresh,
+		});
+
+		if (!oauthCredentials) {
+			setAnthropicAuthToken(null);
+			return hasConfiguredOAuthCredentials ? "reauth-required" : "unavailable";
+		}
+
+		setAnthropicAuthToken(oauthCredentials.apiKey);
+		return "synced";
+	} catch (error) {
+		console.warn("[run-agent] Failed to sync Anthropic OAuth token:", error);
+		if (hasConfiguredOAuthCredentials || options?.forceRefresh) {
+			setAnthropicAuthToken(null);
+			return "reauth-required";
+		}
+		return "unavailable";
+	}
+}
+
+export async function runWithAnthropicOAuthRetry<T>(
+	operation: () => Promise<T>,
+): Promise<T> {
+	return withAnthropicOAuthRetry(operation, {
+		syncToken: syncAnthropicOAuthToken,
+		onRetry: () => {
+			console.warn(
+				"[run-agent] Retrying agent call after Anthropic OAuth refresh",
+			);
+		},
+	});
+}

--- a/packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/run-agent-options.test.ts
+++ b/packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/run-agent-options.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "bun:test";
+import {
+	buildAgentCallOptions,
+	buildRequestEntries,
+	buildResumeData,
+	buildStreamInput,
+	buildThinkingProviderOptions,
+	DEFAULT_AGENT_MAX_STEPS,
+	isToolApprovalRequired,
+	normalizeToolCallId,
+} from "./run-agent-options";
+
+describe("buildRequestEntries", () => {
+	it("builds required entries", () => {
+		const entries = buildRequestEntries({
+			modelId: "anthropic/claude-sonnet-4-6",
+			cwd: "/tmp/repo",
+			apiUrl: "https://api.example.com",
+		});
+
+		expect(entries).toEqual([
+			["modelId", "anthropic/claude-sonnet-4-6"],
+			["cwd", "/tmp/repo"],
+			["apiUrl", "https://api.example.com"],
+		]);
+	});
+
+	it("adds auth headers and thinking entries when present", () => {
+		const entries = buildRequestEntries({
+			modelId: "anthropic/claude-sonnet-4-6",
+			cwd: "/tmp/repo",
+			apiUrl: "https://api.example.com",
+			authHeaders: { Authorization: "Bearer token" },
+			thinkingEnabled: true,
+		});
+
+		expect(entries).toEqual([
+			["modelId", "anthropic/claude-sonnet-4-6"],
+			["cwd", "/tmp/repo"],
+			["apiUrl", "https://api.example.com"],
+			["authHeaders", JSON.stringify({ Authorization: "Bearer token" })],
+			["thinkingEnabled", "true"],
+		]);
+	});
+});
+
+describe("buildStreamInput", () => {
+	it("returns plain text when no file parts are present", () => {
+		const streamInput = buildStreamInput("hello");
+		expect(streamInput).toBe("hello");
+	});
+
+	it("builds multimodal content when file parts are present", () => {
+		const streamInput = buildStreamInput("look", {
+			id: "msg-1",
+			role: "user",
+			parts: [
+				{
+					type: "file",
+					url: "https://cdn.example.com/image.png",
+					mediaType: "image/png",
+					filename: "image.png",
+				},
+				{
+					type: "file",
+					url: "https://cdn.example.com/doc.pdf",
+					mediaType: "application/pdf",
+					filename: "doc.pdf",
+				},
+			],
+		});
+
+		if (typeof streamInput === "string") {
+			throw new Error("Expected multimodal stream input");
+		}
+
+		expect(streamInput.role).toBe("user");
+		expect(streamInput.content).toHaveLength(3);
+		expect(streamInput.content[0]).toEqual({ type: "text", text: "look" });
+		expect(streamInput.content[1]).toEqual({
+			type: "image",
+			image: new URL("https://cdn.example.com/image.png"),
+			mimeType: "image/png",
+		});
+		expect(streamInput.content[2]).toEqual({
+			type: "file",
+			data: new URL("https://cdn.example.com/doc.pdf"),
+			mimeType: "application/pdf",
+		});
+	});
+});
+
+describe("isToolApprovalRequired", () => {
+	it("returns true for approval-required modes", () => {
+		expect(isToolApprovalRequired("default")).toBe(true);
+		expect(isToolApprovalRequired("acceptEdits")).toBe(true);
+	});
+
+	it("returns false for other modes", () => {
+		expect(isToolApprovalRequired("bypassPermissions")).toBe(false);
+		expect(isToolApprovalRequired(undefined)).toBe(false);
+	});
+});
+
+describe("buildThinkingProviderOptions", () => {
+	it("returns undefined when thinking is disabled", () => {
+		expect(buildThinkingProviderOptions(false)).toBeUndefined();
+		expect(buildThinkingProviderOptions(undefined)).toBeUndefined();
+	});
+
+	it("returns anthropic thinking options when enabled", () => {
+		expect(buildThinkingProviderOptions(true)).toEqual({
+			anthropic: {
+				thinking: {
+					type: "enabled",
+					budgetTokens: 10_000,
+				},
+			},
+		});
+	});
+});
+
+describe("normalizeToolCallId", () => {
+	it("strips leading dashes and surrounding spaces", () => {
+		expect(normalizeToolCallId("  ---abc123 ")).toBe("abc123");
+	});
+
+	it("falls back to original value when normalization is empty", () => {
+		expect(normalizeToolCallId("---")).toBe("---");
+	});
+});
+
+describe("buildResumeData", () => {
+	it("returns empty answers on output-error state", () => {
+		expect(buildResumeData("output-error", { answers: { a: "1" } })).toEqual({
+			answers: {},
+		});
+	});
+
+	it("returns answers when output has valid answers object", () => {
+		expect(
+			buildResumeData("output-available", { answers: { foo: "bar" } }),
+		).toEqual({ answers: { foo: "bar" } });
+	});
+
+	it("returns empty answers when output is not an answers object", () => {
+		expect(buildResumeData("output-available", { answers: null })).toEqual({
+			answers: {},
+		});
+		expect(buildResumeData("output-available", "nope")).toEqual({
+			answers: {},
+		});
+	});
+});
+
+describe("buildAgentCallOptions", () => {
+	it("builds shared stream options with approval + thinking", () => {
+		const requestContext = { requestId: "ctx-1" };
+		const abortController = new AbortController();
+
+		const options = buildAgentCallOptions({
+			requestContext,
+			sessionId: "session-1",
+			abortSignal: abortController.signal,
+			permissionMode: "default",
+			thinkingEnabled: true,
+		});
+
+		expect(options).toEqual({
+			requestContext,
+			maxSteps: DEFAULT_AGENT_MAX_STEPS,
+			memory: {
+				thread: "session-1",
+				resource: "session-1",
+			},
+			abortSignal: abortController.signal,
+			requireToolApproval: true,
+			providerOptions: {
+				anthropic: {
+					thinking: {
+						type: "enabled",
+						budgetTokens: 10_000,
+					},
+				},
+			},
+		});
+	});
+
+	it("omits optional fields when not needed", () => {
+		const requestContext = { requestId: "ctx-2" };
+		const abortController = new AbortController();
+
+		const options = buildAgentCallOptions({
+			requestContext,
+			sessionId: "session-2",
+			abortSignal: abortController.signal,
+			permissionMode: "bypassPermissions",
+			thinkingEnabled: false,
+		});
+
+		expect(options).toEqual({
+			requestContext,
+			maxSteps: DEFAULT_AGENT_MAX_STEPS,
+			memory: {
+				thread: "session-2",
+				resource: "session-2",
+			},
+			abortSignal: abortController.signal,
+		});
+	});
+});

--- a/packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/run-agent-options.ts
+++ b/packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/run-agent-options.ts
@@ -1,0 +1,182 @@
+import type { UIMessage } from "ai";
+
+const THINKING_BUDGET_TOKENS = 10_000;
+export const DEFAULT_AGENT_MAX_STEPS = 100;
+
+export type RequestEntries = [string, string][];
+
+export function buildRequestEntries(options: {
+	modelId: string;
+	cwd: string;
+	apiUrl: string;
+	authHeaders?: Record<string, string>;
+	thinkingEnabled?: boolean;
+}): RequestEntries {
+	const requestEntries: RequestEntries = [
+		["modelId", options.modelId],
+		["cwd", options.cwd],
+		["apiUrl", options.apiUrl],
+	];
+
+	if (options.authHeaders && Object.keys(options.authHeaders).length > 0) {
+		requestEntries.push(["authHeaders", JSON.stringify(options.authHeaders)]);
+	}
+
+	if (options.thinkingEnabled) {
+		requestEntries.push(["thinkingEnabled", "true"]);
+	}
+
+	return requestEntries;
+}
+
+type InputImagePart = {
+	type: "image";
+	image: URL;
+	mimeType: `image/${string}`;
+};
+
+type InputFilePart = {
+	type: "file";
+	data: URL;
+	mimeType: string;
+};
+
+type StreamInputWithFiles = {
+	role: "user";
+	content: Array<
+		{ type: "text"; text: string } | InputImagePart | InputFilePart
+	>;
+};
+
+export function buildStreamInput(
+	text: string,
+	message?: UIMessage,
+): string | StreamInputWithFiles {
+	const fileParts =
+		message?.parts?.filter((part) => part.type === "file") ?? [];
+	if (fileParts.length === 0) {
+		return text;
+	}
+
+	return {
+		role: "user",
+		content: [
+			...(text ? [{ type: "text" as const, text }] : []),
+			...fileParts.map((part) => {
+				if (part.mediaType.startsWith("image/")) {
+					return {
+						type: "image" as const,
+						image: new URL(part.url),
+						mimeType: part.mediaType as `image/${string}`,
+					};
+				}
+				return {
+					type: "file" as const,
+					data: new URL(part.url),
+					mimeType: part.mediaType,
+				};
+			}),
+		],
+	};
+}
+
+export function isToolApprovalRequired(permissionMode?: string): boolean {
+	return permissionMode === "default" || permissionMode === "acceptEdits";
+}
+
+export function buildThinkingProviderOptions(thinkingEnabled?: boolean):
+	| {
+			anthropic: {
+				thinking: {
+					type: "enabled";
+					budgetTokens: number;
+				};
+			};
+	  }
+	| undefined {
+	if (!thinkingEnabled) {
+		return undefined;
+	}
+
+	return {
+		anthropic: {
+			thinking: {
+				type: "enabled",
+				budgetTokens: THINKING_BUDGET_TOKENS,
+			},
+		},
+	};
+}
+
+export interface BuildAgentCallOptionsInput<TRequestContext> {
+	requestContext: TRequestContext;
+	sessionId: string;
+	abortSignal: AbortSignal;
+	permissionMode?: string;
+	thinkingEnabled?: boolean;
+}
+
+export function buildAgentCallOptions<TRequestContext>(
+	options: BuildAgentCallOptionsInput<TRequestContext>,
+): {
+	requestContext: TRequestContext;
+	maxSteps: number;
+	memory: { thread: string; resource: string };
+	abortSignal: AbortSignal;
+	requireToolApproval?: boolean;
+	providerOptions?: {
+		anthropic: {
+			thinking: {
+				type: "enabled";
+				budgetTokens: number;
+			};
+		};
+	};
+} {
+	const requireToolApproval = isToolApprovalRequired(options.permissionMode);
+	const thinkingProviderOptions = buildThinkingProviderOptions(
+		options.thinkingEnabled,
+	);
+
+	return {
+		requestContext: options.requestContext,
+		maxSteps: DEFAULT_AGENT_MAX_STEPS,
+		memory: {
+			thread: options.sessionId,
+			resource: options.sessionId,
+		},
+		abortSignal: options.abortSignal,
+		...(requireToolApproval ? { requireToolApproval: true } : {}),
+		...(thinkingProviderOptions
+			? {
+					providerOptions: thinkingProviderOptions,
+				}
+			: {}),
+	};
+}
+
+export function normalizeToolCallId(toolCallId: string): string {
+	const normalized = toolCallId.trim().replace(/^-+/, "");
+	return normalized || toolCallId;
+}
+
+export function buildResumeData(
+	state: "output-available" | "output-error",
+	output: unknown,
+): { answers: Record<string, string> } {
+	if (state === "output-error") {
+		return { answers: {} };
+	}
+
+	if (
+		typeof output === "object" &&
+		output !== null &&
+		"answers" in output &&
+		typeof output.answers === "object" &&
+		output.answers !== null
+	) {
+		return { answers: output.answers as Record<string, string> };
+	}
+
+	return { answers: {} };
+}

--- a/packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/run-agent-session.ts
+++ b/packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/run-agent-session.ts
@@ -1,0 +1,32 @@
+import {
+	sessionAbortControllers,
+	sessionContext,
+	sessionRunIds,
+} from "../../session-state";
+
+export function resetSessionAbortController(
+	sessionId: string,
+): AbortController {
+	const existingController = sessionAbortControllers.get(sessionId);
+	if (existingController) {
+		existingController.abort();
+	}
+
+	const abortController = new AbortController();
+	sessionAbortControllers.set(sessionId, abortController);
+	return abortController;
+}
+
+export function releaseSessionAbortController(
+	sessionId: string,
+	abortController: AbortController,
+): void {
+	if (sessionAbortControllers.get(sessionId) === abortController) {
+		sessionAbortControllers.delete(sessionId);
+	}
+}
+
+export function clearSessionStateForFailure(sessionId: string): void {
+	sessionRunIds.delete(sessionId);
+	sessionContext.delete(sessionId);
+}

--- a/packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/run-agent-stream.test.ts
+++ b/packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/run-agent-stream.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, mock, spyOn } from "bun:test";
+import type { UIMessageChunk } from "ai";
+import type { SessionHost } from "../session-host";
+import {
+	ANTHROPIC_OAUTH_REAUTH_REQUIRED_ERROR_CODE,
+	ANTHROPIC_OAUTH_REAUTH_REQUIRED_MESSAGE,
+	AnthropicOAuthReauthRequiredError,
+} from "./oauth-retry";
+import {
+	buildRunAgentErrorChunk,
+	logRunAgentFailure,
+	prependRunMetadata,
+	writeErrorChunkBestEffort,
+} from "./run-agent-stream";
+
+async function collectChunks(
+	stream: ReadableStream<UIMessageChunk>,
+): Promise<UIMessageChunk[]> {
+	const reader = stream.getReader();
+	const chunks: UIMessageChunk[] = [];
+
+	while (true) {
+		const { done, value } = await reader.read();
+		if (done) {
+			return chunks;
+		}
+		chunks.push(value as UIMessageChunk);
+	}
+}
+
+describe("buildRunAgentErrorChunk", () => {
+	it("builds a standard error chunk for generic errors", () => {
+		const chunk = buildRunAgentErrorChunk(new Error("boom")) as {
+			type: string;
+			errorText?: string;
+			code?: string;
+		};
+
+		expect(chunk.type).toBe("error");
+		expect(chunk.errorText).toBe("boom");
+		expect(chunk.code).toBeUndefined();
+	});
+
+	it("builds oauth reauth chunk with code and canonical text", () => {
+		const chunk = buildRunAgentErrorChunk(
+			new AnthropicOAuthReauthRequiredError(),
+		) as {
+			type: string;
+			errorText?: string;
+			code?: string;
+		};
+
+		expect(chunk.type).toBe("error");
+		expect(chunk.errorText).toBe(ANTHROPIC_OAUTH_REAUTH_REQUIRED_MESSAGE);
+		expect(chunk.code).toBe(ANTHROPIC_OAUTH_REAUTH_REQUIRED_ERROR_CODE);
+	});
+});
+
+describe("prependRunMetadata", () => {
+	it("prepends message-metadata runId before original chunks", async () => {
+		const input = new ReadableStream<UIMessageChunk>({
+			start(controller) {
+				controller.enqueue({ type: "start" } as UIMessageChunk);
+				controller.enqueue({
+					type: "text-delta",
+					id: "text-1",
+					delta: "hello",
+				} as UIMessageChunk);
+				controller.close();
+			},
+		});
+
+		const output = prependRunMetadata(input, "run-123");
+		const chunks = await collectChunks(output);
+		const metadata = chunks[0] as {
+			type: string;
+			messageMetadata?: { runId?: string };
+		};
+
+		expect(metadata.type).toBe("message-metadata");
+		expect(metadata.messageMetadata?.runId).toBe("run-123");
+		expect(chunks[1]).toEqual({ type: "start" });
+		expect(chunks[2]).toEqual({
+			type: "text-delta",
+			id: "text-1",
+			delta: "hello",
+		});
+	});
+});
+
+describe("writeErrorChunkBestEffort", () => {
+	it("swallows host write failures", async () => {
+		const host = {
+			writeStream: mock(async () => {
+				throw new Error("disk full");
+			}),
+		};
+
+		await expect(
+			writeErrorChunkBestEffort(
+				host as unknown as SessionHost,
+				new Error("boom"),
+			),
+		).resolves.toBeUndefined();
+	});
+});
+
+describe("logRunAgentFailure", () => {
+	it("logs with context when provided", () => {
+		const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+
+		try {
+			logRunAgentFailure({
+				sessionId: "session-1",
+				scope: "Tool output continue error",
+				error: new Error("boom"),
+				context: { toolCallId: "call-1" },
+			});
+
+			expect(errorSpy).toHaveBeenCalledWith(
+				"[run-agent] Tool output continue error for session-1:",
+				expect.any(Error),
+				{ toolCallId: "call-1" },
+			);
+		} finally {
+			errorSpy.mockRestore();
+		}
+	});
+
+	it("logs without context when omitted", () => {
+		const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+
+		try {
+			logRunAgentFailure({
+				sessionId: "session-2",
+				scope: "Resume error",
+				error: new Error("boom"),
+			});
+
+			expect(errorSpy).toHaveBeenCalledWith(
+				"[run-agent] Resume error for session-2:",
+				expect.any(Error),
+			);
+		} finally {
+			errorSpy.mockRestore();
+		}
+	});
+});

--- a/packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/run-agent-stream.ts
+++ b/packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/run-agent-stream.ts
@@ -1,0 +1,126 @@
+import { toAISdkStream } from "@superset/agent";
+import type { UIMessageChunk } from "ai";
+import type { SessionHost } from "../session-host";
+import {
+	ANTHROPIC_OAUTH_REAUTH_REQUIRED_ERROR_CODE,
+	ANTHROPIC_OAUTH_REAUTH_REQUIRED_MESSAGE,
+	isAnthropicOAuthReauthRequiredError,
+} from "./oauth-retry";
+
+export function buildRunAgentErrorChunk(error: unknown): UIMessageChunk {
+	const isOAuthReauthError = isAnthropicOAuthReauthRequiredError(error);
+	const errorText = isOAuthReauthError
+		? ANTHROPIC_OAUTH_REAUTH_REQUIRED_MESSAGE
+		: error instanceof Error
+			? error.message
+			: "Agent error";
+
+	return {
+		type: "error",
+		errorText,
+		...(isOAuthReauthError
+			? { code: ANTHROPIC_OAUTH_REAUTH_REQUIRED_ERROR_CODE }
+			: {}),
+	} as UIMessageChunk;
+}
+
+export async function writeErrorChunk(
+	host: SessionHost,
+	error: unknown,
+): Promise<void> {
+	const messageId = crypto.randomUUID();
+	const stream = new ReadableStream<UIMessageChunk>({
+		start(controller) {
+			controller.enqueue(buildRunAgentErrorChunk(error));
+			controller.enqueue({ type: "abort" } as UIMessageChunk);
+			controller.close();
+		},
+	});
+	await host.writeStream(messageId, stream);
+}
+
+export async function writeErrorChunkBestEffort(
+	host: SessionHost,
+	error: unknown,
+): Promise<void> {
+	try {
+		await writeErrorChunk(host, error);
+	} catch {
+		/* best effort */
+	}
+}
+
+export function logRunAgentFailure(options: {
+	sessionId: string;
+	scope: string;
+	error: unknown;
+	context?: Record<string, unknown>;
+}): void {
+	if (options.context) {
+		console.error(
+			`[run-agent] ${options.scope} for ${options.sessionId}:`,
+			options.error,
+			options.context,
+		);
+		return;
+	}
+
+	console.error(
+		`[run-agent] ${options.scope} for ${options.sessionId}:`,
+		options.error,
+	);
+}
+
+export function prependRunMetadata(
+	stream: ReadableStream<UIMessageChunk>,
+	runId: string,
+): ReadableStream<UIMessageChunk> {
+	const reader = stream.getReader();
+	let metadataSent = false;
+
+	return new ReadableStream<UIMessageChunk>({
+		async pull(controller) {
+			if (!metadataSent) {
+				metadataSent = true;
+				controller.enqueue({
+					type: "message-metadata",
+					messageMetadata: { runId },
+				} as UIMessageChunk);
+				return;
+			}
+			const { done, value } = await reader.read();
+			if (done) {
+				controller.close();
+				return;
+			}
+			controller.enqueue(value as UIMessageChunk);
+		},
+		cancel(reason) {
+			return reader.cancel(reason);
+		},
+	});
+}
+
+export async function writeToDurableStream(
+	stream: Parameters<typeof toAISdkStream>[0],
+	host: SessionHost,
+	abortSignal: AbortSignal,
+	options?: { runId?: string },
+): Promise<void> {
+	const messageId = crypto.randomUUID();
+	const aiStream = toAISdkStream(stream, {
+		from: "agent",
+	}) as unknown as ReadableStream<UIMessageChunk>;
+	const streamWithMetadata =
+		typeof options?.runId === "string" && options.runId.length > 0
+			? prependRunMetadata(aiStream, options.runId)
+			: aiStream;
+
+	await host.writeStream(
+		messageId,
+		streamWithMetadata as unknown as ReadableStream,
+		{
+			signal: abortSignal,
+		},
+	);
+}

--- a/packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/run-agent.test.ts
+++ b/packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/run-agent.test.ts
@@ -1,0 +1,462 @@
+import { beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import type { UIMessageChunk } from "ai";
+import type { SessionContext } from "../../session-state";
+import type { SessionHost } from "../session-host";
+
+function createAgentOutput(
+	runId: string,
+): ReadableStream<UIMessageChunk> & { runId: string } {
+	const stream = new ReadableStream<UIMessageChunk>({
+		start(controller) {
+			controller.enqueue({ type: "start" } as UIMessageChunk);
+			controller.close();
+		},
+	});
+	return Object.assign(stream, { runId });
+}
+
+async function collectChunks(
+	stream: ReadableStream<UIMessageChunk>,
+): Promise<UIMessageChunk[]> {
+	const reader = stream.getReader();
+	const chunks: UIMessageChunk[] = [];
+
+	while (true) {
+		const { done, value } = await reader.read();
+		if (done) {
+			return chunks;
+		}
+		chunks.push(value as UIMessageChunk);
+	}
+}
+
+const superagentMocks = {
+	stream: mock(async () => createAgentOutput("run-stream")),
+	resumeStream: mock(async () => createAgentOutput("run-resume")),
+	approveToolCall: mock(async () => createAgentOutput("run-approve")),
+	declineToolCall: mock(async () => createAgentOutput("run-decline")),
+};
+
+class MockRequestContext {
+	readonly entries: [string, string][];
+
+	constructor(entries: [string, string][]) {
+		this.entries = entries;
+	}
+}
+
+const toAISdkStream = mock((stream: unknown) => stream);
+
+const gatherProjectContext = mock(async () => "");
+const parseFileMentions = mock(() => []);
+const buildFileMentionContext = mock(() => "");
+const parseTaskMentions = mock(() => []);
+const buildTaskMentionContext = mock(async () => "");
+
+const runWithProviderAuthRetry = mock(
+	async <T>(
+		operation: () => Promise<T>,
+		_options: { modelId?: string },
+	): Promise<T> => operation(),
+);
+
+mock.module("@superset/agent", () => ({
+	RequestContext: MockRequestContext,
+	superagent: superagentMocks,
+	toAISdkStream,
+}));
+
+mock.module("./context/project-context", () => ({
+	gatherProjectContext,
+}));
+
+mock.module("./context/file-mentions", () => ({
+	parseFileMentions,
+	buildFileMentionContext,
+}));
+
+mock.module("./context/task-mentions", () => ({
+	parseTaskMentions,
+	buildTaskMentionContext,
+}));
+
+mock.module("./provider-auth-retry", () => ({
+	runWithProviderAuthRetry,
+}));
+
+const { runAgent, continueAgentWithToolOutput, resumeAgent } = await import(
+	"./run-agent"
+);
+const { sessionAbortControllers, sessionContext, sessionRunIds } = await import(
+	"../../session-state"
+);
+
+function createHost(): {
+	host: SessionHost;
+	writeStream: ReturnType<typeof mock>;
+} {
+	const writeStream = mock(async () => {});
+	return {
+		host: { writeStream } as unknown as SessionHost,
+		writeStream,
+	};
+}
+
+beforeEach(() => {
+	superagentMocks.stream.mockClear();
+	superagentMocks.resumeStream.mockClear();
+	superagentMocks.approveToolCall.mockClear();
+	superagentMocks.declineToolCall.mockClear();
+	toAISdkStream.mockClear();
+	gatherProjectContext.mockClear();
+	parseFileMentions.mockClear();
+	buildFileMentionContext.mockClear();
+	parseTaskMentions.mockClear();
+	buildTaskMentionContext.mockClear();
+	runWithProviderAuthRetry.mockClear();
+
+	sessionAbortControllers.clear();
+	sessionContext.clear();
+	sessionRunIds.clear();
+});
+
+describe("runAgent", () => {
+	it("streams a message and persists session + run state", async () => {
+		const { host, writeStream } = createHost();
+
+		gatherProjectContext.mockResolvedValue("PROJECT");
+		parseFileMentions.mockReturnValue(["foo.ts"]);
+		buildFileMentionContext.mockReturnValue("FILES");
+		parseTaskMentions.mockReturnValue(["task-1"]);
+		buildTaskMentionContext.mockResolvedValue("TASKS");
+		superagentMocks.stream.mockResolvedValue(createAgentOutput("run-123"));
+
+		await runAgent({
+			sessionId: "session-1",
+			text: "hello",
+			host,
+			modelId: "anthropic/claude-sonnet-4-6",
+			cwd: "/tmp/repo",
+			permissionMode: "default",
+			thinkingEnabled: true,
+			apiUrl: "https://api.example.com",
+			getHeaders: async () => ({ Authorization: "Bearer token" }),
+		});
+
+		expect(runWithProviderAuthRetry).toHaveBeenCalledTimes(1);
+		expect(runWithProviderAuthRetry).toHaveBeenCalledWith(
+			expect.any(Function),
+			{ modelId: "anthropic/claude-sonnet-4-6" },
+		);
+		expect(superagentMocks.stream).toHaveBeenCalledTimes(1);
+		expect(superagentMocks.stream).toHaveBeenCalledWith(
+			"hello",
+			expect.objectContaining({
+				maxSteps: 100,
+				memory: {
+					thread: "session-1",
+					resource: "session-1",
+				},
+				requireToolApproval: true,
+				instructions: "PROJECTFILESTASKS",
+				providerOptions: {
+					anthropic: {
+						thinking: {
+							type: "enabled",
+							budgetTokens: 10_000,
+						},
+					},
+				},
+			}),
+		);
+
+		expect(sessionRunIds.get("session-1")).toBe("run-123");
+		expect(sessionContext.get("session-1")).toEqual({
+			cwd: "/tmp/repo",
+			modelId: "anthropic/claude-sonnet-4-6",
+			permissionMode: "default",
+			thinkingEnabled: true,
+			requestEntries: [
+				["modelId", "anthropic/claude-sonnet-4-6"],
+				["cwd", "/tmp/repo"],
+				["apiUrl", "https://api.example.com"],
+				["authHeaders", JSON.stringify({ Authorization: "Bearer token" })],
+				["thinkingEnabled", "true"],
+			],
+		});
+		expect(writeStream).toHaveBeenCalledTimes(1);
+
+		const streamArg = writeStream.mock.calls[0]?.[1] as
+			| ReadableStream<UIMessageChunk>
+			| undefined;
+		expect(streamArg).toBeDefined();
+		const chunks = await collectChunks(
+			streamArg as ReadableStream<UIMessageChunk>,
+		);
+		const metadata = chunks[0] as {
+			type: string;
+			messageMetadata?: { runId?: string };
+		};
+		expect(metadata.type).toBe("message-metadata");
+		expect(metadata.messageMetadata?.runId).toBe("run-123");
+		expect(sessionAbortControllers.has("session-1")).toBe(false);
+	});
+
+	it("bypasses anthropic oauth retry for non-anthropic models", async () => {
+		const { host, writeStream } = createHost();
+		superagentMocks.stream.mockResolvedValue(createAgentOutput("run-openai"));
+
+		await runAgent({
+			sessionId: "session-openai",
+			text: "hello",
+			host,
+			modelId: "openai/gpt-4.1",
+			cwd: "/tmp/repo",
+			apiUrl: "https://api.example.com",
+			getHeaders: async () => ({}),
+		});
+
+		expect(runWithProviderAuthRetry).toHaveBeenCalledTimes(1);
+		expect(runWithProviderAuthRetry).toHaveBeenCalledWith(
+			expect.any(Function),
+			{ modelId: "openai/gpt-4.1" },
+		);
+		expect(superagentMocks.stream).toHaveBeenCalledTimes(1);
+		expect(writeStream).toHaveBeenCalledTimes(1);
+	});
+
+	it("writes failure chunk/log and clears session state on stream errors", async () => {
+		const { host, writeStream } = createHost();
+		const error = new Error("stream failed");
+		const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+		superagentMocks.stream.mockRejectedValue(error);
+
+		try {
+			await runAgent({
+				sessionId: "session-2",
+				text: "hello",
+				host,
+				modelId: "anthropic/claude-sonnet-4-6",
+				cwd: "/tmp/repo",
+				apiUrl: "https://api.example.com",
+				getHeaders: async () => ({}),
+			});
+		} finally {
+			errorSpy.mockRestore();
+		}
+
+		expect(writeStream).toHaveBeenCalledTimes(1);
+		const errorStream = writeStream.mock.calls[0]?.[1] as
+			| ReadableStream<UIMessageChunk>
+			| undefined;
+		const chunks = await collectChunks(
+			errorStream as ReadableStream<UIMessageChunk>,
+		);
+		expect((chunks[0] as { type: string; errorText?: string }).type).toBe(
+			"error",
+		);
+		expect((chunks[0] as { errorText?: string }).errorText).toBe(
+			"stream failed",
+		);
+		expect((chunks[1] as { type: string }).type).toBe("abort");
+
+		expect(sessionContext.has("session-2")).toBe(false);
+		expect(sessionRunIds.has("session-2")).toBe(false);
+		expect(sessionAbortControllers.has("session-2")).toBe(false);
+	});
+});
+
+describe("continueAgentWithToolOutput", () => {
+	it("uses fallback context, normalizes toolCallId, and writes resumed stream", async () => {
+		const { host, writeStream } = createHost();
+		superagentMocks.resumeStream.mockResolvedValue(createAgentOutput("run-2"));
+
+		const fallbackContext: SessionContext = {
+			cwd: "/tmp/repo",
+			modelId: "anthropic/claude-sonnet-4-6",
+			permissionMode: "default",
+			thinkingEnabled: true,
+			requestEntries: [
+				["modelId", "anthropic/claude-sonnet-4-6"],
+				["cwd", "/tmp/repo"],
+				["apiUrl", "https://api.example.com"],
+			],
+		};
+
+		await continueAgentWithToolOutput({
+			sessionId: "session-3",
+			host,
+			runId: "run-1",
+			toolCallId: "  ---tool-123 ",
+			toolName: "my_tool",
+			state: "output-available",
+			output: { answers: { foo: "bar" } },
+			fallbackContext,
+		});
+
+		expect(runWithProviderAuthRetry).toHaveBeenCalledTimes(1);
+		expect(runWithProviderAuthRetry).toHaveBeenCalledWith(
+			expect.any(Function),
+			{ modelId: "anthropic/claude-sonnet-4-6" },
+		);
+		expect(superagentMocks.resumeStream).toHaveBeenCalledWith(
+			{ answers: { foo: "bar" } },
+			expect.objectContaining({
+				runId: "run-1",
+				toolCallId: "tool-123",
+				maxSteps: 100,
+				memory: {
+					thread: "session-3",
+					resource: "session-3",
+				},
+				requireToolApproval: true,
+			}),
+		);
+		expect(sessionRunIds.get("session-3")).toBe("run-2");
+		expect(sessionContext.get("session-3")).toEqual({
+			cwd: "/tmp/repo",
+			modelId: "anthropic/claude-sonnet-4-6",
+			permissionMode: "default",
+			thinkingEnabled: true,
+			requestEntries: [
+				["modelId", "anthropic/claude-sonnet-4-6"],
+				["cwd", "/tmp/repo"],
+				["apiUrl", "https://api.example.com"],
+			],
+		});
+		expect(writeStream).toHaveBeenCalledTimes(1);
+	});
+
+	it("bypasses anthropic oauth retry for non-anthropic session context", async () => {
+		const { host, writeStream } = createHost();
+		superagentMocks.resumeStream.mockResolvedValue(createAgentOutput("run-3"));
+
+		const fallbackContext: SessionContext = {
+			cwd: "/tmp/repo",
+			modelId: "openai/gpt-4.1",
+			permissionMode: "default",
+			thinkingEnabled: false,
+			requestEntries: [
+				["modelId", "openai/gpt-4.1"],
+				["cwd", "/tmp/repo"],
+				["apiUrl", "https://api.example.com"],
+			],
+		};
+
+		await continueAgentWithToolOutput({
+			sessionId: "session-openai-continue",
+			host,
+			runId: "run-1",
+			toolCallId: "tool-123",
+			toolName: "my_tool",
+			state: "output-available",
+			output: { answers: { foo: "bar" } },
+			fallbackContext,
+		});
+
+		expect(runWithProviderAuthRetry).toHaveBeenCalledTimes(1);
+		expect(runWithProviderAuthRetry).toHaveBeenCalledWith(
+			expect.any(Function),
+			{ modelId: "openai/gpt-4.1" },
+		);
+		expect(superagentMocks.resumeStream).toHaveBeenCalledTimes(1);
+		expect(writeStream).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("resumeAgent", () => {
+	it("updates permission mode and approves tool calls", async () => {
+		const { host, writeStream } = createHost();
+		superagentMocks.approveToolCall.mockResolvedValue(
+			createAgentOutput("run-approve"),
+		);
+		sessionContext.set("session-4", {
+			cwd: "/tmp/repo",
+			modelId: "anthropic/claude-sonnet-4-6",
+			permissionMode: "default",
+			thinkingEnabled: false,
+			requestEntries: [["cwd", "/tmp/repo"]],
+		});
+
+		await resumeAgent({
+			sessionId: "session-4",
+			runId: "run-approve",
+			host,
+			approved: true,
+			toolCallId: "tool-1",
+			permissionMode: "acceptEdits",
+		});
+
+		expect(runWithProviderAuthRetry).toHaveBeenCalledTimes(1);
+		expect(runWithProviderAuthRetry).toHaveBeenCalledWith(
+			expect.any(Function),
+			{ modelId: "anthropic/claude-sonnet-4-6" },
+		);
+		expect(superagentMocks.approveToolCall).toHaveBeenCalledWith(
+			expect.objectContaining({
+				runId: "run-approve",
+				toolCallId: "tool-1",
+			}),
+		);
+		expect(sessionContext.get("session-4")?.permissionMode).toBe("acceptEdits");
+		expect(writeStream).toHaveBeenCalledTimes(1);
+	});
+
+	it("declines tool calls when approved is false", async () => {
+		const { host, writeStream } = createHost();
+		superagentMocks.declineToolCall.mockResolvedValue(
+			createAgentOutput("run-decline"),
+		);
+
+		await resumeAgent({
+			sessionId: "session-5",
+			runId: "run-decline",
+			host,
+			approved: false,
+			toolCallId: "tool-2",
+		});
+
+		expect(runWithProviderAuthRetry).toHaveBeenCalledTimes(1);
+		expect(runWithProviderAuthRetry).toHaveBeenCalledWith(
+			expect.any(Function),
+			{ modelId: undefined },
+		);
+		expect(superagentMocks.declineToolCall).toHaveBeenCalledWith(
+			expect.objectContaining({
+				runId: "run-decline",
+				toolCallId: "tool-2",
+			}),
+		);
+		expect(writeStream).toHaveBeenCalledTimes(1);
+	});
+
+	it("bypasses anthropic oauth retry for non-anthropic resume", async () => {
+		const { host, writeStream } = createHost();
+		superagentMocks.approveToolCall.mockResolvedValue(
+			createAgentOutput("run-openai-approve"),
+		);
+		sessionContext.set("session-openai-resume", {
+			cwd: "/tmp/repo",
+			modelId: "openai/gpt-4.1",
+			permissionMode: "default",
+			thinkingEnabled: false,
+			requestEntries: [["modelId", "openai/gpt-4.1"]],
+		});
+
+		await resumeAgent({
+			sessionId: "session-openai-resume",
+			runId: "run-openai-approve",
+			host,
+			approved: true,
+			toolCallId: "tool-1",
+		});
+
+		expect(runWithProviderAuthRetry).toHaveBeenCalledTimes(1);
+		expect(runWithProviderAuthRetry).toHaveBeenCalledWith(
+			expect.any(Function),
+			{ modelId: "openai/gpt-4.1" },
+		);
+		expect(superagentMocks.approveToolCall).toHaveBeenCalledTimes(1);
+		expect(writeStream).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/chat/src/session-db/collections/messages/materialize.test.ts
+++ b/packages/chat/src/session-db/collections/messages/materialize.test.ts
@@ -330,6 +330,44 @@ describe("materializeMessage", () => {
 		expect(result.parts).toEqual([{ type: "error", text: "something broke" }]);
 	});
 
+	it("preserves error chunk code", () => {
+		const rows = [
+			makeRow({
+				seq: 0,
+				chunk: JSON.stringify({
+					type: "error",
+					errorText: "reauth required",
+					code: "anthropic_oauth_reauth_required",
+				}),
+			}),
+		];
+
+		const result = materializeMessage(rows);
+		expect(result.parts).toEqual([
+			{
+				type: "error",
+				text: "reauth required",
+				code: "anthropic_oauth_reauth_required",
+			},
+		]);
+	});
+
+	it("preserves empty-string error chunk code", () => {
+		const rows = [
+			makeRow({
+				seq: 0,
+				chunk: JSON.stringify({
+					type: "error",
+					errorText: "custom",
+					code: "",
+				}),
+			}),
+		];
+
+		const result = materializeMessage(rows);
+		expect(result.parts).toEqual([{ type: "error", text: "custom", code: "" }]);
+	});
+
 	it("skips custom chunk types (config, control)", () => {
 		const rows = [
 			makeRow({

--- a/packages/chat/src/session-db/collections/messages/materialize.ts
+++ b/packages/chat/src/session-db/collections/messages/materialize.ts
@@ -354,10 +354,17 @@ function materializeStreamedMessage(rows: ChunkRow[]): MessageRow {
 				isComplete = true;
 				break;
 			case "error":
-				parts.push({
-					type: "error",
-					text: c.errorText ?? "An error occurred",
-				} as unknown as AnyUIMessagePart);
+				{
+					const errorChunk = c as {
+						errorText?: string;
+						code?: string;
+					};
+					parts.push({
+						type: "error",
+						text: errorChunk.errorText ?? "An error occurred",
+						...(errorChunk.code != null ? { code: errorChunk.code } : {}),
+					} as unknown as AnyUIMessagePart);
+				}
 				break;
 			case "message-metadata":
 				// No-op


### PR DESCRIPTION
## Summary
- split Anthropic credential handling into focused modules with explicit OAuth + API-key credential parsing
- add OAuth refresh behavior (preflight near expiry, forced refresh on auth failure, timeout handling, in-flight dedupe by config path)
- wire agent startup and run orchestration through provider-scoped auth retry so only Anthropic uses OAuth retry logic
- emit structured OAuth reauth error code in stream errors and preserve error codes in message materialization
- add desktop reauth UX (`ChatErrorMessage`) with structured-code-first detection and fallback text matching
- add focused tests across auth refresh, provider dispatch, run orchestration, stream error handling, materialization, and renderer detection

## Key Files
- `packages/chat/src/host/auth/anthropic/*`
- `packages/chat/src/host/chat-service/agent-manager/agent-manager.ts`
- `packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/*`
- `packages/chat/src/session-db/collections/messages/materialize.ts`
- `apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/MessagePartsRenderer/*`
- `apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/ChatErrorMessage/*`

## Validation
- `bun test packages/chat/src/host/auth/anthropic/anthropic.test.ts packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/oauth-retry.test.ts packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/provider-auth-retry.test.ts packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/run-agent-oauth.test.ts packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/run-agent-options.test.ts packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/run-agent-stream.test.ts packages/chat/src/host/chat-service/agent-manager/stream-watcher/run-agent/run-agent.test.ts packages/chat/src/session-db/collections/messages/materialize.test.ts apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/MessagePartsRenderer/oauth-error.test.ts`
  - result: `78 pass, 0 fail`
- `bunx biome check` on touched files
- `bunx tsc -p packages/chat/tsconfig.json --noEmit`

## Notes
- left existing unstaged local `bun.lock` change out of this PR commit
- `apps/desktop` full `tsc` currently reports unrelated pre-existing route generation/type issues in this branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced chat error messaging with improved visual feedback and action buttons for error resolution.
  * OAuth token auto-refresh capability for seamless re-authentication without manual intervention.
  * Support for agent thinking mode with configurable token budget for extended reasoning.

* **Bug Fixes**
  * Improved error recovery in chat with OAuth-aware re-authentication flows and retry logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->