### PR TITLE
fix(desktop): correct terminal link underline positioning for CJK text

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/file-path-link-provider.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/file-path-link-provider.test.ts
@@ -2,21 +2,41 @@ import { describe, expect, it, mock } from "bun:test";
 import type { IBufferLine, ILink, Terminal } from "@xterm/xterm";
 import { FilePathLinkProvider } from "./file-path-link-provider";
 
-function createMockLine(text: string, isWrapped = false): IBufferLine {
+interface MockCellSpec {
+	chars: string;
+	width: number;
+}
+
+function createMockCell(chars: string, width: number) {
+	return {
+		getChars: () => chars,
+		getWidth: () => width,
+	};
+}
+
+function createMockLine(
+	text: string,
+	isWrapped = false,
+	cells?: MockCellSpec[],
+): IBufferLine {
+	const mockCells = cells?.map((cell) =>
+		createMockCell(cell.chars, cell.width),
+	);
+
 	return {
 		translateToString: () => text,
 		isWrapped,
-		length: text.length,
-		getCell: mock(() => null),
-		getCells: mock(() => []),
+		length: mockCells?.length ?? text.length,
+		getCell: mock((index: number) => mockCells?.[index] ?? null),
+		getCells: mock(() => mockCells ?? []),
 	} as unknown as IBufferLine;
 }
 
 function createMockTerminal(
-	lines: Array<{ text: string; isWrapped?: boolean }>,
+	lines: Array<{ text: string; isWrapped?: boolean; cells?: MockCellSpec[] }>,
 ): Terminal {
 	const mockLines = lines.map((l) =>
-		createMockLine(l.text, l.isWrapped ?? false),
+		createMockLine(l.text, l.isWrapped ?? false, l.cells),
 	);
 
 	return {
@@ -217,6 +237,76 @@ describe("FilePathLinkProvider", () => {
 			expect(links[0].range.start.y).toBe(1);
 			expect(links[0].range.end.x).toBe(10);
 			expect(links[0].range.end.y).toBe(2);
+		});
+
+		it("should account for wide CJK cells before a wrapped path", async () => {
+			const terminal = createMockTerminal([
+				{
+					text: "한글 /tmp/proj",
+					cells: [
+						{ chars: "한", width: 2 },
+						{ chars: "", width: 0 },
+						{ chars: "글", width: 2 },
+						{ chars: "", width: 0 },
+						{ chars: " ", width: 1 },
+						{ chars: "/", width: 1 },
+						{ chars: "t", width: 1 },
+						{ chars: "m", width: 1 },
+						{ chars: "p", width: 1 },
+						{ chars: "/", width: 1 },
+						{ chars: "p", width: 1 },
+						{ chars: "r", width: 1 },
+						{ chars: "o", width: 1 },
+						{ chars: "j", width: 1 },
+					],
+				},
+				{ text: "ect/file.ts", isWrapped: true },
+			]);
+			const onOpen = mock();
+			const provider = new FilePathLinkProvider(terminal, onOpen);
+
+			const links = await getLinks(provider, 1);
+
+			expect(links.length).toBe(1);
+			expect(links[0].text).toBe("/tmp/project/file.ts");
+			expect(links[0].range.start.x).toBe(6);
+			expect(links[0].range.start.y).toBe(1);
+			expect(links[0].range.end.x).toBe(11);
+			expect(links[0].range.end.y).toBe(2);
+		});
+
+		it("should account for surrogate pairs before a path", async () => {
+			const terminal = createMockTerminal([
+				{
+					text: "🙂 /tmp/file.ts",
+					cells: [
+						{ chars: "🙂", width: 2 },
+						{ chars: "", width: 0 },
+						{ chars: " ", width: 1 },
+						{ chars: "/", width: 1 },
+						{ chars: "t", width: 1 },
+						{ chars: "m", width: 1 },
+						{ chars: "p", width: 1 },
+						{ chars: "/", width: 1 },
+						{ chars: "f", width: 1 },
+						{ chars: "i", width: 1 },
+						{ chars: "l", width: 1 },
+						{ chars: "e", width: 1 },
+						{ chars: ".", width: 1 },
+						{ chars: "t", width: 1 },
+						{ chars: "s", width: 1 },
+					],
+				},
+			]);
+			const onOpen = mock();
+			const provider = new FilePathLinkProvider(terminal, onOpen);
+
+			const links = await getLinks(provider, 1);
+
+			expect(links.length).toBe(1);
+			expect(links[0].text).toBe("/tmp/file.ts");
+			expect(links[0].range.start.x).toBe(4);
+			expect(links[0].range.end.x).toBe(15);
 		});
 	});
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/file-path-link-provider.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/file-path-link-provider.test.ts
@@ -215,7 +215,7 @@ describe("FilePathLinkProvider", () => {
 
 			expect(links[0].range.start.x).toBe(1);
 			expect(links[0].range.start.y).toBe(1);
-			expect(links[0].range.end.x).toBe(11);
+			expect(links[0].range.end.x).toBe(10);
 			expect(links[0].range.end.y).toBe(2);
 		});
 	});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/file-path-link-provider.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/file-path-link-provider.ts
