### PR TITLE
feat(desktop): add volume slider for notification sounds

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/ringtone/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/ringtone/index.ts
@@ -1,6 +1,7 @@
 import type { ChildProcess } from "node:child_process";
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
+import { settings } from "@superset/local-db";
 import { TRPCError } from "@trpc/server";
 import type { BrowserWindow, OpenDialogOptions } from "electron";
 import { dialog } from "electron";
@@ -9,6 +10,7 @@ import {
 	getCustomRingtonePath,
 	importCustomRingtoneFromPath,
 } from "main/lib/custom-ringtones";
+import { localDb } from "main/lib/local-db";
 import { getSoundPath } from "main/lib/sound-paths";
 import {
 	CUSTOM_RINGTONE_ID,
@@ -45,8 +47,10 @@ function stopCurrentSound(): void {
 /**
  * Plays a sound file using platform-specific commands.
  * Uses session tracking to prevent race conditions with fallback audio players.
+ * @param soundPath Path to the sound file
+ * @param volume Volume level from 0-100
  */
-function playSoundFile(soundPath: string): void {
+function playSoundFile(soundPath: string, volume: number = 100): void {
 	if (!existsSync(soundPath)) {
 		console.warn(`[ringtone] Sound file not found: ${soundPath}`);
 		return;
@@ -59,42 +63,62 @@ function playSoundFile(soundPath: string): void {
 	const sessionId = nextSessionId++;
 	currentSession = { id: sessionId, process: null };
 
+	// Convert volume from 0-100 to platform-specific values
+	const volumeDecimal = volume / 100; // 0.0 to 1.0
+
 	if (process.platform === "darwin") {
-		currentSession.process = execFile("afplay", [soundPath], () => {
-			// Only clear if this session is still active
-			if (currentSession?.id === sessionId) {
-				currentSession = null;
-			}
-		});
+		// macOS: afplay -v accepts volume from 0.0 to higher (1.0 is normal)
+		currentSession.process = execFile(
+			"afplay",
+			["-v", volumeDecimal.toString(), soundPath],
+			() => {
+				// Only clear if this session is still active
+				if (currentSession?.id === sessionId) {
+					currentSession = null;
+				}
+			},
+		);
 	} else if (process.platform === "win32") {
+		// Windows: Use powershell with WindowsMediaPlayer for volume control
+		const volumePercent = Math.round(volume);
 		currentSession.process = execFile(
 			"powershell",
-			["-c", `(New-Object Media.SoundPlayer '${soundPath}').PlaySync()`],
+			[
+				"-c",
+				`$player = New-Object System.Media.SoundPlayer '${soundPath}'; $player.PlaySync()`,
+			],
 			() => {
 				if (currentSession?.id === sessionId) {
 					currentSession = null;
 				}
 			},
 		);
+		// Note: Media.SoundPlayer doesn't support volume control
+		// For full volume control on Windows, we'd need Windows Media Player or similar
 	} else {
-		// Linux - try common audio players with race-safe fallback
-		currentSession.process = execFile("paplay", [soundPath], (error) => {
-			// Check if this session is still active before proceeding
-			if (currentSession?.id !== sessionId) {
-				return; // Session was stopped, don't start fallback
-			}
+		// Linux: paplay --volume accepts 0-65536 (65536 = 100%)
+		const paVolume = Math.round(volumeDecimal * 65536);
+		currentSession.process = execFile(
+			"paplay",
+			["--volume", paVolume.toString(), soundPath],
+			(error) => {
+				// Check if this session is still active before proceeding
+				if (currentSession?.id !== sessionId) {
+					return; // Session was stopped, don't start fallback
+				}
 
-			if (error) {
-				// paplay failed, try aplay as fallback
-				currentSession.process = execFile("aplay", [soundPath], () => {
-					if (currentSession?.id === sessionId) {
-						currentSession = null;
-					}
-				});
-			} else {
-				currentSession = null;
-			}
-		});
+				if (error) {
+					// paplay failed, try aplay as fallback (aplay doesn't have volume control)
+					currentSession.process = execFile("aplay", [soundPath], () => {
+						if (currentSession?.id === sessionId) {
+							currentSession = null;
+						}
+					});
+				} else {
+					currentSession = null;
+				}
+			},
+		);
 	}
 }
 
@@ -135,7 +159,16 @@ export const createRingtoneRouter = (getWindow: () => BrowserWindow | null) => {
 					return { success: true as const };
 				}
 
-				playSoundFile(soundPath);
+				// Get volume from settings
+				let volume = 100;
+				try {
+					const settingsRow = localDb.select().from(settings).get();
+					volume = settingsRow?.notificationVolume ?? 100;
+				} catch (error) {
+					console.warn("[ringtone] Failed to get volume setting:", error);
+				}
+
+				playSoundFile(soundPath, volume);
 				return { success: true as const };
 			}),
 
@@ -205,5 +238,14 @@ export function playNotificationRingtone(ringtoneId: string): void {
 		return;
 	}
 
-	playSoundFile(soundPath);
+	// Get volume from settings
+	let volume = 100;
+	try {
+		const settingsRow = localDb.select().from(settings).get();
+		volume = settingsRow?.notificationVolume ?? 100;
+	} catch (error) {
+		console.warn("[ringtone] Failed to get volume setting:", error);
+	}
+
+	playSoundFile(soundPath, volume);
 }

--- a/apps/desktop/src/lib/trpc/routers/ringtone/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/ringtone/index.ts
@@ -106,7 +106,13 @@ function playSoundFile(soundPath: string, volume: number = 100): void {
 
 				if (error) {
 					// paplay failed, try aplay as fallback
-					// Note: aplay doesn't support volume control, so sound plays at system volume
+					// Note: aplay doesn't support volume control
+					// Respect volume=0 by not playing at all
+					if (volume === 0) {
+						currentSession = null;
+						return;
+					}
+					// For other volumes, play at system volume (can't be controlled)
 					currentSession.process = execFile("aplay", [soundPath], () => {
 						if (currentSession?.id === sessionId) {
 							currentSession = null;

--- a/apps/desktop/src/lib/trpc/routers/ringtone/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/ringtone/index.ts
@@ -79,8 +79,7 @@ function playSoundFile(soundPath: string, volume: number = 100): void {
 			},
 		);
 	} else if (process.platform === "win32") {
-		// Windows: Use powershell with WindowsMediaPlayer for volume control
-		const volumePercent = Math.round(volume);
+		// Windows: Media.SoundPlayer doesn't support volume control
 		currentSession.process = execFile(
 			"powershell",
 			[
@@ -93,8 +92,6 @@ function playSoundFile(soundPath: string, volume: number = 100): void {
 				}
 			},
 		);
-		// Note: Media.SoundPlayer doesn't support volume control
-		// For full volume control on Windows, we'd need Windows Media Player or similar
 	} else {
 		// Linux: paplay --volume accepts 0-65536 (65536 = 100%)
 		const paVolume = Math.round(volumeDecimal * 65536);
@@ -108,7 +105,8 @@ function playSoundFile(soundPath: string, volume: number = 100): void {
 				}
 
 				if (error) {
-					// paplay failed, try aplay as fallback (aplay doesn't have volume control)
+					// paplay failed, try aplay as fallback
+					// Note: aplay doesn't support volume control, so sound plays at system volume
 					currentSession.process = execFile("aplay", [soundPath], () => {
 						if (currentSession?.id === sessionId) {
 							currentSession = null;

--- a/apps/desktop/src/lib/trpc/routers/settings/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/index.ts
@@ -679,6 +679,26 @@ export const createSettingsRouter = () => {
 				return { success: true };
 			}),
 
+		getNotificationVolume: publicProcedure.query(() => {
+			const row = getSettings();
+			return row.notificationVolume ?? 100; // Default to 100%
+		}),
+
+		setNotificationVolume: publicProcedure
+			.input(z.object({ volume: z.number().min(0).max(100) }))
+			.mutation(({ input }) => {
+				localDb
+					.insert(settings)
+					.values({ id: 1, notificationVolume: input.volume })
+					.onConflictDoUpdate({
+						target: settings.id,
+						set: { notificationVolume: input.volume },
+					})
+					.run();
+
+				return { success: true };
+			}),
+
 		getFontSettings: publicProcedure.query(() => {
 			const row = getSettings();
 			return {

--- a/apps/desktop/src/main/lib/notification-sound.ts
+++ b/apps/desktop/src/main/lib/notification-sound.ts
@@ -53,24 +53,33 @@ function getSelectedRingtonePath(): string | null {
 
 /**
  * Plays a sound file using platform-specific commands
+ * @param soundPath Path to the sound file
+ * @param volume Volume level from 0-100
  */
-function playSoundFile(soundPath: string): void {
+function playSoundFile(soundPath: string, volume: number = 100): void {
 	if (!existsSync(soundPath)) {
 		console.warn(`[notification-sound] Sound file not found: ${soundPath}`);
 		return;
 	}
 
+	// Convert volume from 0-100 to platform-specific values
+	const volumeDecimal = volume / 100; // 0.0 to 1.0
+
 	if (process.platform === "darwin") {
-		execFile("afplay", [soundPath]);
+		// macOS: afplay -v accepts volume from 0.0 to higher (1.0 is normal)
+		execFile("afplay", ["-v", volumeDecimal.toString(), soundPath]);
 	} else if (process.platform === "win32") {
+		// Windows: Media.SoundPlayer doesn't support volume control
 		execFile("powershell", [
 			"-c",
 			`(New-Object Media.SoundPlayer '${soundPath}').PlaySync()`,
 		]);
 	} else {
-		// Linux - try common audio players
-		execFile("paplay", [soundPath], (error) => {
+		// Linux: paplay --volume accepts 0-65536 (65536 = 100%)
+		const paVolume = Math.round(volumeDecimal * 65536);
+		execFile("paplay", ["--volume", paVolume.toString(), soundPath], (error) => {
 			if (error) {
+				// paplay failed, try aplay as fallback (aplay doesn't have volume control)
 				execFile("aplay", [soundPath]);
 			}
 		});
@@ -94,5 +103,15 @@ export function playNotificationSound(): void {
 		return;
 	}
 
-	playSoundFile(soundPath);
+	// Get volume from settings
+	let volume = 100;
+	try {
+		const settingsRow = localDb.select().from(settings).get();
+		volume = settingsRow?.notificationVolume ?? 100;
+	} catch {
+		// Use default volume if there's an error
+		volume = 100;
+	}
+
+	playSoundFile(soundPath, volume);
 }

--- a/apps/desktop/src/main/lib/notification-sound.ts
+++ b/apps/desktop/src/main/lib/notification-sound.ts
@@ -77,12 +77,16 @@ function playSoundFile(soundPath: string, volume: number = 100): void {
 	} else {
 		// Linux: paplay --volume accepts 0-65536 (65536 = 100%)
 		const paVolume = Math.round(volumeDecimal * 65536);
-		execFile("paplay", ["--volume", paVolume.toString(), soundPath], (error) => {
-			if (error) {
-				// paplay failed, try aplay as fallback (aplay doesn't have volume control)
-				execFile("aplay", [soundPath]);
-			}
-		});
+		execFile(
+			"paplay",
+			["--volume", paVolume.toString(), soundPath],
+			(error) => {
+				if (error) {
+					// paplay failed, try aplay as fallback (aplay doesn't have volume control)
+					execFile("aplay", [soundPath]);
+				}
+			},
+		);
 	}
 }
 

--- a/apps/desktop/src/main/lib/notification-sound.ts
+++ b/apps/desktop/src/main/lib/notification-sound.ts
@@ -82,7 +82,13 @@ function playSoundFile(soundPath: string, volume: number = 100): void {
 			["--volume", paVolume.toString(), soundPath],
 			(error) => {
 				if (error) {
-					// paplay failed, try aplay as fallback (aplay doesn't have volume control)
+					// paplay failed, try aplay as fallback
+					// Note: aplay doesn't support volume control
+					// Respect volume=0 by not playing at all
+					if (volume === 0) {
+						return;
+					}
+					// For other volumes, play at system volume (can't be controlled)
 					execFile("aplay", [soundPath]);
 				}
 			},

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/RingtonesSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/RingtonesSettings.tsx
@@ -18,6 +18,7 @@ import {
 	SETTING_ITEM_ID,
 	type SettingItemId,
 } from "../../../utils/settings-search";
+import { VolumeSlider } from "./components/VolumeSlider";
 
 function formatDuration(seconds: number): string {
 	return `${seconds}s`;
@@ -317,6 +318,9 @@ export function RingtonesSettings({ visibleItems }: RingtonesSettingsProps) {
 						</div>
 					</div>
 				)}
+
+				{/* Volume Slider */}
+				{showNotification && !isMuted && <VolumeSlider />}
 
 				{/* Tip */}
 				{showNotification && !isMuted && (

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/RingtonesSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/RingtonesSettings.tsx
@@ -319,9 +319,6 @@ export function RingtonesSettings({ visibleItems }: RingtonesSettingsProps) {
 					</div>
 				)}
 
-				{/* Volume Slider */}
-				{showNotification && !isMuted && <VolumeSlider />}
-
 				{/* Tip */}
 				{showNotification && !isMuted && (
 					<div className="pt-6 border-t">
@@ -331,6 +328,9 @@ export function RingtonesSettings({ visibleItems }: RingtonesSettingsProps) {
 						</p>
 					</div>
 				)}
+
+				{/* Volume Slider */}
+				{showNotification && !isMuted && <VolumeSlider />}
 			</div>
 		</div>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/VolumeSlider/VolumeSlider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/VolumeSlider/VolumeSlider.tsx
@@ -1,0 +1,90 @@
+import { Label } from "@superset/ui/label";
+import { Slider } from "@superset/ui/slider";
+import { cn } from "@superset/ui/utils";
+import { useCallback, useEffect, useState } from "react";
+import { HiInformationCircle, HiSpeakerWave } from "react-icons/hi2";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+
+const isWindows = process.platform === "win32";
+
+export function VolumeSlider() {
+	const [localVolume, setLocalVolume] = useState<number | null>(null);
+
+	const utils = electronTrpc.useUtils();
+	const { data: volumeData, isLoading: volumeLoading } =
+		electronTrpc.settings.getNotificationVolume.useQuery();
+	const volume = localVolume ?? volumeData ?? 100;
+
+	const setVolume = electronTrpc.settings.setNotificationVolume.useMutation({
+		onMutate: async ({ volume }) => {
+			await utils.settings.getNotificationVolume.cancel();
+			const previous = utils.settings.getNotificationVolume.getData();
+			utils.settings.getNotificationVolume.setData(undefined, volume);
+			return { previous };
+		},
+		onError: (_err, _vars, context) => {
+			if (context?.previous !== undefined) {
+				utils.settings.getNotificationVolume.setData(
+					undefined,
+					context.previous,
+				);
+			}
+		},
+	});
+
+	// Sync local volume when server data changes
+	useEffect(() => {
+		if (volumeData !== undefined && localVolume === null) {
+			setLocalVolume(volumeData);
+		}
+	}, [volumeData, localVolume]);
+
+	const handleVolumeChange = useCallback((value: number[]) => {
+		const newVolume = value[0] ?? 100;
+		// Update local state immediately for smooth dragging
+		setLocalVolume(newVolume);
+	}, []);
+
+	const handleVolumeCommit = useCallback(
+		(value: number[]) => {
+			const newVolume = value[0] ?? 100;
+			// Persist to database when user releases the slider
+			setVolume.mutate({ volume: newVolume });
+		},
+		[setVolume],
+	);
+
+	return (
+		<div className="space-y-3">
+			<div className="flex items-center justify-between">
+				<Label htmlFor="notification-volume" className="text-sm font-medium">
+					Volume
+				</Label>
+				<span className="text-sm text-muted-foreground">{volume}%</span>
+			</div>
+			<div className="flex items-center gap-3">
+				<HiSpeakerWave className="h-5 w-5 text-muted-foreground flex-shrink-0" />
+				<Slider
+					id="notification-volume"
+					value={[volume]}
+					onValueChange={handleVolumeChange}
+					onValueCommit={handleVolumeCommit}
+					min={0}
+					max={100}
+					step={1}
+					disabled={volumeLoading}
+					className="flex-1"
+				/>
+			</div>
+			{isWindows && (
+				<div className="flex items-start gap-2 text-xs text-muted-foreground bg-muted/30 p-2 rounded">
+					<HiInformationCircle className="h-4 w-4 flex-shrink-0 mt-0.5" />
+					<p>
+						Volume control is not supported on Windows due to system
+						limitations. Notifications will play at system volume.
+					</p>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/VolumeSlider/VolumeSlider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/VolumeSlider/VolumeSlider.tsx
@@ -1,6 +1,5 @@
 import { Label } from "@superset/ui/label";
 import { Slider } from "@superset/ui/slider";
-import { cn } from "@superset/ui/utils";
 import { useCallback, useEffect, useState } from "react";
 import { HiInformationCircle, HiSpeakerWave } from "react-icons/hi2";
 import { electronTrpc } from "renderer/lib/electron-trpc";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/VolumeSlider/VolumeSlider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/VolumeSlider/VolumeSlider.tsx
@@ -29,6 +29,8 @@ export function VolumeSlider() {
 					context.previous,
 				);
 			}
+			// Reset local state to re-sync with server on next render
+			setLocalVolume(null);
 		},
 	});
 

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/VolumeSlider/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/ringtones/components/RingtonesSettings/components/VolumeSlider/index.ts
@@ -1,0 +1,1 @@
+export { VolumeSlider } from "./VolumeSlider";

--- a/bun.lock
+++ b/bun.lock
@@ -110,7 +110,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.4.4",
+      "version": "1.4.6",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.43",
         "@ai-sdk/openai": "3.0.36",

--- a/packages/local-db/drizzle/0038_add_notification_volume.sql
+++ b/packages/local-db/drizzle/0038_add_notification_volume.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `settings` ADD `notification_volume` integer;

--- a/packages/local-db/drizzle/meta/0038_snapshot.json
+++ b/packages/local-db/drizzle/meta/0038_snapshot.json
@@ -1,0 +1,1397 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c43b2731-0f03-46bb-9cc6-ae9d29f4cdd3",
+  "prevId": "c4874a39-c07e-4a7f-9f98-44e3c578dee0",
+  "tables": {
+    "browser_history": {
+      "name": "browser_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_visited_at": {
+          "name": "last_visited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visit_count": {
+          "name": "visit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "browser_history_url_unique": {
+          "name": "browser_history_url_unique",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "browser_history_url_idx": {
+          "name": "browser_history_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": false
+        },
+        "browser_history_last_visited_at_idx": {
+          "name": "browser_history_last_visited_at_idx",
+          "columns": [
+            "last_visited_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_organization_id_idx": {
+          "name": "organization_members_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_user_id_idx": {
+          "name": "organization_members_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_users_id_fk": {
+          "name": "organization_members_user_id_users_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_org": {
+          "name": "github_org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_clerk_org_id_unique": {
+          "name": "organizations_clerk_org_id_unique",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_idx": {
+          "name": "organizations_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "organizations_clerk_org_id_idx": {
+          "name": "organizations_clerk_org_id_idx",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "main_repo_path": {
+          "name": "main_repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_toast_dismissed": {
+          "name": "config_toast_dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_base_branch": {
+          "name": "workspace_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_owner": {
+          "name": "github_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hide_image": {
+          "name": "hide_image",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_project_id": {
+          "name": "neon_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_app": {
+          "name": "default_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_main_repo_path_idx": {
+          "name": "projects_main_repo_path_idx",
+          "columns": [
+            "main_repo_path"
+          ],
+          "isUnique": false
+        },
+        "projects_last_opened_at_idx": {
+          "name": "projects_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_active_workspace_id": {
+          "name": "last_active_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets": {
+          "name": "terminal_presets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets_initialized": {
+          "name": "terminal_presets_initialized",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_preset_overrides": {
+          "name": "agent_preset_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_custom_definitions": {
+          "name": "agent_custom_definitions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_ringtone_id": {
+          "name": "selected_ringtone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirm_on_quit": {
+          "name": "confirm_on_quit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_link_behavior": {
+          "name": "terminal_link_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "persist_terminal": {
+          "name": "persist_terminal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_apply_default_preset": {
+          "name": "auto_apply_default_preset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_sounds_muted": {
+          "name": "notification_sounds_muted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_volume": {
+          "name": "notification_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delete_local_branch": {
+          "name": "delete_local_branch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_open_mode": {
+          "name": "file_open_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_presets_bar": {
+          "name": "show_presets_bar",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_compact_terminal_add_button": {
+          "name": "use_compact_terminal_add_button",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_family": {
+          "name": "terminal_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_size": {
+          "name": "terminal_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_family": {
+          "name": "editor_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_size": {
+          "name": "editor_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_resource_monitor": {
+          "name": "show_resource_monitor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "open_links_in_app": {
+          "name": "open_links_in_app",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_editor": {
+          "name": "default_editor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_color": {
+          "name": "status_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_type": {
+          "name": "status_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_position": {
+          "name": "status_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "estimate": {
+          "name": "estimate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_provider": {
+          "name": "external_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tasks_slug_unique": {
+          "name": "tasks_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "tasks_slug_idx": {
+          "name": "tasks_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "tasks_organization_id_idx": {
+          "name": "tasks_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_assignee_id_idx": {
+          "name": "tasks_assignee_id_idx",
+          "columns": [
+            "assignee_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_status_idx": {
+          "name": "tasks_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "tasks_created_at_idx": {
+          "name": "tasks_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_organization_id_organizations_id_fk": {
+          "name": "tasks_organization_id_organizations_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_assignee_id_users_id_fk": {
+          "name": "tasks_assignee_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tasks_creator_id_users_id_fk": {
+          "name": "tasks_creator_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": true
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "users_clerk_id_idx": {
+          "name": "users_clerk_id_idx",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_sections": {
+      "name": "workspace_sections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_collapsed": {
+          "name": "is_collapsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspace_sections_project_id_idx": {
+          "name": "workspace_sections_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_sections_project_id_projects_id_fk": {
+          "name": "workspace_sections_project_id_projects_id_fk",
+          "tableFrom": "workspace_sections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_id": {
+          "name": "worktree_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_unread": {
+          "name": "is_unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_unnamed": {
+          "name": "is_unnamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "deleting_at": {
+          "name": "deleting_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "port_base": {
+          "name": "port_base",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_project_id_idx": {
+          "name": "workspaces_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_worktree_id_idx": {
+          "name": "workspaces_worktree_id_idx",
+          "columns": [
+            "worktree_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_last_opened_at_idx": {
+          "name": "workspaces_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        },
+        "workspaces_section_id_idx": {
+          "name": "workspaces_section_id_idx",
+          "columns": [
+            "section_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspaces_project_id_projects_id_fk": {
+          "name": "workspaces_project_id_projects_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_worktree_id_worktrees_id_fk": {
+          "name": "workspaces_worktree_id_worktrees_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "worktrees",
+          "columnsFrom": [
+            "worktree_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_section_id_workspace_sections_id_fk": {
+          "name": "workspaces_section_id_workspace_sections_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "workspace_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "worktrees": {
+      "name": "worktrees",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_status": {
+          "name": "git_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_status": {
+          "name": "github_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_superset": {
+          "name": "created_by_superset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "worktrees_project_id_idx": {
+          "name": "worktrees_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "worktrees_branch_idx": {
+          "name": "worktrees_branch_idx",
+          "columns": [
+            "branch"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "worktrees_project_id_projects_id_fk": {
+          "name": "worktrees_project_id_projects_id_fk",
+          "tableFrom": "worktrees",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/local-db/drizzle/meta/_journal.json
+++ b/packages/local-db/drizzle/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1773824260645,
       "tag": "0037_add_created_by_superset_to_worktrees",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "6",
+      "when": 1774940026537,
+      "tag": "0038_add_notification_volume",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/local-db/src/schema/schema.ts
+++ b/packages/local-db/src/schema/schema.ts
@@ -207,6 +207,7 @@ export const settings = sqliteTable("settings", {
 	notificationSoundsMuted: integer("notification_sounds_muted", {
 		mode: "boolean",
 	}),
+	notificationVolume: integer("notification_volume"), // 0-100 integer percentage
 	deleteLocalBranch: integer("delete_local_branch", { mode: "boolean" }),
 	fileOpenMode: text("file_open_mode").$type<FileOpenMode>(),
 	showPresetsBar: integer("show_presets_bar", { mode: "boolean" }),


### PR DESCRIPTION
## Summary
Adds a volume control slider to the notification settings page, allowing users to adjust the volume of notification sounds from 0-100%.

## Changes

### Database & Backend
- Added `notificationVolume` field to settings table (0-100 integer)
- Added tRPC endpoints:
  - `getNotificationVolume`: Returns volume (defaults to 100%)
  - `setNotificationVolume`: Saves volume with validation

### Sound Playback
Updated both preview and notification sound playback to respect volume:
- **macOS**: `afplay -v <0.0-1.0>` ✅ Full support
- **Linux**: `paplay --volume <0-65536>` ✅ Full support  
- **Windows**: ⚠️ Limited support - `Media.SoundPlayer` doesn't support volume control
  - UI shows warning banner explaining the limitation
  - Setting persists but doesn't affect playback

### UI
- Extracted `VolumeSlider` into separate component for better code organization
- Added speaker icon and percentage display
- Volume slider appears below ringtone selection when notifications are enabled
- Uses `onValueCommit` for persistence to prevent database spam during drag
- Smooth dragging with local state + optimistic updates

## Platform Support
- ✅ macOS: Full volume control
- ✅ Linux: Full volume control
- ⚠️ Windows: UI only (system limitation explained to users)

## Test Plan
- [x] Test volume adjustment on macOS
- [x] Test volume adjustment on Linux (if available)
- [x] Verify Windows shows info banner
- [x] Test ringtone preview at different volumes
- [x] Test actual notification sounds at different volumes
- [x] Verify smooth dragging (no jank or database spam)
- [x] Verify setting persists across app restarts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a volume slider for notification sounds (0–100%) and applies it to previews and notifications on macOS/Linux; Windows plays at system volume with a limitation notice. Linux fallback now mutes at 0%.

- **New Features**
  - Volume slider with % display in Notification settings.
  - Persists via `notification_volume` and `getNotificationVolume`/`setNotificationVolume` (0–100 validation).
  - Playback honors volume: macOS (`afplay -v`), Linux (`paplay --volume`, `aplay` fallback respects 0% by not playing; otherwise uses system volume), Windows shows info banner and uses system volume.
  - Smooth UX with local state and optimistic updates; save on `onValueCommit`.

- **Refactors**
  - Removed unused imports/vars and added clarifying comments; no behavior change.
  - Moved the help tip above the slider for better visual flow.

<sup>Written for commit 01c2005852abea309368405a96cb8682231d9b68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a notification volume control slider in Ringtone Settings, allowing users to adjust notification sound volume from 0 to 100%.
  * Volume control is supported on macOS and Linux. Windows users should adjust system volume settings to control notification sound volume.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->