### PR TITLE
feat(desktop): add deep link support for opening tabs in workspaces

### DIFF
--- a/.sisyphus/evidence/task-10-lsp.txt
+++ b/.sisyphus/evidence/task-10-lsp.txt
@@ -1,0 +1,1 @@
+LSP diagnostics: CLEAN (0 errors, 0 warnings)

--- a/.sisyphus/evidence/task-10-ssh-branch.txt
+++ b/.sisyphus/evidence/task-10-ssh-branch.txt
@@ -1,0 +1,20 @@
+30:import { removeWorktreeFromDisk, runTeardown } from "../utils/teardown";
+215:				if (workspace.type === "ssh") {
+219:					if (settingsRow?.teardownScript && workspace.sshConfig) {
+222:								"main/lib/ssh/script-executor"
+226:								settingsRow.teardownScript,
+227:								workspace.sshConfig,
+231:								"[workspace/delete] SSH teardown script failed:",
+237:					getWorkspaceRuntimeRegistry().removeRuntime(input.id);
+250:				let teardownPromise:
+257:						teardownPromise = runTeardown({
+265:							`[workspace/delete] Skipping teardown: worktree=${!!worktree}, project=${!!project}, pathExists=${worktree ? existsSync(worktree.path) : "N/A"}`,
+270:						`[workspace/delete] No teardown needed: type=${workspace.type}, worktreeId=${workspace.worktreeId ?? "null"}`,
+274:				const [terminalResult, teardownResult] = await Promise.all([
+276:					teardownPromise ?? Promise.resolve({ success: true as const }),
+279:				if (teardownResult && !teardownResult.success) {
+283:							teardownResult.error,
+288:							teardownResult.error,
+293:							error: `Teardown failed: ${teardownResult.error}`,
+294:							output: teardownResult.output,
+557:							const teardownResult = await runTeardown({

--- a/.sisyphus/evidence/task-6-procedures.txt
+++ b/.sisyphus/evidence/task-6-procedures.txt
@@ -1,0 +1,6 @@
+		getDevcontainerScript: publicProcedure.query(() => {
+		setDevcontainerScript: publicProcedure
+		getTeardownScript: publicProcedure.query(() => {
+		setTeardownScript: publicProcedure
+---
+All 4 procedures found in settings router

--- a/.sisyphus/evidence/task-6-typecheck.txt
+++ b/.sisyphus/evidence/task-6-typecheck.txt
@@ -1,0 +1,3 @@
+Desktop typecheck: all errors are pre-existing (panes, react-hotkeys-hook, better-auth modules)
+No errors related to SshSection, devcontainerScript, or teardownScript changes
+LSP diagnostics: clean on all 4 changed files

--- a/apps/desktop/kiran_docs/SSH_WORKSPACES.md
+++ b/apps/desktop/kiran_docs/SSH_WORKSPACES.md
@@ -1,0 +1,266 @@
+# SSH Workspaces
+
+SSH workspaces connect Superset's terminal to a remote devcontainer via SSH. All terminals run on the remote machine with session persistence via [zmx](https://zmx.sh).
+
+## Architecture
+
+```
+xterm.js (renderer)
+    ↕ tRPC stream subscription (IPC)
+node-pty (main process, local PTY)
+    ↕ SIGWINCH for resize
+ssh -tt (ControlMaster multiplexed)
+    ↕ remote PTY
+zmx attach <session-name> (session persistence)
+    ↕ zmx-managed PTY
+$SHELL (user's login shell)
+```
+
+### Key Design Decisions
+
+- **node-pty** wraps SSH in a real local PTY. This gives native resize (SIGWINCH forwarding) and proper terminal behavior.
+- **zmx** (not tmux) handles session persistence. zmx is transparent — no rendering layer, no escape sequence interference, native scrollback. tmux was tried first but caused resize/rendering conflicts with xterm.js.
+- **SSH ControlMaster** multiplexes all connections per workspace over a single TCP connection. One master, many channels.
+- **`stty intr undef quit undef susp undef`** before `exec ssh` — disables local signal character mapping so Ctrl+C/Z/\ pass through to the remote shell instead of killing the local SSH process.
+- **Direct SSH shell** — the user's shell runs inside zmx on the remote. On app restart, `zmx attach` reattaches to the existing session with full state restoration.
+
+## File Structure
+
+```
+apps/desktop/src/main/lib/ssh/
+├── types.ts                    # SshConnectionConfig, DevcontainerScriptInput/Output
+├── connection-manager.ts       # SSH ControlMaster lifecycle (start/stop/exec/spawnPty)
+├── zmx-manager.ts              # zmx session operations (hasSession/killSession/listSessions)
+├── ssh-terminal-manager.ts     # Core terminal runtime (createOrAttach/write/resize/kill/detach)
+├── script-executor.ts          # Devcontainer/teardown script execution
+├── reconnection.ts             # App startup cleanup (stale sockets, orphaned workspaces)
+├── *.test.ts                   # Unit tests for each module
+│
+apps/desktop/src/main/lib/workspace-runtime/
+├── ssh.ts                      # SshWorkspaceRuntime (wires connection + zmx + terminal managers)
+├── registry.ts                 # WorkspaceRuntimeRegistry (dispatches SSH vs local per workspace)
+├── types.ts                    # TerminalRuntime interface (added removeRuntime)
+│
+apps/desktop/src/lib/trpc/routers/
+├── terminal/terminal.ts        # Terminal router (paneWorkspaceMap for SSH routing)
+├── workspaces/procedures/
+│   ├── create.ts               # SSH workspace creation (devcontainer script execution)
+│   ├── delete.ts               # SSH workspace deletion (teardown + cleanup)
+│   └── git-status.ts           # getWorktreeInfo returns sshConfig for SSH workspaces
+├── settings/index.ts           # devcontainerScript/teardownScript settings procedures
+│
+apps/desktop/src/renderer/
+├── components/NewWorkspaceModal/
+│   └── PromptGroup.tsx         # SSH toggle checkbox in creation modal
+├── screens/main/components/
+│   ├── WorkspaceSidebar/WorkspaceListItem/
+│   │   ├── WorkspaceIcon.tsx   # Cloud icon for SSH workspaces
+│   │   └── WorkspaceListItem.tsx
+│   └── WorkspaceView/RightSidebar/
+│       └── SshConfigPanel/     # SSH config view/edit tab
+├── routes/_authenticated/settings/terminal/
+│   └── TerminalSettings/components/SshSection/  # Devcontainer/teardown script settings
+│
+packages/local-db/src/schema/
+├── schema.ts                   # sshConfig column on workspaces, script columns on settings
+├── zod.ts                      # sshWorkspaceConfigSchema, "ssh" in workspaceTypeSchema
+│
+packages/local-db/drizzle/
+└── 0039_add_ssh_workspace_columns.sql  # Migration for new columns
+```
+
+## How It Works
+
+### Creating an SSH Workspace
+
+1. User opens New Workspace modal, toggles "SSH" checkbox
+2. User fills in workspace name and branch (branch is passed to the devcontainer script)
+3. On submit, the `create` tRPC procedure:
+   - Reads the devcontainer script from global settings
+   - Resolves the repo URL via `git remote get-url origin`
+   - Runs the script via `sh -lc` (login shell, inherits user PATH)
+   - Script receives env vars: `SUPERSET_REPO_URL`, `SUPERSET_BRANCH`, `SUPERSET_BRANCH_NO_PREFIX`, `SUPERSET_NEW_BRANCH`, `SUPERSET_WORKSPACE_NAME`, `SUPERSET_WORKSPACE_ID`
+   - Script must print JSON to stdout: `{ host, port, user, workDir, identityFile?, containerName? }`
+   - JSON is validated against `sshWorkspaceConfigSchema`
+   - Workspace record created with `type: "ssh"`, `sshConfig: <parsed config>`
+
+### Opening a Terminal
+
+1. Terminal component mounts → `createOrAttach` tRPC mutation
+2. Terminal router resolves `getTerminalForWorkspace(workspaceId)` → gets `SshWorkspaceRuntime`
+3. `SshTerminalManager.createOrAttach()`:
+   - `connectionManager.ensureAlive()` — starts ControlMaster if not running
+   - `connectionManager.spawnPty()` — spawns `ssh -tt ... zmx attach <session-name>` inside node-pty
+   - zmx creates a new session (if first time) or reattaches (if existing)
+   - `pty.onData()` emits `data:${paneId}` events → stream subscription → renderer
+4. User types → renderer calls `write` → `pty.write(data)` → SSH → remote shell
+
+### Resize
+
+1. xterm.js fit addon detects container size change
+2. Renderer calls `resize` mutation with new cols/rows
+3. `SshTerminalManager.resize()` calls `pty.resize(cols, rows)`
+4. node-pty sends SIGWINCH to SSH process
+5. SSH forwards window-change request to remote
+6. Remote PTY resizes → zmx adjusts → shell redraws
+
+### Workspace Switch (detach/reattach)
+
+1. User switches to another workspace → Terminal component unmounts
+2. `detach()` sets `session.detached = true` — PTY stays alive, output keeps buffering
+3. User switches back → Terminal component mounts → `createOrAttach` called
+4. Finds existing alive session → `reattach()` — reconnects event listeners, provides buffered output as scrollback
+
+### App Restart
+
+1. App quits → all local PTY processes die, but remote zmx sessions stay alive
+2. App restarts → `reconcileOnStartup()` cleans stale ControlMaster sockets and orphaned workspace records
+3. User opens SSH workspace → `createOrAttach` runs
+4. `ensureAlive()` establishes new ControlMaster connection
+5. `spawnPty("zmx attach <session>")` — zmx reattaches to existing remote session
+6. Full terminal state restored (scrollback, running processes, cwd)
+
+### Closing a Terminal Tab
+
+1. `kill()` called → kills local PTY + calls `zmxManager.killSession()` to destroy remote session
+2. Emits `exit:${paneId}` event → renderer removes the tab
+
+### Deleting an SSH Workspace
+
+1. `delete` tRPC procedure detects `type === "ssh"`
+2. Kills all active terminal sessions (local PTYs + remote zmx sessions)
+3. Runs teardown script if configured (receives `SUPERSET_CONTAINER_NAME`, `SUPERSET_HOST`)
+4. `registry.removeRuntime(workspaceId)` — stops ControlMaster, cleans cache
+5. Deletes workspace record from DB
+
+## SSH Connection Details
+
+### ControlMaster
+
+- Socket path: `/tmp/superset-ssh/ctl-<12-char-workspace-id>` (short path to avoid Unix socket 104-byte limit)
+- Started with: `ssh -fN -o ControlMaster=auto -o ControlPath=... -o ServerAliveInterval=60 -o ServerAliveCountMax=3 -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new`
+- All subsequent SSH commands (exec, spawnPty) multiplex over this master
+
+### Ctrl+C Forwarding
+
+The local PTY's line discipline would normally interpret `\x03` as SIGINT and kill SSH. We disable this by running `stty intr undef quit undef susp undef` before `exec ssh`. This undefines the signal characters themselves (not just ISIG flag) — SSH can re-enable ISIG but can't restore undefined characters.
+
+### zmx
+
+- Installed at `~/.local/bin/zmx` on the remote
+- Session names: `superset-<sanitized-pane-id>`
+- `zmx attach <name>` — upsert: creates if new, reattaches if exists
+- `zmx kill <name>` — destroys session
+- `zmx list --short` — lists session names
+
+## Terminal Router Integration
+
+The terminal router (`terminal.ts`) needed significant changes to support per-workspace terminal routing:
+
+### paneWorkspaceMap
+
+A `Map<string, string>` (paneId → workspaceId) tracks which workspace owns each terminal pane. This enables routing pane-scoped operations (write, resize, kill) to the correct terminal runtime.
+
+- **Set before** `createOrAttach` await (not after) to avoid race conditions with cancellation
+- **Cleaned on failure** — if createOrAttach fails, the mapping is removed
+- **Cleaned on exit/disconnect** — stream subscription handlers remove entries
+- **`forgetWorkspace(workspaceId)`** — bulk cleanup when workspace is deleted/closed
+
+### Stream Subscription
+
+The `stream` subscription accepts `{ paneId, workspaceId }` (not just `paneId`) so it can resolve the correct terminal runtime immediately, without depending on paneWorkspaceMap timing.
+
+## Devcontainer Script Contract
+
+### Creation Script
+
+Shell command configured in Settings > Terminal > SSH Workspaces. Executed via login shell (`$SHELL -lc`).
+
+**Environment variables:**
+| Variable | Description |
+|---|---|
+| `SUPERSET_REPO_URL` | Git remote URL (e.g., `git@github.com:org/repo.git`) |
+| `SUPERSET_BRANCH` | Full branch name (e.g., `kirankunigiri/feature-x`) |
+| `SUPERSET_BRANCH_NO_PREFIX` | Branch without user prefix (e.g., `feature-x`) |
+| `SUPERSET_NEW_BRANCH` | `"1"` if creating new branch, `"0"` if existing |
+| `SUPERSET_WORKSPACE_NAME` | User-specified workspace name |
+| `SUPERSET_WORKSPACE_ID` | UUID of the workspace |
+
+**Required JSON output (stdout):**
+```json
+{
+  "host": "192.168.1.100",
+  "port": 22,
+  "user": "developer",
+  "workDir": "/home/dev/workspace",
+  "identityFile": "/path/to/key",
+  "containerName": "my-container-abc"
+}
+```
+
+### Teardown Script
+
+Shell command configured alongside the creation script. Runs on workspace deletion. Failures are non-fatal.
+
+**Environment variables:** `SUPERSET_CONTAINER_NAME`, `SUPERSET_HOST`
+
+## Database Schema
+
+### `workspaces` table (local SQLite)
+- `sshConfig` — `text("ssh_config", { mode: "json" })` — stores `SshWorkspaceConfig` JSON, nullable
+- `type` — `text` column, now accepts `"worktree" | "branch" | "ssh"`
+
+### `settings` table (local SQLite)
+- `devcontainerScript` — `text` — creation shell command
+- `teardownScript` — `text` — teardown shell command
+
+## Known Limitations
+
+- **zmx must be installed** on the remote at `~/.local/bin/zmx`. No auto-install mechanism.
+- **No auto-reconnection** on SSH connection drop. If the connection dies mid-session, the terminal shows an error. User must close and reopen the terminal tab to reconnect.
+- **`cancelCreateOrAttach` is a no-op** — SSH attaches can't be canceled mid-flight. zmx attach is atomic.
+- **V1 is terminals only** — no remote file browser, diff viewer, or git integration.
+- **`StrictHostKeyChecking=accept-new`** — first connection auto-trusts the host key without user confirmation.
+
+## Adding New Features
+
+### Adding a new SSH setting
+1. Add column to `settings` table in `packages/local-db/src/schema/schema.ts`
+2. Generate migration: `cd packages/local-db && bunx drizzle-kit generate --name="add_my_column"`
+3. Add tRPC get/set procedures in `apps/desktop/src/lib/trpc/routers/settings/index.ts`
+4. Add UI in `SshSection.tsx`
+
+### Adding a new field to SSH config
+1. Add to `SshConnectionConfig` in `types.ts`
+2. Add to `sshWorkspaceConfigSchema` in `packages/local-db/src/schema/zod.ts`
+3. Generate migration if the column shape changed
+4. Update `SshConfigPanel` UI
+5. Update `getWorktreeInfo` in `git-status.ts` to return the new field
+6. Update `WorkspaceHoverCard` if it should show in the hover preview
+
+### Supporting a different session persistence tool
+Replace `zmx-manager.ts` with a new manager implementing the same interface:
+- `hasSession(paneId): Promise<boolean>`
+- `killSession(paneId): Promise<void>`
+- `listSessions(): Promise<string[]>`
+- `sanitizeSessionName(paneId): string`
+
+Then update the `spawnPty` command in `ssh-terminal-manager.ts` to use the new tool's attach command.
+
+## Troubleshooting
+
+### Terminal shows "Connection lost. Reconnecting..."
+- SSH connection failed. Check if the remote host is reachable.
+- ControlMaster socket might be stale. Delete `/tmp/superset-ssh/ctl-*` and retry.
+
+### Terminal connects but Ctrl+C kills the session
+- The `stty intr undef` wrapper isn't working. Check `connection-manager.ts` `spawnPty` method.
+
+### Terminal doesn't resize properly
+- Resize goes through `node-pty → SIGWINCH → SSH → remote`. If SSH ControlMaster doesn't forward window-change, resize may not propagate.
+
+### "zmx: command not found" on remote
+- Install zmx: `curl -sL https://zmx.sh/a/zmx-0.4.2-linux-x86_64.tar.gz | tar xz -C ~/.local/bin`
+
+### Devcontainer script fails with exit code 127
+- The script command can't find a binary. The script runs via `$SHELL -lc` which sources your shell profile, but some PATH entries may not be available. Use full paths.

--- a/apps/desktop/scripts/patch-dev-protocol.ts
+++ b/apps/desktop/scripts/patch-dev-protocol.ts
@@ -186,17 +186,23 @@ export function main() {
 
 	const PROTOCOL_SCHEME = `superset-${workspaceName}`;
 	const BUNDLE_ID = `com.superset.desktop.${workspaceName}`;
-	const ELECTRON_DIST_DIR = resolve(
-		import.meta.dirname,
-		"../node_modules/electron/dist",
-	);
-	const ELECTRON_APP_PATH = resolve(ELECTRON_DIST_DIR, "Electron.app");
-	const PLIST_PATH = resolve(ELECTRON_APP_PATH, "Contents/Info.plist");
 
-	if (!existsSync(PLIST_PATH)) {
+	// Electron may be in apps/desktop/node_modules (non-hoisted) or the repo root node_modules (hoisted).
+	const candidates = [
+		resolve(import.meta.dirname, "../node_modules/electron/dist"),
+		resolve(import.meta.dirname, "../../../node_modules/electron/dist"),
+	];
+	const ELECTRON_DIST_DIR = candidates.find((dir) =>
+		existsSync(resolve(dir, "Electron.app/Contents/Info.plist")),
+	);
+
+	if (!ELECTRON_DIST_DIR) {
 		console.log("[patch-dev-protocol] Electron.app not found, skipping");
 		process.exit(0);
 	}
+
+	const ELECTRON_APP_PATH = resolve(ELECTRON_DIST_DIR, "Electron.app");
+	const PLIST_PATH = resolve(ELECTRON_APP_PATH, "Contents/Info.plist");
 
 	const DISPLAY_NAME = `Superset (${bundleDisplayWorkspaceName})`;
 
@@ -218,10 +224,7 @@ export function main() {
 		const isRenamed =
 			lstatSync(ELECTRON_APP_PATH).isSymbolicLink() &&
 			readlinkSync(ELECTRON_APP_PATH) === `${DISPLAY_NAME}.app`;
-		const electronPkgCheck = resolve(
-			import.meta.dirname,
-			"../node_modules/electron",
-		);
+		const electronPkgCheck = resolve(ELECTRON_DIST_DIR, "..");
 		const pathTxtCheck = resolve(electronPkgCheck, "path.txt");
 		let pathTxtCorrect = false;
 		try {
@@ -348,10 +351,7 @@ export function main() {
 	// Update the electron package's path.txt so electron-vite launches from the
 	// renamed .app directly (not through the Electron.app symlink). This ensures
 	// the invocation path contains the correct app name for macOS bundle resolution.
-	const electronPkgDir = resolve(
-		import.meta.dirname,
-		"../node_modules/electron",
-	);
+	const electronPkgDir = resolve(ELECTRON_DIST_DIR, "..");
 	const pathTxtPath = resolve(electronPkgDir, "path.txt");
 	const desiredPathTxt = `${DESIRED_APP_NAME}/Contents/MacOS/Electron`;
 	try {

--- a/apps/desktop/src/lib/trpc/routers/settings/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/index.ts
@@ -83,7 +83,7 @@ function isValidRingtoneId(ringtoneId: string): boolean {
 	return false;
 }
 
-function getSettings() {
+export function getSettings() {
 	let row = localDb.select().from(settings).get();
 	if (!row) {
 		row = localDb.insert(settings).values({ id: 1 }).returning().get();
@@ -922,6 +922,44 @@ export const createSettingsRouter = () => {
 					})
 					.run();
 
+				return { success: true };
+			}),
+
+		getDevcontainerScript: publicProcedure.query(() => {
+			const row = getSettings();
+			return row.devcontainerScript ?? null;
+		}),
+
+		setDevcontainerScript: publicProcedure
+			.input(z.object({ script: z.string().nullable() }))
+			.mutation(({ input }) => {
+				localDb
+					.insert(settings)
+					.values({ id: 1, devcontainerScript: input.script })
+					.onConflictDoUpdate({
+						target: settings.id,
+						set: { devcontainerScript: input.script },
+					})
+					.run();
+				return { success: true };
+			}),
+
+		getTeardownScript: publicProcedure.query(() => {
+			const row = getSettings();
+			return row.teardownScript ?? null;
+		}),
+
+		setTeardownScript: publicProcedure
+			.input(z.object({ script: z.string().nullable() }))
+			.mutation(({ input }) => {
+				localDb
+					.insert(settings)
+					.values({ id: 1, teardownScript: input.script })
+					.onConflictDoUpdate({
+						target: settings.id,
+						set: { teardownScript: input.script },
+					})
+					.run();
 				return { success: true };
 			}),
 

--- a/apps/desktop/src/lib/trpc/routers/terminal/terminal.ts
+++ b/apps/desktop/src/lib/trpc/routers/terminal/terminal.ts
@@ -48,11 +48,34 @@ const SAFE_ID = z
  */
 export const createTerminalRouter = () => {
 	const registry = getWorkspaceRuntimeRegistry();
-	const terminal = registry.getDefault().terminal;
+	const defaultTerminal = registry.getDefault().terminal;
+	const paneWorkspaceMap = new Map<string, string>();
+
+	function getTerminalForWorkspace(workspaceId: string) {
+		return registry.getForWorkspaceId(workspaceId).terminal;
+	}
+
+	function getTerminalForPane(paneId: string) {
+		const workspaceId = paneWorkspaceMap.get(paneId);
+		return workspaceId ? getTerminalForWorkspace(workspaceId) : defaultTerminal;
+	}
+
+	function forgetPaneWorkspace(paneId: string) {
+		paneWorkspaceMap.delete(paneId);
+	}
+
+	function forgetWorkspace(workspaceId: string) {
+		for (const [paneId, wsId] of paneWorkspaceMap.entries()) {
+			if (wsId === workspaceId) {
+				paneWorkspaceMap.delete(paneId);
+			}
+		}
+	}
+
 	if (DEBUG_TERMINAL) {
 		console.log(
 			"[Terminal Router] Using terminal runtime, capabilities:",
-			terminal.capabilities,
+			defaultTerminal.capabilities,
 		);
 	}
 
@@ -115,9 +138,12 @@ export const createTerminalRouter = () => {
 					requestedThemeType: themeType,
 					persistedThemeState: appState.data.themeState,
 				});
+				const workspaceTerminal = getTerminalForWorkspace(workspaceId);
+				const previousWorkspaceId = paneWorkspaceMap.get(paneId);
+				paneWorkspaceMap.set(paneId, workspaceId);
 
 				try {
-					const result = await terminal.createOrAttach({
+					const result = await workspaceTerminal.createOrAttach({
 						paneId,
 						requestId,
 						joinPending,
@@ -157,6 +183,12 @@ export const createTerminalRouter = () => {
 						snapshot: result.snapshot,
 					};
 				} catch (error) {
+					if (previousWorkspaceId) {
+						paneWorkspaceMap.set(paneId, previousWorkspaceId);
+					} else {
+						forgetPaneWorkspace(paneId);
+					}
+
 					const isKilledError =
 						error instanceof TerminalKilledError ||
 						(error instanceof Error &&
@@ -204,7 +236,7 @@ export const createTerminalRouter = () => {
 				}),
 			)
 			.mutation(({ input }) => {
-				terminal.cancelCreateOrAttach(input);
+				getTerminalForPane(input.paneId).cancelCreateOrAttach(input);
 				return { success: true };
 			}),
 
@@ -218,6 +250,7 @@ export const createTerminalRouter = () => {
 			)
 			.mutation(async ({ input }) => {
 				const shouldThrow = input.throwOnError ?? false;
+				const terminal = getTerminalForPane(input.paneId);
 				try {
 					terminal.write(input);
 				} catch (error) {
@@ -252,7 +285,7 @@ export const createTerminalRouter = () => {
 		ackColdRestore: publicProcedure
 			.input(z.object({ paneId: z.string() }))
 			.mutation(({ input }) => {
-				terminal.ackColdRestore(input.paneId);
+				getTerminalForPane(input.paneId).ackColdRestore(input.paneId);
 			}),
 
 		resize: publicProcedure
@@ -265,7 +298,7 @@ export const createTerminalRouter = () => {
 				}),
 			)
 			.mutation(async ({ input }) => {
-				terminal.resize(input);
+				getTerminalForPane(input.paneId).resize(input);
 			}),
 
 		signal: publicProcedure
@@ -276,7 +309,7 @@ export const createTerminalRouter = () => {
 				}),
 			)
 			.mutation(async ({ input }) => {
-				terminal.signal(input);
+				getTerminalForPane(input.paneId).signal(input);
 			}),
 
 		kill: publicProcedure
@@ -286,7 +319,12 @@ export const createTerminalRouter = () => {
 				}),
 			)
 			.mutation(async ({ input }) => {
-				await terminal.kill(input);
+				const terminal = getTerminalForPane(input.paneId);
+				try {
+					await terminal.kill(input);
+				} finally {
+					forgetPaneWorkspace(input.paneId);
+				}
 			}),
 
 		detach: publicProcedure
@@ -296,7 +334,12 @@ export const createTerminalRouter = () => {
 				}),
 			)
 			.mutation(async ({ input }) => {
-				terminal.detach(input);
+				const terminal = getTerminalForPane(input.paneId);
+				try {
+					terminal.detach(input);
+				} finally {
+					forgetPaneWorkspace(input.paneId);
+				}
 			}),
 
 		clearScrollback: publicProcedure
@@ -306,17 +349,17 @@ export const createTerminalRouter = () => {
 				}),
 			)
 			.mutation(async ({ input }) => {
-				await terminal.clearScrollback(input);
+				await getTerminalForPane(input.paneId).clearScrollback(input);
 			}),
 
 		listDaemonSessions: publicProcedure.query(async () => {
-			const { sessions } = await terminal.management.listSessions();
+			const { sessions } = await defaultTerminal.management.listSessions();
 			return { sessions };
 		}),
 
 		killAllDaemonSessions: publicProcedure.mutation(async () => {
 			const client = getTerminalHostClient();
-			const before = await terminal.management.listSessions();
+			const before = await defaultTerminal.management.listSessions();
 			const beforeIds = before.sessions.map((s) => s.sessionId);
 			console.log(
 				"[killAllDaemonSessions] Before kill:",
@@ -327,7 +370,7 @@ export const createTerminalRouter = () => {
 
 			if (beforeIds.length > 0) {
 				const results = await Promise.allSettled(
-					beforeIds.map((paneId) => terminal.kill({ paneId })),
+					beforeIds.map((paneId) => defaultTerminal.kill({ paneId })),
 				);
 				for (const [index, result] of results.entries()) {
 					if (result.status === "rejected") {
@@ -381,7 +424,7 @@ export const createTerminalRouter = () => {
 		killDaemonSessionsForWorkspace: publicProcedure
 			.input(z.object({ workspaceId: z.string() }))
 			.mutation(async ({ input }) => {
-				const { sessions } = await terminal.management.listSessions();
+				const { sessions } = await defaultTerminal.management.listSessions();
 				const toKill = sessions.filter(
 					(session) => session.workspaceId === input.workspaceId,
 				);
@@ -389,7 +432,7 @@ export const createTerminalRouter = () => {
 				if (toKill.length > 0) {
 					const paneIds = toKill.map((session) => session.sessionId);
 					const results = await Promise.allSettled(
-						paneIds.map((paneId) => terminal.kill({ paneId })),
+						paneIds.map((paneId) => defaultTerminal.kill({ paneId })),
 					);
 					for (const [index, result] of results.entries()) {
 						if (result.status === "rejected") {
@@ -406,11 +449,13 @@ export const createTerminalRouter = () => {
 					}
 				}
 
+				forgetWorkspace(input.workspaceId);
+
 				return { killedCount: toKill.length };
 			}),
 
 		clearTerminalHistory: publicProcedure.mutation(async () => {
-			await terminal.management.resetHistoryPersistence();
+			await defaultTerminal.management.resetHistoryPersistence();
 			return { success: true };
 		}),
 
@@ -422,7 +467,7 @@ export const createTerminalRouter = () => {
 		getSession: publicProcedure
 			.input(z.string())
 			.query(async ({ input: paneId }) => {
-				return terminal.getSession(paneId);
+				return getTerminalForPane(paneId).getSession(paneId);
 			}),
 
 		getWorkspaceCwd: publicProcedure
@@ -450,8 +495,19 @@ export const createTerminalRouter = () => {
 			}),
 
 		stream: publicProcedure
-			.input(z.string())
-			.subscription(({ input: paneId }) => {
+			.input(
+				z.union([
+					z.string(),
+					z.object({ paneId: z.string(), workspaceId: z.string() }),
+				]),
+			)
+			.subscription(({ input }) => {
+				const paneId = typeof input === "string" ? input : input.paneId;
+				const workspaceId =
+					typeof input === "string" ? undefined : input.workspaceId;
+				const terminal = workspaceId
+					? getTerminalForWorkspace(workspaceId)
+					: getTerminalForPane(paneId);
 				return observable<
 					| { type: "data"; data: string }
 					| {
@@ -484,11 +540,13 @@ export const createTerminalRouter = () => {
 						signal?: number,
 						reason?: "killed" | "exited" | "error",
 					) => {
+						forgetPaneWorkspace(paneId);
 						// Don't emit.complete() - paneId is reused across restarts, completion would strand listeners
 						emit.next({ type: "exit", exitCode, signal, reason });
 					};
 
 					const onDisconnect = (reason: string) => {
+						forgetPaneWorkspace(paneId);
 						emit.next({ type: "disconnect", reason });
 					};
 

--- a/apps/desktop/src/lib/trpc/routers/terminal/utils/workspace-terminal-context.ts
+++ b/apps/desktop/src/lib/trpc/routers/terminal/utils/workspace-terminal-context.ts
@@ -52,9 +52,11 @@ function loadWorkspaceTerminalContext(
 	return {
 		workspace: row.workspace,
 		workspacePath:
-			row.workspace.type === "branch"
-				? (row.mainRepoPath ?? undefined)
-				: (row.worktreePath ?? undefined),
+			row.workspace.type === "ssh"
+				? (row.workspace.sshConfig?.workDir ?? undefined)
+				: row.workspace.type === "branch"
+					? (row.mainRepoPath ?? undefined)
+					: (row.worktreePath ?? undefined),
 		rootPath: row.mainRepoPath ?? undefined,
 	};
 }

--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
@@ -1,10 +1,17 @@
-import { projects, workspaces, worktrees } from "@superset/local-db";
+import {
+	type SshWorkspaceConfig,
+	projects,
+	workspaces,
+	worktrees,
+} from "@superset/local-db";
+import { TRPCError } from "@trpc/server";
 import { and, eq, isNull, not } from "drizzle-orm";
 import { track } from "main/lib/analytics";
 import { localDb } from "main/lib/local-db";
 import { workspaceInitManager } from "main/lib/workspace-init-manager";
 import { z } from "zod";
 import { publicProcedure, router } from "../../..";
+import { getSettings } from "../../settings";
 import { attemptWorkspaceAutoRenameFromPrompt } from "../utils/ai-name";
 import { resolveWorkspaceBaseBranch } from "../utils/base-branch";
 import { setBranchBaseConfig } from "../utils/base-branch-config";
@@ -266,6 +273,7 @@ export const createCreateProcedures = () => {
 						name: z.string().optional(),
 						prompt: z.string().optional(),
 						branchName: z.string().optional(),
+						ssh: z.boolean().optional(),
 						compareBaseBranch: z.string().optional(),
 						sourceWorkspaceId: z.string().optional(),
 						useExistingBranch: z.boolean().optional(),
@@ -316,6 +324,103 @@ export const createCreateProcedures = () => {
 					throw new Error(
 						`Source workspace "${sourceWorkspace.id}" is not backed by a worktree`,
 					);
+				}
+
+				if (input.ssh === true) {
+					const workspaceId = crypto.randomUUID();
+					const settingsRow = getSettings();
+					const devcontainerScript = settingsRow.devcontainerScript?.trim();
+
+					if (!devcontainerScript) {
+						throw new TRPCError({
+							code: "BAD_REQUEST",
+							message:
+								"No devcontainer script configured. Go to Settings > Terminal > SSH Workspaces to configure one.",
+						});
+					}
+
+					const sshBranch =
+						input.branchName?.trim() ||
+						project.defaultBranch ||
+						project.workspaceBaseBranch ||
+						"main";
+
+					let repoUrl = project.mainRepoPath;
+					try {
+						const { execSync } = await import("node:child_process");
+						repoUrl = execSync("git remote get-url origin", {
+							cwd: project.mainRepoPath,
+							encoding: "utf8",
+						}).trim();
+					} catch {
+						repoUrl = project.mainRepoPath;
+					}
+
+					const { ScriptExecutor } = await import(
+						"main/lib/ssh/script-executor"
+					);
+					const executor = new ScriptExecutor();
+
+					const isNewBranch = !input.useExistingBranch;
+
+					const sshBranchNoPrefix = sshBranch.includes("/")
+						? sshBranch.slice(sshBranch.indexOf("/") + 1)
+						: sshBranch;
+
+					let sshConfig: SshWorkspaceConfig;
+					try {
+						sshConfig = await executor.runDevcontainerScript(
+							devcontainerScript,
+							{
+								repo: repoUrl,
+								branch: sshBranch,
+								branchNoPrefix: sshBranchNoPrefix,
+								newBranch: isNewBranch,
+								workspaceName: input.name ?? "workspace",
+								workspaceId,
+							},
+						);
+					} catch (error) {
+						throw new TRPCError({
+							code: "INTERNAL_SERVER_ERROR",
+							message: `Devcontainer script failed: ${error instanceof Error ? error.message : String(error)}`,
+						});
+					}
+
+					const maxTabOrder = getMaxProjectChildTabOrder(input.projectId);
+					const workspace = localDb
+						.insert(workspaces)
+						.values({
+							id: workspaceId,
+							projectId: project.id,
+							type: "ssh",
+							name: input.name ?? "SSH Workspace",
+							branch: sshBranch,
+							worktreeId: null,
+							sshConfig,
+							tabOrder: maxTabOrder + 1,
+						})
+						.returning()
+						.get();
+
+					setLastActiveWorkspace(workspace.id);
+					activateProject(project);
+
+					track("workspace_created", {
+						workspace_id: workspace.id,
+						project_id: project.id,
+						branch: sshBranch,
+						type: "ssh",
+					});
+
+					return {
+						workspace,
+						initialCommands: null,
+						worktreePath: sshConfig.workDir,
+						projectId: project.id,
+						isInitializing: false,
+						wasExisting: false,
+					};
 				}
 
 				let existingBranchName: string | undefined;

--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/delete.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/delete.ts
@@ -1,7 +1,7 @@
 import { existsSync, realpathSync } from "node:fs";
 import { resolve } from "node:path";
 import type { SelectWorktree } from "@superset/local-db";
-import { worktrees } from "@superset/local-db";
+import { settings, worktrees } from "@superset/local-db";
 import { eq } from "drizzle-orm";
 import { track } from "main/lib/analytics";
 import { localDb } from "main/lib/local-db";
@@ -212,6 +212,41 @@ export const createDeleteProcedures = () => {
 					.getForWorkspaceId(input.id)
 					.terminal.killByWorkspaceId(input.id);
 
+				if (workspace.type === "ssh") {
+					await terminalPromise.catch(() => {});
+
+					const settingsRow = localDb.select().from(settings).get();
+					if (settingsRow?.teardownScript && workspace.sshConfig) {
+						try {
+							const { ScriptExecutor } = await import(
+								"main/lib/ssh/script-executor"
+							);
+							const executor = new ScriptExecutor();
+							await executor.runTeardownScript(
+								settingsRow.teardownScript,
+								workspace.sshConfig,
+							);
+						} catch (e) {
+							console.warn(
+								"[workspace/delete] SSH teardown script failed:",
+								e instanceof Error ? e.message : String(e),
+							);
+						}
+					}
+
+					getWorkspaceRuntimeRegistry().removeRuntime(input.id);
+
+					deleteWorkspace(input.id);
+					if (project) {
+						hideProjectIfNoWorkspaces(workspace.projectId);
+					}
+
+					track("workspace_deleted", { workspace_id: input.id });
+					workspaceInitManager.clearJob(input.id);
+
+					return { success: true };
+				}
+
 				let teardownPromise:
 					| Promise<{ success: boolean; error?: string; output?: string }>
 					| undefined;
@@ -351,14 +386,19 @@ export const createDeleteProcedures = () => {
 			.input(z.object({ id: z.string() }))
 			.mutation(async ({ input }) => {
 				const workspace = getWorkspace(input.id);
+				const runtimeRegistry = getWorkspaceRuntimeRegistry();
 
 				if (!workspace) {
 					throw new Error("Workspace not found");
 				}
 
-				const terminalResult = await getWorkspaceRuntimeRegistry()
+				const terminalResult = await runtimeRegistry
 					.getForWorkspaceId(input.id)
 					.terminal.killByWorkspaceId(input.id);
+
+				if (workspace.type === "ssh") {
+					runtimeRegistry.removeRuntime(input.id);
+				}
 
 				deleteWorkspace(input.id);
 				hideProjectIfNoWorkspaces(workspace.projectId);

--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts
@@ -274,6 +274,24 @@ export const createGitStatusProcedures = () => {
 					return null;
 				}
 
+				if (workspace.type === "ssh" && workspace.sshConfig) {
+					return {
+						worktreeName: workspace.name,
+						branchName: workspace.branch,
+						createdAt: workspace.createdAt,
+						gitStatus: null,
+						githubStatus: null,
+						sshConfig: {
+							host: workspace.sshConfig.host,
+							port: workspace.sshConfig.port,
+							user: workspace.sshConfig.user,
+							workDir: workspace.sshConfig.workDir,
+							identityFile: workspace.sshConfig.identityFile,
+							containerName: workspace.sshConfig.containerName,
+						},
+					};
+				}
+
 				const worktree = workspace.worktreeId
 					? getWorktree(workspace.worktreeId)
 					: null;

--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/query.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/query.ts
@@ -64,7 +64,7 @@ export const createQueryProcedures = () => {
 
 				return {
 					...workspace,
-					type: workspace.type as "worktree" | "branch",
+					type: workspace.type as "worktree" | "branch" | "ssh",
 					worktreePath: getWorkspacePath(workspace) ?? "",
 					project: project
 						? {
@@ -102,7 +102,7 @@ export const createQueryProcedures = () => {
 				sectionId: string | null;
 				worktreeId: string | null;
 				worktreePath: string;
-				type: "worktree" | "branch";
+				type: "worktree" | "branch" | "ssh";
 				branch: string;
 				name: string;
 				tabOrder: number;
@@ -217,7 +217,7 @@ export const createQueryProcedures = () => {
 					const item: WorkspaceItem = {
 						...workspace,
 						sectionId: workspace.sectionId ?? null,
-						type: workspace.type as "worktree" | "branch",
+						type: workspace.type as "worktree" | "branch" | "ssh",
 						worktreePath,
 						isUnread: workspace.isUnread ?? false,
 						isUnnamed: workspace.isUnnamed ?? false,

--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/status.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/status.ts
@@ -1,4 +1,9 @@
-import { workspaceSections, workspaces, worktrees } from "@superset/local-db";
+import {
+	sshWorkspaceConfigSchema,
+	workspaceSections,
+	workspaces,
+	worktrees,
+} from "@superset/local-db";
 import { and, eq, isNull, not } from "drizzle-orm";
 import { localDb } from "main/lib/local-db";
 import { z } from "zod";
@@ -187,6 +192,33 @@ export const createStatusProcedures = () => {
 				setLastActiveWorkspace(input.workspaceId);
 
 				return { success: true, workspaceId: input.workspaceId };
+			}),
+
+		updateSshConfig: publicProcedure
+			.input(
+				z.object({
+					id: z.string(),
+					sshConfig: sshWorkspaceConfigSchema,
+				}),
+			)
+			.mutation(({ input }) => {
+				const workspace = getWorkspaceNotDeleting(input.id);
+				if (!workspace) {
+					throw new Error(
+						`Workspace ${input.id} not found or is being deleted`,
+					);
+				}
+				if (workspace.type !== "ssh") {
+					throw new Error(`Workspace ${input.id} is not an SSH workspace`);
+				}
+
+				localDb
+					.update(workspaces)
+					.set({ sshConfig: input.sshConfig })
+					.where(eq(workspaces.id, input.id))
+					.run();
+
+				return { success: true };
 			}),
 
 		syncBranch: publicProcedure

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/worktree.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/worktree.ts
@@ -1,5 +1,11 @@
-import { projects, type SelectWorkspace, worktrees } from "@superset/local-db";
-import { eq } from "drizzle-orm";
+import path from "node:path";
+import {
+	projects,
+	type SelectWorkspace,
+	workspaces,
+	worktrees,
+} from "@superset/local-db";
+import { eq, isNull } from "drizzle-orm";
 import { localDb } from "main/lib/local-db";
 
 /**
@@ -40,4 +46,39 @@ export function getWorkspacePath(workspace: SelectWorkspace): string | null {
 	}
 
 	return null;
+}
+
+/**
+ * Finds a workspace whose filesystem path matches (or is a parent of) the given cwd.
+ * Prefers the longest (most specific) match when multiple workspaces match.
+ */
+export function resolveWorkspaceByPath(cwd: string): SelectWorkspace | null {
+	const allWorkspaces = localDb
+		.select()
+		.from(workspaces)
+		.where(isNull(workspaces.deletingAt))
+		.all();
+
+	let bestMatch: SelectWorkspace | null = null;
+	let bestMatchLength = 0;
+
+	const normalizedCwd = path.resolve(cwd);
+
+	for (const ws of allWorkspaces) {
+		const wsPath = getWorkspacePath(ws);
+		if (!wsPath) continue;
+
+		const normalizedWsPath = path.resolve(wsPath);
+		if (
+			normalizedCwd === normalizedWsPath ||
+			normalizedCwd.startsWith(`${normalizedWsPath}${path.sep}`)
+		) {
+			if (normalizedWsPath.length > bestMatchLength) {
+				bestMatch = ws;
+				bestMatchLength = normalizedWsPath.length;
+			}
+		}
+	}
+
+	return bestMatch;
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { settings } from "@superset/local-db";
+import { eq } from "drizzle-orm";
 import {
 	app,
 	BrowserWindow,
@@ -32,6 +33,7 @@ import { getHostServiceManager } from "./lib/host-service-manager";
 import { localDb } from "./lib/local-db";
 import { ensureProjectIconsDir, getProjectIconPath } from "./lib/project-icons";
 import { initSentry } from "./lib/sentry";
+import { sshReconnectionManager } from "./lib/ssh/reconnection";
 import {
 	prewarmTerminalRuntime,
 	reconcileDaemonSessions,
@@ -357,6 +359,12 @@ if (!gotTheLock) {
 		await loadWebviewBrowserExtension();
 
 		// Must happen before renderer restore runs
+		await sshReconnectionManager.reconcileOnStartup().catch((error) => {
+			console.warn(
+				"[main] SSH reconciliation failed:",
+				error instanceof Error ? error.message : String(error),
+			);
+		});
 		await reconcileDaemonSessions();
 		prewarmTerminalRuntime();
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -17,6 +17,7 @@ import {
 	parseAuthDeepLink,
 } from "lib/trpc/routers/auth/utils/auth-functions";
 import { applyShellEnvToProcess } from "lib/trpc/routers/workspaces/utils/shell-env";
+import { resolveWorkspaceByPath } from "lib/trpc/routers/workspaces/utils/worktree";
 import {
 	DEFAULT_CONFIRM_ON_QUIT,
 	PLATFORM,
@@ -78,6 +79,68 @@ async function processDeepLink(url: string): Promise<void> {
 		} else {
 			console.error("[main] Auth deep link failed:", result.error);
 		}
+		return;
+	}
+
+	// Handle open-tab deep links: superset://open-tab?type=webview&url=...&cwd=...
+	try {
+		const parsed = new URL(url);
+		const action = parsed.hostname || parsed.pathname.replace(/^\//, "");
+
+		if (action === "open-tab") {
+			const type = parsed.searchParams.get("type");
+			const tabUrl = parsed.searchParams.get("url");
+			const cwd = parsed.searchParams.get("cwd");
+
+			if (!type || !tabUrl || !cwd) {
+				console.warn(
+					"[main] open-tab deep link missing required params (type, url, cwd)",
+				);
+				return;
+			}
+
+			if (type !== "webview") {
+				console.warn(
+					`[main] open-tab deep link rejected unsupported type: ${type}`,
+				);
+				return;
+			}
+
+			// Security: only allow http/https URLs
+			const urlScheme = new URL(tabUrl).protocol;
+			if (urlScheme !== "http:" && urlScheme !== "https:") {
+				console.warn(
+					`[main] open-tab deep link rejected URL with scheme: ${urlScheme}`,
+				);
+				return;
+			}
+
+			const focus = parsed.searchParams.get("focus") === "true";
+
+			const workspace = resolveWorkspaceByPath(cwd);
+			if (!workspace) {
+				console.warn(
+					`[main] open-tab deep link: no workspace found for cwd: ${cwd}`,
+				);
+				return;
+			}
+
+			if (focus) {
+				focusMainWindow();
+			}
+			const windows = BrowserWindow.getAllWindows();
+			if (windows.length > 0) {
+				windows[0].webContents.send("deep-link-open-tab", {
+					workspaceId: workspace.id,
+					type,
+					url: tabUrl,
+					focus,
+				});
+			}
+			return;
+		}
+	} catch (error) {
+		console.warn("[main] Failed to process open-tab deep link:", error);
 		return;
 	}
 

--- a/apps/desktop/src/main/lib/ssh/connection-manager.test.ts
+++ b/apps/desktop/src/main/lib/ssh/connection-manager.test.ts
@@ -1,0 +1,210 @@
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	mock,
+	spyOn,
+} from "bun:test";
+import { EventEmitter } from "node:events";
+import type { ChildProcess } from "node:child_process";
+import type { SshConnectionConfig } from "./types";
+
+const baseConfig: SshConnectionConfig = {
+	host: "test.example.com",
+	port: 2222,
+	user: "dev",
+	workDir: "/workspace",
+};
+
+const configWithKey: SshConnectionConfig = {
+	...baseConfig,
+	identityFile: "/tmp/key",
+};
+
+function createMockChild(opts?: {
+	emitStdout?: string;
+	emitStderr?: string;
+	exitCode?: number;
+}) {
+	const child = new EventEmitter() as EventEmitter & {
+		stdin: EventEmitter & { write: () => void; end: () => void };
+		stdout: EventEmitter;
+		stderr: EventEmitter;
+		kill: () => boolean;
+	};
+	child.stdin = Object.assign(new EventEmitter(), {
+		write: () => {},
+		end: () => {},
+	});
+	child.stdout = new EventEmitter();
+	child.stderr = new EventEmitter();
+	child.kill = () => true;
+
+	setTimeout(() => {
+		if (opts?.emitStdout)
+			child.stdout.emit("data", Buffer.from(opts.emitStdout));
+		if (opts?.emitStderr)
+			child.stderr.emit("data", Buffer.from(opts.emitStderr));
+		child.emit("close", opts?.exitCode ?? 0);
+	}, 5);
+
+	return child as unknown as ChildProcess;
+}
+
+let SshConnectionManager: typeof import("./connection-manager").SshConnectionManager;
+let spawnCalls: Array<{ binary: string; args: string[] }>;
+const spawnMock = mock((..._args: unknown[]) => createMockChild());
+
+describe("SshConnectionManager", () => {
+	beforeAll(async () => {
+		const childProcessModule = await import("node:child_process");
+		spyOn(childProcessModule, "spawn").mockImplementation(((
+			...args: unknown[]
+		) => {
+			spawnCalls.push({
+				binary: args[0] as string,
+				args: args[1] as string[],
+			});
+			return spawnMock(...args);
+		}) as typeof childProcessModule.spawn);
+
+		mock.module("electron", () => ({
+			app: {
+				getPath: (name: string) => `/tmp/superset-test-${name}`,
+			},
+		}));
+
+		({ SshConnectionManager } = await import("./connection-manager"));
+	});
+
+	afterAll(() => {
+		mock.restore();
+	});
+
+	beforeEach(() => {
+		spawnCalls = [];
+		spawnMock.mockImplementation(() => createMockChild());
+	});
+
+	describe("constructor", () => {
+		it("sets controlDir under /tmp/superset-ssh", () => {
+			const mgr = new SshConnectionManager(baseConfig, "ws-abc");
+			expect(mgr.controlDir).toBe("/tmp/superset-ssh");
+		});
+
+		it("sets controlPath using the short workspace id", () => {
+			const mgr = new SshConnectionManager(baseConfig, "ws-abc");
+			expect(mgr.controlPath).toBe("/tmp/superset-ssh/ctl-wsabc");
+		});
+
+		it("does NOT place controlPath under .ssh", () => {
+			const mgr = new SshConnectionManager(baseConfig, "ws-abc");
+			expect(mgr.controlPath).not.toContain("/.ssh/");
+		});
+	});
+
+	describe("SSH args construction", () => {
+		it("includes ControlPath with workspaceId", async () => {
+			const mgr = new SshConnectionManager(baseConfig, "ws-123");
+			await mgr.exec("whoami");
+
+			const args = spawnCalls[0]!.args;
+			const controlPathArg = args.find((a) => a.startsWith("ControlPath="));
+			expect(controlPathArg).toBeDefined();
+			expect(controlPathArg).toBe("ControlPath=/tmp/superset-ssh/ctl-ws123");
+		});
+
+		it("includes ServerAliveInterval=60", async () => {
+			const mgr = new SshConnectionManager(baseConfig, "ws-123");
+			await mgr.exec("whoami");
+
+			const args = spawnCalls[0]!.args;
+			expect(args).toContain("ServerAliveInterval=60");
+		});
+
+		it("includes ConnectTimeout=10", async () => {
+			const mgr = new SshConnectionManager(baseConfig, "ws-123");
+			await mgr.exec("whoami");
+
+			const args = spawnCalls[0]!.args;
+			expect(args).toContain("ConnectTimeout=10");
+		});
+
+		it("includes port from config", async () => {
+			const mgr = new SshConnectionManager(baseConfig, "ws-123");
+			await mgr.exec("whoami");
+
+			const args = spawnCalls[0]!.args;
+			const portIdx = args.indexOf("-p");
+			expect(portIdx).toBeGreaterThan(-1);
+			expect(args[portIdx + 1]).toBe("2222");
+		});
+
+		it("includes user@host", async () => {
+			const mgr = new SshConnectionManager(baseConfig, "ws-123");
+			await mgr.exec("whoami");
+
+			const args = spawnCalls[0]!.args;
+			expect(args).toContain("dev@test.example.com");
+		});
+
+		it("includes -i flag when identityFile is set", async () => {
+			const mgr = new SshConnectionManager(configWithKey, "ws-123");
+			await mgr.exec("whoami");
+
+			const args = spawnCalls[0]!.args;
+			const iIdx = args.indexOf("-i");
+			expect(iIdx).toBeGreaterThan(-1);
+			expect(args[iIdx + 1]).toBe("/tmp/key");
+		});
+
+		it("does NOT include -i flag when identityFile is not set", async () => {
+			const mgr = new SshConnectionManager(baseConfig, "ws-123");
+			await mgr.exec("whoami");
+
+			const args = spawnCalls[0]!.args;
+			expect(args).not.toContain("-i");
+		});
+
+		it("appends the command after -- separator", async () => {
+			const mgr = new SshConnectionManager(baseConfig, "ws-123");
+			await mgr.exec("ls -la");
+
+			const args = spawnCalls[0]!.args;
+			const dashDashIdx = args.indexOf("--");
+			expect(dashDashIdx).toBeGreaterThan(-1);
+			expect(args[dashDashIdx + 1]).toBe("ls -la");
+		});
+	});
+
+	describe("exec", () => {
+		it("resolves with stdout, stderr, and exitCode", async () => {
+			spawnMock.mockImplementationOnce(() =>
+				createMockChild({
+					emitStdout: "hello",
+					emitStderr: "warning",
+					exitCode: 0,
+				}),
+			);
+
+			const mgr = new SshConnectionManager(baseConfig, "ws-123");
+			const result = await mgr.exec("echo hello");
+
+			expect(result.stdout).toBe("hello");
+			expect(result.stderr).toBe("warning");
+			expect(result.exitCode).toBe(0);
+		});
+	});
+
+	describe("spawn", () => {
+		it("uses -tt flag for PTY allocation", () => {
+			const mgr = new SshConnectionManager(baseConfig, "ws-123");
+			mgr.spawn("bash");
+
+			expect(spawnCalls[0]!.args).toContain("-tt");
+		});
+	});
+});

--- a/apps/desktop/src/main/lib/ssh/connection-manager.ts
+++ b/apps/desktop/src/main/lib/ssh/connection-manager.ts
@@ -1,0 +1,287 @@
+import {
+	type ChildProcess,
+	spawn as childProcessSpawn,
+	execFile,
+} from "node:child_process";
+import { existsSync, mkdirSync, readdirSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import type { IPty } from "node-pty";
+import * as pty from "node-pty";
+import type { SshConnectionConfig } from "./types";
+
+const SSH_BINARY = "ssh";
+const START_TIMEOUT_MS = 15_000;
+const RETRY_DELAYS_MS = [1_000, 2_000];
+
+export class SshConnectionError extends Error {
+	constructor(
+		message: string,
+		public readonly cause?: Error,
+	) {
+		super(message);
+		this.name = "SshConnectionError";
+	}
+}
+
+export class SshConnectionManager {
+	readonly controlDir: string;
+	readonly controlPath: string;
+
+	constructor(
+		private readonly config: SshConnectionConfig,
+		private readonly workspaceId: string,
+	) {
+		// Use /tmp to keep socket paths short — Unix sockets have ~104 byte path limit.
+		// App Support paths (especially on macOS) are too long.
+		const shortId = workspaceId.replace(/-/g, "").slice(0, 12);
+		this.controlDir = join("/tmp", "superset-ssh");
+		this.controlPath = join(this.controlDir, `ctl-${shortId}`);
+		mkdirSync(this.controlDir, { recursive: true });
+	}
+
+	private buildBaseArgs(): string[] {
+		return [
+			"-o",
+			`ControlPath=${this.controlPath}`,
+			"-o",
+			"ServerAliveInterval=60",
+			"-o",
+			"ServerAliveCountMax=3",
+			"-o",
+			"ConnectTimeout=10",
+			"-o",
+			"StrictHostKeyChecking=accept-new",
+			"-p",
+			String(this.config.port),
+			...(this.config.identityFile ? ["-i", this.config.identityFile] : []),
+			`${this.config.user}@${this.config.host}`,
+		];
+	}
+
+	async start(): Promise<void> {
+		const args = ["-fN", "-o", "ControlMaster=auto", ...this.buildBaseArgs()];
+
+		await new Promise<void>((resolve, reject) => {
+			const child = childProcessSpawn(SSH_BINARY, args, {
+				stdio: ["ignore", "pipe", "pipe"],
+			});
+			let settled = false;
+			let stderr = "";
+
+			const timeoutId = setTimeout(() => {
+				if (settled) return;
+				settled = true;
+				child.kill();
+				reject(new SshConnectionError("SSH connection start timed out"));
+			}, START_TIMEOUT_MS);
+
+			child.stderr?.on("data", (chunk: Buffer | string) => {
+				stderr += chunk.toString();
+			});
+
+			child.once("error", (error) => {
+				if (settled) return;
+				settled = true;
+				clearTimeout(timeoutId);
+				reject(new SshConnectionError("Failed to start SSH connection", error));
+			});
+
+			child.once("exit", (code) => {
+				if (settled) return;
+				settled = true;
+				clearTimeout(timeoutId);
+				if (code === 0) {
+					resolve();
+					return;
+				}
+
+				reject(
+					new SshConnectionError(
+						stderr.trim() || `SSH exited with code ${code ?? "unknown"}`,
+					),
+				);
+			});
+		});
+	}
+
+	async isAlive(): Promise<boolean> {
+		try {
+			await this.execFileChecked(["-O", "check", ...this.buildBaseArgs()]);
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	async stop(): Promise<void> {
+		try {
+			await this.execFileChecked(["-O", "exit", ...this.buildBaseArgs()]);
+		} catch {}
+
+		try {
+			unlinkSync(this.controlPath);
+		} catch {}
+	}
+
+	async exec(
+		command: string,
+	): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+		const args = [...this.buildBaseArgs(), "--", command];
+		return new Promise((resolve, reject) => {
+			const child = childProcessSpawn(SSH_BINARY, args, {
+				stdio: ["pipe", "pipe", "pipe"],
+			});
+			let stdout = "";
+			let stderr = "";
+
+			child.stdout?.on("data", (chunk: Buffer | string) => {
+				stdout += chunk.toString();
+			});
+			child.stderr?.on("data", (chunk: Buffer | string) => {
+				stderr += chunk.toString();
+			});
+
+			child.once("error", (error) => {
+				reject(new SshConnectionError("Failed to execute SSH command", error));
+			});
+
+			child.once("close", (code) => {
+				resolve({
+					stdout,
+					stderr,
+					exitCode: code ?? -1,
+				});
+			});
+		});
+	}
+
+	spawn(command: string): ChildProcess {
+		return childProcessSpawn(
+			SSH_BINARY,
+			["-tt", ...this.buildBaseArgs(), "--", command],
+			{
+				stdio: ["pipe", "pipe", "pipe"],
+			},
+		);
+	}
+
+	spawnPty(command: string, opts: { cols: number; rows: number }): IPty {
+		const sshArgs = ["-tt", ...this.buildBaseArgs(), "--", command];
+		const sshCmd = [SSH_BINARY, ...sshArgs]
+			.map((a) => `'${a.replaceAll("'", `'\\''`)}'`)
+			.join(" ");
+		return pty.spawn(
+			"/bin/sh",
+			[
+				"-c",
+				`stty intr undef quit undef susp undef 2>/dev/null; exec ${sshCmd}`,
+			],
+			{
+				name: "xterm-256color",
+				cols: opts.cols,
+				rows: opts.rows,
+				cwd: process.env.HOME,
+			},
+		);
+	}
+
+	async ensureAlive(): Promise<void> {
+		let lastError: Error | undefined;
+
+		for (let attempt = 0; attempt < RETRY_DELAYS_MS.length + 1; attempt++) {
+			if (await this.isAlive()) {
+				return;
+			}
+
+			try {
+				await this.start();
+				return;
+			} catch (error) {
+				lastError = error instanceof Error ? error : new Error(String(error));
+			}
+
+			const delay = RETRY_DELAYS_MS[attempt];
+			if (delay) {
+				await this.sleep(delay);
+			}
+		}
+
+		throw new SshConnectionError(
+			`SSH connection failed after 3 attempts${lastError ? `: ${lastError.message}` : ""}`,
+			lastError,
+		);
+	}
+
+	static async cleanupStale(_userData?: string): Promise<void> {
+		const controlDir = join("/tmp", "superset-ssh");
+		if (!existsSync(controlDir)) {
+			return;
+		}
+
+		let entries: string[] = [];
+		try {
+			entries = readdirSync(controlDir);
+		} catch {
+			return;
+		}
+
+		for (const entry of entries) {
+			if (!entry.startsWith("ctl-")) {
+				continue;
+			}
+
+			const socketPath = join(controlDir, entry);
+			try {
+				await new Promise<void>((resolve, reject) => {
+					execFile(
+						SSH_BINARY,
+						["-O", "check", "-o", `ControlPath=${socketPath}`, "dummy@dummy"],
+						(error) => {
+							if (error) {
+								reject(error);
+								return;
+							}
+							resolve();
+						},
+					);
+				});
+			} catch {
+				try {
+					unlinkSync(socketPath);
+				} catch {}
+			}
+		}
+	}
+
+	private execFileChecked(
+		args: string[],
+	): Promise<{ stdout: string; stderr: string }> {
+		return new Promise((resolve, reject) => {
+			execFile(SSH_BINARY, args, (error, stdout, stderr) => {
+				if (error) {
+					reject(new SshConnectionError(stderr.trim() || error.message, error));
+					return;
+				}
+
+				resolve({ stdout, stderr });
+			});
+		});
+	}
+
+	private getControlSocketFiles(): string[] {
+		if (!existsSync(this.controlDir)) {
+			return [];
+		}
+
+		const prefix = `ctl-${this.workspaceId}-`;
+		return readdirSync(this.controlDir)
+			.filter((entry) => entry.startsWith(prefix))
+			.map((entry) => join(this.controlDir, entry));
+	}
+
+	private sleep(ms: number): Promise<void> {
+		return new Promise((resolve) => {
+			setTimeout(resolve, ms);
+		});
+	}
+}

--- a/apps/desktop/src/main/lib/ssh/reconnection.ts
+++ b/apps/desktop/src/main/lib/ssh/reconnection.ts
@@ -1,0 +1,50 @@
+import { sshWorkspaceConfigSchema, workspaces } from "@superset/local-db";
+import { and, eq, isNotNull, isNull } from "drizzle-orm";
+import { app } from "electron";
+import { localDb } from "main/lib/local-db";
+import { SshConnectionManager } from "./connection-manager";
+
+export class SshReconnectionManager {
+	async reconcileOnStartup(): Promise<void> {
+		const userData = app.getPath("userData");
+		await SshConnectionManager.cleanupStale(userData);
+
+		const orphanedResult = localDb
+			.delete(workspaces)
+			.where(and(eq(workspaces.type, "ssh"), isNull(workspaces.sshConfig)))
+			.run();
+
+		if (orphanedResult.changes > 0) {
+			console.warn(
+				`[SshReconnectionManager] Deleted ${orphanedResult.changes} orphaned SSH workspace(s)`,
+			);
+		}
+
+		const sshWorkspaces = localDb
+			.select({
+				id: workspaces.id,
+				sshConfig: workspaces.sshConfig,
+			})
+			.from(workspaces)
+			.where(and(eq(workspaces.type, "ssh"), isNotNull(workspaces.sshConfig)))
+			.all();
+
+		for (const workspace of sshWorkspaces) {
+			try {
+				const config = sshWorkspaceConfigSchema.parse(workspace.sshConfig);
+				const connectionManager = new SshConnectionManager(
+					config,
+					workspace.id,
+				);
+				await connectionManager.isAlive();
+			} catch (error) {
+				console.warn(
+					`[SshReconnectionManager] Failed to inspect workspace ${workspace.id} during startup reconciliation:`,
+					error,
+				);
+			}
+		}
+	}
+}
+
+export const sshReconnectionManager = new SshReconnectionManager();

--- a/apps/desktop/src/main/lib/ssh/script-executor.test.ts
+++ b/apps/desktop/src/main/lib/ssh/script-executor.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { chmodSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	ScriptExecutionError,
+	ScriptExecutor,
+	ScriptOutputError,
+} from "./script-executor";
+import type { DevcontainerScriptInput, SshConnectionConfig } from "./types";
+
+function createTempScript(content: string): string {
+	const path = join(
+		tmpdir(),
+		`test-script-${Date.now()}-${Math.random().toString(36).slice(2)}.sh`,
+	);
+	writeFileSync(path, `#!/bin/bash\n${content}`);
+	chmodSync(path, 0o755);
+	return path;
+}
+
+const baseInput: DevcontainerScriptInput = {
+	repo: "https://github.com/test/repo",
+	branch: "main",
+	workspaceName: "test-ws",
+	workspaceId: "ws-123",
+};
+
+const baseTeardownConfig: SshConnectionConfig = {
+	host: "test.example.com",
+	port: 2222,
+	user: "dev",
+	workDir: "/workspace",
+	containerName: "test-container",
+};
+
+describe("ScriptExecutor", () => {
+	let executor: ScriptExecutor;
+	const tempScripts: string[] = [];
+
+	beforeEach(() => {
+		executor = new ScriptExecutor();
+	});
+
+	afterEach(() => {
+		for (const script of tempScripts) {
+			try {
+				unlinkSync(script);
+			} catch {}
+		}
+		tempScripts.length = 0;
+	});
+
+	describe("runDevcontainerScript", () => {
+		it("parses valid JSON output correctly", async () => {
+			const validOutput = JSON.stringify({
+				host: "remote.example.com",
+				port: 2222,
+				user: "dev",
+				workDir: "/home/dev/workspace",
+			});
+
+			const script = createTempScript(`echo '${validOutput}'`);
+			tempScripts.push(script);
+
+			const result = await executor.runDevcontainerScript(script, baseInput);
+
+			expect(result.host).toBe("remote.example.com");
+			expect(result.port).toBe(2222);
+			expect(result.user).toBe("dev");
+			expect(result.workDir).toBe("/home/dev/workspace");
+		});
+
+		it("parses output with optional fields", async () => {
+			const validOutput = JSON.stringify({
+				host: "remote.example.com",
+				port: 2222,
+				user: "dev",
+				workDir: "/workspace",
+				identityFile: "/tmp/id_rsa",
+				containerName: "my-container",
+			});
+
+			const script = createTempScript(`echo '${validOutput}'`);
+			tempScripts.push(script);
+
+			const result = await executor.runDevcontainerScript(script, baseInput);
+
+			expect(result.identityFile).toBe("/tmp/id_rsa");
+			expect(result.containerName).toBe("my-container");
+		});
+
+		it("throws ScriptExecutionError on non-zero exit", async () => {
+			const script = createTempScript(
+				'echo "something went wrong" >&2\nexit 1',
+			);
+			tempScripts.push(script);
+
+			try {
+				await executor.runDevcontainerScript(script, baseInput);
+				expect.unreachable("Should have thrown");
+			} catch (err) {
+				expect(err).toBeInstanceOf(ScriptExecutionError);
+				const error = err as ScriptExecutionError;
+				expect(error.stderr).toContain("something went wrong");
+				expect(error.exitCode).toBe(1);
+			}
+		});
+
+		it("throws ScriptOutputError on invalid JSON output", async () => {
+			const script = createTempScript('echo "not valid json"');
+			tempScripts.push(script);
+
+			try {
+				await executor.runDevcontainerScript(script, baseInput);
+				expect.unreachable("Should have thrown");
+			} catch (err) {
+				expect(err).toBeInstanceOf(ScriptOutputError);
+				const error = err as ScriptOutputError;
+				expect(error.rawOutput).toContain("not valid json");
+			}
+		});
+
+		it("throws ScriptOutputError when JSON doesn't match schema", async () => {
+			const invalidSchema = JSON.stringify({ foo: "bar" });
+			const script = createTempScript(`echo '${invalidSchema}'`);
+			tempScripts.push(script);
+
+			try {
+				await executor.runDevcontainerScript(script, baseInput);
+				expect.unreachable("Should have thrown");
+			} catch (err) {
+				expect(err).toBeInstanceOf(ScriptOutputError);
+			}
+		});
+
+		it("calls progress callback with stderr lines", async () => {
+			const validOutput = JSON.stringify({
+				host: "remote.example.com",
+				port: 2222,
+				user: "dev",
+				workDir: "/workspace",
+			});
+
+			const script = createTempScript(
+				`echo "step 1" >&2\necho "step 2" >&2\necho '${validOutput}'`,
+			);
+			tempScripts.push(script);
+
+			const progressLines: string[] = [];
+			await executor.runDevcontainerScript(script, baseInput, (line) => {
+				progressLines.push(line);
+			});
+
+			expect(progressLines.length).toBeGreaterThan(0);
+			const joined = progressLines.join("\n");
+			expect(joined).toContain("step 1");
+			expect(joined).toContain("step 2");
+		});
+	});
+
+	describe("runTeardownScript", () => {
+		it("resolves without error on success", async () => {
+			const script = createTempScript("exit 0");
+			tempScripts.push(script);
+
+			await executor.runTeardownScript(script, baseTeardownConfig);
+		});
+
+		it("resolves without error on non-zero exit (never throws)", async () => {
+			const script = createTempScript('echo "teardown failed" >&2\nexit 1');
+			tempScripts.push(script);
+
+			await executor.runTeardownScript(script, baseTeardownConfig);
+		});
+
+		it("resolves without error for non-existent script", async () => {
+			await executor.runTeardownScript(
+				"/nonexistent/script.sh",
+				baseTeardownConfig,
+			);
+		});
+
+		it("calls progress callback with stderr lines", async () => {
+			const script = createTempScript('echo "cleaning up" >&2\nexit 0');
+			tempScripts.push(script);
+
+			const progressLines: string[] = [];
+			await executor.runTeardownScript(script, baseTeardownConfig, (line) => {
+				progressLines.push(line);
+			});
+
+			const joined = progressLines.join("\n");
+			expect(joined).toContain("cleaning up");
+		});
+	});
+});

--- a/apps/desktop/src/main/lib/ssh/script-executor.ts
+++ b/apps/desktop/src/main/lib/ssh/script-executor.ts
@@ -1,0 +1,255 @@
+import { spawn } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { sshWorkspaceConfigSchema } from "@superset/local-db";
+import {
+	getCommandShellArgs,
+	getShellEnv,
+} from "main/lib/agent-setup/shell-wrappers";
+import { buildSafeEnv, sanitizeEnv } from "main/lib/terminal/env";
+import { SUPERSET_DIR_NAME } from "shared/constants";
+import type {
+	DevcontainerScriptInput,
+	DevcontainerScriptOutput,
+	SshConnectionConfig,
+} from "./types";
+
+export class ScriptError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "ScriptError";
+	}
+}
+
+export class ScriptExecutionError extends ScriptError {
+	constructor(
+		message: string,
+		public readonly stderr: string,
+		public readonly exitCode: number,
+	) {
+		super(message);
+		this.name = "ScriptExecutionError";
+	}
+}
+
+export class ScriptTimeoutError extends ScriptError {
+	constructor(timeoutMs: number) {
+		super(`Script timed out after ${timeoutMs}ms`);
+		this.name = "ScriptTimeoutError";
+	}
+}
+
+export class ScriptOutputError extends ScriptError {
+	constructor(
+		message: string,
+		public readonly rawOutput: string,
+	) {
+		super(message);
+		this.name = "ScriptOutputError";
+	}
+}
+
+const DEVCONTAINER_TIMEOUT_MS = 300_000;
+const TEARDOWN_TIMEOUT_MS = 120_000;
+
+function getShellConfig() {
+	const shell =
+		process.env.SHELL ||
+		(process.platform === "darwin" ? "/bin/zsh" : "/bin/bash");
+	const supersetHomeDir =
+		process.env.SUPERSET_HOME_DIR || join(homedir(), SUPERSET_DIR_NAME);
+	const shellWrapperPaths = {
+		BIN_DIR: join(supersetHomeDir, "bin"),
+		ZSH_DIR: join(supersetHomeDir, "zsh"),
+		BASH_DIR: join(supersetHomeDir, "bash"),
+	};
+	return { shell, shellWrapperPaths };
+}
+
+export class ScriptExecutor {
+	runDevcontainerScript(
+		script: string,
+		input: DevcontainerScriptInput,
+		onProgress?: (line: string) => void,
+	): Promise<DevcontainerScriptOutput> {
+		return new Promise((resolve, reject) => {
+			const { shell, shellWrapperPaths } = getShellConfig();
+			const baseEnv = buildSafeEnv(sanitizeEnv(process.env) || {});
+			const wrapperEnv = getShellEnv(shell, shellWrapperPaths);
+			const args = getCommandShellArgs(shell, script, shellWrapperPaths);
+
+			const child = spawn(shell, args, {
+				env: {
+					...baseEnv,
+					...wrapperEnv,
+					SUPERSET_REPO_URL: input.repo,
+					SUPERSET_BRANCH: input.branch,
+					SUPERSET_BRANCH_NO_PREFIX: input.branchNoPrefix,
+					SUPERSET_NEW_BRANCH: input.newBranch ? "1" : "0",
+					SUPERSET_WORKSPACE_NAME: input.workspaceName,
+					SUPERSET_WORKSPACE_ID: input.workspaceId,
+				},
+			});
+
+			let stdoutData = "";
+			let stderrData = "";
+			let settled = false;
+
+			const timeout = setTimeout(() => {
+				if (settled) return;
+				settled = true;
+				child.kill("SIGKILL");
+				reject(new ScriptTimeoutError(DEVCONTAINER_TIMEOUT_MS));
+			}, DEVCONTAINER_TIMEOUT_MS);
+
+			child.stdout.on("data", (chunk: Buffer) => {
+				stdoutData += chunk.toString();
+			});
+
+			child.stderr.on("data", (chunk: Buffer) => {
+				const text = chunk.toString();
+				stderrData += text;
+				if (onProgress) {
+					for (const line of text.split("\n")) {
+						if (line) onProgress(line);
+					}
+				}
+			});
+
+			child.on("error", (err) => {
+				clearTimeout(timeout);
+				if (settled) return;
+				settled = true;
+				reject(
+					new ScriptExecutionError(
+						`Failed to start script: ${err.message}`,
+						stderrData,
+						-1,
+					),
+				);
+			});
+
+			child.on("close", (exitCode) => {
+				clearTimeout(timeout);
+				if (settled) return;
+				settled = true;
+
+				if (exitCode !== 0) {
+					reject(
+						new ScriptExecutionError(
+							`Script failed with exit code ${exitCode}`,
+							stderrData,
+							exitCode ?? 1,
+						),
+					);
+					return;
+				}
+
+				let parsed: unknown;
+				try {
+					parsed = JSON.parse(stdoutData);
+				} catch {
+					reject(
+						new ScriptOutputError(
+							"Script output is not valid JSON",
+							stdoutData,
+						),
+					);
+					return;
+				}
+
+				const result = sshWorkspaceConfigSchema.safeParse(parsed);
+				if (!result.success) {
+					reject(
+						new ScriptOutputError(
+							`Script output does not match expected schema: ${result.error.message}`,
+							stdoutData,
+						),
+					);
+					return;
+				}
+
+				resolve(result.data as DevcontainerScriptOutput);
+			});
+		});
+	}
+
+	runTeardownScript(
+		script: string,
+		config: SshConnectionConfig,
+		onProgress?: (line: string) => void,
+	): Promise<void> {
+		return new Promise((resolve) => {
+			let child: ReturnType<typeof spawn>;
+			try {
+				const { shell, shellWrapperPaths } = getShellConfig();
+				const baseEnv = buildSafeEnv(sanitizeEnv(process.env) || {});
+				const wrapperEnv = getShellEnv(shell, shellWrapperPaths);
+				const args = getCommandShellArgs(shell, script, shellWrapperPaths);
+
+				child = spawn(shell, args, {
+					env: {
+						...baseEnv,
+						...wrapperEnv,
+						SUPERSET_CONTAINER_NAME: config.containerName ?? "",
+						SUPERSET_HOST: config.host,
+					},
+				});
+			} catch (err) {
+				console.warn(
+					"Teardown script failed:",
+					err instanceof Error ? err.message : String(err),
+				);
+				resolve();
+				return;
+			}
+
+			let stderrData = "";
+			let settled = false;
+
+			const timeout = setTimeout(() => {
+				if (settled) return;
+				settled = true;
+				child.kill("SIGKILL");
+				console.warn(
+					"Teardown script failed:",
+					`Script timed out after ${TEARDOWN_TIMEOUT_MS}ms`,
+				);
+				resolve();
+			}, TEARDOWN_TIMEOUT_MS);
+
+			child.stderr?.on("data", (chunk: Buffer) => {
+				const text = chunk.toString();
+				stderrData += text;
+				if (onProgress) {
+					for (const line of text.split("\n")) {
+						if (line) onProgress(line);
+					}
+				}
+			});
+
+			child.on("error", (err) => {
+				clearTimeout(timeout);
+				if (settled) return;
+				settled = true;
+				console.warn("Teardown script failed:", err.message);
+				resolve();
+			});
+
+			child.on("close", (exitCode) => {
+				clearTimeout(timeout);
+				if (settled) return;
+				settled = true;
+
+				if (exitCode !== 0) {
+					console.warn(
+						"Teardown script failed:",
+						`Script exited with code ${exitCode}. stderr: ${stderrData}`,
+					);
+				}
+
+				resolve();
+			});
+		});
+	}
+}

--- a/apps/desktop/src/main/lib/ssh/ssh-terminal-manager.test.ts
+++ b/apps/desktop/src/main/lib/ssh/ssh-terminal-manager.test.ts
@@ -1,0 +1,363 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { SshConnectionManager } from "./connection-manager";
+import { SshTerminalManager } from "./ssh-terminal-manager";
+import type { ZmxSessionManager } from "./zmx-manager";
+
+function createMockPty() {
+	let dataCallback: ((data: string) => void) | null = null;
+	let exitCallback:
+		| ((e: { exitCode: number; signal?: number }) => void)
+		| null = null;
+
+	return {
+		pid: 12345,
+		onData: mock((cb: (data: string) => void) => {
+			dataCallback = cb;
+			return {
+				dispose: () => {
+					dataCallback = null;
+				},
+			};
+		}),
+		onExit: mock((cb: (e: { exitCode: number; signal?: number }) => void) => {
+			exitCallback = cb;
+			return {
+				dispose: () => {
+					exitCallback = null;
+				},
+			};
+		}),
+		write: mock(() => {}),
+		resize: mock(() => {}),
+		kill: mock(() => {}),
+		_emitData: (data: string) => dataCallback?.(data),
+		_emitExit: (exitCode: number, signal?: number) =>
+			exitCallback?.({ exitCode, signal }),
+	};
+}
+
+function createMockDeps() {
+	const ptys: ReturnType<typeof createMockPty>[] = [];
+
+	const mockConn = {
+		ensureAlive: mock(async () => {}),
+		exec: mock(async () => ({ stdout: "", stderr: "", exitCode: 0 })),
+		spawnPty: mock(() => {
+			const pty = createMockPty();
+			ptys.push(pty);
+			return pty;
+		}),
+	} as unknown as SshConnectionManager;
+
+	const mockZmx = {
+		hasSession: mock(async () => false),
+		killSession: mock(async () => {}),
+		sanitizeSessionName: (id: string) => `superset-${id}`,
+		listSessions: mock(async () => []),
+	} as unknown as ZmxSessionManager;
+
+	return { mockConn, mockZmx, ptys };
+}
+
+const baseParams = {
+	paneId: "pane-1",
+	tabId: "tab-1",
+	workspaceId: "ws-1",
+	cwd: "/workspace",
+	cols: 80,
+	rows: 24,
+};
+
+describe("SshTerminalManager", () => {
+	let manager: SshTerminalManager;
+	let deps: ReturnType<typeof createMockDeps>;
+
+	beforeEach(() => {
+		deps = createMockDeps();
+		manager = new SshTerminalManager(deps.mockConn, deps.mockZmx);
+	});
+
+	describe("createOrAttach", () => {
+		it("spawns a zmx attach command when none exists", async () => {
+			const zmx = deps.mockZmx as unknown as Record<string, any>;
+			zmx.hasSession.mockResolvedValue(false);
+
+			const result = await manager.createOrAttach(baseParams);
+
+			expect(deps.mockConn.spawnPty).toHaveBeenCalledTimes(1);
+			expect(deps.mockConn.spawnPty).toHaveBeenCalledWith(
+				"cd '/workspace' && ~/.local/bin/zmx attach 'superset-pane-1'",
+				{ cols: 80, rows: 24 },
+			);
+			expect(result.isNew).toBe(true);
+			expect(result.wasRecovered).toBe(false);
+		});
+
+		it("marks attach as recovered when zmx session exists", async () => {
+			const zmx = deps.mockZmx as unknown as Record<string, any>;
+			zmx.hasSession.mockResolvedValue(true);
+
+			const result = await manager.createOrAttach(baseParams);
+
+			expect(deps.mockConn.spawnPty).toHaveBeenCalledTimes(1);
+			expect(result.isNew).toBe(false);
+			expect(result.wasRecovered).toBe(true);
+			expect(result.scrollback).toBe("");
+			expect(result.snapshot?.cwd).toBe("/workspace");
+		});
+	});
+
+	describe("data events", () => {
+		it("emits data event when pty receives data", async () => {
+			const zmx = deps.mockZmx as unknown as Record<string, any>;
+			zmx.hasSession.mockResolvedValue(false);
+
+			await manager.createOrAttach(baseParams);
+
+			const received: string[] = [];
+			manager.on("data:pane-1", (data: string) => {
+				received.push(data);
+			});
+
+			deps.ptys[0]?._emitData("hello world");
+
+			expect(received).toHaveLength(1);
+			expect(received[0]).toBe("hello world");
+		});
+
+		it("keeps buffering output from pty data", async () => {
+			const zmx = deps.mockZmx as unknown as Record<string, any>;
+			zmx.hasSession.mockResolvedValue(false);
+
+			await manager.createOrAttach(baseParams);
+
+			const received: string[] = [];
+			manager.on("data:pane-1", (data: string) => {
+				received.push(data);
+			});
+
+			deps.ptys[0]?._emitData("error output");
+			deps.ptys[0]?._emitData(" more");
+
+			expect(received).toEqual(["error output", " more"]);
+			expect(manager.getSession("pane-1")?.lastActive).toBeTypeOf("number");
+		});
+	});
+
+	describe("kill", () => {
+		it("destroys zmx session and emits exit event", async () => {
+			const zmx = deps.mockZmx as unknown as Record<string, any>;
+			zmx.hasSession.mockResolvedValue(false);
+			await manager.createOrAttach(baseParams);
+
+			const exitEvents: unknown[] = [];
+			manager.on("exit:pane-1", (...args: unknown[]) => {
+				exitEvents.push(args);
+			});
+
+			await manager.kill({ paneId: "pane-1" });
+
+			expect(zmx.killSession).toHaveBeenCalledTimes(1);
+			expect(zmx.killSession).toHaveBeenCalledWith("pane-1");
+			expect(exitEvents).toHaveLength(1);
+			expect(exitEvents[0]).toEqual([0, undefined, "killed"]);
+		});
+
+		it("kills the SSH process", async () => {
+			const zmx = deps.mockZmx as unknown as Record<string, any>;
+			zmx.hasSession.mockResolvedValue(false);
+			await manager.createOrAttach(baseParams);
+
+			await manager.kill({ paneId: "pane-1" });
+
+			expect(deps.ptys[0]?.kill).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("detach", () => {
+		it("preserves the session and does NOT emit exit event", async () => {
+			const zmx = deps.mockZmx as unknown as Record<string, any>;
+			zmx.hasSession.mockResolvedValue(false);
+			await manager.createOrAttach(baseParams);
+
+			const exitEvents: unknown[] = [];
+			manager.on("exit:pane-1", (...args: unknown[]) => {
+				exitEvents.push(args);
+			});
+
+			manager.detach({ paneId: "pane-1" });
+
+			expect(deps.ptys[0]?.kill).not.toHaveBeenCalled();
+			expect(manager.getSession("pane-1")).not.toBeNull();
+			expect(manager.getSession("pane-1")?.isAlive).toBe(true);
+			expect(manager.getSession("pane-1")?.cwd).toBe("/workspace");
+			expect(exitEvents).toHaveLength(0);
+		});
+
+		it("stops forwarding data after detach", async () => {
+			const zmx = deps.mockZmx as unknown as Record<string, any>;
+			zmx.hasSession.mockResolvedValue(false);
+			await manager.createOrAttach(baseParams);
+
+			const received: string[] = [];
+			manager.on("data:pane-1", (data: string) => {
+				received.push(data);
+			});
+
+			manager.detach({ paneId: "pane-1" });
+			deps.ptys[0]?._emitData("after detach");
+
+			expect(manager.getSession("pane-1")).not.toBeNull();
+			expect(received).toHaveLength(0);
+			expect(deps.ptys[0]?.kill).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("killByWorkspaceId", () => {
+		it("kills SSH processes and remote zmx sessions", async () => {
+			const zmx = deps.mockZmx as unknown as Record<string, any>;
+			zmx.hasSession.mockResolvedValue(false);
+
+			const ptys: ReturnType<typeof createMockPty>[] = [];
+			const conn = deps.mockConn as unknown as Record<string, any>;
+			conn.spawnPty.mockImplementation(() => {
+				const p = createMockPty();
+				ptys.push(p);
+				return p;
+			});
+
+			await manager.createOrAttach({
+				...baseParams,
+				paneId: "p1",
+				workspaceId: "ws-target",
+			});
+			await manager.createOrAttach({
+				...baseParams,
+				paneId: "p2",
+				workspaceId: "ws-target",
+			});
+			await manager.createOrAttach({
+				...baseParams,
+				paneId: "p3",
+				workspaceId: "ws-target",
+			});
+
+			const result = await manager.killByWorkspaceId("ws-target");
+
+			expect(zmx.killSession).toHaveBeenCalledTimes(3);
+			expect(result.killed).toBe(3);
+			expect(result.failed).toBe(0);
+			for (const p of ptys) {
+				expect(p.kill).toHaveBeenCalledTimes(1);
+			}
+		});
+
+		it("only kills sessions matching the workspace id", async () => {
+			const zmx = deps.mockZmx as unknown as Record<string, any>;
+			zmx.hasSession.mockResolvedValue(false);
+			const conn = deps.mockConn as unknown as Record<string, any>;
+			conn.spawnPty.mockImplementation(() => createMockPty());
+
+			await manager.createOrAttach({
+				...baseParams,
+				paneId: "p1",
+				workspaceId: "ws-target",
+			});
+			await manager.createOrAttach({
+				...baseParams,
+				paneId: "p2",
+				workspaceId: "ws-other",
+			});
+
+			const result = await manager.killByWorkspaceId("ws-target");
+
+			expect(result.killed).toBe(1);
+			const otherSession = manager.getSession("p2");
+			expect(otherSession).not.toBeNull();
+			expect(otherSession?.isAlive).toBe(true);
+		});
+	});
+
+	describe("write", () => {
+		it("forwards data to the pty", async () => {
+			const zmx = deps.mockZmx as unknown as Record<string, any>;
+			zmx.hasSession.mockResolvedValue(false);
+			await manager.createOrAttach(baseParams);
+
+			manager.write({ paneId: "pane-1", data: "hello" });
+
+			expect(deps.ptys[0]?.write).toHaveBeenCalledWith("hello");
+		});
+
+		it("does nothing for unknown pane", () => {
+			manager.write({ paneId: "nonexistent", data: "hello" });
+			expect(deps.ptys).toHaveLength(0);
+		});
+	});
+
+	describe("resize", () => {
+		it("calls only pty resize", async () => {
+			const zmx = deps.mockZmx as unknown as Record<string, any>;
+			zmx.hasSession.mockResolvedValue(false);
+			await manager.createOrAttach(baseParams);
+
+			manager.resize({ paneId: "pane-1", cols: 100, rows: 30 });
+
+			expect(deps.ptys[0]?.resize).toHaveBeenCalledWith(100, 30);
+			expect(
+				(deps.mockZmx as unknown as Record<string, any>).resize,
+			).toBeUndefined();
+		});
+	});
+
+	describe("clearScrollback", () => {
+		it("clears buffered output without remote exec", async () => {
+			const zmx = deps.mockZmx as unknown as Record<string, any>;
+			zmx.hasSession.mockResolvedValue(false);
+			await manager.createOrAttach(baseParams);
+
+			deps.ptys[0]?._emitData("buffered output");
+			manager.clearScrollback({ paneId: "pane-1" });
+
+			const recovered = await manager.createOrAttach(baseParams);
+			expect(recovered.scrollback).toBe("");
+			expect(deps.mockConn.exec).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("getSession", () => {
+		it("returns session info for active session", async () => {
+			const zmx = deps.mockZmx as unknown as Record<string, any>;
+			zmx.hasSession.mockResolvedValue(false);
+			await manager.createOrAttach(baseParams);
+
+			const session = manager.getSession("pane-1");
+
+			expect(session).not.toBeNull();
+			expect(session?.isAlive).toBe(true);
+			expect(session?.cwd).toBe("/workspace");
+		});
+
+		it("returns null for unknown pane", () => {
+			expect(manager.getSession("nonexistent")).toBeNull();
+		});
+	});
+
+	describe("capabilities", () => {
+		it("has persistent true and coldRestore false", () => {
+			expect(manager.capabilities.persistent).toBe(true);
+			expect(manager.capabilities.coldRestore).toBe(false);
+		});
+	});
+
+	describe("management", () => {
+		it("provides stub management methods", async () => {
+			expect(manager.management).not.toBeNull();
+			expect(typeof manager.management.listSessions).toBe("function");
+			expect(typeof manager.management.killAllSessions).toBe("function");
+			expect(typeof manager.management.resetHistoryPersistence).toBe(
+				"function",
+			);
+		});
+	});
+});

--- a/apps/desktop/src/main/lib/ssh/ssh-terminal-manager.ts
+++ b/apps/desktop/src/main/lib/ssh/ssh-terminal-manager.ts
@@ -1,0 +1,296 @@
+import { EventEmitter } from "node:events";
+import type { IPty } from "node-pty";
+import type { SshConnectionManager } from "./connection-manager";
+import type { ZmxSessionManager } from "./zmx-manager";
+import type {
+	TerminalCapabilities,
+	TerminalEventSource,
+	TerminalManagement,
+	TerminalSessionOperations,
+	TerminalWorkspaceOperations,
+} from "../workspace-runtime/types";
+import type { CreateSessionParams, SessionResult } from "../terminal/types";
+
+const OUTPUT_BUFFER_MAX = 200_000;
+const OUTPUT_BUFFER_TRIM = 100_000;
+
+interface SshSessionInfo {
+	paneId: string;
+	workspaceId: string;
+	pty: IPty;
+	isAlive: boolean;
+	detached: boolean;
+	cwd: string;
+	lastActive: number;
+	outputBuffer: string;
+}
+
+export class SshTerminalManager
+	extends EventEmitter
+	implements
+		TerminalEventSource,
+		TerminalSessionOperations,
+		TerminalWorkspaceOperations
+{
+	private readonly sessions = new Map<string, SshSessionInfo>();
+	private readonly pendingAttaches = new Map<string, Promise<SessionResult>>();
+
+	readonly capabilities: TerminalCapabilities = {
+		persistent: true,
+		coldRestore: false,
+	};
+
+	readonly management: TerminalManagement = {
+		listSessions: async () => ({ sessions: [] }),
+		killAllSessions: async () => {},
+		resetHistoryPersistence: async () => {},
+	};
+
+	constructor(
+		private readonly connectionManager: SshConnectionManager,
+		private readonly zmxManager: ZmxSessionManager,
+	) {
+		super();
+	}
+
+	async createOrAttach(params: CreateSessionParams): Promise<SessionResult> {
+		const { paneId } = params;
+		const pendingAttach = this.pendingAttaches.get(paneId);
+		if (pendingAttach) {
+			return pendingAttach;
+		}
+
+		const existing = this.sessions.get(paneId);
+		if (existing?.isAlive) {
+			existing.detached = false;
+			return this.reattach(existing, params);
+		}
+
+		const promise = this.createNew(params);
+		this.pendingAttaches.set(paneId, promise);
+
+		try {
+			return await promise;
+		} finally {
+			if (this.pendingAttaches.get(paneId) === promise) {
+				this.pendingAttaches.delete(paneId);
+			}
+		}
+	}
+
+	private reattach(
+		session: SshSessionInfo,
+		params: CreateSessionParams,
+	): Promise<SessionResult> {
+		session.detached = false;
+		const scrollback = session.outputBuffer;
+
+		return Promise.resolve({
+			isNew: false,
+			scrollback,
+			wasRecovered: true,
+			isColdRestore: false,
+			snapshot: {
+				snapshotAnsi: scrollback,
+				rehydrateSequences: "",
+				cwd: session.cwd,
+				modes: {},
+				cols: params.cols ?? 80,
+				rows: params.rows ?? 24,
+				scrollbackLines: scrollback === "" ? 0 : scrollback.split("\n").length,
+			},
+			pid: session.pty.pid,
+		} as SessionResult & { pid: number });
+	}
+
+	private async createNew(params: CreateSessionParams): Promise<SessionResult> {
+		const { paneId } = params;
+		const cwd = params.cwd ?? params.workspacePath ?? "/";
+		const cols = params.cols ?? 80;
+		const rows = params.rows ?? 24;
+
+		await this.connectionManager.ensureAlive();
+
+		const sessionExisted = await this.zmxManager.hasSession(paneId);
+		const sessionName = this.zmxManager.sanitizeSessionName(paneId);
+
+		const ptyProc = this.connectionManager.spawnPty(
+			`cd ${this.shellEscape(cwd)} && ~/.local/bin/zmx attach ${this.shellEscape(sessionName)}`,
+			{ cols, rows },
+		);
+
+		const session: SshSessionInfo = {
+			paneId,
+			workspaceId: params.workspaceId,
+			pty: ptyProc,
+			isAlive: true,
+			detached: false,
+			cwd,
+			lastActive: Date.now(),
+			outputBuffer: "",
+		};
+
+		ptyProc.onData((data) => {
+			session.lastActive = Date.now();
+			session.outputBuffer += data;
+			if (session.outputBuffer.length > OUTPUT_BUFFER_MAX) {
+				session.outputBuffer = session.outputBuffer.slice(-OUTPUT_BUFFER_TRIM);
+			}
+			if (!session.detached) {
+				this.emit(`data:${paneId}`, data);
+			}
+		});
+		ptyProc.onExit(({ exitCode, signal }) => {
+			this.handleExit(paneId, exitCode, signal);
+		});
+
+		this.sessions.set(paneId, session);
+
+		return {
+			isNew: !sessionExisted,
+			scrollback: "",
+			wasRecovered: sessionExisted,
+			isColdRestore: false,
+			snapshot: {
+				snapshotAnsi: "",
+				rehydrateSequences: "",
+				cwd,
+				modes: {},
+				cols,
+				rows,
+				scrollbackLines: 0,
+			},
+			pid: ptyProc.pid,
+		} as SessionResult & { pid: number };
+	}
+
+	write(params: { paneId: string; data: string }): void {
+		const session = this.sessions.get(params.paneId);
+		if (!session?.isAlive) {
+			return;
+		}
+		session.lastActive = Date.now();
+		session.pty.write(params.data);
+	}
+
+	resize(params: { paneId: string; cols: number; rows: number }): void {
+		const session = this.sessions.get(params.paneId);
+		if (!session?.isAlive) {
+			return;
+		}
+		try {
+			session.pty.resize(params.cols, params.rows);
+		} catch {}
+	}
+
+	signal(params: { paneId: string; signal?: string }): void {
+		const session = this.sessions.get(params.paneId);
+		if (!session?.isAlive) {
+			return;
+		}
+		session.lastActive = Date.now();
+		session.pty.kill(params.signal);
+	}
+
+	async kill(params: { paneId: string }): Promise<void> {
+		const session = this.sessions.get(params.paneId);
+		if (!session) {
+			return;
+		}
+		session.isAlive = false;
+		session.pty.kill();
+		await this.zmxManager.killSession(params.paneId).catch(() => {});
+		this.emit(`exit:${params.paneId}`, 0, undefined, "killed");
+		this.sessions.delete(params.paneId);
+	}
+
+	detach(params: { paneId: string }): void {
+		const session = this.sessions.get(params.paneId);
+		if (!session) {
+			return;
+		}
+		session.detached = true;
+	}
+
+	clearScrollback(params: { paneId: string }): void {
+		const session = this.sessions.get(params.paneId);
+		if (!session) {
+			return;
+		}
+		session.outputBuffer = "";
+	}
+
+	ackColdRestore(_paneId: string): void {}
+
+	getSession(
+		paneId: string,
+	): { isAlive: boolean; cwd: string; lastActive: number } | null {
+		const session = this.sessions.get(paneId);
+		if (!session) {
+			return null;
+		}
+		return {
+			isAlive: session.isAlive,
+			cwd: session.cwd,
+			lastActive: session.lastActive,
+		};
+	}
+
+	cancelCreateOrAttach(_params: { paneId: string; requestId: string }): void {}
+
+	async killByWorkspaceId(
+		workspaceId: string,
+	): Promise<{ killed: number; failed: number }> {
+		let killed = 0;
+		for (const [paneId, session] of this.sessions.entries()) {
+			if (session.workspaceId !== workspaceId) {
+				continue;
+			}
+			session.isAlive = false;
+			session.pty.kill();
+			await this.zmxManager.killSession(paneId).catch(() => {});
+			this.sessions.delete(paneId);
+			killed += 1;
+		}
+		return { killed, failed: 0 };
+	}
+
+	async getSessionCountByWorkspaceId(workspaceId: string): Promise<number> {
+		return Array.from(this.sessions.values()).filter(
+			(session) => session.workspaceId === workspaceId,
+		).length;
+	}
+
+	refreshPromptsForWorkspace(_workspaceId: string): void {}
+
+	detachAllListeners(): void {
+		this.removeAllListeners();
+	}
+
+	async cleanup(): Promise<void> {
+		for (const [paneId, session] of this.sessions.entries()) {
+			session.isAlive = false;
+			session.pty.kill();
+			await this.zmxManager.killSession(paneId).catch(() => {});
+		}
+		this.sessions.clear();
+	}
+
+	private handleExit(
+		paneId: string,
+		exitCode: number,
+		signal: number | undefined,
+	): void {
+		const session = this.sessions.get(paneId);
+		if (!session || !session.isAlive) {
+			return;
+		}
+		session.isAlive = false;
+		this.emit(`exit:${paneId}`, exitCode, signal, "exited");
+		this.sessions.delete(paneId);
+	}
+
+	private shellEscape(value: string): string {
+		return `'${value.replaceAll("'", `'\\''`)}'`;
+	}
+}

--- a/apps/desktop/src/main/lib/ssh/types.ts
+++ b/apps/desktop/src/main/lib/ssh/types.ts
@@ -1,0 +1,26 @@
+export interface SshConnectionConfig {
+	host: string;
+	port: number;
+	user: string;
+	identityFile?: string;
+	workDir: string;
+	containerName?: string;
+}
+
+export interface DevcontainerScriptOutput {
+	host: string;
+	port: number;
+	user: string;
+	identityFile?: string;
+	workDir: string;
+	containerName?: string;
+}
+
+export interface DevcontainerScriptInput {
+	repo: string;
+	branch: string;
+	branchNoPrefix: string;
+	newBranch: boolean;
+	workspaceName: string;
+	workspaceId: string;
+}

--- a/apps/desktop/src/main/lib/ssh/zmx-manager.test.ts
+++ b/apps/desktop/src/main/lib/ssh/zmx-manager.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { ZmxSessionManager } from "./zmx-manager";
+import type { SshConnectionManager } from "./connection-manager";
+
+function createMockConnectionManager(): SshConnectionManager & {
+	execCalls: string[];
+	mockExecResult: { stdout: string; stderr: string; exitCode: number };
+} {
+	const mock = {
+		execCalls: [] as string[],
+		mockExecResult: { stdout: "", stderr: "", exitCode: 0 },
+
+		async exec(command: string) {
+			mock.execCalls.push(command);
+			return mock.mockExecResult;
+		},
+	} as unknown as SshConnectionManager & {
+		execCalls: string[];
+		mockExecResult: { stdout: string; stderr: string; exitCode: number };
+	};
+
+	return mock;
+}
+
+describe("ZmxSessionManager", () => {
+	let connMgr: ReturnType<typeof createMockConnectionManager>;
+	let zmx: ZmxSessionManager;
+
+	beforeEach(() => {
+		connMgr = createMockConnectionManager();
+		zmx = new ZmxSessionManager(connMgr);
+	});
+
+	describe("sanitizeSessionName", () => {
+		it("prefixes with superset-", () => {
+			expect(zmx.sanitizeSessionName("abc-123-def")).toBe(
+				"superset-abc-123-def",
+			);
+		});
+
+		it("strips dots from pane id", () => {
+			expect(zmx.sanitizeSessionName("pane.with.dots")).toBe(
+				"superset-panewithdots",
+			);
+		});
+
+		it("strips special characters", () => {
+			expect(zmx.sanitizeSessionName("a!@#b")).toBe("superset-ab");
+		});
+
+		it("preserves hyphens and underscores", () => {
+			expect(zmx.sanitizeSessionName("my_pane-1")).toBe("superset-my_pane-1");
+		});
+
+		it("handles empty string", () => {
+			expect(zmx.sanitizeSessionName("")).toBe("superset-");
+		});
+	});
+
+	describe("killSession", () => {
+		it("calls zmx kill with sanitized name", async () => {
+			await zmx.killSession("pane-1");
+
+			expect(connMgr.execCalls.length).toBe(1);
+			expect(connMgr.execCalls[0]).toContain("~/.local/bin/zmx kill");
+			expect(connMgr.execCalls[0]).toContain("superset-pane-1");
+		});
+	});
+
+	describe("hasSession", () => {
+		it("returns true when exitCode is 0", async () => {
+			connMgr.mockExecResult = { stdout: "", stderr: "", exitCode: 0 };
+			const result = await zmx.hasSession("pane-1");
+			expect(result).toBe(true);
+		});
+
+		it("returns false when exitCode is 1", async () => {
+			connMgr.mockExecResult = { stdout: "", stderr: "", exitCode: 1 };
+			const result = await zmx.hasSession("pane-1");
+			expect(result).toBe(false);
+		});
+
+		it("calls zmx list with grep for sanitized name", async () => {
+			connMgr.mockExecResult = { stdout: "", stderr: "", exitCode: 0 };
+			await zmx.hasSession("pane.2");
+
+			expect(connMgr.execCalls[0]).toContain("~/.local/bin/zmx list --short");
+			expect(connMgr.execCalls[0]).toContain("grep -q");
+			expect(connMgr.execCalls[0]).toContain("superset-pane2");
+		});
+	});
+
+	describe("listSessions", () => {
+		it("returns only sessions with superset- prefix", async () => {
+			connMgr.mockExecResult = {
+				stdout: "superset-pane-1\nother-session\nsuperset-pane-2\n",
+				stderr: "",
+				exitCode: 0,
+			};
+
+			const sessions = await zmx.listSessions();
+			expect(sessions).toEqual(["superset-pane-1", "superset-pane-2"]);
+		});
+
+		it("returns empty array when no matching sessions", async () => {
+			connMgr.mockExecResult = {
+				stdout: "other-session\n",
+				stderr: "",
+				exitCode: 0,
+			};
+
+			const sessions = await zmx.listSessions();
+			expect(sessions).toEqual([]);
+		});
+	});
+});

--- a/apps/desktop/src/main/lib/ssh/zmx-manager.ts
+++ b/apps/desktop/src/main/lib/ssh/zmx-manager.ts
@@ -1,0 +1,43 @@
+import type { SshConnectionManager } from "./connection-manager";
+
+const SESSION_PREFIX = "superset-";
+
+function shellEscape(value: string): string {
+	return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+export class ZmxSessionManager {
+	constructor(private readonly connectionManager: SshConnectionManager) {}
+
+	sanitizeSessionName(paneId: string): string {
+		const sanitizedPaneId = paneId.replaceAll(/[^a-zA-Z0-9_-]/g, "");
+		return `${SESSION_PREFIX}${sanitizedPaneId}`;
+	}
+
+	async hasSession(paneId: string): Promise<boolean> {
+		const sessionName = this.sanitizeSessionName(paneId);
+		const result = await this.connectionManager.exec(
+			`~/.local/bin/zmx list --short 2>/dev/null | grep -q ${shellEscape(sessionName)}`,
+		);
+		return result.exitCode === 0;
+	}
+
+	async killSession(paneId: string): Promise<void> {
+		const sessionName = this.sanitizeSessionName(paneId);
+		try {
+			await this.connectionManager.exec(
+				`~/.local/bin/zmx kill ${shellEscape(sessionName)}`,
+			);
+		} catch {}
+	}
+
+	async listSessions(): Promise<string[]> {
+		const result = await this.connectionManager.exec(
+			"~/.local/bin/zmx list --short 2>/dev/null",
+		);
+		return result.stdout
+			.split("\n")
+			.map((line) => line.trim())
+			.filter((line) => line.startsWith(SESSION_PREFIX));
+	}
+}

--- a/apps/desktop/src/main/lib/workspace-runtime/registry.ts
+++ b/apps/desktop/src/main/lib/workspace-runtime/registry.ts
@@ -13,7 +13,11 @@
  * - Local + cloud workspaces can coexist
  */
 
+import { sshWorkspaceConfigSchema, workspaces } from "@superset/local-db";
+import { eq } from "drizzle-orm";
+import { localDb } from "../local-db";
 import { LocalWorkspaceRuntime } from "./local";
+import { SshWorkspaceRuntime } from "./ssh";
 import type { WorkspaceRuntime, WorkspaceRuntimeRegistry } from "./types";
 
 // =============================================================================
@@ -28,30 +32,46 @@ import type { WorkspaceRuntime, WorkspaceRuntimeRegistry } from "./types";
  */
 class DefaultWorkspaceRuntimeRegistry implements WorkspaceRuntimeRegistry {
 	private localRuntime: LocalWorkspaceRuntime | null = null;
+	private readonly sshRuntimes = new Map<string, SshWorkspaceRuntime>();
 
-	/**
-	 * Get the runtime for a specific workspace.
-	 *
-	 * Currently always returns the local runtime.
-	 * Future: will check workspace metadata to select local vs cloud.
-	 */
-	getForWorkspaceId(_workspaceId: string): WorkspaceRuntime {
-		// Currently all workspaces use the local runtime
-		// Future: check workspace metadata for cloudWorkspaceId to select cloud runtime
+	getForWorkspaceId(workspaceId: string): WorkspaceRuntime {
+		const cached = this.sshRuntimes.get(workspaceId);
+		if (cached) {
+			return cached;
+		}
+
+		const workspace = localDb
+			.select({
+				type: workspaces.type,
+				sshConfig: workspaces.sshConfig,
+			})
+			.from(workspaces)
+			.where(eq(workspaces.id, workspaceId))
+			.get();
+
+		if (workspace?.type === "ssh" && workspace.sshConfig != null) {
+			const config = sshWorkspaceConfigSchema.parse(workspace.sshConfig);
+			const runtime = new SshWorkspaceRuntime(workspaceId, config);
+			this.sshRuntimes.set(workspaceId, runtime);
+			return runtime;
+		}
+
 		return this.getDefault();
 	}
 
-	/**
-	 * Get the default runtime (for global/legacy endpoints).
-	 *
-	 * Returns the local runtime, lazily initialized.
-	 * The runtime instance is cached for the lifetime of the process.
-	 */
 	getDefault(): WorkspaceRuntime {
 		if (!this.localRuntime) {
 			this.localRuntime = new LocalWorkspaceRuntime();
 		}
 		return this.localRuntime;
+	}
+
+	removeRuntime(workspaceId: string): void {
+		const runtime = this.sshRuntimes.get(workspaceId);
+		if (runtime) {
+			runtime.cleanup().catch(() => {});
+			this.sshRuntimes.delete(workspaceId);
+		}
 	}
 }
 

--- a/apps/desktop/src/main/lib/workspace-runtime/ssh.test.ts
+++ b/apps/desktop/src/main/lib/workspace-runtime/ssh.test.ts
@@ -1,0 +1,84 @@
+import { beforeAll, describe, expect, it, mock } from "bun:test";
+
+let SshWorkspaceRuntime: typeof import("./ssh").SshWorkspaceRuntime;
+let SshTerminalManager: typeof import("../ssh/ssh-terminal-manager").SshTerminalManager;
+
+const testConfig = {
+	host: "localhost",
+	port: 22,
+	user: "dev",
+	workDir: "/workspace",
+};
+
+describe("SshWorkspaceRuntime", () => {
+	beforeAll(async () => {
+		mock.module("electron", () => ({
+			app: {
+				getPath: (name: string) => `/tmp/superset-test-${name}`,
+			},
+		}));
+
+		({ SshWorkspaceRuntime } = await import("./ssh"));
+		({ SshTerminalManager } = await import("../ssh/ssh-terminal-manager"));
+	});
+
+	describe("capabilities", () => {
+		it("has persistent terminal and no cold restore", () => {
+			const runtime = new SshWorkspaceRuntime("ws-1", testConfig);
+
+			expect(runtime.capabilities.terminal.persistent).toBe(true);
+			expect(runtime.capabilities.terminal.coldRestore).toBe(false);
+		});
+	});
+
+	describe("management", () => {
+		it("provides non-null management stub", () => {
+			const runtime = new SshWorkspaceRuntime("ws-1", testConfig);
+
+			expect(runtime.terminal.management).not.toBeNull();
+			expect(typeof runtime.terminal.management.listSessions).toBe("function");
+			expect(typeof runtime.terminal.management.killAllSessions).toBe(
+				"function",
+			);
+			expect(typeof runtime.terminal.management.resetHistoryPersistence).toBe(
+				"function",
+			);
+		});
+	});
+
+	describe("terminal", () => {
+		it("is backed by SshTerminalManager", () => {
+			const runtime = new SshWorkspaceRuntime("ws-1", testConfig);
+
+			expect(runtime.terminal).toBeInstanceOf(SshTerminalManager);
+		});
+
+		it("exposes expected session operation methods", () => {
+			const runtime = new SshWorkspaceRuntime("ws-1", testConfig);
+
+			expect(typeof runtime.terminal.createOrAttach).toBe("function");
+			expect(typeof runtime.terminal.write).toBe("function");
+			expect(typeof runtime.terminal.resize).toBe("function");
+			expect(typeof runtime.terminal.kill).toBe("function");
+			expect(typeof runtime.terminal.detach).toBe("function");
+			expect(typeof runtime.terminal.signal).toBe("function");
+		});
+
+		it("exposes workspace operations", () => {
+			const runtime = new SshWorkspaceRuntime("ws-1", testConfig);
+
+			expect(typeof runtime.terminal.killByWorkspaceId).toBe("function");
+			expect(typeof runtime.terminal.getSessionCountByWorkspaceId).toBe(
+				"function",
+			);
+		});
+	});
+
+	describe("identity", () => {
+		it("stores workspace id", () => {
+			const runtime = new SshWorkspaceRuntime("ws-abc", testConfig);
+
+			expect(runtime.id).toBe("ws-abc");
+		});
+	});
+});

--- a/apps/desktop/src/main/lib/workspace-runtime/ssh.ts
+++ b/apps/desktop/src/main/lib/workspace-runtime/ssh.ts
@@ -1,0 +1,41 @@
+import type { SshWorkspaceConfig } from "@superset/local-db";
+import { SshConnectionManager } from "../ssh/connection-manager";
+import { SshTerminalManager } from "../ssh/ssh-terminal-manager";
+import { ZmxSessionManager } from "../ssh/zmx-manager";
+import type {
+	TerminalRuntime,
+	WorkspaceRuntime,
+	WorkspaceRuntimeId,
+} from "./types";
+
+export class SshWorkspaceRuntime implements WorkspaceRuntime {
+	readonly id: WorkspaceRuntimeId;
+	readonly terminal: TerminalRuntime;
+	readonly capabilities: WorkspaceRuntime["capabilities"];
+
+	private readonly connectionManager: SshConnectionManager;
+	private readonly zmxManager: ZmxSessionManager;
+
+	constructor(workspaceId: string, config: SshWorkspaceConfig) {
+		this.id = workspaceId;
+
+		this.connectionManager = new SshConnectionManager(config, workspaceId);
+		this.zmxManager = new ZmxSessionManager(this.connectionManager);
+
+		const terminalManager = new SshTerminalManager(
+			this.connectionManager,
+			this.zmxManager,
+		);
+
+		this.terminal = terminalManager as TerminalRuntime;
+
+		this.capabilities = {
+			terminal: terminalManager.capabilities,
+		};
+	}
+
+	async cleanup(): Promise<void> {
+		await this.terminal.cleanup();
+		await this.connectionManager.stop();
+	}
+}

--- a/apps/desktop/src/main/lib/workspace-runtime/types.ts
+++ b/apps/desktop/src/main/lib/workspace-runtime/types.ts
@@ -218,8 +218,7 @@ export interface WorkspaceRuntime {
 export interface WorkspaceRuntimeRegistry {
 	/**
 	 * Get the runtime for a specific workspace.
-	 * Currently always returns the default local runtime,
-	 * but the interface supports per-workspace selection for cloud.
+	 * Returns an SSH runtime for SSH workspaces, local runtime otherwise.
 	 */
 	getForWorkspaceId(workspaceId: string): WorkspaceRuntime;
 
@@ -228,4 +227,10 @@ export interface WorkspaceRuntimeRegistry {
 	 * Used by settings screens and endpoints that don't have workspace context.
 	 */
 	getDefault(): WorkspaceRuntime;
+
+	/**
+	 * Remove and clean up a cached runtime for a workspace.
+	 * Used when a workspace is deleted to tear down SSH connections.
+	 */
+	removeRuntime(workspaceId: string): void;
 }

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
@@ -21,6 +21,7 @@ import {
 	CommandList,
 	CommandSeparator,
 } from "@superset/ui/command";
+import { Checkbox } from "@superset/ui/checkbox";
 import { Input } from "@superset/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@superset/ui/popover";
 import { toast } from "@superset/ui/sonner";
@@ -34,7 +35,7 @@ import {
 	PaperclipIcon,
 	PlusIcon,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
 	GoArrowUpRight,
 	GoGitBranch,
@@ -272,262 +273,271 @@ function ProjectPickerPill({
 	);
 }
 
-function CompareBaseBranchPickerInline({
-	effectiveCompareBaseBranch,
-	defaultBranch,
-	isBranchesLoading,
-	isBranchesError,
-	branches,
-	worktreeBranches,
-	openableWorktrees,
-	activeWorkspacesByBranch,
-	externalWorktreeBranches,
-	modKey,
-	onSelectCompareBaseBranch,
-	onOpenWorktree,
-	onOpenActiveWorkspace,
-}: {
-	effectiveCompareBaseBranch: string | null;
-	defaultBranch?: string;
-	isBranchesLoading: boolean;
-	isBranchesError: boolean;
-	branches: Array<{ name: string; lastCommitDate: number; isLocal: boolean }>;
-	worktreeBranches: Set<string>;
-	openableWorktrees: Map<string, OpenableWorktreeAction>;
-	activeWorkspacesByBranch: Map<string, string>;
-	externalWorktreeBranches: Set<string>;
-	modKey: string;
-	onSelectCompareBaseBranch: (branchName: string) => void;
-	onOpenWorktree: (action: OpenableWorktreeAction) => void;
-	onOpenActiveWorkspace: (workspaceId: string) => void;
-}) {
-	const [open, setOpen] = useState(false);
-	const [branchSearch, setBranchSearch] = useState("");
-	const [filterMode, setFilterMode] = useState<"all" | "worktrees">("all");
+const CompareBaseBranchPickerInline = memo(
+	function CompareBaseBranchPickerInline({
+		effectiveCompareBaseBranch,
+		defaultBranch,
+		isBranchesLoading,
+		isBranchesError,
+		branches,
+		worktreeBranches,
+		openableWorktrees,
+		activeWorkspacesByBranch,
+		externalWorktreeBranches,
+		modKey,
+		onSelectCompareBaseBranch,
+		onOpenWorktree,
+		onOpenActiveWorkspace,
+	}: {
+		effectiveCompareBaseBranch: string | null;
+		defaultBranch?: string;
+		isBranchesLoading: boolean;
+		isBranchesError: boolean;
+		branches: Array<{ name: string; lastCommitDate: number; isLocal: boolean }>;
+		worktreeBranches: Set<string>;
+		openableWorktrees: Map<string, OpenableWorktreeAction>;
+		activeWorkspacesByBranch: Map<string, string>;
+		externalWorktreeBranches: Set<string>;
+		modKey: string;
+		onSelectCompareBaseBranch: (branchName: string) => void;
+		onOpenWorktree: (action: OpenableWorktreeAction) => void;
+		onOpenActiveWorkspace: (workspaceId: string) => void;
+	}) {
+		const [open, setOpen] = useState(false);
+		const [branchSearch, setBranchSearch] = useState("");
+		const [filterMode, setFilterMode] = useState<"all" | "worktrees">("all");
 
-	const filteredBranches = useMemo(() => {
-		if (!branches.length) return [];
-		if (!branchSearch) return branches;
-		const searchLower = branchSearch.toLowerCase();
-		return branches.filter((branch) =>
-			branch.name.toLowerCase().includes(searchLower),
-		);
-	}, [branches, branchSearch]);
+		const filteredBranches = useMemo(() => {
+			if (!branches.length) return [];
+			if (!branchSearch) return branches;
+			const searchLower = branchSearch.toLowerCase();
+			return branches.filter((branch) =>
+				branch.name.toLowerCase().includes(searchLower),
+			);
+		}, [branches, branchSearch]);
 
-	const displayBranches = useMemo(() => {
-		if (filterMode === "all") return filteredBranches;
-		return filteredBranches.filter((b) => worktreeBranches.has(b.name));
-	}, [filteredBranches, filterMode, worktreeBranches]);
+		const displayBranches = useMemo(() => {
+			if (filterMode === "all") return filteredBranches;
+			return filteredBranches.filter((b) => worktreeBranches.has(b.name));
+		}, [filteredBranches, filterMode, worktreeBranches]);
 
-	if (isBranchesError) {
+		if (isBranchesError) {
+			return (
+				<span className="text-xs text-destructive">
+					Failed to load branches
+				</span>
+			);
+		}
+
 		return (
-			<span className="text-xs text-destructive">Failed to load branches</span>
-		);
-	}
-
-	return (
-		<Popover
-			open={open}
-			onOpenChange={(v) => {
-				setOpen(v);
-				if (!v) {
-					setBranchSearch("");
-					setFilterMode("all");
-				}
-			}}
-		>
-			<PopoverTrigger asChild>
-				<button
-					type="button"
-					disabled={isBranchesLoading}
-					className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 min-w-0 max-w-full"
-				>
-					<GoGitBranch className="size-3 shrink-0" />
-					{isBranchesLoading ? (
-						<span className="h-2.5 w-14 rounded-sm bg-muted-foreground/15 animate-pulse" />
-					) : (
-						<span className="font-mono truncate">
-							{effectiveCompareBaseBranch || "..."}
-						</span>
-					)}
-					<HiChevronUpDown className="size-3 shrink-0" />
-				</button>
-			</PopoverTrigger>
-			<PopoverContent
-				className="w-96 p-0"
-				align="start"
-				onWheel={(event) => event.stopPropagation()}
+			<Popover
+				open={open}
+				onOpenChange={(v) => {
+					setOpen(v);
+					if (!v) {
+						setBranchSearch("");
+						setFilterMode("all");
+					}
+				}}
 			>
-				<Command shouldFilter={false}>
-					<div className="flex items-center gap-0.5 rounded-md bg-muted/40 p-0.5 mx-2 mt-2">
-						{(["all", "worktrees"] as const).map((value) => {
-							const count =
-								value === "all"
-									? branches.length
-									: branches.filter((b) => worktreeBranches.has(b.name)).length;
-							return (
-								<button
-									key={value}
-									type="button"
-									onClick={() => setFilterMode(value)}
-									className={cn(
-										"flex-1 rounded px-2 py-1 text-xs text-center transition-colors",
-										filterMode === value
-											? "bg-background text-foreground shadow-sm"
-											: "text-muted-foreground hover:text-foreground",
-									)}
-								>
-									{value === "all" ? "All" : "Worktrees"}
-									<span className="ml-1 text-foreground/40">{count}</span>
-								</button>
-							);
-						})}
-					</div>
-					<CommandInput
-						placeholder="Search branches..."
-						value={branchSearch}
-						onValueChange={setBranchSearch}
-					/>
-					<CommandList className="max-h-[400px]">
-						<CommandEmpty>No branches found</CommandEmpty>
-						{displayBranches.map((branch) => {
-							const openAction = openableWorktrees.get(branch.name);
-							const activeWorkspaceId = activeWorkspacesByBranch.get(
-								branch.name,
-							);
-							const isExternal = externalWorktreeBranches.has(branch.name);
-							const hasExistingWorkspace = !!(activeWorkspaceId || openAction);
-
-							// Determine icon based on state - all same color
-							let icon: React.ReactNode;
-							if (activeWorkspaceId) {
-								icon = (
-									<GoArrowUpRight className="size-3.5 shrink-0 text-muted-foreground" />
-								);
-							} else if (openAction) {
-								icon = (
-									<ExternalLinkIcon className="size-3.5 shrink-0 text-muted-foreground" />
-								);
-							} else if (branch.isLocal) {
-								icon = (
-									<GoGitBranch className="size-3.5 shrink-0 text-muted-foreground" />
-								);
-							} else {
-								icon = (
-									<GoGlobe className="size-3.5 shrink-0 text-muted-foreground" />
-								);
-							}
-
-							return (
-								<CommandItem
-									key={branch.name}
-									value={branch.name}
-									onSelect={() => {
-										if (activeWorkspaceId) {
-											onOpenActiveWorkspace(activeWorkspaceId);
-										} else if (openAction) {
-											onOpenWorktree(openAction);
-										} else {
-											onSelectCompareBaseBranch(branch.name);
-										}
-										setOpen(false);
-									}}
-									className="group h-11 flex items-center justify-between gap-3 px-3"
-								>
-									<span className="flex items-center gap-2.5 truncate flex-1 min-w-0">
-										{icon}
-										<span className="truncate font-mono text-xs">
-											{branch.name}
-										</span>
-
-										{/* Inline badges */}
-										<span className="flex items-center gap-1.5 shrink-0">
-											{branch.name === defaultBranch && (
-												<span className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
-													default
-												</span>
-											)}
-											{isExternal && !activeWorkspaceId && (
-												<span className="text-[10px] text-muted-foreground/60 bg-muted/60 px-1.5 py-0.5 rounded">
-													external
-												</span>
-											)}
-										</span>
-									</span>
-
-									{/* Right side: time + buttons */}
-									<span className="flex items-center gap-2 shrink-0">
-										{branch.lastCommitDate > 0 && (
-											<span className="text-[11px] text-muted-foreground/70 group-data-[selected=true]:hidden">
-												{formatRelativeTime(branch.lastCommitDate)}
-											</span>
+				<PopoverTrigger asChild>
+					<button
+						type="button"
+						disabled={isBranchesLoading}
+						className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 min-w-0 max-w-full"
+					>
+						<GoGitBranch className="size-3 shrink-0" />
+						{isBranchesLoading ? (
+							<span className="h-2.5 w-14 rounded-sm bg-muted-foreground/15 animate-pulse" />
+						) : (
+							<span className="font-mono truncate">
+								{effectiveCompareBaseBranch || "..."}
+							</span>
+						)}
+						<HiChevronUpDown className="size-3 shrink-0" />
+					</button>
+				</PopoverTrigger>
+				<PopoverContent
+					className="w-96 p-0"
+					align="start"
+					onWheel={(event) => event.stopPropagation()}
+				>
+					<Command shouldFilter={false}>
+						<div className="flex items-center gap-0.5 rounded-md bg-muted/40 p-0.5 mx-2 mt-2">
+							{(["all", "worktrees"] as const).map((value) => {
+								const count =
+									value === "all"
+										? branches.length
+										: branches.filter((b) => worktreeBranches.has(b.name))
+												.length;
+								return (
+									<button
+										key={value}
+										type="button"
+										onClick={() => setFilterMode(value)}
+										className={cn(
+											"flex-1 rounded px-2 py-1 text-xs text-center transition-colors",
+											filterMode === value
+												? "bg-background text-foreground shadow-sm"
+												: "text-muted-foreground hover:text-foreground",
 										)}
+									>
+										{value === "all" ? "All" : "Worktrees"}
+										<span className="ml-1 text-foreground/40">{count}</span>
+									</button>
+								);
+							})}
+						</div>
+						<CommandInput
+							placeholder="Search branches..."
+							value={branchSearch}
+							onValueChange={setBranchSearch}
+						/>
+						<CommandList className="max-h-[400px]">
+							<CommandEmpty>No branches found</CommandEmpty>
+							{displayBranches.map((branch) => {
+								const openAction = openableWorktrees.get(branch.name);
+								const activeWorkspaceId = activeWorkspacesByBranch.get(
+									branch.name,
+								);
+								const isExternal = externalWorktreeBranches.has(branch.name);
+								const hasExistingWorkspace = !!(
+									activeWorkspaceId || openAction
+								);
 
-										{/* Show checkmark for selected base branch when not hovering */}
-										{!hasExistingWorkspace &&
-											effectiveCompareBaseBranch === branch.name && (
-												<HiCheck className="size-4 text-primary group-data-[selected=true]:hidden" />
+								// Determine icon based on state - all same color
+								let icon: React.ReactNode;
+								if (activeWorkspaceId) {
+									icon = (
+										<GoArrowUpRight className="size-3.5 shrink-0 text-muted-foreground" />
+									);
+								} else if (openAction) {
+									icon = (
+										<ExternalLinkIcon className="size-3.5 shrink-0 text-muted-foreground" />
+									);
+								} else if (branch.isLocal) {
+									icon = (
+										<GoGitBranch className="size-3.5 shrink-0 text-muted-foreground" />
+									);
+								} else {
+									icon = (
+										<GoGlobe className="size-3.5 shrink-0 text-muted-foreground" />
+									);
+								}
+
+								return (
+									<CommandItem
+										key={branch.name}
+										value={branch.name}
+										onSelect={() => {
+											if (activeWorkspaceId) {
+												onOpenActiveWorkspace(activeWorkspaceId);
+											} else if (openAction) {
+												onOpenWorktree(openAction);
+											} else {
+												onSelectCompareBaseBranch(branch.name);
+											}
+											setOpen(false);
+										}}
+										className="group h-11 flex items-center justify-between gap-3 px-3"
+									>
+										<span className="flex items-center gap-2.5 truncate flex-1 min-w-0">
+											{icon}
+											<span className="truncate font-mono text-xs">
+												{branch.name}
+											</span>
+
+											{/* Inline badges */}
+											<span className="flex items-center gap-1.5 shrink-0">
+												{branch.name === defaultBranch && (
+													<span className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+														default
+													</span>
+												)}
+												{isExternal && !activeWorkspaceId && (
+													<span className="text-[10px] text-muted-foreground/60 bg-muted/60 px-1.5 py-0.5 rounded">
+														external
+													</span>
+												)}
+											</span>
+										</span>
+
+										{/* Right side: time + buttons */}
+										<span className="flex items-center gap-2 shrink-0">
+											{branch.lastCommitDate > 0 && (
+												<span className="text-[11px] text-muted-foreground/70 group-data-[selected=true]:hidden">
+													{formatRelativeTime(branch.lastCommitDate)}
+												</span>
 											)}
 
-										{/* Action buttons - show on hover/select */}
-										<span className="hidden group-data-[selected=true]:flex items-center gap-1.5">
-											{hasExistingWorkspace && (
+											{/* Show checkmark for selected base branch when not hovering */}
+											{!hasExistingWorkspace &&
+												effectiveCompareBaseBranch === branch.name && (
+													<HiCheck className="size-4 text-primary group-data-[selected=true]:hidden" />
+												)}
+
+											{/* Action buttons - show on hover/select */}
+											<span className="hidden group-data-[selected=true]:flex items-center gap-1.5">
+												{hasExistingWorkspace && (
+													<Button
+														size="sm"
+														variant="ghost"
+														className="h-7 px-2.5 text-xs font-medium hover:bg-accent/10 hover:text-accent-foreground"
+														onClick={(e) => {
+															e.stopPropagation();
+															if (activeWorkspaceId) {
+																onOpenActiveWorkspace(activeWorkspaceId);
+															} else if (openAction) {
+																onOpenWorktree(openAction);
+															}
+															setOpen(false);
+														}}
+													>
+														<GoArrowUpRight className="size-3.5 mr-1" />
+														Open
+														<span className="ml-1 text-[10px] opacity-60">
+															↵
+														</span>
+													</Button>
+												)}
 												<Button
 													size="sm"
-													variant="ghost"
-													className="h-7 px-2.5 text-xs font-medium hover:bg-accent/10 hover:text-accent-foreground"
+													className="h-7 px-2.5 text-xs font-medium"
 													onClick={(e) => {
 														e.stopPropagation();
-														if (activeWorkspaceId) {
-															onOpenActiveWorkspace(activeWorkspaceId);
-														} else if (openAction) {
-															onOpenWorktree(openAction);
-														}
+														onSelectCompareBaseBranch(branch.name);
 														setOpen(false);
 													}}
 												>
-													<GoArrowUpRight className="size-3.5 mr-1" />
-													Open
-													<span className="ml-1 text-[10px] opacity-60">↵</span>
+													{hasExistingWorkspace ? (
+														<>
+															<PlusIcon className="size-3.5 mr-1" />
+															Create
+															<span className="ml-1 text-[10px] opacity-70">
+																{modKey}↵
+															</span>
+														</>
+													) : (
+														<>
+															Create
+															<span className="ml-1 text-[10px] opacity-70">
+																↵
+															</span>
+														</>
+													)}
 												</Button>
-											)}
-											<Button
-												size="sm"
-												className="h-7 px-2.5 text-xs font-medium"
-												onClick={(e) => {
-													e.stopPropagation();
-													onSelectCompareBaseBranch(branch.name);
-													setOpen(false);
-												}}
-											>
-												{hasExistingWorkspace ? (
-													<>
-														<PlusIcon className="size-3.5 mr-1" />
-														Create
-														<span className="ml-1 text-[10px] opacity-70">
-															{modKey}↵
-														</span>
-													</>
-												) : (
-													<>
-														Create
-														<span className="ml-1 text-[10px] opacity-70">
-															↵
-														</span>
-													</>
-												)}
-											</Button>
+											</span>
 										</span>
-									</span>
-								</CommandItem>
-							);
-						})}
-					</CommandList>
-				</Command>
-			</PopoverContent>
-		</Popover>
-	);
-}
+									</CommandItem>
+								);
+							})}
+						</CommandList>
+					</Command>
+				</PopoverContent>
+			</Popover>
+		);
+	},
+);
 
 function PromptGroupInner({
 	projectId,
@@ -592,8 +602,10 @@ function PromptGroupInner({
 	const [issueLinkOpen, setIssueLinkOpen] = useState(false);
 	const [gitHubIssueLinkOpen, setGitHubIssueLinkOpen] = useState(false);
 	const [prLinkOpen, setPRLinkOpen] = useState(false);
+	const [isSSH, setIsSSH] = useState(false);
 	const plusMenuRef = useRef<HTMLDivElement>(null);
 	const submitStartedRef = useRef(false);
+	const handleCreateRef = useRef<(() => Promise<void>) | null>(null);
 	const trimmedPrompt = prompt.trim();
 	const firstIssueSlug = linkedIssues[0]?.slug ?? null;
 
@@ -742,7 +754,7 @@ function PromptGroupInner({
 				? workspaceName.trim()
 				: trimmedPrompt || "New workspace";
 		const willGenerateAIName =
-			!branchNameEdited && !!trimmedPrompt && !linkedPR;
+			!isSSH && !branchNameEdited && !!trimmedPrompt && !linkedPR;
 		const pendingWorkspaceId = crypto.randomUUID();
 		const detachedFiles = attachments.takeFiles();
 
@@ -998,6 +1010,7 @@ ${sanitizeText(truncatedBody)}`;
 									)
 								: aiBranchName) || undefined,
 						compareBaseBranch: compareBaseBranch || undefined,
+						...(isSSH ? { ssh: true } : {}),
 					},
 					{
 						agentLaunchRequest: launchRequest ?? undefined,
@@ -1035,6 +1048,7 @@ ${sanitizeText(truncatedBody)}`;
 		createFromPr,
 		createWorkspace,
 		generateBranchNameMutation,
+		isSSH,
 		linkedIssues,
 		linkedPR,
 		projectId,
@@ -1053,20 +1067,27 @@ ${sanitizeText(truncatedBody)}`;
 	}, [handleCreate]);
 
 	useEffect(() => {
+		handleCreateRef.current = handleCreate;
+	}, [handleCreate]);
+
+	useEffect(() => {
 		if (!isNewWorkspaceModalOpen) return;
 		const handler = (e: KeyboardEvent) => {
 			if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
 				e.preventDefault();
-				void handleCreate();
+				void handleCreateRef.current?.();
 			}
 		};
 		window.addEventListener("keydown", handler);
 		return () => window.removeEventListener("keydown", handler);
-	}, [isNewWorkspaceModalOpen, handleCreate]);
+	}, [isNewWorkspaceModalOpen]);
 
-	const handleCompareBaseBranchSelect = (selectedBaseBranch: string) => {
-		updateDraft({ compareBaseBranch: selectedBaseBranch });
-	};
+	const handleCompareBaseBranchSelect = useCallback(
+		(selectedBaseBranch: string) => {
+			updateDraft({ compareBaseBranch: selectedBaseBranch });
+		},
+		[updateDraft],
+	);
 
 	const handleOpenWorktree = useCallback(
 		(action: OpenableWorktreeAction) => {
@@ -1215,6 +1236,27 @@ ${sanitizeText(truncatedBody)}`;
 					/>
 				</div>
 			</div>
+
+			<div className="flex items-center gap-2">
+				<Checkbox
+					id="ssh-workspace"
+					checked={isSSH}
+					onCheckedChange={(checked) => setIsSSH(checked === true)}
+					className="size-3.5"
+				/>
+				<label
+					htmlFor="ssh-workspace"
+					className="text-xs text-muted-foreground cursor-pointer select-none"
+				>
+					SSH workspace
+				</label>
+			</div>
+			{isSSH && (
+				<p className="text-[11px] text-muted-foreground/60 leading-relaxed">
+					This workspace will connect to a remote devcontainer via SSH.
+					Configure in Settings &gt; Terminal.
+				</p>
+			)}
 
 			<PromptInput
 				onSubmit={handlePromptSubmit}

--- a/apps/desktop/src/renderer/index.tsx
+++ b/apps/desktop/src/renderer/index.tsx
@@ -16,6 +16,7 @@ import { persistentHistory } from "./lib/persistent-hash-history";
 import { posthog } from "./lib/posthog";
 import { electronQueryClient } from "./providers/ElectronTRPCProvider";
 import { routeTree } from "./routeTree.gen";
+import { useTabsStore } from "./stores/tabs/store";
 
 import "./globals.css";
 import "./styles/bundled-fonts.css";
@@ -42,9 +43,38 @@ const handleDeepLink = (path: string) => {
 	console.log("[deep-link] Navigating to:", path);
 	router.navigate({ to: path });
 };
+interface OpenTabPayload {
+	workspaceId: string;
+	type: string;
+	url?: string;
+	focus?: boolean;
+}
+
+const handleOpenTab = (payload: OpenTabPayload) => {
+	console.log(
+		"[deep-link] Opening tab:",
+		payload.type,
+		"in workspace",
+		payload.workspaceId,
+	);
+
+	if (payload.type === "webview" && payload.url) {
+		useTabsStore.getState().addBrowserTab(payload.workspaceId, payload.url);
+
+		if (payload.focus) {
+			localStorage.setItem("lastViewedWorkspaceId", payload.workspaceId);
+			router.navigate({
+				to: "/workspace/$workspaceId",
+				params: { workspaceId: payload.workspaceId },
+			});
+		}
+	}
+};
+
 const ipcRenderer = window.ipcRenderer as typeof window.ipcRenderer | undefined;
 if (ipcRenderer) {
 	ipcRenderer.on("deep-link-navigate", handleDeepLink);
+	ipcRenderer.on("deep-link-open-tab", handleOpenTab);
 } else {
 	reportBootError(
 		"Renderer preload not available (window.ipcRenderer missing)",
@@ -56,6 +86,7 @@ if (import.meta.hot) {
 		unsubscribe();
 		if (ipcRenderer) {
 			ipcRenderer.off("deep-link-navigate", handleDeepLink);
+			ipcRenderer.off("deep-link-open-tab", handleOpenTab);
 		}
 		cleanupBootErrorHandling();
 	});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/WebviewOverlay/WebviewOverlay.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/WebviewOverlay/WebviewOverlay.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useRef } from "react";
+import { useTabsStore } from "renderer/stores/tabs/store";
+import {
+	getOrCreateWebview,
+	setOverlayContainer,
+	syncAllPositions,
+} from "renderer/stores/webview-overlay";
+
+/**
+ * Persistent overlay container for all browser webviews.
+ *
+ * Mounted at the dashboard layout level so it survives workspace/tab route
+ * changes. Webview DOM elements are never reparented — only shown/hidden and
+ * repositioned — which prevents Electron from reloading them.
+ */
+export function WebviewOverlay() {
+	const overlayRef = useRef<HTMLDivElement>(null);
+
+	// Register the overlay container with the module-level manager
+	useEffect(() => {
+		setOverlayContainer(overlayRef.current);
+		return () => setOverlayContainer(null);
+	}, []);
+
+	// Create webviews as panes appear in the store.
+	// Destruction is handled by useBrowserLifecycle.
+	useEffect(() => {
+		// Initialize from current state
+		const state = useTabsStore.getState();
+		for (const [id, pane] of Object.entries(state.panes)) {
+			if (pane.type === "webview") {
+				getOrCreateWebview(id, pane.browser?.currentUrl ?? "about:blank");
+			}
+		}
+
+		return useTabsStore.subscribe((state) => {
+			for (const [id, pane] of Object.entries(state.panes)) {
+				if (pane.type === "webview") {
+					getOrCreateWebview(id, pane.browser?.currentUrl ?? "about:blank");
+				}
+			}
+		});
+	}, []);
+
+	// Sync webview positions to slot rects on resize / layout changes
+	useEffect(() => {
+		let rafId: number | null = null;
+
+		const scheduleSync = () => {
+			if (rafId !== null) return;
+			rafId = requestAnimationFrame(() => {
+				syncAllPositions();
+				rafId = null;
+			});
+		};
+
+		// Observe the parent for size changes (sidebar toggle, window resize, etc.)
+		const resizeObserver = new ResizeObserver(scheduleSync);
+		if (overlayRef.current?.parentElement) {
+			resizeObserver.observe(overlayRef.current.parentElement);
+		}
+
+		window.addEventListener("resize", scheduleSync);
+
+		// Periodic fallback for edge cases (pane splits, drag-resize, etc.)
+		const intervalId = setInterval(scheduleSync, 150);
+
+		return () => {
+			if (rafId !== null) cancelAnimationFrame(rafId);
+			resizeObserver.disconnect();
+			window.removeEventListener("resize", scheduleSync);
+			clearInterval(intervalId);
+		};
+	}, []);
+
+	return (
+		<div
+			ref={overlayRef}
+			style={{
+				position: "fixed",
+				inset: 0,
+				pointerEvents: "none",
+				zIndex: 50,
+			}}
+		/>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/WebviewOverlay/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/WebviewOverlay/index.ts
@@ -1,0 +1,1 @@
+export { WebviewOverlay } from "./WebviewOverlay";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -21,6 +21,7 @@ import {
 	useWorkspaceSidebarStore,
 } from "renderer/stores/workspace-sidebar-state";
 import { TopBar } from "./components/TopBar";
+import { WebviewOverlay } from "./components/WebviewOverlay";
 
 export const Route = createFileRoute("/_authenticated/_dashboard")({
 	component: DashboardLayout,
@@ -134,6 +135,7 @@ function DashboardLayout() {
 					/>
 				)}
 			</div>
+			<WebviewOverlay />
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/TerminalSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/TerminalSettings.tsx
@@ -7,6 +7,7 @@ import {
 import { LinkBehaviorSetting } from "./components/LinkBehaviorSetting";
 import { PresetsSection } from "./components/PresetsSection";
 import { SessionsSection } from "./components/SessionsSection";
+import { SshSection } from "./components/SshSection";
 
 interface TerminalSettingsProps {
 	visibleItems?: SettingItemId[] | null;
@@ -60,6 +61,10 @@ export function TerminalSettings({
 		SETTING_ITEM_ID.TERMINAL_SESSIONS,
 		visibleItems,
 	);
+	const showSshWorkspaces = isItemVisible(
+		SETTING_ITEM_ID.TERMINAL_SSH_WORKSPACES,
+		visibleItems,
+	);
 
 	return (
 		<div className="p-6 max-w-7xl w-full">
@@ -83,6 +88,7 @@ export function TerminalSettings({
 					/>
 				)}
 				{showLinkBehavior && <LinkBehaviorSetting key="link-behavior" />}
+				{showSshWorkspaces && <SshSection key="ssh-workspaces" />}
 				{showSessions && <SessionsSection key="sessions" />}
 			</SectionList>
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/SshSection/SshSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/SshSection/SshSection.tsx
@@ -1,0 +1,133 @@
+import { Label } from "@superset/ui/label";
+import { Textarea } from "@superset/ui/textarea";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+
+function ScriptField({
+	label,
+	description,
+	placeholder,
+	value,
+	onChange,
+}: {
+	label: string;
+	description?: string;
+	placeholder: string;
+	value: string;
+	onChange: (value: string) => void;
+}) {
+	return (
+		<div className="space-y-1.5">
+			<Label className="text-sm font-medium">{label}</Label>
+			{description && (
+				<p className="text-xs text-muted-foreground">{description}</p>
+			)}
+			<Textarea
+				className="font-mono text-xs min-h-[60px] resize-y"
+				placeholder={placeholder}
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+			/>
+		</div>
+	);
+}
+
+export function SshSection() {
+	const { data: devcontainerScript } =
+		electronTrpc.settings.getDevcontainerScript.useQuery();
+	const { data: teardownScript } =
+		electronTrpc.settings.getTeardownScript.useQuery();
+
+	const setDevcontainerMutation =
+		electronTrpc.settings.setDevcontainerScript.useMutation();
+	const setTeardownMutation =
+		electronTrpc.settings.setTeardownScript.useMutation();
+
+	const [devcontainerValue, setDevcontainerValue] = useState("");
+	const [teardownValue, setTeardownValue] = useState("");
+
+	const devcontainerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+		null,
+	);
+	const teardownTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	useEffect(() => {
+		if (devcontainerScript !== undefined) {
+			setDevcontainerValue(devcontainerScript ?? "");
+		}
+	}, [devcontainerScript]);
+
+	useEffect(() => {
+		if (teardownScript !== undefined) {
+			setTeardownValue(teardownScript ?? "");
+		}
+	}, [teardownScript]);
+
+	useEffect(() => {
+		return () => {
+			if (devcontainerTimerRef.current)
+				clearTimeout(devcontainerTimerRef.current);
+			if (teardownTimerRef.current) clearTimeout(teardownTimerRef.current);
+		};
+	}, []);
+
+	const handleDevcontainerChange = useCallback(
+		(value: string) => {
+			setDevcontainerValue(value);
+			if (devcontainerTimerRef.current)
+				clearTimeout(devcontainerTimerRef.current);
+			devcontainerTimerRef.current = setTimeout(() => {
+				devcontainerTimerRef.current = null;
+				setDevcontainerMutation.mutate({
+					script: value.trim() || null,
+				});
+			}, 500);
+		},
+		[setDevcontainerMutation],
+	);
+
+	const handleTeardownChange = useCallback(
+		(value: string) => {
+			setTeardownValue(value);
+			if (teardownTimerRef.current) clearTimeout(teardownTimerRef.current);
+			teardownTimerRef.current = setTimeout(() => {
+				teardownTimerRef.current = null;
+				setTeardownMutation.mutate({
+					script: value.trim() || null,
+				});
+			}, 500);
+		},
+		[setTeardownMutation],
+	);
+
+	return (
+		<div className="space-y-4">
+			<div className="space-y-0.5">
+				<h3 className="text-sm font-semibold">SSH Workspaces</h3>
+				<p className="text-xs text-muted-foreground">
+					Configure scripts for creating and destroying remote devcontainers.
+				</p>
+			</div>
+
+			<ScriptField
+				label="Devcontainer Script"
+				description={
+					"Shell command that runs when creating an SSH workspace. " +
+					"Env vars: $SUPERSET_REPO_URL, $SUPERSET_BRANCH, $SUPERSET_BRANCH_NO_PREFIX, $SUPERSET_NEW_BRANCH (1 or 0), $SUPERSET_WORKSPACE_NAME, $SUPERSET_WORKSPACE_ID. " +
+					"Must print JSON to stdout: { host, port, user, workDir, identityFile?, containerName? }"
+				}
+				placeholder='outpost create "$SUPERSET_BRANCH_NO_PREFIX" --repo "$SUPERSET_REPO_URL" --branch "$SUPERSET_BRANCH" --json'
+				value={devcontainerValue}
+				onChange={handleDevcontainerChange}
+			/>
+
+			<ScriptField
+				label="Teardown Script"
+				description="Shell command that runs when deleting an SSH workspace. Env vars: $SUPERSET_CONTAINER_NAME, $SUPERSET_HOST. Failures are non-fatal — the workspace is always deleted locally."
+				placeholder='outpost destroy "$SUPERSET_CONTAINER_NAME"'
+				value={teardownValue}
+				onChange={handleTeardownChange}
+			/>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/SshSection/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/SshSection/index.ts
@@ -1,0 +1,1 @@
+export { SshSection } from "./SshSection";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -39,6 +39,7 @@ export const SETTING_ITEM_ID = {
 	TERMINAL_QUICK_ADD: "terminal-quick-add",
 	TERMINAL_SESSIONS: "terminal-sessions",
 	TERMINAL_LINK_BEHAVIOR: "terminal-link-behavior",
+	TERMINAL_SSH_WORKSPACES: "terminal-ssh-workspaces",
 
 	MODELS_ANTHROPIC: "models-anthropic",
 	MODELS_OPENAI: "models-openai",
@@ -615,6 +616,22 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"cmd",
 			"ctrl",
 			"browser",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.TERMINAL_SSH_WORKSPACES,
+		section: "terminal",
+		title: "SSH Workspaces",
+		description: "Scripts for creating and destroying remote devcontainers",
+		keywords: [
+			"ssh",
+			"remote",
+			"devcontainer",
+			"teardown",
+			"workspace",
+			"script",
+			"container",
+			"cloud",
 		],
 	},
 	{

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/CollapsedWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/CollapsedWorkspaceItem.tsx
@@ -25,7 +25,7 @@ interface CollapsedWorkspaceItemProps {
 	id: string;
 	name: string;
 	branch: string;
-	type: "worktree" | "branch";
+	type: "worktree" | "branch" | "ssh";
 	isActive: boolean;
 	isUnread: boolean;
 	workspaceStatus: ActivePaneStatus | null;
@@ -81,6 +81,7 @@ export function CollapsedWorkspaceItem({
 		>
 			<WorkspaceIcon
 				isBranchWorkspace={isBranchWorkspace}
+				isSSH={type === "ssh"}
 				isActive={isActive}
 				isUnread={isUnread}
 				workspaceStatus={workspaceStatus}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceIcon.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceIcon.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@superset/ui/utils";
-import { LuFolderGit2, LuLaptop } from "react-icons/lu";
+import { LuCloud, LuFolderGit2, LuLaptop } from "react-icons/lu";
 import { AsciiSpinner } from "renderer/screens/main/components/AsciiSpinner";
 import { StatusIndicator } from "renderer/screens/main/components/StatusIndicator";
 import type { ActivePaneStatus } from "shared/tabs-types";
@@ -7,6 +7,7 @@ import { STROKE_WIDTH } from "../constants";
 
 interface WorkspaceIconProps {
 	isBranchWorkspace: boolean;
+	isSSH: boolean;
 	isActive: boolean;
 	isUnread: boolean;
 	workspaceStatus: ActivePaneStatus | null;
@@ -20,6 +21,7 @@ const OVERLAY_POSITION = {
 
 export function WorkspaceIcon({
 	isBranchWorkspace,
+	isSSH,
 	isActive,
 	isUnread,
 	workspaceStatus,
@@ -32,6 +34,15 @@ export function WorkspaceIcon({
 		<>
 			{workspaceStatus === "working" ? (
 				<AsciiSpinner className="text-base" />
+			) : isSSH ? (
+				<LuCloud
+					className={cn(
+						"size-4",
+						variant === "expanded" && "transition-colors",
+						iconColor,
+					)}
+					strokeWidth={STROKE_WIDTH}
+				/>
 			) : isBranchWorkspace ? (
 				<LuLaptop
 					className={cn(

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -39,7 +39,7 @@ interface WorkspaceListItemProps {
 	worktreePath: string;
 	name: string;
 	branch: string;
-	type: "worktree" | "branch";
+	type: "worktree" | "branch" | "ssh";
 	isUnread?: boolean;
 	index: number;
 	shortcutIndex?: number;
@@ -321,6 +321,7 @@ export function WorkspaceListItem({
 						<div className="relative size-5 flex items-center justify-center">
 							<WorkspaceIcon
 								isBranchWorkspace={isBranchWorkspace}
+								isSSH={type === "ssh"}
 								isActive={isActive}
 								isUnread={isUnread}
 								workspaceStatus={workspaceStatus}
@@ -329,7 +330,14 @@ export function WorkspaceListItem({
 						</div>
 					</TooltipTrigger>
 					<TooltipContent side="right" sideOffset={8}>
-						{isBranchWorkspace ? (
+						{type === "ssh" ? (
+							<>
+								<p className="text-xs font-medium">SSH workspace</p>
+								<p className="text-xs text-muted-foreground">
+									Connected to a remote devcontainer via SSH
+								</p>
+							</>
+						) : isBranchWorkspace ? (
 							<>
 								<p className="text-xs font-medium">Local workspace</p>
 								<p className="text-xs text-muted-foreground">
@@ -380,7 +388,6 @@ export function WorkspaceListItem({
 							>
 								{isBranchWorkspace ? "local" : name || branch}
 							</span>
-
 							{isBranchWorkspace && aheadBehind && (
 								<WorkspaceAheadBehind
 									ahead={aheadBehind.ahead}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/DeleteWorkspaceDialog/DeleteWorkspaceDialog.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/DeleteWorkspaceDialog/DeleteWorkspaceDialog.tsx
@@ -26,7 +26,7 @@ const TERMINAL_COUNT_STALE_TIME_MS = 1_000;
 interface DeleteWorkspaceDialogProps {
 	workspaceId: string;
 	workspaceName: string;
-	workspaceType?: "worktree" | "branch";
+	workspaceType?: "worktree" | "branch" | "ssh";
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/WorkspaceHoverCard.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/WorkspaceHoverCard.tsx
@@ -64,6 +64,8 @@ export function WorkspaceHoverCardContent({
 
 	const worktreeName = worktreeInfo?.worktreeName;
 	const branchName = worktreeInfo?.branchName;
+	const sshConfig = worktreeInfo?.sshConfig;
+	const isSshWorkspace = !!sshConfig;
 	const hasCustomAlias =
 		workspaceAlias && worktreeName && workspaceAlias !== worktreeName;
 
@@ -100,6 +102,19 @@ export function WorkspaceHoverCardContent({
 						)}
 					</div>
 				)}
+				{sshConfig && (
+					<div className="space-y-0.5">
+						<span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+							SSH Connection
+						</span>
+						<div className="text-xs font-mono space-y-0.5">
+							<div>
+								{sshConfig.user}@{sshConfig.host}:{sshConfig.port}
+							</div>
+							<div className="text-muted-foreground">{sshConfig.workDir}</div>
+						</div>
+					</div>
+				)}
 				{worktreeInfo?.createdAt && (
 					<span className="text-xs text-muted-foreground block">
 						{formatDistanceToNow(worktreeInfo.createdAt, { addSuffix: true })}
@@ -120,7 +135,7 @@ export function WorkspaceHoverCardContent({
 				</div>
 			)}
 
-			{isLoadingGithub ? (
+			{!isSshWorkspace && isLoadingGithub ? (
 				<div className="flex items-center gap-2 text-muted-foreground pt-2 border-t border-border">
 					<LuLoaderCircle
 						className="size-3 animate-spin"
@@ -128,7 +143,7 @@ export function WorkspaceHoverCardContent({
 					/>
 					<span className="text-xs">Loading PR...</span>
 				</div>
-			) : pr ? (
+			) : !isSshWorkspace && pr ? (
 				<div className="pt-2 border-t border-border space-y-2">
 					<div className="flex items-center justify-between">
 						<div className="flex items-center gap-1.5 flex-wrap">
@@ -184,7 +199,7 @@ export function WorkspaceHoverCardContent({
 					</Button>
 					{previewButton}
 				</div>
-			) : repoUrl ? (
+			) : !isSshWorkspace && repoUrl ? (
 				<div className="pt-2 border-t border-border space-y-2">
 					<div className="text-xs text-muted-foreground">
 						No PR for this branch

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/BrowserPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/BrowserPane.tsx
@@ -46,17 +46,14 @@ export function BrowserPane({
 		electronTrpc.browser.openDevTools.useMutation();
 
 	const {
-		containerRef,
+		slotRef,
 		goBack,
 		goForward,
 		reload,
 		navigateTo,
 		canGoBack,
 		canGoForward,
-	} = usePersistentWebview({
-		paneId,
-		initialUrl: currentUrl,
-	});
+	} = usePersistentWebview({ paneId });
 
 	const handleOpenDevTools = useCallback(() => {
 		openDevTools({ paneId });
@@ -114,13 +111,16 @@ export function BrowserPane({
 				</div>
 			)}
 		>
-			<div className="relative flex flex-1 h-full">
-				<div ref={containerRef} className="w-full h-full" style={{ flex: 1 }} />
+			<div className="relative flex flex-1 h-full pointer-events-none">
+				{/* Transparent slot — the overlay positions the real webview behind this */}
+				<div ref={slotRef} className="w-full h-full" style={{ flex: 1 }} />
 				{loadError && !isLoading && (
-					<BrowserErrorOverlay error={loadError} onRetry={reload} />
+					<div className="pointer-events-auto">
+						<BrowserErrorOverlay error={loadError} onRetry={reload} />
+					</div>
 				)}
 				{isBlankPage && !isLoading && !loadError && (
-					<div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-background pointer-events-none">
+					<div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-background">
 						<GlobeIcon className="size-10 text-muted-foreground/30" />
 						<div className="text-center">
 							<p className="text-sm font-medium text-muted-foreground/50">

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/index.ts
@@ -1,4 +1,1 @@
-export {
-	destroyPersistentWebview,
-	usePersistentWebview,
-} from "./usePersistentWebview";
+export { usePersistentWebview } from "./usePersistentWebview";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
@@ -1,87 +1,14 @@
 import { useCallback, useEffect, useRef } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useTabsStore } from "renderer/stores/tabs/store";
-
-// ---------------------------------------------------------------------------
-// Module-level singletons
-// ---------------------------------------------------------------------------
-
-const webviewRegistry = new Map<string, Electron.WebviewTag>();
-/** Tracks paneId → last-registered webContentsId so we can re-register if it changes. */
-const registeredWebContentsIds = new Map<string, number>();
-let hiddenContainer: HTMLDivElement | null = null;
-
-function getHiddenContainer(): HTMLDivElement {
-	if (!hiddenContainer) {
-		hiddenContainer = document.createElement("div");
-		hiddenContainer.style.position = "fixed";
-		hiddenContainer.style.left = "-9999px";
-		hiddenContainer.style.top = "-9999px";
-		hiddenContainer.style.width = "100vw";
-		hiddenContainer.style.height = "100vh";
-		hiddenContainer.style.overflow = "hidden";
-		hiddenContainer.style.pointerEvents = "none";
-		document.body.appendChild(hiddenContainer);
-	}
-	return hiddenContainer;
-}
-
-// ---------------------------------------------------------------------------
-// Disable webview interaction during ANY drag operation.
-// Electron <webview> tags create separate compositor layers that swallow
-// drag events before they reach the mosaic drop targets. Setting
-// pointer-events:none directly on the <webview> element tells the
-// compositor to stop routing events to the guest process.
-//
-// We use native HTML5 drag events (capture phase) rather than the drag pane
-// store because the store only covers mosaic pane drags — not tab-bar drags
-// or other drag sources.
-// ---------------------------------------------------------------------------
-
-function setWebviewsDragPassthrough(passthrough: boolean) {
-	for (const webview of webviewRegistry.values()) {
-		webview.style.pointerEvents = passthrough ? "none" : "";
-	}
-}
-
-window.addEventListener(
-	"dragstart",
-	() => setWebviewsDragPassthrough(true),
-	true,
-);
-window.addEventListener(
-	"dragend",
-	() => setWebviewsDragPassthrough(false),
-	true,
-);
-window.addEventListener("drop", () => setWebviewsDragPassthrough(false), true);
-
-/** Call from useBrowserLifecycle when a pane is removed. */
-export function destroyPersistentWebview(paneId: string): void {
-	const webview = webviewRegistry.get(paneId);
-	if (webview) {
-		webview.remove();
-		webviewRegistry.delete(paneId);
-	}
-	registeredWebContentsIds.delete(paneId);
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function sanitizeUrl(url: string): string {
-	if (/^https?:\/\//i.test(url) || url.startsWith("about:")) {
-		return url;
-	}
-	if (url.startsWith("localhost") || url.startsWith("127.0.0.1")) {
-		return `http://${url}`;
-	}
-	if (url.includes(".")) {
-		return `https://${url}`;
-	}
-	return `https://www.google.com/search?q=${encodeURIComponent(url)}`;
-}
+import {
+	registerSlot,
+	unregisterSlot,
+	webviewGoBack,
+	webviewGoForward,
+	webviewNavigateTo,
+	webviewReload,
+} from "renderer/stores/webview-overlay";
 
 // ---------------------------------------------------------------------------
 // Hook
@@ -89,32 +16,34 @@ function sanitizeUrl(url: string): string {
 
 interface UsePersistentWebviewOptions {
 	paneId: string;
-	initialUrl: string;
 }
 
-export function usePersistentWebview({
-	paneId,
-	initialUrl,
-}: UsePersistentWebviewOptions) {
-	const containerRef = useRef<HTMLDivElement | null>(null);
-	const isHistoryNavigation = useRef(false);
-	const faviconUrlRef = useRef<string | undefined>(undefined);
-	const initialUrlRef = useRef(initialUrl);
+/**
+ * Connects a BrowserPane to the global webview overlay.
+ *
+ * - Registers a "slot" element so the overlay knows where to position the
+ *   webview.
+ * - Subscribes to tRPC events (new-window, context-menu) that only matter
+ *   while the pane UI is visible.
+ * - Exposes navigation helpers that operate on the overlay-managed webview.
+ */
+export function usePersistentWebview({ paneId }: UsePersistentWebviewOptions) {
+	const slotRef = useRef<HTMLDivElement | null>(null);
 
-	const navigateBrowserHistory = useTabsStore((s) => s.navigateBrowserHistory);
 	const browserState = useTabsStore((s) => s.panes[paneId]?.browser);
 	const historyIndex = browserState?.historyIndex ?? 0;
 	const historyLength = browserState?.history.length ?? 0;
 	const canGoBack = historyIndex > 0;
 	const canGoForward = historyIndex < historyLength - 1;
 
-	const { mutate: registerBrowser } =
-		electronTrpc.browser.register.useMutation();
-	const { mutate: upsertHistory } =
-		electronTrpc.browserHistory.upsert.useMutation();
+	// Register / unregister the slot element with the overlay manager
+	useEffect(() => {
+		const el = slotRef.current;
+		if (el) registerSlot(paneId, el);
+		return () => unregisterSlot(paneId);
+	}, [paneId]);
 
 	// Subscribe to new-window events (target="_blank" links, window.open)
-	// handled via setWindowOpenHandler in the main process
 	electronTrpc.browser.onNewWindow.useSubscription(
 		{ paneId },
 		{
@@ -146,267 +75,18 @@ export function usePersistentWebview({
 		},
 	);
 
-	// Sync store from webview state (handles agent-triggered navigation while hidden)
-	const syncStoreFromWebview = useCallback(
-		(webview: Electron.WebviewTag) => {
-			try {
-				const url = webview.getURL();
-				const title = webview.getTitle();
-				if (url) {
-					const store = useTabsStore.getState();
-					const currentUrl = store.panes[paneId]?.browser?.currentUrl;
-					if (url !== currentUrl) {
-						store.updateBrowserUrl(
-							paneId,
-							url,
-							title ?? "",
-							faviconUrlRef.current,
-						);
-					}
-				}
-			} catch {
-				// webview may not be ready
-			}
-		},
-		[paneId],
-	);
+	// -- Navigation methods ------------------------------------------------
 
-	// Main lifecycle effect: create or reclaim webview, attach events, park on unmount
-	useEffect(() => {
-		const container = containerRef.current;
-		if (!container) return;
-
-		let webview = webviewRegistry.get(paneId);
-
-		if (webview) {
-			// Reclaim from hidden container
-			container.appendChild(webview);
-			syncStoreFromWebview(webview);
-		} else {
-			// Create new webview
-			webview = document.createElement("webview") as Electron.WebviewTag;
-			webview.setAttribute("partition", "persist:superset");
-			webview.setAttribute("allowpopups", "");
-			webview.style.display = "flex";
-			webview.style.flex = "1";
-			webview.style.width = "100%";
-			webview.style.height = "100%";
-			webview.style.border = "none";
-
-			webviewRegistry.set(paneId, webview);
-			container.appendChild(webview);
-
-			const finalUrl = sanitizeUrl(initialUrlRef.current);
-			webview.src = finalUrl;
-		}
-
-		const wv = webview;
-
-		// -- Event handlers ------------------------------------------------
-
-		const handleDomReady = () => {
-			const webContentsId = wv.getWebContentsId();
-			const previousId = registeredWebContentsIds.get(paneId);
-			// Register on first load, or re-register if webContentsId changed (e.g. after DOM reparenting)
-			if (previousId !== webContentsId) {
-				registeredWebContentsIds.set(paneId, webContentsId);
-				registerBrowser({ paneId, webContentsId });
-			}
-		};
-
-		const handleDidStartLoading = () => {
-			const store = useTabsStore.getState();
-			store.updateBrowserLoading(paneId, true);
-			store.setBrowserError(paneId, null);
-			faviconUrlRef.current = undefined;
-		};
-
-		const handleDidStopLoading = () => {
-			const store = useTabsStore.getState();
-			store.updateBrowserLoading(paneId, false);
-
-			if (isHistoryNavigation.current) {
-				isHistoryNavigation.current = false;
-				return;
-			}
-
-			const url = wv.getURL();
-			const title = wv.getTitle();
-			store.updateBrowserUrl(
-				paneId,
-				url ?? "",
-				title ?? "",
-				faviconUrlRef.current,
-			);
-
-			if (url && url !== "about:blank") {
-				upsertHistory({
-					url,
-					title: title ?? "",
-					faviconUrl: faviconUrlRef.current ?? null,
-				});
-			}
-		};
-
-		const handleDidNavigate = (e: Electron.DidNavigateEvent) => {
-			if (isHistoryNavigation.current) {
-				isHistoryNavigation.current = false;
-				return;
-			}
-			const store = useTabsStore.getState();
-			store.updateBrowserUrl(
-				paneId,
-				e.url ?? "",
-				wv.getTitle() ?? "",
-				faviconUrlRef.current,
-			);
-			store.updateBrowserLoading(paneId, false);
-		};
-
-		const handleDidNavigateInPage = (e: Electron.DidNavigateInPageEvent) => {
-			if (isHistoryNavigation.current) {
-				isHistoryNavigation.current = false;
-				return;
-			}
-			const store = useTabsStore.getState();
-			store.updateBrowserUrl(
-				paneId,
-				e.url ?? "",
-				wv.getTitle() ?? "",
-				faviconUrlRef.current,
-			);
-		};
-
-		const handlePageTitleUpdated = (e: Electron.PageTitleUpdatedEvent) => {
-			const store = useTabsStore.getState();
-			const currentUrl = store.panes[paneId]?.browser?.currentUrl ?? "";
-			store.updateBrowserUrl(
-				paneId,
-				currentUrl,
-				e.title ?? "",
-				faviconUrlRef.current,
-			);
-		};
-
-		const handlePageFaviconUpdated = (e: Electron.PageFaviconUpdatedEvent) => {
-			const favicons = e.favicons;
-			if (favicons && favicons.length > 0) {
-				faviconUrlRef.current = favicons[0];
-				const store = useTabsStore.getState();
-				const currentUrl = store.panes[paneId]?.browser?.currentUrl ?? "";
-				const currentTitle =
-					store.panes[paneId]?.browser?.history[
-						store.panes[paneId]?.browser?.historyIndex ?? 0
-					]?.title ?? "";
-				store.updateBrowserUrl(paneId, currentUrl, currentTitle, favicons[0]);
-				if (currentUrl && currentUrl !== "about:blank") {
-					upsertHistory({
-						url: currentUrl,
-						title: currentTitle,
-						faviconUrl: favicons[0],
-					});
-				}
-			}
-		};
-
-		const handleDidFailLoad = (e: Electron.DidFailLoadEvent) => {
-			if (e.errorCode === -3) return; // ERR_ABORTED
-			const store = useTabsStore.getState();
-			store.updateBrowserLoading(paneId, false);
-			store.setBrowserError(paneId, {
-				code: e.errorCode ?? 0,
-				description: e.errorDescription ?? "",
-				url: e.validatedURL ?? "",
-			});
-		};
-
-		// -- Attach listeners ----------------------------------------------
-
-		wv.addEventListener("dom-ready", handleDomReady);
-		wv.addEventListener("did-start-loading", handleDidStartLoading);
-		wv.addEventListener("did-stop-loading", handleDidStopLoading);
-		wv.addEventListener("did-navigate", handleDidNavigate as EventListener);
-		wv.addEventListener(
-			"did-navigate-in-page",
-			handleDidNavigateInPage as EventListener,
-		);
-		wv.addEventListener(
-			"page-title-updated",
-			handlePageTitleUpdated as EventListener,
-		);
-		wv.addEventListener(
-			"page-favicon-updated",
-			handlePageFaviconUpdated as EventListener,
-		);
-		wv.addEventListener("did-fail-load", handleDidFailLoad as EventListener);
-
-		// -- Cleanup: park in hidden container -----------------------------
-
-		return () => {
-			wv.removeEventListener("dom-ready", handleDomReady);
-			wv.removeEventListener("did-start-loading", handleDidStartLoading);
-			wv.removeEventListener("did-stop-loading", handleDidStopLoading);
-			wv.removeEventListener(
-				"did-navigate",
-				handleDidNavigate as EventListener,
-			);
-			wv.removeEventListener(
-				"did-navigate-in-page",
-				handleDidNavigateInPage as EventListener,
-			);
-			wv.removeEventListener(
-				"page-title-updated",
-				handlePageTitleUpdated as EventListener,
-			);
-			wv.removeEventListener(
-				"page-favicon-updated",
-				handlePageFaviconUpdated as EventListener,
-			);
-			wv.removeEventListener(
-				"did-fail-load",
-				handleDidFailLoad as EventListener,
-			);
-
-			getHiddenContainer().appendChild(wv);
-		};
-		// paneId is stable for the lifetime of a pane; initialUrlRef only used on first create.
-	}, [paneId, registerBrowser, syncStoreFromWebview, upsertHistory]);
-
-	// -- Navigation methods (operate directly on the webview) ---------------
-
-	const goBack = useCallback(() => {
-		const url = navigateBrowserHistory(paneId, "back");
-		if (url) {
-			isHistoryNavigation.current = true;
-			const webview = webviewRegistry.get(paneId);
-			if (webview) webview.loadURL(sanitizeUrl(url));
-		}
-	}, [paneId, navigateBrowserHistory]);
-
-	const goForward = useCallback(() => {
-		const url = navigateBrowserHistory(paneId, "forward");
-		if (url) {
-			isHistoryNavigation.current = true;
-			const webview = webviewRegistry.get(paneId);
-			if (webview) webview.loadURL(sanitizeUrl(url));
-		}
-	}, [paneId, navigateBrowserHistory]);
-
-	const reload = useCallback(() => {
-		const webview = webviewRegistry.get(paneId);
-		if (webview) webview.reload();
-	}, [paneId]);
-
+	const goBack = useCallback(() => webviewGoBack(paneId), [paneId]);
+	const goForward = useCallback(() => webviewGoForward(paneId), [paneId]);
+	const reload = useCallback(() => webviewReload(paneId), [paneId]);
 	const navigateTo = useCallback(
-		(url: string) => {
-			const webview = webviewRegistry.get(paneId);
-			if (webview) webview.loadURL(sanitizeUrl(url));
-		},
+		(url: string) => webviewNavigateTo(paneId, url),
 		[paneId],
 	);
 
 	return {
-		containerRef,
+		slotRef,
 		goBack,
 		goForward,
 		reload,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
@@ -1,6 +1,5 @@
 import { Alert, AlertDescription, AlertTitle } from "@superset/ui/alert";
 import { Button } from "@superset/ui/button";
-import { useParams } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { MosaicBranch } from "react-mosaic-component";
 import type { MarkdownEditorAdapter } from "renderer/components/MarkdownRenderer";
@@ -54,6 +53,7 @@ interface FileViewerPaneProps {
 	paneId: string;
 	path: MosaicBranch[];
 	tabId: string;
+	workspaceId: string;
 	worktreePath: string;
 	splitPaneAuto: (
 		tabId: string,
@@ -117,6 +117,7 @@ export function FileViewerPane({
 	paneId,
 	path,
 	tabId,
+	workspaceId,
 	worktreePath,
 	splitPaneAuto,
 	splitPaneHorizontal,
@@ -127,8 +128,6 @@ export function FileViewerPane({
 	onMoveToTab,
 	onMoveToNewTab,
 }: FileViewerPaneProps) {
-	const { workspaceId } = useParams({ strict: false });
-	const normalizedWorkspaceId = workspaceId ?? worktreePath;
 	const fileViewer = useTabsStore((s) => s.panes[paneId]?.fileViewer);
 	const isFocused = useTabsStore((s) => s.focusedPaneIds[tabId] === paneId);
 	const equalizePaneSplits = useTabsStore((s) => s.equalizePaneSplits);
@@ -160,13 +159,13 @@ export function FileViewerPane({
 	const documentKey = useMemo(
 		() =>
 			buildEditorDocumentKey({
-				workspaceId: normalizedWorkspaceId,
+				workspaceId,
 				filePath,
 				diffCategory,
 				commitHash,
 				oldPath,
 			}),
-		[normalizedWorkspaceId, filePath, diffCategory, commitHash, oldPath],
+		[workspaceId, filePath, diffCategory, commitHash, oldPath],
 	);
 	const documentState = useEditorDocumentsStore(
 		(state) => state.documents[documentKey],
@@ -225,7 +224,7 @@ export function FileViewerPane({
 	});
 
 	useEffect(() => {
-		if (!fileViewer || !normalizedWorkspaceId) {
+		if (!fileViewer) {
 			return;
 		}
 
@@ -237,7 +236,7 @@ export function FileViewerPane({
 		bindFileViewerSession(
 			paneId,
 			{
-				workspaceId: normalizedWorkspaceId,
+				workspaceId,
 				filePath,
 				diffCategory,
 				commitHash,
@@ -255,7 +254,7 @@ export function FileViewerPane({
 	}, [
 		paneId,
 		fileViewer,
-		normalizedWorkspaceId,
+		workspaceId,
 		filePath,
 		diffCategory,
 		commitHash,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
@@ -184,6 +184,7 @@ export function TabView({ tab }: TabViewProps) {
 						paneId={paneId}
 						path={path}
 						tabId={tab.id}
+						workspaceId={tab.workspaceId}
 						worktreePath={worktreePath}
 						splitPaneAuto={splitPaneAuto}
 						splitPaneHorizontal={splitPaneHorizontal}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -272,25 +272,30 @@ export const Terminal = ({ paneId, tabId, workspaceId }: TerminalProps) => {
 	handleStreamErrorRef.current = handleStreamError;
 
 	// Stream subscription
-	electronTrpc.terminal.stream.useSubscription(paneId, {
-		onData: (event) => {
-			if (connectionErrorRef.current && event.type === "data") {
-				setConnectionError(null);
-				retryCountRef.current = 0;
-			}
-			handleStreamData(event);
+	electronTrpc.terminal.stream.useSubscription(
+		{ paneId, workspaceId },
+		{
+			onData: (event) => {
+				if (connectionErrorRef.current && event.type === "data") {
+					setConnectionError(null);
+					retryCountRef.current = 0;
+				}
+				handleStreamData(event);
+			},
+			onError: (error) => {
+				console.error("[Terminal] Stream subscription error:", {
+					paneId,
+					error: error instanceof Error ? error.message : String(error),
+				});
+				setConnectionError(
+					error instanceof Error
+						? error.message
+						: "Connection to terminal lost",
+				);
+			},
+			enabled: true,
 		},
-		onError: (error) => {
-			console.error("[Terminal] Stream subscription error:", {
-				paneId,
-				error: error instanceof Error ? error.message : String(error),
-			});
-			setConnectionError(
-				error instanceof Error ? error.message : "Connection to terminal lost",
-			);
-		},
-		enabled: true,
-	});
+	);
 
 	// Auto-retry when connection error is set
 	useEffect(() => {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/index.tsx
@@ -4,6 +4,7 @@ import { useParams } from "@tanstack/react-router";
 import { useEffect, useMemo, useRef } from "react";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import { resolveActiveTabIdForWorkspace } from "renderer/stores/tabs/utils";
+import { syncAllPositions } from "renderer/stores/webview-overlay";
 import { EmptyTabView } from "./EmptyTabView";
 import { TabView } from "./TabView";
 import { getTabsToRender } from "./utils/getTabsToRender";
@@ -81,7 +82,13 @@ export function TabsContent({
 			tabId: nextTabId,
 		};
 
-		if (!didActivationChange || !nextTabId) {
+		if (!didActivationChange) {
+			return;
+		}
+
+		syncAllPositions();
+
+		if (!nextTabId) {
 			return;
 		}
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/index.tsx
@@ -1,10 +1,12 @@
 import type { ExternalApp } from "@superset/local-db";
+import { cn } from "@superset/ui/utils";
 import { useParams } from "@tanstack/react-router";
 import { useEffect, useMemo, useRef } from "react";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import { resolveActiveTabIdForWorkspace } from "renderer/stores/tabs/utils";
 import { EmptyTabView } from "./EmptyTabView";
 import { TabView } from "./TabView";
+import { getTabsToRender } from "./utils/getTabsToRender";
 
 interface TabsContentProps {
 	defaultExternalApp?: ExternalApp | null;
@@ -19,6 +21,7 @@ export function TabsContent({
 }: TabsContentProps) {
 	const { workspaceId: activeWorkspaceId } = useParams({ strict: false });
 	const allTabs = useTabsStore((s) => s.tabs);
+	const panes = useTabsStore((s) => s.panes);
 	const activeTabIds = useTabsStore((s) => s.activeTabIds);
 	const tabHistoryStacks = useTabsStore((s) => s.tabHistoryStacks);
 	const contentRef = useRef<HTMLDivElement>(null);
@@ -47,10 +50,15 @@ export function TabsContent({
 		return resolvedActiveTabId;
 	}, [activeWorkspaceId, activeTabIds, allTabs, tabHistoryStacks]);
 
-	const tabToRender = useMemo(() => {
-		if (!activeTabId) return null;
-		return allTabs.find((tab) => tab.id === activeTabId) || null;
-	}, [activeTabId, allTabs]);
+	const tabsToRender = useMemo(
+		() =>
+			getTabsToRender({
+				activeTabId,
+				tabs: allTabs,
+				panes,
+			}),
+		[activeTabId, allTabs, panes],
+	);
 
 	useEffect(() => {
 		const nextWorkspaceId = activeWorkspaceId ?? null;
@@ -79,7 +87,7 @@ export function TabsContent({
 
 		const frameId = requestAnimationFrame(() => {
 			const textarea = contentRef.current?.querySelector<HTMLTextAreaElement>(
-				".mosaic-window-focused [data-slot=input-group-control]",
+				'[data-active-tab-content="true"] .mosaic-window-focused [data-slot="input-group-control"]',
 			);
 			textarea?.focus();
 		});
@@ -88,16 +96,36 @@ export function TabsContent({
 	}, [activeTabId, activeWorkspaceId]);
 
 	return (
-		<div ref={contentRef} className="flex-1 min-h-0 flex overflow-hidden">
-			{tabToRender ? (
-				<TabView tab={tabToRender} />
-			) : (
-				<EmptyTabView
-					defaultExternalApp={defaultExternalApp}
-					onOpenInApp={onOpenInApp}
-					onOpenQuickOpen={onOpenQuickOpen}
-				/>
-			)}
+		<div
+			ref={contentRef}
+			className="relative flex flex-1 min-h-0 overflow-hidden"
+		>
+			{tabsToRender.map((tab) => {
+				const isActive = tab.id === activeTabId;
+
+				return (
+					<div
+						key={tab.id}
+						data-active-tab-content={isActive ? "true" : undefined}
+						aria-hidden={!isActive}
+						className={cn(
+							"absolute inset-0 min-h-0",
+							isActive ? "visible z-10" : "invisible pointer-events-none",
+						)}
+					>
+						<TabView tab={tab} />
+					</div>
+				);
+			})}
+			{activeTabId === null ? (
+				<div className="absolute inset-0 z-10 flex min-h-0 overflow-hidden">
+					<EmptyTabView
+						defaultExternalApp={defaultExternalApp}
+						onOpenInApp={onOpenInApp}
+						onOpenQuickOpen={onOpenQuickOpen}
+					/>
+				</div>
+			) : null}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/utils/getTabsToRender/getTabsToRender.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/utils/getTabsToRender/getTabsToRender.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "bun:test";
+import type { Pane, Tab } from "renderer/stores/tabs/types";
+import { getTabsToRender } from "./getTabsToRender";
+
+function createTab(id: string, workspaceId: string, paneId: string): Tab {
+	return {
+		id,
+		name: id,
+		workspaceId,
+		layout: paneId,
+		createdAt: 1,
+	};
+}
+
+function createPane(id: string, tabId: string, type: Pane["type"]): Pane {
+	return {
+		id,
+		tabId,
+		type,
+		name: id,
+	};
+}
+
+describe("getTabsToRender", () => {
+	it("keeps the active tab first and adds inactive browser tabs", () => {
+		const tabs = [
+			createTab("tab-terminal", "ws-1", "pane-terminal"),
+			createTab("tab-browser", "ws-1", "pane-browser"),
+			createTab("tab-chat", "ws-1", "pane-chat"),
+		];
+		const panes: Record<string, Pane> = {
+			"pane-terminal": createPane("pane-terminal", "tab-terminal", "terminal"),
+			"pane-browser": createPane("pane-browser", "tab-browser", "webview"),
+			"pane-chat": createPane("pane-chat", "tab-chat", "chat"),
+		};
+
+		expect(
+			getTabsToRender({
+				activeTabId: "tab-terminal",
+				tabs,
+				panes,
+			}).map((tab) => tab.id),
+		).toEqual(["tab-terminal", "tab-browser"]);
+	});
+
+	it("does not duplicate the active browser tab", () => {
+		const tabs = [createTab("tab-browser", "ws-1", "pane-browser")];
+		const panes: Record<string, Pane> = {
+			"pane-browser": createPane("pane-browser", "tab-browser", "webview"),
+		};
+
+		expect(
+			getTabsToRender({
+				activeTabId: "tab-browser",
+				tabs,
+				panes,
+			}).map((tab) => tab.id),
+		).toEqual(["tab-browser"]);
+	});
+
+	it("keeps browser tabs mounted across workspaces", () => {
+		const tabs = [
+			createTab("tab-terminal", "ws-1", "pane-terminal"),
+			createTab("tab-browser", "ws-2", "pane-browser"),
+		];
+		const panes: Record<string, Pane> = {
+			"pane-terminal": createPane("pane-terminal", "tab-terminal", "terminal"),
+			"pane-browser": createPane("pane-browser", "tab-browser", "webview"),
+		};
+
+		expect(
+			getTabsToRender({
+				activeTabId: "tab-terminal",
+				tabs,
+				panes,
+			}).map((tab) => tab.id),
+		).toEqual(["tab-terminal", "tab-browser"]);
+	});
+
+	it("ignores a stale active tab id and still keeps browser tabs mounted", () => {
+		const tabs = [
+			createTab("tab-terminal", "ws-1", "pane-terminal"),
+			createTab("tab-browser", "ws-1", "pane-browser"),
+		];
+		const panes: Record<string, Pane> = {
+			"pane-terminal": createPane("pane-terminal", "tab-terminal", "terminal"),
+			"pane-browser": createPane("pane-browser", "tab-browser", "webview"),
+		};
+
+		expect(
+			getTabsToRender({
+				activeTabId: "tab-missing",
+				tabs,
+				panes,
+			}).map((tab) => tab.id),
+		).toEqual(["tab-browser"]);
+	});
+
+	it("skips inactive tabs without a browser pane", () => {
+		const tabs = [
+			createTab("tab-terminal", "ws-1", "pane-terminal"),
+			createTab("tab-chat", "ws-2", "pane-chat"),
+		];
+		const panes: Record<string, Pane> = {
+			"pane-terminal": createPane("pane-terminal", "tab-terminal", "terminal"),
+			"pane-chat": createPane("pane-chat", "tab-chat", "chat"),
+		};
+
+		expect(
+			getTabsToRender({
+				activeTabId: null,
+				tabs,
+				panes,
+			}),
+		).toEqual([]);
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/utils/getTabsToRender/getTabsToRender.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/utils/getTabsToRender/getTabsToRender.ts
@@ -1,0 +1,45 @@
+import type { Pane, Tab } from "renderer/stores/tabs/types";
+import { extractPaneIdsFromLayout } from "renderer/stores/tabs/utils";
+
+interface GetTabsToRenderOptions {
+	activeTabId: string | null;
+	tabs: Tab[];
+	panes: Record<string, Pane>;
+}
+
+function tabHasBrowserPane(tab: Tab, panes: Record<string, Pane>): boolean {
+	for (const paneId of extractPaneIdsFromLayout(tab.layout)) {
+		if (panes[paneId]?.type === "webview") {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+export function getTabsToRender({
+	activeTabId,
+	tabs,
+	panes,
+}: GetTabsToRenderOptions): Tab[] {
+	const tabsToRender: Tab[] = [];
+	const seenTabIds = new Set<string>();
+
+	const pushTab = (tab: Tab | null | undefined) => {
+		if (!tab || seenTabIds.has(tab.id)) return;
+		seenTabIds.add(tab.id);
+		tabsToRender.push(tab);
+	};
+
+	pushTab(tabs.find((tab) => tab.id === activeTabId));
+
+	// Intentionally keep browser-bearing tabs mounted across workspaces so their
+	// webviews preserve page state while hidden during workspace switches.
+	for (const tab of tabs) {
+		if (tab.id === activeTabId) continue;
+		if (!tabHasBrowserPane(tab, panes)) continue;
+		pushTab(tab);
+	}
+
+	return tabsToRender;
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/utils/getTabsToRender/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/utils/getTabsToRender/index.ts
@@ -1,0 +1,1 @@
+export { getTabsToRender } from "./getTabsToRender";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/SshConfigPanel/SshConfigPanel.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/SshConfigPanel/SshConfigPanel.tsx
@@ -1,0 +1,201 @@
+import { Button } from "@superset/ui/button";
+import { Input } from "@superset/ui/input";
+import { Label } from "@superset/ui/label";
+import { useCallback, useEffect, useState } from "react";
+import { LuCheck, LuRotateCcw } from "react-icons/lu";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+
+interface SshConfig {
+	host: string;
+	port: number;
+	user: string;
+	workDir: string;
+	identityFile?: string;
+	containerName?: string;
+}
+
+interface SshConfigPanelProps {
+	workspaceId: string;
+	sshConfig: SshConfig;
+}
+
+export function SshConfigPanel({
+	workspaceId,
+	sshConfig,
+}: SshConfigPanelProps) {
+	const [host, setHost] = useState(sshConfig.host);
+	const [port, setPort] = useState(sshConfig.port);
+	const [user, setUser] = useState(sshConfig.user);
+	const [workDir, setWorkDir] = useState(sshConfig.workDir);
+	const [identityFile, setIdentityFile] = useState(
+		sshConfig.identityFile ?? "",
+	);
+	const [containerName, setContainerName] = useState(
+		sshConfig.containerName ?? "",
+	);
+
+	useEffect(() => {
+		setHost(sshConfig.host);
+		setPort(sshConfig.port);
+		setUser(sshConfig.user);
+		setWorkDir(sshConfig.workDir);
+		setIdentityFile(sshConfig.identityFile ?? "");
+		setContainerName(sshConfig.containerName ?? "");
+	}, [sshConfig]);
+
+	const trpcUtils = electronTrpc.useUtils();
+	const updateMutation = electronTrpc.workspaces.updateSshConfig.useMutation({
+		onSuccess: () => {
+			trpcUtils.workspaces.getWorktreeInfo.invalidate({ workspaceId });
+		},
+	});
+
+	const hasChanges =
+		host !== sshConfig.host ||
+		port !== sshConfig.port ||
+		user !== sshConfig.user ||
+		workDir !== sshConfig.workDir ||
+		identityFile !== (sshConfig.identityFile ?? "") ||
+		containerName !== (sshConfig.containerName ?? "");
+
+	const handleSave = useCallback(() => {
+		updateMutation.mutate({
+			id: workspaceId,
+			sshConfig: {
+				host,
+				port,
+				user,
+				workDir,
+				...(identityFile ? { identityFile } : {}),
+				...(containerName ? { containerName } : {}),
+			},
+		});
+	}, [
+		workspaceId,
+		host,
+		port,
+		user,
+		workDir,
+		identityFile,
+		containerName,
+		updateMutation,
+	]);
+
+	const handleReset = useCallback(() => {
+		setHost(sshConfig.host);
+		setPort(sshConfig.port);
+		setUser(sshConfig.user);
+		setWorkDir(sshConfig.workDir);
+		setIdentityFile(sshConfig.identityFile ?? "");
+		setContainerName(sshConfig.containerName ?? "");
+	}, [sshConfig]);
+
+	return (
+		<div className="flex flex-col gap-4 p-3 overflow-y-auto">
+			<div className="flex flex-col gap-1.5">
+				<Label htmlFor="ssh-host" className="text-xs text-muted-foreground">
+					Host
+				</Label>
+				<Input
+					id="ssh-host"
+					value={host}
+					onChange={(e) => setHost(e.target.value)}
+					className="h-7 text-xs"
+					placeholder="hostname or IP"
+				/>
+			</div>
+
+			<div className="flex flex-col gap-1.5">
+				<Label htmlFor="ssh-port" className="text-xs text-muted-foreground">
+					Port
+				</Label>
+				<Input
+					id="ssh-port"
+					type="number"
+					value={port}
+					onChange={(e) => setPort(Number(e.target.value))}
+					className="h-7 text-xs"
+					placeholder="22"
+				/>
+			</div>
+
+			<div className="flex flex-col gap-1.5">
+				<Label htmlFor="ssh-user" className="text-xs text-muted-foreground">
+					User
+				</Label>
+				<Input
+					id="ssh-user"
+					value={user}
+					onChange={(e) => setUser(e.target.value)}
+					className="h-7 text-xs"
+					placeholder="root"
+				/>
+			</div>
+
+			<div className="flex flex-col gap-1.5">
+				<Label htmlFor="ssh-workdir" className="text-xs text-muted-foreground">
+					Working Directory
+				</Label>
+				<Input
+					id="ssh-workdir"
+					value={workDir}
+					onChange={(e) => setWorkDir(e.target.value)}
+					className="h-7 text-xs"
+					placeholder="/home/user/project"
+				/>
+			</div>
+
+			<div className="flex flex-col gap-1.5">
+				<Label htmlFor="ssh-identity" className="text-xs text-muted-foreground">
+					Identity File
+				</Label>
+				<Input
+					id="ssh-identity"
+					value={identityFile}
+					onChange={(e) => setIdentityFile(e.target.value)}
+					className="h-7 text-xs"
+					placeholder="~/.ssh/id_rsa (optional)"
+				/>
+			</div>
+
+			<div className="flex flex-col gap-1.5">
+				<Label
+					htmlFor="ssh-container"
+					className="text-xs text-muted-foreground"
+				>
+					Container Name
+				</Label>
+				<Input
+					id="ssh-container"
+					value={containerName}
+					onChange={(e) => setContainerName(e.target.value)}
+					className="h-7 text-xs"
+					placeholder="my-container (optional)"
+				/>
+			</div>
+
+			{hasChanges && (
+				<div className="flex items-center gap-2 pt-1">
+					<Button
+						size="sm"
+						variant="default"
+						className="h-7 text-xs flex-1"
+						onClick={handleSave}
+						disabled={updateMutation.isPending || !host || !user || !workDir}
+					>
+						<LuCheck className="size-3 mr-1" />
+						{updateMutation.isPending ? "Saving..." : "Save"}
+					</Button>
+					<Button
+						size="sm"
+						variant="ghost"
+						className="h-7 text-xs"
+						onClick={handleReset}
+					>
+						<LuRotateCcw className="size-3" />
+					</Button>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/SshConfigPanel/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/SshConfigPanel/index.ts
@@ -1,0 +1,1 @@
+export { SshConfigPanel } from "./SshConfigPanel";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
@@ -6,6 +6,7 @@ import {
 	LuExpand,
 	LuFile,
 	LuGitCompareArrows,
+	LuMonitorSmartphone,
 	LuShrink,
 	LuX,
 } from "react-icons/lu";
@@ -22,6 +23,7 @@ import type { ChangeCategory, ChangedFile } from "shared/changes-types";
 import { useScrollContext } from "../ChangesContent";
 import { ChangesView } from "./ChangesView";
 import { FilesView } from "./FilesView";
+import { SshConfigPanel } from "./SshConfigPanel";
 import { getSidebarHeaderTabButtonClassName } from "./headerTabStyles";
 
 function TabButton({
@@ -78,6 +80,12 @@ export function RightSidebar() {
 		{ enabled: !!workspaceId },
 	);
 	const worktreePath = workspace?.worktreePath;
+	const { data: worktreeInfo } =
+		electronTrpc.workspaces.getWorktreeInfo.useQuery(
+			{ workspaceId: workspaceId ?? "" },
+			{ enabled: !!workspaceId },
+		);
+	const isSSH = !!worktreeInfo?.sshConfig;
 	const currentMode = useSidebarStore((s) => s.currentMode);
 	const rightSidebarTab = useSidebarStore((s) => s.rightSidebarTab);
 	const setRightSidebarTab = useSidebarStore((s) => s.setRightSidebarTab);
@@ -177,6 +185,15 @@ export function RightSidebar() {
 						label="Files"
 						compact={compactTabs}
 					/>
+					{isSSH && (
+						<TabButton
+							isActive={rightSidebarTab === RightSidebarTab.SSH}
+							onClick={() => setRightSidebarTab(RightSidebarTab.SSH)}
+							icon={<LuMonitorSmartphone className="size-3.5" />}
+							label="SSH"
+							compact={compactTabs}
+						/>
+					)}
 				</div>
 				<div className="flex-1" />
 				<div className="flex items-center h-10 pr-2 gap-0.5">
@@ -236,13 +253,25 @@ export function RightSidebar() {
 			)}
 			<div
 				className={
-					rightSidebarTab === RightSidebarTab.Changes && showChangesTab
-						? "hidden"
-						: "flex-1 min-h-0 flex flex-col overflow-hidden"
+					rightSidebarTab === RightSidebarTab.Files ||
+					(!showChangesTab && rightSidebarTab === RightSidebarTab.Changes)
+						? "flex-1 min-h-0 flex flex-col overflow-hidden"
+						: "hidden"
 				}
 			>
 				<FilesView />
 			</div>
+			{rightSidebarTab === RightSidebarTab.SSH &&
+				isSSH &&
+				workspaceId &&
+				worktreeInfo.sshConfig && (
+					<div className="flex-1 min-h-0 flex flex-col overflow-hidden">
+						<SshConfigPanel
+							workspaceId={workspaceId}
+							sshConfig={worktreeInfo.sshConfig}
+						/>
+					</div>
+				)}
 		</aside>
 	);
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useBrowserLifecycle/useBrowserLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useBrowserLifecycle/useBrowserLifecycle.ts
@@ -1,11 +1,8 @@
 import { useEffect, useRef } from "react";
-import { electronTrpc } from "renderer/lib/electron-trpc";
-import { destroyPersistentWebview } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview";
 import { useTabsStore } from "renderer/stores/tabs/store";
+import { destroyWebview } from "renderer/stores/webview-overlay";
 
 export function useBrowserLifecycle() {
-	const { mutate: unregisterBrowser } =
-		electronTrpc.browser.unregister.useMutation();
 	const previousPaneIdsRef = useRef<Set<string>>(new Set());
 
 	useEffect(() => {
@@ -25,11 +22,10 @@ export function useBrowserLifecycle() {
 			);
 			for (const prevId of previousPaneIdsRef.current) {
 				if (!currentBrowserPaneIds.has(prevId)) {
-					destroyPersistentWebview(prevId);
-					unregisterBrowser({ paneId: prevId });
+					destroyWebview(prevId);
 				}
 			}
 			previousPaneIdsRef.current = currentBrowserPaneIds;
 		});
-	}, [unregisterBrowser]);
+	}, []);
 }

--- a/apps/desktop/src/renderer/stores/sidebar-state.ts
+++ b/apps/desktop/src/renderer/stores/sidebar-state.ts
@@ -9,6 +9,7 @@ export enum SidebarMode {
 export enum RightSidebarTab {
 	Changes = "changes",
 	Files = "files",
+	SSH = "ssh",
 }
 
 export const DEFAULT_SIDEBAR_WIDTH = 250;

--- a/apps/desktop/src/renderer/stores/webview-overlay.ts
+++ b/apps/desktop/src/renderer/stores/webview-overlay.ts
@@ -31,7 +31,6 @@ interface WebviewEntry {
 const webviews = new Map<string, WebviewEntry>();
 const slots = new Map<string, HTMLElement>();
 let overlayContainer: HTMLDivElement | null = null;
-const slotListeners = new Set<() => void>();
 
 // ---------------------------------------------------------------------------
 // Overlay container (called by WebviewOverlay component)
@@ -116,7 +115,6 @@ export function destroyWebview(paneId: string): void {
 	webviews.delete(paneId);
 	electronTrpcClient.browser.unregister.mutate({ paneId }).catch(() => {});
 }
-
 
 // ---------------------------------------------------------------------------
 // Event handlers (permanent — not tied to React lifecycle)
@@ -248,7 +246,6 @@ export function registerSlot(paneId: string, element: HTMLElement): void {
 	slots.set(paneId, element);
 	// syncPosition checks visibility and sets display accordingly
 	syncPosition(paneId);
-	notifySlotListeners();
 }
 
 export function unregisterSlot(paneId: string): void {
@@ -257,11 +254,6 @@ export function unregisterSlot(paneId: string): void {
 	if (entry) {
 		entry.wrapper.style.display = "none";
 	}
-	notifySlotListeners();
-}
-
-function notifySlotListeners(): void {
-	for (const listener of slotListeners) listener();
 }
 
 // ---------------------------------------------------------------------------
@@ -280,6 +272,23 @@ export function syncPosition(paneId: string): void {
 	if (!isVisible) {
 		entry.wrapper.style.display = "none";
 		return;
+	}
+
+	// Hide the webview when BrowserPane is showing an error or blank-state
+	// overlay. Those overlays render inside the normal stacking context and
+	// cannot compete with the fixed z-index overlay, so we hide the webview
+	// wrapper to let the underlying UI show through.
+	const browserState = useTabsStore.getState().panes[paneId]?.browser;
+	if (browserState) {
+		const hasError = browserState.error && !browserState.isLoading;
+		const isBlank =
+			browserState.currentUrl === "about:blank" &&
+			!browserState.isLoading &&
+			!browserState.error;
+		if (hasError || isBlank) {
+			entry.wrapper.style.display = "none";
+			return;
+		}
 	}
 
 	entry.wrapper.style.display = "block";
@@ -328,3 +337,21 @@ export function webviewGoForward(paneId: string): void {
 		if (entry) entry.webview.loadURL(sanitizeUrl(url));
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Drag passthrough — prevent webviews from swallowing pane/tab drags
+// ---------------------------------------------------------------------------
+
+function setAllWrappersPointerEvents(value: string): void {
+	for (const entry of webviews.values()) {
+		entry.wrapper.style.pointerEvents = value;
+	}
+}
+
+window.addEventListener(
+	"dragstart",
+	() => setAllWrappersPointerEvents("none"),
+	true,
+);
+window.addEventListener("dragend", () => setAllWrappersPointerEvents(""), true);
+window.addEventListener("drop", () => setAllWrappersPointerEvents(""), true);

--- a/apps/desktop/src/renderer/stores/webview-overlay.ts
+++ b/apps/desktop/src/renderer/stores/webview-overlay.ts
@@ -1,0 +1,330 @@
+/**
+ * Module-level manager for persistent webview elements.
+ *
+ * Webviews live in a single overlay container mounted at the dashboard layout
+ * level. They are NEVER reparented in the DOM — only shown/hidden and
+ * repositioned — so Electron never reloads their guest processes.
+ *
+ * BrowserPane registers a "slot" (the DOM element where the webview should
+ * visually appear). The overlay positions each webview wrapper to match its
+ * slot's bounding rect.
+ */
+
+import { electronTrpcClient } from "renderer/lib/trpc-client";
+import { useTabsStore } from "renderer/stores/tabs/store";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface WebviewEntry {
+	webview: Electron.WebviewTag;
+	wrapper: HTMLDivElement;
+	webContentsId: number | null;
+	faviconUrl: string | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+const webviews = new Map<string, WebviewEntry>();
+const slots = new Map<string, HTMLElement>();
+let overlayContainer: HTMLDivElement | null = null;
+const slotListeners = new Set<() => void>();
+
+// ---------------------------------------------------------------------------
+// Overlay container (called by WebviewOverlay component)
+// ---------------------------------------------------------------------------
+
+export function setOverlayContainer(el: HTMLDivElement | null): void {
+	overlayContainer = el;
+	if (el) {
+		for (const entry of webviews.values()) {
+			if (!el.contains(entry.wrapper)) {
+				el.appendChild(entry.wrapper);
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// URL helpers
+// ---------------------------------------------------------------------------
+
+function sanitizeUrl(url: string): string {
+	if (/^https?:\/\//i.test(url) || url.startsWith("about:")) return url;
+	if (url.startsWith("localhost") || url.startsWith("127.0.0.1"))
+		return `http://${url}`;
+	if (url.includes(".")) return `https://${url}`;
+	return `https://www.google.com/search?q=${encodeURIComponent(url)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Webview lifecycle
+// ---------------------------------------------------------------------------
+
+export function getOrCreateWebview(
+	paneId: string,
+	initialUrl: string,
+): WebviewEntry {
+	const existing = webviews.get(paneId);
+	if (existing) return existing;
+
+	// Wrapper — positioned absolutely by the overlay
+	const wrapper = document.createElement("div");
+	wrapper.style.position = "absolute";
+	wrapper.style.overflow = "hidden";
+	wrapper.style.display = "none"; // hidden until a slot is registered
+	wrapper.style.pointerEvents = "auto";
+	wrapper.dataset.webviewPane = paneId;
+
+	// Webview element
+	const webview = document.createElement("webview") as Electron.WebviewTag;
+	webview.setAttribute("partition", "persist:superset");
+	webview.setAttribute("allowpopups", "");
+	webview.style.display = "flex";
+	webview.style.flex = "1";
+	webview.style.width = "100%";
+	webview.style.height = "100%";
+	webview.style.border = "none";
+
+	wrapper.appendChild(webview);
+
+	const entry: WebviewEntry = {
+		webview,
+		wrapper,
+		webContentsId: null,
+		faviconUrl: undefined,
+	};
+	webviews.set(paneId, entry);
+
+	if (overlayContainer) {
+		overlayContainer.appendChild(wrapper);
+	}
+
+	webview.src = sanitizeUrl(initialUrl);
+	attachEventHandlers(paneId, entry);
+
+	return entry;
+}
+
+export function destroyWebview(paneId: string): void {
+	const entry = webviews.get(paneId);
+	if (!entry) return;
+	entry.wrapper.remove();
+	webviews.delete(paneId);
+	electronTrpcClient.browser.unregister.mutate({ paneId }).catch(() => {});
+}
+
+
+// ---------------------------------------------------------------------------
+// Event handlers (permanent — not tied to React lifecycle)
+// ---------------------------------------------------------------------------
+
+function attachEventHandlers(paneId: string, entry: WebviewEntry): void {
+	const { webview } = entry;
+
+	const handleDomReady = () => {
+		const id = webview.getWebContentsId();
+		if (entry.webContentsId !== id) {
+			entry.webContentsId = id;
+			electronTrpcClient.browser.register
+				.mutate({ paneId, webContentsId: id })
+				.catch(() => {});
+		}
+	};
+
+	const handleDidStartLoading = () => {
+		const store = useTabsStore.getState();
+		store.updateBrowserLoading(paneId, true);
+		store.setBrowserError(paneId, null);
+		entry.faviconUrl = undefined;
+	};
+
+	const handleDidStopLoading = () => {
+		const store = useTabsStore.getState();
+		store.updateBrowserLoading(paneId, false);
+
+		const url = webview.getURL();
+		const title = webview.getTitle();
+		store.updateBrowserUrl(paneId, url ?? "", title ?? "", entry.faviconUrl);
+
+		if (url && url !== "about:blank") {
+			electronTrpcClient.browserHistory.upsert
+				.mutate({
+					url,
+					title: title ?? "",
+					faviconUrl: entry.faviconUrl ?? null,
+				})
+				.catch(() => {});
+		}
+	};
+
+	const handleDidNavigate = (e: Electron.DidNavigateEvent) => {
+		const store = useTabsStore.getState();
+		store.updateBrowserUrl(
+			paneId,
+			e.url ?? "",
+			webview.getTitle() ?? "",
+			entry.faviconUrl,
+		);
+		store.updateBrowserLoading(paneId, false);
+	};
+
+	const handleDidNavigateInPage = (e: Electron.DidNavigateInPageEvent) => {
+		const store = useTabsStore.getState();
+		store.updateBrowserUrl(
+			paneId,
+			e.url ?? "",
+			webview.getTitle() ?? "",
+			entry.faviconUrl,
+		);
+	};
+
+	const handlePageTitleUpdated = (e: Electron.PageTitleUpdatedEvent) => {
+		const store = useTabsStore.getState();
+		const currentUrl = store.panes[paneId]?.browser?.currentUrl ?? "";
+		store.updateBrowserUrl(paneId, currentUrl, e.title ?? "", entry.faviconUrl);
+	};
+
+	const handlePageFaviconUpdated = (e: Electron.PageFaviconUpdatedEvent) => {
+		const favicons = e.favicons;
+		if (favicons?.length > 0) {
+			entry.faviconUrl = favicons[0];
+			const store = useTabsStore.getState();
+			const browser = store.panes[paneId]?.browser;
+			const currentUrl = browser?.currentUrl ?? "";
+			const currentTitle =
+				browser?.history[browser?.historyIndex ?? 0]?.title ?? "";
+			store.updateBrowserUrl(paneId, currentUrl, currentTitle, favicons[0]);
+			if (currentUrl && currentUrl !== "about:blank") {
+				electronTrpcClient.browserHistory.upsert
+					.mutate({
+						url: currentUrl,
+						title: currentTitle,
+						faviconUrl: favicons[0],
+					})
+					.catch(() => {});
+			}
+		}
+	};
+
+	const handleDidFailLoad = (e: Electron.DidFailLoadEvent) => {
+		if (e.errorCode === -3) return; // ERR_ABORTED
+		const store = useTabsStore.getState();
+		store.updateBrowserLoading(paneId, false);
+		store.setBrowserError(paneId, {
+			code: e.errorCode ?? 0,
+			description: e.errorDescription ?? "",
+			url: e.validatedURL ?? "",
+		});
+	};
+
+	webview.addEventListener("dom-ready", handleDomReady);
+	webview.addEventListener("did-start-loading", handleDidStartLoading);
+	webview.addEventListener("did-stop-loading", handleDidStopLoading);
+	webview.addEventListener("did-navigate", handleDidNavigate as EventListener);
+	webview.addEventListener(
+		"did-navigate-in-page",
+		handleDidNavigateInPage as EventListener,
+	);
+	webview.addEventListener(
+		"page-title-updated",
+		handlePageTitleUpdated as EventListener,
+	);
+	webview.addEventListener(
+		"page-favicon-updated",
+		handlePageFaviconUpdated as EventListener,
+	);
+	webview.addEventListener("did-fail-load", handleDidFailLoad as EventListener);
+}
+
+// ---------------------------------------------------------------------------
+// Slot management (called by BrowserPane)
+// ---------------------------------------------------------------------------
+
+export function registerSlot(paneId: string, element: HTMLElement): void {
+	slots.set(paneId, element);
+	// syncPosition checks visibility and sets display accordingly
+	syncPosition(paneId);
+	notifySlotListeners();
+}
+
+export function unregisterSlot(paneId: string): void {
+	slots.delete(paneId);
+	const entry = webviews.get(paneId);
+	if (entry) {
+		entry.wrapper.style.display = "none";
+	}
+	notifySlotListeners();
+}
+
+function notifySlotListeners(): void {
+	for (const listener of slotListeners) listener();
+}
+
+// ---------------------------------------------------------------------------
+// Position sync
+// ---------------------------------------------------------------------------
+
+export function syncPosition(paneId: string): void {
+	const entry = webviews.get(paneId);
+	const slot = slots.get(paneId);
+	if (!entry || !slot) return;
+
+	// Hide the webview if the slot is not visible (e.g. tab is inactive and
+	// has `visibility: hidden` via the getTabsToRender CSS toggling).
+	// `visibility` is inherited, so this catches hidden ancestors too.
+	const isVisible = getComputedStyle(slot).visibility !== "hidden";
+	if (!isVisible) {
+		entry.wrapper.style.display = "none";
+		return;
+	}
+
+	entry.wrapper.style.display = "block";
+	const rect = slot.getBoundingClientRect();
+	const { wrapper } = entry;
+	wrapper.style.left = `${rect.left}px`;
+	wrapper.style.top = `${rect.top}px`;
+	wrapper.style.width = `${rect.width}px`;
+	wrapper.style.height = `${rect.height}px`;
+}
+
+export function syncAllPositions(): void {
+	for (const paneId of slots.keys()) {
+		syncPosition(paneId);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Navigation (called by BrowserPane via usePersistentWebview)
+// ---------------------------------------------------------------------------
+
+export function webviewNavigateTo(paneId: string, url: string): void {
+	const entry = webviews.get(paneId);
+	if (entry) entry.webview.loadURL(sanitizeUrl(url));
+}
+
+export function webviewReload(paneId: string): void {
+	const entry = webviews.get(paneId);
+	if (entry) entry.webview.reload();
+}
+
+export function webviewGoBack(paneId: string): void {
+	const store = useTabsStore.getState();
+	const url = store.navigateBrowserHistory(paneId, "back");
+	if (url) {
+		const entry = webviews.get(paneId);
+		if (entry) entry.webview.loadURL(sanitizeUrl(url));
+	}
+}
+
+export function webviewGoForward(paneId: string): void {
+	const store = useTabsStore.getState();
+	const url = store.navigateBrowserHistory(paneId, "forward");
+	if (url) {
+		const entry = webviews.get(paneId);
+		if (entry) entry.webview.loadURL(sanitizeUrl(url));
+	}
+}

--- a/packages/local-db/drizzle/0039_add_ssh_workspace_columns.sql
+++ b/packages/local-db/drizzle/0039_add_ssh_workspace_columns.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `settings` ADD `devcontainer_script` text;--> statement-breakpoint
+ALTER TABLE `settings` ADD `teardown_script` text;--> statement-breakpoint
+ALTER TABLE `workspaces` ADD `ssh_config` text;

--- a/packages/local-db/drizzle/meta/0039_snapshot.json
+++ b/packages/local-db/drizzle/meta/0039_snapshot.json
@@ -1,0 +1,1418 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "5875febc-8591-4a03-9571-9e92d08e62fb",
+  "prevId": "1cf43ce9-9e0f-44c4-b4cf-5cafe80bf78d",
+  "tables": {
+    "browser_history": {
+      "name": "browser_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_visited_at": {
+          "name": "last_visited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visit_count": {
+          "name": "visit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "browser_history_url_unique": {
+          "name": "browser_history_url_unique",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "browser_history_url_idx": {
+          "name": "browser_history_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": false
+        },
+        "browser_history_last_visited_at_idx": {
+          "name": "browser_history_last_visited_at_idx",
+          "columns": [
+            "last_visited_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_organization_id_idx": {
+          "name": "organization_members_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_user_id_idx": {
+          "name": "organization_members_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_users_id_fk": {
+          "name": "organization_members_user_id_users_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_org": {
+          "name": "github_org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_clerk_org_id_unique": {
+          "name": "organizations_clerk_org_id_unique",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_idx": {
+          "name": "organizations_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "organizations_clerk_org_id_idx": {
+          "name": "organizations_clerk_org_id_idx",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "main_repo_path": {
+          "name": "main_repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_toast_dismissed": {
+          "name": "config_toast_dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_base_branch": {
+          "name": "workspace_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_owner": {
+          "name": "github_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hide_image": {
+          "name": "hide_image",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_project_id": {
+          "name": "neon_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_app": {
+          "name": "default_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_main_repo_path_idx": {
+          "name": "projects_main_repo_path_idx",
+          "columns": [
+            "main_repo_path"
+          ],
+          "isUnique": false
+        },
+        "projects_last_opened_at_idx": {
+          "name": "projects_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_active_workspace_id": {
+          "name": "last_active_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets": {
+          "name": "terminal_presets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets_initialized": {
+          "name": "terminal_presets_initialized",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_preset_overrides": {
+          "name": "agent_preset_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_custom_definitions": {
+          "name": "agent_custom_definitions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_ringtone_id": {
+          "name": "selected_ringtone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirm_on_quit": {
+          "name": "confirm_on_quit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_link_behavior": {
+          "name": "terminal_link_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "persist_terminal": {
+          "name": "persist_terminal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_apply_default_preset": {
+          "name": "auto_apply_default_preset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_sounds_muted": {
+          "name": "notification_sounds_muted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_volume": {
+          "name": "notification_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delete_local_branch": {
+          "name": "delete_local_branch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_open_mode": {
+          "name": "file_open_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_presets_bar": {
+          "name": "show_presets_bar",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_compact_terminal_add_button": {
+          "name": "use_compact_terminal_add_button",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_family": {
+          "name": "terminal_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_size": {
+          "name": "terminal_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_family": {
+          "name": "editor_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_size": {
+          "name": "editor_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "devcontainer_script": {
+          "name": "devcontainer_script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "teardown_script": {
+          "name": "teardown_script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_resource_monitor": {
+          "name": "show_resource_monitor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "open_links_in_app": {
+          "name": "open_links_in_app",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_editor": {
+          "name": "default_editor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_color": {
+          "name": "status_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_type": {
+          "name": "status_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_position": {
+          "name": "status_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "estimate": {
+          "name": "estimate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_provider": {
+          "name": "external_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tasks_slug_unique": {
+          "name": "tasks_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "tasks_slug_idx": {
+          "name": "tasks_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "tasks_organization_id_idx": {
+          "name": "tasks_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_assignee_id_idx": {
+          "name": "tasks_assignee_id_idx",
+          "columns": [
+            "assignee_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_status_idx": {
+          "name": "tasks_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "tasks_created_at_idx": {
+          "name": "tasks_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_organization_id_organizations_id_fk": {
+          "name": "tasks_organization_id_organizations_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_assignee_id_users_id_fk": {
+          "name": "tasks_assignee_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tasks_creator_id_users_id_fk": {
+          "name": "tasks_creator_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": true
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "users_clerk_id_idx": {
+          "name": "users_clerk_id_idx",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_sections": {
+      "name": "workspace_sections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_collapsed": {
+          "name": "is_collapsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspace_sections_project_id_idx": {
+          "name": "workspace_sections_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_sections_project_id_projects_id_fk": {
+          "name": "workspace_sections_project_id_projects_id_fk",
+          "tableFrom": "workspace_sections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_id": {
+          "name": "worktree_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_unread": {
+          "name": "is_unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_unnamed": {
+          "name": "is_unnamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "deleting_at": {
+          "name": "deleting_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "port_base": {
+          "name": "port_base",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ssh_config": {
+          "name": "ssh_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_project_id_idx": {
+          "name": "workspaces_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_worktree_id_idx": {
+          "name": "workspaces_worktree_id_idx",
+          "columns": [
+            "worktree_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_last_opened_at_idx": {
+          "name": "workspaces_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        },
+        "workspaces_section_id_idx": {
+          "name": "workspaces_section_id_idx",
+          "columns": [
+            "section_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspaces_project_id_projects_id_fk": {
+          "name": "workspaces_project_id_projects_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_worktree_id_worktrees_id_fk": {
+          "name": "workspaces_worktree_id_worktrees_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "worktrees",
+          "columnsFrom": [
+            "worktree_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_section_id_workspace_sections_id_fk": {
+          "name": "workspaces_section_id_workspace_sections_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "workspace_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "worktrees": {
+      "name": "worktrees",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_status": {
+          "name": "git_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_status": {
+          "name": "github_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_superset": {
+          "name": "created_by_superset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "worktrees_project_id_idx": {
+          "name": "worktrees_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "worktrees_branch_idx": {
+          "name": "worktrees_branch_idx",
+          "columns": [
+            "branch"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "worktrees_project_id_projects_id_fk": {
+          "name": "worktrees_project_id_projects_id_fk",
+          "tableFrom": "worktrees",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/local-db/drizzle/meta/_journal.json
+++ b/packages/local-db/drizzle/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1774995017185,
       "tag": "0038_quick_star_brand",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "6",
+      "when": 1775595945825,
+      "tag": "0039_add_ssh_workspace_columns",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/local-db/src/schema/schema.ts
+++ b/packages/local-db/src/schema/schema.ts
@@ -128,6 +128,9 @@ export const workspaces = sqliteTable(
 		// Allocated port base for multi-worktree dev instances.
 		// Each workspace gets a range of 10 ports starting from this base.
 		portBase: integer("port_base"),
+		sshConfig: text("ssh_config", { mode: "json" }).$type<
+			import("./zod").SshWorkspaceConfig | null
+		>(),
 		sectionId: text("section_id").references(() => workspaceSections.id, {
 			onDelete: "set null",
 		}),
@@ -218,6 +221,8 @@ export const settings = sqliteTable("settings", {
 	terminalFontSize: integer("terminal_font_size"),
 	editorFontFamily: text("editor_font_family"),
 	editorFontSize: integer("editor_font_size"),
+	devcontainerScript: text("devcontainer_script"),
+	teardownScript: text("teardown_script"),
 	showResourceMonitor: integer("show_resource_monitor", { mode: "boolean" }),
 	worktreeBaseDir: text("worktree_base_dir"),
 	openLinksInApp: integer("open_links_in_app", { mode: "boolean" }),

--- a/packages/local-db/src/schema/zod.ts
+++ b/packages/local-db/src/schema/zod.ts
@@ -172,10 +172,21 @@ export const agentCustomDefinitionSchema = z.object({
 
 export type AgentCustomDefinition = z.infer<typeof agentCustomDefinitionSchema>;
 
+export const sshWorkspaceConfigSchema = z.object({
+	host: z.string(),
+	port: z.number(),
+	user: z.string(),
+	identityFile: z.string().optional(),
+	workDir: z.string(),
+	containerName: z.string().optional(),
+});
+
+export type SshWorkspaceConfig = z.infer<typeof sshWorkspaceConfigSchema>;
+
 /**
  * Workspace type
  */
-export const workspaceTypeSchema = z.enum(["worktree", "branch"]);
+export const workspaceTypeSchema = z.enum(["worktree", "branch", "ssh"]);
 
 export type WorkspaceType = z.infer<typeof workspaceTypeSchema>;
 


### PR DESCRIPTION
## Summary

Allows opening Superset browser tabs using deep links! This adds a powerful use case - a project run command for a web app can automatically start the dev server AND immediately open the website in a browser tab in your workspace!

- Add `superset://open-tab` deep link that creates browser tabs in a specific workspace, matched by filesystem path
- URL format: `superset://open-tab?type=webview&url=<url>&cwd=<path>[&focus=true]`
- Tabs open silently by default; only navigates to the workspace when `focus=true`
- Fix `patch-dev-protocol.ts` to find Electron in hoisted `node_modules` (was silently skipping in worktrees)

Only webview is supported for now to keep the PR small, but can easily add support for terminal tabs in another PR.

Followups
- Add a superset mcp tool to open a browser pane in a workspace
- Support creating terminal tabs

Demo
![superset-deeplink](https://github.com/user-attachments/assets/7b0516a5-b5a2-44c6-8824-aa17b2337755)

## Details
**Deep link handler** (`apps/desktop/src/main/index.ts`):
- Parses `open-tab` action from deep link URL
- Validates URL scheme (http/https only)
- Resolves workspace by matching `cwd` param against workspace filesystem paths (longest/most specific match wins)
- Sends IPC to renderer with workspace ID and tab config

**Workspace resolution** (`apps/desktop/src/lib/trpc/routers/workspaces/utils/worktree.ts`):
- New `resolveWorkspaceByPath(cwd)` function reusing existing `getWorkspacePath()`

**Renderer handler** (`apps/desktop/src/renderer/index.tsx`):
- Listens for `deep-link-open-tab` IPC, calls `addBrowserTab()` on the tab store
- Optionally navigates to workspace when `focus=true`

**Dev protocol fix** (`apps/desktop/scripts/patch-dev-protocol.ts`):
- Check both local and hoisted `node_modules/electron/dist` paths so worktrees get their protocol registered

## Usage
```bash
# Open a browser tab silently
open "superset://open-tab?type=webview&url=http://localhost:3000&cwd=$(pwd)"

# Open and focus
open "superset://open-tab?type=webview&url=http://localhost:3000&cwd=$(pwd)&focus=true"
```

Can be used in `.superset/config.json` run scripts to auto-open dev server URLs.

## Test plan
- [ ] Run `bun dev`, then `open "superset-<workspace>://open-tab?type=webview&url=https://example.com&cwd=<workspace-path>"` — browser tab should appear in correct workspace
- [ ] Without `focus=true`: tab opens silently, no workspace navigation
- [ ] With `focus=true`: Superset focuses and navigates to the workspace
- [ ] Invalid URL scheme (e.g. `file://`) is rejected
- [ ] Non-matching cwd silently no-ops
- [ ] New worktrees get dev protocol registered automatically on `bun dev`




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SSH workspaces with persistent remote terminals (via zmx) and a settings-driven devcontainer/teardown flow. Also adds `superset://open-tab` deep link to open webview tabs in the best-matching workspace and keeps browser tabs alive across tab switches.

- **New Features**
  - SSH workspaces: terminals run over SSH with ControlMaster multiplexing and zmx session persistence; per-workspace runtime with auto-reconnect on app start.
  - Settings: new `devcontainerScript` and `teardownScript`; create/delete run these to provision/destroy remote devcontainers; SSH config editable in the right sidebar.
  - Deep link: handle `superset://open-tab?type=webview&url=<url>&cwd=<path>[&focus=true]` in main; only `http`/`https`; resolves workspace by `cwd`; opens silently unless `focus=true`.
  - Browser tabs: new overlay keeps webviews persistent across tab/workspace switches; renderer IPC opens tabs in the targeted workspace.

- **Bug Fixes**
  - Dev protocol registration finds Electron in hoisted or local `node_modules`.
  - Webview overlay syncs immediately on tab switch and restores drag passthrough to prevent reloads/flicker.

<sup>Written for commit a1e5feb8122f74bacba318e585bd9d3483a7020b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SSH workspaces: create/connect over SSH with persistent remote terminals, session management, and workspace runtimes.
  * Deep-link: open browser tabs (workspace-aware) via superset:// links.
  * Webview overlay for persistent webview rendering.

* **Improvements**
  * Better Electron distribution detection with graceful handling when not found.
  * Workspace resolution by filesystem path for more reliable matching.

* **Bug Fixes**
  * Startup reconciles SSH connections without failing; teardown errors are logged and surfaced.

* **Documentation**
  * Added SSH workspaces documentation.

* **Tests**
  * Extensive SSH and terminal unit tests added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->