### PR TITLE
fix(desktop): position attachment dropdown below button in new workspace modal

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
@@ -120,7 +120,7 @@ const PlusMenu = forwardRef<
 						<PlusIcon className="size-3.5" />
 					</PromptInputButton>
 				</DropdownMenuTrigger>
-				<DropdownMenuContent side="top" align="end" className="w-52">
+				<DropdownMenuContent side="bottom" align="start" className="w-52">
 					<DropdownMenuItem onSelect={() => attachments.openFileDialog()}>
 						<PaperclipIcon className="size-4" />
 						Add attachment


### PR DESCRIPTION
## Summary
- Changed attachment dropdown in new workspace modal to open downward and align left instead of upward and right

## Why / Context
The dropdown menu was opening upward (`side="top"`) and aligning to the right (`align="end"`), which could cause it to be cut off at the top of the modal or appear awkwardly positioned. Opening downward provides a more standard dropdown experience and keeps the menu fully visible within the modal bounds.

## Manual QA Checklist

### Dropdown Behavior
- [ ] Dropdown opens below the plus button
- [ ] Dropdown aligns to the left edge of the button
- [ ] Menu is fully visible (not cut off)
- [ ] All three menu items are clickable:
  - [ ] "Add attachment" opens file dialog
  - [ ] "Link issue" opens issue link command
  - [ ] "Link pull request" opens PR link command

### Edge Cases
- [ ] Works when modal is near top of screen
- [ ] Works when modal is near bottom of screen

## Testing
- `bun run typecheck`
- Manual: Tested dropdown positioning in new workspace modal

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Positions the attachment dropdown below the plus button in the New Workspace modal to avoid clipping and match typical dropdown behavior. Sets `side="bottom"` and `align="start"` so the menu opens downward and left-aligned within the modal.

<sup>Written for commit bebd4677fc0424d4c9ea22c6accb59a9ec1f5c94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted dropdown menu positioning in the prompt interface. The attachment and link options menu now displays below the action button with left alignment instead of above with right alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->