### PR TITLE
fix: prevent user message overflow on long code blocks

### DIFF
--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/components/MessageList/MessageList.tsx
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/components/MessageList/MessageList.tsx
@@ -123,7 +123,7 @@ export function MessageList({
 							return (
 								<div
 									key={msg.id}
-									className="flex flex-col items-end gap-2"
+									className="flex max-w-full min-w-0 flex-col items-end gap-2"
 									data-chat-user-message="true"
 									data-message-id={msg.id}
 								>
@@ -167,7 +167,7 @@ export function MessageList({
 										</div>
 									)}
 									{hasNonTaskContent && (
-										<div className="max-w-[85%] rounded-lg bg-muted px-4 py-2.5 text-sm text-foreground whitespace-pre-wrap">
+										<div className="max-w-[85%] overflow-x-auto rounded-lg bg-muted px-4 py-2.5 text-sm text-foreground whitespace-pre-wrap">
 											{otherSegments.map((segment, segIdx) => {
 												if (segment.type === "text") {
 													return (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceChat/components/WorkspaceChatInterface/components/ChatMessageList/components/UserMessage/UserMessage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceChat/components/WorkspaceChatInterface/components/ChatMessageList/components/UserMessage/UserMessage.tsx
@@ -107,7 +107,7 @@ export function UserMessage({
 
 	return (
 		<div
-			className="group/msg flex flex-col items-end gap-2"
+			className="group/msg flex max-w-full flex-col items-end gap-2"
 			data-chat-user-message="true"
 			data-message-id={message.id}
 		>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceChat/components/WorkspaceChatInterface/components/ChatMessageList/components/UserMessage/components/UserMessageText/UserMessageText.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceChat/components/WorkspaceChatInterface/components/ChatMessageList/components/UserMessage/components/UserMessageText/UserMessageText.tsx
@@ -34,7 +34,7 @@ export function UserMessageText({
 		return (
 			<div
 				key={`${message.id}-${partIndex}`}
-				className="flex max-w-[85%] flex-col items-end gap-2"
+				className="flex max-w-[85%] min-w-0 flex-col items-end gap-2"
 			>
 				{taskMentions.length > 0 && (
 					<div className="flex flex-wrap justify-end gap-2">
@@ -47,7 +47,7 @@ export function UserMessageText({
 					</div>
 				)}
 				{hasNonTaskContent && (
-					<div className="rounded-lg bg-muted px-4 py-2.5 text-sm text-foreground whitespace-pre-wrap">
+					<div className="max-w-full overflow-x-auto rounded-lg bg-muted px-4 py-2.5 text-sm text-foreground whitespace-pre-wrap">
 						{otherSegments.map((segment, segmentIndex) => {
 							if (segment.type === "text") {
 								return (


### PR DESCRIPTION
## What

Fixes user message layout breaking when pasting large code blocks in chat.

## Changes

- **UserMessageText.tsx** — Added `max-w-full overflow-x-auto` to text bubble so long lines get a horizontal scrollbar instead of blowing out the layout
- **UserMessage.tsx** — Added `max-w-full` to outer wrapper to respect parent `max-w-[680px]` constraint
- **MessageList.tsx** — Added `max-w-full` to user message container to respect parent `max-w-3xl` constraint

## How it works

In flexbox layouts, children can grow beyond their container's max-width. Adding `max-w-full` + `min-w-0` prevents this. The `overflow-x-auto` on the text bubble means long unbreakable code lines get a horizontal scrollbar within the bubble rather than expanding the entire chat layout.

## Test plan

1. Open workspace chat, paste a long code block → should scroll horizontally within the bubble
2. Open new chat (Superset Chat), paste a long code block → same behavior
3. Normal short messages should render unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented user messages from breaking the chat layout when pasting long code blocks. Long lines now scroll horizontally inside the bubble to keep the chat within its max width.

- **Bug Fixes**
  - Added max-w-full and min-w-0 to user message containers in both chat views to respect parent width.
  - Applied overflow-x-auto to the message text bubble so long code lines scroll instead of expanding the layout.

<sup>Written for commit 43f22ada30ea75bb5b35d4c74b5eda7896ffcca7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced user message rendering in the chat interface with improved layout constraints and horizontal scrolling for lengthy content, ensuring better visual presentation and preventing unintended overflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->