### PR TITLE
feat(desktop): add "Open in Editor" action for worktrees

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceContextMenu.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceContextMenu.tsx
@@ -18,6 +18,7 @@ import {
 	LuArrowRightLeft,
 	LuBellOff,
 	LuCopy,
+	LuExternalLink,
 	LuEye,
 	LuEyeOff,
 	LuFolderOpen,
@@ -47,6 +48,7 @@ interface WorkspaceContextMenuProps {
 	sections: { id: string; name: string }[];
 	onRename: () => void;
 	onOpenInFinder: () => void;
+	onOpenInEditor: () => void;
 	onCopyPath: () => void;
 	onSetUnread: (isUnread: boolean) => void;
 	onResetStatus: () => void;
@@ -64,6 +66,7 @@ export function WorkspaceContextMenu({
 	sections,
 	onRename,
 	onOpenInFinder,
+	onOpenInEditor,
 	onCopyPath,
 	onSetUnread,
 	onResetStatus,
@@ -138,6 +141,10 @@ export function WorkspaceContextMenu({
 			<ContextMenuItem onSelect={onOpenInFinder}>
 				<LuFolderOpen className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />
 				Open in Finder
+			</ContextMenuItem>
+			<ContextMenuItem onSelect={onOpenInEditor}>
+				<LuExternalLink className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />
+				Open in Editor
 			</ContextMenuItem>
 			<ContextMenuItem onSelect={onCopyPath}>
 				<LuCopy className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -135,6 +135,10 @@ export function WorkspaceListItem({
 	const openInFinder = electronTrpc.external.openInFinder.useMutation({
 		onError: (error) => toast.error(`Failed to open: ${error.message}`),
 	});
+	const openFileInEditor = electronTrpc.external.openFileInEditor.useMutation({
+		onError: (error) =>
+			toast.error(`Failed to open in editor: ${error.message}`),
+	});
 	const setUnread = electronTrpc.workspaces.setUnread.useMutation({
 		onSuccess: () => utils.workspaces.getAllGrouped.invalidate(),
 		onError: (error) =>
@@ -233,6 +237,11 @@ export function WorkspaceListItem({
 
 	const handleOpenInFinder = () => {
 		if (worktreePath) openInFinder.mutate(worktreePath);
+	};
+
+	const handleOpenInEditor = () => {
+		if (worktreePath)
+			openFileInEditor.mutate({ path: worktreePath, projectId });
 	};
 
 	const { copyToClipboard } = useCopyToClipboard();
@@ -463,6 +472,7 @@ export function WorkspaceListItem({
 				sections={sections}
 				onRename={rename.startRename}
 				onOpenInFinder={handleOpenInFinder}
+				onOpenInEditor={handleOpenInEditor}
 				onCopyPath={handleCopyPath}
 				onSetUnread={(unread) => setUnread.mutate({ id, isUnread: unread })}
 				onResetStatus={() => resetWorkspaceStatus(id)}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/WorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/WorkspaceRow.tsx
@@ -4,11 +4,13 @@ import {
 	ContextMenuItem,
 	ContextMenuTrigger,
 } from "@superset/ui/context-menu";
+import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { useState } from "react";
 import {
 	LuArrowRight,
+	LuExternalLink,
 	LuFolder,
 	LuFolderGit2,
 	LuRotateCw,
@@ -39,6 +41,19 @@ export function WorkspaceRow({
 	const [hasHovered, setHasHovered] = useState(false);
 	const { showDeleteDialog, setShowDeleteDialog, handleDeleteClick } =
 		useWorkspaceDeleteHandler();
+	const openFileInEditor = electronTrpc.external.openFileInEditor.useMutation({
+		onError: (error) =>
+			toast.error(`Failed to open in editor: ${error.message}`),
+	});
+
+	const handleOpenInEditor = () => {
+		if (workspace.worktreePath) {
+			openFileInEditor.mutate({
+				path: workspace.worktreePath,
+				projectId: workspace.projectId,
+			});
+		}
+	};
 	const githubStatusQueryPolicy = getGitHubStatusQueryPolicy("workspace-row", {
 		hasWorkspaceId: !!workspace.workspaceId,
 		isActive:
@@ -193,6 +208,13 @@ export function WorkspaceRow({
 			<ContextMenu>
 				<ContextMenuTrigger asChild>{button}</ContextMenuTrigger>
 				<ContextMenuContent>
+					<ContextMenuItem onSelect={handleOpenInEditor}>
+						<LuExternalLink
+							className="size-4 mr-2"
+							strokeWidth={STROKE_WIDTH}
+						/>
+						Open in Editor
+					</ContextMenuItem>
 					<ContextMenuItem
 						onSelect={() => handleDeleteClick()}
 						className="text-destructive focus:text-destructive"


### PR DESCRIPTION
## Summary
- Adds an "Open in Editor" context menu item to worktrees in both the sidebar (`WorkspaceContextMenu`) and the all-workspaces list view (`WorkspaceRow`)
- Uses the existing `openFileInEditor` tRPC mutation which resolves the user's configured default editor (project-level first, then global fallback)
- Positioned between "Open in Finder" and "Copy Path" in the sidebar context menu

## Test plan
- [ ] Right-click a worktree in the sidebar → verify "Open in Editor" appears between "Open in Finder" and "Copy Path"
- [ ] Click "Open in Editor" → verify it opens the worktree directory in the configured default editor
- [ ] Right-click a worktree in the all-workspaces list view → verify "Open in Editor" appears
- [ ] Test with no default editor configured → verify it falls back to `shell.openPath`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an "Open in Editor" action to worktree context menus so you can jump into your editor from the sidebar and All Workspaces view. Uses the configured default editor (project-level first, then global).

- **New Features**
  - Added "Open in Editor" to `WorkspaceContextMenu` and `WorkspaceRow` context menus; sits between "Open in Finder" and "Copy Path" in the sidebar.
  - Calls `electronTrpc.external.openFileInEditor` to open the worktree path; shows a toast on errors.

<sup>Written for commit 547c9282841ab527ae17c59ecf03f67d702109e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Open in Editor" context menu option for workspaces, enabling quick access to open workspaces directly in your editor.
  * Integrated error notifications to alert users if the action fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->