### PR TITLE
fix(chat-mastra): fallback OM model when Google API key is missing

### DIFF
--- a/packages/chat-mastra/src/server/trpc/service.ts
+++ b/packages/chat-mastra/src/server/trpc/service.ts
@@ -1,7 +1,7 @@
 import type { AppRouter } from "@superset/trpc";
 import { createTRPCClient, httpBatchLink } from "@trpc/client";
 import { initTRPC } from "@trpc/server";
-import { createMastraCode } from "mastracode";
+import { createAuthStorage, createMastraCode } from "mastracode";
 import superjson from "superjson";
 import { searchFiles } from "./utils/file-search";
 import {
@@ -32,6 +32,28 @@ import {
 } from "./zod";
 
 const ENABLE_MASTRA_MCP_SERVERS = false;
+
+function resolveOmModelFromAuth(): string | undefined {
+	if (process.env.GOOGLE_GENERATIVE_AI_API_KEY)
+		return "google/gemini-2.5-flash";
+	const authStorage = createAuthStorage();
+	authStorage.reload();
+	const anthropic = authStorage.get("anthropic");
+	if (
+		anthropic?.type === "oauth" ||
+		(anthropic?.type === "api_key" && anthropic.key.trim())
+	) {
+		return "anthropic/claude-haiku-4-5";
+	}
+	const openai = authStorage.get("openai-codex");
+	if (
+		openai?.type === "oauth" ||
+		(openai?.type === "api_key" && openai.key.trim())
+	) {
+		return "openai/gpt-4.1-nano";
+	}
+	return undefined;
+}
 
 export interface ChatMastraServiceOptions {
 	headers: () => Record<string, string> | Promise<Record<string, string>>;
@@ -89,10 +111,19 @@ export class ChatMastraService {
 					() => Promise.resolve(this.opts.headers()),
 					this.opts.apiUrl,
 				);
+
+				const omModel = resolveOmModelFromAuth();
+
 				const runtimeMastra = await createMastraCode({
 					cwd: runtimeCwd,
 					extraTools,
 					disableMcp: !ENABLE_MASTRA_MCP_SERVERS,
+					...(omModel && {
+						initialState: {
+							observerModelId: omModel,
+							reflectorModelId: omModel,
+						},
+					}),
 				});
 				runtimeMastra.hookManager?.setSessionId(sessionId);
 				await runtimeMastra.harness.init();


### PR DESCRIPTION
## Summary

- When observational memory (OM) triggers at ~30k tokens, it defaults to `google/gemini-2.5-flash`. If `GOOGLE_GENERATIVE_AI_API_KEY` is not set, the call fails with "Could not find API key"
- Added `resolveOmModelFromAuth()` that checks available credentials in priority order: Google env var → Anthropic auth storage → OpenAI auth storage
- Passes the resolved model via `initialState.observerModelId` / `initialState.reflectorModelId` to `createMastraCode()`, which overrides the broken defaults

## Test plan

- [ ] Unset `GOOGLE_GENERATIVE_AI_API_KEY` with Anthropic credentials configured
- [ ] Start a chat session and send enough messages to trigger OM (~30k tokens)
- [ ] Confirm no "Could not find API key" error — OM uses `anthropic/claude-haiku-4-5` instead
- [ ] Verify with Google key set that it still prefers `google/gemini-2.5-flash`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents OM crashes when the Google API key is missing by selecting a fallback model from available auth. This removes the "Could not find API key" error and keeps observational memory running.

- **Bug Fixes**
  - Added a resolver that picks the OM model by priority: Google → Anthropic → OpenAI.
  - Uses `createAuthStorage` to detect credentials and passes the chosen model to `createMastraCode` via `initialState.observerModelId` and `initialState.reflectorModelId`.
  - Keeps `google/gemini-2.5-flash` when the key is set; otherwise falls back to `anthropic/claude-haiku-4-5` or `openai/gpt-4.1-nano`.

<sup>Written for commit 5577a0fe33b94f933f90594e8ba21297d908b09d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Models are now automatically configured based on stored authentication providers, supporting Anthropic, OpenAI, and Google Generative AI.
  * Runtime initialization includes pre-resolved model settings when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->