### PR TITLE
feat(desktop): soft-close terminals to enable live session restore

### DIFF
--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -34,7 +34,10 @@ import {
 	resolveActiveTabIdForWorkspace,
 	resolveFileViewerMode,
 } from "./utils";
-import { killTerminalForPane } from "./utils/terminal-cleanup";
+import {
+	cancelPendingKill,
+	scheduleKillTerminalForPane,
+} from "./utils/terminal-cleanup";
 
 /**
  * Finds the next best tab to activate when closing a tab.
@@ -287,7 +290,7 @@ export const useTabsStore = create<TabsStore>()(
 						// Only kill terminal sessions for terminal panes (avoids unnecessary IPC for file-viewers)
 						const pane = state.panes[paneId];
 						if (pane?.type === "terminal") {
-							killTerminalForPane(paneId);
+							scheduleKillTerminalForPane(paneId);
 						}
 					}
 
@@ -461,7 +464,7 @@ export const useTabsStore = create<TabsStore>()(
 						// in layouts - we must not delete those when they're "removed"
 						if (pane && pane.tabId === tabId) {
 							if (pane.type === "terminal") {
-								killTerminalForPane(paneId);
+								scheduleKillTerminalForPane(paneId);
 							}
 							delete newPanes[paneId];
 						}
@@ -852,7 +855,7 @@ export const useTabsStore = create<TabsStore>()(
 					// Kill terminal sessions for terminal panes
 					for (const id of paneIdsToRemove) {
 						if (state.panes[id]?.type === "terminal") {
-							killTerminalForPane(id);
+							scheduleKillTerminalForPane(id);
 						}
 					}
 
@@ -1664,12 +1667,19 @@ export const useTabsStore = create<TabsStore>()(
 						id: newTabId,
 					};
 
-					// Restore panes with updated tabId references
+					// Restore panes with updated tabId references.
+					// For terminal panes with a pending soft-close kill, reuse the
+					// original pane ID so the daemon session (keyed by paneId) is
+					// found and reattached instead of spawning a new PTY.
 					const idMap = new Map<string, string>();
 					const restoredPanes: Record<string, (typeof entry.panes)[number]> =
 						{};
 					for (const pane of entry.panes) {
-						const newPaneId = generateId("pane");
+						const sessionStillAlive =
+							pane.type === "terminal" && cancelPendingKill(pane.id);
+						const newPaneId = sessionStillAlive
+							? pane.id
+							: generateId("pane");
 						idMap.set(pane.id, newPaneId);
 						restoredPanes[newPaneId] = {
 							...pane,

--- a/apps/desktop/src/renderer/stores/tabs/utils/terminal-cleanup.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils/terminal-cleanup.ts
@@ -1,9 +1,51 @@
 import { electronTrpcClient } from "../../../lib/trpc-client";
 
 /**
- * Uses standalone tRPC client to avoid React hook dependencies
+ * Soft-close delay: terminal sessions are kept alive for this duration after
+ * a pane/tab is closed, allowing "reopen closed tab" (Cmd+Shift+R) to restore
+ * the live session with full scrollback and running processes.
+ */
+const SOFT_CLOSE_DELAY_MS = 60_000;
+
+const pendingKills = new Map<string, ReturnType<typeof setTimeout>>();
+
+/**
+ * Schedule a terminal kill after SOFT_CLOSE_DELAY_MS.
+ * Used by removeTab/removePane so the session stays alive for reopening.
+ */
+export const scheduleKillTerminalForPane = (paneId: string): void => {
+	cancelPendingKill(paneId);
+
+	const timer = setTimeout(() => {
+		pendingKills.delete(paneId);
+		electronTrpcClient.terminal.kill.mutate({ paneId }).catch((error) => {
+			console.warn(`Failed to kill terminal for pane ${paneId}:`, error);
+		});
+	}, SOFT_CLOSE_DELAY_MS);
+
+	pendingKills.set(paneId, timer);
+};
+
+/**
+ * Cancel a pending soft-close kill.
+ * Returns true if a pending kill was cancelled (session is still alive).
+ */
+export const cancelPendingKill = (paneId: string): boolean => {
+	const timer = pendingKills.get(paneId);
+	if (timer) {
+		clearTimeout(timer);
+		pendingKills.delete(paneId);
+		return true;
+	}
+	return false;
+};
+
+/**
+ * Immediately kill a terminal session (no delay).
+ * Used for explicit destroy cases (e.g., pane destroyed while component unmounts).
  */
 export const killTerminalForPane = (paneId: string): void => {
+	cancelPendingKill(paneId);
 	electronTrpcClient.terminal.kill.mutate({ paneId }).catch((error) => {
 		console.warn(`Failed to kill terminal for pane ${paneId}:`, error);
 	});

--- a/apps/desktop/src/renderer/stores/tabs/utils/terminal-cleanup.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils/terminal-cleanup.ts
@@ -1,4 +1,4 @@
-import { electronTrpcClient } from "../../../lib/trpc-client";
+import { electronTrpcClient } from "renderer/lib/trpc-client";
 
 /**
  * Soft-close delay: terminal sessions are kept alive for this duration after

--- a/apps/desktop/src/renderer/stores/tabs/utils/terminal-cleanup.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils/terminal-cleanup.ts
@@ -58,7 +58,9 @@ export const killTerminalForPane = (paneId: string): void => {
 const flushPendingKills = (): void => {
 	for (const [paneId, timer] of pendingKills) {
 		clearTimeout(timer);
-		electronTrpcClient.terminal.kill.mutate({ paneId }).catch(() => {});
+		electronTrpcClient.terminal.kill.mutate({ paneId }).catch((error) => {
+			console.warn(`Failed to flush pending kill for pane ${paneId}:`, error);
+		});
 	}
 	pendingKills.clear();
 };

--- a/apps/desktop/src/renderer/stores/tabs/utils/terminal-cleanup.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils/terminal-cleanup.ts
@@ -6,8 +6,45 @@ import { electronTrpcClient } from "renderer/lib/trpc-client";
  * the live session with full scrollback and running processes.
  */
 const SOFT_CLOSE_DELAY_MS = 60_000;
+const PENDING_KILLS_STORAGE_KEY = "superset:terminal:pending-soft-close-kills";
 
 const pendingKills = new Map<string, ReturnType<typeof setTimeout>>();
+
+const persistPendingKills = (): void => {
+	if (typeof window === "undefined") return;
+	try {
+		window.localStorage.setItem(
+			PENDING_KILLS_STORAGE_KEY,
+			JSON.stringify([...pendingKills.keys()]),
+		);
+	} catch (error) {
+		console.warn("Failed to persist pending soft-close kills:", error);
+	}
+};
+
+const readPersistedPendingKills = (): string[] => {
+	if (typeof window === "undefined") return [];
+	try {
+		const raw = window.localStorage.getItem(PENDING_KILLS_STORAGE_KEY);
+		if (!raw) return [];
+		const parsed = JSON.parse(raw);
+		return Array.isArray(parsed)
+			? parsed.filter((id): id is string => typeof id === "string")
+			: [];
+	} catch (error) {
+		console.warn("Failed to read persisted pending soft-close kills:", error);
+		return [];
+	}
+};
+
+const clearPersistedPendingKills = (): void => {
+	if (typeof window === "undefined") return;
+	try {
+		window.localStorage.removeItem(PENDING_KILLS_STORAGE_KEY);
+	} catch (error) {
+		console.warn("Failed to clear persisted pending soft-close kills:", error);
+	}
+};
 
 /**
  * Schedule a terminal kill after SOFT_CLOSE_DELAY_MS.
@@ -18,12 +55,14 @@ export const scheduleKillTerminalForPane = (paneId: string): void => {
 
 	const timer = setTimeout(() => {
 		pendingKills.delete(paneId);
+		persistPendingKills();
 		electronTrpcClient.terminal.kill.mutate({ paneId }).catch((error) => {
 			console.warn(`Failed to kill terminal for pane ${paneId}:`, error);
 		});
 	}, SOFT_CLOSE_DELAY_MS);
 
 	pendingKills.set(paneId, timer);
+	persistPendingKills();
 };
 
 /**
@@ -35,6 +74,7 @@ export const cancelPendingKill = (paneId: string): boolean => {
 	if (timer) {
 		clearTimeout(timer);
 		pendingKills.delete(paneId);
+		persistPendingKills();
 		return true;
 	}
 	return false;
@@ -63,10 +103,28 @@ const flushPendingKills = (): void => {
 		});
 	}
 	pendingKills.clear();
+	clearPersistedPendingKills();
+};
+
+/**
+ * Recover pending soft-close kills after renderer crash/reload.
+ * If timers were lost, best effort kill the affected pane sessions on next boot.
+ */
+const replayPersistedPendingKills = (): void => {
+	const paneIds = readPersistedPendingKills();
+	if (paneIds.length === 0) return;
+
+	for (const paneId of paneIds) {
+		electronTrpcClient.terminal.kill.mutate({ paneId }).catch((error) => {
+			console.warn(`Failed to replay pending kill for pane ${paneId}:`, error);
+		});
+	}
+	clearPersistedPendingKills();
 };
 
 // Flush pending kills when the renderer is unloading (crash, reload, quit)
 // so that orphan PTY sessions are not left behind.
 if (typeof window !== "undefined") {
+	replayPersistedPendingKills();
 	window.addEventListener("beforeunload", flushPendingKills);
 }

--- a/apps/desktop/src/renderer/stores/tabs/utils/terminal-cleanup.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils/terminal-cleanup.ts
@@ -50,3 +50,21 @@ export const killTerminalForPane = (paneId: string): void => {
 		console.warn(`Failed to kill terminal for pane ${paneId}:`, error);
 	});
 };
