### PR TITLE
feat(desktop): support cmd+click to open files in new tab from changes menu

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
@@ -34,6 +34,7 @@ interface ChangesViewProps {
 		file: ChangedFile,
 		category: ChangeCategory,
 		commitHash?: string,
+		openInNewTab?: boolean,
 	) => void;
 	isExpandedView?: boolean;
 	isActive?: boolean;
@@ -424,7 +425,11 @@ export function ChangesView({
 		[status?.unstaged, status?.untracked],
 	);
 
-	const handleFileSelect = (file: ChangedFile, category: ChangeCategory) => {
+	const handleFileSelect = (
+		file: ChangedFile,
+		category: ChangeCategory,
+		openInNewTab?: boolean,
+	) => {
 		if (!workspaceId || !worktreePath) return;
 		selectFile(
 			workspaceId,
@@ -433,10 +438,14 @@ export function ChangesView({
 			category,
 			null,
 		);
-		onFileOpen?.(file, category);
+		onFileOpen?.(file, category, undefined, openInNewTab);
 	};
 
-	const handleCommitFileSelect = (file: ChangedFile, commitHash: string) => {
+	const handleCommitFileSelect = (
+		file: ChangedFile,
+		commitHash: string,
+		openInNewTab?: boolean,
+	) => {
 		if (!workspaceId || !worktreePath) return;
 		selectFile(
 			workspaceId,
@@ -445,7 +454,7 @@ export function ChangesView({
 			"committed",
 			commitHash,
 		);
-		onFileOpen?.(file, "committed", commitHash);
+		onFileOpen?.(file, "committed", commitHash, openInNewTab);
 	};
 
 	const handleCommitToggle = (hash: string) => {
@@ -553,13 +562,13 @@ export function ChangesView({
 		projectId,
 		isExpandedView,
 		againstBaseFiles,
-		onAgainstBaseFileSelect: (file) => handleFileSelect(file, "against-base"),
+		onAgainstBaseFileSelect: (file, openInNewTab) => handleFileSelect(file, "against-base", openInNewTab),
 		commitsWithFiles,
 		expandedCommits,
 		onCommitToggle: handleCommitToggle,
 		onCommitFileSelect: handleCommitFileSelect,
 		stagedFiles,
-		onStagedFileSelect: (file) => handleFileSelect(file, "staged"),
+		onStagedFileSelect: (file, openInNewTab) => handleFileSelect(file, "staged", openInNewTab),
 		onUnstageFile: (file) =>
 			unstageFileMutation.mutate({
 				worktreePath: worktreePath || "",
@@ -583,7 +592,7 @@ export function ChangesView({
 			unstageAllMutation.isPending ||
 			discardAllStagedMutation.isPending,
 		unstagedFiles: combinedUnstaged,
-		onUnstagedFileSelect: (file) => handleFileSelect(file, "unstaged"),
+		onUnstagedFileSelect: (file, openInNewTab) => handleFileSelect(file, "unstaged", openInNewTab),
 		onStageFile: (file) =>
 			stageFileMutation.mutate({
 				worktreePath: worktreePath || "",

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
@@ -30,6 +30,7 @@ import { useOrderedSections } from "./hooks";
 import { getPRActionState, shouldAutoCreatePRAfterPublish } from "./utils";
 
 interface ChangesViewProps {
+	/** Called when a file is selected. Receives `openInNewTab` when cmd/ctrl+click requests a new pinned tab. */
 	onFileOpen?: (
 		file: ChangedFile,
 		category: ChangeCategory,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/CommitItem/CommitItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/CommitItem/CommitItem.tsx
@@ -18,7 +18,7 @@ interface CommitItemProps {
 	onToggle: () => void;
 	selectedFile: ChangedFile | null;
 	selectedCommitHash: string | null;
-	onFileSelect: (file: ChangedFile, commitHash: string) => void;
+	onFileSelect: (file: ChangedFile, commitHash: string, openInNewTab?: boolean) => void;
 	viewMode: ChangesViewMode;
 	worktreePath: string;
 	isExpandedView?: boolean;
@@ -82,8 +82,8 @@ export function CommitItem({
 }: CommitItemProps) {
 	const hasFiles = commit.files.length > 0;
 
-	const handleFileSelect = (file: ChangedFile) => {
-		onFileSelect(file, commit.hash);
+	const handleFileSelect = (file: ChangedFile, openInNewTab?: boolean) => {
+		onFileSelect(file, commit.hash, openInNewTab);
 	};
 
 	const isCommitSelected = selectedCommitHash === commit.hash;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/CommitItem/CommitItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/CommitItem/CommitItem.tsx
@@ -18,6 +18,7 @@ interface CommitItemProps {
 	onToggle: () => void;
 	selectedFile: ChangedFile | null;
 	selectedCommitHash: string | null;
+	/** Called when a file within a commit is selected. Passes `openInNewTab` when cmd/ctrl was held. */
 	onFileSelect: (file: ChangedFile, commitHash: string, openInNewTab?: boolean) => void;
 	viewMode: ChangesViewMode;
 	worktreePath: string;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileItem/FileItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileItem/FileItem.tsx
@@ -30,7 +30,7 @@ import { RowHoverActions } from "../RowHoverActions";
 interface FileItemProps {
 	file: ChangedFile;
 	isSelected: boolean;
-	onClick: () => void;
+	onClick: (openInNewTab?: boolean) => void;
 	showStats?: boolean;
 	level?: number;
 	onStage?: () => void;
@@ -111,17 +111,22 @@ export function FileItem({
 
 	const fileDragProps = useFileDrag({ absolutePath });
 
-	const handleClick = useCallback(() => {
-		if (clickTimeoutRef.current) {
-			clearTimeout(clickTimeoutRef.current);
-			clickTimeoutRef.current = null;
-		}
+	const handleClick = useCallback(
+		(e: React.MouseEvent) => {
+			const openInNewTab = e.metaKey || e.ctrlKey ? true : undefined;
 
-		clickTimeoutRef.current = setTimeout(() => {
-			clickTimeoutRef.current = null;
-			onClick();
-		}, 300);
-	}, [onClick]);
+			if (clickTimeoutRef.current) {
+				clearTimeout(clickTimeoutRef.current);
+				clickTimeoutRef.current = null;
+			}
+
+			clickTimeoutRef.current = setTimeout(() => {
+				clickTimeoutRef.current = null;
+				onClick(openInNewTab);
+			}, 300);
+		},
+		[onClick],
+	);
 
 	const handleDoubleClick = useCallback(
 		(e: React.MouseEvent) => {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileItem/FileItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileItem/FileItem.tsx
@@ -30,6 +30,7 @@ import { RowHoverActions } from "../RowHoverActions";
 interface FileItemProps {
 	file: ChangedFile;
 	isSelected: boolean;
+	/** Called when the file row is clicked. Passes `true` when cmd/ctrl was held (open in new tab). */
 	onClick: (openInNewTab?: boolean) => void;
 	showStats?: boolean;
 	level?: number;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileList/FileList.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileList/FileList.tsx
@@ -14,7 +14,7 @@ interface FileListProps {
 	viewMode: ChangesViewMode;
 	selectedFile: ChangedFile | null;
 	selectedCommitHash: string | null;
-	onFileSelect: (file: ChangedFile) => void;
+	onFileSelect: (file: ChangedFile, openInNewTab?: boolean) => void;
 	showStats?: boolean;
 	onStage?: (file: ChangedFile) => void;
 	onUnstage?: (file: ChangedFile) => void;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileList/FileList.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileList/FileList.tsx
@@ -14,6 +14,7 @@ interface FileListProps {
 	viewMode: ChangesViewMode;
 	selectedFile: ChangedFile | null;
 	selectedCommitHash: string | null;
+	/** Called when a file is selected. Passes `openInNewTab` when cmd/ctrl was held. */
 	onFileSelect: (file: ChangedFile, openInNewTab?: boolean) => void;
 	showStats?: boolean;
 	onStage?: (file: ChangedFile) => void;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileList/FileListGrouped.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileList/FileListGrouped.tsx
@@ -8,7 +8,7 @@ interface FileListGroupedProps {
 	files: ChangedFile[];
 	selectedFile: ChangedFile | null;
 	selectedCommitHash: string | null;
-	onFileSelect: (file: ChangedFile) => void;
+	onFileSelect: (file: ChangedFile, openInNewTab?: boolean) => void;
 	showStats?: boolean;
 	onStage?: (file: ChangedFile) => void;
 	onUnstage?: (file: ChangedFile) => void;
@@ -66,7 +66,7 @@ function groupFilesByFolder(files: ChangedFile[]): FolderGroup[] {
 interface FolderGroupItemProps {
 	group: FolderGroup;
 	selectedFile: ChangedFile | null;
-	onFileSelect: (file: ChangedFile) => void;
+	onFileSelect: (file: ChangedFile, openInNewTab?: boolean) => void;
 	showStats?: boolean;
 	onStage?: (file: ChangedFile) => void;
 	onUnstage?: (file: ChangedFile) => void;
@@ -151,7 +151,7 @@ function FolderGroupItem({
 					key={file.path}
 					file={file}
 					isSelected={selectedFile?.path === file.path}
-					onClick={() => onFileSelect(file)}
+					onClick={(openInNewTab) => onFileSelect(file, openInNewTab)}
 					showStats={showStats}
 					onStage={onStage ? () => onStage(file) : undefined}
 					onUnstage={onUnstage ? () => onUnstage(file) : undefined}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileList/FileListGroupedVirtualized.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileList/FileListGroupedVirtualized.tsx
@@ -12,7 +12,7 @@ interface FileListGroupedVirtualizedProps {
 	files: ChangedFile[];
 	selectedFile: ChangedFile | null;
 	selectedCommitHash: string | null;
-	onFileSelect: (file: ChangedFile) => void;
+	onFileSelect: (file: ChangedFile, openInNewTab?: boolean) => void;
 	showStats?: boolean;
 	onStage?: (file: ChangedFile) => void;
 	onUnstage?: (file: ChangedFile) => void;
@@ -214,7 +214,7 @@ export function FileListGroupedVirtualized({
 											selectedFile?.path === row.file.path &&
 											(!commitHash || selectedCommitHash === commitHash)
 										}
-										onClick={() => onFileSelect(row.file)}
+										onClick={(openInNewTab) => onFileSelect(row.file, openInNewTab)}
 										showStats={showStats}
 										onStage={onStage ? () => onStage(row.file) : undefined}
 										onUnstage={

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileList/FileListTree.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileList/FileListTree.tsx
@@ -33,7 +33,7 @@ interface FileListTreeProps {
 	files: ChangedFile[];
 	selectedFile: ChangedFile | null;
 	selectedCommitHash: string | null;
-	onFileSelect: (file: ChangedFile) => void;
+	onFileSelect: (file: ChangedFile, openInNewTab?: boolean) => void;
 	showStats?: boolean;
 	onStage?: (file: ChangedFile) => void;
 	onUnstage?: (file: ChangedFile) => void;
@@ -106,7 +106,7 @@ interface TreeNodeComponentProps {
 	level?: number;
 	selectedPath: string | null;
 	selectedCommitHash: string | null;
-	onFileSelect: (file: ChangedFile) => void;
+	onFileSelect: (file: ChangedFile, openInNewTab?: boolean) => void;
 	showStats?: boolean;
 	onStage?: (file: ChangedFile) => void;
 	onUnstage?: (file: ChangedFile) => void;
@@ -227,7 +227,7 @@ function TreeNodeComponent({
 			<FileItem
 				file={file}
 				isSelected={isSelected}
-				onClick={() => onFileSelect(file)}
+				onClick={(openInNewTab) => onFileSelect(file, openInNewTab)}
 				showStats={showStats}
 				level={level}
 				onStage={onStage ? () => onStage(file) : undefined}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileList/FileListTreeVirtualized.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileList/FileListTreeVirtualized.tsx
@@ -21,7 +21,7 @@ interface FileListTreeVirtualizedProps {
 	files: ChangedFile[];
 	selectedFile: ChangedFile | null;
 	selectedCommitHash: string | null;
-	onFileSelect: (file: ChangedFile) => void;
+	onFileSelect: (file: ChangedFile, openInNewTab?: boolean) => void;
 	showStats?: boolean;
 	onStage?: (file: ChangedFile) => void;
 	onUnstage?: (file: ChangedFile) => void;
@@ -287,7 +287,7 @@ export function FileListTreeVirtualized({
 									isSelected={
 										selectedFile?.path === row.file.path && !selectedCommitHash
 									}
-									onClick={() => onFileSelect(row.file)}
+									onClick={(openInNewTab) => onFileSelect(row.file, openInNewTab)}
 									showStats={showStats}
 									level={row.level}
 									onStage={onStage ? () => onStage(row.file) : undefined}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileList/FileListVirtualized.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileList/FileListVirtualized.tsx
@@ -11,7 +11,7 @@ interface FileListVirtualizedProps {
 	files: ChangedFile[];
 	selectedFile: ChangedFile | null;
 	selectedCommitHash: string | null;
-	onFileSelect: (file: ChangedFile) => void;
+	onFileSelect: (file: ChangedFile, openInNewTab?: boolean) => void;
 	showStats?: boolean;
 	onStage?: (file: ChangedFile) => void;
 	onUnstage?: (file: ChangedFile) => void;
@@ -83,7 +83,7 @@ export function FileListVirtualized({
 							<FileItem
 								file={file}
 								isSelected={isSelected}
-								onClick={() => onFileSelect(file)}
+								onClick={(openInNewTab) => onFileSelect(file, openInNewTab)}
 								showStats={showStats}
 								onStage={onStage ? () => onStage(file) : undefined}
 								onUnstage={onUnstage ? () => onUnstage(file) : undefined}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/hooks/useOrderedSections/useOrderedSections.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/hooks/useOrderedSections/useOrderedSections.tsx
@@ -34,13 +34,13 @@ interface UseOrderedSectionsInput {
 	projectId?: string;
 	isExpandedView?: boolean;
 	againstBaseFiles: ChangedFile[];
-	onAgainstBaseFileSelect: (file: ChangedFile) => void;
+	onAgainstBaseFileSelect: (file: ChangedFile, openInNewTab?: boolean) => void;
 	commitsWithFiles: CommitInfo[];
 	expandedCommits: Set<string>;
 	onCommitToggle: (commitHash: string) => void;
-	onCommitFileSelect: (file: ChangedFile, commitHash: string) => void;
+	onCommitFileSelect: (file: ChangedFile, commitHash: string, openInNewTab?: boolean) => void;
 	stagedFiles: ChangedFile[];
-	onStagedFileSelect: (file: ChangedFile) => void;
+	onStagedFileSelect: (file: ChangedFile, openInNewTab?: boolean) => void;
 	onUnstageFile: (file: ChangedFile) => void;
 	onUnstageFiles: (files: ChangedFile[]) => void;
 	onShowDiscardStagedDialog: () => void;
@@ -49,7 +49,7 @@ interface UseOrderedSectionsInput {
 	isUnstageAllPending: boolean;
 	isStagedActioning: boolean;
 	unstagedFiles: ChangedFile[];
-	onUnstagedFileSelect: (file: ChangedFile) => void;
+	onUnstagedFileSelect: (file: ChangedFile, openInNewTab?: boolean) => void;
 	onStageFile: (file: ChangedFile) => void;
 	onStageFiles: (files: ChangedFile[]) => void;
 	onDiscardFile: (file: ChangedFile) => void;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
@@ -133,7 +133,7 @@ export function RightSidebar() {
 	);
 
 	const handleFileOpenPane = useCallback(
-		(file: ChangedFile, category: ChangeCategory, commitHash?: string) => {
+		(file: ChangedFile, category: ChangeCategory, commitHash?: string, openInNewTab?: boolean) => {
 			if (!workspaceId || !worktreePath) return;
 			const absolutePath = toAbsoluteWorkspacePath(worktreePath, file.path);
 			addFileViewerPane(workspaceId, {
@@ -144,6 +144,7 @@ export function RightSidebar() {
 				oldPath: file.oldPath
 					? toAbsoluteWorkspacePath(worktreePath, file.oldPath)
 					: undefined,
+				openInNewTab,
 			});
 			invalidateFileContent(absolutePath);
 		},

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
@@ -132,6 +132,7 @@ export function RightSidebar() {
 		[workspaceId, worktreePath, trpcUtils],
 	);
 
+	/** Opens a changed file in the file viewer. When `openInNewTab` is true (cmd/ctrl+click), creates a new pinned tab. */
 	const handleFileOpenPane = useCallback(
 		(file: ChangedFile, category: ChangeCategory, commitHash?: string, openInNewTab?: boolean) => {
 			if (!workspaceId || !worktreePath) return;


### PR DESCRIPTION
Follow-up to #2544 which added cmd+click support for the **Files** sidebar. This PR extends the same behavior to the **Changes** sidebar.

## Summary
- Extends cmd/ctrl+click "open in new tab" behavior from the Files sidebar (#2544) to the **Changes** sidebar
- Threads `openInNewTab` through the full callback chain: `FileItem` → `FileList*` variants → `CommitItem` → `useOrderedSections` → `ChangesView` → `RightSidebar` → `addFileViewerPane`
- Adds JSDoc comments documenting the new `openInNewTab` parameter
- No store changes needed — the tabs store already supports `openInNewTab` from #2544

## Test plan
- [ ] Open the Changes sidebar with modified files
- [ ] Single-click a file → opens in preview pane (existing behavior, unchanged)
- [ ] Cmd+click (macOS) / Ctrl+click (Windows/Linux) a file → opens in a **new pinned tab**
- [ ] Verify across all change categories: against-base, committed, staged, unstaged
- [ ] Verify in both grouped and tree view modes