### PR TITLE
Desktop: enable resource monitor by default

### DIFF
--- a/apps/desktop/src/shared/constants.ts
+++ b/apps/desktop/src/shared/constants.ts
@@ -43,7 +43,7 @@ export const DEFAULT_AUTO_APPLY_DEFAULT_PRESET = true;
 export const DEFAULT_SHOW_PRESETS_BAR = true;
 export const DEFAULT_USE_COMPACT_TERMINAL_ADD_BUTTON = true;
 export const DEFAULT_TELEMETRY_ENABLED = true;
-export const DEFAULT_SHOW_RESOURCE_MONITOR = false;
+export const DEFAULT_SHOW_RESOURCE_MONITOR = true;
 export const DEFAULT_OPEN_LINKS_IN_APP = false;
 
 // External links (documentation, help resources, etc.)


### PR DESCRIPTION
## Description

Enable the desktop resource monitor preference by default by updating `DEFAULT_SHOW_RESOURCE_MONITOR` to `true`.

## Related Issues

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

- `bun run typecheck --filter=@superset/desktop`

## Screenshots (if applicable)

N/A

## Additional Notes

This affects users with no explicit saved `showResourceMonitor` setting; existing user preferences remain unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable the desktop resource monitor by default to show system usage out of the box. Applies only to users without a saved preference; existing settings are unchanged.

<sup>Written for commit f16f6dfb2f8aee63053f969cd364860d78538efd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features**
  * Resource monitor is now displayed by default, providing immediate visibility into system resource usage without requiring manual activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->