### PR TITLE
fix(desktop): ensure Electron binary is downloaded in worktrees

### DIFF
--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -19,5 +19,16 @@ if [ -n "$CI" ]; then
   exit 0
 fi
 
+# Ensure the Electron binary is downloaded. With linker = "isolated" in bunfig.toml,
+# bun hardlinks from cache and skips per-package install scripts, so Electron's own
+# postinstall (which downloads the binary) does not run in fresh node_modules (e.g. worktrees).
+ELECTRON_INSTALL=$(cd apps/desktop && bun -e "console.log(require.resolve('electron/install.js'))" 2>/dev/null)
+if [ -n "$ELECTRON_INSTALL" ]; then
+  ELECTRON_DIR=$(dirname "$ELECTRON_INSTALL")
+  if [ ! -f "$ELECTRON_DIR/path.txt" ]; then
+    node "$ELECTRON_INSTALL"
+  fi
+fi
+
 # Install native dependencies for desktop app
 bun run --filter=@superset/desktop install:deps


### PR DESCRIPTION
## Summary
- With `linker = "isolated"` in `bunfig.toml`, bun hardlinks packages from its global cache and skips per-package install scripts
- Electron's `install.js` (which downloads the binary into `dist/`) never runs in fresh `node_modules`, so `path.txt` and the binary are missing
- This breaks `bun dev` in git worktrees and any clean install where the Electron binary wasn't already cached locally
- Adds a check in `postinstall.sh` to run Electron's install script when `path.txt` is missing, before the native rebuild step

## Test plan
- [ ] Delete `node_modules/.bun/electron@*/node_modules/electron/path.txt` and `dist/`, run `bun i`, verify Electron binary is restored
- [ ] Create a fresh git worktree, run `bun i && bun dev`, verify desktop app starts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the Electron binary is downloaded in git worktrees and clean installs with `bun`’s isolated linker, fixing `bun dev` failures for the desktop app. We run `electron/install.js` during postinstall when `path.txt` is missing.

- **Bug Fixes**
  - Resolve `electron/install.js` via `bun -e "require.resolve('electron/install.js')"` and run it with `node` if `path.txt` is absent.
  - Execute this before `bun run --filter=@superset/desktop install:deps` so native rebuilds have the binary.

<sup>Written for commit 93a0dd3e0fa28f5b8faab4e2010713f462a6a634. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the installation process to ensure Electron's installation hook is properly initialized during desktop environment setup. The build workflow now includes additional verification steps to optimize the handling of native dependencies, prevent redundant operations, and improve the overall reliability of the setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->