### PR TITLE
fix(desktop): restore new workspace modal persistence

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -1,52 +1,27 @@
-import { CommandDialog, CommandInput, CommandList } from "@superset/ui/command";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@superset/ui/dialog";
 import { toast } from "@superset/ui/sonner";
-import { Tabs, TabsList, TabsTrigger } from "@superset/ui/tabs";
 import { useNavigate } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
-import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useOpenProject } from "renderer/react-query/projects";
 import {
 	useCloseNewWorkspaceModal,
 	useNewWorkspaceModalOpen,
 	usePreSelectedProjectId,
 } from "renderer/stores/new-workspace-modal";
-import { BranchesGroup } from "./components/BranchesGroup";
-import { IssuesGroup } from "./components/IssuesGroup";
-import { ProjectSelector } from "./components/ProjectSelector";
-import { PromptGroup } from "./components/PromptGroup";
-import { PullRequestsGroup } from "./components/PullRequestsGroup";
-
-type Tab = "prompt" | "issues" | "pull-requests" | "branches";
+import { NewWorkspaceModalContent } from "./components/NewWorkspaceModalContent";
+import { NewWorkspaceModalDraftProvider } from "./NewWorkspaceModalDraftContext";
 
 export function NewWorkspaceModal() {
 	const isOpen = useNewWorkspaceModalOpen();
 	const closeModal = useCloseNewWorkspaceModal();
-	const preSelectedProjectId = usePreSelectedProjectId();
-	const [activeTab, setActiveTab] = useState<Tab>("prompt");
-	const [selectedProjectId, setSelectedProjectId] = useState<string | null>(
-		null,
-	);
 	const navigate = useNavigate();
 	const { openNew } = useOpenProject();
-
-	const { data: recentProjects = [] } =
-		electronTrpc.projects.getRecents.useQuery();
-
-	// Sync pre-selected project when modal opens
-	// biome-ignore lint/correctness/useExhaustiveDependencies: reset on modal open
-	useEffect(() => {
-		if (!isOpen) return;
-		if (preSelectedProjectId) {
-			setSelectedProjectId(preSelectedProjectId);
-		} else if (recentProjects.length > 0 && !selectedProjectId) {
-			setSelectedProjectId(recentProjects[0].id);
-		}
-	}, [isOpen]);
-
-	const selectedProject = recentProjects.find(
-		(p) => p.id === selectedProjectId,
-	);
-	const isListTab = activeTab !== "prompt";
+	const preSelectedProjectId = usePreSelectedProjectId();
 
 	const handleImportRepo = async () => {
 		closeModal();
@@ -66,67 +41,26 @@ export function NewWorkspaceModal() {
 	};
 
 	return (
-		<CommandDialog
-			open={isOpen}
-			onOpenChange={(open) => !open && closeModal()}
-			title="New Workspace"
-			description="Create a new workspace from a PR, branch, issue, or prompt."
-			showCloseButton={false}
-			className="sm:max-w-[560px] max-h-[min(70vh,600px)] !top-[calc(50%-min(35vh,300px))] !-translate-y-0 flex flex-col"
-		>
-			<div className="flex items-center justify-between border-b px-3 py-2">
-				<Tabs
-					value={activeTab}
-					onValueChange={(value) => setActiveTab(value as Tab)}
+		<NewWorkspaceModalDraftProvider onClose={closeModal}>
+			<Dialog open={isOpen} onOpenChange={(open) => !open && closeModal()}>
+				<DialogHeader className="sr-only">
+					<DialogTitle>New Workspace</DialogTitle>
+					<DialogDescription>
+						Create a new workspace from a PR, branch, issue, or prompt.
+					</DialogDescription>
+				</DialogHeader>
+				<DialogContent
+					showCloseButton={false}
+					className="sm:max-w-[560px] max-h-[min(70vh,600px)] !top-[calc(50%-min(35vh,300px))] !-translate-y-0 flex flex-col overflow-hidden p-0"
 				>
-					<TabsList>
-						<TabsTrigger value="prompt">Prompt</TabsTrigger>
-						<TabsTrigger value="issues">Issues</TabsTrigger>
-						<TabsTrigger value="pull-requests">Pull requests</TabsTrigger>
-						<TabsTrigger value="branches">Branches</TabsTrigger>
-					</TabsList>
-				</Tabs>
-				<ProjectSelector
-					selectedProjectId={selectedProjectId}
-					selectedProjectName={selectedProject?.name ?? null}
-					recentProjects={recentProjects.filter((p) => Boolean(p.id))}
-					onSelectProject={setSelectedProjectId}
-					onImportRepo={handleImportRepo}
-					onNewProject={handleNewProject}
-				/>
-			</div>
-
-			{isListTab && (
-				<CommandInput
-					placeholder={
-						activeTab === "issues"
-							? "Search by slug, title, or description"
-							: activeTab === "branches"
-								? "Search by name"
-								: "Search by title, number, or author"
-					}
-				/>
-			)}
-
-			<CommandList className="!max-h-none flex-1 overflow-y-auto">
-				{activeTab === "pull-requests" && (
-					<PullRequestsGroup
-						projectId={selectedProjectId}
-						githubOwner={selectedProject?.githubOwner ?? null}
-						repoName={selectedProject?.name ?? null}
-						onClose={closeModal}
+					<NewWorkspaceModalContent
+						isOpen={isOpen}
+						preSelectedProjectId={preSelectedProjectId}
+						onImportRepo={handleImportRepo}
+						onNewProject={handleNewProject}
 					/>
-				)}
-				{activeTab === "branches" && (
-					<BranchesGroup projectId={selectedProjectId} onClose={closeModal} />
-				)}
-				{activeTab === "issues" && (
-					<IssuesGroup projectId={selectedProjectId} onClose={closeModal} />
-				)}
-				{activeTab === "prompt" && (
-					<PromptGroup projectId={selectedProjectId} onClose={closeModal} />
-				)}
-			</CommandList>
-		</CommandDialog>
+				</DialogContent>
+			</Dialog>
+		</NewWorkspaceModalDraftProvider>
 	);
 }

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModalDraftContext.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModalDraftContext.tsx
@@ -1,0 +1,187 @@
+import { toast } from "@superset/ui/sonner";
+import {
+	createContext,
+	type PropsWithChildren,
+	useCallback,
+	useContext,
+	useMemo,
+	useState,
+} from "react";
+
+export type NewWorkspaceModalTab =
+	| "prompt"
+	| "issues"
+	| "pull-requests"
+	| "branches";
+
+export interface NewWorkspaceModalDraft {
+	activeTab: NewWorkspaceModalTab;
+	selectedProjectId: string | null;
+	prompt: string;
+	branchName: string;
+	branchNameEdited: boolean;
+	baseBranch: string | null;
+	showAdvanced: boolean;
+	runSetupScript: boolean;
+	branchSearch: string;
+	issuesQuery: string;
+	pullRequestsQuery: string;
+	branchesQuery: string;
+}
+
+interface NewWorkspaceModalDraftState extends NewWorkspaceModalDraft {
+	draftVersion: number;
+}
+
+const initialDraft: NewWorkspaceModalDraft = {
+	activeTab: "prompt",
+	selectedProjectId: null,
+	prompt: "",
+	branchName: "",
+	branchNameEdited: false,
+	baseBranch: null,
+	showAdvanced: false,
+	runSetupScript: true,
+	branchSearch: "",
+	issuesQuery: "",
+	pullRequestsQuery: "",
+	branchesQuery: "",
+};
+
+function buildInitialDraftState(): NewWorkspaceModalDraftState {
+	return {
+		...initialDraft,
+		draftVersion: 0,
+	};
+}
+
+interface NewWorkspaceModalActionMessages {
+	loading: string;
+	success: string;
+	error: (err: unknown) => string;
+}
+
+interface NewWorkspaceModalDraftContextValue {
+	draft: NewWorkspaceModalDraft;
+	draftVersion: number;
+	closeModal: () => void;
+	closeAndResetDraft: () => void;
+	runAsyncAction: <T>(
+		promise: Promise<T>,
+		messages: NewWorkspaceModalActionMessages,
+	) => Promise<T>;
+	updateDraft: (patch: Partial<NewWorkspaceModalDraft>) => void;
+	resetDraft: () => void;
+	resetDraftIfVersion: (draftVersion: number) => void;
+}
+
+const NewWorkspaceModalDraftContext =
+	createContext<NewWorkspaceModalDraftContextValue | null>(null);
+
+export function NewWorkspaceModalDraftProvider({
+	children,
+	onClose,
+}: PropsWithChildren<{ onClose: () => void }>) {
+	const [state, setState] = useState(buildInitialDraftState);
+
+	const updateDraft = useCallback((patch: Partial<NewWorkspaceModalDraft>) => {
+		setState((state) => ({
+			...state,
+			...patch,
+			draftVersion: state.draftVersion + 1,
+		}));
+	}, []);
+
+	const resetDraft = useCallback(() => {
+		setState((state) => ({
+			...initialDraft,
+			draftVersion: state.draftVersion + 1,
+		}));
+	}, []);
+
+	const resetDraftIfVersion = useCallback((draftVersion: number) => {
+		setState((state) =>
+			state.draftVersion !== draftVersion
+				? state
+				: {
+						...initialDraft,
+						draftVersion: state.draftVersion + 1,
+					},
+		);
+	}, []);
+
+	const closeAndResetDraft = useCallback(() => {
+		resetDraft();
+		onClose();
+	}, [onClose, resetDraft]);
+
+	const runAsyncAction = useCallback(
+		<T,>(promise: Promise<T>, messages: NewWorkspaceModalActionMessages) => {
+			const submitDraftVersion = state.draftVersion;
+			onClose();
+			toast.promise(promise, {
+				loading: messages.loading,
+				success: messages.success,
+				error: (err) => messages.error(err),
+			});
+			void promise
+				.then(() => {
+					resetDraftIfVersion(submitDraftVersion);
+				})
+				.catch(() => undefined);
+			return promise;
+		},
+		[onClose, resetDraftIfVersion, state.draftVersion],
+	);
+
+	const value = useMemo<NewWorkspaceModalDraftContextValue>(
+		() => ({
+			draft: {
+				activeTab: state.activeTab,
+				selectedProjectId: state.selectedProjectId,
+				prompt: state.prompt,
+				branchName: state.branchName,
+				branchNameEdited: state.branchNameEdited,
+				baseBranch: state.baseBranch,
+				showAdvanced: state.showAdvanced,
+				runSetupScript: state.runSetupScript,
+				branchSearch: state.branchSearch,
+				issuesQuery: state.issuesQuery,
+				pullRequestsQuery: state.pullRequestsQuery,
+				branchesQuery: state.branchesQuery,
+			},
+			draftVersion: state.draftVersion,
+			closeModal: onClose,
+			closeAndResetDraft,
+			runAsyncAction,
+			updateDraft,
+			resetDraft,
+			resetDraftIfVersion,
+		}),
+		[
+			closeAndResetDraft,
+			onClose,
+			resetDraft,
+			resetDraftIfVersion,
+			runAsyncAction,
+			state,
+			updateDraft,
+		],
+	);
+
+	return (
+		<NewWorkspaceModalDraftContext.Provider value={value}>
+			{children}
+		</NewWorkspaceModalDraftContext.Provider>
+	);
+}
+
+export function useNewWorkspaceModalDraft() {
+	const context = useContext(NewWorkspaceModalDraftContext);
+	if (!context) {
+		throw new Error(
+			"useNewWorkspaceModalDraft must be used within NewWorkspaceModalDraftProvider",
+		);
+	}
+	return context;
+}

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/BranchesGroup/BranchesGroup.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/BranchesGroup/BranchesGroup.tsx
@@ -1,6 +1,5 @@
 import { Button } from "@superset/ui/button";
 import { CommandEmpty, CommandGroup, CommandItem } from "@superset/ui/command";
-import { toast } from "@superset/ui/sonner";
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback, useMemo } from "react";
 import { GoArrowUpRight, GoGitBranch, GoGlobe } from "react-icons/go";
