### PR TITLE
Fix PR detection matching for workspaces

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/changes/git-operations.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/git-operations.ts
@@ -154,7 +154,6 @@ function extractPRUrl(text: string): string | null {
 
 async function findExistingOpenPRUrl(
 	worktreePath: string,
-	branch: string,
 ): Promise<string | null> {
 	// Prefer tracking-based lookup first for fork/branch-name mismatch scenarios.
 	try {
@@ -185,10 +184,31 @@ async function findExistingOpenPRUrl(
 				message,
 			);
 		}
-		// Fallback to head-branch search below.
+		// Fallback to commit-SHA search below.
 	}
 
+	const byHeadCommit = await findOpenPRByHeadCommit(worktreePath);
+	if (byHeadCommit) {
+		return byHeadCommit;
+	}
+
+	return null;
+}
+
+async function findOpenPRByHeadCommit(
+	worktreePath: string,
+): Promise<string | null> {
 	try {
+		const { stdout: headOutput } = await execWithShellEnv(
+			"git",
+			["rev-parse", "HEAD"],
+			{ cwd: worktreePath },
+		);
+		const headSha = headOutput.trim();
+		if (!headSha) {
+			return null;
+		}
+
 		const { stdout } = await execWithShellEnv(
 			"gh",
 			[
@@ -197,22 +217,25 @@ async function findExistingOpenPRUrl(
 				"--state",
 				"open",
 				"--search",
-				`head:${branch}`,
+				`${headSha} is:pr`,
 				"--limit",
 				"20",
 				"--json",
-				"url",
-				"--jq",
-				'.[0].url // ""',
+				"url,headRefOid",
 			],
 			{ cwd: worktreePath },
 		);
-		const url = stdout.trim();
-		return url || null;
+
+		const parsed = JSON.parse(stdout) as Array<{
+			url?: string;
+			headRefOid?: string;
+		}>;
+		const match = parsed.find((candidate) => candidate.headRefOid === headSha);
+		return match?.url?.trim() || null;
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		console.warn(
-			"[git/findExistingOpenPRUrl] Failed head-branch PR lookup:",
+			"[git/findExistingOpenPRUrl] Failed commit-based PR lookup:",
 			message,
 		);
 		return null;
@@ -424,10 +447,7 @@ export const createGitOperationsRouter = () => {
 						}
 					}
 
-					const existingPRUrl = await findExistingOpenPRUrl(
-						input.worktreePath,
-						branch,
-					);
+					const existingPRUrl = await findExistingOpenPRUrl(input.worktreePath);
 					if (existingPRUrl) {
 						await openPRInBrowser(input.worktreePath, existingPRUrl);
 						await fetchCurrentBranch(git);
@@ -448,7 +468,6 @@ export const createGitOperationsRouter = () => {
 						// recover by opening that existing PR instead of failing.
 						const recoveredPRUrl = await findExistingOpenPRUrl(
 							input.worktreePath,
-							branch,
 						);
 						if (recoveredPRUrl) {
 							await openPRInBrowser(input.worktreePath, recoveredPRUrl);

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.ts
@@ -41,7 +41,7 @@ export async function fetchGitHubPRStatus(
 
 		const [branchCheck, prInfo] = await Promise.all([
 			branchExistsOnRemote(worktreePath, branchName),
-			getPRForBranch(worktreePath, branchName),
+			getPRForBranch(worktreePath),
 		]);
 
 		const result: GitHubStatus = {
@@ -84,15 +84,13 @@ const PR_JSON_FIELDS =
 
 async function getPRForBranch(
 	worktreePath: string,
-	branchName: string,
 ): Promise<GitHubStatus["pr"]> {
 	const byTracking = await getPRByBranchTracking(worktreePath);
 	if (byTracking) {
 		return byTracking;
 	}
 
-	// Fallback for branches where local naming/casing diverges from PR head.
-	return findPRByHeadBranch(worktreePath, branchName);
+	return findPRByHeadCommit(worktreePath);
 }
 
 /**
@@ -130,11 +128,24 @@ async function getPRByBranchTracking(
 	}
 }
 
-async function findPRByHeadBranch(
+/**
+ * Looks up PRs that have local HEAD as their head commit.
+ * This avoids matching unrelated PRs that merely contain the same commit.
+ */
+async function findPRByHeadCommit(
 	worktreePath: string,
-	branchName: string,
 ): Promise<GitHubStatus["pr"]> {
 	try {
+		const { stdout: headOutput } = await execFileAsync(
+			"git",
+			["-C", worktreePath, "rev-parse", "HEAD"],
+			{ timeout: 10_000 },
+		);
+		const headSha = headOutput.trim();
+		if (!headSha) {
+			return null;
+		}
+
 		const { stdout } = await execWithShellEnv(
 			"gh",
 			[
@@ -143,7 +154,7 @@ async function findPRByHeadBranch(
 				"--state",
 				"all",
 				"--search",
-				`head:${branchName}`,
+				`${headSha} is:pr`,
 				"--limit",
 				"20",
 				"--json",
@@ -154,7 +165,7 @@ async function findPRByHeadBranch(
 
 		const candidates = parsePRListResponse(stdout);
 		for (const candidate of candidates) {
-			if (await sharesAncestry(worktreePath, candidate.headRefOid)) {
+			if (candidate.headRefOid === headSha) {
 				return formatPRData(candidate);
 			}
 		}


### PR DESCRIPTION
## Summary
- keep tracking-based PR detection as the first lookup
- replace branch-name fallback with commit-based fallback in workspace status
- require exact `headRefOid == HEAD` in commit fallback to avoid cross-workspace false matches
- keep support for open/closed/merged/draft states in workspace status
- tighten create/open-PR lookup to commit-based open PR matching with exact head OID

## Validation
- bunx biome check on modified files
- bun test apps/desktop/src/lib/trpc/routers/changes/git-operations.test.ts
- verified in /Users/kietho/.superset/worktrees/superset/kitenite/tricky-heather that SHA search candidates exist but exact-head filter removes unrelated PR matches


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request detection logic to use commit-based matching, providing more reliable tracking and linking of open pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->