### PR TITLE
feat(desktop): always show hidden files in file sidebar

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/filesystem/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/filesystem/index.ts
@@ -195,27 +195,15 @@ function matchesPathFilters(
 	return true;
 }
 
-function getSearchCacheKey({
-	rootPath,
-	includeHidden,
-}: {
-	rootPath: string;
-	includeHidden: boolean;
-}) {
-	return `${rootPath}::${includeHidden ? "hidden" : "visible"}`;
+function getSearchCacheKey(rootPath: string) {
+	return rootPath;
 }
 
-async function buildSearchIndex({
-	rootPath,
-	includeHidden,
-}: {
-	rootPath: string;
-	includeHidden: boolean;
-}): Promise<FileSearchIndex> {
+async function buildSearchIndex(rootPath: string): Promise<FileSearchIndex> {
 	const entries = await fg("**/*", {
 		cwd: rootPath,
 		onlyFiles: true,
-		dot: includeHidden,
+		dot: true,
 		followSymbolicLinks: false,
 		unique: true,
 		suppressErrors: true,
@@ -235,14 +223,8 @@ async function buildSearchIndex({
 	return { items, fuse };
 }
 
-async function getSearchIndex({
-	rootPath,
-	includeHidden,
-}: {
-	rootPath: string;
-	includeHidden: boolean;
-}): Promise<FileSearchIndex> {
-	const cacheKey = getSearchCacheKey({ rootPath, includeHidden });
+async function getSearchIndex(rootPath: string): Promise<FileSearchIndex> {
+	const cacheKey = getSearchCacheKey(rootPath);
 	const cached = searchIndexCache.get(cacheKey);
 	const now = Date.now();
 	const inFlight = searchIndexBuilds.get(cacheKey);
@@ -252,7 +234,7 @@ async function getSearchIndex({
 	}
 
 	if (cached && !inFlight) {
-		const buildPromise = buildSearchIndex({ rootPath, includeHidden })
+		const buildPromise = buildSearchIndex(rootPath)
 			.then((index) => {
 				searchIndexCache.set(cacheKey, { index, builtAt: Date.now() });
 				searchIndexBuilds.delete(cacheKey);
@@ -274,7 +256,7 @@ async function getSearchIndex({
 		return await inFlight;
 	}
 
-	const buildPromise = buildSearchIndex({ rootPath, includeHidden })
+	const buildPromise = buildSearchIndex(rootPath)
 		.then((index) => {
 			searchIndexCache.set(cacheKey, { index, builtAt: Date.now() });
 			searchIndexBuilds.delete(cacheKey);
@@ -340,7 +322,6 @@ function rankKeywordMatches(
 interface SearchKeywordWithRipgrepOptions {
 	rootPath: string;
 	query: string;
-	includeHidden: boolean;
 	includePattern: string;
 	excludePattern: string;
 	limit: number;
@@ -349,7 +330,6 @@ interface SearchKeywordWithRipgrepOptions {
 async function searchKeywordWithRipgrep({
 	rootPath,
 	query,
-	includeHidden,
 	includePattern,
 	excludePattern,
 	limit,
@@ -370,9 +350,7 @@ async function searchKeywordWithRipgrep({
 		String(KEYWORD_SEARCH_MAX_COUNT_PER_FILE),
 	];
 
-	if (includeHidden) {
-		args.push("--hidden");
-	}
+	args.push("--hidden", "--no-ignore");
 
 	for (const pattern of DEFAULT_IGNORE_PATTERNS) {
 		args.push("--glob", `!${pattern}`);
@@ -586,17 +564,15 @@ export const createFilesystemRouter = () => {
 				z.object({
 					dirPath: z.string(),
 					rootPath: z.string(),
-					includeHidden: z.boolean().default(false),
 				}),
 			)
 			.query(async ({ input }): Promise<DirectoryEntry[]> => {
-				const { dirPath, rootPath, includeHidden } = input;
+				const { dirPath, rootPath } = input;
 
 				try {
 					const entries = await fs.readdir(dirPath, { withFileTypes: true });
 
 					return entries
-						.filter((entry) => includeHidden || !entry.name.startsWith("."))
 						.map((entry) => {
 							const fullPath = path.join(dirPath, entry.name);
 							const relativePath = path.relative(rootPath, fullPath);
@@ -630,19 +606,12 @@ export const createFilesystemRouter = () => {
 					query: z.string(),
 					includePattern: z.string().default(""),
 					excludePattern: z.string().default(""),
-					includeHidden: z.boolean().default(false),
 					limit: z.number().default(200),
 				}),
 			)
 			.query(async ({ input }) => {
-				const {
-					rootPath,
-					query,
-					includePattern,
-					excludePattern,
-					includeHidden,
-					limit,
-				} = input;
+				const { rootPath, query, includePattern, excludePattern, limit } =
+					input;
 				const trimmedQuery = query.trim();
 
 				if (!trimmedQuery) {
@@ -650,7 +619,7 @@ export const createFilesystemRouter = () => {
 				}
 
 				try {
-					const index = await getSearchIndex({ rootPath, includeHidden });
+					const index = await getSearchIndex(rootPath);
 					const pathMatcher = createPathFilterMatcher({
 						includePattern,
 						excludePattern,
@@ -697,19 +666,12 @@ export const createFilesystemRouter = () => {
 					query: z.string(),
 					includePattern: z.string().default(""),
 					excludePattern: z.string().default(""),
-					includeHidden: z.boolean().default(false),
 					limit: z.number().default(200),
 				}),
 			)
 			.query(async ({ input }): Promise<KeywordSearchMatch[]> => {
-				const {
-					rootPath,
-					query,
-					includePattern,
-					excludePattern,
-					includeHidden,
-					limit,
-				} = input;
+				const { rootPath, query, includePattern, excludePattern, limit } =
+					input;
 				const trimmedQuery = query.trim();
 
 				if (!trimmedQuery) {
@@ -717,7 +679,7 @@ export const createFilesystemRouter = () => {
 				}
 
 				try {
-					const index = await getSearchIndex({ rootPath, includeHidden });
+					const index = await getSearchIndex(rootPath);
 					const pathMatcher = createPathFilterMatcher({
 						includePattern,
 						excludePattern,
@@ -726,7 +688,6 @@ export const createFilesystemRouter = () => {
 						return await searchKeywordWithRipgrep({
 							rootPath,
 							query: trimmedQuery,
-							includeHidden,
 							includePattern,
 							excludePattern,
 							limit,

--- a/apps/desktop/src/renderer/screens/main/components/CommandPalette/useCommandPalette.ts
+++ b/apps/desktop/src/renderer/screens/main/components/CommandPalette/useCommandPalette.ts
@@ -40,7 +40,6 @@ export function useCommandPalette({
 		searchTerm: query,
 		includePattern,
 		excludePattern,
-		includeHidden: false,
 		limit: SEARCH_LIMIT,
 	});
 

--- a/apps/desktop/src/renderer/screens/main/components/KeywordSearch/useKeywordSearch.ts
+++ b/apps/desktop/src/renderer/screens/main/components/KeywordSearch/useKeywordSearch.ts
@@ -57,7 +57,6 @@ export function useKeywordSearch({
 				query: debouncedQuery,
 				includePattern,
 				excludePattern,
-				includeHidden: false,
 				limit: SEARCH_LIMIT,
 			},
 			{

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
@@ -15,7 +15,6 @@ import { useParams } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { LuFile, LuFolder } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
-import { useFileExplorerStore } from "renderer/stores/file-explorer";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import type { DirectoryEntry } from "shared/file-tree-types";
 import { DeleteConfirmDialog } from "./components/DeleteConfirmDialog";
@@ -39,16 +38,10 @@ export function FilesView() {
 
 	const [searchTerm, setSearchTerm] = useState("");
 	const projectId = workspace?.project?.id;
-	const showHiddenFiles = useFileExplorerStore((s) =>
-		projectId ? (s.showHiddenFiles[projectId] ?? false) : false,
-	);
-	const toggleHiddenFiles = useFileExplorerStore((s) => s.toggleHiddenFiles);
 
 	// Refs avoid stale closure in dataLoader callbacks
 	const worktreePathRef = useRef(worktreePath);
 	worktreePathRef.current = worktreePath;
-	const showHiddenFilesRef = useRef(showHiddenFiles);
-	showHiddenFilesRef.current = showHiddenFiles;
 
 	const trpcUtils = electronTrpc.useUtils();
 
@@ -90,7 +83,6 @@ export function FilesView() {
 					const entries = await trpcUtils.filesystem.readDirectory.fetch({
 						dirPath,
 						rootPath: currentPath,
-						includeHidden: showHiddenFilesRef.current,
 					});
 					return entries.map(
 						(e) =>
@@ -144,7 +136,6 @@ export function FilesView() {
 	} = useFileSearch({
 		worktreePath,
 		searchTerm,
-		includeHidden: showHiddenFiles,
 	});
 
 	const addFileViewerPane = useTabsStore((s) => s.addFileViewerPane);
@@ -281,20 +272,6 @@ export function FilesView() {
 		}
 	}, [tree]);
 
-	const handleToggleHiddenFiles = useCallback(() => {
-		if (!projectId) return;
-		// Update ref synchronously so invalidation uses correct value
-		showHiddenFilesRef.current = !showHiddenFilesRef.current;
-		toggleHiddenFiles(projectId);
-		// invalidateChildrenIds doesn't cascade, so invalidate every directory
-		tree.getItemInstance("root")?.invalidateChildrenIds();
-		for (const item of tree.getItems()) {
-			if (item.getItemData()?.isDirectory) {
-				item.invalidateChildrenIds();
-			}
-		}
-	}, [tree, projectId, toggleHiddenFiles]);
-
 	const searchResultEntries = useMemo(() => {
 		return searchResults.map((result) => ({
 			id: result.id,
@@ -322,8 +299,6 @@ export function FilesView() {
 				onNewFolder={() => handleNewFolder(worktreePath)}
 				onCollapseAll={handleCollapseAll}
 				onRefresh={handleRefresh}
-				showHiddenFiles={showHiddenFiles}
-				onToggleHiddenFiles={handleToggleHiddenFiles}
 			/>
 
 			<div className="flex-1 min-h-0 overflow-hidden">

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileTreeToolbar/FileTreeToolbar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileTreeToolbar/FileTreeToolbar.tsx
@@ -4,8 +4,6 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
 	LuChevronsDownUp,
-	LuEye,
-	LuEyeOff,
 	LuFilePlus,
 	LuFolderPlus,
 	LuRefreshCw,
@@ -20,8 +18,6 @@ interface FileTreeToolbarProps {
 	onNewFolder: () => void;
 	onCollapseAll: () => void;
 	onRefresh: () => void;
-	showHiddenFiles: boolean;
-	onToggleHiddenFiles: () => void;
 	isRefreshing?: boolean;
 }
 
@@ -32,8 +28,6 @@ export function FileTreeToolbar({
 	onNewFolder,
 	onCollapseAll,
 	onRefresh,
-	showHiddenFiles,
-	onToggleHiddenFiles,
 	isRefreshing = false,
 }: FileTreeToolbarProps) {
 	const [localSearchTerm, setLocalSearchTerm] = useState(searchTerm);
@@ -132,26 +126,6 @@ export function FileTreeToolbar({
 				</Tooltip>
 
 				<div className="flex-1" />
-
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<Button
-							variant="ghost"
-							size="icon"
-							className="size-6"
-							onClick={onToggleHiddenFiles}
-						>
-							{showHiddenFiles ? (
-								<LuEye className="size-3.5" />
-							) : (
-								<LuEyeOff className="size-3.5" />
-							)}
-						</Button>
-					</TooltipTrigger>
-					<TooltipContent side="bottom">
-						{showHiddenFiles ? "Hide Hidden Files" : "Show Hidden Files"}
-					</TooltipContent>
-				</Tooltip>
 
 				<Tooltip>
 					<TooltipTrigger asChild>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/hooks/useFileSearch/useFileSearch.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/hooks/useFileSearch/useFileSearch.ts
@@ -7,7 +7,6 @@ interface UseFileSearchParams {
 	searchTerm: string;
 	includePattern?: string;
 	excludePattern?: string;
-	includeHidden: boolean;
 	limit?: number;
 }
 
@@ -16,7 +15,6 @@ export function useFileSearch({
 	searchTerm,
 	includePattern = "",
 	excludePattern = "",
-	includeHidden,
 	limit = SEARCH_RESULT_LIMIT,
 }: UseFileSearchParams) {
 	const trimmedQuery = searchTerm.trim();
@@ -31,7 +29,6 @@ export function useFileSearch({
 				query: debouncedQuery,
 				includePattern,
 				excludePattern,
-				includeHidden,
 				limit,
 			},
 			{

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/hooks/useFileTree.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/hooks/useFileTree.ts
@@ -23,10 +23,7 @@ export function useFileTree({
 		Record<string, FileTreeNode[]>
 	>({});
 
-	const { showHiddenFiles, expandedFolders } = useFileExplorerStore();
-	const includeHidden = worktreePath
-		? (showHiddenFiles[worktreePath] ?? false)
-		: false;
+	const { expandedFolders } = useFileExplorerStore();
 	const currentExpandedFolders = worktreePath
 		? expandedFolders[worktreePath] || []
 		: [];
@@ -42,7 +39,6 @@ export function useFileTree({
 		{
 			dirPath: worktreePath || "",
 			rootPath: worktreePath || "",
-			includeHidden,
 		},
 		{
 			enabled: !!worktreePath,
@@ -102,7 +98,6 @@ export function useFileTree({
 				const entries = await trpcUtils.filesystem.readDirectory.fetch({
 					dirPath: nodePath,
 					rootPath: worktreePath,
-					includeHidden,
 				});
 
 				const childNodes: FileTreeNode[] = entries.map((entry) => ({
@@ -125,7 +120,7 @@ export function useFileTree({
 				return [];
 			}
 		},
-		[worktreePath, includeHidden, childrenCache, trpcUtils],
+		[worktreePath, childrenCache, trpcUtils],
 	);
 
 	return {

--- a/apps/desktop/src/renderer/stores/file-explorer.ts
+++ b/apps/desktop/src/renderer/stores/file-explorer.ts
@@ -8,7 +8,6 @@ interface FileExplorerState {
 	expandedFolders: Record<string, string[]>;
 	selectedItems: Record<string, string[]>;
 	searchTerm: Record<string, string>;
-	showHiddenFiles: Record<string, boolean>;
 	sortBy: SortBy;
 	sortDirection: SortDirection;
 	toggleFolder: (worktreePath: string, folderId: string) => void;
@@ -21,7 +20,6 @@ interface FileExplorerState {
 	removeSelectedItem: (worktreePath: string, itemId: string) => void;
 	clearSelection: (worktreePath: string) => void;
 	setSearchTerm: (worktreePath: string, term: string) => void;
-	toggleHiddenFiles: (projectId: string) => void;
 	setSortBy: (sortBy: SortBy) => void;
 	setSortDirection: (direction: SortDirection) => void;
 }
@@ -33,7 +31,6 @@ export const useFileExplorerStore = create<FileExplorerState>()(
 				expandedFolders: {},
 				selectedItems: {},
 				searchTerm: {},
-				showHiddenFiles: {},
 				sortBy: "name",
 				sortDirection: "asc",
 
@@ -139,16 +136,6 @@ export const useFileExplorerStore = create<FileExplorerState>()(
 					});
 				},
 
-				toggleHiddenFiles: (projectId) => {
-					const current = get().showHiddenFiles[projectId] ?? false;
-					set({
-						showHiddenFiles: {
-							...get().showHiddenFiles,
-							[projectId]: !current,
-						},
-					});
-				},
-
 				setSortBy: (sortBy) => {
 					set({ sortBy });
 				},
@@ -160,7 +147,6 @@ export const useFileExplorerStore = create<FileExplorerState>()(
 			{
 				name: "file-explorer-store",
 				partialize: (state) => ({
-					showHiddenFiles: state.showHiddenFiles,
 					sortBy: state.sortBy,
 					sortDirection: state.sortDirection,
 					expandedFolders: state.expandedFolders,


### PR DESCRIPTION
## Summary
- Always show dot files (`.env`, `.gitignore`, etc.) in the file sidebar — a code editor shouldn't hide them
- Remove the hidden files toggle button (eye icon) from the file tree toolbar
- Remove `includeHidden` parameter from the filesystem tRPC router (`readDirectory`, `searchFiles`, `searchKeyword`) and always include hidden files
- Clean up `showHiddenFiles` / `toggleHiddenFiles` state from the file explorer Zustand store

## Test plan
- [x] Open a project with dot files (`.env`, `.gitignore`, `.github/`, etc.) and verify they appear in the file sidebar without any toggle
- [x] Verify file search (cmd+P) returns dot files in results
- [x] Verify keyword search (cmd+shift+F) searches inside dot files
- [x] Confirm the eye icon toggle button is no longer in the file tree toolbar
- [x] Confirm collapse all, refresh, new file/folder toolbar buttons still work

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always show dot files across the desktop app. Removed the hidden-files toggle and related API/state so hidden files are always included in the file tree and searches.

- **New Features**
  - File sidebar always displays dot files (e.g., .env, .gitignore).
  - File and keyword search now include dot files; ripgrep runs with --hidden and --no-ignore (our default ignore globs still apply).

- **Migration**
  - Remove includeHidden from filesystem tRPC calls (readDirectory, searchFiles, searchKeyword).
  - Remove any uses of showHiddenFiles/toggleHiddenFiles and the file tree “eye” toggle in UI/state.

<sup>Written for commit 25a89c77885e7bfda8d9584cb5d03b6534f9e377. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Hidden files are now always included in file listings and search results. The toolbar toggle and related hidden-file settings have been removed, providing a consistent, unified behavior for file visibility and searches across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->