### PR TITLE
fix(electric-proxy): add Vary: Authorization header

### DIFF
--- a/apps/electric-proxy/src/index.ts
+++ b/apps/electric-proxy/src/index.ts
@@ -24,6 +24,7 @@ function addCorsHeaders(response: Response): Response {
 	for (const [key, value] of Object.entries(CORS_HEADERS)) {
 		headers.set(key, value);
 	}
+	headers.set("Vary", "Authorization");
 	return new Response(response.body, {
 		status: response.status,
 		statusText: response.statusText,


### PR DESCRIPTION
## Summary
- Adds `Vary: Authorization` header to Electric SQL proxy responses
- Ensures caches correctly differentiate responses per auth token, preventing stale data when switching orgs/users
- Follows Electric SQL team's recommended approach for [session invalidation with Vary headers](https://electric-sql.com/docs/guides/auth#session-invalidation-with-vary-headers)

## Test plan
- [ ] Deploy to staging and verify `Vary: Authorization` header is present in proxy responses
- [ ] Switch between orgs/users and confirm no stale cached data is served

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `Vary: Authorization` to Electric SQL proxy responses so caches key responses by auth token. This prevents stale data when switching orgs or users.

<sup>Written for commit 4152bd1c7109b471caf245de8ac1ea5cc7717d26. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved cache handling for authenticated requests by updating response headers to properly signal cache variation based on authorization credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->