### PR TITLE
fix(desktop): improve v2 terminal resize handling when hidden

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -2,8 +2,11 @@ import { Button } from "@superset/ui/button";
 import { FitAddon } from "@xterm/addon-fit";
 import { Terminal as XTerm } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
+import { debounce } from "lodash";
 import { useEffect, useRef, useState } from "react";
 import { useWorkspaceWsUrl } from "../../../../../providers/WorkspaceTrpcProvider/WorkspaceTrpcProvider";
+
+const RESIZE_DEBOUNCE_MS = 150;
 
 interface WorkspaceTerminalProps {
 	workspaceId: string;
@@ -74,10 +77,22 @@ export function TerminalPane({ workspaceId }: WorkspaceTerminalProps) {
 			);
 		};
 
-		const resizeObserver = new ResizeObserver(() => {
-			fitAddon.fit();
-			sendResize();
-		});
+		const isRenderable = () => {
+			const rect = container.getBoundingClientRect();
+			return rect.width > 1 && rect.height > 1;
+		};
+
+		const handleResize = debounce(
+			() => {
+				if (!isRenderable()) return;
+				fitAddon.fit();
+				sendResize();
+			},
+			RESIZE_DEBOUNCE_MS,
+			{ leading: true, trailing: true },
+		);
+
+		const resizeObserver = new ResizeObserver(handleResize);
 		resizeObserver.observe(container);
 
 		const onTerminalDataDispose = terminal.onData((data) => {
@@ -132,6 +147,7 @@ export function TerminalPane({ workspaceId }: WorkspaceTerminalProps) {
 
 		return () => {
 			resizeObserver.disconnect();
+			handleResize.cancel();
 			onTerminalDataDispose.dispose();
 			socket.close();
 			terminal.dispose();
@@ -161,7 +177,7 @@ export function TerminalPane({ workspaceId }: WorkspaceTerminalProps) {
 			</div>
 			<div
 				ref={containerRef}
-				className="h-[360px] overflow-hidden rounded-md border border-border bg-[#14100f] p-2"
+				className="size-full overflow-hidden rounded-md border border-border p-2"
 			/>
 		</div>
 	);


### PR DESCRIPTION
## Summary
- Add visibility guard (`isRenderable`) that checks container bounding rect > 1px before calling `fitAddon.fit()` — prevents sending 0 cols/0 rows to the backend when the terminal pane is hidden or collapsed
- Debounce resize events (150ms, leading + trailing) so the first resize fires immediately with no lag, rapid resizes are batched, and the final size is always captured
- Fix container to fill available pane space instead of using a fixed 360px height

## Test plan
- [ ] Open a v2 workspace with a terminal pane, verify it fills available space
- [ ] Resize the pane — terminal should refit immediately and settle correctly
- [ ] Switch to a different tab and back — terminal should not send 0-dimension resize
- [ ] Collapse/expand a split containing a terminal — no errors or layout glitches

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents 0×0 terminal resize events when the v2 terminal pane is hidden or collapsed, and smooths resize behavior. The terminal now fills the available pane space instead of using a fixed height.

- **Bug Fixes**
  - Add `isRenderable` guard to check container bounds before calling `fitAddon.fit()` and sending resize, avoiding 0 cols/rows.
  - Debounce resize with `lodash` (150ms, leading + trailing) to refit immediately, batch rapid resizes, capture the final size; canceled on cleanup.
  - Replace fixed 360px height with `size-full` so the terminal fills the pane.

<sup>Written for commit 3edc935c523335c2b9cbbf7e90f6b46e08cca323. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal pane resize handling performance and responsiveness.
  * Fixed terminal resizing behavior when the pane is not visible.

* **Style**
  * Changed terminal pane layout from fixed height to dynamic full-size sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->