### PR TITLE
fix(desktop): remove redundant double-click from file items

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileItem/FileItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileItem/FileItem.tsx
@@ -4,6 +4,7 @@ import {
 	ContextMenuContent,
 	ContextMenuItem,
 	ContextMenuSeparator,
+	ContextMenuShortcut,
 	ContextMenuTrigger,
 } from "@superset/ui/context-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
@@ -257,6 +258,7 @@ export function FileItem({
 					<ContextMenuItem onClick={openInEditor}>
 						<VscLinkExternal className="mr-2 size-4" />
 						Open in Editor
+						<ContextMenuShortcut>⌘+Click</ContextMenuShortcut>
 					</ContextMenuItem>
 
 					{(onStage || onUnstage || onDiscard) && <ContextMenuSeparator />}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileItem/FileItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/FileItem/FileItem.tsx
@@ -8,7 +8,7 @@ import {
 } from "@superset/ui/context-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import {
 	VscAdd,
 	VscClippy,
@@ -82,8 +82,6 @@ export function FileItem({
 }: FileItemProps) {
 	const [showDiscardDialog, setShowDiscardDialog] = useState(false);
 	const { activeFileKey } = useScrollContext();
-	const clickTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
 	const fileName = getFileName(file.path);
 	const statusBadgeColor = getStatusColor(file.status);
 	const statusIndicator = getStatusIndicator(file.status);
@@ -118,41 +116,10 @@ export function FileItem({
 				return;
 			}
 
-			if (clickTimeoutRef.current) {
-				clearTimeout(clickTimeoutRef.current);
-				clickTimeoutRef.current = null;
-			}
-
-			clickTimeoutRef.current = setTimeout(() => {
-				clickTimeoutRef.current = null;
-				onClick();
-			}, 300);
+			onClick();
 		},
 		[onClick, openInEditor],
 	);
-
-	const handleDoubleClick = useCallback(
-		(e: React.MouseEvent) => {
-			e.preventDefault();
-			e.stopPropagation();
-
-			if (clickTimeoutRef.current) {
-				clearTimeout(clickTimeoutRef.current);
-				clickTimeoutRef.current = null;
-			}
-
-			openInEditor();
-		},
-		[openInEditor],
-	);
-
-	useEffect(() => {
-		return () => {
-			if (clickTimeoutRef.current) {
-				clearTimeout(clickTimeoutRef.current);
-			}
-		};
-	}, []);
 
 	const handleDiscardClick = () => {
 		setShowDiscardDialog(true);
@@ -225,7 +192,6 @@ export function FileItem({
 			<button
 				type="button"
 				onClick={handleClick}
-				onDoubleClick={handleDoubleClick}
 				className={cn(
 					"flex items-center gap-1.5 flex-1 min-w-0 overflow-hidden",
 					hasIndent ? "py-0.5" : "py-1",

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileSearchResultItem/FileSearchResultItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileSearchResultItem/FileSearchResultItem.tsx
@@ -3,6 +3,7 @@ import {
 	ContextMenuContent,
 	ContextMenuItem,
 	ContextMenuSeparator,
+	ContextMenuShortcut,
 	ContextMenuTrigger,
 } from "@superset/ui/context-menu";
 import { cn } from "@superset/ui/utils";
@@ -168,6 +169,7 @@ export function FileSearchResultItem({
 				<ContextMenuItem onClick={openInEditor}>
 					<LuExternalLink className="mr-2 size-4" />
 					Open in Editor
+					<ContextMenuShortcut>⌘+Click</ContextMenuShortcut>
 				</ContextMenuItem>
 
 				<ContextMenuSeparator />

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileSearchResultItem/FileSearchResultItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileSearchResultItem/FileSearchResultItem.tsx
@@ -93,10 +93,6 @@ export function FileSearchResultItem({
 		}
 	};
 
-	const handleDoubleClick = () => {
-		onOpenInEditor(entry);
-	};
-
 	const handleKeyDown = (e: React.KeyboardEvent) => {
 		if (e.key === "Enter") {
 			e.preventDefault();
@@ -117,7 +113,6 @@ export function FileSearchResultItem({
 				"hover:bg-accent/50 transition-colors",
 			)}
 			onClick={handleClick}
-			onDoubleClick={handleDoubleClick}
 			onKeyDown={handleKeyDown}
 		>
 			<span className="flex items-center justify-center w-4 h-4 shrink-0" />

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileTreeItem/FileTreeItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileTreeItem/FileTreeItem.tsx
@@ -4,6 +4,7 @@ import {
 	ContextMenuContent,
 	ContextMenuItem,
 	ContextMenuSeparator,
+	ContextMenuShortcut,
 	ContextMenuTrigger,
 } from "@superset/ui/context-menu";
 import { cn } from "@superset/ui/utils";
@@ -174,6 +175,7 @@ export function FileTreeItem({
 				<ContextMenuItem onClick={openInEditor}>
 					<LuExternalLink className="mr-2 size-4" />
 					Open in Editor
+					<ContextMenuShortcut>⌘+Click</ContextMenuShortcut>
 				</ContextMenuItem>
 
 				<ContextMenuSeparator />

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileTreeItem/FileTreeItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileTreeItem/FileTreeItem.tsx
@@ -85,11 +85,6 @@ export function FileTreeItem({
 		}
 	};
 
-	const handleDoubleClick = (e: React.MouseEvent) => {
-		e.stopPropagation();
-		onOpenInEditor(entry);
-	};
-
 	const handleKeyDown = (e: React.KeyboardEvent) => {
 		if (e.key === "Enter") {
 			e.preventDefault();
@@ -123,7 +118,6 @@ export function FileTreeItem({
 				item.isSelected() && "bg-accent",
 			)}
 			onClick={handleClick}
-			onDoubleClick={handleDoubleClick}
 			onKeyDown={handleKeyDown}
 		>
 			<span className="flex items-center justify-center w-4 h-4 shrink-0">


### PR DESCRIPTION
## Summary
- Remove double-click handlers from FileTreeItem, FileSearchResultItem, and FileItem (ChangesView) since cmd+click already opens files in the external editor
- Remove the 300ms single-click delay in FileItem that was only needed to disambiguate single vs double click, making clicks feel instant

## Test plan
- [ ] Cmd+click a file item in the file tree — opens in editor
- [ ] Cmd+click a file in changes view — opens in editor
- [ ] Single click in changes view — selects file immediately (no delay)
- [ ] Double-click no longer triggers open-in-editor (expected, use cmd+click instead)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed double-click actions from file items and the 300ms single-click delay so selection is instant. Opening files in the external editor now uses Cmd+click across the file tree, search results, and changes view, with a ⌘+Click shortcut hint in the “Open in Editor” context menu.

<sup>Written for commit c83042a886ed86d1c03e0462e9c1faea340f5715. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Simplified file interaction by consolidating double-click behavior into single-click and context menu actions.
  * Added keyboard shortcut hints (⌘+Click) in context menus to clarify how to open files in the editor.
  * Streamlined click handling for more responsive file selection and opening workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->