### PR TITLE
Remove setup config source logs

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/setup.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/setup.ts
@@ -182,18 +182,9 @@ export function loadSetupConfig({
 }): SetupConfig | null {
 	let base = readConfigFromPath(mainRepoPath);
 
-	if (base) {
-		console.log(
-			`[setup] Using main repo config from ${join(mainRepoPath, PROJECT_SUPERSET_DIR_NAME, CONFIG_FILE_NAME)}`,
-		);
-	}
-
 	if (worktreePath) {
 		const config = readConfigFromPath(worktreePath);
 		if (config) {
-			console.log(
-				`[setup] Using worktree config from ${join(worktreePath, PROJECT_SUPERSET_DIR_NAME, CONFIG_FILE_NAME)}`,
-			);
 			base = mergeBaseConfigs(base, config);
 		}
 	}
@@ -208,7 +199,6 @@ export function loadSetupConfig({
 		);
 		const config = readConfigFile(userConfigPath);
 		if (config) {
-			console.log(`[setup] Using user override config from ${userConfigPath}`);
 			base = mergeBaseConfigs(base, config);
 		}
 	}
@@ -222,10 +212,6 @@ export function loadSetupConfig({
 	const localConfig = worktreeLocal ?? readLocalConfigFromPath(mainRepoPath);
 
 	if (localConfig) {
-		const source = worktreeLocal && worktreePath ? worktreePath : mainRepoPath;
-		console.log(
-			`[setup] Applying local config overlay from ${join(source, PROJECT_SUPERSET_DIR_NAME, LOCAL_CONFIG_FILE_NAME)}`,
-		);
 		return mergeConfigs(base, localConfig);
 	}
 


### PR DESCRIPTION
## Summary
- remove config-source logging from the workspace setup config loader
- stop emitting `[setup] Using ... config` lines when switching workspaces
- keep config parsing and validation behavior unchanged

## Testing
- bun test apps/desktop/src/lib/trpc/routers/workspaces/utils/setup.test.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed config-source console logs from the workspace setup loader to eliminate noisy “[setup] Using … config” lines when switching workspaces. Config parsing, validation, and merge behavior are unchanged.

<sup>Written for commit 35be00c5c181be2df712cd42a5d08fca186d7d5f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal logging statements from configuration setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->