### PR TITLE
fix(desktop): restore workspace alias dev display name

### DIFF
--- a/apps/desktop/scripts/patch-dev-protocol.test.ts
+++ b/apps/desktop/scripts/patch-dev-protocol.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+import { join } from "node:path";
+import {
+	deriveWorktreePathFromSegments,
+	getWorktreeSegmentsFromCwd,
+	resolveWorkspaceIdentity,
+} from "./patch-dev-protocol";
+
+const WORKTREE_BASE = join("/tmp", "superset-worktrees");
+
+describe("patch-dev-protocol workspace resolution", () => {
+	it("derives worktree segments from a desktop worktree cwd", () => {
+		const cwd = join(
+			WORKTREE_BASE,
+			"superset",
+			"kitenite",
+			"feature-2058",
+			"apps",
+			"desktop",
+		);
+
+		expect(getWorktreeSegmentsFromCwd(cwd, WORKTREE_BASE)).toEqual([
+			"superset",
+			"kitenite",
+			"feature-2058",
+			"apps",
+			"desktop",
+		]);
+	});
+
+	it("derives the worktree path without the apps/desktop suffix", () => {
+		expect(
+			deriveWorktreePathFromSegments(
+				["superset", "kitenite", "feature-2058", "apps", "desktop"],
+				WORKTREE_BASE,
+			),
+		).toBe(join(WORKTREE_BASE, "superset", "kitenite", "feature-2058"));
+	});
+
+	it("prefers the path-derived workspace name over a stale env value", () => {
+		const identity = resolveWorkspaceIdentity({
+			cwd: join(WORKTREE_BASE, "superset", "feature-2058", "apps", "desktop"),
+			envWorkspaceName: "stale-env-name",
+			worktreeBase: WORKTREE_BASE,
+		});
+
+		expect(identity.workspaceName).toBe("feature-2058");
+		expect(identity.displayWorkspaceName).toBe("feature-2058");
+		expect(identity.bundleDisplayWorkspaceName).toBe("feature-2058");
+	});
+
+	it("prefers the prod DB display name and sanitizes it for the bundle name", () => {
+		const worktreePath = join(WORKTREE_BASE, "superset", "feature-2058");
+		const identity = resolveWorkspaceIdentity({
+			cwd: join(worktreePath, "apps", "desktop"),
+			envWorkspaceName: "feature-2058",
+			worktreeBase: WORKTREE_BASE,
+			lookupDisplayName: (path) =>
+				path === worktreePath ? "Team/Alias" : undefined,
+		});
+
+		expect(identity.workspaceName).toBe("feature-2058");
+		expect(identity.displayWorkspaceName).toBe("Team/Alias");
+		expect(identity.bundleDisplayWorkspaceName).toBe("Team-Alias");
+	});
+
+	it("falls back to the env workspace name outside the worktree root", () => {
+		const identity = resolveWorkspaceIdentity({
+			cwd: join("/tmp", "not-a-worktree"),
+			envWorkspaceName: "env-workspace",
+			worktreeBase: WORKTREE_BASE,
+		});
+
+		expect(identity.workspaceName).toBe("env-workspace");
+		expect(identity.displayWorkspaceName).toBe("env-workspace");
+		expect(identity.bundleDisplayWorkspaceName).toBe("env-workspace");
+		expect(identity.worktreePath).toBeUndefined();
+	});
+});

--- a/apps/desktop/scripts/patch-dev-protocol.ts
+++ b/apps/desktop/scripts/patch-dev-protocol.ts
@@ -9,6 +9,7 @@
  * Needed because app.setAsDefaultProtocolClient() only works when packaged.
  */
 
