### PR TITLE
feat(desktop): add 'Mark as Unread' to terminal and tab context menus

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupItem.tsx
@@ -3,6 +3,7 @@ import {
 	ContextMenu,
 	ContextMenuContent,
 	ContextMenuItem,
+	ContextMenuSeparator,
 	ContextMenuTrigger,
 } from "@superset/ui/context-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
@@ -11,7 +12,7 @@ import { useEffect, useRef, useState } from "react";
 import { useDrag, useDrop } from "react-dnd";
 import { getEmptyImage } from "react-dnd-html5-backend";
 import { HiMiniXMark } from "react-icons/hi2";
-import { LuPencil } from "react-icons/lu";
+import { LuEyeOff, LuPencil } from "react-icons/lu";
 import { MosaicDragType } from "react-mosaic-component";
 import { StatusIndicator } from "renderer/screens/main/components/StatusIndicator";
 import { useDragPaneStore } from "renderer/stores/drag-pane-store";
@@ -28,6 +29,7 @@ interface GroupItemProps {
 	onSelect: () => void;
 	onClose: () => void;
 	onRename: (newName: string) => void;
+	onMarkAsUnread: () => void;
 	onPaneDrop?: (paneId: string) => void;
 	onReorder?: (fromIndex: number, toIndex: number) => void;
 }
