### PR TITLE
chore: enable solve PRs in issue triage action

### DIFF
--- a/.github/prompts/triage-issue.md
+++ b/.github/prompts/triage-issue.md
@@ -1,6 +1,8 @@
-# Issue Triage: Reproduce Bug and Open PR
+# Issue Triage: Reproduce Bug and Solve When Possible
 
-You are triaging GitHub issue `$ISSUE_NUMBER`. Your goal is to reproduce the reported bug with a failing test and open a PR.
+You are triaging GitHub issue `$ISSUE_NUMBER`. Your goal is to:
+- reproduce the reported bug with a test, and
+- if the bug is reproducible and clearly solvable in this run, include a fix in the same PR.
 
 ## Steps
 
@@ -8,19 +10,35 @@ You are triaging GitHub issue `$ISSUE_NUMBER`. Your goal is to reproduce the rep
 
 2. **Find affected code** — Search the codebase (Glob/Grep) for the relevant files, functions, or modules. Read the source code to understand how it works.
 
-3. **Write a reproduction test** — Create a co-located `.test.ts` file (or add to an existing one) using `bun:test` (`describe`/`test`/`expect`). The test should fail, proving the bug exists. You may create minimal helper files or fixtures if needed to reproduce.
+3. **Write a reproduction test** — Create a co-located `.test.ts` file (or add to an existing one) using `bun:test` (`describe`/`test`/`expect`). It must demonstrate the reported behavior. You may create minimal helper files or fixtures if needed.
 
-4. **Run the test** — `bun test <path>` to confirm it fails as expected.
+4. **Run the test** — `bun test <path>`:
+   - If it fails in the expected way, the issue is reproducible.
+   - If it does not fail as expected, continue investigating once; if still not reproducible, follow step 7.
 
-5. **Open a PR** — Run `bun run lint:fix`, then commit, push, and create a PR:
-   - Title: `test: reproduce #$ISSUE_NUMBER — <short bug description>`
-   - Body should include:
-     - What the bug is (in your own words, based on the issue)
-     - What code is affected and why
-     - What the test does and how it proves the bug
-     - `Closes #$ISSUE_NUMBER`
+5. **Attempt a fix when possible** — If reproducible and solvable with a clear, scoped change:
+   - Implement the minimal fix.
+   - Re-run `bun test <path>` to confirm the reproduction test now passes.
+   - Run any nearby targeted tests needed to validate the fix.
+   - If a safe fix is not clear, keep this as reproduction-only and continue to step 6A.
 
-6. **If you can't reproduce** — Comment on the issue explaining what you tried and why a test wasn't feasible. Do not create a PR.
+6. **Open exactly one PR** — Run `bun run lint:fix`, then commit, push, and create a PR:
+   - **6A: Reproduction-only PR (reproducible but not solved)**
+     - Title: `test: reproduce #$ISSUE_NUMBER — <short bug description>`
+     - Body should include:
+       - What the bug is (in your own words, based on the issue)
+       - What code is affected and why
+       - What the test does and how it proves the bug
+       - `Refs #$ISSUE_NUMBER`
+   - **6B: Solve PR (reproducible and solved)**
+     - Title: `fix: solve #$ISSUE_NUMBER — <short bug description>`
+     - Body should include:
+       - Root cause
+       - The fix and why it works
+       - What test(s) prove reproduction and resolution
+       - `Closes #$ISSUE_NUMBER`
+
+7. **If you can't reproduce** — Comment on the issue explaining what you tried and why a test wasn't feasible. Do not create a PR.
 
 ## Security
 

--- a/.github/workflows/triage-issue.yml
+++ b/.github/workflows/triage-issue.yml
@@ -18,7 +18,7 @@ jobs:
   triage:
     name: Triage Issue
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- update the Claude triage prompt to attempt a fix after reproducing an issue
- create a `fix: solve #<issue>` PR when the issue is reproducible and solvable
- keep reproduction-only behavior when not safely solvable, and keep no-PR behavior when not reproducible
- increase triage workflow timeout from 15 to 25 minutes to support the added solve path

## Testing
- not run (workflow/prompt changes only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated issue triage workflow with improved reproduction testing guidance, reorganized workflow steps into distinct paths for reproduction-only and solve scenarios, and introduced optional fix attempts for reproducible and solvable issues with test validation.

* **Chores**
  * Extended job execution timeout window to accommodate extended workflow durations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->