### PR TITLE
feat(desktop): add Mastra Code wrapper hooks

### DIFF
--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-mastracode.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-mastracode.ts
@@ -1,0 +1,129 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+	buildWrapperScript,
+	createWrapper,
+	isSupersetManagedHookCommand,
+	writeFileIfChanged,
+} from "./agent-wrappers-common";
+import { getNotifyScriptPath, NOTIFY_SCRIPT_NAME } from "./notify-hook";
+
+interface MastraCodeHookEntry {
+	type: "command";
+	command: string;
+	matcher?: {
+		tool_name?: string;
+	};
+	timeout?: number;
+	description?: string;
+	[key: string]: unknown;
+}
+
+interface MastraCodeHooksJson {
+	PreToolUse?: MastraCodeHookEntry[];
+	PostToolUse?: MastraCodeHookEntry[];
+	UserPromptSubmit?: MastraCodeHookEntry[];
+	Stop?: MastraCodeHookEntry[];
+	SessionStart?: MastraCodeHookEntry[];
+	SessionEnd?: MastraCodeHookEntry[];
+	[key: string]: unknown;
+}
+
+const MASTRA_CODE_MANAGED_EVENT_NAMES = [
+	"PreToolUse",
+	"PostToolUse",
+	"UserPromptSubmit",
+	"Stop",
+	"SessionStart",
+	"SessionEnd",
+] as const;
+const MASTRA_CODE_TARGET_EVENT_NAMES = ["UserPromptSubmit", "Stop"] as const;
+
+export function getMastraCodeHooksJsonPath(): string {
+	return path.join(os.homedir(), ".mastracode", "hooks.json");
+}
+
+function isSupersetManagedMastraCodeHook(
+	entry: MastraCodeHookEntry,
+	notifyPath: string,
+): boolean {
+	return (
+		entry.command.includes(notifyPath) ||
+		isSupersetManagedHookCommand(entry.command, NOTIFY_SCRIPT_NAME)
+	);
+}
+
+/**
+ * Reads existing ~/.mastracode/hooks.json, merges our lifecycle hooks, and
+ * preserves any user-defined hooks.
+ */
+export function getMastraCodeHooksJsonContent(notifyPath: string): string {
+	const globalPath = getMastraCodeHooksJsonPath();
+
+	let existing: MastraCodeHooksJson = {};
+	try {
+		if (fs.existsSync(globalPath)) {
+			const parsed = JSON.parse(fs.readFileSync(globalPath, "utf-8"));
+			if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+				existing = parsed as MastraCodeHooksJson;
+			}
+		}
+	} catch {
+		console.warn(
+			"[agent-setup] Could not parse existing ~/.mastracode/hooks.json, merging carefully",
+		);
+	}
+
+	// Remove stale Superset-managed hooks across all managed events first.
+	for (const eventName of MASTRA_CODE_MANAGED_EVENT_NAMES) {
+		const current = existing[eventName];
+		if (!Array.isArray(current)) continue;
+		const filtered = current.filter((entry: unknown) => {
+			if (!entry || typeof entry !== "object") return true;
+			const typedEntry = entry as MastraCodeHookEntry;
+			if (typeof typedEntry.command !== "string") return true;
+			return !isSupersetManagedMastraCodeHook(typedEntry, notifyPath);
+		});
+		if (filtered.length > 0) {
+			existing[eventName] = filtered;
+		} else {
+			delete existing[eventName];
+		}
+	}
+
+	// Register only Start/Stop lifecycle hooks for Mastra Code.
+	for (const eventName of MASTRA_CODE_TARGET_EVENT_NAMES) {
+		const current = existing[eventName];
+		const supersetHook: MastraCodeHookEntry = {
+			type: "command",
+			command: notifyPath,
+		};
+
+		if (Array.isArray(current)) {
+			current.push(supersetHook);
+		} else {
+			existing[eventName] = [supersetHook];
+		}
+	}
+
+	return JSON.stringify(existing, null, 2);
+}
+
+export function createMastraCodeHooksJson(): void {
+	const notifyPath = getNotifyScriptPath();
+	const globalPath = getMastraCodeHooksJsonPath();
+	const content = getMastraCodeHooksJsonContent(notifyPath);
+
+	const dir = path.dirname(globalPath);
+	fs.mkdirSync(dir, { recursive: true });
+	const changed = writeFileIfChanged(globalPath, content, 0o644);
+	console.log(
+		`[agent-setup] ${changed ? "Updated" : "Verified"} Mastra Code hooks.json`,
+	);
+}
+
+export function createMastraCodeWrapper(): void {
+	const script = buildWrapperScript("mastracode", `exec "$REAL_BIN" "$@"`);
+	createWrapper("mastracode", script);
+}

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -63,6 +63,7 @@ const {
 	getCursorHooksJsonContent,
 	getCopilotHookScriptPath,
 	getGeminiSettingsJsonContent,
+	getMastraCodeHooksJsonContent,
 } = await import("./agent-wrappers");
 
 describe("agent-wrappers copilot", () => {
@@ -300,6 +301,94 @@ describe("agent-wrappers copilot", () => {
 				def.hooks.some((hook) => hook.command === "/opt/custom-hook.sh"),
 			),
 		).toBe(true);
+		expect(JSON.parse(content2)).toEqual(JSON.parse(content));
+	});
+
+	it("replaces stale Mastra Code hook commands from old superset paths", () => {
+		const mastraCodeHooksPath = path.join(
+			mockedHomeDir,
+			".mastracode",
+			"hooks.json",
+		);
+		const staleHookPath = "/tmp/.superset-old/hooks/notify.sh";
+		const currentHookPath = "/tmp/.superset-new/hooks/notify.sh";
+
+		mkdirSync(path.dirname(mastraCodeHooksPath), { recursive: true });
+		writeFileSync(
+			mastraCodeHooksPath,
+			JSON.stringify(
+				{
+					PreToolUse: [
+						{ type: "command", command: staleHookPath },
+						{ type: "command", command: "echo should-stay" },
+					],
+					PostToolUse: [
+						{ type: "command", command: `${staleHookPath} --legacy-post` },
+					],
+					UserPromptSubmit: [
+						{ type: "command", command: staleHookPath },
+						{ type: "command", command: "/opt/custom-hook.sh" },
+					],
+					Stop: [{ type: "command", command: `${staleHookPath} --legacy` }],
+				},
+				null,
+				2,
+			),
+		);
+
+		const content = getMastraCodeHooksJsonContent(currentHookPath);
+		writeFileSync(mastraCodeHooksPath, content);
+		const content2 = getMastraCodeHooksJsonContent(currentHookPath);
+
+		const parsed = JSON.parse(content) as {
+			PreToolUse: Array<{ type: string; command: string }>;
+			PostToolUse?: Array<{ type: string; command: string }>;
+			UserPromptSubmit: Array<{ type: string; command: string }>;
+			Stop: Array<{ type: string; command: string }>;
+			SessionStart?: Array<{ type: string; command: string }>;
+			SessionEnd?: Array<{ type: string; command: string }>;
+		};
+
+		expect(
+			parsed.UserPromptSubmit.some(
+				(hook) => hook.command === "/opt/custom-hook.sh",
+			),
+		).toBe(true);
+		expect(
+			parsed.UserPromptSubmit.some((hook) =>
+				hook.command.includes(staleHookPath),
+			),
+		).toBe(false);
+		expect(
+			parsed.UserPromptSubmit.some(
+				(hook) => hook.command === currentHookPath && hook.type === "command",
+			),
+		).toBe(true);
+		expect(parsed.UserPromptSubmit).toEqual([
+			{ type: "command", command: "/opt/custom-hook.sh" },
+			{ type: "command", command: currentHookPath },
+		]);
+
+		expect(
+			parsed.Stop.some(
+				(hook) => hook.command === currentHookPath && hook.type === "command",
+			),
+		).toBe(true);
+		expect(
+			parsed.Stop.some((hook) => hook.command.includes(staleHookPath)),
+		).toBe(false);
+		expect(parsed.Stop).toHaveLength(1);
+
+		expect(
+			parsed.PreToolUse.some((hook) => hook.command === "echo should-stay"),
+		).toBe(true);
+		expect(
+			parsed.PreToolUse.some((hook) => hook.command.includes(staleHookPath)),
+		).toBe(false);
+
+		expect(parsed.PostToolUse).toBeUndefined();
+		expect(parsed.SessionStart).toBeUndefined();
+		expect(parsed.SessionEnd).toBeUndefined();
 		expect(JSON.parse(content2)).toEqual(JSON.parse(content));
 	});
 });

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts
@@ -51,3 +51,9 @@ export {
 	getGeminiSettingsJsonContent,
 	getGeminiSettingsJsonPath,
 } from "./agent-wrappers-gemini";
