### PR TITLE
feat(desktop): add setting to swap files/workspace UI position 

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/settings/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/index.ts
@@ -26,6 +26,7 @@ import {
 	DEFAULT_OPEN_LINKS_IN_APP,
 	DEFAULT_SHOW_PRESETS_BAR,
 	DEFAULT_SHOW_RESOURCE_MONITOR,
+	DEFAULT_SWAP_PANELS,
 	DEFAULT_TERMINAL_LINK_BEHAVIOR,
 	DEFAULT_USE_COMPACT_TERMINAL_ADD_BUTTON,
 } from "shared/constants";
@@ -793,6 +794,26 @@ export const createSettingsRouter = () => {
 					.onConflictDoUpdate({
 						target: settings.id,
 						set: { defaultEditor: input.editor },
+					})
+					.run();
+
+				return { success: true };
+			}),
+
+		getSwapPanels: publicProcedure.query(() => {
+			const row = getSettings();
+			return row.swapPanels ?? DEFAULT_SWAP_PANELS;
+		}),
+
+		setSwapPanels: publicProcedure
+			.input(z.object({ enabled: z.boolean() }))
+			.mutation(({ input }) => {
+				localDb
+					.insert(settings)
+					.values({ id: 1, swapPanels: input.enabled })
+					.onConflictDoUpdate({
+						target: settings.id,
+						set: { swapPanels: input.enabled },
 					})
 					.run();
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -20,6 +20,7 @@ import {
 	MAX_WORKSPACE_SIDEBAR_WIDTH,
 	useWorkspaceSidebarStore,
 } from "renderer/stores/workspace-sidebar-state";
+import { DEFAULT_SWAP_PANELS } from "shared/constants";
 import { TopBar } from "./components/TopBar";
 
 export const Route = createFileRoute("/_authenticated/_dashboard")({
@@ -55,6 +56,9 @@ function DashboardLayout() {
 		setIsResizing: setWorkspaceSidebarIsResizing,
 		isCollapsed: isWorkspaceSidebarCollapsed,
 	} = useWorkspaceSidebarStore();
+
+	const { data: swapPanels } = electronTrpc.settings.getSwapPanels.useQuery();
+	const isSwapped = swapPanels ?? DEFAULT_SWAP_PANELS;
 
 	// Global hotkeys for dashboard
 	useAppHotkey(
@@ -116,38 +120,41 @@ function DashboardLayout() {
 		[currentWorkspaceId, currentWorkspace],
 	);
 
+	const workspaceSidebarPanel = isWorkspaceSidebarOpen && (
+		<ResizablePanel
+			width={workspaceSidebarWidth}
+			onWidthChange={setWorkspaceSidebarWidth}
+			isResizing={isWorkspaceSidebarResizing}
+			onResizingChange={setWorkspaceSidebarIsResizing}
+			minWidth={COLLAPSED_WORKSPACE_SIDEBAR_WIDTH}
+			maxWidth={MAX_WORKSPACE_SIDEBAR_WIDTH}
+			handleSide={isSwapped ? "left" : "right"}
+			clampWidth={false}
+			onDoubleClickHandle={() =>
+				setWorkspaceSidebarWidth(DEFAULT_WORKSPACE_SIDEBAR_WIDTH)
+			}
+		>
+			{isV2CloudEnabled ? (
+				<DashboardSidebar isCollapsed={isWorkspaceSidebarCollapsed()} />
+			) : (
+				<WorkspaceSidebar
+					isCollapsed={isWorkspaceSidebarCollapsed()}
+					activeProjectId={currentWorkspace?.projectId ?? null}
+					activeProjectName={currentWorkspace?.project?.name ?? null}
+				/>
+			)}
+		</ResizablePanel>
+	);
+
 	return (
 		<div className="flex flex-col h-full w-full">
 			<TopBar />
 			<div className="flex flex-1 min-h-0 min-w-0 overflow-hidden">
-				{isWorkspaceSidebarOpen && (
-					<ResizablePanel
-						width={workspaceSidebarWidth}
-						onWidthChange={setWorkspaceSidebarWidth}
-						isResizing={isWorkspaceSidebarResizing}
-						onResizingChange={setWorkspaceSidebarIsResizing}
-						minWidth={COLLAPSED_WORKSPACE_SIDEBAR_WIDTH}
-						maxWidth={MAX_WORKSPACE_SIDEBAR_WIDTH}
-						handleSide="right"
-						clampWidth={false}
-						onDoubleClickHandle={() =>
-							setWorkspaceSidebarWidth(DEFAULT_WORKSPACE_SIDEBAR_WIDTH)
-						}
-					>
-						{isV2CloudEnabled ? (
-							<DashboardSidebar isCollapsed={isWorkspaceSidebarCollapsed()} />
-						) : (
-							<WorkspaceSidebar
-								isCollapsed={isWorkspaceSidebarCollapsed()}
-								activeProjectId={currentWorkspace?.projectId ?? null}
-								activeProjectName={currentWorkspace?.project?.name ?? null}
-							/>
-						)}
-					</ResizablePanel>
-				)}
+				{!isSwapped && workspaceSidebarPanel}
 				<div className="flex flex-1 min-h-0 min-w-0">
 					<Outlet />
 				</div>
+				{isSwapped && workspaceSidebarPanel}
 				{deleteTarget && (
 					<DeleteWorkspaceDialog
 						workspaceId={deleteTarget.workspaceId}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/AppearanceSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/AppearanceSettings.tsx
@@ -6,6 +6,7 @@ import {
 } from "../../../utils/settings-search";
 import { FontSettingSection } from "./components/FontSettingSection";
 import { MarkdownStyleSection } from "./components/MarkdownStyleSection";
+import { SwapPanelsSection } from "./components/SwapPanelsSection";
 import { ThemeSection } from "./components/ThemeSection";
 
 /**
@@ -54,6 +55,10 @@ export function AppearanceSettings({ visibleItems }: AppearanceSettingsProps) {
 		SETTING_ITEM_ID.APPEARANCE_CUSTOM_THEMES,
 		visibleItems,
 	);
+	const showSwapPanels = isItemVisible(
+		SETTING_ITEM_ID.APPEARANCE_SWAP_PANELS,
+		visibleItems,
+	);
 	const showThemeSection = showTheme || showCustomThemes;
 
 	return (
@@ -74,6 +79,7 @@ export function AppearanceSettings({ visibleItems }: AppearanceSettingsProps) {
 				{showTerminalFont && (
 					<FontSettingSection key="terminal-font" variant="terminal" />
 				)}
+				{showSwapPanels && <SwapPanelsSection key="swap-panels" />}
 			</SectionList>
 		</div>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/SwapPanelsSection/SwapPanelsSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/SwapPanelsSection/SwapPanelsSection.tsx
@@ -1,0 +1,45 @@
+import { Label } from "@superset/ui/label";
+import { Switch } from "@superset/ui/switch";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+
+export function SwapPanelsSection() {
+	const utils = electronTrpc.useUtils();
+
+	const { data: swapPanels, isLoading } =
+		electronTrpc.settings.getSwapPanels.useQuery();
+	const setSwapPanels = electronTrpc.settings.setSwapPanels.useMutation({
+		onMutate: async ({ enabled }) => {
+			await utils.settings.getSwapPanels.cancel();
+			const previous = utils.settings.getSwapPanels.getData();
+			utils.settings.getSwapPanels.setData(undefined, enabled);
+			return { previous };
+		},
+		onError: (_err, _vars, context) => {
+			if (context?.previous !== undefined) {
+				utils.settings.getSwapPanels.setData(undefined, context.previous);
+			}
+		},
+		onSettled: () => {
+			utils.settings.getSwapPanels.invalidate();
+		},
+	});
+
+	return (
+		<div className="flex items-center justify-between">
+			<div className="space-y-0.5">
+				<Label htmlFor="swap-panels" className="text-sm font-medium">
+					Swap sidebar panels
+				</Label>
+				<p className="text-xs text-muted-foreground">
+					Move files and git changes to the left, workspaces to the right
+				</p>
+			</div>
+			<Switch
+				id="swap-panels"
+				checked={swapPanels ?? false}
+				onCheckedChange={(enabled) => setSwapPanels.mutate({ enabled })}
+				disabled={isLoading || setSwapPanels.isPending}
+			/>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/SwapPanelsSection/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/SwapPanelsSection/index.ts
@@ -1,0 +1,1 @@
+export { SwapPanelsSection } from "./SwapPanelsSection";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/BehaviorSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/BehaviorSettings.tsx
@@ -40,7 +40,6 @@ export function BehaviorSettings({ visibleItems }: BehaviorSettingsProps) {
 		SETTING_ITEM_ID.BEHAVIOR_OPEN_LINKS_IN_APP,
 		visibleItems,
 	);
-
 	const utils = electronTrpc.useUtils();
 
 	const { data: confirmOnQuit, isLoading: isConfirmLoading } =

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.test.ts
@@ -9,6 +9,28 @@ function getIds(items: SettingsItem[]): string[] {
 	return items.map((item) => item.id);
 }
 
+describe("settings search - swap panels", () => {
+	it('searching "swap" returns BEHAVIOR_SWAP_PANELS', () => {
+		const results = searchSettings("swap");
+		const ids = getIds(results);
+		expect(ids).toContain(SETTING_ITEM_ID.APPEARANCE_SWAP_PANELS);
+	});
+
+	it('searching "sidebar" returns BEHAVIOR_SWAP_PANELS', () => {
+		const results = searchSettings("sidebar");
+		const ids = getIds(results);
+		expect(ids).toContain(SETTING_ITEM_ID.APPEARANCE_SWAP_PANELS);
+	});
+
+	it("swap panels item has correct section", () => {
+		const results = searchSettings("swap");
+		const item = results.find(
+			(r) => r.id === SETTING_ITEM_ID.APPEARANCE_SWAP_PANELS,
+		);
+		expect(item?.section).toBe("appearance");
+	});
+});
+
 describe("settings search - font settings", () => {
 	it('searching "font" returns both APPEARANCE_EDITOR_FONT and APPEARANCE_TERMINAL_FONT', () => {
 		const results = searchSettings("font");

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.test.ts
@@ -10,13 +10,13 @@ function getIds(items: SettingsItem[]): string[] {
 }
 
 describe("settings search - swap panels", () => {
-	it('searching "swap" returns BEHAVIOR_SWAP_PANELS', () => {
+	it('searching "swap" returns APPEARANCE_SWAP_PANELS', () => {
 		const results = searchSettings("swap");
 		const ids = getIds(results);
 		expect(ids).toContain(SETTING_ITEM_ID.APPEARANCE_SWAP_PANELS);
 	});
 
-	it('searching "sidebar" returns BEHAVIOR_SWAP_PANELS', () => {
+	it('searching "sidebar" returns APPEARANCE_SWAP_PANELS', () => {
 		const results = searchSettings("sidebar");
 		const ids = getIds(results);
 		expect(ids).toContain(SETTING_ITEM_ID.APPEARANCE_SWAP_PANELS);

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -26,6 +26,7 @@ export const SETTING_ITEM_ID = {
 	BEHAVIOR_FILE_OPEN_MODE: "behavior-file-open-mode",
 	BEHAVIOR_RESOURCE_MONITOR: "behavior-resource-monitor",
 	BEHAVIOR_OPEN_LINKS_IN_APP: "behavior-open-links-in-app",
+	APPEARANCE_SWAP_PANELS: "appearance-swap-panels",
 
 	GIT_BRANCH_PREFIX: "git-branch-prefix",
 	GIT_DELETE_LOCAL_BRANCH: "git-delete-local-branch",
@@ -484,6 +485,26 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"chat",
 			"terminal",
 			"url",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.APPEARANCE_SWAP_PANELS,
+		section: "appearance",
+		title: "Swap sidebar panels",
+		description:
+			"Move files and git changes to the left, workspaces to the right",
+		keywords: [
+			"swap",
+			"panels",
+			"sidebar",
+			"layout",
+			"left",
+			"right",
+			"files",
+			"git",
+			"workspace",
+			"mirror",
+			"flip",
 		],
 	},
 	{

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceLayout/WorkspaceLayout.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceLayout/WorkspaceLayout.tsx
@@ -47,7 +47,9 @@ export function WorkspaceLayout({
 			minWidth={MIN_SIDEBAR_WIDTH}
 			maxWidth={MAX_SIDEBAR_WIDTH}
 			handleSide={isSwapped ? "right" : "left"}
-			className={isExpanded ? (isSwapped ? "border-r-0" : "border-l-0") : undefined}
+			className={
+				isExpanded ? (isSwapped ? "border-r-0" : "border-l-0") : undefined
+			}
 			onDoubleClickHandle={() => setSidebarWidth(DEFAULT_SIDEBAR_WIDTH)}
 		>
 			<RightSidebar />

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceLayout/WorkspaceLayout.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceLayout/WorkspaceLayout.tsx
@@ -1,4 +1,5 @@
 import type { ExternalApp } from "@superset/local-db";
+import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
 	DEFAULT_SIDEBAR_WIDTH,
 	MAX_SIDEBAR_WIDTH,
@@ -6,6 +7,7 @@ import {
 	SidebarMode,
 	useSidebarStore,
 } from "renderer/stores/sidebar-state";
+import { DEFAULT_SWAP_PANELS } from "shared/constants";
 import { ResizablePanel } from "../../ResizablePanel";
 import { ChangesContent, ScrollProvider } from "../ChangesContent";
 import { ContentView } from "../ContentView";
@@ -31,10 +33,30 @@ export function WorkspaceLayout({
 	const setIsResizing = useSidebarStore((s) => s.setIsResizing);
 	const currentMode = useSidebarStore((s) => s.currentMode);
 
+	const { data: swapPanels } = electronTrpc.settings.getSwapPanels.useQuery();
+	const isSwapped = swapPanels ?? DEFAULT_SWAP_PANELS;
+
 	const isExpanded = currentMode === SidebarMode.Changes;
+
+	const sidebarPanel = isSidebarOpen && (
+		<ResizablePanel
+			width={sidebarWidth}
+			onWidthChange={setSidebarWidth}
+			isResizing={isResizing}
+			onResizingChange={setIsResizing}
+			minWidth={MIN_SIDEBAR_WIDTH}
+			maxWidth={MAX_SIDEBAR_WIDTH}
+			handleSide={isSwapped ? "right" : "left"}
+			className={isExpanded ? (isSwapped ? "border-r-0" : "border-l-0") : undefined}
+			onDoubleClickHandle={() => setSidebarWidth(DEFAULT_SIDEBAR_WIDTH)}
+		>
+			<RightSidebar />
+		</ResizablePanel>
+	);
 
 	return (
 		<ScrollProvider>
+			{isSwapped && sidebarPanel}
 			<div className="flex-1 min-w-0 overflow-hidden">
 				{isExpanded ? (
 					<ChangesContent />
@@ -46,21 +68,7 @@ export function WorkspaceLayout({
 					/>
 				)}
 			</div>
-			{isSidebarOpen && (
-				<ResizablePanel
-					width={sidebarWidth}
-					onWidthChange={setSidebarWidth}
-					isResizing={isResizing}
-					onResizingChange={setIsResizing}
-					minWidth={MIN_SIDEBAR_WIDTH}
-					maxWidth={MAX_SIDEBAR_WIDTH}
-					handleSide="left"
-					className={isExpanded ? "border-l-0" : undefined}
-					onDoubleClickHandle={() => setSidebarWidth(DEFAULT_SIDEBAR_WIDTH)}
-				>
-					<RightSidebar />
-				</ResizablePanel>
-			)}
+			{!isSwapped && sidebarPanel}
 		</ScrollProvider>
 	);
 }

--- a/apps/desktop/src/shared/constants.ts
+++ b/apps/desktop/src/shared/constants.ts
@@ -50,6 +50,7 @@ export const DEFAULT_USE_COMPACT_TERMINAL_ADD_BUTTON = true;
 export const DEFAULT_TELEMETRY_ENABLED = true;
 export const DEFAULT_SHOW_RESOURCE_MONITOR = true;
 export const DEFAULT_OPEN_LINKS_IN_APP = false;
+export const DEFAULT_SWAP_PANELS = false;
 
 // External links (documentation, help resources, etc.)
 export const EXTERNAL_LINKS = {

--- a/packages/local-db/src/schema/schema.ts
+++ b/packages/local-db/src/schema/schema.ts
@@ -221,6 +221,7 @@ export const settings = sqliteTable("settings", {
 	worktreeBaseDir: text("worktree_base_dir"),
 	openLinksInApp: integer("open_links_in_app", { mode: "boolean" }),
 	defaultEditor: text("default_editor").$type<ExternalApp>(),
+	swapPanels: integer("swap_panels", { mode: "boolean" }),
 });
 
 export type InsertSettings = typeof settings.$inferInsert;


### PR DESCRIPTION
## Description

I'm so used to have files/git on the left side .. my OCD is striking as hell :)  


## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Screenshots (if applicable)

<img width="1294" height="901" alt="Capture d’écran 2026-03-30 à 18 30 45" src="https://github.com/user-attachments/assets/5c70ab1f-b0b7-4fb6-83a6-f30a05f30e13" />

<img width="1509" height="797" alt="Capture d’écran 2026-03-30 à 18 13 38" src="https://github.com/user-attachments/assets/818af37c-a086-4fd2-9edc-70162d725f49" />



## Additional Notes

I asked on Twitter before doing this PR : 
<img width="583" height="284" alt="Capture d’écran 2026-03-30 à 18 26 14" src="https://github.com/user-attachments/assets/d0080f23-e612-48be-ae66-ee947096bfc0" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Swap sidebar panels" toggle in Appearance settings to let users swap files/git changes and workspaces panels; UI respects the choice in dashboard and workspace views.
* **Settings**
  * Toggle state is persisted with a default value; control is disabled while loading or saving to avoid inconsistent state.
* **Tests**
  * Added search tests so "swap" and "sidebar" queries surface the new setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->