### PR TITLE
docs(desktop): codify codex wrapper-first hooks

### DIFF
--- a/apps/desktop/docs/EXTERNAL_FILES.md
+++ b/apps/desktop/docs/EXTERNAL_FILES.md
@@ -40,7 +40,14 @@ its hook entries into these files while preserving user-defined entries:
 
 | File | Purpose |
 |------|---------|
+| `~/.claude/settings.json` | Claude Code hook registration merge |
+| `~/.codex/hooks.json` | Codex fallback hook registration merge (`SessionStart`, `Stop`) |
 | `~/.factory/settings.json` | Factory Droid hook registration (`UserPromptSubmit`, `Notification`, `PostToolUse`, `Stop`) |
+
+For Codex specifically, this global `hooks.json` is a fallback path only. The
+primary Superset integration is the wrapper in `~/.superset[-{workspace}]/bin/codex`,
+which injects `notify` and watches the Codex session log for richer lifecycle
+events without mutating project-local `.codex/` state.
 
 ### `zsh/` and `bash/` - Shell Integration
 

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-claude-codex-opencode.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-claude-codex-opencode.ts
@@ -304,9 +304,14 @@ export function getCodexGlobalHooksJsonPath(): string {
  * Codex hooks.json uses the same nested structure as Claude/Droid:
  *   { hooks: { EventName: [{ matcher?, hooks: [{ type, command }] }] } }
  *
- * Currently Codex supports SessionStart and Stop events (experimental,
- * added in Codex CLI v0.111.0). We also register the notify command
- * for these events so notifications work even without the wrapper.
+ * Superset intentionally keeps this native Codex hook registration narrow.
+ * The primary integration path is still the wrapper + notify/session-log
+ * watcher, which works inside Superset-managed terminal sessions and covers
+ * richer lifecycle events like per-turn Start and PermissionRequest.
+ *
+ * This hooks.json merge is only a fallback for cases where the wrapper is
+ * bypassed, so we only register the minimal SessionStart + Stop notifications
+ * here rather than trying to mirror Codex's full native hook surface.
  */
 export function getCodexGlobalHooksJsonContent(
 	notifyScriptPath: string,
@@ -363,9 +368,10 @@ export function getCodexGlobalHooksJsonContent(
  * binary wrapper is not in PATH (e.g. user runs codex from outside
  * a Superset terminal).
  *
- * The wrapper is still created for richer event support (task_started,
- * approval_request, exec_command_begin via session log watching) that
- * Codex's native hooks don't yet cover.
+ * The wrapper remains the primary integration path for Superset-managed
+ * terminals because it can synthesize richer lifecycle events from Codex's
+ * notify callback and session log (task_started, approval_request,
+ * exec_command_begin) without mutating project-local CODEX_HOME state.
  */
 export function createCodexHooksJson(): void {
 	const notifyScriptPath = getNotifyScriptPath();

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -916,6 +916,25 @@ describe("agent-wrappers codex hooks.json", () => {
 		).toBe(true);
 	});
 
+	it("does not add UserPromptSubmit to the Codex fallback hooks.json merge", () => {
+		const notifyPath = "/tmp/.superset/hooks/notify.sh";
+		const content = getCodexGlobalHooksJsonContent(notifyPath);
+		expect(content).not.toBeNull();
+		if (content === null) throw new Error("Expected content");
+
+		const parsed = JSON.parse(content) as {
+			hooks: Record<
+				string,
+				Array<{
+					matcher?: string;
+					hooks: Array<{ type: string; command: string }>;
+				}>
+			>;
+		};
+
+		expect(parsed.hooks.UserPromptSubmit).toBeUndefined();
+	});
+
 	it("replaces stale Codex hook commands from old superset paths", () => {
 		const codexHooksPath = path.join(mockedHomeDir, ".codex", "hooks.json");
 		const staleHookPath = "/tmp/.superset-old/hooks/notify.sh";


### PR DESCRIPTION
## Summary
- revert the earlier native Codex hook expansion
- document that Superset's primary Codex integration is the wrapper plus notify/session-log watcher
- add a test that keeps the Codex fallback hooks.json merge limited to SessionStart and Stop

## Testing
- bun test apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
- bun test apps/desktop/src/main/lib/notifications/server.test.ts