### PR TITLE
Fix: settings search bar input state becomes stale

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/account/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/account/page.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useMemo } from "react";
 import { useSettingsSearchQuery } from "renderer/stores/settings-state";
-import { getMatchingItemsForSection } from "../utils/settings-search";
+import { getVisibleSettingIdsForSection } from "../utils/settings-search";
 import { AccountSettings } from "./components/AccountSettings";
 
 export const Route = createFileRoute("/_authenticated/settings/account/")({
@@ -11,12 +11,10 @@ export const Route = createFileRoute("/_authenticated/settings/account/")({
 function AccountSettingsPage() {
 	const searchQuery = useSettingsSearchQuery();
 
-	const visibleItems = useMemo(() => {
-		if (!searchQuery) return null;
-		return getMatchingItemsForSection(searchQuery, "account").map(
-			(item) => item.id,
-		);
-	}, [searchQuery]);
+	const visibleItems = useMemo(
+		() => getVisibleSettingIdsForSection(searchQuery, "account"),
+		[searchQuery],
+	);
 
 	return <AccountSettings visibleItems={visibleItems} />;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/page.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useMemo } from "react";
 import { useSettingsSearchQuery } from "renderer/stores/settings-state";
-import { getMatchingItemsForSection } from "../utils/settings-search";
+import { getVisibleSettingIdsForSection } from "../utils/settings-search";
 import { AgentsSettings } from "./components/AgentsSettings";
 
 export const Route = createFileRoute("/_authenticated/settings/agents/")({
@@ -11,12 +11,10 @@ export const Route = createFileRoute("/_authenticated/settings/agents/")({
 function AgentsSettingsPage() {
 	const searchQuery = useSettingsSearchQuery();
 
-	const visibleItems = useMemo(() => {
-		if (!searchQuery) return null;
-		return getMatchingItemsForSection(searchQuery, "agents").map(
-			(item) => item.id,
-		);
-	}, [searchQuery]);
+	const visibleItems = useMemo(
+		() => getVisibleSettingIdsForSection(searchQuery, "agents"),
+		[searchQuery],
+	);
 
 	return <AgentsSettings visibleItems={visibleItems} />;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/api-keys/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/api-keys/page.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useMemo } from "react";
 import { useSettingsSearchQuery } from "renderer/stores/settings-state";
-import { getMatchingItemsForSection } from "../utils/settings-search";
+import { getVisibleSettingIdsForSection } from "../utils/settings-search";
 import { ApiKeysSettings } from "./components/ApiKeysSettings";
 
 export const Route = createFileRoute("/_authenticated/settings/api-keys/")({
@@ -11,12 +11,10 @@ export const Route = createFileRoute("/_authenticated/settings/api-keys/")({
 function ApiKeysSettingsPage() {
 	const searchQuery = useSettingsSearchQuery();
 
-	const visibleItems = useMemo(() => {
-		if (!searchQuery) return null;
-		return getMatchingItemsForSection(searchQuery, "apikeys").map(
-			(item) => item.id,
-		);
-	}, [searchQuery]);
+	const visibleItems = useMemo(
+		() => getVisibleSettingIdsForSection(searchQuery, "apikeys"),
+		[searchQuery],
+	);
 
 	return <ApiKeysSettings visibleItems={visibleItems} />;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/page.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useMemo } from "react";
 import { useSettingsSearchQuery } from "renderer/stores/settings-state";
-import { getMatchingItemsForSection } from "../utils/settings-search";
+import { getVisibleSettingIdsForSection } from "../utils/settings-search";
 import { AppearanceSettings } from "./components/AppearanceSettings";
 
 export const Route = createFileRoute("/_authenticated/settings/appearance/")({
@@ -11,12 +11,10 @@ export const Route = createFileRoute("/_authenticated/settings/appearance/")({
 function AppearanceSettingsPage() {
 	const searchQuery = useSettingsSearchQuery();
 
-	const visibleItems = useMemo(() => {
-		if (!searchQuery) return null;
-		return getMatchingItemsForSection(searchQuery, "appearance").map(
-			(item) => item.id,
-		);
-	}, [searchQuery]);
+	const visibleItems = useMemo(
+		() => getVisibleSettingIdsForSection(searchQuery, "appearance"),
+		[searchQuery],
+	);
 
 	return <AppearanceSettings visibleItems={visibleItems} />;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/page.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useMemo } from "react";
 import { useSettingsSearchQuery } from "renderer/stores/settings-state";
-import { getMatchingItemsForSection } from "../utils/settings-search";
+import { getVisibleSettingIdsForSection } from "../utils/settings-search";
 import { BehaviorSettings } from "./components/BehaviorSettings";
 
 export const Route = createFileRoute("/_authenticated/settings/behavior/")({
@@ -11,12 +11,10 @@ export const Route = createFileRoute("/_authenticated/settings/behavior/")({
 function BehaviorSettingsPage() {
 	const searchQuery = useSettingsSearchQuery();
 
-	const visibleItems = useMemo(() => {
-		if (!searchQuery) return null;
-		return getMatchingItemsForSection(searchQuery, "behavior").map(
-			(item) => item.id,
-		);
-	}, [searchQuery]);
+	const visibleItems = useMemo(
+		() => getVisibleSettingIdsForSection(searchQuery, "behavior"),
+		[searchQuery],
+	);
 
 	return <BehaviorSettings visibleItems={visibleItems} />;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/page.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useMemo } from "react";
 import { useSettingsSearchQuery } from "renderer/stores/settings-state";
-import { getMatchingItemsForSection } from "../utils/settings-search";
+import { getVisibleSettingIdsForSection } from "../utils/settings-search";
 import { BillingOverview } from "./components/BillingOverview";
 
 export const Route = createFileRoute("/_authenticated/settings/billing/")({
@@ -11,12 +11,10 @@ export const Route = createFileRoute("/_authenticated/settings/billing/")({
 function BillingPage() {
 	const searchQuery = useSettingsSearchQuery();
 
-	const visibleItems = useMemo(() => {
-		if (!searchQuery) return null;
-		return getMatchingItemsForSection(searchQuery, "billing").map(
-			(item) => item.id,
-		);
-	}, [searchQuery]);
+	const visibleItems = useMemo(
+		() => getVisibleSettingIdsForSection(searchQuery, "billing"),
+		[searchQuery],
+	);
 
 	return <BillingOverview visibleItems={visibleItems} />;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/git/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/git/page.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useMemo } from "react";
 import { useSettingsSearchQuery } from "renderer/stores/settings-state";
-import { getMatchingItemsForSection } from "../utils/settings-search";
+import { getVisibleSettingIdsForSection } from "../utils/settings-search";
 import { GitSettings } from "./components/GitSettings";
 
 export const Route = createFileRoute("/_authenticated/settings/git/")({
@@ -11,12 +11,10 @@ export const Route = createFileRoute("/_authenticated/settings/git/")({
 function GitSettingsPage() {
 	const searchQuery = useSettingsSearchQuery();
 
-	const visibleItems = useMemo(() => {
-		if (!searchQuery) return null;
-		return getMatchingItemsForSection(searchQuery, "git").map(
-			(item) => item.id,
-		);
-	}, [searchQuery]);
+	const visibleItems = useMemo(
+		() => getVisibleSettingIdsForSection(searchQuery, "git"),
+		[searchQuery],
+	);
 
 	return <GitSettings visibleItems={visibleItems} />;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/integrations/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/integrations/page.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useMemo } from "react";
 import { useSettingsSearchQuery } from "renderer/stores/settings-state";
-import { getMatchingItemsForSection } from "../utils/settings-search";
+import { getVisibleSettingIdsForSection } from "../utils/settings-search";
 import { IntegrationsSettings } from "./components/IntegrationsSettings";
 
 export const Route = createFileRoute("/_authenticated/settings/integrations/")({
@@ -11,12 +11,10 @@ export const Route = createFileRoute("/_authenticated/settings/integrations/")({
 function IntegrationsSettingsPage() {
 	const searchQuery = useSettingsSearchQuery();
 
-	const visibleItems = useMemo(() => {
-		if (!searchQuery) return null;
-		return getMatchingItemsForSection(searchQuery, "integrations").map(
-			(item) => item.id,
-		);
-	}, [searchQuery]);
+	const visibleItems = useMemo(
+		() => getVisibleSettingIdsForSection(searchQuery, "integrations"),
+		[searchQuery],
+	);
 
 	return <IntegrationsSettings visibleItems={visibleItems} />;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
@@ -9,6 +9,7 @@ import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
 	type SettingsSection,
 	useSettingsSearchQuery,
+	useSettingsStore,
 } from "renderer/stores/settings-state";
 import { SettingsSidebar } from "./components/SettingsSidebar";
 import { getMatchCountBySection } from "./utils/settings-search";
@@ -102,6 +103,8 @@ function SettingsLayout() {
 			);
 			if (firstMatch) {
 				navigate({ to: getPathFromSection(firstMatch), replace: true });
+			} else {
+				useSettingsStore.getState().setSearchQuery("");
 			}
 		}
 	}, [searchQuery, location.pathname, navigate]);

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/models/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/models/page.tsx
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import { createChatServiceIpcClient } from "renderer/components/Chat/utils/chat-service-client";
 import { electronQueryClient } from "renderer/providers/ElectronTRPCProvider";
 import { useSettingsSearchQuery } from "renderer/stores/settings-state";
-import { getMatchingItemsForSection } from "../utils/settings-search";
+import { getVisibleSettingIdsForSection } from "../utils/settings-search";
 import { ModelsSettings } from "./components/ModelsSettings";
 
 export const Route = createFileRoute("/_authenticated/settings/models/")({
@@ -16,12 +16,10 @@ const chatServiceIpcClient = createChatServiceIpcClient();
 function ModelsSettingsPage() {
 	const searchQuery = useSettingsSearchQuery();
 
-	const visibleItems = useMemo(() => {
-		if (!searchQuery) return null;
-		return getMatchingItemsForSection(searchQuery, "models").map(
-			(item) => item.id,
-		);
-	}, [searchQuery]);
+	const visibleItems = useMemo(
+		() => getVisibleSettingIdsForSection(searchQuery, "models"),
+		[searchQuery],
+	);
 
 	return (
 		<ChatServiceProvider

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/organization/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/organization/page.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useMemo } from "react";
 import { useSettingsSearchQuery } from "renderer/stores/settings-state";
-import { getVisibleSettingIdsForSection } from "../utils/settings-search";
+import { getVisibleSettingIdsForSection } from "renderer/routes/_authenticated/settings/utils/settings-search";
 import { OrganizationSettings } from "./components/OrganizationSettings";
 
 export const Route = createFileRoute("/_authenticated/settings/organization/")({

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/organization/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/organization/page.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useMemo } from "react";
 import { useSettingsSearchQuery } from "renderer/stores/settings-state";
-import { getMatchingItemsForSection } from "../utils/settings-search";
+import { getVisibleSettingIdsForSection } from "../utils/settings-search";
 import { OrganizationSettings } from "./components/OrganizationSettings";
 
 export const Route = createFileRoute("/_authenticated/settings/organization/")({
@@ -11,12 +11,10 @@ export const Route = createFileRoute("/_authenticated/settings/organization/")({
 function OrganizationSettingsPage() {
 	const searchQuery = useSettingsSearchQuery();
 
-	const visibleItems = useMemo(() => {
-		if (!searchQuery) return null;
-		return getMatchingItemsForSection(searchQuery, "organization").map(
-			(item) => item.id,
-		);
-	}, [searchQuery]);
+	const visibleItems = useMemo(
+		() => getVisibleSettingIdsForSection(searchQuery, "organization"),
+		[searchQuery],
+	);
 
 	return <OrganizationSettings visibleItems={visibleItems} />;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/permissions/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/permissions/page.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useMemo } from "react";
 import { useSettingsSearchQuery } from "renderer/stores/settings-state";
-import { getMatchingItemsForSection } from "../utils/settings-search/settings-search";
+import { getVisibleSettingIdsForSection } from "../utils/settings-search/settings-search";
 import { PermissionsSettings } from "./components/PermissionsSettings";
 
 export const Route = createFileRoute("/_authenticated/settings/permissions/")({
@@ -11,12 +11,10 @@ export const Route = createFileRoute("/_authenticated/settings/permissions/")({
 function PermissionsSettingsPage() {
 	const searchQuery = useSettingsSearchQuery();
 
-	const visibleItems = useMemo(() => {
-		if (!searchQuery) return null;
-		return getMatchingItemsForSection(searchQuery, "permissions").map(
-			(item) => item.id,
-		);
-	}, [searchQuery]);
+	const visibleItems = useMemo(
+		() => getVisibleSettingIdsForSection(searchQuery, "permissions"),
+		[searchQuery],
+	);
 
 	return <PermissionsSettings visibleItems={visibleItems} />;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/general/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/general/page.tsx
@@ -3,7 +3,7 @@ import { useMemo } from "react";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { NotFound } from "renderer/routes/not-found";
 import { useSettingsSearchQuery } from "renderer/stores/settings-state";
-import { getMatchingItemsForSection } from "../../../utils/settings-search";
+import { getVisibleSettingIdsForSection } from "../../../utils/settings-search";
 import { ProjectSettings } from "../components/ProjectSettings";
 
 export const Route = createFileRoute(
@@ -50,12 +50,10 @@ function GeneralSettingsPage() {
 	const { projectId } = Route.useParams();
 	const searchQuery = useSettingsSearchQuery();
 
-	const visibleItems = useMemo(() => {
-		if (!searchQuery) return null;
-		return getMatchingItemsForSection(searchQuery, "project").map(
-			(item) => item.id,
-		);
-	}, [searchQuery]);
+	const visibleItems = useMemo(
+		() => getVisibleSettingIdsForSection(searchQuery, "project"),
+		[searchQuery],
+	);
 
 	return <ProjectSettings projectId={projectId} visibleItems={visibleItems} />;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/page.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useMemo } from "react";
 import { useSettingsSearchQuery } from "renderer/stores/settings-state";
-import { getMatchingItemsForSection } from "../utils/settings-search";
+import { getVisibleSettingIdsForSection } from "../utils/settings-search";
 import { RingtonesSettings } from "./components/RingtonesSettings";
 
 export const Route = createFileRoute("/_authenticated/settings/ringtones/")({
@@ -11,12 +11,10 @@ export const Route = createFileRoute("/_authenticated/settings/ringtones/")({
 function RingtonesSettingsPage() {
 	const searchQuery = useSettingsSearchQuery();
 
-	const visibleItems = useMemo(() => {
-		if (!searchQuery) return null;
-		return getMatchingItemsForSection(searchQuery, "ringtones").map(
-			(item) => item.id,
-		);
-	}, [searchQuery]);
+	const visibleItems = useMemo(
+		() => getVisibleSettingIdsForSection(searchQuery, "ringtones"),
+		[searchQuery],
+	);
 
 	return <RingtonesSettings visibleItems={visibleItems} />;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/page.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useMemo } from "react";
 import { useSettingsSearchQuery } from "renderer/stores/settings-state";
-import { getMatchingItemsForSection } from "../utils/settings-search";
+import { getVisibleSettingIdsForSection } from "../utils/settings-search";
 import { TerminalSettings } from "./components/TerminalSettings";
 
 export type TerminalSettingsSearch = {
@@ -28,12 +28,10 @@ function TerminalSettingsPage() {
 	const { editPresetId, createProjectId } = Route.useSearch();
 	const searchQuery = useSettingsSearchQuery();
 
-	const visibleItems = useMemo(() => {
-		if (!searchQuery) return null;
-		return getMatchingItemsForSection(searchQuery, "terminal").map(
-			(item) => item.id,
-		);
-	}, [searchQuery]);
+	const visibleItems = useMemo(
+		() => getVisibleSettingIdsForSection(searchQuery, "terminal"),
+		[searchQuery],
+	);
 
 	return (
 		<TerminalSettings

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+	getVisibleSettingIdsForSection,
 	SETTING_ITEM_ID,
 	type SettingsItem,
 	searchSettings,
@@ -61,5 +62,21 @@ describe("settings search - font settings", () => {
 
 		expect(editorFont?.section).toBe("appearance");
 		expect(terminalFont?.section).toBe("appearance");
+	});
+});
+
+describe("getVisibleSettingIdsForSection", () => {
+	it('returns null for "scripts" on terminal (query applies to project only)', () => {
+		expect(getVisibleSettingIdsForSection("scripts", "terminal")).toBeNull();
+	});
+
+	it("returns project script ids for scripts on project section", () => {
+		const ids = getVisibleSettingIdsForSection("scripts", "project");
+		expect(ids).toContain(SETTING_ITEM_ID.PROJECT_SCRIPTS);
+	});
+
+	it("returns null for empty or whitespace query", () => {
+		expect(getVisibleSettingIdsForSection("", "terminal")).toBeNull();
+		expect(getVisibleSettingIdsForSection("   ", "terminal")).toBeNull();
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -1018,6 +1018,15 @@ export function getMatchingItemsForSection(
 	return searchSettings(query).filter((item) => item.section === section);
 }
 
+export function getVisibleSettingIdsForSection(
+	query: string,
+	section: SettingsSection,
+): SettingItemId[] | null {
+	if (!query.trim()) return null;
+	const matches = getMatchingItemsForSection(query, section);
+	return matches.length > 0 ? matches.map((item) => item.id) : null;
+}
+
 export function isItemVisible(
 	itemId: SettingItemId,
 	visibleItems: SettingItemId[] | null | undefined,


### PR DESCRIPTION
## Description

**Bug:** After **Set Run** / **Configure**, the app sets the shared settings search to `"scripts"` to surface Scripts on the project page. That value stayed in the sidebar when opening **Terminal** (e.g. **Manage Presets**). `"scripts"` only matches **project** rows in the search index, so Terminal built `visibleItems` as an **empty array**. `isItemVisible` treats `[]` as “filter to these ids” (none matched), so the whole Terminal page went blank while the search box still said `scripts`. The layout’s auto-redirect list also omits `project`, so it never cleared that stale query.

**Fix:** Clear the search when there’s no valid redirect target for the current query; and treat “no matches in this section” as **no filter** (`null`) instead of **empty filter** (`[]`).

## Related Issues

Haven't found any mention to this issue, but would be happy to add any related issues.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

- `settings-search.test.ts` (`getVisibleSettingIdsForSection`).
- Manual testing to reproduce: Set Run → project settings → **Manage Presets** — desktop app should not stay empty with `scripts` stuck in search.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a stale settings search that could blank out pages (e.g., Terminal after Set Run sets search to "scripts"). We now clear invalid queries and treat “no matches in this section” as no filter, so content stays visible.

- **Bug Fixes**
  - Added `getVisibleSettingIdsForSection(query, section)`; returns null for empty/whitespace queries or no matches.
  - Updated all settings pages to use this helper instead of building empty arrays that hide everything.
  - Cleared the search in settings layout when there’s no valid redirect target; added tests for the helper.

<sup>Written for commit 14215a7e6c91f83dd79ed77cfa3aec16e73c2f4d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Settings search now clears automatically when no matches exist across sections.

* **Refactor**
  * Unified how visible settings are computed across all settings pages, simplifying search handling and removing duplicated in-page logic.

* **New Features**
  * Settings search now consistently returns null for empty/whitespace queries and a normalized list of visible item IDs for non-empty queries.

* **Tests**
  * Added tests covering empty queries, scope-specific matches, and visible-item behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->