### PR TITLE
test(desktop): decouple notification pane resolution from server

### DIFF
--- a/apps/desktop/src/main/lib/notifications/resolve-pane-id.ts
+++ b/apps/desktop/src/main/lib/notifications/resolve-pane-id.ts
@@ -1,3 +1,4 @@
+import { appState } from "../app-state";
 import type { TabsState } from "../app-state/schemas";
 
 /**
@@ -47,6 +48,36 @@ export function resolvePaneIdFromTabsState(
 				return existingPaneId;
 			}
 		}
+	}
+
+	return undefined;
+}
+
+/**
+ * Resolves pane IDs using main-process persisted tabs state when possible.
+ * Explicit pane IDs are trusted to avoid dropping early hook events while
+ * tabsState persistence is still catching up.
+ */
+export function resolvePaneId(
+	paneId: string | undefined,
+	tabId: string | undefined,
+	workspaceId: string | undefined,
+	sessionId: string | undefined,
+): string | undefined {
+	if (paneId) {
+		return paneId;
+	}
+
+	try {
+		return resolvePaneIdFromTabsState(
+			appState.data.tabsState,
+			undefined,
+			tabId,
+			workspaceId,
+			sessionId,
+		);
+	} catch {
+		// App state not initialized yet, ignore
 	}
 
 	return undefined;

--- a/apps/desktop/src/main/lib/notifications/server.test.ts
+++ b/apps/desktop/src/main/lib/notifications/server.test.ts
@@ -1,13 +1,6 @@
-import { describe, expect, it, mock } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { mapEventType } from "./map-event-type";
-
-mock.module("electron", () => ({
-	BrowserWindow: {
-		getAllWindows: () => [],
-	},
-}));
-
-const { resolvePaneId } = await import("./server");
+import { resolvePaneId } from "./resolve-pane-id";
 
 describe("notifications/server", () => {
 	describe("resolvePaneId", () => {

--- a/apps/desktop/src/main/lib/notifications/server.ts
+++ b/apps/desktop/src/main/lib/notifications/server.ts
@@ -5,16 +5,16 @@ import { handleAuthCallback } from "lib/trpc/routers/auth/utils/auth-functions";
 import { NOTIFICATION_EVENTS } from "shared/constants";
 import { env } from "shared/env.shared";
 import type { AgentLifecycleEvent } from "shared/notification-types";
-import { appState } from "../app-state";
 import { HOOK_PROTOCOL_VERSION } from "../terminal/env";
 import { mapEventType } from "./map-event-type";
-import { resolvePaneIdFromTabsState } from "./resolve-pane-id";
+import { resolvePaneId } from "./resolve-pane-id";
 
 // Re-export types for backwards compatibility
 export type {
 	AgentLifecycleEvent,
 	NotificationIds,
 } from "shared/notification-types";
+export { resolvePaneId } from "./resolve-pane-id";
 
 /**
  * The environment this server is running in.
@@ -47,36 +47,6 @@ app.use((req, res, next) => {
 	}
 	next();
 });
-
-/**
- * Resolves pane IDs using main-process persisted tabs state when possible.
- * Explicit pane IDs are trusted to avoid dropping early hook events while
- * tabsState persistence is still catching up.
- */
-export function resolvePaneId(
-	paneId: string | undefined,
-	tabId: string | undefined,
-	workspaceId: string | undefined,
-	sessionId: string | undefined,
-): string | undefined {
-	if (paneId) {
-		return paneId;
-	}
-
-	try {
-		return resolvePaneIdFromTabsState(
-			appState.data.tabsState,
-			undefined,
-			tabId,
-			workspaceId,
-			sessionId,
-		);
-	} catch {
-		// App state not initialized yet, ignore
-	}
-
-	return undefined;
-}
 
 // Agent lifecycle hook
 app.get("/hook/complete", (req, res) => {


### PR DESCRIPTION
## Summary
- move the app-state-backed `resolvePaneId` helper into `resolve-pane-id.ts`
- keep `server.ts` behavior and export surface intact by consuming and re-exporting the helper
- update `server.test.ts` to exercise the pane-resolution logic without importing the Electron-backed server module

## Verification
- `bunx sherif`
- `bun run lint`
- `NEXT_PUBLIC_OUTLIT_KEY=ci-outlit-placeholder-key bun run test`
- `bun run typecheck`
- `NEXT_PUBLIC_OUTLIT_KEY=ci-outlit-placeholder-key bun turbo run build --filter=@superset/desktop`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decouples notification pane resolution from the desktop server by moving the logic into a standalone helper and re-exporting it to keep the public API unchanged. Tests now target the pure helper to remove Electron coupling.

- **Refactors**
  - Moved app-state-backed `resolvePaneId` to `resolve-pane-id.ts`.
  - `server.ts` consumes and re-exports `resolvePaneId` for backward compatibility.
  - Updated tests to import the helper directly and removed the Electron mock.

<sup>Written for commit 3c72950ec3479cb24b4cd541612605a16a940721. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal notification handling code for improved maintainability and modularity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->