### PR TITLE
feat(desktop): add keyboard shortcuts to jump to next/previous unread workspace

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/query.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/query.ts
@@ -297,6 +297,61 @@ export const createQueryProcedures = () => {
 				return orderedWorkspaceIds[nextIndex];
 			}),
 
+		getNextUnreadWorkspace: publicProcedure
+			.input(z.object({ id: z.string() }))
+			.query(({ input }) => {
+				const orderedIds = getWorkspacesInVisualOrder();
+				if (orderedIds.length === 0) return null;
+
+				const currentIndex = orderedIds.indexOf(input.id);
+				if (currentIndex === -1) return null;
+
+				const unreadSet = new Set(
+					localDb
+						.select({ id: workspaces.id })
+						.from(workspaces)
+						.where(eq(workspaces.isUnread, true))
+						.all()
+						.map((w) => w.id),
+				);
+
+				for (let i = 1; i <= orderedIds.length; i++) {
+					const index = (currentIndex + i) % orderedIds.length;
+					if (unreadSet.has(orderedIds[index])) {
+						return orderedIds[index];
+					}
+				}
+				return null;
+			}),
+
+		getPrevUnreadWorkspace: publicProcedure
+			.input(z.object({ id: z.string() }))
+			.query(({ input }) => {
+				const orderedIds = getWorkspacesInVisualOrder();
+				if (orderedIds.length === 0) return null;
+
+				const currentIndex = orderedIds.indexOf(input.id);
+				if (currentIndex === -1) return null;
+
+				const unreadSet = new Set(
+					localDb
+						.select({ id: workspaces.id })
+						.from(workspaces)
+						.where(eq(workspaces.isUnread, true))
+						.all()
+						.map((w) => w.id),
+				);
+
+				for (let i = 1; i <= orderedIds.length; i++) {
+					const index =
+						(currentIndex - i + orderedIds.length) % orderedIds.length;
+					if (unreadSet.has(orderedIds[index])) {
+						return orderedIds[index];
+					}
+				}
+				return null;
+			}),
+
 		getResolvedRunCommands: publicProcedure
 			.input(z.object({ workspaceId: z.string() }))
 			.query(({ input }) => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -620,6 +620,42 @@ function WorkspacePage() {
 		[getNextWorkspace.data, navigate],
 	);
 
+	// Navigate to next unread workspace (⌘⌥N)
+	const getNextUnreadWorkspace =
+		electronTrpc.workspaces.getNextUnreadWorkspace.useQuery(
+			{ id: workspaceId },
+			{ enabled: !!workspaceId },
+		);
+	useAppHotkey(
+		"NEXT_UNREAD_WORKSPACE",
+		() => {
+			const nextId = getNextUnreadWorkspace.data;
+			if (nextId) {
+				navigateToWorkspace(nextId, navigate);
+			}
+		},
+		undefined,
+		[getNextUnreadWorkspace.data, navigate],
+	);
+
+	// Navigate to previous unread workspace (⌘⌥P)
+	const getPrevUnreadWorkspace =
+		electronTrpc.workspaces.getPrevUnreadWorkspace.useQuery(
+			{ id: workspaceId },
+			{ enabled: !!workspaceId },
+		);
+	useAppHotkey(
+		"PREV_UNREAD_WORKSPACE",
+		() => {
+			const prevId = getPrevUnreadWorkspace.data;
+			if (prevId) {
+				navigateToWorkspace(prevId, navigate);
+			}
+		},
+		undefined,
+		[getPrevUnreadWorkspace.data, navigate],
+	);
+
 	return (
 		<div className="flex-1 h-full flex flex-col overflow-hidden">
 			<div className="flex-1 min-h-0 flex overflow-hidden">

--- a/apps/desktop/src/shared/hotkeys.ts
+++ b/apps/desktop/src/shared/hotkeys.ts
@@ -459,6 +459,18 @@ export const HOTKEYS = {
 		label: "Next Workspace",
 		category: "Workspace",
 	}),
+	NEXT_UNREAD_WORKSPACE: defineHotkey({
+		keys: "meta+alt+n",
+		label: "Next Unread Workspace",
+		category: "Workspace",
+		description: "Jump to the next workspace with unread status",
+	}),
+	PREV_UNREAD_WORKSPACE: defineHotkey({
+		keys: "meta+alt+p",
+		label: "Previous Unread Workspace",
+		category: "Workspace",
+		description: "Jump to the previous workspace with unread status",
+	}),
 	CLOSE_WORKSPACE: defineHotkey({
 		keys: "meta+backspace",
 		label: "Close Workspace",

--- a/apps/docs/content/docs/keyboard-shortcuts.mdx
+++ b/apps/docs/content/docs/keyboard-shortcuts.mdx
@@ -15,6 +15,8 @@ description: Customize hotkeys for common actions
 | Switch to Workspace 1-9 | ⌘1-9 |
 | Previous Workspace | ⌘⌥↑ |
 | Next Workspace | ⌘⌥↓ |
+| Next Unread Workspace | ⌘⌥N |
+| Previous Unread Workspace | ⌘⌥P |
 
 ## Layout
 


### PR DESCRIPTION
## Summary
- Add two keyboard shortcuts: **⌘⌥N** (next unread workspace) and **⌘⌥P** (previous unread workspace)
- Add `getNextUnreadWorkspace` / `getPrevUnreadWorkspace` backend queries reusing existing `getWorkspacesInVisualOrder()` and filtering on `workspaces.isUnread`
- Update keyboard shortcuts documentation

## Why / Context
With 10+ workspaces open, there is no way to quickly jump to the next workspace that needs attention. Users must visually scan the sidebar or cycle through all workspaces sequentially with ⌘⌥↑/↓. Fixes #2558.

## Impact
- ⌘⌥N / ⌘⌥P cycle through unread workspaces in sidebar visual order, skipping read ones
- If no unread workspaces exist, the shortcuts do nothing
- Fully customizable via Settings → Keyboard Shortcuts

## Validation
- `bun run typecheck`
- `bun run lint`
- Reuses existing infrastructure: `getWorkspacesInVisualOrder()`, `useAppHotkey()`, `navigateToWorkspace()`, `workspaces.isUnread` DB field
- Docs updated in `keyboard-shortcuts.mdx`

Fixes #2558