### PR TITLE
fix(desktop): prevent chat text animation jumpiness when tool calls follow streamed text

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceChat/components/WorkspaceChatInterface/components/ChatMessageList/components/AssistantMessage/AssistantMessage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceChat/components/WorkspaceChatInterface/components/ChatMessageList/components/AssistantMessage/AssistantMessage.tsx
@@ -154,11 +154,18 @@ export function AssistantMessage({
 		const part = message.content[partIndex];
 
 		if (part.type === "text") {
+			// Don't animate text if tool calls follow it or tools are actively running —
+			// animating text while subsequent parts pop in causes jarring layout jumps.
+			const hasToolCallAfter = message.content
+				.slice(partIndex + 1)
+				.some((p) => p.type === "tool_call" || p.type === "tool_result");
+			const shouldAnimateText =
+				isStreaming && !hasToolCallAfter && previewToolParts.length === 0;
 			nodes.push(
 				<StreamingMessageText
 					key={`${message.id}-${partIndex}`}
 					text={part.text}
-					isAnimating={isStreaming}
+					isAnimating={shouldAnimateText}
 					mermaid={{
 						config: {
 							theme: "default",

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPaneInterface/components/ChatMessageList/components/AssistantMessage/AssistantMessage.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPaneInterface/components/ChatMessageList/components/AssistantMessage/AssistantMessage.tsx
@@ -154,11 +154,18 @@ export function AssistantMessage({
 		const part = message.content[partIndex];
 
 		if (part.type === "text") {
+			// Don't animate text if tool calls follow it or tools are actively running —
+			// animating text while subsequent parts pop in causes jarring layout jumps.
+			const hasToolCallAfter = message.content
+				.slice(partIndex + 1)
+				.some((p) => p.type === "tool_call" || p.type === "tool_result");
+			const shouldAnimateText =
+				isStreaming && !hasToolCallAfter && previewToolParts.length === 0;
 			nodes.push(
 				<StreamingMessageText
 					key={`${message.id}-${partIndex}`}
 					text={part.text}
-					isAnimating={isStreaming}
+					isAnimating={shouldAnimateText}
 					mermaid={{
 						config: {
 							theme: "default",


### PR DESCRIPTION
# What does this PR do? (required)

Fixes jarring layout jumps in the chat UI caused by tool call blocks appearing while preceding text was still animating character-by-character. The `AssistantMessage` component now skips the typewriter animation for text parts that have tool calls following them, or when preview tools are actively running — so tool blocks appear immediately alongside already-visible text instead of popping in mid-animation.

Text that is the final response (no subsequent tool calls) still uses the typewriter animation as intended.

# Link to Basecamp to-do, Trello card, New Relic or Honeybadger (required)

N/A

# QA

## What platforms should be included in QA?

- [x] Desktop web
- [ ] Mobile web
- [ ] iOS
- [ ] Android
- [ ] API
- [ ] N/A

## QA steps

1. Open the desktop app and start a chat session
2. Send a prompt that causes the LLM to respond with text followed by one or more tool calls (e.g. "search for X in my codebase")
3. **Before fix**: text would slowly reveal character-by-character while tool call blocks suddenly appeared below it, causing the layout to shift
4. **After fix**: text before tool calls appears instantly; only the final response text (after all tool calls) uses the typewriter animation
5. Verify that tool call blocks and the final response text render in their correct order without visual jumps
6. Verify that the final assistant response (text with no tool calls after it) still animates with the typewriter effect

## Screenshots (if appropriate)

N/A

# Docs

Update changelog after deployment if the changes in Admin are valuable for Sales, Support or Success teams.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents layout jumps in desktop chat by turning off the typewriter animation for text that comes before tool calls or while preview tools run. Tool blocks now appear immediately next to visible text; only the final response still animates.

- **Bug Fixes**
  - Disable animation for text parts when a following `tool_call` or `tool_result` is detected, or when preview tools are active.
  - Keep the typewriter effect only for the final text segment with no subsequent tool calls.

<sup>Written for commit d73d5ae34850047f9e22613df246bedb093e8b2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

