### PR TITLE
fix(desktop): submit Create Workspace modal from any focused field

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
@@ -72,6 +72,7 @@ import type { LinkedPR } from "../../NewWorkspaceModalDraftContext";
 import { useNewWorkspaceModalDraft } from "../../NewWorkspaceModalDraftContext";
 import { LinkedPRPill } from "./components/LinkedPRPill";
 import { PRLinkCommand } from "./components/PRLinkCommand";
+import { handleCreateShortcutKeyDown } from "./handleCreateShortcutKeyDown";
 
 type WorkspaceCreateAgent = AgentDefinitionId | "none";
 
@@ -745,6 +746,11 @@ function PromptGroupInner({
 				multiple
 				maxFiles={5}
 				maxFileSize={10 * 1024 * 1024}
+				onKeyDown={(event) => {
+					handleCreateShortcutKeyDown(event, () => {
+						void handleCreate();
+					});
+				}}
 				className="[&>[data-slot=input-group]]:rounded-[13px] [&>[data-slot=input-group]]:border-[0.5px] [&>[data-slot=input-group]]:shadow-none [&>[data-slot=input-group]]:bg-foreground/[0.02]"
 			>
 				{(linkedPR ||
@@ -795,12 +801,6 @@ function PromptGroupInner({
 					className="min-h-10"
 					value={prompt}
 					onChange={(e) => updateDraft({ prompt: e.target.value })}
-					onKeyDown={(e) => {
-						if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-							e.preventDefault();
-							void handleCreate();
-						}
-					}}
 				/>
 				<PromptInputFooter>
 					<PromptInputTools className="gap-1.5">

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/handleCreateShortcutKeyDown.test.ts
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/handleCreateShortcutKeyDown.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, mock, test } from "bun:test";
+import { handleCreateShortcutKeyDown } from "./handleCreateShortcutKeyDown";
+
+function createKeyboardEvent(
+	overrides: Partial<{
+		key: string;
+		metaKey: boolean;
+		ctrlKey: boolean;
+	}> = {},
+) {
+	return {
+		key: "Enter",
+		metaKey: false,
+		ctrlKey: false,
+		preventDefault: mock(() => {}),
+		...overrides,
+	};
+}
+
+describe("handleCreateShortcutKeyDown", () => {
+	test("submits when Cmd+Enter is pressed", () => {
+		const event = createKeyboardEvent({ metaKey: true });
+		const onCreate = mock(() => {});
+
+		handleCreateShortcutKeyDown(event, onCreate);
+
+		expect(event.preventDefault).toHaveBeenCalledTimes(1);
+		expect(onCreate).toHaveBeenCalledTimes(1);
+	});
+
+	test("submits when Ctrl+Enter is pressed", () => {
+		const event = createKeyboardEvent({ ctrlKey: true });
+		const onCreate = mock(() => {});
+
+		handleCreateShortcutKeyDown(event, onCreate);
+
+		expect(event.preventDefault).toHaveBeenCalledTimes(1);
+		expect(onCreate).toHaveBeenCalledTimes(1);
+	});
+
+	test("does not submit on plain Enter", () => {
+		const event = createKeyboardEvent();
+		const onCreate = mock(() => {});
+
+		handleCreateShortcutKeyDown(event, onCreate);
+
+		expect(event.preventDefault).not.toHaveBeenCalled();
+		expect(onCreate).not.toHaveBeenCalled();
+	});
+});

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/handleCreateShortcutKeyDown.ts
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/handleCreateShortcutKeyDown.ts
@@ -1,0 +1,18 @@
+type CreateShortcutKeyboardEvent = {
+	key: string;
+	metaKey: boolean;
+	ctrlKey: boolean;
+	preventDefault: () => void;
+};
+
+export function handleCreateShortcutKeyDown(
+	event: CreateShortcutKeyboardEvent,
+	onCreate: () => void,
+) {
+	if (event.key !== "Enter" || (!event.metaKey && !event.ctrlKey)) {
+		return;
+	}
+
+	event.preventDefault();
+	onCreate();
+}


### PR DESCRIPTION
## Summary
- handle Cmd/Ctrl+Enter at the PromptInput form level instead of only on the textarea
- keep the shortcut logic in a small utility so the behavior is testable
- add a regression test covering Cmd+Enter, Ctrl+Enter, and plain Enter

Closes #2454

## Verification
- `bun test ./apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/handleCreateShortcutKeyDown.test.ts`
- `bun run typecheck` *(blocked locally: `tsr` command not found because this checkout does not have workspace dependencies installed)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow submitting the Create Workspace modal with Cmd+Enter or Ctrl+Enter from any focused field. Fixes inconsistent behavior when focus isn’t on the prompt.

- **Bug Fixes**
  - Handle the shortcut at the PromptInput form level via a `handleCreateShortcutKeyDown` util.
  - Added tests covering Cmd+Enter, Ctrl+Enter, and plain Enter.

<sup>Written for commit 1288072466e1c23f8fad23978cd07bc84468c677. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut (Enter+Cmd on Mac or Enter+Ctrl on Windows/Linux) to quickly create new workspaces.

* **Tests**
  * Added unit tests to verify the new keyboard shortcut behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->