### PR TITLE
docs: add desktop UI blocking crash audit

### DIFF
--- a/docs/issues/ui-blocking-crash-audit.md
+++ b/docs/issues/ui-blocking-crash-audit.md
@@ -170,18 +170,33 @@ The renderer should fetch coarse-grained snapshots and subscribe to invalidation
 - Move project icon lookup, slash command discovery, and similar blocking lookups behind async runtime calls.
 - Defer non-essential startup work until after first paint.
 
-### Phase 3: Move local DB ownership to desktop runtime
+### Phase 3: Offload high-latency workspace mutations to runtime workers
+
+- Introduce a runtime job layer for the most blocking operations before the full platform migration is complete.
+- Start with git worktree create and delete flows, since they can block for a long time on git, filesystem teardown, and cleanup.
+- Route those operations through async runtime jobs with progress, cancellation, retries where safe, and terminal status events for the UI.
+- Keep Electron main as a broker that submits jobs and forwards updates, rather than executing the work directly.
+- Use this phase to prove the worker/runtime contract on the worst latency paths before moving the rest of local state management.
+
+Examples of good first candidates:
+
+- git worktree creation
+- git worktree deletion
+- branch sync or fetch paths tied to workspace lifecycle
+- large filesystem cleanup during workspace teardown
+
+### Phase 4: Move local DB ownership to desktop runtime
 
 - Move `better-sqlite3` usage out of Electron main.
 - Move settings, workspaces, projects, and sidebar query assembly into desktop runtime.
 - Keep main as a broker.
 
-### Phase 4: Publish read models instead of raw local joins
+### Phase 5: Publish read models instead of raw local joins
 
 - Replace repeated synchronous joins with runtime-owned snapshots.
 - Invalidate snapshots on mutations instead of rebuilding them ad hoc in the UI path.
 
-### Phase 5: Add enforcement
+### Phase 6: Add enforcement
 
 - Ban Node `*Sync` APIs in renderer and Electron main, except in tightly-reviewed boot shims if unavoidable.
 - Ban `better-sqlite3` imports outside desktop runtime.


### PR DESCRIPTION
## Summary
- add a desktop UI-blocking crash audit doc under `docs/issues/`
- document the main renderer and Electron main-process blocking risks found in the audit
- recommend a long-term architecture based on a dedicated background desktop runtime process

## Testing
- not run (documentation-only change)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a desktop UI‑blocking crash audit under `docs/issues/`. It documents renderer and Electron main‑process blocking risks, proposes a dedicated desktop runtime with a phased migration plan, and adds a runtime worker migration phase with immediate mitigations.

<sup>Written for commit c00cccccfe654379c4d2172b75a508cab3451a0f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a high-severity audit documenting UI-blocking causes (blocking dialogs, synchronous DB/filesystem work, startup tasks, icon resolution) and immediate mitigation opportunities.
  * Described a target architecture (dedicated desktop runtime), async IPC/RPC patterns, read-models and invalidation-driven refresh, and a phased migration plan with guardrails to improve app stability and responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->