### PR TITLE
feat(desktop): add Enter key support for delete workspace modal

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/DeleteWorkspaceDialog/DeleteWorkspaceDialog.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/DeleteWorkspaceDialog/DeleteWorkspaceDialog.tsx
@@ -11,7 +11,7 @@ import { Checkbox } from "@superset/ui/checkbox";
 import { Label } from "@superset/ui/label";
 import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
-import { useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
 	useCloseWorkspace,
@@ -86,7 +86,7 @@ export function DeleteWorkspaceDialog({
 		: terminalCountData;
 	const isLoading = isLoadingGitStatus;
 
-	const handleClose = () => {
+	const handleClose = useCallback(() => {
 		onOpenChange(false);
 
 		toast.promise(closeWorkspace.mutateAsync({ id: workspaceId }), {
@@ -104,9 +104,9 @@ export function DeleteWorkspaceDialog({
 			error: (error) =>
 				error instanceof Error ? error.message : "Failed to hide",
 		});
-	};
+	}, [onOpenChange, closeWorkspace, workspaceId]);
 
-	const handleDelete = async () => {
+	const handleDelete = useCallback(async () => {
 		onOpenChange(false);
 
 		setDeleteLocalBranchSetting.mutate({
@@ -127,13 +127,57 @@ export function DeleteWorkspaceDialog({
 					force: true,
 				}),
 		});
-	};
+	}, [
+		onOpenChange,
+		setDeleteLocalBranchSetting,
+		deleteLocalBranchChecked,
+		workspaceName,
+		deleteWorkspace,
+		workspaceId,
+	]);
 
 	const canDelete = canDeleteData?.canDelete ?? true;
 	const reason = canDeleteData?.reason;
 	const hasChanges = canDeleteData?.hasChanges ?? false;
 	const hasUnpushedCommits = canDeleteData?.hasUnpushedCommits ?? false;
 	const hasWarnings = hasChanges || hasUnpushedCommits;
+
+	// Handle Enter key press to trigger delete/close action
+	useEffect(() => {
+		if (!open) return;
+
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (
+				event.key === "Enter" &&
+				!event.shiftKey &&
+				!event.metaKey &&
+				!event.ctrlKey &&
+				!event.altKey
+			) {
+				event.preventDefault();
+
+				if (isBranch) {
+					// For branch workspaces, Enter triggers close
+					handleClose();
+				} else {
+					// For regular workspaces, Enter triggers delete if enabled
+					if (canDelete && !isLoading) {
+						handleDelete();
+					}
+				}
+			}
+		};
+
+		window.addEventListener("keydown", handleKeyDown);
+		return () => window.removeEventListener("keydown", handleKeyDown);
+	}, [
+		open,
+		isBranch,
+		canDelete,
+		isLoading, // For branch workspaces, Enter triggers close
+		handleClose,
+		handleDelete,
+	]);
 
 	// For branch workspaces, use simplified dialog (only close option)
 	if (isBranch) {

--- a/bun.lock
+++ b/bun.lock
@@ -110,7 +110,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.43",
         "@ai-sdk/openai": "3.0.36",


### PR DESCRIPTION
## Summary
- Add Enter key support to confirm deletion in the delete workspace modal
- Pressing Enter now triggers the primary action (delete for regular workspaces, close for branch workspaces)
- Respects existing validation logic - won't delete if the delete button is disabled or still loading

## Implementation Details
- Added `useEffect` hook to listen for Enter key presses when modal is open
- Wrapped `handleClose` and `handleDelete` in `useCallback` to satisfy linter requirements
- Only responds to plain Enter (ignores Shift+Enter, Cmd+Enter, etc.)
- Automatically cleans up event listener when modal closes

## Test plan
- [x] Open desktop app
- [x] Click X on a workspace sidebar item
- [x] Press Enter when modal opens
- [x] Verify delete is triggered
- [x] Test with branch workspace (should trigger close instead)
- [x] Test when delete is disabled (should not trigger)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Enter key support to the delete workspace dialog to confirm the primary action quickly and consistently. Enter deletes regular workspaces (when allowed) and closes branch workspaces.

- **New Features**
  - Press Enter to confirm: delete (regular) or close (branch).
  - Respects disabled/loading states; won’t trigger when blocked.
  - Only plain Enter; ignores Shift/Cmd/Ctrl/Alt.
  - Event listener auto-cleans when the dialog closes.

- **Dependencies**
  - Bumped `@superset/desktop` to 1.3.2 in bun.lock.

<sup>Written for commit a6020347d35b580e5e1660a354ff45b8cf696a85. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Enter key support to the Delete Workspace dialog. Pressing Enter now closes branch workspaces or confirms deletion for other workspace types when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->