### PR TITLE
fix(desktop): add plus sign to workspace modal keyboard shortcut

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
@@ -495,7 +495,7 @@ function CompareBaseBranchPickerInline({
 														<PlusIcon className="size-3.5 mr-1" />
 														Create
 														<span className="ml-1 text-[10px] opacity-70">
-															{modKey}↵
+															{modKey}+↵
 														</span>
 													</>
 												) : (


### PR DESCRIPTION
## Summary
- Fixed keyboard shortcut display in the new workspace modal to show `⌘+↵` instead of `⌘↵`
- Ensures consistency with other keyboard shortcut hints in the modal

## Changes
- Updated the Create button hint in the branch picker section to include the plus sign between the modifier key and Enter symbol

## Visual
Before: `⌘↵`
After: `⌘+↵`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the keyboard shortcut hint in the New Workspace modal: show ⌘+↵ for Create instead of ⌘↵. This matches the format used in other shortcut hints and keeps the UI consistent.

<sup>Written for commit 9eba13f7460e6c73b508ca7cb96257b723180fd8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated keyboard shortcut hint display format for the Create action to use clearer notation with the modifier key and Enter key combination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->