### PR TITLE
feat(analytics): add PostHog chat analytics + panel_opened event

### DIFF
--- a/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts
+++ b/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts
@@ -457,12 +457,7 @@ export class DaemonTerminalManager extends EventEmitter {
 				);
 			}
 
-			if (response.isNew) {
-				track("terminal_opened", {
-					workspace_id: workspaceId,
-					pane_id: paneId,
-				});
-			} else if (response.wasRecovered) {
+			if (response.wasRecovered) {
 				track("terminal_warm_attached", {
 					workspace_id: workspaceId,
 					pane_id: paneId,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/components/ChatMastraMessageList/ChatMastraMessageList.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/components/ChatMastraMessageList/ChatMastraMessageList.tsx
@@ -42,6 +42,8 @@ interface ChatMastraMessageListProps {
 	isRunning: boolean;
 	currentMessage: MastraMessage | null;
 	workspaceId: string;
+	sessionId: string | null;
+	organizationId: string | null;
 	workspaceCwd?: string;
 	activeTools: MastraActiveTools | undefined;
 	toolInputBuffers: MastraToolInputBuffers | undefined;
@@ -136,6 +138,8 @@ export function ChatMastraMessageList({
 	isRunning,
 	currentMessage,
 	workspaceId,
+	sessionId,
+	organizationId,
 	workspaceCwd,
 	activeTools,
 	toolInputBuffers,
@@ -187,6 +191,8 @@ export function ChatMastraMessageList({
 								key={message.id}
 								message={message}
 								workspaceId={workspaceId}
+								sessionId={sessionId}
+								organizationId={organizationId}
 								workspaceCwd={workspaceCwd}
 								isStreaming={false}
 								previewToolParts={[]}
@@ -199,6 +205,8 @@ export function ChatMastraMessageList({
 						key={`current-${currentMessage.id}`}
 						message={currentMessage}
 						workspaceId={workspaceId}
+						sessionId={sessionId}
+						organizationId={organizationId}
 						workspaceCwd={workspaceCwd}
 						isStreaming
 						previewToolParts={previewToolParts}
@@ -227,6 +235,8 @@ export function ChatMastraMessageList({
 										key={`tool-preview-${part.toolCallId}`}
 										part={part}
 										workspaceId={workspaceId}
+										sessionId={sessionId}
+										organizationId={organizationId}
 										workspaceCwd={workspaceCwd}
 									/>
 								))}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/components/ChatMastraMessageList/components/AssistantMessage/AssistantMessage.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/components/ChatMastraMessageList/components/AssistantMessage/AssistantMessage.tsx
@@ -20,6 +20,8 @@ interface AssistantMessageProps {
 	message: MastraMessage;
 	isStreaming: boolean;
 	workspaceId: string;
+	sessionId?: string | null;
+	organizationId?: string | null;
 	workspaceCwd?: string;
 	previewToolParts?: ToolPart[];
 }
@@ -90,6 +92,8 @@ export function AssistantMessage({
 	message,
 	isStreaming,
 	workspaceId,
+	sessionId,
+	organizationId,
 	workspaceCwd,
 	previewToolParts = [],
 }: AssistantMessageProps) {
@@ -150,6 +154,8 @@ export function AssistantMessage({
 						isStreaming,
 					})}
 					workspaceId={workspaceId}
+					sessionId={sessionId}
+					organizationId={organizationId}
 					workspaceCwd={workspaceCwd}
 				/>,
 			);
@@ -167,6 +173,8 @@ export function AssistantMessage({
 					key={`${message.id}-tool-result-${part.id}`}
 					part={toToolPartFromResult(part)}
 					workspaceId={workspaceId}
+					sessionId={sessionId}
+					organizationId={organizationId}
 					workspaceCwd={workspaceCwd}
 				/>,
 			);
@@ -193,6 +201,8 @@ export function AssistantMessage({
 				key={`${message.id}-tool-preview-${previewPart.toolCallId}`}
 				part={previewPart}
 				workspaceId={workspaceId}
+				sessionId={sessionId}
+				organizationId={organizationId}
 				workspaceCwd={workspaceCwd}
 			/>,
 		);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/types.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/types.ts
@@ -11,6 +11,7 @@ export interface ChatMastraRawSnapshot {
 export interface ChatMastraInterfaceProps {
 	sessionId: string | null;
 	workspaceId: string;
+	organizationId: string | null;
 	cwd: string;
 	onStartFreshSession: () => Promise<{
 		created: boolean;

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -1,6 +1,7 @@
 import type { MosaicNode } from "react-mosaic-component";
 import { updateTree } from "react-mosaic-component";
 import { getFileOpenMode } from "renderer/hooks/useFileOpenMode";
+import { posthog } from "renderer/lib/posthog";
 import { trpcTabsStorage } from "renderer/lib/trpc-storage";
 import { acknowledgedStatus } from "shared/tabs-types";
 import { create } from "zustand";
@@ -143,6 +144,12 @@ export const useTabsStore = create<TabsStore>()(
 						},
 					});
 
+					posthog.capture("panel_opened", {
+						panel_type: "terminal",
+						workspace_id: workspaceId,
+						pane_id: pane.id,
+					});
+
 					return { tabId: tab.id, paneId: pane.id };
 				},
 
@@ -175,6 +182,12 @@ export const useTabsStore = create<TabsStore>()(
 							...state.tabHistoryStacks,
 							[workspaceId]: newHistoryStack,
 						},
+					});
+
+					posthog.capture("panel_opened", {
+						panel_type: "chat",
+						workspace_id: workspaceId,
+						pane_id: pane.id,
 					});
 
 					return { tabId: tab.id, paneId: pane.id };
@@ -237,6 +250,14 @@ export const useTabsStore = create<TabsStore>()(
 							[workspaceId]: newHistoryStack,
 						},
 					});
+
+					for (const paneId of paneIds) {
+						posthog.capture("panel_opened", {
+							panel_type: "terminal",
+							workspace_id: workspaceId,
+							pane_id: paneId,
+						});
+					}
 
 					return { tabId: tab.id, paneIds };
 				},
@@ -497,6 +518,12 @@ export const useTabsStore = create<TabsStore>()(
 						},
 					});
 
+					posthog.capture("panel_opened", {
+						panel_type: "terminal",
+						workspace_id: tab.workspaceId,
+						pane_id: newPane.id,
+					});
+
 					return newPane.id;
 				},
 
@@ -539,6 +566,14 @@ export const useTabsStore = create<TabsStore>()(
 							[tabId]: paneIds[0],
 						},
 					});
+
+					for (const paneId of paneIds) {
+						posthog.capture("panel_opened", {
+							panel_type: "terminal",
+							workspace_id: tab.workspaceId,
+							pane_id: paneId,
+						});
+					}
 
 					return paneIds;
 				},
