### PR TITLE
fix(ui): remove rounded borders from CommandItem list items

### DIFF
--- a/packages/ui/src/components/ui/command.tsx
+++ b/packages/ui/src/components/ui/command.tsx
@@ -147,7 +147,7 @@ function CommandItem({
 		<CommandPrimitive.Item
 			data-slot="command-item"
 			className={cn(
-				"data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				"data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 				className,
 			)}
 			{...props}


### PR DESCRIPTION
## Summary
- Remove `rounded-sm` from `CommandItem` in the shared `command.tsx` component so list items below the search input render with square corners.

## Testing
- `bun run typecheck`
- Manual: opened search dialog, confirmed items no longer have rounded borders

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `rounded-sm` from `CommandItem` in `packages/ui/src/components/ui/command.tsx` so list items under the search input render with square corners and match the input.

<sup>Written for commit a160d0d71c6950f190048d6b62e7a02308b6af8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor code formatting adjustment with no functional impact on users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->