### PR TITLE
fix(desktop): improve workspace auto-name fallback

### DIFF
--- a/apps/desktop/src/lib/ai/call-small-model.test.ts
+++ b/apps/desktop/src/lib/ai/call-small-model.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "bun:test";
+import { callSmallModel } from "./call-small-model";
+
+describe("callSmallModel", () => {
+	it("skips unsupported credentials and falls through to the next working provider", async () => {
+		const { result, attempts } = await callSmallModel({
+			providers: [
+				{
+					id: "openai",
+					name: "OpenAI",
+					resolveCredentials: () => ({
+						apiKey: "oauth-token",
+						kind: "oauth",
+						source: "auth-storage",
+					}),
+					isSupported: () => ({
+						supported: false,
+						reason: "unsupported oauth",
+					}),
+					createModel: () => "openai-model",
+				},
+				{
+					id: "anthropic",
+					name: "Anthropic",
+					resolveCredentials: () => ({
+						apiKey: "anthropic-token",
+						kind: "oauth",
+						source: "auth-storage",
+					}),
+					isSupported: () => ({ supported: true }),
+					createModel: () => "anthropic-model",
+				},
+			],
+			invoke: async ({ providerId, model }) =>
+				providerId === "anthropic" && model === "anthropic-model"
+					? "generated title"
+					: null,
+		});
+
+		expect(result).toBe("generated title");
+		expect(attempts).toEqual([
+			{
+				providerId: "openai",
+				providerName: "OpenAI",
+				credentialKind: "oauth",
+				credentialSource: "auth-storage",
+				outcome: "unsupported-credentials",
+				reason: "unsupported oauth",
+			},
+			{
+				providerId: "anthropic",
+				providerName: "Anthropic",
+				credentialKind: "oauth",
+				credentialSource: "auth-storage",
+				outcome: "succeeded",
+			},
+		]);
+	});
+
+	it("returns null after exhausting providers", async () => {
+		const { result, attempts } = await callSmallModel({
+			providers: [
+				{
+					id: "anthropic",
+					name: "Anthropic",
+					resolveCredentials: () => null,
+					isSupported: () => ({ supported: true }),
+					createModel: () => "unused",
+				},
+				{
+					id: "openai",
+					name: "OpenAI",
+					resolveCredentials: () => ({
+						apiKey: "api-key",
+						kind: "apiKey",
+						source: "runtime-env",
+					}),
+					isSupported: () => ({ supported: true }),
+					createModel: () => "openai-model",
+				},
+			],
+			invoke: async () => null,
+		});
+
+		expect(result).toBeNull();
+		expect(attempts).toEqual([
+			{
+				providerId: "anthropic",
+				providerName: "Anthropic",
+				outcome: "missing-credentials",
+			},
+			{
+				providerId: "openai",
+				providerName: "OpenAI",
+				credentialKind: "apiKey",
+				credentialSource: "runtime-env",
+				outcome: "empty-result",
+			},
+		]);
+	});
+
+	it("continues after a provider throws and returns the next successful result", async () => {
+		const { result, attempts } = await callSmallModel({
+			providers: [
+				{
+					id: "openai",
+					name: "OpenAI",
+					resolveCredentials: () => ({
+						apiKey: "api-key",
+						kind: "apiKey",
+						source: "runtime-env",
+					}),
+					isSupported: () => ({ supported: true }),
+					createModel: () => {
+						throw new Error("provider unavailable");
+					},
+				},
+				{
+					id: "anthropic",
+					name: "Anthropic",
+					resolveCredentials: () => ({
+						apiKey: "anthropic-key",
+						kind: "apiKey",
+						source: "runtime-env",
+					}),
+					isSupported: () => ({ supported: true }),
+					createModel: () => "anthropic-model",
+				},
+			],
+			invoke: async ({ providerId, model }) =>
+				providerId === "anthropic" && model === "anthropic-model"
+					? "fallback title"
+					: null,
+		});
+
+		expect(result).toBe("fallback title");
+		expect(attempts).toEqual([
+			{
+				providerId: "openai",
+				providerName: "OpenAI",
+				credentialKind: "apiKey",
+				credentialSource: "runtime-env",
+				outcome: "failed",
+				reason: "provider unavailable",
+			},
+			{
+				providerId: "anthropic",
+				providerName: "Anthropic",
+				credentialKind: "apiKey",
+				credentialSource: "runtime-env",
+				outcome: "succeeded",
+			},
+		]);
+	});
+});

