### PR TITLE
Make new project setup agent-driven

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/settings/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/index.ts
@@ -27,6 +27,7 @@ import {
 	DEFAULT_TERMINAL_LINK_BEHAVIOR,
 	DEFAULT_USE_COMPACT_TERMINAL_ADD_BUTTON,
 } from "shared/constants";
+import { DEFAULT_PROJECT_CONFIGURATION_LAUNCH_PROMPT_TEMPLATE } from "shared/project-configuration";
 import {
 	CUSTOM_RINGTONE_ID,
 	DEFAULT_RINGTONE_ID,
@@ -672,6 +673,44 @@ export const createSettingsRouter = () => {
 					.onConflictDoUpdate({
 						target: settings.id,
 						set: { openLinksInApp: input.enabled },
+					})
+					.run();
+
+				return { success: true };
+			}),
+
+		getProjectConfigurationLaunchPrompt: publicProcedure.query(() => {
+			const row = getSettings();
+			return (
+				row.projectConfigurationLaunchPrompt ??
+				DEFAULT_PROJECT_CONFIGURATION_LAUNCH_PROMPT_TEMPLATE
+			);
+		}),
+
+		setProjectConfigurationLaunchPrompt: publicProcedure
+			.input(z.object({ prompt: z.string().nullable() }))
+			.mutation(({ input }) => {
+				const prompt =
+					input.prompt?.trim() ||
+					DEFAULT_PROJECT_CONFIGURATION_LAUNCH_PROMPT_TEMPLATE;
+
+				localDb
+					.insert(settings)
+					.values({
+						id: 1,
+						projectConfigurationLaunchPrompt:
+							prompt === DEFAULT_PROJECT_CONFIGURATION_LAUNCH_PROMPT_TEMPLATE
+								? null
+								: prompt,
+					})
+					.onConflictDoUpdate({
+						target: settings.id,
+						set: {
+							projectConfigurationLaunchPrompt:
+								prompt === DEFAULT_PROJECT_CONFIGURATION_LAUNCH_PROMPT_TEMPLATE
+									? null
+									: prompt,
+						},
 					})
 					.run();
 

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts
@@ -63,3 +63,8 @@ export {
 	getMastraGlobalHooksJsonPath,
 	getMastraHooksJsonContent,
 } from "./agent-wrappers-mastra";
+export {
+	createProjectConfigCli,
+	getProjectConfigCliScriptContent,
+	getProjectConfigCliWrapperContent,
+} from "./project-config-cli";

--- a/apps/desktop/src/main/lib/agent-setup/index.ts
+++ b/apps/desktop/src/main/lib/agent-setup/index.ts
@@ -26,6 +26,7 @@ import {
 	OPENCODE_PLUGIN_DIR,
 	ZSH_DIR,
 } from "./paths";
+import { createProjectConfigCli } from "./project-config-cli";
 import {
 	createBashWrapper,
 	createZshWrapper,
@@ -62,6 +63,7 @@ export function setupAgentHooks(): void {
 	createMastraHooksJson();
 	createCopilotHookScript();
 	createCopilotWrapper();
+	createProjectConfigCli();
 
 	createZshWrapper();
 	createBashWrapper();

--- a/apps/desktop/src/main/lib/agent-setup/project-config-cli.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/project-config-cli.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { execFileSync } from "node:child_process";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { getProjectConfigCliScriptContent } from "./project-config-cli";
+
+const TEST_ROOT = path.join(
+	tmpdir(),
+	`superset-project-config-cli-${process.pid}-${Date.now()}`,
+);
+
+describe("project config CLI", () => {
+	let scriptPath: string;
+	let projectRoot: string;
+	let configPath: string;
+
+	beforeEach(() => {
+		scriptPath = path.join(TEST_ROOT, "superset-project-config.js");
+		projectRoot = path.join(TEST_ROOT, "project");
+		configPath = path.join(projectRoot, ".superset", "config.json");
+
+		mkdirSync(projectRoot, { recursive: true });
+		writeFileSync(scriptPath, getProjectConfigCliScriptContent(), {
+			mode: 0o755,
+		});
+	});
+
+	afterEach(() => {
+		rmSync(TEST_ROOT, { recursive: true, force: true });
+	});
+
+	function runCli(args: string[]) {
+		return execFileSync(process.execPath, [scriptPath, ...args], {
+			encoding: "utf-8",
+		});
+	}
+
+	it("shows missing config without creating it", () => {
+		const output = JSON.parse(
+			runCli(["show", "--project-root", projectRoot]),
+		) as {
+			exists: boolean;
+			path: string;
+			config: unknown;
+		};
+
+		expect(output.exists).toBe(false);
+		expect(output.path).toBe(configPath);
+		expect(output.config).toBeNull();
+		expect(existsSync(configPath)).toBe(false);
+	});
+
+	it("writes setup and teardown commands while preserving existing fields", () => {
+		mkdirSync(path.dirname(configPath), { recursive: true });
+		writeFileSync(
+			configPath,
+			JSON.stringify(
+				{
+					name: "keep-me",
+					setup: ["old setup"],
+				},
+				null,
+				2,
+			),
+		);
+
+		runCli([
+			"write",
+			"--project-root",
+			projectRoot,
+			"--setup-json",
+			'["bun install","bun run dev"]',
+			"--teardown",
+			"docker compose down",
+		]);
+
+		const saved = JSON.parse(readFileSync(configPath, "utf-8")) as {
+			name?: string;
+			setup?: string[];
+			teardown?: string[];
+		};
+
+		expect(saved).toEqual({
+			name: "keep-me",
+			setup: ["bun install", "bun run dev"],
+			teardown: ["docker compose down"],
+		});
+	});
+});

--- a/apps/desktop/src/main/lib/agent-setup/project-config-cli.ts
+++ b/apps/desktop/src/main/lib/agent-setup/project-config-cli.ts
@@ -163,9 +163,23 @@ function main() {
   }
 
   if (command === "write") {
-    const setup = [...(options.setupJson ?? []), ...options.setup];
-    const teardown = [...(options.teardownJson ?? []), ...options.teardown];
     const existing = readExistingConfig(configPath);
+    const setup =
+      options.setupJson !== null
+        ? options.setupJson
+        : options.setup.length > 0
+          ? options.setup
+          : Array.isArray(existing.setup)
+            ? existing.setup
+            : [];
+    const teardown =
+      options.teardownJson !== null
+        ? options.teardownJson
+        : options.teardown.length > 0
+          ? options.teardown
+          : Array.isArray(existing.teardown)
+            ? existing.teardown
+            : [];
 
     fs.mkdirSync(path.dirname(configPath), { recursive: true });
 

--- a/apps/desktop/src/main/lib/agent-setup/project-config-cli.ts
+++ b/apps/desktop/src/main/lib/agent-setup/project-config-cli.ts
@@ -1,0 +1,215 @@
+import path from "node:path";
+import { CONFIG_FILE_NAME, PROJECT_SUPERSET_DIR_NAME } from "shared/constants";
+import { SUPERSET_PROJECT_CONFIG_CLI } from "shared/project-configuration";
+import { writeFileIfChanged } from "./agent-wrappers-common";
+import { BIN_DIR, HOOKS_DIR } from "./paths";
+
+const PROJECT_CONFIG_CLI_MARKER = "# Superset project-config cli v1";
+const PROJECT_CONFIG_CLI_SCRIPT_NAME = "superset-project-config.js";
+
+function quoteShellLiteral(value: string): string {
+	return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function getProjectConfigCliScriptPath(): string {
+	return path.join(HOOKS_DIR, PROJECT_CONFIG_CLI_SCRIPT_NAME);
+}
+
+function getProjectConfigCliWrapperPath(): string {
+	return path.join(BIN_DIR, SUPERSET_PROJECT_CONFIG_CLI);
+}
+
+export function getProjectConfigCliScriptContent(): string {
+	return `#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+
+const CONFIG_FILE_NAME = ${JSON.stringify(CONFIG_FILE_NAME)};
+const PROJECT_SUPERSET_DIR_NAME = ${JSON.stringify(PROJECT_SUPERSET_DIR_NAME)};
+
+function printUsage() {
+  console.error("Usage:");
+  console.error("  ${SUPERSET_PROJECT_CONFIG_CLI} show --project-root <path>");
+  console.error("  ${SUPERSET_PROJECT_CONFIG_CLI} write --project-root <path> [--setup <command>]... [--teardown <command>]...");
+  console.error("  ${SUPERSET_PROJECT_CONFIG_CLI} write --project-root <path> [--setup-json <json>] [--teardown-json <json>]");
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function parseStringArrayFlag(value, flagName) {
+  try {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed) || parsed.some((item) => typeof item !== "string")) {
+      throw new Error("Expected an array of strings");
+    }
+    return parsed;
+  } catch (error) {
+    fail(\`Invalid value for \${flagName}: \${error instanceof Error ? error.message : String(error)}\`);
+  }
+}
+
+function parseOptions(argv) {
+  const options = {
+    projectRoot: null,
+    setup: [],
+    teardown: [],
+    setupJson: null,
+    teardownJson: null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+
+    if (arg === "--project-root") {
+      if (!next) {
+        fail("Missing value for --project-root");
+      }
+      options.projectRoot = next;
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--setup") {
+      if (!next) {
+        fail("Missing value for --setup");
+      }
+      options.setup.push(next);
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--teardown") {
+      if (!next) {
+        fail("Missing value for --teardown");
+      }
+      options.teardown.push(next);
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--setup-json") {
+      if (!next) {
+        fail("Missing value for --setup-json");
+      }
+      options.setupJson = parseStringArrayFlag(next, "--setup-json");
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--teardown-json") {
+      if (!next) {
+        fail("Missing value for --teardown-json");
+      }
+      options.teardownJson = parseStringArrayFlag(next, "--teardown-json");
+      index += 1;
+      continue;
+    }
+
+    fail(\`Unknown argument: \${arg}\`);
+  }
+
+  return options;
+}
+
+function getConfigPath(projectRoot) {
+  return path.join(projectRoot, PROJECT_SUPERSET_DIR_NAME, CONFIG_FILE_NAME);
+}
+
+function readExistingConfig(configPath) {
+  if (!fs.existsSync(configPath)) {
+    return {};
+  }
+
+  try {
+    const raw = fs.readFileSync(configPath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("Expected a JSON object");
+    }
+    return parsed;
+  } catch (error) {
+    fail(\`Failed to read existing config at \${configPath}: \${error instanceof Error ? error.message : String(error)}\`);
+  }
+}
+
+function main() {
+  const [command, ...rest] = process.argv.slice(2);
+  if (!command || command === "--help" || command === "-h") {
+    printUsage();
+    process.exit(command ? 0 : 1);
+  }
+
+  const options = parseOptions(rest);
+  if (!options.projectRoot) {
+    fail("--project-root is required");
+  }
+
+  const projectRoot = path.resolve(options.projectRoot);
+  if (!fs.existsSync(projectRoot)) {
+    fail(\`Project root does not exist: \${projectRoot}\`);
+  }
+
+  const configPath = getConfigPath(projectRoot);
+
+  if (command === "show") {
+    const exists = fs.existsSync(configPath);
+    const config = exists ? readExistingConfig(configPath) : null;
+    console.log(JSON.stringify({ projectRoot, path: configPath, exists, config }, null, 2));
+    return;
+  }
+
+  if (command === "write") {
+    const setup = [...(options.setupJson ?? []), ...options.setup];
+    const teardown = [...(options.teardownJson ?? []), ...options.teardown];
+    const existing = readExistingConfig(configPath);
+
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+
+    const nextConfig = {
+      ...existing,
+      setup,
+      teardown,
+    };
+
+    fs.writeFileSync(configPath, JSON.stringify(nextConfig, null, 2) + "\\n", "utf-8");
+    console.log(JSON.stringify({ projectRoot, path: configPath, config: nextConfig }, null, 2));
+    return;
+  }
+
+  fail(\`Unknown command: \${command}\`);
+}
+
+main();
+`;
+}
+
+export function getProjectConfigCliWrapperContent(): string {
+	return `#!/bin/bash
+${PROJECT_CONFIG_CLI_MARKER}
+set -euo pipefail
+
+export ELECTRON_RUN_AS_NODE=1
+exec ${quoteShellLiteral(process.execPath)} ${quoteShellLiteral(getProjectConfigCliScriptPath())} "$@"
+`;
+}
+
+export function createProjectConfigCli(): void {
+	const scriptChanged = writeFileIfChanged(
+		getProjectConfigCliScriptPath(),
+		getProjectConfigCliScriptContent(),
+		0o755,
+	);
+	const wrapperChanged = writeFileIfChanged(
+		getProjectConfigCliWrapperPath(),
+		getProjectConfigCliWrapperContent(),
+		0o755,
+	);
+
+	console.log(
+		`[agent-setup] ${scriptChanged || wrapperChanged ? "Updated" : "Verified"} ${SUPERSET_PROJECT_CONFIG_CLI} CLI`,
+	);
+}

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -8,6 +8,7 @@ import { useOpenProject } from "renderer/react-query/projects";
 import {
 	useCloseNewWorkspaceModal,
 	useNewWorkspaceModalOpen,
+	useOpenNewWorkspaceModal,
 	usePreSelectedProjectId,
 } from "renderer/stores/new-workspace-modal";
 import { BranchesGroup } from "./components/BranchesGroup";
@@ -21,6 +22,7 @@ type Tab = "prompt" | "issues" | "pull-requests" | "branches";
 export function NewWorkspaceModal() {
 	const isOpen = useNewWorkspaceModalOpen();
 	const closeModal = useCloseNewWorkspaceModal();
+	const openModal = useOpenNewWorkspaceModal();
 	const preSelectedProjectId = usePreSelectedProjectId();
 	const [activeTab, setActiveTab] = useState<Tab>("prompt");
 	const [selectedProjectId, setSelectedProjectId] = useState<string | null>(
@@ -51,7 +53,11 @@ export function NewWorkspaceModal() {
 	const handleImportRepo = async () => {
 		closeModal();
 		try {
-			await openNew();
+			const projects = await openNew();
+			const firstProjectId = projects[0]?.id;
+			if (firstProjectId) {
+				openModal(firstProjectId);
+			}
 		} catch (error) {
 			toast.error("Failed to open project", {
 				description:

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
@@ -177,8 +177,9 @@ export function PromptGroup({ projectId, onClose }: PromptGroupProps) {
 	const shouldUseProjectConfigurationPrompt = useMemo(
 		() =>
 			selectedAgent !== "none" &&
+			projectConfig !== undefined &&
 			!hasConfiguredProjectScripts(projectConfig?.content ?? null),
-		[selectedAgent, projectConfig?.content],
+		[selectedAgent, projectConfig],
 	);
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: intentionally reset advanced branch state when project changes

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
@@ -29,6 +29,7 @@ import { electronTrpc } from "renderer/lib/electron-trpc";
 import { resolveEffectiveWorkspaceBaseBranch } from "renderer/lib/workspaceBaseBranch";
 import { useCreateWorkspace } from "renderer/react-query/workspaces";
 import { useHotkeysStore } from "renderer/stores/hotkeys/store";
+import { renderProjectConfigurationLaunchPrompt } from "shared/project-configuration";
 import {
 	resolveBranchPrefix,
 	sanitizeBranchNameWithMaxLength,
@@ -42,6 +43,34 @@ const AGENT_STORAGE_KEY = "lastSelectedWorkspaceCreateAgent";
 interface PromptGroupProps {
 	projectId: string | null;
 	onClose: () => void;
+}
+
+function hasConfiguredProjectScripts(
+	content: string | null | undefined,
+): boolean {
+	if (!content) {
+		return false;
+	}
+
+	try {
+		const parsed = JSON.parse(content) as {
+			setup?: unknown;
+			teardown?: unknown;
+		};
+		const setup = Array.isArray(parsed.setup)
+			? parsed.setup.filter(
+					(value): value is string => typeof value === "string",
+				)
+			: [];
+		const teardown = Array.isArray(parsed.teardown)
+			? parsed.teardown.filter(
+					(value): value is string => typeof value === "string",
+				)
+			: [];
+		return setup.length > 0 || teardown.length > 0;
+	} catch {
+		return false;
+	}
 }
 
 export function PromptGroup({ projectId, onClose }: PromptGroupProps) {
@@ -93,9 +122,15 @@ export function PromptGroup({ projectId, onClose }: PromptGroupProps) {
 		{ id: projectId ?? "" },
 		{ enabled: !!projectId },
 	);
+	const { data: projectConfig } = electronTrpc.config.getConfigContent.useQuery(
+		{ projectId: projectId ?? "" },
+		{ enabled: !!projectId },
+	);
 	const { data: globalBranchPrefix } =
 		electronTrpc.settings.getBranchPrefix.useQuery();
 	const { data: gitInfo } = electronTrpc.settings.getGitInfo.useQuery();
+	const { data: projectConfigurationLaunchPrompt } =
+		electronTrpc.settings.getProjectConfigurationLaunchPrompt.useQuery();
 
 	const resolvedPrefix = useMemo(() => {
 		const projectOverrides = project?.branchPrefixMode != null;
@@ -139,6 +174,12 @@ export function PromptGroup({ projectId, onClose }: PromptGroupProps) {
 		branchSlug && applyPrefix && resolvedPrefix
 			? sanitizeBranchNameWithMaxLength(`${resolvedPrefix}/${branchSlug}`)
 			: branchSlug;
+	const shouldUseProjectConfigurationPrompt = useMemo(
+		() =>
+			selectedAgent !== "none" &&
+			!hasConfiguredProjectScripts(projectConfig?.content ?? null),
+		[selectedAgent, projectConfig?.content],
+	);
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: intentionally reset advanced branch state when project changes
 	useEffect(() => {
@@ -156,6 +197,12 @@ export function PromptGroup({ projectId, onClose }: PromptGroupProps) {
 		trimmedPrompt: string,
 	): AgentLaunchRequest | null => {
 		if (selectedAgent === "none") return null;
+		const launchPrompt = shouldUseProjectConfigurationPrompt
+			? renderProjectConfigurationLaunchPrompt({
+					template: projectConfigurationLaunchPrompt,
+					userRequest: trimmedPrompt,
+				})
+			: trimmedPrompt;
 
 		if (selectedAgent === "superset-chat") {
 			return {
@@ -164,14 +211,14 @@ export function PromptGroup({ projectId, onClose }: PromptGroupProps) {
 				agentType: "superset-chat",
 				source: "new-workspace",
 				chat: {
-					initialPrompt: trimmedPrompt || undefined,
+					initialPrompt: launchPrompt || undefined,
 				},
 			};
 		}
 
-		const command = trimmedPrompt
+		const command = launchPrompt
 			? buildAgentPromptCommand({
-					prompt: trimmedPrompt,
+					prompt: launchPrompt,
 					randomId: window.crypto.randomUUID(),
 					agent: selectedAgent,
 				})
@@ -287,6 +334,12 @@ export function PromptGroup({ projectId, onClose }: PromptGroupProps) {
 					}
 				}}
 			/>
+			{shouldUseProjectConfigurationPrompt && (
+				<p className="text-xs text-muted-foreground">
+					The first agent turn will configure this project for Superset, then
+					continue with your request.
+				</p>
+			)}
 
 			<PromptGroupAdvancedOptions
 				showAdvanced={showAdvanced}

--- a/apps/desktop/src/renderer/routes/_authenticated/_onboarding/new-project/hooks/useProjectCreationHandler/useProjectCreationHandler.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_onboarding/new-project/hooks/useProjectCreationHandler/useProjectCreationHandler.ts
@@ -1,9 +1,11 @@
 import { useNavigate } from "@tanstack/react-router";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
 
 export function useProjectCreationHandler(onError: (error: string) => void) {
 	const utils = electronTrpc.useUtils();
 	const navigate = useNavigate();
+	const openNewWorkspaceModal = useOpenNewWorkspaceModal();
 
 	const handleResult = (
 		result: {
@@ -18,11 +20,8 @@ export function useProjectCreationHandler(onError: (error: string) => void) {
 		if (result.success && result.project) {
 			utils.projects.getRecents.invalidate();
 			resetState?.();
-			navigate({
-				to: "/project/$projectId",
-				params: { projectId: result.project.id },
-				replace: true,
-			});
+			navigate({ to: "/", replace: true });
+			openNewWorkspaceModal(result.project.id);
 		} else if (!result.success && result.error) {
 			onError(result.error);
 		}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/BehaviorSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/BehaviorSettings.tsx
@@ -1,4 +1,5 @@
 import type { FileOpenMode } from "@superset/local-db";
+import { Button } from "@superset/ui/button";
 import { Label } from "@superset/ui/label";
 import {
 	Select,
@@ -8,7 +9,10 @@ import {
 	SelectValue,
 } from "@superset/ui/select";
 import { Switch } from "@superset/ui/switch";
+import { Textarea } from "@superset/ui/textarea";
+import { useEffect, useState } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { DEFAULT_PROJECT_CONFIGURATION_LAUNCH_PROMPT_TEMPLATE } from "shared/project-configuration";
 import {
 	isItemVisible,
 	SETTING_ITEM_ID,
@@ -38,6 +42,10 @@ export function BehaviorSettings({ visibleItems }: BehaviorSettingsProps) {
 	);
 	const showOpenLinksInApp = isItemVisible(
 		SETTING_ITEM_ID.BEHAVIOR_OPEN_LINKS_IN_APP,
+		visibleItems,
+	);
+	const showProjectConfigurationLaunchPrompt = isItemVisible(
+		SETTING_ITEM_ID.BEHAVIOR_PROJECT_CONFIGURATION_LAUNCH_PROMPT,
 		visibleItems,
 	);
 
@@ -159,6 +167,31 @@ export function BehaviorSettings({ visibleItems }: BehaviorSettingsProps) {
 		},
 	);
 
+	const {
+		data: projectConfigurationLaunchPrompt,
+		isLoading: isProjectConfigurationLaunchPromptLoading,
+	} = electronTrpc.settings.getProjectConfigurationLaunchPrompt.useQuery();
+	const setProjectConfigurationLaunchPrompt =
+		electronTrpc.settings.setProjectConfigurationLaunchPrompt.useMutation({
+			onSettled: () => {
+				utils.settings.getProjectConfigurationLaunchPrompt.invalidate();
+			},
+		});
+	const [
+		projectConfigurationLaunchPromptDraft,
+		setProjectConfigurationLaunchPromptDraft,
+	] = useState(DEFAULT_PROJECT_CONFIGURATION_LAUNCH_PROMPT_TEMPLATE);
+
+	useEffect(() => {
+		if (projectConfigurationLaunchPrompt === undefined) return;
+		setProjectConfigurationLaunchPromptDraft(projectConfigurationLaunchPrompt);
+	}, [projectConfigurationLaunchPrompt]);
+
+	const hasProjectConfigurationPromptChanges =
+		projectConfigurationLaunchPromptDraft !==
+		(projectConfigurationLaunchPrompt ??
+			DEFAULT_PROJECT_CONFIGURATION_LAUNCH_PROMPT_TEMPLATE);
+
 	return (
 		<div className="p-6 max-w-4xl w-full">
 			<div className="mb-8">
@@ -278,6 +311,70 @@ export function BehaviorSettings({ visibleItems }: BehaviorSettingsProps) {
 							onCheckedChange={handleTelemetryToggle}
 							disabled={isTelemetryLoading || setTelemetryEnabled.isPending}
 						/>
+					</div>
+				)}
+
+				{showProjectConfigurationLaunchPrompt && (
+					<div className="space-y-3">
+						<div className="space-y-0.5">
+							<Label
+								htmlFor="project-configuration-launch-prompt"
+								className="text-sm font-medium"
+							>
+								New project agent launch prompt
+							</Label>
+							<p className="text-xs text-muted-foreground">
+								Used when a newly opened project launches an agent before it has
+								been configured for Superset. Supports{" "}
+								<code>{"{{show_command}}"}</code>,{" "}
+								<code>{"{{write_command}}"}</code>,{" "}
+								<code>{"{{project_root}}"}</code>, and{" "}
+								<code>{"{{user_request}}"}</code>.
+							</p>
+						</div>
+						<Textarea
+							id="project-configuration-launch-prompt"
+							className="min-h-52 font-mono text-xs"
+							value={projectConfigurationLaunchPromptDraft}
+							onChange={(event) =>
+								setProjectConfigurationLaunchPromptDraft(event.target.value)
+							}
+							disabled={
+								isProjectConfigurationLaunchPromptLoading ||
+								setProjectConfigurationLaunchPrompt.isPending
+							}
+						/>
+						<div className="flex items-center gap-2">
+							<Button
+								variant="outline"
+								onClick={() => {
+									setProjectConfigurationLaunchPromptDraft(
+										DEFAULT_PROJECT_CONFIGURATION_LAUNCH_PROMPT_TEMPLATE,
+									);
+									setProjectConfigurationLaunchPrompt.mutate({ prompt: null });
+								}}
+								disabled={
+									isProjectConfigurationLaunchPromptLoading ||
+									setProjectConfigurationLaunchPrompt.isPending
+								}
+							>
+								Reset
+							</Button>
+							<Button
+								onClick={() =>
+									setProjectConfigurationLaunchPrompt.mutate({
+										prompt: projectConfigurationLaunchPromptDraft,
+									})
+								}
+								disabled={
+									!hasProjectConfigurationPromptChanges ||
+									isProjectConfigurationLaunchPromptLoading ||
+									setProjectConfigurationLaunchPrompt.isPending
+								}
+							>
+								Save prompt
+							</Button>
+						</div>
 					</div>
 				)}
 			</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/BehaviorSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/BehaviorSettings.tsx
@@ -361,11 +361,14 @@ export function BehaviorSettings({ visibleItems }: BehaviorSettingsProps) {
 								Reset
 							</Button>
 							<Button
-								onClick={() =>
+								onClick={() => {
+									const normalizedPrompt =
+										projectConfigurationLaunchPromptDraft.trim();
 									setProjectConfigurationLaunchPrompt.mutate({
-										prompt: projectConfigurationLaunchPromptDraft,
-									})
-								}
+										prompt:
+											normalizedPrompt.length > 0 ? normalizedPrompt : null,
+									});
+								}}
 								disabled={
 									!hasProjectConfigurationPromptChanges ||
 									isProjectConfigurationLaunchPromptLoading ||

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -26,6 +26,8 @@ export const SETTING_ITEM_ID = {
 	BEHAVIOR_FILE_OPEN_MODE: "behavior-file-open-mode",
 	BEHAVIOR_RESOURCE_MONITOR: "behavior-resource-monitor",
 	BEHAVIOR_OPEN_LINKS_IN_APP: "behavior-open-links-in-app",
+	BEHAVIOR_PROJECT_CONFIGURATION_LAUNCH_PROMPT:
+		"behavior-project-configuration-launch-prompt",
 
 	GIT_BRANCH_PREFIX: "git-branch-prefix",
 	GIT_DELETE_LOCAL_BRANCH: "git-delete-local-branch",
@@ -478,6 +480,25 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"chat",
 			"terminal",
 			"url",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.BEHAVIOR_PROJECT_CONFIGURATION_LAUNCH_PROMPT,
+		section: "behavior",
+		title: "New project agent launch prompt",
+		description:
+			"Customize the prompt used when an agent configures a newly opened project for Superset",
+		keywords: [
+			"behavior",
+			"project",
+			"launch prompt",
+			"agent",
+			"configuration",
+			"setup scripts",
+			"superset config",
+			"new project",
+			"onboarding",
+			"workspace setup",
 		],
 	},
 	{

--- a/apps/desktop/src/renderer/screens/main/components/StartView/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/StartView/index.tsx
@@ -5,10 +5,12 @@ import { useCallback, useEffect, useState } from "react";
 import { LuFolderOpen, LuPlus, LuX } from "react-icons/lu";
 import { useOpenProject } from "renderer/react-query/projects";
 import { SupersetLogo } from "renderer/routes/sign-in/components/SupersetLogo";
+import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
 
 export function StartView() {
 	const navigate = useNavigate();
 	const { openNew, openFromPath, isPending } = useOpenProject();
+	const openNewWorkspaceModal = useOpenNewWorkspaceModal();
 	const [error, setError] = useState<string | null>(null);
 	const [isDragOver, setIsDragOver] = useState(false);
 
@@ -38,11 +40,7 @@ export function StartView() {
 			const projects = await openNew();
 			const firstProjectId = projects[0]?.id;
 			if (firstProjectId) {
-				navigate({
-					to: "/project/$projectId",
-					params: { projectId: firstProjectId },
-					replace: true,
-				});
+				openNewWorkspaceModal(firstProjectId);
 			}
 		} catch (err) {
 			setError(err instanceof Error ? err.message : "Failed to open project");
@@ -106,17 +104,13 @@ export function StartView() {
 			try {
 				const project = await openFromPath(filePath);
 				if (project) {
-					navigate({
-						to: "/project/$projectId",
-						params: { projectId: project.id },
-						replace: true,
-					});
+					openNewWorkspaceModal(project.id);
 				}
 			} catch (err) {
 				setError(err instanceof Error ? err.message : "Failed to open project");
 			}
 		},
-		[isPending, openFromPath, navigate],
+		[isPending, openFromPath, openNewWorkspaceModal],
 	);
 
 	return (

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/SidebarDropZone/SidebarDropZone.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/SidebarDropZone/SidebarDropZone.tsx
@@ -1,9 +1,9 @@
 import { cn } from "@superset/ui/utils";
-import { useNavigate } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "framer-motion";
 import { type ReactNode, useCallback, useEffect, useState } from "react";
 import { LuFolderPlus, LuLoader, LuX } from "react-icons/lu";
 import { useOpenProject } from "renderer/react-query/projects";
+import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
 
 interface SidebarDropZoneProps {
 	children: ReactNode;
@@ -11,7 +11,7 @@ interface SidebarDropZoneProps {
 }
 
 export function SidebarDropZone({ children, className }: SidebarDropZoneProps) {
-	const navigate = useNavigate();
+	const openNewWorkspaceModal = useOpenNewWorkspaceModal();
 	const [isDragOver, setIsDragOver] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 
@@ -97,16 +97,13 @@ export function SidebarDropZone({ children, className }: SidebarDropZoneProps) {
 			try {
 				const project = await openFromPath(filePath);
 				if (project) {
-					navigate({
-						to: "/project/$projectId",
-						params: { projectId: project.id },
-					});
+					openNewWorkspaceModal(project.id);
 				}
 			} catch (err) {
 				setError(err instanceof Error ? err.message : "Failed to open project");
 			}
 		},
-		[openFromPath, isPending, navigate],
+		[isPending, openFromPath, openNewWorkspaceModal],
 	);
 
 	return (

--- a/apps/desktop/src/shared/project-configuration.test.ts
+++ b/apps/desktop/src/shared/project-configuration.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "bun:test";
+import {
+	DEFAULT_PROJECT_CONFIGURATION_LAUNCH_PROMPT_TEMPLATE,
+	renderProjectConfigurationLaunchPrompt,
+	SUPERSET_PROJECT_CONFIG_CLI,
+} from "./project-configuration";
+
+describe("renderProjectConfigurationLaunchPrompt", () => {
+	it("renders the default template with CLI commands and user request", () => {
+		const prompt = renderProjectConfigurationLaunchPrompt({
+			userRequest: "Help me get the app running locally.",
+		});
+
+		expect(prompt).toContain(
+			DEFAULT_PROJECT_CONFIGURATION_LAUNCH_PROMPT_TEMPLATE.split("\n")[0],
+		);
+		expect(prompt).toContain(
+			`${SUPERSET_PROJECT_CONFIG_CLI} show --project-root "$SUPERSET_ROOT_PATH"`,
+		);
+		expect(prompt).toContain(
+			`${SUPERSET_PROJECT_CONFIG_CLI} write --project-root "$SUPERSET_ROOT_PATH"`,
+		);
+		expect(prompt).toContain("Help me get the app running locally.");
+		expect(prompt).not.toContain("{{show_command}}");
+	});
+
+	it("falls back when no user request is provided", () => {
+		const prompt = renderProjectConfigurationLaunchPrompt();
+
+		expect(prompt).toContain("No additional request was provided.");
+	});
+});

--- a/apps/desktop/src/shared/project-configuration.ts
+++ b/apps/desktop/src/shared/project-configuration.ts
@@ -1,0 +1,49 @@
+export const SUPERSET_PROJECT_CONFIG_CLI = "superset-project-config";
+
+export const DEFAULT_PROJECT_CONFIGURATION_LAUNCH_PROMPT_TEMPLATE = `You were just launched in a fresh Superset workspace for a newly opened project.
+
+Before you start implementation work, configure this project for Superset by interviewing the user. Ask only the questions needed to figure out the setup commands that should run when a workspace is created and any teardown commands that should run when it is deleted.
+
+Inspect the current configuration with:
+{{show_command}}
+
+Save the shared project configuration with:
+{{write_command}}
+
+Write the shared project configuration at {{project_root}}/.superset/config.json, not a workspace-local copy.
+
+After the configuration is saved, summarize the resulting setup and teardown behavior for the user and then continue with their original request if they have one:
+{{user_request}}`;
+
+export interface RenderProjectConfigurationLaunchPromptOptions {
+	template?: string | null;
+	userRequest?: string | null;
+	projectRoot?: string;
+}
+
+export function getProjectConfigurationCliCommands(
+	projectRoot = "$SUPERSET_ROOT_PATH",
+) {
+	return {
+		show: `${SUPERSET_PROJECT_CONFIG_CLI} show --project-root "${projectRoot}"`,
+		write: `${SUPERSET_PROJECT_CONFIG_CLI} write --project-root "${projectRoot}" --setup-json '["bun install","bun run dev"]' --teardown-json '["docker compose down"]'`,
+	};
+}
+
+export function renderProjectConfigurationLaunchPrompt({
+	template,
+	userRequest,
+	projectRoot = "$SUPERSET_ROOT_PATH",
+}: RenderProjectConfigurationLaunchPromptOptions = {}): string {
+	const { show, write } = getProjectConfigurationCliCommands(projectRoot);
+	const resolvedTemplate =
+		template?.trim() || DEFAULT_PROJECT_CONFIGURATION_LAUNCH_PROMPT_TEMPLATE;
+	const resolvedUserRequest =
+		userRequest?.trim() || "No additional request was provided.";
+
+	return resolvedTemplate
+		.replaceAll("{{show_command}}", show)
+		.replaceAll("{{write_command}}", write)
+		.replaceAll("{{project_root}}", projectRoot)
+		.replaceAll("{{user_request}}", resolvedUserRequest);
+}

--- a/packages/local-db/drizzle/0036_add_project_configuration_launch_prompt_setting.sql
+++ b/packages/local-db/drizzle/0036_add_project_configuration_launch_prompt_setting.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `settings` ADD `project_configuration_launch_prompt` text;

--- a/packages/local-db/drizzle/meta/0036_snapshot.json
+++ b/packages/local-db/drizzle/meta/0036_snapshot.json
@@ -1,0 +1,1375 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0fad9121-3f06-4fb4-95f2-9558212dd068",
+  "prevId": "589aac6d-a11a-44bd-97f9-be06311fcb95",
+  "tables": {
+    "browser_history": {
+      "name": "browser_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_visited_at": {
+          "name": "last_visited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visit_count": {
+          "name": "visit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "browser_history_url_unique": {
+          "name": "browser_history_url_unique",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "browser_history_url_idx": {
+          "name": "browser_history_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": false
+        },
+        "browser_history_last_visited_at_idx": {
+          "name": "browser_history_last_visited_at_idx",
+          "columns": [
+            "last_visited_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_organization_id_idx": {
+          "name": "organization_members_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_user_id_idx": {
+          "name": "organization_members_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_users_id_fk": {
+          "name": "organization_members_user_id_users_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_org": {
+          "name": "github_org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_clerk_org_id_unique": {
+          "name": "organizations_clerk_org_id_unique",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_idx": {
+          "name": "organizations_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "organizations_clerk_org_id_idx": {
+          "name": "organizations_clerk_org_id_idx",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "main_repo_path": {
+          "name": "main_repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_toast_dismissed": {
+          "name": "config_toast_dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_base_branch": {
+          "name": "workspace_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_owner": {
+          "name": "github_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hide_image": {
+          "name": "hide_image",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_project_id": {
+          "name": "neon_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_app": {
+          "name": "default_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_main_repo_path_idx": {
+          "name": "projects_main_repo_path_idx",
+          "columns": [
+            "main_repo_path"
+          ],
+          "isUnique": false
+        },
+        "projects_last_opened_at_idx": {
+          "name": "projects_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_active_workspace_id": {
+          "name": "last_active_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets": {
+          "name": "terminal_presets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets_initialized": {
+          "name": "terminal_presets_initialized",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_ringtone_id": {
+          "name": "selected_ringtone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirm_on_quit": {
+          "name": "confirm_on_quit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_link_behavior": {
+          "name": "terminal_link_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "persist_terminal": {
+          "name": "persist_terminal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_apply_default_preset": {
+          "name": "auto_apply_default_preset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_sounds_muted": {
+          "name": "notification_sounds_muted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delete_local_branch": {
+          "name": "delete_local_branch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_open_mode": {
+          "name": "file_open_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_presets_bar": {
+          "name": "show_presets_bar",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_compact_terminal_add_button": {
+          "name": "use_compact_terminal_add_button",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_family": {
+          "name": "terminal_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_size": {
+          "name": "terminal_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_family": {
+          "name": "editor_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_size": {
+          "name": "editor_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_resource_monitor": {
+          "name": "show_resource_monitor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "open_links_in_app": {
+          "name": "open_links_in_app",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_editor": {
+          "name": "default_editor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_configuration_launch_prompt": {
+          "name": "project_configuration_launch_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_color": {
+          "name": "status_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_type": {
+          "name": "status_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_position": {
+          "name": "status_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "estimate": {
+          "name": "estimate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_provider": {
+          "name": "external_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tasks_slug_unique": {
+          "name": "tasks_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "tasks_slug_idx": {
+          "name": "tasks_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "tasks_organization_id_idx": {
+          "name": "tasks_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_assignee_id_idx": {
+          "name": "tasks_assignee_id_idx",
+          "columns": [
+            "assignee_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_status_idx": {
+          "name": "tasks_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "tasks_created_at_idx": {
+          "name": "tasks_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_organization_id_organizations_id_fk": {
+          "name": "tasks_organization_id_organizations_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_assignee_id_users_id_fk": {
+          "name": "tasks_assignee_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tasks_creator_id_users_id_fk": {
+          "name": "tasks_creator_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": true
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "users_clerk_id_idx": {
+          "name": "users_clerk_id_idx",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_sections": {
+      "name": "workspace_sections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_collapsed": {
+          "name": "is_collapsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspace_sections_project_id_idx": {
+          "name": "workspace_sections_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_sections_project_id_projects_id_fk": {
+          "name": "workspace_sections_project_id_projects_id_fk",
+          "tableFrom": "workspace_sections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_id": {
+          "name": "worktree_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_unread": {
+          "name": "is_unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_unnamed": {
+          "name": "is_unnamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "deleting_at": {
+          "name": "deleting_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "port_base": {
+          "name": "port_base",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_project_id_idx": {
+          "name": "workspaces_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_worktree_id_idx": {
+          "name": "workspaces_worktree_id_idx",
+          "columns": [
+            "worktree_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_last_opened_at_idx": {
+          "name": "workspaces_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        },
+        "workspaces_section_id_idx": {
+          "name": "workspaces_section_id_idx",
+          "columns": [
+            "section_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspaces_project_id_projects_id_fk": {
+          "name": "workspaces_project_id_projects_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_worktree_id_worktrees_id_fk": {
+          "name": "workspaces_worktree_id_worktrees_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "worktrees",
+          "columnsFrom": [
+            "worktree_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_section_id_workspace_sections_id_fk": {
+          "name": "workspaces_section_id_workspace_sections_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "workspace_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "worktrees": {
+      "name": "worktrees",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_status": {
+          "name": "git_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_status": {
+          "name": "github_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "worktrees_project_id_idx": {
+          "name": "worktrees_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "worktrees_branch_idx": {
+          "name": "worktrees_branch_idx",
+          "columns": [
+            "branch"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "worktrees_project_id_projects_id_fk": {
+          "name": "worktrees_project_id_projects_id_fk",
+          "tableFrom": "worktrees",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/local-db/drizzle/meta/_journal.json
+++ b/packages/local-db/drizzle/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1772841491441,
       "tag": "0035_add_workspace_sections",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "6",
+      "when": 1772928908836,
+      "tag": "0036_add_project_configuration_launch_prompt_setting",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/local-db/src/schema/schema.ts
+++ b/packages/local-db/src/schema/schema.ts
@@ -208,6 +208,7 @@ export const settings = sqliteTable("settings", {
 	worktreeBaseDir: text("worktree_base_dir"),
 	openLinksInApp: integer("open_links_in_app", { mode: "boolean" }),
 	defaultEditor: text("default_editor").$type<ExternalApp>(),
+	projectConfigurationLaunchPrompt: text("project_configuration_launch_prompt"),
 });
 
 export type InsertSettings = typeof settings.$inferInsert;


### PR DESCRIPTION
## Summary
- route newly opened projects into the agent-first workspace flow instead of the manual setup screen
- inject a managed `superset-project-config` CLI plus a configurable launch prompt so the first agent turn interviews the user and writes `.superset/config.json`
- add a desktop setting for the new-project configuration launch prompt and persist it in local settings

## Testing
- bun test apps/desktop/src/shared/project-configuration.test.ts apps/desktop/src/main/lib/agent-setup/project-config-cli.test.ts
- bunx biome check apps/desktop/src/shared/project-configuration.ts apps/desktop/src/shared/project-configuration.test.ts apps/desktop/src/main/lib/agent-setup/project-config-cli.ts apps/desktop/src/main/lib/agent-setup/project-config-cli.test.ts apps/desktop/src/main/lib/agent-setup/index.ts apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts apps/desktop/src/lib/trpc/routers/settings/index.ts apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/BehaviorSettings.tsx apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx apps/desktop/src/renderer/screens/main/components/StartView/index.tsx apps/desktop/src/renderer/routes/_authenticated/_onboarding/new-project/hooks/useProjectCreationHandler/useProjectCreationHandler.ts apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/SidebarDropZone/SidebarDropZone.tsx packages/local-db/src/schema/schema.ts packages/local-db/drizzle/0036_add_project_configuration_launch_prompt_setting.sql packages/local-db/drizzle/meta/_journal.json
- bun turbo run typecheck --filter=@superset/desktop --filter=@superset/local-db --filter=@superset/shared

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route newly opened projects into an agent-first flow. The agent interviews the user and writes `.superset/config.json` via a managed `superset-project-config` CLI with a configurable launch prompt.

- **New Features**
  - New projects (start/import/drag) open the agent-first workspace and reopen the New Workspace modal for the new project; gated on project config load to avoid flicker and shows a short first-turn notice.
  - Installed `superset-project-config` CLI during agent setup; supports show/write and preserves existing `setup`/`teardown` when flags are omitted.
  - Inject a launch prompt for unconfigured projects; after saving config, the agent continues with the user’s request.
  - New setting: “New project agent launch prompt” with template variables (`{{show_command}}`, `{{write_command}}`, `{{project_root}}`, `{{user_request}}`), plus Reset/Save in Settings; whitespace-only values normalize to the default.

- **Migration**
  - Adds `project_configuration_launch_prompt` to the `settings` table; no manual steps. Existing installs default to the built-in template when the setting is null.

<sup>Written for commit df1253adbd575c8270f61edba525c8c6ad242c79. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "New project agent launch prompt" setting with UI to edit, reset, and save a default-configured prompt.
  * Added a CLI and wrapper to inspect and write project configuration files, and logic to surface a computed launch prompt during agent setup.
  * Modal-based project opening now opens workspace configuration modals automatically after project creation or drop.

* **Tests**
  * Added unit and integration tests covering the CLI and prompt rendering.

* **Chores**
  * Database schema updated to store the new launch prompt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->