### PR TITLE
fix(chat-mastra): dedupe duplicate tool entries in assistant message rendering

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/components/ChatMastraMessageList/components/AssistantMessage/AssistantMessage.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/components/ChatMastraMessageList/components/AssistantMessage/AssistantMessage.tsx
@@ -134,6 +134,9 @@ export function AssistantMessage({
 		}
 
 		if (part.type === "tool_call") {
+			if (renderedToolCallIds.has(part.id)) {
+				continue;
+			}
 			renderedToolCallIds.add(part.id);
 			const { result, index: resultIndex } = findToolResultForCall({
 				content: message.content,
@@ -161,6 +164,9 @@ export function AssistantMessage({
 		}
 
 		if (part.type === "tool_result") {
+			if (renderedToolCallIds.has(part.id)) {
+				continue;
+			}
 			renderedToolCallIds.add(part.id);
 			nodes.push(
 				<MastraToolCallBlock


### PR DESCRIPTION
## Summary
- prevent duplicate rendering of tool entries when tool_call and tool_result parts share the same tool call id
- guard both tool_call and tool_result paths in AssistantMessage with renderedToolCallIds
- keep existing call/result pairing behavior while ensuring each tool call renders once

## Testing
- bunx biome check apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/components/ChatMastraMessageList/components/AssistantMessage/AssistantMessage.tsx
- bun test packages/chat-mastra/src/client/hooks/use-mastra-chat-display/use-mastra-chat-display.test.ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate rendering of tool calls and results in the chat interface, ensuring each tool interaction appears only once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->