### PR TITLE
feat(desktop): add resolve comment buttons to review tab

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/git-status.ts
@@ -19,9 +19,11 @@ import {
 	refreshDefaultBranch,
 } from "../utils/git";
 import {
+	clearGitHubCachesForWorktree,
 	fetchGitHubPRComments,
 	fetchGitHubPRStatus,
 	type PullRequestCommentsTarget,
+	resolveReviewThread,
 } from "../utils/github";
 
 const gitHubPRCommentsInputSchema = z.object({
@@ -230,6 +232,38 @@ export const createGitStatusProcedures = () => {
 						githubStatus: cachedGitHubStatus,
 					}),
 				});
+			}),
+
+		resolveReviewThread: publicProcedure
+			.input(
+				z.object({
+					workspaceId: z.string(),
+					threadId: z.string(),
+					resolve: z.boolean(),
+				}),
+			)
+			.mutation(async ({ input }) => {
+				const workspace = getWorkspace(input.workspaceId);
+				if (!workspace) {
+					throw new Error(`Workspace ${input.workspaceId} not found`);
+				}
+
+				const worktree = workspace.worktreeId
+					? getWorktree(workspace.worktreeId)
+					: null;
+				if (!worktree) {
+					throw new Error(
+						`Worktree for workspace ${input.workspaceId} not found`,
+					);
+				}
+
+				await resolveReviewThread({
+					worktreePath: worktree.path,
+					threadId: input.threadId,
+					resolve: input.resolve,
+				});
+
+				clearGitHubCachesForWorktree(worktree.path);
 			}),
 
 		getWorktreeInfo: publicProcedure

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/comments.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/comments.ts
@@ -113,9 +113,11 @@ function getReviewThreadCommentId(
 function parseReviewThreadCommentNode({
 	comment,
 	isResolved,
+	threadId,
 }: {
 	comment: ReviewThreadCommentNode;
 	isResolved: boolean;
+	threadId?: string;
 }): PullRequestComment | null {
 	const id = getReviewThreadCommentId(comment);
 	const body = comment.body?.trim();
@@ -136,6 +138,7 @@ function parseReviewThreadCommentNode({
 		path: comment.path,
 		line: comment.line ?? comment.originalLine ?? undefined,
 		isResolved,
+		...(threadId ? { threadId } : {}),
 	};
 }
 
@@ -164,9 +167,11 @@ export function parsePaginatedApiArray(stdout: string): unknown[] {
 export function parseReviewThreadCommentsConnection({
 	comments,
 	isResolved,
+	threadId,
 }: {
 	comments: unknown;
 	isResolved: boolean;
+	threadId?: string;
 }): PullRequestComment[] {
 	const parsed = GHReviewThreadCommentsConnectionSchema.safeParse(comments);
 	if (!parsed.success) {
@@ -182,6 +187,7 @@ export function parseReviewThreadCommentsConnection({
 			const parsedComment = parseReviewThreadCommentNode({
 				comment,
 				isResolved,
+				threadId,
 			});
 			return parsedComment ? [parsedComment] : [];
 		}) ?? []
@@ -201,6 +207,7 @@ export function parseReviewThreadCommentsResponse(
 			return parseReviewThreadCommentsConnection({
 				comments: result.data.comments,
 				isResolved: result.data.isResolved === true,
+				threadId: result.data.id,
 			});
 		}),
 	);
@@ -252,6 +259,48 @@ export function mergePullRequestComments(
 	}
 
 	return sortPullRequestComments([...commentsById.values()]);
+}
+
+const RESOLVE_REVIEW_THREAD_MUTATION = `
+mutation ResolveReviewThread($threadId: ID!) {
+	resolveReviewThread(input: {threadId: $threadId}) {
+		thread {
+			id
+			isResolved
+		}
+	}
+}
+`;
+
+const UNRESOLVE_REVIEW_THREAD_MUTATION = `
+mutation UnresolveReviewThread($threadId: ID!) {
+	unresolveReviewThread(input: {threadId: $threadId}) {
+		thread {
+			id
+			isResolved
+		}
+	}
+}
+`;
+
+export async function resolveReviewThread({
+	worktreePath,
+	threadId,
+	resolve,
+}: {
+	worktreePath: string;
+	threadId: string;
+	resolve: boolean;
+}): Promise<void> {
+	const mutation = resolve
+		? RESOLVE_REVIEW_THREAD_MUTATION
+		: UNRESOLVE_REVIEW_THREAD_MUTATION;
+
+	await execWithShellEnv(
+		"gh",
+		["api", "graphql", "-f", `query=${mutation}`, "-F", `threadId=${threadId}`],
+		{ cwd: worktreePath },
+	);
 }
 
 async function fetchPaginatedCommentsEndpoint(
@@ -360,6 +409,7 @@ async function fetchAdditionalReviewThreadCommentsForThread({
 			...parseReviewThreadCommentsConnection({
 				comments,
 				isResolved,
+				threadId,
 			}),
 		);
 		afterCursor =
@@ -453,6 +503,7 @@ async function fetchReviewThreadCommentsForPullRequest(
 				...parseReviewThreadCommentsConnection({
 					comments: thread.comments,
 					isResolved,
+					threadId: thread.id,
 				}),
 			);
 

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/comments.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/comments.ts
@@ -296,11 +296,19 @@ export async function resolveReviewThread({
 		? RESOLVE_REVIEW_THREAD_MUTATION
 		: UNRESOLVE_REVIEW_THREAD_MUTATION;
 
-	await execWithShellEnv(
+	const { stdout } = await execWithShellEnv(
 		"gh",
 		["api", "graphql", "-f", `query=${mutation}`, "-F", `threadId=${threadId}`],
 		{ cwd: worktreePath },
 	);
+
+	const json = JSON.parse(stdout.trim());
+	if (Array.isArray(json.errors) && json.errors.length > 0) {
+		const msg = json.errors
+			.map((e: { message?: string }) => e.message)
+			.join("; ");
+		throw new Error(msg || "GraphQL mutation failed");
+	}
 }
 
 async function fetchPaginatedCommentsEndpoint(

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/github.ts
@@ -14,7 +14,7 @@ import {
 	readCachedGitHubStatus,
 	readCachedPullRequestComments,
 } from "./cache";
-import { fetchPullRequestComments } from "./comments";
+import { fetchPullRequestComments, resolveReviewThread } from "./comments";
 import { getPRForBranch } from "./pr-resolution";
 import { extractNwoFromUrl, getRepoContext } from "./repo-context";
 import {
@@ -28,7 +28,7 @@ export interface PullRequestCommentsTarget {
 	repoContext: Pick<RepoContext, "repoUrl" | "upstreamUrl" | "isFork">;
 }
 
-export { clearGitHubCachesForWorktree };
+export { clearGitHubCachesForWorktree, resolveReviewThread };
 
 function getPullRequestCommentsRepoNameWithOwner(
 	target: PullRequestCommentsTarget,

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/index.ts
@@ -3,6 +3,7 @@ export {
 	clearGitHubCachesForWorktree,
 	fetchGitHubPRComments,
 	fetchGitHubPRStatus,
+	resolveReviewThread,
 } from "./github";
 export { getPRForBranch } from "./pr-resolution";
 export {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
@@ -822,6 +822,8 @@ export function ChangesView({
 						comments={githubComments}
 						isLoading={isGitHubStatusLoading}
 						isCommentsLoading={isGitHubCommentsLoading}
+						workspaceId={workspaceId}
+						onCommentsChange={refetchGitHubComments}
 					/>
 				</TabsContent>
 			</Tabs>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/ReviewPanel.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/ReviewPanel.tsx
@@ -280,22 +280,11 @@ export function ReviewPanel({
 							{content}
 						</div>
 					)}
-					<div className="absolute right-1 top-1 flex flex-col gap-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
-						{comment.url ? (
-							<a
-								href={comment.url}
-								target="_blank"
-								rel="noopener noreferrer"
-								className="inline-flex size-4 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-								aria-label="Open comment on GitHub"
-							>
-								<LuArrowUpRight className="size-3" />
-							</a>
-						) : null}
+					<div className="absolute right-0.5 top-0.5 flex items-center gap-0.5 rounded-sm bg-background/90 px-0.5 py-0.5 shadow-sm opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
 						{comment.threadId && workspaceId ? (
 							<button
 								type="button"
-								className="inline-flex size-4 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+								className="inline-flex size-5 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
 								onClick={(event) => {
 									event.preventDefault();
 									event.stopPropagation();
@@ -317,7 +306,7 @@ export function ReviewPanel({
 						) : null}
 						<button
 							type="button"
-							className="inline-flex size-4 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+							className="inline-flex size-5 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
 							onClick={(event) => {
 								event.preventDefault();
 								event.stopPropagation();
@@ -331,6 +320,17 @@ export function ReviewPanel({
 								<LuCopy className="size-3" />
 							)}
 						</button>
+						{comment.url ? (
+							<a
+								href={comment.url}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="inline-flex size-5 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+								aria-label="Open comment on GitHub"
+							>
+								<LuArrowUpRight className="size-3" />
+							</a>
+						) : null}
 					</div>
 				</div>
 			);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/ReviewPanel.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/ReviewPanel.tsx
@@ -9,7 +9,14 @@ import { Skeleton } from "@superset/ui/skeleton";
 import { toast } from "@superset/ui/sonner";
 import { cn } from "@superset/ui/utils";
 import { useEffect, useRef, useState } from "react";
-import { LuArrowUpRight, LuCheck, LuCopy } from "react-icons/lu";
+import {
+	LuArrowUpRight,
+	LuCheck,
+	LuCheckCheck,
+	LuCopy,
+	LuLoaderCircle,
+	LuUndo2,
+} from "react-icons/lu";
 import { VscChevronRight } from "react-icons/vsc";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { PRIcon } from "renderer/screens/main/components/PRIcon";
@@ -34,6 +41,8 @@ interface ReviewPanelProps {
 	comments?: PullRequestComment[];
 	isLoading?: boolean;
 	isCommentsLoading?: boolean;
+	workspaceId?: string;
+	onCommentsChange?: () => void;
 }
 
 export function ReviewPanel({
@@ -41,16 +50,23 @@ export function ReviewPanel({
 	comments = [],
 	isLoading = false,
 	isCommentsLoading = false,
+	workspaceId,
+	onCommentsChange,
 }: ReviewPanelProps) {
 	const [checksOpen, setChecksOpen] = useState(true);
 	const [commentsOpen, setCommentsOpen] = useState(true);
 	const [resolvedCommentsGroupOpen, setResolvedCommentsGroupOpen] =
 		useState(false);
 	const [copiedActionKey, setCopiedActionKey] = useState<string | null>(null);
+	const [resolvingThreadIds, setResolvingThreadIds] = useState<Set<string>>(
+		new Set(),
+	);
 	const copiedActionResetTimeoutRef = useRef<ReturnType<
 		typeof setTimeout
 	> | null>(null);
 	const copyToClipboardMutation = electronTrpc.external.copyText.useMutation();
+	const resolveThreadMutation =
+		electronTrpc.workspaces.resolveReviewThread.useMutation();
 
 	useEffect(() => {
 		return () => {
@@ -98,6 +114,38 @@ export function ReviewPanel({
 		});
 	};
 
+	const handleToggleResolve = (comment: PullRequestComment) => {
+		if (!workspaceId || !comment.threadId) return;
+
+		setResolvingThreadIds((prev) => new Set(prev).add(comment.threadId!));
+		resolveThreadMutation.mutate(
+			{
+				workspaceId,
+				threadId: comment.threadId,
+				resolve: !comment.isResolved,
+			},
+			{
+				onSuccess: () => {
+					onCommentsChange?.();
+				},
+				onError: (error) => {
+					const message =
+						error instanceof Error ? error.message : "Unknown error";
+					toast.error(
+						`Failed to ${comment.isResolved ? "unresolve" : "resolve"} thread: ${message}`,
+					);
+				},
+				onSettled: () => {
+					setResolvingThreadIds((prev) => {
+						const next = new Set(prev);
+						next.delete(comment.threadId!);
+						return next;
+					});
+				},
+			},
+		);
+	};
+
 	if (isLoading && !pr) {
 		return (
 			<div className="flex h-full items-center justify-center text-sm text-muted-foreground">
@@ -141,6 +189,39 @@ export function ReviewPanel({
 			actionKey: ALL_COMMENTS_COPY_ACTION_KEY,
 			errorLabel: "Failed to copy comments",
 		});
+	};
+
+	const uniqueResolvableThreadIds = [
+		...new Set(
+			activeComments
+				.map((c) => c.threadId)
+				.filter((id): id is string => !!id),
+		),
+	];
+	const isResolvingAll = resolvingThreadIds.size > 0;
+
+	const handleResolveAll = async () => {
+		if (!workspaceId || uniqueResolvableThreadIds.length === 0) return;
+
+		setResolvingThreadIds(new Set(uniqueResolvableThreadIds));
+
+		try {
+			await Promise.all(
+				uniqueResolvableThreadIds.map((threadId) =>
+					resolveThreadMutation.mutateAsync({
+						workspaceId,
+						threadId,
+						resolve: true,
+					}),
+				),
+			);
+			onCommentsChange?.();
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			toast.error(`Failed to resolve all threads: ${message}`);
+		} finally {
+			setResolvingThreadIds(new Set());
+		}
 	};
 
 	const renderCommentList = (list: PullRequestComment[]) =>
@@ -210,6 +291,29 @@ export function ReviewPanel({
 							>
 								<LuArrowUpRight className="size-3" />
 							</a>
+						) : null}
+						{comment.threadId && workspaceId ? (
+							<button
+								type="button"
+								className="inline-flex size-4 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+								onClick={(event) => {
+									event.preventDefault();
+									event.stopPropagation();
+									handleToggleResolve(comment);
+								}}
+								disabled={resolvingThreadIds.has(comment.threadId)}
+								aria-label={
+									comment.isResolved ? "Unresolve thread" : "Resolve thread"
+								}
+							>
+								{resolvingThreadIds.has(comment.threadId) ? (
+									<LuLoaderCircle className="size-3 animate-spin" />
+								) : comment.isResolved ? (
+									<LuUndo2 className="size-3" />
+								) : (
+									<LuCheckCheck className="size-3" />
+								)}
+							</button>
 						) : null}
 						<button
 							type="button"
@@ -394,18 +498,35 @@ export function ReviewPanel({
 						</span>
 					</CollapsibleTrigger>
 					{activeComments.length > 0 && (
-						<button
-							type="button"
-							className="mr-1.5 shrink-0 flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-[10px] text-muted-foreground transition-colors hover:bg-accent/30 hover:text-foreground"
-							onClick={handleCopyCommentsList}
-						>
-							{copiedActionKey === ALL_COMMENTS_COPY_ACTION_KEY ? (
-								<LuCheck className="size-3" />
-							) : (
-								<LuCopy className="size-3" />
+						<div className="mr-1.5 flex items-center gap-1">
+							{uniqueResolvableThreadIds.length > 0 && workspaceId && (
+								<button
+									type="button"
+									className="shrink-0 flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-[10px] text-muted-foreground transition-colors hover:bg-accent/30 hover:text-foreground disabled:opacity-50"
+									onClick={() => void handleResolveAll()}
+									disabled={isResolvingAll}
+								>
+									{isResolvingAll ? (
+										<LuLoaderCircle className="size-3 animate-spin" />
+									) : (
+										<LuCheckCheck className="size-3" />
+									)}
+									<span>Resolve all</span>
+								</button>
 							)}
-							<span>{copyAllCommentsLabel}</span>
-						</button>
+							<button
+								type="button"
+								className="shrink-0 flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-[10px] text-muted-foreground transition-colors hover:bg-accent/30 hover:text-foreground"
+								onClick={handleCopyCommentsList}
+							>
+								{copiedActionKey === ALL_COMMENTS_COPY_ACTION_KEY ? (
+									<LuCheck className="size-3" />
+								) : (
+									<LuCopy className="size-3" />
+								)}
+								<span>{copyAllCommentsLabel}</span>
+							</button>
+						</div>
 					)}
 				</div>
 				<CollapsibleContent className="px-0.5 pb-1 min-w-0 overflow-hidden">

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/ReviewPanel.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/ReviewPanel.tsx
@@ -61,6 +61,7 @@ export function ReviewPanel({
 	const [resolvingThreadIds, setResolvingThreadIds] = useState<Set<string>>(
 		new Set(),
 	);
+	const [isResolvingAll, setIsResolvingAll] = useState(false);
 	const copiedActionResetTimeoutRef = useRef<ReturnType<
 		typeof setTimeout
 	> | null>(null);
@@ -115,13 +116,14 @@ export function ReviewPanel({
 	};
 
 	const handleToggleResolve = (comment: PullRequestComment) => {
-		if (!workspaceId || !comment.threadId) return;
+		const threadId = comment.threadId;
+		if (!workspaceId || !threadId) return;
 
-		setResolvingThreadIds((prev) => new Set(prev).add(comment.threadId!));
+		setResolvingThreadIds((prev) => new Set(prev).add(threadId));
 		resolveThreadMutation.mutate(
 			{
 				workspaceId,
-				threadId: comment.threadId,
+				threadId,
 				resolve: !comment.isResolved,
 			},
 			{
@@ -138,7 +140,7 @@ export function ReviewPanel({
 				onSettled: () => {
 					setResolvingThreadIds((prev) => {
 						const next = new Set(prev);
-						next.delete(comment.threadId!);
+						next.delete(threadId);
 						return next;
 					});
 				},
@@ -193,21 +195,19 @@ export function ReviewPanel({
 
 	const uniqueResolvableThreadIds = [
 		...new Set(
-			activeComments
-				.map((c) => c.threadId)
-				.filter((id): id is string => !!id),
+			activeComments.map((c) => c.threadId).filter((id): id is string => !!id),
 		),
 	];
-	const isResolvingAll = resolvingThreadIds.size > 0;
-
 	const handleResolveAll = async () => {
 		if (!workspaceId || uniqueResolvableThreadIds.length === 0) return;
 
-		setResolvingThreadIds(new Set(uniqueResolvableThreadIds));
+		const batchIds = uniqueResolvableThreadIds;
+		setIsResolvingAll(true);
+		setResolvingThreadIds((prev) => new Set([...prev, ...batchIds]));
 
 		try {
-			await Promise.all(
-				uniqueResolvableThreadIds.map((threadId) =>
+			const results = await Promise.allSettled(
+				batchIds.map((threadId) =>
 					resolveThreadMutation.mutateAsync({
 						workspaceId,
 						threadId,
@@ -215,12 +215,24 @@ export function ReviewPanel({
 					}),
 				),
 			);
-			onCommentsChange?.();
-		} catch (error) {
-			const message = error instanceof Error ? error.message : "Unknown error";
-			toast.error(`Failed to mark all as done: ${message}`);
+			const failed = results.filter((r) => r.status === "rejected");
+			if (results.some((r) => r.status === "fulfilled")) {
+				onCommentsChange?.();
+			}
+			if (failed.length > 0) {
+				toast.error(
+					`Failed to mark ${failed.length} thread${failed.length === 1 ? "" : "s"} as done`,
+				);
+			}
 		} finally {
-			setResolvingThreadIds(new Set());
+			setIsResolvingAll(false);
+			setResolvingThreadIds((prev) => {
+				const next = new Set(prev);
+				for (const id of batchIds) {
+					next.delete(id);
+				}
+				return next;
+			});
 		}
 	};
 
@@ -291,9 +303,7 @@ export function ReviewPanel({
 									handleToggleResolve(comment);
 								}}
 								disabled={resolvingThreadIds.has(comment.threadId)}
-								aria-label={
-									comment.isResolved ? "Undo done" : "Mark as done"
-								}
+								aria-label={comment.isResolved ? "Undo done" : "Mark as done"}
 							>
 								{resolvingThreadIds.has(comment.threadId) ? (
 									<LuLoaderCircle className="size-3 animate-spin" />

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/ReviewPanel.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/ReviewPanel/ReviewPanel.tsx
@@ -132,7 +132,7 @@ export function ReviewPanel({
 					const message =
 						error instanceof Error ? error.message : "Unknown error";
 					toast.error(
-						`Failed to ${comment.isResolved ? "unresolve" : "resolve"} thread: ${message}`,
+						`Failed to ${comment.isResolved ? "undo" : "mark as done"}: ${message}`,
 					);
 				},
 				onSettled: () => {
@@ -218,7 +218,7 @@ export function ReviewPanel({
 			onCommentsChange?.();
 		} catch (error) {
 			const message = error instanceof Error ? error.message : "Unknown error";
-			toast.error(`Failed to resolve all threads: ${message}`);
+			toast.error(`Failed to mark all as done: ${message}`);
 		} finally {
 			setResolvingThreadIds(new Set());
 		}
@@ -292,7 +292,7 @@ export function ReviewPanel({
 								}}
 								disabled={resolvingThreadIds.has(comment.threadId)}
 								aria-label={
-									comment.isResolved ? "Unresolve thread" : "Resolve thread"
+									comment.isResolved ? "Undo done" : "Mark as done"
 								}
 							>
 								{resolvingThreadIds.has(comment.threadId) ? (
@@ -511,7 +511,7 @@ export function ReviewPanel({
 									) : (
 										<LuCheckCheck className="size-3" />
 									)}
-									<span>Resolve all</span>
+									<span>Mark all done</span>
 								</button>
 							)}
 							<button

--- a/bun.lock
+++ b/bun.lock
@@ -110,7 +110,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.4.4",
+      "version": "1.4.6",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.43",
         "@ai-sdk/openai": "3.0.36",

--- a/packages/local-db/src/schema/zod.ts
+++ b/packages/local-db/src/schema/zod.ts
@@ -36,6 +36,7 @@ export const pullRequestCommentSchema = z.object({
 	path: z.string().optional(),
 	line: z.number().optional(),
 	isResolved: z.boolean().optional(),
+	threadId: z.string().optional(),
 });
 
 export type PullRequestComment = z.infer<typeof pullRequestCommentSchema>;


### PR DESCRIPTION
## Summary
- Add per-comment resolve/unresolve button (checkcheck icon) on hover in the review tab comment list, using GitHub's `resolveReviewThread`/`unresolveReviewThread` GraphQL mutations
- Add "Resolve all" button in the comments section header to batch-resolve all active review threads
- Thread IDs are now propagated from the GitHub API response through to `PullRequestComment` so the UI can target individual threads
- Comments cache is invalidated after resolve/unresolve to reflect the updated state

## Test plan
- [ ] Open a PR with unresolved review comments, verify the resolve button (double-check icon) appears on hover
- [ ] Click resolve on a single comment, verify it moves to the "Resolved" group
- [ ] Click "Resolve all" in the comments header, verify all review threads are resolved
- [ ] In the "Resolved" group, hover a comment and verify the unresolve button (undo icon) appears
- [ ] Click unresolve, verify the comment moves back to active
- [ ] Verify conversation comments (non-thread) do not show the resolve button

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds “Mark as done” controls to the Review tab to resolve/unresolve GitHub review threads from the sidebar, including a “Mark all done” action. Keeps the comments list in sync by clearing caches and refetching after changes.

- **New Features**
  - Per-comment “Mark as done”/“Undo done” on hover with spinner and disabled state.
  - “Mark all done” button to resolve all active threads at once.
  - Uses GitHub GraphQL `resolveReviewThread`/`unresolveReviewThread` via `gh api`; stores `threadId` on `PullRequestComment` for precise targeting.
  - Adds `workspaces.resolveReviewThread` TRPC mutation and invalidates caches to refresh comments; controls show only for threaded review comments.

- **Bug Fixes**
  - Prevented hover action buttons from overlapping the age text by switching to a horizontal row with a subtle background; reordered to mark as done, copy, then link.
  - More robust bulk resolve: uses `Promise.allSettled`, parses GraphQL errors from `gh api`, and only clears batch thread IDs so per-comment toggles aren’t affected.

<sup>Written for commit 416d4b2298e7f03b2b0625e7600b5be4d3553fcf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resolve/unresolve individual GitHub review threads from the Review panel (per-thread button with loading state).
  * "Mark all done" bulk action to resolve all review threads with progress UI.
  * Review panel triggers PR comment refresh after resolve changes.

* **Bug Fixes / Improvements**
  * Comment data now includes thread identifiers so actions map to the correct review threads.
  * Per-comment action UI made more discoverable (always-present).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->