### PR TITLE
fix(desktop): reduce terminal typing latency

### DIFF
--- a/apps/desktop/src/main/terminal-host/pty-subprocess.ts
+++ b/apps/desktop/src/main/terminal-host/pty-subprocess.ts
@@ -57,7 +57,6 @@ const INPUT_QUEUE_HARD_LIMIT_BYTES = 64 * 1024 * 1024; // 64MB
 let outputChunks: string[] = [];
 let outputBytesQueued = 0;
 let outputFlushScheduled = false;
-const OUTPUT_FLUSH_INTERVAL_MS = 32; // ~30 fps max
 const MAX_OUTPUT_BATCH_SIZE_BYTES = 128 * 1024; // 128KB max per flush
 
 // Backpressure - track if stdout is draining
@@ -108,7 +107,9 @@ function queueOutput(data: string): void {
 
 	if (!outputFlushScheduled) {
 		outputFlushScheduled = true;
-		setTimeout(flushOutput, OUTPUT_FLUSH_INTERVAL_MS);
+		// Flush on the next event-loop turn so interactive echo feels immediate,
+		// while still coalescing bursts that arrive in the same PTY callback cycle.
+		setImmediate(flushOutput);
 	}
 }
 


### PR DESCRIPTION
## Summary

Currently, it is really frustrating to type in superset terminals. There is a lot of input delay and it feels sluggish. This fixes it by making typing super smooth.

- replace the daemon PTY output batching timer with a next-turn flush
- remove the fixed ~30fps output cadence that was making terminal typing feel laggy
- keep burst coalescing within the same event-loop cycle without the extra timer delay

## Testing
- bun test apps/desktop/src/main/terminal-host/daemon.test.ts apps/desktop/src/main/terminal-host/session.test.ts --timeout 20000

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce terminal typing latency in the Desktop app by flushing PTY output on the next event-loop turn instead of a 32 ms timer. This removes the ~30 fps cadence so interactive echo feels immediate while still coalescing bursts within the same cycle.

<sup>Written for commit 099fcd526ba2ca8d0120b46d32b56d705cfdba2e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal output now displays with reduced latency by switching to immediate flushing, resulting in faster and more responsive output display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->