### PR TITLE
fix(desktop): correctly track PRs for forked repositories

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/changes/git-operations.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/git-operations.ts
@@ -3,10 +3,13 @@ import simpleGit from "simple-git";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
 import {
+	getPullRequestRepoArgs,
+	getRepoContext,
+} from "../workspaces/utils/github/github";
+import {
 	execWithShellEnv,
 	getProcessEnvWithShellPath,
 } from "../workspaces/utils/shell-env";
-import { getRepoContext } from "../workspaces/utils/github/github";
 import { isUpstreamMissingError } from "./git-utils";
 import { assertRegisteredWorktree } from "./security";
 import {
@@ -210,15 +213,7 @@ async function findOpenPRByHeadCommit(
 			return null;
 		}
 
-		// For forks, cross-repo PRs live on the upstream repo, not the fork.
-		const repoArgs: string[] = [];
-		const repoContext = await getRepoContext(worktreePath);
-		if (repoContext?.isFork) {
-			const normalized = normalizeGitHubRepoUrl(repoContext.upstreamUrl);
-			if (normalized) {
-				repoArgs.push("--repo", normalized.replace("https://github.com/", ""));
-			}
-		}
+		const repoArgs = getPullRequestRepoArgs(await getRepoContext(worktreePath));
 
 		const { stdout } = await execWithShellEnv(
 			"gh",

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { getPullRequestRepoArgs } from "./github";
+
+describe("getPullRequestRepoArgs", () => {
+	test("returns upstream repo args for forks", () => {
+		expect(
+			getPullRequestRepoArgs({
+				isFork: true,
+				upstreamUrl: "git@github.com:superset-sh/superset.git",
+			}),
+		).toEqual(["--repo", "superset-sh/superset"]);
+	});
+
+	test("returns no repo args for non-forks", () => {
+		expect(
+			getPullRequestRepoArgs({
+				isFork: false,
+				upstreamUrl: "https://github.com/superset-sh/superset",
+			}),
+		).toEqual([]);
+	});
+
+	test("returns no repo args for malformed upstream urls", () => {
+		expect(
+			getPullRequestRepoArgs({
+				isFork: true,
+				upstreamUrl: "not-a-github-url",
+			}),
+		).toEqual([]);
+	});
+});

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.ts
@@ -79,7 +79,7 @@ export async function getRepoContext(
 	try {
 		const { stdout } = await execWithShellEnv(
 			"gh",
-			["repo", "view", "--json", "url,isFork,parent,nameWithOwner"],
+			["repo", "view", "--json", "url,isFork,parent"],
 			{ cwd: worktreePath },
 		);
 		const raw = JSON.parse(stdout);
@@ -98,26 +98,22 @@ export async function getRepoContext(
 				repoUrl: data.url,
 				upstreamUrl: data.parent.url,
 				isFork: true,
-				forkNwo: data.nameWithOwner ?? null,
 			};
 		} else {
 			const originUrl = await getOriginUrl(worktreePath);
 			const ghUrl = normalizeGitHubUrl(data.url);
 
 			if (originUrl && ghUrl && originUrl !== ghUrl) {
-				const nwo = extractNwoFromUrl(originUrl);
 				context = {
 					repoUrl: originUrl,
 					upstreamUrl: ghUrl,
 					isFork: true,
-					forkNwo: nwo,
 				};
 			} else {
 				context = {
 					repoUrl: data.url,
 					upstreamUrl: data.url,
 					isFork: false,
-					forkNwo: null,
 				};
 			}
 		}
@@ -132,7 +128,6 @@ export async function getRepoContext(
 	}
 }
 
-
 async function getOriginUrl(worktreePath: string): Promise<string | null> {
 	try {
 		const { stdout } = await execFileAsync(
@@ -145,7 +140,6 @@ async function getOriginUrl(worktreePath: string): Promise<string | null> {
 		return null;
 	}
 }
-
 
 function normalizeGitHubUrl(remoteUrl: string): string | null {
 	const trimmed = remoteUrl.trim();
@@ -172,9 +166,24 @@ function extractNwoFromUrl(normalizedUrl: string): string | null {
 	}
 }
 
+export function getPullRequestRepoArgs(
+	repoContext?: Pick<RepoContext, "isFork" | "upstreamUrl"> | null,
+): string[] {
+	if (!repoContext?.isFork) {
+		return [];
+	}
+
+	const normalizedUpstreamUrl = normalizeGitHubUrl(repoContext.upstreamUrl);
+	if (!normalizedUpstreamUrl) {
+		return [];
+	}
+
+	const repoNameWithOwner = extractNwoFromUrl(normalizedUpstreamUrl);
+	return repoNameWithOwner ? ["--repo", repoNameWithOwner] : [];
+}
 
 const PR_JSON_FIELDS =
-	"number,title,url,state,isDraft,mergedAt,additions,deletions,headRefOid,reviewDecision,statusCheckRollup";
+	"number,title,url,state,isDraft,mergedAt,additions,deletions,headRefOid,reviewDecision,statusCheckRollup,reviewRequests";
 
 async function getPRForBranch(
 	worktreePath: string,
@@ -242,25 +251,12 @@ async function findPRByHeadCommit(
 			return null;
 		}
 
-		// For forks, cross-repo PRs live on the upstream repo, not the fork.
-		const repoArgs: string[] = [];
-		if (repoContext?.isFork) {
-			try {
-				const nwo = new URL(repoContext.upstreamUrl).pathname.slice(1);
-				if (nwo) {
-					repoArgs.push("--repo", nwo);
-				}
-			} catch {
-				// Ignore malformed upstream URL; gh will search the default repo.
-			}
-		}
-
 		const { stdout } = await execWithShellEnv(
 			"gh",
 			[
 				"pr",
 				"list",
-				...repoArgs,
+				...getPullRequestRepoArgs(repoContext),
 				"--state",
 				"all",
 				"--search",
@@ -403,7 +399,15 @@ function formatPRData(data: GHPRResponse): NonNullable<GitHubStatus["pr"]> {
 		reviewDecision: mapReviewDecision(data.reviewDecision),
 		checksStatus: computeChecksStatus(data.statusCheckRollup),
 		checks: parseChecks(data.statusCheckRollup),
+		requestedReviewers: parseReviewRequests(data.reviewRequests),
 	};
+}
+
+function parseReviewRequests(
+	requests: GHPRResponse["reviewRequests"],
+): string[] {
+	if (!requests || requests.length === 0) return [];
+	return requests.map((r) => r.login || r.slug || r.name || "").filter(Boolean);
 }
 
 function mapPRState(

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/types.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/types.ts
@@ -25,6 +25,13 @@ export const GHCheckContextSchema = z.object({
 	workflowName: z.string().optional(),
 });
 
+export const GHReviewRequestSchema = z.object({
+	login: z.string().optional(),
+	name: z.string().optional(),
+	slug: z.string().optional(),
+	type: z.enum(["User", "Team"]).optional(),
+});
+
 export const GHPRResponseSchema = z.object({
 	number: z.number(),
 	title: z.string(),
@@ -40,12 +47,12 @@ export const GHPRResponseSchema = z.object({
 		.nullable(),
 	// statusCheckRollup is an array directly, not { contexts: [...] }
 	statusCheckRollup: z.array(GHCheckContextSchema).nullable(),
+	reviewRequests: z.array(GHReviewRequestSchema).nullable().optional(),
 });
 
 export const GHRepoResponseSchema = z.object({
 	url: z.string(),
 	isFork: z.boolean().optional().default(false),
-	nameWithOwner: z.string().optional(),
 	parent: z.object({ url: z.string() }).nullable().optional(),
 });
 
@@ -53,7 +60,6 @@ export interface RepoContext {
 	repoUrl: string;
 	upstreamUrl: string;
 	isFork: boolean;
-	forkNwo: string | null;
 }
 
 export type GHPRResponse = z.infer<typeof GHPRResponseSchema>;

--- a/packages/local-db/src/schema/zod.ts
+++ b/packages/local-db/src/schema/zod.ts
@@ -40,6 +40,7 @@ export const gitHubStatusSchema = z.object({
 			reviewDecision: z.enum(["approved", "changes_requested", "pending"]),
 			checksStatus: z.enum(["success", "failure", "pending", "none"]),
 			checks: z.array(checkItemSchema),
+			requestedReviewers: z.array(z.string()).optional(),
 		})
 		.nullable(),
 	repoUrl: z.string(),


### PR DESCRIPTION
## Summary

When working in a forked repository, PRs are created against the **upstream** repo — but our GitHub status checks were only searching the fork itself, causing PRs to appear as missing.

This fix detects fork/upstream relationships and queries the correct repository when looking up PR status.
https://github.com/user-attachments/assets/670ce270-4edd-42bf-b44d-19f827d0a7e4

## Changes

- **Fork detection** — `getRepoContext()` uses `gh repo view` to detect forks and resolve the upstream repo URL, with a 5-minute cache to avoid repeated API calls
- **Upstream PR lookup** — When in a fork, `findPRByHeadCommit()` and `findOpenPRByHeadCommit()` pass `--repo <upstream>` to `gh pr list` so cross-repo PRs are found
- **URL normalization** — Handles SSH, HTTPS, and `.git` suffix variants to reliably compare remote URLs
- **Schema updates** — Added `upstreamUrl`, `isFork`, and `forkNwo` to `RepoContext` type and `gitHubStatusSchema`

## Type of Change

- [x] Bug fix

## Testing

- Verified PR status correctly appears when working in a forked repo with a PR open against upstream
- Confirmed non-fork repos continue to work as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull request discovery now works correctly for forked repositories by searching the upstream repository.
  * Added support for displaying requested reviewers on pull requests.
  * Improved detection and tracking of forked repositories and upstream sources.

* **Tests**
  * Added tests for pull request repository argument handling in fork scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->