### PR TITLE
Allow dedup if branch name already exists

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/init.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/init.ts
@@ -1,12 +1,111 @@
+import { workspaces, worktrees } from "@superset/local-db";
 import { observable } from "@trpc/server/observable";
+import { eq } from "drizzle-orm";
+import { localDb } from "main/lib/local-db";
 import { workspaceInitManager } from "main/lib/workspace-init-manager";
 import type { WorkspaceInitProgress } from "shared/types/workspace-init";
+import { deduplicateBranchName } from "shared/utils/branch";
 import { z } from "zod";
 import { publicProcedure, router } from "../../..";
 import { getPresetsForTrigger } from "../../settings";
 import { getProject, getWorkspaceWithRelations } from "../utils/db-helpers";
+import { listBranches } from "../utils/git";
+import { resolveWorktreePath } from "../utils/resolve-worktree-path";
 import { loadSetupConfig } from "../utils/setup";
 import { initializeWorkspaceWorktree } from "../utils/workspace-init";
+
+type WorkspaceRelations = NonNullable<
+	ReturnType<typeof getWorkspaceWithRelations>
+>;
+
+function getRetryInitRelations(workspaceId: string): {
+	workspace: WorkspaceRelations["workspace"];
+	worktree: NonNullable<WorkspaceRelations["worktree"]>;
+	project: NonNullable<WorkspaceRelations["project"]>;
+} {
+	const relations = getWorkspaceWithRelations(workspaceId);
+	if (!relations) {
+		throw new Error("Workspace not found");
+	}
+
+	const { workspace, worktree, project } = relations;
+	if (workspace.deletingAt) {
+		throw new Error("Cannot retry initialization on a workspace being deleted");
+	}
+	if (!worktree) {
+		throw new Error("Worktree not found");
+	}
+	if (!project) {
+		throw new Error("Project not found");
+	}
+
+	return { workspace, worktree, project };
+}
+
+function persistRetryBranchUpdate({
+	workspace,
+	worktreeId,
+	branch,
+	path,
+}: {
+	workspace: WorkspaceRelations["workspace"];
+	worktreeId: string;
+	branch: string;
+	path: string;
+}): void {
+	localDb
+		.update(worktrees)
+		.set({ branch, path })
+		.where(eq(worktrees.id, worktreeId))
+		.run();
+
+	localDb
+		.update(workspaces)
+		.set({
+			branch,
+			...(workspace.isUnnamed ? { name: branch } : {}),
+		})
+		.where(eq(workspaces.id, workspace.id))
+		.run();
+}
+
+async function resolveRetryTarget({
+	workspace,
+	worktree,
+	project,
+	deduplicateBranchName: shouldDeduplicateBranchName,
+}: {
+	workspace: WorkspaceRelations["workspace"];
+	worktree: NonNullable<WorkspaceRelations["worktree"]>;
+	project: NonNullable<WorkspaceRelations["project"]>;
+	deduplicateBranchName: boolean;
+}): Promise<{ branch: string; worktreePath: string }> {
+	const currentBranch = worktree.branch;
+	const currentPath = worktree.path;
+
+	if (!shouldDeduplicateBranchName) {
+		return { branch: currentBranch, worktreePath: currentPath };
+	}
+
+	const { local, remote } = await listBranches(project.mainRepoPath);
+	const deduplicatedBranch = deduplicateBranchName(currentBranch, [
+		...local,
+		...remote,
+	]);
+	if (deduplicatedBranch === currentBranch) {
+		return { branch: currentBranch, worktreePath: currentPath };
+	}
+
+	const deduplicatedPath = resolveWorktreePath(project, deduplicatedBranch);
+	persistRetryBranchUpdate({
+		workspace,
+		worktreeId: worktree.id,
+		branch: deduplicatedBranch,
+		path: deduplicatedPath,
+	});
+
+	return { branch: deduplicatedBranch, worktreePath: deduplicatedPath };
+}
 
 export const createInitProcedures = () => {
 	return router({
@@ -44,29 +143,22 @@ export const createInitProcedures = () => {
 			}),
 
 		retryInit: publicProcedure
-			.input(z.object({ workspaceId: z.string() }))
+			.input(
+				z.object({
+					workspaceId: z.string(),
+					deduplicateBranchName: z.boolean().optional().default(false),
+				}),
+			)
 			.mutation(async ({ input }) => {
-				const relations = getWorkspaceWithRelations(input.workspaceId);
-
-				if (!relations) {
-					throw new Error("Workspace not found");
-				}
-
-				const { workspace, worktree, project } = relations;
-
-				if (workspace.deletingAt) {
-					throw new Error(
-						"Cannot retry initialization on a workspace being deleted",
-					);
-				}
-
-				if (!worktree) {
-					throw new Error("Worktree not found");
-				}
-
-				if (!project) {
-					throw new Error("Project not found");
-				}
+				const { workspace, worktree, project } = getRetryInitRelations(
+					input.workspaceId,
+				);
+				const { branch, worktreePath } = await resolveRetryTarget({
+					workspace,
+					worktree,
+					project,
+					deduplicateBranchName: input.deduplicateBranchName,
+				});
 
 				workspaceInitManager.clearJob(input.workspaceId);
 				workspaceInitManager.startJob(input.workspaceId, workspace.projectId);
@@ -75,8 +167,8 @@ export const createInitProcedures = () => {
 					workspaceId: input.workspaceId,
 					projectId: workspace.projectId,
 					worktreeId: worktree.id,
-					worktreePath: worktree.path,
-					branch: worktree.branch,
+					worktreePath,
+					branch,
 					mainRepoPath: project.mainRepoPath,
 				});
 

--- a/apps/desktop/src/shared/utils/branch.test.ts
+++ b/apps/desktop/src/shared/utils/branch.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+	deduplicateBranchName,
 	sanitizeAuthorPrefix,
 	sanitizeBranchName,
 	sanitizeSegment,
@@ -134,5 +135,45 @@ describe("sanitizeBranchName", () => {
 
 	test("handles only slashes", () => {
 		expect(sanitizeBranchName("///")).toBe("");
+	});
+});
+
+describe("deduplicateBranchName", () => {
+	test("returns candidate when no collision exists", () => {
+		expect(deduplicateBranchName("feature/test", ["main", "develop"])).toBe(
+			"feature/test",
+		);
+	});
+
+	test("appends numeric suffix when branch exists", () => {
+		expect(deduplicateBranchName("feature/test", ["feature/test"])).toBe(
+			"feature/test-1",
+		);
+	});
+
+	test("increments suffix to next available value", () => {
+		expect(
+			deduplicateBranchName("feature/test", [
+				"feature/test",
+				"feature/test-1",
+				"feature/test-2",
+			]),
+		).toBe("feature/test-3");
+	});
+
+	test("treats existing names case-insensitively", () => {
+		expect(deduplicateBranchName("Feature/Test", ["feature/test"])).toBe(
+			"Feature/Test-1",
+		);
+	});
+
+	test("reuses base segment when candidate already ends with a suffix", () => {
+		expect(
+			deduplicateBranchName("feature/test-2", [
+				"feature/test",
+				"feature/test-1",
+				"feature/test-2",
+			]),
+		).toBe("feature/test-3");
 	});
 });

--- a/bun.lock
+++ b/bun.lock
@@ -108,7 +108,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "0.0.86",
+      "version": "0.0.88",
       "dependencies": {
         "@ai-sdk/react": "^3.0.0",
         "@ast-grep/napi": "^0.41.0",


### PR DESCRIPTION
- **Dedup branch name**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic branch name deduplication during workspace initialization. When a duplicate branch name is detected, users can now retry initialization with an automatically deduplicated branch name.
  * New "Retry With Deduplicated Branch" button appears in initialization failure screens when duplicate branch errors occur.

* **Tests**
  * Added test coverage for branch name deduplication logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->