### PR TITLE
fix(desktop): improve markdown table rendering in default style

### DIFF
--- a/apps/desktop/src/renderer/components/MarkdownRenderer/styles/default/config.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/styles/default/config.tsx
@@ -14,16 +14,20 @@ export const defaultConfig: MarkdownStyleConfig = {
 		),
 		table: ({ children }) => (
 			<div className="overflow-x-auto my-4">
-				<table className="min-w-full divide-y divide-border">{children}</table>
+				<table className="w-max min-w-full divide-y divide-border">
+					{children}
+				</table>
 			</div>
 		),
 		th: ({ children }) => (
-			<th className="px-4 py-2 text-left text-sm font-semibold bg-muted">
+			<th className="px-4 py-2 text-left text-sm font-semibold bg-muted align-top">
 				{children}
 			</th>
 		),
 		td: ({ children }) => (
-			<td className="px-4 py-2 text-sm border-t border-border">{children}</td>
+			<td className="px-4 py-2 text-sm border-t border-border align-top">
+				{children}
+			</td>
 		),
 		blockquote: ({ children }) => (
 			<blockquote className="border-l-4 border-muted-foreground/30 pl-4 italic my-4">

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/styles/default/default.css
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/styles/default/default.css
@@ -4,7 +4,7 @@
 }
 
 .default-markdown article {
-	max-width: 65ch;
+	width: 100%;
 	margin: 0 auto;
 }
 


### PR DESCRIPTION
## Summary
- remove the default markdown article width cap so rendered markdown can use full pane width
- make default-style tables size to content while preserving horizontal scrolling
- top-align table header/cell content for dense rows

## Validation
- bunx biome check apps/desktop/src/renderer/components/MarkdownRenderer/styles/default/config.tsx apps/desktop/src/renderer/components/MarkdownRenderer/styles/default/default.css

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand markdown to use the full pane width and improve table readability. Tables now size to their content, keep horizontal scrolling, and top-align header and cell content for dense rows.

<sup>Written for commit 1110bc9bd4a2048e46a779f32b20b50ccc49fee5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved table layout with enhanced width management and vertical alignment in markdown documents
  * Adjusted markdown content to utilize full available width while maintaining proper margins
  * Refined visual presentation of markdown rendering for better readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->