### PR TITLE
test(task): add delete authorization regression coverage

### DIFF
--- a/packages/trpc/src/router/task/task.test.ts
+++ b/packages/trpc/src/router/task/task.test.ts
@@ -334,6 +334,30 @@ describe("task router authorization", () => {
 		expect(syncTaskMock).not.toHaveBeenCalled();
 	});
 
+	it("rejects cross-tenant task deletes before soft-deleting the row", async () => {
+		selectResults.push([{ id: TASK_ID, organizationId: ORGANIZATION_ID }]);
+		verifyOrgMembershipMock.mockImplementationOnce(async () => {
+			throw new TRPCError({
+				code: "FORBIDDEN",
+				message: "Not a member of this organization",
+			});
+		});
+
+		const caller = createCaller(createContext());
+
+		await expect(caller.task.delete(TASK_ID)).rejects.toMatchObject({
+			code: "FORBIDDEN",
+			message: "Not a member of this organization",
+		});
+
+		expect(verifyOrgMembershipMock).toHaveBeenCalledWith(
+			ACTOR_USER_ID,
+			ORGANIZATION_ID,
+		);
+		expect(txState.mocks.updateMock).not.toHaveBeenCalled();
+		expect(syncTaskMock).not.toHaveBeenCalled();
+	});
+
 	it("rejects status changes that point at another organization", async () => {
 		selectResults.push([{ id: TASK_ID, organizationId: ORGANIZATION_ID }]);
 		selectResults.push([]);


### PR DESCRIPTION
## Summary
- add a dedicated task.delete regression test for cross-tenant access
- verify the membership check happens before any soft-delete update runs
- assert delete does not trigger sync when authorization fails

## Testing
- bun test packages/trpc/src/router/task/task.test.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a regression test for `task.delete` to ensure cross-tenant deletes are rejected via org membership checks before any soft-delete runs. Confirms no update occurs and no sync is triggered on authorization failure in `packages/trpc/src/router/task/task.test.ts`.

<sup>Written for commit c921b68c9725c1445854f1096f3564874447d550. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added authorization test to verify that task deletion is properly restricted based on organization membership, ensuring unauthorized access attempts are blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->