### PR TITLE
feat(desktop): add automation test harness

### DIFF
--- a/apps/desktop/e2e/fixtures/desktop.ts
+++ b/apps/desktop/e2e/fixtures/desktop.ts
@@ -1,0 +1,108 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	test as base,
+	type ElectronApplication,
+	_electron as electron,
+	expect,
+	type Page,
+} from "@playwright/test";
+import electronPath from "electron";
+
+interface DesktopFixtures {
+	appWindow: Page;
+	electronApp: ElectronApplication;
+	supersetHomeDir: string;
+}
+
+const appEntry = join(process.cwd(), "dist", "main", "index.js");
+const alwaysCapture =
+	process.env.DESKTOP_E2E_ALWAYS_CAPTURE === "1" ||
+	process.env.DESKTOP_E2E_ALWAYS_CAPTURE === "true";
+const authSeedEnv = {
+	...(process.env.DESKTOP_E2E_AUTH_TOKEN
+		? {
+				DESKTOP_TEST_AUTH_TOKEN: process.env.DESKTOP_E2E_AUTH_TOKEN,
+			}
+		: {}),
+	...(process.env.DESKTOP_E2E_AUTH_EXPIRES_AT
+		? {
+				DESKTOP_TEST_AUTH_EXPIRES_AT: process.env.DESKTOP_E2E_AUTH_EXPIRES_AT,
+			}
+		: {}),
+};
+
+async function waitForMainWindow(
+	electronApp: ElectronApplication,
+): Promise<Page> {
+	await expect
+		.poll(
+			() =>
+				electronApp
+					.windows()
+					.map((window) => window.url())
+					.join("\n"),
+			{ timeout: 90_000 },
+		)
+		.toContain("index.html");
+
+	const mainWindow = electronApp
+		.windows()
+		.find((window) => window.url().includes("index.html"));
+
+	if (!mainWindow) {
+		throw new Error("Desktop E2E could not find the main renderer window.");
+	}
+
+	return mainWindow;
+}
+
+export const test = base.extend<DesktopFixtures>({
+	// biome-ignore lint/correctness/noEmptyPattern: Playwright fixture callbacks require object destructuring for the first parameter.
+	supersetHomeDir: async ({}, use) => {
+		const homeDir = mkdtempSync(join(tmpdir(), "superset-desktop-e2e-"));
+		await use(homeDir);
+	},
+
+	electronApp: async ({ supersetHomeDir }, use, testInfo) => {
+		const electronApp = await electron.launch({
+			executablePath: electronPath,
+			args: [appEntry],
+			env: {
+				...process.env,
+				NODE_ENV: "test",
+				DESKTOP_TEST_MODE: "1",
+				SUPERSET_HOME_DIR: supersetHomeDir,
+				DESKTOP_E2E_ARTIFACTS_DIR: testInfo.outputPath("artifacts"),
+				...authSeedEnv,
+			},
+			recordVideo: alwaysCapture
+				? {
+						dir: testInfo.outputPath("videos"),
+						size: {
+							width: 1440,
+							height: 960,
+						},
+					}
+				: undefined,
+		});
+
+		await use(electronApp);
+		await electronApp.close();
+	},
+
+	appWindow: async ({ electronApp }, use) => {
+		const appWindow = await waitForMainWindow(electronApp);
+		appWindow.on("console", (message) => {
+			console.log(`[desktop console][${message.type()}] ${message.text()}`);
+		});
+		appWindow.on("pageerror", (error) => {
+			console.error(`[desktop pageerror] ${error.message}`);
+		});
+		await appWindow.waitForLoadState("domcontentloaded");
+		await use(appWindow);
+	},
+});
+
+export { expect };

--- a/apps/desktop/e2e/playwright.config.mjs
+++ b/apps/desktop/e2e/playwright.config.mjs
@@ -1,0 +1,25 @@
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "@playwright/test";
+
+const e2eDir = fileURLToPath(new URL(".", import.meta.url));
+const artifactsDir =
+	process.env.DESKTOP_E2E_ARTIFACTS_DIR ??
+	join(process.cwd(), "test-results", "desktop-e2e");
+const alwaysCapture =
+	process.env.DESKTOP_E2E_ALWAYS_CAPTURE === "1" ||
+	process.env.DESKTOP_E2E_ALWAYS_CAPTURE === "true";
+
+export default defineConfig({
+	testDir: join(e2eDir, "specs"),
+	outputDir: join(artifactsDir, "output"),
+	timeout: 90_000,
+	fullyParallel: false,
+	workers: 1,
+	reporter: [["list"]],
+	use: {
+		screenshot: alwaysCapture ? "on" : "only-on-failure",
+		trace: alwaysCapture ? "on" : "retain-on-failure",
+		video: alwaysCapture ? "on" : "retain-on-failure",
+	},
+});

