### PR TITLE
fix(chat): make bash tool output selectable/copyable

### DIFF
--- a/packages/ui/src/components/ai-elements/bash-tool.tsx
+++ b/packages/ui/src/components/ai-elements/bash-tool.tsx
@@ -61,7 +61,7 @@ export const BashTool = ({
 
 	return (
 		<Collapsible
-			className={cn("overflow-hidden rounded-md", className)}
+			className={cn("overflow-hidden rounded-md select-text", className)}
 			onOpenChange={(open) => hasOutput && setIsOutputExpanded(open)}
 			open={hasOutput ? isOutputExpanded : false}
 		>
@@ -114,7 +114,7 @@ export const BashTool = ({
 						{command && (
 							<div className="font-mono text-xs">
 								<span className="text-amber-600 dark:text-amber-400">$ </span>
-								<span className="whitespace-pre-wrap break-all text-foreground">
+								<span className="select-text whitespace-pre-wrap break-all text-foreground">
 									{command}
 								</span>
 							</div>
@@ -122,7 +122,7 @@ export const BashTool = ({
 
 						{/* Stdout */}
 						{stdout && (
-							<div className="mt-1.5 whitespace-pre-wrap break-all font-mono text-xs text-muted-foreground">
+							<div className="mt-1.5 select-text whitespace-pre-wrap break-all font-mono text-xs text-muted-foreground">
 								{stdout}
 							</div>
 						)}
@@ -131,7 +131,7 @@ export const BashTool = ({
 						{stderr && (
 							<div
 								className={cn(
-									"mt-1.5 whitespace-pre-wrap break-all font-mono text-xs",
+									"mt-1.5 select-text whitespace-pre-wrap break-all font-mono text-xs",
 									exitCode === 0 || exitCode === undefined
 										? "text-amber-600 dark:text-amber-400"
 										: "text-rose-500 dark:text-rose-400",


### PR DESCRIPTION
## Summary
- add explicit `select-text` styling to Bash tool message blocks
- ensure command/stdout/stderr text can be highlighted and copied from assistant output

## Testing
- `bunx biome check packages/ui/src/components/ai-elements/bash-tool.tsx`

Closes #2184

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes non-selectable Bash tool output in chat. Users can now highlight and copy commands, stdout, and stderr from assistant messages (Linear #2184).

<sup>Written for commit b2c3f89c5f270df77e793c451456dadb1c7c64ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text selection functionality in bash tool output, enabling users to select and copy text from command output, command lines, and error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->