### PR TITLE
Add security headers to all Next.js apps

### DIFF
--- a/apps/admin/next.config.ts
+++ b/apps/admin/next.config.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import { withSentryConfig } from "@sentry/nextjs";
+import { securityHeaders } from "@superset/shared/security-headers";
 import { config as dotenvConfig } from "dotenv";
 import type { NextConfig } from "next";
 
@@ -40,6 +41,15 @@ const config: NextConfig = {
 				destination: "https://us.i.posthog.com/decide",
 			},
 		];
+	},
+
+	async headers() {
+		return securityHeaders({
+			csp: {
+				"connect-src": ["wss:", "ws:"],
+				"frame-src": ["'self'"],
+			},
+		});
 	},
 
 	skipTrailingSlashRedirect: true,

--- a/apps/api/next.config.ts
+++ b/apps/api/next.config.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import { withSentryConfig } from "@sentry/nextjs";
+import { securityHeaders } from "@superset/shared/security-headers";
 import { config as dotenvConfig } from "dotenv";
 import type { NextConfig } from "next";
 
@@ -22,6 +23,10 @@ const config: NextConfig = {
 				hostname: "*.public.blob.vercel-storage.com",
 			},
 		],
+	},
+
+	async headers() {
+		return securityHeaders();
 	},
 };
 

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import { withSentryConfig } from "@sentry/nextjs";
+import { securityHeaders } from "@superset/shared/security-headers";
 import { config as dotenvConfig } from "dotenv";
 import { createMDX } from "fumadocs-mdx/next";
 
@@ -60,6 +61,13 @@ const config = {
 				destination: "https://us.i.posthog.com/decide",
 			},
 		];
+	},
+	async headers() {
+		return securityHeaders({
+			csp: {
+				"frame-src": ["https://www.youtube.com"],
+			},
+		});
 	},
 	skipTrailingSlashRedirect: true,
 };

--- a/apps/marketing/next.config.ts
+++ b/apps/marketing/next.config.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import { withSentryConfig } from "@sentry/nextjs";
+import { securityHeaders } from "@superset/shared/security-headers";
 import { config as dotenvConfig } from "dotenv";
 import type { NextConfig } from "next";
 
@@ -67,6 +68,15 @@ const config: NextConfig = {
 				permanent: false,
 			},
 		];
+	},
+
+	async headers() {
+		return securityHeaders({
+			csp: {
+				"img-src": ["https://unavatar.io"],
+				"frame-src": ["https://www.youtube.com"],
+			},
+		});
 	},
 
 	skipTrailingSlashRedirect: true,

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import { withSentryConfig } from "@sentry/nextjs";
+import { securityHeaders } from "@superset/shared/security-headers";
 import { config as dotenvConfig } from "dotenv";
 import type { NextConfig } from "next";
 
@@ -40,6 +41,17 @@ const config: NextConfig = {
 				destination: "https://us.i.posthog.com/decide",
 			},
 		];
