### PR TITLE
fix(desktop): can't get out of settings bug

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/SettingsSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/SettingsSidebar.tsx
@@ -1,5 +1,5 @@
 import { COMPANY } from "@superset/shared/constants";
-import { useNavigate, useRouter } from "@tanstack/react-router";
+import { Link } from "@tanstack/react-router";
 import {
 	HiArrowLeft,
 	HiArrowTopRightOnSquare,
@@ -15,32 +15,20 @@ import { GeneralSettings } from "./GeneralSettings";
 import { ProjectsSettings } from "./ProjectsSettings";
 
 export function SettingsSidebar() {
-	const navigate = useNavigate();
-	const router = useRouter();
 	const searchQuery = useSettingsSearchQuery();
 	const setSearchQuery = useSetSettingsSearchQuery();
 	const matchCounts = searchQuery ? getMatchCountBySection(searchQuery) : null;
 
-	const handleBack = () => {
-		if (router.history.canGoBack()) {
-			router.history.back();
-			return;
-		}
-
-		void navigate({ to: "/workspace" });
-	};
-
 	return (
 		<div className="w-56 flex flex-col p-3 overflow-hidden">
 			{/* Back button */}
-			<button
-				type="button"
-				onClick={handleBack}
+			<Link
+				to="/workspace"
 				className="flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors mb-4"
 			>
 				<HiArrowLeft className="h-4 w-4" />
 				<span>Back</span>
-			</button>
+			</Link>
 
 			{/* Settings title */}
 			<h1 className="text-lg font-semibold px-3 mb-4">Settings</h1>


### PR DESCRIPTION
## Summary
- The settings back button used `router.history.back()` which navigated through previously visited settings pages, keeping users stuck in settings
- Replaced with a direct `<Link to="/workspace">` so the back button always exits settings

## Test plan
- [x] Open settings, click through multiple settings pages (Account → Appearance → Keys)
- [x] Press the Back button — should navigate to workspace, not the previous settings page
- [x] Open settings directly (e.g. via deep link) and press Back — should navigate to workspace

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Settings back button so it always exits to the workspace instead of cycling through settings pages. Prevents getting stuck in Settings, including when opened via deep link.

- **Bug Fixes**
  - Replaced history-based back with a direct `Link` to "/workspace" using `@tanstack/react-router`.

<sup>Written for commit 20d251b2a6cf5ccd56a63336c50f8f91343856a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed back button behavior in settings sidebar to reliably navigate to the workspace view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->