### PR TITLE
feat(desktop): persist activeOrganizationId to localStorage

### DIFF
--- a/apps/desktop/src/renderer/components/PostHogUserIdentifier/PostHogUserIdentifier.tsx
+++ b/apps/desktop/src/renderer/components/PostHogUserIdentifier/PostHogUserIdentifier.tsx
@@ -38,12 +38,14 @@ export function PostHogUserIdentifier() {
 	}, [user, session, setUserId]);
 
 	useEffect(() => {
+		if (session === undefined) return;
+
 		if (activeOrganizationId) {
 			localStorage.setItem(ACTIVE_ORG_ID_KEY, activeOrganizationId);
 		} else {
 			localStorage.removeItem(ACTIVE_ORG_ID_KEY);
 		}
-	}, [activeOrganizationId]);
+	}, [session, activeOrganizationId]);
 
 	return null;
 }


### PR DESCRIPTION
## Summary
- Writes `activeOrganizationId` to localStorage under key `active_organization_id` so Chime can read it from Electron's LevelDB for device inventory
- Value updates reactively on org switch and is removed on sign-out

## Storage location
Electron persists localStorage to LevelDB at:
```
~/Library/Application Support/Superset/Partitions/superset/Local Storage/leveldb/
```
Key: `active_organization_id`

## Test plan
- [ ] Sign in and verify `active_organization_id` appears in DevTools > Application > Local Storage
- [ ] Switch orgs and verify the value updates
- [ ] Sign out and verify the key is removed
- [ ] Confirm Chime can read the value from the LevelDB path above

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the active organization ID to `localStorage` as `active_organization_id` so Chime can read it from Electron’s LevelDB; it updates on org switch, is removed on sign‑out, and isn’t cleared until the session resolves.

<sup>Written for commit eb66246ce1537a54570e61658c175d1c08b4387e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Persist the active organization selection so it’s remembered across sessions.
  * Ensure organization selection is cleared on sign-out for cleaner session cleanup.
  * Improve state handling for a more consistent experience when switching between organizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->