### PR TITLE
fix(desktop): refetch branches when opening new workspace modal

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/NewWorkspaceModalContent/NewWorkspaceModalContent.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/NewWorkspaceModalContent/NewWorkspaceModalContent.tsx
@@ -31,6 +31,14 @@ export function NewWorkspaceModalContent({
 	const { draft, updateDraft } = useNewWorkspaceModalDraft();
 	const { data: recentProjects = [] } =
 		electronTrpc.projects.getRecents.useQuery();
+	const utils = electronTrpc.useUtils();
+
+	// Refetch branches (and other data) when the modal opens to avoid stale data
+	useEffect(() => {
+		if (!isOpen) return;
+		void utils.projects.getBranches.invalidate();
+		void utils.projects.getBranchesLocal.invalidate();
+	}, [isOpen, utils]);
 
 	useEffect(() => {
 		if (!isOpen) return;


### PR DESCRIPTION
## Summary
- Invalidate branch queries (`getBranches` + `getBranchesLocal`) when the new workspace modal opens
- Ensures newly created branches appear immediately instead of showing stale cached data
- The Dialog component keeps children mounted when closed, so `refetchOnMount` doesn't work — explicit invalidation is needed

## Test plan
- [ ] Open a project in the desktop app
- [ ] Create a new branch (e.g. via terminal or GitHub)
- [ ] Open the new workspace modal → branches tab
- [ ] Verify the new branch appears in the list
- [ ] Close and reopen the modal — confirm it refetches each time

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the branches list in the New Workspace modal by invalidating branch queries on open, so newly created branches appear immediately.

- **Bug Fixes**
  - Invalidate `getBranches` and `getBranchesLocal` when the modal opens to bypass stale cache (Dialog keeps children mounted, so `refetchOnMount` doesn’t run).

<sup>Written for commit a3fc0444849efa8e10abb54c8f70dc3e889ff4ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workspace modal to ensure branch information remains current by refreshing branch data when the modal opens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->