### PR TITLE
fix(desktop): fix branch search and project switching in New Workspace modal

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/projects/projects.ts
+++ b/apps/desktop/src/lib/trpc/routers/projects/projects.ts
@@ -213,6 +213,7 @@ async function ensureMainWorkspace(project: Project): Promise<void> {
 const SAFE_REPO_NAME_REGEX = /^[a-zA-Z0-9._\- ]+$/;
 const ALLOWED_URL_PROTOCOLS = new Set(["http:", "https:", "ssh:", "git:"]);
 const SSH_GIT_URL_REGEX = /^[\w.-]+@[\w.-]+:[\w./-]+$/;
+const BRANCH_SEARCH_LIMIT = 5000;
 
 /** Extract the repository name from a git URL (HTTPS, SSH, or git:// protocol). */
 function extractRepoName(urlInput: string): string | null {
@@ -660,7 +661,7 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 				z.object({
 					projectId: z.string(),
 					search: z.string().default(""),
-					limit: z.number().min(1).max(200).default(50),
+					limit: z.number().min(1).max(BRANCH_SEARCH_LIMIT).default(50),
 					offset: z.number().min(0).default(0),
 				}),
 			)

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/BranchesGroup/BranchesGroup.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/BranchesGroup/BranchesGroup.tsx
@@ -5,7 +5,6 @@ import { cn } from "@superset/ui/utils";
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { GoArrowUpRight, GoGitBranch, GoGlobe } from "react-icons/go";
-
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useImportAllWorktrees } from "renderer/react-query/workspaces";
 import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
@@ -19,6 +18,7 @@ interface BranchesGroupProps {
 }
 
 const PAGE_SIZE = 50;
+const BRANCH_SEARCH_LIMIT = 5000;
 
 type BranchFilterMode = "all" | "worktrees";
 
