### PR TITLE
feat(desktop): add custom port-check script support

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/ports/ports.ts
+++ b/apps/desktop/src/lib/trpc/routers/ports/ports.ts
@@ -2,9 +2,9 @@ import { workspaces } from "@superset/local-db";
 import { observable } from "@trpc/server/observable";
 import { eq } from "drizzle-orm";
 import { localDb } from "main/lib/local-db";
-import { loadStaticPorts } from "main/lib/static-ports";
+import { loadStaticPorts, runPortCheckScript } from "main/lib/static-ports";
 import { portManager } from "main/lib/terminal/port-manager";
-import type { DetectedPort, EnrichedPort } from "shared/types";
+import type { DetectedPort, EnrichedPort, ScriptPort } from "shared/types";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
 import { getWorkspacePath } from "../workspaces/utils/worktree";
@@ -13,41 +13,170 @@ type PortEvent =
 	| { type: "add"; port: DetectedPort }
 	| { type: "remove"; port: DetectedPort };
 
-function getLabelsForPath(worktreePath: string): Map<number, string> | null {
+interface StaticPortMetadata {
+	labels: Map<number, string>;
+	urls: Map<number, string>;
+	check: string | null;
+}
+
+function getStaticMetadataForPath(
+	worktreePath: string,
+): StaticPortMetadata | null {
 	const result = loadStaticPorts(worktreePath);
-	if (!result.exists || result.error || !result.ports) return null;
+	if (!result.exists || result.error || !result.ports) {
+		// Still return check command even if ports array is empty/missing
+		if (result.check) {
+			return {
+				labels: new Map(),
+				urls: new Map(),
+				check: result.check,
+			};
+		}
+		return null;
+	}
 
 	const labels = new Map<number, string>();
+	const urls = new Map<number, string>();
 	for (const p of result.ports) {
 		labels.set(p.port, p.label);
+		if (p.url) {
+			urls.set(p.port, p.url);
+		}
 	}
-	return labels;
+	return { labels, urls, check: result.check };
+}
+
+function applyScriptPortsToMetadata(
+	scriptPorts: ScriptPort[],
+	metadata: StaticPortMetadata,
+): void {
+	for (const sp of scriptPorts) {
+		if (sp.name && !metadata.labels.has(sp.port)) {
+			metadata.labels.set(sp.port, sp.name);
+		}
+		if (sp.url && !metadata.urls.has(sp.port)) {
+			metadata.urls.set(sp.port, sp.url);
+		}
+	}
+}
+
+function scriptPortToEnrichedPort(
+	sp: ScriptPort,
+	workspaceId: string,
+	metadata: StaticPortMetadata,
+): EnrichedPort {
+	return {
+		port: sp.port,
+		pid: sp.pid ?? 0,
+		processName: sp.name ?? "unknown",
+		paneId: "",
+		workspaceId,
+		detectedAt: Date.now(),
+		address: "0.0.0.0",
+		label: metadata.labels.get(sp.port) ?? sp.name ?? null,
+		url: metadata.urls.get(sp.port) ?? sp.url ?? null,
+	};
+}
+
+interface WorkspaceContext {
+	metadata: StaticPortMetadata | null;
+	wsPath: string | null;
+	scriptPorts: ScriptPort[];
+}
+
+function getWorkspaceContext(workspaceId: string): WorkspaceContext {
+	const ws = localDb
+		.select()
+		.from(workspaces)
+		.where(eq(workspaces.id, workspaceId))
+		.get();
+	const wsPath = ws ? getWorkspacePath(ws) : null;
+	const metadata = wsPath ? getStaticMetadataForPath(wsPath) : null;
+	return { metadata, wsPath, scriptPorts: [] };
 }
 
 export const createPortsRouter = () => {
 	return router({
-		getAll: publicProcedure.query((): EnrichedPort[] => {
+		getAll: publicProcedure.query(async (): Promise<EnrichedPort[]> => {
 			const detectedPorts = portManager.getAllPorts();
 
-			const labelCache = new Map<string, Map<number, string> | null>();
+			const contextCache = new Map<string, WorkspaceContext>();
 
-			return detectedPorts.map((port) => {
-				if (!labelCache.has(port.workspaceId)) {
-					const ws = localDb
-						.select()
-						.from(workspaces)
-						.where(eq(workspaces.id, port.workspaceId))
-						.get();
-					const wsPath = ws ? getWorkspacePath(ws) : null;
-					labelCache.set(
+			// Collect workspace contexts for detected ports
+			for (const port of detectedPorts) {
+				if (!contextCache.has(port.workspaceId)) {
+					contextCache.set(
 						port.workspaceId,
-						wsPath ? getLabelsForPath(wsPath) : null,
+						getWorkspaceContext(port.workspaceId),
 					);
 				}
+			}
 
-				const labels = labelCache.get(port.workspaceId);
-				return { ...port, label: labels?.get(port.port) ?? null };
+			// Also check ALL workspaces for check scripts (ports may not be
+			// detected via PID-tree, e.g. when running inside Zellij/tmux/Docker)
+			const allWorkspaces = localDb.select().from(workspaces).all();
+			for (const ws of allWorkspaces) {
+				if (contextCache.has(ws.id)) continue;
+				const wsPath = getWorkspacePath(ws);
+				if (!wsPath) continue;
+				const metadata = getStaticMetadataForPath(wsPath);
+				if (metadata?.check) {
+					contextCache.set(ws.id, {
+						metadata,
+						wsPath,
+						scriptPorts: [],
+					});
+				}
+			}
+
+			// Run check scripts in parallel
+			const scriptTasks: Promise<void>[] = [];
+			for (const [, ctx] of contextCache) {
+				if (ctx.metadata?.check && ctx.wsPath) {
+					const { check } = ctx.metadata;
+					const { wsPath } = ctx;
+					scriptTasks.push(
+						runPortCheckScript(check, wsPath).then((scriptPorts) => {
+							ctx.scriptPorts = scriptPorts;
+							if (ctx.metadata) {
+								applyScriptPortsToMetadata(scriptPorts, ctx.metadata);
+							}
+						}),
+					);
+				}
+			}
+			await Promise.all(scriptTasks);
+
+			// Build enriched ports from detected ports
+			const detectedPortKeys = new Set<string>();
+			const enrichedPorts: EnrichedPort[] = detectedPorts.map((port) => {
+				detectedPortKeys.add(`${port.workspaceId}:${port.port}`);
+				const ctx = contextCache.get(port.workspaceId);
+				const metadata = ctx?.metadata;
+				return {
+					...port,
+					label: metadata?.labels.get(port.port) ?? null,
+					url: metadata?.urls.get(port.port) ?? null,
+				};
 			});
+
+			// Add script-only ports (not already detected by PID-tree scanner)
+			for (const [workspaceId, ctx] of contextCache) {
+				for (const sp of ctx.scriptPorts) {
+					const key = `${workspaceId}:${sp.port}`;
+					if (detectedPortKeys.has(key)) continue;
+					detectedPortKeys.add(key);
+					enrichedPorts.push(
+						scriptPortToEnrichedPort(
+							sp,
+							workspaceId,
+							ctx.metadata ?? { labels: new Map(), urls: new Map(), check: null },
+						),
+					);
+				}
+			}
+
+			return enrichedPorts;
 		}),
 
 		subscribe: publicProcedure.subscription(() => {

--- a/apps/desktop/src/lib/trpc/routers/ports/ports.ts
+++ b/apps/desktop/src/lib/trpc/routers/ports/ports.ts
@@ -1,12 +1,12 @@
 import { workspaces } from "@superset/local-db";
 import { observable } from "@trpc/server/observable";
-import { eq } from "drizzle-orm";
 import { localDb } from "main/lib/local-db";
 import { loadStaticPorts, runPortCheckScript } from "main/lib/static-ports";
 import { portManager } from "main/lib/terminal/port-manager";
 import type { DetectedPort, EnrichedPort, ScriptPort } from "shared/types";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
+import { getWorkspace } from "../workspaces/utils/db-helpers";
 import { getWorkspacePath } from "../workspaces/utils/worktree";
 
 type PortEvent =
@@ -68,7 +68,7 @@ function scriptPortToEnrichedPort(
 	return {
 		port: sp.port,
 		pid: sp.pid ?? 0,
-		processName: sp.name ?? "unknown",
+		processName: sp.name ?? "",
 		paneId: "",
 		workspaceId,
 		detectedAt: Date.now(),
@@ -81,18 +81,34 @@ function scriptPortToEnrichedPort(
 interface WorkspaceContext {
 	metadata: StaticPortMetadata | null;
 	wsPath: string | null;
-	scriptPorts: ScriptPort[];
 }
 
 function getWorkspaceContext(workspaceId: string): WorkspaceContext {
-	const ws = localDb
-		.select()
-		.from(workspaces)
-		.where(eq(workspaces.id, workspaceId))
-		.get();
+	const ws = getWorkspace(workspaceId);
 	const wsPath = ws ? getWorkspacePath(ws) : null;
 	const metadata = wsPath ? getStaticMetadataForPath(wsPath) : null;
-	return { metadata, wsPath, scriptPorts: [] };
+	return { metadata, wsPath };
+}
+
+/** Simple TTL cache for script results per workspace */
+const SCRIPT_CACHE_TTL_MS = 5_000;
+const scriptCache = new Map<
+	string,
+	{ ports: ScriptPort[]; cachedAt: number }
+>();
+
+async function getCachedScriptPorts(
+	command: string,
+	wsPath: string,
+	workspaceId: string,
+): Promise<ScriptPort[]> {
+	const cached = scriptCache.get(workspaceId);
+	if (cached && Date.now() - cached.cachedAt < SCRIPT_CACHE_TTL_MS) {
+		return cached.ports;
+	}
+	const ports = await runPortCheckScript(command, wsPath);
+	scriptCache.set(workspaceId, { ports, cachedAt: Date.now() });
+	return ports;
 }
 
 export const createPortsRouter = () => {
@@ -121,25 +137,22 @@ export const createPortsRouter = () => {
 				if (!wsPath) continue;
 				const metadata = getStaticMetadataForPath(wsPath);
 				if (metadata?.check) {
-					contextCache.set(ws.id, {
-						metadata,
-						wsPath,
-						scriptPorts: [],
-					});
+					contextCache.set(ws.id, { metadata, wsPath });
 				}
 			}
 
-			// Run check scripts in parallel
+			// Run check scripts in parallel, collect results
+			const scriptResults = new Map<string, ScriptPort[]>();
 			const scriptTasks: Promise<void>[] = [];
-			for (const [, ctx] of contextCache) {
+			for (const [workspaceId, ctx] of contextCache) {
 				if (ctx.metadata?.check && ctx.wsPath) {
 					const { check } = ctx.metadata;
 					const { wsPath } = ctx;
 					scriptTasks.push(
-						runPortCheckScript(check, wsPath).then((scriptPorts) => {
-							ctx.scriptPorts = scriptPorts;
+						getCachedScriptPorts(check, wsPath, workspaceId).then((ports) => {
+							scriptResults.set(workspaceId, ports);
 							if (ctx.metadata) {
-								applyScriptPortsToMetadata(scriptPorts, ctx.metadata);
+								applyScriptPortsToMetadata(ports, ctx.metadata);
 							}
 						}),
 					);
@@ -161,8 +174,9 @@ export const createPortsRouter = () => {
 			});
 
 			// Add script-only ports (not already detected by PID-tree scanner)
-			for (const [workspaceId, ctx] of contextCache) {
-				for (const sp of ctx.scriptPorts) {
+			for (const [workspaceId, ports] of scriptResults) {
+				const ctx = contextCache.get(workspaceId);
+				for (const sp of ports) {
 					const key = `${workspaceId}:${sp.port}`;
 					if (detectedPortKeys.has(key)) continue;
 					detectedPortKeys.add(key);
@@ -170,7 +184,11 @@ export const createPortsRouter = () => {
 						scriptPortToEnrichedPort(
 							sp,
 							workspaceId,
-							ctx.metadata ?? { labels: new Map(), urls: new Map(), check: null },
+							ctx?.metadata ?? {
+								labels: new Map(),
+								urls: new Map(),
+								check: null,
+							},
 						),
 					);
 				}

--- a/apps/desktop/src/main/lib/static-ports/index.ts
+++ b/apps/desktop/src/main/lib/static-ports/index.ts
@@ -1,1 +1,2 @@
 export { loadStaticPorts } from "./loader";
+export { runPortCheckScript } from "./script-runner";

--- a/apps/desktop/src/main/lib/static-ports/loader.test.ts
+++ b/apps/desktop/src/main/lib/static-ports/loader.test.ts
@@ -23,7 +23,12 @@ describe("loadStaticPorts", () => {
 	test("returns exists: false when ports.json does not exist", () => {
 		rmSync(PORTS_FILE, { force: true });
 		const result = loadStaticPorts(WORKTREE_PATH);
-		expect(result).toEqual({ exists: false, ports: null, error: null });
+		expect(result).toEqual({
+			exists: false,
+			ports: null,
+			check: null,
+			error: null,
+		});
 	});
 
 	test("loads valid ports.json with single port", () => {
@@ -36,6 +41,7 @@ describe("loadStaticPorts", () => {
 		expect(result).toEqual({
 			exists: true,
 			ports: [{ port: 3000, label: "Frontend" }],
+			check: null,
 			error: null,
 		});
 	});
@@ -58,6 +64,7 @@ describe("loadStaticPorts", () => {
 				{ port: 8080, label: "API Server" },
 				{ port: 5432, label: "PostgreSQL" },
 			],
+			check: null,
 			error: null,
 		});
 	});
@@ -255,7 +262,151 @@ describe("loadStaticPorts", () => {
 		writeFileSync(PORTS_FILE, JSON.stringify({ ports: [] }));
 
 		const result = loadStaticPorts(WORKTREE_PATH);
-		expect(result).toEqual({ exists: true, ports: [], error: null });
+		expect(result).toEqual({
+			exists: true,
+			ports: [],
+			check: null,
+			error: null,
+		});
+	});
+
+	test("loads port entry with url", () => {
+		const config = {
+			ports: [
+				{
+					port: 5173,
+					label: "Web Client",
+					url: "https://local.tana.inc:5173",
+				},
+			],
+		};
+		writeFileSync(PORTS_FILE, JSON.stringify(config));
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result).toEqual({
+			exists: true,
+			ports: [
+				{
+					port: 5173,
+					label: "Web Client",
+					url: "https://local.tana.inc:5173",
+				},
+			],
+			check: null,
+			error: null,
+		});
+	});
+
+	test("omits url from result when not provided", () => {
+		const config = {
+			ports: [{ port: 3000, label: "Frontend" }],
+		};
+		writeFileSync(PORTS_FILE, JSON.stringify(config));
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result.ports?.[0]).toEqual({ port: 3000, label: "Frontend" });
+		expect("url" in (result.ports?.[0] ?? {})).toBe(false);
+	});
+
+	test("trims whitespace from url", () => {
+		const config = {
+			ports: [
+				{
+					port: 3000,
+					label: "Frontend",
+					url: "  https://example.com  ",
+				},
+			],
+		};
+		writeFileSync(PORTS_FILE, JSON.stringify(config));
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result.ports?.[0].url).toBe("https://example.com");
+	});
+
+	test("returns error when url is not a string", () => {
+		writeFileSync(
+			PORTS_FILE,
+			JSON.stringify({ ports: [{ port: 3000, label: "Test", url: 123 }] }),
+		);
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result.exists).toBe(true);
+		expect(result.ports).toBeNull();
+		expect(result.error).toBe("ports[0].url must be a string");
+	});
+
+	test("returns error when url is empty", () => {
+		writeFileSync(
+			PORTS_FILE,
+			JSON.stringify({ ports: [{ port: 3000, label: "Test", url: "" }] }),
+		);
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result.exists).toBe(true);
+		expect(result.ports).toBeNull();
+		expect(result.error).toBe("ports[0].url cannot be empty");
+	});
+
+	test("loads check command", () => {
+		const config = {
+			check: "pnpm polaris ps --json",
+			ports: [{ port: 3000, label: "Frontend" }],
+		};
+		writeFileSync(PORTS_FILE, JSON.stringify(config));
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result).toEqual({
+			exists: true,
+			ports: [{ port: 3000, label: "Frontend" }],
+			check: "pnpm polaris ps --json",
+			error: null,
+		});
+	});
+
+	test("returns check: null when not provided", () => {
+		const config = {
+			ports: [{ port: 3000, label: "Frontend" }],
+		};
+		writeFileSync(PORTS_FILE, JSON.stringify(config));
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result.check).toBeNull();
+	});
+
+	test("returns error when check is not a string", () => {
+		writeFileSync(
+			PORTS_FILE,
+			JSON.stringify({ check: 123, ports: [{ port: 3000, label: "Test" }] }),
+		);
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result.exists).toBe(true);
+		expect(result.ports).toBeNull();
+		expect(result.error).toBe("'check' field must be a string");
+	});
+
+	test("returns error when check is empty", () => {
+		writeFileSync(
+			PORTS_FILE,
+			JSON.stringify({ check: "", ports: [{ port: 3000, label: "Test" }] }),
+		);
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result.exists).toBe(true);
+		expect(result.ports).toBeNull();
+		expect(result.error).toBe("'check' field cannot be empty");
+	});
+
+	test("trims whitespace from check command", () => {
+		const config = {
+			check: "  pnpm ps --json  ",
+			ports: [],
+		};
+		writeFileSync(PORTS_FILE, JSON.stringify(config));
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result.check).toBe("pnpm ps --json");
 	});
 });
 

--- a/apps/desktop/src/main/lib/static-ports/loader.ts
+++ b/apps/desktop/src/main/lib/static-ports/loader.ts
@@ -6,10 +6,12 @@ import type { StaticPortsResult } from "shared/types";
 interface PortEntry {
 	port: unknown;
 	label: unknown;
+	url?: unknown;
 }
 
 interface PortsConfig {
 	ports: unknown;
+	check?: unknown;
 }
 
 /**
@@ -23,7 +25,7 @@ function validatePortEntry(
 	entry: PortEntry,
 	index: number,
 ):
-	| { valid: true; port: number; label: string }
+	| { valid: true; port: number; label: string; url?: string }
 	| { valid: false; error: string } {
 	if (typeof entry !== "object" || entry === null) {
 		return { valid: false, error: `ports[${index}] must be an object` };
@@ -64,7 +66,29 @@ function validatePortEntry(
 		return { valid: false, error: `ports[${index}].label cannot be empty` };
 	}
 
-	return { valid: true, port, label: label.trim() };
+	const result: { valid: true; port: number; label: string; url?: string } = {
+		valid: true,
+		port,
+		label: label.trim(),
+	};
+
+	if ("url" in entry && entry.url !== undefined) {
+		if (typeof entry.url !== "string") {
+			return {
+				valid: false,
+				error: `ports[${index}].url must be a string`,
+			};
+		}
+		if (entry.url.trim() === "") {
+			return {
+				valid: false,
+				error: `ports[${index}].url cannot be empty`,
+			};
+		}
+		result.url = entry.url.trim();
+	}
+
+	return result;
 }
 
 /**
@@ -81,7 +105,7 @@ export function loadStaticPorts(worktreePath: string): StaticPortsResult {
 	);
 
 	if (!existsSync(portsPath)) {
-		return { exists: false, ports: null, error: null };
+		return { exists: false, ports: null, check: null, error: null };
 	}
 
 	let content: string;
@@ -92,6 +116,7 @@ export function loadStaticPorts(worktreePath: string): StaticPortsResult {
 		return {
 			exists: true,
 			ports: null,
+			check: null,
 			error: `Failed to read ports.json: ${message}`,
 		};
 	}
@@ -104,6 +129,7 @@ export function loadStaticPorts(worktreePath: string): StaticPortsResult {
 		return {
 			exists: true,
 			ports: null,
+			check: null,
 			error: `Invalid JSON in ports.json: ${message}`,
 		};
 	}
@@ -112,6 +138,7 @@ export function loadStaticPorts(worktreePath: string): StaticPortsResult {
 		return {
 			exists: true,
 			ports: null,
+			check: null,
 			error: "ports.json must contain a JSON object",
 		};
 	}
@@ -120,6 +147,7 @@ export function loadStaticPorts(worktreePath: string): StaticPortsResult {
 		return {
 			exists: true,
 			ports: null,
+			check: null,
 			error: "ports.json is missing required field 'ports'",
 		};
 	}
@@ -128,24 +156,55 @@ export function loadStaticPorts(worktreePath: string): StaticPortsResult {
 		return {
 			exists: true,
 			ports: null,
+			check: null,
 			error: "'ports' field must be an array",
 		};
 	}
 
-	const validatedPorts: Array<{ port: number; label: string }> = [];
+	// Validate optional 'check' field
+	let check: string | null = null;
+	if ("check" in parsed && parsed.check !== undefined) {
+		if (typeof parsed.check !== "string") {
+			return {
+				exists: true,
+				ports: null,
+				check: null,
+				error: "'check' field must be a string",
+			};
+		}
+		if (parsed.check.trim() === "") {
+			return {
+				exists: true,
+				ports: null,
+				check: null,
+				error: "'check' field cannot be empty",
+			};
+		}
+		check = parsed.check.trim();
+	}
+
+	const validatedPorts: Array<{ port: number; label: string; url?: string }> =
+		[];
 
 	for (let i = 0; i < parsed.ports.length; i++) {
 		const entry = parsed.ports[i] as PortEntry;
 		const result = validatePortEntry(entry, i);
 
 		if (!result.valid) {
-			return { exists: true, ports: null, error: result.error };
+			return { exists: true, ports: null, check: null, error: result.error };
 		}
 
-		validatedPorts.push({ port: result.port, label: result.label });
+		const portEntry: { port: number; label: string; url?: string } = {
+			port: result.port,
+			label: result.label,
+		};
+		if (result.url) {
+			portEntry.url = result.url;
+		}
+		validatedPorts.push(portEntry);
 	}
 
-	return { exists: true, ports: validatedPorts, error: null };
+	return { exists: true, ports: validatedPorts, check, error: null };
 }
 
 /**

--- a/apps/desktop/src/main/lib/static-ports/script-runner.test.ts
+++ b/apps/desktop/src/main/lib/static-ports/script-runner.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runPortCheckScript } from "./script-runner";
+
+const TEST_DIR = join(tmpdir(), `superset-test-script-runner-${process.pid}`);
+
+describe("runPortCheckScript", () => {
+	beforeEach(() => {
+		mkdirSync(TEST_DIR, { recursive: true });
+	});
+
+	afterEach(() => {
+		if (existsSync(TEST_DIR)) {
+			rmSync(TEST_DIR, { recursive: true, force: true });
+		}
+	});
+
+	test("parses valid JSON array output", async () => {
+		const script = join(TEST_DIR, "check.sh");
+		writeFileSync(
+			script,
+			'#!/bin/sh\necho \'[{"port": 3000, "name": "Frontend", "url": "https://local.dev:3000"}]\'',
+		);
+		await Bun.write(script, await Bun.file(script).text());
+		const { execSync } = await import("node:child_process");
+		execSync(`chmod +x ${script}`);
+
+		const result = await runPortCheckScript(script, TEST_DIR);
+		expect(result).toEqual([
+			{ port: 3000, name: "Frontend", url: "https://local.dev:3000" },
+		]);
+	});
+
+	test("parses output with multiple ports", async () => {
+		const script = join(TEST_DIR, "check.sh");
+		writeFileSync(
+			script,
+			`#!/bin/sh
+echo '[{"port": 3000, "name": "Web"}, {"port": 8000, "name": "API", "pid": 12345}]'`,
+		);
+		const { execSync } = await import("node:child_process");
+		execSync(`chmod +x ${script}`);
+
+		const result = await runPortCheckScript(script, TEST_DIR);
+		expect(result).toEqual([
+			{ port: 3000, name: "Web" },
+			{ port: 8000, name: "API", pid: 12345 },
+		]);
+	});
+
+	test("returns empty array for empty stdout", async () => {
+		const script = join(TEST_DIR, "check.sh");
+		writeFileSync(script, "#!/bin/sh\necho ''");
+		const { execSync } = await import("node:child_process");
+		execSync(`chmod +x ${script}`);
+
+		const result = await runPortCheckScript(script, TEST_DIR);
+		expect(result).toEqual([]);
+	});
+
+	test("returns empty array for non-JSON output", async () => {
+		const script = join(TEST_DIR, "check.sh");
+		writeFileSync(script, "#!/bin/sh\necho 'not json'");
+		const { execSync } = await import("node:child_process");
+		execSync(`chmod +x ${script}`);
+
+		const result = await runPortCheckScript(script, TEST_DIR);
+		expect(result).toEqual([]);
+	});
+
+	test("returns empty array for non-array JSON", async () => {
+		const script = join(TEST_DIR, "check.sh");
+		writeFileSync(script, "#!/bin/sh\necho '{\"port\": 3000}'");
+		const { execSync } = await import("node:child_process");
+		execSync(`chmod +x ${script}`);
+
+		const result = await runPortCheckScript(script, TEST_DIR);
+		expect(result).toEqual([]);
+	});
+
+	test("skips invalid entries in array", async () => {
+		const script = join(TEST_DIR, "check.sh");
+		writeFileSync(
+			script,
+			`#!/bin/sh
+echo '[{"port": 3000, "name": "Valid"}, "invalid", {"port": "bad"}, {"port": 8000}]'`,
+		);
+		const { execSync } = await import("node:child_process");
+		execSync(`chmod +x ${script}`);
+
+		const result = await runPortCheckScript(script, TEST_DIR);
+		expect(result).toEqual([{ port: 3000, name: "Valid" }, { port: 8000 }]);
+	});
+
+	test("returns empty array when command fails", async () => {
+		const result = await runPortCheckScript(
+			"nonexistent-command-xyz",
+			TEST_DIR,
+		);
+		expect(result).toEqual([]);
+	});
+
+	test("runs command with workspace path as cwd", async () => {
+		const subdir = join(TEST_DIR, "workspace");
+		mkdirSync(subdir, { recursive: true });
+		const script = join(TEST_DIR, "check.sh");
+		writeFileSync(
+			script,
+			`#!/bin/sh
+echo "[{\\"port\\": 3000, \\"name\\": \\"$(basename $(pwd))\\"}]"`,
+		);
+		const { execSync } = await import("node:child_process");
+		execSync(`chmod +x ${script}`);
+
+		const result = await runPortCheckScript(script, subdir);
+		expect(result).toEqual([{ port: 3000, name: "workspace" }]);
+	});
+
+	test("coerces string pid to number", async () => {
+		const script = join(TEST_DIR, "check.sh");
+		writeFileSync(
+			script,
+			`#!/bin/sh
+echo '[{"port": 5050, "name": "API", "pid": "45763"}]'`,
+		);
+		const { execSync } = await import("node:child_process");
+		execSync(`chmod +x ${script}`);
+
+		const result = await runPortCheckScript(script, TEST_DIR);
+		expect(result).toEqual([{ port: 5050, name: "API", pid: 45763 }]);
+	});
+
+	test("skips ports outside valid range", async () => {
+		const script = join(TEST_DIR, "check.sh");
+		writeFileSync(
+			script,
+			`#!/bin/sh
+echo '[{"port": 0}, {"port": 65536}, {"port": 3000, "name": "Valid"}]'`,
+		);
+		const { execSync } = await import("node:child_process");
+		execSync(`chmod +x ${script}`);
+
+		const result = await runPortCheckScript(script, TEST_DIR);
+		expect(result).toEqual([{ port: 3000, name: "Valid" }]);
+	});
+});

--- a/apps/desktop/src/main/lib/static-ports/script-runner.ts
+++ b/apps/desktop/src/main/lib/static-ports/script-runner.ts
@@ -1,0 +1,73 @@
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import type { ScriptPort } from "shared/types";
+
+const execAsync = promisify(exec);
+
+const EXEC_TIMEOUT_MS = 5000;
+
+function validateScriptPort(entry: unknown, _index: number): ScriptPort | null {
+	if (typeof entry !== "object" || entry === null) return null;
+
+	const obj = entry as Record<string, unknown>;
+
+	if (typeof obj.port !== "number" || !Number.isInteger(obj.port)) return null;
+	if (obj.port < 1 || obj.port > 65535) return null;
+
+	const result: ScriptPort = { port: obj.port };
+
+	if (typeof obj.name === "string" && obj.name.trim()) {
+		result.name = obj.name.trim();
+	}
+	if (typeof obj.url === "string" && obj.url.trim()) {
+		result.url = obj.url.trim();
+	}
+	if (typeof obj.pid === "number" && Number.isInteger(obj.pid)) {
+		result.pid = obj.pid;
+	} else if (typeof obj.pid === "string") {
+		const parsed = Number.parseInt(obj.pid, 10);
+		if (!Number.isNaN(parsed) && parsed > 0) {
+			result.pid = parsed;
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Run a custom port-check script and parse its JSON output.
+ * Returns an empty array on any error (non-blocking).
+ */
+export async function runPortCheckScript(
+	command: string,
+	workspacePath: string,
+): Promise<ScriptPort[]> {
+	try {
+		const { stdout } = await execAsync(command, {
+			cwd: workspacePath,
+			timeout: EXEC_TIMEOUT_MS,
+			maxBuffer: 1024 * 1024,
+		});
+
+		const trimmed = stdout.trim();
+		if (!trimmed) return [];
+
+		const parsed: unknown = JSON.parse(trimmed);
+		if (!Array.isArray(parsed)) {
+			console.warn("[PortCheckScript] Expected JSON array from check command");
+			return [];
+		}
+
+		const ports: ScriptPort[] = [];
+		for (let i = 0; i < parsed.length; i++) {
+			const validated = validateScriptPort(parsed[i], i);
+			if (validated) {
+				ports.push(validated);
+			}
+		}
+		return ports;
+	} catch (error) {
+		console.warn("[PortCheckScript] Check command failed:", error);
+		return [];
+	}
+}

--- a/apps/desktop/src/main/lib/static-ports/script-runner.ts
+++ b/apps/desktop/src/main/lib/static-ports/script-runner.ts
@@ -6,7 +6,7 @@ const execAsync = promisify(exec);
 
 const EXEC_TIMEOUT_MS = 5000;
 
-function validateScriptPort(entry: unknown, _index: number): ScriptPort | null {
+function validateScriptPort(entry: unknown): ScriptPort | null {
 	if (typeof entry !== "object" || entry === null) return null;
 
 	const obj = entry as Record<string, unknown>;
@@ -46,7 +46,7 @@ export async function runPortCheckScript(
 		const { stdout } = await execAsync(command, {
 			cwd: workspacePath,
 			timeout: EXEC_TIMEOUT_MS,
-			maxBuffer: 1024 * 1024,
+			maxBuffer: 128 * 1024,
 		});
 
 		const trimmed = stdout.trim();
@@ -60,7 +60,7 @@ export async function runPortCheckScript(
 
 		const ports: ScriptPort[] = [];
 		for (let i = 0; i < parsed.length; i++) {
-			const validated = validateScriptPort(parsed[i], i);
+			const validated = validateScriptPort(parsed[i]);
 			if (validated) {
 				ports.push(validated);
 			}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/components/MergedPortBadge/MergedPortBadge.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/components/MergedPortBadge/MergedPortBadge.tsx
@@ -47,7 +47,7 @@ export function MergedPortBadge({ port }: MergedPortBadgeProps) {
 	};
 
 	const handleOpenInBrowser = () => {
-		const url = `http://localhost:${port.port}`;
+		const url = port.url ?? `http://localhost:${port.port}`;
 
 		if (openLinksInApp) {
 			navigateToWorkspace(port.workspaceId, navigate);
@@ -98,7 +98,7 @@ export function MergedPortBadge({ port }: MergedPortBadgeProps) {
 					<div
 						className={`font-mono ${port.label ? "text-muted-foreground" : "font-medium"}`}
 					>
-						localhost:{port.port}
+						{port.url ?? `localhost:${port.port}`}
 					</div>
 					{(port.processName || port.pid != null) && (
 						<div className="text-muted-foreground">

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/components/MergedPortBadge/MergedPortBadge.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/components/MergedPortBadge/MergedPortBadge.tsx
@@ -83,16 +83,15 @@ export function MergedPortBadge({ port }: MergedPortBadgeProps) {
 					>
 						<LuExternalLink className="size-3.5" strokeWidth={STROKE_WIDTH} />
 					</button>
-					{canKill && (
-						<button
-							type="button"
-							onClick={handleClose}
-							aria-label={`Close ${port.label || `port ${port.port}`}`}
-							className="opacity-0 group-hover:opacity-100 pr-1 transition-opacity text-muted-foreground hover:text-primary focus-visible:opacity-100 focus-visible:outline-none"
-						>
-							<LuX className="size-3.5" strokeWidth={STROKE_WIDTH} />
-						</button>
-					)}
+					<button
+						type="button"
+						onClick={handleClose}
+						disabled={!canKill}
+						aria-label={`Close ${port.label || `port ${port.port}`}`}
+						className={`opacity-0 group-hover:opacity-100 pr-1 transition-opacity focus-visible:opacity-100 focus-visible:outline-none ${canKill ? "text-muted-foreground hover:text-primary" : "text-muted-foreground/40 cursor-default"}`}
+					>
+						<LuX className="size-3.5" strokeWidth={STROKE_WIDTH} />
+					</button>
 				</div>
 			</TooltipTrigger>
 			<TooltipContent side="top" sideOffset={6} showArrow={false}>
@@ -109,9 +108,13 @@ export function MergedPortBadge({ port }: MergedPortBadgeProps) {
 							{port.pid > 0 && ` (pid ${port.pid})`}
 						</div>
 					)}
-					{canJumpToTerminal && (
+					{canJumpToTerminal ? (
 						<div className="text-muted-foreground/70 text-[10px]">
 							Click to open workspace
+						</div>
+					) : (
+						<div className="text-muted-foreground/70 text-[10px]">
+							Detected via check script
 						</div>
 					)}
 				</div>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/components/MergedPortBadge/MergedPortBadge.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/components/MergedPortBadge/MergedPortBadge.tsx
@@ -34,6 +34,7 @@ export function MergedPortBadge({ port }: MergedPortBadgeProps) {
 	);
 
 	const canJumpToTerminal = !!port.paneId;
+	const canKill = !!port.paneId;
 
 	const handleClick = () => {
 		if (!port.paneId) return;
@@ -82,14 +83,16 @@ export function MergedPortBadge({ port }: MergedPortBadgeProps) {
 					>
 						<LuExternalLink className="size-3.5" strokeWidth={STROKE_WIDTH} />
 					</button>
-					<button
-						type="button"
-						onClick={handleClose}
-						aria-label={`Close ${port.label || `port ${port.port}`}`}
-						className="opacity-0 group-hover:opacity-100 pr-1 transition-opacity text-muted-foreground hover:text-primary focus-visible:opacity-100 focus-visible:outline-none"
-					>
-						<LuX className="size-3.5" strokeWidth={STROKE_WIDTH} />
-					</button>
+					{canKill && (
+						<button
+							type="button"
+							onClick={handleClose}
+							aria-label={`Close ${port.label || `port ${port.port}`}`}
+							className="opacity-0 group-hover:opacity-100 pr-1 transition-opacity text-muted-foreground hover:text-primary focus-visible:opacity-100 focus-visible:outline-none"
+						>
+							<LuX className="size-3.5" strokeWidth={STROKE_WIDTH} />
+						</button>
+					)}
 				</div>
 			</TooltipTrigger>
 			<TooltipContent side="top" sideOffset={6} showArrow={false}>
@@ -100,10 +103,10 @@ export function MergedPortBadge({ port }: MergedPortBadgeProps) {
 					>
 						{port.url ?? `localhost:${port.port}`}
 					</div>
-					{(port.processName || port.pid != null) && (
+					{(port.processName || port.pid > 0) && (
 						<div className="text-muted-foreground">
 							{port.processName}
-							{port.pid != null && ` (pid ${port.pid})`}
+							{port.pid > 0 && ` (pid ${port.pid})`}
 						</div>
 					)}
 					{canJumpToTerminal && (

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/components/WorkspacePortGroup/WorkspacePortGroup.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/components/WorkspacePortGroup/WorkspacePortGroup.tsx
@@ -19,8 +19,10 @@ export function WorkspacePortGroup({ group }: WorkspacePortGroupProps) {
 		navigateToWorkspace(group.workspaceId, navigate);
 	};
 
+	const killablePorts = group.ports.filter((p) => !!p.paneId);
+
 	const handleCloseAll = () => {
-		killPorts(group.ports);
+		killPorts(killablePorts);
 	};
 
 	return (
@@ -38,13 +40,18 @@ export function WorkspacePortGroup({ group }: WorkspacePortGroupProps) {
 						<button
 							type="button"
 							onClick={handleCloseAll}
-							className="ml-auto p-0.5 rounded hover:bg-muted/50 text-muted-foreground hover:text-primary"
+							disabled={killablePorts.length === 0}
+							className={`ml-auto p-0.5 rounded text-muted-foreground ${killablePorts.length > 0 ? "hover:bg-muted/50 hover:text-primary" : "opacity-40 cursor-default"}`}
 						>
 							<LuX className="size-3" strokeWidth={STROKE_WIDTH} />
 						</button>
 					</TooltipTrigger>
 					<TooltipContent side="top" sideOffset={4}>
-						<p className="text-xs">Close all ports</p>
+						<p className="text-xs">
+							{killablePorts.length > 0
+								? "Close all ports"
+								: "Cannot close ports from check scripts"}
+						</p>
 					</TooltipContent>
 				</Tooltip>
 			</div>

--- a/apps/desktop/src/shared/types/ports.ts
+++ b/apps/desktop/src/shared/types/ports.ts
@@ -11,15 +11,26 @@ export interface DetectedPort {
 export interface StaticPort {
 	port: number;
 	label: string;
+	url?: string;
 	workspaceId: string;
 }
 
 export interface StaticPortsResult {
 	exists: boolean;
 	ports: Omit<StaticPort, "workspaceId">[] | null;
+	check: string | null;
 	error: string | null;
 }
 
 export interface EnrichedPort extends DetectedPort {
 	label: string | null;
+	url: string | null;
+}
+
+/** Output format from custom port-check scripts */
+export interface ScriptPort {
+	port: number;
+	name?: string;
+	url?: string;
+	pid?: number;
 }

--- a/scripts/test-port-check.sh
+++ b/scripts/test-port-check.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# Test script for port-check feature.
+# Fakes running services by spawning lightweight HTTP listeners,
+# and acts as the "check" command for .superset/ports.json.
+#
+# Usage:
+#   ./test-ports.sh start   — Spawn fake services on ports
+#   ./test-ports.sh stop    — Kill all fake services
+#   ./test-ports.sh --json  — Output port check JSON (for .superset/ports.json "check" field)
+#   ./test-ports.sh status  — Show which fake services are running
+
+PORTS=(9100 9101 9102 9103)
+NAMES=("API Server" "Web Client" "Platform" "LLM Proxy")
+URLS=("http://localhost:9100/api" "https://local.dev:9101" "http://localhost:9102" "http://localhost:9103")
+PID_DIR="/tmp/superset-test-ports"
+
+start_services() {
+  mkdir -p "$PID_DIR"
+  for i in "${!PORTS[@]}"; do
+    port="${PORTS[$i]}"
+    name="${NAMES[$i]}"
+
+    if [ -f "$PID_DIR/$port.pid" ] && kill -0 "$(cat "$PID_DIR/$port.pid")" 2>/dev/null; then
+      echo "  $name (port $port) — already running (pid $(cat "$PID_DIR/$port.pid"))"
+      continue
+    fi
+
+    # Spawn a minimal HTTP server that responds with the service name
+    bun -e "Bun.serve({ port: $port, fetch: () => new Response('$name running on port $port') })" &
+    echo $! > "$PID_DIR/$port.pid"
+    echo "  $name (port $port) — started (pid $!)"
+  done
+  echo ""
+  echo "Services started. Use './test-ports.sh --json' as your check command."
+  echo "Add to .superset/ports.json:"
+  echo '  { "check": "./test-ports.sh --json", "ports": [] }'
+}
+
+stop_services() {
+  if [ ! -d "$PID_DIR" ]; then
+    echo "No services running."
+    return
+  fi
+  for i in "${!PORTS[@]}"; do
+    port="${PORTS[$i]}"
+    name="${NAMES[$i]}"
+    if [ -f "$PID_DIR/$port.pid" ]; then
+      pid=$(cat "$PID_DIR/$port.pid")
+      if kill -0 "$pid" 2>/dev/null; then
+        kill "$pid" 2>/dev/null
+        echo "  $name (port $port) — stopped (pid $pid)"
+      else
+        echo "  $name (port $port) — already stopped"
+      fi
+      rm -f "$PID_DIR/$port.pid"
+    fi
+  done
+}
+
+print_json() {
+  first=true
+  echo "["
+  for i in "${!PORTS[@]}"; do
+    port="${PORTS[$i]}"
+    name="${NAMES[$i]}"
+    url="${URLS[$i]}"
+    pid=""
+
+    if [ -f "$PID_DIR/$port.pid" ]; then
+      stored_pid=$(cat "$PID_DIR/$port.pid")
+      if kill -0 "$stored_pid" 2>/dev/null; then
+        pid="$stored_pid"
+      fi
+    fi
+
+    # Only include running services
+    if [ -z "$pid" ]; then
+      continue
+    fi
+
+    if [ "$first" = true ]; then
+      first=false
+    else
+      echo ","
+    fi
+    printf '  {"name": "%s", "port": %d, "url": "%s", "pid": "%s"}' "$name" "$port" "$url" "$pid"
+  done
+  echo ""
+  echo "]"
+}
+
+show_status() {
+  running=0
+  for i in "${!PORTS[@]}"; do
+    port="${PORTS[$i]}"
+    name="${NAMES[$i]}"
+    if [ -f "$PID_DIR/$port.pid" ] && kill -0 "$(cat "$PID_DIR/$port.pid")" 2>/dev/null; then
+      echo "  ✓ $name (port $port) — pid $(cat "$PID_DIR/$port.pid")"
+      running=$((running + 1))
+    else
+      echo "  ✗ $name (port $port) — not running"
+    fi
+  done
+  echo ""
+  echo "$running/${#PORTS[@]} services running"
+}
+
+case "${1:-}" in
+  start)
+    echo "Starting fake services..."
+    start_services
+    ;;
+  stop)
+    echo "Stopping fake services..."
+    stop_services
+    ;;
+  --json)
+    print_json
+    ;;
+  status)
+    show_status
+    ;;
+  *)
+    echo "Usage: $0 {start|stop|--json|status}"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Add support for a `check` command in `.superset/ports.json` that runs a custom script to discover ports — solves port detection failures inside Zellij, tmux, and Docker where PID-tree scanning doesn't work
- Scripts output JSON arrays with port info (`port`, `name`, `url`, `pid`), and results are cached with a 5s TTL to avoid excessive shell spawns
- Add `url` field support on static port entries for custom URL overrides (e.g. `https://local.dev:3000`)
- Script-discovered ports show disabled kill buttons with explanatory tooltips since they can't be terminated via the app
- Include a test script (`scripts/test-port-check.sh`) for easy manual testing

<img width="247" height="325" alt="image" src="https://github.com/user-attachments/assets/23a05608-672f-48c7-a5b6-322ac3ffed10" />


## Test plan
- [x] Run `cd apps/desktop && bun test src/main/lib/static-ports/` — 44 tests should pass
- [x] Run `bun run typecheck` — should pass clean
- [x] Manual: run `./scripts/test-port-check.sh start` then verify ports appear in sidebar
- [x] Manual: verify kill button is disabled for script-detected ports with correct tooltip
- [x] Manual: verify "Open in browser" uses custom URL when provided
- [x] Manual: run `./scripts/test-port-check.sh stop` and verify ports disappear on next poll

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for a `check` script in `.superset/ports.json` to discover ports when PID scanning fails (e.g., Zellij, tmux, Docker). Also adds optional `url` overrides and improves the sidebar UX for script-detected ports.

- **New Features**
  - `check` command in `.superset/ports.json` runs a workspace script that outputs a JSON array of ports (`port`, `name`, `url`, `pid`); results are cached for 5s and merged with static labels/URLs, including ports missed by PID scans.
  - Runs check scripts in parallel across workspaces for faster aggregation.
  - Support `url` on static ports; used for display and “Open in browser”.
  - Script-detected ports show disabled kill buttons with an explanatory tooltip.
  - Adds `scripts/test-port-check.sh` for easy manual testing.

<sup>Written for commit 515d8051b301a6e53cfc7822cb38fa643ba361f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom port detection scripts to discover services beyond system process monitoring.
  * Ports can now display associated URLs for quick access.
  * Ports detected via check scripts are marked as read-only and cannot be closed from the application.
  * Enhanced port metadata with improved labeling and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->