### PR TITLE
desktop: persist selected chat model in chat UI

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/ChatMastraInterface.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/ChatMastraInterface.tsx
@@ -13,6 +13,7 @@ import type React from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { posthog } from "renderer/lib/posthog";
+import { useChatPreferencesStore } from "renderer/stores/chat-preferences";
 import { ChatInputFooter } from "../../ChatPane/ChatInterface/components/ChatInputFooter";
 import { useSlashCommandExecutor } from "../../ChatPane/ChatInterface/hooks/useSlashCommandExecutor";
 import type { SlashCommand } from "../../ChatPane/ChatInterface/hooks/useSlashCommands";
@@ -62,7 +63,14 @@ export function ChatMastraInterface({
 	onRawSnapshotChange,
 }: ChatMastraInterfaceProps) {
 	const { models: availableModels, defaultModel } = useAvailableModels();
-	const [selectedModel, setSelectedModel] = useState<ModelOption | null>(null);
+	const selectedModelId = useChatPreferencesStore(
+		(state) => state.selectedModelId,
+	);
+	const setSelectedModelId = useChatPreferencesStore(
+		(state) => state.setSelectedModelId,
+	);
+	const selectedModel =
+		availableModels.find((model) => model.id === selectedModelId) ?? null;
 	const activeModel = selectedModel ?? defaultModel;
 	const [modelSelectorOpen, setModelSelectorOpen] = useState(false);
 	const [thinkingEnabled, setThinkingEnabled] = useState(false);
@@ -116,19 +124,23 @@ export function ChatMastraInterface({
 
 	const handleSelectModel = useCallback(
 		(model: React.SetStateAction<ModelOption | null>) => {
-			setSelectedModel(model);
-			if (typeof model === "object" && model !== null) {
-				posthog.capture("chat_model_changed", {
-					workspace_id: workspaceId,
-					session_id: sessionId,
-					organization_id: organizationId,
-					model_id: model.id,
-					model_name: model.name,
-					trigger: "picker",
-				});
+			const nextSelectedModel =
+				typeof model === "function" ? model(selectedModel) : model;
+			if (!nextSelectedModel) {
+				setSelectedModelId(null);
+				return;
 			}
+			posthog.capture("chat_model_changed", {
+				workspace_id: workspaceId,
+				session_id: sessionId,
+				organization_id: organizationId,
+				model_id: nextSelectedModel.id,
+				model_name: nextSelectedModel.name,
+				trigger: "picker",
+			});
+			setSelectedModelId(nextSelectedModel.id);
 		},
-		[organizationId, sessionId, workspaceId],
+		[organizationId, selectedModel, sessionId, setSelectedModelId, workspaceId],
 	);
 
 	const sendMessageToSession = useCallback(

--- a/apps/desktop/src/renderer/stores/chat-preferences/index.ts
+++ b/apps/desktop/src/renderer/stores/chat-preferences/index.ts
@@ -1,0 +1,1 @@
+export { useChatPreferencesStore } from "./store";

--- a/apps/desktop/src/renderer/stores/chat-preferences/store.ts
+++ b/apps/desktop/src/renderer/stores/chat-preferences/store.ts
@@ -1,0 +1,25 @@
+import { create } from "zustand";
+import { devtools, persist } from "zustand/middleware";
+
+interface ChatPreferencesState {
+	selectedModelId: string | null;
+	setSelectedModelId: (modelId: string | null) => void;
+}
+
+export const useChatPreferencesStore = create<ChatPreferencesState>()(
+	devtools(
+		persist(
+			(set) => ({
+				selectedModelId: null,
+
+				setSelectedModelId: (modelId) => {
+					set({ selectedModelId: modelId });
+				},
+			}),
+			{
+				name: "chat-preferences",
+			},
+		),
+		{ name: "ChatPreferencesStore" },
+	),
+);

--- a/apps/desktop/src/renderer/stores/index.ts
+++ b/apps/desktop/src/renderer/stores/index.ts
@@ -1,3 +1,4 @@
+export * from "./chat-preferences";
 export * from "./hotkeys";
 export * from "./markdown-preferences";
 export * from "./ports";


### PR DESCRIPTION
## Summary
- persist the chat model selection via a new renderer Zustand store (`chat-preferences`)
- wire `ChatMastraInterface` to read/write `selectedModelId` from the store
- resolve persisted model id against available models, preserving default fallback behavior
- keep existing model-change analytics event emission on picker selections

## Validation
- `bunx biome check apps/desktop/src/renderer/stores/chat-preferences/store.ts apps/desktop/src/renderer/stores/chat-preferences/index.ts apps/desktop/src/renderer/stores/index.ts apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/ChatMastraInterface.tsx`
- `bun run typecheck --filter=@superset/desktop`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the selected chat model in the desktop chat UI so users keep their choice across app restarts. Adds a small Zustand store and wires the model picker to it without changing defaults or analytics.

- **New Features**
  - Added chat-preferences Zustand store (persisted) to save selectedModelId.
  - ChatMastraInterface reads/writes selectedModelId and resolves it to available models; falls back to the default if missing.
  - Keeps chat_model_changed PostHog event on picker selections.

<sup>Written for commit 1ac5acaed8c51a6c6590c8d1a2f7f4a9e89a5185. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced chat model selection persistence and global preference management. Your selected chat model is now automatically saved across sessions and will be restored whenever you return to the application. This improvement eliminates the need to reselect your preferred model each visit, providing a more seamless user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->