### PR TITLE
fix(desktop): persist fullscreen state across app restarts

### DIFF
--- a/apps/desktop/src/main/lib/window-state/bounds-validation.test.ts
+++ b/apps/desktop/src/main/lib/window-state/bounds-validation.test.ts
@@ -228,6 +228,7 @@ describe("getInitialWindowBounds", () => {
 				height: 1080,
 				center: true,
 				isMaximized: false,
+				isFullScreen: false,
 			});
 		});
 
@@ -254,6 +255,7 @@ describe("getInitialWindowBounds", () => {
 				height: 600,
 				center: false,
 				isMaximized: false,
+				isFullScreen: false,
 			});
 		});
 
@@ -284,6 +286,7 @@ describe("getInitialWindowBounds", () => {
 				height: 600,
 				center: true,
 				isMaximized: false,
+				isFullScreen: false,
 			});
 			expect(result.x).toBeUndefined();
 			expect(result.y).toBeUndefined();
@@ -298,6 +301,44 @@ describe("getInitialWindowBounds", () => {
 				isMaximized: true,
 			});
 			expect(result.isMaximized).toBe(true);
+			expect(result.center).toBe(true);
+		});
+	});
+
+	describe("fullscreen state", () => {
+		it("should restore isFullScreen from saved state", () => {
+			const result = getInitialWindowBounds({
+				x: 0,
+				y: 0,
+				width: 1920,
+				height: 1080,
+				isMaximized: false,
+				isFullScreen: true,
+			});
+			expect(result.isFullScreen).toBe(true);
+		});
+
+		it("should default isFullScreen to false when absent from saved state", () => {
+			const result = getInitialWindowBounds({
+				x: 100,
+				y: 200,
+				width: 800,
+				height: 600,
+				isMaximized: false,
+			});
+			expect(result.isFullScreen).toBe(false);
+		});
+
+		it("should preserve isFullScreen when display disconnected", () => {
+			const result = getInitialWindowBounds({
+				x: 2000,
+				y: 100,
+				width: 800,
+				height: 600,
+				isMaximized: false,
+				isFullScreen: true,
+			});
+			expect(result.isFullScreen).toBe(true);
 			expect(result.center).toBe(true);
 		});
 	});

