### PR TITLE
fix(desktop): make terminal OSC8 links open on Cmd/Ctrl+click

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -5,7 +5,7 @@ import { ImageAddon } from "@xterm/addon-image";
 import { LigaturesAddon } from "@xterm/addon-ligatures";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebglAddon } from "@xterm/addon-webgl";
-import type { ITheme } from "@xterm/xterm";
+import type { ILinkHandler, ITheme } from "@xterm/xterm";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { debounce } from "lodash";
 import { electronTrpcClient as trpcClient } from "renderer/lib/trpc-client";
@@ -190,7 +190,37 @@ export function createTerminalInstance(
 
 	// Use provided theme, or fall back to localStorage-based default to prevent flash
 	const theme = initialTheme ?? getDefaultTerminalTheme();
-	const terminalOptions = { ...TERMINAL_OPTIONS, theme };
+
+	const openUrl = (uri: string) => {
+		const handler = urlClickRef?.current;
+		if (handler) {
+			handler(uri);
+			return;
+		}
+		trpcClient.external.openUrl.mutate(uri).catch((error) => {
+			console.error("[Terminal] Failed to open URL:", uri, error);
+			toast.error("Failed to open URL", {
+				description:
+					error instanceof Error
+						? error.message
+						: "Could not open URL in browser",
+			});
+		});
+	};
+
+	// Handle OSC 8 hyperlinks (e.g. Claude Code footer links) using the same
+	// Cmd/Ctrl+click behavior as plain URL links.
+	const linkHandler: ILinkHandler = {
+		activate: (event, text) => {
+			if (!event.metaKey && !event.ctrlKey) {
+				return;
+			}
+			event.preventDefault();
+			openUrl(text);
+		},
+	};
+
+	const terminalOptions = { ...TERMINAL_OPTIONS, theme, linkHandler };
 	const xterm = new XTerm(terminalOptions);
 	const fitAddon = new FitAddon();
 
@@ -244,20 +274,7 @@ export function createTerminalInstance(
 	const cleanupQuerySuppression = suppressQueryResponses(xterm);
 
 	const urlLinkProvider = new UrlLinkProvider(xterm, (_event, uri) => {
-		const handler = urlClickRef?.current;
-		if (handler) {
-			handler(uri);
-			return;
-		}
-		trpcClient.external.openUrl.mutate(uri).catch((error) => {
-			console.error("[Terminal] Failed to open URL:", uri, error);
-			toast.error("Failed to open URL", {
-				description:
-					error instanceof Error
-						? error.message
-						: "Could not open URL in browser",
-			});
-		});
+		openUrl(uri);
 	});
 	xterm.registerLinkProvider(urlLinkProvider);
 


### PR DESCRIPTION
## Summary\n- configure xterm  so OSC 8 hyperlinks (like Claude Code PR review footer links) are handled in Superset\n- require Cmd/Ctrl+click for activation to match existing terminal URL/file-link behavior\n- route OSC 8 link opens through the same  path used by plain URL links, preserving the in-app browser/external browser setting\n\n## Why\nThe terminal already handles plain URLs via a custom link provider, but OSC 8 hyperlinks had no explicit handler configured. In practice this made PR Review status links non-clickable in Superset.\n\n## Testing\n- bun test v1.3.8 (b64edcb4)\n\nCloses #1061

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Cmd/Ctrl+click to open OSC 8 hyperlinks in the desktop terminal, matching existing URL behavior and respecting the in-app/external browser setting. Fixes non-clickable PR Review footer links (addresses #1061).

- **Bug Fixes**
  - Added xterm linkHandler for OSC 8 links.
  - Required Cmd/Ctrl+click to activate links.
  - Centralized URL opening via a shared openUrl helper used by both OSC 8 handler and UrlLinkProvider.

<sup>Written for commit 7e07b67e7076ff698f339ee6c5dcb52748331565. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Terminal hyperlinks are now clickable—hold Cmd/Ctrl and click to open URLs
  * Improved URL handling with centralized error management and notifications
  * Enhanced link consistency and reliability throughout the terminal

<!-- end of auto-generated comment: release notes by coderabbit.ai -->