### PR TITLE
fix(desktop): remove PreToolUse/PostToolUse hooks from Codex

### DIFF
--- a/apps/desktop/docs/EXTERNAL_FILES.md
+++ b/apps/desktop/docs/EXTERNAL_FILES.md
@@ -42,7 +42,7 @@ its hook entries into these files while preserving user-defined entries:
 | File | Purpose |
 |------|---------|
 | `~/.claude/settings.json` | Claude Code hook registration merge |
-| `~/.codex/hooks.json` | Codex hook registration merge (`SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Stop`) |
+| `~/.codex/hooks.json` | Codex hook registration merge (`SessionStart`, `UserPromptSubmit`, `Stop`) |
 | `~/.factory/settings.json` | Factory Droid hook registration (`UserPromptSubmit`, `Notification`, `PostToolUse`, `Stop`) |
 
 For Codex specifically, Superset now relies on native `~/.codex/hooks.json`

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-claude-codex-opencode.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-claude-codex-opencode.ts
@@ -385,12 +385,7 @@ export function getCodexGlobalHooksJsonContent(
 	}
 
 	const managedEvents: Array<{
-		eventName:
-			| "SessionStart"
-			| "UserPromptSubmit"
-			| "PreToolUse"
-			| "PostToolUse"
-			| "Stop";
+		eventName: "SessionStart" | "UserPromptSubmit" | "Stop";
 		definition: ClaudeHookDefinition;
 	}> = [
 		{
@@ -402,20 +397,6 @@ export function getCodexGlobalHooksJsonContent(
 		{
 			eventName: "UserPromptSubmit",
 			definition: {
-				hooks: [{ type: "command", command: notifyScriptPath }],
-			},
-		},
-		{
-			eventName: "PreToolUse",
-			definition: {
-				matcher: "*",
-				hooks: [{ type: "command", command: notifyScriptPath }],
-			},
-		},
-		{
-			eventName: "PostToolUse",
-			definition: {
-				matcher: "*",
 				hooks: [{ type: "command", command: notifyScriptPath }],
 			},
 		},

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -888,7 +888,7 @@ describe("agent-wrappers codex hooks.json", () => {
 		rmSync(TEST_ROOT, { recursive: true, force: true });
 	});
 
-	it("creates Codex hooks.json with prompt and tool lifecycle hooks when no file exists", () => {
+	it("creates Codex hooks.json with prompt and lifecycle hooks when no file exists", () => {
 		const notifyPath = "/tmp/.superset/hooks/notify.sh";
 		const content = getCodexGlobalHooksJsonContent(notifyPath);
 		expect(content).not.toBeNull();
@@ -907,8 +907,6 @@ describe("agent-wrappers codex hooks.json", () => {
 		for (const eventName of [
 			"SessionStart",
 			"UserPromptSubmit",
-			"PreToolUse",
-			"PostToolUse",
 			"Stop",
 		] as const) {
 			const hooks = parsed.hooks[eventName];
@@ -920,12 +918,8 @@ describe("agent-wrappers codex hooks.json", () => {
 			).toBe(true);
 		}
 
-		expect(parsed.hooks.PreToolUse?.every((def) => def.matcher === "*")).toBe(
-			true,
-		);
-		expect(parsed.hooks.PostToolUse?.every((def) => def.matcher === "*")).toBe(
-			true,
-		);
+		expect(parsed.hooks.PreToolUse).toBeUndefined();
+		expect(parsed.hooks.PostToolUse).toBeUndefined();
 	});
 
 	it("preserves user hooks when merging", () => {
@@ -987,7 +981,7 @@ describe("agent-wrappers codex hooks.json", () => {
 
 		const parsed = JSON.parse(content);
 
-		// Preserves user hook
+		// Preserves user hooks (including PreToolUse/PostToolUse which we don't manage)
 		expect(
 			parsed.hooks.Stop.some((def: { hooks: Array<{ command: string }> }) =>
 				def.hooks.some(
@@ -1024,32 +1018,19 @@ describe("agent-wrappers codex hooks.json", () => {
 			),
 		).toBe(true);
 
-		// Adds managed hook
-		expect(
-			parsed.hooks.Stop.some((def: { hooks: Array<{ command: string }> }) =>
-				def.hooks.some(
-					(hook: { command: string }) => hook.command === notifyPath,
+		// Adds managed hooks for SessionStart, UserPromptSubmit, Stop
+		for (const eventName of ["SessionStart", "UserPromptSubmit", "Stop"]) {
+			expect(
+				parsed.hooks[eventName].some(
+					(def: { hooks: Array<{ command: string }> }) =>
+						def.hooks.some(
+							(hook: { command: string }) => hook.command === notifyPath,
+						),
 				),
-			),
-		).toBe(true);
+			).toBe(true);
+		}
 
-		// Also creates prompt + start hooks
-		expect(
-			parsed.hooks.SessionStart.some(
-				(def: { hooks: Array<{ command: string }> }) =>
-					def.hooks.some(
-						(hook: { command: string }) => hook.command === notifyPath,
-					),
-			),
-		).toBe(true);
-		expect(
-			parsed.hooks.UserPromptSubmit.some(
-				(def: { hooks: Array<{ command: string }> }) =>
-					def.hooks.some(
-						(hook: { command: string }) => hook.command === notifyPath,
-					),
-			),
-		).toBe(true);
+		// Does NOT inject managed hooks for PreToolUse/PostToolUse
 		expect(
 			parsed.hooks.PreToolUse.some(
 				(def: { hooks: Array<{ command: string }> }) =>
@@ -1057,7 +1038,7 @@ describe("agent-wrappers codex hooks.json", () => {
 						(hook: { command: string }) => hook.command === notifyPath,
 					),
 			),
-		).toBe(true);
+		).toBe(false);
 		expect(
 			parsed.hooks.PostToolUse.some(
 				(def: { hooks: Array<{ command: string }> }) =>
@@ -1065,37 +1046,7 @@ describe("agent-wrappers codex hooks.json", () => {
 						(hook: { command: string }) => hook.command === notifyPath,
 					),
 			),
-		).toBe(true);
-	});
-
-	it("adds UserPromptSubmit, PreToolUse, and PostToolUse to the Codex hooks.json merge", () => {
-		const notifyPath = "/tmp/.superset/hooks/notify.sh";
-		const content = getCodexGlobalHooksJsonContent(notifyPath);
-		expect(content).not.toBeNull();
-		if (content === null) throw new Error("Expected content");
-
-		const parsed = JSON.parse(content) as {
-			hooks: Record<
-				string,
-				Array<{
-					matcher?: string;
-					hooks: Array<{ type: string; command: string }>;
-				}>
-			>;
-		};
-
-		for (const eventName of [
-			"UserPromptSubmit",
-			"PreToolUse",
-			"PostToolUse",
-		] as const) {
-			expect(parsed.hooks[eventName]).toBeDefined();
-			expect(
-				parsed.hooks[eventName]?.some((def) =>
-					def.hooks.some((hook) => hook.command === notifyPath),
-				),
-			).toBe(true);
-		}
+		).toBe(false);
 	});
 
 	it("replaces stale Codex hook commands from old superset paths", () => {
@@ -1150,8 +1101,6 @@ describe("agent-wrappers codex hooks.json", () => {
 		for (const eventName of [
 			"SessionStart",
 			"UserPromptSubmit",
-			"PreToolUse",
-			"PostToolUse",
 			"Stop",
 		] as const) {
 			const hooks = parsed.hooks[eventName];


### PR DESCRIPTION
## Summary
- Removes `PreToolUse` and `PostToolUse` from the managed Codex hooks in `~/.codex/hooks.json`
- Codex now only gets `SessionStart`, `UserPromptSubmit`, and `Stop` hooks
- User-defined PreToolUse/PostToolUse hooks are still preserved during merge

## Test plan
- [x] All 25 agent-wrappers tests pass
- [ ] Verify Codex sessions still receive start/stop/prompt notifications

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `PreToolUse` and `PostToolUse` from managed Codex hooks to cut overhead. Codex now only registers `SessionStart`, `UserPromptSubmit`, and `Stop`, while preserving any user-defined pre/post hooks on merge.

- **Bug Fixes**
  - Stop injecting `PreToolUse`/`PostToolUse` into `~/.codex/hooks.json`; only manage `SessionStart`, `UserPromptSubmit`, `Stop`.
  - Preserve user-defined pre/post hooks during merges.
  - Update docs and tests to reflect the new hook set and verify behavior.

<sup>Written for commit 8a385dffe2638bac7726e89682cc1f179fbba848. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Codex hooks management to streamline automatically managed lifecycle entries, now limited to `SessionStart`, `UserPromptSubmit`, and `Stop`.
  * Removed `PreToolUse` and `PostToolUse` from the set of managed hook events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->