### PR TITLE
fix(config): avoid creating local .superset when user override exists

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/config/config.ts
+++ b/apps/desktop/src/lib/trpc/routers/config/config.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { access } from "node:fs/promises";
 import { join } from "node:path";
 import { projects, type SelectProject } from "@superset/local-db";
@@ -8,6 +8,10 @@ import type { SetupAction, SetupDetectionResult } from "shared/types/config";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
 import { loadSetupConfig } from "../workspaces/utils/setup";
+import {
+	ensureProjectConfigExists,
+	getProjectConfigPath,
+} from "./utils/config-paths";
 
 function hasConfiguredScripts(
 	project: Pick<SelectProject, "id" | "mainRepoPath">,
@@ -332,26 +336,6 @@ async function detectSetupDefaults(
 	};
 }
 
-function getConfigPath(mainRepoPath: string): string {
-	return join(mainRepoPath, ".superset", "config.json");
-}
-
-function ensureConfigExists(mainRepoPath: string): string {
-	const configPath = getConfigPath(mainRepoPath);
-	const supersetDir = join(mainRepoPath, ".superset");
-
-	if (!existsSync(configPath)) {
-		// Create .superset directory if it doesn't exist
-		if (!existsSync(supersetDir)) {
-			mkdirSync(supersetDir, { recursive: true });
-		}
-		// Create config.json with template
-		writeFileSync(configPath, CONFIG_TEMPLATE, "utf-8");
-	}
-
-	return configPath;
-}
-
 export const createConfigRouter = () => {
 	return router({
 		// Check if we should show the setup card for a project
@@ -399,7 +383,11 @@ export const createConfigRouter = () => {
 				if (!project) {
 					return null;
 				}
-				return ensureConfigExists(project.mainRepoPath);
+				return ensureProjectConfigExists(
+					project.mainRepoPath,
+					CONFIG_TEMPLATE,
+					project.id,
+				);
 			}),
 
 		// Get the config file content
@@ -415,7 +403,10 @@ export const createConfigRouter = () => {
 					return { content: null, exists: false };
 				}
 
-				const configPath = getConfigPath(project.mainRepoPath);
+				const configPath = getProjectConfigPath(
+					project.mainRepoPath,
+					project.id,
+				);
 				if (!existsSync(configPath)) {
 					return { content: null, exists: false };
 				}
@@ -462,7 +453,11 @@ export const createConfigRouter = () => {
 					throw new Error("Project not found");
 				}
 
-				const configPath = ensureConfigExists(project.mainRepoPath);
+				const configPath = ensureProjectConfigExists(
+					project.mainRepoPath,
+					CONFIG_TEMPLATE,
+					project.id,
+				);
 
 				// Read and parse existing config, preserving other fields
 				let existingConfig: Record<string, unknown> = {};

--- a/apps/desktop/src/lib/trpc/routers/config/utils/config-paths.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/config/utils/config-paths.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	CONFIG_FILE_NAME,
+	PROJECT_SUPERSET_DIR_NAME,
+	PROJECTS_DIR_NAME,
+	SUPERSET_DIR_NAME,
+} from "shared/constants";
+import {
+	ensureProjectConfigExists,
+	getProjectConfigPath,
+	getProjectOverrideConfigPath,
+} from "./config-paths";
+
+const TEST_DIR = join(tmpdir(), `superset-config-paths-${process.pid}`);
+const MAIN_REPO = join(TEST_DIR, "main-repo");
+const PROJECT_ID = "config-path-test-project";
+const USER_OVERRIDE_DIR = join(
+	homedir(),
+	SUPERSET_DIR_NAME,
+	PROJECTS_DIR_NAME,
+	PROJECT_ID,
+);
+const USER_OVERRIDE_FILE = join(USER_OVERRIDE_DIR, CONFIG_FILE_NAME);
+const MAIN_CONFIG_FILE = join(
+	MAIN_REPO,
+	PROJECT_SUPERSET_DIR_NAME,
+	CONFIG_FILE_NAME,
+);
+
+afterEach(() => {
+	if (existsSync(TEST_DIR)) {
+		rmSync(TEST_DIR, { recursive: true, force: true });
+	}
+	if (existsSync(USER_OVERRIDE_DIR)) {
+		rmSync(USER_OVERRIDE_DIR, { recursive: true, force: true });
+	}
+});
+
+describe("config path resolution", () => {
+	test("returns user override config path when override exists", () => {
+		mkdirSync(USER_OVERRIDE_DIR, { recursive: true });
+		writeFileSync(USER_OVERRIDE_FILE, '{"setup":["echo override"]}');
+
+		const resolved = getProjectConfigPath(MAIN_REPO, PROJECT_ID);
+		expect(resolved).toBe(USER_OVERRIDE_FILE);
+	});
+
+	test("creates main repo config when no user override exists", () => {
+		mkdirSync(MAIN_REPO, { recursive: true });
+
+		const resolved = ensureProjectConfigExists(
+			MAIN_REPO,
+			'{"setup":[],"teardown":[]}',
+			PROJECT_ID,
+		);
+
+		expect(resolved).toBe(MAIN_CONFIG_FILE);
+		expect(existsSync(MAIN_CONFIG_FILE)).toBe(true);
+		expect(readFileSync(MAIN_CONFIG_FILE, "utf-8")).toBe(
+			'{"setup":[],"teardown":[]}',
+		);
+	});
+
+	test("does not create main repo config when user override exists", () => {
+		mkdirSync(MAIN_REPO, { recursive: true });
+		mkdirSync(USER_OVERRIDE_DIR, { recursive: true });
+		writeFileSync(USER_OVERRIDE_FILE, '{"setup":["echo user"]}');
+
+		const resolved = ensureProjectConfigExists(
+			MAIN_REPO,
+			'{"setup":[],"teardown":[]}',
+			PROJECT_ID,
+		);
+
+		expect(resolved).toBe(USER_OVERRIDE_FILE);
+		expect(existsSync(USER_OVERRIDE_FILE)).toBe(true);
+		expect(existsSync(MAIN_CONFIG_FILE)).toBe(false);
+	});
+
+	test("rejects unsafe project IDs for override path", () => {
+		expect(getProjectOverrideConfigPath("../escape")).toBeNull();
+		expect(getProjectOverrideConfigPath("sub/dir")).toBeNull();
+		expect(getProjectOverrideConfigPath("sub\\dir")).toBeNull();
+	});
+});

--- a/apps/desktop/src/lib/trpc/routers/config/utils/config-paths.ts
+++ b/apps/desktop/src/lib/trpc/routers/config/utils/config-paths.ts
@@ -1,0 +1,60 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+	CONFIG_FILE_NAME,
+	PROJECT_SUPERSET_DIR_NAME,
+	PROJECTS_DIR_NAME,
+	SUPERSET_DIR_NAME,
+} from "shared/constants";
+
+function isSafeProjectId(projectId: string): boolean {
+	return !projectId.includes("/") && !projectId.includes("\\");
+}
+
+export function getProjectOverrideConfigPath(
+	projectId?: string,
+): string | null {
+	if (!projectId || !isSafeProjectId(projectId)) {
+		return null;
+	}
+
+	return join(
+		homedir(),
+		SUPERSET_DIR_NAME,
+		PROJECTS_DIR_NAME,
+		projectId,
+		CONFIG_FILE_NAME,
+	);
+}
+
+export function getProjectConfigPath(
+	mainRepoPath: string,
+	projectId?: string,
+): string {
+	const userOverrideConfigPath = getProjectOverrideConfigPath(projectId);
+	if (userOverrideConfigPath && existsSync(userOverrideConfigPath)) {
+		return userOverrideConfigPath;
+	}
+
+	return join(mainRepoPath, PROJECT_SUPERSET_DIR_NAME, CONFIG_FILE_NAME);
+}
+
+export function ensureProjectConfigExists(
+	mainRepoPath: string,
+	configTemplate: string,
+	projectId?: string,
+): string {
+	const configPath = getProjectConfigPath(mainRepoPath, projectId);
+	if (existsSync(configPath)) {
+		return configPath;
+	}
+
+	const supersetDir = join(mainRepoPath, PROJECT_SUPERSET_DIR_NAME);
+	if (!existsSync(supersetDir)) {
+		mkdirSync(supersetDir, { recursive: true });
+	}
+
+	writeFileSync(configPath, configTemplate, "utf-8");
+	return configPath;
+}


