### PR TITLE
fix(desktop): set default open-in-app to Finder for v2 workspaces

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/OpenInMenuButton/OpenInMenuButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/OpenInMenuButton/OpenInMenuButton.tsx
@@ -36,7 +36,7 @@ export const OpenInMenuButton = memo(function OpenInMenuButton({
 		{ projectId: projectId as string },
 		{ enabled: !!projectId, staleTime: 30000 },
 	);
-	const resolvedApp: ExternalApp = defaultApp ?? "cursor";
+	const resolvedApp: ExternalApp = defaultApp ?? "finder";
 	const openInApp = electronTrpc.external.openInApp.useMutation({
 		onSuccess: () => {
 			if (projectId) {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -115,7 +115,7 @@ function V2WorkspaceContent({
 		{ projectId },
 		{ enabled: !!projectId, staleTime: 30000 },
 	);
-	const resolvedDefaultApp: ExternalApp = defaultApp ?? "cursor";
+	const resolvedDefaultApp: ExternalApp = defaultApp ?? "finder";
 	const { mutate: mutateOpenInApp } =
 		electronTrpc.external.openInApp.useMutation({
 			onSuccess: () => {


### PR DESCRIPTION
## Summary
- Changes the fallback open-in-app from Cursor to Finder in v2 workspaces
- Applies to both the v2 workspace page and the TopBar OpenInMenuButton
- Finder is a more universal default since it's available on all macOS systems

## Test plan
- [ ] Open a v2 workspace with no previously set default app
- [ ] Verify the open-in-app button defaults to Finder
- [ ] Select a different app and confirm it persists as the new default

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the default “Open in” app to `finder` for v2 workspaces when no preference is set, replacing `cursor`. This gives a reliable macOS fallback on machines without Cursor.

- **Bug Fixes**
  - Updated v2 workspace page and TopBar `OpenInMenuButton` to use `finder` as the fallback.

<sup>Written for commit a5bbc0f84e71b23bf70d22b03024bbfbbaf2fe84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated the default application fallback: when no default app is configured, the system now uses Finder instead of Cursor as the default for the Open action and related app selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->