### PR TITLE
feat(desktop): add vertical tab placement option in Appearance settings

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/settings/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/index.ts
@@ -7,6 +7,7 @@ import {
 	FILE_OPEN_MODES,
 	NON_EDITOR_APPS,
 	settings,
+	TAB_PLACEMENTS,
 	TERMINAL_LINK_BEHAVIORS,
 	type TerminalPreset,
 } from "@superset/local-db";
@@ -27,6 +28,7 @@ import {
 	DEFAULT_OPEN_LINKS_IN_APP,
 	DEFAULT_SHOW_PRESETS_BAR,
 	DEFAULT_SHOW_RESOURCE_MONITOR,
+	DEFAULT_TAB_PLACEMENT,
 	DEFAULT_TERMINAL_LINK_BEHAVIOR,
 	DEFAULT_USE_COMPACT_TERMINAL_ADD_BUTTON,
 } from "shared/constants";
@@ -668,6 +670,26 @@ export const createSettingsRouter = () => {
 					.onConflictDoUpdate({
 						target: settings.id,
 						set: { fileOpenMode: input.mode },
+					})
+					.run();
+
+				return { success: true };
+			}),
+
+		getTabPlacement: publicProcedure.query(() => {
+			const row = getSettings();
+			return row.tabPlacement ?? DEFAULT_TAB_PLACEMENT;
+		}),
+
+		setTabPlacement: publicProcedure
+			.input(z.object({ placement: z.enum(TAB_PLACEMENTS) }))
+			.mutation(({ input }) => {
+				localDb
+					.insert(settings)
+					.values({ id: 1, tabPlacement: input.placement })
+					.onConflictDoUpdate({
+						target: settings.id,
+						set: { tabPlacement: input.placement },
 					})
 					.run();
 

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/AppearanceSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/AppearanceSettings.tsx
@@ -6,6 +6,7 @@ import {
 } from "../../../utils/settings-search";
 import { FontSettingSection } from "./components/FontSettingSection";
 import { MarkdownStyleSection } from "./components/MarkdownStyleSection";
+import { TabPlacementSection } from "./components/TabPlacementSection";
 import { ThemeSection } from "./components/ThemeSection";
 
 /**
@@ -55,6 +56,10 @@ export function AppearanceSettings({ visibleItems }: AppearanceSettingsProps) {
 		visibleItems,
 	);
 	const showThemeSection = showTheme || showCustomThemes;
+	const showTabPlacement = isItemVisible(
+		SETTING_ITEM_ID.APPEARANCE_TAB_PLACEMENT,
+		visibleItems,
+	);
 
 	return (
 		<div className="p-6 max-w-4xl w-full">
@@ -67,6 +72,7 @@ export function AppearanceSettings({ visibleItems }: AppearanceSettingsProps) {
 
 			<SectionList>
 				{showThemeSection && <ThemeSection key="theme" />}
+				{showTabPlacement && <TabPlacementSection key="tab-placement" />}
 				{showMarkdown && <MarkdownStyleSection key="markdown" />}
 				{showEditorFont && (
 					<FontSettingSection key="editor-font" variant="editor" />

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/TabPlacementSection/TabPlacementSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/TabPlacementSection/TabPlacementSection.tsx
@@ -1,0 +1,55 @@
+import type { TabPlacement } from "@superset/local-db";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@superset/ui/select";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { DEFAULT_TAB_PLACEMENT } from "shared/constants";
+
+export function TabPlacementSection() {
+	const utils = electronTrpc.useUtils();
+	const { data: tabPlacement } =
+		electronTrpc.settings.getTabPlacement.useQuery();
+	const setTabPlacement = electronTrpc.settings.setTabPlacement.useMutation({
+		onMutate: async ({ placement }) => {
+			await utils.settings.getTabPlacement.cancel();
+			const previous = utils.settings.getTabPlacement.getData();
+			utils.settings.getTabPlacement.setData(undefined, placement);
+			return { previous };
+		},
+		onError: (_err, _vars, context) => {
+			if (context?.previous !== undefined) {
+				utils.settings.getTabPlacement.setData(undefined, context.previous);
+			}
+		},
+		onSettled: () => {
+			utils.settings.getTabPlacement.invalidate();
+		},
+	});
+
+	return (
+		<div>
+			<h3 className="text-sm font-medium mb-2">Tab Placement</h3>
+			<p className="text-sm text-muted-foreground mb-4">
+				Position of the tab bar within the workspace content area
+			</p>
+			<Select
+				value={tabPlacement ?? DEFAULT_TAB_PLACEMENT}
+				onValueChange={(value) =>
+					setTabPlacement.mutate({ placement: value as TabPlacement })
+				}
+			>
+				<SelectTrigger className="w-[200px]">
+					<SelectValue />
+				</SelectTrigger>
+				<SelectContent>
+					<SelectItem value="horizontal">Horizontal (top)</SelectItem>
+					<SelectItem value="vertical">Vertical (left)</SelectItem>
+				</SelectContent>
+			</Select>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/TabPlacementSection/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/TabPlacementSection/index.ts
@@ -1,0 +1,1 @@
+export { TabPlacementSection } from "./TabPlacementSection";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -15,6 +15,7 @@ export const SETTING_ITEM_ID = {
 	APPEARANCE_THEME: "appearance-theme",
 	APPEARANCE_MARKDOWN: "appearance-markdown",
 	APPEARANCE_CUSTOM_THEMES: "appearance-custom-themes",
+	APPEARANCE_TAB_PLACEMENT: "appearance-tab-placement",
 	APPEARANCE_EDITOR_FONT: "appearance-editor-font",
 	APPEARANCE_TERMINAL_FONT: "appearance-terminal-font",
 
@@ -300,6 +301,24 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"typography",
 			"custom",
 			"nerd",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.APPEARANCE_TAB_PLACEMENT,
+		section: "appearance",
+		title: "Tab Placement",
+		description:
+			"Position tabs horizontally across the top or vertically on the left",
+		keywords: [
+			"appearance",
+			"tab",
+			"placement",
+			"position",
+			"horizontal",
+			"vertical",
+			"sidebar",
+			"layout",
+			"orientation",
 		],
 	},
 	{

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupItem.tsx
@@ -45,6 +45,7 @@ interface GroupItemProps {
 	index: number;
 	isActive: boolean;
 	status: PaneStatus | null;
+	orientation?: "horizontal" | "vertical";
 	onSelect: () => void;
 	onClose: () => void;
 	onRename: (newName: string) => void;
@@ -58,6 +59,7 @@ export function GroupItem({
 	index,
 	isActive,
 	status,
+	orientation = "horizontal",
 	onSelect,
 	onClose,
 	onRename,
@@ -65,6 +67,7 @@ export function GroupItem({
 	onPaneDrop,
 	onReorder,
 }: GroupItemProps) {
+	const isVertical = orientation === "vertical";
 	const displayName = getTabDisplayName(tab);
 	const [isEditing, setIsEditing] = useState(false);
 	const [editValue, setEditValue] = useState("");
@@ -186,7 +189,8 @@ export function GroupItem({
 	);
 
 	const tabStyles = cn(
-		"flex items-center gap-2 transition-all w-full shrink-0 pl-3 pr-8 h-full",
+		"flex items-center gap-2 transition-all w-full shrink-0 pl-3 pr-8",
+		isVertical ? "py-1.5" : "h-full",
 		isActive
 			? "text-foreground bg-border/30"
 			: "text-muted-foreground/70 hover:text-muted-foreground hover:bg-tertiary/20",
@@ -213,7 +217,10 @@ export function GroupItem({
 						drag(drop(node));
 					}}
 					className={cn(
-						"group relative flex items-center shrink-0 h-full border-r border-border",
+						"group relative flex items-center shrink-0",
+						isVertical
+							? "w-full border-b border-border"
+							: "h-full border-r border-border",
 						isOver && canDrop && "bg-primary/5",
 						isDragging && "opacity-50 text-muted-foreground/50",
 					)}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupStrip.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/GroupStrip.tsx
@@ -30,7 +30,12 @@ import { GroupItem } from "./GroupItem";
 
 const NO_WORKSPACE_MATCH = "__no_workspace__";
 
-export function GroupStrip() {
+interface GroupStripProps {
+	orientation?: "horizontal" | "vertical";
+}
+
+export function GroupStrip({ orientation = "horizontal" }: GroupStripProps) {
+	const isVertical = orientation === "vertical";
 	const { workspaceId: activeWorkspaceId } = useParams({ strict: false });
 
 	const allTabs = useTabsStore((s) => s.tabs);
@@ -287,8 +292,12 @@ export function GroupStrip() {
 		const container = scrollContainerRef.current;
 		const track = tabsTrackRef.current;
 		if (!container || !track) return;
-		setHasHorizontalOverflow(track.scrollWidth > container.clientWidth + 1);
-	}, []);
+		if (isVertical) {
+			setHasHorizontalOverflow(track.scrollHeight > container.clientHeight + 1);
+		} else {
+			setHasHorizontalOverflow(track.scrollWidth > container.clientWidth + 1);
+		}
+	}, [isVertical]);
 
 	useLayoutEffect(() => {
 		const container = scrollContainerRef.current;
@@ -319,6 +328,7 @@ export function GroupStrip() {
 			useCompactAddButton={useCompactAddButton}
 			showPresetsBar={showPresetsBar ?? DEFAULT_SHOW_PRESETS_BAR}
 			presets={presets}
+			orientation={orientation}
 			onDropToNewTab={movePaneToNewTab}
 			isLastPaneInTab={checkIsLastPaneInTab}
 			onAddTerminal={handleAddGroup}
@@ -336,27 +346,49 @@ export function GroupStrip() {
 	);
 
 	return (
-		<div className="flex h-10 min-w-0 flex-1 items-stretch">
+		<div
+			className={
+				isVertical
+					? "flex flex-col w-full min-h-0 flex-1"
+					: "flex h-10 min-w-0 flex-1 items-stretch"
+			}
+		>
 			<div
 				ref={scrollContainerRef}
-				className="flex min-w-0 flex-1 items-stretch overflow-x-auto overflow-y-hidden"
+				className={
+					isVertical
+						? "flex flex-col min-h-0 flex-1 overflow-y-auto overflow-x-hidden"
+						: "flex min-w-0 flex-1 items-stretch overflow-x-auto overflow-y-hidden"
+				}
 				style={{ scrollbarWidth: "none" }}
 			>
-				<div ref={tabsTrackRef} className="flex items-stretch">
+				<div
+					ref={tabsTrackRef}
+					className={isVertical ? "flex flex-col" : "flex items-stretch"}
+				>
 					{tabs.length > 0 && (
-						<div className="flex items-stretch h-full shrink-0">
+						<div
+							className={
+								isVertical
+									? "flex flex-col w-full shrink-0"
+									: "flex items-stretch h-full shrink-0"
+							}
+						>
 							{tabs.map((tab, index) => {
 								return (
 									<div
 										key={tab.id}
-										className="h-full shrink-0"
-										style={{ width: "160px" }}
+										className={
+											isVertical ? "w-full shrink-0" : "h-full shrink-0"
+										}
+										style={isVertical ? undefined : { width: "160px" }}
 									>
 										<GroupItem
 											tab={tab}
 											index={index}
 											isActive={tab.id === activeTabId}
 											status={tabStatusMap.get(tab.id) ?? null}
+											orientation={orientation}
 											onSelect={() => handleSelectGroup(tab.id)}
 											onClose={() => handleCloseGroup(tab.id)}
 											onRename={(newName) => handleRenameGroup(tab.id, newName)}
@@ -371,9 +403,13 @@ export function GroupStrip() {
 					)}
 					{hasHorizontalOverflow ? (
 						<div
-							className={`h-full shrink-0 ${
-								!useCompactAddButton ? "w-[220px]" : "w-10"
-							}`}
+							className={
+								isVertical
+									? "w-full shrink-0 h-10"
+									: `h-full shrink-0 ${
+											!useCompactAddButton ? "w-[220px]" : "w-10"
+										}`
+							}
 						/>
 					) : (
 						<div className="shrink-0">{plusControl}</div>
@@ -381,7 +417,15 @@ export function GroupStrip() {
 				</div>
 			</div>
 			{hasHorizontalOverflow && (
-				<div className="shrink-0 bg-background/95 pr-1">{plusControl}</div>
+				<div
+					className={
+						isVertical
+							? "shrink-0 bg-background/95 pb-1 flex justify-center"
+							: "shrink-0 bg-background/95 pr-1"
+					}
+				>
+					{plusControl}
+				</div>
 			)}
 		</div>
 	);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/NewTabDropZone.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/NewTabDropZone.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@superset/ui/utils";
 import type { ReactNode } from "react";
 import { useDrop } from "react-dnd";
 import { MosaicDragType } from "react-mosaic-component";
@@ -6,14 +7,17 @@ import { useDragPaneStore } from "renderer/stores/drag-pane-store";
 interface NewTabDropZoneProps {
 	onDrop: (paneId: string) => void;
 	isLastPaneInTab: (paneId: string) => boolean;
+	orientation?: "horizontal" | "vertical";
 	children: ReactNode;
 }
 
 export function NewTabDropZone({
 	onDrop,
 	isLastPaneInTab,
+	orientation = "horizontal",
 	children,
 }: NewTabDropZoneProps) {
+	const isVertical = orientation === "vertical";
 	const [{ isOver, canDrop }, drop] = useDrop<
 		unknown,
 		{ handled: true },
@@ -47,10 +51,18 @@ export function NewTabDropZone({
 			ref={(node) => {
 				drop(node);
 			}}
-			className="relative flex items-center h-full shrink-0 pl-2"
+			className={cn(
+				"relative flex items-center shrink-0 pl-2",
+				isVertical ? "w-full pt-2" : "h-full",
+			)}
 		>
 			{isOver && canDrop && (
-				<div className="absolute left-0 top-0 bottom-0 w-1 bg-primary/20" />
+				<div
+					className={cn(
+						"absolute left-0 top-0 bg-primary/20",
+						isVertical ? "right-0 h-1" : "bottom-0 w-1",
+					)}
+				/>
 			)}
 			{children}
 		</div>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/components/AddTabButton/AddTabButton.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/GroupStrip/components/AddTabButton/AddTabButton.tsx
@@ -20,6 +20,7 @@ interface AddTabButtonProps {
 	useCompactAddButton: boolean;
 	showPresetsBar: boolean;
 	presets: TerminalPreset[];
+	orientation?: "horizontal" | "vertical";
 	onDropToNewTab: (paneId: string) => void;
 	isLastPaneInTab: (paneId: string) => boolean;
 	onAddTerminal: () => void;
@@ -35,6 +36,7 @@ export function AddTabButton({
 	useCompactAddButton,
 	showPresetsBar,
 	presets,
+	orientation = "horizontal",
 	onDropToNewTab,
 	isLastPaneInTab,
 	onAddTerminal,
@@ -45,11 +47,17 @@ export function AddTabButton({
 	onToggleShowPresetsBar,
 	onToggleCompactAddButton,
 }: AddTabButtonProps) {
-	const showBigAddButton = !useCompactAddButton;
+	// In vertical mode, always use compact button since the expanded row doesn't fit
+	const showBigAddButton =
+		orientation === "vertical" ? false : !useCompactAddButton;
 	const showPresetsInDropdown = !showPresetsBar;
 
 	return (
-		<NewTabDropZone onDrop={onDropToNewTab} isLastPaneInTab={isLastPaneInTab}>
+		<NewTabDropZone
+			onDrop={onDropToNewTab}
+			isLastPaneInTab={isLastPaneInTab}
+			orientation={orientation}
+		>
 			<DropdownMenu>
 				<div className="flex items-center shrink-0">
 					{showBigAddButton ? (
@@ -138,15 +146,17 @@ export function AddTabButton({
 					>
 						Show Preset Bar
 					</DropdownMenuCheckboxItem>
-					<DropdownMenuCheckboxItem
-						checked={useCompactAddButton}
-						onCheckedChange={(checked) =>
-							onToggleCompactAddButton(checked === true)
-						}
-						onSelect={(e) => e.preventDefault()}
-					>
-						Use Compact Button
-					</DropdownMenuCheckboxItem>
+					{orientation !== "vertical" && (
+						<DropdownMenuCheckboxItem
+							checked={useCompactAddButton}
+							onCheckedChange={(checked) =>
+								onToggleCompactAddButton(checked === true)
+							}
+							onSelect={(e) => e.preventDefault()}
+						>
+							Use Compact Button
+						</DropdownMenuCheckboxItem>
+					)}
 				</DropdownMenuContent>
 			</DropdownMenu>
 		</NewTabDropZone>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/index.tsx
@@ -27,9 +27,11 @@ export function ContentView({
 	const isSidebarOpen = useSidebarStore((s) => s.isSidebarOpen);
 	const { data: showPresetsBar } =
 		electronTrpc.settings.getShowPresetsBar.useQuery();
-	const { data: tabPlacement } =
+	const { data: tabPlacement, isLoading: isTabPlacementLoading } =
 		electronTrpc.settings.getTabPlacement.useQuery();
 	const isVertical = (tabPlacement ?? DEFAULT_TAB_PLACEMENT) === "vertical";
+
+	if (isTabPlacementLoading) return null;
 
 	if (isVertical) {
 		return (

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/index.tsx
@@ -1,6 +1,12 @@
 import type { ExternalApp } from "@superset/local-db";
+import {
+	ResizableHandle,
+	ResizablePanel,
+	ResizablePanelGroup,
+} from "@superset/ui/resizable";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useSidebarStore } from "renderer/stores/sidebar-state";
+import { DEFAULT_TAB_PLACEMENT } from "shared/constants";
 import { SidebarControl } from "../../SidebarControl";
 import { ContentHeader } from "./ContentHeader";
 import { PresetsBar } from "./components/PresetsBar";
@@ -21,6 +27,43 @@ export function ContentView({
 	const isSidebarOpen = useSidebarStore((s) => s.isSidebarOpen);
 	const { data: showPresetsBar } =
 		electronTrpc.settings.getShowPresetsBar.useQuery();
+	const { data: tabPlacement } =
+		electronTrpc.settings.getTabPlacement.useQuery();
+	const isVertical = (tabPlacement ?? DEFAULT_TAB_PLACEMENT) === "vertical";
+
+	if (isVertical) {
+		return (
+			<ResizablePanelGroup
+				direction="horizontal"
+				className="h-full overflow-hidden"
+			>
+				<ResizablePanel
+					defaultSize={15}
+					minSize={10}
+					maxSize={30}
+					className="flex flex-col border-r bg-background overflow-hidden"
+				>
+					{!isSidebarOpen && (
+						<div className="flex items-center justify-end h-10 px-2 shrink-0 border-b">
+							<SidebarControl />
+						</div>
+					)}
+					<GroupStrip orientation="vertical" />
+				</ResizablePanel>
+				<ResizableHandle />
+				<ResizablePanel defaultSize={85} className="overflow-hidden">
+					<div className="h-full flex flex-col overflow-hidden">
+						{showPresetsBar && <PresetsBar />}
+						<TabsContent
+							defaultExternalApp={defaultExternalApp}
+							onOpenInApp={onOpenInApp}
+							onOpenQuickOpen={onOpenQuickOpen}
+						/>
+					</div>
+				</ResizablePanel>
+			</ResizablePanelGroup>
+		);
+	}
 
 	return (
 		<div className="h-full flex flex-col overflow-hidden">

--- a/apps/desktop/src/shared/constants.ts
+++ b/apps/desktop/src/shared/constants.ts
@@ -50,6 +50,7 @@ export const DEFAULT_USE_COMPACT_TERMINAL_ADD_BUTTON = true;
 export const DEFAULT_TELEMETRY_ENABLED = true;
 export const DEFAULT_SHOW_RESOURCE_MONITOR = true;
 export const DEFAULT_OPEN_LINKS_IN_APP = false;
+export const DEFAULT_TAB_PLACEMENT = "horizontal" as const;
 
 // External links (documentation, help resources, etc.)
 export const EXTERNAL_LINKS = {

--- a/packages/local-db/drizzle/0039_add_tab_placement_setting.sql
+++ b/packages/local-db/drizzle/0039_add_tab_placement_setting.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `settings` ADD `tab_placement` text;

--- a/packages/local-db/drizzle/meta/0039_snapshot.json
+++ b/packages/local-db/drizzle/meta/0039_snapshot.json
@@ -1,0 +1,1404 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f710d195-fa69-402c-803f-fc3ba1099e56",
+  "prevId": "1cf43ce9-9e0f-44c4-b4cf-5cafe80bf78d",
+  "tables": {
+    "browser_history": {
+      "name": "browser_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_visited_at": {
+          "name": "last_visited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visit_count": {
+          "name": "visit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "browser_history_url_unique": {
+          "name": "browser_history_url_unique",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "browser_history_url_idx": {
+          "name": "browser_history_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": false
+        },
+        "browser_history_last_visited_at_idx": {
+          "name": "browser_history_last_visited_at_idx",
+          "columns": [
+            "last_visited_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_organization_id_idx": {
+          "name": "organization_members_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_user_id_idx": {
+          "name": "organization_members_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_users_id_fk": {
+          "name": "organization_members_user_id_users_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_org": {
+          "name": "github_org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_clerk_org_id_unique": {
+          "name": "organizations_clerk_org_id_unique",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_idx": {
+          "name": "organizations_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "organizations_clerk_org_id_idx": {
+          "name": "organizations_clerk_org_id_idx",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "main_repo_path": {
+          "name": "main_repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_toast_dismissed": {
+          "name": "config_toast_dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_base_branch": {
+          "name": "workspace_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_owner": {
+          "name": "github_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hide_image": {
+          "name": "hide_image",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_project_id": {
+          "name": "neon_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_app": {
+          "name": "default_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_main_repo_path_idx": {
+          "name": "projects_main_repo_path_idx",
+          "columns": [
+            "main_repo_path"
+          ],
+          "isUnique": false
+        },
+        "projects_last_opened_at_idx": {
+          "name": "projects_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_active_workspace_id": {
+          "name": "last_active_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets": {
+          "name": "terminal_presets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets_initialized": {
+          "name": "terminal_presets_initialized",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_preset_overrides": {
+          "name": "agent_preset_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_custom_definitions": {
+          "name": "agent_custom_definitions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_ringtone_id": {
+          "name": "selected_ringtone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirm_on_quit": {
+          "name": "confirm_on_quit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_link_behavior": {
+          "name": "terminal_link_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "persist_terminal": {
+          "name": "persist_terminal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_apply_default_preset": {
+          "name": "auto_apply_default_preset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_sounds_muted": {
+          "name": "notification_sounds_muted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_volume": {
+          "name": "notification_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delete_local_branch": {
+          "name": "delete_local_branch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_open_mode": {
+          "name": "file_open_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_presets_bar": {
+          "name": "show_presets_bar",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_compact_terminal_add_button": {
+          "name": "use_compact_terminal_add_button",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_family": {
+          "name": "terminal_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_size": {
+          "name": "terminal_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_family": {
+          "name": "editor_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_size": {
+          "name": "editor_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_resource_monitor": {
+          "name": "show_resource_monitor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "open_links_in_app": {
+          "name": "open_links_in_app",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_editor": {
+          "name": "default_editor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tab_placement": {
+          "name": "tab_placement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_color": {
+          "name": "status_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_type": {
+          "name": "status_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_position": {
+          "name": "status_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "estimate": {
+          "name": "estimate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_provider": {
+          "name": "external_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tasks_slug_unique": {
+          "name": "tasks_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "tasks_slug_idx": {
+          "name": "tasks_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "tasks_organization_id_idx": {
+          "name": "tasks_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_assignee_id_idx": {
+          "name": "tasks_assignee_id_idx",
+          "columns": [
+            "assignee_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_status_idx": {
+          "name": "tasks_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "tasks_created_at_idx": {
+          "name": "tasks_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_organization_id_organizations_id_fk": {
+          "name": "tasks_organization_id_organizations_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_assignee_id_users_id_fk": {
+          "name": "tasks_assignee_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tasks_creator_id_users_id_fk": {
+          "name": "tasks_creator_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": true
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "users_clerk_id_idx": {
+          "name": "users_clerk_id_idx",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_sections": {
+      "name": "workspace_sections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_collapsed": {
+          "name": "is_collapsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspace_sections_project_id_idx": {
+          "name": "workspace_sections_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_sections_project_id_projects_id_fk": {
+          "name": "workspace_sections_project_id_projects_id_fk",
+          "tableFrom": "workspace_sections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_id": {
+          "name": "worktree_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_unread": {
+          "name": "is_unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_unnamed": {
+          "name": "is_unnamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "deleting_at": {
+          "name": "deleting_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "port_base": {
+          "name": "port_base",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_project_id_idx": {
+          "name": "workspaces_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_worktree_id_idx": {
+          "name": "workspaces_worktree_id_idx",
+          "columns": [
+            "worktree_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_last_opened_at_idx": {
+          "name": "workspaces_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        },
+        "workspaces_section_id_idx": {
+          "name": "workspaces_section_id_idx",
+          "columns": [
+            "section_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspaces_project_id_projects_id_fk": {
+          "name": "workspaces_project_id_projects_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_worktree_id_worktrees_id_fk": {
+          "name": "workspaces_worktree_id_worktrees_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "worktrees",
+          "columnsFrom": [
+            "worktree_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_section_id_workspace_sections_id_fk": {
+          "name": "workspaces_section_id_workspace_sections_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "workspace_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "worktrees": {
+      "name": "worktrees",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_status": {
+          "name": "git_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_status": {
+          "name": "github_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_superset": {
+          "name": "created_by_superset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "worktrees_project_id_idx": {
+          "name": "worktrees_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "worktrees_branch_idx": {
+          "name": "worktrees_branch_idx",
+          "columns": [
+            "branch"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "worktrees_project_id_projects_id_fk": {
+          "name": "worktrees_project_id_projects_id_fk",
+          "tableFrom": "worktrees",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/local-db/drizzle/meta/_journal.json
+++ b/packages/local-db/drizzle/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1774995017185,
       "tag": "0038_quick_star_brand",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "6",
+      "when": 1775426374468,
+      "tag": "0039_add_tab_placement_setting",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/local-db/src/schema/schema.ts
+++ b/packages/local-db/src/schema/schema.ts
@@ -9,6 +9,7 @@ import type {
 	FileOpenMode,
 	GitHubStatus,
 	GitStatus,
+	TabPlacement,
 	TerminalLinkBehavior,
 	TerminalPreset,
 	WorkspaceType,
@@ -222,6 +223,7 @@ export const settings = sqliteTable("settings", {
 	worktreeBaseDir: text("worktree_base_dir"),
 	openLinksInApp: integer("open_links_in_app", { mode: "boolean" }),
 	defaultEditor: text("default_editor").$type<ExternalApp>(),
+	tabPlacement: text("tab_placement").$type<TabPlacement>(),
 });
 
 export type InsertSettings = typeof settings.$inferInsert;

--- a/packages/local-db/src/schema/zod.ts
+++ b/packages/local-db/src/schema/zod.ts
@@ -248,3 +248,7 @@ export type BranchPrefixMode = (typeof BRANCH_PREFIX_MODES)[number];
 export const FILE_OPEN_MODES = ["split-pane", "new-tab"] as const;
 
 export type FileOpenMode = (typeof FILE_OPEN_MODES)[number];
+
+export const TAB_PLACEMENTS = ["horizontal", "vertical"] as const;
+
+export type TabPlacement = (typeof TAB_PLACEMENTS)[number];


### PR DESCRIPTION
## Description

Add a new "Tab Placement" setting under Appearance that lets users switch the tab bar between horizontal (top, default) and vertical (left sidebar).

**Database & backend:**
- Add `TabPlacement` type ("horizontal" | "vertical") and `tabPlacement` column to the local-db settings table
- Add `getTabPlacement` / `setTabPlacement` tRPC procedures
- Generate migration 0039_add_tab_placement_setting

**Settings UI:**
- New `TabPlacementSection` component with a Select dropdown
- Registered in AppearanceSettings and settings search index

**Layout changes:**
- `ContentView` switches between the existing horizontal layout and a new vertical layout using `ResizablePanelGroup` (resizable sidebar column, default 15%, min 10%, max 30%)
- `GroupStrip`, `GroupItem`, `NewTabDropZone`, and `AddTabButton` accept an `orientation` prop to adapt flex direction, overflow, borders, and padding for vertical mode
- Vertical tabs use compact `py-1.5` padding instead of the full 40px horizontal row height
- "Use Compact Button" option hidden in vertical mode since it's always forced compact

## Related Issues

Fixes https://github.com/superset-sh/superset/issues/3191

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

1. Default opens in Horizontal mode as before.
2. Did full tests back and forth switching between tab placement modes including restart. 

## Screenshots (if applicable)

<img width="4064" height="2321" alt="image" src="https://github.com/user-attachments/assets/26b03de1-435c-47d0-ae79-e5b0c508f5db" />

Tab placement setting:
<img width="857" height="655" alt="image" src="https://github.com/user-attachments/assets/9f496dad-4c51-469d-a8a9-760762b0ab7e" />





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Tab Placement setting in Appearance to switch the tab bar between horizontal (top, default) and vertical (left sidebar) with a resizable sidebar. Also prevents a brief layout flash for vertical tabs on load.

- **New Features**
  - Stores `TabPlacement` in `@superset/local-db` (`tab_placement`, "horizontal" | "vertical"); adds tRPC `getTabPlacement`/`setTabPlacement`.
  - New Tab Placement section in Appearance with a Select (`@superset/ui/select`) and settings search entry.
  - Vertical layout uses `@superset/ui/resizable` with a left panel (default 15%, min 10%, max 30%).
  - Tabs (`GroupStrip`, `GroupItem`, `NewTabDropZone`, `AddTabButton`) accept an `orientation` prop; vertical mode uses compact padding and hides “Use Compact Button”.
  - Migration `0039_add_tab_placement_setting` runs automatically; default stays horizontal.

- **Bug Fixes**
  - Prevent layout flash by waiting for `getTabPlacement` before rendering `ContentView`.

<sup>Written for commit ddbcb2456714fa60e67a9d4052dd710c5f3d3343. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tab placement setting added to Appearance: choose horizontal (default) or vertical tabs; preference is persisted.
  * Workspace adapts to vertical tab layout with updated tab strip, add-tab controls, and drop targets.

* **Chores**
  * Database and schema updated to store tab placement preference.

* **UX**
  * Appearance settings search and visibility updated to include the new Tab Placement option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->