### PR TITLE
fix(shared): reorder copilot -i flag so prompt is passed correctly

### DIFF
--- a/packages/shared/src/agent-command.test.ts
+++ b/packages/shared/src/agent-command.test.ts
@@ -50,6 +50,18 @@ describe("buildAgentPromptCommand", () => {
 		expect(command).toBe("amp < '.superset/task-demo.md'");
 	});
 
+	it("places -i after --allow-all so prompt is the -i argument for copilot", () => {
+		const command = buildAgentPromptCommand({
+			prompt: "fix the bug",
+			randomId: "cop-1234",
+			agent: "copilot",
+		});
+
+		expect(command).toStartWith("copilot --allow-all -i ");
+		expect(command).toContain("fix the bug");
+		expect(command).toContain("--yolo");
+	});
+
 	it("uses pi interactive mode for prompt launches", () => {
 		const command = buildAgentPromptCommand({
 			prompt: "hello",

--- a/packages/shared/src/builtin-terminal-agents.ts
+++ b/packages/shared/src/builtin-terminal-agents.ts
@@ -125,7 +125,7 @@ export const BUILTIN_TERMINAL_AGENTS = [
 		description:
 			"GitHub's coding agent for planning, editing, and building in your repo.",
 		command: "copilot --allow-all",
-		promptCommand: "copilot -i --allow-all",
+		promptCommand: "copilot --allow-all -i",
 		promptCommandSuffix: "--yolo",
 		includeInDefaultTerminalPresets: true,
 	}),


### PR DESCRIPTION
## Summary

When launching a Copilot workspace with a prompt, the generated command was:

```
copilot -i --allow-all "<prompt>" --yolo
```

This fails with `error: too many arguments` because `--allow-all` is placed between `-i` and the prompt, making the prompt a stray positional argument instead of `-i`'s value.

Fix: swap the flag order so `-i` immediately precedes the prompt:

```
copilot --allow-all -i "<prompt>" --yolo
```

## Changes
- `packages/shared/src/builtin-terminal-agents.ts`: reorder flags in Copilot's `promptCommand`
- `packages/shared/src/agent-command.test.ts`: add test to verify the generated command structure

## Test plan
- [x] `bun test packages/shared/src/agent-command.test.ts` — all 6 tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `copilot` prompt launches by reordering flags so `-i` directly precedes the prompt, preventing the “too many arguments” error. Launching a Copilot workspace with a prompt now works as expected.

- **Bug Fixes**
  - Set `promptCommand` to `copilot --allow-all -i` in `packages/shared/src/builtin-terminal-agents.ts`.
  - Added a test to verify flag order, prompt inclusion, and `--yolo` in `packages/shared/src/agent-command.test.ts`.

<sup>Written for commit 0e90a4c29408f236bc8187baa22492e77adde02e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for copilot terminal agent command generation, including flag validation and argument sequencing.

* **Chores**
  * Optimized command argument ordering for the copilot terminal agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->