### PR TITLE
chore(electric): downsize Fly VM from performance-4x to shared-cpu-2x

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -5,9 +5,9 @@ primary_region = "iad"
 image = "electricsql/electric:1.4.13"
 
 [[vm]]
-memory = "8192mb"
-cpu_kind = "performance"
-cpus = 4
+memory = "512mb"
+cpu_kind = "shared"
+cpus = 2
 
 [env]
 ELECTRIC_DATABASE_USE_IPV6 = "true"


### PR DESCRIPTION
## Summary
- Downsizes `superset-electric` Fly VM from `performance-4x` (4 dedicated CPUs, 8GB RAM, ~$124/mo) to `shared-cpu-2x` (2 shared CPUs, 512MB, ~$4/mo)
- The machine handles ~200 req/min — massively over-provisioned at current size
- This was also causing manual `fly machines update` resizes to revert on every deploy

## Test plan
- [ ] Merge and verify deploy sets the correct VM size
- [ ] Monitor Electric SQL health checks post-deploy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Downsizes the Fly VM for the `superset-electric` proxy from performance-4x (4 dedicated CPUs, 8GB) to shared-cpu-2x (2 shared CPUs, 512MB) to match ~200 req/min load and save about $120/month. Sets the size in `fly.toml` so deploys use the intended config and stop reverting manual resizes.

<sup>Written for commit f46e402ce365c07ad730c2ec996863aba3f05106. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment infrastructure resource configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->