### PR TITLE
feat(desktop): add commit history section to changes sidebar

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/changes/status.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/status.ts
@@ -1,5 +1,9 @@
 import { TRPCError } from "@trpc/server";
-import type { ChangedFile, CommitInfo, GitChangesStatus } from "shared/changes-types";
+import type {
+	ChangedFile,
+	CommitInfo,
+	GitChangesStatus,
+} from "shared/changes-types";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
 import { assertRegisteredWorktree } from "./security/path-validation";

--- a/apps/desktop/src/lib/trpc/routers/changes/status.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/status.ts
@@ -1,5 +1,5 @@
 import { TRPCError } from "@trpc/server";
-import type { ChangedFile, GitChangesStatus } from "shared/changes-types";
+import type { ChangedFile, CommitInfo, GitChangesStatus } from "shared/changes-types";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
 import { assertRegisteredWorktree } from "./security/path-validation";
@@ -98,6 +98,42 @@ export const createStatusRouter = () => {
 						},
 						{
 							dedupeKey: `${input.worktreePath}:${input.commitHash}`,
+							strategy: "coalesce",
+							timeoutMs: 30_000,
+						},
+					);
+				} catch (error) {
+					if (error instanceof Error && error.name === "NotGitRepoError") {
+						throw new TRPCError({
+							code: "BAD_REQUEST",
+							message: error.message,
+						});
+					}
+					throw error;
+				}
+			}),
+
+		getHistory: publicProcedure
+			.input(
+				z.object({
+					worktreePath: z.string(),
+					maxCount: z.number().int().min(1).max(200).default(50),
+					skip: z.number().int().min(0).default(0),
+				}),
+			)
+			.query(async ({ input }): Promise<CommitInfo[]> => {
+				assertRegisteredWorktree(input.worktreePath);
+
+				try {
+					return await runGitTask(
+						"getHistory",
+						{
+							worktreePath: input.worktreePath,
+							maxCount: input.maxCount,
+							skip: input.skip,
+						},
+						{
+							dedupeKey: `${input.worktreePath}:history:${input.skip}:${input.maxCount}`,
 							strategy: "coalesce",
 							timeoutMs: 30_000,
 						},

--- a/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-handlers.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-handlers.ts
@@ -1,6 +1,6 @@
 import { readFile, realpath, stat } from "node:fs/promises";
 import { isAbsolute, relative, resolve, sep } from "node:path";
-import type { ChangedFile, GitChangesStatus } from "shared/changes-types";
+import type { ChangedFile, CommitInfo, GitChangesStatus } from "shared/changes-types";
 import type { SimpleGit, StatusResult } from "simple-git";
 import { getStatusNoLock } from "../../workspaces/utils/git";
 import { getSimpleGitWithShellPath } from "../../workspaces/utils/git-client";
@@ -251,6 +251,28 @@ async function computeCommitFiles({
 	return files;
 }
 
+async function computeHistory({
+	worktreePath,
+	maxCount,
+	skip,
+}: GitTaskPayloadMap["getHistory"]): Promise<CommitInfo[]> {
+	const git = await getSimpleGitWithShellPath(worktreePath);
+
+	try {
+		const logOutput = await git.raw([
+			"log",
+			"HEAD",
+			`--max-count=${maxCount}`,
+			`--skip=${skip}`,
+			"--format=%H|%h|%s|%an|%aI",
+		]);
+		return parseGitLog(logOutput);
+	} catch (error) {
+		logWorkerDebug("failed to compute history", error);
+		return [];
+	}
+}
+
 export async function executeGitTask<TTask extends GitTaskType>(
 	taskType: TTask,
 	payload: GitTaskPayloadMap[TTask],
@@ -263,6 +285,10 @@ export async function executeGitTask<TTask extends GitTaskType>(
 		case "getCommitFiles":
 			return computeCommitFiles(
 				payload as GitTaskPayloadMap["getCommitFiles"],
+			) as Promise<GitTaskResultMap[TTask]>;
+		case "getHistory":
+			return computeHistory(
+				payload as GitTaskPayloadMap["getHistory"],
 			) as Promise<GitTaskResultMap[TTask]>;
 		default: {
 			const exhaustive: never = taskType;

--- a/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-handlers.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-handlers.ts
@@ -1,6 +1,10 @@
 import { readFile, realpath, stat } from "node:fs/promises";
 import { isAbsolute, relative, resolve, sep } from "node:path";
-import type { ChangedFile, CommitInfo, GitChangesStatus } from "shared/changes-types";
+import type {
+	ChangedFile,
+	CommitInfo,
+	GitChangesStatus,
+} from "shared/changes-types";
 import type { SimpleGit, StatusResult } from "simple-git";
 import { getStatusNoLock } from "../../workspaces/utils/git";
 import { getSimpleGitWithShellPath } from "../../workspaces/utils/git-client";

--- a/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-handlers.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-handlers.ts
@@ -273,7 +273,7 @@ async function computeHistory({
 		return parseGitLog(logOutput);
 	} catch (error) {
 		logWorkerDebug("failed to compute history", error);
-		return [];
+		throw error;
 	}
 }
 

--- a/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-types.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-types.ts
@@ -1,4 +1,8 @@
-import type { ChangedFile, CommitInfo, GitChangesStatus } from "shared/changes-types";
+import type {
+	ChangedFile,
+	CommitInfo,
+	GitChangesStatus,
+} from "shared/changes-types";
 
 export interface GitTaskPayloadMap {
 	getStatus: {

--- a/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-types.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-types.ts
@@ -1,4 +1,4 @@
-import type { ChangedFile, GitChangesStatus } from "shared/changes-types";
+import type { ChangedFile, CommitInfo, GitChangesStatus } from "shared/changes-types";
 
 export interface GitTaskPayloadMap {
 	getStatus: {
@@ -9,11 +9,17 @@ export interface GitTaskPayloadMap {
 		worktreePath: string;
 		commitHash: string;
 	};
+	getHistory: {
+		worktreePath: string;
+		maxCount: number;
+		skip: number;
+	};
 }
 
 export interface GitTaskResultMap {
 	getStatus: GitChangesStatus;
 	getCommitFiles: ChangedFile[];
+	getHistory: CommitInfo[];
 }
 
 export type GitTaskType = keyof GitTaskPayloadMap;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
@@ -487,18 +487,6 @@ export function ChangesView({
 		onFileOpen?.(file, "committed", commitHash);
 	};
 
-	const handleHistoryFileSelect = (file: ChangedFile, commitHash: string) => {
-		if (!workspaceId || !worktreePath) return;
-		selectFile(
-			workspaceId,
-			toAbsoluteWorkspacePath(worktreePath, file.path),
-			file,
-			"committed",
-			commitHash,
-		);
-		onFileOpen?.(file, "committed", commitHash);
-	};
-
 	const handleCommitToggle = (hash: string) => {
 		setExpandedCommits((prev) => {
 			const next = new Set(prev);
@@ -822,11 +810,10 @@ export function ChangesView({
 						{worktreePath && workspaceId && (
 							<HistorySection
 								worktreePath={worktreePath}
-								workspaceId={workspaceId}
 								fileListViewMode={fileListViewMode}
 								selectedFile={selectedFile}
 								selectedCommitHash={selectedCommitHash}
-								onCommitFileSelect={handleHistoryFileSelect}
+								onCommitFileSelect={handleCommitFileSelect}
 								projectId={projectId}
 								isExpandedView={isExpandedView}
 								isActive={isActive}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
@@ -25,6 +25,7 @@ import type { ChangeCategory, ChangedFile } from "shared/changes-types";
 import type { FileSystemChangeEvent } from "shared/file-tree-types";
 import { sidebarHeaderTabTriggerClassName } from "../headerTabStyles";
 import { CategorySection } from "./components/CategorySection";
+import { HistorySection } from "./components/HistorySection";
 import { ChangesHeader } from "./components/ChangesHeader";
 import { CommitInput } from "./components/CommitInput";
 import { DiscardConfirmDialog } from "./components/DiscardConfirmDialog";
@@ -486,6 +487,18 @@ export function ChangesView({
 		onFileOpen?.(file, "committed", commitHash);
 	};
 
+	const handleHistoryFileSelect = (file: ChangedFile, commitHash: string) => {
+		if (!workspaceId || !worktreePath) return;
+		selectFile(
+			workspaceId,
+			toAbsoluteWorkspacePath(worktreePath, file.path),
+			file,
+			"committed",
+			commitHash,
+		);
+		onFileOpen?.(file, "committed", commitHash);
+	};
+
 	const handleCommitToggle = (hash: string) => {
 		setExpandedCommits((prev) => {
 			const next = new Set(prev);
@@ -781,33 +794,45 @@ export function ChangesView({
 						/>
 					</div>
 
-					{!hasChanges ? (
-						<div className="flex flex-1 items-center justify-center px-4 text-center text-sm text-muted-foreground">
+					{!hasChanges && (
+						<div className="flex items-center justify-center px-4 py-4 text-center text-sm text-muted-foreground">
 							No changes detected
 						</div>
-					) : (
-						<div
-							className="flex-1 overflow-y-auto"
-							data-changes-scroll-container
-						>
-							{orderedSections
-								.filter((section) => section.count > 0)
-								.map((section) => (
-									<CategorySection
-										key={section.id}
-										id={section.id}
-										title={section.title}
-										count={section.count}
-										isExpanded={section.isExpanded}
-										onToggle={section.onToggle}
-										actions={section.actions}
-										onMove={moveSection}
-									>
-										{section.content}
-									</CategorySection>
-								))}
-						</div>
 					)}
+					<div
+						className="flex-1 overflow-y-auto"
+						data-changes-scroll-container
+					>
+						{orderedSections
+							.filter((section) => section.count > 0)
+							.map((section) => (
+								<CategorySection
+									key={section.id}
+									id={section.id}
+									title={section.title}
+									count={section.count}
+									isExpanded={section.isExpanded}
+									onToggle={section.onToggle}
+									actions={section.actions}
+									onMove={moveSection}
+								>
+									{section.content}
+								</CategorySection>
+							))}
+						{worktreePath && workspaceId && (
+							<HistorySection
+								worktreePath={worktreePath}
+								workspaceId={workspaceId}
+								fileListViewMode={fileListViewMode}
+								selectedFile={selectedFile}
+								selectedCommitHash={selectedCommitHash}
+								onCommitFileSelect={handleHistoryFileSelect}
+								projectId={projectId}
+								isExpandedView={isExpandedView}
+								isActive={isActive}
+							/>
+						)}
+					</div>
 				</TabsContent>
 
 				<TabsContent

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
@@ -30,7 +30,7 @@ import { CommitInput } from "./components/CommitInput";
 import { DiscardConfirmDialog } from "./components/DiscardConfirmDialog";
 import { HistorySection } from "./components/HistorySection";
 import { ReviewPanel } from "./components/ReviewPanel";
-import { useOrderedSections } from "./hooks";
+import { applyCommitFiles, useCommitFiles, useOrderedSections } from "./hooks";
 import { getPRActionState, shouldAutoCreatePRAfterPublish } from "./utils";
 
 interface ChangesViewProps {
@@ -318,6 +318,7 @@ export function ChangesView({
 	const {
 		expandedSections,
 		fileListViewMode,
+		historyExpanded,
 		sectionOrder,
 		selectFile,
 		getSelectedFile,
@@ -435,25 +436,10 @@ export function ChangesView({
 		[isActive, expandedSections.committed, expandedCommits],
 	);
 
-	const commitFilesQueries = electronTrpc.useQueries((t) =>
-		expandedCommitHashes.map((hash) =>
-			t.changes.getCommitFiles({
-				worktreePath: worktreePath || "",
-				commitHash: hash,
-			}),
-		),
+	const commitFilesMap = useCommitFiles(
+		worktreePath ?? "",
+		expandedCommitHashes,
 	);
-
-	const commitFilesMap = useMemo(() => {
-		const map = new Map<string, ChangedFile[]>();
-		expandedCommitHashes.forEach((hash, index) => {
-			const query = commitFilesQueries[index];
-			if (query?.data) {
-				map.set(hash, query.data);
-			}
-		});
-		return map;
-	}, [expandedCommitHashes, commitFilesQueries]);
 
 	const combinedUnstaged = useMemo(
 		() =>
@@ -512,10 +498,7 @@ export function ChangesView({
 		unstagedFiles.length > 0 ||
 		untrackedFiles.length > 0;
 
-	const commitsWithFiles = commits.map((commit) => ({
-		...commit,
-		files: commitFilesMap.get(commit.hash) || commit.files,
-	}));
+	const commitsWithFiles = applyCommitFiles(commits, commitFilesMap);
 
 	useEffect(() => {
 		if (!workspaceId || !worktreePath || !selectedFileState) {
@@ -782,7 +765,7 @@ export function ChangesView({
 						/>
 					</div>
 
-					{!hasChanges && (
+					{!hasChanges && !historyExpanded && (
 						<div className="flex items-center justify-center px-4 py-4 text-center text-sm text-muted-foreground">
 							No changes detected
 						</div>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
@@ -25,10 +25,10 @@ import type { ChangeCategory, ChangedFile } from "shared/changes-types";
 import type { FileSystemChangeEvent } from "shared/file-tree-types";
 import { sidebarHeaderTabTriggerClassName } from "../headerTabStyles";
 import { CategorySection } from "./components/CategorySection";
-import { HistorySection } from "./components/HistorySection";
 import { ChangesHeader } from "./components/ChangesHeader";
 import { CommitInput } from "./components/CommitInput";
 import { DiscardConfirmDialog } from "./components/DiscardConfirmDialog";
+import { HistorySection } from "./components/HistorySection";
 import { ReviewPanel } from "./components/ReviewPanel";
 import { useOrderedSections } from "./hooks";
 import { getPRActionState, shouldAutoCreatePRAfterPublish } from "./utils";
@@ -787,10 +787,7 @@ export function ChangesView({
 							No changes detected
 						</div>
 					)}
-					<div
-						className="flex-1 overflow-y-auto"
-						data-changes-scroll-container
-					>
+					<div className="flex-1 overflow-y-auto" data-changes-scroll-container>
 						{orderedSections
 							.filter((section) => section.count > 0)
 							.map((section) => (

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/CommitListVirtualized/CommitListVirtualized.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/CommitListVirtualized/CommitListVirtualized.tsx
@@ -54,6 +54,7 @@ export function CommitListVirtualized({
 
 	const lastItem = items.at(-1);
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: lastItem is a new object ref each render; only lastItem.index matters
 	useEffect(() => {
 		if (
 			lastItem &&
@@ -63,7 +64,7 @@ export function CommitListVirtualized({
 		) {
 			onLoadMore();
 		}
-	}, [lastItem?.index, commits.length, hasMore, onLoadMore, lastItem]);
+	}, [lastItem?.index, commits.length, hasMore, onLoadMore]);
 
 	return (
 		<div ref={listRef}>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/CommitListVirtualized/CommitListVirtualized.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/CommitListVirtualized/CommitListVirtualized.tsx
@@ -63,7 +63,7 @@ export function CommitListVirtualized({
 		) {
 			onLoadMore();
 		}
-	}, [lastItem?.index, commits.length, hasMore, onLoadMore]);
+	}, [lastItem?.index, commits.length, hasMore, onLoadMore, lastItem]);
 
 	return (
 		<div ref={listRef}>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/CommitListVirtualized/CommitListVirtualized.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/CommitListVirtualized/CommitListVirtualized.tsx
@@ -1,11 +1,12 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import type { ChangedFile, CommitInfo } from "shared/changes-types";
 import type { ChangesViewMode } from "../../types";
 import { CommitItem } from "../CommitItem";
 
 const ESTIMATED_ROW_HEIGHT = 28;
 const OVERSCAN = 10;
+const LOAD_MORE_THRESHOLD = 10;
 
 interface CommitListVirtualizedProps {
 	commits: CommitInfo[];
@@ -18,6 +19,8 @@ interface CommitListVirtualizedProps {
 	worktreePath: string;
 	projectId?: string;
 	isExpandedView?: boolean;
+	onLoadMore?: () => void;
+	hasMore?: boolean;
 }
 
 export function CommitListVirtualized({
@@ -31,6 +34,8 @@ export function CommitListVirtualized({
 	worktreePath,
 	projectId,
 	isExpandedView,
+	onLoadMore,
+	hasMore,
 }: CommitListVirtualizedProps) {
 	const listRef = useRef<HTMLDivElement>(null);
 
@@ -46,6 +51,19 @@ export function CommitListVirtualized({
 	});
 
 	const items = virtualizer.getVirtualItems();
+
+	const lastItem = items.at(-1);
+
+	useEffect(() => {
+		if (
+			lastItem &&
+			lastItem.index >= commits.length - LOAD_MORE_THRESHOLD &&
+			hasMore &&
+			onLoadMore
+		) {
+			onLoadMore();
+		}
+	}, [lastItem?.index, commits.length, hasMore, onLoadMore]);
 
 	return (
 		<div ref={listRef}>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/HistorySection/HistorySection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/HistorySection/HistorySection.tsx
@@ -1,0 +1,206 @@
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "@superset/ui/collapsible";
+import { cn } from "@superset/ui/utils";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useChangesStore } from "renderer/stores/changes";
+import type { ChangedFile, CommitInfo } from "shared/changes-types";
+import { VscChevronRight } from "react-icons/vsc";
+import { CommitListVirtualized } from "../CommitListVirtualized";
+import type { ChangesViewMode } from "../../types";
+
+const PAGE_SIZE = 50;
+
+interface HistorySectionProps {
+	worktreePath: string;
+	workspaceId: string;
+	fileListViewMode: ChangesViewMode;
+	selectedFile: ChangedFile | null;
+	selectedCommitHash: string | null;
+	onCommitFileSelect: (file: ChangedFile, commitHash: string) => void;
+	projectId?: string;
+	isExpandedView?: boolean;
+	isActive: boolean;
+}
+
+export function HistorySection({
+	worktreePath,
+	workspaceId,
+	fileListViewMode,
+	selectedFile,
+	selectedCommitHash,
+	onCommitFileSelect,
+	projectId,
+	isExpandedView,
+	isActive,
+}: HistorySectionProps) {
+	const { historyExpanded, toggleHistory } = useChangesStore();
+	const [pages, setPages] = useState<CommitInfo[][]>([]);
+	const [nextSkip, setNextSkip] = useState(0);
+	const [hasMore, setHasMore] = useState(true);
+	const isFetchingRef = useRef(false);
+	const [expandedCommits, setExpandedCommits] = useState<Set<string>>(
+		new Set(),
+	);
+
+	// Reset when worktree changes
+	// biome-ignore lint/correctness/useExhaustiveDependencies: reset on workspace change
+	useEffect(() => {
+		setPages([]);
+		setNextSkip(0);
+		setHasMore(true);
+		setExpandedCommits(new Set());
+	}, [worktreePath]);
+
+	// First page query — only runs when section is expanded
+	const { data: firstPage, isLoading } =
+		electronTrpc.changes.getHistory.useQuery(
+			{ worktreePath, maxCount: PAGE_SIZE, skip: 0 },
+			{ enabled: !!worktreePath && historyExpanded && isActive },
+		);
+
+	// Store first page when it arrives
+	useEffect(() => {
+		if (firstPage) {
+			setPages([firstPage]);
+			setHasMore(firstPage.length >= PAGE_SIZE);
+			setNextSkip(firstPage.length);
+			isFetchingRef.current = false;
+		}
+	}, [firstPage]);
+
+	// Subsequent page query — enabled only when isFetchingRef is true and nextSkip > 0
+	const [fetchSkip, setFetchSkip] = useState<number | null>(null);
+	const { data: nextPage } = electronTrpc.changes.getHistory.useQuery(
+		{ worktreePath, maxCount: PAGE_SIZE, skip: fetchSkip ?? 0 },
+		{
+			enabled:
+				!!worktreePath &&
+				historyExpanded &&
+				isActive &&
+				fetchSkip !== null &&
+				fetchSkip > 0,
+		},
+	);
+
+	// Append next page when it arrives
+	useEffect(() => {
+		if (nextPage && fetchSkip !== null) {
+			setPages((prev) => [...prev, nextPage]);
+			setHasMore(nextPage.length >= PAGE_SIZE);
+			setNextSkip((prev) => prev + nextPage.length);
+			setFetchSkip(null);
+			isFetchingRef.current = false;
+		}
+	}, [nextPage, fetchSkip]);
+
+	const allCommits = useMemo(() => pages.flat(), [pages]);
+
+	const handleLoadMore = useCallback(() => {
+		if (isFetchingRef.current || !hasMore) return;
+		isFetchingRef.current = true;
+		setFetchSkip(nextSkip);
+	}, [hasMore, nextSkip]);
+
+	const handleCommitToggle = (hash: string) => {
+		setExpandedCommits((prev) => {
+			const next = new Set(prev);
+			if (next.has(hash)) {
+				next.delete(hash);
+			} else {
+				next.add(hash);
+			}
+			return next;
+		});
+	};
+
+	// Fetch files for expanded commits (reuse existing getCommitFiles)
+	const expandedCommitHashes = useMemo(
+		() =>
+			isActive && historyExpanded
+				? Array.from(expandedCommits)
+				: ([] as string[]),
+		[isActive, historyExpanded, expandedCommits],
+	);
+
+	const commitFilesQueries = electronTrpc.useQueries((t) =>
+		expandedCommitHashes.map((hash) =>
+			t.changes.getCommitFiles({
+				worktreePath,
+				commitHash: hash,
+			}),
+		),
+	);
+
+	const commitsWithFiles = useMemo(() => {
+		const filesMap = new Map<string, ChangedFile[]>();
+		expandedCommitHashes.forEach((hash, index) => {
+			const query = commitFilesQueries[index];
+			if (query?.data) {
+				filesMap.set(hash, query.data);
+			}
+		});
+		return allCommits.map((commit) => ({
+			...commit,
+			files: filesMap.get(commit.hash) || commit.files,
+		}));
+	}, [allCommits, expandedCommitHashes, commitFilesQueries]);
+
+	const totalCount = allCommits.length;
+
+	return (
+		<Collapsible open={historyExpanded} onOpenChange={toggleHistory}>
+			<div className="group flex items-center min-w-0">
+				<CollapsibleTrigger
+					className={cn(
+						"flex-1 flex items-center gap-1.5 px-2 py-1.5 text-left min-w-0",
+						"hover:bg-accent/30 cursor-pointer transition-colors",
+					)}
+				>
+					<VscChevronRight
+						className={cn(
+							"size-3 text-muted-foreground shrink-0 transition-transform duration-150",
+							historyExpanded && "rotate-90",
+						)}
+					/>
+					<span className="text-xs font-medium truncate">History</span>
+					{totalCount > 0 && (
+						<span className="text-[10px] text-muted-foreground shrink-0">
+							{totalCount}{hasMore ? "+" : ""}
+						</span>
+					)}
+				</CollapsibleTrigger>
+			</div>
+
+			<CollapsibleContent className="px-0.5 pb-1 min-w-0 overflow-hidden">
+				{isLoading ? (
+					<div className="flex items-center justify-center py-2 text-xs text-muted-foreground">
+						Loading history...
+					</div>
+				) : totalCount === 0 ? (
+					<div className="flex items-center justify-center py-2 text-xs text-muted-foreground">
+						No commits found
+					</div>
+				) : (
+					<CommitListVirtualized
+						commits={commitsWithFiles}
+						expandedCommits={expandedCommits}
+						onCommitToggle={handleCommitToggle}
+						selectedFile={selectedFile}
+						selectedCommitHash={selectedCommitHash}
+						onFileSelect={onCommitFileSelect}
+						viewMode={fileListViewMode}
+						worktreePath={worktreePath}
+						projectId={projectId}
+						isExpandedView={isExpandedView}
+						onLoadMore={handleLoadMore}
+						hasMore={hasMore}
+					/>
+				)}
+			</CollapsibleContent>
+		</Collapsible>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/HistorySection/HistorySection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/HistorySection/HistorySection.tsx
@@ -9,6 +9,7 @@ import { VscChevronRight } from "react-icons/vsc";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useChangesStore } from "renderer/stores/changes";
 import type { ChangedFile, CommitInfo } from "shared/changes-types";
+import { applyCommitFiles, useCommitFiles } from "../../hooks";
 import type { ChangesViewMode } from "../../types";
 import { CommitListVirtualized } from "../CommitListVirtualized";
 
@@ -40,7 +41,7 @@ export function HistorySection({
 	const [nextSkip, setNextSkip] = useState(0);
 	const [hasMore, setHasMore] = useState(true);
 	const isFetchingRef = useRef(false);
-	const lastAppendedPageRef = useRef<CommitInfo[] | null>(null);
+	const lastAppendedSkipRef = useRef<number | null>(null);
 	const [expandedCommits, setExpandedCommits] = useState<Set<string>>(
 		new Set(),
 	);
@@ -52,15 +53,18 @@ export function HistorySection({
 		setNextSkip(0);
 		setHasMore(true);
 		setExpandedCommits(new Set());
-		lastAppendedPageRef.current = null;
+		lastAppendedSkipRef.current = null;
 	}, [worktreePath]);
 
 	// First page query — only runs when section is expanded
-	const { data: firstPage, isLoading } =
-		electronTrpc.changes.getHistory.useQuery(
-			{ worktreePath, maxCount: PAGE_SIZE, skip: 0 },
-			{ enabled: !!worktreePath && historyExpanded && isActive },
-		);
+	const {
+		data: firstPage,
+		isLoading,
+		isError,
+	} = electronTrpc.changes.getHistory.useQuery(
+		{ worktreePath, maxCount: PAGE_SIZE, skip: 0 },
+		{ enabled: !!worktreePath && historyExpanded && isActive },
+	);
 
 	// Store first page when it arrives
 	useEffect(() => {
@@ -86,14 +90,14 @@ export function HistorySection({
 		},
 	);
 
-	// Append next page when it arrives (guard against stale data)
+	// Append next page when it arrives (guard against duplicate appends by tracking skip value)
 	useEffect(() => {
 		if (
 			nextPage &&
 			fetchSkip !== null &&
-			nextPage !== lastAppendedPageRef.current
+			fetchSkip !== lastAppendedSkipRef.current
 		) {
-			lastAppendedPageRef.current = nextPage;
+			lastAppendedSkipRef.current = fetchSkip;
 			setPages((prev) => [...prev, nextPage]);
 			setHasMore(nextPage.length >= PAGE_SIZE);
 			setNextSkip((prev) => prev + nextPage.length);
@@ -110,7 +114,7 @@ export function HistorySection({
 		setFetchSkip(nextSkip);
 	}, [hasMore, nextSkip]);
 
-	const handleCommitToggle = (hash: string) => {
+	const handleCommitToggle = useCallback((hash: string) => {
 		setExpandedCommits((prev) => {
 			const next = new Set(prev);
 			if (next.has(hash)) {
@@ -120,9 +124,8 @@ export function HistorySection({
 			}
 			return next;
 		});
-	};
+	}, []);
 
-	// Fetch files for expanded commits (reuse existing getCommitFiles)
 	const expandedCommitHashes = useMemo(
 		() =>
 			isActive && historyExpanded
@@ -131,28 +134,8 @@ export function HistorySection({
 		[isActive, historyExpanded, expandedCommits],
 	);
 
-	const commitFilesQueries = electronTrpc.useQueries((t) =>
-		expandedCommitHashes.map((hash) =>
-			t.changes.getCommitFiles({
-				worktreePath,
-				commitHash: hash,
-			}),
-		),
-	);
-
-	const commitsWithFiles = useMemo(() => {
-		const filesMap = new Map<string, ChangedFile[]>();
-		expandedCommitHashes.forEach((hash, index) => {
-			const query = commitFilesQueries[index];
-			if (query?.data) {
-				filesMap.set(hash, query.data);
-			}
-		});
-		return allCommits.map((commit) => ({
-			...commit,
-			files: filesMap.get(commit.hash) || commit.files,
-		}));
-	}, [allCommits, expandedCommitHashes, commitFilesQueries]);
+	const commitFilesMap = useCommitFiles(worktreePath, expandedCommitHashes);
+	const commitsWithFiles = applyCommitFiles(allCommits, commitFilesMap);
 
 	const totalCount = allCommits.length;
 
@@ -182,7 +165,11 @@ export function HistorySection({
 			</div>
 
 			<CollapsibleContent className="px-0.5 pb-1 min-w-0 overflow-hidden">
-				{isLoading ? (
+				{isError ? (
+					<div className="flex items-center justify-center py-2 text-xs text-destructive">
+						Failed to load history
+					</div>
+				) : isLoading ? (
 					<div className="flex items-center justify-center py-2 text-xs text-muted-foreground">
 						Loading history...
 					</div>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/HistorySection/HistorySection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/HistorySection/HistorySection.tsx
@@ -16,7 +16,6 @@ const PAGE_SIZE = 50;
 
 interface HistorySectionProps {
 	worktreePath: string;
-	workspaceId: string;
 	fileListViewMode: ChangesViewMode;
 	selectedFile: ChangedFile | null;
 	selectedCommitHash: string | null;
@@ -28,7 +27,6 @@ interface HistorySectionProps {
 
 export function HistorySection({
 	worktreePath,
-	workspaceId,
 	fileListViewMode,
 	selectedFile,
 	selectedCommitHash,
@@ -42,6 +40,7 @@ export function HistorySection({
 	const [nextSkip, setNextSkip] = useState(0);
 	const [hasMore, setHasMore] = useState(true);
 	const isFetchingRef = useRef(false);
+	const lastAppendedPageRef = useRef<CommitInfo[] | null>(null);
 	const [expandedCommits, setExpandedCommits] = useState<Set<string>>(
 		new Set(),
 	);
@@ -53,6 +52,7 @@ export function HistorySection({
 		setNextSkip(0);
 		setHasMore(true);
 		setExpandedCommits(new Set());
+		lastAppendedPageRef.current = null;
 	}, [worktreePath]);
 
 	// First page query — only runs when section is expanded
@@ -86,9 +86,10 @@ export function HistorySection({
 		},
 	);
 
-	// Append next page when it arrives
+	// Append next page when it arrives (guard against stale data)
 	useEffect(() => {
-		if (nextPage && fetchSkip !== null) {
+		if (nextPage && fetchSkip !== null && nextPage !== lastAppendedPageRef.current) {
+			lastAppendedPageRef.current = nextPage;
 			setPages((prev) => [...prev, nextPage]);
 			setHasMore(nextPage.length >= PAGE_SIZE);
 			setNextSkip((prev) => prev + nextPage.length);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/HistorySection/HistorySection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/HistorySection/HistorySection.tsx
@@ -40,20 +40,23 @@ export function HistorySection({
 	const [pages, setPages] = useState<CommitInfo[][]>([]);
 	const [nextSkip, setNextSkip] = useState(0);
 	const [hasMore, setHasMore] = useState(true);
+	const [fetchSkip, setFetchSkip] = useState<number | null>(null);
 	const isFetchingRef = useRef(false);
 	const lastAppendedSkipRef = useRef<number | null>(null);
 	const [expandedCommits, setExpandedCommits] = useState<Set<string>>(
 		new Set(),
 	);
 
-	// Reset when worktree changes
+	// Reset all state when worktree changes
 	// biome-ignore lint/correctness/useExhaustiveDependencies: reset on workspace change
 	useEffect(() => {
 		setPages([]);
 		setNextSkip(0);
 		setHasMore(true);
 		setExpandedCommits(new Set());
+		setFetchSkip(null);
 		lastAppendedSkipRef.current = null;
+		isFetchingRef.current = false;
 	}, [worktreePath]);
 
 	// First page query — only runs when section is expanded
@@ -76,19 +79,19 @@ export function HistorySection({
 		}
 	}, [firstPage]);
 
-	// Subsequent page query — enabled only when isFetchingRef is true and nextSkip > 0
-	const [fetchSkip, setFetchSkip] = useState<number | null>(null);
-	const { data: nextPage } = electronTrpc.changes.getHistory.useQuery(
-		{ worktreePath, maxCount: PAGE_SIZE, skip: fetchSkip ?? 0 },
-		{
-			enabled:
-				!!worktreePath &&
-				historyExpanded &&
-				isActive &&
-				fetchSkip !== null &&
-				fetchSkip > 0,
-		},
-	);
+	// Subsequent page query — enabled only when fetchSkip is set
+	const { data: nextPage, isError: isNextPageError } =
+		electronTrpc.changes.getHistory.useQuery(
+			{ worktreePath, maxCount: PAGE_SIZE, skip: fetchSkip ?? 0 },
+			{
+				enabled:
+					!!worktreePath &&
+					historyExpanded &&
+					isActive &&
+					fetchSkip !== null &&
+					fetchSkip > 0,
+			},
+		);
 
 	// Append next page when it arrives (guard against duplicate appends by tracking skip value)
 	useEffect(() => {
@@ -105,6 +108,14 @@ export function HistorySection({
 			isFetchingRef.current = false;
 		}
 	}, [nextPage, fetchSkip]);
+
+	// Clear fetch lock on paginated query error so infinite scroll can retry
+	useEffect(() => {
+		if (isNextPageError && fetchSkip !== null) {
+			setFetchSkip(null);
+			isFetchingRef.current = false;
+		}
+	}, [isNextPageError, fetchSkip]);
 
 	const allCommits = useMemo(() => pages.flat(), [pages]);
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/HistorySection/HistorySection.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/HistorySection/HistorySection.tsx
@@ -5,12 +5,12 @@ import {
 } from "@superset/ui/collapsible";
 import { cn } from "@superset/ui/utils";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { VscChevronRight } from "react-icons/vsc";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useChangesStore } from "renderer/stores/changes";
 import type { ChangedFile, CommitInfo } from "shared/changes-types";
-import { VscChevronRight } from "react-icons/vsc";
-import { CommitListVirtualized } from "../CommitListVirtualized";
 import type { ChangesViewMode } from "../../types";
+import { CommitListVirtualized } from "../CommitListVirtualized";
 
 const PAGE_SIZE = 50;
 
@@ -88,7 +88,11 @@ export function HistorySection({
 
 	// Append next page when it arrives (guard against stale data)
 	useEffect(() => {
-		if (nextPage && fetchSkip !== null && nextPage !== lastAppendedPageRef.current) {
+		if (
+			nextPage &&
+			fetchSkip !== null &&
+			nextPage !== lastAppendedPageRef.current
+		) {
 			lastAppendedPageRef.current = nextPage;
 			setPages((prev) => [...prev, nextPage]);
 			setHasMore(nextPage.length >= PAGE_SIZE);
@@ -170,7 +174,8 @@ export function HistorySection({
 					<span className="text-xs font-medium truncate">History</span>
 					{totalCount > 0 && (
 						<span className="text-[10px] text-muted-foreground shrink-0">
-							{totalCount}{hasMore ? "+" : ""}
+							{totalCount}
+							{hasMore ? "+" : ""}
 						</span>
 					)}
 				</CollapsibleTrigger>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/HistorySection/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/components/HistorySection/index.ts
@@ -1,0 +1,1 @@
+export { HistorySection } from "./HistorySection";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/hooks/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/hooks/index.ts
@@ -1,3 +1,4 @@
+export { applyCommitFiles, useCommitFiles } from "./useCommitFiles";
 export { useFileDrag } from "./useFileDrag";
 export { useOrderedSections } from "./useOrderedSections";
 export { usePathActions } from "./usePathActions";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/hooks/useCommitFiles.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/hooks/useCommitFiles.ts
@@ -1,0 +1,42 @@
+import { useMemo } from "react";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import type { ChangedFile, CommitInfo } from "shared/changes-types";
+
+/**
+ * Fetches file lists for expanded commits via batched queries.
+ * Shared between the "Commits" section and the "History" section.
+ */
+export function useCommitFiles(
+	worktreePath: string,
+	expandedHashes: string[],
+): Map<string, ChangedFile[]> {
+	const queries = electronTrpc.useQueries((t) =>
+		expandedHashes.map((hash) =>
+			t.changes.getCommitFiles({
+				worktreePath: worktreePath || "",
+				commitHash: hash,
+			}),
+		),
+	);
+
+	return useMemo(() => {
+		const map = new Map<string, ChangedFile[]>();
+		expandedHashes.forEach((hash, index) => {
+			const query = queries[index];
+			if (query?.data) {
+				map.set(hash, query.data);
+			}
+		});
+		return map;
+	}, [expandedHashes, queries]);
+}
+
+export function applyCommitFiles(
+	commits: CommitInfo[],
+	filesMap: Map<string, ChangedFile[]>,
+): CommitInfo[] {
+	return commits.map((commit) => ({
+		...commit,
+		files: filesMap.get(commit.hash) || commit.files,
+	}));
+}

--- a/apps/desktop/src/renderer/stores/changes/store.ts
+++ b/apps/desktop/src/renderer/stores/changes/store.ts
@@ -34,6 +34,7 @@ interface ChangesState {
 	showRenderedMarkdown: Record<string, boolean>;
 	hideUnchangedRegions: boolean;
 	focusMode: boolean;
+	historyExpanded: boolean;
 
 	selectFile: (
 		workspaceId: string,
@@ -60,6 +61,7 @@ interface ChangesState {
 	getShowRenderedMarkdown: (worktreePath: string) => boolean;
 	toggleHideUnchangedRegions: () => void;
 	toggleFocusMode: () => void;
+	toggleHistory: () => void;
 	reset: (workspaceId: string) => void;
 }
 
@@ -78,6 +80,7 @@ const initialState = {
 	showRenderedMarkdown: {} as Record<string, boolean>,
 	hideUnchangedRegions: false,
 	focusMode: false,
+	historyExpanded: false,
 };
 
 export const useChangesStore = create<ChangesState>()(
@@ -219,6 +222,10 @@ export const useChangesStore = create<ChangesState>()(
 					set({ focusMode: !get().focusMode });
 				},
 
+				toggleHistory: () => {
+					set({ historyExpanded: !get().historyExpanded });
+				},
+
 				reset: (workspaceId) => {
 					const { selectedFiles } = get();
 					set({
@@ -231,7 +238,7 @@ export const useChangesStore = create<ChangesState>()(
 			}),
 			{
 				name: "changes-store",
-				version: 5,
+				version: 6,
 				migrate: (persisted, version) => {
 					const state = persisted as Record<string, unknown>;
 					if (version < 2) {
@@ -245,6 +252,9 @@ export const useChangesStore = create<ChangesState>()(
 					}
 					if (version < 5) {
 						state.activeTab = "diffs";
+					}
+					if (version < 6) {
+						state.historyExpanded = false;
 					}
 					state.sectionOrder = normalizeChangeSectionOrder(
 						state.sectionOrder as ChangeCategory[] | undefined,
@@ -261,6 +271,7 @@ export const useChangesStore = create<ChangesState>()(
 					showRenderedMarkdown: state.showRenderedMarkdown,
 					hideUnchangedRegions: state.hideUnchangedRegions,
 					focusMode: state.focusMode,
+					historyExpanded: state.historyExpanded,
 				}),
 			},
 		),


### PR DESCRIPTION
## Summary

- Add "History" collapsible section to the Changes sidebar showing full `git log` with infinite scroll
- Works on any branch including main (where previously no commit history was visible)
- Reuses existing CommitItem/CommitListVirtualized components and "committed" diff path
- History section is always pinned to the bottom, does not participate in drag-reorder
- Extract shared `useCommitFiles` hook to deduplicate commit file fetching

## Test plan

- [ ] On main branch: expand History — full commit log loads
- [ ] On feature branch: existing sections (Against main, Commits, Staged, Unstaged) work as before, History shows all commits
- [ ] Scroll to bottom of History — more commits load automatically (infinite scroll)
- [ ] Click a commit in History — files expand, click a file — diff viewer shows changes
- [ ] Switch workspaces — History resets and reloads
- [ ] Collapse/expand History — state persists across sessions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a collapsible History section to the Changes sidebar that shows the full commit log with infinite scroll and per-commit file diffs. Works on any branch, is pinned at the bottom, remembers its state, and includes safer pagination with proper error handling.

- New Features
  - History section with paginated commit log and infinite scroll.
  - Expand a commit to view files; selecting a file opens its diff (reuses existing Commit UI).
  - Pinned to the bottom and excluded from drag-reorder; state persists across sessions.
  - Added `getHistory` tRPC procedure and git worker task with `maxCount`/`skip` pagination.

- Refactors
  - Extracted `useCommitFiles` and `applyCommitFiles`; added `historyExpanded` to the changes store with migration v6.
  - Improved virtualized list pagination: load-more with race/duplicate guards, proper loading/error states, error propagation to UI, and fetch-state resets on workspace change or errors to enable safe retries.

<sup>Written for commit 3f50d259ed5b67ee7fd6634d15a522e7ccce7ac9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collapsible History section in the Changes view with paginated commit history and incremental "load more" as you scroll.
  * View file changes for specific commits within history; files load when commits are expanded.
  * History expanded/collapsed state is persisted across sessions.

* **Stability**
  * Improved error handling and retry behavior when fetching history pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->