### PR TITLE
Allow Cmd+Enter to submit in new workspace flow

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -181,7 +181,11 @@ export function NewWorkspaceModal() {
 	}, [isOpen, selectedProjectId, mode]);
 
 	const handleKeyDown = (e: React.KeyboardEvent) => {
-		if (e.target instanceof HTMLTextAreaElement) {
+		const isTextareaTarget = e.target instanceof HTMLTextAreaElement;
+		const isSubmitShortcutInTextarea =
+			isTextareaTarget && (e.metaKey || e.ctrlKey);
+
+		if (isTextareaTarget && !isSubmitShortcutInTextarea) {
 			return;
 		}
 


### PR DESCRIPTION
## Summary
- enable submitting new workspace creation with `Cmd+Enter` (and `Ctrl+Enter`) when the description textarea is focused
- preserve plain `Enter` in the textarea for newline insertion
- keep existing enter-to-submit behavior outside the textarea

## Testing
- `bunx biome check apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced keyboard shortcut handling in the New Workspace modal to correctly process submit shortcuts (Ctrl/Cmd+Enter) when triggered from within text input areas, while preserving standard text entry functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->