### PR TITLE
fix(desktop): skip empty branch names in project settings

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/projects/projects.ts
+++ b/apps/desktop/src/lib/trpc/routers/projects/projects.ts
@@ -374,6 +374,7 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 							for (const line of remoteBranchInfo.trim().split("\n")) {
 								if (!line) continue;
 								const lastSpaceIdx = line.lastIndexOf(" ");
+								if (lastSpaceIdx <= 0) continue;
 								let branch = line.substring(0, lastSpaceIdx);
 								const timestamp = Number.parseInt(
 									line.substring(lastSpaceIdx + 1),
@@ -384,7 +385,7 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 									branch = branch.replace("origin/", "");
 								}
 
-								if (branch === "HEAD") continue;
+								if (!branch || branch === "HEAD") continue;
 
 								branchMap.set(branch, {
 									lastCommitDate: timestamp * 1000,
@@ -414,13 +415,14 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 						for (const line of localBranchInfo.trim().split("\n")) {
 							if (!line) continue;
 							const lastSpaceIdx = line.lastIndexOf(" ");
+							if (lastSpaceIdx <= 0) continue;
 							const branch = line.substring(0, lastSpaceIdx);
 							const timestamp = Number.parseInt(
 								line.substring(lastSpaceIdx + 1),
 								10,
 							);
 
-							if (branch === "HEAD") continue;
+							if (!branch || branch === "HEAD") continue;
 
 							if (!branchMap.has(branch)) {
 								branchMap.set(branch, {
@@ -538,6 +540,7 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 							for (const line of remoteBranchInfo.trim().split("\n")) {
 								if (!line) continue;
 								const lastSpaceIdx = line.lastIndexOf(" ");
+								if (lastSpaceIdx <= 0) continue;
 								let branch = line.substring(0, lastSpaceIdx);
 								const timestamp = Number.parseInt(
 									line.substring(lastSpaceIdx + 1),
@@ -549,7 +552,7 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 									branch = branch.replace("origin/", "");
 								}
 
-								if (branch === "HEAD") continue;
+								if (!branch || branch === "HEAD") continue;
 
 								branchMap.set(branch, {
 									lastCommitDate: timestamp * 1000,
@@ -579,13 +582,14 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 						for (const line of localBranchInfo.trim().split("\n")) {
 							if (!line) continue;
 							const lastSpaceIdx = line.lastIndexOf(" ");
+							if (lastSpaceIdx <= 0) continue;
 							const branch = line.substring(0, lastSpaceIdx);
 							const timestamp = Number.parseInt(
 								line.substring(lastSpaceIdx + 1),
 								10,
 							);
 
-							if (branch === "HEAD") continue;
+							if (!branch || branch === "HEAD") continue;
 
 							// Only add if not already in map (remote takes precedence for date)
 							if (!branchMap.has(branch)) {


### PR DESCRIPTION
## Summary
- Fixes "Something went wrong!" crash on the project settings page reported by a Pro subscriber
- Root cause: `git for-each-ref` can output lines without a committer date timestamp. The parsing uses `lastIndexOf(" ")` which returns `-1`, causing `substring(0, -1)` to produce an empty string. This empty branch name reaches `<SelectItem value="">`, triggering Radix UI's invariant: "A <Select.Item /> must have a value prop that is not an empty string"
- Guards all 4 `for-each-ref` parsing blocks (in both `getBranchesLocal` and `getBranches`) to skip malformed lines and empty branch names

## Test plan
- [ ] Open project settings for a repository — no crash
- [ ] Verify branch selector populates correctly
- [ ] Test with a repo that has unusual refs (e.g. annotated tags, orphan branches)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash on Project Settings by skipping malformed `git for-each-ref` lines that produced empty branch names and triggered a Radix Select value error. Branch parsing is now safe and the branch selector loads correctly.

- **Bug Fixes**
  - Guard all four parsing blocks in `getBranches` and `getBranchesLocal`.
  - Skip lines with no space/timestamp (`lastIndexOf(" ") <= 0`).
  - Ignore empty branch names and `HEAD`.

<sup>Written for commit 41b0070255e95fe1e536a4cca1a8a427acb1b061. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch data handling by filtering out empty or malformed branch names, preventing potential erroneous entries in branch lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->