### PR TITLE
fix(desktop): pass WAYLAND_DISPLAY to terminal environment on Linux

### DIFF
--- a/apps/desktop/src/main/lib/terminal/env.ts
+++ b/apps/desktop/src/main/lib/terminal/env.ts
@@ -209,6 +209,7 @@ const ALLOWED_ENV_VARS = new Set([
 
 	// Terminal/display
 	"DISPLAY",
+	"WAYLAND_DISPLAY",
 	"COLORTERM",
 	"TERM_PROGRAM",
 	"TERM_PROGRAM_VERSION",


### PR DESCRIPTION
## Summary
- Add `WAYLAND_DISPLAY` to the terminal environment variable allowlist alongside the existing `DISPLAY` entry

## Why / Context
On Wayland (Linux), clipboard tools inside Superset's terminal (`wl-paste`, `wl-copy`, `xclip`) fail silently because `WAYLAND_DISPLAY` is filtered out by `buildSafeEnv()`. The allowlist included `DISPLAY` (X11) but not its Wayland equivalent. Fixes #2738.

## Impact
- Wayland clipboard tools now work in Superset terminals on Linux
- One-line addition to the existing allowlist, no behavioral changes on macOS or X11

## Validation
- `bun run typecheck`
- `bun run lint`

Fixes #2738