### PR TITLE
fix(desktop): truncate long URLs in browser toolbar

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserToolbar/BrowserToolbar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserToolbar/BrowserToolbar.tsx
@@ -195,7 +195,7 @@ export function BrowserToolbar({
 							</span>
 						) : (
 							<>
-								<span className="shrink-0 whitespace-nowrap text-muted-foreground/60 transition-colors group-hover:text-foreground">
+								<span className="min-w-0 truncate text-muted-foreground/60 transition-colors group-hover:text-foreground">
 									{url}
 								</span>
 								{pageTitle && (


### PR DESCRIPTION
## Summary
- Fix browser URL overflowing and overlapping with nav bar buttons (back/forward/reload, split, close, devtools)
- Changed URL span from `shrink-0 whitespace-nowrap` to `min-w-0 truncate` so long URLs truncate with ellipsis instead of overflowing

## Test plan
- [ ] Open a browser pane and navigate to a page with a very long URL
- [ ] Verify the URL truncates with ellipsis and does not overlap the right-side action buttons
- [ ] Verify clicking the URL bar still enters edit mode with the full URL
- [ ] Verify short URLs still display normally without truncation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Truncate long URLs with ellipsis in the desktop browser toolbar to prevent overlap with navigation buttons. Editing still shows the full URL; short URLs display normally.

<sup>Written for commit aed7bac0f014487f605e621db0c68db254555cca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL display in the browser toolbar to properly truncate long URLs with ellipsis instead of affecting layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->