### PR TITLE
feat(desktop): add Shift+Cmd+Enter to zoom/unzoom the focused pane

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -139,6 +139,7 @@ function WorkspacePage() {
 	const removeTab = useTabsStore((s) => s.removeTab);
 	const removePane = useTabsStore((s) => s.removePane);
 	const setFocusedPane = useTabsStore((s) => s.setFocusedPane);
+	const toggleZoomedPane = useTabsStore((s) => s.toggleZoomedPane);
 	const toggleSidebar = useSidebarStore((s) => s.toggleSidebar);
 	const isSidebarOpen = useSidebarStore((s) => s.isSidebarOpen);
 	const setSidebarOpen = useSidebarStore((s) => s.setSidebarOpen);
@@ -321,6 +322,17 @@ function WorkspacePage() {
 		},
 		undefined,
 		[activeTabId, activeTab?.layout, focusedPaneId, setFocusedPane],
+	);
+
+	useAppHotkey(
+		"ZOOM_PANE",
+		() => {
+			if (activeTabId && focusedPaneId) {
+				toggleZoomedPane(activeTabId, focusedPaneId);
+			}
+		},
+		undefined,
+		[activeTabId, focusedPaneId, toggleZoomedPane],
 	);
 
 	// Open in last used app shortcut

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabContentContextMenu.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabContentContextMenu.tsx
@@ -31,6 +31,8 @@ interface TabContentContextMenuProps {
 	onSplitVertical: PaneContextMenuActions["onSplitVertical"];
 	onSplitWithNewChat?: PaneContextMenuActions["onSplitWithNewChat"];
 	onSplitWithNewBrowser?: PaneContextMenuActions["onSplitWithNewBrowser"];
+	onToggleZoom?: PaneContextMenuActions["onToggleZoom"];
+	isZoomed?: PaneContextMenuActions["isZoomed"];
 	onClosePane: PaneContextMenuActions["onClosePane"];
 	onClearTerminal?: () => void;
 	onScrollToBottom?: () => void;
@@ -49,6 +51,8 @@ export function TabContentContextMenu({
 	onSplitVertical,
 	onSplitWithNewChat,
 	onSplitWithNewBrowser,
+	onToggleZoom,
+	isZoomed,
 	onClosePane,
 	onClearTerminal,
 	onScrollToBottom,
@@ -143,6 +147,8 @@ export function TabContentContextMenu({
 						onSplitVertical,
 						onSplitWithNewChat,
 						onSplitWithNewBrowser,
+						onToggleZoom,
+						isZoomed,
 						onClosePane,
 						currentTabId,
 						availableTabs,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraPane.tsx
@@ -67,6 +67,8 @@ export function ChatMastraPane({
 	const showDevToolbarActions = env.NODE_ENV === "development";
 	const isFocused = useTabsStore((s) => s.focusedPaneIds[tabId] === paneId);
 	const paneName = useTabsStore((s) => s.panes[paneId]?.name ?? "New Chat");
+	const isZoomed = useTabsStore((s) => s.zoomedPaneIds[tabId] === paneId);
+	const toggleZoomedPane = useTabsStore((s) => s.toggleZoomedPane);
 	const setTabAutoTitle = useTabsStore((s) => s.setTabAutoTitle);
 	const setPaneAutoTitle = useTabsStore((s) => s.setPaneAutoTitle);
 	const {
@@ -199,6 +201,8 @@ export function ChatMastraPane({
 						onSplitWithNewBrowser={() =>
 							splitPaneVertical(tabId, paneId, path, { paneType: "webview" })
 						}
+						onToggleZoom={() => toggleZoomedPane(tabId, paneId)}
+						isZoomed={isZoomed}
 						onClosePane={() => removePane(paneId)}
 						currentTabId={tabId}
 						availableTabs={availableTabs}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
@@ -61,6 +61,8 @@ export function FileViewerPane({
 	// Use granular selector to only get this pane's fileViewer data
 	const fileViewer = useTabsStore((s) => s.panes[paneId]?.fileViewer);
 	const isFocused = useTabsStore((s) => s.focusedPaneIds[tabId] === paneId);
+	const isZoomed = useTabsStore((s) => s.zoomedPaneIds[tabId] === paneId);
+	const toggleZoomedPane = useTabsStore((s) => s.toggleZoomedPane);
 	const {
 		viewMode: diffViewMode,
 		setViewMode: setDiffViewMode,
@@ -309,6 +311,8 @@ export function FileViewerPane({
 					onSplitWithNewBrowser={() =>
 						splitPaneVertical(tabId, paneId, path, { paneType: "webview" })
 					}
+					onToggleZoom={() => toggleZoomedPane(tabId, paneId)}
+					isZoomed={isZoomed}
 					onClosePane={() => removePane(paneId)}
 					currentTabId={tabId}
 					availableTabs={availableTabs}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileEditorContextMenu/FileEditorContextMenu.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileEditorContextMenu/FileEditorContextMenu.tsx
@@ -14,6 +14,8 @@ interface FileEditorContextMenuProps {
 	onSplitVertical: () => void;
 	onSplitWithNewChat?: () => void;
 	onSplitWithNewBrowser?: () => void;
+	onToggleZoom?: () => void;
+	isZoomed?: boolean;
 	onClosePane: () => void;
 	currentTabId: string;
 	availableTabs: Tab[];
@@ -29,6 +31,8 @@ export function FileEditorContextMenu({
 	onSplitVertical,
 	onSplitWithNewChat,
 	onSplitWithNewBrowser,
+	onToggleZoom,
+	isZoomed,
 	onClosePane,
 	currentTabId,
 	availableTabs,
@@ -51,6 +55,8 @@ export function FileEditorContextMenu({
 				onSplitVertical,
 				onSplitWithNewChat,
 				onSplitWithNewBrowser,
+				onToggleZoom,
+				isZoomed,
 				onClosePane,
 				currentTabId,
 				availableTabs,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
@@ -81,6 +81,8 @@ interface FileViewerContentProps {
 	onSplitVertical: () => void;
 	onSplitWithNewChat?: () => void;
 	onSplitWithNewBrowser?: () => void;
+	onToggleZoom?: () => void;
+	isZoomed?: boolean;
 	onClosePane: () => void;
 	currentTabId: string;
 	availableTabs: Tab[];
@@ -124,6 +126,8 @@ export function FileViewerContent({
 	onSplitVertical,
 	onSplitWithNewChat,
 	onSplitWithNewBrowser,
+	onToggleZoom,
+	isZoomed,
 	onClosePane,
 	currentTabId,
 	availableTabs,
@@ -314,6 +318,8 @@ export function FileViewerContent({
 			onSplitVertical={onSplitVertical}
 			onSplitWithNewChat={onSplitWithNewChat}
 			onSplitWithNewBrowser={onSplitWithNewBrowser}
+			onToggleZoom={onToggleZoom}
+			isZoomed={isZoomed}
 			onClosePane={onClosePane}
 			currentTabId={currentTabId}
 			availableTabs={availableTabs}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/TabPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/TabPane.tsx
@@ -58,6 +58,8 @@ export function TabPane({
 }: TabPaneProps) {
 	const paneName = useTabsStore((s) => s.panes[paneId]?.name);
 	const paneStatus = useTabsStore((s) => s.panes[paneId]?.status);
+	const isZoomed = useTabsStore((s) => s.zoomedPaneIds[tabId] === paneId);
+	const toggleZoomedPane = useTabsStore((s) => s.toggleZoomedPane);
 
 	const terminalContainerRef = useRef<HTMLDivElement>(null);
 	const getClearCallback = useTerminalCallbacksStore((s) => s.getClearCallback);
@@ -123,6 +125,8 @@ export function TabPane({
 				onSplitWithNewBrowser={() =>
 					splitPaneVertical(tabId, paneId, path, { paneType: "webview" })
 				}
+				onToggleZoom={() => toggleZoomedPane(tabId, paneId)}
+				isZoomed={isZoomed}
 				onClosePane={() => removePane(paneId)}
 				onClearTerminal={handleClearTerminal}
 				onScrollToBottom={handleScrollToBottom}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
@@ -86,8 +86,17 @@ export function TabView({ tab }: TabViewProps) {
 		return result;
 	}, [layoutPaneIds, allPanes, tab.id]);
 
+	const zoomedPaneId = useTabsStore(
+		(s) => s.zoomedPaneIds[tab.id],
+	);
 	const validPaneIds = new Set(Object.keys(tabPanes));
 	const cleanedLayout = cleanLayout(tab.layout, validPaneIds);
+
+	// When a pane is zoomed, show only that pane (if it's still valid)
+	const effectiveLayout =
+		zoomedPaneId && validPaneIds.has(zoomedPaneId)
+			? zoomedPaneId
+			: cleanedLayout;
 
 	// Auto-remove tab when all panes are gone
 	useEffect(() => {
@@ -267,7 +276,7 @@ export function TabView({ tab }: TabViewProps) {
 	);
 
 	// Tab will be removed by useEffect above
-	if (!cleanedLayout) {
+	if (!cleanedLayout || !effectiveLayout) {
 		return null;
 	}
 
@@ -275,7 +284,7 @@ export function TabView({ tab }: TabViewProps) {
 		<div className="relative w-full h-full mosaic-container">
 			<Mosaic<string>
 				renderTile={renderPane}
-				value={cleanedLayout}
+				value={effectiveLayout}
 				onChange={handleLayoutChange}
 				resize="DISABLED"
 				className={
@@ -285,10 +294,12 @@ export function TabView({ tab }: TabViewProps) {
 				}
 				dragAndDropManager={dragDropManager}
 			/>
-			<MosaicSplitOverlay
-				layout={cleanedLayout}
-				onLayoutChange={handleSplitLayoutChange}
-			/>
+			{!zoomedPaneId && (
+				<MosaicSplitOverlay
+					layout={cleanedLayout}
+					onLayoutChange={handleSplitLayoutChange}
+				/>
+			)}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PaneContextMenuItems/PaneContextMenuItems.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PaneContextMenuItems/PaneContextMenuItems.tsx
@@ -9,7 +9,9 @@ import {
 import {
 	LuColumns2,
 	LuGlobe,
+	LuMaximize2,
 	LuMessageSquare,
+	LuMinimize2,
 	LuMoveRight,
 	LuPlus,
 	LuRows2,
@@ -23,6 +25,8 @@ export interface PaneContextMenuActions {
 	onSplitVertical: () => void;
 	onSplitWithNewChat?: () => void;
 	onSplitWithNewBrowser?: () => void;
+	onToggleZoom?: () => void;
+	isZoomed?: boolean;
 	onClosePane: () => void;
 	currentTabId: string;
 	availableTabs: Tab[];
@@ -43,6 +47,7 @@ export function PaneContextMenuItems({
 	const splitRightShortcut = useHotkeyText("SPLIT_RIGHT");
 	const splitWithChatShortcut = useHotkeyText("SPLIT_WITH_CHAT");
 	const splitWithBrowserShortcut = useHotkeyText("SPLIT_WITH_BROWSER");
+	const zoomPaneShortcut = useHotkeyText("ZOOM_PANE");
 	const targetTabs = actions.availableTabs.filter(
 		(tab) => tab.id !== actions.currentTabId,
 	);
@@ -76,6 +81,20 @@ export function PaneContextMenuItems({
 					Split with New Browser
 					{renderShortcut(splitWithBrowserShortcut)}
 				</ContextMenuItem>
+			)}
+			{actions.onToggleZoom && (
+				<>
+					<ContextMenuSeparator />
+					<ContextMenuItem onSelect={actions.onToggleZoom}>
+						{actions.isZoomed ? (
+							<LuMinimize2 className="size-4" />
+						) : (
+							<LuMaximize2 className="size-4" />
+						)}
+						{actions.isZoomed ? "Unzoom Pane" : "Zoom Pane"}
+						{renderShortcut(zoomPaneShortcut)}
+					</ContextMenuItem>
+				</>
 			)}
 			<ContextMenuSeparator />
 			<ContextMenuSub>

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -108,6 +108,7 @@ export const useTabsStore = create<TabsStore>()(
 				focusedPaneIds: {},
 				tabHistoryStacks: {},
 				closedTabsStack: [],
+				zoomedPaneIds: {},
 
 				// Tab operations
 				addTab: (workspaceId, options?: CreatePaneOptions) => {
@@ -924,12 +925,25 @@ export const useTabsStore = create<TabsStore>()(
 
 					const tabName = deriveTabName(newPanes, tab.id);
 
+					// Clear zoom if the zoomed pane was removed
+					let newZoomedPaneIds = state.zoomedPaneIds;
+					if (
+						state.zoomedPaneIds[tab.id] &&
+						paneIdsToRemove.includes(state.zoomedPaneIds[tab.id]!)
+					) {
+						newZoomedPaneIds = {
+							...state.zoomedPaneIds,
+							[tab.id]: undefined,
+						};
+					}
+
 					set({
 						tabs: state.tabs.map((t) =>
 							t.id === tab.id ? { ...t, layout: newLayout, name: tabName } : t,
 						),
 						panes: newPanes,
 						focusedPaneIds: newFocusedPaneIds,
+						zoomedPaneIds: newZoomedPaneIds,
 					});
 				},
 
@@ -1318,6 +1332,18 @@ export const useTabsStore = create<TabsStore>()(
 
 					set(moveResult.result);
 					return moveResult.newTabId;
+				},
+
+				// Zoom operations
+				toggleZoomedPane: (tabId, paneId) => {
+					const state = get();
+					const current = state.zoomedPaneIds[tabId];
+					set({
+						zoomedPaneIds: {
+							...state.zoomedPaneIds,
+							[tabId]: current === paneId ? undefined : paneId,
+						},
+					});
 				},
 
 				// Browser operations

--- a/apps/desktop/src/renderer/stores/tabs/types.ts
+++ b/apps/desktop/src/renderer/stores/tabs/types.ts
@@ -39,6 +39,8 @@ export interface Tab extends BaseTab {
 export interface TabsState extends Omit<BaseTabsState, "tabs"> {
 	tabs: Tab[];
 	closedTabsStack: ClosedTabEntry[];
+	/** Per-tab zoomed pane: when set, only this pane is shown in the tab */
+	zoomedPaneIds: Record<string, string | undefined>;
 }
 
 /**
@@ -205,6 +207,9 @@ export interface TabsStore extends TabsState {
 		paneId: string,
 		launchConfig: AddChatMastraTabOptions["launchConfig"],
 	) => void;
+
+	// Zoom operations
+	toggleZoomedPane: (tabId: string, paneId: string) => void;
 
 	// Query helpers
 	getTabsByWorkspace: (workspaceId: string) => Tab[];

--- a/apps/desktop/src/shared/hotkeys.ts
+++ b/apps/desktop/src/shared/hotkeys.ts
@@ -520,6 +520,12 @@ export const HOTKEYS = {
 		category: "Layout",
 		description: "Close the current pane",
 	}),
+	ZOOM_PANE: defineHotkey({
+		keys: "meta+shift+enter",
+		label: "Zoom Pane",
+		category: "Layout",
+		description: "Toggle zoom on the focused pane to fill the tab",
+	}),
 
 	// Terminal
 	FIND_IN_TERMINAL: defineHotkey({


### PR DESCRIPTION
## Summary
- Adds a **Zoom Pane** toggle (⇧⌘↵ on Mac, Ctrl+Shift+Alt+Enter on Windows/Linux) that expands the focused pane to fill the entire tab area
- Pressing the shortcut again (or right-click > Unzoom Pane) restores the original multi-pane layout
- Zoom state is per-tab and auto-clears when a zoomed pane is removed

## Test plan
- [ ] Split a tab into 2+ panes, focus one, press ⇧⌘↵ — pane fills tab
- [ ] Press ⇧⌘↵ again — original layout restores
- [ ] Right-click pane → verify "Zoom Pane" / "Unzoom Pane" menu item works
- [ ] Close a zoomed pane — tab should not break
- [ ] Verify zoom works across terminal, chat, file-viewer, and browser panes
- [ ] Check shortcut appears in keyboard shortcuts modal (⌘/)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per‑tab Zoom Pane toggle to focus the current pane. Expands the focused pane to fill the tab and restores the original layout on toggle.

- **New Features**
  - New `ZOOM_PANE` hotkey (⇧⌘↵ on macOS; Ctrl+Shift+Alt+Enter on Windows/Linux) to zoom/unzoom the focused pane; shown in the shortcuts modal.
  - Pane context menu adds "Zoom Pane" / "Unzoom Pane" with shortcut hint.
  - Zoom is per tab, hides split controls while active, and auto‑clears if the zoomed pane is closed.
  - Works across terminal, chat, file viewer, and browser panes.

<sup>Written for commit 5aac62e0738a6c18b057248125063b64a4e496de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a zoom pane feature to maximize the focused pane within a tab, hiding other panes
  * New keyboard shortcut: Cmd+Shift+Enter to toggle zoom on the current pane
  * Added zoom toggle options to context menus in file viewer and chat panes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->