### PR TITLE
feat: searchable base branch picker with multi-remote support

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/projects/projects.ts
+++ b/apps/desktop/src/lib/trpc/routers/projects/projects.ts
@@ -523,6 +523,7 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 						isRemote: boolean;
 					}>;
 					defaultBranch: string;
+					remoteNames: string[];
 				}> => {
 					const project = localDb
 						.select()
@@ -539,13 +540,21 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 					const branchSummary = await git.branch(["-a"]);
 
 					const localBranchSet = new Set<string>();
-					const remoteBranchSet = new Set<string>();
 
+					// Collect remote branches grouped by remote name
+					const remoteBranchSets = new Map<string, Set<string>>();
 					for (const name of Object.keys(branchSummary.branches)) {
-						if (name.startsWith("remotes/origin/")) {
-							if (name === "remotes/origin/HEAD") continue;
-							const remoteName = name.replace("remotes/origin/", "");
-							remoteBranchSet.add(remoteName);
+						if (name.startsWith("remotes/")) {
+							const withoutRemotes = name.substring("remotes/".length);
+							const slashIdx = withoutRemotes.indexOf("/");
+							if (slashIdx <= 0) continue;
+							const remoteName = withoutRemotes.substring(0, slashIdx);
+							const branchName = withoutRemotes.substring(slashIdx + 1);
+							if (branchName === "HEAD") continue;
+							if (!remoteBranchSets.has(remoteName)) {
+								remoteBranchSets.set(remoteName, new Set());
+							}
+							remoteBranchSets.get(remoteName)!.add(branchName);
 						} else {
 							localBranchSet.add(name);
 						}
@@ -556,14 +565,15 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 						{ lastCommitDate: number; isLocal: boolean; isRemote: boolean }
 					>();
 
-					// Include cached remote refs (no network needed)
-					if (remoteBranchSet.size > 0) {
+					// Include cached remote refs from all remotes (no network needed)
+					for (const [remoteName, remoteBranchSet] of remoteBranchSets) {
+						if (remoteBranchSet.size === 0) continue;
 						try {
 							const remoteBranchInfo = await git.raw([
 								"for-each-ref",
 								"--sort=-committerdate",
 								"--format=%(refname:short) %(committerdate:unix)",
-								"refs/remotes/origin/",
+								`refs/remotes/${remoteName}/`,
 							]);
 
 							for (const line of remoteBranchInfo.trim().split("\n")) {
@@ -576,28 +586,48 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 									10,
 								);
 
-								if (branch.startsWith("origin/")) {
-									branch = branch.replace("origin/", "");
+								const remotePrefix = `${remoteName}/`;
+								if (branch.startsWith(remotePrefix)) {
+									branch = branch.substring(remotePrefix.length);
 								}
 
-								if (!branch || branch === "HEAD") continue;
+								// Skip HEAD symbolic refs — refname:short outputs just the remote name for these
+								if (!branch || branch === "HEAD" || branch === remoteName) continue;
 
-								branchMap.set(branch, {
-									lastCommitDate: timestamp * 1000,
-									isLocal: localBranchSet.has(branch),
-									isRemote: true,
-								});
+								// For origin, use plain name. For other remotes, prefix with remote name.
+								const branchKey =
+									remoteName === "origin"
+										? branch
+										: `${remoteName}/${branch}`;
+
+								if (!branchMap.has(branchKey)) {
+									branchMap.set(branchKey, {
+										lastCommitDate: timestamp * 1000,
+										isLocal: localBranchSet.has(branch),
+										isRemote: true,
+									});
+								}
 							}
 						} catch {
 							for (const name of remoteBranchSet) {
-								branchMap.set(name, {
-									lastCommitDate: 0,
-									isLocal: localBranchSet.has(name),
-									isRemote: true,
-								});
+								const branchKey =
+									remoteName === "origin"
+										? name
+										: `${remoteName}/${name}`;
+								if (!branchMap.has(branchKey)) {
+									branchMap.set(branchKey, {
+										lastCommitDate: 0,
+										isLocal: localBranchSet.has(name),
+										isRemote: true,
+									});
+								}
 							}
 						}
 					}
+
+					// Collect all origin remote branch names for isRemote flag on local branches
+					const originBranchSet =
+						remoteBranchSets.get("origin") ?? new Set<string>();
 
 					try {
 						const localBranchInfo = await git.raw([
@@ -623,7 +653,7 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 								branchMap.set(branch, {
 									lastCommitDate: timestamp * 1000,
 									isLocal: true,
-									isRemote: remoteBranchSet.has(branch),
+									isRemote: originBranchSet.has(branch),
 								});
 							} else {
 								const existing = branchMap.get(branch);
@@ -638,7 +668,7 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 								branchMap.set(name, {
 									lastCommitDate: 0,
 									isLocal: true,
-									isRemote: remoteBranchSet.has(name),
+									isRemote: originBranchSet.has(name),
 								});
 							}
 						}
@@ -661,7 +691,7 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 						return b.lastCommitDate - a.lastCommitDate;
 					});
 
-					return { branches, defaultBranch };
+					return { branches, defaultBranch, remoteNames: Array.from(remoteBranchSets.keys()) };
 				},
 			),
 
@@ -679,6 +709,7 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 						isRemote: boolean;
 					}>;
 					defaultBranch: string;
