### PR TITLE
Revert PR #2908: workspace deletion fix

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
@@ -866,7 +866,6 @@ export const createCreateProcedures = () => {
 				// 2. Import external worktrees (on disk, not tracked in DB)
 				const allExternalWorktrees = await listExternalWorktrees(
 					project.mainRepoPath,
-					project.id,
 				);
 				const trackedPaths = new Set(projectWorktrees.map((wt) => wt.path));
 

--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/delete.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/delete.ts
@@ -1,4 +1,5 @@
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
+import { resolve } from "node:path";
 import type { SelectWorktree } from "@superset/local-db";
 import { track } from "main/lib/analytics";
 import { workspaceInitManager } from "main/lib/workspace-init-manager";
@@ -21,10 +22,22 @@ import {
 	hasUncommittedChanges,
 	hasUnpushedCommits,
 	listExternalWorktrees,
-	normalizePath,
 	worktreeExists,
 } from "../utils/git";
 import { removeWorktreeFromDisk, runTeardown } from "../utils/teardown";
+
+/**
+ * Normalize a filesystem path for comparison.
+ * Uses realpathSync to resolve symlinks and get canonical path.
+ * Falls back to resolve if realpathSync fails (e.g., path doesn't exist).
+ */
+const normalizePath = (p: string): string => {
+	try {
+		return realpathSync(p);
+	} catch {
+		return resolve(p);
+	}
+};
 
 export const createDeleteProcedures = () => {
 	return router({
@@ -254,12 +267,12 @@ export const createDeleteProcedures = () => {
 					await workspaceInitManager.acquireProjectLock(project.id);
 
 					try {
-						try {
+						// Only delete from disk if this worktree was created by Superset
+						// External worktrees should only have their DB records removed
+						if (worktree.createdBySuperset) {
 							// Safety: Double-check it's not actually external (catches race conditions)
-							// Only delete from disk if the worktree is tracked in our database
 							const externalWorktrees = await listExternalWorktrees(
 								project.mainRepoPath,
-								project.id,
 							);
 							const worktreePathNorm = normalizePath(worktree.path);
 							const isActuallyExternal = externalWorktrees.some(
@@ -268,16 +281,16 @@ export const createDeleteProcedures = () => {
 
 							if (isActuallyExternal) {
 								console.warn(
-									`[workspace/delete] Worktree at ${worktree.path} found in external list - preserving as safety measure`,
+									`[workspace/delete] Worktree at ${worktree.path} marked as created by Superset but found in external list - preserving as safety measure`,
 								);
 								track("worktree_delete_safety_trigger", {
 									workspace_id: input.id,
 									worktree_id: worktree.id,
 									worktree_path: worktree.path,
-									reason: "external_worktree_detected",
+									reason: "external_detection_mismatch",
 								});
 							} else {
-								// Confirmed safe to delete - worktree is tracked in our DB
+								// Confirmed safe to delete
 								const removeResult = await removeWorktreeFromDisk({
 									mainRepoPath: project.mainRepoPath,
 									worktreePath: worktree.path,
@@ -287,33 +300,27 @@ export const createDeleteProcedures = () => {
 									return removeResult;
 								}
 							}
-						} finally {
-							workspaceInitManager.releaseProjectLock(project.id);
+						} else {
+							console.log(
+								`[workspace/delete] Skipping disk deletion for external worktree at ${worktree.path}`,
+							);
 						}
+					} finally {
+						workspaceInitManager.releaseProjectLock(project.id);
+					}
 
-						if (input.deleteLocalBranch && workspace.branch) {
-							try {
-								await deleteLocalBranch({
-									mainRepoPath: project.mainRepoPath,
-									branch: workspace.branch,
-								});
-							} catch (error) {
-								console.error(
-									`[workspace/delete] Branch cleanup failed (non-blocking):`,
-									error instanceof Error ? error.message : String(error),
-								);
-							}
+					if (input.deleteLocalBranch && workspace.branch) {
+						try {
+							await deleteLocalBranch({
+								mainRepoPath: project.mainRepoPath,
+								branch: workspace.branch,
+							});
+						} catch (error) {
+							console.error(
+								`[workspace/delete] Branch cleanup failed (non-blocking):`,
+								error instanceof Error ? error.message : String(error),
+							);
 						}
-					} catch (error) {
-						console.error(
-							`[workspace/delete] Worktree deletion failed:`,
-							error instanceof Error ? error.message : String(error),
-						);
-						clearWorkspaceDeletingStatus(input.id);
-						return {
-							success: false,
-							error: `Failed to delete worktree from disk: ${error instanceof Error ? error.message : String(error)}`,
-						};
 					}
 				}
 
@@ -474,34 +481,32 @@ export const createDeleteProcedures = () => {
 				await workspaceInitManager.acquireProjectLock(project.id);
 
 				try {
-					try {
-						const exists = await worktreeExists(
-							project.mainRepoPath,
-							worktree.path,
-						);
+					const exists = await worktreeExists(
+						project.mainRepoPath,
+						worktree.path,
+					);
 
+					// Only delete from disk if this worktree was created by Superset
+					if (worktree.createdBySuperset) {
 						// Safety: Double-check it's not actually external (catches race conditions)
-						// Only delete from disk if the worktree is tracked in our database
 						const externalWorktrees = await listExternalWorktrees(
 							project.mainRepoPath,
-							project.id,
 						);
-						const worktreePathNorm = normalizePath(worktree.path);
 						const isActuallyExternal = externalWorktrees.some(
-							(wt) => normalizePath(wt.path) === worktreePathNorm,
+							(wt) => wt.path === worktree.path,
 						);
 
 						if (isActuallyExternal) {
 							console.warn(
-								`[worktree/delete] Worktree at ${worktree.path} found in external list - preserving as safety measure`,
+								`[worktree/delete] Worktree at ${worktree.path} marked as created by Superset but found in external list - preserving as safety measure`,
 							);
 							track("worktree_delete_safety_trigger", {
 								worktree_id: input.worktreeId,
 								worktree_path: worktree.path,
-								reason: "external_worktree_detected",
+								reason: "external_detection_mismatch",
 							});
 						} else {
-							// Confirmed safe to delete - worktree is tracked in our DB
+							// Confirmed safe to delete
 							if (exists) {
 								const teardownResult = await runTeardown({
 									mainRepoPath: project.mainRepoPath,
@@ -539,26 +544,21 @@ export const createDeleteProcedures = () => {
 								);
 							}
 						}
-					} finally {
-						workspaceInitManager.releaseProjectLock(project.id);
+					} else {
+						console.log(
+							`[worktree/delete] Skipping disk deletion for external worktree at ${worktree.path}`,
+						);
 					}
-
-					deleteWorktreeRecord(input.worktreeId);
-					hideProjectIfNoWorkspaces(worktree.projectId);
-
-					track("worktree_deleted", { worktree_id: input.worktreeId });
-
-					return { success: true };
-				} catch (error) {
-					console.error(
-						`[worktree/delete] Worktree deletion failed:`,
-						error instanceof Error ? error.message : String(error),
-					);
-					return {
-						success: false,
-						error: `Failed to delete worktree: ${error instanceof Error ? error.message : String(error)}`,
-					};
+				} finally {
+					workspaceInitManager.releaseProjectLock(project.id);
 				}
+
+				deleteWorktreeRecord(input.worktreeId);
+				hideProjectIfNoWorkspaces(worktree.projectId);
+
+				track("worktree_deleted", { worktree_id: input.worktreeId });
+
+				return { success: true };
 			}),
 	});
 };

--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/external-worktree-import.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/external-worktree-import.test.ts
@@ -112,18 +112,18 @@ describe("External worktree detection and import", () => {
 		expect(worktreeList).toContain("feature-external");
 	});
 
-	test("listAllGitWorktrees detects all git worktrees", async () => {
+	test("listExternalWorktrees detects external worktree", async () => {
 		// Create external worktree
 		createExternalWorktree(mainRepoPath, "feature-test", externalWorktreePath);
 
-		// Import the listAllGitWorktrees function
-		const { listAllGitWorktrees } = await import("../utils/git");
+		// Import the listExternalWorktrees function
+		const { listExternalWorktrees } = await import("../utils/git");
 
-		// List all git worktrees
-		const allWorktrees = await listAllGitWorktrees(mainRepoPath);
+		// List external worktrees
+		const externalWorktrees = await listExternalWorktrees(mainRepoPath);
 
 		// Find our external worktree
-		const found = allWorktrees.find((wt) => wt.branch === "feature-test");
+		const found = externalWorktrees.find((wt) => wt.branch === "feature-test");
 
 		expect(found).toBeDefined();
 		expect(found?.path).toBe(externalWorktreePath);

--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts
@@ -296,17 +296,22 @@ export const createGitStatusProcedures = () => {
 					return [];
 				}
 
-				const externalWorktrees = await listExternalWorktrees(
-					project.mainRepoPath,
-					input.projectId,
-				);
+				const allWorktrees = await listExternalWorktrees(project.mainRepoPath);
 
-				return externalWorktrees
+				const trackedWorktrees = localDb
+					.select({ path: worktrees.path })
+					.from(worktrees)
+					.where(eq(worktrees.projectId, input.projectId))
+					.all();
+				const trackedPaths = new Set(trackedWorktrees.map((wt) => wt.path));
+
+				return allWorktrees
 					.filter((wt) => {
 						if (wt.path === project.mainRepoPath) return false;
 						if (wt.isBare) return false;
 						if (wt.isDetached) return false;
 						if (!wt.branch) return false;
+						if (trackedPaths.has(wt.path)) return false;
 						return true;
 					})
 					.map((wt) => ({

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
@@ -1,14 +1,10 @@
 import { execFile, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { realpathSync } from "node:fs";
 import { mkdir, rename } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { promisify } from "node:util";
 import type { BranchPrefixMode } from "@superset/local-db";
-import { worktrees } from "@superset/local-db";
-import { eq } from "drizzle-orm";
 import friendlyWords from "friendly-words";
-import { localDb } from "main/lib/local-db";
 import {
 	sanitizeAuthorPrefix,
 	sanitizeBranchName,
@@ -815,19 +811,6 @@ export async function worktreeExists(
 	}
 }
 
-/**
- * Normalize a filesystem path for comparison.
- * Uses realpathSync to resolve symlinks and get canonical path.
- * Falls back to resolve if realpathSync fails (e.g., path doesn't exist).
- */
-export const normalizePath = (p: string): string => {
-	try {
-		return realpathSync(p);
-	} catch {
-		return resolve(p);
-	}
-};
-
 export interface ExternalWorktree {
 	path: string;
 	branch: string | null;
@@ -835,7 +818,7 @@ export interface ExternalWorktree {
 	isBare: boolean;
 }
 
-export async function listAllGitWorktrees(
+export async function listExternalWorktrees(
 	mainRepoPath: string,
 ): Promise<ExternalWorktree[]> {
 	try {
@@ -876,40 +859,9 @@ export async function listAllGitWorktrees(
 
 		return result;
 	} catch (error) {
-		console.error(`Failed to list all git worktrees: ${error}`);
+		console.error(`Failed to list external worktrees: ${error}`);
 		throw error;
 	}
-}
-
-/**
- * Lists worktrees that exist on disk but are NOT tracked in the database.
- * This is the proper "external worktrees" - ones created outside of Superset.
- * @param mainRepoPath - Path to the main repository
- * @param projectId - Project ID to check against database records
- * @returns Array of external worktrees (not tracked in DB)
- */
-export async function listExternalWorktrees(
-	mainRepoPath: string,
-	projectId: string,
-): Promise<ExternalWorktree[]> {
-	// Get all git worktrees
-	const allGitWorktrees = await listAllGitWorktrees(mainRepoPath);
-
-	// Get all tracked worktree paths from database
-	const trackedWorktrees = localDb
-		.select({ path: worktrees.path })
-		.from(worktrees)
-		.where(eq(worktrees.projectId, projectId))
-		.all();
-
-	const trackedPaths = new Set(
-		trackedWorktrees.map((wt: { path: string }) => normalizePath(wt.path)),
-	);
-
-	// Filter to only worktrees NOT in database
-	return allGitWorktrees.filter(
-		(wt) => !trackedPaths.has(normalizePath(wt.path)),
-	);
 }
 
 /**

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/workspace-creation.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/workspace-creation.ts
@@ -110,10 +110,7 @@ export async function createWorkspaceFromExternalWorktree({
 	}
 
 	// Check for external worktree (exists on disk but not tracked in DB)
-	const externalWorktrees = await listExternalWorktrees(
-		project.mainRepoPath,
-		projectId,
-	);
+	const externalWorktrees = await listExternalWorktrees(project.mainRepoPath);
 
 	// Filter candidates: exclude main repo, bare, and detached
 	const candidates = externalWorktrees.filter(

--- a/bun.lock
+++ b/bun.lock
@@ -110,7 +110,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.4.1",
+      "version": "1.3.2",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.43",
         "@ai-sdk/openai": "3.0.36",


### PR DESCRIPTION
## Summary

Reverts PR #2908 which introduced changes to workspace deletion behavior.

## Reason for Revert

This PR reverts the changes made in #2908 that modified how workspace deletion handles disk cleanup and external worktree detection.

## Original PR
- **Title:** fix(desktop): quickfix restore workspace deletion from disk
- **Merged:** March 26, 2026
- **Commit:** a2268c96d

## Changes Reverted

1. Restoration of workspace file deletion from disk
2. Renaming of `listExternalWorktrees` → `listAllGitWorktrees`
3. New `listExternalWorktrees(mainRepoPath, projectId)` implementation
4. Removal of `createdBySuperset` flag gating
5. Error handling for stuck 'deleting' status

## Files Affected

- `apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts`
- `apps/desktop/src/lib/trpc/routers/workspaces/procedures/delete.ts`
- `apps/desktop/src/lib/trpc/routers/workspaces/procedures/external-worktree-import.test.ts`
- `apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts`
- `apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts`
- `apps/desktop/src/lib/trpc/routers/workspaces/utils/workspace-creation.ts`
- `bun.lock`

## Testing

- [ ] Verify workspace deletion behavior returns to pre-#2908 state
- [ ] Confirm external worktree handling works as expected
- [ ] Check that no workspaces get stuck in 'deleting' status

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts #2908 to restore the previous workspace deletion behavior and safety checks. Disk deletion now only happens for worktrees created by Superset; external worktrees are never removed from disk.

- **Bug Fixes**
  - Re-enable `createdBySuperset` gate for on-disk deletion; external worktrees only remove DB records.
  - Restore path normalization and external worktree safety check in delete flows.
  - Revert `listExternalWorktrees` to `listExternalWorktrees(mainRepoPath)` and move DB filtering to callers (updated `git-status`, creation/import, and tests).

- **Dependencies**
  - Revert `@superset/desktop` version in `bun.lock` to 1.3.2.

<sup>Written for commit 35e3908b5de9e6fc77e87cf4a280e12c2ffd4490. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * External worktree deletion now respects whether worktrees were created by the application or externally—only application-managed worktrees are removed from disk.
  
* **Improvements**
  * Enhanced external worktree detection and filtering logic for more accurate identification of managed vs. unmanaged worktrees.
  * Improved safety warnings to better reflect mismatches between tracked and external worktree states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->