### PR TITLE
fix(desktop): apply shared branch sanitization to generated prefix

### DIFF
--- a/apps/desktop/src/shared/utils/slug.test.ts
+++ b/apps/desktop/src/shared/utils/slug.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { generateBranchName } from "./slug";
+
+describe("generateBranchName", () => {
+	test("applies shared branch sanitization to prefix", () => {
+		const branch = generateBranchName("My New Feature", "FEAT/");
+		expect(branch).toMatch(/^feat\/my-new-feature-[a-z0-9]{4}$/);
+	});
+
+	test("applies shared branch sanitization to nested prefix segments", () => {
+		const branch = generateBranchName("Fix Login", "TEAM/Feature");
+		expect(branch).toMatch(/^team\/feature\/fix-login-[a-z0-9]{4}$/);
+	});
+
+	test("removes invalid prefix characters using shared branch rules", () => {
+		const branch = generateBranchName("Fix Login", "TEAM/Feat:ure?");
+		expect(branch).toMatch(/^team\/feature\/fix-login-[a-z0-9]{4}$/);
+	});
+});

--- a/apps/desktop/src/shared/utils/slug.ts
+++ b/apps/desktop/src/shared/utils/slug.ts
@@ -1,3 +1,5 @@
+import { sanitizeBranchName } from "./branch";
+
 /**
  * Generates a URL-safe slug from a title with randomness to avoid collisions
  *
@@ -76,8 +78,11 @@ export function generateBranchName(title: string, prefix?: string): string {
 	const slug = generateSlug(title);
 
 	if (prefix) {
-		// Remove any trailing slashes from prefix
-		const cleanPrefix = prefix.replace(/\/+$/, "");
+		// Reuse shared branch sanitization rules for consistency.
+		const cleanPrefix = sanitizeBranchName(prefix);
+		if (!cleanPrefix) {
+			return slug;
+		}
 		return `${cleanPrefix}/${slug}`;
 	}
 


### PR DESCRIPTION
## Summary
- make generateBranchName sanitize prefix via shared sanitizeBranchName logic
- keep prefix handling aligned with existing branch naming rules (including lowercasing and invalid-char stripping)
- add unit tests for uppercase, nested, and invalid-character prefixes

## Testing
- bun test apps/desktop/src/shared/utils/slug.test.ts
- bunx biome check apps/desktop/src/shared/utils/slug.ts apps/desktop/src/shared/utils/slug.test.ts


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use shared branch sanitization for prefixes in generateBranchName to keep branch names consistent and valid. Adds tests for uppercase, nested, and invalid-character prefixes.

- **Bug Fixes**
  - Prefix is sanitized via sanitizeBranchName (lowercasing, invalid char removal, normalized segments).
  - If sanitization returns an empty prefix, fallback to the plain slug (no leading slash).
  - Added unit tests covering uppercase, nested segments, and invalid characters.

<sup>Written for commit 054c2679a51a706eaa1bddd63390ebfac27c81a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for branch name generation, validating proper sanitization of prefixes, handling of nested prefix segments, and removal of invalid characters.

* **Improvements**
  * Refactored branch name generation to use consistent prefix sanitization, improving reliability and predictability of generated branch names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->