### PR TITLE
fix: disable Sentry Session Replay across all apps

### DIFF
--- a/apps/admin/src/instrumentation-client.ts
+++ b/apps/admin/src/instrumentation-client.ts
@@ -29,6 +29,8 @@ Sentry.init({
 	enabled: !!env.NEXT_PUBLIC_SENTRY_DSN_ADMIN,
 	tracesSampleRate:
 		env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production" ? 0.1 : 1.0,
+	replaysSessionSampleRate: 0,
+	replaysOnErrorSampleRate: 0,
 	sendDefaultPii: true,
 	debug: false,
 });

--- a/apps/desktop/src/renderer/lib/sentry.ts
+++ b/apps/desktop/src/renderer/lib/sentry.ts
@@ -17,8 +17,6 @@ export async function initSentry(): Promise<void> {
 			dsn: env.SENTRY_DSN_DESKTOP,
 			environment: env.NODE_ENV,
 			tracesSampleRate: 0.1,
-			replaysSessionSampleRate: 0.1,
-			replaysOnErrorSampleRate: 1.0,
 		});
 
 		sentryInitialized = true;

--- a/apps/docs/src/instrumentation-client.ts
+++ b/apps/docs/src/instrumentation-client.ts
@@ -31,6 +31,8 @@ Sentry.init({
 	enabled: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production",
 	tracesSampleRate:
 		env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production" ? 0.1 : 1.0,
+	replaysSessionSampleRate: 0,
+	replaysOnErrorSampleRate: 0,
 	sendDefaultPii: true,
 	debug: false,
 });

--- a/apps/marketing/src/instrumentation-client.ts
+++ b/apps/marketing/src/instrumentation-client.ts
@@ -36,6 +36,8 @@ Sentry.init({
 	enabled: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production",
 	tracesSampleRate:
 		env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production" ? 0.1 : 1.0,
+	replaysSessionSampleRate: 0,
+	replaysOnErrorSampleRate: 0,
 	sendDefaultPii: true,
 	debug: false,
 });

--- a/apps/web/src/instrumentation-client.ts
+++ b/apps/web/src/instrumentation-client.ts
@@ -29,6 +29,8 @@ Sentry.init({
 	enabled: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production",
 	tracesSampleRate:
 		env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production" ? 0.1 : 1.0,
+	replaysSessionSampleRate: 0,
+	replaysOnErrorSampleRate: 0,
 	sendDefaultPii: true,
 	debug: false,
 });


### PR DESCRIPTION
## Summary
- Disable Sentry Session Replay in all client-side environments (desktop renderer, web, marketing, docs, admin).

## Why / Context
We don't use Sentry Session Replay and want to stop sending replay data. The desktop renderer had explicit sample rates (`0.1` / `1.0`), while `@sentry/nextjs` enables replay by default if no rates are set.

## How It Works
- **Desktop renderer**: Removed `replaysSessionSampleRate` and `replaysOnErrorSampleRate` entirely (no replay integration in `@sentry/electron`).
- **Next.js apps** (web, marketing, docs, admin): Explicitly set both rates to `0` to override `@sentry/nextjs` defaults.
- Server-side/edge configs and the desktop main process are unaffected (replay only applies in browser contexts).

## Testing
- `bun run typecheck`
- Verified no other Sentry replay references exist in the codebase

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled Sentry Session Replay across all client-side apps to stop collecting and sending replay data. Prevents @sentry/nextjs from auto-enabling replay and removes replay settings from the desktop renderer.

- **Bug Fixes**
  - Desktop renderer: removed replaysSessionSampleRate and replaysOnErrorSampleRate from Sentry init.
  - Next.js apps (web, marketing, docs, admin): set replaysSessionSampleRate and replaysOnErrorSampleRate to 0 to override defaults.

<sup>Written for commit f4313b991a7bc92005a3cd0b46799108f5c75a56. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled error replay collection across all applications to optimize monitoring configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->