### PR TITLE
fix(desktop): match dropdown trigger color to run button state

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/WorkspaceRunButton/WorkspaceRunButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/WorkspaceRunButton/WorkspaceRunButton.tsx
@@ -145,7 +145,7 @@ export const WorkspaceRunButton = memo(function WorkspaceRunButton({
 							isRunning
 								? "text-emerald-300 border-emerald-500/25 bg-emerald-500/10 hover:bg-emerald-500/20"
 								: !hasRunCommand &&
-									"text-muted-foreground/80 border-border/40 bg-secondary/40",
+										"text-muted-foreground/80 border-border/40 bg-secondary/40",
 						)}
 					>
 						<HiChevronDown className="size-3.5" />


### PR DESCRIPTION
## Summary
- Sync the combo dropdown chevron color on the WorkspaceRunButton with the main button's state-dependent styling so both halves look like one cohesive control.

## Why / Context
The main Run button changes color based on state — emerald when running, muted when unconfigured — but the adjacent dropdown chevron always stayed the default `bg-secondary/50 text-muted-foreground`. This made the split button look visually disconnected, especially in the running state where the left half was green and the right half was grey.

## Manual QA Checklist

### Run Button States
- [ ] **Running state**: both main button and dropdown chevron show emerald styling (`text-emerald-300`, `bg-emerald-500/10`)
- [ ] **Idle with run command**: both halves use default secondary styling
- [ ] **No run command configured**: both halves show muted styling (`text-muted-foreground/80`, `bg-secondary/40`)
- [ ] **Hover on dropdown (running)**: background brightens to `bg-emerald-500/20`
- [ ] **Pending state**: both halves show reduced opacity

## Testing
- `bun run typecheck`
- Visual inspection across all three button states

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align the WorkspaceRunButton dropdown trigger with the main Run button so both halves share state-based styling. Running uses emerald, idle stays secondary, unconfigured is muted; pending opacity and running hover are respected.

- **Refactors**
  - Linted the component file (no functional changes).

<sup>Written for commit 4718564d5e53f60806fd17567e85a3554aa77bb9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dropdown button styling to properly reflect workspace running state and command configuration status. The button now displays an active state when a workspace is running and a muted appearance when no run command is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->