--- a/apps/desktop/e2e/specs/launch.smoke.spec.ts
+++ b/apps/desktop/e2e/specs/launch.smoke.spec.ts
@@ -1,0 +1,101 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { expect, test } from "../fixtures/desktop";
+
+const expectedAuthExpiresAt = process.env.DESKTOP_E2E_AUTH_EXPIRES_AT
+	? new Date(process.env.DESKTOP_E2E_AUTH_EXPIRES_AT).toISOString()
+	: null;
+const shouldExpectAuthenticated =
+	process.env.DESKTOP_E2E_EXPECT_AUTHENTICATED === "1";
+const expectedTokenPresent = Boolean(process.env.DESKTOP_E2E_AUTH_TOKEN);
+const metadataPath = process.env.DESKTOP_E2E_METADATA_PATH ?? null;
+
+test("launches in desktop test mode", async ({
+	appWindow,
+	electronApp,
+	supersetHomeDir,
+}) => {
+	await expect
+		.poll(() => appWindow.evaluate(() => window.App.testMode))
+		.toBe(true);
+
+	await expect
+		.poll(() => appWindow.evaluate(() => window.App.appVersion))
+		.not.toBe("");
+
+	await expect
+		.poll(() => appWindow.evaluate(() => window.App.automation.ping()))
+		.toMatchObject({
+			ok: true,
+			testMode: true,
+		});
+
+	await expect
+		.poll(() =>
+			appWindow.evaluate(() => window.App.automation.getEnvironment()),
+		)
+		.toMatchObject({
+			testMode: true,
+			supersetHomeDir,
+		});
+
+	await expect
+		.poll(() => appWindow.evaluate(() => window.App.automation.getWindowInfo()))
+		.toMatchObject({
+			isVisible: true,
+			bounds: {
+				width: 1440,
+				height: 960,
+			},
+		});
+
+	await expect
+		.poll(() => appWindow.evaluate(() => window.App.automation.getAuthState()))
+		.toMatchObject({
+			tokenPresent: expectedTokenPresent,
+			expiresAt: expectedAuthExpiresAt,
+		});
+
+	await expect
+		.poll(async () => {
+			return electronApp.evaluate(({ app }) => app.isReady());
+		})
+		.toBe(true);
+
+	await expect
+		.poll(() => appWindow.evaluate(() => document.readyState))
+		.toBe("complete");
+	await expect
+		.poll(() => appWindow.evaluate(() => document.body?.innerHTML.length ?? 0))
+		.toBeGreaterThan(0);
+	await expect
+		.poll(() => appWindow.evaluate(() => window.location.href))
+		.toContain("index.html");
+	if (shouldExpectAuthenticated) {
+		await expect
+			.poll(() => appWindow.evaluate(() => window.location.hash))
+			.toMatch(/^#\/(_authenticated|create-organization)(\/.*)?$/);
+		await expect
+			.poll(() => appWindow.evaluate(() => document.body?.innerText ?? ""))
+			.not.toContain("Welcome to Superset");
+		await expect
+			.poll(() => appWindow.evaluate(() => document.body?.innerText ?? ""))
+			.not.toContain("Restoring your session");
+		await expect
+			.poll(() => appWindow.evaluate(() => document.body?.innerText ?? ""))
+			.not.toContain("Sign in to get started");
+	}
+
+	if (metadataPath) {
+		const metadata = await appWindow.evaluate(async () => ({
+			authState: await window.App.automation.getAuthState(),
+			hash: window.location.hash,
+			pathname: window.location.pathname,
+			textSample: (document.body?.innerText ?? "").slice(0, 500),
+		}));
+		mkdirSync(dirname(metadataPath), { recursive: true });
+		writeFileSync(metadataPath, JSON.stringify(metadata, null, 2));
+	}
+
+	await expect(supersetHomeDir).toContain("superset-desktop-e2e-");
+});

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -21,6 +21,13 @@ import {
 config({ path: resolve(__dirname, "../../.env"), override: true, quiet: true });
 
 const DEV_SERVER_PORT = Number(process.env.DESKTOP_VITE_PORT);
+const TRUE_ENV_VALUES = new Set(["1", "true", "yes", "on"]);
+
+function readBooleanEnv(name: string): boolean {
+	const value = process.env[name];
+	if (!value) return false;
+	return TRUE_ENV_VALUES.has(value.toLowerCase());
+}
 
 // Validate required env vars at build time using the Zod schema (single source of truth)
 await import("./src/main/env.main");
@@ -33,8 +40,14 @@ const workspaceDependencies = Object.keys(dependencies).filter((dependency) =>
 	dependency.startsWith("@superset/"),
 );
 
-// Sentry plugin for uploading sourcemaps (only in CI with auth token)
-const sentryPlugin = process.env.SENTRY_AUTH_TOKEN
+const shouldUploadSentrySourcemaps =
+	Boolean(process.env.SENTRY_AUTH_TOKEN) &&
+	!readBooleanEnv("DESKTOP_E2E_BUILD") &&
+	!readBooleanEnv("DESKTOP_TEST_MODE") &&
+	!readBooleanEnv("SKIP_SENTRY_UPLOAD");
+
+// Sentry plugin for uploading sourcemaps in normal builds.
+const sentryPlugin = shouldUploadSentrySourcemaps
 	? sentryVitePlugin({
 			org: "superset-sh",
 			project: "desktop",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -31,6 +31,14 @@
 		"clean:dev": "rimraf ./node_modules/.dev",
 		"generate:routes": "tsr generate",
 		"pretypecheck": "bun run generate:icons && bun run generate:routes",
+		"e2e:prepare": "bun run generate:icons && bun run generate:routes && cross-env DESKTOP_E2E_BUILD=1 SKIP_SENTRY_UPLOAD=1 bun run compile:app",
+		"e2e:auth": "bun run scripts/mint-e2e-auth-session.ts",
+		"e2e:run": "playwright test -c e2e/playwright.config.mjs",
+		"e2e:scenario": "bun run scripts/run-e2e-scenario.ts",
+		"e2e:smoke": "bun run e2e:scenario smoke",
+		"e2e:preview:signed-in": "bun run scripts/capture-authenticated-preview.ts",
+		"e2e:preview:cdp": "bun run scripts/capture-cdp-preview.ts",
+		"e2e": "bun run e2e:prepare && bun run e2e:run",
 		"typecheck": "tsc --noEmit",
 		"test": "bun test"
 	},
@@ -221,6 +229,7 @@
 		"zustand": "^5.0.8"
 	},
 	"devDependencies": {
+		"@playwright/test": "^1.56.1",
 		"@sentry/vite-plugin": "^4.7.0",
 		"@superset/typescript": "workspace:*",
 		"@tailwindcss/vite": "^4.0.9",

--- a/apps/desktop/plans/20260326-desktop-test-automation-implementation.md
+++ b/apps/desktop/plans/20260326-desktop-test-automation-implementation.md
@@ -1,0 +1,56 @@
+# Desktop Test Automation Implementation
+
+## Current Slice
+
+This document tracks the concrete rollout. The current slice is:
+
+1. deterministic desktop test mode
+2. minimal gated automation surface
+3. Playwright launch and scenario runner
+4. explicit auth seeding for authenticated scenarios
+
+## Scope
+
+### Done
+
+- add `DESKTOP_TEST_MODE`
+- isolate desktop state under a test-specific home dir
+- skip updater, tray, notification-center, and Apple Events permission flows in test mode
+- use fixed window bounds in test mode
+- add basic automation commands for ping, environment, and window info
+- add auth state inspect/seed/clear commands to the test automation bridge
+- expose `window.App.testMode`
+- expose `window.App.automation.*` through a dedicated test IPC bridge
+- add Playwright desktop scaffolding under `apps/desktop/e2e/`
+- add a first launch smoke test
+- add `bun run e2e` / `bun run e2e:prepare`
+- add `bun run e2e:scenario <name>` and `bun run e2e:smoke`
+- add `bun run e2e:auth` to mint a short-lived desktop session for tests
+- make `e2e:scenario` emit a per-run JSON summary with artifact paths
+- skip Sentry sourcemap upload during E2E build prep
+- support launch-time auth seeding via `DESKTOP_E2E_AUTH_TOKEN` and `DESKTOP_E2E_AUTH_EXPIRES_AT`
+- support automatic auth minting via `DESKTOP_E2E_AUTH=1` or `DESKTOP_E2E_AUTH_EMAIL=...`
+- prefer explicit token seeding over copied encrypted sign-in files
+
+### Next
+
+- add selector coverage to core screens
+- add dialog stubbing and fixture seeding
+- add more named scenarios agents can invoke
+
+## Commands
+
+- `bun run e2e`
+- `bun run e2e:smoke`
+- `bun run e2e:scenario smoke`
+- `bun run e2e:scenario smoke -- --headed`
+- `bun run e2e:auth`
+- `DESKTOP_E2E_AUTH=1 bun run e2e:scenario smoke`
+- `DESKTOP_E2E_AUTH_EMAIL=person@example.com bun run e2e:scenario smoke`
+- `DESKTOP_E2E_AUTH_TOKEN=... DESKTOP_E2E_AUTH_EXPIRES_AT=... bun run e2e:scenario smoke`
+
+## Design Notes
+
+- Playwright is the canonical reusable test runner.
+- Agents should invoke Playwright scenarios and inspect the resulting artifacts.
+- `desktop-mcp` remains useful for ad hoc local debugging, but the app should not accumulate critical test logic there.

--- a/apps/desktop/plans/20260326-desktop-test-automation-instrumentation-plan.md
+++ b/apps/desktop/plans/20260326-desktop-test-automation-instrumentation-plan.md
@@ -1,0 +1,72 @@
+# Desktop Test Automation Plan
+
+## Goal
+
+Make the same desktop scenarios runnable by humans, CI, and agents.
+
+Playwright is the canonical test surface. `desktop-mcp` is a temporary sidecar for exploration and debugging, and should stay easy to remove.
+
+## Direction
+
+- Use Playwright for reusable desktop scenarios and regression tests.
+- Let agents run Playwright scenarios instead of building a second test framework.
+- Keep a small test-only automation API for deterministic setup and inspection.
+- Keep `desktop-mcp` minimal for screenshots and ad hoc debugging of a running dev app.
+
+## Current Repo Hooks
+
+- Dev CDP already exists in [setup.ts](/Users/kietho/.superset/worktrees/superset/instrument-desktop-test-automation/apps/desktop/src/lib/electron-app/factories/app/setup.ts#L73).
+- `desktop-mcp` already attaches to the running app in [connection-manager.ts](/Users/kietho/.superset/worktrees/superset/instrument-desktop-test-automation/packages/desktop-mcp/src/mcp/connection/connection-manager.ts#L27).
+- Stable selectors are still sparse, for example [CodeEditor.tsx](/Users/kietho/.superset/worktrees/superset/instrument-desktop-test-automation/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/CodeEditor.tsx#L234).
+
+## Near-Term Rollout
+
+### 1. Deterministic Test Mode
+
+- isolate state
+- fix window size
+- skip updater, tray, permission, and quit noise
+
+### 2. Minimal Automation API
+
+- expose gated test helpers like `ping()` and environment/window info
+- add auth seeding, fixture seeding, and dialog stubbing next
+
+### 3. Playwright Harness
+
+- keep `apps/desktop/e2e/` as the canonical scenario layer
+- save screenshots, traces, and video artifacts
+- provide stable commands agents can invoke
+
+### 4. Selector Hardening
+
+- add stable locators to core desktop surfaces
+
+### 5. MCP De-Emphasis
+
+- keep `desktop-mcp` useful for debugging
+- do not move the canonical regression suite there
+
+## Non-Goals
+
+- building a second reusable MCP-first test framework
+- making OS dialog automation the default path
+- keeping `desktop-mcp` as the long-term center if Playwright covers the need
+- copying a developer's encrypted `signin` or `auth-token.enc` state into tests
+
+## Auth
+
+- Default to auth-neutral smoke tests when auth is not under test.
+- For authenticated scenarios, mint a short-lived desktop session token and pass it into test mode.
+- Prefer `DESKTOP_E2E_AUTH=1` in local dev, which mints a session for the default desktop E2E user.
+- Use `DESKTOP_E2E_AUTH_EMAIL=...` when a scenario needs a specific user identity.
+- Seed that token through explicit test hooks, not by copying persisted sign-in files.
+
+## References
+
+- Electron automated testing: https://www.electronjs.org/docs/latest/tutorial/automated-testing
+- Playwright Electron API: https://playwright.dev/docs/api/class-electron
+- Playwright Test Agents: https://playwright.dev/docs/test-agents
+- Playwright tracing: https://playwright.dev/docs/api/class-tracing
+- Playwright locators: https://playwright.dev/docs/locators
+- Playwright CDP connection: https://playwright.dev/docs/api/class-browsertype

--- a/apps/desktop/scripts/capture-authenticated-preview.ts
+++ b/apps/desktop/scripts/capture-authenticated-preview.ts
@@ -1,0 +1,199 @@
+import { spawnSync } from "node:child_process";
+import {
+	copyFileSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+interface RunSummary {
+	auth: {
+		email: string;
+		expiresAt: string;
+		organizationId: string;
+		userId: string;
+	} | null;
+	exitCode: number;
+	ok: boolean;
+	reportFile: string;
+	runDir: string;
+	scenario: string;
+	stage: string;
+}
+
+interface PreviewMetadata {
+	authState: {
+		expiresAt: string | null;
+		tokenPresent: boolean;
+	};
+	hash: string;
+	pathname: string;
+	textSample: string;
+}
+
+function createPreviewId(): string {
+	return `${new Date().toISOString().replaceAll(":", "-")}-signed-in-preview`;
+}
+
+function runCommand(
+	args: string[],
+	env: NodeJS.ProcessEnv,
+	inheritStdout = true,
+) {
+	return spawnSync(process.execPath, args, {
+		cwd: process.cwd(),
+		env,
+		encoding: "utf8",
+		maxBuffer: 16 * 1024 * 1024,
+		stdio: inheritStdout ? "inherit" : ["ignore", "pipe", "inherit"],
+	});
+}
+
+function ensureLocalApiIsReachable(apiUrl: string) {
+	const sessionUrl = new URL("/api/auth/get-session", apiUrl).toString();
+	const response = spawnSync(
+		"curl",
+		["-sS", "-o", "/dev/null", "-w", "%{http_code}", sessionUrl],
+		{
+			cwd: process.cwd(),
+			encoding: "utf8",
+		},
+	);
+
+	if (response.status !== 0 || response.stdout.trim() === "000") {
+		throw new Error(
+			`Desktop preview requires the local API to be running at ${sessionUrl}.`,
+		);
+	}
+}
+
+function findFirstMatchingPath(runDir: string, pattern: RegExp): string | null {
+	const searchResult = spawnSync("rg", ["--files", runDir], {
+		cwd: process.cwd(),
+		encoding: "utf8",
+		maxBuffer: 16 * 1024 * 1024,
+	});
+
+	if (searchResult.status !== 0 || !searchResult.stdout) {
+		return null;
+	}
+
+	const match = searchResult.stdout
+		.split("\n")
+		.map((entry) => entry.trim())
+		.find((entry) => pattern.test(entry));
+
+	return match ? join(runDir, match) : null;
+}
+
+const previewDir = join(
+	process.cwd(),
+	"test-results",
+	"desktop-e2e",
+	"previews",
+	createPreviewId(),
+);
+const metadataPath = join(previewDir, "signed-in-app.json");
+const screenshotPath = join(previewDir, "signed-in-app.png");
+const videoPath = join(previewDir, "signed-in-app.webm");
+const reportFile = join(previewDir, "playwright-report.json");
+
+mkdirSync(previewDir, { recursive: true });
+
+const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3181";
+ensureLocalApiIsReachable(apiUrl);
+
+const runResult = runCommand(
+	["run", "scripts/run-e2e-scenario.ts", "smoke", ...process.argv.slice(2)],
+	{
+		...process.env,
+		DESKTOP_E2E_ALWAYS_CAPTURE: "1",
+		DESKTOP_E2E_AUTH: process.env.DESKTOP_E2E_AUTH ?? "1",
+		DESKTOP_E2E_EXPECT_AUTHENTICATED: "1",
+		DESKTOP_E2E_METADATA_PATH: metadataPath,
+	},
+	false,
+);
+
+const stdout = runResult.stdout?.trim();
+if (!stdout) {
+	throw new Error("Desktop preview run did not produce a summary.");
+}
+
+const summary = JSON.parse(stdout) as RunSummary;
+
+if (!existsSync(summary.reportFile)) {
+	throw new Error("Desktop preview run did not write a Playwright report.");
+}
+
+copyFileSync(summary.reportFile, reportFile);
+
+if (!summary.ok) {
+	console.log(
+		JSON.stringify(
+			{
+				...summary,
+				previewDir,
+				reportFile,
+			},
+			null,
+			2,
+		),
+	);
+	process.exit(summary.exitCode || 1);
+}
+
+const runScreenshotPath =
+	findFirstMatchingPath(summary.runDir, /test-finished-\d+\.png$/) ??
+	findFirstMatchingPath(summary.runDir, /\.png$/);
+const runVideoPath =
+	findFirstMatchingPath(summary.runDir, /main-window\.webm$/) ??
+	findFirstMatchingPath(summary.runDir, /\.webm$/);
+
+if (!runScreenshotPath) {
+	throw new Error("Desktop preview run did not produce a screenshot.");
+}
+
+copyFileSync(runScreenshotPath, screenshotPath);
+
+if (runVideoPath) {
+	copyFileSync(runVideoPath, videoPath);
+}
+
+const metadata = JSON.parse(
+	readFileSync(metadataPath, "utf8"),
+) as PreviewMetadata;
+
+writeFileSync(
+	metadataPath,
+	JSON.stringify(
+		{
+			...metadata,
+			auth: summary.auth,
+			reportFile,
+			runDir: summary.runDir,
+			screenshotPath,
+			videoPath: existsSync(videoPath) ? videoPath : null,
+		},
+		null,
+		2,
+	),
+);
+
+console.log(
+	JSON.stringify(
+		{
+			previewDir,
+			reportFile,
+			runDir: summary.runDir,
+			screenshotPath,
+			videoPath: existsSync(videoPath) ? videoPath : null,
+			auth: summary.auth,
+			hash: metadata.hash,
+		},
+		null,
+		2,
+	),
+);

--- a/apps/desktop/scripts/capture-cdp-preview.ts
+++ b/apps/desktop/scripts/capture-cdp-preview.ts
@@ -1,0 +1,380 @@
+import { spawn, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import electronPath from "electron";
+
+interface MintedDesktopSession {
+	email: string;
+	expiresAt: string;
+	name: string;
+	organizationId: string;
+	token: string;
+	userId: string;
+}
+
+interface CdpTarget {
+	title: string;
+	url: string;
+	webSocketDebuggerUrl: string;
+}
+
+function delay(ms: number) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function createPreviewId(): string {
+	return `${new Date().toISOString().replaceAll(":", "-")}-signed-in-cdp-preview`;
+}
+
+function runCommand(
+	args: string[],
+	env: NodeJS.ProcessEnv,
+	inheritStdout = true,
+) {
+	return spawnSync(process.execPath, args, {
+		cwd: process.cwd(),
+		env,
+		encoding: "utf8",
+		maxBuffer: 16 * 1024 * 1024,
+		stdio: inheritStdout ? "inherit" : ["ignore", "pipe", "inherit"],
+	});
+}
+
+function readBooleanEnv(name: string): boolean {
+	const value = process.env[name];
+	if (!value) return false;
+
+	return ["1", "true", "yes", "on"].includes(value.toLowerCase());
+}
+
+function shouldMintDesktopAuth(): boolean {
+	if (process.env.DESKTOP_E2E_AUTH_TOKEN) {
+		return false;
+	}
+
+	return (
+		readBooleanEnv("DESKTOP_E2E_AUTH") ||
+		Boolean(process.env.DESKTOP_E2E_AUTH_EMAIL)
+	);
+}
+
+function mintDesktopAuth(env: NodeJS.ProcessEnv): MintedDesktopSession {
+	const mintResult = runCommand(["run", "e2e:auth"], env, false);
+
+	if (mintResult.status !== 0) {
+		throw new Error("Failed to mint desktop E2E auth session.");
+	}
+
+	const stdout = mintResult.stdout?.trim();
+	if (!stdout) {
+		throw new Error("Desktop E2E auth mint command did not return JSON.");
+	}
+
+	return JSON.parse(stdout) as MintedDesktopSession;
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+	const response = await fetch(url);
+	if (!response.ok) {
+		throw new Error(`Failed to fetch ${url}: ${response.status}`);
+	}
+
+	return (await response.json()) as T;
+}
+
+function connectToCdpTarget(target: CdpTarget) {
+	const ws = new WebSocket(target.webSocketDebuggerUrl);
+	let nextId = 1;
+	const pending = new Map<
+		number,
+		(msg: { error?: unknown; result?: unknown }) => void
+	>();
+
+	ws.addEventListener("message", (event) => {
+		const msg = JSON.parse(event.data as string) as {
+			id?: number;
+			error?: unknown;
+			result?: unknown;
+		};
+		if (msg.id && pending.has(msg.id)) {
+			pending.get(msg.id)?.(msg);
+			pending.delete(msg.id);
+		}
+	});
+
+	const send = async <T>(
+		method: string,
+		params: Record<string, unknown> = {},
+	) =>
+		new Promise<T>((resolve, reject) => {
+			const id = nextId++;
+			pending.set(id, (msg) => {
+				if (msg.error) {
+					reject(new Error(JSON.stringify(msg.error)));
+					return;
+				}
+
+				resolve(msg.result as T);
+			});
+			ws.send(JSON.stringify({ id, method, params }));
+		});
+
+	return {
+		send,
+		waitForOpen: () =>
+			new Promise<void>((resolve, reject) => {
+				ws.addEventListener("open", () => resolve(), { once: true });
+				ws.addEventListener(
+					"error",
+					(event) => reject(new Error(String(event))),
+					{ once: true },
+				);
+			}),
+		close: () => ws.close(),
+	};
+}
+
+async function waitForRendererTarget(port: number): Promise<CdpTarget> {
+	const deadline = Date.now() + 30_000;
+
+	while (Date.now() < deadline) {
+		try {
+			const targets = await fetchJson<CdpTarget[]>(
+				`http://127.0.0.1:${port}/json/list`,
+			);
+			const pageTarget = targets.find((target) =>
+				target.url.includes("index.html#/"),
+			);
+			if (pageTarget) {
+				return pageTarget;
+			}
+		} catch {}
+
+		await delay(500);
+	}
+
+	throw new Error("Timed out waiting for Electron renderer target.");
+}
+
+async function waitForSignedInRoute(
+	send: <T>(method: string, params?: Record<string, unknown>) => Promise<T>,
+) {
+	const deadline = Date.now() + 30_000;
+
+	while (Date.now() < deadline) {
+		const result = await send<{
+			result: {
+				value: {
+					hash: string;
+					href: string;
+					textSample: string;
+				};
+			};
+		}>("Runtime.evaluate", {
+			expression: `(() => ({
+				href: window.location.href,
+				hash: window.location.hash,
+				textSample: (document.body?.innerText ?? "").slice(0, 500),
+			}))()`,
+			returnByValue: true,
+			awaitPromise: true,
+		});
+
+		const value = result.result.value;
+		if (
+			value.hash.includes("/welcome") ||
+			value.hash.includes("/_authenticated") ||
+			value.hash.includes("/create-organization")
+		) {
+			return value;
+		}
+
+		await delay(500);
+	}
+
+	throw new Error("Timed out waiting for a signed-in desktop route.");
+}
+
+const previewDir = join(
+	process.cwd(),
+	"test-results",
+	"desktop-e2e",
+	"previews",
+	createPreviewId(),
+);
+const framesDir = join(previewDir, "frames");
+const screenshotPath = join(previewDir, "signed-in-app.png");
+const videoPath = join(previewDir, "signed-in-app.webm");
+const metadataPath = join(previewDir, "signed-in-app.json");
+
+mkdirSync(framesDir, { recursive: true });
+
+const mintedDesktopAuth = shouldMintDesktopAuth()
+	? mintDesktopAuth({
+			...process.env,
+			DESKTOP_E2E_AUTH: "1",
+		})
+	: null;
+
+const authToken =
+	process.env.DESKTOP_E2E_AUTH_TOKEN ?? mintedDesktopAuth?.token;
+const authExpiresAt =
+	process.env.DESKTOP_E2E_AUTH_EXPIRES_AT ?? mintedDesktopAuth?.expiresAt;
+
+if (!authToken || !authExpiresAt) {
+	throw new Error(
+		"capture-cdp-preview requires a desktop auth token or DESKTOP_E2E_AUTH=1.",
+	);
+}
+
+const remoteDebuggingPort = 9333;
+const supersetHomeDir = mkdtempSync(join(tmpdir(), "superset-desktop-cdp-"));
+const appEntry = join(process.cwd(), "dist", "main", "index.js");
+
+const electronProcess = spawn(
+	electronPath,
+	[`--remote-debugging-port=${remoteDebuggingPort}`, appEntry],
+	{
+		cwd: process.cwd(),
+		env: {
+			...process.env,
+			NODE_ENV: "test",
+			DESKTOP_TEST_MODE: "1",
+			DESKTOP_TEST_AUTH_TOKEN: authToken,
+			DESKTOP_TEST_AUTH_EXPIRES_AT: authExpiresAt,
+			SUPERSET_HOME_DIR: supersetHomeDir,
+		},
+		stdio: "ignore",
+	},
+);
+
+try {
+	const target = await waitForRendererTarget(remoteDebuggingPort);
+	const cdp = connectToCdpTarget(target);
+	await cdp.waitForOpen();
+	await cdp.send("Page.enable");
+	await cdp.send("Runtime.enable");
+	await delay(1_500);
+
+	const signedInRoute = await waitForSignedInRoute(cdp.send);
+
+	const metadata = await cdp.send<{
+		result: {
+			value: {
+				hash: string;
+				href: string;
+				readyState: string;
+				testMode: boolean | null;
+				textSample: string;
+				title: string;
+			};
+		};
+	}>("Runtime.evaluate", {
+		expression: `(() => ({
+			href: window.location.href,
+			hash: window.location.hash,
+			title: document.title,
+			readyState: document.readyState,
+			textSample: (document.body?.innerText ?? "").slice(0, 500),
+			testMode: window.App?.testMode ?? null,
+		}))()`,
+		returnByValue: true,
+		awaitPromise: true,
+	});
+
+	const screenshot = await cdp.send<{ data: string }>(
+		"Page.captureScreenshot",
+		{
+			format: "png",
+			fromSurface: true,
+		},
+	);
+	writeFileSync(screenshotPath, Buffer.from(screenshot.data, "base64"));
+
+	for (let index = 0; index < 12; index += 1) {
+		const frame = await cdp.send<{ data: string }>("Page.captureScreenshot", {
+			format: "png",
+			fromSurface: true,
+		});
+		writeFileSync(
+			join(framesDir, `frame-${String(index).padStart(4, "0")}.png`),
+			Buffer.from(frame.data, "base64"),
+		);
+		await delay(250);
+	}
+
+	const ffmpegResult = spawnSync(
+		"ffmpeg",
+		[
+			"-y",
+			"-framerate",
+			"4",
+			"-i",
+			join(framesDir, "frame-%04d.png"),
+			"-c:v",
+			"libvpx-vp9",
+			"-pix_fmt",
+			"yuv420p",
+			videoPath,
+		],
+		{
+			cwd: process.cwd(),
+			encoding: "utf8",
+			maxBuffer: 16 * 1024 * 1024,
+			stdio: ["ignore", "pipe", "pipe"],
+		},
+	);
+
+	if (ffmpegResult.status !== 0) {
+		throw new Error(
+			`ffmpeg failed to create preview video: ${ffmpegResult.stderr}`,
+		);
+	}
+
+	writeFileSync(
+		metadataPath,
+		JSON.stringify(
+			{
+				...metadata.result.value,
+				auth: mintedDesktopAuth
+					? {
+							email: mintedDesktopAuth.email,
+							expiresAt: mintedDesktopAuth.expiresAt,
+							organizationId: mintedDesktopAuth.organizationId,
+							userId: mintedDesktopAuth.userId,
+						}
+					: null,
+				devtoolsUrl: target.url,
+				framesDir,
+				screenshotPath,
+				signedInRoute,
+				supersetHomeDir,
+				videoPath,
+			},
+			null,
+			2,
+		),
+	);
+
+	cdp.close();
+
+	console.log(
+		JSON.stringify(
+			{
+				previewDir,
+				screenshotPath,
+				videoPath,
+				metadataPath,
+			},
+			null,
+			2,
+		),
+	);
+} finally {
+	electronProcess.kill("SIGTERM");
+	await delay(500);
+	if (!electronProcess.killed) {
+		electronProcess.kill("SIGKILL");
+	}
+}

--- a/apps/desktop/scripts/mint-e2e-auth-session.ts
+++ b/apps/desktop/scripts/mint-e2e-auth-session.ts
@@ -1,0 +1,240 @@
+import { randomBytes } from "node:crypto";
+import { env as authEnv } from "@superset/auth/env";
+import { dbWs } from "@superset/db/client";
+import {
+	members,
+	organizations,
+	sessions,
+	users,
+} from "@superset/db/schema/auth";
+import { seedDefaultStatuses } from "@superset/db/seed-default-statuses";
+import { and, asc, eq } from "drizzle-orm";
+
+const DEFAULT_EMAIL = "desktop-e2e@local.superset.test";
+const DEFAULT_NAME = "Desktop E2E";
+const DEFAULT_TTL_HOURS = 12;
+const DESKTOP_E2E_SESSION_USER_AGENT = "Superset Desktop E2E";
+const TRUE_ENV_VALUES = new Set(["1", "true", "yes", "on"]);
+
+interface CliOptions {
+	email: string;
+	name: string;
+	ttlHours: number;
+}
+
+interface MintedDesktopSession {
+	email: string;
+	expiresAt: string;
+	name: string;
+	organizationId: string;
+	token: string;
+	userId: string;
+}
+
+function readBooleanEnv(name: string): boolean {
+	const value = process.env[name];
+	if (!value) return false;
+	return TRUE_ENV_VALUES.has(value.toLowerCase());
+}
+
+function parseCliArgs(argv: string[]): CliOptions {
+	let email = process.env.DESKTOP_E2E_AUTH_EMAIL ?? DEFAULT_EMAIL;
+	let name = process.env.DESKTOP_E2E_AUTH_NAME ?? DEFAULT_NAME;
+	let ttlHours = Number(
+		process.env.DESKTOP_E2E_AUTH_TTL_HOURS ?? DEFAULT_TTL_HOURS,
+	);
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+
+		if (arg === "--email") {
+			email = argv[index + 1] ?? email;
+			index += 1;
+			continue;
+		}
+
+		if (arg === "--name") {
+			name = argv[index + 1] ?? name;
+			index += 1;
+			continue;
+		}
+
+		if (arg === "--ttl-hours") {
+			const nextValue = Number(argv[index + 1]);
+			if (Number.isFinite(nextValue)) {
+				ttlHours = nextValue;
+			}
+			index += 1;
+		}
+	}
+
+	if (!Number.isFinite(ttlHours) || ttlHours <= 0) {
+		throw new Error("TTL hours must be a positive number.");
+	}
+
+	return {
+		email,
+		name,
+		ttlHours,
+	};
+}
+
+function sanitizeEmail(email: string): string {
+	return email.trim().toLowerCase();
+}
+
+function slugify(value: string): string {
+	const normalized = value
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "")
+		.slice(0, 48);
+
+	return normalized || "desktop-e2e";
+}
+
+function assertSafeEnvironment(): void {
+	const apiUrl = authEnv.NEXT_PUBLIC_API_URL;
+	const isLocalApi =
+		apiUrl.includes("localhost") || apiUrl.includes("127.0.0.1");
+
+	if (isLocalApi || readBooleanEnv("DESKTOP_E2E_AUTH_ALLOW_REMOTE")) {
+		return;
+	}
+
+	throw new Error(
+		[
+			"Refusing to mint a desktop E2E auth session against a non-local API URL.",
+			`Current NEXT_PUBLIC_API_URL: ${apiUrl}`,
+			"Set DESKTOP_E2E_AUTH_ALLOW_REMOTE=1 to override explicitly.",
+		].join(" "),
+	);
+}
+
+async function mintDesktopSession({
+	email,
+	name,
+	ttlHours,
+}: CliOptions): Promise<MintedDesktopSession> {
+	const normalizedEmail = sanitizeEmail(email);
+	const expiresAt = new Date(Date.now() + ttlHours * 60 * 60 * 1000);
+	const now = new Date();
+
+	return dbWs.transaction(async (tx) => {
+		let [user] = await tx
+			.select({
+				id: users.id,
+				name: users.name,
+				organizationIds: users.organizationIds,
+			})
+			.from(users)
+			.where(eq(users.email, normalizedEmail))
+			.limit(1);
+
+		if (!user) {
+			[user] = await tx
+				.insert(users)
+				.values({
+					email: normalizedEmail,
+					emailVerified: true,
+					name,
+					organizationIds: [],
+				})
+				.returning({
+					id: users.id,
+					name: users.name,
+					organizationIds: users.organizationIds,
+				});
+		}
+
+		const existingMemberships = await tx
+			.select({
+				organizationId: members.organizationId,
+			})
+			.from(members)
+			.where(eq(members.userId, user.id))
+			.orderBy(asc(members.createdAt));
+
+		let organizationId = existingMemberships[0]?.organizationId ?? null;
+
+		if (!organizationId) {
+			const [organization] = await tx
+				.insert(organizations)
+				.values({
+					name: `${user.name}'s Desktop E2E`,
+					slug: `${slugify(user.name)}-${user.id.slice(0, 8)}-desktop-e2e`,
+				})
+				.returning({
+					id: organizations.id,
+				});
+
+			organizationId = organization.id;
+
+			await tx.insert(members).values({
+				organizationId,
+				role: "owner",
+				userId: user.id,
+			});
+
+			await tx
+				.update(users)
+				.set({
+					organizationIds: [organizationId],
+				})
+				.where(eq(users.id, user.id));
+
+			await seedDefaultStatuses(organizationId, tx);
+		} else if (!user.organizationIds.includes(organizationId)) {
+			await tx
+				.update(users)
+				.set({
+					organizationIds: [organizationId, ...user.organizationIds],
+				})
+				.where(eq(users.id, user.id));
+		}
+
+		await tx
+			.delete(sessions)
+			.where(
+				and(
+					eq(sessions.userId, user.id),
+					eq(sessions.userAgent, DESKTOP_E2E_SESSION_USER_AGENT),
+				),
+			);
+
+		const token = randomBytes(32).toString("base64url");
+
+		await tx.insert(sessions).values({
+			token,
+			expiresAt,
+			userId: user.id,
+			activeOrganizationId: organizationId,
+			ipAddress: "127.0.0.1",
+			userAgent: DESKTOP_E2E_SESSION_USER_AGENT,
+			updatedAt: now,
+		});
+
+		return {
+			token,
+			expiresAt: expiresAt.toISOString(),
+			email: normalizedEmail,
+			name: user.name,
+			userId: user.id,
+			organizationId,
+		};
+	});
+}
+
+async function main() {
+	assertSafeEnvironment();
+	const options = parseCliArgs(process.argv.slice(2));
+	const mintedSession = await mintDesktopSession(options);
+	console.log(JSON.stringify(mintedSession, null, 2));
+}
+
+void main().catch((error: unknown) => {
+	console.error(
+		error instanceof Error ? error.message : "Failed to mint E2E auth session.",
+	);
+	process.exit(1);
+});

--- a/apps/desktop/scripts/run-e2e-scenario.ts
+++ b/apps/desktop/scripts/run-e2e-scenario.ts
@@ -1,0 +1,216 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SCENARIO_SPECS = {
+	all: [],
+	smoke: ["e2e/specs/launch.smoke.spec.ts"],
+} as const;
+
+type ScenarioName = keyof typeof SCENARIO_SPECS;
+
+interface CliOptions {
+	scenario: ScenarioName;
+	shouldPrepare: boolean;
+	passthroughArgs: string[];
+}
+
+interface MintedDesktopSession {
+	email: string;
+	expiresAt: string;
+	name: string;
+	organizationId: string;
+	token: string;
+	userId: string;
+}
+
+function parseCliArgs(argv: string[]): CliOptions {
+	let scenario: ScenarioName = "smoke";
+	let scenarioExplicitlySet = false;
+	let shouldPrepare = true;
+	const passthroughArgs: string[] = [];
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+
+		if (arg === "--") {
+			passthroughArgs.push(...argv.slice(index + 1));
+			break;
+		}
+
+		if (arg === "--no-prepare") {
+			shouldPrepare = false;
+			continue;
+		}
+
+		if (!scenarioExplicitlySet && arg in SCENARIO_SPECS) {
+			scenario = arg as ScenarioName;
+			scenarioExplicitlySet = true;
+			continue;
+		}
+
+		passthroughArgs.push(arg);
+	}
+
+	return {
+		scenario,
+		shouldPrepare,
+		passthroughArgs,
+	};
+}
+
+function createRunId(scenario: ScenarioName): string {
+	return `${new Date().toISOString().replaceAll(":", "-")}-${scenario}`;
+}
+
+function readBooleanEnv(name: string): boolean {
+	const value = process.env[name];
+	if (!value) return false;
+
+	return ["1", "true", "yes", "on"].includes(value.toLowerCase());
+}
+
+function runCommand(
+	args: string[],
+	env: NodeJS.ProcessEnv,
+	inheritStdout = true,
+) {
+	return spawnSync(process.execPath, args, {
+		cwd: process.cwd(),
+		env,
+		encoding: "utf8",
+		maxBuffer: 16 * 1024 * 1024,
+		stdio: inheritStdout ? "inherit" : ["ignore", "pipe", "inherit"],
+	});
+}
+
+function shouldMintDesktopAuth(): boolean {
+	if (process.env.DESKTOP_E2E_AUTH_TOKEN) {
+		return false;
+	}
+
+	return (
+		readBooleanEnv("DESKTOP_E2E_AUTH") ||
+		Boolean(process.env.DESKTOP_E2E_AUTH_EMAIL)
+	);
+}
+
+function mintDesktopAuth(env: NodeJS.ProcessEnv): MintedDesktopSession {
+	const mintResult = runCommand(["run", "e2e:auth"], env, false);
+
+	if (mintResult.status !== 0) {
+		throw new Error("Failed to mint desktop E2E auth session.");
+	}
+
+	const stdout = mintResult.stdout?.trim();
+	if (!stdout) {
+		throw new Error("Desktop E2E auth mint command did not return JSON.");
+	}
+
+	return JSON.parse(stdout) as MintedDesktopSession;
+}
+
+const { scenario, shouldPrepare, passthroughArgs } = parseCliArgs(
+	process.argv.slice(2),
+);
+
+const runDir = join(
+	process.cwd(),
+	"test-results",
+	"desktop-e2e",
+	"runs",
+	createRunId(scenario),
+);
+const reportFile = join(runDir, "playwright-report.json");
+
+mkdirSync(runDir, { recursive: true });
+
+if (shouldPrepare) {
+	const prepareResult = runCommand(["run", "e2e:prepare"], {
+		...process.env,
+		DESKTOP_E2E_BUILD: "1",
+		SKIP_SENTRY_UPLOAD: "1",
+	});
+
+	if (prepareResult.status !== 0) {
+		console.log(
+			JSON.stringify(
+				{
+					ok: false,
+					stage: "prepare",
+					scenario,
+					exitCode: prepareResult.status ?? 1,
+					runDir,
+				},
+				null,
+				2,
+			),
+		);
+		process.exit(prepareResult.status ?? 1);
+	}
+}
+
+const mintedDesktopAuth = shouldMintDesktopAuth()
+	? mintDesktopAuth({
+			...process.env,
+			DESKTOP_E2E_AUTH: "1",
+		})
+	: null;
+
+const scenarioSpecs = SCENARIO_SPECS[scenario];
+const testArgs = [
+	"x",
+	"playwright",
+	"test",
+	"-c",
+	"e2e/playwright.config.mjs",
+	"--reporter=json",
+	...scenarioSpecs,
+	...passthroughArgs,
+];
+
+const testResult = runCommand(
+	testArgs,
+	{
+		...process.env,
+		DESKTOP_E2E_ARTIFACTS_DIR: runDir,
+		DESKTOP_E2E_ALWAYS_CAPTURE: process.env.DESKTOP_E2E_ALWAYS_CAPTURE ?? "1",
+		...(mintedDesktopAuth
+			? {
+					DESKTOP_E2E_AUTH_TOKEN: mintedDesktopAuth.token,
+					DESKTOP_E2E_AUTH_EXPIRES_AT: mintedDesktopAuth.expiresAt,
+					DESKTOP_E2E_EXPECT_AUTHENTICATED: "1",
+				}
+			: {}),
+	},
+	false,
+);
+
+const stdout = testResult.stdout ?? "";
+
+writeFileSync(reportFile, stdout);
+
+console.log(
+	JSON.stringify(
+		{
+			ok: testResult.status === 0,
+			stage: "test",
+			scenario,
+			exitCode: testResult.status ?? 1,
+			runDir,
+			reportFile,
+			auth: mintedDesktopAuth
+				? {
+						email: mintedDesktopAuth.email,
+						expiresAt: mintedDesktopAuth.expiresAt,
+						organizationId: mintedDesktopAuth.organizationId,
+						userId: mintedDesktopAuth.userId,
+					}
+				: null,
+		},
+		null,
+		2,
+	),
+);
+
+process.exit(testResult.status ?? 1);

--- a/apps/desktop/src/lib/electron-app/test-automation-ipc.ts
+++ b/apps/desktop/src/lib/electron-app/test-automation-ipc.ts
@@ -1,0 +1,15 @@
+export const DESKTOP_TEST_AUTOMATION_CHANNEL =
+	"superset:desktop-test-automation";
+
+export type DesktopTestAutomationCommand =
+	| { type: "ping" }
+	| { type: "getEnvironment" }
+	| { type: "getWindowInfo" }
+	| { type: "getAuthState" }
+	| { type: "getStoredAuthToken" }
+	| {
+			type: "seedAuthToken";
+			token: string;
+			expiresAt: string;
+	  }
+	| { type: "clearAuthToken" };

--- a/apps/desktop/src/lib/electron-app/test-mode.ts
+++ b/apps/desktop/src/lib/electron-app/test-mode.ts
@@ -1,0 +1,17 @@
+const TRUE_ENV_VALUES = new Set(["1", "true", "yes", "on"]);
+
+function readBooleanEnv(name: string): boolean {
+	const value = process.env[name];
+	if (!value) return false;
+	return TRUE_ENV_VALUES.has(value.toLowerCase());
+}
+
+export const IS_DESKTOP_TEST_MODE = readBooleanEnv("DESKTOP_TEST_MODE");
+
+export const DESKTOP_E2E_ARTIFACTS_DIR =
+	process.env.DESKTOP_E2E_ARTIFACTS_DIR ?? null;
+
+export const DEFAULT_DESKTOP_TEST_WINDOW_BOUNDS = {
+	width: 1440,
+	height: 960,
+} as const;

--- a/apps/desktop/src/lib/trpc/routers/auth/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/auth/index.ts
@@ -1,5 +1,4 @@
 import crypto from "node:crypto";
-import fs from "node:fs/promises";
 import { AUTH_PROVIDERS } from "@superset/shared/constants";
 import { observable } from "@trpc/server/observable";
 import { shell } from "electron";
@@ -12,10 +11,10 @@ import { z } from "zod";
 import { publicProcedure, router } from "../..";
 import {
 	authEvents,
+	clearToken,
 	loadToken,
 	saveToken,
 	stateStore,
-	TOKEN_FILE,
 } from "./utils/auth-functions";
 
 export const createAuthRouter = () => {
@@ -110,8 +109,7 @@ export const createAuthRouter = () => {
 
 		signOut: publicProcedure.mutation(async () => {
 			getHostServiceManager().stopAll();
-			await fs.unlink(TOKEN_FILE).catch(() => {});
-			authEvents.emit("token-cleared");
+			await clearToken();
 			return { success: true };
 		}),
 	});

--- a/apps/desktop/src/lib/trpc/routers/auth/utils/auth-functions.ts
+++ b/apps/desktop/src/lib/trpc/routers/auth/utils/auth-functions.ts
@@ -55,6 +55,14 @@ export async function saveToken({
 }
 
 /**
+ * Remove the persisted token and notify subscribers.
+ */
+export async function clearToken(): Promise<void> {
+	await fs.unlink(TOKEN_FILE).catch(() => {});
+	authEvents.emit("token-cleared");
+}
+
+/**
  * Handle OAuth callback from deep link.
  * Validates CSRF state and saves token.
  */

--- a/apps/desktop/src/lib/trpc/routers/automation/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/automation/index.ts
@@ -1,0 +1,92 @@
+import { TRPCError } from "@trpc/server";
+import type { BrowserWindow } from "electron";
+import { app } from "electron";
+import {
+	DESKTOP_E2E_ARTIFACTS_DIR,
+	IS_DESKTOP_TEST_MODE,
+} from "lib/electron-app/test-mode";
+import { SUPERSET_HOME_DIR } from "main/lib/app-environment";
+import {
+	clearDesktopTestAuthToken,
+	getDesktopTestAuthState,
+	seedDesktopTestAuthToken,
+} from "main/lib/test-auth";
+import { z } from "zod";
+import { publicProcedure, router } from "../..";
+
+function assertDesktopTestMode(): void {
+	if (!IS_DESKTOP_TEST_MODE) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message:
+				"Desktop automation routes are only available when DESKTOP_TEST_MODE=1.",
+		});
+	}
+}
+
+function getWindowInfo(window: BrowserWindow | null) {
+	if (!window) return null;
+
+	return {
+		title: window.getTitle(),
+		url: window.webContents.getURL(),
+		isFocused: window.isFocused(),
+		isVisible: window.isVisible(),
+		bounds: window.getBounds(),
+	};
+}
+
+export const createAutomationRouter = (
+	getWindow: () => BrowserWindow | null,
+) => {
+	return router({
+		ping: publicProcedure.query(() => {
+			assertDesktopTestMode();
+
+			return {
+				ok: true,
+				testMode: true,
+				pid: process.pid,
+				appVersion: app.getVersion(),
+			};
+		}),
+
+		getEnvironment: publicProcedure.query(() => {
+			assertDesktopTestMode();
+
+			return {
+				testMode: true,
+				nodeEnv: process.env.NODE_ENV ?? "development",
+				supersetHomeDir: SUPERSET_HOME_DIR,
+				artifactsDir: DESKTOP_E2E_ARTIFACTS_DIR,
+			};
+		}),
+
+		getWindowInfo: publicProcedure.query(() => {
+			assertDesktopTestMode();
+			return getWindowInfo(getWindow());
+		}),
+
+		getAuthState: publicProcedure.query(async () => {
+			assertDesktopTestMode();
+			return getDesktopTestAuthState();
+		}),
+
+		seedAuthToken: publicProcedure
+			.input(
+				z.object({
+					token: z.string().min(1),
+					expiresAt: z.string(),
+				}),
+			)
+			.mutation(async ({ input }) => {
+				assertDesktopTestMode();
+				return seedDesktopTestAuthToken(input);
+			}),
+
+		clearAuthToken: publicProcedure.mutation(async () => {
+			assertDesktopTestMode();
+			return clearDesktopTestAuthToken();
+		}),
+	});
+};

--- a/apps/desktop/src/lib/trpc/routers/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/index.ts
@@ -3,6 +3,7 @@ import { router } from "..";
 import { createAnalyticsRouter } from "./analytics";
 import { createAuthRouter } from "./auth";
 import { createAutoUpdateRouter } from "./auto-update";
+import { createAutomationRouter } from "./automation";
 import { createBrowserRouter } from "./browser/browser";
 import { createBrowserHistoryRouter } from "./browser-history";
 import { createCacheRouter } from "./cache";
@@ -30,6 +31,7 @@ import { createWorkspacesRouter } from "./workspaces";
 
 export const createAppRouter = (getWindow: () => BrowserWindow | null) => {
 	return router({
+		automation: createAutomationRouter(getWindow),
 		chatRuntimeService: createChatRuntimeServiceRouter(),
 		chatService: createChatServiceRouter(),
 		analytics: createAnalyticsRouter(),

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -11,6 +11,7 @@ import {
 	session,
 } from "electron";
 import { makeAppSetup } from "lib/electron-app/factories/app/setup";
+import { IS_DESKTOP_TEST_MODE } from "lib/electron-app/test-mode";
 import {
 	handleAuthCallback,
 	parseAuthDeepLink,
@@ -36,6 +37,8 @@ import {
 	prewarmTerminalRuntime,
 	reconcileDaemonSessions,
 } from "./lib/terminal";
+import { seedDesktopTestAuthFromEnv } from "./lib/test-auth";
+import { registerDesktopTestAutomationIpc } from "./lib/test-automation-ipc";
 import { disposeTray, initTray } from "./lib/tray";
 import { MainWindow } from "./windows/main";
 
@@ -173,7 +176,10 @@ app.on("before-quit", async (event) => {
 
 	const isDev = process.env.NODE_ENV === "development";
 	const shouldConfirm =
-		!skipConfirmation && !isDev && getConfirmOnQuitSetting();
+		!skipConfirmation &&
+		!isDev &&
+		!IS_DESKTOP_TEST_MODE &&
+		getConfirmOnQuitSetting();
 
 	if (shouldConfirm) {
 		event.preventDefault();
@@ -280,8 +286,13 @@ if (!gotTheLock) {
 
 	(async () => {
 		await app.whenReady();
-		registerWithMacOSNotificationCenter();
-		requestAppleEventsAccess();
+		registerDesktopTestAutomationIpc(
+			() => BrowserWindow.getAllWindows()[0] ?? null,
+		);
+		if (!IS_DESKTOP_TEST_MODE) {
+			registerWithMacOSNotificationCenter();
+			requestAppleEventsAccess();
+		}
 
 		// Must register on both default session and the app's custom partition
 		const iconProtocolHandler = (request: Request) => {
@@ -330,8 +341,13 @@ if (!gotTheLock) {
 
 		ensureProjectIconsDir();
 		setWorkspaceDockIcon();
-		initSentry();
+		if (!IS_DESKTOP_TEST_MODE) {
+			initSentry();
+		}
 		await initAppState();
+		if (IS_DESKTOP_TEST_MODE) {
+			await seedDesktopTestAuthFromEnv();
+		}
 
 		await loadWebviewBrowserExtension();
 
@@ -339,15 +355,19 @@ if (!gotTheLock) {
 		await reconcileDaemonSessions();
 		prewarmTerminalRuntime();
 
-		try {
-			setupAgentHooks();
-		} catch (error) {
-			console.error("[main] Failed to set up agent hooks:", error);
+		if (!IS_DESKTOP_TEST_MODE) {
+			try {
+				setupAgentHooks();
+			} catch (error) {
+				console.error("[main] Failed to set up agent hooks:", error);
+			}
 		}
 
 		await makeAppSetup(() => MainWindow());
-		setupAutoUpdater();
-		initTray();
+		if (!IS_DESKTOP_TEST_MODE) {
+			setupAutoUpdater();
+			initTray();
+		}
 
 		// Process any deep links from cold start
 		const coldStartUrl = findDeepLinkInArgv(process.argv);

--- a/apps/desktop/src/main/lib/app-environment.ts
+++ b/apps/desktop/src/main/lib/app-environment.ts
@@ -1,12 +1,16 @@
 import { chmodSync, existsSync, mkdirSync } from "node:fs";
-import { homedir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
+import { IS_DESKTOP_TEST_MODE } from "lib/electron-app/test-mode";
 import { SUPERSET_DIR_NAME } from "shared/constants";
 
 const SUPERSET_HOME_DIR_ENV = "SUPERSET_HOME_DIR";
+const DEFAULT_SUPERSET_HOME_DIR = IS_DESKTOP_TEST_MODE
+	? join(tmpdir(), SUPERSET_DIR_NAME, "desktop-test", String(process.pid))
+	: join(homedir(), SUPERSET_DIR_NAME);
 
 export const SUPERSET_HOME_DIR =
-	process.env[SUPERSET_HOME_DIR_ENV] || join(homedir(), SUPERSET_DIR_NAME);
+	process.env[SUPERSET_HOME_DIR_ENV] || DEFAULT_SUPERSET_HOME_DIR;
 process.env[SUPERSET_HOME_DIR_ENV] = SUPERSET_HOME_DIR;
 
 export const SUPERSET_HOME_DIR_MODE = 0o700;

--- a/apps/desktop/src/main/lib/test-auth.ts
+++ b/apps/desktop/src/main/lib/test-auth.ts
@@ -1,0 +1,104 @@
+import { IS_DESKTOP_TEST_MODE } from "lib/electron-app/test-mode";
+import {
+	clearToken,
+	loadToken,
+	saveToken,
+} from "lib/trpc/routers/auth/utils/auth-functions";
+
+const DESKTOP_TEST_AUTH_TOKEN_ENV = "DESKTOP_TEST_AUTH_TOKEN";
+const DESKTOP_TEST_AUTH_EXPIRES_AT_ENV = "DESKTOP_TEST_AUTH_EXPIRES_AT";
+
+export interface DesktopTestAuthState {
+	expiresAt: string | null;
+	tokenPresent: boolean;
+}
+
+export interface DesktopTestStoredAuthToken {
+	expiresAt: string | null;
+	token: string | null;
+}
+
+function assertDesktopTestMode(): void {
+	if (!IS_DESKTOP_TEST_MODE) {
+		throw new Error(
+			"Desktop test auth helpers are only available when DESKTOP_TEST_MODE=1.",
+		);
+	}
+}
+
+function validateExpiresAt(expiresAt: string): string {
+	const parsed = new Date(expiresAt);
+	if (Number.isNaN(parsed.getTime())) {
+		throw new Error(
+			"DESKTOP_TEST_AUTH_EXPIRES_AT must be a valid ISO timestamp.",
+		);
+	}
+
+	return parsed.toISOString();
+}
+
+function readDesktopTestAuthSeedFromEnv(): {
+	expiresAt: string;
+	token: string;
+} | null {
+	const token = process.env[DESKTOP_TEST_AUTH_TOKEN_ENV] ?? null;
+	const expiresAt = process.env[DESKTOP_TEST_AUTH_EXPIRES_AT_ENV] ?? null;
+
+	if (!token && !expiresAt) {
+		return null;
+	}
+
+	if (!token || !expiresAt) {
+		throw new Error(
+			`${DESKTOP_TEST_AUTH_TOKEN_ENV} and ${DESKTOP_TEST_AUTH_EXPIRES_AT_ENV} must be set together.`,
+		);
+	}
+
+	return {
+		token,
+		expiresAt: validateExpiresAt(expiresAt),
+	};
+}
+
+export async function getDesktopTestAuthState(): Promise<DesktopTestAuthState> {
+	assertDesktopTestMode();
+	const stored = await loadToken();
+
+	return {
+		tokenPresent: Boolean(stored.token),
+		expiresAt: stored.expiresAt,
+	};
+}
+
+export async function getDesktopTestStoredAuthToken(): Promise<DesktopTestStoredAuthToken> {
+	assertDesktopTestMode();
+	return loadToken();
+}
+
+export async function seedDesktopTestAuthToken(input: {
+	expiresAt: string;
+	token: string;
+}): Promise<DesktopTestAuthState> {
+	assertDesktopTestMode();
+	await saveToken({
+		token: input.token,
+		expiresAt: validateExpiresAt(input.expiresAt),
+	});
+
+	return getDesktopTestAuthState();
+}
+
+export async function clearDesktopTestAuthToken(): Promise<DesktopTestAuthState> {
+	assertDesktopTestMode();
+	await clearToken();
+	return getDesktopTestAuthState();
+}
+
+export async function seedDesktopTestAuthFromEnv(): Promise<void> {
+	assertDesktopTestMode();
+	const seed = readDesktopTestAuthSeedFromEnv();
+	if (!seed) return;
+
+	await saveToken(seed);
+	console.log("[desktop-test-auth] Seeded stored auth token from environment.");
+}

--- a/apps/desktop/src/main/lib/test-automation-ipc.ts
+++ b/apps/desktop/src/main/lib/test-automation-ipc.ts
@@ -1,0 +1,85 @@
+import type { BrowserWindow } from "electron";
+import { app, ipcMain } from "electron";
+import {
+	DESKTOP_TEST_AUTOMATION_CHANNEL,
+	type DesktopTestAutomationCommand,
+} from "lib/electron-app/test-automation-ipc";
+import {
+	DESKTOP_E2E_ARTIFACTS_DIR,
+	IS_DESKTOP_TEST_MODE,
+} from "lib/electron-app/test-mode";
+import { SUPERSET_HOME_DIR } from "./app-environment";
+import {
+	clearDesktopTestAuthToken,
+	getDesktopTestAuthState,
+	getDesktopTestStoredAuthToken,
+	seedDesktopTestAuthToken,
+} from "./test-auth";
+
+function assertDesktopTestMode(): void {
+	if (!IS_DESKTOP_TEST_MODE) {
+		throw new Error(
+			"Desktop automation IPC is only available when DESKTOP_TEST_MODE=1.",
+		);
+	}
+}
+
+function getWindowInfo(window: BrowserWindow | null) {
+	if (!window) return null;
+
+	return {
+		title: window.getTitle(),
+		url: window.webContents.getURL(),
+		isFocused: window.isFocused(),
+		isVisible: window.isVisible(),
+		bounds: window.getBounds(),
+	};
+}
+
+export function registerDesktopTestAutomationIpc(
+	getWindow: () => BrowserWindow | null,
+): void {
+	ipcMain.removeHandler(DESKTOP_TEST_AUTOMATION_CHANNEL);
+	ipcMain.handle(
+		DESKTOP_TEST_AUTOMATION_CHANNEL,
+		async (_event, command: DesktopTestAutomationCommand) => {
+			assertDesktopTestMode();
+
+			switch (command.type) {
+				case "ping":
+					return {
+						ok: true,
+						testMode: true,
+						pid: process.pid,
+						appVersion: app.getVersion(),
+					};
+				case "getEnvironment":
+					return {
+						testMode: true,
+						nodeEnv: process.env.NODE_ENV ?? "development",
+						supersetHomeDir: SUPERSET_HOME_DIR,
+						artifactsDir: DESKTOP_E2E_ARTIFACTS_DIR,
+					};
+				case "getWindowInfo":
+					return getWindowInfo(getWindow());
+				case "getAuthState":
+					return getDesktopTestAuthState();
+				case "getStoredAuthToken":
+					return getDesktopTestStoredAuthToken();
+				case "seedAuthToken":
+					return seedDesktopTestAuthToken({
+						token: command.token,
+						expiresAt: command.expiresAt,
+					});
+				case "clearAuthToken":
+					return clearDesktopTestAuthToken();
+				default: {
+					const exhaustiveCheck: never = command;
+					throw new Error(
+						`Unsupported desktop automation command: ${exhaustiveCheck}`,
+					);
+				}
+			}
+		},
+	);
+}

--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -4,6 +4,10 @@ import { eq } from "drizzle-orm";
 import type { BrowserWindow } from "electron";
 import { app, Notification, nativeTheme } from "electron";
 import { createWindow } from "lib/electron-app/factories/windows/create";
+import {
+	DEFAULT_DESKTOP_TEST_WINDOW_BOUNDS,
+	IS_DESKTOP_TEST_MODE,
+} from "lib/electron-app/test-mode";
 import { createAppRouter } from "lib/trpc/routers";
 import { localDb } from "main/lib/local-db";
 import { NOTIFICATION_EVENTS, PLATFORM } from "shared/constants";
@@ -88,8 +92,15 @@ app.on("child-process-gone", (_event, details) => {
 });
 
 export async function MainWindow() {
-	const savedWindowState = loadWindowState();
-	const initialBounds = getInitialWindowBounds(savedWindowState);
+	const savedWindowState = IS_DESKTOP_TEST_MODE ? null : loadWindowState();
+	const initialBounds = IS_DESKTOP_TEST_MODE
+		? {
+				width: DEFAULT_DESKTOP_TEST_WINDOW_BOUNDS.width,
+				height: DEFAULT_DESKTOP_TEST_WINDOW_BOUNDS.height,
+				center: true,
+				isMaximized: false,
+			}
+		: getInitialWindowBounds(savedWindowState);
 
 	const isDev = env.NODE_ENV === "development";
 	const workspaceName = isDev ? getEnvWorkspaceName() : undefined;
@@ -227,6 +238,7 @@ export async function MainWindow() {
 	let initialized = false;
 	let saveTimeout: ReturnType<typeof setTimeout> | null = null;
 	const debouncedSave = () => {
+		if (IS_DESKTOP_TEST_MODE) return;
 		if (!initialized || window.isDestroyed()) return;
 		if (saveTimeout) clearTimeout(saveTimeout);
 		saveTimeout = setTimeout(() => {
@@ -283,18 +295,22 @@ export async function MainWindow() {
 	});
 
 	window.on("close", () => {
-		// Save window state first, before any cleanup
-		const isMaximized = window.isMaximized();
-		const bounds = isMaximized ? window.getNormalBounds() : window.getBounds();
-		const zoomLevel = window.webContents.getZoomLevel();
-		saveWindowState({
-			x: bounds.x,
-			y: bounds.y,
-			width: bounds.width,
-			height: bounds.height,
-			isMaximized,
-			zoomLevel,
-		});
+		if (!IS_DESKTOP_TEST_MODE) {
+			// Save window state first, before any cleanup
+			const isMaximized = window.isMaximized();
+			const bounds = isMaximized
+				? window.getNormalBounds()
+				: window.getBounds();
+			const zoomLevel = window.webContents.getZoomLevel();
+			saveWindowState({
+				x: bounds.x,
+				y: bounds.y,
+				width: bounds.width,
+				height: bounds.height,
+				isMaximized,
+				zoomLevel,
+			});
+		}
 
 		browserManager.unregisterAll();
 		server.close();

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,7 +1,12 @@
 import "@sentry/electron/preload";
 
 import { contextBridge, ipcRenderer, webUtils } from "electron";
+import {
+	DESKTOP_TEST_AUTOMATION_CHANNEL,
+	type DesktopTestAutomationCommand,
+} from "lib/electron-app/test-automation-ipc";
 import { exposeElectronTRPC } from "trpc-electron/main";
+import { IS_DESKTOP_TEST_MODE } from "../lib/electron-app/test-mode";
 
 declare const __APP_VERSION__: string;
 
@@ -15,11 +20,86 @@ declare global {
 	}
 }
 
+// Expose electron-trpc IPC channel before any renderer client initializes.
+exposeElectronTRPC();
+
+const automationAPI = {
+	ping: () =>
+		invokeDesktopTestAutomation({
+			type: "ping",
+		}) as Promise<{
+			ok: boolean;
+			testMode: boolean;
+			pid: number;
+			appVersion: string;
+		}>,
+	getEnvironment: () =>
+		invokeDesktopTestAutomation({
+			type: "getEnvironment",
+		}) as Promise<{
+			testMode: boolean;
+			nodeEnv: string;
+			supersetHomeDir: string;
+			artifactsDir: string | null;
+		}>,
+	getWindowInfo: () =>
+		invokeDesktopTestAutomation({
+			type: "getWindowInfo",
+		}) as Promise<{
+			title: string;
+			url: string;
+			isFocused: boolean;
+			isVisible: boolean;
+			bounds: {
+				x: number;
+				y: number;
+				width: number;
+				height: number;
+			};
+		} | null>,
+	getAuthState: () =>
+		invokeDesktopTestAutomation({
+			type: "getAuthState",
+		}) as Promise<{
+			tokenPresent: boolean;
+			expiresAt: string | null;
+		}>,
+	getStoredAuthToken: () =>
+		invokeDesktopTestAutomation({
+			type: "getStoredAuthToken",
+		}) as Promise<{
+			token: string | null;
+			expiresAt: string | null;
+		}>,
+	seedAuthToken: (input: { token: string; expiresAt: string }) =>
+		invokeDesktopTestAutomation({
+			type: "seedAuthToken",
+			token: input.token,
+			expiresAt: input.expiresAt,
+		}) as Promise<{
+			tokenPresent: boolean;
+			expiresAt: string | null;
+		}>,
+	clearAuthToken: () =>
+		invokeDesktopTestAutomation({
+			type: "clearAuthToken",
+		}) as Promise<{
+			tokenPresent: boolean;
+			expiresAt: string | null;
+		}>,
+};
+
 const API = {
 	sayHelloFromBridge: () => console.log("\nHello from bridgeAPI! 👋\n\n"),
 	username: process.env.USER,
 	appVersion: __APP_VERSION__,
+	testMode: IS_DESKTOP_TEST_MODE,
+	automation: automationAPI,
 };
+
+function invokeDesktopTestAutomation(command: DesktopTestAutomationCommand) {
+	return ipcRenderer.invoke(DESKTOP_TEST_AUTOMATION_CHANNEL, command);
+}
 
 // Store mapping of user listeners to wrapped listeners for proper cleanup
 type IpcListener = (...args: unknown[]) => void;
@@ -57,9 +137,6 @@ const ipcRendererAPI = {
 		}
 	},
 };
-
-// Expose electron-trpc IPC channel FIRST (must be before contextBridge calls)
-exposeElectronTRPC();
 
 contextBridge.exposeInMainWorld("App", API);
 contextBridge.exposeInMainWorld("ipcRenderer", ipcRendererAPI);

--- a/apps/desktop/src/renderer/providers/AuthProvider/AuthProvider.tsx
+++ b/apps/desktop/src/renderer/providers/AuthProvider/AuthProvider.tsx
@@ -6,12 +6,55 @@ import { electronTrpc } from "../../lib/electron-trpc";
 export function AuthProvider({ children }: { children: ReactNode }) {
 	const [isHydrated, setIsHydrated] = useState(false);
 	const { refetch: refetchSession } = authClient.useSession();
+	const isDesktopTestMode = window.App.testMode;
 
 	const { data: storedToken, isSuccess } =
 		electronTrpc.auth.getStoredToken.useQuery(undefined, {
 			refetchOnWindowFocus: false,
 			refetchOnReconnect: false,
 		});
+
+	useEffect(() => {
+		if (!isDesktopTestMode || isHydrated) return;
+
+		let cancelled = false;
+
+		void window.App.automation
+			.getStoredAuthToken()
+			.then((token) => {
+				if (cancelled) return;
+
+				if (token.token && token.expiresAt) {
+					const isExpired = new Date(token.expiresAt) < new Date();
+					if (!isExpired) {
+						setAuthToken(token.token);
+						setIsHydrated(true);
+						void refetchSession().catch((err) => {
+							console.warn(
+								"[AuthProvider] session refetch failed during test hydration",
+								err,
+							);
+						});
+						return;
+					}
+				}
+
+				setIsHydrated(true);
+			})
+			.catch((err) => {
+				console.warn(
+					"[AuthProvider] test-mode stored token lookup failed",
+					err,
+				);
+				if (!cancelled) {
+					setIsHydrated(true);
+				}
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [isDesktopTestMode, isHydrated, refetchSession]);
 
 	useEffect(() => {
 		if (!isSuccess || isHydrated) return;
@@ -23,25 +66,29 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 				const isExpired = new Date(storedToken.expiresAt) < new Date();
 				if (!isExpired) {
 					setAuthToken(storedToken.token);
-					try {
-						await refetchSession();
-					} catch (err) {
+					if (!cancelled) {
+						setIsHydrated(true);
+					}
+					void refetchSession().catch((err) => {
 						console.warn(
 							"[AuthProvider] session refetch failed during hydration",
 							err,
 						);
-					}
-					try {
-						const res = await authClient.token();
-						if (res.data?.token) {
-							setJwt(res.data.token);
-						}
-					} catch (err) {
-						console.warn(
-							"[AuthProvider] JWT fetch failed during hydration",
-							err,
-						);
-					}
+					});
+					void authClient
+						.token()
+						.then((res) => {
+							if (res.data?.token) {
+								setJwt(res.data.token);
+							}
+						})
+						.catch((err) => {
+							console.warn(
+								"[AuthProvider] JWT fetch failed during hydration",
+								err,
+							);
+						});
+					return;
 				}
 			}
 			if (!cancelled) {
@@ -61,15 +108,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 				setAuthToken(null);
 				await authClient.signOut({ fetchOptions: { throw: false } });
 				setAuthToken(data.token);
-				try {
-					await refetchSession();
-				} catch (err) {
+				setIsHydrated(true);
+				void refetchSession().catch((err) => {
 					console.warn(
 						"[AuthProvider] session refetch failed after token change",
 						err,
 					);
-				}
-				setIsHydrated(true);
+				});
 			} else if (data === null) {
 				setAuthToken(null);
 				setJwt(null);

--- a/bun.lock
+++ b/bun.lock
@@ -110,7 +110,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.3.2",
+      "version": "1.4.1",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.43",
         "@ai-sdk/openai": "3.0.36",
@@ -298,6 +298,7 @@
         "zustand": "^5.0.8",
       },
       "devDependencies": {
+        "@playwright/test": "^1.56.1",
         "@sentry/vite-plugin": "^4.7.0",
         "@superset/typescript": "workspace:*",
         "@tailwindcss/vite": "^4.0.9",
@@ -1875,6 +1876,8 @@
     "@pierre/diffs": ["@pierre/diffs@1.0.10", "", { "dependencies": { "@shikijs/core": "^3.0.0", "@shikijs/engine-javascript": "^3.0.0", "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-ahkpfS30NfaB+PBxnf0/Mc20ySBRTQmM28a7Ojpd0UZixmTyhGhJfBFjvmhX8dSzR22lB3h3OIMMxpB4yYTIOQ=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@playwright/test": ["@playwright/test@1.58.2", "", { "dependencies": { "playwright": "1.58.2" }, "bin": { "playwright": "cli.js" } }, "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA=="],
 
     "@popperjs/core": ["@popperjs/core@2.11.8", "", {}, "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="],
 
@@ -4662,6 +4665,10 @@
 
     "pkg-types": ["pkg-types@2.3.0", "", { "dependencies": { "confbox": "^0.2.2", "exsolve": "^1.0.7", "pathe": "^2.0.3" } }, "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig=="],
 
+    "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
+
+    "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
+
     "plist": ["plist@3.1.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.8", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ=="],
 
     "plur": ["plur@5.1.0", "", { "dependencies": { "irregular-plurals": "^3.3.0" } }, "sha512-VP/72JeXqak2KiOzjgKtQen5y3IZHn+9GOuLDafPv0eXa47xq0At93XahYBs26MsifCQ4enGKwbjBTKgb9QJXg=="],
@@ -6367,6 +6374,8 @@
     "path-scurry/lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
 
     "pkg-conf/find-up": ["find-up@6.3.0", "", { "dependencies": { "locate-path": "^7.1.0", "path-exists": "^5.0.0" } }, "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "plist/xmlbuilder": ["xmlbuilder@15.1.1", "", {}, "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="],
 


### PR DESCRIPTION
## Summary
- add a desktop test mode with automation IPC, preload hooks, and deterministic auth seeding for test and agent-driven runs
- add Playwright desktop E2E scaffolding, a scenario runner, auth session minting, and preview capture scripts for screenshots and video artifacts
- document the instrumentation strategy and implementation, and skip Sentry upload during E2E build preparation

## Verification
- bun x @biomejs/biome check apps/desktop/e2e apps/desktop/scripts apps/desktop/src/lib/electron-app/test-automation-ipc.ts apps/desktop/src/lib/electron-app/test-mode.ts apps/desktop/src/lib/trpc/routers/automation apps/desktop/src/lib/trpc/routers/auth/index.ts apps/desktop/src/lib/trpc/routers/auth/utils/auth-functions.ts apps/desktop/src/lib/trpc/routers/index.ts apps/desktop/src/main/index.ts apps/desktop/src/main/lib/app-environment.ts apps/desktop/src/main/lib/test-auth.ts apps/desktop/src/main/lib/test-automation-ipc.ts apps/desktop/src/main/windows/main.ts apps/desktop/src/preload/index.ts apps/desktop/src/renderer/providers/AuthProvider/AuthProvider.tsx apps/desktop/electron.vite.config.ts apps/desktop/package.json apps/desktop/plans/20260326-desktop-test-automation-implementation.md apps/desktop/plans/20260326-desktop-test-automation-instrumentation-plan.md
- bun run e2e:scenario smoke
- DESKTOP_E2E_AUTH=1 bun run e2e:scenario smoke
- DESKTOP_E2E_AUTH=1 bun run e2e:preview:cdp

## Notes
- Playwright remains the canonical reusable test surface.
- The CDP preview script is the current reliable path for signed-in preview artifacts while direct Playwright Electron video capture still needs follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deterministic desktop test mode and a Playwright-based E2E harness with a small automation API, enabling reliable CI- and agent-driven desktop tests with screenshots, traces, and video. Also adds test-time auth seeding and skips Sentry sourcemap upload during E2E builds.

- **New Features**
  - `DESKTOP_TEST_MODE` isolates app state, fixes window to 1440×960, and skips updater, tray, Apple Events, and quit prompts.
  - Gated automation API via `superset:desktop-test-automation` IPC and TRPC `automation` router, exposed as `window.App.automation` (ping, environment, window info, auth get/seed/clear).
  - Playwright desktop E2E harness under `apps/desktop/e2e/` with Electron fixture and a smoke test; artifacts save to `DESKTOP_E2E_ARTIFACTS_DIR`.
  - Test auth seeding via env (`DESKTOP_E2E_AUTH_TOKEN`/`DESKTOP_E2E_AUTH_EXPIRES_AT`) or minting script; renderer hydrates stored token in test mode.
  - Preview capture scripts produce signed-in screenshots and video (CDP and Playwright paths).
  - Sentry sourcemap upload is skipped for E2E builds; adds `@playwright/test` to dev deps.

- **Migration**
  - Run E2E: `bun run e2e` or `bun run e2e:scenario smoke` (append `-- --headed` for headed).
  - Authenticated runs: set `DESKTOP_E2E_AUTH=1` or provide `DESKTOP_E2E_AUTH_TOKEN` and `DESKTOP_E2E_AUTH_EXPIRES_AT`.
  - Capture previews: `bun run e2e:preview:cdp` (recommended) or `bun run e2e:preview:signed-in`.
  - Ensure `ffmpeg`, `curl`, and `rg` are installed for preview scripts.

<sup>Written for commit 5aabc9398387b0328c3518149cd582928b0a4749. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end testing framework for the desktop application, including test fixtures, automation commands, and smoke test scenarios.
  * Implemented test mode with support for authentication seeding and verification across different app states.

* **Chores**
  * Added Playwright test runner configuration and related dependencies.
  * Introduced test automation scripts for scenario execution and artifact capture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->