### PR TITLE
fix(desktop): restore popover colors on new workspace modal

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -51,7 +51,7 @@ export function NewWorkspaceModal() {
 				</DialogHeader>
 				<DialogContent
 					showCloseButton={false}
-					className="sm:max-w-[560px] max-h-[min(70vh,600px)] !top-[calc(50%-min(35vh,300px))] !-translate-y-0 flex flex-col overflow-hidden p-0"
+					className="bg-popover text-popover-foreground sm:max-w-[560px] max-h-[min(70vh,600px)] !top-[calc(50%-min(35vh,300px))] !-translate-y-0 flex flex-col overflow-hidden p-0"
 				>
 					<NewWorkspaceModalContent
 						isOpen={isOpen}


### PR DESCRIPTION
## Summary
- Adds `bg-popover text-popover-foreground` to the `DialogContent` in the New Workspace modal
- When #2225 switched from `CommandDialog` to `Dialog`/`DialogContent` (to fix textarea keyboard behavior), it lost the popover colors that `Command` previously provided — the modal background fell back to `bg-background` instead of `bg-popover`

## Test plan
- [ ] Open the New Workspace modal and verify colors are consistent across all tabs (Prompt, Issues, PRs, Branches)
- [ ] Verify the modal background matches the command list area

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores popover colors in the New Workspace modal by adding `bg-popover` and `text-popover-foreground` to `DialogContent`. This fixes the regression from switching to `Dialog` and keeps the modal consistent across tabs and with the command list area.

<sup>Written for commit 234f551e3f0b50d482cde1faca827a98517defd4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the New Workspace Modal's visual appearance with updated color styling for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->