### PR TITLE
desktop: add dev:ui script for UI-only local dev

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,6 +18,7 @@
 		"start": "electron-vite preview",
 		"predev": "cross-env NODE_ENV=development bun run clean:dev && cross-env NODE_ENV=development bun run scripts/clean-launch-services.ts && cross-env NODE_ENV=development bun run scripts/patch-dev-protocol.ts",
 		"dev": "cross-env NODE_ENV=development electron-vite dev --watch",
+		"dev:ui": "cross-env SKIP_ENV_VALIDATION=1 bun run dev",
 		"compile:app": "cross-env NODE_OPTIONS=--max-old-space-size=8192 electron-vite build",
 		"copy:native-modules": "bun run scripts/copy-native-modules.ts",
 		"validate:native-runtime": "bun run scripts/validate-native-runtime.ts",


### PR DESCRIPTION
## Summary
- add a new `apps/desktop` script: `dev:ui`
- `dev:ui` runs desktop dev with `SKIP_ENV_VALIDATION=1` so auth/sign-in is skipped

## Why
For UI-only local work, this avoids getting stuck in the desktop OAuth loop when backend auth env is not configured locally.

## Usage
`bun run --cwd apps/desktop dev:ui`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a dev:ui script for the desktop app to run UI-only development by skipping env validation and auth, avoiding the OAuth loop when backend auth isn’t configured locally. Run with: bun run --cwd apps/desktop dev:ui.

<sup>Written for commit 9d3e9f94003849ad852e7aaacb84cffc45fe264c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added development build script for improved workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->