### PR TITLE
Fix preset cwd during eager terminal launch

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/launch-command.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/launch-command.test.ts
@@ -31,6 +31,28 @@ describe("launchCommandInPane", () => {
 		});
 	});
 
+	it("forwards cwd when launching a command into a new terminal session", async () => {
+		const createOrAttach = mock(async () => ({}));
+		const write = mock(async () => ({}));
+
+		await launchCommandInPane({
+			paneId: "pane-1",
+			tabId: "tab-1",
+			workspaceId: "ws-1",
+			command: "echo hello",
+			cwd: "./apps/desktop",
+			createOrAttach,
+			write,
+		});
+
+		expect(createOrAttach).toHaveBeenCalledWith({
+			paneId: "pane-1",
+			tabId: "tab-1",
+			workspaceId: "ws-1",
+			cwd: "./apps/desktop",
+		});
+	});
+
 	it("does not append a second newline when command already has one", async () => {
 		const createOrAttach = mock(async () => ({}));
 		const write = mock(async () => ({}));

--- a/apps/desktop/src/renderer/lib/terminal/launch-command.ts
+++ b/apps/desktop/src/renderer/lib/terminal/launch-command.ts
@@ -2,6 +2,7 @@ interface TerminalCreateOrAttachInput {
 	paneId: string;
 	tabId: string;
 	workspaceId: string;
+	cwd?: string;
 	taskPromptContent?: string;
 	taskPromptFileName?: string;
 }
@@ -17,6 +18,7 @@ interface LaunchCommandInPaneOptions {
 	tabId: string;
 	workspaceId: string;
 	command: string;
+	cwd?: string;
 	createOrAttach: (input: TerminalCreateOrAttachInput) => Promise<unknown>;
 	write: (input: TerminalWriteInput) => Promise<unknown>;
 	noExecute?: boolean;
@@ -77,6 +79,7 @@ export async function launchCommandInPane({
 	tabId,
 	workspaceId,
 	command,
+	cwd,
 	createOrAttach,
 	write,
 	noExecute,
@@ -87,6 +90,7 @@ export async function launchCommandInPane({
 		paneId,
 		tabId,
 		workspaceId,
+		cwd,
 		taskPromptContent,
 		taskPromptFileName,
 	});

--- a/apps/desktop/src/renderer/stores/tabs/useTabsWithPresets.ts
+++ b/apps/desktop/src/renderer/stores/tabs/useTabsWithPresets.ts
@@ -37,6 +37,7 @@ interface PresetPaneLaunch {
 	tabId: string;
 	workspaceId: string;
 	command: string;
+	cwd?: string;
 }
 
 function preparePreset(preset: TerminalPreset): PreparedPreset {
@@ -98,12 +99,13 @@ export function useTabsWithPresets() {
 	}, []);
 
 	const launchPresetCommand = useCallback(
-		({ paneId, tabId, workspaceId, command }: PresetPaneLaunch) => {
+		({ paneId, tabId, workspaceId, command, cwd }: PresetPaneLaunch) => {
 			void launchCommandInPane({
 				paneId,
 				tabId,
 				workspaceId,
 				command,
+				cwd,
 				createOrAttach: (input) => createOrAttach.mutateAsync(input),
 				write: (input) => writeToTerminal.mutateAsync(input),
 			}).catch((error) => {
@@ -187,6 +189,7 @@ export function useTabsWithPresets() {
 						tabId: result.tabId,
 						workspaceId,
 						command,
+						cwd: preset.initialCwd,
 					});
 					applyTabName(result.tabId, preset.name);
 				}
@@ -212,7 +215,15 @@ export function useTabsWithPresets() {
 					(paneId, index) => {
 						const command = preset.commands[index];
 						if (command === undefined) return [];
-						return [{ paneId, tabId: multiPane.tabId, workspaceId, command }];
+						return [
+							{
+								paneId,
+								tabId: multiPane.tabId,
+								workspaceId,
+								command,
+								cwd: preset.initialCwd,
+							},
+						];
 					},
 				);
 				launchPresetCommands(launches);
@@ -230,6 +241,7 @@ export function useTabsWithPresets() {
 					tabId: result.tabId,
 					workspaceId,
 					command,
+					cwd: preset.initialCwd,
 				});
 			}
 			applyTabName(result.tabId, preset.name);
@@ -268,7 +280,15 @@ export function useTabsWithPresets() {
 						(paneId, index) => {
 							const command = preset.commands[index];
 							if (command === undefined) return [];
-							return [{ paneId, tabId: activeTabId, workspaceId, command }];
+							return [
+								{
+									paneId,
+									tabId: activeTabId,
+									workspaceId,
+									command,
+									cwd: preset.initialCwd,
+								},
+							];
 						},
 					);
 					launchPresetCommands(launches);
@@ -289,6 +309,7 @@ export function useTabsWithPresets() {
 							tabId: activeTabId,
 							workspaceId,
 							command,
+							cwd: preset.initialCwd,
 						});
 					}
 					return { tabId: activeTabId, paneId };


### PR DESCRIPTION
## Summary
- forward preset `cwd` through the eager `launchCommandInPane` create/attach path
- pass each preset's configured directory through all preset launch plans in the tabs store
- add a regression test covering `cwd` forwarding during command-triggered terminal creation

## Testing
- `bun test apps/desktop/src/renderer/lib/terminal/launch-command.test.ts apps/desktop/src/lib/trpc/routers/terminal/utils/resolve-cwd.test.ts`
- `bunx @biomejs/biome check apps/desktop/src/renderer/lib/terminal/launch-command.ts apps/desktop/src/renderer/lib/terminal/launch-command.test.ts apps/desktop/src/renderer/stores/tabs/useTabsWithPresets.ts`

## Notes
- Full desktop `tsc` is currently blocked by unrelated/generated route and file-icon artifacts in this worktree (`routeTree.gen` and file icon manifest errors), so I validated the touched paths with focused tests and Biome instead.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes preset cwd being ignored during eager terminal launches so commands start in the correct directory. Propagates `cwd` through command-triggered session creation and adds a regression test.

- **Bug Fixes**
  - Forward `cwd` to terminal create/attach via `launchCommandInPane`.
  - Pass `preset.initialCwd` through all preset launch flows in `useTabsWithPresets`.
  - Add test to ensure `cwd` is forwarded when creating a terminal from a command.

<sup>Written for commit a900f3bcd76eb8e4d6a1bcedc65beb6f4e010e23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now optionally specify a custom working directory when launching commands in terminal sessions and from preset configurations, enabling commands to execute in the desired directory.

* **Tests**
  * Added test coverage validating that specified working directories are properly forwarded when launching commands into new terminal sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->