### PR TITLE
fix: honor preset relative cwd when auto-running commands

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/launch-command.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/launch-command.test.ts
@@ -31,6 +31,28 @@ describe("launchCommandInPane", () => {
 		});
 	});
 
+	it("passes cwd override when provided", async () => {
+		const createOrAttach = mock(async () => ({}));
+		const write = mock(async () => ({}));
+
+		await launchCommandInPane({
+			paneId: "pane-1",
+			tabId: "tab-1",
+			workspaceId: "ws-1",
+			cwd: "./apps",
+			command: "pwd",
+			createOrAttach,
+			write,
+		});
+
+		expect(createOrAttach).toHaveBeenCalledWith({
+			paneId: "pane-1",
+			tabId: "tab-1",
+			workspaceId: "ws-1",
+			cwd: "./apps",
+		});
+	});
+
 	it("does not append a second newline when command already has one", async () => {
 		const createOrAttach = mock(async () => ({}));
 		const write = mock(async () => ({}));

--- a/apps/desktop/src/renderer/lib/terminal/launch-command.ts
+++ b/apps/desktop/src/renderer/lib/terminal/launch-command.ts
@@ -2,6 +2,7 @@ interface TerminalCreateOrAttachInput {
 	paneId: string;
 	tabId: string;
 	workspaceId: string;
+	cwd?: string;
 }
 
 interface TerminalWriteInput {
@@ -14,6 +15,7 @@ interface LaunchCommandInPaneOptions {
 	paneId: string;
 	tabId: string;
 	workspaceId: string;
+	cwd?: string;
 	command: string;
 	createOrAttach: (input: TerminalCreateOrAttachInput) => Promise<unknown>;
 	write: (input: TerminalWriteInput) => Promise<unknown>;
@@ -68,15 +70,25 @@ export async function launchCommandInPane({
 	paneId,
 	tabId,
 	workspaceId,
+	cwd,
 	command,
 	createOrAttach,
 	write,
 }: LaunchCommandInPaneOptions): Promise<void> {
-	await createOrAttach({
-		paneId,
-		tabId,
-		workspaceId,
-	});
+	if (cwd === undefined) {
+		await createOrAttach({
+			paneId,
+			tabId,
+			workspaceId,
+		});
+	} else {
+		await createOrAttach({
+			paneId,
+			tabId,
+			workspaceId,
+			cwd,
+		});
+	}
 
 	await writeCommandInPane({ paneId, command, write });
 }

--- a/apps/desktop/src/renderer/stores/tabs/useTabsWithPresets.ts
+++ b/apps/desktop/src/renderer/stores/tabs/useTabsWithPresets.ts
@@ -37,6 +37,7 @@ interface PresetPaneLaunch {
 	tabId: string;
 	workspaceId: string;
 	command: string;
+	cwd?: string;
 }
 
 function preparePreset(preset: TerminalPreset): PreparedPreset {
@@ -70,6 +71,7 @@ export function useTabsWithPresets() {
 		() => (firstPreset ? buildTerminalCommand(firstPreset.commands) : null),
 		[firstPreset],
 	);
+	const firstPresetInitialCwd = firstPreset?.cwd || undefined;
 
 	const firstPresetOptions: AddTabOptions | undefined = useMemo(() => {
 		if (!firstPreset) return undefined;
@@ -98,11 +100,12 @@ export function useTabsWithPresets() {
 	}, []);
 
 	const launchPresetCommand = useCallback(
-		({ paneId, tabId, workspaceId, command }: PresetPaneLaunch) => {
+		({ paneId, tabId, workspaceId, command, cwd }: PresetPaneLaunch) => {
 			void launchCommandInPane({
 				paneId,
 				tabId,
 				workspaceId,
+				cwd,
 				command,
 				createOrAttach: (input) => createOrAttach.mutateAsync(input),
 				write: (input) => writeToTerminal.mutateAsync(input),
@@ -111,6 +114,7 @@ export function useTabsWithPresets() {
 					paneId,
 					tabId,
 					workspaceId,
+					cwd,
 					error: error instanceof Error ? error.message : String(error),
 				});
 			});
@@ -144,9 +148,15 @@ export function useTabsWithPresets() {
 				tabId,
 				workspaceId,
 				command: firstPresetCommand,
+				cwd: firstPresetInitialCwd,
 			});
 		},
-		[firstPresetCommand, launchPresetCommand, resolveWorkspaceIdForTab],
+		[
+			firstPresetCommand,
+			firstPresetInitialCwd,
+			launchPresetCommand,
+			resolveWorkspaceIdForTab,
+		],
 	);
 
 	const launchFirstPresetInFocusedPane = useCallback(
@@ -162,9 +172,10 @@ export function useTabsWithPresets() {
 				tabId,
 				workspaceId: tab.workspaceId,
 				command: firstPresetCommand,
+				cwd: firstPresetInitialCwd,
 			});
 		},
-		[firstPresetCommand, launchPresetCommand],
+		[firstPresetCommand, firstPresetInitialCwd, launchPresetCommand],
 	);
 
 	const executePresetInNewTab = useCallback(
@@ -187,6 +198,7 @@ export function useTabsWithPresets() {
 						tabId: result.tabId,
 						workspaceId,
 						command,
+						cwd: preset.initialCwd,
 					});
 					applyTabName(result.tabId, preset.name);
 				}
@@ -212,7 +224,15 @@ export function useTabsWithPresets() {
 					(paneId, index) => {
 						const command = preset.commands[index];
 						if (command === undefined) return [];
-						return [{ paneId, tabId: multiPane.tabId, workspaceId, command }];
+						return [
+							{
+								paneId,
+								tabId: multiPane.tabId,
+								workspaceId,
+								command,
+								cwd: preset.initialCwd,
+							},
+						];
 					},
 				);
 				launchPresetCommands(launches);
@@ -230,6 +250,7 @@ export function useTabsWithPresets() {
 					tabId: result.tabId,
 					workspaceId,
 					command,
+					cwd: preset.initialCwd,
 				});
 			}
 			applyTabName(result.tabId, preset.name);
