### PR TITLE
[codex] Fix list_devices MCP schema

### DIFF
--- a/packages/mcp/src/tools/devices/list-devices/list-devices.test.ts
+++ b/packages/mcp/src/tools/devices/list-devices/list-devices.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { z } from "zod";
+
+const getMcpContextMock = mock(() => ({ organizationId: "org-1" }));
+
+let fetchedDevices = [
+	{
+		deviceId: "device-online",
+		deviceName: "Ada's MacBook",
+		deviceType: "desktop",
+		lastSeenAt: new Date(Date.now() - 30_000),
+		ownerId: "user-1",
+		ownerName: "Ada",
+		ownerEmail: "ada@example.com",
+	},
+	{
+		deviceId: "device-offline",
+		deviceName: "Grace's iPhone",
+		deviceType: "mobile",
+		lastSeenAt: new Date(Date.now() - 120_000),
+		ownerId: "user-2",
+		ownerName: "Grace",
+		ownerEmail: "grace@example.com",
+	},
+];
+
+const selectMock = mock(() => ({
+	from: () => ({
+		innerJoin: () => ({
+			where: () => ({
+				orderBy: async () => fetchedDevices,
+			}),
+		}),
+	}),
+}));
+
+mock.module("@superset/db/client", () => ({
+	db: {
+		select: selectMock,
+	},
+}));
+
+mock.module("../../utils", () => ({
+	getMcpContext: getMcpContextMock,
+}));
+
+const { register } = await import("./index");
+
+type RegisteredToolHandler = (
+	args: Record<string, unknown>,
+	extra: unknown,
+) => Promise<{
+	content?: Array<{ text?: string }>;
+	isError?: boolean;
+	structuredContent?: {
+		devices: Array<{
+			deviceId: string;
+			deviceName: string | null;
+			deviceType: string;
+			lastSeenAt: string;
+			ownerId: string;
+			ownerName: string | null;
+			ownerEmail: string;
+			isOnline: boolean;
+		}>;
+	};
+}>;
+
+type RegisteredToolConfig = {
+	inputSchema: Record<string, z.ZodTypeAny>;
+	outputSchema: Record<string, z.ZodTypeAny>;
+};
+
+function createTool() {
+	let config: RegisteredToolConfig | null = null;
+	let handler: RegisteredToolHandler | null = null;
+
+	register({
+		registerTool: (
+			name: string,
+			nextConfig: RegisteredToolConfig,
+			nextHandler: RegisteredToolHandler,
+		) => {
+			if (name === "list_devices") {
+				config = nextConfig;
+				handler = nextHandler;
+			}
+		},
+	} as never);
+
+	if (!config || !handler) {
+		throw new Error("list_devices was not registered");
+	}
+
+	return {
+		config: config as RegisteredToolConfig,
+		handler: handler as RegisteredToolHandler,
+	};
+}
+
+describe("list_devices MCP tool", () => {
+	beforeEach(() => {
+		fetchedDevices = [
+			{
+				deviceId: "device-online",
+				deviceName: "Ada's MacBook",
+				deviceType: "desktop",
+				lastSeenAt: new Date(Date.now() - 30_000),
+				ownerId: "user-1",
+				ownerName: "Ada",
+				ownerEmail: "ada@example.com",
+			},
+			{
+				deviceId: "device-offline",
+				deviceName: "Grace's iPhone",
+				deviceType: "mobile",
+				lastSeenAt: new Date(Date.now() - 120_000),
+				ownerId: "user-2",
+				ownerName: "Grace",
+				ownerEmail: "grace@example.com",
+			},
+		];
+		getMcpContextMock.mockClear();
+		selectMock.mockClear();
+	});
+
+	it("registers input and output schemas that validate includeOffline and isOnline", async () => {
+		const { config, handler } = createTool();
+		const inputSchema = z.object(config.inputSchema);
+		const outputSchema = z.object(config.outputSchema);
+
+		expect(inputSchema.parse({})).toEqual({ includeOffline: false });
+		expect(inputSchema.parse({ includeOffline: true })).toEqual({
+			includeOffline: true,
+		});
+
+		const result = await handler({ includeOffline: true }, {});
+
+		expect(() => outputSchema.parse(result.structuredContent)).not.toThrow();
+	});
+
+	it("returns only online devices by default", async () => {
+		const { handler } = createTool();
+
+		const result = await handler({}, {});
+
+		expect(getMcpContextMock).toHaveBeenCalledTimes(1);
+		expect(selectMock).toHaveBeenCalledTimes(1);
+		expect(result.structuredContent?.devices).toEqual([
+			{
+				deviceId: "device-online",
+				deviceName: "Ada's MacBook",
+				deviceType: "desktop",
+				lastSeenAt: expect.any(String),
+				ownerId: "user-1",
+				ownerName: "Ada",
+				ownerEmail: "ada@example.com",
+				isOnline: true,
+			},
+		]);
+	});
+
+	it("includes offline devices when requested and marks them offline", async () => {
+		const { handler } = createTool();
+
+		const result = await handler({ includeOffline: true }, {});
+
+		expect(result.structuredContent?.devices).toHaveLength(2);
+		expect(result.structuredContent?.devices).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					deviceId: "device-online",
+					isOnline: true,
+				}),
+				expect.objectContaining({
+					deviceId: "device-offline",
+					isOnline: false,
+				}),
+			]),
+		);
+	});
+});

