### PR TITLE
feat(desktop): add customizable PR link provider setting

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/settings/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/index.ts
@@ -4,6 +4,7 @@ import {
 	EXTERNAL_APPS,
 	FILE_OPEN_MODES,
 	NON_EDITOR_APPS,
+	PR_LINK_PROVIDERS,
 	settings,
 	TERMINAL_LINK_BEHAVIORS,
 	type TerminalPreset,
@@ -22,6 +23,7 @@ import {
 	DEFAULT_CONFIRM_ON_QUIT,
 	DEFAULT_FILE_OPEN_MODE,
 	DEFAULT_OPEN_LINKS_IN_APP,
+	DEFAULT_PR_LINK_PROVIDER,
 	DEFAULT_SHOW_PRESETS_BAR,
 	DEFAULT_SHOW_RESOURCE_MONITOR,
 	DEFAULT_TERMINAL_LINK_BEHAVIOR,
@@ -501,6 +503,41 @@ export const createSettingsRouter = () => {
 			quitWithoutConfirmation();
 			return { success: true };
 		}),
+
+		getPrLinkProvider: publicProcedure.query(() => {
+			const row = getSettings();
+			return {
+				provider: row.prLinkProvider ?? DEFAULT_PR_LINK_PROVIDER,
+				customDomain: row.prLinkCustomDomain ?? null,
+			};
+		}),
+
+		setPrLinkProvider: publicProcedure
+			.input(
+				z.object({
+					provider: z.enum(PR_LINK_PROVIDERS),
+					customDomain: z.string().nullable().optional(),
+				}),
+			)
+			.mutation(({ input }) => {
+				localDb
+					.insert(settings)
+					.values({
+						id: 1,
+						prLinkProvider: input.provider,
+						prLinkCustomDomain: input.customDomain ?? null,
+					})
+					.onConflictDoUpdate({
+						target: settings.id,
+						set: {
+							prLinkProvider: input.provider,
+							prLinkCustomDomain: input.customDomain ?? null,
+						},
+					})
+					.run();
+
+				return { success: true };
+			}),
 
 		getBranchPrefix: publicProcedure.query(() => {
 			const row = getSettings();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -39,6 +39,8 @@ import {
 	useHasWorkspaceFailed,
 	useIsWorkspaceInitializing,
 } from "renderer/stores/workspace-init";
+import { transformPrUrl } from "renderer/utils/pr-url";
+import { DEFAULT_PR_LINK_PROVIDER } from "shared/constants";
 
 const EMPTY_HISTORY_STACK: string[] = [];
 
@@ -376,17 +378,24 @@ function WorkspacePage() {
 	const { createOrOpenPR } = useCreateOrOpenPR({
 		worktreePath: workspace?.worktreePath,
 	});
+	const { data: prLinkSettings } =
+		electronTrpc.settings.getPrLinkProvider.useQuery();
+	const prProvider = prLinkSettings?.provider ?? DEFAULT_PR_LINK_PROVIDER;
+	const prCustomDomain = prLinkSettings?.customDomain;
 	useAppHotkey(
 		"OPEN_PR",
 		() => {
 			if (pr?.url) {
-				window.open(pr.url, "_blank");
+				window.open(
+					transformPrUrl(pr.url, prProvider, prCustomDomain),
+					"_blank",
+				);
 			} else {
 				createOrOpenPR();
 			}
 		},
 		undefined,
-		[pr?.url, createOrOpenPR],
+		[pr?.url, createOrOpenPR, prProvider, prCustomDomain],
 	);
 
 	const commandPalette = useCommandPalette({

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/git/components/GitSettings/GitSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/git/components/GitSettings/GitSettings.tsx
@@ -1,4 +1,4 @@
-import type { BranchPrefixMode } from "@superset/local-db";
+import type { BranchPrefixMode, PrLinkProvider } from "@superset/local-db";
 import { Input } from "@superset/ui/input";
 import { Label } from "@superset/ui/label";
 import {
@@ -17,6 +17,7 @@ import {
 	WorktreeLocationPicker,
 } from "../../../components/WorktreeLocationPicker";
 import { BRANCH_PREFIX_MODE_LABELS } from "../../../utils/branch-prefix";
+import { PR_LINK_PROVIDER_LABELS } from "../../../utils/pr-link-provider";
 import {
 	isItemVisible,
 	SETTING_ITEM_ID,
@@ -34,6 +35,10 @@ export function GitSettings({ visibleItems }: GitSettingsProps) {
 	);
 	const showBranchPrefix = isItemVisible(
 		SETTING_ITEM_ID.GIT_BRANCH_PREFIX,
+		visibleItems,
+	);
+	const showPrLinkProvider = isItemVisible(
+		SETTING_ITEM_ID.GIT_PR_LINK_PROVIDER,
 		visibleItems,
 	);
 	const showWorktreeLocation = isItemVisible(
@@ -104,6 +109,44 @@ export function GitSettings({ visibleItems }: GitSettingsProps) {
 		setBranchPrefix.mutate({
 			mode: "custom",
 			customPrefix: sanitized || null,
+		});
+	};
+
+	const { data: prLinkProvider, isLoading: isPrLinkProviderLoading } =
+		electronTrpc.settings.getPrLinkProvider.useQuery();
+
+	const [customDomainInput, setCustomDomainInput] = useState(
+		prLinkProvider?.customDomain ?? "",
+	);
+
+	useEffect(() => {
+		setCustomDomainInput(prLinkProvider?.customDomain ?? "");
+	}, [prLinkProvider?.customDomain]);
+
+	const setPrLinkProvider = electronTrpc.settings.setPrLinkProvider.useMutation(
+		{
+			onError: (err) => {
+				console.error("[settings/pr-link-provider] Failed to update:", err);
+			},
+			onSettled: () => {
+				utils.settings.getPrLinkProvider.invalidate();
+			},
+		},
+	);
+
+	const handlePrLinkProviderChange = (provider: PrLinkProvider) => {
+		setPrLinkProvider.mutate({
+			provider,
+			customDomain: customDomainInput || null,
+		});
+	};
+
+	const handleCustomDomainBlur = () => {
+		const trimmed = customDomainInput.trim().replace(/\/+$/, "");
+		setCustomDomainInput(trimmed);
+		setPrLinkProvider.mutate({
+			provider: "custom",
+			customDomain: trimmed || null,
 		});
 	};
 
@@ -222,6 +265,56 @@ export function GitSettings({ visibleItems }: GitSettingsProps) {
 									onBlur={handleCustomPrefixBlur}
 									className="w-[120px]"
 									disabled={isBranchPrefixLoading || setBranchPrefix.isPending}
+								/>
+							)}
+						</div>
+					</div>
+				)}
+
+				{showPrLinkProvider && (
+					<div className="flex items-center justify-between">
+						<div className="space-y-0.5">
+							<Label className="text-sm font-medium">PR Link Provider</Label>
+							<p className="text-xs text-muted-foreground">
+								Choose where pull request links open
+							</p>
+						</div>
+						<div className="flex items-center gap-2">
+							<Select
+								value={prLinkProvider?.provider ?? "github"}
+								onValueChange={(value) =>
+									handlePrLinkProviderChange(value as PrLinkProvider)
+								}
+								disabled={
+									isPrLinkProviderLoading || setPrLinkProvider.isPending
+								}
+							>
+								<SelectTrigger className="w-[180px]">
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									{(
+										Object.entries(PR_LINK_PROVIDER_LABELS) as [
+											PrLinkProvider,
+											string,
+										][]
+									).map(([value, label]) => (
+										<SelectItem key={value} value={value}>
+											{label}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+							{prLinkProvider?.provider === "custom" && (
+								<Input
+									placeholder="https://example.com"
+									value={customDomainInput}
+									onChange={(e) => setCustomDomainInput(e.target.value)}
+									onBlur={handleCustomDomainBlur}
+									className="w-[200px]"
+									disabled={
+										isPrLinkProviderLoading || setPrLinkProvider.isPending
+									}
 								/>
 							)}
 						</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/pr-link-provider/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/pr-link-provider/index.ts
@@ -1,0 +1,1 @@
+export { PR_LINK_PROVIDER_LABELS } from "./pr-link-provider";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/pr-link-provider/pr-link-provider.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/pr-link-provider/pr-link-provider.ts
@@ -1,0 +1,8 @@
+import type { PrLinkProvider } from "@superset/local-db";
+
+export const PR_LINK_PROVIDER_LABELS: Record<PrLinkProvider, string> = {
+	github: "GitHub",
+	betterhub: "BetterHub",
+	devin: "Devin",
+	custom: "Custom",
+};

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -28,6 +28,7 @@ export const SETTING_ITEM_ID = {
 	BEHAVIOR_OPEN_LINKS_IN_APP: "behavior-open-links-in-app",
 
 	GIT_BRANCH_PREFIX: "git-branch-prefix",
+	GIT_PR_LINK_PROVIDER: "git-pr-link-provider",
 	GIT_DELETE_LOCAL_BRANCH: "git-delete-local-branch",
 	GIT_WORKTREE_LOCATION: "git-worktree-location",
 
@@ -353,6 +354,26 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"warning",
 			"prompt",
 			"unsaved",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.GIT_PR_LINK_PROVIDER,
+		section: "git",
+		title: "PR Link Provider",
+		description: "Choose where pull request links open",
+		keywords: [
+			"git",
+			"pr",
+			"pull request",
+			"link",
+			"provider",
+			"github",
+			"betterhub",
+			"devin",
+			"custom",
+			"review",
+			"code review",
+			"url",
 		],
 	},
 	{

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceStatusBadge.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceStatusBadge.tsx
@@ -1,6 +1,8 @@
 import { cn } from "@superset/ui/utils";
 import { LuCircleDot, LuGitMerge, LuGitPullRequest } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { transformPrUrl } from "renderer/utils/pr-url";
+import { DEFAULT_PR_LINK_PROVIDER } from "shared/constants";
 import { STROKE_WIDTH } from "../constants";
 
 type PRState = "open" | "merged" | "closed" | "draft";
@@ -19,6 +21,10 @@ export function WorkspaceStatusBadge({
 	className,
 }: WorkspaceStatusBadgeProps) {
 	const openUrl = electronTrpc.external.openUrl.useMutation();
+	const { data: prLinkSettings } =
+		electronTrpc.settings.getPrLinkProvider.useQuery();
+	const prProvider = prLinkSettings?.provider ?? DEFAULT_PR_LINK_PROVIDER;
+	const prCustomDomain = prLinkSettings?.customDomain;
 	const iconClass = "w-3 h-3";
 
 	const config = {
@@ -69,7 +75,7 @@ export function WorkspaceStatusBadge({
 	const handleClick = (e: React.MouseEvent) => {
 		if (prUrl) {
 			e.stopPropagation();
-			openUrl.mutate(prUrl);
+			openUrl.mutate(transformPrUrl(prUrl, prProvider, prCustomDomain));
 		}
 	};
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/WorkspaceHoverCard.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/WorkspaceHoverCard.tsx
@@ -9,8 +9,11 @@ import {
 	LuTriangleAlert,
 } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { PR_LINK_PROVIDER_LABELS } from "renderer/routes/_authenticated/settings/utils/pr-link-provider";
 import { usePRStatus } from "renderer/screens/main/hooks";
 import { useHotkeyDisplay } from "renderer/stores/hotkeys";
+import { transformPrUrl } from "renderer/utils/pr-url";
+import { DEFAULT_PR_LINK_PROVIDER } from "shared/constants";
 import { STROKE_WIDTH } from "../../../constants";
 import { ChecksList } from "./components/ChecksList";
 import { ChecksSummary } from "./components/ChecksSummary";
@@ -39,6 +42,11 @@ export function WorkspaceHoverCardContent({
 		previewUrl,
 		isLoading: isLoadingGithub,
 	} = usePRStatus({ workspaceId });
+
+	const { data: prLinkSettings } =
+		electronTrpc.settings.getPrLinkProvider.useQuery();
+	const prProvider = prLinkSettings?.provider ?? DEFAULT_PR_LINK_PROVIDER;
+	const prCustomDomain = prLinkSettings?.customDomain;
 
 	const openPRDisplay = useHotkeyDisplay("OPEN_PR");
 	const hasOpenPRShortcut = !(
@@ -168,9 +176,17 @@ export function WorkspaceHoverCardContent({
 						className="w-full mt-1 h-7 text-xs gap-1.5"
 						asChild
 					>
-						<a href={pr.url} target="_blank" rel="noopener noreferrer">
-							<FaGithub className="size-3" />
-							View on GitHub
+						<a
+							href={transformPrUrl(pr.url, prProvider, prCustomDomain)}
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							{prProvider === "github" ? (
+								<FaGithub className="size-3" />
+							) : (
+								<LuExternalLink className="size-3" strokeWidth={STROKE_WIDTH} />
+							)}
+							View on {PR_LINK_PROVIDER_LABELS[prProvider]}
 							{hasOpenPRShortcut && (
 								<KbdGroup className="ml-auto">
 									{openPRDisplay.map((key) => (

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ChangesHeader/components/PRButton/PRButton.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ChangesHeader/components/PRButton/PRButton.tsx
@@ -17,6 +17,8 @@ import {
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { PRIcon } from "renderer/screens/main/components/PRIcon";
 import { useCreateOrOpenPR } from "renderer/screens/main/hooks";
+import { transformPrUrl } from "renderer/utils/pr-url";
+import { DEFAULT_PR_LINK_PROVIDER } from "shared/constants";
 
 interface PRButtonProps {
 	pr: GitHubStatus["pr"] | null;
@@ -35,6 +37,11 @@ export function PRButton({
 	worktreePath,
 	onRefresh,
 }: PRButtonProps) {
+	const { data: prLinkSettings } =
+		electronTrpc.settings.getPrLinkProvider.useQuery();
+	const prProvider = prLinkSettings?.provider ?? DEFAULT_PR_LINK_PROVIDER;
+	const prCustomDomain = prLinkSettings?.customDomain;
+
 	const mergePRMutation = electronTrpc.changes.mergePR.useMutation({
 		onSuccess: () => {
 			toast.success("PR merged successfully");
@@ -100,11 +107,12 @@ export function PRButton({
 	}
 
 	const canMerge = pr.state === "open";
+	const transformedPrUrl = transformPrUrl(pr.url, prProvider, prCustomDomain);
 
 	if (!canMerge) {
 		return (
 			<a
-				href={pr.url}
+				href={transformedPrUrl}
 				target="_blank"
 				rel="noopener noreferrer"
 				className="flex items-center gap-1 ml-auto hover:opacity-80 transition-opacity"
@@ -120,7 +128,7 @@ export function PRButton({
 	return (
 		<div className="flex items-center ml-auto rounded border border-border overflow-hidden">
 			<a
-				href={pr.url}
+				href={transformedPrUrl}
 				target="_blank"
 				rel="noopener noreferrer"
 				className="flex items-center gap-1 px-1.5 py-0.5 hover:bg-accent transition-colors"

--- a/apps/desktop/src/renderer/screens/main/hooks/useCreateOrOpenPR/useCreateOrOpenPR.ts
+++ b/apps/desktop/src/renderer/screens/main/hooks/useCreateOrOpenPR/useCreateOrOpenPR.ts
@@ -1,6 +1,8 @@
 import { toast } from "@superset/ui/sonner";
 import { useCallback } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { transformPrUrl } from "renderer/utils/pr-url";
+import { DEFAULT_PR_LINK_PROVIDER } from "shared/constants";
 
 interface UseCreateOrOpenPROptions {
 	worktreePath?: string;
@@ -18,6 +20,10 @@ export function useCreateOrOpenPR({
 }: UseCreateOrOpenPROptions): UseCreateOrOpenPRResult {
 	const { mutateAsync, isPending } =
 		electronTrpc.changes.createPR.useMutation();
+	const { data: prLinkSettings } =
+		electronTrpc.settings.getPrLinkProvider.useQuery();
+	const provider = prLinkSettings?.provider ?? DEFAULT_PR_LINK_PROVIDER;
+	const customDomain = prLinkSettings?.customDomain;
 
 	const createOrOpenPR = useCallback(() => {
 		if (!worktreePath || isPending) return;
@@ -25,8 +31,9 @@ export function useCreateOrOpenPR({
 		void (async () => {
 			try {
 				const result = await mutateAsync({ worktreePath });
-				window.open(result.url, "_blank", "noopener,noreferrer");
-				toast.success("Opening GitHub...");
+				const url = transformPrUrl(result.url, provider, customDomain);
+				window.open(url, "_blank", "noopener,noreferrer");
+				toast.success("Opening pull request...");
 				onSuccess?.();
 				return;
 			} catch (error) {
@@ -50,8 +57,9 @@ export function useCreateOrOpenPR({
 					worktreePath,
 					allowOutOfDate: true,
 				});
-				window.open(result.url, "_blank", "noopener,noreferrer");
-				toast.success("Opening GitHub...");
+				const url = transformPrUrl(result.url, provider, customDomain);
+				window.open(url, "_blank", "noopener,noreferrer");
+				toast.success("Opening pull request...");
 				onSuccess?.();
 			} catch (retryError) {
 				const retryMessage =
@@ -59,7 +67,7 @@ export function useCreateOrOpenPR({
 				toast.error(`Failed: ${retryMessage}`);
 			}
 		})();
-	}, [isPending, mutateAsync, onSuccess, worktreePath]);
+	}, [isPending, mutateAsync, onSuccess, worktreePath, provider, customDomain]);
 
 	return {
 		createOrOpenPR,

--- a/apps/desktop/src/renderer/utils/pr-url/index.ts
+++ b/apps/desktop/src/renderer/utils/pr-url/index.ts
@@ -1,0 +1,1 @@
+export { transformPrUrl } from "./pr-url";

--- a/apps/desktop/src/renderer/utils/pr-url/pr-url.ts
+++ b/apps/desktop/src/renderer/utils/pr-url/pr-url.ts
@@ -1,0 +1,29 @@
+import type { PrLinkProvider } from "@superset/local-db";
+
+const PROVIDER_BASE_URLS: Record<
+	Exclude<PrLinkProvider, "custom" | "github">,
+	string
+> = {
+	betterhub: "https://www.better-hub.com",
+	devin: "https://app.devin.ai/review",
+};
+
+export function transformPrUrl(
+	githubUrl: string,
+	provider: PrLinkProvider,
+	customBaseUrl?: string | null,
+): string {
+	if (provider === "github") return githubUrl;
+	if (!githubUrl.includes("/pull/")) return githubUrl;
+
+	const githubBase = "https://github.com";
+	if (!githubUrl.startsWith(githubBase)) return githubUrl;
+
+	if (provider === "custom") {
+		if (!customBaseUrl) return githubUrl;
+		const base = customBaseUrl.replace(/\/+$/, "");
+		return githubUrl.replace(githubBase, base);
+	}
+
+	return githubUrl.replace(githubBase, PROVIDER_BASE_URLS[provider]);
+}

--- a/apps/desktop/src/shared/constants.ts
+++ b/apps/desktop/src/shared/constants.ts
@@ -46,6 +46,7 @@ export const DEFAULT_USE_COMPACT_TERMINAL_ADD_BUTTON = true;
 export const DEFAULT_TELEMETRY_ENABLED = true;
 export const DEFAULT_SHOW_RESOURCE_MONITOR = true;
 export const DEFAULT_OPEN_LINKS_IN_APP = false;
+export const DEFAULT_PR_LINK_PROVIDER = "github" as const;
 
 // External links (documentation, help resources, etc.)
 export const EXTERNAL_LINKS = {

--- a/packages/local-db/drizzle/0036_add_pr_link_provider_settings.sql
+++ b/packages/local-db/drizzle/0036_add_pr_link_provider_settings.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `settings` ADD `pr_link_provider` text;--> statement-breakpoint
+ALTER TABLE `settings` ADD `pr_link_custom_domain` text;

--- a/packages/local-db/drizzle/meta/0036_snapshot.json
+++ b/packages/local-db/drizzle/meta/0036_snapshot.json
@@ -1,0 +1,1382 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "86a1b00d-f6da-4203-aefd-be2fd8505a21",
+  "prevId": "589aac6d-a11a-44bd-97f9-be06311fcb95",
+  "tables": {
+    "browser_history": {
+      "name": "browser_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_visited_at": {
+          "name": "last_visited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visit_count": {
+          "name": "visit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "browser_history_url_unique": {
+          "name": "browser_history_url_unique",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "browser_history_url_idx": {
+          "name": "browser_history_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": false
+        },
+        "browser_history_last_visited_at_idx": {
+          "name": "browser_history_last_visited_at_idx",
+          "columns": [
+            "last_visited_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_organization_id_idx": {
+          "name": "organization_members_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_user_id_idx": {
+          "name": "organization_members_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_users_id_fk": {
+          "name": "organization_members_user_id_users_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_org": {
+          "name": "github_org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_clerk_org_id_unique": {
+          "name": "organizations_clerk_org_id_unique",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_idx": {
+          "name": "organizations_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "organizations_clerk_org_id_idx": {
+          "name": "organizations_clerk_org_id_idx",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "main_repo_path": {
+          "name": "main_repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_toast_dismissed": {
+          "name": "config_toast_dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_base_branch": {
+          "name": "workspace_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_owner": {
+          "name": "github_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hide_image": {
+          "name": "hide_image",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_project_id": {
+          "name": "neon_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_app": {
+          "name": "default_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_main_repo_path_idx": {
+          "name": "projects_main_repo_path_idx",
+          "columns": [
+            "main_repo_path"
+          ],
+          "isUnique": false
+        },
+        "projects_last_opened_at_idx": {
+          "name": "projects_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_active_workspace_id": {
+          "name": "last_active_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets": {
+          "name": "terminal_presets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets_initialized": {
+          "name": "terminal_presets_initialized",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_ringtone_id": {
+          "name": "selected_ringtone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirm_on_quit": {
+          "name": "confirm_on_quit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_link_behavior": {
+          "name": "terminal_link_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "persist_terminal": {
+          "name": "persist_terminal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_apply_default_preset": {
+          "name": "auto_apply_default_preset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_sounds_muted": {
+          "name": "notification_sounds_muted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delete_local_branch": {
+          "name": "delete_local_branch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_open_mode": {
+          "name": "file_open_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_presets_bar": {
+          "name": "show_presets_bar",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_compact_terminal_add_button": {
+          "name": "use_compact_terminal_add_button",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_family": {
+          "name": "terminal_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_size": {
+          "name": "terminal_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_family": {
+          "name": "editor_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_size": {
+          "name": "editor_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_resource_monitor": {
+          "name": "show_resource_monitor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "open_links_in_app": {
+          "name": "open_links_in_app",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_editor": {
+          "name": "default_editor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_link_provider": {
+          "name": "pr_link_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_link_custom_domain": {
+          "name": "pr_link_custom_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_color": {
+          "name": "status_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_type": {
+          "name": "status_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_position": {
+          "name": "status_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "estimate": {
+          "name": "estimate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_provider": {
+          "name": "external_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tasks_slug_unique": {
+          "name": "tasks_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "tasks_slug_idx": {
+          "name": "tasks_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "tasks_organization_id_idx": {
+          "name": "tasks_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_assignee_id_idx": {
+          "name": "tasks_assignee_id_idx",
+          "columns": [
+            "assignee_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_status_idx": {
+          "name": "tasks_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "tasks_created_at_idx": {
+          "name": "tasks_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_organization_id_organizations_id_fk": {
+          "name": "tasks_organization_id_organizations_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_assignee_id_users_id_fk": {
+          "name": "tasks_assignee_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tasks_creator_id_users_id_fk": {
+          "name": "tasks_creator_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": true
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "users_clerk_id_idx": {
+          "name": "users_clerk_id_idx",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_sections": {
+      "name": "workspace_sections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_collapsed": {
+          "name": "is_collapsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspace_sections_project_id_idx": {
+          "name": "workspace_sections_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_sections_project_id_projects_id_fk": {
+          "name": "workspace_sections_project_id_projects_id_fk",
+          "tableFrom": "workspace_sections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_id": {
+          "name": "worktree_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_unread": {
+          "name": "is_unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_unnamed": {
+          "name": "is_unnamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "deleting_at": {
+          "name": "deleting_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "port_base": {
+          "name": "port_base",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_project_id_idx": {
+          "name": "workspaces_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_worktree_id_idx": {
+          "name": "workspaces_worktree_id_idx",
+          "columns": [
+            "worktree_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_last_opened_at_idx": {
+          "name": "workspaces_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        },
+        "workspaces_section_id_idx": {
+          "name": "workspaces_section_id_idx",
+          "columns": [
+            "section_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspaces_project_id_projects_id_fk": {
+          "name": "workspaces_project_id_projects_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_worktree_id_worktrees_id_fk": {
+          "name": "workspaces_worktree_id_worktrees_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "worktrees",
+          "columnsFrom": [
+            "worktree_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_section_id_workspace_sections_id_fk": {
+          "name": "workspaces_section_id_workspace_sections_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "workspace_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "worktrees": {
+      "name": "worktrees",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_status": {
+          "name": "git_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_status": {
+          "name": "github_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "worktrees_project_id_idx": {
+          "name": "worktrees_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "worktrees_branch_idx": {
+          "name": "worktrees_branch_idx",
+          "columns": [
+            "branch"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "worktrees_project_id_projects_id_fk": {
+          "name": "worktrees_project_id_projects_id_fk",
+          "tableFrom": "worktrees",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/local-db/drizzle/meta/_journal.json
+++ b/packages/local-db/drizzle/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1772841491441,
       "tag": "0035_add_workspace_sections",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "6",
+      "when": 1773165885709,
+      "tag": "0036_add_pr_link_provider_settings",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/local-db/src/schema/schema.ts
+++ b/packages/local-db/src/schema/schema.ts
@@ -7,6 +7,7 @@ import type {
 	FileOpenMode,
 	GitHubStatus,
 	GitStatus,
+	PrLinkProvider,
 	TerminalLinkBehavior,
 	TerminalPreset,
 	WorkspaceType,
@@ -208,6 +209,8 @@ export const settings = sqliteTable("settings", {
 	worktreeBaseDir: text("worktree_base_dir"),
 	openLinksInApp: integer("open_links_in_app", { mode: "boolean" }),
 	defaultEditor: text("default_editor").$type<ExternalApp>(),
+	prLinkProvider: text("pr_link_provider").$type<PrLinkProvider>(),
+	prLinkCustomDomain: text("pr_link_custom_domain"),
 });
 
 export type InsertSettings = typeof settings.$inferInsert;

--- a/packages/local-db/src/schema/zod.ts
+++ b/packages/local-db/src/schema/zod.ts
@@ -163,6 +163,18 @@ export const BRANCH_PREFIX_MODES = [
 
 export type BranchPrefixMode = (typeof BRANCH_PREFIX_MODES)[number];
 
+/**
+ * PR link provider options
+ */
+export const PR_LINK_PROVIDERS = [
+	"github",
+	"betterhub",
+	"devin",
+	"custom",
+] as const;
+
+export type PrLinkProvider = (typeof PR_LINK_PROVIDERS)[number];
+
 export const FILE_OPEN_MODES = ["split-pane", "new-tab"] as const;
 
 export type FileOpenMode = (typeof FILE_OPEN_MODES)[number];


### PR DESCRIPTION
## Summary
- Add a **PR Link Provider** setting (Settings > Git) that lets users open PR links in GitHub (default), BetterHub, Devin, or a custom domain
- URL transformation is applied at render/open time — raw GitHub URLs in DB/cache are never modified
- All PR link consumption points (PRButton, ⌘⇧P hotkey, useCreateOrOpenPR hook) respect the setting

## Test plan
- [ ] Settings > Git — confirm "PR Link Provider" dropdown with GitHub/BetterHub/Devin/Custom options
- [ ] Select BetterHub → open existing PR → URL uses `https://www.better-hub.com/owner/repo/pull/123`
- [ ] Select Devin → open existing PR → URL uses `https://app.devin.ai/review/owner/repo/pull/123`
- [ ] Select Custom → enter base URL → open PR → uses custom base URL
- [ ] Select GitHub → confirm original behavior unchanged
- [ ] ⌘⇧P shortcut → respects provider setting
- [ ] PRButton links → use transformed URL
- [ ] Creating a new PR (no existing PR) → always opens GitHub compare URL (not transformed)
- [ ] `bun run typecheck` and `bun run lint:fix` pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a PR Link Provider setting so users can open pull requests in GitHub (default), BetterHub, Devin, or a custom domain. All PR links and shortcuts now honor this setting without changing stored GitHub URLs.

- **New Features**
  - New “PR Link Provider” in Settings > Git with GitHub, BetterHub, Devin, or Custom (base domain).
  - PR URLs transform at open time; raw GitHub URLs remain in DB/cache.
  - Applied across the app: PR buttons, sidebar PR badge and hover card, ⌘⇧P, and the create-or-open PR flow.
  - New PR creation opens the GitHub compare URL (not transformed); default provider is GitHub.
  - Added settings endpoints (`getPrLinkProvider`, `setPrLinkProvider`) and `transformPrUrl` utility.

- **Migration**
  - Local DB adds `settings.pr_link_provider` and `settings.pr_link_custom_domain` columns.

<sup>Written for commit e7367f8b9e80fb987a7212da5344b7bd769b7d17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a PR Link Provider setting in Git settings to choose GitHub, BetterHub, Devin, or a custom domain; a default provider is applied.
  * PR URLs are now transformed app-wide (links, buttons, hotkeys, and open/retry flows) according to the selected provider and optional custom domain.
  * Settings search and UI updated to surface and manage the new PR Link Provider, with user feedback during open actions (e.g., "Opening pull request...").
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/superset-sh/superset/pull/2333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
