### PR TITLE
feat(desktop): add Linear URL parsing for workspace creation

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/IssuesGroup/IssuesGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/IssuesGroup/IssuesGroup.tsx
@@ -1,3 +1,4 @@
+import { parseLinearIssueIdentifier } from "@superset/shared";
 import { Avatar } from "@superset/ui/atoms/Avatar";
 import { Button } from "@superset/ui/button";
 import { CommandEmpty, CommandGroup, CommandItem } from "@superset/ui/command";
@@ -5,12 +6,14 @@ import { toast } from "@superset/ui/sonner";
 import { eq, isNull } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useNavigate } from "@tanstack/react-router";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { GoArrowUpRight } from "react-icons/go";
 import { HiOutlineUserCircle } from "react-icons/hi2";
 import { SiLinear } from "react-icons/si";
 import { GATED_FEATURES, usePaywall } from "renderer/components/Paywall";
 import { useDebouncedValue } from "renderer/hooks/useDebouncedValue";
+import { apiTrpcClient } from "renderer/lib/api-trpc-client";
+import { authClient } from "renderer/lib/auth-client";
 import { getSlugColumnWidth } from "renderer/lib/slug-width";
 import type { WorkspaceHostTarget } from "renderer/lib/v2-workspace-host";
 import {
@@ -36,6 +39,8 @@ export function IssuesGroup({ projectId, hostTarget }: IssuesGroupProps) {
 	const { createWorkspace } = useCreateDashboardWorkspace();
 	const { draft, closeAndResetDraft, runAsyncAction } =
 		useDashboardNewWorkspaceDraft();
+	const { data: session } = authClient.useSession();
+	const activeOrganizationId = session?.session?.activeOrganizationId;
 
 	const { data: integrations } = useLiveQuery(
 		(q) =>
@@ -51,6 +56,18 @@ export function IssuesGroup({ projectId, hostTarget }: IssuesGroupProps) {
 
 	const isLinearConnected =
 		integrations?.some((i) => i.provider === "linear") ?? false;
+
+	// State for fetched Linear issue
+	const [fetchedIssue, setFetchedIssue] = useState<{
+		id: string;
+		identifier: string;
+		title: string;
+		url: string;
+		description?: string;
+		state?: { name: string };
+	} | null>(null);
+	const [isFetchingIssue, setIsFetchingIssue] = useState(false);
+	const [fetchError, setFetchError] = useState<string | null>(null);
 
 	const { data } = useLiveQuery(
 		(q) =>
@@ -95,15 +112,93 @@ export function IssuesGroup({ projectId, hostTarget }: IssuesGroupProps) {
 	const debouncedQuery = useDebouncedValue(draft.issuesQuery, 150);
 	const { search } = useHybridSearch(sortedTasks);
 
+	// Detect Linear URL and fetch issue
+	useEffect(() => {
+		const query = debouncedQuery.trim();
+
+		// Reset state when query changes
+		setFetchedIssue(null);
+		setFetchError(null);
+
+		if (!query || !isLinearConnected || !activeOrganizationId) {
+			return;
+		}
+
+		const issueIdentifier = parseLinearIssueIdentifier(query);
+		if (!issueIdentifier) {
+			return;
+		}
+
+		// Check if issue is already synced locally
+		const alreadySynced = tasks.some((t) => t.slug === issueIdentifier);
+		if (alreadySynced) {
+			return;
+		}
+
+		setIsFetchingIssue(true);
+
+		apiTrpcClient.integration.linear.fetchIssue
+			.query({
+				organizationId: activeOrganizationId,
+				issueIdentifier,
+			})
+			.then((result) => {
+				if ("error" in result) {
+					if (result.error === "LINEAR_NOT_CONNECTED") {
+						setFetchError("Linear is not connected");
+					} else if (result.error === "ISSUE_NOT_FOUND") {
+						setFetchError("Issue not found");
+					} else {
+						setFetchError("Failed to fetch issue");
+					}
+				} else if ("data" in result) {
+					setFetchedIssue(result.data);
+				}
+			})
+			.catch((err) => {
+				console.error("Failed to fetch Linear issue:", err);
+				setFetchError("Failed to fetch issue");
+			})
+			.finally(() => {
+				setIsFetchingIssue(false);
+			});
+	}, [debouncedQuery, isLinearConnected, activeOrganizationId, tasks]);
+
 	const visibleTasks = useMemo(() => {
 		const query = debouncedQuery.trim();
-		if (!query) {
-			return sortedTasks.slice(0, 100);
+		let results = sortedTasks;
+
+		if (query) {
+			results = search(query)
+				.slice(0, 100)
+				.map((result) => result.item);
+		} else {
+			results = sortedTasks.slice(0, 100);
 		}
-		return search(query)
-			.slice(0, 100)
-			.map((result) => result.item);
-	}, [debouncedQuery, sortedTasks, search]);
+
+		// Prepend fetched issue if it exists and doesn't conflict with local tasks
+		if (fetchedIssue && !tasks.some((t) => t.slug === fetchedIssue.identifier)) {
+			return [
+				{
+					id: `fetched-${fetchedIssue.id}`,
+					slug: fetchedIssue.identifier,
+					title: fetchedIssue.title,
+					externalUrl: fetchedIssue.url,
+					status: {
+						name: fetchedIssue.state?.name ?? "Todo",
+						type: "todo",
+						color: "#808080",
+						progressPercent: null,
+					},
+					assignee: null,
+					isFetched: true,
+				} as typeof results[0] & { isFetched: boolean },
+				...results,
+			];
+		}
+
+		return results;
+	}, [debouncedQuery, sortedTasks, search, fetchedIssue, tasks]);
 
 	const slugWidth = useMemo(
 		() => getSlugColumnWidth(visibleTasks.map((t) => t.slug)),
@@ -138,74 +233,99 @@ export function IssuesGroup({ projectId, hostTarget }: IssuesGroupProps) {
 
 	return (
 		<CommandGroup>
-			<CommandEmpty>No issues found.</CommandEmpty>
-			{visibleTasks.map((task) => (
-				<CommandItem
-					key={task.id}
-					onSelect={() => {
-						if (!projectId) {
-							toast.error("Select a project first");
-							return;
-						}
-						const existingId = workspaceByBranch.get(task.slug.toLowerCase());
-						if (existingId) {
-							closeAndResetDraft();
-							navigateToV2Workspace(existingId, navigate);
-							return;
-						}
-						void runAsyncAction(
-							createWorkspace({
-								projectId,
-								name: task.title,
-								branch: task.slug.toLowerCase(),
-								hostTarget,
-							}),
-							{
-								loading: "Creating workspace...",
-								success: "Workspace created",
-								error: (err) =>
-									err instanceof Error
-										? err.message
-										: "Failed to create workspace",
-							},
-						);
-					}}
-					className="group h-12"
-				>
-					{workspaceByBranch.has(task.slug.toLowerCase()) ? (
-						<GoArrowUpRight className="size-4 shrink-0 text-muted-foreground" />
-					) : (
-						<StatusIcon
-							type={task.status.type as StatusType}
-							color={task.status.color}
-							progress={task.status.progressPercent ?? undefined}
-							className="size-4 shrink-0"
-						/>
-					)}
-					<span
-						className="text-muted-foreground shrink-0 text-xs tabular-nums truncate"
-						style={{ width: slugWidth }}
+			<CommandEmpty>
+				{isFetchingIssue ? (
+					<div className="flex items-center gap-2 text-muted-foreground text-sm">
+						<div className="animate-spin rounded-full h-4 w-4 border-b-2 border-current" />
+						Fetching issue from Linear...
+					</div>
+				) : fetchError ? (
+					<div className="text-muted-foreground text-sm">{fetchError}</div>
+				) : (
+					"No issues found."
+				)}
+			</CommandEmpty>
+			{visibleTasks.map((task) => {
+				const isFetched = "isFetched" in task && task.isFetched;
+				return (
+					<CommandItem
+						key={task.id}
+						onSelect={() => {
+							if (!projectId) {
+								toast.error("Select a project first");
+								return;
+							}
+							const existingId = workspaceByBranch.get(task.slug.toLowerCase());
+							if (existingId) {
+								closeAndResetDraft();
+								navigateToV2Workspace(existingId, navigate);
+								return;
+							}
+							void runAsyncAction(
+								createWorkspace({
+									projectId,
+									name: task.title,
+									branch: task.slug.toLowerCase(),
+									hostTarget,
+								}),
+								{
+									loading: "Creating workspace...",
+									success: "Workspace created",
+									error: (err) =>
+										err instanceof Error
+											? err.message
+											: "Failed to create workspace",
+								},
+							);
+						}}
+						className="group h-12"
 					>
-						{task.slug}
-					</span>
-					<span className="truncate flex-1">{task.title}</span>
-					<span className="shrink-0 group-data-[selected=true]:hidden">
-						{task.assignee ? (
-							<Avatar
-								size="xs"
-								fullName={task.assignee.name}
-								image={task.assignee.image}
-							/>
+						{workspaceByBranch.has(task.slug.toLowerCase()) ? (
+							<GoArrowUpRight className="size-4 shrink-0 text-muted-foreground" />
 						) : (
-							<HiOutlineUserCircle className="size-5 text-muted-foreground" />
+							<StatusIcon
+								type={task.status.type as StatusType}
+								color={task.status.color}
+								progress={task.status.progressPercent ?? undefined}
+								className="size-4 shrink-0"
+							/>
 						)}
-					</span>
-					<span className="text-xs text-muted-foreground shrink-0 hidden group-data-[selected=true]:inline">
-						{workspaceByBranch.has(task.slug.toLowerCase()) ? "Open" : "Create"}{" "}
-						↵
-					</span>
-				</CommandItem>
-			))}
+						<span
+							className="text-muted-foreground shrink-0 text-xs tabular-nums truncate"
+							style={{ width: slugWidth }}
+						>
+							{task.slug}
+						</span>
+						<span className="truncate flex-1">
+							<>
+								{task.title}
+								{isFetched && (
+									<span className="ml-2 text-xs text-muted-foreground opacity-70">
+										(from Linear)
+									</span>
+								)}
+							</>
+						</span>
+						<span className="shrink-0 group-data-[selected=true]:hidden">
+							{task.assignee ? (
+								<Avatar
+									size="xs"
+									fullName={task.assignee.name}
+									image={task.assignee.image}
+								/>
+							) : (
+								<HiOutlineUserCircle className="size-5 text-muted-foreground" />
+							)}
+						</span>
+						<span className="text-xs text-muted-foreground shrink-0 hidden group-data-[selected=true]:inline">
+							{workspaceByBranch.has(task.slug.toLowerCase())
+								? "Open"
+								: "Create"}{" "}
+							↵
+						</span>
+					</CommandItem>
+				);
+			})}
 		</CommandGroup>
 	);
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -43,6 +43,10 @@
 		"./claude-command": {
 			"types": "./src/claude-command.ts",
 			"default": "./src/claude-command.ts"
+		},
+		".": {
+			"types": "./src/linear-url-parser.ts",
+			"default": "./src/linear-url-parser.ts"
 		}
 	},
 	"scripts": {

--- a/packages/shared/src/linear-url-parser.test.ts
+++ b/packages/shared/src/linear-url-parser.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+import { parseLinearIssueIdentifier } from "./linear-url-parser";
+
+describe("parseLinearIssueIdentifier", () => {
+	describe("valid Linear URLs", () => {
+		test("parses basic Linear URL with issue identifier", () => {
+			const url = "https://linear.app/superset-sh/issue/SUPER-387/test-issue";
+			expect(parseLinearIssueIdentifier(url)).toBe("SUPER-387");
+		});
+
+		test("parses URL without trailing path", () => {
+			const url = "https://linear.app/superset-sh/issue/SUPER-387";
+			expect(parseLinearIssueIdentifier(url)).toBe("SUPER-387");
+		});
+
+		test("parses URL with different workspace name", () => {
+			const url = "https://linear.app/my-company/issue/ABC-123/feature-request";
+			expect(parseLinearIssueIdentifier(url)).toBe("ABC-123");
+		});
+
+		test("parses URL with multi-character team code", () => {
+			const url = "https://linear.app/workspace/issue/TEAM-9999/long-title-here";
+			expect(parseLinearIssueIdentifier(url)).toBe("TEAM-9999");
+		});
+
+		test("parses URL with single-character team code", () => {
+			const url = "https://linear.app/workspace/issue/A-1/issue";
+			expect(parseLinearIssueIdentifier(url)).toBe("A-1");
+		});
+
+		test("parses URL with query parameters", () => {
+			const url =
+				"https://linear.app/superset-sh/issue/SUPER-387?param=value&other=test";
+			expect(parseLinearIssueIdentifier(url)).toBe("SUPER-387");
+		});
+
+		test("parses URL with hash fragment", () => {
+			const url =
+				"https://linear.app/superset-sh/issue/SUPER-387/title#comment-123";
+			expect(parseLinearIssueIdentifier(url)).toBe("SUPER-387");
+		});
+
+		test("parses URL without https protocol", () => {
+			const url = "http://linear.app/workspace/issue/TEST-42/issue";
+			expect(parseLinearIssueIdentifier(url)).toBe("TEST-42");
+		});
+
+		test("parses URL without protocol", () => {
+			const url = "linear.app/workspace/issue/TEST-42/issue";
+			expect(parseLinearIssueIdentifier(url)).toBe("TEST-42");
+		});
+	});
+
+	describe("invalid inputs", () => {
+		test("returns null for non-Linear URL", () => {
+			const url = "https://github.com/org/repo/issues/123";
+			expect(parseLinearIssueIdentifier(url)).toBeNull();
+		});
+
+		test("returns null for Linear URL without issue identifier", () => {
+			const url = "https://linear.app/superset-sh/settings";
+			expect(parseLinearIssueIdentifier(url)).toBeNull();
+		});
+
+		test("returns null for malformed issue identifier (lowercase)", () => {
+			const url = "https://linear.app/workspace/issue/super-387/title";
+			expect(parseLinearIssueIdentifier(url)).toBeNull();
+		});
+
+		test("returns null for malformed issue identifier (no hyphen)", () => {
+			const url = "https://linear.app/workspace/issue/SUPER387/title";
+			expect(parseLinearIssueIdentifier(url)).toBeNull();
+		});
+
+		test("returns null for malformed issue identifier (no number)", () => {
+			const url = "https://linear.app/workspace/issue/SUPER-/title";
+			expect(parseLinearIssueIdentifier(url)).toBeNull();
+		});
+
+		test("returns null for empty string", () => {
+			expect(parseLinearIssueIdentifier("")).toBeNull();
+		});
+
+		test("returns null for plain text", () => {
+			expect(parseLinearIssueIdentifier("SUPER-387")).toBeNull();
+		});
+
+		test("returns null for partial URL", () => {
+			const url = "linear.app/issue/SUPER-387";
+			expect(parseLinearIssueIdentifier(url)).toBeNull();
+		});
+
+		test("returns null for URL with wrong path structure", () => {
+			const url = "https://linear.app/SUPER-387";
+			expect(parseLinearIssueIdentifier(url)).toBeNull();
+		});
+	});
+
+	describe("edge cases", () => {
+		test("extracts first match if multiple patterns exist", () => {
+			const url =
+				"Check https://linear.app/workspace/issue/FIRST-1/title and https://linear.app/workspace/issue/SECOND-2/title";
+			expect(parseLinearIssueIdentifier(url)).toBe("FIRST-1");
+		});
+
+		test("handles URL with special characters in title", () => {
+			const url =
+				"https://linear.app/workspace/issue/TEST-1/title-with-special-chars-!@#";
+			expect(parseLinearIssueIdentifier(url)).toBe("TEST-1");
+		});
+
+		test("handles URL embedded in text", () => {
+			const text =
+				"Please check https://linear.app/superset-sh/issue/SUPER-387/bug-fix for details";
+			expect(parseLinearIssueIdentifier(text)).toBe("SUPER-387");
+		});
+	});
+});

--- a/packages/shared/src/linear-url-parser.ts
+++ b/packages/shared/src/linear-url-parser.ts
@@ -1,0 +1,23 @@
+/**
+ * Parses a Linear issue URL and extracts the issue identifier.
+ *
+ * @param url - The URL string to parse (e.g., "https://linear.app/superset-sh/issue/SUPER-387/test-issue")
+ * @returns The issue identifier (e.g., "SUPER-387") or null if not found
+ *
+ * @example
+ * ```typescript
+ * parseLinearIssueIdentifier("https://linear.app/superset-sh/issue/SUPER-387/test-issue")
+ * // Returns: "SUPER-387"
+ *
+ * parseLinearIssueIdentifier("not a linear url")
+ * // Returns: null
+ * ```
+ */
+export function parseLinearIssueIdentifier(url: string): string | null {
+	// Match Linear URLs with pattern: linear.app/{workspace}/issue/{IDENTIFIER}/...
+	// Identifier format: uppercase letters, hyphen, digits (e.g., SUPER-387)
+	const regex = /linear\.app\/[^/]+\/issue\/([A-Z]+-\d+)/;
+	const match = url.match(regex);
+
+	return match?.[1] ?? null;
+}

--- a/packages/trpc/src/router/integration/linear/linear.ts
+++ b/packages/trpc/src/router/integration/linear/linear.ts
@@ -155,4 +155,64 @@ export const linearRouter = {
 
 			return { success: true };
 		}),
+
+	fetchIssue: protectedProcedure
+		.input(
+			z.object({
+				organizationId: z.uuid(),
+				issueIdentifier: z.string(),
+			}),
+		)
+		.query(async ({ ctx, input }) => {
+			await verifyOrgMembership(ctx.session.user.id, input.organizationId);
+
+			const client = await getLinearClient(input.organizationId);
+			if (!client) {
+				return { error: "LINEAR_NOT_CONNECTED" };
+			}
+
+			try {
+				// Parse identifier into team key and number (e.g., "SUPER-387" -> team: "SUPER", number: 387)
+				const [teamKey, numberStr] = input.issueIdentifier.split("-");
+				if (!teamKey || !numberStr) {
+					return { error: "INVALID_IDENTIFIER" };
+				}
+
+				const number = Number.parseInt(numberStr, 10);
+				if (Number.isNaN(number)) {
+					return { error: "INVALID_IDENTIFIER" };
+				}
+
+				// Fetch issues by number - Linear SDK supports filtering by number
+				const issues = await client.issues({
+					filter: {
+						number: {
+							eq: number,
+						},
+					},
+				});
+
+				// Find the issue that matches both team and number
+				const issue = issues.nodes.find((i) => i.identifier === input.issueIdentifier);
+				if (!issue) {
+					return { error: "ISSUE_NOT_FOUND" };
+				}
+
+				const state = await issue.state;
+
+				return {
+					data: {
+						id: issue.id,
+						identifier: issue.identifier,
+						title: issue.title,
+						url: issue.url,
+						description: issue.description ?? undefined,
+						state: state ? { name: state.name } : undefined,
+					},
+				};
+			} catch (error) {
+				console.error("Error fetching Linear issue:", error);
+				return { error: "FETCH_FAILED" };
+			}
+		}),
 } satisfies TRPCRouterRecord;


### PR DESCRIPTION
## Summary
Enable users to paste Linear issue URLs (like `https://linear.app/superset-sh/issue/SUPER-387/...`) into the new workspace modal and automatically fetch and display the issue, allowing workspace creation from that issue.

## Changes

### New Files
- **`packages/shared/src/linear-url-parser.ts`** - Regex-based parser to extract issue identifiers from Linear URLs
- **`packages/shared/src/linear-url-parser.test.ts`** - 21 unit tests covering valid URLs, invalid inputs, and edge cases

### Modified Files
- **`packages/trpc/src/router/integration/linear/linear.ts`** - Added `fetchIssue` procedure to fetch Linear issues on-demand by identifier
- **`apps/desktop/src/renderer/.../IssuesGroup.tsx`** - Updated to detect Linear URLs, fetch issues, and display with "(from Linear)" indicator
- **`packages/shared/package.json`** - Exported linear-url-parser from shared package

## How It Works

1. User opens new workspace modal and switches to Issues tab
2. User pastes Linear URL like `https://linear.app/superset-sh/issue/SUPER-387/bug-fix`
3. Component detects URL pattern and extracts identifier "SUPER-387"
4. API call fetches issue details from Linear via tRPC endpoint
5. Issue appears in dropdown with special "(from Linear)" indicator
6. User can select it to create workspace with proper branch name

## Features

✅ URL parsing with comprehensive regex pattern  
✅ On-demand fetching from Linear API  
✅ Loading state while fetching  
✅ Error handling (not connected, issue not found, invalid identifier)  
✅ Prevents duplicate display if issue already synced locally  
✅ Clears fetched issue when search query changes  
✅ Visual indicator for fetched vs synced issues  

## Testing

- [x] Unit tests for URL parser (21 tests, all passing)
- [x] TypeScript compilation
- [ ] Manual testing with Linear URLs
- [ ] Manual testing with edge cases

## Closes

SUPER-387

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Paste a Linear issue URL in the new workspace modal to auto-fetch the issue and create a workspace from it. Closes SUPER-387.

- **New Features**
  - `@superset/shared`: added `parseLinearIssueIdentifier` (21 tests) and exported it.
  - Desktop `IssuesGroup`: detects Linear URLs, fetches via `integration.linear.fetchIssue`, shows "(from Linear)", handles loading/errors, avoids duplicates, and clears fetched results on query change.
  - tRPC: added `integration.linear.fetchIssue` to load issues by identifier with org membership checks and clear error responses.

<sup>Written for commit 3594d0e280610b6c9ec7b6fe852a6fbadee2a5a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

