### PR TITLE
feat(mcp): support updating task status by name

### DIFF
--- a/apps/api/MCP_TOOLS.md
+++ b/apps/api/MCP_TOOLS.md
@@ -54,6 +54,7 @@ const updateTaskInput = z.object({
   priority: z.enum(["urgent", "high", "medium", "low", "none"]).optional(),
   assigneeId: z.string().uuid().nullable().optional().describe("New assignee (null to unassign)"),
   statusId: z.string().uuid().optional().describe("New status ID"),
+  statusName: z.string().optional().describe('New status/section name (for example "Todo", "In Progress", or "In Review")'),
   labels: z.array(z.string()).optional().describe("Replace labels"),
   dueDate: z.string().datetime().nullable().optional().describe("New due date (null to clear)"),
   estimate: z.number().int().positive().nullable().optional(),

--- a/apps/docs/content/docs/mcp.mdx
+++ b/apps/docs/content/docs/mcp.mdx
@@ -209,7 +209,7 @@ API keys grant full access to your organization. Keep them secret and never comm
 | Tool | Description |
 |------|-------------|
 | `create_task` | Create one or more tasks (batch up to 25) |
-| `update_task` | Update existing tasks |
+| `update_task` | Update existing tasks, including moving them between status sections by `statusId` or `statusName` |
 | `list_tasks` | List tasks with filters (status, assignee, priority, labels) |
 | `get_task` | Get a single task by ID or slug |
 | `delete_task` | Soft delete tasks |
@@ -252,6 +252,7 @@ Once connected, you can ask your AI agent to:
 
 - "Create a task for fixing the login bug"
 - "List all my assigned tasks"
+- "Move SUPER-123 to In Progress"
 - "Create a new workspace for the auth feature"
 - "Show me who's online in my team"
 - "Start a Claude session on my MacBook to work on the auth task"

--- a/packages/mcp/src/tools/tasks/update-task/update-task.test.ts
+++ b/packages/mcp/src/tools/tasks/update-task/update-task.test.ts
@@ -1,0 +1,277 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const taskStatusesTable = {
+	id: "task_statuses.id",
+	name: "task_statuses.name",
+	color: "task_statuses.color",
+	type: "task_statuses.type",
+	position: "task_statuses.position",
+	progressPercent: "task_statuses.progress_percent",
+	organizationId: "task_statuses.organization_id",
+};
+
+const tasksTable = {
+	id: "tasks.id",
+	slug: "tasks.slug",
+	title: "tasks.title",
+	statusId: "tasks.status_id",
+	organizationId: "tasks.organization_id",
+	deletedAt: "tasks.deleted_at",
+};
+
+let dbSelectResults: unknown[][] = [];
+let updateResults: unknown[][] = [];
+
+const selectLimitMock = mock(async () => dbSelectResults.shift() ?? []);
+const selectWhereMock = mock((table: unknown) => {
+	if (table === taskStatusesTable) {
+		return Promise.resolve(dbSelectResults.shift() ?? []);
+	}
+
+	return {
+		limit: selectLimitMock,
+	};
+});
+const selectFromMock = mock((table: unknown) => ({
+	where: () => selectWhereMock(table),
+}));
+const selectMock = mock(() => ({
+	from: selectFromMock,
+}));
+
+const updateReturningMock = mock(async () => updateResults.shift() ?? []);
+const updateWhereMock = mock(() => ({
+	returning: updateReturningMock,
+}));
+const updateSetMock = mock(() => ({
+	where: updateWhereMock,
+}));
+const updateMock = mock(() => ({
+	set: updateSetMock,
+}));
+
+const getMcpContextMock = mock(() => ({
+	organizationId: "org-1",
+	userId: "user-1",
+}));
+
+mock.module("@superset/db/client", () => ({
+	db: {
+		select: selectMock,
+	},
+	dbWs: {
+		update: updateMock,
+	},
+}));
+
+mock.module("@superset/db/schema", () => ({
+	taskStatuses: taskStatusesTable,
+	tasks: tasksTable,
+}));
+
+mock.module("drizzle-orm", () => ({
+	and: (...conditions: unknown[]) => ({ type: "and", conditions }),
+	eq: (left: unknown, right: unknown) => ({ type: "eq", left, right }),
+	isNull: (value: unknown) => ({ type: "isNull", value }),
+}));
+
+mock.module("../../utils", () => ({
+	getMcpContext: getMcpContextMock,
+}));
+
+const { register } = await import("./index");
+
+type UpdateTaskHandler = (
+	args: Record<string, unknown>,
+	extra: unknown,
+) => Promise<{
+	structuredContent?: {
+		updated?: Array<Record<string, unknown>>;
+	};
+	content?: Array<{ text?: string }>;
+	isError?: boolean;
+}>;
+
+function createHandler() {
+	const handlers = new Map<string, UpdateTaskHandler>();
+
+	register({
+		registerTool: (
+			name: string,
+			_config: unknown,
+			nextHandler: UpdateTaskHandler,
+		) => {
+			handlers.set(name, nextHandler);
+		},
+	} as never);
+
+	const handler = handlers.get("update_task");
+	if (!handler) {
+		throw new Error("update_task handler was not registered");
+	}
+
+	return handler;
+}
+
+describe("update_task MCP tool", () => {
+	beforeEach(() => {
+		dbSelectResults = [];
+		updateResults = [];
+		selectMock.mockClear();
+		selectFromMock.mockClear();
+		selectWhereMock.mockClear();
+		selectLimitMock.mockClear();
+		updateMock.mockClear();
+		updateSetMock.mockClear();
+		updateWhereMock.mockClear();
+		updateReturningMock.mockClear();
+		getMcpContextMock.mockClear();
+	});
+
+	it("resolves statusName to a statusId and returns status metadata", async () => {
+		dbSelectResults.push(
+			[
+				{
+					id: "status-todo",
+					name: "Todo",
+					color: "#e2e2e2",
+					type: "unstarted",
+					position: 1,
+					progressPercent: 0,
+				},
+				{
+					id: "status-progress",
+					name: "In Progress",
+					color: "#f2c94c",
+					type: "started",
+					position: 2,
+					progressPercent: 50,
+				},
+			],
+			[{ id: "task-1" }],
+		);
+		updateResults.push([
+			{
+				id: "task-1",
+				slug: "add-status-moves",
+				title: "Add status moves",
+				statusId: "status-progress",
+			},
+		]);
+
+		const handler = createHandler();
+		const result = await handler(
+			{
+				updates: [
+					{
+						taskId: "add-status-moves",
+						statusName: "In Progress",
+					},
+				],
+			},
+			{},
+		);
+
+		expect(result.isError).toBeUndefined();
+		expect(updateSetMock).toHaveBeenCalledWith({ statusId: "status-progress" });
+		expect(result.structuredContent?.updated).toEqual([
+			{
+				id: "task-1",
+				slug: "add-status-moves",
+				title: "Add status moves",
+				statusId: "status-progress",
+				statusName: "In Progress",
+				statusType: "started",
+				statusColor: "#f2c94c",
+				statusProgress: 50,
+			},
+		]);
+	});
+
+	it("rejects ambiguous statusName matches", async () => {
+		dbSelectResults.push(
+			[
+				{
+					id: "status-review-a",
+					name: "In Review",
+					color: "#4f46e5",
+					type: "started",
+					position: 3,
+					progressPercent: 80,
+				},
+				{
+					id: "status-review-b",
+					name: "In Review",
+					color: "#6366f1",
+					type: "started",
+					position: 4,
+					progressPercent: 85,
+				},
+			],
+			[{ id: "task-1" }],
+		);
+
+		const handler = createHandler();
+		const result = await handler(
+			{
+				updates: [
+					{
+						taskId: "task-1",
+						statusName: "In Review",
+					},
+				],
+			},
+			{},
+		);
+
+		expect(result.isError).toBe(true);
+		expect(result.content?.[0]?.text).toContain(
+			'Multiple statuses match "In Review"',
+		);
+		expect(updateMock).not.toHaveBeenCalled();
+	});
+
+	it("rejects conflicting statusId and statusName combinations", async () => {
+		dbSelectResults.push(
+			[
+				{
+					id: "status-todo",
+					name: "Todo",
+					color: "#e2e2e2",
+					type: "unstarted",
+					position: 1,
+					progressPercent: 0,
+				},
+				{
+					id: "status-progress",
+					name: "In Progress",
+					color: "#f2c94c",
+					type: "started",
+					position: 2,
+					progressPercent: 50,
+				},
+			],
+			[{ id: "task-1" }],
+		);
+
+		const handler = createHandler();
+		const result = await handler(
+			{
+				updates: [
+					{
+						taskId: "task-1",
+						statusId: "status-todo",
+						statusName: "In Progress",
+					},
+				],
+			},
+			{},
+		);
+
+		expect(result.isError).toBe(true);
+		expect(result.content?.[0]?.text).toContain(
+			"statusId and statusName refer to different statuses",
+		);
+		expect(updateMock).not.toHaveBeenCalled();
+	});
+});

--- a/packages/mcp/src/tools/tasks/update-task/update-task.ts
+++ b/packages/mcp/src/tools/tasks/update-task/update-task.ts
@@ -1,9 +1,11 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { db, dbWs } from "@superset/db/client";
-import { tasks } from "@superset/db/schema";
+import { taskStatuses, tasks } from "@superset/db/schema";
 import { and, eq, isNull } from "drizzle-orm";
 import { z } from "zod";
 import { getMcpContext } from "../../utils";
+
+const nonEmptyStatusName = z.string().trim().min(1);
 
 const updateSchema = z.object({
 	taskId: z.string().describe("Task ID (uuid) or slug"),
@@ -17,6 +19,11 @@ const updateSchema = z.object({
 		.optional()
 		.describe("New assignee (null to unassign)"),
 	statusId: z.string().uuid().optional().describe("New status ID"),
+	statusName: nonEmptyStatusName
+		.optional()
+		.describe(
+			'New status/section name (for example "Todo", "In Progress", or "In Review")',
+		),
 	labels: z.array(z.string()).optional().describe("Replace labels"),
 	dueDate: z
 		.string()
@@ -28,6 +35,38 @@ const updateSchema = z.object({
 });
 
 type UpdateInput = z.infer<typeof updateSchema>;
+type TaskStatusRecord = {
+	id: string;
+	name: string;
+	color: string;
+	type: string;
+	position: number;
+	progressPercent: number | null;
+};
+
+function normalizeStatusName(name: string) {
+	return name.trim().toLowerCase();
+}
+
+function findStatusByName(
+	statuses: TaskStatusRecord[],
+	statusName: string,
+): TaskStatusRecord | null | "ambiguous" {
+	const normalizedName = normalizeStatusName(statusName);
+	const matches = statuses.filter(
+		(status) => normalizeStatusName(status.name) === normalizedName,
+	);
+
+	if (matches.length === 0) {
+		return null;
+	}
+
+	if (matches.length > 1) {
+		return "ambiguous";
+	}
+
+	return matches[0] ?? null;
+}
 
 export function register(server: McpServer) {
 	server.registerTool(
@@ -47,6 +86,11 @@ export function register(server: McpServer) {
 						id: z.string(),
 						slug: z.string(),
 						title: z.string(),
+						statusId: z.string().nullable(),
+						statusName: z.string().nullable(),
+						statusType: z.string().nullable(),
+						statusColor: z.string().nullable(),
+						statusProgress: z.number().nullable(),
 					}),
 				),
 			},
@@ -54,10 +98,25 @@ export function register(server: McpServer) {
 		async (args, extra) => {
 			const ctx = getMcpContext(extra);
 			const updates = args.updates as UpdateInput[];
+			const statuses = await db
+				.select({
+					id: taskStatuses.id,
+					name: taskStatuses.name,
+					color: taskStatuses.color,
+					type: taskStatuses.type,
+					position: taskStatuses.position,
+					progressPercent: taskStatuses.progressPercent,
+				})
+				.from(taskStatuses)
+				.where(eq(taskStatuses.organizationId, ctx.organizationId));
+			const statusesById = new Map(
+				statuses.map((status) => [status.id, status]),
+			);
 
 			const resolvedUpdates: {
 				taskId: string;
 				updateData: Record<string, unknown>;
+				resolvedStatusId?: string;
 			}[] = [];
 
 			for (const [i, update] of updates.entries()) {
@@ -100,8 +159,73 @@ export function register(server: McpServer) {
 					updateData.assigneeDisplayName = null;
 					updateData.assigneeAvatarUrl = null;
 				}
-				if (update.statusId !== undefined)
-					updateData.statusId = update.statusId;
+				let resolvedStatusId: string | undefined;
+				if (update.statusId !== undefined || update.statusName !== undefined) {
+					const statusFromId =
+						update.statusId !== undefined
+							? (statusesById.get(update.statusId) ?? null)
+							: null;
+
+					if (update.statusId !== undefined && !statusFromId) {
+						return {
+							content: [
+								{
+									type: "text",
+									text: `Error: Status not found in organization: ${update.statusId} (index ${i})`,
+								},
+							],
+							isError: true,
+						};
+					}
+
+					const statusFromName =
+						update.statusName !== undefined
+							? findStatusByName(statuses, update.statusName)
+							: null;
+
+					if (statusFromName === "ambiguous") {
+						return {
+							content: [
+								{
+									type: "text",
+									text: `Error: Multiple statuses match "${update.statusName}" in this organization; use statusId instead (index ${i})`,
+								},
+							],
+							isError: true,
+						};
+					}
+
+					if (update.statusName !== undefined && !statusFromName) {
+						return {
+							content: [
+								{
+									type: "text",
+									text: `Error: Status not found in organization: ${update.statusName} (index ${i})`,
+								},
+							],
+							isError: true,
+						};
+					}
+
+					if (
+						statusFromId &&
+						statusFromName &&
+						statusFromId.id !== statusFromName.id
+					) {
+						return {
+							content: [
+								{
+									type: "text",
+									text: `Error: statusId and statusName refer to different statuses for task: ${taskId} (index ${i})`,
+								},
+							],
+							isError: true,
+						};
+					}
+
+					resolvedStatusId = statusFromName?.id ?? statusFromId?.id;
+					updateData.statusId = resolvedStatusId;
+				}
 				if (update.labels !== undefined) updateData.labels = update.labels;
 				if (update.dueDate !== undefined)
 					updateData.dueDate = update.dueDate ? new Date(update.dueDate) : null;
@@ -120,12 +244,25 @@ export function register(server: McpServer) {
 					};
 				}
 
-				resolvedUpdates.push({ taskId: existingTask.id, updateData });
+				resolvedUpdates.push({
+					taskId: existingTask.id,
+					updateData,
+					...(resolvedStatusId ? { resolvedStatusId } : {}),
+				});
 			}
 
-			const updatedTasks: { id: string; slug: string; title: string }[] = [];
+			const updatedTasks: Array<{
+				id: string;
+				slug: string;
+				title: string;
+				statusId: string | null;
+				statusName: string | null;
+				statusType: string | null;
+				statusColor: string | null;
+				statusProgress: number | null;
+			}> = [];
 
-			for (const { taskId, updateData } of resolvedUpdates) {
+			for (const { taskId, updateData, resolvedStatusId } of resolvedUpdates) {
 				const [task] = await dbWs
 					.update(tasks)
 					.set(updateData)
@@ -134,10 +271,20 @@ export function register(server: McpServer) {
 						id: tasks.id,
 						slug: tasks.slug,
 						title: tasks.title,
+						statusId: tasks.statusId,
 					});
 
 				if (task) {
-					updatedTasks.push(task);
+					const status =
+						statusesById.get(resolvedStatusId ?? task.statusId) ?? null;
+
+					updatedTasks.push({
+						...task,
+						statusName: status?.name ?? null,
+						statusType: status?.type ?? null,
+						statusColor: status?.color ?? null,
+						statusProgress: status?.progressPercent ?? null,
+					});
 				}
 			}
 


### PR DESCRIPTION
## Summary
- allow `update_task` to resolve task statuses by `statusName` in addition to `statusId`
- return resolved status metadata from the MCP update result for downstream automation and richer UI rendering
- document the new status-by-name flow and add focused MCP coverage

## Testing
- bun test packages/mcp/src/tools/tasks/update-task/update-task.test.ts
- bunx biome check packages/mcp/src/tools/tasks/update-task/update-task.ts packages/mcp/src/tools/tasks/update-task/update-task.test.ts apps/api/MCP_TOOLS.md apps/docs/content/docs/mcp.mdx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for updating a task’s status by name in MCP `update_task`. The tool now accepts `statusName` and returns status metadata to power automation and richer UI.

- New Features
  - Accept `statusName` alongside `statusId`; resolves within the org and rejects ambiguous or conflicting name/id inputs.
  - Response now includes `statusId`, `statusName`, `statusType`, `statusColor`, and `statusProgress` for each updated task.
  - Updated docs in `apps/api/MCP_TOOLS.md` and `apps/docs/content/docs/mcp.mdx`; added focused tests for status name resolution.

<sup>Written for commit f423eff80f10fa8a0923c425b94eea8f3ba3fe00. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The `update_task` tool now supports specifying task status by name (`statusName`) in addition to status ID.
  * Task results now include enriched status metadata (ID, name, type, color, and progress information).

* **Documentation**
  * Updated MCP tool documentation with examples of moving tasks between status sections.

* **Tests**
  * Added comprehensive test coverage for the task update functionality with multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->