### PR TITLE
fix(desktop): preserve shell wrapper precedence under prompt hooks

### DIFF
--- a/apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts
@@ -349,15 +349,34 @@ add-zsh-hook precmd _superset_user_shadow_precmd
 		createZshWrapper(TEST_PATHS);
 
 		const args = getCommandShellArgs("/bin/zsh", "echo ok", TEST_PATHS);
-		expect(args).toEqual([
-			"-lc",
-			`source "${path.join(TEST_ZSH_DIR, ".zshrc")}" && echo ok`,
-		]);
+		expect(args[0]).toBe("-lc");
+		expect(args[1]).toContain(
+			`source "${path.join(TEST_ZSH_DIR, ".zshrc")}" &&`,
+		);
+		expect(args[1]).toContain("claude() {");
+		expect(args[1]).toContain('command claude "$@"');
+		expect(args[1]).toContain("echo ok");
 	});
 
 	it("falls back to login shell args when zsh wrappers are missing", () => {
 		const args = getCommandShellArgs("/bin/zsh", "echo ok", TEST_PATHS);
-		expect(args).toEqual(["-lc", "echo ok"]);
+		expect(args[0]).toBe("-lc");
+		expect(args[1]).toContain("claude() {");
+		expect(args[1]).toContain('command claude "$@"');
+		expect(args[1]).toContain("echo ok");
+	});
+
+	it("falls back to system managed binary when wrapper path is missing", () => {
+		const args = getCommandShellArgs(
+			"/bin/bash",
+			"claude --version",
+			TEST_PATHS,
+		);
+
+		expect(args[0]).toBe("-lc");
+		expect(args[1]).toContain('_superset_wrapper="/');
+		expect(args[1]).toContain('command claude "$@"');
+		expect(args[1]).toContain("claude --version");
 	});
 
 	it("uses bash rcfile args for interactive bash shells", () => {
@@ -379,6 +398,20 @@ add-zsh-hook precmd _superset_user_shadow_precmd
 	});
 
 	describe("fish shell", () => {
+		it("uses fish-compatible managed command prelude for non-interactive commands", () => {
+			const args = getCommandShellArgs(
+				"/opt/homebrew/bin/fish",
+				"echo ok",
+				TEST_PATHS,
+			);
+
+			expect(args[0]).toBe("-lc");
+			expect(args[1]).toContain("function claude");
+			expect(args[1]).toContain("command claude $argv");
+			expect(args[1]).not.toContain("claude() {");
+			expect(args[1]).toContain("echo ok");
+		});
+
 		it("uses --init-command to prepend BIN_DIR to PATH for fish", () => {
 			const args = getShellArgs("/opt/homebrew/bin/fish", TEST_PATHS);
 

--- a/apps/desktop/src/main/lib/agent-setup/shell-wrappers.ts
+++ b/apps/desktop/src/main/lib/agent-setup/shell-wrappers.ts
@@ -15,8 +15,47 @@ const DEFAULT_PATHS: ShellWrapperPaths = {
 	BASH_DIR,
 };
 
+const MANAGED_BINARIES = [
+	"claude",
+	"codex",
+	"opencode",
+	"gemini",
+	"copilot",
+	"mastracode",
+] as const;
+
 function getShellName(shell: string): string {
 	return shell.split("/").pop() || shell;
+}
+
+function buildManagedCommandPrelude(shellName: string, binDir: string): string {
+	if (shellName === "fish") {
+		return MANAGED_BINARIES.map(
+			(name) =>
+				`functions -q ${name}; and functions -e ${name}
+function ${name}
+  set -l _superset_wrapper "${binDir}/${name}"
+  if test -x "$_superset_wrapper"; and not test -d "$_superset_wrapper"
+    "$_superset_wrapper" $argv
+  else
+    command ${name} $argv
+  end
+end`,
+		).join("\n");
+	}
+
+	return MANAGED_BINARIES.map(
+		(name) =>
+			`unalias ${name} 2>/dev/null || true
+${name}() {
+  _superset_wrapper="${binDir}/${name}"
+  if [ -x "$_superset_wrapper" ] && [ ! -d "$_superset_wrapper" ]; then
+    "$_superset_wrapper" "$@"
+  else
+    command ${name} "$@"
+  fi
+}`,
+	).join("\n");
 }
 
 function writeFileIfChanged(
@@ -290,6 +329,7 @@ export function getShellArgs(
  * Unlike getShellArgs (interactive), we must source profiles inline because:
  * - zsh skips .zshrc for non-interactive shells
  * - bash ignores --rcfile when -c is present
+ * - managed binary prelude enforces app wrappers while falling back to system bins
  */
 export function getCommandShellArgs(
 	shell: string,
@@ -299,11 +339,12 @@ export function getCommandShellArgs(
 	const shellName = getShellName(shell);
 	const zshRc = path.join(paths.ZSH_DIR, ".zshrc");
 	const bashRcfile = path.join(paths.BASH_DIR, "rcfile");
+	const commandWithManagedPrelude = `${buildManagedCommandPrelude(shellName, paths.BIN_DIR)}\n${command}`;
 	if (shellName === "zsh" && fs.existsSync(zshRc)) {
-		return ["-lc", `source "${zshRc}" && ${command}`];
+		return ["-lc", `source "${zshRc}" &&\n${commandWithManagedPrelude}`];
 	}
 	if (shellName === "bash" && fs.existsSync(bashRcfile)) {
-		return ["-c", `source "${bashRcfile}" && ${command}`];
+		return ["-c", `source "${bashRcfile}" &&\n${commandWithManagedPrelude}`];
 	}
-	return ["-lc", command];
+	return ["-lc", commandWithManagedPrelude];
 }


### PR DESCRIPTION
## Summary
- keep zsh compatibility shim files (`.zprofile`, `.zshrc`, `.zlogin`) while preserving native startup semantics via wrapper `.zshenv`
- harden zsh wrapper precedence against prompt-time PATH rewrites by keeping a persistent integration hook (`precmd` + `preexec`) that re-prepends Superset `BIN_DIR`
- harden bash wrapper precedence by installing `_superset_fix_path` into `PROMPT_COMMAND` (array/string-safe) instead of one-shot PATH correction
- add regression tests that reproduce and prevent PATH-shadowing failures for:
  - zsh `precmd` PATH rewrites
  - bash `PROMPT_COMMAND` PATH rewrites

## Validation
- `bun test apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts apps/desktop/src/main/lib/terminal/env.test.ts apps/desktop/src/main/terminal-host/session.test.ts`
- `bunx biome check apps/desktop/src/main/lib/agent-setup/shell-wrappers.ts apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts`

## Debug Notes
- Primary files:
  - `apps/desktop/src/main/lib/agent-setup/shell-wrappers.ts`
  - `apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts`
- Verify runtime behavior in a Superset terminal:
  - `which codex`
  - `which claude`
  - after opening a prompt and running a command, verify wrappers still resolve to `~/.superset*/bin/*`
- Repro checks covered by tests:
  - zsh: user `add-zsh-hook precmd` mutates PATH
  - bash: user `PROMPT_COMMAND` mutates PATH

## Known Limits
- If users forcibly overwrite zsh hook arrays (`precmd_functions=(...)`, `preexec_functions=(...)`) after integration loads, our hooks can be dropped.
- If users later replace `PROMPT_COMMAND` entirely (instead of append/array merge), the bash guard can be removed.
- These are accepted edge cases for now; this PR focuses on common prompt-hook PATH rewrites.

## Rollback Plan
- Revert this hardening commit only:
  - `git revert --no-edit d86a20f35`
- If broader rollback is needed, also revert the wrapper-model commit in this PR stack:
  - `git revert --no-edit 22b621191`
- Re-run validation commands above after any rollback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Adds an integration-driven shell mode that more reliably preserves user startup behavior and enforces wrapper PATH precedence.

* **Bug Fixes**
  * Restores original ZDOTDIR handling for zsh to avoid surprising startup changes.
  * Ensures PATH and prompt-related modifications respect wrapper precedence in zsh and bash.

* **Refactor**
  * Reworked shell wrapper flow for cleaner, more consistent shell startup and environment provisioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->