### PR TITLE
fix(terminal): resolve Korean IME word navigation corruption on macOS

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -526,6 +526,8 @@ export function setupKeyboardHandler(
 	xterm: XTerm,
 	options: KeyboardHandlerOptions = {},
 ): () => void {
+	const deferredTimers = new Set<ReturnType<typeof setTimeout>>();
+
 	const platform =
 		typeof navigator !== "undefined" ? navigator.platform.toLowerCase() : "";
 	const isMac = platform.includes("mac");
@@ -614,7 +616,11 @@ export function setupKeyboardHandler(
 			if (event.type === "keydown" && options.onWrite) {
 				event.preventDefault();
 				// Always defer to let any pending IME _finalizeComposition complete (setTimeout(0) in xterm)
-				setTimeout(() => options.onWrite?.("\x1bb"), 50);
+				const timerId = setTimeout(() => {
+					deferredTimers.delete(timerId);
+					options.onWrite?.("\x1bb");
+				}, 50);
+				deferredTimers.add(timerId);
 			}
 			return false;
 		}
@@ -631,7 +637,11 @@ export function setupKeyboardHandler(
 		if (isOptionRight) {
 			if (event.type === "keydown" && options.onWrite) {
 				event.preventDefault();
-				setTimeout(() => options.onWrite?.("\x1bf"), 50);
+				const timerId = setTimeout(() => {
+					deferredTimers.delete(timerId);
+					options.onWrite?.("\x1bf");
+				}, 50);
+				deferredTimers.add(timerId);
 			}
 			return false;
 		}
@@ -699,6 +709,10 @@ export function setupKeyboardHandler(
 	xterm.attachCustomKeyEventHandler(handler);
 
 	return () => {
+		for (const timerId of deferredTimers) {
+			clearTimeout(timerId);
+		}
+		deferredTimers.clear();
 		xterm.attachCustomKeyEventHandler(() => true);
 	};
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/ime-fix.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/ime-fix.test.ts
@@ -1,36 +1,46 @@
 import { describe, expect, it, mock, beforeEach, afterEach } from "bun:test";
 import type { Terminal as XTerm } from "@xterm/xterm";
 
-// Mock browser globals
-globalThis.window = globalThis as any;
-globalThis.navigator = { 
-    platform: "MacIntel",
-    userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-    language: "en-US"
-} as any;
+// Capture originals before any overrides
+const originalWindow = globalThis.window;
+const originalNavigator = globalThis.navigator;
+const originalLocalStorage = globalThis.localStorage;
+
+// Mock browser globals (needed at module scope for dynamic import)
+globalThis.window = globalThis as unknown as Window & typeof globalThis;
+globalThis.navigator = {
+	platform: "MacIntel",
+	userAgent:
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+	language: "en-US",
+} as unknown as Navigator;
 
 // Mock localStorage
-const mockStorage = new Map();
+const mockStorage = new Map<string, string>();
 globalThis.localStorage = {
-    getItem: (key) => mockStorage.get(key) || null,
-    setItem: (key, val) => mockStorage.set(key, val),
-    removeItem: (key) => mockStorage.delete(key),
-    clear: () => mockStorage.clear(),
-} as any;
+	getItem: (key: string) => mockStorage.get(key) ?? null,
+	setItem: (key: string, val: string) => mockStorage.set(key, val),
+	removeItem: (key: string) => mockStorage.delete(key),
+	clear: () => mockStorage.clear(),
+	get length() {
+		return mockStorage.size;
+	},
+	key: (_index: number) => null,
+} as unknown as Storage;
 
 // Mock dependencies
 mock.module("renderer/lib/trpc-client", () => ({
-    electronTrpcClient: {
-        external: {
-            openUrl: { mutate: mock(() => Promise.resolve()) },
-            openFileInEditor: { mutate: mock(() => Promise.resolve()) },
-        },
-        uiState: {
-            hotkeys: {
-                get: { query: mock(() => Promise.resolve(null)) },
-            }
-        }
-    },
+	electronTrpcClient: {
+		external: {
+			openUrl: { mutate: mock(() => Promise.resolve()) },
+			openFileInEditor: { mutate: mock(() => Promise.resolve()) },
+		},
+		uiState: {
+			hotkeys: {
+				get: { query: mock(() => Promise.resolve(null)) },
+			},
+		},
+	},
 }));
 
 // Mock other imports that might fail in node/bun environment
@@ -46,121 +56,167 @@ mock.module("@xterm/addon-search", () => ({ SearchAddon: class {} }));
 const { setupKeyboardHandler } = await import("./helpers");
 
 describe("IME Fix - setupKeyboardHandler on macOS", () => {
-    const originalNavigator = globalThis.navigator;
+	beforeEach(() => {
+		globalThis.window = globalThis as unknown as Window & typeof globalThis;
+		globalThis.navigator = {
+			platform: "MacIntel",
+			userAgent:
+				"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+			language: "en-US",
+		} as unknown as Navigator;
+		mockStorage.clear();
+	});
 
-    beforeEach(() => {
-        // @ts-expect-error - mocking navigator for tests
-        globalThis.navigator = { 
-            platform: "MacIntel",
-            userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-            language: "en-US"
-        };
-    });
+	afterEach(() => {
+		globalThis.window = originalWindow;
+		globalThis.navigator = originalNavigator;
+		globalThis.localStorage = originalLocalStorage;
+	});
 
-    afterEach(() => {
-        globalThis.navigator = originalNavigator;
-    });
+	it("prevents default and defers onWrite for Option+Left", async () => {
+		const captured: { handler: ((event: KeyboardEvent) => boolean) | null } = {
+			handler: null,
+		};
+		const xterm = {
+			attachCustomKeyEventHandler: (
+				next: (event: KeyboardEvent) => boolean,
+			) => {
+				captured.handler = next;
+			},
+		};
 
-    it("prevents default and defers onWrite for Option+Left", async () => {
-        const captured: { handler: ((event: KeyboardEvent) => boolean) | null } = {
-            handler: null,
-        };
-        const xterm = {
-            attachCustomKeyEventHandler: (next: (event: KeyboardEvent) => boolean) => {
-                captured.handler = next;
-            },
-        };
+		const onWrite = mock(() => {});
+		setupKeyboardHandler(xterm as unknown as XTerm, { onWrite });
 
-        const onWrite = mock(() => {});
-        setupKeyboardHandler(xterm as unknown as XTerm, { onWrite });
+		const preventDefault = mock(() => {});
+		const event = {
+			type: "keydown",
+			key: "ArrowLeft",
+			altKey: true,
+			metaKey: false,
+			ctrlKey: false,
+			shiftKey: false,
+			preventDefault,
+		} as unknown as KeyboardEvent;
 
-        const preventDefault = mock(() => {});
-        const event = {
-            type: "keydown",
-            key: "ArrowLeft",
-            altKey: true,
-            metaKey: false,
-            ctrlKey: false,
-            shiftKey: false,
-            preventDefault,
-        } as unknown as KeyboardEvent;
+		const result = captured.handler?.(event);
 
-        const result = captured.handler?.(event);
+		expect(result).toBe(false);
+		expect(preventDefault).toHaveBeenCalled();
 
-        expect(result).toBe(false);
-        expect(preventDefault).toHaveBeenCalled();
-        
-        // Should not be called immediately
-        expect(onWrite).not.toHaveBeenCalled();
+		// Should not be called immediately
+		expect(onWrite).not.toHaveBeenCalled();
 
-        // Wait for deferral (50ms)
-        await new Promise(resolve => setTimeout(resolve, 100));
-        expect(onWrite).toHaveBeenCalledWith("b");
-    });
+		// Wait for deferral (50ms)
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(onWrite).toHaveBeenCalledWith("\x1bb");
+	});
 
-    it("prevents default and defers onWrite for Option+Right", async () => {
-        const captured: { handler: ((event: KeyboardEvent) => boolean) | null } = {
-            handler: null,
-        };
-        const xterm = {
-            attachCustomKeyEventHandler: (next: (event: KeyboardEvent) => boolean) => {
-                captured.handler = next;
-            },
-        };
+	it("prevents default and defers onWrite for Option+Right", async () => {
+		const captured: { handler: ((event: KeyboardEvent) => boolean) | null } = {
+			handler: null,
+		};
+		const xterm = {
+			attachCustomKeyEventHandler: (
+				next: (event: KeyboardEvent) => boolean,
+			) => {
+				captured.handler = next;
+			},
+		};
 
-        const onWrite = mock(() => {});
-        setupKeyboardHandler(xterm as unknown as XTerm, { onWrite });
+		const onWrite = mock(() => {});
+		setupKeyboardHandler(xterm as unknown as XTerm, { onWrite });
 
-        const preventDefault = mock(() => {});
-        const event = {
-            type: "keydown",
-            key: "ArrowRight",
-            altKey: true,
-            metaKey: false,
-            ctrlKey: false,
-            shiftKey: false,
-            preventDefault,
-        } as unknown as KeyboardEvent;
+		const preventDefault = mock(() => {});
+		const event = {
+			type: "keydown",
+			key: "ArrowRight",
+			altKey: true,
+			metaKey: false,
+			ctrlKey: false,
+			shiftKey: false,
+			preventDefault,
+		} as unknown as KeyboardEvent;
 
-        const result = captured.handler?.(event);
+		const result = captured.handler?.(event);
 
-        expect(result).toBe(false);
-        expect(preventDefault).toHaveBeenCalled();
-        
-        // Should not be called immediately
-        expect(onWrite).not.toHaveBeenCalled();
+		expect(result).toBe(false);
+		expect(preventDefault).toHaveBeenCalled();
 
-        // Wait for deferral (50ms)
-        await new Promise(resolve => setTimeout(resolve, 100));
-        expect(onWrite).toHaveBeenCalledWith("f");
-    });
+		// Should not be called immediately
+		expect(onWrite).not.toHaveBeenCalled();
 
-    it("blocks bare Alt keydown on macOS to prevent CompositionHelper corruption", () => {
-        const captured: { handler: ((event: KeyboardEvent) => boolean) | null } = {
-            handler: null,
-        };
-        const xterm = {
-            attachCustomKeyEventHandler: (next: (event: KeyboardEvent) => boolean) => {
-                captured.handler = next;
-            },
-        };
+		// Wait for deferral (50ms)
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(onWrite).toHaveBeenCalledWith("\x1bf");
+	});
 
-        const onWrite = mock(() => {});
-        setupKeyboardHandler(xterm as unknown as XTerm, { onWrite });
+	it("blocks bare Alt keydown on macOS to prevent CompositionHelper corruption", () => {
+		const captured: { handler: ((event: KeyboardEvent) => boolean) | null } = {
+			handler: null,
+		};
+		const xterm = {
+			attachCustomKeyEventHandler: (
+				next: (event: KeyboardEvent) => boolean,
+			) => {
+				captured.handler = next;
+			},
+		};
 
-        const event = {
-            type: "keydown",
-            key: "Alt",
-            altKey: true,
-            metaKey: false,
-            ctrlKey: false,
-            shiftKey: false,
-        } as unknown as KeyboardEvent;
+		const onWrite = mock(() => {});
+		setupKeyboardHandler(xterm as unknown as XTerm, { onWrite });
 
-        const result = captured.handler?.(event);
+		const event = {
+			type: "keydown",
+			key: "Alt",
+			altKey: true,
+			metaKey: false,
+			ctrlKey: false,
+			shiftKey: false,
+		} as unknown as KeyboardEvent;
 
-        // Should return false to block the event from reaching xterm's CompositionHelper
-        expect(result).toBe(false);
-        expect(onWrite).not.toHaveBeenCalled();
-    });
+		const result = captured.handler?.(event);
+
+		// Should return false to block the event from reaching xterm's CompositionHelper
+		expect(result).toBe(false);
+		expect(onWrite).not.toHaveBeenCalled();
+	});
+
+	it("cancels deferred writes on cleanup", async () => {
+		const captured: { handler: ((event: KeyboardEvent) => boolean) | null } = {
+			handler: null,
+		};
+		const xterm = {
+			attachCustomKeyEventHandler: (
+				next: (event: KeyboardEvent) => boolean,
+			) => {
+				captured.handler = next;
+			},
+		};
+
+		const onWrite = mock(() => {});
+		const cleanup = setupKeyboardHandler(xterm as unknown as XTerm, {
+			onWrite,
+		});
+
+		const preventDefault = mock(() => {});
+		const event = {
+			type: "keydown",
+			key: "ArrowLeft",
+			altKey: true,
+			metaKey: false,
+			ctrlKey: false,
+			shiftKey: false,
+			preventDefault,
+		} as unknown as KeyboardEvent;
+
+		captured.handler?.(event);
+
+		// Cleanup before the deferred write fires
+		cleanup();
+
+		// Wait past the deferral window
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(onWrite).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
This PR fixes the issue where Korean IME composition would break during word navigation (Option+Left/Right) on macOS.

### Changes:
- Blocked browser-native word jump by adding `event.preventDefault()` to Option+Left/Right.
- Blocked bare Alt keydown on macOS to prevent `CompositionHelper` pollution.
- Maintained a 50ms deferral for word navigation to ensure composition finalization.
- Added verification tests in `ime-fix.test.ts`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Korean IME composition corruption in the terminal on macOS during Option+Left/Right word navigation. Blocks native word jumps, defers terminal writes, and cancels pending writes on teardown; adds tests for behavior and cleanup.

- **Bug Fixes**
  - Block native word jumps on Option+Left/Right with event.preventDefault().
  - Defer word-move writes by 50ms to let IME finalize.
  - Block bare Alt keydown on macOS to avoid `CompositionHelper` textarea corruption.
  - Cancel pending deferred writes on teardown to prevent stale PTY input; extend `ime-fix.test.ts` to cover deferral, prevention, Alt block, and cleanup with isolated globals.

<sup>Written for commit e340e577a1c1ce4e73cc4cb86d84f6afdc177b80. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Terminal IME behavior on macOS: Alt/Option keypresses (including Option+Left/Right) are now handled to avoid interfering with ongoing composition, reducing accidental input or navigation during typing.

* **Tests**
  * Added tests validating IME keyboard handling, deferred key processing, and proper cleanup of pending actions on teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->