### PR TITLE
feat(panes): double-click separator to equalize split

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -139,7 +139,7 @@ export function TerminalPane({ workspaceId }: WorkspaceTerminalProps) {
 	}, [websocketUrl]);
 
 	return (
-		<div className="w-full rounded-lg border border-border p-4">
+		<div className="w-full p-4">
 			<div className="mb-3 flex items-center justify-between gap-3">
 				<div>
 					<h2 className="text-sm font-medium">terminal</h2>
@@ -161,7 +161,7 @@ export function TerminalPane({ workspaceId }: WorkspaceTerminalProps) {
 			</div>
 			<div
 				ref={containerRef}
-				className="h-[360px] overflow-hidden rounded-md border border-border bg-[#14100f] p-2"
+				className="h-[360px] overflow-hidden bg-[#14100f] p-2"
 			/>
 		</div>
 	);

--- a/packages/panes/src/react/components/Workspace/components/Tab/Tab.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/Tab.tsx
@@ -3,6 +3,7 @@ import {
 	ResizablePanel,
 	ResizablePanelGroup,
 } from "@superset/ui/resizable";
+import { useRef } from "react";
 import type { StoreApi } from "zustand/vanilla";
 import type { WorkspaceStore } from "../../../../../core/store";
 import type { LayoutNode, Tab as TabType } from "../../../../../types";
@@ -26,6 +27,61 @@ function weightsToPercentages(weights: number[]): number[] {
 	const total = weights.reduce((sum, w) => sum + w, 0);
 	if (total === 0) return weights.map(() => 100 / weights.length);
 	return weights.map((w) => (w / total) * 100);
+}
+
+function SplitView<TData>({
+	store,
+	tab,
+	node,
+	registry,
+	paneActions,
+}: {
+	store: StoreApi<WorkspaceStore<TData>>;
+	tab: TabType<TData>;
+	node: Extract<LayoutNode, { type: "split" }>;
+	registry: PaneRegistry<TData>;
+	paneActions?: TabProps<TData>["paneActions"];
+}) {
+	const groupRef = useRef<React.ComponentRef<typeof ResizablePanelGroup>>(null);
+	const percentages = weightsToPercentages(node.weights);
+
+	return (
+		<ResizablePanelGroup
+			ref={groupRef}
+			direction={node.direction}
+			onLayout={(sizes) => {
+				store.getState().resizeSplit({
+					tabId: tab.id,
+					splitId: node.id,
+					weights: sizes,
+				});
+			}}
+			onDoubleClick={(e) => {
+				e.stopPropagation();
+				const equal = node.children.map(() => 100 / node.children.length);
+				groupRef.current?.setLayout(equal);
+			}}
+		>
+			{node.children.map((child, index) => {
+				const key = child.type === "pane" ? child.paneId : child.id;
+				return (
+					<>
+						{index > 0 && <ResizableHandle key={`handle-${key}`} />}
+						<ResizablePanel key={key} defaultSize={percentages[index]}>
+							<LayoutNodeView
+								store={store}
+								tab={tab}
+								node={child}
+								registry={registry}
+								paneActions={paneActions}
+								parentDirection={node.direction}
+							/>
+						</ResizablePanel>
+					</>
+				);
+			})}
+		</ResizablePanelGroup>
+	);
 }
 
 function LayoutNodeView<TData>({
@@ -60,38 +116,14 @@ function LayoutNodeView<TData>({
 		);
 	}
 
-	const percentages = weightsToPercentages(node.weights);
-
 	return (
-		<ResizablePanelGroup
-			direction={node.direction}
-			onLayout={(sizes) => {
-				store.getState().resizeSplit({
-					tabId: tab.id,
-					splitId: node.id,
-					weights: sizes,
-				});
-			}}
-		>
-			{node.children.map((child, index) => {
-				const key = child.type === "pane" ? child.paneId : child.id;
-				return (
-					<>
-						{index > 0 && <ResizableHandle key={`handle-${key}`} />}
-						<ResizablePanel key={key} defaultSize={percentages[index]}>
-							<LayoutNodeView
-								store={store}
-								tab={tab}
-								node={child}
-								registry={registry}
-								paneActions={paneActions}
-								parentDirection={node.direction}
-							/>
-						</ResizablePanel>
-					</>
-				);
-			})}
-		</ResizablePanelGroup>
+		<SplitView
+			store={store}
+			tab={tab}
+			node={node}
+			registry={registry}
+			paneActions={paneActions}
+		/>
 	);
 }
 

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
@@ -204,7 +204,7 @@ export function Pane<TData>({
 		// biome-ignore lint/a11y/noStaticElementInteractions: clicking anywhere in a pane focuses it (standard IDE behavior)
 		<div
 			ref={setRefs}
-			className="relative flex h-full w-full flex-col overflow-hidden border-[0.5px] border-border"
+			className="relative flex h-full w-full flex-col overflow-hidden"
 			onMouseDown={context.actions.focus}
 		>
 			<PaneHeader


### PR DESCRIPTION
## Summary
- Adds double-click on separators to equalize all pane sizes within a split
- Works around react-resizable-panels v3 not supporting `onDoubleClick` on handles by listening on the `PanelGroup` with `stopPropagation` to scope to the correct split
- Extracts `SplitView` component to avoid hooks-after-early-return lint violation

## Test plan
- [ ] Split panes unevenly, double-click near the separator — panes should equalize
- [ ] Nested splits: double-clicking should only equalize the targeted split, not parents

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Double-click a split separator to equalize panes in that split, scoped to the current group for nested layouts. Separators now render at the intended thickness by removing pane borders and terminal pane borders/rounding.

- **New Features**
  - Listens for double-click on the `ResizablePanelGroup` and uses its `setLayout` API to set equal sizes.
  - Uses `stopPropagation` to scope the action to the current split since `react-resizable-panels` v3 doesn't support handle double-clicks.

- **Bug Fixes**
  - Removed pane border to avoid doubling with the resize handle and reduce perceived separator thickness.
  - Removed terminal pane borders and rounding to avoid redundant edges with the pane system.

<sup>Written for commit e9f908ef87eac2b0a6c8e723a8f80cf4a2bb5e05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Double-click on split panels to equalize sizes of all child panels within that split.

* **Refactor**
  * Reorganized split/pane layout handling to separate responsibilities while preserving existing resize behavior.

* **Style**
  * Removed subtle border styling from pane and terminal containers for a cleaner, streamlined appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->