### PR TITLE
refactor(desktop): simplify PR URL matching in workspace modal

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PullRequestsGroup/PullRequestsGroup.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PullRequestsGroup/PullRequestsGroup.tsx
@@ -85,8 +85,8 @@ export function PullRequestsGroup({
 			[...(pullRequests ?? [])].sort((a, b) => {
 				if (a.state === "open" && b.state !== "open") return -1;
 				if (a.state !== "open" && b.state === "open") return 1;
-				const aTime = a.updatedAt ? new Date(a.updatedAt).getTime() : 0;
-				const bTime = b.updatedAt ? new Date(b.updatedAt).getTime() : 0;
+				const aTime = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+				const bTime = b.createdAt ? new Date(b.createdAt).getTime() : 0;
 				return bTime - aTime;
 			}),
 		[pullRequests],


### PR DESCRIPTION
## Summary
- Reverts the custom URL regex parser and standalone URL CommandItem from #2282
- Adds exact URL match check before Fuse fuzzy search — pasting a PR URL still works naturally
- Shows all PRs (open, closed, merged) sorted with open first, instead of filtering to open only

## Test plan
- [ ] Paste a PR URL in the pull requests search — should match the PR exactly
- [ ] Search by title/author/number — fuzzy search still works
- [ ] Default view shows open PRs first, closed/merged after
- [ ] Selecting a matched PR still creates a workspace correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies PR selection in the New Workspace modal by removing the custom URL parser and adding an exact PR URL check before fuzzy search. Shows all PRs with open first, then sorts by createdAt for stable results.

- **Refactors**
  - Removed custom URL regex parser and standalone URL item.
  - Added exact PR URL match before `Fuse` search; pasting a PR URL selects it.
  - Query all PRs and sort open first, then by `createdAt` desc; cap visible list at 100.
  - Kept fuzzy search on title, author, and number.

<sup>Written for commit a0819376ec621f3084acdc20bf06e490fe576de4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified PR list: shows open PRs first, then sorted by creation date; when idle, up to 100 PRs are shown.
  * Search now runs over the full PR list and returns an exact match when the query exactly equals a PR URL.
  * Updated UI to display the new "visible PRs" list and adjusted icons/labels accordingly.

* **Bug Fixes / UX**
  * Removed the URL-based PR creation flow and its UI.
  * Simplified messaging and GitHub connect prompt for no-repo / no-PR states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->