### PR TITLE
Fix workspace run startup race by aligning with presets

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/useWorkspaceRunCommand.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/useWorkspaceRunCommand.ts
@@ -4,6 +4,10 @@ import { buildTerminalCommand } from "renderer/lib/terminal/launch-command";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import { useTerminalCallbacksStore } from "renderer/stores/tabs/terminal-callbacks";
+import {
+	createWorkspaceRun,
+	setPaneWorkspaceRunState,
+} from "renderer/stores/tabs/workspace-run";
 
 interface UseWorkspaceRunCommandOptions {
 	workspaceId: string;
@@ -45,10 +49,7 @@ export function useWorkspaceRunCommand({
 			setIsPending(true);
 			try {
 				await electronTrpcClient.terminal.kill.mutate({ paneId: runPane.id });
-				setPaneWorkspaceRun(runPane.id, {
-					workspaceId,
-					state: "stopped-by-user",
-				});
+				setPaneWorkspaceRunState(runPane.id, "stopped-by-user");
 			} catch (error) {
 				toast.error("Failed to stop workspace run command", {
 					description: error instanceof Error ? error.message : "Unknown error",
@@ -88,10 +89,14 @@ export function useWorkspaceRunCommand({
 					setFocusedPane(tab.id, runPane.id);
 				}
 
-				setPaneWorkspaceRun(runPane.id, {
-					workspaceId,
-					state: "running",
-				});
+				setPaneWorkspaceRun(
+					runPane.id,
+					createWorkspaceRun({
+						workspaceId,
+						state: "running",
+						command,
+					}),
+				);
 
 				try {
 					const restartCallback = getRestartCallback(runPane.id);
@@ -115,16 +120,17 @@ export function useWorkspaceRunCommand({
 						});
 						// Re-assert running state — the kill above may have triggered
 						// the exit listener which flipped state to stopped-by-user.
-						setPaneWorkspaceRun(runPane.id, {
-							workspaceId,
-							state: "running",
-						});
+						setPaneWorkspaceRun(
+							runPane.id,
+							createWorkspaceRun({
+								workspaceId,
+								state: "running",
+								command,
+							}),
+						);
 					}
 				} catch (error) {
-					setPaneWorkspaceRun(runPane.id, {
-						workspaceId,
-						state: "stopped-by-exit",
-					});
+					setPaneWorkspaceRunState(runPane.id, "stopped-by-exit");
 					toast.error("Failed to run workspace command", {
 						description:
 							error instanceof Error ? error.message : "Unknown error",
@@ -133,14 +139,21 @@ export function useWorkspaceRunCommand({
 				return;
 			}
 
-			// Create new pane — command is not passed here; instead the terminal
-			// lifecycle detects pane.workspaceRun.state === "running" on mount and
-			// reads the command from defaultRestartCommandRef (resolved via tRPC query).
+			// Create new pane and persist the resolved command on the pane metadata
+			// before mount. Terminal lifecycle then sees the same click-time command
+			// snapshot that presets use, instead of waiting on a follow-up query.
 			const result = addTab(workspaceId, { initialCwd });
 			const { tabId, paneId } = result;
 
 			setPaneName(paneId, "Workspace Run");
-			setPaneWorkspaceRun(paneId, { workspaceId, state: "running" });
+			setPaneWorkspaceRun(
+				paneId,
+				createWorkspaceRun({
+					workspaceId,
+					state: "running",
+					command,
+				}),
+			);
 			setActiveTab(workspaceId, tabId);
 			setFocusedPane(tabId, paneId);
 		} catch (error) {

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -28,6 +28,7 @@ import { useHotkeysSync } from "renderer/stores/hotkeys";
 import { useSettingsStore } from "renderer/stores/settings-state";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import { useAgentHookListener } from "renderer/stores/tabs/useAgentHookListener";
+import { setPaneWorkspaceRunState } from "renderer/stores/tabs/workspace-run";
 import { useWorkspaceInitStore } from "renderer/stores/workspace-init";
 import { MOCK_ORG_ID, NOTIFICATION_EVENTS } from "shared/constants";
 import { AgentHooks } from "./components/AgentHooks";
@@ -80,10 +81,7 @@ function AuthenticatedLayout() {
 					event.data.reason === "killed"
 						? "stopped-by-user"
 						: "stopped-by-exit";
-				useTabsStore.getState().setPaneWorkspaceRun(event.data.paneId, {
-					workspaceId: pane.workspaceRun.workspaceId,
-					state: nextState,
-				});
+				setPaneWorkspaceRunState(event.data.paneId, nextState);
 			}
 		},
 	});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -58,9 +58,11 @@ export const Terminal = ({ paneId, tabId, workspaceId }: TerminalProps) => {
 		);
 
 	const defaultRestartCommandRef = useRef<string | undefined>(undefined);
-	defaultRestartCommandRef.current = isWorkspaceRunPane
-		? (buildTerminalCommand(workspaceRunConfig?.commands) ?? undefined)
-		: undefined;
+	defaultRestartCommandRef.current =
+		pane?.workspaceRun?.command ??
+		(isWorkspaceRunPane
+			? (buildTerminalCommand(workspaceRunConfig?.commands) ?? undefined)
+			: undefined);
 
 	const utils = electronTrpc.useUtils();
 	const updateWorkspace = electronTrpc.workspaces.update.useMutation({

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalStream.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalStream.ts
@@ -2,6 +2,7 @@ import { toast } from "@superset/ui/sonner";
 import type { Terminal as XTerm } from "@xterm/xterm";
 import { useCallback, useRef } from "react";
 import { useTabsStore } from "renderer/stores/tabs/store";
+import { setPaneWorkspaceRunState } from "renderer/stores/tabs/workspace-run";
 import { DEBUG_TERMINAL } from "../config";
 import type { TerminalExitReason, TerminalStreamEvent } from "../types";
 
@@ -68,10 +69,7 @@ export function useTerminalStream({
 				const nextState = wasKilledByUser
 					? "stopped-by-user"
 					: "stopped-by-exit";
-				useTabsStore.getState().setPaneWorkspaceRun(paneId, {
-					workspaceId: currentPaneForRun.workspaceRun.workspaceId,
-					state: nextState,
-				});
+				setPaneWorkspaceRunState(paneId, nextState);
 			}
 
 			if (wasKilledByUser) {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/workspaceRun.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/workspaceRun.test.ts
@@ -9,6 +9,7 @@ const storeState = {
 			workspaceRun?: {
 				workspaceId: string;
 				state: "running" | "stopped-by-user" | "stopped-by-exit";
+				command?: string;
 			};
 		}
 	>,
@@ -18,6 +19,7 @@ const storeState = {
 			workspaceRun: {
 				workspaceId: string;
 				state: "running" | "stopped-by-user" | "stopped-by-exit";
+				command?: string;
 			} | null,
 		) => {
 			if (!storeState.panes[paneId]) {
@@ -44,7 +46,9 @@ mock.module("renderer/stores/tabs/store", () => ({
 	},
 }));
 
-const { recoverWorkspaceRunPane } = await import("./workspaceRun");
+const { recoverWorkspaceRunPane, setPaneWorkspaceRunState } = await import(
+	"./workspaceRun"
+);
 
 describe("recoverWorkspaceRunPane", () => {
 	beforeEach(() => {
@@ -139,5 +143,31 @@ describe("recoverWorkspaceRunPane", () => {
 		expect(xterm.writeln).not.toHaveBeenCalled();
 		expect(done).not.toHaveBeenCalled();
 		expect(setExitStatus).not.toHaveBeenCalled();
+	});
+
+	it("preserves the stored run command when updating workspace-run state", () => {
+		storeState.panes["pane-3"] = {
+			workspaceRun: {
+				workspaceId: "ws-3",
+				state: "running",
+				command: "bun run dev",
+			},
+		};
+
+		const updatedWorkspaceRun = setPaneWorkspaceRunState(
+			"pane-3",
+			"stopped-by-exit",
+		);
+
+		expect(updatedWorkspaceRun).toEqual({
+			workspaceId: "ws-3",
+			state: "stopped-by-exit",
+			command: "bun run dev",
+		});
+		expect(storeState.setPaneWorkspaceRun).toHaveBeenCalledWith("pane-3", {
+			workspaceId: "ws-3",
+			state: "stopped-by-exit",
+			command: "bun run dev",
+		});
 	});
 });

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/workspaceRun.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/workspaceRun.ts
@@ -1,11 +1,11 @@
 import type { MutableRefObject } from "react";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
-import { useTabsStore } from "renderer/stores/tabs/store";
-import type { Pane } from "shared/tabs-types";
-
-type PaneWorkspaceRun = NonNullable<Pane["workspaceRun"]>;
-
-type WorkspaceRunState = PaneWorkspaceRun["state"];
+import {
+	getPaneWorkspaceRun,
+	type PaneWorkspaceRun,
+	setPaneWorkspaceRunState,
+	type WorkspaceRunState,
+} from "renderer/stores/tabs/workspace-run";
 
 interface RecoverWorkspaceRunPaneOptions {
 	paneId: string;
@@ -21,31 +21,11 @@ interface RecoverWorkspaceRunPaneOptions {
 	setExitStatus: (status: "killed" | "exited" | null) => void;
 }
 
-export function getPaneWorkspaceRun(paneId: string): PaneWorkspaceRun | null {
-	return useTabsStore.getState().panes[paneId]?.workspaceRun ?? null;
-}
-
-export function hasPaneWorkspaceRun(paneId: string): boolean {
-	return Boolean(getPaneWorkspaceRun(paneId));
-}
-
-export function setPaneWorkspaceRunState(
-	paneId: string,
-	state: WorkspaceRunState,
-): PaneWorkspaceRun | null {
-	const workspaceRun = getPaneWorkspaceRun(paneId);
-	if (!workspaceRun) return null;
-
-	useTabsStore.getState().setPaneWorkspaceRun(paneId, {
-		workspaceId: workspaceRun.workspaceId,
-		state,
-	});
-
-	return {
-		workspaceId: workspaceRun.workspaceId,
-		state,
-	};
-}
+export {
+	getPaneWorkspaceRun,
+	hasPaneWorkspaceRun,
+	setPaneWorkspaceRunState,
+} from "renderer/stores/tabs/workspace-run";
 
 export function resolveWorkspaceRunAttachMode(
 	paneId: string,

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -1083,12 +1083,18 @@ export const useTabsStore = create<TabsStore>()(
 					set((state) => {
 						const pane = state.panes[paneId];
 						if (!pane) return state;
+						const nextWorkspaceRun = workspaceRun
+							? {
+									...pane.workspaceRun,
+									...workspaceRun,
+								}
+							: undefined;
 						return {
 							panes: {
 								...state.panes,
 								[paneId]: {
 									...pane,
-									workspaceRun: workspaceRun ?? undefined,
+									workspaceRun: nextWorkspaceRun,
 								},
 							},
 						};

--- a/apps/desktop/src/renderer/stores/tabs/types.ts
+++ b/apps/desktop/src/renderer/stores/tabs/types.ts
@@ -139,6 +139,7 @@ export interface TabsStore extends TabsState {
 		workspaceRun: {
 			workspaceId: string;
 			state: "running" | "stopped-by-user" | "stopped-by-exit";
+			command?: string;
 		} | null,
 	) => void;
 	setPaneAutoTitle: (paneId: string, title: string) => void;

--- a/apps/desktop/src/renderer/stores/tabs/workspace-run.ts
+++ b/apps/desktop/src/renderer/stores/tabs/workspace-run.ts
@@ -1,0 +1,46 @@
+import type { Pane } from "shared/tabs-types";
+import { useTabsStore } from "./store";
+
+export type PaneWorkspaceRun = NonNullable<Pane["workspaceRun"]>;
+export type WorkspaceRunState = PaneWorkspaceRun["state"];
+
+export function createWorkspaceRun({
+	workspaceId,
+	state,
+	command,
+}: {
+	workspaceId: string;
+	state: WorkspaceRunState;
+	command?: string;
+}): PaneWorkspaceRun {
+	return {
+		workspaceId,
+		state,
+		...(command ? { command } : {}),
+	};
+}
+
+export function getPaneWorkspaceRun(paneId: string): PaneWorkspaceRun | null {
+	return useTabsStore.getState().panes[paneId]?.workspaceRun ?? null;
+}
+
+export function hasPaneWorkspaceRun(paneId: string): boolean {
+	return Boolean(getPaneWorkspaceRun(paneId));
+}
+
+export function setPaneWorkspaceRunState(
+	paneId: string,
+	state: WorkspaceRunState,
+): PaneWorkspaceRun | null {
+	const workspaceRun = getPaneWorkspaceRun(paneId);
+	if (!workspaceRun) return null;
+
+	const nextWorkspaceRun = createWorkspaceRun({
+		workspaceId: workspaceRun.workspaceId,
+		state,
+		command: workspaceRun.command,
+	});
+
+	useTabsStore.getState().setPaneWorkspaceRun(paneId, nextWorkspaceRun);
+	return nextWorkspaceRun;
+}

--- a/apps/desktop/src/shared/tabs-types.ts
+++ b/apps/desktop/src/shared/tabs-types.ts
@@ -145,6 +145,7 @@ export interface Pane {
 	workspaceRun?: {
 		workspaceId: string;
 		state: "running" | "stopped-by-user" | "stopped-by-exit";
+		command?: string;
 	};
 }
 


### PR DESCRIPTION
## Summary
- align workspace run startup with preset launches by snapshotting the resolved run command onto pane metadata before terminal mount
- prefer the stored workspace run command during terminal attach and restart so the first launch no longer races a follow-up query
- extract shared workspace-run helpers so start, stop, recovery, and exit paths reuse the same state-shaping logic

## Testing
- bun test apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/workspaceRun.test.ts
- bun run --cwd apps/desktop typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the workspace run startup race by snapshotting the resolved run command onto pane metadata before the terminal mounts. Aligns workspace-run start/attach/restart flows with presets so the first launch and restarts no longer wait on a follow-up query.

- **Bug Fixes**
  - Snapshot the resolved command to pane.workspaceRun.command on pane creation; terminal attach/restart reuses it.
  - Update exit/kill via a shared helper that switches state and preserves the stored command.
  - Prevent flicker/race by preferring the stored command over a follow-up query.

- **Refactors**
  - Added `renderer/stores/tabs/workspace-run` with `createWorkspaceRun`, `getPaneWorkspaceRun`, and `setPaneWorkspaceRunState`.
  - Tabs store now merges `workspaceRun` updates to avoid dropping `command`.
  - Extended tests to assert the command is preserved across state changes.

<sup>Written for commit 91f8b27448c2a4494aa00459ad6e66d8670dd6db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced terminal restart to preserve the original command used.

* **Refactor**
  * Improved internal workspace state management and command persistence infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->