### PR TITLE
desktop: disable prod CDP and switch browser devtools to detached mode

### DIFF
--- a/apps/desktop/src/lib/electron-app/factories/app/setup.ts
+++ b/apps/desktop/src/lib/electron-app/factories/app/setup.ts
@@ -70,7 +70,12 @@ PLATFORM.IS_WINDOWS &&
 
 app.commandLine.appendSwitch("force-color-profile", "srgb");
 
-// Enable CDP for browser DevTools and desktop automation MCP
-const cdpPort = String(process.env.DESKTOP_AUTOMATION_PORT || 41729);
-app.commandLine.appendSwitch("remote-debugging-port", cdpPort);
-app.commandLine.appendSwitch("remote-allow-origins", "*");
+// Only expose CDP in development when a port is explicitly configured.
+const cdpPort =
+	env.NODE_ENV === "development"
+		? process.env.DESKTOP_AUTOMATION_PORT
+		: undefined;
+if (cdpPort) {
+	app.commandLine.appendSwitch("remote-debugging-port", cdpPort);
+	app.commandLine.appendSwitch("remote-allow-origins", "*");
+}

--- a/apps/desktop/src/lib/trpc/routers/browser/browser.ts
+++ b/apps/desktop/src/lib/trpc/routers/browser/browser.ts
@@ -136,13 +136,6 @@ export const createBrowserRouter = () => {
 				return { success: true };
 			}),
 
