### PR TITLE
fix(desktop): replace all placeholder instances in notify-hook template

### DIFF
--- a/apps/desktop/src/main/lib/agent-setup/notify-hook.ts
+++ b/apps/desktop/src/main/lib/agent-setup/notify-hook.ts
@@ -40,8 +40,8 @@ export function getNotifyScriptPath(): string {
 export function getNotifyScriptContent(): string {
 	const template = fs.readFileSync(NOTIFY_SCRIPT_TEMPLATE_PATH, "utf-8");
 	return template
-		.replace("{{MARKER}}", NOTIFY_SCRIPT_MARKER)
-		.replace("{{DEFAULT_PORT}}", String(env.DESKTOP_NOTIFICATIONS_PORT));
+		.replaceAll("{{MARKER}}", NOTIFY_SCRIPT_MARKER)
+		.replaceAll("{{DEFAULT_PORT}}", String(env.DESKTOP_NOTIFICATIONS_PORT));
 }
 
 export function createNotifyScript(): void {


### PR DESCRIPTION
## Summary
- Fix `getNotifyScriptContent()` to use `replaceAll()` instead of `replace()` for template placeholders
- The template has two `{{DEFAULT_PORT}}` instances (debug and non-debug curl branches), but `replace()` only substituted the first one
- This caused the generated `notify.sh` to fail, breaking Claude Code hooks

## Test plan
- [x] Verify both `{{DEFAULT_PORT}}` placeholders in template are replaced in generated script
- [x] Confirm hook notifications work in both debug and production modes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where notification configuration was not fully applied in certain scenarios, ensuring all necessary replacements are properly processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->