### PR TITLE
fix(desktop): persist browser tabs with overlay-owned surfaces

### DIFF
--- a/apps/desktop/docs/PERSISTENT_BROWSER_OVERLAY_REFACTOR.md
+++ b/apps/desktop/docs/PERSISTENT_BROWSER_OVERLAY_REFACTOR.md
@@ -1,0 +1,101 @@
+# Persistent Browser Overlay Refactor
+
+This document describes the cleaner architecture for persistent browser tabs in Desktop and the refactor that follows from it.
+
+## Problem
+
+We want browser panes to preserve page state across:
+
+- tab switches
+- workspace switches
+- layout changes inside the workspace view
+
+The first persistence implementation solved the Electron reload problem by moving `<webview>` nodes into a dashboard-level overlay and positioning them over transparent pane slots. That part was directionally right, but the ownership model stayed split across too many places:
+
+- `WebviewOverlay` owned the global container
+- `webview-overlay.ts` owned imperative DOM wrappers and positioning
+- `BrowserPane` still owned blank/error browser chrome and portaled it back into the overlay
+- `TabsContent` had to force periodic resyncs because visibility changes were not naturally part of the overlay lifecycle
+
+That left us with an architecture that worked, but still felt like two UIs glued together.
+
+## Design Goals
+
+- Keep each browser pane backed by one stable Electron `<webview>` node for the life of that pane.
+- Never reparent that `<webview>` during tab/workspace switching.
+- Make the overlay the real owner of browser rendering, not just a parking lot for DOM nodes.
+- Keep pane-level browser controls in `BrowserPane`, but move page rendering and page chrome into the overlay surface.
+- Replace polling-based position correction with event-driven updates.
+
+## Target Architecture
+
+### 1. React-owned overlay surfaces
+
+`WebviewOverlay` renders one `PersistentBrowserSurface` per browser pane currently in the tabs store.
+
+Each surface owns:
+
+- the positioned wrapper
+- the DOM host for the persistent `<webview>`
+- the blank state
+- the error overlay
+- visibility and geometry sync to its registered pane slot
+
+This means the browser page and its chrome live in one React subtree.
+
+### 2. Small imperative core for the actual webview node
+
+`renderer/stores/webview-overlay.ts` becomes a thin module-level registry for persistent Electron webviews:
+
+- create/get persistent webview by `paneId`
+- attach the existing webview node to a stable host element owned by the surface
+- register/unregister the current pane slot element
+- destroy the webview when the pane is removed
+- expose imperative browser actions (`navigate`, `reload`, history navigation)
+
+The registry still matters because Electron webview DOM nodes are stateful and need stable identity outside normal React reconciliation.
+
+### 3. BrowserPane becomes a slot + toolbar
+
+`BrowserPane` is reduced to:
+
+- browser toolbar
+- devtools/open/split actions
+- a transparent slot element registered with the overlay
+
+It no longer owns blank/error page chrome and no longer portals UI into the overlay.
+
+### 4. Event-driven layout sync
+
+Each `PersistentBrowserSurface` computes its placement from the registered slot and updates when:
+
+- the slot is registered or unregistered
+- the slot element resizes
+- the window resizes
+- tab/workspace activation changes cause visibility changes in the pane tree
+
+The important shift is that layout sync is now driven by concrete events instead of a `setInterval` fallback loop.
+
+## Invariants
+
+- One browser pane maps to one persistent webview node.
+- Browser state is destroyed only when the pane is removed from the tabs store.
+- Hidden tabs keep their browser surfaces mounted but not visible.
+- Browser chrome is rendered in the same overlay surface as the webview it belongs to.
+- Main-process browser registration still keys off the same `paneId`.
+
+## Migration Plan
+
+1. Keep the existing tabs-store-driven pane lifecycle.
+2. Introduce `PersistentBrowserSurface` under `WebviewOverlay`.
+3. Simplify the registry so it owns only persistent webview identity, not React chrome.
+4. Move blank/error rendering out of `BrowserPane` and into the overlay surface.
+5. Replace periodic `syncAllPositions()` polling with surface-level observers plus explicit activation signals.
+6. Leave browser toolbar actions and tRPC subscriptions in `BrowserPane`/`usePersistentWebview`, since those are still pane-local concerns.
+
+## Expected Benefits
+
+- Clearer ownership: overlay surfaces render the page and its chrome, pane components render the workspace UI around it.
+- Fewer cross-layer hacks: no portal from `BrowserPane` back into the overlay.
+- Better behavior under tab switches: visibility changes become part of the surface lifecycle instead of something corrected later by polling.
+- Easier follow-up work: blank states, loading states, devtools affordances, or per-browser overlays can all evolve inside the browser surface component.

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/WebviewOverlay/WebviewOverlay.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/WebviewOverlay/WebviewOverlay.tsx
@@ -1,87 +1,36 @@
-import { useEffect, useRef } from "react";
+import { useMemo } from "react";
 import { useTabsStore } from "renderer/stores/tabs/store";