+	},
+
+	async headers() {
+		return securityHeaders({
+			csp: {
+				"script-src": ["'unsafe-eval'"],
+				"img-src": ["blob:"],
+				"connect-src": ["wss:", "ws:"],
+				"frame-src": ["'self'"],
+			},
+		});
 	},
 
 	skipTrailingSlashRedirect: true,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -31,6 +31,10 @@
 		"./claude-command": {
 			"types": "./src/claude-command.ts",
 			"default": "./src/claude-command.ts"
+		},
+		"./security-headers": {
+			"types": "./src/security-headers/index.ts",
+			"default": "./src/security-headers/index.ts"
 		}
 	},
 	"scripts": {

--- a/packages/shared/src/security-headers/index.ts
+++ b/packages/shared/src/security-headers/index.ts
@@ -1,0 +1,65 @@
+type CspDirectives = Partial<Record<string, string[]>>;
+
+interface SecurityHeadersOptions {
+	/** Additional CSP directives to merge with defaults */
+	csp?: CspDirectives;
+}
+
+const DEFAULT_CSP: CspDirectives = {
+	"default-src": ["'self'"],
+	"script-src": ["'self'", "'unsafe-inline'"],
+	"style-src": ["'self'", "'unsafe-inline'"],
+	"img-src": ["'self'", "data:", "https://*.public.blob.vercel-storage.com"],
+	"font-src": ["'self'"],
+	"connect-src": ["'self'", "https://*.ingest.sentry.io"],
+	"frame-src": ["'none'"],
+	"object-src": ["'none'"],
+	"base-uri": ["'self'"],
+	"form-action": ["'self'"],
+	"frame-ancestors": ["'none'"],
+	"media-src": ["'self'"],
+	"worker-src": ["'self'", "blob:"],
+};
+
+function buildCsp(overrides: CspDirectives = {}): string {
+	const merged: CspDirectives = { ...DEFAULT_CSP };
+	for (const [key, values] of Object.entries(overrides)) {
+		if (!values) continue;
+		const existing = merged[key] ?? [];
+		merged[key] = [...new Set([...existing, ...values])];
+	}
+	return Object.entries(merged)
+		.map(([key, values]) => `${key} ${(values ?? []).join(" ")}`)
+		.join("; ");
+}
+
+/**
+ * Returns Next.js `headers()` config with security headers.
+ * CSP directives are merged with sensible defaults — pass overrides to extend.
+ */
+export function securityHeaders(options: SecurityHeadersOptions = {}) {
+	const csp = buildCsp(options.csp);
+
+	return [
+		{
+			source: "/(.*)",
+			headers: [
+				{ key: "Content-Security-Policy", value: csp },
+				{ key: "X-Content-Type-Options", value: "nosniff" },
+				{ key: "X-Frame-Options", value: "SAMEORIGIN" },
+				{
+					key: "Referrer-Policy",
+					value: "strict-origin-when-cross-origin",
+				},
+				{
+					key: "Strict-Transport-Security",
+					value: "max-age=63072000; includeSubDomains",
+				},
+				{
+					key: "Permissions-Policy",
+					value: "camera=(), microphone=(), geolocation=(), browsing-topics=()",
+				},
+			],
+		},
+	];
+}


### PR DESCRIPTION
## Summary
- Created shared `securityHeaders()` utility in `@superset/shared/security-headers` that returns Next.js `headers()` config with all required security headers
- Integrated into all 5 Next.js apps (`marketing`, `web`, `admin`, `api`, `docs`) with per-app CSP customization
- Marketing has the strictest CSP; web/admin allow more flexibility (websockets, unsafe-eval, blob images)

### Headers added
- `Content-Security-Policy` (per-app, marketing strictest)
- `X-Content-Type-Options: nosniff`
- `X-Frame-Options: SAMEORIGIN`
- `Referrer-Policy: strict-origin-when-cross-origin`
- `Strict-Transport-Security: max-age=63072000; includeSubDomains`
- `Permissions-Policy: camera=(), microphone=(), geolocation=(), browsing-topics=()`

## Test plan
- [ ] Deploy to preview and verify headers appear on all apps via browser DevTools (Network tab → Response Headers)
- [ ] Verify marketing site loads correctly (YouTube embed, unavatar.io images, PostHog analytics, Sentry monitoring)
- [ ] Verify web app loads correctly (websocket connections, blob URLs, dynamic features)
- [ ] Verify docs site loads correctly (YouTube embeds)
- [ ] Run through [securityheaders.com](https://securityheaders.com) to confirm grade improvement

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add shared security headers across all Next.js apps to harden security and resolve recent malware flagging on superset.sh. Introduces `securityHeaders()` in `@superset/shared/security-headers` and integrates it into `marketing`, `web`, `admin`, `api`, and `docs` with app-specific CSP.

- **New Features**
  - Shared `securityHeaders()` returning Next.js `headers()` with CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, and Permissions-Policy.
  - CSP overrides:
    - marketing: `img-src https://unavatar.io`, `frame-src https://www.youtube.com`.
    - web: `script-src 'unsafe-eval'`, `img-src blob:`, `connect-src wss: ws:`, `frame-src 'self'`.
    - admin: `connect-src wss: ws:`, `frame-src 'self'`.
    - docs: `frame-src https://www.youtube.com`.
    - api: defaults only.

<sup>Written for commit fe8cbe0827c7fc4118cf4bba4102a575d98ad5da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented centralized security headers configuration across all applications with customized security policies for enhanced request handling and resource loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->