### PR TITLE
fix(desktop): make terminal Cmd/Ctrl+click links work for OSC 8 hyperlinks

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -5,7 +5,7 @@ import { ImageAddon } from "@xterm/addon-image";
 import { LigaturesAddon } from "@xterm/addon-ligatures";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebglAddon } from "@xterm/addon-webgl";
-import type { ITheme } from "@xterm/xterm";
+import type { ILinkHandler, ITheme } from "@xterm/xterm";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { debounce } from "lodash";
 import { electronTrpcClient as trpcClient } from "renderer/lib/trpc-client";
@@ -190,7 +190,37 @@ export function createTerminalInstance(
 
 	// Use provided theme, or fall back to localStorage-based default to prevent flash
 	const theme = initialTheme ?? getDefaultTerminalTheme();
-	const terminalOptions = { ...TERMINAL_OPTIONS, theme };
+
+	const openUrl = (uri: string) => {
+		const handler = urlClickRef?.current;
+		if (handler) {
+			handler(uri);
+			return;
+		}
+		trpcClient.external.openUrl.mutate(uri).catch((error) => {
+			console.error("[Terminal] Failed to open URL:", uri, error);
+			toast.error("Failed to open URL", {
+				description:
+					error instanceof Error
+						? error.message
+						: "Could not open URL in browser",
+			});
+		});
+	};
+
+	// Handle OSC 8 hyperlinks (e.g. Claude Code footer links) using the same
+	// Cmd/Ctrl+click behavior as plain URL links.
+	const linkHandler: ILinkHandler = {
+		activate: (event, text) => {
+			if (!event.metaKey && !event.ctrlKey) {
+				return;
+			}
+			event.preventDefault();
+			openUrl(text);
+		},
+	};
+
+	const terminalOptions = { ...TERMINAL_OPTIONS, theme, linkHandler };
 	const xterm = new XTerm(terminalOptions);
 	const fitAddon = new FitAddon();
 
@@ -244,20 +274,7 @@ export function createTerminalInstance(
 	const cleanupQuerySuppression = suppressQueryResponses(xterm);
 
 	const urlLinkProvider = new UrlLinkProvider(xterm, (_event, uri) => {
-		const handler = urlClickRef?.current;
-		if (handler) {
-			handler(uri);
-			return;
-		}
-		trpcClient.external.openUrl.mutate(uri).catch((error) => {
-			console.error("[Terminal] Failed to open URL:", uri, error);
-			toast.error("Failed to open URL", {
-				description:
-					error instanceof Error
-						? error.message
-						: "Could not open URL in browser",
-			});
-		});
+		openUrl(uri);
 	});
 	xterm.registerLinkProvider(urlLinkProvider);
 


### PR DESCRIPTION
## Summary
- add an explicit xterm link handler so OSC 8 hyperlinks are handled in the desktop terminal
- require Cmd/Ctrl+click in that handler to match existing terminal URL/file-link activation behavior
- route OSC 8 opens through the same openUrl helper used by the custom URL link provider, preserving existing in-app/external browser behavior and error toast handling

## Why
Terminal output can include OSC 8 hyperlinks (for example in tool-generated output). Without an explicit link handler, these links were not reliably activating on Cmd/Ctrl+click.

## Testing
- bun test apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/url-link-provider.test.ts

Closes #1836


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Cmd/Ctrl+click to open OSC 8 hyperlinks in the desktop terminal. Matches existing terminal link behavior and preserves in-app/external routing and error toasts. Addresses Linear issue #1836.

- **Bug Fixes**
  - Added an explicit xterm ILinkHandler for OSC 8 hyperlinks with Cmd/Ctrl+click activation.
  - Routed opens through the shared openUrl helper (urlClickRef → trpc external.openUrl) to reuse existing behavior and error handling.
  - Kept handling consistent with the UrlLinkProvider for plain URL links.

<sup>Written for commit 99a572e9f12d501a13e0ce67b7805d620b25b647. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clickable hyperlink support in Terminal with Cmd/Ctrl-click activation
  * Improved URL handling with enhanced error reporting via notifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->