### PR TITLE
feat(desktop): support arrow key navigation to file tree

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/FilesView.tsx
@@ -1,6 +1,7 @@
 import {
 	asyncDataLoaderFeature,
 	expandAllFeature,
+	hotkeysCoreFeature,
 	type ItemInstance,
 	selectionFeature,
 } from "@headless-tree/core";
@@ -232,7 +233,13 @@ export function FilesView() {
 				}
 			},
 		},
-		features: [asyncDataLoaderFeature, selectionFeature, expandAllFeature],
+		features: [
+			asyncDataLoaderFeature,
+			selectionFeature,
+			expandAllFeature,
+			hotkeysCoreFeature,
+		],
+		ignoreHotkeysOnInputs: true,
 	});
 
 	const prevWorktreePathRef = useRef(worktreePath);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileTreeItem/FileTreeItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileTreeItem/FileTreeItem.tsx
@@ -72,6 +72,7 @@ export function FileTreeItem({
 
 	const handleClick = (e: React.MouseEvent) => {
 		e.stopPropagation();
+		item.setFocused();
 		if (isFolder) {
 			if (isExpanded) {
 				item.collapse();
@@ -113,7 +114,7 @@ export function FileTreeItem({
 				paddingLeft: level * indent,
 			}}
 			role="treeitem"
-			tabIndex={0}
+			tabIndex={item.isFocused() ? 0 : -1}
 			aria-expanded={isFolder ? isExpanded : undefined}
 			className={cn(
 				"flex items-center gap-1 px-1 cursor-pointer select-none",


### PR DESCRIPTION
## Summary

The file tree sidebar didn't support arrow key navigation. `@headless-tree` already has keyboard navigation built in, but `hotkeysCoreFeature` wasn't included in the features array so it was inactive. Instead of writing custom keyboard handlers, this enables the library's built-in support.

Enabling the feature also brings ArrowLeft/Right (folder expand/collapse) and Home/End for free since they're part of the same tree hotkey preset.

## Changes

- Added `hotkeysCoreFeature` to tree features — enables arrow key navigation
- Applied roving tabindex on `FileTreeItem` (`tabIndex={0}` → `item.isFocused() ? 0 : -1`) and added `item.setFocused()` on click for focus state sync
- Set `ignoreHotkeysOnInputs: true` so tree hotkeys don't fire while typing in rename/new-item inputs

## Testing

- [ ] Click a file/folder in the tree, then ArrowUp/Down to move focus
- [ ] ArrowRight to expand folders, ArrowLeft to collapse
- [ ] Enter still opens files and toggles folders
- [ ] Arrow keys inside rename input don't trigger tree navigation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed focus handling for file tree items when clicked or navigating with keyboard.
  * Hotkeys are now suppressed when typing in input fields to prevent accidental activation.

* **New Features**
  * Enhanced hotkey support in the file tree for improved keyboard navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->