### PR TITLE
Add block-no-verify PreToolUse hook to .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,5 +2,18 @@
 	"attribution": {
 		"commit": "",
 		"pr": ""
+	},
+	"hooks": {
+		"PreToolUse": [
+			{
+				"matcher": "Bash",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "npx block-no-verify@1.1.2"
+					}
+				]
+			}
+		]
 	}
 }


### PR DESCRIPTION
## Summary

Adds `block-no-verify@1.1.2` as a `PreToolUse` Bash hook in `.claude/settings.json`, alongside the existing attribution config.

## Details

When an agent runs `git commit` or `git push` with the hook-bypass flag, it silently disables pre-commit, commit-msg, and pre-push hooks. `block-no-verify` reads `tool_input.command` from the Claude Code hook stdin, detects the hook-bypass flag across all git subcommands, and exits 2 to block. The existing attribution config is preserved unchanged.

Closes #2616

---

_Disclosure: I am the author and maintainer of `block-no-verify`._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `block-no-verify@1.1.2` as a Bash `PreToolUse` hook in `.claude/settings.json` to stop agents from bypassing git hooks with `--no-verify` and similar flags. Enforces pre-commit, commit-msg, and pre-push hooks; addresses #2616.

- **New Features**
  - Runs `npx block-no-verify@1.1.2` for Bash tools via `PreToolUse`.
  - Parses `tool_input.command` and blocks on hook-bypass flags (exit code 2).
  - Keeps existing attribution config unchanged.

<sup>Written for commit 2c279040c9a5c52937170cc428c93bf295c190af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->