### PR TITLE
fix(desktop): prevent duplicate panes when file-open mode is new-tab

### DIFF
--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -756,9 +756,7 @@ export const useTabsStore = create<TabsStore>()(
 
 					const tabPaneIds = extractPaneIdsFromLayout(activeTab.layout);
 					const reuseExisting = options.reuseExisting ?? "workspace";
-					const canReuseExistingPane =
-						!options.openInNewTab && reuseExisting !== "none";
-					const existingFileViewerPane = canReuseExistingPane
+					const existingFileViewerPane = reuseExisting !== "none"
 						? findReusableFileViewerPane({
 								workspaceId,
 								activeTabId: activeTab.id,
@@ -828,7 +826,7 @@ export const useTabsStore = create<TabsStore>()(
 
 					// If we found an unpinned (preview) file-viewer pane, reuse it
 					// (skip reuse when explicitly requesting a new tab, e.g. cmd+click)
-					if (fileViewerPanes.length > 0 && canReuseExistingPane) {
+					if (fileViewerPanes.length > 0 && !options.openInNewTab && reuseExisting !== "none") {
 						const paneToReuse = fileViewerPanes[0];
 						const existingFileViewer = paneToReuse.fileViewer;
 						if (!existingFileViewer) {


### PR DESCRIPTION
## Summary
- Decouples the existing-pane lookup from the `openInNewTab` flag in `addFileViewerPane`
- Previously, when file-open mode was set to "new-tab", the store skipped searching for an already-open pane entirely, which could create duplicates
- Now the store always finds an existing pane first, but only reuses it in-place when `openInNewTab` is false

https://github.com/user-attachments/assets/d098c4ae-35df-41e6-bb93-9c9c6a5e964b


## Test plan
- [ ] Set file-open mode to "New tab" in Settings → Behavior
- [ ] Open a file — verify it opens in a new tab
- [ ] Open the same file again — verify it activates the existing tab instead of creating a duplicate
- [ ] Set file-open mode to "Split pane" and verify normal split-pane reuse still works
- [ ] Cmd+click a file (force new tab) — verify it still opens in a new tab

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent duplicate file-viewer panes when file-open mode is set to "New tab". The store now always finds an existing pane first and only reuses it when `openInNewTab` is false, so opening the same file activates the existing tab; split-pane reuse and cmd+click to force a new tab still work as before.

<sup>Written for commit dd120967c318deac863517b08ccf27150ed9c279. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal logic for managing file viewer pane reuse behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->