### PR TITLE
fix(desktop): apply shell env to GitHub status checks

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/shell-env.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/shell-env.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { applyShellEnvToProcess, getProcessEnvWithShellEnv } from "./shell-env";
+
+describe("shell env merging", () => {
+	test("getProcessEnvWithShellEnv fills in missing shell variables", async () => {
+		const env = await getProcessEnvWithShellEnv(
+			{
+				PATH: "/usr/bin:/bin",
+				NODE_ENV: "development",
+			},
+			{
+				PATH: "/opt/homebrew/bin:/usr/bin:/bin",
+				GITHUB_TOKEN: "ghp_test",
+				GH_TOKEN: "ghp_alt",
+			},
+		);
+
+		expect(env.PATH).toBe("/usr/bin:/bin");
+		expect(env.NODE_ENV).toBe("development");
+		expect(env.GITHUB_TOKEN).toBe("ghp_test");
+		expect(env.GH_TOKEN).toBe("ghp_alt");
+	});
+
+	test("applyShellEnvToProcess preserves existing values", async () => {
+		const targetEnv: NodeJS.ProcessEnv = {
+			NODE_ENV: "production",
+			GITHUB_TOKEN: "existing-token",
+		};
+
+		await applyShellEnvToProcess(targetEnv, {
+			NODE_ENV: "development",
+			GITHUB_TOKEN: "shell-token",
+			GH_TOKEN: "shell-gh-token",
+		});
+
+		expect(targetEnv.NODE_ENV).toBe("production");
+		expect(targetEnv.GITHUB_TOKEN).toBe("existing-token");
+		expect(targetEnv.GH_TOKEN).toBe("shell-gh-token");
+	});
+
+	test("applyShellEnvToProcess ignores empty shell env input", async () => {
+		const targetEnv: NodeJS.ProcessEnv = {};
+
+		await applyShellEnvToProcess(targetEnv, {});
+
+		expect(targetEnv).toEqual({});
+	});
+});

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/shell-env.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/shell-env.ts
@@ -101,6 +101,40 @@ export function clearShellEnvCache(): void {
 	pathFixSucceeded = false;
 }
 
