### PR TITLE
Add remote sandbox shim surface note

### DIFF
--- a/remote-sandbox-shim-surface.md
+++ b/remote-sandbox-shim-surface.md
@@ -2,6 +2,16 @@
 
 This is the final state I would target for the remote filesystem shim.
 
+Summary:
+
+- `listDirectory` for directory listings
+- `readFile` for text and byte reads, including paged reads
+- `getMetadata` for path metadata and revision tokens
+- `writeFile` for plain and conflict-aware writes
+- `createDirectory`, `deletePath`, `movePath`, and `copyPath` for path mutations
+- `searchFiles` and `searchContent` for path and content search
+- `watchPath` for filesystem change events
+
 ## Core API
 
 ### `listDirectory`
@@ -12,28 +22,74 @@ Returns the direct children of a directory.
 listDirectory({ absolutePath })
 ```
 
-### `readFile`
-
-Reads a file as text or bytes. `maxBytes` supports capped reads.
-Use this instead of separate text, bytes, and capped-read primitives.
+Returns:
 
 ```ts
-readFile({ absolutePath, maxBytes, encoding })
+{
+  entries: Array<{
+    absolutePath: string
+    name: string
+    kind: "file" | "directory" | "symlink" | "other"
+  }>
+}
 ```
+
+### `readFile`
+
+Reads a file as text or bytes. `offset` and `maxBytes` support paged reads.
+Should return an opaque `revision` token representing the version of the file that was read.
+
+```ts
+readFile({ absolutePath, offset, maxBytes, encoding })
+```
+
+Returns:
+
+```ts
+{
+  kind: "text" | "bytes"
+  content: string | Uint8Array
+  byteLength: number
+  exceededLimit: boolean
+  revision: string
+}
+```
+
+If `exceededLimit` is `true`, more data is available after the returned chunk and the client can continue reading by calling `readFile` again with a larger `offset`.
 
 ### `getMetadata`
 
 Returns file metadata, or `null` if the path does not exist.
-Use this instead of separate `exists` and `stat` calls.
+Should return an opaque `revision` token representing the current version of the path.
 
 ```ts
 getMetadata({ absolutePath })
 ```
 
+Returns:
+
+```ts
+null | {
+  absolutePath: string
+  kind: "file" | "directory" | "symlink" | "other"
+  size: number | null
+  createdAt: string | null
+  modifiedAt: string | null
+  accessedAt: string | null
+  mode?: number | null
+  permissions?: string | null
+  owner?: string | null
+  group?: string | null
+  symlinkTarget?: string | null
+  revision: string
+}
+```
+
 ### `writeFile`
 
 Writes file contents. `ifMatch` is the recommended conflict-aware write mechanism.
-Use an opaque revision token from `readFile` or `getMetadata`.
+Use an opaque `revision` token from `readFile` or `getMetadata`. A revision is a freshness token for the version of the file the client last observed.
+Without a `precondition`, this should act as a plain overwrite-or-create write.
 
 ```ts
 writeFile({
@@ -46,36 +102,85 @@ writeFile({
 })
 ```
 
-### `createPath`
-
-Creates a file or directory. `content` only applies to file creation.
+Returns:
 
 ```ts
-createPath({ absolutePath, kind, content })
+| {
+    ok: true
+    revision: string
+  }
+| {
+    ok: false
+    reason: "conflict"
+    currentRevision: string
+  }
 ```
 
-### `deletePaths`
+### `createDirectory`
 
-Deletes one or more paths. `permanent` controls trash vs hard delete behavior.
+Creates a directory. File creation should happen through `writeFile`.
 
 ```ts
-deletePaths({ absolutePaths, permanent })
+createDirectory({ absolutePath })
 ```
 
-### `movePaths`
-
-Moves one or more paths. Rename is just a same-parent move.
+Returns:
 
 ```ts
-movePaths({ sourceAbsolutePaths, destinationAbsolutePath })
+{
+  absolutePath: string
+  kind: "directory"
+}
 ```
 
-### `copyPaths`
+### `deletePath`
 
-Copies one or more paths.
+Deletes a path. `permanent` controls trash vs hard delete behavior.
 
 ```ts
-copyPaths({ sourceAbsolutePaths, destinationAbsolutePath })
+deletePath({ absolutePath, permanent })
+```
+
+Returns:
+
+```ts
+{
+  absolutePath: string
+}
+```
+
+### `movePath`
+
+Moves a path. Rename is just a same-parent move.
+
+```ts
+movePath({ sourceAbsolutePath, destinationAbsolutePath })
+```
+
+Returns:
+
+```ts
+{
+  fromAbsolutePath: string
+  toAbsolutePath: string
+}
+```
+
+### `copyPath`
+
+Copies a path.
+
+```ts
+copyPath({ sourceAbsolutePath, destinationAbsolutePath })
+```
+
+Returns:
+
+```ts
+{
+  fromAbsolutePath: string
+  toAbsolutePath: string
+}
 ```
 
 ### `searchFiles`
@@ -86,6 +191,20 @@ Searches file names and paths.
 searchFiles({ query, includeHidden, includePattern, excludePattern, limit })
 ```
 
+Returns:
+
+```ts
+{
+  matches: Array<{
+    absolutePath: string
+    relativePath: string
+    name: string
+    kind: "file" | "directory" | "symlink" | "other"
+    score: number
+  }>
+}
+```
+
 ### `searchContent`
 
 Searches file contents and should return line/column-oriented matches.
@@ -94,23 +213,39 @@ Searches file contents and should return line/column-oriented matches.
 searchContent({ query, includeHidden, includePattern, excludePattern, limit })
 ```
 
+Returns:
+
+```ts
+{
+  matches: Array<{
+    absolutePath: string
+    relativePath: string
+    line: number
+    column: number
+    preview: string
+  }>
+}
+```
+
 ### `watchPath`
 
-Subscribes to path changes. This should be the primitive watch operation.
-Any workspace-wide watch should be a wrapper around this.
+Subscribes to path changes.
 
 ```ts
 watchPath({ absolutePath, recursive })
 ```
 
-## Consolidation
+Yields:
 
-- `readTextFile`, `readFileBuffer`, and `readFileBufferUpTo` collapse into `readFile`
-- `exists` and `stat` collapse into `getMetadata`
-- `writeTextFile` and `guardedWriteTextFile` collapse into `writeFile`
-- `createFile` and `createDirectory` collapse into `createPath`
-- `rename` is just a same-parent `movePaths`
-- `watchWorkspace` becomes `watchPath(workspaceRoot)`
+```ts
+{
+  events: Array<{
+    kind: "create" | "update" | "delete" | "rename" | "overflow"
+    absolutePath: string
+    oldAbsolutePath?: string
+  }>
+}
+```
 
 ## Search
 


### PR DESCRIPTION
## Summary
- add a markdown note describing the remote sandbox shim surface
- split the filesystem abstraction into V1, V1.5, and deferred methods
- call out guarded writes as the canonical save primitive

## Testing
- not run (documentation-only change)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a doc that defines the remote sandbox filesystem shim surface and boundaries. It establishes a pure path-based core API (`listDirectory`, `readFile`, `getMetadata` with revision tokens, `writeFile` with `precondition.ifMatch`, `createDirectory`, `deletePath`/`movePath`/`copyPath`, `searchFiles`/`searchContent`, `watchPath`), consolidates older variants (`exists`+`stat` → `getMetadata`, `watchWorkspace` → `watchPath`), and clarifies that workspace scoping and helpers live above the shim. No runtime changes.

<sup>Written for commit fd7236878946900735d1efc472361fedfc62f4ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Remote Sandbox Shim Surface documentation describing file, directory, metadata, search and watch capabilities.
  * Documents how related APIs are consolidated into unified primitives and guidance on preserving distinct search behaviors.
  * Covers workspace scoping, conflict-aware write semantics, handling of missing paths, and watch wrapper behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->