### PR TITLE
feat(desktop): remember last used directory for project dialogs

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/projects/projects.ts
+++ b/apps/desktop/src/lib/trpc/routers/projects/projects.ts
@@ -1,6 +1,6 @@
 import { existsSync, statSync } from "node:fs";
 import { access, mkdir, rm } from "node:fs/promises";
-import { basename, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import {
 	BRANCH_PREFIX_MODES,
 	EXTERNAL_APPS,
@@ -336,6 +336,16 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 				.where(isNotNull(projects.tabOrder))
 				.orderBy(desc(projects.lastOpenedAt))
 				.all();
+		}),
+
+		getLastProjectDir: publicProcedure.query((): string | null => {
+			const row = localDb
+				.select({ mainRepoPath: projects.mainRepoPath })
+				.from(projects)
+				.orderBy(desc(projects.lastOpenedAt))
+				.limit(1)
+				.get();
+			return row ? dirname(row.mainRepoPath) : null;
 		}),
 
 		listPullRequests: publicProcedure
@@ -1054,9 +1064,19 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 			if (!window) {
 				return { canceled: false, error: "No window available" };
 			}
+
+			const lastRow = localDb
+				.select({ mainRepoPath: projects.mainRepoPath })
+				.from(projects)
+				.orderBy(desc(projects.lastOpenedAt))
+				.limit(1)
+				.get();
+			const defaultPath = lastRow ? dirname(lastRow.mainRepoPath) : undefined;
+
 			const result = await dialog.showOpenDialog(window, {
 				properties: ["openDirectory", "multiSelections"],
 				title: "Open Project",
+				defaultPath,
 			});
 
 			if (result.canceled || result.filePaths.length === 0) {

--- a/apps/desktop/src/renderer/routes/_authenticated/_onboarding/new-project/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_onboarding/new-project/page.tsx
@@ -54,11 +54,17 @@ function NewProjectPage() {
 	const [parentDir, setParentDir] = useState("");
 
 	const { data: homeDir } = electronTrpc.window.getHomeDir.useQuery();
+	const { data: lastProjectDir } =
+		electronTrpc.projects.getLastProjectDir.useQuery();
 
 	useEffect(() => {
-		if (parentDir || !homeDir) return;
-		setParentDir(`${homeDir}/.superset/projects`);
-	}, [homeDir, parentDir]);
+		if (parentDir) return;
+		if (lastProjectDir) {
+			setParentDir(lastProjectDir);
+		} else if (homeDir) {
+			setParentDir(`${homeDir}/.superset/projects`);
+		}
+	}, [homeDir, lastProjectDir, parentDir]);
 
 	return (
 		<div className="flex flex-col h-full w-full relative overflow-hidden bg-background">

--- a/apps/desktop/src/renderer/routes/_authenticated/_onboarding/new-project/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_onboarding/new-project/page.tsx
@@ -54,17 +54,18 @@ function NewProjectPage() {
 	const [parentDir, setParentDir] = useState("");
 
 	const { data: homeDir } = electronTrpc.window.getHomeDir.useQuery();
-	const { data: lastProjectDir } =
+	const { data: lastProjectDir, isFetched: lastProjectDirFetched } =
 		electronTrpc.projects.getLastProjectDir.useQuery();
 
 	useEffect(() => {
 		if (parentDir) return;
+		if (!lastProjectDirFetched) return;
 		if (lastProjectDir) {
 			setParentDir(lastProjectDir);
 		} else if (homeDir) {
 			setParentDir(`${homeDir}/.superset/projects`);
 		}
-	}, [homeDir, lastProjectDir, parentDir]);
+	}, [homeDir, lastProjectDir, lastProjectDirFetched, parentDir]);
 
 	return (
 		<div className="flex flex-col h-full w-full relative overflow-hidden bg-background">


### PR DESCRIPTION
## Summary
- Default the folder picker to the parent directory of the most recently opened project when opening or creating a new project
- Derive the path from existing `projects.mainRepoPath` + `lastOpenedAt` index — no schema changes or migrations needed

## Why / Context
Users who keep all projects in one folder (e.g., `~/Documents/projects/`) must re-navigate to that location every time they open or create a project. This is a quality-of-life improvement requested in #2942.

## Impact
- "Open Project" dialog now opens at the parent directory of the last opened project
- "New Project" page pre-fills the location with the last project's parent directory
- First-ever use (no projects) falls back to OS default / `~/.superset/projects`
- Deleted directories are handled gracefully by Electron (walks up to nearest valid ancestor)

## Validation
- `bun run typecheck`
- `bun run lint`
- Manual: Open project from `~/code/foo` then re-open dialog — starts at `~/code/`
- Manual: New Project page shows last project's parent dir
- Manual: First use with no projects falls back to defaults

Closes #2942

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The project file picker now pre-populates with the parent directory of your most recently opened project (falling back to the default projects folder), making new-project selection faster and more convenient.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->