### PR TITLE
fix(desktop): add new section target to move menu

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceContextMenu.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceContextMenu.tsx
@@ -22,6 +22,7 @@ import {
 	LuEyeOff,
 	LuFolderOpen,
 	LuFolderPlus,
+	LuMinus,
 	LuPencil,
 } from "react-icons/lu";
 import {
@@ -150,7 +151,8 @@ export function WorkspaceContextMenu({
 					</ContextMenuItem>
 					<ContextMenuSeparator />
 					<ContextMenuItem onSelect={() => handleMoveToSection(null)}>
-						No Section
+						<LuMinus className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />
+						Ungrouped
 					</ContextMenuItem>
 					{sections.length > 0 && <ContextMenuSeparator />}
 					{sections.map((section) => (


### PR DESCRIPTION
## Summary
- add a `New Section` option inside the workspace `Move to Section` submenu
- allow creating a new section from the current workspace as well as from a multi-selection
- keep existing section and `No Section` targets in the same menu flow

## Verification
- `bunx biome check apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceContextMenu.tsx`
- `bunx tsc -p apps/desktop/tsconfig.json --noEmit --pretty false` *(fails due to pre-existing generated route and asset typing issues, including missing `apps/desktop/src/renderer/routeTree.gen` and `resources/public/file-icons/manifest.json`)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a “New Section” option to the workspace context menu and make “Move to Section” always available. You can now create a section from the current workspace or a multi-selection in the same flow.

- New Features
  - “Move to Section” submenu includes: New Section, Ungrouped, then existing sections.
  - When multiple workspaces are selected, “New Section” uses the selection and clears it after creation.

<sup>Written for commit 50798eaeeb104656fea29248ad058525c6f54001. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Ungrouped" option in the Move to Section menu to allow removing section assignments from workspace items.

* **UI Improvements**
  * Reorganized the Move to Section submenu for more consistent and accessible section management.
  * "New Section" option relocated to the Move to Section submenu for improved accessibility and discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->