### PR TITLE
feat(desktop): add Arch-One and Pulse sidebar tabs with Greptile integration

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/arch-one/daily-briefing.ts
+++ b/apps/desktop/src/lib/trpc/routers/arch-one/daily-briefing.ts
@@ -1,0 +1,203 @@
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { createOpenAI } from "@ai-sdk/openai";
+import {
+	getCredentialsFromAnySource as getAnthropicCredentialsFromAnySource,
+	getAnthropicProviderOptions,
+	getOpenAICredentialsFromAnySource,
+} from "@superset/chat/host";
+import { generateText } from "ai";
+import { z } from "zod";
+import { publicProcedure, router } from "../..";
+
+const briefingCache = new Map<
+	string,
+	{ summary: string; generatedAt: number }
+>();
+
+const CACHE_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
+
+const activityDataSchema = z.object({
+	completedTasks: z.array(
+		z.object({ slug: z.string(), title: z.string(), completedBy: z.string() }),
+	),
+	startedTasks: z.array(
+		z.object({ slug: z.string(), title: z.string(), assignee: z.string() }),
+	),
+	newTasks: z.array(z.object({ slug: z.string(), title: z.string() })),
+	mergedPRs: z.array(
+		z.object({
+			prNumber: z.number(),
+			title: z.string(),
+			authorLogin: z.string(),
+		}),
+	),
+	openedPRs: z.array(
+		z.object({
+			prNumber: z.number(),
+			title: z.string(),
+			authorLogin: z.string(),
+			isDraft: z.boolean(),
+		}),
+	),
+	staleTasks: z.array(
+		z.object({
+			slug: z.string(),
+			title: z.string(),
+			assignee: z.string(),
+			daysSinceUpdate: z.number(),
+		}),
+	),
+	teamOpenPRs: z.array(
+		z.object({
+			prNumber: z.number(),
+			title: z.string(),
+			authorLogin: z.string(),
+			isDraft: z.boolean(),
+			reviewDecision: z.string().nullable(),
+			checksStatus: z.string(),
+			additions: z.number(),
+			deletions: z.number(),
+			createdAt: z.string(),
+		}),
+	),
+});
+
+function getCacheKey(): string {
+	const now = new Date();
+	return `${now.getFullYear()}-${now.getMonth()}-${now.getDate()}`;
+}
+
+async function callLLM(prompt: string): Promise<string | null> {
+	// Try Anthropic first, then OpenAI
+	const anthropicCreds = getAnthropicCredentialsFromAnySource();
+	if (anthropicCreds) {
+		try {
+			const anthropic = createAnthropic(
+				getAnthropicProviderOptions(anthropicCreds),
+			);
+			const result = await generateText({
+				model: anthropic("claude-haiku-4-5-20251001"),
+				prompt,
+				maxOutputTokens: 500,
+			});
+			if (result.text) return result.text;
+		} catch (error) {
+			console.error("[daily-briefing] Anthropic generation failed", error);
+		}
+	}
+
+	const openaiCreds = getOpenAICredentialsFromAnySource();
+	if (openaiCreds) {
+		try {
+			const openai = createOpenAI({ apiKey: openaiCreds.apiKey });
+			const result = await generateText({
+				model: openai("gpt-4o-mini"),
+				prompt,
+				maxOutputTokens: 500,
+			});
+			if (result.text) return result.text;
+		} catch (error) {
+			console.error("[daily-briefing] OpenAI generation failed", error);
+		}
+	}
+
+	return null;
+}
+
+export const createDailyBriefingRouter = () => {
+	return router({
+		generateBriefing: publicProcedure
+			.input(z.object({ activityData: activityDataSchema }))
+			.mutation(async ({ input }) => {
+				const { activityData } = input;
+
+				const sections: string[] = [];
+				if (activityData.completedTasks.length > 0) {
+					sections.push(
+						`Completed tasks (${activityData.completedTasks.length}):\n${activityData.completedTasks.map((t) => `- ${t.slug}: ${t.title} (by ${t.completedBy})`).join("\n")}`,
+					);
+				}
+				if (activityData.startedTasks.length > 0) {
+					sections.push(
+						`Started tasks (${activityData.startedTasks.length}):\n${activityData.startedTasks.map((t) => `- ${t.slug}: ${t.title} (${t.assignee})`).join("\n")}`,
+					);
+				}
+				if (activityData.newTasks.length > 0) {
+					sections.push(
+						`New tasks (${activityData.newTasks.length}):\n${activityData.newTasks.map((t) => `- ${t.slug}: ${t.title}`).join("\n")}`,
+					);
+				}
+				if (activityData.mergedPRs.length > 0) {
+					sections.push(
+						`Merged PRs (${activityData.mergedPRs.length}):\n${activityData.mergedPRs.map((p) => `- #${p.prNumber}: ${p.title} (by ${p.authorLogin})`).join("\n")}`,
+					);
+				}
+				if (activityData.openedPRs.length > 0) {
+					sections.push(
+						`Opened PRs (${activityData.openedPRs.length}):\n${activityData.openedPRs.map((p) => `- #${p.prNumber}: ${p.title} (by ${p.authorLogin})${p.isDraft ? " [draft]" : ""}`).join("\n")}`,
+					);
+				}
+				if (activityData.staleTasks.length > 0) {
+					sections.push(
+						`Stale/blocked tasks:\n${activityData.staleTasks.map((t) => `- ${t.slug}: ${t.title} (${t.assignee}, ${t.daysSinceUpdate}d since update)`).join("\n")}`,
+					);
+				}
+				if (activityData.teamOpenPRs.length > 0) {
+					sections.push(
+						`Currently open PRs — what teammates are working on (${activityData.teamOpenPRs.length}):\n${activityData.teamOpenPRs
+							.map((p) => {
+								const status = p.isDraft
+									? "draft"
+									: p.reviewDecision === "APPROVED"
+										? "approved"
+										: p.reviewDecision === "CHANGES_REQUESTED"
+											? "changes requested"
+											: "awaiting review";
+								const ci =
+									p.checksStatus === "failure"
+										? ", CI failing"
+										: p.checksStatus === "pending"
+											? ", CI pending"
+											: "";
+								return `- #${p.prNumber}: ${p.title} (by ${p.authorLogin}, ${status}${ci}, +${p.additions}/-${p.deletions})`;
+							})
+							.join("\n")}`,
+					);
+				}
+
+				if (sections.length === 0) {
+					return {
+						summary: "No recent activity to summarize.",
+						generatedAt: Date.now(),
+					};
+				}
+
+				const prompt = `You are a concise engineering team assistant. Summarize this team activity for a developer starting their day. Use 3-5 bullet points in markdown. Highlight anything blocked or noteworthy. Include a brief note on what teammates are currently working on based on open PRs. Be brief and actionable.
+
+Recent team activity:
+
+${sections.join("\n\n")}`;
+
+				const summary = await callLLM(prompt);
+				if (!summary) {
+					return {
+						summary:
+							"Could not generate briefing. Check that AI credentials are configured.",
+						generatedAt: Date.now(),
+					};
+				}
+
+				const result = { summary, generatedAt: Date.now() };
+				briefingCache.set(getCacheKey(), result);
+				return result;
+			}),
+
+		getBriefing: publicProcedure.query(() => {
+			const cached = briefingCache.get(getCacheKey());
+			if (cached && Date.now() - cached.generatedAt < CACHE_TTL_MS) {
+				return cached;
+			}
+			return null;
+		}),
+	});
+};

--- a/apps/desktop/src/lib/trpc/routers/arch-one/env-sync.ts
+++ b/apps/desktop/src/lib/trpc/routers/arch-one/env-sync.ts
@@ -1,0 +1,109 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { z } from "zod";
+import { publicProcedure, router } from "../..";
+
+interface EnvFileStatus {
+	name: string;
+	relativePath: string;
+	exists: boolean;
+	hash: string | null;
+	lastModified: string | null;
+	keyCount: number;
+}
+
+interface EnvSyncResult {
+	files: EnvFileStatus[];
+	inSync: boolean;
+	staleFiles: string[];
+}
+
+const ENV_FILES = [
+	{ name: "Edge Functions", relativePath: "supabase/functions/.env" },
+	{ name: "Droplet Server", relativePath: "droplet-server/.env" },
+	{ name: "Frontend", relativePath: "frontend/.env.local" },
+	{ name: "Scripts", relativePath: "scripts/.env.local" },
+] as const;
+
+function hashEnvKeys(content: string): string {
+	// Parse env content, extract key=value pairs, sort by key, hash
+	const lines = content
+		.split("\n")
+		.filter((l) => l.trim() && !l.startsWith("#"))
+		.map((l) => l.trim())
+		.sort();
+	return createHash("md5").update(lines.join("\n")).digest("hex").slice(0, 8);
+}
+
+function countKeys(content: string): number {
+	return content
+		.split("\n")
+		.filter((l) => l.trim() && !l.startsWith("#") && l.includes("=")).length;
+}
+
+export const createEnvSyncRouter = () => {
+	return router({
+		getEnvSyncStatus: publicProcedure
+			.input(z.object({ worktreePath: z.string() }))
+			.query(({ input }): EnvSyncResult => {
+				const files: EnvFileStatus[] = ENV_FILES.map((envFile) => {
+					const fullPath = join(input.worktreePath, envFile.relativePath);
+					if (!existsSync(fullPath)) {
+						return {
+							name: envFile.name,
+							relativePath: envFile.relativePath,
+							exists: false,
+							hash: null,
+							lastModified: null,
+							keyCount: 0,
+						};
+					}
+					try {
+						const content = readFileSync(fullPath, "utf-8");
+						const stat = statSync(fullPath);
+						return {
+							name: envFile.name,
+							relativePath: envFile.relativePath,
+							exists: true,
+							hash: hashEnvKeys(content),
+							lastModified: stat.mtime.toISOString(),
+							keyCount: countKeys(content),
+						};
+					} catch {
+						return {
+							name: envFile.name,
+							relativePath: envFile.relativePath,
+							exists: false,
+							hash: null,
+							lastModified: null,
+							keyCount: 0,
+						};
+					}
+				});
+
+				// Time-based staleness: files are "stale" if modified >5 min before the newest
+				const existingFiles = files.filter((f) => f.exists && f.lastModified);
+				const latestTime = existingFiles.reduce((max, f) => {
+					const t = new Date(f.lastModified ?? 0).getTime();
+					return t > max ? t : max;
+				}, 0);
+
+				const STALE_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
+				const staleFiles = latestTime
+					? existingFiles
+							.filter((f) => {
+								const t = new Date(f.lastModified ?? 0).getTime();
+								return latestTime - t > STALE_THRESHOLD_MS;
+							})
+							.map((f) => f.name)
+					: [];
+
+				return {
+					files,
+					inSync: staleFiles.length === 0,
+					staleFiles,
+				};
+			}),
+	});
+};

--- a/apps/desktop/src/lib/trpc/routers/arch-one/git-status.ts
+++ b/apps/desktop/src/lib/trpc/routers/arch-one/git-status.ts
@@ -1,0 +1,59 @@
+import simpleGit from "simple-git";
+import { z } from "zod";
+import { publicProcedure, router } from "../..";
+
+interface GitStatusResult {
+	branch: string | null;
+	ahead: number;
+	behind: number;
+	staged: number;
+	modified: number;
+	untracked: number;
+	stashes: number;
+	hasConflicts: boolean;
+	lastCommitMessage: string | null;
+	lastCommitDate: string | null;
+}
+
+export const createGitStatusRouter = () => {
+	return router({
+		getGitStatus: publicProcedure
+			.input(z.object({ worktreePath: z.string() }))
+			.query(async ({ input }): Promise<GitStatusResult> => {
+				try {
+					const git = simpleGit(input.worktreePath);
+					const [status, log, stashList] = await Promise.all([
+						git.status(),
+						git.log({ maxCount: 1 }).catch(() => null),
+						git.stashList().catch(() => null),
+					]);
+
+					return {
+						branch: status.current,
+						ahead: status.ahead,
+						behind: status.behind,
+						staged: status.staged.length,
+						modified: status.modified.length + status.renamed.length,
+						untracked: status.not_added.length,
+						stashes: stashList?.total ?? 0,
+						hasConflicts: status.conflicted.length > 0,
+						lastCommitMessage: log?.latest?.message ?? null,
+						lastCommitDate: log?.latest?.date ?? null,
+					};
+				} catch {
+					return {
+						branch: null,
+						ahead: 0,
+						behind: 0,
+						staged: 0,
+						modified: 0,
+						untracked: 0,
+						stashes: 0,
+						hasConflicts: false,
+						lastCommitMessage: null,
+						lastCommitDate: null,
+					};
+				}
+			}),
+	});
+};

--- a/apps/desktop/src/lib/trpc/routers/arch-one/greptile.ts
+++ b/apps/desktop/src/lib/trpc/routers/arch-one/greptile.ts
@@ -1,0 +1,510 @@
+import { type ChildProcess, exec, spawn } from "node:child_process";
+import { openSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import simpleGit from "simple-git";
+import { z } from "zod";
+import { publicProcedure, router } from "../..";
+
+const execAsync = promisify(exec);
+const MAX_FIX_ITERATIONS = 10;
+
+interface GreptileScore {
+	score: number | null;
+	maxScore: number;
+	summary: string | null;
+	issues: string[];
+	reviewContent: string | null;
+	prNumber: number | null;
+	prTitle: string | null;
+	prUrl: string | null;
+	reviewing: boolean;
+	latestReviewId: number | null;
+	owner: string | null;
+	repo: string | null;
+	error: string | null;
+}
+
+type FixPhase =
+	| "idle"
+	| "fixing"
+	| "waiting-for-review"
+	| "done"
+	| "max-reached"
+	| "stopped";
+
+interface FixLoopEntry {
+	process: ChildProcess | null;
+	phase: FixPhase;
+	iteration: number;
+	lastTriggeredScore: number | null;
+	reviewIdAtFixStart: number | null;
+	exitCode: number | null;
+	startedAt: number | null;
+	logFile: string | null;
+	pollTimer: ReturnType<typeof setInterval> | null;
+	worktreePath: string;
+}
+
+// Track fix loop state per worktree — persists across workspace switches
+const fixLoopState = new Map<string, FixLoopEntry>();
+
+function getFixLoopStatus(worktreePath: string) {
+	const entry = fixLoopState.get(worktreePath);
+	if (!entry) {
+		return {
+			phase: "idle" as FixPhase,
+			iteration: 0,
+			lastTriggeredScore: null as number | null,
+			startedAt: null as number | null,
+			logFile: null as string | null,
+			maxIterations: MAX_FIX_ITERATIONS,
+		};
+	}
+	return {
+		phase: entry.phase,
+		iteration: entry.iteration,
+		lastTriggeredScore: entry.lastTriggeredScore,
+		startedAt: entry.startedAt,
+		logFile: entry.logFile,
+		maxIterations: MAX_FIX_ITERATIONS,
+	};
+}
+
+function stopPollTimer(entry: FixLoopEntry) {
+	if (entry.pollTimer) {
+		clearInterval(entry.pollTimer);
+		entry.pollTimer = null;
+	}
+}
+
+function startReviewPolling(entry: FixLoopEntry) {
+	stopPollTimer(entry);
+
+	const poll = async () => {
+		if (entry.phase !== "waiting-for-review") {
+			stopPollTimer(entry);
+			return;
+		}
+
+		try {
+			const data = await getGreptileScore(entry.worktreePath);
+
+			// Still reviewing — skip
+			if (data.reviewing) return;
+
+			// No new review yet
+			if (
+				data.latestReviewId === null ||
+				data.latestReviewId === entry.reviewIdAtFixStart
+			)
+				return;
+
+			// New review — check the score
+			if (data.score === null || data.score === undefined) return;
+
+			// Score is good — done!
+			if (data.score >= 4) {
+				entry.phase = "done";
+				stopPollTimer(entry);
+				return;
+			}
+
+			// Score still < 4 — trigger next iteration
+			const nextIteration = entry.iteration + 1;
+			if (nextIteration > MAX_FIX_ITERATIONS) {
+				entry.phase = "max-reached";
+				stopPollTimer(entry);
+				return;
+			}
+
+			spawnFixProcess(
+				entry,
+				nextIteration,
+				data.score,
+				data.reviewContent,
+				data.prNumber,
+				data.owner,
+				data.repo,
+			);
+		} catch {
+			// will retry on next poll
+		}
+	};
+
+	entry.pollTimer = setInterval(poll, 15_000);
+	// Also poll once shortly after starting (give Greptile a moment)
+	setTimeout(poll, 3_000);
+}
+
+function spawnFixProcess(
+	entry: FixLoopEntry,
+	iteration: number,
+	score: number,
+	reviewContent: string | null,
+	prNumber: number | null,
+	owner: string | null,
+	repo: string | null,
+) {
+	// Kill any existing process
+	if (entry.process) {
+		try {
+			entry.process.kill();
+		} catch {
+			// ignore
+		}
+	}
+	stopPollTimer(entry);
+
+	const ownerRepo = owner && repo ? `${owner}/${repo}` : "{owner}/{repo}";
+
+	let prompt: string;
+	if (reviewContent && prNumber) {
+		prompt = `Fix Greptile code review issues on PR #${prNumber}. Iteration ${iteration}/${MAX_FIX_ITERATIONS}, current score: ${score}/5.
+
+## Review Comments
+${reviewContent}
+
+## Steps
+1. Read each file mentioned above at the specified line
+2. Fix valid issues. Skip false positives — do not waste time on incorrect suggestions
+3. Stage changed files, commit with message: "fix: address greptile review feedback"
+4. Push to the current branch
+5. Resolve addressed review threads on GitHub:
+   - Get thread IDs: gh api graphql -f query='{ repository(owner: "${owner ?? "{owner}"}", name: "${repo ?? "{repo}"}") { pullRequest(number: ${prNumber}) { reviewThreads(first: 100) { nodes { id isResolved path comments(first: 1) { nodes { body } } } } } } }'
+   - For each unresolved thread you fixed, resolve it: gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "THREAD_ID"}) { thread { isResolved } } }'
+
+## If the comments above are incomplete
+Fetch full review comments yourself:
+  gh api repos/${ownerRepo}/pulls/${prNumber}/reviews --jq '[.[] | select(.user.login == "greptile-apps[bot]")] | last | .id'
+  gh api repos/${ownerRepo}/pulls/${prNumber}/reviews/REVIEW_ID/comments --jq '.[] | {path, line, body}'`;
+	} else if (prNumber) {
+		prompt = `Check the latest Greptile review comments on PR #${prNumber} and fix all issues, then commit and push. Iteration ${iteration}/${MAX_FIX_ITERATIONS}, current score: ${score}/5.
+
+Fetch review comments:
+  gh api repos/${ownerRepo}/pulls/${prNumber}/reviews --jq '[.[] | select(.user.login == "greptile-apps[bot]")] | last | .id'
+  gh api repos/${ownerRepo}/pulls/${prNumber}/reviews/REVIEW_ID/comments --jq '.[] | {path, line, body}'
+
+Fix every issue, commit with message "fix: address greptile review feedback", and push.`;
+	} else {
+		prompt =
+			"Check the latest Greptile review comments on the current PR and fix all issues, then commit and push.";
+	}
+
+	const logFile = join(tmpdir(), `greptile-fix-${Date.now()}.log`);
+	const fd = openSync(logFile, "w");
+
+	const child = spawn(
+		"claude",
+		["--dangerously-skip-permissions", "-p", prompt],
+		{
+			cwd: entry.worktreePath,
+			detached: true,
+			stdio: ["ignore", fd, fd],
+		},
+	);
+
+	entry.process = child;
+	entry.phase = "fixing";
+	entry.iteration = iteration;
+	entry.lastTriggeredScore = score;
+	entry.exitCode = null;
+	entry.startedAt = Date.now();
+	entry.logFile = logFile;
+
+	child.on("exit", async (code) => {
+		if (entry.process !== child) return;
+		entry.exitCode = code;
+
+		// Capture current reviewId so we can detect when a NEW review lands
+		try {
+			const data = await getGreptileScore(entry.worktreePath);
+			entry.reviewIdAtFixStart = data.latestReviewId;
+		} catch {
+			entry.reviewIdAtFixStart = null;
+		}
+
+		entry.phase = "waiting-for-review";
+		startReviewPolling(entry);
+	});
+
+	child.on("error", () => {
+		if (entry.process !== child) return;
+		entry.exitCode = -1;
+		entry.phase = "waiting-for-review";
+		startReviewPolling(entry);
+	});
+
+	child.unref();
+}
+
+// Greptile check runs can get stuck at IN_PROGRESS permanently,
+// so we don't rely on them. Instead we detect "reviewing" by:
+// - No greptile_comment in PR body yet but a review exists, OR
+// - The PR body has pending markers (reviewing/analyzing/in progress)
+// The latestReviewId change is the reliable signal that a new review landed.
+
+async function getGreptileScore(worktreePath: string): Promise<GreptileScore> {
+	const empty: GreptileScore = {
+		score: null,
+		maxScore: 5,
+		summary: null,
+		issues: [],
+		reviewContent: null,
+		prNumber: null,
+		prTitle: null,
+		prUrl: null,
+		reviewing: false,
+		latestReviewId: null,
+		owner: null,
+		repo: null,
+		error: null,
+	};
+
+	try {
+		// Get current branch
+		const git = simpleGit(worktreePath);
+		const branch = (await git.branch()).current;
+		if (!branch || branch === "main" || branch === "master") {
+			return { ...empty, error: "No feature branch (on main)" };
+		}
+
+		// Find PR for this branch — get body (where Greptile embeds its review)
+		let prJson: string;
+		try {
+			const { stdout } = await execAsync(
+				"gh pr view --json number,title,url,body --jq '.' 2>/dev/null",
+				{ cwd: worktreePath, timeout: 15_000 },
+			);
+			prJson = stdout.trim();
+		} catch {
+			return { ...empty, error: "No PR found for this branch" };
+		}
+
+		if (!prJson) {
+			return { ...empty, error: "No PR found for this branch" };
+		}
+
+		const pr = JSON.parse(prJson) as {
+			number: number;
+			title: string;
+			url: string;
+			body: string;
+		};
+
+		// Extract owner/repo for GraphQL instructions in fix prompt
+		let owner: string | null = null;
+		let repo: string | null = null;
+		try {
+			const { stdout: repoJson } = await execAsync(
+				"gh repo view --json owner,name --jq '{owner: .owner.login, name: .name}' 2>/dev/null",
+				{ cwd: worktreePath, timeout: 15_000 },
+			);
+			const parsed = JSON.parse(repoJson.trim()) as {
+				owner: string;
+				name: string;
+			};
+			owner = parsed.owner;
+			repo = parsed.name;
+		} catch {
+			// non-critical — prompt will use {owner}/{repo} placeholders
+		}
+
+		// Get latest review ID from greptile-apps[bot] (used to detect new reviews)
+		let latestReviewId: number | null = null;
+		let reviewContent: string | null = null;
+		try {
+			const { stdout: reviewsJson } = await execAsync(
+				`gh api repos/{owner}/{repo}/pulls/${pr.number}/reviews --jq '[.[] | select(.user.login == "greptile-apps[bot]")] | last | .id' 2>/dev/null`,
+				{ cwd: worktreePath, timeout: 15_000 },
+			);
+			const reviewIdStr = reviewsJson.trim();
+			if (reviewIdStr && reviewIdStr !== "null") {
+				latestReviewId = Number.parseInt(reviewIdStr, 10);
+				// Get review comments with file/line context (not just body)
+				const { stdout: commentsJson } = await execAsync(
+					`gh api repos/{owner}/{repo}/pulls/${pr.number}/reviews/${latestReviewId}/comments --jq '[.[] | {path, line, body}]' 2>/dev/null`,
+					{ cwd: worktreePath, timeout: 15_000 },
+				);
+				const comments = JSON.parse(commentsJson.trim() || "[]") as {
+					path: string | null;
+					line: number | null;
+					body: string;
+				}[];
+				reviewContent = comments
+					.map((c) => {
+						const loc = c.path
+							? `### ${c.path}${c.line ? ` (line ${c.line})` : ""}`
+							: "### (general comment)";
+						return `${loc}\n${c.body}`;
+					})
+					.join("\n\n")
+					.slice(0, 15000);
+			}
+		} catch {
+			// non-critical
+		}
+
+		// Extract the Greptile section from the PR body
+		const greptileMatch = pr.body?.match(
+			/<!-- greptile_comment -->([\s\S]*?)<!-- \/greptile_comment -->/,
+		);
+
+		if (!greptileMatch) {
+			return {
+				...empty,
+				prNumber: pr.number,
+				prTitle: pr.title,
+				prUrl: pr.url,
+				latestReviewId,
+				reviewing: false,
+				error: "No Greptile review on this PR yet",
+			};
+		}
+
+		const greptileSection = greptileMatch[1];
+
+		// Extract score
+		const scoreMatch = greptileSection.match(
+			/Confidence\s+Score:\s*(\d)\s*\/\s*5/i,
+		);
+		const score = scoreMatch ? Number.parseInt(scoreMatch[1], 10) : null;
+
+		// Extract summary
+		let summary: string | null = null;
+		const summaryMatch = greptileSection.match(
+			/<h3>Greptile Summary<\/h3>\s*([\s\S]*?)(?=<h3>)/,
+		);
+		if (summaryMatch) {
+			summary = summaryMatch[1]
+				.replace(/<[^>]+>/g, "")
+				.split("\n")
+				.map((l) => l.trim())
+				.filter((l) => l.length > 0)
+				.slice(0, 3)
+				.join(" ")
+				.slice(0, 300);
+		}
+
+		// Extract issues — bullet points between Confidence Score and Important Files
+		const issuesMatch = greptileSection.match(
+			/Confidence\s+Score:\s*\d\s*\/\s*5<\/h3>\s*([\s\S]*?)(?=<h3>Important\s+Files|<h3>Greptile\s+Summary|$)/i,
+		);
+		const issues: string[] = [];
+		if (issuesMatch) {
+			const raw = issuesMatch[1]
+				.replace(/<[^>]+>/g, "")
+				.split("\n")
+				.map((l) => l.trim())
+				.filter((l) => l.length > 0);
+			for (const line of raw) {
+				if (issues.length < 10) {
+					issues.push(line.slice(0, 500));
+				}
+			}
+		}
+
+		// Determine reviewing state from PR body content
+		const reviewing =
+			score === null &&
+			(greptileSection.includes("reviewing") ||
+				greptileSection.includes("in progress") ||
+				greptileSection.includes("analyzing"));
+
+		return {
+			score,
+			maxScore: 5,
+			summary,
+			issues,
+			reviewContent,
+			prNumber: pr.number,
+			prTitle: pr.title,
+			prUrl: pr.url,
+			reviewing,
+			latestReviewId,
+			owner,
+			repo,
+			error: null,
+		};
+	} catch (error) {
+		return {
+			...empty,
+			error: error instanceof Error ? error.message : "Failed to fetch",
+		};
+	}
+}
+
+export const createGreptileRouter = () => {
+	return router({
+		getGreptileScore: publicProcedure
+			.input(z.object({ worktreePath: z.string() }))
+			.query(async ({ input }): Promise<GreptileScore> => {
+				return getGreptileScore(input.worktreePath);
+			}),
+
+		getFixStatus: publicProcedure
+			.input(z.object({ worktreePath: z.string() }))
+			.query(({ input }) => {
+				return getFixLoopStatus(input.worktreePath);
+			}),
+
+		fixGreptile: publicProcedure
+			.input(
+				z.object({
+					worktreePath: z.string(),
+					reviewContent: z.string().optional(),
+					prNumber: z.number().optional(),
+					owner: z.string().optional(),
+					repo: z.string().optional(),
+				}),
+			)
+			.mutation(({ input }) => {
+				let entry = fixLoopState.get(input.worktreePath);
+				if (!entry) {
+					entry = {
+						process: null,
+						phase: "idle",
+						iteration: 0,
+						lastTriggeredScore: null,
+						reviewIdAtFixStart: null,
+						exitCode: null,
+						startedAt: null,
+						logFile: null,
+						pollTimer: null,
+						worktreePath: input.worktreePath,
+					};
+					fixLoopState.set(input.worktreePath, entry);
+				}
+
+				spawnFixProcess(
+					entry,
+					1,
+					0,
+					input.reviewContent ?? null,
+					input.prNumber ?? null,
+					input.owner ?? null,
+					input.repo ?? null,
+				);
+				return { started: true };
+			}),
+
+		stopFix: publicProcedure
+			.input(z.object({ worktreePath: z.string() }))
+			.mutation(({ input }) => {
+				const entry = fixLoopState.get(input.worktreePath);
+				if (entry) {
+					if (entry.process) {
+						try {
+							entry.process.kill();
+						} catch {
+							// ignore
+						}
+					}
+					stopPollTimer(entry);
+					entry.phase = "stopped";
+				}
+				return { stopped: true };
+			}),
+	});
+};

