### PR TITLE
fix(desktop): align terminal link underlines for CJK text

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/cell-width.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/cell-width.ts
@@ -1,5 +1,4 @@
 const COMBINING_MARK_REGEX = /\p{Mark}/u;
-const EXTENDED_PICTOGRAPHIC_REGEX = /\p{Extended_Pictographic}/u;
 
 /**
  * Mirrors xterm's cell width behavior for common cases:
@@ -16,7 +15,7 @@ function getCodePointCellWidth(char: string, codePoint: number): number {
 		return 0;
 	}
 
-	if (isFullWidthCodePoint(codePoint) || EXTENDED_PICTOGRAPHIC_REGEX.test(char)) {
+	if (isFullWidthCodePoint(codePoint)) {
 		return 2;
 	}
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/cell-width.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/cell-width.ts
@@ -1,0 +1,80 @@
+const COMBINING_MARK_REGEX = /\p{Mark}/u;
+const EXTENDED_PICTOGRAPHIC_REGEX = /\p{Extended_Pictographic}/u;
+
+/**
+ * Mirrors xterm's cell width behavior for common cases:
+ * - CJK/full-width chars occupy 2 cells
+ * - combining marks occupy 0 cells
+ * - control chars occupy 0 cells
+ */
+function getCodePointCellWidth(char: string, codePoint: number): number {
+	if (codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f)) {
+		return 0;
+	}
+
+	if (COMBINING_MARK_REGEX.test(char)) {
+		return 0;
+	}
+
+	if (isFullWidthCodePoint(codePoint) || EXTENDED_PICTOGRAPHIC_REGEX.test(char)) {
+		return 2;
+	}
+
+	return 1;
+}
+
+// Adapted from the de-facto fullwidth detection used by string-width/is-fullwidth-code-point.
+function isFullWidthCodePoint(codePoint: number): boolean {
+	return (
+		codePoint >= 0x1100 &&
+		(codePoint <= 0x115f || // Hangul Jamo
+			codePoint === 0x2329 ||
+			codePoint === 0x232a ||
+			// CJK Radicals Supplement .. Yi Radicals
+			(codePoint >= 0x2e80 && codePoint <= 0xa4cf && codePoint !== 0x303f) ||
+			// Hangul Jamo Extended-A
+			(codePoint >= 0xa960 && codePoint <= 0xa97c) ||
+			// Hangul Syllables
+			(codePoint >= 0xac00 && codePoint <= 0xd7a3) ||
+			// CJK Compatibility Ideographs
+			(codePoint >= 0xf900 && codePoint <= 0xfaff) ||
+			// Vertical forms
+			(codePoint >= 0xfe10 && codePoint <= 0xfe19) ||
+			// CJK Compatibility Forms .. Small Form Variants
+			(codePoint >= 0xfe30 && codePoint <= 0xfe6f) ||
+			// Fullwidth Forms
+			(codePoint >= 0xff00 && codePoint <= 0xff60) ||
+			(codePoint >= 0xffe0 && codePoint <= 0xffe6) ||
+			// Kana Supplement .. Enclosed Ideographic Supplement
+			(codePoint >= 0x1b000 && codePoint <= 0x1f251) ||
+			// CJK Unified Ideographs Extension B..Tertiary Ideographic Plane
+			(codePoint >= 0x20000 && codePoint <= 0x3fffd))
+	);
+}
+
+export function getCellWidthForText(text: string): number {
+	return getCellWidthUpToIndex(text, text.length);
+}
+
+export function getCellWidthUpToIndex(text: string, utf16Index: number): number {
+	if (!text || utf16Index <= 0) {
+		return 0;
+	}
+
+	const end = Math.min(utf16Index, text.length);
+	let width = 0;
+	let i = 0;
+
+	while (i < end) {
+		const codePoint = text.codePointAt(i);
+		if (codePoint === undefined) {
+			break;
+		}
+
+		const char = String.fromCodePoint(codePoint);
+		width += getCodePointCellWidth(char, codePoint);
+		i += codePoint > 0xffff ? 2 : 1;
+	}
+
+	return width;
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/file-path-link-provider.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/file-path-link-provider.test.ts
@@ -2,43 +2,13 @@ import { describe, expect, it, mock } from "bun:test";
 import type { IBufferLine, ILink, Terminal } from "@xterm/xterm";
 import { FilePathLinkProvider } from "./file-path-link-provider";
 
-function getCharCellWidth(char: string): number {
-	const codePoint = char.codePointAt(0);
-	if (codePoint === undefined) return 1;
-
-	return codePoint > 0xff ? 2 : 1;
-}
-
 function createMockLine(text: string, isWrapped = false): IBufferLine {
-	const cells = Array.from(text).flatMap((char) => {
-		const width = getCharCellWidth(char);
-		if (width === 2) {
-			return [
-				{
-					getChars: () => char,
-					getWidth: () => 2,
-				},
-				{
-					getChars: () => "",
-					getWidth: () => 0,
-				},
-			];
-		}
-
-		return [
-			{
-				getChars: () => char,
-				getWidth: () => 1,
-			},
-		];
-	});
-
 	return {
 		translateToString: () => text,
 		isWrapped,
-		length: cells.length,
-		getCell: mock((index: number) => cells[index] ?? null),
-		getCells: mock(() => cells),
+		length: text.length,
+		getCell: mock(() => null),
+		getCells: mock(() => []),
 	} as unknown as IBufferLine;
 }
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/file-path-link-provider.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/file-path-link-provider.test.ts
@@ -2,13 +2,43 @@ import { describe, expect, it, mock } from "bun:test";
 import type { IBufferLine, ILink, Terminal } from "@xterm/xterm";
 import { FilePathLinkProvider } from "./file-path-link-provider";
 
+function getCharCellWidth(char: string): number {
+	const codePoint = char.codePointAt(0);
+	if (codePoint === undefined) return 1;
+
+	return codePoint > 0xff ? 2 : 1;
+}
+
 function createMockLine(text: string, isWrapped = false): IBufferLine {
+	const cells = Array.from(text).flatMap((char) => {
+		const width = getCharCellWidth(char);
+		if (width === 2) {
+			return [
+				{
+					getChars: () => char,
+					getWidth: () => 2,
+				},
+				{
+					getChars: () => "",
+					getWidth: () => 0,
+				},
+			];
+		}
+
+		return [
+			{
+				getChars: () => char,
+				getWidth: () => 1,
+			},
+		];
+	});
+
 	return {
 		translateToString: () => text,
 		isWrapped,
-		length: text.length,
-		getCell: mock(() => null),
-		getCells: mock(() => []),
+		length: cells.length,
+		getCell: mock((index: number) => cells[index] ?? null),
+		getCells: mock(() => cells),
 	} as unknown as IBufferLine;
 }
 
@@ -105,6 +135,20 @@ describe("FilePathLinkProvider", () => {
 			expect(links[0].text).toBe("/path/file.ts:42:10");
 		});
 
+		it("should calculate path start column using terminal cell width for CJK prefixes", async () => {
+			const terminal = createMockTerminal([
+				{ text: "错误在 ./src/index.ts:12" },
+			]);
+			const onOpen = mock();
+			const provider = new FilePathLinkProvider(terminal, onOpen);
+
+			const links = await getLinks(provider, 1);
+
+			expect(links.length).toBe(1);
+			// "错误在 " => 7 terminal cells (not 4 UTF-16 chars)
+			expect(links[0].range.start.x).toBe(8);
+		});
+
 		it("should detect multiple paths on one line", async () => {
 			const terminal = createMockTerminal([
 				{ text: "Import ./src/a.ts and ./src/b.ts" },
@@ -117,6 +161,21 @@ describe("FilePathLinkProvider", () => {
 			expect(links.length).toBe(2);
 			expect(links[0].text).toBe("./src/a.ts");
 			expect(links[1].text).toBe("./src/b.ts");
+		});
+
+		it("should calculate link start column using terminal cell width for CJK prefixes", async () => {
+			const terminal = createMockTerminal([
+				{
+					text: "本地 main 改动都在 ./fix/hardened-error-handling-and-consistency 分支上。",
+				},
+			]);
+			const onOpen = mock();
+			const provider = new FilePathLinkProvider(terminal, onOpen);
+
+			const links = await getLinks(provider, 1);
+
+			expect(links.length).toBe(1);
+			expect(links[0].range.start.x).toBe(20);
 		});
 	});
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/file-path-link-provider.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/file-path-link-provider.ts
@@ -8,6 +8,7 @@ import {
 	removeLinkSuffix,
 } from "@superset/shared/terminal-link-parsing";
 import type { ILink, ILinkProvider, Terminal } from "@xterm/xterm";
+import { getCellWidthUpToIndex } from "./cell-width";
 
 /**
  * A link provider that detects file paths in terminal output using VSCode's
@@ -122,8 +123,9 @@ export class FilePathLinkProvider implements ILinkProvider {
 			const range = this.calculateLinkRange(
 				linkStart,
 				linkEnd,
-				prevLineLength,
-				lineLength,
+				prevLineText,
+				lineText,
+				nextLineText,
 				bufferLineNumber,
 				isCurrentLineWrapped,
 				nextLineIsWrapped,
@@ -160,8 +162,9 @@ export class FilePathLinkProvider implements ILinkProvider {
 				const range = this.calculateLinkRange(
 					linkStart,
 					linkEnd,
-					prevLineLength,
-					lineLength,
+					prevLineText,
+					lineText,
+					nextLineText,
 					bufferLineNumber,
 					isCurrentLineWrapped,
 					nextLineIsWrapped,
@@ -330,14 +333,15 @@ export class FilePathLinkProvider implements ILinkProvider {
 	private calculateLinkRange(
 		matchIndex: number,
 		matchEnd: number,
-		prevLineLength: number,
-		lineLength: number,
+		prevLineText: string,
+		lineText: string,
+		nextLineText: string,
 		bufferLineNumber: number,
 		isCurrentLineWrapped: boolean,
 		nextLineIsWrapped: boolean,
 	): ILink["range"] {
-		const currentLineStart = prevLineLength;
-		const currentLineEnd = prevLineLength + lineLength;
+		const currentLineStart = prevLineText.length;
+		const currentLineEnd = prevLineText.length + lineText.length;
 
 		const startsInPrevLine =
 			isCurrentLineWrapped && matchIndex < currentLineStart;
@@ -350,21 +354,22 @@ export class FilePathLinkProvider implements ILinkProvider {
 
 		if (startsInPrevLine) {
 			startY = bufferLineNumber - 1;
-			startX = matchIndex + 1;
+			startX = getCellWidthUpToIndex(prevLineText, matchIndex) + 1;
 		} else {
 			startY = bufferLineNumber;
-			startX = matchIndex - currentLineStart + 1;
+			startX =
+				getCellWidthUpToIndex(lineText, matchIndex - currentLineStart) + 1;
 		}
 
 		if (endsInNextLine) {
 			endY = bufferLineNumber + 1;
-			endX = matchEnd - currentLineEnd + 1;
+			endX = getCellWidthUpToIndex(nextLineText, matchEnd - currentLineEnd) + 1;
 		} else if (matchEnd <= currentLineStart) {
 			endY = bufferLineNumber - 1;
-			endX = matchEnd + 1;
+			endX = getCellWidthUpToIndex(prevLineText, matchEnd) + 1;
 		} else {
 			endY = bufferLineNumber;
-			endX = matchEnd - currentLineStart + 1;
+			endX = getCellWidthUpToIndex(lineText, matchEnd - currentLineStart) + 1;
 		}
 
 		return {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/multi-line-link-provider.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/multi-line-link-provider.ts
@@ -1,4 +1,8 @@
 import type { ILink, ILinkProvider, Terminal } from "@xterm/xterm";
+import {
+	getCellWidthForText,
+	getCellWidthUpToIndex,
+} from "./cell-width";
 
 export interface LinkMatch {
 	text: string;
@@ -202,8 +206,9 @@ export abstract class MultiLineLinkProvider implements ILinkProvider {
 				0,
 				Math.min(offset - line.startOffset, line.text.length),
 			);
+			const localCellWidth = getCellWidthUpToIndex(line.text, localOffset);
 			return {
-				x: line.leadingTrim + localOffset + 1,
+				x: line.leadingTrim + localCellWidth + 1,
 				y: line.lineNumber,
 			};
 		}
@@ -213,7 +218,7 @@ export abstract class MultiLineLinkProvider implements ILinkProvider {
 			return { x: 1, y: 1 };
 		}
 		return {
-			x: lastLine.leadingTrim + lastLine.text.length + 1,
+			x: lastLine.leadingTrim + getCellWidthForText(lastLine.text) + 1,
 			y: lastLine.lineNumber,
 		};
 	}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/url-link-provider.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/url-link-provider.test.ts
@@ -126,6 +126,20 @@ describe("UrlLinkProvider", () => {
 			expect(links[0].range.start.x).toBe(14);
 		});
 
+		it("should keep common symbol prefixes single-width in link column math", async () => {
+			const terminal = createMockTerminal([
+				{ text: "©®™ https://example.com/path" },
+			]);
+			const onOpen = mock();
+			const provider = new UrlLinkProvider(terminal, onOpen);
+
+			const links = await getLinks(provider, 1);
+
+			expect(links.length).toBe(1);
+			// "©®™ " => 4 cells when symbols are treated as single-width.
+			expect(links[0].range.start.x).toBe(5);
+		});
+
 		it("should detect URLs with port numbers", async () => {
 			const terminal = createMockTerminal([
 				{ text: "Server at http://localhost:3000/api" },

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/url-link-provider.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/url-link-provider.test.ts
@@ -112,6 +112,20 @@ describe("UrlLinkProvider", () => {
 			expect(links[1].text).toBe("https://b.com");
 		});
 
+		it("should calculate link start column using terminal cell width for CJK prefixes", async () => {
+			const terminal = createMockTerminal([
+				{ text: "本地 main 在 https://example.com/path" },
+			]);
+			const onOpen = mock();
+			const provider = new UrlLinkProvider(terminal, onOpen);
+
+			const links = await getLinks(provider, 1);
+
+			expect(links.length).toBe(1);
+			// "本地 main 在 " => 13 terminal cells (not 10 UTF-16 chars)
+			expect(links[0].range.start.x).toBe(14);
+		});
+
 		it("should detect URLs with port numbers", async () => {
 			const terminal = createMockTerminal([
 				{ text: "Server at http://localhost:3000/api" },


### PR DESCRIPTION
## Summary
- fix terminal link range positioning to use terminal cell width instead of UTF-16 length
- apply the same cell-width mapping to both URL and file-path link providers
- add regression tests for CJK-prefixed lines so link underlines start at the correct column

## Why
Terminal link underlines could appear shifted when a line contains wide characters (e.g. Chinese) before the link/path.

Fixes #2231

## Testing
- Added unit tests in:
  - apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/url-link-provider.test.ts
  - apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/file-path-link-provider.test.ts
- Local test run was not possible in this environment (bun is unavailable).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix terminal link underline alignment when CJK/wide characters appear before links by using terminal cell width instead of UTF-16 length. Applies to URL and file-path links, including wrapped lines, and keeps common symbols single-width to avoid regressions. Fixes #2231.

- **Bug Fixes**
  - Added a cell-width utility mirroring `@xterm/xterm` (full-width=2; combining/control=0) and keeping common symbols single-width.
  - Used cell width for range math in `FilePathLinkProvider` and multi-line links, handling prev/current/next lines and wraps.
  - Added tests for CJK prefixes and symbol prefixes in URL and file-path links.

<sup>Written for commit 49b37e12bba7520bb744c2c13e7f42cab5fd3003. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal link detection and positioning to account for variable cell widths (CJK/full-width characters and combining marks), fixing inaccurate link boundaries and placement in wrapped lines and file-path links.

* **Tests**
  * Added tests verifying link start/end calculations with wide-character prefixes and symbol-prefix edge cases to ensure correct positioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->