### PR TITLE
feat(desktop): add delete workspace button to empty tab view

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/EmptyTabView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/EmptyTabView.tsx
@@ -5,9 +5,12 @@ import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useCallback, useMemo } from "react";
 import type { IconType } from "react-icons";
 import { BsTerminalPlus } from "react-icons/bs";
-import { LuExternalLink, LuSearch } from "react-icons/lu";
+import { LuExternalLink, LuSearch, LuTrash2 } from "react-icons/lu";
 import { TbMessageCirclePlus, TbWorld } from "react-icons/tb";
 import { getAppOption } from "renderer/components/OpenInExternalDropdown";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useWorkspaceDeleteHandler } from "renderer/react-query/workspaces";
+import { DeleteWorkspaceDialog } from "renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/DeleteWorkspaceDialog/DeleteWorkspaceDialog";
 import { useHotkeyDisplay } from "renderer/stores/hotkeys";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import { useTabsWithPresets } from "renderer/stores/tabs/useTabsWithPresets";
@@ -42,6 +45,12 @@ export function EmptyTabView({
 	const addBrowserTab = useTabsStore((s) => s.addBrowserTab);
 	const hasAiChat = useFeatureFlagEnabled(FEATURE_FLAGS.AI_CHAT);
 	const activeTheme = useTheme();
+
+	const { data: workspace } = electronTrpc.workspaces.get.useQuery({
+		id: workspaceId,
+	});
+	const { showDeleteDialog, setShowDeleteDialog, handleDeleteClick } =
+		useWorkspaceDeleteHandler();
 
 	const newGroupDisplay = useHotkeyDisplay("NEW_GROUP");
 	const newChatDisplay = useHotkeyDisplay("NEW_CHAT");
@@ -157,7 +166,26 @@ export function EmptyTabView({
 						/>
 					))}
 				</div>
+				{workspace && (
+					<button
+						type="button"
+						className="mx-auto mt-6 flex items-center gap-1 text-xs text-muted-foreground/50 transition-colors hover:text-muted-foreground"
+						onClick={handleDeleteClick}
+					>
+						<LuTrash2 className="size-3" />
+						Delete workspace
+					</button>
+				)}
 			</div>
+			{workspace && (
+				<DeleteWorkspaceDialog
+					workspaceId={workspaceId}
+					workspaceName={workspace.name}
+					workspaceType={workspace.type}
+					open={showDeleteDialog}
+					onOpenChange={setShowDeleteDialog}
+				/>
+			)}
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary
- Add a "Delete workspace" link to the empty state view (shown when all tabs are closed), so users can delete the current workspace without navigating to the sidebar.

## Why / Context
When a workspace has no open tabs, the empty state shows actions like "Open Terminal" and "Search Files" but no way to delete the workspace. Users had to find it in the sidebar or workspace list. This adds a low-emphasis shortcut right where you'd want it.

## How It Works
- Queries the current workspace via `electronTrpc.workspaces.get` to get name and type
- Renders a subtle text button (`text-xs text-muted-foreground/50`) with a small trash icon below the existing action buttons
- Reuses the existing `DeleteWorkspaceDialog` and `useWorkspaceDeleteHandler` hook — same confirmation flow with git status checks, uncommitted changes warnings, hide vs delete options

## Manual QA Checklist

### Delete Button
- [ ] Button appears below action buttons in empty tab view
- [ ] Button is visually subtle (doesn't compete with primary actions)
- [ ] Clicking opens the delete workspace confirmation dialog
- [ ] Dialog shows correct workspace name and type

### Dialog Behavior
- [ ] Worktree workspace: shows Cancel / Hide / Delete options
- [ ] Branch workspace: shows Cancel / Close options
- [ ] Git status warnings display correctly (uncommitted changes, unpushed commits)
- [ ] "Also delete local branch" checkbox works
- [ ] Deleting navigates away from the workspace

### Edge Cases
- [ ] Button doesn't render while workspace data is loading
- [ ] Works correctly after switching between workspaces

## Testing
- `bun run typecheck` — passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a Delete workspace action to the empty tab view so users can remove the current workspace without opening the sidebar. Uses the existing confirmation dialog and safety checks.

- **New Features**
  - Renders a subtle text button with a trash icon under existing actions (only after workspace loads).
  - Retrieves the current workspace via `electronTrpc.workspaces.get`.
  - Reuses `DeleteWorkspaceDialog` and `useWorkspaceDeleteHandler` for the confirmation flow (git warnings, hide vs delete options).

<sup>Written for commit f4f28dbff1abd700914d29dde8cc0488b894cbe9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added delete workspace functionality with a new delete button and confirmation dialog to prevent accidental deletion of workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->