### PR TITLE
fix(desktop): add keyboard accessibility to MosaicSplitOverlay handles

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/MosaicSplitOverlay/MosaicSplitOverlay.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/MosaicSplitOverlay/MosaicSplitOverlay.tsx
@@ -2,117 +2,18 @@ import { cn } from "@superset/ui/utils";
 import { useCallback, useRef } from "react";
 import type { MosaicNode, MosaicPath } from "react-mosaic-component";
 import { useDragPaneStore } from "renderer/stores/drag-pane-store";
-
-interface BoundingBox {
-	top: number;
-	right: number;
-	bottom: number;
-	left: number;
-}
-
-interface SplitInfo {
-	path: MosaicPath;
-	direction: "row" | "column";
-	boundingBox: BoundingBox;
-	splitPercentage: number;
-}
-
-function getAbsoluteSplitPercentage(
-	box: BoundingBox,
-	splitPercentage: number,
-	direction: "row" | "column",
-): number {
-	if (direction === "column") {
-		const height = 100 - box.top - box.bottom;
-		return (height * splitPercentage) / 100 + box.top;
-	}
-	const width = 100 - box.right - box.left;
-	return (width * splitPercentage) / 100 + box.left;
-}
-
-function getRelativeSplitPercentage(
-	box: BoundingBox,
-	absolutePercentage: number,
-	direction: "row" | "column",
-): number {
-	if (direction === "column") {
-		const height = 100 - box.top - box.bottom;
-		return ((absolutePercentage - box.top) / height) * 100;
-	}
-	const width = 100 - box.right - box.left;
-	return ((absolutePercentage - box.left) / width) * 100;
-}
-
-function splitBox(
-	box: BoundingBox,
-	splitPercentage: number,
-	direction: "row" | "column",
-): { first: BoundingBox; second: BoundingBox } {
-	const abs = getAbsoluteSplitPercentage(box, splitPercentage, direction);
-	if (direction === "column") {
-		return {
-			first: { ...box, bottom: 100 - abs },
-			second: { ...box, top: abs },
-		};
-	}
-	return {
-		first: { ...box, right: 100 - abs },
-		second: { ...box, left: abs },
-	};
-}
-
-function collectSplits(
-	node: MosaicNode<string>,
-	box: BoundingBox,
-	path: MosaicPath,
-	out: SplitInfo[],
-): void {
-	if (typeof node === "string") return;
-
-	const pct = node.splitPercentage ?? 50;
-	out.push({
-		path,
-		direction: node.direction,
-		boundingBox: box,
-		splitPercentage: pct,
-	});
-
-	const { first, second } = splitBox(box, pct, node.direction);
-	collectSplits(node.first, first, [...path, "first"], out);
-	collectSplits(node.second, second, [...path, "second"], out);
-}
-
-const MIN_PERCENTAGE = 20;
-const HANDLE_SIZE = 20;
-
-function updateSplitPercentage(
-	node: MosaicNode<string>,
-	path: MosaicPath,
-	newPercentage: number,
-): MosaicNode<string> {
-	if (path.length === 0) {
-		if (typeof node === "string") return node;
-		return { ...node, splitPercentage: newPercentage };
-	}
-	if (typeof node === "string") return node;
-	const [head, ...rest] = path;
-	return {
-		...node,
-		[head]: updateSplitPercentage(node[head], rest, newPercentage),
-	};
-}
-
-function equalizeSplitPercentages(
-	node: MosaicNode<string>,
-): MosaicNode<string> {
-	if (typeof node === "string") return node;
-	return {
-		...node,
-		splitPercentage: 50,
-		first: equalizeSplitPercentages(node.first),
-		second: equalizeSplitPercentages(node.second),
-	};
-}
+import {
+	HANDLE_SIZE,
+	KEYBOARD_STEP,
+	MIN_PERCENTAGE,
+	type SplitInfo,
+	collectSplits,
+	equalizeSplitPercentages,
+	getAbsoluteSplitPercentage,
+	getRelativeSplitPercentage,
+	splitBox,
+	updateSplitPercentage,
+} from "./mosaicSplitUtils";
 
 interface MosaicSplitOverlayProps {
 	layout: MosaicNode<string>;
@@ -124,7 +25,7 @@ export function MosaicSplitOverlay({
 	onLayoutChange,
 }: MosaicSplitOverlayProps) {
 	const splits: SplitInfo[] = [];
-	const emptyBox: BoundingBox = { top: 0, right: 0, bottom: 0, left: 0 };
+	const emptyBox = { top: 0, right: 0, bottom: 0, left: 0 };
 	collectSplits(layout, emptyBox, [], splits);
 
 	if (splits.length === 0) return null;
@@ -234,6 +135,27 @@ function SplitHandle({ split, layout, onLayoutChange }: SplitHandleProps) {
 		[layout, onLayoutChange],
 	);
 
+	const handleKeyDown = useCallback(
+		(e: React.KeyboardEvent) => {
+			const increase = isRow ? "ArrowRight" : "ArrowDown";
+			const decrease = isRow ? "ArrowLeft" : "ArrowUp";
+
+			if (e.key === increase || e.key === decrease) {
+				e.preventDefault();
+				const delta = e.key === increase ? KEYBOARD_STEP : -KEYBOARD_STEP;
+				const next = Math.max(
+					MIN_PERCENTAGE,
+					Math.min(100 - MIN_PERCENTAGE, split.splitPercentage + delta),
+				);
+				onLayoutChange(updateSplitPercentage(layout, split.path, next));
+			} else if (e.key === "Enter" || e.key === " ") {
+				e.preventDefault();
+				onLayoutChange(equalizeSplitPercentages(layout));
+			}
+		},
+		[isRow, layout, onLayoutChange, split.path, split.splitPercentage],
+	);
+
 	const style: React.CSSProperties = isRow
 		? {
 				top: `${split.boundingBox.top}%`,
@@ -254,15 +176,19 @@ function SplitHandle({ split, layout, onLayoutChange }: SplitHandleProps) {
 			role="separator"
 			aria-orientation={isRow ? "vertical" : "horizontal"}
 			aria-valuenow={Math.round(split.splitPercentage)}
+			aria-valuemin={MIN_PERCENTAGE}
+			aria-valuemax={100 - MIN_PERCENTAGE}
+			aria-label={isRow ? "Vertical split handle" : "Horizontal split handle"}
 			tabIndex={0}
 			ref={containerRef}
 			onMouseDown={handleMouseDown}
 			onDoubleClick={handleDoubleClick}
+			onKeyDown={handleKeyDown}
 			className={cn(
 				"absolute z-20",
 				isRow ? "cursor-col-resize" : "cursor-row-resize",
 				"after:absolute after:transition-colors",
-				"hover:after:bg-border",
+				"hover:after:bg-border focus-visible:after:bg-border",
 				isRow
 					? "after:top-0 after:bottom-0 after:left-1/2 after:-translate-x-1/2 after:w-px"
 					: "after:left-0 after:right-0 after:top-1/2 after:-translate-y-1/2 after:h-px",

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/MosaicSplitOverlay/MosaicSplitOverlay.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/MosaicSplitOverlay/MosaicSplitOverlay.tsx
@@ -8,7 +8,6 @@ import {
 	MIN_PERCENTAGE,
 	type SplitInfo,
 	collectSplits,
-	equalizeSplitPercentages,
 	getAbsoluteSplitPercentage,
 	getRelativeSplitPercentage,
 	splitBox,
@@ -130,9 +129,9 @@ function SplitHandle({ split, layout, onLayoutChange }: SplitHandleProps) {
 		(e: React.MouseEvent) => {
 			e.preventDefault();
 			e.stopPropagation();
-			onLayoutChange(equalizeSplitPercentages(layout));
+			onLayoutChange(updateSplitPercentage(layout, split.path, 50));
 		},
-		[layout, onLayoutChange],
+		[layout, onLayoutChange, split.path],
 	);
 
 	const handleKeyDown = useCallback(
@@ -150,7 +149,7 @@ function SplitHandle({ split, layout, onLayoutChange }: SplitHandleProps) {
 				onLayoutChange(updateSplitPercentage(layout, split.path, next));
 			} else if (e.key === "Enter" || e.key === " ") {
 				e.preventDefault();
-				onLayoutChange(equalizeSplitPercentages(layout));
+				onLayoutChange(updateSplitPercentage(layout, split.path, 50));
 			}
 		},
 		[isRow, layout, onLayoutChange, split.path, split.splitPercentage],

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/MosaicSplitOverlay/mosaicSplitUtils.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/MosaicSplitOverlay/mosaicSplitUtils.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, test } from "bun:test";
+import {
+	KEYBOARD_STEP,
+	MIN_PERCENTAGE,
+	collectSplits,
+	equalizeSplitPercentages,
+	getAbsoluteSplitPercentage,
+	getRelativeSplitPercentage,
+	splitBox,
+	updateSplitPercentage,
+} from "./mosaicSplitUtils";
+
+const emptyBox = { top: 0, right: 0, bottom: 0, left: 0 };
+
+describe("getAbsoluteSplitPercentage", () => {
+	test("row: maps relative pct to absolute in full box", () => {
+		expect(getAbsoluteSplitPercentage(emptyBox, 50, "row")).toBe(50);
+	});
+
+	test("row: accounts for left/right offsets", () => {
+		const box = { top: 0, bottom: 0, left: 20, right: 20 };
+		// width=60, 50% of 60 = 30, + left 20 = 50
+		expect(getAbsoluteSplitPercentage(box, 50, "row")).toBe(50);
+	});
+
+	test("row: 0% maps to left edge", () => {
+		const box = { top: 0, bottom: 0, left: 20, right: 20 };
+		expect(getAbsoluteSplitPercentage(box, 0, "row")).toBe(20);
+	});
+
+	test("column: maps relative pct to absolute in full box", () => {
+		expect(getAbsoluteSplitPercentage(emptyBox, 25, "column")).toBe(25);
+	});
+
+	test("column: accounts for top/bottom offsets", () => {
+		const box = { top: 10, bottom: 10, left: 0, right: 0 };
+		// height=80, 50% of 80 = 40, + top 10 = 50
+		expect(getAbsoluteSplitPercentage(box, 50, "column")).toBe(50);
+	});
+});
+
+describe("getRelativeSplitPercentage", () => {
+	test("row: round-trips with getAbsoluteSplitPercentage", () => {
+		const box = { top: 0, bottom: 0, left: 10, right: 10 };
+		const relative = 60;
+		const abs = getAbsoluteSplitPercentage(box, relative, "row");
+		expect(getRelativeSplitPercentage(box, abs, "row")).toBeCloseTo(relative);
+	});
+
+	test("column: round-trips with getAbsoluteSplitPercentage", () => {
+		const box = { top: 5, bottom: 15, left: 0, right: 0 };
+		const relative = 30;
+		const abs = getAbsoluteSplitPercentage(box, relative, "column");
+		expect(getRelativeSplitPercentage(box, abs, "column")).toBeCloseTo(relative);
+	});
+});
+
+describe("splitBox", () => {
+	test("row 50%: splits box into equal left/right halves", () => {
+		const { first, second } = splitBox(emptyBox, 50, "row");
+		expect(first.right).toBeCloseTo(50);
+		expect(second.left).toBeCloseTo(50);
+		expect(first.top).toBe(0);
+		expect(first.bottom).toBe(0);
+	});
+
+	test("column 50%: splits box into equal top/bottom halves", () => {
+		const { first, second } = splitBox(emptyBox, 50, "column");
+		expect(first.bottom).toBeCloseTo(50);
+		expect(second.top).toBeCloseTo(50);
+		expect(first.left).toBe(0);
+		expect(first.right).toBe(0);
+	});
+
+	test("row: preserves top/bottom on both halves", () => {
+		const box = { top: 5, bottom: 5, left: 0, right: 0 };
+		const { first, second } = splitBox(box, 50, "row");
+		expect(first.top).toBe(5);
+		expect(second.top).toBe(5);
+	});
+
+	test("column: preserves left/right on both halves", () => {
+		const box = { top: 0, bottom: 0, left: 15, right: 15 };
+		const { first, second } = splitBox(box, 50, "column");
+		expect(first.left).toBe(15);
+		expect(second.right).toBe(15);
+	});
+});
+
+describe("collectSplits", () => {
+	test("leaf node produces no splits", () => {
+		const out: ReturnType<typeof collectSplits> extends void
+			? never
+			: unknown[] = [];
+		const splits: Parameters<typeof collectSplits>[3] = [];
+		collectSplits("pane-a", emptyBox, [], splits);
+		expect(splits).toHaveLength(0);
+	});
+
+	test("single split node produces one entry", () => {
+		const splits: Parameters<typeof collectSplits>[3] = [];
+		collectSplits(
+			{ direction: "row", first: "a", second: "b", splitPercentage: 40 },
+			emptyBox,
+			[],
+			splits,
+		);
+		expect(splits).toHaveLength(1);
+		expect(splits[0].direction).toBe("row");
+		expect(splits[0].splitPercentage).toBe(40);
+		expect(splits[0].path).toEqual([]);
+	});
+
+	test("defaults splitPercentage to 50 when undefined", () => {
+		const splits: Parameters<typeof collectSplits>[3] = [];
+		collectSplits(
+			{ direction: "column", first: "a", second: "b" },
+			emptyBox,
+			[],
+			splits,
+		);
+		expect(splits[0].splitPercentage).toBe(50);
+	});
+
+	test("nested tree produces splits for each branch node", () => {
+		const splits: Parameters<typeof collectSplits>[3] = [];
+		collectSplits(
+			{
+				direction: "row",
+				first: { direction: "column", first: "a", second: "b" },
+				second: "c",
+			},
+			emptyBox,
+			[],
+			splits,
+		);
+		expect(splits).toHaveLength(2);
+		expect(splits[1].path).toEqual(["first"]);
+		expect(splits[1].direction).toBe("column");
+	});
+});
+
+describe("updateSplitPercentage", () => {
+	test("updates root node percentage", () => {
+		const node = { direction: "row" as const, first: "a", second: "b", splitPercentage: 50 };
+		const updated = updateSplitPercentage(node, [], 70);
+		expect(typeof updated !== "string" && updated.splitPercentage).toBe(70);
+	});
+
+	test("updates nested node at path", () => {
+		const node = {
+			direction: "row" as const,
+			first: { direction: "column" as const, first: "a", second: "b", splitPercentage: 30 },
+			second: "c",
+			splitPercentage: 50,
+		};
+		const updated = updateSplitPercentage(node, ["first"], 60);
+		if (typeof updated === "string") throw new Error("unexpected leaf");
+		if (typeof updated.first === "string") throw new Error("unexpected leaf");
+		expect(updated.first.splitPercentage).toBe(60);
+		expect(updated.splitPercentage).toBe(50);
+	});
+
+	test("leaf node returns unchanged", () => {
+		expect(updateSplitPercentage("a", [], 50)).toBe("a");
+	});
+});
+
+describe("equalizeSplitPercentages", () => {
+	test("leaf node returns unchanged", () => {
+		expect(equalizeSplitPercentages("a")).toBe("a");
+	});
+
+	test("sets root splitPercentage to 50", () => {
+		const node = { direction: "row" as const, first: "a", second: "b", splitPercentage: 70 };
+		const result = equalizeSplitPercentages(node);
+		if (typeof result === "string") throw new Error("unexpected leaf");
+		expect(result.splitPercentage).toBe(50);
+	});
+
+	test("recursively equalizes nested nodes", () => {
+		const node = {
+			direction: "row" as const,
+			splitPercentage: 70,
+			first: { direction: "column" as const, first: "a", second: "b", splitPercentage: 30 },
+			second: "c",
+		};
+		const result = equalizeSplitPercentages(node);
+		if (typeof result === "string") throw new Error("unexpected leaf");
+		if (typeof result.first === "string") throw new Error("unexpected leaf");
+		expect(result.splitPercentage).toBe(50);
+		expect(result.first.splitPercentage).toBe(50);
+	});
+});
+
+describe("constants", () => {
+	test("MIN_PERCENTAGE is 20", () => expect(MIN_PERCENTAGE).toBe(20));
+	test("KEYBOARD_STEP is positive", () => expect(KEYBOARD_STEP).toBeGreaterThan(0));
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/MosaicSplitOverlay/mosaicSplitUtils.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/MosaicSplitOverlay/mosaicSplitUtils.test.ts
@@ -89,9 +89,6 @@ describe("splitBox", () => {
 
 describe("collectSplits", () => {
 	test("leaf node produces no splits", () => {
-		const out: ReturnType<typeof collectSplits> extends void
-			? never
-			: unknown[] = [];
 		const splits: Parameters<typeof collectSplits>[3] = [];
 		collectSplits("pane-a", emptyBox, [], splits);
 		expect(splits).toHaveLength(0);
@@ -195,5 +192,5 @@ describe("equalizeSplitPercentages", () => {
 
 describe("constants", () => {
 	test("MIN_PERCENTAGE is 20", () => expect(MIN_PERCENTAGE).toBe(20));
-	test("KEYBOARD_STEP is positive", () => expect(KEYBOARD_STEP).toBeGreaterThan(0));
+	test("KEYBOARD_STEP is 5", () => expect(KEYBOARD_STEP).toBe(5));
 });

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/MosaicSplitOverlay/mosaicSplitUtils.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/MosaicSplitOverlay/mosaicSplitUtils.ts
@@ -1,0 +1,113 @@
+import type { MosaicNode, MosaicPath } from "react-mosaic-component";
+
+export interface BoundingBox {
+	top: number;
+	right: number;
+	bottom: number;
+	left: number;
+}
+
+export interface SplitInfo {
+	path: MosaicPath;
+	direction: "row" | "column";
+	boundingBox: BoundingBox;
+	splitPercentage: number;
+}
+
+export function getAbsoluteSplitPercentage(
+	box: BoundingBox,
+	splitPercentage: number,
+	direction: "row" | "column",
+): number {
+	if (direction === "column") {
+		const height = 100 - box.top - box.bottom;
+		return (height * splitPercentage) / 100 + box.top;
+	}
+	const width = 100 - box.right - box.left;
+	return (width * splitPercentage) / 100 + box.left;
+}
+
+export function getRelativeSplitPercentage(
+	box: BoundingBox,
+	absolutePercentage: number,
+	direction: "row" | "column",
+): number {
+	if (direction === "column") {
+		const height = 100 - box.top - box.bottom;
+		return ((absolutePercentage - box.top) / height) * 100;
+	}
+	const width = 100 - box.right - box.left;
+	return ((absolutePercentage - box.left) / width) * 100;
+}
+
+export function splitBox(
+	box: BoundingBox,
+	splitPercentage: number,
+	direction: "row" | "column",
+): { first: BoundingBox; second: BoundingBox } {
+	const abs = getAbsoluteSplitPercentage(box, splitPercentage, direction);
+	if (direction === "column") {
+		return {
+			first: { ...box, bottom: 100 - abs },
+			second: { ...box, top: abs },
+		};
+	}
+	return {
+		first: { ...box, right: 100 - abs },
+		second: { ...box, left: abs },
+	};
+}
+
+export function collectSplits(
+	node: MosaicNode<string>,
+	box: BoundingBox,
+	path: MosaicPath,
+	out: SplitInfo[],
+): void {
+	if (typeof node === "string") return;
+
+	const pct = node.splitPercentage ?? 50;
+	out.push({
+		path,
+		direction: node.direction,
+		boundingBox: box,
+		splitPercentage: pct,
+	});
+
+	const { first, second } = splitBox(box, pct, node.direction);
+	collectSplits(node.first, first, [...path, "first"], out);
+	collectSplits(node.second, second, [...path, "second"], out);
+}
+
+export const MIN_PERCENTAGE = 20;
+export const HANDLE_SIZE = 20;
+export const KEYBOARD_STEP = 5;
+
+export function updateSplitPercentage(
+	node: MosaicNode<string>,
+	path: MosaicPath,
+	newPercentage: number,
+): MosaicNode<string> {
+	if (path.length === 0) {
+		if (typeof node === "string") return node;
+		return { ...node, splitPercentage: newPercentage };
+	}
+	if (typeof node === "string") return node;
+	const [head, ...rest] = path;
+	return {
+		...node,
+		[head]: updateSplitPercentage(node[head], rest, newPercentage),
+	};
+}
+
+export function equalizeSplitPercentages(
+	node: MosaicNode<string>,
+): MosaicNode<string> {
+	if (typeof node === "string") return node;
+	return {
+		...node,
+		splitPercentage: 50,
+		first: equalizeSplitPercentages(node.first),
+		second: equalizeSplitPercentages(node.second),
+	};
+}


### PR DESCRIPTION
## Summary

Follow-up to #2084 (double-click pane divider to equalize widths).

Split handles were given `tabIndex={0}` making them keyboard-focusable, but had no `onKeyDown` handler — so keyboard-only users could focus them but not do anything.

**Changes:**
- Arrow keys (←/→ for row splits, ↑/↓ for column splits) move the split by 5% per keypress, clamped to `[20%, 80%]`
- Enter/Space equalizes all panes to 50/50, matching the double-click behavior
- Added `aria-valuemin`, `aria-valuemax`, and `aria-label` so screen readers can announce the handle's range and orientation
- Added `focus-visible:after:bg-border` so the divider line is visible when focused via keyboard
- Extracted all pure coordinate/tree utilities into a co-located `mosaicSplitUtils.ts` module

## Test plan

- [x] 23 unit tests added for all pure utility functions — all pass
- [ ] Tab to a split handle — divider line should be visible (focus ring via `after:` pseudo-element)
- [ ] Press ← or → on a row split — pane should resize by 5%
- [ ] Press ↑ or ↓ on a column split — pane should resize by 5%
- [ ] Press Enter or Space on any handle — all panes equalize to 50/50
- [ ] Drag resize still works normally
- [ ] Double-click to equalize still works normally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds keyboard and screen reader support to MosaicSplitOverlay split handles so keyboard users can resize panes and reset the focused split to 50%. Refactors split math into a utility module with unit tests.

- **Bug Fixes**
  - Arrow keys move the split by 5% on the correct axis, clamped to 20–80%.
  - Enter/Space and double-click reset only the focused split to 50% (not all panes).
  - Adds role=separator and ARIA attributes (orientation, valuemin/max/now, label) plus focus-visible styling.

- **Refactors**
  - Extracts coordinate/tree helpers into mosaicSplitUtils.ts.
  - Adds 23 unit tests covering split math and tree updates.

<sup>Written for commit 4ca42bdb38c61934e19b3de048487a8bd9330c15. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keyboard control for workspace split handles: Arrow keys nudge sizes; Enter/Space reset to 50%.

* **Accessibility**
  * ARIA attributes added to resize handles.
  * Focus-visible and hover styling improved for better discoverability.

* **Bug Fixes**
  * More consistent and clamped split resizing behavior to prevent extreme/invalid sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->