### PR TITLE
fix(slack): resolve org correctly before Pro gating

### DIFF
--- a/apps/api/src/app/api/integrations/slack/callback/route.ts
+++ b/apps/api/src/app/api/integrations/slack/callback/route.ts
@@ -1,16 +1,24 @@
 import { WebClient } from "@slack/web-api";
-import { db } from "@superset/db/client";
+import { db, dbWs } from "@superset/db/client";
 import type { SlackConfig } from "@superset/db/schema";
 import {
 	integrationConnections,
 	members,
 	usersSlackUsers,
 } from "@superset/db/schema";
-import { and, eq, ne } from "drizzle-orm";
+import { and, eq, ne, sql } from "drizzle-orm";
 
 import { env } from "@/env";
 import { posthog } from "@/lib/analytics";
 import { verifySignedState } from "@/lib/oauth-state";
+
+type DbWsTransaction = Parameters<Parameters<typeof dbWs.transaction>[0]>[0];
+
+async function acquireSlackTeamLock(tx: DbWsTransaction, teamId: string) {
+	await tx.execute(
+		sql`select pg_advisory_xact_lock(hashtextextended(${teamId}, 0))`,
+	);
+}
 
 export async function GET(request: Request) {
 	const url = new URL(request.url);
@@ -82,60 +90,66 @@ export async function GET(request: Request) {
 				`${env.NEXT_PUBLIC_WEB_URL}/integrations/slack?error=slack_api_error`,
 			);
 		}
+		const accessToken = tokenData.access_token;
+		const teamName = tokenData.team.name ?? null;
 
 		const config: SlackConfig = {
 			provider: "slack",
 		};
 
-		await db
-			.delete(integrationConnections)
-			.where(
-				and(
-					eq(integrationConnections.provider, "slack"),
-					eq(integrationConnections.externalOrgId, teamId),
-					ne(integrationConnections.organizationId, organizationId),
-				),
-			);
+		await dbWs.transaction(async (tx) => {
+			await acquireSlackTeamLock(tx, teamId);
 
-		await db
-			.insert(integrationConnections)
-			.values({
-				organizationId,
-				connectedByUserId: userId,
-				provider: "slack",
-				accessToken: tokenData.access_token,
-				externalOrgId: teamId,
-				externalOrgName: tokenData.team.name,
-				config,
-			})
-			.onConflictDoUpdate({
-				target: [
-					integrationConnections.organizationId,
-					integrationConnections.provider,
-				],
-				set: {
-					accessToken: tokenData.access_token,
-					externalOrgId: teamId,
-					externalOrgName: tokenData.team.name,
+			await tx
+				.delete(integrationConnections)
+				.where(
+					and(
+						eq(integrationConnections.provider, "slack"),
+						eq(integrationConnections.externalOrgId, teamId),
+						ne(integrationConnections.organizationId, organizationId),
+					),
+				);
+
+			await tx
+				.insert(integrationConnections)
+				.values({
+					organizationId,
 					connectedByUserId: userId,
+					provider: "slack",
+					accessToken,
+					externalOrgId: teamId,
+					externalOrgName: teamName,
 					config,
-					updatedAt: new Date(),
-				},
-			});
+				})
+				.onConflictDoUpdate({
+					target: [
+						integrationConnections.organizationId,
+						integrationConnections.provider,
+					],
+					set: {
+						accessToken,
+						externalOrgId: teamId,
+						externalOrgName: teamName,
+						connectedByUserId: userId,
+						config,
+						updatedAt: new Date(),
+					},
+				});
 
-		await db
-			.delete(usersSlackUsers)
-			.where(
-				and(
-					eq(usersSlackUsers.teamId, teamId),
-					ne(usersSlackUsers.organizationId, organizationId),
-				),
-			);
+			await tx
+				.delete(usersSlackUsers)
+				.where(
+					and(
+						eq(usersSlackUsers.teamId, teamId),
+						ne(usersSlackUsers.organizationId, organizationId),
+					),
+				);
+		});
 
 		console.log("[slack/callback] Connected workspace:", {
 			organizationId,
 			teamId,
-			teamName: tokenData.team.name,
+			teamName,
 		});
 
 		posthog.capture({

--- a/apps/api/src/app/api/integrations/slack/callback/route.ts
+++ b/apps/api/src/app/api/integrations/slack/callback/route.ts
@@ -1,8 +1,12 @@
 import { WebClient } from "@slack/web-api";
 import { db } from "@superset/db/client";
 import type { SlackConfig } from "@superset/db/schema";
-import { integrationConnections, members } from "@superset/db/schema";
-import { and, eq } from "drizzle-orm";
+import {
+	integrationConnections,
+	members,
+	usersSlackUsers,
+} from "@superset/db/schema";
+import { and, eq, ne } from "drizzle-orm";
 
 import { env } from "@/env";
 import { posthog } from "@/lib/analytics";
@@ -71,9 +75,27 @@ export async function GET(request: Request) {
 			);
 		}
 
+		const teamId = tokenData.team.id;
+		if (!teamId) {
+			console.error("[slack/callback] Slack team ID missing in OAuth response");
+			return Response.redirect(
+				`${env.NEXT_PUBLIC_WEB_URL}/integrations/slack?error=slack_api_error`,
+			);
+		}
+
 		const config: SlackConfig = {
 			provider: "slack",
 		};
+
+		await db
+			.delete(integrationConnections)
+			.where(
+				and(
+					eq(integrationConnections.provider, "slack"),
+					eq(integrationConnections.externalOrgId, teamId),
+					ne(integrationConnections.organizationId, organizationId),
+				),
+			);
 
 		await db
 			.insert(integrationConnections)
@@ -82,7 +104,7 @@ export async function GET(request: Request) {
 				connectedByUserId: userId,
 				provider: "slack",
 				accessToken: tokenData.access_token,
-				externalOrgId: tokenData.team.id,
+				externalOrgId: teamId,
 				externalOrgName: tokenData.team.name,
 				config,
 			})