@@ -743,6 +778,12 @@ export const useTabsStore = create<TabsStore>()(
 							},
 						});
 
+						posthog.capture("panel_opened", {
+							panel_type: "file_viewer",
+							workspace_id: workspaceId,
+							pane_id: newPane.id,
+						});
+
 						return newPane.id;
 					}
 
@@ -769,6 +810,12 @@ export const useTabsStore = create<TabsStore>()(
 							...state.focusedPaneIds,
 							[activeTab.id]: newPane.id,
 						},
+					});
+
+					posthog.capture("panel_opened", {
+						panel_type: "file_viewer",
+						workspace_id: activeTab.workspaceId,
+						pane_id: newPane.id,
 					});
 
 					return newPane.id;
@@ -1074,6 +1121,12 @@ export const useTabsStore = create<TabsStore>()(
 							[tabId]: newPane.id,
 						},
 					});
+
+					posthog.capture("panel_opened", {
+						panel_type: "terminal",
+						workspace_id: tab.workspaceId,
+						pane_id: newPane.id,
+					});
 				},
 
 				splitPaneHorizontal: (tabId, sourcePaneId, path, options) => {
@@ -1125,6 +1178,12 @@ export const useTabsStore = create<TabsStore>()(
 							...state.focusedPaneIds,
 							[tabId]: newPane.id,
 						},
+					});
+
+					posthog.capture("panel_opened", {
+						panel_type: "terminal",
+						workspace_id: tab.workspaceId,
+						pane_id: newPane.id,
 					});
 				},
 
