### PR TITLE
Revert "Revert "fix(chat-mastra): dedupe duplicate tool entries in assistant message rendering""

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/components/ChatMastraMessageList/components/AssistantMessage/AssistantMessage.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/components/ChatMastraMessageList/components/AssistantMessage/AssistantMessage.tsx
@@ -138,6 +138,9 @@ export function AssistantMessage({
 		}
 
 		if (part.type === "tool_call") {
+			if (renderedToolCallIds.has(part.id)) {
+				continue;
+			}
 			renderedToolCallIds.add(part.id);
 			const { result, index: resultIndex } = findToolResultForCall({
 				content: message.content,
@@ -167,6 +170,9 @@ export function AssistantMessage({
 		}
 
 		if (part.type === "tool_result") {
+			if (renderedToolCallIds.has(part.id)) {
+				continue;
+			}
 			renderedToolCallIds.add(part.id);
 			nodes.push(
 				<MastraToolCallBlock


### PR DESCRIPTION
Reverts superset-sh/superset#1890

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where duplicate tool calls and results appeared in chat conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->