### PR TITLE
fix(desktop): normalize resource monitor CPU values

### DIFF
--- a/apps/desktop/src/main/lib/resource-metrics/index.ts
+++ b/apps/desktop/src/main/lib/resource-metrics/index.ts
@@ -4,6 +4,7 @@ import { app } from "electron";
 import { localDb } from "main/lib/local-db";
 import { getProcessTree } from "main/lib/terminal/port-scanner";
 import { getWorkspaceRuntimeRegistry } from "main/lib/workspace-runtime/registry";
+import os from "node:os";
 import pidusage from "pidusage";
 
 interface ProcessMetrics {
@@ -25,6 +26,18 @@ interface WorkspaceMetrics {
 	cpu: number;
 	memory: number;
 	sessions: SessionMetrics[];
+}
+
+const LOGICAL_CPU_COUNT = Math.max(1, os.cpus().length);
+
+// pidusage / Electron process metrics report CPU as "per-core %" and can exceed
+// 100 on multi-core systems. Convert to machine-level percent for UI display.
+function normalizeCpuPercent(perCorePercent: number): number {
+	if (!Number.isFinite(perCorePercent) || perCorePercent <= 0) {
+		return 0;
+	}
+
+	return perCorePercent / LOGICAL_CPU_COUNT;
 }
 
 interface AppMetrics extends ProcessMetrics {
@@ -95,7 +108,7 @@ export async function collectResourceMetrics(): Promise<ResourceMetricsSnapshot>
 	};
 
 	for (const proc of electronMetrics) {
-		const cpu = proc.cpu.percentCPUUsage;
+		const cpu = normalizeCpuPercent(proc.cpu.percentCPUUsage);
 		// workingSetSize is in KB
 		const memory = proc.memory.workingSetSize * 1024;
 		let target = other;
@@ -122,7 +135,7 @@ export async function collectResourceMetrics(): Promise<ResourceMetricsSnapshot>
 		for (const pid of treePids) {
 			const stats = pidStats[pid];
 			if (stats) {
-				cpu += stats.cpu;
+				cpu += normalizeCpuPercent(stats.cpu);
 				memory += stats.memory;
 			}
 		}


### PR DESCRIPTION
## Summary
- normalize CPU metrics by logical core count before aggregating app/session/workspace usage
- keep memory reporting unchanged
- add a small note documenting why raw CPU values could exceed 100%

## Why
pidusage and Electron process metrics report CPU as per-core percentages, so totals can exceed 100 on multi-core machines. This change converts them to machine-level percentages for the resource monitor UI.

Fixes #2074

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize CPU usage in the desktop resource monitor by dividing per-core values by logical CPU count so totals stay within 0–100% per machine (fixes #2074). Memory reporting is unchanged, and a short note explains why raw CPU can exceed 100% on multi-core systems.

<sup>Written for commit 7456b57fdbe1570d455d7411216f9fffe84de59b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CPU usage reporting to provide accurate system-wide percentages across different multi-core processor configurations.

* **New Features**
  * Added extended process metrics tracking for comprehensive resource monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->