### PR TITLE
fix(chat-mastra): surface runtime/provider errors in chat UI

### DIFF
--- a/packages/chat-mastra/src/client/hooks/use-mastra-chat-display/use-mastra-chat-display.test.ts
+++ b/packages/chat-mastra/src/client/hooks/use-mastra-chat-display/use-mastra-chat-display.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import type { inferRouterOutputs } from "@trpc/server";
 import type { ChatMastraServiceRouter } from "../../../server/trpc";
-import { withoutActiveTurnAssistantHistory } from "./use-mastra-chat-display";
+import {
+	resolveChatErrorMessage,
+	withoutActiveTurnAssistantHistory,
+} from "./use-mastra-chat-display";
 
 type RouterOutputs = inferRouterOutputs<ChatMastraServiceRouter>;
 type SessionOutputs = RouterOutputs["session"];
@@ -29,10 +32,31 @@ function assistantMessage(
 	} as unknown as ListMessagesOutput[number];
 }
 
+function assistantErrorMessage(
+	id: string,
+	error: unknown,
+): ListMessagesOutput[number] {
+	return {
+		id,
+		role: "assistant",
+		content: [{ type: "error", text: "request failed" }],
+		error,
+		createdAt: new Date("2026-02-26T00:00:00.000Z"),
+	} as unknown as ListMessagesOutput[number];
+}
+
 function asCurrentMessage(
 	message: ListMessagesOutput[number],
 ): DisplayStateOutput["currentMessage"] {
 	return message as unknown as DisplayStateOutput["currentMessage"];
+}
+
+function makeDisplayState(errorMessage?: unknown): DisplayStateOutput {
+	return {
+		isRunning: false,
+		currentMessage: null,
+		errorMessage,
+	} as unknown as DisplayStateOutput;
 }
 
 describe("withoutActiveTurnAssistantHistory", () => {
@@ -80,5 +104,44 @@ describe("withoutActiveTurnAssistantHistory", () => {
 		});
 
 		expect(messages.map((message) => message.id)).toEqual(["u_1", "a_1"]);
+	});
+});
+
+describe("resolveChatErrorMessage", () => {
+	it("prefers runtime displayState errorMessage over history", () => {
+		const message = resolveChatErrorMessage({
+			displayState: makeDisplayState("Runtime request failed"),
+			messages: [assistantErrorMessage("a_1", "Older assistant failure")],
+		});
+
+		expect(message).toBe("Runtime request failed");
+	});
+
+	it("falls back to latest assistant error when runtime errorMessage is absent", () => {
+		const message = resolveChatErrorMessage({
+			displayState: makeDisplayState(undefined),
+			messages: [
+				userMessage("u_1", "hello"),
+				assistantErrorMessage("a_1", {
+					message: "AI_APICallError2: Upstream provider timed out",
+				}),
+			],
+		});
+
+		expect(message).toBe("Upstream provider timed out");
+	});
+
+	it("does not surface stale assistant error after a later successful assistant reply", () => {
+		const message = resolveChatErrorMessage({
+			displayState: makeDisplayState(undefined),
+			messages: [
+				userMessage("u_1", "first"),
+				assistantErrorMessage("a_error", "Temporary failure"),
+				userMessage("u_2", "retry"),
+				assistantMessage("a_success", "Done."),
+			],
+		});
+
+		expect(message).toBeNull();
 	});
 });

--- a/packages/chat-mastra/src/client/hooks/use-mastra-chat-display/use-mastra-chat-display.ts
+++ b/packages/chat-mastra/src/client/hooks/use-mastra-chat-display/use-mastra-chat-display.ts
@@ -18,6 +18,15 @@ type HistoryMessagePart = HistoryMessage["content"][number];
 export type MastraChatDisplayState = DisplayStateOutput;
 export type MastraChatHistoryMessages = ListMessagesOutput;
 
