### PR TITLE
feat(desktop): add pane header rename

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/RenameInput/RenameInput.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/RenameInput/RenameInput.tsx
@@ -6,6 +6,7 @@ interface RenameInputProps {
 	onSubmit: () => void;
 	onCancel: () => void;
 	className?: string;
+	maxLength?: number;
 }
 
 export function RenameInput({
@@ -14,6 +15,7 @@ export function RenameInput({
 	onSubmit,
 	onCancel,
 	className,
+	maxLength,
 }: RenameInputProps) {
 	const inputRef = useRef<HTMLInputElement>(null);
 
@@ -49,6 +51,7 @@ export function RenameInput({
 			onKeyDown={handleKeyDown}
 			onClick={(e) => e.stopPropagation()}
 			onMouseDown={(e) => e.stopPropagation()}
+			maxLength={maxLength}
 			className={className}
 		/>
 	);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupItem.tsx
@@ -8,13 +8,14 @@ import {
 } from "@superset/ui/context-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useDrag, useDrop } from "react-dnd";
 import { getEmptyImage } from "react-dnd-html5-backend";
 import { HiMiniXMark } from "react-icons/hi2";
 import { LuEyeOff, LuPencil } from "react-icons/lu";
 import { MosaicDragType } from "react-mosaic-component";
 import { StatusIndicator } from "renderer/screens/main/components/StatusIndicator";
+import { RenameInput } from "renderer/screens/main/components/WorkspaceSidebar/RenameInput";
 import { useDragPaneStore } from "renderer/stores/drag-pane-store";
 import type { PaneStatus, Tab } from "renderer/stores/tabs/types";
 import { getTabDisplayName } from "renderer/stores/tabs/utils";
@@ -49,7 +50,6 @@ export function GroupItem({
 	const displayName = getTabDisplayName(tab);
 	const [isEditing, setIsEditing] = useState(false);
 	const [editValue, setEditValue] = useState("");
-	const inputRef = useRef<HTMLInputElement>(null);
 
 	// Drag source for tab reordering
 	const [{ isDragging }, drag, preview] = useDrag(
@@ -130,16 +130,12 @@ export function GroupItem({
 		[onPaneDrop, onReorder, tab.id, index],
 	);
 
-	useEffect(() => {
-		if (isEditing) {
-			// Use rAF to ensure focus happens after context menu closes
-			const id = requestAnimationFrame(() => {
-				inputRef.current?.focus();
-				inputRef.current?.select();
-			});
-			return () => cancelAnimationFrame(id);
-		}
-	}, [isEditing]);
+	const tabStyles = cn(
+		"flex items-center gap-2 transition-all w-full shrink-0 pl-3 pr-8 h-full",
+		isActive
+			? "text-foreground bg-border/30"
+			: "text-muted-foreground/70 hover:text-muted-foreground hover:bg-tertiary/20",
+	);
 
 	const startEditing = () => {
 		setEditValue(displayName);
@@ -153,23 +149,6 @@ export function GroupItem({
 		}
 		setIsEditing(false);
 	};
-
-	const handleKeyDown = (e: React.KeyboardEvent) => {
-		if (e.key === "Enter") {
-			e.preventDefault();
-			handleSave();
-		} else if (e.key === "Escape") {
-			e.preventDefault();
-			setIsEditing(false);
-		}
-	};
-
-	const tabStyles = cn(
-		"flex items-center gap-2 transition-all w-full shrink-0 pl-3 pr-8 h-full",
-		isActive
-			? "text-foreground bg-border/30"
-			: "text-muted-foreground/70 hover:text-muted-foreground hover:bg-tertiary/20",
-	);
 
 	return (
 		<ContextMenu>
@@ -186,62 +165,60 @@ export function GroupItem({
 					style={{ cursor: isDragging ? "grabbing" : undefined }}
 				>
 					{isEditing ? (
-						<div className="flex items-center w-full shrink-0 px-2 h-full">
-							<input
-								ref={inputRef}
-								type="text"
+						<div className="flex h-full w-full shrink-0 items-center px-2">
+							<RenameInput
 								value={editValue}
-								onChange={(e) => setEditValue(e.target.value)}
-								onBlur={handleSave}
-								onKeyDown={handleKeyDown}
+								onChange={setEditValue}
+								onSubmit={handleSave}
+								onCancel={() => setIsEditing(false)}
 								maxLength={64}
 								className="text-sm w-full min-w-0 px-1 py-0.5 rounded border border-border bg-background text-foreground outline-none focus:ring-1 focus:ring-ring"
 							/>
 						</div>
 					) : (
-						<button
-							type="button"
-							onClick={onSelect}
-							onDoubleClick={startEditing}
-							onAuxClick={(e) => {
-								if (e.button === 1) {
-									e.preventDefault();
-									onClose();
-								}
-							}}
-							className={tabStyles}
-						>
-							<span className="text-sm truncate flex-1 text-left">
-								{displayName}
-							</span>
-							{status && status !== "idle" && (
-								<StatusIndicator status={status} />
-							)}
-						</button>
-					)}
-					{!isEditing && (
-						<div className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center gap-0.5 hidden group-hover:flex">
-							<Tooltip delayDuration={500}>
-								<TooltipTrigger asChild>
-									<Button
-										type="button"
-										variant="ghost"
-										size="icon"
-										onClick={(e) => {
-											e.stopPropagation();
-											onClose();
-										}}
-										className="cursor-pointer size-6 hover:bg-muted"
-										aria-label="Close pane"
-									>
-										<HiMiniXMark className="size-4" />
-									</Button>
-								</TooltipTrigger>
-								<TooltipContent side="top" showArrow={false}>
-									Close pane
-								</TooltipContent>
-							</Tooltip>
-						</div>
+						<>
+							<button
+								type="button"
+								onClick={onSelect}
+								onDoubleClick={startEditing}
+								onAuxClick={(e) => {
+									if (e.button === 1) {
+										e.preventDefault();
+										onClose();
+									}
+								}}
+								className={tabStyles}
+							>
+								<span className="text-sm truncate flex-1 text-left">
+									{displayName}
+								</span>
+								{status && status !== "idle" && (
+									<StatusIndicator status={status} />
+								)}
+							</button>
+							<div className="absolute right-1 top-1/2 -translate-y-1/2 hidden items-center gap-0.5 group-hover:flex">
+								<Tooltip delayDuration={500}>
+									<TooltipTrigger asChild>
+										<Button
+											type="button"
+											variant="ghost"
+											size="icon"
+											onClick={(e) => {
+												e.stopPropagation();
+												onClose();
+											}}
+											className="cursor-pointer size-6 hover:bg-muted"
+											aria-label="Close pane"
+										>
+											<HiMiniXMark className="size-4" />
+										</Button>
+									</TooltipTrigger>
+									<TooltipContent side="top" showArrow={false}>
+										Close pane
+									</TooltipContent>
+								</Tooltip>
+							</div>
+						</>
 					)}
 				</div>
 			</ContextMenuTrigger>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/TabPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/TabPane.tsx
@@ -10,7 +10,7 @@ import { useTerminalCallbacksStore } from "renderer/stores/tabs/terminal-callbac
 import type { SplitPaneOptions, Tab } from "renderer/stores/tabs/types";
 import { TabContentContextMenu } from "../TabContentContextMenu";
 import { Terminal } from "../Terminal";
-import { BasePaneWindow, PaneToolbarActions } from "./components";
+import { BasePaneWindow, PaneTitle, PaneToolbarActions } from "./components";
 
 interface TabPaneProps {
 	paneId: string;
@@ -58,6 +58,7 @@ export function TabPane({
 }: TabPaneProps) {
 	const paneName = useTabsStore((s) => s.panes[paneId]?.name);
 	const paneStatus = useTabsStore((s) => s.panes[paneId]?.status);
+	const setPaneName = useTabsStore((s) => s.setPaneName);
 	const setPaneStatus = useTabsStore((s) => s.setPaneStatus);
 	const equalizePaneSplits = useTabsStore((s) => s.equalizePaneSplits);
 
@@ -100,9 +101,11 @@ export function TabPane({
 			renderToolbar={(handlers) => (
 				<div className="flex h-full w-full items-center justify-between px-3">
 					<div className="flex min-w-0 items-center gap-2">
-						<span className="truncate text-sm text-muted-foreground">
-							{paneName || "Terminal"}
-						</span>
+						<PaneTitle
+							name={paneName ?? ""}
+							fallback="Terminal"
+							onRename={(newName) => setPaneName(paneId, newName)}
+						/>
 						{paneStatus && paneStatus !== "idle" && (
 							<StatusIndicator status={paneStatus} />
 						)}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/PaneTitle/PaneTitle.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/PaneTitle/PaneTitle.tsx
@@ -1,0 +1,58 @@
+import { cn } from "@superset/ui/utils";
+import { useState } from "react";
+import { RenameInput } from "renderer/screens/main/components/WorkspaceSidebar/RenameInput";
+
+interface PaneTitleProps {
+	name: string;
+	fallback: string;
+	onRename: (newName: string) => void;
+	className?: string;
+}
+
+export function PaneTitle({
+	name,
+	fallback,
+	onRename,
+	className = "truncate text-sm text-muted-foreground",
+}: PaneTitleProps) {
+	const [isEditing, setIsEditing] = useState(false);
+	const [editValue, setEditValue] = useState("");
+
+	const displayName = name || fallback;
+
+	const startEditing = () => {
+		setEditValue(displayName);
+		setIsEditing(true);
+	};
+
+	const handleSave = () => {
+		const trimmedValue = editValue.trim();
+		if (trimmedValue && trimmedValue !== displayName) {
+			onRename(trimmedValue);
+		}
+		setIsEditing(false);
+	};
+
+	if (isEditing) {
+		return (
+			<RenameInput
+				value={editValue}
+				onChange={setEditValue}
+				onSubmit={handleSave}
+				onCancel={() => setIsEditing(false)}
+				maxLength={64}
+				className={cn(
+					"min-w-0 rounded border border-border bg-background px-1 py-0.5 text-sm text-foreground outline-none focus:ring-1 focus:ring-ring",
+					className,
+				)}
+			/>
+		);
+	}
+
+	return (
+		// biome-ignore lint/a11y/noStaticElementInteractions: double-click to rename
+		<span className={className} onDoubleClick={startEditing}>
+			{displayName}
+		</span>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/PaneTitle/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/PaneTitle/index.ts
@@ -1,0 +1,1 @@
+export { PaneTitle } from "./PaneTitle";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/index.ts
@@ -1,3 +1,4 @@
 export { BasePaneWindow, type PaneHandlers } from "./BasePaneWindow";
 export { MosaicSplitOverlay } from "./MosaicSplitOverlay";
+export { PaneTitle } from "./PaneTitle";
 export { PaneToolbarActions } from "./PaneToolbarActions";


### PR DESCRIPTION
## Feature
Allow panes to be renamed


Demo GIF
![ss-tab-rename](https://github.com/user-attachments/assets/b4904fed-1d2e-46cc-8cbd-374604e44fec)

## Summary
- add inline rename support to desktop pane headers via a shared `PaneTitle` component
- keep the top-level tab strip on its original button-or-input structure while reusing the shared `RenameInput` behavior
- extend the shared rename input with an optional `maxLength` so both rename flows can share the same keyboard and focus handling

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds inline rename to desktop pane headers using a shared `PaneTitle` component. Extends `RenameInput` with `maxLength` to unify rename behavior across pane headers and the tab strip.

- **New Features**
  - Introduced `PaneTitle` in `TabPane` for double‑click rename; updates store via `setPaneName`.
  - Extended `RenameInput` with optional `maxLength` (64) and shared submit/cancel handling.
  - Updated group strip item to reuse `RenameInput` while keeping the existing button/input structure.

<sup>Written for commit f83bbed45e550ee50e97665a417bf14d2d0eca81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now rename pane titles by double-clicking on the title text.

* **Improvements**
  * Enhanced editing UI consistency for group item and pane title renaming.
  * Added configurable character length limits for rename input fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->