### PR TITLE
feat(cli): add superset cli tool

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -759,8 +759,16 @@
       },
     },
     "packages/scripts": {
-      "name": "@superset/scripts",
+      "name": "@superset/cli",
       "version": "0.1.0",
+      "bin": {
+        "superset": "./src/bin.ts",
+      },
+      "devDependencies": {
+        "@superset/typescript": "workspace:*",
+        "bun-types": "^1.3.1",
+        "typescript": "^5.9.3",
+      },
     },
     "packages/shared": {
       "name": "@superset/shared",
@@ -2279,6 +2287,8 @@
 
     "@superset/chat": ["@superset/chat@workspace:packages/chat"],
 
+    "@superset/cli": ["@superset/cli@workspace:packages/scripts"],
+
     "@superset/db": ["@superset/db@workspace:packages/db"],
 
     "@superset/desktop": ["@superset/desktop@workspace:apps/desktop"],
@@ -2300,8 +2310,6 @@
     "@superset/mcp": ["@superset/mcp@workspace:packages/mcp"],
 
     "@superset/mobile": ["@superset/mobile@workspace:apps/mobile"],
-
-    "@superset/scripts": ["@superset/scripts@workspace:packages/scripts"],
 
     "@superset/shared": ["@superset/shared@workspace:packages/shared"],
 

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -8,7 +8,7 @@ The `superset` CLI lets users interact with the Superset desktop app from the te
 
 ## Architecture
 
-```
+```text
 ┌──────────────┐         superset://          ┌──────────────────┐
 │  superset    │  ──── deep link protocol ──► │  Desktop App     │
 │  CLI binary  │                              │  (Electron)      │
@@ -47,7 +47,7 @@ Follows the existing `@superset/desktop-mcp` pattern: `bin` field in `package.js
 
 Open a project in the desktop app.
 
-```
+```bash
 superset .                  # open cwd
 superset ~/Projects/myapp   # open specific path
 ```
@@ -66,7 +66,7 @@ superset ~/Projects/myapp   # open specific path
 
 Open a project with a named worktree workspace. Path defaults to cwd.
 
-```
+```bash
 superset worktree my-feature
 superset worktree hotfix-auth ~/Projects/myapp
 ```
@@ -84,7 +84,7 @@ This creates a full git worktree — a separate working directory with its own c
 
 Open a project with a branch-type workspace. Path defaults to cwd.
 
-```
+```bash
 superset branch feature/onboarding
 superset branch fix/typo ~/Projects/myapp
 ```
@@ -101,7 +101,7 @@ Unlike `worktree`, this is lightweight — no separate directory on disk, just a
 
 Open the built-in browser pane for the current workspace's dev server. Equivalent to pressing `cmd+shift+b` in the app, but pre-navigated to the detected (or specified) port.
 
-```
+```bash
 superset dev         # auto-detect running dev server port
 superset dev 3001    # open browser to localhost:3001
 ```
@@ -119,7 +119,7 @@ superset dev 3001    # open browser to localhost:3001
 
 Initiate authentication.
 
-```
+```bash
 superset login
 ```
 
@@ -134,7 +134,7 @@ superset login
 
 Clear the current auth session.
 
-```
+```bash
 superset logout
 ```
 
@@ -148,12 +148,12 @@ superset logout
 
 Show project and workspace info for the current directory. This is a read-only command — it queries the local SQLite database directly without needing the desktop app to be running.
 
-```
+```bash
 superset status
 ```
 
 **Example output:**
-```
+```text
 Project:    myapp
 Path:       ~/Projects/myapp
 Branch:     main
@@ -165,7 +165,7 @@ Workspaces: 3 (2 worktree, 1 branch)
 
 **Flow:**
 1. Resolve cwd to absolute path
-2. Query `projects` table by `mainRepoPath`
+2. Query `projects` table by `mainRepoPath`, falling back to `worktrees` table by `path` (supports running from inside a worktree directory)
 3. Query `workspaces` and `worktrees` tables by `projectId`
 4. Print formatted output
 
@@ -177,12 +177,12 @@ If no project found: `No Superset project found for this directory.`
 
 List all known projects. Read-only, queries local SQLite directly.
 
-```
+```bash
 superset list
 ```
 
 **Example output:**
-```
+```text
 Projects:
   myapp         ~/Projects/myapp          last opened 2h ago
   website       ~/Projects/website        last opened 1d ago
@@ -195,7 +195,7 @@ Projects:
 
 Open the PR view for the current branch's workspace.
 
-```
+```bash
 superset pr
 ```
 
@@ -209,7 +209,7 @@ superset pr
 
 Open a Superset URL directly in the desktop app. Useful for opening shared links (e.g., from Slack or a browser) in the native app instead of the web.
 
-```
+```bash
 superset open https://app.superset.sh/workspace/abc123
 superset open superset://project/xyz
 ```
@@ -225,7 +225,7 @@ superset open superset://project/xyz
 
 View and manage CLI configuration.
 
-```
+```bash
 superset config                  # show current config
 superset config set <key> <val>  # set a config value
 superset config get <key>        # get a config value

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -1,0 +1,289 @@
+# Superset CLI Specification
+
+## Overview
+
+The `superset` CLI lets users interact with the Superset desktop app from the terminal. Instead of switching to the app to open a project, create a worktree, or check status, users can do it inline from their shell.
+
+**Scope:** macOS first. Other platforms are future work.
+
+## Architecture
+
+```
+┌──────────────┐         superset://          ┌──────────────────┐
+│  superset    │  ──── deep link protocol ──► │  Desktop App     │
+│  CLI binary  │                              │  (Electron)      │
+│              │  ◄─── local SQLite reads ──  │                  │
+└──────────────┘                              └──────────────────┘
+```
+
+Two layers:
+
+1. **CLI layer** — parses arguments, resolves paths, constructs intent. Lives in `packages/scripts/`.
+2. **Desktop bridge** — communicates with the desktop app via the `superset://` deep link protocol (already registered in `apps/desktop/electron-builder.ts` and handled in `apps/desktop/src/main/index.ts`). Read-only queries (status, list) go directly against the local SQLite database via `@superset/local-db`.
+
+The CLI does not embed application logic. It translates user intent into either a deep link (for actions that need the desktop app) or a local DB query (for read-only info).
+
+## Package
+
+| Field | Value |
+|-------|-------|
+| Location | `packages/scripts/` |
+| Package name | `@superset/cli` |
+| Binary name | `superset` |
+| Entry point | `src/bin.ts` |
+| Runtime | Bun |
+
+Follows the existing `@superset/desktop-mcp` pattern: `bin` field in `package.json` points directly to a `.ts` file with a `#!/usr/bin/env node` shebang.
+
+### Dependencies
+
+- `@superset/local-db` — read project/worktree/workspace data from local SQLite
+- Lightweight arg parser (e.g., `arg`) or manual parsing — the command surface is small enough either way
+- `open` (or `Bun.spawn` with macOS `open` command) — to trigger `superset://` URLs
+
+## Command Reference
+
+### `superset .` / `superset <path>`
+
+Open a project in the desktop app.
+
+```
+superset .                  # open cwd
+superset ~/Projects/myapp   # open specific path
+```
+
+**Flow:**
+1. Resolve the path to an absolute directory
+2. Query local SQLite `projects` table for a matching `mainRepoPath`
+3. If found → deep link to focus that project
+4. If not found → deep link to create and open it from the given path
+
+**Output:** `Opening in Superset...` then exit (fire-and-forget).
+
+---
+
+### `superset worktree <name> [path]`
+
+Open a project with a named worktree workspace. Path defaults to cwd.
+
+```
+superset worktree my-feature
+superset worktree hotfix-auth ~/Projects/myapp
+```
+
+**Flow:**
+1. Resolve path to project (same as `superset .`)
+2. Signal the desktop app to open or create a worktree-type workspace with the given name
+3. Desktop app creates the git worktree on disk if it doesn't exist
+
+This creates a full git worktree — a separate working directory with its own checked-out branch.
+
+---
+
+### `superset branch <name> [path]`
+
+Open a project with a branch-type workspace. Path defaults to cwd.
+
+```
+superset branch feature/onboarding
+superset branch fix/typo ~/Projects/myapp
+```
+
+**Flow:**
+1. Resolve path to project
+2. Signal desktop app to open or create a branch-type workspace
+
+Unlike `worktree`, this is lightweight — no separate directory on disk, just a branch switch within the existing working tree.
+
+---
+
+### `superset dev [port]`
+
+Open the built-in browser pane for the current workspace's dev server. Equivalent to pressing `cmd+shift+b` in the app, but pre-navigated to the detected (or specified) port.
+
+```
+superset dev         # auto-detect running dev server port
+superset dev 3001    # open browser to localhost:3001
+```
+
+**Flow:**
+1. Resolve cwd to a project and workspace (match against `mainRepoPath` or worktree `path`)
+2. Signal the desktop app to open a browser pane in that workspace
+3. If a port is specified, navigate to `localhost:<port>`
+4. If no port specified, the app uses its port manager (which scans for listening TCP ports via `lsof` every 2.5s) to detect the dev server
+5. If no port detected yet, opens browser to `about:blank` — the port badge appears once the server is up
+
+---
+
+### `superset login`
+
+Initiate authentication.
+
+```
+superset login
+```
+
+**Flow:**
+1. Deep link to the desktop app's auth/login flow
+2. Desktop app handles OAuth
+3. CLI prints `Opening login...` and exits
+
+---
+
+### `superset logout`
+
+Clear the current auth session.
+
+```
+superset logout
+```
+
+**Flow:**
+1. Deep link to the desktop app's logout/session-clear flow
+2. CLI prints `Logged out.` and exits
+
+---
+
+### `superset status`
+
+Show project and workspace info for the current directory. This is a read-only command — it queries the local SQLite database directly without needing the desktop app to be running.
+
+```
+superset status
+```
+
+**Example output:**
+```
+Project:    myapp
+Path:       ~/Projects/myapp
+Branch:     main
+Workspaces: 3 (2 worktree, 1 branch)
+  ● my-feature  worktree  ~/.superset/worktrees/myapp/my-feature
+  ● hotfix-auth  worktree  ~/.superset/worktrees/myapp/hotfix-auth
+  ○ staging      branch
+```
+
+**Flow:**
+1. Resolve cwd to absolute path
+2. Query `projects` table by `mainRepoPath`
+3. Query `workspaces` and `worktrees` tables by `projectId`
+4. Print formatted output
+
+If no project found: `No Superset project found for this directory.`
+
+---
+
+### `superset list`
+
+List all known projects. Read-only, queries local SQLite directly.
+
+```
+superset list
+```
+
+**Example output:**
+```
+Projects:
+  myapp         ~/Projects/myapp          last opened 2h ago
+  website       ~/Projects/website        last opened 1d ago
+  api-server    ~/Projects/api-server     last opened 3d ago
+```
+
+---
+
+### `superset pr`
+
+Open the PR view for the current branch's workspace.
+
+```
+superset pr
+```
+
+**Flow:**
+1. Resolve cwd to project and detect current git branch
+2. Deep link to open the PR view for that branch in the desktop app
+
+---
+
+### `superset open <url>`
+
+Open a Superset URL directly in the desktop app. Useful for opening shared links (e.g., from Slack or a browser) in the native app instead of the web.
+
+```
+superset open https://app.superset.sh/workspace/abc123
+superset open superset://project/xyz
+```
+
+**Flow:**
+1. If the URL is an `https://app.superset.sh/...` URL, extract the path and convert to a deep link
+2. If the URL is already a `superset://` protocol URL, pass it through directly
+3. Open via deep link — desktop app navigates to the appropriate view
+
+---
+
+### `superset config`
+
+View and manage CLI configuration.
+
+```
+superset config                  # show current config
+superset config set <key> <val>  # set a config value
+superset config get <key>        # get a config value
+superset config reset            # reset to defaults
+```
+
+**Config options:**
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `default-workspace-type` | `worktree` | Default type for new workspaces (`worktree` or `branch`) |
+| `auto-open` | `true` | Whether to launch the desktop app if not running |
+| `output` | `text` | Output format (`text` or `json`) for status/list commands |
+
+**Storage:** Config is stored in `~/.superset/cli.json`. The CLI reads this on every invocation.
+
+---
+
+## Installation
+
+The CLI should be auto-installed to `/usr/local/bin/superset` as part of the desktop app's install process, similar to how VS Code installs the `code` command.
+
+**Implementation approach:**
+- During the Electron app build (`electron-builder.ts`), include a post-install step that symlinks or copies the CLI binary to `/usr/local/bin/superset`
+- The binary should be a small shell wrapper or bun-compiled binary that invokes the CLI entry point
+- For development: `bun link` in `packages/scripts/` makes the command available globally
+
+**Considerations:**
+- `/usr/local/bin/` may require elevated permissions — handle gracefully with a prompt or fall back to `~/.local/bin/`
+- Provide a manual install command in the app's settings (like VS Code's "Install 'code' command in PATH")
+
+## Desktop-Side Requirements
+
+The desktop app needs to handle CLI-originated intents. The specific protocol routes and IPC mechanisms are internal implementation details. At minimum, the desktop app must support:
+
+- **Open project by path** — given a filesystem path, create or focus the project
+- **Open worktree workspace** — given a project + worktree name, create or focus the worktree workspace
+- **Open branch workspace** — given a project + branch name, create or focus the branch workspace
+- **Open browser pane** — given a workspace (+ optional port), open the built-in browser
+- **Auth flows** — login and logout triggered externally
+- **PR view** — navigate to PR view for a given branch
+- **URL routing** — accept `app.superset.sh` URLs and navigate to the corresponding view
+
+The existing deep link infrastructure (`processDeepLink` in `apps/desktop/src/main/index.ts`, renderer IPC via `deep-link-navigate`) provides the foundation. Route handling on the renderer side (TanStack Router) will need new routes or query params to support these intents.
+
+## Key Existing Infrastructure
+
+| Component | Location | Relevance |
+|-----------|----------|-----------|
+| Deep link protocol | `apps/desktop/electron-builder.ts:114-118` | `superset://` scheme registration |
+| Deep link handler | `apps/desktop/src/main/index.ts:59-92` | Processes incoming protocol URLs |
+| Local DB schema | `packages/local-db/src/schema/schema.ts` | projects, worktrees, workspaces tables |
+| Port manager | `apps/desktop/src/main/lib/terminal/port-manager.ts` | Dev server port detection |
+| Browser hotkey | `apps/desktop/src/shared/hotkeys.ts:552-556` | `meta+shift+b` → NEW_BROWSER |
+| Existing CLI pattern | `packages/desktop-mcp/src/bin.ts` | Reference for bin entry structure |
+
+## Future Considerations
+
+- `superset task <description>` — create a task from the terminal
+- Windows/Linux support
+- Shell completions (bash, zsh, fish)

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -33,7 +33,7 @@ The CLI does not embed application logic. It translates user intent into either 
 | Entry point | `src/bin.ts` |
 | Runtime | Bun |
 
