### PR TITLE
fix(api): prevent Vercel CDN from caching Electric responses

### DIFF
--- a/apps/api/vercel.json
+++ b/apps/api/vercel.json
@@ -1,0 +1,11 @@
+{
+	"headers": [
+		{
+			"source": "/api/electric/(.*)",
+			"headers": [
+				{ "key": "CDN-Cache-Control", "value": "no-store" },
+				{ "key": "Vercel-CDN-Cache-Control", "value": "no-store" }
+			]
+		}
+	]
+}


### PR DESCRIPTION
## Summary
- Add `vercel.json` to `apps/api` that sets `CDN-Cache-Control: no-store` and `Vercel-CDN-Cache-Control: no-store` on `/api/electric/*` routes
- Prevents Vercel's edge cache from incorrectly caching and serving stale Electric shape data (per [Electric's Vercel guidance](https://electric-sql.com/docs/guides/deployment))
- Electric Cloud already provides its own CDN/DDN layer for caching

## Test plan
- [x] `bun run typecheck --filter=@superset/api` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration for API response headers on electric API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->