### PR TITLE
feat(desktop): add GitLab MR support to Reviews Tab

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/changes/utils/worktree-status-caches.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/utils/worktree-status-caches.ts
@@ -1,7 +1,11 @@
 import { clearGitHubCachesForWorktree } from "../../workspaces/utils/github";
+import { clearGitLabCachesForWorktree } from "../../workspaces/utils/gitlab";
+import { clearVCSProviderCache } from "../../workspaces/utils/vcs-provider";
 import { clearStatusCacheForWorktree } from "./status-cache";
 
 export function clearWorktreeStatusCaches(worktreePath: string): void {
 	clearGitHubCachesForWorktree(worktreePath);
+	clearGitLabCachesForWorktree(worktreePath);
+	clearVCSProviderCache(worktreePath);
 	clearStatusCacheForWorktree(worktreePath);
 }

--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts
@@ -23,6 +23,13 @@ import {
 	fetchGitHubPRStatus,
 	type PullRequestCommentsTarget,
 } from "../utils/github";
+import {
+	extractProjectPath,
+	fetchGitLabMRComments,
+	fetchGitLabMRStatus,
+	type MRCommentsTarget,
+} from "../utils/gitlab";
+import { detectVCSProvider } from "../utils/vcs-provider";
 
 const gitHubPRCommentsInputSchema = z.object({
 	workspaceId: z.string(),
@@ -62,6 +69,46 @@ function resolveCommentsPullRequestTarget({
 			upstreamUrl,
 			isFork: input.isFork ?? githubStatus?.isFork ?? false,
 		},
+	};
+}
+
+function resolveCommentsMRTarget({
+	input,
+	githubStatus,
+}: {
+	input: z.infer<typeof gitHubPRCommentsInputSchema>;
+	githubStatus: GitHubStatus | null | undefined;
+}): MRCommentsTarget | null {
+	const mrIid = input.prNumber ?? githubStatus?.pr?.number;
+	if (!mrIid) {
+		return null;
+	}
+
+	const repoUrl = input.repoUrl ?? githubStatus?.repoUrl;
+	if (!repoUrl) {
+		return null;
+	}
+
+	const upstreamUrl =
+		input.upstreamUrl ?? githubStatus?.upstreamUrl ?? githubStatus?.repoUrl;
+	if (!upstreamUrl) {
+		return null;
+	}
+
+	const projectPath = extractProjectPath(upstreamUrl);
+	if (!projectPath) {
+		return null;
+	}
+
+	return {
+		mrIid,
+		repoContext: {
+			repoUrl,
+			upstreamUrl,
+			isFork: input.isFork ?? githubStatus?.isFork ?? false,
+			projectPath,
+		},
+		mrWebUrl: githubStatus?.pr?.url,
 	};
 }
 
@@ -163,7 +210,11 @@ export const createGitStatusProcedures = () => {
 					return null;
 				}
 
-				const freshStatus = await fetchGitHubPRStatus(worktree.path);
+				const provider = await detectVCSProvider(worktree.path);
+				const freshStatus =
+					provider === "gitlab"
+						? await fetchGitLabMRStatus(worktree.path)
+						: await fetchGitHubPRStatus(worktree.path);
 
 				if (freshStatus) {
 					localDb
@@ -191,7 +242,18 @@ export const createGitStatusProcedures = () => {
 					return [];
 				}
 
+				const provider = await detectVCSProvider(worktree.path);
 				const cachedGitHubStatus = worktree.githubStatus ?? null;
+
+				if (provider === "gitlab") {
+					return fetchGitLabMRComments({
+						worktreePath: worktree.path,
+						mergeRequest: resolveCommentsMRTarget({
+							input,
+							githubStatus: cachedGitHubStatus,
+						}),
+					});
+				}
 
 				return fetchGitHubPRComments({
 					worktreePath: worktree.path,

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/gitlab/cache.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/gitlab/cache.ts
@@ -1,0 +1,88 @@
+import type { GitHubStatus, PullRequestComment } from "@superset/local-db";
+import {
+	type CachedResourceReadOptions,
+	type CacheState,
+	createCachedResource,
+} from "../github/cached-resource";
+import type { GitLabRepoContext } from "./types";
+
+const GITLAB_STATUS_CACHE_TTL_MS = 10_000;
+const GITLAB_MR_COMMENTS_CACHE_TTL_MS = 30_000;
+const GITLAB_REPO_CONTEXT_CACHE_TTL_MS = 300_000;
+
+const MAX_GITLAB_STATUS_CACHE_ENTRIES = 256;
+const MAX_GITLAB_MR_COMMENTS_CACHE_ENTRIES = 512;
+const MAX_GITLAB_REPO_CONTEXT_CACHE_ENTRIES = 256;
+
+const gitlabStatusResource = createCachedResource<GitHubStatus | null>({
+	ttlMs: GITLAB_STATUS_CACHE_TTL_MS,
+	maxEntries: MAX_GITLAB_STATUS_CACHE_ENTRIES,
+});
+
+const mrCommentsResource = createCachedResource<PullRequestComment[]>({
+	ttlMs: GITLAB_MR_COMMENTS_CACHE_TTL_MS,
+	maxEntries: MAX_GITLAB_MR_COMMENTS_CACHE_ENTRIES,
+});
+
+const repoContextResource = createCachedResource<GitLabRepoContext | null>({
+	ttlMs: GITLAB_REPO_CONTEXT_CACHE_TTL_MS,
+	maxEntries: MAX_GITLAB_REPO_CONTEXT_CACHE_ENTRIES,
+});
+
+export function readCachedGitLabStatus(
+	worktreePath: string,
+	load: () => Promise<GitHubStatus | null>,
+	options?: CachedResourceReadOptions<GitHubStatus | null>,
+): Promise<GitHubStatus | null> {
+	return gitlabStatusResource.read(worktreePath, load, {
+		...options,
+		shouldCache: options?.shouldCache ?? ((value) => value !== null),
+	});
+}
+
+export function makeMRCommentsCachePrefix(worktreePath: string): string {
+	return `${worktreePath}::gitlab-comments::`;
+}
+
+export function makeMRCommentsCacheKey({
+	worktreePath,
+	projectPath,
+	mrIid,
+}: {
+	worktreePath: string;
+	projectPath: string;
+	mrIid: number;
+}): string {
+	return `${makeMRCommentsCachePrefix(worktreePath)}${projectPath}#${mrIid}`;
+}
+
+export function getCachedMRCommentsState(
+	cacheKey: string,
+): CacheState<PullRequestComment[]> | null {
+	return mrCommentsResource.getState(cacheKey);
+}
+
+export function readCachedMRComments(
+	cacheKey: string,
+	load: () => Promise<PullRequestComment[]>,
+	options?: CachedResourceReadOptions<PullRequestComment[]>,
+): Promise<PullRequestComment[]> {
+	return mrCommentsResource.read(cacheKey, load, options);
+}
+
+export function readCachedRepoContext(
+	worktreePath: string,
+	load: () => Promise<GitLabRepoContext | null>,
+	options?: CachedResourceReadOptions<GitLabRepoContext | null>,
+): Promise<GitLabRepoContext | null> {
+	return repoContextResource.read(worktreePath, load, {
+		...options,
+		shouldCache: options?.shouldCache ?? ((value) => value !== null),
+	});
+}
+
+export function clearGitLabCachesForWorktree(worktreePath: string): void {
+	gitlabStatusResource.invalidate(worktreePath);
+	repoContextResource.invalidate(worktreePath);
+	mrCommentsResource.invalidatePrefix(makeMRCommentsCachePrefix(worktreePath));
+}

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/gitlab/comments.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/gitlab/comments.ts
@@ -1,0 +1,160 @@
+import type { PullRequestComment } from "@superset/local-db";
+import { execWithShellEnv } from "../shell-env";
+import { GLDiscussionSchema } from "./types";
+
+function parseTimestamp(value?: string): number | undefined {
+	if (!value) {
+		return undefined;
+	}
+	const timestamp = new Date(value).getTime();
+	return Number.isNaN(timestamp) ? undefined : timestamp;
+}
+
+function sortComments(comments: PullRequestComment[]): PullRequestComment[] {
+	return comments.sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0));
+}
+
+/**
+ * Fetches MR discussions from the GitLab API using `glab api`.
+ * Discussions contain threaded notes (comments), including inline diff comments
+ * and general MR comments.
+ */
+async function fetchMRDiscussions(
+	worktreePath: string,
+	projectPath: string,
+	mrIid: number,
+): Promise<PullRequestComment[]> {
+	const comments: PullRequestComment[] = [];
+	let page = 1;
+
+	while (true) {
+		let stdout: string;
+		try {
+			const result = await execWithShellEnv(
+				"glab",
+				[
+					"api",
+					`projects/${projectPath}/merge_requests/${mrIid}/discussions?per_page=100&page=${page}`,
+				],
+				{ cwd: worktreePath },
+			);
+			stdout = result.stdout;
+		} catch (error) {
+			console.warn("[GitLab] Failed to fetch MR discussions:", {
+				error,
+				projectPath,
+				mrIid,
+				page,
+			});
+			break;
+		}
+
+		const trimmed = stdout.trim();
+		if (!trimmed || trimmed === "null" || trimmed === "[]") {
+			break;
+		}
+
+		let raw: unknown;
+		try {
+			raw = JSON.parse(trimmed);
+		} catch (error) {
+			console.warn(
+				"[GitLab] Failed to parse MR discussions JSON:",
+				error instanceof Error ? error.message : String(error),
+			);
+			break;
+		}
+
+		if (!Array.isArray(raw) || raw.length === 0) {
+			break;
+		}
+
+		for (const rawDiscussion of raw) {
+			const result = GLDiscussionSchema.safeParse(rawDiscussion);
+			if (!result.success) {
+				continue;
+			}
+
+			const discussion = result.data;
+			// Determine resolution state from the first resolvable note
+			const firstResolvableNote = discussion.notes.find(
+				(note) => note.resolvable,
+			);
+			const isResolved = firstResolvableNote?.resolved ?? false;
+
+			for (const note of discussion.notes) {
+				// Skip system notes (merge events, label changes, etc.)
+				if (note.system) {
+					continue;
+				}
+
+				const body = note.body?.trim();
+				if (!body) {
+					continue;
+				}
+
+				const isDiffNote = note.type === "DiffNote";
+				const kind: PullRequestComment["kind"] = isDiffNote
+					? "review"
+					: "conversation";
+
+				comments.push({
+					id: `${kind}-${note.id}`,
+					authorLogin: note.author.username,
+					...(note.author.avatar_url
+						? { avatarUrl: note.author.avatar_url }
+						: {}),
+					body,
+					createdAt: parseTimestamp(note.created_at),
+					url: undefined, // Will be set by the caller with MR web_url
+					kind,
+					...(isDiffNote && note.position
+						? {
+								path: note.position.new_path ?? note.position.old_path,
+								line:
+									note.position.new_line ?? note.position.old_line ?? undefined,
+							}
+						: {}),
+					isResolved: note.resolvable ? isResolved : false,
+				});
+			}
+		}
+
+		// If we got fewer than 100 discussions, we've reached the end
+		if (raw.length < 100) {
+			break;
+		}
+
+		page++;
+	}
+
+	return sortComments(comments);
+}
+
+/**
+ * Fetches all MR comments (discussions) and returns them as PullRequestComment[].
+ * Sets comment URLs based on the MR web URL.
+ */
+export async function fetchMergeRequestComments({
+	worktreePath,
+	projectPath,
+	mrIid,
+	mrWebUrl,
+}: {
+	worktreePath: string;
+	projectPath: string;
+	mrIid: number;
+	mrWebUrl?: string;
+}): Promise<PullRequestComment[]> {
+	const comments = await fetchMRDiscussions(worktreePath, projectPath, mrIid);
+
+	// Set comment URLs
+	if (mrWebUrl) {
+		for (const comment of comments) {
+			const noteId = comment.id.replace(/^(review|conversation)-/, "");
+			comment.url = `${mrWebUrl}#note_${noteId}`;
+		}
+	}
+
+	return comments;
+}

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/gitlab/gitlab.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/gitlab/gitlab.ts
@@ -1,0 +1,207 @@
+import type { GitHubStatus, PullRequestComment } from "@superset/local-db";
+import { branchExistsOnRemote } from "../git";
+import { execGitWithShellPath } from "../git-client";
+import { parseUpstreamRef } from "../upstream-ref";
+import {
+	clearGitLabCachesForWorktree,
+	getCachedMRCommentsState,
+	makeMRCommentsCacheKey,
+	readCachedGitLabStatus,
+	readCachedMRComments,
+} from "./cache";
+import { fetchMergeRequestComments } from "./comments";
+import { getMRForBranch } from "./mr-resolution";
+import { getGitLabRepoContext } from "./repo-context";
+import type { GitLabRepoContext } from "./types";
+
+export interface MRCommentsTarget {
+	mrIid: number;
+	repoContext: Pick<
+		GitLabRepoContext,
+		"repoUrl" | "upstreamUrl" | "isFork" | "projectPath"
+	>;
+	mrWebUrl?: string;
+}
+
+export { clearGitLabCachesForWorktree };
+
+function getMRCommentsProjectPath(target: MRCommentsTarget): string | null {
+	return target.repoContext.projectPath || null;
+}
+
+async function resolveMRCommentsTarget(
+	worktreePath: string,
+): Promise<MRCommentsTarget | null> {
+	const repoContext = await getGitLabRepoContext(worktreePath, {
+		forceFresh: true,
+	});
+	if (!repoContext) {
+		return null;
+	}
+
+	const [branchResult, shaResult] = await Promise.all([
+		execGitWithShellPath(["rev-parse", "--abbrev-ref", "HEAD"], {
+			cwd: worktreePath,
+		}),
+		execGitWithShellPath(["rev-parse", "HEAD"], {
+			cwd: worktreePath,
+		}),
+	]);
+	const branchName = branchResult.stdout.trim();
+	const headSha = shaResult.stdout.trim();
+
+	const mrInfo = await getMRForBranch(
+		worktreePath,
+		branchName,
+		repoContext,
+		headSha,
+	);
+	if (!mrInfo) {
+		return null;
+	}
+
+	return {
+		mrIid: mrInfo.number,
+		repoContext,
+		mrWebUrl: mrInfo.url,
+	};
+}
+
+async function refreshGitLabMRStatus(
+	worktreePath: string,
+): Promise<GitHubStatus | null> {
+	try {
+		const repoContext = await getGitLabRepoContext(worktreePath, {
+			forceFresh: true,
+		});
+		if (!repoContext) {
+			return null;
+		}
+
+		const [branchResult, shaResult, upstreamResult] = await Promise.all([
+			execGitWithShellPath(["rev-parse", "--abbrev-ref", "HEAD"], {
+				cwd: worktreePath,
+			}),
+			execGitWithShellPath(["rev-parse", "HEAD"], { cwd: worktreePath }),
+			execGitWithShellPath(["rev-parse", "--abbrev-ref", "@{upstream}"], {
+				cwd: worktreePath,
+			}).catch(() => ({ stdout: "", stderr: "" })),
+		]);
+
+		const branchName = branchResult.stdout.trim();
+		const headSha = shaResult.stdout.trim();
+		const parsedUpstreamRef = parseUpstreamRef(upstreamResult.stdout.trim());
+		const trackingRemote = parsedUpstreamRef?.remoteName ?? "origin";
+		const remoteBranchName =
+			parsedUpstreamRef?.branchName?.trim() || branchName;
+
+		const mrInfo = await getMRForBranch(
+			worktreePath,
+			branchName,
+			repoContext,
+			headSha,
+		);
+
+		const branchCheck = await branchExistsOnRemote(
+			worktreePath,
+			remoteBranchName,
+			trackingRemote,
+		);
+
+		const result: GitHubStatus = {
+			pr: mrInfo,
+			repoUrl: repoContext.repoUrl,
+			upstreamUrl: repoContext.upstreamUrl,
+			isFork: repoContext.isFork,
+			branchExistsOnRemote: branchCheck.status === "exists",
+			previewUrl: undefined,
+			lastRefreshed: Date.now(),
+		};
+
+		return result;
+	} catch {
+		return null;
+	}
+}
+
+async function refreshGitLabMRComments({
+	worktreePath,
+	projectPath,
+	mrIid,
+	mrWebUrl,
+}: {
+	worktreePath: string;
+	projectPath: string;
+	mrIid: number;
+	mrWebUrl?: string;
+}): Promise<PullRequestComment[]> {
+	return fetchMergeRequestComments({
+		worktreePath,
+		projectPath,
+		mrIid,
+		mrWebUrl,
+	});
+}
+
+/**
+ * Fetches GitLab MR status for a worktree using the `glab` CLI.
+ * Returns null if `glab` is not installed, not authenticated, or on error.
+ */
+export async function fetchGitLabMRStatus(
+	worktreePath: string,
+): Promise<GitHubStatus | null> {
+	return readCachedGitLabStatus(worktreePath, () =>
+		refreshGitLabMRStatus(worktreePath),
+	);
+}
+
+export async function fetchGitLabMRComments({
+	worktreePath,
+	mergeRequest,
+}: {
+	worktreePath: string;
+	mergeRequest?: MRCommentsTarget | null;
+}): Promise<PullRequestComment[]> {
+	try {
+		const mrTarget =
+			mergeRequest ?? (await resolveMRCommentsTarget(worktreePath));
+		if (!mrTarget) {
+			return [];
+		}
+
+		const projectPath = getMRCommentsProjectPath(mrTarget);
+		if (!projectPath) {
+			return [];
+		}
+
+		const cacheKey = makeMRCommentsCacheKey({
+			worktreePath,
+			projectPath,
+			mrIid: mrTarget.mrIid,
+		});
+
+		try {
+			return await readCachedMRComments(cacheKey, () =>
+				refreshGitLabMRComments({
+					worktreePath,
+					projectPath,
+					mrIid: mrTarget.mrIid,
+					mrWebUrl: mrTarget.mrWebUrl,
+				}),
+			);
+		} catch (error) {
+			const cached = getCachedMRCommentsState(cacheKey);
+			if (cached) {
+				console.warn(
+					"[GitLab] Failed to refresh MR comments; using cached value:",
+					error,
+				);
+				return cached.value;
+			}
+
+			throw error;
+		}
+	} catch {
+		return [];
+	}
+}

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/gitlab/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/gitlab/index.ts
@@ -1,0 +1,12 @@
+export type { MRCommentsTarget } from "./gitlab";
+export {
+	clearGitLabCachesForWorktree,
+	fetchGitLabMRComments,
+	fetchGitLabMRStatus,
+} from "./gitlab";
+export {
+	extractProjectPath,
+	extractRawProjectPath,
+	getGitLabRepoContext,
+	normalizeGitLabUrl,
+} from "./repo-context";

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/gitlab/mr-resolution.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/gitlab/mr-resolution.ts
@@ -259,7 +259,11 @@ async function fetchPipelineChecks(
 
 		const rawJobs: unknown = JSON.parse(jobsStdout.trim());
 		if (!Array.isArray(rawJobs) || rawJobs.length === 0) {
-			return ["none", []];
+			// No jobs but pipeline exists — use pipeline-level status
+			const pipelineStatus = mapPipelineStatusToChecksStatus(
+				latestPipelineResult.data.status,
+			);
+			return [pipelineStatus, []];
 		}
 
 		const checks: CheckItem[] = [];
@@ -274,9 +278,8 @@ async function fetchPipelineChecks(
 
 			const job = jobResult.data;
 			const status = mapJobStatus(job.status);
-			const durationText = job.duration
-				? formatDuration(job.duration)
-				: undefined;
+			const durationText =
+				job.duration != null ? formatDuration(job.duration) : undefined;
 
 			checks.push({
 				name: job.name,
@@ -305,6 +308,22 @@ async function fetchPipelineChecks(
 			error instanceof Error ? error.message : String(error),
 		);
 		return ["none", []];
+	}
+}
+
+function mapPipelineStatusToChecksStatus(
+	status: string,
+): NonNullable<GitHubStatus["pr"]>["checksStatus"] {
+	switch (status) {
+		case "success":
+			return "success";
+		case "failed":
+			return "failure";
+		case "canceled":
+		case "skipped":
+			return "none";
+		default:
+			return "pending";
 	}
 }
 

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/gitlab/mr-resolution.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/gitlab/mr-resolution.ts
@@ -269,6 +269,7 @@ async function fetchPipelineChecks(
 		const checks: CheckItem[] = [];
 		let hasFailure = false;
 		let hasPending = false;
+		let hasSuccess = false;
 
 		for (const rawJob of rawJobs) {
 			const jobResult = GLJobSchema.safeParse(rawJob);
@@ -290,6 +291,7 @@ async function fetchPipelineChecks(
 
 			if (status === "failure") hasFailure = true;
 			if (status === "pending") hasPending = true;
+			if (status === "success") hasSuccess = true;
 		}
 
 		const checksStatus: NonNullable<GitHubStatus["pr"]>["checksStatus"] =
@@ -299,7 +301,9 @@ async function fetchPipelineChecks(
 					? "failure"
 					: hasPending
 						? "pending"
-						: "success";
+						: hasSuccess
+							? "success"
+							: "none";
 
 		return [checksStatus, checks];
 	} catch (error) {

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/gitlab/mr-resolution.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/gitlab/mr-resolution.ts
@@ -20,7 +20,11 @@ export async function getMRForBranch(
 	repoContext: GitLabRepoContext,
 	headSha?: string,
 ): Promise<GitHubStatus["pr"]> {
-	const byView = await getMRByView(worktreePath, localBranch);
+	const byView = await getMRByView(
+		worktreePath,
+		localBranch,
+		repoContext.projectPath,
+	);
 	if (byView) {
 		return byView;
 	}
@@ -31,6 +35,7 @@ export async function getMRForBranch(
 async function getMRByView(
 	worktreePath: string,
 	localBranch: string,
+	projectPath: string,
 ): Promise<GitHubStatus["pr"]> {
 	try {
 		const { stdout } = await execWithShellEnv(
@@ -49,7 +54,7 @@ async function getMRByView(
 			return null;
 		}
 
-		return formatMRData(worktreePath, data);
+		return formatMRData(worktreePath, data, projectPath);
 	} catch (error) {
 		if (
 			error instanceof Error &&
@@ -58,6 +63,10 @@ async function getMRByView(
 		) {
 			return null;
 		}
+		console.warn(
+			"[GitLab] getMRByView failed:",
+			error instanceof Error ? error.message : String(error),
+		);
 		return null;
 	}
 }
@@ -65,7 +74,7 @@ async function getMRByView(
 async function findMRBySourceBranch(
 	worktreePath: string,
 	localBranch: string,
-	_repoContext: GitLabRepoContext,
+	repoContext: GitLabRepoContext,
 	headSha?: string,
 ): Promise<GitHubStatus["pr"]> {
 	try {
@@ -91,8 +100,14 @@ async function findMRBySourceBranch(
 
 		const sorted = sortMRCandidates(candidates, headSha);
 		const best = sorted[0];
-		return best ? formatMRData(worktreePath, best) : null;
-	} catch {
+		return best
+			? formatMRData(worktreePath, best, repoContext.projectPath)
+			: null;
+	} catch (error) {
+		console.warn(
+			"[GitLab] findMRBySourceBranch failed:",
+			error instanceof Error ? error.message : String(error),
+		);
 		return null;
 	}
 }
@@ -135,15 +150,21 @@ function sortMRCandidates(
 async function formatMRData(
 	worktreePath: string,
 	data: GLMRResponse,
+	projectPath: string,
 ): Promise<NonNullable<GitHubStatus["pr"]>> {
-	const [reviewDecision, requestedReviewers] = await fetchApprovalStatus(
+	const [reviewDecision] = await fetchApprovalStatus(
 		worktreePath,
 		data.iid,
+		projectPath,
 	);
 	const [checksStatus, checks] = await fetchPipelineChecks(
 		worktreePath,
 		data.iid,
+		projectPath,
 	);
+
+	const requestedReviewers =
+		data.reviewers?.map((r) => r.username).filter(Boolean) ?? [];
 
 	return {
 		number: data.iid,
@@ -157,10 +178,7 @@ async function formatMRData(
 		reviewDecision,
 		checksStatus,
 		checks,
-		requestedReviewers:
-			requestedReviewers.length > 0
-				? requestedReviewers
-				: (data.reviewers?.map((r) => r.username).filter(Boolean) ?? []),
+		requestedReviewers,
 	};
 }
 
@@ -177,38 +195,42 @@ function mapMRState(
 async function fetchApprovalStatus(
 	worktreePath: string,
 	mrIid: number,
-): Promise<[NonNullable<GitHubStatus["pr"]>["reviewDecision"], string[]]> {
+	projectPath: string,
+): Promise<[NonNullable<GitHubStatus["pr"]>["reviewDecision"]]> {
 	try {
 		const { stdout } = await execWithShellEnv(
 			"glab",
-			["api", `merge_requests/${mrIid}/approvals`],
+			["api", `projects/${projectPath}/merge_requests/${mrIid}/approvals`],
 			{ cwd: worktreePath },
 		);
 
 		const raw: unknown = JSON.parse(stdout.trim());
 		const result = GLApprovalsResponseSchema.safeParse(raw);
 		if (!result.success) {
-			return ["pending", []];
+			return ["pending"];
 		}
 
-		const approvedBy =
-			result.data.approved_by?.map((a) => a.user.username) ?? [];
 		const decision = result.data.approved ? "approved" : "pending";
-		return [decision, approvedBy];
-	} catch {
-		return ["pending", []];
+		return [decision];
+	} catch (error) {
+		console.warn(
+			"[GitLab] fetchApprovalStatus failed:",
+			error instanceof Error ? error.message : String(error),
+		);
+		return ["pending"];
 	}
 }
 
 async function fetchPipelineChecks(
 	worktreePath: string,
 	mrIid: number,
+	projectPath: string,
 ): Promise<[NonNullable<GitHubStatus["pr"]>["checksStatus"], CheckItem[]]> {
 	try {
 		// Get pipelines for this MR
 		const { stdout: pipelinesStdout } = await execWithShellEnv(
 			"glab",
-			["api", `merge_requests/${mrIid}/pipelines`],
+			["api", `projects/${projectPath}/merge_requests/${mrIid}/pipelines`],
 			{ cwd: worktreePath },
 		);
 
@@ -230,7 +252,7 @@ async function fetchPipelineChecks(
 			"glab",
 			[
 				"api",
-				`pipelines/${pipelineId}/jobs?per_page=100&include_retried=false`,
+				`projects/${projectPath}/pipelines/${pipelineId}/jobs?per_page=100&include_retried=false`,
 			],
 			{ cwd: worktreePath },
 		);
@@ -277,7 +299,11 @@ async function fetchPipelineChecks(
 						: "success";
 
 		return [checksStatus, checks];
-	} catch {
+	} catch (error) {
+		console.warn(
+			"[GitLab] fetchPipelineChecks failed:",
+			error instanceof Error ? error.message : String(error),
+		);
 		return ["none", []];
 	}
 }

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/gitlab/mr-resolution.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/gitlab/mr-resolution.ts
@@ -247,18 +247,29 @@ async function fetchPipelineChecks(
 
 		const pipelineId = latestPipelineResult.data.id;
 
-		// Get jobs for the latest pipeline
-		const { stdout: jobsStdout } = await execWithShellEnv(
-			"glab",
-			[
-				"api",
-				`projects/${projectPath}/pipelines/${pipelineId}/jobs?per_page=100&include_retried=false`,
-			],
-			{ cwd: worktreePath },
-		);
+		// Get jobs for the latest pipeline (paginated)
+		const allRawJobs: unknown[] = [];
+		let jobPage = 1;
+		while (true) {
+			const { stdout: jobsStdout } = await execWithShellEnv(
+				"glab",
+				[
+					"api",
+					`projects/${projectPath}/pipelines/${pipelineId}/jobs?per_page=100&include_retried=false&page=${jobPage}`,
+				],
+				{ cwd: worktreePath },
+			);
 
-		const rawJobs: unknown = JSON.parse(jobsStdout.trim());
-		if (!Array.isArray(rawJobs) || rawJobs.length === 0) {
+			const pageJobs: unknown = JSON.parse(jobsStdout.trim());
+			if (!Array.isArray(pageJobs) || pageJobs.length === 0) {
+				break;
+			}
+			allRawJobs.push(...pageJobs);
+			if (pageJobs.length < 100) break;
+			jobPage++;
+		}
+
+		if (allRawJobs.length === 0) {
 			// No jobs but pipeline exists — use pipeline-level status
 			const pipelineStatus = mapPipelineStatusToChecksStatus(
 				latestPipelineResult.data.status,
@@ -271,7 +282,7 @@ async function fetchPipelineChecks(
 		let hasPending = false;
 		let hasSuccess = false;
 
-		for (const rawJob of rawJobs) {
+		for (const rawJob of allRawJobs) {
 			const jobResult = GLJobSchema.safeParse(rawJob);
 			if (!jobResult.success) {
 				continue;
@@ -347,12 +358,13 @@ function mapJobStatus(status: string): CheckItem["status"] {
 	}
 }
 
-function formatDuration(seconds: number): string {
-	if (seconds < 60) {
-		return `${Math.round(seconds)}s`;
+function formatDuration(rawSeconds: number): string {
+	const total = Math.round(rawSeconds);
+	if (total < 60) {
+		return `${total}s`;
 	}
-	const minutes = Math.floor(seconds / 60);
-	const remainingSeconds = Math.round(seconds % 60);
+	const minutes = Math.floor(total / 60);
+	const remainingSeconds = total % 60;
 	return remainingSeconds > 0
 		? `${minutes}m ${remainingSeconds}s`
 		: `${minutes}m`;

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/gitlab/mr-resolution.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/gitlab/mr-resolution.ts
@@ -1,0 +1,366 @@
+import type { CheckItem, GitHubStatus } from "@superset/local-db";
+import { execWithShellEnv } from "../shell-env";
+import {
+	type GitLabRepoContext,
+	GLApprovalsResponseSchema,
+	GLJobSchema,
+	type GLMRResponse,
+	GLMRResponseSchema,
+	GLPipelineSchema,
+} from "./types";
+
+/**
+ * Finds the MR associated with the current branch, trying multiple strategies:
+ * 1. `glab mr view` (uses current branch tracking)
+ * 2. `glab mr list --source-branch` (explicit branch search)
+ */
+export async function getMRForBranch(
+	worktreePath: string,
+	localBranch: string,
+	repoContext: GitLabRepoContext,
+	headSha?: string,
+): Promise<GitHubStatus["pr"]> {
+	const byView = await getMRByView(worktreePath, localBranch);
+	if (byView) {
+		return byView;
+	}
+
+	return findMRBySourceBranch(worktreePath, localBranch, repoContext, headSha);
+}
+
+async function getMRByView(
+	worktreePath: string,
+	localBranch: string,
+): Promise<GitHubStatus["pr"]> {
+	try {
+		const { stdout } = await execWithShellEnv(
+			"glab",
+			["mr", "view", "--output", "json"],
+			{ cwd: worktreePath },
+		);
+
+		const data = parseMRResponse(stdout);
+		if (!data) {
+			return null;
+		}
+
+		// Verify the MR's source branch matches
+		if (data.source_branch !== localBranch) {
+			return null;
+		}
+
+		return formatMRData(worktreePath, data);
+	} catch (error) {
+		if (
+			error instanceof Error &&
+			(error.message.toLowerCase().includes("no merge requests found") ||
+				error.message.toLowerCase().includes("no open merge request"))
+		) {
+			return null;
+		}
+		return null;
+	}
+}
+
+async function findMRBySourceBranch(
+	worktreePath: string,
+	localBranch: string,
+	_repoContext: GitLabRepoContext,
+	headSha?: string,
+): Promise<GitHubStatus["pr"]> {
+	try {
+		const { stdout } = await execWithShellEnv(
+			"glab",
+			[
+				"mr",
+				"list",
+				"--source-branch",
+				localBranch,
+				"--state",
+				"all",
+				"--output",
+				"json",
+			],
+			{ cwd: worktreePath },
+		);
+
+		const candidates = parseMRListResponse(stdout);
+		if (candidates.length === 0) {
+			return null;
+		}
+
+		const sorted = sortMRCandidates(candidates, headSha);
+		const best = sorted[0];
+		return best ? formatMRData(worktreePath, best) : null;
+	} catch {
+		return null;
+	}
+}
+
+function sortMRCandidates(
+	candidates: GLMRResponse[],
+	headSha?: string,
+): GLMRResponse[] {
+	const getStateRank = (mr: GLMRResponse): number => {
+		if (mr.state === "opened") return 2;
+		if (mr.state === "merged") return 1;
+		return 0;
+	};
+
+	return [...candidates].sort((a, b) => {
+		// Prefer SHA match
+		const aMatchesSha = Number(Boolean(headSha && a.sha === headSha));
+		const bMatchesSha = Number(Boolean(headSha && b.sha === headSha));
+		if (aMatchesSha !== bMatchesSha) {
+			return bMatchesSha - aMatchesSha;
+		}
+
+		// Prefer open > merged > closed
+		const stateDelta = getStateRank(b) - getStateRank(a);
+		if (stateDelta !== 0) {
+			return stateDelta;
+		}
+
+		// Most recently merged first
+		const aMergedAt = a.merged_at ? Date.parse(a.merged_at) : 0;
+		const bMergedAt = b.merged_at ? Date.parse(b.merged_at) : 0;
+		if (aMergedAt !== bMergedAt) {
+			return bMergedAt - aMergedAt;
+		}
+
+		return b.iid - a.iid;
+	});
+}
+
+async function formatMRData(
+	worktreePath: string,
+	data: GLMRResponse,
+): Promise<NonNullable<GitHubStatus["pr"]>> {
+	const [reviewDecision, requestedReviewers] = await fetchApprovalStatus(
+		worktreePath,
+		data.iid,
+	);
+	const [checksStatus, checks] = await fetchPipelineChecks(
+		worktreePath,
+		data.iid,
+	);
+
+	return {
+		number: data.iid,
+		title: data.title,
+		url: data.web_url,
+		state: mapMRState(data.state, data.draft),
+		mergedAt: data.merged_at ? new Date(data.merged_at).getTime() : undefined,
+		additions: data.diff_stats?.additions ?? 0,
+		deletions: data.diff_stats?.deletions ?? 0,
+		headRefName: data.source_branch,
+		reviewDecision,
+		checksStatus,
+		checks,
+		requestedReviewers:
+			requestedReviewers.length > 0
+				? requestedReviewers
+				: (data.reviewers?.map((r) => r.username).filter(Boolean) ?? []),
+	};
+}
+
+function mapMRState(
+	state: GLMRResponse["state"],
+	isDraft: boolean,
+): NonNullable<GitHubStatus["pr"]>["state"] {
+	if (state === "merged") return "merged";
+	if (state === "closed" || state === "locked") return "closed";
+	if (isDraft) return "draft";
+	return "open";
+}
+
+async function fetchApprovalStatus(
+	worktreePath: string,
+	mrIid: number,
+): Promise<[NonNullable<GitHubStatus["pr"]>["reviewDecision"], string[]]> {
+	try {
+		const { stdout } = await execWithShellEnv(
+			"glab",
+			["api", `merge_requests/${mrIid}/approvals`],
+			{ cwd: worktreePath },
+		);
+
+		const raw: unknown = JSON.parse(stdout.trim());
+		const result = GLApprovalsResponseSchema.safeParse(raw);
+		if (!result.success) {
+			return ["pending", []];
+		}
+
+		const approvedBy =
+			result.data.approved_by?.map((a) => a.user.username) ?? [];
+		const decision = result.data.approved ? "approved" : "pending";
+		return [decision, approvedBy];
+	} catch {
+		return ["pending", []];
+	}
+}
+
+async function fetchPipelineChecks(
+	worktreePath: string,
+	mrIid: number,
+): Promise<[NonNullable<GitHubStatus["pr"]>["checksStatus"], CheckItem[]]> {
+	try {
+		// Get pipelines for this MR
+		const { stdout: pipelinesStdout } = await execWithShellEnv(
+			"glab",
+			["api", `merge_requests/${mrIid}/pipelines`],
+			{ cwd: worktreePath },
+		);
+
+		const rawPipelines: unknown = JSON.parse(pipelinesStdout.trim());
+		if (!Array.isArray(rawPipelines) || rawPipelines.length === 0) {
+			return ["none", []];
+		}
+
+		// Use the latest pipeline
+		const latestPipelineResult = GLPipelineSchema.safeParse(rawPipelines[0]);
+		if (!latestPipelineResult.success) {
+			return ["none", []];
+		}
+
+		const pipelineId = latestPipelineResult.data.id;
+
+		// Get jobs for the latest pipeline
+		const { stdout: jobsStdout } = await execWithShellEnv(
+			"glab",
+			[
+				"api",
+				`pipelines/${pipelineId}/jobs?per_page=100&include_retried=false`,
+			],
+			{ cwd: worktreePath },
+		);
+
+		const rawJobs: unknown = JSON.parse(jobsStdout.trim());
+		if (!Array.isArray(rawJobs) || rawJobs.length === 0) {
+			return ["none", []];
+		}
+
+		const checks: CheckItem[] = [];
+		let hasFailure = false;
+		let hasPending = false;
+
+		for (const rawJob of rawJobs) {
+			const jobResult = GLJobSchema.safeParse(rawJob);
+			if (!jobResult.success) {
+				continue;
+			}
+
+			const job = jobResult.data;
+			const status = mapJobStatus(job.status);
+			const durationText = job.duration
+				? formatDuration(job.duration)
+				: undefined;
+
+			checks.push({
+				name: job.name,
+				status,
+				url: job.web_url,
+				durationText,
+			});
+
+			if (status === "failure") hasFailure = true;
+			if (status === "pending") hasPending = true;
+		}
+
+		const checksStatus: NonNullable<GitHubStatus["pr"]>["checksStatus"] =
+			checks.length === 0
+				? "none"
+				: hasFailure
+					? "failure"
+					: hasPending
+						? "pending"
+						: "success";
+
+		return [checksStatus, checks];
+	} catch {
+		return ["none", []];
+	}
+}
+
+function mapJobStatus(status: string): CheckItem["status"] {
+	switch (status) {
+		case "success":
+			return "success";
+		case "failed":
+			return "failure";
+		case "canceled":
+			return "cancelled";
+		case "skipped":
+		case "manual":
+			return "skipped";
+		default:
+			return "pending";
+	}
+}
+
+function formatDuration(seconds: number): string {
+	if (seconds < 60) {
+		return `${Math.round(seconds)}s`;
+	}
+	const minutes = Math.floor(seconds / 60);
+	const remainingSeconds = Math.round(seconds % 60);
+	return remainingSeconds > 0
+		? `${minutes}m ${remainingSeconds}s`
+		: `${minutes}m`;
+}
+
+function parseMRResponse(stdout: string): GLMRResponse | null {
+	const trimmed = stdout.trim();
+	if (!trimmed || trimmed === "null") {
+		return null;
+	}
+
+	let raw: unknown;
+	try {
+		raw = JSON.parse(trimmed);
+	} catch (error) {
+		console.warn(
+			"[GitLab] Failed to parse MR response JSON:",
+			error instanceof Error ? error.message : String(error),
+		);
+		return null;
+	}
+
+	const result = GLMRResponseSchema.safeParse(raw);
+	if (!result.success) {
+		console.error("[GitLab] MR schema validation failed:", result.error);
+		return null;
+	}
+	return result.data;
+}
+
+function parseMRListResponse(stdout: string): GLMRResponse[] {
+	const trimmed = stdout.trim();
+	if (!trimmed || trimmed === "null" || trimmed === "[]") {
+		return [];
+	}
+
+	let raw: unknown;
+	try {
+		raw = JSON.parse(trimmed);
+	} catch (error) {
+		console.warn(
+			"[GitLab] Failed to parse MR list response JSON:",
+			error instanceof Error ? error.message : String(error),
+		);
+		return [];
+	}
+
+	if (!Array.isArray(raw)) {
+		return [];
+	}
+
+	const parsed: GLMRResponse[] = [];
+	for (const item of raw) {
+		const result = GLMRResponseSchema.safeParse(item);
+		if (result.success) {
+			parsed.push(result.data);
+		}
+	}
+	return parsed;
+}

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/gitlab/repo-context.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/gitlab/repo-context.ts
@@ -110,7 +110,12 @@ async function refreshRepoContext(
 		// Check if there's an upstream remote (fork setup)
 		const upstreamUrl = await getUpstreamRemoteUrl(worktreePath);
 
-		if (upstreamUrl && upstreamUrl !== originUrl) {
+		// Compare ignoring protocol differences (http vs https)
+		const isSameRepo =
+			upstreamUrl &&
+			upstreamUrl.replace(/^https?:\/\//, "") ===
+				originUrl.replace(/^https?:\/\//, "");
+		if (upstreamUrl && !isSameRepo) {
 			const upstreamProjectPath = extractProjectPath(upstreamUrl);
 			return {
 				repoUrl: originUrl,

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/gitlab/repo-context.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/gitlab/repo-context.ts
@@ -1,0 +1,136 @@
+import { execGitWithShellPath } from "../git-client";
+import { readCachedRepoContext } from "./cache";
+import type { GitLabRepoContext } from "./types";
+
+/**
+ * Normalizes a GitLab remote URL to a canonical HTTPS URL.
+ * Handles SSH, HTTPS, and self-hosted variants.
+ */
+export function normalizeGitLabUrl(remoteUrl: string): string | null {
+	const trimmed = remoteUrl.trim();
+
+	// SSH: git@gitlab.com:group/project.git
+	const sshMatch = trimmed.match(/^git@(?<host>[^:]+):(?<path>.+?)(?:\.git)?$/);
+	if (sshMatch?.groups) {
+		return `https://${sshMatch.groups.host}/${sshMatch.groups.path}`;
+	}
+
+	// SSH with protocol: ssh://git@gitlab.com/group/project.git
+	const sshProtoMatch = trimmed.match(
+		/^ssh:\/\/git@(?<host>[^/]+)\/(?<path>.+?)(?:\.git)?$/,
+	);
+	if (sshProtoMatch?.groups) {
+		return `https://${sshProtoMatch.groups.host}/${sshProtoMatch.groups.path}`;
+	}
+
+	// HTTPS: https://gitlab.com/group/project.git
+	const httpsMatch = trimmed.match(
+		/^https?:\/\/(?<host>[^/]+)\/(?<path>.+?)(?:\.git)?\/?$/,
+	);
+	if (httpsMatch?.groups) {
+		return `https://${httpsMatch.groups.host}/${httpsMatch.groups.path}`;
+	}
+
+	return null;
+}
+
+/**
+ * Extracts the project path from a normalized GitLab URL.
+ * Returns the path URL-encoded for use in GitLab API calls.
+ */
+export function extractProjectPath(normalizedUrl: string): string | null {
+	try {
+		const path = new URL(normalizedUrl).pathname.slice(1);
+		return path ? encodeURIComponent(path) : null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Extracts the raw (non-encoded) project path from a normalized GitLab URL.
+ */
+export function extractRawProjectPath(normalizedUrl: string): string | null {
+	try {
+		const path = new URL(normalizedUrl).pathname.slice(1);
+		return path || null;
+	} catch {
+		return null;
+	}
+}
+
+async function getOriginUrl(worktreePath: string): Promise<string | null> {
+	try {
+		const { stdout } = await execGitWithShellPath(
+			["remote", "get-url", "origin"],
+			{ cwd: worktreePath },
+		);
+		return normalizeGitLabUrl(stdout.trim());
+	} catch {
+		return null;
+	}
+}
+
+async function getUpstreamRemoteUrl(
+	worktreePath: string,
+): Promise<string | null> {
+	try {
+		const { stdout } = await execGitWithShellPath(
+			["remote", "get-url", "upstream"],
+			{ cwd: worktreePath },
+		);
+		return normalizeGitLabUrl(stdout.trim());
+	} catch {
+		return null;
+	}
+}
+
+async function refreshRepoContext(
+	worktreePath: string,
+): Promise<GitLabRepoContext | null> {
+	try {
+		const originUrl = await getOriginUrl(worktreePath);
+		if (!originUrl) {
+			return null;
+		}
+
+		const projectPath = extractProjectPath(originUrl);
+		if (!projectPath) {
+			return null;
+		}
+
+		// Check if there's an upstream remote (fork setup)
+		const upstreamUrl = await getUpstreamRemoteUrl(worktreePath);
+
+		if (upstreamUrl && upstreamUrl !== originUrl) {
+			const upstreamProjectPath = extractProjectPath(upstreamUrl);
+			return {
+				repoUrl: originUrl,
+				upstreamUrl,
+				isFork: true,
+				projectPath: upstreamProjectPath ?? projectPath,
+			};
+		}
+
+		return {
+			repoUrl: originUrl,
+			upstreamUrl: originUrl,
+			isFork: false,
+			projectPath,
+		};
+	} catch (error) {
+		console.warn("[GitLab] Failed to refresh repo context:", error);
+		return null;
+	}
+}
+
+export async function getGitLabRepoContext(
+	worktreePath: string,
+	options?: { forceFresh?: boolean },
+): Promise<GitLabRepoContext | null> {
+	return readCachedRepoContext(
+		worktreePath,
+		() => refreshRepoContext(worktreePath),
+		{ forceFresh: options?.forceFresh },
+	);
+}

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/gitlab/repo-context.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/gitlab/repo-context.ts
@@ -3,8 +3,8 @@ import { readCachedRepoContext } from "./cache";
 import type { GitLabRepoContext } from "./types";
 
 /**
- * Normalizes a GitLab remote URL to a canonical HTTPS URL.
- * Handles SSH, HTTPS, and self-hosted variants.
+ * Normalizes a GitLab remote URL to a canonical URL.
+ * SSH URLs are converted to HTTPS. HTTP/HTTPS URLs preserve their original protocol.
  */
 export function normalizeGitLabUrl(remoteUrl: string): string | null {
 	const trimmed = remoteUrl.trim();
@@ -23,12 +23,12 @@ export function normalizeGitLabUrl(remoteUrl: string): string | null {
 		return `https://${sshProtoMatch.groups.host}/${sshProtoMatch.groups.path}`;
 	}
 
-	// HTTPS: https://gitlab.com/group/project.git
+	// HTTPS/HTTP: https://gitlab.com/group/project.git or http://gitlab.example.com/group/project.git
 	const httpsMatch = trimmed.match(
-		/^https?:\/\/(?<host>[^/]+)\/(?<path>.+?)(?:\.git)?\/?$/,
+		/^(?<protocol>https?:\/\/)(?<host>[^/]+)\/(?<path>.+?)(?:\.git)?\/?$/,
 	);
 	if (httpsMatch?.groups) {
-		return `https://${httpsMatch.groups.host}/${httpsMatch.groups.path}`;
+		return `${httpsMatch.groups.protocol}${httpsMatch.groups.host}/${httpsMatch.groups.path}`;
 	}
 
 	return null;
@@ -66,7 +66,11 @@ async function getOriginUrl(worktreePath: string): Promise<string | null> {
 			{ cwd: worktreePath },
 		);
 		return normalizeGitLabUrl(stdout.trim());
-	} catch {
+	} catch (error) {
+		console.warn(
+			"[GitLab] getOriginUrl failed:",
+			error instanceof Error ? error.message : String(error),
+		);
 		return null;
 	}
 }
@@ -80,7 +84,11 @@ async function getUpstreamRemoteUrl(
 			{ cwd: worktreePath },
 		);
 		return normalizeGitLabUrl(stdout.trim());
-	} catch {
+	} catch (error) {
+		console.warn(
+			"[GitLab] getUpstreamRemoteUrl failed:",
+			error instanceof Error ? error.message : String(error),
+		);
 		return null;
 	}
 }

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/gitlab/types.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/gitlab/types.ts
@@ -1,0 +1,145 @@
+import { z } from "zod";
+
+// ── Repo Context ──
+
+export const GLRepoResponseSchema = z.object({
+	full_path: z.string().optional(),
+	path_with_namespace: z.string().optional(),
+	http_url_to_repo: z.string().optional(),
+	web_url: z.string().optional(),
+	forked_from_project: z
+		.object({
+			path_with_namespace: z.string().optional(),
+			http_url_to_repo: z.string().optional(),
+			web_url: z.string().optional(),
+		})
+		.nullable()
+		.optional(),
+});
+
+export interface GitLabRepoContext {
+	repoUrl: string;
+	upstreamUrl: string;
+	isFork: boolean;
+	projectPath: string; // URL-encoded project path for API calls
+}
+
+// ── Merge Request ──
+
+export const GLMRResponseSchema = z.object({
+	iid: z.number(),
+	title: z.string(),
+	web_url: z.string(),
+	state: z.enum(["opened", "closed", "merged", "locked"]),
+	draft: z.boolean().optional().default(false),
+	merged_at: z.string().nullable().optional(),
+	source_branch: z.string(),
+	sha: z.string(),
+	diff_stats: z
+		.object({
+			additions: z.number(),
+			deletions: z.number(),
+		})
+		.optional(),
+	source_project_id: z.number().optional(),
+	target_project_id: z.number().optional(),
+	reviewers: z
+		.array(
+			z.object({
+				username: z.string(),
+			}),
+		)
+		.nullable()
+		.optional(),
+});
+
+export type GLMRResponse = z.infer<typeof GLMRResponseSchema>;
+
+// ── Approvals ──
+
+export const GLApprovalsResponseSchema = z.object({
+	approved: z.boolean(),
+	approvals_required: z.number().optional(),
+	approvals_left: z.number().optional(),
+	approved_by: z
+		.array(
+			z.object({
+				user: z.object({
+					username: z.string(),
+					avatar_url: z.string().optional(),
+				}),
+			}),
+		)
+		.optional(),
+});
+
+// ── Pipeline & Jobs ──
+
+export const GLPipelineSchema = z.object({
+	id: z.number(),
+	status: z.enum([
+		"created",
+		"waiting_for_resource",
+		"preparing",
+		"pending",
+		"running",
+		"success",
+		"failed",
+		"canceled",
+		"skipped",
+		"manual",
+		"scheduled",
+	]),
+	web_url: z.string(),
+	ref: z.string().optional(),
+	sha: z.string().optional(),
+});
+
+export const GLJobSchema = z.object({
+	id: z.number(),
+	name: z.string(),
+	status: z.enum([
+		"created",
+		"pending",
+		"running",
+		"failed",
+		"success",
+		"canceled",
+		"skipped",
+		"manual",
+	]),
+	web_url: z.string(),
+	duration: z.number().nullable().optional(),
+	stage: z.string().optional(),
+});
+
+// ── Notes & Discussions ──
+
+export const GLNoteAuthorSchema = z.object({
+	username: z.string(),
+	avatar_url: z.string().optional(),
+});
+
+export const GLNotePositionSchema = z.object({
+	new_path: z.string().optional(),
+	new_line: z.number().nullable().optional(),
+	old_path: z.string().optional(),
+	old_line: z.number().nullable().optional(),
+});
+
+export const GLNoteSchema = z.object({
+	id: z.number(),
+	body: z.string(),
+	author: GLNoteAuthorSchema,
+	created_at: z.string(),
+	system: z.boolean(),
+	resolvable: z.boolean().optional(),
+	resolved: z.boolean().optional(),
+	type: z.string().nullable().optional(),
+	position: GLNotePositionSchema.nullable().optional(),
+});
+
+export const GLDiscussionSchema = z.object({
+	id: z.string(),
+	notes: z.array(GLNoteSchema),
+});

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/vcs-provider.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/vcs-provider.ts
@@ -20,8 +20,8 @@ function extractHostname(remoteUrl: string): string | null {
 		return sshMatch[1];
 	}
 
-	// SSH with protocol: ssh://git@host/path
-	const sshProtoMatch = trimmed.match(/^ssh:\/\/git@([^/]+)/);
+	// SSH with protocol: ssh://git@host/path or ssh://git@host:port/path
+	const sshProtoMatch = trimmed.match(/^ssh:\/\/git@([^/:]+)/);
 	if (sshProtoMatch) {
 		return sshProtoMatch[1];
 	}

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/vcs-provider.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/vcs-provider.ts
@@ -1,0 +1,78 @@
+import { execGitWithShellPath } from "./git-client";
+import { createCachedResource } from "./github/cached-resource";
+
+export type VCSProvider = "github" | "gitlab" | "unknown";
+
+const VCS_PROVIDER_CACHE_TTL_MS = 300_000; // 5 minutes
+const MAX_VCS_PROVIDER_CACHE_ENTRIES = 256;
+
+const vcsProviderResource = createCachedResource<VCSProvider>({
+	ttlMs: VCS_PROVIDER_CACHE_TTL_MS,
+	maxEntries: MAX_VCS_PROVIDER_CACHE_ENTRIES,
+});
+
+export function detectProviderFromUrl(remoteUrl: string): VCSProvider {
+	const lower = remoteUrl.toLowerCase();
+
+	if (
+		lower.includes("github.com") ||
+		lower.includes("github.com:") ||
+		lower.includes("github.com/")
+	) {
+		return "github";
+	}
+
+	if (
+		lower.includes("gitlab.com") ||
+		lower.includes("gitlab.com:") ||
+		lower.includes("gitlab.com/")
+	) {
+		return "gitlab";
+	}
+
+	return "unknown";
+}
+
+async function resolveVCSProvider(worktreePath: string): Promise<VCSProvider> {
+	try {
+		const { stdout } = await execGitWithShellPath(
+			["remote", "get-url", "origin"],
+			{ cwd: worktreePath },
+		);
+		const remoteUrl = stdout.trim();
+		if (!remoteUrl) {
+			return "unknown";
+		}
+
+		const provider = detectProviderFromUrl(remoteUrl);
+		if (provider !== "unknown") {
+			return provider;
+		}
+
+		// For self-hosted instances, try glab to detect GitLab
+		try {
+			const { execWithShellEnv } = await import("./shell-env");
+			await execWithShellEnv("glab", ["repo", "view", "--output", "json"], {
+				cwd: worktreePath,
+			});
+			return "gitlab";
+		} catch {
+			// glab failed — not GitLab, fall back to GitHub (backwards compat)
+			return "github";
+		}
+	} catch {
+		return "unknown";
+	}
+}
+
+export async function detectVCSProvider(
+	worktreePath: string,
+): Promise<VCSProvider> {
+	return vcsProviderResource.read(worktreePath, () =>
+		resolveVCSProvider(worktreePath),
+	);
+}
+
+export function clearVCSProviderCache(worktreePath: string): void {
+	vcsProviderResource.invalidate(worktreePath);
+}

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/vcs-provider.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/vcs-provider.ts
@@ -11,22 +11,41 @@ const vcsProviderResource = createCachedResource<VCSProvider>({
 	maxEntries: MAX_VCS_PROVIDER_CACHE_ENTRIES,
 });
 
-export function detectProviderFromUrl(remoteUrl: string): VCSProvider {
-	const lower = remoteUrl.toLowerCase();
+function extractHostname(remoteUrl: string): string | null {
+	const trimmed = remoteUrl.trim().toLowerCase();
 
-	if (
-		lower.includes("github.com") ||
-		lower.includes("github.com:") ||
-		lower.includes("github.com/")
-	) {
+	// SSH: git@host:path
+	const sshMatch = trimmed.match(/^git@([^:]+):/);
+	if (sshMatch) {
+		return sshMatch[1];
+	}
+
+	// SSH with protocol: ssh://git@host/path
+	const sshProtoMatch = trimmed.match(/^ssh:\/\/git@([^/]+)/);
+	if (sshProtoMatch) {
+		return sshProtoMatch[1];
+	}
+
+	// HTTPS/HTTP: https://host/path
+	try {
+		const url = new URL(trimmed);
+		return url.hostname;
+	} catch {
+		return null;
+	}
+}
+
+export function detectProviderFromUrl(remoteUrl: string): VCSProvider {
+	const hostname = extractHostname(remoteUrl);
+	if (!hostname) {
+		return "unknown";
+	}
+
+	if (hostname === "github.com" || hostname.endsWith(".github.com")) {
 		return "github";
 	}
 
-	if (
-		lower.includes("gitlab.com") ||
-		lower.includes("gitlab.com:") ||
-		lower.includes("gitlab.com/")
-	) {
+	if (hostname === "gitlab.com" || hostname.endsWith(".gitlab.com")) {
 		return "gitlab";
 	}
 
@@ -57,8 +76,8 @@ async function resolveVCSProvider(worktreePath: string): Promise<VCSProvider> {
 			});
 			return "gitlab";
 		} catch {
-			// glab failed — not GitLab, fall back to GitHub (backwards compat)
-			return "github";
+			// glab failed — not GitLab, provider is unknown
+			return "unknown";
 		}
 	} catch {
 		return "unknown";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/ReviewPanel.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/ReviewPanel.tsx
@@ -144,7 +144,8 @@ export function ReviewPanel({
 	if (!pr) {
 		return (
 			<div className="flex h-full items-center justify-center px-4 text-center text-sm text-muted-foreground">
-				Open a pull request to view review status, checks, and comments.
+				Open a pull request or merge request to view review status, checks, and
+				comments.
 			</div>
 		);
 	}
@@ -246,7 +247,7 @@ export function ReviewPanel({
 								target="_blank"
 								rel="noopener noreferrer"
 								className="inline-flex size-4 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-								aria-label="Open comment on GitHub"
+								aria-label="Open comment"
 							>
 								<LuArrowUpRight className="size-3" />
 							</a>


### PR DESCRIPTION
## Summary
- Auto-detect GitHub vs GitLab from git remote URL (new `vcs-provider.ts`)
- Add full GitLab MR support using `glab` CLI, mirroring the existing `gh` CLI integration
- Fetch MR status, approvals, pipeline jobs/checks, and discussion comments
- Map GitLab concepts to existing provider-agnostic types (`GitHubStatus`, `PullRequestComment`, `CheckItem`)
- Update Review tab UI text to be provider-neutral ("Open a pull request or merge request...")

## How it works
- New `utils/gitlab/` module mirrors `utils/github/` with 7 files: types, repo-context, mr-resolution, comments, cache, gitlab orchestrator, and barrel exports
- tRPC procedures (`getGitHubStatus`, `getGitHubPRComments`) are now polymorphic — they detect the provider and route to the correct implementation internally
- No UI changes needed beyond fixing two hardcoded "GitHub" strings — the ReviewPanel already uses provider-agnostic types

## GitLab → Internal Type Mapping
| GitLab | Internal | Notes |
|--------|----------|-------|
| MR `iid` | `pr.number` | Direct |
| MR approvals | `pr.reviewDecision` | approved→"approved", else→"pending" |
| Pipeline jobs | `pr.checks` | Each job → CheckItem |
| Discussions | PullRequestComment[] | DiffNote→"review", other→"conversation" |
| Discussion `resolved` | `isResolved` | Direct |

## Test plan
- [ ] Clone a GitLab repo, create a branch with an MR
- [ ] Ensure `glab auth status` shows authenticated
- [ ] Open workspace in desktop app → Reviews tab should show MR title, approval status, pipeline checks, and comments
- [ ] Verify GitHub repos still work as before (no regression)
- [ ] Verify `glab` not installed returns null gracefully (same as `gh` not installed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add GitLab merge request support to the Reviews tab with automatic GitHub/GitLab detection. Shows MR status, approvals, checks, and comments via `glab`, with provider‑neutral UI and support for self‑hosted GitLab.

- **Bug Fixes**
  - Use pipeline-level status when no jobs are available or parseable.
  - Preserve check duration when it is 0.
  - Compare URLs ignoring http/https when detecting forks.
  - Handle SSH port in hostname extraction for provider detection.
  - Treat pipelines with only cancelled/skipped/manual jobs as "none" (not "success").
  - Paginate pipeline jobs to include jobs beyond the first 100.
  - Round seconds before formatting durations to avoid outputs like "1m 60s".

- **Migration**
  - Install and authenticate `glab` for GitLab repos (verify with `glab auth status`). Repos without `glab` return null gracefully.

<sup>Written for commit ef00ad49168315ef63a21a5f78436e1d20416413. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitLab merge request support: MR status, discussions/comments, approvals, pipelines/checks, and repo-context resolution.
  * Per-worktree VCS provider detection (GitHub/GitLab/unknown) with caching and dedicated MR/comments/status caches.

* **Bug Fixes / Chores**
  * Clearing worktree status now also invalidates GitLab and VCS-provider caches.

* **UI/UX Updates**
  * Updated copy to include merge requests and changed comment action aria-label to “Open comment”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->