### PR TITLE
feat(panes): add drag-to-reorder tabs

### DIFF
--- a/packages/panes/src/core/store/store.test.ts
+++ b/packages/panes/src/core/store/store.test.ts
@@ -757,3 +757,69 @@ describe("edge cases", () => {
 		expect(store.getState().activeTabId).toBe("injected");
 	});
 });
+
+describe("reorderTab", () => {
+	it("moves a tab forward", () => {
+		const store = makeStore();
+		store.getState().addTab({ id: "t1", panes: [tp("p1")] });
+		store.getState().addTab({ id: "t2", panes: [tp("p2")] });
+		store.getState().addTab({ id: "t3", panes: [tp("p3")] });
+
+		store.getState().reorderTab({ tabId: "t1", toIndex: 2 });
+
+		expect(store.getState().tabs.map((t) => t.id)).toEqual(["t2", "t3", "t1"]);
+	});
+
+	it("moves a tab backward", () => {
+		const store = makeStore();
+		store.getState().addTab({ id: "t1", panes: [tp("p1")] });
+		store.getState().addTab({ id: "t2", panes: [tp("p2")] });
+		store.getState().addTab({ id: "t3", panes: [tp("p3")] });
+
+		store.getState().reorderTab({ tabId: "t3", toIndex: 0 });
+
+		expect(store.getState().tabs.map((t) => t.id)).toEqual(["t3", "t1", "t2"]);
+	});
+
+	it("is a no-op when moving to same index", () => {
+		const store = makeStore();
+		store.getState().addTab({ id: "t1", panes: [tp("p1")] });
+		store.getState().addTab({ id: "t2", panes: [tp("p2")] });
+
+		const before = store.getState().tabs.map((t) => t.id);
+		store.getState().reorderTab({ tabId: "t1", toIndex: 0 });
+
+		expect(store.getState().tabs.map((t) => t.id)).toEqual(before);
+	});
+
+	it("is a no-op for unknown tabId", () => {
+		const store = makeStore();
+		store.getState().addTab({ id: "t1", panes: [tp("p1")] });
+
+		const before = store.getState().tabs.map((t) => t.id);
+		store.getState().reorderTab({ tabId: "missing", toIndex: 0 });
+
+		expect(store.getState().tabs.map((t) => t.id)).toEqual(before);
+	});
+
+	it("clamps toIndex to valid range", () => {
+		const store = makeStore();
+		store.getState().addTab({ id: "t1", panes: [tp("p1")] });
+		store.getState().addTab({ id: "t2", panes: [tp("p2")] });
+
+		store.getState().reorderTab({ tabId: "t1", toIndex: 100 });
+
+		expect(store.getState().tabs.map((t) => t.id)).toEqual(["t2", "t1"]);
+	});
+
+	it("preserves activeTabId", () => {
+		const store = makeStore();
+		store.getState().addTab({ id: "t1", panes: [tp("p1")] });
+		store.getState().addTab({ id: "t2", panes: [tp("p2")] });
+		store.getState().setActiveTab("t2");
+
+		store.getState().reorderTab({ tabId: "t1", toIndex: 1 });
+
+		expect(store.getState().activeTabId).toBe("t2");
+	});
+});

--- a/packages/panes/src/core/store/store.ts
+++ b/packages/panes/src/core/store/store.ts
@@ -145,6 +145,8 @@ export interface WorkspaceStore<TData> extends WorkspaceState<TData> {
 		position: SplitPosition;
 	}) => void;
 
+	reorderTab: (args: { tabId: string; toIndex: number }) => void;
+
 	replaceState: (
 		next:
 			| WorkspaceState<TData>
@@ -706,6 +708,19 @@ export function createWorkspaceStore<TData>(
 					tabs: nextTabs,
 					activeTabId: targetTab.id,
 				};
+			});
+		},
+
+		reorderTab: (args) => {
+			set((s) => {
+				const fromIndex = s.tabs.findIndex((t) => t.id === args.tabId);
+				if (fromIndex === -1) return s;
+				const toIndex = Math.max(0, Math.min(args.toIndex, s.tabs.length - 1));
+				if (fromIndex === toIndex) return s;
+				const nextTabs = [...s.tabs];
+				const [tab] = nextTabs.splice(fromIndex, 1);
+				nextTabs.splice(toIndex, 0, tab!);
+				return { tabs: nextTabs };
 			});
 		},
 

