### PR TITLE
fix(desktop): normalize mcp workspace list payload

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/list-workspaces.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/list-workspaces.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import type { SelectProject, SelectWorkspace } from "@superset/local-db";
-import { buildWorkspaceList } from "./list-workspaces.utils";
-import type { WorkspaceListGroup } from "./types";
+import {
+	buildWorkspaceList,
+	type WorkspaceListSourceProject,
+	type WorkspaceListSourceWorkspace,
+} from "./list-workspaces.utils";
 
 describe("buildWorkspaceList", () => {
 	it("returns compact workspace summaries with resolved paths and active state", () => {
@@ -9,78 +11,35 @@ describe("buildWorkspaceList", () => {
 			{
 				id: "workspace-worktree",
 				projectId: "project-1",
-				worktreeId: "worktree-1",
 				type: "worktree",
 				branch: "feature/mcp-fix",
 				name: "MCP Fix",
-				tabOrder: 1,
-				createdAt: 1,
-				updatedAt: 1,
-				lastOpenedAt: 1,
-				isUnread: false,
-				isUnnamed: false,
-				deletingAt: null,
-				portBase: null,
-				sectionId: null,
 			},
 			{
 				id: "workspace-branch",
 				projectId: "project-1",
-				worktreeId: null,
 				type: "branch",
 				branch: "main",
 				name: "Main",
-				tabOrder: 2,
-				createdAt: 2,
-				updatedAt: 2,
-				lastOpenedAt: 2,
-				isUnread: false,
-				isUnnamed: false,
-				deletingAt: null,
-				portBase: null,
-				sectionId: null,
 			},
-		] satisfies SelectWorkspace[];
+		] satisfies WorkspaceListSourceWorkspace[];
 
 		const projects = [
 			{
 				id: "project-1",
-				name: "Superset",
 				mainRepoPath: "/repos/superset",
-				defaultBranch: "main",
-				workspaceBaseBranch: null,
-				color: "#000000",
-				tabOrder: 1,
-				lastOpenedAt: 1,
-				githubOwner: null,
-				iconUrl: null,
-				hideImage: false,
-				createdAt: 1,
 			},
-		] as unknown as SelectProject[];
-
-		const groupedWorkspaces = [
-			{
-				project: {
-					id: "project-1",
-					mainRepoPath: "/repos/superset",
-				},
-				workspaces: [
-					{
-						id: "workspace-worktree",
-						worktreePath: "/repos/superset-feature-mcp-fix",
-					},
-				],
-				sections: [],
-			},
-		] satisfies WorkspaceListGroup[];
+		] satisfies WorkspaceListSourceProject[];
 
 		expect(
 			buildWorkspaceList({
 				workspaces,
 				projects,
-				groupedWorkspaces,
 				activeWorkspaceId: "workspace-worktree",
+				getWorktreePathByWorkspaceId: (workspaceId) =>
+					workspaceId === "workspace-worktree"
+						? "/repos/superset-feature-mcp-fix"
+						: undefined,
 			}),
 		).toEqual([
 			{
@@ -109,21 +68,11 @@ describe("buildWorkspaceList", () => {
 			{
 				id: "workspace-worktree",
 				projectId: "project-1",
-				worktreeId: "worktree-1",
 				type: "worktree",
 				branch: "feature/missing-path",
 				name: "Missing Path",
-				tabOrder: 1,
-				createdAt: 1,
-				updatedAt: 1,
-				lastOpenedAt: 1,
-				isUnread: false,
-				isUnnamed: false,
-				deletingAt: null,
-				portBase: null,
-				sectionId: null,
 			},
-		] satisfies SelectWorkspace[];
+		] satisfies WorkspaceListSourceWorkspace[];
 
 		expect(
 			buildWorkspaceList({

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/list-workspaces.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/list-workspaces.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
-import { buildWorkspaceList } from "./list-workspaces.utils";
+import {
+	buildWorkspaceList,
+	type ListedWorkspace,
+} from "./list-workspaces.utils";
 import type { CommandResult, ToolContext, ToolDefinition } from "./types";
 
 const schema = z.object({});
@@ -7,7 +10,7 @@ const schema = z.object({});
 async function execute(
 	_params: z.infer<typeof schema>,
 	ctx: ToolContext,
-): Promise<CommandResult> {
+): Promise<CommandResult<{ workspaces: ListedWorkspace[] }>> {
 	const workspaces = ctx.getWorkspaces();
 
 	if (!workspaces) {
@@ -20,14 +23,17 @@ async function execute(
 			workspaces: buildWorkspaceList({
 				workspaces,
 				projects: ctx.getProjects(),
-				groupedWorkspaces: ctx.getWorkspaceGroups(),
 				activeWorkspaceId: ctx.getActiveWorkspaceId(),
-			}) as unknown as Record<string, unknown>[],
+				getWorktreePathByWorkspaceId: ctx.getWorktreePathByWorkspaceId,
+			}),
 		},
 	};
 }
 
-export const listWorkspaces: ToolDefinition<typeof schema> = {
+export const listWorkspaces: ToolDefinition<
+	typeof schema,
+	{ workspaces: ListedWorkspace[] }
+> = {
 	name: "list_workspaces",
 	schema,
 	execute,

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/list-workspaces.utils.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/list-workspaces.utils.ts
@@ -1,5 +1,4 @@
 import type { SelectProject, SelectWorkspace } from "@superset/local-db";
-import type { WorkspaceListGroup } from "./types";
 
 export interface ListedWorkspace {
 	id: string;
@@ -11,33 +10,30 @@ export interface ListedWorkspace {
 	type: "worktree" | "branch";
 }
 
+export type WorkspaceListSourceWorkspace = Pick<
+	SelectWorkspace,
+	"id" | "name" | "branch" | "projectId" | "type"
+>;
+
+export type WorkspaceListSourceProject = Pick<
+	SelectProject,
+	"id" | "mainRepoPath"
+>;
+
 export function buildWorkspaceList({
 	workspaces,
 	projects,
-	groupedWorkspaces,
 	activeWorkspaceId,
+	getWorktreePathByWorkspaceId,
 }: {
-	workspaces: SelectWorkspace[];
-	projects?: SelectProject[];
-	groupedWorkspaces?: WorkspaceListGroup[];
+	workspaces: WorkspaceListSourceWorkspace[];
+	projects?: WorkspaceListSourceProject[];
 	activeWorkspaceId: string | null;
+	getWorktreePathByWorkspaceId?: (workspaceId: string) => string | undefined;
 }): ListedWorkspace[] {
 	const mainRepoPathByProjectId = new Map(
 		(projects ?? []).map((project) => [project.id, project.mainRepoPath]),
 	);
-	const worktreePathByWorkspaceId = new Map<string, string>();
-
-	for (const group of groupedWorkspaces ?? []) {
-		for (const workspace of group.workspaces) {
-			worktreePathByWorkspaceId.set(workspace.id, workspace.worktreePath);
-		}
-
-		for (const section of group.sections) {
-			for (const workspace of section.workspaces) {
-				worktreePathByWorkspaceId.set(workspace.id, workspace.worktreePath);
-			}
-		}
-	}
 
 	return workspaces.map((workspace) => ({
 		id: workspace.id,
@@ -45,7 +41,7 @@ export function buildWorkspaceList({
 		path:
 			workspace.type === "branch"
 				? (mainRepoPathByProjectId.get(workspace.projectId) ?? "")
-				: (worktreePathByWorkspaceId.get(workspace.id) ?? ""),
+				: (getWorktreePathByWorkspaceId?.(workspace.id) ?? ""),
 		branch: workspace.branch,
 		isActive: workspace.id === activeWorkspaceId,
 		projectId: workspace.projectId,

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/types.ts
@@ -2,9 +2,11 @@ import type { SelectProject, SelectWorkspace } from "@superset/local-db";
 import type { electronTrpc } from "renderer/lib/electron-trpc";
 import type { z } from "zod";
 
-export interface CommandResult {
+export interface CommandResult<
+	TData extends Record<string, unknown> = Record<string, unknown>,
+> {
 	success: boolean;
-	data?: Record<string, unknown>;
+	data?: TData;
 	error?: string;
 }
 
@@ -12,24 +14,6 @@ export interface BulkItemError {
 	index: number;
 	error: string;
 	[key: string]: unknown;
-}
-
-export interface WorkspaceListGroupItem {
-	id: string;
-	worktreePath: string;
-}
-
-export interface WorkspaceListSection {
-	workspaces: WorkspaceListGroupItem[];
-}
-
-export interface WorkspaceListGroup {
-	project: {
-		id: string;
-		mainRepoPath: string;
-	};
-	workspaces: WorkspaceListGroupItem[];
-	sections: WorkspaceListSection[];
 }
 
 export function buildBulkResult<T>({
@@ -44,7 +28,7 @@ export function buildBulkResult<T>({
 	itemKey: string;
 	allFailedMessage: string;
 	total: number;
-}): CommandResult {
+}): CommandResult<Record<string, unknown>> {
 	const data: Record<string, unknown> = {
 		[itemKey]: items,
 		summary: { total, succeeded: items.length, failed: errors.length },
@@ -75,14 +59,20 @@ export interface ToolContext {
 	// Query helpers
 	refetchWorkspaces: () => Promise<unknown>;
 	getWorkspaces: () => SelectWorkspace[] | undefined;
-	getWorkspaceGroups: () => WorkspaceListGroup[] | undefined;
 	getProjects: () => SelectProject[] | undefined;
 	getActiveWorkspaceId: () => string | null;
+	getWorktreePathByWorkspaceId: (workspaceId: string) => string | undefined;
 }
 
 // Tool definition with schema and execute function
-export interface ToolDefinition<T extends z.ZodType> {
+export interface ToolDefinition<
+	T extends z.ZodType,
+	TResult extends Record<string, unknown> = Record<string, unknown>,
+> {
 	name: string;
 	schema: T;
-	execute: (params: z.infer<T>, ctx: ToolContext) => Promise<CommandResult>;
+	execute: (
+		params: z.infer<T>,
+		ctx: ToolContext,
+	) => Promise<CommandResult<TResult>>;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/useCommandWatcher.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/useCommandWatcher.ts
@@ -38,6 +38,23 @@ export function useCommandWatcher() {
 	const { data: workspaceGroups } =
 		electronTrpc.workspaces.getAllGrouped.useQuery();
 	const { data: projects } = electronTrpc.projects.getRecents.useQuery();
+	const worktreePathByWorkspaceId = useMemo(() => {
+		const pathByWorkspaceId = new Map<string, string>();
+
+		for (const group of workspaceGroups ?? []) {
+			for (const workspace of group.workspaces) {
+				pathByWorkspaceId.set(workspace.id, workspace.worktreePath);
+			}
+
+			for (const section of group.sections) {
+				for (const workspace of section.workspaces) {
+					pathByWorkspaceId.set(workspace.id, workspace.worktreePath);
+				}
+			}
+		}
+
+		return pathByWorkspaceId;
+	}, [workspaceGroups]);
 
 	const getCurrentWorkspaceIdFromRoute = useCallback(() => {
 		const hash = window.location.hash;
@@ -56,9 +73,10 @@ export function useCommandWatcher() {
 			terminalWrite,
 			refetchWorkspaces: async () => refetchWorkspaces(),
 			getWorkspaces: () => workspaces,
-			getWorkspaceGroups: () => workspaceGroups,
 			getProjects: () => projects,
 			getActiveWorkspaceId: getCurrentWorkspaceIdFromRoute,
+			getWorktreePathByWorkspaceId: (workspaceId) =>
+				worktreePathByWorkspaceId.get(workspaceId),
 		}),
 		[
 			createWorktree,
@@ -69,9 +87,9 @@ export function useCommandWatcher() {
 			terminalWrite,
 			refetchWorkspaces,
 			workspaces,
-			workspaceGroups,
 			projects,
 			getCurrentWorkspaceIdFromRoute,
+			worktreePathByWorkspaceId,
 		],
 	);
 


### PR DESCRIPTION
## Summary
- normalize the desktop `list_workspaces` MCP response to a compact, stable workspace summary instead of returning raw local-db rows
- resolve workspace paths and active state before writing the command result back to `agent_commands`
- tighten the tool contract by using typed results, a smaller watcher context surface, and minimal mapper fixtures in tests

## Why / Context
`list_workspaces` was the odd tool out in the desktop command watcher: it returned raw workspace records instead of a trimmed DTO like the adjacent MCP tools. That mismatch made the payload less stable for MCP consumers and was the most likely cause behind the timeout report for this command.

## How It Works
The desktop watcher still reads workspace, grouped-workspace, and project data, but it now precomputes a `workspaceId -> worktreePath` lookup before invoking the tool. `list_workspaces` uses a small mapper to emit a normalized list with resolved `path`, `branch`, and `isActive` fields. Branch workspaces use the project main repo path, while worktree workspaces use the lookup derived from grouped workspaces.

The follow-up refactor removes the previous double-cast in the tool response, makes `CommandResult`/`ToolDefinition` typed, and keeps the workspace-list-only shapes out of the shared tool types file.

## Manual QA Checklist
- [ ] Run `list_workspaces` against a live desktop device and confirm the command completes without timing out
- [ ] Verify branch workspaces return the project main repo path
- [ ] Verify worktree workspaces return their worktree path and mark the active workspace correctly

## Testing
- `bun test apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/list-workspaces.test.ts`
- `bun run --cwd apps/desktop typecheck`
- `bun run lint`
- Attempted earlier: `bun run build` (the build reached Electron bundle generation and asset output, but the shell session did not return cleanly, so I am not counting it as fully verified)

## Known Limitations
- I did not rerun a live end-to-end MCP invocation from a connected desktop session in this workspace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved workspace listing: shows resolved paths, branch, project association, and active state; supports worktree path lookup.
  * Tool context now exposes a worktree-path accessor for accurate path resolution.

* **Tests**
  * Added tests verifying compact workspace summaries, path fallback behavior, and active-state calculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->