### PR TITLE
feat(desktop): default terminal file links to open in file viewer

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/LinkBehaviorSetting.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/LinkBehaviorSetting.tsx
@@ -47,7 +47,7 @@ export function LinkBehaviorSetting() {
 				</p>
 			</div>
 			<Select
-				value={terminalLinkBehavior ?? "external-editor"}
+				value={terminalLinkBehavior ?? "file-viewer"}
 				onValueChange={(value) =>
 					setTerminalLinkBehavior.mutate({
 						behavior: value as TerminalLinkBehavior,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useFileLinkClick.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useFileLinkClick.ts
@@ -32,7 +32,7 @@ export function useFileLinkClick({
 
 	const handleFileLinkClick = useCallback(
 		(path: string, line?: number, column?: number) => {
-			const behavior = terminalLinkBehavior ?? "external-editor";
+			const behavior = terminalLinkBehavior ?? "file-viewer";
 
 			// Helper to open in external editor
 			const openInExternalEditor = () => {

--- a/apps/desktop/src/shared/constants.ts
+++ b/apps/desktop/src/shared/constants.ts
@@ -38,7 +38,7 @@ export const MOCK_ORG_ID = "mock-org-id";
 
 // Default user preference values
 export const DEFAULT_CONFIRM_ON_QUIT = true;
-export const DEFAULT_TERMINAL_LINK_BEHAVIOR = "external-editor" as const;
+export const DEFAULT_TERMINAL_LINK_BEHAVIOR = "file-viewer" as const;
 export const DEFAULT_FILE_OPEN_MODE = "split-pane" as const;
 export const DEFAULT_AUTO_APPLY_DEFAULT_PRESET = true;
 export const DEFAULT_SHOW_PRESETS_BAR = true;


### PR DESCRIPTION
## Summary
- Changes the default terminal link behavior from "external-editor" to "file-viewer"
- Cmd+clicking file paths in the terminal now opens them in the built-in file viewer by default
- Existing users who have explicitly set their preference are unaffected — only the fallback for unset preferences changes

## Test plan
- [x] Fresh install: Cmd+click a file path in the terminal and verify it opens in the file viewer
- [x] Existing user with "external-editor" explicitly set: verify their preference is preserved
- [x] Settings UI: verify the select dropdown shows "File viewer" as the default

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changed the default terminal link behavior from `external-editor` to `file-viewer` so Cmd+clicking file paths opens in the built-in file viewer by default. Applies to fresh installs and users without a set preference; existing preferences are preserved.

<sup>Written for commit 93afc5bbde00c3ac00ff6773eb6a839a851ba552. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features**
  * Changed the default behavior for opening file links clicked in the terminal. File links now open in the built-in file viewer instead of an external editor by default, offering a more seamless workflow. Users can still configure this preference in terminal settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->