### PR TITLE
feat(desktop): add Intel (x64) macOS build support

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -112,7 +112,7 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: bun run package -- --publish never --config ${{ inputs.electron_builder_config }} --arch ${{ matrix.arch }}
+        run: bun run package -- --publish never --config ${{ inputs.electron_builder_config }} --${{ matrix.arch }}
 
       - name: Verify app-update.yml exists
         working-directory: apps/desktop

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -104,33 +104,6 @@ jobs:
           SUPERSET_WORKSPACE_NAME: superset
         run: bun run compile:app
 
-      - name: Install cross-arch native platform packages
-        if: matrix.arch == 'x64'
-        working-directory: apps/desktop
-        run: |
-          # When cross-compiling for x64 on an arm64 runner, Bun only installs
-          # arm64 platform-specific packages. We need to manually fetch the x64
-          # variants for native modules that ship pre-built binaries.
-          # We download and extract directly to avoid modifying package.json/bun.lock.
-          install_npm_pkg() {
-            local pkg_name=$1 version=$2 dest=$3
-            local tarball_name=$(echo "$pkg_name" | sed 's/@//;s/\//-/')
-            local url="https://registry.npmjs.org/${pkg_name}/-/${tarball_name}-${version}.tgz"
-            echo "Fetching ${pkg_name}@${version}"
-            mkdir -p "$dest"
-            curl -sL "$url" | tar xz -C "$dest" --strip-components=1
-          }
-
-          # ast-grep x64 platform package
-          AST_GREP_VERSION=$(node -p "require('./node_modules/@ast-grep/napi/package.json').optionalDependencies['@ast-grep/napi-darwin-x64']")
-          install_npm_pkg "@ast-grep/napi-darwin-x64" "$AST_GREP_VERSION" "node_modules/@ast-grep/napi-darwin-x64"
-
-          # libsql x64 platform package
-          LIBSQL_VERSION=$(node -p "try{require('./node_modules/libsql/package.json').optionalDependencies['@libsql/darwin-x64']}catch(e){''}")
-          if [ -n "$LIBSQL_VERSION" ]; then
-            install_npm_pkg "@libsql/darwin-x64" "$LIBSQL_VERSION" "node_modules/@libsql/darwin-x64"
-          fi
-
       - name: Build Electron app
         working-directory: apps/desktop
         env:
@@ -139,6 +112,7 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          TARGET_ARCH: ${{ matrix.arch }}
         run: bun run package -- --publish never --config ${{ inputs.electron_builder_config }} --${{ matrix.arch }}
 
       - name: Verify app-update.yml exists

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -104,6 +104,33 @@ jobs:
           SUPERSET_WORKSPACE_NAME: superset
         run: bun run compile:app
 
+      - name: Install cross-arch native platform packages
+        if: matrix.arch == 'x64'
+        working-directory: apps/desktop
+        run: |
+          # When cross-compiling for x64 on an arm64 runner, Bun only installs
+          # arm64 platform-specific packages. We need to manually fetch the x64
+          # variants for native modules that ship pre-built binaries.
+          # We download and extract directly to avoid modifying package.json/bun.lock.
+          install_npm_pkg() {
+            local pkg_name=$1 version=$2 dest=$3
+            local tarball_name=$(echo "$pkg_name" | sed 's/@//;s/\//-/')
+            local url="https://registry.npmjs.org/${pkg_name}/-/${tarball_name}-${version}.tgz"
+            echo "Fetching ${pkg_name}@${version}"
+            mkdir -p "$dest"
+            curl -sL "$url" | tar xz -C "$dest" --strip-components=1
+          }
+
+          # ast-grep x64 platform package
+          AST_GREP_VERSION=$(node -p "require('./node_modules/@ast-grep/napi/package.json').optionalDependencies['@ast-grep/napi-darwin-x64']")
+          install_npm_pkg "@ast-grep/napi-darwin-x64" "$AST_GREP_VERSION" "node_modules/@ast-grep/napi-darwin-x64"
+
+          # libsql x64 platform package
+          LIBSQL_VERSION=$(node -p "try{require('./node_modules/libsql/package.json').optionalDependencies['@libsql/darwin-x64']}catch(e){''}")
+          if [ -n "$LIBSQL_VERSION" ]; then
+            install_npm_pkg "@libsql/darwin-x64" "$LIBSQL_VERSION" "node_modules/@libsql/darwin-x64"
+          fi
+
       - name: Build Electron app
         working-directory: apps/desktop
         env:

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -117,7 +117,14 @@ jobs:
       - name: Verify app-update.yml exists
         working-directory: apps/desktop
         run: |
