### PR TITLE
feat(desktop): preset bar context actions + drag reorder

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/presets/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/presets/page.tsx
@@ -1,10 +1,29 @@
 import { createFileRoute, Navigate } from "@tanstack/react-router";
 
+type LegacyPresetsSearch = {
+	editPresetId?: string;
+	presetId?: string;
+};
+
 export const Route = createFileRoute("/_authenticated/settings/presets/")({
 	component: PresetsRedirect,
+	validateSearch: (search: Record<string, unknown>): LegacyPresetsSearch => ({
+		editPresetId:
+			typeof search.editPresetId === "string" ? search.editPresetId : undefined,
+		presetId: typeof search.presetId === "string" ? search.presetId : undefined,
+	}),
 });
 
 // Presets have been merged into Terminal settings
 function PresetsRedirect() {
-	return <Navigate to="/settings/terminal" replace />;
+	const { editPresetId, presetId } = Route.useSearch();
+	return (
+		<Navigate
+			to="/settings/terminal"
+			search={{
+				editPresetId: editPresetId ?? presetId,
+			}}
+			replace
+		/>
+	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/TerminalSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/TerminalSettings.tsx
@@ -10,6 +10,8 @@ import { SessionsSection } from "./components/SessionsSection";
 
 interface TerminalSettingsProps {
 	visibleItems?: SettingItemId[] | null;
+	editingPresetId?: string | null;
+	onEditingPresetIdChange?: (presetId: string | null) => void;
 }
 
 /**
@@ -33,7 +35,11 @@ function SectionList({ children }: { children: ReactNode[] }) {
 	);
 }
 
-export function TerminalSettings({ visibleItems }: TerminalSettingsProps) {
+export function TerminalSettings({
+	visibleItems,
+	editingPresetId,
+	onEditingPresetIdChange,
+}: TerminalSettingsProps) {
 	const showPresets = isItemVisible(
 		SETTING_ITEM_ID.TERMINAL_PRESETS,
 		visibleItems,
@@ -66,6 +72,8 @@ export function TerminalSettings({ visibleItems }: TerminalSettingsProps) {
 						key="presets"
 						showPresets={showPresets}
 						showQuickAdd={showQuickAdd}
+						editingPresetId={editingPresetId}
+						onEditingPresetIdChange={onEditingPresetIdChange}
 					/>
 				)}
 				{showLinkBehavior && <LinkBehaviorSetting key="link-behavior" />}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/page.tsx
@@ -4,11 +4,23 @@ import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import { getMatchingItemsForSection } from "../utils/settings-search";
 import { TerminalSettings } from "./components/TerminalSettings";
 
+export type TerminalSettingsSearch = {
+	editPresetId?: string;
+};
+
 export const Route = createFileRoute("/_authenticated/settings/terminal/")({
 	component: TerminalSettingsPage,
+	validateSearch: (
+		search: Record<string, unknown>,
+	): TerminalSettingsSearch => ({
+		editPresetId:
+			typeof search.editPresetId === "string" ? search.editPresetId : undefined,
+	}),
 });
 
 function TerminalSettingsPage() {
+	const navigate = Route.useNavigate();
+	const { editPresetId } = Route.useSearch();
 	const searchQuery = useSettingsSearchQuery();
 
 	const visibleItems = useMemo(() => {
@@ -18,5 +30,18 @@ function TerminalSettingsPage() {
 		);
 	}, [searchQuery]);
 
-	return <TerminalSettings visibleItems={visibleItems} />;
+	return (
+		<TerminalSettings
+			visibleItems={visibleItems}
+			editingPresetId={editPresetId ?? null}
+			onEditingPresetIdChange={(presetId) => {
+				navigate({
+					search: {
+						editPresetId: presetId ?? undefined,
+					},
+					replace: true,
+				});
+			}}
+		/>
+	);
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar/components/PresetBarItem/PresetBarItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar/components/PresetBarItem/PresetBarItem.tsx
@@ -1,0 +1,137 @@
+import type { TerminalPreset } from "@superset/local-db";
+import { Button } from "@superset/ui/button";
+import {
+	ContextMenu,
+	ContextMenuContent,
+	ContextMenuItem,
+	ContextMenuSeparator,
+	ContextMenuTrigger,
+} from "@superset/ui/context-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { useEffect, useRef } from "react";
+import { useDrag, useDrop } from "react-dnd";
+import { HiMiniCommandLine } from "react-icons/hi2";
+import { getPresetIcon } from "renderer/assets/app-icons/preset-icons";
+import { HotkeyTooltipContent } from "renderer/components/HotkeyTooltipContent/HotkeyTooltipContent";
+import type { HotkeyId } from "shared/hotkeys";
+
+const PRESET_BAR_ITEM_TYPE = "PRESET_BAR_ITEM";
+
+interface PresetBarItemProps {
+	preset: TerminalPreset;
+	pinnedIndex: number;
+	hotkeyId?: HotkeyId;
+	isDark: boolean;
+	canOpen: boolean;
+	onOpenDefault: (preset: TerminalPreset) => void;
+	onOpenInNewTab: (preset: TerminalPreset) => void;
+	onOpenInPane: (preset: TerminalPreset) => void;
+	onEdit: (preset: TerminalPreset) => void;
+	onLocalReorder: (fromIndex: number, toIndex: number) => void;
+	onPersistReorder: (presetId: string, targetPinnedIndex: number) => void;
+}
+
+export function PresetBarItem({
+	preset,
+	pinnedIndex,
+	hotkeyId,
+	isDark,
+	canOpen,
+	onOpenDefault,
+	onOpenInNewTab,
+	onOpenInPane,
+	onEdit,
+	onLocalReorder,
+	onPersistReorder,
+}: PresetBarItemProps) {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const icon = getPresetIcon(preset.name, isDark);
+	const label = preset.description || preset.name || "default";
+
+	const [{ isDragging }, drag] = useDrag(
+		() => ({
+			type: PRESET_BAR_ITEM_TYPE,
+			item: {
+				id: preset.id,
+				index: pinnedIndex,
+				originalIndex: pinnedIndex,
+			},
+			collect: (monitor) => ({
+				isDragging: monitor.isDragging(),
+			}),
+		}),
+		[preset.id, pinnedIndex],
+	);
+
+	const [, drop] = useDrop({
+		accept: PRESET_BAR_ITEM_TYPE,
+		hover: (item: { id: string; index: number; originalIndex: number }) => {
+			if (item.index !== pinnedIndex) {
+				onLocalReorder(item.index, pinnedIndex);
+				item.index = pinnedIndex;
+			}
+		},
+		drop: (item: { id: string; index: number; originalIndex: number }) => {
+			if (item.originalIndex !== item.index) {
+				onPersistReorder(item.id, item.index);
+			}
+		},
+	});
+
+	useEffect(() => {
+		drag(drop(containerRef));
+	}, [drag, drop]);
+
+	return (
+		<ContextMenu>
+			<ContextMenuTrigger asChild>
+				<div
+					ref={containerRef}
+					className={isDragging ? "opacity-40" : undefined}
+					style={{ cursor: isDragging ? "grabbing" : "grab" }}
+				>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								variant="ghost"
+								size="sm"
+								className="h-6 px-2 gap-1.5 text-xs shrink-0"
+								onClick={() => onOpenDefault(preset)}
+							>
+								{icon ? (
+									<img src={icon} alt="" className="size-3.5 object-contain" />
+								) : (
+									<HiMiniCommandLine className="size-3.5" />
+								)}
+								<span className="truncate max-w-[120px]">
+									{preset.name || "default"}
+								</span>
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent side="bottom" sideOffset={4}>
+							<HotkeyTooltipContent label={label} hotkeyId={hotkeyId} />
+						</TooltipContent>
+					</Tooltip>
+				</div>
+			</ContextMenuTrigger>
+			<ContextMenuContent>
+				<ContextMenuItem
+					disabled={!canOpen}
+					onSelect={() => onOpenInNewTab(preset)}
+				>
+					Open in new tab
+				</ContextMenuItem>
+				<ContextMenuItem
+					disabled={!canOpen}
+					onSelect={() => onOpenInPane(preset)}
+				>
+					Open in pane
+				</ContextMenuItem>
+				<ContextMenuSeparator />
+				<ContextMenuItem onSelect={() => onEdit(preset)}>
+					Edit preset
+				</ContextMenuItem>
+			</ContextMenuContent>
+		</ContextMenu>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar/components/PresetBarItem/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar/components/PresetBarItem/index.ts
@@ -1,0 +1,1 @@
+export { PresetBarItem } from "./PresetBarItem";

--- a/apps/desktop/src/renderer/stores/tabs/useTabsWithPresets.ts
+++ b/apps/desktop/src/renderer/stores/tabs/useTabsWithPresets.ts
@@ -19,6 +19,7 @@ import { resolveActiveTabIdForWorkspace } from "./utils";
 
 interface OpenPresetOptions {
 	target?: PresetOpenTarget;
+	modeOverride?: PresetMode;
 }
 
 interface PreparedPreset {
@@ -312,7 +313,8 @@ export function useTabsWithPresets() {
 		) => {
 			const prepared = preparePreset(preset);
 			const target = options?.target ?? "new-tab";
-			return executePreset(workspaceId, prepared, target);
+			const mode = options?.modeOverride ?? prepared.mode;
+			return executePreset(workspaceId, { ...prepared, mode }, target);
 		},
 		[executePreset],
 	);


### PR DESCRIPTION
## Summary
- add a right-click context menu for preset bar items with actions to open in a new tab, open in pane, and edit preset
- add drag-and-drop reordering for pinned preset bar items and persist order via `reorderTerminalPresets`
- add explicit preset launch mode override support for context actions (`split-pane` override for pane action)
- add terminal settings routing support for opening a specific preset editor via `editPresetId` search params
- forward legacy `/settings/presets` search params (`editPresetId` / `presetId`) into `/settings/terminal`

## Testing
- `bunx biome check --write apps/desktop/src/renderer/stores/tabs/useTabsWithPresets.ts apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar/PresetsBar.tsx apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar/components/PresetBarItem/PresetBarItem.tsx apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar/components/PresetBarItem/index.ts apps/desktop/src/renderer/routes/_authenticated/settings/terminal/page.tsx apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/TerminalSettings.tsx apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/PresetsSection.tsx apps/desktop/src/renderer/routes/_authenticated/settings/presets/page.tsx`
- `bunx turbo typecheck --filter=@superset/desktop`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Drag-and-drop reordering of pinned presets in the preset bar for easier workflow customization.
  * Enhanced preset management with context menu options to open presets in different contexts.
  * Unified preset editing interface integrated into terminal settings for streamlined preset management.
  * Preset execution mode override capability for flexible preset execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->