### PR TITLE
fix(settings): show workspace name/context in Manage sessions

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/SessionsSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/SessionsSection.tsx
@@ -17,11 +17,22 @@ export function SessionsSection() {
 
 	const { data: daemonSessions } =
 		electronTrpc.terminal.listDaemonSessions.useQuery();
+	const { data: allWorkspaces } = electronTrpc.workspaces.getAll.useQuery();
 	const sessions = daemonSessions?.sessions ?? [];
 	const aliveSessions = useMemo(
 		() => sessions.filter((session) => session.isAlive),
 		[sessions],
 	);
+	const workspaceNames = useMemo(() => {
+		if (!allWorkspaces) return {};
+		return allWorkspaces.reduce(
+			(acc, workspace) => {
+				acc[workspace.id] = workspace.name;
+				return acc;
+			},
+			{} as Record<string, string>,
+		);
+	}, [allWorkspaces]);
 	const sessionsSorted = useMemo(() => {
 		return [...aliveSessions].sort((a, b) => {
 			if (a.attachedClients !== b.attachedClients) {
@@ -200,7 +211,9 @@ export function SessionsSection() {
 										<th className="px-2 py-2 text-left font-medium">
 											Workspace
 										</th>
-										<th className="px-2 py-2 text-left font-medium">Session</th>
+										<th className="px-2 py-2 text-left font-medium">
+											Session / Created
+										</th>
 										<th className="px-2 py-2 text-right font-medium">
 											Clients
 										</th>
@@ -214,11 +227,22 @@ export function SessionsSection() {
 								<tbody className="divide-y divide-border/60">
 									{sessionsSorted.map((session) => (
 										<tr key={session.sessionId} className="hover:bg-muted/30">
-											<td className="px-2 py-2 font-mono">
-												{session.workspaceId}
+											<td className="px-2 py-2 align-top">
+												<div className="min-w-0">
+													<div className="truncate font-medium">
+														{workspaceNames[session.workspaceId] ??
+															"Unknown workspace"}
+													</div>
+													<div className="font-mono text-[11px] text-muted-foreground">
+														{session.workspaceId}
+													</div>
+												</div>
 											</td>
-											<td className="px-2 py-2 font-mono">
-												{session.sessionId}
+											<td className="px-2 py-2 align-top">
+												<div className="font-mono">{session.sessionId}</div>
+												<div className="text-[11px] text-muted-foreground">
+													{formatTimestamp(session.createdAt)}
+												</div>
 											</td>
 											<td className="px-2 py-2 text-right">
 												{session.attachedClients}


### PR DESCRIPTION
## Summary\n- fetch workspace metadata in terminal settings\n- show each session's workspace name (plus workspace id) in the Manage sessions table\n- show session created timestamp under session id to make rows easier to identify\n\nCloses #1356\n\n## Validation\n- Checked 1 file in 5ms. No fixes applied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show workspace names (with IDs) and session creation times in Terminal Settings → Manage sessions to make rows easier to identify. Implements Linear #1356 by fetching workspace metadata and adding the created time under each session ID, with a fallback to “Unknown workspace” if a name isn’t available.

<sup>Written for commit afbf5be963fd61639825b0a25d66261bd164c711. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Terminal sessions now display the workspace name alongside the workspace ID
- Session creation timestamps are now visible with formatted display
- Updated "Session" column header to "Session / Created" to reflect enhanced information display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->