### PR TITLE
fix(desktop): unknown icon for ts/js files

### DIFF
--- a/apps/desktop/scripts/generate-file-icons.ts
+++ b/apps/desktop/scripts/generate-file-icons.ts
@@ -55,6 +55,20 @@ function run() {
 		defaultFolderOpenIcon: manifest.folderExpanded ?? "folder-open",
 	};
 
+	// material-icon-theme relies on VS Code's languageIds for base extensions.
+	// Since Electron has no languageId system, add them explicitly.
+	const baseExtensionDefaults: Record<string, string> = {
+		ts: "typescript",
+		js: "javascript",
+	};
+
+	for (const [ext, icon] of Object.entries(baseExtensionDefaults)) {
+		if (!condensed.fileExtensions[ext]) {
+			condensed.fileExtensions[ext] = icon;
+			referencedIcons.add(icon);
+		}
+	}
+
 	// Prepare output directory
 	if (existsSync(OUT_DIR)) {
 		rmSync(OUT_DIR, { recursive: true });


### PR DESCRIPTION
## Description

Some typescript files haven't a correct icon

## Related Issues


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

- Check typescript files
- Check javascript files

## Screenshots (if applicable)
<img width="230" height="502" alt="Screenshot 2026-03-20 at 02 06 36" src="https://github.com/user-attachments/assets/2d6f90c3-d96d-4cc5-9d65-ceefe114f226" />
<img width="257" height="660" alt="Screenshot 2026-03-20 at 02 07 25" src="https://github.com/user-attachments/assets/f7cd3ef8-4aa6-4430-a969-cb94f4720993" />


## Additional Notes

<!-- Add any other context about the PR here -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unknown icons for .ts and .js files in the desktop app by adding explicit extension-to-icon mappings in `generate-file-icons.ts`. TypeScript and JavaScript files now show the correct `material-icon-theme` icons without relying on VS Code language IDs.

- **Bug Fixes**
  - Added base defaults: `ts` → `typescript`, `js` → `javascript`.
  - Marks these icons as referenced so they are included in the generated set.

<sup>Written for commit 7a62d7cb2d874a2fa7991942cc7848a9f1edc425. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file icon generation to ensure TypeScript and JavaScript files always display appropriate icons. This enhancement guarantees proper visual identification of these widely-used file types in the desktop application, even when the base icon theme lacks default icon entries for them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->