### PR TITLE
fix(desktop): update ahead/behind on sidebar-hover cadence

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -42,7 +42,6 @@ import { STROKE_WIDTH } from "../constants";
 import { CollapsedWorkspaceItem } from "./CollapsedWorkspaceItem";
 import { DeleteWorkspaceDialog, WorkspaceHoverCardContent } from "./components";
 import {
-	AHEAD_BEHIND_STALE_TIME,
 	GITHUB_STATUS_STALE_TIME,
 	HOVER_CARD_CLOSE_DELAY,
 	HOVER_CARD_OPEN_DELAY,
@@ -145,8 +144,8 @@ export function WorkspaceListItem({
 		{ workspaceId: id },
 		{
 			enabled: isBranchWorkspace,
-			staleTime: AHEAD_BEHIND_STALE_TIME,
-			refetchInterval: AHEAD_BEHIND_STALE_TIME,
+			staleTime: GITHUB_STATUS_STALE_TIME,
+			refetchInterval: hasHovered ? GITHUB_STATUS_STALE_TIME : false,
 		},
 	);
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/constants.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/constants.ts
@@ -1,5 +1,4 @@
 export const MAX_KEYBOARD_SHORTCUT_INDEX = 9;
 export const GITHUB_STATUS_STALE_TIME = 30_000;
-export const AHEAD_BEHIND_STALE_TIME = 60_000;
 export const HOVER_CARD_OPEN_DELAY = 400;
 export const HOVER_CARD_CLOSE_DELAY = 100;


### PR DESCRIPTION
## Summary
- align branch-workspace ahead/behind query stale time with sidebar git status timing (30s)
- start ahead/behind interval refresh after workspace item hover, matching sidebar hover-driven status behavior
- remove the separate 60s ahead/behind constant

## Testing
- bunx biome check apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/constants.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted branch status data refresh timing for workspace display to use consistent GitHub status configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->