--- a/apps/desktop/src/main/lib/window-state/bounds-validation.ts
+++ b/apps/desktop/src/main/lib/window-state/bounds-validation.ts
@@ -75,6 +75,7 @@ export interface InitialWindowBounds {
 	height: number;
 	center: boolean;
 	isMaximized: boolean;
+	isFullScreen: boolean;
 }
 
 /**
@@ -96,6 +97,7 @@ export function getInitialWindowBounds(
 			height: workAreaSize.height,
 			center: true,
 			isMaximized: false,
+			isFullScreen: false,
 		};
 	}
 
@@ -111,6 +113,8 @@ export function getInitialWindowBounds(
 		height,
 	};
 
+	const isFullScreen = savedState.isFullScreen ?? false;
+
 	// Saved position visible on a connected display → restore exactly
 	if (isVisibleOnAnyDisplay(savedBounds)) {
 		return {
@@ -120,6 +124,7 @@ export function getInitialWindowBounds(
 			height,
 			center: false,
 			isMaximized: savedState.isMaximized,
+			isFullScreen,
 		};
 	}
 
@@ -129,5 +134,6 @@ export function getInitialWindowBounds(
 		height,
 		center: true,
 		isMaximized: savedState.isMaximized,
+		isFullScreen,
 	};
 }

--- a/apps/desktop/src/main/lib/window-state/window-state.test.ts
+++ b/apps/desktop/src/main/lib/window-state/window-state.test.ts
@@ -127,6 +127,44 @@ describe("isValidWindowState", () => {
 			).toBe(true);
 		});
 
+		it("should accept valid window state with isFullScreen true", () => {
+			expect(
+				isValidWindowState({
+					x: 100,
+					y: 200,
+					width: 800,
+					height: 600,
+					isMaximized: false,
+					isFullScreen: true,
+				}),
+			).toBe(true);
+		});
+
+		it("should accept valid window state with isFullScreen false", () => {
+			expect(
+				isValidWindowState({
+					x: 100,
+					y: 200,
+					width: 800,
+					height: 600,
+					isMaximized: false,
+					isFullScreen: false,
+				}),
+			).toBe(true);
+		});
+
+		it("should accept valid window state without isFullScreen (backward compat)", () => {
+			expect(
+				isValidWindowState({
+					x: 100,
+					y: 200,
+					width: 800,
+					height: 600,
+					isMaximized: false,
+				}),
+			).toBe(true);
+		});
+
 		it("should accept MAX_SAFE_INTEGER dimensions", () => {
 			expect(
 				isValidWindowState({
@@ -250,6 +288,32 @@ describe("isValidWindowState", () => {
 					height: 600,
 					isMaximized: false,
 					zoomLevel: "1.5" as unknown as number,
+				}),
+			).toBe(false);
+		});
+
+		it("should reject string isFullScreen", () => {
+			expect(
+				isValidWindowState({
+					x: 0,
+					y: 0,
+					width: 800,
+					height: 600,
+					isMaximized: false,
+					isFullScreen: "true" as unknown as boolean,
+				}),
+			).toBe(false);
+		});
+
+		it("should reject number isFullScreen", () => {
+			expect(
+				isValidWindowState({
+					x: 0,
+					y: 0,
+					width: 800,
+					height: 600,
+					isMaximized: false,
+					isFullScreen: 1 as unknown as boolean,
 				}),
 			).toBe(false);
 		});

--- a/apps/desktop/src/main/lib/window-state/window-state.ts
+++ b/apps/desktop/src/main/lib/window-state/window-state.ts
@@ -14,6 +14,7 @@ export interface WindowState {
 	width: number;
 	height: number;
 	isMaximized: boolean;
+	isFullScreen?: boolean;
 	zoomLevel?: number;
 }
 
@@ -70,6 +71,7 @@ export function isValidWindowState(value: unknown): value is WindowState {
 		Number.isFinite(v.height) &&
 		(v.height as number) > 0 &&
 		typeof v.isMaximized === "boolean" &&
+		(v.isFullScreen === undefined || typeof v.isFullScreen === "boolean") &&
 		(v.zoomLevel === undefined || Number.isFinite(v.zoomLevel))
 	);
 }

--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -232,15 +232,18 @@ export async function MainWindow() {
 		saveTimeout = setTimeout(() => {
 			if (window.isDestroyed()) return;
 			const isMaximized = window.isMaximized();
-			const bounds = isMaximized
-				? window.getNormalBounds()
-				: window.getBounds();
+			const isFullScreen = window.isFullScreen();
+			const bounds =
+				isMaximized || isFullScreen
+					? window.getNormalBounds()
+					: window.getBounds();
 			saveWindowState({
 				x: bounds.x,
 				y: bounds.y,
 				width: bounds.width,
 				height: bounds.height,
 				isMaximized,
+				isFullScreen,
 				zoomLevel: window.webContents.getZoomLevel(),
 			});
 		}, 500);
@@ -250,7 +253,9 @@ export async function MainWindow() {
 
 	window.webContents.once("did-finish-load", async () => {
 		console.log("[main-window] Renderer loaded successfully");
-		if (initialBounds.isMaximized) {
+		if (initialBounds.isFullScreen) {
+			window.setFullScreen(true);
+		} else if (initialBounds.isMaximized) {
 			window.maximize();
 		}
 		if (savedWindowState?.zoomLevel !== undefined) {
@@ -285,7 +290,11 @@ export async function MainWindow() {
 	window.on("close", () => {
 		// Save window state first, before any cleanup
 		const isMaximized = window.isMaximized();
-		const bounds = isMaximized ? window.getNormalBounds() : window.getBounds();
+		const isFullScreen = window.isFullScreen();
+		const bounds =
+			isMaximized || isFullScreen
+				? window.getNormalBounds()
+				: window.getBounds();
 		const zoomLevel = window.webContents.getZoomLevel();
 		saveWindowState({
 			x: bounds.x,
@@ -293,6 +302,7 @@ export async function MainWindow() {
 			width: bounds.width,
 			height: bounds.height,
 			isMaximized,
+			isFullScreen,
 			zoomLevel,
 		});
 


### PR DESCRIPTION
## Summary

- Add `isFullScreen` to `WindowState` (optional, backward-compatible with existing saved states)
- Save fullscreen state on window close and move/resize
- Restore fullscreen on launch, taking priority over maximized (mutually exclusive on macOS)
- Use `getNormalBounds()` when fullscreen so windowed dimensions are preserved

Closes #2775

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

- `cd apps/desktop && bun test src/main/lib/window-state/` — 73 tests pass
- `bun run typecheck` — passes
- `bun run lint:fix` — no fixes needed
- Manual: enter fullscreen → quit → reopen → app restores in fullscreen
- Manual: verified `~/.superset/window-state.json` contains `"isFullScreen": true` after quitting in fullscreen
- Backward compat: existing saved states without `isFullScreen` load without issues