### PR TITLE
fix(desktop): refresh GitHub status after PR mutations

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/changes/git-operations.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/git-operations.ts
@@ -7,6 +7,7 @@ import {
 	getSimpleGitWithShellPath,
 } from "../workspaces/utils/git-client";
 import {
+	clearGitHubStatusCacheForWorktree,
 	getPullRequestRepoArgs,
 	getRepoContext,
 } from "../workspaces/utils/github/github";
@@ -70,6 +71,11 @@ async function fetchCurrentBranch(git: SimpleGit): Promise<void> {
 		}
 		throw error;
 	}
+}
+
+function clearWorktreeStatusCaches(worktreePath: string): void {
+	clearGitHubStatusCacheForWorktree(worktreePath);
+	clearStatusCacheForWorktree(worktreePath);
 }
 
 async function pushWithSetUpstream({
@@ -538,7 +544,7 @@ export const createGitOperationsRouter = () => {
 					const existingPRUrl = await findExistingOpenPRUrl(input.worktreePath);
 					if (existingPRUrl) {
 						await fetchCurrentBranch(git);
-						clearStatusCacheForWorktree(input.worktreePath);
+						clearWorktreeStatusCaches(input.worktreePath);
 						return { success: true, url: existingPRUrl };
 					}
 
@@ -549,7 +555,7 @@ export const createGitOperationsRouter = () => {
 							branch,
 						);
 						await fetchCurrentBranch(git);
-						clearStatusCacheForWorktree(input.worktreePath);
+						clearWorktreeStatusCaches(input.worktreePath);
 
 						return { success: true, url };
 					} catch (error) {
@@ -560,7 +566,7 @@ export const createGitOperationsRouter = () => {
 						);
 						if (recoveredPRUrl) {
 							await fetchCurrentBranch(git);
-							clearStatusCacheForWorktree(input.worktreePath);
+							clearWorktreeStatusCaches(input.worktreePath);
 							return { success: true, url: recoveredPRUrl };
 						}
 						throw error;
@@ -583,7 +589,7 @@ export const createGitOperationsRouter = () => {
 
 					try {
 						await execWithShellEnv("gh", args, { cwd: input.worktreePath });
-						clearStatusCacheForWorktree(input.worktreePath);
+						clearWorktreeStatusCaches(input.worktreePath);
 						return { success: true, mergedAt: new Date().toISOString() };
 					} catch (error) {
 						const message =

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.ts
@@ -14,6 +14,10 @@ import {
 const cache = new Map<string, { data: GitHubStatus; timestamp: number }>();
 const CACHE_TTL_MS = 10_000;
 
+export function clearGitHubStatusCacheForWorktree(worktreePath: string): void {
+	cache.delete(worktreePath);
+}
+
 /**
  * Fetches GitHub PR status for a worktree using the `gh` CLI.
  * Returns null if `gh` is not installed, not authenticated, or on error.

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/index.ts
@@ -1,1 +1,4 @@
-export { fetchGitHubPRStatus } from "./github";
+export {
+	clearGitHubStatusCacheForWorktree,
+	fetchGitHubPRStatus,
+} from "./github";


### PR DESCRIPTION
## Summary
- clear the GitHub PR status cache when create/open PR flows complete
- clear the same cache after merge so the immediate refetch shows merged state right away
- factor the paired cache invalidation behind a small helper in git operations

## Testing
- bunx @biomejs/biome@2.4.2 check apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.ts apps/desktop/src/lib/trpc/routers/workspaces/utils/github/index.ts apps/desktop/src/lib/trpc/routers/changes/git-operations.ts
- bun run --cwd apps/desktop typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the GitHub PR status in Desktop immediately after creating, opening, or merging a PR by clearing cached status. This prevents stale state and shows the correct merged/open state right away.

- **Bug Fixes**
  - Clear GitHub PR status cache and local status cache for the worktree after create/open/merge, forcing an immediate refetch.
  - Add `clearGitHubStatusCacheForWorktree` and a `clearWorktreeStatusCaches` helper; export the new function and use it in git operations with `gh`.

<sup>Written for commit e1fef05d6316472c0c5c94eedc0cf932dde1c212. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cache handling for pull request operations. GitHub status information is now properly refreshed after PR creation, merge, and recovery actions to ensure accurate data is consistently displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->