### PR TITLE
feat(desktop): Auto-detect worktree changes without manual import

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/sync.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/sync.ts
@@ -1,0 +1,47 @@
+import { observable } from "@trpc/server/observable";
+import {
+	type WorktreeSyncEvent,
+	worktreeSyncService,
+} from "main/lib/worktree-sync";
+import { z } from "zod";
+import { publicProcedure, router } from "../../..";
+
+/** Create tRPC procedures for worktree sync (manual triggers and real-time subscription). */
+export const createSyncProcedures = () => {
+	return router({
+		/**
+		 * Manually trigger a full sync for a single project.
+		 * Imports new worktrees and removes stale ones.
+		 */
+		syncWorktrees: publicProcedure
+			.input(z.object({ projectId: z.string() }))
+			.mutation(async ({ input }) => {
+				return worktreeSyncService.syncProject(input.projectId);
+			}),
+
+		/**
+		 * Manually trigger a full sync across all active projects.
+		 */
+		syncAllWorktrees: publicProcedure.mutation(async () => {
+			return worktreeSyncService.syncAllActiveProjects();
+		}),
+
+		/**
+		 * Subscription that emits events whenever worktrees are auto-synced
+		 * (new worktrees imported or stale ones removed).
+		 */
+		onWorktreeSync: publicProcedure.subscription(() => {
+			return observable<WorktreeSyncEvent>((emit) => {
+				const handler = (event: WorktreeSyncEvent) => {
+					emit.next(event);
+				};
+
+				worktreeSyncService.on("sync", handler);
+
+				return () => {
+					worktreeSyncService.off("sync", handler);
+				};
+			});
+		}),
+	});
+};

--- a/apps/desktop/src/lib/trpc/routers/workspaces/workspaces.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/workspaces.ts
@@ -7,6 +7,7 @@ import { createInitProcedures } from "./procedures/init";
 import { createQueryProcedures } from "./procedures/query";
 import { createSectionsProcedures } from "./procedures/sections";
 import { createStatusProcedures } from "./procedures/status";
