### PR TITLE
fix(desktop): preserve cursor position when saving a file

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
@@ -607,7 +607,6 @@ export function FileViewerPane({
 							diffData={diffData}
 							editorRef={editorRef}
 							markdownEditorRef={markdownEditorRef}
-							draftContentRef={draftContentRef}
 							renderedContent={renderedContent}
 							initialLine={initialLine}
 							initialColumn={initialColumn}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/components/FileViewerContent/FileViewerContent.tsx
@@ -111,7 +111,6 @@ interface FileViewerContentProps {
 	diffData: DiffData | undefined;
 	editorRef: MutableRefObject<CodeEditorAdapter | null>;
 	markdownEditorRef: MutableRefObject<MarkdownEditorAdapter | null>;
-	draftContentRef: MutableRefObject<string | null>;
 	renderedContent: string;
 	initialLine?: number;
 	initialColumn?: number;
@@ -147,7 +146,6 @@ export function FileViewerContent({
 	diffData,
 	editorRef,
 	markdownEditorRef,
-	draftContentRef,
 	renderedContent,
 	initialLine,
 	initialColumn,


### PR DESCRIPTION
## Summary
- Fix cursor jumping to top of file when saving in the code editor.

## Why / Context
When saving a file, `useFileSave` clears `draftContentRef.current = null` and triggers a re-render via `setIsDirty(false)` **before** the `readFile` query refetch completes. The CodeEditor's `value` prop was `draftContentRef.current ?? rawFileData.content`, which fell back to the stale pre-edit `rawFileData.content`. This caused CodeMirror to replace the entire document with the old content (resetting cursor to position 0), then flip back when the refetch completed — a visible flash and lost cursor position.

## How It Works
Changed the CodeEditor `value` prop from `draftContentRef.current ?? rawFileData.content` to `renderedContent`. The `renderedContent` prop (already computed in `FileViewerPane` and passed down) falls back to `originalContentRef.current`, which is updated **synchronously** during save — so the editor always receives the correct content with no stale window. This is the same value source already used by the markdown renderer.

## Manual QA Checklist

### File Saving
- [ ] Open a file, edit it, save with Cmd+S — cursor stays in place
- [ ] Open a file, scroll down, edit in the middle, save — scroll position preserved
- [ ] Open a file, make multiple edits across the file, save — no flash/flicker

### Edge Cases
- [ ] Save a file with no changes (Cmd+S on clean file) — no cursor jump
- [ ] Edit and save rapidly — no race condition or content flash
- [ ] External file change while editor is clean — content updates correctly
- [ ] External file change while editor is dirty — conflict alert still works

## Testing
- `bun run typecheck` — passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves cursor and scroll when saving in the desktop code editor. Uses rendered content to avoid flicker during save.

- **Bug Fixes**
  - Set `CodeEditor.value` to `renderedContent` instead of `draftContentRef.current ?? rawFileData.content` to avoid a stale-content swap during `readFile` refetch; removed unused `draftContentRef` prop.

<sup>Written for commit f222da595c5ad99de8b3aa5178faaf7b4c1aaff9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File viewer now consistently displays the correct (rendered) file content in the editor, preventing stale draft values from appearing during view/edit sessions.
  * Editing, save, and reload flows continue to work reliably with the updated content selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->