### PR TITLE
[desktop] Add workspace name and path context to Manage sessions table

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/terminal/terminal.ts
+++ b/apps/desktop/src/lib/trpc/routers/terminal/terminal.ts
@@ -295,7 +295,25 @@ export const createTerminalRouter = () => {
 
 		listDaemonSessions: publicProcedure.query(async () => {
 			const { sessions } = await terminal.management.listSessions();
-			return { sessions };
+			const workspacesById = new Map(
+				localDb
+					.select()
+					.from(workspaces)
+					.all()
+					.map((workspace) => [workspace.id, workspace] as const),
+			);
+
+			return {
+				sessions: sessions.map((session) => {
+					const workspace = workspacesById.get(session.workspaceId);
+					const workspacePath = workspace ? getWorkspacePath(workspace) : null;
+					return {
+						...session,
+						workspaceName: workspace?.name ?? null,
+						workspacePath,
+					};
+				}),
+			};
 		}),
 
 		killAllDaemonSessions: publicProcedure.mutation(async () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/SessionsSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/SessionsSection.tsx
@@ -214,8 +214,15 @@ export function SessionsSection() {
 								<tbody className="divide-y divide-border/60">
 									{sessionsSorted.map((session) => (
 										<tr key={session.sessionId} className="hover:bg-muted/30">
-											<td className="px-2 py-2 font-mono">
-												{session.workspaceId}
+											<td className="px-2 py-2">
+												<div className="font-mono truncate max-w-[10rem]" title={session.workspaceId}>
+													{session.workspaceName ?? session.workspaceId}
+												</div>
+												{session.workspacePath && (
+													<div className="text-[10px] text-muted-foreground truncate max-w-[10rem]" title={session.workspacePath}>
+														{session.workspacePath}
+													</div>
+												)}
 											</td>
 											<td className="px-2 py-2 font-mono">
 												{session.sessionId}


### PR DESCRIPTION
Fixes #1356

## Summary

Enhances the \"Manage sessions\" table in Terminal Settings with workspace context:

- **Backend**: `listDaemonSessions` now enriches each session with:
  - `workspaceName`: Human-readable workspace name
  - `workspacePath`: Full path to the workspace directory

- **Frontend**: Updated table to display:
  - Workspace name (primary) with ID as fallback
  - Workspace path (secondary, dimmed) when available

## Changes

1. **Terminal router** (`terminal.ts`):
   - Join sessions with local workspace DB records
   - Add `workspaceName` and `workspacePath` to response

2. **SessionsSection.tsx**:
   - Display workspace name (or ID if no name)
   - Show workspace path as secondary info
   - Truncate long paths with tooltips

## Test Plan

- [ ] Verify sessions display correctly in Settings → Terminal
- [ ] Confirm workspace names appear for named workspaces
- [ ] Confirm paths display for worktree-based workspaces
- [ ] Verify fallback to ID when workspace has no name

## Screenshot

N/A (table UI enhancement)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds workspace context to the Manage sessions table so users can identify sessions by workspace name and path. Addresses #1356.

- **New Features**
  - API: listDaemonSessions now includes workspaceName and workspacePath by joining local workspace records.
  - UI: Shows workspace name (falls back to ID) and a dimmed workspace path as a second line.
  - Truncates long values with tooltips for full text.

<sup>Written for commit a775dd48730710ef634ce76bf3226c3475e208ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal sessions now display workspace names and workspace paths alongside sessions, with improved formatting including truncation and tooltips for better workspace identification and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->