### PR TITLE
fix(desktop): stabilize workspace sidebar drag start

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectSection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectSection.tsx
@@ -1,7 +1,7 @@
 import { toast } from "@superset/ui/sonner";
 import { cn } from "@superset/ui/utils";
 import { AnimatePresence, motion } from "framer-motion";
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useDrag, useDrop } from "react-dnd";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useReorderProjects } from "renderer/react-query/projects";
@@ -230,32 +230,39 @@ export function ProjectSection({
 		},
 	});
 
+	const projectHeaderRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		drag(drop(projectHeaderRef));
+	}, [drag, drop]);
+
 	if (isSidebarCollapsed) {
 		return (
 			<div
-				ref={(node) => {
-					drag(drop(node));
-				}}
 				className={cn(
 					"flex flex-col items-center py-2 border-b border-border last:border-b-0",
 					isDragging && "opacity-30",
 				)}
-				style={{ cursor: isDragging ? "grabbing" : "grab" }}
 			>
-				<ProjectHeader
-					projectId={projectId}
-					projectName={projectName}
-					projectColor={projectColor}
-					githubOwner={githubOwner}
-					mainRepoPath={mainRepoPath}
-					hideImage={hideImage}
-					iconUrl={iconUrl}
-					isCollapsed={isCollapsed}
-					isSidebarCollapsed={isSidebarCollapsed}
-					onToggleCollapse={() => toggleProjectCollapsed(projectId)}
-					workspaceCount={totalWorkspaceCount}
-					onNewWorkspace={handleNewWorkspace}
-				/>
+				<div
+					ref={projectHeaderRef}
+					className={cn("w-full", isDragging && "cursor-grabbing")}
+				>
+					<ProjectHeader
+						projectId={projectId}
+						projectName={projectName}
+						projectColor={projectColor}
+						githubOwner={githubOwner}
+						mainRepoPath={mainRepoPath}
+						hideImage={hideImage}
+						iconUrl={iconUrl}
+						isCollapsed={isCollapsed}
+						isSidebarCollapsed={isSidebarCollapsed}
+						onToggleCollapse={() => toggleProjectCollapsed(projectId)}
+						workspaceCount={totalWorkspaceCount}
+						onNewWorkspace={handleNewWorkspace}
+					/>
+				</div>
 				<AnimatePresence initial={false}>
 					{!isCollapsed && (
 						<motion.div
@@ -336,29 +343,30 @@ export function ProjectSection({
 
 	return (
 		<div
-			ref={(node) => {
-				drag(drop(node));
-			}}
 			className={cn(
 				"border-b border-border last:border-b-0",
 				isDragging && "opacity-30",
 			)}
-			style={{ cursor: isDragging ? "grabbing" : "grab" }}
 		>
-			<ProjectHeader
-				projectId={projectId}
-				projectName={projectName}
-				projectColor={projectColor}
-				githubOwner={githubOwner}
-				mainRepoPath={mainRepoPath}
-				hideImage={hideImage}
-				iconUrl={iconUrl}
-				isCollapsed={isCollapsed}
-				isSidebarCollapsed={isSidebarCollapsed}
-				onToggleCollapse={() => toggleProjectCollapsed(projectId)}
-				workspaceCount={totalWorkspaceCount}
-				onNewWorkspace={handleNewWorkspace}
-			/>
+			<div
+				ref={projectHeaderRef}
+				className={cn("w-full", isDragging && "cursor-grabbing")}
+			>
+				<ProjectHeader
+					projectId={projectId}
+					projectName={projectName}
+					projectColor={projectColor}
+					githubOwner={githubOwner}
+					mainRepoPath={mainRepoPath}
+					hideImage={hideImage}
+					iconUrl={iconUrl}
+					isCollapsed={isCollapsed}
+					isSidebarCollapsed={isSidebarCollapsed}
+					onToggleCollapse={() => toggleProjectCollapsed(projectId)}
+					workspaceCount={totalWorkspaceCount}
+					onNewWorkspace={handleNewWorkspace}
+				/>
+			</div>
 
 			<AnimatePresence initial={false}>
 				{!isCollapsed && (

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/CollapsedWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/CollapsedWorkspaceItem.tsx
@@ -29,7 +29,7 @@ interface CollapsedWorkspaceItemProps {
 	isActive: boolean;
 	isUnread: boolean;
 	workspaceStatus: ActivePaneStatus | null;
-	itemRef: RefObject<HTMLElement | null>;
+	itemRef: RefObject<HTMLButtonElement | null>;
 	showDeleteDialog: boolean;
 	setShowDeleteDialog: (open: boolean) => void;
 	onMouseEnter: () => void;
@@ -63,9 +63,7 @@ export function CollapsedWorkspaceItem({
 
 	const collapsedButton = (
 		<button
-			ref={(node) => {
-				(itemRef as React.MutableRefObject<HTMLElement | null>).current = node;
-			}}
+			ref={itemRef}
 			type="button"
 			onClick={onClick}
 			onAuxClick={(e) => {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -104,19 +104,31 @@ export function WorkspaceListItem({
 		fuzzy: true,
 	});
 
-	const itemRef = useRef<HTMLElement | null>(null);
-	useEffect(() => {
-		if (isActive) {
-			itemRef.current?.scrollIntoView({ block: "nearest", behavior: "smooth" });
-		}
-	}, [isActive]);
-
 	const { isDragging, drag, drop } = useWorkspaceDnD({
 		id,
 		projectId,
 		sectionId,
 		index,
 	});
+
+	const expandedItemRef = useRef<HTMLDivElement>(null);
+	const collapsedItemRef = useRef<HTMLButtonElement>(null);
+
+	useEffect(() => {
+		if (isCollapsed) {
+			drag(drop(collapsedItemRef));
+			return;
+		}
+		drag(drop(expandedItemRef));
+	}, [drag, drop, isCollapsed]);
+
+	useEffect(() => {
+		if (!isActive) return;
+		const activeNode = isCollapsed
+			? collapsedItemRef.current
+			: expandedItemRef.current;
+		activeNode?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+	}, [isActive, isCollapsed]);
 
 	const openInFinder = electronTrpc.external.openInFinder.useMutation({
 		onError: (error) => toast.error(`Failed to open: ${error.message}`),
@@ -243,7 +255,7 @@ export function WorkspaceListItem({
 				isActive={isActive}
 				isUnread={isUnread}
 				workspaceStatus={workspaceStatus}
-				itemRef={itemRef}
+				itemRef={collapsedItemRef}
 				showDeleteDialog={showDeleteDialog}
 				setShowDeleteDialog={setShowDeleteDialog}
 				onMouseEnter={handleMouseEnter}
@@ -259,10 +271,7 @@ export function WorkspaceListItem({
 		<div
 			role="button"
 			tabIndex={0}
-			ref={(node) => {
-				itemRef.current = node;
-				drag(drop(node));
-			}}
+			ref={expandedItemRef}
 			onClick={handleClick}
 			onKeyDown={(e) => {
 				if (e.key === "Enter" || e.key === " ") {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSection/WorkspaceSection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSection/WorkspaceSection.tsx
@@ -11,7 +11,7 @@ import {
 import { toast } from "@superset/ui/sonner";
 import { cn } from "@superset/ui/utils";
 import { AnimatePresence, motion } from "framer-motion";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useDrag, useDrop } from "react-dnd";
 import { HiChevronRight } from "react-icons/hi2";
 import { LuPalette, LuPencil, LuTrash2 } from "react-icons/lu";
@@ -128,6 +128,18 @@ export function WorkspaceSection({
 	});
 
 	const clickTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const sectionContainerRef = useRef<HTMLDivElement>(null);
+	const sectionDragHandleRef = useRef<HTMLDivElement>(null);
+	const sectionHeaderRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (isSidebarCollapsed) {
+			sectionDrop(sectionContainerRef);
+			sectionDrag(sectionDragHandleRef);
+			return;
+		}
+		sectionDrag(sectionDrop(sectionHeaderRef));
+	}, [isSidebarCollapsed, sectionDrag, sectionDrop]);
 
 	const handleClick = useCallback(() => {
 		if (clickTimer.current) return;
@@ -167,9 +179,7 @@ export function WorkspaceSection({
 	if (isSidebarCollapsed) {
 		return (
 			<div
-				ref={(node) => {
-					sectionDrop(node);
-				}}
+				ref={sectionContainerRef}
 				{...dropZone.handlers}
 				className={cn(
 					"relative flex flex-col -ml-0.5",
@@ -178,9 +188,7 @@ export function WorkspaceSection({
 				style={sectionBorderStyle}
 			>
 				<div
-					ref={(node) => {
-						sectionDrag(node);
-					}}
+					ref={sectionDragHandleRef}
 					className="absolute inset-y-0 -left-1 w-2 cursor-grab"
 				/>
 				<WorkspaceList
@@ -204,9 +212,7 @@ export function WorkspaceSection({
 			<ContextMenu>
 				<ContextMenuTrigger asChild>
 					<div
-						ref={(node) => {
-							sectionDrag(sectionDrop(node));
-						}}
+						ref={sectionHeaderRef}
 						className={cn(
 							"flex items-center w-full pl-2 pr-2 py-2 text-[11px] font-medium uppercase tracking-wider",
 							"text-muted-foreground hover:bg-muted/50 transition-colors",


### PR DESCRIPTION
## Summary
- limit project drag bindings to the project header instead of the full project container
- switch workspace and section drag/drop bindings to stable ref-object connectors so sidebar rerenders do not detach drag sources unpredictably
- keep the existing sidebar reorder and section move behavior while avoiding nested project/workspace drag-source conflicts

## Root cause
Workspace rows in the legacy sidebar were nested inside a parent project drag source, and several drag/drop connectors were rebound via inline ref callbacks during reorder-driven rerenders. That combination made drag start intermittently fail, especially after a workspace had already been moved in the sidebar.

## Verification
- `bunx biome check apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectSection.tsx apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceSection/WorkspaceSection.tsx apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/CollapsedWorkspaceItem.tsx`
- `bunx tsc -p apps/desktop/tsconfig.json --noEmit` *(fails in this workspace because generated route types like `routeTree.gen` are missing, plus unrelated existing route typing errors)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes drag start in the desktop workspace sidebar by moving drag handles to stable refs and limiting project drag to the header. Prevents intermittent drag failures after reordering while keeping existing reorder and section move behavior.

- **Bug Fixes**
  - Limit project drag to the header; avoid dragging the full container.
  - Use stable ref connectors for workspace/section drag and drop to survive rerenders.
  - Separate refs for collapsed vs expanded items and keep active item auto-scroll.
  - Wire section drag/drop by mode: container drop + handle drag when collapsed; header drag+drop when expanded.
  - Correct `CollapsedWorkspaceItem` ref type to `HTMLButtonElement`.

<sup>Written for commit c4aaa223ff44e8ac1ebc3ef8f6ff11988e19d64f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved drag-and-drop handling for workspace and project items with more reliable reference management and enhanced cursor feedback during interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->