### PR TITLE
fix(auth): disable API key rate limiting — breaks MCP after ~7 calls

### DIFF
--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -172,6 +172,9 @@ export const auth = betterAuth({
 			enableMetadata: true,
 			enableSessionForAPIKeys: true,
 			defaultPrefix: "sk_live_",
+			rateLimit: {
+				enabled: false,
+			},
 		}),
 		jwt({
 			jwks: {


### PR DESCRIPTION
## Summary
- Better-auth's API key plugin defaults to **10 requests per 24 hours** with rate limiting enabled
- MCP clients use ~3 requests on init (capabilities, tool listing, etc.), leaving only ~7 tool calls before the key gets blocked
- Disables rate limiting on API keys entirely — our API already has its own rate limiting at the infrastructure level

## Context
Customer reported API keys dying after a handful of MCP tool calls. Root cause is better-auth's aggressive default rate limit config that we weren't overriding.

## Test plan
- [ ] Create a new API key and verify MCP works beyond 10 requests
- [ ] Verify existing API keys are unaffected (rate limit fields in DB are per-key, but new config prevents new keys from getting the restrictive defaults)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled `better-auth` API key rate limiting to stop MCP keys from being blocked after ~7 calls. Our infra already enforces rate limits, so keys now work beyond the previous 10-requests/24h default.

- **Bug Fixes**
  - Set `rateLimit.enabled = false` in the API key plugin.
  - New keys no longer inherit restrictive defaults; existing keys remain unchanged.

<sup>Written for commit f248042eeb710b686032da65b7f520c7a138dc38. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API key authentication requests are no longer subject to rate limiting, allowing for more reliable access to authentication endpoints without hitting rate limit thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->