### PR TITLE
fix(codex): add explicit SSE type to MCP server configs

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,7 +1,9 @@
 [mcp_servers.superset]
+type = "sse"
 url = "https://api.superset.sh/api/agent/mcp"
 
 [mcp_servers.expo-mcp]
+type = "sse"
 url = "https://mcp.expo.dev/mcp"
 enabled = false
 
@@ -10,12 +12,15 @@ command = "maestro"
 args = ["mcp"]
 
 [mcp_servers.neon]
+type = "sse"
 url = "https://mcp.neon.tech/mcp"
 
 [mcp_servers.linear]
+type = "sse"
 url = "https://mcp.linear.app/mcp"
 
 [mcp_servers.sentry]
+type = "sse"
 url = "https://mcp.sentry.dev/mcp"
 
 [mcp_servers.desktop-automation]


### PR DESCRIPTION
## Summary
- Adds `type = "sse"` to SSE-based MCP server entries in `.codex/config.toml` (superset, expo-mcp, neon, linear, sentry)
- Codex requires this field to correctly identify SSE transport for remote MCP servers

## Test plan
- [ ] Verify Codex connects to MCP servers with updated config

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `type = "sse"` to SSE-based MCP server entries in `.codex/config.toml` so Codex correctly uses SSE transport and connects reliably (`superset`, `expo-mcp`, `neon`, `linear`, `sentry`).

<sup>Written for commit 1f11e7711f36eca830b5b6ad6193307904a02957. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service integration configuration to specify communication protocol settings across multiple server endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->