### PR TITLE
fix(desktop): remove dollar amount from yearly billing text

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/plans/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/plans/page.tsx
@@ -79,7 +79,7 @@ const PLAN_CARDS: PlanCardData[] = [
 		priceNote: { monthly: "per user/month", yearly: "per user/month" },
 		billingText: {
 			monthly: "Billed monthly",
-			yearly: "$180/year · billed annually",
+			yearly: "Billed yearly",
 		},
 		showBillingToggle: true,
 		actions: [


### PR DESCRIPTION
## Summary
- Replaced `"$180/year · billed annually"` with `"Billed yearly"` on the Pro plan card when yearly billing is toggled on

## Test plan
- [ ] Open Settings > Billing > Plans, toggle yearly billing on Pro plan, verify it shows "Billed yearly" instead of "$180/year · billed annually"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
On the Pro plan card in Settings → Billing → Plans, show "Billed yearly" when yearly billing is enabled. This removes the hardcoded "$180/year · billed annually" text and simplifies the copy.

<sup>Written for commit ce72a69366ecb2f7152b48ce877586b685ebb066. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Pro plan's yearly billing description text for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->