### PR TITLE
fix(security): add HTTPS and content-type validation to Linear image proxy

### DIFF
--- a/apps/api/src/app/api/proxy/linear-image/route.ts
+++ b/apps/api/src/app/api/proxy/linear-image/route.ts
@@ -35,6 +35,11 @@ export async function GET(request: Request): Promise<Response> {
 		return new Response("Invalid URL", { status: 400 });
 	}
 
+	// Security: Enforce HTTPS protocol
+	if (parsedUrl.protocol !== "https:") {
+		return new Response("Only HTTPS URLs are allowed", { status: 400 });
+	}
+
 	if (parsedUrl.host !== LINEAR_IMAGE_HOST) {
 		return new Response(`Only ${LINEAR_IMAGE_HOST} URLs are allowed`, {
 			status: 400,
@@ -71,7 +76,15 @@ export async function GET(request: Request): Promise<Response> {
 		});
 	}
 
-	const contentType = linearResponse.headers.get("content-type") ?? "image/png";
+	// Security: Whitelist allowed image content types
+	const allowedTypes = ["image/png", "image/jpeg", "image/gif", "image/webp", "image/svg+xml"];
+	const contentType = linearResponse.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase() ?? "image/png";
+
+	if (!allowedTypes.includes(contentType)) {
+		console.error("[proxy/linear-image] Blocked non-image content type:", contentType);
+		return new Response("Unsupported content type", { status: 400 });
+	}
+
 	const imageData = await linearResponse.arrayBuffer();
 
 	return new Response(imageData, {


### PR DESCRIPTION
Fixes #2229

## Security Improvements

### 1. HTTPS Enforcement
```typescript
if (parsedUrl.protocol !== "https:") {
  return new Response("Only HTTPS URLs are allowed", { status: 400 });
}
```

### 2. Content-Type Whitelist
```typescript
const allowedTypes = ["image/png", "image/jpeg", "image/gif", "image/webp", "image/svg+xml"];
if (!allowedTypes.includes(contentType)) {
  return new Response("Unsupported content type", { status: 400 });
}
```

## Vulnerabilities Prevented
- Protocol downgrade attacks
- Content sniffing via non-image content types
- Reflected content vulnerabilities

Credit: Issue reported with suggested fix included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds HTTPS enforcement and an image content-type whitelist to the Linear image proxy to block protocol downgrade and non-image responses. This prevents serving HTML/JS via the proxy and limits output to safe image types.

- **Bug Fixes**
  - Enforce HTTPS-only URLs.
  - Whitelist image content types (png, jpeg, gif, webp, svg) and reject others.

<sup>Written for commit f55bc94aeebc5de31bae2306cb3e957f70d0c25c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced image proxy security by requiring HTTPS URLs.
  * Added validation to ensure only supported image formats are served.
  * Improved error handling with clearer responses for unsupported content types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->