@@ -93,7 +115,7 @@ export async function GET(request: Request) {
 				],
 				set: {
 					accessToken: tokenData.access_token,
-					externalOrgId: tokenData.team.id,
+					externalOrgId: teamId,
 					externalOrgName: tokenData.team.name,
 					connectedByUserId: userId,
 					config,
@@ -101,16 +123,25 @@ export async function GET(request: Request) {
 				},
 			});
 
+		await db
+			.delete(usersSlackUsers)
+			.where(
+				and(
+					eq(usersSlackUsers.teamId, teamId),
+					ne(usersSlackUsers.organizationId, organizationId),
+				),
+			);
+
 		console.log("[slack/callback] Connected workspace:", {
 			organizationId,
-			teamId: tokenData.team.id,
+			teamId,
 			teamName: tokenData.team.name,
 		});
 
 		posthog.capture({
 			distinctId: userId,
 			event: "slack_connected",
-			properties: { team_id: tokenData.team.id },
+			properties: { team_id: teamId },
 		});
 
 		return Response.redirect(`${env.NEXT_PUBLIC_WEB_URL}/integrations/slack`);

--- a/apps/api/src/app/api/integrations/slack/events/process-app-home-opened/process-app-home-opened.ts
+++ b/apps/api/src/app/api/integrations/slack/events/process-app-home-opened/process-app-home-opened.ts
@@ -1,6 +1,7 @@
 import { db } from "@superset/db/client";
-import { integrationConnections, usersSlackUsers } from "@superset/db/schema";
+import { usersSlackUsers } from "@superset/db/schema";
 import { and, eq } from "drizzle-orm";
+import { getSlackConnectionForTeam } from "../../utils/resolve-team-connection";
 import { generateConnectUrl } from "../utils/generate-connect-url";
 import { createSlackClient } from "../utils/slack-client";
 import { buildHomeView } from "./build-home-view";
