### PR TITLE
fix(desktop): prioritize remote setup config when creating workspaces

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
@@ -36,7 +36,11 @@ import {
 	worktreeExists,
 } from "../utils/git";
 import { resolveWorktreePath } from "../utils/resolve-worktree-path";
-import { copySupersetConfigToWorktree, loadSetupConfig } from "../utils/setup";
+import {
+	copySupersetConfigToWorktree,
+	loadSetupConfig,
+	loadSetupConfigForPendingWorktree,
+} from "../utils/setup";
 import { initializeWorkspaceWorktree } from "../utils/workspace-init";
 
 interface CreateWorkspaceFromWorktreeParams {
@@ -489,10 +493,14 @@ export const createCreateProcedures = () => {
 					useExistingBranch: input.useExistingBranch,
 				});
 
-				const setupConfig = loadSetupConfig({
+				const setupSourceBranch = input.useExistingBranch
+					? branch
+					: targetBranch;
+				const setupConfig = await loadSetupConfigForPendingWorktree({
 					mainRepoPath: project.mainRepoPath,
 					worktreePath,
 					projectId: project.id,
+					sourceBranch: setupSourceBranch,
 				});
 
 				return {

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/setup.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/setup.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { PROJECTS_DIR_NAME, SUPERSET_DIR_NAME } from "shared/constants";
-import { loadSetupConfig } from "./setup";
+import { loadSetupConfig, loadSetupConfigForPendingWorktree } from "./setup";
 
 const TEST_DIR = join(tmpdir(), `superset-test-setup-${process.pid}`);
 const MAIN_REPO = join(TEST_DIR, "main-repo");
@@ -224,5 +225,88 @@ describe("loadSetupConfig", () => {
 			projectId: PROJECT_ID,
 		});
 		expect(config).toEqual(mainConfig);
+	});
+
+	test("pending worktree resolution prefers remote branch config over stale local main", async () => {
+		const gitDir = join(TEST_DIR, "git-remote-priority");
+		const localRepo = join(gitDir, "local-repo");
+		const remoteRepo = join(gitDir, "origin.git");
+		const upstreamClone = join(gitDir, "upstream-clone");
+		const pendingWorktreePath = join(gitDir, "pending-worktree");
+		const remoteConfig = { setup: ["echo remote-setup"] };
+
+		mkdirSync(gitDir, { recursive: true });
+
+		execFileSync("git", ["init", "--bare", remoteRepo], { stdio: "pipe" });
+
+		mkdirSync(localRepo, { recursive: true });
+		execFileSync("git", ["init", "-b", "main"], {
+			cwd: localRepo,
+			stdio: "pipe",
+		});
+		execFileSync("git", ["config", "user.email", "setup-test@example.com"], {
+			cwd: localRepo,
+			stdio: "pipe",
+		});
+		execFileSync("git", ["config", "user.name", "Setup Test"], {
+			cwd: localRepo,
+			stdio: "pipe",
+		});
+		writeFileSync(join(localRepo, "README.md"), "initial\n");
+		execFileSync("git", ["add", "README.md"], {
+			cwd: localRepo,
+			stdio: "pipe",
+		});
+		execFileSync("git", ["commit", "-m", "initial"], {
+			cwd: localRepo,
+			stdio: "pipe",
+		});
+		execFileSync("git", ["remote", "add", "origin", remoteRepo], {
+			cwd: localRepo,
+			stdio: "pipe",
+		});
+		execFileSync("git", ["push", "-u", "origin", "main"], {
+			cwd: localRepo,
+			stdio: "pipe",
+		});
+
+		execFileSync("git", ["clone", remoteRepo, upstreamClone], {
+			stdio: "pipe",
+		});
+		execFileSync("git", ["config", "user.email", "setup-test@example.com"], {
+			cwd: upstreamClone,
+			stdio: "pipe",
+		});
+		execFileSync("git", ["config", "user.name", "Setup Test"], {
+			cwd: upstreamClone,
+			stdio: "pipe",
+		});
+		mkdirSync(join(upstreamClone, ".superset"), { recursive: true });
+		writeFileSync(
+			join(upstreamClone, ".superset", "config.json"),
+			JSON.stringify(remoteConfig),
+		);
+		execFileSync("git", ["add", ".superset/config.json"], {
+			cwd: upstreamClone,
+			stdio: "pipe",
+		});
+		execFileSync("git", ["commit", "-m", "add setup config"], {
+			cwd: upstreamClone,
+			stdio: "pipe",
+		});
+		execFileSync("git", ["push", "origin", "main"], {
+			cwd: upstreamClone,
+			stdio: "pipe",
+		});
+
+		expect(existsSync(join(localRepo, ".superset", "config.json"))).toBe(false);
+
+		const config = await loadSetupConfigForPendingWorktree({
+			mainRepoPath: localRepo,
+			worktreePath: pendingWorktreePath,
+			sourceBranch: "main",
+		});
+
+		expect(config).toEqual(remoteConfig);
 	});
 });

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/setup.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/setup.ts
@@ -1,6 +1,8 @@
+import { execFile } from "node:child_process";
 import { cpSync, existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { promisify } from "node:util";
 import {
 	CONFIG_FILE_NAME,
 	PROJECT_SUPERSET_DIR_NAME,
@@ -8,6 +10,10 @@ import {
 	SUPERSET_DIR_NAME,
 } from "shared/constants";
 import type { SetupConfig } from "shared/types";
+import { fetchDefaultBranch } from "./git";
+
+const execFileAsync = promisify(execFile);
+const CONFIG_RELATIVE_PATH = `${PROJECT_SUPERSET_DIR_NAME}/${CONFIG_FILE_NAME}`;
 
 /**
  * Worktrees don't include gitignored files, so copy .superset from main repo
@@ -38,17 +44,7 @@ function readConfigFile(configPath: string): SetupConfig | null {
 
 	try {
 		const content = readFileSync(configPath, "utf-8");
-		const parsed = JSON.parse(content) as SetupConfig;
-
-		if (parsed.setup && !Array.isArray(parsed.setup)) {
-			throw new Error("'setup' field must be an array of strings");
-		}
-
-		if (parsed.teardown && !Array.isArray(parsed.teardown)) {
-			throw new Error("'teardown' field must be an array of strings");
-		}
-
-		return parsed;
+		return parseSetupConfig(content);
 	} catch (error) {
 		console.error(
 			`Failed to read setup config at ${configPath}: ${error instanceof Error ? error.message : String(error)}`,
@@ -57,10 +53,64 @@ function readConfigFile(configPath: string): SetupConfig | null {
 	}
 }
 
+function parseSetupConfig(content: string): SetupConfig {
+	const parsed = JSON.parse(content) as SetupConfig;
+
+	if (parsed.setup && !Array.isArray(parsed.setup)) {
+		throw new Error("'setup' field must be an array of strings");
+	}
+
+	if (parsed.teardown && !Array.isArray(parsed.teardown)) {
+		throw new Error("'teardown' field must be an array of strings");
+	}
+
+	return parsed;
+}
+
 function readConfigFromPath(basePath: string): SetupConfig | null {
-	return readConfigFile(
-		join(basePath, PROJECT_SUPERSET_DIR_NAME, CONFIG_FILE_NAME),
+	return readConfigFile(join(basePath, CONFIG_RELATIVE_PATH));
+}
+
+function readUserOverrideConfig(projectId?: string): SetupConfig | null {
+	if (!projectId || projectId.includes("/") || projectId.includes("\\")) {
+		return null;
+	}
+
+	const userConfigPath = join(
+		homedir(),
+		SUPERSET_DIR_NAME,
+		PROJECTS_DIR_NAME,
+		projectId,
+		CONFIG_FILE_NAME,
 	);
+	const config = readConfigFile(userConfigPath);
+	if (config) {
+		console.log(`[setup] Using user override config from ${userConfigPath}`);
+	}
+	return config;
+}
+
+async function readConfigFromGitRef(
+	mainRepoPath: string,
+	ref: string,
+): Promise<SetupConfig | null> {
+	try {
+		const { stdout } = await execFileAsync(
+			"git",
+			["-C", mainRepoPath, "show", `${ref}:${CONFIG_RELATIVE_PATH}`],
+			{ timeout: 15_000 },
+		);
+		const config = parseSetupConfig(stdout);
+		console.log(
+			`[setup] Using git ref config from ${ref}:${CONFIG_RELATIVE_PATH}`,
+		);
+		return config;
+	} catch (error) {
+		console.warn(
+			`[setup] Could not read config from git ref ${ref}: ${error instanceof Error ? error.message : String(error)}`,
+		);
+		return null;
+	}
 }
 
 /**
@@ -80,26 +130,16 @@ export function loadSetupConfig({
 	worktreePath?: string;
 	projectId?: string;
 }): SetupConfig | null {
-	if (projectId && !projectId.includes("/") && !projectId.includes("\\")) {
-		const userConfigPath = join(
-			homedir(),
-			SUPERSET_DIR_NAME,
-			PROJECTS_DIR_NAME,
-			projectId,
-			CONFIG_FILE_NAME,
-		);
-		const config = readConfigFile(userConfigPath);
-		if (config) {
-			console.log(`[setup] Using user override config from ${userConfigPath}`);
-			return config;
-		}
+	const userConfig = readUserOverrideConfig(projectId);
+	if (userConfig) {
+		return userConfig;
 	}
 
 	if (worktreePath) {
 		const config = readConfigFromPath(worktreePath);
 		if (config) {
 			console.log(
-				`[setup] Using worktree config from ${join(worktreePath, PROJECT_SUPERSET_DIR_NAME, CONFIG_FILE_NAME)}`,
+				`[setup] Using worktree config from ${join(worktreePath, CONFIG_RELATIVE_PATH)}`,
 			);
 			return config;
 		}
@@ -108,8 +148,79 @@ export function loadSetupConfig({
 	const config = readConfigFromPath(mainRepoPath);
 	if (config) {
 		console.log(
-			`[setup] Using main repo config from ${join(mainRepoPath, PROJECT_SUPERSET_DIR_NAME, CONFIG_FILE_NAME)}`,
+			`[setup] Using main repo config from ${join(mainRepoPath, CONFIG_RELATIVE_PATH)}`,
 		);
 	}
 	return config;
+}
+
+/**
+ * Resolves setup/teardown config for workspace creation before the worktree
+ * has been materialized on disk.
+ *
+ * Priority:
+ *   1. User override
+ *   2. Existing worktree (if already present)
+ *   3. Remote source branch ref (origin/<branch>)
+ *   4. Local source branch ref (<branch>)
+ *   5. Main repo working tree
+ */
+export async function loadSetupConfigForPendingWorktree({
+	mainRepoPath,
+	worktreePath,
+	projectId,
+	sourceBranch,
+}: {
+	mainRepoPath: string;
+	worktreePath: string;
+	projectId?: string;
+	sourceBranch: string;
+}): Promise<SetupConfig | null> {
+	const userConfig = readUserOverrideConfig(projectId);
+	if (userConfig) {
+		return userConfig;
+	}
+
+	if (existsSync(worktreePath)) {
+		const config = readConfigFromPath(worktreePath);
+		if (config) {
+			console.log(
+				`[setup] Using worktree config from ${join(worktreePath, CONFIG_RELATIVE_PATH)}`,
+			);
+			return config;
+		}
+	}
+
+	try {
+		await fetchDefaultBranch(mainRepoPath, sourceBranch);
+	} catch (error) {
+		console.warn(
+			`[setup] Failed to fetch origin/${sourceBranch} before reading setup config: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+
+	const remoteConfig = await readConfigFromGitRef(
+		mainRepoPath,
+		`origin/${sourceBranch}`,
+	);
+	if (remoteConfig) {
+		return remoteConfig;
+	}
+
+	const localBranchConfig = await readConfigFromGitRef(
+		mainRepoPath,
+		sourceBranch,
+	);
+	if (localBranchConfig) {
+		return localBranchConfig;
+	}
+
+	const mainConfig = readConfigFromPath(mainRepoPath);
+	if (mainConfig) {
+		console.log(
+			`[setup] Using main repo config from ${join(mainRepoPath, CONFIG_RELATIVE_PATH)}`,
+		);
+	}
+
+	return mainConfig;
 }


### PR DESCRIPTION
## Summary\n- fix setup-script config resolution during workspace creation when the worktree does not exist yet\n- add a pending-worktree config resolver that checks user override, then remote/local branch refs, then local main working tree\n- wire  to use the pending resolver so stale local  does not suppress setup scripts\n- add regression test reproducing stale local main + updated remote config\n\n## Root Cause\n resolved setup commands before the new worktree was materialized, so worktree config was unreadable and resolution could fall back to stale local main checkout.\n\n## Validation\n- bun test v1.3.9 (cf6cdbbb)
[setup] Using main repo config from /var/folders/6p/h3cw025x0z38clvxby6gqylh0000gn/T/superset-test-setup-47576/main-repo/.superset/config.json
[setup] Using worktree config from /var/folders/6p/h3cw025x0z38clvxby6gqylh0000gn/T/superset-test-setup-47576/worktree/.superset/config.json
[setup] Using main repo config from /var/folders/6p/h3cw025x0z38clvxby6gqylh0000gn/T/superset-test-setup-47576/main-repo/.superset/config.json
[setup] Using user override config from /Users/kietho/.superset-fix-setup-script-priority/projects/test-project-id/config.json
[setup] Using user override config from /Users/kietho/.superset-fix-setup-script-priority/projects/test-project-id/config.json
[setup] Using main repo config from /var/folders/6p/h3cw025x0z38clvxby6gqylh0000gn/T/superset-test-setup-47576/main-repo/.superset/config.json
[setup] Using main repo config from /var/folders/6p/h3cw025x0z38clvxby6gqylh0000gn/T/superset-test-setup-47576/main-repo/.superset/config.json
[setup] Using user override config from /Users/kietho/.superset-fix-setup-script-priority/projects/test-project-id/config.json
[setup] Using main repo config from /var/folders/6p/h3cw025x0z38clvxby6gqylh0000gn/T/superset-test-setup-47576/main-repo/.superset/config.json
[setup] Using git ref config from origin/main:.superset/config.json\n- \n- Checked 2039 files in 542ms. No fixes applied.\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved workspace setup configuration handling for pending worktrees to prioritize remote branch configurations over stale local versions, ensuring more reliable initialization and proper base branch context selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->