### PR TITLE
fix(desktop): prevent browser pane reload on tab switch

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
@@ -11,6 +11,7 @@ const webviewRegistry = new Map<string, Electron.WebviewTag>();
 const registeredWebContentsIds = new Map<string, number>();
 let persistentContainer: HTMLDivElement | null = null;
 
+/** Lazily creates a 0×0 fixed container on `<body>` that holds all webviews. */
 function getPersistentContainer(): HTMLDivElement {
 	if (!persistentContainer) {
 		persistentContainer = document.createElement("div");
@@ -42,6 +43,7 @@ const pointerEventsRefCounts = new WeakMap<
 	{ noneCount: number; autoCount: number; original: string }
 >();
 
+/** Ref-count a pointer-events override on `el`; `"none"` always wins over `"auto"`. */
 function acquirePointerEvents(el: HTMLElement, value: "none" | "auto"): void {
 	let entry = pointerEventsRefCounts.get(el);
 	if (!entry) {
@@ -54,6 +56,7 @@ function acquirePointerEvents(el: HTMLElement, value: "none" | "auto"): void {
 	el.style.pointerEvents = entry.noneCount > 0 ? "none" : "auto";
 }
 
+/** Release a previously acquired pointer-events override; restores original when all refs drop. */
 function releasePointerEvents(el: HTMLElement, value: "none" | "auto"): void {
 	const entry = pointerEventsRefCounts.get(el);
 	if (!entry) return;
@@ -98,6 +101,7 @@ function createPointerEventsHole(container: HTMLElement): () => void {
 	};
 }
 
+/** Copies the container's bounding rect onto the fixed-position webview. */
 function syncBounds(
 	webview: Electron.WebviewTag,
 	container: HTMLElement,
@@ -109,7 +113,7 @@ function syncBounds(
 	webview.style.height = `${rect.height}px`;
 }
 
-/** Call from useBrowserLifecycle when a pane is removed. */
+/** Removes the webview element and cleans up registry entries for a closed pane. */
 export function destroyPersistentWebview(paneId: string): void {
 	const webview = webviewRegistry.get(paneId);
 	if (webview) {
@@ -123,6 +127,7 @@ export function destroyPersistentWebview(paneId: string): void {
 // Helpers
 // ---------------------------------------------------------------------------
 
+/** Normalises user input into a loadable URL (adds protocol or falls back to Google search). */
 function sanitizeUrl(url: string): string {
 	if (/^https?:\/\//i.test(url) || url.startsWith("about:")) {
 		return url;
@@ -145,6 +150,11 @@ interface UsePersistentWebviewOptions {
 	initialUrl: string;
 }
 
+/**
+ * Manages a persistent `<webview>` that lives outside the React tree to avoid
+ * reload-on-reparent. Syncs position via `ResizeObserver` and punches a
+ * pointer-events hole through ancestors so the webview receives input.
+ */
 export function usePersistentWebview({
 	paneId,
 	initialUrl,


### PR DESCRIPTION
## Description

Switching tabs caused `<webview>` elements to fully reload, losing scroll position, form inputs, and page state. The root cause was `container.appendChild(webview)` — reparenting a webview to a different DOM node destroys and recreates its Electron renderer process.

The webview now lives permanently in a fixed-position container appended to `<body>` and is never reparented. On mount it becomes visible and its bounds are synced to the React placeholder div via `getBoundingClientRect` + `ResizeObserver`. On unmount it is hidden with `visibility: hidden`.

Because the webview sits outside the `<app>` React tree, a pointer-events hole is punched through the ancestor chain (container → `<app>`) so DOM hit-testing reaches the webview. Siblings at each level get `pointer-events: auto` so the rest of the UI stays interactive.

## Related Issues

Closes #1637

## Type of Change

- [x] Bug fix

## Testing

- Verified webview renders correctly with proper bounds
- Verified clicking and scrolling works within the webview
- Verified switching tabs preserves page state (no reload)
- Verified rest of UI (sidebar, toolbar, other panes) remains interactive
- TypeScript compiles cleanly (`bun run typecheck --filter=@superset/desktop`)

## Screenshots (if applicable)

N/A

## Additional Notes

**Key changes in `usePersistentWebview.ts`:**

1. **Persistent container**: Webview is appended once to a `position: fixed; width: 0; height: 0; overflow: visible` div on `<body>` and never moved
2. **Bounds syncing**: `syncBounds()` reads `container.getBoundingClientRect()` and positions the webview as a fixed overlay; a `ResizeObserver` keeps it in sync
3. **Pointer-events hole**: `createPointerEventsHole()` walks from the container to `<app>`, setting `pointer-events: none` on each ancestor and `pointer-events: auto` on their siblings, restored on unmount

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents webview reloads on tab switch by keeping the Electron webview persistent and syncing its bounds to the React container. Preserves page state, keeps the UI interactive, supports multiple panes safely, and adds concise JSDoc docs for the lifecycle. Closes #1637.

- **Bug Fixes**
  - Webview stays in a fixed, 0×0 container on <body> (overflow: visible) and is never reparented.
  - Bounds synced to the React placeholder via getBoundingClientRect and a ResizeObserver (disconnected on unmount).
  - On unmount, webview is hidden (visibility: hidden; pointer-events: none) instead of moved.
  - Pointer-events hole from the placeholder up to <app>; siblings set to pointer-events: auto; now ref-counted and tracks none/auto separately so "none" always wins, ensuring shared ancestors work correctly across multiple panes.

<sup>Written for commit 0c8cea2f9a40324a9beede37efe9c9e3788fb50e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Webviews are moved to a persistent, off-React container for smoother tab switching, parking/restoration, and more reliable sizing.

* **Bug Fixes**
  * Improved pointer-event handling and continuous layout sync to prevent missed clicks, drag issues, and visual glitches during activation and window resizes.

* **New Features**
  * Added lifecycle controls and reuse/reclamation for persistent webviews plus an API to explicitly destroy a pane's persistent webview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->