### PR TITLE
fix(desktop): mock process.platform in getAppCommand tests for CI

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/external/helpers.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/helpers.test.ts
@@ -4,6 +4,16 @@ import path from "node:path";
 import { getAppCommand, resolvePath, stripPathWrappers } from "./helpers";
 
 describe("getAppCommand", () => {
+	const originalPlatform = process.platform;
+
+	beforeEach(() => {
+		Object.defineProperty(process, "platform", { value: "darwin" });
+	});
+
+	afterEach(() => {
+		Object.defineProperty(process, "platform", { value: originalPlatform });
+	});
+
 	test("returns null for finder (handled specially)", () => {
 		expect(getAppCommand("finder", "/path/to/file")).toBeNull();
 	});


### PR DESCRIPTION
## Summary
- `getAppCommand` tests hardcoded macOS expectations (`open -a`) but CI runs on Linux, causing all assertions to fail
- Added `beforeEach`/`afterEach` hooks to mock `process.platform` as `"darwin"` so tests pass on all platforms

## Test plan
- [x] Tests pass locally (99/99)
- [x] Typecheck passes
- [x] Lint passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mocked process.platform to "darwin" in getAppCommand tests so macOS-specific "open -a" expectations pass in Linux CI, ensuring cross-platform test consistency.

<sup>Written for commit c2063718f6a694dc5cc4cc330948de08eeea4935. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure for improved cross-platform testing reliability by properly mocking the operating system platform during test execution. Ensures consistent test behavior across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->