### PR TITLE
fix(desktop): improve changes sidebar status contrast

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ChangesHeader/ChangesHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ChangesHeader/ChangesHeader.tsx
@@ -239,9 +239,12 @@ function RefreshButton({ onRefresh }: { onRefresh: () => void }) {
 }
 
 const reviewTagStyles = {
-	approved: "bg-emerald-500/15 text-emerald-500",
-	changes_requested: "bg-destructive/15 text-destructive-foreground",
-	pending: "bg-amber-500/15 text-amber-500",
+	approved:
+		"border border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+	changes_requested:
+		"border border-red-500/20 bg-red-500/10 text-red-700 dark:text-red-300",
+	pending:
+		"border border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-300",
 } as const;
 
 const reviewTagLabels = {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/PRChecksStatus/PRChecksStatus.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/PRChecksStatus/PRChecksStatus.tsx
@@ -14,9 +14,15 @@ interface PRChecksStatusProps {
 }
 
 const checkIconConfig = {
-	success: { icon: LuCheck, className: "text-emerald-500" },
-	failure: { icon: LuX, className: "text-destructive-foreground" },
-	pending: { icon: LuLoaderCircle, className: "text-amber-500" },
+	success: {
+		icon: LuCheck,
+		className: "text-emerald-600 dark:text-emerald-400",
+	},
+	failure: { icon: LuX, className: "text-red-600 dark:text-red-400" },
+	pending: {
+		icon: LuLoaderCircle,
+		className: "text-amber-600 dark:text-amber-400",
+	},
 	skipped: { icon: LuMinus, className: "text-muted-foreground" },
 	cancelled: { icon: LuMinus, className: "text-muted-foreground" },
 } as const;
@@ -39,14 +45,14 @@ function CheckRow({ check }: { check: CheckItem }) {
 				href={check.url}
 				target="_blank"
 				rel="noopener noreferrer"
-				className="block text-muted-foreground hover:text-foreground transition-colors"
+				className="block text-foreground/80 hover:text-foreground transition-colors"
 			>
 				{content}
 			</a>
 		);
 	}
 
-	return <div className="text-muted-foreground">{content}</div>;
+	return <div className="text-foreground/80">{content}</div>;
 }
 
 export function PRChecksStatus({ pr }: PRChecksStatusProps) {
@@ -70,7 +76,7 @@ export function PRChecksStatus({ pr }: PRChecksStatusProps) {
 			<button
 				type="button"
 				onClick={() => setChecksExpanded(!checksExpanded)}
-				className="flex items-center gap-1.5 text-[11px] text-muted-foreground hover:text-foreground transition-colors"
+				className="flex items-center gap-1.5 text-[11px] text-foreground/75 hover:text-foreground transition-colors"
 			>
 				{checksExpanded ? (
 					<LuChevronDown className="size-3 shrink-0" />


### PR DESCRIPTION
## Summary
- fix low-contrast review and PR checks styling in the changes sidebar for light mode
- replace destructive foreground usage on neutral/tinted surfaces with readable light/dark status colors
- raise check row text contrast so PR checks remain legible in the sidebar

## Validation
- bunx @biomejs/biome check apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/PRChecksStatus/PRChecksStatus.tsx apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ChangesHeader/ChangesHeader.tsx
- bun run --cwd apps/desktop typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves contrast for review status tags and PR check rows in the Changes sidebar, especially in light mode, to make statuses readable and accessible.

- **Bug Fixes**
  - Review tags: replace low-contrast styles with bordered, tinted backgrounds and clearer text colors (light: `*-700`, dark: `*-300`).
  - PR checks: use stronger icon colors (`*-600` light, `*-400` dark), raise row text from muted to `text-foreground/80`, and adjust toggle to `text-foreground/75`.
  - Removes `destructive-foreground` usage on neutral/tinted surfaces.

<sup>Written for commit 0f6546e2257895dc4d98a6fbd2d3dc34b7251597. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined review tag styling with enhanced dark mode support for approval, changes requested, and pending statuses including improved border and background colors.
  * Enhanced PR check status indicator colors and text styling with improved dark mode variants for better visibility.
  * Updated button and icon group styling to align with the new refined color scheme and transparency levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->