### PR TITLE
Fix workspace drag start inside sections

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/hooks/useSectionDropZone.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/hooks/useSectionDropZone.ts
@@ -23,10 +23,9 @@ export function useSectionDropZone({
 	onAutoExpand,
 }: UseSectionDropZoneOptions) {
 	const [isDragOver, setIsDragOver] = useState(false);
-	const activeDragItem = useActiveDragItemStore(
-		(state) => state.activeDragItem,
+	const isDropTarget = useActiveDragItemStore(
+		(state) => state.activeDragItem !== null && canAccept(state.activeDragItem),
 	);
-	const isDropTarget = activeDragItem !== null && canAccept(activeDragItem);
 	const dragEnterCount = useRef(0);
 	const autoExpandTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const moveToSection = useMoveWorkspaceToSection();
@@ -50,32 +49,31 @@ export function useSectionDropZone({
 
 	const handleDrop = useCallback(
 		(e: React.DragEvent) => {
+			const item = getActiveDragItem();
+			if (!item || !canAccept(item)) return;
 			e.preventDefault();
 			if (autoExpandTimer.current) {
 				clearTimeout(autoExpandTimer.current);
 				autoExpandTimer.current = null;
 			}
-			const item = getActiveDragItem();
-			if (item && canAccept(item)) {
-				if (item.selectedIds && item.selectedIds.length > 1) {
-					bulkMoveToSection.mutate({
-						workspaceIds: item.selectedIds,
-						sectionId: targetSectionId,
-						...(targetSectionId === null && targetRootPlacement
-							? { rootPlacement: targetRootPlacement }
-							: {}),
-					});
-				} else {
-					moveToSection.mutate({
-						workspaceId: item.id,
-						sectionId: targetSectionId,
-						...(targetSectionId === null && targetRootPlacement
-							? { rootPlacement: targetRootPlacement }
-							: {}),
-					});
-				}
-				item.handled = true;
+			if (item.selectedIds && item.selectedIds.length > 1) {
+				bulkMoveToSection.mutate({
+					workspaceIds: item.selectedIds,
+					sectionId: targetSectionId,
+					...(targetSectionId === null && targetRootPlacement
+						? { rootPlacement: targetRootPlacement }
+						: {}),
+				});
+			} else {
+				moveToSection.mutate({
+					workspaceId: item.id,
+					sectionId: targetSectionId,
+					...(targetSectionId === null && targetRootPlacement
+						? { rootPlacement: targetRootPlacement }
+						: {}),
+				});
 			}
+			item.handled = true;
 			dragEnterCount.current = 0;
 			setIsDragOver(false);
 		},
@@ -90,17 +88,16 @@ export function useSectionDropZone({
 
 	const handleDragEnter = useCallback(
 		(e: React.DragEvent) => {
+			const item = getActiveDragItem();
+			if (!item || !canAccept(item)) return;
 			e.preventDefault();
 			dragEnterCount.current++;
-			const item = getActiveDragItem();
-			if (item && canAccept(item)) {
-				setIsDragOver(true);
-				if (onAutoExpand && !autoExpandTimer.current) {
-					autoExpandTimer.current = setTimeout(() => {
-						onAutoExpand();
-						autoExpandTimer.current = null;
-					}, 600);
-				}
+			setIsDragOver(true);
+			if (onAutoExpand && !autoExpandTimer.current) {
+				autoExpandTimer.current = setTimeout(() => {
+					onAutoExpand();
+					autoExpandTimer.current = null;
+				}, 600);
 			}
 		},
 		[canAccept, onAutoExpand],


### PR DESCRIPTION
## Issue
- dragging a workspace row was flaky specifically when that row lived inside a section
- top-level workspace rows and section headers were fine, which pointed to the section wrapper path rather than the workspace item itself
- the section drop-zone hook subscribed to the full `activeDragItem`, so section containers could rerender right as native drag was starting
- section `dragenter` and `drop` handlers also called `preventDefault` before confirming the dragged item was actually valid for that section

## Intent
- make drag start inside sections feel stable without broadening the change beyond the section-specific path
- avoid adding new persistence behavior during drag start; server writes should still happen only on drop/end
- keep the PR narrow and remove speculative fixes that did not clearly address the verified repro

## Summary
- subscribe section wrappers only to the derived `isDropTarget` state instead of the full drag item
- bail out of section `dragenter` and `drop` handlers before `preventDefault` unless the dragged workspace can actually be accepted
- preserve existing server persistence semantics; no server writes were added during drag start

## Testing
- bunx biome check apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/hooks/useSectionDropZone.ts
- bunx tsc --noEmit -p apps/desktop/tsconfig.json --pretty false


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved drag-and-drop responsiveness in the workspace sidebar with more reliable drop-target validation and streamlined event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->