### PR TITLE
fix(desktop): align chat message content with prompt input

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/components/ChatMastraMessageList/ChatMastraMessageList.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraInterface/components/ChatMastraMessageList/ChatMastraMessageList.tsx
@@ -172,7 +172,7 @@ export function ChatMastraMessageList({
 
 	return (
 		<Conversation className="flex-1">
-			<ConversationContent className="mx-auto w-full max-w-3xl py-6 pl-6 pr-16">
+			<ConversationContent className="mx-auto w-full max-w-[680px] py-6">
 				<div ref={messageListRef} className="flex flex-col gap-6">
 					{shouldShowConversationLoading ? (
 						<ConversationLoadingState />


### PR DESCRIPTION
## Summary
- The chat message area used `max-w-3xl` (768px) with asymmetric padding (`pl-6`/`pr-16`) to reserve space for the absolutely-positioned scrollback rail, causing streamed text to sit ~20px left of the symmetrically-centered prompt input (`max-w-[680px]`)
- Replaced with `max-w-[680px]` and removed the asymmetric padding so message content aligns with the prompt input
- The scrollback rail is absolutely positioned and unaffected by this change

## Test plan
- [x] Open a chat and send a message — verify streamed text left-aligns with the prompt input
- [x] Scroll through a long conversation — verify the scrollback rail still renders correctly in the top-right
- [x] Resize the window — verify the message area and prompt input stay aligned at all widths

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns chat message content with the prompt input by switching the message container to `max-w-[680px]` and removing asymmetric padding. Fixes the ~20px left shift caused by `max-w-3xl` + `pl-6/pr-16`, with the scrollback rail unaffected since it’s absolutely positioned.

<sup>Written for commit 1c442177a0d3e0fa738e47352d0b67d8e0cfe812. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the width and padding of the chat message display area for improved visual layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->