### PR TITLE
feat(api): route @superset.sh users to Electric Cloud

### DIFF
--- a/apps/api/src/app/api/electric/[...path]/route.ts
+++ b/apps/api/src/app/api/electric/[...path]/route.ts
@@ -25,9 +25,10 @@ export async function GET(request: Request): Promise<Response> {
 	}
 
 	const useCloud =
-		request.headers.get("x-electric-backend") === "cloud" &&
 		env.ELECTRIC_SOURCE_ID &&
-		env.ELECTRIC_SOURCE_SECRET;
+		env.ELECTRIC_SOURCE_SECRET &&
+		(request.headers.get("x-electric-backend") === "cloud" ||
+			sessionData.user.email?.endsWith("@superset.sh"));
 
 	const originUrl = useCloud
 		? new URL("/v1/shape", "https://api.electric-sql.cloud")
@@ -37,7 +38,7 @@ export async function GET(request: Request): Promise<Response> {
 		// biome-ignore lint/style/noNonNullAssertion: guarded by useCloud check above
 		originUrl.searchParams.set("source_id", env.ELECTRIC_SOURCE_ID!);
 		// biome-ignore lint/style/noNonNullAssertion: guarded by useCloud check above
-		originUrl.searchParams.set("source_secret", env.ELECTRIC_SOURCE_SECRET!);
+		originUrl.searchParams.set("secret", env.ELECTRIC_SOURCE_SECRET!);
 	} else {
 		originUrl.searchParams.set("secret", env.ELECTRIC_SECRET);
 	}


### PR DESCRIPTION
## Summary
- Enable Electric Cloud for `@superset.sh` users when cloud env vars are set, without requiring the `X-Electric-Backend` header — for internal dogfooding before full rollout
- Fix cloud query param from `source_secret` to `secret` to match the Electric Cloud API
- Other users sending `X-Electric-Backend: cloud` still get cloud (backwards compat); everyone else stays on local Electric

## Test plan
- [x] `bun run lint:fix` — clean
- [x] `bun run typecheck --filter=@superset/api` — passes
- [x] `bun test` — 1417 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated cloud backend integration authentication logic and request parameter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->