### PR TITLE
fix(chat-mastra): dedupe merged assistant fragments during streaming

### DIFF
--- a/packages/chat-mastra/src/client/hooks/use-mastra-chat-display/hooks/use-messages/message-dedupe.test.ts
+++ b/packages/chat-mastra/src/client/hooks/use-mastra-chat-display/hooks/use-messages/message-dedupe.test.ts
@@ -47,6 +47,50 @@ function assistantWithDuplicateToolParts(id: string): MastraMessage {
 	} as unknown as MastraMessage;
 }
 
+function assistantWithResolvedAndExecutingDuplicateToolCall(
+	id: string,
+): MastraMessage {
+	return {
+		id,
+		role: "assistant",
+		content: [
+			{
+				type: "tool_call",
+				id: "tc_complete",
+				name: "read_file",
+				args: { path: "a.ts" },
+			},
+			{
+				type: "tool_result",
+				id: "tc_complete",
+				name: "read_file",
+				result: { content: "contents" },
+				isError: false,
+			},
+			{
+				type: "tool_call",
+				id: "tc_executing",
+				name: "read_file",
+				args: { path: "a.ts" },
+			},
+			{ type: "text", text: "done" },
+		],
+		createdAt: new Date("2026-02-25T00:00:00.000Z"),
+	} as unknown as MastraMessage;
+}
+
+function assistantMessage(
+	id: string,
+	content: MastraMessage["content"],
+): MastraMessage {
+	return {
+		id,
+		role: "assistant",
+		content,
+		createdAt: new Date("2026-02-25T00:00:00.000Z"),
+	} as unknown as MastraMessage;
+}
+
 describe("dedupeMessages", () => {
 	it("dedupes duplicate message IDs and keeps the latest payload", () => {
 		const oldMessage = userMessage("m_1", "old");
@@ -90,5 +134,100 @@ describe("dedupeMessages", () => {
 		expect(deduped?.content[2]).toMatchObject({ type: "text", text: "done" });
 		expect(summary.droppedToolPartCount).toBe(2);
 		expect(summary.droppedToolPartsByMessage).toEqual({ a_1: 2 });
+	});
+
+	it("prefers resolved tool calls over matching executing duplicates", () => {
+		const assistantMessage =
+			assistantWithResolvedAndExecutingDuplicateToolCall("a_2");
+
+		const { messages, summary } = dedupeMessages([assistantMessage]);
+		const deduped = messages[0];
+
+		expect(deduped?.content).toHaveLength(3);
+		expect(deduped?.content[0]).toMatchObject({
+			type: "tool_call",
+			id: "tc_complete",
+			name: "read_file",
+			args: { path: "a.ts" },
+		});
+		expect(deduped?.content[1]).toMatchObject({
+			type: "tool_result",
+			id: "tc_complete",
+			result: { content: "contents" },
+		});
+		expect(deduped?.content[2]).toMatchObject({ type: "text", text: "done" });
+		expect(summary.droppedToolPartCount).toBe(1);
+		expect(summary.droppedToolPartsByMessage).toEqual({ a_2: 1 });
+	});
+
+	it("drops assistant fragments subsumed by a later assistant message in the same turn", () => {
+		const user = userMessage("u_1", "start");
+		const assistantTools = assistantMessage("a_tools", [
+			{ type: "text", text: "Sure, let me check." },
+			{
+				type: "tool_call",
+				id: "tc_1",
+				name: "view",
+				args: { path: "." },
+			},
+			{
+				type: "tool_result",
+				id: "tc_1",
+				name: "view",
+				result: { content: "files..." },
+				isError: false,
+			},
+		]);
+		const assistantSummary = assistantMessage("a_summary", [
+			{ type: "text", text: "Here is the summary." },
+		]);
+		const mergedAssistant = assistantMessage("a_current", [
+			{ type: "text", text: "Sure, let me check." },
+			{
+				type: "tool_call",
+				id: "tc_1",
+				name: "view",
+				args: { path: "." },
+			},
+			{
+				type: "tool_result",
+				id: "tc_1",
+				name: "view",
+				result: { content: "files..." },
+				isError: false,
+			},
+			{ type: "text", text: "Here is the summary." },
+		]);
+
+		const { messages, summary } = dedupeMessages([
+			user,
+			assistantTools,
+			assistantSummary,
+			mergedAssistant,
+		]);
+
+		expect(messages.map((message) => message.id)).toEqual(["u_1", "a_current"]);
+		expect(summary.droppedMessageIds).toEqual(["a_tools", "a_summary"]);
+		expect(summary.finalMessageCount).toBe(2);
+	});
+
+	it("does not drop assistant messages across user turn boundaries", () => {
+		const { messages, summary } = dedupeMessages([
+			userMessage("u_1", "first"),
+			assistantMessage("a_1", [{ type: "text", text: "same" }]),
+			userMessage("u_2", "second"),
+			assistantMessage("a_2", [
+				{ type: "text", text: "same" },
+				{ type: "text", text: "plus" },
+			]),
+		]);
+
+		expect(messages.map((message) => message.id)).toEqual([
+			"u_1",
+			"a_1",
+			"u_2",
+			"a_2",
+		]);
+		expect(summary.droppedMessageIds).toEqual([]);
 	});
 });

--- a/packages/chat-mastra/src/client/hooks/use-mastra-chat-display/hooks/use-messages/message-dedupe.ts
+++ b/packages/chat-mastra/src/client/hooks/use-mastra-chat-display/hooks/use-messages/message-dedupe.ts
@@ -13,13 +13,110 @@ export interface DedupeSummary {
 	droppedToolPartsByMessage: Record<string, number>;
 }
 
+function toStableJson(value: unknown): string {
+	if (value === undefined) return "undefined";
+	if (value === null) return "null";
+	if (Array.isArray(value)) {
+		return `[${value.map((item) => toStableJson(item)).join(",")}]`;
+	}
+	if (typeof value === "object") {
+		const entries = Object.entries(value as Record<string, unknown>).sort(
+			([left], [right]) => left.localeCompare(right),
+		);
+		return `{${entries
+			.map(
+				([key, entryValue]) =>
+					`${JSON.stringify(key)}:${toStableJson(entryValue)}`,
+			)
+			.join(",")}}`;
+	}
+	return JSON.stringify(value);
+}
+
+function getToolCallSignature(part: { name: string; args: unknown }): string {
+	return `${part.name}:${toStableJson(part.args)}`;
+}
+
+function countPartKeys(parts: MastraMessage["content"]): Map<string, number> {
+	const counts = new Map<string, number>();
+	for (const part of parts) {
+		const key = toStableJson(part);
+		counts.set(key, (counts.get(key) ?? 0) + 1);
+	}
+	return counts;
+}
+
+function isContentSubset(
+	subset: MastraMessage["content"],
+	superset: MastraMessage["content"],
+): boolean {
+	if (subset.length > superset.length) return false;
+	const remaining = countPartKeys(superset);
+
+	for (const part of subset) {
+		const key = toStableJson(part);
+		const count = remaining.get(key) ?? 0;
+		if (count <= 0) return false;
+		if (count === 1) {
+			remaining.delete(key);
+		} else {
+			remaining.set(key, count - 1);
+		}
+	}
+
+	return true;
+}
+
+function pruneSubsumedAssistantMessages(messages: MastraMessage[]): {
+	messages: MastraMessage[];
+	droppedMessageIds: string[];
+} {
+	const droppedIndexes = new Set<number>();
+	const droppedMessageIds: string[] = [];
+
+	for (let index = 0; index < messages.length; index++) {
+		const current = messages[index];
+		if (!current || current.role !== "assistant") continue;
+
+		for (
+			let nextIndex = index + 1;
+			nextIndex < messages.length;
+			nextIndex += 1
+		) {
+			const next = messages[nextIndex];
+			if (!next) continue;
+
+			// Only compare assistant messages within the same turn.
+			if (next.role === "user") break;
+			if (next.role !== "assistant") continue;
+
+			if (!isContentSubset(current.content, next.content)) {
+				continue;
+			}
+
+			droppedIndexes.add(index);
+			droppedMessageIds.push(current.id);
+			break;
+		}
+	}
+
+	if (droppedIndexes.size === 0) {
+		return { messages, droppedMessageIds };
+	}
+
+	return {
+		messages: messages.filter((_, index) => !droppedIndexes.has(index)),
+		droppedMessageIds,
+	};
+}
+
 export function dedupeMessageToolParts(message: MastraMessage): {
 	message: MastraMessage;
 	droppedCount: number;
 } {
 	const toolCallIndexes = new Map<string, number>();
 	const toolResultIndexes = new Map<string, number>();
-	const dedupedContent: MastraMessage["content"] = [];
+	let dedupedContent: MastraMessage["content"] = [];
 	let droppedCount = 0;
 
 	for (const part of message.content) {
@@ -50,6 +147,59 @@ export function dedupeMessageToolParts(message: MastraMessage): {
 		}
 
 		dedupedContent.push(part);
+	}
+
+	const resolvedToolCallIds = new Set(
+		dedupedContent
+			.filter(
+				(
+					part,
+				): part is Extract<
+					MastraMessage["content"][number],
+					{ type: "tool_result" }
+				> => part.type === "tool_result",
+			)
+			.map((part) => part.id),
+	);
+
+	if (resolvedToolCallIds.size > 0) {
+		const resolvedToolSignatures = new Set(
+			dedupedContent
+				.filter(
+					(
+						part,
+					): part is Extract<
+						MastraMessage["content"][number],
+						{ type: "tool_call" }
+					> => part.type === "tool_call" && resolvedToolCallIds.has(part.id),
+				)
+				.map((part) => getToolCallSignature(part)),
+		);
+
+		if (resolvedToolSignatures.size > 0) {
+			const nextContent: MastraMessage["content"] = [];
+			for (const part of dedupedContent) {
+				if (part.type !== "tool_call") {
+					nextContent.push(part);
+					continue;
+				}
+
+				const hasMatchingResult = resolvedToolCallIds.has(part.id);
+				if (hasMatchingResult) {
+					nextContent.push(part);
+					continue;
+				}
+
+				const signature = getToolCallSignature(part);
+				if (resolvedToolSignatures.has(signature)) {
+					droppedCount += 1;
+					continue;
+				}
+
+				nextContent.push(part);
+			}
+			dedupedContent = nextContent;
+		}
 	}
 
 	if (droppedCount === 0) {
@@ -91,12 +241,21 @@ export function dedupeMessages(candidates: MastraMessage[]): {
 		}
 	}
 
+	const orderedByIdDedupedMessages = [...messagesById.values()];
+	const {
+		messages: prunedMessages,
+		droppedMessageIds: droppedSubsumedMessageIds,
+	} = pruneSubsumedAssistantMessages(orderedByIdDedupedMessages);
+	const allDroppedMessageIds = [
+		...new Set([...droppedMessageIds, ...droppedSubsumedMessageIds]),
+	];
+
 	return {
-		messages: [...messagesById.values()],
+		messages: prunedMessages,
 		summary: {
 			initialMessageCount: candidates.length,
-			finalMessageCount: messagesById.size,
-			droppedMessageIds,
+			finalMessageCount: prunedMessages.length,
+			droppedMessageIds: allDroppedMessageIds,
 			droppedToolPartCount,
 			droppedToolPartsByMessage,
 		},


### PR DESCRIPTION
## Summary
- fix chat-mastra message dedupe for mixed `messages` + `currentMessage` payloads where a merged assistant message coexists with earlier assistant fragments from the same turn
- drop assistant fragments when their content is fully subsumed by a later assistant message before the next user turn
- keep existing per-message tool part dedupe and add collapse of executing tool calls when an equivalent resolved call exists

## Why
In streaming transitions, the display can include both:
- an earlier assistant fragment containing tool calls/results, and
- a later merged assistant message with the same content plus final text.

ID-only dedupe cannot remove these because IDs differ, so duplicate tool blocks/text render in chat.

## Testing
- `bun test packages/chat-mastra/src/client/hooks/use-mastra-chat-display/hooks/use-messages/message-dedupe.test.ts`
- `bunx biome check packages/chat-mastra/src/client/hooks/use-mastra-chat-display/hooks/use-messages/message-dedupe.ts packages/chat-mastra/src/client/hooks/use-mastra-chat-display/hooks/use-messages/message-dedupe.test.ts`

Added regression tests for:
- resolved tool call vs matching executing duplicate
- subsumed assistant fragment pruning in the same turn
- no cross-turn pruning across user boundaries


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced message deduplication logic to properly prioritize resolved tool calls over duplicate executing ones and eliminate redundant assistant message fragments within conversations.

* **Tests**
  * Added comprehensive test coverage for message deduplication including resolved tool call handling, cross-message subsumption detection, and proper message ordering across conversation turns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->