### PR TITLE
fix: preserve case in branch prefix to prevent worktree corruption

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
@@ -394,7 +394,7 @@ export async function getBranchPrefix({
 		case "author": {
 			const authorName = await getGitAuthorName(repoPath);
 			if (authorName) {
-				return authorName.toLowerCase().replace(/\s+/g, "-");
+				return authorName.replace(/\s+/g, "-");
 			}
 			return null;
 		}

--- a/apps/desktop/src/shared/utils/branch.test.ts
+++ b/apps/desktop/src/shared/utils/branch.test.ts
@@ -68,25 +68,29 @@ describe("sanitizeSegment", () => {
 });
 
 describe("sanitizeAuthorPrefix", () => {
-	test("lowercases and trims", () => {
-		expect(sanitizeAuthorPrefix("  John Doe  ")).toBe("john-doe");
+	test("preserves case and trims", () => {
+		expect(sanitizeAuthorPrefix("  John Doe  ")).toBe("John-Doe");
 	});
 
 	test("replaces spaces with hyphens", () => {
-		expect(sanitizeAuthorPrefix("John Doe")).toBe("john-doe");
+		expect(sanitizeAuthorPrefix("John Doe")).toBe("John-Doe");
+	});
+
+	test("preserves GitHub username case", () => {
+		expect(sanitizeAuthorPrefix("Kitenite")).toBe("Kitenite");
 	});
 
 	test("removes special characters but keeps underscores and dots", () => {
-		expect(sanitizeAuthorPrefix("John's Name!")).toBe("johns-name");
+		expect(sanitizeAuthorPrefix("John's Name!")).toBe("Johns-Name");
 		expect(sanitizeAuthorPrefix("user_name")).toBe("user_name");
 	});
 
 	test("collapses multiple hyphens", () => {
-		expect(sanitizeAuthorPrefix("John--Doe")).toBe("john-doe");
+		expect(sanitizeAuthorPrefix("John--Doe")).toBe("John-Doe");
 	});
 
 	test("removes leading/trailing hyphens", () => {
-		expect(sanitizeAuthorPrefix("-John-")).toBe("john");
+		expect(sanitizeAuthorPrefix("-John-")).toBe("John");
 	});
 
 	test("handles empty string", () => {

--- a/apps/desktop/src/shared/utils/branch.ts
+++ b/apps/desktop/src/shared/utils/branch.ts
@@ -18,8 +18,29 @@ export function sanitizeSegment(
 		.slice(0, maxLength);
 }
 
+/**
+ * Like sanitizeSegment but preserves the original case.
+ * Used for author/GitHub username prefixes where case must match
+ * the git ref exactly to avoid case-mismatch issues with packed-refs.
+ */
+function sanitizeSegmentPreserveCase(
+	text: string,
+	maxLength = DEFAULT_BRANCH_SEGMENT_MAX_LENGTH,
+): string {
+	return text
+		.trim()
+		.replace(/\s+/g, "-")
+		.replace(/[^a-zA-Z0-9._+@-]/g, "")
+		.replace(/\.{2,}/g, ".")
+		.replace(/@\{/g, "@")
+		.replace(/-+/g, "-")
+		.replace(/^[-.]|[-.]+$/g, "")
+		.replace(/\.lock$/g, "")
+		.slice(0, maxLength);
+}
+
 export function sanitizeAuthorPrefix(name: string): string {
-	return sanitizeSegment(name);
+	return sanitizeSegmentPreserveCase(name);
 }
 
 export function sanitizeBranchName(name: string): string {
@@ -111,5 +132,5 @@ export function resolveBranchPrefix({
 		default:
 			return null;
 	}
-	return prefix ? sanitizeSegment(prefix) : null;
+	return prefix ? sanitizeSegmentPreserveCase(prefix) : null;
 }


### PR DESCRIPTION
## Problem

When creating workspaces, the branch prefix (GitHub username / git author name) was being lowercased. For example, `Kitenite` became `kitenite`, creating branches like `kitenite/easy-earthquake`.

When these branches are pushed to GitHub and later packed locally, `packed-refs` stores the canonical casing from the remote (`Kitenite/easy-earthquake`). On macOS's case-insensitive filesystem, loose ref files ignore case, but `packed-refs` uses exact string matching. The lowercase HEAD reference couldn't resolve against the uppercase packed ref, causing:
- Worktrees showing **"No commits yet"**
- `git status` returning null commits (`000000000`)
- Recurring corruption across all worktrees

## When it happens

During workspace creation in `create.ts`:
1. `getBranchPrefix()` fetches the author name/GitHub username
2. `sanitizeAuthorPrefix()` sanitizes it — **lowercasing in the process**
3. Branch is created with lowercase prefix
4. After push + pack, case mismatch breaks the worktree

## Fix

Three locations were lowercasing the prefix:
- `sanitizeAuthorPrefix()` → delegated to `sanitizeSegment()` which calls `.toLowerCase()`
- `getBranchPrefix()` "author" mode → explicitly called `.toLowerCase()`
- `resolveBranchPrefix()` → passed prefix through `sanitizeSegment()`

Added `sanitizeSegmentPreserveCase()` that applies the same sanitization (trim, replace spaces, remove special chars, collapse dots/hyphens) **without lowercasing**. Used it in `sanitizeAuthorPrefix()` and `resolveBranchPrefix()`. Removed `.toLowerCase()` from `getBranchPrefix()` author mode.

## Files changed

- `apps/desktop/src/shared/utils/branch.ts` — added `sanitizeSegmentPreserveCase()`, updated `sanitizeAuthorPrefix()` and `resolveBranchPrefix()`
- `apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts` — removed `.toLowerCase()` from `getBranchPrefix()` author mode
- `apps/desktop/src/shared/utils/branch.test.ts` — updated tests to expect case-preserved output

## Test plan

```
bun test apps/desktop/src/shared/utils/branch.test.ts
# 38 pass, 0 fail
```

Verified existing worktrees with uppercase `Kitenite/` prefix continue to work. New workspaces will now create branches with the original-cased prefix, matching what GitHub stores.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves branch prefix case (author/GitHub username) to match remote refs and prevent worktree corruption after refs are packed. Fixes "No commits yet" and 000000000 statuses on macOS.

- **Bug Fixes**
  - Added sanitizeSegmentPreserveCase to sanitize without lowercasing.
  - Used it in sanitizeAuthorPrefix and resolveBranchPrefix.
  - Removed .toLowerCase() from getBranchPrefix (author mode).
  - Updated tests to expect case-preserved output.

<sup>Written for commit ab0dbc669b4c3fad6b178c9fc83d6f29cb65d396. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Branch prefixes now preserve the original capitalization of author names instead of converting them to lowercase (e.g., "John Doe" becomes "John-Doe" instead of "john-doe").

* **Tests**
  * Updated test cases to verify case-preserving behavior in branch name generation with various inputs and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->