### PR TITLE
feat(mcp): support prompt-driven agent launches without tasks

### DIFF
--- a/packages/mcp/src/tools/devices/start-agent-session/start-agent-session.ts
+++ b/packages/mcp/src/tools/devices/start-agent-session/start-agent-session.ts
@@ -4,6 +4,7 @@ import { taskStatuses, tasks } from "@superset/db/schema";
 import {
 	type AGENT_TYPES,
 	buildAgentCommand,
+	buildAgentPromptCommand,
 	buildAgentTaskPrompt,
 } from "@superset/shared/agent-command";
 import {
@@ -49,7 +50,18 @@ async function fetchTask({
 
 const inputSchemaShape = {
 	deviceId: z.string().min(1).describe("Target device ID"),
-	taskId: z.string().min(1).describe("Task ID to work on"),
+	taskId: z
+		.string()
+		.min(1)
+		.optional()
+		.describe("Task ID to work on. Required unless prompt is provided."),
+	prompt: z
+		.string()
+		.min(1)
+		.optional()
+		.describe(
+			"Direct prompt to start the agent with. Use this for task-free launches. Required unless taskId is provided.",
+		),
 	workspaceId: z
 		.string()
 		.min(1)
@@ -69,14 +81,17 @@ const inputSchemaShape = {
 		),
 };
 
-const inputSchema = z.object(inputSchemaShape);
+const inputSchema = z.object(inputSchemaShape).refine(
+	(data) => data.taskId || data.prompt,
+	{ message: "Either taskId or prompt must be provided" },
+);
 
 const ERROR_TASK_NOT_FOUND = {
 	content: [{ type: "text" as const, text: "Error: Task not found" }],
 	isError: true,
 };
 
-function buildLaunchRequest({
+function buildTaskLaunchRequest({
 	workspaceId,
 	paneId,
 	agent,
@@ -85,12 +100,8 @@ function buildLaunchRequest({
 	workspaceId: string;
 	paneId?: string;
 	agent: (typeof STARTABLE_AGENT_TYPES)[number];
-	task: Awaited<ReturnType<typeof fetchTask>>;
+	task: NonNullable<Awaited<ReturnType<typeof fetchTask>>>;
 }): AgentLaunchRequest {
-	if (!task) {
-		throw new Error("Task not found");
-	}
-
 	if (agent === "superset-chat") {
 		return {
 			kind: "chat",
@@ -122,12 +133,53 @@ function buildLaunchRequest({
 	};
 }
 
+function buildPromptLaunchRequest({
+	workspaceId,
+	paneId,
+	agent,
+	prompt,
+}: {
+	workspaceId: string;
+	paneId?: string;
+	agent: (typeof STARTABLE_AGENT_TYPES)[number];
+	prompt: string;
+}): AgentLaunchRequest {
+	if (agent === "superset-chat") {
+		return {
+			kind: "chat",
+			workspaceId,
+			agentType: "superset-chat",
+			source: "mcp",
+			chat: {
+				...(paneId ? { paneId } : {}),
+				initialPrompt: prompt,
+				retryCount: 1,
+			},
+		};
+	}
+
+	return {
+		kind: "terminal",
+		workspaceId,
+		agentType: agent,
+		source: "mcp",
+		terminal: {
+			command: buildAgentPromptCommand({
+				prompt,
+				randomId: crypto.randomUUID(),
+				agent: agent as (typeof AGENT_TYPES)[number],
+			}),
+			...(paneId ? { paneId } : {}),
+		},
+	};
+}
+
 export function register(server: McpServer) {
 	server.registerTool(
 		"start_agent_session",
 		{
 			description:
-				"Start an autonomous AI session for a task in an existing workspace. Supports terminal agents and Superset Chat. When paneId is provided, launch behavior is scoped to the tab containing that pane.",
+				"Start an autonomous AI session in an existing workspace. Provide either a taskId to work on a tracked task, or a prompt for a direct task-free launch. Supports terminal agents and Superset Chat. When paneId is provided, launch behavior is scoped to the tab containing that pane.",
 			inputSchema: inputSchemaShape,
 		},
 		async (args, extra) => {
@@ -148,18 +200,39 @@ export function register(server: McpServer) {
 			const input = parsed.data;
 			const agent = input.agent ?? "claude";
 
-			const task = await fetchTask({
-				taskId: input.taskId,
-				organizationId: ctx.organizationId,
-			});
-			if (!task) return ERROR_TASK_NOT_FOUND;
+			let request: AgentLaunchRequest;
 
-			const request = buildLaunchRequest({
-				workspaceId: input.workspaceId,
-				paneId: input.paneId,
-				agent,
-				task,
-			});
+			if (input.taskId) {
+				const task = await fetchTask({
+					taskId: input.taskId,
+					organizationId: ctx.organizationId,
+				});
+				if (!task) return ERROR_TASK_NOT_FOUND;
+
+				request = buildTaskLaunchRequest({
+					workspaceId: input.workspaceId,
+					paneId: input.paneId,
+					agent,
+					task,
+				});
+			} else if (typeof input.prompt === "string") {
+				request = buildPromptLaunchRequest({
+					workspaceId: input.workspaceId,
+					paneId: input.paneId,
+					agent,
+					prompt: input.prompt,
+				});
+			} else {
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: "Error: Either taskId or prompt must be provided",
+						},
+					],
+					isError: true,
+				};
+			}
 
 			const params: Record<string, unknown> = {
 				workspaceId: input.workspaceId,
@@ -170,7 +243,7 @@ export function register(server: McpServer) {
 
 			if (request.kind === "terminal") {
 				params.command = request.terminal.command;
-				params.name = request.terminal.name;
+				if (request.terminal.name) params.name = request.terminal.name;
 			} else {
 				params.openChatPane = true;
 				params.chatLaunchConfig = {


### PR DESCRIPTION
## Description

Add optional `prompt` parameter to the `start_agent_session` MCP tool, making `taskId` optional when a prompt is provided. This enables task-free agent launches — useful when orchestrating agents from external tools (e.g. another Claude session dispatching work across repos) without needing to create Superset tasks first.

The `buildAgentPromptCommand` plumbing already exists in `agent-command.ts` and is used by the Slack agent and desktop new-workspace modal. This change wires it through the MCP tool's input schema.

**Changes:**
- `taskId` becomes optional; new `prompt` field added to input schema
- Zod `.refine()` ensures at least one of `taskId` or `prompt` is provided
- New `buildPromptLaunchRequest()` routes prompt-only launches to `buildAgentPromptCommand` directly
- Renamed `buildLaunchRequest` → `buildTaskLaunchRequest` for clarity
- Task-based launches are completely unchanged

## Related Issues

<!-- No existing issue — filing based on firsthand experience orchestrating multi-repo agent workflows via MCP -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

- `start_agent_session` with `taskId` only — unchanged behavior
- `start_agent_session` with `prompt` only — launches agent with prompt directly
- `start_agent_session` with both `taskId` and `prompt` — `taskId` takes precedence
- `start_agent_session` with neither — validation error: "Either taskId or prompt must be provided"
- Works for all agent types including `superset-chat`

## Screenshots (if applicable)

N/A — MCP tool, no UI changes.

## Additional Notes

The motivating use case: from a Claude session in repo A, create workspaces across repos B, C, D via `create_workspace`, then launch agents in each with a prompt describing the work. Currently this requires creating Superset tasks as an intermediary (which itself fails for non-Linear orgs — see #2389).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent sessions can be launched by task ID or by providing a direct prompt.
  * Added explicit support for prompt-based launches; terminal naming is applied only when a task provides a name.
  * Tool descriptions and messages clarified to show task-based vs. prompt-based launch options.
* **Bug Fixes**
  * Now returns a clear error if neither task ID nor prompt is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->