### PR TITLE
feat(desktop): remove AI_CHAT feature flag

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/EmptyTabView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/EmptyTabView.tsx
@@ -1,7 +1,5 @@
 import type { ExternalApp } from "@superset/local-db";
-import { FEATURE_FLAGS } from "@superset/shared/constants";
 import { useParams } from "@tanstack/react-router";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useCallback, useMemo } from "react";
 import type { IconType } from "react-icons";
 import { BsTerminalPlus } from "react-icons/bs";
@@ -40,7 +38,6 @@ export function EmptyTabView({
 	const { addTab } = useTabsWithPresets();
 	const addChatMastraTab = useTabsStore((s) => s.addChatMastraTab);
 	const addBrowserTab = useTabsStore((s) => s.addBrowserTab);
-	const hasAiChat = useFeatureFlagEnabled(FEATURE_FLAGS.AI_CHAT);
 	const activeTheme = useTheme();
 
 	const newGroupDisplay = useHotkeyDisplay("NEW_GROUP");
@@ -77,17 +74,14 @@ export function EmptyTabView({
 				icon: BsTerminalPlus,
 				onClick: handleShowTerminal,
 			},
-		];
-
-		if (hasAiChat) {
-			baseActions.push({
+			{
 				id: "new-agent",
 				label: "Open Chat",
 				display: newChatDisplay,
 				icon: TbMessageCirclePlus,
 				onClick: handleNewAgent,
-			});
-		}
+			},
+		];
 
 		baseActions.push({
 			id: "open-browser",
@@ -120,7 +114,6 @@ export function EmptyTabView({
 		handleNewAgent,
 		handleOpenBrowser,
 		handleShowTerminal,
-		hasAiChat,
 		newBrowserDisplay,
 		newChatDisplay,
 		newGroupDisplay,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupStrip.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupStrip.tsx
@@ -1,9 +1,7 @@
 import type { TerminalPreset } from "@superset/local-db";
-import { FEATURE_FLAGS } from "@superset/shared/constants";
 import { eq, or } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useNavigate, useParams } from "@tanstack/react-router";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import {
 	useCallback,
 	useEffect,
@@ -54,7 +52,6 @@ export function GroupStrip() {
 	const { presets } = usePresets();
 	const navigate = useNavigate();
 
-	const hasAiChat = useFeatureFlagEnabled(FEATURE_FLAGS.AI_CHAT);
 	const scrollContainerRef = useRef<HTMLDivElement>(null);
 	const tabsTrackRef = useRef<HTMLDivElement>(null);
 	const [hasHorizontalOverflow, setHasHorizontalOverflow] = useState(false);
@@ -315,7 +312,6 @@ export function GroupStrip() {
 
 	const plusControl = (
 		<AddTabButton
-			hasAiChat={hasAiChat === true}
 			useCompactAddButton={useCompactAddButton}
 			showPresetsBar={showPresetsBar ?? DEFAULT_SHOW_PRESETS_BAR}
 			presets={presets}
@@ -372,11 +368,7 @@ export function GroupStrip() {
 					{hasHorizontalOverflow ? (
 						<div
 							className={`h-full shrink-0 ${
-								!useCompactAddButton
-									? hasAiChat
-										? "w-[220px]"
-										: "w-[170px]"
-									: "w-10"
+								!useCompactAddButton ? "w-[220px]" : "w-10"
 							}`}
 						/>
 					) : (

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/components/AddTabButton/AddTabButton.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/components/AddTabButton/AddTabButton.tsx
@@ -17,7 +17,6 @@ import { NewTabDropZone } from "../../NewTabDropZone";
 import { PresetsSubmenu } from "./components/PresetsSubmenu";
 
 interface AddTabButtonProps {
-	hasAiChat: boolean;
 	useCompactAddButton: boolean;
 	showPresetsBar: boolean;
 	presets: TerminalPreset[];
@@ -33,7 +32,6 @@ interface AddTabButtonProps {
 }
 
 export function AddTabButton({
-	hasAiChat,
 	useCompactAddButton,
 	showPresetsBar,
 	presets,
@@ -64,16 +62,14 @@ export function AddTabButton({
 								<BsTerminalPlus className="size-3.5" />
 								Terminal
 							</Button>
-							{hasAiChat && (
-								<Button
-									variant="ghost"
-									className="h-7 rounded-none border border-l-0 border-border/60 bg-muted/30 px-1.5 gap-1 text-xs text-muted-foreground hover:bg-accent/60 hover:text-foreground"
-									onClick={onAddChat}
-								>
-									<TbMessageCirclePlus className="size-3.5" />
-									Chat
-								</Button>
-							)}
+							<Button
+								variant="ghost"
+								className="h-7 rounded-none border border-l-0 border-border/60 bg-muted/30 px-1.5 gap-1 text-xs text-muted-foreground hover:bg-accent/60 hover:text-foreground"
+								onClick={onAddChat}
+							>
+								<TbMessageCirclePlus className="size-3.5" />
+								Chat
+							</Button>
 							<Button
 								variant="ghost"
 								className="h-7 rounded-none border border-l-0 border-border/60 bg-muted/30 px-1.5 gap-1 text-xs text-muted-foreground hover:bg-accent/60 hover:text-foreground"
@@ -112,13 +108,11 @@ export function AddTabButton({
 								<span>Terminal</span>
 								<HotkeyMenuShortcut hotkeyId="NEW_GROUP" />
 							</DropdownMenuItem>
-							{hasAiChat && (
-								<DropdownMenuItem onClick={onAddChat} className="gap-2">
-									<TbMessageCirclePlus className="size-4" />
-									<span>Chat</span>
-									<HotkeyMenuShortcut hotkeyId="NEW_CHAT" />
-								</DropdownMenuItem>
-							)}
+							<DropdownMenuItem onClick={onAddChat} className="gap-2">
+								<TbMessageCirclePlus className="size-4" />
+								<span>Chat</span>
+								<HotkeyMenuShortcut hotkeyId="NEW_CHAT" />
+							</DropdownMenuItem>
 							<DropdownMenuItem onClick={onAddBrowser} className="gap-2">
 								<TbWorld className="size-4" />
 								<span>Browser</span>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
@@ -1,8 +1,6 @@
 import "react-mosaic-component/react-mosaic-component.css";
 import "./mosaic-theme.css";
 
-import { FEATURE_FLAGS } from "@superset/shared/constants";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useCallback, useEffect, useMemo } from "react";
 import {
 	Mosaic,
@@ -40,7 +38,6 @@ export function TabView({ tab }: TabViewProps) {
 	const setFocusedPane = useTabsStore((s) => s.setFocusedPane);
 	const movePaneToTab = useTabsStore((s) => s.movePaneToTab);
 	const movePaneToNewTab = useTabsStore((s) => s.movePaneToNewTab);
-	const hasAiChat = useFeatureFlagEnabled(FEATURE_FLAGS.AI_CHAT);
 	const allTabs = useTabsStore((s) => s.tabs);
 	const allPanes = useTabsStore((s) => s.panes);
 
@@ -176,7 +173,7 @@ export function TabView({ tab }: TabViewProps) {
 			}
 
 			// Route chat panes to ChatMastraPane component
-			if (paneInfo.type === "chat-mastra" && hasAiChat) {
+			if (paneInfo.type === "chat-mastra") {
 				return (
 					<ChatMastraPane
 						paneId={paneId}
@@ -255,7 +252,6 @@ export function TabView({ tab }: TabViewProps) {
 			workspaceTabs,
 			movePaneToTab,
 			movePaneToNewTab,
-			hasAiChat,
 		],
 	);
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -53,8 +53,6 @@ export const FEATURE_FLAGS = {
 	ELECTRIC_TASKS_ACCESS: "electric-tasks-access",
 	/** Gates access to GitHub integration (currently buggy, internal only). */
 	GITHUB_INTEGRATION_ACCESS: "github-integration-access",
-	/** Gates access to AI chat (@superset.sh internal only). */
-	AI_CHAT: "ai-chat",
 	/** Gates access to Slack integration (internal only). */
 	SLACK_INTEGRATION_ACCESS: "slack-integration-access",
 	/** Gates access to Cloud features (environment variables, sandboxes). */


### PR DESCRIPTION
## Summary
- Removes the `AI_CHAT` (`ai-chat`) PostHog feature flag from `FEATURE_FLAGS` in `packages/shared`
- Removes all `useFeatureFlagEnabled(FEATURE_FLAGS.AI_CHAT)` checks in the desktop app
- Chat UI (buttons, panes, empty tab actions) is now always rendered unconditionally

## Test plan
- [x] Verify the Chat button appears in the tab strip add button (both expanded and compact modes)
- [x] Verify "Open Chat" appears in the empty tab view
- [x] Verify `ChatMastraPane` renders correctly when opening a chat pane
- [x] Verify hotkeys `Cmd+Shift+T` (New Chat) and `Cmd+Shift+E` (Split with Chat) work
- [x] Verify no TypeScript errors (`bun run typecheck`)
- [x] Verify lint passes (`bun run lint`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `AI_CHAT` (`ai-chat`) feature flag and made Chat generally available in the desktop app. Chat buttons, panes, and empty tab actions now render unconditionally, and New Chat/Split with Chat hotkeys are always enabled.

- **Refactors**
  - Deleted `FEATURE_FLAGS.AI_CHAT` from `packages/shared/src/constants.ts`.
  - Removed `useFeatureFlagEnabled` checks from `posthog-js/react`; simplified `AddTabButton`, `EmptyTabView`, `GroupStrip`, and `TabView` to always include Chat.

<sup>Written for commit 7bdfbdd633b3d0b373b0e602695471c2ccf8a7ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * AI chat functionality is now permanently enabled and universally available to all users across the desktop application, including in workspace views, tabs, and content management areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->