### PR TITLE
feat(desktop): double-click pane divider to equalize widths

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -11,6 +11,7 @@ import { useAppHotkey } from "renderer/stores/hotkeys";
 import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
 import {
 	COLLAPSED_WORKSPACE_SIDEBAR_WIDTH,
+	DEFAULT_WORKSPACE_SIDEBAR_WIDTH,
 	MAX_WORKSPACE_SIDEBAR_WIDTH,
 	useWorkspaceSidebarStore,
 } from "renderer/stores/workspace-sidebar-state";
@@ -101,6 +102,9 @@ function DashboardLayout() {
 						maxWidth={MAX_WORKSPACE_SIDEBAR_WIDTH}
 						handleSide="right"
 						clampWidth={false}
+						onDoubleClickHandle={() =>
+							setWorkspaceSidebarWidth(DEFAULT_WORKSPACE_SIDEBAR_WIDTH)
+						}
 					>
 						<WorkspaceSidebar
 							isCollapsed={isWorkspaceSidebarCollapsed()}

--- a/apps/desktop/src/renderer/screens/main/components/ResizablePanel/ResizablePanel.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/ResizablePanel/ResizablePanel.tsx
@@ -27,6 +27,8 @@ interface ResizablePanelProps {
 	 * @default true
 	 */
 	clampWidth?: boolean;
+	/** Callback when the resize handle is double-clicked */
+	onDoubleClickHandle?: () => void;
 }
 
 export function ResizablePanel({
@@ -40,6 +42,7 @@ export function ResizablePanel({
 	handleSide,
 	className,
 	clampWidth = true,
+	onDoubleClickHandle,
 }: ResizablePanelProps) {
 	const startXRef = useRef(0);
 	const startWidthRef = useRef(0);
@@ -137,6 +140,7 @@ export function ResizablePanel({
 				aria-valuemax={maxWidth}
 				tabIndex={0}
 				onMouseDown={handleMouseDown}
+				onDoubleClick={onDoubleClickHandle}
 				className={cn(
 					"absolute top-0 w-5 h-full cursor-col-resize z-10",
 					"after:absolute after:top-0 after:w-1 after:h-full after:transition-colors",

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/MosaicSplitOverlay/MosaicSplitOverlay.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/MosaicSplitOverlay/MosaicSplitOverlay.tsx
@@ -1,0 +1,265 @@
+import { cn } from "@superset/ui/utils";
+import { useCallback, useRef } from "react";
+import type { MosaicNode, MosaicPath } from "react-mosaic-component";
+
+interface BoundingBox {
+	top: number;
+	right: number;
+	bottom: number;
+	left: number;
+}
+
+interface SplitInfo {
+	path: MosaicPath;
+	direction: "row" | "column";
+	boundingBox: BoundingBox;
+	splitPercentage: number;
+}
+
+function getAbsoluteSplitPercentage(
+	box: BoundingBox,
+	splitPercentage: number,
+	direction: "row" | "column",
+): number {
+	if (direction === "column") {
+		const height = 100 - box.top - box.bottom;
+		return (height * splitPercentage) / 100 + box.top;
+	}
+	const width = 100 - box.right - box.left;
+	return (width * splitPercentage) / 100 + box.left;
+}
+
+function getRelativeSplitPercentage(
+	box: BoundingBox,
+	absolutePercentage: number,
+	direction: "row" | "column",
+): number {
+	if (direction === "column") {
+		const height = 100 - box.top - box.bottom;
+		return ((absolutePercentage - box.top) / height) * 100;
+	}
+	const width = 100 - box.right - box.left;
+	return ((absolutePercentage - box.left) / width) * 100;
+}
+
+function splitBox(
+	box: BoundingBox,
+	splitPercentage: number,
+	direction: "row" | "column",
+): { first: BoundingBox; second: BoundingBox } {
+	const abs = getAbsoluteSplitPercentage(box, splitPercentage, direction);
+	if (direction === "column") {
+		return {
+			first: { ...box, bottom: 100 - abs },
+			second: { ...box, top: abs },
+		};
+	}
+	return {
+		first: { ...box, right: 100 - abs },
+		second: { ...box, left: abs },
+	};
+}
+
+function collectSplits(
+	node: MosaicNode<string>,
+	box: BoundingBox,
+	path: MosaicPath,
+	out: SplitInfo[],
+): void {
+	if (typeof node === "string") return;
+
+	const pct = node.splitPercentage ?? 50;
+	out.push({
+		path,
+		direction: node.direction,
+		boundingBox: box,
+		splitPercentage: pct,
+	});
+
+	const { first, second } = splitBox(box, pct, node.direction);
+	collectSplits(node.first, first, [...path, "first"], out);
+	collectSplits(node.second, second, [...path, "second"], out);
+}
+
+const MIN_PERCENTAGE = 20;
+const HANDLE_SIZE = 20;
+
+function updateSplitPercentage(
+	node: MosaicNode<string>,
+	path: MosaicPath,
+	newPercentage: number,
+): MosaicNode<string> {
+	if (path.length === 0) {
+		if (typeof node === "string") return node;
+		return { ...node, splitPercentage: newPercentage };
+	}
+	if (typeof node === "string") return node;
+	const [head, ...rest] = path;
+	return {
+		...node,
+		[head]: updateSplitPercentage(node[head], rest, newPercentage),
+	};
+}
+
+function equalizeSplitPercentages(
+	node: MosaicNode<string>,
+): MosaicNode<string> {
+	if (typeof node === "string") return node;
+	return {
+		...node,
+		splitPercentage: 50,
+		first: equalizeSplitPercentages(node.first),
+		second: equalizeSplitPercentages(node.second),
+	};
+}
+
+interface MosaicSplitOverlayProps {
+	layout: MosaicNode<string>;
+	onLayoutChange: (layout: MosaicNode<string>) => void;
+}
+
+export function MosaicSplitOverlay({
+	layout,
+	onLayoutChange,
+}: MosaicSplitOverlayProps) {
+	const splits: SplitInfo[] = [];
+	const emptyBox: BoundingBox = { top: 0, right: 0, bottom: 0, left: 0 };
+	collectSplits(layout, emptyBox, [], splits);
+
+	if (splits.length === 0) return null;
+
+	return (
+		<>
+			{splits.map((split) => (
+				<SplitHandle
+					key={split.path.join(",")}
+					split={split}
+					layout={layout}
+					onLayoutChange={onLayoutChange}
+				/>
+			))}
+		</>
+	);
+}
+
+interface SplitHandleProps {
+	split: SplitInfo;
+	layout: MosaicNode<string>;
+	onLayoutChange: (layout: MosaicNode<string>) => void;
+}
+
+function SplitHandle({ split, layout, onLayoutChange }: SplitHandleProps) {
+	const containerRef = useRef<HTMLDivElement | null>(null);
+	const isDragging = useRef(false);
+
+	const absolutePosition = getAbsoluteSplitPercentage(
+		split.boundingBox,
+		split.splitPercentage,
+		split.direction,
+	);
+
+	const isRow = split.direction === "row";
+
+	const handleMouseDown = useCallback(
+		(e: React.MouseEvent) => {
+			e.preventDefault();
+			e.stopPropagation();
+			isDragging.current = true;
+
+			const root = containerRef.current?.closest(
+				".mosaic-container",
+			) as HTMLElement | null;
+			if (!root) return;
+
+			document.body.style.userSelect = "none";
+			document.body.style.cursor = isRow ? "col-resize" : "row-resize";
+
+			const onMouseMove = (moveEvent: MouseEvent) => {
+				const rect = root.getBoundingClientRect();
+				let absolutePct: number;
+				if (isRow) {
+					absolutePct = ((moveEvent.clientX - rect.left) / rect.width) * 100;
+				} else {
+					absolutePct = ((moveEvent.clientY - rect.top) / rect.height) * 100;
+				}
+
+				const relativePct = getRelativeSplitPercentage(
+					split.boundingBox,
+					absolutePct,
+					split.direction,
+				);
+				const clamped = Math.max(
+					MIN_PERCENTAGE,
+					Math.min(100 - MIN_PERCENTAGE, relativePct),
+				);
+				const newLayout = updateSplitPercentage(layout, split.path, clamped);
+				onLayoutChange(newLayout);
+			};
+
+			const onMouseUp = () => {
+				isDragging.current = false;
+				document.body.style.userSelect = "";
+				document.body.style.cursor = "";
+				document.removeEventListener("mousemove", onMouseMove);
+				document.removeEventListener("mouseup", onMouseUp);
+			};
+
+			document.addEventListener("mousemove", onMouseMove);
+			document.addEventListener("mouseup", onMouseUp);
+		},
+		[
+			isRow,
+			layout,
+			onLayoutChange,
+			split.boundingBox,
+			split.direction,
+			split.path,
+		],
+	);
+
+	const handleDoubleClick = useCallback(
+		(e: React.MouseEvent) => {
+			e.preventDefault();
+			e.stopPropagation();
+			onLayoutChange(equalizeSplitPercentages(layout));
+		},
+		[layout, onLayoutChange],
+	);
+
+	const style: React.CSSProperties = isRow
+		? {
+				top: `${split.boundingBox.top}%`,
+				bottom: `${split.boundingBox.bottom}%`,
+				left: `calc(${absolutePosition}% - ${HANDLE_SIZE / 2}px)`,
+				width: HANDLE_SIZE,
+			}
+		: {
+				left: `${split.boundingBox.left}%`,
+				right: `${split.boundingBox.right}%`,
+				top: `calc(${absolutePosition}% - ${HANDLE_SIZE / 2}px)`,
+				height: HANDLE_SIZE,
+			};
+
+	return (
+		// biome-ignore lint/a11y/useSemanticElements: <hr> is not appropriate for interactive resize handles
+		<div
+			role="separator"
+			aria-orientation={isRow ? "vertical" : "horizontal"}
+			aria-valuenow={Math.round(split.splitPercentage)}
+			tabIndex={0}
+			ref={containerRef}
+			onMouseDown={handleMouseDown}
+			onDoubleClick={handleDoubleClick}
+			className={cn(
+				"absolute z-20",
+				isRow ? "cursor-col-resize" : "cursor-row-resize",
+				"after:absolute after:transition-colors",
+				"hover:after:bg-border",
+				isRow
+					? "after:top-0 after:bottom-0 after:left-1/2 after:-translate-x-1/2 after:w-px"
+					: "after:left-0 after:right-0 after:top-1/2 after:-translate-y-1/2 after:h-px",
+			)}
+			style={style}
+		/>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/MosaicSplitOverlay/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/MosaicSplitOverlay/index.ts
@@ -1,0 +1,1 @@
+export { MosaicSplitOverlay } from "./MosaicSplitOverlay";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/index.ts
@@ -1,2 +1,3 @@
 export { BasePaneWindow, type PaneHandlers } from "./BasePaneWindow";
+export { MosaicSplitOverlay } from "./MosaicSplitOverlay";
 export { PaneToolbarActions } from "./PaneToolbarActions";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
@@ -21,6 +21,7 @@ import {
 import { useTheme } from "renderer/stores/theme";
 import { BrowserPane } from "./BrowserPane";
 import { ChatMastraPane } from "./ChatMastraPane";
+import { MosaicSplitOverlay } from "./components";
 import { DevToolsPane } from "./DevToolsPane";
 import { FileViewerPane } from "./FileViewerPane";
 import { TabPane } from "./TabPane";
@@ -258,23 +259,35 @@ export function TabView({ tab }: TabViewProps) {
 		],
 	);
 
+	const handleSplitLayoutChange = useCallback(
+		(newLayout: MosaicNode<string>) => {
+			updateTabLayout(tab.id, newLayout);
+		},
+		[tab.id, updateTabLayout],
+	);
+
 	// Tab will be removed by useEffect above
 	if (!cleanedLayout) {
 		return null;
 	}
 
 	return (
-		<div className="w-full h-full mosaic-container">
+		<div className="relative w-full h-full mosaic-container">
 			<Mosaic<string>
 				renderTile={renderPane}
 				value={cleanedLayout}
 				onChange={handleLayoutChange}
+				resize="DISABLED"
 				className={
 					activeTheme?.type === "light"
 						? "mosaic-theme-light"
 						: "mosaic-theme-dark"
 				}
 				dragAndDropManager={dragDropManager}
+			/>
+			<MosaicSplitOverlay
+				layout={cleanedLayout}
+				onLayoutChange={handleSplitLayoutChange}
 			/>
 		</div>
 	);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceLayout/WorkspaceLayout.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceLayout/WorkspaceLayout.tsx
@@ -1,5 +1,6 @@
 import type { ExternalApp } from "@superset/local-db";
 import {
+	DEFAULT_SIDEBAR_WIDTH,
 	MAX_SIDEBAR_WIDTH,
 	MIN_SIDEBAR_WIDTH,
 	SidebarMode,
@@ -55,6 +56,7 @@ export function WorkspaceLayout({
 					maxWidth={MAX_SIDEBAR_WIDTH}
 					handleSide="left"
 					className={isExpanded ? "border-l-0" : undefined}
+					onDoubleClickHandle={() => setSidebarWidth(DEFAULT_SIDEBAR_WIDTH)}
 				>
 					<RightSidebar />
 				</ResizablePanel>

--- a/apps/desktop/src/renderer/stores/sidebar-state.ts
+++ b/apps/desktop/src/renderer/stores/sidebar-state.ts
@@ -11,7 +11,7 @@ export enum RightSidebarTab {
 	Files = "files",
 }
 
-const DEFAULT_SIDEBAR_WIDTH = 250;
+export const DEFAULT_SIDEBAR_WIDTH = 250;
 export const MIN_SIDEBAR_WIDTH = 200;
 export const MAX_SIDEBAR_WIDTH = 500;
 

--- a/apps/desktop/src/renderer/stores/workspace-sidebar-state.ts
+++ b/apps/desktop/src/renderer/stores/workspace-sidebar-state.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { devtools, persist } from "zustand/middleware";
 
-const DEFAULT_WORKSPACE_SIDEBAR_WIDTH = 280;
+export const DEFAULT_WORKSPACE_SIDEBAR_WIDTH = 280;
 export const COLLAPSED_WORKSPACE_SIDEBAR_WIDTH = 52;
 const MIN_WORKSPACE_SIDEBAR_WIDTH = 220;
 export const MAX_WORKSPACE_SIDEBAR_WIDTH = 400;

--- a/bun.lock
+++ b/bun.lock
@@ -109,7 +109,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.43",
         "@ai-sdk/openai": "3.0.36",


### PR DESCRIPTION
## Summary
- Double-click any sidebar divider to reset it to its default width (250px for right sidebar, 280px for workspace sidebar)
- Double-click any content pane divider to equalize all panes to 50/50
- Replaces mosaic's built-in `Split` component with a custom `MosaicSplitOverlay` that handles both drag resize and double-click natively

Closes SUPER-360

## Test plan
- [ ] Split workspace into 2+ panes, resize them unevenly, double-click a divider — all panes should equalize to 50/50
- [ ] Drag resize on content pane dividers still works normally
- [ ] Double-click right sidebar divider — resets to 250px
- [ ] Double-click workspace sidebar divider — resets to 280px
- [ ] Horizontal (column) splits also work correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add double-click to all split handles for fast layout resets. Sidebars snap to default widths; content panes equalize to 50/50. Satisfies SUPER-360.

- **New Features**
  - Double-click right sidebar handle resets to 250px.
  - Double-click workspace sidebar handle resets to 280px.
  - Double-click any content split equalizes all panes to 50/50 (rows and columns).
  - Drag resizing still works.

- **Refactors**
  - Replaced Mosaic’s built-in resize with MosaicSplitOverlay that handles drag and double-click (Mosaic rendered with resize="DISABLED").
  - ResizablePanel adds onDoubleClickHandle and is wired in dashboard/workspace layouts to reset using DEFAULT_SIDEBAR_WIDTH and DEFAULT_WORKSPACE_SIDEBAR_WIDTH.

<sup>Written for commit 2456b6da7534b46e9838e5805e8cdae994d0a01d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Double-click workspace and sidebar resize handles to reset to default widths.
  * Drag split-panel handles to resize and adjust layout proportions via an interactive overlay.
  * Double-click split handles to equalize panels to 50%.
  * Improved split-handle interactions with keyboard/pointer accessibility cues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->