### PR TITLE
fix(desktop): style invoice rows as individual cards

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/RecentInvoices/RecentInvoices.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/RecentInvoices/RecentInvoices.tsx
@@ -41,15 +41,15 @@ export function RecentInvoices() {
 	}
 
 	return (
-		<div className="rounded-lg border bg-card p-4">
+		<div>
 			<h3 className="text-sm font-medium mb-3">Recent invoices</h3>
-			<div className="space-y-0.5">
+			<div className="space-y-2">
 				{invoices.map((invoice) => (
 					<div
 						key={invoice.id}
-						className="group flex items-center justify-between rounded-md px-2 py-1.5 -mx-2 hover:bg-muted/50 transition-colors"
+						className="group flex items-center justify-between rounded-lg border bg-card px-4 py-5"
 					>
-						<div className="flex items-center gap-3 text-sm">
+						<div className="flex items-center gap-6 text-sm">
 							<span className="text-muted-foreground">
 								{formatDate(invoice.date)}
 							</span>


### PR DESCRIPTION
## Summary
- Restyled recent invoices on the billing page so each invoice renders as its own bordered card instead of rows inside a single container
- Wider spacing between date and amount, taller card height for better readability
- "View" external link button appears on group hover only

## Test plan
- [ ] Open Settings > Billing in desktop app with an active subscription
- [ ] Verify each invoice renders as a separate card with border
- [ ] Hover over a card and confirm "View" link appears
- [ ] Click "View" and confirm it opens the Stripe hosted invoice in browser

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Styled recent invoices in Settings → Billing so each invoice renders as its own bordered card instead of rows in a single container. Increased spacing for readability and show the “View” link on hover only.

<sup>Written for commit 30dea4e38b0189f4dfc9e1f39c80eb3dd9ef1d52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified the Recent Invoices display with cleaner card styling and improved vertical spacing between entries.
  * Enhanced visual hierarchy with increased horizontal gaps between invoice row elements.
  * Refined hover and interaction states for a more polished user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->