### PR TITLE
fix(ui): disable smooth chat auto-scroll on resize

### DIFF
--- a/packages/ui/src/components/ai-elements/conversation.tsx
+++ b/packages/ui/src/components/ai-elements/conversation.tsx
@@ -13,7 +13,7 @@ export const Conversation = ({ className, ...props }: ConversationProps) => (
 	<StickToBottom
 		className={cn("relative flex-1 overflow-y-hidden", className)}
 		initial="instant"
-		resize="smooth"
+		resize="instant"
 		role="log"
 		{...props}
 	/>


### PR DESCRIPTION
## Summary
- change shared `Conversation` stick-to-bottom resize behavior from `smooth` to `instant`
- prevents animated jumps to bottom when chat content/layout changes (including thread switches)
- applies consistently to chat panes using the shared ai-elements conversation wrapper

## Testing
- `bunx biome check packages/ui/src/components/ai-elements/conversation.tsx`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled smooth auto-scroll on resize in the shared Conversation component. This prevents jumpy scroll when content or layout changes and applies across all chat panes using the ai-elements wrapper.

<sup>Written for commit 40f18ae88841dd647eb9e836a2e602186412568b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the conversation component's resize animation behavior from smooth to instant transitions for faster responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->