### PR TITLE
feat(desktop): add ⌘+Backspace shortcut to delete current workspace

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -4,7 +4,10 @@ import {
 	useMatchRoute,
 	useNavigate,
 } from "@tanstack/react-router";
+import { useCallback } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useDeleteWorkspace } from "renderer/react-query/workspaces";
+import { deleteWithToast } from "renderer/routes/_authenticated/components/TeardownLogsDialog";
 import { ResizablePanel } from "renderer/screens/main/components/ResizablePanel";
 import { WorkspaceSidebar } from "renderer/screens/main/components/WorkspaceSidebar";
 import { useAppHotkey } from "renderer/stores/hotkeys";
@@ -87,6 +90,31 @@ function DashboardLayout() {
 		undefined,
 		[openNewWorkspaceModal, currentWorkspace?.projectId],
 	);
+
+	const deleteWorkspace = useDeleteWorkspace();
+
+	const handleDeleteWorkspace = useCallback(() => {
+		if (!currentWorkspaceId || !currentWorkspace) return;
+
+		deleteWithToast({
+			name: currentWorkspace.name,
+			deleteFn: () =>
+				deleteWorkspace.mutateAsync({
+					id: currentWorkspaceId,
+					deleteLocalBranch: false,
+				}),
+			forceDeleteFn: () =>
+				deleteWorkspace.mutateAsync({
+					id: currentWorkspaceId,
+					deleteLocalBranch: false,
+					force: true,
+				}),
+		});
+	}, [currentWorkspaceId, currentWorkspace, deleteWorkspace]);
+
+	useAppHotkey("DELETE_WORKSPACE", handleDeleteWorkspace, undefined, [
+		handleDeleteWorkspace,
+	]);
 
 	return (
 		<div className="flex flex-col h-full w-full">

--- a/apps/desktop/src/shared/hotkeys.ts
+++ b/apps/desktop/src/shared/hotkeys.ts
@@ -730,6 +730,12 @@ export const HOTKEYS = {
 		category: "Workspace",
 		description: "Open existing PR or create a new one on GitHub",
 	}),
+	DELETE_WORKSPACE: defineHotkey({
+		keys: "meta+backspace",
+		label: "Delete Workspace",
+		category: "Workspace",
+		description: "Delete the current workspace and run teardown",
+	}),
 
 	// Window
 	NEW_WINDOW: defineHotkey({


### PR DESCRIPTION
## Summary
- Adds a `DELETE_WORKSPACE` hotkey (`⌘+Backspace` on Mac, `Ctrl+Shift+Backspace` on Windows/Linux) that immediately deletes the current workspace
- Skips the confirmation dialog — directly triggers teardown and deletion via `deleteWithToast`
- If teardown fails, the existing toast UI with "Delete Anyway" and "View Logs" options still appears

## Test plan
- [ ] Open a workspace and press `⌘+Backspace` — workspace should be deleted with a toast notification
- [ ] Verify teardown commands run (check toast progress)
- [ ] If teardown fails, verify "Delete Anyway" / "View Logs" toast actions work
- [ ] Verify the shortcut appears in Settings > Keyboard under the Workspace category
- [ ] Verify shortcut does nothing when no workspace is active

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `DELETE_WORKSPACE` shortcut (⌘+Backspace) to instantly tear down and delete the current workspace. Skips the confirmation dialog and shows progress/failure actions via the existing toast.

- **New Features**
  - Registers `DELETE_WORKSPACE` in the Workspace category; visible in Settings > Keyboard.
  - Binds the shortcut to run teardown with toast feedback and fallback actions ("Delete Anyway", "View Logs").
  - No-op when no workspace is active.

<sup>Written for commit 3fff43f0855f93252a3bbaf9e5a4820b1b5fb5f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut (Meta+Backspace) to delete workspaces quickly from the dashboard
  * Workspace deletion now supports configurable options for managing associated local branches during removal
  * Integrated delete functionality into the application's hotkey system for seamless keyboard-driven access
  * Users receive toast notifications confirming successful workspace deletion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->