### PR TITLE
feat(desktop): add fish shell support for agent notifications

### DIFF
--- a/apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts
@@ -108,12 +108,25 @@ describe("shell-wrappers", () => {
 		it("uses --init-command to prepend BIN_DIR to PATH for fish", () => {
 			const args = getShellArgs("/opt/homebrew/bin/fish", TEST_PATHS);
 
-			// Should have login flag, --init-command, and PATH prepend command
-			expect(args[0]).toBe("-l");
-			expect(args[1]).toBe("--init-command");
-			// init-command should prepend BIN_DIR to PATH using fish syntax
-			expect(args[2]).toContain("set -gx PATH");
-			expect(args[2]).toContain(TEST_BIN_DIR);
+			expect(args).toEqual([
+				"-l",
+				"--init-command",
+				`set -l _superset_bin "${TEST_BIN_DIR}"; contains -- "$_superset_bin" $PATH; or set -gx PATH "$_superset_bin" $PATH`,
+			]);
+		});
+
+		it("escapes fish init-command BIN_DIR safely", () => {
+			const fishPath = '/tmp/with space/quote"buck$slash\\bin';
+			const args = getShellArgs("/opt/homebrew/bin/fish", {
+				...TEST_PATHS,
+				BIN_DIR: fishPath,
+			});
+
+			expect(args).toEqual([
+				"-l",
+				"--init-command",
+				`set -l _superset_bin "/tmp/with space/quote\\"buck\\$slash\\\\bin"; contains -- "$_superset_bin" $PATH; or set -gx PATH "$_superset_bin" $PATH`,
+			]);
 		});
 	});
 });

--- a/apps/desktop/src/main/lib/agent-setup/shell-wrappers.ts
+++ b/apps/desktop/src/main/lib/agent-setup/shell-wrappers.ts
@@ -70,6 +70,13 @@ function buildPathPrependFunction(binDir: string): string {
 _superset_prepend_bin`;
 }
 
+function escapeFishDoubleQuoted(value: string): string {
+	return value
+		.replaceAll("\\", "\\\\")
+		.replaceAll('"', '\\"')
+		.replaceAll("$", "\\$");
+}
+
 export function createZshWrapper(
 	paths: ShellWrapperPaths = DEFAULT_PATHS,
 ): void {
@@ -188,12 +195,13 @@ export function getShellArgs(
 		return ["--rcfile", path.join(paths.BASH_DIR, "rcfile")];
 	}
 	if (shellName === "fish") {
-		// Use --init-command to prepend BIN_DIR to PATH after config is loaded
-		// This ensures agent wrappers are found first, even after user's config modifies PATH
+		// Use --init-command to prepend BIN_DIR to PATH after config is loaded.
+		// Use fish list-aware checks to avoid duplicate PATH entries across nested shells.
+		const escapedBinDir = escapeFishDoubleQuoted(paths.BIN_DIR);
 		return [
 			"-l",
 			"--init-command",
-			`set -gx PATH ${paths.BIN_DIR} $PATH`,
+			`set -l _superset_bin "${escapedBinDir}"; contains -- "$_superset_bin" $PATH; or set -gx PATH "$_superset_bin" $PATH`,
 		];
 	}
 	if (["zsh", "sh", "ksh"].includes(shellName)) {


### PR DESCRIPTION
## Description

Claude Code notifications didn't work when using fish shell because fish lacked the wrapper support that zsh and bash have. The agent wrapper scripts in `~/.superset/bin` weren't being prioritized in PATH.

Fish shell provides `--init-command` flag that runs a command after user config is loaded. Using this to prepend `~/.superset/bin` to PATH ensures agent wrappers take precedence:

```bash
fish -l --init-command='set -gx PATH ~/.superset/bin $PATH'
```

- Add fish shell support using `--init-command` flag to prepend `BIN_DIR` to PATH after user config is loaded
- This ensures agent wrappers (claude, codex, etc.) are found first, enabling notifications for fish shell users
- Includes unit tests for the new fish shell behavior

## Related Issues

#1461 

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

- [x] Unit tests pass for fish shell args
- [x] Manual test: Start Superset desktop with fish shell, verify notifications work

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fish shell startup now safely prepends the agent tools directory to PATH (including correct escaping for spaces/special chars) so wrappers are found before user shell config.

* **Tests**
  * Added tests verifying Fish startup arguments, PATH-prepend behavior, and proper escaping to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->