### PR TITLE
fix(desktop): prevent Enter in search popovers from creating workspace

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -193,6 +193,8 @@ export function NewWorkspaceModal() {
 	}, [isOpen, selectedProjectId, mode]);
 
 	const handleKeyDown = (e: React.KeyboardEvent) => {
+		if (e.defaultPrevented) return;
+
 		const isTextareaTarget = e.target instanceof HTMLTextAreaElement;
 		const isSubmitShortcutInTextarea =
 			isTextareaTarget && (e.metaKey || e.ctrlKey);


### PR DESCRIPTION
## Summary
- Fixes workspace search keyboard navigation in the new workspace modal
- When pressing Enter in a cmdk Command search input (e.g., base branch selector popover), the event bubbled through the React portal to the Dialog's `handleKeyDown`, which intercepted it and triggered `handleCreateWorkspace` with the stale base branch value
- Added `e.defaultPrevented` guard so the dialog respects cmdk's prior handling of the Enter key

## Test plan
- [ ] Open new workspace modal, select a project, expand advanced options
- [ ] Open the base branch popover, type a search query, navigate with arrow keys to a non-first item
- [ ] Press Enter — should select the highlighted branch without creating a workspace
- [ ] Verify Cmd+Enter from the title textarea still creates a workspace
- [ ] Verify Enter from the branch name input still creates a workspace

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops Enter in cmdk search popovers inside the New Workspace modal from creating a workspace. The dialog now respects cmdk’s handling to avoid submitting with a stale base branch.

- **Bug Fixes**
  - Added an e.defaultPrevented guard in NewWorkspaceModal handleKeyDown so Enter selects the highlighted popover item only, while Cmd/Ctrl+Enter in the title textarea and Enter in the branch name input still submit as before.

<sup>Written for commit 8f93cbda2a9b7fb777824007c5a097c1be7c28ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved keyboard event handling in the new workspace modal to prevent duplicate or conflicting key actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->