### PR TITLE
Add notes pane and polish notes/mosaic borders

### DIFF
--- a/apps/desktop/plans/done/20260304-1805-notes-pane-goal-and-polish.md
+++ b/apps/desktop/plans/done/20260304-1805-notes-pane-goal-and-polish.md
@@ -1,0 +1,25 @@
+# Notes Pane Goal And Polish
+
+## Goal
+Ship a new Notes pane that feels native in the workspace tab system, and fix visual regressions that made it look broken:
+
+1. A weird black border in Notes pane/editor states.
+2. A weird black border in Mosaic drag/split preview states.
+3. Fragile Notes save/hydration behavior that risked missed or stale writes.
+
+## What Was Implemented
+1. Added Notes pane routing, state shape, creation flow, and persistence wiring through the desktop UI state and notes tRPC router.
+2. Implemented Notes editor with TipTap + markdown storage in `.superset/notes/<file>.md`.
+3. Hardened Notes editor styling to remove unexpected focus/border chrome.
+4. Refined Notes editor save lifecycle:
+   - Debounced writes with explicit target tracking (`worktreePath` + `filePath`).
+   - Safe hydration per note file.
+   - Flush pending writes on unmount/switch.
+5. Overrode Mosaic preview/drop-target defaults so drag/split previews no longer fall back to black default borders.
+
+## Validation
+1. `bunx biome check` on touched files passes.
+2. `bun run --cwd apps/desktop typecheck` passes.
+
+## Outcome
+Notes pane now behaves and looks consistent with the rest of the workspace panes, and Mosaic preview overlays are themed correctly instead of showing default black borders.

--- a/apps/desktop/src/lib/trpc/routers/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/index.ts
@@ -14,6 +14,7 @@ import { createExternalRouter } from "./external";
 import { createFilesystemRouter } from "./filesystem";
 import { createHotkeysRouter } from "./hotkeys";
 import { createMenuRouter } from "./menu";
+import { createNotesRouter } from "./notes";
 import { createNotificationsRouter } from "./notifications";
 import { createPermissionsRouter } from "./permissions";
 import { createPortsRouter } from "./ports";
