### PR TITLE
Revert "fix(terminal): auto-close terminal pane on shell exit"

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -82,7 +82,6 @@ export const Terminal = ({ paneId, tabId, workspaceId }: TerminalProps) => {
 	tabIdRef.current = tabId;
 	const setFocusedPane = useTabsStore((s) => s.setFocusedPane);
 	const setPaneName = useTabsStore((s) => s.setPaneName);
-	const removePane = useTabsStore((s) => s.removePane);
 	const focusedPaneId = useTabsStore((s) => s.focusedPaneIds[tabId]);
 	const terminalTheme = useTerminalTheme();
 
@@ -251,7 +250,6 @@ export const Terminal = ({ paneId, tabId, workspaceId }: TerminalProps) => {
 			setConnectionError,
 			updateModesFromData,
 			updateCwdFromData,
-			onShellExit: () => removePane(paneId),
 		});
 
 	// Populate handler refs for flushPendingEvents to use

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalStream.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalStream.ts
@@ -16,7 +16,6 @@ export interface UseTerminalStreamOptions {
 	setConnectionError: (error: string | null) => void;
 	updateModesFromData: (data: string) => void;
 	updateCwdFromData: (data: string) => void;
-	onShellExit?: () => void;
 }
 
 export interface UseTerminalStreamReturn {
@@ -43,7 +42,6 @@ export function useTerminalStream({
 	setConnectionError,
 	updateModesFromData,
 	updateCwdFromData,
-	onShellExit,
 }: UseTerminalStreamOptions): UseTerminalStreamReturn {
 	const setPaneStatus = useTabsStore((s) => s.setPaneStatus);
 	const firstStreamDataReceivedRef = useRef(false);
@@ -62,12 +60,6 @@ export function useTerminalStream({
 			const wasKilledByUser = reason === "killed";
 			wasKilledByUserRef.current = wasKilledByUser;
 			setExitStatus(wasKilledByUser ? "killed" : "exited");
-
-			const shouldAutoClosePane = !wasKilledByUser && exitCode === 0;
-			if (shouldAutoClosePane) {
-				onShellExit?.();
-				return;
-			}
 
 			if (wasKilledByUser) {
 				xterm.writeln("\r\n\r\n[Session killed]");
@@ -93,7 +85,6 @@ export function useTerminalStream({
 			wasKilledByUserRef,
 			setExitStatus,
 			setPaneStatus,
-			onShellExit,
 		],
 	);
 


### PR DESCRIPTION
Reverts superset-sh/superset#1880

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the auto-close behavior for terminal panes on shell exit. Terminal panes now remain open after the shell exits, keeping output visible; removed the auto-close callback from `useTerminalStream` and the pane removal call in `Terminal`.

<sup>Written for commit e4af81d33c1967150505ece5f3d582fffa7ac472. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal panes no longer automatically close when the shell exits, allowing you to view the terminal session output without the pane disappearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->