### PR TITLE
fix: add NEXT_PUBLIC_ELECTRIC_URL to macOS desktop build

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -92,6 +92,7 @@ jobs:
           NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL }}
           NEXT_PUBLIC_DOCS_URL: ${{ secrets.NEXT_PUBLIC_DOCS_URL }}
           NEXT_PUBLIC_STREAMS_URL: ${{ secrets.NEXT_PUBLIC_STREAMS_URL }}
+          NEXT_PUBLIC_ELECTRIC_URL: ${{ secrets.NEXT_PUBLIC_ELECTRIC_URL }}
           SENTRY_DSN_DESKTOP: ${{ secrets.SENTRY_DSN_DESKTOP }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SUPERSET_WORKSPACE_NAME: superset


### PR DESCRIPTION
## Summary
- The macOS build in `build-desktop.yml` was missing `NEXT_PUBLIC_ELECTRIC_URL` in the compile env vars (Linux already had it)
- Without this, macOS builds fall back to the hardcoded default in t3-env, which works but is inconsistent with Linux

## Test plan
- [x] Verified Linux build already has the env var
- [x] Confirmed t3-env default prevents build breakage even without the secret

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add NEXT_PUBLIC_ELECTRIC_URL to the macOS desktop build so it uses the secret like Linux instead of the t3-env default. This ensures consistent Electric configuration across platforms.

<sup>Written for commit 43979d27bede6dd1282ff180b2980da69eda62dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated desktop application build workflow configuration to include necessary environment setup for macOS and Linux compilation phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->