-import {
-	getOrCreateWebview,
-	setOverlayContainer,
-	syncAllPositions,
-} from "renderer/stores/webview-overlay";
+import { PersistentBrowserSurface } from "./components/PersistentBrowserSurface";
 
 /**
- * Persistent overlay container for all browser webviews.
+ * Persistent overlay for all browser webviews.
  *
- * Mounted at the dashboard layout level so it survives workspace/tab route
- * changes. Webview DOM elements are never reparented — only shown/hidden and
- * repositioned — which prevents Electron from reloading them.
+ * Mounted at the dashboard layout level so browser surfaces survive
+ * workspace/tab route changes. Each browser pane gets one stable overlay-owned
+ * surface that positions a persistent Electron webview over its registered slot.
  */
 export function WebviewOverlay() {
-	const overlayRef = useRef<HTMLDivElement>(null);
-
-	// Register the overlay container with the module-level manager
-	useEffect(() => {
-		setOverlayContainer(overlayRef.current);
-		return () => setOverlayContainer(null);
-	}, []);
-
-	// Create webviews as panes appear in the store.
-	// Destruction is handled by useBrowserLifecycle.
-	useEffect(() => {
-		// Initialize from current state
-		const state = useTabsStore.getState();
-		for (const [id, pane] of Object.entries(state.panes)) {
-			if (pane.type === "webview") {
-				getOrCreateWebview(id, pane.browser?.currentUrl ?? "about:blank");
-			}
-		}
-
-		return useTabsStore.subscribe((state) => {
-			for (const [id, pane] of Object.entries(state.panes)) {
-				if (pane.type === "webview") {
-					getOrCreateWebview(id, pane.browser?.currentUrl ?? "about:blank");
-				}
-			}
-		});
-	}, []);
-
-	// Sync webview positions to slot rects on resize / layout changes
-	useEffect(() => {
-		let rafId: number | null = null;
-
-		const scheduleSync = () => {
-			if (rafId !== null) return;
-			rafId = requestAnimationFrame(() => {
-				syncAllPositions();
-				rafId = null;
-			});
-		};
-
-		// Observe the parent for size changes (sidebar toggle, window resize, etc.)
-		const resizeObserver = new ResizeObserver(scheduleSync);
-		if (overlayRef.current?.parentElement) {
-			resizeObserver.observe(overlayRef.current.parentElement);
-		}
-
-		window.addEventListener("resize", scheduleSync);
-
-		// Periodic fallback for edge cases (pane splits, drag-resize, etc.)
-		const intervalId = setInterval(scheduleSync, 150);
-
-		return () => {
-			if (rafId !== null) cancelAnimationFrame(rafId);
-			resizeObserver.disconnect();
-			window.removeEventListener("resize", scheduleSync);
-			clearInterval(intervalId);
-		};
-	}, []);
+	const panes = useTabsStore((state) => state.panes);
+	const browserPaneIds = useMemo(
+		() =>
+			Object.entries(panes)
+				.filter(([, pane]) => pane.type === "webview")
+				.map(([paneId]) => paneId),
+		[panes],
+	);
 
 	return (
 		<div
-			ref={overlayRef}
 			style={{
 				position: "fixed",
 				inset: 0,
 				pointerEvents: "none",
 				zIndex: 50,
 			}}
-		/>
+		>
+			{browserPaneIds.map((paneId) => (
+				<PersistentBrowserSurface key={paneId} paneId={paneId} />
+			))}
+		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/WebviewOverlay/WebviewOverlay.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/WebviewOverlay/WebviewOverlay.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useRef } from "react";
+import { useTabsStore } from "renderer/stores/tabs/store";
+import {
+	getOrCreateWebview,
+	setOverlayContainer,
+	syncAllPositions,
+} from "renderer/stores/webview-overlay";
+
+/**
+ * Persistent overlay container for all browser webviews.
+ *
+ * Mounted at the dashboard layout level so it survives workspace/tab route
+ * changes. Webview DOM elements are never reparented — only shown/hidden and
+ * repositioned — which prevents Electron from reloading them.
+ */
+export function WebviewOverlay() {
+	const overlayRef = useRef<HTMLDivElement>(null);
+
+	// Register the overlay container with the module-level manager
+	useEffect(() => {
+		setOverlayContainer(overlayRef.current);
+		return () => setOverlayContainer(null);
+	}, []);
+
+	// Create webviews as panes appear in the store.
+	// Destruction is handled by useBrowserLifecycle.
+	useEffect(() => {
+		// Initialize from current state
+		const state = useTabsStore.getState();
+		for (const [id, pane] of Object.entries(state.panes)) {
+			if (pane.type === "webview") {
+				getOrCreateWebview(id, pane.browser?.currentUrl ?? "about:blank");
+			}
+		}
+
+		return useTabsStore.subscribe((state) => {
+			for (const [id, pane] of Object.entries(state.panes)) {
+				if (pane.type === "webview") {
+					getOrCreateWebview(id, pane.browser?.currentUrl ?? "about:blank");
+				}
+			}
+		});
+	}, []);
+
+	// Sync webview positions to slot rects on resize / layout changes
+	useEffect(() => {
+		let rafId: number | null = null;
+
+		const scheduleSync = () => {
+			if (rafId !== null) return;
+			rafId = requestAnimationFrame(() => {
+				syncAllPositions();
+				rafId = null;
+			});
+		};
+
+		// Observe the parent for size changes (sidebar toggle, window resize, etc.)
+		const resizeObserver = new ResizeObserver(scheduleSync);
+		if (overlayRef.current?.parentElement) {
+			resizeObserver.observe(overlayRef.current.parentElement);
+		}
+
+		window.addEventListener("resize", scheduleSync);
+
+		// Periodic fallback for edge cases (pane splits, drag-resize, etc.)
+		const intervalId = setInterval(scheduleSync, 150);
+
+		return () => {
+			if (rafId !== null) cancelAnimationFrame(rafId);
+			resizeObserver.disconnect();
+			window.removeEventListener("resize", scheduleSync);
+			clearInterval(intervalId);
+		};
+	}, []);
+
+	return (
+		<div
+			ref={overlayRef}
+			style={{
+				position: "fixed",
+				inset: 0,
+				pointerEvents: "none",
+				zIndex: 50,
+			}}
+		/>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/WebviewOverlay/components/PersistentBrowserSurface/PersistentBrowserSurface.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/WebviewOverlay/components/PersistentBrowserSurface/PersistentBrowserSurface.tsx
@@ -1,0 +1,190 @@
+import { GlobeIcon } from "lucide-react";
+import {
+	useCallback,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	useState,
+	useSyncExternalStore,
+} from "react";
+import { BrowserErrorOverlay } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/components/BrowserErrorOverlay";
+import { DEFAULT_BROWSER_URL } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/constants";
+import { useTabsStore } from "renderer/stores/tabs/store";
+import {
+	attachWebviewToHost,
+	getOverlayLayoutVersion,
+	getSlotElement,
+	subscribeOverlayLayout,
+	webviewReload,
+} from "renderer/stores/webview-overlay";
+
+interface PersistentBrowserSurfaceProps {
+	paneId: string;
+}
+
+interface SurfacePlacement {
+	left: number;
+	top: number;
+	width: number;
+	height: number;
+	isVisible: boolean;
+}
+
+const HIDDEN_SURFACE_PLACEMENT: SurfacePlacement = {
+	left: 0,
+	top: 0,
+	width: 0,
+	height: 0,
+	isVisible: false,
+};
+
+function placementsAreEqual(
+	left: SurfacePlacement,
+	right: SurfacePlacement,
+): boolean {
+	return (
+		left.left === right.left &&
+		left.top === right.top &&
+		left.width === right.width &&
+		left.height === right.height &&
+		left.isVisible === right.isVisible
+	);
+}
+
+function readPlacementFromSlot(paneId: string): SurfacePlacement {
+	const slot = getSlotElement(paneId);
+	if (!slot || !slot.isConnected) {
+		return HIDDEN_SURFACE_PLACEMENT;
+	}
+
+	const isVisible = getComputedStyle(slot).visibility !== "hidden";
+	if (!isVisible) {
+		return HIDDEN_SURFACE_PLACEMENT;
+	}
+
+	const rect = slot.getBoundingClientRect();
+	if (rect.width <= 0 || rect.height <= 0) {
+		return HIDDEN_SURFACE_PLACEMENT;
+	}
+
+	return {
+		left: rect.left,
+		top: rect.top,
+		width: rect.width,
+		height: rect.height,
+		isVisible: true,
+	};
+}
+
+export function PersistentBrowserSurface({
+	paneId,
+}: PersistentBrowserSurfaceProps) {
+	const pane = useTabsStore((state) => state.panes[paneId]);
+	const browserState = pane?.browser;
+	const currentUrl = browserState?.currentUrl ?? DEFAULT_BROWSER_URL;
+	const isLoading = browserState?.isLoading ?? false;
+	const loadError = browserState?.error ?? null;
+	const isBlankPage = currentUrl === DEFAULT_BROWSER_URL;
+	const hostRef = useRef<HTMLDivElement>(null);
+	const overlayLayoutVersion = useSyncExternalStore(
+		subscribeOverlayLayout,
+		getOverlayLayoutVersion,
+		getOverlayLayoutVersion,
+	);
+	const slotElement = useMemo(() => {
+		void overlayLayoutVersion;
+		return getSlotElement(paneId);
+	}, [paneId, overlayLayoutVersion]);
+	const [placement, setPlacement] = useState<SurfacePlacement>(() =>
+		readPlacementFromSlot(paneId),
+	);
+
+	const syncPlacement = useCallback(() => {
+		const nextPlacement = readPlacementFromSlot(paneId);
+		setPlacement((previousPlacement) =>
+			placementsAreEqual(previousPlacement, nextPlacement)
+				? previousPlacement
+				: nextPlacement,
+		);
+	}, [paneId]);
+
+	const handleReload = useCallback(() => {
+		webviewReload(paneId);
+	}, [paneId]);
+
+	useLayoutEffect(() => {
+		if (!pane || pane.type !== "webview") {
+			return;
+		}
+
+		const hostElement = hostRef.current;
+		if (!hostElement) {
+			return;
+		}
+
+		attachWebviewToHost(paneId, hostElement, currentUrl);
+	}, [pane, paneId, currentUrl]);
+
+	useLayoutEffect(() => {
+		syncPlacement();
+
+		if (!slotElement) {
+			return;
+		}
+
+		const resizeObserver = new ResizeObserver(syncPlacement);
+		resizeObserver.observe(slotElement);
+		window.addEventListener("resize", syncPlacement);
+
+		return () => {
+			resizeObserver.disconnect();
+			window.removeEventListener("resize", syncPlacement);
+		};
+	}, [slotElement, syncPlacement]);
+
+	if (!pane || pane.type !== "webview") {
+		return null;
+	}
+
+	return (
+		<div
+			style={{
+				position: "absolute",
+				left: placement.left,
+				top: placement.top,
+				width: placement.width,
+				height: placement.height,
+				display: placement.isVisible ? "block" : "none",
+				overflow: "hidden",
+				pointerEvents: placement.isVisible ? "auto" : "none",
+			}}
+		>
+			<div
+				ref={hostRef}
+				style={{
+					position: "absolute",
+					inset: 0,
+				}}
+			/>
+			{loadError && !isLoading ? (
+				<div className="absolute inset-0 z-10 pointer-events-auto">
+					<BrowserErrorOverlay error={loadError} onRetry={handleReload} />
+				</div>
+			) : isBlankPage && !isLoading && !loadError ? (
+				<div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-background pointer-events-none">
+					<GlobeIcon className="size-10 text-muted-foreground/30" />
+					<div className="text-center">
+						<p className="text-sm font-medium text-muted-foreground/50">
+							Browser
+						</p>
+						<p className="mt-1 text-xs text-muted-foreground/30">
+							Enter a URL above, or instruct an agent to navigate
+							<br />
+							and use the browser
+						</p>
+					</div>
+				</div>
+			) : null}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/WebviewOverlay/components/PersistentBrowserSurface/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/WebviewOverlay/components/PersistentBrowserSurface/index.ts
@@ -1,0 +1,1 @@
+export { PersistentBrowserSurface } from "./PersistentBrowserSurface";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/WebviewOverlay/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/WebviewOverlay/index.ts
@@ -1,0 +1,1 @@
+export { WebviewOverlay } from "./WebviewOverlay";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -19,6 +19,7 @@ import {
 	useWorkspaceSidebarStore,
 } from "renderer/stores/workspace-sidebar-state";
 import { TopBar } from "./components/TopBar";
+import { WebviewOverlay } from "./components/WebviewOverlay";
 
 export const Route = createFileRoute("/_authenticated/_dashboard")({
 	component: DashboardLayout,
@@ -124,6 +125,7 @@ function DashboardLayout() {
 				)}
 				<Outlet />
 			</div>
+			<WebviewOverlay />
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/BrowserPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/BrowserPane.tsx
@@ -1,12 +1,9 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
-import { GlobeIcon } from "lucide-react";
 import { useCallback } from "react";
-import { createPortal } from "react-dom";
 import { TbDeviceDesktop } from "react-icons/tb";
 import type { MosaicBranch } from "react-mosaic-component";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import { BasePaneWindow, PaneToolbarActions } from "../components";
-import { BrowserErrorOverlay } from "./components/BrowserErrorOverlay";
 import { BrowserToolbar } from "./components/BrowserToolbar";
 import { BrowserOverflowMenu } from "./components/BrowserToolbar/components/BrowserOverflowMenu";
 import { DEFAULT_BROWSER_URL } from "./constants";
@@ -41,12 +38,10 @@ export function BrowserPane({
 	const pageTitle =
 		browserState?.history[browserState.historyIndex]?.title ?? "";
 	const isLoading = browserState?.isLoading ?? false;
-	const loadError = browserState?.error ?? null;
 	const isBlankPage = currentUrl === "about:blank";
 
 	const {
 		slotRef,
-		chromeRoot,
 		goBack,
 		goForward,
 		reload,
@@ -59,91 +54,62 @@ export function BrowserPane({
 		openDevToolsPane(tabId, paneId, path);
 	}, [openDevToolsPane, tabId, paneId, path]);
 
-	const browserChrome =
-		loadError && !isLoading ? (
-			<div className="pointer-events-auto">
-				<BrowserErrorOverlay error={loadError} onRetry={reload} />
-			</div>
-		) : isBlankPage && !isLoading && !loadError ? (
-			<div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-background">
-				<GlobeIcon className="size-10 text-muted-foreground/30" />
-				<div className="text-center">
-					<p className="text-sm font-medium text-muted-foreground/50">
-						Browser
-					</p>
-					<p className="mt-1 text-xs text-muted-foreground/30">
-						Enter a URL above, or instruct an agent to navigate
-						<br />
-						and use the browser
-					</p>
-				</div>
-			</div>
-		) : null;
-
 	return (
-		<>
-			<BasePaneWindow
-				paneId={paneId}
-				path={path}
-				tabId={tabId}
-				splitPaneAuto={splitPaneAuto}
-				removePane={removePane}
-				setFocusedPane={setFocusedPane}
-				renderToolbar={(handlers) => (
-					<div className="flex h-full w-full items-center justify-between min-w-0">
-						<BrowserToolbar
-							currentUrl={currentUrl}
-							pageTitle={pageTitle}
-							isLoading={isLoading}
-							canGoBack={canGoBack}
-							canGoForward={canGoForward}
-							onGoBack={goBack}
-							onGoForward={goForward}
-							onReload={reload}
-							onNavigate={navigateTo}
+		<BasePaneWindow
+			paneId={paneId}
+			path={path}
+			tabId={tabId}
+			splitPaneAuto={splitPaneAuto}
+			removePane={removePane}
+			setFocusedPane={setFocusedPane}
+			renderToolbar={(handlers) => (
+				<div className="flex h-full w-full items-center justify-between min-w-0">
+					<BrowserToolbar
+						currentUrl={currentUrl}
+						pageTitle={pageTitle}
+						isLoading={isLoading}
+						canGoBack={canGoBack}
+						canGoForward={canGoForward}
+						onGoBack={goBack}
+						onGoForward={goForward}
+						onReload={reload}
+						onNavigate={navigateTo}
+					/>
+					<div className="flex items-center shrink-0">
+						<div className="mx-1.5 h-3.5 w-px bg-muted-foreground/60" />
+						<PaneToolbarActions
+							splitOrientation={handlers.splitOrientation}
+							onSplitPane={handlers.onSplitPane}
+							onClosePane={handlers.onClosePane}
+							closeHotkeyId="CLOSE_TERMINAL"
+							leadingActions={
+								<>
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<button
+												type="button"
+												onClick={handleOpenDevTools}
+												className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
+											>
+												<TbDeviceDesktop className="size-3.5" />
+											</button>
+										</TooltipTrigger>
+										<TooltipContent side="bottom" showArrow={false}>
+											Open DevTools
+										</TooltipContent>
+									</Tooltip>
+									<BrowserOverflowMenu paneId={paneId} hasPage={!isBlankPage} />
+								</>
+							}
 						/>
-						<div className="flex items-center shrink-0">
-							<div className="mx-1.5 h-3.5 w-px bg-muted-foreground/60" />
-							<PaneToolbarActions
-								splitOrientation={handlers.splitOrientation}
-								onSplitPane={handlers.onSplitPane}
-								onClosePane={handlers.onClosePane}
-								closeHotkeyId="CLOSE_TERMINAL"
-								leadingActions={
-									<>
-										<Tooltip>
-											<TooltipTrigger asChild>
-												<button
-													type="button"
-													onClick={handleOpenDevTools}
-													className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
-												>
-													<TbDeviceDesktop className="size-3.5" />
-												</button>
-											</TooltipTrigger>
-											<TooltipContent side="bottom" showArrow={false}>
-												Open DevTools
-											</TooltipContent>
-										</Tooltip>
-										<BrowserOverflowMenu
-											paneId={paneId}
-											hasPage={!isBlankPage}
-										/>
-									</>
-								}
-							/>
-						</div>
 					</div>
-				)}
-			>
-				<div className="relative flex flex-1 h-full pointer-events-none">
-					{/* Transparent slot — the overlay positions the real webview here */}
-					<div ref={slotRef} className="h-full w-full" style={{ flex: 1 }} />
 				</div>
-			</BasePaneWindow>
-			{chromeRoot && browserChrome
-				? createPortal(browserChrome, chromeRoot)
-				: null}
-		</>
+			)}
+		>
+			<div className="relative flex flex-1 h-full pointer-events-none">
+				{/* Transparent slot — the overlay positions the real webview here */}
+				<div ref={slotRef} className="h-full w-full" style={{ flex: 1 }} />
+			</div>
+		</BasePaneWindow>
 	);
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/BrowserPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/BrowserPane.tsx
@@ -1,6 +1,7 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { GlobeIcon } from "lucide-react";
 import { useCallback } from "react";
+import { createPortal } from "react-dom";
 import { TbDeviceDesktop } from "react-icons/tb";
 import type { MosaicBranch } from "react-mosaic-component";
 import { useTabsStore } from "renderer/stores/tabs/store";
@@ -45,6 +46,7 @@ export function BrowserPane({
 
 	const {
 		slotRef,
+		chromeRoot,
 		goBack,
 		goForward,
 		reload,
@@ -57,82 +59,91 @@ export function BrowserPane({
 		openDevToolsPane(tabId, paneId, path);
 	}, [openDevToolsPane, tabId, paneId, path]);
 
-	return (
-		<BasePaneWindow
-			paneId={paneId}
-			path={path}
-			tabId={tabId}
-			splitPaneAuto={splitPaneAuto}
-			removePane={removePane}
-			setFocusedPane={setFocusedPane}
-			renderToolbar={(handlers) => (
-				<div className="flex h-full w-full items-center justify-between min-w-0">
-					<BrowserToolbar
-						currentUrl={currentUrl}
-						pageTitle={pageTitle}
-						isLoading={isLoading}
-						canGoBack={canGoBack}
-						canGoForward={canGoForward}
-						onGoBack={goBack}
-						onGoForward={goForward}
-						onReload={reload}
-						onNavigate={navigateTo}
-					/>
-					<div className="flex items-center shrink-0">
-						<div className="mx-1.5 h-3.5 w-px bg-muted-foreground/60" />
-						<PaneToolbarActions
-							splitOrientation={handlers.splitOrientation}
-							onSplitPane={handlers.onSplitPane}
-							onClosePane={handlers.onClosePane}
-							closeHotkeyId="CLOSE_TERMINAL"
-							leadingActions={
-								<>
-									<Tooltip>
-										<TooltipTrigger asChild>
-											<button
-												type="button"
-												onClick={handleOpenDevTools}
-												className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
-											>
-												<TbDeviceDesktop className="size-3.5" />
-											</button>
-										</TooltipTrigger>
-										<TooltipContent side="bottom" showArrow={false}>
-											Open DevTools
-										</TooltipContent>
-									</Tooltip>
-									<BrowserOverflowMenu paneId={paneId} hasPage={!isBlankPage} />
-								</>
-							}
-						/>
-					</div>
+	const browserChrome =
+		loadError && !isLoading ? (
+			<div className="pointer-events-auto">
+				<BrowserErrorOverlay error={loadError} onRetry={reload} />
+			</div>
+		) : isBlankPage && !isLoading && !loadError ? (
+			<div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-background">
+				<GlobeIcon className="size-10 text-muted-foreground/30" />
+				<div className="text-center">
+					<p className="text-sm font-medium text-muted-foreground/50">
+						Browser
+					</p>
+					<p className="mt-1 text-xs text-muted-foreground/30">
+						Enter a URL above, or instruct an agent to navigate
+						<br />
+						and use the browser
+					</p>
 				</div>
-			)}
-		>
-			<div className="relative flex flex-1 h-full pointer-events-none">
-				{/* Transparent slot — the overlay positions the real webview behind this */}
-				<div ref={slotRef} className="w-full h-full" style={{ flex: 1 }} />
-				{loadError && !isLoading && (
-					<div className="pointer-events-auto">
-						<BrowserErrorOverlay error={loadError} onRetry={reload} />
-					</div>
-				)}
-				{isBlankPage && !isLoading && !loadError && (
-					<div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-background">
-						<GlobeIcon className="size-10 text-muted-foreground/30" />
-						<div className="text-center">
-							<p className="text-sm font-medium text-muted-foreground/50">
-								Browser
-							</p>
-							<p className="mt-1 text-xs text-muted-foreground/30">
-								Enter a URL above, or instruct an agent to navigate
-								<br />
-								and use the browser
-							</p>
+			</div>
+		) : null;
+
+	return (
+		<>
+			<BasePaneWindow
+				paneId={paneId}
+				path={path}
+				tabId={tabId}
+				splitPaneAuto={splitPaneAuto}
+				removePane={removePane}
+				setFocusedPane={setFocusedPane}
+				renderToolbar={(handlers) => (
+					<div className="flex h-full w-full items-center justify-between min-w-0">
+						<BrowserToolbar
+							currentUrl={currentUrl}
+							pageTitle={pageTitle}
+							isLoading={isLoading}
+							canGoBack={canGoBack}
+							canGoForward={canGoForward}
+							onGoBack={goBack}
+							onGoForward={goForward}
+							onReload={reload}
+							onNavigate={navigateTo}
+						/>
+						<div className="flex items-center shrink-0">
+							<div className="mx-1.5 h-3.5 w-px bg-muted-foreground/60" />
+							<PaneToolbarActions
+								splitOrientation={handlers.splitOrientation}
+								onSplitPane={handlers.onSplitPane}
+								onClosePane={handlers.onClosePane}
+								closeHotkeyId="CLOSE_TERMINAL"
+								leadingActions={
+									<>
+										<Tooltip>
+											<TooltipTrigger asChild>
+												<button
+													type="button"
+													onClick={handleOpenDevTools}
+													className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
+												>
+													<TbDeviceDesktop className="size-3.5" />
+												</button>
+											</TooltipTrigger>
+											<TooltipContent side="bottom" showArrow={false}>
+												Open DevTools
+											</TooltipContent>
+										</Tooltip>
+										<BrowserOverflowMenu
+											paneId={paneId}
+											hasPage={!isBlankPage}
+										/>
+									</>
+								}
+							/>
 						</div>
 					</div>
 				)}
-			</div>
-		</BasePaneWindow>
+			>
+				<div className="relative flex flex-1 h-full pointer-events-none">
+					{/* Transparent slot — the overlay positions the real webview here */}
+					<div ref={slotRef} className="h-full w-full" style={{ flex: 1 }} />
+				</div>
+			</BasePaneWindow>
+			{chromeRoot && browserChrome
+				? createPortal(browserChrome, chromeRoot)
+				: null}
+		</>
 	);
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/BrowserPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/BrowserPane.tsx
@@ -44,17 +44,14 @@ export function BrowserPane({
 	const isBlankPage = currentUrl === "about:blank";
 
 	const {
-		containerRef,
+		slotRef,
 		goBack,
 		goForward,
 		reload,
 		navigateTo,
 		canGoBack,
 		canGoForward,
-	} = usePersistentWebview({
-		paneId,
-		initialUrl: currentUrl,
-	});
+	} = usePersistentWebview({ paneId });
 
 	const handleOpenDevTools = useCallback(() => {
 		openDevToolsPane(tabId, paneId, path);
@@ -112,13 +109,16 @@ export function BrowserPane({
 				</div>
 			)}
 		>
-			<div className="relative flex flex-1 h-full">
-				<div ref={containerRef} className="w-full h-full" style={{ flex: 1 }} />
+			<div className="relative flex flex-1 h-full pointer-events-none">
+				{/* Transparent slot — the overlay positions the real webview behind this */}
+				<div ref={slotRef} className="w-full h-full" style={{ flex: 1 }} />
 				{loadError && !isLoading && (
-					<BrowserErrorOverlay error={loadError} onRetry={reload} />
+					<div className="pointer-events-auto">
+						<BrowserErrorOverlay error={loadError} onRetry={reload} />
+					</div>
 				)}
 				{isBlankPage && !isLoading && !loadError && (
-					<div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-background pointer-events-none">
+					<div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-background">
 						<GlobeIcon className="size-10 text-muted-foreground/30" />
 						<div className="text-center">
 							<p className="text-sm font-medium text-muted-foreground/50">

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/index.ts
@@ -1,4 +1,1 @@
-export {
-	destroyPersistentWebview,
-	usePersistentWebview,
-} from "./usePersistentWebview";
+export { usePersistentWebview } from "./usePersistentWebview";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
@@ -1,7 +1,14 @@
-import { useCallback, useEffect, useRef } from "react";
+import {
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
+} from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import {
+	getOrCreateWebview,
 	registerSlot,
 	unregisterSlot,
 	webviewGoBack,
@@ -29,15 +36,24 @@ interface UsePersistentWebviewOptions {
  */
 export function usePersistentWebview({ paneId }: UsePersistentWebviewOptions) {
 	const slotRef = useRef<HTMLDivElement | null>(null);
+	const [chromeRoot, setChromeRoot] = useState<HTMLDivElement | null>(null);
 
 	const browserState = useTabsStore((s) => s.panes[paneId]?.browser);
+	const currentUrl = browserState?.currentUrl ?? "about:blank";
 	const historyIndex = browserState?.historyIndex ?? 0;
 	const historyLength = browserState?.history.length ?? 0;
 	const canGoBack = historyIndex > 0;
 	const canGoForward = historyIndex < historyLength - 1;
 
-	// Register / unregister the slot element with the overlay manager
+	// Ensure the overlay entry exists before the pane needs to render browser UI
+	// chrome like the blank state or error screen.
 	useEffect(() => {
+		const entry = getOrCreateWebview(paneId, currentUrl);
+		setChromeRoot(entry.chromeRoot);
+	}, [paneId, currentUrl]);
+
+	// Register / unregister the slot element with the overlay manager
+	useLayoutEffect(() => {
 		const el = slotRef.current;
 		if (el) registerSlot(paneId, el);
 		return () => unregisterSlot(paneId);
@@ -87,6 +103,7 @@ export function usePersistentWebview({ paneId }: UsePersistentWebviewOptions) {
 
 	return {
 		slotRef,
+		chromeRoot,
 		goBack,
 		goForward,
 		reload,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
@@ -1,14 +1,7 @@
-import {
-	useCallback,
-	useEffect,
-	useLayoutEffect,
-	useRef,
-	useState,
-} from "react";
+import { useCallback, useLayoutEffect, useRef } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import {
-	getOrCreateWebview,
 	registerSlot,
 	unregisterSlot,
 	webviewGoBack,
@@ -36,21 +29,12 @@ interface UsePersistentWebviewOptions {
  */
 export function usePersistentWebview({ paneId }: UsePersistentWebviewOptions) {
 	const slotRef = useRef<HTMLDivElement | null>(null);
-	const [chromeRoot, setChromeRoot] = useState<HTMLDivElement | null>(null);
 
 	const browserState = useTabsStore((s) => s.panes[paneId]?.browser);
-	const currentUrl = browserState?.currentUrl ?? "about:blank";
 	const historyIndex = browserState?.historyIndex ?? 0;
 	const historyLength = browserState?.history.length ?? 0;
 	const canGoBack = historyIndex > 0;
 	const canGoForward = historyIndex < historyLength - 1;
-
-	// Ensure the overlay entry exists before the pane needs to render browser UI
-	// chrome like the blank state or error screen.
-	useEffect(() => {
-		const entry = getOrCreateWebview(paneId, currentUrl);
-		setChromeRoot(entry.chromeRoot);
-	}, [paneId, currentUrl]);
 
 	// Register / unregister the slot element with the overlay manager
 	useLayoutEffect(() => {
@@ -103,7 +87,6 @@ export function usePersistentWebview({ paneId }: UsePersistentWebviewOptions) {
 
 	return {
 		slotRef,
-		chromeRoot,
 		goBack,
 		goForward,
 		reload,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
@@ -1,57 +1,14 @@
 import { useCallback, useEffect, useRef } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useTabsStore } from "renderer/stores/tabs/store";
-
-// ---------------------------------------------------------------------------
-// Module-level singletons
-// ---------------------------------------------------------------------------
-
-const webviewRegistry = new Map<string, Electron.WebviewTag>();
-/** Tracks paneId → last-registered webContentsId so we can re-register if it changes. */
-const registeredWebContentsIds = new Map<string, number>();
-let hiddenContainer: HTMLDivElement | null = null;
-
-function getHiddenContainer(): HTMLDivElement {
-	if (!hiddenContainer) {
-		hiddenContainer = document.createElement("div");
-		hiddenContainer.style.position = "fixed";
-		hiddenContainer.style.left = "-9999px";
-		hiddenContainer.style.top = "-9999px";
-		hiddenContainer.style.width = "100vw";
-		hiddenContainer.style.height = "100vh";
-		hiddenContainer.style.overflow = "hidden";
-		hiddenContainer.style.pointerEvents = "none";
-		document.body.appendChild(hiddenContainer);
-	}
-	return hiddenContainer;
-}
-
-/** Call from useBrowserLifecycle when a pane is removed. */
-export function destroyPersistentWebview(paneId: string): void {
-	const webview = webviewRegistry.get(paneId);
-	if (webview) {
-		webview.remove();
-		webviewRegistry.delete(paneId);
-	}
-	registeredWebContentsIds.delete(paneId);
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function sanitizeUrl(url: string): string {
-	if (/^https?:\/\//i.test(url) || url.startsWith("about:")) {
-		return url;
-	}
-	if (url.startsWith("localhost") || url.startsWith("127.0.0.1")) {
-		return `http://${url}`;
-	}
-	if (url.includes(".")) {
-		return `https://${url}`;
-	}
-	return `https://www.google.com/search?q=${encodeURIComponent(url)}`;
-}
+import {
+	registerSlot,
+	unregisterSlot,
+	webviewGoBack,
+	webviewGoForward,
+	webviewNavigateTo,
+	webviewReload,
+} from "renderer/stores/webview-overlay";
 
 // ---------------------------------------------------------------------------
 // Hook
@@ -59,32 +16,34 @@ function sanitizeUrl(url: string): string {
 
 interface UsePersistentWebviewOptions {
 	paneId: string;
-	initialUrl: string;
 }
 
-export function usePersistentWebview({
-	paneId,
-	initialUrl,
-}: UsePersistentWebviewOptions) {
-	const containerRef = useRef<HTMLDivElement | null>(null);
-	const isHistoryNavigation = useRef(false);
-	const faviconUrlRef = useRef<string | undefined>(undefined);
-	const initialUrlRef = useRef(initialUrl);
+/**
+ * Connects a BrowserPane to the global webview overlay.
+ *
+ * - Registers a "slot" element so the overlay knows where to position the
+ *   webview.
+ * - Subscribes to tRPC events (new-window, context-menu) that only matter
+ *   while the pane UI is visible.
+ * - Exposes navigation helpers that operate on the overlay-managed webview.
+ */
+export function usePersistentWebview({ paneId }: UsePersistentWebviewOptions) {
+	const slotRef = useRef<HTMLDivElement | null>(null);
 
-	const navigateBrowserHistory = useTabsStore((s) => s.navigateBrowserHistory);
 	const browserState = useTabsStore((s) => s.panes[paneId]?.browser);
 	const historyIndex = browserState?.historyIndex ?? 0;
 	const historyLength = browserState?.history.length ?? 0;
 	const canGoBack = historyIndex > 0;
 	const canGoForward = historyIndex < historyLength - 1;
 
-	const { mutate: registerBrowser } =
-		electronTrpc.browser.register.useMutation();
-	const { mutate: upsertHistory } =
-		electronTrpc.browserHistory.upsert.useMutation();
+	// Register / unregister the slot element with the overlay manager
+	useEffect(() => {
+		const el = slotRef.current;
+		if (el) registerSlot(paneId, el);
+		return () => unregisterSlot(paneId);
+	}, [paneId]);
 
 	// Subscribe to new-window events (target="_blank" links, window.open)
-	// handled via setWindowOpenHandler in the main process
 	electronTrpc.browser.onNewWindow.useSubscription(
 		{ paneId },
 		{
@@ -116,267 +75,18 @@ export function usePersistentWebview({
 		},
 	);
 
-	// Sync store from webview state (handles agent-triggered navigation while hidden)
-	const syncStoreFromWebview = useCallback(
-		(webview: Electron.WebviewTag) => {
-			try {
-				const url = webview.getURL();
-				const title = webview.getTitle();
-				if (url) {
-					const store = useTabsStore.getState();
-					const currentUrl = store.panes[paneId]?.browser?.currentUrl;
-					if (url !== currentUrl) {
-						store.updateBrowserUrl(
-							paneId,
-							url,
-							title ?? "",
-							faviconUrlRef.current,
-						);
-					}
-				}
-			} catch {
-				// webview may not be ready
-			}
-		},
-		[paneId],
-	);
+	// -- Navigation methods ------------------------------------------------
 
-	// Main lifecycle effect: create or reclaim webview, attach events, park on unmount
-	useEffect(() => {
-		const container = containerRef.current;
-		if (!container) return;
-
-		let webview = webviewRegistry.get(paneId);
-
-		if (webview) {
-			// Reclaim from hidden container
-			container.appendChild(webview);
-			syncStoreFromWebview(webview);
-		} else {
-			// Create new webview
-			webview = document.createElement("webview") as Electron.WebviewTag;
-			webview.setAttribute("partition", "persist:superset");
-			webview.setAttribute("allowpopups", "");
-			webview.style.display = "flex";
-			webview.style.flex = "1";
-			webview.style.width = "100%";
-			webview.style.height = "100%";
-			webview.style.border = "none";
-
-			webviewRegistry.set(paneId, webview);
-			container.appendChild(webview);
-
-			const finalUrl = sanitizeUrl(initialUrlRef.current);
-			webview.src = finalUrl;
-		}
-
-		const wv = webview;
-
-		// -- Event handlers ------------------------------------------------
-
-		const handleDomReady = () => {
-			const webContentsId = wv.getWebContentsId();
-			const previousId = registeredWebContentsIds.get(paneId);
-			// Register on first load, or re-register if webContentsId changed (e.g. after DOM reparenting)
-			if (previousId !== webContentsId) {
-				registeredWebContentsIds.set(paneId, webContentsId);
-				registerBrowser({ paneId, webContentsId });
-			}
-		};
-
-		const handleDidStartLoading = () => {
-			const store = useTabsStore.getState();
-			store.updateBrowserLoading(paneId, true);
-			store.setBrowserError(paneId, null);
-			faviconUrlRef.current = undefined;
-		};
-
-		const handleDidStopLoading = () => {
-			const store = useTabsStore.getState();
-			store.updateBrowserLoading(paneId, false);
-
-			if (isHistoryNavigation.current) {
-				isHistoryNavigation.current = false;
-				return;
-			}
-
-			const url = wv.getURL();
-			const title = wv.getTitle();
-			store.updateBrowserUrl(
-				paneId,
-				url ?? "",
-				title ?? "",
-				faviconUrlRef.current,
-			);
-
-			if (url && url !== "about:blank") {
-				upsertHistory({
-					url,
-					title: title ?? "",
-					faviconUrl: faviconUrlRef.current ?? null,
-				});
-			}
-		};
-
-		const handleDidNavigate = (e: Electron.DidNavigateEvent) => {
-			if (isHistoryNavigation.current) {
-				isHistoryNavigation.current = false;
-				return;
-			}
-			const store = useTabsStore.getState();
-			store.updateBrowserUrl(
-				paneId,
-				e.url ?? "",
-				wv.getTitle() ?? "",
-				faviconUrlRef.current,
-			);
-			store.updateBrowserLoading(paneId, false);
-		};
-
-		const handleDidNavigateInPage = (e: Electron.DidNavigateInPageEvent) => {
-			if (isHistoryNavigation.current) {
-				isHistoryNavigation.current = false;
-				return;
-			}
-			const store = useTabsStore.getState();
-			store.updateBrowserUrl(
-				paneId,
-				e.url ?? "",
-				wv.getTitle() ?? "",
-				faviconUrlRef.current,
-			);
-		};
-
-		const handlePageTitleUpdated = (e: Electron.PageTitleUpdatedEvent) => {
-			const store = useTabsStore.getState();
-			const currentUrl = store.panes[paneId]?.browser?.currentUrl ?? "";
-			store.updateBrowserUrl(
-				paneId,
-				currentUrl,
-				e.title ?? "",
-				faviconUrlRef.current,
-			);
-		};
-
-		const handlePageFaviconUpdated = (e: Electron.PageFaviconUpdatedEvent) => {
-			const favicons = e.favicons;
-			if (favicons && favicons.length > 0) {
-				faviconUrlRef.current = favicons[0];
-				const store = useTabsStore.getState();
-				const currentUrl = store.panes[paneId]?.browser?.currentUrl ?? "";
-				const currentTitle =
-					store.panes[paneId]?.browser?.history[
-						store.panes[paneId]?.browser?.historyIndex ?? 0
-					]?.title ?? "";
-				store.updateBrowserUrl(paneId, currentUrl, currentTitle, favicons[0]);
-				if (currentUrl && currentUrl !== "about:blank") {
-					upsertHistory({
-						url: currentUrl,
-						title: currentTitle,
-						faviconUrl: favicons[0],
-					});
-				}
-			}
-		};
-
-		const handleDidFailLoad = (e: Electron.DidFailLoadEvent) => {
-			if (e.errorCode === -3) return; // ERR_ABORTED
-			const store = useTabsStore.getState();
-			store.updateBrowserLoading(paneId, false);
-			store.setBrowserError(paneId, {
-				code: e.errorCode ?? 0,
-				description: e.errorDescription ?? "",
-				url: e.validatedURL ?? "",
-			});
-		};
-
-		// -- Attach listeners ----------------------------------------------
-
-		wv.addEventListener("dom-ready", handleDomReady);
-		wv.addEventListener("did-start-loading", handleDidStartLoading);
-		wv.addEventListener("did-stop-loading", handleDidStopLoading);
-		wv.addEventListener("did-navigate", handleDidNavigate as EventListener);
-		wv.addEventListener(
-			"did-navigate-in-page",
-			handleDidNavigateInPage as EventListener,
-		);
-		wv.addEventListener(
-			"page-title-updated",
-			handlePageTitleUpdated as EventListener,
-		);
-		wv.addEventListener(
-			"page-favicon-updated",
-			handlePageFaviconUpdated as EventListener,
-		);
-		wv.addEventListener("did-fail-load", handleDidFailLoad as EventListener);
-
-		// -- Cleanup: park in hidden container -----------------------------
-
-		return () => {
-			wv.removeEventListener("dom-ready", handleDomReady);
-			wv.removeEventListener("did-start-loading", handleDidStartLoading);
-			wv.removeEventListener("did-stop-loading", handleDidStopLoading);
-			wv.removeEventListener(
-				"did-navigate",
-				handleDidNavigate as EventListener,
-			);
-			wv.removeEventListener(
-				"did-navigate-in-page",
-				handleDidNavigateInPage as EventListener,
-			);
-			wv.removeEventListener(
-				"page-title-updated",
-				handlePageTitleUpdated as EventListener,
-			);
-			wv.removeEventListener(
-				"page-favicon-updated",
-				handlePageFaviconUpdated as EventListener,
-			);
-			wv.removeEventListener(
-				"did-fail-load",
-				handleDidFailLoad as EventListener,
-			);
-
-			getHiddenContainer().appendChild(wv);
-		};
-		// paneId is stable for the lifetime of a pane; initialUrlRef only used on first create.
-	}, [paneId, registerBrowser, syncStoreFromWebview, upsertHistory]);
-
-	// -- Navigation methods (operate directly on the webview) ---------------
-
-	const goBack = useCallback(() => {
-		const url = navigateBrowserHistory(paneId, "back");
-		if (url) {
-			isHistoryNavigation.current = true;
-			const webview = webviewRegistry.get(paneId);
-			if (webview) webview.loadURL(sanitizeUrl(url));
-		}
-	}, [paneId, navigateBrowserHistory]);
-
-	const goForward = useCallback(() => {
-		const url = navigateBrowserHistory(paneId, "forward");
-		if (url) {
-			isHistoryNavigation.current = true;
-			const webview = webviewRegistry.get(paneId);
-			if (webview) webview.loadURL(sanitizeUrl(url));
-		}
-	}, [paneId, navigateBrowserHistory]);
-
-	const reload = useCallback(() => {
-		const webview = webviewRegistry.get(paneId);
-		if (webview) webview.reload();
-	}, [paneId]);
-
+	const goBack = useCallback(() => webviewGoBack(paneId), [paneId]);
+	const goForward = useCallback(() => webviewGoForward(paneId), [paneId]);
+	const reload = useCallback(() => webviewReload(paneId), [paneId]);
 	const navigateTo = useCallback(
-		(url: string) => {
-			const webview = webviewRegistry.get(paneId);
-			if (webview) webview.loadURL(sanitizeUrl(url));
-		},
+		(url: string) => webviewNavigateTo(paneId, url),
 		[paneId],
 	);
 
 	return {
-		containerRef,
+		slotRef,
 		goBack,
 		goForward,
 		reload,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
@@ -1,6 +1,5 @@
 import { Alert, AlertDescription, AlertTitle } from "@superset/ui/alert";
 import { Button } from "@superset/ui/button";
-import { useParams } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { MosaicBranch } from "react-mosaic-component";
 import type { MarkdownEditorAdapter } from "renderer/components/MarkdownRenderer";
@@ -54,6 +53,7 @@ interface FileViewerPaneProps {
 	paneId: string;
 	path: MosaicBranch[];
 	tabId: string;
+	workspaceId: string;
 	worktreePath: string;
 	splitPaneAuto: (
 		tabId: string,
@@ -117,6 +117,7 @@ export function FileViewerPane({
 	paneId,
 	path,
 	tabId,
+	workspaceId,
 	worktreePath,
 	splitPaneAuto,
 	splitPaneHorizontal,
@@ -127,8 +128,6 @@ export function FileViewerPane({
 	onMoveToTab,
 	onMoveToNewTab,
 }: FileViewerPaneProps) {
-	const { workspaceId } = useParams({ strict: false });
-	const normalizedWorkspaceId = workspaceId ?? worktreePath;
 	const fileViewer = useTabsStore((s) => s.panes[paneId]?.fileViewer);
 	const isFocused = useTabsStore((s) => s.focusedPaneIds[tabId] === paneId);
 	const equalizePaneSplits = useTabsStore((s) => s.equalizePaneSplits);
@@ -160,13 +159,13 @@ export function FileViewerPane({
 	const documentKey = useMemo(
 		() =>
 			buildEditorDocumentKey({
-				workspaceId: normalizedWorkspaceId,
+				workspaceId,
 				filePath,
 				diffCategory,
 				commitHash,
 				oldPath,
 			}),
-		[normalizedWorkspaceId, filePath, diffCategory, commitHash, oldPath],
+		[workspaceId, filePath, diffCategory, commitHash, oldPath],
 	);
 	const documentState = useEditorDocumentsStore(
 		(state) => state.documents[documentKey],
@@ -225,7 +224,7 @@ export function FileViewerPane({
 	});
 
 	useEffect(() => {
-		if (!fileViewer || !normalizedWorkspaceId) {
+		if (!fileViewer) {
 			return;
 		}
 
@@ -237,7 +236,7 @@ export function FileViewerPane({
 		bindFileViewerSession(
 			paneId,
 			{
-				workspaceId: normalizedWorkspaceId,
+				workspaceId,
 				filePath,
 				diffCategory,
 				commitHash,
@@ -255,7 +254,7 @@ export function FileViewerPane({
 	}, [
 		paneId,
 		fileViewer,
-		normalizedWorkspaceId,
+		workspaceId,
 		filePath,
 		diffCategory,
 		commitHash,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
@@ -184,6 +184,7 @@ export function TabView({ tab }: TabViewProps) {
 						paneId={paneId}
 						path={path}
 						tabId={tab.id}
+						workspaceId={tab.workspaceId}
 						worktreePath={worktreePath}
 						splitPaneAuto={splitPaneAuto}
 						splitPaneHorizontal={splitPaneHorizontal}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/index.tsx
@@ -1,9 +1,10 @@
 import type { ExternalApp } from "@superset/local-db";
 import { cn } from "@superset/ui/utils";
 import { useParams } from "@tanstack/react-router";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef } from "react";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import { resolveActiveTabIdForWorkspace } from "renderer/stores/tabs/utils";
+import { syncAllPositions } from "renderer/stores/webview-overlay";
 import { EmptyTabView } from "./EmptyTabView";
 import { TabView } from "./TabView";
 import { getTabsToRender } from "./utils/getTabsToRender";
@@ -33,6 +34,7 @@ export function TabsContent({
 		workspaceId: null,
 		tabId: null,
 	});
+	const previousOverlaySyncKeyRef = useRef<string | null>(null);
 
 	const activeTabId = useMemo(() => {
 		if (!activeWorkspaceId) return null;
@@ -59,6 +61,21 @@ export function TabsContent({
 			}),
 		[activeTabId, allTabs, panes],
 	);
+	const renderedTabIds = useMemo(
+		() => tabsToRender.map((tab) => tab.id).join("|"),
+		[tabsToRender],
+	);
+	const overlaySyncKey = `${activeWorkspaceId ?? ""}:${activeTabId ?? ""}:${renderedTabIds}`;
+
+	// Tab/workspace activation changes only toggle CSS visibility, so force an
+	// immediate overlay sync after React commits the new active content.
+	useLayoutEffect(() => {
+		if (previousOverlaySyncKeyRef.current === overlaySyncKey) {
+			return;
+		}
+		previousOverlaySyncKeyRef.current = overlaySyncKey;
+		syncAllPositions();
+	}, [overlaySyncKey]);
 
 	useEffect(() => {
 		const nextWorkspaceId = activeWorkspaceId ?? null;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/index.tsx
@@ -1,10 +1,12 @@
 import type { ExternalApp } from "@superset/local-db";
+import { cn } from "@superset/ui/utils";
 import { useParams } from "@tanstack/react-router";
 import { useEffect, useMemo, useRef } from "react";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import { resolveActiveTabIdForWorkspace } from "renderer/stores/tabs/utils";
 import { EmptyTabView } from "./EmptyTabView";
 import { TabView } from "./TabView";
+import { getTabsToRender } from "./utils/getTabsToRender";
 
 interface TabsContentProps {
 	defaultExternalApp?: ExternalApp | null;
@@ -19,6 +21,7 @@ export function TabsContent({
 }: TabsContentProps) {
 	const { workspaceId: activeWorkspaceId } = useParams({ strict: false });
 	const allTabs = useTabsStore((s) => s.tabs);
+	const panes = useTabsStore((s) => s.panes);
 	const activeTabIds = useTabsStore((s) => s.activeTabIds);
 	const tabHistoryStacks = useTabsStore((s) => s.tabHistoryStacks);
 	const contentRef = useRef<HTMLDivElement>(null);
@@ -47,10 +50,15 @@ export function TabsContent({
 		return resolvedActiveTabId;
 	}, [activeWorkspaceId, activeTabIds, allTabs, tabHistoryStacks]);
 
-	const tabToRender = useMemo(() => {
-		if (!activeTabId) return null;
-		return allTabs.find((tab) => tab.id === activeTabId) || null;
-	}, [activeTabId, allTabs]);
+	const tabsToRender = useMemo(
+		() =>
+			getTabsToRender({
+				activeTabId,
+				tabs: allTabs,
+				panes,
+			}),
+		[activeTabId, allTabs, panes],
+	);
 
 	useEffect(() => {
 		const nextWorkspaceId = activeWorkspaceId ?? null;
@@ -79,7 +87,7 @@ export function TabsContent({
 
 		const frameId = requestAnimationFrame(() => {
 			const textarea = contentRef.current?.querySelector<HTMLTextAreaElement>(
-				".mosaic-window-focused [data-slot=input-group-control]",
+				'[data-active-tab-content="true"] .mosaic-window-focused [data-slot="input-group-control"]',
 			);
 			textarea?.focus();
 		});
@@ -88,16 +96,36 @@ export function TabsContent({
 	}, [activeTabId, activeWorkspaceId]);
 
 	return (
-		<div ref={contentRef} className="flex-1 min-h-0 flex overflow-hidden">
-			{tabToRender ? (
-				<TabView tab={tabToRender} />
-			) : (
-				<EmptyTabView
-					defaultExternalApp={defaultExternalApp}
-					onOpenInApp={onOpenInApp}
-					onOpenQuickOpen={onOpenQuickOpen}
-				/>
-			)}
+		<div
+			ref={contentRef}
+			className="relative flex flex-1 min-h-0 overflow-hidden"
+		>
+			{tabsToRender.map((tab) => {
+				const isActive = tab.id === activeTabId;
+
+				return (
+					<div
+						key={tab.id}
+						data-active-tab-content={isActive ? "true" : undefined}
+						aria-hidden={!isActive}
+						className={cn(
+							"absolute inset-0 min-h-0",
+							isActive ? "visible z-10" : "invisible pointer-events-none",
+						)}
+					>
+						<TabView tab={tab} />
+					</div>
+				);
+			})}
+			{activeTabId === null ? (
+				<div className="absolute inset-0 z-10 flex min-h-0 overflow-hidden">
+					<EmptyTabView
+						defaultExternalApp={defaultExternalApp}
+						onOpenInApp={onOpenInApp}
+						onOpenQuickOpen={onOpenQuickOpen}
+					/>
+				</div>
+			) : null}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/index.tsx
@@ -4,7 +4,7 @@ import { useParams } from "@tanstack/react-router";
 import { useEffect, useLayoutEffect, useMemo, useRef } from "react";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import { resolveActiveTabIdForWorkspace } from "renderer/stores/tabs/utils";
-import { syncAllPositions } from "renderer/stores/webview-overlay";
+import { notifyOverlayLayoutChanged } from "renderer/stores/webview-overlay";
 import { EmptyTabView } from "./EmptyTabView";
 import { TabView } from "./TabView";
 import { getTabsToRender } from "./utils/getTabsToRender";
@@ -74,7 +74,7 @@ export function TabsContent({
 			return;
 		}
 		previousOverlaySyncKeyRef.current = overlaySyncKey;
-		syncAllPositions();
+		notifyOverlayLayoutChanged();
 	}, [overlaySyncKey]);
 
 	useEffect(() => {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/utils/getTabsToRender/getTabsToRender.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/utils/getTabsToRender/getTabsToRender.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "bun:test";
+import type { Pane, Tab } from "renderer/stores/tabs/types";
+import { getTabsToRender } from "./getTabsToRender";
+
+function createTab(id: string, workspaceId: string, paneId: string): Tab {
+	return {
+		id,
+		name: id,
+		workspaceId,
+		layout: paneId,
+		createdAt: 1,
+	};
+}
+
+function createPane(id: string, tabId: string, type: Pane["type"]): Pane {
+	return {
+		id,
+		tabId,
+		type,
+		name: id,
+	};
+}
+
+describe("getTabsToRender", () => {
+	it("keeps the active tab first and adds inactive browser tabs", () => {
+		const tabs = [
+			createTab("tab-terminal", "ws-1", "pane-terminal"),
+			createTab("tab-browser", "ws-1", "pane-browser"),
+			createTab("tab-chat", "ws-1", "pane-chat"),
+		];
+		const panes: Record<string, Pane> = {
+			"pane-terminal": createPane("pane-terminal", "tab-terminal", "terminal"),
+			"pane-browser": createPane("pane-browser", "tab-browser", "webview"),
+			"pane-chat": createPane("pane-chat", "tab-chat", "chat"),
+		};
+
+		expect(
+			getTabsToRender({
+				activeTabId: "tab-terminal",
+				tabs,
+				panes,
+			}).map((tab) => tab.id),
+		).toEqual(["tab-terminal", "tab-browser"]);
+	});
+
+	it("does not duplicate the active browser tab", () => {
+		const tabs = [createTab("tab-browser", "ws-1", "pane-browser")];
+		const panes: Record<string, Pane> = {
+			"pane-browser": createPane("pane-browser", "tab-browser", "webview"),
+		};
+
+		expect(
+			getTabsToRender({
+				activeTabId: "tab-browser",
+				tabs,
+				panes,
+			}).map((tab) => tab.id),
+		).toEqual(["tab-browser"]);
+	});
+
+	it("keeps browser tabs mounted across workspaces", () => {
+		const tabs = [
+			createTab("tab-terminal", "ws-1", "pane-terminal"),
+			createTab("tab-browser", "ws-2", "pane-browser"),
+		];
+		const panes: Record<string, Pane> = {
+			"pane-terminal": createPane("pane-terminal", "tab-terminal", "terminal"),
+			"pane-browser": createPane("pane-browser", "tab-browser", "webview"),
+		};
+
+		expect(
+			getTabsToRender({
+				activeTabId: "tab-terminal",
+				tabs,
+				panes,
+			}).map((tab) => tab.id),
+		).toEqual(["tab-terminal", "tab-browser"]);
+	});
+
+	it("ignores a stale active tab id and still keeps browser tabs mounted", () => {
+		const tabs = [
+			createTab("tab-terminal", "ws-1", "pane-terminal"),
+			createTab("tab-browser", "ws-1", "pane-browser"),
+		];
+		const panes: Record<string, Pane> = {
+			"pane-terminal": createPane("pane-terminal", "tab-terminal", "terminal"),
+			"pane-browser": createPane("pane-browser", "tab-browser", "webview"),
+		};
+
+		expect(
+			getTabsToRender({
+				activeTabId: "tab-missing",
+				tabs,
+				panes,
+			}).map((tab) => tab.id),
+		).toEqual(["tab-browser"]);
+	});
+
+	it("skips inactive tabs without a browser pane", () => {
+		const tabs = [
+			createTab("tab-terminal", "ws-1", "pane-terminal"),
+			createTab("tab-chat", "ws-2", "pane-chat"),
+		];
+		const panes: Record<string, Pane> = {
+			"pane-terminal": createPane("pane-terminal", "tab-terminal", "terminal"),
+			"pane-chat": createPane("pane-chat", "tab-chat", "chat"),
+		};
+
+		expect(
+			getTabsToRender({
+				activeTabId: null,
+				tabs,
+				panes,
+			}),
+		).toEqual([]);
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/utils/getTabsToRender/getTabsToRender.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/utils/getTabsToRender/getTabsToRender.ts
@@ -1,0 +1,45 @@
+import type { Pane, Tab } from "renderer/stores/tabs/types";
+import { extractPaneIdsFromLayout } from "renderer/stores/tabs/utils";
+
+interface GetTabsToRenderOptions {
+	activeTabId: string | null;
+	tabs: Tab[];
+	panes: Record<string, Pane>;
+}
+
+function tabHasBrowserPane(tab: Tab, panes: Record<string, Pane>): boolean {
+	for (const paneId of extractPaneIdsFromLayout(tab.layout)) {
+		if (panes[paneId]?.type === "webview") {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+export function getTabsToRender({
+	activeTabId,
+	tabs,
+	panes,
+}: GetTabsToRenderOptions): Tab[] {
+	const tabsToRender: Tab[] = [];
+	const seenTabIds = new Set<string>();
+
+	const pushTab = (tab: Tab | null | undefined) => {
+		if (!tab || seenTabIds.has(tab.id)) return;
+		seenTabIds.add(tab.id);
+		tabsToRender.push(tab);
+	};
+
+	pushTab(tabs.find((tab) => tab.id === activeTabId));
+
+	// Intentionally keep browser-bearing tabs mounted across workspaces so their
+	// webviews preserve page state while hidden during workspace switches.
+	for (const tab of tabs) {
+		if (tab.id === activeTabId) continue;
+		if (!tabHasBrowserPane(tab, panes)) continue;
+		pushTab(tab);
+	}
+
+	return tabsToRender;
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/utils/getTabsToRender/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/utils/getTabsToRender/index.ts
@@ -1,0 +1,1 @@
+export { getTabsToRender } from "./getTabsToRender";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useBrowserLifecycle/useBrowserLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/hooks/useBrowserLifecycle/useBrowserLifecycle.ts
@@ -1,11 +1,8 @@
 import { useEffect, useRef } from "react";
-import { electronTrpc } from "renderer/lib/electron-trpc";
-import { destroyPersistentWebview } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview";
 import { useTabsStore } from "renderer/stores/tabs/store";
+import { destroyWebview } from "renderer/stores/webview-overlay";
 
 export function useBrowserLifecycle() {
-	const { mutate: unregisterBrowser } =
-		electronTrpc.browser.unregister.useMutation();
 	const previousPaneIdsRef = useRef<Set<string>>(new Set());
 
 	useEffect(() => {
@@ -25,11 +22,10 @@ export function useBrowserLifecycle() {
 			);
 			for (const prevId of previousPaneIdsRef.current) {
 				if (!currentBrowserPaneIds.has(prevId)) {
-					destroyPersistentWebview(prevId);
-					unregisterBrowser({ paneId: prevId });
+					destroyWebview(prevId);
 				}
 			}
 			previousPaneIdsRef.current = currentBrowserPaneIds;
 		});
-	}, [unregisterBrowser]);
+	}, []);
 }

--- a/apps/desktop/src/renderer/stores/webview-overlay.ts
+++ b/apps/desktop/src/renderer/stores/webview-overlay.ts
@@ -20,6 +20,7 @@ import { useTabsStore } from "renderer/stores/tabs/store";
 interface WebviewEntry {
 	webview: Electron.WebviewTag;
 	wrapper: HTMLDivElement;
+	chromeRoot: HTMLDivElement;
 	webContentsId: number | null;
 	faviconUrl: string | undefined;
 }
@@ -89,11 +90,21 @@ export function getOrCreateWebview(
 	webview.style.height = "100%";
 	webview.style.border = "none";
 
+	// Browser UI overlays render into this layer so they stay above the webview
+	// even though the actual webview element lives in the global overlay.
+	const chromeRoot = document.createElement("div");
+	chromeRoot.style.position = "absolute";
+	chromeRoot.style.inset = "0";
+	chromeRoot.style.pointerEvents = "none";
+	chromeRoot.style.zIndex = "1";
+
 	wrapper.appendChild(webview);
+	wrapper.appendChild(chromeRoot);
 
 	const entry: WebviewEntry = {
 		webview,
 		wrapper,
+		chromeRoot,
 		webContentsId: null,
 		faviconUrl: undefined,
 	};
@@ -116,7 +127,6 @@ export function destroyWebview(paneId: string): void {
 	webviews.delete(paneId);
 	electronTrpcClient.browser.unregister.mutate({ paneId }).catch(() => {});
 }
-
 
 // ---------------------------------------------------------------------------
 // Event handlers (permanent — not tied to React lifecycle)

--- a/apps/desktop/src/renderer/stores/webview-overlay.ts
+++ b/apps/desktop/src/renderer/stores/webview-overlay.ts
@@ -1,57 +1,44 @@
 /**
  * Module-level manager for persistent webview elements.
  *
- * Webviews live in a single overlay container mounted at the dashboard layout
- * level. They are NEVER reparented in the DOM — only shown/hidden and
- * repositioned — so Electron never reloads their guest processes.
- *
- * BrowserPane registers a "slot" (the DOM element where the webview should
- * visually appear). The overlay positions each webview wrapper to match its
- * slot's bounding rect.
+ * React owns the overlay surfaces and positioning. This module only owns the
+ * stable Electron webview node for each browser pane plus the imperative
+ * browser actions that operate on that node.
  */
 
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { useTabsStore } from "renderer/stores/tabs/store";
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
 interface WebviewEntry {
 	webview: Electron.WebviewTag;
-	wrapper: HTMLDivElement;
-	chromeRoot: HTMLDivElement;
 	webContentsId: number | null;
 	faviconUrl: string | undefined;
 }
 
-// ---------------------------------------------------------------------------
-// State
-// ---------------------------------------------------------------------------
-
 const webviews = new Map<string, WebviewEntry>();
 const slots = new Map<string, HTMLElement>();
-let overlayContainer: HTMLDivElement | null = null;
-const slotListeners = new Set<() => void>();
+const overlayLayoutListeners = new Set<() => void>();
+let overlayLayoutVersion = 0;
 
-// ---------------------------------------------------------------------------
-// Overlay container (called by WebviewOverlay component)
-// ---------------------------------------------------------------------------
-
-export function setOverlayContainer(el: HTMLDivElement | null): void {
-	overlayContainer = el;
-	if (el) {
-		for (const entry of webviews.values()) {
-			if (!el.contains(entry.wrapper)) {
-				el.appendChild(entry.wrapper);
-			}
-		}
+function emitOverlayLayoutChange(): void {
+	overlayLayoutVersion += 1;
+	for (const listener of overlayLayoutListeners) {
+		listener();
 	}
 }
 
-// ---------------------------------------------------------------------------
-// URL helpers
-// ---------------------------------------------------------------------------
+export function subscribeOverlayLayout(listener: () => void): () => void {
+	overlayLayoutListeners.add(listener);
+	return () => overlayLayoutListeners.delete(listener);
+}
+
+export function getOverlayLayoutVersion(): number {
+	return overlayLayoutVersion;
+}
+
+export function notifyOverlayLayoutChanged(): void {
+	emitOverlayLayoutChange();
+}
 
 function sanitizeUrl(url: string): string {
 	if (/^https?:\/\//i.test(url) || url.startsWith("about:")) return url;
@@ -61,26 +48,10 @@ function sanitizeUrl(url: string): string {
 	return `https://www.google.com/search?q=${encodeURIComponent(url)}`;
 }
 
-// ---------------------------------------------------------------------------
-// Webview lifecycle
-// ---------------------------------------------------------------------------
-
-export function getOrCreateWebview(
-	paneId: string,
-	initialUrl: string,
-): WebviewEntry {
+function getOrCreateWebview(paneId: string, initialUrl: string): WebviewEntry {
 	const existing = webviews.get(paneId);
 	if (existing) return existing;
 
-	// Wrapper — positioned absolutely by the overlay
-	const wrapper = document.createElement("div");
-	wrapper.style.position = "absolute";
-	wrapper.style.overflow = "hidden";
-	wrapper.style.display = "none"; // hidden until a slot is registered
-	wrapper.style.pointerEvents = "auto";
-	wrapper.dataset.webviewPane = paneId;
-
-	// Webview element
 	const webview = document.createElement("webview") as Electron.WebviewTag;
 	webview.setAttribute("partition", "persist:superset");
 	webview.setAttribute("allowpopups", "");
@@ -89,48 +60,38 @@ export function getOrCreateWebview(
 	webview.style.width = "100%";
 	webview.style.height = "100%";
 	webview.style.border = "none";
-
-	// Browser UI overlays render into this layer so they stay above the webview
-	// even though the actual webview element lives in the global overlay.
-	const chromeRoot = document.createElement("div");
-	chromeRoot.style.position = "absolute";
-	chromeRoot.style.inset = "0";
-	chromeRoot.style.pointerEvents = "none";
-	chromeRoot.style.zIndex = "1";
-
-	wrapper.appendChild(webview);
-	wrapper.appendChild(chromeRoot);
+	webview.src = sanitizeUrl(initialUrl);
 
 	const entry: WebviewEntry = {
 		webview,
-		wrapper,
-		chromeRoot,
 		webContentsId: null,
 		faviconUrl: undefined,
 	};
 	webviews.set(paneId, entry);
 
-	if (overlayContainer) {
-		overlayContainer.appendChild(wrapper);
-	}
-
-	webview.src = sanitizeUrl(initialUrl);
 	attachEventHandlers(paneId, entry);
 
 	return entry;
 }
 
+export function attachWebviewToHost(
+	paneId: string,
+	hostElement: HTMLElement,
+	initialUrl: string,
+): void {
+	const entry = getOrCreateWebview(paneId, initialUrl);
+	if (!hostElement.contains(entry.webview)) {
+		hostElement.appendChild(entry.webview);
+	}
+}
+
 export function destroyWebview(paneId: string): void {
 	const entry = webviews.get(paneId);
 	if (!entry) return;
-	entry.wrapper.remove();
+	entry.webview.remove();
 	webviews.delete(paneId);
 	electronTrpcClient.browser.unregister.mutate({ paneId }).catch(() => {});
 }
-
-// ---------------------------------------------------------------------------
-// Event handlers (permanent — not tied to React lifecycle)
-// ---------------------------------------------------------------------------
 
 function attachEventHandlers(paneId: string, entry: WebviewEntry): void {
 	const { webview } = entry;
@@ -250,66 +211,19 @@ function attachEventHandlers(paneId: string, entry: WebviewEntry): void {
 	webview.addEventListener("did-fail-load", handleDidFailLoad as EventListener);
 }
 
-// ---------------------------------------------------------------------------
-// Slot management (called by BrowserPane)
-// ---------------------------------------------------------------------------
-
 export function registerSlot(paneId: string, element: HTMLElement): void {
 	slots.set(paneId, element);
-	// syncPosition checks visibility and sets display accordingly
-	syncPosition(paneId);
-	notifySlotListeners();
+	emitOverlayLayoutChange();
 }
 
 export function unregisterSlot(paneId: string): void {
 	slots.delete(paneId);
-	const entry = webviews.get(paneId);
-	if (entry) {
-		entry.wrapper.style.display = "none";
-	}
-	notifySlotListeners();
+	emitOverlayLayoutChange();
 }
 
-function notifySlotListeners(): void {
-	for (const listener of slotListeners) listener();
+export function getSlotElement(paneId: string): HTMLElement | null {
+	return slots.get(paneId) ?? null;
 }
-
-// ---------------------------------------------------------------------------
-// Position sync
-// ---------------------------------------------------------------------------
-
-export function syncPosition(paneId: string): void {
-	const entry = webviews.get(paneId);
-	const slot = slots.get(paneId);
-	if (!entry || !slot) return;
-
-	// Hide the webview if the slot is not visible (e.g. tab is inactive and
-	// has `visibility: hidden` via the getTabsToRender CSS toggling).
-	// `visibility` is inherited, so this catches hidden ancestors too.
-	const isVisible = getComputedStyle(slot).visibility !== "hidden";
-	if (!isVisible) {
-		entry.wrapper.style.display = "none";
-		return;
-	}
-
-	entry.wrapper.style.display = "block";
-	const rect = slot.getBoundingClientRect();
-	const { wrapper } = entry;
-	wrapper.style.left = `${rect.left}px`;
-	wrapper.style.top = `${rect.top}px`;
-	wrapper.style.width = `${rect.width}px`;
-	wrapper.style.height = `${rect.height}px`;
-}
-
-export function syncAllPositions(): void {
-	for (const paneId of slots.keys()) {
-		syncPosition(paneId);
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Navigation (called by BrowserPane via usePersistentWebview)
-// ---------------------------------------------------------------------------
 
 export function webviewNavigateTo(paneId: string, url: string): void {
 	const entry = webviews.get(paneId);

--- a/apps/desktop/src/renderer/stores/webview-overlay.ts
+++ b/apps/desktop/src/renderer/stores/webview-overlay.ts
@@ -1,0 +1,330 @@
+/**
+ * Module-level manager for persistent webview elements.
+ *
+ * Webviews live in a single overlay container mounted at the dashboard layout
+ * level. They are NEVER reparented in the DOM — only shown/hidden and
+ * repositioned — so Electron never reloads their guest processes.
+ *
+ * BrowserPane registers a "slot" (the DOM element where the webview should
+ * visually appear). The overlay positions each webview wrapper to match its
+ * slot's bounding rect.
+ */
+
+import { electronTrpcClient } from "renderer/lib/trpc-client";
+import { useTabsStore } from "renderer/stores/tabs/store";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface WebviewEntry {
+	webview: Electron.WebviewTag;
+	wrapper: HTMLDivElement;
+	webContentsId: number | null;
+	faviconUrl: string | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+const webviews = new Map<string, WebviewEntry>();
+const slots = new Map<string, HTMLElement>();
+let overlayContainer: HTMLDivElement | null = null;
+const slotListeners = new Set<() => void>();
+
+// ---------------------------------------------------------------------------
+// Overlay container (called by WebviewOverlay component)
+// ---------------------------------------------------------------------------
+
+export function setOverlayContainer(el: HTMLDivElement | null): void {
+	overlayContainer = el;
+	if (el) {
+		for (const entry of webviews.values()) {
+			if (!el.contains(entry.wrapper)) {
+				el.appendChild(entry.wrapper);
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// URL helpers
+// ---------------------------------------------------------------------------
+
+function sanitizeUrl(url: string): string {
+	if (/^https?:\/\//i.test(url) || url.startsWith("about:")) return url;
+	if (url.startsWith("localhost") || url.startsWith("127.0.0.1"))
+		return `http://${url}`;
+	if (url.includes(".")) return `https://${url}`;
+	return `https://www.google.com/search?q=${encodeURIComponent(url)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Webview lifecycle
+// ---------------------------------------------------------------------------
+
+export function getOrCreateWebview(
+	paneId: string,
+	initialUrl: string,
+): WebviewEntry {
+	const existing = webviews.get(paneId);
+	if (existing) return existing;
+
+	// Wrapper — positioned absolutely by the overlay
+	const wrapper = document.createElement("div");
+	wrapper.style.position = "absolute";
+	wrapper.style.overflow = "hidden";
+	wrapper.style.display = "none"; // hidden until a slot is registered
+	wrapper.style.pointerEvents = "auto";
+	wrapper.dataset.webviewPane = paneId;
+
+	// Webview element
+	const webview = document.createElement("webview") as Electron.WebviewTag;
+	webview.setAttribute("partition", "persist:superset");
+	webview.setAttribute("allowpopups", "");
+	webview.style.display = "flex";
+	webview.style.flex = "1";
+	webview.style.width = "100%";
+	webview.style.height = "100%";
+	webview.style.border = "none";
+
+	wrapper.appendChild(webview);
+
+	const entry: WebviewEntry = {
+		webview,
+		wrapper,
+		webContentsId: null,
+		faviconUrl: undefined,
+	};
+	webviews.set(paneId, entry);
+
+	if (overlayContainer) {
+		overlayContainer.appendChild(wrapper);
+	}
+
+	webview.src = sanitizeUrl(initialUrl);
+	attachEventHandlers(paneId, entry);
+
+	return entry;
+}
+
+export function destroyWebview(paneId: string): void {
+	const entry = webviews.get(paneId);
+	if (!entry) return;
+	entry.wrapper.remove();
+	webviews.delete(paneId);
+	electronTrpcClient.browser.unregister.mutate({ paneId }).catch(() => {});
+}
+
+
+// ---------------------------------------------------------------------------
+// Event handlers (permanent — not tied to React lifecycle)
+// ---------------------------------------------------------------------------
+
+function attachEventHandlers(paneId: string, entry: WebviewEntry): void {
+	const { webview } = entry;
+
+	const handleDomReady = () => {
+		const id = webview.getWebContentsId();
+		if (entry.webContentsId !== id) {
+			entry.webContentsId = id;
+			electronTrpcClient.browser.register
+				.mutate({ paneId, webContentsId: id })
+				.catch(() => {});
+		}
+	};
+
+	const handleDidStartLoading = () => {
+		const store = useTabsStore.getState();
+		store.updateBrowserLoading(paneId, true);
+		store.setBrowserError(paneId, null);
+		entry.faviconUrl = undefined;
+	};
+
+	const handleDidStopLoading = () => {
+		const store = useTabsStore.getState();
+		store.updateBrowserLoading(paneId, false);
+
+		const url = webview.getURL();
+		const title = webview.getTitle();
+		store.updateBrowserUrl(paneId, url ?? "", title ?? "", entry.faviconUrl);
+
+		if (url && url !== "about:blank") {
+			electronTrpcClient.browserHistory.upsert
+				.mutate({
+					url,
+					title: title ?? "",
+					faviconUrl: entry.faviconUrl ?? null,
+				})
+				.catch(() => {});
+		}
+	};
+
+	const handleDidNavigate = (e: Electron.DidNavigateEvent) => {
+		const store = useTabsStore.getState();
+		store.updateBrowserUrl(
+			paneId,
+			e.url ?? "",
+			webview.getTitle() ?? "",
+			entry.faviconUrl,
+		);
+		store.updateBrowserLoading(paneId, false);
+	};
+
+	const handleDidNavigateInPage = (e: Electron.DidNavigateInPageEvent) => {
+		const store = useTabsStore.getState();
+		store.updateBrowserUrl(
+			paneId,
+			e.url ?? "",
+			webview.getTitle() ?? "",
+			entry.faviconUrl,
+		);
+	};
+
+	const handlePageTitleUpdated = (e: Electron.PageTitleUpdatedEvent) => {
+		const store = useTabsStore.getState();
+		const currentUrl = store.panes[paneId]?.browser?.currentUrl ?? "";
+		store.updateBrowserUrl(paneId, currentUrl, e.title ?? "", entry.faviconUrl);
+	};
+
+	const handlePageFaviconUpdated = (e: Electron.PageFaviconUpdatedEvent) => {
+		const favicons = e.favicons;
+		if (favicons?.length > 0) {
+			entry.faviconUrl = favicons[0];
+			const store = useTabsStore.getState();
+			const browser = store.panes[paneId]?.browser;
+			const currentUrl = browser?.currentUrl ?? "";
+			const currentTitle =
+				browser?.history[browser?.historyIndex ?? 0]?.title ?? "";
+			store.updateBrowserUrl(paneId, currentUrl, currentTitle, favicons[0]);
+			if (currentUrl && currentUrl !== "about:blank") {
+				electronTrpcClient.browserHistory.upsert
+					.mutate({
+						url: currentUrl,
+						title: currentTitle,
+						faviconUrl: favicons[0],
+					})
+					.catch(() => {});
+			}
+		}
+	};
+
+	const handleDidFailLoad = (e: Electron.DidFailLoadEvent) => {
+		if (e.errorCode === -3) return; // ERR_ABORTED
+		const store = useTabsStore.getState();
+		store.updateBrowserLoading(paneId, false);
+		store.setBrowserError(paneId, {
+			code: e.errorCode ?? 0,
+			description: e.errorDescription ?? "",
+			url: e.validatedURL ?? "",
+		});
+	};
+
+	webview.addEventListener("dom-ready", handleDomReady);
+	webview.addEventListener("did-start-loading", handleDidStartLoading);
+	webview.addEventListener("did-stop-loading", handleDidStopLoading);
+	webview.addEventListener("did-navigate", handleDidNavigate as EventListener);
+	webview.addEventListener(
+		"did-navigate-in-page",
+		handleDidNavigateInPage as EventListener,
+	);
+	webview.addEventListener(
+		"page-title-updated",
+		handlePageTitleUpdated as EventListener,
+	);
+	webview.addEventListener(
+		"page-favicon-updated",
+		handlePageFaviconUpdated as EventListener,
+	);
+	webview.addEventListener("did-fail-load", handleDidFailLoad as EventListener);
+}
+
+// ---------------------------------------------------------------------------
+// Slot management (called by BrowserPane)
+// ---------------------------------------------------------------------------
+
+export function registerSlot(paneId: string, element: HTMLElement): void {
+	slots.set(paneId, element);
+	// syncPosition checks visibility and sets display accordingly
+	syncPosition(paneId);
+	notifySlotListeners();
+}
+
+export function unregisterSlot(paneId: string): void {
+	slots.delete(paneId);
+	const entry = webviews.get(paneId);
+	if (entry) {
+		entry.wrapper.style.display = "none";
+	}
+	notifySlotListeners();
+}
+
+function notifySlotListeners(): void {
+	for (const listener of slotListeners) listener();
+}
+
+// ---------------------------------------------------------------------------
+// Position sync
+// ---------------------------------------------------------------------------
+
+export function syncPosition(paneId: string): void {
+	const entry = webviews.get(paneId);
+	const slot = slots.get(paneId);
+	if (!entry || !slot) return;
+
+	// Hide the webview if the slot is not visible (e.g. tab is inactive and
+	// has `visibility: hidden` via the getTabsToRender CSS toggling).
+	// `visibility` is inherited, so this catches hidden ancestors too.
+	const isVisible = getComputedStyle(slot).visibility !== "hidden";
+	if (!isVisible) {
+		entry.wrapper.style.display = "none";
+		return;
+	}
+
+	entry.wrapper.style.display = "block";
+	const rect = slot.getBoundingClientRect();
+	const { wrapper } = entry;
+	wrapper.style.left = `${rect.left}px`;
+	wrapper.style.top = `${rect.top}px`;
+	wrapper.style.width = `${rect.width}px`;
+	wrapper.style.height = `${rect.height}px`;
+}
+
+export function syncAllPositions(): void {
+	for (const paneId of slots.keys()) {
+		syncPosition(paneId);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Navigation (called by BrowserPane via usePersistentWebview)
+// ---------------------------------------------------------------------------
+
+export function webviewNavigateTo(paneId: string, url: string): void {
+	const entry = webviews.get(paneId);
+	if (entry) entry.webview.loadURL(sanitizeUrl(url));
+}
+
+export function webviewReload(paneId: string): void {
+	const entry = webviews.get(paneId);
+	if (entry) entry.webview.reload();
+}
+
+export function webviewGoBack(paneId: string): void {
+	const store = useTabsStore.getState();
+	const url = store.navigateBrowserHistory(paneId, "back");
+	if (url) {
+		const entry = webviews.get(paneId);
+		if (entry) entry.webview.loadURL(sanitizeUrl(url));
+	}
+}
+
+export function webviewGoForward(paneId: string): void {
+	const store = useTabsStore.getState();
+	const url = store.navigateBrowserHistory(paneId, "forward");
+	if (url) {
+		const entry = webviews.get(paneId);
+		if (entry) entry.webview.loadURL(sanitizeUrl(url));
+	}
+}


### PR DESCRIPTION
## Summary
- replace the imperative dashboard webview wrapper manager with overlay-owned `PersistentBrowserSurface` components
- move blank/error browser chrome into those surfaces and reduce `BrowserPane` to toolbar + slot registration
- add a desktop design doc for the persistent browser overlay refactor

## Why
This is the cleaner version of the browser-tab persistence work: the overlay now owns page rendering and page chrome, while the store module only owns persistent webview identity and imperative browser actions.

This PR is intended to replace #2771.

## Validation
- `bunx @biomejs/biome@2.4.2 check apps/desktop/docs/PERSISTENT_BROWSER_OVERLAY_REFACTOR.md apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/WebviewOverlay/WebviewOverlay.tsx apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/WebviewOverlay/components/PersistentBrowserSurface/PersistentBrowserSurface.tsx apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/WebviewOverlay/components/PersistentBrowserSurface/index.ts apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/BrowserPane.tsx apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/index.tsx apps/desktop/src/renderer/stores/webview-overlay.ts`
- `bun test apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/utils/getTabsToRender/getTabsToRender.test.ts`
- `bunx tsc --noEmit -p apps/desktop/tsconfig.json --ignoreDeprecations 6.0`

## Notes
- I did not run the Electron app manually.
- Plain `tsc` is still blocked by the existing `baseUrl` deprecation in `apps/desktop/tsconfig.json`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist browser tabs by moving webview ownership into overlay-managed surfaces. Pages now keep state across tab and workspace switches with less flicker and simpler ownership.

- **Refactors**
  - Added `WebviewOverlay` with one `PersistentBrowserSurface` per browser pane; overlay owns the webview, blank/error chrome, and positioning (doc added in PERSISTENT_BROWSER_OVERLAY_REFACTOR.md).
  - Introduced `renderer/stores/webview-overlay.ts` to manage persistent webview identity and actions (`navigate`, history, `reload`) with slot registration and event-driven layout sync.
  - Simplified `BrowserPane` to a toolbar plus transparent slot via `usePersistentWebview`; UI chrome moved into overlay surfaces.
  - Updated `TabsContent` to keep inactive browser tabs mounted across workspaces; added `getTabsToRender` and tests to control which tabs render.

<sup>Written for commit b070ca9a3d19d76f1a54e96ed9b58cb5bc98ff2a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced persistent browser overlay architecture for improved webview stability across workspace and tab changes.
  * Enhanced multi-tab rendering with event-driven layout synchronization for browser surfaces.

* **Refactor**
  * Redesigned browser pane management to use slot-based registration instead of direct DOM ownership, improving performance and reliability.
  * Streamlined browser navigation and error handling through centralized overlay coordination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->