### PR TITLE
Adding Autohand Code CLI integration

### DIFF
--- a/.autohand/commands
+++ b/.autohand/commands
@@ -1,0 +1,1 @@
+../.agents/commands

--- a/.autohand/config.json
+++ b/.autohand/config.json
@@ -1,0 +1,44 @@
+{
+  "mcp": {
+    "servers": [
+      {
+        "name": "superset",
+        "transport": "http",
+        "url": "https://api.superset.sh/api/agent/mcp"
+      },
+      {
+        "name": "expo-mcp",
+        "transport": "http",
+        "url": "https://mcp.expo.dev/mcp",
+        "enabled": false
+      },
+      {
+        "name": "maestro",
+        "transport": "stdio",
+        "command": "maestro",
+        "args": ["mcp"]
+      },
+      {
+        "name": "neon",
+        "transport": "http",
+        "url": "https://mcp.neon.tech/mcp"
+      },
+      {
+        "name": "linear",
+        "transport": "http",
+        "url": "https://mcp.linear.app/mcp"
+      },
+      {
+        "name": "sentry",
+        "transport": "http",
+        "url": "https://mcp.sentry.dev/mcp"
+      },
+      {
+        "name": "desktop-automation",
+        "transport": "stdio",
+        "command": "bun",
+        "args": ["run", "packages/desktop-mcp/src/bin.ts"]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,8 @@ superset-dev-data/
 !.codex/config.toml
 !.codex/commands
 !.codex/prompts
+
+# Autohand workspace config (track only shared config/symlinks; ignore runtime state)
+.autohand/*
+!.autohand/config.json
+!.autohand/commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,8 +70,8 @@ bun run clean:workspaces   # Clean all workspace node_modules
 ## Agent Rules
 1. **Type safety** - avoid `any` unless necessary
 2. **Prefer `gh` CLI** - when performing git operations (PRs, issues, checkout, etc.), prefer the GitHub CLI (`gh`) over raw `git` commands where possible
-3. **Shared command source** - keep command definitions in `.agents/commands/` only. `.claude/commands` and `.cursor/commands` should be symlinks to `../.agents/commands`. (`packages/chat` discovers slash commands from `.claude/commands`.)
-4. **Workspace MCP config** - keep shared MCP servers in `.mcp.json`; `.cursor/mcp.json` should link to `../.mcp.json`. Codex uses `.codex/config.toml` (run with `CODEX_HOME=.codex codex ...`). OpenCode uses `opencode.json` and should mirror the same MCP set using OpenCode's `remote`/`local` schema.
+3. **Shared command source** - keep command definitions in `.agents/commands/` only. `.claude/commands`, `.cursor/commands`, `.codex/commands`, and `.autohand/commands` should be symlinks to `../.agents/commands`. (`packages/chat` discovers slash commands from `.claude/commands`.)
+4. **Workspace MCP config** - keep shared MCP servers in `.mcp.json`; `.cursor/mcp.json` should link to `../.mcp.json`. Codex uses `.codex/config.toml` (run with `CODEX_HOME=.codex codex ...`). OpenCode uses `opencode.json` and should mirror the same MCP set using OpenCode's `remote`/`local` schema. Autohand uses `.autohand/config.json` with MCP servers under `mcp.servers[]` (array format with `name`, `transport`, `url`/`command` fields).
 5. **Mastracode fork workflow** - for Superset's internal `mastracode` fork bundle and release process, follow `docs/mastracode-fork-workflow.md`.
 
 ---

--- a/apps/desktop/src/lib/trpc/routers/settings/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/index.ts
@@ -95,6 +95,7 @@ const DEFAULT_PRESET_AGENTS = [
 	"copilot",
 	"opencode",
 	"gemini",
+	"autohand",
 ] as const;
 
 const DEFAULT_PRESETS: Omit<TerminalPreset, "id">[] = DEFAULT_PRESET_AGENTS.map(

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-autohand.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-autohand.ts
@@ -1,0 +1,120 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+	buildWrapperScript,
+	createWrapper,
+	isSupersetManagedHookCommand,
+	writeFileIfChanged,
+} from "./agent-wrappers-common";
+import { getNotifyScriptPath, NOTIFY_SCRIPT_NAME } from "./notify-hook";
+
+interface AutohandHookEntry {
+	event: string;
+	command: string;
+	enabled: boolean;
+	[key: string]: unknown;
+}
+
+interface AutohandHooksSection {
+	enabled?: boolean;
+	hooks?: AutohandHookEntry[];
+	[key: string]: unknown;
+}
+
+interface AutohandConfig {
+	provider?: string;
+	hooks?: AutohandHooksSection;
+	[key: string]: unknown;
+}
+
+function quoteShellPath(filePath: string): string {
+	return `'${filePath.replaceAll("'", "'\\''")}'`;
+}
+
+export function getAutohandGlobalConfigPath(): string {
+	const autohandHome =
+		process.env.AUTOHAND_HOME || path.join(os.homedir(), ".autohand");
+	return path.join(autohandHome, "config.json");
+}
+
+export function createAutohandWrapper(): void {
+	const script = buildWrapperScript("autohand", `exec "$REAL_BIN" "$@"`);
+	createWrapper("autohand", script);
+}
+
+/**
+ * Reads existing ~/.autohand/config.json (or $AUTOHAND_HOME/config.json),
+ * merges our hook entries (identified by notify script path), and preserves
+ * all non-hook settings (provider, workspace, ui, permissions, mcp, etc.).
+ *
+ * Autohand uses a nested hooks format:
+ *   { hooks: { enabled: true, hooks: [{ event, command, enabled }] } }
+ *
+ * Event mapping (Superset -> Autohand):
+ *   UserPromptSubmit -> pre-prompt
+ *   Stop -> stop
+ *   PostToolUse -> post-tool
+ */
+export function getAutohandHooksConfigContent(
+	notifyScriptPath: string,
+): string {
+	const globalPath = getAutohandGlobalConfigPath();
+
+	let existing: AutohandConfig = {};
+	try {
+		if (fs.existsSync(globalPath)) {
+			existing = JSON.parse(fs.readFileSync(globalPath, "utf-8"));
+		}
+	} catch {
+		console.warn(
+			"[agent-setup] Could not parse existing Autohand config.json, merging carefully",
+		);
+	}
+
+	if (!existing.hooks || typeof existing.hooks !== "object") {
+		existing.hooks = { enabled: true, hooks: [] };
+	}
+
+	if (existing.hooks.enabled === undefined) {
+		existing.hooks.enabled = true;
+	}
+
+	const notifyCommand = `bash ${quoteShellPath(notifyScriptPath)}`;
+	const managedEvents = ["pre-prompt", "stop", "post-tool"] as const;
+
+	const currentHooks = Array.isArray(existing.hooks.hooks)
+		? existing.hooks.hooks
+		: [];
+
+	// Filter out stale Superset-managed hooks
+	const filtered = currentHooks.filter(
+		(entry: AutohandHookEntry) =>
+			!(
+				entry.command?.includes(notifyScriptPath) ||
+				isSupersetManagedHookCommand(entry.command, NOTIFY_SCRIPT_NAME)
+			),
+	);
+
+	// Add fresh hooks for all managed events
+	for (const event of managedEvents) {
+		filtered.push({ event, command: notifyCommand, enabled: true });
+	}
+
+	existing.hooks.hooks = filtered;
+
+	return JSON.stringify(existing, null, 2);
+}
+
+export function createAutohandHooksConfig(): void {
+	const notifyScriptPath = getNotifyScriptPath();
+	const globalPath = getAutohandGlobalConfigPath();
+	const content = getAutohandHooksConfigContent(notifyScriptPath);
+
+	const dir = path.dirname(globalPath);
+	fs.mkdirSync(dir, { recursive: true });
+	const changed = writeFileIfChanged(globalPath, content, 0o644);
+	console.log(
+		`[agent-setup] ${changed ? "Updated" : "Verified"} Autohand config.json`,
+	);
+}

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -59,10 +59,12 @@ const {
 	buildCodexWrapperExecLine,
 	buildCopilotWrapperExecLine,
 	buildWrapperScript,
+	createAutohandWrapper,
 	createCodexWrapper,
 	createMastraWrapper,
-	getCursorHooksJsonContent,
+	getAutohandHooksConfigContent,
 	getCopilotHookScriptPath,
+	getCursorHooksJsonContent,
 	getGeminiSettingsJsonContent,
 	getMastraHooksJsonContent,
 } = await import("./agent-wrappers");
@@ -375,5 +377,80 @@ describe("agent-wrappers copilot", () => {
 			),
 		).toBe(true);
 		expect(JSON.parse(content2)).toEqual(JSON.parse(content));
+	});
+
+	it("replaces stale Autohand hook commands from old superset paths", () => {
+		const autohandConfigDir = path.join(mockedHomeDir, ".autohand");
+		const autohandConfigPath = path.join(autohandConfigDir, "config.json");
+		const staleHookPath = "/tmp/.superset-old/hooks/notify.sh";
+		const currentHookPath = "/tmp/.superset-new/hooks/notify.sh";
+
+		mkdirSync(autohandConfigDir, { recursive: true });
+		writeFileSync(
+			autohandConfigPath,
+			JSON.stringify(
+				{
+					provider: "openrouter",
+					hooks: {
+						enabled: true,
+						hooks: [
+							{ event: "pre-prompt", command: `bash '${staleHookPath}'`, enabled: true },
+							{ event: "stop", command: `bash '${staleHookPath}'`, enabled: true },
+							{ event: "post-tool", command: `bash '${staleHookPath}'`, enabled: true },
+							{ event: "session-start", command: "/usr/local/bin/custom-hook", enabled: true },
+						],
+					},
+				},
+				null,
+				2,
+			),
+		);
+
+		const content = getAutohandHooksConfigContent(currentHookPath);
+		writeFileSync(autohandConfigPath, content);
+		const content2 = getAutohandHooksConfigContent(currentHookPath);
+
+		const parsed = JSON.parse(content) as {
+			provider?: string;
+			hooks?: { enabled?: boolean; hooks?: Array<{ event: string; command: string; enabled: boolean }> };
+		};
+		const managedEvents = ["pre-prompt", "stop", "post-tool"] as const;
+
+		// Verify provider config is preserved
+		expect(parsed.provider).toBe("openrouter");
+
+		// Verify hooks are enabled
+		expect(parsed.hooks?.enabled).toBe(true);
+
+		const hooks = parsed.hooks?.hooks ?? [];
+
+		for (const eventName of managedEvents) {
+			const eventHooks = hooks.filter((h) => h.event === eventName);
+			expect(eventHooks.length).toBe(1);
+			expect(eventHooks[0].command).toBe(`bash '${currentHookPath}'`);
+			expect(eventHooks[0].enabled).toBe(true);
+			expect(
+				eventHooks.some((h) => h.command.includes(staleHookPath)),
+			).toBe(false);
+		}
+
+		// Verify user-defined hooks are preserved
+		const customHooks = hooks.filter((h) => h.event === "session-start");
+		expect(customHooks.length).toBe(1);
+		expect(customHooks[0].command).toBe("/usr/local/bin/custom-hook");
+
+		// Idempotency check
+		expect(JSON.parse(content2)).toEqual(JSON.parse(content));
+	});
+
+	it("creates autohand wrapper passthrough", () => {
+		createAutohandWrapper();
+
+		const wrapperPath = path.join(TEST_BIN_DIR, "autohand");
+		const wrapper = readFileSync(wrapperPath, "utf-8");
+
+		expect(wrapper).toContain("# Superset wrapper for autohand");
+		expect(wrapper).toContain('REAL_BIN="$(find_real_binary "autohand")"');
+		expect(wrapper).toContain('exec "$REAL_BIN" "$@"');
 	});
 });

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts
@@ -57,3 +57,9 @@ export {
 	getMastraGlobalHooksJsonPath,
 	getMastraHooksJsonContent,
 } from "./agent-wrappers-mastra";
