### PR TITLE
fix(desktop): harden workspace run recovery

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/useWorkspaceRunCommand.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/useWorkspaceRunCommand.ts
@@ -59,24 +59,24 @@ export function useWorkspaceRunCommand({
 			return;
 		}
 
-		// START: always fetch the latest config so run-script detection never
-		// depends on stale cache state or on a query still loading in the view.
-		const runConfig =
-			await electronTrpcClient.workspaces.getResolvedRunCommands.query({
-				workspaceId,
-			});
-		const command = buildTerminalCommand(runConfig.commands);
-		if (!command) {
-			toast.error("No workspace run command configured", {
-				description:
-					"Add a run script in Project Settings to use the workspace run shortcut.",
-			});
-			return;
-		}
-
 		isStartingRef.current = true;
 		setIsPending(true);
 		try {
+			// START: always fetch the latest config so run-script detection never
+			// depends on stale cache state or on a query still loading in the view.
+			const runConfig =
+				await electronTrpcClient.workspaces.getResolvedRunCommands.query({
+					workspaceId,
+				});
+			const command = buildTerminalCommand(runConfig.commands);
+			if (!command) {
+				toast.error("No workspace run command configured", {
+					description:
+						"Add a run script in Project Settings to use the workspace run shortcut.",
+				});
+				return;
+			}
+
 			const initialCwd = worktreePath?.trim() ? worktreePath : undefined;
 
 			// Reuse existing run pane if available
@@ -143,6 +143,10 @@ export function useWorkspaceRunCommand({
 			setPaneWorkspaceRun(paneId, { workspaceId, state: "running" });
 			setActiveTab(workspaceId, tabId);
 			setFocusedPane(tabId, paneId);
+		} catch (error) {
+			toast.error("Failed to resolve workspace run command", {
+				description: error instanceof Error ? error.message : "Unknown error",
+			});
 		} finally {
 			isStartingRef.current = false;
 			setIsPending(false);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
@@ -515,7 +515,11 @@ export function useTerminalLifecycle({
 							},
 							onError: (error) => {
 								if (!isAttachActive()) return;
+								const workspaceRun = getPaneWorkspaceRun(paneId);
 								if (error.message?.includes("TERMINAL_SESSION_KILLED")) {
+									if (workspaceRun) {
+										setPaneWorkspaceRunState(paneId, "stopped-by-user");
+									}
 									wasKilledByUserRef.current = true;
 									isExitedRef.current = true;
 									isStreamReadyRef.current = false;
@@ -524,6 +528,9 @@ export function useTerminalLifecycle({
 									return;
 								}
 								console.error("[Terminal] Failed to create/attach:", error);
+								if (workspaceRun) {
+									setPaneWorkspaceRunState(paneId, "stopped-by-exit");
+								}
 								setConnectionError(
 									error.message || "Failed to connect to terminal",
 								);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/workspaceRun.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/workspaceRun.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const mockGetSessionQuery = mock();
+
+const storeState = {
+	panes: {} as Record<
+		string,
+		{
+			workspaceRun?: {
+				workspaceId: string;
+				state: "running" | "stopped-by-user" | "stopped-by-exit";
+			};
+		}
+	>,
+	setPaneWorkspaceRun: mock(
+		(
+			paneId: string,
+			workspaceRun: {
+				workspaceId: string;
+				state: "running" | "stopped-by-user" | "stopped-by-exit";
+			} | null,
+		) => {
+			if (!storeState.panes[paneId]) {
+				storeState.panes[paneId] = {};
+			}
+			storeState.panes[paneId].workspaceRun = workspaceRun ?? undefined;
+		},
+	),
+};
+
+mock.module("renderer/lib/trpc-client", () => ({
+	electronTrpcClient: {
+		terminal: {
+			getSession: {
+				query: mockGetSessionQuery,
+			},
+		},
+	},
+}));
+
+mock.module("renderer/stores/tabs/store", () => ({
+	useTabsStore: {
+		getState: () => storeState,
+	},
+}));
+
+const { recoverWorkspaceRunPane } = await import("./workspaceRun");
+
+describe("recoverWorkspaceRunPane", () => {
+	beforeEach(() => {
+		mockGetSessionQuery.mockReset();
+		storeState.panes = {};
+		storeState.setPaneWorkspaceRun.mockClear();
+	});
+
+	it("does not query session state for panes already stopped by user", async () => {
+		storeState.panes["pane-1"] = {
+			workspaceRun: {
+				workspaceId: "ws-1",
+				state: "stopped-by-user",
+			},
+		};
+
+		const xterm = { writeln: mock(() => {}) };
+		const done = mock(() => {});
+		const startAttach = mock(() => {});
+		const setExitStatus = mock(() => {});
+		const isExitedRef = { current: false };
+		const wasKilledByUserRef = { current: false };
+		const isStreamReadyRef = { current: false };
+		const workspaceRun = storeState.panes["pane-1"]?.workspaceRun;
+		if (!workspaceRun) {
+			throw new Error("Expected pane-1 workspaceRun to exist");
+		}
+
+		const handled = await recoverWorkspaceRunPane({
+			paneId: "pane-1",
+			workspaceRun,
+			isNewWorkspaceRun: false,
+			xterm,
+			shouldAbort: () => false,
+			startAttach,
+			done,
+			isExitedRef,
+			wasKilledByUserRef,
+			isStreamReadyRef,
+			setExitStatus,
+		});
+
+		expect(handled).toBe(true);
+		expect(mockGetSessionQuery).not.toHaveBeenCalled();
+		expect(startAttach).not.toHaveBeenCalled();
+		expect(isExitedRef.current).toBe(true);
+		expect(wasKilledByUserRef.current).toBe(true);
+		expect(isStreamReadyRef.current).toBe(true);
+		expect(setExitStatus).toHaveBeenCalledWith("killed");
+		expect(xterm.writeln).toHaveBeenCalledWith("\r\n[Session killed]");
+		expect(xterm.writeln).toHaveBeenCalledWith("[Press any key to restart]");
+		expect(done).toHaveBeenCalled();
+	});
+
+	it("falls back to attach when session inspection fails for running panes", async () => {
+		storeState.panes["pane-2"] = {
+			workspaceRun: {
+				workspaceId: "ws-2",
+				state: "running",
+			},
+		};
+		mockGetSessionQuery.mockRejectedValueOnce(new Error("transport down"));
+
+		const xterm = { writeln: mock(() => {}) };
+		const done = mock(() => {});
+		const startAttach = mock(() => {});
+		const setExitStatus = mock(() => {});
+		const isExitedRef = { current: false };
+		const wasKilledByUserRef = { current: false };
+		const isStreamReadyRef = { current: false };
+		const workspaceRun = storeState.panes["pane-2"]?.workspaceRun;
+		if (!workspaceRun) {
+			throw new Error("Expected pane-2 workspaceRun to exist");
+		}
+
+		const handled = await recoverWorkspaceRunPane({
+			paneId: "pane-2",
+			workspaceRun,
+			isNewWorkspaceRun: false,
+			xterm,
+			shouldAbort: () => false,
+			startAttach,
+			done,
+			isExitedRef,
+			wasKilledByUserRef,
+			isStreamReadyRef,
+			setExitStatus,
+		});
+
+		expect(handled).toBe(true);
+		expect(startAttach).toHaveBeenCalled();
+		expect(xterm.writeln).not.toHaveBeenCalled();
+		expect(done).not.toHaveBeenCalled();
+		expect(setExitStatus).not.toHaveBeenCalled();
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/workspaceRun.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/workspaceRun.ts
@@ -79,6 +79,25 @@ export async function recoverWorkspaceRunPane({
 		return false;
 	}
 
+	const showExitedState = (state: WorkspaceRunState): boolean => {
+		const wasStoppedByUser = state === "stopped-by-user";
+		setPaneWorkspaceRunState(paneId, state);
+		isExitedRef.current = true;
+		wasKilledByUserRef.current = wasStoppedByUser;
+		isStreamReadyRef.current = true;
+		setExitStatus(wasStoppedByUser ? "killed" : "exited");
+		xterm.writeln(
+			wasStoppedByUser ? "\r\n[Session killed]" : "\r\n[Process exited]",
+		);
+		xterm.writeln("[Press any key to restart]");
+		done();
+		return true;
+	};
+
+	if (workspaceRun.state !== "running") {
+		return showExitedState(workspaceRun.state);
+	}
+
 	try {
 		const existingSession =
 			await electronTrpcClient.terminal.getSession.query(paneId);
@@ -90,32 +109,15 @@ export async function recoverWorkspaceRunPane({
 			return true;
 		}
 
-		const wasStoppedByUser = workspaceRun.state === "stopped-by-user";
-		const resolvedState =
-			workspaceRun.state === "running" ? "stopped-by-exit" : workspaceRun.state;
-
-		setPaneWorkspaceRunState(paneId, resolvedState);
-		isExitedRef.current = true;
-		wasKilledByUserRef.current = wasStoppedByUser;
-		isStreamReadyRef.current = true;
-		setExitStatus(wasStoppedByUser ? "killed" : "exited");
-		xterm.writeln(
-			wasStoppedByUser ? "\r\n[Session killed]" : "\r\n[Process exited]",
-		);
-		xterm.writeln("[Press any key to restart]");
-		done();
-		return true;
-	} catch {
+		return showExitedState("stopped-by-exit");
+	} catch (error) {
 		if (shouldAbort()) return true;
 
-		setPaneWorkspaceRunState(paneId, "stopped-by-exit");
-		isExitedRef.current = true;
-		wasKilledByUserRef.current = false;
-		isStreamReadyRef.current = true;
-		setExitStatus("exited");
-		xterm.writeln("\r\n[Process exited]");
-		xterm.writeln("[Press any key to restart]");
-		done();
+		console.warn(
+			`[workspace-run] Failed to inspect session for pane ${paneId}:`,
+			error,
+		);
+		startAttach();
 		return true;
 	}
 }


### PR DESCRIPTION
## Summary
- catch workspace run command lookup failures before start and surface a toast instead of leaking a rejected promise
- roll back optimistic workspace-run state when the initial terminal attach fails
- avoid querying session state for already-stopped panes and fall back to attach if session inspection fails for a running pane

## Testing
- bun test apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/workspaceRun.test.ts apps/desktop/src/main/terminal-host/session.test.ts apps/desktop/src/renderer/lib/terminal/launch-command.test.ts apps/desktop/src/lib/trpc/routers/workspaces/utils/setup.test.ts
- bunx biome check apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/useWorkspaceRunCommand.ts apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/workspaceRun.ts apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/workspaceRun.test.ts
- bunx tsc -p apps/desktop/tsconfig.json --noEmit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens workspace run recovery in the Desktop app. Shows clear errors, prevents stale state, and makes pane recovery resilient when sessions are stopped or unreachable.

- **Bug Fixes**
  - Show a toast and stop startup when resolving the workspace run command fails (no leaked promise).
  - Roll back optimistic workspace-run state on initial attach errors; mark as stopped-by-user or stopped-by-exit.
  - Improve recovery: skip session checks for panes already stopped; if session inspection fails for a running pane, fall back to attach. Added tests for these paths.

<sup>Written for commit fc79158daf2338e12a97c547ecfac3d2e744c8e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for workspace run command resolution with user-facing error messages.
  * Enhanced terminal session error handling with proper state transitions during connection failures.
  * Fixed workspace run state consistency during terminal recovery scenarios.

* **Tests**
  * Added comprehensive test coverage for terminal session recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->