### PR TITLE
fix(codex): add missing type to posthog MCP server config

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -24,6 +24,7 @@ type = "sse"
 url = "https://mcp.sentry.dev/mcp"
 
 [mcp_servers.posthog]
+type = "sse"
 url = "https://mcp.posthog.com/mcp"
 
 [mcp_servers.desktop-automation]


### PR DESCRIPTION
## Summary
- Add missing `type = "sse"` to the `posthog` MCP server entry in `.codex/config.toml`

## Why / Context
Codex was failing to start with:
```
Error loading config.toml: url is not supported for stdio
in `mcp_servers.posthog`
```
The `posthog` entry had a `url` field but no `type = "sse"`, so Codex defaulted to `stdio` transport which doesn't support URLs. Every other SSE-based MCP server in the file already had `type = "sse"` set.

## Testing
- Verified Codex launches without the config error after the fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Codex startup by adding `type = "sse"` to the `posthog` MCP server in `.codex/config.toml`, so it uses SSE instead of defaulting to `stdio`.

- **Bug Fixes**
  - Prevents "url is not supported for stdio" and allows Codex to launch successfully.

<sup>Written for commit 76e7fc507d89daf713196675246c61a7693fe8ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration settings for improved server communication handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->