### PR TITLE
fix(auth): resolve MCP OAuth 500 without active organization

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -23,6 +23,7 @@
 	},
 	"scripts": {
 		"clean": "git clean -xdf .cache .turbo dist node_modules",
+		"test": "bun test",
 		"typecheck": "tsc --noEmit --emitDeclarationOnly false"
 	},
 	"dependencies": {

--- a/packages/auth/src/lib/resolve-session-organization-state.test.ts
+++ b/packages/auth/src/lib/resolve-session-organization-state.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { SelectMember } from "@superset/db/schema/auth";
+import {
+	type ResolveSessionOrganizationDeps,
+	resolveSessionOrganizationState,
+} from "./resolve-session-organization-state";
+
+function createMember(
+	organizationId: string,
+	overrides: Partial<SelectMember> = {},
+): SelectMember {
+	return {
+		id: `member-${organizationId}`,
+		organizationId,
+		userId: "user-1",
+		role: "member",
+		createdAt: new Date("2026-03-21T00:00:00.000Z"),
+		...overrides,
+	};
+}
+
+describe("resolveSessionOrganizationState", () => {
+	const listMemberships = mock<
+		ResolveSessionOrganizationDeps["listMemberships"]
+	>(async () => []);
+	const updateSessionActiveOrganization = mock<
+		ResolveSessionOrganizationDeps["updateSessionActiveOrganization"]
+	>(async () => true);
+	const getSessionActiveOrganization = mock<
+		ResolveSessionOrganizationDeps["getSessionActiveOrganization"]
+	>(async () => null);
+
+	const deps: ResolveSessionOrganizationDeps = {
+		listMemberships,
+		updateSessionActiveOrganization,
+		getSessionActiveOrganization,
+	};
+
+	beforeEach(() => {
+		listMemberships.mockReset();
+		updateSessionActiveOrganization.mockReset();
+		getSessionActiveOrganization.mockReset();
+		updateSessionActiveOrganization.mockImplementation(async () => true);
+		getSessionActiveOrganization.mockImplementation(async () => null);
+	});
+
+	it("falls back to the most recent membership when active org is missing", async () => {
+		listMemberships.mockImplementation(async () => [
+			createMember("org-1"),
+			createMember("org-2", {
+				createdAt: new Date("2026-03-20T00:00:00.000Z"),
+			}),
+		]);
+
+		const result = await resolveSessionOrganizationState(
+			{
+				userId: "user-1",
+				session: { id: "session-1", activeOrganizationId: null },
+			},
+			deps,
+		);
+
+		expect(result.activeOrganizationId).toBe("org-1");
+		expect(result.membership?.organizationId).toBe("org-1");
+		expect(updateSessionActiveOrganization).toHaveBeenCalledWith({
+			sessionId: "session-1",
+			previousActiveOrganizationId: null,
+			nextActiveOrganizationId: "org-1",
+		});
+		expect(getSessionActiveOrganization).not.toHaveBeenCalled();
+	});
+
+	it("replaces stale active org ids with the most recent valid membership", async () => {
+		listMemberships.mockImplementation(async () => [
+			createMember("org-2"),
+			createMember("org-1", {
+				createdAt: new Date("2026-03-20T00:00:00.000Z"),
+			}),
+		]);
+
+		const result = await resolveSessionOrganizationState(
+			{
+				userId: "user-1",
+				session: {
+					id: "session-1",
+					activeOrganizationId: "org-missing",
+				},
+			},
+			deps,
+		);
+
+		expect(result.activeOrganizationId).toBe("org-2");
+		expect(result.membership?.organizationId).toBe("org-2");
+		expect(updateSessionActiveOrganization).toHaveBeenCalledWith({
+			sessionId: "session-1",
+			previousActiveOrganizationId: "org-missing",
+			nextActiveOrganizationId: "org-2",
+		});
+	});
+
+	it("clears stale active org ids when the user has no memberships", async () => {
+		listMemberships.mockImplementation(async () => []);
+
+		const result = await resolveSessionOrganizationState(
+			{
+				userId: "user-1",
+				session: {
+					id: "session-1",
+					activeOrganizationId: "org-missing",
+				},
+			},
+			deps,
+		);
+
+		expect(result.activeOrganizationId).toBeNull();
+		expect(result.membership).toBeUndefined();
+		expect(updateSessionActiveOrganization).toHaveBeenCalledWith({
+			sessionId: "session-1",
+			previousActiveOrganizationId: "org-missing",
+			nextActiveOrganizationId: null,
+		});
+	});
+
+	it("prefers the latest persisted active org when the compare-and-swap write loses the race", async () => {
+		listMemberships.mockImplementation(async () => [
+			createMember("org-1"),
+			createMember("org-2", {
+				createdAt: new Date("2026-03-20T00:00:00.000Z"),
+			}),
+		]);
+		updateSessionActiveOrganization.mockImplementation(async () => false);
+		getSessionActiveOrganization.mockImplementation(async () => "org-2");
+
+		const result = await resolveSessionOrganizationState(
+			{
+				userId: "user-1",
+				session: { id: "session-1", activeOrganizationId: null },
+			},
+			deps,
+		);
+
+		expect(result.activeOrganizationId).toBe("org-2");
+		expect(result.membership?.organizationId).toBe("org-2");
+		expect(getSessionActiveOrganization).toHaveBeenCalledWith("session-1");
+	});
+});

--- a/packages/auth/src/lib/resolve-session-organization-state.ts
+++ b/packages/auth/src/lib/resolve-session-organization-state.ts
@@ -1,0 +1,123 @@
+import { db } from "@superset/db/client";
+import { members } from "@superset/db/schema";
+import type { SelectMember } from "@superset/db/schema/auth";
+import * as authSchema from "@superset/db/schema/auth";
+import { and, desc, eq, sql } from "drizzle-orm";
+
+export type SessionOrganizationContext = {
+	id?: string;
+	activeOrganizationId?: string | null;
+};
+
+export interface ResolveSessionOrganizationDeps {
+	listMemberships: (userId: string) => Promise<SelectMember[]>;
+	updateSessionActiveOrganization: (input: {
+		sessionId: string;
+		previousActiveOrganizationId: string | null;
+		nextActiveOrganizationId: string | null;
+	}) => Promise<boolean>;
+	getSessionActiveOrganization: (sessionId: string) => Promise<string | null>;
+}
+
+const defaultResolveSessionOrganizationDeps: ResolveSessionOrganizationDeps = {
+	listMemberships: (userId) =>
+		db.query.members.findMany({
+			where: eq(members.userId, userId),
+			orderBy: desc(members.createdAt),
+		}),
+	updateSessionActiveOrganization: async ({
+		sessionId,
+		previousActiveOrganizationId,
+		nextActiveOrganizationId,
+	}) => {
+		const updatedSessions = await db
+			.update(authSchema.sessions)
+			.set({ activeOrganizationId: nextActiveOrganizationId })
+			.where(
+				and(
+					eq(authSchema.sessions.id, sessionId),
+					sql`${authSchema.sessions.activeOrganizationId} is not distinct from ${previousActiveOrganizationId}`,
+				),
+			)
+			.returning({ id: authSchema.sessions.id });
+
+		return updatedSessions.length > 0;
+	},
+	getSessionActiveOrganization: async (sessionId) => {
+		const [sessionRow] = await db
+			.select({
+				activeOrganizationId: authSchema.sessions.activeOrganizationId,
+			})
+			.from(authSchema.sessions)
+			.where(eq(authSchema.sessions.id, sessionId))
+			.limit(1);
+
+		return sessionRow?.activeOrganizationId ?? null;
+	},
+};
+
+export async function resolveSessionOrganizationState(
+	{
+		userId,
+		session,
+	}: {
+		userId?: string | null;
+		session?: SessionOrganizationContext | null;
+	},
+	deps: ResolveSessionOrganizationDeps = defaultResolveSessionOrganizationDeps,
+) {
+	const previousActiveOrganizationId = session?.activeOrganizationId ?? null;
+	let activeOrganizationId = previousActiveOrganizationId;
+	if (!userId) {
+		return {
+			activeOrganizationId,
+			allMemberships: [],
+			membership: undefined,
+		};
+	}
+
+	const allMemberships = await deps.listMemberships(userId);
+
+	const nextMembership =
+		(previousActiveOrganizationId
+			? allMemberships.find(
+					(item) => item.organizationId === previousActiveOrganizationId,
+				)
+			: undefined) ?? allMemberships[0];
+
+	const nextActiveOrganizationId = nextMembership?.organizationId ?? null;
+	if (nextActiveOrganizationId !== previousActiveOrganizationId) {
+		if (session?.id) {
+			const updated = await deps.updateSessionActiveOrganization({
+				sessionId: session.id,
+				previousActiveOrganizationId,
+				nextActiveOrganizationId,
+			});
+
+			if (updated) {
+				activeOrganizationId = nextActiveOrganizationId;
+			} else {
+				// Another request won the race to update this session; prefer
+				// the latest persisted active org instead of clobbering it.
+				activeOrganizationId = await deps.getSessionActiveOrganization(
+					session.id,
+				);
+			}
+		} else {
+			activeOrganizationId = nextActiveOrganizationId;
+		}
+	}
+
+	const membership =
+		(activeOrganizationId
+			? allMemberships.find(
+					(item) => item.organizationId === activeOrganizationId,
+				)
+			: undefined) ?? (!activeOrganizationId ? allMemberships[0] : undefined);
+
+	return {
+		activeOrganizationId,
+		allMemberships,
+		membership,
+	};
+}

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -32,6 +32,10 @@ import { acceptInvitationEndpoint } from "./lib/accept-invitation-endpoint";
 import { generateMagicTokenForInvite } from "./lib/generate-magic-token";
 import { invitationRateLimit } from "./lib/rate-limit";
 import { resend } from "./lib/resend";
+import {
+	resolveSessionOrganizationState,
+	type SessionOrganizationContext,
+} from "./lib/resolve-session-organization-state";
 import { stripeClient } from "./stripe";
 import { formatPrice, getOrganizationOwners } from "./utils";
 
@@ -46,57 +50,6 @@ const desktopDevOrigins =
 				`http://127.0.0.1:${desktopDevPort}`,
 			]
 		: [];