@@ -338,8 +338,9 @@ export class FilePathLinkProvider implements ILinkProvider {
 				return charOffset;
 			}
 			if (cell.getWidth() === 0) continue;
-			if (charCount === charOffset) return col;
-			charCount++;
+			const codeUnitLength = Math.max(cell.getChars().length, 1);
+			if (charOffset < charCount + codeUnitLength) return col;
+			charCount += codeUnitLength;
 		}
 		return bufferLine.length;
 	}
@@ -370,19 +371,29 @@ export class FilePathLinkProvider implements ILinkProvider {
 			startX = this.charOffsetToColumn(bufferLineNumber - 2, matchIndex) + 1;
 		} else {
 			startY = bufferLineNumber;
-			startX = this.charOffsetToColumn(bufferLineNumber - 1, matchIndex - currentLineStart) + 1;
+			startX =
+				this.charOffsetToColumn(
+					bufferLineNumber - 1,
+					matchIndex - currentLineStart,
+				) + 1;
 		}
 
 		// End positions: 0-based exclusive end = 1-based inclusive end, so no +1
 		if (endsInNextLine) {
 			endY = bufferLineNumber + 1;
-			endX = this.charOffsetToColumn(bufferLineNumber, matchEnd - currentLineEnd);
+			endX = this.charOffsetToColumn(
+				bufferLineNumber,
+				matchEnd - currentLineEnd,
+			);
 		} else if (matchEnd <= currentLineStart) {
 			endY = bufferLineNumber - 1;
 			endX = this.charOffsetToColumn(bufferLineNumber - 2, matchEnd);
 		} else {
 			endY = bufferLineNumber;
-			endX = this.charOffsetToColumn(bufferLineNumber - 1, matchEnd - currentLineStart);
+			endX = this.charOffsetToColumn(
+				bufferLineNumber - 1,
+				matchEnd - currentLineStart,
+			);
 		}
 
 		return {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/file-path-link-provider.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/file-path-link-provider.ts
@@ -327,6 +327,23 @@ export class FilePathLinkProvider implements ILinkProvider {
 		this.onOpen(event, cleanPath, fallback.line, fallback.col);
 	}
 
+	private charOffsetToColumn(lineIndex: number, charOffset: number): number {
+		const bufferLine = this.terminal.buffer.active.getLine(lineIndex);
+		if (!bufferLine) return charOffset;
+
+		let charCount = 0;
+		for (let col = 0; col < bufferLine.length; col++) {
+			const cell = bufferLine.getCell(col);
+			if (!cell) {
+				return charOffset;
+			}
+			if (cell.getWidth() === 0) continue;
+			if (charCount === charOffset) return col;
+			charCount++;
+		}
+		return bufferLine.length;
+	}
+
 	private calculateLinkRange(
 		matchIndex: number,
 		matchEnd: number,
@@ -350,21 +367,22 @@ export class FilePathLinkProvider implements ILinkProvider {
 
 		if (startsInPrevLine) {
 			startY = bufferLineNumber - 1;
-			startX = matchIndex + 1;
+			startX = this.charOffsetToColumn(bufferLineNumber - 2, matchIndex) + 1;
 		} else {
 			startY = bufferLineNumber;
-			startX = matchIndex - currentLineStart + 1;
+			startX = this.charOffsetToColumn(bufferLineNumber - 1, matchIndex - currentLineStart) + 1;
 		}
 
+		// End positions: 0-based exclusive end = 1-based inclusive end, so no +1
 		if (endsInNextLine) {
 			endY = bufferLineNumber + 1;
-			endX = matchEnd - currentLineEnd + 1;
+			endX = this.charOffsetToColumn(bufferLineNumber, matchEnd - currentLineEnd);
 		} else if (matchEnd <= currentLineStart) {
 			endY = bufferLineNumber - 1;
-			endX = matchEnd + 1;
+			endX = this.charOffsetToColumn(bufferLineNumber - 2, matchEnd);
 		} else {
 			endY = bufferLineNumber;
-			endX = matchEnd - currentLineStart + 1;
+			endX = this.charOffsetToColumn(bufferLineNumber - 1, matchEnd - currentLineStart);
 		}
 
 		return {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/multi-line-link-provider.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/multi-line-link-provider.ts
@@ -50,6 +50,29 @@ export abstract class MultiLineLinkProvider implements ILinkProvider {
 		return match;
 	}
 
+	/**
+	 * Convert a character offset in translateToString(true) output to a
+	 * terminal column (0-based). Wide characters (CJK/Korean) occupy 2
+	 * columns but are 1 JS string character.
+	 */
+	protected charOffsetToColumn(lineIndex: number, charOffset: number): number {
+		const bufferLine = this.terminal.buffer.active.getLine(lineIndex);
+		if (!bufferLine) return charOffset;
+
+		let charCount = 0;
+		for (let col = 0; col < bufferLine.length; col++) {
+			const cell = bufferLine.getCell(col);
+			if (!cell) {
+				// No cell API available — assume 1:1 char-to-column mapping
+				return charOffset;
+			}
+			if (cell.getWidth() === 0) continue;
+			if (charCount === charOffset) return col;
+			charCount++;
+		}
+		return bufferLine.length;
+	}
+
 	protected buildRangesForMatch(
 		matchIndex: number,
 		matchEnd: number,
@@ -202,8 +225,10 @@ export abstract class MultiLineLinkProvider implements ILinkProvider {
 				0,
 				Math.min(offset - line.startOffset, line.text.length),
 			);
+			// For start: 0-based column → +1 for 1-based
+			// For end: 0-based exclusive end = 1-based inclusive end, so no +1
 			return {
-				x: line.leadingTrim + localOffset + 1,
+				x: line.leadingTrim + this.charOffsetToColumn(line.index, localOffset) + (isEnd ? 0 : 1),
 				y: line.lineNumber,
 			};
 		}
@@ -213,7 +238,7 @@ export abstract class MultiLineLinkProvider implements ILinkProvider {
 			return { x: 1, y: 1 };
 		}
 		return {
-			x: lastLine.leadingTrim + lastLine.text.length + 1,
+			x: lastLine.leadingTrim + this.charOffsetToColumn(lastLine.index, lastLine.text.length) + (isEnd ? 0 : 1),
 			y: lastLine.lineNumber,
 		};
 	}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/multi-line-link-provider.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/multi-line-link-provider.ts
@@ -67,8 +67,9 @@ export abstract class MultiLineLinkProvider implements ILinkProvider {
 				return charOffset;
 			}
 			if (cell.getWidth() === 0) continue;
-			if (charCount === charOffset) return col;
-			charCount++;
+			const codeUnitLength = Math.max(cell.getChars().length, 1);
+			if (charOffset < charCount + codeUnitLength) return col;
+			charCount += codeUnitLength;
 		}
 		return bufferLine.length;
 	}
@@ -228,7 +229,9 @@ export abstract class MultiLineLinkProvider implements ILinkProvider {
 			// For start: 0-based column → +1 for 1-based
 			// For end: 0-based exclusive end = 1-based inclusive end, so no +1
 			return {
-				x: line.leadingTrim + this.charOffsetToColumn(line.index, localOffset) + (isEnd ? 0 : 1),
+				x:
+					this.charOffsetToColumn(line.index, line.leadingTrim + localOffset) +
+					(isEnd ? 0 : 1),
 				y: line.lineNumber,
 			};
 		}
@@ -238,7 +241,11 @@ export abstract class MultiLineLinkProvider implements ILinkProvider {
 			return { x: 1, y: 1 };
 		}
 		return {
-			x: lastLine.leadingTrim + this.charOffsetToColumn(lastLine.index, lastLine.text.length) + (isEnd ? 0 : 1),
+			x:
+				this.charOffsetToColumn(
+					lastLine.index,
+					lastLine.leadingTrim + lastLine.text.length,
+				) + (isEnd ? 0 : 1),
 			y: lastLine.lineNumber,
 		};
 	}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/url-link-provider.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/url-link-provider.test.ts
