### PR TITLE
fix: filter deleted projects from workspace modal dropdown

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/projects/projects.ts
+++ b/apps/desktop/src/lib/trpc/routers/projects/projects.ts
@@ -10,7 +10,7 @@ import {
 	workspaces,
 } from "@superset/local-db";
 import { TRPCError } from "@trpc/server";
-import { and, desc, eq, inArray, isNull, not } from "drizzle-orm";
+import { and, desc, eq, inArray, isNotNull, isNull, not } from "drizzle-orm";
 import type { BrowserWindow } from "electron";
 import { dialog } from "electron";
 import { track } from "main/lib/analytics";
@@ -287,6 +287,7 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 			return localDb
 				.select()
 				.from(projects)
+				.where(isNotNull(projects.tabOrder))
 				.orderBy(desc(projects.lastOpenedAt))
 				.all();
 		}),


### PR DESCRIPTION
## Summary
- Filter out deleted/closed projects (where `tabOrder` is null) from the `getRecents` tRPC query so they no longer appear in the workspace modal dropdown

## Test plan
- [ ] Delete a project via right-click context menu
- [ ] Open the new workspace modal
- [ ] Verify the deleted project no longer appears in the project dropdown

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop showing deleted/closed projects in the workspace modal dropdown. The getRecents query now only returns projects with a tabOrder, so the dropdown lists active projects only.

- **Bug Fixes**
  - Added isNotNull(projects.tabOrder) to getRecents to exclude deleted projects (tabOrder=null).

<sup>Written for commit 00936a1e5823d0ab3d30f5c1c1b88a71ee356ace. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with the recent projects list where incomplete or improperly initialized project entries could appear in the history. The list now properly filters projects to show only valid entries, ensuring users see a cleaner and more reliable view of recently accessed projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->