### PR TITLE
fix(desktop): fix stale project icon after replacing with a new image

### DIFF
--- a/apps/desktop/src/main/lib/project-icons.ts
+++ b/apps/desktop/src/main/lib/project-icons.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, readdirSync, unlinkSync } from "node:fs";
 import { copyFile, writeFile } from "node:fs/promises";
 import { extname, join } from "node:path";
@@ -45,10 +46,10 @@ function removeExistingIcon(projectId: string): void {
 }
 
 /**
- * Returns the protocol URL for a project icon.
+ * Returns the protocol URL for a project icon with a cache-busting query param.
  */
 export function getProjectIconProtocolUrl(projectId: string): string {
-	return `superset-icon://projects/${projectId}`;
+	return `superset-icon://projects/${projectId}?v=${encodeURIComponent(randomUUID())}`;
 }
 
 /**

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/ProjectSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/ProjectSettings.tsx
@@ -142,7 +142,9 @@ export function ProjectSettings({
 	const fileInputRef = useRef<HTMLInputElement>(null);
 
 	const handleIconUpload = useCallback(() => {
-		fileInputRef.current?.click();
+		if (!fileInputRef.current) return;
+		fileInputRef.current.value = "";
+		fileInputRef.current.click();
 	}, []);
 
 	const handleFileChange = useCallback(


### PR DESCRIPTION
## Issue
When you click replace image in workspace settings, you don't see the updated icon, so it looks as if nothing happened. In reality it did work, but electron is displaying a cached older version of the image.

## Fix
- Always append a cache-busting UUID query param to project icon protocol URLs, so Chromium never serves a stale cached image after the user replaces an icon
- Clear the file input value before opening the file picker, so re-selecting the same file still triggers `onChange`. This is in case a user edited/renamed an image file with the same name

Demo GIF
![ss-replace-icon](https://github.com/user-attachments/assets/4a003d99-6902-4f89-9116-b194208e8f96)

## Test plan
- [ ] Set a project icon, then replace it with a different image — verify the new icon appears immediately
- [ ] Replace a project icon with the same file (e.g., after editing it externally) — verify it updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project icons now properly refresh when updated to prevent display of stale cached versions.
  * Fixed ability to re-upload the same project icon file without closing and reopening the dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->