### PR TITLE
fix: fall back to OS default when no editor is configured

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/external/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/index.ts
@@ -156,9 +156,15 @@ export const createExternalRouter = () => {
 			)
 			.mutation(async ({ input }) => {
 				const filePath = resolvePath(input.path, input.cwd);
-				// Preserve first-run behavior for terminal/file-link flows.
-				// If no project/global default editor is configured yet, fall back to Cursor.
-				const app = resolveDefaultEditor(input.projectId) ?? "cursor";
+				const app = resolveDefaultEditor(input.projectId);
+
+				if (!app) {
+					// No preferred editor configured yet.
+					// Fall back to OS default file handler so Cmd/Ctrl+click still works
+					// even when Cursor (or any specific editor) isn't installed.
+					await shell.openPath(filePath);
+					return;
+				}
 
 				await openPathInApp(filePath, app);
 			}),


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->
When no preferred editor is configured, `openFileInEditor` was hardcoded 
to fall back to Cursor. This caused cmd+clicking a file to silently fail 
for users who don't have Cursor installed. Now falls back to 
`shell.openPath()` which delegates to the OS default file handler.


## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->
fixes #1665 

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes
The previous hardcoded `"cursor"` fallback was silently failing for users 
without Cursor installed. The fix is minimal — one extra null check and a 
`shell.openPath()` call when no editor is resolved.

<!-- Add any other context about the PR here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file opening behavior: Files now open with the system's default handler when no editor is configured, providing a more reliable experience instead of attempting to use an unavailable fallback option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->