### PR TITLE
fix(chat-mastra): restore chat UI hook session targeting

### DIFF
--- a/packages/chat-mastra/src/server/trpc/service.runtime-creation.test.ts
+++ b/packages/chat-mastra/src/server/trpc/service.runtime-creation.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const SESSION_ID = "11111111-1111-4111-8111-111111111111";
+const THREAD_ID = "thread-1";
+
+const setSessionIdMock = mock((_: string) => {});
+const runSessionStartMock = mock(async () => ({
+	allowed: true,
+	results: [],
+	warnings: [],
+}));
+const harnessSubscribeMock = mock((_: (event: unknown) => void) => () => {});
+const harnessInitMock = mock(async () => {});
+const harnessSetResourceIdMock = mock((_: { resourceId: string }) => {});
+const harnessSelectOrCreateThreadMock = mock(async () => {
+	setSessionIdMock(THREAD_ID);
+});
+const createMastraCodeMock = mock(async () => ({
+	harness: {
+		init: harnessInitMock,
+		setResourceId: harnessSetResourceIdMock,
+		selectOrCreateThread: harnessSelectOrCreateThreadMock,
+		subscribe: harnessSubscribeMock,
+	},
+	mcpManager: null,
+	hookManager: {
+		setSessionId: setSessionIdMock,
+		runSessionStart: runSessionStartMock,
+	},
+}));
+const createAuthStorageMock = mock(() => ({
+	reload: () => {},
+	get: () => undefined,
+}));
+
+mock.module("mastracode", () => ({
+	createAuthStorage: createAuthStorageMock,
+	createMastraCode: createMastraCodeMock,
+}));
+
+const { ChatMastraService } = await import("./service");
+
+describe("ChatMastraService runtime creation", () => {
+	beforeEach(() => {
+		setSessionIdMock.mockClear();
+		runSessionStartMock.mockClear();
+		harnessSubscribeMock.mockClear();
+		harnessInitMock.mockClear();
+		harnessSetResourceIdMock.mockClear();
+		harnessSelectOrCreateThreadMock.mockClear();
+		createMastraCodeMock.mockClear();
+		createAuthStorageMock.mockClear();
+	});
+
+	it("reasserts the Superset session id after thread selection", async () => {
+		const service = new ChatMastraService({
+			headers: async () => ({}),
+			apiUrl: "http://localhost:3000",
+		});
+
+		const runtime = await (
+			service as unknown as {
+				getOrCreateRuntime: (
+					sessionId: string,
+					cwd?: string,
+				) => Promise<{ sessionId: string }>;
+			}
+		).getOrCreateRuntime(SESSION_ID, "/tmp/project");
+
+		expect(runtime.sessionId).toBe(SESSION_ID);
+		expect(setSessionIdMock.mock.calls.map(([sessionId]) => sessionId)).toEqual(
+			[SESSION_ID, THREAD_ID, SESSION_ID],
+		);
+		expect(runSessionStartMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/chat-mastra/src/server/trpc/service.ts
+++ b/packages/chat-mastra/src/server/trpc/service.ts
@@ -15,6 +15,7 @@ import {
 	restartRuntimeFromUserMessage,
 	runSessionStartHook,
 	subscribeToSessionEvents,
+	syncRuntimeHookSessionId,
 } from "./utils/runtime";
 import { getSupersetMcpTools } from "./utils/runtime/superset-mcp";
 import {
@@ -140,6 +141,7 @@ export class ChatMastraService {
 					pendingSandboxQuestion: null,
 					cwd: runtimeCwd,
 				};
+				syncRuntimeHookSessionId(runtime);
 				await runSessionStartHook(runtime).catch(() => {});
 				subscribeToSessionEvents(runtime);
 				this.runtimes.set(sessionId, runtime);

--- a/packages/chat-mastra/src/server/trpc/utils/runtime/index.ts
+++ b/packages/chat-mastra/src/server/trpc/utils/runtime/index.ts
@@ -11,6 +11,7 @@ export {
 	restartRuntimeFromUserMessage,
 	runSessionStartHook,
 	subscribeToSessionEvents,
+	syncRuntimeHookSessionId,
 } from "./runtime";
 export {
 	authenticateRuntimeMcpServer,

--- a/packages/chat-mastra/src/server/trpc/utils/runtime/runtime.test.ts
+++ b/packages/chat-mastra/src/server/trpc/utils/runtime/runtime.test.ts
@@ -100,6 +100,26 @@ function createRuntimeForTitleTest(options?: {
 }
 
 describe("runtime error propagation", () => {
+	it("restores Superset session id after Mastra thread events", () => {
+		const { runtime, emit } = createRuntimeForTest();
+		const setSessionId = {
+			calls: [] as string[],
+		};
+		runtime.hookManager = {
+			setSessionId: (sessionId: string) => {
+				setSessionId.calls.push(sessionId);
+			},
+		} as RuntimeSession["hookManager"];
+
+		emit({ type: "thread_created", thread: { id: "thread-1" } });
+		emit({ type: "thread_changed", threadId: "thread-2" });
+
+		expect(setSessionId.calls).toEqual([
+			"11111111-1111-1111-1111-111111111111",
+			"11111111-1111-1111-1111-111111111111",
+		]);
+	});
+
 	it("extracts nested provider message from error.data.error.message", () => {
 		const { runtime, emit } = createRuntimeForTest();
 		emit({

--- a/packages/chat-mastra/src/server/trpc/utils/runtime/runtime.ts
+++ b/packages/chat-mastra/src/server/trpc/utils/runtime/runtime.ts
@@ -34,6 +34,10 @@ export interface RuntimeSession {
 	cwd: string;
 }
 
+export function syncRuntimeHookSessionId(runtime: RuntimeSession): void {
+	runtime.hookManager?.setSessionId(runtime.sessionId);
+}
+
 type ApiClient = ReturnType<typeof createTRPCClient<AppRouter>>;
 
 interface TextContentPart {
@@ -173,6 +177,13 @@ export async function destroyRuntime(runtime: RuntimeSession): Promise<void> {
  */
 export function subscribeToSessionEvents(runtime: RuntimeSession): void {
 	runtime.harness.subscribe((event: unknown) => {
+		if (
+			isHarnessThreadChangedEvent(event) ||
+			isHarnessThreadCreatedEvent(event)
+		) {
+			syncRuntimeHookSessionId(runtime);
+			return;
+		}
 		if (isHarnessErrorEvent(event) || isHarnessWorkspaceErrorEvent(event)) {
 			runtime.lastErrorMessage = toRuntimeErrorMessage(event.error);
 			return;
@@ -245,6 +256,27 @@ function isHarnessSandboxAccessRequestEvent(event: unknown): event is {
 		typeof event.questionId === "string" &&
 		typeof event.path === "string" &&
 		typeof event.reason === "string"
+	);
+}
+
+function isHarnessThreadChangedEvent(
+	event: unknown,
+): event is { type: "thread_changed"; threadId: string } {
+	return (
+		isObjectRecord(event) &&
+		event.type === "thread_changed" &&
+		typeof event.threadId === "string"
+	);
+}
+
+function isHarnessThreadCreatedEvent(
+	event: unknown,
+): event is { type: "thread_created"; thread: { id: string } } {
+	return (
+		isObjectRecord(event) &&
+		event.type === "thread_created" &&
+		isObjectRecord(event.thread) &&
+		typeof event.thread.id === "string"
 	);
 }
 


### PR DESCRIPTION
## Summary
- keep `chat-mastra` hook events keyed to the Superset chat session id instead of Mastra internal thread ids
- reassert the Superset session id after initial thread selection and on later `thread_created` / `thread_changed` events
- add regression coverage for runtime creation and thread event handling

## Root Cause
Upstream `mastracode` now rewrites `hookManager.session_id` to the active Mastra thread id. Our desktop chat hook notifications resolve panes by the Superset chat session id, so hook events stopped mapping back to the chat UI after thread selection/switches.

## Testing
- `bun test packages/chat-mastra/src/server/trpc/service.runtime-creation.test.ts packages/chat-mastra/src/server/trpc/service.test.ts packages/chat-mastra/src/server/trpc/utils/runtime/runtime.test.ts packages/chat-mastra/src/client/hooks/use-mastra-chat-display/use-mastra-chat-display.test.ts`
- `bunx biome check packages/chat-mastra/src/server/trpc/service.ts packages/chat-mastra/src/server/trpc/utils/runtime/index.ts packages/chat-mastra/src/server/trpc/utils/runtime/runtime.ts packages/chat-mastra/src/server/trpc/utils/runtime/runtime.test.ts packages/chat-mastra/src/server/trpc/service.runtime-creation.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat UI hook routing by keeping `chat-mastra` events keyed to the Superset chat session id instead of Mastra thread ids. Restores correct pane targeting after thread selection and switches.

- **Bug Fixes**
  - Work around `mastracode` overwriting the hook session id with the active thread id.
  - Reassert the Superset session id on runtime creation and on thread events (`thread_created` / `thread_changed`).
  - Added regression tests for runtime creation and thread event handling.

<sup>Written for commit 1d565ec79d81d1356b30b6ba4e6e767f24263877. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session ID synchronization to ensure proper state consistency during thread operations.

* **Tests**
  * Added unit tests to verify session ID preservation and proper event handling during runtime creation and thread lifecycle events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->