-Follows the existing `@superset/desktop-mcp` pattern: `bin` field in `package.json` points directly to a `.ts` file with a `#!/usr/bin/env node` shebang.
+Follows the existing `@superset/desktop-mcp` pattern: `bin` field in `package.json` points directly to a `.ts` file with a `#!/usr/bin/env bun` shebang.
 
 ### Dependencies
 

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,9 +1,18 @@
 {
-	"name": "@superset/scripts",
+	"name": "@superset/cli",
 	"version": "0.1.0",
 	"private": true,
 	"type": "module",
+	"bin": {
+		"superset": "./src/bin.ts"
+	},
 	"scripts": {
-		"clean": "git clean -xdf .cache .turbo dist node_modules"
+		"clean": "git clean -xdf .cache .turbo dist node_modules",
+		"typecheck": "tsc --noEmit --emitDeclarationOnly false"
+	},
+	"devDependencies": {
+		"@superset/typescript": "workspace:*",
+		"bun-types": "^1.3.1",
+		"typescript": "^5.9.3"
 	}
 }

--- a/packages/scripts/src/bin.ts
+++ b/packages/scripts/src/bin.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env bun
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { branchCommand } from "./commands/branch.js";
 import { configCommand } from "./commands/config.js";
 import { devCommand } from "./commands/dev.js";
