### PR TITLE
feat(desktop): auto-sync chat titles and lazy backfill for untitled sessions

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceChat/hooks/useWorkspaceChatController/useWorkspaceChatController.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceChat/hooks/useWorkspaceChatController/useWorkspaceChatController.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { StartFreshSessionResult } from "renderer/components/Chat/ChatInterface/types";
 import { env } from "renderer/env.renderer";
 import { authClient, getAuthToken } from "renderer/lib/auth-client";
+import { MOCK_ORG_ID } from "shared/constants";
 import { posthog } from "renderer/lib/posthog";
 import { workspaceTrpc } from "renderer/lib/workspace-trpc";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
@@ -89,7 +90,9 @@ export function useWorkspaceChatController({
 	workspaceId: string;
 }) {
 	const { data: session } = authClient.useSession();
-	const organizationId = session?.session?.activeOrganizationId ?? null;
+	const organizationId = env.SKIP_ENV_VALIDATION
+		? MOCK_ORG_ID
+		: (session?.session?.activeOrganizationId ?? null);
 	const collections = useCollections();
 	const [sessionId, setSessionId] = useState<string | null>(null);
 	const [isSessionInitializing, setIsSessionInitializing] = useState(false);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/ChatPane.tsx
@@ -4,7 +4,7 @@ import {
 } from "@superset/chat/client";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { CopyIcon } from "lucide-react";
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import type { MosaicBranch } from "react-mosaic-component";
 import { createChatServiceIpcClient } from "renderer/components/Chat/utils/chat-service-client";
 import { env } from "renderer/env.renderer";
@@ -95,6 +95,29 @@ export function ChatPane({
 		handleRawSnapshotChange,
 		handleCopyRawSnapshot,
 	} = useChatRawSnapshot({ sessionId });
+
+	const currentDbTitle =
+		sessionItems.find((s) => s.sessionId === sessionId)?.title ?? "";
+
+	useEffect(() => {
+		if (!currentDbTitle) return;
+		setPaneAutoTitle(paneId, currentDbTitle);
+		setTabAutoTitle(tabId, currentDbTitle);
+	}, [currentDbTitle, paneId, tabId, setPaneAutoTitle, setTabAutoTitle]);
+
+	// Lazy backfill: if the session has no DB title, trigger generation once.
+	// Covers existing sessions (old chats) and cases where sendMessage title gen failed.
+	const titleGenerationAttemptedRef = useRef<string | null>(null);
+	useEffect(() => {
+		if (!sessionId || !workspacePath) return;
+		if (currentDbTitle) return;
+		if (titleGenerationAttemptedRef.current === sessionId) return;
+		titleGenerationAttemptedRef.current = sessionId;
+		void chatRuntimeIpcClient.session.generateTitle.mutate({
+			sessionId,
+			cwd: workspacePath,
+		});
+	}, [sessionId, workspacePath, currentDbTitle]);
 
 	const applySubmittedMessageFallbackTitle = useCallback(
 		(message: string) => {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/hooks/useChatPaneController/useChatPaneController.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/ChatPane/hooks/useChatPaneController/useChatPaneController.ts
@@ -6,6 +6,7 @@ import type { StartFreshSessionResult } from "renderer/components/Chat/ChatInter
 import { env } from "renderer/env.renderer";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { authClient, getAuthToken } from "renderer/lib/auth-client";
+import { MOCK_ORG_ID } from "shared/constants";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { posthog } from "renderer/lib/posthog";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
@@ -131,7 +132,9 @@ export function useChatPaneController({
 	const launchConfig = pane?.chat?.launchConfig ?? null;
 	const needsLegacySessionBootstrap = sessionId === null;
 	const { data: session } = authClient.useSession();
-	const organizationId = session?.session?.activeOrganizationId ?? null;
+	const organizationId = env.SKIP_ENV_VALIDATION
+		? MOCK_ORG_ID
+		: (session?.session?.activeOrganizationId ?? null);
 	const collections = useCollections();
 	const legacySessionBootstrapRef = useRef(false);
 	const ensuredRef = useRef<string | null>(null);

--- a/packages/chat/src/server/trpc/service.ts
+++ b/packages/chat/src/server/trpc/service.ts
@@ -312,6 +312,16 @@ export class ChatRuntimeService {
 						});
 					}),
 
+				generateTitle: t.procedure
+					.input(sessionIdInput)
+					.mutation(async ({ input }) => {
+						const runtime = await this.getOrCreateRuntime(
+							input.sessionId,
+							input.cwd,
+						);
+						await generateAndSetTitle(runtime, this.apiClient);
+					}),
+
 				stop: t.procedure.input(sessionIdInput).mutation(async ({ input }) => {
 					const runtime = await this.getOrCreateRuntime(
 						input.sessionId,


### PR DESCRIPTION
## Summary

Auto-sync chat pane/tab titles from the database and lazily backfill titles for older sessions that never got one.

### Changes

- **ChatPane.tsx**: Watch the session's DB title and push it to pane/tab auto-titles. If a session has no title yet (old chats or failed generation), trigger `generateTitle` once to retroactively create one.
- **ChatRuntimeService (service.ts)**: Add a `session.generateTitle` tRPC mutation so ChatPane can request title generation on demand.
- **useChatPaneController / useWorkspaceChatController**: Use `MOCK_ORG_ID` when `SKIP_ENV_VALIDATION` is set so chat works in local dev without a real auth session.

### Test Plan

- Open an existing chat session that has no title → verify a title is generated and reflected in the tab/pane.
- Send a new message in a fresh session → verify the title auto-syncs once generated.
- Verify dev mode (`SKIP_ENV_VALIDATION`) still boots chat correctly with `MOCK_ORG_ID`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-syncs chat pane/tab titles with the session title in the DB and lazily backfills titles for untitled sessions. Keeps tabs consistent and readable without manual refresh.

- **New Features**
  - Sync pane/tab titles with the DB session title in real time.
  - Backfill titles for untitled sessions once via new tRPC `session.generateTitle`.
  - In dev (`SKIP_ENV_VALIDATION`), use `MOCK_ORG_ID` so chat works without an auth org.

<sup>Written for commit e2bdbb53cd3a9f6848031df014dbfc03b0a2308a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic title generation for chat sessions without existing titles.

* **Improvements**
  * Enhanced synchronization of session titles between the database and user interface to ensure chat session names remain current and accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->