--- a/packages/mcp/src/tools/devices/list-devices/list-devices.ts
+++ b/packages/mcp/src/tools/devices/list-devices/list-devices.ts
@@ -1,32 +1,43 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { db } from "@superset/db/client";
-import { devicePresence, users } from "@superset/db/schema";
+import { devicePresence, deviceTypeValues, users } from "@superset/db/schema";
 import { desc, eq } from "drizzle-orm";
 import { z } from "zod";
 import { getMcpContext } from "../../utils";
+
+const DEVICE_ONLINE_WINDOW_MS = 60_000;
 
 export function register(server: McpServer) {
 	server.registerTool(
 		"list_devices",
 		{
-			description: "List registered devices in the organization",
-			inputSchema: {},
+			description:
+				"List devices in the organization. By default, only devices seen within the last 60 seconds are returned.",
+			inputSchema: {
+				includeOffline: z
+					.boolean()
+					.default(false)
+					.describe("Include devices that have not checked in recently"),
+			},
 			outputSchema: {
 				devices: z.array(
 					z.object({
 						deviceId: z.string(),
 						deviceName: z.string().nullable(),
-						deviceType: z.string(),
-						lastSeenAt: z.string(),
+						deviceType: z.enum(deviceTypeValues),
+						lastSeenAt: z.string().datetime(),
 						ownerId: z.string(),
 						ownerName: z.string().nullable(),
 						ownerEmail: z.string(),
+						isOnline: z.boolean(),
 					}),
 				),
 			},
 		},
-		async (_args, extra) => {
+		async (args, extra) => {
 			const ctx = getMcpContext(extra);
+			const includeOffline = args.includeOffline === true;
+			const onlineCutoff = Date.now() - DEVICE_ONLINE_WINDOW_MS;
 
 			const devices = await db
 				.select({
@@ -43,10 +54,17 @@ export function register(server: McpServer) {
 				.where(eq(devicePresence.organizationId, ctx.organizationId))
 				.orderBy(desc(devicePresence.lastSeenAt));
 
-			const result = devices.map((d) => ({
-				...d,
-				lastSeenAt: d.lastSeenAt.toISOString(),
-			}));
+			const result = devices
+				.map((d) => {
+					const isOnline = d.lastSeenAt.getTime() >= onlineCutoff;
+
+					return {
+						...d,
+						lastSeenAt: d.lastSeenAt.toISOString(),
+						isOnline,
+					};
+				})
+				.filter((device) => includeOffline || device.isOnline);
 
 			return {
 				structuredContent: { devices: result },


### PR DESCRIPTION
## What changed
- fixed the `list_devices` MCP tool so each returned device includes `isOnline`
- added `includeOffline` to the tool input schema and implemented online/offline filtering in the handler
- tightened the output schema to match the documented device contract, including enum-backed `deviceType` and ISO datetime validation for `lastSeenAt`
- added a focused regression test covering schema registration plus online-only and offline-inclusive responses

## Root cause
The MCP server registered `list_devices` with an output schema that did not match the behavior expected by callers and documented elsewhere in the repo. Downstream consumers expected `isOnline`, but the handler never returned it. That caused structured output validation to fail with `data/devices/0 must have required property 'isOnline'`.

## Impact
- `list_devices` no longer fails schema validation when called through the MCP endpoint
- callers can discover device IDs again
- `includeOffline: true` now behaves consistently instead of failing with the same schema error

## Validation
- `bun test src/tools/devices/list-devices/list-devices.test.ts`
- `bun run typecheck` in `packages/mcp`
- `bunx biome check packages/mcp/src/tools/devices/list-devices/list-devices.ts packages/mcp/src/tools/devices/list-devices/list-devices.test.ts`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the MCP `list_devices` tool to match the documented device contract so structured responses validate and device discovery works again. Adds online/offline handling and returns `isOnline` per device.

- **Bug Fixes**
  - Return `isOnline` and default to online-only (last check-in within 60s); add `includeOffline` input to include all devices.
  - Tighten output schema: `deviceType` uses enum-backed `deviceTypeValues`, `lastSeenAt` is ISO datetime.
  - Add a regression test covering schema registration and online/offline responses.

<sup>Written for commit 063c70086aa281fd64f8861b67042f053c962356. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `includeOffline` parameter to control visibility of offline devices (defaults to online only)
  * Devices now include an `isOnline` status indicator
  * Improved validation for device types and last-seen timestamps

* **Tests**
  * Added comprehensive test suite for the list_devices tool

<!-- end of auto-generated comment: release notes by coderabbit.ai -->