### PR TITLE
fix(desktop): cmd+click opens file in new tab from file tree

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
@@ -416,10 +416,11 @@ export function FilesView() {
 	const [showDeleteDialog, setShowDeleteDialog] = useState(false);
 
 	const handleFileActivate = useCallback(
-		(entry: DirectoryEntry) => {
+		(entry: DirectoryEntry, openInNewTab?: boolean) => {
 			if (!workspaceId || !worktreePath || entry.isDirectory) return;
 			addFileViewerPane(workspaceId, {
 				filePath: entry.path,
+				openInNewTab,
 			});
 		},
 		[workspaceId, worktreePath, addFileViewerPane],

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileSearchResultItem/FileSearchResultItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileSearchResultItem/FileSearchResultItem.tsx
@@ -25,7 +25,7 @@ interface FileSearchResultItemProps {
 	entry: DirectoryEntry;
 	worktreePath: string;
 	projectId?: string;
-	onActivate: (entry: DirectoryEntry) => void;
+	onActivate: (entry: DirectoryEntry, openInNewTab?: boolean) => void;
 	onOpenInEditor: (entry: DirectoryEntry) => void;
 	onNewFile: (parentPath: string) => void;
 	onNewFolder: (parentPath: string) => void;
@@ -83,9 +83,9 @@ export function FileSearchResultItem({
 
 	const fileDragProps = useFileDrag({ absolutePath: entry.path });
 
-	const handleClick = () => {
+	const handleClick = (e: React.MouseEvent) => {
 		if (!entry.isDirectory) {
-			onActivate(entry);
+			onActivate(entry, e.metaKey || e.ctrlKey ? true : undefined);
 		}
 	};
 
@@ -97,7 +97,7 @@ export function FileSearchResultItem({
 		if (e.key === "Enter") {
 			e.preventDefault();
 			if (!entry.isDirectory) {
-				onActivate(entry);
+				onActivate(entry, e.metaKey || e.ctrlKey ? true : undefined);
 			}
 		}
 	};

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileTreeItem/FileTreeItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileTreeItem/FileTreeItem.tsx
@@ -30,7 +30,7 @@ interface FileTreeItemProps {
 	indent: number;
 	worktreePath: string;
 	projectId?: string;
-	onActivate: (entry: DirectoryEntry) => void;
+	onActivate: (entry: DirectoryEntry, openInNewTab?: boolean) => void;
 	onOpenInEditor: (entry: DirectoryEntry) => void;
 	onNewFile: (parentPath: string) => void;
 	onNewFolder: (parentPath: string) => void;
@@ -79,7 +79,7 @@ export function FileTreeItem({
 				item.expand();
 			}
 		} else {
-			onActivate(entry);
+			onActivate(entry, e.metaKey || e.ctrlKey ? true : undefined);
 		}
 	};
 
@@ -98,7 +98,7 @@ export function FileTreeItem({
 					item.expand();
 				}
 			} else {
-				onActivate(entry);
+				onActivate(entry, e.metaKey || e.ctrlKey ? true : undefined);
 			}
 		}
 	};

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -739,7 +739,8 @@ export const useTabsStore = create<TabsStore>()(
 						);
 
 					// If we found an unpinned (preview) file-viewer pane, reuse it
-					if (fileViewerPanes.length > 0) {
+					// (skip reuse when explicitly requesting a new tab, e.g. cmd+click)
+					if (fileViewerPanes.length > 0 && !options.openInNewTab) {
 						const paneToReuse = fileViewerPanes[0];
 						const existingFileViewer = paneToReuse.fileViewer;
 						if (!existingFileViewer) {
@@ -837,7 +838,10 @@ export const useTabsStore = create<TabsStore>()(
 					if (options.openInNewTab) {
 						const workspaceId = activeTab.workspaceId;
 						const newTabId = generateId("tab");
-						const newPane = createFileViewerPane(newTabId, options);
+						const newPane = createFileViewerPane(newTabId, {
+							...options,
+							isPinned: true,
+						});
 
 						const newTab = {
 							id: newTabId,


### PR DESCRIPTION
## Summary

- Cmd+click (or Ctrl+click on Windows/Linux) on a file in the file tree or search results now opens it in a new tab
- Fixed the tabs store to skip preview-pane reuse when `openInNewTab` is requested, which was swallowing the new-tab intent
- New tabs opened via cmd+click are pinned so they persist

## Test plan

- [ ] Click a file in file tree → opens in current/preview pane (existing behavior)
- [ ] Cmd+click a file in file tree → opens in a new tab
- [ ] Cmd+click a file in file search results → opens in a new tab
- [ ] New tab from cmd+click is pinned (doesn't get replaced by subsequent single clicks)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cmd/Ctrl+click or Cmd/Ctrl+Enter on a file in the file tree or search opens it in a new, pinned tab. Single-click keeps the existing preview behavior.

- **New Features**
  - Cmd/Ctrl+click or Cmd/Ctrl+Enter opens files in a new tab from the file tree and search.

- **Bug Fixes**
  - Tabs store skips preview-pane reuse and pins the tab when `openInNewTab` is set, ensuring a persistent new tab is created.

<sup>Written for commit cc2f6c3c263f8ef51043228cfa278a0ef5722930. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hold Cmd (macOS) or Ctrl (Windows/Linux) while clicking a file or pressing Enter on a file in the file list, file tree, or search results to open it in a dedicated, pinned new tab.
  * New-tab opens are kept separate from preview tabs and will not reuse or replace existing preview panes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->