### PR TITLE
Fix branch selection in new workspace modal

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
@@ -528,7 +528,7 @@ export const createCreateProcedures = () => {
 				};
 			}),
 
-		createBranchWorkspace: publicProcedure
+		openMainRepoWorkspace: publicProcedure
 			.input(
 				z.object({
 					projectId: z.string(),

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/BranchesGroup/BranchesGroup.test.ts
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/BranchesGroup/BranchesGroup.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { buildCreateWorkspaceFromBranchInput } from "./buildCreateWorkspaceFromBranchInput";
+
+describe("buildCreateWorkspaceFromBranchInput", () => {
+	test("creates a worktree workspace request for an existing branch", () => {
+		expect(
+			buildCreateWorkspaceFromBranchInput(
+				"project-123",
+				"feature/fix-worktree-regression",
+			),
+		).toEqual({
+			projectId: "project-123",
+			branchName: "feature/fix-worktree-regression",
+			useExistingBranch: true,
+			applyPrefix: false,
+		});
+	});
+});

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/BranchesGroup/BranchesGroup.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/BranchesGroup/BranchesGroup.tsx
@@ -9,7 +9,7 @@ import { GoArrowUpRight, GoGitBranch, GoGlobe } from "react-icons/go";
 import { useDebouncedValue } from "renderer/hooks/useDebouncedValue";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
-	useCreateBranchWorkspace,
+	useCreateWorkspace,
 	useHandleOpenedWorktree,
 	useImportAllWorktrees,
 	useOpenExternalWorktree,
@@ -17,6 +17,7 @@ import {
 import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { useHotkeysStore } from "renderer/stores/hotkeys/store";
 import { useNewWorkspaceModalDraft } from "../../NewWorkspaceModalDraftContext";
+import { buildCreateWorkspaceFromBranchInput } from "./buildCreateWorkspaceFromBranchInput";
 import { resolveBranchAction } from "./resolveBranchAction";
 
 interface BranchesGroupProps {
@@ -29,7 +30,7 @@ export function BranchesGroup({ projectId }: BranchesGroupProps) {
 	const platform = useHotkeysStore((state) => state.platform);
 	const modKey = platform === "darwin" ? "⌘" : "Ctrl";
 	const navigate = useNavigate();
-	const createBranchWorkspace = useCreateBranchWorkspace();
+	const createWorkspace = useCreateWorkspace();
 	const handleOpenedWorktree = useHandleOpenedWorktree();
 	const importAllWorktrees = useImportAllWorktrees();
 	const openExternalWorktree = useOpenExternalWorktree();
@@ -209,10 +210,9 @@ export function BranchesGroup({ projectId }: BranchesGroupProps) {
 		(branchName: string) => {
 			if (!projectId) return;
 			void runAsyncAction(
-				createBranchWorkspace.mutateAsync({
-					projectId,
-					branch: branchName,
-				}),
+				createWorkspace.mutateAsync(
+					buildCreateWorkspaceFromBranchInput(projectId, branchName),
+				),
 				{
 					loading: "Creating workspace from branch...",
 					success: "Workspace created",
@@ -221,7 +221,7 @@ export function BranchesGroup({ projectId }: BranchesGroupProps) {
 				},
 			);
 		},
-		[createBranchWorkspace, projectId, runAsyncAction],
+		[createWorkspace, projectId, runAsyncAction],
 	);
 
 	const handleOpen = useCallback(

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/BranchesGroup/buildCreateWorkspaceFromBranchInput.ts
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/BranchesGroup/buildCreateWorkspaceFromBranchInput.ts
@@ -1,0 +1,11 @@
+export function buildCreateWorkspaceFromBranchInput(
+	projectId: string,
+	branchName: string,
+) {
+	return {
+		projectId,
+		branchName,
+		useExistingBranch: true,
+		applyPrefix: false,
+	} as const;
+}

--- a/apps/desktop/src/renderer/react-query/workspaces/index.ts
+++ b/apps/desktop/src/renderer/react-query/workspaces/index.ts
@@ -1,5 +1,4 @@
 export { useCloseWorkspace } from "./useCloseWorkspace";
-export { useCreateBranchWorkspace } from "./useCreateBranchWorkspace";
 export { useCreateFromPr } from "./useCreateFromPr";
 export { useCreateSectionFromWorkspaces } from "./useCreateSectionFromWorkspaces";
 export { useCreateWorkspace } from "./useCreateWorkspace";
@@ -10,6 +9,7 @@ export { useImportAllWorktrees } from "./useImportAllWorktrees";
 export { useMoveWorkspacesToSection } from "./useMoveWorkspacesToSection";
 export { useMoveWorkspaceToSection } from "./useMoveWorkspaceToSection";
 export { useOpenExternalWorktree } from "./useOpenExternalWorktree";
+export { useOpenMainRepoWorkspace } from "./useOpenMainRepoWorkspace";
 export { useReorderProjectChildren } from "./useReorderProjectChildren";
 export { useReorderSections } from "./useReorderSections";
 export { useReorderWorkspaces } from "./useReorderWorkspaces";

--- a/apps/desktop/src/renderer/react-query/workspaces/useOpenMainRepoWorkspace.ts
+++ b/apps/desktop/src/renderer/react-query/workspaces/useOpenMainRepoWorkspace.ts
@@ -4,9 +4,9 @@ import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/u
 import { useWorkspaceInitStore } from "renderer/stores/workspace-init";
 import type { WorkspaceInitProgress } from "shared/types/workspace-init";
 
-export function useCreateBranchWorkspace(
+export function useOpenMainRepoWorkspace(
 	options?: Parameters<
-		typeof electronTrpc.workspaces.createBranchWorkspace.useMutation
+		typeof electronTrpc.workspaces.openMainRepoWorkspace.useMutation
 	>[0],
 ) {
 	const navigate = useNavigate();
@@ -16,7 +16,7 @@ export function useCreateBranchWorkspace(
 	);
 	const updateProgress = useWorkspaceInitStore((s) => s.updateProgress);
 
-	return electronTrpc.workspaces.createBranchWorkspace.useMutation({
+	return electronTrpc.workspaces.openMainRepoWorkspace.useMutation({
 		...options,
 		onSuccess: async (data, ...rest) => {
 			await utils.workspaces.invalidate();
@@ -29,7 +29,7 @@ export function useCreateBranchWorkspace(
 					});
 				} catch (error) {
 					console.error(
-						"[useCreateBranchWorkspace] Failed to fetch setup commands:",
+						"[useOpenMainRepoWorkspace] Failed to fetch setup commands:",
 						error,
 					);
 				}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarFooter.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarFooter.tsx
@@ -10,7 +10,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useNavigate } from "@tanstack/react-router";
 import { LuFolderGit, LuFolderOpen, LuFolderPlus } from "react-icons/lu";
 import { useOpenProject } from "renderer/react-query/projects";
-import { useCreateBranchWorkspace } from "renderer/react-query/workspaces";
+import { useOpenMainRepoWorkspace } from "renderer/react-query/workspaces";
 import { STROKE_WIDTH } from "./constants";
 import { HostServiceStatus } from "./HostServiceStatus";
 
@@ -23,7 +23,7 @@ export function WorkspaceSidebarFooter({
 }: WorkspaceSidebarFooterProps) {
 	const navigate = useNavigate();
 	const { openNew, isPending: isOpenPending } = useOpenProject();
-	const createBranchWorkspace = useCreateBranchWorkspace();
+	const openMainRepoWorkspace = useOpenMainRepoWorkspace();
 
 	const handleOpenProject = async () => {
 		try {
@@ -31,7 +31,7 @@ export function WorkspaceSidebarFooter({
 
 			for (const project of projects) {
 				try {
-					await createBranchWorkspace.mutateAsync({
+					await openMainRepoWorkspace.mutateAsync({
 						projectId: project.id,
 					});
 				} catch (err) {
@@ -49,7 +49,7 @@ export function WorkspaceSidebarFooter({
 		}
 	};
 
-	const isLoading = isOpenPending || createBranchWorkspace.isPending;
+	const isLoading = isOpenPending || openMainRepoWorkspace.isPending;
 
 	if (isCollapsed) {
 		return (


### PR DESCRIPTION
## Summary
- route branch selection in the new workspace modal through worktree creation instead of the main-repo workspace path
- keep the main-repo workspace flow for opening repositories, but rename it to `openMainRepoWorkspace` so its purpose is explicit
- add a regression test for the branch-selection create payload

## Testing
- bun test apps/desktop/src/renderer/components/NewWorkspaceModal/components/BranchesGroup/BranchesGroup.test.ts apps/desktop/src/renderer/components/NewWorkspaceModal/components/BranchesGroup/resolveBranchAction.test.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes branch selection in the New Workspace modal by creating a worktree workspace for the chosen branch instead of a main-repo workspace. Clarifies the main-repo flow with a rename and adds a regression test.

- **Bug Fixes**
  - Route branch selection through worktree creation using `useCreateWorkspace` with `buildCreateWorkspaceFromBranchInput` (sends `{ projectId, branchName, useExistingBranch: true, applyPrefix: false }`).
  - Add a unit test to verify the branch-based create payload.

- **Refactors**
  - Rename TRPC procedure `createBranchWorkspace` to `openMainRepoWorkspace`; add `useOpenMainRepoWorkspace` and update sidebar usage.
  - Keep the “open repository” flow on the main-repo path; branch-based creation stays in the modal.

<sup>Written for commit b26ca95d3b3729aa49f570cdcb6a92165ad97aa4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit test validation for branch workspace creation workflow.

* **Refactor**
  * Updated workspace creation components with improved internal structure and helper functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->