@@ -15,11 +16,9 @@ export async function processAppHomeOpened({
 	event,
 	teamId,
 }: ProcessAppHomeOpenedParams): Promise<void> {
-	const connection = await db.query.integrationConnections.findFirst({
-		where: and(
-			eq(integrationConnections.provider, "slack"),
-			eq(integrationConnections.externalOrgId, teamId),
-		),
+	const connection = await getSlackConnectionForTeam({
+		teamId,
+		slackUserId: event.user,
 	});
 
 	if (!connection) {
@@ -34,6 +33,7 @@ export async function processAppHomeOpened({
 		where: and(
 			eq(usersSlackUsers.slackUserId, event.user),
 			eq(usersSlackUsers.teamId, teamId),
+			eq(usersSlackUsers.organizationId, connection.organizationId),
 		),
 		with: { user: true },
 	});
@@ -43,7 +43,11 @@ export async function processAppHomeOpened({
 
 	const connectUrl = isUserLinked
 		? undefined
-		: generateConnectUrl({ slackUserId: event.user, teamId });
+		: generateConnectUrl({
+				slackUserId: event.user,
+				teamId,
+				organizationId: connection.organizationId,
+			});
 
 	const slack = createSlackClient(connection.accessToken);
 

--- a/apps/api/src/app/api/integrations/slack/events/process-assistant-message/process-assistant-message.ts
+++ b/apps/api/src/app/api/integrations/slack/events/process-assistant-message/process-assistant-message.ts
@@ -1,11 +1,8 @@
 import { db } from "@superset/db/client";
-import {
-	integrationConnections,
-	subscriptions,
-	usersSlackUsers,
-} from "@superset/db/schema";
+import { subscriptions, usersSlackUsers } from "@superset/db/schema";
 import { and, eq } from "drizzle-orm";
 import { posthog } from "@/lib/analytics";
+import { getSlackConnectionForTeam } from "../../utils/resolve-team-connection";
 import { generateConnectUrl } from "../utils/generate-connect-url";
 import {
 	formatErrorForSlack,
@@ -59,11 +56,9 @@ export async function processAssistantMessage({
 		user: event.user,
 	});
 
-	const connection = await db.query.integrationConnections.findFirst({
-		where: and(
-			eq(integrationConnections.provider, "slack"),
-			eq(integrationConnections.externalOrgId, teamId),
-		),
+	const connection = await getSlackConnectionForTeam({
+		teamId,
+		slackUserId: event.user,
 	});
 
 	if (!connection) {
@@ -82,6 +77,7 @@ export async function processAssistantMessage({
 					where: and(
 						eq(usersSlackUsers.slackUserId, event.user),
 						eq(usersSlackUsers.teamId, teamId),
+						eq(usersSlackUsers.organizationId, connection.organizationId),
 					),
 					columns: { userId: true, modelPreference: true },
 				})
@@ -147,6 +143,7 @@ export async function processAssistantMessage({
 		const connectUrl = generateConnectUrl({
 			slackUserId: event.user,
 			teamId,
+			organizationId: connection.organizationId,
 		});
 		await slack.chat.postMessage({
 			channel: event.channel,

--- a/apps/api/src/app/api/integrations/slack/events/process-entity-details/process-entity-details.ts
+++ b/apps/api/src/app/api/integrations/slack/events/process-entity-details/process-entity-details.ts
@@ -1,7 +1,8 @@
 import type { SlackEvent } from "@slack/types";
 import { db } from "@superset/db/client";
-import { integrationConnections, tasks } from "@superset/db/schema";
+import { tasks } from "@superset/db/schema";
 import { and, eq } from "drizzle-orm";
+import { getSlackConnectionForTeam } from "../../utils/resolve-team-connection";
 import { createSlackClient } from "../utils/slack-client";
 import {
 	createTaskFlexpaneObject,
@@ -32,12 +33,7 @@ export async function processEntityDetails({
 		externalRef: event.external_ref,
 	});
 
-	const connection = await db.query.integrationConnections.findFirst({
-		where: and(
-			eq(integrationConnections.provider, "slack"),
-			eq(integrationConnections.externalOrgId, teamId),
-		),
-	});
+	const connection = await getSlackConnectionForTeam({ teamId });
 
 	if (!connection) {
 		console.error(

--- a/apps/api/src/app/api/integrations/slack/events/process-link-shared/process-link-shared.ts
+++ b/apps/api/src/app/api/integrations/slack/events/process-link-shared/process-link-shared.ts
@@ -26,7 +26,10 @@ export async function processLinkShared({
 		linkCount: event.links.length,
 	});
 
-	const connection = await getSlackConnectionForTeam({ teamId });
+	const connection = await getSlackConnectionForTeam({
+		teamId,
+		slackUserId: event.user,
+	});
 
 	if (!connection) {
 		console.error(

--- a/apps/api/src/app/api/integrations/slack/events/process-link-shared/process-link-shared.ts
+++ b/apps/api/src/app/api/integrations/slack/events/process-link-shared/process-link-shared.ts
@@ -1,7 +1,8 @@
 import type { EntityMetadata, LinkSharedEvent } from "@slack/types";
 import { db } from "@superset/db/client";
-import { integrationConnections, tasks } from "@superset/db/schema";
+import { tasks } from "@superset/db/schema";
 import { and, eq } from "drizzle-orm";
+import { getSlackConnectionForTeam } from "../../utils/resolve-team-connection";
 import { createSlackClient } from "../utils/slack-client";
 import {
 	createTaskWorkObject,
@@ -25,12 +26,7 @@ export async function processLinkShared({
 		linkCount: event.links.length,
 	});
 
-	const connection = await db.query.integrationConnections.findFirst({
-		where: and(
-			eq(integrationConnections.provider, "slack"),
-			eq(integrationConnections.externalOrgId, teamId),
-		),
-	});
+	const connection = await getSlackConnectionForTeam({ teamId });
 
 	if (!connection) {
 		console.error(

--- a/apps/api/src/app/api/integrations/slack/events/process-mention/process-mention.ts
+++ b/apps/api/src/app/api/integrations/slack/events/process-mention/process-mention.ts
@@ -1,11 +1,8 @@
 import { db } from "@superset/db/client";
-import {
-	integrationConnections,
-	subscriptions,
-	usersSlackUsers,
-} from "@superset/db/schema";
+import { subscriptions, usersSlackUsers } from "@superset/db/schema";
 import { and, eq } from "drizzle-orm";
 import { posthog } from "@/lib/analytics";
+import { getSlackConnectionForTeam } from "../../utils/resolve-team-connection";
 import { generateConnectUrl } from "../utils/generate-connect-url";
 import {
 	formatErrorForSlack,
@@ -58,11 +55,9 @@ export async function processSlackMention({
 		user: event.user,
 	});
 
-	const connection = await db.query.integrationConnections.findFirst({
-		where: and(
-			eq(integrationConnections.provider, "slack"),
-			eq(integrationConnections.externalOrgId, teamId),
-		),
+	const connection = await getSlackConnectionForTeam({
+		teamId,
+		slackUserId: event.user,
 	});
 
 	if (!connection) {
@@ -81,6 +76,7 @@ export async function processSlackMention({
 					where: and(
 						eq(usersSlackUsers.slackUserId, event.user),
 						eq(usersSlackUsers.teamId, teamId),
+						eq(usersSlackUsers.organizationId, connection.organizationId),
 					),
 					columns: { userId: true, modelPreference: true },
 				})
@@ -146,6 +142,7 @@ export async function processSlackMention({
 		const connectUrl = generateConnectUrl({
 			slackUserId: event.user,
 			teamId,
+			organizationId: connection.organizationId,
 		});
 		await slack.chat.postMessage({
 			channel: event.channel,

--- a/apps/api/src/app/api/integrations/slack/events/utils/generate-connect-url/generate-connect-url.ts
+++ b/apps/api/src/app/api/integrations/slack/events/utils/generate-connect-url/generate-connect-url.ts
@@ -4,13 +4,16 @@ import { env } from "@/env";
 export function generateConnectUrl({
 	slackUserId,
 	teamId,
+	organizationId,
 }: {
 	slackUserId: string;
 	teamId: string;
+	organizationId?: string;
 }): string {
 	const payload = JSON.stringify({
 		slackUserId,
 		teamId,
+		organizationId,
 		exp: Date.now() + 10 * 60 * 1000,
 	});
 	const signature = createHmac("sha256", env.SLACK_SIGNING_SECRET)

--- a/apps/api/src/app/api/integrations/slack/link/route.ts
+++ b/apps/api/src/app/api/integrations/slack/link/route.ts
@@ -6,6 +6,7 @@ import { findOrgMembership } from "@superset/db/utils";
 import { and, eq } from "drizzle-orm";
 import { headers } from "next/headers";
 import { env } from "@/env";
+import { getSlackConnectionForTeam } from "../utils/resolve-team-connection";
 
 export async function GET(request: Request) {
 	const url = new URL(request.url);
@@ -16,7 +17,12 @@ export async function GET(request: Request) {
 		return new Response("Missing token or signature", { status: 400 });
 	}
 
-	let payload: { slackUserId: string; teamId: string; exp: number };
+	let payload: {
+		slackUserId: string;
+		teamId: string;
+		organizationId?: string;
+		exp: number;
+	};
 	try {
 		const decoded = Buffer.from(token, "base64url").toString("utf-8");
 		const expectedSig = createHmac("sha256", env.SLACK_SIGNING_SECRET)
@@ -48,17 +54,25 @@ export async function GET(request: Request) {
 		);
 	}
 
-	const connection = await db.query.integrationConnections.findFirst({
-		where: and(
-			eq(integrationConnections.provider, "slack"),
-			eq(integrationConnections.externalOrgId, payload.teamId),
-		),
-	});
+	const connection = payload.organizationId
+		? await db.query.integrationConnections.findFirst({
+				where: and(
+					eq(integrationConnections.provider, "slack"),
+					eq(integrationConnections.externalOrgId, payload.teamId),
+					eq(integrationConnections.organizationId, payload.organizationId),
+				),
+			})
+		: await getSlackConnectionForTeam({
+				teamId: payload.teamId,
+				slackUserId: payload.slackUserId,
+			});
 
 	if (!connection) {
 		return new Response(
-			"Slack workspace not connected to any Superset organization.",
-			{ status: 404 },
+			payload.organizationId
+				? "Slack workspace connection changed. Please try again from the Slack Home tab."
+				: "Slack workspace not connected to any Superset organization.",
+			{ status: payload.organizationId ? 410 : 404 },
 		);
 	}
 

--- a/apps/api/src/app/api/integrations/slack/utils/resolve-team-connection/index.ts
+++ b/apps/api/src/app/api/integrations/slack/utils/resolve-team-connection/index.ts
@@ -1,0 +1,5 @@
+export {
+	getSlackConnectionForTeam,
+	resolveSlackConnectionForTeam,
+	selectSlackConnectionForTeam,
+} from "./resolve-team-connection";

--- a/apps/api/src/app/api/integrations/slack/utils/resolve-team-connection/resolve-team-connection.test.ts
+++ b/apps/api/src/app/api/integrations/slack/utils/resolve-team-connection/resolve-team-connection.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "bun:test";
+import type { SelectIntegrationConnection } from "@superset/db/schema";
+import {
+	resolveSlackConnectionForTeam,
+	selectSlackConnectionForTeam,
+} from "./resolve-team-connection";
+
+function createConnection(
+	organizationId: string,
+	updatedAt: string,
+): SelectIntegrationConnection {
+	return {
+		id: `connection-${organizationId}`,
+		organizationId,
+		connectedByUserId: "user-1",
+		provider: "slack",
+		accessToken: `token-${organizationId}`,
+		refreshToken: null,
+		tokenExpiresAt: null,
+		externalOrgId: "team-1",
+		externalOrgName: "Workspace",
+		config: { provider: "slack" },
+		createdAt: new Date(updatedAt),
+		updatedAt: new Date(updatedAt),
+	};
+}
+
+describe("selectSlackConnectionForTeam", () => {
+	it("returns the newest Slack connection for a team", () => {
+		const connection = selectSlackConnectionForTeam([
+			createConnection("org-free", "2026-03-25T12:00:00.000Z"),
+			createConnection("org-pro", "2026-03-26T12:00:00.000Z"),
+		]);
+
+		expect(connection?.organizationId).toBe("org-pro");
+	});
+
+	it("uses createdAt as a tiebreaker when updatedAt matches", () => {
+		const connection = selectSlackConnectionForTeam([
+			{
+				...createConnection("org-older", "2026-03-26T12:00:00.000Z"),
+				createdAt: new Date("2026-03-25T12:00:00.000Z"),
+			},
+			{
+				...createConnection("org-newer", "2026-03-26T12:00:00.000Z"),
+				createdAt: new Date("2026-03-26T12:00:00.000Z"),
+			},
+		]);
+
+		expect(connection?.organizationId).toBe("org-newer");
+	});
+
+	it("returns null when the Slack team is not connected", () => {
+		const connection = selectSlackConnectionForTeam([]);
+
+		expect(connection).toBe(null);
+	});
+});
+
+describe("resolveSlackConnectionForTeam", () => {
+	it("prefers the linked organization when duplicates exist", () => {
+		const { connection, resolution } = resolveSlackConnectionForTeam({
+			connections: [
+				createConnection("org-free", "2026-03-25T12:00:00.000Z"),
+				createConnection("org-pro", "2026-03-26T12:00:00.000Z"),
+			],
+			linkedOrganizationId: "org-free",
+		});
+
+		expect(connection?.organizationId).toBe("org-free");
+		expect(resolution).toBe("linked_organization");
+	});
+
+	it("falls back to the latest connection when the linked org is missing", () => {
+		const { connection, resolution } = resolveSlackConnectionForTeam({
+			connections: [
+				createConnection("org-free", "2026-03-25T12:00:00.000Z"),
+				createConnection("org-pro", "2026-03-26T12:00:00.000Z"),
+			],
+			linkedOrganizationId: "org-missing",
+		});
+
+		expect(connection?.organizationId).toBe("org-pro");
+		expect(resolution).toBe("latest_connection");
+	});
+});

--- a/apps/api/src/app/api/integrations/slack/utils/resolve-team-connection/resolve-team-connection.ts
+++ b/apps/api/src/app/api/integrations/slack/utils/resolve-team-connection/resolve-team-connection.ts
@@ -1,0 +1,99 @@
+import { db } from "@superset/db/client";
+import type { SelectIntegrationConnection } from "@superset/db/schema";
+import { integrationConnections, usersSlackUsers } from "@superset/db/schema";
+import { and, desc, eq } from "drizzle-orm";
+
+export function selectSlackConnectionForTeam(
+	connections: SelectIntegrationConnection[],
+) {
+	return (
+		[...connections].sort((left, right) => {
+			const updatedDiff = right.updatedAt.getTime() - left.updatedAt.getTime();
+			if (updatedDiff !== 0) {
+				return updatedDiff;
+			}
+
+			return right.createdAt.getTime() - left.createdAt.getTime();
+		})[0] ?? null
+	);
+}
+
+export function resolveSlackConnectionForTeam({
+	connections,
+	linkedOrganizationId,
+}: {
+	connections: SelectIntegrationConnection[];
+	linkedOrganizationId?: string | null;
+}) {
+	if (linkedOrganizationId) {
+		const linkedConnection =
+			connections.find(
+				(connection) => connection.organizationId === linkedOrganizationId,
+			) ?? null;
+
+		if (linkedConnection) {
+			return {
+				connection: linkedConnection,
+				resolution: "linked_organization" as const,
+			};
+		}
+	}
+
+	return {
+		connection: selectSlackConnectionForTeam(connections),
+		resolution: "latest_connection" as const,
+	};
+}
+
+export async function getSlackConnectionForTeam({
+	teamId,
+	slackUserId,
+}: {
+	teamId: string;
+	slackUserId?: string;
+}) {
+	const connections = await db.query.integrationConnections.findMany({
+		where: and(
+			eq(integrationConnections.provider, "slack"),
+			eq(integrationConnections.externalOrgId, teamId),
+		),
+		orderBy: [
+			desc(integrationConnections.updatedAt),
+			desc(integrationConnections.createdAt),
+		],
+	});
+
+	let linkedOrganizationId: string | null = null;
+
+	if (connections.length > 1 && slackUserId) {
+		const slackUserLink = await db.query.usersSlackUsers.findFirst({
+			where: and(
+				eq(usersSlackUsers.slackUserId, slackUserId),
+				eq(usersSlackUsers.teamId, teamId),
+			),
+			columns: { organizationId: true },
+		});
+
+		linkedOrganizationId = slackUserLink?.organizationId ?? null;
+	}
+
+	const { connection, resolution } = resolveSlackConnectionForTeam({
+		connections,
+		linkedOrganizationId,
+	});
+
+	if (connection && connections.length > 1) {
+		console.warn(
+			"[slack/resolve-team-connection] Multiple Slack connections found for team; selecting one deterministically.",
+			{
+				teamId,
+				selectedOrganizationId: connection.organizationId,
+				organizationIds: connections.map((item) => item.organizationId),
+				resolution,
+				slackUserId,
+			},
+		);
+	}
+
+	return connection;
+}


### PR DESCRIPTION
## Summary
- centralize Slack `teamId -> org` resolution instead of doing ad-hoc `findFirst` lookups in each handler
- prefer the linked Slack user's organization when duplicate workspace mappings exist so linked users do not hit a false Pro gate
- thread the resolved organization through Slack connect URLs and clean up stale workspace/user mappings on reconnect

## Testing
- `bun test apps/api/src/app/api/integrations/slack/utils/resolve-team-connection/resolve-team-connection.test.ts`
- `bun run --cwd apps/api typecheck`
- `./node_modules/.bin/biome check apps/api/src/app/api/integrations/slack/callback/route.ts apps/api/src/app/api/integrations/slack/events/process-app-home-opened/process-app-home-opened.ts apps/api/src/app/api/integrations/slack/events/process-assistant-message/process-assistant-message.ts apps/api/src/app/api/integrations/slack/events/process-entity-details/process-entity-details.ts apps/api/src/app/api/integrations/slack/events/process-link-shared/process-link-shared.ts apps/api/src/app/api/integrations/slack/events/process-mention/process-mention.ts apps/api/src/app/api/integrations/slack/events/utils/generate-connect-url/generate-connect-url.ts apps/api/src/app/api/integrations/slack/link/route.ts apps/api/src/app/api/integrations/slack/utils/resolve-team-connection/resolve-team-connection.ts apps/api/src/app/api/integrations/slack/utils/resolve-team-connection/resolve-team-connection.test.ts apps/api/src/app/api/integrations/slack/utils/resolve-team-connection/index.ts`

## Follow-up
- duplicate workspace mappings are still prevented in app logic rather than with a schema-level uniqueness constraint; that hardening can follow separately

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deterministically resolve the correct Slack organization per team and make reconnect cleanup transactional to prevent false Pro gating and stabilize linking and events.

- **Bug Fixes**
  - Prefer the linked Slack user's organization when duplicate workspace mappings exist to ensure correct gating and permissions.
  - Transactionally clean up conflicting `integrationConnections` and cross‑org `usersSlackUsers` on reconnect under an advisory lock; return 410 when a link token targets an outdated org.

- **Refactors**
  - Centralize `teamId -> org` resolution and use it across Slack handlers.
  - Include `organizationId` in connect URL payloads and honor it in link requests for consistent linking.

<sup>Written for commit 87b42da08d050fe91a97f91000875b9291554be4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better Slack OAuth callback error handling when workspace data is missing.
  * Cleanup of stale Slack workspace connections that belonged to other organizations.
  * More reliable Slack user-to-organization linkage to avoid wrong connection matches.

* **Refactor**
  * Centralized Slack connection resolution used across Slack event handlers for consistent behavior.

* **New Features**
  * Connect URL now can include organization context to produce correct linking flows.

* **Tests**
  * Added unit tests for Slack connection selection and resolution logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->