### PR TITLE
fix(auth): gate member-added email to accepted invitations

### DIFF
--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -349,18 +349,31 @@ export const auth = betterAuth({
 						),
 					});
 
-					await resend.emails.send({
-						from: "Superset <noreply@superset.sh>",
-						to: user.email,
-						subject: `You've been added to ${organization.name}`,
-						react: MemberAddedEmail({
-							memberName: user.name,
-							organizationName: organization.name,
-							role: member.role,
-							addedByName: "A team admin",
-							dashboardLink: env.NEXT_PUBLIC_WEB_URL,
-						}),
+					// This email is invitation-specific. Auto-enroll and direct addMember
+					// calls should not send the invite-style "you were added" message.
+					const acceptedInvitation = await db.query.invitations.findFirst({
+						where: and(
+							eq(authSchema.invitations.organizationId, organization.id),
+							eq(authSchema.invitations.email, user.email),
+							eq(authSchema.invitations.status, "accepted"),
+						),
+						orderBy: desc(authSchema.invitations.createdAt),
 					});
+
+					if (acceptedInvitation) {
+						await resend.emails.send({
+							from: "Superset <noreply@superset.sh>",
+							to: user.email,
+							subject: `You've been added to ${organization.name}`,
+							react: MemberAddedEmail({
+								memberName: user.name,
+								organizationName: organization.name,
+								role: member.role,
+								addedByName: "A team admin",
+								dashboardLink: env.NEXT_PUBLIC_WEB_URL,
+							}),
+						});
+					}
 
 					if (!subscription?.stripeSubscriptionId) return;
 					if (subscription.plan === "enterprise") return;


### PR DESCRIPTION
## Summary
- prevent invite-style `MemberAddedEmail` from sending for signup auto-enroll flows
- in `organizationHooks.afterAddMember`, send `MemberAddedEmail` only when an accepted invitation exists for the same org + email
- keep billing/seat side effects unchanged

## Validation
- `bun run lint` ✅
- `bun test` ❌ (workspace dependency/module resolution failures in this environment, e.g. missing `dotenv`, `zod`, `@superset/chat/shared`, etc.)
- `bun run typecheck` ❌ (fails because `turbo` not on PATH in this shell)
- `bunx turbo typecheck` ❌ (fails in existing workspace setup at `apps/electric-proxy`: missing `@cloudflare/workers-types` and missing shared tsconfig)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send the “member added” email only when a user accepts an invitation. Prevents invite-style emails for auto-enroll and direct add flows; billing/seat logic is unchanged.

- **Bug Fixes**
  - Gate `MemberAddedEmail` in `organizationHooks.afterAddMember` behind a check for a matching accepted invitation.
  - Skip the email for auto-enroll and direct adds; keep subscription/seat handling unchanged.

<sup>Written for commit 311a94fb8c662f386c3f3e73543b7fda75feeddd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated invitation email sending behavior when adding members to organizations to only send emails when a prior accepted invitation exists for that user within the organization. Subscription checks, billing updates, and Slack notifications remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->