### PR TITLE
feat(desktop): show requested reviewers in workspace hover card

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.ts
@@ -80,7 +80,7 @@ async function getRepoUrl(worktreePath: string): Promise<string | null> {
 }
 
 const PR_JSON_FIELDS =
-	"number,title,url,state,isDraft,mergedAt,additions,deletions,headRefOid,reviewDecision,statusCheckRollup";
+	"number,title,url,state,isDraft,mergedAt,additions,deletions,headRefOid,reviewDecision,statusCheckRollup,reviewRequests";
 
 async function getPRForBranch(
 	worktreePath: string,
@@ -293,7 +293,15 @@ function formatPRData(data: GHPRResponse): NonNullable<GitHubStatus["pr"]> {
 		reviewDecision: mapReviewDecision(data.reviewDecision),
 		checksStatus: computeChecksStatus(data.statusCheckRollup),
 		checks: parseChecks(data.statusCheckRollup),
+		requestedReviewers: parseReviewRequests(data.reviewRequests),
 	};
+}
+
+function parseReviewRequests(
+	requests: GHPRResponse["reviewRequests"],
+): string[] {
+	if (!requests || requests.length === 0) return [];
+	return requests.map((r) => r.login || r.slug || r.name || "").filter(Boolean);
 }
 
 function mapPRState(

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/types.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/types.ts
@@ -25,6 +25,13 @@ export const GHCheckContextSchema = z.object({
 	workflowName: z.string().optional(),
 });
 
+export const GHReviewRequestSchema = z.object({
+	login: z.string().optional(),
+	name: z.string().optional(),
+	slug: z.string().optional(),
+	type: z.enum(["User", "Team"]).optional(),
+});
+
 export const GHPRResponseSchema = z.object({
 	number: z.number(),
 	title: z.string(),
@@ -40,6 +47,7 @@ export const GHPRResponseSchema = z.object({
 		.nullable(),
 	// statusCheckRollup is an array directly, not { contexts: [...] }
 	statusCheckRollup: z.array(GHCheckContextSchema).nullable(),
+	reviewRequests: z.array(GHReviewRequestSchema).nullable().optional(),
 });
 
 export const GHRepoResponseSchema = z.object({

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/WorkspaceHoverCard.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/WorkspaceHoverCard.tsx
@@ -115,13 +115,19 @@ export function WorkspaceHoverCardContent({
 			) : pr ? (
 				<div className="pt-2 border-t border-border space-y-2">
 					<div className="flex items-center justify-between">
-						<div className="flex items-center gap-2">
+						<div className="flex items-center gap-1.5 flex-wrap">
 							<span className="text-xs font-medium text-muted-foreground">
 								#{pr.number}
 							</span>
 							<PRStatusBadge state={pr.state} />
+							{pr.state === "open" && (
+								<ReviewStatus
+									status={pr.reviewDecision}
+									requestedReviewers={pr.requestedReviewers}
+								/>
+							)}
 						</div>
-						<div className="flex items-center gap-1.5 text-xs font-mono">
+						<div className="flex items-center gap-1.5 text-xs font-mono shrink-0">
 							<span className="text-emerald-500">+{pr.additions}</span>
 							<span className="text-destructive-foreground">
 								-{pr.deletions}
@@ -135,8 +141,6 @@ export function WorkspaceHoverCardContent({
 						<div className="space-y-2 pt-1">
 							<div className="flex items-center gap-2 text-xs">
 								<ChecksSummary checks={pr.checks} status={pr.checksStatus} />
-								<span className="text-muted-foreground">·</span>
-								<ReviewStatus status={pr.reviewDecision} />
 							</div>
 							{pr.checks.length > 0 && <ChecksList checks={pr.checks} />}
 						</div>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/components/ReviewStatus/ReviewStatus.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/components/ReviewStatus/ReviewStatus.tsx
@@ -1,18 +1,38 @@
 interface ReviewStatusProps {
 	status: "approved" | "changes_requested" | "pending";
+	requestedReviewers?: string[];
 }
 
-export function ReviewStatus({ status }: ReviewStatusProps) {
+export function ReviewStatus({
+	status,
+	requestedReviewers,
+}: ReviewStatusProps) {
 	const config = {
-		approved: { label: "Approved", className: "text-emerald-500" },
+		approved: {
+			label: "Approved",
+			className: "bg-emerald-500/15 text-emerald-500",
+		},
 		changes_requested: {
 			label: "Changes requested",
-			className: "text-destructive-foreground",
+			className: "bg-destructive/15 text-destructive-foreground",
 		},
-		pending: { label: "Review pending", className: "text-muted-foreground" },
+		pending: {
+			label:
+				requestedReviewers && requestedReviewers.length > 0
+					? `Awaiting ${requestedReviewers.join(", ")}`
+					: "Review pending",
+			className: "bg-amber-500/15 text-amber-500",
+		},
 	};
 
 	const { label, className } = config[status];
 
-	return <span className={className}>{label}</span>;
+	return (
+		<span
+			className={`text-[10px] font-medium px-1.5 py-0.5 rounded-md shrink-0 truncate max-w-[200px] ${className}`}
+			title={label}
+		>
+			{label}
+		</span>
+	);
 }

--- a/packages/local-db/src/schema/zod.ts
+++ b/packages/local-db/src/schema/zod.ts
@@ -40,6 +40,7 @@ export const gitHubStatusSchema = z.object({
 			reviewDecision: z.enum(["approved", "changes_requested", "pending"]),
 			checksStatus: z.enum(["success", "failure", "pending", "none"]),
 			checks: z.array(checkItemSchema),
+			requestedReviewers: z.array(z.string()).optional(),
 		})
 		.nullable(),
 	repoUrl: z.string(),


### PR DESCRIPTION
## Summary
- Fetch `reviewRequests` from the existing `gh pr view` call (zero additional API calls) and display reviewer usernames in the hover card.
- Restyle `ReviewStatus` as a colored pill badge matching `PRStatusBadge`, moved next to the Open/Draft tag so review state is immediately visible.
- When reviewers are assigned and pending, badge shows "Awaiting username" instead of generic "Review pending".

## Why / Context
The review status was easy to miss — it was plain text buried in the checks summary line below the PR title. Moving it into the badge row next to the PR state tag and styling it as a matching pill makes it scannable at a glance. Showing *who* is assigned to review (rather than just "pending") gives more actionable context without leaving the sidebar.

## How It Works
1. **Data**: Added `reviewRequests` to the `--json` fields in the existing `gh pr view` call. The `gh` CLI returns user and team review requests in one response — `parseReviewRequests()` normalizes both shapes into a `string[]` of display names (`login` for users, `slug` for teams).
2. **Schema**: Added `requestedReviewers: string[]` (optional) to `gitHubStatusSchema` in `local-db`. Optional for backward compat with cached SQLite data.
3. **UI**: `ReviewStatus` now renders as a `text-[10px]` pill badge with status-specific background colors (amber for pending, green for approved, red for changes requested). Truncates with `max-w-[200px]` and shows full text on hover via `title` attribute.

## Manual QA Checklist

### Hover Card - Review Badge
- [x] PR with no reviewers assigned: shows "Review pending" amber badge
- [x] PR with reviewer assigned (pending): shows "Awaiting username" amber badge
- [x] PR with multiple reviewers: shows "Awaiting user1, user2" (truncates if long)
- [ ] PR approved: shows "Approved" green badge
- [ ] PR with changes requested: shows "Changes requested" red badge
- [x] Draft/merged/closed PRs: review badge hidden (unchanged behavior)
- [x] Badge sits inline next to `Open` tag, doesn't overflow hover card

### Regression
- [ ] Checks summary still displays correctly below PR title
- [ ] Hover card loads without delay regression (same `gh` call)
- [ ] Old cached workspaces without `requestedReviewers` render without errors

## Testing
- `bun run lint:fix` — passes (2 files auto-formatted)
- `bun run typecheck` — passes (only pre-existing unrelated error in ChangesView)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows requested reviewers in the workspace hover card and moves review status to a pill badge next to the PR state, making review info visible at a glance with no extra GitHub API calls.

- **New Features**
  - Adds reviewRequests to the existing gh pr view JSON and normalizes user/team requests into requestedReviewers: string[].
  - Persists requestedReviewers in local-db schema (optional for backward compatibility).
  - Renders ReviewStatus as a colored pill beside PRStatusBadge; shows “Awaiting {names}” when pending, green for approved, red for changes requested.
  - Truncates long reviewer lists and shows full text on hover.

<sup>Written for commit d444eb643ca99c4be7ed9c0be3f14956004b6197. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added display of requested reviewers for pull requests, showing dynamic labels indicating who reviews are awaited from.

* **Style**
  * Enhanced review status visual indicators with background colors for approved and changes-requested states.
  * Improved spacing and layout in PR metadata display for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->