### PR TITLE
fix(desktop): render first chat message immediately during session init

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/ChatMastraInterface.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/ChatMastraInterface.tsx
@@ -1,7 +1,6 @@
 import { chatServiceTrpc } from "@superset/chat/client";
 import {
 	chatMastraServiceTrpc,
-	type UseMastraChatDisplayReturn,
 	useMastraChatDisplay,
 } from "@superset/chat-mastra/client";
 import {
@@ -27,62 +26,16 @@ import { McpControls } from "./components/McpControls";
 import { useMcpUi } from "./hooks/useMcpUi";
 import type { ChatMastraInterfaceProps } from "./types";
 import {
+	hasMatchingUserMessage,
+	type MastraHistoryMessage,
+	toOptimisticUserMessage,
+} from "./utils/optimisticUserMessage";
+import {
 	type ChatSendMessageInput,
 	sendMessageForSession,
 	toSendFailureMessage,
 } from "./utils/sendMessage";
 import { toMastraImages } from "./utils/toMastraImages";
-
-type MastraHistoryMessage = NonNullable<
-	UseMastraChatDisplayReturn["messages"]
->[number];
-
-function toOptimisticUserMessage(
-	input: ChatSendMessageInput,
-): MastraHistoryMessage | null {
-	const text = input.payload.content.trim();
-	const images = input.payload.images ?? [];
-	if (!text && images.length === 0) return null;
-
-	return {
-		id: `optimistic-${crypto.randomUUID()}`,
-		role: "user",
-		content: [
-			...(text ? [{ type: "text", text }] : []),
-			...images.map((image) => ({
-				type: "image",
-				data: image.data,
-				mimeType: image.mimeType,
-			})),
-		],
-		createdAt: new Date(),
-	} as MastraHistoryMessage;
-}
-
-function toUserMessageSignature(message: MastraHistoryMessage): string | null {
-	if (message.role !== "user") return null;
-	return message.content
-		.map((part) => {
-			if (part.type === "text") return `text:${part.text}`;
-			if (part.type === "image") return `image:${part.mimeType}:${part.data}`;
-			return `${part.type}:${JSON.stringify(part)}`;
-		})
-		.join("||");
-}
-
-function hasMatchingUserMessage({
-	messages,
-	candidate,
-}: {
-	messages: MastraHistoryMessage[];
-	candidate: MastraHistoryMessage;
-}): boolean {
-	const signature = toUserMessageSignature(candidate);
-	if (!signature) return false;
-	return messages.some(
-		(message) => toUserMessageSignature(message) === signature,
-	);
-}
 
 function useAvailableModels(): {
 	models: ModelOption[];
@@ -343,7 +296,7 @@ export function ChatMastraInterface({
 		if (!pendingImmediateUserMessage) return;
 		if (
 			hasMatchingUserMessage({
-				messages: messages as MastraHistoryMessage[],
+				messages,
 				candidate: pendingImmediateUserMessage,
 			})
 		) {
@@ -355,7 +308,7 @@ export function ChatMastraInterface({
 		if (!pendingImmediateUserMessage) return messages;
 		if (
 			hasMatchingUserMessage({
-				messages: messages as MastraHistoryMessage[],
+				messages,
 				candidate: pendingImmediateUserMessage,
 			})
 		) {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/utils/optimisticUserMessage/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/utils/optimisticUserMessage/index.ts
@@ -1,0 +1,5 @@
+export {
+	hasMatchingUserMessage,
+	type MastraHistoryMessage,
+	toOptimisticUserMessage,
+} from "./optimisticUserMessage";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/utils/optimisticUserMessage/optimisticUserMessage.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/utils/optimisticUserMessage/optimisticUserMessage.ts
@@ -1,0 +1,53 @@
+import type { UseMastraChatDisplayReturn } from "@superset/chat-mastra/client";
+import type { ChatSendMessageInput } from "../sendMessage";
+
+export type MastraHistoryMessage = NonNullable<
+	UseMastraChatDisplayReturn["messages"]
+>[number];
+
+export function toOptimisticUserMessage(
+	input: ChatSendMessageInput,
+): MastraHistoryMessage | null {
+	const text = input.payload.content.trim();
+	const images = input.payload.images ?? [];
+	if (!text && images.length === 0) return null;
+
+	return {
+		id: `optimistic-${crypto.randomUUID()}`,
+		role: "user",
+		content: [
+			...(text ? [{ type: "text", text }] : []),
+			...images.map((image) => ({
+				type: "image",
+				data: image.data,
+				mimeType: image.mimeType,
+			})),
+		],
+		createdAt: new Date(),
+	} as MastraHistoryMessage;
+}
+
+function toUserMessageSignature(message: MastraHistoryMessage): string | null {
+	if (message.role !== "user") return null;
+	return message.content
+		.map((part) => {
+			if (part.type === "text") return `text:${part.text}`;
+			if (part.type === "image") return `image:${part.mimeType}:${part.data}`;
+			return `${part.type}:${JSON.stringify(part)}`;
+		})
+		.join("||");
+}
+
+export function hasMatchingUserMessage({
+	messages,
+	candidate,
+}: {
+	messages: MastraHistoryMessage[];
+	candidate: MastraHistoryMessage;
+}): boolean {
+	const signature = toUserMessageSignature(candidate);
+	if (!signature) return false;
+	return messages.some(
+		(message) => toUserMessageSignature(message) === signature,
+	);
+}


### PR DESCRIPTION
## Summary
- fix delayed user-message rendering in Chat Mastra when the session is empty/new
- add optimistic cache insertion for sends routed through `sendToSession` (fresh-session path)
- add immediate local optimistic user message while waiting for `ensureSessionReady()` on pre-seeded but not-yet-ready sessions
- dedupe/clear the local optimistic entry when the real message arrives, and roll back on send failure

## Root cause
When a pane had a session id but no session record yet, sends waited on session initialization before `commands.sendMessage()` ran, so optimistic UI did not show immediately. For fresh-session sends, the direct mutate path also bypassed optimistic insertion.

## Validation
- `bun run typecheck --filter=@superset/desktop`
- `bun test apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/utils/sendMessage/sendMessage.test.ts`
- `bunx biome check apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/ChatMastraInterface.tsx`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the first user message immediately during session init. Adds optimistic rendering with rollback and signature-based dedup.

- **Bug Fixes**
  - Add optimistic user message for fresh-session sends; remove on failure.
  - Render a local immediate user message while waiting for a pre-seeded session; dedupe when the real one arrives (signature match) or on error.
  - Use a small pending state and memoized visible messages; reset on scope/session changes. Extract helpers to utils/optimisticUserMessage.

<sup>Written for commit cfe3a7322d3e81eb5c40cb6ed3df6e06af15196f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optimistic messaging in chat: Messages now display instantly as you send them, without waiting for server confirmation. This provides immediate visual feedback and a more responsive chat experience. The system automatically handles backend synchronization and gracefully manages failures by reverting messages if transmission errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->