### PR TITLE
feat(desktop): git changes sidebar with resource-oriented API

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -1,14 +1,18 @@
 import { Button } from "@superset/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { Search } from "lucide-react";
-import { type ReactNode, useState } from "react";
+import { useMemo, useState } from "react";
 import { FilesTab } from "./components/FilesTab";
 import { SidebarHeader } from "./components/SidebarHeader";
-
-type SidebarTab = "files" | "changes" | "checks";
+import { useChangesTab } from "./hooks/useChangesTab";
+import type { SidebarTabDefinition } from "./types";
 
 interface WorkspaceSidebarProps {
 	onSelectFile: (absolutePath: string) => void;
+	onSelectDiffFile?: (
+		path: string,
+		category: "against-base" | "staged" | "unstaged",
+	) => void;
 	onSearch?: () => void;
 	selectedFilePath?: string;
 	workspaceId: string;
@@ -43,50 +47,60 @@ function IconButton({
 
 export function WorkspaceSidebar({
 	onSelectFile,
+	onSelectDiffFile,
 	onSearch,
 	selectedFilePath,
 	workspaceId,
 	workspaceName,
 }: WorkspaceSidebarProps) {
-	const [activeTab, setActiveTab] = useState<SidebarTab>("files");
+	const [activeTab, setActiveTab] = useState("files");
 
-	const tabActions: Record<SidebarTab, ReactNode> = {
-		files: <IconButton icon={Search} tooltip="Search" onClick={onSearch} />,
-		changes: null,
-		checks: null,
-	};
+	const changesTab = useChangesTab({
+		workspaceId,
+		onSelectFile: onSelectDiffFile,
+	});
 
-	return (
-		<div className="flex h-full min-h-0 flex-col overflow-hidden border-l border-border bg-background">
-			<SidebarHeader
-				tabs={[
-					{ id: "files", label: "All files" },
-					{ id: "changes", label: "Changes" },
-					{ id: "checks", label: "Checks" },
-				]}
-				activeTab={activeTab}
-				onTabChange={(id) => setActiveTab(id as SidebarTab)}
-				actions={tabActions[activeTab]}
-			/>
-
-			<div className={activeTab === "files" ? "min-h-0 flex-1" : "hidden"}>
+	const filesTab: SidebarTabDefinition = useMemo(
+		() => ({
+			id: "files",
+			label: "All files",
+			actions: <IconButton icon={Search} tooltip="Search" onClick={onSearch} />,
+			content: (
 				<FilesTab
 					onSelectFile={onSelectFile}
 					selectedFilePath={selectedFilePath}
 					workspaceId={workspaceId}
 					workspaceName={workspaceName}
 				/>
-			</div>
-			<div className={activeTab === "changes" ? "min-h-0 flex-1" : "hidden"}>
+			),
+		}),
+		[onSearch, onSelectFile, selectedFilePath, workspaceId, workspaceName],
+	);
+
+	const checksTab: SidebarTabDefinition = useMemo(
+		() => ({
+			id: "checks",
+			label: "Checks",
+			content: (
 				<div className="flex h-full items-center justify-center text-sm text-muted-foreground">
 					Coming soon
 				</div>
-			</div>
-			<div className={activeTab === "checks" ? "min-h-0 flex-1" : "hidden"}>
-				<div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-					Coming soon
-				</div>
-			</div>
+			),
+		}),
+		[],
+	);
+
+	const tabs = [filesTab, changesTab, checksTab];
+	const activeTabDef = tabs.find((t) => t.id === activeTab);
+
+	return (
+		<div className="flex h-full min-h-0 flex-col overflow-hidden border-l border-border bg-background">
+			<SidebarHeader
+				tabs={tabs}
+				activeTab={activeTab}
+				onTabChange={setActiveTab}
+			/>
+			<div className="min-h-0 flex-1">{activeTabDef?.content}</div>
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/SidebarHeader/SidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/SidebarHeader/SidebarHeader.tsx
@@ -1,26 +1,19 @@
 import { cn } from "@superset/ui/utils";
-import type { ReactNode } from "react";
-
-interface Tab {
-	id: string;
-	label: string;
-	icon?: ReactNode;
-	badge?: number;
-}
+import type { SidebarTabDefinition } from "../../types";
 
 interface SidebarHeaderProps {
-	tabs: Tab[];
+	tabs: SidebarTabDefinition[];
 	activeTab: string;
 	onTabChange: (id: string) => void;
-	actions?: ReactNode;
 }
 
 export function SidebarHeader({
 	tabs,
 	activeTab,
 	onTabChange,
-	actions,
 }: SidebarHeaderProps) {
+	const actions = tabs.find((t) => t.id === activeTab)?.actions;
+
 	return (
 		<div className="flex h-10 shrink-0 items-stretch border-b border-border">
 			<div className="flex flex-1 items-stretch">
@@ -36,7 +29,6 @@ export function SidebarHeader({
 								: "text-muted-foreground/70 hover:text-muted-foreground hover:bg-tertiary/20",
 						)}
 					>
-						{tab.icon}
 						{tab.label}
 						{tab.badge != null && tab.badge > 0 && (
 							<span className="text-xs tabular-nums">{tab.badge}</span>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/BaseBranchSelector/BaseBranchSelector.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/BaseBranchSelector/BaseBranchSelector.tsx
@@ -1,0 +1,80 @@
+import type { AppRouter } from "@superset/host-service";
+import { Popover, PopoverContent, PopoverTrigger } from "@superset/ui/popover";
+import { ScrollArea } from "@superset/ui/scroll-area";
+import type { inferRouterOutputs } from "@trpc/server";
+import { Check, ChevronDown } from "lucide-react";
+import { useMemo, useState } from "react";
+
+type Branch =
+	inferRouterOutputs<AppRouter>["git"]["listBranches"]["branches"][number];
+
+interface BaseBranchSelectorProps {
+	branches: Branch[];
+	currentValue: string;
+	onChange: (branchName: string) => void;
+}
+
+export function BaseBranchSelector({
+	branches,
+	currentValue,
+	onChange,
+}: BaseBranchSelectorProps) {
+	const [open, setOpen] = useState(false);
+	const [search, setSearch] = useState("");
+
+	const filtered = useMemo(() => {
+		if (!search) return branches;
+		const lower = search.toLowerCase();
+		return branches.filter((b) => b.name.toLowerCase().includes(lower));
+	}, [branches, search]);
+
+	return (
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverTrigger asChild>
+				<button
+					type="button"
+					className="inline-flex items-center gap-0.5 font-medium text-foreground hover:underline"
+				>
+					{currentValue}
+					<ChevronDown className="size-3" />
+				</button>
+			</PopoverTrigger>
+			<PopoverContent className="w-64 p-0" align="start">
+				<div className="border-b px-3 py-2">
+					<input
+						placeholder="Search branches..."
+						value={search}
+						onChange={(e) => setSearch(e.target.value)}
+						className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+					/>
+				</div>
+				<ScrollArea className="max-h-[200px]">
+					<div className="p-1">
+						{filtered.map((branch) => (
+							<button
+								key={branch.name}
+								type="button"
+								className="flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-sm hover:bg-accent"
+								onClick={() => {
+									onChange(branch.name);
+									setOpen(false);
+									setSearch("");
+								}}
+							>
+								<span className="truncate">{branch.name}</span>
+								{branch.name === currentValue && (
+									<Check className="size-3.5 shrink-0" />
+								)}
+							</button>
+						))}
+						{filtered.length === 0 && (
+							<div className="px-2 py-3 text-center text-sm text-muted-foreground">
+								No branches found
+							</div>
+						)}
+					</div>
+				</ScrollArea>
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/BaseBranchSelector/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/BaseBranchSelector/index.ts
@@ -1,0 +1,1 @@
+export { BaseBranchSelector } from "./BaseBranchSelector";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/ChangesFileList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/ChangesFileList.tsx
@@ -1,0 +1,260 @@
+import type { AppRouter } from "@superset/host-service";
+import type { inferRouterOutputs } from "@trpc/server";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { useMemo, useState } from "react";
+import { FileIcon } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils";
+
+type ChangedFile =
+	inferRouterOutputs<AppRouter>["git"]["getStatus"]["againstBase"][number];
+type FileStatus = ChangedFile["status"];
+type ChangeCategory = "against-base" | "staged" | "unstaged";
+
+const STATUS_COLORS: Record<FileStatus, string> = {
+	added: "text-green-400",
+	copied: "text-purple-400",
+	changed: "text-yellow-400",
+	deleted: "text-red-400",
+	modified: "text-yellow-400",
+	renamed: "text-blue-400",
+	untracked: "text-green-400",
+};
+
+const STATUS_LETTERS: Record<FileStatus, string> = {
+	added: "A",
+	copied: "C",
+	changed: "T",
+	deleted: "D",
+	modified: "M",
+	renamed: "R",
+	untracked: "U",
+};
+
+function groupByFolder(
+	files: ChangedFile[],
+): Array<{ folder: string; files: ChangedFile[] }> {
+	const map = new Map<string, ChangedFile[]>();
+	for (const file of files) {
+		const lastSlash = file.path.lastIndexOf("/");
+		const folder = lastSlash > 0 ? file.path.slice(0, lastSlash) : "";
+		const existing = map.get(folder);
+		if (existing) existing.push(file);
+		else map.set(folder, [file]);
+	}
+	return Array.from(map.entries()).map(([folder, files]) => ({
+		folder,
+		files,
+	}));
+}
+
+function StatusIndicator({ status }: { status: FileStatus }) {
+	return (
+		<span className={`shrink-0 text-[10px] font-bold ${STATUS_COLORS[status]}`}>
+			{STATUS_LETTERS[status]}
+		</span>
+	);
+}
+
+function FileRow({
+	file,
+	category,
+	onSelect,
+}: {
+	file: ChangedFile;
+	category: ChangeCategory;
+	onSelect?: (path: string, category: ChangeCategory) => void;
+}) {
+	const fileName = file.path.split("/").pop() ?? file.path;
+
+	return (
+		<button
+			type="button"
+			className="flex w-full items-center gap-1.5 pl-6 pr-3 py-1 text-left text-xs hover:bg-accent/50"
+			onClick={() => onSelect?.(file.path, category)}
+		>
+			<FileIcon fileName={fileName} className="size-3.5 shrink-0" />
+			<span className="truncate font-medium">{fileName}</span>
+			<span className="ml-auto flex items-center gap-1.5 shrink-0">
+				{(file.additions > 0 || file.deletions > 0) && (
+					<span className="text-[10px] text-muted-foreground">
+						{file.additions > 0 && (
+							<span className="text-green-400">+{file.additions}</span>
+						)}
+						{file.additions > 0 && file.deletions > 0 && " "}
+						{file.deletions > 0 && (
+							<span className="text-red-400">-{file.deletions}</span>
+						)}
+					</span>
+				)}
+				<StatusIndicator status={file.status} />
+			</span>
+		</button>
+	);
+}
+
+function FolderGroup({
+	folder,
+	files,
+	category,
+	onSelectFile,
+}: {
+	folder: string;
+	files: ChangedFile[];
+	category: ChangeCategory;
+	onSelectFile?: (path: string, category: ChangeCategory) => void;
+}) {
+	// Shorten long folder paths
+	const displayFolder =
+		folder.length > 40 ? `...${folder.slice(folder.length - 37)}` : folder;
+
+	return (
+		<div>
+			{folder && (
+				<div className="flex items-center gap-1 px-3 py-1 text-[11px] text-muted-foreground">
+					<span className="truncate">{displayFolder}</span>
+					<span className="shrink-0">{files.length}</span>
+				</div>
+			)}
+			{files.map((file) => (
+				<FileRow
+					key={file.path}
+					file={file}
+					category={category}
+					onSelect={onSelectFile}
+				/>
+			))}
+		</div>
+	);
+}
+
+function Section({
+	title,
+	files,
+	category,
+	defaultOpen,
+	onSelectFile,
+}: {
+	title: string;
+	files: ChangedFile[];
+	category: ChangeCategory;
+	defaultOpen: boolean;
+	onSelectFile?: (path: string, category: ChangeCategory) => void;
+}) {
+	const [isOpen, setIsOpen] = useState(defaultOpen);
+	const groups = useMemo(() => groupByFolder(files), [files]);
+
+	if (files.length === 0) return null;
+
+	return (
+		<div>
+			<button
+				type="button"
+				className="flex w-full items-center gap-1 px-2 py-1.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground hover:bg-accent/50"
+				onClick={() => setIsOpen(!isOpen)}
+			>
+				{isOpen ? (
+					<ChevronDown className="size-3" />
+				) : (
+					<ChevronRight className="size-3" />
+				)}
+				<span>{title}</span>
+				<span className="ml-auto rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium">
+					{files.length}
+				</span>
+			</button>
+			{isOpen &&
+				groups.map((group) => (
+					<FolderGroup
+						key={group.folder}
+						folder={group.folder}
+						files={group.files}
+						category={category}
+						onSelectFile={onSelectFile}
+					/>
+				))}
+		</div>
+	);
+}
+
+interface ChangesFileListProps {
+	files: ChangedFile[];
+	staged?: ChangedFile[];
+	unstaged?: ChangedFile[];
+	defaultBranchName?: string;
+	isLoading?: boolean;
+	category?: ChangeCategory;
+	onSelectFile?: (path: string, category: ChangeCategory) => void;
+}
+
+export function ChangesFileList({
+	files,
+	staged,
+	unstaged,
+	defaultBranchName,
+	isLoading,
+	category = "against-base",
+	onSelectFile,
+}: ChangesFileListProps) {
+	if (isLoading) {
+		return (
+			<div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+				Loading...
+			</div>
+		);
+	}
+
+	const totalFiles =
+		files.length + (staged?.length ?? 0) + (unstaged?.length ?? 0);
+
+	if (totalFiles === 0) {
+		return (
+			<div className="px-3 py-6 text-center text-sm text-muted-foreground">
+				No changes
+			</div>
+		);
+	}
+
+	// If staged/unstaged are provided, show three sections
+	if (staged !== undefined && unstaged !== undefined) {
+		return (
+			<div className="min-h-0 flex-1 overflow-y-auto">
+				<Section
+					title={`Against ${defaultBranchName ?? "base"}`}
+					files={files}
+					category="against-base"
+					defaultOpen={true}
+					onSelectFile={onSelectFile}
+				/>
+				<Section
+					title="Staged"
+					files={staged}
+					category="staged"
+					defaultOpen={true}
+					onSelectFile={onSelectFile}
+				/>
+				<Section
+					title="Unstaged"
+					files={unstaged}
+					category="unstaged"
+					defaultOpen={true}
+					onSelectFile={onSelectFile}
+				/>
+			</div>
+		);
+	}
+
+	// Single list (filtered by commit or uncommitted)
+	const groups = groupByFolder(files);
+	return (
+		<div className="min-h-0 flex-1 overflow-y-auto">
+			{groups.map((group) => (
+				<FolderGroup
+					key={group.folder}
+					folder={group.folder}
+					files={group.files}
+					category={category}
+					onSelectFile={onSelectFile}
+				/>
+			))}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/index.ts
@@ -1,0 +1,1 @@
+export { ChangesFileList } from "./ChangesFileList";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/CommitFilterDropdown/CommitFilterDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/CommitFilterDropdown/CommitFilterDropdown.tsx
@@ -1,0 +1,132 @@
+import type { AppRouter } from "@superset/host-service";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import type { inferRouterOutputs } from "@trpc/server";
+import { Check, ChevronDown, ListFilter } from "lucide-react";
+import { useState } from "react";
+import type { ChangesFilter } from "../../useChangesTab";
+import { CommitRow } from "./components/CommitRow";
+import { RangeModal } from "./components/RangeModal";
+
+type Commit =
+	inferRouterOutputs<AppRouter>["git"]["listCommits"]["commits"][number];
+
+function getFilterLabel(filter: ChangesFilter, commits: Commit[]): string {
+	if (filter.kind === "all") return "All changes";
+	if (filter.kind === "uncommitted") return "Uncommitted";
+	if (filter.kind === "range") {
+		const from = commits.find((c) => c.hash === filter.fromHash);
+		const to = commits.find((c) => c.hash === filter.toHash);
+		return `${from?.shortHash ?? filter.fromHash.slice(0, 7)}..${to?.shortHash ?? filter.toHash.slice(0, 7)}`;
+	}
+	const commit = commits.find((c) => c.hash === filter.hash);
+	return commit?.shortHash ?? filter.hash.slice(0, 7);
+}
+
+interface CommitFilterDropdownProps {
+	filter: ChangesFilter;
+	onFilterChange: (filter: ChangesFilter) => void;
+	commits: Commit[];
+	uncommittedCount?: number;
+}
+
+export function CommitFilterDropdown({
+	filter,
+	onFilterChange,
+	commits,
+	uncommittedCount,
+}: CommitFilterDropdownProps) {
+	const [rangeModalOpen, setRangeModalOpen] = useState(false);
+
+	return (
+		<>
+			<DropdownMenu>
+				<DropdownMenuTrigger asChild>
+					<button
+						type="button"
+						className="flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
+					>
+						<span className="max-w-[140px] truncate">
+							{getFilterLabel(filter, commits)}
+						</span>
+						<ChevronDown className="size-3" />
+					</button>
+				</DropdownMenuTrigger>
+				<DropdownMenuContent align="start" className="w-72">
+					<DropdownMenuItem onSelect={() => onFilterChange({ kind: "all" })}>
+						<div className="flex flex-1 items-center justify-between">
+							<span>All changes</span>
+							{filter.kind === "all" && <Check className="size-3.5" />}
+						</div>
+					</DropdownMenuItem>
+
+					<DropdownMenuItem
+						onSelect={() => onFilterChange({ kind: "uncommitted" })}
+					>
+						<div className="flex flex-1 items-center justify-between">
+							<div>
+								<div>Uncommitted changes</div>
+								{uncommittedCount != null && (
+									<div className="text-[10px] text-muted-foreground">
+										{uncommittedCount} files changed
+									</div>
+								)}
+							</div>
+							{filter.kind === "uncommitted" && <Check className="size-3.5" />}
+						</div>
+					</DropdownMenuItem>
+
+					{commits.length > 1 && (
+						<DropdownMenuItem onSelect={() => setRangeModalOpen(true)}>
+							<div className="flex flex-1 items-center justify-between">
+								<div className="flex items-center gap-2">
+									<ListFilter className="size-3.5 text-muted-foreground" />
+									<span>Select range...</span>
+								</div>
+								{filter.kind === "range" && <Check className="size-3.5" />}
+							</div>
+						</DropdownMenuItem>
+					)}
+
+					{commits.length > 0 && (
+						<>
+							<DropdownMenuSeparator />
+							{commits.map((commit) => (
+								<DropdownMenuItem
+									key={commit.hash}
+									onSelect={() =>
+										onFilterChange({
+											kind: "commit",
+											hash: commit.hash,
+										})
+									}
+								>
+									<CommitRow
+										commit={commit}
+										isSelected={
+											filter.kind === "commit" && filter.hash === commit.hash
+										}
+									/>
+								</DropdownMenuItem>
+							))}
+						</>
+					)}
+				</DropdownMenuContent>
+			</DropdownMenu>
+
+			<RangeModal
+				open={rangeModalOpen}
+				onOpenChange={setRangeModalOpen}
+				commits={commits}
+				onSelect={(fromHash, toHash) =>
+					onFilterChange({ kind: "range", fromHash, toHash })
+				}
+			/>
+		</>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/CommitFilterDropdown/components/CommitRow/CommitRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/CommitFilterDropdown/components/CommitRow/CommitRow.tsx
@@ -1,0 +1,36 @@
+import type { AppRouter } from "@superset/host-service";
+import type { inferRouterOutputs } from "@trpc/server";
+import { Check } from "lucide-react";
+
+type Commit =
+	inferRouterOutputs<AppRouter>["git"]["listCommits"]["commits"][number];
+
+function timeAgo(date: string): string {
+	const seconds = Math.floor((Date.now() - new Date(date).getTime()) / 1000);
+	if (seconds < 60) return "just now";
+	const minutes = Math.floor(seconds / 60);
+	if (minutes < 60) return `${minutes}m ago`;
+	const hours = Math.floor(minutes / 60);
+	if (hours < 24) return `${hours}h ago`;
+	const days = Math.floor(hours / 24);
+	return `${days}d ago`;
+}
+
+interface CommitRowProps {
+	commit: Commit;
+	isSelected?: boolean;
+}
+
+export function CommitRow({ commit, isSelected }: CommitRowProps) {
+	return (
+		<div className="flex flex-1 items-center justify-between">
+			<div className="min-w-0">
+				<div className="truncate text-sm">{commit.message}</div>
+				<div className="text-xs text-muted-foreground">
+					{commit.shortHash} · {commit.author} · {timeAgo(commit.date)}
+				</div>
+			</div>
+			{isSelected && <Check className="size-3.5 shrink-0" />}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/CommitFilterDropdown/components/CommitRow/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/CommitFilterDropdown/components/CommitRow/index.ts
@@ -1,0 +1,1 @@
+export { CommitRow } from "./CommitRow";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/CommitFilterDropdown/components/RangeModal/RangeModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/CommitFilterDropdown/components/RangeModal/RangeModal.tsx
@@ -10,7 +10,7 @@ import {
 } from "@superset/ui/dialog";
 import { ScrollArea } from "@superset/ui/scroll-area";
 import type { inferRouterOutputs } from "@trpc/server";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { CommitRow } from "../CommitRow";
 
 type Commit =
@@ -31,6 +31,14 @@ export function RangeModal({
 }: RangeModalProps) {
 	const [fromIdx, setFromIdx] = useState<number | null>(null);
 	const [toIdx, setToIdx] = useState<number | null>(null);
+
+	// Reset selection when modal opens/closes
+	useEffect(() => {
+		if (!open) {
+			setFromIdx(null);
+			setToIdx(null);
+		}
+	}, [open]);
 
 	const handleClick = (idx: number) => {
 		if (fromIdx === null) {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/CommitFilterDropdown/components/RangeModal/RangeModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/CommitFilterDropdown/components/RangeModal/RangeModal.tsx
@@ -1,0 +1,108 @@
+import type { AppRouter } from "@superset/host-service";
+import { Button } from "@superset/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@superset/ui/dialog";
+import { ScrollArea } from "@superset/ui/scroll-area";
+import type { inferRouterOutputs } from "@trpc/server";
+import { useState } from "react";
+import { CommitRow } from "../CommitRow";
+
+type Commit =
+	inferRouterOutputs<AppRouter>["git"]["listCommits"]["commits"][number];
+
+interface RangeModalProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	commits: Commit[];
+	onSelect: (fromHash: string, toHash: string) => void;
+}
+
+export function RangeModal({
+	open,
+	onOpenChange,
+	commits,
+	onSelect,
+}: RangeModalProps) {
+	const [fromIdx, setFromIdx] = useState<number | null>(null);
+	const [toIdx, setToIdx] = useState<number | null>(null);
+
+	const handleClick = (idx: number) => {
+		if (fromIdx === null) {
+			setFromIdx(idx);
+			setToIdx(idx);
+		} else if (toIdx === fromIdx) {
+			setToIdx(idx);
+		} else {
+			setFromIdx(idx);
+			setToIdx(idx);
+		}
+	};
+
+	const minIdx =
+		fromIdx !== null && toIdx !== null ? Math.min(fromIdx, toIdx) : -1;
+	const maxIdx =
+		fromIdx !== null && toIdx !== null ? Math.max(fromIdx, toIdx) : -1;
+	const hasRange = minIdx !== maxIdx && minIdx >= 0;
+
+	const handleApply = () => {
+		if (!hasRange) return;
+		const from = commits[maxIdx];
+		const to = commits[minIdx];
+		if (from && to) {
+			onSelect(from.hash, to.hash);
+			onOpenChange(false);
+			setFromIdx(null);
+			setToIdx(null);
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange} modal>
+			<DialogContent className="sm:max-w-md">
+				<DialogHeader>
+					<DialogTitle>Select commit range</DialogTitle>
+					<DialogDescription>
+						Click two commits to define the range.
+					</DialogDescription>
+				</DialogHeader>
+
+				<ScrollArea className="max-h-[300px]">
+					<div className="space-y-0.5">
+						{commits.map((commit, idx) => {
+							const inRange = idx >= minIdx && idx <= maxIdx;
+							return (
+								<button
+									key={commit.hash}
+									type="button"
+									onClick={() => handleClick(idx)}
+									className={`flex w-full items-start gap-2 rounded-sm px-2 py-1.5 text-left text-sm ${
+										inRange
+											? "bg-accent text-accent-foreground"
+											: "hover:bg-accent/50"
+									}`}
+								>
+									<CommitRow commit={commit} />
+								</button>
+							);
+						})}
+					</div>
+				</ScrollArea>
+
+				<DialogFooter>
+					<Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
+						Cancel
+					</Button>
+					<Button size="sm" disabled={!hasRange} onClick={handleApply}>
+						Apply
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/CommitFilterDropdown/components/RangeModal/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/CommitFilterDropdown/components/RangeModal/index.ts
@@ -1,0 +1,1 @@
+export { RangeModal } from "./RangeModal";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/CommitFilterDropdown/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/CommitFilterDropdown/index.ts
@@ -1,0 +1,1 @@
+export { CommitFilterDropdown } from "./CommitFilterDropdown";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/index.ts
@@ -1,0 +1,1 @@
+export { type ChangesFilter, useChangesTab } from "./useChangesTab";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
@@ -1,0 +1,395 @@
+import type { AppRouter } from "@superset/host-service";
+import { toast } from "@superset/ui/sonner";
+import { workspaceTrpc } from "@superset/workspace-client";
+import type { inferRouterOutputs } from "@trpc/server";
+import { GitBranch, Pencil } from "lucide-react";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import type { ChangesFilter } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
+import type { SidebarTabDefinition } from "../../types";
+import { BaseBranchSelector } from "./components/BaseBranchSelector";
+import { ChangesFileList } from "./components/ChangesFileList";
+import { CommitFilterDropdown } from "./components/CommitFilterDropdown";
+
+export type { ChangesFilter };
+
+type RouterOutputs = inferRouterOutputs<AppRouter>;
+type Commit = RouterOutputs["git"]["listCommits"]["commits"][number];
+
+interface UseChangesTabParams {
+	workspaceId: string;
+	onSelectFile?: (
+		path: string,
+		category: "against-base" | "staged" | "unstaged",
+	) => void;
+}
+
+type Branch = RouterOutputs["git"]["listBranches"]["branches"][number];
+
+function ChangesHeader({
+	currentBranch,
+	defaultBranchName,
+	commitCount,
+	totalFiles,
+	totalAdditions,
+	totalDeletions,
+	onRenameBranch,
+	canRename,
+	filter,
+	onFilterChange,
+	commits,
+	uncommittedCount,
+	branches,
+	onBaseBranchChange,
+}: {
+	currentBranch: { name: string; aheadCount: number; behindCount: number };
+	defaultBranchName: string;
+	commitCount: number;
+	totalFiles: number;
+	totalAdditions: number;
+	totalDeletions: number;
+	filter: ChangesFilter;
+	onFilterChange: (filter: ChangesFilter) => void;
+	commits: Commit[];
+	uncommittedCount: number;
+	branches: Branch[];
+	onBaseBranchChange: (branchName: string) => void;
+	onRenameBranch: (newName: string) => void;
+	canRename: boolean;
+}) {
+	const [isEditing, setIsEditing] = useState(false);
+	const [editValue, setEditValue] = useState(currentBranch.name);
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	const startEditing = () => {
+		setEditValue(currentBranch.name);
+		setIsEditing(true);
+		requestAnimationFrame(() => inputRef.current?.select());
+	};
+
+	const handleSubmit = () => {
+		const trimmed = editValue.trim();
+		if (trimmed && trimmed !== currentBranch.name) {
+			onRenameBranch(trimmed);
+		}
+		setIsEditing(false);
+	};
+
+	return (
+		<div className="border-b border-border bg-muted/30 px-3 py-2.5 space-y-1.5">
+			{/* Branch name */}
+			<div className="group flex items-center gap-1.5 text-xs">
+				<GitBranch className="size-3.5 shrink-0 text-muted-foreground" />
+				{isEditing ? (
+					<input
+						ref={inputRef}
+						value={editValue}
+						onChange={(e) => setEditValue(e.target.value)}
+						onKeyDown={(e) => {
+							if (e.key === "Enter") handleSubmit();
+							if (e.key === "Escape") setIsEditing(false);
+						}}
+						onBlur={handleSubmit}
+						className="min-w-0 flex-1 truncate bg-transparent font-medium outline-none ring-1 ring-ring rounded-sm px-1"
+					/>
+				) : (
+					<>
+						<span className="truncate font-medium">{currentBranch.name}</span>
+						{canRename && (
+							<button
+								type="button"
+								onClick={startEditing}
+								className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground hover:text-foreground"
+							>
+								<Pencil className="size-3" />
+							</button>
+						)}
+					</>
+				)}
+			</div>
+
+			{/* Commits from base */}
+			<div className="text-[11px] text-muted-foreground">
+				{commitCount} {commitCount === 1 ? "commit" : "commits"} from{" "}
+				<BaseBranchSelector
+					branches={branches}
+					currentValue={defaultBranchName}
+					onChange={onBaseBranchChange}
+				/>
+			</div>
+
+			{/* Remote status */}
+			{currentBranch.aheadCount > 0 && currentBranch.behindCount > 0 && (
+				<div className="text-[11px] text-muted-foreground">
+					<div>Your branch and</div>
+					<div className="font-medium text-foreground">
+						origin/{currentBranch.name}
+					</div>
+					<div>have diverged</div>
+					<div>
+						{currentBranch.aheadCount} local not pushed,{" "}
+						{currentBranch.behindCount} remote to pull
+					</div>
+				</div>
+			)}
+			{currentBranch.aheadCount > 0 && currentBranch.behindCount === 0 && (
+				<div className="text-[11px] text-muted-foreground">
+					<div>
+						{currentBranch.aheadCount}{" "}
+						{currentBranch.aheadCount === 1 ? "commit" : "commits"} ahead of
+					</div>
+					<div className="font-medium text-foreground">
+						origin/{currentBranch.name}
+					</div>
+				</div>
+			)}
+			{currentBranch.behindCount > 0 && currentBranch.aheadCount === 0 && (
+				<div className="text-[11px] text-muted-foreground">
+					<div>
+						{currentBranch.behindCount}{" "}
+						{currentBranch.behindCount === 1 ? "commit" : "commits"} behind
+					</div>
+					<div className="font-medium text-foreground">
+						origin/{currentBranch.name}
+					</div>
+				</div>
+			)}
+
+			{/* Filter + stats */}
+			<div className="flex items-center justify-between pt-0.5">
+				<CommitFilterDropdown
+					filter={filter}
+					onFilterChange={onFilterChange}
+					commits={commits}
+					uncommittedCount={uncommittedCount}
+				/>
+				<div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+					<span>{totalFiles} files changed</span>
+					{(totalAdditions > 0 || totalDeletions > 0) && (
+						<span>
+							{totalAdditions > 0 && (
+								<span className="text-green-400">+{totalAdditions}</span>
+							)}
+							{totalAdditions > 0 && totalDeletions > 0 && " "}
+							{totalDeletions > 0 && (
+								<span className="text-red-400">-{totalDeletions}</span>
+							)}
+						</span>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export function useChangesTab({
+	workspaceId,
+	onSelectFile,
+}: UseChangesTabParams): SidebarTabDefinition {
+	const collections = useCollections();
+	const localState = collections.v2WorkspaceLocalState.get(workspaceId);
+	const filter: ChangesFilter = localState?.sidebarState?.changesFilter ?? {
+		kind: "all",
+	};
+	const baseBranch: string | null =
+		localState?.sidebarState?.baseBranch ?? null;
+
+	const setFilter = useCallback(
+		(next: ChangesFilter) => {
+			if (!collections.v2WorkspaceLocalState.get(workspaceId)) return;
+			collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
+				draft.sidebarState.changesFilter = next;
+			});
+		},
+		[collections, workspaceId],
+	);
+
+	const setBaseBranch = useCallback(
+		(branchName: string) => {
+			if (!collections.v2WorkspaceLocalState.get(workspaceId)) return;
+			collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
+				draft.sidebarState.baseBranch = branchName;
+			});
+		},
+		[collections, workspaceId],
+	);
+
+	const status = workspaceTrpc.git.getStatus.useQuery(
+		{ workspaceId, baseBranch: baseBranch ?? undefined },
+		{ refetchInterval: 3_000, refetchOnWindowFocus: true },
+	);
+
+	const commits = workspaceTrpc.git.listCommits.useQuery(
+		{ workspaceId, baseBranch: baseBranch ?? undefined },
+		{ refetchInterval: 3_000, refetchOnWindowFocus: true },
+	);
+
+	const branches = workspaceTrpc.git.listBranches.useQuery(
+		{ workspaceId },
+		{ refetchInterval: 30_000, refetchOnWindowFocus: true },
+	);
+
+	const renameBranchMutation = workspaceTrpc.git.renameBranch.useMutation();
+
+	const handleRenameBranch = useCallback(
+		(newName: string) => {
+			const currentName = status.data?.currentBranch.name;
+			if (!currentName) return;
+			toast.promise(
+				renameBranchMutation.mutateAsync({
+					workspaceId,
+					oldName: currentName,
+					newName,
+				}),
+				{
+					loading: `Renaming branch to ${newName}...`,
+					success: `Branch renamed to ${newName}`,
+					error: (err) =>
+						err instanceof Error ? err.message : "Failed to rename branch",
+				},
+			);
+		},
+		[workspaceId, status.data?.currentBranch.name, renameBranchMutation],
+	);
+
+	// Can only rename if branch hasn't been pushed (aheadCount === total commits means nothing pushed)
+	const canRenameBranch = !status.data?.currentBranch.upstream;
+
+	const commitFilesInput =
+		filter.kind === "commit"
+			? { workspaceId, commitHash: filter.hash }
+			: filter.kind === "range"
+				? { workspaceId, commitHash: filter.toHash, fromHash: filter.fromHash }
+				: { workspaceId, commitHash: "" };
+
+	const commitFiles = workspaceTrpc.git.getCommitFiles.useQuery(
+		commitFilesInput,
+		{ enabled: filter.kind === "commit" || filter.kind === "range" },
+	);
+
+	const totalChanges = status.data
+		? status.data.againstBase.length +
+			status.data.staged.length +
+			status.data.unstaged.length
+		: 0;
+
+	const totalAdditions = status.data
+		? [
+				...status.data.againstBase,
+				...status.data.staged,
+				...status.data.unstaged,
+			].reduce((sum, f) => sum + f.additions, 0)
+		: 0;
+
+	const totalDeletions = status.data
+		? [
+				...status.data.againstBase,
+				...status.data.staged,
+				...status.data.unstaged,
+			].reduce((sum, f) => sum + f.deletions, 0)
+		: 0;
+
+	const content = useMemo(() => {
+		if (status.isLoading) {
+			return (
+				<div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+					Loading changes...
+				</div>
+			);
+		}
+
+		if (!status.data) {
+			return (
+				<div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+					Unable to load git status
+				</div>
+			);
+		}
+
+		let fileList: React.ReactNode;
+
+		if (filter.kind === "commit" || filter.kind === "range") {
+			fileList = (
+				<ChangesFileList
+					files={commitFiles.data?.files ?? []}
+					isLoading={commitFiles.isLoading}
+					onSelectFile={onSelectFile}
+					category="against-base"
+				/>
+			);
+		} else if (filter.kind === "uncommitted") {
+			fileList = (
+				<ChangesFileList
+					files={[...status.data.staged, ...status.data.unstaged]}
+					onSelectFile={onSelectFile}
+					category="unstaged"
+				/>
+			);
+		} else {
+			// Merge all files into a single flat list, deduplicating by path
+			// (a file can appear in both againstBase and staged/unstaged)
+			const allFilesMap = new Map<
+				string,
+				(typeof status.data.againstBase)[number]
+			>();
+			for (const f of status.data.againstBase) allFilesMap.set(f.path, f);
+			for (const f of status.data.staged) allFilesMap.set(f.path, f);
+			for (const f of status.data.unstaged) allFilesMap.set(f.path, f);
+
+			fileList = (
+				<ChangesFileList
+					files={Array.from(allFilesMap.values())}
+					onSelectFile={onSelectFile}
+					category="against-base"
+				/>
+			);
+		}
+
+		return (
+			<div className="flex h-full min-h-0 flex-col">
+				<ChangesHeader
+					currentBranch={status.data.currentBranch}
+					defaultBranchName={status.data.defaultBranch.name}
+					commitCount={commits.data?.commits.length ?? 0}
+					totalFiles={totalChanges}
+					totalAdditions={totalAdditions}
+					totalDeletions={totalDeletions}
+					filter={filter}
+					onFilterChange={setFilter}
+					commits={commits.data?.commits ?? []}
+					uncommittedCount={
+						status.data.staged.length + status.data.unstaged.length
+					}
+					branches={branches.data?.branches ?? []}
+					onBaseBranchChange={setBaseBranch}
+					onRenameBranch={handleRenameBranch}
+					canRename={canRenameBranch}
+				/>
+				<div className="min-h-0 flex-1 overflow-y-auto">{fileList}</div>
+			</div>
+		);
+	}, [
+		status.data,
+		status.isLoading,
+		filter,
+		commitFiles.data,
+		commitFiles.isLoading,
+		commits.data,
+		totalChanges,
+		totalAdditions,
+		totalDeletions,
+		onSelectFile,
+		setFilter,
+		branches.data?.branches,
+		canRenameBranch,
+		handleRenameBranch,
+		setBaseBranch,
+	]);
+
+	return {
+		id: "changes",
+		label: "Changes",
+		badge: totalChanges > 0 ? totalChanges : undefined,
+		content,
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/types.ts
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+export interface SidebarTabDefinition {
+	id: string;
+	label: string;
+	badge?: number;
+	actions?: ReactNode;
+	content: ReactNode;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -14,6 +14,19 @@ export const dashboardSidebarProjectSchema = z.object({
 
 const paneWorkspaceStateSchema = z.custom<WorkspaceState<unknown>>();
 
+const changesFilterSchema = z.discriminatedUnion("kind", [
+	z.object({ kind: z.literal("all") }),
+	z.object({ kind: z.literal("uncommitted") }),
+	z.object({ kind: z.literal("commit"), hash: z.string() }),
+	z.object({
+		kind: z.literal("range"),
+		fromHash: z.string(),
+		toHash: z.string(),
+	}),
+]);
+
+export type ChangesFilter = z.infer<typeof changesFilterSchema>;
+
 export const workspaceLocalStateSchema = z.object({
 	workspaceId: z.string().uuid(),
 	createdAt: persistedDateSchema,
@@ -21,6 +34,8 @@ export const workspaceLocalStateSchema = z.object({
 		projectId: z.string().uuid(),
 		tabOrder: z.number().int().default(0),
 		sectionId: z.string().uuid().nullable().default(null),
+		changesFilter: changesFilterSchema.default({ kind: "all" }),
+		baseBranch: z.string().nullable().default(null),
 	}),
 	paneLayout: paneWorkspaceStateSchema,
 	rightSidebarOpen: z.boolean().default(false),

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -275,8 +275,10 @@ export const gitRouter = router({
 					modifiedContent = await git.show([`:0:${input.path}`]);
 				} catch {}
 			} else {
+				// Unstaged: compare index (staged version) against working tree
+				// If file isn't in index (untracked), originalContent stays empty = "new file"
 				try {
-					originalContent = await git.show([`HEAD:${input.path}`]);
+					originalContent = await git.show([`:0:${input.path}`]);
 				} catch {}
 				try {
 					modifiedContent = await readFile(
@@ -402,7 +404,12 @@ export const gitRouter = router({
 					},
 				);
 				reviewThreads = parseGraphQLThreads(result);
-			} catch {}
+			} catch (error) {
+				console.warn(
+					"[git.getPullRequestThreads] Failed to fetch review threads:",
+					error,
+				);
+			}
 
 			const conversationComments: IssueComment[] = [];
 			try {
@@ -433,7 +440,12 @@ export const gitRouter = router({
 					hasMore = comments.length === 100;
 					page++;
 				}
-			} catch {}
+			} catch (error) {
+				console.warn(
+					"[git.getPullRequestThreads] Failed to fetch conversation comments:",
+					error,
+				);
+			}
 
 			return { reviewThreads, conversationComments };
 		}),

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -9,6 +9,7 @@ import type {
 	CheckConclusionState,
 	CheckRun,
 	CheckStatusState,
+	Commit,
 	IssueComment,
 	MergeableState,
 	PullRequestReviewDecision,
@@ -24,8 +25,8 @@ import {
 } from "./utils/git-helpers";
 import {
 	type GraphQLThreadsResult,
-	REVIEW_THREADS_QUERY,
 	parseGraphQLThreads,
+	REVIEW_THREADS_QUERY,
 } from "./utils/graphql";
 import { resolveWorktreePath } from "./utils/resolve-worktree";
 
@@ -93,10 +94,7 @@ export const gitRouter = router({
 				git.status(),
 			]);
 
-			const againstBase = await getChangedFilesForDiff(git, [
-				baseRef,
-				"HEAD",
-			]);
+			const againstBase = await getChangedFilesForDiff(git, [baseRef, "HEAD"]);
 
 			// Staged — use status.files index character for correct status
 			const stagedNumstat = parseNumstat(
@@ -148,6 +146,99 @@ export const gitRouter = router({
 			}
 
 			return { currentBranch, defaultBranch, againstBase, staged, unstaged };
+		}),
+
+	listCommits: protectedProcedure
+		.input(
+			z.object({
+				workspaceId: z.string(),
+				baseBranch: z.string().optional(),
+			}),
+		)
+		.query(async ({ ctx, input }) => {
+			const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
+			const git = await ctx.git(worktreePath);
+
+			const defaultBranchName =
+				input.baseBranch ?? (await getDefaultBranchName(git));
+			const baseRef = defaultBranchName
+				? `origin/${defaultBranchName}`
+				: "HEAD";
+
+			const commits: Commit[] = [];
+			try {
+				const raw = await git.raw([
+					"log",
+					`${baseRef}..HEAD`,
+					"--format=%H\t%h\t%s\t%an\t%aI",
+				]);
+				for (const line of raw.trim().split("\n")) {
+					if (!line) continue;
+					const [hash, shortHash, message, author, date] = line.split("\t");
+					commits.push({
+						hash: hash ?? "",
+						shortHash: shortHash ?? "",
+						message: message ?? "",
+						author: author ?? "",
+						date: date ?? "",
+					});
+				}
+			} catch {}
+
+			return { commits };
+		}),
+
+	getCommitFiles: protectedProcedure
+		.input(
+			z.object({
+				workspaceId: z.string(),
+				commitHash: z.string(),
+				fromHash: z.string().optional(),
+			}),
+		)
+		.query(async ({ ctx, input }) => {
+			const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
+			const git = await ctx.git(worktreePath);
+
+			const from = input.fromHash ? input.fromHash : `${input.commitHash}^`;
+			const files = await getChangedFilesForDiff(git, [from, input.commitHash]);
+
+			return { files };
+		}),
+
+	renameBranch: protectedProcedure
+		.input(
+			z.object({
+				workspaceId: z.string(),
+				oldName: z.string(),
+				newName: z.string(),
+			}),
+		)
+		.mutation(async ({ ctx, input }) => {
+			const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
+			const git = await ctx.git(worktreePath);
+
+			// Check if branch has been pushed to remote
+			try {
+				const remote = await git.raw([
+					"ls-remote",
+					"--heads",
+					"origin",
+					input.oldName,
+				]);
+				if (remote.trim()) {
+					throw new TRPCError({
+						code: "PRECONDITION_FAILED",
+						message: "Cannot rename a branch that has been pushed to remote",
+					});
+				}
+			} catch (error) {
+				if (error instanceof TRPCError) throw error;
+				// ls-remote failed — probably no remote, safe to rename
+			}
+
+			await git.raw(["branch", "-m", input.oldName, input.newName]);
+			return { name: input.newName };
 		}),
 
 	getDiff: protectedProcedure
@@ -233,10 +324,8 @@ export const gitRouter = router({
 					checks = parsed.map(
 						(c: Record<string, unknown>): CheckRun => ({
 							name: (c.name as string) ?? "",
-							status: ((c.status as string) ??
-								"completed") as CheckStatusState,
-							conclusion: (c.conclusion ??
-								null) as CheckConclusionState | null,
+							status: ((c.status as string) ?? "completed") as CheckStatusState,
+							conclusion: (c.conclusion ?? null) as CheckConclusionState | null,
 							detailsUrl: (c.url as string) ?? null,
 							startedAt: (c.startedAt as string) ?? null,
 							completedAt: (c.completedAt as string) ?? null,
@@ -256,9 +345,7 @@ export const gitRouter = router({
 					null) as PullRequestReviewDecision | null,
 				mergeable: "unknown" as MergeableState,
 				headRefName: pr.headBranch ?? "",
-				updatedAt: pr.updatedAt
-					? new Date(pr.updatedAt).toISOString()
-					: "",
+				updatedAt: pr.updatedAt ? new Date(pr.updatedAt).toISOString() : "",
 				checks,
 			};
 		}),
@@ -322,14 +409,13 @@ export const gitRouter = router({
 				let page = 1;
 				let hasMore = true;
 				while (hasMore) {
-					const { data: comments } =
-						await octokit.issues.listComments({
-							owner: project.repoOwner,
-							repo: project.repoName,
-							issue_number: pr.prNumber,
-							per_page: 100,
-							page,
-						});
+					const { data: comments } = await octokit.issues.listComments({
+						owner: project.repoOwner,
+						repo: project.repoName,
+						issue_number: pr.prNumber,
+						per_page: 100,
+						page,
+					});
 					for (const c of comments) {
 						const body = c.body?.trim();
 						if (!body) continue;

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -1,24 +1,354 @@
+import { readFile } from "node:fs/promises";
+import { TRPCError } from "@trpc/server";
+import { eq } from "drizzle-orm";
 import { z } from "zod";
+import { projects, pullRequests, workspaces } from "../../../db/schema";
 import { protectedProcedure, router } from "../../index";
+import type {
+	ChangedFile,
+	CheckConclusionState,
+	CheckRun,
+	CheckStatusState,
+	IssueComment,
+	MergeableState,
+	PullRequestReviewDecision,
+	PullRequestReviewThread,
+	PullRequestState,
+} from "./types";
+import {
+	buildBranch,
+	getChangedFilesForDiff,
+	getDefaultBranchName,
+	mapGitStatus,
+	parseNumstat,
+} from "./utils/git-helpers";
+import {
+	type GraphQLThreadsResult,
+	REVIEW_THREADS_QUERY,
+	parseGraphQLThreads,
+} from "./utils/graphql";
+import { resolveWorktreePath } from "./utils/resolve-worktree";
 
-// TODO: Remove this test router in favor of product-led endpoints (i.e. workspace.create())
 export const gitRouter = router({
-	status: protectedProcedure
-		.input(z.object({ path: z.string() }))
+	listBranches: protectedProcedure
+		.input(z.object({ workspaceId: z.string() }))
 		.query(async ({ ctx, input }) => {
-			const git = await ctx.git(input.path);
-			const status = await git.status();
+			const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
+			const git = await ctx.git(worktreePath);
+
+			const currentBranchName = (
+				await git.revparse(["--abbrev-ref", "HEAD"]).catch(() => "")
+			).trim();
+			const defaultBranchName = await getDefaultBranchName(git);
+
+			let branchNames: string[] = [];
+			try {
+				const raw = await git.raw([
+					"branch",
+					"--list",
+					"--format=%(refname:short)",
+				]);
+				branchNames = raw.trim().split("\n").filter(Boolean);
+			} catch {}
+
+			const branches = await Promise.all(
+				branchNames.map((name) =>
+					buildBranch(
+						git,
+						name,
+						name === currentBranchName,
+						defaultBranchName ? `origin/${defaultBranchName}` : undefined,
+					),
+				),
+			);
+
+			return { branches };
+		}),
+
+	getStatus: protectedProcedure
+		.input(
+			z.object({
+				workspaceId: z.string(),
+				baseBranch: z.string().optional(),
+			}),
+		)
+		.query(async ({ ctx, input }) => {
+			const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
+			const git = await ctx.git(worktreePath);
+
+			const currentBranchName = (
+				await git.revparse(["--abbrev-ref", "HEAD"]).catch(() => "")
+			).trim();
+			const defaultBranchName =
+				input.baseBranch ?? (await getDefaultBranchName(git));
+			const baseRef = defaultBranchName
+				? `origin/${defaultBranchName}`
+				: "HEAD";
+
+			const [currentBranch, defaultBranch, status] = await Promise.all([
+				buildBranch(git, currentBranchName, true, baseRef),
+				defaultBranchName
+					? buildBranch(git, defaultBranchName, false)
+					: buildBranch(git, currentBranchName, true),
+				git.status(),
+			]);
+
+			const againstBase = await getChangedFilesForDiff(git, [
+				baseRef,
+				"HEAD",
+			]);
+
+			// Staged — use status.files index character for correct status
+			const stagedNumstat = parseNumstat(
+				await git.raw(["diff", "--numstat", "--cached"]).catch(() => ""),
+			);
+			const staged: ChangedFile[] = [];
+			for (const file of status.files) {
+				const idx = file.index;
+				if (idx && idx !== " " && idx !== "?") {
+					const stats = stagedNumstat.get(file.path) ?? {
+						additions: 0,
+						deletions: 0,
+					};
+					staged.push({
+						path: file.path,
+						status: mapGitStatus(idx),
+						additions: stats.additions,
+						deletions: stats.deletions,
+					});
+				}
+			}
+
+			// Unstaged — use status.files working_dir character
+			const unstagedNumstat = parseNumstat(
+				await git.raw(["diff", "--numstat"]).catch(() => ""),
+			);
+			const unstaged: ChangedFile[] = [];
+			for (const file of status.files) {
+				const wd = file.working_dir;
+				if (file.index === "?" && wd === "?") {
+					unstaged.push({
+						path: file.path,
+						status: "untracked",
+						additions: 0,
+						deletions: 0,
+					});
+				} else if (wd && wd !== " ") {
+					const stats = unstagedNumstat.get(file.path) ?? {
+						additions: 0,
+						deletions: 0,
+					};
+					unstaged.push({
+						path: file.path,
+						status: mapGitStatus(wd),
+						additions: stats.additions,
+						deletions: stats.deletions,
+					});
+				}
+			}
+
+			return { currentBranch, defaultBranch, againstBase, staged, unstaged };
+		}),
+
+	getDiff: protectedProcedure
+		.input(
+			z.object({
+				workspaceId: z.string(),
+				path: z.string(),
+				category: z.enum(["against-base", "staged", "unstaged"]),
+				baseBranch: z.string().optional(),
+			}),
+		)
+		.query(async ({ ctx, input }) => {
+			const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
+			const git = await ctx.git(worktreePath);
+
+			let originalContent = "";
+			let modifiedContent = "";
+
+			if (input.category === "against-base") {
+				const baseBranch =
+					input.baseBranch ?? (await getDefaultBranchName(git));
+				const baseRef = baseBranch ? `origin/${baseBranch}` : "HEAD";
+				try {
+					originalContent = await git.show([`${baseRef}:${input.path}`]);
+				} catch {}
+				try {
+					modifiedContent = await git.show([`HEAD:${input.path}`]);
+				} catch {}
+			} else if (input.category === "staged") {
+				try {
+					originalContent = await git.show([`HEAD:${input.path}`]);
+				} catch {}
+				try {
+					modifiedContent = await git.show([`:0:${input.path}`]);
+				} catch {}
+			} else {
+				try {
+					originalContent = await git.show([`HEAD:${input.path}`]);
+				} catch {}
+				try {
+					modifiedContent = await readFile(
+						`${worktreePath}/${input.path}`,
+						"utf-8",
+					);
+				} catch {}
+			}
+
+			const fileName = input.path.split("/").pop() ?? input.path;
 			return {
-				current: status.current,
-				tracking: status.tracking,
-				ahead: status.ahead,
-				behind: status.behind,
-				staged: status.staged,
-				modified: status.modified,
-				not_added: status.not_added,
-				deleted: status.deleted,
-				conflicted: status.conflicted,
-				isClean: status.isClean(),
+				oldFile: { name: fileName, contents: originalContent },
+				newFile: { name: fileName, contents: modifiedContent },
 			};
+		}),
+
+	getPullRequest: protectedProcedure
+		.input(z.object({ workspaceId: z.string() }))
+		.query(({ ctx, input }) => {
+			const workspace = ctx.db.query.workspaces
+				.findFirst({ where: eq(workspaces.id, input.workspaceId) })
+				.sync();
+			if (!workspace) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Workspace not found",
+				});
+			}
+			if (!workspace.pullRequestId) return null;
+
+			const pr = ctx.db.query.pullRequests
+				.findFirst({ where: eq(pullRequests.id, workspace.pullRequestId) })
+				.sync();
+			if (!pr) {
+				throw new TRPCError({
+					code: "INTERNAL_SERVER_ERROR",
+					message: `Pull request ${workspace.pullRequestId} not found in database`,
+				});
+			}
+
+			let checks: CheckRun[] = [];
+			try {
+				const parsed = JSON.parse(pr.checksJson);
+				if (Array.isArray(parsed)) {
+					checks = parsed.map(
+						(c: Record<string, unknown>): CheckRun => ({
+							name: (c.name as string) ?? "",
+							status: ((c.status as string) ??
+								"completed") as CheckStatusState,
+							conclusion: (c.conclusion ??
+								null) as CheckConclusionState | null,
+							detailsUrl: (c.url as string) ?? null,
+							startedAt: (c.startedAt as string) ?? null,
+							completedAt: (c.completedAt as string) ?? null,
+						}),
+					);
+				}
+			} catch {}
+
+			return {
+				number: pr.prNumber,
+				url: pr.url,
+				title: pr.title,
+				body: null as string | null,
+				state: pr.state as PullRequestState,
+				isDraft: pr.isDraft ?? false,
+				reviewDecision: (pr.reviewDecision ??
+					null) as PullRequestReviewDecision | null,
+				mergeable: "unknown" as MergeableState,
+				headRefName: pr.headBranch ?? "",
+				updatedAt: pr.updatedAt
+					? new Date(pr.updatedAt).toISOString()
+					: "",
+				checks,
+			};
+		}),
+
+	getPullRequestThreads: protectedProcedure
+		.input(z.object({ workspaceId: z.string() }))
+		.query(async ({ ctx, input }) => {
+			const workspace = ctx.db.query.workspaces
+				.findFirst({ where: eq(workspaces.id, input.workspaceId) })
+				.sync();
+			if (!workspace) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Workspace not found",
+				});
+			}
+			if (!workspace.pullRequestId) {
+				return { reviewThreads: [], conversationComments: [] };
+			}
+
+			const pr = ctx.db.query.pullRequests
+				.findFirst({ where: eq(pullRequests.id, workspace.pullRequestId) })
+				.sync();
+			if (!pr) {
+				throw new TRPCError({
+					code: "INTERNAL_SERVER_ERROR",
+					message: `Pull request ${workspace.pullRequestId} not found in database`,
+				});
+			}
+
+			const project = ctx.db.query.projects
+				.findFirst({ where: eq(projects.id, workspace.projectId) })
+				.sync();
+			if (!project) {
+				throw new TRPCError({
+					code: "INTERNAL_SERVER_ERROR",
+					message: `Project ${workspace.projectId} not found in database`,
+				});
+			}
+			if (!project.repoOwner || !project.repoName) {
+				return { reviewThreads: [], conversationComments: [] };
+			}
+
+			const octokit = await ctx.github();
+
+			let reviewThreads: PullRequestReviewThread[] = [];
+			try {
+				const result: GraphQLThreadsResult = await octokit.graphql(
+					REVIEW_THREADS_QUERY,
+					{
+						owner: project.repoOwner,
+						name: project.repoName,
+						prNumber: pr.prNumber,
+					},
+				);
+				reviewThreads = parseGraphQLThreads(result);
+			} catch {}
+
+			const conversationComments: IssueComment[] = [];
+			try {
+				let page = 1;
+				let hasMore = true;
+				while (hasMore) {
+					const { data: comments } =
+						await octokit.issues.listComments({
+							owner: project.repoOwner,
+							repo: project.repoName,
+							issue_number: pr.prNumber,
+							per_page: 100,
+							page,
+						});
+					for (const c of comments) {
+						const body = c.body?.trim();
+						if (!body) continue;
+						conversationComments.push({
+							id: c.id,
+							user: {
+								login: c.user?.login ?? "ghost",
+								avatarUrl: c.user?.avatar_url ?? "",
+							},
+							body,
+							createdAt: c.created_at ?? "",
+							htmlUrl: c.html_url ?? "",
+						});
+					}
+					hasMore = comments.length === 100;
+					page++;
+				}
+			} catch {}
+
+			return { reviewThreads, conversationComments };
 		}),
 });

--- a/packages/host-service/src/trpc/router/git/index.ts
+++ b/packages/host-service/src/trpc/router/git/index.ts
@@ -1,1 +1,2 @@
 export { gitRouter } from "./git";
+export type * from "./types";

--- a/packages/host-service/src/trpc/router/git/types.ts
+++ b/packages/host-service/src/trpc/router/git/types.ts
@@ -119,3 +119,11 @@ export interface ChangedFile {
 	additions: number;
 	deletions: number;
 }
+
+export interface Commit {
+	hash: string;
+	shortHash: string;
+	message: string;
+	author: string;
+	date: string;
+}

--- a/packages/host-service/src/trpc/router/git/types.ts
+++ b/packages/host-service/src/trpc/router/git/types.ts
@@ -1,0 +1,121 @@
+/**
+ * Git & GitHub types for the git tRPC router.
+ *
+ * Design principle: mirror GitHub's data model. Base types are subsets of
+ * GitHub's GraphQL/REST schema. Our extensions (Branch, ChangedFile) add
+ * local git concepts using the same naming conventions.
+ */
+
+// ---------------------------------------------------------------------------
+// GitHub enums (lowercased from GraphQL SCREAMING_CASE)
+// ---------------------------------------------------------------------------
+
+/** GitHub GraphQL: PatchStatus */
+export type PatchStatus =
+	| "added"
+	| "copied"
+	| "changed"
+	| "deleted"
+	| "modified"
+	| "renamed";
+
+/** GitHub GraphQL: DiffSide */
+export type DiffSide = "LEFT" | "RIGHT";
+
+/** GitHub GraphQL: PullRequestState */
+export type PullRequestState = "open" | "closed" | "merged";
+
+/** GitHub GraphQL: PullRequestReviewDecision */
+export type PullRequestReviewDecision =
+	| "approved"
+	| "changes_requested"
+	| "review_required";
+
+/** GitHub GraphQL: CheckStatusState */
+export type CheckStatusState =
+	| "completed"
+	| "in_progress"
+	| "pending"
+	| "queued";
+
+/** GitHub GraphQL: CheckConclusionState */
+export type CheckConclusionState =
+	| "success"
+	| "failure"
+	| "cancelled"
+	| "skipped"
+	| "neutral"
+	| "timed_out"
+	| "action_required"
+	| "stale";
+
+/** GitHub GraphQL: MergeableState */
+export type MergeableState = "mergeable" | "conflicting" | "unknown";
+
+// ---------------------------------------------------------------------------
+// GitHub objects (subset of fields we use)
+// ---------------------------------------------------------------------------
+
+export interface GitHubActor {
+	login: string;
+	avatarUrl: string;
+}
+
+export interface PullRequestReviewComment {
+	id: string;
+	databaseId: number;
+	author: GitHubActor;
+	body: string;
+	createdAt: string;
+}
+
+export interface PullRequestReviewThread {
+	id: string;
+	isResolved: boolean;
+	diffSide: DiffSide;
+	line: number | null;
+	path: string;
+	comments: PullRequestReviewComment[];
+}
+
+export interface CheckRun {
+	name: string;
+	status: CheckStatusState;
+	conclusion: CheckConclusionState | null;
+	detailsUrl: string | null;
+	startedAt: string | null;
+	completedAt: string | null;
+}
+
+export interface IssueComment {
+	id: number;
+	user: GitHubActor;
+	body: string;
+	createdAt: string;
+	htmlUrl: string;
+}
+
+// ---------------------------------------------------------------------------
+// Our resource types
+// ---------------------------------------------------------------------------
+
+/** Extends GitHub's PatchStatus with "untracked" for local working tree */
+export type FileStatus = PatchStatus | "untracked";
+
+export interface Branch {
+	name: string;
+	isHead: boolean;
+	upstream: string | null;
+	aheadCount: number;
+	behindCount: number;
+	lastCommitHash: string;
+	lastCommitDate: string;
+}
+
+export interface ChangedFile {
+	path: string;
+	oldPath?: string;
+	status: FileStatus;
+	additions: number;
+	deletions: number;
+}

--- a/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
@@ -95,9 +95,7 @@ export async function buildBranch(
 			await git.raw(["config", `branch.${name}.merge`]).catch(() => "")
 		).trim();
 		upstream =
-			remote && merge
-				? `${remote}/${merge.replace("refs/heads/", "")}`
-				: null;
+			remote && merge ? `${remote}/${merge.replace("refs/heads/", "")}` : null;
 	} catch {
 		upstream = null;
 	}
@@ -119,9 +117,7 @@ export async function buildBranch(
 	}
 
 	try {
-		const log = (
-			await git.raw(["log", "-1", "--format=%H\t%aI", name])
-		).trim();
+		const log = (await git.raw(["log", "-1", "--format=%H\t%aI", name])).trim();
 		const [hash, date] = log.split("\t");
 		lastCommitHash = hash ?? "";
 		lastCommitDate = date ?? "";

--- a/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
+++ b/packages/host-service/src/trpc/router/git/utils/git-helpers.ts
@@ -1,0 +1,164 @@
+import type { SimpleGit } from "simple-git";
+import type { Branch, ChangedFile, FileStatus } from "../types";
+
+/** Map git's single-letter status codes to GitHub-aligned FileStatus */
+export function mapGitStatus(code: string): FileStatus {
+	switch (code) {
+		case "A":
+			return "added";
+		case "M":
+			return "modified";
+		case "D":
+			return "deleted";
+		case "R":
+			return "renamed";
+		case "C":
+			return "copied";
+		case "T":
+			return "changed";
+		case "?":
+			return "untracked";
+		default:
+			return "modified";
+	}
+}
+
+export function parseNumstat(
+	raw: string,
+): Map<string, { additions: number; deletions: number }> {
+	const result = new Map<string, { additions: number; deletions: number }>();
+	for (const line of raw.trim().split("\n")) {
+		if (!line) continue;
+		const [add, del, ...pathParts] = line.split("\t");
+		const path = pathParts.join("\t");
+		result.set(path, {
+			additions: add === "-" ? 0 : Number.parseInt(add ?? "0", 10),
+			deletions: del === "-" ? 0 : Number.parseInt(del ?? "0", 10),
+		});
+	}
+	return result;
+}
+
+export function parseNameStatus(
+	raw: string,
+): Array<{ status: string; path: string; oldPath?: string }> {
+	const results: Array<{ status: string; path: string; oldPath?: string }> = [];
+	for (const line of raw.trim().split("\n")) {
+		if (!line) continue;
+		const parts = line.split("\t");
+		const statusCode = parts[0]?.[0] ?? "?";
+		if (statusCode === "R" || statusCode === "C") {
+			results.push({
+				status: statusCode,
+				path: parts[2] ?? "",
+				oldPath: parts[1],
+			});
+		} else {
+			results.push({ status: statusCode, path: parts[1] ?? "" });
+		}
+	}
+	return results;
+}
+
+export async function getDefaultBranchName(
+	git: SimpleGit,
+): Promise<string | null> {
+	try {
+		const ref = await git.raw([
+			"symbolic-ref",
+			"refs/remotes/origin/HEAD",
+			"--short",
+		]);
+		return ref.trim().replace(/^origin\//, "");
+	} catch {
+		return null;
+	}
+}
+
+export async function buildBranch(
+	git: SimpleGit,
+	name: string,
+	isHead: boolean,
+	compareRef?: string,
+): Promise<Branch> {
+	let upstream: string | null = null;
+	let aheadCount = 0;
+	let behindCount = 0;
+	let lastCommitHash = "";
+	let lastCommitDate = "";
+
+	try {
+		const remote = (
+			await git.raw(["config", `branch.${name}.remote`]).catch(() => "")
+		).trim();
+		const merge = (
+			await git.raw(["config", `branch.${name}.merge`]).catch(() => "")
+		).trim();
+		upstream =
+			remote && merge
+				? `${remote}/${merge.replace("refs/heads/", "")}`
+				: null;
+	} catch {
+		upstream = null;
+	}
+
+	if (compareRef) {
+		try {
+			const counts = (
+				await git.raw([
+					"rev-list",
+					"--left-right",
+					"--count",
+					`${compareRef}...${name}`,
+				])
+			).trim();
+			const [behind, ahead] = counts.split("\t").map(Number);
+			aheadCount = ahead ?? 0;
+			behindCount = behind ?? 0;
+		} catch {}
+	}
+
+	try {
+		const log = (
+			await git.raw(["log", "-1", "--format=%H\t%aI", name])
+		).trim();
+		const [hash, date] = log.split("\t");
+		lastCommitHash = hash ?? "";
+		lastCommitDate = date ?? "";
+	} catch {}
+
+	return {
+		name,
+		isHead,
+		upstream,
+		aheadCount,
+		behindCount,
+		lastCommitHash,
+		lastCommitDate,
+	};
+}
+
+export async function getChangedFilesForDiff(
+	git: SimpleGit,
+	diffArgs: string[],
+): Promise<ChangedFile[]> {
+	try {
+		const [nameStatusRaw, numstatRaw] = await Promise.all([
+			git.raw(["diff", "--name-status", ...diffArgs]),
+			git.raw(["diff", "--numstat", ...diffArgs]),
+		]);
+		const nameStatus = parseNameStatus(nameStatusRaw);
+		const numstat = parseNumstat(numstatRaw);
+		return nameStatus
+			.filter((f) => f.path)
+			.map((f) => ({
+				path: f.path,
+				oldPath: f.oldPath,
+				status: mapGitStatus(f.status),
+				additions: (numstat.get(f.path) ?? { additions: 0 }).additions,
+				deletions: (numstat.get(f.path) ?? { deletions: 0 }).deletions,
+			}));
+	} catch {
+		return [];
+	}
+}

--- a/packages/host-service/src/trpc/router/git/utils/graphql.ts
+++ b/packages/host-service/src/trpc/router/git/utils/graphql.ts
@@ -1,0 +1,83 @@
+import type {
+	DiffSide,
+	PullRequestReviewComment,
+	PullRequestReviewThread,
+} from "../types";
+
+export const REVIEW_THREADS_QUERY = `
+	query($owner: String!, $name: String!, $prNumber: Int!) {
+		repository(owner: $owner, name: $name) {
+			pullRequest(number: $prNumber) {
+				reviewThreads(first: 100) {
+					nodes {
+						id
+						isResolved
+						diffSide
+						comments(first: 100) {
+							nodes {
+								id
+								databaseId
+								author { login avatarUrl }
+								body
+								createdAt
+								path
+								line
+								originalLine
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+`;
+
+export interface GraphQLThreadsResult {
+	repository: {
+		pullRequest: {
+			reviewThreads: {
+				nodes: Array<{
+					id: string;
+					isResolved: boolean;
+					diffSide: string;
+					comments: {
+						nodes: Array<{
+							id: string;
+							databaseId: number;
+							author: { login: string; avatarUrl: string } | null;
+							body: string;
+							createdAt: string;
+							path: string;
+							line: number | null;
+							originalLine: number | null;
+						}>;
+					};
+				}>;
+			};
+		};
+	};
+}
+
+export function parseGraphQLThreads(
+	result: GraphQLThreadsResult,
+): PullRequestReviewThread[] {
+	return result.repository.pullRequest.reviewThreads.nodes.map((thread) => {
+		const firstComment = thread.comments.nodes[0];
+		return {
+			id: thread.id,
+			isResolved: thread.isResolved,
+			diffSide: (thread.diffSide === "LEFT" ? "LEFT" : "RIGHT") as DiffSide,
+			line: firstComment?.line ?? firstComment?.originalLine ?? null,
+			path: firstComment?.path ?? "",
+			comments: thread.comments.nodes.map(
+				(c): PullRequestReviewComment => ({
+					id: c.id,
+					databaseId: c.databaseId,
+					author: c.author ?? { login: "ghost", avatarUrl: "" },
+					body: c.body,
+					createdAt: c.createdAt,
+				}),
+			),
+		};
+	});
+}

--- a/packages/host-service/src/trpc/router/git/utils/resolve-worktree.ts
+++ b/packages/host-service/src/trpc/router/git/utils/resolve-worktree.ts
@@ -1,0 +1,20 @@
+import { TRPCError } from "@trpc/server";
+import { eq } from "drizzle-orm";
+import { workspaces } from "../../../../db/schema";
+import type { protectedProcedure } from "../../../index";
+
+export function resolveWorktreePath(
+	ctx: Parameters<Parameters<typeof protectedProcedure.query>[0]>[0]["ctx"],
+	workspaceId: string,
+): string {
+	const workspace = ctx.db.query.workspaces
+		.findFirst({ where: eq(workspaces.id, workspaceId) })
+		.sync();
+	if (!workspace?.worktreePath) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Workspace not found",
+		});
+	}
+	return workspace.worktreePath;
+}


### PR DESCRIPTION
## Summary
- New git tRPC router with GitHub-aligned types mirroring GraphQL/REST schema
- Resource-oriented endpoints: `getStatus`, `listBranches`, `listCommits`, `getCommitFiles`, `getDiff`, `getPullRequest`, `getPullRequestThreads`
- ChangesTab sidebar with card-style header showing branch info, commit count, ahead/behind status, file stats
- Commit filter dropdown (All changes / Uncommitted / Select range / individual commits)
- Base branch selector with searchable popover
- Branch rename (unpushed branches only) with inline edit
- Tab registry pattern: hooks return `SidebarTabDefinition`, only active tab mounted
- Filter state persisted in workspace local state

## Test plan
- [ ] Open v2 workspace, switch to Changes tab
- [ ] Verify branch name and commit count display correctly
- [ ] Change base branch via dropdown — file list updates
- [ ] Switch commit filter: All changes → Uncommitted → specific commit
- [ ] Select commit range via modal
- [ ] Rename branch (only shows pencil icon on unpushed branches)
- [ ] Verify ahead/behind origin status messages
- [ ] File list groups by folder correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce a Git Changes sidebar backed by a resource‑oriented git API. It shows accurate changes against base/staged/unstaged, supports commit/range filtering, base branch selection, and inline branch rename (unpushed only).

- **New Features**
  - New git router with GitHub‑aligned types and endpoints: `getStatus`, `listBranches`, `listCommits`, `getCommitFiles`, `getDiff`, `getPullRequest`, `getPullRequestThreads`, `renameBranch`.
  - Changes tab header: branch info (inline rename), ahead/behind, commit count, file stats, and a searchable base branch selector.
  - Commit filter: All, Uncommitted, single commit, or range (modal). Filter and base branch persist per workspace.
  - Grouped file list with status badges and +/- counts; clicking a file triggers the diff callback.

- **Bug Fixes**
  - Fixed unstaged diff to compare index `:0:` vs working tree (not `HEAD`).
  - Added warnings for GitHub thread fetch errors in `getPullRequestThreads`.
  - Reset range modal selection when the modal closes.

<sup>Written for commit b843f0894620040abd34c71d1360c4ebb260335d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full "Changes" tab in the workspace sidebar showing repository status.
  * View and filter changes by against-base, staged, unstaged, commit, or commit range.
  * Base branch selector to compare against different branches.
  * Commit filter dropdown and interactive commit-range modal.
  * Navigable file change list with status badges and addition/deletion counts.
  * Inline branch rename and improved commit browsing/details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->