### PR TITLE
feat: add state-based sidebar icons with database caching

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts
@@ -163,6 +163,20 @@ export const createGitStatusProcedures = () => {
 					return null;
 				}
 
+				// Check if we have cached data that's still fresh
+				const CACHE_DURATION = 30_000; // 30 seconds
+				const cachedStatus = worktree.githubStatus;
+				const now = Date.now();
+
+				if (
+					cachedStatus?.lastRefreshed &&
+					now - cachedStatus.lastRefreshed < CACHE_DURATION
+				) {
+					// Cache is still fresh, return it
+					return cachedStatus;
+				}
+
+				// Cache is stale or missing, fetch fresh data
 				const freshStatus = await fetchGitHubPRStatus(worktree.path);
 
 				if (freshStatus) {

--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts
@@ -32,6 +32,12 @@ const gitHubPRCommentsInputSchema = z.object({
 	isFork: z.boolean().optional(),
 });
 
+// Map to track pending GitHub status fetches to prevent concurrent requests
+const pendingGitHubStatusFetches = new Map<
+	string,
+	Promise<GitHubStatus | null>
+>();
+
 function resolveCommentsPullRequestTarget({
 	input,
 	githubStatus,
@@ -176,18 +182,34 @@ export const createGitStatusProcedures = () => {
 					return cachedStatus;
 				}
 
-				// Cache is stale or missing, fetch fresh data
-				const freshStatus = await fetchGitHubPRStatus(worktree.path);
-
-				if (freshStatus) {
-					localDb
-						.update(worktrees)
-						.set({ githubStatus: freshStatus })
-						.where(eq(worktrees.id, worktree.id))
-						.run();
+				// Check if there's already a pending fetch for this worktree
+				const pendingFetch = pendingGitHubStatusFetches.get(worktree.id);
+				if (pendingFetch) {
+					// Return the existing promise to avoid duplicate fetches
+					return pendingFetch;
 				}
 
-				return freshStatus;
+				// Cache is stale or missing, fetch fresh data
+				const fetchPromise = fetchGitHubPRStatus(worktree.path)
+					.then((freshStatus) => {
+						if (freshStatus) {
+							localDb
+								.update(worktrees)
+								.set({ githubStatus: freshStatus })
+								.where(eq(worktrees.id, worktree.id))
+								.run();
+						}
+						return freshStatus;
+					})
+					.finally(() => {
+						// Clean up the pending fetch entry
+						pendingGitHubStatusFetches.delete(worktree.id);
+					});
+
+				// Store the promise to deduplicate concurrent requests
+				pendingGitHubStatusFetches.set(worktree.id, fetchPromise);
+
+				return fetchPromise;
 			}),
 
 		getGitHubPRComments: publicProcedure

--- a/apps/desktop/src/renderer/screens/main/components/PRIcon/PRIcon.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/PRIcon/PRIcon.tsx
@@ -1,5 +1,9 @@
 import { cn } from "@superset/ui/utils";
-import { LuCircleDot, LuGitMerge, LuGitPullRequest } from "react-icons/lu";
+import {
+	LuGitMerge,
+	LuGitPullRequest,
+	LuGitPullRequestClosed,
+} from "react-icons/lu";
 
 export type PRState = "open" | "merged" | "closed" | "draft";
 
@@ -10,16 +14,16 @@ interface PRIconProps {
 
 const stateStyles: Record<PRState, string> = {
 	open: "text-emerald-500",
-	merged: "text-violet-500",
-	closed: "text-red-500",
+	merged: "text-purple-500",
+	closed: "text-destructive",
 	draft: "text-muted-foreground",
 };
 
 /**
  * Renders a PR icon with color based on state.
  * - open: green pull request icon
- * - merged: purple/violet merge icon
- * - closed: red dot icon
+ * - merged: purple merge icon
+ * - closed: red closed pull request icon
  * - draft: muted pull request icon
  */
 export function PRIcon({ state, className }: PRIconProps) {
@@ -30,7 +34,7 @@ export function PRIcon({ state, className }: PRIconProps) {
 	}
 
 	if (state === "closed") {
-		return <LuCircleDot className={baseClass} />;
+		return <LuGitPullRequestClosed className={baseClass} />;
 	}
 
 	// open or draft

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/CollapsedWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/CollapsedWorkspaceItem.tsx
@@ -21,6 +21,8 @@ import { DeleteWorkspaceDialog, WorkspaceHoverCardContent } from "./components";
 import { HOVER_CARD_CLOSE_DELAY, HOVER_CARD_OPEN_DELAY } from "./constants";
 import { WorkspaceIcon } from "./WorkspaceIcon";
 
+type PRState = "open" | "merged" | "closed" | "draft";
+
 interface CollapsedWorkspaceItemProps {
 	id: string;
 	name: string;
@@ -36,6 +38,7 @@ interface CollapsedWorkspaceItemProps {
 	onClick: () => void;
 	onDeleteClick: () => void;
 	onCopyPath: () => void;
+	prState?: PRState;
 }
 
 export function CollapsedWorkspaceItem({
@@ -53,6 +56,7 @@ export function CollapsedWorkspaceItem({
 	onClick,
 	onDeleteClick,
 	onCopyPath,
+	prState,
 }: CollapsedWorkspaceItemProps) {
 	const isBranchWorkspace = type === "branch";
 	const deleteDialogCoordinator = useMemo(
@@ -85,6 +89,7 @@ export function CollapsedWorkspaceItem({
 				isUnread={isUnread}
 				workspaceStatus={workspaceStatus}
 				variant="collapsed"
+				prState={prState}
 			/>
 		</button>
 	);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceIcon.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceIcon.tsx
@@ -1,9 +1,17 @@
 import { cn } from "@superset/ui/utils";
-import { LuFolderGit2, LuLaptop } from "react-icons/lu";
+import {
+	LuCircleDot,
+	LuFolderGit2,
+	LuGitMerge,
+	LuGitPullRequest,
+	LuLaptop,
+} from "react-icons/lu";
 import { AsciiSpinner } from "renderer/screens/main/components/AsciiSpinner";
 import { StatusIndicator } from "renderer/screens/main/components/StatusIndicator";
 import type { ActivePaneStatus } from "shared/tabs-types";
 import { STROKE_WIDTH } from "../constants";
+
+type PRState = "open" | "merged" | "closed" | "draft";
 
 interface WorkspaceIconProps {
 	isBranchWorkspace: boolean;
@@ -11,6 +19,7 @@ interface WorkspaceIconProps {
 	isUnread: boolean;
 	workspaceStatus: ActivePaneStatus | null;
 	variant: "collapsed" | "expanded";
+	prState?: PRState;
 }
 
 const OVERLAY_POSITION = {
@@ -24,33 +33,115 @@ export function WorkspaceIcon({
 	isUnread,
 	workspaceStatus,
 	variant,
+	prState,
 }: WorkspaceIconProps) {
 	const overlayPosition = OVERLAY_POSITION[variant];
-	const iconColor = isActive ? "text-foreground" : "text-muted-foreground";
 
-	return (
-		<>
-			{workspaceStatus === "working" ? (
-				<AsciiSpinner className="text-base" />
-			) : isBranchWorkspace ? (
+	// Determine color based on PR state or default to active/inactive
+	const getIconColor = () => {
+		if (!prState) {
+			return isActive ? "text-foreground" : "text-muted-foreground";
+		}
+
+		switch (prState) {
+			case "open":
+				return "text-emerald-500";
+			case "merged":
+				return "text-purple-500";
+			case "closed":
+				return "text-destructive";
+			case "draft":
+				return "text-muted-foreground";
+			default:
+				return isActive ? "text-foreground" : "text-muted-foreground";
+		}
+	};
+
+	// Determine icon based on workspace type and PR state
+	const getIcon = () => {
+		if (workspaceStatus === "working") {
+			return <AsciiSpinner className="text-base" />;
+		}
+
+		if (isBranchWorkspace) {
+			return (
 				<LuLaptop
 					className={cn(
 						"size-4",
 						variant === "expanded" && "transition-colors",
-						iconColor,
+						getIconColor(),
 					)}
 					strokeWidth={STROKE_WIDTH}
 				/>
-			) : (
-				<LuFolderGit2
-					className={cn(
-						"size-4",
-						variant === "expanded" && "transition-colors",
-						iconColor,
-					)}
-					strokeWidth={STROKE_WIDTH}
-				/>
-			)}
+			);
+		}
+
+		// For worktree workspaces, use PR state icons if available
+		if (prState) {
+			switch (prState) {
+				case "open":
+					return (
+						<LuGitPullRequest
+							className={cn(
+								"size-4",
+								variant === "expanded" && "transition-colors",
+								getIconColor(),
+							)}
+							strokeWidth={STROKE_WIDTH}
+						/>
+					);
+				case "merged":
+					return (
+						<LuGitMerge
+							className={cn(
+								"size-4",
+								variant === "expanded" && "transition-colors",
+								getIconColor(),
+							)}
+							strokeWidth={STROKE_WIDTH}
+						/>
+					);
+				case "closed":
+					return (
+						<LuCircleDot
+							className={cn(
+								"size-4",
+								variant === "expanded" && "transition-colors",
+								getIconColor(),
+							)}
+							strokeWidth={STROKE_WIDTH}
+						/>
+					);
+				case "draft":
+					return (
+						<LuGitPullRequest
+							className={cn(
+								"size-4",
+								variant === "expanded" && "transition-colors",
+								getIconColor(),
+							)}
+							strokeWidth={STROKE_WIDTH}
+						/>
+					);
+			}
+		}
+
+		// Default to folder icon for worktree without PR state
+		return (
+			<LuFolderGit2
+				className={cn(
+					"size-4",
+					variant === "expanded" && "transition-colors",
+					getIconColor(),
+				)}
+				strokeWidth={STROKE_WIDTH}
+			/>
+		);
+	};
+
+	return (
+		<>
+			{getIcon()}
 			{workspaceStatus && workspaceStatus !== "working" && (
 				<span className={cn("absolute", overlayPosition)}>
 					<StatusIndicator status={workspaceStatus} />

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceIcon.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceIcon.tsx
@@ -1,9 +1,9 @@
 import { cn } from "@superset/ui/utils";
 import {
-	LuCircleDot,
 	LuFolderGit2,
 	LuGitMerge,
 	LuGitPullRequest,
+	LuGitPullRequestClosed,
 	LuLaptop,
 } from "react-icons/lu";
 import { AsciiSpinner } from "renderer/screens/main/components/AsciiSpinner";
@@ -103,7 +103,7 @@ export function WorkspaceIcon({
 					);
 				case "closed":
 					return (
-						<LuCircleDot
+						<LuGitPullRequestClosed
 							className={cn(
 								"size-4",
 								variant === "expanded" && "transition-colors",

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -146,7 +146,7 @@ export function WorkspaceListItem({
 		electronTrpc.workspaces.getGitHubStatus.useQuery(
 			{ workspaceId: id },
 			{
-				enabled: hasHovered && type === "worktree",
+				enabled: type === "worktree",
 				staleTime: GITHUB_STATUS_STALE_TIME,
 			},
 		);
@@ -262,6 +262,7 @@ export function WorkspaceListItem({
 				onClick={handleClick}
 				onDeleteClick={handleDeleteClick}
 				onCopyPath={handleCopyPath}
+				prState={githubStatus?.pr?.state}
 			/>
 		);
 	}
@@ -317,6 +318,7 @@ export function WorkspaceListItem({
 								isUnread={isUnread}
 								workspaceStatus={workspaceStatus}
 								variant="expanded"
+								prState={githubStatus?.pr?.state}
 							/>
 						</div>
 					</TooltipTrigger>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceStatusBadge.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceStatusBadge.tsx
@@ -1,5 +1,9 @@
 import { cn } from "@superset/ui/utils";
-import { LuCircleDot, LuGitMerge, LuGitPullRequest } from "react-icons/lu";
+import {
+	LuGitMerge,
+	LuGitPullRequest,
+	LuGitPullRequestClosed,
+} from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { STROKE_WIDTH } from "../constants";
 
@@ -44,7 +48,7 @@ export function WorkspaceStatusBadge({
 		},
 		closed: {
 			icon: (
-				<LuCircleDot
+				<LuGitPullRequestClosed
 					className={cn(iconClass, "text-destructive")}
 					strokeWidth={STROKE_WIDTH}
 				/>


### PR DESCRIPTION
## Summary
Workspace sidebar icons now dynamically reflect PR state with matching colors, and GitHub status is cached in the database to eliminate constant refetching on hover.

## Changes

### State-based Icons
- **Open PRs**: Green pull request icon
- **Draft PRs**: Gray pull request icon  
- **Merged PRs**: Purple merge icon
- **Closed PRs**: Red dot icon
- **Local workspaces**: Laptop icon (unchanged)
- **Worktrees without PR**: Folder icon (unchanged)

### Database Caching
- Implemented 30-second cache for GitHub status in local database
- Query enabled immediately to return cached data instantly
- Only fetches from GitHub when cache is stale or missing
- Eliminates the constant reloading previously seen on hover

### Visual Consistency
- Icons match the colors of PR status badges
- PR badges retain original design with icons and gray text

## Technical Details

**Files Modified:**
- `WorkspaceIcon.tsx` - Added PR state-based icons and colors
- `CollapsedWorkspaceItem.tsx` - Pass PR state to icon component
- `WorkspaceListItem.tsx` - Enable query immediately, pass PR state to icons
- `git-status.ts` - Add database caching with 30-second cache duration

## Test Plan
- [ ] Verify icons display correct colors for each PR state
- [ ] Confirm cached GitHub status loads instantly on sidebar render
- [ ] Test that cache refreshes after 30 seconds
- [ ] Check local workspace still shows laptop icon
- [ ] Verify worktrees without PRs show folder icon

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add state-based sidebar icons and a 30s DB-cached GitHub status with request deduplication. Icons and colors are consistent across the app, and we stop refetching and duplicate calls.

- **New Features**
  - PR-state icons: open (green PR), draft (gray PR), merged (purple merge), closed (red closed-PR).
  - Local workspaces keep laptop; worktrees without a PR use folder.
  - Icons match badge colors; PR badges keep gray text. All PR icons use the same set across the app.

- **Performance**
  - Cache GitHub status for 30s; query enabled immediately for worktrees; refresh only when stale.
  - Deduplicate concurrent fetches per worktree to reuse a single request.

<sup>Written for commit 803f6e777f18564fd95132a673dcbdc270cb6d70. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

