### PR TITLE
fix(desktop): batch PTY output to prevent bun dev crashes in terminal

### DIFF
--- a/apps/desktop/src/main/terminal-host/pty-subprocess.ts
+++ b/apps/desktop/src/main/terminal-host/pty-subprocess.ts
@@ -57,6 +57,7 @@ const INPUT_QUEUE_HARD_LIMIT_BYTES = 64 * 1024 * 1024; // 64MB
 let outputChunks: string[] = [];
 let outputBytesQueued = 0;
 let outputFlushScheduled = false;
+const OUTPUT_FLUSH_INTERVAL_MS = 16; // Match terminal-style frame batching (~60fps)
 const MAX_OUTPUT_BATCH_SIZE_BYTES = 128 * 1024; // 128KB max per flush
 
 // Backpressure - track if stdout is draining
@@ -103,9 +104,9 @@ function queueOutput(data: string): void {
 
 	if (!outputFlushScheduled) {
 		outputFlushScheduled = true;
-		// Flush on the next event-loop turn so interactive echo feels immediate,
-		// while still coalescing bursts that arrive in the same PTY callback cycle.
-		setImmediate(flushOutput);
+		// Timed batching keeps TUI redraws coherent and avoids flooding the renderer
+		// with tiny per-turn frames while still staying under a single display frame.
+		setTimeout(flushOutput, OUTPUT_FLUSH_INTERVAL_MS);
 	}
 }
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -57,11 +57,12 @@ export const Terminal = ({ paneId, tabId, workspaceId }: TerminalProps) => {
 			{ enabled: isWorkspaceRunPane },
 		);
 
+	const workspaceRunRestartCommand = isWorkspaceRunPane
+		? buildTerminalCommand(workspaceRunConfig?.commands)
+		: null;
 	const defaultRestartCommandRef = useRef<string | undefined>(undefined);
 	defaultRestartCommandRef.current =
-		(isWorkspaceRunPane
-			? (buildTerminalCommand(workspaceRunConfig?.commands) ?? undefined)
-			: undefined) ?? pane?.workspaceRun?.command;
+		workspaceRunRestartCommand ?? pane?.workspaceRun?.command;
 
 	const utils = electronTrpc.useUtils();
 	const updateWorkspace = electronTrpc.workspaces.update.useMutation({


### PR DESCRIPTION
## Summary
- Replace `setImmediate` with a 16ms `setTimeout` for PTY output flushing, coalescing rapid TUI redraws into coherent ~60fps frames instead of flooding the renderer with tiny per-turn frames
- Extract `workspaceRunRestartCommand` computation outside the ref assignment in Terminal.tsx for clarity

## Test plan
- [ ] Run `bun dev` in the desktop terminal and verify it no longer crashes
- [ ] Confirm interactive terminal echo still feels responsive (no perceptible lag from the 16ms batching)
- [ ] Test TUI apps (e.g. `htop`, `vim`) render correctly without flickering

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch PTY output every 16ms (~60fps) to stop flooding the renderer and fix crashes in the desktop terminal when running `bun dev`. Also moved `workspaceRunRestartCommand` computation out of the ref assignment in `Terminal.tsx` for clarity.

<sup>Written for commit b119527da0b273d42640ffe8f0714702135aea96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized terminal output batching with improved flush interval timing for better performance
  * Refactored workspace run pane restart command initialization for cleaner configuration handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->