### PR TITLE
feat(desktop): custom icon/emoji for terminal presets

### DIFF
--- a/apps/desktop/src/renderer/assets/app-icons/preset-icons/index.ts
+++ b/apps/desktop/src/renderer/assets/app-icons/preset-icons/index.ts
@@ -1,8 +1,15 @@
-import { getPresetIcon, PRESET_ICONS } from "@superset/ui/icons/preset-icons";
+import {
+	getPresetIcon,
+	PRESET_ICONS,
+	resolvePresetIcon,
+} from "@superset/ui/icons/preset-icons";
 import { useThemeStore } from "renderer/stores/theme/store";
 
-export { PRESET_ICONS, getPresetIcon };
-export type { PresetIconSet } from "@superset/ui/icons/preset-icons";
+export { PRESET_ICONS, getPresetIcon, resolvePresetIcon };
+export type {
+	PresetIconSet,
+	ResolvedPresetIcon,
+} from "@superset/ui/icons/preset-icons";
 
 export function usePresetIcon(presetName: string): string | undefined {
 	const activeTheme = useThemeStore((state) => state.activeTheme);

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/presets/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/presets/types.ts
@@ -2,7 +2,7 @@ import type { TerminalPreset } from "@superset/local-db";
 
 export type { TerminalPreset };
 
-export type PresetColumnKey = "name" | "description" | "cwd";
+export type PresetColumnKey = "name" | "description" | "cwd" | "icon";
 
 export interface PresetColumnConfig {
 	key: PresetColumnKey;

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/components/PresetEditorSheet/PresetEditorSheet.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/components/PresetEditorSheet/PresetEditorSheet.tsx
@@ -168,14 +168,29 @@ export function PresetEditorSheet({
 										htmlFor="preset-name"
 										tooltip="The preset name shown in your presets list and launch surfaces."
 									/>
-									<Input
-										id="preset-name"
-										value={preset.name}
-										onChange={(e) => onFieldChange("name", e.target.value)}
-										onBlur={() => onFieldBlur("name")}
-										className={fieldClassName}
-										placeholder="e.g. Dev Server"
-									/>
+									<div className="flex items-center gap-2">
+										<Input
+											id="preset-icon"
+											value={preset.icon ?? ""}
+											onChange={(e) => onFieldChange("icon", e.target.value)}
+											onBlur={() => onFieldBlur("icon")}
+											className={`${fieldClassName} w-12 text-center px-1`}
+											placeholder="🚀"
+											maxLength={4}
+											aria-label="Icon emoji"
+										/>
+										<Input
+											id="preset-name"
+											value={preset.name}
+											onChange={(e) => onFieldChange("name", e.target.value)}
+											onBlur={() => onFieldBlur("name")}
+											className={`${fieldClassName} flex-1`}
+											placeholder="e.g. Dev Server"
+										/>
+									</div>
+									<p className="text-xs text-muted-foreground">
+										Add an emoji to visually distinguish this preset in the bar.
+									</p>
 								</div>
 
 								<div className="space-y-2">

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar/PresetsBar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar/PresetsBar.tsx
@@ -18,7 +18,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { HiMiniCog6Tooth, HiMiniCommandLine } from "react-icons/hi2";
 import { LuCirclePlus, LuPin } from "react-icons/lu";
 import {
-	getPresetIcon,
+	resolvePresetIcon,
 	useIsDarkTheme,
 } from "renderer/assets/app-icons/preset-icons";
 import { HotkeyMenuShortcut } from "renderer/components/HotkeyMenuShortcut";
@@ -376,7 +376,11 @@ export function PresetsBar() {
 				</Tooltip>
 				<DropdownMenuContent align="start" className="w-56">
 					{managedPresets.map((item) => {
-						const icon = getPresetIcon(item.iconName, isDark);
+						const icon = resolvePresetIcon(
+							item.iconName,
+							isDark,
+							item.preset?.icon,
+						);
 						const isPinned = item.preset
 							? isPresetPinnedToBar(item.preset.pinnedToBar)
 							: false;
@@ -409,8 +413,16 @@ export function PresetsBar() {
 									});
 								}}
 							>
-								{icon ? (
-									<img src={icon} alt="" className="size-4 object-contain" />
+								{icon?.type === "image" ? (
+									<img
+										src={icon.value}
+										alt=""
+										className="size-4 object-contain"
+									/>
+								) : icon?.type === "emoji" ? (
+									<span className="size-4 text-sm leading-4 text-center">
+										{icon.value}
+									</span>
 								) : (
 									<HiMiniCommandLine className="size-4" />
 								)}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar/components/PresetBarItem/PresetBarItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/components/PresetsBar/components/PresetBarItem/PresetBarItem.tsx
@@ -11,7 +11,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useEffect, useRef } from "react";
 import { useDrag, useDrop } from "react-dnd";
 import { HiMiniCommandLine } from "react-icons/hi2";
-import { getPresetIcon } from "renderer/assets/app-icons/preset-icons";
+import { resolvePresetIcon } from "renderer/assets/app-icons/preset-icons";
 import { HotkeyTooltipContent } from "renderer/components/HotkeyTooltipContent/HotkeyTooltipContent";
 import type { HotkeyId } from "shared/hotkeys";
 
@@ -49,7 +49,7 @@ export function PresetBarItem({
 	onPersistReorder,
 }: PresetBarItemProps) {
 	const containerRef = useRef<HTMLDivElement>(null);
-	const icon = getPresetIcon(preset.name, isDark);
+	const icon = resolvePresetIcon(preset.name, isDark, preset.icon);
 	const label = preset.description || preset.name || "default";
 
 	const [{ isDragging }, drag] = useDrag(
@@ -102,8 +102,16 @@ export function PresetBarItem({
 								className="h-6 px-2 gap-1.5 text-xs shrink-0"
 								onClick={() => onOpenDefault(preset)}
 							>
-								{icon ? (
-									<img src={icon} alt="" className="size-3.5 object-contain" />
+								{icon?.type === "image" ? (
+									<img
+										src={icon.value}
+										alt=""
+										className="size-3.5 object-contain"
+									/>
+								) : icon?.type === "emoji" ? (
+									<span className="size-3.5 text-[11px] leading-[14px] text-center">
+										{icon.value}
+									</span>
 								) : (
 									<HiMiniCommandLine className="size-3.5" />
 								)}

--- a/packages/local-db/src/schema/zod.ts
+++ b/packages/local-db/src/schema/zod.ts
@@ -113,6 +113,7 @@ export const terminalPresetSchema = z.object({
 	applyOnWorkspaceCreated: z.boolean().optional(),
 	applyOnNewTab: z.boolean().optional(),
 	executionMode: z.enum(EXECUTION_MODES).optional(),
+	icon: z.string().optional(),
 });
 
 export type TerminalPreset = z.infer<typeof terminalPresetSchema>;

--- a/packages/ui/src/assets/icons/preset-icons/index.ts
+++ b/packages/ui/src/assets/icons/preset-icons/index.ts
@@ -33,14 +33,72 @@ export const PRESET_ICONS: Record<string, PresetIconSet> = {
 	opencode: { light: opencodeIcon, dark: opencodeWhiteIcon },
 };
 
+/**
+ * Returns true when `value` is a single emoji (or emoji sequence)
+ * rather than an icon key or plain text.
+ */
+export function isEmoji(value: string): boolean {
+	const trimmed = value.trim();
+	if (trimmed.length === 0) return false;
+	// Strip emoji presentation / variation selectors, ZWJ, skin-tone modifiers, and keycap
+	const stripped = trimmed.replace(
+		/[\u200D\uFE0E\uFE0F\u20E3\u{1F3FB}-\u{1F3FF}]/gu,
+		"",
+	);
+	// After stripping joiners, every remaining char should be in an emoji range
+	return /^[\p{Emoji_Presentation}\p{Extended_Pictographic}]+$/u.test(stripped);
+}
+
+export interface ResolvedPresetIcon {
+	type: "image" | "emoji";
+	value: string;
+}
+
+/**
+ * Resolve the icon for a terminal preset.
+ *
+ * Priority:
+ * 1. Explicit `iconOverride` that is an emoji → { type: "emoji", value }
+ * 2. Explicit `iconOverride` that matches a PRESET_ICONS key → { type: "image", value }
+ * 3. Name-based match against PRESET_ICONS → { type: "image", value }
+ * 4. undefined (caller renders a generic fallback)
+ */
+export function resolvePresetIcon(
+	presetName: string,
+	isDark: boolean,
+	iconOverride?: string,
+): ResolvedPresetIcon | undefined {
+	if (iconOverride) {
+		const trimmed = iconOverride.trim();
+		if (isEmoji(trimmed)) {
+			return { type: "emoji", value: trimmed };
+		}
+		const overrideSet = PRESET_ICONS[trimmed.toLowerCase()];
+		if (overrideSet) {
+			return {
+				type: "image",
+				value: isDark ? overrideSet.dark : overrideSet.light,
+			};
+		}
+	}
+
+	const normalizedName = presetName.toLowerCase().trim();
+	const iconSet = PRESET_ICONS[normalizedName];
+	if (!iconSet) return undefined;
+	return {
+		type: "image",
+		value: isDark ? iconSet.dark : iconSet.light,
+	};
+}
+
+/** @deprecated Use `resolvePresetIcon` instead. */
 export function getPresetIcon(
 	presetName: string,
 	isDark: boolean,
 ): string | undefined {
-	const normalizedName = presetName.toLowerCase().trim();
-	const iconSet = PRESET_ICONS[normalizedName];
-	if (!iconSet) return undefined;
-	return isDark ? iconSet.dark : iconSet.light;
+	const resolved = resolvePresetIcon(presetName, isDark);
+	if (!resolved || resolved.type === "emoji") return undefined;
+	return resolved.value;
 }
 
 export {


### PR DESCRIPTION
## Summary

- Adds an optional `icon` field to the `TerminalPreset` schema (emoji string)
- Updates icon resolution to prioritize the explicit icon field over name-based matching, with emoji detection
- Adds an inline emoji input next to the preset name in the editor sheet
- Renders emoji icons in both the preset bar and the presets dropdown

Closes #3164

## Changes

| File | What |
|------|------|
| `packages/local-db/src/schema/zod.ts` | Add `icon: z.string().optional()` to `terminalPresetSchema` |
| `packages/ui/src/assets/icons/preset-icons/index.ts` | Add `isEmoji()`, `resolvePresetIcon()`, and `ResolvedPresetIcon` type |
| `apps/desktop/.../preset-icons/index.ts` | Re-export new utilities |
| `apps/desktop/.../presets/types.ts` | Add `"icon"` to `PresetColumnKey` |
| `apps/desktop/.../PresetBarItem.tsx` | Use `resolvePresetIcon`, render emoji/image/fallback |
| `apps/desktop/.../PresetsBar.tsx` | Same for the manage-presets dropdown |
| `apps/desktop/.../PresetEditorSheet.tsx` | Add emoji input field next to preset name |

## Icon resolution priority

1. `preset.icon` is an emoji → render as text
2. `preset.icon` matches a `PRESET_ICONS` key → render that SVG
3. `preset.name` matches a `PRESET_ICONS` key → render that SVG (existing behavior)
4. Fallback → generic terminal icon

## Test plan

- [ ] Create a preset, type an emoji (e.g. 🚀) in the icon field → emoji appears in preset bar
- [ ] Create a preset with no icon and a known name (e.g. "Claude") → SVG icon still appears
- [ ] Create a preset with no icon and an unknown name → generic terminal icon appears
- [ ] Set icon to a built-in key (e.g. "claude") → SVG icon renders
- [ ] Edit a preset, clear the icon field → falls back to name-based or generic icon
- [ ] Verify presets persist across app restart (icon field saved in SQLite JSON)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds custom icon/emoji support for terminal presets so users can visually distinguish presets in the bar and dropdown. Implements #3164.

- **New Features**
  - Optional `icon` field on `TerminalPreset` (persisted via `packages/local-db`).
  - Emoji input added next to the preset name in the editor; emoji renders as text in UI.
  - Icon resolution: emoji override > built-in key override > name-based match > fallback.

- **Refactors**
  - Introduced `resolvePresetIcon` and `isEmoji` in `@superset/ui/icons/preset-icons` (re-exported in desktop); updated call sites to use the resolver.
  - Kept `getPresetIcon` as a deprecated wrapper; added `"icon"` to `PresetColumnKey`.

<sup>Written for commit 187d2d6137bb8ac734f3c1d8d53fd444010f377c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now assign custom emoji icons to terminal presets for enhanced visual distinction and organization
  * Preset editor features a new emoji input field with helper text guidance for icon customization
  * Preset display components now render custom emoji icons alongside traditional image-based icons
  * Expanded icon support: emoji, image, and default fallback icons for presets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->