### PR TITLE
fix(linear): restore continuous task sync into views

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,10 @@ NEXT_PUBLIC_ADMIN_URL=http://localhost:3003
 NEXT_PUBLIC_MARKETING_URL=http://localhost:3002
 NEXT_PUBLIC_DOCS_URL=http://localhost:3004
 
+# Public API URL used by external integrations that cannot call localhost
+# (for example Linear OAuth callbacks and webhooks in local dev)
+LINEAR_PUBLIC_API_URL=
+
 # -----------------------------------------------------------------------------
 # Better Auth
 # -----------------------------------------------------------------------------

--- a/apps/api/src/app/api/integrations/linear/callback/route.ts
+++ b/apps/api/src/app/api/integrations/linear/callback/route.ts
@@ -8,6 +8,256 @@ import { env } from "@/env";
 import { verifySignedState } from "@/lib/oauth-state";
 
 const qstash = new Client({ token: env.QSTASH_TOKEN });
+const LINEAR_WEBHOOK_URL = `${env.NEXT_PUBLIC_API_URL}/api/integrations/linear/webhook`;
+const ISSUE_RESOURCE_TYPES = ["Issue"];
+
+const EXISTING_WEBHOOKS_QUERY = `
+	query ExistingWebhooks {
+		webhooks {
+			nodes {
+				id
+				url
+				enabled
+				allPublicTeams
+				secret
+				resourceTypes
+				team {
+					id
+				}
+			}
+		}
+	}
+`;
+
+const TEAMS_QUERY = `
+	query TeamsForWebhooks {
+		teams {
+			nodes {
+				id
+				name
+				private
+			}
+		}
+	}
+`;
+
+const CREATE_WEBHOOK_MUTATION = `
+	mutation CreateWebhook($input: WebhookCreateInput!) {
+		webhookCreate(input: $input) {
+			success
+			webhook {
+				id
+				enabled
+			}
+		}
+	}
+`;
+
+const UPDATE_WEBHOOK_MUTATION = `
+	mutation UpdateWebhook($id: String!, $input: WebhookUpdateInput!) {
+		webhookUpdate(id: $id, input: $input) {
+			success
+			webhook {
+				id
+				enabled
+			}
+		}
+	}
+`;
+
+interface LinearTokenResponse {
+	access_token: string;
+	expires_in?: number;
+	refresh_token?: string;
+}
+
+interface LinearWebhookRecord {
+	id: string;
+	url: string;
+	enabled: boolean;
+	allPublicTeams: boolean | null;
+	secret: string | null;
+	resourceTypes: string[];
+	team: { id: string } | null;
+}
+
+interface ExistingWebhooksResponse {
+	webhooks: {
+		nodes: LinearWebhookRecord[];
+	};
+}
+
+interface TeamsResponse {
+	teams: {
+		nodes: Array<{
+			id: string;
+			name: string;
+			private: boolean;
+		}>;
+	};
+}
+
+interface WebhookMutationResponse {
+	webhookCreate?: {
+		success: boolean;
+		webhook: { id: string; enabled: boolean } | null;
+	};
+	webhookUpdate?: {
+		success: boolean;
+		webhook: { id: string; enabled: boolean } | null;
+	};
+}
+
+function buildLinearRedirect(params?: {
+	error?: string;
+	warning?: string;
+}): string {
+	const redirectUrl = new URL("/integrations/linear", env.NEXT_PUBLIC_WEB_URL);
+
+	if (params?.error) {
+		redirectUrl.searchParams.set("error", params.error);
+	}
+
+	if (params?.warning) {
+		redirectUrl.searchParams.set("warning", params.warning);
+	}
+
+	return redirectUrl.toString();
+}
+
+function webhookNeedsUpdate(webhook: LinearWebhookRecord): boolean {
+	if (!webhook.enabled) {
+		return true;
+	}
+
+	if (webhook.url !== LINEAR_WEBHOOK_URL) {
+		return true;
+	}
+
+	if (webhook.secret !== env.LINEAR_WEBHOOK_SECRET) {
+		return true;
+	}
+
+	return !ISSUE_RESOURCE_TYPES.every((resourceType) =>
+		webhook.resourceTypes.includes(resourceType),
+	);
+}
+
+async function upsertIssueWebhook(
+	linearClient: LinearClient,
+	existingWebhook: LinearWebhookRecord | undefined,
+	input:
+		| {
+				allPublicTeams: true;
+				label: string;
+		  }
+		| {
+				teamId: string;
+				label: string;
+		  },
+) {
+	if (existingWebhook && !webhookNeedsUpdate(existingWebhook)) {
+		return;
+	}
+
+	if (existingWebhook) {
+		const response = await linearClient.client.request<
+			WebhookMutationResponse,
+			{
+				id: string;
+				input: {
+					enabled: boolean;
+					label: string;
+					resourceTypes: string[];
+					secret: string;
+					url: string;
+				};
+			}
+		>(UPDATE_WEBHOOK_MUTATION, {
+			id: existingWebhook.id,
+			input: {
+				enabled: true,
+				label: input.label,
+				resourceTypes: ISSUE_RESOURCE_TYPES,
+				secret: env.LINEAR_WEBHOOK_SECRET,
+				url: LINEAR_WEBHOOK_URL,
+			},
+		});
+
+		if (!response.webhookUpdate?.success) {
+			throw new Error("Failed to update Linear webhook");
+		}
+
+		return;
+	}
+
+	const response = await linearClient.client.request<
+		WebhookMutationResponse,
+		{
+			input: {
+				allPublicTeams?: boolean;
+				label: string;
+				resourceTypes: string[];
+				secret: string;
+				teamId?: string;
+				url: string;
+			};
+		}
+	>(CREATE_WEBHOOK_MUTATION, {
+		input: {
+			...input,
+			resourceTypes: ISSUE_RESOURCE_TYPES,
+			secret: env.LINEAR_WEBHOOK_SECRET,
+			url: LINEAR_WEBHOOK_URL,
+		},
+	});
+
+	if (!response.webhookCreate?.success) {
+		throw new Error("Failed to create Linear webhook");
+	}
+}
+
+async function ensureLinearIssueWebhooks(linearClient: LinearClient) {
+	const [existingWebhooksResponse, teamsResponse] = await Promise.all([
+		linearClient.client.request<
+			ExistingWebhooksResponse,
+			Record<string, never>
+		>(EXISTING_WEBHOOKS_QUERY),
+		linearClient.client.request<TeamsResponse, Record<string, never>>(
+			TEAMS_QUERY,
+		),
+	]);
+
+	const existingWebhooks = existingWebhooksResponse.webhooks.nodes.filter(
+		(webhook) => webhook.url === LINEAR_WEBHOOK_URL,
+	);
+
+	const publicWebhook =
+		existingWebhooks.find(
+			(webhook) => webhook.allPublicTeams && webhook.enabled,
+		) ?? existingWebhooks.find((webhook) => webhook.allPublicTeams);
+
+	await upsertIssueWebhook(linearClient, publicWebhook, {
+		allPublicTeams: true,
+		label: "Superset Task Sync (public teams)",
+	});
+
+	for (const team of teamsResponse.teams.nodes) {
+		if (!team.private) {
+			continue;
+		}
+
+		const existingTeamWebhook =
+			existingWebhooks.find(
+				(webhook) => webhook.team?.id === team.id && webhook.enabled,
+			) ?? existingWebhooks.find((webhook) => webhook.team?.id === team.id);
+
+		await upsertIssueWebhook(linearClient, existingTeamWebhook, {
+			teamId: team.id,
+			label: `Superset Task Sync (${team.name})`,
+		});
+	}
+}
 
 export async function GET(request: Request) {
 	const url = new URL(request.url);
@@ -16,23 +266,17 @@ export async function GET(request: Request) {
 	const error = url.searchParams.get("error");
 
 	if (error) {
-		return Response.redirect(
-			`${env.NEXT_PUBLIC_WEB_URL}/integrations/linear?error=oauth_denied`,
-		);
+		return Response.redirect(buildLinearRedirect({ error: "oauth_denied" }));
 	}
 
 	if (!code || !state) {
-		return Response.redirect(
-			`${env.NEXT_PUBLIC_WEB_URL}/integrations/linear?error=missing_params`,
-		);
+		return Response.redirect(buildLinearRedirect({ error: "missing_params" }));
 	}
 
 	// Verify signed state (prevents forgery)
 	const stateData = verifySignedState(state);
 	if (!stateData) {
-		return Response.redirect(
-			`${env.NEXT_PUBLIC_WEB_URL}/integrations/linear?error=invalid_state`,
-		);
+		return Response.redirect(buildLinearRedirect({ error: "invalid_state" }));
 	}
 
 	const { organizationId, userId } = stateData;
@@ -50,9 +294,7 @@ export async function GET(request: Request) {
 			organizationId,
 			userId,
 		});
-		return Response.redirect(
-			`${env.NEXT_PUBLIC_WEB_URL}/integrations/linear?error=unauthorized`,
-		);
+		return Response.redirect(buildLinearRedirect({ error: "unauthorized" }));
 	}
 
 	const tokenResponse = await fetch("https://api.linear.app/oauth/token", {
@@ -69,12 +311,11 @@ export async function GET(request: Request) {
 
 	if (!tokenResponse.ok) {
 		return Response.redirect(
-			`${env.NEXT_PUBLIC_WEB_URL}/integrations/linear?error=token_exchange_failed`,
+			buildLinearRedirect({ error: "token_exchange_failed" }),
 		);
 	}
 
-	const tokenData: { access_token: string; expires_in?: number } =
-		await tokenResponse.json();
+	const tokenData: LinearTokenResponse = await tokenResponse.json();
 
 	const linearClient = new LinearClient({
 		accessToken: tokenData.access_token,
@@ -85,6 +326,14 @@ export async function GET(request: Request) {
 	const tokenExpiresAt = tokenData.expires_in
 		? new Date(Date.now() + tokenData.expires_in * 1000)
 		: null;
+	let warning: string | undefined;
+
+	try {
+		await ensureLinearIssueWebhooks(linearClient);
+	} catch (error) {
+		console.error("[linear/callback] Failed to ensure issue webhooks:", error);
+		warning = "webhook_setup_failed";
+	}
 
 	await db
 		.insert(integrationConnections)
@@ -93,6 +342,7 @@ export async function GET(request: Request) {
 			connectedByUserId: userId,
 			provider: "linear",
 			accessToken: tokenData.access_token,
+			refreshToken: tokenData.refresh_token ?? null,
 			tokenExpiresAt,
 			externalOrgId: linearOrg.id,
 			externalOrgName: linearOrg.name,
@@ -104,6 +354,7 @@ export async function GET(request: Request) {
 			],
 			set: {
 				accessToken: tokenData.access_token,
+				refreshToken: tokenData.refresh_token ?? null,
 				tokenExpiresAt,
 				externalOrgId: linearOrg.id,
 				externalOrgName: linearOrg.name,
@@ -121,9 +372,9 @@ export async function GET(request: Request) {
 	} catch (error) {
 		console.error("Failed to queue initial sync job:", error);
 		return Response.redirect(
-			`${env.NEXT_PUBLIC_WEB_URL}/integrations/linear?warning=sync_queued_failed`,
+			buildLinearRedirect({ warning: "sync_queued_failed" }),
 		);
 	}
 
-	return Response.redirect(`${env.NEXT_PUBLIC_WEB_URL}/integrations/linear`);
+	return Response.redirect(buildLinearRedirect({ warning }));
 }

--- a/apps/api/src/app/api/integrations/linear/callback/route.ts
+++ b/apps/api/src/app/api/integrations/linear/callback/route.ts
@@ -8,7 +8,9 @@ import { env } from "@/env";
 import { verifySignedState } from "@/lib/oauth-state";
 
 const qstash = new Client({ token: env.QSTASH_TOKEN });
-const LINEAR_WEBHOOK_URL = `${env.NEXT_PUBLIC_API_URL}/api/integrations/linear/webhook`;
+const LINEAR_PUBLIC_API_URL =
+	env.LINEAR_PUBLIC_API_URL ?? env.NEXT_PUBLIC_API_URL;
+const LINEAR_WEBHOOK_URL = `${LINEAR_PUBLIC_API_URL}/api/integrations/linear/webhook`;
 const ISSUE_RESOURCE_TYPES = ["Issue"];
 
 const EXISTING_WEBHOOKS_QUERY = `
@@ -304,7 +306,7 @@ export async function GET(request: Request) {
 			grant_type: "authorization_code",
 			client_id: env.LINEAR_CLIENT_ID,
 			client_secret: env.LINEAR_CLIENT_SECRET,
-			redirect_uri: `${env.NEXT_PUBLIC_API_URL}/api/integrations/linear/callback`,
+			redirect_uri: `${LINEAR_PUBLIC_API_URL}/api/integrations/linear/callback`,
 			code,
 		}),
 	});

--- a/apps/api/src/app/api/integrations/linear/connect/route.ts
+++ b/apps/api/src/app/api/integrations/linear/connect/route.ts
@@ -47,7 +47,7 @@ export async function GET(request: Request) {
 		`${env.NEXT_PUBLIC_API_URL}/api/integrations/linear/callback`,
 	);
 	linearAuthUrl.searchParams.set("response_type", "code");
-	linearAuthUrl.searchParams.set("scope", "read,write,issues:create");
+	linearAuthUrl.searchParams.set("scope", "read,write,issues:create,admin");
 	linearAuthUrl.searchParams.set("state", state);
 
 	return Response.redirect(linearAuthUrl.toString());

--- a/apps/api/src/app/api/integrations/linear/connect/route.ts
+++ b/apps/api/src/app/api/integrations/linear/connect/route.ts
@@ -39,12 +39,14 @@ export async function GET(request: Request) {
 		organizationId,
 		userId: session.user.id,
 	});
+	const linearPublicApiUrl =
+		env.LINEAR_PUBLIC_API_URL ?? env.NEXT_PUBLIC_API_URL;
 
 	const linearAuthUrl = new URL("https://linear.app/oauth/authorize");
 	linearAuthUrl.searchParams.set("client_id", env.LINEAR_CLIENT_ID);
 	linearAuthUrl.searchParams.set(
 		"redirect_uri",
-		`${env.NEXT_PUBLIC_API_URL}/api/integrations/linear/callback`,
+		`${linearPublicApiUrl}/api/integrations/linear/callback`,
 	);
 	linearAuthUrl.searchParams.set("response_type", "code");
 	linearAuthUrl.searchParams.set("scope", "read,write,issues:create,admin");

--- a/apps/api/src/app/api/integrations/linear/webhook/route.ts
+++ b/apps/api/src/app/api/integrations/linear/webhook/route.ts
@@ -13,11 +13,16 @@ import {
 	users,
 	webhookEvents,
 } from "@superset/db/schema";
-import { mapPriorityFromLinear } from "@superset/trpc/integrations/linear";
+import {
+	getLinearClient,
+	mapPriorityFromLinear,
+} from "@superset/trpc/integrations/linear";
 import { and, eq, sql } from "drizzle-orm";
 import { env } from "@/env";
+import { syncWorkflowStates } from "../jobs/initial-sync/syncWorkflowStates";
 
 const webhookClient = new LinearWebhookClient(env.LINEAR_WEBHOOK_SECRET);
+const LINEAR_DELIVERY_HEADER = "Linear-Delivery";
 
 export async function POST(request: Request) {
 	const body = await request.text();
@@ -27,10 +32,18 @@ export async function POST(request: Request) {
 		return Response.json({ error: "Missing signature" }, { status: 401 });
 	}
 
-	const payload = webhookClient.parseData(Buffer.from(body), signature);
+	let payload: ReturnType<typeof webhookClient.parseData>;
+	try {
+		payload = webhookClient.parseData(Buffer.from(body), signature);
+	} catch {
+		return Response.json({ error: "Invalid signature" }, { status: 401 });
+	}
 
 	// Store event with idempotent handling
-	const eventId = `${payload.organizationId}-${payload.webhookTimestamp}`;
+	const deliveryId = request.headers.get(LINEAR_DELIVERY_HEADER);
+	const eventId =
+		deliveryId ??
+		`${payload.webhookId}-${payload.webhookTimestamp}-${payload.type}-${payload.action}`;
 
 	const [webhookEvent] = await db
 		.insert(webhookEvents)
@@ -124,7 +137,7 @@ async function processIssueEvent(
 	const issue = payload.data;
 
 	if (payload.action === "create" || payload.action === "update") {
-		const taskStatus = await db.query.taskStatuses.findFirst({
+		let taskStatus = await db.query.taskStatuses.findFirst({
 			where: and(
 				eq(taskStatuses.organizationId, connection.organizationId),
 				eq(taskStatuses.externalProvider, "linear"),
@@ -133,11 +146,26 @@ async function processIssueEvent(
 		});
 
 		if (!taskStatus) {
-			// TODO(SUPER-237): Handle new workflow states in webhooks by triggering syncWorkflowStates
-			// Currently webhooks silently fail when Linear has new statuses that aren't synced yet.
-			// Should either: (1) trigger workflow state sync and retry, (2) queue for retry, or (3) keep periodic sync only
+			const linearClient = await getLinearClient(connection.organizationId);
+			if (linearClient) {
+				await syncWorkflowStates({
+					client: linearClient,
+					organizationId: connection.organizationId,
+				});
+
+				taskStatus = await db.query.taskStatuses.findFirst({
+					where: and(
+						eq(taskStatuses.organizationId, connection.organizationId),
+						eq(taskStatuses.externalProvider, "linear"),
+						eq(taskStatuses.externalId, issue.state.id),
+					),
+				});
+			}
+		}
+
+		if (!taskStatus) {
 			console.warn(
-				`[webhook] Status not found for state ${issue.state.id}, skipping update`,
+				`[linear/webhook] Status not found for state ${issue.state.id}, skipping update`,
 			);
 			return "skipped";
 		}

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -22,6 +22,7 @@ export const env = createEnv({
 		BETTER_AUTH_SECRET: z.string(),
 		LINEAR_CLIENT_ID: z.string().min(1),
 		LINEAR_CLIENT_SECRET: z.string().min(1),
+		LINEAR_PUBLIC_API_URL: z.string().url().optional(),
 		LINEAR_WEBHOOK_SECRET: z.string().min(1),
 		GH_APP_ID: z.string().min(1),
 		GH_APP_PRIVATE_KEY: z.string().min(1),

--- a/apps/web/src/app/(dashboard)/integrations/linear/components/ConnectionControls/ConnectionControls.tsx
+++ b/apps/web/src/app/(dashboard)/integrations/linear/components/ConnectionControls/ConnectionControls.tsx
@@ -21,11 +21,13 @@ import { useTRPC } from "@/trpc/react";
 interface ConnectionControlsProps {
 	organizationId: string;
 	isConnected: boolean;
+	showReconnect?: boolean;
 }
 
 export function ConnectionControls({
 	organizationId,
 	isConnected,
+	showReconnect = false,
 }: ConnectionControlsProps) {
 	const trpc = useTRPC();
 	const router = useRouter();
@@ -54,29 +56,34 @@ export function ConnectionControls({
 
 	if (isConnected) {
 		return (
-			<AlertDialog>
-				<AlertDialogTrigger asChild>
-					<Button variant="outline" disabled={disconnectMutation.isPending}>
-						<Unplug className="mr-2 size-4" />
-						{disconnectMutation.isPending ? "Disconnecting..." : "Disconnect"}
-					</Button>
-				</AlertDialogTrigger>
-				<AlertDialogContent>
-					<AlertDialogHeader>
-						<AlertDialogTitle>Disconnect Linear?</AlertDialogTitle>
-						<AlertDialogDescription>
-							This will remove the connection between your organization and
-							Linear. You can reconnect at any time.
-						</AlertDialogDescription>
-					</AlertDialogHeader>
-					<AlertDialogFooter>
-						<AlertDialogCancel>Cancel</AlertDialogCancel>
-						<AlertDialogAction onClick={handleDisconnect}>
-							Disconnect
-						</AlertDialogAction>
-					</AlertDialogFooter>
-				</AlertDialogContent>
-			</AlertDialog>
+			<div className="flex flex-wrap items-center gap-3">
+				{showReconnect ? (
+					<Button onClick={handleConnect}>Reconnect Linear</Button>
+				) : null}
+				<AlertDialog>
+					<AlertDialogTrigger asChild>
+						<Button variant="outline" disabled={disconnectMutation.isPending}>
+							<Unplug className="mr-2 size-4" />
+							{disconnectMutation.isPending ? "Disconnecting..." : "Disconnect"}
+						</Button>
+					</AlertDialogTrigger>
+					<AlertDialogContent>
+						<AlertDialogHeader>
+							<AlertDialogTitle>Disconnect Linear?</AlertDialogTitle>
+							<AlertDialogDescription>
+								This will remove the connection between your organization and
+								Linear. You can reconnect at any time.
+							</AlertDialogDescription>
+						</AlertDialogHeader>
+						<AlertDialogFooter>
+							<AlertDialogCancel>Cancel</AlertDialogCancel>
+							<AlertDialogAction onClick={handleDisconnect}>
+								Disconnect
+							</AlertDialogAction>
+						</AlertDialogFooter>
+					</AlertDialogContent>
+				</AlertDialog>
+			</div>
 		);
 	}
 

--- a/apps/web/src/app/(dashboard)/integrations/linear/components/ErrorHandler/ErrorHandler.tsx
+++ b/apps/web/src/app/(dashboard)/integrations/linear/components/ErrorHandler/ErrorHandler.tsx
@@ -9,6 +9,14 @@ const ERROR_MESSAGES: Record<string, string> = {
 	missing_params: "Invalid OAuth response. Please try again.",
 	invalid_state: "Invalid state parameter. Please try again.",
 	token_exchange_failed: "Failed to connect to Linear. Please try again.",
+	unauthorized: "You no longer have access to this organization.",
+};
+
+const WARNING_MESSAGES: Record<string, string> = {
+	sync_queued_failed:
+		"Linear connected, but initial sync failed to start. Please try reconnecting.",
+	webhook_setup_failed:
+		"Linear connected, but real-time sync could not be enabled. Reconnect using a Linear workspace admin account.",
 };
 
 export function ErrorHandler() {
@@ -16,8 +24,12 @@ export function ErrorHandler() {
 
 	useEffect(() => {
 		const error = searchParams.get("error");
+		const warning = searchParams.get("warning");
 		if (error) {
 			toast.error(ERROR_MESSAGES[error] ?? "Something went wrong.");
+			window.history.replaceState({}, "", "/integrations/linear");
+		} else if (warning) {
+			toast.warning(WARNING_MESSAGES[warning] ?? "Warning occurred.");
 			window.history.replaceState({}, "", "/integrations/linear");
 		}
 	}, [searchParams]);

--- a/apps/web/src/app/(dashboard)/integrations/linear/page.tsx
+++ b/apps/web/src/app/(dashboard)/integrations/linear/page.tsx
@@ -1,3 +1,4 @@
+import { Alert, AlertDescription, AlertTitle } from "@superset/ui/alert";
 import { Badge } from "@superset/ui/badge";
 import {
 	Card,
@@ -6,7 +7,7 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@superset/ui/card";
-import { ArrowLeft, CheckCircle2 } from "lucide-react";
+import { AlertTriangle, ArrowLeft, CheckCircle2 } from "lucide-react";
 import Link from "next/link";
 import { SiLinear } from "react-icons/si";
 import { api } from "@/trpc/server";
@@ -30,6 +31,7 @@ export default async function LinearIntegrationPage() {
 
 	const connection = await trpc.integration.linear.getConnection.query({
 		organizationId: organization.id,
+		includeHealth: true,
 	});
 	const isConnected = !!connection;
 
@@ -75,10 +77,28 @@ export default async function LinearIntegrationPage() {
 						Connect your Linear workspace to sync issues bidirectionally.
 					</CardDescription>
 				</CardHeader>
-				<CardContent>
+				<CardContent className="space-y-4">
+					{connection?.needsReconnect ? (
+						<Alert>
+							<AlertTriangle className="size-4" />
+							<AlertTitle>Reconnect Linear to restore live sync</AlertTitle>
+							<AlertDescription>
+								<p>
+									{connection.reconnectReason === "missing_webhook"
+										? "We could not find an active Linear webhook for this organization."
+										: "This connection needs to be re-authorized so Superset can verify and repair the webhook setup."}
+								</p>
+								<p>
+									Reconnect without disconnecting to refresh the OAuth grant and
+									re-enable continuous sync into task views.
+								</p>
+							</AlertDescription>
+						</Alert>
+					) : null}
 					<ConnectionControls
 						organizationId={organization.id}
 						isConnected={isConnected}
+						showReconnect={connection?.needsReconnect ?? false}
 					/>
 				</CardContent>
 			</Card>

--- a/packages/trpc/src/env.ts
+++ b/packages/trpc/src/env.ts
@@ -17,6 +17,8 @@ export const env = createEnv({
 		NEXT_PUBLIC_WEB_URL: z.string().url(),
 		KV_REST_API_URL: z.string().url().optional(),
 		KV_REST_API_TOKEN: z.string().optional(),
+		LINEAR_CLIENT_ID: z.string().min(1),
+		LINEAR_CLIENT_SECRET: z.string().min(1),
 		// GitHub App credentials
 		GH_APP_ID: z.string().min(1),
 		GH_APP_PRIVATE_KEY: z.string().min(1),

--- a/packages/trpc/src/env.ts
+++ b/packages/trpc/src/env.ts
@@ -19,6 +19,7 @@ export const env = createEnv({
 		KV_REST_API_TOKEN: z.string().optional(),
 		LINEAR_CLIENT_ID: z.string().min(1),
 		LINEAR_CLIENT_SECRET: z.string().min(1),
+		LINEAR_PUBLIC_API_URL: z.string().url().optional(),
 		// GitHub App credentials
 		GH_APP_ID: z.string().min(1),
 		GH_APP_PRIVATE_KEY: z.string().min(1),

--- a/packages/trpc/src/router/integration/linear/linear.ts
+++ b/packages/trpc/src/router/integration/linear/linear.ts
@@ -11,11 +11,16 @@ import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure } from "../../../trpc";
 import { verifyOrgAdmin, verifyOrgMembership } from "../utils";
-import { getLinearClient } from "./utils";
+import { getLinearClient, getLinearReconnectStatus } from "./utils";
 
 export const linearRouter = {
 	getConnection: protectedProcedure
-		.input(z.object({ organizationId: z.uuid() }))
+		.input(
+			z.object({
+				organizationId: z.uuid(),
+				includeHealth: z.boolean().optional(),
+			}),
+		)
 		.query(async ({ ctx, input }) => {
 			await verifyOrgMembership(ctx.session.user.id, input.organizationId);
 			const connection = await db.query.integrationConnections.findFirst({
@@ -26,7 +31,16 @@ export const linearRouter = {
 				columns: { id: true, config: true },
 			});
 			if (!connection) return null;
-			return { config: connection.config as LinearConfig | null };
+
+			const reconnectStatus = input.includeHealth
+				? await getLinearReconnectStatus(input.organizationId)
+				: { needsReconnect: false as const };
+
+			return {
+				config: connection.config as LinearConfig | null,
+				needsReconnect: reconnectStatus.needsReconnect,
+				reconnectReason: reconnectStatus.reconnectReason,
+			};
 		}),
 
 	disconnect: protectedProcedure

--- a/packages/trpc/src/router/integration/linear/utils.ts
+++ b/packages/trpc/src/router/integration/linear/utils.ts
@@ -1,7 +1,19 @@
 import { LinearClient } from "@linear/sdk";
 import { db } from "@superset/db/client";
-import { integrationConnections } from "@superset/db/schema";
+import {
+	integrationConnections,
+	type SelectIntegrationConnection,
+} from "@superset/db/schema";
 import { and, eq } from "drizzle-orm";
+import { env } from "../../../env";
+
+const LINEAR_TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
+
+interface LinearTokenResponse {
+	access_token: string;
+	expires_in?: number;
+	refresh_token?: string;
+}
 
 type Priority = "urgent" | "high" | "medium" | "low" | "none";
 
@@ -35,10 +47,64 @@ export function mapPriorityFromLinear(linearPriority: number): Priority {
 	}
 }
 
+function shouldRefreshLinearToken(
+	connection: SelectIntegrationConnection,
+): boolean {
+	if (!connection.refreshToken || !connection.tokenExpiresAt) {
+		return false;
+	}
+
+	return (
+		connection.tokenExpiresAt.getTime() <=
+		Date.now() + LINEAR_TOKEN_REFRESH_BUFFER_MS
+	);
+}
+
+async function refreshLinearConnectionToken(
+	connection: SelectIntegrationConnection,
+): Promise<SelectIntegrationConnection> {
+	const tokenResponse = await fetch("https://api.linear.app/oauth/token", {
+		method: "POST",
+		headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		body: new URLSearchParams({
+			grant_type: "refresh_token",
+			client_id: env.LINEAR_CLIENT_ID,
+			client_secret: env.LINEAR_CLIENT_SECRET,
+			refresh_token: connection.refreshToken ?? "",
+		}),
+	});
+
+	if (!tokenResponse.ok) {
+		throw new Error("Failed to refresh Linear access token");
+	}
+
+	const tokenData = (await tokenResponse.json()) as LinearTokenResponse;
+	const tokenExpiresAt = tokenData.expires_in
+		? new Date(Date.now() + tokenData.expires_in * 1000)
+		: null;
+
+	const [updatedConnection] = await db
+		.update(integrationConnections)
+		.set({
+			accessToken: tokenData.access_token,
+			refreshToken: tokenData.refresh_token ?? connection.refreshToken,
+			tokenExpiresAt,
+			updatedAt: new Date(),
+		})
+		.where(eq(integrationConnections.id, connection.id))
+		.returning();
+
+	if (!updatedConnection) {
+		throw new Error("Failed to persist refreshed Linear token");
+	}
+
+	return updatedConnection;
+}
+
 export async function getLinearClient(
 	organizationId: string,
 ): Promise<LinearClient | null> {
-	const connection = await db.query.integrationConnections.findFirst({
+	let connection = await db.query.integrationConnections.findFirst({
 		where: and(
 			eq(integrationConnections.organizationId, organizationId),
 			eq(integrationConnections.provider, "linear"),
@@ -47,6 +113,14 @@ export async function getLinearClient(
 
 	if (!connection) {
 		return null;
+	}
+
+	if (shouldRefreshLinearToken(connection)) {
+		try {
+			connection = await refreshLinearConnectionToken(connection);
+		} catch (error) {
+			console.error("[linear] Failed to refresh access token:", error);
+		}
 	}
 
 	return new LinearClient({ accessToken: connection.accessToken });

--- a/packages/trpc/src/router/integration/linear/utils.ts
+++ b/packages/trpc/src/router/integration/linear/utils.ts
@@ -8,11 +8,34 @@ import { and, eq } from "drizzle-orm";
 import { env } from "../../../env";
 
 const LINEAR_TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
+const LINEAR_WEBHOOK_URL = `${env.NEXT_PUBLIC_API_URL}/api/integrations/linear/webhook`;
+
+const EXISTING_WEBHOOKS_QUERY = `
+	query ExistingWebhooks {
+		webhooks {
+			nodes {
+				id
+				url
+				enabled
+			}
+		}
+	}
+`;
 
 interface LinearTokenResponse {
 	access_token: string;
 	expires_in?: number;
 	refresh_token?: string;
+}
+
+interface ExistingWebhooksResponse {
+	webhooks: {
+		nodes: Array<{
+			id: string;
+			url: string;
+			enabled: boolean;
+		}>;
+	};
 }
 
 type Priority = "urgent" | "high" | "medium" | "low" | "none";
@@ -124,4 +147,42 @@ export async function getLinearClient(
 	}
 
 	return new LinearClient({ accessToken: connection.accessToken });
+}
+
+export async function getLinearReconnectStatus(
+	organizationId: string,
+): Promise<{
+	needsReconnect: boolean;
+	reconnectReason?: "missing_webhook" | "reauth_required";
+}> {
+	const client = await getLinearClient(organizationId);
+
+	if (!client) {
+		return { needsReconnect: false };
+	}
+
+	try {
+		const response = await client.client.request<
+			ExistingWebhooksResponse,
+			Record<string, never>
+		>(EXISTING_WEBHOOKS_QUERY);
+
+		const hasMatchingWebhook = response.webhooks.nodes.some(
+			(webhook) => webhook.enabled && webhook.url === LINEAR_WEBHOOK_URL,
+		);
+
+		if (!hasMatchingWebhook) {
+			return {
+				needsReconnect: true,
+				reconnectReason: "missing_webhook",
+			};
+		}
+
+		return { needsReconnect: false };
+	} catch {
+		return {
+			needsReconnect: true,
+			reconnectReason: "reauth_required",
+		};
+	}
 }

--- a/packages/trpc/src/router/integration/linear/utils.ts
+++ b/packages/trpc/src/router/integration/linear/utils.ts
@@ -8,7 +8,9 @@ import { and, eq } from "drizzle-orm";
 import { env } from "../../../env";
 
 const LINEAR_TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
-const LINEAR_WEBHOOK_URL = `${env.NEXT_PUBLIC_API_URL}/api/integrations/linear/webhook`;
+const LINEAR_WEBHOOK_URL = `${
+	env.LINEAR_PUBLIC_API_URL ?? env.NEXT_PUBLIC_API_URL
+}/api/integrations/linear/webhook`;
 
 const EXISTING_WEBHOOKS_QUERY = `
 	query ExistingWebhooks {


### PR DESCRIPTION
## Summary
- create or repair Linear issue webhooks during OAuth callback and request the `admin` scope needed to manage them
- make inbound webhook processing more reliable by using the Linear delivery id for idempotency and re-syncing workflow states before skipping updates
- store and refresh Linear OAuth tokens so background sync paths do not silently decay after the initial connect

## Root Cause
The connect flow only saved the OAuth token and queued the initial import. It never guaranteed that Linear webhooks were actually provisioned, so ongoing updates into Superset task views depended on manual or out-of-band webhook setup.

## Notes
- if an existing Linear connection was authorized before this change, it should reconnect once to grant the new `admin` scope and let webhook repair run
- if webhook setup still fails after reconnect, the authorizing Linear user is likely not a workspace admin

## Verification
- `bunx @biomejs/biome check --write apps/api/src/app/api/integrations/linear/connect/route.ts apps/api/src/app/api/integrations/linear/callback/route.ts apps/api/src/app/api/integrations/linear/webhook/route.ts packages/trpc/src/router/integration/linear/utils.ts packages/trpc/src/env.ts 'apps/web/src/app/(dashboard)/integrations/linear/components/ErrorHandler/ErrorHandler.tsx'`
- `bunx tsc --noEmit --ignoreDeprecations 6.0 -p apps/api/tsconfig.json`
- `bunx tsc --noEmit -p packages/trpc/tsconfig.json`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores continuous sync of Linear issues into Superset task views and adds a reconnect flow for legacy connections. Uses a public API URL for OAuth callbacks and webhooks so external callbacks work in all environments, and improves webhook reliability and token refresh.

- **New Features**
  - Auto-create or repair Linear issue webhooks on OAuth callback for public and private teams using `LINEAR_PUBLIC_API_URL` (fallbacks to `NEXT_PUBLIC_API_URL`); requires `admin` scope.
  - Store and refresh Linear OAuth tokens with a safety buffer; adds `LINEAR_CLIENT_ID` and `LINEAR_CLIENT_SECRET` support and refresh logic in `getLinearClient`.
  - Detect missing/disabled webhooks and prompt reconnect: `getConnection({ includeHealth: true })` returns `needsReconnect` with reason; the page shows an alert and a “Reconnect Linear” button, with warning toasts for partial setup.

- **Bug Fixes**
  - Verify webhook signatures and use the `Linear-Delivery` header for idempotency with a robust fallback id; invalid signatures return 401.
  - On issue events, re-sync workflow states if a status is missing, then proceed or skip only if still not found.
  - Align webhook configuration (URL, secret, resource types) to prevent drift and keep updates flowing.

<sup>Written for commit 920c33c98a9434a3ae901282435cddeda1990d81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic provisioning and management of Linear webhooks
  * OAuth token refresh to maintain continuous connection
  * Automatic synchronization of missing workflow statuses
* **Bug Fixes**
  * Safer webhook payload validation with clearer signature handling
  * Improved idempotency for webhook event processing
* **Improvements**
  * Warning notifications and a reconnect UI for non-critical integration issues
  * OAuth now requests admin permissions during authorization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->