### PR TITLE
feat: add merge queue status for PR indicator

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceHoverCardContent/components/PullRequestStatusBadge/PullRequestStatusBadge.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceHoverCardContent/components/PullRequestStatusBadge/PullRequestStatusBadge.tsx
@@ -1,5 +1,5 @@
 interface PullRequestStatusBadgeProps {
-	state: "open" | "draft" | "merged" | "closed";
+	state: "open" | "draft" | "merged" | "closed" | "queued";
 }
 
 export function PullRequestStatusBadge({ state }: PullRequestStatusBadgeProps) {
@@ -8,6 +8,7 @@ export function PullRequestStatusBadge({ state }: PullRequestStatusBadgeProps) {
 		draft: "bg-muted text-muted-foreground",
 		merged: "bg-violet-500/15 text-violet-500",
 		closed: "bg-destructive/15 text-destructive-foreground",
+		queued: "bg-amber-500/15 text-amber-500",
 	};
 
 	const labels = {
@@ -15,6 +16,7 @@ export function PullRequestStatusBadge({ state }: PullRequestStatusBadgeProps) {
 		draft: "Draft",
 		merged: "Merged",
 		closed: "Closed",
+		queued: "Queued",
 	};
 
 	return (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceHoverCardContent/components/PullRequestStatusBadge/PullRequestStatusBadge.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceHoverCardContent/components/PullRequestStatusBadge/PullRequestStatusBadge.tsx
@@ -1,7 +1,9 @@
+/** Props accepted by the {@link PullRequestStatusBadge} component. */
 interface PullRequestStatusBadgeProps {
 	state: "open" | "draft" | "merged" | "closed" | "queued";
 }
 
+/** Renders a small coloured badge indicating the pull request state inside the dashboard sidebar hover card. */
 export function PullRequestStatusBadge({ state }: PullRequestStatusBadgeProps) {
 	const styles = {
 		open: "bg-emerald-500/15 text-emerald-500",

--- a/apps/desktop/src/renderer/screens/main/components/PRIcon/PRIcon.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/PRIcon/PRIcon.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@superset/ui/utils";
 import { LuCircleDot, LuGitMerge, LuGitPullRequest } from "react-icons/lu";
 
-export type PRState = "open" | "merged" | "closed" | "draft";
+export type PRState = "open" | "merged" | "closed" | "draft" | "queued";
 
 interface PRIconProps {
 	state: PRState;
@@ -13,6 +13,7 @@ const stateStyles: Record<PRState, string> = {
 	merged: "text-violet-500",
 	closed: "text-red-500",
 	draft: "text-muted-foreground",
+	queued: "text-amber-500",
 };
 
 /**
@@ -21,6 +22,7 @@ const stateStyles: Record<PRState, string> = {
  * - merged: purple/violet merge icon
  * - closed: red dot icon
  * - draft: muted pull request icon
+ * - queued: amber pull request icon (in merge queue)
  */
 export function PRIcon({ state, className }: PRIconProps) {
 	const baseClass = cn(stateStyles[state], className);
@@ -33,6 +35,6 @@ export function PRIcon({ state, className }: PRIconProps) {
 		return <LuCircleDot className={baseClass} />;
 	}
 
-	// open or draft
+	// open, draft, or queued
 	return <LuGitPullRequest className={baseClass} />;
 }

--- a/apps/desktop/src/renderer/screens/main/components/PRIcon/PRIcon.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/PRIcon/PRIcon.tsx
@@ -1,8 +1,10 @@
 import { cn } from "@superset/ui/utils";
 import { LuCircleDot, LuGitMerge, LuGitPullRequest } from "react-icons/lu";
 
+/** Possible visual states for a pull request icon. Includes "queued" for merge queue entries. */
 export type PRState = "open" | "merged" | "closed" | "draft" | "queued";
 
+/** Props accepted by the {@link PRIcon} component. */
 interface PRIconProps {
 	state: PRState;
 	className?: string;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/components/PRStatusBadge/PRStatusBadge.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/components/PRStatusBadge/PRStatusBadge.tsx
@@ -1,5 +1,5 @@
 interface PRStatusBadgeProps {
-	state: "open" | "draft" | "merged" | "closed";
+	state: "open" | "draft" | "merged" | "closed" | "queued";
 }
 
 export function PRStatusBadge({ state }: PRStatusBadgeProps) {
@@ -8,6 +8,7 @@ export function PRStatusBadge({ state }: PRStatusBadgeProps) {
 		draft: "bg-muted text-muted-foreground",
 		merged: "bg-violet-500/15 text-violet-500",
 		closed: "bg-destructive/15 text-destructive-foreground",
+		queued: "bg-amber-500/15 text-amber-500",
 	};
 
 	const labels = {
@@ -15,6 +16,7 @@ export function PRStatusBadge({ state }: PRStatusBadgeProps) {
 		draft: "Draft",
 		merged: "Merged",
 		closed: "Closed",
+		queued: "Queued",
 	};
 
 	return (

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/components/PRStatusBadge/PRStatusBadge.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/components/PRStatusBadge/PRStatusBadge.tsx
@@ -1,7 +1,9 @@
+/** Props accepted by the {@link PRStatusBadge} component. */
 interface PRStatusBadgeProps {
 	state: "open" | "draft" | "merged" | "closed" | "queued";
 }
 
+/** Renders a small coloured badge showing the current pull request state label (e.g. "Open", "Queued"). */
 export function PRStatusBadge({ state }: PRStatusBadgeProps) {
 	const styles = {
 		open: "bg-emerald-500/15 text-emerald-500",

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -441,7 +441,7 @@ export class PullRequestRuntimeManager {
 				prNumber: node.number,
 				url: node.url,
 				title: node.title,
-				state: mapPullRequestState(node.state, node.isDraft),
+				state: mapPullRequestState(node.state, node.isDraft, node.mergeQueueEntry),
 				isDraft: node.isDraft,
 				headBranch: node.headRefName,
 				headSha: node.headRefOid,

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/query.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/query.ts
@@ -12,6 +12,9 @@ export const PULL_REQUESTS_QUERY = `
 					headRefOid
 					reviewDecision
 					updatedAt
+					mergeQueueEntry {
+						position
+					}
 					statusCheckRollup {
 						contexts(first: 50) {
 							nodes {

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/query.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/query.ts
@@ -1,3 +1,7 @@
+/**
+ * GraphQL query that fetches the latest 100 pull requests for a given repository.
+ * Includes PR metadata, review decisions, merge queue status, and CI check results.
+ */
 export const PULL_REQUESTS_QUERY = `
 	query PullRequestsForSidebar($owner: String!, $repo: String!) {
 		repository(owner: $owner, name: $repo) {

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/types.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/types.ts
@@ -36,6 +36,7 @@ export interface GraphQLPullRequestNode {
 	headRefOid: string;
 	reviewDecision: "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | null;
 	updatedAt: string;
+	mergeQueueEntry: { position: number } | null;
 	statusCheckRollup: {
 		contexts: {
 			nodes: GraphQLCheckContextNode[];

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/types.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/types.ts
@@ -1,3 +1,4 @@
+/** Represents a GitHub Actions check run node returned by the GraphQL API. */
 export interface GraphQLCheckRunNode {
 	__typename: "CheckRun";
 	name: string;
@@ -13,6 +14,7 @@ export interface GraphQLCheckRunNode {
 	} | null;
 }
 
+/** Represents a commit status context node returned by the GraphQL API. */
 export interface GraphQLStatusContextNode {
 	__typename: "StatusContext";
 	context: string;
@@ -21,11 +23,13 @@ export interface GraphQLStatusContextNode {
 	createdAt: string | null;
 }
 
+/** Union of possible check context nodes - either a CheckRun, a StatusContext, or null. */
 export type GraphQLCheckContextNode =
 	| GraphQLCheckRunNode
 	| GraphQLStatusContextNode
 	| null;
 
+/** Shape of a single pull request node as returned by the GitHub GraphQL API. */
 export interface GraphQLPullRequestNode {
 	number: number;
 	title: string;
@@ -44,6 +48,7 @@ export interface GraphQLPullRequestNode {
 	} | null;
 }
 
+/** Top-level shape of the GraphQL response for the pull requests query. */
 export interface PullRequestsGraphQLResult {
 	repository?: {
 		pullRequests?: {

--- a/packages/host-service/src/runtime/pull-requests/utils/pull-request-mappers/pull-request-mappers.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/pull-request-mappers/pull-request-mappers.ts
@@ -3,7 +3,7 @@ import type {
 	GraphQLPullRequestNode,
 } from "../github-query";
 
-export type PullRequestState = "open" | "draft" | "merged" | "closed";
+export type PullRequestState = "open" | "draft" | "merged" | "closed" | "queued";
 export type ReviewDecision =
 	| "approved"
 	| "changes_requested"
@@ -21,10 +21,12 @@ export interface PullRequestCheck {
 export function mapPullRequestState(
 	state: GraphQLPullRequestNode["state"],
 	isDraft: boolean,
+	mergeQueueEntry?: GraphQLPullRequestNode["mergeQueueEntry"],
 ): PullRequestState {
 	if (state === "MERGED") return "merged";
 	if (state === "CLOSED") return "closed";
 	if (isDraft) return "draft";
+	if (mergeQueueEntry != null) return "queued";
 	return "open";
 }
 
@@ -88,7 +90,7 @@ export function computeChecksStatus(checks: PullRequestCheck[]): ChecksStatus {
 }
 
 export function coercePullRequestState(value: string | null): PullRequestState {
-	if (value === "merged" || value === "closed" || value === "draft") {
+	if (value === "merged" || value === "closed" || value === "draft" || value === "queued") {
 		return value;
 	}
 	return "open";

--- a/packages/host-service/src/runtime/pull-requests/utils/pull-request-mappers/pull-request-mappers.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/pull-request-mappers/pull-request-mappers.ts
@@ -3,21 +3,30 @@ import type {
 	GraphQLPullRequestNode,
 } from "../github-query";
 
+/** Normalized pull request state used across the application. Includes "queued" for PRs that are in a merge queue. */
 export type PullRequestState = "open" | "draft" | "merged" | "closed" | "queued";
+/** Normalized review decision value. Null means no review decision is available. */
 export type ReviewDecision =
 	| "approved"
 	| "changes_requested"
 	| "pending"
 	| null;
+/** Aggregated status of all CI checks on a pull request. "none" when there are no checks at all. */
 export type ChecksStatus = "success" | "failure" | "pending" | "none";
 type CheckStatus = "success" | "failure" | "pending" | "skipped" | "cancelled";
 
+/** Single CI check associated with a pull request, combining CheckRun and StatusContext into one shape. */
 export interface PullRequestCheck {
 	name: string;
 	status: CheckStatus;
 	url: string | null;
 }
 
+/**
+ * Maps the raw GitHub PR state into a normalized {@link PullRequestState}.
+ * When {@link mergeQueueEntry} is present the PR is considered "queued",
+ * which takes priority over the regular "open" state.
+ */
 export function mapPullRequestState(
 	state: GraphQLPullRequestNode["state"],
 	isDraft: boolean,
@@ -30,6 +39,7 @@ export function mapPullRequestState(
 	return "open";
 }
 
+/** Converts a GitHub GraphQL review decision value into a normalized lowercase form. */
 export function mapReviewDecision(
 	value: GraphQLPullRequestNode["reviewDecision"],
 ): ReviewDecision {
@@ -39,6 +49,10 @@ export function mapReviewDecision(
 	return null;
 }
 
+/**
+ * Parses raw GraphQL check context nodes into a deduplicated list of {@link PullRequestCheck}.
+ * When the same check name appears more than once, only the most recent run is kept.
+ */
 export function parseCheckContexts(
 	nodes: GraphQLCheckContextNode[],
 ): PullRequestCheck[] {
@@ -82,6 +96,7 @@ export function parseCheckContexts(
 	);
 }
 
+/** Derives an aggregated {@link ChecksStatus} from a list of individual checks. */
 export function computeChecksStatus(checks: PullRequestCheck[]): ChecksStatus {
 	if (checks.length === 0) return "none";
 	if (checks.some((check) => check.status === "failure")) return "failure";
@@ -89,6 +104,7 @@ export function computeChecksStatus(checks: PullRequestCheck[]): ChecksStatus {
 	return "success";
 }
 
+/** Safely coerces an arbitrary string into a valid {@link PullRequestState}, defaulting to "open". */
 export function coercePullRequestState(value: string | null): PullRequestState {
 	if (value === "merged" || value === "closed" || value === "draft" || value === "queued") {
 		return value;
@@ -96,6 +112,7 @@ export function coercePullRequestState(value: string | null): PullRequestState {
 	return "open";
 }
 
+/** Safely coerces an arbitrary string into a valid {@link ReviewDecision}, defaulting to null. */
 export function coerceReviewDecision(value: string | null): ReviewDecision {
 	if (
 		value === "approved" ||
@@ -107,6 +124,7 @@ export function coerceReviewDecision(value: string | null): ReviewDecision {
 	return null;
 }
 
+/** Safely coerces an arbitrary string into a valid {@link ChecksStatus}, defaulting to "none". */
 export function coerceChecksStatus(value: string | null): ChecksStatus {
 	if (value === "success" || value === "failure" || value === "pending") {
 		return value;
@@ -114,6 +132,7 @@ export function coerceChecksStatus(value: string | null): ChecksStatus {
 	return "none";
 }
 
+/** Parses a JSON string into an array of {@link PullRequestCheck}. Returns an empty array on invalid input. */
 export function parseChecksJson(value: string | null): PullRequestCheck[] {
 	if (!value) return [];
 

--- a/packages/local-db/src/schema/zod.ts
+++ b/packages/local-db/src/schema/zod.ts
@@ -49,7 +49,7 @@ export const gitHubStatusSchema = z.object({
 			number: z.number(),
 			title: z.string(),
 			url: z.string(),
-			state: z.enum(["open", "draft", "merged", "closed"]),
+			state: z.enum(["open", "draft", "merged", "closed", "queued"]),
 			mergedAt: z.number().optional(),
 			additions: z.number(),
 			deletions: z.number(),


### PR DESCRIPTION
## Problem

When a PR is added to GitHub merge queue, the PR status indicator in the sidebar shows no state or falls back to generic "open". There is no visual indication that the PR is actually queued for merging.

I noticed this when our team started using merge queues and I couldnt tell from Superset which PRs were waiting in the queue vs just open.

## What I changed

Added `"queued"` as a new PR state across the full stack (8 files):

**Backend (GraphQL + mapping)**
- `packages/host-service/.../github-query/query.ts` - Added `mergeQueueEntry { position }` to the PR GraphQL query
- `packages/host-service/.../github-query/types.ts` - Added `mergeQueueEntry` field to `GraphQLPullRequestNode`
- `packages/host-service/.../pull-request-mappers.ts` - Added `"queued"` to `PullRequestState` type, updated `mapPullRequestState()` to check for `mergeQueueEntry != null`, updated `coercePullRequestState()` to accept `"queued"`
- `packages/host-service/.../pull-requests.ts` - Pass `node.mergeQueueEntry` to `mapPullRequestState()`

**Schema**
- `packages/local-db/src/schema/zod.ts` - Added `"queued"` to the PR state zod enum

**UI (both badge components + icon)**
- `PRStatusBadge.tsx` (workspace sidebar) - Added queued style (amber) and label
- `PullRequestStatusBadge.tsx` (dashboard sidebar) - Same amber styling
- `PRIcon.tsx` - Added `"queued"` to `PRState` type with amber color

The queued state shows as **amber/yellow** badge with text "Queued" - visually distinct from open (green), draft (gray), merged (purple), closed (red).

## How merge queue detection works

GitHub's GraphQL API provides `mergeQueueEntry` field on pull request nodes. When a PR is in the merge queue, this field is non-null and contains the queue position. When not in queue, its null. So the logic is simply:

```typescript
if (mergeQueueEntry != null) return "queued";
```

This runs after the merged/closed/draft checks, so only open PRs that are in the queue get the "queued" state.

Closes #2870

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Queued" pull request status across the app: displays as "Queued" with amber styling, updates PR icons to treat queued like other active states, and surfaces queue position so PRs in the merge queue are clearly indicated.
* **Chores**
  * Backend and local data schema updated to record and expose merge-queue information so the UI can show the queued state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->