+export {
+	createAutohandHooksConfig,
+	createAutohandWrapper,
+	getAutohandGlobalConfigPath,
+	getAutohandHooksConfigContent,
+} from "./agent-wrappers-autohand";

--- a/apps/desktop/src/main/lib/agent-setup/index.ts
+++ b/apps/desktop/src/main/lib/agent-setup/index.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
 import {
 	cleanupGlobalOpenCodePlugin,
+	createAutohandHooksConfig,
+	createAutohandWrapper,
 	createClaudeWrapper,
 	createCodexWrapper,
 	createCopilotHookScript,
@@ -58,6 +60,8 @@ export function setupAgentHooks(): void {
 	createMastraHooksJson();
 	createCopilotHookScript();
 	createCopilotWrapper();
+	createAutohandWrapper();
+	createAutohandHooksConfig();
 
 	createZshWrapper();
 	createBashWrapper();

--- a/apps/desktop/src/main/lib/agent-setup/shell-wrappers.ts
+++ b/apps/desktop/src/main/lib/agent-setup/shell-wrappers.ts
@@ -53,6 +53,7 @@ const SHIMMED_BINARIES = [
 	"gemini",
 	"copilot",
 	"mastracode",
+	"autohand",
 ];
 
 /**

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/components/QuickAddPresets/QuickAddPresets.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/components/QuickAddPresets/QuickAddPresets.tsx
@@ -1,3 +1,4 @@
+import { AGENT_LABELS } from "@superset/shared/agent-command";
 import { Button } from "@superset/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { HiOutlineCheck } from "react-icons/hi2";
@@ -46,7 +47,7 @@ export function QuickAddPresets({
 										className="h-3 w-3 object-contain"
 									/>
 								) : null}
-								{template.name}
+								{AGENT_LABELS[template.name as keyof typeof AGENT_LABELS] || template.name}
 							</Button>
 						</TooltipTrigger>
 						<TooltipContent side="bottom" showArrow={false}>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/components/AddTabButton/components/PresetsSubmenu/PresetsSubmenu.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/components/AddTabButton/components/PresetsSubmenu/PresetsSubmenu.tsx
@@ -1,3 +1,4 @@
+import { AGENT_LABELS } from "@superset/shared/agent-command";
 import type { TerminalPreset } from "@superset/local-db";
 import {
 	DropdownMenuItem,
@@ -53,7 +54,7 @@ export function PresetsSubmenu({
 								) : (
 									<HiMiniCommandLine className="size-4" />
 								)}
-								<span className="truncate">{preset.name || "default"}</span>
+								<span className="truncate">{AGENT_LABELS[preset.name as keyof typeof AGENT_LABELS] || preset.name || "default"}</span>
 								{hotkeyId ? <HotkeyMenuShortcut hotkeyId={hotkeyId} /> : null}
 							</DropdownMenuItem>
 						);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar/PresetsBar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar/PresetsBar.tsx
@@ -1,4 +1,5 @@
 import {
+	AGENT_LABELS,
 	AGENT_PRESET_COMMANDS,
 	AGENT_PRESET_DESCRIPTIONS,
 	AGENT_TYPES,
@@ -374,7 +375,7 @@ export function PresetsBar() {
 								) : (
 									<HiMiniCommandLine className="size-4" />
 								)}
-								<span className="truncate">{item.name || "default"}</span>
+								<span className="truncate">{AGENT_LABELS[item.name as keyof typeof AGENT_LABELS] || item.name || "default"}</span>
 								<div className="ml-auto flex items-center gap-2">
 									{hotkeyId ? <HotkeyMenuShortcut hotkeyId={hotkeyId} /> : null}
 									{hasPreset ? (

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar/components/PresetBarItem/PresetBarItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar/components/PresetBarItem/PresetBarItem.tsx
@@ -1,3 +1,4 @@
+import { AGENT_LABELS } from "@superset/shared/agent-command";
 import type { TerminalPreset } from "@superset/local-db";
 import { Button } from "@superset/ui/button";
 import {
@@ -104,7 +105,7 @@ export function PresetBarItem({
 									<HiMiniCommandLine className="size-3.5" />
 								)}
 								<span className="truncate max-w-[120px]">
-									{preset.name || "default"}
+									{AGENT_LABELS[preset.name as keyof typeof AGENT_LABELS] || preset.name || "default"}
 								</span>
 							</Button>
 						</TooltipTrigger>

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "@superset/repo",
@@ -108,7 +107,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.0.1",
+      "version": "1.0.3",
       "dependencies": {
         "@ai-sdk/react": "^3.0.0",
         "@ast-grep/napi": "^0.41.0",
@@ -835,9 +834,9 @@
 
     "@a2a-js/sdk": ["@a2a-js/sdk@0.2.5", "", { "dependencies": { "@types/cors": "^2.8.17", "@types/express": "^4.17.23", "body-parser": "^2.2.0", "cors": "^2.8.5", "express": "^4.21.2", "uuid": "^11.1.0" } }, "sha512-VTDuRS5V0ATbJ/LkaQlisMnTAeYKXAK6scMguVBstf+KIBQ7HIuKhiXLv+G/hvejkV+THoXzoNifInAkU81P1g=="],
 
-    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.48", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-QSvz0XumBFaxulalUB+3D2/tLvfsYjIcG3HlqOxmmXIzATIBLInTVEw0Sy3yXJjqhNQZedBokVrN53Bh/V+eWQ=="],
+    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.49", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-EU/odEtJeqAWY9gRgCBQEK3m1p9nXPdGuvy4XF4q5TFJqUD+x5ykGUpJUL7Eo+pzXddHP+VyP8yW12FpB9EsYA=="],
 
-    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.57", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-3MugqOlGfCOjlsBGGARJ5Zrioh78X3+rulHCayCMPySYKY+wc8GGFlFCCh4mleWQFShjMyqWT7eeLTuVSj/WSg=="],
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.58", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-2e1hBCKsd+7m0hELwrakR1QDfZfFhz9PF2d4qb8TxQueEyApo7ydlEWRpXeKC+KdA2FRV21dMb1G6FxdeNDa2w=="],
 
     "@ai-sdk/openai": ["@ai-sdk/openai@3.0.36", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-foY3onGY8l3q9niMw0Cwe9xrYnm46keIWL57NRw6F3DKzSW9TYTfx0cQJs/j8lXJ8lPzqNxpMO/zXOkqCUt3IQ=="],
 
@@ -2647,7 +2646,7 @@
 
     "aggregate-error": ["aggregate-error@4.0.1", "", { "dependencies": { "clean-stack": "^4.0.0", "indent-string": "^5.0.0" } }, "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w=="],
 
-    "ai": ["ai@6.0.103", "", { "dependencies": { "@ai-sdk/gateway": "3.0.57", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-4eY6Ut4u41zKH+P2S/oLlZrwxeWQh4kIV1FjE34Jhoiwg+v1AyfSYM8FslXk9rTAtIIaOBimrCUqXacC5RBqJw=="],
+    "ai": ["ai@6.0.104", "", { "dependencies": { "@ai-sdk/gateway": "3.0.58", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-boYGxbtdsa1YX3uuN7BV0FvAL3sGq7p/RLAMonK94jyt5C7sKj6jfib3/wD12koqX53htLTI/l4tX0HqNFRMZQ=="],
 
     "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
@@ -5987,10 +5986,6 @@
 
     "make-fetch-happen/proc-log": ["proc-log@5.0.0", "", {}, "sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ=="],
 
-    "mastracode/@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.49", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-EU/odEtJeqAWY9gRgCBQEK3m1p9nXPdGuvy4XF4q5TFJqUD+x5ykGUpJUL7Eo+pzXddHP+VyP8yW12FpB9EsYA=="],
-
-    "mastracode/ai": ["ai@6.0.104", "", { "dependencies": { "@ai-sdk/gateway": "3.0.58", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-boYGxbtdsa1YX3uuN7BV0FvAL3sGq7p/RLAMonK94jyt5C7sKj6jfib3/wD12koqX53htLTI/l4tX0HqNFRMZQ=="],
-
     "matcher/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
@@ -7412,8 +7407,6 @@
     "jest-haste-map/jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
     "lighthouse-logger/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
-
-    "mastracode/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.58", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-2e1hBCKsd+7m0hELwrakR1QDfZfFhz9PF2d4qb8TxQueEyApo7ydlEWRpXeKC+KdA2FRV21dMb1G6FxdeNDa2w=="],
 
     "metro-babel-transformer/hermes-parser/hermes-estree": ["hermes-estree@0.32.0", "", {}, "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ=="],
 

--- a/docs/plans/2026-03-02-autohand-integration-design.md
+++ b/docs/plans/2026-03-02-autohand-integration-design.md
@@ -1,0 +1,101 @@
+# Autohand CLI Integration Design
+
+## Goal
+
+Add native support for Autohand Code CLI (`autohand`) to Superset, following the same integration patterns used by Codex, Gemini, and Mastra. Full feature parity: agent type, config-based hooks, shell wrapper, shell shim, SVG icons, UI preset, and MCP config.
+
+## Decisions
+
+- **Hook style:** Config-based hooks via `~/.autohand/config.json` (Mastra pattern)
+- **Danger mode:** `--unrestricted` flag (no approval prompts)
+- **Task command:** `autohand --unrestricted -p` + heredoc prompt
+- **Shell shim:** Yes, add to `SHIMMED_BINARIES`
+- **MCP config:** Project-level `.autohand/config.json` + commands symlink
+
+## Integration Points
+
+### 1. Agent Type (`packages/shared/src/agent-command.ts`)
+
+- Add `"autohand"` to `AGENT_TYPES`
+- `AGENT_LABELS`: `"Autohand"`
+- `AGENT_PRESET_COMMANDS`: `["autohand --unrestricted"]`
+- `AGENT_PRESET_DESCRIPTIONS`: `"Danger mode: All permissions auto-approved"`
+- `AGENT_COMMANDS` builder: `autohand --unrestricted -p` + heredoc
+
+### 2. Hook Config Writer (`apps/desktop/.../agent-wrappers-autohand.ts`)
+
+New file following Mastra pattern. Reads/merges `~/.autohand/config.json`:
+
+```json
+{
+  "hooks": {
+    "enabled": true,
+    "hooks": [
+      { "event": "pre-prompt", "command": "bash '/path/notify.sh'", "enabled": true },
+      { "event": "stop", "command": "bash '/path/notify.sh'", "enabled": true },
+      { "event": "post-tool", "command": "bash '/path/notify.sh'", "enabled": true }
+    ]
+  }
+}
+```
+
+Event mapping:
+- Superset `UserPromptSubmit` -> Autohand `pre-prompt`
+- Superset `Stop` -> Autohand `stop`
+- Superset `PostToolUse` -> Autohand `post-tool`
+
+Merge logic preserves all non-hook config (provider, workspace, ui, permissions).
+
+### 3. Shell Wrapper
+
+Simple exec passthrough (like Gemini): `exec "$REAL_BIN" "$@"`
+
+### 4. Shell Shim
+
+Add `"autohand"` to `SHIMMED_BINARIES` in `shell-wrappers.ts`.
+
+### 5. UI Icons
+
+Create `autohand.svg` and `autohand-white.svg` in preset-icons. Register in `PRESET_ICONS` map.
+
+### 6. UI Preset
+
+Add `"autohand"` to `DEFAULT_PRESET_AGENTS` in settings router.
+
+### 7. MCP Config (Project-level)
+
+Create `.autohand/config.json` at project root with MCP servers matching `.mcp.json`:
+
+```json
+{
+  "mcp": {
+    "servers": [
+      { "name": "superset", "transport": "http", "url": "https://api.superset.sh/api/agent/mcp" },
+      { "name": "neon", "transport": "http", "url": "https://mcp.neon.tech/mcp" },
+      { "name": "linear", "transport": "http", "url": "https://mcp.linear.app/mcp" },
+      { "name": "sentry", "transport": "http", "url": "https://mcp.sentry.dev/mcp" },
+      { "name": "maestro", "transport": "stdio", "command": "maestro", "args": ["mcp"] },
+      { "name": "desktop-automation", "transport": "stdio", "command": "bun", "args": ["run", "packages/desktop-mcp/src/bin.ts"] }
+    ]
+  }
+}
+```
+
+Create `.autohand/commands` symlink -> `../.agents/commands`.
+
+### 8. Tests
+
+Add to `agent-wrappers.test.ts`:
+- Hook merge preserves user config
+- Stale hook replacement
+- Wrapper creation
+
+## Commit Plan
+
+1. Add autohand agent type to shared package
+2. Create autohand hook config writer + wrapper
+3. Wire up in agent-setup index + shell shims
+4. Add SVG icons + register in preset-icons
+5. Add to default presets in settings router
+6. Add project-level MCP config + commands symlink
+7. Add tests

--- a/docs/plans/2026-03-02-autohand-integration-plan.md
+++ b/docs/plans/2026-03-02-autohand-integration-plan.md
@@ -1,0 +1,640 @@
+# Autohand CLI Integration — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add full native support for Autohand Code CLI to Superset with feature parity to existing agents (Codex, Gemini, Mastra).
+
+**Architecture:** Config-based hooks written to `~/.autohand/config.json` (matching Autohand's `HooksSettings` format), exec-passthrough shell wrapper, shell shim, SVG icons, UI preset, and project-level MCP config at `.autohand/config.json`.
+
+**Tech Stack:** TypeScript, Bun, SVG, shell scripting
+
+---
+
+### Task 1: Add autohand agent type to shared package
+
+**Files:**
+- Modify: `packages/shared/src/agent-command.ts`
+
+**Step 1: Add "autohand" to AGENT_TYPES array (line 1-8)**
+
+In `AGENT_TYPES`, add `"autohand"` after `"cursor-agent"`:
+
+```typescript
+export const AGENT_TYPES = [
+	"claude",
+	"codex",
+	"gemini",
+	"opencode",
+	"copilot",
+	"cursor-agent",
+	"autohand",
+] as const;
+```
+
+**Step 2: Add autohand to AGENT_LABELS (line 12-19)**
+
+```typescript
+export const AGENT_LABELS: Record<AgentType, string> = {
+	claude: "Claude",
+	codex: "Codex",
+	gemini: "Gemini",
+	opencode: "OpenCode",
+	copilot: "Copilot",
+	"cursor-agent": "Cursor Agent",
+	autohand: "Autohand",
+};
+```
+
+**Step 3: Add autohand to AGENT_PRESET_COMMANDS (line 21-30)**
+
+```typescript
+export const AGENT_PRESET_COMMANDS: Record<AgentType, string[]> = {
+	claude: ["claude --dangerously-skip-permissions"],
+	codex: [
+		'codex -c model_reasoning_effort="high" --ask-for-approval never --sandbox danger-full-access -c model_reasoning_summary="detailed" -c model_supports_reasoning_summaries=true',
+	],
+	gemini: ["gemini --yolo"],
+	opencode: ["opencode"],
+	copilot: ["copilot --allow-all"],
+	"cursor-agent": ["cursor-agent"],
+	autohand: ["autohand --unrestricted"],
+};
+```
+
+**Step 4: Add autohand to AGENT_PRESET_DESCRIPTIONS (line 32-39)**
+
+```typescript
+export const AGENT_PRESET_DESCRIPTIONS: Record<AgentType, string> = {
+	claude: "Danger mode: All permissions auto-approved",
+	codex: "Danger mode: All permissions auto-approved",
+	gemini: "Danger mode: All permissions auto-approved",
+	opencode: "OpenCode: Open-source AI coding agent",
+	copilot: "Danger mode: All permissions auto-approved",
+	"cursor-agent": "Cursor AI agent for terminal-based coding assistance",
+	autohand: "Danger mode: All permissions auto-approved",
+};
+```
+
+**Step 5: Add autohand to AGENT_COMMANDS builder (line 98-118)**
+
+```typescript
+const AGENT_COMMANDS: Record<
+	AgentType,
+	(prompt: string, delimiter: string) => string
+> = {
+	claude: (prompt, delimiter) =>
+		buildHeredoc(prompt, delimiter, "claude --dangerously-skip-permissions"),
+	codex: (prompt, delimiter) =>
+		buildHeredoc(
+			prompt,
+			delimiter,
+			'codex -c model_reasoning_effort="high" --ask-for-approval never --sandbox danger-full-access --',
+		),
+	gemini: (prompt, delimiter) =>
+		buildHeredoc(prompt, delimiter, "gemini --yolo"),
+	opencode: (prompt, delimiter) =>
+		buildHeredoc(prompt, delimiter, "opencode --prompt"),
+	copilot: (prompt, delimiter) =>
+		buildHeredoc(prompt, delimiter, "copilot -i", "--yolo"),
+	"cursor-agent": (prompt, delimiter) =>
+		buildHeredoc(prompt, delimiter, "cursor-agent --yolo"),
+	autohand: (prompt, delimiter) =>
+		buildHeredoc(prompt, delimiter, "autohand --unrestricted -p"),
+};
+```
+
+**Step 6: Commit**
+
+```bash
+git add packages/shared/src/agent-command.ts
+git commit -m "feat: add autohand agent type to shared package"
+```
+
+---
+
+### Task 2: Create autohand hook config writer and wrapper
+
+**Files:**
+- Create: `apps/desktop/src/main/lib/agent-setup/agent-wrappers-autohand.ts`
+
+**Step 1: Create the autohand wrappers module**
+
+This follows the Mastra pattern. Autohand stores hooks in `~/.autohand/config.json` under `hooks.hooks[]` array with `event`, `command`, `enabled` fields.
+
+```typescript
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+	buildWrapperScript,
+	createWrapper,
+	isSupersetManagedHookCommand,
+	writeFileIfChanged,
+} from "./agent-wrappers-common";
+import { getNotifyScriptPath, NOTIFY_SCRIPT_NAME } from "./notify-hook";
+
+interface AutohandHookDefinition {
+	event: string;
+	command: string;
+	enabled?: boolean;
+	description?: string;
+	[key: string]: unknown;
+}
+
+interface AutohandHooksSettings {
+	enabled?: boolean;
+	hooks?: AutohandHookDefinition[];
+}
+
+interface AutohandConfigJson {
+	hooks?: AutohandHooksSettings;
+	[key: string]: unknown;
+}
+
+function quoteShellPath(filePath: string): string {
+	return `'${filePath.replaceAll("'", "'\\''")}'`;
+}
+
+export function getAutohandGlobalConfigPath(): string {
+	return path.join(
+		process.env.AUTOHAND_HOME || path.join(os.homedir(), ".autohand"),
+		"config.json",
+	);
+}
+
+export function createAutohandWrapper(): void {
+	const script = buildWrapperScript("autohand", `exec "$REAL_BIN" "$@"`);
+	createWrapper("autohand", script);
+}
+
+/**
+ * Reads existing ~/.autohand/config.json, merges our hook entries (identified
+ * by notify script path), and preserves all other config settings.
+ *
+ * Autohand stores hooks as:
+ *   { hooks: { enabled: true, hooks: [{ event, command, enabled }] } }
+ */
+export function getAutohandHooksConfigContent(
+	notifyScriptPath: string,
+): string {
+	const globalPath = getAutohandGlobalConfigPath();
+
+	let existing: AutohandConfigJson = {};
+	try {
+		if (fs.existsSync(globalPath)) {
+			existing = JSON.parse(fs.readFileSync(globalPath, "utf-8"));
+		}
+	} catch {
+		console.warn(
+			"[agent-setup] Could not parse existing ~/.autohand/config.json, merging carefully",
+		);
+	}
+
+	if (!existing.hooks || typeof existing.hooks !== "object") {
+		existing.hooks = { enabled: true, hooks: [] };
+	}
+	if (!Array.isArray(existing.hooks.hooks)) {
+		existing.hooks.hooks = [];
+	}
+
+	// Ensure hooks are globally enabled
+	existing.hooks.enabled = true;
+
+	const notifyCommand = `bash ${quoteShellPath(notifyScriptPath)}`;
+	const managedEvents = ["pre-prompt", "stop", "post-tool"] as const;
+
+	// Filter out stale Superset hook entries, then add fresh ones
+	const filtered = existing.hooks.hooks.filter(
+		(entry: AutohandHookDefinition) =>
+			!managedEvents.includes(entry.event as (typeof managedEvents)[number]) ||
+			!(
+				entry.command?.includes(notifyScriptPath) ||
+				isSupersetManagedHookCommand(entry.command, NOTIFY_SCRIPT_NAME)
+			),
+	);
+
+	for (const event of managedEvents) {
+		// Remove any existing Superset-managed hooks for this event
+		const withoutStale = filtered.filter(
+			(entry: AutohandHookDefinition) =>
+				entry.event !== event ||
+				!(
+					entry.command?.includes(notifyScriptPath) ||
+					isSupersetManagedHookCommand(entry.command, NOTIFY_SCRIPT_NAME)
+				),
+		);
+		filtered.length = 0;
+		filtered.push(...withoutStale);
+
+		filtered.push({
+			event,
+			command: notifyCommand,
+			enabled: true,
+		});
+	}
+
+	existing.hooks.hooks = filtered;
+
+	return JSON.stringify(existing, null, 2);
+}
+
+export function createAutohandHooksConfig(): void {
+	const notifyScriptPath = getNotifyScriptPath();
+	const globalPath = getAutohandGlobalConfigPath();
+	const content = getAutohandHooksConfigContent(notifyScriptPath);
+
+	const dir = path.dirname(globalPath);
+	fs.mkdirSync(dir, { recursive: true });
+	const changed = writeFileIfChanged(globalPath, content, 0o644);
+	console.log(
+		`[agent-setup] ${changed ? "Updated" : "Verified"} Autohand config.json`,
+	);
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add apps/desktop/src/main/lib/agent-setup/agent-wrappers-autohand.ts
+git commit -m "feat: create autohand hook config writer and wrapper"
+```
+
+---
+
+### Task 3: Wire up autohand in barrel exports, agent-setup index, and shell shims
+
+**Files:**
+- Modify: `apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts`
+- Modify: `apps/desktop/src/main/lib/agent-setup/index.ts`
+- Modify: `apps/desktop/src/main/lib/agent-setup/shell-wrappers.ts`
+
+**Step 1: Add autohand exports to agent-wrappers.ts barrel**
+
+Append to the end of `agent-wrappers.ts`:
+
+```typescript
+export {
+	createAutohandHooksConfig,
+	createAutohandWrapper,
+	getAutohandGlobalConfigPath,
+	getAutohandHooksConfigContent,
+} from "./agent-wrappers-autohand";
+```
+
+**Step 2: Add autohand to setupAgentHooks in index.ts**
+
+Import `createAutohandWrapper` and `createAutohandHooksConfig` from `"./agent-wrappers"`, then add calls inside `setupAgentHooks()` (after `createCopilotWrapper()`, before `createZshWrapper()`):
+
+```typescript
+createAutohandWrapper();
+createAutohandHooksConfig();
+```
+
+The import line in index.ts should be updated to include the new exports.
+
+**Step 3: Add "autohand" to SHIMMED_BINARIES in shell-wrappers.ts (line 49-56)**
+
+```typescript
+const SHIMMED_BINARIES = [
+	"claude",
+	"codex",
+	"opencode",
+	"gemini",
+	"copilot",
+	"mastracode",
+	"autohand",
+];
+```
+
+**Step 4: Commit**
+
+```bash
+git add apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts \
+       apps/desktop/src/main/lib/agent-setup/index.ts \
+       apps/desktop/src/main/lib/agent-setup/shell-wrappers.ts
+git commit -m "feat: wire autohand into agent-setup and shell shims"
+```
+
+---
+
+### Task 4: Add autohand SVG icons and register in preset-icons
+
+**Files:**
+- Create: `packages/ui/src/assets/icons/preset-icons/autohand.svg`
+- Create: `packages/ui/src/assets/icons/preset-icons/autohand-white.svg`
+- Modify: `packages/ui/src/assets/icons/preset-icons/index.ts`
+
+**Step 1: Create autohand.svg (dark icon for light backgrounds)**
+
+Create an SVG icon representing Autohand's brand — a stylized "A" with a hand motif, consistent with the Autohand icon (blue circle with white "A"). For the preset icon, use a simplified version without the circle background, just the "A" glyph in black fill.
+
+SVG at `packages/ui/src/assets/icons/preset-icons/autohand.svg`:
+
+```svg
+<svg width="721" height="721" viewBox="0 0 721 721" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M360.5 120C340.2 120 322.1 132.4 315.1 151.3L168.7 546.7C163.5 560.8 173.9 576 189.1 576H234.5C248.3 576 260.5 567.8 265.2 554.8L293.8 476H427.2L455.8 554.8C460.5 567.8 472.7 576 486.5 576H531.9C547.1 576 557.5 560.8 552.3 546.7L405.9 151.3C398.9 132.4 380.8 120 360.5 120ZM316.7 406L360.5 287.5L404.3 406H316.7Z" fill="black"/>
+  <path d="M360.5 620C399.3 620 431.5 608 456.5 584L472.5 600C500 576 520 544 520 504H440C440 528 420 548 396 560L360.5 576L325 560C301 548 281 528 281 504H201C201 544 221 576 248.5 600L264.5 584C289.5 608 321.7 620 360.5 620Z" fill="black" opacity="0.3"/>
+</svg>
+```
+
+**Step 2: Create autohand-white.svg (light icon for dark backgrounds)**
+
+Same paths but with `fill="white"`.
+
+**Step 3: Register icons in index.ts**
+
+Add imports and register in `PRESET_ICONS`:
+
+```typescript
+import autohandIcon from "./autohand.svg";
+import autohandWhiteIcon from "./autohand-white.svg";
+
+// In PRESET_ICONS:
+autohand: { light: autohandIcon, dark: autohandWhiteIcon },
+
+// In exports:
+export { autohandIcon, autohandWhiteIcon };
+```
+
+**Step 4: Commit**
+
+```bash
+git add packages/ui/src/assets/icons/preset-icons/autohand.svg \
+       packages/ui/src/assets/icons/preset-icons/autohand-white.svg \
+       packages/ui/src/assets/icons/preset-icons/index.ts
+git commit -m "feat: add autohand SVG icons to preset-icons"
+```
+
+---
+
+### Task 5: Add autohand to default presets in settings router
+
+**Files:**
+- Modify: `apps/desktop/src/lib/trpc/routers/settings/index.ts`
+
+**Step 1: Add "autohand" to DEFAULT_PRESET_AGENTS (line 92-98)**
+
+```typescript
+const DEFAULT_PRESET_AGENTS = [
+	"claude",
+	"codex",
+	"copilot",
+	"opencode",
+	"gemini",
+	"autohand",
+] as const;
+```
+
+**Step 2: Commit**
+
+```bash
+git add apps/desktop/src/lib/trpc/routers/settings/index.ts
+git commit -m "feat: add autohand to default terminal presets"
+```
+
+---
+
+### Task 6: Add project-level MCP config and commands symlink
+
+**Files:**
+- Create: `.autohand/config.json` (project-level MCP config)
+- Create: `.autohand/commands` (symlink to `../.agents/commands`)
+- Modify: `.gitignore`
+
+**Step 1: Create .autohand/config.json with MCP servers**
+
+```json
+{
+  "mcp": {
+    "servers": [
+      {
+        "name": "superset",
+        "transport": "http",
+        "url": "https://api.superset.sh/api/agent/mcp"
+      },
+      {
+        "name": "expo-mcp",
+        "transport": "http",
+        "url": "https://mcp.expo.dev/mcp",
+        "enabled": false
+      },
+      {
+        "name": "maestro",
+        "transport": "stdio",
+        "command": "maestro",
+        "args": ["mcp"]
+      },
+      {
+        "name": "neon",
+        "transport": "http",
+        "url": "https://mcp.neon.tech/mcp"
+      },
+      {
+        "name": "linear",
+        "transport": "http",
+        "url": "https://mcp.linear.app/mcp"
+      },
+      {
+        "name": "sentry",
+        "transport": "http",
+        "url": "https://mcp.sentry.dev/mcp"
+      },
+      {
+        "name": "desktop-automation",
+        "transport": "stdio",
+        "command": "bun",
+        "args": ["run", "packages/desktop-mcp/src/bin.ts"]
+      }
+    ]
+  }
+}
+```
+
+**Step 2: Create commands symlink**
+
+```bash
+cd superset && ln -s ../.agents/commands .autohand/commands
+```
+
+**Step 3: Add .autohand gitignore rules to .gitignore**
+
+Append after the .codex section (line 85):
+
+```gitignore
+# Autohand workspace config (track only shared config/symlinks; ignore runtime state)
+.autohand/*
+!.autohand/config.json
+!.autohand/commands
+```
+
+**Step 4: Commit**
+
+```bash
+git add .autohand/config.json .autohand/commands .gitignore
+git commit -m "feat: add autohand project-level MCP config and commands"
+```
+
+---
+
+### Task 7: Add tests for autohand integration
+
+**Files:**
+- Modify: `apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts`
+
+**Step 1: Import autohand functions in test file**
+
+In the dynamic import block (around line 58-68), add:
+
+```typescript
+const {
+	buildCodexWrapperExecLine,
+	buildCopilotWrapperExecLine,
+	buildWrapperScript,
+	createCodexWrapper,
+	createAutohandWrapper,
+	getAutohandHooksConfigContent,
+	createMastraWrapper,
+	getCursorHooksJsonContent,
+	getCopilotHookScriptPath,
+	getGeminiSettingsJsonContent,
+	getMastraHooksJsonContent,
+} = await import("./agent-wrappers");
+```
+
+**Step 2: Add test for autohand hook merge logic**
+
+```typescript
+it("replaces stale Autohand hook commands from old superset paths", () => {
+	const autohandConfigDir = path.join(mockedHomeDir, ".autohand");
+	const autohandConfigPath = path.join(autohandConfigDir, "config.json");
+	const staleHookPath = "/tmp/.superset-old/hooks/notify.sh";
+	const currentHookPath = "/tmp/.superset-new/hooks/notify.sh";
+
+	mkdirSync(autohandConfigDir, { recursive: true });
+	writeFileSync(
+		autohandConfigPath,
+		JSON.stringify(
+			{
+				provider: "openrouter",
+				hooks: {
+					enabled: true,
+					hooks: [
+						{
+							event: "pre-prompt",
+							command: `bash '${staleHookPath}'`,
+							enabled: true,
+						},
+						{
+							event: "stop",
+							command: `bash '${staleHookPath}'`,
+							enabled: true,
+						},
+						{
+							event: "post-tool",
+							command: `bash '${staleHookPath}'`,
+							enabled: true,
+						},
+						{
+							event: "session-start",
+							command: "/usr/local/bin/custom-hook",
+							enabled: true,
+						},
+					],
+				},
+			},
+			null,
+			2,
+		),
+	);
+
+	const content = getAutohandHooksConfigContent(currentHookPath);
+	writeFileSync(autohandConfigPath, content);
+	const content2 = getAutohandHooksConfigContent(currentHookPath);
+
+	const parsed = JSON.parse(content) as AutohandConfigJson;
+	const managedEvents = ["pre-prompt", "stop", "post-tool"] as const;
+
+	// Verify provider config is preserved
+	expect(parsed.provider).toBe("openrouter");
+
+	// Verify hooks are enabled
+	expect(parsed.hooks?.enabled).toBe(true);
+
+	const hooks = parsed.hooks?.hooks ?? [];
+
+	for (const eventName of managedEvents) {
+		const eventHooks = hooks.filter(
+			(h: { event: string }) => h.event === eventName,
+		);
+		expect(eventHooks.length).toBe(1);
+		expect(eventHooks[0].command).toBe(`bash '${currentHookPath}'`);
+		expect(eventHooks[0].enabled).toBe(true);
+		// Verify stale path is gone
+		expect(
+			eventHooks.some((h: { command: string }) =>
+				h.command.includes(staleHookPath),
+			),
+		).toBe(false);
+	}
+
+	// Verify user-defined hooks are preserved
+	const customHooks = hooks.filter(
+		(h: { event: string }) => h.event === "session-start",
+	);
+	expect(customHooks.length).toBe(1);
+	expect(customHooks[0].command).toBe("/usr/local/bin/custom-hook");
+
+	// Idempotency check
+	expect(JSON.parse(content2)).toEqual(JSON.parse(content));
+});
+```
+
+**Step 3: Add test for autohand wrapper creation**
+
+```typescript
+it("creates autohand wrapper passthrough", () => {
+	createAutohandWrapper();
+
+	const wrapperPath = path.join(TEST_BIN_DIR, "autohand");
+	const wrapper = readFileSync(wrapperPath, "utf-8");
+
+	expect(wrapper).toContain("# Superset wrapper for autohand");
+	expect(wrapper).toContain('REAL_BIN="$(find_real_binary "autohand")"');
+	expect(wrapper).toContain('exec "$REAL_BIN" "$@"');
+});
+```
+
+**Step 4: Run the tests**
+
+```bash
+cd apps/desktop && bun test src/main/lib/agent-setup/agent-wrappers.test.ts
+```
+
+Expected: All existing tests pass, plus the 2 new autohand tests.
+
+**Step 5: Commit**
+
+```bash
+git add apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+git commit -m "test: add autohand integration tests"
+```
+
+---
+
+### Task 8: Update AGENTS.md with autohand config instructions
+
+**Files:**
+- Modify: `AGENTS.md`
+
+**Step 1: Add autohand to Agent Rules section**
+
+In the "Agent Rules" section (item 4 about workspace MCP config), add autohand reference:
+
+> Autohand uses `.autohand/config.json` at the project root (run with `autohand --config .autohand/config.json` or from the project directory).
+
+**Step 2: Commit**
+
+```bash
+git add AGENTS.md
+git commit -m "docs: add autohand config instructions to AGENTS.md"
+```

--- a/packages/shared/src/agent-command.ts
+++ b/packages/shared/src/agent-command.ts
@@ -5,6 +5,7 @@ export const AGENT_TYPES = [
 	"opencode",
 	"copilot",
 	"cursor-agent",
+	"autohand",
 ] as const;
 
 export type AgentType = (typeof AGENT_TYPES)[number];
@@ -16,6 +17,7 @@ export const AGENT_LABELS: Record<AgentType, string> = {
 	opencode: "OpenCode",
 	copilot: "Copilot",
 	"cursor-agent": "Cursor Agent",
+	autohand: "Autohand Code",
 };
 
 export const AGENT_PRESET_COMMANDS: Record<AgentType, string[]> = {
@@ -27,6 +29,7 @@ export const AGENT_PRESET_COMMANDS: Record<AgentType, string[]> = {
 	opencode: ["opencode"],
 	copilot: ["copilot --allow-all"],
 	"cursor-agent": ["cursor-agent"],
+	autohand: ["autohand --unrestricted"],
 };
 
 export const AGENT_PRESET_DESCRIPTIONS: Record<AgentType, string> = {
@@ -36,6 +39,7 @@ export const AGENT_PRESET_DESCRIPTIONS: Record<AgentType, string> = {
 	opencode: "OpenCode: Open-source AI coding agent",
 	copilot: "Danger mode: All permissions auto-approved",
 	"cursor-agent": "Cursor AI agent for terminal-based coding assistance",
+	autohand: "Danger mode: All permissions auto-approved",
 };
 
 export interface TaskInput {
@@ -115,6 +119,8 @@ const AGENT_COMMANDS: Record<
 		buildHeredoc(prompt, delimiter, "copilot -i", "--yolo"),
 	"cursor-agent": (prompt, delimiter) =>
 		buildHeredoc(prompt, delimiter, "cursor-agent --yolo"),
+	autohand: (prompt, delimiter) =>
+		buildHeredoc(prompt, delimiter, "autohand --unrestricted -p"),
 };
 
 export function buildAgentPromptCommand({

--- a/packages/ui/src/assets/icons/preset-icons/autohand-white.svg
+++ b/packages/ui/src/assets/icons/preset-icons/autohand-white.svg
@@ -1,0 +1,21 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- 4x2 grid Autohand logo (white fill for dark backgrounds) -->
+  <!-- Row 1 -->
+  <circle cx="4.5" cy="8" r="2" stroke="white" stroke-width="0.8" fill="none"/>
+  <circle cx="4.5" cy="8" r="0.7" fill="white"/>
+  <circle cx="9.5" cy="8" r="2" stroke="white" stroke-width="0.8" fill="none"/>
+  <circle cx="9.5" cy="8" r="0.7" fill="white"/>
+  <circle cx="14.5" cy="8" r="2" stroke="white" stroke-width="0.8" fill="none"/>
+  <circle cx="14.5" cy="8" r="0.7" fill="white"/>
+  <circle cx="19.5" cy="8" r="2" stroke="white" stroke-width="0.8" fill="none"/>
+  <circle cx="19.5" cy="8" r="0.7" fill="white"/>
+  <!-- Row 2 -->
+  <circle cx="4.5" cy="16" r="2" stroke="white" stroke-width="0.8" fill="none"/>
+  <circle cx="4.5" cy="16" r="0.7" fill="white"/>
+  <circle cx="9.5" cy="16" r="2" stroke="white" stroke-width="0.8" fill="none"/>
+  <circle cx="9.5" cy="16" r="0.7" fill="white"/>
+  <circle cx="14.5" cy="16" r="2" stroke="white" stroke-width="0.8" fill="none"/>
+  <circle cx="14.5" cy="16" r="0.7" fill="white"/>
+  <circle cx="19.5" cy="16" r="2" stroke="white" stroke-width="0.8" fill="none"/>
+  <circle cx="19.5" cy="16" r="0.7" fill="white"/>
+</svg>

--- a/packages/ui/src/assets/icons/preset-icons/autohand.svg
+++ b/packages/ui/src/assets/icons/preset-icons/autohand.svg
@@ -1,0 +1,21 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- 4x2 grid Autohand logo (dark fill for light backgrounds) -->
+  <!-- Row 1 -->
+  <circle cx="4.5" cy="8" r="2" stroke="#1a1a1a" stroke-width="0.8" fill="none"/>
+  <circle cx="4.5" cy="8" r="0.7" fill="#1a1a1a"/>
+  <circle cx="9.5" cy="8" r="2" stroke="#1a1a1a" stroke-width="0.8" fill="none"/>
+  <circle cx="9.5" cy="8" r="0.7" fill="#1a1a1a"/>
+  <circle cx="14.5" cy="8" r="2" stroke="#1a1a1a" stroke-width="0.8" fill="none"/>
+  <circle cx="14.5" cy="8" r="0.7" fill="#1a1a1a"/>
+  <circle cx="19.5" cy="8" r="2" stroke="#1a1a1a" stroke-width="0.8" fill="none"/>
+  <circle cx="19.5" cy="8" r="0.7" fill="#1a1a1a"/>
+  <!-- Row 2 -->
+  <circle cx="4.5" cy="16" r="2" stroke="#1a1a1a" stroke-width="0.8" fill="none"/>
+  <circle cx="4.5" cy="16" r="0.7" fill="#1a1a1a"/>
+  <circle cx="9.5" cy="16" r="2" stroke="#1a1a1a" stroke-width="0.8" fill="none"/>
+  <circle cx="9.5" cy="16" r="0.7" fill="#1a1a1a"/>
+  <circle cx="14.5" cy="16" r="2" stroke="#1a1a1a" stroke-width="0.8" fill="none"/>
+  <circle cx="14.5" cy="16" r="0.7" fill="#1a1a1a"/>
+  <circle cx="19.5" cy="16" r="2" stroke="#1a1a1a" stroke-width="0.8" fill="none"/>
+  <circle cx="19.5" cy="16" r="0.7" fill="#1a1a1a"/>
+</svg>

--- a/packages/ui/src/assets/icons/preset-icons/index.ts
+++ b/packages/ui/src/assets/icons/preset-icons/index.ts
@@ -1,3 +1,5 @@
+import autohandIcon from "./autohand.svg";
+import autohandWhiteIcon from "./autohand-white.svg";
 import claudeIcon from "./claude.svg";
 import codexIcon from "./codex.svg";
 import codexWhiteIcon from "./codex-white.svg";
@@ -14,6 +16,7 @@ export interface PresetIconSet {
 }
 
 export const PRESET_ICONS: Record<string, PresetIconSet> = {
+	autohand: { light: autohandIcon, dark: autohandWhiteIcon },
 	claude: { light: claudeIcon, dark: claudeIcon },
 	codex: { light: codexIcon, dark: codexWhiteIcon },
 	copilot: { light: copilotIcon, dark: copilotWhiteIcon },
@@ -33,6 +36,8 @@ export function getPresetIcon(
 }
 
 export {
+	autohandIcon,
+	autohandWhiteIcon,
 	claudeIcon,
 	codexIcon,
 	codexWhiteIcon,


### PR DESCRIPTION
 Add native support for the [Autohand Code CLI](https://github.com/autohandai/code-cli) as a first-class agent in Superset, with full parity alongside Claude, Codex, Gemini, OpenCode, Copilot, and Cursor Agent.

  **What this adds:**
  - Agent type registration in all shared maps (types, labels, commands, descriptions)
  - Config-based hook management that reads/merges `~/.autohand/config.json`, replaces stale superset hooks, and preserves user-defined hooks (follows the Mastra integration pattern)
  - Shell wrapper passthrough and `SHIMMED_BINARIES` entry for PATH-based agent discovery
  - Official brand SVG icons (light and dark variants)
  - Default terminal preset with `--unrestricted` danger mode
  - `AGENT_LABELS` used for display names across all preset UI components (PresetsBar, PresetBarItem, QuickAddPresets, PresetsSubmenu) — this benefits all agents, not just Autohand
  - Project-level `.autohand/config.json` MCP server definitions and `.autohand/commands` symlink
  - Updated AGENTS.md rules 3 and 4 with autohand config documentation

  ## Related Issues

  N/A — new feature request for Autohand Code CLI support.

  ## Type of Change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Documentation
  - [ ] Refactor
  - [ ] Other (please describe):

  ## Testing

  - All 8 `agent-wrappers.test.ts` tests pass (75 assertions) including 2 new autohand-specific tests
  - Tests cover: hook config merging, stale hook replacement, idempotency, user-defined hook preservation, provider config retention, and wrapper passthrough creation
  - No TypeScript errors in any modified files (pre-existing drizzle-orm type issues in unrelated packages remain)
  - Desktop app builds successfully (3,387 modules compiled)
  - Verified in dev mode: Autohand Code appears in agent dropdown, presets bar, and quick-add settings with correct icon and label

### Additional Notes

  - Hook event mapping: Superset UserPromptSubmit → Autohand pre-prompt, Stop → stop, PostToolUse → post-tool
  - The AGENT_LABELS display change is a small UX improvement for all agents (they now show proper cased names like "Claude" instead of "claude" in the presets bar)
  - Autohand supports --unrestricted for auto-approving all permissions and --unrestricted -p for piped/task mode


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add native Autohand Code CLI support as a first-class agent with config-based hooks, a shell wrapper/shim, brand icons, and default presets. This lets users select Autohand in the UI; hooks merge safely; danger mode (--unrestricted) is the default.

- **New Features**
  - Registered Autohand across agent maps (types, labels, commands, descriptions); UI now uses AGENT_LABELS for proper names.
  - Hooks: read/merge ~/.autohand/config.json, replace stale Superset hooks, preserve user-defined hooks; map events pre-prompt, stop, post-tool.
  - Shell: added passthrough wrapper and PATH shim via SHIMMED_BINARIES.
  - UI: added light/dark SVG icons and a default terminal preset with --unrestricted.
  - Project config: added .autohand/config.json MCP servers and .autohand/commands symlink; updated AGENTS.md; added tests for hook merging and wrapper creation.

<sup>Written for commit 45b9b19d5abd53f80ac4cd744d0ca0465b0a1f0f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated Autohand as a new agent type available in terminal presets with dedicated UI icons and labels
  * Added Autohand to default agent options for code execution workflows
  * Configured Autohand MCP server integration for extended workspace functionality

* **Documentation**
  * Added Autohand integration guidelines and configuration examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->