### PR TITLE
Make new-tab the default preset execution mode

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/settings/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/index.ts
@@ -118,7 +118,7 @@ function initializeDefaultPresets() {
 			: DEFAULT_PRESETS.map((p) => ({
 					id: crypto.randomUUID(),
 					...p,
-					executionMode: p.executionMode ?? "split-pane",
+					executionMode: p.executionMode ?? "new-tab",
 				}));
 
 	saveTerminalPresets(mergedPresets, { terminalPresetsInitialized: true });
@@ -161,7 +161,7 @@ export const createSettingsRouter = () => {
 				const preset: TerminalPreset = {
 					id: crypto.randomUUID(),
 					...input,
-					executionMode: input.executionMode ?? "split-pane",
+					executionMode: input.executionMode ?? "new-tab",
 				};
 
 				const presets = getNormalizedTerminalPresets();

--- a/apps/desktop/src/lib/trpc/routers/settings/preset-execution-mode.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/preset-execution-mode.test.ts
@@ -30,11 +30,12 @@ describe("normalizeExecutionMode", () => {
 		);
 	});
 
-	it("maps legacy and missing modes to split-pane", () => {
+	it("maps legacy modes to split-pane and missing modes to new-tab", () => {
 		expect(normalizeExecutionMode("split-pane")).toBe("split-pane");
 		expect(normalizeExecutionMode("parallel")).toBe("split-pane");
 		expect(normalizeExecutionMode("sequential")).toBe("split-pane");
-		expect(normalizeExecutionMode(undefined)).toBe("split-pane");
+		expect(normalizeExecutionMode(undefined)).toBe("new-tab");
+		expect(normalizeExecutionMode("unknown")).toBe("new-tab");
 	});
 });
 
@@ -51,7 +52,7 @@ describe("normalizeTerminalPresets", () => {
 			"new-tab",
 			"new-tab-split-pane",
 			"split-pane",
-			"split-pane",
+			"new-tab",
 		] satisfies TerminalPreset["executionMode"][]);
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetRow/PresetRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetRow/PresetRow.tsx
@@ -1,3 +1,4 @@
+import { normalizeExecutionMode } from "@superset/local-db";
 import { Badge } from "@superset/ui/badge";
 import { useEffect, useRef } from "react";
 import { useDrag, useDrop } from "react-dnd";
@@ -65,11 +66,7 @@ export function PresetRow({
 		preset.applyOnNewTab ||
 		(!preset.applyOnWorkspaceCreated && preset.isDefault)
 	);
-	const modeValue =
-		preset.executionMode === "new-tab" ||
-		preset.executionMode === "new-tab-split-pane"
-			? preset.executionMode
-			: "split-pane";
+	const modeValue = normalizeExecutionMode(preset.executionMode);
 	const modeLabel =
 		modeValue === "new-tab"
 			? preset.commands.length > 1

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/PresetsSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/PresetsSection.tsx
@@ -1,4 +1,8 @@
-import type { ExecutionMode, TerminalPreset } from "@superset/local-db";
+import {
+	type ExecutionMode,
+	normalizeExecutionMode,
+	type TerminalPreset,
+} from "@superset/local-db";
 import { Button } from "@superset/ui/button";
 import { Label } from "@superset/ui/label";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -233,7 +237,7 @@ export function PresetsSection({
 			name: "",
 			cwd: "",
 			commands: [""],
-			executionMode: "split-pane",
+			executionMode: "new-tab",
 		});
 	}, [createPreset]);
 
@@ -303,13 +307,12 @@ export function PresetsSection({
 		(!editingPreset?.applyOnWorkspaceCreated && editingPreset?.isDefault)
 	);
 	const hasMultipleCommands = (editingPreset?.commands.length ?? 0) > 1;
-	const modeValue: ExecutionMode =
-		editingPreset?.executionMode === "new-tab" ||
-		editingPreset?.executionMode === "new-tab-split-pane"
-			? hasMultipleCommands
-				? editingPreset.executionMode
-				: "new-tab"
-			: "split-pane";
+	const normalizedMode = normalizeExecutionMode(editingPreset?.executionMode);
+	const modeValue: ExecutionMode = hasMultipleCommands
+		? normalizedMode
+		: normalizedMode === "split-pane"
+			? "split-pane"
+			: "new-tab";
 
 	const handleEditorFieldChange = useCallback(
 		(column: PresetColumnKey, value: string) => {

--- a/apps/desktop/src/renderer/stores/tabs/preset-launch.test.ts
+++ b/apps/desktop/src/renderer/stores/tabs/preset-launch.test.ts
@@ -13,11 +13,12 @@ describe("normalizeExecutionMode", () => {
 		);
 	});
 
-	it("maps legacy and unknown modes to split-pane", () => {
+	it("maps legacy modes to split-pane and defaults unknown modes to new-tab", () => {
 		expect(normalizeExecutionMode("split-pane")).toBe("split-pane");
 		expect(normalizeExecutionMode("parallel")).toBe("split-pane");
 		expect(normalizeExecutionMode("sequential")).toBe("split-pane");
-		expect(normalizeExecutionMode(undefined)).toBe("split-pane");
+		expect(normalizeExecutionMode(undefined)).toBe("new-tab");
+		expect(normalizeExecutionMode("unknown")).toBe("new-tab");
 	});
 });
 

--- a/packages/local-db/src/schema/zod.ts
+++ b/packages/local-db/src/schema/zod.ts
@@ -66,7 +66,11 @@ export function normalizeExecutionMode(mode: unknown): ExecutionMode {
 		return mode;
 	}
 
-	return "split-pane";
+	if (mode === "parallel" || mode === "sequential") {
+		return "split-pane";
+	}
+
+	return "new-tab";
 }
 
 /**


### PR DESCRIPTION
## Summary
- make `new-tab` the default execution mode for newly created presets
- default normalized/unknown preset modes to `new-tab` while preserving legacy `parallel`/`sequential` -> `split-pane` mapping
- update preset settings UI fallback handling and related unit tests

## Testing
- bun test apps/desktop/src/renderer/stores/tabs/preset-launch.test.ts
- bun test apps/desktop/src/lib/trpc/routers/settings/preset-execution-mode.test.ts
- bunx biome check packages/local-db/src/schema/zod.ts apps/desktop/src/lib/trpc/routers/settings/index.ts apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/PresetsSection.tsx apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetRow/PresetRow.tsx apps/desktop/src/renderer/stores/tabs/preset-launch.test.ts apps/desktop/src/lib/trpc/routers/settings/preset-execution-mode.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default execution mode for newly created or missing terminal presets is now "new-tab-split-pane".
  * Unknown or undefined execution modes now normalize to "new-tab-split-pane".
  * Legacy "parallel" now maps to "new-tab-split-pane"; "sequential" and "split-pane" remain "split-pane".
  * Settings UI now displays these normalized execution mode values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->