+function copyStringEnv(
+	baseEnv: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+	const env: Record<string, string> = {};
+
+	for (const [key, value] of Object.entries(baseEnv)) {
+		if (typeof value === "string") {
+			env[key] = value;
+		}
+	}
+
+	return env;
+}
+
+/**
+ * Returns process env merged with missing variables from the user's shell.
+ * Existing values always win so Electron/app-managed vars remain intact.
+ */
+export async function getProcessEnvWithShellEnv(
+	baseEnv: NodeJS.ProcessEnv = process.env,
+	shellEnvResult?: Record<string, string>,
+): Promise<Record<string, string>> {
+	const env = copyStringEnv(baseEnv);
+	const resolvedShellEnv = shellEnvResult ?? (await getShellEnvironment());
+
+	for (const [key, value] of Object.entries(resolvedShellEnv)) {
+		if (!(key in env)) {
+			env[key] = value;
+		}
+	}
+
+	return env;
+}
+
 /**
  * Returns process env merged with login-shell PATH.
  * Use this for child processes that should resolve binaries exactly
@@ -110,13 +144,7 @@ export async function getProcessEnvWithShellPath(
 	baseEnv: NodeJS.ProcessEnv = process.env,
 ): Promise<Record<string, string>> {
 	const shellEnvResult = await getShellEnvironment();
-	const env: Record<string, string> = {};
-
-	for (const [key, value] of Object.entries(baseEnv)) {
-		if (typeof value === "string") {
-			env[key] = value;
-		}
-	}
+	const env = await getProcessEnvWithShellEnv(baseEnv, shellEnvResult);
 
 	const shellPath = shellEnvResult.PATH || shellEnvResult.Path;
 	if (!shellPath) {
@@ -146,8 +174,16 @@ export async function execWithShellEnv(
 	args: string[],
 	options?: Omit<ExecFileOptionsWithStringEncoding, "encoding">,
 ): Promise<{ stdout: string; stderr: string }> {
+	const baseEnv = options?.env
+		? { ...process.env, ...options.env }
+		: process.env;
+
 	try {
-		return await execFileAsync(cmd, args, { ...options, encoding: "utf8" });
+		return await execFileAsync(cmd, args, {
+			...options,
+			encoding: "utf8",
+			env: await getProcessEnvWithShellEnv(baseEnv),
+		});
 	} catch (error) {
 		// Only retry on ENOENT (command not found), only on macOS
 		// Skip if we've already successfully fixed PATH, or if a fix attempt is in progress
@@ -167,11 +203,15 @@ export async function execWithShellEnv(
 
 		try {
 			const shellEnvResult = await getShellEnvironment();
+			const mergedShellEnv = await getProcessEnvWithShellEnv(
+				baseEnv,
+				shellEnvResult,
+			);
 
 			// Retry with fixed env (respect caller's other env vars, force PATH if present)
 			const retryEnv = shellEnvResult.PATH
-				? { ...shellEnvResult, ...options?.env, PATH: shellEnvResult.PATH }
-				: { ...shellEnvResult, ...options?.env };
+				? { ...mergedShellEnv, PATH: shellEnvResult.PATH }
+				: mergedShellEnv;
 
 			const result = await execFileAsync(cmd, args, {
 				...options,
@@ -193,6 +233,23 @@ export async function execWithShellEnv(
 			pathFixSucceeded = false;
 			console.error("[shell-env] Retry failed:", retryError);
 			throw retryError;
+		}
+	}
+}
+
+/**
+ * Enriches the running process environment with missing values from the user's
+ * interactive shell so later child processes inherit tokens and similar vars.
+ */
+export async function applyShellEnvToProcess(
+	targetEnv: NodeJS.ProcessEnv = process.env,
+	shellEnvResult?: Record<string, string>,
+): Promise<void> {
+	const mergedEnv = await getProcessEnvWithShellEnv(targetEnv, shellEnvResult);
+
+	for (const [key, value] of Object.entries(mergedEnv)) {
+		if (typeof targetEnv[key] !== "string") {
+			targetEnv[key] = value;
 		}
 	}
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -15,6 +15,7 @@ import {
 	handleAuthCallback,
 	parseAuthDeepLink,
 } from "lib/trpc/routers/auth/utils/auth-functions";
+import { applyShellEnvToProcess } from "lib/trpc/routers/workspaces/utils/shell-env";
 import {
 	DEFAULT_CONFIRM_ON_QUIT,
 	PLATFORM,
@@ -40,6 +41,10 @@ import { MainWindow } from "./windows/main";
 
 console.log("[main] Local database ready:", !!localDb);
 const IS_DEV = process.env.NODE_ENV === "development";
+
+void applyShellEnvToProcess().catch((error) => {
+	console.error("[main] Failed to apply shell environment:", error);
+});
 
 // Dev mode: label the app with the workspace name so multiple worktrees are distinguishable
 if (IS_DEV) {


### PR DESCRIPTION
## Summary
- merge missing interactive-shell env vars into desktop child process environments instead of only fixing PATH
- prewarm the desktop process env at startup so GitHub status checks inherit `GITHUB_TOKEN`/`GH_TOKEN` when launched from Finder or Dock
- add focused tests covering missing-token merge behavior and non-overwrite semantics

## Problem
Some users see `GitHub is not available for this workspace` because `gh repo view` runs without shell-exported auth tokens in the desktop backend. When that happens, GitHub status resolution returns `null` and the UI collapses to the generic unavailable message.

## Testing
- `bun test apps/desktop/src/lib/trpc/routers/workspaces/utils/shell-env.test.ts apps/desktop/src/lib/trpc/routers/workspaces/utils/git.test.ts`
- `bun run typecheck` (from `apps/desktop`)

Fixes #2216
Related to #2122

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure desktop GitHub status checks inherit the user's shell environment (not just PATH) so `gh` runs with auth tokens when the app is started from Finder or the Dock. Fixes #2216.

- **Bug Fixes**
  - Apply the shell environment to the main process at startup so child processes inherit tokens.
  - Merge missing shell vars into child process env in `execWithShellEnv` without overwriting existing values.
  - Add unit tests for merge behavior and non-overwrite semantics.

<sup>Written for commit 8048169629ff6771f7b612fb94dea64bb7af3961. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell environment variable initialization at startup to ensure system shell-configured variables are properly available throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->