+const AI_API_CALL_ERROR_PREFIX = /^\s*AI_APICallError\d*:\s*/;
+const MAX_ERROR_PARSE_DEPTH = 10;
+const GENERIC_ERROR_TOKENS = new Set([
+	"error",
+	"workspace_error",
+	"agent_start",
+	"agent_end",
+]);
+
 export interface UseMastraChatDisplayOptions {
 	sessionId: string | null;
 	cwd?: string;
@@ -35,6 +44,160 @@ function findLastUserMessageIndex(messages: ListMessagesOutput): number {
 		if (messages[index]?.role === "user") return index;
 	}
 	return -1;
+}
+
+function toNonEmptyString(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeErrorMessage(message: string): string {
+	let normalized = message.trim();
+	while (AI_API_CALL_ERROR_PREFIX.test(normalized)) {
+		normalized = normalized.replace(AI_API_CALL_ERROR_PREFIX, "").trim();
+	}
+	return normalized;
+}
+
+function toUserFacingErrorMessage(message: string): string | null {
+	const normalized = normalizeErrorMessage(message);
+	if (normalized.length === 0) return null;
+	const lower = normalized.toLowerCase();
+	if (GENERIC_ERROR_TOKENS.has(lower)) return null;
+	return normalized;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+	return value as Record<string, unknown>;
+}
+
+function extractErrorMessageFromUnknown(
+	value: unknown,
+	seen: WeakSet<object>,
+	depth = 0,
+): string | null {
+	if (depth > MAX_ERROR_PARSE_DEPTH) return null;
+
+	const asString = toNonEmptyString(value);
+	if (asString) {
+		return toUserFacingErrorMessage(asString);
+	}
+
+	if (value instanceof Error) {
+		const message = toNonEmptyString(value.message);
+		if (message) return normalizeErrorMessage(message);
+		const causeMessage = extractErrorMessageFromUnknown(
+			(value as Error & { cause?: unknown }).cause,
+			seen,
+			depth + 1,
+		);
+		if (causeMessage) return causeMessage;
+	}
+
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			const nested = extractErrorMessageFromUnknown(item, seen, depth + 1);
+			if (nested) return nested;
+		}
+		return null;
+	}
+
+	const record = asRecord(value);
+	if (!record) return null;
+	if (seen.has(record)) return null;
+	seen.add(record);
+
+	const preferredKeys = [
+		"userFacingMessage",
+		"displayMessage",
+		"error",
+		"cause",
+		"data",
+		"details",
+		"responseBody",
+		"body",
+		"payload",
+		"result",
+	];
+	for (const key of preferredKeys) {
+		const nested = extractErrorMessageFromUnknown(record[key], seen, depth + 1);
+		if (nested) return nested;
+	}
+
+	const messageKeys = ["message", "errorMessage", "reason", "text"];
+	for (const key of messageKeys) {
+		const message = toNonEmptyString(record[key]);
+		if (!message) continue;
+		const normalized = toUserFacingErrorMessage(message);
+		if (normalized) return normalized;
+	}
+
+	for (const nestedValue of Object.values(record)) {
+		const nested = extractErrorMessageFromUnknown(nestedValue, seen, depth + 1);
+		if (nested) return nested;
+	}
+
+	return null;
+}
+
+function extractErrorMessage(value: unknown): string | null {
+	return extractErrorMessageFromUnknown(value, new WeakSet(), 0);
+}
+
+function getAssistantMessageErrorMessage(message: HistoryMessage): string | null {
+	if (message.role !== "assistant") return null;
+
+	const messageRecord = asRecord(message);
+	if (!messageRecord) return null;
+
+	const directError = extractErrorMessage(messageRecord.error);
+	if (directError) return directError;
+
+	const metadata = asRecord(messageRecord.metadata);
+	if (metadata) {
+		const metadataError = extractErrorMessage(metadata.error);
+		if (metadataError) return metadataError;
+	}
+
+	if (!Array.isArray(messageRecord.content)) return null;
+
+	for (const part of messageRecord.content) {
+		const contentPart = asRecord(part);
+		if (!contentPart || contentPart.type !== "error") continue;
+		const partError = extractErrorMessage(
+			contentPart.error ?? contentPart.text ?? contentPart.message,
+		);
+		if (partError) return partError;
+	}
+
+	return null;
+}
+
+export function findLatestAssistantErrorMessage(
+	messages: ListMessagesOutput,
+): string | null {
+	for (let index = messages.length - 1; index >= 0; index -= 1) {
+		const message = messages[index];
+		if (!message || message.role !== "assistant") continue;
+		return getAssistantMessageErrorMessage(message);
+	}
+	return null;
+}
+
+export function resolveChatErrorMessage({
+	displayState,
+	messages,
+}: {
+	displayState: DisplayStateOutput | null;
+	messages: ListMessagesOutput;
+}): string | null {
+	const runtimeError = extractErrorMessage(
+		asRecord(displayState)?.errorMessage ?? null,
+	);
+	if (runtimeError) return runtimeError;
+	return findLatestAssistantErrorMessage(messages);
 }
 
 export function withoutActiveTurnAssistantHistory({
@@ -127,6 +290,14 @@ export function useMastraChatDisplay(options: UseMastraChatDisplayOptions) {
 			isRunning,
 		});
 	}, [historicalMessages, optimisticUserMessage, currentMessage, isRunning]);
