### PR TITLE
fix(desktop): prevent webview from swallowing mosaic drag events

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
@@ -26,6 +26,28 @@ function getHiddenContainer(): HTMLDivElement {
 	return hiddenContainer;
 }
 
+// ---------------------------------------------------------------------------
+// Disable webview interaction during ANY drag operation.
+// Electron <webview> tags create separate compositor layers that swallow
+// drag events before they reach the mosaic drop targets. Setting
+// pointer-events:none directly on the <webview> element tells the
+// compositor to stop routing events to the guest process.
+//
+// We use native HTML5 drag events (capture phase) rather than the drag pane
+// store because the store only covers mosaic pane drags — not tab-bar drags
+// or other drag sources.
+// ---------------------------------------------------------------------------
+
+function setWebviewsDragPassthrough(passthrough: boolean) {
+	for (const webview of webviewRegistry.values()) {
+		webview.style.pointerEvents = passthrough ? "none" : "";
+	}
+}
+
+window.addEventListener("dragstart", () => setWebviewsDragPassthrough(true), true);
+window.addEventListener("dragend", () => setWebviewsDragPassthrough(false), true);
+window.addEventListener("drop", () => setWebviewsDragPassthrough(false), true);
+
 /** Call from useBrowserLifecycle when a pane is removed. */
 export function destroyPersistentWebview(paneId: string): void {
 	const webview = webviewRegistry.get(paneId);


### PR DESCRIPTION
## Summary

Dragging top level tabs into an active browser tab is currently broken. This fixes it.

Broken Demo (before)
![drag-browser-tab-broken](https://github.com/user-attachments/assets/fef77ff0-7e46-4000-9497-b68227ed0e8b)

Fixed Demo (after)
![drag-browser-tab-fixed](https://github.com/user-attachments/assets/36f20d01-f39c-4127-9f65-d5c09d445448)

- Fixes drag-and-drop not working when dropping panes onto browser tabs
- Electron `<webview>` tags create separate compositor layers that capture drag events before they reach react-mosaic drop targets
- Sets `pointer-events: none` directly on the `<webview>` element during any HTML5 drag operation so the compositor stops routing events to the guest process

## How it works

Native `dragstart`/`dragend`/`drop` event listeners (capture phase) toggle `pointer-events` on all registered webview elements. This is done at the module level in `usePersistentWebview` so it covers all drag sources (tab bar drags, mosaic pane drags, etc.).

The webview remains fully visible during drag — only event routing is disabled.

## Test plan

- [ ] Open a browser pane in one tab, terminal in another
- [ ] Drag the terminal tab down onto the browser tab — split should work
- [ ] Drag browser tab onto terminal tab — split should work
- [ ] Verify normal browser interaction (clicking, scrolling, typing) still works after drag completes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pane/tab drag-and-drop onto browser tabs by stopping Electron webviews from capturing drag events so `react-mosaic` drop targets receive them.

- **Bug Fixes**
  - Toggle `pointer-events: none` on all `<webview>` elements during any HTML5 drag (`dragstart`, `dragend`, `drop`) to bypass the guest compositor.
  - Implemented at module scope in `usePersistentWebview` so it covers tab-bar and pane drags; interaction returns to normal after drag ends.

<sup>Written for commit b397f4492acabd27a67fe25a9a9fcfeab4ec4c21. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag-and-drop behavior for webview elements, ensuring proper event handling during drag operations without interference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->