### PR TITLE
feat(desktop): show project names in port workspace labels

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/hooks/usePortsData.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/hooks/usePortsData.ts
@@ -31,16 +31,28 @@ export function usePortsData() {
 
 	const ports = detectedPorts ?? [];
 
+	const { data: recentProjects } =
+		electronTrpc.projects.getRecents.useQuery();
+
 	const workspaceNames = useMemo(() => {
 		if (!allWorkspaces) return {};
+		const projectNames: Record<string, string> = {};
+		if (recentProjects) {
+			for (const p of recentProjects) {
+				projectNames[p.id] = p.name;
+			}
+		}
 		return allWorkspaces.reduce(
 			(acc, ws) => {
-				acc[ws.id] = ws.name;
+				const projectName = projectNames[ws.projectId];
+				acc[ws.id] = projectName
+					? `${projectName}: ${ws.name}`
+					: ws.name;
 				return acc;
 			},
 			{} as Record<string, string>,
 		);
-	}, [allWorkspaces]);
+	}, [allWorkspaces, recentProjects]);
 
 	const workspacePortGroups = useMemo(() => {
 		const groupMap = new Map<string, EnrichedPort[]>();


### PR DESCRIPTION
## Summary
- Prefixes workspace names with their project name (e.g. `MyProject: main`) in the ports list sidebar
- Fetches recent projects via `projects.getRecents` query and builds a lookup map
- Helps distinguish ports when multiple projects have workspaces with the same name

<img width="247" height="223" alt="image" src="https://github.com/user-attachments/assets/7a51ac3c-4ce8-44bd-be78-0f08c3c850ce" />

## Test plan
- [x] Open the ports list sidebar with multiple projects active
- [x] Verify workspace labels show `ProjectName: WorkspaceName` format
- [x] Verify workspaces without a matching project still show just the workspace name

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports sidebar now shows project names before workspace names (e.g. "MyProject: main"). This makes it easier to tell ports apart across projects.

- **New Features**
  - Build a project lookup from `projects.getRecents` to format workspace labels.
  - Fallback to the workspace name when a project match is missing.

<sup>Written for commit 321ab57143816a23d93b51a8a8d328d1a415b317. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Workspace names in the sidebar now display with associated project name prefixes for recent projects, providing clearer identification of workspace-project relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->