@@ -54,7 +54,7 @@ export function BranchesGroup({ projectId }: BranchesGroupProps) {
 		{
 			projectId: projectId ?? "",
 			search: "",
-			limit: 5000,
+			limit: BRANCH_SEARCH_LIMIT,
 			offset: 0,
 		},
 		{

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/NewWorkspaceModalContent/NewWorkspaceModalContent.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/NewWorkspaceModalContent/NewWorkspaceModalContent.tsx
@@ -30,7 +30,7 @@ export function NewWorkspaceModalContent({
 	onNewProject,
 }: NewWorkspaceModalContentProps) {
 	const { draft, updateDraft } = useNewWorkspaceModalDraft();
-	const { data: recentProjects = [] } =
+	const { data: recentProjects = [], isFetched: areRecentProjectsFetched } =
 		electronTrpc.projects.getRecents.useQuery();
 	const utils = electronTrpc.useUtils();
 
@@ -55,14 +55,22 @@ export function NewWorkspaceModalContent({
 
 		if (
 			preSelectedProjectId &&
-			appliedPreSelectionRef.current !== preSelectedProjectId
+			preSelectedProjectId !== appliedPreSelectionRef.current
 		) {
-			appliedPreSelectionRef.current = preSelectedProjectId;
-			if (preSelectedProjectId !== draft.selectedProjectId) {
-				updateDraft({ selectedProjectId: preSelectedProjectId });
+			if (!areRecentProjectsFetched) return;
+			const hasPreSelectedProject = recentProjects.some(
+				(project) => project.id === preSelectedProjectId,
+			);
+			if (hasPreSelectedProject) {
+				appliedPreSelectionRef.current = preSelectedProjectId;
+				if (preSelectedProjectId !== draft.selectedProjectId) {
+					updateDraft({ selectedProjectId: preSelectedProjectId });
+				}
+				return;
 			}
-			return;
 		}
+
+		if (!areRecentProjectsFetched) return;
 
 		const hasSelectedProject = recentProjects.some(
 			(project) => project.id === draft.selectedProjectId,
@@ -72,6 +80,7 @@ export function NewWorkspaceModalContent({
 		}
 	}, [
 		draft.selectedProjectId,
+		areRecentProjectsFetched,
 		isOpen,
 		preSelectedProjectId,
 		recentProjects,

--- a/apps/desktop/src/renderer/components/V2NewWorkspaceModal/components/V2NewWorkspaceModalContent/V2NewWorkspaceModalContent.tsx
+++ b/apps/desktop/src/renderer/components/V2NewWorkspaceModal/components/V2NewWorkspaceModalContent/V2NewWorkspaceModalContent.tsx
@@ -41,6 +41,7 @@ export function V2NewWorkspaceModalContent({
 		[collections],
 	);
 	const v2Projects = useMemo(() => v2ProjectsData ?? [], [v2ProjectsData]);
+	const areV2ProjectsReady = v2ProjectsData !== undefined;
 
 	const appliedPreSelectionRef = useRef<string | null>(null);
 
@@ -57,15 +58,22 @@ export function V2NewWorkspaceModalContent({
 		// Only use preSelectedProjectId if it matches an actual v2 project
 		if (
 			preSelectedProjectId &&
-			appliedPreSelectionRef.current !== preSelectedProjectId &&
-			v2Projects.some((p) => p.id === preSelectedProjectId)
+			preSelectedProjectId !== appliedPreSelectionRef.current
 		) {
-			appliedPreSelectionRef.current = preSelectedProjectId;
-			if (preSelectedProjectId !== draft.selectedProjectId) {
-				updateDraft({ selectedProjectId: preSelectedProjectId });
+			if (!areV2ProjectsReady) return;
+			const hasPreSelectedProject = v2Projects.some(
+				(project) => project.id === preSelectedProjectId,
+			);
+			if (hasPreSelectedProject) {
+				appliedPreSelectionRef.current = preSelectedProjectId;
+				if (preSelectedProjectId !== draft.selectedProjectId) {
+					updateDraft({ selectedProjectId: preSelectedProjectId });
+				}
+				return;
 			}
-			return;
 		}
+
+		if (!areV2ProjectsReady) return;
 
 		const hasSelectedProject = v2Projects.some(
 			(project) => project.id === draft.selectedProjectId,
@@ -75,6 +83,7 @@ export function V2NewWorkspaceModalContent({
 		}
 	}, [
 		draft.selectedProjectId,
+		areV2ProjectsReady,
 		isOpen,
 		preSelectedProjectId,
 		v2Projects,


### PR DESCRIPTION
## Summary

<img width="655" height="582" alt="image" src="https://github.com/user-attachments/assets/63aa61d0-a653-4c48-a99f-60a967c9aa5f" />

<img width="666" height="242" alt="image" src="https://github.com/user-attachments/assets/72277f00-f871-4f7a-b3a6-9a944a56503a" />

Fixes three bugs in the "New Workspace" modal and makes branch search instant:

- **"All" branch search returns 0 results** — `git for-each-ref` glob patterns (`*MCP*`) don't cross `/` boundaries and are case-sensitive. Replaced with JS-side case-insensitive substring filtering on the full ref list.
- **Branch search is now instant** — All branches are fetched once and cached; filtering happens client-side with no debounce delay or repeated IPC round-trips.
- **"Worktrees" tab search does nothing** — `worktreeBranchRows` useMemo never filtered by the search query. Since `shouldFilter={false}` disables cmdk's built-in filtering, added an explicit `.filter()` with case-insensitive match.
- **Project switching reverts to pre-selected project** — `useEffect` with `draft.selectedProjectId` in deps caused a re-run loop that reset the user's selection. Used a `useRef` flag so pre-selection only fires once per modal open.

## Changed files

| File | Fix |
|------|-----|
| `apps/desktop/src/lib/trpc/routers/projects/projects.ts` | JS-side branch filtering instead of git glob |
| `.../BranchesGroup/BranchesGroup.tsx` | Client-side instant search, filter worktree rows by query |
| `.../NewWorkspaceModalContent/NewWorkspaceModalContent.tsx` | One-shot pre-selection via ref (V1) |
| `.../V2NewWorkspaceModalContent/V2NewWorkspaceModalContent.tsx` | One-shot pre-selection via ref (V2) |

## Test plan

- [ ] Open New Workspace modal → "All" tab, type a query → results filter instantly (no 300ms lag)
- [ ] Search for a branch with `/` in the name (e.g. `Roshvan/MCP-624`) — should appear in results
- [ ] Search is case-insensitive (e.g. `mcp` matches `MCP-624`)
- [ ] Switch to "Worktrees" tab and search — results filter correctly
- [ ] Switch projects in the modal — selection sticks, doesn't revert
- [ ] Close and reopen modal — pre-selection applies correctly on fresh open
- [ ] Infinite scroll (type nothing, scroll down) — still loads more branches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pre-selection in workspace modals now applies only once when opened and only if the project exists; selection is guarded by readiness checks.
  * Pagination reliably resets when branch queries change.

* **Improvements**
  * Branch search now uses case-insensitive substring matching with larger server result limits and consistent client-side filtering; remote results are preferred.
  * More robust repository/project detection for more reliable project selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->