+export {
+	createMastraCodeHooksJson,
+	createMastraCodeWrapper,
+	getMastraCodeHooksJsonContent,
+	getMastraCodeHooksJsonPath,
+} from "./agent-wrappers-mastracode";

--- a/apps/desktop/src/main/lib/agent-setup/index.ts
+++ b/apps/desktop/src/main/lib/agent-setup/index.ts
@@ -11,6 +11,8 @@ import {
 	createGeminiHookScript,
 	createGeminiSettingsJson,
 	createGeminiWrapper,
+	createMastraCodeHooksJson,
+	createMastraCodeWrapper,
 	createOpenCodePlugin,
 	createOpenCodeWrapper,
 } from "./agent-wrappers";
@@ -52,6 +54,8 @@ export function setupAgentHooks(): void {
 	createGeminiHookScript();
 	createGeminiWrapper();
 	createGeminiSettingsJson();
+	createMastraCodeWrapper();
+	createMastraCodeHooksJson();
 	createCopilotHookScript();
 	createCopilotWrapper();
 

--- a/apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts
@@ -49,6 +49,9 @@ describe("shell-wrappers", () => {
 		expect(zshrc).toContain(`codex() { "${TEST_BIN_DIR}/codex" "$@"; }`);
 		expect(zshrc).toContain(`opencode() { "${TEST_BIN_DIR}/opencode" "$@"; }`);
 		expect(zshrc).toContain(`copilot() { "${TEST_BIN_DIR}/copilot" "$@"; }`);
+		expect(zshrc).toContain(
+			`mastracode() { "${TEST_BIN_DIR}/mastracode" "$@"; }`,
+		);
 		expect(zshrc).toContain("rehash 2>/dev/null || true");
 
 		expect(zlogin).toContain("if [[ -o interactive ]]; then");
@@ -56,6 +59,9 @@ describe("shell-wrappers", () => {
 		expect(zlogin).toContain("_superset_prepend_bin()");
 		expect(zlogin).toContain(`claude() { "${TEST_BIN_DIR}/claude" "$@"; }`);
 		expect(zlogin).toContain(`copilot() { "${TEST_BIN_DIR}/copilot" "$@"; }`);
+		expect(zlogin).toContain(
+			`mastracode() { "${TEST_BIN_DIR}/mastracode" "$@"; }`,
+		);
 		expect(zlogin).toContain("rehash 2>/dev/null || true");
 	});
 
@@ -68,6 +74,9 @@ describe("shell-wrappers", () => {
 		expect(rcfile).toContain(`codex() { "${TEST_BIN_DIR}/codex" "$@"; }`);
 		expect(rcfile).toContain(`opencode() { "${TEST_BIN_DIR}/opencode" "$@"; }`);
 		expect(rcfile).toContain(`copilot() { "${TEST_BIN_DIR}/copilot" "$@"; }`);
+		expect(rcfile).toContain(
+			`mastracode() { "${TEST_BIN_DIR}/mastracode" "$@"; }`,
+		);
 		expect(rcfile).toContain("hash -r 2>/dev/null || true");
 	});
 

--- a/apps/desktop/src/main/lib/agent-setup/shell-wrappers.ts
+++ b/apps/desktop/src/main/lib/agent-setup/shell-wrappers.ts
@@ -46,7 +46,14 @@ function writeFileIfChanged(
 }
 
 /** Agent binaries that get wrapper shims to guarantee resolution. */
-const SHIMMED_BINARIES = ["claude", "codex", "opencode", "gemini", "copilot"];
+const SHIMMED_BINARIES = [
+	"claude",
+	"codex",
+	"opencode",
+	"gemini",
+	"copilot",
+	"mastracode",
+];
 
 /**
  * Shell function shims that override PATH-based lookup.


### PR DESCRIPTION
## Summary
- add a `mastracode` wrapper shim so Superset-managed binary resolution includes Mastra Code
- manage `~/.mastracode/hooks.json` by preserving user hooks while replacing stale Superset-managed entries
- register only `UserPromptSubmit` and `Stop` hooks for Superset lifecycle state updates
- add regression tests for Mastra hook merge behavior and shell shim generation

## Testing
- `bun test apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts`
- `bunx biome check apps/desktop/src/main/lib/agent-setup/agent-wrappers-mastracode.ts apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts apps/desktop/src/main/lib/agent-setup/index.ts apps/desktop/src/main/lib/agent-setup/shell-wrappers.ts apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts`
