### PR TITLE
fix(web): tighten app response headers to prevent iframing

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -42,6 +42,21 @@ const config: NextConfig = {
 		];
 	},
 
+	async headers() {
+		return [
+			{
+				source: "/(.*)",
+				headers: [
+					{ key: "X-Frame-Options", value: "DENY" },
+					{
+						key: "Content-Security-Policy",
+						value: "frame-ancestors 'none'",
+					},
+				],
+			},
+		];
+	},
+
 	skipTrailingSlashRedirect: true,
 };
 


### PR DESCRIPTION
## Description

Tightens default response headers on the web app to align with existing hardening in adjacent surfaces and reduce unintended embedding behavior.

## Related Issues

Internal follow-up.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

- `bun --filter @superset/web typecheck`
- Verified `/` and `/sign-in` return the expected headers locally

## Screenshots (if applicable)

N/A

## Additional Notes

Keeping the PR description intentionally narrow until rollout.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block iframe embedding to mitigate clickjacking by setting global response headers. Adds `X-Frame-Options: DENY` and `Content-Security-Policy: frame-ancestors 'none'` across all routes.

<sup>Written for commit 4ee2f6fa85e8c4d8f772d68a02b6dc2e72740502. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented HTTP security headers to prevent the application from being embedded in frames on external websites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->