### PR TITLE
feat(desktop): stream subagent activity inline instead of persistent bottom panel

### DIFF
--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ToolCallBlock/ToolCallBlock.tsx
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ToolCallBlock/ToolCallBlock.tsx
@@ -54,6 +54,8 @@ interface ToolCallBlockProps {
 		toolCallId: string,
 		answers: Record<string, string>,
 	) => Promise<void> | void;
+	/** Live streaming state for a running subagent, keyed by tool-call ID. */
+	activeSubagent?: Record<string, unknown>;
 }
 
 interface DiffPaneTarget {
@@ -69,6 +71,7 @@ export function ToolCallBlock({
 	sessionId,
 	organizationId,
 	onAnswer,
+	activeSubagent,
 }: ToolCallBlockProps) {
 	const args = getArgs(part);
 	const result = getResult(part);
@@ -596,7 +599,14 @@ export function ToolCallBlock({
 	}
 
 	if (toolName === "subagent") {
-		return <SubagentToolCall part={part} args={args} result={result} />;
+		return (
+			<SubagentToolCall
+				part={part}
+				args={args}
+				result={result}
+				activeSubagent={activeSubagent}
+			/>
+		);
 	}
 
 	// --- Fallback: generic tool UI ---

--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ToolCallBlock/components/SubagentToolCall/SubagentToolCall.tsx
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/ToolCallBlock/components/SubagentToolCall/SubagentToolCall.tsx
@@ -15,6 +15,8 @@ interface SubagentToolCallProps {
 	part: ToolPart;
 	args: Record<string, unknown>;
 	result: Record<string, unknown>;
+	/** Live streaming state from activeSubagents map, if this subagent is still running. */
+	activeSubagent?: Record<string, unknown>;
 }
 
 function asString(value: unknown): string | null {
@@ -23,30 +25,91 @@ function asString(value: unknown): string | null {
 	return trimmed.length > 0 ? trimmed : null;
 }
 
+function asNumber(value: unknown): number | undefined {
+	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+		return undefined;
+	}
+	return value;
+}
+
+interface ToolBadge {
+	name: string;
+	isError: boolean;
+}
+
+function parseLiveToolCalls(value: unknown): ToolBadge[] {
+	if (!Array.isArray(value)) return [];
+	return value
+		.map((item) => {
+			if (typeof item !== "object" || item === null) return null;
+			const record = item as Record<string, unknown>;
+			const name = asString(record.name);
+			if (!name) return null;
+			return { name, isError: record.isError === true };
+		})
+		.filter((item): item is ToolBadge => item !== null);
+}
+
 export function SubagentToolCall({
 	part,
 	args,
 	result,
+	activeSubagent,
 }: SubagentToolCallProps) {
 	const [isOpen, setIsOpen] = useState(false);
 	const [renderMarkdown, setRenderMarkdown] = useState(true);
 	const markdownToggleId = useId();
-	const isPending =
-		part.state !== "output-available" && part.state !== "output-error";
+
+	const hasCompleted =
+		part.state === "output-available" || part.state === "output-error";
+	const isLive = !hasCompleted && activeSubagent !== undefined;
+
+	// Derive status
+	const isPending = !hasCompleted && !isLive;
+	const isRunning = isLive;
 	const isError =
 		part.state === "output-error" ||
 		result.isError === true ||
-		(asString(result.error) ?? "").length > 0;
+		(asString(result.error) ?? "").length > 0 ||
+		(isLive && activeSubagent.isError === true);
+
 	const task = asString(args.task) ?? "Running subagent task...";
 	const agentType = asString(args.agentType) ?? "subagent";
+
+	// For completed subagents, parse from the tool result.
+	// For live subagents, derive from the streaming state.
 	const parsed = useMemo(() => parseSubagentToolResult(result), [result]);
+
+	const liveText = isLive
+		? (asString(activeSubagent.textDelta) ??
+			asString(activeSubagent.result) ??
+			"")
+		: "";
+	const liveModelId = isLive ? asString(activeSubagent.modelId) : undefined;
+	const liveDurationMs = isLive
+		? asNumber(activeSubagent.durationMs)
+		: undefined;
+	const liveToolCalls = useMemo(
+		() => (isLive ? parseLiveToolCalls(activeSubagent.toolCalls) : []),
+		[isLive, activeSubagent?.toolCalls],
+	);
+
+	// Use live data when running, parsed result data when completed
+	const displayText = hasCompleted ? parsed.text : liveText;
+	const displayModelId = hasCompleted
+		? parsed.modelId
+		: (liveModelId ?? undefined);
+	const displayDurationMs = hasCompleted
+		? parsed.durationMs
+		: (liveDurationMs ?? undefined);
+	const displayTools = hasCompleted ? parsed.tools : liveToolCalls;
 
 	const hasDetails =
 		task.length > 0 ||
-		parsed.text.length > 0 ||
-		parsed.tools.length > 0 ||
-		Boolean(parsed.modelId) ||
-		parsed.durationMs !== undefined;
+		displayText.length > 0 ||
+		displayTools.length > 0 ||
+		Boolean(displayModelId) ||
+		displayDurationMs !== undefined;
 
 	return (
 		<Collapsible
@@ -68,13 +131,13 @@ export function SubagentToolCall({
 						<BotIcon className="h-3 w-3 shrink-0 text-muted-foreground" />
 						<ShimmerLabel
 							className="truncate text-xs text-muted-foreground"
-							isShimmering={isPending}
+							isShimmering={isPending || isRunning}
 						>
 							{`Subagent (${agentType})`}
 						</ShimmerLabel>
 					</div>
 					<div className="ml-2 flex h-6 w-6 items-center justify-center text-muted-foreground">
-						{isPending ? (
+						{isPending || isRunning ? (
 							<Loader2Icon className="h-3 w-3 animate-spin" />
 						) : isError ? (
 							<XIcon className="h-3 w-3" />
@@ -90,14 +153,14 @@ export function SubagentToolCall({
 						<div className="font-medium text-foreground">{task}</div>
 						<div className="text-muted-foreground">
 							{agentType}
-							{parsed.modelId ? ` • ${parsed.modelId}` : ""}
-							{parsed.durationMs !== undefined
-								? ` • ${Math.round(parsed.durationMs)} ms`
+							{displayModelId ? ` • ${displayModelId}` : ""}
+							{displayDurationMs !== undefined
+								? ` • ${Math.round(displayDurationMs)} ms`
 								: ""}
 						</div>
-						{parsed.tools.length > 0 ? (
+						{displayTools.length > 0 ? (
 							<div className="flex flex-wrap gap-1.5">
-								{parsed.tools.map((tool, index) => (
+								{displayTools.map((tool, index) => (
 									<span
 										key={`${tool.name}-${index}`}
 										className={cn(
@@ -112,12 +175,12 @@ export function SubagentToolCall({
 								))}
 							</div>
 						) : null}
-						{parsed.text ? (
+						{displayText ? (
 							<MarkdownToggleContent
 								toggleId={markdownToggleId}
 								checked={renderMarkdown}
 								onCheckedChange={setRenderMarkdown}
-								content={parsed.text}
+								content={displayText}
 								markdownContainerClassName="max-h-[32rem] overflow-auto rounded border bg-background/80 p-2"
 								plainContainerClassName="max-h-[32rem] overflow-auto rounded border bg-background/80 p-2 text-xs whitespace-pre-wrap break-words"
 							/>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceChat/components/WorkspaceChatInterface/components/ChatMessageList/ChatMessageList.test.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceChat/components/WorkspaceChatInterface/components/ChatMessageList/ChatMessageList.test.tsx
@@ -90,9 +90,6 @@ mock.module("./components/MessageScrollbackRail", () => ({
 	}) => <div data-rail-count={messages.length} />,
 }));
 
-mock.module("./components/SubagentExecutionMessage", () => ({
-	SubagentExecutionMessage: () => <div>SUBAGENT_EXECUTION_MESSAGE</div>,
-}));
 
 mock.module("./components/PendingApprovalMessage", () => ({
 	PendingApprovalMessage: () => null,
@@ -277,7 +274,7 @@ describe("ChatMessageList", () => {
 		expect(html).not.toContain("Response stopped");
 	});
 
-	it("renders subagent activity while keeping anchored pending plan inline", () => {
+	it("does not render standalone subagent panel; activity streams inline via SubagentToolCall", () => {
 		const html = renderListHtml({
 			messages: [
 				{
@@ -310,7 +307,9 @@ describe("ChatMessageList", () => {
 			} as never,
 		});
 
-		expect(html).toContain("SUBAGENT_EXECUTION_MESSAGE");
+		// Subagent activity is no longer rendered as a standalone panel
+		expect(html).not.toContain("SUBAGENT_EXECUTION_MESSAGE");
+		// The plan is still not shown standalone because it's anchored inline
 		expect(html).not.toContain("PENDING_PLAN_APPROVAL_MESSAGE");
 	});
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceChat/components/WorkspaceChatInterface/components/ChatMessageList/ChatMessageList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceChat/components/WorkspaceChatInterface/components/ChatMessageList/ChatMessageList.tsx
@@ -18,7 +18,7 @@ import { MessageScrollbackRail } from "./components/MessageScrollbackRail";
 import { PendingApprovalMessage } from "./components/PendingApprovalMessage";
 import { PendingPlanApprovalMessage } from "./components/PendingPlanApprovalMessage";
 import { PendingQuestionMessage } from "./components/PendingQuestionMessage";
-import { SubagentExecutionMessage } from "./components/SubagentExecutionMessage";
+
 import { ThinkingMessage } from "./components/ThinkingMessage";
 import { ToolPreviewMessage } from "./components/ToolPreviewMessage";
 import { UserMessage } from "./components/UserMessage";
@@ -105,11 +105,8 @@ export function ChatMessageList({
 			}),
 		[activeTools, toolInputBuffers],
 	);
-	const activeSubagentEntries = useMemo(
-		() => (activeSubagents ? [...activeSubagents.entries()] : []),
-		[activeSubagents],
-	);
-	const hasSubagentActivity = activeSubagentEntries.length > 0;
+	const hasSubagentActivity =
+		activeSubagents !== undefined && activeSubagents.size > 0;
 
 	const pendingPlanToolCallId = useMemo(() => {
 		const anchorMessages: ChatMessage[] = [...renderedMessages];
@@ -242,6 +239,7 @@ export function ChatMessageList({
 							workspaceCwd={workspaceCwd}
 							isStreaming
 							previewToolParts={previewToolParts}
+							activeSubagents={activeSubagents}
 							{...inlineToolStateProps}
 						/>
 					)}
@@ -258,9 +256,6 @@ export function ChatMessageList({
 							isPlanSubmitting={isPlanSubmitting}
 							onPlanRespond={onPlanRespond}
 						/>
-					) : null}
-					{hasSubagentActivity ? (
-						<SubagentExecutionMessage subagents={activeSubagentEntries} />
 					) : null}
 					{pendingApproval && (
 						<PendingApprovalMessage

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceChat/components/WorkspaceChatInterface/components/ChatMessageList/components/AssistantMessage/AssistantMessage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceChat/components/WorkspaceChatInterface/components/ChatMessageList/components/AssistantMessage/AssistantMessage.tsx
@@ -34,6 +34,7 @@ interface AssistantMessageProps {
 		action: "approved" | "rejected";
 		feedback?: string;
 	}) => Promise<void>;
+	activeSubagents?: Map<string, unknown>;
 }
 
 function ImagePart({ data, mimeType }: { data: string; mimeType: string }) {
@@ -111,6 +112,7 @@ export function AssistantMessage({
 	pendingPlanToolCallId = null,
 	isPlanSubmitting = false,
 	onPlanRespond,
+	activeSubagents,
 }: AssistantMessageProps) {
 	const addFileViewerPane = useTabsStore((store) => store.addFileViewerPane);
 	const nodes: ReactNode[] = [];
@@ -261,6 +263,7 @@ export function AssistantMessage({
 					sessionId={sessionId}
 					organizationId={organizationId}
 					workspaceCwd={workspaceCwd}
+					activeSubagent={activeSubagents?.get(part.id) as Record<string, unknown> | undefined}
 				/>,
 			);
 			nodes.push(...getInlineToolStateNodes(part.id));
@@ -284,6 +287,7 @@ export function AssistantMessage({
 					sessionId={sessionId}
 					organizationId={organizationId}
 					workspaceCwd={workspaceCwd}
+					activeSubagent={activeSubagents?.get(part.id) as Record<string, unknown> | undefined}
 				/>,
 			);
 			nodes.push(...getInlineToolStateNodes(part.id));
@@ -313,6 +317,7 @@ export function AssistantMessage({
 				sessionId={sessionId}
 				organizationId={organizationId}
 				workspaceCwd={workspaceCwd}
+				activeSubagent={activeSubagents?.get(previewPart.toolCallId) as Record<string, unknown> | undefined}
 			/>,
 		);
 		nodes.push(...getInlineToolStateNodes(previewPart.toolCallId));

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPaneInterface/components/ChatMessageList/ChatMessageList.test.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPaneInterface/components/ChatMessageList/ChatMessageList.test.tsx
@@ -90,10 +90,6 @@ mock.module("./components/MessageScrollbackRail", () => ({
 	}) => <div data-rail-count={messages.length} />,
 }));
 
-mock.module("./components/SubagentExecutionMessage", () => ({
-	SubagentExecutionMessage: () => <div>SUBAGENT_EXECUTION_MESSAGE</div>,
-}));
-
 mock.module("./components/PendingApprovalMessage", () => ({
 	PendingApprovalMessage: () => null,
 }));
@@ -277,7 +273,7 @@ describe("ChatMessageList", () => {
 		expect(html).not.toContain("Response stopped");
 	});
 
-	it("renders subagent activity while keeping anchored pending plan inline", () => {
+	it("does not render standalone subagent panel; activity streams inline via SubagentToolCall", () => {
 		const html = renderListHtml({
 			messages: [
 				{
@@ -310,7 +306,9 @@ describe("ChatMessageList", () => {
 			} as never,
 		});
 
-		expect(html).toContain("SUBAGENT_EXECUTION_MESSAGE");
+		// Subagent activity is no longer rendered as a standalone panel
+		expect(html).not.toContain("SUBAGENT_EXECUTION_MESSAGE");
+		// The plan is still not shown standalone because it's anchored inline
 		expect(html).not.toContain("PENDING_PLAN_APPROVAL_MESSAGE");
 	});
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPaneInterface/components/ChatMessageList/ChatMessageList.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPaneInterface/components/ChatMessageList/ChatMessageList.tsx
@@ -18,7 +18,6 @@ import { MessageScrollbackRail } from "./components/MessageScrollbackRail";
 import { PendingApprovalMessage } from "./components/PendingApprovalMessage";
 import { PendingPlanApprovalMessage } from "./components/PendingPlanApprovalMessage";
 import { PendingQuestionMessage } from "./components/PendingQuestionMessage";
-import { SubagentExecutionMessage } from "./components/SubagentExecutionMessage";
 import { ThinkingMessage } from "./components/ThinkingMessage";
 import { ToolPreviewMessage } from "./components/ToolPreviewMessage";
 import { UserMessage } from "./components/UserMessage";
@@ -105,11 +104,8 @@ export function ChatMessageList({
 			}),
 		[activeTools, toolInputBuffers],
 	);
-	const activeSubagentEntries = useMemo(
-		() => (activeSubagents ? [...activeSubagents.entries()] : []),
-		[activeSubagents],
-	);
-	const hasSubagentActivity = activeSubagentEntries.length > 0;
+	const hasSubagentActivity =
+		activeSubagents !== undefined && activeSubagents.size > 0;
 
 	const pendingPlanToolCallId = useMemo(() => {
 		const anchorMessages: ChatMessage[] = [...renderedMessages];
@@ -242,6 +238,7 @@ export function ChatMessageList({
 							workspaceCwd={workspaceCwd}
 							isStreaming
 							previewToolParts={previewToolParts}
+							activeSubagents={activeSubagents}
 							{...inlineToolStateProps}
 						/>
 					)}
@@ -258,9 +255,6 @@ export function ChatMessageList({
 							isPlanSubmitting={isPlanSubmitting}
 							onPlanRespond={onPlanRespond}
 						/>
-					) : null}
-					{hasSubagentActivity ? (
-						<SubagentExecutionMessage subagents={activeSubagentEntries} />
 					) : null}
 					{pendingApproval && (
 						<PendingApprovalMessage

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPaneInterface/components/ChatMessageList/components/AssistantMessage/AssistantMessage.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPaneInterface/components/ChatMessageList/components/AssistantMessage/AssistantMessage.tsx
@@ -34,6 +34,7 @@ interface AssistantMessageProps {
 		action: "approved" | "rejected";
 		feedback?: string;
 	}) => Promise<void>;
+	activeSubagents?: Map<string, unknown>;
 }
 
 function ImagePart({ data, mimeType }: { data: string; mimeType: string }) {
@@ -111,6 +112,7 @@ export function AssistantMessage({
 	pendingPlanToolCallId = null,
 	isPlanSubmitting = false,
 	onPlanRespond,
+	activeSubagents,
 }: AssistantMessageProps) {
 	const addFileViewerPane = useTabsStore((store) => store.addFileViewerPane);
 	const nodes: ReactNode[] = [];
@@ -261,6 +263,7 @@ export function AssistantMessage({
 					sessionId={sessionId}
 					organizationId={organizationId}
 					workspaceCwd={workspaceCwd}
+					activeSubagent={activeSubagents?.get(part.id) as Record<string, unknown> | undefined}
 				/>,
 			);
 			nodes.push(...getInlineToolStateNodes(part.id));
@@ -284,6 +287,7 @@ export function AssistantMessage({
 					sessionId={sessionId}
 					organizationId={organizationId}
 					workspaceCwd={workspaceCwd}
+					activeSubagent={activeSubagents?.get(part.id) as Record<string, unknown> | undefined}
 				/>,
 			);
 			nodes.push(...getInlineToolStateNodes(part.id));
@@ -313,6 +317,7 @@ export function AssistantMessage({
 				sessionId={sessionId}
 				organizationId={organizationId}
 				workspaceCwd={workspaceCwd}
+				activeSubagent={activeSubagents?.get(previewPart.toolCallId) as Record<string, unknown> | undefined}
 			/>,
 		);
 		nodes.push(...getInlineToolStateNodes(previewPart.toolCallId));


### PR DESCRIPTION
## Problem

The `SubagentExecutionMessage` rendered as a persistent panel at the bottom of the chat thread. When subagents were running, this panel pushed pending plans and questions out of view, making it hard to interact with them.

## Solution

Stream subagent activity data into the existing inline `SubagentToolCall` collapsible (which already renders per-tool-call within `AssistantMessage`), and remove the standalone bottom panel.

### Changes

- **`SubagentToolCall.tsx`** — Added `activeSubagent` prop. When a tool call is pending and live streaming data is available, the collapsible shows streaming text, tool badges, model ID, and duration. Collapsed by default.
- **`ToolCallBlock.tsx`** — Added `activeSubagent` prop, passes it through to `SubagentToolCall`.
- **`AssistantMessage.tsx`** (both implementations) — Added `activeSubagents` prop, passes the relevant entry to each `ToolCallBlock` via `activeSubagents.get(toolCallId)`.
- **`ChatMessageList.tsx`** (both implementations) — Removed standalone `SubagentExecutionMessage` render block and import. Passes `activeSubagents` to the streaming `AssistantMessage`.
- **`ChatMessageList.test.tsx`** (both implementations) — Updated tests to verify the standalone panel is no longer rendered. Removed dead mocks.

## Test Plan

- `bun test --filter ChatMessageList` — 30 tests pass, 0 failures
- TypeScript compilation clean (no new errors)
- Manual: subagent activity now appears inline within the tool call collapsible, pending plans/questions remain visible at the bottom of the chat

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stream subagent activity inline within each subagent tool call instead of a persistent bottom panel, keeping pending plans and questions visible. The collapsible now shows live text, tools, model, and duration while running.

- **New Features**
  - `SubagentToolCall` streams live data for pending calls; collapsed by default.
  - Shows tool badges (with error state), model ID, duration, and a spinner while running.

- **Refactors**
  - Thread `activeSubagents` through `ChatMessageList` → `AssistantMessage` → `ToolCallBlock` → `SubagentToolCall`.
  - Remove the standalone `SubagentExecutionMessage` and related imports/renders; update tests to assert inline behavior in both workspace and main chat implementations.

<sup>Written for commit 46c0329824745e415db93aec4e3ceb2ee2bf79df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subagent execution now streams inline with live updates, displaying real-time progress and results as the subagent runs.

* **Refactor**
  * Consolidated subagent activity display by integrating it directly into the conversation flow instead of showing as a separate panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->