@@ -12,7 +14,10 @@ import { statusCommand } from "./commands/status.js";
 import { worktreeCommand } from "./commands/worktree.js";
 import { bold, dim } from "./lib/output.js";
 
-const VERSION = "0.1.0";
+const pkg = JSON.parse(
+	readFileSync(join(import.meta.dirname, "../package.json"), "utf-8"),
+);
+const VERSION: string = pkg.version;
 
 const args = process.argv.slice(2);
 const command = args[0];

--- a/packages/scripts/src/bin.ts
+++ b/packages/scripts/src/bin.ts
@@ -1,0 +1,94 @@
+#!/usr/bin/env bun
+import { branchCommand } from "./commands/branch.js";
+import { configCommand } from "./commands/config.js";
+import { devCommand } from "./commands/dev.js";
+import { listCommand } from "./commands/list.js";
+import { loginCommand } from "./commands/login.js";
+import { logoutCommand } from "./commands/logout.js";
+import { openCommand } from "./commands/open.js";
+import { openUrlCommand } from "./commands/open-url.js";
+import { prCommand } from "./commands/pr.js";
+import { statusCommand } from "./commands/status.js";
+import { worktreeCommand } from "./commands/worktree.js";
+import { bold, dim } from "./lib/output.js";
+
+const VERSION = "0.1.0";
+
+const args = process.argv.slice(2);
+const command = args[0];
+
+if (!command || command === "--help" || command === "-h") {
+	printHelp();
+	process.exit(0);
+}
+
+if (command === "--version" || command === "-v") {
+	console.log(VERSION);
+	process.exit(0);
+}
+
+const commandArgs = args.slice(1);
+
+switch (command) {
+	case "worktree":
+		worktreeCommand(commandArgs);
+		break;
+	case "branch":
+		branchCommand(commandArgs);
+		break;
+	case "dev":
+		devCommand(commandArgs);
+		break;
+	case "login":
+		loginCommand();
+		break;
+	case "logout":
+		logoutCommand();
+		break;
+	case "status":
+		statusCommand();
+		break;
+	case "list":
+		listCommand();
+		break;
+	case "pr":
+		prCommand();
+		break;
+	case "open":
+		openUrlCommand(commandArgs);
+		break;
+	case "config":
+		configCommand(commandArgs);
+		break;
+	default:
+		// Treat as a path: superset . / superset ~/Projects/myapp
+		openCommand([command, ...commandArgs]);
+		break;
+}
+
+function printHelp(): void {
+	console.log(`
+${bold("superset")} - Superset CLI ${dim(`v${VERSION}`)}
+
+${bold("Usage:")}
+  superset <command> [options]
+  superset <path>              Open a project in Superset
+
+${bold("Commands:")}
+  ${bold(".")} / ${bold("<path>")}                  Open a project by path
+  ${bold("worktree")} <name> [path]      Create/open a worktree workspace
+  ${bold("branch")} <name> [path]        Create/open a branch workspace
+  ${bold("dev")} [port]                  Open dev server browser pane
+  ${bold("login")}                       Sign in to Superset
+  ${bold("logout")}                      Sign out of Superset
+  ${bold("status")}                      Show project info for current directory
+  ${bold("list")}                        List all known projects
+  ${bold("pr")}                          Open PR view for current branch
+  ${bold("open")} <url>                  Open a Superset URL in the desktop app
+  ${bold("config")} [set|get|reset]      Manage CLI configuration
+
+${bold("Options:")}
+  -h, --help                   Show this help message
+  -v, --version                Show version
+`);
+}

--- a/packages/scripts/src/commands/branch.ts
+++ b/packages/scripts/src/commands/branch.ts
@@ -1,0 +1,32 @@
+import { findProjectByPath } from "../lib/db.js";
+import { openDeepLink } from "../lib/deep-link.js";
+import { error, info } from "../lib/output.js";
+import { resolveProjectPath } from "../lib/resolve.js";
+
+export function branchCommand(args: string[]): void {
+	const name = args[0];
+	if (!name) {
+		error("Usage: superset branch <name> [path]");
+		process.exit(1);
+	}
+
+	let absPath: string;
+	try {
+		absPath = resolveProjectPath(args[1]);
+	} catch (e) {
+		error((e as Error).message);
+		process.exit(1);
+	}
+
+	const project = findProjectByPath(absPath);
+	if (!project) {
+		openDeepLink(
+			`open?path=${encodeURIComponent(absPath)}&branch=${encodeURIComponent(name)}`,
+		);
+		info(`Opening ${absPath} with branch ${name} in Superset...`);
+		return;
+	}
+
+	openDeepLink(`project/${project.id}/branch/${encodeURIComponent(name)}`);
+	info(`Opening branch ${name} in ${project.name}...`);
+}

