### PR TITLE
Add loading state while merging PRs

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ChangesHeader/components/PRButton/PRButton.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ChangesHeader/components/PRButton/PRButton.tsx
@@ -36,11 +36,18 @@ export function PRButton({
 	onRefresh,
 }: PRButtonProps) {
 	const mergePRMutation = electronTrpc.changes.mergePR.useMutation({
-		onSuccess: () => {
-			toast.success("PR merged successfully");
+		onMutate: () => {
+			const toastId = toast.loading("Merging PR...");
+			return { toastId };
+		},
+		onSuccess: (_data, _variables, context) => {
+			toast.success("PR merged successfully", { id: context?.toastId });
 			onRefresh();
 		},
-		onError: (error) => toast.error(`Merge failed: ${error.message}`),
+		onError: (error, _variables, context) =>
+			toast.error(`Merge failed: ${error.message}`, {
+				id: context?.toastId,
+			}),
 	});
 
 	const { createOrOpenPR, isPending: isCreateOrOpenPRPending } =
@@ -118,7 +125,10 @@ export function PRButton({
 	}
 
 	return (
-		<div className="flex items-center ml-auto rounded border border-border overflow-hidden">
+		<div
+			className="flex items-center ml-auto rounded border border-border overflow-hidden"
+			aria-busy={mergePRMutation.isPending}
+		>
 			<a
 				href={pr.url}
 				target="_blank"
@@ -137,8 +147,17 @@ export function PRButton({
 						type="button"
 						className="flex items-center px-1 py-0.5 hover:bg-accent transition-colors"
 						disabled={mergePRMutation.isPending}
+						aria-label={
+							mergePRMutation.isPending
+								? "Merging pull request"
+								: "Open merge options"
+						}
 					>
-						<VscChevronDown className="size-3 text-muted-foreground" />
+						{mergePRMutation.isPending ? (
+							<VscLoading className="size-3 animate-spin text-muted-foreground" />
+						) : (
+							<VscChevronDown className="size-3 text-muted-foreground" />
+						)}
 					</button>
 				</DropdownMenuTrigger>
 				<DropdownMenuContent align="end" className="w-44">


### PR DESCRIPTION
## Summary
- show a loading toast while a pull request merge is in flight
- reuse that toast for merge success and failure states
- show a spinner in the merge trigger while the request is pending

## Testing
- bunx biome check apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ChangesHeader/components/PRButton/PRButton.tsx
- bun run --cwd apps/desktop typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a loading state to PR merges so users get immediate feedback while a merge is in progress. The same toast updates on success or failure, and the merge menu shows a spinner and is disabled during the request.

- **New Features**
  - Show a "Merging PR..." loading toast that updates to success/failure.
  - Replace the chevron with a spinner and disable the merge trigger while pending.
  - Improve accessibility with aria-busy on the container and dynamic aria-labels.

<sup>Written for commit dcf28e5151eeb9f7c718236e261b331f8adb4ad6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual loading feedback with an animated spinning icon displayed during pull request merge operations
  * Improved toast notification handling to properly track and display merge operation status throughout the complete lifecycle
  * Enhanced accessibility with descriptive aria-labels that indicate merge state and functionality
  * Merge button is disabled while a merge operation is pending to prevent accidental duplicate submissions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->