### PR TITLE
fix(desktop): keep unrelated panes interactive during drag

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/BasePaneWindow.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/BasePaneWindow.tsx
@@ -5,6 +5,7 @@ import { useDragPaneStore } from "renderer/stores/drag-pane-store";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import type { SplitOrientation } from "../../hooks";
 import { useSplitOrientation } from "../../hooks";
+import { shouldDisablePanePointerEvents } from "./pointer-events";
 
 export interface PaneHandlers {
 	onFocus: () => void;
@@ -56,10 +57,15 @@ export function BasePaneWindow({
 	const isActive = useTabsStore((s) => s.focusedPaneIds[tabId] === paneId);
 	const containerRef = useRef<HTMLDivElement>(null);
 	const splitOrientation = useSplitOrientation(containerRef);
-	const isDragging = useDragPaneStore((s) => s.draggingPaneId !== null);
+	const draggingPaneId = useDragPaneStore((s) => s.draggingPaneId);
 	const isResizing = useDragPaneStore((s) => s.isResizing);
 	const setDragging = useDragPaneStore((s) => s.setDragging);
 	const clearDragging = useDragPaneStore((s) => s.clearDragging);
+	const shouldDisablePointerEvents = shouldDisablePanePointerEvents({
+		draggingPaneId,
+		paneId,
+		isResizing,
+	});
 
 	const handleFocus = () => {
 		setFocusedPane(tabId, paneId);
@@ -107,7 +113,7 @@ export function BasePaneWindow({
 			<div
 				ref={containerRef}
 				className={contentClassName}
-				style={isDragging || isResizing ? { pointerEvents: "none" } : undefined}
+				style={shouldDisablePointerEvents ? { pointerEvents: "none" } : undefined}
 				onClick={handleFocus}
 			>
 				{children}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/pointer-events.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/pointer-events.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import { shouldDisablePanePointerEvents } from "./pointer-events";
+
+describe("shouldDisablePanePointerEvents", () => {
+  it("disables pointer events for the pane currently being dragged", () => {
+    expect(
+      shouldDisablePanePointerEvents({
+        draggingPaneId: "pane-a",
+        paneId: "pane-a",
+        isResizing: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps unrelated panes interactive while another pane is being dragged", () => {
+    expect(
+      shouldDisablePanePointerEvents({
+        draggingPaneId: "pane-a",
+        paneId: "pane-b",
+        isResizing: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("still disables pointer events while resizing", () => {
+    expect(
+      shouldDisablePanePointerEvents({
+        draggingPaneId: null,
+        paneId: "pane-b",
+        isResizing: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/pointer-events.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/pointer-events.ts
@@ -1,0 +1,20 @@
+export interface PanePointerEventsOptions {
+  draggingPaneId: string | null;
+  paneId: string;
+  isResizing: boolean;
+}
+
+/**
+ * Disable pointer events only for the pane being dragged.
+ *
+ * Keeping all panes inert during any drag can leave unrelated terminals feeling
+ * unscrollable when drag state lingers or when a different pane is being moved.
+ */
+export function shouldDisablePanePointerEvents({
+  draggingPaneId,
+  paneId,
+  isResizing,
+}: PanePointerEventsOptions): boolean {
+  if (isResizing) return true;
+  return draggingPaneId === paneId;
+}


### PR DESCRIPTION
## Summary
- limit pane pointer-event disabling to the pane currently being dragged
- keep the existing resize guard in place
- add a focused unit test for the pointer-event gating logic

## Why
When any pane drag was active, every pane in the tab view became `pointer-events: none`. That makes unrelated terminal panes feel dead/unscrollable if drag state lingers or a different pane is being moved.

## Testing
- `bun test apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/pointer-events.test.ts`

Closes #2183

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make panes stay interactive during drag by only disabling pointer events on the pane being moved. Keeps terminals scrollable and addresses #2183.

- **Bug Fixes**
  - Add shouldDisablePanePointerEvents helper to gate pointer events by draggingPaneId, paneId, and isResizing.
  - Use the helper in BasePaneWindow to apply pointer-events only when needed.
  - Add a focused unit test for the gating logic.

<sup>Written for commit 22e94009e45ce06538c6ef4d9e6f8cd01ab75225. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pointer event handling during pane dragging and resizing to improve interaction responsiveness and prevent unintended interactions with inactive panes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->