### PR TITLE
Add Cmd+Shift+W to close active tab

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -132,6 +132,7 @@ function WorkspacePage() {
 	const reopenClosedTab = useTabsStore((s) => s.reopenClosedTab);
 	const addBrowserTab = useTabsStore((s) => s.addBrowserTab);
 	const setActiveTab = useTabsStore((s) => s.setActiveTab);
+	const removeTab = useTabsStore((s) => s.removeTab);
 	const removePane = useTabsStore((s) => s.removePane);
 	const setFocusedPane = useTabsStore((s) => s.setFocusedPane);
 	const toggleSidebar = useSidebarStore((s) => s.toggleSidebar);
@@ -208,6 +209,16 @@ function WorkspacePage() {
 		},
 		undefined,
 		[focusedPaneId, removePane],
+	);
+	useAppHotkey(
+		"CLOSE_TAB",
+		() => {
+			if (activeTabId) {
+				removeTab(activeTabId);
+			}
+		},
+		undefined,
+		[activeTabId, removeTab],
 	);
 
 	useAppHotkey(

--- a/apps/desktop/src/shared/hotkeys.ts
+++ b/apps/desktop/src/shared/hotkeys.ts
@@ -539,6 +539,12 @@ export const HOTKEYS = {
 		label: "Close Terminal",
 		category: "Terminal",
 	}),
+	CLOSE_TAB: defineHotkey({
+		keys: "meta+shift+w",
+		label: "Close Tab",
+		category: "Terminal",
+		description: "Close the current tab",
+	}),
 	CLEAR_TERMINAL: defineHotkey({
 		keys: "meta+k",
 		label: "Clear Terminal",
@@ -713,7 +719,7 @@ export const HOTKEYS = {
 		isHidden: true,
 	}),
 	CLOSE_WINDOW: defineHotkey({
-		keys: "meta+shift+w",
+		keys: "meta+shift+q",
 		label: "Close Window",
 		category: "Window",
 	}),

--- a/apps/docs/content/docs/keyboard-shortcuts.mdx
+++ b/apps/docs/content/docs/keyboard-shortcuts.mdx
@@ -35,6 +35,7 @@ description: Customize hotkeys for common actions
 | Action | Shortcut |
 |--------|----------|
 | New Tab | ⌘T |
+| Close Tab | ⌘⇧W |
 | Close Terminal | ⌘W |
 | Clear Terminal | ⌘K |
 | Find in Terminal | ⌘F |
@@ -51,7 +52,7 @@ description: Customize hotkeys for common actions
 |--------|----------|
 | Open in App | ⌘O |
 | Copy Path | ⌘⇧C |
-| Close Window | ⌘⇧W |
+| Close Window | ⌘⇧Q |
 | Show Keyboard Shortcuts | ⌘/ |
 
 ## Customize


### PR DESCRIPTION
## Summary
- add a new `CLOSE_TAB` hotkey bound to `Cmd+Shift+W`
- handle `CLOSE_TAB` in the workspace route by closing the active tab
- move `CLOSE_WINDOW` to `Cmd+Shift+Q` to avoid chord conflicts
- update keyboard shortcut docs to match

## Validation
- `bun run lint:fix`
- `bun test apps/desktop/src/shared/hotkeys.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Close Tab" keyboard shortcut (⌘⇧W) for closing the current tab within your workspace.
  * Reassigned "Close Window" keyboard shortcut from ⌘⇧W to ⌘⇧Q.

* **Documentation**
  * Updated keyboard shortcuts documentation to reflect the new "Close Tab" and modified "Close Window" keyboard bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->