### PR TITLE
fix(desktop): remove severity colors from resource monitor indicator

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/components/MetricBadge/MetricBadge.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/components/MetricBadge/MetricBadge.tsx
@@ -1,33 +1,18 @@
-import { cn } from "@superset/ui/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
-import type { UsageSeverity } from "../../types";
-import { getUsageClasses } from "../../utils/resourceSeverity";
 
 interface MetricBadgeProps {
 	label: string;
 	value: string;
-	severity?: UsageSeverity;
 	tooltip?: string;
 }
 
-export function MetricBadge({
-	label,
-	value,
-	severity = "normal",
-	tooltip,
-}: MetricBadgeProps) {
-	const classes = getUsageClasses(severity);
+export function MetricBadge({ label, value, tooltip }: MetricBadgeProps) {
 	const content = (
 		<div className="min-w-0 px-1 py-0.5">
 			<span className="block text-[10px] text-muted-foreground uppercase tracking-wide whitespace-nowrap">
 				{label}
 			</span>
-			<span
-				className={cn(
-					"block text-base leading-5 font-medium tabular-nums whitespace-nowrap",
-					classes.metricClass,
-				)}
-			>
+			<span className="block text-base leading-5 font-medium tabular-nums whitespace-nowrap text-muted-foreground">
 				{value}
 			</span>
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/components/UsageSeverityBadge/UsageSeverityBadge.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/components/UsageSeverityBadge/UsageSeverityBadge.tsx
@@ -1,23 +1,9 @@
-import { cn } from "@superset/ui/lib/utils";
 import type { UsageSeverity } from "../../types";
 
 interface UsageSeverityBadgeProps {
 	severity: UsageSeverity;
 }
 
-export function UsageSeverityBadge({ severity }: UsageSeverityBadgeProps) {
-	if (severity === "normal") return null;
-
-	return (
-		<span
-			className={cn(
-				"rounded px-1 py-0.5 text-[10px] font-medium",
-				severity === "high" && "bg-destructive/12 text-destructive/90",
-				severity === "elevated" &&
-					"bg-amber-500/12 text-amber-700 dark:text-amber-300",
-			)}
-		>
-			{severity === "high" ? "Hot" : "Elevated"}
-		</span>
-	);
+export function UsageSeverityBadge(_props: UsageSeverityBadgeProps) {
+	return null;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/utils/resourceSeverity.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/utils/resourceSeverity.ts
@@ -39,29 +39,11 @@ export function getUsageSeverity(
 }
 
 export function getUsageClasses(
-	severity: UsageSeverity,
+	_severity: UsageSeverity,
 	nested = false,
 ): UsageClasses {
 	const normalRowClass = nested ? "bg-muted/30" : "";
 	const normalHoverClass = nested ? "hover:bg-muted/60" : "hover:bg-muted/50";
-
-	if (severity === "high") {
-		return {
-			rowClass: nested ? "bg-destructive/6" : "bg-destructive/4",
-			hoverClass: nested ? "hover:bg-destructive/10" : "hover:bg-destructive/8",
-			labelClass: "text-foreground",
-			metricClass: "text-destructive/90",
-		};
-	}
-
-	if (severity === "elevated") {
-		return {
-			rowClass: nested ? "bg-amber-500/8" : "bg-amber-500/4",
-			hoverClass: nested ? "hover:bg-amber-500/12" : "hover:bg-amber-500/8",
-			labelClass: "text-foreground",
-			metricClass: "text-amber-700 dark:text-amber-300",
-		};
-	}
 
 	return {
 		rowClass: normalRowClass,


### PR DESCRIPTION
## Summary
- Remove red/amber severity coloring from the resource consumption monitor in the top bar
- Metrics now always display in neutral muted colors regardless of usage level
- Severity detection logic is preserved for potential future use

## Test plan
- [ ] Open the resource consumption popover and verify all metrics display in neutral colors
- [ ] Trigger high CPU/memory usage and confirm no red/amber coloring appears

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed severity-based colors from the desktop Resource Consumption monitor so all metrics show in neutral muted text. Severity detection remains in code but no longer renders in the UI.

- **Refactors**
  - MetricBadge: removed severity prop/handling; metric value uses text-muted-foreground.
  - UsageSeverityBadge: now always returns null (no “Hot”/“Elevated” badges).
  - resourceSeverity: getUsageClasses ignores severity; dropped elevated/high branches and kept neutral defaults.

<sup>Written for commit f7a2dd2f73c3e0cc4f5f3477ca56a82e024acb02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified MetricBadge component by removing severity-based styling and indicators.
  * Removed severity badges from the resource consumption display.
  * Added tooltip support to metric badges for providing contextual information.
  * Streamlined component interfaces by removing unused severity parameters.
  * Updated internal utility functions to reduce complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->