### PR TITLE
desktop: allow switching between monthly and yearly billing

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/plans/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/plans/page.tsx
@@ -4,7 +4,7 @@ import { Switch } from "@superset/ui/switch";
 import { cn } from "@superset/ui/utils";
 import { useLiveQuery } from "@tanstack/react-db";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { format } from "date-fns";
+import { differenceInDays, format } from "date-fns";
 import { Fragment, useState } from "react";
 import { HiArrowLeft, HiArrowUpRight, HiCheck } from "react-icons/hi2";
 import { env } from "renderer/env.renderer";
@@ -215,6 +215,14 @@ function PlansPage() {
 	const currentPlan: PlanTier = (subscriptionData?.plan as PlanTier) ?? "free";
 	const cancelAt = subscriptionData?.cancelAt;
 
+	const isCurrentlyYearly =
+		subscriptionData?.periodStart &&
+		subscriptionData?.periodEnd &&
+		differenceInDays(
+			new Date(subscriptionData.periodEnd),
+			new Date(subscriptionData.periodStart),
+		) > 60;
+
 	const { data: membersData } = useLiveQuery(
 		(q) =>
 			q
@@ -295,6 +303,7 @@ function PlansPage() {
 					seats: memberCount,
 					successUrl: `${env.NEXT_PUBLIC_WEB_URL}/settings/billing?success=true`,
 					cancelUrl: env.NEXT_PUBLIC_WEB_URL,
+					returnUrl: env.NEXT_PUBLIC_WEB_URL,
 					disableRedirect: true,
 				},
 				{
@@ -397,6 +406,29 @@ function PlansPage() {
 												variant: "default" as const,
 											},
 										];
+									} else if (isCurrent && plan.id === "pro") {
+										const intervalMatches = isYearly === !!isCurrentlyYearly;
+										if (intervalMatches) {
+											planActions = [
+												{
+													label: "Current plan",
+													action: "current" as const,
+													variant: "secondary" as const,
+												},
+											];
+										} else {
+											planActions = [
+												{
+													label: isUpgrading
+														? "Changing..."
+														: isYearly
+															? "Change to Annual"
+															: "Change to Monthly",
+													action: "upgrade" as const,
+													variant: "default" as const,
+												},
+											];
+										}
 									} else if (isCurrent) {
 										planActions = [
 											{


### PR DESCRIPTION
## Summary
- Pro users can now switch between monthly and yearly billing from the plans page
- Derives current billing interval from subscription `periodStart`/`periodEnd` dates (>60 days = yearly)
- Shows "Change to Annual" or "Change to Monthly" button when the toggle differs from current interval
- Adds `returnUrl` to the upgrade call so users return to the app after confirming in Stripe Billing Portal

## Test plan
- [ ] Pro monthly user: toggle to yearly → button shows "Change to Annual" → click opens Stripe Billing Portal → confirm → period dates update → UI reflects new state
- [ ] Pro yearly user: toggle to monthly → "Change to Monthly" → same flow
- [ ] Pro user with matching interval: toggle matches current → "Current plan" (disabled)
- [ ] Free user: upgrade flow unchanged
- [ ] Typecheck passes (`bun run typecheck`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Pro users to switch between monthly and yearly billing on the Plans page. Detects the current interval from subscription dates and returns users to the app after confirming in Stripe.

- **New Features**
  - Added monthly/yearly toggle for Pro plans; shows “Change to Annual/Monthly” if selection differs, or “Current plan” if it matches.
  - Infers current interval using periodStart/periodEnd (>60 days = yearly).
  - Added returnUrl to the upgrade flow so users come back to the app after Stripe; free plan flow unchanged.

<sup>Written for commit ce19c379ec7c67805687a5f9270a577ec5732b89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Pro plan users can now switch between annual and monthly billing intervals directly from the billing settings.
  * Billing plan display now accurately reflects whether your subscription is currently on an annual or monthly cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->