### PR TITLE
Fix typo: boy scoute to boy scout

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,6 @@ Please note we have a [code of conduct](./CODE_OF_CONDUCT.md), please follow it 
 
 ## Style guide
 
-We try to follow guidelines from [Clean Code](https://gist.github.com/wojteklu/73c6914cc446146b8b533c0988cf8d29) and the boy scoute rule:
+We try to follow guidelines from [Clean Code](https://gist.github.com/wojteklu/73c6914cc446146b8b533c0988cf8d29) and the boy scout rule:
 
 "Leave the code cleaner, not messier, than how you found it". 


### PR DESCRIPTION
Fixes typo in CONTRIBUTING.md where 'boy scoute rule' should be 'boy scout rule'.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a typo in CONTRIBUTING.md: "boy scoute rule" -> "boy scout rule" in the style guide.

<sup>Written for commit 5bf292b0858ec9de2f86687001b454653014e296. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typographical error in the contribution guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->