### PR TITLE
fix: show helpful error message for git ENOENT

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/projects/projects.ts
+++ b/apps/desktop/src/lib/trpc/routers/projects/projects.ts
@@ -68,12 +68,24 @@ type OpenNewMultiResult =
 	| { canceled: false; multi: true; results: FolderOutcome[] }
 	| OpenNewError;
 
+const GIT_NOT_FOUND_MESSAGE =
+	'Git was not found. Your shell config (e.g. ~/.zshrc) may contain a broken command that corrupts PATH.\n\nCommon cause: export PATH="$(npm bin -g):$PATH"\n\nFix: remove or fix the line in ~/.zshrc, then restart the app.';
+
+function isGitNotFoundError(err: unknown): boolean {
+	if (!(err instanceof Error)) return false;
+	if ("code" in err && err.code === "ENOENT") return true;
+	return err.message.includes("spawn git ENOENT");
+}
+
 async function initGitRepo(path: string): Promise<{ defaultBranch: string }> {
 	const git = await getSimpleGitWithShellPath(path);
 
 	try {
 		await git.init(["--initial-branch=main"]);
 	} catch (err) {
+		if (isGitNotFoundError(err)) {
+			throw new Error(GIT_NOT_FOUND_MESSAGE);
+		}
 		console.warn("Git init with --initial-branch failed, using fallback:", err);
 		await git.init();
 	}
@@ -902,7 +914,13 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 
 					outcomes.push({ status: "success", project });
 				} catch (gitError) {
-					if (gitError instanceof NotGitRepoError) {
+					if (isGitNotFoundError(gitError)) {
+						outcomes.push({
+							status: "error",
+							selectedPath,
+							error: GIT_NOT_FOUND_MESSAGE,
+						});
+					} else if (gitError instanceof NotGitRepoError) {
 						outcomes.push({ status: "needsGitInit", selectedPath });
 					} else {
 						const msg =
@@ -952,6 +970,12 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 				try {
 					mainRepoPath = await getGitRoot(selectedPath);
 				} catch (error) {
+					if (isGitNotFoundError(error)) {
+						return {
+							canceled: false,
+							error: GIT_NOT_FOUND_MESSAGE,
+						};
+					}
 					if (error instanceof NotGitRepoError) {
 						return {
 							canceled: false,
@@ -1140,6 +1164,13 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 						project,
 					};
 				} catch (error) {
+					if (isGitNotFoundError(error)) {
+						return {
+							canceled: false as const,
+							success: false as const,
+							error: GIT_NOT_FOUND_MESSAGE,
+						};
+					}
 					const errorMessage =
 						error instanceof Error ? error.message : String(error);
 					return {

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -57,10 +57,18 @@ export function NewWorkspaceModal() {
 		try {
 			await openNew();
 		} catch (error) {
-			toast.error("Failed to open project", {
-				description:
-					error instanceof Error ? error.message : "An unknown error occurred",
-			});
+			const message =
+				error instanceof Error ? error.message : "An unknown error occurred";
+			if (message.includes("spawn git ENOENT")) {
+				toast.error("Git was not found", {
+					description:
+						'Your shell config (e.g. ~/.zshrc) may have a broken command that corrupts PATH. Check for lines like export PATH="$(npm bin -g):$PATH" and remove them.',
+				});
+			} else {
+				toast.error("Failed to open project", {
+					description: message,
+				});
+			}
 		}
 	};
 

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
@@ -647,8 +647,14 @@ function PromptGroupInner({
 			{
 				loading: "Creating workspace...",
 				success: "Workspace created",
-				error: (err) =>
-					err instanceof Error ? err.message : "Failed to create workspace",
+				error: (err) => {
+					const message =
+						err instanceof Error ? err.message : "Failed to create workspace";
+					if (message.includes("spawn git ENOENT")) {
+						return 'Git was not found. Your shell config (e.g. ~/.zshrc) may have a broken command that corrupts PATH. Check for lines like export PATH="$(npm bin -g):$PATH" and remove them.';
+					}
+					return message;
+				},
 			},
 		);
 	}, [

--- a/apps/desktop/src/renderer/routes/_authenticated/_onboarding/new-project/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_onboarding/new-project/page.tsx
@@ -127,7 +127,7 @@ function NewProjectPage() {
 
 						{error && (
 							<div className="w-full flex items-start gap-2 rounded-md px-4 py-3 bg-destructive/10 border border-destructive/20">
-								<span className="flex-1 text-sm text-destructive">{error}</span>
+								<span className="flex-1 text-sm text-destructive whitespace-pre-line">{error}</span>
 								<button
 									type="button"
 									onClick={() => setError(null)}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarFooter.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarFooter.tsx
@@ -41,10 +41,18 @@ export function WorkspaceSidebarFooter({
 				}
 			}
 		} catch (error) {
-			toast.error("Failed to open project", {
-				description:
-					error instanceof Error ? error.message : "An unknown error occurred",
-			});
+			const message =
+				error instanceof Error ? error.message : "An unknown error occurred";
+			if (message.includes("spawn git ENOENT")) {
+				toast.error("Git was not found", {
+					description:
+						'Your shell config (e.g. ~/.zshrc) may have a broken command that corrupts PATH. Check for lines like export PATH="$(npm bin -g):$PATH" and remove them.',
+				});
+			} else {
+				toast.error("Failed to open project", {
+					description: message,
+				});
+			}
 		}
 	};
 


### PR DESCRIPTION
## Summary

- When `git` binary cannot be found (`spawn git ENOENT`), show a user-friendly error message explaining the likely cause and how to fix it
- Common cause: deprecated shell commands like `$(npm bin -g)` in `~/.zshrc` inject error output into `PATH`, breaking binary resolution
- Applied to all git-dependent flows: `openNew`, `openFromPath`, `cloneRepo`, `createEmptyRepo`, and new workspace creation
- Added `whitespace-pre-line` to new-project error display for proper line break rendering

### Before
Raw `spawn git ENOENT` stack trace shown to user

### After
<img width="592" height="610" alt="SCR-20260317-lmmt" src="https://github.com/user-attachments/assets/616087bd-76b7-406a-9edd-0bca29109b89" />
<img width="347" height="139" alt="SCR-20260317-lmgn" src="https://github.com/user-attachments/assets/e2f4788d-b897-4a5a-bd8e-4fd756f6fe67" />
<img width="351" height="132" alt="SCR-20260317-lmep" src="https://github.com/user-attachments/assets/00a002c5-6885-4c2a-ab13-0daecece4faa" />

## Test plan
- [ ] Add `export PATH="$(npm bin -g):$PATH"` to `~/.zshrc`
- [ ] Launch desktop app
- [ ] Try "Add Repository" > "Open Project" → verify helpful message
- [ ] Try "New Workspace" → verify helpful message in toast
- [ ] Try "New Project" > "Empty" > "Create" → verify helpful message
- [ ] Try "New Project" > "Clone" → verify helpful message
- [ ] Remove the line from `~/.zshrc` and verify normal operation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a clear, actionable message when Git isn’t missing (`spawn git ENOENT`), explaining likely PATH issues from shell config and how to fix them. Improves UX across git-dependent actions.

- **Bug Fixes**
  - Detect ENOENT and replace the raw stack with guidance (broken PATH from lines like `export PATH="$(npm bin -g):$PATH"` and how to fix).
  - Applied to `openNew`, `openFromPath`, `cloneRepo`, `createEmptyRepo`, and new workspace creation.
  - Updated toasts in NewWorkspace and Sidebar; added `whitespace-pre-line` to render multi-line errors in the new project page.

<sup>Written for commit 4af1605c65f8b4d2e087a69f23bad0bcf4856fd9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messaging when Git is unavailable across project operations. Users now receive clear, actionable guidance about configuring their system PATH instead of generic error messages when attempting to open, clone, or create projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->