### PR TITLE
fix(desktop): prevent duplicate panes when file-open mode is new-tab

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -1,9 +1,6 @@
 import type { PaneRegistry, RendererContext } from "@superset/panes";
 import { FileCode2, Globe, MessageSquare, TerminalSquare } from "lucide-react";
 import { useMemo } from "react";
-import { ChatPane } from "./components/ChatPane";
-import { WorkspaceFilePreview } from "./components/FilesPane/components/WorkspaceFilePreview/WorkspaceFilePreview";
-import { TerminalPane } from "./components/TerminalPane";
 import type {
 	BrowserPaneData,
 	ChatPaneData,
@@ -11,6 +8,9 @@ import type {
 	FilePaneData,
 	PaneViewerData,
 } from "../../types";
+import { ChatPane } from "./components/ChatPane";
+import { WorkspaceFilePreview } from "./components/FilesPane/components/WorkspaceFilePreview/WorkspaceFilePreview";
+import { TerminalPane } from "./components/TerminalPane";
 
 function getFileTitle(filePath: string): string {
 	return filePath.split("/").pop() ?? filePath;
@@ -40,9 +40,7 @@ export function usePaneRegistry(
 			terminal: {
 				getIcon: () => <TerminalSquare className="size-4" />,
 				getTitle: () => "Terminal",
-				renderPane: () => (
-					<TerminalPane workspaceId={workspaceId} />
-				),
+				renderPane: () => <TerminalPane workspaceId={workspaceId} />,
 			},
 			browser: {
 				getIcon: () => <Globe className="size-4" />,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/useV2WorkspacePaneLayout.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/useV2WorkspacePaneLayout.ts
@@ -1,7 +1,4 @@
-import {
-	createWorkspaceStore,
-	type WorkspaceState,
-} from "@superset/panes";
+import { createWorkspaceStore, type WorkspaceState } from "@superset/panes";
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useEffect, useMemo, useRef, useState } from "react";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -1,10 +1,11 @@
-import { Workspace, type PaneActionConfig } from "@superset/panes";
+import { type PaneActionConfig, Workspace } from "@superset/panes";
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useCallback, useMemo } from "react";
 import { HiMiniXMark } from "react-icons/hi2";
 import { TbLayoutColumns, TbLayoutRows } from "react-icons/tb";
+import { HotkeyTooltipContent } from "renderer/components/HotkeyTooltipContent";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import {
@@ -12,7 +13,6 @@ import {
 	useCommandPalette,
 } from "renderer/screens/main/components/CommandPalette";
 import { PresetsBar } from "renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar";
-import { HotkeyTooltipContent } from "renderer/components/HotkeyTooltipContent";
 import { useAppHotkey } from "renderer/stores/hotkeys";
 import { AddTabMenu } from "./components/AddTabMenu";
 import { WorkspaceEmptyState } from "./components/WorkspaceEmptyState";
@@ -79,22 +79,24 @@ function WorkspaceContent({
 	const utils = electronTrpc.useUtils();
 	const { data: showPresetsBar, isLoading: isLoadingPresetsBar } =
 		electronTrpc.settings.getShowPresetsBar.useQuery();
-	const setShowPresetsBar = electronTrpc.settings.setShowPresetsBar.useMutation({
-		onMutate: async ({ enabled }) => {
-			await utils.settings.getShowPresetsBar.cancel();
-			const previous = utils.settings.getShowPresetsBar.getData();
-			utils.settings.getShowPresetsBar.setData(undefined, enabled);
-			return { previous };
+	const setShowPresetsBar = electronTrpc.settings.setShowPresetsBar.useMutation(
+		{
+			onMutate: async ({ enabled }) => {
+				await utils.settings.getShowPresetsBar.cancel();
+				const previous = utils.settings.getShowPresetsBar.getData();
+				utils.settings.getShowPresetsBar.setData(undefined, enabled);
+				return { previous };
+			},
+			onError: (_error, _variables, context) => {
+				if (context?.previous !== undefined) {
+					utils.settings.getShowPresetsBar.setData(undefined, context.previous);
+				}
+			},
+			onSettled: () => {
+				utils.settings.getShowPresetsBar.invalidate();
+			},
 		},
-		onError: (_error, _variables, context) => {
-			if (context?.previous !== undefined) {
-				utils.settings.getShowPresetsBar.setData(undefined, context.previous);
-			}
-		},
-		onSettled: () => {
-			utils.settings.getShowPresetsBar.invalidate();
-		},
-	});
+	);
 
 	const openFilePane = useCallback(
 		(filePath: string) => {
@@ -206,10 +208,7 @@ function WorkspaceContent({
 				key: "close",
 				icon: <HiMiniXMark className="size-3.5" />,
 				tooltip: (
-					<HotkeyTooltipContent
-						label="Close pane"
-						hotkeyId="CLOSE_TERMINAL"
-					/>
+					<HotkeyTooltipContent label="Close pane" hotkeyId="CLOSE_TERMINAL" />
 				),
 				onClick: (ctx) => ctx.actions.close(),
 			},

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
@@ -62,7 +62,11 @@ function ensureSidebarWorkspaceRecord(
 			tabOrder: getNextTabOrder(topLevelOrders),
 			sectionId: null,
 		},
-		paneLayout: { version: 1, tabs: [], activeTabId: null } satisfies WorkspaceState<unknown>,
+		paneLayout: {
+			version: 1,
+			tabs: [],
+			activeTabId: null,
+		} satisfies WorkspaceState<unknown>,
 	});
 }
 

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -756,17 +756,18 @@ export const useTabsStore = create<TabsStore>()(
 
 					const tabPaneIds = extractPaneIdsFromLayout(activeTab.layout);
 					const reuseExisting = options.reuseExisting ?? "workspace";
-					const existingFileViewerPane = reuseExisting !== "none"
-						? findReusableFileViewerPane({
-								workspaceId,
-								activeTabId: activeTab.id,
-								tabs: state.tabs,
-								panes: state.panes,
-								tabHistoryStacks: state.tabHistoryStacks,
-								reuseExisting,
-								options,
-							})
-						: null;
+					const existingFileViewerPane =
+						reuseExisting !== "none"
+							? findReusableFileViewerPane({
+									workspaceId,
+									activeTabId: activeTab.id,
+									tabs: state.tabs,
+									panes: state.panes,
+									tabHistoryStacks: state.tabHistoryStacks,
+									reuseExisting,
+									options,
+								})
+							: null;
 
 					if (existingFileViewerPane) {
 						const nextPane = applyFileViewerOpenOptionsToPane(
@@ -826,7 +827,11 @@ export const useTabsStore = create<TabsStore>()(
 
 					// If we found an unpinned (preview) file-viewer pane, reuse it
 					// (skip reuse when explicitly requesting a new tab, e.g. cmd+click)
-					if (fileViewerPanes.length > 0 && !options.openInNewTab && reuseExisting !== "none") {
+					if (
+						fileViewerPanes.length > 0 &&
+						!options.openInNewTab &&
+						reuseExisting !== "none"
+					) {
 						const paneToReuse = fileViewerPanes[0];
 						const existingFileViewer = paneToReuse.fileViewer;
 						if (!existingFileViewer) {

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -756,9 +756,7 @@ export const useTabsStore = create<TabsStore>()(
 
 					const tabPaneIds = extractPaneIdsFromLayout(activeTab.layout);
 					const reuseExisting = options.reuseExisting ?? "workspace";
-					const canReuseExistingPane =
-						!options.openInNewTab && reuseExisting !== "none";
-					const existingFileViewerPane = canReuseExistingPane
+					const existingFileViewerPane = reuseExisting !== "none"
 						? findReusableFileViewerPane({
 								workspaceId,
 								activeTabId: activeTab.id,
@@ -828,7 +826,7 @@ export const useTabsStore = create<TabsStore>()(
 
 					// If we found an unpinned (preview) file-viewer pane, reuse it
 					// (skip reuse when explicitly requesting a new tab, e.g. cmd+click)
-					if (fileViewerPanes.length > 0 && canReuseExistingPane) {
+					if (fileViewerPanes.length > 0 && !options.openInNewTab && reuseExisting !== "none") {
 						const paneToReuse = fileViewerPanes[0];
 						const existingFileViewer = paneToReuse.fileViewer;
 						if (!existingFileViewer) {


### PR DESCRIPTION
## Summary
- Always find existing file viewer pane regardless of open mode (from #3093)
- Auto-fix lint formatting and import ordering

## Test plan
- [ ] Verify file viewer panes are reused correctly across open modes
- [ ] Confirm lint passes with `bun run lint`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate file viewer panes when the file-open mode is set to “new-tab.” We now always find an already-open file first and only reuse it in-place when not opening in a new tab.

- **Bug Fixes**
  - Decoupled reusable-pane lookup from `openInNewTab`, so existing file viewer panes are always found first.
  - Reuse the found pane only when `openInNewTab` is false and `reuseExisting` is not `"none"`, avoiding duplicates across open modes.
  - Minor lint and import order cleanups; no behavior changes.

<sup>Written for commit 6c175492c0f2ffbdd42f5fae04ae326a05a3678d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization through better import ordering across workspace components
  * Optimized pane reuse logic for enhanced condition handling
  * Simplified component implementations while maintaining existing functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->