--- a/apps/desktop/src/lib/trpc/routers/arch-one/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/arch-one/index.ts
@@ -1,0 +1,31 @@
+import { router } from "../..";
+import { createDailyBriefingRouter } from "./daily-briefing";
+import { createEnvSyncRouter } from "./env-sync";
+import { createGitStatusRouter } from "./git-status";
+import { createGreptileRouter } from "./greptile";
+import { createSeedUsersRouter } from "./seed-users";
+import { createServiceHealthRouter } from "./service-health";
+import { createSlotManagerRouter } from "./slot-manager";
+import { createTestResultsRouter } from "./test-results";
+
+export const createArchOneRouter = () => {
+	const gitStatusRouter = createGitStatusRouter();
+	const serviceHealthRouter = createServiceHealthRouter();
+	const testResultsRouter = createTestResultsRouter();
+	const envSyncRouter = createEnvSyncRouter();
+	const greptileRouter = createGreptileRouter();
+	const seedUsersRouter = createSeedUsersRouter();
+	const dailyBriefingRouter = createDailyBriefingRouter();
+	const slotManagerRouter = createSlotManagerRouter();
+
+	return router({
+		...gitStatusRouter._def.procedures,
+		...serviceHealthRouter._def.procedures,
+		...testResultsRouter._def.procedures,
+		...envSyncRouter._def.procedures,
+		...greptileRouter._def.procedures,
+		...seedUsersRouter._def.procedures,
+		...dailyBriefingRouter._def.procedures,
+		...slotManagerRouter._def.procedures,
+	});
+};

--- a/apps/desktop/src/lib/trpc/routers/arch-one/seed-users.ts
+++ b/apps/desktop/src/lib/trpc/routers/arch-one/seed-users.ts
@@ -1,0 +1,72 @@
+import { z } from "zod";
+import { publicProcedure, router } from "../..";
+
+interface SeededUser {
+	email: string;
+	name: string;
+	createdAt: string;
+}
+
+interface SeededUsersResult {
+	users: SeededUser[];
+	total: number;
+	error: string | null;
+}
+
+const SUPABASE_LOCAL_API = "http://localhost:54321";
+const SUPABASE_LOCAL_SERVICE_KEY =
+	"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU";
+
+async function fetchSeededUsers(): Promise<SeededUsersResult> {
+	try {
+		const response = await fetch(
+			`${SUPABASE_LOCAL_API}/auth/v1/admin/users?per_page=50`,
+			{
+				headers: {
+					apikey: SUPABASE_LOCAL_SERVICE_KEY,
+					Authorization: `Bearer ${SUPABASE_LOCAL_SERVICE_KEY}`,
+				},
+			},
+		);
+
+		if (!response.ok) {
+			return {
+				users: [],
+				total: 0,
+				error: `Supabase API: ${response.status}`,
+			};
+		}
+
+		const data = (await response.json()) as {
+			users: Array<{
+				email: string;
+				user_metadata?: { name?: string };
+				created_at: string;
+			}>;
+		};
+
+		const users: SeededUser[] = (data.users ?? []).map((u) => ({
+			email: u.email,
+			name: u.user_metadata?.name ?? "",
+			createdAt: u.created_at,
+		}));
+
+		return { users, total: users.length, error: null };
+	} catch (error) {
+		return {
+			users: [],
+			total: 0,
+			error: error instanceof Error ? error.message : "Failed to fetch",
+		};
+	}
+}
+
+export const createSeedUsersRouter = () => {
+	return router({
+		getSeededUsers: publicProcedure
+			.input(z.object({ worktreePath: z.string() }))
+			.query(async (): Promise<SeededUsersResult> => {
+				return fetchSeededUsers();
+			}),
+	});
+};

