### PR TITLE
fix(desktop): symlink as a file

### DIFF
--- a/packages/workspace-fs/src/fs.ts
+++ b/packages/workspace-fs/src/fs.ts
@@ -378,20 +378,35 @@ export async function listDirectory({
 	const targetPath = ensureWithinRoot({ rootPath, absolutePath });
 	const entries = await fs.readdir(targetPath, { withFileTypes: true });
 
-	return entries
-		.map((entry) => ({
-			absolutePath: path.join(targetPath, entry.name),
-			name: entry.name,
-			kind: direntToKind(entry),
-		}))
-		.sort((left, right) => {
-			const leftIsDir = left.kind === "directory";
-			const rightIsDir = right.kind === "directory";
-			if (leftIsDir !== rightIsDir) {
-				return leftIsDir ? -1 : 1;
+	const mapped = await Promise.all(
+		entries.map(async (entry) => {
+			let kind = direntToKind(entry);
+			// Resolve symlinks to determine target type (e.g. symlinked dirs in node_modules)
+			if (kind === "symlink") {
+				try {
+					const stats = await fs.stat(path.join(targetPath, entry.name));
+					if (stats.isDirectory()) kind = "directory";
+					else if (stats.isFile()) kind = "file";
+				} catch {
+					// Dangling symlink or permission error — keep as "symlink"
+				}
 			}
-			return left.name.localeCompare(right.name);
-		});
+			return {
+				absolutePath: path.join(targetPath, entry.name),
+				name: entry.name,
+				kind,
+			};
+		}),
+	);
+
+	return mapped.sort((left, right) => {
+		const leftIsDir = left.kind === "directory";
+		const rightIsDir = right.kind === "directory";
+		if (leftIsDir !== rightIsDir) {
+			return leftIsDir ? -1 : 1;
+		}
+		return left.name.localeCompare(right.name);
+	});
 }
 
 export async function readFile({


### PR DESCRIPTION
## Description

I made fix for a symlink folders, specially in node_modules. Previously they showed as files, but now as a folders

## Related Issues

Probably No

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

- recheck folders in node_modules

## Screenshots (if applicable)
<img width="262" height="1041" alt="Screenshot 2026-03-20 at 12 50 54" src="https://github.com/user-attachments/assets/ead0f91a-f1e8-43de-a182-e197bbf29a3c" />
<img width="213" height="848" alt="Screenshot 2026-03-20 at 12 51 04" src="https://github.com/user-attachments/assets/d3dc29e9-c494-4505-a637-98f1e72a888a" />



## Additional Notes

<!-- Add any other context about the PR here -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes directory listing to resolve symlink targets so symlinked folders (e.g., in `node_modules`) show as directories instead of files. Improves accuracy of the desktop file tree.

- **Bug Fixes**
  - Resolve symlinks in `packages/workspace-fs` `listDirectory` via `fs.stat` to detect directory vs file.
  - Keep kind as "symlink" if target cannot be resolved (dangling/permission).
  - Preserve sort: directories first, then name.

<sup>Written for commit 81fa265eccc1935e3772cd52c5b1aa0a5f30d908. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Directory listings now resolve symlinks to accurately display their target type (file or directory)
  * Improved error handling for inaccessible or broken symlinks
  * Enhanced directory listing sort order consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->