### PR TITLE
feat(desktop): add microcopy to update prompts

### DIFF
--- a/apps/desktop/src/renderer/components/UpdateRequiredPage/UpdateRequiredPage.tsx
+++ b/apps/desktop/src/renderer/components/UpdateRequiredPage/UpdateRequiredPage.tsx
@@ -75,6 +75,10 @@ export function UpdateRequiredPage({
 						<span>Required version: {minimumVersion}+</span>
 					</div>
 
+					<p className="text-xs text-muted-foreground/70">
+						Your terminal sessions won't be interrupted.
+					</p>
+
 					{isError && (
 						<p className="text-sm text-destructive">
 							{updateStatus.error || "Update check failed. Please try again."}

--- a/apps/desktop/src/renderer/components/UpdateToast/UpdateToast.tsx
+++ b/apps/desktop/src/renderer/components/UpdateToast/UpdateToast.tsx
@@ -77,6 +77,9 @@ export function UpdateToast({
 								? `Version ${version} is ready to install`
 								: "Ready to install"}
 						</span>
+						<span className="text-xs text-muted-foreground/70">
+							Your terminal sessions won't be interrupted.
+						</span>
 					</>
 				)}
 			</div>


### PR DESCRIPTION
## Summary
- Added "Your terminal sessions won't be interrupted." microcopy to the **UpdateToast** (bottom-right notification when an update is ready) and **UpdateRequiredPage** (forced update blocker screen)
- Addresses user feedback where users were hesitant to update because they feared losing running terminal sessions

## Test plan
- [ ] Run desktop app in dev mode, use **Dev menu → Simulate Update Ready** to trigger the update toast and verify the microcopy appears
- [ ] Verify the UpdateRequiredPage shows the same message (can be tested by lowering the minimum version check)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added “Your terminal sessions won't be interrupted.” to the update toast and the forced update page to reassure users they can install updates without losing active terminal sessions.

<sup>Written for commit 0410b5ada2fdb8c802f35a3c3989a95329ffc358. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Interface**
  * Added clarifying messages indicating that terminal sessions remain uninterrupted during application updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->