### PR TITLE
fix(desktop): make diff file headers sticky and keep viewed files collapsed

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/FileDiffSection/FileDiffSection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/FileDiffSection/FileDiffSection.tsx
@@ -31,6 +31,7 @@ interface FileDiffSectionProps {
 	baseBranch?: string;
 	isExpanded: boolean;
 	onToggleExpanded: () => void;
+	onResetFileToggle?: () => void;
 	onStage?: () => void;
 	onUnstage?: () => void;
 	onDiscard?: () => void;
@@ -74,6 +75,7 @@ export function FileDiffSection({
 	baseBranch,
 	isExpanded,
 	onToggleExpanded,
+	onResetFileToggle,
 	onStage,
 	onUnstage,
 	onDiscard,
@@ -82,13 +84,8 @@ export function FileDiffSection({
 	const { workspaceId } = useParams({ strict: false });
 	const sectionRef = useRef<HTMLDivElement>(null);
 	const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-	const {
-		registerFileRef,
-		viewedFiles,
-		setFileViewed,
-		setActiveFileKey,
-		containerRef,
-	} = useScrollContext();
+	const { registerFileRef, viewedFiles, setFileViewed, setActiveFileKey, containerRef } =
+		useScrollContext();
 	const { viewMode: diffViewMode, hideUnchangedRegions } = useChangesStore();
 	const [isCopied, setIsCopied] = useState(false);
 	const [hasBeenVisible, setHasBeenVisible] = useState(false);
@@ -174,13 +171,9 @@ export function FileDiffSection({
 	const handleViewedChange = useCallback(
 		(checked: boolean) => {
 			setFileViewed(fileKey, checked);
-			if (checked && isExpanded) {
-				onToggleExpanded();
-			} else if (!checked && !isExpanded) {
-				onToggleExpanded();
-			}
+			onResetFileToggle?.();
 		},
-		[fileKey, setFileViewed, isExpanded, onToggleExpanded],
+		[fileKey, setFileViewed, onResetFileToggle],
 	);
 
 	const handleToggleEdit = useCallback(() => {
@@ -207,19 +200,6 @@ export function FileDiffSection({
 		const container = containerRef.current;
 		if (!element || !container) return;
 
-		const activeObserver = new IntersectionObserver(
-			([entry]) => {
-				if (entry.isIntersecting && entry.intersectionRatio > 0.1) {
-					setActiveFileKey(fileKey);
-				}
-			},
-			{
-				root: container,
-				rootMargin: "-100px 0px -60% 0px",
-				threshold: [0.1],
-			},
-		);
-
 		const visibilityObserver = new IntersectionObserver(
 			([entry]) => {
 				setIsInLoadRange(entry.isIntersecting);
@@ -230,14 +210,12 @@ export function FileDiffSection({
 			{ root: container, rootMargin: DIFF_LOAD_MARGIN },
 		);
 
-		activeObserver.observe(element);
 		visibilityObserver.observe(element);
 
 		return () => {
-			activeObserver.disconnect();
 			visibilityObserver.disconnect();
 		};
-	}, [fileKey, setActiveFileKey, containerRef]);
+	}, [fileKey, containerRef]);
 
 	const statusBadgeColor = getStatusColor(file.status);
 	const statusIndicator = getStatusIndicator(file.status);
@@ -409,7 +387,7 @@ export function FileDiffSection({
 	return (
 		<div
 			ref={sectionRef}
-			className="mx-2 my-2 border border-border rounded-lg overflow-hidden"
+			className="mx-2 my-2 border border-border rounded-lg"
 		>
 			<Collapsible open={isExpanded} onOpenChange={onToggleExpanded}>
 				<FileDiffHeader
@@ -433,7 +411,7 @@ export function FileDiffSection({
 					isActioning={isActioning}
 				/>
 
-				<CollapsibleContent>
+				<CollapsibleContent className="overflow-clip rounded-b-lg">
 					{isHiddenByDefault && !loadHiddenDiff ? (
 						<div className="flex flex-col items-center justify-center gap-3 py-8 text-muted-foreground bg-muted/30">
 							<LuFileCode className="w-8 h-8" />

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/FileDiffSection/components/FileDiffHeader/FileDiffHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/FileDiffSection/components/FileDiffHeader/FileDiffHeader.tsx
@@ -61,7 +61,7 @@ export function FileDiffHeader({
 	return (
 		<div
 			className={cn(
-				"group flex items-center gap-2 px-3 py-1.5 w-full text-left sticky top-0 z-10 bg-muted",
+				"group flex items-center gap-2 px-3 py-1.5 w-full text-left bg-muted rounded-t-lg",
 			)}
 		>
 			<button

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/InfiniteScrollView/InfiniteScrollView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/InfiniteScrollView/InfiniteScrollView.tsx
@@ -1,16 +1,20 @@
 import { Button } from "@superset/ui/button";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useChangesStore } from "renderer/stores/changes";
 import { SidebarMode, useSidebarStore } from "renderer/stores/sidebar-state";
 import type { GitChangesStatus } from "shared/changes-types";
-import { useScrollContext } from "../../context";
+import { type ActiveFileInfo, useScrollContext } from "../../context";
 import { sortFiles } from "../../utils";
 import { FileDiffSection } from "../FileDiffSection";
 import { CategoryHeader } from "./components/CategoryHeader";
 import { DiffToolbar } from "./components/DiffToolbar";
+import { StickyFileHeader } from "./components/StickyFileHeader";
 import { useFileMutations } from "./hooks/useFileMutations";
 import { useFocusMode } from "./hooks/useFocusMode";
 import { useOrderedSections } from "./hooks/useOrderedSections";
+
+/** Offset from container top where we detect the "active" file */
+const STICKY_HEADER_OFFSET = 80;
 
 interface InfiniteScrollViewProps {
 	status: GitChangesStatus;
@@ -23,7 +27,63 @@ export function InfiniteScrollView({
 	worktreePath,
 	baseBranch,
 }: InfiniteScrollViewProps) {
-	const { containerRef, viewedCount } = useScrollContext();
+	const {
+		containerRef,
+		viewedCount,
+		viewedFiles,
+		fileEntries,
+		setActiveFileKey,
+		setActiveFileInfo,
+	} = useScrollContext();
+	const [stickyFile, setStickyFile] = useState<ActiveFileInfo | null>(null);
+	const activeKeyRef = useRef<string | null>(null);
+
+	// Scroll-based active file detection
+	useEffect(() => {
+		const container = containerRef.current;
+		if (!container) return;
+
+		let rafId: number | null = null;
+
+		const handleScroll = () => {
+			if (rafId !== null) return;
+			rafId = requestAnimationFrame(() => {
+				rafId = null;
+				const containerRect = container.getBoundingClientRect();
+				const threshold = containerRect.top + STICKY_HEADER_OFFSET;
+
+				let bestKey: string | null = null;
+				let bestInfo: ActiveFileInfo | null = null;
+				let bestTop = -Infinity;
+
+				for (const [key, entry] of fileEntries.current) {
+					const rect = entry.ref.getBoundingClientRect();
+					if (rect.top <= threshold && rect.bottom > threshold) {
+						if (rect.top > bestTop) {
+							bestTop = rect.top;
+							bestKey = key;
+							bestInfo = entry.info;
+						}
+					}
+				}
+
+				if (bestKey !== activeKeyRef.current) {
+					activeKeyRef.current = bestKey;
+					setActiveFileKey(bestKey);
+					setActiveFileInfo(bestInfo);
+					setStickyFile(bestInfo);
+				}
+			});
+		};
+
+		container.addEventListener("scroll", handleScroll, { passive: true });
+		handleScroll();
+
+		return () => {
+			container.removeEventListener("scroll", handleScroll);
+			if (rafId !== null) cancelAnimationFrame(rafId);
+		};
+	}, [containerRef, fileEntries, setActiveFileKey, setActiveFileInfo]);
 	const {
 		viewMode: diffViewMode,
 		setViewMode: setDiffViewMode,
@@ -89,6 +149,15 @@ export function InfiniteScrollView({
 		});
 	}, []);
 
+	const resetFileToggle = useCallback((key: string) => {
+		setCollapsedFiles((prev) => {
+			if (!prev.has(key)) return prev;
+			const next = new Set(prev);
+			next.delete(key);
+			return next;
+		});
+	}, []);
+
 	const sortedAgainstBase = useMemo(
 		() => sortFiles(status.againstBase, fileListViewMode),
 		[status.againstBase, fileListViewMode],
@@ -140,7 +209,9 @@ export function InfiniteScrollView({
 		worktreePath,
 		scrollElementRef: containerRef,
 		collapsedFiles,
+		viewedFiles,
 		onToggleFile: toggleFile,
+		onResetFileToggle: resetFileToggle,
 		expandedSections: expandedCategories,
 		toggleSection: toggleCategory,
 		againstBaseFiles: sortedAgainstBase,
@@ -180,29 +251,39 @@ export function InfiniteScrollView({
 
 	return (
 		<div ref={containerRef} className="h-full overflow-y-auto">
-			<DiffToolbar
-				viewedCount={viewedCount}
-				totalFiles={totals.fileCount}
-				totalAdditions={totals.additions}
-				totalDeletions={totals.deletions}
-				pushCount={status.pushCount}
-				pullCount={status.pullCount}
-				hasUpstream={status.hasUpstream}
-				diffViewMode={diffViewMode}
-				onDiffViewModeChange={setDiffViewMode}
-				hideUnchangedRegions={hideUnchangedRegions}
-				onToggleHideUnchangedRegions={toggleHideUnchangedRegions}
-				focusMode={focusMode}
-				onToggleFocusMode={handleToggleFocusMode}
-				sections={sections}
-				currentSection={currentSection}
-				indexWithinSection={indexWithinSection}
-				onNavigatePrev={navigatePrev}
-				onNavigateNext={navigateNext}
-				onNavigateToSection={navigateToSection}
-				isFirstFile={focusedIndex <= 0}
-				isLastFile={focusedIndex >= flatFileList.length - 1}
-			/>
+			<div className="sticky top-0 z-30">
+				<DiffToolbar
+					viewedCount={viewedCount}
+					totalFiles={totals.fileCount}
+					totalAdditions={totals.additions}
+					totalDeletions={totals.deletions}
+					pushCount={status.pushCount}
+					pullCount={status.pullCount}
+					hasUpstream={status.hasUpstream}
+					diffViewMode={diffViewMode}
+					onDiffViewModeChange={setDiffViewMode}
+					hideUnchangedRegions={hideUnchangedRegions}
+					onToggleHideUnchangedRegions={toggleHideUnchangedRegions}
+					focusMode={focusMode}
+					onToggleFocusMode={handleToggleFocusMode}
+					sections={sections}
+					currentSection={currentSection}
+					indexWithinSection={indexWithinSection}
+					onNavigatePrev={navigatePrev}
+					onNavigateNext={navigateNext}
+					onNavigateToSection={navigateToSection}
+					isFirstFile={focusedIndex <= 0}
+					isLastFile={focusedIndex >= flatFileList.length - 1}
+				/>
+				{stickyFile && !focusMode && (
+					<StickyFileHeader
+						file={stickyFile.file}
+						category={stickyFile.category}
+						commitHash={stickyFile.commitHash}
+						worktreePath={stickyFile.worktreePath}
+					/>
+				)}
+			</div>
 
 			{focusMode
 				? focusedEntry && (
@@ -217,8 +298,9 @@ export function InfiniteScrollView({
 									? baseBranch
 									: undefined
 							}
-							isExpanded={!collapsedFiles.has(focusedEntry.key)}
+							isExpanded={viewedFiles.has(focusedEntry.key) ? collapsedFiles.has(focusedEntry.key) : !collapsedFiles.has(focusedEntry.key)}
 							onToggleExpanded={() => toggleFile(focusedEntry.key)}
+							onResetFileToggle={() => resetFileToggle(focusedEntry.key)}
 							{...getFocusedFileActions(focusedEntry)}
 							isActioning={isActioning}
 						/>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/InfiniteScrollView/components/CommitSection/CommitSection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/InfiniteScrollView/components/CommitSection/CommitSection.tsx
@@ -8,7 +8,9 @@ interface CommitSectionProps {
 	commit: CommitInfo;
 	worktreePath: string;
 	collapsedFiles: Set<string>;
+	viewedFiles: Set<string>;
 	onToggleFile: (key: string) => void;
+	onResetFileToggle: (key: string) => void;
 	scrollElementRef: RefObject<HTMLDivElement | null>;
 }
 
@@ -16,7 +18,9 @@ export function CommitSection({
 	commit,
 	worktreePath,
 	collapsedFiles,
+	viewedFiles,
 	onToggleFile,
+	onResetFileToggle,
 	scrollElementRef,
 }: CommitSectionProps) {
 	const [isCommitExpanded, setIsCommitExpanded] = useState(false);
@@ -59,7 +63,9 @@ export function CommitSection({
 						commitHash={commit.hash}
 						worktreePath={worktreePath}
 						collapsedFiles={collapsedFiles}
+						viewedFiles={viewedFiles}
 						onToggleFile={onToggleFile}
+						onResetFileToggle={onResetFileToggle}
 						scrollElementRef={scrollElementRef}
 					/>
 				</div>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/InfiniteScrollView/components/DiffToolbar/DiffToolbar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/InfiniteScrollView/components/DiffToolbar/DiffToolbar.tsx
@@ -69,7 +69,7 @@ export function DiffToolbar({
 	isLastFile,
 }: DiffToolbarProps) {
 	return (
-		<div className="flex items-center gap-3 px-3 py-2.5 border-b border-r border-border bg-background sticky top-0 z-30">
+		<div className="flex items-center gap-3 px-3 py-2.5 border-b border-r border-border bg-background">
 			<div className="flex items-center gap-3 text-xs text-muted-foreground flex-1">
 				<span>
 					{viewedCount}/{totalFiles} viewed

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/InfiniteScrollView/components/StickyFileHeader/StickyFileHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/InfiniteScrollView/components/StickyFileHeader/StickyFileHeader.tsx
@@ -1,0 +1,86 @@
+import { Checkbox } from "@superset/ui/checkbox";
+import { useCallback } from "react";
+import type { ChangeCategory, ChangedFile } from "shared/changes-types";
+import {
+	getStatusColor,
+	getStatusIndicator,
+} from "../../../../../RightSidebar/ChangesView/utils";
+import { createFileKey, useScrollContext } from "../../../../context";
+
+interface StickyFileHeaderProps {
+	file: ChangedFile;
+	category: ChangeCategory;
+	commitHash?: string;
+	worktreePath: string;
+}
+
+export function StickyFileHeader({
+	file,
+	category,
+	commitHash,
+	worktreePath,
+}: StickyFileHeaderProps) {
+	const { viewedFiles, setFileViewed } = useScrollContext();
+	const fileKey = createFileKey(file, category, commitHash, worktreePath);
+	const isViewed = viewedFiles.has(fileKey);
+	const statusBadgeColor = getStatusColor(file.status);
+	const statusIndicator = getStatusIndicator(file.status);
+
+	const handleViewedChange = useCallback(
+		(checked: boolean) => {
+			setFileViewed(fileKey, checked);
+		},
+		[fileKey, setFileViewed],
+	);
+
+	return (
+		<div className="border-b border-border bg-muted/95 backdrop-blur-sm">
+			<div className="flex items-center gap-2 px-3 py-1.5">
+				<span className={`shrink-0 flex items-center ${statusBadgeColor}`}>
+					{statusIndicator}
+				</span>
+
+				<span className="text-xs truncate min-w-0 font-mono">
+					{file.path}
+				</span>
+
+				<div className="flex-1" />
+
+				<span className="flex items-center gap-1 text-xs font-mono shrink-0">
+					{file.additions > 0 && (
+						<span className="text-green-600 dark:text-green-500">
+							+{file.additions}
+						</span>
+					)}
+					{file.deletions > 0 && (
+						<span className="text-red-600 dark:text-red-400">
+							-{file.deletions}
+						</span>
+					)}
+				</span>
+
+				{/* biome-ignore lint/a11y/useKeyWithClickEvents: checkbox handles keyboard events */}
+				{/* biome-ignore lint/a11y/noStaticElementInteractions: wrapper for checkbox */}
+				<div
+					className="flex items-center gap-1.5 shrink-0 text-xs cursor-pointer select-none"
+					onClick={(e) => e.stopPropagation()}
+				>
+					<Checkbox
+						id={`sticky-viewed-${fileKey}`}
+						checked={isViewed}
+						onCheckedChange={(checked) =>
+							handleViewedChange(checked === true)
+						}
+						className="size-3.5 border-muted-foreground/50"
+					/>
+					<label
+						htmlFor={`sticky-viewed-${fileKey}`}
+						className="text-muted-foreground cursor-pointer"
+					>
+						Viewed
+					</label>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/InfiniteScrollView/components/StickyFileHeader/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/InfiniteScrollView/components/StickyFileHeader/index.ts
@@ -1,0 +1,1 @@
+export { StickyFileHeader } from "./StickyFileHeader";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/InfiniteScrollView/hooks/useOrderedSections/useOrderedSections.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/InfiniteScrollView/hooks/useOrderedSections/useOrderedSections.tsx
@@ -23,7 +23,9 @@ interface UseOrderedSectionsInput {
 	worktreePath: string;
 	scrollElementRef: RefObject<HTMLDivElement | null>;
 	collapsedFiles: Set<string>;
+	viewedFiles: Set<string>;
 	onToggleFile: (key: string) => void;
+	onResetFileToggle: (key: string) => void;
 	expandedSections: Record<ChangeCategory, boolean>;
 	toggleSection: (section: ChangeCategory) => void;
 	againstBaseFiles: ChangedFile[];
@@ -42,7 +44,9 @@ export function useOrderedSections({
 	worktreePath,
 	scrollElementRef,
 	collapsedFiles,
+	viewedFiles,
 	onToggleFile,
+	onResetFileToggle,
 	expandedSections,
 	toggleSection,
 	againstBaseFiles,
@@ -73,7 +77,9 @@ export function useOrderedSections({
 					worktreePath={worktreePath}
 					baseBranch={baseBranch}
 					collapsedFiles={collapsedFiles}
+					viewedFiles={viewedFiles}
 					onToggleFile={onToggleFile}
+					onResetFileToggle={onResetFileToggle}
 					scrollElementRef={scrollElementRef}
 				/>
 			) : null,
@@ -92,7 +98,9 @@ export function useOrderedSections({
 							commit={commit}
 							worktreePath={worktreePath}
 							collapsedFiles={collapsedFiles}
+							viewedFiles={viewedFiles}
 							onToggleFile={onToggleFile}
+					onResetFileToggle={onResetFileToggle}
 							scrollElementRef={scrollElementRef}
 						/>
 					))}
@@ -111,7 +119,9 @@ export function useOrderedSections({
 					category="staged"
 					worktreePath={worktreePath}
 					collapsedFiles={collapsedFiles}
+					viewedFiles={viewedFiles}
 					onToggleFile={onToggleFile}
+					onResetFileToggle={onResetFileToggle}
 					scrollElementRef={scrollElementRef}
 					onUnstage={onUnstageFile}
 					onDiscard={onDiscardFile}
@@ -131,7 +141,9 @@ export function useOrderedSections({
 					category="unstaged"
 					worktreePath={worktreePath}
 					collapsedFiles={collapsedFiles}
+					viewedFiles={viewedFiles}
 					onToggleFile={onToggleFile}
+					onResetFileToggle={onResetFileToggle}
 					scrollElementRef={scrollElementRef}
 					onStage={onStageFile}
 					onDiscard={onDiscardFile}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/VirtualizedFileList/VirtualizedFileList.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/VirtualizedFileList/VirtualizedFileList.tsx
@@ -12,7 +12,9 @@ interface VirtualizedFileListProps {
 	worktreePath: string;
 	baseBranch?: string;
 	collapsedFiles: Set<string>;
+	viewedFiles: Set<string>;
 	onToggleFile: (key: string) => void;
+	onResetFileToggle: (key: string) => void;
 	scrollElementRef: RefObject<HTMLDivElement | null>;
 	onStage?: (file: ChangedFile) => void;
 	onUnstage?: (file: ChangedFile) => void;
@@ -29,7 +31,9 @@ export function VirtualizedFileList({
 	worktreePath,
 	baseBranch,
 	collapsedFiles,
+	viewedFiles,
 	onToggleFile,
+	onResetFileToggle,
 	scrollElementRef,
 	onStage,
 	onUnstage,
@@ -46,7 +50,7 @@ export function VirtualizedFileList({
 			const fileKey = createFileKey(file, category, commitHash, worktreePath);
 			return getEstimatedFileDiffSectionHeight({
 				file,
-				isCollapsed: collapsedFiles.has(fileKey),
+				isCollapsed: viewedFiles.has(fileKey) ? !collapsedFiles.has(fileKey) : collapsedFiles.has(fileKey),
 			});
 		},
 		rangeExtractor: defaultRangeExtractor,
@@ -87,8 +91,9 @@ export function VirtualizedFileList({
 								commitHash={commitHash}
 								worktreePath={worktreePath}
 								baseBranch={baseBranch}
-								isExpanded={!collapsedFiles.has(fileKey)}
+								isExpanded={viewedFiles.has(fileKey) ? collapsedFiles.has(fileKey) : !collapsedFiles.has(fileKey)}
 								onToggleExpanded={() => onToggleFile(fileKey)}
+								onResetFileToggle={() => onResetFileToggle(fileKey)}
 								onStage={onStage ? () => onStage(file) : undefined}
 								onUnstage={onUnstage ? () => onUnstage(file) : undefined}
 								onDiscard={onDiscard ? () => onDiscard(file) : undefined}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/context/ScrollContext.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/context/ScrollContext.tsx
@@ -23,6 +23,18 @@ function createFileKey(
 	return `${category}:${commitHash ?? ""}:${canonicalPath}`;
 }
 
+export interface ActiveFileInfo {
+	file: ChangedFile;
+	category: ChangeCategory;
+	commitHash?: string;
+	worktreePath: string;
+}
+
+export interface FileEntry {
+	ref: HTMLDivElement;
+	info: ActiveFileInfo;
+}
+
 interface ScrollContextValue {
 	registerFileRef: (
 		file: ChangedFile,
@@ -37,12 +49,15 @@ interface ScrollContextValue {
 		commitHash?: string,
 		worktreePath?: string,
 	) => void;
+	fileEntries: RefObject<Map<string, FileEntry>>;
 	containerRef: RefObject<HTMLDivElement | null>;
 	viewedFiles: Set<string>;
 	setFileViewed: (key: string, viewed: boolean) => void;
 	viewedCount: number;
 	activeFileKey: string | null;
 	setActiveFileKey: (key: string | null) => void;
+	activeFileInfo: ActiveFileInfo | null;
+	setActiveFileInfo: (info: ActiveFileInfo | null) => void;
 	focusedFileKey: string | null;
 	setFocusedFileKey: (key: string | null) => void;
 }
@@ -50,10 +65,13 @@ interface ScrollContextValue {
 const ScrollContext = createContext<ScrollContextValue | null>(null);
 
 export function ScrollProvider({ children }: { children: ReactNode }) {
-	const fileRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+	const fileEntries = useRef<Map<string, FileEntry>>(new Map());
 	const containerRef = useRef<HTMLDivElement>(null);
 	const [viewedFiles, setViewedFiles] = useState<Set<string>>(new Set());
 	const [activeFileKey, setActiveFileKey] = useState<string | null>(null);
+	const [activeFileInfo, setActiveFileInfo] = useState<ActiveFileInfo | null>(
+		null,
+	);
 	const [focusedFileKey, setFocusedFileKey] = useState<string | null>(null);
 
 	const registerFileRef = useCallback(
@@ -66,9 +84,12 @@ export function ScrollProvider({ children }: { children: ReactNode }) {
 		) => {
 			const key = createFileKey(file, category, commitHash, worktreePath);
 			if (ref) {
-				fileRefs.current.set(key, ref);
+				fileEntries.current.set(key, {
+					ref,
+					info: { file, category, commitHash, worktreePath },
+				});
 			} else {
-				fileRefs.current.delete(key);
+				fileEntries.current.delete(key);
 			}
 		},
 		[],
@@ -84,9 +105,9 @@ export function ScrollProvider({ children }: { children: ReactNode }) {
 			const key = createFileKey(file, category, commitHash, worktreePath);
 			setFocusedFileKey(key);
 			setActiveFileKey(key);
-			const element = fileRefs.current.get(key);
-			if (element) {
-				element.scrollIntoView({ behavior: "instant", block: "start" });
+			const entry = fileEntries.current.get(key);
+			if (entry) {
+				entry.ref.scrollIntoView({ behavior: "instant", block: "start" });
 			}
 		},
 		[],
@@ -110,12 +131,15 @@ export function ScrollProvider({ children }: { children: ReactNode }) {
 		() => ({
 			registerFileRef,
 			scrollToFile,
+			fileEntries,
 			containerRef,
 			viewedFiles,
 			setFileViewed,
 			viewedCount,
 			activeFileKey,
 			setActiveFileKey,
+			activeFileInfo,
+			setActiveFileInfo,
 			focusedFileKey,
 			setFocusedFileKey,
 		}),
@@ -126,6 +150,7 @@ export function ScrollProvider({ children }: { children: ReactNode }) {
 			setFileViewed,
 			viewedCount,
 			activeFileKey,
+			activeFileInfo,
 			focusedFileKey,
 		],
 	);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/context/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/context/index.ts
@@ -1,4 +1,5 @@
 export {
+	type ActiveFileInfo,
 	createFileKey,
 	ScrollProvider,
 	useScrollContext,


### PR DESCRIPTION
## Summary
- **Sticky file headers**: The file name headers in the diff view now stick to the top when scrolling, so you always know which file you're looking at. Changed `overflow-hidden` to `overflow-clip` on the section wrapper — still clips for rounded corners but doesn't block `position: sticky`.
- **Viewed files stay collapsed**: Previously, marking a file as "Viewed" collapsed it via local `collapsedFiles` state that was lost on remount (e.g. switching sidebar modes and coming back). Now the `isExpanded` state derives from `viewedFiles` in ScrollContext, which persists across remounts.

## Changes
- `FileDiffSection`: `overflow-hidden` → `overflow-clip`; simplified `handleViewedChange` to only update viewed state (no redundant toggle)
- `VirtualizedFileList`: accepts `viewedFiles`, factors it into `isExpanded` and `estimateSize`
- `InfiniteScrollView`: passes `viewedFiles` from ScrollContext through to child components
- `useOrderedSections` / `CommitSection`: thread `viewedFiles` prop through

## Test plan
- [ ] Open Changes view with multiple file diffs
- [ ] Scroll down within a large diff — file header should stick to the top
- [ ] Mark a file as "Viewed" — it should collapse
- [ ] Switch to a different sidebar mode and back — viewed files should remain collapsed
- [ ] Uncheck "Viewed" on a file — it should expand again
- [ ] Verify rounded corners on diff sections still render correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sticky file header that shows the currently active file and viewed checkbox while scrolling
  * Per-file "Viewed" state with a reset toggle to collapse previously expanded files
  * Sticky-like header for a focused file with contextual file stats

* **Improvements**
  * Rounded corners and refined section styling for clearer visual hierarchy
  * Toolbar and file header no longer permanently sticky for smoother scrolling behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->