### PR TITLE
Add shortcut to equalize pane splits

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -561,6 +561,18 @@ function WorkspacePage() {
 		],
 	);
 
+	const equalizePaneSplits = useTabsStore((s) => s.equalizePaneSplits);
+	useAppHotkey(
+		"EQUALIZE_PANE_SPLITS",
+		() => {
+			if (activeTabId) {
+				equalizePaneSplits(activeTabId);
+			}
+		},
+		undefined,
+		[activeTabId, equalizePaneSplits],
+	);
+
 	// Navigate to previous workspace (⌘↑)
 	const getPreviousWorkspace =
 		electronTrpc.workspaces.getPreviousWorkspace.useQuery(

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabContentContextMenu.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabContentContextMenu.tsx
@@ -32,6 +32,7 @@ interface TabContentContextMenuProps {
 	onSplitVertical: PaneContextMenuActions["onSplitVertical"];
 	onSplitWithNewChat?: PaneContextMenuActions["onSplitWithNewChat"];
 	onSplitWithNewBrowser?: PaneContextMenuActions["onSplitWithNewBrowser"];
+	onEqualizePaneSplits?: PaneContextMenuActions["onEqualizePaneSplits"];
 	onClosePane: PaneContextMenuActions["onClosePane"];
 	onClearTerminal?: () => void;
 	onScrollToBottom?: () => void;
@@ -51,6 +52,7 @@ export function TabContentContextMenu({
 	onSplitVertical,
 	onSplitWithNewChat,
 	onSplitWithNewBrowser,
+	onEqualizePaneSplits,
 	onClosePane,
 	onClearTerminal,
 	onScrollToBottom,
@@ -155,6 +157,7 @@ export function TabContentContextMenu({
 						onSplitVertical,
 						onSplitWithNewChat,
 						onSplitWithNewBrowser,
+						onEqualizePaneSplits,
 						onClosePane,
 						currentTabId,
 						availableTabs,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatMastraPane/ChatMastraPane.tsx
@@ -66,6 +66,7 @@ export function ChatMastraPane({
 }: ChatMastraPaneProps) {
 	const showDevToolbarActions = env.NODE_ENV === "development";
 	const isFocused = useTabsStore((s) => s.focusedPaneIds[tabId] === paneId);
+	const equalizePaneSplits = useTabsStore((s) => s.equalizePaneSplits);
 	const paneName = useTabsStore((s) => s.panes[paneId]?.name ?? "New Chat");
 	const setTabAutoTitle = useTabsStore((s) => s.setTabAutoTitle);
 	const setPaneAutoTitle = useTabsStore((s) => s.setPaneAutoTitle);
@@ -199,6 +200,7 @@ export function ChatMastraPane({
 						onSplitWithNewBrowser={() =>
 							splitPaneVertical(tabId, paneId, path, { paneType: "webview" })
 						}
+						onEqualizePaneSplits={() => equalizePaneSplits(tabId)}
 						onClosePane={() => removePane(paneId)}
 						currentTabId={tabId}
 						availableTabs={availableTabs}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
@@ -73,6 +73,7 @@ export function FileViewerPane({
 	// Use granular selector to only get this pane's fileViewer data
 	const fileViewer = useTabsStore((s) => s.panes[paneId]?.fileViewer);
 	const isFocused = useTabsStore((s) => s.focusedPaneIds[tabId] === paneId);
+	const equalizePaneSplits = useTabsStore((s) => s.equalizePaneSplits);
 	const {
 		viewMode: diffViewMode,
 		setViewMode: setDiffViewMode,
@@ -545,6 +546,7 @@ export function FileViewerPane({
 							onSplitWithNewBrowser={() =>
 								splitPaneVertical(tabId, paneId, path, { paneType: "webview" })
 							}
+							onEqualizePaneSplits={() => equalizePaneSplits(tabId)}
 							onClosePane={() => removePane(paneId)}
 							currentTabId={tabId}
 							availableTabs={availableTabs}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/DiffViewerContextMenu/DiffViewerContextMenu.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/DiffViewerContextMenu/DiffViewerContextMenu.tsx
@@ -19,6 +19,7 @@ interface DiffViewerContextMenuProps {
 	onSplitVertical: () => void;
 	onSplitWithNewChat?: () => void;
 	onSplitWithNewBrowser?: () => void;
+	onEqualizePaneSplits?: () => void;
 	onClosePane: () => void;
 	currentTabId: string;
 	availableTabs: Tab[];
@@ -54,6 +55,7 @@ export function DiffViewerContextMenu({
 	onSplitVertical,
 	onSplitWithNewChat,
 	onSplitWithNewBrowser,
+	onEqualizePaneSplits,
 	onClosePane,
 	currentTabId,
 	availableTabs,
@@ -136,6 +138,7 @@ export function DiffViewerContextMenu({
 				onSplitVertical,
 				onSplitWithNewChat,
 				onSplitWithNewBrowser,
+				onEqualizePaneSplits,
 				onClosePane,
 				currentTabId,
 				availableTabs,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileEditorContextMenu/FileEditorContextMenu.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileEditorContextMenu/FileEditorContextMenu.tsx
@@ -14,6 +14,7 @@ interface FileEditorContextMenuProps {
 	onSplitVertical: () => void;
 	onSplitWithNewChat?: () => void;
 	onSplitWithNewBrowser?: () => void;
+	onEqualizePaneSplits?: () => void;
 	onClosePane: () => void;
 	currentTabId: string;
 	availableTabs: Tab[];
@@ -29,6 +30,7 @@ export function FileEditorContextMenu({
 	onSplitVertical,
 	onSplitWithNewChat,
 	onSplitWithNewBrowser,
+	onEqualizePaneSplits,
 	onClosePane,
 	currentTabId,
 	availableTabs,
@@ -51,6 +53,7 @@ export function FileEditorContextMenu({
 				onSplitVertical,
 				onSplitWithNewChat,
 				onSplitWithNewBrowser,
+				onEqualizePaneSplits,
 				onClosePane,
 				currentTabId,
 				availableTabs,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
@@ -116,6 +116,7 @@ interface FileViewerContentProps {
 	onSplitVertical: () => void;
 	onSplitWithNewChat?: () => void;
 	onSplitWithNewBrowser?: () => void;
+	onEqualizePaneSplits?: () => void;
 	onClosePane: () => void;
 	currentTabId: string;
 	availableTabs: Tab[];
@@ -160,6 +161,7 @@ export function FileViewerContent({
 	onSplitVertical,
 	onSplitWithNewChat,
 	onSplitWithNewBrowser,
+	onEqualizePaneSplits,
 	onClosePane,
 	currentTabId,
 	availableTabs,
@@ -311,6 +313,7 @@ export function FileViewerContent({
 				onSplitVertical={onSplitVertical}
 				onSplitWithNewChat={onSplitWithNewChat}
 				onSplitWithNewBrowser={onSplitWithNewBrowser}
+				onEqualizePaneSplits={onEqualizePaneSplits}
 				onClosePane={onClosePane}
 				currentTabId={currentTabId}
 				availableTabs={availableTabs}
@@ -466,6 +469,7 @@ export function FileViewerContent({
 			onSplitVertical={onSplitVertical}
 			onSplitWithNewChat={onSplitWithNewChat}
 			onSplitWithNewBrowser={onSplitWithNewBrowser}
+			onEqualizePaneSplits={onEqualizePaneSplits}
 			onClosePane={onClosePane}
 			currentTabId={currentTabId}
 			availableTabs={availableTabs}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/TabPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/TabPane.tsx
@@ -59,6 +59,7 @@ export function TabPane({
 	const paneName = useTabsStore((s) => s.panes[paneId]?.name);
 	const paneStatus = useTabsStore((s) => s.panes[paneId]?.status);
 	const setPaneStatus = useTabsStore((s) => s.setPaneStatus);
+	const equalizePaneSplits = useTabsStore((s) => s.equalizePaneSplits);
 
 	const terminalContainerRef = useRef<HTMLDivElement>(null);
 	const getClearCallback = useTerminalCallbacksStore((s) => s.getClearCallback);
@@ -124,6 +125,7 @@ export function TabPane({
 				onSplitWithNewBrowser={() =>
 					splitPaneVertical(tabId, paneId, path, { paneType: "webview" })
 				}
+				onEqualizePaneSplits={() => equalizePaneSplits(tabId)}
 				onClosePane={() => removePane(paneId)}
 				onClearTerminal={handleClearTerminal}
 				onScrollToBottom={handleScrollToBottom}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/MosaicSplitOverlay/MosaicSplitOverlay.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/MosaicSplitOverlay/MosaicSplitOverlay.tsx
@@ -2,6 +2,7 @@ import { cn } from "@superset/ui/utils";
 import { useCallback, useRef } from "react";
 import type { MosaicNode, MosaicPath } from "react-mosaic-component";
 import { useDragPaneStore } from "renderer/stores/drag-pane-store";
+import { equalizeSplitPercentages } from "renderer/stores/tabs/utils";
 
 interface BoundingBox {
 	top: number;
@@ -99,18 +100,6 @@ function updateSplitPercentage(
 	return {
 		...node,
 		[head]: updateSplitPercentage(node[head], rest, newPercentage),
-	};
-}
-
-function equalizeSplitPercentages(
-	node: MosaicNode<string>,
-): MosaicNode<string> {
-	if (typeof node === "string") return node;
-	return {
-		...node,
-		splitPercentage: 50,
-		first: equalizeSplitPercentages(node.first),
-		second: equalizeSplitPercentages(node.second),
 	};
 }
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PaneContextMenuItems/PaneContextMenuItems.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PaneContextMenuItems/PaneContextMenuItems.tsx
@@ -8,6 +8,7 @@ import {
 } from "@superset/ui/context-menu";
 import {
 	LuColumns2,
+	LuEqual,
 	LuGlobe,
 	LuMessageSquare,
 	LuMoveRight,
@@ -23,6 +24,7 @@ export interface PaneContextMenuActions {
 	onSplitVertical: () => void;
 	onSplitWithNewChat?: () => void;
 	onSplitWithNewBrowser?: () => void;
+	onEqualizePaneSplits?: () => void;
 	onClosePane: () => void;
 	currentTabId: string;
 	availableTabs: Tab[];
@@ -43,6 +45,7 @@ export function PaneContextMenuItems({
 	const splitRightShortcut = useHotkeyText("SPLIT_RIGHT");
 	const splitWithChatShortcut = useHotkeyText("SPLIT_WITH_CHAT");
 	const splitWithBrowserShortcut = useHotkeyText("SPLIT_WITH_BROWSER");
+	const equalizePaneSplitsShortcut = useHotkeyText("EQUALIZE_PANE_SPLITS");
 	const targetTabs = actions.availableTabs.filter(
 		(tab) => tab.id !== actions.currentTabId,
 	);
@@ -75,6 +78,13 @@ export function PaneContextMenuItems({
 					<LuGlobe className="size-4" />
 					Split with New Browser
 					{renderShortcut(splitWithBrowserShortcut)}
+				</ContextMenuItem>
+			)}
+			{actions.onEqualizePaneSplits && (
+				<ContextMenuItem onSelect={actions.onEqualizePaneSplits}>
+					<LuEqual className="size-4" />
+					Equalize Pane Splits
+					{renderShortcut(equalizePaneSplitsShortcut)}
 				</ContextMenuItem>
 			)}
 			<ContextMenuSeparator />

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -29,6 +29,7 @@ import {
 	createFileViewerPane,
 	createPane,
 	createTabWithPane,
+	equalizeSplitPercentages,
 	extractPaneIdsFromLayout,
 	generateId,
 	generateTabName,
@@ -498,6 +499,13 @@ export const useTabsStore = create<TabsStore>()(
 						panes: newPanes,
 						focusedPaneIds: newFocusedPaneIds,
 					});
+				},
+
+				equalizePaneSplits: (tabId) => {
+					const tab = get().tabs.find((t) => t.id === tabId);
+					if (!tab?.layout || typeof tab.layout === "string") return;
+					const equalizedLayout = equalizeSplitPercentages(tab.layout);
+					get().updateTabLayout(tabId, equalizedLayout);
 				},
 
 				// Pane operations

--- a/apps/desktop/src/renderer/stores/tabs/types.ts
+++ b/apps/desktop/src/renderer/stores/tabs/types.ts
@@ -174,6 +174,9 @@ export interface TabsStore extends TabsState {
 		options?: SplitPaneOptions,
 	) => void;
 
+	// Equalize operations
+	equalizePaneSplits: (tabId: string) => void;
+
 	// Move operations
 	movePaneToTab: (paneId: string, targetTabId: string) => void;
 	movePaneToNewTab: (paneId: string) => string;

--- a/apps/desktop/src/renderer/stores/tabs/utils.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils.ts
@@ -585,6 +585,32 @@ export const addPaneToLayout = (
 });
 
 /**
+ * Counts the number of leaf panes in a mosaic subtree.
+ */
+const countLeaves = (node: MosaicNode<string>): number => {
+	if (typeof node === "string") return 1;
+	return countLeaves(node.first) + countLeaves(node.second);
+};
+
+/**
+ * Recursively sets split percentages so all leaf panes get equal space.
+ * Each split is proportional to the number of leaves on each side.
+ */
+export const equalizeSplitPercentages = (
+	node: MosaicNode<string>,
+): MosaicNode<string> => {
+	if (typeof node === "string") return node;
+	const leftLeaves = countLeaves(node.first);
+	const rightLeaves = countLeaves(node.second);
+	return {
+		...node,
+		splitPercentage: (leftLeaves / (leftLeaves + rightLeaves)) * 100,
+		first: equalizeSplitPercentages(node.first),
+		second: equalizeSplitPercentages(node.second),
+	};
+};
+
+/**
  * Builds a balanced multi-pane Mosaic layout using recursive binary splits.
  * For 3+ panes, alternates between column and row splits to create a grid.
  */

--- a/apps/desktop/src/shared/hotkeys.ts
+++ b/apps/desktop/src/shared/hotkeys.ts
@@ -514,6 +514,16 @@ export const HOTKEYS = {
 			linux: "ctrl+shift+alt+s",
 		},
 	}),
+	EQUALIZE_PANE_SPLITS: defineHotkey({
+		keys: "meta+shift+0",
+		label: "Equalize Pane Splits",
+		category: "Layout",
+		description: "Make all panes equal size",
+		defaults: {
+			win32: "ctrl+shift+0",
+			linux: "ctrl+shift+0",
+		},
+	}),
 	CLOSE_PANE: defineHotkey({
 		keys: "meta+w",
 		label: "Close Pane",


### PR DESCRIPTION
## Summary
- Adds `Cmd+Shift+0` (`Ctrl+Shift+0` on Windows/Linux) to equalize all pane splits in the active tab
- Adds "Equalize Pane Splits" to the pane right-click context menu
- Extracts `equalizeSplitPercentages` into a shared utility so both the hotkey and the existing double-click-to-equalize on split handles use the same code
- The algorithm counts leaf panes on each side of every split node, so it handles unbalanced/right-heavy trees correctly (not just 50/50 at every level)

## Test plan
- [x] Split panes unevenly (drag dividers, split multiple times to one side) → press `Cmd+Shift+0` → all panes become equal width/height
- [x] Right-click a pane → "Equalize Pane Splits" menu item appears with shortcut text
- [x] Double-click a split handle still equalizes (unchanged behavior)
- [x] Shortcut appears in Settings > Keyboard > Layout category

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Cmd+Shift+0 (Ctrl+Shift+0) to equalize all panes in the active tab and expose the action in pane context menus. Uses a proportional split algorithm so all panes end up the same size, even in unbalanced trees.

- **New Features**
  - Global hotkey `EQUALIZE_PANE_SPLITS`; wired to the active tab and shown under Settings > Keyboard (Layout).
  - "Equalize Pane Splits" added to pane context menus with shortcut hint.

- **Refactors**
  - Moved `equalizeSplitPercentages` to `tabs/utils` and reused by the hotkey, context menu, and split-handle double-click.
  - Algorithm sets split percentages from leaf counts per side to distribute space evenly.

<sup>Written for commit 61e55aa9dd9c254f00cb6ea566d9e0086cbb6a7f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Equalize Pane Splits" feature to make all panes equal size in the current tab, accessible via keyboard shortcut (Ctrl+Shift+0 on Windows/Linux, Cmd+Shift+0 on Mac) or pane context menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->