### PR TITLE
fix(ports): respect browser preference when opening detected ports

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/components/MergedPortBadge/MergedPortBadge.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/components/MergedPortBadge/MergedPortBadge.tsx
@@ -1,6 +1,7 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useNavigate } from "@tanstack/react-router";
 import { LuExternalLink, LuX } from "react-icons/lu";
+import { electronTrpc } from "renderer/lib/electron-trpc";
 import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import type { EnrichedPort } from "shared/types";
@@ -16,6 +17,9 @@ export function MergedPortBadge({ port }: MergedPortBadgeProps) {
 	const setActiveTab = useTabsStore((s) => s.setActiveTab);
 	const setFocusedPane = useTabsStore((s) => s.setFocusedPane);
 	const openInBrowserPane = useTabsStore((s) => s.openInBrowserPane);
+	const { data: openLinksInApp } =
+		electronTrpc.settings.getOpenLinksInApp.useQuery();
+	const openUrl = electronTrpc.external.openUrl.useMutation();
 	const { killPort } = useKillPort();
 
 	const displayContent = port.label ? (
@@ -43,8 +47,15 @@ export function MergedPortBadge({ port }: MergedPortBadgeProps) {
 	};
 
 	const handleOpenInBrowser = () => {
-		navigateToWorkspace(port.workspaceId, navigate);
-		openInBrowserPane(port.workspaceId, `http://localhost:${port.port}`);
+		const url = `http://localhost:${port.port}`;
+
+		if (openLinksInApp) {
+			navigateToWorkspace(port.workspaceId, navigate);
+			openInBrowserPane(port.workspaceId, url);
+			return;
+		}
+
+		openUrl.mutate(url);
 	};
 
 	const handleClose = () => {


### PR DESCRIPTION
## Summary\n- read the `Open links in app browser` setting before handling port badge open actions\n- open detected ports in the in-app browser only when that setting is enabled\n- otherwise open detected ports in the system browser via `external.openUrl`\n\n## Validation\n- `bunx biome check apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/components/MergedPortBadge/MergedPortBadge.tsx`\n\nCloses #1797

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opening a port now respects the "Open links in app browser" setting, addressing Linear #1797. When enabled, ports open in the in-app browser; otherwise they open in the system browser via external.openUrl.

<sup>Written for commit f288f317e6312ca1c2198780f5b9352fdbb958f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for opening links within the app based on user preference settings, with fallback to open externally when disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->