### PR TITLE
fix(desktop): remove tooltips from New Workspace modal dropdowns

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/NewWorkspaceCreateFlow/NewWorkspaceCreateFlow.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/NewWorkspaceCreateFlow/NewWorkspaceCreateFlow.tsx
@@ -12,7 +12,6 @@ import {
 	SelectValue,
 } from "@superset/ui/select";
 import { Textarea } from "@superset/ui/textarea";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import type { ReactNode, RefObject } from "react";
 import { GoGitBranch } from "react-icons/go";
 import {
@@ -69,16 +68,9 @@ export function NewWorkspaceCreateFlow({
 							onSelectedAgentChange(value)
 						}
 					>
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<SelectTrigger className="h-8 text-xs w-auto max-w-full">
-									<SelectValue placeholder="No agent" className="truncate" />
-								</SelectTrigger>
-							</TooltipTrigger>
-							<TooltipContent side="bottom" showArrow={false}>
-								Send the description as prompt to the agent
-							</TooltipContent>
-						</Tooltip>
+						<SelectTrigger className="h-8 text-xs w-auto max-w-full">
+							<SelectValue placeholder="No agent" className="truncate" />
+						</SelectTrigger>
 						<SelectContent>
 							<SelectItem value="none">No agent</SelectItem>
 							{agentOptions.map((agent) => {

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/ProjectSelector/ProjectSelector.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/ProjectSelector/ProjectSelector.tsx
@@ -6,7 +6,6 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { HiCheck, HiChevronDown } from "react-icons/hi2";
 import { LuFolderOpen } from "react-icons/lu";
 
@@ -34,28 +33,21 @@ export function ProjectSelector({
 }: ProjectSelectorProps) {
 	return (
 		<DropdownMenu>
-			<Tooltip>
-				<TooltipTrigger asChild>
-					<DropdownMenuTrigger asChild>
-						<Button
-							variant="outline"
-							className={`w-full h-8 text-sm justify-between font-normal min-w-0 ${className ?? ""}`}
-						>
-							<span
-								className={`truncate ${
-									selectedProjectName ? "" : "text-muted-foreground"
-								}`}
-							>
-								{selectedProjectName ?? "Select project"}
-							</span>
-							<HiChevronDown className="size-4 text-muted-foreground shrink-0" />
-						</Button>
-					</DropdownMenuTrigger>
-				</TooltipTrigger>
-				<TooltipContent side="bottom" showArrow={false}>
-					Project the workspace belongs to
-				</TooltipContent>
-			</Tooltip>
+			<DropdownMenuTrigger asChild>
+				<Button
+					variant="outline"
+					className={`w-full h-8 text-sm justify-between font-normal min-w-0 ${className ?? ""}`}
+				>
+					<span
+						className={`truncate ${
+							selectedProjectName ? "" : "text-muted-foreground"
+						}`}
+					>
+						{selectedProjectName ?? "Select project"}
+					</span>
+					<HiChevronDown className="size-4 text-muted-foreground shrink-0" />
+				</Button>
+			</DropdownMenuTrigger>
 			<DropdownMenuContent
 				align="start"
 				className="w-[--radix-dropdown-menu-trigger-width]"


### PR DESCRIPTION
## Summary
- Remove tooltip wrappers from the agent and project dropdowns in the New Workspace modal. The placeholders ("No agent", "Select project") are self-explanatory.

## Testing
- `bun run typecheck` — pre-existing errors only, none from these changes
- Manual: opened New Workspace modal, confirmed dropdowns render and function without tooltips

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed tooltips from the agent and project dropdowns in the New Workspace modal to reduce hover noise and simplify the UI. The placeholders (“No agent” and “Select project”) provide clear context without extra hints.

<sup>Written for commit ff32c1a87051b90e078a0f0a0f563b588345bc01. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed tooltip displays from the agent selector control in the new workspace creation flow and the project dropdown menu trigger.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->