### PR TITLE
fix(electric-proxy): use Cache API for cross-zone caching

### DIFF
--- a/apps/electric-proxy/src/index.ts
+++ b/apps/electric-proxy/src/index.ts
@@ -86,11 +86,16 @@ export default {
 		const upstreamUrl = buildUpstreamUrl(url, tableName, whereClause, env);
 
 		// Use the Worker's own URL as the cache key (required for Cache API).
-		// Strip organizationId since it's already encoded in the where clause
-		// sent upstream — the rest of the params (table, offset, handle, etc.)
-		// naturally deduplicate requests from the same org.
+		// organizationId must stay in the key to prevent cross-tenant cache sharing.
+		// For auth.organizations (no organizationId param), the where clause depends
+		// on the user's JWT org list, so add a stable derivative to scope the cache.
 		const cacheUrl = new URL(request.url);
-		cacheUrl.searchParams.delete("organizationId");
+		if (tableName === "auth.organizations") {
+			cacheUrl.searchParams.set(
+				"_orgIds",
+				[...auth.organizationIds].sort().join(","),
+			);
+		}
 		const cacheKey = new Request(cacheUrl.toString());
 
 		const cache = caches.default;


### PR DESCRIPTION
## Summary
- `cacheEverything: true` is silently ignored when subrequests target another Cloudflare zone (`api.electric-sql.cloud` is behind CF), resulting in 0% cache rate
- Switches to the Cache API (`caches.default`) which stores responses in the Worker's own cache, bypassing cross-zone restrictions
- Uses the Worker's own URL as the cache key (per CF docs), stripping `organizationId` since it's already encoded in the upstream where clause
- Only caches responses that include `cache-control` headers, respecting Electric's caching semantics

## Test plan
- [ ] Deploy to preview and verify cache rate > 0% in CF dashboard subrequests panel
- [ ] Confirm same org + same table requests produce cache hits
- [ ] Verify live/SSE requests (which lack cache-control headers) are not cached

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 0% cache rate in electric-proxy by switching to Cloudflare’s Cache API for cross-zone requests. Secures cache keys to prevent cross-tenant leaks and standardizes CORS headers.

- **Bug Fixes**
  - Replaced cf.cacheEverything with caches.default; cache writes via ctx.waitUntil.
  - Cache key uses the Worker URL; keep organizationId, and for auth.organizations add _orgIds (sorted JWT org IDs).
  - Only caches response.ok with cache-control; live/SSE remain uncached.
  - Centralized CORS headers for all responses (including cached); strip content-encoding/length.

<sup>Written for commit ce0732e75f952ddc3581876d831d4cf886a12058. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CORS header handling and OPTIONS responses to ensure reliable cross-origin requests and consistent response headers.

* **Performance**
  * Added smart response caching to reduce latency and server load, including stable organization-aware cache keys so users see consistent, faster results for repeated requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->