### PR TITLE
fix(desktop): preserve user shell wrappers while keeping Superset hooks

### DIFF
--- a/apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdirSync, readFileSync, rmSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { chmodSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
@@ -45,6 +46,7 @@ describe("shell-wrappers", () => {
 		expect(zshenv).toContain(`export ZDOTDIR="${TEST_ZSH_DIR}"`);
 
 		expect(zshrc).toContain("_superset_prepend_bin()");
+		expect(zshrc).toContain("if ! typeset -f claude > /dev/null 2>&1; then");
 		expect(zshrc).toContain(`claude() { "${TEST_BIN_DIR}/claude" "$@"; }`);
 		expect(zshrc).toContain(`codex() { "${TEST_BIN_DIR}/codex" "$@"; }`);
 		expect(zshrc).toContain(`opencode() { "${TEST_BIN_DIR}/opencode" "$@"; }`);
@@ -54,6 +56,7 @@ describe("shell-wrappers", () => {
 		expect(zlogin).toContain("if [[ -o interactive ]]; then");
 		expect(zlogin).toContain('source "$_superset_home/.zlogin"');
 		expect(zlogin).toContain("_superset_prepend_bin()");
+		expect(zlogin).toContain("if ! typeset -f claude > /dev/null 2>&1; then");
 		expect(zlogin).toContain(`claude() { "${TEST_BIN_DIR}/claude" "$@"; }`);
 		expect(zlogin).toContain(`copilot() { "${TEST_BIN_DIR}/copilot" "$@"; }`);
 		expect(zlogin).toContain("rehash 2>/dev/null || true");
@@ -64,11 +67,50 @@ describe("shell-wrappers", () => {
 
 		const rcfile = readFileSync(path.join(TEST_BASH_DIR, "rcfile"), "utf-8");
 		expect(rcfile).toContain("_superset_prepend_bin()");
+		expect(rcfile).toContain("if ! typeset -f claude > /dev/null 2>&1; then");
 		expect(rcfile).toContain(`claude() { "${TEST_BIN_DIR}/claude" "$@"; }`);
 		expect(rcfile).toContain(`codex() { "${TEST_BIN_DIR}/codex" "$@"; }`);
 		expect(rcfile).toContain(`opencode() { "${TEST_BIN_DIR}/opencode" "$@"; }`);
 		expect(rcfile).toContain(`copilot() { "${TEST_BIN_DIR}/copilot" "$@"; }`);
 		expect(rcfile).toContain("hash -r 2>/dev/null || true");
+	});
+
+	it("preserves user-defined bash wrappers and still reaches Superset binary via command", () => {
+		createBashWrapper(TEST_PATHS);
+
+		const homeDir = path.join(TEST_ROOT, "home");
+		const markerFile = path.join(TEST_ROOT, "claude-args.txt");
+		const userBashrcPath = path.join(homeDir, ".bashrc");
+		const wrapperBinaryPath = path.join(TEST_BIN_DIR, "claude");
+		const rcfilePath = path.join(TEST_BASH_DIR, "rcfile");
+
+		mkdirSync(homeDir, { recursive: true });
+		writeFileSync(
+			userBashrcPath,
+			'claude() { AWS_PROFILE="$BEDROCK_AWS_PROFILE" command claude "$@"; }\n',
+		);
+		writeFileSync(
+			wrapperBinaryPath,
+			'#!/bin/bash\nprintf \'%s\\n\' "$@" > "$SUPERSET_WRAPPER_ARGS_FILE"\n',
+			{ mode: 0o755 },
+		);
+		chmodSync(wrapperBinaryPath, 0o755);
+
+		execFileSync(
+			"bash",
+			["-c", `source "${rcfilePath}" && claude "from-user-wrapper"`],
+			{
+				env: {
+					...process.env,
+					BEDROCK_AWS_PROFILE: "bedrock-profile",
+					HOME: homeDir,
+					PATH: `${TEST_BIN_DIR}:${process.env.PATH || ""}`,
+					SUPERSET_WRAPPER_ARGS_FILE: markerFile,
+				},
+			},
+		);
+
+		expect(readFileSync(markerFile, "utf-8").trim()).toBe("from-user-wrapper");
 	});
 
 	it("uses login zsh command args when wrappers exist", () => {

--- a/apps/desktop/src/main/lib/agent-setup/shell-wrappers.ts
+++ b/apps/desktop/src/main/lib/agent-setup/shell-wrappers.ts
@@ -53,10 +53,16 @@ const SHIMMED_BINARIES = ["claude", "codex", "opencode", "gemini", "copilot"];
  * Functions take precedence over PATH in both zsh and bash,
  * so even if a precmd hook or .zlogin re-orders PATH, the
  * wrapped binary is always invoked.
+ *
+ * To preserve user-defined wrappers (e.g. env setup functions),
+ * only install a shim when the function is not already defined.
+ * User wrappers can delegate via `command <name>` and still reach
+ * Superset's binary wrapper through PATH.
  */
 function buildShimFunctions(binDir: string): string {
 	return SHIMMED_BINARIES.map(
-		(name) => `${name}() { "${binDir}/${name}" "$@"; }`,
+		(name) =>
+			`if ! typeset -f ${name} > /dev/null 2>&1; then\n  ${name}() { "${binDir}/${name}" "$@"; }\nfi`,
 	).join("\n");
 }
 


### PR DESCRIPTION
## Summary
- guard shell function shims with `typeset -f` so Superset does not override user-defined wrappers from `.bashrc`/`.zshrc`
- keep the BIN_DIR PATH prepend behavior so wrappers that delegate with `command <agent>` still resolve to Superset wrapper binaries
- add a behavioral bash test proving user wrappers are preserved while still reaching the Superset wrapper path

## Testing
- bun test apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts

Closes #1812


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shell wrapper installation now respects existing user-defined wrappers instead of overwriting them. User wrappers are preserved while maintaining access to the Superset binary through the system PATH.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->