### PR TITLE
fix(marketing): add security headers to improve domain reputation

### DIFF
--- a/apps/marketing/next.config.ts
+++ b/apps/marketing/next.config.ts
@@ -69,6 +69,26 @@ const config: NextConfig = {
 		];
 	},
 
+	async headers() {
+		return [
+			{
+				source: "/(.*)",
+				headers: [
+					{ key: "X-Content-Type-Options", value: "nosniff" },
+					{ key: "X-Frame-Options", value: "DENY" },
+					{
+						key: "Referrer-Policy",
+						value: "strict-origin-when-cross-origin",
+					},
+					{
+						key: "Permissions-Policy",
+						value: "camera=(), microphone=(), geolocation=()",
+					},
+				],
+			},
+		];
+	},
+
 	skipTrailingSlashRedirect: true,
 };
 


### PR DESCRIPTION
## Summary
- superset.sh is being flagged as phishing by **Avira** (1/35 engines on URLVoid), which cascades into Norton, Avast, and AVG via Gen Digital's shared engine
- Adds standard security response headers (`X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`) to signal legitimacy to automated scanners
- False positive report submitted to Avira directly

## Test plan
- [ ] Verify marketing site loads correctly after deploy
- [ ] Confirm YouTube embed in VideoSection still works (X-Frame-Options: DENY only prevents *being* framed, not framing others)
- [ ] Confirm PostHog, Sentry, and Outlit analytics still function
- [ ] Check response headers via `curl -sI https://superset.sh` after deploy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add security response headers across the marketing site to improve domain reputation and reduce phishing false positives from Avira/Norton/Avast/AVG. Implemented globally via `headers()` in `apps/marketing/next.config.ts` with `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin`, and `Permissions-Policy` (camera, microphone, geolocation disabled).

<sup>Written for commit da815aba5088aaf6c1f3d86f0c3a168294f65952. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated HTTP security header configuration across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->