### PR TITLE
fix(desktop): send agent launch request from issues tab

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/IssuesGroup/IssuesGroup.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/IssuesGroup/IssuesGroup.tsx
@@ -1,3 +1,8 @@
+import {
+	buildTaskLaunchRequest,
+	STARTABLE_AGENT_TYPES,
+	type StartableAgentType,
+} from "@superset/shared/agent-launch";
 import { Avatar } from "@superset/ui/atoms/Avatar";
 import { Button } from "@superset/ui/button";
 import { CommandEmpty, CommandGroup, CommandItem } from "@superset/ui/command";
@@ -176,12 +181,38 @@ export function IssuesGroup({ projectId }: IssuesGroupProps) {
 							navigateToWorkspace(existingId, navigate);
 							return;
 						}
+						const storedAgent = localStorage.getItem("lastSelectedAgent");
+						const agentType: StartableAgentType =
+							storedAgent &&
+							(STARTABLE_AGENT_TYPES as readonly string[]).includes(storedAgent)
+								? (storedAgent as StartableAgentType)
+								: "claude";
+						const autoExecute =
+							localStorage.getItem("agentAutoRun") !== "false";
+						const launchRequest = buildTaskLaunchRequest({
+							task: {
+								id: task.id,
+								slug: task.slug,
+								title: task.title,
+								description: task.description,
+								priority: task.priority,
+								statusName: task.status.name,
+								labels: task.labels,
+							},
+							workspaceId: "pending-workspace",
+							agentType,
+							source: "new-workspace",
+							autoExecute,
+						});
 						void runAsyncAction(
-							createWorkspace.mutateAsync({
-								projectId,
-								name: task.title,
-								branchName: task.slug.toLowerCase(),
-							}),
+							createWorkspace.mutateAsyncWithPendingSetup(
+								{
+									projectId,
+									name: task.title,
+									branchName: task.slug.toLowerCase(),
+								},
+								{ agentLaunchRequest: launchRequest },
+							),
 							{
 								loading: "Creating workspace...",
 								success: "Workspace created",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/OpenInWorkspace/OpenInWorkspace.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/OpenInWorkspace/OpenInWorkspace.tsx
@@ -1,9 +1,6 @@
 import {
-	buildAgentFileCommand,
-	buildAgentTaskPrompt,
-} from "@superset/shared/agent-command";
-import {
 	type AgentLaunchRequest,
+	buildTaskLaunchRequest,
 	STARTABLE_AGENT_LABELS,
 	STARTABLE_AGENT_TYPES,
 	type StartableAgentType,
@@ -91,50 +88,22 @@ export function OpenInWorkspace({ task }: OpenInWorkspaceProps) {
 		await handleSelectProject(effectiveProjectId);
 	};
 
-	const buildLaunchRequest = (workspaceId: string): AgentLaunchRequest => {
-		const taskInput = {
-			id: task.id,
-			slug: task.slug,
-			title: task.title,
-			description: task.description,
-			priority: task.priority,
-			statusName: task.status.name,
-			labels: task.labels,
-		};
-
-		if (selectedAgent === "superset-chat") {
-			return {
-				kind: "chat",
-				workspaceId,
-				agentType: "superset-chat",
-				source: "open-in-workspace",
-				chat: {
-					initialPrompt: buildAgentTaskPrompt(taskInput),
-					retryCount: 1,
-					autoExecute: autoRun,
-					taskSlug: task.slug,
-				},
-			};
-		}
-
-		const taskPromptFileName = `task-${task.slug}.md`;
-		return {
-			kind: "terminal",
+	const buildLaunchRequest = (workspaceId: string): AgentLaunchRequest =>
+		buildTaskLaunchRequest({
+			task: {
+				id: task.id,
+				slug: task.slug,
+				title: task.title,
+				description: task.description,
+				priority: task.priority,
+				statusName: task.status.name,
+				labels: task.labels,
+			},
 			workspaceId,
 			agentType: selectedAgent,
 			source: "open-in-workspace",
-			terminal: {
-				command: buildAgentFileCommand({
-					filePath: `.superset/${taskPromptFileName}`,
-					agent: selectedAgent,
-				}),
-				name: task.slug,
-				taskPromptContent: buildAgentTaskPrompt(taskInput),
-				taskPromptFileName,
-				autoExecute: autoRun,
-			},
-		};
-	};
+			autoExecute: autoRun,
+		});
 
 	const handleSelectProject = async (projectId: string) => {
 		const branchName = deriveBranchName({

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/RunInWorkspacePopover/RunInWorkspacePopover.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/RunInWorkspacePopover/RunInWorkspacePopover.tsx
@@ -1,9 +1,6 @@
 import {
-	buildAgentFileCommand,
-	buildAgentTaskPrompt,
-} from "@superset/shared/agent-command";
-import {
 	type AgentLaunchRequest,
+	buildTaskLaunchRequest,
 	STARTABLE_AGENT_LABELS,
 	STARTABLE_AGENT_TYPES,
 	type StartableAgentType,
@@ -120,50 +117,22 @@ export function RunInWorkspacePopover({
 	const buildLaunchRequest = (
 		task: TaskWithStatus,
 		workspaceId: string,
-	): AgentLaunchRequest => {
-		const taskInput = {
-			id: task.id,
-			slug: task.slug,
-			title: task.title,
-			description: task.description,
-			priority: task.priority,
-			statusName: task.status.name,
-			labels: task.labels,
-		};
-
-		if (selectedAgent === "superset-chat") {
-			return {
-				kind: "chat",
-				workspaceId,
-				agentType: "superset-chat",
-				source: "open-in-workspace",
-				chat: {
-					initialPrompt: buildAgentTaskPrompt(taskInput),
-					retryCount: 1,
-					autoExecute: autoRun,
-					taskSlug: task.slug,
-				},
-			};
-		}
-
-		const taskPromptFileName = `task-${task.slug}.md`;
-		return {
-			kind: "terminal",
+	): AgentLaunchRequest =>
+		buildTaskLaunchRequest({
+			task: {
+				id: task.id,
+				slug: task.slug,
+				title: task.title,
+				description: task.description,
+				priority: task.priority,
+				statusName: task.status.name,
+				labels: task.labels,
+			},
 			workspaceId,
 			agentType: selectedAgent,
 			source: "open-in-workspace",
-			terminal: {
-				command: buildAgentFileCommand({
-					filePath: `.superset/${taskPromptFileName}`,
-					agent: selectedAgent,
-				}),
-				name: task.slug,
-				taskPromptContent: buildAgentTaskPrompt(taskInput),
-				taskPromptFileName,
-				autoExecute: autoRun,
-			},
-		};
-	};
+			autoExecute: autoRun,
+		});
 
 	const handleRun = async () => {
 		if (!effectiveProjectId) return;

--- a/packages/shared/src/agent-launch.ts
+++ b/packages/shared/src/agent-launch.ts
@@ -1,5 +1,12 @@
 import { z } from "zod";
-import { AGENT_LABELS, AGENT_TYPES, type AgentType } from "./agent-command";
+import {
+	AGENT_LABELS,
+	AGENT_TYPES,
+	type AgentType,
+	buildAgentFileCommand,
+	buildAgentTaskPrompt,
+	type TaskInput,
+} from "./agent-command";
 
 export const STARTABLE_AGENT_TYPES = [...AGENT_TYPES, "superset-chat"] as const;
 
@@ -173,4 +180,57 @@ export function normalizeAgentLaunchRequest(
 
 	const legacy = legacyAgentLaunchRequestSchema.parse(request);
 	return agentLaunchRequestSchema.parse(normalizeLegacyLaunchRequest(legacy));
+}
+
+/**
+ * Builds an AgentLaunchRequest for a task, used when creating workspaces
+ * from the issues tab, task sidebar, or batch run popover.
+ */
+export function buildTaskLaunchRequest({
+	task,
+	workspaceId,
+	agentType,
+	source,
+	autoExecute,
+}: {
+	task: TaskInput;
+	workspaceId: string;
+	agentType: StartableAgentType;
+	source: AgentLaunchSource;
+	autoExecute?: boolean;
+}): AgentLaunchRequest {
+	const prompt = buildAgentTaskPrompt(task);
+
+	if (agentType === "superset-chat") {
+		return {
+			kind: "chat",
+			workspaceId,
+			agentType: "superset-chat",
+			source,
+			chat: {
+				initialPrompt: prompt,
+				retryCount: 1,
+				autoExecute,
+				taskSlug: task.slug,
+			},
+		};
+	}
+
+	const taskPromptFileName = `task-${task.slug}.md`;
+	return {
+		kind: "terminal",
+		workspaceId,
+		agentType,
+		source,
+		terminal: {
+			command: buildAgentFileCommand({
+				filePath: `.superset/${taskPromptFileName}`,
+				agent: agentType,
+			}),
+			name: task.slug,
+			taskPromptContent: prompt,
+			taskPromptFileName,
+			autoExecute,
+		},
+	};
 }


### PR DESCRIPTION
## Summary
- **Fix**: Issues tab in New Workspace modal now sends an `AgentLaunchRequest` when creating a workspace, matching the task view behavior (uses `mutateAsyncWithPendingSetup` instead of bare `mutateAsync`)
- **Refactor**: Extract duplicated `buildLaunchRequest` logic into shared `buildTaskLaunchRequest()` in `@superset/shared/agent-launch`, used by `IssuesGroup`, `OpenInWorkspace`, and `RunInWorkspacePopover`
- Agent type and auto-run preferences are read from localStorage (`lastSelectedAgent`, `agentAutoRun`), consistent with the task view

## Test plan
- [ ] Open New Workspace modal → Issues tab → select an issue → verify agent session launches with task prompt
- [ ] Open task detail → sidebar "Open in Workspace" → verify agent session still launches correctly
- [ ] Select multiple tasks → "Run in Workspace" batch popover → verify agent sessions launch correctly
- [ ] Verify existing workspace detection still navigates without creating duplicates

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes workspace creation from the Issues tab by launching the agent with the task prompt and honoring saved agent and auto-run settings. Centralizes launch request building to keep behavior consistent across the app.

- **Bug Fixes**
  - Issues tab now sends an `AgentLaunchRequest` via `mutateAsyncWithPendingSetup` when creating a workspace.
  - Reads `lastSelectedAgent` and `agentAutoRun` from localStorage to match the task view.

- **Refactors**
  - Added `buildTaskLaunchRequest` in `@superset/shared/agent-launch`.
  - Replaced duplicated launch logic in `IssuesGroup`, `OpenInWorkspace`, and `RunInWorkspacePopover`.

<sup>Written for commit a56dc529edcb3a3874e78520f9e9c54e0766c669. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified agent launch request handling across task and workspace creation flows for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->