### PR TITLE
feat: auto-organize workspaces by PR status

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts
@@ -23,6 +23,7 @@ import {
 	fetchGitHubPRStatus,
 	type PullRequestCommentsTarget,
 } from "../utils/github";
+import { categorizePR, type PRCategory } from "../utils/map-pr-state";
 
 const gitHubPRCommentsInputSchema = z.object({
 	workspaceId: z.string(),
@@ -256,6 +257,90 @@ export const createGitStatusProcedures = () => {
 						workspace: workspace ?? null,
 					};
 				});
+			}),
+
+		getProjectPRStatuses: publicProcedure
+			.input(z.object({ projectId: z.string() }))
+			.query(async ({ input }) => {
+				const projectWorkspaces = localDb
+					.select({
+						workspaceId: workspaces.id,
+						worktreeId: workspaces.worktreeId,
+					})
+					.from(workspaces)
+					.where(
+						and(
+							eq(workspaces.projectId, input.projectId),
+							isNull(workspaces.deletingAt),
+						),
+					)
+					.all();
+
+				const STALE_THRESHOLD_MS = 5 * 60 * 1000;
+				const MAX_CONCURRENT_REFRESHES = 5;
+				const now = Date.now();
+
+				const results: Record<string, PRCategory> = {};
+
+				const staleWorktrees: Array<{
+					workspaceId: string;
+					worktreeId: string;
+					path: string;
+				}> = [];
+
+				for (const ws of projectWorkspaces) {
+					if (!ws.worktreeId) {
+						results[ws.workspaceId] = "no-pr";
+						continue;
+					}
+
+					const wt = getWorktree(ws.worktreeId);
+					if (!wt) {
+						results[ws.workspaceId] = "no-pr";
+						continue;
+					}
+
+					const cached = wt.githubStatus;
+					if (cached) {
+						results[ws.workspaceId] = categorizePR(cached);
+
+						if (
+							cached.lastRefreshed &&
+							now - cached.lastRefreshed > STALE_THRESHOLD_MS
+						) {
+							staleWorktrees.push({
+								workspaceId: ws.workspaceId,
+								worktreeId: wt.id,
+								path: wt.path,
+							});
+						}
+					} else {
+						results[ws.workspaceId] = "no-pr";
+						staleWorktrees.push({
+							workspaceId: ws.workspaceId,
+							worktreeId: wt.id,
+							path: wt.path,
+						});
+					}
+				}
+
+				const toRefresh = staleWorktrees.slice(0, MAX_CONCURRENT_REFRESHES);
+				if (toRefresh.length > 0) {
+					void Promise.allSettled(
+						toRefresh.map(async (item) => {
+							const freshStatus = await fetchGitHubPRStatus(item.path);
+							if (freshStatus) {
+								localDb
+									.update(worktrees)
+									.set({ githubStatus: freshStatus })
+									.where(eq(worktrees.id, item.worktreeId))
+									.run();
+							}
+						}),
+					);
+				}
+
+				return results;
 			}),
 
 		getExternalWorktrees: publicProcedure

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/map-pr-state.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/map-pr-state.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import type { GitHubStatus } from "@superset/local-db";
+import { categorizePR } from "./map-pr-state";
+
+function makeStatus(
+	overrides: Partial<{
+		pr: Partial<NonNullable<GitHubStatus["pr"]>> | null;
+	}> = {},
+): GitHubStatus {
+	const base: GitHubStatus = {
+		repoUrl: "https://github.com/org/repo",
+		branchExistsOnRemote: true,
+		lastRefreshed: Date.now(),
+		pr: null,
+	};
+
+	if (overrides.pr === null || overrides.pr === undefined) {
+		return { ...base, pr: overrides.pr ?? null };
+	}
+
+	return {
+		...base,
+		pr: {
+			number: 1,
+			title: "test",
+			url: "https://github.com/org/repo/pull/1",
+			state: "open",
+			additions: 0,
+			deletions: 0,
+			reviewDecision: "pending",
+			checksStatus: "none",
+			checks: [],
+			...overrides.pr,
+		},
+	};
+}
+
+describe("mapPRState", () => {
+	test("returns no-pr when pr is null", () => {
+		expect(categorizePR(makeStatus({ pr: null }))).toBe("no-pr");
+	});
+
+	test("returns draft for draft PRs", () => {
+		expect(categorizePR(makeStatus({ pr: { state: "draft" } }))).toBe("draft");
+	});
+
+	test("returns in-review for open PRs without approval", () => {
+		expect(
+			categorizePR(
+				makeStatus({ pr: { state: "open", reviewDecision: "pending" } }),
+			),
+		).toBe("in-review");
+	});
+
+	test("returns in-review for open PRs with changes requested", () => {
+		expect(
+			categorizePR(
+				makeStatus({
+					pr: { state: "open", reviewDecision: "changes_requested" },
+				}),
+			),
+		).toBe("in-review");
+	});
+
+	test("returns approved for open PRs with approved review", () => {
+		expect(
+			categorizePR(
+				makeStatus({ pr: { state: "open", reviewDecision: "approved" } }),
+			),
+		).toBe("approved");
+	});
+
+	test("returns merged for merged PRs", () => {
+		expect(categorizePR(makeStatus({ pr: { state: "merged" } }))).toBe(
+			"merged",
+		);
+	});
+
+	test("returns closed for closed PRs", () => {
+		expect(categorizePR(makeStatus({ pr: { state: "closed" } }))).toBe(
+			"closed",
+		);
+	});
+
+	test("does not return approved for draft PRs even with approved review", () => {
+		expect(
+			categorizePR(
+				makeStatus({ pr: { state: "draft", reviewDecision: "approved" } }),
+			),
+		).toBe("draft");
+	});
+});

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/map-pr-state.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/map-pr-state.ts
@@ -1,0 +1,28 @@
+import type { GitHubStatus } from "@superset/local-db";
+
+export type PRCategory =
+	| "draft"
+	| "in-review"
+	| "approved"
+	| "merged"
+	| "closed"
+	| "no-pr";
+
+export function categorizePR(status: GitHubStatus): PRCategory {
+	if (!status.pr) return "no-pr";
+	if (status.pr.state === "open" && status.pr.reviewDecision === "approved") {
+		return "approved";
+	}
+	switch (status.pr.state) {
+		case "draft":
+			return "draft";
+		case "open":
+			return "in-review";
+		case "merged":
+			return "merged";
+		case "closed":
+			return "closed";
+		default:
+			return "no-pr";
+	}
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectHeader.tsx
@@ -16,6 +16,7 @@ import { useState } from "react";
 import { HiChevronRight, HiMiniPlus } from "react-icons/hi2";
 import {
 	LuFolderOpen,
+	LuGitPullRequest,
 	LuImage,
 	LuImageOff,
 	LuListPlus,
@@ -29,6 +30,7 @@ import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useUpdateProject } from "renderer/react-query/projects/useUpdateProject";
 import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { useProjectRename } from "renderer/screens/main/hooks/useProjectRename";
+import { useV2ProjectLocalMetaStore } from "renderer/stores/v2-project-local-meta";
 import { STROKE_WIDTH } from "../constants";
 import { RenameInput } from "../RenameInput";
 import { CloseProjectDialog } from "./CloseProjectDialog";
@@ -70,6 +72,12 @@ export function ProjectHeader({
 	const params = useParams({ strict: false }) as { workspaceId?: string };
 	const [isCloseDialogOpen, setIsCloseDialogOpen] = useState(false);
 	const rename = useProjectRename(projectId, projectName);
+	const autoOrganizeEnabled = useV2ProjectLocalMetaStore(
+		(s) => s.getProjectMeta(projectId).autoOrganizeByPRStatus,
+	);
+	const toggleAutoOrganize = useV2ProjectLocalMetaStore(
+		(s) => s.toggleAutoOrganize,
+	);
 
 	const closeProject = electronTrpc.projects.close.useMutation({
 		onMutate: async ({ id }) => {
@@ -159,6 +167,10 @@ export function ProjectHeader({
 		createSection.mutate({ projectId, name: "New Section" });
 	};
 
+	const handleToggleAutoOrganize = () => {
+		toggleAutoOrganize(projectId);
+	};
+
 	const colorPickerSubmenu = (
 		<ContextMenuSub>
 			<ContextMenuSubTrigger>
@@ -226,6 +238,15 @@ export function ProjectHeader({
 							Project Settings
 						</ContextMenuItem>
 						{colorPickerSubmenu}
+						<ContextMenuItem onSelect={handleToggleAutoOrganize}>
+							<LuGitPullRequest
+								className="size-4 mr-2"
+								strokeWidth={STROKE_WIDTH}
+							/>
+							{autoOrganizeEnabled
+								? "Disable Auto-Organize by PR"
+								: "Auto-Organize by PR Status"}
+						</ContextMenuItem>
 						<ContextMenuItem onSelect={handleNewSection}>
 							<LuListPlus className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />
 							New Section
@@ -363,6 +384,15 @@ export function ProjectHeader({
 							<LuImageOff className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />
 						)}
 						{hideImage ? "Show Image" : "Hide Image"}
+					</ContextMenuItem>
+					<ContextMenuItem onSelect={handleToggleAutoOrganize}>
+						<LuGitPullRequest
+							className="size-4 mr-2"
+							strokeWidth={STROKE_WIDTH}
+						/>
+						{autoOrganizeEnabled
+							? "Disable Auto-Organize by PR"
+							: "Auto-Organize by PR Status"}
 					</ContextMenuItem>
 					<ContextMenuItem onSelect={handleNewSection}>
 						<LuListPlus className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectSection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectSection.tsx
@@ -1,6 +1,7 @@
 import { toast } from "@superset/ui/sonner";
 import { cn } from "@superset/ui/utils";
 import { AnimatePresence, motion } from "framer-motion";
+import type { PRCategory } from "lib/trpc/routers/workspaces/utils/map-pr-state";
 import { useEffect, useMemo, useRef } from "react";
 import { useDrag, useDrop } from "react-dnd";
 import { electronTrpc } from "renderer/lib/electron-trpc";
@@ -10,6 +11,7 @@ import {
 	useOpenNewWorkspaceModal,
 	usePendingWorkspace,
 } from "renderer/stores/new-workspace-modal";
+import { useV2ProjectLocalMetaStore } from "renderer/stores/v2-project-local-meta";
 import { useSectionDropZone } from "../hooks";
 import type { SidebarSection, SidebarWorkspace } from "../types";
 import { WorkspaceListItem } from "../WorkspaceListItem";
@@ -18,6 +20,33 @@ import { WorkspaceSection } from "../WorkspaceSection";
 import { ProjectHeader } from "./ProjectHeader";
 
 const PROJECT_TYPE = "PROJECT";
+
+const PR_ORDER: readonly PRCategory[] = [
+	"approved",
+	"in-review",
+	"draft",
+	"merged",
+	"closed",
+	"no-pr",
+];
+
+const PR_LABELS: Record<PRCategory, string> = {
+	approved: "Approved",
+	"in-review": "In Review",
+	draft: "Draft",
+	merged: "Merged",
+	closed: "Closed",
+	"no-pr": "In Progress",
+};
+
+const PR_COLORS: Record<PRCategory, string | null> = {
+	approved: "#22c55e",
+	"in-review": "#10b981",
+	draft: "#6b7280",
+	merged: "#8b5cf6",
+	closed: "#ef4444",
+	"no-pr": null,
+};
 
 type TopLevelChild =
 	| {
@@ -77,6 +106,19 @@ export function ProjectSection({
 	const reorderProjects = useReorderProjects();
 	const utils = electronTrpc.useUtils();
 	const pendingWorkspace = usePendingWorkspace();
+	const autoOrganizeEnabled = useV2ProjectLocalMetaStore(
+		(s) => s.getProjectMeta(projectId).autoOrganizeByPRStatus,
+	);
+
+	const { data: prStatuses } =
+		electronTrpc.workspaces.getProjectPRStatuses.useQuery(
+			{ projectId },
+			{
+				enabled: autoOrganizeEnabled,
+				refetchInterval: 60_000,
+				staleTime: 30_000,
+			},
+		);
 
 	const isCollapsed = isProjectCollapsed(projectId);
 	const totalWorkspaceCount =
@@ -92,6 +134,65 @@ export function ProjectSection({
 		) : null;
 
 	const { orderedWorkspaceIds, topLevelChildren } = useMemo(() => {
+		if (autoOrganizeEnabled && prStatuses) {
+			const allWs = [...workspaces, ...sections.flatMap((s) => s.workspaces)];
+
+			const ungrouped: SidebarWorkspace[] = [];
+			const grouped = new Map<string, SidebarWorkspace[]>();
+			for (const cat of PR_ORDER) grouped.set(cat, []);
+
+			for (const ws of allWs) {
+				const cat = prStatuses[ws.id] ?? "no-pr";
+				if (cat === "no-pr" && ws.type === "branch") {
+					ungrouped.push(ws);
+				} else {
+					grouped.get(cat)?.push(ws);
+				}
+			}
+
+			const ids: string[] = [];
+			const renderables: TopLevelChild[] = [];
+			let shortcutOffset = shortcutBaseIndex;
+			let topLevelIndex = 0;
+
+			for (const ws of ungrouped) {
+				ids.push(ws.id);
+				renderables.push({
+					kind: "workspace",
+					workspace: ws,
+					topLevelIndex,
+					shortcutIndex: shortcutOffset,
+				});
+				shortcutOffset++;
+				topLevelIndex++;
+			}
+
+			for (const cat of PR_ORDER) {
+				const catWs = grouped.get(cat) ?? [];
+				if (catWs.length === 0) continue;
+				for (const ws of catWs) ids.push(ws.id);
+				const section: SidebarSection = {
+					id: `auto-pr-${cat}`,
+					projectId,
+					name: PR_LABELS[cat],
+					tabOrder: topLevelIndex,
+					isCollapsed: false,
+					color: PR_COLORS[cat] ?? null,
+					workspaces: catWs,
+				};
+				renderables.push({
+					kind: "section",
+					section,
+					topLevelIndex,
+					shortcutBaseIndex: shortcutOffset,
+				});
+				shortcutOffset += catWs.length;
+				topLevelIndex++;
+			}
+
+			return { orderedWorkspaceIds: ids, topLevelChildren: renderables };
+		}
+
 		const topLevelWorkspacesById = new Map(
 			workspaces.map((workspace) => [workspace.id, workspace]),
 		);
@@ -136,7 +237,15 @@ export function ProjectSection({
 			orderedWorkspaceIds: ids,
 			topLevelChildren: renderables,
 		};
-	}, [shortcutBaseIndex, sections, topLevelItems, workspaces]);
+	}, [
+		autoOrganizeEnabled,
+		prStatuses,
+		shortcutBaseIndex,
+		sections,
+		topLevelItems,
+		workspaces,
+		projectId,
+	]);
 
 	const topUngroupedDropZone = useSectionDropZone({
 		canAccept: (item) =>

--- a/apps/desktop/src/renderer/stores/v2-project-local-meta.ts
+++ b/apps/desktop/src/renderer/stores/v2-project-local-meta.ts
@@ -4,6 +4,7 @@ import { devtools, persist } from "zustand/middleware";
 interface ProjectMeta {
 	isCollapsed: boolean;
 	tabOrder: number;
+	autoOrganizeByPRStatus: boolean;
 }
 
 interface V2ProjectLocalMetaState {
@@ -12,11 +13,13 @@ interface V2ProjectLocalMetaState {
 	getProjectMeta: (id: string) => ProjectMeta;
 	toggleProjectCollapsed: (id: string) => void;
 	setProjectTabOrder: (id: string, order: number) => void;
+	toggleAutoOrganize: (id: string) => void;
 }
 
 const DEFAULT_PROJECT_META: ProjectMeta = {
 	isCollapsed: false,
 	tabOrder: 0,
+	autoOrganizeByPRStatus: false,
 };
 
 export const useV2ProjectLocalMetaStore = create<V2ProjectLocalMetaState>()(
@@ -48,6 +51,21 @@ export const useV2ProjectLocalMetaStore = create<V2ProjectLocalMetaState>()(
 							projects: {
 								...state.projects,
 								[id]: { ...current, tabOrder: order },
+							},
+						};
+					});
+				},
+
+				toggleAutoOrganize: (id) => {
+					set((state) => {
+						const current = state.projects[id] ?? DEFAULT_PROJECT_META;
+						return {
+							projects: {
+								...state.projects,
+								[id]: {
+									...current,
+									autoOrganizeByPRStatus: !current.autoOrganizeByPRStatus,
+								},
 							},
 						};
 					});


### PR DESCRIPTION
## Summary

Just a suggestion on an approach that i implemented locally that i really wanted


Adds an opt-in per-project feature that automatically groups workspaces into virtual sections based on their GitHub PR status.

- **Toggle**: Right-click project header > "Auto-Organize by PR Status"
- **Sections**: Approved, In Review, Draft, Merged, Closed, In Progress (no PR)
- **No migration**: Preference stored in Zustand persisted to localStorage (`v2-project-local-meta`)
- **Reversible**: Toggling off instantly restores original manual sections
- **Virtual sections**: Color-coded by status, no rename/delete/drag (read-only)

### How it works

1. New `getProjectPRStatuses` tRPC procedure batch-reads cached `githubStatus` from worktrees table, refreshing stale entries (>5min) with a concurrency cap of 5
2. `useAutoOrganize` hook polls every 60s and groups workspaces into virtual `SidebarSection` objects
3. `ProjectSection` swaps in virtual sections when enabled, disabling drag-and-drop between them
4. `WorkspaceSection` respects `isAutoManaged` prop to disable rename/delete/drag/color

### Files changed

| File | Change |
|------|--------|
| `v2-project-local-meta.ts` | Added `autoOrganizeByPRStatus` preference |
| `git-status.ts` | New `getProjectPRStatuses` procedure + `mapPRState` helper |
| `useAutoOrganize.ts` | New hook for virtual section grouping |
| `ProjectSection.tsx` | Consumes `useAutoOrganize`, passes virtual sections |
| `ProjectHeader.tsx` | Context menu toggle item |
| `WorkspaceSection.tsx` | `isAutoManaged` prop disables editing interactions |

Closes #2750
<img width="171" height="694" alt="image" src="https://github.com/user-attachments/assets/a134467e-199e-4f8b-a40a-4187b82d43fc" />


<img width="287" height="343" alt="image" src="https://github.com/user-attachments/assets/d5113ad9-2434-4fb8-a20d-96b2892517d7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-organize workspaces by pull request status (approved, in-review, draft, merged, closed, no-pr)
  * Context menu toggle to enable/disable PR-based auto-organization per project
  * Background refresh of PR statuses with staleness detection to keep status groups up to date

* **Tests**
  * Added unit tests covering PR status categorization logic
<!-- end of auto-generated comment: release notes by coderabbit.ai -->