### PR TITLE
fix(desktop): add trustedDependencies for bun isolated linker

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,16 @@
 	},
 	"patchedDependencies": {
 		"@durable-streams/state@0.2.1": "patches/@durable-streams%2Fstate@0.2.1.patch"
-	}
+	},
+	"trustedDependencies": [
+		"better-sqlite3",
+		"bufferutil",
+		"electron",
+		"esbuild",
+		"koffi",
+		"node-pty",
+		"sharp",
+		"utf-8-validate",
+		"workerd"
+	]
 }


### PR DESCRIPTION
## Summary
- With `linker = "isolated"` in `bunfig.toml`, bun skips dependency lifecycle scripts unless packages are listed in `trustedDependencies`
- This caused `electron`'s `postinstall: "node install.js"` (which downloads the binary) to never run in fresh `node_modules` (e.g. new git worktrees), breaking `bun dev` with "Electron uninstall" errors
- Adds `trustedDependencies` to root `package.json` for all packages with install/postinstall scripts: `electron`, `esbuild`, `better-sqlite3`, `node-pty`, `sharp`, `workerd`, `bufferutil`, `utf-8-validate`, `koffi`

Supersedes #3099 — this fixes the root cause (bun not running dependency lifecycle scripts) rather than working around it in `postinstall.sh`.

## Test plan
- [ ] Delete `node_modules` in a worktree, run `bun i`, verify `node_modules/.bun/electron@*/node_modules/electron/dist/` exists
- [ ] Run `bun dev` and verify desktop app starts without "Electron uninstall" error

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing Electron binaries when using Bun’s isolated linker by adding `trustedDependencies` to the root `package.json`. This makes lifecycle scripts run on fresh installs and unblocks `bun dev`.

- **Bug Fixes**
  - Added `trustedDependencies` for: `electron`, `esbuild`, `better-sqlite3`, `node-pty`, `sharp`, `workerd`, `bufferutil`, `utf-8-validate`, `koffi`.
  - Ensures their install/postinstall scripts run with `linker = "isolated"`.

<sup>Written for commit c53023a64b84480ab90d03405ae200c3586dbefa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration for enhanced dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->