### PR TITLE
feat(panes): add drag-and-drop pane rearrangement

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -1,9 +1,6 @@
 import type { PaneRegistry, RendererContext } from "@superset/panes";
 import { FileCode2, Globe, MessageSquare, TerminalSquare } from "lucide-react";
 import { useMemo } from "react";
-import { ChatPane } from "./components/ChatPane";
-import { WorkspaceFilePreview } from "./components/FilesPane/components/WorkspaceFilePreview/WorkspaceFilePreview";
-import { TerminalPane } from "./components/TerminalPane";
 import type {
 	BrowserPaneData,
 	ChatPaneData,
@@ -11,6 +8,9 @@ import type {
 	FilePaneData,
 	PaneViewerData,
 } from "../../types";
+import { ChatPane } from "./components/ChatPane";
+import { WorkspaceFilePreview } from "./components/FilesPane/components/WorkspaceFilePreview/WorkspaceFilePreview";
+import { TerminalPane } from "./components/TerminalPane";
 
 function getFileTitle(filePath: string): string {
 	return filePath.split("/").pop() ?? filePath;
@@ -40,9 +40,7 @@ export function usePaneRegistry(
 			terminal: {
 				getIcon: () => <TerminalSquare className="size-4" />,
 				getTitle: () => "Terminal",
-				renderPane: () => (
-					<TerminalPane workspaceId={workspaceId} />
-				),
+				renderPane: () => <TerminalPane workspaceId={workspaceId} />,
 			},
 			browser: {
 				getIcon: () => <Globe className="size-4" />,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/useV2WorkspacePaneLayout.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/useV2WorkspacePaneLayout.ts
@@ -1,7 +1,4 @@
-import {
-	createWorkspaceStore,
-	type WorkspaceState,
-} from "@superset/panes";
+import { createWorkspaceStore, type WorkspaceState } from "@superset/panes";
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useEffect, useMemo, useRef, useState } from "react";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -1,10 +1,11 @@
-import { Workspace, type PaneActionConfig } from "@superset/panes";
+import { type PaneActionConfig, Workspace } from "@superset/panes";
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useCallback, useMemo } from "react";
 import { HiMiniXMark } from "react-icons/hi2";
 import { TbLayoutColumns, TbLayoutRows } from "react-icons/tb";
+import { HotkeyTooltipContent } from "renderer/components/HotkeyTooltipContent";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import {
@@ -12,7 +13,6 @@ import {
 	useCommandPalette,
 } from "renderer/screens/main/components/CommandPalette";
 import { PresetsBar } from "renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar";
-import { HotkeyTooltipContent } from "renderer/components/HotkeyTooltipContent";
 import { useAppHotkey } from "renderer/stores/hotkeys";
 import { AddTabMenu } from "./components/AddTabMenu";
 import { WorkspaceEmptyState } from "./components/WorkspaceEmptyState";
@@ -79,22 +79,24 @@ function WorkspaceContent({
 	const utils = electronTrpc.useUtils();
 	const { data: showPresetsBar, isLoading: isLoadingPresetsBar } =
 		electronTrpc.settings.getShowPresetsBar.useQuery();
-	const setShowPresetsBar = electronTrpc.settings.setShowPresetsBar.useMutation({
-		onMutate: async ({ enabled }) => {
-			await utils.settings.getShowPresetsBar.cancel();
-			const previous = utils.settings.getShowPresetsBar.getData();
-			utils.settings.getShowPresetsBar.setData(undefined, enabled);
-			return { previous };
+	const setShowPresetsBar = electronTrpc.settings.setShowPresetsBar.useMutation(
+		{
+			onMutate: async ({ enabled }) => {
+				await utils.settings.getShowPresetsBar.cancel();
+				const previous = utils.settings.getShowPresetsBar.getData();
+				utils.settings.getShowPresetsBar.setData(undefined, enabled);
+				return { previous };
+			},
+			onError: (_error, _variables, context) => {
+				if (context?.previous !== undefined) {
+					utils.settings.getShowPresetsBar.setData(undefined, context.previous);
+				}
+			},
+			onSettled: () => {
+				utils.settings.getShowPresetsBar.invalidate();
+			},
 		},
-		onError: (_error, _variables, context) => {
-			if (context?.previous !== undefined) {
-				utils.settings.getShowPresetsBar.setData(undefined, context.previous);
-			}
-		},
-		onSettled: () => {
-			utils.settings.getShowPresetsBar.invalidate();
-		},
-	});
+	);
 
 	const openFilePane = useCallback(
 		(filePath: string) => {
@@ -206,10 +208,7 @@ function WorkspaceContent({
 				key: "close",
 				icon: <HiMiniXMark className="size-3.5" />,
 				tooltip: (
-					<HotkeyTooltipContent
-						label="Close pane"
-						hotkeyId="CLOSE_TERMINAL"
-					/>
+					<HotkeyTooltipContent label="Close pane" hotkeyId="CLOSE_TERMINAL" />
 				),
 				onClick: (ctx) => ctx.actions.close(),
 			},

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
@@ -62,7 +62,11 @@ function ensureSidebarWorkspaceRecord(
 			tabOrder: getNextTabOrder(topLevelOrders),
 			sectionId: null,
 		},
-		paneLayout: { version: 1, tabs: [], activeTabId: null } satisfies WorkspaceState<unknown>,
+		paneLayout: {
+			version: 1,
+			tabs: [],
+			activeTabId: null,
+		} satisfies WorkspaceState<unknown>,
 	});
 }
 

--- a/bun.lock
+++ b/bun.lock
@@ -766,6 +766,8 @@
       "dependencies": {
         "@superset/ui": "workspace:*",
         "lucide-react": "^0.563.0",
+        "react-dnd": "^16.0.1",
+        "react-dnd-html5-backend": "^16.0.1",
         "zustand": "^5.0.8",
       },
       "devDependencies": {

--- a/packages/panes/package.json
+++ b/packages/panes/package.json
@@ -17,6 +17,8 @@
 	"dependencies": {
 		"@superset/ui": "workspace:*",
 		"lucide-react": "^0.563.0",
+		"react-dnd": "^16.0.1",
+		"react-dnd-html5-backend": "^16.0.1",
 		"zustand": "^5.0.8"
 	},
 	"devDependencies": {

--- a/packages/panes/src/core/store/store.test.ts
+++ b/packages/panes/src/core/store/store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import type { WorkspaceState } from "../../types";
+import type { Tab, WorkspaceState } from "../../types";
 import type { CreatePaneInput } from "./store";
 import { createWorkspaceStore } from "./store";
 
@@ -574,6 +574,148 @@ describe("openPane", () => {
 		if (layout?.type === "split") {
 			expect(layout.children).toHaveLength(2);
 		}
+	});
+});
+
+describe("movePaneToSplit", () => {
+	it("moves a pane within the same tab", () => {
+		const store = makeStore({
+			version: 1,
+			tabs: [
+				{
+					id: "t1",
+					createdAt: Date.now(),
+					activePaneId: "p1",
+					layout: {
+						type: "split",
+						id: "s1",
+						direction: "horizontal",
+						children: [
+							{ type: "pane", paneId: "p1" },
+							{ type: "pane", paneId: "p2" },
+						],
+						weights: [1, 1],
+					},
+					panes: {
+						p1: { id: "p1", kind: "test", data: { label: "p1" } },
+						p2: { id: "p2", kind: "test", data: { label: "p2" } },
+					},
+				},
+			],
+			activeTabId: "t1",
+		});
+
+		store.getState().movePaneToSplit({
+			sourcePaneId: "p1",
+			targetPaneId: "p2",
+			position: "bottom",
+		});
+
+		const tab = store.getState().tabs[0];
+		expect(tab).toBeDefined();
+		// p1 should now be split below p2
+		expect(tab?.panes.p1).toBeDefined();
+		expect(tab?.panes.p2).toBeDefined();
+		expect(tab?.activePaneId).toBe("p1");
+	});
+
+	it("moves a pane across tabs", () => {
+		const store = makeStore({
+			version: 1,
+			tabs: [
+				{
+					id: "t1",
+					createdAt: Date.now(),
+					activePaneId: "p1",
+					layout: {
+						type: "split",
+						id: "s1",
+						direction: "horizontal",
+						children: [
+							{ type: "pane", paneId: "p1" },
+							{ type: "pane", paneId: "p2" },
+						],
+						weights: [1, 1],
+					},
+					panes: {
+						p1: { id: "p1", kind: "test", data: { label: "p1" } },
+						p2: { id: "p2", kind: "test", data: { label: "p2" } },
+					},
+				},
+				{
+					id: "t2",
+					createdAt: Date.now(),
+					activePaneId: "p3",
+					layout: { type: "pane", paneId: "p3" },
+					panes: {
+						p3: { id: "p3", kind: "test", data: { label: "p3" } },
+					},
+				},
+			],
+			activeTabId: "t1",
+		});
+
+		store.getState().movePaneToSplit({
+			sourcePaneId: "p1",
+			targetPaneId: "p3",
+			position: "right",
+		});
+
+		// Source tab should have p2 only
+		const t1 = store.getState().tabs.find((t) => t.id === "t1");
+		expect(t1?.panes.p1).toBeUndefined();
+		expect(t1?.layout).toEqual({ type: "pane", paneId: "p2" });
+
+		// Target tab should have p3 + p1
+		const t2 = store.getState().tabs.find((t) => t.id === "t2");
+		expect(t2?.panes.p1).toBeDefined();
+		expect(t2?.panes.p3).toBeDefined();
+		expect(t2?.activePaneId).toBe("p1");
+		expect(store.getState().activeTabId).toBe("t2");
+	});
+
+	it("removes source tab when last pane is moved out", () => {
+		const store = makeStore();
+		store.getState().addTab({ id: "t1", panes: [tp("p1")] });
+		store.getState().addTab({ id: "t2", panes: [tp("p2")] });
+
+		const tab1 = store.getState().tabs[0] as Tab<TestData>;
+		const tab2 = store.getState().tabs[1] as Tab<TestData>;
+		const p1Id = Object.keys(tab1.panes)[0] as string;
+		const p2Id = Object.keys(tab2.panes)[0] as string;
+
+		store.getState().movePaneToSplit({
+			sourcePaneId: p1Id,
+			targetPaneId: p2Id,
+			position: "right",
+		});
+
+		expect(store.getState().tabs).toHaveLength(1);
+	});
+
+	it("is a no-op when dropping on self", () => {
+		const store = makeStore();
+		store.getState().addTab({ id: "t1", panes: [tp("p1")] });
+
+		const tab0 = store.getState().tabs[0] as Tab<TestData>;
+		const p1Id = Object.keys(tab0.panes)[0] as string;
+		const before = structuredClone({
+			version: store.getState().version,
+			tabs: store.getState().tabs,
+			activeTabId: store.getState().activeTabId,
+		});
+
+		store.getState().movePaneToSplit({
+			sourcePaneId: p1Id,
+			targetPaneId: p1Id,
+			position: "right",
+		});
+
+		expect({
+			version: store.getState().version,
+			tabs: store.getState().tabs,
+			activeTabId: store.getState().activeTabId,
+		}).toEqual(before);
 	});
 });
 

--- a/packages/panes/src/core/store/store.ts
+++ b/packages/panes/src/core/store/store.ts
@@ -139,6 +139,12 @@ export interface WorkspaceStore<TData> extends WorkspaceState<TData> {
 	}) => void;
 	equalizeSplit: (args: { tabId: string; splitId: string }) => void;
 
+	movePaneToSplit: (args: {
+		sourcePaneId: string;
+		targetPaneId: string;
+		position: SplitPosition;
+	}) => void;
+
 	replaceState: (
 		next:
 			| WorkspaceState<TData>
@@ -614,6 +620,91 @@ export function createWorkspaceStore<TData>(
 								}
 							: t,
 					),
+				};
+			});
+		},
+
+		movePaneToSplit: (args) => {
+			set((s) => {
+				// Find source and target tabs by pane ID
+				let sourceTab: Tab<TData> | undefined;
+				let sourcePane: Pane<TData> | undefined;
+				let targetTab: Tab<TData> | undefined;
+				for (const t of s.tabs) {
+					if (t.panes[args.sourcePaneId]) {
+						sourceTab = t;
+						sourcePane = t.panes[args.sourcePaneId];
+					}
+					if (t.panes[args.targetPaneId]) {
+						targetTab = t;
+					}
+				}
+				if (!sourceTab || !sourcePane) return s;
+				if (!targetTab || !targetTab.layout) return s;
+				if (!findPaneInLayout(targetTab.layout, args.targetPaneId)) return s;
+
+				// Don't drop on self
+				if (args.sourcePaneId === args.targetPaneId) return s;
+
+				// Remove from source layout
+				const nextSourceLayout = removePaneFromLayout(
+					sourceTab.layout,
+					args.sourcePaneId,
+				);
+				const { [args.sourcePaneId]: _, ...nextSourcePanes } = sourceTab.panes;
+
+				// Insert into target layout
+				const nextTargetLayout = splitPaneInLayout(
+					// If same tab, use the already-modified layout
+					sourceTab.id === targetTab.id && nextSourceLayout
+						? nextSourceLayout
+						: targetTab.layout,
+					args.targetPaneId,
+					sourcePane.id,
+					args.position,
+				);
+
+				const nextTabs = s.tabs
+					.map((t) => {
+						if (sourceTab.id === targetTab.id && t.id === sourceTab.id) {
+							// Same-tab move
+							if (!nextSourceLayout) return null; // shouldn't happen since we check targetPaneId != sourcePaneId
+							return {
+								...t,
+								layout: nextTargetLayout,
+								panes: { ...nextSourcePanes, [sourcePane.id]: sourcePane },
+								activePaneId: sourcePane.id,
+							};
+						}
+						if (t.id === sourceTab.id) {
+							// Source tab — pane removed
+							if (!nextSourceLayout) return null; // last pane removed, tab will be filtered
+							return {
+								...t,
+								layout: nextSourceLayout,
+								panes: nextSourcePanes,
+								activePaneId:
+									t.activePaneId === args.sourcePaneId
+										? findFirstPaneId(nextSourceLayout)
+										: t.activePaneId,
+							};
+						}
+						if (t.id === targetTab.id) {
+							// Target tab — pane added
+							return {
+								...t,
+								layout: nextTargetLayout,
+								panes: { ...t.panes, [sourcePane.id]: sourcePane },
+								activePaneId: sourcePane.id,
+							};
+						}
+						return t;
+					})
+					.filter((t): t is Tab<TData> => t !== null);
+
+				return {
+					tabs: nextTabs,
+					activeTabId: targetTab.id,
 				};
 			});
 		},

--- a/packages/panes/src/react/components/Workspace/Workspace.tsx
+++ b/packages/panes/src/react/components/Workspace/Workspace.tsx
@@ -1,4 +1,6 @@
 import { cn } from "@superset/ui/utils";
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
 import { useStore } from "zustand";
 import type { WorkspaceProps } from "../../types";
 import { Tab } from "./components/Tab";
@@ -29,46 +31,50 @@ export function Workspace<TData>({
 	};
 
 	return (
-		<div
-			className={cn(
-				"flex h-full w-full min-h-0 min-w-0 flex-col overflow-hidden bg-background text-foreground",
-				className,
-			)}
-		>
-			<TabBar
-				tabs={tabs}
-				activeTabId={activeTabId}
-				onSelectTab={(tabId) => store.getState().setActiveTab(tabId)}
-				onCloseTab={closeTab}
-				onCloseOtherTabs={(tabId) => {
-					for (const tab of tabs) {
-						if (tab.id !== tabId) closeTab(tab.id);
+		<DndProvider backend={HTML5Backend}>
+			<div
+				className={cn(
+					"flex h-full w-full min-h-0 min-w-0 flex-col overflow-hidden bg-background text-foreground",
+					className,
+				)}
+			>
+				<TabBar
+					tabs={tabs}
+					activeTabId={activeTabId}
+					onSelectTab={(tabId) => store.getState().setActiveTab(tabId)}
+					onCloseTab={closeTab}
+					onCloseOtherTabs={(tabId) => {
+						for (const tab of tabs) {
+							if (tab.id !== tabId) closeTab(tab.id);
+						}
+					}}
+					onCloseAllTabs={() => {
+						for (const tab of tabs) {
+							closeTab(tab.id);
+						}
+					}}
+					onRenameTab={(tabId, title) =>
+						store
+							.getState()
+							.setTabTitleOverride({ tabId, titleOverride: title })
 					}
-				}}
-				onCloseAllTabs={() => {
-					for (const tab of tabs) {
-						closeTab(tab.id);
-					}
-				}}
-				onRenameTab={(tabId, title) =>
-					store.getState().setTabTitleOverride({ tabId, titleOverride: title })
-				}
-				getTabTitle={(tab) => tab.titleOverride ?? tab.id}
-				renderAddTabMenu={renderAddTabMenu}
-				renderTabAccessory={renderTabAccessory}
-			/>
-			{activeTab ? (
-				<Tab
-					store={store}
-					tab={activeTab}
-					registry={registry}
-					paneActions={paneActions}
+					getTabTitle={(tab) => tab.titleOverride ?? tab.id}
+					renderAddTabMenu={renderAddTabMenu}
+					renderTabAccessory={renderTabAccessory}
 				/>
-			) : (
-				<div className="flex min-h-0 min-w-0 flex-1 items-center justify-center text-sm text-muted-foreground">
-					{renderEmptyState?.() ?? "No tabs open"}
-				</div>
-			)}
-		</div>
+				{activeTab ? (
+					<Tab
+						store={store}
+						tab={activeTab}
+						registry={registry}
+						paneActions={paneActions}
+					/>
+				) : (
+					<div className="flex min-h-0 min-w-0 flex-1 items-center justify-center text-sm text-muted-foreground">
+						{renderEmptyState?.() ?? "No tabs open"}
+					</div>
+				)}
+			</div>
+		</DndProvider>
 	);
 }

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
@@ -1,15 +1,21 @@
-import { useMemo } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { useDrop } from "react-dnd";
 import type { StoreApi } from "zustand/vanilla";
 import type { WorkspaceStore } from "../../../../../../../core/store";
-import type { Pane as PaneType, Tab } from "../../../../../../../types";
+import type {
+	Pane as PaneType,
+	SplitPosition,
+	Tab,
+} from "../../../../../../../types";
 import type {
 	PaneActionConfig,
 	PaneRegistry,
 	RendererContext,
 } from "../../../../../../types";
 import { PaneHeaderActions } from "../../../../../PaneHeaderActions";
+import { DropZoneOverlay } from "./components/DropZoneOverlay";
 import { PaneContent } from "./components/PaneContent";
-import { PaneHeader } from "./components/PaneHeader";
+import { PANE_DRAG_TYPE, PaneHeader } from "./components/PaneHeader";
 
 interface PaneComponentProps<TData> {
 	store: StoreApi<WorkspaceStore<TData>>;
@@ -37,6 +43,21 @@ function resolveActions<TData>(
 	if (!config) return defaults;
 	if (typeof config === "function") return config(context, defaults);
 	return config;
+}
+
+function getDropPosition(
+	clientX: number,
+	clientY: number,
+	rect: DOMRect,
+): SplitPosition {
+	const cx = rect.left + rect.width / 2;
+	const cy = rect.top + rect.height / 2;
+	const dx = clientX - cx;
+	const dy = clientY - cy;
+	if (Math.abs(dx) > Math.abs(dy)) {
+		return dx > 0 ? "right" : "left";
+	}
+	return dy > 0 ? "bottom" : "top";
 }
 
 export function Pane<TData>({
@@ -118,6 +139,57 @@ export function Pane<TData>({
 		tabPosition,
 	]);
 
+	const dropPositionRef = useRef<SplitPosition | null>(null);
+	const [dropPosition, setDropPosition] = useState<SplitPosition | null>(null);
+	const dropRef = useRef<HTMLDivElement>(null);
+
+	const [{ isOver, canDrop }, connectDrop] = useDrop(
+		() => ({
+			accept: PANE_DRAG_TYPE,
+			canDrop: (item: { paneId: string }) => item.paneId !== pane.id,
+			hover: (_item, monitor) => {
+				const offset = monitor.getClientOffset();
+				const el = dropRef.current;
+				if (!offset || !el) return;
+				const rect = el.getBoundingClientRect();
+				const pos = getDropPosition(offset.x, offset.y, rect);
+				if (pos !== dropPositionRef.current) {
+					dropPositionRef.current = pos;
+					setDropPosition(pos);
+				}
+			},
+			drop: (item: { paneId: string }) => {
+				const pos = dropPositionRef.current;
+				if (!pos) return;
+				store.getState().movePaneToSplit({
+					sourcePaneId: item.paneId,
+					targetPaneId: pane.id,
+					position: pos,
+				});
+			},
+			collect: (monitor) => ({
+				isOver: monitor.isOver(),
+				canDrop: monitor.canDrop(),
+			}),
+		}),
+		[pane.id, tab.id, store],
+	);
+
+	// Merge refs: connectDrop needs a node, and we need dropRef for rect calculations
+	const setRefs = useCallback(
+		(node: HTMLDivElement | null) => {
+			(dropRef as React.MutableRefObject<HTMLDivElement | null>).current = node;
+			connectDrop(node);
+		},
+		[connectDrop],
+	);
+
+	// Clear drop position when not hovering
+	if (!isOver && dropPositionRef.current !== null) {
+		dropPositionRef.current = null;
+		if (dropPosition !== null) setDropPosition(null);
+	}
+
 	const title = definition
 		? (pane.titleOverride ?? definition.getTitle?.(context) ?? pane.id)
 		: `Unknown: ${pane.kind}`;
@@ -126,10 +198,13 @@ export function Pane<TData>({
 	const headerExtras = definition?.renderHeaderExtras?.(context);
 	const toolbar = definition?.renderToolbar?.(context);
 
+	const isDropTarget = isOver && canDrop;
+
 	return (
 		// biome-ignore lint/a11y/noStaticElementInteractions: clicking anywhere in a pane focuses it (standard IDE behavior)
 		<div
-			className="flex h-full w-full flex-col overflow-hidden border-[0.5px] border-border"
+			ref={setRefs}
+			className="relative flex h-full w-full flex-col overflow-hidden border-[0.5px] border-border"
 			onMouseDown={context.actions.focus}
 		>
 			<PaneHeader
@@ -140,6 +215,7 @@ export function Pane<TData>({
 				headerExtras={headerExtras}
 				toolbar={toolbar}
 				actionsContent={<context.components.PaneHeaderActions />}
+				paneId={pane.id}
 			/>
 			<PaneContent>
 				{definition ? (
@@ -150,6 +226,7 @@ export function Pane<TData>({
 					</div>
 				)}
 			</PaneContent>
+			{isDropTarget && <DropZoneOverlay position={dropPosition} />}
 		</div>
 	);
 }

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/DropZoneOverlay/DropZoneOverlay.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/DropZoneOverlay/DropZoneOverlay.tsx
@@ -1,0 +1,28 @@
+import type { SplitPosition } from "../../../../../../../../../types";
+
+interface DropZoneOverlayProps {
+	position: SplitPosition | null;
+}
+
+const ZONE_STYLES: Record<SplitPosition, React.CSSProperties> = {
+	top: { top: 0, left: 0, width: "100%", height: "50%" },
+	bottom: { top: "50%", left: 0, width: "100%", height: "50%" },
+	left: { top: 0, left: 0, width: "50%", height: "100%" },
+	right: { top: 0, left: "50%", width: "50%", height: "100%" },
+};
+
+export function DropZoneOverlay({ position }: DropZoneOverlayProps) {
+	if (!position) return null;
+
+	return (
+		<div className="pointer-events-none absolute inset-0 z-10">
+			<div
+				className="absolute rounded-sm border-2 border-primary/70 bg-primary/10"
+				style={{
+					...ZONE_STYLES[position],
+					transition: "all 150ms ease",
+				}}
+			/>
+		</div>
+	);
+}

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/DropZoneOverlay/index.ts
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/DropZoneOverlay/index.ts
@@ -1,0 +1,1 @@
+export { DropZoneOverlay } from "./DropZoneOverlay";

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/PaneHeader.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/PaneHeader.tsx
@@ -1,5 +1,7 @@
 import { cn } from "@superset/ui/utils";
-import type { ReactNode } from "react";
+import { type ReactNode, useCallback, useRef } from "react";
+import { useDrag } from "react-dnd";
+import { DefaultHeaderContent } from "./components/DefaultHeaderContent";
 
 interface PaneHeaderProps {
 	title: ReactNode;
@@ -9,7 +11,10 @@ interface PaneHeaderProps {
 	headerExtras?: ReactNode;
 	actionsContent: ReactNode;
 	toolbar?: ReactNode;
+	paneId?: string;
 }
+
+export const PANE_DRAG_TYPE = "pane";
 
 export function PaneHeader({
 	title,
@@ -19,41 +24,48 @@ export function PaneHeader({
 	headerExtras,
 	actionsContent,
 	toolbar,
+	paneId,
 }: PaneHeaderProps) {
-	const chrome = cn(
-		"flex h-7 shrink-0 items-center transition-[background-color] duration-150",
-		isActive ? "bg-secondary" : "bg-tertiary",
+	const [{ isDragging }, connectDrag] = useDrag(
+		() => ({
+			type: PANE_DRAG_TYPE,
+			item: { paneId },
+			canDrag: !!paneId,
+			collect: (monitor) => ({
+				isDragging: monitor.isDragging(),
+			}),
+		}),
+		[paneId],
 	);
 
-	// Full eject — pane owns the entire toolbar content
-	if (toolbar) {
-		return <div className={chrome}>{toolbar}</div>;
-	}
+	const nodeRef = useRef<HTMLDivElement>(null);
+	const setRef = useCallback(
+		(node: HTMLDivElement | null) => {
+			(nodeRef as React.MutableRefObject<HTMLDivElement | null>).current = node;
+			connectDrag(node);
+		},
+		[connectDrag],
+	);
 
-	// Default layout — matches v1 BasePaneWindow toolbar pattern
 	return (
-		<div className={chrome}>
-			<div className="flex h-full w-full items-center justify-between px-3">
-				<div className="flex min-w-0 items-center gap-2">
-					{titleContent ?? (
-						<>
-							{icon && <span className="shrink-0">{icon}</span>}
-							<span
-								className={cn(
-									"truncate text-sm transition-colors duration-150",
-									isActive ? "text-foreground" : "text-muted-foreground",
-								)}
-							>
-								{title}
-							</span>
-						</>
-					)}
-				</div>
-				<div className="flex shrink-0 items-center gap-0.5">
-					{headerExtras}
-					{actionsContent}
-				</div>
-			</div>
+		<div
+			ref={setRef}
+			className={cn(
+				"flex h-7 shrink-0 items-center transition-[background-color] duration-150 cursor-grab",
+				isActive ? "bg-secondary" : "bg-tertiary",
+				isDragging && "opacity-30",
+			)}
+		>
+			{toolbar ?? (
+				<DefaultHeaderContent
+					title={title}
+					icon={icon}
+					isActive={isActive}
+					titleContent={titleContent}
+					headerExtras={headerExtras}
+					actionsContent={actionsContent}
+				/>
+			)}
 		</div>
 	);
 }

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/components/DefaultHeaderContent/DefaultHeaderContent.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/components/DefaultHeaderContent/DefaultHeaderContent.tsx
@@ -1,0 +1,48 @@
+import { cn } from "@superset/ui/utils";
+import type { ReactNode } from "react";
+
+interface DefaultHeaderContentProps {
+	title: ReactNode;
+	icon?: ReactNode;
+	isActive: boolean;
+	titleContent?: ReactNode;
+	headerExtras?: ReactNode;
+	actionsContent: ReactNode;
+}
+
+export function DefaultHeaderContent({
+	title,
+	icon,
+	isActive,
+	titleContent,
+	headerExtras,
+	actionsContent,
+}: DefaultHeaderContentProps) {
+	return (
+		<div className="flex h-full w-full items-center justify-between px-3">
+			<div className="flex min-w-0 items-center gap-2">
+				{titleContent ?? (
+					<>
+						{icon && <span className="shrink-0">{icon}</span>}
+						<span
+							className={cn(
+								"truncate text-sm transition-colors duration-150",
+								isActive ? "text-foreground" : "text-muted-foreground",
+							)}
+						>
+							{title}
+						</span>
+					</>
+				)}
+			</div>
+			{/* biome-ignore lint/a11y/noStaticElementInteractions: stop drag from starting on action buttons */}
+			<div
+				className="flex shrink-0 items-center gap-0.5"
+				onMouseDown={(e) => e.stopPropagation()}
+			>
+				{headerExtras}
+				{actionsContent}
+			</div>
+		</div>
+	);
+}

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/components/DefaultHeaderContent/index.ts
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/components/DefaultHeaderContent/index.ts
@@ -1,0 +1,1 @@
+export { DefaultHeaderContent } from "./DefaultHeaderContent";

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/index.ts
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/index.ts
@@ -1,1 +1,1 @@
-export { PaneHeader } from "./PaneHeader";
+export { PANE_DRAG_TYPE, PaneHeader } from "./PaneHeader";

--- a/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
@@ -9,8 +9,10 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { PencilIcon, XIcon } from "lucide-react";
-import { type ReactNode, useState } from "react";
+import { type ReactNode, useCallback, useRef, useState } from "react";
+import { useDrop } from "react-dnd";
 import type { Tab } from "../../../../../../../types";
+import { PANE_DRAG_TYPE } from "../../../Tab/components/Pane/components/PaneHeader";
 import { TabRenameInput } from "./components/TabRenameInput";
 
 interface TabItemProps<TData> {
@@ -57,10 +59,38 @@ export function TabItem<TData>({
 		stopEditing();
 	};
 
+	const [{ isOver }, connectDrop] = useDrop(
+		() => ({
+			accept: PANE_DRAG_TYPE,
+			hover: () => {
+				if (!isActive) onSelect();
+			},
+			collect: (monitor) => ({
+				isOver: monitor.isOver(),
+			}),
+		}),
+		[isActive, onSelect],
+	);
+
+	const nodeRef = useRef<HTMLDivElement>(null);
+	const setDropRef = useCallback(
+		(node: HTMLDivElement | null) => {
+			(nodeRef as React.MutableRefObject<HTMLDivElement | null>).current = node;
+			connectDrop(node);
+		},
+		[connectDrop],
+	);
+
 	return (
 		<ContextMenu>
 			<ContextMenuTrigger asChild>
-				<div className="group relative flex h-full w-full items-center border-r border-border">
+				<div
+					ref={setDropRef}
+					className={cn(
+						"group relative flex h-full w-full items-center border-r border-border",
+						isOver && "bg-primary/5",
+					)}
+				>
 					{isEditing ? (
 						<div className="flex h-full w-full shrink-0 items-center px-2">
 							<TabRenameInput


### PR DESCRIPTION
## Summary
- Add DnD support using `react-dnd` so users can drag panes by their headers and drop onto other panes to rearrange the layout
- Each pane handles its own drop via `useDrop`'s `drop()` callback — no shared state needed
- New `movePaneToSplit` store action handles same-tab and cross-tab pane moves atomically

## Changes
- **PaneHeader**: `useDrag` makes headers draggable
- **Pane**: `useDrop` with `hover()` for zone detection + `drop()` calls `movePaneToSplit` directly
- **TabItem**: `useDrop` with `hover()` switches tabs during drag
- **DropZoneOverlay**: new component — animated split-zone indicator (top/right/bottom/left)
- **Workspace**: `DndProvider` wrapper (replaced `@dnd-kit` `DndContext`)
- **Store**: `movePaneToSplit` action + tests
- Removed `@dnd-kit/core`, added `react-dnd` + `react-dnd-html5-backend`
- Removed `PaneDragItem` type (drag item is just `{ paneId: string }`)

## Test plan
- [ ] Drag pane header → source dims, native drag preview follows cursor
- [ ] Hover over pane content → 4-zone overlay appears, active zone highlights
- [ ] Move cursor between zones → highlight animates smoothly
- [ ] Drop on zone → pane moves to that position (split created)
- [ ] Drag to tab bar → tab switches on hover
- [ ] Drop on different tab's pane → cross-tab move works
- [ ] Move last pane out of source tab → source tab removed
- [ ] Drop on self → no-op
- [ ] 61 store tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add drag-and-drop pane rearrangement with `react-dnd`, letting users drag a pane header and drop onto another pane to split or reorder. Works across tabs with animated zone hints and no shared drag state.

- **New Features**
  - Draggable pane headers via `useDrag`; header actions don’t start a drag.
  - Panes accept drops via `useDrop` and show a 4-zone overlay (top/right/bottom/left) while hovering.
  - Tab bar switches on hover during drag for cross-tab drops, with hover feedback.
  - New `movePaneToSplit` store action for same- and cross-tab moves; removes empty source tabs, focuses the dropped pane/tab, and ignores self-drops.
  - Workspace wrapped in `DndProvider` with `HTML5Backend`.

- **Dependencies**
  - Added `react-dnd` and `react-dnd-html5-backend`.

<sup>Written for commit fe6b528e92937cb38cc83dc24294562b602bba5f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added drag-and-drop support for panes with visual drop zone indicators showing the exact placement position
  * Panes can now be moved between tabs and reorganized within the same tab
  * Destination tabs automatically select when dragging panes between them
  * Drop zone overlay provides visual feedback during pane rearrangement
<!-- end of auto-generated comment: release notes by coderabbit.ai -->