### PR TITLE
chore: add run command to .superset/config.json

### DIFF
--- a/.superset/config.json
+++ b/.superset/config.json
@@ -1,4 +1,11 @@
 {
-	"setup": ["./.superset/setup.sh"],
-	"teardown": ["./.superset/teardown.sh"]
+  "setup": [
+    "./.superset/setup.sh"
+  ],
+  "teardown": [
+    "./.superset/teardown.sh"
+  ],
+  "run": [
+    "bun dev"
+  ]
 }


### PR DESCRIPTION
## Summary
- Adds a `run` command (`bun dev`) to `.superset/config.json` so the Superset harness knows how to start the dev server
- Reformats JSON for consistency

## Test plan
- [ ] Verify `bun dev` starts correctly when triggered via the Superset harness

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `run` command to `.superset/config.json` so the Superset harness can start the dev server with `bun dev`. Also reformats the JSON for consistency.

<sup>Written for commit 27ec6d9bb0c030c1b518eb613ba21081bf17b642. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration to enhance the setup, execution, and cleanup process workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->