--- a/packages/panes/src/react/components/Workspace/Workspace.tsx
+++ b/packages/panes/src/react/components/Workspace/Workspace.tsx
@@ -58,6 +58,9 @@ export function Workspace<TData>({
 							.getState()
 							.setTabTitleOverride({ tabId, titleOverride: title })
 					}
+					onReorderTab={(tabId, toIndex) =>
+						store.getState().reorderTab({ tabId, toIndex })
+					}
 					getTabTitle={(tab) => tab.titleOverride ?? tab.id}
 					renderAddTabMenu={renderAddTabMenu}
 					renderTabAccessory={renderTabAccessory}

--- a/packages/panes/src/react/components/Workspace/components/TabBar/TabBar.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/TabBar.tsx
@@ -14,8 +14,10 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { useDrop } from "react-dnd";
 import type { Tab } from "../../../../../types";
-import { TabItem } from "./components/TabItem";
+import { TAB_DRAG_TYPE, TabItem } from "./components/TabItem";
+import { computeInsertIndex, TAB_WIDTH } from "./utils";
 
 interface TabBarProps<TData> {
 	tabs: Tab<TData>[];
@@ -25,6 +27,7 @@ interface TabBarProps<TData> {
 	onCloseOtherTabs: (tabId: string) => void;
 	onCloseAllTabs: () => void;
 	onRenameTab: (tabId: string, title: string) => void;
+	onReorderTab: (tabId: string, toIndex: number) => void;
 	getTabTitle: (tab: Tab<TData>) => string;
 	renderAddTabMenu?: () => ReactNode;
 	renderTabAccessory?: (tab: Tab<TData>) => ReactNode;
@@ -68,6 +71,7 @@ export function TabBar<TData>({
 	onCloseOtherTabs,
 	onCloseAllTabs,
 	onRenameTab,
+	onReorderTab,
 	getTabTitle,
 	renderAddTabMenu,
 	renderTabAccessory,
@@ -75,6 +79,65 @@ export function TabBar<TData>({
 	const scrollContainerRef = useRef<HTMLDivElement>(null);
 	const tabsTrackRef = useRef<HTMLDivElement>(null);
 	const [hasHorizontalOverflow, setHasHorizontalOverflow] = useState(false);
+
+	const insertIndexRef = useRef<number | null>(null);
+	const [insertIndex, setInsertIndex] = useState<number | null>(null);
+
+	const [{ isOver }, connectDrop] = useDrop(
+		() => ({
+			accept: TAB_DRAG_TYPE,
+			hover: (_item, monitor) => {
+				const track = tabsTrackRef.current;
+				const offset = monitor.getClientOffset();
+				if (!track || !offset) return;
+
+				const idx = computeInsertIndex(
+					offset.x,
+					track.getBoundingClientRect(),
+					tabs.length,
+				);
+				if (idx !== insertIndexRef.current) {
+					insertIndexRef.current = idx;
+					setInsertIndex(idx);
+				}
+			},
+			drop: (item: { tabId: string }) => {
+				const idx = insertIndexRef.current;
+				if (idx === null) return;
+
+				const dragIndex = tabs.findIndex((t) => t.id === item.tabId);
+				if (dragIndex === -1) return;
+
+				// Adjust for removal of dragged tab
+				let toIndex = idx;
+				if (dragIndex < toIndex) toIndex--;
+
+				insertIndexRef.current = null;
+				setInsertIndex(null);
+				onReorderTab(item.tabId, toIndex);
+			},
+			collect: (monitor) => ({
+				isOver: monitor.isOver(),
+			}),
+		}),
+		[tabs, onReorderTab],
+	);
+
+	// Clear indicator when cursor leaves the tab bar
+	if (!isOver && insertIndexRef.current !== null) {
+		insertIndexRef.current = null;
+		if (insertIndex !== null) setInsertIndex(null);
+	}
+
+	const setScrollContainerRef = useCallback(
+		(node: HTMLDivElement | null) => {
+			(
+				scrollContainerRef as React.MutableRefObject<HTMLDivElement | null>
+			).current = node;
+			connectDrop(node);
+		},
+		[connectDrop],
+	);
 
 	const updateOverflow = useCallback(() => {
 		const container = scrollContainerRef.current;
@@ -104,6 +167,8 @@ export function TabBar<TData>({
 		requestAnimationFrame(updateOverflow);
 	}, [updateOverflow]);
 
+	const insertLineLeft = insertIndex !== null ? insertIndex * TAB_WIDTH : null;
+
 	if (tabs.length === 0) {
 		return (
 			<div className="group/root-tabs flex h-10 min-w-0 shrink-0 items-stretch border-b border-border bg-background">
@@ -118,7 +183,7 @@ export function TabBar<TData>({
 	return (
 		<div className="group/root-tabs flex h-10 min-w-0 shrink-0 items-stretch border-b border-border bg-background">
 			<div
-				ref={scrollContainerRef}
+				ref={setScrollContainerRef}
 				className={cn(
 					"flex min-w-0 flex-1 items-stretch overflow-x-auto overflow-y-hidden",
 					hasHorizontalOverflow
@@ -132,15 +197,16 @@ export function TabBar<TData>({
 						: "hide-scrollbar",
 				)}
 			>
-				<div ref={tabsTrackRef} className="flex h-full items-stretch">
-					{tabs.map((tab) => (
+				<div ref={tabsTrackRef} className="relative flex h-full items-stretch">
+					{tabs.map((tab, i) => (
 						<div
 							className="h-full shrink-0"
 							key={tab.id}
-							style={{ width: "160px" }}
+							style={{ width: TAB_WIDTH }}
 						>
 							<TabItem
 								tab={tab}
+								index={i}
 								isActive={tab.id === activeTabId}
 								onSelect={() => onSelectTab(tab.id)}
 								onClose={() => onCloseTab(tab.id)}
@@ -152,6 +218,12 @@ export function TabBar<TData>({
 							/>
 						</div>
 					))}
+					{insertLineLeft !== null && (
+						<div
+							className="pointer-events-none absolute top-0 z-10 h-full w-0.5 bg-primary opacity-85"
+							style={{ left: insertLineLeft }}
+						/>
+					)}
 					{!hasHorizontalOverflow && (
 						<div className="flex h-full w-10 shrink-0 items-stretch">
 							<AddTabButton renderAddTabMenu={renderAddTabMenu} />

--- a/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
@@ -10,13 +10,16 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { PencilIcon, XIcon } from "lucide-react";
 import { type ReactNode, useCallback, useRef, useState } from "react";
-import { useDrop } from "react-dnd";
+import { useDrag, useDrop } from "react-dnd";
 import type { Tab } from "../../../../../../../types";
 import { PANE_DRAG_TYPE } from "../../../Tab/components/Pane/components/PaneHeader";
 import { TabRenameInput } from "./components/TabRenameInput";
 
+export const TAB_DRAG_TYPE = "tab";
+
 interface TabItemProps<TData> {
 	tab: Tab<TData>;
+	index: number;
 	isActive: boolean;
 	onSelect: () => void;
 	onClose: () => void;
@@ -29,6 +32,7 @@ interface TabItemProps<TData> {
 
 export function TabItem<TData>({
 	tab,
+	index,
 	isActive,
 	onSelect,
 	onClose,
@@ -59,7 +63,21 @@ export function TabItem<TData>({
 		stopEditing();
 	};
 
-	const [{ isOver }, connectDrop] = useDrop(
+	const nodeRef = useRef<HTMLDivElement>(null);
+
+	const [{ isDragging }, connectDrag] = useDrag(
+		() => ({
+			type: TAB_DRAG_TYPE,
+			item: { tabId: tab.id, index },
+			collect: (monitor) => ({
+				isDragging: monitor.isDragging(),
+			}),
+		}),
+		[tab.id, index],
+	);
+
+	// Existing pane-to-tab drop (hovering a pane over a tab switches to it)
+	const [{ isOver: isPaneOver }, connectPaneDrop] = useDrop(
 		() => ({
 			accept: PANE_DRAG_TYPE,
 			hover: () => {
@@ -72,24 +90,27 @@ export function TabItem<TData>({
 		[isActive, onSelect],
 	);
 
-	const nodeRef = useRef<HTMLDivElement>(null);
-	const setDropRef = useCallback(
+	const setRef = useCallback(
 		(node: HTMLDivElement | null) => {
 			(nodeRef as React.MutableRefObject<HTMLDivElement | null>).current = node;
-			connectDrop(node);
+			connectDrag(node);
+			connectPaneDrop(node);
 		},
-		[connectDrop],
+		[connectDrag, connectPaneDrop],
 	);
 
 	return (
 		<ContextMenu>
 			<ContextMenuTrigger asChild>
+				{/* biome-ignore lint/a11y/noStaticElementInteractions: mousedown selects tab immediately before drag threshold */}
 				<div
-					ref={setDropRef}
+					ref={setRef}
 					className={cn(
 						"group relative flex h-full w-full items-center border-r border-border",
-						isOver && "bg-primary/5",
+						isPaneOver && "bg-primary/5",
+						isDragging && "opacity-30",
 					)}
+					onMouseDown={onSelect}
 				>
 					{isEditing ? (
 						<div className="flex h-full w-full shrink-0 items-center px-2">
@@ -104,7 +125,10 @@ export function TabItem<TData>({
 						</div>
 					) : (
 						<>
-							<Tooltip delayDuration={500}>
+							<Tooltip
+								delayDuration={500}
+								open={isDragging ? false : undefined}
+							>
 								<TooltipTrigger asChild>
 									<button
 										className={cn(

--- a/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/index.ts
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/index.ts
@@ -1,1 +1,1 @@
-export { TabItem } from "./TabItem";
+export { TAB_DRAG_TYPE, TabItem } from "./TabItem";

--- a/packages/panes/src/react/components/Workspace/components/TabBar/utils/index.ts
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/utils/index.ts
@@ -1,0 +1,1 @@
+export { computeInsertIndex, TAB_WIDTH } from "./utils";

--- a/packages/panes/src/react/components/Workspace/components/TabBar/utils/utils.ts
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/utils/utils.ts
@@ -1,0 +1,17 @@
+export const TAB_WIDTH = 160;
+
+export function computeInsertIndex(
+	clientX: number,
+	trackRect: DOMRect,
+	tabCount: number,
+): number {
+	const x = clientX - trackRect.left;
+	const tabIndex = Math.floor(x / TAB_WIDTH);
+	const withinTab = x % TAB_WIDTH;
+
+	// Past all tabs → insert at end
+	if (tabIndex >= tabCount) return tabCount;
+
+	// Left half → insert before this tab, right half → insert after
+	return withinTab > TAB_WIDTH / 2 ? tabIndex + 1 : tabIndex;
+}


### PR DESCRIPTION
## Summary
- Drag tabs in the tab bar to reorder them
- TabBar owns the drop interaction — computes insertion index from cursor x-position and fixed tab width (160px)
- Insertion line (absolute-positioned `bg-primary` div) shows where the tab will land, including past the last tab
- Native HTML5 drag preview, source tab dims during drag

## Changes
- **Store**: new `reorderTab` action — splice-based with index clamping
- **TabItem**: `useDrag` makes tabs draggable, `onMouseDown` selects tab immediately on press
- **TabBar**: `useDrop` on scroll container for full-width drop coverage, renders insertion line at `insertIndex * TAB_WIDTH`
- **Workspace**: wires `onReorderTab` to store
- Tooltip suppressed on source tab during drag

## Test plan
- [ ] Drag a tab → source dims, native preview follows cursor
- [ ] Hover over tab area → insertion line appears at correct gap
- [ ] Hover past last tab → line shows at end
- [ ] Drop → tab moves to new position
- [ ] Drag leaves tab bar → line disappears
- [ ] Drag a pane over tab bar → still switches tabs (existing behavior)
- [ ] Click a tab without dragging → selects immediately
- [ ] 67 store tests pass (6 new for reorderTab)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add drag-to-reorder tabs in the workspace tab bar with a clear drop indicator to make tab management faster and more intuitive.

- **New Features**
  - Drag tabs to reorder; an insertion line shows where the tab will land (including after the last tab) and hides when leaving the bar.
  - `TabBar` handles drop via `react-dnd` on the scroll container and computes the target index from cursor x-position with a 160px `TAB_WIDTH`.
  - New store action `reorderTab` with index clamping; wired through `Workspace.onReorderTab`; active tab is preserved (+6 tests).
  - UX polish: native drag preview, dragged tab dims, tooltip hidden during drag, and mouse down selects immediately; pane-over still switches tabs.

<sup>Written for commit 5ad04b76c3de83796bf7d57cf975abde63613b5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced drag-and-drop tab reordering—users can now reorganize tabs by dragging them to their desired positions within the workspace.

* **Tests**
  * Added comprehensive test suite validating tab reordering behavior, including edge cases and state preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->