+import { createSyncProcedures } from "./procedures/sync";
 
 export const createWorkspacesRouter = () => {
 	return mergeRouters(
@@ -18,6 +19,7 @@ export const createWorkspacesRouter = () => {
 		createInitProcedures(),
 		createSectionsProcedures(),
 		createGenerateBranchNameProcedures(),
+		createSyncProcedures(),
 	);
 };
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -48,6 +48,7 @@ import {
 	getTerminalHostClient,
 } from "./lib/terminal-host/client";
 import { disposeTray, initTray } from "./lib/tray";
+import { worktreeSyncService } from "./lib/worktree-sync";
 import { MainWindow } from "./windows/main";
 
 console.log("[main] Local database ready:", !!localDb);
@@ -214,6 +215,7 @@ app.on("before-quit", async (event) => {
 
 	isQuitting = true;
 	try {
+		worktreeSyncService.stopAll();
 		if (isDev) {
 			await runDevQuitCleanup();
 		} else {
@@ -405,6 +407,17 @@ if (!gotTheLock) {
 		await makeAppSetup(() => MainWindow());
 		setupAutoUpdater();
 		initTray();
+
+		// Start watching all active projects for external worktree changes
+		worktreeSyncService.startWatchingAllActiveProjects();
+
+		// Re-sync worktrees when the app regains focus (catches changes made while app was in background)
+		app.on("browser-window-focus", () => {
+			worktreeSyncService.syncAllActiveProjects().catch((error) => {
+				console.error("[worktree-sync] Focus sync failed:", error);
+			});
+		});
+
 
 		const coldStartUrl = findDeepLinkInArgv(process.argv);
 		if (coldStartUrl) {

--- a/apps/desktop/src/main/lib/worktree-sync.test.ts
+++ b/apps/desktop/src/main/lib/worktree-sync.test.ts
@@ -1,0 +1,703 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { execSync } from "node:child_process";
+import {
+	existsSync,
+	mkdirSync,
+	realpathSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ── DB mock ──────────────────────────────────────────────────────────────────
+// The sync service queries `projects`, `worktrees`, and `workspaces` tables.
+// We keep in-memory arrays that the test can populate and the mock returns.
+
+let mockWorktrees: Array<{
+	id: string;
+	projectId: string;
+	path: string;
+	branch: string;
+	baseBranch: string;
+	gitStatus: unknown;
+}> = [];
+let mockWorkspaces: Array<{
+	id: string;
+	projectId: string;
+	worktreeId: string;
+	type: string;
+	branch: string;
+	name: string;
+	tabOrder: number;
+}> = [];
+let mockProjects: Array<{
+	id: string;
+	mainRepoPath: string;
+	tabOrder: number | null;
+	defaultBranch: string | null;
+	workspaceBaseBranch: string | null;
+}> = [];
+
+let insertedWorktrees: Array<Record<string, unknown>> = [];
+let insertedWorkspaces: Array<Record<string, unknown>> = [];
+let deletedWorktreeIds: string[] = [];
+let deletedWorkspaceIds: string[] = [];
+
+/** Reset all in-memory mock arrays to their empty state between tests. */
+function resetMockState() {
+	mockWorktrees = [];
+	mockWorkspaces = [];
+	mockProjects = [];
+	insertedWorktrees = [];
+	insertedWorkspaces = [];
+	deletedWorktreeIds = [];
+	deletedWorkspaceIds = [];
+}
+
+// Build a mock Drizzle-like query chain.
+// The sync service uses patterns like:
+//   localDb.select().from(worktrees).where(...).all()
+//   localDb.select({ id: ..., mainRepoPath: ... }).from(projects).where(...).all()
+//   localDb.insert(worktrees).values({...}).returning().get()
+//   localDb.delete(worktrees).where(...).run()
+//
+// NOTE: The mock ignores where() predicates and returns full arrays.
+// Tests scope correctness by setting up mock data per-project.
+// Real query filtering is covered by the Drizzle ORM + SQLite integration.
+
+/** Build a mock Drizzle-like localDb that reads from/writes to the in-memory arrays. */
+function buildMockLocalDb() {
+	// Track which table the current chain targets
+	let currentTable: string | null = null;
+
+	const selectChain = {
+		from: (table: { id?: unknown }) => {
+			// Identify table by checking known marker keys
+			if (table === mockTables.worktrees) currentTable = "worktrees";
+			else if (table === mockTables.workspaces) currentTable = "workspaces";
+			else if (table === mockTables.projects) currentTable = "projects";
+			return {
+				where: () => ({
+					all: () => {
+						if (currentTable === "worktrees") return [...mockWorktrees];
+						if (currentTable === "workspaces") return [...mockWorkspaces];
+						if (currentTable === "projects") return [...mockProjects];
+						return [];
+					},
+					get: () => {
+						if (currentTable === "projects") return mockProjects[0];
+						if (currentTable === "worktrees") return mockWorktrees[0];
+						return undefined;
+					},
+				}),
+				all: () => {
+					if (currentTable === "worktrees") return [...mockWorktrees];
+					if (currentTable === "workspaces") return [...mockWorkspaces];
+					if (currentTable === "projects") return [...mockProjects];
+					return [];
+				},
+			};
+		},
+	};
+
+	return {
+		select: () => selectChain,
+		insert: (table: unknown) => {
+			if (table === mockTables.worktrees) currentTable = "worktrees";
+			else if (table === mockTables.workspaces) currentTable = "workspaces";
+			return {
+				values: (vals: Record<string, unknown>) => ({
+					returning: () => ({
+						get: () => {
+							const record = {
+								id: `mock-${currentTable}-${Date.now()}-${Math.random()}`,
+								...vals,
+							};
+							if (currentTable === "worktrees") insertedWorktrees.push(record);
+							if (currentTable === "workspaces")
+								insertedWorkspaces.push(record);
+							return record;
+						},
+					}),
+					run: () => {
+						const record = {
+							id: `mock-${currentTable}-${Date.now()}-${Math.random()}`,
+							...vals,
+						};
+						if (currentTable === "worktrees") insertedWorktrees.push(record);
+						if (currentTable === "workspaces") insertedWorkspaces.push(record);
+					},
+				}),
+			};
+		},
+		delete: (table: unknown) => {
+			if (table === mockTables.worktrees) currentTable = "worktrees";
+			else if (table === mockTables.workspaces) currentTable = "workspaces";
+			return {
+				where: () => ({
+					run: () => {
+						// We track deletions through the db-helpers mock below
+					},
+				}),
+			};
+		},
+		update: () => ({
+			set: () => ({
+				where: () => ({
+					run: () => {},
+				}),
+			}),
+		}),
+	};
+}
+
+const mockTables = {
+	worktrees: { id: "worktrees.id", projectId: "worktrees.projectId" },
+	workspaces: { id: "workspaces.id", worktreeId: "workspaces.worktreeId" },
+	projects: { id: "projects.id", tabOrder: "projects.tabOrder" },
+};
+
+mock.module("main/lib/local-db", () => ({
+	localDb: buildMockLocalDb(),
+}));
+
+mock.module("@superset/local-db", () => ({
+	projects: mockTables.projects,
+	workspaces: mockTables.workspaces,
+	worktrees: mockTables.worktrees,
+}));
+
+mock.module("drizzle-orm", () => ({
+	eq: () => "eq",
+	and: () => "and",
+	isNotNull: () => "isNotNull",
+	isNull: () => "isNull",
+}));
+
+mock.module("main/lib/analytics", () => ({
+	track: () => {},
+}));
+
+// Mock db-helpers to track deletions
+mock.module("lib/trpc/routers/workspaces/utils/db-helpers", () => ({
+	deleteWorkspace: (id: string) => {
+		deletedWorkspaceIds.push(id);
+	},
+	deleteWorktreeRecord: (id: string) => {
+		deletedWorktreeIds.push(id);
+	},
+	getMaxProjectChildTabOrder: () => 0,
+	activateProject: () => {},
+	hideProjectIfNoWorkspaces: () => {},
+	updateActiveWorkspaceIfRemoved: () => {},
+}));
+
+// base-branch is a pure function — use the real implementation.
+// Do NOT mock it; bun's mock.module is global and would poison
+// other test files (e.g. base-branch.test.ts) in the same run.
+
+mock.module("lib/trpc/routers/workspaces/utils/base-branch-config", () => ({
+	setBranchBaseConfig: async () => {},
+}));
+
+mock.module("lib/trpc/routers/workspaces/utils/setup", () => ({
+	copySupersetConfigToWorktree: () => {},
+}));
+
+// We do NOT mock git.ts — we use real git repos for integration testing
+// (listExternalWorktrees and worktreeExists shell out to `git`)
+
+const { worktreeSyncService } = await import("./worktree-sync");
+type WorktreeSyncEvent = {
+	projectId: string;
+	imported: number;
+	removed: number;
+};
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+const TEST_DIR = join(
+	realpathSync(tmpdir()),
+	`superset-test-worktree-sync-${process.pid}`,
+);
+
+/** Create a real git repository in the temp directory with an initial commit. */
+function createTestRepo(name: string): string {
+	const repoPath = join(TEST_DIR, name);
+	mkdirSync(repoPath, { recursive: true });
+	execSync("git init", { cwd: repoPath, stdio: "ignore" });
+	execSync("git config user.email 'test@test.com'", {
+		cwd: repoPath,
+		stdio: "ignore",
+	});
+	execSync("git config user.name 'Test'", {
+		cwd: repoPath,
+		stdio: "ignore",
+	});
+	// Seed commit so branches can be created
+	writeFileSync(join(repoPath, "README.md"), "# test\n");
+	execSync("git add . && git commit -m 'init'", {
+		cwd: repoPath,
+		stdio: "ignore",
+	});
+	return repoPath;
+}
+
+/** Add a git worktree for the given branch and return its path on disk. */
+function addGitWorktree(mainRepoPath: string, branch: string): string {
+	const worktreePath = join(TEST_DIR, `wt-${branch}`);
+	execSync(`git worktree add "${worktreePath}" -b "${branch}"`, {
+		cwd: mainRepoPath,
+		stdio: "ignore",
+	});
+	return worktreePath;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("WorktreeSyncService", () => {
+	beforeEach(() => {
+		mkdirSync(TEST_DIR, { recursive: true });
+		resetMockState();
+	});
+
+	afterEach(() => {
+		worktreeSyncService.stopAll();
+		if (existsSync(TEST_DIR)) {
+			rmSync(TEST_DIR, { recursive: true, force: true });
+		}
+	});
+
+	describe("syncProject — import new worktrees", () => {
+		test("imports an externally created worktree", async () => {
+			const repoPath = createTestRepo("import-test");
+			const wtPath = addGitWorktree(repoPath, "feature-external");
+
+			// DB has no worktrees tracked yet
+			mockProjects = [
+				{
+					id: "proj-1",
+					mainRepoPath: repoPath,
+					tabOrder: 0,
+					defaultBranch: "main",
+					workspaceBaseBranch: null,
+				},
+			];
+			mockWorktrees = [];
+			mockWorkspaces = [];
+
+			const result = await worktreeSyncService.syncProject("proj-1", repoPath);
+
+			expect(result.imported).toBe(1);
+			expect(result.removed).toBe(0);
+			expect(insertedWorktrees.length).toBe(1);
+			expect(insertedWorktrees[0].branch).toBe("feature-external");
+			expect(insertedWorktrees[0].path).toBe(wtPath);
+			expect(insertedWorkspaces.length).toBe(1);
+			expect(insertedWorkspaces[0].branch).toBe("feature-external");
+		});
+
+		test("marks imported worktrees as createdBySuperset: false", async () => {
+			const repoPath = createTestRepo("created-by-flag");
+			addGitWorktree(repoPath, "external-branch");
+
+			mockProjects = [
+				{
+					id: "proj-1",
+					mainRepoPath: repoPath,
+					tabOrder: 0,
+					defaultBranch: "main",
+					workspaceBaseBranch: null,
+				},
+			];
+			mockWorktrees = [];
+			mockWorkspaces = [];
+
+			await worktreeSyncService.syncProject("proj-1", repoPath);
+
+			expect(insertedWorktrees.length).toBe(1);
+			expect(insertedWorktrees[0].createdBySuperset).toBe(false);
+		});
+
+		test("imports multiple externally created worktrees", async () => {
+			const repoPath = createTestRepo("multi-import");
+			addGitWorktree(repoPath, "feat-a");
+			addGitWorktree(repoPath, "feat-b");
+			addGitWorktree(repoPath, "feat-c");
+
+			mockProjects = [
+				{
+					id: "proj-1",
+					mainRepoPath: repoPath,
+					tabOrder: 0,
+					defaultBranch: "main",
+					workspaceBaseBranch: null,
+				},
+			];
+			mockWorktrees = [];
+			mockWorkspaces = [];
+
+			const result = await worktreeSyncService.syncProject("proj-1", repoPath);
+
+			expect(result.imported).toBe(3);
+			expect(insertedWorktrees.length).toBe(3);
+			const branches = insertedWorktrees.map((wt) => wt.branch).sort();
+			expect(branches).toEqual(["feat-a", "feat-b", "feat-c"]);
+		});
+
+		test("does not import worktrees already tracked in DB", async () => {
+			const repoPath = createTestRepo("already-tracked");
+			const wtPath = addGitWorktree(repoPath, "existing-branch");
+
+			mockProjects = [
+				{
+					id: "proj-1",
+					mainRepoPath: repoPath,
+					tabOrder: 0,
+					defaultBranch: "main",
+					workspaceBaseBranch: null,
+				},
+			];
+			mockWorktrees = [
+				{
+					id: "wt-1",
+					projectId: "proj-1",
+					path: wtPath,
+					branch: "existing-branch",
+					baseBranch: "main",
+					gitStatus: null,
+				},
+			];
+			mockWorkspaces = [];
+
+			const result = await worktreeSyncService.syncProject("proj-1", repoPath);
+
+			expect(result.imported).toBe(0);
+			expect(insertedWorktrees.length).toBe(0);
+		});
+	});
+
+	describe("syncProject — remove stale worktrees", () => {
+		test("removes a worktree that no longer exists on disk", async () => {
+			const repoPath = createTestRepo("remove-stale");
+
+			mockProjects = [
+				{
+					id: "proj-1",
+					mainRepoPath: repoPath,
+					tabOrder: 0,
+					defaultBranch: "main",
+					workspaceBaseBranch: null,
+				},
+			];
+			// DB says we have a worktree at a path that doesn't exist
+			mockWorktrees = [
+				{
+					id: "wt-stale",
+					projectId: "proj-1",
+					path: join(TEST_DIR, "wt-does-not-exist"),
+					branch: "deleted-branch",
+					baseBranch: "main",
+					gitStatus: null,
+				},
+			];
+			mockWorkspaces = [
+				{
+					id: "ws-stale",
+					projectId: "proj-1",
+					worktreeId: "wt-stale",
+					type: "worktree",
+					branch: "deleted-branch",
+					name: "deleted-branch",
+					tabOrder: 1,
+				},
+			];
+
+			const result = await worktreeSyncService.syncProject("proj-1", repoPath);
+
+			expect(result.removed).toBe(1);
+			expect(deletedWorktreeIds).toContain("wt-stale");
+			expect(deletedWorkspaceIds).toContain("ws-stale");
+		});
+
+		test("does not remove worktrees that still exist on disk", async () => {
+			const repoPath = createTestRepo("keep-existing");
+			const wtPath = addGitWorktree(repoPath, "still-here");
+
+			mockProjects = [
+				{
+					id: "proj-1",
+					mainRepoPath: repoPath,
+					tabOrder: 0,
+					defaultBranch: "main",
+					workspaceBaseBranch: null,
+				},
+			];
+			mockWorktrees = [
+				{
+					id: "wt-exists",
+					projectId: "proj-1",
+					path: wtPath,
+					branch: "still-here",
+					baseBranch: "main",
+					gitStatus: null,
+				},
+			];
+			mockWorkspaces = [];
+
+			const result = await worktreeSyncService.syncProject("proj-1", repoPath);
+
+			expect(result.removed).toBe(0);
+			expect(deletedWorktreeIds).toHaveLength(0);
+		});
+	});
+
+	describe("syncProject — combined import + remove", () => {
+		test("imports new and removes stale in the same sync", async () => {
+			const repoPath = createTestRepo("combined");
+			addGitWorktree(repoPath, "new-feature");
+
+			mockProjects = [
+				{
+					id: "proj-1",
+					mainRepoPath: repoPath,
+					tabOrder: 0,
+					defaultBranch: "main",
+					workspaceBaseBranch: null,
+				},
+			];
+			mockWorktrees = [
+				{
+					id: "wt-stale",
+					projectId: "proj-1",
+					path: join(TEST_DIR, "wt-gone"),
+					branch: "old-feature",
+					baseBranch: "main",
+					gitStatus: null,
+				},
+			];
+			mockWorkspaces = [];
+
+			const result = await worktreeSyncService.syncProject("proj-1", repoPath);
+
+			expect(result.imported).toBe(1);
+			expect(result.removed).toBe(1);
+			expect(insertedWorktrees[0].branch).toBe("new-feature");
+			expect(deletedWorktreeIds).toContain("wt-stale");
+		});
+	});
+
+	describe("syncProject — no-op cases", () => {
+		test("returns zeros when everything is in sync", async () => {
+			const repoPath = createTestRepo("in-sync");
+			const wtPath = addGitWorktree(repoPath, "synced-branch");
+
+			mockProjects = [
+				{
+					id: "proj-1",
+					mainRepoPath: repoPath,
+					tabOrder: 0,
+					defaultBranch: "main",
+					workspaceBaseBranch: null,
+				},
+			];
+			mockWorktrees = [
+				{
+					id: "wt-synced",
+					projectId: "proj-1",
+					path: wtPath,
+					branch: "synced-branch",
+					baseBranch: "main",
+					gitStatus: null,
+				},
+			];
+			mockWorkspaces = [];
+
+			const result = await worktreeSyncService.syncProject("proj-1", repoPath);
+
+			expect(result.imported).toBe(0);
+			expect(result.removed).toBe(0);
+		});
+
+		test("returns zeros for a repo with no worktrees", async () => {
+			const repoPath = createTestRepo("no-worktrees");
+
+			mockProjects = [
+				{
+					id: "proj-1",
+					mainRepoPath: repoPath,
+					tabOrder: 0,
+					defaultBranch: "main",
+					workspaceBaseBranch: null,
+				},
+			];
+			mockWorktrees = [];
+			mockWorkspaces = [];
+
+			const result = await worktreeSyncService.syncProject("proj-1", repoPath);
+
+			expect(result.imported).toBe(0);
+			expect(result.removed).toBe(0);
+		});
+	});
+
+	describe("syncProject — emits sync event", () => {
+		test("emits sync event when changes occur", async () => {
+			const repoPath = createTestRepo("emit-test");
+			addGitWorktree(repoPath, "event-branch");
+
+			mockProjects = [
+				{
+					id: "proj-1",
+					mainRepoPath: repoPath,
+					tabOrder: 0,
+					defaultBranch: "main",
+					workspaceBaseBranch: null,
+				},
+			];
+			mockWorktrees = [];
+			mockWorkspaces = [];
+
+			const events: Array<{
+				projectId: string;
+				imported: number;
+				removed: number;
+			}> = [];
+			worktreeSyncService.on("sync", (e) => events.push(e));
+
+			await worktreeSyncService.syncProject("proj-1", repoPath);
+
+			expect(events).toHaveLength(1);
+			expect(events[0].projectId).toBe("proj-1");
+			expect(events[0].imported).toBe(1);
+
+			worktreeSyncService.removeAllListeners("sync");
+		});
+
+		test("does not emit sync event when no changes", async () => {
+			const repoPath = createTestRepo("no-emit-test");
+
+			mockProjects = [
+				{
+					id: "proj-1",
+					mainRepoPath: repoPath,
+					tabOrder: 0,
+					defaultBranch: "main",
+					workspaceBaseBranch: null,
+				},
+			];
+			mockWorktrees = [];
+			mockWorkspaces = [];
+
+			const events: unknown[] = [];
+			worktreeSyncService.on("sync", (e) => events.push(e));
+
+			await worktreeSyncService.syncProject("proj-1", repoPath);
+
+			expect(events).toHaveLength(0);
+
+			worktreeSyncService.removeAllListeners("sync");
+		});
+	});
+
+	describe("watcher lifecycle", () => {
+		test("startWatching / stopWatching does not throw", () => {
+			const repoPath = createTestRepo("watcher-lifecycle");
+			// Create a worktree so .git/worktrees/ directory exists
+			addGitWorktree(repoPath, "watcher-test");
+
+			expect(() =>
+				worktreeSyncService.startWatching("proj-wl", repoPath),
+			).not.toThrow();
+
+			expect(() => worktreeSyncService.stopWatching("proj-wl")).not.toThrow();
+		});
+
+		test("startWatching is idempotent", () => {
+			const repoPath = createTestRepo("watcher-idempotent");
+			addGitWorktree(repoPath, "idem-test");
+
+			worktreeSyncService.startWatching("proj-idem", repoPath);
+			// Second call should be a no-op
+			expect(() =>
+				worktreeSyncService.startWatching("proj-idem", repoPath),
+			).not.toThrow();
+
+			worktreeSyncService.stopWatching("proj-idem");
+		});
+
+		test("stopAll cleans up all watchers", () => {
+			const repo1 = createTestRepo("watcher-all-1");
+			const repo2 = createTestRepo("watcher-all-2");
+			addGitWorktree(repo1, "all-test-1");
+			addGitWorktree(repo2, "all-test-2");
+
+			worktreeSyncService.startWatching("proj-all-1", repo1);
+			worktreeSyncService.startWatching("proj-all-2", repo2);
+
+			expect(() => worktreeSyncService.stopAll()).not.toThrow();
+		});
+
+		test("watches .git parent when .git/worktrees does not exist", () => {
+			const repoPath = createTestRepo("no-wt-dir");
+			// No worktrees created, so .git/worktrees/ doesn't exist yet
+
+			expect(() =>
+				worktreeSyncService.startWatching("proj-no-wt", repoPath),
+			).not.toThrow();
+
+			worktreeSyncService.stopWatching("proj-no-wt");
+		});
+	});
+
+	describe("concurrent sync protection", () => {
+		test("second concurrent call returns zeros and queued re-sync executes", async () => {
+			const repoPath = createTestRepo("concurrent");
+			addGitWorktree(repoPath, "concurrent-branch");
+
+			mockProjects = [
+				{
+					id: "proj-1",
+					mainRepoPath: repoPath,
+					tabOrder: 0,
+					defaultBranch: "main",
+					workspaceBaseBranch: null,
+				},
+			];
+			mockWorktrees = [];
+			mockWorkspaces = [];
+
+			// Spy on doSync to count actual sync executions (not just return values)
+			let doSyncCallCount = 0;
+			const originalDoSync = (worktreeSyncService as any).doSync;
+			(worktreeSyncService as any).doSync = async function (
+				...args: unknown[]
+			) {
+				doSyncCallCount++;
+				return originalDoSync.apply(this, args);
+			};
+
+			// Fire two syncs simultaneously — the second should be queued, not run concurrently
+			const [r1, r2] = await Promise.all([
+				worktreeSyncService.syncProject("proj-1", repoPath),
+				worktreeSyncService.syncProject("proj-1", repoPath),
+			]);
+
+			// The second call should have returned zeros immediately (queued a re-sync)
+			expect(r2.imported).toBe(0);
+			expect(r2.removed).toBe(0);
+
+			// The first call should have done the actual import
+			expect(r1.imported).toBe(1);
+			expect(r1.projectId).toBe("proj-1");
+
+			// doSync must have been called exactly twice: once for the first sync,
+			// once for the queued re-sync drain. This is the only reliable way to
+			// verify the drain ran — the re-sync finds nothing new so it emits no event.
+			expect(doSyncCallCount).toBe(2);
+
+			(worktreeSyncService as any).doSync = originalDoSync;
+		});
+	});
+});

--- a/apps/desktop/src/main/lib/worktree-sync.ts
+++ b/apps/desktop/src/main/lib/worktree-sync.ts
@@ -1,0 +1,444 @@
+import { EventEmitter } from "node:events";
+import { existsSync, type FSWatcher, watch } from "node:fs";
+import path from "node:path";
+import { projects, workspaces, worktrees } from "@superset/local-db";
+import { eq, isNotNull } from "drizzle-orm";
+import { resolveWorkspaceBaseBranch } from "lib/trpc/routers/workspaces/utils/base-branch";
+import { setBranchBaseConfig } from "lib/trpc/routers/workspaces/utils/base-branch-config";
+import {
+	activateProject,
+	deleteWorkspace,
+	deleteWorktreeRecord,
+	getMaxProjectChildTabOrder,
+	hideProjectIfNoWorkspaces,
+	updateActiveWorkspaceIfRemoved,
+} from "lib/trpc/routers/workspaces/utils/db-helpers";
+import {
+	listExternalWorktrees,
+	worktreeExists,
+} from "lib/trpc/routers/workspaces/utils/git";
+import { copySupersetConfigToWorktree } from "lib/trpc/routers/workspaces/utils/setup";
+import { track } from "./analytics";
+import { localDb } from "./local-db";
+
+export interface WorktreeSyncEvent {
+	projectId: string;
+	imported: number;
+	removed: number;
+}
+
+/**
+ * Watches `.git/worktrees/` directories for each registered project
+ * and auto-syncs worktree state (imports new, removes stale) on changes.
+ */
+class WorktreeSyncService extends EventEmitter {
+	private watchers = new Map<string, FSWatcher>();
+	private debounceTimers = new Map<string, NodeJS.Timeout>();
+	private syncInProgress = new Set<string>();
+	private pendingResync = new Map<string, string | undefined>();
+
+	private static readonly DEBOUNCE_MS = 1500;
+
+	/**
+	 * Start watching the `.git/worktrees/` directory for a project.
+	 */
+	startWatching(projectId: string, mainRepoPath: string): void {
+		if (this.watchers.has(projectId)) {
+			return;
+		}
+
+		const gitWorktreesDir = path.join(mainRepoPath, ".git", "worktrees");
+
+		if (!existsSync(gitWorktreesDir)) {
+			// No worktrees directory yet — it will be created when the first worktree is added.
+			// We also watch the .git dir itself so we can detect when .git/worktrees/ appears.
+			this.watchParentForWorktreesDir(projectId, mainRepoPath);
+			return;
+		}
+
+		this.attachWatcher(projectId, mainRepoPath, gitWorktreesDir);
+	}
+
+	/**
+	 * Watch the .git directory for creation of the worktrees/ subdirectory.
+	 */
+	private watchParentForWorktreesDir(
+		projectId: string,
+		mainRepoPath: string,
+	): void {
+		const gitDir = path.join(mainRepoPath, ".git");
+		if (!existsSync(gitDir)) return;
+
+		try {
+			const worktreesDir = path.join(gitDir, "worktrees");
+			const watcher = watch(gitDir, (_eventType, filename) => {
+				// filename can be null or unreliable on some platforms — always verify on disk
+				if (
+					(filename === "worktrees" || filename === null) &&
+					existsSync(worktreesDir)
+				) {
+					// The worktrees directory just appeared — switch to watching it directly
+					watcher.close();
+					this.watchers.delete(projectId);
+					this.startWatching(projectId, mainRepoPath);
+					// Sync now to catch worktrees created during the handoff gap
+					this.debouncedSync(projectId, mainRepoPath);
+				}
+			});
+
+			watcher.on("error", (error) => {
+				console.warn(
+					`[worktree-sync] .git watcher error for project ${projectId}:`,
+					error,
+				);
+				watcher.close();
+				this.watchers.delete(projectId);
+			});
+
+			this.watchers.set(projectId, watcher);
+		} catch (error) {
+			console.warn(
+				`[worktree-sync] Failed to watch .git for project ${projectId}:`,
+				error,
+			);
+		}
+	}
+
+	/**
+	 * Attach a filesystem watcher to the `.git/worktrees/` directory and trigger
+	 * a debounced sync whenever its contents change.
+	 */
+	private attachWatcher(
+		projectId: string,
+		mainRepoPath: string,
+		gitWorktreesDir: string,
+	): void {
+		try {
+			const watcher = watch(gitWorktreesDir, { recursive: false }, () => {
+				this.debouncedSync(projectId, mainRepoPath);
+			});
+
+			watcher.on("error", (error) => {
+				console.warn(
+					`[worktree-sync] Watcher error for project ${projectId}:`,
+					error,
+				);
+				watcher.close();
+				this.watchers.delete(projectId);
+			});
+
+			this.watchers.set(projectId, watcher);
+			console.log(
+				`[worktree-sync] Watching ${gitWorktreesDir} for project ${projectId}`,
+			);
+		} catch (error) {
+			console.warn(
+				`[worktree-sync] Failed to watch ${gitWorktreesDir}:`,
+				error,
+			);
+		}
+	}
+
+	/**
+	 * Stop watching a specific project.
+	 */
+	stopWatching(projectId: string): void {
+		const timer = this.debounceTimers.get(projectId);
+		if (timer) {
+			clearTimeout(timer);
+			this.debounceTimers.delete(projectId);
+		}
+
+		this.pendingResync.delete(projectId);
+
+		const watcher = this.watchers.get(projectId);
+		if (watcher) {
+			watcher.close();
+			this.watchers.delete(projectId);
+		}
+	}
+
+	/**
+	 * Stop all watchers.
+	 */
+	stopAll(): void {
+		for (const projectId of this.watchers.keys()) {
+			this.stopWatching(projectId);
+		}
+	}
+
+	/**
+	 * Start watching all active projects (projects with a non-null tabOrder).
+	 */
+	startWatchingAllActiveProjects(): void {
+		const activeProjects = localDb
+			.select({ id: projects.id, mainRepoPath: projects.mainRepoPath })
+			.from(projects)
+			.where(isNotNull(projects.tabOrder))
+			.all();
+
+		for (const project of activeProjects) {
+			this.startWatching(project.id, project.mainRepoPath);
+		}
+
+		if (activeProjects.length > 0) {
+			console.log(
+				`[worktree-sync] Started watching ${activeProjects.length} active project(s)`,
+			);
+		}
+	}
+
+	/**
+	 * Debounce sync to avoid rapid-fire during batch worktree operations.
+	 */
+	private debouncedSync(projectId: string, mainRepoPath: string): void {
+		const existing = this.debounceTimers.get(projectId);
+		if (existing) {
+			clearTimeout(existing);
+		}
+
+		const timer = setTimeout(() => {
+			this.debounceTimers.delete(projectId);
+			this.syncProject(projectId, mainRepoPath).catch((error) => {
+				console.error(
+					`[worktree-sync] Sync failed for project ${projectId}:`,
+					error,
+				);
+			});
+		}, WorktreeSyncService.DEBOUNCE_MS);
+
+		this.debounceTimers.set(projectId, timer);
+	}
+
+	/**
+	 * Sync worktrees for a single project: import new, remove stale.
+	 */
+	async syncProject(
+		projectId: string,
+		mainRepoPath?: string,
+	): Promise<WorktreeSyncEvent> {
+		if (this.syncInProgress.has(projectId)) {
+			// Queue a re-sync so filesystem changes during an active sync aren't lost
+			this.pendingResync.set(projectId, mainRepoPath);
+			return { projectId, imported: 0, removed: 0 };
+		}
+
+		this.syncInProgress.add(projectId);
+
+		let result: WorktreeSyncEvent = { projectId, imported: 0, removed: 0 };
+		let syncError: unknown;
+		try {
+			result = await this.doSync(projectId, mainRepoPath);
+		} catch (error) {
+			syncError = error;
+		} finally {
+			this.syncInProgress.delete(projectId);
+		}
+
+		// Drain queued re-sync even after failure so filesystem changes aren't lost
+		if (this.pendingResync.has(projectId)) {
+			const pendingPath = this.pendingResync.get(projectId);
+			this.pendingResync.delete(projectId);
+			await this.syncProject(projectId, pendingPath);
+		}
+
+		if (syncError !== undefined) {
+			throw syncError;
+		}
+		return result;
+	}
+
+	/**
+	 * Core sync logic: compares on-disk worktrees against the local DB,
+	 * removes stale entries and imports newly discovered worktrees.
+	 */
+	private async doSync(
+		projectId: string,
+		mainRepoPath?: string,
+	): Promise<WorktreeSyncEvent> {
+		const project = mainRepoPath
+			? { id: projectId, mainRepoPath }
+			: localDb.select().from(projects).where(eq(projects.id, projectId)).get();
+
+		if (!project) {
+			return { projectId, imported: 0, removed: 0 };
+		}
+
+		const fullProject = localDb
+			.select()
+			.from(projects)
+			.where(eq(projects.id, projectId))
+			.get();
+
+		if (!fullProject) {
+			return { projectId, imported: 0, removed: 0 };
+		}
+
+		let imported = 0;
+		let removed = 0;
+
+		// --- Phase 1: Remove stale worktrees (in DB but no longer on disk) ---
+		const dbWorktrees = localDb
+			.select()
+			.from(worktrees)
+			.where(eq(worktrees.projectId, projectId))
+			.all();
+
+		for (const wt of dbWorktrees) {
+			const exists = await worktreeExists(fullProject.mainRepoPath, wt.path);
+			if (!exists) {
+				// Remove associated workspace(s) first
+				const associatedWorkspaces = localDb
+					.select()
+					.from(workspaces)
+					.where(eq(workspaces.worktreeId, wt.id))
+					.all();
+
+				for (const ws of associatedWorkspaces) {
+					updateActiveWorkspaceIfRemoved(ws.id);
+					deleteWorkspace(ws.id);
+				}
+
+				deleteWorktreeRecord(wt.id);
+				removed++;
+			}
+		}
+
+		// --- Phase 2: Import new worktrees (on disk but not in DB) ---
+		const allExternalWorktrees = await listExternalWorktrees(
+			fullProject.mainRepoPath,
+		);
+
+		// Re-query tracked paths after removals
+		const currentTracked = localDb
+			.select({ path: worktrees.path })
+			.from(worktrees)
+			.where(eq(worktrees.projectId, projectId))
+			.all();
+		const trackedPaths = new Set(currentTracked.map((wt) => wt.path));
+
+		const newWorktrees = allExternalWorktrees.filter((wt) => {
+			if (wt.path === fullProject.mainRepoPath) return false;
+			if (wt.isBare) return false;
+			if (wt.isDetached) return false;
+			if (!wt.branch) return false;
+			if (trackedPaths.has(wt.path)) return false;
+			return true;
+		});
+
+		if (newWorktrees.length > 0) {
+			const baseBranch = resolveWorkspaceBaseBranch({
+				workspaceBaseBranch: fullProject.workspaceBaseBranch,
+				defaultBranch: fullProject.defaultBranch,
+			});
+
+			for (const ext of newWorktrees) {
+				// biome-ignore lint/style/noNonNullAssertion: filtered above
+				const branch = ext.branch!;
+
+				const worktree = localDb
+					.insert(worktrees)
+					.values({
+						projectId,
+						path: ext.path,
+						branch,
+						baseBranch,
+						gitStatus: {
+							branch,
+							needsRebase: false,
+							ahead: 0,
+							behind: 0,
+							lastRefreshed: Date.now(),
+						},
+						createdBySuperset: false, // External worktree — never delete from disk
+					})
+					.returning()
+					.get();
+
+				const maxTabOrder = getMaxProjectChildTabOrder(projectId);
+				localDb
+					.insert(workspaces)
+					.values({
+						projectId,
+						worktreeId: worktree.id,
+						type: "worktree",
+						branch,
+						name: branch,
+						isUnnamed: false,
+						tabOrder: maxTabOrder + 1,
+					})
+					.run();
+
+				imported++;
+
+				// Best-effort post-import config — DB rows are already committed above
+				try {
+					await setBranchBaseConfig({
+						repoPath: fullProject.mainRepoPath,
+						branch,
+						baseBranch,
+						isExplicit: false,
+					});
+					copySupersetConfigToWorktree(fullProject.mainRepoPath, ext.path);
+				} catch (error) {
+					console.warn(
+						`[worktree-sync] Post-import config failed for ${branch}:`,
+						error,
+					);
+				}
+			}
+		}
+
+		// --- Phase 3: Re-open closed worktrees (in DB, no active workspace, still on disk) ---
+		// Skipped — closed worktrees are intentional state. The user can re-open them.
+
+		if (imported > 0 || removed > 0) {
+			if (imported > 0) {
+				activateProject(fullProject);
+			}
+			hideProjectIfNoWorkspaces(projectId);
+
+			const event: WorktreeSyncEvent = { projectId, imported, removed };
+			this.emit("sync", event);
+
+			track("worktrees_auto_synced", {
+				project_id: projectId,
+				imported,
+				removed,
+			});
+
+			console.log(
+				`[worktree-sync] Project ${projectId}: imported=${imported}, removed=${removed}`,
+			);
+		}
+
+		return { projectId, imported, removed };
+	}
+
+	/**
+	 * Sync all active projects and ensure watchers are running for each.
+	 */
+	async syncAllActiveProjects(): Promise<WorktreeSyncEvent[]> {
+		const activeProjects = localDb
+			.select({ id: projects.id, mainRepoPath: projects.mainRepoPath })
+			.from(projects)
+			.where(isNotNull(projects.tabOrder))
+			.all();
+
+		const results: WorktreeSyncEvent[] = [];
+		for (const project of activeProjects) {
+			// Ensure watcher is running (no-op if already watching)
+			this.startWatching(project.id, project.mainRepoPath);
+
+			const result = await this.syncProject(project.id, project.mainRepoPath);
+			if (result.imported > 0 || result.removed > 0) {
+				results.push(result);
+			}
+		}
+
+		return results;
+	}
+}
+
+/** Singleton worktree sync service instance */
+export const worktreeSyncService = new WorktreeSyncService();

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -145,6 +145,17 @@ function AuthenticatedLayout() {
 		},
 	});
 
+	// Worktree auto-sync subscription — invalidate queries when worktrees are
+	// created or destroyed outside of Superset (e.g. via CLI scripts)
+	electronTrpc.workspaces.onWorktreeSync.useSubscription(undefined, {
+		onData: (event) => {
+			if (event.imported > 0 || event.removed > 0) {
+				utils.workspaces.invalidate();
+				utils.projects.getRecents.invalidate();
+			}
+		},
+	});
+
 	// Menu navigation subscription
 	electronTrpc.menu.subscribe.useSubscription(undefined, {
 		onData: (event) => {


### PR DESCRIPTION
## What

Adds a `WorktreeSyncService` that watches `.git/worktrees/` directories for each active project and automatically imports new worktrees and removes stale ones from the sidebar. No manual refresh or import needed.

## Why

Closes #2662. Users who manage worktrees via external CLI scripts (e.g. across multiple repos for fullstack development) currently need ~10 clicks per worktree lifecycle to keep Superset in sync. This eliminates that friction entirely.

## How it works

- **File watcher**: Watches `.git/worktrees/` for each active project using `fs.watch`. Falls back to watching `.git/` if the worktrees directory doesn't exist yet.
- **Debounced sync**: On filesystem changes, waits 1.5s then runs a two-phase sync: (1) remove DB records for worktrees no longer on disk, (2) import new worktrees found on disk.
- **Focus sync**: Also syncs all active projects when the app window regains focus, catching any changes made while Superset was in the background.
- **Safety**: All auto-imported worktrees are marked `createdBySuperset: false` so deleting them from the UI only removes the DB record, never the worktree on disk.
- **tRPC subscription**: `onWorktreeSync` pushes events to the renderer, which invalidates workspace queries to update the sidebar.

## How to Test

1. Run the desktop app in dev mode: `cd apps/desktop && SKIP_ENV_VALIDATION=1 bun dev`
2. Open a project that has a registered main repo
3. In a separate terminal, create an external worktree:
   ```bash
   cd /path/to/your/project
   git worktree add /tmp/test-auto-sync -b test-auto-sync
   ```
4. The sidebar should update within ~2 seconds showing the new workspace
5. Remove the worktree:
   ```bash
   git worktree remove /tmp/test-auto-sync
   ```
6. The workspace should disappear from the sidebar within ~2 seconds
7. Test focus sync: minimize Superset, create/remove a worktree, then click back into Superset
8. Verify deleting an auto-imported workspace from the UI does NOT delete it from disk

Run tests: `cd apps/desktop && bun test src/main/lib/worktree-sync.test.ts` (16 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic worktree synchronization: detects external Git worktree adds/removals, updates app state, emits sync events, and refreshes workspace/project lists on startup and when app gains focus.
  * Real-time subscription/API to push worktree sync events to the UI.

* **Tests**
  * Integration tests covering import/remove flows, watcher lifecycle, event emission, and concurrent sync handling.

* **Chores**
  * Ensures sync watchers stop cleanly on app shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->