+import { Database as BunSqliteDatabase } from "bun:sqlite";
 import { execSync } from "node:child_process";
 import {
 	existsSync,
@@ -38,203 +39,333 @@ import {
 	getWorkspaceName,
 } from "../src/shared/worktree-id";
 
-if (process.platform !== "darwin") {
-	console.log("[patch-dev-protocol] Skipping - not macOS");
-	process.exit(0);
-}
+const DEFAULT_WORKTREE_BASE = resolve(homedir(), ".superset/worktrees");
+const DEFAULT_PROD_DB_PATH = resolve(homedir(), ".superset/local.db");
 
-if (process.env.NODE_ENV !== "development") {
-	console.log("[patch-dev-protocol] Skipping - non-development mode");
-	process.exit(0);
-}
+type ResolveWorkspaceIdentityOptions = {
+	cwd?: string;
+	envWorkspaceName?: string;
+	lookupDisplayName?: (worktreePath: string) => string | undefined;
+	worktreeBase?: string;
+};
 
-function deriveWorkspaceNameFromPath(): string | undefined {
-	const worktreeBase = resolve(homedir(), ".superset/worktrees");
-	const cwdRelative = relative(worktreeBase, process.cwd());
+export function getWorktreeSegmentsFromCwd(
+	cwd = process.cwd(),
+	worktreeBase = DEFAULT_WORKTREE_BASE,
+): string[] | undefined {
+	const cwdRelative = relative(worktreeBase, cwd);
 
 	if (!cwdRelative || cwdRelative.startsWith("..") || isAbsolute(cwdRelative)) {
 		return undefined;
 	}
 
 	const segments = cwdRelative.split(sep).filter(Boolean);
+	return segments.length >= 2 ? segments : undefined;
+}
+
+export function deriveWorkspaceNameFromSegments(
+	segments: string[] | undefined,
+): string | undefined {
+	if (!segments) return undefined;
 	return deriveWorkspaceNameFromWorktreeSegments(segments);
 }
 
-const workspaceName = getWorkspaceName() ?? deriveWorkspaceNameFromPath();
-if (!workspaceName) {
-	console.log("[patch-dev-protocol] Skipping - workspace name not resolved");
-	process.exit(0);
-}
-const PROTOCOL_SCHEME = `superset-${workspaceName}`;
-const BUNDLE_ID = `com.superset.desktop.${workspaceName}`;
-const ELECTRON_DIST_DIR = resolve(
-	import.meta.dirname,
-	"../node_modules/electron/dist",
-);
-const ELECTRON_APP_PATH = resolve(ELECTRON_DIST_DIR, "Electron.app");
-const PLIST_PATH = resolve(ELECTRON_APP_PATH, "Contents/Info.plist");
+export function deriveWorktreePathFromSegments(
+	segments: string[] | undefined,
+	worktreeBase = DEFAULT_WORKTREE_BASE,
+): string | undefined {
+	if (!segments) return undefined;
 
-if (!existsSync(PLIST_PATH)) {
-	console.log("[patch-dev-protocol] Electron.app not found, skipping");
-	process.exit(0);
+	const appsIndex = segments.lastIndexOf("apps");
+	const endIndex =
+		appsIndex > 1 && segments[appsIndex + 1] === "desktop"
+			? appsIndex
+			: segments.length;
+	if (endIndex <= 1) return undefined;
+
+	return resolve(worktreeBase, ...segments.slice(0, endIndex));
 }
 
-const DISPLAY_NAME = `Superset (${workspaceName})`;
+export function getWorkspaceDisplayNameFromProdDb(
+	worktreePath: string,
+	prodDbPath = DEFAULT_PROD_DB_PATH,
+): string | undefined {
+	if (!existsSync(prodDbPath)) return undefined;
 
-try {
-	const currentBundleId = execSync(
-		`/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "${PLIST_PATH}" 2>/dev/null`,
-		{ encoding: "utf-8" },
-	).trim();
-	const currentScheme = execSync(
-		`/usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:0:CFBundleURLSchemes:0" "${PLIST_PATH}" 2>/dev/null`,
-		{ encoding: "utf-8" },
-	).trim();
-	const currentName = execSync(
-		`/usr/libexec/PlistBuddy -c "Print :CFBundleName" "${PLIST_PATH}" 2>/dev/null`,
-		{ encoding: "utf-8" },
-	).trim();
-
-	// Also check if the .app has been renamed and path.txt is updated
-	const isRenamed =
-		lstatSync(ELECTRON_APP_PATH).isSymbolicLink() &&
-		readlinkSync(ELECTRON_APP_PATH) === `${DISPLAY_NAME}.app`;
-	const electronPkgCheck = resolve(
-		import.meta.dirname,
-		"../node_modules/electron",
-	);
-	const pathTxtCheck = resolve(electronPkgCheck, "path.txt");
-	let pathTxtCorrect = false;
 	try {
-		pathTxtCorrect =
-			readFileSync(pathTxtCheck, "utf-8").trim() ===
-			`${DISPLAY_NAME}.app/Contents/MacOS/Electron`;
-	} catch {}
-
-	if (
-		currentBundleId === BUNDLE_ID &&
-		currentScheme === PROTOCOL_SCHEME &&
-		currentName === DISPLAY_NAME &&
-		isRenamed &&
-		pathTxtCorrect
-	) {
-		console.log(
-			`[patch-dev-protocol] ${PROTOCOL_SCHEME}:// already registered`,
+		const prodDb = new BunSqliteDatabase(prodDbPath, {
+			readonly: true,
+			create: false,
+		});
+		try {
+			const row = prodDb
+				.query(
+					`SELECT w.name as name
+					 FROM workspaces w
+					 INNER JOIN worktrees wt ON w.worktree_id = wt.id
+					 WHERE wt.path = ?
+					   AND w.deleting_at IS NULL
+					 ORDER BY w.last_opened_at DESC
+					 LIMIT 1`,
+				)
+				.get(worktreePath) as { name?: string } | null;
+			const name = row?.name?.trim();
+			return name ? name : undefined;
+		} finally {
+			prodDb.close();
+		}
+	} catch (error) {
+		console.warn(
+			"[patch-dev-protocol] Failed to resolve workspace display name from prod DB:",
+			error,
 		);
+		return undefined;
+	}
+}
+
+export function resolveWorkspaceIdentity(
+	options: ResolveWorkspaceIdentityOptions = {},
+): {
+	bundleDisplayWorkspaceName?: string;
+	displayWorkspaceName?: string;
+	worktreePath?: string;
+	workspaceName?: string;
+} {
+	const worktreeSegments = getWorktreeSegmentsFromCwd(
+		options.cwd,
+		options.worktreeBase,
+	);
+	const workspaceName =
+		deriveWorkspaceNameFromSegments(worktreeSegments) ??
+		options.envWorkspaceName;
+	if (!workspaceName) {
+		return {};
+	}
+
+	const worktreePath = deriveWorktreePathFromSegments(
+		worktreeSegments,
+		options.worktreeBase,
+	);
+	const resolvedDisplayName = worktreePath
+		? options.lookupDisplayName?.(worktreePath)?.trim()
+		: undefined;
+	const displayWorkspaceName = resolvedDisplayName || workspaceName;
+	const bundleDisplayWorkspaceName =
+		displayWorkspaceName.replaceAll("/", "-").trim() || workspaceName;
+
+	return {
+		workspaceName,
+		worktreePath,
+		displayWorkspaceName,
+		bundleDisplayWorkspaceName,
+	};
+}
+
+export function main() {
+	if (process.platform !== "darwin") {
+		console.log("[patch-dev-protocol] Skipping - not macOS");
 		process.exit(0);
 	}
-} catch {}
 
-console.log(`[patch-dev-protocol] Registering ${PROTOCOL_SCHEME}:// scheme...`);
+	if (process.env.NODE_ENV !== "development") {
+		console.log("[patch-dev-protocol] Skipping - non-development mode");
+		process.exit(0);
+	}
 
-execSync(
-	`/usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier ${BUNDLE_ID}" "${PLIST_PATH}"`,
-);
+	// Prefer path-derived name so stale .env values never override the active worktree.
+	const { bundleDisplayWorkspaceName, workspaceName, worktreePath } =
+		resolveWorkspaceIdentity({
+			cwd: process.cwd(),
+			envWorkspaceName: getWorkspaceName(),
+			lookupDisplayName: getWorkspaceDisplayNameFromProdDb,
+		});
+	if (!workspaceName || !bundleDisplayWorkspaceName) {
+		console.log("[patch-dev-protocol] Skipping - workspace name not resolved");
+		process.exit(0);
+	}
 
-// CFBundleName exists in default Electron plist, so Set works
-execSync(
-	`/usr/libexec/PlistBuddy -c "Set :CFBundleName ${DISPLAY_NAME}" "${PLIST_PATH}"`,
-);
-
-// CFBundleDisplayName may not exist — delete then add to handle both cases
-try {
-	execSync(
-		`/usr/libexec/PlistBuddy -c "Delete :CFBundleDisplayName" "${PLIST_PATH}" 2>/dev/null`,
+	const PROTOCOL_SCHEME = `superset-${workspaceName}`;
+	const BUNDLE_ID = `com.superset.desktop.${workspaceName}`;
+	const ELECTRON_DIST_DIR = resolve(
+		import.meta.dirname,
+		"../node_modules/electron/dist",
 	);
-} catch {}
-execSync(
-	`/usr/libexec/PlistBuddy -c "Add :CFBundleDisplayName string '${DISPLAY_NAME}'" "${PLIST_PATH}"`,
-);
+	const ELECTRON_APP_PATH = resolve(ELECTRON_DIST_DIR, "Electron.app");
+	const PLIST_PATH = resolve(ELECTRON_APP_PATH, "Contents/Info.plist");
 
-// Remove existing URL types to avoid stale entries from previous patches
-try {
-	execSync(
-		`/usr/libexec/PlistBuddy -c "Delete :CFBundleURLTypes" "${PLIST_PATH}" 2>/dev/null`,
+	if (!existsSync(PLIST_PATH)) {
+		console.log("[patch-dev-protocol] Electron.app not found, skipping");
+		process.exit(0);
+	}
+
+	const DISPLAY_NAME = `Superset (${bundleDisplayWorkspaceName})`;
+
+	try {
+		const currentBundleId = execSync(
+			`/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "${PLIST_PATH}" 2>/dev/null`,
+			{ encoding: "utf-8" },
+		).trim();
+		const currentScheme = execSync(
+			`/usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:0:CFBundleURLSchemes:0" "${PLIST_PATH}" 2>/dev/null`,
+			{ encoding: "utf-8" },
+		).trim();
+		const currentName = execSync(
+			`/usr/libexec/PlistBuddy -c "Print :CFBundleName" "${PLIST_PATH}" 2>/dev/null`,
+			{ encoding: "utf-8" },
+		).trim();
+
+		// Also check if the .app has been renamed and path.txt is updated
+		const isRenamed =
+			lstatSync(ELECTRON_APP_PATH).isSymbolicLink() &&
+			readlinkSync(ELECTRON_APP_PATH) === `${DISPLAY_NAME}.app`;
+		const electronPkgCheck = resolve(
+			import.meta.dirname,
+			"../node_modules/electron",
+		);
+		const pathTxtCheck = resolve(electronPkgCheck, "path.txt");
+		let pathTxtCorrect = false;
+		try {
+			pathTxtCorrect =
+				readFileSync(pathTxtCheck, "utf-8").trim() ===
+				`${DISPLAY_NAME}.app/Contents/MacOS/Electron`;
+		} catch {}
+
+		if (
+			currentBundleId === BUNDLE_ID &&
+			currentScheme === PROTOCOL_SCHEME &&
+			currentName === DISPLAY_NAME &&
+			isRenamed &&
+			pathTxtCorrect
+		) {
+			console.log(
+				`[patch-dev-protocol] ${PROTOCOL_SCHEME}:// already registered`,
+			);
+			process.exit(0);
+		}
+	} catch {}
+
+	console.log(
+		`[patch-dev-protocol] Registering ${PROTOCOL_SCHEME}:// scheme...`,
 	);
-} catch {}
 
-const commands = [
-	`Add :CFBundleURLTypes array`,
-	`Add :CFBundleURLTypes:0 dict`,
-	`Add :CFBundleURLTypes:0:CFBundleURLName string 'Superset Dev'`,
-	`Add :CFBundleURLTypes:0:CFBundleURLSchemes array`,
-	`Add :CFBundleURLTypes:0:CFBundleURLSchemes:0 string '${PROTOCOL_SCHEME}'`,
-	`Add :CFBundleURLTypes:0:CFBundleTypeRole string 'Editor'`,
-];
+	execSync(
+		`/usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier ${BUNDLE_ID}" "${PLIST_PATH}"`,
+	);
 
-for (const cmd of commands) {
-	execSync(`/usr/libexec/PlistBuddy -c "${cmd}" "${PLIST_PATH}"`);
-}
+	// CFBundleName exists in default Electron plist, so Set works
+	execSync(
+		`/usr/libexec/PlistBuddy -c "Set :CFBundleName ${DISPLAY_NAME}" "${PLIST_PATH}"`,
+	);
 
-// Rename Electron.app so macOS uses our display name for the dock label.
-// The plist CFBundleName is set correctly, but Electron's runtime overrides
-// the in-memory value before the dock reads it. Renaming the .app bundle
-// ensures macOS sees the correct name from the bundle directory itself.
-// A symlink preserves backward compatibility for the `electron` npm package.
-const DESIRED_APP_NAME = `${DISPLAY_NAME}.app`;
-const desiredAppPath = resolve(ELECTRON_DIST_DIR, DESIRED_APP_NAME);
-let actualAppPath = ELECTRON_APP_PATH;
+	// CFBundleDisplayName may not exist — delete then add to handle both cases
+	try {
+		execSync(
+			`/usr/libexec/PlistBuddy -c "Delete :CFBundleDisplayName" "${PLIST_PATH}" 2>/dev/null`,
+		);
+	} catch {}
+	execSync(
+		`/usr/libexec/PlistBuddy -c "Add :CFBundleDisplayName string '${DISPLAY_NAME}'" "${PLIST_PATH}"`,
+	);
 
-try {
-	const stats = lstatSync(ELECTRON_APP_PATH);
+	// Remove existing URL types to avoid stale entries from previous patches
+	try {
+		execSync(
+			`/usr/libexec/PlistBuddy -c "Delete :CFBundleURLTypes" "${PLIST_PATH}" 2>/dev/null`,
+		);
+	} catch {}
 
-	if (stats.isSymbolicLink()) {
-		const currentTarget = readlinkSync(ELECTRON_APP_PATH);
-		if (currentTarget === DESIRED_APP_NAME) {
-			// Already correctly renamed
-			actualAppPath = desiredAppPath;
-		} else {
-			// Different workspace name from previous run — update
-			const oldTargetPath = resolve(ELECTRON_DIST_DIR, currentTarget);
-			unlinkSync(ELECTRON_APP_PATH);
-			if (existsSync(oldTargetPath)) {
-				renameSync(oldTargetPath, desiredAppPath);
+	const commands = [
+		`Add :CFBundleURLTypes array`,
+		`Add :CFBundleURLTypes:0 dict`,
+		`Add :CFBundleURLTypes:0:CFBundleURLName string 'Superset Dev'`,
+		`Add :CFBundleURLTypes:0:CFBundleURLSchemes array`,
+		`Add :CFBundleURLTypes:0:CFBundleURLSchemes:0 string '${PROTOCOL_SCHEME}'`,
+		`Add :CFBundleURLTypes:0:CFBundleTypeRole string 'Editor'`,
+	];
+
+	for (const cmd of commands) {
+		execSync(`/usr/libexec/PlistBuddy -c "${cmd}" "${PLIST_PATH}"`);
+	}
+
+	// Rename Electron.app so macOS uses our display name for the dock label.
+	// The plist CFBundleName is set correctly, but Electron's runtime overrides
+	// the in-memory value before the dock reads it. Renaming the .app bundle
+	// ensures macOS sees the correct name from the bundle directory itself.
+	// A symlink preserves backward compatibility for the `electron` npm package.
+	const DESIRED_APP_NAME = `${DISPLAY_NAME}.app`;
+	const desiredAppPath = resolve(ELECTRON_DIST_DIR, DESIRED_APP_NAME);
+	let actualAppPath = ELECTRON_APP_PATH;
+
+	try {
+		const stats = lstatSync(ELECTRON_APP_PATH);
+
+		if (stats.isSymbolicLink()) {
+			const currentTarget = readlinkSync(ELECTRON_APP_PATH);
+			if (currentTarget === DESIRED_APP_NAME) {
+				// Already correctly renamed
+				actualAppPath = desiredAppPath;
+			} else {
+				// Different workspace name from previous run — update
+				const oldTargetPath = resolve(ELECTRON_DIST_DIR, currentTarget);
+				unlinkSync(ELECTRON_APP_PATH);
+				if (existsSync(oldTargetPath)) {
+					renameSync(oldTargetPath, desiredAppPath);
+				}
+				symlinkSync(DESIRED_APP_NAME, ELECTRON_APP_PATH);
+				actualAppPath = desiredAppPath;
 			}
+		} else {
+			// Real directory — rename and create symlink
+			if (existsSync(desiredAppPath)) {
+				rmSync(desiredAppPath, { recursive: true });
+			}
+			renameSync(ELECTRON_APP_PATH, desiredAppPath);
 			symlinkSync(DESIRED_APP_NAME, ELECTRON_APP_PATH);
 			actualAppPath = desiredAppPath;
 		}
-	} else {
-		// Real directory — rename and create symlink
-		if (existsSync(desiredAppPath)) {
-			rmSync(desiredAppPath, { recursive: true });
-		}
-		renameSync(ELECTRON_APP_PATH, desiredAppPath);
-		symlinkSync(DESIRED_APP_NAME, ELECTRON_APP_PATH);
-		actualAppPath = desiredAppPath;
+
+		console.log(
+			`[patch-dev-protocol] Renamed Electron.app to ${DESIRED_APP_NAME}`,
+		);
+	} catch (err) {
+		console.warn("[patch-dev-protocol] Failed to rename Electron.app:", err);
 	}
 
-	console.log(
-		`[patch-dev-protocol] Renamed Electron.app to ${DESIRED_APP_NAME}`,
+	try {
+		execSync(
+			`/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f "${actualAppPath}"`,
+		);
+		console.log(
+			`[patch-dev-protocol] Registered ${PROTOCOL_SCHEME}:// with Launch Services`,
+		);
+	} catch (err) {
+		console.warn(
+			"[patch-dev-protocol] Failed to register with Launch Services:",
+			err,
+		);
+	}
+
+	// Update the electron package's path.txt so electron-vite launches from the
+	// renamed .app directly (not through the Electron.app symlink). This ensures
+	// the invocation path contains the correct app name for macOS bundle resolution.
+	const electronPkgDir = resolve(
+		import.meta.dirname,
+		"../node_modules/electron",
 	);
-} catch (err) {
-	console.warn("[patch-dev-protocol] Failed to rename Electron.app:", err);
+	const pathTxtPath = resolve(electronPkgDir, "path.txt");
+	const desiredPathTxt = `${DESIRED_APP_NAME}/Contents/MacOS/Electron`;
+	try {
+		writeFileSync(pathTxtPath, desiredPathTxt);
+		console.log(
+			`[patch-dev-protocol] Updated path.txt to use ${DESIRED_APP_NAME}`,
+		);
+	} catch (err) {
+		console.warn("[patch-dev-protocol] Failed to update path.txt:", err);
+	}
+
+	return { worktreePath, workspaceName };
 }
 
-try {
-	execSync(
-		`/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f "${actualAppPath}"`,
-	);
-	console.log(
-		`[patch-dev-protocol] Registered ${PROTOCOL_SCHEME}:// with Launch Services`,
-	);
-} catch (err) {
-	console.warn(
-		"[patch-dev-protocol] Failed to register with Launch Services:",
-		err,
-	);
-}
-
-// Update the electron package's path.txt so electron-vite launches from the
-// renamed .app directly (not through the Electron.app symlink). This ensures
-// the invocation path contains the correct app name for macOS bundle resolution.
-const electronPkgDir = resolve(import.meta.dirname, "../node_modules/electron");
-const pathTxtPath = resolve(electronPkgDir, "path.txt");
-const desiredPathTxt = `${DESIRED_APP_NAME}/Contents/MacOS/Electron`;
-try {
-	writeFileSync(pathTxtPath, desiredPathTxt);
-	console.log(
-		`[patch-dev-protocol] Updated path.txt to use ${DESIRED_APP_NAME}`,
-	);
-} catch (err) {
-	console.warn("[patch-dev-protocol] Failed to update path.txt:", err);
+if (import.meta.main) {
+	main();
 }


### PR DESCRIPTION
## Summary
- restore the workspace alias display-name logic that was unintentionally removed from `apps/desktop/scripts/patch-dev-protocol.ts` in #2058
- bring back the prod DB alias lookup and the original priority order so path-derived workspace names win over stale env values
- use the DB-backed alias for `DISPLAY_NAME` again and add focused regression coverage for the restored resolution flow

## Context
PR #2058 removed behavior added the day before in #2050 (`c95adaa82`). This PR restores only that unrelated desktop regression.

## Testing
- bun test apps/desktop/scripts/patch-dev-protocol.test.ts
- bun run --cwd apps/desktop typecheck
- bunx biome check apps/desktop/scripts/patch-dev-protocol.ts apps/desktop/scripts/patch-dev-protocol.test.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the workspace alias display-name logic in the desktop dev protocol script, fixing the regression from #2058. Dev builds now show the correct workspace name and register the right macOS scheme and app label.

- **Bug Fixes**
  - Prefer path-derived workspace names over env vars to avoid stale values.
  - Resolve display name from the prod DB by worktree path; sanitize for bundle use.
  - Apply the display name to CFBundleName/DisplayName, rename Electron.app, update path.txt, and re-register the superset-${workspaceName} scheme.
  - Added focused tests for segment parsing, precedence, DB lookup, sanitization, and fallbacks.

<sup>Written for commit c544bbf0a844dc0ba042c7196c58b8f9ea78ddb2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for workspace resolution helper functions, covering path derivation, name resolution, and edge case handling.

* **Refactor**
  * Refactored workspace identity resolution into modular helper functions with enhanced error handling and improved logging in development scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->