### PR TITLE
fix: add POSIX end-of-options separator to agent prompt commands

### DIFF
--- a/packages/shared/src/agent-command.test.ts
+++ b/packages/shared/src/agent-command.test.ts
@@ -15,7 +15,7 @@ describe("buildAgentPromptCommand", () => {
 		expect(command).toContain("- Only modified file: runtime.ts");
 	});
 
-	it("does not change non-codex commands", () => {
+	it("adds `--` before claude prompt payload", () => {
 		const command = buildAgentPromptCommand({
 			prompt: "hello",
 			randomId: "abcd-efgh",
@@ -23,18 +23,54 @@ describe("buildAgentPromptCommand", () => {
 		});
 
 		expect(command).toStartWith(
-			"claude --dangerously-skip-permissions \"$(cat <<'SUPERSET_PROMPT_abcdefgh'",
+			"claude --dangerously-skip-permissions -- \"$(cat <<'SUPERSET_PROMPT_abcdefgh'",
 		);
 	});
 
-	it("uses pi interactive mode for prompt launches", () => {
+	it("adds `--` before pi prompt payload", () => {
 		const command = buildAgentPromptCommand({
 			prompt: "hello",
 			randomId: "pi-1234",
 			agent: "pi",
 		});
 
-		expect(command).toStartWith("pi \"$(cat <<'SUPERSET_PROMPT_pi1234'");
+		expect(command).toStartWith("pi -- \"$(cat <<'SUPERSET_PROMPT_pi1234'");
 		expect(command).not.toContain("pi -p");
+	});
+
+	it("does not break when prompt starts with dashes", () => {
+		const command = buildAgentPromptCommand({
+			prompt: "---\ntitle: My Doc\n---\nContent here",
+			randomId: "dash-test",
+			agent: "claude",
+		});
+
+		expect(command).toContain('-- "$(cat');
+		expect(command).toContain("---\ntitle: My Doc\n---\nContent here");
+	});
+
+	it("places gemini --yolo flag before `--` separator", () => {
+		const command = buildAgentPromptCommand({
+			prompt: "hello",
+			randomId: "gem-1234",
+			agent: "gemini",
+		});
+
+		expect(command).toStartWith(
+			"gemini --yolo -- \"$(cat <<'SUPERSET_PROMPT_gem1234'",
+		);
+		expect(command).not.toContain(')" --yolo');
+	});
+
+	it("places copilot --yolo flag before `--` separator", () => {
+		const command = buildAgentPromptCommand({
+			prompt: "hello",
+			randomId: "cop-1234",
+			agent: "copilot",
+		});
+
+		expect(command).toStartWith(
+			"copilot -i --allow-all --yolo -- \"$(cat <<'SUPERSET_PROMPT_cop1234'",
+		);
 	});
 });

--- a/packages/shared/src/agent-command.ts
+++ b/packages/shared/src/agent-command.ts
@@ -67,31 +67,28 @@ export const AGENT_PROMPT_COMMANDS: Record<
 	AgentPromptCommandDefaults
 > = {
 	claude: {
-		command: AGENT_PRESET_COMMANDS.claude[0] ?? "claude",
+		command: `${AGENT_PRESET_COMMANDS.claude[0] ?? "claude"} --`,
 	},
 	codex: {
 		command: `${AGENT_PRESET_COMMANDS.codex[0] ?? "codex"} --`,
 	},
 	gemini: {
-		command: "gemini",
-		suffix: "--yolo",
+		command: "gemini --yolo --",
 	},
 	mastracode: {
-		command: AGENT_PRESET_COMMANDS.mastracode[0] ?? "mastracode",
+		command: `${AGENT_PRESET_COMMANDS.mastracode[0] ?? "mastracode"} --`,
 	},
 	opencode: {
 		command: "opencode --prompt",
 	},
 	pi: {
-		command: AGENT_PRESET_COMMANDS.pi[0] ?? "pi",
+		command: `${AGENT_PRESET_COMMANDS.pi[0] ?? "pi"} --`,
 	},
 	copilot: {
-		command: "copilot -i --allow-all",
-		suffix: "--yolo",
+		command: "copilot -i --allow-all --yolo --",
 	},
 	"cursor-agent": {
-		command: AGENT_PRESET_COMMANDS["cursor-agent"][0] ?? "cursor-agent",
-		suffix: "--yolo",
+		command: `${AGENT_PRESET_COMMANDS["cursor-agent"][0] ?? "cursor-agent"} --yolo --`,
 	},
 };
 


### PR DESCRIPTION
## Summary
- Add POSIX `--` (end-of-options) separator to all agent prompt commands so prompts starting with dashes are not misinterpreted as CLI flags
- Merge suffix flags (`--yolo`) into the command string before `--` for agents that had them (`gemini`, `copilot`, `cursor-agent`)

## Why / Context
Pasting text starting with `---` (e.g., markdown frontmatter) into a prompt causes agent CLIs to interpret the dashes as flags, breaking the command. The `--` separator tells POSIX-compliant CLIs that everything after it is positional content. `codex` already had this fix; this extends it to all other agents. Fixes #2369.

## Impact
- `claude`, `mastracode`, `pi`: command now ends with `--` before the prompt heredoc
- `gemini`, `copilot`, `cursor-agent`: suffix flags moved before `--` (all flags precede the separator)
- `codex`: already had `--`, unchanged
- `opencode`: uses `--prompt` named flag, unchanged
- Fully backward compatible for prompts without leading dashes

## Validation
- `bun test packages/shared/src/agent-command.test.ts` — 6 tests pass
- `bun run typecheck`
- `bun run lint`

Fixes #2369

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the POSIX `--` separator to all agent prompt commands so prompts starting with dashes aren’t parsed as CLI flags. Moves agent-specific suffix flags before the separator; fixes #2369.

- **Bug Fixes**
  - `claude`, `mastracode`, `pi`: append `--` before the prompt heredoc.
  - `gemini`, `copilot`, `cursor-agent`: merge `--yolo` into the command before `--`.
  - `codex`: already had `--`, unchanged; `opencode`: uses `--prompt`, unchanged.

<sup>Written for commit 42afe2f736c4b4f9421934feecfe6fdeb309307d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated agent command tests to verify proper `--` separator handling before prompt payloads and correct behavior for prompts starting with dashes.

* **Chores**
  * Standardized command argument structure across all supported agents (claude, gemini, copilot, pi, cursor-agent, mastracode) to include consistent separator syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->