+					remoteNames: string[];
 				}> => {
 					const project = localDb
 						.select()
@@ -692,27 +723,33 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 					const git = await getSimpleGitWithShellPath(project.mainRepoPath);
 
 					try {
-						await git.fetch(["--prune"]);
+						await git.fetch(["--all", "--prune"]);
 					} catch {
 						// Best effort: continue with locally available refs when offline.
 					}
 
-					let hasOrigin = false;
+					let remotes: Array<{ name: string }> = [];
 					try {
-						const remotes = await git.getRemotes();
-						hasOrigin = remotes.some((r) => r.name === "origin");
+						remotes = await git.getRemotes();
 					} catch {}
 
 					const branchSummary = await git.branch(["-a"]);
 
 					const localBranchSet = new Set<string>();
-					const remoteBranchSet = new Set<string>();
-
+					// Collect remote branches grouped by remote name
+					const remoteBranchSets = new Map<string, Set<string>>();
 					for (const name of Object.keys(branchSummary.branches)) {
-						if (name.startsWith("remotes/origin/")) {
-							if (name === "remotes/origin/HEAD") continue;
-							const remoteName = name.replace("remotes/origin/", "");
-							remoteBranchSet.add(remoteName);
+						if (name.startsWith("remotes/")) {
+							const withoutRemotes = name.substring("remotes/".length);
+							const slashIdx = withoutRemotes.indexOf("/");
+							if (slashIdx <= 0) continue;
+							const remoteName = withoutRemotes.substring(0, slashIdx);
+							const branchName = withoutRemotes.substring(slashIdx + 1);
+							if (branchName === "HEAD") continue;
+							if (!remoteBranchSets.has(remoteName)) {
+								remoteBranchSets.set(remoteName, new Set());
+							}
+							remoteBranchSets.get(remoteName)!.add(branchName);
 						} else {
 							localBranchSet.add(name);
 						}
@@ -723,13 +760,15 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 						{ lastCommitDate: number; isLocal: boolean; isRemote: boolean }
 					>();
 
-					if (hasOrigin) {
+					for (const remote of remotes) {
+						const remoteBranchSet = remoteBranchSets.get(remote.name);
+						if (!remoteBranchSet?.size) continue;
 						try {
 							const remoteBranchInfo = await git.raw([
 								"for-each-ref",
 								"--sort=-committerdate",
 								"--format=%(refname:short) %(committerdate:unix)",
-								"refs/remotes/origin/",
+								`refs/remotes/${remote.name}/`,
 							]);
 
 							for (const line of remoteBranchInfo.trim().split("\n")) {
@@ -743,28 +782,48 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 								);
 
 								// Normalize remote branch names
-								if (branch.startsWith("origin/")) {
-									branch = branch.replace("origin/", "");
+								const remotePrefix = `${remote.name}/`;
+								if (branch.startsWith(remotePrefix)) {
+									branch = branch.substring(remotePrefix.length);
 								}
 
-								if (!branch || branch === "HEAD") continue;
+								// Skip HEAD symbolic refs — refname:short outputs just the remote name for these
+								if (!branch || branch === "HEAD" || branch === remote.name) continue;
 
-								branchMap.set(branch, {
-									lastCommitDate: timestamp * 1000,
-									isLocal: localBranchSet.has(branch),
-									isRemote: true,
-								});
+								// For origin, use plain name. For other remotes, prefix with remote name.
+								const branchKey =
+									remote.name === "origin"
+										? branch
+										: `${remote.name}/${branch}`;
+
+								if (!branchMap.has(branchKey)) {
+									branchMap.set(branchKey, {
+										lastCommitDate: timestamp * 1000,
+										isLocal: localBranchSet.has(branch),
+										isRemote: true,
+									});
+								}
 							}
 						} catch {
 							for (const name of remoteBranchSet) {
-								branchMap.set(name, {
-									lastCommitDate: 0,
-									isLocal: localBranchSet.has(name),
-									isRemote: true,
-								});
+								const branchKey =
+									remote.name === "origin"
+										? name
+										: `${remote.name}/${name}`;
+								if (!branchMap.has(branchKey)) {
+									branchMap.set(branchKey, {
+										lastCommitDate: 0,
+										isLocal: localBranchSet.has(name),
+										isRemote: true,
+									});
+								}
 							}
 						}
 					}
+
+					// Collect origin branch names for isRemote flag on local branches
+					const originBranchSet =
+						remoteBranchSets.get("origin") ?? new Set<string>();
 
 					try {
 						const localBranchInfo = await git.raw([
@@ -791,7 +850,7 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 								branchMap.set(branch, {
 									lastCommitDate: timestamp * 1000,
 									isLocal: true,
-									isRemote: remoteBranchSet.has(branch),
+									isRemote: originBranchSet.has(branch),
 								});
 							} else {
 								// Update isLocal flag for branches that exist both locally and remotely
@@ -808,7 +867,7 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 								branchMap.set(name, {
 									lastCommitDate: 0,
 									isLocal: true,
-									isRemote: remoteBranchSet.has(name),
+									isRemote: originBranchSet.has(name),
 								});
 							}
 						}
@@ -846,7 +905,7 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 						return b.lastCommitDate - a.lastCommitDate;
 					});
 
-					return { branches, defaultBranch };
+					return { branches, defaultBranch, remoteNames: remotes.map((r) => r.name) };
 				},
 			),
 
@@ -890,44 +949,65 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 					// Always list all refs — git glob `*` doesn't cross `/` and is
 					// case-sensitive, so we filter in JS for reliable substring search.
 					const localPattern = "refs/heads/";
-					const remotePattern = "refs/remotes/origin/";
 
 					const branchMap = new Map<
 						string,
 						{ lastCommitDate: number; isLocal: boolean; isRemote: boolean }
 					>();
 
-					// Fetch remote refs
+					// Fetch remote refs from all configured remotes
+					let remotes: Array<{ name: string }> = [];
 					try {
-						const remoteOutput = await git.raw([
-							"for-each-ref",
-							"--sort=-committerdate",
-							"--format=%(refname:short) %(committerdate:unix)",
-							remotePattern,
-						]);
+						remotes = await git.getRemotes();
+					} catch {}
 
-						for (const line of remoteOutput.trim().split("\n")) {
-							if (!line) continue;
-							const lastSpaceIdx = line.lastIndexOf(" ");
-							let branch = line.substring(0, lastSpaceIdx);
-							const timestamp = Number.parseInt(
-								line.substring(lastSpaceIdx + 1),
-								10,
-							);
+					for (const remote of remotes) {
+						const remotePattern = `refs/remotes/${remote.name}/`;
+						try {
+							const remoteOutput = await git.raw([
+								"for-each-ref",
+								"--sort=-committerdate",
+								"--format=%(refname:short) %(committerdate:unix)",
+								remotePattern,
+							]);
 
-							if (branch.startsWith("origin/")) {
-								branch = branch.replace("origin/", "");
+							for (const line of remoteOutput.trim().split("\n")) {
+								if (!line) continue;
+								const lastSpaceIdx = line.lastIndexOf(" ");
+								let branch = line.substring(0, lastSpaceIdx);
+								const timestamp = Number.parseInt(
+									line.substring(lastSpaceIdx + 1),
+									10,
+								);
+
+								// Strip remote prefix from refname:short output
+								const remotePrefix = `${remote.name}/`;
+								if (branch.startsWith(remotePrefix)) {
+									branch = branch.substring(remotePrefix.length);
+								}
+								// Skip HEAD symbolic refs — refname:short outputs just the remote name for these
+								if (!branch || branch === "HEAD" || branch === remote.name) continue;
+
+								// For origin, use plain name. For other remotes, prefix with remote name.
+								const branchKey =
+									remote.name === "origin"
+										? branch
+										: `${remote.name}/${branch}`;
+
+								if (!branchMap.has(branchKey)) {
+									branchMap.set(branchKey, {
+										lastCommitDate: timestamp * 1000,
+										isLocal: false,
+										isRemote: true,
+									});
+								}
 							}
-							if (branch === "HEAD") continue;
-
-							branchMap.set(branch, {
-								lastCommitDate: timestamp * 1000,
-								isLocal: false,
-								isRemote: true,
-							});
+						} catch (err) {
+							console.warn(
+								`[searchBranches] Failed to list remote refs for ${remote.name}:`,
+								err,
+							);
 						}
-					} catch (err) {
-						console.warn("[searchBranches] Failed to list remote refs:", err);
 					}
 
 					// Fetch local refs

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/base-branch.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/base-branch.test.ts
@@ -23,23 +23,23 @@ describe("resolveWorkspaceBaseBranch", () => {
 		expect(resolved).toBe("feature/long-lived");
 	});
 
-	test("falls back to repository default branch when project preference is absent", () => {
+	test("falls back to origin/<default> when project preference is absent", () => {
 		const resolved = resolveWorkspaceBaseBranch({
 			defaultBranch: "main",
 			knownBranches: ["main", "feature/long-lived"],
 		});
 
-		expect(resolved).toBe("main");
+		expect(resolved).toBe("origin/main");
 	});
 
-	test("falls back to repository default when stored preference is stale", () => {
+	test("falls back to origin/<default> when stored preference is stale", () => {
 		const resolved = resolveWorkspaceBaseBranch({
 			workspaceBaseBranch: "feature/deleted",
 			defaultBranch: "main",
 			knownBranches: ["main", "feature/long-lived"],
 		});
 
-		expect(resolved).toBe("main");
+		expect(resolved).toBe("origin/main");
 	});
 
 	test("uses workspace base branch when knownBranches is unavailable (offline)", () => {
@@ -49,8 +49,14 @@ describe("resolveWorkspaceBaseBranch", () => {
 		});
 		expect(resolved).toBe("feature/long-lived");
 	});
-	test('falls back to "main" when no defaultBranch or workspaceBaseBranch is provided', () => {
+	test('falls back to "origin/main" when no defaultBranch or workspaceBaseBranch is provided', () => {
 		const resolved = resolveWorkspaceBaseBranch({});
-		expect(resolved).toBe("main");
+		expect(resolved).toBe("origin/main");
+	});
+	test("preserves already-qualified default branch", () => {
+		const resolved = resolveWorkspaceBaseBranch({
+			defaultBranch: "upstream/main",
+		});
+		expect(resolved).toBe("upstream/main");
 	});
 });

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/base-branch.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/base-branch.ts
@@ -16,7 +16,12 @@ export function resolveWorkspaceBaseBranch({
 	defaultBranch,
 	knownBranches,
 }: ResolveWorkspaceBaseBranchParams): string {
-	const fallbackBranch = normalizeBranch(defaultBranch) ?? "main";
+	const rawDefault = normalizeBranch(defaultBranch) ?? "main";
+	// Default to origin/<branch> so new workspaces base off the remote tracking
+	// branch rather than a potentially stale local checkout.
+	const fallbackBranch = rawDefault.includes("/")
+		? rawDefault
+		: `origin/${rawDefault}`;
 	const explicit = normalizeBranch(explicitBaseBranch);
 	if (explicit) {
 		return explicit;

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
@@ -1299,8 +1299,14 @@ export async function listBranches(
 
 	const remoteResult = await git.branch(["-r"]);
 	const remote = remoteResult.all
-		.filter((b) => b.startsWith("origin/") && !b.includes("->"))
-		.map((b) => b.replace("origin/", ""));
+		.filter((b) => !b.includes("->"))
+		.map((b) => {
+			// Strip "origin/" prefix for backward compat, keep prefix for other remotes
+			if (b.startsWith("origin/")) {
+				return b.replace("origin/", "");
+			}
+			return b;
+		});
 
 	return { local, remote };
 }

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/workspace-init.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/workspace-init.ts
@@ -203,6 +203,26 @@ export async function initializeWorkspaceWorktree({
 		);
 		const hasRemote = await hasOriginRemote(mainRepoPath);
 
+		// Parse remote-qualified branch names (e.g., "upstream/main" → { remote: "upstream", branch: "main" })
+		// Plain names like "main" are treated as { remote: undefined, branch: "main" }
+		const parseRemoteQualifiedBranch = (
+			name: string,
+		): { remote: string | undefined; branch: string } => {
+			const slashIdx = name.indexOf("/");
+			if (slashIdx <= 0) return { remote: undefined, branch: name };
+			const potentialRemote = name.substring(0, slashIdx);
+			// Only treat as remote-qualified if it looks like a remote name (not a path like "feature/foo")
+			// We check if a tracking ref exists for this pattern
+			const potentialBranch = name.substring(slashIdx + 1);
+			return { remote: potentialRemote, branch: potentialBranch };
+		};
+
+		const parsed = parseRemoteQualifiedBranch(effectiveBaseBranch);
+		// The remote to use for this base branch (defaults to "origin" for plain names)
+		const effectiveRemote = parsed.remote ?? "origin";
+		// The plain branch name without remote prefix
+		const effectivePlainBranch = parsed.branch;
+
 		type LocalStartPointResult = {
 			ref: string;
 			fallbackBranch?: string;
@@ -210,23 +230,24 @@ export async function initializeWorkspaceWorktree({
 
 		const resolveLocalStartPoint = async (
 			reason: string,
-			checkOriginRefs: boolean,
+			checkRemoteRefs: boolean,
 		): Promise<LocalStartPointResult> => {
-			if (checkOriginRefs) {
-				const originRef = `origin/${effectiveBaseBranch}`;
-				if (await refExistsLocally(mainRepoPath, originRef)) {
+			if (checkRemoteRefs) {
+				// For remote-qualified names, use the specified remote; otherwise use origin
+				const remoteRef = `${effectiveRemote}/${effectivePlainBranch}`;
+				if (await refExistsLocally(mainRepoPath, remoteRef)) {
 					console.log(
-						`[workspace-init] ${reason}. Using local tracking ref: ${originRef}`,
+						`[workspace-init] ${reason}. Using local tracking ref: ${remoteRef}`,
 					);
-					return { ref: originRef };
+					return { ref: remoteRef };
 				}
 			}
 
-			if (await refExistsLocally(mainRepoPath, effectiveBaseBranch)) {
+			if (await refExistsLocally(mainRepoPath, effectivePlainBranch)) {
 				console.log(
-					`[workspace-init] ${reason}. Using local branch: ${effectiveBaseBranch}`,
+					`[workspace-init] ${reason}. Using local branch: ${effectivePlainBranch}`,
 				);
-				return { ref: effectiveBaseBranch };
+				return { ref: effectivePlainBranch };
 			}
 
 			if (baseBranchWasExplicit) {
@@ -238,8 +259,8 @@ export async function initializeWorkspaceWorktree({
 
 			const commonBranches = ["main", "master", "develop", "trunk"];
 			for (const branch of commonBranches) {
-				if (branch === effectiveBaseBranch) continue;
-				if (checkOriginRefs) {
+				if (branch === effectivePlainBranch) continue;
+				if (checkRemoteRefs) {
 					const fallbackOriginRef = `origin/${branch}`;
 					if (await refExistsLocally(mainRepoPath, fallbackOriginRef)) {
 						console.log(
@@ -302,19 +323,20 @@ export async function initializeWorkspaceWorktree({
 		if (hasRemote) {
 			const branchCheck = await branchExistsOnRemote(
 				mainRepoPath,
-				effectiveBaseBranch,
+				effectivePlainBranch,
+				effectiveRemote,
 			);
 
 			if (branchCheck.status === "exists") {
-				const originRef = `origin/${effectiveBaseBranch}`;
+				const remoteRef = `${effectiveRemote}/${effectivePlainBranch}`;
 
 				// VALIDATION: Verify the remote-tracking ref actually exists locally
 				// branchExistsOnRemote checks the remote, but the local ref might not be fetched yet
-				if (await refExistsLocally(mainRepoPath, originRef)) {
-					startPoint = originRef;
+				if (await refExistsLocally(mainRepoPath, remoteRef)) {
+					startPoint = remoteRef;
 				} else {
 					console.warn(
-						`[workspace-init] Remote branch "${effectiveBaseBranch}" exists but local tracking ref "${originRef}" not found. Falling back to local ref.`,
+						`[workspace-init] Remote branch "${effectiveBaseBranch}" exists but local tracking ref "${remoteRef}" not found. Falling back to local ref.`,
 					);
 					manager.updateProgress(
 						workspaceId,
@@ -335,7 +357,7 @@ export async function initializeWorkspaceWorktree({
 							"failed",
 							"No local reference available",
 							baseBranchWasExplicit
-								? `Branch "${effectiveBaseBranch}" exists on remote but has not been fetched yet, and no local branch exists. Please run "git fetch origin ${effectiveBaseBranch}" and try again.`
+								? `Branch "${effectiveBaseBranch}" exists on remote but has not been fetched yet, and no local branch exists. Please run "git fetch ${effectiveRemote} ${effectivePlainBranch}" and try again.`
 								: `Branch "${effectiveBaseBranch}" not found locally. Please run "git fetch" and try again.`,
 						);
 						return;

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/ProjectSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/ProjectSettings.tsx
@@ -11,8 +11,17 @@ import {
 	AlertDialogTrigger,
 } from "@superset/ui/alert-dialog";
 import { Button } from "@superset/ui/button";
+import {
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from "@superset/ui/command";
 import { Input } from "@superset/ui/input";
 import { Label } from "@superset/ui/label";
+import { Popover, PopoverContent, PopoverTrigger } from "@superset/ui/popover";
 import {
 	Select,
 	SelectContent,
@@ -25,8 +34,10 @@ import { Switch } from "@superset/ui/switch";
 import { cn } from "@superset/ui/utils";
 import { useNavigate } from "@tanstack/react-router";
 import type { ReactNode } from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+	HiCheck,
+	HiChevronUpDown,
 	HiOutlineCog6Tooth,
 	HiOutlineCommandLine,
 	HiOutlineFolderOpen,
@@ -35,6 +46,7 @@ import {
 import { LuImagePlus, LuTrash2 } from "react-icons/lu";
 import { ColorSelector } from "renderer/components/ColorSelector";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { formatRelativeTime } from "renderer/lib/formatRelativeTime";
 import {
 	useImportAllWorktrees,
 	useOpenExternalWorktree,
@@ -54,7 +66,6 @@ import {
 import { ProjectSettingsHeader } from "../ProjectSettingsHeader";
 import { ScriptsEditor } from "./components/ScriptsEditor";
 
-const REPO_DEFAULT_BASE_BRANCH = "__repo_default__";
 
 export function SettingsSection({
 	icon,
@@ -97,11 +108,19 @@ export function ProjectSettings({
 	const { data: project } = electronTrpc.projects.get.useQuery({
 		id: projectId,
 	});
-	const { data: branchData, isLoading: isBranchDataLoading } =
+	const { data: localBranchData, isLoading: isLocalBranchDataLoading } =
+		electronTrpc.projects.getBranchesLocal.useQuery(
+			{ projectId },
+			{ enabled: !!projectId },
+		);
+	const { data: remoteBranchData } =
 		electronTrpc.projects.getBranches.useQuery(
 			{ projectId },
 			{ enabled: !!projectId },
 		);
+	// Use remote data when available, fall back to fast local data
+	const branchData = remoteBranchData ?? localBranchData;
+	const isBranchDataLoading = isLocalBranchDataLoading;
 	const { data: gitAuthor } = electronTrpc.projects.getGitAuthor.useQuery({
 		id: projectId,
 	});
@@ -115,6 +134,30 @@ export function ProjectSettings({
 	const [selectedWorktreePath, setSelectedWorktreePath] = useState<
 		string | null
 	>(null);
+	const [baseBranchOpen, setBaseBranchOpen] = useState(false);
+	const [baseBranchSearch, setBaseBranchSearch] = useState("");
+
+
+
+	const filteredBranches = useMemo(() => {
+		const branches = (branchData?.branches ?? []).map((branch) => {
+			// storedValue: always the full remote-qualified name (for persistence + trigger)
+			const storedValue =
+				branch.isRemote && !branch.name.includes("/")
+					? `origin/${branch.name}`
+					: branch.name;
+			// menuLabel: origin branches always plain, non-origin remotes always prefixed
+			const menuLabel = branch.name;
+			return { ...branch, storedValue, menuLabel };
+		});
+		if (!baseBranchSearch) return branches;
+		const searchLower = baseBranchSearch.toLowerCase();
+		return branches.filter(
+			(branch) =>
+				branch.menuLabel.toLowerCase().includes(searchLower) ||
+				branch.storedValue.toLowerCase().includes(searchLower),
+		);
+	}, [branchData?.branches, baseBranchSearch]);
 
 	useEffect(() => {
 		setCustomPrefixInput(project?.branchPrefixCustom ?? "");
@@ -206,7 +249,7 @@ export function ProjectSettings({
 		updateProject.mutate({
 			id: projectId,
 			patch: {
-				workspaceBaseBranch: value === REPO_DEFAULT_BASE_BRANCH ? null : value,
+				workspaceBaseBranch: value,
 			},
 		});
 	};
@@ -280,17 +323,26 @@ export function ProjectSettings({
 
 	const currentMode = project.branchPrefixMode ?? "default";
 	const previewPrefix = getPreviewPrefix(currentMode);
-	const repoDefaultBranch =
+	const rawDefaultBranch =
 		branchData?.defaultBranch ?? project.defaultBranch ?? "main";
-	const workspaceBaseBranchValue =
-		project.workspaceBaseBranch ?? REPO_DEFAULT_BASE_BRANCH;
+	const repoDefaultBranch = rawDefaultBranch.includes("/")
+		? rawDefaultBranch
+		: `origin/${rawDefaultBranch}`;
 	const workspaceBaseBranchMissing =
 		!isBranchDataLoading &&
 		!!project.workspaceBaseBranch &&
 		!!branchData &&
-		!branchData.branches.some(
-			(branch) => branch.name === project.workspaceBaseBranch,
-		);
+		!branchData.branches.some((branch) => {
+			const stored =
+				branch.isRemote && !branch.name.includes("/")
+					? `origin/${branch.name}`
+					: branch.name;
+			return stored === project.workspaceBaseBranch;
+		});
+	const workspaceBaseBranchValue =
+		workspaceBaseBranchMissing
+			? repoDefaultBranch
+			: (project.workspaceBaseBranch ?? repoDefaultBranch);
 
 	return (
 		<div className="p-6 max-w-4xl w-full select-text">
@@ -365,34 +417,82 @@ export function ProjectSettings({
 								branch.
 							</p>
 						</div>
-						<Select
-							value={workspaceBaseBranchValue}
-							onValueChange={handleWorkspaceBaseBranchChange}
-							disabled={updateProject.isPending || isBranchDataLoading}
+						<Popover
+							open={baseBranchOpen}
+							onOpenChange={(v) => {
+								setBaseBranchOpen(v);
+								if (!v) setBaseBranchSearch("");
+								if (v) {
+									requestAnimationFrame(() => {
+										const selected = document.querySelector(
+											"[data-selected='']",
+										);
+										selected?.scrollIntoView({ block: "nearest" });
+									});
+								}
+							}}
 						>
-							<SelectTrigger className="w-[260px]">
-								{isBranchDataLoading ? (
-									<span className="text-muted-foreground">Loading...</span>
-								) : (
-									<SelectValue />
-								)}
-							</SelectTrigger>
-							<SelectContent>
-								<SelectItem value={REPO_DEFAULT_BASE_BRANCH}>
-									Use repository default ({repoDefaultBranch})
-								</SelectItem>
-								{workspaceBaseBranchMissing && project.workspaceBaseBranch && (
-									<SelectItem value={project.workspaceBaseBranch}>
-										{project.workspaceBaseBranch} (missing)
-									</SelectItem>
-								)}
-								{(branchData?.branches ?? []).map((branch) => (
-									<SelectItem key={branch.name} value={branch.name}>
-										{branch.name}
-									</SelectItem>
-								))}
-							</SelectContent>
-						</Select>
+							<PopoverTrigger asChild>
+								<Button
+									variant="outline"
+									className="w-[260px] justify-between font-normal"
+									disabled={updateProject.isPending || isBranchDataLoading}
+								>
+									{isBranchDataLoading ? (
+										<span className="text-muted-foreground">Loading...</span>
+									) : (
+										<span className="truncate">
+											{workspaceBaseBranchValue}
+										</span>
+									)}
+									<HiChevronUpDown className="ml-2 size-4 shrink-0 opacity-50" />
+								</Button>
+							</PopoverTrigger>
+							<PopoverContent
+								className="w-[300px] p-0"
+								align="end"
+								onWheel={(event) => event.stopPropagation()}
+							>
+								<Command shouldFilter={false}>
+									<CommandInput
+										placeholder="Search branches..."
+										value={baseBranchSearch}
+										onValueChange={setBaseBranchSearch}
+									/>
+									<CommandList className="max-h-[300px]">
+										<CommandEmpty>No branches found</CommandEmpty>
+										<CommandGroup>
+											{filteredBranches.map((branch) => (
+												<CommandItem
+													key={branch.storedValue}
+													value={branch.menuLabel}
+													onSelect={() => {
+														handleWorkspaceBaseBranchChange(branch.storedValue);
+														setBaseBranchOpen(false);
+													}}
+													className="flex items-center justify-between"
+													data-selected={workspaceBaseBranchValue === branch.storedValue ? "" : undefined}
+												>
+													<span className="truncate">
+														{branch.menuLabel}
+													</span>
+													<span className="flex items-center gap-2 shrink-0">
+														{branch.lastCommitDate > 0 && (
+															<span className="text-xs text-muted-foreground">
+																{formatRelativeTime(branch.lastCommitDate)}
+															</span>
+														)}
+														{workspaceBaseBranchValue === branch.storedValue && (
+															<HiCheck className="size-4 text-primary" />
+														)}
+													</span>
+												</CommandItem>
+											))}
+										</CommandGroup>
+									</CommandList>
+								</Command>
+							</PopoverContent>
+						</Popover>
 					</div>
 					{workspaceBaseBranchMissing && (
 						<p className="text-xs text-destructive">


### PR DESCRIPTION
## Summary

Replaces the non-searchable `<Select>` in Project Settings → Workspace Base Branch with a searchable `Popover+Command` picker. Also adds support for selecting branches from any configured remote (not just `origin`).

## Changes

### Backend
- **Multi-remote support**: All three branch endpoints (`getBranchesLocal`, `getBranches`, `searchBranches`) now iterate all configured remotes via `git.getRemotes()` instead of hardcoding `origin`
- **Naming convention**: Origin branches use plain names (e.g. `main`), non-origin remotes are prefixed (e.g. `upstream/main`)
- **Remote names in response**: Endpoints return `remoteNames` array so frontend can adapt display logic based on number of remotes
- **HEAD ref filtering**: Fixed phantom branch entries (e.g. `origin/origin`) caused by `refname:short` outputting just the remote name for HEAD symbolic refs
- **Default fallback**: `resolveWorkspaceBaseBranch` falls back to `origin/<default>` instead of plain local branch name to avoid stale local refs

### Frontend (ProjectSettings)
- **Searchable picker**: Popover+Command with client-side filtering replaces static Select
- **Smart display**: Plain branch names when single remote, prefixed names when multiple remotes exist to disambiguate
- **Stored values**: Always remote-qualified for remote branches (e.g. `origin/master`)
- **Missing branch UX**: Button shows the fallback default branch, error message below explains the change — no more redundant "(missing)" item in dropdown

### Workspace Init
- **`parseRemoteQualifiedBranch` helper**: Parses `upstream/main` → `{ remote: "upstream", branch: "main" }` to avoid constructing invalid refs like `origin/upstream/main`
- **Remote-aware start point**: `resolveLocalStartPoint` uses extracted remote name instead of hardcoding `origin`

## Test Plan
- Typecheck passes across all 20 packages
- Updated `base-branch.test.ts` to reflect `origin/` prefix in fallback behavior
- Manual testing: open Project Settings, verify branches from all remotes appear, search works, selection persists

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a searchable base-branch picker in Project Settings and full multi-remote branch support. Improves defaults and workspace init so remote-qualified branches like upstream/main work reliably.

- **New Features**
  - Branch APIs (`getBranchesLocal`, `getBranches`, `searchBranches`) now iterate all remotes and return `remoteNames`; origin uses plain names (e.g. `main`), other remotes use `remote/branch`.
  - Searchable base-branch picker with client-side filtering and last-commit times; remote-aware labels and stored values are remote-qualified; uses remote data with local fallback.
  - Remote-aware workspace init that parses `remote/branch` and starts from the correct tracking ref.

- **Bug Fixes**
  - Filter out HEAD symbolic refs to prevent phantom entries like `origin/origin`.
  - Fallback base branch is now `origin/<default>` (preserves already-qualified defaults).
  - Use `git fetch --all --prune` and fix `isRemote` detection for local branches.
  - Normalize remote names in `listBranches`: strip `origin/`, keep other remote prefixes.

<sup>Written for commit 0b6e253406a50aff49666306032fe90283b55d6b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Branch discovery now lists branches from all configured remotes, de-duplicates by name, and exposes remote names.
  * Base-branch picker updated to a searchable popover with improved filtering, relative commit times, and clearer selection.

* **Bug Fixes**
  * Base-branch resolution and fallbacks now consistently use remote-qualified names (e.g., origin/...) to avoid ambiguous or stale defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->