### PR TITLE
fix(linear): clean up Linear tasks and statuses on disconnect

### DIFF
--- a/apps/api/src/app/api/integrations/linear/jobs/initial-sync/route.ts
+++ b/apps/api/src/app/api/integrations/linear/jobs/initial-sync/route.ts
@@ -8,7 +8,7 @@ import {
 	users,
 } from "@superset/db/schema";
 import { Receiver } from "@upstash/qstash";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, isNull } from "drizzle-orm";
 import chunk from "lodash.chunk";
 import { z } from "zod";
 import { env } from "@/env";
@@ -81,14 +81,61 @@ async function performInitialSync(
 ) {
 	await syncWorkflowStates({ client, organizationId });
 
-	const statusByExternalId = new Map<string, string>();
-	const statuses = await db.query.taskStatuses.findMany({
-		where: and(
-			eq(taskStatuses.organizationId, organizationId),
-			eq(taskStatuses.externalProvider, "linear"),
-		),
+	// Remap existing local tasks from default statuses to Linear statuses
+	const allStatuses = await db.query.taskStatuses.findMany({
+		where: eq(taskStatuses.organizationId, organizationId),
 	});
-	for (const status of statuses) {
+
+	const linearStatusByType = new Map<string, string>();
+	const defaultStatusIds: string[] = [];
+
+	for (const status of allStatuses) {
+		if (status.externalProvider === "linear" && status.type) {
+			// Pick the first Linear status per type (lowest position)
+			if (!linearStatusByType.has(status.type)) {
+				linearStatusByType.set(status.type, status.id);
+			}
+		}
+		if (!status.externalProvider) {
+			defaultStatusIds.push(status.id);
+		}
+	}
+
+	// Remap tasks from default statuses to matching Linear statuses
+	if (defaultStatusIds.length > 0 && linearStatusByType.size > 0) {
+		for (const status of allStatuses) {
+			if (!status.externalProvider && status.type) {
+				const linearStatusId = linearStatusByType.get(status.type);
+				if (linearStatusId) {
+					await db
+						.update(tasks)
+						.set({ statusId: linearStatusId })
+						.where(
+							and(
+								eq(tasks.organizationId, organizationId),
+								eq(tasks.statusId, status.id),
+							),
+						);
+				}
+			}
+		}
+
+		// Delete now-unused default statuses
+		await db
+			.delete(taskStatuses)
+			.where(
+				and(
+					eq(taskStatuses.organizationId, organizationId),
+					isNull(taskStatuses.externalProvider),
+				),
+			);
+	}
+
+	const statusByExternalId = new Map<string, string>();
+	const linearStatuses = allStatuses.filter(
+		(s) => s.externalProvider === "linear",
+	);
+	for (const status of linearStatuses) {
 		if (status.externalId) {
 			statusByExternalId.set(status.externalId, status.id);
 		}

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -5,6 +5,7 @@ import { db } from "@superset/db/client";
 import { members, subscriptions } from "@superset/db/schema";
 import type { sessions } from "@superset/db/schema/auth";
 import * as authSchema from "@superset/db/schema/auth";
+import { seedDefaultStatuses } from "@superset/db/seed-default-statuses";
 import { MemberAddedEmail } from "@superset/email/emails/member-added";
 import { MemberAddedBillingEmail } from "@superset/email/emails/member-added-billing";
 import { MemberRemovedEmail } from "@superset/email/emails/member-removed";
@@ -295,6 +296,8 @@ export const auth = betterAuth({
 						.update(authSchema.organizations)
 						.set({ stripeCustomerId: customer.id })
 						.where(eq(authSchema.organizations.id, organization.id));
+
+					await seedDefaultStatuses(organization.id);
 				},
 
 				beforeDeleteOrganization: async ({ organization }) => {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -24,6 +24,10 @@
 			"types": "./src/schema/auth.ts",
 			"default": "./src/schema/auth.ts"
 		},
+		"./seed-default-statuses": {
+			"types": "./src/seed-default-statuses.ts",
+			"default": "./src/seed-default-statuses.ts"
+		},
 		"./utils": {
 			"types": "./src/utils/index.ts",
 			"default": "./src/utils/index.ts"

--- a/packages/db/src/seed-default-statuses.ts
+++ b/packages/db/src/seed-default-statuses.ts
@@ -1,0 +1,56 @@
+import { and, eq, isNull } from "drizzle-orm";
+import { dbWs } from "./client";
+import type { InsertTaskStatus } from "./schema";
+import { taskStatuses } from "./schema";
+
+type DbWsTransaction = Parameters<Parameters<typeof dbWs.transaction>[0]>[0];
+type Executor = typeof dbWs | DbWsTransaction;
+
+const DEFAULT_STATUSES: Array<
+	Pick<InsertTaskStatus, "name" | "color" | "type" | "position">
+> = [
+	{ name: "Backlog", color: "#95a2b3", type: "backlog", position: 0 },
+	{ name: "Todo", color: "#e2e2e2", type: "unstarted", position: 1 },
+	{ name: "In Progress", color: "#f2c94c", type: "started", position: 2 },
+	{ name: "Done", color: "#0e9f6e", type: "completed", position: 3 },
+	{ name: "Canceled", color: "#95a2b3", type: "canceled", position: 4 },
+];
+
+/**
+ * Seed default task statuses for an organization. Idempotent.
+ * Pass a transaction (`tx`) to run within an existing transaction,
+ * otherwise wraps in its own via `dbWs`.
+ */
+export async function seedDefaultStatuses(
+	organizationId: string,
+	executor: Executor = dbWs,
+): Promise<string> {
+	const [existing] = await executor
+		.select({ id: taskStatuses.id })
+		.from(taskStatuses)
+		.where(
+			and(
+				eq(taskStatuses.organizationId, organizationId),
+				eq(taskStatuses.type, "backlog"),
+				isNull(taskStatuses.externalProvider),
+			),
+		)
+		.orderBy(taskStatuses.position)
+		.limit(1);
+
+	if (existing) return existing.id;
+
+	const rows = DEFAULT_STATUSES.map((s) => ({
+		...s,
+		organizationId,
+	}));
+
+	const created = await executor
+		.insert(taskStatuses)
+		.values(rows)
+		.returning({ id: taskStatuses.id, type: taskStatuses.type });
+
+	const backlog = created.find((s) => s.type === "backlog");
+	if (!backlog) throw new Error("Failed to seed default task statuses");
+	return backlog.id;
+}

--- a/packages/mcp/src/tools/tasks/create-task/create-task.ts
+++ b/packages/mcp/src/tools/tasks/create-task/create-task.ts
@@ -1,52 +1,10 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { db, dbWs } from "@superset/db/client";
-import type { InsertTaskStatus } from "@superset/db/schema";
-import { taskStatuses, tasks } from "@superset/db/schema";
+import { tasks } from "@superset/db/schema";
+import { seedDefaultStatuses } from "@superset/db/seed-default-statuses";
 import { and, eq, ilike, or } from "drizzle-orm";
 import { z } from "zod";
 import { getMcpContext } from "../../utils";
-
-const DEFAULT_STATUSES: Array<
-	Pick<InsertTaskStatus, "name" | "color" | "type" | "position">
-> = [
-	{ name: "Backlog", color: "#95a2b3", type: "backlog", position: 0 },
-	{ name: "Todo", color: "#e2e2e2", type: "unstarted", position: 1 },
-	{ name: "In Progress", color: "#f2c94c", type: "started", position: 2 },
-	{ name: "Done", color: "#0e9f6e", type: "completed", position: 3 },
-	{ name: "Canceled", color: "#95a2b3", type: "canceled", position: 4 },
-];
-
-async function ensureDefaultStatuses(organizationId: string): Promise<string> {
-	const [existing] = await db
-		.select({ id: taskStatuses.id })
-		.from(taskStatuses)
-		.where(
-			and(
-				eq(taskStatuses.organizationId, organizationId),
-				eq(taskStatuses.type, "backlog"),
-			),
-		)
-		.orderBy(taskStatuses.position)
-		.limit(1);
-
-	if (existing) return existing.id;
-
-	const rows = DEFAULT_STATUSES.map((s) => ({
-		...s,
-		organizationId,
-	}));
-
-	const created = await dbWs.transaction(async (tx) => {
-		return tx
-			.insert(taskStatuses)
-			.values(rows)
-			.returning({ id: taskStatuses.id, type: taskStatuses.type });
-	});
-
-	const backlog = created.find((s) => s.type === "backlog");
-	if (!backlog) throw new Error("Failed to seed default task statuses");
-	return backlog.id;
-}
 
 const PRIORITIES = ["urgent", "high", "medium", "low", "none"] as const;
 type TaskPriority = (typeof PRIORITIES)[number];
@@ -132,7 +90,7 @@ export function register(server: McpServer) {
 			const needsDefaultStatus = taskInputs.some((t) => !t.statusId);
 
 			if (needsDefaultStatus) {
-				defaultStatusId = await ensureDefaultStatuses(ctx.organizationId);
+				defaultStatusId = await seedDefaultStatuses(ctx.organizationId);
 			}
 
 			const baseSlugs = taskInputs.map((t) => generateBaseSlug(t.title));

--- a/packages/trpc/src/router/integration/linear/linear.ts
+++ b/packages/trpc/src/router/integration/linear/linear.ts
@@ -1,10 +1,11 @@
-import { db } from "@superset/db/client";
+import { db, dbWs } from "@superset/db/client";
 import {
 	integrationConnections,
 	type LinearConfig,
 	taskStatuses,
 	tasks,
 } from "@superset/db/schema";
+import { seedDefaultStatuses } from "@superset/db/seed-default-statuses";
 import type { TRPCRouterRecord } from "@trpc/server";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
@@ -33,7 +34,8 @@ export const linearRouter = {
 		.mutation(async ({ ctx, input }) => {
 			await verifyOrgAdmin(ctx.session.user.id, input.organizationId);
 
-			const result = await db.transaction(async (tx) => {
+			const result = await dbWs.transaction(async (tx) => {
+				// 1. Delete Linear-synced tasks
 				await tx
 					.delete(tasks)
 					.where(
@@ -43,6 +45,44 @@ export const linearRouter = {
 						),
 					);
 
+				// 2. Seed default statuses inside the transaction
+				const backlogStatusId = await seedDefaultStatuses(
+					input.organizationId,
+					tx,
+				);
+
+				// 3. Remap remaining local tasks from Linear statuses to default statuses
+				const allStatuses = await tx.query.taskStatuses.findMany({
+					where: eq(taskStatuses.organizationId, input.organizationId),
+				});
+
+				const defaultStatusByType = new Map<string, string>();
+				for (const status of allStatuses) {
+					if (!status.externalProvider && status.type) {
+						if (!defaultStatusByType.has(status.type)) {
+							defaultStatusByType.set(status.type, status.id);
+						}
+					}
+				}
+
+				for (const status of allStatuses) {
+					if (status.externalProvider === "linear") {
+						const defaultStatusId =
+							(status.type && defaultStatusByType.get(status.type)) ||
+							backlogStatusId;
+						await tx
+							.update(tasks)
+							.set({ statusId: defaultStatusId })
+							.where(
+								and(
+									eq(tasks.organizationId, input.organizationId),
+									eq(tasks.statusId, status.id),
+								),
+							);
+					}
+				}
+
+				// 4. Delete Linear task statuses
 				await tx
 					.delete(taskStatuses)
 					.where(
@@ -52,6 +92,7 @@ export const linearRouter = {
 						),
 					);
 
+				// 5. Delete the integration connection
 				return tx
 					.delete(integrationConnections)
 					.where(

--- a/packages/trpc/src/router/organization/organization.ts
+++ b/packages/trpc/src/router/organization/organization.ts
@@ -5,6 +5,7 @@ import {
 	sessions as authSessions,
 	invitations,
 } from "@superset/db/schema/auth";
+import { seedDefaultStatuses } from "@superset/db/seed-default-statuses";
 import { findOrgMembership } from "@superset/db/utils";
 import { canRemoveMember, type OrganizationRole } from "@superset/shared/auth";
 import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
@@ -134,6 +135,8 @@ export const organizationRouter = {
 					userId: ctx.session.user.id,
 					role: "owner",
 				});
+
+				await seedDefaultStatuses(organization.id);
 			}
 
 			return organization;


### PR DESCRIPTION
## Summary
- Deletes Linear-synced tasks and task statuses when disconnecting the integration, preventing duplicates when reconnecting to a different Linear org
- Wraps deletes in a transaction (tasks → statuses → connection) to respect FK constraints and ensure atomicity
- Includes lint autofix for formatting in `create-task.ts`

## Test plan
- [ ] Disconnect Linear integration, verify tasks and task statuses with `externalProvider = 'linear'` are removed
- [ ] Reconnect to Linear, verify initial sync creates fresh data without duplicates

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up Linear data on disconnect and remaps tasks between default and Linear statuses on connect/disconnect to prevent duplicates while preserving task state. Also seeds default task statuses automatically on org creation and first task creation to avoid “No default status found” errors.

- **Bug Fixes**
  - Disconnect: delete Linear `tasks`/`task_statuses`, seed defaults in a `dbWs` transaction, remap remaining tasks back by type (fallback to Backlog), then remove the `integrationConnections` row.
  - Connect (initial sync): remap local tasks from default → matching Linear statuses by type, then delete default (non-external) statuses before syncing.
  - Default statuses: extracted `seedDefaultStatuses` in `@superset/db`; run on org creation (`auth` + `trpc`) and in `create-task`; idempotent and ignores external-provider rows.

<sup>Written for commit 489070cd6eaf9726386864b53d8751bb37dd1c26. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organizations now get default task statuses automatically when created.

* **Bug Fixes**
  * Improved integration disconnect to fully clean up linked tasks and statuses.

* **Refactor**
  * Centralized default-status handling and improved status remapping during initial syncs for more consistent task status behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->