+	const errorMessage = useMemo(
+		() =>
+			resolveChatErrorMessage({
+				displayState,
+				messages: historicalMessages,
+			}),
+		[displayState, historicalMessages],
+	);
 
 	const commands = useMemo(
 		() => ({
@@ -235,6 +406,7 @@ export function useMastraChatDisplay(options: UseMastraChatDisplayOptions) {
 	return {
 		...displayState,
 		messages,
+		errorMessage,
 		error: displayQuery.error ?? messagesQuery.error ?? commandError ?? null,
 		commands,
 	};

--- a/packages/chat-mastra/src/server/trpc/service.ts
+++ b/packages/chat-mastra/src/server/trpc/service.ts
@@ -14,6 +14,7 @@ import {
 	runSessionStartHook,
 	subscribeToSessionEvents,
 } from "./utils/runtime";
+import { extractRuntimeErrorMessage } from "./utils/runtime/runtime";
 import { isMastraMcpEnabled } from "./utils/runtime/mcp-gate";
 import { getSupersetMcpTools } from "./utils/runtime/superset-mcp";
 import {
@@ -32,6 +33,46 @@ import {
 export interface ChatMastraServiceOptions {
 	headers: () => Record<string, string> | Promise<Record<string, string>>;
 	apiUrl: string;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return null;
+	}
+	return value as Record<string, unknown>;
+}
+
+function getCurrentAssistantErrorMessage(
+	displayState: Awaited<ReturnType<RuntimeSession["harness"]["getDisplayState"]>>,
+): string | null {
+	const state = asRecord(displayState);
+	if (!state) return null;
+
+	const currentMessage = asRecord(state.currentMessage);
+	if (!currentMessage) return null;
+	if (currentMessage.role !== "assistant") return null;
+
+	const directError = extractRuntimeErrorMessage(currentMessage.error);
+	if (directError) return directError;
+
+	const metadata = asRecord(currentMessage.metadata);
+	if (metadata) {
+		const metadataError = extractRuntimeErrorMessage(metadata.error);
+		if (metadataError) return metadataError;
+	}
+
+	if (!Array.isArray(currentMessage.content)) return null;
+
+	for (const part of currentMessage.content) {
+		const contentPart = asRecord(part);
+		if (!contentPart || contentPart.type !== "error") continue;
+		const partError = extractRuntimeErrorMessage(
+			contentPart.error ?? contentPart.text ?? contentPart.message,
+		);
+		if (partError) return partError;
+	}
+
+	return null;
 }
 
 export class ChatMastraService {
@@ -105,6 +146,7 @@ export class ChatMastraService {
 					hookManager: runtimeMastra.hookManager,
 					mcpManualStatuses: new Map(),
 					cwd: runtimeCwd,
+					lastErrorMessage: null,
 				};
 				await runSessionStartHook(runtime).catch(() => {});
 				subscribeToSessionEvents(runtime, this.apiClient);
@@ -171,7 +213,14 @@ export class ChatMastraService {
 							input.sessionId,
 							input.cwd,
 						);
-						return runtime.harness.getDisplayState();
+						const displayState = await runtime.harness.getDisplayState();
+						const assistantError =
+							getCurrentAssistantErrorMessage(displayState);
+						const errorMessage = assistantError ?? runtime.lastErrorMessage ?? null;
+						return {
+							...displayState,
+							errorMessage,
+						};
 					}),
 
 				listMessages: t.procedure
@@ -201,6 +250,7 @@ export class ChatMastraService {
 								scope: "thread",
 							});
 						}
+						runtime.lastErrorMessage = null;
 						return runtime.harness.sendMessage(input.payload);
 					}),
 

