### PR TITLE
fix: eliminate scroll/width flicker when switching terminal tabs

### DIFF
--- a/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts
+++ b/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts
@@ -79,6 +79,40 @@ export class DaemonTerminalManager extends EventEmitter {
 		this.killedSessionTombstones.delete(paneId);
 	}
 
+	/**
+	 * Tear down all sessions and daemon registrations on disconnect/error.
+	 * Covers both locally-tracked sessions and daemon-only pane IDs that
+	 * were seeded by reconcileOnStartup() but never locally attached.
+	 */
+	private teardownAllSessions(reason: string): void {
+		// Collect daemon-only pane IDs before clearing
+		const daemonOnlyPaneIds = new Set<string>();
+		for (const paneId of this.daemonAliveSessionIds) {
+			if (!this.sessions.has(paneId)) {
+				daemonOnlyPaneIds.add(paneId);
+			}
+		}
+
+		this.daemonAliveSessionIds.clear();
+		this.daemonSessionIdsHydrated = false;
+
+		// Tear down locally-tracked sessions
+		for (const [paneId, session] of this.sessions.entries()) {
+			if (session.isAlive) {
+				session.isAlive = false;
+				session.pid = null;
+				portManager.unregisterDaemonSession(paneId);
+				this.historyManager.closeHistoryWriter(paneId);
+				this.emit(`disconnect:${paneId}`, reason);
+			}
+		}
+
+		// Unregister daemon-only panes (seeded by reconcileOnStartup)
+		for (const paneId of daemonOnlyPaneIds) {
+			portManager.unregisterDaemonSession(paneId);
+		}
+	}
+
 	private initializeClient(): void {
 		this.client = getTerminalHostClient();
 		this.setupClientEventHandlers();
@@ -238,35 +272,12 @@ export class DaemonTerminalManager extends EventEmitter {
 			track("terminal_daemon_disconnected", {
 				active_session_count: activeSessionCount,
 			});
-			this.daemonAliveSessionIds.clear();
-			this.daemonSessionIdsHydrated = false;
-			for (const [paneId, session] of this.sessions.entries()) {
-				if (session.isAlive) {
-					session.isAlive = false;
-					session.pid = null;
-					portManager.unregisterDaemonSession(paneId);
-					this.historyManager.closeHistoryWriter(paneId);
-					this.emit(
-						`disconnect:${paneId}`,
-						"Connection to terminal daemon lost",
-					);
-				}
-			}
+			this.teardownAllSessions("Connection to terminal daemon lost");
 		});
 
 		this.client.on("error", (error: Error) => {
 			console.error("[DaemonTerminalManager] Client error:", error.message);
-			this.daemonAliveSessionIds.clear();
-			this.daemonSessionIdsHydrated = false;
-			for (const [paneId, session] of this.sessions.entries()) {
-				if (session.isAlive) {
-					session.isAlive = false;
-					session.pid = null;
-					portManager.unregisterDaemonSession(paneId);
-					this.historyManager.closeHistoryWriter(paneId);
-					this.emit(`disconnect:${paneId}`, error.message);
-				}
-			}
+			this.teardownAllSessions(error.message);
 		});
 
 		this.client.on(

--- a/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts
+++ b/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts
@@ -98,11 +98,12 @@ export class DaemonTerminalManager extends EventEmitter {
 
 		// Tear down locally-tracked sessions
 		for (const [paneId, session] of this.sessions.entries()) {
-			if (session.isAlive) {
-				session.isAlive = false;
-				session.pid = null;
-				portManager.unregisterDaemonSession(paneId);
-				this.historyManager.closeHistoryWriter(paneId);
+			const wasAlive = session.isAlive;
+			session.isAlive = false;
+			session.pid = null;
+			portManager.unregisterDaemonSession(paneId);
+			this.historyManager.closeHistoryWriter(paneId);
+			if (wasAlive) {
 				this.emit(`disconnect:${paneId}`, reason);
 			}
 		}

--- a/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts
+++ b/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts
@@ -242,6 +242,10 @@ export class DaemonTerminalManager extends EventEmitter {
 			this.daemonSessionIdsHydrated = false;
 			for (const [paneId, session] of this.sessions.entries()) {
 				if (session.isAlive) {
+					session.isAlive = false;
+					session.pid = null;
+					portManager.unregisterDaemonSession(paneId);
+					this.historyManager.closeHistoryWriter(paneId);
 					this.emit(
 						`disconnect:${paneId}`,
 						"Connection to terminal daemon lost",
@@ -256,6 +260,10 @@ export class DaemonTerminalManager extends EventEmitter {
 			this.daemonSessionIdsHydrated = false;
 			for (const [paneId, session] of this.sessions.entries()) {
 				if (session.isAlive) {
+					session.isAlive = false;
+					session.pid = null;
+					portManager.unregisterDaemonSession(paneId);
+					this.historyManager.closeHistoryWriter(paneId);
 					this.emit(`disconnect:${paneId}`, error.message);
 				}
 			}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalColdRestore.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalColdRestore.ts
@@ -205,12 +205,6 @@ export function useTerminalColdRestore({
 			},
 			{
 				onSuccess: (result: CreateOrAttachResult) => {
-					// Drop all events queued during reconnection — they belong to
-					// the dead session or the reconnection window and cannot be
-					// reliably attributed to the new attach.  The snapshot in
-					// `result` already contains the authoritative initial content.
-					pendingEventsRef.current = [];
-
 					pendingInitialStateRef.current = result;
 					maybeApplyInitialState();
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalColdRestore.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalColdRestore.ts
@@ -205,6 +205,12 @@ export function useTerminalColdRestore({
 			},
 			{
 				onSuccess: (result: CreateOrAttachResult) => {
+					// Drop stale error/disconnect events queued during reconnection
+					// to prevent them from triggering a spurious retry cycle
+					pendingEventsRef.current = pendingEventsRef.current.filter(
+						(e) => e.type === "data",
+					);
+
 					pendingInitialStateRef.current = result;
 					maybeApplyInitialState();
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalColdRestore.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalColdRestore.ts
@@ -205,11 +205,11 @@ export function useTerminalColdRestore({
 			},
 			{
 				onSuccess: (result: CreateOrAttachResult) => {
-					// Drop stale error/disconnect events queued during reconnection
-					// to prevent them from triggering a spurious retry cycle
-					pendingEventsRef.current = pendingEventsRef.current.filter(
-						(e) => e.type === "data",
-					);
+					// Drop all events queued during reconnection — they belong to
+					// the dead session or the reconnection window and cannot be
+					// reliably attributed to the new attach.  The snapshot in
+					// `result` already contains the authoritative initial content.
+					pendingEventsRef.current = [];
 
 					pendingInitialStateRef.current = result;
 					maybeApplyInitialState();

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
@@ -504,6 +504,10 @@ export function useTerminalLifecycle({
 			restartCommand: workspaceRunRestartCommand,
 		} = resolveWorkspaceRunAttachMode(paneId, defaultRestartCommandRef.current);
 
+		// Fit before attach so createOrAttach sends correct cols/rows
+		// to the daemon — prevents snapshot being captured at wrong dimensions
+		fitAddon.fit();
+
 		const cancelInitialAttach = scheduleTerminalAttach({
 			paneId,
 			priority: isFocusedRef.current ? 0 : 1,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalRestore.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalRestore.ts
@@ -120,13 +120,37 @@ export function useTerminalRestore({
 		++restoreSequenceRef.current;
 		const restoreSequence = restoreSequenceRef.current;
 		try {
+			const termEl = xterm.element?.parentElement ?? xterm.element;
+			const isReattach = !result.isNew;
+
+			// Hide reattached terminals during snapshot restore to prevent
+			// visible scroll/width flicker while tmux repaints at new dimensions
+			if (termEl && isReattach) {
+				termEl.style.opacity = "0";
+				termEl.style.transition = "none";
+			}
+
+			// Fit BEFORE writing so createOrAttach sends correct cols/rows
+			fitAddon.fit();
+
 			const scheduleFitAndScroll = () => {
-				requestAnimationFrame(() => {
+				const reveal = () => {
 					if (xtermRef.current !== xterm) return;
 					if (restoreSequenceRef.current !== restoreSequence) return;
 					fitAddon.fit();
 					scrollToBottom(xterm);
-				});
+					if (termEl && termEl.isConnected) {
+						termEl.style.opacity = "";
+						termEl.style.transition = "";
+					}
+				};
+				// Reattach: delay reveal 250ms to let TUI apps (tmux)
+				// repaint at correct dimensions after SIGWINCH
+				if (isReattach) {
+					setTimeout(reveal, 250);
+				} else {
+					requestAnimationFrame(reveal);
+				}
 			};
 
 			// Canonical initial content: prefer snapshot (daemon mode) over scrollback

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalRestore.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalRestore.ts
@@ -119,8 +119,14 @@ export function useTerminalRestore({
 		pendingInitialStateRef.current = null;
 		++restoreSequenceRef.current;
 		const restoreSequence = restoreSequenceRef.current;
+		const termEl = xterm.element?.parentElement ?? xterm.element;
+		const restoreVisibility = () => {
+			if (termEl && termEl.isConnected) {
+				termEl.style.opacity = "";
+				termEl.style.transition = "";
+			}
+		};
 		try {
-			const termEl = xterm.element?.parentElement ?? xterm.element;
 			const isReattach = !result.isNew;
 
 			// Hide reattached terminals during snapshot restore to prevent
@@ -139,10 +145,7 @@ export function useTerminalRestore({
 					if (restoreSequenceRef.current !== restoreSequence) return;
 					fitAddon.fit();
 					scrollToBottom(xterm);
-					if (termEl && termEl.isConnected) {
-						termEl.style.opacity = "";
-						termEl.style.transition = "";
-					}
+					restoreVisibility();
 				};
 				// Reattach: delay reveal 250ms to let TUI apps (tmux)
 				// repaint at correct dimensions after SIGWINCH
@@ -253,6 +256,7 @@ export function useTerminalRestore({
 				updateCwdRef.current(initialAnsi);
 			}
 		} catch (error) {
+			restoreVisibility();
 			console.error("[Terminal] Restoration failed:", error);
 			isStreamReadyRef.current = true;
 			flushPendingEvents();


### PR DESCRIPTION
## Summary
- Call `fitAddon.fit()` before `scheduleTerminalAttach` so `createOrAttach` sends correct `cols/rows` to the daemon — snapshot is captured at the right dimensions
- Hide reattached terminals (`opacity: 0`) during snapshot restore to suppress visible scroll
- Delay reveal by 250ms for reattached sessions to let TUI apps (tmux, vim) repaint at correct dimensions after `SIGWINCH`; new sessions appear instantly via `requestAnimationFrame`
- Guard `reveal()` with `termEl.isConnected` to avoid touching detached DOM nodes
- Reset `transition` style alongside `opacity` in reveal

## Context
When switching tabs, the terminal snapshot was rendered at stale dimensions. The daemon captures the snapshot immediately after resize, before the TUI app has repainted. This caused a visible width flicker as tmux repainted at the correct column count in a subsequent frame.

New sessions (`result.isNew === true`) are unaffected — they have no prior content to flicker, so they appear instantly.

## Test plan
- [ ] Switch between terminal tabs with tmux/agent-deck sessions — no scroll or width flicker
- [ ] Switch to a plain shell tab — appears instantly, no 250ms delay
- [ ] Open a new terminal tab — appears instantly
- [ ] Resize window, then switch tabs — no stale-width flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates scroll/width flicker when switching terminal tabs by fitting before attach and delaying the reveal for reattached sessions. Also prevents cold-restore kill loops after daemon restarts by dropping stale events early and fully tearing down sessions.

- **Bug Fixes**
  - Fit before attach: call `fitAddon.fit()` so `createOrAttach` sends correct `cols/rows` and snapshots render at the right width.
  - Reattach reveal: hide during snapshot restore, delay reveal 250ms (post-`SIGWINCH`), reset `opacity`/`transition`, guard with `termEl.isConnected`; new sessions reveal via `requestAnimationFrame`; always restore visibility on errors.
  - Cold restore: clear stale queued events before `createOrAttach` and use the snapshot as the initial state; preserve buffered new-session events for flush.
  - Daemon teardown: add `teardownAllSessions()` and use it in `disconnected`/`error` to mark sessions dead, null PIDs, unregister with `portManager`, close history writers for all sessions, and unregister daemon-only pane IDs before emitting disconnect.

<sup>Written for commit ac4ee2cdd448c344f215de42305ad10a0a103c58. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal daemon cleanup and session recovery during disconnects and errors.
  * Enhanced terminal geometry calculation during attachment operations.
  * Optimized terminal restoration rendering and reattachment experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->