### PR TITLE
fix(desktop): virtualize git history commit list

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-handlers.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-handlers.ts
@@ -132,6 +132,7 @@ async function getBranchComparison(
 		const logOutput = await git.raw([
 			"log",
 			`origin/${defaultBranch}..HEAD`,
+			"--max-count=500",
 			"--format=%H|%h|%s|%an|%aI",
 		]);
 		commits = parseGitLog(logOutput);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/CommitListVirtualized/CommitListVirtualized.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/CommitListVirtualized/CommitListVirtualized.tsx
@@ -1,0 +1,87 @@
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { useRef } from "react";
+import type { ChangedFile, CommitInfo } from "shared/changes-types";
+import type { ChangesViewMode } from "../../types";
+import { CommitItem } from "../CommitItem";
+
+const ESTIMATED_ROW_HEIGHT = 28;
+const OVERSCAN = 10;
+
+interface CommitListVirtualizedProps {
+	commits: CommitInfo[];
+	expandedCommits: Set<string>;
+	onCommitToggle: (commitHash: string) => void;
+	selectedFile: ChangedFile | null;
+	selectedCommitHash: string | null;
+	onFileSelect: (file: ChangedFile, commitHash: string) => void;
+	viewMode: ChangesViewMode;
+	worktreePath: string;
+	projectId?: string;
+	isExpandedView?: boolean;
+}
+
+export function CommitListVirtualized({
+	commits,
+	expandedCommits,
+	onCommitToggle,
+	selectedFile,
+	selectedCommitHash,
+	onFileSelect,
+	viewMode,
+	worktreePath,
+	projectId,
+	isExpandedView,
+}: CommitListVirtualizedProps) {
+	const listRef = useRef<HTMLDivElement>(null);
+
+	const virtualizer = useVirtualizer({
+		count: commits.length,
+		getScrollElement: () =>
+			listRef.current?.closest(
+				"[data-changes-scroll-container]",
+			) as HTMLElement | null,
+		estimateSize: () => ESTIMATED_ROW_HEIGHT,
+		overscan: OVERSCAN,
+		scrollMargin: listRef.current?.offsetTop ?? 0,
+	});
+
+	const items = virtualizer.getVirtualItems();
+
+	return (
+		<div ref={listRef}>
+			<div
+				className="relative w-full"
+				style={{ height: virtualizer.getTotalSize() }}
+			>
+				{items.map((virtualRow) => {
+					const commit = commits[virtualRow.index];
+
+					return (
+						<div
+							key={virtualRow.key}
+							data-index={virtualRow.index}
+							ref={virtualizer.measureElement}
+							className="absolute left-0 w-full"
+							style={{
+								top: virtualRow.start - (virtualizer.options.scrollMargin ?? 0),
+							}}
+						>
+							<CommitItem
+								commit={commit}
+								isExpanded={expandedCommits.has(commit.hash)}
+								onToggle={() => onCommitToggle(commit.hash)}
+								selectedFile={selectedFile}
+								selectedCommitHash={selectedCommitHash}
+								onFileSelect={onFileSelect}
+								viewMode={viewMode}
+								worktreePath={worktreePath}
+								projectId={projectId}
+								isExpandedView={isExpandedView}
+							/>
+						</div>
+					);
+				})}
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/CommitListVirtualized/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/CommitListVirtualized/index.ts
@@ -1,0 +1,1 @@
+export { CommitListVirtualized } from "./CommitListVirtualized";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/hooks/useOrderedSections/useOrderedSections.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/hooks/useOrderedSections/useOrderedSections.tsx
@@ -8,7 +8,7 @@ import type {
 	ChangedFile,
 	CommitInfo,
 } from "shared/changes-types";
-import { CommitItem } from "../../components/CommitItem";
+import { CommitListVirtualized } from "../../components/CommitListVirtualized";
 import { FileList } from "../../components/FileList";
 import type { ChangesViewMode } from "../../types";
 
@@ -126,23 +126,20 @@ export function useOrderedSections({
 			count: commitCount,
 			isExpanded: expandedSections.committed,
 			onToggle: () => toggleSection("committed"),
-			content: expandedSections.committed
-				? commitsWithFiles.map((commit) => (
-						<CommitItem
-							key={commit.hash}
-							commit={commit}
-							isExpanded={expandedCommits.has(commit.hash)}
-							onToggle={() => onCommitToggle(commit.hash)}
-							selectedFile={selectedFile}
-							selectedCommitHash={selectedCommitHash}
-							onFileSelect={onCommitFileSelect}
-							viewMode={fileListViewMode}
-							worktreePath={worktreePath}
-							projectId={projectId}
-							isExpandedView={isExpandedView}
-						/>
-					))
-				: null,
+			content: expandedSections.committed ? (
+				<CommitListVirtualized
+					commits={commitsWithFiles}
+					expandedCommits={expandedCommits}
+					onCommitToggle={onCommitToggle}
+					selectedFile={selectedFile}
+					selectedCommitHash={selectedCommitHash}
+					onFileSelect={onCommitFileSelect}
+					viewMode={fileListViewMode}
+					worktreePath={worktreePath}
+					projectId={projectId}
+					isExpandedView={isExpandedView}
+				/>
+			) : null,
 		},
 		staged: {
 			id: "staged",

--- a/bun.lock
+++ b/bun.lock
@@ -110,7 +110,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.2.4",
+      "version": "1.3.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.43",
         "@ai-sdk/openai": "3.0.36",


### PR DESCRIPTION
## Summary
- Virtualize the commit list in the git history panel using `@tanstack/react-virtual` (already used by file lists in the same panel)
- Cap `git log` query to 500 commits via `--max-count=500`
- Drops DOM elements from ~130K to ~500 for repos with large commit history, eliminating CPU pegging at 200%, 1.55GB heap, and multi-second app freezes

## Test plan
- [ ] Open a workspace with many commits ahead of base branch
- [ ] Expand the "Commits" section in the changes sidebar
- [ ] Verify smooth scrolling through the commit list
- [ ] Verify expanding a commit still shows its file list
- [ ] Verify CPU/memory usage stays reasonable

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Virtualized the Git history commit list using `@tanstack/react-virtual` and capped `git log` to 500 commits. This cuts DOM nodes on large repos and prevents CPU spikes and UI freezes.

- **Performance**
  - Added a virtualized `CommitListVirtualized` list (28px row estimate, overscan 10) and wired it into the Changes sidebar.
  - Capped `git log origin/<default>..HEAD` with `--max-count=500`.
  - Preserved commit expand/collapse, file selection, and smooth scrolling.

<sup>Written for commit 4ea6214048be528fab6f33599f96f3dbd7c0acc2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Faster and smoother scrolling of large commit lists via virtualized commit rendering.
  * Branch comparisons now return up to 500 most recent commits to improve responsiveness on large histories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->