### PR TITLE
fix(mcp): seed default task statuses for non-Linear orgs

### DIFF
--- a/packages/mcp/src/tools/tasks/create-task/create-task.ts
+++ b/packages/mcp/src/tools/tasks/create-task/create-task.ts
@@ -1,9 +1,78 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { db, dbWs } from "@superset/db/client";
+import type { InsertTaskStatus } from "@superset/db/schema";
 import { taskStatuses, tasks } from "@superset/db/schema";
-import { and, eq, ilike, or } from "drizzle-orm";
+import { and, eq, ilike, or, sql } from "drizzle-orm";
 import { z } from "zod";
 import { getMcpContext } from "../../utils";
+
+const DEFAULT_STATUSES: Array<
+	Pick<InsertTaskStatus, "name" | "color" | "type" | "position">
+> = [
+	{ name: "Backlog", color: "#95a2b3", type: "backlog", position: 0 },
+	{ name: "Todo", color: "#e2e2e2", type: "todo", position: 1 },
+	{ name: "In Progress", color: "#f2c94c", type: "working", position: 2 },
+	{ name: "Done", color: "#0e9f6e", type: "completed", position: 3 },
+	{ name: "Canceled", color: "#95a2b3", type: "canceled", position: 4 },
+];
+
+async function ensureDefaultStatuses(
+	organizationId: string,
+): Promise<string> {
+	return dbWs.transaction(async (tx) => {
+		// Serialize per-org to prevent concurrent first-run races from
+		// inserting duplicate default statuses.
+		await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${organizationId}))`);
+
+		// Check for ANY existing statuses, not just backlog — avoid inserting
+		// defaults when the org already has statuses from another source.
+		const [existing] = await tx
+			.select({ id: taskStatuses.id, type: taskStatuses.type })
+			.from(taskStatuses)
+			.where(eq(taskStatuses.organizationId, organizationId))
+			.orderBy(taskStatuses.position)
+			.limit(1);
+
+		if (existing) {
+			// Org has statuses — find the backlog one specifically.
+			if (existing.type === "backlog") return existing.id;
+
+			const [backlog] = await tx
+				.select({ id: taskStatuses.id })
+				.from(taskStatuses)
+				.where(
+					and(
+						eq(taskStatuses.organizationId, organizationId),
+						eq(taskStatuses.type, "backlog"),
+					),
+				)
+				.orderBy(taskStatuses.position)
+				.limit(1);
+
+			if (!backlog) {
+				throw new Error(
+					"Organization has task statuses but no backlog status",
+				);
+			}
+			return backlog.id;
+		}
+
+		// No statuses at all — seed defaults.
+		const rows = DEFAULT_STATUSES.map((s) => ({
+			...s,
+			organizationId,
+		}));
+
+		const created = await tx
+			.insert(taskStatuses)
+			.values(rows)
+			.returning({ id: taskStatuses.id, type: taskStatuses.type });
+
+		const backlog = created.find((s) => s.type === "backlog");
+		if (!backlog) throw new Error("Failed to seed default task statuses");
+		return backlog.id;
+	});
+}
 
 const PRIORITIES = ["urgent", "high", "medium", "low", "none"] as const;
 type TaskPriority = (typeof PRIORITIES)[number];
@@ -89,25 +158,7 @@ export function register(server: McpServer) {
 			const needsDefaultStatus = taskInputs.some((t) => !t.statusId);
 
 			if (needsDefaultStatus) {
-				const [defaultStatus] = await db
-					.select({ id: taskStatuses.id })
-					.from(taskStatuses)
-					.where(
-						and(
-							eq(taskStatuses.organizationId, ctx.organizationId),
-							eq(taskStatuses.type, "backlog"),
-						),
-					)
-					.orderBy(taskStatuses.position)
-					.limit(1);
-
-				defaultStatusId = defaultStatus?.id;
-				if (!defaultStatusId) {
-					return {
-						content: [{ type: "text", text: "Error: No default status found" }],
-						isError: true,
-					};
-				}
+				defaultStatusId = await ensureDefaultStatuses(ctx.organizationId);
 			}
 
 			const baseSlugs = taskInputs.map((t) => generateBaseSlug(t.title));


### PR DESCRIPTION
## Description

Replace the hard "No default status found" error in `create_task` with auto-seeding of default task statuses.

`task_statuses` is only populated by Linear sync (`syncWorkflowStates`). Organizations without Linear integration get an empty table, causing every `create_task` call to fail with "No default status found." There's no seeding on org creation and no MCP tool to create statuses manually.

**Changes:**
- Extract `ensureDefaultStatuses()` — looks up existing backlog status, seeds 5 defaults (Backlog, Todo, In Progress, Done, Canceled) if none exist
- Idempotent: existing statuses from Linear sync are untouched
- Uses `dbWs.transaction` for the insert, consistent with existing patterns

## Related Issues

<!-- No existing issue — discovered while orchestrating multi-repo agent workflows via MCP for a non-Linear org -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

- `create_task` on org with existing statuses (Linear-synced) — unchanged behavior
- `create_task` on org with no statuses — seeds defaults, creates task successfully
- Second `create_task` call — reuses seeded statuses, no duplicate inserts
- `list_task_statuses` after seeding — returns the 5 default statuses
- `create_task` with explicit `statusId` — no seeding triggered

## Screenshots (if applicable)

N/A — MCP tool, no UI changes.

## Additional Notes

This is a prerequisite for non-Linear orgs to use the task → agent session workflow. Also unblocks #2388 (prompt-driven launches) for users who want to use tasks but can't create them today.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved task-creation to reliably ensure default task statuses exist per organization.
  * Added concurrency-safe seeding with per-organization locking to prevent race conditions on first use.
  * Creation now consistently uses the seeded backlog status when available.
  * Preserves existing error behavior if a backlog status cannot be found or created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->