### PR TITLE
fix(ui): Correct active tab appearance in light theme

### DIFF
--- a/apps/mobile/components/ui/tabs.tsx
+++ b/apps/mobile/components/ui/tabs.tsx
@@ -22,7 +22,7 @@ function TabsList({
 	return (
 		<TabsPrimitive.List
 			className={cn(
-				"bg-muted flex h-9 flex-row items-center justify-center rounded-lg p-[3px]",
+				"bg-background flex h-9 flex-row items-center justify-center rounded-lg p-[3px]",
 				Platform.select({ web: "inline-flex w-fit", native: "mr-auto" }),
 				className,
 			)}
@@ -51,7 +51,7 @@ function TabsTrigger({
 					}),
 					props.disabled && "opacity-50",
 					props.value === value &&
-						"bg-background dark:border-foreground/10 dark:bg-input/30",
+						"bg-muted dark:border-foreground/10 dark:bg-input/30",
 					className,
 				)}
 				{...props}


### PR DESCRIPTION
## Summary

In light themes, the active tab incorrectly appeared darker than inactive tabs, creating an inverted visual hierarchy. This was due to the background colors being swapped in the tab component's implementation. This patch corrects the styles for the active tab and the tab list to ensure the active tab is always lighter, aligning with standard UI conventions.

## Changes

- **apps/mobile/components/ui/tabs.tsx**: In `apps/mobile/components/ui/tabs.tsx`, the background colors for `TabsList` and the active `TabsTrigger` have been swapped. `TabsList` now uses `bg-background` and the active `TabsTrigger` uses `bg-muted`. This corrects the visual hierarchy in light mode, making the active tab lighter than the inactive tabs, which resolves the reported bug.

## Related Issue

Closes #3147



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the active tab appearance in the light theme so the active tab is lighter than inactive tabs. Resolves #3147.

- **Bug Fixes**
  - Swapped background classes in `apps/mobile/components/ui/tabs.tsx`: `TabsList` uses `bg-background`, and the active `TabsTrigger` uses `bg-muted` (dark theme behavior unchanged).

<sup>Written for commit 453485be1207fdd318787c1c769855b97c990780. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted tab component styling to swap background colors between active and inactive states for improved visual distinction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->