### PR TITLE
fix(desktop): derive branch names from prompt before random fallback

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
@@ -3,6 +3,8 @@ import { and, eq, isNull, not } from "drizzle-orm";
 import { track } from "main/lib/analytics";
 import { localDb } from "main/lib/local-db";
 import { workspaceInitManager } from "main/lib/workspace-init-manager";
+import { deduplicateBranchName } from "shared/utils/branch";
+import { deriveWorkspaceBranchFromPrompt } from "shared/utils/workspace-naming";
 import { z } from "zod";
 import { publicProcedure, router } from "../../..";
 import { attemptWorkspaceAutoRenameFromPrompt } from "../utils/ai-name";
@@ -360,6 +362,10 @@ export const createCreateProcedures = () => {
 
 				const withPrefix = (name: string): string =>
 					branchPrefix ? `${branchPrefix}/${name}` : name;
+				const requestedBranchName = input.branchName?.trim();
+				const promptDerivedBranchName = !existingBranchName && !requestedBranchName
+					? deriveWorkspaceBranchFromPrompt(input.prompt ?? input.name ?? "")
+					: "";
 
 				let branch: string;
 				if (existingBranchName) {
@@ -369,11 +375,20 @@ export const createCreateProcedures = () => {
 						);
 					}
 					branch = existingBranchName;
-				} else if (input.branchName?.trim()) {
+				} else if (requestedBranchName) {
 					branch = sanitizeBranchNameWithMaxLength(
-						withPrefix(input.branchName),
+						withPrefix(requestedBranchName),
 						undefined,
 						{ preserveFirstSegmentCase: true },
+					);
+				} else if (promptDerivedBranchName) {
+					branch = deduplicateBranchName(
+						sanitizeBranchNameWithMaxLength(
+							withPrefix(promptDerivedBranchName),
+							undefined,
+							{ preserveFirstSegmentCase: true },
+						),
+						existingBranches,
 					);
 				} else {
 					branch = generateBranchName({
@@ -382,7 +397,7 @@ export const createCreateProcedures = () => {
 					});
 				}
 
-				if (input.branchName?.trim()) {
+				if (requestedBranchName) {
 					const existing = findWorktreeWorkspaceByBranch({
 						projectId: input.projectId,
 						branch,


### PR DESCRIPTION
## Summary
- derive a deterministic branch candidate from `prompt` (or `name`) when `branchName` is not explicitly provided
- deduplicate prompt-derived branch names with numeric suffixes instead of immediately falling back to random adjective-noun names
- keep existing random generation as a last-resort fallback when no prompt/name slug is available

This restores title/prompt-based branch naming behavior for the new workspace flow and avoids surprising random branch names for normal prompt-based workspace creation.

Fixes #2177

## Testing
- `bun test apps/desktop/src/shared/utils/workspace-naming.test.ts apps/desktop/src/shared/utils/branch.test.ts`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the prompt/title to derive workspace branch names before falling back to random names. Restores predictable branch naming in the new workspace flow and avoids unexpected random branches. Fixes #2177.

- **Bug Fixes**
  - Derive a branch candidate from prompt/title when branchName isn’t provided.
  - Deduplicate prompt-derived names with numeric suffixes if they already exist.
  - Keep random adjective-noun generation as a final fallback.

<sup>Written for commit 5555c58dfffbcafe8a38d7b0785c16fd8869b22b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced branch name resolution logic during workspace creation with improved deduplication and support for deriving branch names from prompts when branch names are not explicitly provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->