### PR TITLE
desktop: clarify preset launch copy for current tab vs new tab

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/components/PresetEditorSheet/PresetEditorSheet.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/components/PresetEditorSheet/PresetEditorSheet.tsx
@@ -136,7 +136,7 @@ export function PresetEditorSheet({
 							<div className="space-y-2">
 								<LabelWithTooltip
 									label="Launch Mode"
-									tooltip="Controls whether commands open in the active tab, one new tab with panes, or one new tab per command."
+									tooltip="Controls whether commands open in the current tab, one new tab with panes, or one new tab per command."
 								/>
 								{hasMultipleCommands ? (
 									<div className="rounded-md border border-border p-3">
@@ -157,7 +157,7 @@ export function PresetEditorSheet({
 													htmlFor="preset-multi-command-split-pane"
 													className="text-sm font-medium"
 												>
-													Run all commands in one tab using split panes
+													Open all commands in current tab using split panes
 												</Label>
 											</div>
 											<div className="flex items-start gap-2">
@@ -170,7 +170,7 @@ export function PresetEditorSheet({
 													htmlFor="preset-multi-command-new-tab"
 													className="text-sm font-medium"
 												>
-													Open each command in its own tab
+													Open each command in its own new tab
 												</Label>
 											</div>
 											<div className="flex items-start gap-2">
@@ -199,8 +199,10 @@ export function PresetEditorSheet({
 											<SelectValue />
 										</SelectTrigger>
 										<SelectContent>
-											<SelectItem value="split-pane">Split Pane</SelectItem>
-											<SelectItem value="new-tab">New Tab</SelectItem>
+											<SelectItem value="split-pane">
+												Open in current tab
+											</SelectItem>
+											<SelectItem value="new-tab">Open in new tab</SelectItem>
 										</SelectContent>
 									</Select>
 								)}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar/components/PresetBarItem/PresetBarItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar/components/PresetBarItem/PresetBarItem.tsx
@@ -117,15 +117,15 @@ export function PresetBarItem({
 			<ContextMenuContent>
 				<ContextMenuItem
 					disabled={!canOpen}
-					onSelect={() => onOpenInNewTab(preset)}
+					onSelect={() => onOpenInPane(preset)}
 				>
-					Open in new tab
+					Open in current tab
 				</ContextMenuItem>
 				<ContextMenuItem
 					disabled={!canOpen}
-					onSelect={() => onOpenInPane(preset)}
+					onSelect={() => onOpenInNewTab(preset)}
 				>
-					Open in pane
+					Open in new tab
 				</ContextMenuItem>
 				<ContextMenuSeparator />
 				<ContextMenuItem onSelect={() => onEdit(preset)}>


### PR DESCRIPTION
## Summary\n- update terminal preset launch mode copy to explicitly use "current tab" vs "new tab"\n- update single-command mode labels to "Open in current tab" and "Open in new tab"\n- update presets bar context menu so the first action is "Open in current tab" and the second is "Open in new tab"\n\n## Testing\n- bunx biome check apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/components/PresetEditorSheet/PresetEditorSheet.tsx apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar/components/PresetBarItem/PresetBarItem.tsx\n\n## Notes\n- copy-only update, no behavior changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated preset launch mode labels and tooltips to use clearer, more consistent terminology for opening commands in the current tab versus new tabs. Improved consistency across editor and context menu interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->