### PR TITLE
feat(desktop): focus prompt textarea when switching to a chat tab

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPane.tsx
@@ -73,14 +73,14 @@ export function ChatPane({
 	const chatContainerRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
-		if (isActiveTab && !prevIsActiveTabRef.current) {
+		if (isActiveTab && !prevIsActiveTabRef.current && isFocused) {
 			const textarea = chatContainerRef.current?.querySelector<HTMLTextAreaElement>(
 				"[data-slot=input-group-control]",
 			);
 			textarea?.focus();
 		}
 		prevIsActiveTabRef.current = isActiveTab;
-	}, [isActiveTab]);
+	}, [isActiveTab, isFocused]);
 	const equalizePaneSplits = useTabsStore((s) => s.equalizePaneSplits);
 	const paneName = useTabsStore((s) => s.panes[paneId]?.name ?? "New Chat");
 	const setTabAutoTitle = useTabsStore((s) => s.setTabAutoTitle);


### PR DESCRIPTION
# What does this PR do? (required)
When clicking on an existing chat tab, the prompt textarea is now automatically focused so users can start typing immediately without an extra click.

# Link to Basecamp to-do, Trello card, New Relic or Honeybadger (required)
N/A

# QA
## What platforms should be included in QA?
- [x] Desktop web
- [ ] Mobile web
- [ ] iOS
- [ ] Android
- [ ] API
- [ ] N/A

## QA steps
1. Open the desktop app with multiple chat tabs
2. Click on a chat tab that is not currently active
3. Verify the prompt textarea is focused (cursor appears in the input) immediately after switching tabs — no extra click required
4. Confirm this does not trigger when the app first loads or when a new tab is created and switched to programmatically

## Screenshots (if appropriate)
N/A

# Docs
Update changelog after deployment if the changes in Admin are valuable for Sales, Support or Success teams.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically focuses the chat prompt textarea when you switch to an existing chat tab in the desktop app so you can type right away. It runs only on user-initiated tab switches and only for the focused pane in split view, not on initial load or when a tab is created or activated programmatically.

<sup>Written for commit dc7ddaa9e3b4954446de91dbbc7431bfce0853eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Chat input now reliably receives focus when switching to a chat tab and the pane is active, so users can begin typing immediately without extra clicks.
  * Improved behavior when returning to an active chat tab while the pane is focused, ensuring the input field is brought into focus consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->