### PR TITLE
Preserve assistant soft line breaks in chat markdown

### DIFF
--- a/packages/ui/src/components/ai-elements/message.test.tsx
+++ b/packages/ui/src/components/ai-elements/message.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it, mock } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { ReactNode } from "react";
+
+const streamdownCalls: Array<Record<string, unknown>> = [];
+
+mock.module("@streamdown/mermaid", () => ({
+	mermaid: {},
+}));
+
+mock.module("streamdown", () => ({
+	Streamdown: (props: Record<string, unknown>) => {
+		streamdownCalls.push(props);
+		return <div>{props.children as ReactNode}</div>;
+	},
+}));
+
+const { MessageResponse } = await import("./message");
+
+describe("MessageResponse", () => {
+	it("preserves assistant soft line breaks in markdown paragraphs", () => {
+		streamdownCalls.length = 0;
+
+		renderToStaticMarkup(<MessageResponse>foo{"\n"}bar</MessageResponse>);
+
+		const call = streamdownCalls.at(-1);
+		expect(call).toBeDefined();
+		expect(call?.className).toContain("[&_p]:whitespace-pre-wrap");
+		expect(call?.className).toContain("[&_li]:whitespace-pre-wrap");
+	});
+});

--- a/packages/ui/src/components/ai-elements/message.tsx
+++ b/packages/ui/src/components/ai-elements/message.tsx
@@ -317,7 +317,7 @@ export const MessageResponse = memo(
 		<Streamdown
 			animated={animated ?? defaultMessageAnimation}
 			className={cn(
-				"text-foreground [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_ol]:list-outside [&_ol]:pl-6 [&_ul]:list-outside [&_ul]:pl-6 [&_:not(pre)>code]:break-all",
+				"text-foreground [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_ol]:list-outside [&_ol]:pl-6 [&_ul]:list-outside [&_ul]:pl-6 [&_li]:break-words [&_li]:whitespace-pre-wrap [&_p]:break-words [&_p]:whitespace-pre-wrap [&_:not(pre)>code]:break-all",
 				className,
 			)}
 			isAnimating={isAnimating}


### PR DESCRIPTION
## Description

Preserve soft line breaks in assistant chat markdown so wrapped file paths and commands do not get flattened into space-separated text.

This updates the shared `MessageResponse` `Streamdown` wrapper to keep paragraph and list-item whitespace with `whitespace-pre-wrap`, which avoids turning newline-separated path segments into broken clickable text in the chat transcript.

The PR also adds a small unit test that locks the `MessageResponse` whitespace contract.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

- Added a unit test for `MessageResponse` whitespace handling.
- I did not complete a local `bun test` run in this temp clone because dependencies were not already installed and the install was interrupted.

## Screenshots (if applicable)

Not applicable.

## Additional Notes

I traced the issue back to assistant chat rendering rather than the terminal link provider. Terminal multiline file-path detection already exists; the regression comes from markdown paragraph whitespace collapsing in the assistant transcript.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves soft line breaks in assistant chat markdown so wrapped file paths and commands render correctly. Applies `whitespace-pre-wrap` to paragraphs and list items in the `MessageResponse` `Streamdown` wrapper to prevent newline collapsing.

- **Bug Fixes**
  - Added a unit test to lock `MessageResponse` whitespace handling.

<sup>Written for commit 487be8bcb59d1a53ec981e130aae7f31ebbc03e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text wrapping behavior for paragraphs and list items in message responses, ensuring proper whitespace preservation.

* **Tests**
  * Added test coverage for message component whitespace handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->