### PR TITLE
fix(desktop): clear new workspace form immediately on submit

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModalDraftContext.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModalDraftContext.tsx
@@ -69,6 +69,10 @@ interface NewWorkspaceModalActionMessages {
 	error: (err: unknown) => string;
 }
 
+interface NewWorkspaceModalActionOptions {
+	closeAndReset?: boolean;
+}
+
 interface NewWorkspaceModalDraftContextValue {
 	draft: NewWorkspaceModalDraft;
 	draftVersion: number;
@@ -82,10 +86,10 @@ interface NewWorkspaceModalDraftContextValue {
 	runAsyncAction: <T>(
 		promise: Promise<T>,
 		messages: NewWorkspaceModalActionMessages,
+		options?: NewWorkspaceModalActionOptions,
 	) => Promise<T>;
 	updateDraft: (patch: Partial<NewWorkspaceModalDraft>) => void;
 	resetDraft: () => void;
-	resetDraftIfVersion: (draftVersion: number) => void;
 }
 
 const NewWorkspaceModalDraftContext =
@@ -119,27 +123,21 @@ export function NewWorkspaceModalDraftProvider({
 		}));
 	}, []);
 
-	const resetDraftIfVersion = useCallback((draftVersion: number) => {
-		setState((state) =>
-			state.draftVersion !== draftVersion
-				? state
-				: {
-						...initialDraft,
-						draftVersion: state.draftVersion + 1,
-						resetKey: state.resetKey + 1,
-					},
-		);
-	}, []);
-
 	const closeAndResetDraft = useCallback(() => {
 		resetDraft();
 		onClose();
 	}, [onClose, resetDraft]);
 
 	const runAsyncAction = useCallback(
-		<T,>(promise: Promise<T>, messages: NewWorkspaceModalActionMessages) => {
-			onClose();
-			resetDraft();
+		<T,>(
+			promise: Promise<T>,
+			messages: NewWorkspaceModalActionMessages,
+			options?: NewWorkspaceModalActionOptions,
+		) => {
+			if (options?.closeAndReset !== false) {
+				onClose();
+				resetDraft();
+			}
 			toast.promise(promise, {
 				loading: messages.loading,
 				success: messages.success,
@@ -175,7 +173,6 @@ export function NewWorkspaceModalDraftProvider({
 			runAsyncAction,
 			updateDraft,
 			resetDraft,
-			resetDraftIfVersion,
 		}),
 		[
 			closeAndResetDraft,
@@ -185,7 +182,6 @@ export function NewWorkspaceModalDraftProvider({
 			openTrackedWorktree,
 			onClose,
 			resetDraft,
-			resetDraftIfVersion,
 			runAsyncAction,
 			state,
 			updateDraft,

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
@@ -54,8 +54,10 @@ import { resolveEffectiveWorkspaceBaseBranch } from "renderer/lib/workspaceBaseB
 import { ProjectThumbnail } from "renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectThumbnail";
 import { useHotkeysStore } from "renderer/stores/hotkeys/store";
 import {
-	useSetIsGeneratingBranchName,
+	useClearPendingWorkspace,
+	useNewWorkspaceModalOpen,
 	useSetPendingWorkspace,
+	useSetPendingWorkspaceStatus,
 } from "renderer/stores/new-workspace-modal";
 import { buildPromptAgentLaunchRequest } from "shared/utils/agent-launch-request";
 import {
@@ -389,7 +391,9 @@ function PromptGroupInner({
 }: PromptGroupProps) {
 	const platform = useHotkeysStore((state) => state.platform);
 	const modKey = platform === "darwin" ? "⌘" : "Ctrl";
+	const isNewWorkspaceModalOpen = useNewWorkspaceModalOpen();
 	const {
+		closeAndResetDraft,
 		closeModal,
 		createWorkspace,
 		createFromPr,
@@ -398,8 +402,9 @@ function PromptGroupInner({
 		updateDraft,
 	} = useNewWorkspaceModalDraft();
 	const attachments = useProviderAttachments();
+	const clearPendingWorkspace = useClearPendingWorkspace();
 	const setPendingWorkspace = useSetPendingWorkspace();
-	const setIsGeneratingBranchNameGlobal = useSetIsGeneratingBranchName();
+	const setPendingWorkspaceStatus = useSetPendingWorkspaceStatus();
 	const {
 		baseBranch,
 		prompt,
@@ -436,21 +441,18 @@ function PromptGroupInner({
 	const [issueLinkOpen, setIssueLinkOpen] = useState(false);
 	const [prLinkOpen, setPRLinkOpen] = useState(false);
 	const plusMenuRef = useRef<HTMLDivElement>(null);
+	const submitStartedRef = useRef(false);
 	const trimmedPrompt = prompt.trim();
 	const firstIssueSlug = linkedIssues[0]?.slug ?? null;
 
 	// AI branch name generation (on submit only)
 	const generateBranchNameMutation =
 		electronTrpc.workspaces.generateBranchName.useMutation();
-	const [isGeneratingBranchName, setIsGeneratingBranchName] = useState(false);
-
-	// Track component mount state for cleanup
-	const isMountedRef = useRef(true);
 	useEffect(() => {
-		return () => {
-			isMountedRef.current = false;
-		};
-	}, []);
+		if (isNewWorkspaceModalOpen) {
+			submitStartedRef.current = false;
+		}
+	}, [isNewWorkspaceModalOpen]);
 
 	const { data: project } = electronTrpc.projects.get.useQuery(
 		{ id: projectId ?? "" },
@@ -549,200 +551,202 @@ function PromptGroupInner({
 			return;
 		}
 
-		// Prevent re-entry while generation/creation is in flight
-		if (
-			isGeneratingBranchName ||
-			generateBranchNameMutation.isPending ||
-			createWorkspace.isPending ||
-			createFromPr.isPending
-		) {
+		if (submitStartedRef.current) {
 			return;
 		}
+		submitStartedRef.current = true;
 
-		// Set pending workspace immediately for suspense UI
 		const displayName =
 			workspaceNameEdited && workspaceName.trim()
 				? workspaceName.trim()
 				: trimmedPrompt || "New workspace";
-
 		const willGenerateAIName =
 			!branchNameEdited && !!trimmedPrompt && !linkedPR;
+		const pendingWorkspaceId = crypto.randomUUID();
+		const detachedFiles = attachments.takeFiles();
 
 		setPendingWorkspace({
+			id: pendingWorkspaceId,
 			projectId,
 			name: displayName,
-			isGeneratingBranchName: willGenerateAIName,
+			status: willGenerateAIName ? "generating-branch" : "preparing",
 		});
+		closeAndResetDraft();
 
-		// Generate AI branch name if needed (before creating workspace)
-		let aiBranchName: string | null = null;
-		if (willGenerateAIName) {
-			setIsGeneratingBranchName(true);
-			let timeoutId: NodeJS.Timeout | null = null;
-			try {
-				// Add timeout to prevent hanging indefinitely
-				const AI_GENERATION_TIMEOUT_MS = 30000; // 30 seconds
-				const timeoutPromise = new Promise<never>((_, reject) => {
-					timeoutId = setTimeout(
-						() => reject(new Error("AI generation timeout")),
-						AI_GENERATION_TIMEOUT_MS,
-					);
-				});
+		try {
+			let aiBranchName: string | null = null;
+			if (willGenerateAIName) {
+				let timeoutId: NodeJS.Timeout | null = null;
+				try {
+					const AI_GENERATION_TIMEOUT_MS = 30000;
+					const timeoutPromise = new Promise<never>((_, reject) => {
+						timeoutId = setTimeout(
+							() => reject(new Error("AI generation timeout")),
+							AI_GENERATION_TIMEOUT_MS,
+						);
+					});
 
-				const result = await Promise.race([
-					generateBranchNameMutation.mutateAsync({
-						prompt: trimmedPrompt,
-						projectId,
-					}),
-					timeoutPromise,
-				]);
+					const result = await Promise.race([
+						generateBranchNameMutation.mutateAsync({
+							prompt: trimmedPrompt,
+							projectId,
+						}),
+						timeoutPromise,
+					]);
 
-				// Clear timeout on successful completion
-				if (timeoutId) clearTimeout(timeoutId);
-				aiBranchName = result.branchName;
-			} catch (error) {
-				// Clear timeout on error
-				if (timeoutId) clearTimeout(timeoutId);
+					if (timeoutId) clearTimeout(timeoutId);
+					aiBranchName = result.branchName;
+				} catch (error) {
+					if (timeoutId) clearTimeout(timeoutId);
 
-				// Distinguish error types for better user feedback
-				const errorMessage =
-					error instanceof Error ? error.message : String(error);
-				if (errorMessage.includes("timeout")) {
-					console.warn("[PromptGroup] AI generation timeout");
-					toast.info("Using random branch name (AI generation timed out)");
-				} else if (
-					errorMessage.toLowerCase().includes("auth") ||
-					errorMessage.includes("401") ||
-					errorMessage.includes("403")
-				) {
-					console.error("[PromptGroup] AI auth error:", error);
-					toast.error(
-						"AI authentication failed. Please check your AI settings.",
-					);
-					setPendingWorkspace(null);
-					return; // Don't continue with workspace creation on auth errors
-				} else {
-					console.warn("[PromptGroup] AI generation failed:", error);
-					toast.info("Using random branch name (AI generation unavailable)");
-				}
-				// Continue with workspace creation - backend will use random name
-			} finally {
-				// Always clear global state to prevent stuck "Generating..." in sidebar
-				setIsGeneratingBranchNameGlobal(false);
-				// Only update local state if component is still mounted
-				if (isMountedRef.current) {
-					setIsGeneratingBranchName(false);
+					const errorMessage =
+						error instanceof Error ? error.message : String(error);
+					if (errorMessage.includes("timeout")) {
+						console.warn("[PromptGroup] AI generation timeout");
+						toast.info("Using random branch name (AI generation timed out)");
+					} else if (
+						errorMessage.toLowerCase().includes("auth") ||
+						errorMessage.includes("401") ||
+						errorMessage.includes("403")
+					) {
+						console.error("[PromptGroup] AI auth error:", error);
+						toast.error(
+							"AI authentication failed. Please check your AI settings.",
+						);
+						clearPendingWorkspace(pendingWorkspaceId);
+						return;
+					} else {
+						console.warn("[PromptGroup] AI generation failed:", error);
+						toast.info("Using random branch name (AI generation unavailable)");
+					}
+				} finally {
+					setPendingWorkspaceStatus(pendingWorkspaceId, "preparing");
 				}
 			}
-		}
 
-		let convertedFiles: ConvertedFile[] | undefined;
-		if (attachments.files.length > 0) {
+			let convertedFiles: ConvertedFile[] | undefined;
+			if (detachedFiles.length > 0) {
+				try {
+					convertedFiles = await Promise.all(
+						detachedFiles.map(async (file) => ({
+							data: await convertBlobUrlToDataUrl(file.url),
+							mediaType: file.mediaType,
+							filename: file.filename,
+						})),
+					);
+				} catch (err) {
+					clearPendingWorkspace(pendingWorkspaceId);
+					toast.error(
+						err instanceof Error
+							? err.message
+							: "Failed to process attachments",
+					);
+					return;
+				}
+			}
+
+			let launchRequest: AgentLaunchRequest | null = null;
 			try {
-				convertedFiles = await Promise.all(
-					attachments.files.map(async (file) => ({
-						data: await convertBlobUrlToDataUrl(file.url),
-						mediaType: file.mediaType,
-						filename: file.filename,
-					})),
-				);
-			} catch (err) {
-				setPendingWorkspace(null);
+				launchRequest = buildLaunchRequest(trimmedPrompt, convertedFiles);
+			} catch (error) {
+				clearPendingWorkspace(pendingWorkspaceId);
 				toast.error(
-					err instanceof Error ? err.message : "Failed to process attachments",
+					error instanceof Error
+						? error.message
+						: "Failed to prepare agent launch",
 				);
 				return;
 			}
-		}
 
-		let launchRequest: AgentLaunchRequest | null = null;
-		try {
-			launchRequest = buildLaunchRequest(trimmedPrompt, convertedFiles);
-		} catch (error) {
-			setPendingWorkspace(null);
-			toast.error(
-				error instanceof Error
-					? error.message
-					: "Failed to prepare agent launch",
-			);
-			return;
-		}
+			setPendingWorkspaceStatus(pendingWorkspaceId, "creating");
 
-		if (linkedPR) {
+			if (linkedPR) {
+				void runAsyncAction(
+					createFromPr.mutateAsyncWithSetup(
+						{ projectId, prUrl: linkedPR.url },
+						launchRequest ?? undefined,
+					),
+					{
+						loading: `Creating workspace from PR #${linkedPR.prNumber}...`,
+						success: "Workspace created from PR",
+						error: (err) =>
+							err instanceof Error
+								? err.message
+								: "Failed to create workspace from PR",
+					},
+					{ closeAndReset: false },
+				).finally(() => {
+					clearPendingWorkspace(pendingWorkspaceId);
+				});
+				return;
+			}
+
 			void runAsyncAction(
-				createFromPr.mutateAsyncWithSetup(
-					{ projectId, prUrl: linkedPR.url },
-					launchRequest ?? undefined,
+				createWorkspace.mutateAsyncWithPendingSetup(
+					{
+						projectId,
+						name:
+							workspaceNameEdited && workspaceName.trim()
+								? workspaceName.trim()
+								: undefined,
+						prompt: trimmedPrompt || undefined,
+						branchName:
+							(branchNameEdited && branchName.trim()
+								? sanitizeBranchNameWithMaxLength(
+										branchName.trim(),
+										undefined,
+										{
+											preserveCase: true,
+										},
+									)
+								: aiBranchName) || undefined,
+						baseBranch: baseBranch || undefined,
+					},
+					{
+						agentLaunchRequest: launchRequest ?? undefined,
+						resolveInitialCommands: runSetupScript
+							? (commands) => commands
+							: () => null,
+					},
 				),
 				{
-					loading: `Creating workspace from PR #${linkedPR.prNumber}...`,
-					success: "Workspace created from PR",
+					loading: "Creating workspace...",
+					success: "Workspace created",
 					error: (err) =>
-						err instanceof Error
-							? err.message
-							: "Failed to create workspace from PR",
+						err instanceof Error ? err.message : "Failed to create workspace",
 				},
+				{ closeAndReset: false },
 			).finally(() => {
-				setPendingWorkspace(null);
+				clearPendingWorkspace(pendingWorkspaceId);
 			});
-			return;
+		} finally {
+			for (const file of detachedFiles) {
+				if (file.url?.startsWith("blob:")) {
+					URL.revokeObjectURL(file.url);
+				}
+			}
 		}
-
-		void runAsyncAction(
-			createWorkspace.mutateAsyncWithPendingSetup(
-				{
-					projectId,
-					name:
-						workspaceNameEdited && workspaceName.trim()
-							? workspaceName.trim()
-							: undefined,
-					prompt: trimmedPrompt || undefined,
-					branchName:
-						(branchNameEdited && branchName.trim()
-							? sanitizeBranchNameWithMaxLength(branchName.trim(), undefined, {
-									preserveCase: true,
-								})
-							: aiBranchName) || undefined,
-					baseBranch: baseBranch || undefined,
-				},
-				{
-					agentLaunchRequest: launchRequest ?? undefined,
-					resolveInitialCommands: runSetupScript
-						? (commands) => commands
-						: () => null,
-				},
-			),
-			{
-				loading: isGeneratingBranchName
-					? "Generating branch name..."
-					: "Creating workspace...",
-				success: "Workspace created",
-				error: (err) =>
-					err instanceof Error ? err.message : "Failed to create workspace",
-			},
-		).finally(() => {
-			setPendingWorkspace(null);
-		});
 	}, [
-		attachments.files,
+		attachments,
 		baseBranch,
 		branchName,
 		branchNameEdited,
 		buildLaunchRequest,
+		closeAndResetDraft,
+		clearPendingWorkspace,
 		convertBlobUrlToDataUrl,
 		createFromPr,
 		createWorkspace,
 		generateBranchNameMutation,
-		isGeneratingBranchName,
 		linkedPR,
 		projectId,
 		runAsyncAction,
 		runSetupScript,
 		setPendingWorkspace,
+		setPendingWorkspaceStatus,
 		trimmedPrompt,
 		workspaceName,
 		workspaceNameEdited,
-		setIsGeneratingBranchNameGlobal,
 	]);
 
 	const handlePromptSubmit = useCallback(() => {
@@ -795,9 +799,6 @@ function PromptGroupInner({
 					<Input
 						className={cn(
 							"border-none bg-transparent text-xs font-mono text-muted-foreground/60 px-0 h-auto focus-visible:ring-0 placeholder:text-muted-foreground/30 focus:text-muted-foreground text-right placeholder:text-right overflow-hidden text-ellipsis",
-							isGeneratingBranchName &&
-								!branchNameEdited &&
-								"animate-pulse placeholder:animate-pulse",
 						)}
 						placeholder="branch name"
 						value={branchName}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceDraftContext.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceDraftContext.tsx
@@ -62,6 +62,10 @@ interface DashboardNewWorkspaceActionMessages {
 	error: (err: unknown) => string;
 }
 
+interface DashboardNewWorkspaceActionOptions {
+	closeAndReset?: boolean;
+}
+
 interface DashboardNewWorkspaceDraftContextValue {
 	draft: DashboardNewWorkspaceDraft;
 	draftVersion: number;
@@ -70,10 +74,10 @@ interface DashboardNewWorkspaceDraftContextValue {
 	runAsyncAction: <T>(
 		promise: Promise<T>,
 		messages: DashboardNewWorkspaceActionMessages,
+		options?: DashboardNewWorkspaceActionOptions,
 	) => Promise<T>;
 	updateDraft: (patch: Partial<DashboardNewWorkspaceDraft>) => void;
 	resetDraft: () => void;
-	resetDraftIfVersion: (draftVersion: number) => void;
 }
 
 const DashboardNewWorkspaceDraftContext =
@@ -116,17 +120,6 @@ export function DashboardNewWorkspaceDraftProvider({
 		}));
 	}, []);
 
-	const resetDraftIfVersion = useCallback((draftVersion: number) => {
-		setState((state) =>
-			state.draftVersion !== draftVersion
-				? state
-				: {
-						...initialDraft,
-						draftVersion: state.draftVersion + 1,
-					},
-		);
-	}, []);
-
 	const closeAndResetDraft = useCallback(() => {
 		resetDraft();
 		onClose();
@@ -136,9 +129,12 @@ export function DashboardNewWorkspaceDraftProvider({
 		<T,>(
 			promise: Promise<T>,
 			messages: DashboardNewWorkspaceActionMessages,
+			options?: DashboardNewWorkspaceActionOptions,
 		) => {
-			onClose();
-			resetDraft();
+			if (options?.closeAndReset !== false) {
+				onClose();
+				resetDraft();
+			}
 			toast.promise(promise, {
 				loading: messages.loading,
 				success: messages.success,
@@ -171,13 +167,11 @@ export function DashboardNewWorkspaceDraftProvider({
 			runAsyncAction,
 			updateDraft,
 			resetDraft,
-			resetDraftIfVersion,
 		}),
 		[
 			closeAndResetDraft,
 			onClose,
 			resetDraft,
-			resetDraftIfVersion,
 			runAsyncAction,
 			state,
 			updateDraft,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/PendingWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/PendingWorkspaceItem.tsx
@@ -12,6 +12,13 @@ export function PendingWorkspaceItem({
 
 	if (!pendingWorkspace) return null;
 
+	const statusLabel =
+		pendingWorkspace.status === "generating-branch"
+			? "Generating..."
+			: pendingWorkspace.status === "preparing"
+				? "Preparing..."
+				: "Creating...";
+
 	// Collapsed variant: icon-only with loader
 	if (isCollapsed) {
 		return (
@@ -32,11 +39,7 @@ export function PendingWorkspaceItem({
 			</div>
 			<div className="flex items-center gap-1 text-muted-foreground shrink-0">
 				<Loader2Icon className="size-3 animate-spin" />
-				<span className="text-xs">
-					{pendingWorkspace.isGeneratingBranchName
-						? "Generating..."
-						: "Creating..."}
-				</span>
+				<span className="text-xs">{statusLabel}</span>
 			</div>
 		</div>
 	);

--- a/apps/desktop/src/renderer/stores/new-workspace-modal.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-modal.ts
@@ -2,9 +2,10 @@ import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 
 interface PendingWorkspace {
+	id: string;
 	projectId: string;
 	name: string;
-	isGeneratingBranchName: boolean;
+	status: "preparing" | "generating-branch" | "creating";
 }
 
 interface NewWorkspaceModalState {
@@ -14,7 +15,11 @@ interface NewWorkspaceModalState {
 	openModal: (projectId?: string) => void;
 	closeModal: () => void;
 	setPendingWorkspace: (workspace: PendingWorkspace | null) => void;
-	setIsGeneratingBranchName: (isGenerating: boolean) => void;
+	clearPendingWorkspace: (id: string) => void;
+	setPendingWorkspaceStatus: (
+		id: string,
+		status: PendingWorkspace["status"],
+	) => void;
 }
 
 export const useNewWorkspaceModalStore = create<NewWorkspaceModalState>()(
@@ -36,15 +41,24 @@ export const useNewWorkspaceModalStore = create<NewWorkspaceModalState>()(
 				set({ pendingWorkspace: workspace });
 			},
 
-			setIsGeneratingBranchName: (isGenerating: boolean) => {
+			clearPendingWorkspace: (id) => {
 				set((state) => {
-					if (!state.pendingWorkspace) {
+					if (state.pendingWorkspace?.id !== id) {
+						return {};
+					}
+					return { pendingWorkspace: null };
+				});
+			},
+
+			setPendingWorkspaceStatus: (id, status) => {
+				set((state) => {
+					if (state.pendingWorkspace?.id !== id) {
 						return {};
 					}
 					return {
 						pendingWorkspace: {
 							...state.pendingWorkspace,
-							isGeneratingBranchName: isGenerating,
+							status,
 						},
 					};
 				});
@@ -66,5 +80,7 @@ export const usePendingWorkspace = () =>
 	useNewWorkspaceModalStore((state) => state.pendingWorkspace);
 export const useSetPendingWorkspace = () =>
 	useNewWorkspaceModalStore((state) => state.setPendingWorkspace);
-export const useSetIsGeneratingBranchName = () =>
-	useNewWorkspaceModalStore((state) => state.setIsGeneratingBranchName);
+export const useClearPendingWorkspace = () =>
+	useNewWorkspaceModalStore((state) => state.clearPendingWorkspace);
+export const useSetPendingWorkspaceStatus = () =>
+	useNewWorkspaceModalStore((state) => state.setPendingWorkspaceStatus);

--- a/packages/ui/src/components/ai-elements/prompt-input.tsx
+++ b/packages/ui/src/components/ai-elements/prompt-input.tsx
@@ -78,6 +78,7 @@ export type AttachmentsContext = {
 	files: (FileUIPart & { id: string })[];
 	add: (files: File[] | FileList) => void;
 	setFiles: (files: FileUIPart[]) => void;
+	takeFiles: () => (FileUIPart & { id: string })[];
 	remove: (id: string) => void;
 	clear: () => void;
 	openFileDialog: () => void;
@@ -211,6 +212,16 @@ export function PromptInputProvider({
 		});
 	}, []);
 
+	const takeFiles = useCallback(() => {
+		const takenFiles = attachmentsRef.current;
+		attachmentsRef.current = [];
+		setAttachmentFiles([]);
+		if (fileInputRef.current) {
+			fileInputRef.current.value = "";
+		}
+		return takenFiles;
+	}, []);
+
 	// Keep a ref to attachments for cleanup on unmount (avoids stale closure)
 	const attachmentsRef = useRef(attachmentFiles);
 	attachmentsRef.current = attachmentFiles;
@@ -235,12 +246,13 @@ export function PromptInputProvider({
 			files: attachmentFiles,
 			add,
 			setFiles,
+			takeFiles,
 			remove,
 			clear,
 			openFileDialog,
 			fileInputRef,
 		}),
-		[attachmentFiles, add, setFiles, remove, clear, openFileDialog],
+		[attachmentFiles, add, setFiles, takeFiles, remove, clear, openFileDialog],
 	);
 
 	const __registerFileInput = useCallback(
@@ -630,10 +642,23 @@ export const PromptInput = ({
 		});
 	}, []);
 
+	const takeFilesLocal = useCallback(() => {
+		const takenFiles = filesRef.current;
+		filesRef.current = [];
+		setItems([]);
+		if (inputRef.current) {
+			inputRef.current.value = "";
+		}
+		return takenFiles;
+	}, []);
+
 	const add = usingProvider ? controller.attachments.add : addLocal;
 	const setFiles = usingProvider
 		? controller.attachments.setFiles
 		: setLocalFiles;
+	const takeFiles = usingProvider
+		? controller.attachments.takeFiles
+		: takeFilesLocal;
 	const remove = usingProvider ? controller.attachments.remove : removeLocal;
 	const clear = usingProvider ? controller.attachments.clear : clearLocal;
 	const openFileDialog = usingProvider
@@ -747,12 +772,13 @@ export const PromptInput = ({
 			files: files.map((item) => ({ ...item, id: item.id })),
 			add,
 			setFiles,
+			takeFiles,
 			remove,
 			clear,
 			openFileDialog,
 			fileInputRef: inputRef,
 		}),
-		[files, add, setFiles, remove, clear, openFileDialog],
+		[files, add, setFiles, takeFiles, remove, clear, openFileDialog],
 	);
 
 	const handleSubmit: FormEventHandler<HTMLFormElement> = (event) => {


### PR DESCRIPTION
# What does this PR do? (required)

When submitting the New Workspace dialog, the form would show stale prompt/branch values if re-opened before the workspace finished configuring. The shared mutation's `isPending` also kept the submit button disabled across re-opens. This PR resets the draft state synchronously on submit (instead of waiting for the async workspace creation to resolve), so the form is immediately clean and re-usable while prior workspace(s) are still being configured in the background.

# Link to Basecamp to-do, Trello card, New Relic or Honeybadger (required)

N/A

# QA
## What platforms should be included in QA?
- [ ] Desktop web
- [ ] Mobile web
- [ ] iOS
- [ ] Android
- [ ] API
- [x] N/A

## QA steps

1. Open the New Workspace dialog with a repo pre-selected and "Claude" as the entrypoint
2. Type a prompt and click submit
3. Immediately re-open the New Workspace dialog
4. Verify the prompt and branch name fields are empty (not showing the previous submission's values)
5. Verify the submit button is enabled and not showing a spinner
6. Type a second prompt and submit — confirm both workspaces are created and each opens a terminal tab with its respective Claude prompt

## Screenshots (if appropriate)

N/A

# Docs
Update changelog after deployment if the changes in Admin are valuable for Sales, Support or Success teams.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Instantly close and clear the New Workspace modal on submit to prevent stale prompt/branch values and keep the submit button usable on reopen. You can start a second workspace while the first configures; the sidebar now shows clearer status.

- **Bug Fixes**
  - Close and reset draft immediately on submit in both modal providers (not after the async create finishes).
  - Keep the submit button ready between opens by removing shared `isPending` disable and spinner.
  - Detach and clear prompt attachments on submit; track pending workspace by id with status (`generating-branch`, `preparing`, `creating`) for accurate sidebar labels.
  - Resolve initial commands only when `runSetupScript` is enabled to avoid stale refs.

<sup>Written for commit 9ba9ad7bbf5f4ad4d9f8a368129b82636339b27c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Drafts now close and reset immediately when the workspace modal is submitted/closed (optionally prevented), removing version-based deferred resets.
  * Internal pending-workspace state simplified to a status-based flow for clearer lifecycle handling.

* **UI Changes**
  * Submit button remains enabled and no longer shows a spinner during submission.
  * Pending workspace items show clear status labels: "Generating...", "Preparing...", or "Creating...".
  * Attachments are atomically captured at submit time to prevent lost or duplicated files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->