@@ -8,17 +7,18 @@ import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useCreateBranchWorkspace } from "renderer/react-query/workspaces";
 import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { useHotkeysStore } from "renderer/stores/hotkeys/store";
+import { useNewWorkspaceModalDraft } from "../../NewWorkspaceModalDraftContext";
 
 interface BranchesGroupProps {
 	projectId: string | null;
-	onClose: () => void;
 }
 
-export function BranchesGroup({ projectId, onClose }: BranchesGroupProps) {
+export function BranchesGroup({ projectId }: BranchesGroupProps) {
 	const platform = useHotkeysStore((state) => state.platform);
 	const modKey = platform === "darwin" ? "⌘" : "Ctrl";
 	const navigate = useNavigate();
 	const createBranchWorkspace = useCreateBranchWorkspace();
+	const { closeAndResetDraft, runAsyncAction } = useNewWorkspaceModalDraft();
 
 	// Fast query: local branches + cached remote refs (no network)
 	const { data: localData, isLoading: isLocalLoading } =
@@ -63,8 +63,7 @@ export function BranchesGroup({ projectId, onClose }: BranchesGroupProps) {
 	const handleCreate = useCallback(
 		(branchName: string) => {
 			if (!projectId) return;
-			onClose();
-			toast.promise(
+			void runAsyncAction(
 				createBranchWorkspace.mutateAsync({
 					projectId,
 					branch: branchName,
@@ -77,15 +76,15 @@ export function BranchesGroup({ projectId, onClose }: BranchesGroupProps) {
 				},
 			);
 		},
-		[projectId, onClose, createBranchWorkspace],
+		[createBranchWorkspace, projectId, runAsyncAction],
 	);
 
 	const handleOpen = useCallback(
 		(workspaceId: string) => {
-			onClose();
+			closeAndResetDraft();
 			navigateToWorkspace(workspaceId, navigate);
 		},
-		[onClose, navigate],
+		[closeAndResetDraft, navigate],
 	);
 
 	if (!projectId) {

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/IssuesGroup/IssuesGroup.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/IssuesGroup/IssuesGroup.tsx
@@ -19,17 +19,18 @@ import {
 } from "renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/shared/StatusIcon";
 import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useNewWorkspaceModalDraft } from "../../NewWorkspaceModalDraftContext";
 
 interface IssuesGroupProps {
 	projectId: string | null;
-	onClose: () => void;
 }
 
-export function IssuesGroup({ projectId, onClose }: IssuesGroupProps) {
+export function IssuesGroup({ projectId }: IssuesGroupProps) {
 	const collections = useCollections();
 	const navigate = useNavigate();
 	const { gateFeature } = usePaywall();
 	const createWorkspace = useCreateWorkspace();
+	const { closeAndResetDraft, runAsyncAction } = useNewWorkspaceModalDraft();
 
 	const { data: integrations } = useLiveQuery(
 		(q) =>
@@ -100,7 +101,7 @@ export function IssuesGroup({ projectId, onClose }: IssuesGroupProps) {
 					variant="outline"
 					onClick={() => {
 						gateFeature(GATED_FEATURES.INTEGRATIONS, () => {
-							onClose();
+							closeAndResetDraft();
 							navigate({ to: "/settings/integrations" });
 						});
 					}}
@@ -125,12 +126,11 @@ export function IssuesGroup({ projectId, onClose }: IssuesGroupProps) {
 						}
 						const existingId = workspaceByBranch.get(task.slug.toLowerCase());
 						if (existingId) {
-							onClose();
+							closeAndResetDraft();
 							navigateToWorkspace(existingId, navigate);
 							return;
 						}
-						onClose();
-						toast.promise(
+						void runAsyncAction(
 							createWorkspace.mutateAsync({
 								projectId,
 								name: task.title,

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/NewWorkspaceModalContent/NewWorkspaceModalContent.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/NewWorkspaceModalContent/NewWorkspaceModalContent.tsx
@@ -1,0 +1,154 @@
+import { Command, CommandInput, CommandList } from "@superset/ui/command";
+import { Tabs, TabsList, TabsTrigger } from "@superset/ui/tabs";
+import { useEffect } from "react";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import {
+	type NewWorkspaceModalTab,
+	useNewWorkspaceModalDraft,
+} from "../../NewWorkspaceModalDraftContext";
+import { BranchesGroup } from "../BranchesGroup";
+import { IssuesGroup } from "../IssuesGroup";
+import { ProjectSelector } from "../ProjectSelector";
+import { PromptGroup } from "../PromptGroup";
+import { PullRequestsGroup } from "../PullRequestsGroup";
+
+const COMMAND_CLASS_NAME =
+	"[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5 flex h-full w-full flex-1 flex-col overflow-hidden rounded-none";
+
+interface NewWorkspaceModalContentProps {
+	isOpen: boolean;
+	preSelectedProjectId: string | null;
+	onImportRepo: () => Promise<void>;
+	onNewProject: () => void;
+}
+
+export function NewWorkspaceModalContent({
+	isOpen,
+	preSelectedProjectId,
+	onImportRepo,
+	onNewProject,
+}: NewWorkspaceModalContentProps) {
+	const { draft, updateDraft } = useNewWorkspaceModalDraft();
+	const { data: recentProjects = [] } =
+		electronTrpc.projects.getRecents.useQuery();
+
+	useEffect(() => {
+		if (!isOpen) return;
+
+		if (
+			preSelectedProjectId &&
+			preSelectedProjectId !== draft.selectedProjectId
+		) {
+			updateDraft({ selectedProjectId: preSelectedProjectId });
+			return;
+		}
+
+		const hasSelectedProject = recentProjects.some(
+			(project) => project.id === draft.selectedProjectId,
+		);
+		if (!hasSelectedProject) {
+			updateDraft({ selectedProjectId: recentProjects[0]?.id ?? null });
+		}
+	}, [
+		draft.selectedProjectId,
+		isOpen,
+		preSelectedProjectId,
+		recentProjects,
+		updateDraft,
+	]);
+
+	const selectedProject = recentProjects.find(
+		(project) => project.id === draft.selectedProjectId,
+	);
+	const isListTab = draft.activeTab !== "prompt";
+	const listQuery =
+		draft.activeTab === "issues"
+			? draft.issuesQuery
+			: draft.activeTab === "branches"
+				? draft.branchesQuery
+				: draft.pullRequestsQuery;
+
+	const handleListQueryChange = (value: string) => {
+		switch (draft.activeTab) {
+			case "issues":
+				updateDraft({ issuesQuery: value });
+				return;
+			case "branches":
+				updateDraft({ branchesQuery: value });
+				return;
+			case "pull-requests":
+				updateDraft({ pullRequestsQuery: value });
+				return;
+			default:
+				return;
+		}
+	};
+
+	return (
+		<>
+			<div className="flex items-center justify-between border-b px-3 py-2">
+				<Tabs
+					value={draft.activeTab}
+					onValueChange={(value) =>
+						updateDraft({ activeTab: value as NewWorkspaceModalTab })
+					}
+				>
+					<TabsList>
+						<TabsTrigger value="prompt">Prompt</TabsTrigger>
+						<TabsTrigger value="issues">Issues</TabsTrigger>
+						<TabsTrigger value="pull-requests">Pull requests</TabsTrigger>
+						<TabsTrigger value="branches">Branches</TabsTrigger>
+					</TabsList>
+				</Tabs>
+				<ProjectSelector
+					selectedProjectId={draft.selectedProjectId}
+					selectedProjectName={selectedProject?.name ?? null}
+					recentProjects={recentProjects.filter((project) =>
+						Boolean(project.id),
+					)}
+					onSelectProject={(selectedProjectId) =>
+						updateDraft({ selectedProjectId })
+					}
+					onImportRepo={onImportRepo}
+					onNewProject={onNewProject}
+				/>
+			</div>
+
+			{isListTab ? (
+				<Command className={COMMAND_CLASS_NAME}>
+					<CommandInput
+						value={listQuery}
+						onValueChange={handleListQueryChange}
+						placeholder={
+							draft.activeTab === "issues"
+								? "Search by slug, title, or description"
+								: draft.activeTab === "branches"
+									? "Search by name"
+									: "Search by title, number, or author"
+						}
+					/>
+
+					<CommandList className="!max-h-none flex-1 overflow-y-auto">
+						{draft.activeTab === "pull-requests" && (
+							<PullRequestsGroup
+								projectId={draft.selectedProjectId}
+								githubOwner={selectedProject?.githubOwner ?? null}
+								repoName={selectedProject?.name ?? null}
+							/>
+						)}
+						{draft.activeTab === "branches" && (
+							<BranchesGroup projectId={draft.selectedProjectId} />
+						)}
+						{draft.activeTab === "issues" && (
+							<IssuesGroup projectId={draft.selectedProjectId} />
+						)}
+					</CommandList>
+				</Command>
+			) : (
+				<div className="flex-1 overflow-y-auto">
+					<PromptGroup projectId={draft.selectedProjectId} />
+				</div>
+			)}
+		</>
+	);
+}

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/NewWorkspaceModalContent/index.ts
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/NewWorkspaceModalContent/index.ts
@@ -1,0 +1,1 @@
+export { NewWorkspaceModalContent } from "./NewWorkspaceModalContent";

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
@@ -33,6 +33,7 @@ import {
 	resolveBranchPrefix,
 	sanitizeBranchNameWithMaxLength,
 } from "shared/utils/branch";
+import { useNewWorkspaceModalDraft } from "../../NewWorkspaceModalDraftContext";
 import { PromptGroupAdvancedOptions } from "./components/PromptGroupAdvancedOptions";
 
 type WorkspaceCreateAgent = StartableAgentType | "none";
@@ -41,23 +42,26 @@ const AGENT_STORAGE_KEY = "lastSelectedWorkspaceCreateAgent";
 
 interface PromptGroupProps {
 	projectId: string | null;
-	onClose: () => void;
 }
 
-export function PromptGroup({ projectId, onClose }: PromptGroupProps) {
+export function PromptGroup({ projectId }: PromptGroupProps) {
 	const navigate = useNavigate();
 	const platform = useHotkeysStore((state) => state.platform);
 	const modKey = platform === "darwin" ? "⌘" : "Ctrl";
 	const isDark = useIsDarkTheme();
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
-	const [prompt, setPrompt] = useState("");
-	const [branchName, setBranchName] = useState("");
-	const [branchNameEdited, setBranchNameEdited] = useState(false);
-	const [baseBranch, setBaseBranch] = useState<string | null>(null);
+	const { closeModal, draft, runAsyncAction, updateDraft } =
+		useNewWorkspaceModalDraft();
 	const [baseBranchOpen, setBaseBranchOpen] = useState(false);
-	const [branchSearch, setBranchSearch] = useState("");
-	const [showAdvanced, setShowAdvanced] = useState(false);
-	const [runSetupScript, setRunSetupScript] = useState(true);
+	const {
+		baseBranch,
+		branchName,
+		branchNameEdited,
+		branchSearch,
+		prompt,
+		runSetupScript,
+		showAdvanced,
+	} = draft;
 	const runSetupScriptRef = useRef(runSetupScript);
 	runSetupScriptRef.current = runSetupScript;
 	const createWorkspace = useCreateWorkspace({
@@ -145,12 +149,19 @@ export function PromptGroup({ projectId, onClose }: PromptGroupProps) {
 			? sanitizeBranchNameWithMaxLength(`${resolvedPrefix}/${branchSlug}`)
 			: branchSlug;
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: intentionally reset advanced branch state when project changes
+	const previousProjectIdRef = useRef(projectId);
+
 	useEffect(() => {
-		setBaseBranch(null);
+		if (previousProjectIdRef.current === projectId) {
+			return;
+		}
+		previousProjectIdRef.current = projectId;
+		updateDraft({
+			baseBranch: null,
+			branchSearch: "",
+		});
 		setBaseBranchOpen(false);
-		setBranchSearch("");
-	}, [projectId]);
+	}, [projectId, updateDraft]);
 
 	const handleAgentChange = (value: WorkspaceCreateAgent) => {
 		setSelectedAgent(value);
@@ -202,9 +213,7 @@ export function PromptGroup({ projectId, onClose }: PromptGroupProps) {
 			return;
 		}
 		const launchRequest = buildLaunchRequest(trimmedPrompt);
-
-		onClose();
-		toast.promise(
+		void runAsyncAction(
 			createWorkspace.mutateAsyncWithPendingSetup(
 				{
 					projectId,
@@ -225,25 +234,31 @@ export function PromptGroup({ projectId, onClose }: PromptGroupProps) {
 	};
 
 	const handleBranchNameChange = (value: string) => {
-		setBranchName(value);
-		setBranchNameEdited(true);
+		updateDraft({
+			branchName: value,
+			branchNameEdited: true,
+		});
 	};
 
 	const handleBranchNameBlur = () => {
 		if (!branchName.trim()) {
-			setBranchName("");
-			setBranchNameEdited(false);
+			updateDraft({
+				branchName: "",
+				branchNameEdited: false,
+			});
 		}
 	};
 
 	const handleBaseBranchSelect = (selectedBaseBranch: string) => {
-		setBaseBranch(selectedBaseBranch);
+		updateDraft({
+			baseBranch: selectedBaseBranch,
+			branchSearch: "",
+		});
 		setBaseBranchOpen(false);
-		setBranchSearch("");
 	};
 
 	return (
-		<div className="p-3 space-y-3" cmdk-group="">
+		<div className="p-3 space-y-3">
 			<Select
 				value={selectedAgent}
 				onValueChange={(value: WorkspaceCreateAgent) =>
@@ -284,7 +299,7 @@ export function PromptGroup({ projectId, onClose }: PromptGroupProps) {
 				className="min-h-24 max-h-48 text-sm resize-y field-sizing-fixed"
 				placeholder="What do you want to do?"
 				value={prompt}
-				onChange={(e) => setPrompt(e.target.value)}
+				onChange={(e) => updateDraft({ prompt: e.target.value })}
 				onKeyDown={(e) => {
 					if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
 						e.preventDefault();
@@ -295,12 +310,12 @@ export function PromptGroup({ projectId, onClose }: PromptGroupProps) {
 
 			<PromptGroupAdvancedOptions
 				showAdvanced={showAdvanced}
-				onShowAdvancedChange={setShowAdvanced}
+				onShowAdvancedChange={(showAdvanced) => updateDraft({ showAdvanced })}
 				branchInputValue={branchNameEdited ? branchName : branchPreview}
 				onBranchInputChange={handleBranchNameChange}
 				onBranchInputBlur={handleBranchNameBlur}
 				onEditPrefix={() => {
-					onClose();
+					closeModal();
 					navigate({ to: "/settings/behavior" });
 				}}
 				isBranchesError={isBranchesError}
@@ -310,11 +325,13 @@ export function PromptGroup({ projectId, onClose }: PromptGroupProps) {
 				effectiveBaseBranch={effectiveBaseBranch}
 				defaultBranch={branchData?.defaultBranch}
 				branchSearch={branchSearch}
-				onBranchSearchChange={setBranchSearch}
+				onBranchSearchChange={(branchSearch) => updateDraft({ branchSearch })}
 				filteredBranches={filteredBranches}
 				onSelectBaseBranch={handleBaseBranchSelect}
 				runSetupScript={runSetupScript}
-				onRunSetupScriptChange={setRunSetupScript}
+				onRunSetupScriptChange={(runSetupScript) =>
+					updateDraft({ runSetupScript })
+				}
 			/>
 
 			<Button

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PullRequestsGroup/PullRequestsGroup.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PullRequestsGroup/PullRequestsGroup.tsx
@@ -16,24 +16,24 @@ import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useCreateFromPr } from "renderer/react-query/workspaces/useCreateFromPr";
 import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useNewWorkspaceModalDraft } from "../../NewWorkspaceModalDraftContext";
 
 interface PullRequestsGroupProps {
 	projectId: string | null;
 	githubOwner: string | null;
 	repoName: string | null;
-	onClose: () => void;
 }
 
 export function PullRequestsGroup({
 	projectId,
 	githubOwner,
 	repoName,
-	onClose,
 }: PullRequestsGroupProps) {
 	const collections = useCollections();
 	const navigate = useNavigate();
 	const { gateFeature } = usePaywall();
 	const createFromPr = useCreateFromPr();
+	const { closeAndResetDraft, runAsyncAction } = useNewWorkspaceModalDraft();
 
 	// Match GitHub repository by owner + name from the local project
 	const { data: repoData } = useLiveQuery(
@@ -105,7 +105,7 @@ export function PullRequestsGroup({
 					variant="outline"
 					onClick={() => {
 						gateFeature(GATED_FEATURES.INTEGRATIONS, () => {
-							onClose();
+							closeAndResetDraft();
 							navigate({ to: "/settings/integrations" });
 						});
 					}}
@@ -138,12 +138,11 @@ export function PullRequestsGroup({
 						}
 						const existingId = workspaceByBranch.get(pr.headBranch);
 						if (existingId) {
-							onClose();
+							closeAndResetDraft();
 							navigateToWorkspace(existingId, navigate);
 							return;
 						}
-						onClose();
-						toast.promise(
+						void runAsyncAction(
 							createFromPr.mutateAsync({
 								projectId,
 								prUrl: pr.url,

--- a/apps/desktop/src/renderer/stores/new-workspace-modal.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-modal.ts
@@ -26,7 +26,6 @@ export const useNewWorkspaceModalStore = create<NewWorkspaceModalState>()(
 	),
 );
 
-// Convenience hooks
 export const useNewWorkspaceModalOpen = () =>
 	useNewWorkspaceModalStore((state) => state.isOpen);
 export const useOpenNewWorkspaceModal = () =>


### PR DESCRIPTION
## Summary
- restore new workspace modal draft persistence across close/reopen for tab selection, selected project, prompt draft, advanced options, and per-tab searches
- render the prompt flow outside the `cmdk` command list again so the textarea keeps native multiline and arrow-key behavior
- keep the global modal store focused on open/close state only, and move draft persistence into a modal-local `useState` context with shared close/reset and async-success helpers to cut down repeated action wiring

## Testing
- `bunx biome check apps/desktop/src/renderer/stores/new-workspace-modal.ts apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModalDraftContext.tsx apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx apps/desktop/src/renderer/components/NewWorkspaceModal/components/IssuesGroup/IssuesGroup.tsx apps/desktop/src/renderer/components/NewWorkspaceModal/components/BranchesGroup/BranchesGroup.tsx apps/desktop/src/renderer/components/NewWorkspaceModal/components/PullRequestsGroup/PullRequestsGroup.tsx`
- `bunx tsc -p apps/desktop/tsconfig.json --noEmit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modal now preserves inputs and per-tab searches via a centralized draft provider and hook.
  * Unified modal content with tabbed views for Prompt, Issues, Pull Requests, and Branches; project selector always visible.

* **Bug Fixes**
  * More consistent create/import flows with clear loading/success/error feedback and reliable draft cleanup.
  * Navigation and project selection now behave consistently across tabs.

* **Style**
  * Updated dialog layout and clearer tab-to-prompt navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->