+
+/**
+ * Flush all pending soft-close kills immediately.
+ * Called on renderer teardown to prevent orphan PTY sessions.
+ */
+const flushPendingKills = (): void => {
+	for (const [paneId, timer] of pendingKills) {
+		clearTimeout(timer);
+		electronTrpcClient.terminal.kill.mutate({ paneId }).catch(() => {});
+	}
+	pendingKills.clear();
+};
+
+// Flush pending kills when the renderer is unloading (crash, reload, quit)
+// so that orphan PTY sessions are not left behind.
+if (typeof window !== "undefined") {
+	window.addEventListener("beforeunload", flushPendingKills);
+}


### PR DESCRIPTION
## Summary

- When closing a pane/tab, terminal PTY sessions are now **kept alive for 60 seconds** instead of being killed immediately
- If the user reopens the tab (`Cmd+Shift+R`) within that window, the original session is **reattached with full scrollback and running processes preserved**
- After 60 seconds without reopening, the session is killed as before (no resource leak)
- The existing `Cmd+Shift+R` reopen already restores tab/pane UI structure via `closedTabsStack` — this PR makes it actually useful for terminals

## Problem

Currently `Cmd+Shift+R` ("Reopen Closed Tab") restores the tab layout but spawns fresh empty terminals because the PTY was killed immediately on close. Accidentally closing a terminal with a long-running process or important scrollback history means losing it forever.

