### PR TITLE
fix(desktop): send correct terminal dimensions after attach for TUI apps

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
@@ -556,20 +556,6 @@ export function useTerminalLifecycle({
 								setConnectionError(null);
 								clearPaneInitialDataRef.current(paneId);
 
-								requestAnimationFrame(() => {
-									if (!isAttachActive()) return;
-									const prevCols = xterm.cols;
-									const prevRows = xterm.rows;
-									fitAddon.fit();
-									if (xterm.cols !== prevCols || xterm.rows !== prevRows) {
-										resizeRef.current({
-											paneId,
-											cols: xterm.cols,
-											rows: xterm.rows,
-										});
-									}
-								});
-
 								const storedColdRestore = coldRestoreState.get(paneId);
 								if (storedColdRestore?.isRestored) {
 									setIsRestoredMode(true);
@@ -600,6 +586,20 @@ export function useTerminalLifecycle({
 									didFirstRenderRef.current = true;
 									return;
 								}
+
+								requestAnimationFrame(() => {
+									if (!isAttachActive()) return;
+									const prevCols = xterm.cols;
+									const prevRows = xterm.rows;
+									fitAddon.fit();
+									if (xterm.cols !== prevCols || xterm.rows !== prevRows) {
+										resizeRef.current({
+											paneId,
+											cols: xterm.cols,
+											rows: xterm.rows,
+										});
+									}
+								});
 
 								pendingInitialStateRef.current = result;
 								maybeApplyInitialState();


### PR DESCRIPTION
## Summary
- When opening a terminal via preset (Ctrl+1), ink-based TUI apps like Claude Code rendered at ~1/3 width because the PTY was spawned with stale container dimensions
- After a successful `createOrAttach`, schedules a `requestAnimationFrame` to re-fit xterm and send corrected dimensions to the PTY via SIGWINCH
- The resize is only sent if dimensions actually changed, making it a no-op when the initial size was already correct

https://github.com/user-attachments/assets/5b982c10-8902-41cc-a2b7-a8536524ab4b



## Root Cause
`fitAddon.fit()` runs synchronously in `createTerminalInstance` before the container has its final layout. The `ResizeObserver` catches the correct size but is debounced at 150ms. Most CLIs handle the late SIGWINCH fine, but ink-based TUI apps (Claude Code) commit to the initial width during their first render cycle and don't fully reflow.

## Test plan
- [x] Open a Claude Code preset via Ctrl+1 — verify it renders at full terminal width immediately
- [x] Open other CLI presets (Codex, OpenCode) — verify no regression
- [x] Resize the window while a terminal is active — verify resize still works correctly
- [ ] Split panes and open presets — verify dimensions are correct in all panes
- [ ] Reattach to an existing session — verify no double resize or flicker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal sizing now waits for the interface layout to settle before finalizing dimensions, ensuring new or attached terminals render at the correct columns/rows and preventing misaligned or incorrectly sized terminal content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->