### PR TITLE
fix(desktop): retry auth session recovery on sign-in

### DIFF
--- a/apps/desktop/src/renderer/routes/sign-in/components/SessionRecoveryNotice/SessionRecoveryNotice.tsx
+++ b/apps/desktop/src/renderer/routes/sign-in/components/SessionRecoveryNotice/SessionRecoveryNotice.tsx
@@ -1,0 +1,41 @@
+import { Button } from "@superset/ui/button";
+import { Spinner } from "@superset/ui/spinner";
+
+interface SessionRecoveryNoticeProps {
+	isOnline: boolean;
+	isRecoveringSession: boolean;
+	isRetryPending: boolean;
+	onRetry: () => void;
+}
+
+export function SessionRecoveryNotice({
+	isOnline,
+	isRecoveringSession,
+	isRetryPending,
+	onRetry,
+}: SessionRecoveryNoticeProps) {
+	return (
+		<div className="mb-6 flex w-full max-w-xs flex-col items-center gap-3 rounded-lg border border-border/60 bg-muted/20 px-4 py-3 text-center">
+			<div className="flex items-center gap-2 text-sm text-muted-foreground">
+				{isRecoveringSession ? (
+					<>
+						<Spinner className="size-4" />
+						<span>Retrying automatically on focus and every 15s</span>
+					</>
+				) : (
+					<span>
+						Session still unavailable. You can retry now or sign in again.
+					</span>
+				)}
+			</div>
+			<Button
+				variant="outline"
+				size="sm"
+				onClick={onRetry}
+				disabled={!isOnline || isRetryPending}
+			>
+				{isRetryPending ? "Retrying..." : "Retry now"}
+			</Button>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/sign-in/components/SessionRecoveryNotice/index.ts
+++ b/apps/desktop/src/renderer/routes/sign-in/components/SessionRecoveryNotice/index.ts
@@ -1,0 +1,1 @@
+export { SessionRecoveryNotice } from "./SessionRecoveryNotice";

--- a/apps/desktop/src/renderer/routes/sign-in/hooks/useSessionRecovery/index.ts
+++ b/apps/desktop/src/renderer/routes/sign-in/hooks/useSessionRecovery/index.ts
@@ -1,0 +1,1 @@
+export { useSessionRecovery } from "./useSessionRecovery";

--- a/apps/desktop/src/renderer/routes/sign-in/hooks/useSessionRecovery/useSessionRecovery.ts
+++ b/apps/desktop/src/renderer/routes/sign-in/hooks/useSessionRecovery/useSessionRecovery.ts
@@ -1,0 +1,82 @@
+import { useEffect, useEffectEvent, useRef, useState } from "react";
+import { useOnlineStatus } from "renderer/hooks/useOnlineStatus";
+import { authClient, getAuthToken } from "renderer/lib/auth-client";
+
+const SESSION_RECOVERY_INTERVAL_MS = 15_000;
+
+export function useSessionRecovery() {
+	const {
+		data: session,
+		isPending,
+		isRefetching,
+		refetch,
+	} = authClient.useSession();
+	const isOnline = useOnlineStatus();
+	const hasLocalToken = !!getAuthToken();
+	const [hasRecoveryAttempted, setHasRecoveryAttempted] = useState(false);
+	const recoveryInFlightRef = useRef(false);
+
+	const retrySessionRecovery = useEffectEvent(async () => {
+		if (
+			!hasLocalToken ||
+			!!session?.user ||
+			!isOnline ||
+			recoveryInFlightRef.current
+		) {
+			return;
+		}
+
+		recoveryInFlightRef.current = true;
+		setHasRecoveryAttempted(true);
+
+		try {
+			await refetch();
+		} catch (error) {
+			console.warn("[sign-in] session recovery refetch failed", error);
+		} finally {
+			recoveryInFlightRef.current = false;
+		}
+	});
+
+	useEffect(() => {
+		if (!hasLocalToken || !!session?.user || !isOnline) {
+			return;
+		}
+
+		void retrySessionRecovery();
+
+		const interval = window.setInterval(() => {
+			void retrySessionRecovery();
+		}, SESSION_RECOVERY_INTERVAL_MS);
+
+		const handleWindowFocus = () => {
+			void retrySessionRecovery();
+		};
+
+		const handleVisibilityChange = () => {
+			if (document.visibilityState === "visible") {
+				void retrySessionRecovery();
+			}
+		};
+
+		window.addEventListener("focus", handleWindowFocus);
+		document.addEventListener("visibilitychange", handleVisibilityChange);
+
+		return () => {
+			window.clearInterval(interval);
+			window.removeEventListener("focus", handleWindowFocus);
+			document.removeEventListener("visibilitychange", handleVisibilityChange);
+		};
+	}, [hasLocalToken, isOnline, session?.user]);
+
+	return {
+		hasLocalToken,
+		isOnline,
+		isPending,
+		isRecoveringSession:
+			hasLocalToken && (isRefetching || !hasRecoveryAttempted),
+		isRetryPending: isRefetching,
+		retrySessionRecovery,
+		session,
+	};
+}

--- a/apps/desktop/src/renderer/routes/sign-in/page.tsx
+++ b/apps/desktop/src/renderer/routes/sign-in/page.tsx
@@ -6,17 +6,26 @@ import { FaGithub } from "react-icons/fa";
 import { FcGoogle } from "react-icons/fc";
 import { env } from "renderer/env.renderer";
 import { track } from "renderer/lib/analytics";
-import { authClient } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { SessionRecoveryNotice } from "./components/SessionRecoveryNotice";
 import { SupersetLogo } from "./components/SupersetLogo";
+import { useSessionRecovery } from "./hooks/useSessionRecovery";
 
 export const Route = createFileRoute("/sign-in/")({
 	component: SignInPage,
 });
 
 function SignInPage() {
-	const { data: session, isPending } = authClient.useSession();
 	const signInMutation = electronTrpc.auth.signIn.useMutation();
+	const {
+		hasLocalToken,
+		isOnline,
+		isPending,
+		isRecoveringSession,
+		isRetryPending,
+		retrySessionRecovery,
+		session,
+	} = useSessionRecovery();
 
 	// Dev bypass: skip sign-in entirely
 	if (env.SKIP_ENV_VALIDATION) {
@@ -57,9 +66,20 @@ function SignInPage() {
 							Welcome to Superset
 						</h1>
 						<p className="text-sm text-muted-foreground">
-							Sign in to get started
+							{hasLocalToken
+								? "Restoring your session"
+								: "Sign in to get started"}
 						</p>
 					</div>
+
+					{hasLocalToken ? (
+						<SessionRecoveryNotice
+							isOnline={isOnline}
+							isRecoveringSession={isRecoveringSession}
+							isRetryPending={isRetryPending}
+							onRetry={() => void retrySessionRecovery()}
+						/>
+					) : null}
 
 					<div className="flex flex-col gap-3 w-full max-w-xs">
 						<Button
@@ -67,6 +87,7 @@ function SignInPage() {
 							size="lg"
 							onClick={() => signIn("github")}
 							className="w-full gap-3"
+							disabled={signInMutation.isPending}
 						>
 							<FaGithub className="size-5" />
 							Continue with GitHub
@@ -77,6 +98,7 @@ function SignInPage() {
 							size="lg"
 							onClick={() => signIn("google")}
 							className="w-full gap-3"
+							disabled={signInMutation.isPending}
 						>
 							<FcGoogle className="size-5" />
 							Continue with Google


### PR DESCRIPTION
## Summary
- retry desktop session recovery when the sign-in screen is shown but a local auth token still exists
- revalidate session on focus, when the window becomes visible, and on a 15s interval so wifi changes recover without a renderer refresh
- refactor the recovery logic into a route-local hook and component for easier maintenance

## Testing
- bunx @biomejs/biome check apps/desktop/src/renderer/routes/sign-in/page.tsx apps/desktop/src/renderer/routes/sign-in/hooks/useSessionRecovery/useSessionRecovery.ts apps/desktop/src/renderer/routes/sign-in/components/SessionRecoveryNotice/SessionRecoveryNotice.tsx
- bun --filter @superset/desktop typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries desktop auth session recovery on the sign-in screen when a local token exists, and keeps retrying on focus, visibility, and every 15s so network changes recover without a refresh. Adds a small notice with a manual “Retry now” action.

- **Bug Fixes**
  - Retry session recovery if a local token is present.
  - Revalidate on focus, when visible, and every 15s; skip when offline; block concurrent retries.

- **Refactors**
  - Extracted logic into useSessionRecovery hook and SessionRecoveryNotice component.
  - Updated sign-in page to use the hook, show the notice, and disable provider buttons during sign-in.

<sup>Written for commit c853803e9cc53a40940360121de6cba2f19dd742. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic session recovery during sign-in with manual retry option
  * Session recovery attempts happen automatically every 15 seconds when online
  * Sign-in page displays recovery status and allows users to trigger retries immediately
  * Sign-in buttons remain disabled while recovery is in progress

<!-- end of auto-generated comment: release notes by coderabbit.ai -->