### PR TITLE
fix(desktop): debounce git refresh on workspace file changes

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/changes/git-metadata.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/git-metadata.ts
@@ -1,0 +1,100 @@
+import { observable } from "@trpc/server/observable";
+import type { FileSystemChangeEvent } from "shared/file-tree-types";
+import { z } from "zod";
+import { publicProcedure, router } from "../..";
+import { subscribeRegisteredGitMetadataEvents } from "../workspace-fs-service";
+
+function isClosedStreamError(error: unknown): boolean {
+	return (
+		error instanceof TypeError &&
+		"code" in error &&
+		error.code === "ERR_INVALID_STATE"
+	);
+}
+
+export const createGitMetadataRouter = () => {
+	return router({
+		subscribeGitMetadata: publicProcedure
+			.input(
+				z.object({
+					worktreePath: z.string(),
+				}),
+			)
+			.subscription(({ input }) => {
+				return observable<FileSystemChangeEvent>((emit) => {
+					let isDisposed = false;
+					let cleanup: (() => Promise<void>) | null = null;
+
+					const runCleanup = () => {
+						isDisposed = true;
+						if (!cleanup) {
+							return;
+						}
+
+						const currentCleanup = cleanup;
+						cleanup = null;
+						void currentCleanup().catch((error) => {
+							console.error("[changes/subscribeGitMetadata] Cleanup failed:", {
+								worktreePath: input.worktreePath,
+								error,
+							});
+						});
+					};
+
+					const safeNext = (event: FileSystemChangeEvent) => {
+						if (isDisposed) {
+							return;
+						}
+
+						try {
+							emit.next(event);
+						} catch (error) {
+							if (isClosedStreamError(error)) {
+								runCleanup();
+								return;
+							}
+
+							throw error;
+						}
+					};
+
+					void subscribeRegisteredGitMetadataEvents(
+						input.worktreePath,
+						(event) => {
+							safeNext(event);
+						},
+					)
+						.then((unsubscribe) => {
+							if (isDisposed) {
+								void unsubscribe().catch((error) => {
+									console.error(
+										"[changes/subscribeGitMetadata] Late cleanup failed:",
+										{
+											worktreePath: input.worktreePath,
+											error,
+										},
+									);
+								});
+								return;
+							}
+
+							cleanup = unsubscribe;
+						})
+						.catch((error) => {
+							console.error("[changes/subscribeGitMetadata] Failed:", {
+								worktreePath: input.worktreePath,
+								error,
+							});
+							safeNext({
+								type: "overflow",
+								revision: 0,
+							});
+						});
+
+					return () => {
+						runCleanup();
+					};
+				});
+			}),
+	});
+};

--- a/apps/desktop/src/lib/trpc/routers/changes/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/index.ts
@@ -1,6 +1,7 @@
 import { router } from "../..";
 import { createBranchesRouter } from "./branches";
 import { createFileContentsRouter } from "./file-contents";
+import { createGitMetadataRouter } from "./git-metadata";
 import { createGitOperationsRouter } from "./git-operations";
 import { createStagingRouter } from "./staging";
 import { createStatusRouter } from "./status";
