### PR TITLE
fix(linear): revoke OAuth token on disconnect

### DIFF
--- a/packages/trpc/src/router/integration/linear/linear.ts
+++ b/packages/trpc/src/router/integration/linear/linear.ts
@@ -34,6 +34,13 @@ export const linearRouter = {
 		.mutation(async ({ ctx, input }) => {
 			await verifyOrgAdmin(ctx.session.user.id, input.organizationId);
 
+			const client = await getLinearClient(input.organizationId);
+			if (client) {
+				try {
+					await client.logout();
+				} catch {}
+			}
+
 			const result = await dbWs.transaction(async (tx) => {
 				// 1. Delete Linear-synced tasks
 				await tx


### PR DESCRIPTION
## Summary
- When disconnecting Linear, we now call `client.logout()` via the Linear SDK to revoke the OAuth token on Linear's side before cleaning up locally
- Previously, disconnecting only deleted our local data but left the OAuth app installed in the user's Linear workspace

## Test plan
- [ ] Connect Linear integration
- [ ] Disconnect Linear integration
- [ ] Verify Superset no longer appears as an authorized app in Linear settings
- [ ] Verify local cleanup (tasks, statuses, connection) still works correctly
- [ ] Verify disconnect still succeeds if the token is already expired/invalid

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disconnecting Linear now revokes the OAuth token via `client.logout()` before local cleanup, removing our app from Linear’s authorized apps. Fixes the issue where disconnecting left the app installed in Linear.

- **Bug Fixes**
  - Call `client.logout()` (if available) to revoke the token on Linear before DB cleanup.
  - Keep local cleanup intact; disconnect succeeds even if the token is expired or missing.

<sup>Written for commit e0f43bafc99d49c83a931d86f508597578af1201. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linear integration disconnect to properly logout the client before cleanup, ensuring more thorough removal of the integration connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->