### PR TITLE
Fix v1 workspace drag back to project root

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/sections.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/sections.ts
@@ -1,5 +1,5 @@
 import { workspaceSections, workspaces } from "@superset/local-db";
-import { eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, isNull } from "drizzle-orm";
 import { localDb } from "main/lib/local-db";
 import {
 	PROJECT_COLOR_DEFAULT,
@@ -8,7 +8,9 @@ import {
 import { z } from "zod";
 import { publicProcedure, router } from "../../..";
 import { getMaxProjectChildTabOrder } from "../utils/db-helpers";
+import { placeWorkspacesAtProjectChildBoundary } from "../utils/project-children-order";
 import { reorderItems } from "../utils/reorder";
+import { computeVisualOrder } from "../utils/visual-order";
 
 const SECTION_COLORS = PROJECT_COLORS.filter(
 	(c) => c.value !== PROJECT_COLOR_DEFAULT,
@@ -17,6 +19,79 @@ const SECTION_COLORS = PROJECT_COLORS.filter(
 function randomSectionColor(): string {
 	return SECTION_COLORS[Math.floor(Math.random() * SECTION_COLORS.length)]
 		.value;
+}
+
+type RootPlacement = "top" | "bottom";
+
+function moveWorkspacesToRootBoundary(
+	workspaceIds: string[],
+	rootPlacement: RootPlacement,
+) {
+	const movingWorkspaces = localDb
+		.select()
+		.from(workspaces)
+		.where(inArray(workspaces.id, workspaceIds))
+		.all();
+
+	if (movingWorkspaces.length === 0) return;
+
+	const projectId = movingWorkspaces[0].projectId;
+	if (movingWorkspaces.some((workspace) => workspace.projectId !== projectId)) {
+		throw new Error(
+			"Cannot move workspaces to the project root across different projects",
+		);
+	}
+
+	const projectWorkspaces = localDb
+		.select()
+		.from(workspaces)
+		.where(
+			and(eq(workspaces.projectId, projectId), isNull(workspaces.deletingAt)),
+		)
+		.all();
+	const projectSections = localDb
+		.select()
+		.from(workspaceSections)
+		.where(eq(workspaceSections.projectId, projectId))
+		.all();
+
+	const targetWorkspaceIds = new Set(workspaceIds);
+	const orderedWorkspaceIds = computeVisualOrder(
+		[{ id: projectId, tabOrder: 0 }],
+		projectWorkspaces,
+		projectSections,
+	).filter((id) => targetWorkspaceIds.has(id));
+	const missingWorkspaceIds = workspaceIds.filter(
+		(id) => !orderedWorkspaceIds.includes(id),
+	);
+	const normalizedItems = placeWorkspacesAtProjectChildBoundary(
+		projectId,
+		projectWorkspaces,
+		projectSections,
+		[...orderedWorkspaceIds, ...missingWorkspaceIds],
+		rootPlacement,
+	);
+	const movingWorkspaceIdSet = new Set(workspaceIds);
+
+	for (const item of normalizedItems) {
+		if (item.kind === "workspace") {
+			localDb
+				.update(workspaces)
+				.set({
+					tabOrder: item.tabOrder,
+					...(movingWorkspaceIdSet.has(item.id) ? { sectionId: null } : {}),
+				})
+				.where(eq(workspaces.id, item.id))
+				.run();
+			continue;
+		}
+
+		localDb
+			.update(workspaceSections)
+			.set({ tabOrder: item.tabOrder })
+			.where(eq(workspaceSections.id, item.id))
+			.run();
+	}
 }
 
 export const createSectionsProcedures = () => {
@@ -184,9 +259,16 @@ export const createSectionsProcedures = () => {
 				z.object({
 					workspaceIds: z.array(z.string()).min(1),
 					sectionId: z.string().nullable(),
+					rootPlacement: z.enum(["top", "bottom"]).optional(),
 				}),
 			)
 			.mutation(({ input }) => {
+				const matchingWorkspaces = localDb
+					.select()
+					.from(workspaces)
+					.where(inArray(workspaces.id, input.workspaceIds))
+					.all();
+
 				if (input.sectionId) {
 					const section = localDb
 						.select()
@@ -199,12 +281,6 @@ export const createSectionsProcedures = () => {
 					}
 
 					const targetProjectId = section.projectId;
-					const matchingWorkspaces = localDb
-						.select()
-						.from(workspaces)
-						.where(inArray(workspaces.id, input.workspaceIds))
-						.all();
-
 					for (const ws of matchingWorkspaces) {
 						if (ws.projectId !== targetProjectId) {
 							throw new Error(
@@ -212,6 +288,11 @@ export const createSectionsProcedures = () => {
 							);
 						}
 					}
+				}
+
+				if (input.sectionId === null && input.rootPlacement) {
+					moveWorkspacesToRootBoundary(input.workspaceIds, input.rootPlacement);
+					return { success: true };
 				}
 
 				localDb
@@ -228,6 +309,7 @@ export const createSectionsProcedures = () => {
 				z.object({
 					workspaceId: z.string(),
 					sectionId: z.string().nullable(),
+					rootPlacement: z.enum(["top", "bottom"]).optional(),
 				}),
 			)
 			.mutation(({ input }) => {
@@ -257,6 +339,14 @@ export const createSectionsProcedures = () => {
 							"Cannot move workspace to a section in a different project",
 						);
 					}
+				}
+
+				if (input.sectionId === null && input.rootPlacement) {
+					moveWorkspacesToRootBoundary(
+						[input.workspaceId],
+						input.rootPlacement,
+					);
+					return { success: true };
 				}
 
 				localDb

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/project-children-order.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/project-children-order.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
 	computeNextProjectChildTabOrder,
 	getProjectChildItems,
+	placeWorkspacesAtProjectChildBoundary,
 	reorderProjectChildItems,
 } from "./project-children-order";
 
@@ -73,6 +74,52 @@ describe("reorderProjectChildItems", () => {
 			{ id: "s1", kind: "section", projectId: "p1", tabOrder: 0 },
 			{ id: "w1", kind: "workspace", projectId: "p1", tabOrder: 1 },
 			{ id: "w2", kind: "workspace", projectId: "p1", tabOrder: 2 },
+		]);
+	});
+});
+
+describe("placeWorkspacesAtProjectChildBoundary", () => {
+	test("places moved section workspaces at the top of mixed project children", () => {
+		const reordered = placeWorkspacesAtProjectChildBoundary(
+			"p1",
+			[
+				{ id: "w-top", projectId: "p1", sectionId: null, tabOrder: 1 },
+				{ id: "w-in-section", projectId: "p1", sectionId: "s1", tabOrder: 0 },
+			],
+			[{ id: "s1", projectId: "p1", tabOrder: 0 }],
+			["w-in-section"],
+			"top",
+		);
+
+		expect(reordered).toEqual([
+			{ id: "w-in-section", kind: "workspace", projectId: "p1", tabOrder: 0 },
+			{ id: "s1", kind: "section", projectId: "p1", tabOrder: 1 },
+			{ id: "w-top", kind: "workspace", projectId: "p1", tabOrder: 2 },
+		]);
+	});
+
+	test("places multiple moved workspaces at the bottom in the provided order", () => {
+		const reordered = placeWorkspacesAtProjectChildBoundary(
+			"p1",
+			[
+				{ id: "w-top", projectId: "p1", sectionId: null, tabOrder: 0 },
+				{ id: "w-a", projectId: "p1", sectionId: "s1", tabOrder: 0 },
+				{ id: "w-b", projectId: "p1", sectionId: "s2", tabOrder: 0 },
+			],
+			[
+				{ id: "s1", projectId: "p1", tabOrder: 1 },
+				{ id: "s2", projectId: "p1", tabOrder: 2 },
+			],
+			["w-a", "w-b"],
+			"bottom",
+		);
+
+		expect(reordered).toEqual([
+			{ id: "w-top", kind: "workspace", projectId: "p1", tabOrder: 0 },
+			{ id: "s1", kind: "section", projectId: "p1", tabOrder: 1 },
+			{ id: "s2", kind: "section", projectId: "p1", tabOrder: 2 },
+			{ id: "w-a", kind: "workspace", projectId: "p1", tabOrder: 3 },
+			{ id: "w-b", kind: "workspace", projectId: "p1", tabOrder: 4 },
 		]);
 	});
 });

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/project-children-order.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/project-children-order.ts
@@ -27,6 +27,8 @@ export type ProjectChildItem =
 			tabOrder: number;
 	  };
 
+export type ProjectChildBoundaryPlacement = "top" | "bottom";
+
 function isTopLevelWorkspace(
 	workspace: WorkspaceLike,
 	projectSectionIds: Set<string>,
@@ -84,4 +86,34 @@ export function reorderProjectChildItems(
 	toIndex: number,
 ): ProjectChildItem[] {
 	return reorderItems(items, fromIndex, toIndex);
+}
+
+export function placeWorkspacesAtProjectChildBoundary(
+	projectId: string,
+	workspaces: WorkspaceLike[],
+	sections: SectionLike[],
+	orderedWorkspaceIds: string[],
+	placement: ProjectChildBoundaryPlacement,
+): ProjectChildItem[] {
+	const movingWorkspaceIds = new Set(orderedWorkspaceIds);
+	const existingItems = getProjectChildItems(
+		projectId,
+		workspaces.filter((workspace) => !movingWorkspaceIds.has(workspace.id)),
+		sections,
+	);
+	const movingItems = orderedWorkspaceIds.map((id) => ({
+		id,
+		kind: "workspace" as const,
+		projectId,
+		tabOrder: 0,
+	}));
+	const nextItems =
+		placement === "top"
+			? [...movingItems, ...existingItems]
+			: [...existingItems, ...movingItems];
+
+	return nextItems.map((item, index) => ({
+		...item,
+		tabOrder: index,
+	}));
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectSection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectSection.tsx
@@ -125,11 +125,31 @@ export function ProjectSection({
 		};
 	}, [shortcutBaseIndex, sections, topLevelItems, workspaces]);
 
-	const ungroupedDropZone = useSectionDropZone({
+	const topUngroupedDropZone = useSectionDropZone({
 		canAccept: (item) =>
 			item.sectionId !== null && item.projectId === projectId,
 		targetSectionId: null,
+		targetRootPlacement: "top",
 	});
+
+	const bottomUngroupedDropZone = useSectionDropZone({
+		canAccept: (item) =>
+			item.sectionId !== null && item.projectId === projectId,
+		targetSectionId: null,
+		targetRootPlacement: "bottom",
+	});
+	const showRootDropZones =
+		topUngroupedDropZone.isDropTarget || bottomUngroupedDropZone.isDropTarget;
+
+	const getRootDropZoneClassName = (
+		isDropTarget: boolean,
+		isDragOver: boolean,
+	) =>
+		cn(
+			"transition-colors rounded-sm",
+			isDropTarget && !isDragOver && "border border-dashed border-primary/20",
+			isDragOver && "bg-primary/5 border border-solid border-primary/30",
+		);
 
 	const handleNewWorkspace = () => {
 		openModal(projectId);
@@ -233,6 +253,18 @@ export function ProjectSection({
 							className="overflow-hidden w-full"
 						>
 							<div className="flex flex-col items-center gap-1 pt-1">
+								{showRootDropZones && topLevelChildren.length > 0 && (
+									<div
+										{...topUngroupedDropZone.handlers}
+										className={cn(
+											"w-full h-5",
+											getRootDropZoneClassName(
+												topUngroupedDropZone.isDropTarget,
+												topUngroupedDropZone.isDragOver,
+											),
+										)}
+									/>
+								)}
 								{topLevelChildren.map((item) =>
 									item.kind === "workspace" ? (
 										<WorkspaceListItem
@@ -267,6 +299,18 @@ export function ProjectSection({
 											orderedWorkspaceIds={orderedWorkspaceIds}
 										/>
 									),
+								)}
+								{showRootDropZones && topLevelChildren.length > 0 && (
+									<div
+										{...bottomUngroupedDropZone.handlers}
+										className={cn(
+											"w-full h-5",
+											getRootDropZoneClassName(
+												bottomUngroupedDropZone.isDropTarget,
+												bottomUngroupedDropZone.isDragOver,
+											),
+										)}
+									/>
 								)}
 							</div>
 						</motion.div>
@@ -312,16 +356,27 @@ export function ProjectSection({
 						className="overflow-hidden"
 					>
 						<div className="pb-1">
-							{topLevelChildren.length === 0 && (
+							{showRootDropZones && topLevelChildren.length === 0 && (
 								<div
-									{...ungroupedDropZone.handlers}
+									{...topUngroupedDropZone.handlers}
 									className={cn(
 										"transition-colors rounded-sm min-h-8",
-										ungroupedDropZone.isDropTarget &&
-											!ungroupedDropZone.isDragOver &&
-											"border border-dashed border-primary/20",
-										ungroupedDropZone.isDragOver &&
-											"bg-primary/5 border-solid border-primary/30",
+										getRootDropZoneClassName(
+											topUngroupedDropZone.isDropTarget,
+											topUngroupedDropZone.isDragOver,
+										),
+									)}
+								/>
+							)}
+							{showRootDropZones && topLevelChildren.length > 0 && (
+								<div
+									{...topUngroupedDropZone.handlers}
+									className={cn(
+										"h-5",
+										getRootDropZoneClassName(
+											topUngroupedDropZone.isDropTarget,
+											topUngroupedDropZone.isDragOver,
+										),
 									)}
 								/>
 							)}
@@ -357,6 +412,18 @@ export function ProjectSection({
 										orderedWorkspaceIds={orderedWorkspaceIds}
 									/>
 								),
+							)}
+							{showRootDropZones && topLevelChildren.length > 0 && (
+								<div
+									{...bottomUngroupedDropZone.handlers}
+									className={cn(
+										"h-5",
+										getRootDropZoneClassName(
+											bottomUngroupedDropZone.isDropTarget,
+											bottomUngroupedDropZone.isDragOver,
+										),
+									)}
+								/>
 							)}
 						</div>
 					</motion.div>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/hooks/useSectionDropZone.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/hooks/useSectionDropZone.ts
@@ -12,12 +12,14 @@ import type { DragItem } from "../types";
 interface UseSectionDropZoneOptions {
 	canAccept: (item: DragItem) => boolean;
 	targetSectionId: string | null;
+	targetRootPlacement?: "top" | "bottom";
 	onAutoExpand?: () => void;
 }
 
 export function useSectionDropZone({
 	canAccept,
 	targetSectionId,
+	targetRootPlacement,
 	onAutoExpand,
 }: UseSectionDropZoneOptions) {
 	const [isDragOver, setIsDragOver] = useState(false);
@@ -59,11 +61,17 @@ export function useSectionDropZone({
 					bulkMoveToSection.mutate({
 						workspaceIds: item.selectedIds,
 						sectionId: targetSectionId,
+						...(targetSectionId === null && targetRootPlacement
+							? { rootPlacement: targetRootPlacement }
+							: {}),
 					});
 				} else {
 					moveToSection.mutate({
 						workspaceId: item.id,
 						sectionId: targetSectionId,
+						...(targetSectionId === null && targetRootPlacement
+							? { rootPlacement: targetRootPlacement }
+							: {}),
 					});
 				}
 				item.handled = true;
@@ -71,7 +79,13 @@ export function useSectionDropZone({
 			dragEnterCount.current = 0;
 			setIsDragOver(false);
 		},
-		[canAccept, targetSectionId, moveToSection, bulkMoveToSection],
+		[
+			canAccept,
+			targetSectionId,
+			targetRootPlacement,
+			moveToSection,
+			bulkMoveToSection,
+		],
 	);
 
 	const handleDragEnter = useCallback(


### PR DESCRIPTION
## Summary
- restore v1 workspace sidebar drop targets for moving section workspaces back to the project root
- support deterministic top and bottom root placement when dragging out of sections
- only show the larger root drop lanes during a relevant drag so the list stays clean at rest

## Testing
- bun test apps/desktop/src/lib/trpc/routers/workspaces/utils/project-children-order.test.ts
- bunx biome check apps/desktop/src/lib/trpc/routers/workspaces/procedures/sections.ts apps/desktop/src/lib/trpc/routers/workspaces/utils/project-children-order.ts apps/desktop/src/lib/trpc/routers/workspaces/utils/project-children-order.test.ts apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/hooks/useSectionDropZone.ts apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectSection.tsx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the ability to drag workspaces from sections back to the project root with deterministic top/bottom placement. Root drop lanes only appear during a relevant drag to keep the sidebar clean.

- **Bug Fixes**
  - Brought back root drop targets in the sidebar; moved workspaces land at the top or bottom in a stable order.
  - Extended TRPC move APIs with optional `rootPlacement` for `null` `sectionId` and normalized ordering across mixed root/section lists.
  - Only show larger root drop lanes while dragging; added tests for boundary placement logic.

<sup>Written for commit d55d27e62c5affebf090fd92d08a15d05f63eb67. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspaces can now be moved to the top or bottom of a project root level, providing more flexible workspace organization alongside sections.
  * Added visual drop zone indicators for root-level placement positions to guide drag-and-drop interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->