### PR TITLE
Remove Codex Spark from chat model options

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -108,7 +108,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "0.0.88",
+      "version": "1.0.1",
       "dependencies": {
         "@ai-sdk/react": "^3.0.0",
         "@ast-grep/napi": "^0.41.0",

--- a/packages/trpc/src/router/chat/chat.ts
+++ b/packages/trpc/src/router/chat/chat.ts
@@ -27,11 +27,6 @@ const AVAILABLE_MODELS = [
 		provider: "OpenAI",
 	},
 	{
-		id: "openai/gpt-5.3-codex-spark",
-		name: "GPT-5.3 Codex Spark",
-		provider: "OpenAI",
-	},
-	{
 		id: "openai/gpt-5.2",
 		name: "GPT-5.2",
 		provider: "OpenAI",


### PR DESCRIPTION
## Summary
- remove `openai/gpt-5.3-codex-spark` from the chat `AVAILABLE_MODELS` list
- keep `openai/gpt-5.3-codex` and `openai/gpt-5.2` unchanged
- include existing `bun.lock` version metadata update for `@superset/desktop`

## Testing
- not run (not requested)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an unavailable AI model from the selection options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->