### PR TITLE
fix(desktop): prepend https:// for bare hostnames in browser toolbar

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserToolbar/BrowserToolbar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserToolbar/BrowserToolbar.tsx
@@ -42,7 +42,7 @@ export function BrowserToolbar({
 
 	const autocomplete = useUrlAutocomplete({
 		onSelect: (selectedUrl) => {
-			onNavigate(selectedUrl);
+			onNavigate(normalizeUrl(selectedUrl));
 			setIsEditing(false);
 		},
 	});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserToolbar/BrowserToolbar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserToolbar/BrowserToolbar.tsx
@@ -8,12 +8,7 @@ import {
 } from "react-icons/tb";
 import { UrlSuggestions } from "./components/UrlSuggestions";
 import { useUrlAutocomplete } from "./hooks/useUrlAutocomplete";
-
-function displayUrl(url: string): string {
-	if (url === "about:blank") return "";
-	// Strip trailing slash for cleaner display (e.g. "https://github.com/" → "https://github.com")
-	return url.endsWith("/") ? url.slice(0, -1) : url;
-}
+import { displayUrl, normalizeUrl } from "./utils";
 
 interface BrowserToolbarProps {
 	currentUrl: string;
@@ -77,7 +72,7 @@ export function BrowserToolbar({
 			e.preventDefault();
 			const trimmed = urlInputValue.trim();
 			if (trimmed) {
-				onNavigate(trimmed);
+				onNavigate(normalizeUrl(trimmed));
 				setIsEditing(false);
 				autocomplete.close();
 			}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserToolbar/utils.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserToolbar/utils.test.ts
@@ -66,6 +66,38 @@ describe("normalizeUrl", () => {
 		);
 	});
 
+	test("leaves about:blank unchanged", () => {
+		expect(normalizeUrl("about:blank")).toBe("about:blank");
+	});
+
+	test("leaves data: URLs unchanged", () => {
+		expect(normalizeUrl("data:text/html,<h1>hi</h1>")).toBe(
+			"data:text/html,<h1>hi</h1>",
+		);
+	});
+
+	test("prepends http:// to bare localhost", () => {
+		expect(normalizeUrl("localhost")).toBe("http://localhost");
+	});
+
+	test("prepends http:// to localhost with port", () => {
+		expect(normalizeUrl("localhost:3000")).toBe("http://localhost:3000");
+	});
+
+	test("prepends http:// to localhost with path", () => {
+		expect(normalizeUrl("localhost:3000/api/health")).toBe(
+			"http://localhost:3000/api/health",
+		);
+	});
+
+	test("prepends http:// to 127.0.0.1", () => {
+		expect(normalizeUrl("127.0.0.1:8080")).toBe("http://127.0.0.1:8080");
+	});
+
+	test("prepends http:// to [::1]", () => {
+		expect(normalizeUrl("[::1]:4000")).toBe("http://[::1]:4000");
+	});
+
 	test("trims whitespace before normalizing", () => {
 		expect(normalizeUrl("  github.com  ")).toBe("https://github.com");
 	});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserToolbar/utils.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserToolbar/utils.test.ts
@@ -115,4 +115,8 @@ describe("normalizeUrl", () => {
 			"https://api.example.com/v1",
 		);
 	});
+
+	test("prepends https:// to hostname with port (not treated as scheme)", () => {
+		expect(normalizeUrl("github.com:3000")).toBe("https://github.com:3000");
+	});
 });

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserToolbar/utils.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserToolbar/utils.test.ts
@@ -98,6 +98,10 @@ describe("normalizeUrl", () => {
 		expect(normalizeUrl("[::1]:4000")).toBe("http://[::1]:4000");
 	});
 
+	test("prepends https:// to non-loopback IPv6", () => {
+		expect(normalizeUrl("[2001:db8::1]:8080")).toBe("https://[2001:db8::1]:8080");
+	});
+
 	test("trims whitespace before normalizing", () => {
 		expect(normalizeUrl("  github.com  ")).toBe("https://github.com");
 	});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserToolbar/utils.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserToolbar/utils.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { displayUrl, normalizeUrl } from "./utils";
+
+describe("displayUrl", () => {
+	test("returns empty string for about:blank", () => {
+		expect(displayUrl("about:blank")).toBe("");
+	});
+
+	test("strips trailing slash from root URL", () => {
+		expect(displayUrl("https://github.com/")).toBe("https://github.com");
+	});
+
+	test("strips trailing slash from path", () => {
+		expect(displayUrl("https://github.com/foo/bar/")).toBe(
+			"https://github.com/foo/bar",
+		);
+	});
+
+	test("leaves URL unchanged when no trailing slash", () => {
+		expect(displayUrl("https://github.com/foo/bar")).toBe(
+			"https://github.com/foo/bar",
+		);
+	});
+
+	test("preserves query string", () => {
+		expect(displayUrl("https://example.com/search?q=hello")).toBe(
+			"https://example.com/search?q=hello",
+		);
+	});
+
+	test("preserves fragment", () => {
+		expect(displayUrl("https://example.com/page#section")).toBe(
+			"https://example.com/page#section",
+		);
+	});
+
+	test("handles http scheme", () => {
+		expect(displayUrl("http://example.com/")).toBe("http://example.com");
+	});
+});
+
+describe("normalizeUrl", () => {
+	test("prepends https:// to bare hostname", () => {
+		expect(normalizeUrl("github.com")).toBe("https://github.com");
+	});
+
+	test("prepends https:// to hostname with path", () => {
+		expect(normalizeUrl("github.com/foo/bar")).toBe(
+			"https://github.com/foo/bar",
+		);
+	});
+
+	test("leaves https:// URLs unchanged", () => {
+		expect(normalizeUrl("https://github.com")).toBe("https://github.com");
+	});
+
+	test("leaves http:// URLs unchanged", () => {
+		expect(normalizeUrl("http://localhost:3000")).toBe(
+			"http://localhost:3000",
+		);
+	});
+
+	test("leaves file:// URLs unchanged", () => {
+		expect(normalizeUrl("file:///home/user/index.html")).toBe(
+			"file:///home/user/index.html",
+		);
+	});
+
+	test("trims whitespace before normalizing", () => {
+		expect(normalizeUrl("  github.com  ")).toBe("https://github.com");
+	});
+
+	test("returns empty string for blank input", () => {
+		expect(normalizeUrl("   ")).toBe("");
+	});
+
+	test("handles subdomain", () => {
+		expect(normalizeUrl("api.example.com/v1")).toBe(
+			"https://api.example.com/v1",
+		);
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserToolbar/utils.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserToolbar/utils.ts
@@ -12,7 +12,11 @@ const LOCALHOST_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
 
 /** Extract the bare hostname from a schemeless input like `localhost:3000/path`. */
 function extractHost(input: string): string {
-	if (input.startsWith("[")) return "[::1]"; // IPv6
+	if (input.startsWith("[")) {
+		// IPv6 bracketed address — extract up to the closing bracket
+		const end = input.indexOf("]");
+		return end !== -1 ? input.slice(0, end + 1) : input;
+	}
 	return input.split("/")[0].split(":")[0];
 }
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserToolbar/utils.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserToolbar/utils.ts
@@ -8,14 +8,32 @@ export function displayUrl(url: string): string {
 	return url.endsWith("/") ? url.slice(0, -1) : url;
 }
 
+const LOCALHOST_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
+
+/** Extract the bare hostname from a schemeless input like `localhost:3000/path`. */
+function extractHost(input: string): string {
+	if (input.startsWith("[")) return "[::1]"; // IPv6
+	return input.split("/")[0].split(":")[0];
+}
+
 /**
- * Prepends "https://" when the input has no scheme, so bare hostnames
- * like "github.com" navigate correctly instead of being treated as
- * relative paths.
+ * Prepends a scheme when the input has none, matching Chrome/Firefox behavior:
+ * - localhost / 127.0.0.1 / [::1] get `http://` (local dev servers rarely use TLS)
+ * - All other bare hostnames get `https://`
+ * - Inputs that already have any scheme (`https://`, `http://`, `about:`, `data:`, etc.)
+ *   pass through unchanged.
  */
 export function normalizeUrl(input: string): string {
 	const trimmed = input.trim();
 	if (!trimmed) return trimmed;
-	if (/^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//.test(trimmed)) return trimmed;
-	return `https://${trimmed}`;
+
+	// Already has a scheme (`scheme:` or `scheme://`).
+	// Exception: `localhost:port` looks like a scheme but is a host:port pair.
+	if (/^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(trimmed)) {
+		const potentialHost = trimmed.split(":")[0];
+		if (!LOCALHOST_HOSTS.has(potentialHost)) return trimmed;
+	}
+
+	const scheme = LOCALHOST_HOSTS.has(extractHost(trimmed)) ? "http" : "https";
+	return `${scheme}://${trimmed}`;
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserToolbar/utils.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserToolbar/utils.ts
@@ -1,0 +1,21 @@
+/**
+ * Strips trailing slash and returns empty string for blank pages.
+ * e.g. "https://github.com/" → "https://github.com"
+ *      "about:blank"        → ""
+ */
+export function displayUrl(url: string): string {
+	if (url === "about:blank") return "";
+	return url.endsWith("/") ? url.slice(0, -1) : url;
+}
+
+/**
+ * Prepends "https://" when the input has no scheme, so bare hostnames
+ * like "github.com" navigate correctly instead of being treated as
+ * relative paths.
+ */
+export function normalizeUrl(input: string): string {
+	const trimmed = input.trim();
+	if (!trimmed) return trimmed;
+	if (/^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//.test(trimmed)) return trimmed;
+	return `https://${trimmed}`;
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserToolbar/utils.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserToolbar/utils.ts
@@ -32,10 +32,11 @@ export function normalizeUrl(input: string): string {
 	if (!trimmed) return trimmed;
 
 	// Already has a scheme (`scheme:` or `scheme://`).
-	// Exception: `localhost:port` looks like a scheme but is a host:port pair.
+	// Exceptions: `localhost:port` and `hostname.com:port` look like schemes but are host:port pairs.
+	// Real scheme names (https, about, data, file…) contain no dots and are not known hostnames.
 	if (/^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(trimmed)) {
 		const potentialHost = trimmed.split(":")[0];
-		if (!LOCALHOST_HOSTS.has(potentialHost)) return trimmed;
+		if (!LOCALHOST_HOSTS.has(potentialHost) && !potentialHost.includes(".")) return trimmed;
 	}
 
 	const scheme = LOCALHOST_HOSTS.has(extractHost(trimmed)) ? "http" : "https";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useTabsStore } from "renderer/stores/tabs/store";
+import { normalizeUrl } from "../../components/BrowserToolbar/utils";
 
 // ---------------------------------------------------------------------------
 // Module-level singletons
@@ -34,28 +35,6 @@ export function destroyPersistentWebview(paneId: string): void {
 		webviewRegistry.delete(paneId);
 	}
 	registeredWebContentsIds.delete(paneId);
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-const LOCALHOST_HOSTS = new Set(["localhost", "127.0.0.1"]);
-
-function sanitizeUrl(url: string): string {
-	// Pass through any URL that already has a scheme (https://, http://, file://, about:, data:, etc.)
-	// Guard against localhost:port being misidentified as a scheme.
-	if (/^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(url)) {
-		const potentialHost = url.split(":")[0];
-		if (!LOCALHOST_HOSTS.has(potentialHost)) return url;
-	}
-	if (url.startsWith("localhost") || url.startsWith("127.0.0.1")) {
-		return `http://${url}`;
-	}
-	if (url.includes(".")) {
-		return `https://${url}`;
-	}
-	return `https://www.google.com/search?q=${encodeURIComponent(url)}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -154,7 +133,7 @@ export function usePersistentWebview({
 			webviewRegistry.set(paneId, webview);
 			container.appendChild(webview);
 
-			const finalUrl = sanitizeUrl(initialUrlRef.current);
+			const finalUrl = normalizeUrl(initialUrlRef.current);
 			webview.src = finalUrl;
 		}
 
@@ -337,7 +316,7 @@ export function usePersistentWebview({
 		if (url) {
 			isHistoryNavigation.current = true;
 			const webview = webviewRegistry.get(paneId);
-			if (webview) webview.loadURL(sanitizeUrl(url));
+			if (webview) webview.loadURL(normalizeUrl(url));
 		}
 	}, [paneId, navigateBrowserHistory]);
 
@@ -346,7 +325,7 @@ export function usePersistentWebview({
 		if (url) {
 			isHistoryNavigation.current = true;
 			const webview = webviewRegistry.get(paneId);
-			if (webview) webview.loadURL(sanitizeUrl(url));
+			if (webview) webview.loadURL(normalizeUrl(url));
 		}
 	}, [paneId, navigateBrowserHistory]);
 
@@ -358,7 +337,7 @@ export function usePersistentWebview({
 	const navigateTo = useCallback(
 		(url: string) => {
 			const webview = webviewRegistry.get(paneId);
-			if (webview) webview.loadURL(sanitizeUrl(url));
+			if (webview) webview.loadURL(normalizeUrl(url));
 		},
 		[paneId],
 	);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
@@ -40,9 +40,14 @@ export function destroyPersistentWebview(paneId: string): void {
 // Helpers
 // ---------------------------------------------------------------------------
 
+const LOCALHOST_HOSTS = new Set(["localhost", "127.0.0.1"]);
+
 function sanitizeUrl(url: string): string {
-	if (/^https?:\/\//i.test(url) || url.startsWith("about:")) {
-		return url;
+	// Pass through any URL that already has a scheme (https://, http://, file://, about:, data:, etc.)
+	// Guard against localhost:port being misidentified as a scheme.
+	if (/^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(url)) {
+		const potentialHost = url.split(":")[0];
+		if (!LOCALHOST_HOSTS.has(potentialHost)) return url;
 	}
 	if (url.startsWith("localhost") || url.startsWith("127.0.0.1")) {
 		return `http://${url}`;


### PR DESCRIPTION
## Summary

- Typing `github.com` in the browser toolbar navigated to a relative path instead of `https://github.com`
- Extracts `displayUrl` and a new `normalizeUrl` utility from `BrowserToolbar.tsx` into a co-located `utils.ts`
- `normalizeUrl` detects inputs with no scheme and prepends `https://`, matching standard browser behavior
- URLs that already carry a scheme (`https://`, `http://`, `file://`, etc.) pass through unchanged

## Test plan

- [x] 15 unit tests added covering `displayUrl` and `normalizeUrl` — all pass (`bun test ...utils.test.ts`)
- [ ] Open a browser pane, type `github.com` and press Enter — should navigate to `https://github.com`
- [ ] Type `https://github.com` — should navigate normally, no double-scheme
- [ ] Type `http://localhost:3000` — should navigate normally
- [ ] Existing truncation behavior (long URLs, short URLs, edit mode) unaffected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes URL normalization in the browser toolbar and webview so bare hostnames open over https, while localhost and loopback IPs use http. Unifies normalization across form submit, autocomplete, and webview for consistent navigation.

- **Bug Fixes**
  - Prepend `https://` for bare hostnames and `hostname:port`; use `http://` for `localhost`, `127.0.0.1`, and `[::1]`.
  - Keep inputs with a scheme (`https`, `http`, `file`, `about:`, `data:`) unchanged; trim whitespace.
  - Parse bracketed IPv6 correctly; non-loopback addresses default to `https`; treat `github.com:3000` as host:port (not a scheme).
  - Preserve non-http schemes in the webview to avoid forcing `https` on `file://`, `about:`, and `data:` URLs.

- **Refactors**
  - Extract `displayUrl` and `normalizeUrl` into a utils module and replace the duplicate webview sanitizer; all navigation paths use `normalizeUrl`.
  - Add 24 unit tests covering blank pages, trailing slashes, scheme-only inputs, localhost/IPs, IPv6, hostname:port, and whitespace.

<sup>Written for commit e06485b570edbdfc44d10e7523f34822c44de3d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Navigation inputs are normalized before use for consistent link handling while displayed addresses remain user-friendly.
  * Bare hostnames now default to HTTPS; localhost-style hosts default to HTTP.
  * Displayed URLs omit unnecessary trailing slashes and treat special values like about:blank appropriately.

* **Tests**
  * Added comprehensive tests covering URL normalization and display across many edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->