### PR TITLE
desktop: add mastracode agent hook wrapper

### DIFF
--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-mastra.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-mastra.ts
@@ -2,6 +2,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
+	buildWrapperScript,
+	createWrapper,
 	isSupersetManagedHookCommand,
 	writeFileIfChanged,
 } from "./agent-wrappers-common";
@@ -38,6 +40,11 @@ function quoteShellPath(filePath: string): string {
 
 export function getMastraGlobalHooksJsonPath(): string {
 	return path.join(os.homedir(), ".mastracode", "hooks.json");
+}
+
+export function createMastraWrapper(): void {
+	const script = buildWrapperScript("mastracode", `exec "$REAL_BIN" "$@"`);
+	createWrapper("mastracode", script);
 }
 
 /**

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -60,6 +60,7 @@ const {
 	buildCopilotWrapperExecLine,
 	buildWrapperScript,
 	createCodexWrapper,
+	createMastraWrapper,
 	getCursorHooksJsonContent,
 	getCopilotHookScriptPath,
 	getGeminiSettingsJsonContent,
@@ -144,6 +145,17 @@ describe("agent-wrappers copilot", () => {
 		);
 		expect(execLine).not.toContain("{{NOTIFY_PATH}}");
 		expect(wrapper).toContain(execLine);
+	});
+
+	it("creates mastracode wrapper passthrough", () => {
+		createMastraWrapper();
+
+		const wrapperPath = path.join(TEST_BIN_DIR, "mastracode");
+		const wrapper = readFileSync(wrapperPath, "utf-8");
+
+		expect(wrapper).toContain("# Superset wrapper for mastracode");
+		expect(wrapper).toContain('REAL_BIN="$(find_real_binary "mastracode")"');
+		expect(wrapper).toContain('exec "$REAL_BIN" "$@"');
 	});
 
 	it("replaces stale Cursor hook commands from old superset paths", () => {

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts
@@ -53,6 +53,7 @@ export {
 } from "./agent-wrappers-gemini";
 export {
 	createMastraHooksJson,
+	createMastraWrapper,
 	getMastraGlobalHooksJsonPath,
 	getMastraHooksJsonContent,
 } from "./agent-wrappers-mastra";

--- a/apps/desktop/src/main/lib/agent-setup/index.ts
+++ b/apps/desktop/src/main/lib/agent-setup/index.ts
@@ -12,6 +12,7 @@ import {
 	createGeminiSettingsJson,
 	createGeminiWrapper,
 	createMastraHooksJson,
+	createMastraWrapper,
 	createOpenCodePlugin,
 	createOpenCodeWrapper,
 } from "./agent-wrappers";
@@ -53,6 +54,7 @@ export function setupAgentHooks(): void {
 	createGeminiHookScript();
 	createGeminiWrapper();
 	createGeminiSettingsJson();
+	createMastraWrapper();
 	createMastraHooksJson();
 	createCopilotHookScript();
 	createCopilotWrapper();

--- a/apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts
@@ -49,6 +49,9 @@ describe("shell-wrappers", () => {
 		expect(zshrc).toContain(`codex() { "${TEST_BIN_DIR}/codex" "$@"; }`);
 		expect(zshrc).toContain(`opencode() { "${TEST_BIN_DIR}/opencode" "$@"; }`);
 		expect(zshrc).toContain(`copilot() { "${TEST_BIN_DIR}/copilot" "$@"; }`);
+		expect(zshrc).toContain(
+			`mastracode() { "${TEST_BIN_DIR}/mastracode" "$@"; }`,
+		);
 		expect(zshrc).toContain("rehash 2>/dev/null || true");
 
 		expect(zlogin).toContain("if [[ -o interactive ]]; then");
@@ -56,6 +59,9 @@ describe("shell-wrappers", () => {
 		expect(zlogin).toContain("_superset_prepend_bin()");
 		expect(zlogin).toContain(`claude() { "${TEST_BIN_DIR}/claude" "$@"; }`);
 		expect(zlogin).toContain(`copilot() { "${TEST_BIN_DIR}/copilot" "$@"; }`);
+		expect(zlogin).toContain(
+			`mastracode() { "${TEST_BIN_DIR}/mastracode" "$@"; }`,
+		);
 		expect(zlogin).toContain("rehash 2>/dev/null || true");
 	});
 
@@ -68,6 +74,9 @@ describe("shell-wrappers", () => {
 		expect(rcfile).toContain(`codex() { "${TEST_BIN_DIR}/codex" "$@"; }`);
 		expect(rcfile).toContain(`opencode() { "${TEST_BIN_DIR}/opencode" "$@"; }`);
 		expect(rcfile).toContain(`copilot() { "${TEST_BIN_DIR}/copilot" "$@"; }`);
+		expect(rcfile).toContain(
+			`mastracode() { "${TEST_BIN_DIR}/mastracode" "$@"; }`,
+		);
 		expect(rcfile).toContain("hash -r 2>/dev/null || true");
 	});
 

--- a/apps/desktop/src/main/lib/agent-setup/shell-wrappers.ts
+++ b/apps/desktop/src/main/lib/agent-setup/shell-wrappers.ts
@@ -46,7 +46,14 @@ function writeFileIfChanged(
 }
 
 /** Agent binaries that get wrapper shims to guarantee resolution. */
-const SHIMMED_BINARIES = ["claude", "codex", "opencode", "gemini", "copilot"];
+const SHIMMED_BINARIES = [
+	"claude",
+	"codex",
+	"opencode",
+	"gemini",
+	"copilot",
+	"mastracode",
+];
 
 /**
  * Shell function shims that override PATH-based lookup.


### PR DESCRIPTION
## Summary
- add a `mastracode` binary wrapper in desktop agent setup so Superset resolves the real CLI through `~/.superset*/bin` like other agent CLIs
- wire `createMastraWrapper()` into setup/export flow
- add `mastracode` shell shims for zsh/bash wrappers
- extend agent-setup tests to cover mastracode wrapper creation and shell shim generation

## Testing
- bun test apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts
- bunx biome check apps/desktop/src/main/lib/agent-setup/agent-wrappers-mastra.ts apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts apps/desktop/src/main/lib/agent-setup/index.ts apps/desktop/src/main/lib/agent-setup/shell-wrappers.ts apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Mastra agents with automatic setup and shell wrapper integration
  * Mastra commands are now available across bash, zsh, and login shells

<!-- end of auto-generated comment: release notes by coderabbit.ai -->