### PR TITLE
feat(desktop): make CMD+R reload configurable in keyboard shortcuts

### DIFF
--- a/apps/desktop/src/main/lib/menu.ts
+++ b/apps/desktop/src/main/lib/menu.ts
@@ -37,6 +37,7 @@ export function registerMenuHotkeyUpdates() {
 }
 
 export function createApplicationMenu() {
+	const reloadAccelerator = getMenuAccelerator("RELOAD_WINDOW");
 	const closeAccelerator = getMenuAccelerator("CLOSE_WINDOW");
 	const showHotkeysAccelerator = getMenuAccelerator("SHOW_HOTKEYS");
 	const openSettingsAccelerator = getMenuAccelerator("OPEN_SETTINGS");
@@ -57,7 +58,13 @@ export function createApplicationMenu() {
 		{
 			label: "View",
 			submenu: [
-				{ role: "reload" },
+				{
+					label: "Reload",
+					accelerator: reloadAccelerator,
+					click: () => {
+						BrowserWindow.getFocusedWindow()?.reload();
+					},
+				},
 				{ role: "forceReload" },
 				{ role: "toggleDevTools" },
 				{ type: "separator" },

--- a/apps/desktop/src/shared/hotkeys.ts
+++ b/apps/desktop/src/shared/hotkeys.ts
@@ -809,6 +809,14 @@ export const HOTKEYS = {
 		category: "Terminal",
 	}),
 
+	// Window
+	RELOAD_WINDOW: defineHotkey({
+		keys: "meta+r",
+		label: "Reload Window",
+		category: "Window",
+		description: "Reload the current window",
+	}),
+
 	// Help
 	OPEN_SETTINGS: defineHotkey({
 		keys: "meta+,",


### PR DESCRIPTION
## Summary
- Adds `RELOAD_WINDOW` hotkey entry (default `⌘R`) to the keyboard shortcuts settings
- Replaces the built-in Electron `role: "reload"` menu item with a custom one backed by the hotkeys system
- Users can now rebind or unassign `⌘R` from the Keyboard Shortcuts settings page

## Why
I'd like to use CMD+R as the shortcut for the run command instead of hot reload

## Test plan
- [ ] Open Settings → Keyboard Shortcuts, verify "Reload Window" appears under the Window category with ⌘R as the default
- [ ] Rebind ⌘R to a different action, verify reload no longer triggers on ⌘R
- [ ] Verify View → Reload menu item reflects the updated keybinding

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make ⌘R (Reload) configurable in Keyboard Shortcuts so users can rebind or unassign it. Replaces Electron’s built-in reload menu with a hotkey-backed action that keeps the View → Reload accelerator in sync.

<sup>Written for commit f598cdb30b089cc9b6fc0b3156650349d1f0b2aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced "Reload Window" hotkey with customizable keyboard binding (default: Meta+R on Mac)
  * Integrated platform-specific keyboard accelerators into the main application menu
  * Enhanced window management with quick reload capability accessible via keyboard shortcut and menu option
  * Hotkey binding automatically adapts to different operating systems

<!-- end of auto-generated comment: release notes by coderabbit.ai -->