### PR TITLE
fix(desktop): settings back button navigates to origin route

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -4,9 +4,10 @@ import {
 	createFileRoute,
 	Navigate,
 	Outlet,
+	useLocation,
 	useNavigate,
 } from "@tanstack/react-router";
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import { DndProvider } from "react-dnd";
 import { HiOutlineWifi } from "react-icons/hi2";
 import { NewWorkspaceModal } from "renderer/components/NewWorkspaceModal";
@@ -21,6 +22,7 @@ import { showWorkspaceAutoNameWarningToast } from "renderer/lib/workspaces/showW
 import { InitGitDialog } from "renderer/react-query/projects/InitGitDialog";
 import { WorkspaceInitEffects } from "renderer/screens/main/components/WorkspaceInitEffects";
 import { useHotkeysSync } from "renderer/stores/hotkeys";
+import { useSettingsStore } from "renderer/stores/settings-state";
 import { useAgentHookListener } from "renderer/stores/tabs/useAgentHookListener";
 import { useWorkspaceInitStore } from "renderer/stores/workspace-init";
 import { MOCK_ORG_ID } from "shared/constants";
@@ -43,6 +45,8 @@ function AuthenticatedLayout() {
 	const hasLocalToken = !!getAuthToken();
 	const isOnline = useOnlineStatus();
 	const navigate = useNavigate();
+	const location = useLocation();
+	const setOriginRoute = useSettingsStore((s) => s.setOriginRoute);
 	const utils = electronTrpc.useUtils();
 	const shownWorkspaceInitWarningsRef = useRef(new Set<string>());
 
@@ -54,6 +58,12 @@ function AuthenticatedLayout() {
 	useAgentHookListener();
 	useUpdateListener();
 	useHotkeysSync();
+
+	useEffect(() => {
+		if (!location.pathname.startsWith("/settings")) {
+			setOriginRoute(location.pathname);
+		}
+	}, [location.pathname, setOriginRoute]);
 
 	// Workspace initialization progress subscription
 	const updateInitProgress = useWorkspaceInitStore((s) => s.updateProgress);

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/SettingsSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/SettingsSidebar.tsx
@@ -8,6 +8,7 @@ import {
 } from "react-icons/hi2";
 import {
 	useSetSettingsSearchQuery,
+	useSettingsOriginRoute,
 	useSettingsSearchQuery,
 } from "renderer/stores/settings-state";
 import { getMatchCountBySection } from "../../utils/settings-search";
@@ -17,13 +18,14 @@ import { ProjectsSettings } from "./ProjectsSettings";
 export function SettingsSidebar() {
 	const searchQuery = useSettingsSearchQuery();
 	const setSearchQuery = useSetSettingsSearchQuery();
+	const originRoute = useSettingsOriginRoute();
 	const matchCounts = searchQuery ? getMatchCountBySection(searchQuery) : null;
 
 	return (
 		<div className="w-56 flex flex-col p-3 overflow-hidden">
 			{/* Back button */}
 			<Link
-				to="/workspace"
+				to={originRoute}
 				className="flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors mb-4"
 			>
 				<HiArrowLeft className="h-4 w-4" />

--- a/apps/desktop/src/renderer/stores/settings-state.ts
+++ b/apps/desktop/src/renderer/stores/settings-state.ts
@@ -23,12 +23,14 @@ interface SettingsState {
 	activeProjectId: string | null;
 	searchQuery: string;
 	isOpen: boolean;
+	originRoute: string;
 
 	setActiveSection: (section: SettingsSection) => void;
 	setActiveProject: (projectId: string | null) => void;
 	setSearchQuery: (query: string) => void;
 	openSettings: (section?: SettingsSection) => void;
 	closeSettings: () => void;
+	setOriginRoute: (route: string) => void;
 }
 
 export const useSettingsStore = create<SettingsState>()(
@@ -38,6 +40,7 @@ export const useSettingsStore = create<SettingsState>()(
 			activeProjectId: null,
 			searchQuery: "",
 			isOpen: false,
+			originRoute: "/workspace",
 
 			setActiveSection: (section) => set({ activeSection: section }),
 
@@ -60,6 +63,8 @@ export const useSettingsStore = create<SettingsState>()(
 					isOpen: false,
 					searchQuery: "",
 				}),
+
+			setOriginRoute: (route) => set({ originRoute: route }),
 		}),
 		{ name: "SettingsStore" },
 	),
@@ -77,3 +82,5 @@ export const useActiveProjectId = () =>
 	useSettingsStore((state) => state.activeProjectId);
 export const useCloseSettings = () =>
 	useSettingsStore((state) => state.closeSettings);
+export const useSettingsOriginRoute = () =>
+	useSettingsStore((state) => state.originRoute);


### PR DESCRIPTION
## Summary
- The settings sidebar back button was hardcoded to `/workspace`, so it always went to the last-viewed workspace regardless of where the user entered settings from
- Added `originRoute` tracking to the settings Zustand store — the `_authenticated` layout watches `location.pathname` and records the last non-settings route
- The back button now uses this stored route, correctly returning to `/tasks`, `/workspaces`, `/project/...`, or wherever the user came from (defaults to `/workspace` for deep links)

## Test plan
- [ ] Navigate to settings from different routes (workspace, tasks, workspaces list, project page) and verify the back button returns to each correctly
- [ ] Navigate between settings sub-pages (account → appearance → models) and verify the back button still returns to the original pre-settings route
- [ ] Deep link to settings and verify fallback to `/workspace`
- [ ] Use the global hotkey and menu to open settings and verify back works

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the settings back button so it returns to the page the user came from. We now track the last non-settings path and use it as the back target, with a fallback to `/workspace` for deep links.

- **Bug Fixes**
  - Added `originRoute` to the settings store and update it from the authenticated layout when outside `/settings`.
  - Back button uses the stored route instead of a hardcoded `/workspace`, preserving the original page after navigating within settings.

<sup>Written for commit c036d218cfe95776f8fe4a69c1cbb961e43a431f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Settings navigation: The back button now returns you to the page you were viewing before entering Settings, instead of always redirecting to the workspace view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->