@@ -1217,6 +1276,12 @@ export const useTabsStore = create<TabsStore>()(
 							...state.tabHistoryStacks,
 							[workspaceId]: newHistoryStack,
 						},
+					});
+
+					posthog.capture("panel_opened", {
+						panel_type: "browser",
+						workspace_id: workspaceId,
+						pane_id: pane.id,
 					});
 
 					return { tabId: tab.id, paneId: pane.id };
@@ -1338,6 +1403,12 @@ export const useTabsStore = create<TabsStore>()(
 								...state.focusedPaneIds,
 								[activeTab.id]: newPane.id,
 							},
+						});
+
+						posthog.capture("panel_opened", {
+							panel_type: "browser",
+							workspace_id: workspaceId,
+							pane_id: newPane.id,
 						});
 					}
 				},
@@ -1560,6 +1631,12 @@ export const useTabsStore = create<TabsStore>()(
 							...state.focusedPaneIds,
 							[tabId]: browserPaneId,
 						},
+					});
+
+					posthog.capture("panel_opened", {
+						panel_type: "devtools",
+						workspace_id: tab.workspaceId,
+						pane_id: newPane.id,
 					});
 
 					return newPane.id;


### PR DESCRIPTION
## Summary

- **Remove** `terminal_opened` from daemon-manager (spammy ~53k events/week) and replace with a generic `panel_opened` event in the Zustand tab store, covering all pane types: `terminal`, `chat`, `file_viewer`, `browser`, `devtools`
- **Add** chat analytics events across ChatMastraPane and ChatMastraInterface via inline `posthog.capture()` calls
- **Thread** `onTrackEvent` callbacks through `useSlashCommandExecutor` and `useMcpUi` for package-boundary-safe tracking

### New events

| Event | Key properties |
|---|---|
| `panel_opened` | `panel_type`, `pane_id`, `workspace_id` |
| `chat_session_created` | `session_id`, `workspace_id`, `organization_id` |
| `chat_session_opened` | `session_id`, `workspace_id`, `organization_id` |
| `chat_session_deleted` | `session_id`, `workspace_id`, `organization_id` |
| `chat_message_sent` | `model_id`, `attachment_count`, `is_slash_command`, `message_length`, `turn_number` |
| `chat_slash_command_used` | `command_name`, `command_type` |
| `chat_model_changed` | `model_id`, `model_name`, `trigger` (`picker` / `slash_command`) |
| `chat_turn_aborted` | `model_id` |
| `chat_file_opened_from_tool` | `tool_name`, `open_target` (`view` / `diff`) |
| `chat_mcp_overview_opened` | `server_count`, `enabled_count` |

## Test plan

- [ ] Open a terminal tab → `panel_opened` with `panel_type: "terminal"`
- [ ] Open a chat tab → `panel_opened` with `panel_type: "chat"` + `chat_session_created`
- [ ] Send a message → `chat_message_sent`
- [ ] Switch models via picker → `chat_model_changed` with `trigger: "picker"`
- [ ] Use `/model` slash command → `chat_model_changed` with `trigger: "slash_command"` + `chat_slash_command_used`
- [ ] Use `/stop` → `chat_turn_aborted`
- [ ] Click a file path in tool results → `chat_file_opened_from_tool`
- [ ] Confirm `terminal_opened` no longer fires

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced analytics tracking across chat interactions, including model selection, message sending, session management, and tool usage.
  * Improved telemetry collection for panel and terminal operations to better understand user behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->