### PR TITLE
feat(desktop): add pin/unpin toggle to terminal presets settings table

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetRow/PresetRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetRow/PresetRow.tsx
@@ -2,7 +2,7 @@ import { normalizeExecutionMode } from "@superset/local-db";
 import { Badge } from "@superset/ui/badge";
 import { useEffect, useRef } from "react";
 import { useDrag, useDrop } from "react-dnd";
-import { LuGripVertical } from "react-icons/lu";
+import { LuGripVertical, LuPin } from "react-icons/lu";
 import type { TerminalPreset } from "renderer/routes/_authenticated/settings/presets/types";
 
 const PRESET_TYPE = "TERMINAL_PRESET";
@@ -14,6 +14,7 @@ interface PresetRowProps {
 	onEdit: (presetId: string) => void;
 	onLocalReorder: (fromIndex: number, toIndex: number) => void;
 	onPersistReorder: (presetId: string, targetIndex: number) => void;
+	onTogglePin: (presetId: string, pinned: boolean) => void;
 }
 
 export function PresetRow({
@@ -23,8 +24,9 @@ export function PresetRow({
 	onEdit,
 	onLocalReorder,
 	onPersistReorder,
+	onTogglePin,
 }: PresetRowProps) {
-	const rowRef = useRef<HTMLButtonElement>(null);
+	const rowRef = useRef<HTMLDivElement>(null);
 	const dragHandleRef = useRef<HTMLDivElement>(null);
 
 	const [{ isDragging }, drag, preview] = useDrag(
@@ -82,10 +84,19 @@ export function PresetRow({
 	const commandsToShow = preset.commands.length > 0 ? preset.commands : [""];
 
 	return (
-		<button
-			type="button"
+		// biome-ignore lint/a11y/useSemanticElements: div needed to avoid invalid nested <button> elements
+		<div
+			role="button"
+			tabIndex={0}
 			ref={rowRef}
 			onClick={() => onEdit(preset.id)}
+			onKeyDown={(e) => {
+				if (e.target !== e.currentTarget) return;
+				if (e.key === "Enter" || e.key === " ") {
+					e.preventDefault();
+					onEdit(preset.id);
+				}
+			}}
 			className={`w-full flex items-start gap-4 py-3 px-4 text-left cursor-pointer hover:bg-accent/30 transition-colors ${
 				isEven ? "bg-accent/20" : ""
 			} ${isDragging ? "opacity-30" : ""}`}
@@ -135,6 +146,31 @@ export function PresetRow({
 					</Badge>
 				) : null}
 			</div>
-		</button>
+
+			<div className="w-16 shrink-0 flex items-center justify-center">
+				<button
+					type="button"
+					className="p-1 rounded hover:bg-accent/50 transition-colors"
+					onClick={(e) => {
+						e.stopPropagation();
+						const isPinned = preset.pinnedToBar !== false;
+						onTogglePin(preset.id, !isPinned);
+					}}
+					title={preset.pinnedToBar !== false ? "Unpin from bar" : "Pin to bar"}
+					aria-label={
+						preset.pinnedToBar !== false ? "Unpin from bar" : "Pin to bar"
+					}
+					aria-pressed={preset.pinnedToBar !== false}
+				>
+					<LuPin
+						className={`size-3.5 ${
+							preset.pinnedToBar !== false
+								? "text-foreground"
+								: "text-muted-foreground/40"
+						}`}
+					/>
+				</button>
+			</div>
+		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/PresetsSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/PresetsSection.tsx
@@ -269,6 +269,16 @@ export function PresetsSection({
 		[setPresetAutoApply],
 	);
 
+	const handleTogglePin = useCallback(
+		(presetId: string, pinned: boolean) => {
+			updatePreset.mutate({
+				id: presetId,
+				patch: { pinnedToBar: pinned },
+			});
+		},
+		[updatePreset],
+	);
+
 	const handleLocalReorder = useCallback(
 		(fromIndex: number, toIndex: number) => {
 			setLocalPresets((prev) => {
@@ -401,6 +411,7 @@ export function PresetsSection({
 						onEdit={setEditingPreset}
 						onLocalReorder={handleLocalReorder}
 						onPersistReorder={handlePersistReorder}
+						onTogglePin={handleTogglePin}
 					/>
 					<p className="text-xs text-muted-foreground">
 						Click a preset row to edit details.

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/components/PresetsTable/PresetsTable.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/components/PresetsTable/PresetsTable.tsx
@@ -9,6 +9,7 @@ interface PresetsTableProps {
 	onEdit: (presetId: string) => void;
 	onLocalReorder: (fromIndex: number, toIndex: number) => void;
 	onPersistReorder: (presetId: string, targetIndex: number) => void;
+	onTogglePin: (presetId: string, pinned: boolean) => void;
 }
 
 export function PresetsTable({
@@ -18,6 +19,7 @@ export function PresetsTable({
 	onEdit,
 	onLocalReorder,
 	onPersistReorder,
+	onTogglePin,
 }: PresetsTableProps) {
 	return (
 		<div className="rounded-lg border border-border overflow-hidden">
@@ -27,6 +29,7 @@ export function PresetsTable({
 				<div className="flex-[1.2] min-w-0">Commands</div>
 				<div className="w-32 shrink-0">Mode</div>
 				<div className="w-36 shrink-0">Auto-run</div>
+				<div className="w-16 shrink-0 text-center">Pinned</div>
 			</div>
 
 			<div
@@ -47,6 +50,7 @@ export function PresetsTable({
 							onEdit={onEdit}
 							onLocalReorder={onLocalReorder}
 							onPersistReorder={onPersistReorder}
+							onTogglePin={onTogglePin}
 						/>
 					))
 				) : (


### PR DESCRIPTION
Allow pinning/unpinning presets to the bar directly from the Settings Terminal page, matching the existing pin behavior in the PresetsBar dropdown.

## Description

  - Add a "Pinned" column to the Terminal Presets table in Settings
  - Each row shows a pin icon that toggles pinnedToBar via the existing updatePreset mutation
  - Matches the pin/unpin behavior already available in the PresetsBar dropdown

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

  - Open Settings → Terminal
  - Verify "Pinned" column header appears in the presets table
  - Click the pin icon on a preset — verify it toggles between pinned (solid) and unpinned (faded)
  - Verify clicking the pin icon doesn't open the preset editor (stopPropagation)
  - Verify pinned/unpinned state persists after navigating away and back
  - Verify the PresetsBar reflects the change (unpinned presets disappear from the bar)

## Screenshots

| Before | After |
| ------- | ----- |
| <img width="999" height="325" alt="Screenshot 2026-03-12 at 4 03 05 PM" src="https://github.com/user-attachments/assets/0c0880b1-2f51-4572-8696-7152de70322e" /> | <img width="999" height="325" alt="Screenshot 2026-03-12 at 4 03 36 PM" src="https://github.com/user-attachments/assets/b8548970-1147-4488-aa6a-dff8a200e06e" /> |

## Additional Notes

Briefly discussed this idea with @AviPeltz today.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a pin/unpin toggle to the Terminal Presets table so you can manage bar pins directly from Settings. Matches the PresetsBar dropdown and updates instantly.

- **New Features**
  - Added “Pinned” column with a pin button on each row.
  - Clicking the pin toggles `pinnedToBar` via the existing `updatePreset` mutation and does not open the editor.
  - State persists and the PresetsBar reflects updates immediately.
  - Accessibility: row is keyboard-activatable (Enter/Space), and the pin button includes `aria-label` and `aria-pressed`.

<sup>Written for commit 6249f035023ace00324d6e9bb03a97951ed70b8e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal preset pinning: a pin button and new "Pinned" column let users toggle presets to prioritize favorites in the presets table.

* **Accessibility**
  * Preset rows are keyboard-accessible (Enter/Space) for editing; pin controls include dynamic labels, ARIA-friendly titles, focusable behavior, and do not interfere with row interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->