### PR TITLE
fix(desktop): restore terminal focus on click

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.test.ts
@@ -34,6 +34,7 @@ mock.module("renderer/lib/trpc-client", () => ({
 const {
 	getDefaultTerminalBg,
 	getDefaultTerminalTheme,
+	setupClickToMoveCursor,
 	setupCopyHandler,
 	setupKeyboardHandler,
 	setupPasteHandler,
@@ -308,6 +309,67 @@ describe("setupCopyHandler", () => {
 		const copyListener = listeners.get("copy");
 		expect(copyListener).toBeDefined();
 		expect(() => copyListener?.(copyEvent)).not.toThrow();
+	});
+});
+
+describe("setupClickToMoveCursor", () => {
+	function createXtermStub() {
+		const listeners = new Map<string, EventListener>();
+		const element = {
+			addEventListener: mock((eventName: string, listener: EventListener) => {
+				listeners.set(eventName, listener);
+			}),
+			removeEventListener: mock((eventName: string) => {
+				listeners.delete(eventName);
+			}),
+		} as unknown as HTMLElement;
+		const focus = mock(() => {});
+		const xterm = {
+			element,
+			focus,
+			buffer: {
+				normal: {},
+				active: {},
+			},
+			hasSelection: mock(() => false),
+			cols: 80,
+			rows: 24,
+		} as unknown as XTerm;
+		return { xterm, listeners, focus };
+	}
+
+	it("focuses terminal on plain left mouse down", () => {
+		const { xterm, listeners, focus } = createXtermStub();
+
+		setupClickToMoveCursor(xterm, { onWrite: mock(() => {}) });
+
+		const mouseDownListener = listeners.get("mousedown");
+		expect(mouseDownListener).toBeDefined();
+		mouseDownListener?.({
+			button: 0,
+			metaKey: false,
+			ctrlKey: false,
+			altKey: false,
+		} as MouseEvent);
+
+		expect(focus).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not force focus on modifier-assisted click", () => {
+		const { xterm, listeners, focus } = createXtermStub();
+
+		setupClickToMoveCursor(xterm, { onWrite: mock(() => {}) });
+
+		const mouseDownListener = listeners.get("mousedown");
+		expect(mouseDownListener).toBeDefined();
+		mouseDownListener?.({
+			button: 0,
+			metaKey: true,
+			ctrlKey: false,
+			altKey: false,
+		} as MouseEvent);
+
+		expect(focus).not.toHaveBeenCalled();
 	});
 });
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -798,6 +798,12 @@ export function setupClickToMoveCursor(
 	xterm: XTerm,
 	options: ClickToMoveOptions,
 ): () => void {
+	const handleMouseDown = (event: MouseEvent) => {
+		if (event.button !== 0) return;
+		if (event.metaKey || event.ctrlKey || event.altKey) return;
+		xterm.focus();
+	};
+
 	const handleClick = (event: MouseEvent) => {
 		// Don't interfere with full-screen apps (vim, less, etc. use alternate buffer)
 		if (xterm.buffer.active !== xterm.buffer.normal) return;
@@ -823,9 +829,11 @@ export function setupClickToMoveCursor(
 		options.onWrite(arrowKey.repeat(Math.abs(delta)));
 	};
 
+	xterm.element?.addEventListener("mousedown", handleMouseDown);
 	xterm.element?.addEventListener("click", handleClick);
 
 	return () => {
+		xterm.element?.removeEventListener("mousedown", handleMouseDown);
 		xterm.element?.removeEventListener("click", handleClick);
 	};
 }


### PR DESCRIPTION
## Summary\n- refocus xterm on plain left mouse down inside terminal panes\n- keep modifier-assisted clicks untouched (cmd/ctrl/alt)\n- add unit coverage for the new mousedown focus behavior\n\n## Why\nIssue #960 reports terminal input becoming unresponsive after clicking inside a terminal pane. Explicitly refocusing xterm on mousedown ensures keyboard input is reattached before click-to-move logic runs.\n\n## Testing\n- attempted: bun test v1.3.8 (b64edcb4) *(fails in this environment due missing workspace deps, e.g.  / )*\n\nCloses #960

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unresponsive terminal input after clicking by restoring focus on plain left mousedown. Cmd/Ctrl/Alt clicks keep their existing behavior. Closes #960.

- **Bug Fixes**
  - Focus xterm on mousedown for left-clicks before click-to-move logic.
  - Add unit tests covering focus behavior and modifier-assisted clicks.

<sup>Written for commit 6d5c837b01116ff5ed73e3407db7e313efa0f395. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Terminal now focuses when you click on it with the left mouse button. Modifier key combinations are properly handled to prevent unintended focus behavior.

* **Tests**
  * Added unit tests verifying terminal focus behavior on mouse down events, including proper handling of modifier keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->