### PR TITLE
Disable Streamdown external-link safety popup in chat messages

### DIFF
--- a/packages/ui/src/components/ai-elements/message.tsx
+++ b/packages/ui/src/components/ai-elements/message.tsx
@@ -321,6 +321,7 @@ export const MessageResponse = memo(
 				className,
 			)}
 			isAnimating={isAnimating}
+			linkSafety={{ enabled: false }}
 			mode="streaming"
 			plugins={isAnimating ? undefined : streamdownPlugins}
 			{...props}


### PR DESCRIPTION
## Summary
- disable Streamdown link-safety modal in MessageResponse
- force linkSafety to { enabled: false } so chat links no longer show the external-link confirmation popup

## Testing
- bun run typecheck --filter=@superset/desktop

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable the Streamdown external-link safety popup in chat messages so links open directly. Sets linkSafety: { enabled: false } on the MessageResponse renderer to remove the confirmation modal.

<sup>Written for commit 6e43d5b0bd5d2c4d55f33b99539ce81056e227f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable link safety settings for AI-generated message responses. Link safety validation checks are now disabled by default in the message streaming component. This allows links within AI-generated content to be rendered without additional safety filters, while preserving all other message functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->