### PR TITLE
feat(desktop): add workspace Actions — per-project commands surfaced in the TopBar

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/config/config.ts
+++ b/apps/desktop/src/lib/trpc/routers/config/config.ts
@@ -4,7 +4,11 @@ import { join } from "node:path";
 import { projects, type SelectProject } from "@superset/local-db";
 import { eq } from "drizzle-orm";
 import { localDb } from "main/lib/local-db";
-import type { SetupAction, SetupDetectionResult } from "shared/types/config";
+import type {
+	SetupAction,
+	SetupDetectionResult,
+	WorkspaceAction,
+} from "shared/types/config";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
 import { loadSetupConfig } from "../workspaces/utils/setup";
@@ -484,7 +488,7 @@ export const createConfigRouter = () => {
 					existingConfig = {};
 				}
 
-				// Merge existing config with new setup/teardown values
+				// Merge existing config with new setup/teardown values, preserving actions
 				const config = {
 					...existingConfig,
 					setup: input.setup,
@@ -497,6 +501,74 @@ export const createConfigRouter = () => {
 					return { success: true };
 				} catch (error) {
 					console.error("[config/updateConfig] Failed to write config:", error);
+					throw new Error("Failed to save config");
+				}
+			}),
+
+		// Update the actions array in the config file
+		updateActions: publicProcedure
+			.input(
+				z.object({
+					projectId: z.string(),
+					actions: z.array(
+						z.object({
+							id: z.string(),
+							name: z.string(),
+							command: z.string(),
+							icon: z
+								.enum([
+									"run",
+									"tool",
+									"debug",
+									"test",
+									"terminal",
+									"sparkles",
+									"bolt",
+									"rocket",
+									"build",
+									"deploy",
+								] as const)
+								.optional(),
+						}),
+					),
+				}),
+			)
+			.mutation(({ input }) => {
+				const project = localDb
+					.select()
+					.from(projects)
+					.where(eq(projects.id, input.projectId))
+					.get();
+				if (!project) {
+					throw new Error("Project not found");
+				}
+
+				const configPath = ensureConfigExists(project.mainRepoPath);
+
+				let existingConfig: Record<string, unknown> = {};
+				try {
+					const existingContent = readFileSync(configPath, "utf-8");
+					const parsed = JSON.parse(existingContent);
+					if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+						existingConfig = parsed;
+					}
+				} catch {
+					existingConfig = {};
+				}
+
+				const config = {
+					...existingConfig,
+					actions: input.actions as WorkspaceAction[],
+				};
+
+				try {
+					writeFileSync(configPath, JSON.stringify(config, null, 2), "utf-8");
+					return { success: true };
+				} catch (error) {
+					console.error(
+						"[config/updateActions] Failed to write config:",
+						error,
+					);
 					throw new Error("Failed to save config");
 				}
 			}),

--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/query.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/query.ts
@@ -7,6 +7,7 @@ import {
 import { TRPCError } from "@trpc/server";
 import { eq, isNotNull, isNull } from "drizzle-orm";
 import { localDb } from "main/lib/local-db";
+import type { ActionIconKey } from "shared/types/config";
 import { z } from "zod";
 import { publicProcedure, router } from "../../..";
 import { getWorkspace } from "../utils/db-helpers";
@@ -345,6 +346,92 @@ export const createQueryProcedures = () => {
 				return {
 					commands: config?.run ?? [],
 				};
+			}),
+
+		getResolvedActions: publicProcedure
+			.input(z.object({ workspaceId: z.string() }))
+			.query(({ input }) => {
+				const workspace = localDb
+					.select()
+					.from(workspaces)
+					.where(eq(workspaces.id, input.workspaceId))
+					.get();
+				if (!workspace) {
+					throw new TRPCError({
+						code: "NOT_FOUND",
+						message: `Workspace ${input.workspaceId} not found`,
+					});
+				}
+
+				const project = localDb
+					.select()
+					.from(projects)
+					.where(eq(projects.id, workspace.projectId))
+					.get();
+				if (!project) {
+					return { actions: [], lastUsedActionId: null };
+				}
+
+				const worktree = workspace.worktreeId
+					? localDb
+							.select()
+							.from(worktrees)
+							.where(eq(worktrees.id, workspace.worktreeId))
+							.get()
+					: null;
+
+				const worktreePath =
+					workspace.type === "worktree" && worktree?.path
+						? worktree.path
+						: workspace.type === "branch"
+							? project.mainRepoPath
+							: undefined;
+
+				const config = loadSetupConfig({
+					mainRepoPath: project.mainRepoPath,
+					worktreePath,
+					projectId: project.id,
+				});
+
+				const actions: {
+					id: string;
+					name: string;
+					command: string;
+					icon?: ActionIconKey;
+				}[] = [];
+
+				// Custom actions only — the run script has its own dedicated button
+				for (const action of config?.actions ?? []) {
+					if (action.command.trim()) {
+						actions.push({
+							id: action.id,
+							name: action.name,
+							command: action.command,
+							icon: action.icon,
+						});
+					}
+				}
+
+				return {
+					actions,
+					lastUsedActionId: workspace.lastUsedActionId ?? null,
+				};
+			}),
+
+		setLastUsedAction: publicProcedure
+			.input(
+				z.object({
+					workspaceId: z.string(),
+					actionId: z.string(),
+				}),
+			)
+			.mutation(({ input }) => {
+				localDb
+					.update(workspaces)
+					.set({ lastUsedActionId: input.actionId })
+					.where(eq(workspaces.id, input.workspaceId))
+					.run();
+				return { success: true };
 			}),
 	});
 };

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/setup.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/setup.ts
@@ -53,6 +53,10 @@ function readConfigFile(configPath: string): SetupConfig | null {
 			throw new Error("'run' field must be an array of strings");
 		}
 
