### PR TITLE
fix(desktop): add close action for empty expanded changes view

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/InfiniteScrollView/InfiniteScrollView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/InfiniteScrollView/InfiniteScrollView.tsx
@@ -1,5 +1,7 @@
+import { Button } from "@superset/ui/button";
 import { useCallback, useMemo, useState } from "react";
 import { useChangesStore } from "renderer/stores/changes";
+import { SidebarMode, useSidebarStore } from "renderer/stores/sidebar-state";
 import type { GitChangesStatus } from "shared/changes-types";
 import { useScrollContext } from "../../context";
 import { sortFiles } from "../../utils";
@@ -33,6 +35,10 @@ export function InfiniteScrollView({
 		moveSection,
 		toggleSection: toggleCategory,
 	} = useChangesStore();
+	const isExpandedView = useSidebarStore(
+		(state) => state.currentMode === SidebarMode.Changes,
+	);
+	const setSidebarMode = useSidebarStore((state) => state.setMode);
 	const [collapsedFiles, setCollapsedFiles] = useState<Set<string>>(new Set());
 
 	const { stageFileMutation, unstageFileMutation, handleDiscard, isActioning } =
@@ -157,8 +163,17 @@ export function InfiniteScrollView({
 
 	if (!hasChanges) {
 		return (
-			<div className="flex items-center justify-center h-full text-muted-foreground">
-				No changes detected
+			<div className="flex h-full flex-col items-center justify-center gap-3 text-muted-foreground">
+				<div>No changes detected</div>
+				{isExpandedView ? (
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={() => setSidebarMode(SidebarMode.Tabs)}
+					>
+						Close expanded view
+					</Button>
+				) : null}
 			</div>
 		);
 	}


### PR DESCRIPTION
## Summary
- add a close button to the expanded changes empty state when no diffs are detected
- collapse back to the standard tabs view from that empty state
- keep the existing sidebar empty state unchanged

## Testing
- bunx biome check apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/InfiniteScrollView/InfiniteScrollView.tsx
- bun run --cwd apps/desktop typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Close expanded view” button to the empty state of the expanded Changes view when no diffs are detected, letting users collapse back to the standard tabs. The sidebar’s other empty states are unchanged.

<sup>Written for commit 8f872cf8bea398c0c925571ce5b470d631ca7ca2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a button to close the expanded changes view, making navigation easier.
  * Improved the layout of the no-changes interface with better spacing and alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->