### PR TITLE
fix(desktop): reuse existing file viewer tabs across workspace

### DIFF
--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -33,7 +33,6 @@ import {
 	createTabWithPane,
 	equalizeSplitPercentages,
 	extractPaneIdsFromLayout,
-	fileViewerTargetsMatch,
 	findReusableFileViewerPane,
 	generateId,
 	generateTabName,
@@ -726,15 +725,19 @@ export const useTabsStore = create<TabsStore>()(
 
 					const tabPaneIds = extractPaneIdsFromLayout(activeTab.layout);
 					const reuseExisting = options.reuseExisting ?? "workspace";
-					const existingFileViewerPane = findReusableFileViewerPane({
-						workspaceId,
-						activeTabId: activeTab.id,
-						tabs: state.tabs,
-						panes: state.panes,
-						tabHistoryStacks: state.tabHistoryStacks,
-						reuseExisting,
-						options,
-					});
+					const canReuseExistingPane =
+						!options.openInNewTab && reuseExisting !== "none";
+					const existingFileViewerPane = canReuseExistingPane
+						? findReusableFileViewerPane({
+								workspaceId,
+								activeTabId: activeTab.id,
+								tabs: state.tabs,
+								panes: state.panes,
+								tabHistoryStacks: state.tabHistoryStacks,
+								reuseExisting,
+								options,
+							})
+						: null;
 
 					if (existingFileViewerPane) {
 						const nextPane = applyFileViewerOpenOptionsToPane(
@@ -794,48 +797,11 @@ export const useTabsStore = create<TabsStore>()(
 
 					// If we found an unpinned (preview) file-viewer pane, reuse it
 					// (skip reuse when explicitly requesting a new tab, e.g. cmd+click)
-					if (fileViewerPanes.length > 0 && !options.openInNewTab) {
+					if (fileViewerPanes.length > 0 && canReuseExistingPane) {
 						const paneToReuse = fileViewerPanes[0];
-						const existingFileViewer = paneToReuse.fileViewer;
-						if (!existingFileViewer) {
+						if (!paneToReuse.fileViewer) {
 							// Should not happen due to filter above, but satisfy type checker
 							return "";
-						}
-
-						if (fileViewerTargetsMatch(existingFileViewer, options)) {
-							const nextPane = applyFileViewerOpenOptionsToPane(
-								paneToReuse,
-								options,
-							);
-							const nextPanes =
-								nextPane === paneToReuse
-									? state.panes
-									: {
-											...state.panes,
-											[paneToReuse.id]: nextPane,
-										};
-							const didPaneNameChange = nextPane.name !== paneToReuse.name;
-
-							set({
-								panes: nextPanes,
-								...(didPaneNameChange
-									? {
-											tabs: state.tabs.map((tab) =>
-												tab.id === paneToReuse.tabId
-													? {
-															...tab,
-															name: deriveTabName(nextPanes, tab.id),
-														}
-													: tab,
-											),
-										}
-									: {}),
-								focusedPaneIds: {
-									...state.focusedPaneIds,
-									[activeTab.id]: paneToReuse.id,
-								},
-							});
-							return paneToReuse.id;
 						}
 
 						// Different file - replace the preview pane content

--- a/apps/desktop/src/renderer/stores/tabs/types.ts
+++ b/apps/desktop/src/renderer/stores/tabs/types.ts
@@ -88,7 +88,7 @@ export interface AddFileViewerPaneOptions {
 	isPinned?: boolean;
 	/** If true, opens in a new tab instead of splitting the current tab */
 	openInNewTab?: boolean;
-	/** Controls whether an already-open matching file viewer is focused instead of opened again */
+	/** Controls whether file-viewer opens may reuse existing panes instead of always opening a fresh pane/tab */
 	reuseExisting?: FileViewerReuseScope;
 }
 

--- a/apps/desktop/src/renderer/stores/tabs/utils.test.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils.test.ts
@@ -6,6 +6,7 @@ import {
 	applyFileViewerOpenOptionsToPane,
 	buildMultiPaneLayout,
 	createChatPane,
+	fileViewerTargetsMatch,
 	findPanePath,
 	findReusableFileViewerPane,
 	getAdjacentPaneId,
@@ -519,6 +520,42 @@ describe("findReusableFileViewerPane", () => {
 		});
 
 		expect(result?.id).toBe("pane-c");
+	});
+});
+
+describe("fileViewerTargetsMatch", () => {
+	it("matches remote urls with only a trailing slash difference", () => {
+		expect(
+			fileViewerTargetsMatch(
+				{
+					filePath: "https://example.com/files/readme.md/",
+					diffCategory: undefined,
+					commitHash: undefined,
+				},
+				{
+					filePath: "https://example.com/files/readme.md",
+					diffCategory: undefined,
+					commitHash: undefined,
+				},
+			),
+		).toBe(true);
+	});
+
+	it("does not normalize distinct remote urls beyond the trailing slash", () => {
+		expect(
+			fileViewerTargetsMatch(
+				{
+					filePath: "https://example.com/files//readme.md",
+					diffCategory: undefined,
+					commitHash: undefined,
+				},
+				{
+					filePath: "https://example.com/files/readme.md",
+					diffCategory: undefined,
+					commitHash: undefined,
+				},
+			),
+		).toBe(false);
 	});
 });
 

--- a/apps/desktop/src/renderer/stores/tabs/utils.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils.ts
@@ -1,5 +1,9 @@
 import type { MosaicBranch, MosaicNode } from "react-mosaic-component";
-import { getPathBaseName, pathsMatch } from "shared/absolute-paths";
+import {
+	getPathBaseName,
+	isRemotePath,
+	pathsMatch,
+} from "shared/absolute-paths";
 import {
 	type ChangeCategory,
 	type FileStatus,
@@ -701,8 +705,19 @@ export const fileViewerTargetsMatch = (
 		return false;
 	}
 
+	const normalizeRemoteFileTarget = (value: string): string => {
+		return value.endsWith("/") && !value.endsWith("://")
+			? value.slice(0, -1)
+			: value;
+	};
+	const filePathsMatch =
+		isRemotePath(fileViewer.filePath) || isRemotePath(options.filePath)
+			? normalizeRemoteFileTarget(fileViewer.filePath) ===
+				normalizeRemoteFileTarget(options.filePath)
+			: pathsMatch(fileViewer.filePath, options.filePath);
+
 	return (
-		pathsMatch(fileViewer.filePath, options.filePath) &&
+		filePathsMatch &&
 		fileViewer.diffCategory === options.diffCategory &&
 		fileViewer.commitHash === options.commitHash
 	);


### PR DESCRIPTION
## Summary
- reuse existing file-viewer panes across the workspace instead of opening duplicate tabs for the same file target
- keep preview-pane replacement behavior for non-matching files in the active tab
- extract reusable pane activation and file-viewer matching helpers, and reuse the activation helper for browser panes

## Testing
- bun test apps/desktop/src/renderer/stores/tabs/utils.test.ts
- bunx biome check apps/desktop/src/renderer/stores/tabs/store.ts apps/desktop/src/renderer/stores/tabs/utils.ts apps/desktop/src/renderer/stores/tabs/utils.test.ts apps/desktop/src/renderer/stores/tabs/types.ts
- bunx tsc -p apps/desktop/tsconfig.json --noEmit *(currently blocked by existing repo issues: missing routeTree.gen and resources/public/file-icons/manifest.json)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reuses existing file-viewer panes to prevent duplicate tabs for the same file. Honors reuse scope, keeps preview-pane replace behavior, and makes focusing and tab naming consistent.

- **Bug Fixes**
  - Respect reuse scope during open, prefer most-recently-used panes, and skip reuse when `openInNewTab` is true.
  - Improve matching and state updates: match by path/`diffCategory`/`commitHash` (normalizes trailing slashes for remote URLs); preserve pinned state and user titles; apply `viewMode`/`line`/`column` only when provided; update the tab name only when it changes.
  - Correctly activate the pane’s tab, focus it, and acknowledge review status across all panes in the tab.

- **New Features**
  - Added `reuseExisting` to file open options: `none` | `active-tab` | `workspace` (default `workspace`).
  - Extracted helpers for matching, applying options, and activation, with tests covering MRU selection, option behavior, and remote URL normalization.

<sup>Written for commit 6cd1004b46d21eb7a27d5b3824adcc2608e31e78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable file viewer pane reuse scope with selectable reuse policies.

* **Improvements**
  * Centralized and more reliable pane activation, focus and history handling in workspaces.
  * Smarter reuse and naming behavior when opening files, preserving view mode, pin state and display names.
  * Improved file-target matching (handles remote URL trailing-slash normalization).

* **Tests**
  * Added tests covering reuse modes, target matching, option application, and activation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->