### PR TITLE
fix(desktop): remove bg color for project icons

### DIFF
--- a/apps/desktop/src/renderer/globals.css
+++ b/apps/desktop/src/renderer/globals.css
@@ -1,6 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
-@import "../../../../packages/ui/node_modules/streamdown/styles.css";
+@import "streamdown/styles.css";
 
 @source "./**/*.{ts,tsx}";
 @source "../../../../packages/ui/src/**/*.{ts,tsx}";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectThumbnail/ProjectThumbnail.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectThumbnail/ProjectThumbnail.tsx
@@ -73,6 +73,7 @@ export function ProjectThumbnail({
 	const owner = avatarData?.owner ?? githubOwner;
 	const firstLetter = projectName.charAt(0).toUpperCase();
 	const hasCustomColor = isCustomColor(projectColor);
+	const shouldUseTransparentIconFrame = projectColor === PROJECT_COLOR_DEFAULT;
 
 	// Border: gray by default, custom color with slight transparency when set
 	const borderClasses = cn(
@@ -88,8 +89,10 @@ export function ProjectThumbnail({
 		return (
 			<div
 				className={cn(
-					"relative size-6 rounded overflow-hidden flex-shrink-0 bg-muted",
-					borderClasses,
+					"relative size-6 rounded overflow-hidden flex-shrink-0",
+					!shouldUseTransparentIconFrame && "bg-muted",
+					!shouldUseTransparentIconFrame && borderClasses,
+					shouldUseTransparentIconFrame && "p-[1.5px]",
 					className,
 				)}
 				style={borderStyle}


### PR DESCRIPTION
## Summary

- Unrelated but necessary - update the `streamdown/styles.css` import. The project crashed without this change, but lmk if it's an issue with my environment setup instead
- For projects with an icon, the default background color looks bad. The "default" color option should remove the background when an icon exists.

<img width="1243" height="353" alt="ss-transparent-icons" src="https://github.com/user-attachments/assets/d1418016-e856-4cad-a9c9-1441cb43f511" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined the visual appearance of project thumbnails in the workspace sidebar, improving the styling presentation for projects with default colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->