### PR TITLE
ci: update Claude Code workflow models

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -48,7 +48,9 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          claude -p "$(cat .github/prompts/generate-changelog.md)" --allowedTools "Bash(git*)" "Bash(gh*)" "Bash(date*)" "Bash(ls*)" "Read" "Write" "Edit" "Glob" "Grep"
+          claude -p "$(cat .github/prompts/generate-changelog.md)" \
+            --model sonnet \
+            --allowedTools "Bash(git*)" "Bash(gh*)" "Bash(date*)" "Bash(ls*)" "Read" "Write" "Edit" "Glob" "Grep"
 
       - name: Check for changes
         id: check-changes

--- a/.github/workflows/triage-issue.yml
+++ b/.github/workflows/triage-issue.yml
@@ -70,4 +70,6 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          claude -p "$(cat .github/prompts/triage-issue.md)" --dangerously-skip-permissions
+          claude -p "$(cat .github/prompts/triage-issue.md)" \
+            --model opus \
+            --dangerously-skip-permissions

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -48,7 +48,9 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          claude -p "$(cat .github/prompts/update-docs.md)" --allowedTools "Bash(git*)" "Bash(gh*)" "Bash(date*)" "Bash(ls*)" "Read" "Write" "Edit" "Glob" "Grep"
+          claude -p "$(cat .github/prompts/update-docs.md)" \
+            --model sonnet \
+            --allowedTools "Bash(git*)" "Bash(gh*)" "Bash(date*)" "Bash(ls*)" "Read" "Write" "Edit" "Glob" "Grep"
 
       - name: Check for changes
         id: check-changes


### PR DESCRIPTION
## Summary
- add explicit Claude Code model aliases to the GitHub workflow automations
- use `sonnet` for changelog and docs updates
- use `opus` for issue triage, which does reproduction and possible fixes

## Validation
- ran `claude -h` locally and confirmed the CLI supports `--model` aliases like `sonnet` and `opus`
- ran `claude -p --model sonnet --tools "" --no-session-persistence "Reply with exactly: OK"`
- ran `claude -p --model opus --tools "" --no-session-persistence "Reply with exactly: OK"`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin Claude Code models in CI to make runs consistent and better suited to each task. Use sonnet for changelog/docs and opus for issue triage.

- **Refactors**
  - Added `--model sonnet` to `.github/workflows/generate-changelog.yml` and `.github/workflows/update-docs.yml`; tools unchanged.
  - Added `--model opus` to `.github/workflows/triage-issue.yml`; keeps `--dangerously-skip-permissions`.

<sup>Written for commit d0d132f6a44f1b2cc8f3c8e605780a1bfb2285a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow configurations used in changelog generation, issue triage, and documentation update processes to enhance internal tooling reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->