### PR TITLE
fix(desktop): match expanded add-tab button style to compact plus button

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/components/AddTabButton/AddTabButton.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/components/AddTabButton/AddTabButton.tsx
@@ -57,8 +57,8 @@ export function AddTabButton({
 					{showBigAddButton ? (
 						<>
 							<Button
-								variant="outline"
-								className="h-7 rounded-r-none pl-2 pr-1.5 gap-1 text-xs"
+								variant="ghost"
+								className="h-7 rounded-r-none pl-2 pr-1.5 gap-1 text-xs border border-border/60 bg-muted/30 text-muted-foreground hover:bg-accent/60 hover:text-foreground"
 								onClick={onAddTerminal}
 							>
 								<BsTerminalPlus className="size-3.5" />
@@ -66,8 +66,8 @@ export function AddTabButton({
 							</Button>
 							{hasAiChat && (
 								<Button
-									variant="outline"
-									className="h-7 rounded-none border-l-0 px-1.5 gap-1 text-xs"
+									variant="ghost"
+									className="h-7 rounded-none border border-l-0 border-border/60 bg-muted/30 px-1.5 gap-1 text-xs text-muted-foreground hover:bg-accent/60 hover:text-foreground"
 									onClick={onAddChat}
 								>
 									<TbMessageCirclePlus className="size-3.5" />
@@ -75,8 +75,8 @@ export function AddTabButton({
 								</Button>
 							)}
 							<Button
-								variant="outline"
-								className="h-7 rounded-none border-l-0 px-1.5 gap-1 text-xs"
+								variant="ghost"
+								className="h-7 rounded-none border border-l-0 border-border/60 bg-muted/30 px-1.5 gap-1 text-xs text-muted-foreground hover:bg-accent/60 hover:text-foreground"
 								onClick={onAddBrowser}
 							>
 								<TbWorld className="size-3.5" />
@@ -84,9 +84,9 @@ export function AddTabButton({
 							</Button>
 							<DropdownMenuTrigger asChild>
 								<Button
-									variant="outline"
+									variant="ghost"
 									size="icon"
-									className="size-7 rounded-l-none border-l-0 px-1"
+									className="size-7 rounded-l-none border border-l-0 border-border/60 bg-muted/30 px-1 text-muted-foreground hover:bg-accent/60 hover:text-foreground"
 								>
 									<HiMiniChevronDown className="size-3" />
 								</Button>


### PR DESCRIPTION
## Summary
- Applies the same `bg-muted/30`, `border-border/60`, `text-muted-foreground`, and `hover:bg-accent/60` styling from the compact plus button to the expanded mode buttons (Terminal, Chat, Browser, chevron)
- Switches expanded buttons from `variant="outline"` to `variant="ghost"` to avoid default outline border conflicts

## Test plan
- [x] Toggle "Use Compact Button" off in the add-tab dropdown to see the expanded mode
- [x] Verify the expanded buttons visually match the compact plus button's background, border, and hover states

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make expanded add‑tab buttons match the compact plus button. Fixes inconsistent colors and hover states in expanded mode.

- **Bug Fixes**
  - Switched expanded buttons to `variant="ghost"` to remove conflicting outline borders.
  - Applied shared styles (`bg-muted/30`, `border border-border/60`, `text-muted-foreground`, `hover:bg-accent/60`) to Terminal, Chat, Browser, and chevron buttons, with proper left-border rules for grouping.

<sup>Written for commit 027de614a35f53a66361a969af8f728544696f05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual styling of add-tab buttons with enhanced hover states and refined appearance for better UI consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->