### PR TITLE
feat(desktop): move run button to presets bar with cmd+g shortcut

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
@@ -10,7 +10,6 @@ import { ResourceConsumption } from "./components/ResourceConsumption";
 import { SearchBarTrigger } from "./components/SearchBarTrigger";
 import { SidebarToggle } from "./components/SidebarToggle";
 import { WindowControls } from "./components/WindowControls";
-import { WorkspaceRunButton } from "./components/WorkspaceRunButton";
 
 export function TopBar() {
 	const { data: platform } = electronTrpc.window.getPlatform.useQuery();
@@ -60,13 +59,6 @@ export function TopBar() {
 						<HiOutlineWifi className="size-3.5" />
 						<span>Offline</span>
 					</div>
-				)}
-				{workspaceId && (
-					<WorkspaceRunButton
-						projectId={workspace?.projectId ?? workspace?.project?.id}
-						workspaceId={workspaceId}
-						worktreePath={workspace?.worktreePath}
-					/>
 				)}
 				{workspace?.worktreePath && (
 					<OpenInMenuButton

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/WorkspaceRunButton/WorkspaceRunButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/WorkspaceRunButton/WorkspaceRunButton.tsx
@@ -4,7 +4,6 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { useNavigate } from "@tanstack/react-router";
 import { memo, useCallback } from "react";
@@ -14,9 +13,9 @@ import {
 	HiMiniPlay,
 	HiMiniStop,
 } from "react-icons/hi2";
-import { HotkeyTooltipContent } from "renderer/components/HotkeyTooltipContent";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useWorkspaceRunCommand } from "renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/useWorkspaceRunCommand";
+import { useHotkeyText } from "renderer/stores/hotkeys";
 import { useSetSettingsSearchQuery } from "renderer/stores/settings-state";
 
 interface WorkspaceRunButtonProps {
@@ -32,6 +31,7 @@ export const WorkspaceRunButton = memo(function WorkspaceRunButton({
 }: WorkspaceRunButtonProps) {
 	const navigate = useNavigate();
 	const setSettingsSearchQuery = useSetSettingsSearchQuery();
+	const hotkeyText = useHotkeyText("RUN_WORKSPACE_COMMAND");
 	const { isRunning, isPending, toggleWorkspaceRun } = useWorkspaceRunCommand({
 		workspaceId,
 		worktreePath,
@@ -79,57 +79,43 @@ export const WorkspaceRunButton = memo(function WorkspaceRunButton({
 		: hasRunCommand
 			? "Run workspace command"
 			: "Configure workspace run command";
-	const tooltipLabel = isPending
-		? isRunning
-			? "Stopping workspace run command"
-			: "Starting workspace run command"
-		: isRunning
-			? "Stop workspace run command"
-			: hasRunCommand
-				? "Run workspace command"
-				: "Configure workspace run command";
 
 	return (
 		<div className="flex items-center no-drag">
 			{/* Main button - Run/Stop action */}
-			<Tooltip>
-				<TooltipTrigger asChild>
-					<button
-						type="button"
-						onClick={handleRunClick}
-						disabled={isPending}
-						aria-label={buttonAriaLabel}
-						className={cn(
-							"group flex items-center gap-1.5 h-6 px-1.5 sm:px-2 rounded-l border border-r-0 border-border/60 bg-secondary/50 text-xs font-medium",
-							"transition-all duration-150 ease-out",
-							"hover:bg-secondary hover:border-border",
-							"focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-							"active:scale-[0.98]",
-							isPending && "opacity-50 pointer-events-none",
-							isRunning
-								? "text-emerald-300 border-emerald-500/25 bg-emerald-500/10"
-								: hasRunCommand
-									? "text-foreground"
-									: "text-muted-foreground/80 border-border/40 bg-secondary/40",
-						)}
-					>
-						{isRunning ? (
-							<HiMiniStop className="size-3.5 shrink-0" />
-						) : hasRunCommand ? (
-							<HiMiniPlay className="size-3.5 shrink-0" />
-						) : (
-							<HiMiniCog6Tooth className="size-3.5 shrink-0" />
-						)}
-						<span className="hidden sm:inline">{buttonLabel}</span>
-					</button>
-				</TooltipTrigger>
-				<TooltipContent side="bottom" sideOffset={6}>
-					<HotkeyTooltipContent
-						label={tooltipLabel}
-						hotkeyId="RUN_WORKSPACE_COMMAND"
-					/>
-				</TooltipContent>
-			</Tooltip>
+			<button
+				type="button"
+				onClick={handleRunClick}
+				disabled={isPending}
+				aria-label={buttonAriaLabel}
+				className={cn(
+					"group flex items-center gap-1.5 h-6 px-1.5 sm:px-2 rounded-l border border-r-0 border-border/60 bg-secondary/50 text-xs font-medium",
+					"transition-all duration-150 ease-out",
+					"hover:bg-secondary hover:border-border",
+					"focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+					"active:scale-[0.98]",
+					isPending && "opacity-50 pointer-events-none",
+					isRunning
+						? "text-emerald-300 border-emerald-500/25 bg-emerald-500/10"
+						: hasRunCommand
+							? "text-foreground"
+							: "text-muted-foreground/80 border-border/40 bg-secondary/40",
+				)}
+			>
+				{isRunning ? (
+					<HiMiniStop className="size-3.5 shrink-0" />
+				) : hasRunCommand ? (
+					<HiMiniPlay className="size-3.5 shrink-0" />
+				) : (
+					<HiMiniCog6Tooth className="size-3.5 shrink-0" />
+				)}
+				<span className="hidden sm:inline">{buttonLabel}</span>
+				{hotkeyText && hotkeyText !== "Unassigned" && (
+					<span className="hidden sm:inline text-[10px] text-muted-foreground/60 ml-1">
+						{hotkeyText}
+					</span>
+				)}
+			</button>
 
 			{/* Dropdown trigger */}
 			<DropdownMenu>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar/PresetsBar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar/PresetsBar.tsx
@@ -24,6 +24,7 @@ import {
 import { HotkeyMenuShortcut } from "renderer/components/HotkeyMenuShortcut";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { usePresets } from "renderer/react-query/presets";
+import { WorkspaceRunButton } from "renderer/routes/_authenticated/_dashboard/components/TopBar/components/WorkspaceRunButton";
 import { PRESET_HOTKEY_IDS } from "renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/usePresetHotkeys";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import { useTabsWithPresets } from "renderer/stores/tabs/useTabsWithPresets";
@@ -151,6 +152,10 @@ export function PresetsBar() {
 				utils.settings.getShowPresetsBar.invalidate();
 			},
 		},
+	);
+	const { data: workspace } = electronTrpc.workspaces.get.useQuery(
+		{ id: workspaceId ?? "" },
+		{ enabled: !!workspaceId },
 	);
 	const presetsByName = useMemo(() => {
 		const map = new Map<string, typeof presets>();
@@ -461,6 +466,15 @@ export function PresetsBar() {
 					/>
 				);
 			})}
+			{workspaceId && (
+				<div className="ml-auto flex items-center gap-1 shrink-0">
+					<WorkspaceRunButton
+						projectId={workspace?.projectId ?? workspace?.project?.id}
+						workspaceId={workspaceId}
+						worktreePath={workspace?.worktreePath}
+					/>
+				</div>
+			)}
 		</div>
 	);
 }

--- a/apps/desktop/src/shared/hotkeys.ts
+++ b/apps/desktop/src/shared/hotkeys.ts
@@ -723,7 +723,7 @@ export const HOTKEYS = {
 		description: "Quickly create a workspace in the current project",
 	}),
 	RUN_WORKSPACE_COMMAND: defineHotkey({
-		keys: "meta+shift+g",
+		keys: "meta+g",
 		label: "Run Workspace Command",
 		category: "Workspace",
 		description: "Start or stop the workspace run command",


### PR DESCRIPTION
## Summary
Moves the workspace run button from the top bar to the presets bar and improves the keyboard shortcut for better accessibility and UX.

## Changes
- **Relocated WorkspaceRunButton**: Moved from TopBar to PresetsBar, positioned at the far right using `ml-auto`
- **Improved shortcut**: Changed from `cmd+shift+g` to `cmd+g` for easier access
- **Cleaner UI**: Removed tooltip, added inline shortcut display next to button label
- **Better positioning**: Button now appears at the end of the presets bar, separate from preset items

## Benefits
- More intuitive keyboard shortcut (`cmd+g` for "Go/Run")
- Run button is now co-located with other workspace actions in the presets bar
- Cleaner top bar with fewer controls
- Shortcut is always visible on the button itself

## Screenshots
The run button now appears on the right side of the presets bar showing "Run ⌘G" or "Stop ⌘G".

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the workspace Run/Stop button to the presets bar for better placement, and simplified the shortcut to Cmd+G for quicker access. The button now shows the shortcut inline and frees up space in the top bar.

- **New Features**
  - Moved `WorkspaceRunButton` to the presets bar and right-aligned it.
  - Replaced the tooltip with an inline shortcut label on the button.
  - Changed the hotkey from `meta+shift+g` to `meta+g` in `apps/desktop/src/shared/hotkeys.ts`.

<sup>Written for commit 9fa33fe42d647872c2e7aa2dcd1945456701b67b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Relocated workspace run button within the interface.
  * Simplified keyboard shortcut for run command from ⌘⇧G to ⌘G.
  * Enhanced hotkey display with inline text indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->