### PR TITLE
fix(desktop): preserve branch name case in all segments during workspace creation

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
@@ -370,7 +370,7 @@ export const createCreateProcedures = () => {
 					branch = sanitizeBranchNameWithMaxLength(
 						withPrefix(input.branchName),
 						undefined,
-						{ preserveFirstSegmentCase: true },
+						{ preserveCase: true },
 					);
 				} else {
 					branch = generateBranchName({

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/PromptGroup/PromptGroup.tsx
@@ -105,7 +105,7 @@ export function PromptGroup({
 
 	const branchSlug = branchNameEdited
 		? sanitizeBranchNameWithMaxLength(branchName, undefined, {
-				preserveFirstSegmentCase: true,
+				preserveCase: true,
 			})
 		: sanitizeBranchNameWithMaxLength(trimmedPrompt);
 

--- a/apps/desktop/src/shared/utils/branch.test.ts
+++ b/apps/desktop/src/shared/utils/branch.test.ts
@@ -148,6 +148,12 @@ describe("sanitizeBranchName", () => {
 	test("handles only slashes", () => {
 		expect(sanitizeBranchName("///")).toBe("");
 	});
+
+	test("preserves case in all segments when preserveCase is true", () => {
+		expect(sanitizeBranchName("feat/AAA-1_dummy", { preserveCase: true })).toBe(
+			"feat/AAA-1_dummy",
+		);
+	});
 });
 
 describe("truncateBranchName", () => {
@@ -183,6 +189,14 @@ describe("sanitizeBranchNameWithMaxLength", () => {
 				preserveFirstSegmentCase: true,
 			}),
 		).toBe("Fix_Bug");
+	});
+
+	test("preserves case in all segments when preserveCase is true", () => {
+		expect(
+			sanitizeBranchNameWithMaxLength("Kitenite/feat/AAA-1_dummy", 100, {
+				preserveCase: true,
+			}),
+		).toBe("Kitenite/feat/AAA-1_dummy");
 	});
 });
 


### PR DESCRIPTION
## Summary
- Switch two call sites from `preserveFirstSegmentCase: true` to `preserveCase: true` so typed branch names keep their original casing in all `/`-separated segments
- Add unit tests confirming full-case preservation for both `sanitizeBranchName` and `sanitizeBranchNameWithMaxLength`

## Why / Context
When creating a workspace with a manually typed branch name like `feat/AAA-1_dummy`, the branch was created as `feat/aaa-1_dummy`. The `preserveFirstSegmentCase` option only preserved case for segment index 0 — when a prefix was prepended (e.g. `Kitenite/feat/AAA-1_dummy`), only `Kitenite` kept its case. Fixes #2916.

## Impact
- Branch names typed in the dashboard "New Workspace" form and the backend `create` procedure now preserve case in all segments
- Auto-generated branch names (from prompts) remain lowercase by design
- The `NewWorkspaceModal` (Cmd+N) already used `preserveCase: true` correctly — no change needed there

## Validation
- `bun test apps/desktop/src/shared/utils/branch.test.ts` — all 43 tests pass
- `bun run typecheck`
- `bun run lint`

Fixes #2916