### PR TITLE
feat: allow custom theme mapping for System theme mode

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/SystemThemeCard/SystemThemeCard.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/SystemThemeCard/SystemThemeCard.tsx
@@ -1,18 +1,22 @@
 import { cn } from "@superset/ui/utils";
 import { HiCheck } from "react-icons/hi2";
-import { darkTheme, lightTheme } from "shared/themes";
+import type { Theme } from "shared/themes";
 
 interface SystemThemeCardProps {
 	isSelected: boolean;
 	onSelect: () => void;
+	darkTheme: Theme | undefined;
+	lightTheme: Theme | undefined;
 }
 
 export function SystemThemeCard({
 	isSelected,
 	onSelect,
+	darkTheme,
+	lightTheme,
 }: SystemThemeCardProps) {
-	const darkTerminal = darkTheme.terminal;
-	const lightTerminal = lightTheme.terminal;
+	const darkTerminal = darkTheme?.terminal;
+	const lightTerminal = lightTheme?.terminal;
 
 	if (!darkTerminal || !lightTerminal) {
 		return null;
@@ -59,15 +63,17 @@ export function SystemThemeCard({
 						</div>
 					</div>
 					<div className="flex gap-0.5 mt-2">
-						{[darkTerminal.red, darkTerminal.green, darkTerminal.yellow].map(
-							(color) => (
-								<div
-									key={color}
-									className="h-2 w-3 rounded-sm"
-									style={{ backgroundColor: color }}
-								/>
-							),
-						)}
+						{[
+							darkTerminal.red,
+							darkTerminal.green,
+							darkTerminal.yellow,
+						].map((color) => (
+							<div
+								key={color}
+								className="h-2 w-3 rounded-sm"
+								style={{ backgroundColor: color }}
+							/>
+						))}
 					</div>
 				</div>
 
@@ -99,15 +105,17 @@ export function SystemThemeCard({
 						</div>
 					</div>
 					<div className="flex gap-0.5 mt-2">
-						{[lightTerminal.red, lightTerminal.green, lightTerminal.yellow].map(
-							(color) => (
-								<div
-									key={color}
-									className="h-2 w-3 rounded-sm"
-									style={{ backgroundColor: color }}
-								/>
-							),
-						)}
+						{[
+							lightTerminal.red,
+							lightTerminal.green,
+							lightTerminal.yellow,
+						].map((color) => (
+							<div
+								key={color}
+								className="h-2 w-3 rounded-sm"
+								style={{ backgroundColor: color }}
+							/>
+						))}
 					</div>
 				</div>
 			</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/ThemeSection/ThemeSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/ThemeSection/ThemeSection.tsx
@@ -1,5 +1,12 @@
 import { COMPANY } from "@superset/shared/constants";
 import { Button } from "@superset/ui/button";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@superset/ui/select";
 import { toast } from "@superset/ui/sonner";
 import { type ChangeEvent, useRef, useState } from "react";
 import {
@@ -9,7 +16,10 @@ import {
 } from "react-icons/hi2";
 import {
 	SYSTEM_THEME_ID,
+	useSetSystemTheme,
 	useSetTheme,
+	useSystemDarkThemeId,
+	useSystemLightThemeId,
 	useThemeId,
 	useThemeStore,
 } from "renderer/stores";
@@ -28,11 +38,17 @@ export function ThemeSection() {
 	const [isImporting, setIsImporting] = useState(false);
 	const activeThemeId = useThemeId();
 	const setTheme = useSetTheme();
+	const setSystemTheme = useSetSystemTheme();
+	const systemDarkThemeId = useSystemDarkThemeId();
+	const systemLightThemeId = useSystemLightThemeId();
 	const activeTheme = useThemeStore((state) => state.activeTheme);
 	const customThemes = useThemeStore((state) => state.customThemes);
 	const upsertCustomThemes = useThemeStore((state) => state.upsertCustomThemes);
 
 	const allThemes = [...builtInThemes, ...customThemes];
+	const darkThemes = allThemes.filter((t) => t.type === "dark");
+	const lightThemes = allThemes.filter((t) => t.type === "light");
+	const isSystemSelected = activeThemeId === SYSTEM_THEME_ID;
 
 	const handleImport = async (event: ChangeEvent<HTMLInputElement>) => {
 		const file = event.target.files?.[0];
@@ -166,8 +182,14 @@ export function ThemeSection() {
 			</div>
 			<div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
 				<SystemThemeCard
-					isSelected={activeThemeId === SYSTEM_THEME_ID}
+					isSelected={isSystemSelected}
 					onSelect={() => setTheme(SYSTEM_THEME_ID)}
+					darkTheme={darkThemes.find(
+						(t) => t.id === systemDarkThemeId,
+					)}
+					lightTheme={lightThemes.find(
+						(t) => t.id === systemLightThemeId,
+					)}
 				/>
 				{allThemes.map((theme) => (
 					<ThemeCard
@@ -178,6 +200,61 @@ export function ThemeSection() {
 					/>
 				))}
 			</div>
+
+			{/* System theme mapping — shown below the grid when System is active */}
+			{isSystemSelected && (
+				<div className="mt-3 flex flex-wrap items-center gap-x-2 gap-y-1.5 rounded-lg border border-border bg-card px-4 py-3">
+					<span className="text-xs font-medium text-muted-foreground">
+						System uses
+					</span>
+					<Select
+						value={systemDarkThemeId}
+						onValueChange={(id) =>
+							setSystemTheme("dark", id)
+						}
+					>
+						<SelectTrigger size="sm" className="w-auto">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							{darkThemes.map((theme) => (
+								<SelectItem
+									key={theme.id}
+									value={theme.id}
+								>
+									{theme.name}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+					<span className="text-xs text-muted-foreground">
+						when dark,
+					</span>
+					<Select
+						value={systemLightThemeId}
+						onValueChange={(id) =>
+							setSystemTheme("light", id)
+						}
+					>
+						<SelectTrigger size="sm" className="w-auto">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							{lightThemes.map((theme) => (
+								<SelectItem
+									key={theme.id}
+									value={theme.id}
+								>
+									{theme.name}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+					<span className="text-xs text-muted-foreground">
+						when light
+					</span>
+				</div>
+			)}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/stores/theme/index.ts
+++ b/apps/desktop/src/renderer/stores/theme/index.ts
@@ -1,7 +1,10 @@
 export {
 	SYSTEM_THEME_ID,
 	useResolvedTheme,
+	useSetSystemTheme,
 	useSetTheme,
+	useSystemDarkThemeId,
+	useSystemLightThemeId,
 	useTerminalTheme,
 	useTheme,
 	useThemeId,

--- a/apps/desktop/src/renderer/stores/theme/store.test.ts
+++ b/apps/desktop/src/renderer/stores/theme/store.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Mock trpc-storage before importing the store — the persist middleware
+// tries to reach Electron IPC which isn't available in tests.
+mock.module("../../lib/trpc-storage", () => {
+	const noopStorage = {
+		getItem: () => null,
+		setItem: () => {},
+		removeItem: () => {},
+	};
+	return {
+		trpcThemeStorage: noopStorage,
+		trpcTabsStorage: noopStorage,
+		trpcHotkeysStorage: noopStorage,
+		trpcRingtoneStorage: noopStorage,
+		setSkipNextHotkeysPersist: () => {},
+	};
+});
+
+// Provide a minimal matchMedia so getSystemPreferredThemeType() works.
+if (typeof window !== "undefined" && !window.matchMedia) {
+	// biome-ignore lint/suspicious/noExplicitAny: minimal mock for tests
+	(window as any).matchMedia = () => ({
+		matches: true, // simulate dark mode
+		addEventListener: () => {},
+		removeEventListener: () => {},
+	});
+}
+
+const { SYSTEM_THEME_ID, useThemeStore } = await import("./store");
+
+function getState() {
+	return useThemeStore.getState();
+}
+
+describe("system theme mapping", () => {
+	beforeEach(() => {
+		useThemeStore.setState({
+			activeThemeId: "dark",
+			systemDarkThemeId: "dark",
+			systemLightThemeId: "light",
+			customThemes: [],
+		});
+	});
+
+	test("initial system theme IDs default to dark and light", () => {
+		expect(getState().systemDarkThemeId).toBe("dark");
+		expect(getState().systemLightThemeId).toBe("light");
+	});
+
+	test("setSystemTheme updates the dark mapping", () => {
+		getState().setSystemTheme("dark", "monokai");
+		expect(getState().systemDarkThemeId).toBe("monokai");
+		expect(getState().systemLightThemeId).toBe("light");
+	});
+
+	test("setSystemTheme updates the light mapping", () => {
+		getState().setSystemTheme("light", "catppuccin-latte");
+		expect(getState().systemDarkThemeId).toBe("dark");
+		expect(getState().systemLightThemeId).toBe("catppuccin-latte");
+	});
+
+	test("removeCustomTheme resets system dark mapping if it references the removed theme", () => {
+		getState().setSystemTheme("dark", "custom-dark");
+		expect(getState().systemDarkThemeId).toBe("custom-dark");
+
+		getState().removeCustomTheme("custom-dark");
+		expect(getState().systemDarkThemeId).toBe("dark");
+	});
+
+	test("removeCustomTheme resets system light mapping if it references the removed theme", () => {
+		getState().setSystemTheme("light", "custom-light");
+		expect(getState().systemLightThemeId).toBe("custom-light");
+
+		getState().removeCustomTheme("custom-light");
+		expect(getState().systemLightThemeId).toBe("light");
+	});
+
+	test("removeCustomTheme does not reset unrelated system mappings", () => {
+		getState().setSystemTheme("dark", "monokai");
+		getState().setSystemTheme("light", "catppuccin-latte");
+
+		getState().removeCustomTheme("some-other-theme");
+		expect(getState().systemDarkThemeId).toBe("monokai");
+		expect(getState().systemLightThemeId).toBe("catppuccin-latte");
+	});
+
+	test("setTheme to system stores SYSTEM_THEME_ID as activeThemeId", () => {
+		getState().setTheme(SYSTEM_THEME_ID);
+		expect(getState().activeThemeId).toBe(SYSTEM_THEME_ID);
+	});
+});

--- a/apps/desktop/src/renderer/stores/theme/store.ts
+++ b/apps/desktop/src/renderer/stores/theme/store.ts
@@ -19,6 +19,12 @@ interface ThemeState {
 	/** Current active theme ID (can be "system" or a specific theme ID) */
 	activeThemeId: string;
 
+	/** Theme ID to use when system preference is dark (defaults to "dark") */
+	systemDarkThemeId: string;
+
+	/** Theme ID to use when system preference is light (defaults to "light") */
+	systemLightThemeId: string;
+
 	/** List of custom (user-imported) themes */
 	customThemes: Theme[];
 
@@ -30,6 +36,9 @@ interface ThemeState {
 
 	/** Set the active theme by ID (can be "system" or a specific theme ID) */
 	setTheme: (themeId: string) => void;
+
+	/** Set which theme to use for a given system preference mode */
+	setSystemTheme: (mode: "dark" | "light", themeId: string) => void;
 
 	/** Add a custom theme */
 	addCustomTheme: (theme: Theme) => void;
@@ -62,11 +71,17 @@ function getSystemPreferredThemeType(): "dark" | "light" {
 
 /**
  * Resolve a theme ID to the actual theme ID to use.
- * If "system" is passed, resolves to "dark" or "light" based on OS preference.
+ * If "system" is passed, resolves based on OS preference and the configured
+ * system theme mappings.
  */
-function resolveThemeId(themeId: string): string {
+function resolveThemeId(
+	themeId: string,
+	systemDarkThemeId: string,
+	systemLightThemeId: string,
+): string {
 	if (themeId === SYSTEM_THEME_ID) {
-		return getSystemPreferredThemeType();
+		const osMode = getSystemPreferredThemeType();
+		return osMode === "dark" ? systemDarkThemeId : systemLightThemeId;
 	}
 	return themeId;
 }
@@ -126,6 +141,8 @@ export const useThemeStore = create<ThemeState>()(
 		persist(
 			(set, get) => ({
 				activeThemeId: DEFAULT_THEME_ID,
+				systemDarkThemeId: "dark",
+				systemLightThemeId: "light",
 				customThemes: [],
 				activeTheme: null,
 				terminalTheme: null,
@@ -133,7 +150,11 @@ export const useThemeStore = create<ThemeState>()(
 				setTheme: (themeId: string) => {
 					const state = get();
 					// Resolve system theme to actual theme ID
-					const resolvedId = resolveThemeId(themeId);
+					const resolvedId = resolveThemeId(
+						themeId,
+						state.systemDarkThemeId,
+						state.systemLightThemeId,
+					);
 					const theme = findTheme(resolvedId, state.customThemes);
 
 					if (!theme) {
@@ -148,6 +169,22 @@ export const useThemeStore = create<ThemeState>()(
 						activeTheme: theme, // Store the resolved theme
 						terminalTheme,
 					});
+				},
+
+				setSystemTheme: (mode: "dark" | "light", themeId: string) => {
+					const state = get();
+					const update =
+						mode === "dark"
+							? { systemDarkThemeId: themeId }
+							: { systemLightThemeId: themeId };
+
+					set(update);
+
+					// Re-apply if system theme is currently active
+					if (state.activeThemeId === SYSTEM_THEME_ID) {
+						const nextState = get();
+						nextState.setTheme(SYSTEM_THEME_ID);
+					}
 				},
 
 				addCustomTheme: (theme: Theme) => {
@@ -184,7 +221,11 @@ export const useThemeStore = create<ThemeState>()(
 					}
 
 					const customThemes = Array.from(customThemesById.values());
-					const resolvedId = resolveThemeId(state.activeThemeId);
+					const resolvedId = resolveThemeId(
+						state.activeThemeId,
+						state.systemDarkThemeId,
+						state.systemLightThemeId,
+					);
 					const resolvedTheme = findTheme(resolvedId, customThemes);
 
 					if (!resolvedTheme) {
@@ -210,7 +251,17 @@ export const useThemeStore = create<ThemeState>()(
 						state.setTheme(DEFAULT_THEME_ID);
 					}
 
+					// Reset system theme mappings if they reference the removed theme
+					const updates: Partial<ThemeState> = {};
+					if (state.systemDarkThemeId === themeId) {
+						updates.systemDarkThemeId = "dark";
+					}
+					if (state.systemLightThemeId === themeId) {
+						updates.systemLightThemeId = "light";
+					}
+
 					set((state) => ({
+						...updates,
 						customThemes: state.customThemes.filter((t) => t.id !== themeId),
 					}));
 				},
@@ -230,7 +281,11 @@ export const useThemeStore = create<ThemeState>()(
 
 				initializeTheme: () => {
 					const state = get();
-					const resolvedId = resolveThemeId(state.activeThemeId);
+					const resolvedId = resolveThemeId(
+						state.activeThemeId,
+						state.systemDarkThemeId,
+						state.systemLightThemeId,
+					);
 					const theme = findTheme(resolvedId, state.customThemes);
 
 					if (theme) {
@@ -264,6 +319,8 @@ export const useThemeStore = create<ThemeState>()(
 				storage: trpcThemeStorage,
 				partialize: (state) => ({
 					activeThemeId: state.activeThemeId,
+					systemDarkThemeId: state.systemDarkThemeId,
+					systemLightThemeId: state.systemLightThemeId,
 					customThemes: state.customThemes,
 				}),
 				onRehydrateStorage: () => (state) => {
@@ -284,4 +341,10 @@ export const useResolvedTheme = () =>
 export const useTerminalTheme = () =>
 	useThemeStore((state) => state.terminalTheme);
 export const useSetTheme = () => useThemeStore((state) => state.setTheme);
+export const useSetSystemTheme = () =>
+	useThemeStore((state) => state.setSystemTheme);
 export const useThemeId = () => useThemeStore((state) => state.activeThemeId);
+export const useSystemDarkThemeId = () =>
+	useThemeStore((state) => state.systemDarkThemeId);
+export const useSystemLightThemeId = () =>
+	useThemeStore((state) => state.systemLightThemeId);


### PR DESCRIPTION
## Summary
- Adds the ability to configure which dark/light themes are used when "System" theme mode is selected, instead of always defaulting to the built-in Dark/Light themes
- Theme selectors render as an inline configuration strip below the theme grid when System is active ("System uses [X] when dark, [Y] when light")
- System theme mappings reset to defaults when a referenced custom theme is removed

<img width="1235" height="814" alt="image" src="https://github.com/user-attachments/assets/c2edd7b6-0970-4de4-a117-535e8d0e3260" />


## Test plan
- [x] Typecheck passes (`bun run --cwd apps/desktop typecheck`)
- [x] All 1231 tests pass (`bun test` — 0 failures)
- [x] 7 new store tests cover system theme mapping behavior
- [x] Manual: select System theme, verify dark/light dropdowns appear below grid
- [x] Manual: change dark/light mappings and verify preview updates
- [x] Manual: import custom theme, assign it to System mapping, then delete it — mapping should reset to default

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable dark/light theme mapping for System mode so users can choose which themes apply to OS dark/light. Shows compact selectors below the theme grid when System is selected and updates the preview instantly.

- **New Features**
  - Choose the dark and light themes System mode uses via dropdowns shown when System is active.
  - Theme resolution now respects these mappings and reapplies immediately if changed while System is active.
  - Mappings auto-reset to defaults if a referenced custom theme is removed.
  - Added store hooks for setting/getting mappings and tests covering the behavior.

<sup>Written for commit 7cf2627fcc63588582e9ede81db248f7a4616e16. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now configure which dark and light themes are automatically applied when the system theme mode is active, enabling custom appearance preferences based on operating system color scheme changes.

* **Tests**
  * Added comprehensive test coverage for system theme mapping and configuration functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->