--- a/packages/chat-mastra/src/server/trpc/utils/runtime/runtime.test.ts
+++ b/packages/chat-mastra/src/server/trpc/utils/runtime/runtime.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "bun:test";
+import type { RuntimeSession } from "./runtime";
+import {
+	extractRuntimeErrorMessage,
+	normalizeRuntimeErrorMessage,
+	subscribeToSessionEvents,
+} from "./runtime";
+
+function createEventRuntime(): {
+	runtime: RuntimeSession;
+	emit: (event: unknown) => void;
+	stopReasons: string[];
+} {
+	let subscriber: ((event: unknown) => void) | null = null;
+	const stopReasons: string[] = [];
+
+	const runtime = {
+		sessionId: "session_test",
+		harness: {
+			subscribe(callback: (event: unknown) => void) {
+				subscriber = callback;
+			},
+			listMessages: async () => [],
+			getCurrentMode: () => ({
+				agent: {
+					generateTitleFromUserMessage: async () => "",
+				},
+			}),
+			getFullModelId: () => "model-id",
+		},
+		mcpManager: {},
+		hookManager: {
+			runStop: (_: unknown, reason: string) => {
+				stopReasons.push(reason);
+				return Promise.resolve();
+			},
+		},
+		mcpManualStatuses: new Map(),
+		cwd: "/tmp/workspace",
+		lastErrorMessage: "previous error",
+	} as unknown as RuntimeSession;
+
+	return {
+		runtime,
+		emit: (event: unknown) => subscriber?.(event),
+		stopReasons,
+	};
+}
+
+describe("normalizeRuntimeErrorMessage", () => {
+	it("strips AI_APICallErrorN prefixes", () => {
+		expect(
+			normalizeRuntimeErrorMessage(
+				"AI_APICallError2: AI_APICallError9: Upstream provider timed out",
+			),
+		).toBe("Upstream provider timed out");
+	});
+});
+
+describe("extractRuntimeErrorMessage", () => {
+	it("extracts nested provider errors from runtime event shapes", () => {
+		const message = extractRuntimeErrorMessage({
+			type: "workspace_error",
+			error: {
+				cause: {
+					responseBody: {
+						error: {
+							message: "AI_APICallError5: Rate limit exceeded",
+						},
+					},
+				},
+			},
+		});
+
+		expect(message).toBe("Rate limit exceeded");
+	});
+});
+
+describe("subscribeToSessionEvents", () => {
+	it("captures error and workspace_error messages and clears on agent_start", () => {
+		const { runtime, emit } = createEventRuntime();
+		subscribeToSessionEvents(
+			runtime,
+			{
+				chat: { updateTitle: { mutate: async () => undefined } },
+			} as never,
+		);
+
+		emit({
+			type: "error",
+			error: {
+				cause: {
+					responseBody: {
+						error: { message: "AI_APICallError3: Provider unavailable" },
+					},
+				},
+			},
+		});
+		expect(runtime.lastErrorMessage).toBe("Provider unavailable");
+
+		emit({
+			type: "workspace_error",
+			payload: {
+				error: "Workspace failed to initialize",
+			},
+		});
+		expect(runtime.lastErrorMessage).toBe("Workspace failed to initialize");
+
+		emit({ type: "agent_start" });
+		expect(runtime.lastErrorMessage).toBeNull();
+	});
+
+	it("does not clear lastErrorMessage on agent_end complete", () => {
+		const { runtime, emit, stopReasons } = createEventRuntime();
+		runtime.lastErrorMessage = "Keep this error visible";
+		subscribeToSessionEvents(
+			runtime,
+			{
+				chat: { updateTitle: { mutate: async () => undefined } },
+			} as never,
+		);
+
+		emit({ type: "agent_end", reason: "complete" });
+
+		expect(runtime.lastErrorMessage).toBe("Keep this error visible");
+		expect(stopReasons).toEqual(["complete"]);
+	});
+});

