### PR TITLE
feat(desktop): add worker thread pool for heavy git reads

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -101,6 +101,10 @@ export default defineConfig({
 					"terminal-host": resolve("src/main/terminal-host/index.ts"),
 					// PTY subprocess - spawned by terminal-host for each terminal
 					"pty-subprocess": resolve("src/main/terminal-host/pty-subprocess.ts"),
+					// Git worker thread - offloads heavy git reads from main thread
+					"git-worker-thread": resolve(
+						"src/main/lib/git-worker/worker-thread.ts",
+					),
 				},
 				output: {
 					dir: resolve(devPath, "main"),

--- a/apps/desktop/src/lib/trpc/routers/changes/status.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/status.ts
@@ -3,6 +3,11 @@ import type { ChangedFile, GitChangesStatus } from "shared/changes-types";
 import type { StatusResult } from "simple-git";
 import simpleGit from "simple-git";
 import { z } from "zod";
+import {
+	isGitWorkerEnabled,
+	submitGetCommitFiles,
+	submitGetStatus,
+} from "../../../../main/lib/git-worker";
 import { publicProcedure, router } from "../..";
 import { getStatusNoLock, NotGitRepoError } from "../workspaces/utils/git";
 import { assertRegisteredWorktree, secureFs } from "./security";
@@ -47,59 +52,21 @@ export const createStatusRouter = () => {
 
 				let statusPromise!: Promise<GitChangesStatus>;
 				statusPromise = (async (): Promise<GitChangesStatus> => {
-					const git = simpleGit(input.worktreePath);
-
-					let status: StatusResult;
-					try {
-						status = await getStatusNoLock(input.worktreePath);
-					} catch (error) {
-						if (error instanceof NotGitRepoError) {
-							throw new TRPCError({
-								code: "BAD_REQUEST",
-								message: error.message,
-							});
-						}
-						throw error;
+					if (isGitWorkerEnabled()) {
+						return await getStatusViaWorker(input.worktreePath, defaultBranch);
 					}
-					const parsed = parseGitStatus(status);
+					return await getStatusMainThread(input.worktreePath, defaultBranch);
+				})();
 
-					const [branchComparison, trackingStatus] = await Promise.all([
-						getBranchComparison(git, defaultBranch),
-						getTrackingBranchStatus(git),
-						applyNumstatToFiles(git, parsed.staged, [
-							"diff",
-							"--cached",
-							"--numstat",
-						]),
-						applyNumstatToFiles(git, parsed.unstaged, ["diff", "--numstat"]),
-						applyUntrackedLineCount(input.worktreePath, parsed.untracked),
-					]);
-
-					const result: GitChangesStatus = {
-						branch: parsed.branch,
-						defaultBranch,
-						againstBase: branchComparison.againstBase,
-						commits: branchComparison.commits,
-						staged: parsed.staged,
-						unstaged: parsed.unstaged,
-						untracked: parsed.untracked,
-						ahead: branchComparison.ahead,
-						behind: branchComparison.behind,
-						pushCount: trackingStatus.pushCount,
-						pullCount: trackingStatus.pullCount,
-						hasUpstream: trackingStatus.hasUpstream,
-					};
+				setInFlightStatus(cacheKey, statusPromise);
+				try {
+					const result = await statusPromise;
 
 					// Guard against stale in-flight completion after explicit invalidation.
 					if (getInFlightStatus(cacheKey) === statusPromise) {
 						setCachedStatus(cacheKey, result);
 					}
 					return result;
-				})();
-
-				setInFlightStatus(cacheKey, statusPromise);
-				try {
-					return await statusPromise;
 				} finally {
 					if (getInFlightStatus(cacheKey) === statusPromise) {
 						clearInFlightStatus(cacheKey);
@@ -117,29 +84,122 @@ export const createStatusRouter = () => {
 			.query(async ({ input }): Promise<ChangedFile[]> => {
 				assertRegisteredWorktree(input.worktreePath);
 
-				const git = simpleGit(input.worktreePath);
-
-				const nameStatus = await git.raw([
-					"diff-tree",
-					"--no-commit-id",
-					"--name-status",
-					"-r",
+				if (isGitWorkerEnabled()) {
+					return await getCommitFilesViaWorker(
+						input.worktreePath,
+						input.commitHash,
+					);
+				}
+				return await getCommitFilesMainThread(
+					input.worktreePath,
 					input.commitHash,
-				]);
-				const files = parseNameStatus(nameStatus);
-
-				await applyNumstatToFiles(git, files, [
-					"diff-tree",
-					"--no-commit-id",
-					"--numstat",
-					"-r",
-					input.commitHash,
-				]);
-
-				return files;
+				);
 			}),
 	});
 };
+
+// ---------------------------------------------------------------------------
+// Worker-based implementations
+// ---------------------------------------------------------------------------
+
+async function getStatusViaWorker(
+	worktreePath: string,
+	defaultBranch: string,
+): Promise<GitChangesStatus> {
+	try {
+		return await submitGetStatus({ worktreePath, defaultBranch });
+	} catch (error) {
+		const msg = error instanceof Error ? error.message : String(error);
+		if (msg.includes("Not a git repository")) {
+			throw new TRPCError({
+				code: "BAD_REQUEST",
+				message: msg,
+			});
+		}
+		throw error;
+	}
+}
+
+async function getCommitFilesViaWorker(
+	worktreePath: string,
+	commitHash: string,
+): Promise<ChangedFile[]> {
+	return await submitGetCommitFiles({ worktreePath, commitHash });
+}
+
+// ---------------------------------------------------------------------------
+// Main-thread fallback implementations (SUPERSET_GIT_WORKER=0)
+// ---------------------------------------------------------------------------
+
+async function getStatusMainThread(
+	worktreePath: string,
+	defaultBranch: string,
+): Promise<GitChangesStatus> {
+	const git = simpleGit(worktreePath);
+
+	let status: StatusResult;
+	try {
+		status = await getStatusNoLock(worktreePath);
+	} catch (error) {
+		if (error instanceof NotGitRepoError) {
+			throw new TRPCError({
+				code: "BAD_REQUEST",
+				message: error.message,
+			});
+		}
+		throw error;
+	}
+	const parsed = parseGitStatus(status);
+
+	const [branchComparison, trackingStatus] = await Promise.all([
+		getBranchComparison(git, defaultBranch),
+		getTrackingBranchStatus(git),
+		applyNumstatToFiles(git, parsed.staged, ["diff", "--cached", "--numstat"]),
+		applyNumstatToFiles(git, parsed.unstaged, ["diff", "--numstat"]),
+		applyUntrackedLineCount(worktreePath, parsed.untracked),
+	]);
+
+	return {
+		branch: parsed.branch,
+		defaultBranch,
+		againstBase: branchComparison.againstBase,
+		commits: branchComparison.commits,
+		staged: parsed.staged,
+		unstaged: parsed.unstaged,
+		untracked: parsed.untracked,
+		ahead: branchComparison.ahead,
+		behind: branchComparison.behind,
+		pushCount: trackingStatus.pushCount,
+		pullCount: trackingStatus.pullCount,
+		hasUpstream: trackingStatus.hasUpstream,
+	};
+}
+
+async function getCommitFilesMainThread(
+	worktreePath: string,
+	commitHash: string,
+): Promise<ChangedFile[]> {
+	const git = simpleGit(worktreePath);
+
+	const nameStatus = await git.raw([
+		"diff-tree",
+		"--no-commit-id",
+		"--name-status",
+		"-r",
+		commitHash,
+	]);
+	const files = parseNameStatus(nameStatus);
+
+	await applyNumstatToFiles(git, files, [
+		"diff-tree",
+		"--no-commit-id",
+		"--numstat",
+		"-r",
+		commitHash,
+	]);
+
+	return files;
+}
 
 interface BranchComparison {
 	commits: GitChangesStatus["commits"];

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -27,6 +27,7 @@ import { requestAppleEventsAccess } from "./lib/apple-events-permission";
 import { setupAutoUpdater } from "./lib/auto-updater";
 import { setWorkspaceDockIcon } from "./lib/dock-icon";
 import { loadWebviewBrowserExtension } from "./lib/extensions";
+import { destroyGitWorkerPool } from "./lib/git-worker";
 import { localDb } from "./lib/local-db";
 import { reportMainProcessError } from "./lib/notifications/server";
 import { outlit } from "./lib/outlit";
@@ -188,11 +189,11 @@ app.on("before-quit", async (event) => {
 			console.error("[main] Quit confirmation dialog failed:", error);
 		}
 	}
-
 	// Quit confirmed or no confirmation needed - exit immediately
 	// Let OS clean up child processes, tray, etc.
 	isQuitting = true;
 	await outlit.shutdown();
+	await destroyGitWorkerPool();
 	disposeTray();
 	app.exit(0);
 });

--- a/apps/desktop/src/main/lib/git-worker/index.ts
+++ b/apps/desktop/src/main/lib/git-worker/index.ts
@@ -1,0 +1,108 @@
+/**
+ * Git Worker Runtime
+ *
+ * Singleton worker pool for offloading heavy git reads from the main thread.
+ * Used by tRPC routers via the convenience functions exported here.
+ *
+ * Feature flag: set SUPERSET_GIT_WORKER=0 to disable and fall back to
+ * main-thread execution (default: enabled).
+ */
+
+import { join } from "node:path";
+import { GitWorkerPool } from "./pool";
+import type { GitTaskPayloads, GitTaskResults } from "./types";
+
+// ---------------------------------------------------------------------------
+// Feature flag
+// ---------------------------------------------------------------------------
+
+const GIT_WORKER_ENABLED = process.env.SUPERSET_GIT_WORKER !== "0";
+
+const GIT_WORKER_DEBUG = process.env.SUPERSET_GIT_WORKER_DEBUG === "1";
+
+// ---------------------------------------------------------------------------
+// Singleton pool
+// ---------------------------------------------------------------------------
+
+let pool: GitWorkerPool | null = null;
+
+/**
+ * Resolve the built worker script path.
+ * In electron-vite builds, all main-process entry points are emitted
+ * to the same output directory alongside the main index.js.
+ */
+function getWorkerScriptPath(): string {
+	// __dirname points to dist/main/ in the built app
+	return join(__dirname, "git-worker-thread.js");
+}
+
+function getPool(): GitWorkerPool {
+	if (!pool) {
+		pool = new GitWorkerPool(getWorkerScriptPath(), {
+			maxWorkers: 2,
+			maxQueueSize: 50,
+			defaultTimeoutMs: 30_000,
+			debug: GIT_WORKER_DEBUG,
+		});
+	}
+	return pool;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function isGitWorkerEnabled(): boolean {
+	return GIT_WORKER_ENABLED;
+}
+
+/**
+ * Submit a getStatus task to the worker pool.
+ */
+export function submitGetStatus(
+	payload: GitTaskPayloads["getStatus"],
+): Promise<GitTaskResults["getStatus"]> {
+	return getPool().submit("getStatus", payload, {
+		dedupeKey: `${payload.worktreePath}:${payload.defaultBranch}`,
+		timeoutMs: 30_000,
+	});
+}
+
+/**
+ * Submit a getCommitFiles task to the worker pool.
+ */
+export function submitGetCommitFiles(
+	payload: GitTaskPayloads["getCommitFiles"],
+): Promise<GitTaskResults["getCommitFiles"]> {
+	return getPool().submit("getCommitFiles", payload, {
+		dedupeKey: `commitFiles:${payload.worktreePath}:${payload.commitHash}`,
+		timeoutMs: 30_000,
+	});
+}
+
+/**
+ * Cancel pending git tasks for a given worktree path.
+ * Call this on workspace switch or section collapse.
+ */
+export function cancelGitTasksForWorktree(worktreePath: string): void {
+	if (!pool) return;
+	pool.cancelByPrefix(worktreePath);
+}
+
+/**
+ * Get current worker pool metrics for observability.
+ */
+export function getGitWorkerMetrics() {
+	if (!pool) return null;
+	return pool.getMetrics();
+}
+
+/**
+ * Shut down the worker pool. Call on app quit.
+ */
+export async function destroyGitWorkerPool(): Promise<void> {
+	if (pool) {
+		await pool.destroy();
+		pool = null;
+	}
+}

--- a/apps/desktop/src/main/lib/git-worker/pool.ts
+++ b/apps/desktop/src/main/lib/git-worker/pool.ts
@@ -1,0 +1,461 @@
+/**
+ * Git Worker Pool
+ *
+ * Main-thread orchestrator for offloading heavy git reads to worker_threads.
+ * Features:
+ * - Bounded concurrency pool
+ * - Task coalescing (same dedupeKey joins in-flight task)
+ * - Latest-wins for repeated status requests
+ * - Per-task timeout with cancellation
+ * - Worker crash isolation with automatic restart
+ * - Backpressure (queue cap)
+ * - Observability metrics
+ */
+
+import { randomUUID } from "node:crypto";
+import { Worker } from "node:worker_threads";
+import type {
+	GitTask,
+	GitTaskPayloads,
+	GitTaskResults,
+	GitTaskType,
+	GitWorkerMetrics,
+	GitWorkerPoolConfig,
+	WorkerRequest,
+	WorkerResponse,
+} from "./types";
+import { DEFAULT_POOL_CONFIG } from "./types";
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+interface PendingTask<T extends GitTaskType = GitTaskType> {
+	task: GitTask<T>;
+	resolve: (result: GitTaskResults[T]) => void;
+	reject: (error: Error) => void;
+	generation: number;
+	timer?: ReturnType<typeof setTimeout>;
+}
+
+interface WorkerSlot {
+	worker: Worker;
+	busy: boolean;
+	currentTaskId: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Pool implementation
+// ---------------------------------------------------------------------------
+
+export class GitWorkerPool {
+	private readonly config: GitWorkerPoolConfig;
+	private readonly workerScriptPath: string;
+	private slots: WorkerSlot[] = [];
+	private queue: PendingTask[] = [];
+	private inFlight = new Map<string, PendingTask>();
+	/** dedupeKey → { taskId, generation } for coalescing */
+	private dedupeMap = new Map<
+		string,
+		{ taskId: string; generation: number; subscribers: PendingTask[] }
+	>();
+	/** dedupeKey → monotonic generation counter for latest-wins */
+	private generationCounters = new Map<string, number>();
+	private metrics: GitWorkerMetrics = {
+		tasksSubmitted: 0,
+		tasksCompleted: 0,
+		tasksFailed: 0,
+		tasksTimedOut: 0,
+		tasksCoalesced: 0,
+		tasksCancelled: 0,
+		workerRestarts: 0,
+		currentQueueSize: 0,
+		currentActiveWorkers: 0,
+	};
+	private destroyed = false;
+
+	constructor(
+		workerScriptPath: string,
+		config: Partial<GitWorkerPoolConfig> = {},
+	) {
+		this.config = { ...DEFAULT_POOL_CONFIG, ...config };
+		this.workerScriptPath = workerScriptPath;
+		this.initWorkers();
+	}
+
+	// -----------------------------------------------------------------------
+	// Public API
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Submit a typed task to the worker pool.
+	 * Returns a promise that resolves with the task result.
+	 */
+	submit<T extends GitTaskType>(
+		taskType: T,
+		payload: GitTaskPayloads[T],
+		options: {
+			dedupeKey: string;
+			timeoutMs?: number;
+		},
+	): Promise<GitTaskResults[T]> {
+		if (this.destroyed) {
+			return Promise.reject(new Error("Worker pool is destroyed"));
+		}
+
+		this.metrics.tasksSubmitted++;
+		const { dedupeKey, timeoutMs = this.config.defaultTimeoutMs } = options;
+
+		// Bump generation for this dedupe key
+		const generation = (this.generationCounters.get(dedupeKey) ?? 0) + 1;
+		this.generationCounters.set(dedupeKey, generation);
+
+		const task: GitTask<T> = {
+			id: randomUUID(),
+			taskType,
+			payload,
+			dedupeKey,
+			timeoutMs,
+		};
+
+		// Check coalescing: if there's an in-flight task with the same dedupeKey,
+		// subscribe to its result instead of queuing a new one.
+		const existing = this.dedupeMap.get(dedupeKey);
+		if (existing) {
+			this.metrics.tasksCoalesced++;
+			this.log(
+				`Coalescing task ${task.id} onto ${existing.taskId} (key=${dedupeKey})`,
+			);
+
+			return new Promise<GitTaskResults[T]>((resolve, reject) => {
+				const pending: PendingTask<T> = {
+					task,
+					resolve,
+					reject,
+					generation,
+				};
+				existing.subscribers.push(pending as unknown as PendingTask);
+			});
+		}
+
+		// Backpressure check
+		if (this.queue.length >= this.config.maxQueueSize) {
+			this.metrics.tasksFailed++;
+			return Promise.reject(
+				new Error(
+					`Worker pool queue full (${this.config.maxQueueSize} tasks). Try again later.`,
+				),
+			);
+		}
+
+		return new Promise<GitTaskResults[T]>((resolve, reject) => {
+			const pending: PendingTask<T> = {
+				task,
+				resolve,
+				reject,
+				generation,
+			};
+
+			// Register in dedupe map
+			this.dedupeMap.set(dedupeKey, {
+				taskId: task.id,
+				generation,
+				subscribers: [],
+			});
+
+			this.queue.push(pending as unknown as PendingTask);
+			this.metrics.currentQueueSize = this.queue.length;
+			this.drain();
+		});
+	}
+
+	/**
+	 * Cancel all pending tasks for a given dedupe key prefix.
+	 * In-flight tasks are NOT cancelled (they'll complete but results are dropped).
+	 */
+	cancelByPrefix(prefix: string): void {
+		// Cancel queued tasks
+		const remaining: PendingTask[] = [];
+		for (const pending of this.queue) {
+			if (pending.task.dedupeKey.startsWith(prefix)) {
+				this.metrics.tasksCancelled++;
+				pending.reject(new Error("Task cancelled"));
+				if (pending.timer) clearTimeout(pending.timer);
+				this.dedupeMap.delete(pending.task.dedupeKey);
+			} else {
+				remaining.push(pending);
+			}
+		}
+		this.queue = remaining;
+		this.metrics.currentQueueSize = this.queue.length;
+
+		// Mark in-flight tasks as stale by bumping generation
+		for (const [key] of this.dedupeMap) {
+			if (key.startsWith(prefix)) {
+				const gen = (this.generationCounters.get(key) ?? 0) + 1;
+				this.generationCounters.set(key, gen);
+			}
+		}
+	}
+
+	getMetrics(): Readonly<GitWorkerMetrics> {
+		this.metrics.currentQueueSize = this.queue.length;
+		this.metrics.currentActiveWorkers = this.slots.filter((s) => s.busy).length;
+		return { ...this.metrics };
+	}
+
+	async destroy(): Promise<void> {
+		this.destroyed = true;
+
+		// Reject all queued tasks
+		for (const pending of this.queue) {
+			pending.reject(new Error("Worker pool destroyed"));
+			if (pending.timer) clearTimeout(pending.timer);
+		}
+		this.queue = [];
+
+		// Reject all in-flight tasks
+		for (const [, pending] of this.inFlight) {
+			pending.reject(new Error("Worker pool destroyed"));
+			if (pending.timer) clearTimeout(pending.timer);
+		}
+		this.inFlight.clear();
+		this.dedupeMap.clear();
+
+		// Terminate all workers
+		const terminations = this.slots.map((slot) => slot.worker.terminate());
+		await Promise.allSettled(terminations);
+		this.slots = [];
+	}
+
+	// -----------------------------------------------------------------------
+	// Worker lifecycle
+	// -----------------------------------------------------------------------
+
+	private initWorkers(): void {
+		for (let i = 0; i < this.config.maxWorkers; i++) {
+			this.slots.push(this.createWorkerSlot());
+		}
+	}
+
+	private createWorkerSlot(): WorkerSlot {
+		const worker = new Worker(this.workerScriptPath);
+		const slot: WorkerSlot = {
+			worker,
+			busy: false,
+			currentTaskId: null,
+		};
+
+		worker.on("message", (response: WorkerResponse) => {
+			this.handleWorkerResponse(slot, response);
+		});
+
+		worker.on("error", (err) => {
+			console.error("[git-worker] Worker error:", err.message);
+			this.handleWorkerCrash(slot);
+		});
+
+		worker.on("exit", (code) => {
+			if (this.destroyed) return;
+			if (code !== 0 || slot.busy) {
+				console.warn(
+					`[git-worker] Worker exited with code ${code}${slot.busy ? " (had in-flight task)" : ""}, restarting...`,
+				);
+				this.handleWorkerCrash(slot);
+			}
+		});
+
+		return slot;
+	}
+
+	private handleWorkerCrash(slot: WorkerSlot): void {
+		// Reject the in-flight task if any
+		if (slot.currentTaskId) {
+			const pending = this.inFlight.get(slot.currentTaskId);
+			if (pending) {
+				this.metrics.tasksFailed++;
+				this.resolveTask(pending, undefined, new Error("Worker crashed"));
+				this.inFlight.delete(slot.currentTaskId);
+			}
+		}
+
+		// Replace the crashed worker
+		if (!this.destroyed) {
+			this.metrics.workerRestarts++;
+			const idx = this.slots.indexOf(slot);
+			if (idx !== -1) {
+				const newSlot = this.createWorkerSlot();
+				this.slots[idx] = newSlot;
+				this.drain();
+			}
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Task dispatch
+	// -----------------------------------------------------------------------
+
+	private drain(): void {
+		while (this.queue.length > 0) {
+			const slot = this.slots.find((s) => !s.busy);
+			if (!slot) break;
+
+			const pending = this.queue.shift();
+			if (!pending) break;
+			this.metrics.currentQueueSize = this.queue.length;
+
+			// Check if this task's generation is stale (latest-wins)
+			const currentGen =
+				this.generationCounters.get(pending.task.dedupeKey) ?? 0;
+			if (pending.generation < currentGen) {
+				this.log(
+					`Dropping stale task ${pending.task.id} (gen=${pending.generation}, current=${currentGen})`,
+				);
+				this.metrics.tasksCancelled++;
+				pending.reject(new Error("Task superseded by newer request"));
+				this.dedupeMap.delete(pending.task.dedupeKey);
+				continue;
+			}
+
+			this.dispatch(slot, pending);
+		}
+	}
+
+	private dispatch(slot: WorkerSlot, pending: PendingTask): void {
+		slot.busy = true;
+		slot.currentTaskId = pending.task.id;
+		this.inFlight.set(pending.task.id, pending);
+
+		// Set up timeout
+		pending.timer = setTimeout(() => {
+			this.log(
+				`Task ${pending.task.id} timed out after ${pending.task.timeoutMs}ms`,
+			);
+			this.metrics.tasksTimedOut++;
+
+			// Terminate and replace the worker
+			slot.worker.terminate().catch(() => {});
+			this.inFlight.delete(pending.task.id);
+			this.resolveTask(
+				pending,
+				undefined,
+				new Error(`Task timed out after ${pending.task.timeoutMs}ms`),
+			);
+
+			// Replace worker
+			if (!this.destroyed) {
+				this.metrics.workerRestarts++;
+				const idx = this.slots.indexOf(slot);
+				if (idx !== -1) {
+					this.slots[idx] = this.createWorkerSlot();
+					this.drain();
+				}
+			}
+		}, pending.task.timeoutMs);
+
+		const request: WorkerRequest = {
+			id: pending.task.id,
+			taskType: pending.task.taskType,
+			payload: pending.task.payload,
+		};
+
+		this.log(
+			`Dispatching ${pending.task.taskType} (id=${pending.task.id}, key=${pending.task.dedupeKey})`,
+		);
+		slot.worker.postMessage(request);
+	}
+
+	// -----------------------------------------------------------------------
+	// Response handling
+	// -----------------------------------------------------------------------
+
+	private handleWorkerResponse(
+		slot: WorkerSlot,
+		response: WorkerResponse,
+	): void {
+		slot.busy = false;
+		slot.currentTaskId = null;
+
+		const pending = this.inFlight.get(response.id);
+		if (!pending) {
+			// Response for an already-timed-out or cancelled task
+			return;
+		}
+
+		this.inFlight.delete(response.id);
+		if (pending.timer) clearTimeout(pending.timer);
+
+		// Check if result is stale (latest-wins)
+		const currentGen = this.generationCounters.get(pending.task.dedupeKey) ?? 0;
+		if (pending.generation < currentGen) {
+			this.log(
+				`Dropping stale result for ${pending.task.id} (gen=${pending.generation}, current=${currentGen})`,
+			);
+			this.metrics.tasksCancelled++;
+			this.resolveTask(
+				pending,
+				undefined,
+				new Error("Result superseded by newer request"),
+			);
+		} else if (response.ok) {
+			this.metrics.tasksCompleted++;
+			this.log(
+				`Completed ${pending.task.taskType} (id=${pending.task.id}) in ${response.durationMs.toFixed(0)}ms`,
+			);
+			this.resolveTask(pending, response.result, undefined);
+		} else {
+			this.metrics.tasksFailed++;
+			const error = new Error(response.error);
+			if (response.code) {
+				(error as Error & { code?: string }).code = response.code;
+			}
+			this.resolveTask(pending, undefined, error);
+		}
+
+		// Continue draining the queue
+		this.drain();
+	}
+
+	private resolveTask(
+		pending: PendingTask,
+		result: GitTaskResults[GitTaskType] | undefined,
+		error: Error | undefined,
+	): void {
+		const dedupeEntry = this.dedupeMap.get(pending.task.dedupeKey);
+
+		if (error) {
+			pending.reject(error);
+			// Also reject all subscribers
+			if (dedupeEntry) {
+				for (const sub of dedupeEntry.subscribers) {
+					sub.reject(error);
+				}
+			}
+		} else {
+			// biome-ignore lint/style/noNonNullAssertion: result is defined when error is undefined
+			pending.resolve(result!);
+			// Also resolve all subscribers
+			if (dedupeEntry) {
+				for (const sub of dedupeEntry.subscribers) {
+					// biome-ignore lint/style/noNonNullAssertion: result is defined when error is undefined
+					sub.resolve(result!);
+				}
+			}
+		}
+
+		// Clean up dedupe entry
+		if (dedupeEntry) {
+			this.dedupeMap.delete(pending.task.dedupeKey);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Debug logging
+	// -----------------------------------------------------------------------
+
+	private log(msg: string): void {
+		if (this.config.debug) {
+			console.log(`[git-worker] ${msg}`);
+		}
+	}
+}

--- a/apps/desktop/src/main/lib/git-worker/types.ts
+++ b/apps/desktop/src/main/lib/git-worker/types.ts
@@ -1,0 +1,112 @@
+/**
+ * Git Worker Thread — Type Contracts
+ *
+ * Defines the typed task contracts and message protocol between
+ * the main thread (pool) and the worker thread.
+ */
+
+import type { ChangedFile, GitChangesStatus } from "shared/changes-types";
+
+// ---------------------------------------------------------------------------
+// Task type registry
+// ---------------------------------------------------------------------------
+
+export type GitTaskType = "getStatus" | "getCommitFiles";
+
+/** Payload per task type */
+export interface GitTaskPayloads {
+	getStatus: {
+		worktreePath: string;
+		defaultBranch: string;
+	};
+	getCommitFiles: {
+		worktreePath: string;
+		commitHash: string;
+	};
+}
+
+/** Result per task type */
+export interface GitTaskResults {
+	getStatus: GitChangesStatus;
+	getCommitFiles: ChangedFile[];
+}
+
+// ---------------------------------------------------------------------------
+// Task descriptor (main → pool)
+// ---------------------------------------------------------------------------
+
+export interface GitTask<T extends GitTaskType = GitTaskType> {
+	id: string;
+	taskType: T;
+	payload: GitTaskPayloads[T];
+	dedupeKey: string;
+	timeoutMs: number;
+}
+
+// ---------------------------------------------------------------------------
+// Worker message protocol (main ↔ worker thread)
+// ---------------------------------------------------------------------------
+
+/** Main thread → worker */
+export interface WorkerRequest {
+	id: string;
+	taskType: GitTaskType;
+	payload: GitTaskPayloads[GitTaskType];
+}
+
+/** Worker → main thread (success) */
+export interface WorkerSuccessResponse {
+	id: string;
+	ok: true;
+	result: GitTaskResults[GitTaskType];
+	durationMs: number;
+}
+
+/** Worker → main thread (error) */
+export interface WorkerErrorResponse {
+	id: string;
+	ok: false;
+	error: string;
+	code?: string;
+	durationMs: number;
+}
+
+export type WorkerResponse = WorkerSuccessResponse | WorkerErrorResponse;
+
+// ---------------------------------------------------------------------------
+// Pool configuration
+// ---------------------------------------------------------------------------
+
+export interface GitWorkerPoolConfig {
+	/** Max concurrent workers (default: 2) */
+	maxWorkers: number;
+	/** Max queued tasks before backpressure error (default: 50) */
+	maxQueueSize: number;
+	/** Default task timeout in ms (default: 30_000) */
+	defaultTimeoutMs: number;
+	/** Enable debug logging (default: false) */
+	debug: boolean;
+}
+
+export const DEFAULT_POOL_CONFIG: GitWorkerPoolConfig = {
+	maxWorkers: 2,
+	maxQueueSize: 50,
+	defaultTimeoutMs: 30_000,
+	debug: false,
+};
+
+// ---------------------------------------------------------------------------
+// Pool metrics (observability)
+// ---------------------------------------------------------------------------
+
+export interface GitWorkerMetrics {
+	tasksSubmitted: number;
+	tasksCompleted: number;
+	tasksFailed: number;
+	tasksTimedOut: number;
+	tasksCoalesced: number;
+	tasksCancelled: number;
+	workerRestarts: number;
+	currentQueueSize: number;
+	currentActiveWorkers: number;
+}

--- a/apps/desktop/src/main/lib/git-worker/worker-thread.ts
+++ b/apps/desktop/src/main/lib/git-worker/worker-thread.ts
@@ -1,0 +1,618 @@
+/**
+ * Git Worker Thread
+ *
+ * Runs in a Node.js worker_thread. Receives git task requests via parentPort,
+ * executes them, and posts results back. This keeps heavy git reads
+ * off the Electron main thread.
+ *
+ * IMPORTANT: This file must NOT import any Electron modules.
+ * It runs as a standalone Node.js worker thread.
+ */
+
+import { execFile } from "node:child_process";
+import { readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { parentPort } from "node:worker_threads";
+import type { FileStatus } from "shared/changes-types";
+import simpleGit from "simple-git";
+import type {
+	GitTaskPayloads,
+	GitTaskResults,
+	WorkerRequest,
+	WorkerResponse,
+} from "./types";
+
+const execFileAsync = promisify(execFile);
+
+if (!parentPort) {
+	throw new Error("git-worker must be run as a worker_thread");
+}
+
+const port = parentPort;
+
+// ---------------------------------------------------------------------------
+// Task handlers
+// ---------------------------------------------------------------------------
+
+type TaskHandler<T extends keyof GitTaskPayloads> = (
+	payload: GitTaskPayloads[T],
+) => Promise<GitTaskResults[T]>;
+
+const handlers: {
+	[K in keyof GitTaskPayloads]: TaskHandler<K>;
+} = {
+	getStatus: handleGetStatus,
+	getCommitFiles: handleGetCommitFiles,
+};
+
+// ---------------------------------------------------------------------------
+// Message loop
+// ---------------------------------------------------------------------------
+
+port.on("message", async (msg: WorkerRequest) => {
+	const start = performance.now();
+	try {
+		const handler = handlers[msg.taskType];
+		// Cast is safe: taskType is discriminated
+		const result = await (handler as TaskHandler<typeof msg.taskType>)(
+			msg.payload,
+		);
+		const response: WorkerResponse = {
+			id: msg.id,
+			ok: true,
+			result,
+			durationMs: performance.now() - start,
+		};
+		port.postMessage(response);
+	} catch (err) {
+		const response: WorkerResponse = {
+			id: msg.id,
+			ok: false,
+			error: err instanceof Error ? err.message : String(err),
+			code: getErrorCode(err),
+			durationMs: performance.now() - start,
+		};
+		port.postMessage(response);
+	}
+});
+
+function getErrorCode(err: unknown): string | undefined {
+	if (err instanceof Error && "code" in err) {
+		return String((err as Error & { code: unknown }).code);
+	}
+	return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// getStatus handler
+// ---------------------------------------------------------------------------
+
+interface ExecFileException extends Error {
+	code?: number | string;
+	stderr?: string;
+}
+
+function isExecFileException(error: unknown): error is ExecFileException {
+	return (
+		error instanceof Error &&
+		("code" in error || "signal" in error || "killed" in error)
+	);
+}
+
+class NotGitRepoError extends Error {
+	constructor(repoPath: string) {
+		super(`Not a git repository: ${repoPath}`);
+		this.name = "NotGitRepoError";
+	}
+}
+
+async function getStatusNoLock(
+	repoPath: string,
+): Promise<ReturnType<typeof parsePortelainStatus>> {
+	try {
+		const { stdout } = await execFileAsync(
+			"git",
+			[
+				"--no-optional-locks",
+				"-C",
+				repoPath,
+				"status",
+				"--porcelain=v1",
+				"-b",
+				"-z",
+				"-uall",
+			],
+			{ timeout: 30_000 },
+		);
+		return parsePortelainStatus(stdout);
+	} catch (error) {
+		if (isExecFileException(error)) {
+			if (error.code === "ENOENT") {
+				throw new Error("Git is not installed or not found in PATH");
+			}
+			const stderr = error.stderr || error.message || "";
+			if (stderr.includes("not a git repository")) {
+				throw new NotGitRepoError(repoPath);
+			}
+		}
+		throw new Error(
+			`Failed to get git status: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+}
+
+// Inline porcelain parser (same logic as workspaces/utils/git.ts)
+interface StatusResultCompat {
+	files: Array<{
+		path: string;
+		from: string;
+		index: string;
+		working_dir: string;
+	}>;
+	current: string | null;
+	tracking: string | null;
+	detached: boolean;
+}
+
+function parsePortelainStatus(stdout: string): StatusResultCompat {
+	const entries = stdout.split("\0").filter(Boolean);
+
+	let current: string | null = null;
+	let tracking: string | null = null;
+	let isDetached = false;
+
+	const files: StatusResultCompat["files"] = [];
+
+	let i = 0;
+	while (i < entries.length) {
+		const entry = entries[i];
+		if (!entry) {
+			i++;
+			continue;
+		}
+
+		if (entry.startsWith("## ")) {
+			const branchInfo = entry.slice(3);
+			if (branchInfo.startsWith("HEAD (no branch)") || branchInfo === "HEAD") {
+				isDetached = true;
+				current = "HEAD";
+			} else if (
+				branchInfo.startsWith("No commits yet on ") ||
+				branchInfo.startsWith("Initial commit on ")
+			) {
+				const parts = branchInfo.split(" ");
+				current = parts[parts.length - 1] || null;
+			} else {
+				const trackingMatch = branchInfo.match(/^(.+?)\.\.\.(.+?)(?:\s|$)/);
+				if (trackingMatch) {
+					current = trackingMatch[1] ?? null;
+					tracking = trackingMatch[2]?.split(" ")[0] ?? null;
+				} else {
+					current = branchInfo.split(" ")[0] || null;
+				}
+			}
+			i++;
+			continue;
+		}
+
+		if (entry.length < 3) {
+			i++;
+			continue;
+		}
+
+		const indexStatus = entry[0] as string;
+		const workingStatus = entry[1] as string;
+		const path = entry.slice(3);
+		let from: string | undefined;
+
+		if (indexStatus === "R" || indexStatus === "C") {
+			i++;
+			from = entries[i];
+		}
+
+		files.push({
+			path,
+			from: from ?? path,
+			index: indexStatus,
+			working_dir: workingStatus,
+		});
+
+		i++;
+	}
+
+	return { files, current, tracking, detached: isDetached };
+}
+
+// Parse status into categorized files
+interface ParsedStatus {
+	branch: string;
+	staged: ChangedFileData[];
+	unstaged: ChangedFileData[];
+	untracked: ChangedFileData[];
+}
+
+interface ChangedFileData {
+	path: string;
+	oldPath?: string;
+	status: FileStatus;
+	additions: number;
+	deletions: number;
+}
+
+function parseGitStatusResult(status: StatusResultCompat): ParsedStatus {
+	const staged: ChangedFileData[] = [];
+	const unstaged: ChangedFileData[] = [];
+	const untracked: ChangedFileData[] = [];
+
+	for (const file of status.files) {
+		const path = file.path;
+		const index = file.index;
+		const working = file.working_dir;
+
+		if (index === "?" && working === "?") {
+			untracked.push({
+				path,
+				status: "untracked",
+				additions: 0,
+				deletions: 0,
+			});
+			continue;
+		}
+
+		if (index && index !== " " && index !== "?") {
+			staged.push({
+				path,
+				oldPath: file.path !== file.from ? file.from : undefined,
+				status: mapGitStatus(index, " "),
+				additions: 0,
+				deletions: 0,
+			});
+		}
+
+		if (working && working !== " " && working !== "?") {
+			unstaged.push({
+				path,
+				status: mapGitStatus(" ", working),
+				additions: 0,
+				deletions: 0,
+			});
+		}
+	}
+
+	return {
+		branch: status.current || "HEAD",
+		staged,
+		unstaged,
+		untracked,
+	};
+}
+
+function mapGitStatus(gitIndex: string, gitWorking: string): FileStatus {
+	if (gitIndex === "A" || gitWorking === "A") return "added";
+	if (gitIndex === "D" || gitWorking === "D") return "deleted";
+	if (gitIndex === "R") return "renamed";
+	if (gitIndex === "C") return "copied";
+	if (gitIndex === "?" || gitWorking === "?") return "untracked";
+	return "modified";
+}
+
+// Numstat helpers
+function parseDiffNumstat(
+	numstatOutput: string,
+): Map<string, { additions: number; deletions: number }> {
+	const stats = new Map<string, { additions: number; deletions: number }>();
+
+	for (const line of numstatOutput.trim().split("\n")) {
+		if (!line.trim()) continue;
+		const [addStr, delStr, ...pathParts] = line.split("\t");
+		const rawPath = pathParts.join("\t");
+		if (!rawPath) continue;
+
+		const additions =
+			addStr === "-" ? 0 : Number.parseInt(addStr ?? "0", 10) || 0;
+		const deletions =
+			delStr === "-" ? 0 : Number.parseInt(delStr ?? "0", 10) || 0;
+		const statEntry = { additions, deletions };
+
+		const renameMatch = rawPath.match(/^(.+) => (.+)$/);
+		if (renameMatch?.[1] && renameMatch[2]) {
+			stats.set(renameMatch[2], statEntry);
+			stats.set(renameMatch[1], statEntry);
+		} else {
+			stats.set(rawPath, statEntry);
+		}
+	}
+
+	return stats;
+}
+
+async function applyNumstatToFiles(
+	git: ReturnType<typeof simpleGit>,
+	files: ChangedFileData[],
+	diffArgs: string[],
+): Promise<void> {
+	if (files.length === 0) return;
+	try {
+		const numstat = await git.raw(diffArgs);
+		const stats = parseDiffNumstat(numstat);
+		for (const file of files) {
+			const fileStat = stats.get(file.path);
+			if (fileStat) {
+				file.additions = fileStat.additions;
+				file.deletions = fileStat.deletions;
+			}
+		}
+	} catch {}
+}
+
+// Git log parser
+interface CommitInfoData {
+	hash: string;
+	shortHash: string;
+	message: string;
+	author: string;
+	date: string; // ISO string — Date is not transferable across worker boundary
+	files: ChangedFileData[];
+}
+
+function parseGitLog(logOutput: string): CommitInfoData[] {
+	if (!logOutput.trim()) return [];
+
+	const commits: CommitInfoData[] = [];
+	const lines = logOutput.trim().split("\n");
+
+	for (const line of lines) {
+		if (!line.trim()) continue;
+		const parts = line.split("|");
+		if (parts.length < 5) continue;
+
+		const hash = parts[0]?.trim();
+		const shortHash = parts[1]?.trim();
+		const message = parts.slice(2, -2).join("|").trim();
+		const author = parts[parts.length - 2]?.trim();
+		const dateStr = parts[parts.length - 1]?.trim();
+
+		if (!hash || !shortHash) continue;
+
+		let dateIso: string;
+		if (dateStr) {
+			const parsed = new Date(dateStr);
+			dateIso = Number.isNaN(parsed.getTime())
+				? new Date().toISOString()
+				: parsed.toISOString();
+		} else {
+			dateIso = new Date().toISOString();
+		}
+
+		commits.push({
+			hash,
+			shortHash,
+			message: message || "",
+			author: author || "",
+			date: dateIso,
+			files: [],
+		});
+	}
+
+	return commits;
+}
+
+function parseNameStatus(nameStatusOutput: string): ChangedFileData[] {
+	const files: ChangedFileData[] = [];
+
+	for (const line of nameStatusOutput.trim().split("\n")) {
+		if (!line.trim()) continue;
+		const parts = line.split("\t");
+		const statusCode = parts[0];
+		if (!statusCode) continue;
+
+		const isRenameOrCopy =
+			statusCode.startsWith("R") || statusCode.startsWith("C");
+		const path = isRenameOrCopy ? parts[2] : parts[1];
+		const oldPath = isRenameOrCopy ? parts[1] : undefined;
+
+		if (!path) continue;
+
+		let status: FileStatus;
+		switch (statusCode[0]) {
+			case "A":
+				status = "added";
+				break;
+			case "D":
+				status = "deleted";
+				break;
+			case "R":
+				status = "renamed";
+				break;
+			case "C":
+				status = "copied";
+				break;
+			default:
+				status = "modified";
+		}
+
+		files.push({ path, oldPath, status, additions: 0, deletions: 0 });
+	}
+
+	return files;
+}
+
+// ---------------------------------------------------------------------------
+// getStatus — full implementation
+// ---------------------------------------------------------------------------
+
+const MAX_LINE_COUNT_SIZE = 1 * 1024 * 1024;
+
+async function applyUntrackedLineCount(
+	worktreePath: string,
+	untracked: ChangedFileData[],
+): Promise<void> {
+	for (const file of untracked) {
+		try {
+			const filePath = join(worktreePath, file.path);
+			const stats = await stat(filePath);
+			if (stats.size > MAX_LINE_COUNT_SIZE) continue;
+
+			const content = await readFile(filePath, "utf-8");
+			file.additions = content.split("\n").length;
+			file.deletions = 0;
+		} catch {}
+	}
+}
+
+interface BranchComparisonData {
+	commits: CommitInfoData[];
+	againstBase: ChangedFileData[];
+	ahead: number;
+	behind: number;
+}
+
+async function getBranchComparison(
+	git: ReturnType<typeof simpleGit>,
+	defaultBranch: string,
+): Promise<BranchComparisonData> {
+	let commits: CommitInfoData[] = [];
+	let againstBase: ChangedFileData[] = [];
+	let ahead = 0;
+	let behind = 0;
+
+	try {
+		const tracking = await git.raw([
+			"rev-list",
+			"--left-right",
+			"--count",
+			`origin/${defaultBranch}...HEAD`,
+		]);
+		const [behindStr, aheadStr] = tracking.trim().split(/\s+/);
+		behind = Number.parseInt(behindStr || "0", 10);
+		ahead = Number.parseInt(aheadStr || "0", 10);
+
+		const logOutput = await git.raw([
+			"log",
+			`origin/${defaultBranch}..HEAD`,
+			"--format=%H|%h|%s|%an|%aI",
+		]);
+		commits = parseGitLog(logOutput);
+
+		if (ahead > 0) {
+			const nameStatus = await git.raw([
+				"diff",
+				"--name-status",
+				`origin/${defaultBranch}...HEAD`,
+			]);
+			againstBase = parseNameStatus(nameStatus);
+
+			await applyNumstatToFiles(git, againstBase, [
+				"diff",
+				"--numstat",
+				`origin/${defaultBranch}...HEAD`,
+			]);
+		}
+	} catch {}
+
+	return { commits, againstBase, ahead, behind };
+}
+
+async function getTrackingBranchStatus(
+	git: ReturnType<typeof simpleGit>,
+): Promise<{ pushCount: number; pullCount: number; hasUpstream: boolean }> {
+	try {
+		const upstream = await git.raw([
+			"rev-parse",
+			"--abbrev-ref",
+			"@{upstream}",
+		]);
+		if (!upstream.trim()) {
+			return { pushCount: 0, pullCount: 0, hasUpstream: false };
+		}
+
+		const tracking = await git.raw([
+			"rev-list",
+			"--left-right",
+			"--count",
+			"@{upstream}...HEAD",
+		]);
+		const [pullStr, pushStr] = tracking.trim().split(/\s+/);
+		return {
+			pushCount: Number.parseInt(pushStr || "0", 10),
+			pullCount: Number.parseInt(pullStr || "0", 10),
+			hasUpstream: true,
+		};
+	} catch {
+		return { pushCount: 0, pullCount: 0, hasUpstream: false };
+	}
+}
+
+async function handleGetStatus(
+	payload: GitTaskPayloads["getStatus"],
+): Promise<GitTaskResults["getStatus"]> {
+	const { worktreePath, defaultBranch } = payload;
+
+	const git = simpleGit(worktreePath);
+
+	const statusResult = await getStatusNoLock(worktreePath);
+	const parsed = parseGitStatusResult(statusResult);
+
+	const [branchComparison, trackingStatus] = await Promise.all([
+		getBranchComparison(git, defaultBranch),
+		getTrackingBranchStatus(git),
+		applyNumstatToFiles(git, parsed.staged, ["diff", "--cached", "--numstat"]),
+		applyNumstatToFiles(git, parsed.unstaged, ["diff", "--numstat"]),
+		applyUntrackedLineCount(worktreePath, parsed.untracked),
+	]);
+
+	// Convert CommitInfoData (ISO strings) to CommitInfo (Date objects)
+	// Note: Dates are serialized as ISO strings across the worker boundary,
+	// and SuperJSON in tRPC will handle Date serialization to the client.
+	const commits = branchComparison.commits.map((c) => ({
+		...c,
+		date: new Date(c.date),
+	}));
+
+	return {
+		branch: parsed.branch,
+		defaultBranch,
+		againstBase:
+			branchComparison.againstBase as GitTaskResults["getStatus"]["againstBase"],
+		commits,
+		staged: parsed.staged as GitTaskResults["getStatus"]["staged"],
+		unstaged: parsed.unstaged as GitTaskResults["getStatus"]["unstaged"],
+		untracked: parsed.untracked as GitTaskResults["getStatus"]["untracked"],
+		ahead: branchComparison.ahead,
+		behind: branchComparison.behind,
+		pushCount: trackingStatus.pushCount,
+		pullCount: trackingStatus.pullCount,
+		hasUpstream: trackingStatus.hasUpstream,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// getCommitFiles handler
+// ---------------------------------------------------------------------------
+
+async function handleGetCommitFiles(
+	payload: GitTaskPayloads["getCommitFiles"],
+): Promise<GitTaskResults["getCommitFiles"]> {
+	const { worktreePath, commitHash } = payload;
+	const git = simpleGit(worktreePath);
+
+	const nameStatus = await git.raw([
+		"diff-tree",
+		"--no-commit-id",
+		"--name-status",
+		"-r",
+		commitHash,
+	]);
+	const files = parseNameStatus(nameStatus);
+
+	await applyNumstatToFiles(git, files, [
+		"diff-tree",
+		"--no-commit-id",
+		"--numstat",
+		"-r",
+		commitHash,
+	]);
+
+	return files as GitTaskResults["getCommitFiles"];
+}


### PR DESCRIPTION
## Summary
Introduces a `worker_threads`-based pool to offload heavy git operations (`getStatus`, `getCommitFiles`) from the Electron main thread, keeping the UI responsive even with 500+ changed files.

## Architecture
- **types.ts**: Task contract types — typed payloads and results per task type
- **worker-thread.ts**: Self-contained Node.js worker that executes git commands via `child_process` and `simple-git`. Cannot import Electron modules.
- **pool.ts**: Bounded concurrency pool with:
  - Dedupe key coalescing (same key joins in-flight task)
  - Latest-wins generation tracking (stale tasks dropped)
  - Per-task timeout with worker termination and restart
  - Crash isolation with automatic worker replacement
  - Backpressure via queue cap
  - Lightweight timing metrics
- **index.ts**: Singleton pool instance, `isGitWorkerEnabled()` feature flag, and typed submit helpers

## Integration
- Status router checks feature flag → delegates to worker pool or falls back to existing main-thread implementation
- Worker thread script added as separate Vite/Rollup build entry point
- Pool gracefully destroyed on app quit

## Rollout
- Feature flag (`SUPERSET_GIT_WORKER=1`) controls opt-in — disabled by default
- Existing main-thread code path preserved as fallback
- Phase 2 (future PR): migrate remaining heavy git read paths

## Testing
- Lint: clean
- Typecheck: no new errors (pre-existing `bun` type def issue on base)
- Build: no new failures (pre-existing build issue on base branch)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a worker_threads pool to offload heavy git reads (status and commit files) from the Electron main process, keeping the UI responsive on large repos. The status router uses the pool behind a feature flag with a safe main-thread fallback.

- **New Features**
  - Worker thread pool with bounded concurrency and queue backpressure.
  - Coalesces duplicate requests and drops stale ones (latest-wins).
  - Per-task timeouts with worker termination and automatic restart.
  - Crash isolation and lightweight metrics for observability.
  - Status and commit-files routes delegate to the pool when enabled; otherwise use existing logic.
  - Added a dedicated build entry for the worker script and clean shutdown on app quit.

- **Migration**
  - Enabled by default; set SUPERSET_GIT_WORKER=0 to disable (fallback to main thread).
  - Optional: set SUPERSET_GIT_WORKER_DEBUG=1 for verbose logging.

<sup>Written for commit 24eee961d8bf83eb9f6da8a9ddf0f54ddbc86404. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a background worker system for Git operations to optimize main thread performance and responsiveness.
  * Enhanced application shutdown with proper cleanup of background worker processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->