### PR TITLE
feat(desktop): sort pull requests by most recently updated

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PullRequestsGroup/PullRequestsGroup.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PullRequestsGroup/PullRequestsGroup.tsx
@@ -96,7 +96,14 @@ export function PullRequestsGroup({
 	}, [allWorkspaces, projectId]);
 
 	const allOpenPrs = useMemo(
-		() => (pullRequests ?? []).filter((pr) => pr.state === "open"),
+		() =>
+			(pullRequests ?? [])
+				.filter((pr) => pr.state === "open")
+				.sort((a, b) => {
+					const aTime = a.updatedAt ? new Date(a.updatedAt).getTime() : 0;
+					const bTime = b.updatedAt ? new Date(b.updatedAt).getTime() : 0;
+					return bTime - aTime;
+				}),
 		[pullRequests],
 	);
 


### PR DESCRIPTION
## Summary
- Sort open pull requests in the NewWorkspaceModal by `updatedAt` descending so the most recently updated PRs appear first.

## Testing
- `bun run typecheck`
- Manual: open NewWorkspaceModal → Pull Requests tab → verify PRs are ordered by most recently updated

## Notes
- Matches the existing server-side sort order (`orderBy: [desc(githubPullRequests.updatedAt)]` in tRPC `listPullRequests`)
- Follows the same pattern as `IssuesGroup` which sorts tasks before display via `compareTasks`
- When a search query is active, Fuse.js relevance ranking takes precedence over recency

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sort open pull requests in the NewWorkspaceModal by most recently updated (`updatedAt` descending) so the latest activity shows first. This matches the server-side `listPullRequests` order and keeps search behavior unchanged (Fuse.js relevance still takes priority when a query is active).

<sup>Written for commit 9846c8a113aaa8963d906a71533ea4d0d2d8f5fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Open pull requests now display sorted by most recent activity first, making it easier to find recently updated requests in the workspace modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->