### PR TITLE
fix(chat): keep conversation pinned to bottom on rerender

### DIFF
--- a/packages/ui/src/components/ai-elements/conversation.tsx
+++ b/packages/ui/src/components/ai-elements/conversation.tsx
@@ -13,7 +13,7 @@ export const Conversation = ({ className, ...props }: ConversationProps) => (
 	<StickToBottom
 		className={cn("relative flex-1 overflow-y-hidden", className)}
 		initial="instant"
-		resize="smooth"
+		resize="instant"
 		role="log"
 		{...props}
 	/>


### PR DESCRIPTION
## Summary
- switch shared ai-elements conversation wrapper resize behavior from `smooth` to `instant`
- preserve bottom anchoring while removing visible animated catch-up on rerenders/re-hydration
- applies to both desktop chat UIs that consume the shared `Conversation` primitive

## Testing
- bunx biome check packages/ui/src/components/ai-elements/conversation.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Modified the conversation component's resize behavior to provide instant updates instead of smooth animations. This improves responsiveness when the interface adjusts to different viewport sizes and content changes, delivering faster visual feedback during dynamic interactions. The change optimizes how the component responds to layout shifts and ensures smoother user experiences across various device configurations and content scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->