### PR TITLE
fix(desktop): derive default branch slug from workspace prompt

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -24,10 +24,8 @@ import {
 	useNewWorkspaceModalOpen,
 	usePreSelectedProjectId,
 } from "renderer/stores/new-workspace-modal";
-import {
-	resolveBranchPrefix,
-	sanitizeBranchNameWithMaxLength,
-} from "shared/utils/branch";
+import { resolveBranchPrefix, sanitizeBranchNameWithMaxLength } from "shared/utils/branch";
+import { resolveWorkspaceBranchDraft } from "./workspaceBranchDraft";
 import type { ImportSourceTab } from "./components/ExistingWorktreesList";
 import { ImportFlow } from "./components/ImportFlow";
 import { NewWorkspaceAdvancedOptions } from "./components/NewWorkspaceAdvancedOptions";
@@ -161,11 +159,11 @@ export function NewWorkspaceModal() {
 		setBaseBranch(null);
 	}, [selectedProjectId]);
 
-	const branchSlug = branchNameEdited
-		? sanitizeBranchNameWithMaxLength(branchName)
-		: "";
-
-	const applyPrefix = !branchNameEdited;
+	const { branchSlug, applyPrefix } = resolveWorkspaceBranchDraft({
+		title,
+		branchName,
+		branchNameEdited,
+	});
 
 	const branchPreview =
 		branchSlug && applyPrefix && resolvedPrefix

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/workspaceBranchDraft.test.ts
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/workspaceBranchDraft.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { resolveWorkspaceBranchDraft } from "./workspaceBranchDraft";
+
+describe("resolveWorkspaceBranchDraft", () => {
+	test("uses sanitized title when branch name is not manually edited", () => {
+		expect(
+			resolveWorkspaceBranchDraft({
+				title: "  Fix branch name generation in modal  ",
+				branchName: "",
+				branchNameEdited: false,
+			}),
+		).toEqual({
+			branchSlug: "fix-branch-name-generation-in-modal",
+			applyPrefix: true,
+		});
+	});
+
+	test("uses sanitized custom branch name when manually edited", () => {
+		expect(
+			resolveWorkspaceBranchDraft({
+				title: "ignored title",
+				branchName: "Feature/Use Better Branch",
+				branchNameEdited: true,
+			}),
+		).toEqual({
+			branchSlug: "feature/use-better-branch",
+			applyPrefix: false,
+		});
+	});
+
+	test("returns empty branch slug when source input is blank", () => {
+		expect(
+			resolveWorkspaceBranchDraft({
+				title: "   ",
+				branchName: "",
+				branchNameEdited: false,
+			}),
+		).toEqual({
+			branchSlug: "",
+			applyPrefix: true,
+		});
+	});
+});

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/workspaceBranchDraft.ts
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/workspaceBranchDraft.ts
@@ -1,0 +1,23 @@
+import { sanitizeBranchNameWithMaxLength } from "shared/utils/branch";
+
+interface ResolveWorkspaceBranchDraftInput {
+	title: string;
+	branchName: string;
+	branchNameEdited: boolean;
+}
+
+export function resolveWorkspaceBranchDraft({
+	title,
+	branchName,
+	branchNameEdited,
+}: ResolveWorkspaceBranchDraftInput): {
+	branchSlug: string;
+	applyPrefix: boolean;
+} {
+	const source = branchNameEdited ? branchName : title.trim();
+
+	return {
+		branchSlug: sanitizeBranchNameWithMaxLength(source),
+		applyPrefix: !branchNameEdited,
+	};
+}


### PR DESCRIPTION
## Summary\n- derive the default new-workspace branch slug from the "What do you want to do?" prompt when users do not manually edit branch name\n- keep manual branch edits authoritative and disable automatic prefixing only for manual edits\n- add focused unit tests for branch draft resolution logic\n\n## Testing\n- bun test apps/desktop/src/renderer/components/NewWorkspaceModal/workspaceBranchDraft.test.ts apps/desktop/src/shared/utils/branch.test.ts\n\nCloses #2094

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives the default branch slug from the workspace prompt when the branch name isn't edited (closes #2094). Manual edits remain authoritative and skip automatic prefixing.

- **Bug Fixes**
  - Extracted a resolver to compute branchSlug and applyPrefix in NewWorkspaceModal.
  - Added unit tests for title-derived slugs, manual edits, and blank inputs.

<sup>Written for commit 8de686ca79a7c6471b3dd13b0db956c84aee623a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal organization of workspace branch handling logic to enhance code maintainability.

* **Tests**
  * Added comprehensive test coverage for workspace branch handling across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->