### PR TITLE
perf(desktop): show branches instantly in new workspace modal

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/projects/projects.ts
+++ b/apps/desktop/src/lib/trpc/routers/projects/projects.ts
@@ -314,6 +314,161 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 				return { canceled: false as const, path: result.filePaths[0] };
 			}),
 
+		// Fast: returns only local branches + cached remote refs (no network)
+		getBranchesLocal: publicProcedure
+			.input(z.object({ projectId: z.string() }))
+			.query(
+				async ({
+					input,
+				}): Promise<{
+					branches: Array<{
+						name: string;
+						lastCommitDate: number;
+						isLocal: boolean;
+						isRemote: boolean;
+					}>;
+					defaultBranch: string;
+				}> => {
+					const project = localDb
+						.select()
+						.from(projects)
+						.where(eq(projects.id, input.projectId))
+						.get();
+					if (!project) {
+						throw new Error(`Project ${input.projectId} not found`);
+					}
+
+					const git = simpleGit(project.mainRepoPath);
+
+					// No fetch — use only locally available refs
+					const branchSummary = await git.branch(["-a"]);
+
+					const localBranchSet = new Set<string>();
+					const remoteBranchSet = new Set<string>();
+
+					for (const name of Object.keys(branchSummary.branches)) {
+						if (name.startsWith("remotes/origin/")) {
+							if (name === "remotes/origin/HEAD") continue;
+							const remoteName = name.replace("remotes/origin/", "");
+							remoteBranchSet.add(remoteName);
+						} else {
+							localBranchSet.add(name);
+						}
+					}
+
+					const branchMap = new Map<
+						string,
+						{ lastCommitDate: number; isLocal: boolean; isRemote: boolean }
+					>();
+
+					// Include cached remote refs (no network needed)
+					if (remoteBranchSet.size > 0) {
+						try {
+							const remoteBranchInfo = await git.raw([
+								"for-each-ref",
+								"--sort=-committerdate",
+								"--format=%(refname:short) %(committerdate:unix)",
+								"refs/remotes/origin/",
+							]);
+
+							for (const line of remoteBranchInfo.trim().split("\n")) {
+								if (!line) continue;
+								const lastSpaceIdx = line.lastIndexOf(" ");
+								let branch = line.substring(0, lastSpaceIdx);
+								const timestamp = Number.parseInt(
+									line.substring(lastSpaceIdx + 1),
+									10,
+								);
+
+								if (branch.startsWith("origin/")) {
+									branch = branch.replace("origin/", "");
+								}
+
+								if (branch === "HEAD") continue;
+
+								branchMap.set(branch, {
+									lastCommitDate: timestamp * 1000,
+									isLocal: localBranchSet.has(branch),
+									isRemote: true,
+								});
+							}
+						} catch {
+							for (const name of remoteBranchSet) {
+								branchMap.set(name, {
+									lastCommitDate: 0,
+									isLocal: localBranchSet.has(name),
+									isRemote: true,
+								});
+							}
+						}
+					}
+
+					try {
+						const localBranchInfo = await git.raw([
+							"for-each-ref",
+							"--sort=-committerdate",
+							"--format=%(refname:short) %(committerdate:unix)",
+							"refs/heads/",
+						]);
+
+						for (const line of localBranchInfo.trim().split("\n")) {
+							if (!line) continue;
+							const lastSpaceIdx = line.lastIndexOf(" ");
+							const branch = line.substring(0, lastSpaceIdx);
+							const timestamp = Number.parseInt(
+								line.substring(lastSpaceIdx + 1),
+								10,
+							);
+
+							if (branch === "HEAD") continue;
+
+							if (!branchMap.has(branch)) {
+								branchMap.set(branch, {
+									lastCommitDate: timestamp * 1000,
+									isLocal: true,
+									isRemote: remoteBranchSet.has(branch),
+								});
+							} else {
+								const existing = branchMap.get(branch);
+								if (existing) {
+									existing.isLocal = true;
+								}
+							}
+						}
+					} catch {
+						for (const name of localBranchSet) {
+							if (!branchMap.has(name)) {
+								branchMap.set(name, {
+									lastCommitDate: 0,
+									isLocal: true,
+									isRemote: remoteBranchSet.has(name),
+								});
+							}
+						}
+					}
+
+					const branches = Array.from(branchMap.entries()).map(
+						([name, data]) => ({
+							name,
+							...data,
+						}),
+					);
+
+					const defaultBranch =
+						project.defaultBranch ||
+						(await getDefaultBranch(project.mainRepoPath));
+
+					branches.sort((a, b) => {
+						if (a.name === defaultBranch) return -1;
+						if (b.name === defaultBranch) return 1;
+						return b.lastCommitDate - a.lastCommitDate;
+					});
+
+					return { branches, defaultBranch };
+				},
+			),
+
+		// Slow: fetches from remote and returns the full, up-to-date branch list
 		getBranches: publicProcedure
 			.input(z.object({ projectId: z.string() }))
 			.query(

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/BranchesGroup/BranchesGroup.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/BranchesGroup/BranchesGroup.tsx
@@ -20,10 +20,21 @@ export function BranchesGroup({ projectId, onClose }: BranchesGroupProps) {
 	const navigate = useNavigate();
 	const createBranchWorkspace = useCreateBranchWorkspace();
 
-	const { data, isLoading } = electronTrpc.projects.getBranches.useQuery(
+	// Fast query: local branches + cached remote refs (no network)
+	const { data: localData, isLoading: isLocalLoading } =
+		electronTrpc.projects.getBranchesLocal.useQuery(
+			{ projectId: projectId ?? "" },
+			{ enabled: !!projectId },
+		);
+
+	// Slow query: fetches from remote, runs in background
+	const { data: remoteData } = electronTrpc.projects.getBranches.useQuery(
 		{ projectId: projectId ?? "" },
 		{ enabled: !!projectId },
 	);
+
+	// Use remote data when available, fall back to local data
+	const data = remoteData ?? localData;
 
 	const { data: allWorkspaces = [] } =
 		electronTrpc.workspaces.getAll.useQuery();
@@ -85,7 +96,7 @@ export function BranchesGroup({ projectId, onClose }: BranchesGroupProps) {
 		);
 	}
 
-	if (isLoading) {
+	if (isLocalLoading) {
 		return (
 			<CommandGroup>
 				<CommandEmpty>Loading branches...</CommandEmpty>

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
@@ -82,13 +82,18 @@ export function PromptGroup({ projectId, onClose }: PromptGroupProps) {
 		{ enabled: !!projectId },
 	);
 	const {
-		data: branchData,
+		data: localBranchData,
 		isLoading: isBranchesLoading,
 		isError: isBranchesError,
-	} = electronTrpc.projects.getBranches.useQuery(
+	} = electronTrpc.projects.getBranchesLocal.useQuery(
 		{ projectId: projectId ?? "" },
 		{ enabled: !!projectId },
 	);
+	const { data: remoteBranchData } = electronTrpc.projects.getBranches.useQuery(
+		{ projectId: projectId ?? "" },
+		{ enabled: !!projectId },
+	);
+	const branchData = remoteBranchData ?? localBranchData;
 	const { data: gitAuthor } = electronTrpc.projects.getGitAuthor.useQuery(
 		{ id: projectId ?? "" },
 		{ enabled: !!projectId },


### PR DESCRIPTION
## Summary
- Added `getBranchesLocal` tRPC procedure that returns branches using only local git refs (no network calls)
- New workspace modal now calls `getBranchesLocal` first for instant display, then `getBranches` (with `git fetch`) in the background
- When remote data arrives, it seamlessly replaces the local data — no loading spinner needed

The bottleneck was `git fetch --prune` and `refreshDefaultBranch` (both network calls) blocking the entire branch list from rendering.

## Test plan
- [ ] Open new workspace modal → Branches tab should load instantly
- [ ] Verify remote-only branches appear after a brief delay (background fetch)
- [ ] Test offline: branches tab should still show local + cached remote branches
- [ ] Verify creating a workspace from a branch still works correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Branches in the New Workspace modal now load instantly by showing local and cached remote refs first, then auto-updating with remote data in the background. This removes blocking `git fetch` work and avoids the loading spinner.

- **New Features**
  - Added `getBranchesLocal` tRPC procedure to return local branches + cached remote refs without network calls.
  - Updated `BranchesGroup` and `PromptGroup` to use `getBranchesLocal` first and `getBranches` in the background for up-to-date data.
  - Works offline; shows local + cached remote branches and updates when connectivity returns.

<sup>Written for commit ff623a222cae920695d02187b0243ac467ab5388. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Faster branch selection in workspace creation. Branches now load instantly from your local repository cache while the app fetches the latest remote branch information in the background. This provides quick access to branch options with up-to-date data when available, improving the setup experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->