### PR TITLE
Remove unused organization read procedures

### DIFF
--- a/packages/trpc/src/router/organization/organization.ts
+++ b/packages/trpc/src/router/organization/organization.ts
@@ -9,53 +9,12 @@ import { seedDefaultStatuses } from "@superset/db/seed-default-statuses";
 import { findOrgMembership } from "@superset/db/utils";
 import { canRemoveMember, type OrganizationRole } from "@superset/shared/auth";
 import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
-import { and, desc, eq, ne, sql } from "drizzle-orm";
+import { and, eq, ne, sql } from "drizzle-orm";
 import { z } from "zod";
 import { generateImagePathname, uploadImage } from "../../lib/upload";
 import { protectedProcedure, publicProcedure } from "../../trpc";
 
 export const organizationRouter = {
-	all: publicProcedure.query(() => {
-		return db.query.organizations.findMany({
-			orderBy: desc(organizations.createdAt),
-			with: {
-				members: {
-					with: {
-						user: true,
-					},
-				},
-			},
-		});
-	}),
-
-	byId: publicProcedure.input(z.string().uuid()).query(({ input }) => {
-		return db.query.organizations.findFirst({
-			where: eq(organizations.id, input),
-			with: {
-				members: {
-					with: {
-						user: true,
-					},
-				},
-				projects: true,
-			},
-		});
-	}),
-
-	bySlug: publicProcedure.input(z.string()).query(({ input }) => {
-		return db.query.organizations.findFirst({
-			where: eq(organizations.slug, input),
-			with: {
-				members: {
-					with: {
-						user: true,
-					},
-				},
-				projects: true,
-			},
-		});
-	}),
-
 	getInvitation: publicProcedure.input(z.uuid()).query(async ({ input }) => {
 		const invitation = await db.query.invitations.findFirst({
 			where: eq(invitations.id, input),


### PR DESCRIPTION
## Summary
- remove unused read procedures from the organization tRPC router
- keep the invitation lookup flow unchanged

## Testing
- bun run typecheck --filter=@superset/trpc --filter=@superset/web --filter=@superset/api --filter=@superset/desktop
- bunx @biomejs/biome@2.4.2 check packages/trpc/src/router/organization/organization.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused organization read procedures from the tRPC router to shrink the public API surface and clean up dead code. Invitation lookup flow stays the same.

- **Refactors**
  - Removed `all`, `byId`, and `bySlug` public queries from the organization router.
  - Dropped unused `desc` import from `drizzle-orm`.

<sup>Written for commit 5cdbf08401976e90c51f0ba82a0cd4f8a65995aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed endpoint for retrieving all organizations with member and user information
  * Removed endpoint for retrieving organizations by identifier with associated member, user, and project details
  * Removed endpoint for retrieving organizations by slug with associated member, user, and project details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->