@@ -47,6 +48,7 @@ export const createAppRouter = (getWindow: () => BrowserWindow | null) => {
 		ports: createPortsRouter(),
 		resourceMetrics: createResourceMetricsRouter(),
 		menu: createMenuRouter(),
+		notes: createNotesRouter(),
 		hotkeys: createHotkeysRouter(getWindow),
 		external: createExternalRouter(),
 		settings: createSettingsRouter(),

--- a/apps/desktop/src/lib/trpc/routers/notes/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/notes/index.ts
@@ -1,0 +1,61 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+import { publicProcedure, router } from "../..";
+
+const NOTES_DIR = ".superset/notes";
+
+export const createNotesRouter = () => {
+	return router({
+		read: publicProcedure
+			.input(
+				z.object({
+					worktreePath: z.string(),
+					fileName: z.string(),
+				}),
+			)
+			.query(async ({ input }) => {
+				const filePath = path.join(
+					input.worktreePath,
+					NOTES_DIR,
+					input.fileName,
+				);
+				try {
+					return await fs.readFile(filePath, "utf-8");
+				} catch {
+					return null;
+				}
+			}),
+
+		write: publicProcedure
+			.input(
+				z.object({
+					worktreePath: z.string(),
+					fileName: z.string(),
+					content: z.string(),
+				}),
+			)
+			.mutation(async ({ input }) => {
+				const dirPath = path.join(input.worktreePath, NOTES_DIR);
+				await fs.mkdir(dirPath, { recursive: true });
+				const filePath = path.join(dirPath, input.fileName);
+				await fs.writeFile(filePath, input.content, "utf-8");
+			}),
+
+		list: publicProcedure
+			.input(
+				z.object({
+					worktreePath: z.string(),
+				}),
+			)
+			.query(async ({ input }) => {
+				const dirPath = path.join(input.worktreePath, NOTES_DIR);
+				try {
+					const entries = await fs.readdir(dirPath);
+					return entries.filter((e) => e.endsWith(".md"));
+				} catch {
+					return [];
+				}
+			}),
+	});
+};

--- a/apps/desktop/src/lib/trpc/routers/ui-state/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/ui-state/index.ts
@@ -49,6 +49,7 @@ const paneSchema = z.object({
 		"file-viewer",
 		"chat-mastra",
 		"devtools",
+		"notes",
 	]),
 	name: z.string(),
 	isNew: z.boolean().optional(),
@@ -90,6 +91,12 @@ const paneSchema = z.object({
 	devtools: z
 		.object({
 			targetPaneId: z.string(),
+		})
+		.optional(),
+	notes: z
+		.object({
+			content: z.string(),
+			filePath: z.string(),
 		})
 		.optional(),
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -130,6 +130,7 @@ function WorkspacePage() {
 	const addChatMastraTab = useTabsStore((s) => s.addChatMastraTab);
 	const reopenClosedTab = useTabsStore((s) => s.reopenClosedTab);
 	const addBrowserTab = useTabsStore((s) => s.addBrowserTab);
+	const addNotesTab = useTabsStore((s) => s.addNotesTab);
 	const setActiveTab = useTabsStore((s) => s.setActiveTab);
 	const removeTab = useTabsStore((s) => s.removeTab);
 	const removePane = useTabsStore((s) => s.removePane);
@@ -196,6 +197,10 @@ function WorkspacePage() {
 	useAppHotkey("NEW_BROWSER", () => addBrowserTab(workspaceId), undefined, [
 		workspaceId,
 		addBrowserTab,
+	]);
+	useAppHotkey("NEW_NOTES", () => addNotesTab(workspaceId), undefined, [
+		workspaceId,
+		addNotesTab,
 	]);
 	usePresetHotkeys(openTabWithPreset);
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupStrip.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupStrip.tsx
@@ -41,6 +41,7 @@ export function GroupStrip() {
 	const { addTab, openPreset } = useTabsWithPresets();
 	const addChatMastraTab = useTabsStore((s) => s.addChatMastraTab);
 	const addBrowserTab = useTabsStore((s) => s.addBrowserTab);
+	const addNotesTab = useTabsStore((s) => s.addNotesTab);
 	const renameTab = useTabsStore((s) => s.renameTab);
 	const removeTab = useTabsStore((s) => s.removeTab);
 	const setActiveTab = useTabsStore((s) => s.setActiveTab);
@@ -193,6 +194,11 @@ export function GroupStrip() {
 		addBrowserTab(activeWorkspaceId);
 	};
 
+	const handleAddNotes = () => {
+		if (!activeWorkspaceId) return;
+		addNotesTab(activeWorkspaceId);
+	};
+
 	const handleOpenPreset = useCallback(
 		(preset: TerminalPreset) => {
 			if (!activeWorkspaceId) return;
@@ -278,6 +284,7 @@ export function GroupStrip() {
 			onAddTerminal={handleAddGroup}
 			onAddChat={handleAddChat}
 			onAddBrowser={handleAddBrowser}
+			onAddNotes={handleAddNotes}
 			onOpenPreset={handleOpenPreset}
 			onConfigurePresets={handleOpenPresetsSettings}
 			onToggleShowPresetsBar={(enabled) =>
@@ -327,8 +334,8 @@ export function GroupStrip() {
 							className={`h-full shrink-0 ${
 								!useCompactAddButton
 									? hasAiChat
-										? "w-[220px]"
-										: "w-[170px]"
+										? "w-[280px]"
+										: "w-[230px]"
 									: "w-10"
 							}`}
 						/>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/components/AddTabButton/AddTabButton.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/components/AddTabButton/AddTabButton.tsx
@@ -11,7 +11,7 @@ import {
 import { BsTerminalPlus } from "react-icons/bs";
 import { HiMiniChevronDown } from "react-icons/hi2";
 import { LuPlus } from "react-icons/lu";
-import { TbMessageCirclePlus, TbWorld } from "react-icons/tb";
+import { TbFileText, TbMessageCirclePlus, TbWorld } from "react-icons/tb";
 import { HotkeyMenuShortcut } from "renderer/components/HotkeyMenuShortcut";
 import { NewTabDropZone } from "../../NewTabDropZone";
 import { PresetsSubmenu } from "./components/PresetsSubmenu";
@@ -26,6 +26,7 @@ interface AddTabButtonProps {
 	onAddTerminal: () => void;
 	onAddChat: () => void;
 	onAddBrowser: () => void;
+	onAddNotes: () => void;
 	onOpenPreset: (preset: TerminalPreset) => void;
 	onConfigurePresets: () => void;
 	onToggleShowPresetsBar: (enabled: boolean) => void;
@@ -42,6 +43,7 @@ export function AddTabButton({
 	onAddTerminal,
 	onAddChat,
 	onAddBrowser,
+	onAddNotes,
 	onOpenPreset,
 	onConfigurePresets,
 	onToggleShowPresetsBar,
@@ -81,6 +83,14 @@ export function AddTabButton({
 							>
 								<TbWorld className="size-3.5" />
 								Browser
+							</Button>
+							<Button
+								variant="outline"
+								className="h-7 rounded-none border-l-0 px-1.5 gap-1 text-xs"
+								onClick={onAddNotes}
+							>
+								<TbFileText className="size-3.5" />
+								Notes
 							</Button>
 							<DropdownMenuTrigger asChild>
 								<Button
@@ -123,6 +133,11 @@ export function AddTabButton({
 								<TbWorld className="size-4" />
 								<span>Browser</span>
 								<HotkeyMenuShortcut hotkeyId="NEW_BROWSER" />
+							</DropdownMenuItem>
+							<DropdownMenuItem onClick={onAddNotes} className="gap-2">
+								<TbFileText className="size-4" />
+								<span>Notes</span>
+								<HotkeyMenuShortcut hotkeyId="NEW_NOTES" />
 							</DropdownMenuItem>
 							<DropdownMenuSeparator />
 						</>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/NotesPane/NotesPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/NotesPane/NotesPane.tsx
@@ -1,0 +1,268 @@
+import "./notes-editor.css";
+
+import { Extension, type Editor as TiptapEditor } from "@tiptap/core";
+import { Blockquote } from "@tiptap/extension-blockquote";
+import { Bold } from "@tiptap/extension-bold";
+import { BulletList } from "@tiptap/extension-bullet-list";
+import { Code } from "@tiptap/extension-code";
+import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
+import { Document } from "@tiptap/extension-document";
+import { HardBreak } from "@tiptap/extension-hard-break";
+import { Heading } from "@tiptap/extension-heading";
+import { History } from "@tiptap/extension-history";
+import { Italic } from "@tiptap/extension-italic";
+import { ListItem } from "@tiptap/extension-list-item";
+import { OrderedList } from "@tiptap/extension-ordered-list";
+import { Paragraph } from "@tiptap/extension-paragraph";
+import Placeholder from "@tiptap/extension-placeholder";
+import { Strike } from "@tiptap/extension-strike";
+import TaskItem from "@tiptap/extension-task-item";
+import TaskList from "@tiptap/extension-task-list";
+import { Text } from "@tiptap/extension-text";
+import { EditorContent, useEditor } from "@tiptap/react";
+import { common, createLowlight } from "lowlight";
+import { useCallback, useEffect, useRef } from "react";
+import type { MosaicBranch } from "react-mosaic-component";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useTabsStore } from "renderer/stores/tabs/store";
+import { Markdown } from "tiptap-markdown";
+import { BasePaneWindow, PaneToolbarActions } from "../components";
+
+const lowlight = createLowlight(common);
+
+const SAVE_DEBOUNCE_MS = 500;
+
+function getMarkdown(editor: TiptapEditor): string {
+	const storage = editor.storage as unknown as Record<
+		string,
+		{ getMarkdown?: () => string }
+	>;
+	return storage.markdown?.getMarkdown?.() ?? "";
+}
+
+const KeyboardHandler = Extension.create({
+	name: "notesKeyboardHandler",
+	addKeyboardShortcuts() {
+		return {
+			Tab: ({ editor }) => {
+				if (editor.commands.sinkListItem("listItem")) return true;
+				if (editor.commands.sinkListItem("taskItem")) return true;
+				return true;
+			},
+			"Shift-Tab": ({ editor }) => {
+				if (editor.commands.liftListItem("listItem")) return true;
+				if (editor.commands.liftListItem("taskItem")) return true;
+				return true;
+			},
+		};
+	},
+});
+
+interface NotesPaneProps {
+	paneId: string;
+	path: MosaicBranch[];
+	tabId: string;
+	worktreePath: string;
+	splitPaneAuto: (
+		tabId: string,
+		sourcePaneId: string,
+		dimensions: { width: number; height: number },
+		path?: MosaicBranch[],
+	) => void;
+	removePane: (paneId: string) => void;
+	setFocusedPane: (tabId: string, paneId: string) => void;
+}
+
+export function NotesPane({
+	paneId,
+	path,
+	tabId,
+	worktreePath,
+	splitPaneAuto,
+	removePane,
+	setFocusedPane,
+}: NotesPaneProps) {
+	const filePath = useTabsStore((s) => s.panes[paneId]?.notes?.filePath) ?? "";
+	const writeMutation = electronTrpc.notes.write.useMutation();
+	const { data: fileContent, isLoading } = electronTrpc.notes.read.useQuery(
+		{ worktreePath, fileName: filePath },
+		{ enabled: !!worktreePath && !!filePath },
+	);
+
+	const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const isHydratingRef = useRef(false);
+	const hydratedFileRef = useRef<string | null>(null);
+	const pendingSaveRef = useRef(false);
+	const pendingTargetRef = useRef<{
+		worktreePath: string;
+		filePath: string;
+	} | null>(null);
+
+	const saveToFile = useCallback(
+		(target: { worktreePath: string; filePath: string; content: string }) => {
+			if (!target.worktreePath || !target.filePath) return;
+			writeMutation.mutate({
+				worktreePath: target.worktreePath,
+				fileName: target.filePath,
+				content: target.content,
+			});
+		},
+		[writeMutation],
+	);
+
+	const flushPendingSave = useCallback(
+		(editorToFlush: TiptapEditor | null) => {
+			if (!editorToFlush || !pendingSaveRef.current) return;
+
+			if (debounceRef.current) {
+				clearTimeout(debounceRef.current);
+				debounceRef.current = null;
+			}
+
+			const target = pendingTargetRef.current;
+			if (!target) return;
+
+			saveToFile({
+				...target,
+				content: getMarkdown(editorToFlush),
+			});
+
+			pendingSaveRef.current = false;
+			pendingTargetRef.current = null;
+		},
+		[saveToFile],
+	);
+
+	const editor = useEditor({
+		extensions: [
+			Document,
+			Text,
+			Paragraph.configure({
+				HTMLAttributes: { class: "mt-0 mb-2 leading-relaxed" },
+			}),
+			Heading.configure({ levels: [1, 2, 3, 4, 5, 6] }),
+			Bold,
+			Italic,
+			Strike,
+			Code.configure({
+				HTMLAttributes: {
+					class: "font-mono text-sm px-1 py-0.5 rounded bg-muted",
+				},
+			}),
+			CodeBlockLowlight.configure({
+				lowlight,
+				HTMLAttributes: {
+					class:
+						"my-3 p-3 rounded-md bg-muted overflow-x-auto font-mono text-sm",
+				},
+			}),
+			BulletList.configure({
+				HTMLAttributes: { class: "notes-list mt-0 pl-6" },
+			}),
+			OrderedList.configure({
+				HTMLAttributes: { class: "mt-0 mb-2 pl-6 list-decimal" },
+			}),
+			ListItem,
+			TaskList.configure({
+				HTMLAttributes: { class: "mt-0 mb-2 pl-0 list-none" },
+			}),
+			TaskItem.configure({
+				HTMLAttributes: { class: "flex items-start gap-2 mb-1" },
+				nested: true,
+			}),
+			Blockquote.configure({
+				HTMLAttributes: {
+					class: "my-3 pl-4 border-l-2 border-border text-muted-foreground",
+				},
+			}),
+			HardBreak,
+			History,
+			Placeholder.configure({
+				placeholder: "Write your notes here...",
+				emptyNodeClass:
+					"first:before:text-muted-foreground first:before:float-left first:before:h-0 first:before:pointer-events-none first:before:content-[attr(data-placeholder)]",
+			}),
+			Markdown.configure({
+				html: false,
+				transformPastedText: true,
+				transformCopiedText: true,
+			}),
+			KeyboardHandler,
+		],
+		content: "",
+		editorProps: {
+			attributes: {
+				class: "focus:outline-none min-h-full",
+			},
+		},
+		onUpdate: ({ editor }) => {
+			if (isHydratingRef.current || !worktreePath || !filePath) return;
+
+			const target = { worktreePath, filePath };
+			pendingTargetRef.current = target;
+			pendingSaveRef.current = true;
+
+			if (debounceRef.current) {
+				clearTimeout(debounceRef.current);
+			}
+
+			debounceRef.current = setTimeout(() => {
+				saveToFile({
+					...target,
+					content: getMarkdown(editor),
+				});
+				pendingSaveRef.current = false;
+				pendingTargetRef.current = null;
+				debounceRef.current = null;
+			}, SAVE_DEBOUNCE_MS);
+		},
+	});
+
+	useEffect(() => {
+		if (!editor || isLoading || !filePath) return;
+		if (hydratedFileRef.current === filePath) return;
+
+		flushPendingSave(editor);
+
+		isHydratingRef.current = true;
+		editor.commands.setContent(fileContent ?? "", { emitUpdate: false });
+		hydratedFileRef.current = filePath;
+		queueMicrotask(() => {
+			isHydratingRef.current = false;
+		});
+	}, [editor, fileContent, filePath, flushPendingSave, isLoading]);
+
+	useEffect(() => {
+		return () => {
+			flushPendingSave(editor);
+		};
+	}, [editor, flushPendingSave]);
+
+	return (
+		<BasePaneWindow
+			paneId={paneId}
+			path={path}
+			tabId={tabId}
+			splitPaneAuto={splitPaneAuto}
+			removePane={removePane}
+			setFocusedPane={setFocusedPane}
+			renderToolbar={(handlers) => (
+				<div className="flex h-full w-full items-center justify-between">
+					<div className="flex h-full items-center px-2">
+						<span className="text-xs text-muted-foreground">Notes</span>
+					</div>
+					<PaneToolbarActions
+						splitOrientation={handlers.splitOrientation}
+						onSplitPane={handlers.onSplitPane}
+						onClosePane={handlers.onClosePane}
+						closeHotkeyId="CLOSE_TERMINAL"
+					/>
+				</div>
+			)}
+		>
+			<div className="notes-editor h-full w-full overflow-y-auto p-3 text-sm">
+				<EditorContent editor={editor} className="h-full" />
+			</div>
+		</BasePaneWindow>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/NotesPane/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/NotesPane/index.ts
@@ -1,0 +1,1 @@
+export { NotesPane } from "./NotesPane";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/NotesPane/notes-editor.css
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/NotesPane/notes-editor.css
@@ -1,0 +1,95 @@
+/* Tiptap editor — fill pane body and strip default chrome */
+.notes-editor .tiptap {
+	height: 100%;
+	outline: none;
+	border: none;
+	box-shadow: none;
+	background: transparent;
+}
+
+.notes-editor .ProseMirror,
+.notes-editor .ProseMirror:focus,
+.notes-editor .ProseMirror:focus-visible {
+	outline: none;
+	border: none;
+	box-shadow: none;
+}
+
+/* Alternating bullet styles */
+.notes-list {
+	list-style-type: disc;
+}
+
+.notes-list ul {
+	list-style-type: circle;
+	margin: 0;
+	padding-left: 1.5rem;
+}
+
+.notes-list ul ul {
+	list-style-type: disc;
+}
+
+.notes-list ul ul ul {
+	list-style-type: circle;
+}
+
+.notes-list li {
+	margin: 0;
+}
+
+/* Task list checkbox styling */
+ul[data-type="taskList"] li[data-type="taskItem"] {
+	display: flex;
+	align-items: flex-start;
+	gap: 0.5rem;
+}
+
+ul[data-type="taskList"] li[data-type="taskItem"] > label {
+	display: flex;
+	align-items: center;
+	margin-top: 0.125rem;
+}
+
+ul[data-type="taskList"]
+	li[data-type="taskItem"]
+	> label
+	> input[type="checkbox"] {
+	appearance: none;
+	width: 1rem;
+	height: 1rem;
+	border: 1.5px solid hsl(var(--border));
+	border-radius: 0.25rem;
+	background-color: transparent;
+	cursor: pointer;
+	transition: all 0.15s ease;
+}
+
+ul[data-type="taskList"]
+	li[data-type="taskItem"]
+	> label
+	> input[type="checkbox"]:hover {
+	border-color: hsl(var(--primary));
+}
+
+ul[data-type="taskList"]
+	li[data-type="taskItem"]
+	> label
+	> input[type="checkbox"]:checked {
+	background-color: hsl(var(--primary));
+	border-color: hsl(var(--primary));
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20 6 9 17 4 12'%3E%3C/polyline%3E%3C/svg%3E");
+	background-size: 0.75rem;
+	background-position: center;
+	background-repeat: no-repeat;
+}
+
+ul[data-type="taskList"]
+	li[data-type="taskItem"]
+	> label
+	> input[type="checkbox"]:focus {
+	outline: none;
+	box-shadow:
+		0 0 0 2px hsl(var(--background)),
+		0 0 0 4px hsl(var(--ring));
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
@@ -23,6 +23,7 @@ import { BrowserPane } from "./BrowserPane";
 import { ChatMastraPane } from "./ChatMastraPane";
 import { DevToolsPane } from "./DevToolsPane";
 import { FileViewerPane } from "./FileViewerPane";
+import { NotesPane } from "./NotesPane";
 import { TabPane } from "./TabPane";
 
 interface TabViewProps {
@@ -201,6 +202,21 @@ export function TabView({ tab }: TabViewProps) {
 						paneId={paneId}
 						path={path}
 						tabId={tab.id}
+						splitPaneAuto={splitPaneAuto}
+						removePane={removePane}
+						setFocusedPane={setFocusedPane}
+					/>
+				);
+			}
+
+			// Route notes panes
+			if (paneInfo.type === "notes") {
+				return (
+					<NotesPane
+						paneId={paneId}
+						path={path}
+						tabId={tab.id}
+						worktreePath={worktreePath}
 						splitPaneAuto={splitPaneAuto}
 						removePane={removePane}
 						setFocusedPane={setFocusedPane}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/mosaic-theme.css
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/mosaic-theme.css
@@ -2,29 +2,50 @@
 	background: transparent;
 }
 
-:is(.mosaic-theme-dark, .mosaic-theme-light) .mosaic-root {
+/*
+ * All overrides use `.mosaic:is(...)` prefix to beat the built-in
+ * `.mosaic.mosaic-blueprint-theme` rules (specificity 0,4,0).
+ */
+
+.mosaic:is(.mosaic-theme-dark, .mosaic-theme-light) .mosaic-root {
 	top: 0;
 	left: 0;
 	right: 0;
 	bottom: 0;
 }
 
-:is(.mosaic-theme-dark, .mosaic-theme-light) .mosaic-tile {
+.mosaic:is(.mosaic-theme-dark, .mosaic-theme-light) .mosaic-tile {
 	margin: 0;
 }
 
-:is(.mosaic-theme-dark, .mosaic-theme-light) .mosaic-window {
+.mosaic:is(.mosaic-theme-dark, .mosaic-theme-light) .mosaic-window {
 	border: 0.5px solid var(--color-border);
 	border-radius: 0;
 	overflow: hidden;
 	box-shadow: none;
 }
-:is(.mosaic-theme-dark, .mosaic-theme-light) .mosaic-window-focused {
+.mosaic:is(.mosaic-theme-dark, .mosaic-theme-light) .mosaic-preview {
+	border: 0.5px solid var(--color-border);
+	border-radius: 0;
+	overflow: hidden;
+	box-shadow: none;
+	background: var(--color-background);
+}
+.mosaic:is(.mosaic-theme-dark, .mosaic-theme-light)
+	.mosaic-window
+	.mosaic-preview,
+.mosaic:is(.mosaic-theme-dark, .mosaic-theme-light)
+	.mosaic-preview
+	.mosaic-preview {
+	border: 0.5px solid var(--color-border);
+	max-height: none;
+}
+.mosaic:is(.mosaic-theme-dark, .mosaic-theme-light) .mosaic-window-focused {
 	border-color: var(--color-border);
 }
 
-:is(.mosaic-theme-dark, .mosaic-theme-light)
-	.mosaic-window
+.mosaic:is(.mosaic-theme-dark, .mosaic-theme-light)
+	:is(.mosaic-window, .mosaic-preview)
 	.mosaic-window-toolbar {
 	background: var(--color-tertiary);
 	height: 28px;
@@ -33,9 +54,10 @@
 	align-items: center;
 	transition: background-color 0.15s ease;
 	border-radius: 0;
+	box-shadow: none;
 }
-:is(.mosaic-theme-dark, .mosaic-theme-light)
-	.mosaic-window
+.mosaic:is(.mosaic-theme-dark, .mosaic-theme-light)
+	:is(.mosaic-window, .mosaic-preview)
 	.mosaic-window-toolbar
 	.mosaic-window-controls {
 	opacity: 0;
@@ -44,27 +66,27 @@
 	align-items: center;
 	height: 100%;
 }
-:is(.mosaic-theme-dark, .mosaic-theme-light)
-	.mosaic-window
+.mosaic:is(.mosaic-theme-dark, .mosaic-theme-light)
+	:is(.mosaic-window, .mosaic-preview)
 	.mosaic-window-toolbar:hover
 	.mosaic-window-controls,
-:is(.mosaic-theme-dark, .mosaic-theme-light)
-	.mosaic-window-focused
+.mosaic:is(.mosaic-theme-dark, .mosaic-theme-light)
+	:is(.mosaic-window-focused, .mosaic-preview)
 	.mosaic-window-toolbar
 	.mosaic-window-controls,
-:is(.mosaic-theme-dark, .mosaic-theme-light)
-	.mosaic-window
+.mosaic:is(.mosaic-theme-dark, .mosaic-theme-light)
+	:is(.mosaic-window, .mosaic-preview)
 	.mosaic-window-toolbar:focus-within
 	.mosaic-window-controls {
 	opacity: 1;
 }
-:is(.mosaic-theme-dark, .mosaic-theme-light)
-	.mosaic-window-focused
+.mosaic:is(.mosaic-theme-dark, .mosaic-theme-light)
+	:is(.mosaic-window-focused, .mosaic-preview)
 	.mosaic-window-toolbar {
 	background: var(--color-secondary);
 }
-:is(.mosaic-theme-dark, .mosaic-theme-light)
-	.mosaic-window
+.mosaic:is(.mosaic-theme-dark, .mosaic-theme-light)
+	:is(.mosaic-window, .mosaic-preview)
 	.mosaic-window-title {
 	color: var(--color-muted-foreground);
 	font-size: 11px;
@@ -72,13 +94,13 @@
 	letter-spacing: 0.01em;
 	transition: color 0.15s ease;
 }
-:is(.mosaic-theme-dark, .mosaic-theme-light)
-	.mosaic-window-focused
+.mosaic:is(.mosaic-theme-dark, .mosaic-theme-light)
+	:is(.mosaic-window-focused, .mosaic-preview)
 	.mosaic-window-title {
 	color: var(--color-foreground);
 }
-:is(.mosaic-theme-dark, .mosaic-theme-light)
-	.mosaic-window
+.mosaic:is(.mosaic-theme-dark, .mosaic-theme-light)
+	:is(.mosaic-window, .mosaic-preview)
 	.mosaic-window-body {
 	background: transparent;
 	border: none;
@@ -94,22 +116,32 @@
 	outline: 2px solid var(--color-ring);
 	outline-offset: -2px;
 }
-:is(.mosaic-theme-dark, .mosaic-theme-light) .mosaic-split {
+.mosaic:is(.mosaic-theme-dark, .mosaic-theme-light) .mosaic-split {
 	background: transparent;
 	opacity: 1;
 	transition: background-color 0.15s ease;
 }
 
-:is(.mosaic-theme-dark, .mosaic-theme-light) .mosaic-split.-column {
+.mosaic:is(.mosaic-theme-dark, .mosaic-theme-light) .mosaic-split.-column {
 	cursor: row-resize;
 }
 
-:is(.mosaic-theme-dark, .mosaic-theme-light) .mosaic-split.-row {
+.mosaic:is(.mosaic-theme-dark, .mosaic-theme-light) .mosaic-split.-row {
 	cursor: col-resize;
 }
 
-/* Drop target when hovering - shows the split preview */
-.mosaic-drop-target .drop-target-container .drop-target.drop-target-hover {
+/* Drop target preview while dragging panes */
+.mosaic:is(.mosaic-theme-dark, .mosaic-theme-light) .mosaic-drop-target
+	.drop-target-container
+	.drop-target {
+	background: transparent;
+	border: 1px solid transparent;
+}
+
+.mosaic:is(.mosaic-theme-dark, .mosaic-theme-light)
+	.mosaic-drop-target
+	.drop-target-container
+	.drop-target.drop-target-hover {
 	background: rgba(59, 130, 246, 0.1);
 	border: 1px solid rgba(59, 130, 246, 0.3);
 	opacity: 1;

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -22,6 +22,7 @@ import {
 	createChatMastraTabWithPane,
 	createDevToolsPane,
 	createFileViewerPane,
+	createNotesTabWithPane,
 	createPane,
 	createTabWithPane,
 	extractPaneIdsFromLayout,
@@ -190,6 +191,46 @@ export const useTabsStore = create<TabsStore>()(
 
 					posthog.capture("panel_opened", {
 						panel_type: "chat",
+						workspace_id: workspaceId,
+						pane_id: pane.id,
+					});
+
+					return { tabId: tab.id, paneId: pane.id };
+				},
+
+				addNotesTab: (workspaceId: string) => {
+					const state = get();
+
+					const { tab, pane } = createNotesTabWithPane(workspaceId);
+
+					const currentActiveId = state.activeTabIds[workspaceId];
+					const historyStack = state.tabHistoryStacks[workspaceId] || [];
+					const newHistoryStack = currentActiveId
+						? [
+								currentActiveId,
+								...historyStack.filter((id) => id !== currentActiveId),
+							]
+						: historyStack;
+
+					set({
+						tabs: [...state.tabs, tab],
+						panes: { ...state.panes, [pane.id]: pane },
+						activeTabIds: {
+							...state.activeTabIds,
+							[workspaceId]: tab.id,
+						},
+						focusedPaneIds: {
+							...state.focusedPaneIds,
+							[tab.id]: pane.id,
+						},
+						tabHistoryStacks: {
+							...state.tabHistoryStacks,
+							[workspaceId]: newHistoryStack,
+						},
+					});
+
+					posthog.capture("panel_opened", {
+						panel_type: "notes",
 						workspace_id: workspaceId,
 						pane_id: pane.id,
 					});

--- a/apps/desktop/src/renderer/stores/tabs/types.ts
+++ b/apps/desktop/src/renderer/stores/tabs/types.ts
@@ -92,6 +92,7 @@ export interface TabsStore extends TabsState {
 		workspaceId: string,
 		options?: AddChatMastraTabOptions,
 	) => { tabId: string; paneId: string };
+	addNotesTab: (workspaceId: string) => { tabId: string; paneId: string };
 	addTabWithMultiplePanes: (
 		workspaceId: string,
 		options: AddTabWithMultiplePanesOptions,

--- a/apps/desktop/src/renderer/stores/tabs/utils.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils.ts
@@ -11,6 +11,7 @@ import type {
 	DiffLayout,
 	FileViewerMode,
 	FileViewerState,
+	NotesPaneState,
 } from "shared/tabs-types";
 import type { AddChatMastraTabOptions, Pane, PaneType, Tab } from "./types";
 
@@ -296,6 +297,41 @@ export const createDevToolsPane = (
 		name: "DevTools",
 		devtools,
 	};
+};
+
+/**
+ * Creates a new notes pane
+ */
+export const createNotesPane = (tabId: string): Pane => {
+	const id = generateId("pane");
+	const notes: NotesPaneState = { content: "", filePath: `note-${id}.md` };
+	return {
+		id,
+		tabId,
+		type: "notes",
+		name: "Notes",
+		notes,
+	};
+};
+
+/**
+ * Creates a new tab with a notes pane atomically
+ */
+export const createNotesTabWithPane = (
+	workspaceId: string,
+): { tab: Tab; pane: Pane } => {
+	const tabId = generateId("tab");
+	const pane = createNotesPane(tabId);
+
+	const tab: Tab = {
+		id: tabId,
+		name: "Notes",
+		workspaceId,
+		layout: pane.id,
+		createdAt: Date.now(),
+	};
+
+	return { tab, pane };
 };
 
 /**

--- a/apps/desktop/src/shared/hotkeys.ts
+++ b/apps/desktop/src/shared/hotkeys.ts
@@ -534,6 +534,11 @@ export const HOTKEYS = {
 		label: "New Browser",
 		category: "Terminal",
 	}),
+	NEW_NOTES: defineHotkey({
+		keys: "meta+alt+n",
+		label: "New Notes",
+		category: "Terminal",
+	}),
 	CLOSE_TERMINAL: defineHotkey({
 		keys: "meta+w",
 		label: "Close Terminal",

--- a/apps/desktop/src/shared/tabs-types.ts
+++ b/apps/desktop/src/shared/tabs-types.ts
@@ -13,7 +13,8 @@ export type PaneType =
 	| "webview"
 	| "file-viewer"
 	| "chat-mastra"
-	| "devtools";
+	| "devtools"
+	| "notes";
 
 /**
  * Pane status for agent lifecycle indicators
@@ -139,6 +140,7 @@ export interface Pane {
 	chatMastra?: ChatMastraPaneState; // For Mastra chat panes
 	browser?: BrowserPaneState; // For browser (webview) panes
 	devtools?: DevToolsPaneState; // For devtools panes
+	notes?: NotesPaneState; // For notes panes
 }
 
 export interface ChatMastraLaunchConfig {
@@ -197,6 +199,14 @@ export interface BrowserPaneState {
 export interface DevToolsPaneState {
 	/** The pane ID of the browser pane being inspected */
 	targetPaneId: string;
+}
+
+/**
+ * Notes pane-specific properties
+ */
+export interface NotesPaneState {
+	content: string;
+	filePath: string;
 }
 
 /**


### PR DESCRIPTION
# Notes Pane Goal And Polish

## Goal
Ship a new Notes pane that feels native in the workspace tab system, and fix visual regressions that made it look broken:

1. A weird black border in Notes pane/editor states.
2. A weird black border in Mosaic drag/split preview states.
3. Fragile Notes save/hydration behavior that risked missed or stale writes.

## What Was Implemented
1. Added Notes pane routing, state shape, creation flow, and persistence wiring through the desktop UI state and notes tRPC router.
2. Implemented Notes editor with TipTap + markdown storage in `.superset/notes/<file>.md`.
3. Hardened Notes editor styling to remove unexpected focus/border chrome.
4. Refined Notes editor save lifecycle:
   - Debounced writes with explicit target tracking (`worktreePath` + `filePath`).
   - Safe hydration per note file.
   - Flush pending writes on unmount/switch.
5. Overrode Mosaic preview/drop-target defaults so drag/split previews no longer fall back to black default borders.

## Validation
1. `bunx biome check` on touched files passes.
2. `bun run --cwd apps/desktop typecheck` passes.

## Outcome
Notes pane now behaves and looks consistent with the rest of the workspace panes, and Mosaic preview overlays are themed correctly instead of showing default black borders.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native Notes pane with a clean TipTap editor and markdown storage. Also fixes black borders in Notes and Mosaic previews, and makes note saving reliable.

- **New Features**
  - Notes pane with TipTap editor, routed like other panes.
  - Markdown persisted via tRPC notes router to .superset/notes/<file>.md.
  - New Notes hotkey (meta+alt+n) and “Notes” option in Add Tab.

- **Bug Fixes**
  - Removed unexpected black borders in Notes and Mosaic drag/split previews with themed CSS overrides.
  - Debounced writes, safe per-file hydration, and flush-on-unmount to prevent missed or stale saves.

<sup>Written for commit faedf2d986706cf98d3297a242cba0461a1b5b17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

