### PR TITLE
fix(desktop): close terminal tab on clean shell exit

### DIFF
--- a/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts
+++ b/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts
@@ -645,7 +645,16 @@ export class DaemonTerminalManager extends EventEmitter {
 			this.historyManager.closeHistoryWriter(paneId, 0);
 		}
 
-		await this.client.kill({ sessionId: paneId, deleteHistory });
+		try {
+			await this.client.kill({ sessionId: paneId, deleteHistory });
+		} catch (error) {
+			const message =
+				error instanceof Error ? error.message : String(error);
+			if (message.toLowerCase().includes("not found")) {
+				return;
+			}
+			throw error;
+		}
 	}
 
 	detach(params: { paneId: string }): void {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalStream.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalStream.ts
@@ -44,6 +44,7 @@ export function useTerminalStream({
 	updateCwdFromData,
 }: UseTerminalStreamOptions): UseTerminalStreamReturn {
 	const setPaneStatus = useTabsStore((s) => s.setPaneStatus);
+	const removePane = useTabsStore((s) => s.removePane);
 	const firstStreamDataReceivedRef = useRef(false);
 
 	// Refs to use latest values in callbacks
@@ -64,6 +65,10 @@ export function useTerminalStream({
 			if (wasKilledByUser) {
 				xterm.writeln("\r\n\r\n[Session killed]");
 				xterm.writeln("[Restart to start a new session]");
+			} else if (exitCode === 0) {
+				// Clean exit (e.g. typing "exit") — close the pane/tab
+				removePane(paneId);
+				return;
 			} else {
 				xterm.writeln(`\r\n\r\n[Process exited with code ${exitCode}]`);
 				xterm.writeln("[Press any key to restart]");
@@ -85,6 +90,7 @@ export function useTerminalStream({
 			wasKilledByUserRef,
 			setExitStatus,
 			setPaneStatus,
+			removePane,
 		],
 	);
 


### PR DESCRIPTION
## What

When a user types `exit` in a blank terminal, the shell process exits with code 0. Previously this showed:

```
[Process exited with code 0]
[Press any key to restart]
```

Now the pane/tab closes automatically on a clean exit (exit code 0).

## Changes

**`apps/desktop/.../Terminal/hooks/useTerminalStream.ts`**
- Added `removePane` from the tabs store
- On clean shell exit (exit code 0, not killed by user), calls `removePane(paneId)` to close the pane/tab
- Killed sessions still show the killed overlay (unchanged)
- Non-zero exit codes still show the restart prompt (unchanged)

## Test plan

1. Open a terminal tab
2. Type `exit` → tab should close
3. Open a terminal, run a command that exits non-zero (e.g. `exit 1`) → should show restart prompt as before
4. Kill a terminal session → should show killed overlay as before
5. Split pane with two terminals, type `exit` in one → only that pane closes, other remains

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the terminal pane/tab on clean shell exit (exit code 0); non‑zero exits and killed sessions keep their overlays. Killing an already-exited session now ignores the benign "not found" error while surfacing other errors.

<sup>Written for commit c0b7c9cacbc0cb580785d0bc53d28ec34b0cbc87. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal panes now automatically close after a clean exit, keeping the workspace tidy and reducing manual cleanup.
  * Terminal shutdown errors for already-stopped sessions are now handled silently, preventing unnecessary error propagation and improving overall stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->