### PR TITLE
chore(desktop): remove spammy terminal_warm_attached PostHog event

### DIFF
--- a/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts
+++ b/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts
@@ -457,16 +457,6 @@ export class DaemonTerminalManager extends EventEmitter {
 				);
 			}
 
-			if (response.wasRecovered) {
-				track("terminal_warm_attached", {
-					workspace_id: workspaceId,
-					pane_id: paneId,
-					snapshot_bytes: response.snapshot.snapshotAnsi
-						? Buffer.byteLength(response.snapshot.snapshotAnsi, "utf8")
-						: 0,
-				});
-			}
-
 			return {
 				isNew: response.isNew,
 				scrollback: "",


### PR DESCRIPTION
## Summary
- Removes the `terminal_warm_attached` PostHog tracking event from `DaemonTerminalManager`
- This event fires ~640k times/week (~91k/day), making it the 3rd highest event by volume without providing useful analytics

## Test plan
- [x] Lint passes
- [x] Typecheck passes (`@superset/desktop`)
- [ ] Verify PostHog event volume drops after deploy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the terminal_warm_attached PostHog event from DaemonTerminalManager when recovering a terminal session. This cuts ~640k weekly events and reduces analytics noise without affecting functionality.

<sup>Written for commit 0d1c67e4c70af9c99b15beba8b19104319190f4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed analytics tracking for warm-recovered terminal sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->