### PR TITLE
fix(desktop): use shell.openExternal for mailto links on billing plans page

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/plans/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/plans/page.tsx
@@ -365,7 +365,7 @@ function PlansPage() {
 						<button
 							type="button"
 							onClick={() => {
-								track("enterprise_trial_requested", {
+								track("billing_support_contacted", {
 									source: "billing_plans_inline",
 								});
 								openUrl.mutate("mailto:founders@superset.sh");


### PR DESCRIPTION
## Summary
- The "Request a trial" button and "contact us" link on the Enterprise plan card used `window.open("mailto:...")` which doesn't open the email client in Electron
- Replaced with `electronTrpc.external.openUrl` which calls `shell.openExternal()` — the correct Electron API for mailto links

## Test plan
- [ ] Open Settings > Billing > Plans
- [ ] Click "Request a trial" on the Enterprise card — should open default email client
- [ ] Click "contact us" link in the plan description — should open default email client

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mailto links on the desktop Billing > Plans page by routing through electronTrpc.external.openUrl (shell.openExternal) so “Request a trial” and inline “contact us” open the default email client. Adds analytics: enterprise_trial_requested for the trial button (source: billing_plans) and billing_support_contacted for the inline link (source: billing_plans_inline).

<sup>Written for commit f27d6364c70ad7fe35c5b7d8dc27a2bbb8aeadb3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added analytics events to the billing plans flow to record contact and trial requests.

* **Refactor**
  * Billing contact actions now use the app’s native URL opener instead of direct window navigation.
  * Replaced inline mailto links with button-driven actions for more consistent handling and tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->