### PR TITLE
feat(desktop): wire up v2 workspace hotkeys

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarShortcuts/useDashboardSidebarShortcuts.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarShortcuts/useDashboardSidebarShortcuts.ts
@@ -1,4 +1,4 @@
-import { useNavigate } from "@tanstack/react-router";
+import { useMatchRoute, useNavigate } from "@tanstack/react-router";
 import { useCallback, useMemo } from "react";
 import { useHotkey } from "renderer/hotkeys";
 import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
@@ -47,6 +47,34 @@ export function useDashboardSidebarShortcuts(
 	useHotkey("JUMP_TO_WORKSPACE_7", () => switchToWorkspace(6));
 	useHotkey("JUMP_TO_WORKSPACE_8", () => switchToWorkspace(7));
 	useHotkey("JUMP_TO_WORKSPACE_9", () => switchToWorkspace(8));
+
+	// Prev/next workspace navigation (cycles)
+	const matchRoute = useMatchRoute();
+	const currentWorkspaceMatch = matchRoute({
+		to: "/v2-workspace/$workspaceId",
+		fuzzy: true,
+	});
+	const currentWorkspaceId =
+		currentWorkspaceMatch !== false ? currentWorkspaceMatch.workspaceId : null;
+
+	useHotkey("PREV_WORKSPACE", () => {
+		if (!currentWorkspaceId || flattenedWorkspaces.length === 0) return;
+		const index = flattenedWorkspaces.findIndex(
+			(w) => w.id === currentWorkspaceId,
+		);
+		const prevIndex = index <= 0 ? flattenedWorkspaces.length - 1 : index - 1;
+		navigateToV2Workspace(flattenedWorkspaces[prevIndex].id, navigate);
+	});
+
+	useHotkey("NEXT_WORKSPACE", () => {
+		if (!currentWorkspaceId || flattenedWorkspaces.length === 0) return;
+		const index = flattenedWorkspaces.findIndex(
+			(w) => w.id === currentWorkspaceId,
+		);
+		const nextIndex =
+			index >= flattenedWorkspaces.length - 1 || index === -1 ? 0 : index + 1;
+		navigateToV2Workspace(flattenedWorkspaces[nextIndex].id, navigate);
+	});
 
 	return workspaceShortcutLabels;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/index.ts
@@ -1,0 +1,1 @@
+export { useWorkspaceHotkeys } from "./useWorkspaceHotkeys";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
@@ -1,0 +1,243 @@
+import type { WorkspaceStore } from "@superset/panes";
+import { useCallback } from "react";
+import { useHotkey } from "renderer/hotkeys";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import type { StoreApi } from "zustand";
+import type {
+	BrowserPaneData,
+	ChatPaneData,
+	PaneViewerData,
+	TerminalPaneData,
+} from "../../types";
+
+export function useWorkspaceHotkeys({
+	store,
+	workspaceId,
+}: {
+	store: StoreApi<WorkspaceStore<PaneViewerData>>;
+	workspaceId: string;
+}) {
+	const collections = useCollections();
+
+	useHotkey("TOGGLE_SIDEBAR", () => {
+		if (!collections.v2WorkspaceLocalState.get(workspaceId)) return;
+		collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
+			draft.rightSidebarOpen = !draft.rightSidebarOpen;
+		});
+	});
+
+	// --- Tab creation ---
+
+	useHotkey("NEW_GROUP", () => {
+		store.getState().addTab({
+			titleOverride: "Terminal",
+			panes: [
+				{
+					kind: "terminal",
+					data: { terminalId: crypto.randomUUID() } as TerminalPaneData,
+				},
+			],
+		});
+	});
+
+	useHotkey("NEW_CHAT", () => {
+		store.getState().addTab({
+			titleOverride: "Chat",
+			panes: [{ kind: "chat", data: { sessionId: null } as ChatPaneData }],
+		});
+	});
+
+	useHotkey("NEW_BROWSER", () => {
+		store.getState().addTab({
+			titleOverride: "Browser",
+			panes: [
+				{
+					kind: "browser",
+					data: {
+						url: "http://localhost:3000",
+						mode: "preview",
+					} as BrowserPaneData,
+				},
+			],
+		});
+	});
+
+	// --- Tab management ---
+
+	useHotkey("CLOSE_TERMINAL", () => {
+		const state = store.getState();
+		const active = state.getActivePane();
+		if (active) {
+			state.closePane({ tabId: active.tabId, paneId: active.pane.id });
+		}
+	});
+
+	useHotkey("CLOSE_TAB", () => {
+		const state = store.getState();
+		if (state.activeTabId) {
+			state.removeTab(state.activeTabId);
+		}
+	});
+
+	useHotkey("PREV_TAB", () => {
+		const state = store.getState();
+		if (!state.activeTabId || state.tabs.length === 0) return;
+		const index = state.tabs.findIndex((t) => t.id === state.activeTabId);
+		const prevIndex = index <= 0 ? state.tabs.length - 1 : index - 1;
+		state.setActiveTab(state.tabs[prevIndex].id);
+	});
+
+	useHotkey("NEXT_TAB", () => {
+		const state = store.getState();
+		if (!state.activeTabId || state.tabs.length === 0) return;
+		const index = state.tabs.findIndex((t) => t.id === state.activeTabId);
+		const nextIndex =
+			index >= state.tabs.length - 1 || index === -1 ? 0 : index + 1;
+		state.setActiveTab(state.tabs[nextIndex].id);
+	});
+
+	useHotkey("PREV_TAB_ALT", () => {
+		const state = store.getState();
+		if (!state.activeTabId || state.tabs.length === 0) return;
+		const index = state.tabs.findIndex((t) => t.id === state.activeTabId);
+		const prevIndex = index <= 0 ? state.tabs.length - 1 : index - 1;
+		state.setActiveTab(state.tabs[prevIndex].id);
+	});
+
+	useHotkey("NEXT_TAB_ALT", () => {
+		const state = store.getState();
+		if (!state.activeTabId || state.tabs.length === 0) return;
+		const index = state.tabs.findIndex((t) => t.id === state.activeTabId);
+		const nextIndex =
+			index >= state.tabs.length - 1 || index === -1 ? 0 : index + 1;
+		state.setActiveTab(state.tabs[nextIndex].id);
+	});
+
+	const switchToTab = useCallback(
+		(index: number) => {
+			const state = store.getState();
+			const tab = state.tabs[index];
+			if (tab) state.setActiveTab(tab.id);
+		},
+		[store],
+	);
+
+	useHotkey("JUMP_TO_TAB_1", () => switchToTab(0));
+	useHotkey("JUMP_TO_TAB_2", () => switchToTab(1));
+	useHotkey("JUMP_TO_TAB_3", () => switchToTab(2));
+	useHotkey("JUMP_TO_TAB_4", () => switchToTab(3));
+	useHotkey("JUMP_TO_TAB_5", () => switchToTab(4));
+	useHotkey("JUMP_TO_TAB_6", () => switchToTab(5));
+	useHotkey("JUMP_TO_TAB_7", () => switchToTab(6));
+	useHotkey("JUMP_TO_TAB_8", () => switchToTab(7));
+	useHotkey("JUMP_TO_TAB_9", () => switchToTab(8));
+
+	// --- Pane management ---
+
+	useHotkey("PREV_PANE", () => {
+		const state = store.getState();
+		const tab = state.getActiveTab();
+		if (!tab || !tab.activePaneId) return;
+		const paneIds = Object.keys(tab.panes);
+		const index = paneIds.indexOf(tab.activePaneId);
+		const prevIndex = index <= 0 ? paneIds.length - 1 : index - 1;
+		state.setActivePane({ tabId: tab.id, paneId: paneIds[prevIndex] });
+	});
+
+	useHotkey("NEXT_PANE", () => {
+		const state = store.getState();
+		const tab = state.getActiveTab();
+		if (!tab || !tab.activePaneId) return;
+		const paneIds = Object.keys(tab.panes);
+		const index = paneIds.indexOf(tab.activePaneId);
+		const nextIndex = index >= paneIds.length - 1 ? 0 : index + 1;
+		state.setActivePane({ tabId: tab.id, paneId: paneIds[nextIndex] });
+	});
+
+	useHotkey("SPLIT_AUTO", () => {
+		const state = store.getState();
+		const active = state.getActivePane();
+		if (!active) return;
+		state.splitPane({
+			tabId: active.tabId,
+			paneId: active.pane.id,
+			position: "right",
+			newPane: {
+				kind: "terminal",
+				data: { terminalId: crypto.randomUUID() } as TerminalPaneData,
+			},
+		});
+	});
+
+	useHotkey("SPLIT_RIGHT", () => {
+		const state = store.getState();
+		const active = state.getActivePane();
+		if (!active) return;
+		state.splitPane({
+			tabId: active.tabId,
+			paneId: active.pane.id,
+			position: "right",
+			newPane: {
+				kind: "terminal",
+				data: { terminalId: crypto.randomUUID() } as TerminalPaneData,
+			},
+		});
+	});
+
+	useHotkey("SPLIT_DOWN", () => {
+		const state = store.getState();
+		const active = state.getActivePane();
+		if (!active) return;
+		state.splitPane({
+			tabId: active.tabId,
+			paneId: active.pane.id,
+			position: "bottom",
+			newPane: {
+				kind: "terminal",
+				data: { terminalId: crypto.randomUUID() } as TerminalPaneData,
+			},
+		});
+	});
+
+	useHotkey("SPLIT_WITH_CHAT", () => {
+		const state = store.getState();
+		const active = state.getActivePane();
+		if (!active) return;
+		state.splitPane({
+			tabId: active.tabId,
+			paneId: active.pane.id,
+			position: "right",
+			newPane: {
+				kind: "chat",
+				data: { sessionId: null } as ChatPaneData,
+			},
+		});
+	});
+
+	useHotkey("SPLIT_WITH_BROWSER", () => {
+		const state = store.getState();
+		const active = state.getActivePane();
+		if (!active) return;
+		state.splitPane({
+			tabId: active.tabId,
+			paneId: active.pane.id,
+			position: "right",
+			newPane: {
+				kind: "browser",
+				data: {
+					url: "http://localhost:3000",
+					mode: "preview",
+				} as BrowserPaneData,
+			},
+		});
+	});
+
+	useHotkey("EQUALIZE_PANE_SPLITS", () => {
+		const state = store.getState();
+		const tab = state.getActiveTab();
+		if (!tab) return;
+		if (tab.layout.type === "split") {
+			state.equalizeSplit({ tabId: tab.id, splitId: tab.layout.id });
+		}
+	});
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -23,6 +23,7 @@ import { WorkspaceNotFoundState } from "./components/WorkspaceNotFoundState";
 import { WorkspaceSidebar } from "./components/WorkspaceSidebar";
 import { usePaneRegistry } from "./hooks/usePaneRegistry";
 import { useV2WorkspacePaneLayout } from "./hooks/useV2WorkspacePaneLayout";
