### PR TITLE
feat(desktop): skip collapsed sections in workspace switching shortcuts

### DIFF
--- a/apps/desktop/src/renderer/hooks/useWorkspaceShortcuts.ts
+++ b/apps/desktop/src/renderer/hooks/useWorkspaceShortcuts.ts
@@ -29,7 +29,9 @@ export function useWorkspaceShortcuts() {
 				return workspace ? [workspace] : [];
 			}
 
-			return sectionsById.get(item.id)?.workspaces ?? [];
+			const section = sectionsById.get(item.id);
+			if (!section || section.isCollapsed) return [];
+			return section.workspaces;
 		});
 	});
 


### PR DESCRIPTION
## Summary
- Filter out workspaces from collapsed sections when mapping ⌘1-9 shortcuts so they only target visible workspaces in the sidebar

## Why / Context
Users with many workspaces collapse sections they are not actively using. But ⌘1-9 still counts collapsed workspaces, making the shortcuts map to hidden entries instead of the visible ones. A user with 10 workspaces but only 3 visible still needs ⌘7+ to reach them. Fixes #2141.

## Impact
- ⌘1-9 now maps to visible (uncollapsed) workspaces only
- Ungrouped workspaces (not in a section) are always included
- Collapsing/expanding a section dynamically updates the shortcut mapping (reactive via tRPC query)
- No backend changes — `isCollapsed` was already available in the `getAllGrouped` response

## Validation
- `bun run typecheck`
- `bun run lint`
- Manual: collapse a section, ⌘1-9 should skip its workspaces

Fixes #2141

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip workspaces in collapsed sections when mapping ⌘1–9, so shortcuts only target visible workspaces in the sidebar. Fixes #2141.

- **Bug Fixes**
  - Ungrouped workspaces remain included.
  - Mapping updates instantly when sections collapse/expand.
  - No backend changes; reuses existing `isCollapsed` data.

<sup>Written for commit 56aaaf0a0905838e2895d6d245d6dc228241e0dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced workspace shortcuts resolution logic to correctly respect collapsed section states and gracefully handle missing or incomplete section data. This improvement ensures workspace shortcuts display accurately and consistently, providing a more stable navigation experience when section states change or data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->