### PR TITLE
Add --trust-workspace to Claude preset command

### DIFF
--- a/apps/docs/content/docs/terminal-presets.mdx
+++ b/apps/docs/content/docs/terminal-presets.mdx
@@ -43,7 +43,7 @@ Presets are parallel by default.
 
 Pre-configured presets for popular AI agents:
 
-- **claude** - `claude --dangerously-skip-permissions`
+- **claude** - `claude --dangerously-skip-permissions --trust-workspace`
 - **codex** - Full danger mode with high reasoning effort
 - **gemini** - `gemini --yolo`
 - **cursor-agent** - Cursor AI agent

--- a/packages/shared/src/agent-command.ts
+++ b/packages/shared/src/agent-command.ts
@@ -19,7 +19,7 @@ export const AGENT_LABELS: Record<AgentType, string> = {
 };
 
 export const AGENT_PRESET_COMMANDS: Record<AgentType, string[]> = {
-	claude: ["claude --dangerously-skip-permissions"],
+	claude: ["claude --dangerously-skip-permissions --trust-workspace"],
 	codex: [
 		'codex -c model_reasoning_effort="high" --ask-for-approval never --sandbox danger-full-access -c model_reasoning_summary="detailed" -c model_supports_reasoning_summaries=true',
 	],
@@ -100,7 +100,11 @@ const AGENT_COMMANDS: Record<
 	(prompt: string, delimiter: string) => string
 > = {
 	claude: (prompt, delimiter) =>
-		buildHeredoc(prompt, delimiter, "claude --dangerously-skip-permissions"),
+		buildHeredoc(
+			prompt,
+			delimiter,
+			"claude --dangerously-skip-permissions --trust-workspace",
+		),
 	codex: (prompt, delimiter) =>
 		buildHeredoc(
 			prompt,


### PR DESCRIPTION
## Summary
- add `--trust-workspace` to the Claude quick preset command
- add `--trust-workspace` to the Claude heredoc command builder used for task launches
- update terminal preset docs to match the new Claude command

## Testing
- not run (command string/docs update only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Claude preset command to include `--trust-workspace` flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->