### PR TITLE
feat(desktop): add close option to workspace sidebar context menu

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceContextMenu.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceContextMenu.tsx
@@ -24,6 +24,7 @@ import {
 	LuFolderPlus,
 	LuMinus,
 	LuPencil,
+	LuX,
 } from "react-icons/lu";
 import {
 	useCreateSectionFromWorkspaces,
@@ -48,6 +49,7 @@ interface WorkspaceContextMenuProps {
 	onCopyPath: () => void;
 	onSetUnread: (isUnread: boolean) => void;
 	onResetStatus: () => void;
+	onClose: () => void;
 	children: React.ReactNode;
 }
 
@@ -64,6 +66,7 @@ export function WorkspaceContextMenu({
 	onCopyPath,
 	onSetUnread,
 	onResetStatus,
+	onClose,
 	children,
 }: WorkspaceContextMenuProps) {
 	const [isContextMenuOpen, setIsContextMenuOpen] = useState(false);
@@ -172,6 +175,15 @@ export function WorkspaceContextMenu({
 					<LuBellOff className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />
 					Clear Status
 				</ContextMenuItem>
+			)}
+			{!isBranchWorkspace && (
+				<>
+					<ContextMenuSeparator />
+					<ContextMenuItem onSelect={onClose}>
+						<LuX className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />
+						Close Worktree
+					</ContextMenuItem>
+				</>
 			)}
 		</>
 	);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -457,6 +457,7 @@ export function WorkspaceListItem({
 				onCopyPath={handleCopyPath}
 				onSetUnread={(unread) => setUnread.mutate({ id, isUnread: unread })}
 				onResetStatus={() => resetWorkspaceStatus(id)}
+				onClose={handleDeleteClick}
 			>
 				{content}
 			</WorkspaceContextMenu>


### PR DESCRIPTION
## Summary
- Added "Close Worktree" option to the right-click context menu on workspace sidebar items
- Provides an additional way to close workspaces beyond the existing hover X button
- Only shown for worktree workspaces (not branch workspaces)

## Changes
- Updated `WorkspaceContextMenu` component to include a close menu item
- Added `onClose` prop and connected it to the existing delete handler
- Used the same `LuX` icon and "Close Worktree" label as the collapsed item

## Test plan
- [x] Right-click on a worktree workspace in the sidebar
- [x] Verify "Close Worktree" option appears at the bottom of the context menu
- [x] Verify clicking it shows the delete confirmation dialog
- [x] Verify the option does NOT appear for branch workspaces
- [x] Lint passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a "Close Worktree" option to the workspace sidebar context menu for another way to close worktrees. It opens the existing delete confirmation and only shows for worktree workspaces.

- **New Features**
  - Menu item added in WorkspaceContextMenu using the `LuX` icon.
  - Introduced `onClose` prop and wired it to the existing delete handler in WorkspaceListItem.

<sup>Written for commit c6e930d70b08f80b450a7cdad53ce66f91a0e174. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Close Worktree" option to the workspace context menu for non-branch workspaces, enabling users to close workspaces directly from the sidebar menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->