### PR TITLE
fix(desktop): sync plan gating with live subscriptions

### DIFF
--- a/apps/desktop/src/renderer/components/Paywall/usePaywall.ts
+++ b/apps/desktop/src/renderer/components/Paywall/usePaywall.ts
@@ -1,13 +1,11 @@
+import { useCurrentPlan } from "renderer/hooks/useCurrentPlan";
 import { authClient } from "renderer/lib/auth-client";
 import type { GatedFeature } from "./constants";
 import { paywall } from "./Paywall";
 
-type UserPlan = "free" | "pro" | "enterprise";
-
 export function usePaywall() {
 	const { data: session } = authClient.useSession();
-
-	const userPlan: UserPlan = (session?.session?.plan as UserPlan) ?? "free";
+	const userPlan = useCurrentPlan();
 
 	function hasAccess(feature: GatedFeature): boolean {
 		void feature;

--- a/apps/desktop/src/renderer/hooks/useCurrentPlan.test.ts
+++ b/apps/desktop/src/renderer/hooks/useCurrentPlan.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "bun:test";
+import { resolveCurrentPlan } from "./useCurrentPlan";
+
+describe("resolveCurrentPlan", () => {
+	it("prefers the live subscription plan over a stale session plan", () => {
+		expect(
+			resolveCurrentPlan({
+				subscriptionPlan: "pro",
+				sessionPlan: "free",
+				subscriptionsLoaded: true,
+			}),
+		).toBe("pro");
+	});
+
+	it("treats loaded subscriptions with no active plan as free", () => {
+		expect(
+			resolveCurrentPlan({
+				subscriptionPlan: null,
+				sessionPlan: "pro",
+				subscriptionsLoaded: true,
+			}),
+		).toBe("free");
+	});
+
+	it("falls back to the session plan while subscriptions are still loading", () => {
+		expect(
+			resolveCurrentPlan({
+				subscriptionPlan: null,
+				sessionPlan: "pro",
+				subscriptionsLoaded: false,
+			}),
+		).toBe("pro");
+	});
+
+	it("supports enterprise subscriptions", () => {
+		expect(
+			resolveCurrentPlan({
+				subscriptionPlan: "enterprise",
+				sessionPlan: "free",
+				subscriptionsLoaded: true,
+			}),
+		).toBe("enterprise");
+	});
+});

--- a/apps/desktop/src/renderer/hooks/useCurrentPlan.ts
+++ b/apps/desktop/src/renderer/hooks/useCurrentPlan.ts
@@ -1,0 +1,57 @@
+import { useLiveQuery } from "@tanstack/react-db";
+import { authClient } from "renderer/lib/auth-client";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+
+export type UserPlan = "free" | "pro" | "enterprise";
+
+interface ResolveCurrentPlanArgs {
+	subscriptionPlan?: string | null;
+	sessionPlan?: string | null;
+	subscriptionsLoaded: boolean;
+}
+
+function isPaidPlan(
+	plan: string | null | undefined,
+): plan is "pro" | "enterprise" {
+	return plan === "pro" || plan === "enterprise";
+}
+
+export function resolveCurrentPlan({
+	subscriptionPlan,
+	sessionPlan,
+	subscriptionsLoaded,
+}: ResolveCurrentPlanArgs): UserPlan {
+	if (isPaidPlan(subscriptionPlan)) {
+		return subscriptionPlan;
+	}
+
+	if (subscriptionsLoaded) {
+		return "free";
+	}
+
+	if (isPaidPlan(sessionPlan)) {
+		return sessionPlan;
+	}
+
+	return "free";
+}
+
+export function useCurrentPlan(): UserPlan {
+	const { data: session } = authClient.useSession();
+	const collections = useCollections();
+
+	const { data: subscriptionsData } = useLiveQuery(
+		(q) => q.from({ subscriptions: collections.subscriptions }),
+		[collections],
+	);
+
+	const activeSubscription = subscriptionsData?.find(
+		(subscription) => subscription.status === "active",
+	);
+
+	return resolveCurrentPlan({
+		subscriptionPlan: activeSubscription?.plan,
+		sessionPlan: session?.session?.plan,
+		subscriptionsLoaded: subscriptionsData !== undefined,
+	});
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/plans/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/plans/page.tsx
@@ -136,7 +136,7 @@ const COMPARISON_SECTIONS: ComparisonSection[] = [
 			},
 			{
 				label: "GitHub integration",
-				values: [true, true, true],
+				values: [null, true, true],
 			},
 			{
 				label: "Cloud workspaces",

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/members/components/MembersSettings/components/MemberActions/MemberActions.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/members/components/MembersSettings/components/MemberActions/MemberActions.tsx
@@ -19,6 +19,7 @@ import { toast } from "@superset/ui/sonner";
 import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import { HiEllipsisVertical, HiOutlineTrash } from "react-icons/hi2";
+import { useCurrentPlan } from "renderer/hooks/useCurrentPlan";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { authClient } from "renderer/lib/auth-client";
 import type { TeamMember } from "../../../../types";
@@ -37,12 +38,8 @@ export function MemberActions({
 	canRemove: boolean;
 }) {
 	const [isChangingRole, setIsChangingRole] = useState(false);
-	const { data: session, refetch: refetchSession } = authClient.useSession();
-	const plan = session?.session?.plan as
-		| "free"
-		| "pro"
-		| "enterprise"
-		| undefined;
+	const { refetch: refetchSession } = authClient.useSession();
+	const plan = useCurrentPlan();
 	const navigate = useNavigate();
 
 	const availableRoles = getAvailableRoleChanges(


### PR DESCRIPTION
## Summary
- derive desktop entitlements from the live subscriptions collection instead of a stale session snapshot
- reuse the shared plan resolver for paywall gating and member billing copy
- align the billing plans matrix so GitHub integration is no longer shown on Free

## Testing
- bun test apps/desktop/src/renderer/hooks/useCurrentPlan.test.ts
- bunx @biomejs/biome check apps/desktop/src/renderer/hooks/useCurrentPlan.ts apps/desktop/src/renderer/hooks/useCurrentPlan.test.ts apps/desktop/src/renderer/components/Paywall/usePaywall.ts apps/desktop/src/renderer/routes/_authenticated/settings/members/components/MembersSettings/components/MemberActions/MemberActions.tsx apps/desktop/src/renderer/routes/_authenticated/settings/billing/plans/page.tsx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync desktop plan gating with live subscriptions so entitlement checks and billing UI update in real time. Also hides GitHub integration on Free.

- **Bug Fixes**
  - Added `useCurrentPlan` and `resolveCurrentPlan` to prefer live subscription data, with session fallback while loading (tests included).
  - Switched paywall (`usePaywall`) and member actions to use the shared plan resolver.
  - Updated billing plans matrix to not show GitHub integration on Free.

<sup>Written for commit 9c17b6c31ae1f4df9bce9d22fee1cdf078fee045. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * GitHub integration feature availability in the billing plan comparison has been updated to accurately reflect what is included with each plan.

* **Improvements**
  * Enhanced plan information management with improved consistency and reliability in determining user plan status across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->