@@ -9,6 +10,7 @@ export const createChangesRouter = () => {
 	const branchesRouter = createBranchesRouter();
 	const statusRouter = createStatusRouter();
 	const fileContentsRouter = createFileContentsRouter();
+	const gitMetadataRouter = createGitMetadataRouter();
 	const stagingRouter = createStagingRouter();
 	const gitOperationsRouter = createGitOperationsRouter();
 
@@ -21,6 +23,9 @@ export const createChangesRouter = () => {
 
 		// File contents operations
 		...fileContentsRouter._def.procedures,
+
+		// Git metadata subscriptions
+		...gitMetadataRouter._def.procedures,
 
 		// Staging operations
 		...stagingRouter._def.procedures,

--- a/apps/desktop/src/lib/trpc/routers/workspace-fs-service.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspace-fs-service.ts
@@ -14,10 +14,21 @@ import type {
 } from "shared/file-tree-types";
 import { assertRegisteredWorktree } from "./changes/security/path-validation";
 import { getWorkspace } from "./workspaces/utils/db-helpers";
+import { getGitWatchRoots } from "./workspaces/utils/git-client";
 import { execWithShellEnv } from "./workspaces/utils/shell-env";
 import { getWorkspacePath } from "./workspaces/utils/worktree";
 
 const filesystemWatcherManager = new WorkspaceFsWatcherManager();
+const gitMetadataWatcherManager = new WorkspaceFsWatcherManager({
+	ignore: [
+		"**/objects/**",
+		"**/logs/**",
+		"**/hooks/**",
+		"**/info/**",
+		"**/rr-cache/**",
+		"**/lfs/**",
+	],
+});
 const MAX_SEARCH_RESULTS = 500;
 
 export interface WorkspaceKeywordSearchMatch {
@@ -368,6 +379,32 @@ export async function* watchWorkspaceFileSystemEvents(
 	})) {
 		yield toFileSystemChangeEvent(event, rootPath);
 	}
+}
+
+export async function subscribeRegisteredGitMetadataEvents(
+	worktreePath: string,
+	listener: (event: FileSystemChangeEvent) => void,
+): Promise<() => Promise<void>> {
+	assertRegisteredWorktree(worktreePath);
+	const rootPaths = await getGitWatchRoots(worktreePath);
+
+	const cleanups = await Promise.all(
+		rootPaths.map((rootPath) =>
+			gitMetadataWatcherManager.subscribe(
+				{
+					workspaceId: worktreePath,
+					rootPath,
+				},
+				(event) => {
+					listener(toFileSystemChangeEvent(event, rootPath));
+				},
+			),
+		),
+	);
+
+	return async () => {
+		await Promise.all(cleanups.map(async (cleanup) => await cleanup()));
+	};
 }
 
 export async function searchWorkspaceFiles(input: {

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git-client.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git-client.ts
@@ -2,6 +2,7 @@ import {
 	type ExecFileOptionsWithStringEncoding,
 	execFile,
 } from "node:child_process";
+import path from "node:path";
 import { promisify } from "node:util";
 import simpleGit, { type SimpleGit } from "simple-git";
 import { getProcessEnvWithShellPath } from "./shell-env";
@@ -29,4 +30,27 @@ export async function execGitWithShellPath(
 		encoding: "utf8",
 		env,
 	});
+}
+
+export async function getGitWatchRoots(
+	worktreePath: string,
+): Promise<string[]> {
+	const { stdout } = await execGitWithShellPath(
+		["rev-parse", "--path-format=absolute", "--git-dir", "--git-common-dir"],
+		{ cwd: worktreePath },
+	);
+
+	return Array.from(
+		new Set(
+			stdout
+				.split(/\r?\n/)
+				.map((line) => line.trim())
+				.filter(Boolean)
+				.map((rootPath) =>
+					path.isAbsolute(rootPath)
+						? path.normalize(rootPath)
+						: path.resolve(worktreePath, rootPath),
+				),
+		),
+	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -21,7 +21,11 @@ import { useWorkspaceFileEventBridge } from "renderer/screens/main/components/Wo
 import { useWorkspaceRenameReconciliation } from "renderer/screens/main/components/WorkspaceView/hooks/useWorkspaceRenameReconciliation";
 import { WorkspaceInitializingView } from "renderer/screens/main/components/WorkspaceView/WorkspaceInitializingView";
 import { WorkspaceLayout } from "renderer/screens/main/components/WorkspaceView/WorkspaceLayout";
-import { useCreateOrOpenPR, usePRStatus } from "renderer/screens/main/hooks";
+import {
+	useCreateOrOpenPR,
+	usePRStatus,
+	useWorkspaceGitChangesRefresh,
+} from "renderer/screens/main/hooks";
 import { useAppHotkey } from "renderer/stores/hotkeys";
 import { SidebarMode, useSidebarStore } from "renderer/stores/sidebar-state";
 import { getPaneDimensions } from "renderer/stores/tabs/pane-refs";
@@ -79,11 +83,25 @@ function WorkspacePage() {
 	const { data: workspace } = electronTrpc.workspaces.get.useQuery({
 		id: workspaceId,
 	});
+	const worktreePath = workspace?.worktreePath;
+	const { data: branchData } = electronTrpc.changes.getBranches.useQuery(
+		{ worktreePath: worktreePath ?? "" },
+		{ enabled: Boolean(worktreePath) },
+	);
+	const effectiveBaseBranch =
+		branchData?.worktreeBaseBranch ?? branchData?.defaultBranch ?? "main";
+
 	useWorkspaceFileEventBridge(workspaceId, Boolean(workspace?.worktreePath));
 	useWorkspaceRenameReconciliation({
 		workspaceId,
-		worktreePath: workspace?.worktreePath,
-		enabled: Boolean(workspace?.worktreePath),
+		worktreePath,
+		enabled: Boolean(worktreePath),
+	});
+	useWorkspaceGitChangesRefresh({
+		workspaceId,
+		worktreePath,
+		defaultBranch: effectiveBaseBranch,
+		enabled: Boolean(workspaceId && worktreePath),
 	});
 	const navigate = useNavigate();
 	const routeNavigate = Route.useNavigate();

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -10,6 +10,7 @@ import { useWorkspaceDeleteHandler } from "renderer/react-query/workspaces";
 import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { useBranchSyncInvalidation } from "renderer/screens/main/hooks/useBranchSyncInvalidation";
 import { useGitChangesStatus } from "renderer/screens/main/hooks/useGitChangesStatus";
+import { useWorkspaceGitChangesRefresh } from "renderer/screens/main/hooks/useWorkspaceGitChangesRefresh";
 import { useWorkspaceRename } from "renderer/screens/main/hooks/useWorkspaceRename";
 import { useActiveDragItemStore } from "renderer/stores/active-drag-item";
 import { useTabsStore } from "renderer/stores/tabs/store";
@@ -129,10 +130,17 @@ export function WorkspaceListItem({
 			},
 		);
 
-	const { status: localChanges } = useGitChangesStatus({
+	const { status: localChanges, effectiveBaseBranch } = useGitChangesStatus({
 		worktreePath,
-		enabled: hasHovered && !!worktreePath,
+		enabled: (hasHovered || isActive) && !!worktreePath,
 		staleTime: GITHUB_STATUS_STALE_TIME,
+	});
+
+	useWorkspaceGitChangesRefresh({
+		workspaceId: id,
+		worktreePath,
+		defaultBranch: effectiveBaseBranch,
+		enabled: isActive && Boolean(worktreePath),
 	});
 
 	const { data: aheadBehind, refetch: refetchAheadBehind } =

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -10,7 +10,6 @@ import { useWorkspaceDeleteHandler } from "renderer/react-query/workspaces";
 import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { useBranchSyncInvalidation } from "renderer/screens/main/hooks/useBranchSyncInvalidation";
 import { useGitChangesStatus } from "renderer/screens/main/hooks/useGitChangesStatus";
-import { useWorkspaceGitChangesRefresh } from "renderer/screens/main/hooks/useWorkspaceGitChangesRefresh";
 import { useWorkspaceRename } from "renderer/screens/main/hooks/useWorkspaceRename";
 import { useActiveDragItemStore } from "renderer/stores/active-drag-item";
 import { useTabsStore } from "renderer/stores/tabs/store";
@@ -130,17 +129,10 @@ export function WorkspaceListItem({
 			},
 		);
 
-	const { status: localChanges, effectiveBaseBranch } = useGitChangesStatus({
+	const { status: localChanges } = useGitChangesStatus({
 		worktreePath,
 		enabled: (hasHovered || isActive) && !!worktreePath,
 		staleTime: GITHUB_STATUS_STALE_TIME,
-	});
-
-	useWorkspaceGitChangesRefresh({
-		workspaceId: id,
-		worktreePath,
-		defaultBranch: effectiveBaseBranch,
-		enabled: isActive && Boolean(worktreePath),
 	});
 
 	const { data: aheadBehind, refetch: refetchAheadBehind } =

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/ChangesContent.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/ChangesContent.tsx
@@ -1,6 +1,7 @@
 import { useParams } from "@tanstack/react-router";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useGitChangesStatus } from "renderer/screens/main/hooks/useGitChangesStatus";
+import { useWorkspaceGitChangesRefresh } from "renderer/screens/main/hooks/useWorkspaceGitChangesRefresh";
 import {
 	RightSidebarTab,
 	useSidebarStore,
@@ -20,8 +21,14 @@ export function ChangesContent() {
 
 	const { status, isLoading, effectiveBaseBranch } = useGitChangesStatus({
 		worktreePath,
-		refetchInterval: isChangesSidebarVisible ? undefined : 2500,
 		refetchOnWindowFocus: !isChangesSidebarVisible,
+	});
+
+	useWorkspaceGitChangesRefresh({
+		workspaceId,
+		worktreePath,
+		defaultBranch: effectiveBaseBranch,
+		enabled: Boolean(workspaceId && worktreePath),
 	});
 
 	if (!worktreePath) {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/ChangesContent.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/ChangesContent.tsx
@@ -1,7 +1,6 @@
 import { useParams } from "@tanstack/react-router";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useGitChangesStatus } from "renderer/screens/main/hooks/useGitChangesStatus";
-import { useWorkspaceGitChangesRefresh } from "renderer/screens/main/hooks/useWorkspaceGitChangesRefresh";
 import {
 	RightSidebarTab,
 	useSidebarStore,
@@ -22,13 +21,6 @@ export function ChangesContent() {
 	const { status, isLoading, effectiveBaseBranch } = useGitChangesStatus({
 		worktreePath,
 		refetchOnWindowFocus: !isChangesSidebarVisible,
-	});
-
-	useWorkspaceGitChangesRefresh({
-		workspaceId,
-		worktreePath,
-		defaultBranch: effectiveBaseBranch,
-		enabled: Boolean(workspaceId && worktreePath),
 	});
 
 	if (!worktreePath) {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
@@ -39,8 +39,6 @@ interface ChangesViewProps {
 	isActive?: boolean;
 }
 
-const INACTIVE_BRANCH_REFETCH_INTERVAL_MS = 10_000;
-
 interface PendingChangesRefresh {
 	invalidateBranches: boolean;
 	invalidateSelectedFile: boolean;
@@ -89,11 +87,7 @@ export function ChangesView({
 	const { status, isLoading, effectiveBaseBranch, branchData, refetch } =
 		useGitChangesStatus({
 			worktreePath,
-			refetchInterval: isActive ? 2500 : undefined,
 			refetchOnWindowFocus: isActive,
-			branchRefetchInterval: isActive
-				? undefined
-				: INACTIVE_BRANCH_REFETCH_INTERVAL_MS,
 			branchRefetchOnWindowFocus: true,
 		});
 
@@ -374,7 +368,7 @@ export function ChangesView({
 				});
 			}, 75);
 		},
-		Boolean(workspaceId && worktreePath),
+		Boolean(workspaceId && worktreePath && isActive),
 	);
 
 	const expandedCommitHashes = useMemo(

--- a/apps/desktop/src/renderer/screens/main/hooks/index.ts
+++ b/apps/desktop/src/renderer/screens/main/hooks/index.ts
@@ -2,4 +2,5 @@ export { useBranchSyncInvalidation } from "./useBranchSyncInvalidation";
 export { useCreateOrOpenPR } from "./useCreateOrOpenPR";
 export { useGitChangesStatus } from "./useGitChangesStatus";
 export { usePRStatus } from "./usePRStatus";
+export { useWorkspaceGitChangesRefresh } from "./useWorkspaceGitChangesRefresh";
 export { useWorkspaceRename } from "./useWorkspaceRename";

--- a/apps/desktop/src/renderer/screens/main/hooks/useWorkspaceGitChangesRefresh/index.ts
+++ b/apps/desktop/src/renderer/screens/main/hooks/useWorkspaceGitChangesRefresh/index.ts
@@ -1,0 +1,1 @@
+export { useWorkspaceGitChangesRefresh } from "./useWorkspaceGitChangesRefresh";

--- a/apps/desktop/src/renderer/screens/main/hooks/useWorkspaceGitChangesRefresh/useWorkspaceGitChangesRefresh.ts
+++ b/apps/desktop/src/renderer/screens/main/hooks/useWorkspaceGitChangesRefresh/useWorkspaceGitChangesRefresh.ts
@@ -1,0 +1,67 @@
+import { useEffect, useRef } from "react";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useWorkspaceFileEvents } from "renderer/screens/main/components/WorkspaceView/hooks/useWorkspaceFileEvents";
+
+const DEFAULT_DEBOUNCE_MS = 75;
+
+interface UseWorkspaceGitChangesRefreshOptions {
+	workspaceId?: string;
+	worktreePath?: string;
+	defaultBranch?: string;
+	enabled?: boolean;
+	debounceMs?: number;
+}
+
+export function useWorkspaceGitChangesRefresh({
+	workspaceId,
+	worktreePath,
+	defaultBranch,
+	enabled = true,
+	debounceMs = DEFAULT_DEBOUNCE_MS,
+}: UseWorkspaceGitChangesRefreshOptions): void {
+	const trpcUtils = electronTrpc.useUtils();
+	const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	useEffect(() => {
+		return () => {
+			if (refreshTimerRef.current) {
+				clearTimeout(refreshTimerRef.current);
+				refreshTimerRef.current = null;
+			}
+		};
+	}, []);
+
+	useWorkspaceFileEvents(
+		workspaceId ?? "",
+		() => {
+			if (!worktreePath || !defaultBranch) {
+				return;
+			}
+
+			if (refreshTimerRef.current) {
+				clearTimeout(refreshTimerRef.current);
+			}
+
+			refreshTimerRef.current = setTimeout(() => {
+				refreshTimerRef.current = null;
+				Promise.all([
+					trpcUtils.changes.getStatus.invalidate({
+						worktreePath,
+						defaultBranch,
+					}),
+					trpcUtils.changes.getBranches.invalidate({ worktreePath }),
+				]).catch((error) => {
+					console.error(
+						"[useWorkspaceGitChangesRefresh] Failed to refresh git changes:",
+						{
+							workspaceId,
+							worktreePath,
+							error,
+						},
+					);
+				});
+			}, debounceMs);
+		},
+		enabled && Boolean(workspaceId && worktreePath && defaultBranch),
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/hooks/useWorkspaceGitChangesRefresh/useWorkspaceGitChangesRefresh.ts
+++ b/apps/desktop/src/renderer/screens/main/hooks/useWorkspaceGitChangesRefresh/useWorkspaceGitChangesRefresh.ts
@@ -21,6 +21,66 @@ export function useWorkspaceGitChangesRefresh({
 }: UseWorkspaceGitChangesRefreshOptions): void {
 	const trpcUtils = electronTrpc.useUtils();
 	const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const previousConfigKeyRef = useRef<string | null>(null);
+	const isEnabled =
+		enabled && Boolean(workspaceId && worktreePath && defaultBranch);
+	const refreshConfigKey = [
+		workspaceId ?? "",
+		worktreePath ?? "",
+		defaultBranch ?? "",
+		enabled ? "enabled" : "disabled",
+		String(debounceMs),
+	].join("::");
+
+	const scheduleRefresh = () => {
+		if (!worktreePath || !defaultBranch) {
+			return;
+		}
+
+		if (refreshTimerRef.current) {
+			clearTimeout(refreshTimerRef.current);
+		}
+
+		refreshTimerRef.current = setTimeout(() => {
+			refreshTimerRef.current = null;
+			Promise.all([
+				trpcUtils.changes.getStatus.invalidate({
+					worktreePath,
+					defaultBranch,
+				}),
+				trpcUtils.changes.getBranches.invalidate({ worktreePath }),
+			]).catch((error) => {
+				console.error(
+					"[useWorkspaceGitChangesRefresh] Failed to refresh git changes:",
+					{
+						workspaceId,
+						worktreePath,
+						error,
+					},
+				);
+			});
+		}, debounceMs);
+	};
+
+	useEffect(() => {
+		if (!isEnabled && refreshTimerRef.current) {
+			clearTimeout(refreshTimerRef.current);
+			refreshTimerRef.current = null;
+		}
+	}, [isEnabled]);
+
+	useEffect(() => {
+		if (
+			previousConfigKeyRef.current &&
+			previousConfigKeyRef.current !== refreshConfigKey &&
+			refreshTimerRef.current
+		) {
+			clearTimeout(refreshTimerRef.current);
+			refreshTimerRef.current = null;
+		}
+
+		previousConfigKeyRef.current = refreshConfigKey;
+	}, [refreshConfigKey]);
 
 	useEffect(() => {
 		return () => {
@@ -34,34 +94,28 @@ export function useWorkspaceGitChangesRefresh({
 	useWorkspaceFileEvents(
 		workspaceId ?? "",
 		() => {
-			if (!worktreePath || !defaultBranch) {
-				return;
-			}
-
-			if (refreshTimerRef.current) {
-				clearTimeout(refreshTimerRef.current);
-			}
-
-			refreshTimerRef.current = setTimeout(() => {
-				refreshTimerRef.current = null;
-				Promise.all([
-					trpcUtils.changes.getStatus.invalidate({
-						worktreePath,
-						defaultBranch,
-					}),
-					trpcUtils.changes.getBranches.invalidate({ worktreePath }),
-				]).catch((error) => {
-					console.error(
-						"[useWorkspaceGitChangesRefresh] Failed to refresh git changes:",
-						{
-							workspaceId,
-							worktreePath,
-							error,
-						},
-					);
-				});
-			}, debounceMs);
+			scheduleRefresh();
 		},
-		enabled && Boolean(workspaceId && worktreePath && defaultBranch),
+		isEnabled,
+	);
+
+	electronTrpc.changes.subscribeGitMetadata.useSubscription(
+		{ worktreePath: worktreePath ?? "" },
+		{
+			enabled: isEnabled,
+			onData: () => {
+				scheduleRefresh();
+			},
+			onError: (error) => {
+				console.error(
+					"[useWorkspaceGitChangesRefresh] Git metadata subscription failed:",
+					{
+						workspaceId,
+						worktreePath,
+						error,
+					},
+				);
+			},
+		},
 	);
 }


### PR DESCRIPTION
## Summary
- replace interval-based git change refresh in desktop workspace views with debounced filesystem-event invalidation
- keep the active workspace sidebar item fresh using the same watcher-driven path
- avoid doing refresh work for inactive or idle workspace views

## Testing
- bun run --cwd apps/desktop typecheck
- bunx biome check apps/desktop/src/renderer/screens/main/hooks/useWorkspaceGitChangesRefresh/useWorkspaceGitChangesRefresh.ts apps/desktop/src/renderer/screens/main/hooks/useWorkspaceGitChangesRefresh/index.ts apps/desktop/src/renderer/screens/main/hooks/index.ts apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/ChangesContent.tsx apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace polling-based Git refresh with a debounced, event-driven flow triggered by workspace file changes and `.git` metadata updates. Keeps changes and branches fresh while cutting background work, especially when views are inactive.

- **Bug Fixes**
  - Added `changes.subscribeGitMetadata` to stream `.git` updates using Git watch roots and ignore heavy dirs (e.g., `objects`, `logs`).
  - Introduced `useWorkspaceGitChangesRefresh` to subscribe to file/metadata events, debounce (75ms), and invalidate `changes.getStatus` and `changes.getBranches`.
  - Integrated the hook at the workspace page and derive `effectiveBaseBranch` from `changes.getBranches`.
  - Removed interval refetching in `ChangesView` and `ChangesContent`; only active views subscribe; the sidebar item updates when hovered or active.

<sup>Written for commit c4e0ccd7c4d799be052bcd4149279412c4ccc810. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic workspace Git-change refresh and metadata streaming to keep change lists up to date.

* **Improvements**
  * Broadened when local-change detection runs so active workspaces update more responsively.
  * Simplified background polling/refetch logic so change views refresh only when active, reducing unnecessary updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->