### PR TITLE
fix(ci): add generate:icons step to desktop build

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "@superset/desktop",
 	"productName": "Superset",
 	"description": "The last developer tool you'll ever need",
-	"version": "1.1.0",
+	"version": "1.0.6",
 	"main": "./dist/main/index.js",
 	"resources": "src/resources",
 	"repository": {


### PR DESCRIPTION
## Summary
- Adds a `generate:icons` step before `compile:app` in the desktop CI build workflow (both macOS and Linux jobs)
- The renderer imports `resources/public/file-icons/manifest.json` which is generated by `bun run generate:icons`. CI was calling `compile:app` directly, skipping this step and causing a Rollup resolve error.

## Test plan
- [x] Triggered CI build on this branch: https://github.com/superset-sh/superset/actions/runs/22803424540