### PR TITLE
fix(terminal): auto-close terminal pane on shell exit

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -82,6 +82,7 @@ export const Terminal = ({ paneId, tabId, workspaceId }: TerminalProps) => {
 	tabIdRef.current = tabId;
 	const setFocusedPane = useTabsStore((s) => s.setFocusedPane);
 	const setPaneName = useTabsStore((s) => s.setPaneName);
+	const removePane = useTabsStore((s) => s.removePane);
 	const focusedPaneId = useTabsStore((s) => s.focusedPaneIds[tabId]);
 	const terminalTheme = useTerminalTheme();
 
@@ -250,6 +251,7 @@ export const Terminal = ({ paneId, tabId, workspaceId }: TerminalProps) => {
 			setConnectionError,
 			updateModesFromData,
 			updateCwdFromData,
+			onShellExit: () => removePane(paneId),
 		});
 
 	// Populate handler refs for flushPendingEvents to use

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalStream.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalStream.ts
@@ -16,6 +16,7 @@ export interface UseTerminalStreamOptions {
 	setConnectionError: (error: string | null) => void;
 	updateModesFromData: (data: string) => void;
 	updateCwdFromData: (data: string) => void;
+	onShellExit?: () => void;
 }
 
 export interface UseTerminalStreamReturn {
@@ -42,6 +43,7 @@ export function useTerminalStream({
 	setConnectionError,
 	updateModesFromData,
 	updateCwdFromData,
+	onShellExit,
 }: UseTerminalStreamOptions): UseTerminalStreamReturn {
 	const setPaneStatus = useTabsStore((s) => s.setPaneStatus);
 	const firstStreamDataReceivedRef = useRef(false);
@@ -60,6 +62,12 @@ export function useTerminalStream({
 			const wasKilledByUser = reason === "killed";
 			wasKilledByUserRef.current = wasKilledByUser;
 			setExitStatus(wasKilledByUser ? "killed" : "exited");
+
+			const shouldAutoClosePane = !wasKilledByUser && exitCode === 0;
+			if (shouldAutoClosePane) {
+				onShellExit?.();
+				return;
+			}
 
 			if (wasKilledByUser) {
 				xterm.writeln("\r\n\r\n[Session killed]");
@@ -85,6 +93,7 @@ export function useTerminalStream({
 			wasKilledByUserRef,
 			setExitStatus,
 			setPaneStatus,
+			onShellExit,
 		],
 	);
 


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->
When a shell exits cleanly (exit code 0), the terminal pane is now 
automatically removed instead of showing "Press any key to restart". 
Non-zero exits still show the exit message so users can see what went wrong.

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->
Fixes #953

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal pane management—terminal panes now properly clean up automatically when shell sessions exit cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->