### PR TITLE
fix(desktop): stop window from fullscreening on dev restart

### DIFF
--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -220,7 +220,35 @@ export async function MainWindow() {
 		});
 	}
 
-	window.webContents.on("did-finish-load", async () => {
+	// Persist window bounds on move/resize so state survives app.exit(0)
+	// (which skips the close handler — e.g. electron-vite SIGTERM during dev).
+	// Gated by `initialized` so the initial maximize() doesn't immediately
+	// write isMaximized: true back to disk before the user touches the window.
+	let initialized = false;
+	let saveTimeout: ReturnType<typeof setTimeout> | null = null;
+	const debouncedSave = () => {
+		if (!initialized || window.isDestroyed()) return;
+		if (saveTimeout) clearTimeout(saveTimeout);
+		saveTimeout = setTimeout(() => {
+			if (window.isDestroyed()) return;
+			const isMaximized = window.isMaximized();
+			const bounds = isMaximized
+				? window.getNormalBounds()
+				: window.getBounds();
+			saveWindowState({
+				x: bounds.x,
+				y: bounds.y,
+				width: bounds.width,
+				height: bounds.height,
+				isMaximized,
+				zoomLevel: window.webContents.getZoomLevel(),
+			});
+		}, 500);
+	};
+	window.on("move", debouncedSave);
+	window.on("resize", debouncedSave);
+
+	window.webContents.once("did-finish-load", async () => {
 		console.log("[main-window] Renderer loaded successfully");
 		if (initialBounds.isMaximized) {
 			window.maximize();
@@ -229,6 +257,7 @@ export async function MainWindow() {
 			window.webContents.setZoomLevel(savedWindowState.zoomLevel);
 		}
 		window.show();
+		initialized = true;
 	});
 
 	window.webContents.on(


### PR DESCRIPTION
## Summary
- Window state was only saved in the `close` handler, but `app.exit(0)` (triggered by electron-vite SIGTERM during dev restarts) skips `close` entirely — leaving a stale `window-state.json` that often had `isMaximized: true`
- Added debounced (500ms) window state persistence on `move`/`resize` events so the state file is always fresh on disk regardless of how the process exits
- Changed `did-finish-load` from `on` to `once` so renderer reloads don't re-maximize the window
- Gated debounced saves behind an `initialized` flag so the initial `maximize()` call doesn't immediately write `isMaximized: true` back to disk

## Test plan
- [ ] Start desktop dev server, resize window to something smaller than fullscreen
- [ ] Edit a main process file to trigger a rebuild — window should stay at the same size/position
- [ ] Verify `~/.superset/window-state.json` updates after moving/resizing the window
- [ ] Verify production quit still saves state correctly via the `close` handler

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the desktop window from going fullscreen on dev restarts by keeping window state fresh and avoiding re-maximize on renderer reloads.

- **Bug Fixes**
  - Save window bounds and zoom level on move/resize (500ms debounce) so state survives app.exit(0)/SIGTERM during dev.
  - Use once for did-finish-load to stop repeated maximize on renderer reloads.
  - Gate saves behind an initialized flag so the initial maximize isn’t persisted.

<sup>Written for commit 24ad8b20594222302a95a0d37163fe8a98fb8d87. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable window state persistence: position, size, and zoom are now saved correctly after moves/resizes.
  * Prevents incorrect size/position from being stored when restoring from maximized.
  * Avoids saving window state during initial startup, preventing premature or duplicate saves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->