### PR TITLE
docs: clarify remote Superset usage with Clawdbot/OpenClaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,21 @@ If it runs in a terminal, it runs on Superset
 
 **[Download Superset for macOS](https://github.com/superset-sh/superset/releases/latest)**
 
+### Running Superset on a remote machine (Clawdbot/OpenClaw)
+
+Superset is a desktop app, so it needs to run on a macOS machine with a GUI session.
+
+If you want to use it remotely, there are two supported setups:
+
+1. **Run Superset locally, connect to remote repos via SSH in terminals**
+   - Open your repo in Superset as normal
+   - Use SSH/Tailscale/VPN inside Superset terminals for remote development
+2. **Run Superset on a remote Mac and access that desktop remotely**
+   - Keep Superset running on the remote host
+   - Connect via your preferred remote desktop workflow
+
+If your setup has DNS/privacy blockers enabled, make sure required Superset API domains are reachable or login/session sync may fail.
+
 ### Build from Source
 
 <details>


### PR DESCRIPTION
## Summary\n- add a dedicated README section for running Superset with remote machine setups\n- document two supported workflows (local app + remote SSH, or remote Mac + remote desktop)\n- add DNS/privacy blocker caveat so users can avoid login/session sync failures\n\nCloses #959

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a README section for using Superset on remote machines (Clawdbot/OpenClaw). It covers two workflows (local app + SSH to remote repos, or remote Mac + remote desktop) and warns to allow required API domains when using DNS/privacy blockers to avoid login/session sync issues, addressing #959.

<sup>Written for commit bdaab351f413f0928578fc00d7045998d2dac71d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on running Superset on a remote machine with multiple setup options and considerations for DNS/privacy blockers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->