-          APP_DIR=$(ls -d release/mac-${{ matrix.arch }}/*.app | head -1)
+          # electron-builder uses mac-arm64/ for arm64 and mac/ for x64 (when host is arm64)
+          APP_DIR=$(find release -maxdepth 2 -name "*.app" -type d | head -1)
+          if [ -z "$APP_DIR" ]; then
+            echo "::error::No .app bundle found in release/"
+            ls -la release/
+            exit 1
+          fi
+          echo "Found app bundle: $APP_DIR"
           test -f "$APP_DIR/Contents/Resources/app-update.yml" || {
             echo "::error::app-update.yml missing from $APP_DIR/Contents/Resources/ — auto-update will be broken"
             exit 1

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [arm64]
+        arch: [arm64, x64]
 
     steps:
       - name: Checkout code
@@ -112,12 +112,12 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: bun run package -- --publish never --config ${{ inputs.electron_builder_config }}
+        run: bun run package -- --publish never --config ${{ inputs.electron_builder_config }} --arch ${{ matrix.arch }}
 
       - name: Verify app-update.yml exists
         working-directory: apps/desktop
         run: |
-          APP_DIR=$(ls -d release/mac-arm64/*.app | head -1)
+          APP_DIR=$(ls -d release/mac-${{ matrix.arch }}/*.app | head -1)
           test -f "$APP_DIR/Contents/Resources/app-update.yml" || {
             echo "::error::app-update.yml missing from $APP_DIR/Contents/Resources/ — auto-update will be broken"
             exit 1
@@ -142,7 +142,7 @@ jobs:
       - name: Upload auto-update manifest
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.artifact_prefix }}-mac-update-manifest
+          name: ${{ inputs.artifact_prefix }}-mac-${{ matrix.arch }}-update-manifest
           path: apps/desktop/release/*-mac.yml
           retention-days: ${{ inputs.artifact_retention_days }}
           if-no-files-found: error

--- a/.github/workflows/release-desktop-canary.yml
+++ b/.github/workflows/release-desktop-canary.yml
@@ -115,6 +115,15 @@ jobs:
               break
             fi
           done
+          # Prerelease builds may request canary-mac.yml; keep latest-mac.yml as fallback.
+          for file in *-mac.yml; do
+            if [[ -f "$file" && "$file" != "canary-mac.yml" && "$file" != "latest-mac.yml" ]]; then
+              cp "$file" "canary-mac.yml"
+              cp "$file" "latest-mac.yml"
+              echo "Created canary manifests: canary-mac.yml, latest-mac.yml from $file"
+              break
+            fi
+          done
 
       - name: List artifacts
         run: |

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -94,6 +94,14 @@ jobs:
               break
             fi
           done
+          # Keep macOS updater manifest at a stable filename for electron-updater lookups.
+          for file in *-mac.yml; do
+            if [[ -f "$file" && "$file" != "latest-mac.yml" ]]; then
+              cp "$file" "latest-mac.yml"
+              echo "Created stable copy: latest-mac.yml"
+              break
+            fi
+          done
           echo "Release artifacts:"
           ls -la
 

--- a/apps/desktop/electron-builder.ts
+++ b/apps/desktop/electron-builder.ts
@@ -145,7 +145,7 @@ const config: Configuration = {
 		target: [
 			{
 				target: "default",
-				arch: ["arm64"],
+				arch: ["arm64", "x64"],
 			},
 		],
 		hardenedRuntime: true,

--- a/apps/desktop/electron-builder.ts
+++ b/apps/desktop/electron-builder.ts
@@ -142,12 +142,7 @@ const config: Configuration = {
 	mac: {
 		...(existsSync(macIconPath) ? { icon: macIconPath } : {}),
 		category: "public.app-category.utilities",
-		target: [
-			{
-				target: "default",
-				arch: ["arm64", "x64"],
-			},
-		],
+		target: "default",
 		hardenedRuntime: true,
 		gatekeeperAssess: false,
 		notarize: true,

--- a/apps/desktop/scripts/copy-native-modules.ts
+++ b/apps/desktop/scripts/copy-native-modules.ts
@@ -129,8 +129,11 @@ function fetchNpmPackage(
 	version: string,
 	destPath: string,
 ): boolean {
-	const scopedName = packageName.replace(/^@/, "").replace("/", "-");
-	const url = `https://registry.npmjs.org/${packageName}/-/${scopedName}-${version}.tgz`;
+	// npm tarball URL: @scope/pkg/-/pkg-version.tgz (filename uses pkg name without scope)
+	const barePackageName = packageName.includes("/")
+		? packageName.split("/")[1]
+		: packageName;
+	const url = `https://registry.npmjs.org/${packageName}/-/${barePackageName}-${version}.tgz`;
 	console.log(`  ${packageName}: fetching from npm (${version})`);
 	try {
 		mkdirSync(destPath, { recursive: true });

--- a/apps/desktop/scripts/copy-native-modules.ts
+++ b/apps/desktop/scripts/copy-native-modules.ts
@@ -23,7 +23,14 @@ import {
 	realpathSync,
 	rmSync,
 } from "node:fs";
+import { execSync } from "node:child_process";
 import { dirname, join } from "node:path";
+
+// Target architecture for cross-compilation. When set, platform-specific
+// packages for this arch are fetched from npm if not already present.
+// Set via TARGET_ARCH env var (e.g., TARGET_ARCH=x64).
+const TARGET_ARCH = process.env.TARGET_ARCH || process.arch;
+const TARGET_PLATFORM = process.env.TARGET_PLATFORM || process.platform;
 
 // Native modules that must exist for the app to work
 const NATIVE_MODULES = [
@@ -113,6 +120,31 @@ function copyModuleIfSymlink(
 	return true;
 }
 
+/**
+ * Fetch an npm package tarball and extract it to destPath.
+ * Used when cross-compiling and the target platform package isn't in the Bun store.
+ */
+function fetchNpmPackage(
+	packageName: string,
+	version: string,
+	destPath: string,
+): boolean {
+	const scopedName = packageName.replace(/^@/, "").replace("/", "-");
+	const url = `https://registry.npmjs.org/${packageName}/-/${scopedName}-${version}.tgz`;
+	console.log(`  ${packageName}: fetching from npm (${version})`);
+	try {
+		mkdirSync(destPath, { recursive: true });
+		execSync(`curl -sL "${url}" | tar xz -C "${destPath}" --strip-components=1`, {
+			stdio: "pipe",
+		});
+		console.log(`    Extracted to: ${destPath}`);
+		return true;
+	} catch (err) {
+		console.error(`  [ERROR] Failed to fetch ${packageName}@${version}: ${err}`);
+		return false;
+	}
+}
+
 function copyAstGrepPlatformPackages(nodeModulesDir: string): void {
 	const astGrepNapiPath = join(nodeModulesDir, "@ast-grep", "napi");
 	if (!existsSync(astGrepNapiPath)) return;
@@ -133,6 +165,12 @@ function copyAstGrepPlatformPackages(nodeModulesDir: string): void {
 
 	if (platformPackages.length === 0) return;
 
+	// Determine which platform package we need for the target arch
+	const targetPlatformSuffix = `${TARGET_PLATFORM === "darwin" ? "darwin" : TARGET_PLATFORM === "win32" ? "win32" : "linux"}-${TARGET_ARCH}`;
+	const targetPkg = platformPackages.find((pkg) =>
+		pkg.name.includes(targetPlatformSuffix),
+	);
+
 	// Bun isolated installs keep package payloads in workspaceRoot/node_modules/.bun
 	const bunStoreDir = getBunStoreDir(nodeModulesDir);
 	let resolvedPlatformPackage = false;
@@ -151,30 +189,34 @@ function copyAstGrepPlatformPackages(nodeModulesDir: string): void {
 			platformPkg.name,
 			platformPkg.version,
 		);
-		if (!bunStoreFolderName) {
-			console.warn(
-				`  ${platformPkg.name}: no Bun store entry matched version ${platformPkg.version}`,
+		if (bunStoreFolderName) {
+			const sourcePath = join(
+				bunStoreDir,
+				bunStoreFolderName,
+				"node_modules",
+				platformPkg.name,
 			);
-			continue;
+			if (existsSync(sourcePath)) {
+				console.log(`  ${platformPkg.name}: copying from Bun store`);
+				mkdirSync(dirname(destPath), { recursive: true });
+				cpSync(sourcePath, destPath, { recursive: true });
+				resolvedPlatformPackage = true;
+				continue;
+			}
 		}
 
-		const sourcePath = join(
-			bunStoreDir,
-			bunStoreFolderName,
-			"node_modules",
-			platformPkg.name,
+		// If this is the target platform package and it's not in the Bun store,
+		// fetch it from npm (cross-compilation scenario)
+		if (targetPkg && platformPkg.name === targetPkg.name) {
+			if (fetchNpmPackage(platformPkg.name, platformPkg.version, destPath)) {
+				resolvedPlatformPackage = true;
+				continue;
+			}
+		}
+
+		console.warn(
+			`  ${platformPkg.name}: not found in Bun store or node_modules`,
 		);
-		if (!existsSync(sourcePath)) {
-			console.warn(
-				`  ${platformPkg.name}: Bun store path missing after resolve (${sourcePath})`,
-			);
-			continue;
-		}
-
-		console.log(`  ${platformPkg.name}: copying from Bun store`);
-		mkdirSync(dirname(destPath), { recursive: true });
-		cpSync(sourcePath, destPath, { recursive: true });
-		resolvedPlatformPackage = true;
 	}
 
 	if (!resolvedPlatformPackage) {
@@ -198,7 +240,7 @@ function copyLibsqlDependencies(nodeModulesDir: string): void {
 		readFileSync(libsqlPkgJsonPath, "utf8"),
 	) as LibsqlPackageJson;
 	const deps = Object.keys(libsqlPkg.dependencies ?? {});
-	const optionalDeps = Object.keys(libsqlPkg.optionalDependencies ?? {});
+	const optionalDeps = libsqlPkg.optionalDependencies ?? {};
 
 	console.log("\nPreparing libsql runtime dependencies...");
 	for (const dep of deps) {
@@ -206,7 +248,7 @@ function copyLibsqlDependencies(nodeModulesDir: string): void {
 	}
 
 	// Copy whichever optional native platform packages Bun installed for this platform.
-	for (const dep of optionalDeps) {
+	for (const dep of Object.keys(optionalDeps)) {
 		copyModuleIfSymlink(nodeModulesDir, dep, false);
 	}
 
@@ -228,10 +270,23 @@ function copyLibsqlDependencies(nodeModulesDir: string): void {
 			copyModuleIfSymlink(nodeModulesDir, `@libsql/${entry}`, false);
 		}
 	}
+
+	// Cross-compilation: ensure the target platform's @libsql package is present
+	const targetSuffix = `${TARGET_PLATFORM}-${TARGET_ARCH}`;
+	const targetLibsqlPkgs = Object.entries(optionalDeps).filter(([name]) =>
+		name.includes(targetSuffix),
+	);
+	for (const [name, version] of targetLibsqlPkgs) {
+		const destPath = join(nodeModulesDir, name);
+		if (!existsSync(destPath)) {
+			fetchNpmPackage(name, version, destPath);
+		}
+	}
 }
 
 function prepareNativeModules() {
 	console.log("Preparing native modules for electron-builder...");
+	console.log(`  Target: ${TARGET_PLATFORM}/${TARGET_ARCH} (host: ${process.platform}/${process.arch})`);
 
 	// bun creates symlinks for direct dependencies in the workspace's node_modules
 	const nodeModulesDir = join(dirname(import.meta.dirname), "node_modules");

--- a/apps/desktop/scripts/copy-native-modules.ts
+++ b/apps/desktop/scripts/copy-native-modules.ts
@@ -13,6 +13,7 @@
  * This is safe because bun install will recreate the symlinks on next install.
  */
 
+import { execSync } from "node:child_process";
 import {
 	cpSync,
 	existsSync,
@@ -23,7 +24,6 @@ import {
 	realpathSync,
 	rmSync,
 } from "node:fs";
-import { execSync } from "node:child_process";
 import { dirname, join } from "node:path";
 
 // Target architecture for cross-compilation. When set, platform-specific
@@ -137,13 +137,18 @@ function fetchNpmPackage(
 	console.log(`  ${packageName}: fetching from npm (${version})`);
 	try {
 		mkdirSync(destPath, { recursive: true });
-		execSync(`curl -sL "${url}" | tar xz -C "${destPath}" --strip-components=1`, {
-			stdio: "pipe",
-		});
+		execSync(
+			`curl -sL "${url}" | tar xz -C "${destPath}" --strip-components=1`,
+			{
+				stdio: "pipe",
+			},
+		);
 		console.log(`    Extracted to: ${destPath}`);
 		return true;
 	} catch (err) {
-		console.error(`  [ERROR] Failed to fetch ${packageName}@${version}: ${err}`);
+		console.error(
+			`  [ERROR] Failed to fetch ${packageName}@${version}: ${err}`,
+		);
 		return false;
 	}
 }
@@ -289,7 +294,9 @@ function copyLibsqlDependencies(nodeModulesDir: string): void {
 
 function prepareNativeModules() {
 	console.log("Preparing native modules for electron-builder...");
-	console.log(`  Target: ${TARGET_PLATFORM}/${TARGET_ARCH} (host: ${process.platform}/${process.arch})`);
+	console.log(
+		`  Target: ${TARGET_PLATFORM}/${TARGET_ARCH} (host: ${process.platform}/${process.arch})`,
+	);
 
 	// bun creates symlinks for direct dependencies in the workspace's node_modules
 	const nodeModulesDir = join(dirname(import.meta.dirname), "node_modules");

--- a/apps/desktop/scripts/validate-native-runtime.ts
+++ b/apps/desktop/scripts/validate-native-runtime.ts
@@ -88,23 +88,26 @@ function collectFiles(rootDir: string): string[] {
 }
 
 function getPlatformLibsqlCandidates(): string[] {
-	if (process.platform === "darwin") {
+	const targetArch = process.env.TARGET_ARCH || process.arch;
+	const targetPlatform = process.env.TARGET_PLATFORM || process.platform;
+
+	if (targetPlatform === "darwin") {
 		return [
-			process.arch === "arm64" ? "@libsql/darwin-arm64" : "@libsql/darwin-x64",
+			targetArch === "arm64" ? "@libsql/darwin-arm64" : "@libsql/darwin-x64",
 		];
 	}
 
-	if (process.platform === "linux") {
-		if (process.arch === "arm64") {
+	if (targetPlatform === "linux") {
+		if (targetArch === "arm64") {
 			return ["@libsql/linux-arm64-gnu", "@libsql/linux-arm64-musl"];
 		}
-		if (process.arch === "arm") {
+		if (targetArch === "arm") {
 			return ["@libsql/linux-arm-gnueabihf", "@libsql/linux-arm-musleabihf"];
 		}
 		return ["@libsql/linux-x64-gnu", "@libsql/linux-x64-musl"];
 	}
 
-	if (process.platform === "win32") {
+	if (targetPlatform === "win32") {
 		return ["@libsql/win32-x64-msvc"];
 	}
 


### PR DESCRIPTION
## Summary
- Add `x64` to macOS build matrix so arm64 and Intel builds run in parallel
- Pass `--arch` from CI matrix to electron-builder for per-job architecture targeting
- Fix app-update.yml verification and artifact names to be arch-aware
- Release workflows already handle multiple architectures via glob patterns

## Test plan
- [ ] Both arm64 and x64 macOS builds pass in CI
- [ ] Artifacts for both architectures are uploaded correctly
- [ ] Test x64 DMG under Rosetta on Apple Silicon

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Intel (x64) macOS build support and stabilizes cross-arch packaging for the desktop app. CI now builds `arm64` and `x64` in parallel, fetches the right native binaries, and keeps macOS updater manifests at stable names.

- **New Features**
  - Add `x64` to the macOS build matrix; `arm64` and `x64` builds run in parallel.

- **Bug Fixes**
  - Use `--x64`/`--arm64` flags and remove `arch` from `electron-builder` config so CLI flags control the build.
  - Find the built `.app` dynamically for `app-update.yml` verification; upload arch-suffixed artifacts.
  - Move cross-arch native handling into `copy-native-modules.ts`: honors `TARGET_ARCH`/`TARGET_PLATFORM`, fetches target `@ast-grep/napi-*` and `@libsql/*` from npm when missing, fixes scoped package tarball URL resolution; update `validate-native-runtime.ts` to respect the target arch.
  - Stabilize macOS auto-update manifests in release workflows by copying to `latest-mac.yml` (and `canary-mac.yml`).

<sup>Written for commit 9f36540520ab72cc5a302b0a151c242c81a92480. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Desktop build now produces macOS packages for both Apple Silicon (arm64) and Intel (x64).
  * Build workflow fetches and installs cross-architecture native runtime packages when building x64 artifacts.
  * Release workflows and packaging generate and upload architecture-specific artifacts and update manifests.
  * macOS packaging configuration simplified to use a single default target for both architectures, and app bundle discovery/verification now supports arch-specific bundles with improved logging and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->