### PR TITLE
Render question prompts as markdown and add optimistic question UX

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/components/ChatMastraMessageList/components/PendingQuestionMessage/PendingQuestionMessage.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/components/ChatMastraMessageList/components/PendingQuestionMessage/PendingQuestionMessage.tsx
@@ -1,5 +1,9 @@
 import type { UseMastraChatDisplayReturn } from "@superset/chat-mastra/client";
-import { Message, MessageContent } from "@superset/ui/ai-elements/message";
+import {
+	Message,
+	MessageContent,
+	MessageResponse,
+} from "@superset/ui/ai-elements/message";
 import { Button } from "@superset/ui/button";
 import { Input } from "@superset/ui/input";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -23,6 +27,7 @@ export function PendingQuestionMessage({
 	onRespond,
 }: PendingQuestionMessageProps) {
 	const [freeText, setFreeText] = useState("");
+	const [optimisticAnswer, setOptimisticAnswer] = useState<string | null>(null);
 	const [selectedOptionLabel, setSelectedOptionLabel] = useState<string | null>(
 		null,
 	);
@@ -47,6 +52,7 @@ export function PendingQuestionMessage({
 		if (previousQuestionIdRef.current === currentQuestionId) return;
 		previousQuestionIdRef.current = currentQuestionId;
 		setFreeText("");
+		setOptimisticAnswer(null);
 		setSelectedOptionLabel(null);
 	}, [question]);
 
@@ -62,16 +68,20 @@ export function PendingQuestionMessage({
 		question.question?.trim() || "The agent asked a question.";
 	const answerText = freeText.trim();
 	const canRespond = questionId.length > 0;
+	const hasOptimisticAnswer = optimisticAnswer !== null;
+	const controlsDisabled = isSubmitting || !canRespond || hasOptimisticAnswer;
 
 	const handleOptionSelect = async (optionLabel: string): Promise<void> => {
 		if (!canRespond || isSubmitting || inFlightResponseRef.current) return;
 		inFlightResponseRef.current = true;
 		const previousSelection = selectedOptionLabel;
 		setSelectedOptionLabel(optionLabel);
+		setOptimisticAnswer(optionLabel);
 		try {
 			await onRespond(questionId, optionLabel);
 		} catch (error) {
 			console.error("Failed to submit question option response", error);
+			setOptimisticAnswer(null);
 			setSelectedOptionLabel(previousSelection);
 		} finally {
 			inFlightResponseRef.current = false;
@@ -88,10 +98,12 @@ export function PendingQuestionMessage({
 			return;
 		}
 		inFlightResponseRef.current = true;
+		setOptimisticAnswer(answerText);
 		try {
 			await onRespond(questionId, answerText);
 		} catch (error) {
 			console.error("Failed to submit question free-text response", error);
+			setOptimisticAnswer(null);
 		} finally {
 			inFlightResponseRef.current = false;
 		}
@@ -101,9 +113,33 @@ export function PendingQuestionMessage({
 		<Message from="assistant">
 			<MessageContent>
 				<div className="w-full max-w-none space-y-3 rounded-xl border bg-card/95 p-3">
-					<div className="text-sm text-foreground">{questionText}</div>
+					<div className="rounded-md border bg-muted/20 p-3">
+						<MessageResponse
+							animated={false}
+							isAnimating={false}
+							mermaid={{
+								config: {
+									theme: "default",
+								},
+							}}
+						>
+							{questionText}
+						</MessageResponse>
+					</div>
 
-					{options.length > 0 ? (
+					{hasOptimisticAnswer ? (
+						<div className="rounded-md border bg-muted/20 p-3">
+							<div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+								Submitted answer
+							</div>
+							<div className="mt-1 text-sm text-foreground">
+								{optimisticAnswer}
+							</div>
+							<div className="mt-1 text-xs text-muted-foreground">
+								Waiting for agent confirmation...
+							</div>
+						</div>
+					) : options.length > 0 ? (
 						<div className="space-y-2">
 							{options.map((option, index) => (
 								<Button
@@ -115,7 +151,7 @@ export function PendingQuestionMessage({
 											? "border-primary bg-primary/10 text-primary"
 											: ""
 									}`}
-									disabled={isSubmitting || !canRespond}
+									disabled={controlsDisabled}
 									onClick={() => {
 										void handleOptionSelect(option.label);
 									}}
@@ -144,15 +180,13 @@ export function PendingQuestionMessage({
 								value={freeText}
 								onChange={(event) => setFreeText(event.target.value)}
 								placeholder="Type your answer..."
-								disabled={isSubmitting || !canRespond}
+								disabled={controlsDisabled}
 							/>
 							<Button
 								type="submit"
-								disabled={
-									isSubmitting || !canRespond || answerText.length === 0
-								}
+								disabled={controlsDisabled || answerText.length === 0}
 							>
-								{isSubmitting ? "Sending..." : "Submit"}
+								{isSubmitting || hasOptimisticAnswer ? "Sending..." : "Submit"}
 							</Button>
 						</form>
 					)}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/MastraToolCallBlock/MastraToolCallBlock.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/MastraToolCallBlock/MastraToolCallBlock.tsx
@@ -1,10 +1,9 @@
 import { BashTool } from "@superset/ui/ai-elements/bash-tool";
 import { FileDiffTool } from "@superset/ui/ai-elements/file-diff-tool";
-import { UserQuestionTool } from "@superset/ui/ai-elements/user-question-tool";
 import { WebFetchTool } from "@superset/ui/ai-elements/web-fetch-tool";
 import { WebSearchTool } from "@superset/ui/ai-elements/web-search-tool";
 import { getToolName } from "ai";
-import { FileIcon, FolderIcon, MessageCircleQuestionIcon } from "lucide-react";
+import { FileIcon, FolderIcon } from "lucide-react";
 import { useCallback, useMemo } from "react";
 import { posthog } from "renderer/lib/posthog";
 import { useChangesStore } from "renderer/stores/changes";
@@ -20,6 +19,7 @@ import {
 	toWsToolState,
 } from "../../utils/tool-helpers";
 import { ReadOnlyToolCall } from "../ReadOnlyToolCall";
+import { AskUserQuestionToolCall } from "./components/AskUserQuestionToolCall";
 import { EditToolExpandedDiff } from "./components/EditToolExpandedDiff";
 import { GenericToolCall } from "./components/GenericToolCall";
 import { SubagentToolCall } from "./components/SubagentToolCall";
@@ -32,7 +32,10 @@ interface MastraToolCallBlockProps {
 	workspaceCwd?: string;
 	sessionId?: string | null;
 	organizationId?: string | null;
-	onAnswer?: (toolCallId: string, answers: Record<string, string>) => void;
+	onAnswer?: (
+		toolCallId: string,
+		answers: Record<string, string>,
+	) => Promise<void> | void;
 }
 
 interface DiffPaneTarget {
@@ -455,33 +458,14 @@ export function MastraToolCallBlock({
 
 	// --- Ask user question → UserQuestionTool ---
 	if (toolName === "ask_user_question") {
-		const questions = Array.isArray(args.questions) ? args.questions : [];
-
-		if (part.state === "output-available" || part.state === "output-error") {
-			return (
-				<GenericToolCall
-					part={part}
-					toolName="Question"
-					icon={MessageCircleQuestionIcon}
-				/>
-			);
-		}
-
-		if (questions.length === 0) {
-			return (
-				<GenericToolCall
-					part={part}
-					toolName="Question"
-					icon={MessageCircleQuestionIcon}
-				/>
-			);
-		}
-
 		return (
-			<UserQuestionTool
-				questions={questions}
-				onAnswer={(answers) => onAnswer?.(part.toolCallId, answers)}
-				onSkip={() => onAnswer?.(part.toolCallId, {})}
+			<AskUserQuestionToolCall
+				part={part}
+				args={args}
+				result={result}
+				outputObject={outputObject}
+				nestedResultObject={nestedResultObject}
+				onAnswer={onAnswer}
 			/>
 		);
 	}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/MastraToolCallBlock/components/AskUserQuestionToolCall/AskUserQuestionToolCall.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/MastraToolCallBlock/components/AskUserQuestionToolCall/AskUserQuestionToolCall.tsx
@@ -1,0 +1,269 @@
+import { MessageResponse } from "@superset/ui/ai-elements/message";
+import { UserQuestionTool } from "@superset/ui/ai-elements/user-question-tool";
+import { MessageCircleQuestionIcon } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import type { ToolPart } from "../../../../utils/tool-helpers";
+import { GenericToolCall } from "../GenericToolCall";
+
+interface QuestionToolOption {
+	label: string;
+	description?: string;
+}
+
+interface QuestionToolQuestion {
+	question: string;
+	header?: string;
+	options: QuestionToolOption[];
+	multiSelect?: boolean;
+}
+
+interface AskUserQuestionToolCallProps {
+	part: ToolPart;
+	args: Record<string, unknown>;
+	result: Record<string, unknown>;
+	outputObject?: Record<string, unknown>;
+	nestedResultObject?: Record<string, unknown>;
+	onAnswer?: (
+		toolCallId: string,
+		answers: Record<string, string>,
+	) => Promise<void> | void;
+}
+
+function toRecord(value: unknown): Record<string, unknown> | undefined {
+	if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+		return value as Record<string, unknown>;
+	}
+	return undefined;
+}
+
+function toQuestionToolQuestions(value: unknown): QuestionToolQuestion[] {
+	if (!Array.isArray(value)) return [];
+
+	return value
+		.map((item): QuestionToolQuestion | null => {
+			if (typeof item !== "object" || item === null) return null;
+			const record = item as Record<string, unknown>;
+			const question =
+				typeof record.question === "string" ? record.question.trim() : "";
+			if (!question) return null;
+
+			const options = Array.isArray(record.options)
+				? record.options
+						.map((option): QuestionToolOption | null => {
+							if (typeof option !== "object" || option === null) return null;
+							const optionRecord = option as Record<string, unknown>;
+							const label =
+								typeof optionRecord.label === "string"
+									? optionRecord.label.trim()
+									: "";
+							if (!label) return null;
+							const description =
+								typeof optionRecord.description === "string"
+									? optionRecord.description.trim()
+									: "";
+
+							return description ? { label, description } : { label };
+						})
+						.filter((option): option is QuestionToolOption => option !== null)
+				: [];
+
+			const header =
+				typeof record.header === "string" ? record.header.trim() : "";
+			const multiSelect =
+				typeof record.multiSelect === "boolean"
+					? record.multiSelect
+					: undefined;
+
+			return {
+				question,
+				...(header ? { header } : {}),
+				options,
+				...(multiSelect === undefined ? {} : { multiSelect }),
+			};
+		})
+		.filter((question): question is QuestionToolQuestion => question !== null);
+}
+
+function toQuestionToolAnswers(value: unknown): Record<string, string> {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		return {};
+	}
+
+	const answers: Record<string, string> = {};
+	for (const [key, answer] of Object.entries(value)) {
+		if (typeof answer !== "string") continue;
+		const trimmedKey = key.trim();
+		const trimmedAnswer = answer.trim();
+		if (!trimmedKey || !trimmedAnswer) continue;
+		answers[trimmedKey] = trimmedAnswer;
+	}
+
+	return answers;
+}
+
+function findAnswerForQuestion({
+	answers,
+	questionText,
+}: {
+	answers: Record<string, string>;
+	questionText: string;
+}): string | undefined {
+	const directAnswer = answers[questionText];
+	if (directAnswer) return directAnswer;
+
+	const trimmedQuestion = questionText.trim();
+	for (const [answerKey, answerValue] of Object.entries(answers)) {
+		if (answerKey.trim() === trimmedQuestion) return answerValue;
+	}
+
+	return undefined;
+}
+
+function buildQuestionMarkdown({
+	questions,
+	answers,
+}: {
+	questions: QuestionToolQuestion[];
+	answers: Record<string, string>;
+}): string {
+	if (questions.length === 0) return "";
+
+	const lines: string[] = ["### Agent question"];
+	for (const [index, question] of questions.entries()) {
+		lines.push("");
+		if (questions.length > 1) {
+			lines.push(`#### ${index + 1}`);
+		}
+		if (question.header) {
+			lines.push(`_${question.header}_`);
+		}
+		lines.push(question.question);
+
+		const answer = findAnswerForQuestion({
+			answers,
+			questionText: question.question,
+		});
+		if (answer) {
+			lines.push("");
+			lines.push(`**Answer:** ${answer}`);
+		}
+	}
+
+	return lines.join("\n").trim();
+}
+
+export function AskUserQuestionToolCall({
+	part,
+	args,
+	result,
+	outputObject,
+	nestedResultObject,
+	onAnswer,
+}: AskUserQuestionToolCallProps) {
+	const [optimisticAnswers, setOptimisticAnswers] = useState<Record<
+		string,
+		string
+	> | null>(null);
+	const [isSubmittingLocally, setIsSubmittingLocally] = useState(false);
+
+	useEffect(() => {
+		if (part.state === "output-available" || part.state === "output-error") {
+			setIsSubmittingLocally(false);
+		}
+	}, [part.state]);
+
+	const questions = useMemo(() => {
+		return toQuestionToolQuestions(args.questions);
+	}, [args.questions]);
+
+	const serverAnswers = useMemo(() => {
+		return toQuestionToolAnswers(
+			toRecord(result.answers) ??
+				toRecord(outputObject?.answers) ??
+				toRecord(nestedResultObject?.answers),
+		);
+	}, [nestedResultObject?.answers, outputObject?.answers, result.answers]);
+
+	const answers = optimisticAnswers ?? serverAnswers;
+	const markdown = buildQuestionMarkdown({ questions, answers });
+	const hasOutput =
+		part.state === "output-available" || part.state === "output-error";
+	const hasQuestions = questions.length > 0;
+	const canRespond = Boolean(onAnswer) && !hasOutput && !isSubmittingLocally;
+
+	const messageBlock = markdown ? (
+		<div className="rounded-lg border border-border/60 bg-muted/20 p-3">
+			<MessageResponse
+				animated={false}
+				isAnimating={false}
+				mermaid={{
+					config: {
+						theme: "default",
+					},
+				}}
+			>
+				{markdown}
+			</MessageResponse>
+		</div>
+	) : null;
+
+	const handleSubmit = (submittedAnswers: Record<string, string>): void => {
+		if (!onAnswer || isSubmittingLocally) return;
+		setOptimisticAnswers(submittedAnswers);
+		setIsSubmittingLocally(true);
+
+		void Promise.resolve(onAnswer(part.toolCallId, submittedAnswers)).catch(
+			() => {
+				setOptimisticAnswers(null);
+				setIsSubmittingLocally(false);
+			},
+		);
+	};
+
+	if (!hasQuestions) {
+		return (
+			<GenericToolCall
+				part={part}
+				toolName="Question"
+				icon={MessageCircleQuestionIcon}
+			/>
+		);
+	}
+
+	if (hasOutput || !onAnswer || optimisticAnswers) {
+		return (
+			<div className="space-y-2">
+				{messageBlock}
+				<GenericToolCall
+					part={part}
+					toolName="Question"
+					icon={MessageCircleQuestionIcon}
+				/>
+			</div>
+		);
+	}
+
+	if (!canRespond) {
+		return (
+			<div className="space-y-2">
+				{messageBlock}
+				<GenericToolCall
+					part={part}
+					toolName="Question"
+					icon={MessageCircleQuestionIcon}
+				/>
+			</div>
+		);
+	}
+
+	return (
+		<div className="space-y-2">
+			{messageBlock}
+			<UserQuestionTool
+				questions={questions}
+				onAnswer={handleSubmit}
+				onSkip={() => handleSubmit({})}
+			/>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/MastraToolCallBlock/components/AskUserQuestionToolCall/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/MastraToolCallBlock/components/AskUserQuestionToolCall/index.ts
@@ -1,0 +1,1 @@
+export { AskUserQuestionToolCall } from "./AskUserQuestionToolCall";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/MessagePartsRenderer/MessagePartsRenderer.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/MessagePartsRenderer/MessagePartsRenderer.tsx
@@ -31,7 +31,10 @@ interface MessagePartsRendererProps {
 	isStreaming: boolean;
 	workspaceId?: string;
 	workspaceCwd?: string;
-	onAnswer?: (toolCallId: string, answers: Record<string, string>) => void;
+	onAnswer?: (
+		toolCallId: string,
+		answers: Record<string, string>,
+	) => Promise<void> | void;
 }
 
 export function MessagePartsRenderer({


### PR DESCRIPTION
## Summary
- render question prompts as markdown in both tool-call and pending-question chat flows
- refactor `ask_user_question` handling into a dedicated `AskUserQuestionToolCall` component
- add optimistic answer submission UX so selected/submitted answers show immediately before server roundtrip
- update chat renderer answer callback typing to allow async handlers

## UX Fixes
- markdown question content now preserves headings/lists/line breaks instead of showing raw markdown text
- after answering a question, UI immediately shows submitted state and disables controls while awaiting confirmation

## Validation
- `bunx biome check` on touched files
- `bunx turbo typecheck --filter=@superset/desktop`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renders question prompts as Markdown across pending-question and tool-call flows, and adds optimistic answer submission so the UI shows your answer immediately. Also allows async answer handlers.

- **New Features**
  - Render question text as Markdown via MessageResponse (headings, lists, line breaks preserved; mermaid supported).
  - Optimistic submission: shows “Submitted answer,” disables controls, and displays “Sending…” while waiting.
  - Introduce AskUserQuestionToolCall to handle Markdown rendering, derive answers from tool results, and manage optimistic state; falls back to GenericToolCall when output is available.
  - Support async onAnswer handlers in MastraToolCallBlock and MessagePartsRenderer.

<sup>Written for commit ce5736082e605f29def5b5d7fbfe02e3deade520. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced user question response workflow with optimistic updates—answers now display immediately upon submission, showing "Submitted answer" status with instant visual confirmation.
  * Improved question tool integration in chat with refined state management and support for asynchronous answer submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->