@@ -268,7 +289,15 @@ export function useTabsWithPresets() {
 						(paneId, index) => {
 							const command = preset.commands[index];
 							if (command === undefined) return [];
-							return [{ paneId, tabId: activeTabId, workspaceId, command }];
+							return [
+								{
+									paneId,
+									tabId: activeTabId,
+									workspaceId,
+									command,
+									cwd: preset.initialCwd,
+								},
+							];
 						},
 					);
 					launchPresetCommands(launches);
@@ -289,6 +318,7 @@ export function useTabsWithPresets() {
 							tabId: activeTabId,
 							workspaceId,
 							command,
+							cwd: preset.initialCwd,
 						});
 					}
 					return { tabId: activeTabId, paneId };


### PR DESCRIPTION
## Summary
- pass preset cwd through launchCommandInPane to terminal.createOrAttach
- thread preset initialCwd through all preset auto-launch paths (new-tab, split-pane, first-preset launches)
- add unit coverage to ensure cwd is forwarded when provided

## Why
Preset commands were being auto-launched via launchCommandInPane, but that helper called createOrAttach without the preset cwd. This could start sessions in the workspace root and make relative preset directories (like ./apps) appear ignored.

## Validation
- bun test apps/desktop/src/renderer/lib/terminal/launch-command.test.ts
- bunx biome check apps/desktop/src/renderer/lib/terminal/launch-command.ts apps/desktop/src/renderer/lib/terminal/launch-command.test.ts apps/desktop/src/renderer/stores/tabs/useTabsWithPresets.ts

Closes #1916


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures preset commands always run in their configured cwd (including relative paths) across all auto-launch flows, instead of defaulting to the workspace root. Closes #1916.

- **Bug Fixes**
  - Thread cwd through launchCommandInPane to createOrAttach.
  - Pass preset.initialCwd to all preset launch paths (startup first preset, focused pane, new tab, multi-pane).
  - Add unit test to verify cwd is forwarded during terminal creation.

<sup>Written for commit 206e6096bde4594e41ed83c908f329a5a0d815e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added the ability to specify a working directory when launching terminal panes, enabling users to control the initial working directory for both direct terminal launches and preset-based launch configurations.

* **Tests**
  * Added comprehensive test coverage to validate that the working directory parameter is correctly propagated during terminal pane launch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->