+import { useWorkspaceHotkeys } from "./hooks/useWorkspaceHotkeys";
 import type {
 	BrowserPaneData,
 	ChatPaneData,
@@ -214,19 +215,9 @@ function WorkspaceContent({
 		[],
 	);
 
-	const collections = useCollections();
 	const sidebarOpen = localWorkspaceState?.rightSidebarOpen ?? false;
-	const toggleSidebar = useCallback(() => {
-		if (!collections.v2WorkspaceLocalState.get(workspaceId)) return;
-		collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
-			draft.rightSidebarOpen = !draft.rightSidebarOpen;
-		});
-	}, [collections, workspaceId]);
 
-	useHotkey("TOGGLE_SIDEBAR", toggleSidebar);
-	useHotkey("NEW_GROUP", addTerminalTab);
-	useHotkey("NEW_CHAT", addChatTab);
-	useHotkey("NEW_BROWSER", addBrowserTab);
+	useWorkspaceHotkeys({ store, workspaceId });
 	useHotkey("QUICK_OPEN", handleQuickOpen);
 
 	return (

--- a/bun.lock
+++ b/bun.lock
@@ -108,6 +108,10 @@
         "typescript": "^5.9.3",
       },
     },
+    "apps/cli": {
+      "name": "cli",
+      "version": "0.0.0",
+    },
     "apps/desktop": {
       "name": "@superset/desktop",
       "version": "1.4.7",
@@ -3137,6 +3141,8 @@
     "clean-stack": ["clean-stack@4.2.0", "", { "dependencies": { "escape-string-regexp": "5.0.0" } }, "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg=="],
 
     "clean-yaml-object": ["clean-yaml-object@0.1.0", "", {}, "sha512-3yONmlN9CSAkzNwnRCiJQ7Q2xK5mWuEfL3PuTZcAUzhObbXsfsnMptJzXwz93nc5zn9V9TwCVMmV7w4xsm43dw=="],
+
+    "cli": ["cli@workspace:apps/cli"],
 
     "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
 


### PR DESCRIPTION
## Summary

- Add `useV2WorkspaceHotkeys` hook with tab management (close, prev/next, jump 1-9), pane management (prev/next, split auto/right/down/chat/browser, equalize), and tab creation (new terminal/chat/browser)
- Add prev/next workspace navigation (⌘⌥↑/↓) to `useDashboardSidebarShortcuts` with cycling (wraps around)
- `OPEN_IN_APP` already handled by shared `OpenInMenuButton` in TopBar

**Not ported (v2 features not built yet):**
- `REOPEN_TAB` — needs tab history tracking
- `RUN_WORKSPACE_COMMAND` — not built for v2
- `COPY_PATH` / `OPEN_PR` — need host service workspace data
- `TOGGLE_EXPAND_SIDEBAR` — v2 sidebar doesn't have expand/collapse modes
- `OPEN_PRESET_1..9` — presets use v1 tab system

## Test plan

- [ ] ⌘T / ⌘⇧T / ⌘⇧B — new terminal/chat/browser tabs
- [ ] ⌘W — close pane, ⌘⇧W — close tab
- [ ] ⌘⌥←/→ — prev/next tab, ctrl+tab/ctrl+shift+tab — alt tab cycling
- [ ] ⌘⌥1-9 — jump to tab by index
- [ ] ⌘⇧←/→ — prev/next pane
- [ ] ⌘D / ⌘⇧D / ⌘E — split right/down/auto
- [ ] ⌘⇧E / ⌘⇧S — split with chat/browser
- [ ] ⌘⇧0 — equalize pane splits
- [ ] ⌘⌥↑/↓ — prev/next workspace (cycles)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired up all v2 workspace hotkeys for full keyboard control of tabs, panes, sidebar, and workspace navigation. Integrated `useWorkspaceHotkeys` in the v2 workspace and added wrap-around prev/next workspace switching via `useDashboardSidebarShortcuts`.

- **New Features**
  - Hook `useWorkspaceHotkeys` for v2 workspaces; adds right sidebar toggle.
  - Tabs: create terminal/chat/browser; close tab/pane; prev/next (incl. alt-tab); jump to 1–9.
  - Panes: prev/next; split auto/right/down or with chat/browser; equalize.
  - Sidebar: prev/next workspace navigation with wrap-around.

- **Refactors**
  - Centralized hotkey wiring into `useWorkspaceHotkeys` and `useDashboardSidebarShortcuts`; removed inline handlers from the v2 workspace page.

<sup>Written for commit f80eb46929c94ae8187830b13108343b30c02012. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workspace navigation hotkeys to jump to previous/next workspace.
  * Added workspace-scoped hotkeys for tab and pane management: create new tabs (terminal/chat/browser), close tabs/panes, switch between tabs, jump to numbered tabs, cycle pane focus, split panes in various orientations, and equalize split layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->