### PR TITLE
fix(desktop): remove broken "Learn more" link on integrations settings

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/integrations/components/IntegrationsSettings/IntegrationsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/integrations/components/IntegrationsSettings/IntegrationsSettings.tsx
@@ -1,4 +1,4 @@
-import { COMPANY, FEATURE_FLAGS } from "@superset/shared/constants";
+import { FEATURE_FLAGS } from "@superset/shared/constants";
 import { Badge } from "@superset/ui/badge";
 import { Button } from "@superset/ui/button";
 import {
@@ -186,16 +186,7 @@ export function IntegrationsSettings({
 			</div>
 
 			<p className="mt-6 text-xs text-muted-foreground">
-				Manage integrations in the web app to connect and configure services.{" "}
-				<a
-					href={`${COMPANY.DOCS_URL}/integrations`}
-					target="_blank"
-					rel="noopener noreferrer"
-					className="inline-flex items-center gap-1 text-primary hover:underline"
-				>
-					Learn more
-					<HiOutlineArrowTopRightOnSquare className="h-3 w-3" />
-				</a>
+				Manage integrations in the web app to connect and configure services.
 			</p>
 		</div>
 	);


### PR DESCRIPTION
## Summary
- Removed the broken "Learn more" link on the Integrations settings page (Settings > Integrations) that pointed to `docs.superset.sh/integrations` (404)
- Cleaned up the unused `COMPANY` import

## Test plan
- [ ] Open Settings > Integrations in the desktop app and verify the descriptive text displays without a broken link

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the broken “Learn more” link on Settings > Integrations in the desktop app that pointed to a 404 docs page, preventing dead navigation. Cleaned up the unused `COMPANY` import.

<sup>Written for commit bb9e7c6c2f81b3422816ab0bac22ce622e3297c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the external "Learn more" link from the integrations settings footer text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->