### PR TITLE
Make diff pane selectable and jump to raw edit

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
@@ -85,8 +85,6 @@ export function FileViewerPane({
 	const oldPath = fileViewer?.oldPath;
 	const initialLine = fileViewer?.initialLine;
 	const initialColumn = fileViewer?.initialColumn;
-	const initialSelectionStartLine = fileViewer?.initialSelectionStartLine;
-	const initialSelectionEndLine = fileViewer?.initialSelectionEndLine;
 
 	const pinPane = useTabsStore((s) => s.pinPane);
 
@@ -180,8 +178,6 @@ export function FileViewerPane({
 		location?: {
 			line?: number;
 			column?: number;
-			selectionStartLine?: number;
-			selectionEndLine?: number;
 		},
 	) => {
 		const panes = useTabsStore.getState().panes;
@@ -198,12 +194,6 @@ export function FileViewerPane({
 							initialLine: location?.line ?? currentPane.fileViewer.initialLine,
 							initialColumn:
 								location?.column ?? currentPane.fileViewer.initialColumn,
-							initialSelectionStartLine:
-								location?.selectionStartLine ??
-								currentPane.fileViewer.initialSelectionStartLine,
-							initialSelectionEndLine:
-								location?.selectionEndLine ??
-								currentPane.fileViewer.initialSelectionEndLine,
 						},
 					},
 				},
@@ -211,20 +201,8 @@ export function FileViewerPane({
 		}
 	};
 
-	const handleSwitchToRawAtLocation = (
-		line: number,
-		column: number,
-		selection?: {
-			startLine: number;
-			endLine: number;
-		},
-	) => {
-		switchToMode("raw", {
-			line,
-			column,
-			selectionStartLine: selection?.startLine,
-			selectionEndLine: selection?.endLine,
-		});
+	const handleSwitchToRawAtLocation = (line: number, column: number) => {
+		switchToMode("raw", { line, column });
 	};
 
 	const handleViewModeChange = (value: string) => {
@@ -330,8 +308,6 @@ export function FileViewerPane({
 					draftContentRef={draftContentRef}
 					initialLine={initialLine}
 					initialColumn={initialColumn}
-					initialSelectionStartLine={initialSelectionStartLine}
-					initialSelectionEndLine={initialSelectionEndLine}
 					diffViewMode={diffViewMode}
 					hideUnchangedRegions={hideUnchangedRegions}
 					onSaveRaw={handleSaveRaw}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
@@ -21,7 +21,6 @@ import {
 	type DiffDomLocation,
 	getColumnFromDiffPoint,
 	getDiffLocationFromEvent,
-	getRawSectionForDiffLocation,
 	mapDiffLocationToRawPosition,
 } from "./utils/diff-location";
 
@@ -107,21 +106,12 @@ interface FileViewerContentProps {
 	draftContentRef: MutableRefObject<string | null>;
 	initialLine?: number;
 	initialColumn?: number;
-	initialSelectionStartLine?: number;
-	initialSelectionEndLine?: number;
 	diffViewMode: DiffViewMode;
 	hideUnchangedRegions: boolean;
 	onSaveRaw: () => Promise<void>;
 	onEditorChange: (value: string | undefined) => void;
 	setIsDirty: (dirty: boolean) => void;
-	onSwitchToRawAtLocation: (
-		line: number,
-		column: number,
-		selection?: {
-			startLine: number;
-			endLine: number;
-		},
-	) => void;
+	onSwitchToRawAtLocation: (line: number, column: number) => void;
 	onSplitHorizontal: () => void;
 	onSplitVertical: () => void;
 	onSplitWithNewChat?: () => void;
@@ -160,8 +150,6 @@ export function FileViewerContent({
 	draftContentRef,
 	initialLine,
 	initialColumn,
-	initialSelectionStartLine,
-	initialSelectionEndLine,
 	diffViewMode,
 	hideUnchangedRegions,
 	onSaveRaw,
@@ -198,12 +186,7 @@ export function FileViewerContent({
 	// biome-ignore lint/correctness/useExhaustiveDependencies: Reset when requested cursor target changes
 	useEffect(() => {
 		hasAppliedInitialLocationRef.current = false;
-	}, [
-		initialLine,
-		initialColumn,
-		initialSelectionStartLine,
-		initialSelectionEndLine,
-	]);
+	}, [initialLine, initialColumn]);
 
 	useEffect(() => {
 		if (viewMode !== "raw") {
@@ -258,17 +241,8 @@ export function FileViewerContent({
 			lineType: location.lineType,
 			column: location.column,
 		});
-		const rawSection = getRawSectionForDiffLocation({
-			contents: diffData,
-			lineNumber: location.lineNumber,
-			side: location.side,
-		});
 
-		onSwitchToRawAtLocation(
-			position.lineNumber,
-			position.column,
-			rawSection ?? undefined,
-		);
+		onSwitchToRawAtLocation(position.lineNumber, position.column);
 	};
 
 	useEffect(() => {
@@ -300,18 +274,13 @@ export function FileViewerContent({
 			return;
 		}
 
-		editorRef.current.revealPosition(initialLine, initialColumn ?? 1, {
-			startLine: initialSelectionStartLine ?? initialLine,
-			endLine: initialSelectionEndLine ?? initialLine,
-		});
+		editorRef.current.revealPosition(initialLine, initialColumn ?? 1);
 		hasAppliedInitialLocationRef.current = true;
 	}, [
 		viewMode,
 		editorRef,
 		initialLine,
 		initialColumn,
-		initialSelectionStartLine,
-		initialSelectionEndLine,
 		isLoadingRaw,
 		rawFileData,
 	]);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/utils/diff-location.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/utils/diff-location.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { FileContents } from "shared/changes-types";
-import {
-	getRawSectionForDiffLocation,
-	mapDiffLocationToRawPosition,
-} from "./diff-location";
+import { mapDiffLocationToRawPosition } from "./diff-location";
 
 describe("mapDiffLocationToRawPosition", () => {
 	it("keeps addition-side clicks on the same modified line", () => {
@@ -125,44 +122,6 @@ describe("mapDiffLocationToRawPosition", () => {
 		).toEqual({
 			lineNumber: 1,
 			column: 5,
-		});
-	});
-
-	it("returns the modified hunk range for addition-side clicks", () => {
-		const contents: FileContents = {
-			original: "one\ntwo\nthree\nfour",
-			modified: "one\ntwo changed\nthree\nfour\nfive",
-			language: "text",
-		};
-
-		expect(
-			getRawSectionForDiffLocation({
-				contents,
-				lineNumber: 2,
-				side: "additions",
-			}),
-		).toEqual({
-			startLine: 1,
-			endLine: 5,
-		});
-	});
-
-	it("returns the modified hunk range for deletion-side clicks", () => {
-		const contents: FileContents = {
-			original: "one\ntwo\nthree\nfour",
-			modified: "zero\none\nthree\nfour",
-			language: "text",
-		};
-
-		expect(
-			getRawSectionForDiffLocation({
-				contents,
-				lineNumber: 2,
-				side: "deletions",
-			}),
-		).toEqual({
-			startLine: 1,
-			endLine: 4,
 		});
 	});
 });

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/utils/diff-location.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/utils/diff-location.ts
@@ -33,11 +33,6 @@ export interface RawEditorPosition {
 	column: number;
 }
 
-export interface RawEditorRange {
-	startLine: number;
-	endLine: number;
-}
-
 function isSupportedLineType(lineType: string): lineType is LineTypes {
 	return (
 		lineType === "context" ||
@@ -180,93 +175,6 @@ function mapOldSideLineToRawLine(
 	}
 
 	return clampLineNumber(lineNumber + lineDelta, modifiedLines);
-}
-
-export function getRawSectionForDiffLocation({
-	contents,
-	lineNumber,
-	side,
-}: Pick<
-	MapDiffLocationToRawPositionOptions,
-	"contents" | "lineNumber" | "side"
->): RawEditorRange | null {
-	const modifiedLines = contents.modified.split("\n");
-	const diff = parseDiffFromFile(
-		{ name: "before", contents: contents.original },
-		{ name: "after", contents: contents.modified },
-	);
-
-	for (const hunk of diff.hunks) {
-		let currentOldLine = hunk.deletionStart;
-		let currentNewLine = hunk.additionStart;
-		let containsLocation = false;
-
-		for (const chunk of hunk.hunkContent) {
-			if (chunk.type === "context") {
-				const contextLineCount = chunk.lines.length;
-
-				if (
-					side === "additions" &&
-					lineNumber >= currentNewLine &&
-					lineNumber < currentNewLine + contextLineCount
-				) {
-					containsLocation = true;
-					break;
-				}
-
-				if (
-					side === "deletions" &&
-					lineNumber >= currentOldLine &&
-					lineNumber < currentOldLine + contextLineCount
-				) {
-					containsLocation = true;
-					break;
-				}
-
-				currentOldLine += contextLineCount;
-				currentNewLine += contextLineCount;
-				continue;
-			}
-
-			if (
-				side === "deletions" &&
-				lineNumber >= currentOldLine &&
-				lineNumber < currentOldLine + chunk.deletions.length
-			) {
-				containsLocation = true;
-				break;
-			}
-
-			if (
-				side === "additions" &&
-				lineNumber >= currentNewLine &&
-				lineNumber < currentNewLine + chunk.additions.length
-			) {
-				containsLocation = true;
-				break;
-			}
-
-			currentOldLine += chunk.deletions.length;
-			currentNewLine += chunk.additions.length;
-		}
-
-		if (!containsLocation) {
-			continue;
-		}
-
-		const rawStartLine = clampLineNumber(hunk.additionStart, modifiedLines);
-		const rawEndLine = clampLineNumber(
-			Math.max(hunk.additionStart, hunk.additionStart + hunk.additionCount - 1),
-			modifiedLines,
-		);
-
-		return {
-			startLine: rawStartLine,
-			endLine: rawEndLine,
-		};
-	}
-
-	return null;
 }
 
 export function mapDiffLocationToRawPosition({

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/CodeEditorAdapter/CodeEditorAdapter.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/CodeEditorAdapter/CodeEditorAdapter.ts
@@ -3,20 +3,11 @@ export interface EditorSelectionLines {
 	endLine: number;
 }
 
-export interface EditorHighlightRange {
-	startLine: number;
-	endLine: number;
-}
-
 export interface CodeEditorAdapter {
 	focus(): void;
 	getValue(): string;
 	setValue(value: string): void;
-	revealPosition(
-		line: number,
-		column?: number,
-		highlightRange?: EditorHighlightRange,
-	): void;
+	revealPosition(line: number, column?: number): void;
 	getSelectionLines(): EditorSelectionLines | null;
 	selectAll(): void;
 	cut(): void;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/CodeEditor.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/CodeEditor.tsx
@@ -11,16 +11,8 @@ import {
 	openSearchPanel,
 	searchKeymap,
 } from "@codemirror/search";
+import { Compartment, EditorSelection, EditorState } from "@codemirror/state";
 import {
-	Compartment,
-	EditorSelection,
-	EditorState,
-	StateEffect,
-	StateField,
-} from "@codemirror/state";
-import {
-	Decoration,
-	type DecorationSet,
 	drawSelection,
 	dropCursor,
 	EditorView,
@@ -49,64 +41,6 @@ interface CodeEditorProps {
 	onSave?: () => void;
 }
 
-const setHighlightRangeEffect = StateEffect.define<{
-	from: number;
-	to: number;
-} | null>();
-
-function createJumpTargetDecorations(
-	state: EditorState,
-	from: number,
-	to: number,
-): DecorationSet {
-	const startLine = state.doc.lineAt(from).number;
-	const endLine = state.doc.lineAt(to).number;
-	const decorations = [];
-
-	for (let lineNumber = startLine; lineNumber <= endLine; lineNumber += 1) {
-		const line = state.doc.line(lineNumber);
-		decorations.push(
-			Decoration.line({
-				class: "cm-jump-target-section",
-			}).range(line.from),
-		);
-		decorations.push(
-			Decoration.mark({
-				class: "cm-jump-target-section-text",
-			}).range(line.from, line.to),
-		);
-	}
-
-	return Decoration.set(decorations);
-}
-
-const highlightRangeField = StateField.define<DecorationSet>({
-	create: () => Decoration.none,
-	update(decorations, transaction) {
-		decorations = decorations.map(transaction.changes);
-
-		for (const effect of transaction.effects) {
-			if (!effect.is(setHighlightRangeEffect)) {
-				continue;
-			}
-
-			if (!effect.value) {
-				decorations = Decoration.none;
-				continue;
-			}
-
-			decorations = createJumpTargetDecorations(
-				transaction.state,
-				effect.value.from,
-				effect.value.to,
-			);
-		}
-
-		return decorations;
-	},
-	provide: (field) => EditorView.decorations.from(field),
-});
-
 function createCodeMirrorAdapter(view: EditorView): CodeEditorAdapter {
 	let disposed = false;
 
@@ -126,38 +60,14 @@ function createCodeMirrorAdapter(view: EditorView): CodeEditorAdapter {
 				},
 			});
 		},
-		revealPosition(line, column = 1, highlightRange) {
+		revealPosition(line, column = 1) {
 			const safeLine = Math.max(1, Math.min(line, view.state.doc.lines));
 			const lineInfo = view.state.doc.line(safeLine);
 			const offset = Math.min(column - 1, lineInfo.length);
 			const anchor = lineInfo.from + Math.max(0, offset);
-			const effects = [];
-
-			if (highlightRange) {
-				const startLine = Math.max(
-					1,
-					Math.min(highlightRange.startLine, view.state.doc.lines),
-				);
-				const endLine = Math.max(
-					startLine,
-					Math.min(highlightRange.endLine, view.state.doc.lines),
-				);
-				const startLineInfo = view.state.doc.line(startLine);
-				const endLineInfo = view.state.doc.line(endLine);
-
-				effects.push(
-					setHighlightRangeEffect.of({
-						from: startLineInfo.from,
-						to: endLineInfo.to,
-					}),
-				);
-			} else {
-				effects.push(setHighlightRangeEffect.of(null));
-			}
 
 			view.dispatch({
 				selection: EditorSelection.cursor(anchor),
-				effects,
 				scrollIntoView: true,
 			});
 			view.focus();
@@ -300,7 +210,6 @@ export function CodeEditor({
 		const state = EditorState.create({
 			doc: value,
 			extensions: [
-				highlightRangeField,
 				lineNumbers(),
 				highlightActiveLineGutter(),
 				highlightSpecialChars(),
@@ -320,19 +229,6 @@ export function CodeEditor({
 				EditorView.contentAttributes.of({
 					"data-testid": "code-editor",
 					spellcheck: "false",
-				}),
-				EditorView.theme({
-					".cm-jump-target-section": {
-						backgroundColor:
-							"color-mix(in srgb, var(--accent) 24%, transparent)",
-						boxShadow:
-							"inset 3px 0 0 color-mix(in srgb, var(--accent) 75%, white)",
-					},
-					".cm-jump-target-section-text": {
-						backgroundColor:
-							"color-mix(in srgb, var(--accent) 14%, transparent)",
-						borderRadius: "2px",
-					},
 				}),
 				keymap.of([
 					indentWithTab,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/constants.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/constants.ts
@@ -8,8 +8,6 @@ export const MIDNIGHT_CODE_COLORS = {
 	muted: "#636d83",
 	activeLine: "#ffffff0a",
 	selection: "#4b5668",
-	jumpTargetSection: "#61afef24",
-	jumpTargetSectionEdge: "#61afef66",
 	search: "#e5c07b33",
 	searchActive: "#e5c07b55",
 	panel: "#21252b",

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/createCodeMirrorTheme.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/createCodeMirrorTheme.ts
@@ -53,10 +53,6 @@ export function createCodeMirrorTheme(
 				{
 					backgroundColor: MIDNIGHT_CODE_COLORS.selection,
 				},
-			".cm-line.cm-jump-target-section": {
-				backgroundColor: MIDNIGHT_CODE_COLORS.jumpTargetSection,
-				boxShadow: `inset 2px 0 0 ${MIDNIGHT_CODE_COLORS.jumpTargetSectionEdge}`,
-			},
 			".cm-selectionMatch": {
 				backgroundColor: MIDNIGHT_CODE_COLORS.search,
 			},

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -730,12 +730,6 @@ export const useTabsStore = create<TabsStore>()(
 													options.line ?? existingFileViewer.initialLine,
 												initialColumn:
 													options.column ?? existingFileViewer.initialColumn,
-												initialSelectionStartLine:
-													options.selectionStartLine ??
-													existingFileViewer.initialSelectionStartLine,
-												initialSelectionEndLine:
-													options.selectionEndLine ??
-													existingFileViewer.initialSelectionEndLine,
 											},
 										},
 									},
@@ -782,8 +776,6 @@ export const useTabsStore = create<TabsStore>()(
 										oldPath: options.oldPath,
 										initialLine: options.line,
 										initialColumn: options.column,
-										initialSelectionStartLine: options.selectionStartLine,
-										initialSelectionEndLine: options.selectionEndLine,
 									},
 								},
 							},

--- a/apps/desktop/src/renderer/stores/tabs/types.ts
+++ b/apps/desktop/src/renderer/stores/tabs/types.ts
@@ -78,10 +78,6 @@ export interface AddFileViewerPaneOptions {
 	line?: number;
 	/** Column to scroll to (raw mode only) */
 	column?: number;
-	/** Start of a raw highlight range to reveal */
-	selectionStartLine?: number;
-	/** End of a raw highlight range to reveal */
-	selectionEndLine?: number;
 	/** If true, opens pinned (permanent). If false/undefined, opens in preview mode (can be replaced) */
 	isPinned?: boolean;
 	/** If true, opens in a new tab instead of splitting the current tab */

--- a/apps/desktop/src/renderer/stores/tabs/utils.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils.ts
@@ -184,10 +184,6 @@ export interface CreateFileViewerPaneOptions {
 	line?: number;
 	/** Column to scroll to (raw mode only) */
 	column?: number;
-	/** Start of a raw highlight range to reveal */
-	selectionStartLine?: number;
-	/** End of a raw highlight range to reveal */
-	selectionEndLine?: number;
 }
 
 /**
@@ -216,8 +212,6 @@ export const createFileViewerPane = (
 		oldPath: options.oldPath,
 		initialLine: options.line,
 		initialColumn: options.column,
-		initialSelectionStartLine: options.selectionStartLine,
-		initialSelectionEndLine: options.selectionEndLine,
 	};
 
 	// Use filename for display name

--- a/apps/desktop/src/shared/tabs-types.ts
+++ b/apps/desktop/src/shared/tabs-types.ts
@@ -119,9 +119,6 @@ export interface FileViewerState {
 	initialLine?: number;
 	/** Initial column to scroll to (raw mode only, transient - applied once) */
 	initialColumn?: number;
-	/** Initial raw highlight range to reveal (transient - applied once) */
-	initialSelectionStartLine?: number;
-	initialSelectionEndLine?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary
- make the file viewer diff pane text selectable and add the pane right-click context menu there
- handle diff double-click natively so raw view opens at the matching line and column for editing
- preserve selected diff text by stopping the pane focus click when the browser still has an active diff selection
- preserve updated line and column targets when reusing the same file viewer pane and cover the mapping with a focused unit test

## Verification
- bun test apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/utils/diff-location.test.ts
- bunx biome check apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/LightDiffViewer/LightDiffViewer.tsx apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/utils/diff-location.ts apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/utils/diff-location.test.ts apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/DiffViewerContextMenu/DiffViewerContextMenu.tsx apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/DiffViewerContextMenu/index.ts apps/desktop/src/renderer/stores/tabs/store.ts
- bun run typecheck --filter=@superset/desktop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Context menu added to the diff viewer with editor and pane actions.
  * Hover-to-highlight lines and double-click to jump from diff to the corresponding raw file location.
  * Location-aware view switching preserves line/column when moving between diff and raw views.
  * Text selection enabled inside diffs.

* **Tests**
  * Added unit tests validating diff-to-raw position mapping.

* **Behavior**
  * Preview pane now respects requested line/column when reusing an existing preview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->