### PR TITLE
fix(desktop): handle missing worktree paths in filesystem watcher

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/filesystem/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/filesystem/index.ts
@@ -1,3 +1,4 @@
+import { toErrorMessage } from "@superset/workspace-fs/host";
 import { observable } from "@trpc/server/observable";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
@@ -11,18 +12,6 @@ function isClosedStreamError(error: unknown): boolean {
 	);
 }
 
-function getErrorMessage(error: unknown): string {
-	if (error instanceof Error) {
-		return error.message;
-	}
-
-	if (typeof error === "object" && error !== null && "message" in error) {
-		return String((error as { message: unknown }).message);
-	}
-
-	return String(error);
-}
-
 const writeFileContentSchema = z.union([
 	z.string(),
 	z.object({
@@ -30,6 +19,14 @@ const writeFileContentSchema = z.union([
 		data: z.string(),
 	}),
 ]);
+
+type WatchPathEventBatch = {
+	events: Array<{
+		kind: string;
+		absolutePath: string;
+		oldAbsolutePath?: string;
+	}>;
+};
 
 export const createFilesystemRouter = () => {
 	return router({
@@ -253,13 +250,7 @@ export const createFilesystemRouter = () => {
 				}),
 			)
 			.subscription(({ input }) => {
-				return observable<{
-					events: Array<{
-						kind: string;
-						absolutePath: string;
-						oldAbsolutePath?: string;
-					}>;
-				}>((emit) => {
+				return observable<WatchPathEventBatch>((emit) => {
 					const service = getServiceForWorkspace(input.workspaceId);
 					let isDisposed = false;
 					const stream = service.watchPath({
@@ -278,13 +269,7 @@ export const createFilesystemRouter = () => {
 						});
 					};
 
-					const emitIfOpen = (value: {
-						events: Array<{
-							kind: string;
-							absolutePath: string;
-							oldAbsolutePath?: string;
-						}>;
-					}): boolean => {
+					const emitIfOpen = (value: WatchPathEventBatch): boolean => {
 						try {
 							emit.next(value);
 							return true;
@@ -313,7 +298,7 @@ export const createFilesystemRouter = () => {
 						} catch (error) {
 							console.error("[filesystem/watchPath] Failed:", {
 								workspaceId: input.workspaceId,
-								error: getErrorMessage(error),
+								error: toErrorMessage(error),
 							});
 
 							if (

--- a/bun.lock
+++ b/bun.lock
@@ -110,7 +110,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.1.7",
+      "version": "1.2.1",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.43",
         "@ai-sdk/openai": "3.0.36",

--- a/packages/workspace-fs/src/error-message.ts
+++ b/packages/workspace-fs/src/error-message.ts
@@ -1,0 +1,11 @@
+export function toErrorMessage(error: unknown): string {
+	if (error instanceof Error) {
+		return error.message;
+	}
+
+	if (typeof error === "object" && error !== null && "message" in error) {
+		return String((error as { message: unknown }).message);
+	}
+
+	return String(error);
+}

--- a/packages/workspace-fs/src/host/index.ts
+++ b/packages/workspace-fs/src/host/index.ts
@@ -1,3 +1,4 @@
+export * from "../error-message";
 export * from "../fs";
 export * from "../paths";
 export * from "../search";

--- a/packages/workspace-fs/src/watch.ts
+++ b/packages/workspace-fs/src/watch.ts
@@ -5,6 +5,7 @@ import {
 	type Event as ParcelWatcherEvent,
 	subscribe as subscribeToFilesystem,
 } from "@parcel/watcher";
+import { toErrorMessage } from "./error-message";
 import { normalizeAbsolutePath } from "./paths";
 import {
 	DEFAULT_IGNORE_PATTERNS,
@@ -35,18 +36,6 @@ interface WatcherState {
 	pathTypes: Map<string, boolean>;
 	pendingEvents: ParcelWatcherEvent[];
 	flushTimer: ReturnType<typeof setTimeout> | null;
-}
-
-function getErrorMessage(error: unknown): string {
-	if (error instanceof Error) {
-		return error.message;
-	}
-
-	if (typeof error === "object" && error !== null && "message" in error) {
-		return String((error as { message: unknown }).message);
-	}
-
-	return String(error);
 }
 
 function coalesceWatchEvent(
@@ -410,7 +399,7 @@ export class FsWatcherManager {
 				if (error) {
 					console.error("[workspace-fs/watch] Watcher error:", {
 						absolutePath: state.absolutePath,
-						error: getErrorMessage(error),
+						error: toErrorMessage(error),
 					});
 					this.emit(state, {
 						events: [{ kind: "overflow", absolutePath: state.absolutePath }],


### PR DESCRIPTION
## Description

Fixes the desktop app crashing on Linux when a workspace's worktree path doesn't exist. The filesystem watcher (`@parcel/watcher`) throws a native "Bad file descriptor" error that isn't handled gracefully, causing the app to become unstable and eventually force-quit.

Closes #2430

## Related Issues

- #2430 — Desktop app crashes on Linux — filesystem watcher fails on non-existent worktree path
- #405 — Linux support (tracking issue)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

### 1. Path validation before watcher subscribe (`packages/workspace-fs/src/watch.ts`)
- Added `stat()` check in `createWatcher()` before calling `@parcel/watcher`'s `subscribe()`
- Validates the path exists **and** is a directory via `stats.isDirectory()`
- Only catches `ENOENT`/`ENOTDIR` — rethrows permission and I/O errors so they aren't masked
- Throws a descriptive error (`Cannot watch workspace: path does not exist`) instead of the cryptic native `EBADF`

### 2. Native error serialization (`packages/workspace-fs/src/watch.ts`)
- Watcher callback error handler now extracts `.message` from errors instead of logging the raw object
- Native `@parcel/watcher` errors serialize as `{}` via `JSON.stringify()` — this fix produces useful log output

### 3. Subscription error handling (`apps/desktop/src/lib/trpc/routers/filesystem/index.ts`)
- Improved error extraction in the `subscribe` catch block — handles `Error` instances, objects with `.message`, and fallback to `String()`
- Previously logged `[filesystem/subscribe] Failed: [object Object]`, now logs the actual error message
- Calls `runCleanup()` after emitting overflow on failure to release the dead producer

## Testing

Reproduced by watching a non-existent path with `@parcel/watcher`:
```ts
await subscribe("/nonexistent/path", callback);
// Before fix: throws "Bad file descriptor", logged as {}
// After fix: throws "Cannot watch workspace: path does not exist"
```

Verified watcher still works correctly on valid paths (both main repo and worktree directories).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and normalization in the file-watching system for clearer messages.
  * Added pre-flight validation to ensure watched paths exist and are directories, with descriptive errors.
  * Safer event emission to avoid sending to closed streams and ensure proper cleanup on termination or failures.
  * Emits an overflow event when appropriate so consumers can handle overflow before cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->