### PR TITLE
fix(desktop): preserve tab state by keeping workspace tabs mounted

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/BrowserPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/BrowserPane.tsx
@@ -15,6 +15,8 @@ interface BrowserPaneProps {
 	paneId: string;
 	path: MosaicBranch[];
 	tabId: string;
+	/** Whether this pane's tab is currently active/visible */
+	isActive?: boolean;
 	splitPaneAuto: (
 		tabId: string,
 		sourcePaneId: string,
@@ -29,6 +31,7 @@ export function BrowserPane({
 	paneId,
 	path,
 	tabId,
+	isActive: _isActive,
 	splitPaneAuto,
 	removePane,
 	setFocusedPane,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraPane.tsx
@@ -24,6 +24,8 @@ interface ChatMastraPaneProps {
 	path: MosaicBranch[];
 	tabId: string;
 	workspaceId: string;
+	/** Whether this pane's tab is currently active/visible */
+	isActive?: boolean;
 	splitPaneAuto: (
 		tabId: string,
 		sourcePaneId: string,
@@ -52,6 +54,7 @@ export function ChatMastraPane({
 	path,
 	tabId,
 	workspaceId,
+	isActive: _isActive,
 	splitPaneAuto,
 	splitPaneHorizontal,
 	splitPaneVertical,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/DevToolsPane/DevToolsPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/DevToolsPane/DevToolsPane.tsx
@@ -24,18 +24,23 @@ export function DevToolsPane({
 	path,
 	tabId,
 	targetPaneId,
-	isActive: _isActive,
+	isActive = true,
 	splitPaneAuto,
 	removePane,
 	setFocusedPane,
 }: DevToolsPaneProps) {
 	// Query the CDP debug server for the DevTools frontend URL.
 	// Poll every 1s until a URL is obtained (the browser webview may still be loading).
+	// Pause polling when pane is inactive to reduce background work.
 	const { data } = electronTrpc.browser.getDevToolsUrl.useQuery(
 		{ browserPaneId: targetPaneId },
 		{
 			refetchOnWindowFocus: false,
-			refetchInterval: (query) => (query.state.data?.url ? false : 1000),
+			refetchInterval: (query) => {
+				// Don't poll when inactive or when URL is already obtained
+				if (!isActive || query.state.data?.url) return false;
+				return 1000;
+			},
 		},
 	);
 	const devToolsUrl = data?.url;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/DevToolsPane/DevToolsPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/DevToolsPane/DevToolsPane.tsx
@@ -7,6 +7,8 @@ interface DevToolsPaneProps {
 	path: MosaicBranch[];
 	tabId: string;
 	targetPaneId: string;
+	/** Whether this pane's tab is currently active/visible */
+	isActive?: boolean;
 	splitPaneAuto: (
 		tabId: string,
 		sourcePaneId: string,
@@ -22,6 +24,7 @@ export function DevToolsPane({
 	path,
 	tabId,
 	targetPaneId,
+	isActive: _isActive,
 	splitPaneAuto,
 	removePane,
 	setFocusedPane,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
@@ -20,6 +20,8 @@ interface FileViewerPaneProps {
 	path: MosaicBranch[];
 	tabId: string;
 	worktreePath: string;
+	/** Whether this pane's tab is currently active/visible */
+	isActive?: boolean;
 	splitPaneAuto: (
 		tabId: string,
 		sourcePaneId: string,
@@ -48,6 +50,7 @@ export function FileViewerPane({
 	path,
 	tabId,
 	worktreePath,
+	isActive: _isActive,
 	splitPaneAuto,
 	splitPaneHorizontal,
 	splitPaneVertical,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/TabPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/TabPane.tsx
@@ -17,6 +17,8 @@ interface TabPaneProps {
 	path: MosaicBranch[];
 	tabId: string;
 	workspaceId: string;
+	/** Whether this pane's tab is currently active/visible */
+	isActive?: boolean;
 	splitPaneAuto: (
 		tabId: string,
 		sourcePaneId: string,
@@ -45,6 +47,7 @@ export function TabPane({
 	path,
 	tabId,
 	workspaceId,
+	isActive: _isActive,
 	splitPaneAuto,
 	splitPaneHorizontal,
 	splitPaneVertical,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
@@ -27,9 +27,11 @@ import { TabPane } from "./TabPane";
 
 interface TabViewProps {
 	tab: Tab;
+	/** Whether this tab is currently active/visible. Can be used by panes to throttle expensive effects. */
+	isActive?: boolean;
 }
 
-export function TabView({ tab }: TabViewProps) {
+export function TabView({ tab, isActive = true }: TabViewProps) {
 	const activeTheme = useTheme();
 	const updateTabLayout = useTabsStore((s) => s.updateTabLayout);
 	const removePane = useTabsStore((s) => s.removePane);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
@@ -164,6 +164,7 @@ export function TabView({ tab, isActive = true }: TabViewProps) {
 						path={path}
 						tabId={tab.id}
 						worktreePath={worktreePath}
+						isActive={isActive}
 						splitPaneAuto={splitPaneAuto}
 						splitPaneHorizontal={splitPaneHorizontal}
 						splitPaneVertical={splitPaneVertical}
@@ -184,6 +185,7 @@ export function TabView({ tab, isActive = true }: TabViewProps) {
 						path={path}
 						tabId={tab.id}
 						workspaceId={tab.workspaceId}
+						isActive={isActive}
 						splitPaneAuto={splitPaneAuto}
 						splitPaneHorizontal={splitPaneHorizontal}
 						splitPaneVertical={splitPaneVertical}
@@ -203,6 +205,7 @@ export function TabView({ tab, isActive = true }: TabViewProps) {
 						paneId={paneId}
 						path={path}
 						tabId={tab.id}
+						isActive={isActive}
 						splitPaneAuto={splitPaneAuto}
 						removePane={removePane}
 						setFocusedPane={setFocusedPane}
@@ -218,6 +221,7 @@ export function TabView({ tab, isActive = true }: TabViewProps) {
 						path={path}
 						tabId={tab.id}
 						targetPaneId={paneInfo.devtools.targetPaneId}
+						isActive={isActive}
 						splitPaneAuto={splitPaneAuto}
 						removePane={removePane}
 						setFocusedPane={setFocusedPane}
@@ -232,6 +236,7 @@ export function TabView({ tab, isActive = true }: TabViewProps) {
 					path={path}
 					tabId={tab.id}
 					workspaceId={tab.workspaceId}
+					isActive={isActive}
 					splitPaneAuto={splitPaneAuto}
 					splitPaneHorizontal={splitPaneHorizontal}
 					splitPaneVertical={splitPaneVertical}
@@ -248,6 +253,7 @@ export function TabView({ tab, isActive = true }: TabViewProps) {
 			tab.id,
 			tab.workspaceId,
 			worktreePath,
+			isActive,
 			splitPaneAuto,
 			splitPaneHorizontal,
 			splitPaneVertical,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/index.tsx
@@ -55,7 +55,7 @@ export function TabsContent({
 						key={tab.id}
 						className={`w-full h-full ${tab.id === activeTabId ? "block" : "hidden"}`}
 					>
-						<TabView tab={tab} />
+						<TabView tab={tab} isActive={tab.id === activeTabId} />
 					</div>
 				))
 			) : (

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/index.tsx
@@ -38,15 +38,26 @@ export function TabsContent({
 		return resolvedActiveTabId;
 	}, [activeWorkspaceId, activeTabIds, allTabs, tabHistoryStacks]);
 
-	const tabToRender = useMemo(() => {
-		if (!activeTabId) return null;
-		return allTabs.find((tab) => tab.id === activeTabId) || null;
-	}, [activeTabId, allTabs]);
+	// Get all tabs for the current workspace to keep them mounted
+	const workspaceTabs = useMemo(() => {
+		if (!activeWorkspaceId) return [];
+		return allTabs.filter((tab) => tab.workspaceId === activeWorkspaceId);
+	}, [activeWorkspaceId, allTabs]);
+
+	const hasActiveTabs = workspaceTabs.length > 0 && activeTabId !== null;
 
 	return (
 		<div className="flex-1 min-h-0 flex overflow-hidden">
-			{tabToRender ? (
-				<TabView tab={tabToRender} />
+			{hasActiveTabs ? (
+				// Render all workspace tabs, hide inactive ones to preserve state
+				workspaceTabs.map((tab) => (
+					<div
+						key={tab.id}
+						className={`w-full h-full ${tab.id === activeTabId ? "block" : "hidden"}`}
+					>
+						<TabView tab={tab} />
+					</div>
+				))
 			) : (
 				<EmptyTabView
 					defaultExternalApp={defaultExternalApp}


### PR DESCRIPTION
## Description
Keeps all workspace tabs mounted (but hidden) instead of unmounting on tab switch. This preserves scroll position, input state, and prevents the double input bar issue.

Previously, switching away from a terminal/chat tab would unmount the component entirely, causing:
- Double input bar on return (component reinitializing)
- Scroll position reset to bottom
- Loss of any transient UI state

This change keeps all tabs within a workspace mounted but hides inactive ones with CSS. The active tab is shown with `display:block` while inactive tabs use `display:hidden` (Tailwind).

## Related Issues
Fixes #1830
Related to #1935, #1637

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing
1. Open a terminal tab, run commands to generate output
2. Scroll up in the terminal
3. Switch to another tab
4. Switch back — scroll position should be preserved
5. Verify no duplicate input bars appear
6. Test browser pane — page should not reload on tab switch

## Additional Notes
- Minimal change: 1 file, ~15 lines modified
- Uses existing Tailwind classes (`hidden`/`block`)
- Memory tradeoff: tabs stay mounted, but this matches user expectation and prevents state loss

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep workspace tabs mounted to preserve scroll/input state and avoid reloads. Propagate isActive to panes and pause DevTools CDP polling when the tab is hidden.

- **Bug Fixes**
  - Render all tabs in the active workspace; show active with block, hide others with hidden.
  - Preserve scroll and input state; no duplicate input bar or unwanted reloads.
  - Pass isActive from TabsContent to TabView and all panes; DevToolsPane uses it to stop CDP URL polling when inactive.

<sup>Written for commit 5287ba5b73096d83c9059d18375c84eb58d969f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Keeps all workspace tabs mounted so switching preserves component state and user input.
  * Renders multiple per-workspace tab containers, showing the active tab while hiding others to maintain state.
  * Improved empty-state: displays a clear view when a workspace has no tabs.
  * Tabs now report active/inactive status to enable more efficient background handling.

* **Performance**
  * DevTools polling now pauses when a pane is inactive, reducing unnecessary work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->