+		if (parsed.actions !== undefined && !Array.isArray(parsed.actions)) {
+			throw new Error("'actions' field must be an array");
+		}
+
 		return parsed;
 	} catch (error) {
 		console.error(
@@ -124,6 +128,7 @@ function mergeBaseConfigs(
 		setup: override.setup ?? base.setup,
 		teardown: override.teardown ?? base.teardown,
 		run: override.run ?? base.run,
+		actions: override.actions ?? base.actions,
 	};
 }
 

--- a/apps/desktop/src/renderer/components/IconPicker/IconPicker.tsx
+++ b/apps/desktop/src/renderer/components/IconPicker/IconPicker.tsx
@@ -1,0 +1,83 @@
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import { cn } from "@superset/ui/utils";
+import {
+	HiMiniBeaker,
+	HiMiniBolt,
+	HiMiniBugAnt,
+	HiMiniCommandLine,
+	HiMiniCpuChip,
+	HiMiniCube,
+	HiMiniPlay,
+	HiMiniRocketLaunch,
+	HiMiniWrenchScrewdriver,
+	HiSparkles,
+} from "react-icons/hi2";
+import type { ActionIconKey } from "shared/types/config";
+
+export const ACTION_ICONS: {
+	key: ActionIconKey;
+	label: string;
+	Icon: React.ComponentType<{ className?: string }>;
+}[] = [
+	{ key: "run", label: "Run", Icon: HiMiniPlay },
+	{ key: "tool", label: "Tool", Icon: HiMiniWrenchScrewdriver },
+	{ key: "debug", label: "Debug", Icon: HiMiniBugAnt },
+	{ key: "test", label: "Test", Icon: HiMiniBeaker },
+	{ key: "terminal", label: "Terminal", Icon: HiMiniCommandLine },
+	{ key: "sparkles", label: "AI", Icon: HiSparkles },
+	{ key: "bolt", label: "Bolt", Icon: HiMiniBolt },
+	{ key: "rocket", label: "Deploy", Icon: HiMiniRocketLaunch },
+	{ key: "build", label: "Build", Icon: HiMiniCube },
+	{ key: "deploy", label: "Server", Icon: HiMiniCpuChip },
+];
+
+export function getIconComponent(
+	key: ActionIconKey | undefined,
+): React.ComponentType<{ className?: string }> {
+	return ACTION_ICONS.find((i) => i.key === key)?.Icon ?? HiMiniPlay;
+}
+
+interface IconPickerProps {
+	value: ActionIconKey | undefined;
+	onChange: (key: ActionIconKey) => void;
+	className?: string;
+}
+
+export function IconPicker({ value, onChange, className }: IconPickerProps) {
+	const CurrentIcon = getIconComponent(value);
+
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<button
+					type="button"
+					className={cn(
+						"flex items-center justify-center size-10 rounded-lg bg-muted hover:bg-muted/80 border border-border/50 transition-colors shrink-0",
+						"focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+						className,
+					)}
+					aria-label="Select icon"
+				>
+					<CurrentIcon className="size-5 text-foreground" />
+				</button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="start" className="w-44">
+				{ACTION_ICONS.map(({ key, label, Icon }) => (
+					<DropdownMenuItem
+						key={key}
+						onClick={() => onChange(key)}
+						className={cn(value === key && "font-medium bg-accent/50")}
+					>
+						<Icon className="mr-2 size-4 shrink-0 text-muted-foreground" />
+						{label}
+					</DropdownMenuItem>
+				))}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/apps/desktop/src/renderer/components/IconPicker/index.ts
+++ b/apps/desktop/src/renderer/components/IconPicker/index.ts
@@ -1,0 +1,1 @@
+export { ACTION_ICONS, getIconComponent, IconPicker } from "./IconPicker";

--- a/apps/desktop/src/renderer/lib/project-scripts.ts
+++ b/apps/desktop/src/renderer/lib/project-scripts.ts
@@ -10,5 +10,6 @@ export async function invalidateProjectScriptQueries(
 		utils.config.getConfigContent.invalidate({ projectId }),
 		utils.config.shouldShowSetupCard.invalidate({ projectId }),
 		utils.workspaces.getResolvedRunCommands.invalidate(),
+		utils.workspaces.getResolvedActions.invalidate(),
 	]);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
@@ -3,6 +3,7 @@ import { HiOutlineWifi } from "react-icons/hi2";
 import { useOnlineStatus } from "renderer/hooks/useOnlineStatus";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { getWorkspaceDisplayName } from "renderer/lib/getWorkspaceDisplayName";
+import { ActionsButton } from "./components/ActionsButton";
 import { NavigationControls } from "./components/NavigationControls";
 import { OpenInMenuButton } from "./components/OpenInMenuButton";
 import { OrganizationDropdown } from "./components/OrganizationDropdown";
@@ -72,6 +73,13 @@ export function TopBar() {
 						<HiOutlineWifi className="size-3.5" />
 						<span>Offline</span>
 					</div>
+				)}
+				{!isV2WorkspaceRoute && workspaceId && (
+					<ActionsButton
+						workspaceId={workspaceId}
+						projectId={workspace?.project?.id ?? workspace?.projectId}
+						worktreePath={workspace?.worktreePath}
+					/>
 				)}
 				{isV2WorkspaceRoute ? (
 					<V2WorkspaceOpenInButton workspaceId={v2WorkspaceId} />

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ActionsButton/ActionsButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ActionsButton/ActionsButton.tsx
@@ -1,0 +1,261 @@
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import { cn } from "@superset/ui/utils";
+import { useNavigate } from "@tanstack/react-router";
+import { memo, useCallback, useMemo, useRef, useState } from "react";
+import {
+	HiChevronDown,
+	HiMiniCheck,
+	HiMiniCog6Tooth,
+	HiMiniPlay,
+	HiMiniPlus,
+} from "react-icons/hi2";
+import { getIconComponent } from "renderer/components/IconPicker";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import {
+	buildTerminalCommand,
+	launchCommandInPane,
+} from "renderer/lib/terminal/launch-command";
+import { electronTrpcClient } from "renderer/lib/trpc-client";
+import { useTabsStore } from "renderer/stores/tabs/store";
+import type { ActionIconKey, WorkspaceAction } from "shared/types/config";
+import { AddActionDialog } from "./components/AddActionDialog";
+
+interface ActionsButtonProps {
+	workspaceId: string;
+	projectId?: string | null;
+	worktreePath?: string | null;
+}
+
+type ResolvedAction = {
+	id: string;
+	name: string;
+	command: string;
+	icon?: ActionIconKey;
+};
+
+export const ActionsButton = memo(function ActionsButton({
+	workspaceId,
+	projectId,
+	worktreePath,
+}: ActionsButtonProps) {
+	const navigate = useNavigate();
+	const isLaunchingRef = useRef(false);
+	const [isPending, setIsPending] = useState(false);
+	const [addDialogOpen, setAddDialogOpen] = useState(false);
+
+	const addTab = useTabsStore((s) => s.addTab);
+	const setPaneName = useTabsStore((s) => s.setPaneName);
+	const setActiveTab = useTabsStore((s) => s.setActiveTab);
+	const setFocusedPane = useTabsStore((s) => s.setFocusedPane);
+
+	const { data: actionsData } =
+		electronTrpc.workspaces.getResolvedActions.useQuery(
+			{ workspaceId },
+			{ enabled: !!workspaceId },
+		);
+
+	const actions: ResolvedAction[] = actionsData?.actions ?? [];
+	const lastUsedActionId = actionsData?.lastUsedActionId ?? null;
+
+	const surfacedAction = useMemo<ResolvedAction | null>(() => {
+		if (actions.length === 0) return null;
+		return actions.find((a) => a.id === lastUsedActionId) ?? actions[0];
+	}, [actions, lastUsedActionId]);
+
+	const hasActions = actions.length > 0;
+
+	// The existing actions as WorkspaceAction[] for AddActionDialog
+	const existingActions: WorkspaceAction[] = actions.map((a) => ({
+		id: a.id,
+		name: a.name,
+		command: a.command,
+		icon: a.icon,
+	}));
+
+	const launchAction = useCallback(
+		async (action: ResolvedAction) => {
+			if (isLaunchingRef.current) return;
+			isLaunchingRef.current = true;
+			setIsPending(true);
+
+			try {
+				const command = buildTerminalCommand([action.command]);
+				if (!command) return;
+
+				const initialCwd = worktreePath?.trim() ? worktreePath : undefined;
+				const { tabId, paneId } = addTab(workspaceId, { initialCwd });
+
+				setPaneName(paneId, action.name);
+				setActiveTab(workspaceId, tabId);
+				setFocusedPane(tabId, paneId);
+
+				await launchCommandInPane({
+					paneId,
+					tabId,
+					workspaceId,
+					command,
+					cwd: initialCwd,
+					createOrAttach: (input) =>
+						electronTrpcClient.terminal.createOrAttach.mutate({
+							...input,
+							allowKilled: true,
+						}),
+					write: (input) => electronTrpcClient.terminal.write.mutate(input),
+				});
+
+				// Persist last used (fire and forget)
+				electronTrpcClient.workspaces.setLastUsedAction
+					.mutate({ workspaceId, actionId: action.id })
+					.catch((err) =>
+						console.error("[actions] Failed to persist last used:", err),
+					);
+			} catch (err) {
+				console.error("[actions] Failed to launch action:", err);
+			} finally {
+				isLaunchingRef.current = false;
+				setIsPending(false);
+			}
+		},
+		[
+			addTab,
+			setActiveTab,
+			setFocusedPane,
+			setPaneName,
+			workspaceId,
+			worktreePath,
+		],
+	);
+
+	const handleMainClick = useCallback(() => {
+		if (!hasActions) {
+			setAddDialogOpen(true);
+			return;
+		}
+		if (surfacedAction) void launchAction(surfacedAction);
+	}, [hasActions, launchAction, surfacedAction]);
+
+	const handleConfigureClick = useCallback(() => {
+		if (!projectId) return;
+		void navigate({
+			to: "/settings/project/$projectId/general",
+			params: { projectId },
+			hash: "actions",
+		});
+	}, [navigate, projectId]);
+
+	const SurfacedIcon = surfacedAction
+		? getIconComponent(surfacedAction.icon)
+		: HiMiniPlay;
+
+	return (
+		<>
+			<div className="flex items-center no-drag">
+				{/* Main button — runs the surfaced (last-used) action */}
+				<button
+					type="button"
+					onClick={handleMainClick}
+					disabled={isPending}
+					aria-label={
+						surfacedAction ? `Run ${surfacedAction.name}` : "Add action"
+					}
+					className={cn(
+						"group flex items-center gap-1.5 h-6 px-1.5 sm:pl-1.5 sm:pr-2 rounded-l border border-r-0 border-border/60 bg-secondary/50 text-xs font-medium",
+						"transition-all duration-150 ease-out",
+						"hover:bg-secondary hover:border-border",
+						"focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+						"active:scale-[0.98]",
+						isPending && "opacity-50 pointer-events-none",
+						!hasActions &&
+							"text-muted-foreground/80 border-border/40 bg-secondary/40",
+					)}
+				>
+					{hasActions ? (
+						<SurfacedIcon className="size-3.5 shrink-0" />
+					) : (
+						<HiMiniPlus className="size-3.5 shrink-0" />
+					)}
+					<span className="hidden sm:inline">
+						{hasActions ? (surfacedAction?.name ?? "Actions") : "Add action"}
+					</span>
+				</button>
+
+				{/* Dropdown — lists all actions */}
+				<DropdownMenu>
+					<DropdownMenuTrigger asChild>
+						<button
+							type="button"
+							disabled={isPending}
+							className={cn(
+								"flex items-center justify-center h-6 w-6 rounded-r border border-border/60 bg-secondary/50 text-muted-foreground",
+								"transition-all duration-150 ease-out",
+								"hover:bg-secondary hover:border-border hover:text-foreground",
+								"focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+								"active:scale-[0.98]",
+								isPending && "opacity-50 pointer-events-none",
+								!hasActions &&
+									"text-muted-foreground/80 border-border/40 bg-secondary/40",
+							)}
+						>
+							<HiChevronDown className="size-3.5" />
+						</button>
+					</DropdownMenuTrigger>
+
+					<DropdownMenuContent align="end" className="w-52">
+						{hasActions && (
+							<DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+								app actions
+							</DropdownMenuLabel>
+						)}
+
+						{actions.map((action) => {
+							const Icon = getIconComponent(action.icon);
+							const isSurfaced = action.id === surfacedAction?.id;
+							return (
+								<DropdownMenuItem
+									key={action.id}
+									onClick={() => void launchAction(action)}
+									className={cn(isSurfaced && "font-medium")}
+								>
+									<Icon className="mr-2 size-4 shrink-0 text-muted-foreground" />
+									<span className="truncate flex-1">{action.name}</span>
+									{isSurfaced && (
+										<HiMiniCheck className="ml-auto size-3.5 shrink-0 text-muted-foreground" />
+									)}
+								</DropdownMenuItem>
+							);
+						})}
+
+						{hasActions && <DropdownMenuSeparator />}
+
+						<DropdownMenuItem onClick={() => setAddDialogOpen(true)}>
+							<HiMiniPlus className="mr-2 size-4 shrink-0 text-muted-foreground" />
+							Add action
+						</DropdownMenuItem>
+
+						<DropdownMenuItem
+							onClick={handleConfigureClick}
+							disabled={!projectId}
+						>
+							<HiMiniCog6Tooth className="mr-2 size-4 shrink-0 text-muted-foreground" />
+							Configure
+						</DropdownMenuItem>
+					</DropdownMenuContent>
+				</DropdownMenu>
+			</div>
+
+			<AddActionDialog
+				open={addDialogOpen}
+				onClose={() => setAddDialogOpen(false)}
+				projectId={projectId}
+				existingActions={existingActions}
+			/>
+		</>
+	);
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ActionsButton/components/AddActionDialog/AddActionDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ActionsButton/components/AddActionDialog/AddActionDialog.tsx
@@ -1,0 +1,167 @@
+import { Button } from "@superset/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogTitle,
+} from "@superset/ui/dialog";
+import { Input } from "@superset/ui/input";
+import { Label } from "@superset/ui/label";
+import { toast } from "@superset/ui/sonner";
+import { useNavigate } from "@tanstack/react-router";
+import { useCallback, useState } from "react";
+import { getIconComponent, IconPicker } from "renderer/components/IconPicker";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { invalidateProjectScriptQueries } from "renderer/lib/project-scripts";
+import type { ActionIconKey, WorkspaceAction } from "shared/types/config";
+import { v4 as uuidv4 } from "uuid";
+
+interface AddActionDialogProps {
+	open: boolean;
+	onClose: () => void;
+	projectId: string | null | undefined;
+	existingActions: WorkspaceAction[];
+}
+
+export function AddActionDialog({
+	open,
+	onClose,
+	projectId,
+	existingActions,
+}: AddActionDialogProps) {
+	const navigate = useNavigate();
+	const utils = electronTrpc.useUtils();
+	const updateActionsMutation = electronTrpc.config.updateActions.useMutation();
+
+	const [name, setName] = useState("");
+	const [command, setCommand] = useState("");
+	const [icon, setIcon] = useState<ActionIconKey>("run");
+	const [isSaving, setIsSaving] = useState(false);
+
+	const reset = useCallback(() => {
+		setName("");
+		setCommand("");
+		setIcon("run");
+		setIsSaving(false);
+	}, []);
+
+	const handleClose = useCallback(() => {
+		reset();
+		onClose();
+	}, [reset, onClose]);
+
+	const handleSave = useCallback(async () => {
+		if (!name.trim() || !command.trim() || !projectId) return;
+		setIsSaving(true);
+		try {
+			const newAction: WorkspaceAction = {
+				id: uuidv4(),
+				name: name.trim(),
+				command: command.trim(),
+				icon,
+			};
+			const updated = [...existingActions, newAction];
+			await updateActionsMutation.mutateAsync({
+				projectId,
+				actions: updated,
+			});
+			await invalidateProjectScriptQueries(utils, projectId);
+			toast.success(`Action "${name.trim()}" saved`);
+			handleClose();
+		} catch (err) {
+			console.error("[add-action] Failed to save:", err);
+			setIsSaving(false);
+		}
+	}, [
+		name,
+		command,
+		icon,
+		projectId,
+		existingActions,
+		updateActionsMutation,
+		utils,
+		handleClose,
+	]);
+
+	const handleEnvironmentSettings = useCallback(() => {
+		if (!projectId) return;
+		handleClose();
+		void navigate({
+			to: "/settings/project/$projectId/general",
+			params: { projectId },
+			hash: "actions",
+		});
+	}, [navigate, projectId, handleClose]);
+
+	const PreviewIcon = getIconComponent(icon);
+
+	return (
+		<Dialog open={open} onOpenChange={(o) => !o && handleClose()}>
+			<DialogContent className="max-w-md p-6 gap-0">
+				{/* Top icon */}
+				<div className="flex items-center justify-center size-12 rounded-xl bg-muted mb-4 shrink-0">
+					<PreviewIcon className="size-6 text-foreground" />
+				</div>
+
+				<DialogTitle className="text-xl font-bold mb-1">Add action</DialogTitle>
+				<DialogDescription className="text-sm text-muted-foreground mb-5">
+					Create a new command to run from the toolbar.
+				</DialogDescription>
+
+				{/* Name */}
+				<div className="space-y-2 mb-4">
+					<Label className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+						Name
+					</Label>
+					<div className="flex items-center gap-2">
+						<IconPicker value={icon} onChange={setIcon} />
+						<Input
+							value={name}
+							onChange={(e) => setName(e.target.value)}
+							placeholder="e.g. Dev Server"
+							className="h-10 text-sm flex-1"
+							onKeyDown={(e) => {
+								if (e.key === "Enter") void handleSave();
+							}}
+							autoFocus
+						/>
+					</div>
+				</div>
+
+				{/* Command */}
+				<div className="space-y-2 mb-6">
+					<Label className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+						Command to run
+					</Label>
+					<textarea
+						value={command}
+						onChange={(e) => setCommand(e.target.value)}
+						placeholder={"eg:\nnpm install\nnpm run"}
+						rows={5}
+						className="w-full rounded-lg border border-border bg-muted/30 p-3 text-sm font-mono resize-none focus:outline-none focus:ring-1 focus:ring-ring"
+					/>
+				</div>
+
+				{/* Footer */}
+				<div className="flex items-center justify-between gap-3">
+					<button
+						type="button"
+						onClick={handleEnvironmentSettings}
+						className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+					>
+						Environment settings
+					</button>
+					<Button
+						type="button"
+						size="sm"
+						disabled={!name.trim() || !command.trim() || isSaving}
+						onClick={() => void handleSave()}
+						className="px-5"
+					>
+						Save
+					</Button>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ActionsButton/components/AddActionDialog/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ActionsButton/components/AddActionDialog/index.ts
@@ -1,0 +1,1 @@
+export { AddActionDialog } from "./AddActionDialog";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ActionsButton/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/ActionsButton/index.ts
@@ -1,0 +1,1 @@
+export { ActionsButton } from "./ActionsButton";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/ProjectSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/ProjectSettings.tsx
@@ -52,6 +52,7 @@ import {
 	SETTING_ITEM_ID,
 } from "../../../../utils/settings-search";
 import { ProjectSettingsHeader } from "../ProjectSettingsHeader";
+import { ActionsEditor } from "./components/ActionsEditor";
 import { ScriptsEditor } from "./components/ScriptsEditor";
 
 const REPO_DEFAULT_BASE_BRANCH = "__repo_default__";
@@ -569,6 +570,10 @@ export function ProjectSettings({
 
 				<div className="pt-3 border-t">
 					<ScriptsEditor projectId={project.id} />
+				</div>
+
+				<div className="pt-3 border-t">
+					<ActionsEditor projectId={project.id} />
 				</div>
 
 				<SettingsSection

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/components/ActionsEditor/ActionsEditor.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/components/ActionsEditor/ActionsEditor.tsx
@@ -1,0 +1,197 @@
+import { Button } from "@superset/ui/button";
+import { Input } from "@superset/ui/input";
+import { Label } from "@superset/ui/label";
+import { cn } from "@superset/ui/utils";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { HiMiniPlus, HiMiniTrash } from "react-icons/hi2";
+import { IconPicker } from "renderer/components/IconPicker";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { invalidateProjectScriptQueries } from "renderer/lib/project-scripts";
+import type { WorkspaceAction } from "shared/types/config";
+import { v4 as uuidv4 } from "uuid";
+
+interface ActionsEditorProps {
+	projectId: string;
+	className?: string;
+}
+
+function parseActionsFromConfig(content: string | null): WorkspaceAction[] {
+	if (!content) return [];
+	try {
+		const parsed = JSON.parse(content);
+		return Array.isArray(parsed.actions) ? parsed.actions : [];
+	} catch {
+		return [];
+	}
+}
+
+interface ActionCardProps {
+	action: WorkspaceAction;
+	onUpdate: (id: string, patch: Partial<WorkspaceAction>) => void;
+	onDelete: (id: string) => void;
+}
+
+function ActionCard({ action, onUpdate, onDelete }: ActionCardProps) {
+	return (
+		<div className="rounded-lg border border-border bg-background p-4 space-y-4">
+			{/* Name row */}
+			<div className="space-y-1.5">
+				<Label className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+					Name
+				</Label>
+				<div className="flex items-center gap-2">
+					<IconPicker
+						value={action.icon}
+						onChange={(key) => onUpdate(action.id, { icon: key })}
+					/>
+					<Input
+						value={action.name}
+						onChange={(e) => onUpdate(action.id, { name: e.target.value })}
+						placeholder="Action name"
+						className="h-10 text-sm"
+					/>
+				</div>
+			</div>
+
+			{/* Command row */}
+			<div className="space-y-1.5">
+				<Label className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+					Command
+				</Label>
+				<Input
+					value={action.command}
+					onChange={(e) => onUpdate(action.id, { command: e.target.value })}
+					placeholder="e.g. bun run dev"
+					className="h-10 text-sm font-mono"
+				/>
+			</div>
+
+			{/* Footer with delete */}
+			<div className="flex items-center justify-end pt-1">
+				<button
+					type="button"
+					onClick={() => onDelete(action.id)}
+					className="text-muted-foreground hover:text-destructive transition-colors"
+					aria-label="Delete action"
+				>
+					<HiMiniTrash className="size-4" />
+				</button>
+			</div>
+		</div>
+	);
+}
+
+export function ActionsEditor({ projectId, className }: ActionsEditorProps) {
+	const utils = electronTrpc.useUtils();
+
+	const { data: configData } = electronTrpc.config.getConfigContent.useQuery(
+		{ projectId },
+		{ enabled: !!projectId },
+	);
+
+	const [actions, setActions] = useState<WorkspaceAction[]>([]);
+	const debounceRef = useRef<NodeJS.Timeout | null>(null);
+	const latestActionsRef = useRef<WorkspaceAction[]>([]);
+
+	latestActionsRef.current = actions;
+
+	const updateActionsMutation = electronTrpc.config.updateActions.useMutation();
+
+	useEffect(() => {
+		// Don't overwrite if there's a pending debounce
+		if (debounceRef.current) return;
+		setActions(parseActionsFromConfig(configData?.content ?? null));
+	}, [configData?.content]);
+
+	const persistActions = useCallback(() => {
+		if (debounceRef.current) clearTimeout(debounceRef.current);
+		debounceRef.current = setTimeout(async () => {
+			debounceRef.current = null;
+			try {
+				await updateActionsMutation.mutateAsync({
+					projectId,
+					actions: latestActionsRef.current,
+				});
+				await invalidateProjectScriptQueries(utils, projectId);
+			} catch (error) {
+				console.error("[actions/save] Failed to save:", error);
+			}
+		}, 500);
+	}, [projectId, updateActionsMutation, utils]);
+
+	// Cleanup on unmount
+	useEffect(() => {
+		return () => {
+			if (debounceRef.current) clearTimeout(debounceRef.current);
+		};
+	}, []);
+
+	const handleAddAction = useCallback(() => {
+		const action: WorkspaceAction = {
+			id: uuidv4(),
+			name: "",
+			command: "",
+			icon: "run",
+		};
+		const updated = [...latestActionsRef.current, action];
+		setActions(updated);
+		persistActions();
+	}, [persistActions]);
+
+	const handleDeleteAction = useCallback(
+		(id: string) => {
+			const updated = latestActionsRef.current.filter((a) => a.id !== id);
+			setActions(updated);
+			persistActions();
+		},
+		[persistActions],
+	);
+
+	const handleUpdateAction = useCallback(
+		(id: string, patch: Partial<WorkspaceAction>) => {
+			const updated = latestActionsRef.current.map((a) =>
+				a.id === id ? { ...a, ...patch } : a,
+			);
+			setActions(updated);
+			persistActions();
+		},
+		[persistActions],
+	);
+
+	return (
+		<div className={cn("space-y-4", className)} id="actions">
+			<div className="flex items-center justify-between">
+				<div>
+					<h3 className="text-base font-semibold text-foreground">Actions</h3>
+					<p className="text-sm text-muted-foreground mt-0.5">
+						These actions can run any command and will be displayed in the
+						header.
+					</p>
+				</div>
+				<Button
+					type="button"
+					variant="secondary"
+					size="sm"
+					onClick={handleAddAction}
+					className="shrink-0"
+				>
+					<HiMiniPlus className="size-4 mr-1" />
+					Add action
+				</Button>
+			</div>
+
+			{actions.length > 0 && (
+				<div className="space-y-3">
+					{actions.map((action) => (
+						<ActionCard
+							key={action.id}
+							action={action}
+							onUpdate={handleUpdateAction}
+							onDelete={handleDeleteAction}
+						/>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/components/ActionsEditor/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/components/ProjectSettings/components/ActionsEditor/index.ts
@@ -1,0 +1,1 @@
+export { ActionsEditor } from "./ActionsEditor";

--- a/apps/desktop/src/shared/types/config.ts
+++ b/apps/desktop/src/shared/types/config.ts
@@ -1,7 +1,27 @@
+export type ActionIconKey =
+	| "run"
+	| "tool"
+	| "debug"
+	| "test"
+	| "terminal"
+	| "sparkles"
+	| "bolt"
+	| "rocket"
+	| "build"
+	| "deploy";
+
+export interface WorkspaceAction {
+	id: string;
+	name: string;
+	command: string;
+	icon?: ActionIconKey;
+}
+
 export interface SetupConfig {
 	setup?: string[];
 	teardown?: string[];
 	run?: string[];
+	actions?: WorkspaceAction[];
 }
 
 export interface LocalScriptMerge {

--- a/packages/local-db/drizzle/0039_add_last_used_action_id.sql
+++ b/packages/local-db/drizzle/0039_add_last_used_action_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `workspaces` ADD `last_used_action_id` text;

--- a/packages/local-db/drizzle/meta/_journal.json
+++ b/packages/local-db/drizzle/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1774995017185,
       "tag": "0038_quick_star_brand",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "6",
+      "when": 1775000000000,
+      "tag": "0039_add_last_used_action_id",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/local-db/src/schema/schema.ts
+++ b/packages/local-db/src/schema/schema.ts
@@ -131,6 +131,8 @@ export const workspaces = sqliteTable(
 		sectionId: text("section_id").references(() => workspaceSections.id, {
 			onDelete: "set null",
 		}),
+		// ID of the last action run in this workspace (for surfacing in the actions button)
+		lastUsedActionId: text("last_used_action_id"),
 	},
 	(table) => [
 		index("workspaces_project_id_idx").on(table.projectId),


### PR DESCRIPTION
## Summary
- Adds an **Actions** system: per-project one-click commands stored in `.superset/config.json` under the `actions` key, separate from `run`/`setup`/`teardown`
- Adds an **ActionsButton** split button to the TopBar (left of Open), showing the last-used action and a dropdown to run any action or add new ones
- Adds an **ActionsEditor** to project settings and an **AddActionDialog** accessible directly from the TopBar dropdown

<img width="694" height="338" alt="Actions" src="https://github.com/user-attachments/assets/aef6d2a8-32d8-4064-82c4-cd95ef4f3ea1" />

## Why / Context
Projects need a way to surface arbitrary commands (dev server, linter, test runner, AI agents, etc.) as one-click buttons without conflating them with the lifecycle scripts (`setup`/`teardown`) or the stateful `run` button. Actions are manual + foreground but without the run-state tracking — closer to bookmarked terminal commands.

## How It Works

**Config layer** (`actions` key in `.superset/config.json`):
```json
{
  "actions": [
    { "id": "uuid", "name": "Dev Server", "command": "bun run dev", "icon": "run" }
  ]
}
```
Actions flow through the existing 3-tier config resolution (user override → worktree → main repo).

**tRPC procedures:**
- `config.updateActions` — replaces the actions array while preserving all other config fields
- `workspaces.getResolvedActions` — resolves config and returns actions + `lastUsedActionId`
- `workspaces.setLastUsedAction` — persists last-clicked action per workspace in SQLite

**TopBar ActionsButton:**
- Main button shows last-used action icon + name (or `+ Add action` if none defined)
- Clicking runs the action in a new terminal tab, then updates `lastUsedActionId` (fire-and-forget)
- Chevron opens dropdown: actions list (checkmark on last-used) → separator → `Add action` → `Configure`

**AddActionDialog:** Icon picker + name + multiline command textarea. Saves and shows a success toast. "Environment settings" navigates to `project settings#actions`.

**ActionsEditor:** Card-per-action layout in project settings with inline editing, debounced autosave, and delete.

**IconPicker:** Shared component with 10 icons (run, tool, debug, test, terminal, sparkles, bolt, rocket, build, deploy). Exported as `getIconComponent(key)` for use anywhere an action icon needs rendering.

## Manual QA Checklist

### No actions defined
- [ ] ActionsButton shows `+ Add action` label
- [ ] Dropdown shows only `Add action` + `Configure` (no separator above them)
- [ ] Clicking main button opens AddActionDialog

### AddActionDialog
- [ ] Icon picker updates the preview icon at the top of the dialog live
- [ ] Save is disabled until both name and command are filled
- [ ] Saving shows a success toast and closes the dialog
- [ ] New action immediately appears in the TopBar dropdown
- [ ] "Environment settings" closes dialog and navigates to project settings#actions

### ActionsButton with actions
- [ ] Main button shows last-used action icon + name
- [ ] Clicking main button launches action in a new terminal tab
- [ ] Tab is named after the action
- [ ] Dropdown shows checkmark next to last-used action
- [ ] Clicking a different action updates the checkmark on next open
- [ ] `Configure` navigates to project settings#actions

### ActionsEditor (project settings)
- [ ] Actions listed as cards with icon picker, name, command inputs
- [ ] Editing any field autosaves (debounced)
- [ ] Delete removes the action and reflects immediately in TopBar
- [ ] `Add action` button in the header opens a new blank card

### Config / cross-workspace
- [ ] Actions defined in `.superset/config.json` appear in all workspaces for that project
- [ ] `lastUsedActionId` is per-workspace (different workspaces can have different last-used)

## Testing
- `bun run typecheck` — 22/22 pass
- `bun run lint` — clean
- Manual testing in dev mode

## Design Decisions
- **Actions separate from Run**: `run` has dedicated state tracking (stop/force-stop), actions don't. Keeping them as separate buttons avoids conflating stateful and stateless execution.
- **Per-workspace last-used in SQLite**: Allows each workspace to independently remember its preferred action without touching the shared config file.
- **Debounced autosave in ActionsEditor**: 500ms debounce via `latestActionsRef` avoids losing edits when the user types quickly across fields.

## Follow-ups
- Action output options (background/headless vs foreground tab)
- Lifecycle actions (workspace-create, workspace-delete triggers)
- Reorder actions via drag-and-drop in ActionsEditor

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds workspace Actions: per-project one‑click commands stored in `.superset/config.json` and shown as a new split button in the TopBar. Lets you run common tools quickly and re-run the last action per workspace.

- **New Features**
  - Config: new `actions` array in `.superset/config.json` (`{ id, name, command, icon }`), resolved across user/worktree/repo.
  - API: `config.updateActions`, `workspaces.getResolvedActions`, `workspaces.setLastUsedAction`.
  - UI: TopBar `ActionsButton` (main runs last used; dropdown lists actions, Add, Configure).
  - Settings: `ActionsEditor` to add/edit/delete with 500ms autosave; `AddActionDialog` from the TopBar.
  - Shared: `IconPicker` with 10 icons and `getIconComponent`.

- **Migration**
  - DB: adds `workspaces.last_used_action_id` (no manual steps).
  - If no actions exist, the button shows “+ Add action” and opens the dialog.

<sup>Written for commit 6f96fe321a25fa5c012cc86aa6e68fb77729b693. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

