### PR TITLE
feat(desktop): add loading message state for chat conversations

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/ChatMastraInterface.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/ChatMastraInterface.tsx
@@ -175,6 +175,7 @@ export function ChatMastraInterface({
 		messages,
 		currentMessage,
 		isRunning = false,
+		isConversationLoading = false,
 		error = null,
 		activeTools,
 		toolInputBuffers,
@@ -719,6 +720,7 @@ export function ChatMastraInterface({
 					messages={visibleMessages}
 					isFocused={isFocused}
 					isRunning={canAbort}
+					isConversationLoading={isConversationLoading}
 					isAwaitingAssistant={isAwaitingAssistant}
 					currentMessage={currentMessage ?? null}
 					interruptedMessage={interruptedMessage}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/components/ChatMastraMessageList/ChatMastraMessageList.test.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/components/ChatMastraMessageList/ChatMastraMessageList.test.tsx
@@ -10,6 +10,9 @@ mock.module("@superset/ui/ai-elements/conversation", () => ({
 		HTMLDivElement,
 		{ children: React.ReactNode }
 	>(({ children }, ref) => <div ref={ref}>{children}</div>),
+	ConversationLoadingState: ({ label }: { label?: string }) => (
+		<div>{label ?? "Loading conversation..."}</div>
+	),
 	ConversationEmptyState: ({ title }: { title?: string }) => (
 		<div>{title ?? "Empty"}</div>
 	),
@@ -149,6 +152,7 @@ function createBaseProps(
 		messages: [] as never,
 		isFocused: true,
 		isRunning: false,
+		isConversationLoading: false,
 		isAwaitingAssistant: false,
 		currentMessage: null,
 		interruptedMessage: null,
@@ -181,6 +185,15 @@ function renderListHtml(
 }
 
 describe("ChatMastraMessageList", () => {
+	it("shows loading state while conversation history is loading", () => {
+		const html = renderListHtml({
+			isConversationLoading: true,
+		});
+
+		expect(html).toContain("Loading conversation...");
+		expect(html).not.toContain("Start a conversation");
+	});
+
 	it("shows interrupted preview content after stop and hides the source assistant message", () => {
 		const html = renderListHtml({
 			messages: [

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/components/ChatMastraMessageList/ChatMastraMessageList.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/components/ChatMastraMessageList/ChatMastraMessageList.tsx
@@ -3,6 +3,7 @@ import {
 	Conversation,
 	ConversationContent,
 	ConversationEmptyState,
+	ConversationLoadingState,
 	ConversationScrollButton,
 } from "@superset/ui/ai-elements/conversation";
 import { Message, MessageContent } from "@superset/ui/ai-elements/message";
@@ -54,6 +55,7 @@ interface ChatMastraMessageListProps {
 	messages: MastraMessage[];
 	isFocused: boolean;
 	isRunning: boolean;
+	isConversationLoading: boolean;
 	isAwaitingAssistant: boolean;
 	currentMessage: MastraMessage | null;
 	interruptedMessage: {
@@ -152,26 +154,27 @@ function getStreamingPreviewToolParts({
 	activeTools: MastraActiveTools | undefined;
 	toolInputBuffers: MastraToolInputBuffers | undefined;
 }): ToolPart[] {
-	const activeEntries = toToolEntries(activeTools);
-	const inputEntries = toToolEntries(toolInputBuffers);
+	const activeById = new Map(toToolEntries(activeTools));
+	const inputBufferById = new Map(toToolEntries(toolInputBuffers));
 	const knownIds = new Set<string>([
-		...activeEntries.map(([id]) => id),
-		...inputEntries.map(([id]) => id),
+		...activeById.keys(),
+		...inputBufferById.keys(),
 	]);
 
-	return [...knownIds].map((toolCallId) => {
-		const toolState =
-			activeEntries.find(([id]) => id === toolCallId)?.[1] ?? null;
-		const inputBuffer =
-			inputEntries.find(([id]) => id === toolCallId)?.[1] ?? null;
-		return toPreviewToolPart({ toolCallId, toolState, inputBuffer });
-	});
+	return [...knownIds].map((toolCallId) =>
+		toPreviewToolPart({
+			toolCallId,
+			toolState: activeById.get(toolCallId) ?? null,
+			inputBuffer: inputBufferById.get(toolCallId) ?? null,
+		}),
+	);
 }
 
 export function ChatMastraMessageList({
 	messages,
 	isFocused,
 	isRunning,
+	isConversationLoading,
 	isAwaitingAssistant,
 	currentMessage,
 	interruptedMessage,
@@ -255,12 +258,20 @@ export function ChatMastraMessageList({
 		canShowPendingAssistantUi && previewToolParts.length === 0;
 	const shouldShowToolPreview =
 		canShowPendingAssistantUi && previewToolParts.length > 0;
+	const hasConversationContent =
+		renderedMessages.length > 0 || Boolean(interruptedPreview);
+	const shouldShowConversationLoading =
+		isConversationLoading && !isAwaitingAssistant && !hasConversationContent;
+	const shouldShowEmptyState =
+		!shouldShowConversationLoading && !hasConversationContent;
 
 	return (
 		<Conversation className="flex-1">
 			<ConversationContent className="mx-auto w-full max-w-3xl py-6 pl-6 pr-16">
 				<div ref={messageListRef} className="flex flex-col gap-6">
-					{renderedMessages.length === 0 && !interruptedPreview ? (
+					{shouldShowConversationLoading ? (
+						<ConversationLoadingState />
+					) : shouldShowEmptyState ? (
 						<ConversationEmptyState
 							title="Start a conversation"
 							description="Ask anything to get started"

--- a/packages/chat-mastra/src/client/hooks/use-mastra-chat-display/use-mastra-chat-display.ts
+++ b/packages/chat-mastra/src/client/hooks/use-mastra-chat-display/use-mastra-chat-display.ts
@@ -87,29 +87,28 @@ export function useMastraChatDisplay(options: UseMastraChatDisplayOptions) {
 	const { sessionId, cwd, enabled = true, fps = 60 } = options;
 	const utils = chatMastraServiceTrpc.useUtils();
 	const [commandError, setCommandError] = useState<unknown>(null);
+	const queryInput = sessionId
+		? { sessionId, ...(cwd ? { cwd } : {}) }
+		: skipToken;
+	const isQueryEnabled = enabled && Boolean(sessionId);
+	const refetchIntervalMs = toRefetchIntervalMs(fps);
+	const queryOptions = {
+		enabled: isQueryEnabled,
+		refetchInterval: refetchIntervalMs,
+		refetchIntervalInBackground: true,
+		refetchOnWindowFocus: false,
+		staleTime: 0,
+		gcTime: 0,
+	} as const;
 
 	const displayQuery = chatMastraServiceTrpc.session.getDisplayState.useQuery(
-		sessionId ? { sessionId, ...(cwd ? { cwd } : {}) } : skipToken,
-		{
-			enabled: enabled && Boolean(sessionId),
-			refetchInterval: toRefetchIntervalMs(fps),
-			refetchIntervalInBackground: true,
-			refetchOnWindowFocus: false,
-			staleTime: 0,
-			gcTime: 0,
-		},
+		queryInput,
+		queryOptions,
 	);
 
 	const messagesQuery = chatMastraServiceTrpc.session.listMessages.useQuery(
-		sessionId ? { sessionId, ...(cwd ? { cwd } : {}) } : skipToken,
-		{
-			enabled: enabled && Boolean(sessionId),
-			refetchInterval: toRefetchIntervalMs(fps),
-			refetchIntervalInBackground: true,
-			refetchOnWindowFocus: false,
-			staleTime: 0,
-			gcTime: 0,
-		},
+		queryInput,
+		queryOptions,
 	);
 
 	const displayState = displayQuery.data ?? null;
@@ -120,6 +119,10 @@ export function useMastraChatDisplay(options: UseMastraChatDisplayOptions) {
 			: null;
 	const currentMessage = displayState?.currentMessage ?? null;
 	const isRunning = displayState?.isRunning ?? false;
+	const isConversationLoading =
+		isQueryEnabled &&
+		messagesQuery.data === undefined &&
+		(messagesQuery.isLoading || messagesQuery.isFetching);
 	const historicalMessages = messagesQuery.data ?? [];
 	const latestAssistantErrorMessage = isRunning
 		? null
@@ -273,6 +276,7 @@ export function useMastraChatDisplay(options: UseMastraChatDisplayOptions) {
 	return {
 		...displayState,
 		messages,
+		isConversationLoading,
 		error:
 			runtimeErrorMessage ??
 			latestAssistantErrorMessage ??

--- a/packages/ui/src/components/ai-elements/conversation.tsx
+++ b/packages/ui/src/components/ai-elements/conversation.tsx
@@ -6,6 +6,7 @@ import { useCallback } from "react";
 import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
 import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
+import { Loader } from "./loader";
 
 export type ConversationProps = ComponentProps<typeof StickToBottom>;
 
@@ -39,6 +40,24 @@ export type ConversationEmptyStateProps = ComponentProps<"div"> & {
 	icon?: React.ReactNode;
 };
 
+type ConversationStateContainerProps = ComponentProps<"div">;
+
+const ConversationStateContainer = ({
+	className,
+	children,
+	...props
+}: ConversationStateContainerProps) => (
+	<div
+		className={cn(
+			"flex size-full flex-col items-center justify-center gap-3 p-8 text-center",
+			className,
+		)}
+		{...props}
+	>
+		{children}
+	</div>
+);
+
 export const ConversationEmptyState = ({
 	className,
 	title = "No messages yet",
@@ -47,13 +66,7 @@ export const ConversationEmptyState = ({
 	children,
 	...props
 }: ConversationEmptyStateProps) => (
-	<div
-		className={cn(
-			"flex size-full flex-col items-center justify-center gap-3 p-8 text-center",
-			className,
-		)}
-		{...props}
-	>
+	<ConversationStateContainer className={className} {...props}>
 		{children ?? (
 			<>
 				{icon && <div className="text-muted-foreground">{icon}</div>}
@@ -65,7 +78,29 @@ export const ConversationEmptyState = ({
 				</div>
 			</>
 		)}
-	</div>
+	</ConversationStateContainer>
+);
+
+export type ConversationLoadingStateProps = ComponentProps<"div"> & {
+	label?: string;
+	icon?: React.ReactNode;
+};
+
+export const ConversationLoadingState = ({
+	className,
+	label = "Loading conversation...",
+	icon,
+	children,
+	...props
+}: ConversationLoadingStateProps) => (
+	<ConversationStateContainer className={className} {...props}>
+		{children ?? (
+			<>
+				{icon ?? <Loader className="text-muted-foreground" size={14} />}
+				<p className="text-muted-foreground text-sm">{label}</p>
+			</>
+		)}
+	</ConversationStateContainer>
 );
 
 export type ConversationScrollButtonProps = ComponentProps<typeof Button>;


### PR DESCRIPTION
## Summary
- add a reusable `ConversationLoadingState` UI primitive in `@superset/ui`
- surface `isConversationLoading` from `useMastraChatDisplay`
- wire loading state through `ChatMastraInterface` into `ChatMastraMessageList`
- show loading state instead of empty state while initial conversation history is loading
- add/refactor tests for loading + interrupted message behavior

## Validation
- bun test apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/components/ChatMastraMessageList/ChatMastraMessageList.test.tsx
- bun run typecheck --filter=@superset/desktop --filter=@superset/chat-mastra --filter=@superset/ui
- bunx biome check on changed files


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a loading state to desktop chat conversations so users see “Loading conversation...” while initial history loads, instead of an empty screen. Improves clarity during session startup.

- **New Features**
  - Added ConversationLoadingState UI primitive in @superset/ui.
  - Exposed isConversationLoading from useMastraChatDisplay based on messages query status.
  - ChatMastraMessageList shows loading state when history is fetching and no content is present.
  - Added tests for loading state and interrupted message behavior.

- **Refactors**
  - Consolidated TRPC query inputs/options and derived isConversationLoading.
  - Simplified tool preview assembly using Maps for active tools and input buffers.

<sup>Written for commit 56df5cda59bfac1508087099ba4fecfa73ff29f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a loading state indicator that displays "Loading conversation..." when a conversation is being loaded, improving visibility into background data fetching operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->