### PR TITLE
[codex] move v2 terminal to Ghostty VT via forked ghostty-web

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -167,6 +167,7 @@
 		"framer-motion": "^12.23.26",
 		"friendly-words": "^1.3.1",
 		"fuse.js": "^7.1.0",
+		"ghostty-web": "github:superset-sh/ghostty-web#a9d3ebed8ddeef90fa653347d464897baad736b6",
 		"highlight.js": "^11.11.1",
 		"http-proxy": "^1.18.1",
 		"idb": "^8.0.3",

--- a/apps/desktop/src/renderer/lib/terminal/ghostty-vt.ts
+++ b/apps/desktop/src/renderer/lib/terminal/ghostty-vt.ts
@@ -1,0 +1,15 @@
+import { Ghostty } from "ghostty-web";
+import ghosttyWasmUrl from "ghostty-web/ghostty-vt.wasm?url";
+
+let ghosttyPromise: Promise<Ghostty> | null = null;
+
+export function getGhosttyInstance(): Promise<Ghostty> {
+	if (!ghosttyPromise) {
+		ghosttyPromise = Ghostty.load(ghosttyWasmUrl).catch((error) => {
+			ghosttyPromise = null;
+			throw error;
+		});
+	}
+
+	return ghosttyPromise;
+}

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -12,63 +12,112 @@ import {
 	disposeTransport,
 	sendDispose,
 	sendResize,
+	setConnectionState,
 	type TerminalTransport,
 } from "./terminal-ws-transport";
 
 interface RegistryEntry {
-	runtime: TerminalRuntime;
+	runtime: TerminalRuntime | null;
+	runtimePromise: Promise<TerminalRuntime>;
 	transport: TerminalTransport;
+	attachVersion: number;
+	disposed: boolean;
 }
 
 class TerminalRuntimeRegistryImpl {
 	private entries = new Map<string, RegistryEntry>();
 
 	private getOrCreate(paneId: string): RegistryEntry {
-		let entry = this.entries.get(paneId);
+		const entry = this.entries.get(paneId);
 		if (entry) return entry;
 
-		entry = {
-			runtime: createRuntime(paneId),
+		const nextEntry: RegistryEntry = {
+			runtime: null,
+			runtimePromise: Promise.resolve(null as never),
 			transport: createTransport(),
+			attachVersion: 0,
+			disposed: false,
 		};
+		nextEntry.runtimePromise = createRuntime(paneId).then((runtime) => {
+			nextEntry.runtime = runtime;
+			return runtime;
+		});
 
-		this.entries.set(paneId, entry);
-		return entry;
+		this.entries.set(paneId, nextEntry);
+		return nextEntry;
 	}
 
 	attach(paneId: string, container: HTMLDivElement, wsUrl: string) {
-		const { runtime, transport } = this.getOrCreate(paneId);
+		const entry = this.getOrCreate(paneId);
+		const attachVersion = ++entry.attachVersion;
 
-		attachToContainer(runtime, container, () => {
-			sendResize(transport, runtime.terminal.cols, runtime.terminal.rows);
-		});
+		void entry.runtimePromise
+			.then((runtime) => {
+				if (entry.disposed) {
+					disposeRuntime(runtime);
+					return;
+				}
+				if (this.entries.get(paneId) !== entry) return;
+				if (attachVersion !== entry.attachVersion) return;
 
-		connect(transport, runtime.terminal, wsUrl);
+				attachToContainer(runtime, container, () => {
+					sendResize(
+						entry.transport,
+						runtime.terminal.cols,
+						runtime.terminal.rows,
+					);
+				});
+
+				connect(entry.transport, runtime.terminal, wsUrl);
+			})
+			.catch((error) => {
+				console.error(
+					"[terminal-v2] Failed to initialize Ghostty runtime:",
+					error,
+				);
+				if (this.entries.get(paneId) !== entry) return;
+				setConnectionState(entry.transport, "closed");
+			});
 	}
 
 	/**
 	 * Detach the terminal from its DOM container.
 	 *
 	 * This only removes the DOM attachment (wrapper, resize observer, focus).
-	 * The WebSocket and xterm data flow are intentionally kept alive so output
-	 * written while the pane is hidden is not lost.  Disposal of the transport
+	 * The WebSocket and terminal data flow are intentionally kept alive so output
+	 * written while the pane is hidden is not lost. Disposal of the transport
 	 * happens exclusively through {@link dispose} when the paneId is removed
 	 * from persisted pane state.
 	 */
 	detach(paneId: string) {
 		const entry = this.entries.get(paneId);
 		if (!entry) return;
+		entry.attachVersion += 1;
 
-		detachFromContainer(entry.runtime);
+		if (entry.runtime) {
+			detachFromContainer(entry.runtime);
+		}
 	}
 
 	dispose(paneId: string) {
 		const entry = this.entries.get(paneId);
 		if (!entry) return;
+		entry.disposed = true;
+		entry.attachVersion += 1;
 
 		sendDispose(entry.transport);
 		disposeTransport(entry.transport);
-		disposeRuntime(entry.runtime);
+		if (entry.runtime) {
+			disposeRuntime(entry.runtime);
+		} else {
+			void entry.runtimePromise
+				.then((runtime) => {
+					disposeRuntime(runtime);
+				})
+				.catch(() => {
+					// Initialization failed; nothing else to clean up.
+				});
+		}
 
 		this.entries.delete(paneId);
 	}

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -1,18 +1,14 @@
-import { FitAddon } from "@xterm/addon-fit";
-import { SerializeAddon } from "@xterm/addon-serialize";
-import { Terminal as XTerm } from "@xterm/xterm";
+import { FitAddon, Terminal as GhosttyTerminal } from "ghostty-web";
+import { getGhosttyInstance } from "./ghostty-vt";
 
-const SERIALIZE_SCROLLBACK = 1000;
-const STORAGE_KEY_PREFIX = "terminal-buffer:";
 const DIMS_KEY_PREFIX = "terminal-dims:";
 const DEFAULT_COLS = 120;
 const DEFAULT_ROWS = 32;
 
 export interface TerminalRuntime {
 	paneId: string;
-	terminal: XTerm;
+	terminal: GhosttyTerminal;
 	fitAddon: FitAddon;
-	serializeAddon: SerializeAddon;
 	/** Reparented between containers across attach/detach cycles — not recreated. */
 	wrapper: HTMLDivElement;
 	container: HTMLDivElement | null;
@@ -22,51 +18,31 @@ export interface TerminalRuntime {
 	lastRows: number;
 }
 
-function createTerminal(
+async function createTerminal(
 	cols: number,
 	rows: number,
-): {
-	terminal: XTerm;
+): Promise<{
+	terminal: GhosttyTerminal;
 	fitAddon: FitAddon;
-	serializeAddon: SerializeAddon;
-} {
+}> {
+	const ghostty = await getGhosttyInstance();
 	const fitAddon = new FitAddon();
-	const serializeAddon = new SerializeAddon();
-	const terminal = new XTerm({
+	const terminal = new GhosttyTerminal({
+		ghostty,
 		cols,
 		rows,
 		cursorBlink: true,
 		fontFamily:
 			'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
 		fontSize: 12,
+		scrollback: 10_000,
 		theme: {
 			background: "#14100f",
 			foreground: "#f5efe9",
 		},
 	});
 	terminal.loadAddon(fitAddon);
-	terminal.loadAddon(serializeAddon);
-	return { terminal, fitAddon, serializeAddon };
-}
-
-function persistBuffer(paneId: string, serializeAddon: SerializeAddon) {
-	try {
-		const data = serializeAddon.serialize({ scrollback: SERIALIZE_SCROLLBACK });
-		localStorage.setItem(`${STORAGE_KEY_PREFIX}${paneId}`, data);
-	} catch {}
-}
-
-function restoreBuffer(paneId: string, terminal: XTerm) {
-	try {
-		const data = localStorage.getItem(`${STORAGE_KEY_PREFIX}${paneId}`);
-		if (data) terminal.write(data);
-	} catch {}
-}
-
-function clearPersistedBuffer(paneId: string) {
-	try {
-		localStorage.removeItem(`${STORAGE_KEY_PREFIX}${paneId}`);
-	} catch {}
+	return { terminal, fitAddon };
 }
 
 function persistDimensions(paneId: string, cols: number, rows: number) {
@@ -112,24 +88,23 @@ function measureAndResize(runtime: TerminalRuntime) {
 	runtime.lastRows = runtime.terminal.rows;
 }
 
-export function createRuntime(paneId: string): TerminalRuntime {
+export async function createRuntime(paneId: string): Promise<TerminalRuntime> {
 	const savedDims = loadSavedDimensions(paneId);
 	const cols = savedDims?.cols ?? DEFAULT_COLS;
 	const rows = savedDims?.rows ?? DEFAULT_ROWS;
 
-	const { terminal, fitAddon, serializeAddon } = createTerminal(cols, rows);
+	const { terminal, fitAddon } = await createTerminal(cols, rows);
 
 	const wrapper = document.createElement("div");
 	wrapper.style.width = "100%";
 	wrapper.style.height = "100%";
+	wrapper.style.overflow = "hidden";
 	terminal.open(wrapper);
-	restoreBuffer(paneId, terminal);
 
 	return {
 		paneId,
 		terminal,
 		fitAddon,
-		serializeAddon,
 		wrapper,
 		container: null,
 		resizeObserver: null,
@@ -147,10 +122,6 @@ export function attachToContainer(
 	container.appendChild(runtime.wrapper);
 	measureAndResize(runtime);
 
-	// Force a full repaint — the renderer may have skipped paint frames while
-	// the wrapper was detached from the DOM and receiving background data.
-	runtime.terminal.refresh(0, runtime.terminal.rows - 1);
-
 	runtime.resizeObserver?.disconnect();
 	const observer = new ResizeObserver(() => {
 		measureAndResize(runtime);
@@ -163,7 +134,6 @@ export function attachToContainer(
 }
 
 export function detachFromContainer(runtime: TerminalRuntime) {
-	persistBuffer(runtime.paneId, runtime.serializeAddon);
 	persistDimensions(runtime.paneId, runtime.lastCols, runtime.lastRows);
 	runtime.resizeObserver?.disconnect();
 	runtime.resizeObserver = null;
@@ -176,6 +146,5 @@ export function disposeRuntime(runtime: TerminalRuntime) {
 	runtime.resizeObserver = null;
 	runtime.wrapper.remove();
 	runtime.terminal.dispose();
-	clearPersistedBuffer(runtime.paneId);
 	clearPersistedDimensions(runtime.paneId);
 }

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -1,4 +1,4 @@
-import type { Terminal as XTerm } from "@xterm/xterm";
+import type { Terminal as GhosttyTerminal } from "ghostty-web";
 
 export type ConnectionState = "disconnected" | "connecting" | "open" | "closed";
 
@@ -17,7 +17,7 @@ export interface TerminalTransport {
 	stateListeners: Set<() => void>;
 }
 
-function setConnectionState(
+export function setConnectionState(
 	transport: TerminalTransport,
 	state: ConnectionState,
 ) {
@@ -39,7 +39,7 @@ export function createTransport(): TerminalTransport {
 
 export function connect(
 	transport: TerminalTransport,
-	terminal: XTerm,
+	terminal: GhosttyTerminal,
 	wsUrl: string,
 ) {
 	// Idempotent: skip if already connected/connecting to the same endpoint.

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -1,4 +1,3 @@
-import "@xterm/xterm/css/xterm.css";
 import { useEffect, useRef, useSyncExternalStore } from "react";
 import {
 	type ConnectionState,

--- a/bun.lock
+++ b/bun.lock
@@ -244,6 +244,7 @@
         "framer-motion": "^12.23.26",
         "friendly-words": "^1.3.1",
         "fuse.js": "^7.1.0",
+        "ghostty-web": "github:superset-sh/ghostty-web#a9d3ebed8ddeef90fa653347d464897baad736b6",
         "highlight.js": "^11.11.1",
         "http-proxy": "^1.18.1",
         "idb": "^8.0.3",
@@ -3774,6 +3775,8 @@
     "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
 
     "getenv": ["getenv@2.0.0", "", {}, "sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ=="],
+
+    "ghostty-web": ["ghostty-web@github:superset-sh/ghostty-web#a9d3ebe", {}, "superset-sh-ghostty-web-a9d3ebe", "sha512-eE/ZHXiSA3tgLluDnY8yjiEhVTL3iLPsidH6hRPaiUJvVOaPNkq4UgOxz7tNBzfjSnltVIpywv8VyyW/bocAhQ=="],
 
     "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
 


### PR DESCRIPTION
## What changed
- switched the desktop v2 terminal renderer from xterm.js to Ghostty VT via `ghostty-web`
- added async runtime initialization for the Ghostty WASM terminal and kept the existing websocket/session lifecycle intact
- removed the old v2 xterm CSS import and xterm-only buffer serialization path
- pinned `apps/desktop` to the forked `superset-sh/ghostty-web` commit that patches DPR/font-metric seams in the canvas renderer

## Why
The v2 terminal needed a real Ghostty-based emulator path, but the off-the-shelf `ghostty-web` package showed character seam/gutter artifacts from canvas font metric rounding. Forking let us patch the renderer immediately and consume a fixed commit without waiting on upstream release timing.

## Impact
- v2 terminal panes now use Ghostty VT in the renderer instead of xterm.js
- backend PTY/session handling is still the existing `node-pty` websocket host-service path
- the desktop app now depends on `github:superset-sh/ghostty-web#a9d3ebed8ddeef90fa653347d464897baad736b6`

## Validation
- `bun run --cwd apps/desktop typecheck`
- `bun run --cwd apps/desktop compile:app`
- in fork `/tmp/superset-ghostty-web`: `bun run lint`
- in fork `/tmp/superset-ghostty-web`: `bun run typecheck`
- in fork `/tmp/superset-ghostty-web`: `bun test lib/renderer.test.ts`
- in fork `/tmp/superset-ghostty-web`: `bun run build:lib`

## Notes
- the fork branch is `superset/fix-renderer-dpr-seams`
- the fork commit consumed here is `a9d3ebed8ddeef90fa653347d464897baad736b6`
- the upstream `ghostty-web` full test suite is not green in a clean clone because its WASM test harness expects a browser document URL; I did not change that in this patch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move the v2 desktop terminal from xterm.js to Ghostty VT using `ghostty-web` for better rendering and fewer visual seams. The existing PTY/WebSocket session flow stays the same.

- **New Features**
  - Switch v2 panes to Ghostty VT with async WASM init and error handling.
  - Defer attach until runtime loads; keep WS/session alive across detach; clean disposal.
  - Persist terminal dimensions; remove xterm-only buffer serialization and CSS import.

- **Dependencies**
  - Add `ghostty-web` from `github:superset-sh/ghostty-web` to use a patched canvas renderer (DPR/font-metric seams).

<sup>Written for commit 34076aae18b9c51aa519e73816a5e98190a83350. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Migrated terminal implementation framework with updated runtime system and lazy initialization.
  * Removed scrollback buffer persistence and localStorage caching functionality.
  * Updated terminal initialization process to support asynchronous loading and improved error handling.
  * Enhanced terminal container styling and overflow management for better rendering performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->