### PR TITLE
fix: fetch remote refs before listing branches in import tab

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/projects/projects.ts
+++ b/apps/desktop/src/lib/trpc/routers/projects/projects.ts
@@ -338,6 +338,12 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 
 					const git = simpleGit(project.mainRepoPath);
 
+					try {
+						await git.fetch(["--prune"]);
+					} catch {
+						// Best effort: continue with locally available refs when offline.
+					}
+
 					let hasOrigin = false;
 					try {
 						const remotes = await git.getRemotes();


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->
Before listing branches, the code was relying on locally cached remote 
refs which could be stale — especially after a fresh clone. Added 
`git fetch --prune` before branch enumeration so remote refs are always 
up to date. The fetch is wrapped in try/catch so it degrades gracefully 
when offline.


## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->
Fixes #1597

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced branch detection to better handle offline scenarios and network interruptions by gracefully handling fetch failures and using locally cached branch information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->