### PR TITLE
feat(desktop): add Qoder CLI agent integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Superset works with any CLI-based coding agent, including:
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | Fully supported |
 | [GitHub Copilot](https://github.com/features/copilot) | Fully supported |
 | [OpenCode](https://github.com/opencode-ai/opencode) | Fully supported |
+| [Qoder CLI](https://qoder.com/cli) | Fully supported |
 | Any CLI agent | Will work |
 
 If it runs in a terminal, it runs on Superset

--- a/apps/desktop/docs/EXTERNAL_FILES.md
+++ b/apps/desktop/docs/EXTERNAL_FILES.md
@@ -21,6 +21,7 @@ This separation prevents multiple instances from interfering with each other.
 | `codex` | Wrapper for Codex CLI that injects notification hooks |
 | `droid` | Wrapper for Factory Droid CLI that preserves Superset hook integration |
 | `opencode` | Wrapper for OpenCode CLI that sets `OPENCODE_CONFIG_DIR` |
+| `qodercli` | Wrapper for Qoder CLI that preserves Superset hook integration |
 
 These wrappers are added to `PATH` via shell integration, allowing them to intercept
 agent commands and inject Superset-specific configuration.
@@ -41,6 +42,7 @@ its hook entries into these files while preserving user-defined entries:
 | File | Purpose |
 |------|---------|
 | `~/.factory/settings.json` | Factory Droid hook registration (`UserPromptSubmit`, `Notification`, `PostToolUse`, `Stop`) |
+| `~/.qoder/settings.json` | Qoder CLI hook registration (`Notification`) |
 
 ### `zsh/` and `bash/` - Shell Integration
 

--- a/apps/desktop/docs/EXTERNAL_FILES.md
+++ b/apps/desktop/docs/EXTERNAL_FILES.md
@@ -18,8 +18,11 @@ This separation prevents multiple instances from interfering with each other.
 | File | Purpose |
 |------|---------|
 | `claude` | Wrapper for Claude Code CLI that injects notification hooks |
+| `copilot` | Wrapper for GitHub Copilot CLI that preserves Superset hook integration with repo-local hook config |
 | `codex` | Wrapper for Codex CLI that injects notification hooks |
 | `droid` | Wrapper for Factory Droid CLI that preserves Superset hook integration |
+| `gemini` | Wrapper for Gemini CLI that injects notification hooks through Gemini settings |
+| `mastracode` | Wrapper for Mastra CLI that preserves Superset hook integration via global `~/.mastracode/hooks.json` |
 | `opencode` | Wrapper for OpenCode CLI that sets `OPENCODE_CONFIG_DIR` |
 | `qodercli` | Wrapper for Qoder CLI that preserves Superset hook integration |
 

--- a/apps/desktop/src/lib/trpc/routers/settings/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/index.ts
@@ -95,6 +95,7 @@ const DEFAULT_PRESET_AGENTS = [
 	"copilot",
 	"opencode",
 	"gemini",
+	"qodercli",
 ] as const;
 
 const DEFAULT_PRESETS: Omit<TerminalPreset, "id">[] = DEFAULT_PRESET_AGENTS.map(

--- a/apps/desktop/src/lib/trpc/routers/settings/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/index.ts
@@ -11,6 +11,7 @@ import {
 import {
 	AGENT_PRESET_COMMANDS,
 	AGENT_PRESET_DESCRIPTIONS,
+	defaultPresetAgents,
 } from "@superset/shared/agent-command";
 import { TRPCError } from "@trpc/server";
 import { app } from "electron";
@@ -89,16 +90,7 @@ function saveTerminalPresets(
 		.run();
 }
 
-const DEFAULT_PRESET_AGENTS = [
-	"claude",
-	"codex",
-	"copilot",
-	"opencode",
-	"gemini",
-	"qodercli",
-] as const;
-
-const DEFAULT_PRESETS: Omit<TerminalPreset, "id">[] = DEFAULT_PRESET_AGENTS.map(
+const DEFAULT_PRESETS: Omit<TerminalPreset, "id">[] = defaultPresetAgents.map(
 	(name) => ({
 		name,
 		description: AGENT_PRESET_DESCRIPTIONS[name],

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-common.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-common.ts
@@ -38,10 +38,10 @@ export function writeFileIfChanged(
 }
 
 export function isSupersetManagedHookCommand(
-	command: string | undefined,
+	command: unknown,
 	scriptName: string,
 ): boolean {
-	if (!command) return false;
+	if (typeof command !== "string") return false;
 	const normalized = command.replaceAll("\\", "/");
 	if (!normalized.includes(`/hooks/${scriptName}`)) return false;
 	return SUPERSET_MANAGED_HOOK_PATH_PATTERN.test(normalized);

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-common.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-common.ts
@@ -11,6 +11,7 @@ export const SUPERSET_MANAGED_BINARIES = [
 	"gemini",
 	"copilot",
 	"mastracode",
+	"qodercli",
 ] as const;
 
 const SUPERSET_MANAGED_HOOK_PATH_PATTERN = /\/\.superset(?:-[^/'"\s\\]+)?\//;

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-qoder.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-qoder.ts
@@ -1,0 +1,152 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+	buildWrapperScript,
+	createWrapper,
+	isSupersetManagedHookCommand,
+	writeFileIfChanged,
+} from "./agent-wrappers-common";
+import { getNotifyScriptPath, NOTIFY_SCRIPT_NAME } from "./notify-hook";
+
+interface QoderHookConfig {
+	type: "command";
+	command: string;
+	[key: string]: unknown;
+}
+
+interface QoderHookDefinition {
+	hooks?: QoderHookConfig[];
+	[key: string]: unknown;
+}
+
+interface QoderSettingsJson {
+	hooks?: Record<string, QoderHookDefinition[]>;
+	[key: string]: unknown;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isManagedHookCommand(
+	command: string | undefined,
+	notifyScriptPath: string,
+): boolean {
+	return (
+		command?.includes(notifyScriptPath) ||
+		isSupersetManagedHookCommand(command, NOTIFY_SCRIPT_NAME)
+	);
+}
+
+function readExistingQoderSettings(
+	globalPath: string,
+): QoderSettingsJson | null {
+	if (!fs.existsSync(globalPath)) {
+		return {};
+	}
+
+	try {
+		const parsed = JSON.parse(fs.readFileSync(globalPath, "utf-8"));
+		if (!isPlainObject(parsed)) {
+			console.warn(
+				"[agent-setup] Expected ~/.qoder/settings.json to contain a JSON object; skipping Qoder hook merge",
+			);
+			return null;
+		}
+		return parsed;
+	} catch (error) {
+		console.warn(
+			"[agent-setup] Could not parse existing ~/.qoder/settings.json; skipping Qoder hook merge:",
+			error,
+		);
+		return null;
+	}
+}
+
+function removeManagedHooksFromDefinition(
+	definition: QoderHookDefinition,
+	notifyScriptPath: string,
+): QoderHookDefinition | null {
+	if (!Array.isArray(definition.hooks)) {
+		return definition;
+	}
+
+	const filteredHooks = definition.hooks.filter(
+		(hook) => !isManagedHookCommand(hook.command, notifyScriptPath),
+	);
+
+	if (filteredHooks.length === definition.hooks.length) {
+		return definition;
+	}
+
+	if (filteredHooks.length === 0) {
+		return null;
+	}
+
+	return {
+		...definition,
+		hooks: filteredHooks,
+	};
+}
+
+export function getQoderSettingsJsonPath(): string {
+	return path.join(os.homedir(), ".qoder", "settings.json");
+}
+
+export function createQoderWrapper(): void {
+	const script = buildWrapperScript("qodercli", `exec "$REAL_BIN" "$@"`);
+	createWrapper("qodercli", script);
+}
+
+/**
+ * Reads existing ~/.qoder/settings.json, merges our Notification hook
+ * definition (identified by notify script path), and preserves any user-defined
+ * hooks.
+ *
+ * Qoder CLI currently supports Notification hooks only:
+ *   { hooks: { Notification: [{ hooks: [{ type, command }] }] } }
+ */
+export function getQoderSettingsJsonContent(
+	notifyScriptPath: string,
+): string | null {
+	const globalPath = getQoderSettingsJsonPath();
+	const existing = readExistingQoderSettings(globalPath);
+	if (!existing) return null;
+
+	if (!existing.hooks || typeof existing.hooks !== "object") {
+		existing.hooks = {};
+	}
+
+	const current = existing.hooks.Notification;
+	const definition: QoderHookDefinition = {
+		hooks: [{ type: "command", command: notifyScriptPath }],
+	};
+
+	if (Array.isArray(current)) {
+		const filtered = current.flatMap((entry: QoderHookDefinition) => {
+			const cleaned = removeManagedHooksFromDefinition(entry, notifyScriptPath);
+			return cleaned ? [cleaned] : [];
+		});
+		filtered.push(definition);
+		existing.hooks.Notification = filtered;
+	} else {
+		existing.hooks.Notification = [definition];
+	}
+
+	return JSON.stringify(existing, null, 2);
+}
+
+export function createQoderSettingsJson(): void {
+	const notifyScriptPath = getNotifyScriptPath();
+	const globalPath = getQoderSettingsJsonPath();
+	const content = getQoderSettingsJsonContent(notifyScriptPath);
+	if (content === null) return;
+
+	const dir = path.dirname(globalPath);
+	fs.mkdirSync(dir, { recursive: true });
+	const changed = writeFileIfChanged(globalPath, content, 0o644);
+	console.log(
+		`[agent-setup] ${changed ? "Updated" : "Verified"} Qoder settings.json`,
+	);
+}

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-qoder.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-qoder.ts
@@ -21,7 +21,7 @@ interface QoderHookDefinition {
 }
 
 interface QoderSettingsJson {
-	hooks?: Record<string, QoderHookDefinition[]>;
+	hooks?: Record<string, unknown>;
 	[key: string]: unknown;
 }
 
@@ -72,11 +72,14 @@ function removeManagedHooksFromDefinition(
 		return definition;
 	}
 
-	const filteredHooks = definition.hooks.filter(
+	const currentHooks = definition.hooks.filter(
+		(hook): hook is QoderHookConfig => isPlainObject(hook),
+	);
+	const filteredHooks = currentHooks.filter(
 		(hook) => !isManagedHookCommand(hook.command, notifyScriptPath),
 	);
 
-	if (filteredHooks.length === definition.hooks.length) {
+	if (filteredHooks.length === currentHooks.length) {
 		return definition;
 	}
 
@@ -114,7 +117,7 @@ export function getQoderSettingsJsonContent(
 	const existing = readExistingQoderSettings(globalPath);
 	if (!existing) return null;
 
-	if (!existing.hooks || typeof existing.hooks !== "object") {
+	if (!isPlainObject(existing.hooks)) {
 		existing.hooks = {};
 	}
 
@@ -123,16 +126,19 @@ export function getQoderSettingsJsonContent(
 		hooks: [{ type: "command", command: notifyScriptPath }],
 	};
 
-	if (Array.isArray(current)) {
-		const filtered = current.flatMap((entry: QoderHookDefinition) => {
-			const cleaned = removeManagedHooksFromDefinition(entry, notifyScriptPath);
-			return cleaned ? [cleaned] : [];
-		});
-		filtered.push(definition);
-		existing.hooks.Notification = filtered;
-	} else {
-		existing.hooks.Notification = [definition];
-	}
+	const filtered = Array.isArray(current)
+		? current
+				.filter((entry): entry is QoderHookDefinition => isPlainObject(entry))
+				.flatMap((entry) => {
+					const cleaned = removeManagedHooksFromDefinition(
+						entry,
+						notifyScriptPath,
+					);
+					return cleaned ? [cleaned] : [];
+				})
+		: [];
+
+	existing.hooks.Notification = [...filtered, definition];
 
 	return JSON.stringify(existing, null, 2);
 }
@@ -143,10 +149,17 @@ export function createQoderSettingsJson(): void {
 	const content = getQoderSettingsJsonContent(notifyScriptPath);
 	if (content === null) return;
 
-	const dir = path.dirname(globalPath);
-	fs.mkdirSync(dir, { recursive: true });
-	const changed = writeFileIfChanged(globalPath, content, 0o644);
-	console.log(
-		`[agent-setup] ${changed ? "Updated" : "Verified"} Qoder settings.json`,
-	);
+	try {
+		const dir = path.dirname(globalPath);
+		fs.mkdirSync(dir, { recursive: true });
+		const changed = writeFileIfChanged(globalPath, content, 0o644);
+		console.log(
+			`[agent-setup] ${changed ? "Updated" : "Verified"} Qoder settings.json`,
+		);
+	} catch (error) {
+		console.warn(
+			"[agent-setup] Failed to write Qoder settings.json; continuing setup:",
+			error,
+		);
+	}
 }

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-qoder.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-qoder.ts
@@ -30,11 +30,15 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 }
 
 function isManagedHookCommand(
-	command: string | undefined,
+	command: unknown,
 	notifyScriptPath: string,
 ): boolean {
+	if (typeof command !== "string") {
+		return false;
+	}
+
 	return (
-		command?.includes(notifyScriptPath) ||
+		command.includes(notifyScriptPath) ||
 		isSupersetManagedHookCommand(command, NOTIFY_SCRIPT_NAME)
 	);
 }

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -63,11 +63,13 @@ const {
 	createDroidSettingsJson,
 	createDroidWrapper,
 	createMastraWrapper,
+	createQoderWrapper,
 	getCursorHooksJsonContent,
 	getCopilotHookScriptPath,
 	getDroidSettingsJsonContent,
 	getGeminiSettingsJsonContent,
 	getMastraHooksJsonContent,
+	getQoderSettingsJsonContent,
 } = await import("./agent-wrappers");
 const { reconcileManagedEntries } = await import("./agent-wrappers-common");
 
@@ -221,6 +223,17 @@ describe("agent-wrappers copilot", () => {
 
 		expect(wrapper).toContain("# Superset wrapper for droid");
 		expect(wrapper).toContain('REAL_BIN="$(find_real_binary "droid")"');
+		expect(wrapper).toContain('exec "$REAL_BIN" "$@"');
+	});
+
+	it("creates qodercli wrapper passthrough", () => {
+		createQoderWrapper();
+
+		const wrapperPath = path.join(TEST_BIN_DIR, "qodercli");
+		const wrapper = readFileSync(wrapperPath, "utf-8");
+
+		expect(wrapper).toContain("# Superset wrapper for qodercli");
+		expect(wrapper).toContain('REAL_BIN="$(find_real_binary "qodercli")"');
 		expect(wrapper).toContain('exec "$REAL_BIN" "$@"');
 	});
 
@@ -542,6 +555,74 @@ describe("agent-wrappers copilot", () => {
 		expect(parsed.hooks.PostToolUse.some((def) => def.matcher === "*")).toBe(
 			true,
 		);
+		expect(JSON.parse(content2)).toEqual(JSON.parse(content));
+	});
+
+	it("replaces stale Qoder hook commands from old superset paths", () => {
+		const qoderSettingsPath = path.join(mockedHomeDir, ".qoder", "settings.json");
+		const staleHookPath = "/tmp/.superset-old/hooks/notify.sh";
+		const currentHookPath = "/tmp/.superset-new/hooks/notify.sh";
+
+		mkdirSync(path.dirname(qoderSettingsPath), { recursive: true });
+		writeFileSync(
+			qoderSettingsPath,
+			JSON.stringify(
+				{
+					hooks: {
+						Notification: [
+							{
+								hooks: [
+									{ type: "command", command: staleHookPath },
+									{ type: "command", command: "/opt/custom-notify.sh" },
+								],
+							},
+						],
+					},
+				},
+				null,
+				2,
+			),
+		);
+
+		const content = getQoderSettingsJsonContent(currentHookPath);
+		expect(content).not.toBeNull();
+		if (content === null) {
+			throw new Error("Expected Qoder settings content for valid JSON object");
+		}
+		writeFileSync(qoderSettingsPath, content);
+
+		const content2 = getQoderSettingsJsonContent(currentHookPath);
+		expect(content2).not.toBeNull();
+		if (content2 === null) {
+			throw new Error("Expected Qoder settings content after rewrite");
+		}
+
+		const parsed = JSON.parse(content) as {
+			hooks: Record<
+				string,
+				Array<{
+					hooks: Array<{ type: string; command: string }>;
+				}>
+			>;
+		};
+
+		const notificationHooks = parsed.hooks.Notification;
+		expect(Array.isArray(notificationHooks)).toBe(true);
+		expect(
+			notificationHooks.some((entry) =>
+				entry.hooks.some((hook) => hook.command === currentHookPath),
+			),
+		).toBe(true);
+		expect(
+			notificationHooks.some((entry) =>
+				entry.hooks.some((hook) => hook.command.includes(staleHookPath)),
+			),
+		).toBe(false);
+		expect(
+			notificationHooks.some((entry) =>
+				entry.hooks.some((hook) => hook.command === "/opt/custom-notify.sh"),
+			),
+		).toBe(true);
 		expect(JSON.parse(content2)).toEqual(JSON.parse(content));
 	});
 

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -712,6 +712,38 @@ describe("agent-wrappers copilot", () => {
 		]);
 	});
 
+	it("ignores truthy non-string Qoder hook commands without throwing", () => {
+		const qoderSettingsPath = path.join(
+			mockedHomeDir,
+			".qoder",
+			"settings.json",
+		);
+		const currentHookPath = "/tmp/.superset-new/hooks/notify.sh";
+
+		mkdirSync(path.dirname(qoderSettingsPath), { recursive: true });
+		writeFileSync(
+			qoderSettingsPath,
+			JSON.stringify(
+				{
+					hooks: {
+						Notification: [
+							{
+								hooks: [
+									{ type: "command", command: 42 },
+									{ type: "command", command: "/opt/custom-notify.sh" },
+								],
+							},
+						],
+					},
+				},
+				null,
+				2,
+			),
+		);
+
+		expect(() => getQoderSettingsJsonContent(currentHookPath)).not.toThrow();
+	});
+
 	it("continues setup when Qoder settings.json cannot be written", () => {
 		mkdirSync(mockedHomeDir, { recursive: true });
 		writeFileSync(path.join(mockedHomeDir, ".qoder"), "blocked");

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -631,6 +631,33 @@ describe("agent-wrappers copilot", () => {
 		expect(JSON.parse(content2)).toEqual(JSON.parse(content));
 	});
 
+	it("initializes Qoder settings for first-time users", () => {
+		const qoderSettingsPath = path.join(
+			mockedHomeDir,
+			".qoder",
+			"settings.json",
+		);
+		const currentHookPath = path.join(TEST_HOOKS_DIR, "notify.sh");
+
+		expect(getQoderSettingsJsonContent(currentHookPath)).not.toBeNull();
+		expect(() => createQoderSettingsJson()).not.toThrow();
+		expect(readFileSync(qoderSettingsPath, "utf-8")).toBe(
+			JSON.stringify(
+				{
+					hooks: {
+						Notification: [
+							{
+								hooks: [{ type: "command", command: currentHookPath }],
+							},
+						],
+					},
+				},
+				null,
+				2,
+			),
+		);
+	});
+
 	it("sanitizes malformed Qoder Notification hooks before merging", () => {
 		const qoderSettingsPath = path.join(
 			mockedHomeDir,

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -63,6 +63,7 @@ const {
 	createDroidSettingsJson,
 	createDroidWrapper,
 	createMastraWrapper,
+	createQoderSettingsJson,
 	createQoderWrapper,
 	getCursorHooksJsonContent,
 	getCopilotHookScriptPath,
@@ -559,7 +560,11 @@ describe("agent-wrappers copilot", () => {
 	});
 
 	it("replaces stale Qoder hook commands from old superset paths", () => {
-		const qoderSettingsPath = path.join(mockedHomeDir, ".qoder", "settings.json");
+		const qoderSettingsPath = path.join(
+			mockedHomeDir,
+			".qoder",
+			"settings.json",
+		);
 		const staleHookPath = "/tmp/.superset-old/hooks/notify.sh";
 		const currentHookPath = "/tmp/.superset-new/hooks/notify.sh";
 
@@ -624,6 +629,67 @@ describe("agent-wrappers copilot", () => {
 			),
 		).toBe(true);
 		expect(JSON.parse(content2)).toEqual(JSON.parse(content));
+	});
+
+	it("sanitizes malformed Qoder Notification hooks before merging", () => {
+		const qoderSettingsPath = path.join(
+			mockedHomeDir,
+			".qoder",
+			"settings.json",
+		);
+		const staleHookPath = "/tmp/.superset-old/hooks/notify.sh";
+		const currentHookPath = "/tmp/.superset-new/hooks/notify.sh";
+
+		mkdirSync(path.dirname(qoderSettingsPath), { recursive: true });
+		writeFileSync(
+			qoderSettingsPath,
+			JSON.stringify(
+				{
+					hooks: {
+						Notification: [
+							null,
+							"invalid-entry",
+							{
+								hooks: [
+									null,
+									{ type: "command", command: staleHookPath },
+									{ type: "command", command: "/opt/custom-notify.sh" },
+								],
+							},
+						],
+					},
+				},
+				null,
+				2,
+			),
+		);
+
+		const content = getQoderSettingsJsonContent(currentHookPath);
+		expect(content).not.toBeNull();
+		if (content === null) {
+			throw new Error("Expected Qoder settings content for malformed JSON");
+		}
+
+		const parsed = JSON.parse(content) as {
+			hooks: { Notification: Array<{ hooks?: Array<{ command?: string }> }> };
+		};
+		expect(parsed.hooks.Notification).toHaveLength(2);
+		expect(
+			parsed.hooks.Notification.every((entry) => typeof entry === "object"),
+		).toBe(true);
+		expect(parsed.hooks.Notification[0]?.hooks).toEqual([
+			{ type: "command", command: "/opt/custom-notify.sh" },
+		]);
+		expect(parsed.hooks.Notification[1]?.hooks).toEqual([
+			{ type: "command", command: currentHookPath },
+		]);
+	});
+
+	it("continues setup when Qoder settings.json cannot be written", () => {
+		mkdirSync(mockedHomeDir, { recursive: true });
+		writeFileSync(path.join(mockedHomeDir, ".qoder"), "blocked");
+
+		expect(() => createQoderSettingsJson()).not.toThrow();
 	});
 
 	it("skips Droid settings writes when the existing JSON is invalid", () => {

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.ts
@@ -63,3 +63,9 @@ export {
 	getMastraGlobalHooksJsonPath,
 	getMastraHooksJsonContent,
 } from "./agent-wrappers-mastra";
+export {
+	createQoderSettingsJson,
+	createQoderWrapper,
+	getQoderSettingsJsonContent,
+	getQoderSettingsJsonPath,
+} from "./agent-wrappers-qoder";

--- a/apps/desktop/src/main/lib/agent-setup/index.ts
+++ b/apps/desktop/src/main/lib/agent-setup/index.ts
@@ -17,6 +17,8 @@ import {
 	createMastraWrapper,
 	createOpenCodePlugin,
 	createOpenCodeWrapper,
+	createQoderSettingsJson,
+	createQoderWrapper,
 } from "./agent-wrappers";
 import { createNotifyScript } from "./notify-hook";
 import {
@@ -60,6 +62,8 @@ export function setupAgentHooks(): void {
 	createGeminiSettingsJson();
 	createMastraWrapper();
 	createMastraHooksJson();
+	createQoderWrapper();
+	createQoderSettingsJson();
 	createCopilotHookScript();
 	createCopilotWrapper();
 

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.test.ts
@@ -62,4 +62,10 @@ describe("settings search - font settings", () => {
 		expect(editorFont?.section).toBe("appearance");
 		expect(terminalFont?.section).toBe("appearance");
 	});
+
+	it('searching "qoder cli" returns TERMINAL_QUICK_ADD', () => {
+		const results = searchSettings("qoder cli");
+		const ids = getIds(results);
+		expect(ids).toContain(SETTING_ITEM_ID.TERMINAL_QUICK_ADD);
+	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -515,6 +515,7 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"cursor",
 			"opencode",
 			"qoder",
+			"qoder cli",
 			"qodercli",
 			"ai",
 			"assistant",

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -514,6 +514,8 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"gemini",
 			"cursor",
 			"opencode",
+			"qoder",
+			"qodercli",
 			"ai",
 			"assistant",
 		],

--- a/apps/docs/content/docs/agent-integration.mdx
+++ b/apps/docs/content/docs/agent-integration.mdx
@@ -16,6 +16,7 @@ Run AI coding agents in isolated workspaces. Each agent works independently with
 - **OpenCode** - Open-source alternative
 - **Gemini CLI** - Google's CLI agent
 - **Cursor Agent** - Cursor AI agent
+- **Qoder CLI** - Qoder's coding agent
 
 ## Chat
 

--- a/apps/docs/content/docs/terminal-presets.mdx
+++ b/apps/docs/content/docs/terminal-presets.mdx
@@ -48,6 +48,7 @@ Pre-configured presets for popular AI agents:
 - **gemini** - `gemini --yolo`
 - **cursor-agent** - Cursor AI agent
 - **opencode** - Open-source AI coding agent
+- **qodercli** - `qodercli --yolo`
 
 ## Preset Bar
 

--- a/packages/mcp/src/tools/devices/start-agent-session/start-agent-session.ts
+++ b/packages/mcp/src/tools/devices/start-agent-session/start-agent-session.ts
@@ -65,7 +65,7 @@ const inputSchemaShape = {
 		.enum(STARTABLE_AGENT_TYPES)
 		.optional()
 		.describe(
-			'AI agent to use: "claude", "codex", "gemini", "opencode", "copilot", "cursor-agent", or "superset-chat". Defaults to "claude".',
+			'AI agent to use: "claude", "codex", "gemini", "opencode", "copilot", "cursor-agent", "qodercli", or "superset-chat". Defaults to "claude".',
 		),
 };
 

--- a/packages/shared/src/agent-command.test.ts
+++ b/packages/shared/src/agent-command.test.ts
@@ -26,4 +26,17 @@ describe("buildAgentPromptCommand", () => {
 			"claude --dangerously-skip-permissions \"$(cat <<'SUPERSET_PROMPT_abcdefgh'",
 		);
 	});
+
+	it("uses non-interactive print mode for qodercli prompts", () => {
+		const command = buildAgentPromptCommand({
+			prompt: "fix the failing tests",
+			randomId: "qoder-1234",
+			agent: "qodercli",
+		});
+
+		expect(command).toStartWith(
+			"qodercli --yolo -p \"$(cat <<'SUPERSET_PROMPT_qoder1234'",
+		);
+		expect(command).toContain("fix the failing tests");
+	});
 });

--- a/packages/shared/src/agent-command.ts
+++ b/packages/shared/src/agent-command.ts
@@ -42,6 +42,15 @@ export const AGENT_PRESET_DESCRIPTIONS: Record<AgentType, string> = {
 	qodercli: "Danger mode: All permissions auto-approved",
 };
 
+export const defaultPresetAgents = [
+	"claude",
+	"codex",
+	"copilot",
+	"opencode",
+	"gemini",
+	"qodercli",
+] as const satisfies readonly AgentType[];
+
 export interface TaskInput {
 	id: string;
 	slug: string;

--- a/packages/shared/src/agent-command.ts
+++ b/packages/shared/src/agent-command.ts
@@ -5,6 +5,7 @@ export const AGENT_TYPES = [
 	"opencode",
 	"copilot",
 	"cursor-agent",
+	"qodercli",
 ] as const;
 
 export type AgentType = (typeof AGENT_TYPES)[number];
@@ -16,6 +17,7 @@ export const AGENT_LABELS: Record<AgentType, string> = {
 	opencode: "OpenCode",
 	copilot: "Copilot",
 	"cursor-agent": "Cursor Agent",
+	qodercli: "Qoder CLI",
 };
 
 export const AGENT_PRESET_COMMANDS: Record<AgentType, string[]> = {
@@ -27,6 +29,7 @@ export const AGENT_PRESET_COMMANDS: Record<AgentType, string[]> = {
 	opencode: ["opencode"],
 	copilot: ["copilot --allow-all"],
 	"cursor-agent": ["cursor-agent"],
+	qodercli: ["qodercli --yolo"],
 };
 
 export const AGENT_PRESET_DESCRIPTIONS: Record<AgentType, string> = {
@@ -36,6 +39,7 @@ export const AGENT_PRESET_DESCRIPTIONS: Record<AgentType, string> = {
 	opencode: "OpenCode: Open-source AI coding agent",
 	copilot: "Danger mode: All permissions auto-approved",
 	"cursor-agent": "Cursor AI agent for terminal-based coding assistance",
+	qodercli: "Danger mode: All permissions auto-approved",
 };
 
 export interface TaskInput {
@@ -115,6 +119,8 @@ const AGENT_COMMANDS: Record<
 		buildHeredoc(prompt, delimiter, "copilot -i", "--yolo"),
 	"cursor-agent": (prompt, delimiter) =>
 		buildHeredoc(prompt, delimiter, "cursor-agent --yolo"),
+	qodercli: (prompt, delimiter) =>
+		buildHeredoc(prompt, delimiter, "qodercli --yolo -p"),
 };
 
 export function buildAgentPromptCommand({


### PR DESCRIPTION
## Description

Adds first-class Qoder CLI support across Superset's existing agent launch pipeline.

This wires `qodercli` into shared agent definitions, terminal presets, MCP agent session startup, and desktop agent setup. It also adds a dedicated desktop wrapper plus `~/.qoder/settings.json` hook merge logic so Superset notifications keep working without clobbering user-defined Qoder hooks.

Docs and external file references were updated to reflect the new supported agent.

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

Ran:

- `~/.bun/bin/bun test packages/shared/src/agent-command.test.ts packages/shared/src/agent-launch.test.ts`
- `~/.bun/bin/bun test apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts`

Verified:

- `qodercli` is available as a startable agent type and preset template
- autonomous task prompt generation uses `qodercli --yolo -p`
- desktop wrapper creation works for `qodercli`
- stale Superset-managed Qoder hooks are replaced in `~/.qoder/settings.json` while user hooks are preserved

## Screenshots (if applicable)

N/A

## Additional Notes

Qoder hook integration is scoped to the currently documented `Notification` hook support in `~/.qoder/settings.json`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first-class `qodercli` integration across desktop, shared presets, and MCP, with a desktop wrapper and safe Notification hook merge. Also hardens Qoder hook parsing and adds a “qoder cli” search alias.

- **New Features**
  - Added `qodercli` to agent types, labels, shared `defaultPresetAgents`/presets (`qodercli --yolo`), and prompt commands (`qodercli --yolo -p`); MCP session start now accepts `qodercli`.
  - Desktop wrapper for `qodercli` and automatic `~/.qoder/settings.json` Notification hook merge that preserves user hooks; created on startup; settings search includes `qoder`, `qodercli`, and "qoder cli"; docs updated.

- **Bug Fixes**
  - More robust Qoder hook handling: sanitizes malformed entries, ignores non-string `command` values, skips invalid JSON, and continues setup if writes fail; `qodercli` marked as a Superset-managed binary so stale hook paths are cleaned up.
  - Added tests for first-run setup, stale hook replacement, wrapper passthrough, and malformed hook entries.

<sup>Written for commit 47167176cf47428cc43aeb5e8d7d00bece5b2617. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Qoder CLI added as a supported agent with a Quick-Add template (qodercli --yolo)
  * Installer now creates a Qoder CLI wrapper and initializes per-user Qoder settings for Notification hooks
  * Terminal presets and quick-add search updated to include Qoder CLI

* **Documentation**
  * README and docs updated to list Qoder CLI as a supported agent

* **Tests**
  * New tests covering Qoder CLI commands and settings handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->