### PR TITLE
fix(desktop): add zsh precmd hook to persist BIN_DIR in PATH

### DIFF
--- a/apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts
@@ -29,6 +29,11 @@ const TEST_PATHS: ShellWrapperPaths = {
 	ZSH_DIR: TEST_ZSH_DIR,
 	BASH_DIR: TEST_BASH_DIR,
 };
+const SPECIAL_SHELL_PATH_SEGMENT = `special $USER "quoted" 'single'`;
+
+function quoteShellLiteral(value: string): string {
+	return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
 
 function isZshAvailable(): boolean {
 	try {
@@ -70,16 +75,22 @@ describe("shell-wrappers", () => {
 		const zlogin = readFileSync(path.join(TEST_ZSH_DIR, ".zlogin"), "utf-8");
 
 		expect(zshenv).toContain('source "$_superset_home/.zshenv"');
-		expect(zshenv).toContain(`export ZDOTDIR="${TEST_ZSH_DIR}"`);
+		expect(zshenv).toContain(
+			`export ZDOTDIR=${quoteShellLiteral(TEST_ZSH_DIR)}`,
+		);
 		expect(zprofile).toContain('export ZDOTDIR="$_superset_home"');
 		expect(zprofile).toContain('source "$_superset_home/.zprofile"');
-		expect(zprofile).toContain(`export ZDOTDIR="${TEST_ZSH_DIR}"`);
+		expect(zprofile).toContain(
+			`export ZDOTDIR=${quoteShellLiteral(TEST_ZSH_DIR)}`,
+		);
 		expect(zprofile.indexOf('export ZDOTDIR="$_superset_home"')).toBeLessThan(
 			zprofile.indexOf('source "$_superset_home/.zprofile"'),
 		);
 
 		expect(zshrc).toContain("_superset_prepend_bin()");
-		expect(zshrc.split(`export PATH="${TEST_BIN_DIR}:$PATH"`)).toHaveLength(2);
+		expect(zshrc).toContain(
+			`export PATH=${quoteShellLiteral(TEST_BIN_DIR)}:"$PATH"`,
+		);
 		expect(zshrc).not.toContain(`claude() { "${TEST_BIN_DIR}/claude" "$@"; }`);
 		expect(zshrc).toContain("rehash 2>/dev/null || true");
 		expect(zshrc).toContain('export ZDOTDIR="$_superset_home"');
@@ -103,6 +114,9 @@ describe("shell-wrappers", () => {
 		);
 		expect(zlogin).toContain("_superset_prepend_bin()");
 		expect(zlogin).toContain(
+			`export PATH=${quoteShellLiteral(TEST_BIN_DIR)}:"$PATH"`,
+		);
+		expect(zlogin).toContain(
 			"typeset -ga precmd_functions 2>/dev/null || true",
 		);
 		expect(zlogin).toContain(
@@ -121,12 +135,16 @@ describe("shell-wrappers", () => {
 		const rcfile = readFileSync(path.join(TEST_BASH_DIR, "rcfile"), "utf-8");
 
 		expect(zshrc).toContain("_superset_prepend_bin()");
-		expect(zshrc.split(`export PATH="${TEST_BIN_DIR}:$PATH"`)).toHaveLength(2);
+		expect(zshrc).toContain(
+			`export PATH=${quoteShellLiteral(TEST_BIN_DIR)}:"$PATH"`,
+		);
 		expect(zshrc).not.toContain(`claude() { "${TEST_BIN_DIR}/claude" "$@"; }`);
 		expect(zlogin).toContain("_superset_prepend_bin()");
 		expect(zlogin).not.toContain(`claude() { "${TEST_BIN_DIR}/claude" "$@"; }`);
 		expect(rcfile).toContain("_superset_prepend_bin()");
-		expect(rcfile.split(`export PATH="${TEST_BIN_DIR}:$PATH"`)).toHaveLength(2);
+		expect(rcfile).toContain(
+			`export PATH=${quoteShellLiteral(TEST_BIN_DIR)}:"$PATH"`,
+		);
 		expect(rcfile).not.toContain(`claude() { "${TEST_BIN_DIR}/claude" "$@"; }`);
 	});
 
@@ -218,7 +236,9 @@ fi
 
 		const rcfile = readFileSync(path.join(TEST_BASH_DIR, "rcfile"), "utf-8");
 		expect(rcfile).toContain("_superset_prepend_bin()");
-		expect(rcfile.split(`export PATH="${TEST_BIN_DIR}:$PATH"`)).toHaveLength(2);
+		expect(rcfile).toContain(
+			`export PATH=${quoteShellLiteral(TEST_BIN_DIR)}:"$PATH"`,
+		);
 		expect(rcfile).not.toContain(`claude() { "${TEST_BIN_DIR}/claude" "$@"; }`);
 		expect(rcfile).toContain("hash -r 2>/dev/null || true");
 	});
@@ -229,10 +249,10 @@ fi
 		const args = getCommandShellArgs("/bin/zsh", "echo ok", TEST_PATHS);
 		expect(args[0]).toBe("-lc");
 		expect(args[1]).toContain(
-			`source "${path.join(TEST_ZSH_DIR, ".zshrc")}" &&`,
+			`source ${quoteShellLiteral(path.join(TEST_ZSH_DIR, ".zshrc"))} &&`,
 		);
 		expect(args[1]).toContain(
-			`_superset_wrapper="${path.join(TEST_BIN_DIR, "claude")}"`,
+			`_superset_wrapper=${quoteShellLiteral(path.join(TEST_BIN_DIR, "claude"))}`,
 		);
 		expect(args[1]).toContain('command claude "$@"');
 		expect(args[1]).toContain("echo ok");
@@ -242,10 +262,10 @@ fi
 		const args = getCommandShellArgs("/bin/zsh", "echo ok", TEST_PATHS);
 		expect(args[0]).toBe("-lc");
 		expect(args[1]).not.toContain(
-			`source "${path.join(TEST_ZSH_DIR, ".zshrc")}" &&`,
+			`source ${quoteShellLiteral(path.join(TEST_ZSH_DIR, ".zshrc"))} &&`,
 		);
 		expect(args[1]).toContain(
-			`_superset_wrapper="${path.join(TEST_BIN_DIR, "claude")}"`,
+			`_superset_wrapper=${quoteShellLiteral(path.join(TEST_BIN_DIR, "claude"))}`,
 		);
 		expect(args[1]).toContain('command claude "$@"');
 		expect(args[1]).toContain("echo ok");
@@ -465,6 +485,47 @@ precmd_functions+=(_mise_hook_precmd)
 		expect(typeLine).toContain(integrationBinDir);
 	});
 
+	it("zsh wrappers treat special characters in generated paths literally", () => {
+		if (!isZshAvailable()) return;
+
+		const integrationRoot = path.join(TEST_ROOT, SPECIAL_SHELL_PATH_SEGMENT);
+		const integrationBinDir = path.join(integrationRoot, "superset-bin");
+		const integrationZshDir = path.join(integrationRoot, "zsh");
+		const integrationBashDir = path.join(integrationRoot, "bash");
+		const homeDir = path.join(integrationRoot, "home");
+
+		mkdirSync(integrationBinDir, { recursive: true });
+		mkdirSync(integrationZshDir, { recursive: true });
+		mkdirSync(integrationBashDir, { recursive: true });
+		mkdirSync(homeDir, { recursive: true });
+
+		writeFileSync(
+			path.join(integrationBinDir, "claude"),
+			"#!/usr/bin/env bash\necho wrapper\n",
+		);
+		chmodSync(path.join(integrationBinDir, "claude"), 0o755);
+		writeFileSync(path.join(homeDir, ".zshrc"), "\n");
+		writeFileSync(path.join(homeDir, ".zlogin"), "\n");
+
+		createZshWrapper({
+			BIN_DIR: integrationBinDir,
+			ZSH_DIR: integrationZshDir,
+			BASH_DIR: integrationBashDir,
+		});
+
+		const output = execFileSync("zsh", ["-lic", "claude"], {
+			encoding: "utf-8",
+			env: {
+				HOME: homeDir,
+				PATH: "/usr/bin:/bin",
+				SUPERSET_ORIG_ZDOTDIR: homeDir,
+				ZDOTDIR: integrationZshDir,
+			},
+		}).trim();
+
+		expect(output.trim()).toBe("wrapper");
+	});
+
 	it("zsh startup remains healthy when precmd_functions is readonly", () => {
 		if (!isZshAvailable()) return;
 
@@ -505,6 +566,52 @@ typeset -gr -a precmd_functions
 		}).trim();
 
 		expect(output).toBe("STARTUP_OK");
+	});
+
+	it("bash managed commands treat special characters in wrapper paths literally", () => {
+		const integrationRoot = path.join(TEST_ROOT, SPECIAL_SHELL_PATH_SEGMENT);
+		const homeDir = path.join(integrationRoot, "home");
+		const systemBinDir = path.join(integrationRoot, "system-bin");
+		const specialPaths: ShellWrapperPaths = {
+			BIN_DIR: path.join(integrationRoot, "bin"),
+			ZSH_DIR: path.join(integrationRoot, "zsh"),
+			BASH_DIR: path.join(integrationRoot, "bash"),
+		};
+
+		mkdirSync(homeDir, { recursive: true });
+		mkdirSync(systemBinDir, { recursive: true });
+		mkdirSync(specialPaths.BIN_DIR, { recursive: true });
+		mkdirSync(specialPaths.BASH_DIR, { recursive: true });
+
+		writeFileSync(
+			path.join(systemBinDir, "claude"),
+			`#!/usr/bin/env bash
+echo system
+`,
+		);
+		chmodSync(path.join(systemBinDir, "claude"), 0o755);
+
+		writeFileSync(
+			path.join(specialPaths.BIN_DIR, "claude"),
+			`#!/usr/bin/env bash
+echo wrapper
+`,
+		);
+		chmodSync(path.join(specialPaths.BIN_DIR, "claude"), 0o755);
+
+		createBashWrapper(specialPaths);
+
+		const args = getCommandShellArgs("/bin/bash", "claude", specialPaths);
+		const output = execFileSync("bash", args, {
+			encoding: "utf-8",
+			env: {
+				...process.env,
+				HOME: homeDir,
+				PATH: `${systemBinDir}:/usr/bin:/bin`,
+			},
+		}).trim();
+
+		expect(output).toBe("wrapper");
 	});
 
 	describe("fish shell", () => {

--- a/apps/desktop/src/main/lib/agent-setup/shell-wrappers.ts
+++ b/apps/desktop/src/main/lib/agent-setup/shell-wrappers.ts
@@ -22,6 +22,10 @@ function getShellName(shell: string): string {
 	return shell.split("/").pop() || shell;
 }
 
+function quoteShellLiteral(value: string): string {
+	return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
 function logModeDiagnostics(shellName: string): void {
 	const key = `${shellName}:native`;
 	if (modeDiagnosticsLogged.has(key)) return;
@@ -82,7 +86,7 @@ end`,
 		(name) =>
 			`unalias ${name} 2>/dev/null || true
 ${name}() {
-  _superset_wrapper="${binDir}/${name}"
+  _superset_wrapper=${quoteShellLiteral(`${binDir}/${name}`)}
   if [ -x "$_superset_wrapper" ] && [ ! -d "$_superset_wrapper" ]; then
     "$_superset_wrapper" "$@"
   else
@@ -96,8 +100,8 @@ ${name}() {
 function buildPathPrependFunction(binDir: string): string {
 	return `_superset_prepend_bin() {
   case ":$PATH:" in
-    *:"${binDir}":*) ;;
-    *) export PATH="${binDir}:$PATH" ;;
+    *:${quoteShellLiteral(binDir)}:*) ;;
+    *) export PATH=${quoteShellLiteral(binDir)}:"$PATH" ;;
   esac
 }
 _superset_prepend_bin`;
@@ -113,8 +117,8 @@ function buildZshPrecmdHook(binDir: string): string {
 	return `typeset -ga precmd_functions 2>/dev/null || true
 _superset_ensure_path() {
   case ":$PATH:" in
-    *:"${binDir}":*) ;;
-    *) PATH="${binDir}:$PATH" ;;
+    *:${quoteShellLiteral(binDir)}:*) ;;
+    *) PATH=${quoteShellLiteral(binDir)}:"$PATH" ;;
   esac
 }
 {
@@ -134,6 +138,7 @@ export function createZshWrapper(
 	paths: ShellWrapperPaths = DEFAULT_PATHS,
 ): void {
 	logModeDiagnostics("zsh");
+	const quotedZshDir = quoteShellLiteral(paths.ZSH_DIR);
 
 	// .zshenv is always sourced first by zsh (interactive + non-interactive).
 	// Temporarily restore the user's ZDOTDIR while sourcing user config, then
@@ -143,7 +148,7 @@ export function createZshWrapper(
 _superset_home="\${SUPERSET_ORIG_ZDOTDIR:-$HOME}"
 export ZDOTDIR="$_superset_home"
 [[ -f "$_superset_home/.zshenv" ]] && source "$_superset_home/.zshenv"
-export ZDOTDIR="${paths.ZSH_DIR}"
+export ZDOTDIR=${quotedZshDir}
 `;
 	const wroteZshenv = writeFileIfChanged(zshenvPath, zshenvScript, 0o644);
 
@@ -154,7 +159,7 @@ export ZDOTDIR="${paths.ZSH_DIR}"
 _superset_home="\${SUPERSET_ORIG_ZDOTDIR:-$HOME}"
 export ZDOTDIR="$_superset_home"
 [[ -f "$_superset_home/.zprofile" ]] && source "$_superset_home/.zprofile"
-export ZDOTDIR="${paths.ZSH_DIR}"
+export ZDOTDIR=${quotedZshDir}
 `;
 	const wroteZprofile = writeFileIfChanged(zprofilePath, zprofileScript, 0o644);
 
@@ -168,7 +173,7 @@ ${buildPathPrependFunction(paths.BIN_DIR)}
 ${buildZshPrecmdHook(paths.BIN_DIR)}
 rehash 2>/dev/null || true
 # Restore ZDOTDIR so our .zlogin runs after user's .zlogin
-export ZDOTDIR="${paths.ZSH_DIR}"
+export ZDOTDIR=${quotedZshDir}
 `;
 	const wroteZshrc = writeFileIfChanged(zshrcPath, zshrcScript, 0o644);
 
@@ -288,10 +293,16 @@ export function getCommandShellArgs(
 	const bashRcfile = path.join(paths.BASH_DIR, "rcfile");
 	const commandWithManagedPrelude = `${buildManagedCommandPrelude(shellName, paths.BIN_DIR)}\n${command}`;
 	if (shellName === "zsh" && fs.existsSync(zshRc)) {
-		return ["-lc", `source "${zshRc}" &&\n${commandWithManagedPrelude}`];
+		return [
+			"-lc",
+			`source ${quoteShellLiteral(zshRc)} &&\n${commandWithManagedPrelude}`,
+		];
 	}
 	if (shellName === "bash" && fs.existsSync(bashRcfile)) {
-		return ["-c", `source "${bashRcfile}" &&\n${commandWithManagedPrelude}`];
+		return [
+			"-c",
+			`source ${quoteShellLiteral(bashRcfile)} &&\n${commandWithManagedPrelude}`,
+		];
 	}
 	return ["-lc", commandWithManagedPrelude];
 }


### PR DESCRIPTION
## Summary

Tools like `mise` and `asdf` register zsh `precmd` hooks that dynamically reconstruct `PATH` on every prompt. This removes `~/.superset/bin` added by the zsh wrapper, causing agent wrapper binaries (`claude`, `codex`, etc.) to resolve to their original paths and bypass Superset's lifecycle hooks.

**Root cause**: `mise activate zsh` installs a `precmd` hook that rebuilds PATH from shims, dropping any entries added earlier by Superset's `.zshrc` wrapper.

**Fix**: Add a zsh `precmd` hook (via `add-zsh-hook`) in the `.zshrc` wrapper that re-asserts `BIN_DIR` at the front of PATH after every prompt. The hook is idempotent — it only prepends when `BIN_DIR` is missing.

### Why this approach

- Uses the same mechanism (`precmd`) that causes the problem, ensuring correct execution order
- Non-invasive: doesn't override user shell functions (avoids conflict with #1812)
- Idempotent `case` guard prevents PATH duplication across nested shells

## Changes

- `shell-wrappers.ts`: Added `buildZshPrecmdHook()` function and integrated it into the `.zshrc` wrapper template
- `shell-wrappers.test.ts`: Added assertions for precmd hook presence in generated `.zshrc`

## Test plan

- [x] Existing tests pass (15/15)
- [x] New assertions verify precmd hook is present in `.zshrc` output
- [ ] Manual verification: open Superset terminal with `mise activate zsh` → confirm `which claude` resolves to `~/.superset/bin/claude`
- [ ] Verify agent status indicators (working/permission/review) appear in sidebar during active sessions

Fixes #2068

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep ~/.superset/bin at the front of PATH in zsh with an idempotent precmd hook that runs last and stays safe under strict configs. Also quote all generated wrapper paths so PATH updates and managed commands work with spaces and special characters (Fixes #2068).

- **Bug Fixes**
  - Register the hook via precmd_functions and keep it last; integrate into both .zshrc and .zlogin to survive PATH rebuilds from tools like mise/asdf without duplicates.
  - Best-effort registration when precmd_functions is readonly to avoid shell startup failures.
  - Quote ZDOTDIR, BIN_DIR, sourced rc paths, and managed command targets; update PATH exports to use literal quoting; add tests for special-character paths and late .zlogin PATH resets; extract isZshAvailable() to skip where zsh is unavailable.

<sup>Written for commit a3d77240f73cdfdd3b4a937afd70648d5209ef3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * zsh startup now re-asserts the app bin directory during startup to ensure the correct CLI is used, even when user startup hooks modify PATH or make precmd hooks readonly.
  * Wrapper generation now safely quotes paths and home-dotfile locations so special characters in paths are handled literally.

* **Tests**
  * Expanded tests cover precmd hook registration, PATH preservation, quoting of special-paths, and skip gracefully if zsh is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->