### PR TITLE
fix(api): update task slug to Linear identifier after first sync

### DIFF
--- a/apps/api/src/app/api/integrations/linear/jobs/sync-task/route.ts
+++ b/apps/api/src/app/api/integrations/linear/jobs/sync-task/route.ts
@@ -214,6 +214,7 @@ async function syncTaskToLinear(
 		await db
 			.update(tasks)
 			.set({
+				slug: issue.identifier,
 				externalProvider: "linear",
 				externalId: issue.id,
 				externalKey: issue.identifier,


### PR DESCRIPTION
## Summary
- When a locally created task is first synced to Linear, update the `slug` to the Linear identifier (e.g., `SUPER-238`) so the task is consistently identified by its Linear key across the UI

Previously, the sync-task job wrote `externalKey`, `externalId`, and `externalUrl` but left `slug` as the original title-based value. This meant a task created locally as `link-workspaces-and-tasks` would keep that slug even after being synced as `SUPER-238` in Linear.

## Test plan
- [ ] Create a task locally, verify it gets a title-based slug
- [ ] Trigger sync to Linear, verify the slug updates to the Linear identifier
- [ ] Verify the task is still accessible by the new slug in the UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the Linear integration where task identifiers were not being properly saved when creating new tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->