### PR TITLE
Support separate canary signing secrets

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -106,11 +106,11 @@ jobs:
       - name: Build Electron app
         working-directory: apps/desktop
         env:
-          CSC_LINK: ${{ secrets.MAC_CERTIFICATE }}
-          CSC_KEY_PASSWORD: ${{ secrets.MAC_CERTIFICATE_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          CSC_LINK: ${{ inputs.channel == 'canary' && secrets.CANARY_MAC_CERTIFICATE || secrets.MAC_CERTIFICATE }}
+          CSC_KEY_PASSWORD: ${{ inputs.channel == 'canary' && secrets.CANARY_MAC_CERTIFICATE_PASSWORD || secrets.MAC_CERTIFICATE_PASSWORD }}
+          APPLE_ID: ${{ inputs.channel == 'canary' && secrets.CANARY_APPLE_ID || secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ inputs.channel == 'canary' && secrets.CANARY_APPLE_ID_PASSWORD || secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ inputs.channel == 'canary' && secrets.CANARY_APPLE_TEAM_ID || secrets.APPLE_TEAM_ID }}
           TARGET_ARCH: ${{ matrix.arch }}
         run: bun run package -- --publish never --config ${{ inputs.electron_builder_config }} --${{ matrix.arch }}
 

--- a/apps/desktop/RELEASE.md
+++ b/apps/desktop/RELEASE.md
@@ -64,10 +64,17 @@ The workflow creates stable-named copies (without version) so these URLs always 
 
 ## Code Signing
 
-macOS code signing uses these repository secrets:
+macOS code signing uses these GitHub Actions secrets:
 
 - `MAC_CERTIFICATE` / `MAC_CERTIFICATE_PASSWORD`
 - `APPLE_ID` / `APPLE_ID_PASSWORD` / `APPLE_TEAM_ID`
+
+Canary builds can use a different Apple account and signing certificate by defining these optional secrets. If they are not set, canary falls back to the shared secrets above.
+
+- `CANARY_MAC_CERTIFICATE` / `CANARY_MAC_CERTIFICATE_PASSWORD`
+- `CANARY_APPLE_ID` / `CANARY_APPLE_ID_PASSWORD` / `CANARY_APPLE_TEAM_ID`
+
+The reusable desktop build workflow currently reads secrets from the same GitHub Actions context as the stable build, so add the `CANARY_*` secrets anywhere that workflow already gets its existing signing secrets from.
 
 ## Local Testing
 


### PR DESCRIPTION
## Description

Allow desktop canary builds to use a separate Apple signing certificate and notarization account from stable.

This updates the reusable desktop build workflow so canary prefers `CANARY_*` signing secrets and falls back to the existing shared secrets when they are not set. It also documents the new canary-specific secrets in the desktop release guide.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [x] Documentation
- [ ] New feature
- [ ] Refactor
- [ ] Other (please describe):

## Testing

Not run locally. `actionlint` is not installed in this environment.

## Screenshots (if applicable)

N/A

## Additional Notes

This leaves the stable release path unchanged and enables canary-only signing key rotation via GitHub Actions secrets.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let desktop canary builds use a separate Apple signing certificate and notarization account. Falls back to existing secrets if `CANARY_*` are not set; stable builds are unchanged.

- New Features
  - Workflow uses `CANARY_*` secrets when `channel` is `canary` for `CSC_LINK`, `CSC_KEY_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, and `APPLE_TEAM_ID`.
  - Updated `apps/desktop/RELEASE.md` to document the `CANARY_*` secrets and fallback behavior.

- Migration
  - Optionally add `CANARY_MAC_CERTIFICATE`, `CANARY_MAC_CERTIFICATE_PASSWORD`, `CANARY_APPLE_ID`, `CANARY_APPLE_ID_PASSWORD`, `CANARY_APPLE_TEAM_ID` in the same GitHub Actions context as the stable secrets.

<sup>Written for commit 9e24d20960f13ea35be6f954890e3699c8e057e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for canary builds with separate signing credentials, enabling different release channels to use environment-specific configuration.

* **Documentation**
  * Updated release documentation to clarify GitHub Actions secrets usage and provide setup instructions for canary signing.

* **Chores**
  * Updated build workflow to conditionally select appropriate environment variables based on the release channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->