### PR TITLE
feat(desktop): add right-click context menu for browser webview links

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/browser/browser.ts
+++ b/apps/desktop/src/lib/trpc/routers/browser/browser.ts
@@ -115,6 +115,20 @@ export const createBrowserRouter = () => {
 				});
 			}),
 
+		onContextMenuAction: publicProcedure
+			.input(z.object({ paneId: z.string() }))
+			.subscription(({ input }) => {
+				return observable<{ action: string; url: string }>((emit) => {
+					const handler = (data: { action: string; url: string }) => {
+						emit.next(data);
+					};
+					browserManager.on(`context-menu-action:${input.paneId}`, handler);
+					return () => {
+						browserManager.off(`context-menu-action:${input.paneId}`, handler);
+					};
+				});
+			}),
+
 		openDevTools: publicProcedure
 			.input(z.object({ paneId: z.string() }))
 			.mutation(({ input }) => {

--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "node:events";
-import { app, clipboard, webContents } from "electron";
+import { app, clipboard, Menu, shell, webContents } from "electron";
 
 interface ConsoleEntry {
 	level: "log" | "warn" | "error" | "info" | "debug";
@@ -26,15 +26,18 @@ class BrowserManager extends EventEmitter {
 	private paneWebContentsIds = new Map<string, number>();
 	private consoleLogs = new Map<string, ConsoleEntry[]>();
 	private consoleListeners = new Map<string, () => void>();
+	private contextMenuListeners = new Map<string, () => void>();
 
 	register(paneId: string, webContentsId: number): void {
-		// Clean up previous console listener if re-registering with a new webContentsId
+		// Clean up previous listeners if re-registering with a new webContentsId
 		const prevId = this.paneWebContentsIds.get(paneId);
 		if (prevId != null && prevId !== webContentsId) {
-			const cleanup = this.consoleListeners.get(paneId);
-			if (cleanup) {
-				cleanup();
-				this.consoleListeners.delete(paneId);
+			for (const map of [this.consoleListeners, this.contextMenuListeners]) {
+				const cleanup = map.get(paneId);
+				if (cleanup) {
+					cleanup();
+					map.delete(paneId);
+				}
 			}
 		}
 		this.paneWebContentsIds.set(paneId, webContentsId);
@@ -50,14 +53,17 @@ class BrowserManager extends EventEmitter {
 				return { action: "deny" as const };
 			});
 			this.setupConsoleCapture(paneId, wc);
+			this.setupContextMenu(paneId, wc);
 		}
 	}
 
 	unregister(paneId: string): void {
-		const cleanup = this.consoleListeners.get(paneId);
-		if (cleanup) {
-			cleanup();
-			this.consoleListeners.delete(paneId);
+		for (const map of [this.consoleListeners, this.contextMenuListeners]) {
+			const cleanup = map.get(paneId);
+			if (cleanup) {
+				cleanup();
+				map.delete(paneId);
+			}
 		}
 		this.paneWebContentsIds.delete(paneId);
 		this.consoleLogs.delete(paneId);
@@ -155,6 +161,116 @@ class BrowserManager extends EventEmitter {
 		} catch {
 			return null;
 		}
+	}
+
+	private setupContextMenu(paneId: string, wc: Electron.WebContents): void {
+		const handler = (
+			_event: Electron.Event,
+			params: Electron.ContextMenuParams,
+		) => {
+			const { linkURL, pageURL, selectionText, editFlags } = params;
+
+			const menuItems: Electron.MenuItemConstructorOptions[] = [];
+
+			if (linkURL) {
+				menuItems.push(
+					{
+						label: "Open Link in Default Browser",
+						click: () => shell.openExternal(linkURL),
+					},
+					{
+						label: "Open Link as New Split",
+						click: () =>
+							this.emit(`context-menu-action:${paneId}`, {
+								action: "open-in-split" as const,
+								url: linkURL,
+							}),
+					},
+					{
+						label: "Copy Link Address",
+						click: () => clipboard.writeText(linkURL),
+					},
+					{ type: "separator" },
+				);
+			}
+
+			if (selectionText) {
+				menuItems.push({
+					label: "Copy",
+					enabled: editFlags.canCopy,
+					click: () => wc.copy(),
+				});
+			}
+
+			if (editFlags.canPaste) {
+				menuItems.push({
+					label: "Paste",
+					click: () => wc.paste(),
+				});
+			}
+
+			if (editFlags.canSelectAll) {
+				menuItems.push({
+					label: "Select All",
+					click: () => wc.selectAll(),
+				});
+			}
+
+			if (selectionText || editFlags.canPaste || editFlags.canSelectAll) {
+				menuItems.push({ type: "separator" });
+			}
+
+			menuItems.push(
+				{
+					label: "Back",
+					enabled: wc.canGoBack(),
+					click: () => wc.goBack(),
+				},
+				{
+					label: "Forward",
+					enabled: wc.canGoForward(),
+					click: () => wc.goForward(),
+				},
+				{
+					label: "Reload",
+					click: () => wc.reload(),
+				},
+			);
+
+			if (!linkURL) {
+				menuItems.push(
+					{ type: "separator" },
+					{
+						label: "Open Page in Default Browser",
+						click: () => {
+							if (pageURL && pageURL !== "about:blank") {
+								shell.openExternal(pageURL);
+							}
+						},
+						enabled: !!pageURL && pageURL !== "about:blank",
+					},
+					{
+						label: "Copy Page URL",
+						click: () => {
+							if (pageURL) clipboard.writeText(pageURL);
+						},
+						enabled: !!pageURL && pageURL !== "about:blank",
+					},
+				);
+			}
+
+			const menu = Menu.buildFromTemplate(menuItems);
+			menu.popup();
+		};
+
+		wc.on("context-menu", handler);
+		this.contextMenuListeners.set(paneId, () => {
+			try {
+				wc.off("context-menu", handler);
+			} catch {
+				// webContents may be destroyed
+			}
+		});
 	}
 
 	private setupConsoleCapture(paneId: string, wc: Electron.WebContents): void {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
@@ -99,6 +99,23 @@ export function usePersistentWebview({
 		},
 	);
 
+	// Subscribe to context menu actions (e.g. "Open Link as New Split")
+	electronTrpc.browser.onContextMenuAction.useSubscription(
+		{ paneId },
+		{
+			onData: ({ action, url }: { action: string; url: string }) => {
+				if (action === "open-in-split") {
+					const state = useTabsStore.getState();
+					const pane = state.panes[paneId];
+					if (!pane) return;
+					const tab = state.tabs.find((t) => t.id === pane.tabId);
+					if (!tab) return;
+					state.openInBrowserPane(tab.workspaceId, url);
+				}
+			},
+		},
+	);
+
 	// Sync store from webview state (handles agent-triggered navigation while hidden)
 	const syncStoreFromWebview = useCallback(
 		(webview: Electron.WebviewTag) => {

--- a/bun.lock
+++ b/bun.lock
@@ -109,7 +109,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.1.0",
+      "version": "1.1.2",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.43",
         "@ai-sdk/openai": "3.0.36",


### PR DESCRIPTION
## Summary
- Adds a native Electron context menu when right-clicking in the browser webview
- **On links**: "Open Link in Default Browser", "Open Link as New Split", "Copy Link Address"
- **On page**: Copy/Paste/Select All, Back/Forward/Reload, "Open Page in Default Browser", "Copy Page URL"
- "Open as New Split" opens the link URL in a new/existing browser split pane via `openInBrowserPane`

Closes https://linear.app/superset/issue/add-right-click-context-menu-for-links-in-superset

## Test plan
- [ ] Right-click an `<a>` link in the browser — verify link-specific items appear
- [ ] "Open Link in Default Browser" opens the URL in the system browser
- [ ] "Open Link as New Split" opens the URL in a new browser split pane
- [ ] "Copy Link Address" copies the URL to clipboard
- [ ] Right-click on page background — verify standard menu without link items
- [ ] Copy/Paste/Select All work correctly when applicable
- [ ] Back/Forward/Reload navigation items work

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native right-click context menu to the desktop browser pane webview with link actions and standard page controls. Fulfills the Linear request to add link context menus and supports opening links in a new split.

- **New Features**
  - Link menu: Open in Default Browser, Open as New Split, Copy Link Address.
  - Page menu: Copy/Paste/Select All, Back/Forward/Reload, Open Page in Default Browser, Copy Page URL.
  - Wiring: main process builds the menu and emits `context-menu-action:<paneId>`; new `browser.onContextMenuAction` subscription routes "open-in-split" to `openInBrowserPane`.

<sup>Written for commit ba2fcb297c28944dab7148d6c4f7c10d504d1489. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added right-click context menu to browser panes with dynamic options based on context, including:
    * Open links in new splits, default browser, or copy link addresses
    * Copy selected text and page URLs
    * Paste and select all functionality
    * Navigation controls (back, forward, reload)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->