### PR TITLE
fix(desktop): increase maxBuffer for git status to prevent buffer overflow in large repos

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
@@ -151,7 +151,7 @@ export async function getStatusNoLock(repoPath: string): Promise<StatusResult> {
 				"-z",
 				"-uall",
 			],
-			{ env, timeout: 30_000 },
+			{ env, timeout: 30_000, maxBuffer: 10 * 1024 * 1024 },
 		);
 
 		return parsePortelainStatus(stdout);


### PR DESCRIPTION
## Summary
- Set `maxBuffer: 10MB` on the `execFileAsync` call in `getStatusNoLock` to prevent `stdout maxBuffer length exceeded` errors in large repositories.

## Why / Context
Sentry event [#7320400476] reports `Failed to get git status: stdout maxBuffer length exceeded` in production. The `getStatusNoLock` function runs `git status --porcelain=v1 -z -uall` via Node's `execFileAsync` without specifying `maxBuffer`, so it defaults to ~1MB. The `-uall` flag expands untracked directories into individual file entries — a single large untracked folder (e.g., `node_modules` missing from `.gitignore`, build artifacts, datasets) can push the output well past 1MB. When that happens, Node kills the child process and the user's changes view silently fails to load, retrying and failing on every poll.

## How It Works
Node's `maxBuffer` is a ceiling, not a pre-allocation. The process only uses memory proportional to actual output size. Setting it to 10MB (consistent with `port-scanner.ts` and other `execFileAsync` calls in the desktop app) prevents the crash without meaningfully increasing memory usage for normal repos.

## Testing
- `bun run typecheck`

## Known Limitations
- If a repo genuinely produces >10MB of git status output, it will still fail. At that scale the changes UI wouldn't be useful anyway, but a future improvement could cap the number of files parsed or switch to a streaming approach.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents buffer overflow crashes in large repos by increasing the stdout limit for the git status call in the desktop app. Resolves the Sentry-reported “Failed to get git status” error and keeps the Changes view stable.

- **Bug Fixes**
  - Set `maxBuffer` to 10MB on `execFileAsync` in `getStatusNoLock` when running `git status --porcelain=v1 -z -uall`.

<sup>Written for commit 809a67454913f3dbfdf5991093115b67fd86fd29. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved handling of git status operations in larger repositories by increasing the buffer capacity for capturing git command outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->