-
-type SessionOrganizationContext = {
-	id?: string;
-	activeOrganizationId?: string | null;
-};
-
-async function resolveSessionOrganizationState({
-	userId,
-	session,
-}: {
-	userId?: string | null;
-	session?: SessionOrganizationContext | null;
-}) {
-	let activeOrganizationId = session?.activeOrganizationId ?? null;
-	if (!userId) {
-		return {
-			activeOrganizationId,
-			allMemberships: [],
-			membership: undefined,
-		};
-	}
-
-	const allMemberships = await db.query.members.findMany({
-		where: eq(members.userId, userId),
-		orderBy: desc(members.createdAt),
-	});
-
-	const membership =
-		(activeOrganizationId
-			? allMemberships.find(
-					(item) => item.organizationId === activeOrganizationId,
-				)
-			: undefined) ?? allMemberships[0];
-
-	const nextActiveOrganizationId = membership?.organizationId ?? null;
-	if (nextActiveOrganizationId !== activeOrganizationId) {
-		activeOrganizationId = nextActiveOrganizationId;
-		if (session?.id) {
-			await db
-				.update(authSchema.sessions)
-				.set({ activeOrganizationId })
-				.where(eq(authSchema.sessions.id, session.id));
-		}
-	}
-
-	return {
-		activeOrganizationId,
-		allMemberships,
-		membership,
-	};
-}
 
 export const auth = betterAuth({
 	baseURL: env.NEXT_PUBLIC_API_URL,

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -7,5 +7,5 @@
 		"declarationMap": false
 	},
 	"include": ["src"],
-	"exclude": ["node_modules", "dist"]
+	"exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
- avoid OAuth authorize 500s when `session.activeOrganizationId` is missing
- reuse shared organization resolution in `oauthProvider.postLogin.consentReferenceId` and `customSession`
- backfill or correct the active organization from memberships before consent and token issuance

## Testing
- bun run --cwd packages/auth typecheck
- bunx @biomejs/biome@2.4.2 check packages/auth/src/server.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MCP OAuth 500s when the session has no active organization by resolving and persisting the correct org from memberships with race-safe updates. Consent and token issuance in `packages/auth` now work even when the session starts without an org.

- **Bug Fixes**
  - Added a shared resolver that backfills `activeOrganizationId` from memberships and uses compare-and-swap to avoid clobbering newer session writes; falls back to the latest persisted org on races.
  - Applied the resolver in `oauthProvider.postLogin.consentReferenceId` and `customSession` so consent no longer throws and the session org stays consistent.

<sup>Written for commit efbaa546441d50e4798307607a65051375be0d82. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved session and organization-membership handling during authentication for more reliable active-organization selection and session consistency.
* **Tests**
  * Added test coverage validating membership selection, session updates, and race-condition handling.
* **Chores**
  * Added a project test script and excluded tests from TypeScript compilation to streamline development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->