--- a/packages/scripts/src/commands/config.ts
+++ b/packages/scripts/src/commands/config.ts
@@ -1,0 +1,76 @@
+import {
+	type CliConfig,
+	CONFIG_KEYS,
+	loadConfig,
+	resetConfig,
+	setConfigValue,
+} from "../lib/config.js";
+import { bold, dim, error, green, info } from "../lib/output.js";
+
+export function configCommand(args: string[]): void {
+	const subcommand = args[0];
+
+	if (!subcommand) {
+		showConfig();
+		return;
+	}
+
+	switch (subcommand) {
+		case "set":
+			setCommand(args.slice(1));
+			break;
+		case "get":
+			getCommand(args.slice(1));
+			break;
+		case "reset":
+			resetConfig();
+			info("Config reset to defaults.");
+			break;
+		default:
+			error(`Unknown subcommand: ${subcommand}. Use set, get, or reset.`);
+			process.exit(1);
+	}
+}
+
+function showConfig(): void {
+	const config = loadConfig();
+	console.log(bold("CLI Config:"));
+	for (const [key, desc] of Object.entries(CONFIG_KEYS)) {
+		const value = config[key as keyof CliConfig];
+		console.log(`  ${key} = ${green(String(value))}  ${dim(desc)}`);
+	}
+}
+
+function setCommand(args: string[]): void {
+	const [key, value] = args;
+	if (!key || !value) {
+		error("Usage: superset config set <key> <value>");
+		process.exit(1);
+	}
+
+	try {
+		setConfigValue(key, value);
+		info(`Set ${key} = ${value}`);
+	} catch (e) {
+		error((e as Error).message);
+		process.exit(1);
+	}
+}
+
+function getCommand(args: string[]): void {
+	const key = args[0];
+	if (!key) {
+		error("Usage: superset config get <key>");
+		process.exit(1);
+	}
+
+	const config = loadConfig();
+	if (!(key in config)) {
+		error(
+			`Unknown key: ${key}. Valid keys: ${Object.keys(CONFIG_KEYS).join(", ")}`,
+		);
+		process.exit(1);
+	}
+
+	console.log(config[key as keyof CliConfig]);
+}

