### PR TITLE
fix(desktop): allow importing empty repos with unborn HEAD

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
@@ -1283,8 +1283,17 @@ export async function getCurrentBranch(
 	try {
 		const branch = await git.revparse(["--abbrev-ref", "HEAD"]);
 		const trimmed = branch.trim();
-		// "HEAD" means detached HEAD state
-		return trimmed === "HEAD" ? null : trimmed;
+		if (trimmed && trimmed !== "HEAD") {
+			return trimmed;
+		}
+	} catch {
+		// Fall back to symbolic-ref below for unborn HEAD repos.
+	}
+
+	try {
+		const branch = await git.raw(["symbolic-ref", "--short", "HEAD"]);
+		const trimmed = branch.trim();
+		return trimmed || null;
 	} catch {
 		return null;
 	}


### PR DESCRIPTION
## Summary
- Fix empty-repo import path by making `getCurrentBranch()` handle unborn `HEAD`
- Add fallback to `git symbolic-ref --short HEAD` when `rev-parse --abbrev-ref HEAD` is not usable
- Add regression tests for unborn-HEAD repos and detached-HEAD behavior

## Validation
- `bun test apps/desktop/src/lib/trpc/routers/workspaces/utils/git.test.ts`
- `bunx biome check apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts apps/desktop/src/lib/trpc/routers/workspaces/utils/git.test.ts`

## References
- Fixes #1663
- Related: #1681

## Credit
- Thanks @vincentclaes for the original bug report and repro details in #1663

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved robustness of branch detection in edge cases, including empty repositories and detached HEAD states.

* **Tests**
  * Added test coverage for branch detection in various git repository states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->