-		getDevToolsUrl: publicProcedure
-			.input(z.object({ browserPaneId: z.string() }))
-			.query(async ({ input }) => {
-				const url = await browserManager.getDevToolsUrl(input.browserPaneId);
-				return { url };
-			}),
-
 		getPageInfo: publicProcedure
 			.input(z.object({ paneId: z.string() }))
 			.query(({ input }) => {

--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "node:events";
-import { app, clipboard, Menu, shell, webContents } from "electron";
+import { clipboard, Menu, shell, webContents } from "electron";
 
 interface ConsoleEntry {
 	level: "log" | "warn" | "error" | "info" | "debug";
@@ -111,56 +111,6 @@ class BrowserManager extends EventEmitter {
 		const wc = this.getWebContents(paneId);
 		if (!wc) return;
 		wc.openDevTools({ mode: "detach" });
-	}
-
-	async getDevToolsUrl(browserPaneId: string): Promise<string | null> {
-		const wc = this.getWebContents(browserPaneId);
-		if (!wc) return null;
-
-		const cdpPort = app.commandLine.getSwitchValue("remote-debugging-port");
-		if (!cdpPort) return null;
-
-		try {
-			const targetUrl = wc.getURL();
-			const res = await fetch(`http://127.0.0.1:${cdpPort}/json`);
-			const targets = (await res.json()) as Array<{
-				id: string;
-				url: string;
-				type: string;
-				webSocketDebuggerUrl?: string;
-			}>;
-
-			const webviewTargets = targets.filter(
-				(t) => t.type === "page" || t.type === "webview",
-			);
-
-			// Strategy 1: Exact URL match
-			let target = webviewTargets.find((t) => t.url === targetUrl);
-
-			// Strategy 2: Match ignoring trailing slash / fragment differences
-			if (!target && targetUrl) {
-				const normalize = (u: string) =>
-					u.replace(/\/?(#.*)?$/, "").toLowerCase();
-				const normalizedTarget = normalize(targetUrl);
-				target = webviewTargets.find(
-					(t) => normalize(t.url) === normalizedTarget,
-				);
-			}
-
-			// Strategy 3: If only one webview target exists, use it
-			if (!target) {
-				const webviewOnly = webviewTargets.filter((t) => t.type === "webview");
-				if (webviewOnly.length === 1) {
-					target = webviewOnly[0];
-				}
-			}
-
-			if (!target) return null;
-
-			return `http://127.0.0.1:${cdpPort}/devtools/inspector.html?ws=127.0.0.1:${cdpPort}/devtools/page/${target.id}`;
-		} catch {
-			return null;
-		}
 	}
 
 	private setupContextMenu(paneId: string, wc: Electron.WebContents): void {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/BrowserPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/BrowserPane.tsx
@@ -3,6 +3,7 @@ import { GlobeIcon } from "lucide-react";
 import { useCallback } from "react";
 import { TbDeviceDesktop } from "react-icons/tb";
 import type { MosaicBranch } from "react-mosaic-component";
+import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import { BasePaneWindow, PaneToolbarActions } from "../components";
 import { BrowserErrorOverlay } from "./components/BrowserErrorOverlay";
@@ -34,7 +35,6 @@ export function BrowserPane({
 	setFocusedPane,
 }: BrowserPaneProps) {
 	const pane = useTabsStore((s) => s.panes[paneId]);
-	const openDevToolsPane = useTabsStore((s) => s.openDevToolsPane);
 	const browserState = pane?.browser;
 	const currentUrl = browserState?.currentUrl ?? DEFAULT_BROWSER_URL;
 	const pageTitle =
@@ -42,6 +42,8 @@ export function BrowserPane({
 	const isLoading = browserState?.isLoading ?? false;
 	const loadError = browserState?.error ?? null;
 	const isBlankPage = currentUrl === "about:blank";
+	const { mutate: openDevTools } =
+		electronTrpc.browser.openDevTools.useMutation();
 
 	const {
 		containerRef,
@@ -57,8 +59,8 @@ export function BrowserPane({
 	});
 
 	const handleOpenDevTools = useCallback(() => {
-		openDevToolsPane(tabId, paneId, path);
-	}, [openDevToolsPane, tabId, paneId, path]);
+		openDevTools({ paneId });
+	}, [openDevTools, paneId]);
 
 	return (
 		<BasePaneWindow

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/DevToolsPane/DevToolsPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/DevToolsPane/DevToolsPane.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import type { MosaicBranch } from "react-mosaic-component";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { BasePaneWindow, PaneToolbarActions } from "../components";
@@ -26,16 +27,12 @@ export function DevToolsPane({
 	removePane,
 	setFocusedPane,
 }: DevToolsPaneProps) {
-	// Query the CDP debug server for the DevTools frontend URL.
-	// Poll every 1s until a URL is obtained (the browser webview may still be loading).
-	const { data } = electronTrpc.browser.getDevToolsUrl.useQuery(
-		{ browserPaneId: targetPaneId },
-		{
-			refetchOnWindowFocus: false,
-			refetchInterval: (query) => (query.state.data?.url ? false : 1000),
-		},
-	);
-	const devToolsUrl = data?.url;
+	const { mutate: openDevTools } =
+		electronTrpc.browser.openDevTools.useMutation();
+
+	useEffect(() => {
+		openDevTools({ paneId: targetPaneId });
+	}, [openDevTools, targetPaneId]);
 
 	return (
 		<BasePaneWindow
@@ -59,17 +56,16 @@ export function DevToolsPane({
 				</div>
 			)}
 		>
-			{devToolsUrl ? (
-				<webview
-					src={devToolsUrl}
-					className="w-full h-full"
-					style={{ display: "flex", flex: 1 }}
-				/>
-			) : (
-				<div className="flex h-full w-full items-center justify-center text-muted-foreground text-xs">
-					Connecting to DevTools...
-				</div>
-			)}
+			<div className="flex h-full w-full flex-col items-center justify-center gap-3 text-muted-foreground text-xs">
+				<div>DevTools open in a separate window.</div>
+				<button
+					type="button"
+					onClick={() => openDevTools({ paneId: targetPaneId })}
+					className="rounded border border-border px-3 py-1.5 text-foreground transition-colors hover:bg-accent"
+				>
+					Reopen DevTools
+				</button>
+			</div>
 		</BasePaneWindow>
 	);
 }

--- a/apps/desktop/src/shared/env.shared.ts
+++ b/apps/desktop/src/shared/env.shared.ts
@@ -20,7 +20,6 @@ const envSchema = z.object({
 	DESKTOP_VITE_PORT: z.coerce.number().default(5173),
 	DESKTOP_NOTIFICATIONS_PORT: z.coerce.number().default(51741),
 	ELECTRIC_PORT: z.coerce.number().default(5133),
-	DESKTOP_AUTOMATION_PORT: z.coerce.number().default(41729),
 	// Workspace name for instance isolation
 	SUPERSET_WORKSPACE_NAME: z.string().default("superset"),
 });
@@ -37,7 +36,6 @@ export const env = envSchema.parse({
 	DESKTOP_VITE_PORT: process.env.DESKTOP_VITE_PORT,
 	DESKTOP_NOTIFICATIONS_PORT: process.env.DESKTOP_NOTIFICATIONS_PORT,
 	ELECTRIC_PORT: process.env.ELECTRIC_PORT,
-	DESKTOP_AUTOMATION_PORT: process.env.DESKTOP_AUTOMATION_PORT,
 	SUPERSET_WORKSPACE_NAME: process.env.SUPERSET_WORKSPACE_NAME,
 });
 

--- a/packages/desktop-mcp/src/mcp/connection/connection-manager.ts
+++ b/packages/desktop-mcp/src/mcp/connection/connection-manager.ts
@@ -2,8 +2,6 @@ import puppeteer, { type Browser, type Page } from "puppeteer-core";
 import { ConsoleCapture } from "../console-capture/index.js";
 import { FocusLock } from "../focus-lock/index.js";
 
-const CDP_PORT = Number(process.env.DESKTOP_AUTOMATION_PORT) || 41729;
-
 /**
  * Manages a CDP connection to the Electron renderer via puppeteer-core.
  *
@@ -27,8 +25,15 @@ export class ConnectionManager {
 	}
 
 	private async connect(): Promise<Page> {
+		const cdpPort = process.env.DESKTOP_AUTOMATION_PORT;
+		if (!cdpPort) {
+			throw new Error(
+				"[desktop-mcp] Desktop automation is unavailable. CDP is only enabled in development when DESKTOP_AUTOMATION_PORT is set.",
+			);
+		}
+
 		this.browser = await puppeteer.connect({
-			browserURL: `http://127.0.0.1:${CDP_PORT}`,
+			browserURL: `http://127.0.0.1:${cdpPort}`,
 			protocolTimeout: 60_000,
 			defaultViewport: null,
 		});


### PR DESCRIPTION
## Summary
- disable remote debugging in production and only enable CDP in development when `DESKTOP_AUTOMATION_PORT` is explicitly set
- remove the fixed automation port fallback and make `desktop-mcp` fail clearly when automation is disabled
- switch browser DevTools to Electron's native detached DevTools window so the app no longer depends on the embedded CDP inspector path
- remove the old CDP-backed DevTools URL lookup path from the browser router and manager

## Testing
- `bunx biome check apps/desktop/src/lib/electron-app/factories/app/setup.ts apps/desktop/src/shared/env.shared.ts packages/desktop-mcp/src/mcp/connection/connection-manager.ts apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/BrowserPane.tsx apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/DevToolsPane/DevToolsPane.tsx apps/desktop/src/lib/trpc/routers/browser/browser.ts apps/desktop/src/main/lib/browser/browser-manager.ts`
- `bunx tsc --noEmit --ignoreDeprecations 6.0 -p packages/desktop-mcp/tsconfig.json`
- `bunx tsc --noEmit --ignoreDeprecations 6.0 -p apps/desktop/tsconfig.json` *(fails in this branch due to existing unrelated route generation / type issues, including missing `routeTree.gen` and downstream route typing errors)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated DevTools opening behavior to launch in a separate window instead of inline within the application.
  * Added "Reopen DevTools" button for easier access to developer tools.

* **Chores**
  * Simplified Chrome DevTools Protocol configuration to only activate in development environments when explicitly configured.
  * Removed unused automation-related environment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->