### PR TITLE
fix(chat): let mastracode choose observational memory models

### DIFF
--- a/packages/chat/src/server/trpc/service.ts
+++ b/packages/chat/src/server/trpc/service.ts
@@ -1,7 +1,7 @@
 import type { AppRouter } from "@superset/trpc";
 import { createTRPCClient, httpBatchLink } from "@trpc/client";
 import { initTRPC } from "@trpc/server";
-import { createAuthStorage, createMastraCode } from "mastracode";
+import { createMastraCode } from "mastracode";
 import superjson from "superjson";
 import { searchFiles } from "./utils/file-search";
 import {
@@ -34,28 +34,6 @@ import {
 } from "./zod";
 
 const ENABLE_MASTRA_MCP_SERVERS = false;
-
-function resolveOmModelFromAuth(): string | undefined {
-	if (process.env.GOOGLE_GENERATIVE_AI_API_KEY)
-		return "google/gemini-2.5-flash";
-	const authStorage = createAuthStorage();
-	authStorage.reload();
-	const anthropic = authStorage.get("anthropic");
-	if (
-		anthropic?.type === "oauth" ||
-		(anthropic?.type === "api_key" && anthropic.key.trim())
-	) {
-		return "anthropic/claude-haiku-4-5";
-	}
-	const openai = authStorage.get("openai-codex");
-	if (
-		openai?.type === "oauth" ||
-		(openai?.type === "api_key" && openai.key.trim())
-	) {
-		return "openai/gpt-4.1-nano";
-	}
-	return undefined;
-}
 
 export interface ChatRuntimeServiceOptions {
 	headers: () => Record<string, string> | Promise<Record<string, string>>;
@@ -115,18 +93,10 @@ export class ChatRuntimeService {
 					this.opts.apiUrl,
 				);
 
-				const omModel = resolveOmModelFromAuth();
-
 				const runtime = await createMastraCode({
 					cwd: runtimeCwd,
 					extraTools,
 					disableMcp: !ENABLE_MASTRA_MCP_SERVERS,
-					...(omModel && {
-						initialState: {
-							observerModelId: omModel,
-							reflectorModelId: omModel,
-						},
-					}),
 				});
 				runtime.hookManager?.setSessionId(sessionId);
 				await runtime.harness.init();


### PR DESCRIPTION
## Summary
- remove the Superset-side observational memory model override in the chat runtime
- let `createMastraCode(...)` use mastracode's own OM defaults and provider selection
- stop forcing `openai/gpt-4.1-nano` for observer/reflector models on the Codex auth path

## Testing
- bunx biome check packages/chat/src/server/trpc/service.ts
- bun run --cwd packages/chat typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified runtime initialization by removing dynamic model selection logic. The system now uses static configuration options instead of conditionally deriving settings from authentication credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop overriding observational memory model selection in the chat runtime. The runtime now defers to `mastracode` defaults for observer and reflector models, no longer forcing `openai/gpt-4.1-nano` on the Codex auth path.

<sup>Written for commit 15826b6c8855a55c768ac1b69cb39c61bc0e1db5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

