### PR TITLE
fix(desktop): focus chat input on tab activation

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPane.tsx
@@ -4,7 +4,7 @@ import {
 } from "@superset/chat/client";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { CopyIcon } from "lucide-react";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback } from "react";
 import type { MosaicBranch } from "react-mosaic-component";
 import { createChatServiceIpcClient } from "renderer/components/Chat/utils/chat-service-client";
 import { env } from "renderer/env.renderer";
@@ -68,22 +68,6 @@ export function ChatPane({
 }: ChatPaneProps) {
 	const showDevToolbarActions = env.NODE_ENV === "development";
 	const isFocused = useTabsStore((s) => s.focusedPaneIds[tabId] === paneId);
-	const isActiveTab = useTabsStore(
-		(s) => s.activeTabIds[workspaceId] === tabId,
-	);
-	const prevIsActiveTabRef = useRef(isActiveTab);
-	const chatContainerRef = useRef<HTMLDivElement>(null);
-
-	useEffect(() => {
-		if (isActiveTab && !prevIsActiveTabRef.current && isFocused) {
-			const textarea =
-				chatContainerRef.current?.querySelector<HTMLTextAreaElement>(
-					"[data-slot=input-group-control]",
-				);
-			textarea?.focus();
-		}
-		prevIsActiveTabRef.current = isActiveTab;
-	}, [isActiveTab, isFocused]);
 	const equalizePaneSplits = useTabsStore((s) => s.equalizePaneSplits);
 	const paneName = useTabsStore((s) => s.panes[paneId]?.name ?? "New Chat");
 	const setTabAutoTitle = useTabsStore((s) => s.setTabAutoTitle);
@@ -226,7 +210,7 @@ export function ChatPane({
 						onMoveToNewTab={onMoveToNewTab}
 						closeLabel="Close Chat"
 					>
-						<div ref={chatContainerRef} className="h-full w-full">
+						<div className="h-full w-full">
 							<ChatPaneInterface
 								sessionId={sessionId}
 								initialLaunchConfig={launchConfig}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/index.tsx
@@ -1,6 +1,6 @@
 import type { ExternalApp } from "@superset/local-db";
 import { useParams } from "@tanstack/react-router";
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import { resolveActiveTabIdForWorkspace } from "renderer/stores/tabs/utils";
 import { EmptyTabView } from "./EmptyTabView";
@@ -21,6 +21,15 @@ export function TabsContent({
 	const allTabs = useTabsStore((s) => s.tabs);
 	const activeTabIds = useTabsStore((s) => s.activeTabIds);
 	const tabHistoryStacks = useTabsStore((s) => s.tabHistoryStacks);
+	const contentRef = useRef<HTMLDivElement>(null);
+	const hasMountedRef = useRef(false);
+	const previousActivationRef = useRef<{
+		workspaceId: string | null;
+		tabId: string | null;
+	}>({
+		workspaceId: null,
+		tabId: null,
+	});
 
 	const activeTabId = useMemo(() => {
 		if (!activeWorkspaceId) return null;
@@ -43,8 +52,43 @@ export function TabsContent({
 		return allTabs.find((tab) => tab.id === activeTabId) || null;
 	}, [activeTabId, allTabs]);
 
+	useEffect(() => {
+		const nextWorkspaceId = activeWorkspaceId ?? null;
+		const nextTabId = activeTabId ?? null;
+		if (!hasMountedRef.current) {
+			hasMountedRef.current = true;
+			previousActivationRef.current = {
+				workspaceId: nextWorkspaceId,
+				tabId: nextTabId,
+			};
+			return;
+		}
+
+		const previousActivation = previousActivationRef.current;
+		const didActivationChange =
+			previousActivation.workspaceId !== nextWorkspaceId ||
+			previousActivation.tabId !== nextTabId;
+		previousActivationRef.current = {
+			workspaceId: nextWorkspaceId,
+			tabId: nextTabId,
+		};
+
+		if (!didActivationChange || !nextTabId) {
+			return;
+		}
+
+		const frameId = requestAnimationFrame(() => {
+			const textarea = contentRef.current?.querySelector<HTMLTextAreaElement>(
+				".mosaic-window-focused [data-slot=input-group-control]",
+			);
+			textarea?.focus();
+		});
+
+		return () => cancelAnimationFrame(frameId);
+	}, [activeTabId, activeWorkspaceId]);
+
 	return (
-		<div className="flex-1 min-h-0 flex overflow-hidden">
+		<div ref={contentRef} className="flex-1 min-h-0 flex overflow-hidden">
 			{tabToRender ? (
 				<TabView tab={tabToRender} />
 			) : (


### PR DESCRIPTION
# What does this PR do? (required)
Fixes chat-input autofocus so it follows the active workspace/tab transition instead of only a tab-click code path.

This covers:
- clicking into a chat tab
- switching chat tabs with hotkeys
- changing workspaces when the active tab is a chat tab
- opening a new chat tab after the initial app load

It also removes the previous `ChatPane`-local activation detector, which could not work reliably because inactive tabs are not kept mounted.

# Link to Basecamp to-do, Trello card, New Relic or Honeybadger (required)
N/A

# QA
## What platforms should be included in QA?
- [x] Desktop web
- [ ] Mobile web
- [ ] iOS
- [ ] Android
- [ ] API
- [ ] N/A

## QA steps
1. Open a workspace with at least one chat tab and one non-chat tab.
2. Switch away from the chat tab, then return by clicking the tab.
3. Switch away and return using the keyboard tab-switch hotkeys.
4. Switch to another workspace whose active tab is a chat tab.
5. Create a new chat tab after the app is already loaded.
6. In each case above, verify the prompt textarea is focused automatically.
7. Verify non-chat tabs do not receive this behavior.

## Validation
- `bunx biome check apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/index.tsx apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPane.tsx`

# Docs
No docs update needed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat input autofocus so it follows active tab and workspace changes, not just tab clicks. The prompt is now focused when you switch tabs with hotkeys, change workspaces, or open a new chat.

- **Bug Fixes**
  - Focus chat textarea when activating a chat tab via click, hotkeys, workspace switch, or creating a new chat after load.
  - Moved focus logic to `TabsContent` with activation tracking and `requestAnimationFrame`; removed unreliable `ChatPane`-local detector.

<sup>Written for commit 701615b1fdaa5ac16eedcfd277e9fc3ede3f1a84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactoring**
  * Enhanced focus management for chat input when switching between workspace tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->