### PR TITLE
Reduce default agent prompt verbosity

### DIFF
--- a/packages/shared/src/agent-prompt-template.ts
+++ b/packages/shared/src/agent-prompt-template.ts
@@ -13,41 +13,23 @@ export const AGENT_TASK_PROMPT_VARIABLES = [
 export type AgentTaskPromptVariable =
 	(typeof AGENT_TASK_PROMPT_VARIABLES)[number];
 
-export const DEFAULT_TERMINAL_TASK_PROMPT_TEMPLATE = `You are working on task "{{title}}" ({{slug}}).
-
+export const DEFAULT_TERMINAL_TASK_PROMPT_TEMPLATE = `Task: "{{title}}" ({{slug}})
 Priority: {{priority}}
 Status: {{statusName}}
 Labels: {{labels}}
 
-## Task Description
-
 {{description}}
 
-## Instructions
+Work in the current workspace. Inspect the relevant code, make the needed changes, verify them when practical, and update task "{{id}}" with a short summary when done.`;
 
-You are running fully autonomously. Do not ask questions or wait for user feedback — make all decisions independently based on the codebase and task description.
-
-1. Explore the codebase to understand the relevant code and architecture
-2. Create a detailed execution plan for this task including:
-   - Purpose and scope of the changes
-   - Key assumptions
-   - Concrete implementation steps with specific files to modify
-   - How to validate the changes work correctly
-3. Implement the plan
-4. Verify your changes work correctly (run relevant tests, typecheck, lint)
-5. When done, use the Superset MCP \`update_task\` tool to update task "{{id}}" with a summary of what was done`;
-
-export const DEFAULT_CHAT_TASK_PROMPT_TEMPLATE = `You are helping with task "{{title}}" ({{slug}}).
-
+export const DEFAULT_CHAT_TASK_PROMPT_TEMPLATE = `Task: "{{title}}" ({{slug}})
 Priority: {{priority}}
 Status: {{statusName}}
 Labels: {{labels}}
 
-## Task Description
-
 {{description}}
 
-Help with this task in the current workspace. Start by summarizing the goal, then take the next concrete step.`;
+Help with this task in the current workspace and take the next concrete step.`;
 
 type TaskPromptVariables = Record<AgentTaskPromptVariable, string>;
 


### PR DESCRIPTION
## Summary
- shorten the built-in terminal task prompt to remove the long planning and autonomy checklist
- keep the task metadata and a brief instruction to work in the workspace, verify changes, and update the task when done
- shorten the default chat task prompt to match the simpler style

## Testing
- bun test packages/shared/src/agent-prompt-template.test.ts packages/shared/src/agent-launch.test.ts
- bun test apps/desktop/src/shared/utils/agent-settings.test.ts apps/desktop/src/shared/utils/agent-launch-request.test.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified the default agent task prompts by removing the long autonomy/planning checklist and keeping only task metadata with a brief instruction. This reduces noise and makes terminal and chat prompts consistent.

- **Refactors**
  - Shortened `DEFAULT_TERMINAL_TASK_PROMPT_TEMPLATE` to show metadata and a single instruction: work in the workspace, verify changes when practical, and update task `{{id}}` with a short summary.
  - Shortened `DEFAULT_CHAT_TASK_PROMPT_TEMPLATE` to match the same format and guidance: help in the current workspace and take the next concrete step.

<sup>Written for commit cc9a41e8289a629cd2e9a370d200b1b894bd74d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined AI agent prompt templates for terminal and chat task handling to improve instruction clarity and agent behavior focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->