### PR TITLE
fix(desktop): handle null clipboardData for terminal copy on Linux/Wayland

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.test.ts
@@ -34,6 +34,7 @@ mock.module("renderer/lib/trpc-client", () => ({
 const {
 	getDefaultTerminalBg,
 	getDefaultTerminalTheme,
+	setupCopyHandler,
 	setupKeyboardHandler,
 	setupPasteHandler,
 } = await import("./helpers");
@@ -197,6 +198,116 @@ describe("setupKeyboardHandler", () => {
 
 		expect(onWrite).toHaveBeenCalledWith("\x1bb");
 		expect(onWrite).toHaveBeenCalledWith("\x1bf");
+	});
+});
+
+describe("setupCopyHandler", () => {
+	const originalNavigator = globalThis.navigator;
+
+	afterEach(() => {
+		globalThis.navigator = originalNavigator;
+	});
+
+	function createXtermStub(selection: string) {
+		const listeners = new Map<string, EventListener>();
+		const element = {
+			addEventListener: mock((eventName: string, listener: EventListener) => {
+				listeners.set(eventName, listener);
+			}),
+			removeEventListener: mock((eventName: string) => {
+				listeners.delete(eventName);
+			}),
+		} as unknown as HTMLElement;
+		const xterm = {
+			element,
+			getSelection: mock(() => selection),
+		} as unknown as XTerm;
+		return { xterm, listeners };
+	}
+
+	it("trims trailing whitespace and writes to clipboardData when available", () => {
+		const { xterm, listeners } = createXtermStub("foo   \nbar  ");
+		setupCopyHandler(xterm);
+
+		const preventDefault = mock(() => {});
+		const setData = mock(() => {});
+		const copyEvent = {
+			preventDefault,
+			clipboardData: { setData },
+		} as unknown as ClipboardEvent;
+
+		const copyListener = listeners.get("copy");
+		expect(copyListener).toBeDefined();
+		copyListener?.(copyEvent);
+
+		expect(preventDefault).toHaveBeenCalled();
+		expect(setData).toHaveBeenCalledWith("text/plain", "foo\nbar");
+	});
+
+	it("prefers clipboardData path over navigator.clipboard fallback", () => {
+		const { xterm, listeners } = createXtermStub("foo   \nbar  ");
+		const writeText = mock(() => Promise.resolve());
+
+		// @ts-expect-error - mocking navigator for tests
+		globalThis.navigator = { clipboard: { writeText } };
+
+		setupCopyHandler(xterm);
+
+		const preventDefault = mock(() => {});
+		const setData = mock(() => {});
+		const copyEvent = {
+			preventDefault,
+			clipboardData: { setData },
+		} as unknown as ClipboardEvent;
+
+		const copyListener = listeners.get("copy");
+		expect(copyListener).toBeDefined();
+		copyListener?.(copyEvent);
+
+		expect(preventDefault).toHaveBeenCalled();
+		expect(setData).toHaveBeenCalledWith("text/plain", "foo\nbar");
+		expect(writeText).not.toHaveBeenCalled();
+	});
+
+	it("falls back to navigator.clipboard.writeText when clipboardData is missing", () => {
+		const { xterm, listeners } = createXtermStub("foo   \nbar  ");
+		const writeText = mock(() => Promise.resolve());
+
+		// @ts-expect-error - mocking navigator for tests
+		globalThis.navigator = { clipboard: { writeText } };
+
+		setupCopyHandler(xterm);
+
+		const preventDefault = mock(() => {});
+		const copyEvent = {
+			preventDefault,
+			clipboardData: null,
+		} as unknown as ClipboardEvent;
+
+		const copyListener = listeners.get("copy");
+		expect(copyListener).toBeDefined();
+		copyListener?.(copyEvent);
+
+		expect(preventDefault).not.toHaveBeenCalled();
+		expect(writeText).toHaveBeenCalledWith("foo\nbar");
+	});
+
+	it("does not throw when clipboardData is missing and navigator.clipboard is unavailable", () => {
+		const { xterm, listeners } = createXtermStub("foo   \nbar  ");
+
+		// @ts-expect-error - mocking navigator for tests
+		globalThis.navigator = {};
+
+		setupCopyHandler(xterm);
+
+		const copyEvent = {
+			preventDefault: mock(() => {}),
+			clipboardData: null,
+		} as unknown as ClipboardEvent;
+
+		const copyListener = listeners.get("copy");
+		expect(copyListener).toBeDefined();
+		expect(() => copyListener?.(copyEvent)).not.toThrow();
 	});
 });
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -346,8 +346,17 @@ export function setupCopyHandler(xterm: XTerm): () => void {
 			.map((line) => line.trimEnd())
 			.join("\n");
 
-		event.preventDefault();
-		event.clipboardData?.setData("text/plain", trimmedText);
+		// On Linux/Wayland in Electron, clipboardData can be null for copy events.
+		// Only cancel default behavior when we can write directly to event clipboardData.
+		if (event.clipboardData) {
+			event.preventDefault();
+			event.clipboardData.setData("text/plain", trimmedText);
+			return;
+		}
+
+		// Fallback path when clipboardData is unavailable.
+		// Keep default browser copy behavior and best-effort write trimmed text.
+		void navigator.clipboard?.writeText(trimmedText).catch(() => {});
 	};
 
 	element.addEventListener("copy", handleCopy);


### PR DESCRIPTION
## Summary
- Fix terminal Ctrl+C (copy) being completely broken on Linux/Wayland by handling `null` `ClipboardEvent.clipboardData`.

## Why / Context
On Linux/Wayland in Electron, `ClipboardEvent.clipboardData` is `null` for copy events. The existing code unconditionally called `event.preventDefault()` and then used optional chaining (`event.clipboardData?.setData(...)`) — meaning it prevented the browser's default copy and then silently did nothing. Copy was completely broken on Linux.

## How It Works
- Guard on `event.clipboardData` being truthy before calling `preventDefault()` and writing to it (the happy path on macOS/Windows).
- When `clipboardData` is `null` (Linux/Wayland), skip `preventDefault()` so the browser's default copy still works, and best-effort overwrite with the trimmed text via `navigator.clipboard.writeText`.
- The fallback is fire-and-forget with `.catch(() => {})` so it never throws.

## Manual QA Checklist

### Terminal Copy
- [x] Ctrl+C / Cmd+C copies selected terminal text (macOS — existing behavior preserved)
- [ ] Ctrl+Shift+C copies selected terminal text (Linux/Wayland — was broken, now works)
- [x] Trailing whitespace is trimmed from copied lines
- [x] Copy with no selection does not error

## Testing
- `bun run typecheck` — passes
- `cd apps/desktop && bun test src/.../Terminal/helpers.test.ts` — 15/15 pass (4 new tests for `setupCopyHandler`)

Test cases added:
1. Writes trimmed text via `clipboardData.setData` when available
2. Prefers `clipboardData` over `navigator.clipboard` fallback
3. Falls back to `navigator.clipboard.writeText` when `clipboardData` is null
4. Gracefully handles both APIs being unavailable (no throw)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal clipboard functionality with enhanced fallback support for various system environments.

* **Tests**
  * Added comprehensive test coverage for clipboard operations, including fallback scenarios and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->