### PR TITLE
feat(desktop): support latest Mastra tool aliases in chat UI

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/MastraToolCallBlock/MastraToolCallBlock.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/MastraToolCallBlock/MastraToolCallBlock.tsx
@@ -151,7 +151,9 @@ export function MastraToolCallBlock({
 
 	// --- Write file → FileDiffTool (write mode) ---
 	if (toolName === "mastra_workspace_write_file") {
-		const filePath = String(args.path ?? args.filePath ?? "");
+		const filePath = String(
+			args.path ?? args.filePath ?? args.relative_workspace_path ?? "",
+		);
 		const content = String(args.content ?? args.data ?? "");
 		return (
 			<FileDiffTool
@@ -165,9 +167,15 @@ export function MastraToolCallBlock({
 
 	// --- Edit file → FileDiffTool (diff mode) ---
 	if (toolName === "mastra_workspace_edit_file") {
-		const filePath = String(args.path ?? args.filePath ?? "");
-		const oldString = String(args.oldString ?? args.old_string ?? "");
-		const newString = String(args.newString ?? args.new_string ?? "");
+		const filePath = String(
+			args.path ?? args.filePath ?? args.relative_workspace_path ?? "",
+		);
+		const oldString = String(
+			args.oldString ?? args.old_string ?? args.old_str ?? "",
+		);
+		const newString = String(
+			args.newString ?? args.new_string ?? args.new_str ?? "",
+		);
 		return (
 			<FileDiffTool
 				filePath={filePath}
@@ -257,6 +265,22 @@ export function MastraToolCallBlock({
 		return (
 			<GenericToolCall part={part} toolName="Delete path" icon={FileIcon} />
 		);
+	}
+
+	if (toolName === "request_sandbox_access") {
+		return <GenericToolCall part={part} toolName="Request sandbox access" />;
+	}
+
+	if (toolName === "task_write") {
+		return <GenericToolCall part={part} toolName="Write task list" />;
+	}
+
+	if (toolName === "task_check") {
+		return <GenericToolCall part={part} toolName="Update task status" />;
+	}
+
+	if (toolName === "submit_plan") {
+		return <GenericToolCall part={part} toolName="Submit plan" />;
 	}
 
 	// --- Fallback: generic tool UI ---

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/utils/tool-helpers.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/utils/tool-helpers.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+import { normalizeToolName } from "./tool-helpers";
+
+describe("normalizeToolName", () => {
+	it("normalizes Mastra built-in tool names to supported render targets", () => {
+		expect(normalizeToolName("view")).toBe("mastra_workspace_read_file");
+		expect(normalizeToolName("search_content")).toBe("mastra_workspace_search");
+		expect(normalizeToolName("find_files")).toBe("mastra_workspace_list_files");
+		expect(normalizeToolName("write_file")).toBe("mastra_workspace_write_file");
+		expect(normalizeToolName("string_replace_lsp")).toBe(
+			"mastra_workspace_edit_file",
+		);
+		expect(normalizeToolName("execute_command")).toBe(
+			"mastra_workspace_execute_command",
+		);
+		expect(normalizeToolName("web_search")).toBe("web_search");
+		expect(normalizeToolName("web_extract")).toBe("web_fetch");
+		expect(normalizeToolName("ask_user")).toBe("ask_user_question");
+		expect(normalizeToolName("ast_smart_edit")).toBe("ast_smart_edit");
+		expect(normalizeToolName("request_sandbox_access")).toBe(
+			"request_sandbox_access",
+		);
+		expect(normalizeToolName("task_write")).toBe("task_write");
+		expect(normalizeToolName("task_check")).toBe("task_check");
+		expect(normalizeToolName("submit_plan")).toBe("submit_plan");
+	});
+
+	it("preserves unknown names", () => {
+		expect(normalizeToolName("some_future_tool")).toBe("some_future_tool");
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/utils/tool-helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/utils/tool-helpers.ts
@@ -7,10 +7,12 @@ type ToolPart = Extract<UIMessage["parts"][number], { type: `tool-${string}` }>;
 export type { ToolPart };
 
 const TOOL_NAME_ALIASES: Record<string, string> = {
+	// Mastra Code built-ins
 	execute_command: "mastra_workspace_execute_command",
 	run_command: "mastra_workspace_execute_command",
 	run_terminal_cmd: "mastra_workspace_execute_command",
 	write_file: "mastra_workspace_write_file",
+	string_replace_lsp: "mastra_workspace_edit_file",
 	edit_file: "mastra_workspace_edit_file",
 	read_file: "mastra_workspace_read_file",
 	view: "mastra_workspace_read_file",
@@ -22,6 +24,15 @@ const TOOL_NAME_ALIASES: Record<string, string> = {
 	index: "mastra_workspace_index",
 	mkdir: "mastra_workspace_mkdir",
 	delete: "mastra_workspace_delete",
+	web_extract: "web_fetch",
+	ask_user: "ask_user_question",
+
+	// Keep explicit passthroughs for newer Mastra tool names
+	ast_smart_edit: "ast_smart_edit",
+	request_sandbox_access: "request_sandbox_access",
+	task_write: "task_write",
+	task_check: "task_check",
+	submit_plan: "submit_plan",
 };
 
 export function normalizeToolName(toolName: string): string {


### PR DESCRIPTION
## Summary
- add Mastra tool alias mappings for newer built-ins (including `string_replace_lsp`, `web_extract`, `ask_user`, task/plan/sandbox tools)
- improve file tool argument parsing compatibility for LSP-style payload keys
- add focused tests for tool name normalization

## Testing
- bun test apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/utils/tool-helpers.test.ts
- bun run typecheck (in `apps/desktop`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new tool handlers: request_sandbox_access, task_write, task_check, and submit_plan for expanded workflow capabilities.

* **Improvements**
  * Enhanced file path resolution for workspace file operations with flexible fallback support.
  * Extended argument normalization for file editing with additional parameter aliases.

* **Tests**
  * Added test suite for tool name mapping and normalization functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->