### PR TITLE
fix(desktop): restore commits section in changes sidebar

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/hooks/useOrderedSections/useOrderedSections.test.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/hooks/useOrderedSections/useOrderedSections.test.tsx
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import type {
+	ChangeCategory,
+	ChangedFile,
+	CommitInfo,
+} from "shared/changes-types";
+import { useOrderedSections } from "./useOrderedSections";
+
+const emptyFile = (): ChangedFile => ({
+	path: "src/example.ts",
+	status: "modified",
+	additions: 0,
+	deletions: 0,
+});
+
+const emptyArgs = {
+	sectionOrder: [
+		"against-base",
+		"committed",
+		"staged",
+		"unstaged",
+	] satisfies ChangeCategory[],
+	effectiveBaseBranch: "main",
+	expandedSections: {
+		"against-base": true,
+		committed: true,
+		staged: true,
+		unstaged: true,
+	},
+	toggleSection: () => {},
+	fileListViewMode: "tree" as const,
+	selectedFile: null,
+	selectedCommitHash: null,
+	worktreePath: "/tmp/repo",
+	projectId: undefined,
+	isExpandedView: false,
+	againstBaseFiles: [] as ChangedFile[],
+	onAgainstBaseFileSelect: () => {},
+	commitsWithFiles: [] as CommitInfo[],
+	expandedCommits: new Set<string>(),
+	onCommitToggle: () => {},
+	onCommitFileSelect: () => {},
+	stagedFiles: [] as ChangedFile[],
+	onStagedFileSelect: () => {},
+	onUnstageFile: () => {},
+	onUnstageFiles: () => {},
+	onShowDiscardStagedDialog: () => {},
+	onUnstageAll: () => {},
+	isDiscardAllStagedPending: false,
+	isUnstageAllPending: false,
+	isStagedActioning: false,
+	unstagedFiles: [] as ChangedFile[],
+	onUnstagedFileSelect: () => {},
+	onStageFile: () => {},
+	onStageFiles: () => {},
+	onDiscardFile: () => {},
+	onShowDiscardUnstagedDialog: () => {},
+	onStageAll: () => {},
+	isDiscardAllUnstagedPending: false,
+	isStageAllPending: false,
+	isUnstagedActioning: false,
+};
+
+describe("useOrderedSections", () => {
+	test("keeps the commits section visible when commit files are lazy-loaded", () => {
+		const sections = useOrderedSections({
+			...emptyArgs,
+			commitsWithFiles: [
+				{
+					hash: "abc123",
+					shortHash: "abc123",
+					message: "feat: lazy commit files",
+					author: "Test User",
+					date: new Date("2026-03-06T12:00:00.000Z"),
+					files: [],
+				},
+			],
+		});
+
+		const committedSection = sections.find((section) => section.id === "committed");
+
+		expect(committedSection).toBeDefined();
+		expect(committedSection?.count).toBe(1);
+	});
+
+	test("does not change other section counts", () => {
+		const sections = useOrderedSections({
+			...emptyArgs,
+			againstBaseFiles: [emptyFile()],
+			stagedFiles: [emptyFile(), emptyFile()],
+			unstagedFiles: [emptyFile(), emptyFile(), emptyFile()],
+		});
+
+		expect(sections.find((section) => section.id === "against-base")?.count).toBe(1);
+		expect(sections.find((section) => section.id === "staged")?.count).toBe(2);
+		expect(sections.find((section) => section.id === "unstaged")?.count).toBe(3);
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/hooks/useOrderedSections/useOrderedSections.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/hooks/useOrderedSections/useOrderedSections.tsx
@@ -98,10 +98,7 @@ export function useOrderedSections({
 	isStageAllPending,
 	isUnstagedActioning,
 }: UseOrderedSectionsInput) {
-	const committedFileCount = commitsWithFiles.reduce(
-		(acc, commit) => acc + commit.files.length,
-		0,
-	);
+	const commitCount = commitsWithFiles.length;
 
 	const sectionDefinitions: Record<ChangeCategory, OrderedSection> = {
 		"against-base": {
@@ -127,7 +124,7 @@ export function useOrderedSections({
 		committed: {
 			id: "committed",
 			title: "Commits",
-			count: committedFileCount,
+			count: commitCount,
 			isExpanded: expandedSections.committed,
 			onToggle: () => toggleSection("committed"),
 			content: expandedSections.committed


### PR DESCRIPTION
## Summary
- restore the changes sidebar committed section count to use the number of commits instead of the number of lazily loaded commit files
- keep the commits section visible when commit summaries are present but per-commit file lists have not been fetched yet
- add a regression test covering the lazy-loaded commit-files case

## Testing
- bun test apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/hooks/useOrderedSections/useOrderedSections.test.tsx
- bun test apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/utils/pr-action-state.test.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the Commits section in the Changes sidebar so it shows the number of commits and stays visible when commit files are still loading.

- **Bug Fixes**
  - Count commits using commitsWithFiles.length instead of summing file counts.
  - Keep the Commits section visible when commit summaries exist but files are lazy-loaded.
  - Added a regression test to cover the lazy-loaded commit-files case.

<sup>Written for commit cae5f05e5e94e994fb327a42086dcd34af7689c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Commits section to accurately display the total number of commits instead of individual file counts.

* **Tests**
  * Added comprehensive unit tests for the section ordering functionality to verify behavior across different states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->