### PR TITLE
fix: remove unsupported reasoning.summary flags from codex preset

### DIFF
--- a/packages/shared/src/agent-command.test.ts
+++ b/packages/shared/src/agent-command.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { buildAgentPromptCommand } from "./agent-command";
+import { AGENT_PRESET_COMMANDS, buildAgentPromptCommand } from "./agent-command";
 
 describe("buildAgentPromptCommand", () => {
 	it("adds `--` before codex prompt payload", () => {
@@ -25,5 +25,15 @@ describe("buildAgentPromptCommand", () => {
 		expect(command).toStartWith(
 			"claude --dangerously-skip-permissions \"$(cat <<'SUPERSET_PROMPT_abcdefgh'",
 		);
+	});
+});
+
+describe("AGENT_PRESET_COMMANDS", () => {
+	it("does not set reasoning.summary for codex preset", () => {
+		const codexPreset = AGENT_PRESET_COMMANDS.codex[0];
+
+		expect(codexPreset).toContain('model_reasoning_effort="high"');
+		expect(codexPreset).not.toContain("model_reasoning_summary");
+		expect(codexPreset).not.toContain("model_supports_reasoning_summaries");
 	});
 });

--- a/packages/shared/src/agent-command.ts
+++ b/packages/shared/src/agent-command.ts
@@ -21,7 +21,7 @@ export const AGENT_LABELS: Record<AgentType, string> = {
 export const AGENT_PRESET_COMMANDS: Record<AgentType, string[]> = {
 	claude: ["claude --dangerously-skip-permissions"],
 	codex: [
-		'codex -c model_reasoning_effort="high" --dangerously-bypass-approvals-and-sandbox -c model_reasoning_summary="detailed" -c model_supports_reasoning_summaries=true',
+		'codex -c model_reasoning_effort="high" --dangerously-bypass-approvals-and-sandbox',
 	],
 	gemini: ["gemini --yolo"],
 	opencode: ["opencode"],


### PR DESCRIPTION
## Summary
- Remove `model_reasoning_summary` and `model_supports_reasoning_summaries` flags from the codex preset command
- These flags are unsupported by some codex models (e.g. `gpt-5.3-codex-spark`) and cause API errors

## Test plan
- Added unit test ensuring preset does not include reasoning.summary configuration
- Existing tests continue to pass

Fixes #1898

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the model_reasoning_summary and model_supports_reasoning_summaries flags from the codex preset to prevent API errors on models that don't support them (e.g., gpt-5.3-codex-spark), fixing #1898. Added a unit test to ensure the codex preset never includes reasoning.summary settings.

<sup>Written for commit 1ea1462a4fb058fb0c96f21ad860aa8627805b50. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added verification tests for agent command preset configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->