### PR TITLE
fix(agent): replace in-memory store with postgres to fix memory leak

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -16,8 +16,9 @@
 	"dependencies": {
 		"@ai-sdk/anthropic": "^3.0.43",
 		"@mastra/ai-sdk": "^1.0.4",
-		"@mastra/core": "^1.3.0",
-		"@mastra/memory": "^1.2.0",
+		"@mastra/core": "^1.8.0",
+		"@mastra/memory": "^1.5.2",
+		"@mastra/pg": "^1.7.0",
 		"cheerio": "^1.2.0",
 		"mastracode": "^0.4.0",
 		"zod": "^4.3.5"

--- a/packages/agent/src/superagent.ts
+++ b/packages/agent/src/superagent.ts
@@ -1,13 +1,13 @@
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { Agent } from "@mastra/core/agent";
 import { Mastra } from "@mastra/core/mastra";
-import { InMemoryStore } from "@mastra/core/storage";
 import {
 	LocalFilesystem,
 	LocalSandbox,
 	Workspace,
 } from "@mastra/core/workspace";
 import { Memory } from "@mastra/memory";
+import { PostgresStore } from "@mastra/pg";
 import { askUserQuestionTool, webFetchTool, webSearchTool } from "./tools";
 
 // ---------------------------------------------------------------------------
@@ -92,7 +92,10 @@ function resolveModel({
 	return modelId;
 }
 
-export const storage = new InMemoryStore({ id: "superagent-db" });
+export const storage = new PostgresStore({
+	connectionString:
+		process.env.DATABASE_URL_UNPOOLED ?? process.env.DATABASE_URL ?? "",
+});
 
 export const memory = new Memory({
 	options: {


### PR DESCRIPTION
## Summary

- `InMemoryStore` in `packages/agent/src/superagent.ts` is a process-singleton JS `Map` that accumulates every agent session's conversation history, tool call results, and approval snapshots — and is never pruned or evicted
- with many agents running many sessions (codex, claude, opencode, etc.) the node.js heap grows unboundedly, causing slowdowns and eventual oom crashes
- replaces it with `PostgresStore` from `@mastra/pg` (already in the lockfile via `mastracode`) backed by the existing neon connection (`DATABASE_URL_UNPOOLED` → `DATABASE_URL`)
- heap usage stays flat regardless of session count; storage is durable across restarts as a bonus

## Changes

- `packages/agent/src/superagent.ts` — swap `InMemoryStore` → `PostgresStore`
- `packages/agent/package.json` — add `@mastra/pg ^1.7.0`, bump `@mastra/core` to `^1.8.0` and `@mastra/memory` to `^1.5.2` to match what is already resolved in the lockfile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Updated core and memory packages to latest versions with enhanced features and stability improvements
  * Added PostgreSQL database support for improved storage capabilities

* **Infrastructure**
  * Agent storage mechanism upgraded from temporary in-memory storage to PostgreSQL-backed persistence, ensuring data retention across application sessions and restarts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->