### PR TITLE
Refresh local ahead/behind status on workspace hover

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -140,14 +140,15 @@ export function WorkspaceListItem({
 		staleTime: GITHUB_STATUS_STALE_TIME,
 	});
 
-	const { data: aheadBehind } = electronTrpc.workspaces.getAheadBehind.useQuery(
-		{ workspaceId: id },
-		{
-			enabled: isBranchWorkspace,
-			staleTime: GITHUB_STATUS_STALE_TIME,
-			refetchInterval: hasHovered ? GITHUB_STATUS_STALE_TIME : false,
-		},
-	);
+	const { data: aheadBehind, refetch: refetchAheadBehind } =
+		electronTrpc.workspaces.getAheadBehind.useQuery(
+			{ workspaceId: id },
+			{
+				enabled: isBranchWorkspace,
+				staleTime: GITHUB_STATUS_STALE_TIME,
+				refetchInterval: hasHovered ? GITHUB_STATUS_STALE_TIME : false,
+			},
+		);
 
 	useBranchSyncInvalidation({
 		gitBranch: localChanges?.branch,
@@ -193,6 +194,7 @@ export function WorkspaceListItem({
 
 	const handleMouseEnter = () => {
 		if (!hasHovered) setHasHovered(true);
+		if (isBranchWorkspace) void refetchAheadBehind();
 	};
 
 	const handleOpenInFinder = () => {


### PR DESCRIPTION
## Summary
- trigger immediate `getAheadBehind` refetch when a workspace list item is hovered
- keep existing interval polling behavior after hover
- scope behavior to local/branch workspaces only

## Testing
- bunx biome check apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced workspace status data refresh in the sidebar. Workspace information now updates more promptly when interacting with branch workspaces, ensuring up-to-date ahead/behind metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->