### PR TITLE
fix(desktop): remove severity-based coloring from resource monitor badge

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/ResourceConsumption.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/ResourceConsumption.tsx
@@ -1,4 +1,3 @@
-import { cn } from "@superset/ui/lib/utils";
 import { Popover, PopoverContent, PopoverTrigger } from "@superset/ui/popover";
 import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
@@ -11,7 +10,6 @@ import { WorkspaceResourceSection } from "./components/WorkspaceResourceSection"
 import type { UsageValues } from "./types";
 import { formatCpu, formatMemory, formatPercent } from "./utils/formatters";
 import { normalizeResourceMetricsSnapshot } from "./utils/normalizeSnapshot";
-import { getUsageClasses, getUsageSeverity } from "./utils/resourceSeverity";
 
 function getTotalUsage(
 	cpu: number | undefined,
@@ -111,10 +109,6 @@ export function ResourceConsumption() {
 		normalizedSnapshot?.totalCpu,
 		normalizedSnapshot?.totalMemory,
 	);
-	const totalSeverity = getUsageSeverity(totalUsage, totalUsage, {
-		includeShare: false,
-	});
-	const totalUsageClasses = getUsageClasses(totalSeverity);
 
 	const trackedMemorySharePercent = normalizedSnapshot
 		? getTrackedMemorySharePercent(
@@ -127,28 +121,12 @@ export function ResourceConsumption() {
 			<PopoverTrigger asChild>
 				<button
 					type="button"
-					className={cn(
-						"no-drag flex items-center gap-1.5 h-6 px-1.5 rounded border border-border/60 bg-secondary/50 hover:bg-secondary hover:border-border transition-all duration-150 ease-out focus:outline-none focus:ring-1 focus:ring-ring",
-						totalSeverity === "elevated" &&
-							"border-amber-500/25 bg-amber-500/8 hover:bg-amber-500/12",
-						totalSeverity === "high" &&
-							"border-destructive/25 bg-destructive/8 hover:bg-destructive/12",
-					)}
+					className="no-drag flex items-center gap-1.5 h-6 px-1.5 rounded border border-border/60 bg-secondary/50 hover:bg-secondary hover:border-border transition-all duration-150 ease-out focus:outline-none focus:ring-1 focus:ring-ring"
 					aria-label="Resource consumption"
 				>
-					<HiOutlineCpuChip
-						className={cn(
-							"h-3.5 w-3.5 shrink-0",
-							totalUsageClasses.metricClass,
-						)}
-					/>
+					<HiOutlineCpuChip className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
 					{normalizedSnapshot && (
-						<span
-							className={cn(
-								"text-xs font-medium tabular-nums",
-								totalUsageClasses.metricClass,
-							)}
-						>
+						<span className="text-xs font-medium tabular-nums text-muted-foreground">
 							{formatMemory(normalizedSnapshot.totalMemory)}
 						</span>
 					)}


### PR DESCRIPTION
## Summary
- Removed amber/red severity-based coloring from the resource monitor badge in the top bar
- The badge now uses standard theme colors (`bg-secondary`, `border-border`, `text-muted-foreground`) regardless of memory usage level
- Cleaned up unused imports (`cn`, `getUsageClasses`, `getUsageSeverity`)

## Test plan
- [x] Verify the resource monitor badge in the top bar uses neutral theme colors at all memory usage levels
- [x] Verify the popover content still displays correctly when clicked

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed severity-based coloring from the top bar resource monitor badge and switched to neutral theme colors to reduce distraction. Cleaned up unused severity utilities and imports; popover content and interactions remain unchanged.

<sup>Written for commit a4607055ce6f313ddb7637dcad966fc6682238ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the resource consumption display in the dashboard's top bar. Removed dynamic styling adjustments previously applied to CPU and memory metric presentations. The display now uses consistent, static styling throughout instead of severity-based visual variations, providing a simplified interface for monitoring system resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->