### PR TITLE
fix(desktop): prevent new-workspace text input overflow

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -386,7 +386,7 @@ export function NewWorkspaceModal() {
 				)}
 
 				{selectedProjectId && (
-					<div className="px-4 pb-4">
+					<div className="px-4 pb-4 min-w-0">
 						{mode === "new" && (
 							<NewWorkspaceCreateFlow
 								projectSelector={projectSelector}

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/ExistingWorktreesList/components/PrUrlSection.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/ExistingWorktreesList/components/PrUrlSection.tsx
@@ -25,11 +25,11 @@ export function PrUrlSection({
 
 	return (
 		<div className="space-y-1.5">
-			<div className="flex gap-2">
-				<div className="relative flex-1">
+			<div className="flex min-w-0 gap-2">
+				<div className="relative min-w-0 flex-1">
 					<GoGitPullRequest className="absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground" />
 					<Input
-						className="h-8 text-sm pl-8 pr-3"
+						className="h-8 w-full min-w-0 max-w-full text-sm pl-8 pr-3"
 						placeholder="Paste PR URL..."
 						value={prUrl}
 						onChange={(e) => onPrUrlChange(e.target.value)}

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/NewWorkspaceCreateFlow/NewWorkspaceCreateFlow.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/NewWorkspaceCreateFlow/NewWorkspaceCreateFlow.tsx
@@ -54,7 +54,7 @@ export function NewWorkspaceCreateFlow({
 	const isDark = useIsDarkTheme();
 
 	return (
-		<div className="space-y-3">
+		<div className="space-y-3 min-w-0">
 			<div className="flex items-end gap-3 min-w-0">
 				<div className="flex-1 min-w-0">{projectSelector}</div>
 				<div className="shrink-0 max-w-[45%]">
@@ -101,7 +101,7 @@ export function NewWorkspaceCreateFlow({
 			<Textarea
 				ref={titleInputRef}
 				id="title"
-				className="min-h-20 text-sm resize-y"
+				className="min-h-20 min-w-0 w-full max-w-full field-sizing-fixed text-sm resize-y"
 				placeholder="What do you want to do?"
 				value={title}
 				onChange={(e) => onTitleChange(e.target.value)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/project/$projectId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/project/$projectId/page.tsx
@@ -162,7 +162,10 @@ function ProjectPage() {
 			<div className="flex-1 flex overflow-y-auto">
 				<div className="flex-1 flex items-center justify-center">
 					{/* biome-ignore lint/a11y/noStaticElementInteractions: onKeyDown for Enter-to-submit */}
-					<div className="w-full max-w-md mx-6" onKeyDown={handleKeyDown}>
+					<div
+						className="w-full max-w-md min-w-0 mx-6"
+						onKeyDown={handleKeyDown}
+					>
 						<h1 className="text-3xl font-semibold text-foreground tracking-tight mb-2">
 							Create your first workspace
 						</h1>
@@ -178,7 +181,7 @@ function ProjectPage() {
 								<Input
 									id="task-title"
 									ref={titleInputRef}
-									className="h-11 text-base bg-card/50 border-border/60 focus:border-primary/40 focus:ring-primary/20 transition-all"
+									className="h-11 w-full min-w-0 max-w-full text-base bg-card/50 border-border/60 focus:border-primary/40 focus:ring-primary/20 transition-all"
 									placeholder="e.g. Add dark mode, Fix checkout bug"
 									value={title}
 									onChange={(e) => setTitle(e.target.value)}
@@ -186,14 +189,14 @@ function ProjectPage() {
 							</div>
 
 							<p
-								className={`text-xs text-muted-foreground flex items-center gap-2 transition-all duration-200 ${title ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-1"}`}
+								className={`text-xs text-muted-foreground flex min-w-0 items-center gap-2 transition-all duration-200 ${title ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-1"}`}
 							>
 								<GoGitBranch className="size-3" />
-								<span className="font-mono">
+								<span className="font-mono min-w-0 truncate">
 									{generateBranchFromTitle({ title, authorPrefix }) ||
 										"branch-name"}
 								</span>
-								<span className="text-muted-foreground/50">
+								<span className="shrink-0 text-muted-foreground/50">
 									from {effectiveBaseBranch}
 								</span>
 							</p>


### PR DESCRIPTION
## Summary
- prevent new workspace prompt input from overflowing modal bounds by enforcing shrink-safe width constraints
- add container `min-w-0` and `max-w-full` guards in New Workspace modal and PR URL row
- apply the same overflow-safe sizing to the dashboard Create workspace card input and branch preview row

## Validation
- bunx biome check on touched files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved layout handling in workspace modals and project settings to prevent text overflow
  * Enhanced input and text field sizing for consistent full-width display
  * Refined container constraints for better responsive behavior across form elements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->