### PR TITLE
feat(desktop): add project groups to workspace sidebar

### DIFF
--- a/apps/desktop/src/renderer/hooks/useWorkspaceShortcuts.ts
+++ b/apps/desktop/src/renderer/hooks/useWorkspaceShortcuts.ts
@@ -1,8 +1,10 @@
 import { useNavigate } from "@tanstack/react-router";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { useAppHotkey } from "renderer/stores/hotkeys";
+import { useProjectGroupsStore } from "renderer/stores/project-groups-state";
+import { groupProjectsBySidebarGroups } from "renderer/screens/main/components/WorkspaceSidebar/utils/groupProjectsBySidebarGroups";
 
 /**
  * Shared hook for workspace keyboard shortcuts.
@@ -10,12 +12,26 @@ import { useAppHotkey } from "renderer/stores/hotkeys";
  *
  * Handles ⌘1-9 workspace switching shortcuts (global).
  */
-export function useWorkspaceShortcuts() {
+	export function useWorkspaceShortcuts() {
 	const { data: groups = [] } =
 		electronTrpc.workspaces.getAllGrouped.useQuery();
+	const projectGroups = useProjectGroupsStore((state) => state.groups);
+	const projectAssignments = useProjectGroupsStore(
+		(state) => state.projectAssignments,
+	);
 	const navigate = useNavigate();
 
-	const allWorkspaces = groups.flatMap((group) => {
+	const orderedProjects = useMemo(
+		() =>
+			groupProjectsBySidebarGroups({
+				projectGroups,
+				projectAssignments,
+				projects: groups,
+			}).flatMap((bucket) => bucket.projects),
+		[groups, projectAssignments, projectGroups],
+	);
+
+	const allWorkspaces = orderedProjects.flatMap((group) => {
 		const topLevelWorkspacesById = new Map(
 			group.workspaces.map((workspace) => [workspace.id, workspace]),
 		);
@@ -72,7 +88,7 @@ export function useWorkspaceShortcuts() {
 	]);
 
 	return {
-		groups,
+		groups: orderedProjects,
 		allWorkspaces,
 	};
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectGroupSection/ProjectGroupSection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectGroupSection/ProjectGroupSection.tsx
@@ -1,0 +1,208 @@
+import { Button } from "@superset/ui/button";
+import {
+	ContextMenu,
+	ContextMenuContent,
+	ContextMenuItem,
+	ContextMenuSeparator,
+	ContextMenuTrigger,
+} from "@superset/ui/context-menu";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import { cn } from "@superset/ui/utils";
+import { AnimatePresence, motion } from "framer-motion";
+import { useDrop } from "react-dnd";
+import { useState } from "react";
+import { HiChevronRight } from "react-icons/hi2";
+import { LuFolderPlus, LuPencil, LuPlus, LuTrash2 } from "react-icons/lu";
+import { RenameInput } from "../RenameInput";
+
+const PROJECT_TYPE = "PROJECT";
+
+interface ProjectGroupSectionProps {
+	groupId: string;
+	name: string;
+	projectCount: number;
+	workspaceCount: number;
+	isCollapsed: boolean;
+	isDefault?: boolean;
+	onToggleCollapse: () => void;
+	onRename: (name: string) => void;
+	onDelete: () => void;
+	onProjectDrop: (projectId: string) => void;
+	onAddProject: (projectId: string) => void;
+	availableProjects: Array<{ id: string; name: string }>;
+	children: React.ReactNode;
+}
+
+export function ProjectGroupSection({
+	groupId,
+	name,
+	projectCount,
+	workspaceCount,
+	isCollapsed,
+	isDefault = false,
+	onToggleCollapse,
+	onRename,
+	onDelete,
+	onProjectDrop,
+	onAddProject,
+	availableProjects,
+	children,
+}: ProjectGroupSectionProps) {
+	const [isEditing, setIsEditing] = useState(false);
+	const [renameValue, setRenameValue] = useState(name);
+
+	const handleStartRename = () => {
+		setRenameValue(name);
+		setIsEditing(true);
+	};
+
+	const handleSubmitRename = () => {
+		const trimmed = renameValue.trim();
+		if (trimmed && trimmed !== name) {
+			onRename(trimmed);
+		}
+		setIsEditing(false);
+	};
+
+	const [{ isOver, canDrop }, drop] = useDrop(
+		() => ({
+			accept: PROJECT_TYPE,
+			canDrop: (item: { projectId: string }) => Boolean(item.projectId),
+			drop: (item: { projectId: string }) => {
+				onProjectDrop(item.projectId);
+				return { groupId };
+			},
+			collect: (monitor) => ({
+				isOver: monitor.isOver({ shallow: true }),
+				canDrop: monitor.canDrop(),
+			}),
+		}),
+		[groupId, onProjectDrop],
+	);
+
+	return (
+		<div
+			ref={(node) => {
+				drop(node);
+			}}
+			className={cn(
+				"border-b border-border/60 last:border-b-0 transition-colors",
+				canDrop && "bg-primary/5",
+				isOver && "bg-primary/10 ring-1 ring-inset ring-primary/30",
+			)}
+		>
+			<ContextMenu>
+				<ContextMenuTrigger asChild>
+					<div
+						className={cn(
+							"flex items-center gap-2 px-3 py-2 text-xs uppercase tracking-[0.16em] text-muted-foreground/90",
+							"bg-muted/35 hover:bg-muted/50 transition-colors",
+						)}
+					>
+						<button
+							type="button"
+							onClick={onToggleCollapse}
+							onDoubleClick={handleStartRename}
+							className="flex min-w-0 flex-1 items-center gap-2 text-left"
+						>
+							<HiChevronRight
+								className={cn(
+									"size-3.5 shrink-0 transition-transform",
+									!isCollapsed && "rotate-90",
+								)}
+							/>
+							{isEditing ? (
+								<RenameInput
+									value={renameValue}
+									onChange={setRenameValue}
+									onSubmit={handleSubmitRename}
+									onCancel={() => setIsEditing(false)}
+									maxLength={48}
+									className="h-6 min-w-0 flex-1 rounded border border-border bg-background px-2 py-0 text-sm normal-case tracking-normal text-foreground"
+								/>
+							) : (
+								<>
+									<span className="truncate">{name}</span>
+									<span className="text-[10px] tracking-normal lowercase text-muted-foreground/80">
+										{projectCount} project{projectCount !== 1 ? "s" : ""} • {workspaceCount} workspace{workspaceCount !== 1 ? "s" : ""}
+									</span>
+								</>
+							)}
+						</button>
+						<DropdownMenu>
+							<DropdownMenuTrigger asChild>
+								<Button
+									type="button"
+									variant="ghost"
+									size="icon"
+									className="size-6 shrink-0"
+									onClick={(event) => event.stopPropagation()}
+								>
+									<LuPlus className="size-3.5" />
+								</Button>
+							</DropdownMenuTrigger>
+							<DropdownMenuContent align="end" className="w-56">
+								{availableProjects.length === 0 ? (
+									<DropdownMenuItem disabled>No projects available</DropdownMenuItem>
+								) : (
+									availableProjects.map((project) => (
+										<DropdownMenuItem
+											key={project.id}
+											onClick={() => onAddProject(project.id)}
+										>
+											{project.name}
+										</DropdownMenuItem>
+									))
+								)}
+							</DropdownMenuContent>
+						</DropdownMenu>
+					</div>
+				</ContextMenuTrigger>
+				<ContextMenuContent>
+					<ContextMenuItem onSelect={handleStartRename}>
+						<LuPencil className="mr-2 size-4" />
+						Rename Group
+					</ContextMenuItem>
+					{!isDefault && (
+						<>
+							<ContextMenuSeparator />
+							<ContextMenuItem
+								onSelect={onDelete}
+								className="text-destructive focus:text-destructive"
+							>
+								<LuTrash2 className="mr-2 size-4 text-destructive" />
+								Delete Group
+							</ContextMenuItem>
+						</>
+					)}
+				</ContextMenuContent>
+			</ContextMenu>
+
+			<AnimatePresence initial={false}>
+				{!isCollapsed && (
+					<motion.div
+						initial={{ height: 0, opacity: 0 }}
+						animate={{ height: "auto", opacity: 1 }}
+						exit={{ height: 0, opacity: 0 }}
+						transition={{ duration: 0.16, ease: "easeOut" }}
+						className="overflow-hidden"
+					>
+						{projectCount === 0 ? (
+							<div className="px-4 py-3 text-sm text-muted-foreground/80">
+								<LuFolderPlus className="mb-1 size-4" />
+								Drag a project here or use the project menu.
+							</div>
+						) : (
+							children
+						)}
+					</motion.div>
+				)}
+			</AnimatePresence>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectGroupSection/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectGroupSection/index.ts
@@ -1,0 +1,1 @@
+export { ProjectGroupSection } from "./ProjectGroupSection";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectHeader.tsx
@@ -12,13 +12,14 @@ import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { useNavigate, useParams } from "@tanstack/react-router";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { HiChevronRight, HiMiniPlus } from "react-icons/hi2";
 import {
 	LuFolderOpen,
 	LuImage,
 	LuImageOff,
 	LuListPlus,
+	LuPanelTop,
 	LuPalette,
 	LuPencil,
 	LuSettings,
@@ -28,6 +29,10 @@ import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useUpdateProject } from "renderer/react-query/projects/useUpdateProject";
 import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { useProjectRename } from "renderer/screens/main/hooks/useProjectRename";
+import {
+	CURRENT_PROJECT_GROUP_ID,
+	useProjectGroupsStore,
+} from "renderer/stores/project-groups-state";
 import {
 	PROJECT_COLOR_DEFAULT,
 	PROJECT_COLORS,
@@ -73,6 +78,18 @@ export function ProjectHeader({
 	const params = useParams({ strict: false }) as { workspaceId?: string };
 	const [isCloseDialogOpen, setIsCloseDialogOpen] = useState(false);
 	const rename = useProjectRename(projectId, projectName);
+	const orderedProjectGroups = useProjectGroupsStore((state) => state.groups);
+	const projectAssignments = useProjectGroupsStore(
+		(state) => state.projectAssignments,
+	);
+	const setProjectGroup = useProjectGroupsStore((state) => state.setProjectGroup);
+	const currentProjectGroupId = useMemo(() => {
+		const assigned = projectAssignments[projectId];
+		if (!assigned || assigned === CURRENT_PROJECT_GROUP_ID) return CURRENT_PROJECT_GROUP_ID;
+		return orderedProjectGroups.some((group) => group.id === assigned)
+			? assigned
+			: null;
+	}, [orderedProjectGroups, projectAssignments, projectId]);
 
 	const closeProject = electronTrpc.projects.close.useMutation({
 		onMutate: async ({ id }) => {
@@ -162,6 +179,37 @@ export function ProjectHeader({
 		createSection.mutate({ projectId, name: "New Section" });
 	};
 
+	const moveToGroupSubmenu = (
+		<ContextMenuSub>
+			<ContextMenuSubTrigger>
+				<LuPanelTop className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />
+				Move to Group
+			</ContextMenuSubTrigger>
+			<ContextMenuSubContent className="w-44">
+				{orderedProjectGroups.map((group) => (
+					<ContextMenuItem
+						key={group.id}
+						onSelect={() => setProjectGroup(projectId, group.id)}
+					>
+						<span>{group.name}</span>
+						{currentProjectGroupId === group.id && (
+							<span className="ml-auto text-xs text-muted-foreground">✓</span>
+						)}
+					</ContextMenuItem>
+				))}
+				<ContextMenuSeparator />
+				<ContextMenuItem
+					onSelect={() => setProjectGroup(projectId, "__ungrouped__")}
+				>
+					<span>Other Projects</span>
+					{projectAssignments[projectId] === "__ungrouped__" && (
+						<span className="ml-auto text-xs text-muted-foreground">✓</span>
+					)}
+				</ContextMenuItem>
+			</ContextMenuSubContent>
+		</ContextMenuSub>
+	);
+
 	const colorPickerSubmenu = (
 		<ContextMenuSub>
 			<ContextMenuSubTrigger>
@@ -245,6 +293,7 @@ export function ProjectHeader({
 							<LuSettings className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />
 							Project Settings
 						</ContextMenuItem>
+						{moveToGroupSubmenu}
 						{colorPickerSubmenu}
 						<ContextMenuItem onSelect={handleNewSection}>
 							<LuListPlus className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />
@@ -371,11 +420,12 @@ export function ProjectHeader({
 						<LuFolderOpen className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />
 						Open in Finder
 					</ContextMenuItem>
-					<ContextMenuItem onSelect={handleOpenSettings}>
-						<LuSettings className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />
-						Project Settings
-					</ContextMenuItem>
-					{colorPickerSubmenu}
+				<ContextMenuItem onSelect={handleOpenSettings}>
+					<LuSettings className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />
+					Project Settings
+				</ContextMenuItem>
+				{moveToGroupSubmenu}
+				{colorPickerSubmenu}
 					<ContextMenuItem onSelect={handleToggleImage}>
 						{hideImage ? (
 							<LuImage className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectSection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectSection.tsx
@@ -30,6 +30,7 @@ type TopLevelChild =
 	  };
 
 interface ProjectSectionProps {
+	projectGroupId: string;
 	projectId: string;
 	projectName: string;
 	projectColor: string;
@@ -50,9 +51,11 @@ interface ProjectSectionProps {
 	index: number;
 	/** Whether the sidebar is in collapsed mode */
 	isCollapsed?: boolean;
+	onMoveToProjectGroup?: (projectId: string, groupId: string) => void;
 }
 
 export function ProjectSection({
+	projectGroupId,
 	projectId,
 	projectName,
 	projectColor,
@@ -66,6 +69,7 @@ export function ProjectSection({
 	shortcutBaseIndex,
 	index,
 	isCollapsed: isSidebarCollapsed = false,
+	onMoveToProjectGroup,
 }: ProjectSectionProps) {
 	const { isProjectCollapsed, toggleProjectCollapsed } =
 		useWorkspaceSidebarStore();
@@ -158,9 +162,10 @@ export function ProjectSection({
 	const [{ isDragging }, drag] = useDrag(
 		() => ({
 			type: PROJECT_TYPE,
-			item: { projectId, index, originalIndex: index },
+			item: { projectId, index, originalIndex: index, groupId: projectGroupId },
 			end: (item, monitor) => {
 				if (!item) return;
+				if (item.groupId !== projectGroupId) return;
 				if (monitor.didDrop()) return;
 				if (item.originalIndex !== item.index) {
 					reorderProjects.mutate(
@@ -186,7 +191,11 @@ export function ProjectSection({
 			projectId: string;
 			index: number;
 			originalIndex: number;
+			groupId: string;
 		}) => {
+			if (item.groupId !== projectGroupId) {
+				return;
+			}
 			if (item.index !== index) {
 				utils.workspaces.getAllGrouped.setData(undefined, (oldData) => {
 					if (!oldData) return oldData;
@@ -202,7 +211,13 @@ export function ProjectSection({
 			projectId: string;
 			index: number;
 			originalIndex: number;
+			groupId: string;
 		}) => {
+			if (item.groupId !== projectGroupId) {
+				onMoveToProjectGroup?.(item.projectId, projectGroupId);
+				item.groupId = projectGroupId;
+				return { movedGroup: true };
+			}
 			if (item.originalIndex !== item.index) {
 				reorderProjects.mutate(
 					{ fromIndex: item.originalIndex, toIndex: item.index },

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -1,8 +1,11 @@
 import { useCallback, useEffect, useMemo } from "react";
 import { useWorkspaceShortcuts } from "renderer/hooks/useWorkspaceShortcuts";
+import { groupProjectsBySidebarGroups } from "renderer/screens/main/components/WorkspaceSidebar/utils/groupProjectsBySidebarGroups";
 import { useWorkspaceSelectionStore } from "renderer/stores/workspace-selection";
+import { useProjectGroupsStore } from "renderer/stores/project-groups-state";
 import { MultiDragPreview } from "./MultiDragPreview";
 import { PortsList } from "./PortsList";
+import { ProjectGroupSection } from "./ProjectGroupSection";
 import { ProjectSection } from "./ProjectSection";
 import { SetupScriptCard } from "./SetupScriptCard";
 import { SidebarDropZone } from "./SidebarDropZone";
@@ -22,11 +25,34 @@ export function WorkspaceSidebar({
 }: WorkspaceSidebarProps) {
 	const { groups } = useWorkspaceShortcuts();
 	const clearSelection = useWorkspaceSelectionStore((s) => s.clearSelection);
+	const projectGroups = useProjectGroupsStore((state) => state.groups);
+	const projectAssignments = useProjectGroupsStore(
+		(state) => state.projectAssignments,
+	);
+	const createProjectGroup = useProjectGroupsStore((state) => state.createGroup);
+	const renameProjectGroup = useProjectGroupsStore((state) => state.renameGroup);
+	const deleteProjectGroup = useProjectGroupsStore((state) => state.deleteGroup);
+	const setProjectGroup = useProjectGroupsStore((state) => state.setProjectGroup);
+	const toggleProjectGroupCollapsed = useProjectGroupsStore(
+		(state) => state.toggleGroupCollapsed,
+	);
+
+	const groupedProjects = useMemo(
+		() =>
+			groupProjectsBySidebarGroups({
+				projectGroups,
+				projectAssignments,
+				projects: groups,
+			}),
+		[groups, projectAssignments, projectGroups],
+	);
 
 	const projectShortcutIndices = useMemo(
 		() =>
-			groups.reduce<{ indices: number[]; cumulative: number }>(
-				(acc, group) => ({
+				groupedProjects
+					.flatMap((bucket) => bucket.projects)
+					.reduce<{ indices: number[]; cumulative: number }>(
+						(acc, group) => ({
 					indices: [...acc.indices, acc.cumulative],
 					cumulative:
 						acc.cumulative +
@@ -35,10 +61,10 @@ export function WorkspaceSidebar({
 							(sum, s) => sum + s.workspaces.length,
 							0,
 						),
-				}),
-				{ indices: [], cumulative: 0 },
-			).indices,
-		[groups],
+						}),
+						{ indices: [], cumulative: 0 },
+					).indices,
+		[groupedProjects],
 	);
 
 	useEffect(() => {
@@ -71,30 +97,87 @@ export function WorkspaceSidebar({
 
 	return (
 		<SidebarDropZone className="flex flex-col h-full bg-muted/45 dark:bg-muted/35">
-			<WorkspaceSidebarHeader isCollapsed={isCollapsed} />
+			<WorkspaceSidebarHeader
+				isCollapsed={isCollapsed}
+				onCreateProjectGroup={() => createProjectGroup()}
+			/>
 
 			{/* biome-ignore lint/a11y/noStaticElementInteractions: mousedown on empty sidebar space clears selection */}
 			<div
 				className="flex-1 overflow-y-auto hide-scrollbar"
 				onMouseDown={handleSidebarMouseDown}
 			>
-				{groups.map((group, index) => (
-					<ProjectSection
-						key={group.project.id}
-						projectId={group.project.id}
-						projectName={group.project.name}
-						projectColor={group.project.color}
-						githubOwner={group.project.githubOwner}
-						mainRepoPath={group.project.mainRepoPath}
-						hideImage={group.project.hideImage}
-						iconUrl={group.project.iconUrl}
-						workspaces={group.workspaces}
-						sections={group.sections ?? []}
-						topLevelItems={group.topLevelItems}
-						shortcutBaseIndex={projectShortcutIndices[index]}
-						index={index}
-						isCollapsed={isCollapsed}
-					/>
+				{groupedProjects.map((projectGroup) => (
+					<ProjectGroupSection
+						key={projectGroup.id}
+						groupId={projectGroup.id}
+						name={projectGroup.name}
+						projectCount={projectGroup.projectCount}
+						workspaceCount={projectGroup.workspaceCount}
+						isCollapsed={projectGroup.isCollapsed}
+						isDefault={projectGroup.isDefault}
+						onToggleCollapse={() =>
+							toggleProjectGroupCollapsed(projectGroup.id)
+						}
+						onRename={(name) => renameProjectGroup(projectGroup.id, name)}
+						onDelete={() => deleteProjectGroup(projectGroup.id)}
+						onProjectDrop={(projectId) =>
+							setProjectGroup(
+								projectId,
+								projectGroup.id === "__ungrouped__"
+									? "__ungrouped__"
+									: projectGroup.id,
+							)
+						}
+						onAddProject={(projectId) =>
+							setProjectGroup(
+								projectId,
+								projectGroup.id === "__ungrouped__"
+									? "__ungrouped__"
+									: projectGroup.id,
+							)
+						}
+						availableProjects={groups
+							.filter((group) => {
+								const assignment = projectAssignments[group.project.id] ?? "current";
+								return assignment !== projectGroup.id;
+							})
+							.map((group) => ({
+								id: group.project.id,
+								name: group.project.name,
+							}))}
+					>
+						{projectGroup.projects.map((group, index) => {
+							const globalIndex = groups.findIndex(
+								(candidate) => candidate.project.id === group.project.id,
+							);
+							return (
+								<ProjectSection
+									key={group.project.id}
+									projectGroupId={projectGroup.id}
+									projectId={group.project.id}
+									projectName={group.project.name}
+									projectColor={group.project.color}
+									githubOwner={group.project.githubOwner}
+									mainRepoPath={group.project.mainRepoPath}
+									hideImage={group.project.hideImage}
+									iconUrl={group.project.iconUrl}
+									workspaces={group.workspaces}
+									sections={group.sections ?? []}
+									topLevelItems={group.topLevelItems}
+									shortcutBaseIndex={projectShortcutIndices[globalIndex] ?? index}
+									index={globalIndex >= 0 ? globalIndex : index}
+									isCollapsed={isCollapsed}
+									onMoveToProjectGroup={(projectId, groupId) =>
+										setProjectGroup(
+											projectId,
+											groupId === "__ungrouped__" ? "__ungrouped__" : groupId,
+										)
+									}
+								/>
+							);
+						})}
+					</ProjectGroupSection>
 				))}
 
 				{groups.length === 0 && !isCollapsed && (

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarHeader/WorkspaceSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSidebarHeader/WorkspaceSidebarHeader.tsx
@@ -2,7 +2,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { useMatchRoute, useNavigate } from "@tanstack/react-router";
 import { HiOutlineClipboardDocumentList } from "react-icons/hi2";
-import { LuLayers } from "react-icons/lu";
+import { LuFolderPlus, LuLayers } from "react-icons/lu";
 import { GATED_FEATURES, usePaywall } from "renderer/components/Paywall";
 import { useTasksFilterStore } from "renderer/routes/_authenticated/_dashboard/tasks/stores/tasks-filter-state";
 import { STROKE_WIDTH } from "../constants";
@@ -10,10 +10,12 @@ import { NewWorkspaceButton } from "./NewWorkspaceButton";
 
 interface WorkspaceSidebarHeaderProps {
 	isCollapsed?: boolean;
+	onCreateProjectGroup?: () => void;
 }
 
 export function WorkspaceSidebarHeader({
 	isCollapsed = false,
+	onCreateProjectGroup,
 }: WorkspaceSidebarHeaderProps) {
 	const navigate = useNavigate();
 	const matchRoute = useMatchRoute();
@@ -50,6 +52,19 @@ export function WorkspaceSidebarHeader({
 	if (isCollapsed) {
 		return (
 			<div className="flex flex-col items-center border-b border-border py-2 gap-2">
+				<Tooltip delayDuration={300}>
+					<TooltipTrigger asChild>
+						<button
+							type="button"
+							onClick={onCreateProjectGroup}
+							className="flex items-center justify-center size-8 rounded-md transition-colors text-muted-foreground hover:text-foreground hover:bg-accent/50"
+						>
+							<LuFolderPlus className="size-4" strokeWidth={STROKE_WIDTH} />
+						</button>
+					</TooltipTrigger>
+					<TooltipContent side="right">New project group</TooltipContent>
+				</Tooltip>
+
 				<Tooltip delayDuration={300}>
 					<TooltipTrigger asChild>
 						<button
@@ -110,6 +125,17 @@ export function WorkspaceSidebarHeader({
 					<LuLayers className="size-4" strokeWidth={STROKE_WIDTH} />
 				</div>
 				<span className="text-sm font-medium flex-1 text-left">Workspaces</span>
+			</button>
+
+			<button
+				type="button"
+				onClick={onCreateProjectGroup}
+				className="flex items-center gap-2 px-2 py-1.5 w-full rounded-md transition-colors text-muted-foreground hover:text-foreground hover:bg-accent/50"
+			>
+				<div className="flex items-center justify-center size-5">
+					<LuFolderPlus className="size-4" strokeWidth={STROKE_WIDTH} />
+				</div>
+				<span className="text-sm font-medium flex-1 text-left">New Group</span>
 			</button>
 
 			<button

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/utils/groupProjectsBySidebarGroups.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/utils/groupProjectsBySidebarGroups.ts
@@ -1,0 +1,87 @@
+import {
+	CURRENT_PROJECT_GROUP_ID,
+	UNGROUPED_PROJECT_GROUP_ID,
+	type ProjectGroupItem,
+} from "renderer/stores/project-groups-state";
+
+interface SidebarProjectLike {
+	project: {
+		id: string;
+	};
+	workspaces: Array<unknown>;
+	sections?: Array<{
+		workspaces: Array<unknown>;
+	}>;
+}
+
+export interface GroupedProjectBucket<TProject extends SidebarProjectLike> {
+	id: string;
+	name: string;
+	isCollapsed: boolean;
+	projects: TProject[];
+	projectCount: number;
+	workspaceCount: number;
+	isDefault: boolean;
+}
+
+export function groupProjectsBySidebarGroups<TProject extends SidebarProjectLike>({
+	projectGroups,
+	projectAssignments,
+	projects,
+}: {
+	projectGroups: ProjectGroupItem[];
+	projectAssignments: Record<string, string | null | undefined>;
+	projects: TProject[];
+}): GroupedProjectBucket<TProject>[] {
+	const orderedGroups = [...projectGroups].sort((a, b) => a.order - b.order);
+	const buckets = new Map<string, GroupedProjectBucket<TProject>>(
+		orderedGroups.map((group) => [
+			group.id,
+			{
+				id: group.id,
+				name: group.name,
+				isCollapsed: group.isCollapsed,
+				projects: [],
+				projectCount: 0,
+				workspaceCount: 0,
+				isDefault: group.id === CURRENT_PROJECT_GROUP_ID,
+			},
+		]),
+	);
+
+	buckets.set(UNGROUPED_PROJECT_GROUP_ID, {
+		id: UNGROUPED_PROJECT_GROUP_ID,
+		name: "Other Projects",
+		isCollapsed: false,
+		projects: [],
+		projectCount: 0,
+		workspaceCount: 0,
+		isDefault: false,
+	});
+
+	for (const project of projects) {
+		const assignedGroupId = projectAssignments[project.project.id];
+		const bucket =
+			assignedGroupId === UNGROUPED_PROJECT_GROUP_ID
+				? buckets.get(UNGROUPED_PROJECT_GROUP_ID)
+				: buckets.get(assignedGroupId ?? CURRENT_PROJECT_GROUP_ID) ??
+					buckets.get(CURRENT_PROJECT_GROUP_ID) ??
+					buckets.get(UNGROUPED_PROJECT_GROUP_ID);
+		if (!bucket) continue;
+
+		const workspaceCount =
+			project.workspaces.length +
+			(project.sections ?? []).reduce(
+				(sum, section) => sum + section.workspaces.length,
+				0,
+			);
+
+		bucket.projects.push(project);
+		bucket.projectCount += 1;
+		bucket.workspaceCount += workspaceCount;
+	}
+
+	return [...orderedGroups.map((group) => buckets.get(group.id)).filter(Boolean), buckets.get(UNGROUPED_PROJECT_GROUP_ID)]
+		.filter((bucket): bucket is GroupedProjectBucket<TProject> => Boolean(bucket))
+		.filter((bucket) => bucket.id !== UNGROUPED_PROJECT_GROUP_ID || bucket.projects.length > 0);
+}

--- a/apps/desktop/src/renderer/stores/index.ts
+++ b/apps/desktop/src/renderer/stores/index.ts
@@ -1,6 +1,7 @@
 export * from "./chat-preferences";
 export * from "./hotkeys";
 export * from "./markdown-preferences";
+export * from "./project-groups-state";
 export * from "./ports";
 export * from "./ringtone";
 export * from "./settings-state";

--- a/apps/desktop/src/renderer/stores/project-groups-state.ts
+++ b/apps/desktop/src/renderer/stores/project-groups-state.ts
@@ -1,0 +1,156 @@
+import { create } from "zustand";
+import { devtools, persist } from "zustand/middleware";
+
+export const CURRENT_PROJECT_GROUP_ID = "current";
+export const UNGROUPED_PROJECT_GROUP_ID = "__ungrouped__";
+
+export interface ProjectGroupItem {
+	id: string;
+	name: string;
+	order: number;
+	isCollapsed: boolean;
+}
+
+interface ProjectGroupsState {
+	groups: ProjectGroupItem[];
+	projectAssignments: Record<string, string | null | undefined>;
+
+	createGroup: (name?: string) => string;
+	renameGroup: (groupId: string, name: string) => void;
+	deleteGroup: (groupId: string) => void;
+	toggleGroupCollapsed: (groupId: string) => void;
+	setProjectGroup: (projectId: string, groupId: string | null) => void;
+}
+
+const DEFAULT_GROUPS: ProjectGroupItem[] = [
+	{
+		id: CURRENT_PROJECT_GROUP_ID,
+		name: "Current",
+		order: 0,
+		isCollapsed: false,
+	},
+];
+
+function getNextGroupName(groups: ProjectGroupItem[]): string {
+	const baseName = "New Group";
+	const names = new Set(groups.map((group) => group.name));
+	if (!names.has(baseName)) {
+		return baseName;
+	}
+
+	let suffix = 2;
+	while (names.has(`${baseName} ${suffix}`)) {
+		suffix += 1;
+	}
+
+	return `${baseName} ${suffix}`;
+}
+
+function ensureDefaultGroups(groups: ProjectGroupItem[]): ProjectGroupItem[] {
+	if (groups.some((group) => group.id === CURRENT_PROJECT_GROUP_ID)) {
+		return [...groups].sort((a, b) => a.order - b.order);
+	}
+
+	return [...DEFAULT_GROUPS, ...groups].map((group, index) => ({
+		...group,
+		order: index,
+	}));
+}
+
+export const useProjectGroupsStore = create<ProjectGroupsState>()(
+	devtools(
+		persist(
+			(set, get) => ({
+				groups: DEFAULT_GROUPS,
+				projectAssignments: {},
+
+				createGroup: (name) => {
+					const groups = ensureDefaultGroups(get().groups);
+					const id = crypto.randomUUID();
+					const nextGroup: ProjectGroupItem = {
+						id,
+						name: name?.trim() || getNextGroupName(groups),
+						order: groups.length,
+						isCollapsed: false,
+					};
+
+					set({ groups: [...groups, nextGroup] });
+					return id;
+				},
+
+				renameGroup: (groupId, name) => {
+					const trimmedName = name.trim();
+					if (!trimmedName) return;
+
+					set((state) => ({
+						groups: ensureDefaultGroups(state.groups).map((group) =>
+							group.id === groupId ? { ...group, name: trimmedName } : group,
+						),
+					}));
+				},
+
+				deleteGroup: (groupId) => {
+					if (groupId === CURRENT_PROJECT_GROUP_ID) return;
+
+					set((state) => {
+						const nextAssignments = { ...state.projectAssignments };
+						for (const [projectId, assignedGroupId] of Object.entries(nextAssignments)) {
+							if (assignedGroupId === groupId) {
+								nextAssignments[projectId] = null;
+							}
+						}
+
+						return {
+							groups: ensureDefaultGroups(state.groups)
+								.filter((group) => group.id !== groupId)
+								.map((group, index) => ({ ...group, order: index })),
+							projectAssignments: nextAssignments,
+						};
+					});
+				},
+
+				toggleGroupCollapsed: (groupId) => {
+					set((state) => ({
+						groups: ensureDefaultGroups(state.groups).map((group) =>
+							group.id === groupId
+								? { ...group, isCollapsed: !group.isCollapsed }
+								: group,
+						),
+					}));
+				},
+
+				setProjectGroup: (projectId, groupId) => {
+					set((state) => {
+						const nextAssignments = {
+							...state.projectAssignments,
+							[projectId]: groupId,
+						};
+						return {
+							projectAssignments: nextAssignments,
+						};
+					});
+				},
+
+			}),
+			{
+				name: "project-groups-store",
+				version: 2,
+				migrate: (persistedState) => {
+					const state = persistedState as Partial<ProjectGroupsState> | undefined;
+					return {
+						groups: ensureDefaultGroups(state?.groups ?? DEFAULT_GROUPS),
+						projectAssignments: Object.fromEntries(
+							Object.entries(state?.projectAssignments ?? {}).map(
+								([projectId, groupId]) => [
+									projectId,
+									groupId === null ? CURRENT_PROJECT_GROUP_ID : groupId,
+								],
+							),
+						),
+					};
+				},
+			},
+		),
+		{ name: "ProjectGroupsStore" },
+	),
+);


### PR DESCRIPTION
## Description
- add manual project groups in the workspace sidebar with a default Current section
- let users create, rename, collapse, and delete project groups
- allow moving projects into groups from the project menu and group header actions

## Related Issues
- related to workspace sidebar organization improvements

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing
- `bun run --cwd apps/desktop typecheck`
- `SKIP_ENV_VALIDATION=1 bun run --cwd apps/desktop dev`

## Screenshots (if applicable)
- n/a

## Additional Notes
- maintainers can modify this PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add project groups to the workspace sidebar so users can organize projects into custom groups. Keyboard shortcuts and navigation now follow the grouped order, and group state persists between sessions.

- New Features
  - Custom project groups with create, rename, collapse, and delete
  - Default "Current" group and automatic "Other Projects" bucket
  - Drag-and-drop projects onto group headers; add via group dropdown
  - "Move to Group" action in the project context menu
  - Group headers show project and workspace counts; “New Group” button in sidebar header

- Refactors
  - Workspace switching shortcuts use group-aware project ordering
  - Drag-and-drop reorders within a group; cross-group drop moves the project
  - Added `groupProjectsBySidebarGroups` utility and `ProjectGroupSection` component
  - Introduced persisted `project-groups-state` store (with migration) and exported from `stores/index.ts`

<sup>Written for commit 2e2a0fa95026868581176d731b2a20701e07baa8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced project groups to organize and manage projects in the workspace sidebar.
  * Added the ability to create, rename, and delete project groups.
  * Added the ability to move projects between groups via drag-and-drop or context menu.
  * Added the ability to collapse and expand project groups for improved workspace organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->