### PR TITLE
fix(desktop): autofocus rename field when renaming a tab

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupItem.tsx
@@ -128,9 +128,13 @@ export function GroupItem({
 	);
 
 	useEffect(() => {
-		if (isEditing && inputRef.current) {
-			inputRef.current.focus();
-			inputRef.current.select();
+		if (isEditing) {
+			// Use rAF to ensure focus happens after context menu closes
+			const id = requestAnimationFrame(() => {
+				inputRef.current?.focus();
+				inputRef.current?.select();
+			});
+			return () => cancelAnimationFrame(id);
 		}
 	}, [isEditing]);
 


### PR DESCRIPTION
## Summary
- When renaming a tab (via double-click or context menu), the input field now receives focus automatically so you can start typing immediately
- Uses `requestAnimationFrame` to ensure focus happens after the context menu closes

## Test plan
- [ ] Double-click a tab name → input should be focused and text selected
- [ ] Right-click a tab → click "Rename" → input should be focused and text selected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Autofocuses the tab rename input so you can type immediately after starting a rename (double‑click or context menu). Focus and text selection are applied with requestAnimationFrame after the menu closes to prevent lost focus.

<sup>Written for commit 0947d3ad813b7904a25454a08027508c8d6e95c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed focus and selection timing in editing mode to ensure proper behavior when entering edit mode after closing context menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->