### PR TITLE
feat(desktop): add terminal sessions sidebar

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TerminalSidebar/TerminalSidebar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TerminalSidebar/TerminalSidebar.tsx
@@ -1,0 +1,111 @@
+import { Button } from "@superset/ui/button";
+import { ScrollArea } from "@superset/ui/scroll-area";
+import { useParams } from "@tanstack/react-router";
+import { useMemo } from "react";
+import { LuPlus } from "react-icons/lu";
+import { useTabsStore } from "renderer/stores/tabs/store";
+import type { Pane } from "renderer/stores/tabs/types";
+import { resolveActiveTabIdForWorkspace } from "renderer/stores/tabs/utils";
+import { pickHigherStatus } from "shared/tabs-types";
+import { TerminalSidebarItem } from "./components/TerminalSidebarItem";
+
+export function TerminalSidebar() {
+	const { workspaceId: activeWorkspaceId } = useParams({ strict: false });
+	const tabs = useTabsStore((state) => state.tabs);
+	const panes = useTabsStore((state) => state.panes);
+	const activeTabIds = useTabsStore((state) => state.activeTabIds);
+	const tabHistoryStacks = useTabsStore((state) => state.tabHistoryStacks);
+	const focusedPaneIds = useTabsStore((state) => state.focusedPaneIds);
+	const addTab = useTabsStore((state) => state.addTab);
+	const renameTab = useTabsStore((state) => state.renameTab);
+	const removeTab = useTabsStore((state) => state.removeTab);
+	const setActiveTab = useTabsStore((state) => state.setActiveTab);
+
+	const workspaceTabs = useMemo(
+		() =>
+			activeWorkspaceId
+				? tabs.filter((tab) => tab.workspaceId === activeWorkspaceId)
+				: [],
+		[activeWorkspaceId, tabs],
+	);
+
+	const activeTabId = useMemo(() => {
+		if (!activeWorkspaceId) return null;
+		return resolveActiveTabIdForWorkspace({
+			workspaceId: activeWorkspaceId,
+			tabs,
+			activeTabIds,
+			tabHistoryStacks,
+		});
+	}, [activeWorkspaceId, tabs, activeTabIds, tabHistoryStacks]);
+
+	const tabStatusMap = useMemo(() => {
+		const result = new Map<string, ReturnType<typeof pickHigherStatus>>();
+		for (const pane of Object.values(panes)) {
+			if (!pane.status || pane.status === "idle") continue;
+			result.set(pane.tabId, pickHigherStatus(result.get(pane.tabId), pane.status));
+		}
+		return result;
+	}, [panes]);
+
+	const panesByTabId = useMemo(() => {
+		const result = new Map<string, Pane[]>();
+		for (const pane of Object.values(panes)) {
+			const existing = result.get(pane.tabId);
+			if (existing) {
+				existing.push(pane);
+			} else {
+				result.set(pane.tabId, [pane]);
+			}
+		}
+		return result;
+	}, [panes]);
+
+	if (!activeWorkspaceId || workspaceTabs.length === 0) {
+		return null;
+	}
+
+	return (
+		<aside className="flex h-full w-72 shrink-0 flex-col border-r bg-background/80">
+			<div className="flex items-center justify-between gap-2 border-b px-3 py-2">
+				<div className="min-w-0">
+					<div className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+						Sessions
+					</div>
+					<div className="text-sm text-muted-foreground">
+						{workspaceTabs.length} open
+					</div>
+				</div>
+				<div className="flex items-center gap-1">
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						className="gap-1.5"
+						onClick={() => addTab(activeWorkspaceId)}
+					>
+						<LuPlus className="size-4" />
+						New
+					</Button>
+				</div>
+			</div>
+			<ScrollArea className="min-h-0 flex-1">
+				<div className="space-y-1 p-2">
+					{workspaceTabs.map((tab) => (
+						<TerminalSidebarItem
+							key={tab.id}
+							tab={tab}
+							panes={panesByTabId.get(tab.id) ?? []}
+							activePaneId={focusedPaneIds[tab.id]}
+							isActive={tab.id === activeTabId}
+							status={tabStatusMap.get(tab.id) ?? null}
+							onSelect={() => setActiveTab(activeWorkspaceId, tab.id)}
+							onRename={(name) => renameTab(tab.id, name)}
+							onClose={() => removeTab(tab.id)}
+						/>
+					))}
+				</div>
+			</ScrollArea>
+		</aside>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TerminalSidebar/TerminalSidebar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TerminalSidebar/TerminalSidebar.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@superset/ui/button";
 import { ScrollArea } from "@superset/ui/scroll-area";
+import { cn } from "@superset/ui/utils";
 import { useParams } from "@tanstack/react-router";
 import { useMemo } from "react";
 import { LuPlus } from "react-icons/lu";
@@ -9,7 +10,15 @@ import { resolveActiveTabIdForWorkspace } from "renderer/stores/tabs/utils";
 import { pickHigherStatus } from "shared/tabs-types";
 import { TerminalSidebarItem } from "./components/TerminalSidebarItem";
 
-export function TerminalSidebar() {
+interface TerminalSidebarProps {
+	className?: string;
+	embedded?: boolean;
+}
+
+export function TerminalSidebar({
+	className,
+	embedded = false,
+}: TerminalSidebarProps = {}) {
 	const { workspaceId: activeWorkspaceId } = useParams({ strict: false });
 	const tabs = useTabsStore((state) => state.tabs);
 	const panes = useTabsStore((state) => state.panes);
@@ -66,7 +75,13 @@ export function TerminalSidebar() {
 	}
 
 	return (
-		<aside className="flex h-full w-72 shrink-0 flex-col border-r bg-background/80">
+		<aside
+			className={cn(
+				"flex h-full min-h-0 flex-col bg-background/80",
+				embedded ? "w-full" : "w-72 shrink-0 border-r",
+				className,
+			)}
+		>
 			<div className="flex items-center justify-between gap-2 border-b px-3 py-2">
 				<div className="min-w-0">
 					<div className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TerminalSidebar/components/TerminalSidebarItem/TerminalSidebarItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TerminalSidebar/components/TerminalSidebarItem/TerminalSidebarItem.tsx
@@ -1,0 +1,144 @@
+import { Button } from "@superset/ui/button";
+import { cn } from "@superset/ui/utils";
+import { useMemo, useState } from "react";
+import { HiMiniXMark } from "react-icons/hi2";
+import { LuFileText, LuGlobe, LuMessageSquare, LuTerminal } from "react-icons/lu";
+import { StatusIndicator } from "renderer/screens/main/components/StatusIndicator";
+import { RenameInput } from "renderer/screens/main/components/WorkspaceSidebar/RenameInput";
+import type { Pane, PaneStatus, PaneType, Tab } from "renderer/stores/tabs/types";
+import { getTabDisplayName } from "renderer/stores/tabs/utils";
+
+interface TerminalSidebarItemProps {
+	tab: Tab;
+	panes: Pane[];
+	activePaneId?: string;
+	isActive: boolean;
+	status: PaneStatus | null;
+	onSelect: () => void;
+	onRename: (name: string) => void;
+	onClose: () => void;
+}
+
+function getPaneTypeIcon(type: PaneType | undefined) {
+	switch (type) {
+		case "chat":
+			return LuMessageSquare;
+		case "webview":
+			return LuGlobe;
+		case "file-viewer":
+			return LuFileText;
+		default:
+			return LuTerminal;
+	}
+}
+
+function formatSubtitle(panes: Pane[], activePaneId?: string): string {
+	const activePane = panes.find((pane) => pane.id === activePaneId) ?? panes[0];
+	const cwd = activePane?.cwd?.trim();
+	if (cwd) {
+		const parts = cwd.split("/").filter(Boolean);
+		if (parts.length >= 2) {
+			return parts.slice(-2).join("/");
+		}
+		return parts[0] || cwd;
+	}
+
+	return panes.length === 1 ? "1 pane" : `${panes.length} panes`;
+}
+
+export function TerminalSidebarItem({
+	tab,
+	panes,
+	activePaneId,
+	isActive,
+	status,
+	onSelect,
+	onRename,
+	onClose,
+}: TerminalSidebarItemProps) {
+	const displayName = getTabDisplayName(tab);
+	const [isEditing, setIsEditing] = useState(false);
+	const [editValue, setEditValue] = useState(displayName);
+	const activePane = useMemo(
+		() => panes.find((pane) => pane.id === activePaneId) ?? panes[0],
+		[activePaneId, panes],
+	);
+	const subtitle = useMemo(
+		() => formatSubtitle(panes, activePaneId),
+		[activePaneId, panes],
+	);
+	const Icon = getPaneTypeIcon(activePane?.type);
+
+	const handleStartEditing = () => {
+		setEditValue(displayName);
+		setIsEditing(true);
+	};
+
+	const handleSave = () => {
+		const trimmedValue = editValue.trim();
+		if (trimmedValue && trimmedValue !== displayName) {
+			onRename(trimmedValue);
+		}
+		setIsEditing(false);
+	};
+
+	return (
+		<div
+			className={cn(
+				"group relative rounded-lg border transition-colors",
+				isActive
+					? "border-border bg-accent/60 text-foreground"
+					: "border-transparent text-muted-foreground hover:border-border/60 hover:bg-accent/30 hover:text-foreground",
+			)}
+		>
+			{isEditing ? (
+				<div className="px-3 py-2">
+					<RenameInput
+						value={editValue}
+						onChange={setEditValue}
+						onSubmit={handleSave}
+						onCancel={() => setIsEditing(false)}
+						maxLength={64}
+						className="w-full rounded border border-border bg-background px-2 py-1 text-sm text-foreground outline-none focus:ring-1 focus:ring-ring"
+					/>
+				</div>
+			) : (
+				<>
+					<button
+						type="button"
+						onClick={onSelect}
+						onDoubleClick={handleStartEditing}
+						className="flex w-full items-start gap-3 px-3 py-2 text-left"
+					>
+						<div className="mt-0.5 shrink-0 text-muted-foreground">
+							<Icon className="size-4" />
+						</div>
+						<div className="min-w-0 flex-1">
+							<div className="flex items-center gap-2">
+								<span className="truncate text-sm font-medium">{displayName}</span>
+								{status && status !== "idle" && <StatusIndicator status={status} />}
+							</div>
+							<div className="truncate text-xs text-muted-foreground/80">
+								{subtitle}
+							</div>
+						</div>
+					</button>
+					<div className="absolute right-2 top-2 hidden group-hover:block">
+						<Button
+							type="button"
+							variant="ghost"
+							size="icon"
+							className="size-6 text-muted-foreground hover:text-foreground"
+							onClick={(event) => {
+								event.stopPropagation();
+								onClose();
+							}}
+						>
+							<HiMiniXMark className="size-4" />
+						</Button>
+					</div>
+				</>
+			)}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TerminalSidebar/components/TerminalSidebarItem/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TerminalSidebar/components/TerminalSidebarItem/index.ts
@@ -1,0 +1,1 @@
+export { TerminalSidebarItem } from "./TerminalSidebarItem";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TerminalSidebar/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TerminalSidebar/index.ts
@@ -1,0 +1,1 @@
+export { TerminalSidebar } from "./TerminalSidebar";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/index.tsx
@@ -4,7 +4,6 @@ import { useMemo } from "react";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import { resolveActiveTabIdForWorkspace } from "renderer/stores/tabs/utils";
 import { EmptyTabView } from "./EmptyTabView";
-import { TerminalSidebar } from "./TerminalSidebar";
 import { TabView } from "./TabView";
 
 interface TabsContentProps {
@@ -47,12 +46,9 @@ export function TabsContent({
 	return (
 		<div className="flex-1 min-h-0 flex overflow-hidden">
 			{tabToRender ? (
-				<>
-					<TerminalSidebar />
-					<div className="min-w-0 flex-1">
-						<TabView tab={tabToRender} />
-					</div>
-				</>
+				<div className="min-w-0 flex-1">
+					<TabView tab={tabToRender} />
+				</div>
 			) : (
 				<EmptyTabView
 					defaultExternalApp={defaultExternalApp}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/index.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import { resolveActiveTabIdForWorkspace } from "renderer/stores/tabs/utils";
 import { EmptyTabView } from "./EmptyTabView";
+import { TerminalSidebar } from "./TerminalSidebar";
 import { TabView } from "./TabView";
 
 interface TabsContentProps {
@@ -46,7 +47,12 @@ export function TabsContent({
 	return (
 		<div className="flex-1 min-h-0 flex overflow-hidden">
 			{tabToRender ? (
-				<TabView tab={tabToRender} />
+				<>
+					<TerminalSidebar />
+					<div className="min-w-0 flex-1">
+						<TabView tab={tabToRender} />
+					</div>
+				</>
 			) : (
 				<EmptyTabView
 					defaultExternalApp={defaultExternalApp}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
@@ -8,10 +8,12 @@ import {
 	LuFile,
 	LuGitCompareArrows,
 	LuShrink,
+	LuTerminal,
 	LuX,
 } from "react-icons/lu";
 import { HotkeyTooltipContent } from "renderer/components/HotkeyTooltipContent";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { TerminalSidebar } from "../ContentView/TabsContent/TerminalSidebar";
 import {
 	RightSidebarTab,
 	SidebarMode,
@@ -94,6 +96,7 @@ export function RightSidebar() {
 	const isExpanded = currentMode === SidebarMode.Changes;
 	const compactTabs = sidebarWidth < 250;
 	const showChangesTab = !!worktreePath;
+ 	const showSessionsTab = currentMode !== SidebarMode.Changes;
 
 	const handleExpandToggle = () => {
 		setMode(isExpanded ? SidebarMode.Tabs : SidebarMode.Changes);
@@ -184,6 +187,15 @@ export function RightSidebar() {
 						label="Files"
 						compact={compactTabs}
 					/>
+					{showSessionsTab && (
+						<TabButton
+							isActive={rightSidebarTab === RightSidebarTab.Sessions}
+							onClick={() => setRightSidebarTab(RightSidebarTab.Sessions)}
+							icon={<LuTerminal className="size-3.5" />}
+							label="Sessions"
+							compact={compactTabs}
+						/>
+					)}
 				</div>
 				<div className="flex-1" />
 				<div className="flex items-center h-10 pr-2 gap-0.5">
@@ -251,7 +263,11 @@ export function RightSidebar() {
 						: "flex-1 min-h-0 flex flex-col overflow-hidden"
 				}
 			>
-				<FilesView />
+				{rightSidebarTab === RightSidebarTab.Sessions ? (
+					<TerminalSidebar embedded className="border-0 bg-background" />
+				) : (
+					<FilesView />
+				)}
 			</div>
 		</aside>
 	);

--- a/apps/desktop/src/renderer/stores/sidebar-state.ts
+++ b/apps/desktop/src/renderer/stores/sidebar-state.ts
@@ -9,6 +9,7 @@ export enum SidebarMode {
 export enum RightSidebarTab {
 	Changes = "changes",
 	Files = "files",
+	Sessions = "sessions",
 }
 
 export const DEFAULT_SIDEBAR_WIDTH = 250;


### PR DESCRIPTION
## Description
- add a vertical sessions navigator for workspace tabs
- move the sessions list into the right sidebar so the main content area keeps more horizontal space
- support switching, renaming, closing, and creating sessions from the sidebar

## Related Issues
- related to terminal navigation usability improvements

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing
- `bun run --cwd apps/desktop typecheck`
- `bun run --cwd apps/desktop build:dev`

## Screenshots (if applicable)
- n/a

## Additional Notes
- maintainers can modify this PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a vertical Sessions sidebar in the right panel to manage terminal tabs per workspace, restoring horizontal space in the main view. You can switch, create, rename, and close sessions directly from the sidebar.

- New Features
  - Introduces `RightSidebarTab.Sessions` and embeds `TerminalSidebar` with a session count and “New” button.
  - Each session item shows name, status, cwd (or pane count), and a type icon; click to switch, double‑click to rename, and use the close button to remove.
  - Supports create/rename/close via `useTabsStore`; active tab and statuses aggregate across panes.
  - Minor layout tweak in `TabsContent` to ensure the main view flexes correctly alongside the sidebar.

<sup>Written for commit d80e0bf675242bc78a9a6da95647330ffe67e9c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a Sessions sidebar accessible from the right panel to manage terminal sessions within your workspace.
* Sessions can be created, renamed, and closed directly from the sidebar.
* Session status indicators and workspace-specific session grouping now display for quick reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->