### PR TITLE
fix(desktop): auto-focus input field when creating new file or folder in sidebar

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/NewItemInput/NewItemInput.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/NewItemInput/NewItemInput.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@superset/ui/utils";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { LuCheck, LuFile, LuFolder, LuX } from "react-icons/lu";
 import { TREE_INDENT } from "../../constants";
 import type { NewItemMode } from "../../types";
@@ -20,6 +20,16 @@ export function NewItemInput({
 	level = 0,
 }: NewItemInputProps) {
 	const [value, setValue] = useState("");
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	useEffect(() => {
+		const timer = setTimeout(() => {
+			if (inputRef.current) {
+				inputRef.current.focus();
+			}
+		}, 50);
+		return () => clearTimeout(timer);
+	}, []);
 
 	const handleSubmit = () => {
 		const trimmed = value.trim();
@@ -53,10 +63,12 @@ export function NewItemInput({
 			<span className="w-4 h-4 shrink-0" />
 			<Icon className="size-4 shrink-0 text-amber-500" />
 			<input
+				ref={inputRef}
 				type="text"
 				value={value}
 				onChange={(e) => setValue(e.target.value)}
 				onKeyDown={handleKeyDown}
+				onBlur={handleSubmit}
 				placeholder={isFolder ? "folder name" : "file name"}
 				className={cn(
 					"flex-1 min-w-0 px-1 py-0 text-xs",

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/NewItemInput/NewItemInput.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/NewItemInput/NewItemInput.tsx
@@ -77,6 +77,7 @@ export function NewItemInput({
 			/>
 			<button
 				type="button"
+				onMouseDown={(e) => e.preventDefault()}
 				onClick={handleSubmit}
 				className="p-0.5 hover:bg-background/50 rounded"
 			>


### PR DESCRIPTION
## Summary
- Auto-focus the inline input field when clicking "New File" or "New Folder" in the sidebar file tree
- Add `onBlur` to submit on click-away and `onMouseDown` preventDefault on the confirm button to prevent double-submit

## Why / Context
The input field appeared but did not receive focus, forcing the user to manually click it before typing. This broke the expected keyboard-first workflow. The sibling `RenameInput` component already had this pattern working correctly. Fixes #2796.

## Impact
- Users can immediately start typing after clicking "New File" / "New Folder"
- Clicking away from the input submits the name (or cancels if empty), matching `RenameInput` behavior
- No double-submit when clicking the check button thanks to `onMouseDown` preventDefault

## Validation
- `bun run typecheck`
- `bun run lint`
- Follows the exact same auto-focus pattern as the existing `RenameInput` component

Fixes #2796