### PR TITLE
fix(desktop): presets menu stays open on unpin

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar/PresetsBar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar/PresetsBar.tsx
@@ -380,7 +380,8 @@ export function PresetsBar() {
 								key={item.key}
 								className="gap-2"
 								disabled={createPreset.isPending}
-								onClick={() => {
+								onSelect={(event) => {
+									event.preventDefault();
 									if (hasPreset && item.preset) {
 										updatePreset.mutate({
 											id: item.preset.id,


### PR DESCRIPTION
## Description

Fixes `Manage Presets` behavior in the preset bar dropdown: after clicking `Unpin` (or `Pin`), the dropdown no longer closes immediately.
Now users can pin/unpin multiple presets in one open menu session.

## Related Issues

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

1. Click the gear icon (`Manage Presets`).
2. Click `Unpin` on one preset.
3. Confirm the preset is unpinned and the dropdown stays open.
4. Click `Unpin` on additional presets without reopening the menu.
5. Confirm each action applies and menu remains open until explicitly closed.

## Screenshots (if applicable)

https://github.com/user-attachments/assets/822021f5-042d-40dd-be2f-866a01c4cda3

## Additional Notes




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the Presets dropdown open after Pin/Unpin in Manage Presets, so users can update multiple presets without reopening the menu.

- **Bug Fixes**
  - Use onSelect with event.preventDefault on menu items to stop the dropdown from closing after pin/unpin.

<sup>Written for commit 2e4f43c6acb08c69c304e2fe27d4f69ead3433d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dropdown menu selection behavior in the presets bar to ensure proper handling of preset interactions and prevent unintended default actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->