### PR TITLE
fix(desktop): narrow sidebar workspace drag start

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -4,6 +4,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { useMatchRoute, useNavigate } from "@tanstack/react-router";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { getEmptyImage } from "react-dnd-html5-backend";
 import { HiMiniXMark } from "react-icons/hi2";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useWorkspaceDeleteHandler } from "renderer/react-query/workspaces";
@@ -95,18 +96,26 @@ export function WorkspaceListItem({
 	});
 
 	const itemRef = useRef<HTMLElement | null>(null);
+	const rowRef = useRef<HTMLDivElement | null>(null);
+	const dragHotspotRef = useRef<HTMLDivElement | null>(null);
 	useEffect(() => {
 		if (isActive) {
 			itemRef.current?.scrollIntoView({ block: "nearest", behavior: "smooth" });
 		}
 	}, [isActive]);
 
-	const { isDragging, drag, drop } = useWorkspaceDnD({
+	const { isDragging, drag, drop, preview } = useWorkspaceDnD({
 		id,
 		projectId,
 		sectionId,
 		index,
 	});
+
+	useEffect(() => {
+		preview(getEmptyImage(), { captureDraggingState: true });
+		drop(rowRef);
+		drag(dragHotspotRef);
+	}, [preview, drop, drag]);
 
 	const openInFinder = electronTrpc.external.openInFinder.useMutation({
 		onError: (error) => toast.error(`Failed to open: ${error.message}`),
@@ -253,8 +262,8 @@ export function WorkspaceListItem({
 			role="button"
 			tabIndex={0}
 			ref={(node) => {
+				rowRef.current = node;
 				itemRef.current = node;
-				drag(drop(node));
 			}}
 			onClick={handleClick}
 			onKeyDown={(e) => {
@@ -282,6 +291,12 @@ export function WorkspaceListItem({
 			)}
 			style={{ cursor: isDragging ? "grabbing" : "pointer" }}
 		>
+			<div
+				ref={dragHotspotRef}
+				aria-hidden="true"
+				className="absolute inset-y-0 left-0 w-4 cursor-grab active:cursor-grabbing"
+			/>
+
 			{isActive && (
 				<div className="absolute left-0 top-0 bottom-0 w-0.5 bg-primary rounded-r" />
 			)}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/useWorkspaceDnD.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/useWorkspaceDnD.ts
@@ -69,7 +69,7 @@ export function useWorkspaceDnD({
 		[reorderProjectChildren, reorderWorkspacesInSection, utils],
 	);
 
-	const [{ isDragging }, drag] = useDrag(
+	const [{ isDragging }, drag, preview] = useDrag(
 		() => ({
 			type: WORKSPACE_DND_TYPE,
 			item: () => {
@@ -196,5 +196,5 @@ export function useWorkspaceDnD({
 		},
 	});
 
-	return { isDragging, drag, drop };
+	return { isDragging, drag, drop, preview };
 }


### PR DESCRIPTION
## Summary
- revert the earlier handle-based experiments and keep the sidebar UI unchanged
- limit workspace drag start to a narrow, non-visual left gutter instead of the full row
- suppress the native HTML5 drag ghost so dragging inside sections no longer makes the whole row feel draggable

## Testing
- bunx biome check apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/useWorkspaceDnD.ts apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
- bunx tsc -p apps/desktop/tsconfig.json --noEmit *(still fails in this worktree due to unrelated existing missing generated files like `routeTree.gen` and `resources/public/file-icons/manifest.json`)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Visible drag handle (reorder grip) added to workspace items and improved drag preview for clearer reordering feedback.

* **Bug Fixes**
  * Drag targets separated from the main clickable row to prevent accidental navigation/activation while dragging, preserving click and keyboard behavior and correct cursor states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->