### PR DESCRIPTION
## Summary
- resolve project config path by preferring user override config when present
- avoid creating local project `.superset/config.json` when a user override config already exists
- add regression tests for path resolution and safe project-id handling

## Testing
- bun test apps/desktop/src/lib/trpc/routers/config/utils/config-paths.test.ts
- bunx biome check apps/desktop/src/lib/trpc/routers/config/config.ts apps/desktop/src/lib/trpc/routers/config/utils/config-paths.ts apps/desktop/src/lib/trpc/routers/config/utils/config-paths.test.ts

Closes #2129


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer the user’s override config (~/.superset/projects/<projectId>/config.json) over the local .superset/config.json and stop creating the local file when an override exists. Adds safe project ID handling and regression tests, addressing #2129.

- **Bug Fixes**
  - Resolve config path by checking the user override first; fallback to the project’s .superset/config.json.
  - Skip creating .superset/config.json when a user override exists.
  - Validate project IDs to prevent path traversal; ignore unsafe IDs.
  - Update the config router to use new path utilities (getProjectConfigPath, ensureProjectConfigExists).

<sup>Written for commit 71c0f29a30af271c5a6daf5c26eb88d5b43411fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configuration management now supports project-scoped settings with per-project user override capabilities.
  * Added validation safeguards for project identifiers to prevent path-related security issues.

* **Tests**
  * Added test coverage for configuration path resolution, override precedence, and safety checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->