### PR TITLE
feat(desktop): show review dot when workspace setup completes in background

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceInitEffects.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceInitEffects.tsx
@@ -9,6 +9,7 @@ import { launchAgentSession } from "renderer/lib/agent-session-orchestrator";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { writeCommandsInPane } from "renderer/lib/terminal/launch-command";
 import { useTabsStore } from "renderer/stores/tabs/store";
+import { extractPaneIdsFromLayout } from "renderer/stores/tabs/utils";
 import { useTabsWithPresets } from "renderer/stores/tabs/useTabsWithPresets";
 import {
 	type PendingTerminalSetup,
@@ -42,6 +43,28 @@ export function WorkspaceInitEffects() {
 		electronTrpc.terminal.createOrAttach.useMutation();
 	const terminalWrite = electronTrpc.terminal.write.useMutation();
 	const utils = electronTrpc.useUtils();
+	const setPaneStatus = useTabsStore((state) => state.setPaneStatus);
+
+	/** Mark workspace panes as "review" if the user is not currently viewing it. */
+	const notifyWorkspaceReady = useCallback(
+		(workspaceId: string) => {
+			const isViewingWorkspace =
+				window.location.pathname.includes(`/workspace/${workspaceId}`);
+			if (isViewingWorkspace) return;
+
+			const state = useTabsStore.getState();
+			for (const tab of state.tabs) {
+				if (tab.workspaceId !== workspaceId) continue;
+				for (const paneId of extractPaneIdsFromLayout(tab.layout)) {
+					const pane = state.panes[paneId];
+					if (pane && pane.status !== "working" && pane.status !== "permission") {
+						setPaneStatus(paneId, "review");
+					}
+				}
+			}
+		},
+		[setPaneStatus],
+	);
 
 	const openPresetsInActiveTab = useCallback(
 		(workspaceId: string, presets: PendingTerminalSetup["defaultPresets"]) => {
@@ -319,6 +342,7 @@ export function WorkspaceInitEffects() {
 				handleTerminalSetup(setup, () => {
 					removePendingTerminalSetup(workspaceId);
 					processingRef.current.delete(workspaceId);
+					notifyWorkspaceReady(workspaceId);
 				});
 				continue;
 			}
@@ -340,6 +364,7 @@ export function WorkspaceInitEffects() {
 								removePendingTerminalSetup(workspaceId);
 								clearProgress(workspaceId);
 								processingRef.current.delete(workspaceId);
+								notifyWorkspaceReady(workspaceId);
 							});
 						})
 						.catch((error) => {
@@ -351,6 +376,7 @@ export function WorkspaceInitEffects() {
 								removePendingTerminalSetup(workspaceId);
 								clearProgress(workspaceId);
 								processingRef.current.delete(workspaceId);
+								notifyWorkspaceReady(workspaceId);
 							});
 						});
 				} else {
@@ -358,6 +384,7 @@ export function WorkspaceInitEffects() {
 						removePendingTerminalSetup(workspaceId);
 						clearProgress(workspaceId);
 						processingRef.current.delete(workspaceId);
+						notifyWorkspaceReady(workspaceId);
 					});
 				}
 			}
@@ -400,6 +427,7 @@ export function WorkspaceInitEffects() {
 					handleTerminalSetup(fetchedSetup, () => {
 						clearProgress(workspaceId);
 						processingRef.current.delete(workspaceId);
+						notifyWorkspaceReady(workspaceId);
 					});
 				})
 				.catch((error) => {
@@ -417,6 +445,7 @@ export function WorkspaceInitEffects() {
 		removePendingTerminalSetup,
 		clearProgress,
 		handleTerminalSetup,
+		notifyWorkspaceReady,
 		utils.workspaces.getSetupCommands,
 	]);
 


### PR DESCRIPTION
## Summary

When a user creates a workspace and tabs away while it initializes, there's no visual indication when setup finishes. This PR adds a green "review" dot on the workspace icon in the sidebar once background setup completes.

## Changes

**`WorkspaceInitEffects.tsx`** — Added `notifyWorkspaceReady()` callback that:

1. Checks if the user is currently viewing the workspace (via URL pathname)
2. If **not** viewing, marks all workspace panes with `"review"` status
3. The existing `StatusIndicator` system renders this as a green dot on the workspace icon
4. Clicking the workspace dismisses the dot via `clearWorkspaceAttentionStatus()`

Called in all 5 `onComplete` handlers in the main effect to cover every code path (immediate setup, post-init ready, fetch error fallback, presets available, orphaned workspace recovery).

## How it works

- User creates workspace → navigated there immediately (unchanged)
- User sees init progress → tabs away to another workspace
- Background init completes → `handleTerminalSetup` runs → `onComplete` fires
- `notifyWorkspaceReady()` detects user is elsewhere → sets pane statuses to `"review"`
- `WorkspaceIcon` renders green dot overlay
- User clicks workspace → green dot dismissed → workspace loads

## Test plan

1. Create a new workspace with a setup script
2. While it initializes, switch to a different workspace
3. Verify a green dot appears on the new workspace's icon when setup finishes
4. Click the workspace — verify the dot disappears and workspace loads normally
5. Create a workspace and stay on it — verify no dot appears (user is already viewing)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a green "review" dot to the workspace icon when a workspace finishes initializing in the background, so users know it's ready. The dot only shows if you're not viewing that workspace and clears when you open it.

- **New Features**
  - Added `notifyWorkspaceReady()` in `WorkspaceInitEffects.tsx` to set pane status to `"review"` for non-active workspaces.
  - Triggered from all `onComplete` paths after terminal setup to cover every init flow.
  - Skips panes in `"working"`/`"permission"` states; dot clears on open via `clearWorkspaceAttentionStatus()`.

<sup>Written for commit 28589b7d310671bb6ef976bf8109a3a799959462. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced workspace initialization process by ensuring pane statuses are properly synchronized when workspaces complete setup, improving state consistency across terminal initialization completion paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->