### PR TITLE
chore(desktop): upgrade Electron 40.2.1 → 40.8.5

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -240,7 +240,7 @@
 		"@vitejs/plugin-react": "^5.0.1",
 		"code-inspector-plugin": "^1.2.2",
 		"cross-env": "^10.0.0",
-		"electron": "40.2.1",
+		"electron": "40.8.5",
 		"electron-builder": "^26.4.0",
 		"electron-vite": "^4.0.0",
 		"material-icon-theme": "^5.32.0",

--- a/bun.lock
+++ b/bun.lock
@@ -110,7 +110,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.4.6",
+      "version": "1.4.7",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.43",
         "@ai-sdk/openai": "3.0.36",
@@ -317,7 +317,7 @@
         "@vitejs/plugin-react": "^5.0.1",
         "code-inspector-plugin": "^1.2.2",
         "cross-env": "^10.0.0",
-        "electron": "40.2.1",
+        "electron": "40.8.5",
         "electron-builder": "^26.4.0",
         "electron-vite": "^4.0.0",
         "material-icon-theme": "^5.32.0",
@@ -3453,7 +3453,7 @@
 
     "electric-proxy": ["electric-proxy@workspace:apps/electric-proxy"],
 
-    "electron": ["electron@40.2.1", "", { "dependencies": { "@electron/get": "^2.0.0", "@types/node": "^24.9.0", "extract-zip": "^2.0.1" }, "bin": { "electron": "cli.js" } }, "sha512-0zOeyN8LB1KHIjVV5jyMmQmkqx3J8OkkVlab3p7vOM28jI46blxW7M52Tcdi6X2m5o2jj8ejOlAh5+boL3w8aQ=="],
+    "electron": ["electron@40.8.5", "", { "dependencies": { "@electron/get": "^2.0.0", "@types/node": "^24.9.0", "extract-zip": "^2.0.1" }, "bin": { "electron": "cli.js" } }, "sha512-pgTY/VPQKaiU4sTjfU96iyxCXrFm4htVPCMRT4b7q9ijNTRgtLmLvcmzp2G4e7xDrq9p7OLHSmu1rBKFf6Y1/A=="],
 
     "electron-builder": ["electron-builder@26.8.1", "", { "dependencies": { "app-builder-lib": "26.8.1", "builder-util": "26.8.1", "builder-util-runtime": "9.5.1", "chalk": "^4.1.2", "ci-info": "^4.2.0", "dmg-builder": "26.8.1", "fs-extra": "^10.1.0", "lazy-val": "^1.0.5", "simple-update-notifier": "2.0.0", "yargs": "^17.6.2" }, "bin": { "electron-builder": "cli.js", "install-app-deps": "install-app-deps.js" } }, "sha512-uWhx1r74NGpCagG0ULs/P9Nqv2nsoo+7eo4fLUOB8L8MdWltq9odW/uuLXMFCDGnPafknYLZgjNX0ZIFRzOQAw=="],
 


### PR DESCRIPTION
## Summary
- Upgrade Electron from `40.2.1` to `40.8.5` (latest 40.x stable, released March 26 2026)
- Fixes 4 Dependabot security alerts: protocol handler injection, second-instance IPC OOB read, use-after-free in fullscreen/download callbacks, and registry key injection
- Stays on the same major version to avoid breaking changes from Chromium/Node major bumps

## Test plan
- [x] `bun install` completes without errors
- [x] Native modules rebuilt successfully (better-sqlite3, node-pty, @parcel/watcher, bufferutil, utf-8-validate)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Manual smoke test: `bun dev` in `apps/desktop` launches correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `electron` from 40.2.1 to 40.8.5 to apply security patches while staying on the 40.x line. Fixes four Dependabot alerts (protocol handler injection, second-instance IPC OOB read, use-after-free in fullscreen/download callbacks, and registry key injection) without introducing Chromium/Node major bumps.

<sup>Written for commit 42e368e89e3193466a9879e400d59a0e9583c77d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop application's development environment to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->