### PR TITLE
Update OpenAI models: replace GPT-5.2 with GPT-5.4

### DIFF
--- a/packages/trpc/src/router/chat/chat.ts
+++ b/packages/trpc/src/router/chat/chat.ts
@@ -22,13 +22,13 @@ const AVAILABLE_MODELS = [
 		provider: "Anthropic",
 	},
 	{
-		id: "openai/gpt-5.3-codex",
-		name: "GPT-5.3 Codex",
+		id: "openai/gpt-5.4",
+		name: "GPT-5.4",
 		provider: "OpenAI",
 	},
 	{
-		id: "openai/gpt-5.2",
-		name: "GPT-5.2",
+		id: "openai/gpt-5.3-codex",
+		name: "GPT-5.3 Codex",
 		provider: "OpenAI",
 	},
 ];


### PR DESCRIPTION
## Summary
- Replace `openai/gpt-5.2` with `openai/gpt-5.4` (OpenAI's new flagship model)
- Keep `openai/gpt-5.3-codex` as a secondary option
- GPT-5.4 supersedes GPT-5.2 with improved coding, document understanding, tool use, and 1M context window

## Test plan
- [ ] Verify model picker shows GPT-5.4 and GPT-5.3 Codex
- [ ] Verify chat works with the new GPT-5.4 model ID

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `openai/gpt-5.2` with `openai/gpt-5.4` and kept `openai/gpt-5.3-codex` as a secondary option. The model list now surfaces GPT-5.4 as the primary OpenAI model with better coding, document understanding, tool use, and a 1M context window.

<sup>Written for commit 94619d85aa84258b402090e254b0da8cbd84451f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated available AI models in the chat feature with the latest releases. Users can now access refreshed model options that provide enhanced capabilities, improved performance metrics, and modern features to support better conversation experiences. These updates ensure users always have access to the most current and capable AI models available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->