### PR TITLE
fix(desktop): avoid stale historical PR matches

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.test.ts
@@ -10,6 +10,7 @@ import {
 	branchMatchesPR,
 	getPRHeadBranchCandidates,
 	prMatchesLocalBranch,
+	shouldAcceptPRMatch,
 } from "./pr-resolution";
 import {
 	getPullRequestRepoArgs,
@@ -404,6 +405,53 @@ describe("prMatchesLocalBranch", () => {
 				headRepositoryOwner: null,
 			}),
 		).toBe(false);
+	});
+});
+
+describe("shouldAcceptPRMatch", () => {
+	test("keeps open PR matches even when local HEAD differs", () => {
+		expect(
+			shouldAcceptPRMatch({
+				localBranch: "feature/my-thing",
+				headSha: "local-head-sha",
+				pr: {
+					headRefName: "feature/my-thing",
+					headRefOid: "remote-head-sha",
+					headRepositoryOwner: null,
+					state: "OPEN",
+				},
+			}),
+		).toBe(true);
+	});
+
+	test("rejects historical PR matches when the head commit differs", () => {
+		expect(
+			shouldAcceptPRMatch({
+				localBranch: "feature/my-thing",
+				headSha: "new-head-sha",
+				pr: {
+					headRefName: "feature/my-thing",
+					headRefOid: "old-pr-head-sha",
+					headRepositoryOwner: null,
+					state: "MERGED",
+				},
+			}),
+		).toBe(false);
+	});
+
+	test("accepts historical PR matches when the head commit still matches", () => {
+		expect(
+			shouldAcceptPRMatch({
+				localBranch: "feature/my-thing",
+				headSha: "same-head-sha",
+				pr: {
+					headRefName: "feature/my-thing",
+					headRefOid: "same-head-sha",
+					headRepositoryOwner: null,
+					state: "MERGED",
+				},
+			}),
+		).toBe(true);
 	});
 });
 

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/pr-resolution.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/pr-resolution.ts
@@ -17,7 +17,11 @@ export async function getPRForBranch(
 	repoContext?: RepoContext,
 	headSha?: string,
 ): Promise<GitHubStatus["pr"]> {
-	const byTracking = await getPRByBranchTracking(worktreePath, localBranch);
+	const byTracking = await getPRByBranchTracking(
+		worktreePath,
+		localBranch,
+		headSha,
+	);
 	if (byTracking) {
 		return byTracking;
 	}
@@ -90,6 +94,36 @@ export function prMatchesLocalBranch(
 	return pr.headRepositoryOwner?.login?.toLowerCase() === ownerPrefix;
 }
 
+function isHistoricalPullRequestState(state: GHPRResponse["state"]): boolean {
+	return state === "CLOSED" || state === "MERGED";
+}
+
+export function shouldAcceptPRMatch({
+	localBranch,
+	pr,
+	headSha,
+}: {
+	localBranch: string;
+	pr: Pick<
+		GHPRResponse,
+		"headRefName" | "headRefOid" | "headRepositoryOwner" | "state"
+	>;
+	headSha?: string;
+}): boolean {
+	if (!prMatchesLocalBranch(localBranch, pr)) {
+		return false;
+	}
+
+	// Historical PRs should only attach when this workspace still points at the
+	// exact PR head commit. Otherwise, reusing a branch name can surface an old,
+	// unrelated closed or merged PR.
+	if (headSha && isHistoricalPullRequestState(pr.state)) {
+		return pr.headRefOid === headSha;
+	}
+
+	return true;
+}
+
 function sortPRCandidates(
 	candidates: GHPRResponse[],
 	headSha?: string,
@@ -133,6 +167,7 @@ function sortPRCandidates(
 async function getPRByBranchTracking(
 	worktreePath: string,
 	localBranch: string,
+	headSha?: string,
 ): Promise<GitHubStatus["pr"]> {
 	try {
 		const { stdout } = await execWithShellEnv(
@@ -150,7 +185,7 @@ async function getPRByBranchTracking(
 		// `gh pr view` can match via stale tracking refs (e.g. refs/pull/N/head)
 		// left over from a previous `gh pr checkout`, causing a new workspace
 		// to incorrectly show an old, unrelated PR.
-		if (!prMatchesLocalBranch(localBranch, data)) {
+		if (!shouldAcceptPRMatch({ localBranch, pr: data, headSha })) {
 			return null;
 		}
 
@@ -199,7 +234,7 @@ async function findPRByHeadBranch(
 			);
 
 			for (const candidate of parsePRListResponse(stdout)) {
-				if (prMatchesLocalBranch(localBranch, candidate)) {
+				if (shouldAcceptPRMatch({ localBranch, pr: candidate, headSha })) {
 					matches.set(candidate.number, candidate);
 				}
 			}


### PR DESCRIPTION
## Summary
- tighten desktop PR resolution so branch-name matches do not attach stale closed or merged PRs unless the workspace HEAD still matches that PR head commit
- keep open PR matching behavior unchanged so active branch workflows continue to resolve normally
- add targeted tests for open and historical PR matching behavior

## Verification
- bun test apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.test.ts
- bunx biome check apps/desktop/src/lib/trpc/routers/workspaces/utils/github/pr-resolution.ts apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.test.ts

Task: ab8cd32a-0770-4add-9611-eaab15df7692

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops stale PRs from auto-attaching in Desktop when a branch name is reused by only accepting closed/merged PRs if the workspace HEAD matches the PR head commit. Open PR matching stays the same.

- **Bug Fixes**
  - Added shouldAcceptPRMatch to verify branch match and, for closed/merged PRs, require head SHA equality.
  - Passed headSha through tracking and search; replaced direct checks with shouldAcceptPRMatch.
  - Added tests for open vs. historical matching; aligns with Linear task ab8cd32a-0770-4add-9611-eaab15df7692.

<sup>Written for commit ec8d4704d0cb707ab8fd9a2f1a1ed60c83293b94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for pull request matching validation across different PR states.

* **Bug Fixes**
  * Improved pull request detection to correctly handle OPEN, MERGED, and CLOSED pull requests with accurate branch state matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->