@@ -40,6 +42,7 @@ export function GroupItem({
 	onSelect,
 	onClose,
 	onRename,
+	onMarkAsUnread,
 	onPaneDrop,
 	onReorder,
 }: GroupItemProps) {
@@ -247,6 +250,12 @@ export function GroupItem({
 					<LuPencil className="size-4 mr-2" />
 					Rename
 				</ContextMenuItem>
+				<ContextMenuSeparator />
+				<ContextMenuItem onSelect={onMarkAsUnread}>
+					<LuEyeOff className="size-4 mr-2" />
+					Mark as Unread
+				</ContextMenuItem>
+				<ContextMenuSeparator />
 				<ContextMenuItem onSelect={onClose}>
 					<HiMiniXMark className="size-4 mr-2" />
 					Close

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupStrip.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupStrip.tsx
@@ -47,6 +47,7 @@ export function GroupStrip() {
 	const movePaneToTab = useTabsStore((s) => s.movePaneToTab);
 	const movePaneToNewTab = useTabsStore((s) => s.movePaneToNewTab);
 	const reorderTabs = useTabsStore((s) => s.reorderTabs);
+	const setPaneStatus = useTabsStore((s) => s.setPaneStatus);
 
 	const setTabAutoTitle = useTabsStore((s) => s.setTabAutoTitle);
 	const setPaneAutoTitle = useTabsStore((s) => s.setPaneAutoTitle);
@@ -256,6 +257,14 @@ export function GroupStrip() {
 		renameTab(tabId, newName);
 	};
 
+	const handleMarkTabAsUnread = (tabId: string) => {
+		for (const pane of Object.values(panes)) {
+			if (pane.tabId === tabId) {
+				setPaneStatus(pane.id, "review");
+			}
+		}
+	};
+
 	const handleReorderTabs = useCallback(
 		(fromIndex: number, toIndex: number) => {
 			if (activeWorkspaceId) {
@@ -351,6 +360,7 @@ export function GroupStrip() {
 											onSelect={() => handleSelectGroup(tab.id)}
 											onClose={() => handleCloseGroup(tab.id)}
 											onRename={(newName) => handleRenameGroup(tab.id, newName)}
+											onMarkAsUnread={() => handleMarkTabAsUnread(tab.id)}
 											onPaneDrop={(paneId) => movePaneToTab(paneId, tab.id)}
 											onReorder={handleReorderTabs}
 										/>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabContentContextMenu.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabContentContextMenu.tsx
@@ -13,6 +13,7 @@ import {
 	LuClipboard,
 	LuClipboardCopy,
 	LuEraser,
+	LuEyeOff,
 } from "react-icons/lu";
 import { useHotkeyText } from "renderer/stores/hotkeys";
 import {
@@ -36,6 +37,7 @@ interface TabContentContextMenuProps {
 	onScrollToBottom?: () => void;
 	getSelection?: () => string;
 	onPaste?: (text: string) => void;
+	onMarkAsUnread?: () => void;
 	currentTabId: PaneContextMenuActions["currentTabId"];
 	availableTabs: PaneContextMenuActions["availableTabs"];
 	onMoveToTab: PaneContextMenuActions["onMoveToTab"];
@@ -54,6 +56,7 @@ export function TabContentContextMenu({
 	onScrollToBottom,
 	getSelection,
 	onPaste,
+	onMarkAsUnread,
 	currentTabId,
 	availableTabs,
 	onMoveToTab,
@@ -137,6 +140,15 @@ export function TabContentContextMenu({
 					</ContextMenuItem>
 				)}
 				{hasTerminalActions && <ContextMenuSeparator />}
+				{onMarkAsUnread && (
+					<>
+						<ContextMenuItem onSelect={onMarkAsUnread}>
+							<LuEyeOff className="size-4" />
+							Mark as Unread
+						</ContextMenuItem>
+						<ContextMenuSeparator />
+					</>
+				)}
 				<PaneContextMenuItems
 					actions={{
 						onSplitHorizontal,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/TabPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/TabPane.tsx
@@ -58,6 +58,7 @@ export function TabPane({
 }: TabPaneProps) {
 	const paneName = useTabsStore((s) => s.panes[paneId]?.name);
 	const paneStatus = useTabsStore((s) => s.panes[paneId]?.status);
+	const setPaneStatus = useTabsStore((s) => s.setPaneStatus);
 
 	const terminalContainerRef = useRef<HTMLDivElement>(null);
 	const getClearCallback = useTerminalCallbacksStore((s) => s.getClearCallback);
@@ -128,6 +129,7 @@ export function TabPane({
 				onScrollToBottom={handleScrollToBottom}
 				getSelection={() => getGetSelectionCallback(paneId)?.() ?? ""}
 				onPaste={(text) => getPasteCallback(paneId)?.(text)}
+				onMarkAsUnread={() => setPaneStatus(paneId, "review")}
 				currentTabId={tabId}
 				availableTabs={availableTabs}
 				onMoveToTab={onMoveToTab}

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -946,10 +946,17 @@ export const useTabsStore = create<TabsStore>()(
 					const pane = state.panes[paneId];
 					if (!pane || pane.tabId !== tabId) return;
 
+					const alreadyFocused = state.focusedPaneIds[tabId] === paneId;
+
 					set({
 						panes: {
 							...state.panes,
-							[paneId]: { ...pane, status: acknowledgedStatus(pane.status) },
+							[paneId]: {
+								...pane,
+								status: alreadyFocused
+									? pane.status
+									: acknowledgedStatus(pane.status),
+							},
 						},
 						focusedPaneIds: {
 							...state.focusedPaneIds,


### PR DESCRIPTION
## Summary
- Adds a "Mark as Unread" option to the terminal pane right-click context menu and the tab header right-click context menu
- Sets pane status to `"review"` (green dot indicator) — the same indicator shown when an agent completes work
- Fixes a race in `setFocusedPane` where re-focusing the already-focused pane would immediately clear the review status; now skips acknowledgment when focus isn't changing

## Test plan
- [ ] Right-click a terminal pane → click "Mark as Unread" → green dot appears on the tab
- [ ] Right-click a tab header → click "Mark as Unread" → green dot appears on the tab
- [ ] Green dot persists until switching to a different tab/pane and back
- [ ] Normal agent lifecycle indicators (working/permission/review) still behave correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds “Mark as Unread” to the terminal and tab header context menus to flag work for later review with the green dot. Also fixes a focus race so the indicator doesn’t clear when re-focusing the same pane.

- **New Features**
  - Terminal pane context menu: Mark as Unread sets the current pane status to "review" (green dot).
  - Tab header context menu: Mark as Unread sets all panes in the tab to "review".

- **Bug Fixes**
  - Prevent clearing "review" status when calling `setFocusedPane` on an already-focused pane, so the green dot persists until switching away.

<sup>Written for commit a8fcc846f611758153c0ed5ebcc2763dc812e3d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added "Mark as Unread" context menu action for group items and tab panes, enabling users to mark content as requiring review
- New context menu items with icon to indicate unread/review status

**Bug Fixes**
- Resolved an issue where refocusing an already-focused pane would unintentionally alter its status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->