### PR TITLE
[codex] fix(desktop): preserve chat cursor position

### DIFF
--- a/apps/desktop/src/renderer/components/Chat/ChatInterface/hooks/useFocusPromptOnPane.ts
+++ b/apps/desktop/src/renderer/components/Chat/ChatInterface/hooks/useFocusPromptOnPane.ts
@@ -3,10 +3,11 @@ import { useEffect } from "react";
 
 export function useFocusPromptOnPane(isFocused: boolean) {
 	const { textInput } = usePromptInputController();
+	const focusPrompt = textInput.focus;
 
 	useEffect(() => {
 		if (isFocused) {
-			textInput.focus();
+			focusPrompt();
 		}
-	}, [isFocused, textInput]);
+	}, [focusPrompt, isFocused]);
 }


### PR DESCRIPTION
## Summary

This change fixes the desktop chat composer moving the caret to the start of the prompt while typing.

## What Changed

- updated the chat prompt focus hook to depend on the stable `textInput.focus` callback instead of the full `textInput` controller object
- kept the existing behavior of focusing the prompt when the pane becomes active, without re-focusing on ordinary input rerenders

## Root Cause

`useFocusPromptOnPane` depended on the entire `textInput` object from the prompt controller. That object is recreated whenever the controlled prompt value changes, so the effect ran again on each keystroke while the pane was focused. Re-focusing the textarea during typing reset the selection and made the cursor jump.

## Impact

Typing in the desktop chat composer should now preserve the caret position across rerenders, including edits in the middle of existing text.

## Validation

- `cd apps/desktop && bun run typecheck`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the desktop chat composer cursor jumping to the start while typing. The focus hook now uses the stable textInput.focus callback instead of the full controller, so the prompt keeps its caret on rerenders and only auto-focuses when the pane becomes active.

<sup>Written for commit c93923257a4697c7afa8b83ca4240db078f6ffb4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved chat input focus handling efficiency in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->