### PR TITLE
fix(desktop): use router history for settings back navigation

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/SettingsSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/SettingsSidebar.tsx
@@ -1,5 +1,5 @@
 import { COMPANY } from "@superset/shared/constants";
-import { Link } from "@tanstack/react-router";
+import { useNavigate, useRouter } from "@tanstack/react-router";
 import {
 	HiArrowLeft,
 	HiArrowTopRightOnSquare,
@@ -15,20 +15,32 @@ import { GeneralSettings } from "./GeneralSettings";
 import { ProjectsSettings } from "./ProjectsSettings";
 
 export function SettingsSidebar() {
+	const navigate = useNavigate();
+	const router = useRouter();
 	const searchQuery = useSettingsSearchQuery();
 	const setSearchQuery = useSetSettingsSearchQuery();
 	const matchCounts = searchQuery ? getMatchCountBySection(searchQuery) : null;
 
+	const handleBack = () => {
+		if (router.history.canGoBack()) {
+			router.history.back();
+			return;
+		}
+
+		void navigate({ to: "/workspace" });
+	};
+
 	return (
 		<div className="w-56 flex flex-col p-3 overflow-hidden">
 			{/* Back button */}
-			<Link
-				to="/workspace"
+			<button
+				type="button"
+				onClick={handleBack}
 				className="flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors mb-4"
 			>
 				<HiArrowLeft className="h-4 w-4" />
 				<span>Back</span>
-			</Link>
+			</button>
 
 			{/* Settings title */}
 			<h1 className="text-lg font-semibold px-3 mb-4">Settings</h1>


### PR DESCRIPTION
## Summary
- make the settings sidebar back button use the same router history back flow as the top bar
- fall back to `/workspace` only when there is no back history entry
- preserve workspace route query params by relying on the existing persistent router history

## Testing
- bun test apps/desktop/src/renderer/lib/persistent-hash-history/persistent-hash-history.test.ts
- bunx biome check apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/SettingsSidebar.tsx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use router history for the Settings sidebar Back button to make navigation consistent. Falls back to `/workspace` only if there’s no history.

- **Bug Fixes**
  - Replaced the link with a button that calls `router.history.back()` via `useRouter` from `@tanstack/react-router`; uses `useNavigate` for the fallback.
  - Preserves workspace query params by relying on the persistent router history, matching the "keep queries" requirement.

<sup>Written for commit 90d0a3c930323e2a3f463921f6c976187557ee78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced back button navigation in Settings. The back button now intelligently uses browser history when available, with automatic fallback to workspace view for seamless navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->