### PR TITLE
feat(desktop): add host support to static port configuration

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/ports/ports.ts
+++ b/apps/desktop/src/lib/trpc/routers/ports/ports.ts
@@ -48,8 +48,15 @@ export const createPortsRouter = () => {
 				}
 
 				const staticPorts = staticCache.get(port.workspaceId);
-				const matches =
-					staticPorts?.filter((sp) => sp.port === port.port) ?? [];
+				const matchesByHost = new Map<string, StaticPortInfo>();
+				for (const sp of staticPorts ?? []) {
+					if (sp.port !== port.port) continue;
+					const key = (sp.host ?? "localhost").toLowerCase();
+					if (!matchesByHost.has(key)) {
+						matchesByHost.set(key, sp);
+					}
+				}
+				const matches = [...matchesByHost.values()];
 
 				if (matches.length === 0) {
 					enriched.push({ ...port, label: null, host: null });

--- a/apps/desktop/src/lib/trpc/routers/ports/ports.ts
+++ b/apps/desktop/src/lib/trpc/routers/ports/ports.ts
@@ -13,15 +13,16 @@ type PortEvent =
 	| { type: "add"; port: DetectedPort }
 	| { type: "remove"; port: DetectedPort };
 
-function getLabelsForPath(worktreePath: string): Map<number, string> | null {
+interface StaticPortInfo {
+	port: number;
+	label: string;
+	host?: string;
+}
+
+function getStaticPortsForPath(worktreePath: string): StaticPortInfo[] | null {
 	const result = loadStaticPorts(worktreePath);
 	if (!result.exists || result.error || !result.ports) return null;
-
-	const labels = new Map<number, string>();
-	for (const p of result.ports) {
-		labels.set(p.port, p.label);
-	}
-	return labels;
+	return result.ports;
 }
 
 export const createPortsRouter = () => {
@@ -29,25 +30,41 @@ export const createPortsRouter = () => {
 		getAll: publicProcedure.query((): EnrichedPort[] => {
 			const detectedPorts = portManager.getAllPorts();
 
-			const labelCache = new Map<string, Map<number, string> | null>();
+			const staticCache = new Map<string, StaticPortInfo[] | null>();
+			const enriched: EnrichedPort[] = [];
 
-			return detectedPorts.map((port) => {
-				if (!labelCache.has(port.workspaceId)) {
+			for (const port of detectedPorts) {
+				if (!staticCache.has(port.workspaceId)) {
 					const ws = localDb
 						.select()
 						.from(workspaces)
 						.where(eq(workspaces.id, port.workspaceId))
 						.get();
 					const wsPath = ws ? getWorkspacePath(ws) : null;
-					labelCache.set(
+					staticCache.set(
 						port.workspaceId,
-						wsPath ? getLabelsForPath(wsPath) : null,
+						wsPath ? getStaticPortsForPath(wsPath) : null,
 					);
 				}
 
-				const labels = labelCache.get(port.workspaceId);
-				return { ...port, label: labels?.get(port.port) ?? null };
-			});
+				const staticPorts = staticCache.get(port.workspaceId);
+				const matches =
+					staticPorts?.filter((sp) => sp.port === port.port) ?? [];
+
+				if (matches.length === 0) {
+					enriched.push({ ...port, label: null, host: null });
+				} else {
+					for (const match of matches) {
+						enriched.push({
+							...port,
+							label: match.label,
+							host: match.host ?? null,
+						});
+					}
+				}
+			}
+
+			return enriched;
 		}),
 
 		subscribe: publicProcedure.subscription(() => {

--- a/apps/desktop/src/main/lib/static-ports/loader.test.ts
+++ b/apps/desktop/src/main/lib/static-ports/loader.test.ts
@@ -364,6 +364,54 @@ describe("loadStaticPorts", () => {
 			host: "api.localhost",
 		});
 	});
+
+	test("returns error when host contains URL path", () => {
+		writeFileSync(
+			PORTS_FILE,
+			JSON.stringify({
+				ports: [{ port: 3000, label: "Test", host: "app.localhost/path" }],
+			}),
+		);
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result.error).toBe("ports[0].host contains invalid characters");
+	});
+
+	test("returns error when host contains query string", () => {
+		writeFileSync(
+			PORTS_FILE,
+			JSON.stringify({
+				ports: [{ port: 3000, label: "Test", host: "app.localhost?x=1" }],
+			}),
+		);
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result.error).toBe("ports[0].host contains invalid characters");
+	});
+
+	test("returns error when host contains userinfo", () => {
+		writeFileSync(
+			PORTS_FILE,
+			JSON.stringify({
+				ports: [{ port: 3000, label: "Test", host: "user@host" }],
+			}),
+		);
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result.error).toBe("ports[0].host contains invalid characters");
+	});
+
+	test("returns error when host contains colon", () => {
+		writeFileSync(
+			PORTS_FILE,
+			JSON.stringify({
+				ports: [{ port: 3000, label: "Test", host: "localhost:8080" }],
+			}),
+		);
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result.error).toBe("ports[0].host contains invalid characters");
+	});
 });
 
 describe("hasStaticPortsConfig", () => {

--- a/apps/desktop/src/main/lib/static-ports/loader.test.ts
+++ b/apps/desktop/src/main/lib/static-ports/loader.test.ts
@@ -257,6 +257,113 @@ describe("loadStaticPorts", () => {
 		const result = loadStaticPorts(WORKTREE_PATH);
 		expect(result).toEqual({ exists: true, ports: [], error: null });
 	});
+
+	test("loads valid entry with host", () => {
+		const config = {
+			ports: [{ port: 3000, label: "App 1", host: "app1.localhost" }],
+		};
+		writeFileSync(PORTS_FILE, JSON.stringify(config));
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result).toEqual({
+			exists: true,
+			ports: [{ port: 3000, label: "App 1", host: "app1.localhost" }],
+			error: null,
+		});
+	});
+
+	test("loads valid entry without host (backward compat)", () => {
+		const config = {
+			ports: [{ port: 3000, label: "Frontend" }],
+		};
+		writeFileSync(PORTS_FILE, JSON.stringify(config));
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result.ports?.[0]).toEqual({ port: 3000, label: "Frontend" });
+		expect(result.ports?.[0]).not.toHaveProperty("host");
+	});
+
+	test("returns error when host is not a string", () => {
+		writeFileSync(
+			PORTS_FILE,
+			JSON.stringify({ ports: [{ port: 3000, label: "Test", host: 123 }] }),
+		);
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result.error).toBe("ports[0].host must be a string");
+	});
+
+	test("returns error when host is empty", () => {
+		writeFileSync(
+			PORTS_FILE,
+			JSON.stringify({ ports: [{ port: 3000, label: "Test", host: "" }] }),
+		);
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result.error).toBe("ports[0].host cannot be empty");
+	});
+
+	test("returns error when host is only whitespace", () => {
+		writeFileSync(
+			PORTS_FILE,
+			JSON.stringify({
+				ports: [{ port: 3000, label: "Test", host: "   " }],
+			}),
+		);
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result.error).toBe("ports[0].host cannot be empty");
+	});
+
+	test("trims whitespace from host", () => {
+		const config = {
+			ports: [{ port: 3000, label: "App", host: " app.localhost " }],
+		};
+		writeFileSync(PORTS_FILE, JSON.stringify(config));
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result.ports?.[0].host).toBe("app.localhost");
+	});
+
+	test("allows same port with different hosts", () => {
+		const config = {
+			ports: [
+				{ port: 3000, label: "App 1", host: "app1.localhost" },
+				{ port: 3000, label: "App 2", host: "app2.localhost" },
+			],
+		};
+		writeFileSync(PORTS_FILE, JSON.stringify(config));
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result).toEqual({
+			exists: true,
+			ports: [
+				{ port: 3000, label: "App 1", host: "app1.localhost" },
+				{ port: 3000, label: "App 2", host: "app2.localhost" },
+			],
+			error: null,
+		});
+	});
+
+	test("handles mixed entries with and without host", () => {
+		const config = {
+			ports: [
+				{ port: 3000, label: "Frontend" },
+				{ port: 8080, label: "API", host: "api.localhost" },
+			],
+		};
+		writeFileSync(PORTS_FILE, JSON.stringify(config));
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result.ports).toHaveLength(2);
+		expect(result.ports?.[0]).toEqual({ port: 3000, label: "Frontend" });
+		expect(result.ports?.[0]).not.toHaveProperty("host");
+		expect(result.ports?.[1]).toEqual({
+			port: 8080,
+			label: "API",
+			host: "api.localhost",
+		});
+	});
 });
 
 describe("hasStaticPortsConfig", () => {

--- a/apps/desktop/src/main/lib/static-ports/loader.ts
+++ b/apps/desktop/src/main/lib/static-ports/loader.ts
@@ -73,13 +73,20 @@ function validatePortEntry(
 				error: `ports[${index}].host must be a string`,
 			};
 		}
-		if (host.trim() === "") {
+		const trimmedHost = host.trim();
+		if (trimmedHost === "") {
 			return {
 				valid: false,
 				error: `ports[${index}].host cannot be empty`,
 			};
 		}
-		return { valid: true, port, label: label.trim(), host: host.trim() };
+		if (/[/:?#@]/.test(trimmedHost)) {
+			return {
+				valid: false,
+				error: `ports[${index}].host contains invalid characters`,
+			};
+		}
+		return { valid: true, port, label: label.trim(), host: trimmedHost };
 	}
 
 	return { valid: true, port, label: label.trim() };

--- a/apps/desktop/src/main/lib/static-ports/loader.ts
+++ b/apps/desktop/src/main/lib/static-ports/loader.ts
@@ -6,6 +6,7 @@ import type { StaticPortsResult } from "shared/types";
 interface PortEntry {
 	port: unknown;
 	label: unknown;
+	host: unknown;
 }
 
 interface PortsConfig {
@@ -23,7 +24,7 @@ function validatePortEntry(
 	entry: PortEntry,
 	index: number,
 ):
-	| { valid: true; port: number; label: string }
+	| { valid: true; port: number; label: string; host?: string }
 	| { valid: false; error: string } {
 	if (typeof entry !== "object" || entry === null) {
 		return { valid: false, error: `ports[${index}] must be an object` };
@@ -62,6 +63,23 @@ function validatePortEntry(
 
 	if (label.trim() === "") {
 		return { valid: false, error: `ports[${index}].label cannot be empty` };
+	}
+
+	if ("host" in entry) {
+		const { host } = entry;
+		if (typeof host !== "string") {
+			return {
+				valid: false,
+				error: `ports[${index}].host must be a string`,
+			};
+		}
+		if (host.trim() === "") {
+			return {
+				valid: false,
+				error: `ports[${index}].host cannot be empty`,
+			};
+		}
+		return { valid: true, port, label: label.trim(), host: host.trim() };
 	}
 
 	return { valid: true, port, label: label.trim() };
@@ -132,7 +150,8 @@ export function loadStaticPorts(worktreePath: string): StaticPortsResult {
 		};
 	}
 
-	const validatedPorts: Array<{ port: number; label: string }> = [];
+	const validatedPorts: Array<{ port: number; label: string; host?: string }> =
+		[];
 
 	for (let i = 0; i < parsed.ports.length; i++) {
 		const entry = parsed.ports[i] as PortEntry;
@@ -142,7 +161,11 @@ export function loadStaticPorts(worktreePath: string): StaticPortsResult {
 			return { exists: true, ports: null, error: result.error };
 		}
 
-		validatedPorts.push({ port: result.port, label: result.label });
+		validatedPorts.push({
+			port: result.port,
+			label: result.label,
+			...(result.host ? { host: result.host } : {}),
+		});
 	}
 
 	return { exists: true, ports: validatedPorts, error: null };

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/components/MergedPortBadge/MergedPortBadge.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/components/MergedPortBadge/MergedPortBadge.tsx
@@ -47,7 +47,7 @@ export function MergedPortBadge({ port }: MergedPortBadgeProps) {
 	};
 
 	const handleOpenInBrowser = () => {
-		const url = `http://localhost:${port.port}`;
+		const url = `http://${port.host || "localhost"}:${port.port}`;
 
 		if (openLinksInApp) {
 			navigateToWorkspace(port.workspaceId, navigate);
@@ -98,7 +98,7 @@ export function MergedPortBadge({ port }: MergedPortBadgeProps) {
 					<div
 						className={`font-mono ${port.label ? "text-muted-foreground" : "font-medium"}`}
 					>
-						localhost:{port.port}
+						{port.host || "localhost"}:{port.port}
 					</div>
 					{(port.processName || port.pid != null) && (
 						<div className="text-muted-foreground">

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/components/WorkspacePortGroup/WorkspacePortGroup.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/PortsList/components/WorkspacePortGroup/WorkspacePortGroup.tsx
@@ -50,7 +50,10 @@ export function WorkspacePortGroup({ group }: WorkspacePortGroupProps) {
 			</div>
 			<div className="flex flex-wrap gap-1 px-3">
 				{group.ports.map((port) => (
-					<MergedPortBadge key={port.port} port={port} />
+					<MergedPortBadge
+						key={`${port.host || "localhost"}:${port.port}`}
+						port={port}
+					/>
 				))}
 			</div>
 		</div>

--- a/apps/desktop/src/shared/types/ports.ts
+++ b/apps/desktop/src/shared/types/ports.ts
@@ -11,6 +11,7 @@ export interface DetectedPort {
 export interface StaticPort {
 	port: number;
 	label: string;
+	host?: string;
 	workspaceId: string;
 }
 
@@ -22,4 +23,5 @@ export interface StaticPortsResult {
 
 export interface EnrichedPort extends DetectedPort {
 	label: string | null;
+	host: string | null;
 }


### PR DESCRIPTION
## Summary
- Add an optional `host` field to `.superset/ports.json` entries so users with host-based local routing get the correct URL when clicking "Open in Browser"
- Fan out port enrichment when the same port number has multiple hosts (e.g., `app1.localhost:3000` and `app2.localhost:3000`)
- Fully backward compatible — existing configs without `host` work unchanged

## Why / Context
Users with subdomain-based local routing (e.g., `app1.localhost:3000`, `my-branch.web-service.localhost:1355`) get `localhost` when opening a port in the browser, which breaks routing. The current config only supports `port` + `label`. Fixes #2368.

**Example config:**
```json
{
  "ports": [
    { "port": 3000, "host": "app1.localhost", "label": "App 1" },
    { "port": 3000, "host": "app2.localhost", "label": "App 2" }
  ]
}
```

## Impact
- "Open in Browser" now uses `host:port` instead of `localhost:port` when a host is configured
- Tooltip displays the custom host
- Same port number can appear multiple times with different hosts
- Entries without `host` continue to use `localhost` as before

## Validation
- `bun test apps/desktop/src/main/lib/static-ports/loader.test.ts` — 32 tests pass (8 new for host)
- `bun run typecheck`
- `bun run lint`

Closes #2368

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds host support to static port config so host-based local routing opens the correct URL and shows the right host. Allows multiple hosts on the same port and dedupes per host while keeping existing configs working.

- **New Features**
  - Optional `host` field in `.superset/ports.json`; entries without `host` default to `localhost`.
  - "Open in Browser" and tooltips use `{host}:{port}`; list keys include host to avoid clashes.
  - Enrichment fans out when the same port has different hosts and dedupes by normalized host.
  - Validates `host` (trimmed string, non-empty, no / ? # @ :) with tests; updated types (`StaticPort`, `EnrichedPort`).

<sup>Written for commit f733cc108738cb8d5240e866b332db3e5d577b0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional host field for static port entries, allowing custom host addresses per port

* **Improvements**
  * Browser links and tooltips now use each port's configured host (defaults to localhost)
  * Improved handling and display for ports that share numbers across different hosts

* **Tests**
  * Expanded validation and normalization tests for the host field, including error cases and trimming behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->