--- a/packages/scripts/src/commands/dev.ts
+++ b/packages/scripts/src/commands/dev.ts
@@ -1,12 +1,16 @@
-import { findProjectByPath, findWorkspaceByBranch } from "../lib/db.js";
+import { findWorkspaceByBranch, resolveProject } from "../lib/db.js";
 import { openDeepLink } from "../lib/deep-link.js";
 import { error, info } from "../lib/output.js";
 import { getCurrentBranch, resolveProjectPath } from "../lib/resolve.js";
 
 export function devCommand(args: string[]): void {
-	const port = args[0] ? Number.parseInt(args[0], 10) : undefined;
-	if (port !== undefined && (Number.isNaN(port) || port < 1 || port > 65535)) {
+	if (args[0] && !/^\d+$/.test(args[0])) {
 		error(`Invalid port: ${args[0]}`);
+		process.exit(1);
+	}
+	const port = args[0] ? Number.parseInt(args[0], 10) : undefined;
+	if (port !== undefined && (port < 1 || port > 65535)) {
+		error(`Port out of range: ${port}. Must be 1-65535.`);
 		process.exit(1);
 	}
 
@@ -18,7 +22,7 @@ export function devCommand(args: string[]): void {
 		process.exit(1);
 	}
 
-	const project = findProjectByPath(absPath);
+	const project = resolveProject(absPath);
 	if (!project) {
 		error("No Superset project found for this directory.");
 		process.exit(1);

--- a/packages/scripts/src/commands/dev.ts
+++ b/packages/scripts/src/commands/dev.ts
@@ -1,0 +1,41 @@
+import { findProjectByPath, findWorkspaceByBranch } from "../lib/db.js";
+import { openDeepLink } from "../lib/deep-link.js";
+import { error, info } from "../lib/output.js";
+import { getCurrentBranch, resolveProjectPath } from "../lib/resolve.js";
+
+export function devCommand(args: string[]): void {
+	const port = args[0] ? Number.parseInt(args[0], 10) : undefined;
+	if (port !== undefined && (Number.isNaN(port) || port < 1 || port > 65535)) {
+		error(`Invalid port: ${args[0]}`);
+		process.exit(1);
+	}
+
+	let absPath: string;
+	try {
+		absPath = resolveProjectPath();
+	} catch (e) {
+		error((e as Error).message);
+		process.exit(1);
+	}
+
+	const project = findProjectByPath(absPath);
+	if (!project) {
+		error("No Superset project found for this directory.");
+		process.exit(1);
+	}
+
+	const branch = getCurrentBranch(absPath);
+	const workspace = branch
+		? findWorkspaceByBranch(project.id, branch)
+		: undefined;
+
+	const portParam = port ? `?port=${port}` : "";
+
+	if (workspace) {
+		openDeepLink(`project/${project.id}/dev/${workspace.id}${portParam}`);
+	} else {
+		openDeepLink(`project/${project.id}/dev${portParam}`);
+	}
+
+	info(`Opening dev server${port ? ` on port ${port}` : ""} in Superset...`);
+}

--- a/packages/scripts/src/commands/list.ts
+++ b/packages/scripts/src/commands/list.ts
@@ -1,0 +1,27 @@
+import { getAllProjects } from "../lib/db.js";
+import {
+	bold,
+	dim,
+	formatRelativeTime,
+	info,
+	printTable,
+} from "../lib/output.js";
+import { tildeContract } from "../lib/resolve.js";
+
+export function listCommand(): void {
+	const projects = getAllProjects();
+
+	if (projects.length === 0) {
+		info("No projects found. Open a project in Superset first.");
+		return;
+	}
+
+	console.log(bold("Projects:"));
+	printTable(
+		projects.map((p) => [
+			p.name,
+			dim(tildeContract(p.main_repo_path)),
+			dim(formatRelativeTime(p.last_opened_at)),
+		]),
+	);
+}

--- a/packages/scripts/src/commands/login.ts
+++ b/packages/scripts/src/commands/login.ts
@@ -1,0 +1,7 @@
+import { openDeepLink } from "../lib/deep-link.js";
+import { info } from "../lib/output.js";
+
+export function loginCommand(): void {
+	openDeepLink("auth/login");
+	info("Opening login in Superset...");
+}

--- a/packages/scripts/src/commands/logout.ts
+++ b/packages/scripts/src/commands/logout.ts
@@ -1,0 +1,7 @@
+import { openDeepLink } from "../lib/deep-link.js";
+import { info } from "../lib/output.js";
+
+export function logoutCommand(): void {
+	openDeepLink("auth/logout");
+	info("Logging out of Superset...");
+}

--- a/packages/scripts/src/commands/open-url.ts
+++ b/packages/scripts/src/commands/open-url.ts
@@ -19,14 +19,15 @@ export function openUrlCommand(args: string[]): void {
 
 	try {
 		const parsed = new URL(url);
-		if (parsed.hostname === APP_DOMAIN) {
+		if (parsed.protocol === "https:" && parsed.hostname === APP_DOMAIN) {
 			const path = parsed.pathname.slice(1) + parsed.search + parsed.hash;
 			openDeepLink(path);
 			info("Opening in Superset...");
 			return;
 		}
-	} catch {
-		// Not a valid URL
+	} catch (e) {
+		error(`Invalid URL: ${e instanceof Error ? e.message : String(e)}`);
+		process.exit(1);
 	}
 
 	error(

--- a/packages/scripts/src/commands/open-url.ts
+++ b/packages/scripts/src/commands/open-url.ts
@@ -1,0 +1,36 @@
+import { openDeepLink } from "../lib/deep-link.js";
+import { error, info } from "../lib/output.js";
+
+const APP_DOMAIN = "app.superset.sh";
+
+export function openUrlCommand(args: string[]): void {
+	const url = args[0];
+	if (!url) {
+		error("Usage: superset open <url>");
+		process.exit(1);
+	}
+
+	if (url.startsWith("superset://")) {
+		const path = url.replace("superset://", "");
+		openDeepLink(path);
+		info("Opening in Superset...");
+		return;
+	}
+
+	try {
+		const parsed = new URL(url);
+		if (parsed.hostname === APP_DOMAIN) {
+			const path = parsed.pathname.slice(1) + parsed.search + parsed.hash;
+			openDeepLink(path);
+			info("Opening in Superset...");
+			return;
+		}
+	} catch {
+		// Not a valid URL
+	}
+
+	error(
+		`Unsupported URL. Provide a superset:// or https://${APP_DOMAIN}/ URL.`,
+	);
+	process.exit(1);
+}

--- a/packages/scripts/src/commands/open.ts
+++ b/packages/scripts/src/commands/open.ts
@@ -1,0 +1,24 @@
+import { findProjectByPath } from "../lib/db.js";
+import { openDeepLink } from "../lib/deep-link.js";
+import { error, info } from "../lib/output.js";
+import { resolveProjectPath } from "../lib/resolve.js";
+
+export function openCommand(args: string[]): void {
+	let absPath: string;
+	try {
+		absPath = resolveProjectPath(args[0]);
+	} catch (e) {
+		error((e as Error).message);
+		process.exit(1);
+	}
+
+	const project = findProjectByPath(absPath);
+
+	if (project) {
+		openDeepLink(`project/${project.id}`);
+		info(`Opening ${project.name} in Superset...`);
+	} else {
+		openDeepLink(`open?path=${encodeURIComponent(absPath)}`);
+		info(`Opening ${absPath} in Superset...`);
+	}
+}

--- a/packages/scripts/src/commands/pr.ts
+++ b/packages/scripts/src/commands/pr.ts
@@ -1,4 +1,4 @@
-import { findProjectByPath, findWorkspaceByBranch } from "../lib/db.js";
+import { findWorkspaceByBranch, resolveProject } from "../lib/db.js";
 import { openDeepLink } from "../lib/deep-link.js";
 import { error, info } from "../lib/output.js";
 import { getCurrentBranch, resolveProjectPath } from "../lib/resolve.js";
@@ -12,7 +12,7 @@ export function prCommand(): void {
 		process.exit(1);
 	}
 
-	const project = findProjectByPath(absPath);
+	const project = resolveProject(absPath);
 	if (!project) {
 		error("No Superset project found for this directory.");
 		process.exit(1);

--- a/packages/scripts/src/commands/pr.ts
+++ b/packages/scripts/src/commands/pr.ts
@@ -1,0 +1,38 @@
+import { findProjectByPath, findWorkspaceByBranch } from "../lib/db.js";
+import { openDeepLink } from "../lib/deep-link.js";
+import { error, info } from "../lib/output.js";
+import { getCurrentBranch, resolveProjectPath } from "../lib/resolve.js";
+
+export function prCommand(): void {
+	let absPath: string;
+	try {
+		absPath = resolveProjectPath();
+	} catch (e) {
+		error((e as Error).message);
+		process.exit(1);
+	}
+
+	const project = findProjectByPath(absPath);
+	if (!project) {
+		error("No Superset project found for this directory.");
+		process.exit(1);
+	}
+
+	const branch = getCurrentBranch(absPath);
+	if (!branch) {
+		error("Could not determine current branch.");
+		process.exit(1);
+	}
+
+	const workspace = findWorkspaceByBranch(project.id, branch);
+
+	if (workspace) {
+		openDeepLink(`project/${project.id}/pr/${workspace.id}`);
+	} else {
+		openDeepLink(
+			`project/${project.id}/pr?branch=${encodeURIComponent(branch)}`,
+		);
+	}
+
+	info(`Opening PR for ${branch} in Superset...`);
+}

--- a/packages/scripts/src/commands/status.ts
+++ b/packages/scripts/src/commands/status.ts
@@ -1,4 +1,4 @@
-import { findProjectByPath, getWorkspacesForProject } from "../lib/db.js";
+import { getWorkspacesForProject, resolveProject } from "../lib/db.js";
 import { bold, cyan, dim, error, info } from "../lib/output.js";
 import {
 	getCurrentBranch,
@@ -15,7 +15,7 @@ export function statusCommand(): void {
 		process.exit(1);
 	}
 
-	const project = findProjectByPath(absPath);
+	const project = resolveProject(absPath);
 	if (!project) {
 		info("No Superset project found for this directory.");
 		return;

--- a/packages/scripts/src/commands/status.ts
+++ b/packages/scripts/src/commands/status.ts
@@ -1,0 +1,49 @@
+import { findProjectByPath, getWorkspacesForProject } from "../lib/db.js";
+import { bold, cyan, dim, error, info } from "../lib/output.js";
+import {
+	getCurrentBranch,
+	resolveProjectPath,
+	tildeContract,
+} from "../lib/resolve.js";
+
+export function statusCommand(): void {
+	let absPath: string;
+	try {
+		absPath = resolveProjectPath();
+	} catch (e) {
+		error((e as Error).message);
+		process.exit(1);
+	}
+
+	const project = findProjectByPath(absPath);
+	if (!project) {
+		info("No Superset project found for this directory.");
+		return;
+	}
+
+	const branch = getCurrentBranch(absPath);
+	const rows = getWorkspacesForProject(project.id);
+	const worktreeCount = rows.filter((r) => r.ws_type === "worktree").length;
+	const branchCount = rows.filter((r) => r.ws_type === "branch").length;
+
+	console.log(`${bold("Project:")}    ${project.name}`);
+	console.log(
+		`${bold("Path:")}       ${tildeContract(project.main_repo_path)}`,
+	);
+	if (branch) {
+		console.log(`${bold("Branch:")}     ${branch}`);
+	}
+
+	const parts: string[] = [];
+	if (worktreeCount > 0) parts.push(`${worktreeCount} worktree`);
+	if (branchCount > 0) parts.push(`${branchCount} branch`);
+	console.log(
+		`${bold("Workspaces:")} ${rows.length}${parts.length > 0 ? ` (${parts.join(", ")})` : ""}`,
+	);
+
+	for (const row of rows) {
+		const indicator = row.ws_type === "worktree" ? cyan("●") : dim("○");
+		const wtPath = row.wt_path ? dim(`  ${tildeContract(row.wt_path)}`) : "";
+		console.log(`  ${indicator} ${row.ws_name}  ${dim(row.ws_type)}${wtPath}`);
+	}
+}

--- a/packages/scripts/src/commands/status.ts
+++ b/packages/scripts/src/commands/status.ts
@@ -35,8 +35,12 @@ export function statusCommand(): void {
 	}
 
 	const parts: string[] = [];
-	if (worktreeCount > 0) parts.push(`${worktreeCount} worktree`);
-	if (branchCount > 0) parts.push(`${branchCount} branch`);
+	if (worktreeCount > 0)
+		parts.push(
+			`${worktreeCount} ${worktreeCount === 1 ? "worktree" : "worktrees"}`,
+		);
+	if (branchCount > 0)
+		parts.push(`${branchCount} ${branchCount === 1 ? "branch" : "branches"}`);
 	console.log(
 		`${bold("Workspaces:")} ${rows.length}${parts.length > 0 ? ` (${parts.join(", ")})` : ""}`,
 	);

--- a/packages/scripts/src/commands/worktree.ts
+++ b/packages/scripts/src/commands/worktree.ts
@@ -1,0 +1,32 @@
+import { findProjectByPath } from "../lib/db.js";
+import { openDeepLink } from "../lib/deep-link.js";
+import { error, info } from "../lib/output.js";
+import { resolveProjectPath } from "../lib/resolve.js";
+
+export function worktreeCommand(args: string[]): void {
+	const name = args[0];
+	if (!name) {
+		error("Usage: superset worktree <name> [path]");
+		process.exit(1);
+	}
+
+	let absPath: string;
+	try {
+		absPath = resolveProjectPath(args[1]);
+	} catch (e) {
+		error((e as Error).message);
+		process.exit(1);
+	}
+
+	const project = findProjectByPath(absPath);
+	if (!project) {
+		openDeepLink(
+			`open?path=${encodeURIComponent(absPath)}&worktree=${encodeURIComponent(name)}`,
+		);
+		info(`Opening ${absPath} with worktree ${name} in Superset...`);
+		return;
+	}
+
+	openDeepLink(`project/${project.id}/worktree/${encodeURIComponent(name)}`);
+	info(`Opening worktree ${name} in ${project.name}...`);
+}

--- a/packages/scripts/src/lib/config.ts
+++ b/packages/scripts/src/lib/config.ts
@@ -34,7 +34,10 @@ export function loadConfig(): CliConfig {
 	try {
 		const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 		return { ...DEFAULTS, ...raw };
-	} catch {
+	} catch (e) {
+		console.warn(
+			`Warning: could not read CLI config at ${CONFIG_PATH}, using defaults: ${e instanceof Error ? e.message : String(e)}`,
+		);
 		return { ...DEFAULTS };
 	}
 }
@@ -42,7 +45,7 @@ export function loadConfig(): CliConfig {
 export function saveConfig(config: CliConfig): void {
 	const dir = dirname(CONFIG_PATH);
 	if (!existsSync(dir)) {
-		mkdirSync(dir, { recursive: true });
+		mkdirSync(dir, { recursive: true, mode: 0o700 });
 	}
 	writeFileSync(CONFIG_PATH, `${JSON.stringify(config, null, 2)}\n`);
 }
@@ -56,7 +59,7 @@ export function resetConfig(): void {
 export function setConfigValue(key: string, value: string): CliConfig {
 	const config = loadConfig();
 
-	if (!(key in DEFAULTS)) {
+	if (!Object.hasOwn(DEFAULTS, key)) {
 		throw new Error(
 			`Unknown config key: ${key}. Valid keys: ${Object.keys(DEFAULTS).join(", ")}`,
 		);

--- a/packages/scripts/src/lib/config.ts
+++ b/packages/scripts/src/lib/config.ts
@@ -1,0 +1,90 @@
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+const CONFIG_PATH = join(homedir(), ".superset", "cli.json");
+
+export interface CliConfig {
+	defaultWorkspaceType: "worktree" | "branch";
+	autoOpen: boolean;
+	output: "text" | "json";
+}
+
+const DEFAULTS: CliConfig = {
+	defaultWorkspaceType: "worktree",
+	autoOpen: true,
+	output: "text",
+};
+
+export const CONFIG_KEYS: Record<keyof CliConfig, string> = {
+	defaultWorkspaceType: "Default workspace type (worktree | branch)",
+	autoOpen: "Launch desktop app if not running (true | false)",
+	output: "Output format (text | json)",
+};
+
+export function loadConfig(): CliConfig {
+	if (!existsSync(CONFIG_PATH)) return { ...DEFAULTS };
+
+	try {
+		const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+		return { ...DEFAULTS, ...raw };
+	} catch {
+		return { ...DEFAULTS };
+	}
+}
+
+export function saveConfig(config: CliConfig): void {
+	const dir = dirname(CONFIG_PATH);
+	if (!existsSync(dir)) {
+		mkdirSync(dir, { recursive: true });
+	}
+	writeFileSync(CONFIG_PATH, `${JSON.stringify(config, null, 2)}\n`);
+}
+
+export function resetConfig(): void {
+	if (existsSync(CONFIG_PATH)) {
+		unlinkSync(CONFIG_PATH);
+	}
+}
+
+export function setConfigValue(key: string, value: string): CliConfig {
+	const config = loadConfig();
+
+	if (!(key in DEFAULTS)) {
+		throw new Error(
+			`Unknown config key: ${key}. Valid keys: ${Object.keys(DEFAULTS).join(", ")}`,
+		);
+	}
+
+	const typedKey = key as keyof CliConfig;
+
+	if (typedKey === "autoOpen") {
+		if (value !== "true" && value !== "false") {
+			throw new Error(
+				`Invalid value for autoOpen: ${value}. Use true or false.`,
+			);
+		}
+		config.autoOpen = value === "true";
+	} else if (typedKey === "defaultWorkspaceType") {
+		if (value !== "worktree" && value !== "branch") {
+			throw new Error(
+				`Invalid value for defaultWorkspaceType: ${value}. Use worktree or branch.`,
+			);
+		}
+		config.defaultWorkspaceType = value;
+	} else if (typedKey === "output") {
+		if (value !== "text" && value !== "json") {
+			throw new Error(`Invalid value for output: ${value}. Use text or json.`);
+		}
+		config.output = value;
+	}
+
+	saveConfig(config);
+	return config;
+}

--- a/packages/scripts/src/lib/db.ts
+++ b/packages/scripts/src/lib/db.ts
@@ -37,18 +37,19 @@ export interface Worktree {
 	base_branch: string | null;
 }
 
-function getDb(): Database {
-	if (!existsSync(DB_PATH)) {
-		throw new Error(
-			"Superset database not found. Is the desktop app installed?",
-		);
-	}
+function getDb(): Database | null {
+	if (!existsSync(DB_PATH)) return null;
 
-	return new Database(DB_PATH, { readonly: true });
+	try {
+		return new Database(DB_PATH, { readonly: true });
+	} catch {
+		return null;
+	}
 }
 
 export function findProjectByPath(absPath: string): Project | null {
 	const db = getDb();
+	if (!db) return null;
 	return db
 		.query<Project, [string]>(
 			"SELECT * FROM projects WHERE main_repo_path = ? LIMIT 1",
@@ -56,8 +57,25 @@ export function findProjectByPath(absPath: string): Project | null {
 		.get(absPath);
 }
 
+export function findProjectByWorktreePath(absPath: string): Project | null {
+	const db = getDb();
+	if (!db) return null;
+	return db
+		.query<Project, [string]>(
+			`SELECT p.* FROM projects p
+			JOIN worktrees wt ON wt.project_id = p.id
+			WHERE wt.path = ? LIMIT 1`,
+		)
+		.get(absPath);
+}
+
+export function resolveProject(absPath: string): Project | null {
+	return findProjectByPath(absPath) ?? findProjectByWorktreePath(absPath);
+}
+
 export function getAllProjects(): Project[] {
 	const db = getDb();
+	if (!db) return [];
 	return db
 		.query<Project, []>("SELECT * FROM projects ORDER BY last_opened_at DESC")
 		.all();
@@ -78,6 +96,7 @@ export function getWorkspacesForProject(
 	projectId: string,
 ): WorkspaceWithWorktree[] {
 	const db = getDb();
+	if (!db) return [];
 	return db
 		.query<WorkspaceWithWorktree, [string]>(
 			`SELECT
@@ -102,6 +121,7 @@ export function findWorkspaceByBranch(
 	branch: string,
 ): Workspace | null {
 	const db = getDb();
+	if (!db) return null;
 	return db
 		.query<Workspace, [string, string]>(
 			"SELECT * FROM workspaces WHERE project_id = ? AND branch = ? AND deleting_at IS NULL LIMIT 1",

--- a/packages/scripts/src/lib/db.ts
+++ b/packages/scripts/src/lib/db.ts
@@ -1,0 +1,110 @@
+import { Database } from "bun:sqlite";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const DB_PATH = join(homedir(), ".superset", "local.db");
+
+export interface Project {
+	id: string;
+	main_repo_path: string;
+	name: string;
+	color: string;
+	tab_order: number | null;
+	last_opened_at: number;
+	created_at: number;
+	default_branch: string | null;
+	worktree_base_dir: string | null;
+}
+
+export interface Workspace {
+	id: string;
+	project_id: string;
+	worktree_id: string | null;
+	type: "worktree" | "branch";
+	branch: string;
+	name: string;
+	tab_order: number;
+	last_opened_at: number;
+	deleting_at: number | null;
+}
+
+export interface Worktree {
+	id: string;
+	project_id: string;
+	path: string;
+	branch: string;
+	base_branch: string | null;
+}
+
+function getDb(): Database {
+	if (!existsSync(DB_PATH)) {
+		throw new Error(
+			"Superset database not found. Is the desktop app installed?",
+		);
+	}
+
+	return new Database(DB_PATH, { readonly: true });
+}
+
+export function findProjectByPath(absPath: string): Project | null {
+	const db = getDb();
+	return db
+		.query<Project, [string]>(
+			"SELECT * FROM projects WHERE main_repo_path = ? LIMIT 1",
+		)
+		.get(absPath);
+}
+
+export function getAllProjects(): Project[] {
+	const db = getDb();
+	return db
+		.query<Project, []>("SELECT * FROM projects ORDER BY last_opened_at DESC")
+		.all();
+}
+
+export interface WorkspaceWithWorktree {
+	ws_id: string;
+	ws_name: string;
+	ws_type: "worktree" | "branch";
+	ws_branch: string;
+	ws_last_opened_at: number;
+	wt_id: string | null;
+	wt_path: string | null;
+	wt_branch: string | null;
+}
+
+export function getWorkspacesForProject(
+	projectId: string,
+): WorkspaceWithWorktree[] {
+	const db = getDb();
+	return db
+		.query<WorkspaceWithWorktree, [string]>(
+			`SELECT
+				w.id as ws_id,
+				w.name as ws_name,
+				w.type as ws_type,
+				w.branch as ws_branch,
+				w.last_opened_at as ws_last_opened_at,
+				wt.id as wt_id,
+				wt.path as wt_path,
+				wt.branch as wt_branch
+			FROM workspaces w
+			LEFT JOIN worktrees wt ON w.worktree_id = wt.id
+			WHERE w.project_id = ? AND w.deleting_at IS NULL
+			ORDER BY w.last_opened_at DESC`,
+		)
+		.all(projectId);
+}
+
+export function findWorkspaceByBranch(
+	projectId: string,
+	branch: string,
+): Workspace | null {
+	const db = getDb();
+	return db
+		.query<Workspace, [string, string]>(
+			"SELECT * FROM workspaces WHERE project_id = ? AND branch = ? AND deleting_at IS NULL LIMIT 1",
+		)
+		.get(projectId, branch);
+}

--- a/packages/scripts/src/lib/db.ts
+++ b/packages/scripts/src/lib/db.ts
@@ -3,7 +3,9 @@ import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-const DB_PATH = join(homedir(), ".superset", "local.db");
+const supersetHomeDir =
+	process.env.SUPERSET_HOME_DIR || join(homedir(), ".superset");
+const DB_PATH = join(supersetHomeDir, "local.db");
 
 export interface Project {
 	id: string;
@@ -42,7 +44,8 @@ function getDb(): Database | null {
 
 	try {
 		return new Database(DB_PATH, { readonly: true });
-	} catch {
+	} catch (err) {
+		console.warn("[superset] Failed to open local database:", err);
 		return null;
 	}
 }

--- a/packages/scripts/src/lib/deep-link.ts
+++ b/packages/scripts/src/lib/deep-link.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 
-const PROTOCOL = "superset";
+const PROTOCOL = process.env.SUPERSET_PROTOCOL ?? "superset";
 
 export function openDeepLink(path: string): void {
 	const url = `${PROTOCOL}://${path}`;

--- a/packages/scripts/src/lib/deep-link.ts
+++ b/packages/scripts/src/lib/deep-link.ts
@@ -1,0 +1,8 @@
+import { spawn } from "node:child_process";
+
+const PROTOCOL = "superset";
+
+export function openDeepLink(path: string): void {
+	const url = `${PROTOCOL}://${path}`;
+	spawn("open", [url], { stdio: "ignore", detached: true }).unref();
+}

--- a/packages/scripts/src/lib/output.ts
+++ b/packages/scripts/src/lib/output.ts
@@ -1,0 +1,48 @@
+const ESC = "\x1b[";
+
+export const bold = (s: string) => `${ESC}1m${s}${ESC}0m`;
+export const dim = (s: string) => `${ESC}2m${s}${ESC}0m`;
+export const green = (s: string) => `${ESC}32m${s}${ESC}0m`;
+export const red = (s: string) => `${ESC}31m${s}${ESC}0m`;
+export const cyan = (s: string) => `${ESC}36m${s}${ESC}0m`;
+export const yellow = (s: string) => `${ESC}33m${s}${ESC}0m`;
+
+export function formatRelativeTime(timestamp: number): string {
+	const diff = Date.now() - timestamp;
+	const seconds = Math.floor(diff / 1000);
+	const minutes = Math.floor(seconds / 60);
+	const hours = Math.floor(minutes / 60);
+	const days = Math.floor(hours / 24);
+
+	if (days > 0) return `${days}d ago`;
+	if (hours > 0) return `${hours}h ago`;
+	if (minutes > 0) return `${minutes}m ago`;
+	return "just now";
+}
+
+export function printTable(rows: string[][]): void {
+	if (rows.length === 0) return;
+
+	const firstRow = rows[0];
+	if (!firstRow) return;
+
+	const colWidths = firstRow.map((_, colIdx) =>
+		Math.max(...rows.map((row) => (row[colIdx] ?? "").length)),
+	);
+
+	for (const row of rows) {
+		const line = row
+			.map((cell, i) => (cell ?? "").padEnd((colWidths[i] ?? 0) + 2))
+			.join("")
+			.trimEnd();
+		console.log(`  ${line}`);
+	}
+}
+
+export function error(message: string): void {
+	console.error(`${red("error:")} ${message}`);
+}
+
+export function info(message: string): void {
+	console.log(message);
+}

--- a/packages/scripts/src/lib/resolve.ts
+++ b/packages/scripts/src/lib/resolve.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, lstatSync, readFileSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 export function resolveProjectPath(pathArg?: string): string {
@@ -21,8 +21,32 @@ export function isGitRepo(dir: string): boolean {
 	return existsSync(join(dir, ".git"));
 }
 
+function resolveGitDir(dir: string): string | null {
+	const gitPath = join(dir, ".git");
+	if (!existsSync(gitPath)) return null;
+
+	const stat = lstatSync(gitPath);
+	if (stat.isDirectory()) {
+		return gitPath;
+	}
+
+	// In worktrees, .git is a file containing "gitdir: /path/to/real/.git/worktrees/name"
+	const content = readFileSync(gitPath, "utf-8").trim();
+	const prefix = "gitdir: ";
+	if (content.startsWith(prefix)) {
+		const gitdir = content.slice(prefix.length);
+		// Resolve relative paths against the worktree directory
+		return resolve(dir, gitdir);
+	}
+
+	return null;
+}
+
 export function getCurrentBranch(dir: string): string | null {
-	const headPath = join(dir, ".git", "HEAD");
+	const gitDir = resolveGitDir(dir);
+	if (!gitDir) return null;
+
+	const headPath = join(gitDir, "HEAD");
 	if (!existsSync(headPath)) return null;
 
 	const head = readFileSync(headPath, "utf-8").trim();
@@ -37,7 +61,12 @@ export function getCurrentBranch(dir: string): string | null {
 
 export function tildeContract(absPath: string): string {
 	const home = process.env.HOME;
-	if (home && absPath.startsWith(home)) {
+	if (
+		home &&
+		(absPath === home ||
+			absPath.startsWith(`${home}/`) ||
+			absPath.startsWith(`${home}\\`))
+	) {
 		return `~${absPath.slice(home.length)}`;
 	}
 	return absPath;

--- a/packages/scripts/src/lib/resolve.ts
+++ b/packages/scripts/src/lib/resolve.ts
@@ -1,0 +1,44 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+export function resolveProjectPath(pathArg?: string): string {
+	const raw = pathArg ?? ".";
+	const abs = resolve(raw);
+
+	if (!existsSync(abs)) {
+		throw new Error(`Path does not exist: ${abs}`);
+	}
+
+	const stat = statSync(abs);
+	if (!stat.isDirectory()) {
+		throw new Error(`Not a directory: ${abs}`);
+	}
+
+	return abs;
+}
+
+export function isGitRepo(dir: string): boolean {
+	return existsSync(join(dir, ".git"));
+}
+
+export function getCurrentBranch(dir: string): string | null {
+	const headPath = join(dir, ".git", "HEAD");
+	if (!existsSync(headPath)) return null;
+
+	const head = readFileSync(headPath, "utf-8").trim();
+	const refPrefix = "ref: refs/heads/";
+	if (head.startsWith(refPrefix)) {
+		return head.slice(refPrefix.length);
+	}
+
+	// Detached HEAD — return short hash
+	return head.slice(0, 8);
+}
+
+export function tildeContract(absPath: string): string {
+	const home = process.env.HOME;
+	if (home && absPath.startsWith(home)) {
+		return `~${absPath.slice(home.length)}`;
+	}
+	return absPath;
+}

--- a/packages/scripts/src/lib/resolve.ts
+++ b/packages/scripts/src/lib/resolve.ts
@@ -55,8 +55,8 @@ export function getCurrentBranch(dir: string): string | null {
 		return head.slice(refPrefix.length);
 	}
 
-	// Detached HEAD — return short hash
-	return head.slice(0, 8);
+	// Detached HEAD — not on a branch
+	return null;
 }
 
 export function tildeContract(absPath: string): string {

--- a/packages/scripts/tsconfig.json
+++ b/packages/scripts/tsconfig.json
@@ -3,7 +3,7 @@
 	"compilerOptions": {
 		"outDir": "./dist",
 		"rootDir": "./src",
-		"types": ["node"]
+		"types": ["bun-types"]
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["node_modules", "dist"]


### PR DESCRIPTION
Adds a `superset` CLI that communicates with the desktop app via deep links and reads from the local SQLite database. See docs/cli-spec.md for the full spec.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `superset` CLI to control the desktop app via `superset://` deep links and query the local SQLite DB. Open projects/workspaces, launch dev, view PRs, open app links, and manage config from the terminal.

- **New Features**
  - New `superset` CLI in `@superset/cli` with commands: open by positional path (`superset .` or `superset <path>`), `worktree`, `branch`, `dev [port]`, `pr`, `open <url>` (supports `https://app.superset.sh` and `superset://`), `status`/`list` (read-only), `login`, `logout`, and `config` (get/set/reset).
  - Reads from `~/.superset/local.db` for `status`/`list`, stores config at `~/.superset/cli.json`; resolves projects from main repo or worktree paths; macOS only (uses `open`); supports `SUPERSET_HOME_DIR` and `SUPERSET_PROTOCOL` overrides. Full spec in `docs/cli-spec.md`.

- **Dependencies**
  - Renamed package `@superset/scripts` to `@superset/cli` and added bin `superset` (`packages/scripts/src/bin.ts`); added dev deps `typescript`, `bun-types`, `@superset/typescript`; switched tsconfig types to `bun-types`; added `typecheck`; updated `bun.lock`.

<sup>Written for commit c8cf4d88779a9c47f071dd75f27767f877e8ba4a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new superset CLI with a single "superset" entrypoint and commands: worktree, branch, dev, pr, open, open-url, list, status, config, login, logout.
  * CLI can open projects/workspaces, translate URLs/deep links, and show formatted project/status listings.
  * Added persistent CLI configuration (defaults, set/get/reset) and read-only local project discovery.

* **Documentation**
  * Added a comprehensive CLI specification and command reference with examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->