--- a/packages/chat-mastra/src/server/trpc/utils/runtime/runtime.ts
+++ b/packages/chat-mastra/src/server/trpc/utils/runtime/runtime.ts
@@ -25,6 +25,7 @@ export interface RuntimeSession {
 	hookManager: RuntimeHookManager;
 	mcpManualStatuses: Map<string, RuntimeMcpServerStatus>;
 	cwd: string;
+	lastErrorMessage?: string | null;
 }
 
 type ApiClient = ReturnType<typeof createTRPCClient<AppRouter>>;
@@ -36,6 +37,127 @@ interface TextContentPart {
 interface MessageLike {
 	role: string;
 	content: Array<{ type: string; text?: string }>;
+}
+
+const AI_API_CALL_ERROR_PREFIX = /^\s*AI_APICallError\d*:\s*/;
+const MAX_ERROR_PARSE_DEPTH = 12;
+const GENERIC_ERROR_TOKENS = new Set([
+	"error",
+	"workspace_error",
+	"agent_start",
+	"agent_end",
+]);
+
+function toNonEmptyString(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+	return value as Record<string, unknown>;
+}
+
+export function normalizeRuntimeErrorMessage(message: string): string {
+	let normalized = message.trim();
+	while (AI_API_CALL_ERROR_PREFIX.test(normalized)) {
+		normalized = normalized.replace(AI_API_CALL_ERROR_PREFIX, "").trim();
+	}
+	return normalized;
+}
+
+function toUserFacingErrorMessage(message: string): string | null {
+	const normalized = normalizeRuntimeErrorMessage(message);
+	if (normalized.length === 0) return null;
+	const lower = normalized.toLowerCase();
+	if (GENERIC_ERROR_TOKENS.has(lower)) return null;
+	return normalized;
+}
+
+function extractRuntimeErrorMessageFromUnknown(
+	value: unknown,
+	seen: WeakSet<object>,
+	depth = 0,
+): string | null {
+	if (depth > MAX_ERROR_PARSE_DEPTH) return null;
+
+	const asString = toNonEmptyString(value);
+	if (asString) {
+		return toUserFacingErrorMessage(asString);
+	}
+
+	if (value instanceof Error) {
+		const ownMessage = toNonEmptyString(value.message);
+		if (ownMessage) {
+			return normalizeRuntimeErrorMessage(ownMessage);
+		}
+
+		const causeMessage = extractRuntimeErrorMessageFromUnknown(
+			(value as Error & { cause?: unknown }).cause,
+			seen,
+			depth + 1,
+		);
+		if (causeMessage) return causeMessage;
+	}
+
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			const nested = extractRuntimeErrorMessageFromUnknown(item, seen, depth + 1);
+			if (nested) return nested;
+		}
+		return null;
+	}
+
+	const record = asRecord(value);
+	if (!record) return null;
+	if (seen.has(record)) return null;
+	seen.add(record);
+
+	// Prioritize nested provider payloads where actionable messages usually live.
+	const preferredKeys = [
+		"userFacingMessage",
+		"displayMessage",
+		"error",
+		"cause",
+		"data",
+		"details",
+		"responseBody",
+		"body",
+		"payload",
+		"result",
+	];
+	for (const key of preferredKeys) {
+		const nested = extractRuntimeErrorMessageFromUnknown(
+			record[key],
+			seen,
+			depth + 1,
+		);
+		if (nested) return nested;
+	}
+
+	const messageKeys = ["message", "errorMessage", "reason"];
+	for (const key of messageKeys) {
+		const message = toNonEmptyString(record[key]);
+		if (!message) continue;
+		const normalized = toUserFacingErrorMessage(message);
+		if (normalized) return normalized;
+	}
+
+	for (const nestedValue of Object.values(record)) {
+		const nested = extractRuntimeErrorMessageFromUnknown(
+			nestedValue,
+			seen,
+			depth + 1,
+		);
+		if (nested) return nested;
+	}
+
+	return null;
+}
+
+export function extractRuntimeErrorMessage(value: unknown): string | null {
+	return extractRuntimeErrorMessageFromUnknown(value, new WeakSet(), 0);
 }
 
 /**
@@ -96,9 +218,27 @@ export function subscribeToSessionEvents(
 	runtime: RuntimeSession,
 	apiClient: ApiClient,
 ): void {
-	runtime.harness.subscribe((event: { type: string; reason?: string }) => {
-		if (event.type === "agent_end") {
-			const raw = event.reason;
+	runtime.harness.subscribe((event: unknown) => {
+		const eventRecord = asRecord(event);
+		if (!eventRecord) return;
+		const eventType = toNonEmptyString(eventRecord.type);
+		if (!eventType) return;
+
+		if (eventType === "agent_start") {
+			runtime.lastErrorMessage = null;
+			return;
+		}
+
+		if (eventType === "error" || eventType === "workspace_error") {
+			const message = extractRuntimeErrorMessage(eventRecord);
+			if (message) {
+				runtime.lastErrorMessage = message;
+			}
+			return;
+		}
+
+		if (eventType === "agent_end") {
+			const raw = toNonEmptyString(eventRecord.reason);
 			const reason = raw === "aborted" || raw === "error" ? raw : "complete";
 			if (runtime.hookManager) {
 				void runtime.hookManager.runStop(undefined, reason).catch(() => {});


### PR DESCRIPTION
## Summary
- add runtime `lastErrorMessage` tracking on session state
- capture `error` and `workspace_error` events, extract nested provider/runtime messages, and normalize `AI_APICallErrorN:` prefixes
- clear runtime error on `agent_start` and before `sendMessage`; keep error visible across `agent_end` with reason `complete`
- have `getDisplayState` return `errorMessage` from current assistant error first, then runtime `lastErrorMessage`
- update chat display hook to prefer runtime `errorMessage`, fallback to latest assistant error, and avoid stale error after later successful assistant message

## Scope guardrails
- only touched chat error-surfacing files in `packages/chat-mastra`
- no auth/model-picker/OAuth/router auth changes

## Validation
- `bun test packages/chat-mastra/src/server/trpc/utils/runtime/runtime.test.ts`
- `bun test packages/chat-mastra/src/client/hooks/use-mastra-chat-display/use-mastra-chat-display.test.ts`

Both tests passed locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved error message handling and display in chat conversations with enhanced error extraction and normalization.
  * Error messages are now properly tracked and displayed during chat interactions with better user-facing error reporting.
  * Robust error handling supports more complex error scenarios throughout the chat system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->