### PR TITLE
feat(desktop): add sorting to resource usage popover

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/ResourceConsumption.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/ResourceConsumption.tsx
@@ -1,16 +1,36 @@
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuRadioGroup,
+	DropdownMenuRadioItem,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
 import { Popover, PopoverContent, PopoverTrigger } from "@superset/ui/popover";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { useLiveQuery } from "@tanstack/react-db";
 import { useNavigate } from "@tanstack/react-router";
-import { useState } from "react";
-import { HiOutlineArrowPath, HiOutlineCpuChip } from "react-icons/hi2";
+import { useMemo, useState } from "react";
+import {
+	HiOutlineArrowPath,
+	HiOutlineBarsArrowDown,
+	HiOutlineCpuChip,
+} from "react-icons/hi2";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import { AppResourceSection } from "./components/AppResourceSection";
 import { MetricBadge } from "./components/MetricBadge";
 import { WorkspaceResourceSection } from "./components/WorkspaceResourceSection";
-import type { UsageValues } from "./types";
+import type { SortOption, UsageValues } from "./types";
 import { formatCpu, formatMemory, formatPercent } from "./utils/formatters";
 import { normalizeResourceMetricsSnapshot } from "./utils/normalizeSnapshot";
+
+const SORT_LABELS: Record<SortOption, string> = {
+	memory: "Memory",
+	cpu: "CPU",
+	name: "Name",
+	sidebar: "Sidebar order",
+};
 
 function getTotalUsage(
 	cpu: number | undefined,
@@ -32,6 +52,7 @@ function getTrackedMemorySharePercent(
 
 export function ResourceConsumption() {
 	const [open, setOpen] = useState(false);
+	const [sortOption, setSortOption] = useState<SortOption>("memory");
 	const [collapsedProjects, setCollapsedProjects] = useState<Set<string>>(
 		new Set(),
 	);
@@ -43,9 +64,38 @@ export function ResourceConsumption() {
 	const panes = useTabsStore((state) => state.panes);
 	const setActiveTab = useTabsStore((state) => state.setActiveTab);
 	const setFocusedPane = useTabsStore((state) => state.setFocusedPane);
+	const collections = useCollections();
 
 	const { data: enabled } =
 		electronTrpc.settings.getShowResourceMonitor.useQuery();
+
+	const { data: rawSidebarProjects = [] } = useLiveQuery(
+		(q) =>
+			q
+				.from({ sp: collections.v2SidebarProjects })
+				.orderBy(({ sp }) => sp.tabOrder, "asc")
+				.select(({ sp }) => ({ projectId: sp.projectId })),
+		[collections],
+	);
+
+	const { data: rawSidebarWorkspaces = [] } = useLiveQuery(
+		(q) =>
+			q
+				.from({ ws: collections.v2WorkspaceLocalState })
+				.orderBy(({ ws }) => ws.sidebarState.tabOrder, "asc")
+				.select(({ ws }) => ({ workspaceId: ws.workspaceId })),
+		[collections],
+	);
+
+	const sidebarProjectOrder = useMemo(
+		() => rawSidebarProjects.map((p) => p.projectId),
+		[rawSidebarProjects],
+	);
+
+	const sidebarWorkspaceOrder = useMemo(
+		() => rawSidebarWorkspaces.map((w) => w.workspaceId),
+		[rawSidebarWorkspaces],
+	);
 
 	const {
 		data: snapshot,
@@ -154,16 +204,51 @@ export function ResourceConsumption() {
 						<h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
 							Resource Usage
 						</h4>
-						<button
-							type="button"
-							onClick={() => refetch()}
-							className="p-0.5 rounded hover:bg-muted transition-colors"
-							aria-label="Refresh metrics"
-						>
-							<HiOutlineArrowPath
-								className={`h-3.5 w-3.5 text-muted-foreground ${isFetching ? "animate-spin" : ""}`}
-							/>
-						</button>
+						<div className="flex items-center gap-0.5">
+							<DropdownMenu>
+								<DropdownMenuTrigger asChild>
+									<button
+										type="button"
+										className="flex items-center gap-1 px-1.5 py-0.5 rounded text-[11px] text-muted-foreground hover:bg-muted transition-colors"
+										aria-label="Sort workspaces"
+									>
+										<HiOutlineBarsArrowDown className="h-3.5 w-3.5" />
+										<span>{SORT_LABELS[sortOption]}</span>
+									</button>
+								</DropdownMenuTrigger>
+								<DropdownMenuContent align="end" className="w-40">
+									<DropdownMenuRadioGroup
+										value={sortOption}
+										onValueChange={(value) =>
+											setSortOption(value as SortOption)
+										}
+									>
+										<DropdownMenuRadioItem value="memory">
+											Memory
+										</DropdownMenuRadioItem>
+										<DropdownMenuRadioItem value="cpu">
+											CPU
+										</DropdownMenuRadioItem>
+										<DropdownMenuRadioItem value="name">
+											Name
+										</DropdownMenuRadioItem>
+										<DropdownMenuRadioItem value="sidebar">
+											Sidebar order
+										</DropdownMenuRadioItem>
+									</DropdownMenuRadioGroup>
+								</DropdownMenuContent>
+							</DropdownMenu>
+							<button
+								type="button"
+								onClick={() => refetch()}
+								className="p-0.5 rounded hover:bg-muted transition-colors"
+								aria-label="Refresh metrics"
+							>
+								<HiOutlineArrowPath
+									className={`h-3.5 w-3.5 text-muted-foreground ${isFetching ? "animate-spin" : ""}`}
+								/>
+							</button>
+						</div>
 					</div>
 
 					{normalizedSnapshot && (
@@ -198,6 +283,9 @@ export function ResourceConsumption() {
 					{normalizedSnapshot && (
 						<WorkspaceResourceSection
 							workspaces={normalizedSnapshot.workspaces}
+							sortOption={sortOption}
+							sidebarProjectOrder={sidebarProjectOrder}
+							sidebarWorkspaceOrder={sidebarWorkspaceOrder}
 							collapsedProjects={collapsedProjects}
 							toggleProject={toggleProject}
 							collapsedWorkspaces={collapsedWorkspaces}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/components/WorkspaceResourceSection/WorkspaceResourceSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/components/WorkspaceResourceSection/WorkspaceResourceSection.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@superset/ui/lib/utils";
 import { HiOutlineChevronDown, HiOutlineChevronRight } from "react-icons/hi2";
-import type { WorkspaceMetrics } from "../../types";
+import type { SortOption, WorkspaceMetrics } from "../../types";
 import { formatCpu, formatMemory } from "../../utils/formatters";
 import {
 	getUsageClasses,
@@ -22,6 +22,9 @@ interface ProjectResourceGroup {
 
 interface WorkspaceResourceSectionProps {
 	workspaces: WorkspaceMetrics[];
+	sortOption: SortOption;
+	sidebarProjectOrder: string[];
+	sidebarWorkspaceOrder: string[];
 	collapsedProjects: Set<string>;
 	toggleProject: (projectId: string) => void;
 	collapsedWorkspaces: Set<string>;
@@ -59,6 +62,68 @@ function groupWorkspacesByProject(
 	return [...projectMap.values()];
 }
 
+function sortWorkspaces(
+	workspaces: WorkspaceMetrics[],
+	sortOption: SortOption,
+	sidebarWorkspaceOrder: string[],
+): WorkspaceMetrics[] {
+	const sorted = [...workspaces];
+	switch (sortOption) {
+		case "memory":
+			sorted.sort((a, b) => b.memory - a.memory);
+			break;
+		case "cpu":
+			sorted.sort((a, b) => b.cpu - a.cpu);
+			break;
+		case "name":
+			sorted.sort((a, b) => a.workspaceName.localeCompare(b.workspaceName));
+			break;
+		case "sidebar": {
+			const orderMap = new Map(
+				sidebarWorkspaceOrder.map((id, index) => [id, index]),
+			);
+			sorted.sort(
+				(a, b) =>
+					(orderMap.get(a.workspaceId) ?? Number.MAX_SAFE_INTEGER) -
+					(orderMap.get(b.workspaceId) ?? Number.MAX_SAFE_INTEGER),
+			);
+			break;
+		}
+	}
+	return sorted;
+}
+
+function sortProjectGroups(
+	groups: ProjectResourceGroup[],
+	sortOption: SortOption,
+	sidebarProjectOrder: string[],
+): ProjectResourceGroup[] {
+	const sorted = [...groups];
+	switch (sortOption) {
+		case "memory":
+			sorted.sort((a, b) => b.memory - a.memory);
+			break;
+		case "cpu":
+			sorted.sort((a, b) => b.cpu - a.cpu);
+			break;
+		case "name":
+			sorted.sort((a, b) => a.projectName.localeCompare(b.projectName));
+			break;
+		case "sidebar": {
+			const orderMap = new Map(
+				sidebarProjectOrder.map((id, index) => [id, index]),
+			);
+			sorted.sort(
+				(a, b) =>
+					(orderMap.get(a.projectId) ?? Number.MAX_SAFE_INTEGER) -
+					(orderMap.get(b.projectId) ?? Number.MAX_SAFE_INTEGER),
+			);
+			break;
+		}
+	}
+	return sorted;
+}
+
 function getProjectTotals(projects: ProjectResourceGroup[]) {
 	return projects.reduce(
 		(acc, project) => ({
@@ -71,6 +136,9 @@ function getProjectTotals(projects: ProjectResourceGroup[]) {
 
 export function WorkspaceResourceSection({
 	workspaces,
+	sortOption,
+	sidebarProjectOrder,
+	sidebarWorkspaceOrder,
 	collapsedProjects,
 	toggleProject,
 	collapsedWorkspaces,
@@ -79,7 +147,20 @@ export function WorkspaceResourceSection({
 	navigateToPane,
 	getPaneName,
 }: WorkspaceResourceSectionProps) {
-	const projectGroups = groupWorkspacesByProject(workspaces);
+	const rawProjectGroups = groupWorkspacesByProject(workspaces);
+	const sortedProjectGroups = sortProjectGroups(
+		rawProjectGroups,
+		sortOption,
+		sidebarProjectOrder,
+	);
+	const projectGroups = sortedProjectGroups.map((group) => ({
+		...group,
+		workspaces: sortWorkspaces(
+			group.workspaces,
+			sortOption,
+			sidebarWorkspaceOrder,
+		),
+	}));
 	const projectTotals = getProjectTotals(projectGroups);
 
 	return projectGroups.map((project) => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ResourceConsumption/types.ts
@@ -1,5 +1,7 @@
 export type UsageSeverity = "normal" | "elevated" | "high";
 
+export type SortOption = "memory" | "cpu" | "name" | "sidebar";
+
 export interface UsageValues {
 	cpu: number;
 	memory: number;


### PR DESCRIPTION
## Summary
- Adds a sort dropdown to the resource usage popover header (next to the refresh button) with four options: **Memory** (default, high→low), **CPU** (high→low), **Name** (A→Z), and **Sidebar order** (matches left sidebar visual ordering)
- Sorting applies to both project groups and individual workspaces within each group
- Uses lightweight `useLiveQuery` calls on sidebar collections for the sidebar order option

## Test plan
- [ ] Open the resource usage popover via the CPU chip button in the top bar
- [ ] Verify the sort dropdown appears next to the refresh button showing "Memory" by default
- [ ] Switch between Memory, CPU, Name, and Sidebar order — confirm workspaces reorder correctly
- [ ] Verify the sort dropdown menu closes properly and doesn't interfere with the popover
- [ ] Confirm the refresh button still works as expected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a sort dropdown to the resource usage popover so you can sort projects and workspaces by Memory (default), CPU, Name, or Sidebar order. This makes it easier to spot heavy usage and mirror the left sidebar without affecting the refresh button.

- New Features
  - Sort dropdown in the popover header (Memory high→low by default; also CPU, Name A→Z, Sidebar order).
  - Sorting applies to both project groups and their workspaces.
  - "Sidebar order" mirrors the left sidebar using `useLiveQuery` from `@tanstack/react-db` over `v2SidebarProjects` and `v2WorkspaceLocalState`.

<sup>Written for commit a24c62bf6ec5e1923c14437bc9869e89175343ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace sorting to the Resource Usage dashboard. Users can now sort resource consumption data by memory usage, CPU usage, alphabetical name, or sidebar order through a new dropdown menu in the header. The existing refresh functionality remains intact and accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->