--- a/apps/desktop/src/lib/ai/call-small-model.ts
+++ b/apps/desktop/src/lib/ai/call-small-model.ts
@@ -1,0 +1,160 @@
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { createOpenAI } from "@ai-sdk/openai";
+import {
+	type ClaudeCredentials,
+	getCredentialsFromAnySource as getAnthropicCredentialsFromAnySource,
+	getAnthropicProviderOptions,
+	getOpenAICredentialsFromAnySource,
+} from "@superset/chat/host";
+
+type SmallModelCredential = {
+	apiKey: string;
+	kind: "apiKey" | "oauth";
+	source: string;
+};
+
+export type SmallModelProviderId = "anthropic" | "openai";
+
+export interface SmallModelAttempt {
+	providerId: SmallModelProviderId;
+	providerName: string;
+	credentialKind?: SmallModelCredential["kind"];
+	credentialSource?: string;
+	outcome:
+		| "missing-credentials"
+		| "unsupported-credentials"
+		| "empty-result"
+		| "failed"
+		| "succeeded";
+	reason?: string;
+}
+
+export interface SmallModelInvocationContext {
+	providerId: SmallModelProviderId;
+	providerName: string;
+	model: unknown;
+	credentials: SmallModelCredential;
+}
+
+export interface SmallModelProvider<
+	TCredentials extends SmallModelCredential = SmallModelCredential,
+> {
+	id: SmallModelProviderId;
+	name: string;
+	resolveCredentials: () => TCredentials | null;
+	isSupported: (credentials: TCredentials) => {
+		supported: boolean;
+		reason?: string;
+	};
+	createModel: (credentials: TCredentials) => unknown | Promise<unknown>;
+}
+
+const DEFAULT_SMALL_MODEL_PROVIDERS: SmallModelProvider[] = [
+	{
+		id: "anthropic",
+		name: "Anthropic",
+		resolveCredentials: () => getAnthropicCredentialsFromAnySource(),
+		isSupported: () => ({ supported: true }),
+		createModel: (credentials) =>
+			createAnthropic(
+				getAnthropicProviderOptions(credentials as ClaudeCredentials),
+			)("claude-haiku-4-5-20251001"),
+	},
+	{
+		id: "openai",
+		name: "OpenAI",
+		resolveCredentials: () => getOpenAICredentialsFromAnySource(),
+		isSupported: (credentials) =>
+			credentials.kind === "apiKey"
+				? { supported: true }
+				: {
+						supported: false,
+						reason:
+							"OpenAI Codex OAuth credentials do not support the generic small-model path.",
+					},
+		createModel: (credentials) =>
+			createOpenAI({ apiKey: credentials.apiKey })("gpt-4o-mini"),
+	},
+];
+
+export async function callSmallModel<TResult>({
+	invoke,
+	providers = DEFAULT_SMALL_MODEL_PROVIDERS,
+}: {
+	invoke: (
+		context: SmallModelInvocationContext,
+	) => Promise<TResult | null | undefined>;
+	providers?: SmallModelProvider[];
+}): Promise<{
+	result: TResult | null;
+	attempts: SmallModelAttempt[];
+}> {
+	const attempts: SmallModelAttempt[] = [];
+
+	for (const provider of providers) {
+		const credentials = provider.resolveCredentials();
+		if (!credentials) {
+			attempts.push({
+				providerId: provider.id,
+				providerName: provider.name,
+				outcome: "missing-credentials",
+			});
+			continue;
+		}
+
+		const support = provider.isSupported(credentials);
+		if (!support.supported) {
+			attempts.push({
+				providerId: provider.id,
+				providerName: provider.name,
+				credentialKind: credentials.kind,
+				credentialSource: credentials.source,
+				outcome: "unsupported-credentials",
+				reason: support.reason,
+			});
+			continue;
+		}
+
+		try {
+			const model = await provider.createModel(credentials);
+			const result = await invoke({
+				providerId: provider.id,
+				providerName: provider.name,
+				model,
+				credentials,
+			});
+			if (result) {
+				attempts.push({
+					providerId: provider.id,
+					providerName: provider.name,
+					credentialKind: credentials.kind,
+					credentialSource: credentials.source,
+					outcome: "succeeded",
+				});
+				return { result, attempts };
+			}
+
+			attempts.push({
+				providerId: provider.id,
+				providerName: provider.name,
+				credentialKind: credentials.kind,
+				credentialSource: credentials.source,
+				outcome: "empty-result",
+			});
+		} catch (error) {
+			attempts.push({
+				providerId: provider.id,
+				providerName: provider.name,
+				credentialKind: credentials.kind,
+				credentialSource: credentials.source,
+				outcome: "failed",
+				reason: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}
+
+	return {
+		result: null,
+		attempts,
+	};
+}

--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
@@ -3,6 +3,10 @@ import { and, eq, isNull, not } from "drizzle-orm";
 import { track } from "main/lib/analytics";
 import { localDb } from "main/lib/local-db";
 import { workspaceInitManager } from "main/lib/workspace-init-manager";
+import {
+	createWorkspaceAutoRenameWarning,
+	type WorkspaceAutoRenameWarning,
+} from "shared/workspace-auto-rename-warning";
 import { z } from "zod";
 import { publicProcedure, router } from "../../..";
 import { attemptWorkspaceAutoRenameFromPrompt } from "../utils/ai-name";
@@ -412,7 +416,7 @@ export const createCreateProcedures = () => {
 							branch,
 							name: input.name ?? branch,
 						});
-						let autoRenameWarning: string | undefined;
+						let autoRenameWarning: WorkspaceAutoRenameWarning | undefined;
 						try {
 							const autoRenameResult =
 								await attemptWorkspaceAutoRenameFromPrompt({
@@ -428,7 +432,8 @@ export const createCreateProcedures = () => {
 								workspaceId: workspace.id,
 								error: error instanceof Error ? error.message : String(error),
 							});
-							autoRenameWarning = "Couldn't auto-name this workspace.";
+							autoRenameWarning =
+								createWorkspaceAutoRenameWarning("generation-failed");
 						}
 						activateProject(project);
 						const setupConfig = loadSetupConfig({

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/ai-name.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/ai-name.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, mock } from "bun:test";
+
+mock.module("lib/ai/call-small-model", () => ({
+	callSmallModel: mock(async () => ({
+		result: null,
+		attempts: [],
+	})),
+}));
+
+mock.module("@superset/chat/host", () => ({
+	generateTitleFromMessage: mock(async () => null),
+}));
+
+mock.module("main/lib/local-db", () => ({
+	localDb: {},
+}));
+
+mock.module("@superset/local-db", () => ({
+	workspaces: {},
+}));
+
+const { generateWorkspaceNameFromPrompt } = await import("./ai-name");
+
+describe("generateWorkspaceNameFromPrompt", () => {
+	it("falls back to a prompt-derived title when no providers are available", async () => {
+		await expect(
+			generateWorkspaceNameFromPrompt("  debug   prod rename failure  "),
+		).resolves.toBe("debug prod rename failure");
+	});
+});

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/ai-name.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/ai-name.ts
@@ -1,14 +1,13 @@
-import { createAnthropic } from "@ai-sdk/anthropic";
-import { createOpenAI } from "@ai-sdk/openai";
-import {
-	generateTitleFromMessage,
-	getCredentialsFromAnySource as getAnthropicCredentialsFromAnySource,
-	getAnthropicProviderOptions,
-	getOpenAICredentialsFromAnySource,
-} from "@superset/chat/host";
+import { generateTitleFromMessage } from "@superset/chat/host";
 import { workspaces } from "@superset/local-db";
 import { and, eq, isNull } from "drizzle-orm";
+import { callSmallModel } from "lib/ai/call-small-model";
 import { localDb } from "main/lib/local-db";
+import { deriveWorkspaceTitleFromPrompt } from "shared/utils/workspace-naming";
+import {
+	createWorkspaceAutoRenameWarning,
+	type WorkspaceAutoRenameWarning,
+} from "shared/workspace-auto-rename-warning";
 import { getWorkspaceAutoRenameDecision } from "./workspace-auto-rename";
 
 export type WorkspaceAutoRenameResult =
@@ -24,74 +23,55 @@ export type WorkspaceAutoRenameResult =
 				| "workspace-deleting"
 				| "workspace-named"
 				| "workspace-name-changed";
-			warning?: string;
+			warning?: WorkspaceAutoRenameWarning;
 	  };
-
-type AgentModel = Extract<
-	Parameters<typeof generateTitleFromMessage>[0],
-	{ agentModel: unknown }
->["agentModel"];
-type AnthropicCredentials = NonNullable<
-	ReturnType<typeof getAnthropicCredentialsFromAnySource>
->;
-type OpenAICredentials = NonNullable<
-	ReturnType<typeof getOpenAICredentialsFromAnySource>
->;
-
-interface TitleProvider {
-	name: "Anthropic" | "OpenAI";
-	agentId: string;
-	resolveCredentials: () => AnthropicCredentials | OpenAICredentials | null;
-	createModel: (
-		credentials: AnthropicCredentials | OpenAICredentials,
-	) => AgentModel;
-}
-
-const TITLE_PROVIDERS: TitleProvider[] = [
-	{
-		name: "Anthropic",
-		agentId: "workspace-namer-anthropic",
-		resolveCredentials: () => getAnthropicCredentialsFromAnySource(),
-		createModel: (credentials) =>
-			createAnthropic(getAnthropicProviderOptions(credentials))(
-				"claude-haiku-4-5-20251001",
-			),
-	},
-	{
-		name: "OpenAI",
-		agentId: "workspace-namer-openai",
-		resolveCredentials: () => getOpenAICredentialsFromAnySource(),
-		createModel: (credentials) =>
-			createOpenAI({ apiKey: credentials.apiKey })("gpt-4o-mini"),
-	},
-];
 
 export async function generateWorkspaceNameFromPrompt(
 	prompt: string,
 ): Promise<string | null> {
-	for (const provider of TITLE_PROVIDERS) {
-		const credentials = provider.resolveCredentials();
-		if (!credentials) {
-			continue;
-		}
-
-		try {
-			const title = await generateTitleFromMessage({
+	const { result, attempts } = await callSmallModel<string>({
+		invoke: async ({ providerId, providerName, model }) => {
+			return generateTitleFromMessage({
 				message: prompt,
-				agentModel: provider.createModel(credentials),
-				agentId: provider.agentId,
+				agentModel: model,
+				agentId: `workspace-namer-${providerId}`,
 				agentName: "Workspace Namer",
 				instructions: "You generate concise workspace titles.",
+				tracingContext: {
+					surface: "workspace-auto-name",
+					provider: providerName,
+				},
 			});
-			if (title) {
-				return title;
-			}
-		} catch (error) {
+		},
+	});
+	if (result) {
+		return result;
+	}
+
+	for (const attempt of attempts) {
+		if (attempt.outcome === "failed") {
 			console.error(
-				`[workspace-ai-name] ${provider.name} title generation failed`,
-				error,
+				`[workspace-ai-name] ${attempt.providerName} title generation failed`,
+				attempt.reason,
+			);
+			continue;
+		}
+		if (attempt.outcome === "unsupported-credentials") {
+			console.info(
+				`[workspace-ai-name] Skipping ${attempt.providerName} for title generation`,
+				{
+					reason: attempt.reason,
+					credentialKind: attempt.credentialKind,
+					credentialSource: attempt.credentialSource,
+				},
 			);
 		}
+	}
+
+	const fallbackTitle = deriveWorkspaceTitleFromPrompt(prompt);
+	if (fallbackTitle) {
+		console.info("[workspace-ai-name] Falling back to prompt-derived title");
+		return fallbackTitle;
 	}
 
 	return null;
@@ -111,15 +91,10 @@ export async function attemptWorkspaceAutoRenameFromPrompt({
 
 	const generatedName = await generateWorkspaceNameFromPrompt(cleanedPrompt);
 	if (!generatedName) {
-		const hasCredentials =
-			getAnthropicCredentialsFromAnySource() !== null ||
-			getOpenAICredentialsFromAnySource() !== null;
 		return {
 			status: "skipped",
-			reason: hasCredentials ? "generation-failed" : "missing-credentials",
-			warning: hasCredentials
-				? "Couldn't auto-name this workspace."
-				: "Couldn't auto-name this workspace because chat credentials aren't configured.",
+			reason: "generation-failed",
+			warning: createWorkspaceAutoRenameWarning("generation-failed"),
 		};
 	}
 

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/workspace-init.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/workspace-init.ts
@@ -4,6 +4,10 @@ import { track } from "main/lib/analytics";
 import { localDb } from "main/lib/local-db";
 import { workspaceInitManager } from "main/lib/workspace-init-manager";
 import type { WorkspaceInitStep } from "shared/types/workspace-init";
+import {
+	createWorkspaceAutoRenameWarning,
+	type WorkspaceAutoRenameWarning,
+} from "shared/workspace-auto-rename-warning";
 import { attemptWorkspaceAutoRenameFromPrompt } from "./ai-name";
 import { resolveWorkspaceBaseBranch } from "./base-branch";
 import { getBranchBaseConfig, setBranchBaseConfig } from "./base-branch-config";
@@ -53,7 +57,7 @@ export async function initializeWorkspaceWorktree({
 }: WorkspaceInitParams): Promise<void> {
 	const manager = workspaceInitManager;
 	const completeReadyState = async (): Promise<void> => {
-		let warning: string | undefined;
+		let warning: WorkspaceAutoRenameWarning | undefined;
 		try {
 			const autoRenameResult = await attemptWorkspaceAutoRenameFromPrompt({
 				workspaceId,
@@ -68,7 +72,7 @@ export async function initializeWorkspaceWorktree({
 				workspaceId,
 				error: error instanceof Error ? error.message : String(error),
 			});
-			warning = "Couldn't auto-name this workspace.";
+			warning = createWorkspaceAutoRenameWarning("generation-failed");
 		}
 
 		if (manager.isCancellationRequested(workspaceId)) {

--- a/apps/desktop/src/main/lib/workspace-init-manager.ts
+++ b/apps/desktop/src/main/lib/workspace-init-manager.ts
@@ -3,6 +3,7 @@ import type {
 	WorkspaceInitProgress,
 	WorkspaceInitStep,
 } from "shared/types/workspace-init";
+import type { WorkspaceAutoRenameWarning } from "shared/workspace-auto-rename-warning";
 
 interface InitJob {
 	workspaceId: string;
@@ -115,7 +116,7 @@ class WorkspaceInitManager extends EventEmitter {
 		step: WorkspaceInitStep,
 		message: string,
 		error?: string,
-		warning?: string,
+		warning?: WorkspaceAutoRenameWarning,
 	): void {
 		const job = this.jobs.get(workspaceId);
 		if (!job) {

--- a/apps/desktop/src/renderer/lib/show-workspace-auto-rename-warning-toast.ts
+++ b/apps/desktop/src/renderer/lib/show-workspace-auto-rename-warning-toast.ts
@@ -1,0 +1,27 @@
+import { toast } from "@superset/ui/sonner";
+import {
+	getWorkspaceAutoRenameWarningContent,
+	type WorkspaceAutoRenameWarning,
+} from "shared/workspace-auto-rename-warning";
+
+export function showWorkspaceAutoRenameWarningToast({
+	warning,
+	onOpenApiKeys,
+}: {
+	warning: WorkspaceAutoRenameWarning;
+	onOpenApiKeys?: () => void;
+}) {
+	const content = getWorkspaceAutoRenameWarningContent(warning.reason);
+
+	toast.warning(content.title, {
+		description: content.description,
+		...(onOpenApiKeys && content.primaryActionLabel
+			? {
+					action: {
+						label: content.primaryActionLabel,
+						onClick: onOpenApiKeys,
+					},
+				}
+			: {}),
+	});
+}

--- a/apps/desktop/src/renderer/react-query/workspaces/useCreateWorkspace.ts
+++ b/apps/desktop/src/renderer/react-query/workspaces/useCreateWorkspace.ts
@@ -1,7 +1,7 @@
-import { toast } from "@superset/ui/sonner";
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback, useRef } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { showWorkspaceAutoRenameWarningToast } from "renderer/lib/show-workspace-auto-rename-warning-toast";
 import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import type { PendingTerminalSetup } from "renderer/stores/workspace-init";
 import { useWorkspaceInitStore } from "renderer/stores/workspace-init";
@@ -66,8 +66,9 @@ export function useCreateWorkspace(options?: UseCreateWorkspaceOptions) {
 			}
 
 			if (!data.isInitializing && data.autoRenameWarning) {
-				toast.warning("Workspace created without auto-name", {
-					description: data.autoRenameWarning,
+				showWorkspaceAutoRenameWarningToast({
+					warning: data.autoRenameWarning,
+					onOpenApiKeys: () => navigate({ to: "/settings/api-keys" }),
 				});
 			}
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -16,6 +16,7 @@ import {
 	KeywordSearch,
 	useKeywordSearch,
 } from "renderer/screens/main/components/KeywordSearch";
+import { WorkspaceAutoRenameWarningNotice } from "renderer/screens/main/components/WorkspaceView/components/WorkspaceAutoRenameWarningNotice";
 import { WorkspaceInitializingView } from "renderer/screens/main/components/WorkspaceView/WorkspaceInitializingView";
 import { WorkspaceLayout } from "renderer/screens/main/components/WorkspaceView/WorkspaceLayout";
 import { useCreateOrOpenPR, usePRStatus } from "renderer/screens/main/hooks";
@@ -35,6 +36,7 @@ import {
 import {
 	useHasWorkspaceFailed,
 	useIsWorkspaceInitializing,
+	useWorkspaceInitProgress,
 } from "renderer/stores/workspace-init";
 
 const EMPTY_HISTORY_STACK: string[] = [];
@@ -105,6 +107,7 @@ function WorkspacePage() {
 	// Check if workspace is initializing or failed
 	const isInitializing = useIsWorkspaceInitializing(workspaceId);
 	const hasFailed = useHasWorkspaceFailed(workspaceId);
+	const initProgress = useWorkspaceInitProgress(workspaceId);
 
 	// Check for incomplete init after app restart
 	const gitStatus = workspace?.worktree?.gitStatus;
@@ -598,11 +601,21 @@ function WorkspacePage() {
 						isInterrupted={hasIncompleteInit && !isInitializing}
 					/>
 				) : (
-					<WorkspaceLayout
-						defaultExternalApp={defaultApp}
-						onOpenInApp={handleOpenInApp}
-						onOpenQuickOpen={handleQuickOpen}
-					/>
+					<>
+						{initProgress?.warning ? (
+							<div className="border-b border-border bg-background px-4 py-3">
+								<WorkspaceAutoRenameWarningNotice
+									reason={initProgress.warning.reason}
+									onOpenApiKeys={() => navigate({ to: "/settings/api-keys" })}
+								/>
+							</div>
+						) : null}
+						<WorkspaceLayout
+							defaultExternalApp={defaultApp}
+							onOpenInApp={handleOpenInApp}
+							onOpenQuickOpen={handleQuickOpen}
+						/>
+					</>
 				)}
 			</div>
 			<CommandPalette

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -1,5 +1,4 @@
 import { Button } from "@superset/ui/button";
-import { toast } from "@superset/ui/sonner";
 import { Spinner } from "@superset/ui/spinner";
 import {
 	createFileRoute,
@@ -18,6 +17,7 @@ import { useOnlineStatus } from "renderer/hooks/useOnlineStatus";
 import { authClient, getAuthToken } from "renderer/lib/auth-client";
 import { dragDropManager } from "renderer/lib/dnd";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { showWorkspaceAutoRenameWarningToast } from "renderer/lib/show-workspace-auto-rename-warning-toast";
 import { InitGitDialog } from "renderer/react-query/projects/InitGitDialog";
 import { WorkspaceInitEffects } from "renderer/screens/main/components/WorkspaceInitEffects";
 import { useHotkeysSync } from "renderer/stores/hotkeys";
@@ -64,8 +64,9 @@ function AuthenticatedLayout() {
 				!shownWorkspaceInitWarningsRef.current.has(progress.workspaceId)
 			) {
 				shownWorkspaceInitWarningsRef.current.add(progress.workspaceId);
-				toast.warning("Workspace created without auto-name", {
-					description: progress.warning,
+				showWorkspaceAutoRenameWarningToast({
+					warning: progress.warning,
+					onOpenApiKeys: () => navigate({ to: "/settings/api-keys" }),
 				});
 			}
 			if (progress.step === "ready" || progress.step === "failed") {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceInitializingView/WorkspaceInitializingView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceInitializingView/WorkspaceInitializingView.tsx
@@ -8,12 +8,14 @@ import {
 } from "@superset/ui/alert-dialog";
 import { Button } from "@superset/ui/button";
 import { cn } from "@superset/ui/utils";
+import { useNavigate } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 import { HiExclamationTriangle } from "react-icons/hi2";
 import { LuCheck, LuCircle, LuGitBranch, LuLoader } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useDeleteWorkspace } from "renderer/react-query/workspaces";
 import { deleteWithToast } from "renderer/routes/_authenticated/components/TeardownLogsDialog";
+import { WorkspaceAutoRenameWarningNotice } from "renderer/screens/main/components/WorkspaceView/components/WorkspaceAutoRenameWarningNotice";
 import {
 	useHasWorkspaceFailed,
 	useWorkspaceInitProgress,
@@ -59,6 +61,7 @@ export function WorkspaceInitializingView({
 	workspaceName,
 	isInterrupted = false,
 }: WorkspaceInitializingViewProps) {
+	const navigate = useNavigate();
 	const progress = useWorkspaceInitProgress(workspaceId);
 	const hasFailed = useHasWorkspaceFailed(workspaceId);
 	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -320,6 +323,14 @@ export function WorkspaceInitializingView({
 					</h2>
 					<p className="text-sm text-muted-foreground">{workspaceName}</p>
 				</div>
+
+				{progress?.warning ? (
+					<WorkspaceAutoRenameWarningNotice
+						reason={progress.warning.reason}
+						onOpenApiKeys={() => navigate({ to: "/settings/api-keys" })}
+						className="w-full text-left"
+					/>
+				) : null}
 
 				{/* Step list */}
 				<div className="w-full space-y-2">

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/WorkspaceAutoRenameWarningNotice/WorkspaceAutoRenameWarningNotice.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/WorkspaceAutoRenameWarningNotice/WorkspaceAutoRenameWarningNotice.tsx
@@ -1,0 +1,51 @@
+import { Alert, AlertDescription, AlertTitle } from "@superset/ui/alert";
+import { Button } from "@superset/ui/button";
+import { cn } from "@superset/ui/utils";
+import { HiExclamationTriangle } from "react-icons/hi2";
+import {
+	getWorkspaceAutoRenameWarningContent,
+	type WorkspaceAutoRenameWarningReason,
+} from "shared/workspace-auto-rename-warning";
+
+interface WorkspaceAutoRenameWarningNoticeProps {
+	reason: WorkspaceAutoRenameWarningReason;
+	onOpenApiKeys?: () => void;
+	className?: string;
+}
+
+export function WorkspaceAutoRenameWarningNotice({
+	reason,
+	onOpenApiKeys,
+	className,
+}: WorkspaceAutoRenameWarningNoticeProps) {
+	const content = getWorkspaceAutoRenameWarningContent(reason);
+
+	return (
+		<Alert
+			className={cn(
+				"border-amber-500/25 bg-amber-500/6 text-amber-950 dark:text-amber-50",
+				className,
+			)}
+		>
+			<HiExclamationTriangle className="text-amber-600 dark:text-amber-400" />
+			<AlertTitle className="text-amber-900 dark:text-amber-100">
+				{content.title}
+			</AlertTitle>
+			<AlertDescription className="gap-3 text-amber-900/80 dark:text-amber-100/80">
+				<p>{content.description}</p>
+				<div className="flex flex-wrap gap-2">
+					{onOpenApiKeys && content.primaryActionLabel ? (
+						<Button size="sm" variant="outline" onClick={onOpenApiKeys}>
+							{content.primaryActionLabel}
+						</Button>
+					) : null}
+				</div>
+				<ul className="list-disc space-y-1 pl-4">
+					{content.suggestedActions.map((action) => (
+						<li key={action}>{action}</li>
+					))}
+				</ul>
+			</AlertDescription>
+		</Alert>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/WorkspaceAutoRenameWarningNotice/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/WorkspaceAutoRenameWarningNotice/index.ts
@@ -1,0 +1,1 @@
+export { WorkspaceAutoRenameWarningNotice } from "./WorkspaceAutoRenameWarningNotice";

--- a/apps/desktop/src/shared/types/workspace-init.ts
+++ b/apps/desktop/src/shared/types/workspace-init.ts
@@ -1,3 +1,5 @@
+import type { WorkspaceAutoRenameWarning } from "shared/workspace-auto-rename-warning";
+
 /**
  * Workspace initialization progress types.
  * Used for streaming progress updates during workspace creation.
@@ -20,7 +22,7 @@ export interface WorkspaceInitProgress {
 	step: WorkspaceInitStep;
 	message: string;
 	error?: string;
-	warning?: string;
+	warning?: WorkspaceAutoRenameWarning;
 }
 
 export const INIT_STEP_MESSAGES: Record<WorkspaceInitStep, string> = {

--- a/apps/desktop/src/shared/workspace-auto-rename-warning.test.ts
+++ b/apps/desktop/src/shared/workspace-auto-rename-warning.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import {
+	createWorkspaceAutoRenameWarning,
+	getWorkspaceAutoRenameWarningContent,
+} from "./workspace-auto-rename-warning";
+
+describe("workspace auto rename warning", () => {
+	test("creates a missing-credentials warning message", () => {
+		expect(createWorkspaceAutoRenameWarning("missing-credentials")).toEqual({
+			reason: "missing-credentials",
+			message:
+				"Couldn't auto-name this workspace because no chat API key is configured.",
+		});
+	});
+
+	test("returns actionable content for generation failures", () => {
+		expect(getWorkspaceAutoRenameWarningContent("generation-failed")).toEqual({
+			title: "Workspace auto-name failed",
+			description:
+				"Superset could not generate a workspace title. Common causes are an expired API key, missing model access, a provider error, or a network issue.",
+			suggestedActions: [
+				"Check your API key and provider access in Settings > API Keys.",
+				"Retry later or rename the workspace manually from the sidebar.",
+			],
+			primaryActionLabel: "Open API Keys",
+		});
+	});
+});

--- a/apps/desktop/src/shared/workspace-auto-rename-warning.ts
+++ b/apps/desktop/src/shared/workspace-auto-rename-warning.ts
@@ -1,0 +1,59 @@
+export type WorkspaceAutoRenameWarningReason =
+	| "missing-credentials"
+	| "generation-failed";
+
+export interface WorkspaceAutoRenameWarning {
+	reason: WorkspaceAutoRenameWarningReason;
+	message: string;
+}
+
+interface WorkspaceAutoRenameWarningContent {
+	title: string;
+	description: string;
+	suggestedActions: string[];
+	primaryActionLabel?: string;
+}
+
+const WARNING_MESSAGES: Record<WorkspaceAutoRenameWarningReason, string> = {
+	"missing-credentials":
+		"Couldn't auto-name this workspace because no chat API key is configured.",
+	"generation-failed": "Couldn't auto-name this workspace.",
+};
+
+export function createWorkspaceAutoRenameWarning(
+	reason: WorkspaceAutoRenameWarningReason,
+): WorkspaceAutoRenameWarning {
+	return {
+		reason,
+		message: WARNING_MESSAGES[reason],
+	};
+}
+
+export function getWorkspaceAutoRenameWarningContent(
+	reason: WorkspaceAutoRenameWarningReason,
+): WorkspaceAutoRenameWarningContent {
+	switch (reason) {
+		case "missing-credentials":
+			return {
+				title: "Workspace kept its branch name",
+				description:
+					"Superset could not auto-name this workspace because no OpenAI or Anthropic API key is configured.",
+				suggestedActions: [
+					"Add an API key in Settings > API Keys.",
+					"Rename the workspace manually from the sidebar if you want a custom title now.",
+				],
+				primaryActionLabel: "Open API Keys",
+			};
+		case "generation-failed":
+			return {
+				title: "Workspace auto-name failed",
+				description:
+					"Superset could not generate a workspace title. Common causes are an expired API key, missing model access, a provider error, or a network issue.",
+				suggestedActions: [
+					"Check your API key and provider access in Settings > API Keys.",
+					"Retry later or rename the workspace manually from the sidebar.",
+				],
+				primaryActionLabel: "Open API Keys",
+			};
+	}
+}


### PR DESCRIPTION
## Summary
- add a generic desktop `callSmallModel` helper that tries Anthropic and OpenAI in order, skips unsupported credential kinds, and falls back cleanly on provider failures
- keep workspace auto-naming on the first successful small-model result and fall back to a prompt-derived title instead of failing immediately
- improve the desktop UX for auto-name degradation with actionable warnings during initialization, on the workspace page, and in the toast action

## Testing
- bun test apps/desktop/src/lib/ai/call-small-model.test.ts apps/desktop/src/lib/trpc/routers/workspaces/utils/ai-name.test.ts apps/desktop/src/shared/workspace-auto-rename-warning.test.ts
- bunx biome check apps/desktop/src/lib/ai/call-small-model.ts apps/desktop/src/lib/ai/call-small-model.test.ts apps/desktop/src/lib/trpc/routers/workspaces/utils/ai-name.ts apps/desktop/src/lib/trpc/routers/workspaces/utils/ai-name.test.ts apps/desktop/src/shared/workspace-auto-rename-warning.test.ts packages/chat/package.json packages/chat/src/host/auth/openai/openai.ts packages/chat/src/host/auth/openai/index.ts packages/chat/src/host/index.ts
- bunx tsc -p packages/chat/tsconfig.json --noEmit
- bunx tsc -p apps/desktop/tsconfig.json --noEmit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves desktop workspace auto‑naming with a provider‑fallback small‑model helper and a clean fallback to a prompt‑derived title. Adds clear, actionable warnings in toasts, during initialization, and on the workspace page.

- **New Features**
  - Added `callSmallModel` helper that tries Anthropic then OpenAI, skips unsupported creds (e.g., OpenAI OAuth), logs attempt outcomes, and returns the first success (`@ai-sdk/anthropic`, `@ai-sdk/openai`).
  - Workspace naming now calls `generateTitleFromMessage` via the helper and falls back to a prompt‑derived title when models fail or return nothing.
  - Introduced `WorkspaceAutoRenameWarning` with reasons `missing-credentials` and `generation-failed`, surfaced:
    - During initialization (notice in Initializing view),
    - On the workspace page (banner),
    - And via a toast with “Open API Keys” action.
  - Wired warnings through create/init flows and types to carry structured data end‑to‑end.
  - Added tests for the helper, naming fallback, and warning content.

<sup>Written for commit 68efcd5e50d4adbe2a5bfaff90e0e18d6429c658. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New AI-powered framework supporting multiple providers (Anthropic and OpenAI) for intelligent workspace name generation.
  * Structured auto-rename warning system with actionable prompts directing users to configure missing API credentials.

* **Tests**
  * Unit tests covering AI provider fallback and error scenarios.
  * Tests validating workspace name generation with fallback mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->