### PR TITLE
feat(marketing): add status page link to footer

### DIFF
--- a/apps/marketing/src/app/components/Footer/Footer.tsx
+++ b/apps/marketing/src/app/components/Footer/Footer.tsx
@@ -2,6 +2,7 @@
 
 import { COMPANY } from "@superset/shared/constants";
 import { motion } from "framer-motion";
+import { ArrowUpRight } from "lucide-react";
 import Link from "next/link";
 import { SocialLinks } from "../SocialLinks";
 
@@ -69,6 +70,15 @@ export function Footer() {
 							>
 								Terms
 							</Link>
+							<a
+								href="https://statuspage.incident.io/superset"
+								target="_blank"
+								rel="noopener noreferrer"
+								className="text-muted-foreground hover:text-foreground transition-colors inline-flex items-center gap-1 group"
+							>
+								Status
+								<ArrowUpRight className="w-3 h-3 opacity-0 group-hover:opacity-100 transition-opacity" />
+							</a>
 						</nav>
 					</div>
 


### PR DESCRIPTION
## Summary
- Added status page link to marketing site footer
- Link opens in new tab with external indicator
- Arrow icon appears on hover for better UX

## Changes
- Added "Status" link pointing to https://statuspage.incident.io/superset
- Positioned at the end of footer navigation (after Terms)
- Added `ArrowUpRight` icon from lucide-react that fades in on hover
- Includes proper `target="_blank"` and `rel="noopener noreferrer"` attributes

## Test plan
- ✅ Lint passed
- ✅ Typecheck passed
- Visual: Hover over Status link to see arrow animation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a “Status” link to the marketing site footer for quick access to uptime updates. The link appears after Terms, opens in a new tab with rel protection, and shows an `ArrowUpRight` icon from `lucide-react` that fades in on hover.

<sup>Written for commit 9c44a74dd8092a00c1b78b07e8133260456c30f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Status" link in the footer navigation that directs users to the status page, opening in a new tab with a visual indicator icon on hover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->