### PR TITLE
desktop: keep read-file tool collapsed by default

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/ReadOnlyToolCall/ReadOnlyToolCall.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/ReadOnlyToolCall/ReadOnlyToolCall.tsx
@@ -16,7 +16,7 @@ import {
 	SearchIcon,
 	XIcon,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { getWorkspaceToolFilePath } from "../../utils/file-paths";
 import type { ToolPart } from "../../utils/tool-helpers";
 import {
@@ -79,7 +79,6 @@ export function ReadOnlyToolCall({
 	onOpenFileInPane,
 }: ReadOnlyToolCallProps) {
 	const [isOpen, setIsOpen] = useState(false);
-	const [hasAutoOpened, setHasAutoOpened] = useState(false);
 	const args = getArgs(part);
 	const toolName = normalizeToolName(getToolName(part));
 	const output =
@@ -97,18 +96,6 @@ export function ReadOnlyToolCall({
 		? extractReadFileContent(output)
 		: undefined;
 	const hasDetails = part.input != null || output != null || isError;
-
-	useEffect(() => {
-		if (
-			!hasAutoOpened &&
-			isReadFileTool &&
-			Boolean(readFileContent) &&
-			!isPending
-		) {
-			setIsOpen(true);
-			setHasAutoOpened(true);
-		}
-	}, [hasAutoOpened, isPending, isReadFileTool, readFileContent]);
 
 	let title = "Read file";
 	let subtitle = String(args.path ?? args.filePath ?? args.query ?? "");


### PR DESCRIPTION
## Summary
- remove auto-open behavior for the read-file tool call block in chat
- keep read-file tool collapsed by default until manually expanded
- preserve existing manual toggle behavior and status rendering

## Testing
- bunx biome check apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/ReadOnlyToolCall/ReadOnlyToolCall.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Read File tool panel no longer automatically opens; users must now manually interact to expand the panel when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->