### PR TITLE
fix(desktop): match Projects section heading style in settings sidebar

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/ProjectsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/ProjectsSettings.tsx
@@ -38,8 +38,8 @@ export function ProjectsSettings({ searchQuery }: ProjectsSettingsProps) {
 	}
 
 	return (
-		<div className="mb-4">
-			<h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wider px-3 mb-2">
+		<div className="mt-4 mb-4">
+			<h2 className="text-[10px] font-medium text-muted-foreground/60 uppercase tracking-[0.1em] px-3 mb-1">
 				Projects
 				{searchQuery && hasProjectMatches && (
 					<span className="ml-2 text-xs bg-accent/50 px-1.5 py-0.5 rounded">


### PR DESCRIPTION
## Summary
- Aligned the "Projects" section heading in the settings sidebar to use the same styles as all other section headings (`text-[10px]`, `muted-foreground/60`, `tracking-[0.1em]`, `mb-1`)
- Added `mt-4` top margin for consistent spacing between sections

## Test plan
- [ ] Open Settings sidebar and verify the "Projects" heading matches the style of "System", "Personal", etc.
- [ ] Verify spacing between the last general section and "Projects" is consistent with spacing between other sections

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned the Projects heading in the Settings sidebar with other section headings and added top margin for consistent spacing between sections.

<sup>Written for commit e374cd7a406278cc6c9e94c2114fa5f8dec0e464. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated visual styling of the Projects settings header with adjusted spacing and typography.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->