### PR TITLE
ui(desktop): always show keyboard shortcut on New Workspace button

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarHeader/NewWorkspaceButton.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarHeader/NewWorkspaceButton.tsx
@@ -73,7 +73,7 @@ export function NewWorkspaceButton({
 				<LuPlus className="size-3" strokeWidth={STROKE_WIDTH_THICK} />
 			</div>
 			<span className="flex-1 text-left">New Workspace</span>
-			<span className="text-[10px] text-muted-foreground/50 opacity-0 group-hover:opacity-100 transition-opacity font-mono tabular-nums shrink-0">
+			<span className="text-[10px] text-muted-foreground/40 group-hover:text-muted-foreground/80 transition-colors font-mono tabular-nums shrink-0">
 				{shortcutText}
 			</span>
 		</button>


### PR DESCRIPTION
## Summary
- Always display the keyboard shortcut (⌘N) on the New Workspace button instead of only showing it on hover.
- On hover, the shortcut text brightens for emphasis.

## Why / Context
The shortcut was invisible until hover, so users had no way to discover it without mousing over the button. Making it always visible improves discoverability while keeping it subtle enough not to clutter the UI.

## How It Works
Replaced `opacity-0 group-hover:opacity-100` with color-based visibility:
- Default: `text-muted-foreground/40` (subtle but visible)
- Hover: `text-muted-foreground/80` (brighter)
- Transition changed from `transition-opacity` to `transition-colors`

## Manual QA Checklist
- [ ] Shortcut text visible on the New Workspace button without hovering
- [ ] Shortcut text brightens on hover
- [ ] Collapsed sidebar mode still shows shortcut in tooltip (unchanged)

## Testing
- Visual inspection in dev mode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always show the ⌘N keyboard shortcut on the New Workspace button to improve discoverability. The text is subtle by default and brightens on hover using color transitions, replacing the previous opacity toggle.

<sup>Written for commit 06d5f34605aeed9b60181f30bf7980d98716f114. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the visual presentation of shortcut text in the workspace creation button. Shortcut text is now always visible at reduced opacity and becomes more prominent on hover, providing clearer visual feedback to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->