### PR TITLE
fix(desktop): update chat input placeholder and preserve spacing

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/ChatInputFooter/ChatInputFooter.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatInterface/components/ChatInputFooter/ChatInputFooter.tsx
@@ -137,7 +137,7 @@ export function ChatInputFooter({
 											slashCommands={slashCommands}
 										/>
 										<PromptInputTextarea
-											placeholder="Ask anything..."
+											placeholder="Ask to make changes, @mention files, run /commands"
 											className="min-h-10"
 										/>
 										<ChatComposerControls
@@ -161,11 +161,7 @@ export function ChatInputFooter({
 							</MentionAnchor>
 						</MentionProvider>
 					</SlashCommandInput>
-					<div className="flex items-center px-2 pt-1.5">
-						<span className="text-xs text-muted-foreground/50">
-							Use '@' to mention files, run /commands
-						</span>
-					</div>
+					<div className="py-1.5" />
 				</div>
 			)}
 		</ChatInputDropZone>


### PR DESCRIPTION
## Summary
- Replace generic "Ask anything..." placeholder with descriptive "Ask to make changes, @mention files, run /commands"
- Remove hint text below the chat input but preserve vertical spacing with a `py-1.5` spacer

## Test plan
- [ ] Verify placeholder text shows correctly in empty chat input
- [ ] Verify spacing below the chat input is preserved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve the desktop chat input by replacing the generic placeholder with “Ask to make changes, @mention files, run /commands” and removing the redundant hint text. Keeps layout stable by preserving vertical spacing with a small `py-1.5` spacer.

<sup>Written for commit 25f51f88d83ca6cee1368de987594f3dfd6c3b05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the chat input placeholder text to provide clearer guidance on available actions, including making changes, mentioning files, and running commands.
  * Streamlined the inline help text layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->