@@ -2,22 +2,42 @@ import { describe, expect, it, mock } from "bun:test";
 import type { IBufferLine, ILink, Terminal } from "@xterm/xterm";
 import { UrlLinkProvider } from "./url-link-provider";
 
-function createMockLine(text: string, isWrapped = false): IBufferLine {
+interface MockCellSpec {
+	chars: string;
+	width: number;
+}
+
+function createMockCell(chars: string, width: number) {
+	return {
+		getChars: () => chars,
+		getWidth: () => width,
+	};
+}
+
+function createMockLine(
+	text: string,
+	isWrapped = false,
+	cells?: MockCellSpec[],
+): IBufferLine {
+	const mockCells = cells?.map((cell) =>
+		createMockCell(cell.chars, cell.width),
+	);
+
 	return {
 		translateToString: () => text,
 		isWrapped,
-		length: text.length,
-		getCell: mock(() => null),
-		getCells: mock(() => []),
+		length: mockCells?.length ?? text.length,
+		getCell: mock((index: number) => mockCells?.[index] ?? null),
+		getCells: mock(() => mockCells ?? []),
 	} as unknown as IBufferLine;
 }
 
 function createMockTerminal(
-	lines: Array<{ text: string; isWrapped?: boolean }>,
+	lines: Array<{ text: string; isWrapped?: boolean; cells?: MockCellSpec[] }>,
 	cols = 80,
 ): Terminal {
 	const mockLines = lines.map((l) =>
-		createMockLine(l.text, l.isWrapped ?? false),
+		createMockLine(l.text, l.isWrapped ?? false, l.cells),
 	);
 
 	return {
@@ -415,6 +435,49 @@ describe("UrlLinkProvider", () => {
 			);
 			expect(links[0].range.start.y).toBe(1);
 			expect(links[0].range.end.y).toBe(2);
+		});
+
+		it("should include tab-width leading trim columns on continuation lines", async () => {
+			const terminal = createMockTerminal(
+				[
+					{
+						text: "Visit https://example.com/very/long/path/segment",
+					},
+					{
+						text: "\t/continued",
+						cells: [
+							{ chars: "\t", width: 4 },
+							{ chars: "", width: 0 },
+							{ chars: "", width: 0 },
+							{ chars: "", width: 0 },
+							{ chars: "/", width: 1 },
+							{ chars: "c", width: 1 },
+							{ chars: "o", width: 1 },
+							{ chars: "n", width: 1 },
+							{ chars: "t", width: 1 },
+							{ chars: "i", width: 1 },
+							{ chars: "n", width: 1 },
+							{ chars: "u", width: 1 },
+							{ chars: "e", width: 1 },
+							{ chars: "d", width: 1 },
+						],
+					},
+				],
+				50,
+			);
+			const onOpen = mock();
+			const provider = new UrlLinkProvider(terminal, onOpen);
+
+			const links = await getLinks(provider, 1);
+
+			expect(links.length).toBe(1);
+			expect(links[0].text).toBe(
+				"https://example.com/very/long/path/segment/continued",
+			);
+			expect(links[0].range.start.y).toBe(1);
+			expect(links[0].range.end.y).toBe(2);
+			expect(links[0].range.start.x).toBe(7);
+			expect(links[0].range.end.x).toBe(14);
 		});
 
 		it("should not merge plain prose after a complete URL", async () => {


### PR DESCRIPTION
## Summary
- CJK (Chinese/Japanese/Korean) characters occupy **2 terminal columns** but are only **1 character** in JavaScript strings
- Both `MultiLineLinkProvider` and `FilePathLinkProvider` used JS string char offsets directly as xterm column positions, causing link underlines to appear at wrong positions when CJK text precedes a link
- Added `charOffsetToColumn()` helper that walks xterm `IBufferLine` cells to compute accurate column positions
- Fixed off-by-one on link `end.x` (xterm range end is inclusive)

### Before
<img width="551" height="150" alt="image" src="https://github.com/user-attachments/assets/94aa22d0-9650-49be-8069-8cf848e31334" />

### After
<img width="557" height="158" alt="image" src="https://github.com/user-attachments/assets/d723dfe6-1404-4c9c-b65f-8d225694b546" />


## Test plan
- [x] All existing link provider tests pass (83 tests, 697 assertions)
- [x] Updated `end.x` test expectation to match inclusive semantics
- [ ] Manual: output text with Korean/CJK characters before a file path in terminal, verify underline aligns correctly

Fixes #2231
Fixes #2317


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misaligned terminal link underlines when CJK, emoji, or tab-indented text precede URLs or file paths. Links now align to the correct terminal columns across wrapped lines. Fixes #2231 and #2317.

- **Bug Fixes**
  - Added `charOffsetToColumn()` in `MultiLineLinkProvider` and `FilePathLinkProvider` to map JS offsets to terminal columns by walking buffer cells (handles wide CJK, zero-width cells, and UTF‑16 surrogate pairs).
  - Updated range calculations to use this mapping for start/end, treat `end.x` as inclusive, and include tab-width leading trim on continuation lines; added regression tests for CJK, emoji, and tab-indented continuations.

<sup>Written for commit 944a97332f1543099f778d52c0591671b1df949c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate link detection and coordinate calculation in the terminal for paths and URLs that include wide characters (CJK, emoji) and when links span wrapped lines; range endpoints now compute correctly across wrapped boundaries.

* **Tests**
  * Added and updated tests covering wide-cell scenarios, surrogate-pair emoji, and wrapped-line URL/path detection to validate coordinates and link merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->