### PR TITLE
perf(desktop): reduce startup chat preload and title sync fanout

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/CollectionsProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/CollectionsProvider.tsx
@@ -49,7 +49,7 @@ export function CollectionsProvider({ children }: { children: ReactNode }) {
 	useEffect(() => {
 		if (!organizationIds) return;
 		for (const orgId of organizationIds) {
-			preloadCollections(orgId);
+			preloadCollections(orgId, { includeChatCollections: false });
 		}
 	}, [organizationIds]);
 

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
@@ -374,12 +374,19 @@ function createOrgCollections(organizationId: string): OrgCollections {
  */
 export async function preloadCollections(
 	organizationId: string,
+	options?: {
+		includeChatCollections?: boolean;
+	},
 ): Promise<void> {
-	const { organizations, ...orgCollections } = getCollections(organizationId);
+	const { organizations, chatSessions, sessionHosts, ...orgCollections } =
+		getCollections(organizationId);
+	const includeChatCollections = options?.includeChatCollections ?? true;
+	const collectionsToPreload = includeChatCollections
+		? [...Object.values(orgCollections), chatSessions, sessionHosts]
+		: Object.values(orgCollections);
+
 	await Promise.allSettled(
-		Object.values(orgCollections).map((c) =>
-			(c as Collection<object>).preload(),
-		),
+		collectionsToPreload.map((c) => (c as Collection<object>).preload()),
 	);
 }
 


### PR DESCRIPTION
## Summary
- reduce background startup preload fanout by skipping chat collections (`chatSessions`, `sessionHosts`) during multi-org eager preload
- preserve org-switch behavior by keeping full preload (including chat collections) when switching organizations
- scope GroupStrip chat title sync query to active workspace and only when chat tabs exist

## Why
Recent startup reports point to background work happening before chat panes are opened. This keeps chat behavior intact while reducing always-on startup subscriptions/work.

## Behavior
- Chat tab titles still sync reactively for chat tabs in the active workspace.
- Switching orgs still preloads full collections for the target org.

## Validation
- `bunx biome check` on modified files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chat session title synchronization to occur only within active workspace context, preventing cross-workspace data inconsistencies.

* **Performance**
  * Optimized collection preloading to reduce initial data fetch overhead by refining which collection types are loaded upfront.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->