### PR TITLE
fix(desktop): resolve fetch() error on New Workspace modal attachment submit

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
@@ -5,6 +5,7 @@ import {
 	PromptInputAttachments,
 	PromptInputButton,
 	PromptInputFooter,
+	type PromptInputMessage,
 	PromptInputSubmit,
 	PromptInputTextarea,
 	PromptInputTools,
@@ -727,7 +728,7 @@ function PromptGroupInner({
 		[],
 	);
 
-	const handleCreate = useCallback(async () => {
+	const handleCreate = useCallback(async (preConvertedFiles?: PromptInputMessage["files"]) => {
 		if (!projectId) {
 			toast.error("Select a project first");
 			return;
@@ -807,7 +808,16 @@ function PromptGroupInner({
 			}
 
 			let convertedFiles: ConvertedFile[] = [];
-			if (detachedFiles.length > 0) {
+			if (preConvertedFiles) {
+				// Files were already converted to data URLs by PromptInput before
+				// calling handleCreate. Using them directly avoids a second fetch()
+				// on blob URLs that may have been revoked by clearComposer().
+				convertedFiles = preConvertedFiles.map((file) => ({
+					data: file.url ?? "",
+					mediaType: file.mediaType ?? "",
+					filename: file.filename,
+				}));
+			} else if (detachedFiles.length > 0) {
 				try {
 					convertedFiles = await Promise.all(
 						detachedFiles.map(async (file) => ({
@@ -1049,9 +1059,14 @@ ${sanitizeText(truncatedBody)}`;
 		workspaceNameEdited,
 	]);
 
-	const handlePromptSubmit = useCallback(() => {
-		void handleCreate();
-	}, [handleCreate]);
+	const handlePromptSubmit = useCallback(
+		(message: PromptInputMessage) => {
+			// Pass already-converted files so handleCreate doesn't re-fetch
+			// blob URLs that PromptInput.handleSubmit may have revoked via clearComposer().
+			void handleCreate(message.files);
+		},
+		[handleCreate],
+	);
 
 	useEffect(() => {
 		if (!isNewWorkspaceModalOpen) return;


### PR DESCRIPTION
## Summary

- **Bug**: Attaching a file to the New Workspace modal and submitting caused a \`fetch()\` error on the blob URL, clearing the pending workspace state (\"context lost\").
- **Root cause**: Race condition between \`PromptInput.handleSubmit\` and \`handleCreate\` over blob URL lifecycle.
- **Fix**: Pass the already-converted files from \`PromptInput.handleSubmit\` through \`handlePromptSubmit\` into \`handleCreate\`, avoiding a redundant (and failing) re-fetch.

## Root cause detail

When a file is attached and the form is submitted:

1. \`PromptInput.handleSubmit\` converts blob URLs → data URLs via \`fetch()\` ✅
2. **\`clearComposer()\`** is called → queues \`setAttachmentFiles(prev => { URL.revokeObjectURL(prev); return []; })\`
3. \`onSubmit\` → \`handlePromptSubmit\` → \`handleCreate()\` runs synchronously:
   - \`attachments.takeFiles()\` reads \`attachmentsRef.current\` (still has old blob URLs before re-render)
   - Queues its own \`setAttachmentFiles([])\`
4. React flushes both batched updates **in order** — \`clearComposer\`'s updater runs **first**, sees the original files, and **revokes the blob URLs**
5. \`handleCreate\` resumes and calls \`fetch(blob:...)\` → URL already revoked → throws → \`clearPendingWorkspace\` called → workspace creation silently fails

The fix passes \`message.files\` (already data URLs) from \`handlePromptSubmit\` to \`handleCreate\`. When \`preConvertedFiles\` is provided, the conversion block is skipped entirely — no \`fetch()\` on revoked URLs.

The keyboard shortcut path (\`Cmd/Ctrl+Enter\`) is unchanged, as it calls \`handleCreate()\` directly without going through \`PromptInput.handleSubmit\`.

## Files changed

- \`apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx\`
  - Add \`PromptInputMessage\` import
  - \`handleCreate\` accepts optional \`preConvertedFiles?: PromptInputMessage["files"]\`
  - \`handlePromptSubmit\` passes \`message.files\` to \`handleCreate\`
  - File conversion block: uses pre-converted files when available, falls back to blob fetch otherwise

## Test plan
- [ ] Attach a file in the New Workspace modal and submit — workspace should be created with the attachment, no fetch error
- [ ] Submit without attachment — unaffected
- [ ] Submit via Cmd+Enter with attachment — unaffected (uses direct \`handleCreate()\` path)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in the New Workspace modal where submitting with an attachment triggered a `fetch()` error on a revoked blob URL. Workspace creation now completes and preserves the pending state.

- **Bug Fixes**
  - Pass pre-converted files from `PromptInput.handleSubmit` through `handlePromptSubmit` to `handleCreate`.
  - Skip blob-to-data URL conversion when `preConvertedFiles` are provided to avoid a second `fetch(blob:...)`.
  - Cmd/Ctrl+Enter path is unchanged and still calls `handleCreate` directly.

<sup>Written for commit 5183f46e6a4b3530b3dad26e41c4efd6af1b375e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file attachment handling in the new workspace prompt creation flow to support pre-converted attachment data, ensuring attachments are processed more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->