### PR TITLE
fix(desktop): improve memory attribution and reduce background webview pressure

### DIFF
--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -40,7 +40,9 @@ class BrowserManager extends EventEmitter {
 		this.paneWebContentsIds.set(paneId, webContentsId);
 		const wc = webContents.fromId(webContentsId);
 		if (wc) {
-			wc.setBackgroundThrottling(false);
+			// Keep throttling enabled so parked/offscreen persistent webviews don't
+			// run at full speed in the background.
+			wc.setBackgroundThrottling(true);
 			wc.setWindowOpenHandler(({ url }) => {
 				if (url && url !== "about:blank") {
 					this.emit(`new-window:${paneId}`, url);

--- a/apps/desktop/src/main/lib/resource-metrics/index.ts
+++ b/apps/desktop/src/main/lib/resource-metrics/index.ts
@@ -30,6 +30,7 @@ interface WorkspaceMetrics {
 interface AppMetrics extends ProcessMetrics {
 	main: ProcessMetrics;
 	renderer: ProcessMetrics;
+	other: ProcessMetrics;
 }
 
 export interface ResourceMetricsSnapshot {
@@ -86,19 +87,32 @@ export async function collectResourceMetrics(): Promise<ResourceMetricsSnapshot>
 	const electronMetrics = app.getAppMetrics();
 	const main: ProcessMetrics = { cpu: 0, memory: 0 };
 	const renderer: ProcessMetrics = { cpu: 0, memory: 0 };
+	const other: ProcessMetrics = { cpu: 0, memory: 0 };
+
+	const isRendererProcessType = (type: string): boolean => {
+		const normalized = type.toLowerCase();
+		return normalized === "renderer" || normalized === "tab";
+	};
+
 	for (const proc of electronMetrics) {
 		const cpu = proc.cpu.percentCPUUsage;
 		// workingSetSize is in KB
 		const memory = proc.memory.workingSetSize * 1024;
-		const target = proc.type === "Browser" ? main : renderer;
+		let target = other;
+		if (proc.type === "Browser") {
+			target = main;
+		} else if (isRendererProcessType(proc.type)) {
+			target = renderer;
+		}
 		target.cpu += cpu;
 		target.memory += memory;
 	}
 	const appMetrics: AppMetrics = {
-		cpu: main.cpu + renderer.cpu,
-		memory: main.memory + renderer.memory,
+		cpu: main.cpu + renderer.cpu + other.cpu,
+		memory: main.memory + renderer.memory + other.memory,
 		main,
 		renderer,
+		other,
 	};
 
 	const sessionAggregated = new Map<string, { cpu: number; memory: number }>();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/ResourceConsumption.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/ResourceConsumption.tsx
@@ -169,6 +169,24 @@ export function ResourceConsumption() {
 									</span>
 								</div>
 							</div>
+							{(snapshot.app.other.cpu > 0 ||
+								snapshot.app.other.memory > 0) && (
+								<div className="px-3 py-1.5 pl-6 flex items-center justify-between bg-muted/30">
+									<span className="text-[11px] text-muted-foreground min-w-0 truncate">
+										Other
+									</span>
+									<div
+										className={`${METRIC_COLS} text-[11px] text-muted-foreground`}
+									>
+										<span className={CPU_COL}>
+											{formatCpu(snapshot.app.other.cpu)}
+										</span>
+										<span className={MEM_COL}>
+											{formatMemory(snapshot.app.other.memory)}
+										</span>
+									</div>
+								</div>
+							)}
 						</div>
 					)}
 


### PR DESCRIPTION
## Summary
- Improve resource monitor attribution so Electron process usage is split into `main`, `renderer`, and `other` instead of lumping all non-browser processes into renderer.
- Surface `Other` in the Resource Usage UI so totals are explainable and debugging is actionable.
- Re-enable background throttling for persistent browser webviews to reduce hidden/offscreen memory and CPU pressure introduced by persistent webview behavior.

## Why
Recent desktop regressions were traced back to:
- `6eb9bf622` (persistent browser webviews) keeping browser webContents alive while hidden.
- `ccb6011e10` (Sequoia anti-white-screen hardening) broad backgrounding changes that can increase baseline pressure.

This PR specifically addresses item **3** from the investigation: improve monitor attribution so we can correctly identify where memory is going, and reduce one concrete hidden-webview pressure source from the persistent-webview path.

## Changes
- `apps/desktop/src/main/lib/resource-metrics/index.ts`
  - Added `app.other` bucket.
  - Classified Electron process types more precisely (`Browser` -> main, `Renderer`/`Tab` -> renderer, remainder -> other).
- `apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/ResourceConsumption.tsx`
  - Added an `Other` row in the app section.
- `apps/desktop/src/main/lib/browser/browser-manager.ts`
  - Set persistent browser webContents background throttling to `true` (instead of forcing `false`).

## Validation
- `bunx biome check` on touched files passed.
- Full desktop TypeScript check is currently blocked by existing route generation issues (`routeTree.gen` missing), unrelated to this PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves resource attribution in the desktop app and cuts background CPU/memory by re-enabling throttling for persistent webviews. Totals are now split into main, renderer, and other, with “Other” shown in the Resource Usage panel.

- **New Features**
  - More precise Electron process classification: Browser → main; renderer/tab → renderer; others → other.
  - Added an “Other” bucket to metrics and display it in the Resource Usage panel.

- **Bug Fixes**
  - Re-enabled background throttling for persistent browser webviews to reduce hidden/offscreen CPU and memory use.

<sup>Written for commit ac2de938c282288b5a2028f259a50417c039e592. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Other" category to per-app resource consumption display, showing additional process metrics alongside Main and Renderer when applicable.

* **Improvements**
  * Enabled background throttling for webContents to optimize resource usage.
  * Extended resource metrics aggregation to track and include processes outside Main and Renderer categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->