## How it works

1. **`scheduleKillTerminalForPane`** replaces the immediate `killTerminalForPane` in `removeTab`, `removePane`, and `setTabLayout`. It schedules the kill with a 60-second delay.
2. **`cancelPendingKill`** cancels the scheduled kill and returns `true` if the session is still alive.
3. **`reopenClosedTab`** now calls `cancelPendingKill` for each terminal pane. If the session is still alive, it **reuses the original pane ID** instead of generating a new one. Since the daemon uses `paneId` as `sessionId`, `createOrAttach` naturally finds and reattaches to the existing session.
4. The immediate `killTerminalForPane` is preserved for explicit destroy cases (e.g., `useTerminalLifecycle` cleanup when a pane is destroyed from the store).

## Test plan

- [ ] Close a terminal pane with `Cmd+W`, immediately `Cmd+Shift+R` — terminal should restore with full scrollback and running process
- [ ] Close a pane, wait >60s, then `Cmd+Shift+R` — should get a fresh empty terminal
- [ ] Close a tab with multiple terminal panes, reopen — all panes restore with live sessions
- [ ] Drag-remove a pane from layout — should schedule kill (not immediate)
- [ ] Close a tab with a mix of terminal + non-terminal panes — terminals get soft-close, others get new IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closing a terminal now soft-closes its PTY for 60 seconds, enabling live session restore via Reopen Closed Tab (Cmd+Shift+R). Pending kills persist across renderer restarts to prevent orphan PTYs.

- **Refactors**
  - Add scheduleKillTerminalForPane (60s) and cancelPendingKill; keep immediate kill; switch trpc-client import to renderer/lib/trpc-client.
  - Reopen cancels pending kills and reuses pane IDs in removeTab/removePane/setTabLayout to reattach sessions.

- **Bug Fixes**
  - Flush pending soft-close kills on beforeunload and warn on failures to avoid orphan PTYs.
  - Persist pending kills to localStorage and replay on startup to clean up after renderer restarts.

<sup>Written for commit 769e13ade6e3d3a609d0e138cedb521fe5364828. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Soft-close for terminals with delayed termination so closed tabs can be reopened and restore live sessions, preserving terminal identity when cancellation occurs.
  * Persistence of pending soft-closes across app restarts, with automatic replay on load.

* **Bug Fixes**
  * Replaced immediate terminal kills with schedule/cancel mechanism to prevent premature termination.
  * Ensures pending terminations are flushed on teardown to avoid orphaned sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->