### PR TITLE
perf(desktop): preload Electric collections for active org only

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/CollectionsProvider.test.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/CollectionsProvider.test.tsx
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+const preloadCollectionsMock = mock(() => Promise.resolve());
+
+mock.module("./collections", () => ({
+	getCollections: mock(() => ({})),
+	preloadCollections: preloadCollectionsMock,
+}));
+
+const { preloadActiveOrganizationCollections } = await import(
+	"./CollectionsProvider"
+);
+
+describe("preloadActiveOrganizationCollections", () => {
+	const originalConsoleError = console.error;
+
+	beforeEach(() => {
+		preloadCollectionsMock.mockReset();
+		preloadCollectionsMock.mockImplementation(() => Promise.resolve());
+		console.error = mock(() => undefined);
+	});
+
+	afterEach(() => {
+		console.error = originalConsoleError;
+	});
+
+	it("preloads active org collections with includeChatCollections disabled", () => {
+		preloadActiveOrganizationCollections("org-123");
+
+		expect(preloadCollectionsMock).toHaveBeenCalledWith("org-123", {
+			includeChatCollections: false,
+		});
+	});
+
+	it("logs preload errors from fire-and-forget call", async () => {
+		const error = new Error("boom");
+		preloadCollectionsMock.mockImplementation(() => Promise.reject(error));
+
+		preloadActiveOrganizationCollections("org-123");
+		await new Promise((resolve) => {
+			setTimeout(resolve, 0);
+		});
+
+		expect(console.error).toHaveBeenCalledWith(
+			"[collections-provider] Failed to preload active org collections:",
+			error,
+		);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/CollectionsProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/CollectionsProvider.tsx
@@ -18,6 +18,20 @@ type CollectionsContextType = ReturnType<typeof getCollections> & {
 
 const CollectionsContext = createContext<CollectionsContextType | null>(null);
 
+export function preloadActiveOrganizationCollections(
+	activeOrganizationId: string | null | undefined,
+): void {
+	if (!activeOrganizationId) return;
+	void preloadCollections(activeOrganizationId, {
+		includeChatCollections: false,
+	}).catch((error) => {
+		console.error(
+			"[collections-provider] Failed to preload active org collections:",
+			error,
+		);
+	});
+}
+
 export function CollectionsProvider({ children }: { children: ReactNode }) {
 	const { data: session, refetch: refetchSession } = authClient.useSession();
 	const activeOrganizationId = env.SKIP_ENV_VALIDATION
@@ -45,8 +59,7 @@ export function CollectionsProvider({ children }: { children: ReactNode }) {
 	// Preload collections for the active org only.
 	// Collections are lazy — they don't sync until subscribed or preloaded.
 	useEffect(() => {
-		if (!activeOrganizationId) return;
-		preloadCollections(activeOrganizationId, { includeChatCollections: false });
+		preloadActiveOrganizationCollections(activeOrganizationId);
 	}, [activeOrganizationId]);
 
 	const collections = useMemo(() => {


### PR DESCRIPTION
## Summary
- Preload Electric collections only for the active organization instead of all orgs the user belongs to
- Avoids unnecessary Electric sync subscriptions on startup and reduces overhead when the user has multiple organizations

## Test plan
- [x] Verify collections load correctly for the active org
- [ ] Switch orgs and confirm collections load on demand
- [ ] Check that startup performance is not regressed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Changed collection preloading to load only the currently active organization's collections instead of preloading across all organizations.
* **Bug Fix**
  * Made preload fire-and-forget behavior resilient to errors by adding error handling to avoid unhandled rejections.
* **Tests**
  * Added unit tests covering the active-organization preload behavior and its error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->