--- a/apps/desktop/src/lib/trpc/routers/arch-one/service-health.ts
+++ b/apps/desktop/src/lib/trpc/routers/arch-one/service-health.ts
@@ -1,0 +1,187 @@
+import { exec } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { createConnection } from "node:net";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { z } from "zod";
+import { publicProcedure, router } from "../..";
+
+const execAsync = promisify(exec);
+
+interface ServiceStatus {
+	name: string;
+	port: number;
+	running: boolean;
+	processAlive: boolean;
+	uptimeSeconds: number | null;
+	restartCommand: string;
+}
+
+function checkPort(port: number, timeout = 1000): Promise<boolean> {
+	return new Promise((resolve) => {
+		const socket = createConnection({ port, host: "127.0.0.1" }, () => {
+			socket.destroy();
+			resolve(true);
+		});
+		socket.setTimeout(timeout);
+		socket.on("timeout", () => {
+			socket.destroy();
+			resolve(false);
+		});
+		socket.on("error", () => {
+			socket.destroy();
+			resolve(false);
+		});
+	});
+}
+
+async function isProcessAlive(pattern: string): Promise<boolean> {
+	try {
+		const { stdout } = await execAsync(`pgrep -f "${pattern}" 2>/dev/null`);
+		return stdout.trim().length > 0;
+	} catch {
+		return false;
+	}
+}
+
+function resolveFrontendPort(worktreePath: string): number {
+	// 1. Check env files for FRONTEND_PORT
+	const envPaths = [
+		join(worktreePath, "frontend", ".env.local"),
+		join(worktreePath, "frontend", ".env"),
+		join(worktreePath, ".env"),
+	];
+	for (const envPath of envPaths) {
+		try {
+			if (!existsSync(envPath)) continue;
+			const content = readFileSync(envPath, "utf-8");
+			const match = content.match(/^FRONTEND_PORT\s*=\s*(\d+)/m);
+			if (match) return Number.parseInt(match[1], 10);
+		} catch {
+			// continue
+		}
+	}
+
+	// 2. Parse vite.config.ts for default port
+	try {
+		const viteConfig = join(worktreePath, "frontend", "vite.config.ts");
+		if (existsSync(viteConfig)) {
+			const content = readFileSync(viteConfig, "utf-8");
+			const match = content.match(/FRONTEND_PORT\s*\?\?\s*['"](\d+)['"]/);
+			if (match) return Number.parseInt(match[1], 10);
+		}
+	} catch {
+		// continue
+	}
+
+	return 8080;
+}
+
+interface ServiceDef {
+	name: string;
+	port: number;
+	processPattern: string;
+	restartCommand: string;
+}
+
+function getServices(worktreePath: string): ServiceDef[] {
+	const frontendPort = resolveFrontendPort(worktreePath);
+	return [
+		{
+			name: "Supabase",
+			port: 54322,
+			processPattern: "supabase",
+			restartCommand: "supabase start",
+		},
+		{
+			name: "Docker",
+			port: 2375,
+			processPattern: "com.docker",
+			restartCommand: "open -a Docker",
+		},
+		{
+			name: "Frontend",
+			port: frontendPort,
+			processPattern: `vite.*${frontendPort}`,
+			restartCommand: "npm run frontend:dev",
+		},
+		{
+			name: "Droplet",
+			port: 8787,
+			processPattern: "droplet.*8787",
+			restartCommand: "npm run droplet:start",
+		},
+	];
+}
+
+// Track when services were first seen running
+const serviceStartTimes = new Map<string, number>();
+
+export const createServiceHealthRouter = () => {
+	return router({
+		getServiceHealth: publicProcedure
+			.input(z.object({ worktreePath: z.string() }))
+			.query(async ({ input }): Promise<ServiceStatus[]> => {
+				const services = getServices(input.worktreePath);
+				const now = Date.now();
+				const results = await Promise.all(
+					services.map(async (service) => {
+						const [portUp, procAlive] = await Promise.all([
+							checkPort(service.port),
+							isProcessAlive(service.processPattern),
+						]);
+						const running = portUp || procAlive;
+
+						if (running) {
+							if (!serviceStartTimes.has(service.name)) {
+								serviceStartTimes.set(service.name, now);
+							}
+						} else {
+							serviceStartTimes.delete(service.name);
+						}
+
+						const startTime = serviceStartTimes.get(service.name);
+						return {
+							name: service.name,
+							port: service.port,
+							running,
+							processAlive: procAlive,
+							uptimeSeconds: startTime
+								? Math.floor((now - startTime) / 1000)
+								: null,
+							restartCommand: service.restartCommand,
+						};
+					}),
+				);
+				return results;
+			}),
+
+		restartService: publicProcedure
+			.input(
+				z.object({
+					worktreePath: z.string(),
+					serviceName: z.string(),
+				}),
+			)
+			.mutation(async ({ input }) => {
+				const services = getServices(input.worktreePath);
+				const service = services.find((s) => s.name === input.serviceName);
+				if (!service) {
+					return { success: false, error: "Unknown service" };
+				}
+				try {
+					await execAsync(service.restartCommand, {
+						cwd: input.worktreePath,
+						timeout: 30_000,
+					});
+					serviceStartTimes.delete(service.name);
+					return { success: true };
+				} catch (error) {
+					return {
+						success: false,
+						error: error instanceof Error ? error.message : "Restart failed",
+					};
+				}
+			}),
+	});
+};

--- a/apps/desktop/src/lib/trpc/routers/arch-one/slot-manager.ts
+++ b/apps/desktop/src/lib/trpc/routers/arch-one/slot-manager.ts
@@ -1,0 +1,148 @@
+import { exec } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import simpleGit from "simple-git";
+import { z } from "zod";
+import { publicProcedure, router } from "../..";
+
+const execAsync = promisify(exec);
+
+const REGISTRY_PATH = join(homedir(), ".alike-dev-slots.json");
+
+interface SlotEntry {
+	path: string;
+	tmux_session: string;
+	dead_since?: number;
+}
+
+interface Registry {
+	slots: Record<string, SlotEntry | null>;
+}
+
+interface SlotInfo {
+	slot: number;
+	path: string | null;
+	tmuxSession: string | null;
+	branch: string | null;
+	alive: boolean;
+}
+
+async function isTmuxAlive(session: string): Promise<boolean> {
+	try {
+		await execAsync(`tmux has-session -t ${session} 2>/dev/null`);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function getBranch(path: string): Promise<string | null> {
+	try {
+		const git = simpleGit(path);
+		return (await git.branch()).current || null;
+	} catch {
+		return null;
+	}
+}
+
+export const createSlotManagerRouter = () => {
+	return router({
+		getSlotStatus: publicProcedure.query(async (): Promise<SlotInfo[]> => {
+			let registry: Registry;
+			try {
+				const text = await readFile(REGISTRY_PATH, "utf-8");
+				registry = JSON.parse(text) as Registry;
+			} catch {
+				return Array.from({ length: 4 }, (_, i) => ({
+					slot: i + 1,
+					path: null,
+					tmuxSession: null,
+					branch: null,
+					alive: false,
+				}));
+			}
+
+			const slots: SlotInfo[] = [];
+			for (let i = 1; i <= 4; i++) {
+				const entry = registry.slots[String(i)];
+				if (entry) {
+					const [alive, branch] = await Promise.all([
+						isTmuxAlive(entry.tmux_session),
+						getBranch(entry.path),
+					]);
+					slots.push({
+						slot: i,
+						path: entry.path,
+						tmuxSession: entry.tmux_session,
+						branch,
+						alive,
+					});
+				} else {
+					slots.push({
+						slot: i,
+						path: null,
+						tmuxSession: null,
+						branch: null,
+						alive: false,
+					});
+				}
+			}
+			return slots;
+		}),
+
+		allocateSlot: publicProcedure
+			.input(
+				z.object({
+					worktreePath: z.string(),
+				}),
+			)
+			.mutation(async ({ input }): Promise<{ slot: number | null; error: string | null }> => {
+				try {
+					const { stdout } = await execAsync(
+						`npx deno run --allow-all scripts/slot-alloc.ts allocate "${input.worktreePath}"`,
+						{ cwd: input.worktreePath, timeout: 30_000 },
+					);
+					// Parse the slot number from stdout (e.g. "Acquired slot 2")
+					const match = stdout.match(/slot\s+(\d+)/i);
+					return { slot: match ? Number(match[1]) : null, error: null };
+				} catch (err) {
+					const message = err instanceof Error ? err.message : "Allocation failed";
+					// Check if slots are full
+					if (message.includes("__SLOTS_FULL__") || message.includes("All slots occupied")) {
+						return { slot: null, error: "All slots are occupied" };
+					}
+					return { slot: null, error: message };
+				}
+			}),
+
+		killSlot: publicProcedure
+			.input(
+				z.object({
+					tmuxSession: z.string(),
+					path: z.string(),
+				}),
+			)
+			.mutation(async ({ input }) => {
+				// Kill the tmux session
+				try {
+					await execAsync(`tmux kill-session -t ${input.tmuxSession}`);
+				} catch {
+					// Session may already be dead
+				}
+
+				// Release the slot
+				try {
+					await execAsync(
+						`npx deno run --allow-all scripts/slot-alloc.ts release "${input.path}" --force`,
+						{ cwd: input.path, timeout: 15_000 },
+					);
+				} catch {
+					// Best effort — slot may already be freed
+				}
+
+				return { killed: true };
+			}),
+	});
+};

--- a/apps/desktop/src/lib/trpc/routers/arch-one/test-results.ts
+++ b/apps/desktop/src/lib/trpc/routers/arch-one/test-results.ts
@@ -1,0 +1,62 @@
+import { exec } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { z } from "zod";
+import { publicProcedure, router } from "../..";
+
+const execAsync = promisify(exec);
+
+interface TestResult {
+	total: number;
+	passed: number;
+	failed: number;
+	skipped: number;
+	duration: number | null;
+	lastRun: string | null;
+	failedTests: string[];
+}
+
+export const createTestResultsRouter = () => {
+	return router({
+		getTestResults: publicProcedure
+			.input(z.object({ worktreePath: z.string() }))
+			.query(async ({ input }): Promise<TestResult> => {
+				// Try to read cached test results from common output locations
+				const possiblePaths = [
+					join(input.worktreePath, "test-results.json"),
+					join(input.worktreePath, ".test-results.json"),
+					join(input.worktreePath, "coverage", "test-results.json"),
+				];
+
+				for (const resultPath of possiblePaths) {
+					try {
+						if (!existsSync(resultPath)) continue;
+						const content = readFileSync(resultPath, "utf-8");
+						const data = JSON.parse(content);
+						return {
+							total: data.numTotalTests ?? data.total ?? 0,
+							passed: data.numPassedTests ?? data.passed ?? 0,
+							failed: data.numFailedTests ?? data.failed ?? 0,
+							skipped: data.numPendingTests ?? data.skipped ?? 0,
+							duration: data.duration ?? null,
+							lastRun: data.startTime ?? data.lastRun ?? null,
+							failedTests: (data.failedTests ?? []).slice(0, 10),
+						};
+					} catch {
+						continue;
+					}
+				}
+
+				return {
+					total: 0,
+					passed: 0,
+					failed: 0,
+					skipped: 0,
+					duration: null,
+					lastRun: null,
+					failedTests: [],
+				};
+			}),
+	});
+};

--- a/apps/desktop/src/lib/trpc/routers/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/index.ts
@@ -1,6 +1,7 @@
 import type { BrowserWindow } from "electron";
 import { router } from "..";
 import { createAnalyticsRouter } from "./analytics";
+import { createArchOneRouter } from "./arch-one";
 import { createAuthRouter } from "./auth";
 import { createAutoUpdateRouter } from "./auto-update";
 import { createBrowserRouter } from "./browser/browser";
@@ -53,6 +54,7 @@ export const createAppRouter = (getWindow: () => BrowserWindow | null) => {
 		config: createConfigRouter(),
 		uiState: createUiStateRouter(),
 		ringtone: createRingtoneRouter(getWindow),
+		archOne: createArchOneRouter(),
 	});
 };
 

--- a/apps/desktop/src/renderer/components/Paywall/usePaywall.ts
+++ b/apps/desktop/src/renderer/components/Paywall/usePaywall.ts
@@ -9,9 +9,8 @@ export function usePaywall() {
 
 	const userPlan: UserPlan = (session?.session?.plan as UserPlan) ?? "free";
 
-	function hasAccess(feature: GatedFeature): boolean {
-		void feature;
-		return userPlan === "pro" || userPlan === "enterprise";
+	function hasAccess(_feature: GatedFeature): boolean {
+		return true;
 	}
 
 	function gateFeature(

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/GreptileScoreBadge.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/GreptileScoreBadge.tsx
@@ -1,0 +1,63 @@
+import { cn } from "@superset/ui/utils";
+import { LuLoader, LuShieldCheck } from "react-icons/lu";
+import { STROKE_WIDTH } from "../constants";
+
+interface GreptileScoreBadgeProps {
+	score: number | null;
+	reviewing: boolean;
+	className?: string;
+}
+
+function getScoreColor(score: number) {
+	if (score >= 4) return { text: "text-emerald-500", bg: "bg-emerald-500/10" };
+	if (score >= 3) return { text: "text-yellow-500", bg: "bg-yellow-500/10" };
+	if (score >= 2) return { text: "text-orange-500", bg: "bg-orange-500/10" };
+	return { text: "text-destructive", bg: "bg-destructive/10" };
+}
+
+export function GreptileScoreBadge({
+	score,
+	reviewing,
+	className,
+}: GreptileScoreBadgeProps) {
+	if (!reviewing && score === null) return null;
+
+	const iconClass = "w-3 h-3";
+
+	if (reviewing) {
+		return (
+			<div
+				className={cn(
+					"flex items-center justify-center gap-1 px-1.5 py-0.5 rounded-md text-[10px] leading-none shrink-0",
+					"bg-muted",
+					className,
+				)}
+			>
+				<LuLoader
+					className={cn(iconClass, "text-muted-foreground animate-spin")}
+					strokeWidth={STROKE_WIDTH}
+				/>
+			</div>
+		);
+	}
+
+	const colors = getScoreColor(score as number);
+
+	return (
+		<div
+			className={cn(
+				"flex items-center justify-center gap-1 px-1.5 py-0.5 rounded-md text-[10px] leading-none shrink-0",
+				colors.bg,
+				className,
+			)}
+		>
+			<LuShieldCheck
+				className={cn(iconClass, colors.text)}
+				strokeWidth={STROKE_WIDTH}
+			/>
+			<span className={cn("font-mono tabular-nums leading-none", colors.text)}>
+				{score}
+			</span>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -22,6 +22,7 @@ import {
 	GITHUB_STATUS_STALE_TIME,
 	MAX_KEYBOARD_SHORTCUT_INDEX,
 } from "./constants";
+import { GreptileScoreBadge } from "./GreptileScoreBadge";
 import { useWorkspaceDnD } from "./useWorkspaceDnD";
 import { WorkspaceAheadBehind } from "./WorkspaceAheadBehind";
 import { WorkspaceContextMenu } from "./WorkspaceContextMenu";
@@ -144,6 +145,14 @@ export function WorkspaceListItem({
 				refetchInterval: hasHovered ? GITHUB_STATUS_STALE_TIME : false,
 			},
 		);
+
+	const { data: greptileData } = electronTrpc.archOne.getGreptileScore.useQuery(
+		{ worktreePath: worktreePath ?? "" },
+		{
+			enabled: hasHovered && !!worktreePath,
+			staleTime: GITHUB_STATUS_STALE_TIME,
+		},
+	);
 
 	useBranchSyncInvalidation({
 		gitBranch: localChanges?.branch,
@@ -398,21 +407,29 @@ export function WorkspaceListItem({
 							</div>
 						</div>
 
-						{(showBranchSubtitle || pr) && (
+						{(showBranchSubtitle || pr || greptileData) && (
 							<div className="flex items-center gap-2 text-[11px] w-full">
 								{showBranchSubtitle && (
 									<span className="text-muted-foreground/60 truncate font-mono leading-tight">
 										{branch}
 									</span>
 								)}
-								{pr && (
-									<WorkspaceStatusBadge
-										state={pr.state}
-										prNumber={pr.number}
-										prUrl={pr.url}
-										className="ml-auto"
-									/>
-								)}
+								<div className="flex items-center gap-1 ml-auto">
+									{greptileData &&
+										(greptileData.score !== null || greptileData.reviewing) && (
+											<GreptileScoreBadge
+												score={greptileData.score}
+												reviewing={greptileData.reviewing}
+											/>
+										)}
+									{pr && (
+										<WorkspaceStatusBadge
+											state={pr.state}
+											prNumber={pr.number}
+											prUrl={pr.url}
+										/>
+									)}
+								</div>
 							</div>
 						)}
 					</div>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/ArchOneView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/ArchOneView.tsx
@@ -1,0 +1,216 @@
+import { useParams } from "@tanstack/react-router";
+import { useCallback } from "react";
+import { LuPlay, LuRadar, LuRefreshCw, LuUnplug } from "react-icons/lu";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useTabsStore } from "renderer/stores/tabs/store";
+import { EnvSyncSection } from "./components/EnvSyncSection";
+import { GitStatusSection } from "./components/GitStatusSection";
+import { GreptileSection } from "./components/GreptileSection";
+import { SeedSection } from "./components/SeedSection";
+import { ServicesSection } from "./components/ServicesSection";
+import { SlotManagerSection } from "./components/SlotManagerSection";
+import { TestResultsSection } from "./components/TestResultsSection";
+import { useEnvSync } from "./hooks/useEnvSync";
+import { useGitStatus } from "./hooks/useGitStatus";
+import { useFixStatus, useGreptileScore } from "./hooks/useGreptileScore";
+import { useSeededUsers } from "./hooks/useSeededUsers";
+import { useServiceHealth } from "./hooks/useServiceHealth";
+import { useTestResults } from "./hooks/useTestResults";
+
+export type FixPhase =
+	| "idle"
+	| "fixing"
+	| "waiting-for-review"
+	| "done"
+	| "max-reached"
+	| "stopped";
+
+export interface FixLoopState {
+	phase: FixPhase;
+	iteration: number;
+	lastTriggeredScore: number | null;
+}
+
+export function ArchOneView() {
+	const { workspaceId } = useParams({ strict: false });
+	const { data: workspace } = electronTrpc.workspaces.get.useQuery(
+		{ id: workspaceId ?? "" },
+		{ enabled: !!workspaceId },
+	);
+	const worktreePath = workspace?.worktreePath;
+
+	const gitStatus = useGitStatus(worktreePath);
+	const serviceHealth = useServiceHealth(worktreePath);
+	const testResults = useTestResults(worktreePath);
+	const envSync = useEnvSync(worktreePath);
+	const seededUsers = useSeededUsers(worktreePath);
+
+	// Fix loop state lives on the backend — just read it
+	const fixStatus = useFixStatus(worktreePath);
+	const fixLoop: FixLoopState = fixStatus.data ?? {
+		phase: "idle",
+		iteration: 0,
+		lastTriggeredScore: null,
+	};
+	const maxIterations = fixStatus.data?.maxIterations ?? 10;
+
+	// Poll greptile faster during active fix loop (for UI display)
+	const isFixActive =
+		fixLoop.phase === "fixing" || fixLoop.phase === "waiting-for-review";
+	const greptilePollInterval = isFixActive ? 15_000 : 30_000;
+	const greptile = useGreptileScore(worktreePath, greptilePollInterval);
+
+	const fixGreptile = electronTrpc.archOne.fixGreptile.useMutation();
+	const stopFix = electronTrpc.archOne.stopFix.useMutation();
+
+	const handleFixGreptile = useCallback(() => {
+		if (!worktreePath) return;
+		fixGreptile.mutate({
+			worktreePath,
+			reviewContent: greptile.data?.reviewContent ?? undefined,
+			prNumber: greptile.data?.prNumber ?? undefined,
+		});
+	}, [
+		worktreePath,
+		fixGreptile,
+		greptile.data?.reviewContent,
+		greptile.data?.prNumber,
+	]);
+
+	const handleStopFix = useCallback(() => {
+		if (!worktreePath) return;
+		stopFix.mutate({ worktreePath });
+	}, [worktreePath, stopFix]);
+
+	// Terminal spawn helpers
+	const addPane = useTabsStore((s) => s.addPane);
+	const tabs = useTabsStore((s) => s.tabs);
+	const terminalWrite = electronTrpc.terminal.write.useMutation();
+	const spawnCommand = useCallback(
+		(command: string) => {
+			if (!workspaceId) return;
+			const currentTab = tabs.find((t) => t.workspaceId === workspaceId);
+			if (!currentTab) return;
+
+			const paneId = addPane(currentTab.id);
+			if (paneId) {
+				setTimeout(() => {
+					terminalWrite.mutate({ paneId, data: `${command}\r` });
+				}, 500);
+			}
+		},
+		[workspaceId, tabs, addPane, terminalWrite],
+	);
+
+	const handleRerunTests = useCallback(() => {
+		spawnCommand("npm run test:fast");
+	}, [spawnCommand]);
+
+	const handleRestartService = useCallback(
+		(restartCommand: string) => {
+			spawnCommand(restartCommand);
+		},
+		[spawnCommand],
+	);
+
+	const handleEnvSync = useCallback(() => {
+		if (!workspaceId) return;
+		const currentTab = tabs.find((t) => t.workspaceId === workspaceId);
+		if (!currentTab) return;
+
+		const paneId = addPane(currentTab.id);
+		if (paneId) {
+			setTimeout(() => {
+				terminalWrite.mutate({
+					paneId,
+					data: "npm run dev:sync\r",
+				});
+			}, 500);
+		}
+	}, [workspaceId, tabs, addPane, terminalWrite]);
+
+	if (!worktreePath) {
+		return (
+			<div className="flex flex-col items-center justify-center h-full text-muted-foreground text-sm p-4">
+				<LuRadar className="size-8 mb-2 opacity-50" />
+				<span>Select a workspace</span>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col overflow-y-auto h-full">
+			<div className="flex items-center gap-2 px-3 py-2 border-b border-border">
+				<LuRadar className="size-4 text-primary" />
+				<span className="text-sm font-semibold">Alike GUI</span>
+				<div className="ml-auto flex items-center gap-1">
+					<button
+						type="button"
+						title="Full Stack Dev"
+						onClick={() => spawnCommand("npm run dev")}
+						className="p-1 rounded hover:bg-accent/50 text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+					>
+						<LuPlay className="size-3.5" />
+					</button>
+					<button
+						type="button"
+						title="Dev Detached"
+						onClick={() => spawnCommand("npm run dev:detached")}
+						className="p-1 rounded hover:bg-accent/50 text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+					>
+						<LuUnplug className="size-3.5" />
+					</button>
+					<button
+						type="button"
+						title="Reset DB"
+						onClick={() => spawnCommand("npm run dev:resetdb")}
+						className="p-1 rounded hover:bg-accent/50 text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+					>
+						<LuRefreshCw className="size-3.5" />
+					</button>
+				</div>
+			</div>
+
+			<div className="flex-1 overflow-y-auto">
+				<SlotManagerSection
+					worktreePath={worktreePath}
+					onSpawnCommand={spawnCommand}
+				/>
+				<GitStatusSection
+					data={gitStatus.data}
+					isLoading={gitStatus.isLoading}
+				/>
+				<GreptileSection
+					data={greptile.data}
+					isLoading={greptile.isLoading}
+					onRefresh={greptile.refetch}
+					onFixGreptile={handleFixGreptile}
+					onStopFix={handleStopFix}
+					fixLoop={fixLoop}
+					maxIterations={maxIterations}
+				/>
+				<ServicesSection
+					data={serviceHealth.data}
+					isLoading={serviceHealth.isLoading}
+					onRestart={handleRestartService}
+				/>
+				<EnvSyncSection
+					data={envSync.data}
+					isLoading={envSync.isLoading}
+					onSync={handleEnvSync}
+				/>
+				<TestResultsSection
+					data={testResults.data}
+					isLoading={testResults.isLoading}
+					onRerun={handleRerunTests}
+				/>
+				<SeedSection
+					onRunSeed={spawnCommand}
+					seededUsers={seededUsers.data}
+					isLoadingUsers={seededUsers.isLoading}
+					onRefreshUsers={seededUsers.refetch}
+				/>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/components/EnvSyncSection/EnvSyncSection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/components/EnvSyncSection/EnvSyncSection.tsx
@@ -1,0 +1,139 @@
+import { Button } from "@superset/ui/button";
+import { cn } from "@superset/ui/utils";
+import { useState } from "react";
+import {
+	LuCheck,
+	LuChevronDown,
+	LuChevronRight,
+	LuKeyRound,
+} from "react-icons/lu";
+
+interface EnvSyncSectionProps {
+	data:
+		| {
+				files: {
+					name: string;
+					relativePath: string;
+					exists: boolean;
+					hash: string | null;
+					lastModified: string | null;
+					keyCount: number;
+				}[];
+				inSync: boolean;
+				staleFiles: string[];
+		  }
+		| undefined;
+	isLoading: boolean;
+	onSync: () => void;
+}
+
+function formatRelativeTime(dateStr: string | null): string {
+	if (!dateStr) return "unknown";
+	const now = Date.now();
+	const then = new Date(dateStr).getTime();
+	const diffMs = now - then;
+	const diffMin = Math.floor(diffMs / 60_000);
+	if (diffMin < 1) return "just now";
+	if (diffMin < 60) return `${diffMin}m ago`;
+	const diffHr = Math.floor(diffMin / 60);
+	if (diffHr < 24) return `${diffHr}h ago`;
+	const diffDays = Math.floor(diffHr / 24);
+	return `${diffDays}d ago`;
+}
+
+export function EnvSyncSection({
+	data,
+	isLoading,
+	onSync,
+}: EnvSyncSectionProps) {
+	const [collapsed, setCollapsed] = useState(false);
+
+	return (
+		<div className="overflow-hidden border-t border-border">
+			<button
+				type="button"
+				onClick={() => setCollapsed(!collapsed)}
+				className={cn(
+					"flex w-full items-center gap-1.5 px-3 py-2",
+					"text-xs font-medium uppercase tracking-wider text-muted-foreground",
+					"hover:bg-accent/30 cursor-pointer transition-colors",
+				)}
+			>
+				{collapsed ? (
+					<LuChevronRight className="size-3 shrink-0" />
+				) : (
+					<LuChevronDown className="size-3 shrink-0" />
+				)}
+				<LuKeyRound className="size-3 shrink-0" />
+				<span>Env Status</span>
+			</button>
+
+			{!collapsed && (
+				<div className="px-3 py-2 text-sm">
+					{isLoading ? (
+						<p className="text-muted-foreground">Loading...</p>
+					) : !data ? (
+						<p className="text-muted-foreground">No env data available</p>
+					) : data.inSync ? (
+						<div className="flex items-center gap-1.5 text-green-500">
+							<LuCheck className="size-3 shrink-0" />
+							<span>All in sync</span>
+							<span className="text-muted-foreground">
+								({data.files.length} files)
+							</span>
+						</div>
+					) : (
+						<div className="space-y-1.5">
+							{data.files.map((file) => {
+								const isStale = data.staleFiles.includes(file.name);
+								return (
+									<div
+										key={file.relativePath}
+										className="flex items-center gap-2"
+									>
+										<div
+											className={cn(
+												"size-2 rounded-full shrink-0",
+												!file.exists
+													? "bg-red-500"
+													: isStale
+														? "bg-orange-400"
+														: "bg-green-500",
+											)}
+										/>
+										<span className="truncate">{file.name}</span>
+										<span className="text-muted-foreground text-xs shrink-0">
+											{file.keyCount} keys
+										</span>
+										{file.hash && (
+											<span className="font-mono text-muted-foreground text-xs shrink-0">
+												{file.hash.slice(0, 6)}
+											</span>
+										)}
+										<span className="text-muted-foreground text-xs shrink-0 ml-auto">
+											{formatRelativeTime(file.lastModified)}
+										</span>
+										{isStale && (
+											<span className="text-xs text-orange-400 bg-orange-400/10 rounded px-1 shrink-0">
+												stale
+											</span>
+										)}
+									</div>
+								);
+							})}
+
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={onSync}
+								className="mt-2 gap-1.5"
+							>
+								Sync All
+							</Button>
+						</div>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/components/EnvSyncSection/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/components/EnvSyncSection/index.ts
@@ -1,0 +1,1 @@
+export { EnvSyncSection } from "./EnvSyncSection";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/components/GitStatusSection/GitStatusSection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/components/GitStatusSection/GitStatusSection.tsx
@@ -1,0 +1,99 @@
+import { cn } from "@superset/ui/utils";
+import { useState } from "react";
+import {
+	LuChevronDown,
+	LuChevronRight,
+	LuGitBranch,
+} from "react-icons/lu";
+
+interface GitStatusSectionProps {
+	data:
+		| {
+				branch: string | null;
+				ahead: number;
+				behind: number;
+				staged: number;
+				modified: number;
+				untracked: number;
+				stashes: number;
+				hasConflicts: boolean;
+				lastCommitMessage: string | null;
+				lastCommitDate: string | null;
+		  }
+		| undefined;
+	isLoading: boolean;
+}
+
+export function GitStatusSection({ data, isLoading }: GitStatusSectionProps) {
+	const [collapsed, setCollapsed] = useState(false);
+
+	return (
+		<div className="overflow-hidden border-t border-border">
+			<button
+				type="button"
+				onClick={() => setCollapsed(!collapsed)}
+				className={cn(
+					"flex w-full items-center gap-1.5 px-3 py-2",
+					"text-xs font-medium uppercase tracking-wider text-muted-foreground",
+					"hover:bg-accent/30 cursor-pointer transition-colors",
+				)}
+			>
+				{collapsed ? (
+					<LuChevronRight className="size-3 shrink-0" />
+				) : (
+					<LuChevronDown className="size-3 shrink-0" />
+				)}
+				<LuGitBranch className="size-3 shrink-0" />
+				<span>Git Status</span>
+				{data?.branch && (
+					<span className="ml-auto text-[10px] font-mono bg-muted px-1.5 py-0.5 rounded-full truncate max-w-[120px]">
+						{data.branch}
+					</span>
+				)}
+			</button>
+
+			{!collapsed && (
+				<div className="px-3 py-2 text-sm">
+					{isLoading ? (
+						<p className="text-muted-foreground">Loading...</p>
+					) : !data ? (
+						<p className="text-muted-foreground">No git data</p>
+					) : (
+						<div className="space-y-1">
+							{data.hasConflicts && (
+								<div className="text-destructive text-xs font-medium">
+									Merge conflicts detected
+								</div>
+							)}
+							<div className="flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
+								{data.staged > 0 && (
+									<span className="text-green-500">
+										+{data.staged} staged
+									</span>
+								)}
+								{data.modified > 0 && (
+									<span className="text-yellow-500">
+										~{data.modified} modified
+									</span>
+								)}
+								{data.untracked > 0 && (
+									<span className="text-muted-foreground">
+										{data.untracked} untracked
+									</span>
+								)}
+								{data.ahead > 0 && <span>{data.ahead} ahead</span>}
+								{data.behind > 0 && <span>{data.behind} behind</span>}
+								{data.stashes > 0 && <span>{data.stashes} stashed</span>}
+							</div>
+							{data.lastCommitMessage && (
+								<p className="text-xs text-muted-foreground/70 truncate">
+									{data.lastCommitMessage}
+								</p>
+							)}
+						</div>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/components/GitStatusSection/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/components/GitStatusSection/index.ts
@@ -1,0 +1,1 @@
+export { GitStatusSection } from "./GitStatusSection";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/components/GreptileSection/GreptileSection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/components/GreptileSection/GreptileSection.tsx
@@ -1,0 +1,381 @@
+import { cn } from "@superset/ui/utils";
+import { useState } from "react";
+import {
+	LuChevronDown,
+	LuChevronRight,
+	LuExternalLink,
+	LuLoader,
+	LuPlay,
+	LuRefreshCw,
+	LuShield,
+	LuSquare,
+} from "react-icons/lu";
+import type { FixLoopState } from "../../ArchOneView";
+
+interface GreptileData {
+	score: number | null;
+	maxScore: number;
+	summary: string | null;
+	issues: string[];
+	prNumber: number | null;
+	prTitle: string | null;
+	prUrl: string | null;
+	reviewing: boolean;
+	error: string | null;
+}
+
+interface GreptileSectionProps {
+	data: GreptileData | undefined;
+	isLoading: boolean;
+	onRefresh: () => void;
+	onFixGreptile: () => void;
+	onStopFix: () => void;
+	fixLoop: FixLoopState;
+	maxIterations: number;
+}
+
+function ScoreBar({ score, max }: { score: number; max: number }) {
+	const percentage = (score / max) * 100;
+	const color =
+		score >= 4
+			? "bg-green-500"
+			: score >= 3
+				? "bg-yellow-500"
+				: score >= 2
+					? "bg-orange-500"
+					: "bg-red-500";
+
+	return (
+		<div className="flex items-center gap-2">
+			<div className="flex-1 h-2 rounded-full bg-accent/50 overflow-hidden">
+				<div
+					className={cn("h-full rounded-full transition-all", color)}
+					style={{ width: `${percentage}%` }}
+				/>
+			</div>
+			<span
+				className={cn(
+					"text-sm font-bold shrink-0",
+					score >= 4
+						? "text-green-500"
+						: score >= 3
+							? "text-yellow-500"
+							: score >= 2
+								? "text-orange-500"
+								: "text-red-500",
+				)}
+			>
+				{score}/{max}
+			</span>
+		</div>
+	);
+}
+
+function ScoreLabel({ score }: { score: number }) {
+	if (score >= 5)
+		return <span className="text-green-400">Production ready</span>;
+	if (score >= 4)
+		return <span className="text-green-400">Minor polish needed</span>;
+	if (score >= 3)
+		return <span className="text-yellow-400">Implementation issues</span>;
+	if (score >= 2)
+		return <span className="text-orange-400">Significant bugs</span>;
+	return <span className="text-red-400">Critical problems</span>;
+}
+
+function FixLoopBadge({
+	fixLoop,
+	maxIterations,
+}: {
+	fixLoop: FixLoopState;
+	maxIterations: number;
+}) {
+	if (fixLoop.phase === "idle") return null;
+
+	if (fixLoop.phase === "fixing") {
+		return (
+			<div className="flex items-center gap-1.5 text-xs text-blue-400 bg-blue-500/10 rounded px-2 py-1">
+				<LuLoader className="size-3 animate-spin" />
+				<span>
+					Claude is fixing ({fixLoop.iteration}/{maxIterations})
+				</span>
+			</div>
+		);
+	}
+
+	if (fixLoop.phase === "waiting-for-review") {
+		return (
+			<div className="flex items-center gap-1.5 text-xs text-yellow-400 bg-yellow-500/10 rounded px-2 py-1">
+				<LuLoader className="size-3 animate-spin" />
+				<span>
+					Waiting for Greptile re-review ({fixLoop.iteration}/{maxIterations})
+				</span>
+			</div>
+		);
+	}
+
+	if (fixLoop.phase === "done") {
+		return (
+			<div className="text-xs text-green-400 bg-green-500/10 rounded px-2 py-1">
+				Fixed in {fixLoop.iteration}{" "}
+				{fixLoop.iteration === 1 ? "iteration" : "iterations"}
+			</div>
+		);
+	}
+
+	if (fixLoop.phase === "max-reached") {
+		return (
+			<div className="text-xs text-orange-400 bg-orange-500/10 rounded px-2 py-1">
+				Max iterations reached ({maxIterations})
+			</div>
+		);
+	}
+
+	if (fixLoop.phase === "stopped") {
+		return (
+			<div className="text-xs text-muted-foreground bg-accent/30 rounded px-2 py-1">
+				Stopped after {fixLoop.iteration}{" "}
+				{fixLoop.iteration === 1 ? "iteration" : "iterations"}
+			</div>
+		);
+	}
+
+	return null;
+}
+
+export function GreptileSection({
+	data,
+	isLoading,
+	onRefresh,
+	onFixGreptile,
+	onStopFix,
+	fixLoop,
+	maxIterations,
+}: GreptileSectionProps) {
+	const [collapsed, setCollapsed] = useState(false);
+
+	const isFixActive =
+		fixLoop.phase === "fixing" || fixLoop.phase === "waiting-for-review";
+
+	return (
+		<div className="overflow-hidden border-t border-border">
+			<button
+				type="button"
+				onClick={() => setCollapsed(!collapsed)}
+				className={cn(
+					"flex w-full items-center gap-1.5 px-3 py-2",
+					"text-xs font-medium uppercase tracking-wider text-muted-foreground",
+					"hover:bg-accent/30 cursor-pointer transition-colors",
+				)}
+			>
+				{collapsed ? (
+					<LuChevronRight className="size-3 shrink-0" />
+				) : (
+					<LuChevronDown className="size-3 shrink-0" />
+				)}
+				<LuShield className="size-3 shrink-0" />
+				<span>Greptile</span>
+				{fixLoop.phase === "fixing" && (
+					<span className="ml-auto inline-flex items-center gap-1 text-[10px] text-blue-400">
+						<LuLoader className="size-2.5 animate-spin" />
+						Fixing {fixLoop.iteration}/{maxIterations}
+					</span>
+				)}
+				{fixLoop.phase === "waiting-for-review" && (
+					<span className="ml-auto inline-flex items-center gap-1 text-[10px] text-yellow-400">
+						<LuLoader className="size-2.5 animate-spin" />
+						Re-reviewing
+					</span>
+				)}
+				{!isFixActive && data?.reviewing && (
+					<span className="ml-auto inline-flex items-center gap-1 text-[10px] text-yellow-400">
+						<LuLoader className="size-2.5 animate-spin" />
+						Reviewing
+					</span>
+				)}
+				{data?.score !== null &&
+					data?.score !== undefined &&
+					!data.reviewing &&
+					!isFixActive && (
+						<span
+							className={cn(
+								"ml-auto text-xs font-bold",
+								data.score >= 4
+									? "text-green-500"
+									: data.score >= 3
+										? "text-yellow-500"
+										: "text-red-500",
+							)}
+						>
+							{data.score}/5
+						</span>
+					)}
+			</button>
+
+			{!collapsed && (
+				<div className="px-3 py-2 text-sm space-y-2">
+					{isLoading ? (
+						<p className="text-muted-foreground">Loading...</p>
+					) : !data || data.error ? (
+						<div className="space-y-1.5">
+							<p className="text-muted-foreground text-xs">
+								{data?.error ?? "No data"}
+							</p>
+							{data?.prNumber && data.prUrl && (
+								<a
+									href={data.prUrl}
+									target="_blank"
+									rel="noreferrer"
+									className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+								>
+									PR #{data.prNumber}
+									<LuExternalLink className="size-3" />
+								</a>
+							)}
+							<button
+								type="button"
+								onClick={onRefresh}
+								className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+							>
+								<LuRefreshCw className="size-3" />
+								Refresh
+							</button>
+						</div>
+					) : data.reviewing && !isFixActive ? (
+						<div className="space-y-2">
+							{data.prNumber && (
+								<div className="flex items-center gap-1.5 text-xs">
+									<a
+										href={data.prUrl ?? "#"}
+										target="_blank"
+										rel="noreferrer"
+										className="text-primary hover:underline truncate"
+									>
+										#{data.prNumber} {data.prTitle}
+									</a>
+								</div>
+							)}
+							<div className="flex items-center gap-2 text-xs text-yellow-400">
+								<LuLoader className="size-3 animate-spin" />
+								<span>Greptile is reviewing this PR...</span>
+							</div>
+							<div className="flex items-center gap-3">
+								{data.prUrl && (
+									<a
+										href={data.prUrl}
+										target="_blank"
+										rel="noreferrer"
+										className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+									>
+										View PR
+										<LuExternalLink className="size-3" />
+									</a>
+								)}
+								<button
+									type="button"
+									onClick={onRefresh}
+									className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+								>
+									<LuRefreshCw className="size-3" />
+									Refresh
+								</button>
+							</div>
+						</div>
+					) : (
+						<div className="space-y-2">
+							{/* PR info */}
+							{data.prNumber && (
+								<div className="flex items-center gap-1.5 text-xs">
+									<a
+										href={data.prUrl ?? "#"}
+										target="_blank"
+										rel="noreferrer"
+										className="text-primary hover:underline truncate"
+									>
+										#{data.prNumber} {data.prTitle}
+									</a>
+								</div>
+							)}
+
+							{/* Score bar */}
+							{data.score !== null && (
+								<>
+									<ScoreBar score={data.score} max={data.maxScore} />
+									<p className="text-xs">
+										<ScoreLabel score={data.score} />
+									</p>
+								</>
+							)}
+
+							{/* Fix loop status */}
+							<FixLoopBadge fixLoop={fixLoop} maxIterations={maxIterations} />
+
+							{/* Summary */}
+							{data.summary && (
+								<p className="text-xs text-muted-foreground line-clamp-3">
+									{data.summary}
+								</p>
+							)}
+
+							{/* Issues */}
+							{data.issues && data.issues.length > 0 && (
+								<ul className="space-y-1 text-xs text-muted-foreground">
+									{data.issues.map((issue) => (
+										<li key={issue} className="flex gap-1.5 items-start">
+											<span className="text-red-400 shrink-0 mt-0.5">
+												&bull;
+											</span>
+											<span>{issue}</span>
+										</li>
+									))}
+								</ul>
+							)}
+
+							{/* Actions */}
+							<div className="flex items-center gap-3 flex-wrap">
+								{data.prUrl && (
+									<a
+										href={data.prUrl}
+										target="_blank"
+										rel="noreferrer"
+										className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+									>
+										View PR
+										<LuExternalLink className="size-3" />
+									</a>
+								)}
+								<button
+									type="button"
+									onClick={onRefresh}
+									className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+								>
+									<LuRefreshCw className="size-3" />
+									Refresh
+								</button>
+								{isFixActive ? (
+									<button
+										type="button"
+										onClick={onStopFix}
+										className="flex items-center gap-1 text-xs transition-colors cursor-pointer font-medium text-red-400 hover:text-red-300"
+									>
+										<LuSquare className="size-3" />
+										Stop
+									</button>
+								) : (
+									<button
+										type="button"
+										onClick={onFixGreptile}
+										className="flex items-center gap-1 text-xs transition-colors cursor-pointer font-medium text-primary hover:text-primary/80"
+									>
+										<LuPlay className="size-3" />
+										Fix with Claude
+									</button>
+								)}
+							</div>
+						</div>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/components/GreptileSection/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/components/GreptileSection/index.ts
@@ -1,0 +1,1 @@
+export { GreptileSection } from "./GreptileSection";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/components/QuickActionsSection/QuickActionsSection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/components/QuickActionsSection/QuickActionsSection.tsx
@@ -1,0 +1,100 @@
+import { Button } from "@superset/ui/button";
+import { cn } from "@superset/ui/utils";
+import { useParams } from "@tanstack/react-router";
+import { useState } from "react";
+import type { IconType } from "react-icons/lib";
+import {
+	LuChevronDown,
+	LuChevronRight,
+	LuPlay,
+	LuRefreshCw,
+	LuZap,
+} from "react-icons/lu";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useTabsStore } from "renderer/stores/tabs/store";
+
+interface QuickAction {
+	label: string;
+	command: string;
+	icon: IconType;
+}
+
+const QUICK_ACTIONS: QuickAction[] = [
+	{ label: "Full Stack Dev", command: "npm run dev", icon: LuPlay },
+	{
+		label: "Dev Detached",
+		command: "npm run dev:detached",
+		icon: LuPlay,
+	},
+	{ label: "Reset DB", command: "npm run dev:resetdb", icon: LuRefreshCw },
+];
+
+export function QuickActionsSection() {
+	const [collapsed, setCollapsed] = useState(false);
+	const { workspaceId } = useParams({ strict: false });
+	const addPane = useTabsStore((s) => s.addPane);
+	const tabs = useTabsStore((s) => s.tabs);
+	const terminalWrite = electronTrpc.terminal.write.useMutation();
+
+	const handleAction = (command: string) => {
+		if (!workspaceId) return;
+
+		const currentTab = tabs.find((t) => t.workspaceId === workspaceId);
+		if (!currentTab) return;
+
+		const paneId = addPane(currentTab.id);
+		if (paneId) {
+			// Small delay to let the terminal initialize before writing
+			setTimeout(() => {
+				terminalWrite.mutate({
+					paneId,
+					data: `${command}\r`,
+				});
+			}, 500);
+		}
+	};
+
+	return (
+		<div className="overflow-hidden border-t border-border">
+			<button
+				type="button"
+				onClick={() => setCollapsed(!collapsed)}
+				className={cn(
+					"flex w-full items-center gap-1.5 px-3 py-2",
+					"text-xs font-medium uppercase tracking-wider text-muted-foreground",
+					"hover:bg-accent/30 cursor-pointer transition-colors",
+				)}
+			>
+				{collapsed ? (
+					<LuChevronRight className="size-3 shrink-0" />
+				) : (
+					<LuChevronDown className="size-3 shrink-0" />
+				)}
+				<LuZap className="size-3 shrink-0" />
+				<span>Quick Actions</span>
+			</button>
+
+			{!collapsed && (
+				<div className="px-3 py-2">
+					<div className="flex flex-wrap gap-1.5">
+						{QUICK_ACTIONS.map((action) => {
+							const Icon = action.icon;
+							return (
+								<Button
+									key={action.label}
+									variant="outline"
+									size="sm"
+									onClick={() => handleAction(action.command)}
+									className="gap-1.5 text-xs"
+								>
+									<Icon className="size-3" />
+									{action.label}
+								</Button>
+							);
+						})}
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/components/SeedSection/SeedSection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/components/SeedSection/SeedSection.tsx
@@ -1,0 +1,286 @@
+import { Button } from "@superset/ui/button";
+import { cn } from "@superset/ui/utils";
+import { useState } from "react";
+import {
+	LuCheck,
+	LuChevronDown,
+	LuChevronRight,
+	LuCopy,
+	LuDatabase,
+	LuPlay,
+	LuRefreshCw,
+	LuUsers,
+} from "react-icons/lu";
+
+interface SeedOption {
+	id: string;
+	name: string;
+	command: string;
+	description: string;
+	resetsDb: boolean;
+}
+
+const SEED_OPTIONS: SeedOption[] = [
+	{
+		id: "fixed",
+		name: "Fixed Test User",
+		command: "npm run seed:test-user:fixed",
+		description: "Single user with fixed credentials. Quick & deterministic.",
+		resetsDb: false,
+	},
+	{
+		id: "two-users",
+		name: "Two Users",
+		command: "npm run seed:two-users",
+		description:
+			"Two users with orgs, copilots, and conversations. Resets DB first.",
+		resetsDb: true,
+	},
+	{
+		id: "ui-demo",
+		name: "UI Demo",
+		command: "npm run seed:ui-demo",
+		description:
+			"Owner + 3 collaborators with tasks, conversations, and updates.",
+		resetsDb: false,
+	},
+	{
+		id: "comprehensive",
+		name: "Comprehensive",
+		command: "npm run seed:comprehensive",
+		description:
+			"Two fully-featured users (Alice & Bob) with shared workspace and A2A.",
+		resetsDb: false,
+	},
+	{
+		id: "world-model",
+		name: "World Model",
+		command: "npm run seed:world-model",
+		description:
+			"Rich entity graph for 3D visualization. 10 people, projects, events, locations.",
+		resetsDb: false,
+	},
+	{
+		id: "org-small",
+		name: "Org: Small",
+		command: "npm run seed:org -- --preset=small",
+		description: "5 users, minimal data. Good for quick tests.",
+		resetsDb: false,
+	},
+	{
+		id: "org-medium",
+		name: "Org: Medium",
+		command: "npm run seed:org -- --preset=medium",
+		description: "15 users with moderate data. Integration testing.",
+		resetsDb: false,
+	},
+	{
+		id: "org-large",
+		name: "Org: Large",
+		command: "npm run seed:org -- --preset=large",
+		description: "30 users with heavy data. Load testing.",
+		resetsDb: false,
+	},
+	{
+		id: "org-demo",
+		name: "Org: Demo",
+		command: "npm run seed:org -- --preset=demo",
+		description: "10 users with external contacts. Demo environments.",
+		resetsDb: false,
+	},
+	{
+		id: "resetdb",
+		name: "Reset DB",
+		command: "npm run dev:resetdb",
+		description: "Full database reset + restart services + re-seed RAG data.",
+		resetsDb: true,
+	},
+];
+
+interface SeededUser {
+	email: string;
+	name: string;
+	createdAt: string;
+}
+
+interface SeedSectionProps {
+	onRunSeed: (command: string) => void;
+	seededUsers:
+		| { users: SeededUser[]; total: number; error: string | null }
+		| undefined;
+	isLoadingUsers: boolean;
+	onRefreshUsers: () => void;
+}
+
+function CopyableText({
+	text,
+	className,
+}: {
+	text: string;
+	className?: string;
+}) {
+	const [copied, setCopied] = useState(false);
+
+	const handleCopy = () => {
+		navigator.clipboard.writeText(text);
+		setCopied(true);
+		setTimeout(() => setCopied(false), 1500);
+	};
+
+	return (
+		<button
+			type="button"
+			onClick={handleCopy}
+			className={cn(
+				"inline-flex items-center gap-1 font-mono text-xs px-1 py-0.5 rounded",
+				"bg-accent/50 hover:bg-accent transition-colors cursor-pointer",
+				className,
+			)}
+		>
+			<span className="truncate">{text}</span>
+			{copied ? (
+				<LuCheck className="size-2.5 shrink-0 text-green-500" />
+			) : (
+				<LuCopy className="size-2.5 shrink-0 text-muted-foreground" />
+			)}
+		</button>
+	);
+}
+
+export function SeedSection({
+	onRunSeed,
+	seededUsers,
+	isLoadingUsers,
+	onRefreshUsers,
+}: SeedSectionProps) {
+	const [collapsed, setCollapsed] = useState(false);
+	const [selectedId, setSelectedId] = useState(SEED_OPTIONS[0].id);
+
+	const selected = SEED_OPTIONS.find((o) => o.id === selectedId);
+
+	const handleRun = () => {
+		if (!selected) return;
+		onRunSeed(selected.command);
+	};
+
+	const users = seededUsers?.users ?? [];
+
+	return (
+		<div className="overflow-hidden border-t border-border">
+			<button
+				type="button"
+				onClick={() => setCollapsed(!collapsed)}
+				className={cn(
+					"flex w-full items-center gap-1.5 px-3 py-2",
+					"text-xs font-medium uppercase tracking-wider text-muted-foreground",
+					"hover:bg-accent/30 cursor-pointer transition-colors",
+				)}
+			>
+				{collapsed ? (
+					<LuChevronRight className="size-3 shrink-0" />
+				) : (
+					<LuChevronDown className="size-3 shrink-0" />
+				)}
+				<LuDatabase className="size-3 shrink-0" />
+				<span>Seed</span>
+				{!collapsed && users.length > 0 && (
+					<span className="ml-auto text-[10px] text-muted-foreground">
+						{users.length} users
+					</span>
+				)}
+			</button>
+
+			{!collapsed && (
+				<div className="px-3 py-2 space-y-2">
+					{/* Dropdown + Run */}
+					<div className="flex items-center gap-1.5">
+						<select
+							value={selectedId}
+							onChange={(e) => setSelectedId(e.target.value)}
+							className={cn(
+								"flex-1 min-w-0 text-sm rounded-md px-2 py-1",
+								"bg-accent/30 border border-border",
+								"text-foreground cursor-pointer",
+								"focus:outline-none focus:ring-1 focus:ring-primary",
+							)}
+						>
+							{SEED_OPTIONS.map((option) => (
+								<option key={option.id} value={option.id}>
+									{option.name}
+									{option.resetsDb ? " (resets DB)" : ""}
+								</option>
+							))}
+						</select>
+						<Button
+							variant="default"
+							size="sm"
+							className="gap-1 text-xs shrink-0"
+							onClick={handleRun}
+						>
+							<LuPlay className="size-3" />
+							Run
+						</Button>
+					</div>
+
+					{/* Selected seed details */}
+					{selected && (
+						<p className="text-xs text-muted-foreground">
+							{selected.description}
+						</p>
+					)}
+
+					{/* Seeded users from Supabase */}
+					<div className="space-y-1.5 pt-1 border-t border-border/50">
+						<div className="flex items-center justify-between">
+							<span className="inline-flex items-center gap-1 text-xs font-medium">
+								<LuUsers className="size-3" />
+								Seeded Users
+							</span>
+							<button
+								type="button"
+								onClick={onRefreshUsers}
+								className="flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+							>
+								<LuRefreshCw
+									className={cn("size-2.5", isLoadingUsers && "animate-spin")}
+								/>
+								Refresh
+							</button>
+						</div>
+
+						{isLoadingUsers ? (
+							<p className="text-xs text-muted-foreground">Loading...</p>
+						) : seededUsers?.error ? (
+							<p className="text-xs text-muted-foreground">
+								{seededUsers.error}
+							</p>
+						) : users.length === 0 ? (
+							<p className="text-xs text-muted-foreground">
+								No users found. Run a seed to create users.
+							</p>
+						) : (
+							<div className="space-y-1 max-h-40 overflow-y-auto">
+								{users.map((user) => (
+									<div
+										key={user.email}
+										className="flex items-center gap-1.5 text-xs"
+									>
+										{user.name && (
+											<span className="shrink-0 text-[10px] px-1 py-0.5 rounded bg-blue-500/20 text-blue-400 truncate max-w-[80px]">
+												{user.name}
+											</span>
+										)}
+										<CopyableText
+											text={user.email}
+											className="flex-1 min-w-0"
+										/>
+									</div>
+								))}
+							</div>
+						)}
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/components/SeedSection/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/components/SeedSection/index.ts
@@ -1,0 +1,1 @@
+export { SeedSection } from "./SeedSection";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/components/ServicesSection/ServicesSection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/components/ServicesSection/ServicesSection.tsx
@@ -1,0 +1,112 @@
+import { Button } from "@superset/ui/button";
+import { cn } from "@superset/ui/utils";
+import { useState } from "react";
+import {
+	LuChevronDown,
+	LuChevronRight,
+	LuRotateCw,
+	LuServer,
+} from "react-icons/lu";
+
+interface ServicesSectionProps {
+	data:
+		| {
+				name: string;
+				port: number;
+				running: boolean;
+				processAlive: boolean;
+				uptimeSeconds: number | null;
+				restartCommand: string;
+		  }[]
+		| undefined;
+	isLoading: boolean;
+	onRestart: (restartCommand: string) => void;
+}
+
+function formatUptime(seconds: number | null): string {
+	if (seconds === null) return "";
+	if (seconds < 60) return "< 1m";
+	const hours = Math.floor(seconds / 3600);
+	const minutes = Math.floor((seconds % 3600) / 60);
+	if (hours > 0) return `${hours}h ${minutes}m`;
+	return `${minutes}m`;
+}
+
+export function ServicesSection({
+	data,
+	isLoading,
+	onRestart,
+}: ServicesSectionProps) {
+	const [collapsed, setCollapsed] = useState(false);
+
+	return (
+		<div className="overflow-hidden border-t border-border">
+			<button
+				type="button"
+				onClick={() => setCollapsed(!collapsed)}
+				className={cn(
+					"flex w-full items-center gap-1.5 px-3 py-2",
+					"text-xs font-medium uppercase tracking-wider text-muted-foreground",
+					"hover:bg-accent/30 cursor-pointer transition-colors",
+				)}
+			>
+				{collapsed ? (
+					<LuChevronRight className="size-3 shrink-0" />
+				) : (
+					<LuChevronDown className="size-3 shrink-0" />
+				)}
+				<LuServer className="size-3 shrink-0" />
+				<span>Services</span>
+			</button>
+
+			{!collapsed && (
+				<div className="px-3 py-2 text-sm">
+					{isLoading ? (
+						<p className="text-muted-foreground">Loading...</p>
+					) : !data || data.length === 0 ? (
+						<p className="text-muted-foreground">No services detected</p>
+					) : (
+						<div className="space-y-1.5">
+							{data.map((service) => (
+								<div
+									key={`${service.name}-${service.port}`}
+									className="flex items-center gap-2"
+								>
+									<div
+										className={cn(
+											"size-2 rounded-full shrink-0",
+											service.running
+												? "bg-green-500"
+												: service.processAlive
+													? "bg-yellow-500"
+													: "bg-red-500",
+										)}
+									/>
+									<span className="truncate">{service.name}</span>
+									<span className="text-muted-foreground shrink-0">
+										({service.port})
+									</span>
+									{service.running && service.uptimeSeconds !== null && (
+										<span className="text-muted-foreground text-xs ml-auto shrink-0">
+											{formatUptime(service.uptimeSeconds)}
+										</span>
+									)}
+									{!service.running && (
+										<Button
+											variant="ghost"
+											size="icon"
+											className="ml-auto size-6 shrink-0"
+											onClick={() => onRestart(service.restartCommand)}
+										>
+											<LuRotateCw className="size-3" />
+										</Button>
+									)}
+								</div>
+							))}
+						</div>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/components/ServicesSection/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/components/ServicesSection/index.ts
@@ -1,0 +1,1 @@
+export { ServicesSection } from "./ServicesSection";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/components/SlotManagerSection/SlotManagerSection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/components/SlotManagerSection/SlotManagerSection.tsx
@@ -1,0 +1,212 @@
+import { Button } from "@superset/ui/button";
+import { cn } from "@superset/ui/utils";
+import { useState } from "react";
+import {
+	LuChevronDown,
+	LuChevronRight,
+	LuCircle,
+	LuLoader,
+	LuPlus,
+	LuRefreshCw,
+	LuServer,
+	LuTrash2,
+} from "react-icons/lu";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+
+interface SlotManagerSectionProps {
+	worktreePath: string | undefined;
+	onSpawnCommand: (command: string) => void;
+}
+
+export function SlotManagerSection({
+	worktreePath,
+	onSpawnCommand,
+}: SlotManagerSectionProps) {
+	const [collapsed, setCollapsed] = useState(false);
+	const utils = electronTrpc.useUtils();
+
+	const { data: slots, isLoading } =
+		electronTrpc.archOne.getSlotStatus.useQuery(undefined, {
+			staleTime: 10_000,
+			refetchInterval: 30_000,
+		});
+
+	const killSlot = electronTrpc.archOne.killSlot.useMutation({
+		onSuccess: () => {
+			utils.archOne.getSlotStatus.invalidate();
+		},
+	});
+
+	const allocateSlot = electronTrpc.archOne.allocateSlot.useMutation({
+		onSuccess: (result) => {
+			utils.archOne.getSlotStatus.invalidate();
+			if (result.slot !== null) {
+				onSpawnCommand("npm run dev:detached");
+			}
+		},
+	});
+
+	const [killingSlot, setKillingSlot] = useState<number | null>(null);
+
+	const handleKill = async (
+		slot: number,
+		tmuxSession: string,
+		path: string,
+	) => {
+		setKillingSlot(slot);
+		try {
+			await killSlot.mutateAsync({ tmuxSession, path });
+		} finally {
+			setKillingSlot(null);
+		}
+	};
+
+	const handleAllocate = () => {
+		if (!worktreePath) return;
+		allocateSlot.mutate({ worktreePath });
+	};
+
+	const occupiedCount = slots?.filter((s) => s.path !== null).length ?? 0;
+	const totalSlots = slots?.length ?? 4;
+	const hasAvailableSlot = occupiedCount < totalSlots;
+	const isCurrentWorkspaceAllocated = slots?.some(
+		(s) => s.path === worktreePath,
+	);
+
+	return (
+		<div className="overflow-hidden border-t border-border">
+			<button
+				type="button"
+				onClick={() => setCollapsed(!collapsed)}
+				className={cn(
+					"flex w-full items-center gap-1.5 px-3 py-2",
+					"text-xs font-medium uppercase tracking-wider text-muted-foreground",
+					"hover:bg-accent/30 cursor-pointer transition-colors",
+				)}
+			>
+				{collapsed ? (
+					<LuChevronRight className="size-3 shrink-0" />
+				) : (
+					<LuChevronDown className="size-3 shrink-0" />
+				)}
+				<LuServer className="size-3 shrink-0" />
+				<span>Dev Slots</span>
+				<span className="ml-auto text-[10px] bg-muted px-1.5 py-0.5 rounded-full tabular-nums">
+					{occupiedCount}/{totalSlots}
+				</span>
+			</button>
+
+			{!collapsed && (
+				<div className="px-3 py-2 text-sm">
+					{isLoading ? (
+						<p className="text-muted-foreground">Loading...</p>
+					) : !slots ? (
+						<p className="text-muted-foreground">
+							No slot registry found
+						</p>
+					) : (
+						<div className="space-y-1.5">
+							{slots.map((slot) => (
+								<div
+									key={slot.slot}
+									className="flex items-center gap-2"
+								>
+									<LuCircle
+										className={cn(
+											"size-2 shrink-0",
+											slot.path
+												? slot.alive
+													? "fill-green-500 text-green-500"
+													: "fill-yellow-500 text-yellow-500"
+												: "fill-muted text-muted",
+										)}
+									/>
+									<span className="shrink-0 text-muted-foreground tabular-nums">
+										{slot.slot}
+									</span>
+									{slot.path ? (
+										<>
+											<span className="truncate flex-1 font-mono text-xs">
+												{slot.branch ?? slot.path.split("/").pop()}
+											</span>
+											<span className="shrink-0 text-muted-foreground text-[10px] tabular-nums">
+												:{8080 + slot.slot * 100}
+											</span>
+											{killingSlot === slot.slot ? (
+												<LuLoader className="size-3 shrink-0 animate-spin text-muted-foreground" />
+											) : (
+												<Button
+													variant="ghost"
+													size="icon"
+													className="ml-auto size-6 shrink-0"
+													title={`Kill slot ${slot.slot}`}
+													onClick={() =>
+														handleKill(
+															slot.slot,
+															slot.tmuxSession ?? "",
+															slot.path ?? "",
+														)
+													}
+												>
+													<LuTrash2 className="size-3" />
+												</Button>
+											)}
+										</>
+									) : (
+										<span className="text-muted-foreground/50 text-xs">
+											available
+										</span>
+									)}
+								</div>
+							))}
+							<div className="flex gap-1.5 pt-1">
+								{worktreePath && hasAvailableSlot && !isCurrentWorkspaceAllocated && (
+									<Button
+										variant="ghost"
+										size="sm"
+										className="flex-1 h-7 text-xs"
+										onClick={handleAllocate}
+										disabled={allocateSlot.isPending}
+									>
+										{allocateSlot.isPending ? (
+											<LuLoader className="size-3 mr-1.5 animate-spin" />
+										) : (
+											<LuPlus className="size-3 mr-1.5" />
+										)}
+										Setup Slot
+									</Button>
+								)}
+								<Button
+									variant="ghost"
+									size="sm"
+									className={cn(
+										"h-7 text-xs",
+										worktreePath && hasAvailableSlot && !isCurrentWorkspaceAllocated
+											? "flex-1"
+											: "w-full",
+									)}
+									onClick={() =>
+										utils.archOne.getSlotStatus.invalidate()
+									}
+								>
+									<LuRefreshCw className="size-3 mr-1.5" />
+									Refresh
+								</Button>
+							</div>
+							{allocateSlot.isError && (
+								<p className="text-destructive text-xs">
+									{allocateSlot.error.message}
+								</p>
+							)}
+							{allocateSlot.data?.error && (
+								<p className="text-destructive text-xs">
+									{allocateSlot.data.error}
+								</p>
+							)}
+						</div>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/components/SlotManagerSection/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/components/SlotManagerSection/index.ts
@@ -1,0 +1,1 @@
+export { SlotManagerSection } from "./SlotManagerSection";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/components/TestResultsSection/TestResultsSection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/components/TestResultsSection/TestResultsSection.tsx
@@ -1,0 +1,129 @@
+import { Button } from "@superset/ui/button";
+import { cn } from "@superset/ui/utils";
+import { useState } from "react";
+import {
+	LuChevronDown,
+	LuChevronRight,
+	LuPlay,
+	LuTestTube,
+} from "react-icons/lu";
+
+interface TestResultsSectionProps {
+	data:
+		| {
+				total: number;
+				passed: number;
+				failed: number;
+				skipped: number;
+				duration: number | null;
+				lastRun: string | null;
+				failedTests: string[];
+		  }
+		| undefined;
+	isLoading: boolean;
+	onRerun: () => void;
+}
+
+export function TestResultsSection({
+	data,
+	isLoading,
+	onRerun,
+}: TestResultsSectionProps) {
+	const [collapsed, setCollapsed] = useState(false);
+
+	return (
+		<div className="overflow-hidden border-t border-border">
+			<button
+				type="button"
+				onClick={() => setCollapsed(!collapsed)}
+				className={cn(
+					"flex w-full items-center gap-1.5 px-3 py-2",
+					"text-xs font-medium uppercase tracking-wider text-muted-foreground",
+					"hover:bg-accent/30 cursor-pointer transition-colors",
+				)}
+			>
+				{collapsed ? (
+					<LuChevronRight className="size-3 shrink-0" />
+				) : (
+					<LuChevronDown className="size-3 shrink-0" />
+				)}
+				<LuTestTube className="size-3 shrink-0" />
+				<span>Tests</span>
+				{data && data.total > 0 && (
+					<span
+						className={cn(
+							"ml-auto text-[10px] px-1.5 py-0.5 rounded-full tabular-nums",
+							data.failed > 0
+								? "bg-destructive/10 text-destructive"
+								: "bg-green-500/10 text-green-500",
+						)}
+					>
+						{data.passed}/{data.total}
+					</span>
+				)}
+			</button>
+
+			{!collapsed && (
+				<div className="px-3 py-2 text-sm">
+					{isLoading ? (
+						<p className="text-muted-foreground">Loading...</p>
+					) : !data || data.total === 0 ? (
+						<div className="space-y-2">
+							<p className="text-muted-foreground text-xs">
+								No test results found
+							</p>
+							<Button
+								variant="ghost"
+								size="sm"
+								className="w-full h-7 text-xs"
+								onClick={onRerun}
+							>
+								<LuPlay className="size-3 mr-1.5" />
+								Run Tests
+							</Button>
+						</div>
+					) : (
+						<div className="space-y-2">
+							<div className="flex flex-wrap gap-x-3 gap-y-0.5 text-xs">
+								<span className="text-green-500">
+									{data.passed} passed
+								</span>
+								{data.failed > 0 && (
+									<span className="text-destructive">
+										{data.failed} failed
+									</span>
+								)}
+								{data.skipped > 0 && (
+									<span className="text-muted-foreground">
+										{data.skipped} skipped
+									</span>
+								)}
+							</div>
+							{data.failedTests.length > 0 && (
+								<div className="space-y-0.5">
+									{data.failedTests.map((test) => (
+										<p
+											key={test}
+											className="text-xs text-destructive truncate font-mono"
+										>
+											{test}
+										</p>
+									))}
+								</div>
+							)}
+							<Button
+								variant="ghost"
+								size="sm"
+								className="w-full h-7 text-xs"
+								onClick={onRerun}
+							>
+								<LuPlay className="size-3 mr-1.5" />
+								Re-run Tests
+							</Button>
+						</div>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/components/TestResultsSection/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/components/TestResultsSection/index.ts
@@ -1,0 +1,1 @@
+export { TestResultsSection } from "./TestResultsSection";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/hooks/useEnvSync.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/hooks/useEnvSync.ts
@@ -1,0 +1,14 @@
+import { electronTrpc } from "renderer/lib/electron-trpc";
+
+export function useEnvSync(worktreePath: string | undefined) {
+	const { data, isLoading, refetch } =
+		electronTrpc.archOne.getEnvSyncStatus.useQuery(
+			{ worktreePath: worktreePath ?? "" },
+			{
+				enabled: !!worktreePath,
+				refetchInterval: 30_000,
+			},
+		);
+
+	return { data, isLoading, refetch };
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/hooks/useGitStatus.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/hooks/useGitStatus.ts
@@ -1,0 +1,14 @@
+import { electronTrpc } from "renderer/lib/electron-trpc";
+
+export function useGitStatus(worktreePath: string | undefined) {
+	const { data, isLoading, refetch } =
+		electronTrpc.archOne.getGitStatus.useQuery(
+			{ worktreePath: worktreePath ?? "" },
+			{
+				enabled: !!worktreePath,
+				refetchInterval: 15_000,
+			},
+		);
+
+	return { data, isLoading, refetch };
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/hooks/useGreptileScore.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/hooks/useGreptileScore.ts
@@ -1,0 +1,30 @@
+import { electronTrpc } from "renderer/lib/electron-trpc";
+
+export function useGreptileScore(
+	worktreePath: string | undefined,
+	pollInterval = 60_000,
+) {
+	const { data, isLoading, error, refetch, dataUpdatedAt } =
+		electronTrpc.archOne.getGreptileScore.useQuery(
+			{ worktreePath: worktreePath ?? "" },
+			{
+				enabled: !!worktreePath,
+				staleTime: Math.min(pollInterval, 60_000),
+				refetchInterval: pollInterval,
+			},
+		);
+
+	return { data, isLoading, error, refetch, dataUpdatedAt };
+}
+
+export function useFixStatus(worktreePath: string | undefined) {
+	const { data, refetch } = electronTrpc.archOne.getFixStatus.useQuery(
+		{ worktreePath: worktreePath ?? "" },
+		{
+			enabled: !!worktreePath,
+			refetchInterval: 5_000,
+		},
+	);
+
+	return { data, refetch };
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/hooks/useSeededUsers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/hooks/useSeededUsers.ts
@@ -1,0 +1,15 @@
+import { electronTrpc } from "renderer/lib/electron-trpc";
+
+export function useSeededUsers(worktreePath: string | undefined) {
+	const { data, isLoading, refetch } =
+		electronTrpc.archOne.getSeededUsers.useQuery(
+			{ worktreePath: worktreePath ?? "" },
+			{
+				enabled: !!worktreePath,
+				refetchInterval: 30_000,
+				staleTime: 15_000,
+			},
+		);
+
+	return { data, isLoading, refetch };
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/hooks/useServiceHealth.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/hooks/useServiceHealth.ts
@@ -1,0 +1,14 @@
+import { electronTrpc } from "renderer/lib/electron-trpc";
+
+export function useServiceHealth(worktreePath: string | undefined) {
+	const { data, isLoading } =
+		electronTrpc.archOne.getServiceHealth.useQuery(
+			{ worktreePath: worktreePath ?? "" },
+			{
+				enabled: !!worktreePath,
+				refetchInterval: 30_000,
+			},
+		);
+
+	return { data, isLoading };
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/hooks/useTestResults.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/hooks/useTestResults.ts
@@ -1,0 +1,14 @@
+import { electronTrpc } from "renderer/lib/electron-trpc";
+
+export function useTestResults(worktreePath: string | undefined) {
+	const { data, isLoading, refetch } =
+		electronTrpc.archOne.getTestResults.useQuery(
+			{ worktreePath: worktreePath ?? "" },
+			{
+				enabled: !!worktreePath,
+				refetchInterval: 30_000,
+			},
+		);
+
+	return { data, isLoading, refetch };
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ArchOneView/index.ts
@@ -1,0 +1,1 @@
+export { ArchOneView } from "./ArchOneView";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/PulseView/PulseView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/PulseView/PulseView.tsx
@@ -1,0 +1,13 @@
+import { DailyBriefingSection } from "./components/DailyBriefingSection";
+import { IssueQueueSection } from "./components/IssueQueueSection";
+import { TeamActivitySection } from "./components/TeamActivitySection";
+
+export function PulseView() {
+	return (
+		<div className="flex-1 min-h-0 overflow-y-auto">
+			<DailyBriefingSection />
+			<IssueQueueSection />
+			<TeamActivitySection />
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/PulseView/components/DailyBriefingSection/DailyBriefingSection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/PulseView/components/DailyBriefingSection/DailyBriefingSection.tsx
@@ -1,0 +1,265 @@
+import { cn } from "@superset/ui/utils";
+import { eq, isNull } from "@tanstack/db";
+import { useLiveQuery } from "@tanstack/react-db";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+	LuChevronDown,
+	LuChevronRight,
+	LuLoader,
+	LuRefreshCw,
+	LuSparkles,
+} from "react-icons/lu";
+import { authClient } from "renderer/lib/auth-client";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+
+const LAST_BRIEFING_KEY = "pulse-last-briefing-date";
+
+function formatTimeAgo(timestamp: number): string {
+	const diffMs = Date.now() - timestamp;
+	const minutes = Math.floor(diffMs / 60000);
+	if (minutes < 1) return "just now";
+	if (minutes < 60) return `${minutes}m ago`;
+	const hours = Math.floor(minutes / 60);
+	if (hours < 24) return `${hours}h ago`;
+	return `${Math.floor(hours / 24)}d ago`;
+}
+
+export function DailyBriefingSection() {
+	const [collapsed, setCollapsed] = useState(false);
+	const collections = useCollections();
+	const { data: session } = authClient.useSession();
+	const _currentUserId = session?.user?.id;
+
+	const { data: cachedBriefing } = electronTrpc.archOne.getBriefing.useQuery();
+	const generateBriefing = electronTrpc.archOne.generateBriefing.useMutation();
+
+	const [briefing, setBriefing] = useState<{
+		summary: string;
+		generatedAt: number;
+	} | null>(null);
+
+	useEffect(() => {
+		if (cachedBriefing) {
+			setBriefing(cachedBriefing);
+		}
+	}, [cachedBriefing]);
+
+	// Query recent tasks
+	const { data: tasksWithStatus } = useLiveQuery(
+		(q) =>
+			q
+				.from({ tasks: collections.tasks })
+				.innerJoin({ status: collections.taskStatuses }, ({ tasks, status }) =>
+					eq(tasks.statusId, status.id),
+				)
+				.leftJoin({ assignee: collections.users }, ({ tasks, assignee }) =>
+					eq(tasks.assigneeId, assignee.id),
+				)
+				.select(({ tasks, status, assignee }) => ({
+					...tasks,
+					status,
+					assignee: assignee ?? null,
+				}))
+				.where(({ tasks }) => isNull(tasks.deletedAt)),
+		[collections],
+	);
+
+	// Query recent PRs
+	const { data: pullRequests } = useLiveQuery(
+		(q) =>
+			q
+				.from({ prs: collections.githubPullRequests })
+				.select(({ prs }) => ({ ...prs })),
+		[collections],
+	);
+
+	const activityData = useMemo(() => {
+		if (!tasksWithStatus) return null;
+
+		const now = Date.now();
+		const oneDayAgo = now - 24 * 60 * 60 * 1000;
+		const threeDaysAgo = now - 3 * 24 * 60 * 60 * 1000;
+
+		const completedTasks = tasksWithStatus
+			.filter(
+				(t) => t.completedAt && new Date(t.completedAt).getTime() > oneDayAgo,
+			)
+			.map((t) => ({
+				slug: t.slug,
+				title: t.title,
+				completedBy: t.assignee?.name ?? t.assigneeDisplayName ?? "Unknown",
+			}));
+
+		const startedTasks = tasksWithStatus
+			.filter(
+				(t) =>
+					t.status.type === "started" &&
+					t.startedAt &&
+					new Date(t.startedAt).getTime() > oneDayAgo,
+			)
+			.map((t) => ({
+				slug: t.slug,
+				title: t.title,
+				assignee: t.assignee?.name ?? t.assigneeDisplayName ?? "Unknown",
+			}));
+
+		const newTasks = tasksWithStatus
+			.filter((t) => new Date(t.createdAt).getTime() > oneDayAgo)
+			.map((t) => ({ slug: t.slug, title: t.title }));
+
+		const mergedPRs = (pullRequests ?? [])
+			.filter(
+				(p) =>
+					p.state === "merged" &&
+					p.mergedAt &&
+					new Date(p.mergedAt).getTime() > oneDayAgo,
+			)
+			.map((p) => ({
+				prNumber: p.prNumber,
+				title: p.title,
+				authorLogin: p.authorLogin,
+			}));
+
+		const openedPRs = (pullRequests ?? [])
+			.filter(
+				(p) =>
+					p.state === "open" && new Date(p.createdAt).getTime() > oneDayAgo,
+			)
+			.map((p) => ({
+				prNumber: p.prNumber,
+				title: p.title,
+				authorLogin: p.authorLogin,
+				isDraft: p.isDraft,
+			}));
+
+		const staleTasks = tasksWithStatus
+			.filter(
+				(t) =>
+					t.status.type === "started" &&
+					new Date(t.updatedAt).getTime() < threeDaysAgo,
+			)
+			.map((t) => ({
+				slug: t.slug,
+				title: t.title,
+				assignee: t.assignee?.name ?? t.assigneeDisplayName ?? "Unknown",
+				daysSinceUpdate: Math.floor(
+					(now - new Date(t.updatedAt).getTime()) / (24 * 60 * 60 * 1000),
+				),
+			}));
+
+		// All currently open PRs — shows what teammates are actively working on
+		const teamOpenPRs = (pullRequests ?? [])
+			.filter((p) => p.state === "open")
+			.map((p) => ({
+				prNumber: p.prNumber,
+				title: p.title,
+				authorLogin: p.authorLogin,
+				isDraft: p.isDraft,
+				reviewDecision: p.reviewDecision ?? null,
+				checksStatus: p.checksStatus,
+				additions: p.additions,
+				deletions: p.deletions,
+				createdAt: new Date(p.createdAt).toISOString(),
+			}));
+
+		return {
+			completedTasks,
+			startedTasks,
+			newTasks,
+			mergedPRs,
+			openedPRs,
+			staleTasks,
+			teamOpenPRs,
+		};
+	}, [tasksWithStatus, pullRequests]);
+
+	const handleGenerate = useCallback(async () => {
+		if (!activityData) return;
+
+		try {
+			const result = await generateBriefing.mutateAsync({
+				activityData,
+			});
+			setBriefing(result);
+			localStorage.setItem(LAST_BRIEFING_KEY, new Date().toDateString());
+		} catch (error) {
+			console.error("[DailyBriefing] Generation failed", error);
+		}
+	}, [activityData, generateBriefing]);
+
+	// Auto-generate on first open of the day
+	useEffect(() => {
+		const lastDate = localStorage.getItem(LAST_BRIEFING_KEY);
+		const today = new Date().toDateString();
+		if (
+			lastDate !== today &&
+			activityData &&
+			!briefing &&
+			!generateBriefing.isPending
+		) {
+			handleGenerate();
+		}
+	}, [activityData, briefing, generateBriefing.isPending, handleGenerate]);
+
+	const isLoading = generateBriefing.isPending;
+
+	return (
+		<div className="overflow-hidden">
+			<button
+				type="button"
+				onClick={() => setCollapsed(!collapsed)}
+				className={cn(
+					"flex w-full items-center gap-1.5 px-3 py-2",
+					"text-xs font-medium uppercase tracking-wider text-muted-foreground",
+					"hover:bg-accent/30 cursor-pointer transition-colors",
+				)}
+			>
+				{collapsed ? (
+					<LuChevronRight className="size-3 shrink-0" />
+				) : (
+					<LuChevronDown className="size-3 shrink-0" />
+				)}
+				<LuSparkles className="size-3 shrink-0" />
+				<span>Daily Briefing</span>
+				<span className="flex-1" />
+				<button
+					type="button"
+					onClick={(e) => {
+						e.stopPropagation();
+						handleGenerate();
+					}}
+					disabled={isLoading}
+					className="hover:text-foreground transition-colors p-0.5"
+					title="Refresh briefing"
+				>
+					<LuRefreshCw className={cn("size-3", isLoading && "animate-spin")} />
+				</button>
+			</button>
+
+			{!collapsed && (
+				<div className="px-3 py-2 text-xs">
+					{isLoading ? (
+						<div className="flex items-center gap-2 text-muted-foreground py-2">
+							<LuLoader className="size-3 animate-spin" />
+							<span>Generating briefing...</span>
+						</div>
+					) : briefing ? (
+						<div className="space-y-2">
+							<div className="prose prose-xs prose-invert max-w-none text-xs leading-relaxed whitespace-pre-wrap">
+								{briefing.summary}
+							</div>
+							<p className="text-[10px] text-muted-foreground">
+								Generated {formatTimeAgo(briefing.generatedAt)}
+							</p>
+						</div>
+					) : (
+						<p className="text-muted-foreground py-1">
+							Click refresh to generate a briefing
+						</p>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/PulseView/components/DailyBriefingSection/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/PulseView/components/DailyBriefingSection/index.ts
@@ -1,0 +1,1 @@
+export { DailyBriefingSection } from "./DailyBriefingSection";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/PulseView/components/IssueQueueSection/IssueQueueSection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/PulseView/components/IssueQueueSection/IssueQueueSection.tsx
@@ -1,0 +1,246 @@
+import type { TaskPriority } from "@superset/db/enums";
+import { toast } from "@superset/ui/sonner";
+import { cn } from "@superset/ui/utils";
+import { eq, isNull } from "@tanstack/db";
+import { useLiveQuery } from "@tanstack/react-db";
+import { useNavigate } from "@tanstack/react-router";
+import { useMemo, useState } from "react";
+import { GoArrowUpRight } from "react-icons/go";
+import {
+	LuChevronDown,
+	LuChevronRight,
+	LuInbox,
+	LuLoader,
+} from "react-icons/lu";
+import { authClient } from "renderer/lib/auth-client";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { formatRelativeTime } from "renderer/lib/formatRelativeTime";
+import { getSlugColumnWidth } from "renderer/lib/slug-width";
+import { useCreateWorkspace } from "renderer/react-query/workspaces";
+import { PriorityIcon } from "renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/shared/PriorityIcon";
+import {
+	StatusIcon,
+	type StatusType,
+} from "renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/shared/StatusIcon";
+import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+
+const PRIORITY_ORDER: Record<string, number> = {
+	urgent: 0,
+	high: 1,
+	medium: 2,
+	low: 3,
+	none: 4,
+};
+
+export function IssueQueueSection() {
+	const [collapsed, setCollapsed] = useState(false);
+	const collections = useCollections();
+	const navigate = useNavigate();
+	const { data: session } = authClient.useSession();
+	const currentUserId = session?.user?.id;
+	const createWorkspace = useCreateWorkspace();
+	const [creatingSlug, setCreatingSlug] = useState<string | null>(null);
+
+	const { data: tasksWithStatus, isLoading } = useLiveQuery(
+		(q) =>
+			q
+				.from({ tasks: collections.tasks })
+				.innerJoin({ status: collections.taskStatuses }, ({ tasks, status }) =>
+					eq(tasks.statusId, status.id),
+				)
+				.leftJoin({ assignee: collections.users }, ({ tasks, assignee }) =>
+					eq(tasks.assigneeId, assignee.id),
+				)
+				.leftJoin({ creator: collections.users }, ({ tasks, creator }) =>
+					eq(tasks.creatorId, creator.id),
+				)
+				.select(({ tasks, status, assignee, creator }) => ({
+					...tasks,
+					status,
+					assignee: assignee ?? null,
+					creator: creator ?? null,
+				}))
+				.where(({ tasks }) => isNull(tasks.deletedAt)),
+		[collections],
+	);
+
+	const { data: allWorkspaces = [] } =
+		electronTrpc.workspaces.getAll.useQuery();
+
+	const workspaceByBranch = useMemo(() => {
+		const map = new Map<string, { id: string; projectId: string }>();
+		for (const w of allWorkspaces) {
+			map.set(w.branch, { id: w.id, projectId: w.projectId });
+		}
+		return map;
+	}, [allWorkspaces]);
+
+	const filteredTasks = useMemo(() => {
+		if (!tasksWithStatus || !currentUserId) return [];
+
+		return tasksWithStatus
+			.filter(
+				(t) =>
+					t.assigneeId === currentUserId &&
+					t.status.type !== "completed" &&
+					t.status.type !== "canceled",
+			)
+			.sort((a, b) => {
+				const pa = PRIORITY_ORDER[a.priority] ?? 4;
+				const pb = PRIORITY_ORDER[b.priority] ?? 4;
+				if (pa !== pb) return pa - pb;
+				return (
+					new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+				);
+			});
+	}, [tasksWithStatus, currentUserId]);
+
+	const slugWidth = useMemo(
+		() => getSlugColumnWidth(filteredTasks.map((t) => t.slug)),
+		[filteredTasks],
+	);
+
+	const handleTaskClick = async (task: (typeof filteredTasks)[0]) => {
+		const existing = workspaceByBranch.get(task.slug.toLowerCase());
+		if (existing) {
+			navigateToWorkspace(existing.id, navigate);
+			return;
+		}
+
+		// Need a projectId — use the first project from existing workspaces, or fail gracefully
+		const firstProjectId = allWorkspaces[0]?.projectId;
+		if (!firstProjectId) {
+			toast.error("No project found. Create a workspace first.");
+			return;
+		}
+
+		setCreatingSlug(task.slug);
+		try {
+			await createWorkspace.mutateAsync({
+				projectId: firstProjectId,
+				name: task.title,
+				branchName: task.slug.toLowerCase(),
+			});
+		} catch (err) {
+			toast.error(
+				err instanceof Error ? err.message : "Failed to create workspace",
+			);
+		} finally {
+			setCreatingSlug(null);
+		}
+	};
+
+	const queueCount = filteredTasks.filter(
+		(t) => !workspaceByBranch.has(t.slug.toLowerCase()),
+	).length;
+
+	return (
+		<div className="overflow-hidden">
+			<button
+				type="button"
+				onClick={() => setCollapsed(!collapsed)}
+				className={cn(
+					"flex w-full items-center gap-1.5 px-3 py-2",
+					"text-xs font-medium uppercase tracking-wider text-muted-foreground",
+					"hover:bg-accent/30 cursor-pointer transition-colors",
+				)}
+			>
+				{collapsed ? (
+					<LuChevronRight className="size-3 shrink-0" />
+				) : (
+					<LuChevronDown className="size-3 shrink-0" />
+				)}
+				<LuInbox className="size-3 shrink-0" />
+				<span>Issue Queue</span>
+				{queueCount > 0 && (
+					<span className="ml-auto text-[10px] bg-muted px-1.5 py-0.5 rounded-full tabular-nums">
+						{queueCount}
+					</span>
+				)}
+			</button>
+
+			{!collapsed && (
+				<div className="text-sm">
+					{isLoading ? (
+						<p className="px-3 py-2 text-muted-foreground">Loading...</p>
+					) : filteredTasks.length === 0 ? (
+						<p className="px-3 py-2 text-muted-foreground">
+							No assigned issues
+						</p>
+					) : (
+						<div className="space-y-px">
+							{filteredTasks.map((task) => {
+								const hasWorkspace = workspaceByBranch.has(
+									task.slug.toLowerCase(),
+								);
+								const isCreating = creatingSlug === task.slug;
+								return (
+									<button
+										key={task.id}
+										type="button"
+										onClick={() => handleTaskClick(task)}
+										disabled={isCreating}
+										className={cn(
+											"flex w-full items-start gap-2 px-3 py-1.5 text-left",
+											"hover:bg-accent/30 transition-colors group",
+											isCreating && "opacity-50",
+										)}
+									>
+										<div className="mt-0.5 shrink-0">
+											{isCreating ? (
+												<LuLoader className="size-3.5 animate-spin text-muted-foreground" />
+											) : hasWorkspace ? (
+												<GoArrowUpRight className="size-3.5 text-muted-foreground" />
+											) : (
+												<StatusIcon
+													type={task.status.type as StatusType}
+													color={task.status.color}
+													progress={task.status.progressPercent ?? undefined}
+													className="size-3.5"
+												/>
+											)}
+										</div>
+										<div className="flex flex-col gap-0.5 min-w-0 flex-1">
+											<div className="flex items-center gap-2">
+												<span
+													className="text-muted-foreground shrink-0 text-xs tabular-nums truncate"
+													style={{ width: slugWidth }}
+												>
+													{task.slug}
+												</span>
+												<span className="truncate flex-1 text-xs">
+													{task.title}
+												</span>
+												<PriorityIcon
+													priority={task.priority as TaskPriority}
+													statusType={task.status.type}
+													className="size-3 shrink-0"
+												/>
+											</div>
+											<div className="flex items-center gap-1.5 text-[10px] text-muted-foreground/60">
+												{task.creator && (
+													<span className="truncate">{task.creator.name}</span>
+												)}
+												{task.creator && task.createdAt && (
+													<span>&middot;</span>
+												)}
+												{task.createdAt && (
+													<span className="shrink-0">
+														{formatRelativeTime(
+															new Date(task.createdAt).getTime(),
+														)}
+													</span>
+												)}
+											</div>
+										</div>
+									</button>
+								);
+							})}
+						</div>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/PulseView/components/IssueQueueSection/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/PulseView/components/IssueQueueSection/index.ts
@@ -1,0 +1,1 @@
+export { IssueQueueSection } from "./IssueQueueSection";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/PulseView/components/TeamActivitySection/TeamActivitySection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/PulseView/components/TeamActivitySection/TeamActivitySection.tsx
@@ -1,0 +1,338 @@
+import { Avatar } from "@superset/ui/atoms/Avatar";
+import { cn } from "@superset/ui/utils";
+import { eq, isNull } from "@tanstack/db";
+import { useLiveQuery } from "@tanstack/react-db";
+import { useMemo, useState } from "react";
+import {
+	LuChevronDown,
+	LuChevronRight,
+	LuGitPullRequest,
+	LuUsers,
+} from "react-icons/lu";
+import { authClient } from "renderer/lib/auth-client";
+import {
+	StatusIcon,
+	type StatusType,
+} from "renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/shared/StatusIcon";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+
+interface TeammateActivity {
+	userId: string;
+	name: string;
+	image: string | null;
+	activeIssues: Array<{
+		id: string;
+		slug: string;
+		title: string;
+		statusType: string;
+		statusColor: string;
+		statusProgress: number | null;
+	}>;
+	openPRs: Array<{
+		id: string;
+		title: string;
+		prNumber: number;
+		url: string;
+		isDraft: boolean;
+		reviewDecision: string | null;
+	}>;
+}
+
+function ReviewBadge({ decision }: { decision: string | null }) {
+	if (!decision) return null;
+
+	const config: Record<string, { label: string; className: string }> = {
+		APPROVED: {
+			label: "Approved",
+			className: "text-green-600 bg-green-500/10",
+		},
+		CHANGES_REQUESTED: {
+			label: "Changes",
+			className: "text-orange-600 bg-orange-500/10",
+		},
+		REVIEW_REQUIRED: {
+			label: "Review",
+			className: "text-yellow-600 bg-yellow-500/10",
+		},
+	};
+
+	const c = config[decision];
+	if (!c) return null;
+
+	return (
+		<span
+			className={cn(
+				"text-[10px] px-1 py-0.5 rounded font-medium shrink-0",
+				c.className,
+			)}
+		>
+			{c.label}
+		</span>
+	);
+}
+
+function TeammateRow({ teammate }: { teammate: TeammateActivity }) {
+	const [expanded, setExpanded] = useState(false);
+	const totalItems = teammate.activeIssues.length + teammate.openPRs.length;
+
+	if (totalItems === 0) return null;
+
+	return (
+		<div className="overflow-hidden">
+			<button
+				type="button"
+				onClick={() => setExpanded(!expanded)}
+				className={cn(
+					"flex w-full items-center gap-2 px-3 py-1.5",
+					"hover:bg-accent/30 transition-colors text-sm",
+				)}
+			>
+				{expanded ? (
+					<LuChevronDown className="size-3 shrink-0 text-muted-foreground" />
+				) : (
+					<LuChevronRight className="size-3 shrink-0 text-muted-foreground" />
+				)}
+				<Avatar size="xs" fullName={teammate.name} image={teammate.image} />
+				<span className="truncate flex-1 text-left">{teammate.name}</span>
+				<span className="flex items-center gap-1.5 shrink-0 text-xs text-muted-foreground">
+					{teammate.activeIssues.length > 0 && (
+						<span>{teammate.activeIssues.length} issues</span>
+					)}
+					{teammate.openPRs.length > 0 && (
+						<span className="flex items-center gap-0.5">
+							<LuGitPullRequest className="size-3" />
+							{teammate.openPRs.length}
+						</span>
+					)}
+				</span>
+			</button>
+
+			{expanded && (
+				<div className="pl-8 pr-3 py-1 space-y-px">
+					{teammate.activeIssues.map((issue) => (
+						<div
+							key={issue.id}
+							className="flex items-center gap-2 py-1 text-xs"
+						>
+							<StatusIcon
+								type={issue.statusType as StatusType}
+								color={issue.statusColor}
+								progress={issue.statusProgress ?? undefined}
+								className="size-3 shrink-0"
+							/>
+							<span className="text-muted-foreground shrink-0">
+								{issue.slug}
+							</span>
+							<span className="truncate">{issue.title}</span>
+						</div>
+					))}
+					{teammate.openPRs.map((pr) => (
+						<div key={pr.id} className="flex items-center gap-2 py-1 text-xs">
+							<LuGitPullRequest
+								className={cn(
+									"size-3 shrink-0",
+									pr.isDraft ? "text-muted-foreground" : "text-green-500",
+								)}
+							/>
+							<span className="text-muted-foreground shrink-0">
+								#{pr.prNumber}
+							</span>
+							<span className="truncate flex-1">{pr.title}</span>
+							<ReviewBadge decision={pr.reviewDecision} />
+						</div>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}
+
+export function TeamActivitySection() {
+	const [collapsed, setCollapsed] = useState(false);
+	const collections = useCollections();
+	const { data: session } = authClient.useSession();
+	const currentUserId = session?.user?.id;
+
+	const { data: tasksWithStatus } = useLiveQuery(
+		(q) =>
+			q
+				.from({ tasks: collections.tasks })
+				.innerJoin({ status: collections.taskStatuses }, ({ tasks, status }) =>
+					eq(tasks.statusId, status.id),
+				)
+				.select(({ tasks, status }) => ({
+					...tasks,
+					status,
+				}))
+				.where(({ tasks }) => isNull(tasks.deletedAt)),
+		[collections],
+	);
+
+	const { data: users } = useLiveQuery(
+		(q) =>
+			q
+				.from({ users: collections.users })
+				.select(({ users }) => ({ ...users })),
+		[collections],
+	);
+
+	const { data: members } = useLiveQuery(
+		(q) =>
+			q
+				.from({ members: collections.members })
+				.select(({ members }) => ({ ...members })),
+		[collections],
+	);
+
+	const { data: pullRequests } = useLiveQuery(
+		(q) =>
+			q
+				.from({ prs: collections.githubPullRequests })
+				.select(({ prs }) => ({ ...prs })),
+		[collections],
+	);
+
+	const teammates = useMemo(() => {
+		if (!users || !members || !tasksWithStatus || !currentUserId) return [];
+
+		const orgMemberIds = new Set(members.map((m) => m.userId));
+
+		// Build user map
+		const userMap = new Map(users.map((u) => [u.id, u]));
+
+		// Build PR lookup by authorLogin -> user (best-effort heuristic)
+		const loginToUserId = new Map<string, string>();
+		if (pullRequests) {
+			for (const user of users) {
+				// Try to match by checking if any PR authorLogin maps to this user's email prefix
+				const emailPrefix = user.email.split("@")[0]?.toLowerCase();
+				if (emailPrefix) {
+					for (const pr of pullRequests) {
+						if (pr.authorLogin.toLowerCase() === emailPrefix) {
+							loginToUserId.set(pr.authorLogin.toLowerCase(), user.id);
+						}
+					}
+				}
+			}
+		}
+
+		const activityMap = new Map<string, TeammateActivity>();
+
+		// Group active issues by assignee
+		for (const task of tasksWithStatus) {
+			if (
+				!task.assigneeId ||
+				task.assigneeId === currentUserId ||
+				task.status.type === "completed" ||
+				task.status.type === "canceled"
+			)
+				continue;
+			if (!orgMemberIds.has(task.assigneeId)) continue;
+
+			let activity = activityMap.get(task.assigneeId);
+			if (!activity) {
+				const user = userMap.get(task.assigneeId);
+				activity = {
+					userId: task.assigneeId,
+					name: user?.name ?? task.assigneeDisplayName ?? "Unknown",
+					image: user?.image ?? task.assigneeAvatarUrl ?? null,
+					activeIssues: [],
+					openPRs: [],
+				};
+				activityMap.set(task.assigneeId, activity);
+			}
+			activity.activeIssues.push({
+				id: task.id,
+				slug: task.slug,
+				title: task.title,
+				statusType: task.status.type,
+				statusColor: task.status.color,
+				statusProgress: task.status.progressPercent,
+			});
+		}
+
+		// Group open PRs by author
+		if (pullRequests) {
+			for (const pr of pullRequests) {
+				if (pr.state !== "open") continue;
+
+				const userId = loginToUserId.get(pr.authorLogin.toLowerCase());
+				if (!userId || userId === currentUserId) continue;
+				if (!orgMemberIds.has(userId)) continue;
+
+				let activity = activityMap.get(userId);
+				if (!activity) {
+					const user = userMap.get(userId);
+					activity = {
+						userId,
+						name: user?.name ?? pr.authorLogin,
+						image: user?.image ?? pr.authorAvatarUrl ?? null,
+						activeIssues: [],
+						openPRs: [],
+					};
+					activityMap.set(userId, activity);
+				}
+				activity.openPRs.push({
+					id: pr.id,
+					title: pr.title,
+					prNumber: pr.prNumber,
+					url: pr.url,
+					isDraft: pr.isDraft,
+					reviewDecision: pr.reviewDecision,
+				});
+			}
+		}
+
+		return Array.from(activityMap.values()).sort(
+			(a, b) =>
+				b.activeIssues.length +
+				b.openPRs.length -
+				(a.activeIssues.length + a.openPRs.length),
+		);
+	}, [users, members, tasksWithStatus, pullRequests, currentUserId]);
+
+	const teammateCount = teammates.length;
+
+	return (
+		<div className="overflow-hidden border-t border-border">
+			<button
+				type="button"
+				onClick={() => setCollapsed(!collapsed)}
+				className={cn(
+					"flex w-full items-center gap-1.5 px-3 py-2",
+					"text-xs font-medium uppercase tracking-wider text-muted-foreground",
+					"hover:bg-accent/30 cursor-pointer transition-colors",
+				)}
+			>
+				{collapsed ? (
+					<LuChevronRight className="size-3 shrink-0" />
+				) : (
+					<LuChevronDown className="size-3 shrink-0" />
+				)}
+				<LuUsers className="size-3 shrink-0" />
+				<span>Team Activity</span>
+				{teammateCount > 0 && (
+					<span className="ml-auto text-[10px] bg-muted px-1.5 py-0.5 rounded-full tabular-nums">
+						{teammateCount}
+					</span>
+				)}
+			</button>
+
+			{!collapsed && (
+				<div className="text-sm">
+					{teammates.length === 0 ? (
+						<p className="px-3 py-2 text-muted-foreground text-xs">
+							No team activity
+						</p>
+					) : (
+						<div className="space-y-px">
+							{teammates.map((teammate) => (
+								<TeammateRow key={teammate.userId} teammate={teammate} />
+							))}
+						</div>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/PulseView/components/TeamActivitySection/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/PulseView/components/TeamActivitySection/index.ts
@@ -1,0 +1,1 @@
+export { TeamActivitySection } from "./TeamActivitySection";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/PulseView/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/PulseView/index.ts
@@ -1,0 +1,1 @@
+export { PulseView } from "./PulseView";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
@@ -4,9 +4,11 @@ import { cn } from "@superset/ui/utils";
 import { useParams } from "@tanstack/react-router";
 import { useCallback } from "react";
 import {
+	LuActivity,
 	LuExpand,
 	LuFile,
 	LuGitCompareArrows,
+	LuRadar,
 	LuShrink,
 	LuX,
 } from "react-icons/lu";
@@ -20,8 +22,10 @@ import {
 import { useTabsStore } from "renderer/stores/tabs/store";
 import type { ChangeCategory, ChangedFile } from "shared/changes-types";
 import { useScrollContext } from "../ChangesContent";
+import { ArchOneView } from "./ArchOneView";
 import { ChangesView } from "./ChangesView";
 import { FilesView } from "./FilesView";
+import { PulseView } from "./PulseView";
 
 function TabButton({
 	isActive,
@@ -174,6 +178,20 @@ export function RightSidebar() {
 						label="Files"
 						compact={compactTabs}
 					/>
+					<TabButton
+						isActive={rightSidebarTab === RightSidebarTab.ArchOne}
+						onClick={() => setRightSidebarTab(RightSidebarTab.ArchOne)}
+						icon={<LuRadar className="size-3.5" />}
+						label="Arch-One"
+						compact={compactTabs}
+					/>
+					<TabButton
+						isActive={rightSidebarTab === RightSidebarTab.Pulse}
+						onClick={() => setRightSidebarTab(RightSidebarTab.Pulse)}
+						icon={<LuActivity className="size-3.5" />}
+						label="Pulse"
+						compact={compactTabs}
+					/>
 				</div>
 				<div className="flex-1" />
 				<div className="flex items-center h-10 pr-2 gap-0.5">
@@ -236,12 +254,30 @@ export function RightSidebar() {
 			)}
 			<div
 				className={
-					rightSidebarTab === RightSidebarTab.Changes && showChangesTab
-						? "hidden"
-						: "flex-1 min-h-0 flex flex-col overflow-hidden"
+					rightSidebarTab === RightSidebarTab.Files
+						? "flex-1 min-h-0 flex flex-col overflow-hidden"
+						: "hidden"
 				}
 			>
 				<FilesView />
+			</div>
+			<div
+				className={
+					rightSidebarTab === RightSidebarTab.ArchOne
+						? "flex-1 min-h-0 flex flex-col overflow-hidden"
+						: "hidden"
+				}
+			>
+				<ArchOneView />
+			</div>
+			<div
+				className={
+					rightSidebarTab === RightSidebarTab.Pulse
+						? "flex-1 min-h-0 flex flex-col overflow-hidden"
+						: "hidden"
+				}
+			>
+				<PulseView />
 			</div>
 		</aside>
 	);

--- a/apps/desktop/src/renderer/stores/sidebar-state.ts
+++ b/apps/desktop/src/renderer/stores/sidebar-state.ts
@@ -9,6 +9,8 @@ export enum SidebarMode {
 export enum RightSidebarTab {
 	Changes = "changes",
 	Files = "files",
+	ArchOne = "arch-one",
+	Pulse = "pulse",
 }
 
 export const DEFAULT_SIDEBAR_WIDTH = 250;


### PR DESCRIPTION
## Summary
- Adds **Arch-One** sidebar tab: Greptile score display, auto-fix loop that spawns Claude to address review comments, service health, env sync, test results, slot manager, seed users
- Adds **Pulse** sidebar tab: LLM-generated daily briefing with team activity summary, issue queue, and team activity feed
- Improves Greptile auto-fixer prompt: review comments now include file paths and line numbers, structured prompt with GraphQL thread resolution instructions, owner/repo extracted for accurate queries
- Daily briefing now surfaces **all open PRs** so you can see what teammates are currently working on (review status, CI state, diff size)

## Test plan
- [ ] Verify Arch-One tab renders in right sidebar with Greptile score
- [ ] Trigger Greptile auto-fix and check `/tmp/greptile-fix-*.log` — prompt should include file paths and line numbers
- [ ] Open Pulse tab and generate a daily briefing — verify it includes a "what teammates are working on" section from open PRs
- [ ] Run `cd apps/desktop && bun run typecheck` — passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds new Arch‑One and Pulse right‑sidebar tabs with Greptile integration and an LLM-powered daily briefing. This lets developers track code quality, local service health, and team activity without leaving the app.

- New Features
  - Arch‑One tab: Greptile score + auto‑fix loop (start/stop), Git status, Service health, Env sync, Test results, Slot manager, Seed users, Quick actions.
  - Pulse tab: Daily briefing with team activity summary; Issue queue; Team activity feed. Briefing lists all open PRs with review/CI/diff size.
  - Workspace list shows a Greptile score badge and live "reviewing" state.
  - New `archOne` TRPC routers power the UI: `greptile`, `daily-briefing`, `env-sync`, `git-status`, `service-health`, `test-results`, `slot-manager`, `seed-users`.
  - Paywall check temporarily allows access to these features.

- Refactors
  - Greptile auto‑fixer prompt now includes file paths and line numbers, structured GraphQL thread resolution, and owner/repo from `gh repo view`; truncation increased to 15KB.
  - Daily briefing uses a 4‑hour cache to cut duplicate LLM calls.

<sup>Written for commit 8b572b32a9df96f025fcf98333f9b95ee562b8e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added AI-powered daily briefing summarizing your daily activity
  * Introduced Greptile code quality score with automated fix assistance
  * Added workspace slot management for multi-workspace development
  * Launched comprehensive status dashboards: Git, environment files, services, and tests
  * Added team activity and issue queue views for better collaboration visibility
  * Implemented seeded user management for development environments

* **Improvements**
  * Removed feature access restrictions to unlock all capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->