### PR TITLE
feat(desktop): pane context menus + binary tree layout

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -98,6 +98,30 @@ class TerminalRuntimeRegistryImpl {
 		this.entries.delete(terminalId);
 	}
 
+	getSelection(terminalId: string): string {
+		const entry = this.entries.get(terminalId);
+		return entry?.runtime?.terminal.getSelection() ?? "";
+	}
+
+	clear(terminalId: string): void {
+		const entry = this.entries.get(terminalId);
+		entry?.runtime?.terminal.clear();
+	}
+
+	scrollToBottom(terminalId: string): void {
+		const entry = this.entries.get(terminalId);
+		entry?.runtime?.terminal.scrollToBottom();
+	}
+
+	paste(terminalId: string, text: string): void {
+		const entry = this.entries.get(terminalId);
+		entry?.runtime?.terminal.paste(text);
+	}
+
+	getTerminal(terminalId: string) {
+		return this.entries.get(terminalId)?.runtime?.terminal ?? null;
+	}
+
 	getAllTerminalIds(): Set<string> {
 		return new Set(this.entries.keys());
 	}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useDefaultContextMenuActions/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useDefaultContextMenuActions/index.ts
@@ -1,0 +1,1 @@
+export { useDefaultContextMenuActions } from "./useDefaultContextMenuActions";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useDefaultContextMenuActions/useDefaultContextMenuActions.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useDefaultContextMenuActions/useDefaultContextMenuActions.tsx
@@ -1,0 +1,160 @@
+import type { ContextMenuActionConfig, RendererContext } from "@superset/panes";
+import { useMemo } from "react";
+import {
+	LuColumns2,
+	LuEqual,
+	LuGlobe,
+	LuMessageSquare,
+	LuMoveRight,
+	LuPlus,
+	LuRows2,
+	LuX,
+} from "react-icons/lu";
+import { useHotkeyDisplay } from "renderer/hotkeys";
+import type {
+	BrowserPaneData,
+	ChatPaneData,
+	PaneViewerData,
+	TerminalPaneData,
+} from "../../types";
+
+export function useDefaultContextMenuActions(): ContextMenuActionConfig<PaneViewerData>[] {
+	const splitDownShortcut = useHotkeyDisplay("SPLIT_DOWN").text;
+	const splitRightShortcut = useHotkeyDisplay("SPLIT_RIGHT").text;
+	const splitWithChatShortcut = useHotkeyDisplay("SPLIT_WITH_CHAT").text;
+	const splitWithBrowserShortcut = useHotkeyDisplay("SPLIT_WITH_BROWSER").text;
+	const equalizePaneSplitsShortcut = useHotkeyDisplay(
+		"EQUALIZE_PANE_SPLITS",
+	).text;
+	const closePaneShortcut = useHotkeyDisplay("CLOSE_TERMINAL").text;
+
+	return useMemo<ContextMenuActionConfig<PaneViewerData>[]>(
+		() => [
+			{
+				key: "split-horizontal",
+				label: "Split Horizontally",
+				icon: <LuRows2 />,
+				shortcut:
+					splitDownShortcut !== "Unassigned" ? splitDownShortcut : undefined,
+				onSelect: (ctx) => {
+					ctx.actions.split("down", {
+						kind: "terminal",
+						data: {
+							terminalId: crypto.randomUUID(),
+						} as TerminalPaneData,
+					});
+				},
+			},
+			{
+				key: "split-vertical",
+				label: "Split Vertically",
+				icon: <LuColumns2 />,
+				shortcut:
+					splitRightShortcut !== "Unassigned" ? splitRightShortcut : undefined,
+				onSelect: (ctx) => {
+					ctx.actions.split("right", {
+						kind: "terminal",
+						data: {
+							terminalId: crypto.randomUUID(),
+						} as TerminalPaneData,
+					});
+				},
+			},
+			{
+				key: "split-with-chat",
+				label: "Split with New Chat",
+				icon: <LuMessageSquare />,
+				shortcut:
+					splitWithChatShortcut !== "Unassigned"
+						? splitWithChatShortcut
+						: undefined,
+				onSelect: (ctx) => {
+					ctx.actions.split("right", {
+						kind: "chat",
+						data: { sessionId: null } as ChatPaneData,
+					});
+				},
+			},
+			{
+				key: "split-with-browser",
+				label: "Split with New Browser",
+				icon: <LuGlobe />,
+				shortcut:
+					splitWithBrowserShortcut !== "Unassigned"
+						? splitWithBrowserShortcut
+						: undefined,
+				onSelect: (ctx) => {
+					ctx.actions.split("right", {
+						kind: "browser",
+						data: {
+							url: "http://localhost:3000",
+							mode: "preview",
+						} as BrowserPaneData,
+					});
+				},
+			},
+			{
+				key: "equalize-splits",
+				label: "Equalize Pane Splits",
+				icon: <LuEqual />,
+				shortcut:
+					equalizePaneSplitsShortcut !== "Unassigned"
+						? equalizePaneSplitsShortcut
+						: undefined,
+				onSelect: (ctx) => {
+					ctx.store.getState().equalizeTab({ tabId: ctx.tab.id });
+				},
+			},
+			{ key: "sep-move", type: "separator" },
+			{
+				key: "move-to-tab",
+				label: "Move to Tab",
+				icon: <LuMoveRight />,
+				children: (ctx: RendererContext<PaneViewerData>) => {
+					const tabs = ctx.store.getState().tabs;
+					const otherTabs = tabs.filter((t) => t.id !== ctx.tab.id);
+					const items: ContextMenuActionConfig<PaneViewerData>[] =
+						otherTabs.map((tab) => ({
+							key: `move-to-${tab.id}`,
+							label: tab.titleOverride ?? tab.id,
+							onSelect: () => {
+								ctx.store
+									.getState()
+									.movePaneToTab({ paneId: ctx.pane.id, targetTabId: tab.id });
+							},
+						}));
+					if (otherTabs.length > 0) {
+						items.push({ key: "sep-new-tab", type: "separator" });
+					}
+					items.push({
+						key: "move-to-new-tab",
+						label: "New Tab",
+						icon: <LuPlus />,
+						onSelect: () => {
+							ctx.store.getState().movePaneToNewTab({ paneId: ctx.pane.id });
+						},
+					});
+					return items;
+				},
+			},
+			{ key: "sep-close", type: "separator" },
+			{
+				key: "close-pane",
+				label: "Close Pane",
+				icon: <LuX />,
+				variant: "destructive",
+				shortcut:
+					closePaneShortcut !== "Unassigned" ? closePaneShortcut : undefined,
+				onSelect: (ctx) => ctx.actions.close(),
+			},
+		],
+		[
+			splitDownShortcut,
+			splitRightShortcut,
+			splitWithChatShortcut,
+			splitWithBrowserShortcut,
+			equalizePaneSplitsShortcut,
+			closePaneShortcut,
+		],
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -86,10 +86,11 @@ export function TerminalPane({ ctx, workspaceId }: TerminalPaneProps) {
 		terminalRuntimeRegistry.scrollToBottom(terminalId);
 	});
 
+	// connectionState in deps ensures terminal ref re-derives after connect/disconnect
+	// biome-ignore lint/correctness/useExhaustiveDependencies: connectionState is intentionally included to trigger re-derive
 	const terminal = useMemo(
 		() => terminalRuntimeRegistry.getTerminal(terminalId),
-		// biome-ignore lint/correctness/useExhaustiveDependencies: connectionState triggers re-derive after attach
-		[terminalId],
+		[terminalId, connectionState],
 	);
 
 	return (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -1,6 +1,7 @@
 import type { RendererContext } from "@superset/panes";
 import "@xterm/xterm/css/xterm.css";
-import { useEffect, useRef, useSyncExternalStore } from "react";
+import { useEffect, useMemo, useRef, useSyncExternalStore } from "react";
+import { useHotkey } from "renderer/hotkeys";
 import {
 	type ConnectionState,
 	terminalRuntimeRegistry,
@@ -10,6 +11,7 @@ import type {
 	TerminalPaneData,
 } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
 import { useWorkspaceWsUrl } from "renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceTrpcProvider/WorkspaceTrpcProvider";
+import { ScrollToBottomButton } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/ScrollToBottomButton";
 import { useTheme } from "renderer/stores/theme";
 import { resolveTerminalThemeType } from "renderer/stores/theme/utils";
 import { useTerminalAppearance } from "./hooks/useTerminalAppearance";
@@ -76,13 +78,30 @@ export function TerminalPane({ ctx, workspaceId }: TerminalPaneProps) {
 		terminalRuntimeRegistry.updateAppearance(terminalId, appearance);
 	}, [terminalId, appearance]);
 
+	useHotkey("CLEAR_TERMINAL", () => {
+		terminalRuntimeRegistry.clear(terminalId);
+	});
+
+	useHotkey("SCROLL_TO_BOTTOM", () => {
+		terminalRuntimeRegistry.scrollToBottom(terminalId);
+	});
+
+	const terminal = useMemo(
+		() => terminalRuntimeRegistry.getTerminal(terminalId),
+		// biome-ignore lint/correctness/useExhaustiveDependencies: connectionState triggers re-derive after attach
+		[terminalId],
+	);
+
 	return (
 		<div className="flex h-full w-full flex-col p-2">
-			<div
-				ref={containerRef}
-				className="min-h-0 flex-1 overflow-hidden"
-				style={{ backgroundColor: appearance.background }}
-			/>
+			<div className="relative min-h-0 flex-1 overflow-hidden">
+				<div
+					ref={containerRef}
+					className="h-full w-full"
+					style={{ backgroundColor: appearance.background }}
+				/>
+				<ScrollToBottomButton terminal={terminal} />
+			</div>
 			{connectionState === "closed" && (
 				<div className="flex items-center gap-2 border-t border-border px-3 py-1.5 text-xs text-muted-foreground">
 					<span>Disconnected</span>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -1,7 +1,19 @@
-import type { PaneRegistry, RendererContext } from "@superset/panes";
+import type {
+	ContextMenuActionConfig,
+	PaneRegistry,
+	RendererContext,
+} from "@superset/panes";
 import { alert } from "@superset/ui/atoms/Alert";
 import { Circle, Globe, MessageSquare, TerminalSquare } from "lucide-react";
 import { useMemo } from "react";
+import {
+	LuArrowDownToLine,
+	LuClipboard,
+	LuClipboardCopy,
+	LuEraser,
+} from "react-icons/lu";
+import { useHotkeyDisplay } from "renderer/hotkeys";
+import { terminalRuntimeRegistry } from "renderer/lib/terminal/terminal-runtime-registry";
 import { FileIcon } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils";
 import type {
 	BrowserPaneData,
@@ -9,6 +21,7 @@ import type {
 	DevtoolsPaneData,
 	FilePaneData,
 	PaneViewerData,
+	TerminalPaneData,
 } from "../../types";
 import { ChatPane } from "./components/ChatPane";
 import { FilePane } from "./components/FilePane";
@@ -18,9 +31,16 @@ function getFileName(filePath: string): string {
 	return filePath.split("/").pop() ?? filePath;
 }
 
+const MOD_KEY = navigator.platform.toLowerCase().includes("mac")
+	? "⌘"
+	: "Ctrl+";
+
 export function usePaneRegistry(
 	workspaceId: string,
 ): PaneRegistry<PaneViewerData> {
+	const clearShortcut = useHotkeyDisplay("CLEAR_TERMINAL").text;
+	const scrollToBottomShortcut = useHotkeyDisplay("SCROLL_TO_BOTTOM").text;
+
 	return useMemo<PaneRegistry<PaneViewerData>>(
 		() => ({
 			file: {
@@ -78,6 +98,10 @@ export function usePaneRegistry(
 						});
 					});
 				},
+				contextMenuActions: (_ctx, defaults) =>
+					defaults.map((d) =>
+						d.key === "close-pane" ? { ...d, label: "Close File" } : d,
+					),
 			},
 			terminal: {
 				getIcon: () => <TerminalSquare className="size-4" />,
@@ -85,6 +109,73 @@ export function usePaneRegistry(
 				renderPane: (ctx: RendererContext<PaneViewerData>) => (
 					<TerminalPane ctx={ctx} workspaceId={workspaceId} />
 				),
+				contextMenuActions: (_ctx, defaults) => {
+					const terminalActions: ContextMenuActionConfig<PaneViewerData>[] = [
+						{
+							key: "copy",
+							label: "Copy",
+							icon: <LuClipboardCopy />,
+							shortcut: `${MOD_KEY}C`,
+							disabled: (ctx) => {
+								const { terminalId } = ctx.pane.data as TerminalPaneData;
+								return !terminalRuntimeRegistry.getSelection(terminalId);
+							},
+							onSelect: (ctx) => {
+								const { terminalId } = ctx.pane.data as TerminalPaneData;
+								const text = terminalRuntimeRegistry.getSelection(terminalId);
+								if (text) navigator.clipboard.writeText(text);
+							},
+						},
+						{
+							key: "paste",
+							label: "Paste",
+							icon: <LuClipboard />,
+							shortcut: `${MOD_KEY}V`,
+							onSelect: async (ctx) => {
+								const { terminalId } = ctx.pane.data as TerminalPaneData;
+								try {
+									const text = await navigator.clipboard.readText();
+									if (text) terminalRuntimeRegistry.paste(terminalId, text);
+								} catch {
+									// Clipboard access denied
+								}
+							},
+						},
+						{ key: "sep-terminal-clipboard", type: "separator" },
+						{
+							key: "clear-terminal",
+							label: "Clear Terminal",
+							icon: <LuEraser />,
+							shortcut:
+								clearShortcut !== "Unassigned" ? clearShortcut : undefined,
+							onSelect: (ctx) => {
+								const { terminalId } = ctx.pane.data as TerminalPaneData;
+								terminalRuntimeRegistry.clear(terminalId);
+							},
+						},
+						{
+							key: "scroll-to-bottom",
+							label: "Scroll to Bottom",
+							icon: <LuArrowDownToLine />,
+							shortcut:
+								scrollToBottomShortcut !== "Unassigned"
+									? scrollToBottomShortcut
+									: undefined,
+							onSelect: (ctx) => {
+								const { terminalId } = ctx.pane.data as TerminalPaneData;
+								terminalRuntimeRegistry.scrollToBottom(terminalId);
+							},
+						},
+						{ key: "sep-terminal-defaults", type: "separator" },
+					];
+
+					// Update close label
+					const modifiedDefaults = defaults.map((d) =>
+						d.key === "close-pane" ? { ...d, label: "Close Terminal" } : d,
+					);
+
+					return [...terminalActions, ...modifiedDefaults];
+				},
 			},
 			browser: {
 				getIcon: () => <Globe className="size-4" />,
@@ -102,6 +193,10 @@ export function usePaneRegistry(
 						/>
 					);
 				},
+				contextMenuActions: (_ctx, defaults) =>
+					defaults.map((d) =>
+						d.key === "close-pane" ? { ...d, label: "Close Browser" } : d,
+					),
 			},
 			chat: {
 				getIcon: () => <MessageSquare className="size-4" />,
@@ -120,6 +215,10 @@ export function usePaneRegistry(
 						/>
 					);
 				},
+				contextMenuActions: (_ctx, defaults) =>
+					defaults.map((d) =>
+						d.key === "close-pane" ? { ...d, label: "Close Chat" } : d,
+					),
 			},
 			devtools: {
 				getTitle: () => "DevTools",
@@ -133,6 +232,6 @@ export function usePaneRegistry(
 				},
 			},
 		}),
-		[workspaceId],
+		[workspaceId, clearShortcut, scrollToBottomShortcut],
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
@@ -236,8 +236,6 @@ export function useWorkspaceHotkeys({
 		const state = store.getState();
 		const tab = state.getActiveTab();
 		if (!tab) return;
-		if (tab.layout.type === "split") {
-			state.equalizeSplit({ tabId: tab.id, splitId: tab.layout.id });
-		}
+		state.equalizeTab({ tabId: tab.id });
 	});
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -21,6 +21,7 @@ import { AddTabMenu } from "./components/AddTabMenu";
 import { WorkspaceEmptyState } from "./components/WorkspaceEmptyState";
 import { WorkspaceNotFoundState } from "./components/WorkspaceNotFoundState";
 import { WorkspaceSidebar } from "./components/WorkspaceSidebar";
+import { useDefaultContextMenuActions } from "./hooks/useDefaultContextMenuActions";
 import { usePaneRegistry } from "./hooks/usePaneRegistry";
 import { useV2WorkspacePaneLayout } from "./hooks/useV2WorkspacePaneLayout";
 import { useWorkspaceHotkeys } from "./hooks/useWorkspaceHotkeys";
@@ -82,6 +83,7 @@ function WorkspaceContent({
 		workspaceId,
 	});
 	const paneRegistry = usePaneRegistry(workspaceId);
+	const defaultContextMenuActions = useDefaultContextMenuActions();
 
 	const utils = electronTrpc.useUtils();
 	const { data: showPresetsBar, isLoading: isLoadingPresetsBar } =
@@ -232,6 +234,7 @@ function WorkspaceContent({
 						<Workspace<PaneViewerData>
 							registry={paneRegistry}
 							paneActions={defaultPaneActions}
+							contextMenuActions={defaultContextMenuActions}
 							renderAddTabMenu={() => (
 								<AddTabMenu
 									onAddTerminal={addTerminalTab}

--- a/packages/panes/src/core/store/store.test.ts
+++ b/packages/panes/src/core/store/store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import type { Tab, WorkspaceState } from "../../types";
+import type { WorkspaceState } from "../../types";
 import type { CreatePaneInput } from "./store";
 import { createWorkspaceStore } from "./store";
 
@@ -137,10 +137,7 @@ describe("pane operations", () => {
 		const store = makeStore();
 		store.getState().addTab({ id: "t1", panes: [tp("p1")] });
 
-		store.getState().setPanePinned({
-			paneId: "p1",
-			pinned: true,
-		});
+		store.getState().setPanePinned({ paneId: "p1", pinned: true });
 
 		expect(store.getState().getPane("p1")?.pane.pinned).toBe(true);
 	});
@@ -160,7 +157,6 @@ describe("pane operations", () => {
 		});
 
 		const tab = store.getState().tabs[0];
-		expect(tab).toBeDefined();
 		expect(tab?.panes.p1).toBeUndefined();
 		expect(tab?.panes.p2?.data.label).toBe("new");
 		expect(tab?.activePaneId).toBe("p2");
@@ -194,7 +190,7 @@ describe("pane operations", () => {
 });
 
 describe("split operations", () => {
-	it("splits a single pane into a split with weights [1, 1]", () => {
+	it("splits a single pane into a binary split", () => {
 		const store = makeStore();
 		store.getState().addTab({ id: "t1", panes: [tp("p1")] });
 
@@ -209,10 +205,9 @@ describe("split operations", () => {
 		expect(layout?.type).toBe("split");
 		if (layout?.type === "split") {
 			expect(layout.direction).toBe("horizontal");
-			expect(layout.weights).toEqual([1, 1]);
-			expect(layout.children).toHaveLength(2);
-			expect(layout.children[0]).toEqual({ type: "pane", paneId: "p1" });
-			expect(layout.children[1]).toEqual({ type: "pane", paneId: "p2" });
+			expect(layout.splitPercentage).toBeUndefined();
+			expect(layout.first).toEqual({ type: "pane", paneId: "p1" });
+			expect(layout.second).toEqual({ type: "pane", paneId: "p2" });
 		}
 	});
 
@@ -230,8 +225,8 @@ describe("split operations", () => {
 		const layout = store.getState().tabs[0]?.layout;
 		if (layout?.type === "split") {
 			expect(layout.direction).toBe("horizontal");
-			expect(layout.children[0]).toEqual({ type: "pane", paneId: "p2" });
-			expect(layout.children[1]).toEqual({ type: "pane", paneId: "p1" });
+			expect(layout.first).toEqual({ type: "pane", paneId: "p2" });
+			expect(layout.second).toEqual({ type: "pane", paneId: "p1" });
 		}
 	});
 
@@ -249,70 +244,36 @@ describe("split operations", () => {
 		const layout = store.getState().tabs[0]?.layout;
 		if (layout?.type === "split") {
 			expect(layout.direction).toBe("vertical");
-			expect(layout.children[0]).toEqual({ type: "pane", paneId: "p1" });
-			expect(layout.children[1]).toEqual({ type: "pane", paneId: "p2" });
+			expect(layout.first).toEqual({ type: "pane", paneId: "p1" });
+			expect(layout.second).toEqual({ type: "pane", paneId: "p2" });
 		}
 	});
 
-	it("split within same-direction split halves target weight and inserts adjacent", () => {
-		const store = makeStore({
-			version: 1,
-			tabs: [
-				{
-					id: "t1",
-					createdAt: Date.now(),
-					activePaneId: "p1",
-					layout: {
-						type: "split",
-						id: "s1",
-						direction: "horizontal",
-						children: [
-							{ type: "pane", paneId: "p1" },
-							{ type: "pane", paneId: "p2" },
-							{ type: "pane", paneId: "p3" },
-						],
-						weights: [3, 2, 1],
-					},
-					panes: {
-						p1: { id: "p1", kind: "test", data: { label: "p1" } },
-						p2: { id: "p2", kind: "test", data: { label: "p2" } },
-						p3: { id: "p3", kind: "test", data: { label: "p3" } },
-					},
-				},
-			],
-			activeTabId: "t1",
-		});
-
-		store.getState().splitPane({
-			tabId: "t1",
-			paneId: "p2",
-			position: "right",
-			newPane: tp("p4"),
-		});
-
-		const layout = store.getState().tabs[0]?.layout;
-		if (layout?.type === "split") {
-			expect(layout.weights).toEqual([3, 1, 1, 1]);
-			expect(layout.children).toHaveLength(4);
-			expect(layout.children[2]).toEqual({ type: "pane", paneId: "p4" });
-		}
-	});
-
-	it("split with custom weights", () => {
+	it("split creates nested binary split (no flattening)", () => {
 		const store = makeStore();
 		store.getState().addTab({ id: "t1", panes: [tp("p1")] });
-
 		store.getState().splitPane({
 			tabId: "t1",
 			paneId: "p1",
 			position: "right",
 			newPane: tp("p2"),
-			weights: [3, 1],
+		});
+		store.getState().splitPane({
+			tabId: "t1",
+			paneId: "p2",
+			position: "right",
+			newPane: tp("p3"),
 		});
 
 		const layout = store.getState().tabs[0]?.layout;
 		if (layout?.type === "split") {
-			expect(layout.weights).toEqual([3, 1]);
+			expect(layout.first).toEqual({ type: "pane", paneId: "p1" });
+			// p2 is now in a nested split with p3
+			expect(layout.second.type).toBe("split");
+			if (layout.second.type === "split") {
+				expect(layout.second.first).toEqual({ type: "pane", paneId: "p2" });
+				expect(layout.second.second).toEqual({ type: "pane", paneId: "p3" });
+			}
 		}
 	});
 
@@ -335,155 +296,107 @@ describe("split operations", () => {
 		expect(store.getState().tabs[0]?.activePaneId).toBe("p1");
 	});
 
-	it("resizes a split", () => {
-		const store = makeStore({
-			version: 1,
-			tabs: [
-				{
-					id: "t1",
-					createdAt: Date.now(),
-					activePaneId: "p1",
-					layout: {
-						type: "split",
-						id: "s1",
-						direction: "horizontal",
-						children: [
-							{ type: "pane", paneId: "p1" },
-							{ type: "pane", paneId: "p2" },
-						],
-						weights: [1, 1],
-					},
-					panes: {
-						p1: { id: "p1", kind: "test", data: { label: "p1" } },
-						p2: { id: "p2", kind: "test", data: { label: "p2" } },
-					},
-				},
-			],
-			activeTabId: "t1",
+	it("resizes a split via path", () => {
+		const store = makeStore();
+		store.getState().addTab({ id: "t1", panes: [tp("p1")] });
+		store.getState().splitPane({
+			tabId: "t1",
+			paneId: "p1",
+			position: "right",
+			newPane: tp("p2"),
 		});
 
 		store.getState().resizeSplit({
 			tabId: "t1",
-			splitId: "s1",
-			weights: [3, 7],
+			path: [],
+			splitPercentage: 30,
 		});
 
 		const layout = store.getState().tabs[0]?.layout;
 		if (layout?.type === "split") {
-			expect(layout.weights).toEqual([3, 7]);
+			expect(layout.splitPercentage).toBe(30);
 		}
 	});
 
-	it("equalizes a split — all weights become 1", () => {
-		const store = makeStore({
-			version: 1,
-			tabs: [
-				{
-					id: "t1",
-					createdAt: Date.now(),
-					activePaneId: "p1",
-					layout: {
-						type: "split",
-						id: "s1",
-						direction: "horizontal",
-						children: [
-							{ type: "pane", paneId: "p1" },
-							{ type: "pane", paneId: "p2" },
-							{ type: "pane", paneId: "p3" },
-						],
-						weights: [10, 30, 60],
-					},
-					panes: {
-						p1: { id: "p1", kind: "test", data: { label: "p1" } },
-						p2: { id: "p2", kind: "test", data: { label: "p2" } },
-						p3: { id: "p3", kind: "test", data: { label: "p3" } },
-					},
-				},
-			],
-			activeTabId: "t1",
+	it("equalizes all splits in a tab by leaf count", () => {
+		const store = makeStore();
+		store.getState().addTab({ id: "t1", panes: [tp("p1")] });
+		store.getState().splitPane({
+			tabId: "t1",
+			paneId: "p1",
+			position: "right",
+			newPane: tp("p2"),
+		});
+		store.getState().splitPane({
+			tabId: "t1",
+			paneId: "p2",
+			position: "bottom",
+			newPane: tp("p3"),
 		});
 
-		store.getState().equalizeSplit({ tabId: "t1", splitId: "s1" });
+		// Resize root to skewed
+		store.getState().resizeSplit({
+			tabId: "t1",
+			path: [],
+			splitPercentage: 80,
+		});
+
+		store.getState().equalizeTab({ tabId: "t1" });
 
 		const layout = store.getState().tabs[0]?.layout;
+		// Root: [p1, [p2, p3]] → 1 leaf vs 2 leaves → 33.33%
 		if (layout?.type === "split") {
-			expect(layout.weights).toEqual([1, 1, 1]);
+			expect(layout.splitPercentage).toBeCloseTo(33.33, 1);
+			if (layout.second.type === "split") {
+				expect(layout.second.splitPercentage).toBe(50);
+			}
 		}
 	});
 });
 
 describe("collapsing", () => {
-	it("close pane in 2-pane split collapses to remaining leaf", () => {
-		const store = makeStore({
-			version: 1,
-			tabs: [
-				{
-					id: "t1",
-					createdAt: Date.now(),
-					activePaneId: "p1",
-					layout: {
-						type: "split",
-						id: "s1",
-						direction: "horizontal",
-						children: [
-							{ type: "pane", paneId: "p1" },
-							{ type: "pane", paneId: "p2" },
-						],
-						weights: [1, 1],
-					},
-					panes: {
-						p1: { id: "p1", kind: "test", data: { label: "p1" } },
-						p2: { id: "p2", kind: "test", data: { label: "p2" } },
-					},
-				},
-			],
-			activeTabId: "t1",
+	it("close pane in 2-pane split — sibling promotion", () => {
+		const store = makeStore();
+		store.getState().addTab({ id: "t1", panes: [tp("p1")] });
+		store.getState().splitPane({
+			tabId: "t1",
+			paneId: "p1",
+			position: "right",
+			newPane: tp("p2"),
 		});
 
 		store.getState().closePane({ tabId: "t1", paneId: "p1" });
 
 		const tab = store.getState().tabs[0];
-		expect(tab).toBeDefined();
 		expect(tab?.layout).toEqual({ type: "pane", paneId: "p2" });
 		expect(tab?.activePaneId).toBe("p2");
 		expect(tab?.panes.p1).toBeUndefined();
 	});
 
-	it("close pane in 3-pane split removes child + weight", () => {
-		const store = makeStore({
-			version: 1,
-			tabs: [
-				{
-					id: "t1",
-					createdAt: Date.now(),
-					activePaneId: "p2",
-					layout: {
-						type: "split",
-						id: "s1",
-						direction: "horizontal",
-						children: [
-							{ type: "pane", paneId: "p1" },
-							{ type: "pane", paneId: "p2" },
-							{ type: "pane", paneId: "p3" },
-						],
-						weights: [3, 2, 1],
-					},
-					panes: {
-						p1: { id: "p1", kind: "test", data: { label: "p1" } },
-						p2: { id: "p2", kind: "test", data: { label: "p2" } },
-						p3: { id: "p3", kind: "test", data: { label: "p3" } },
-					},
-				},
-			],
-			activeTabId: "t1",
+	it("close pane in nested split — only sibling affected", () => {
+		const store = makeStore();
+		store.getState().addTab({ id: "t1", panes: [tp("p1")] });
+		store.getState().splitPane({
+			tabId: "t1",
+			paneId: "p1",
+			position: "right",
+			newPane: tp("p2"),
+		});
+		store.getState().splitPane({
+			tabId: "t1",
+			paneId: "p2",
+			position: "bottom",
+			newPane: tp("p3"),
 		});
 
-		store.getState().closePane({ tabId: "t1", paneId: "p2" });
+		// Layout: [p1, [p2, p3]]
+		// Close p3 → [p1, p2] (sibling promotion of p2)
+		store.getState().closePane({ tabId: "t1", paneId: "p3" });
 
 		const layout = store.getState().tabs[0]?.layout;
 		if (layout?.type === "split") {
-			expect(layout.children).toHaveLength(2);
-			expect(layout.weights).toEqual([3, 1]);
+			expect(layout.first).toEqual({ type: "pane", paneId: "p1" });
+			expect(layout.second).toEqual({ type: "pane", paneId: "p2" });
 		}
 	});
 
@@ -498,31 +411,16 @@ describe("collapsing", () => {
 	});
 
 	it("activePaneId falls back to sibling after close", () => {
-		const store = makeStore({
-			version: 1,
-			tabs: [
-				{
-					id: "t1",
-					createdAt: Date.now(),
-					activePaneId: "p1",
-					layout: {
-						type: "split",
-						id: "s1",
-						direction: "horizontal",
-						children: [
-							{ type: "pane", paneId: "p1" },
-							{ type: "pane", paneId: "p2" },
-						],
-						weights: [1, 1],
-					},
-					panes: {
-						p1: { id: "p1", kind: "test", data: { label: "p1" } },
-						p2: { id: "p2", kind: "test", data: { label: "p2" } },
-					},
-				},
-			],
-			activeTabId: "t1",
+		const store = makeStore();
+		store.getState().addTab({ id: "t1", panes: [tp("p1")] });
+		store.getState().splitPane({
+			tabId: "t1",
+			paneId: "p1",
+			position: "right",
+			newPane: tp("p2"),
 		});
+		// Make p1 active
+		store.getState().setActivePane({ tabId: "t1", paneId: "p1" });
 
 		store.getState().closePane({ tabId: "t1", paneId: "p1" });
 		expect(store.getState().tabs[0]?.activePaneId).toBe("p2");
@@ -570,38 +468,18 @@ describe("openPane", () => {
 
 		const layout = store.getState().tabs[0]?.layout;
 		expect(layout?.type).toBe("split");
-		if (layout?.type === "split") {
-			expect(layout.children).toHaveLength(2);
-		}
 	});
 });
 
 describe("movePaneToSplit", () => {
 	it("moves a pane within the same tab", () => {
-		const store = makeStore({
-			version: 1,
-			tabs: [
-				{
-					id: "t1",
-					createdAt: Date.now(),
-					activePaneId: "p1",
-					layout: {
-						type: "split",
-						id: "s1",
-						direction: "horizontal",
-						children: [
-							{ type: "pane", paneId: "p1" },
-							{ type: "pane", paneId: "p2" },
-						],
-						weights: [1, 1],
-					},
-					panes: {
-						p1: { id: "p1", kind: "test", data: { label: "p1" } },
-						p2: { id: "p2", kind: "test", data: { label: "p2" } },
-					},
-				},
-			],
-			activeTabId: "t1",
+		const store = makeStore();
+		store.getState().addTab({ id: "t1", panes: [tp("p1")] });
+		store.getState().splitPane({
+			tabId: "t1",
+			paneId: "p1",
+			position: "right",
+			newPane: tp("p2"),
 		});
 
 		store.getState().movePaneToSplit({
@@ -611,48 +489,21 @@ describe("movePaneToSplit", () => {
 		});
 
 		const tab = store.getState().tabs[0];
-		expect(tab).toBeDefined();
-		// p1 should now be split below p2
 		expect(tab?.panes.p1).toBeDefined();
 		expect(tab?.panes.p2).toBeDefined();
 		expect(tab?.activePaneId).toBe("p1");
 	});
 
 	it("moves a pane across tabs", () => {
-		const store = makeStore({
-			version: 1,
-			tabs: [
-				{
-					id: "t1",
-					createdAt: Date.now(),
-					activePaneId: "p1",
-					layout: {
-						type: "split",
-						id: "s1",
-						direction: "horizontal",
-						children: [
-							{ type: "pane", paneId: "p1" },
-							{ type: "pane", paneId: "p2" },
-						],
-						weights: [1, 1],
-					},
-					panes: {
-						p1: { id: "p1", kind: "test", data: { label: "p1" } },
-						p2: { id: "p2", kind: "test", data: { label: "p2" } },
-					},
-				},
-				{
-					id: "t2",
-					createdAt: Date.now(),
-					activePaneId: "p3",
-					layout: { type: "pane", paneId: "p3" },
-					panes: {
-						p3: { id: "p3", kind: "test", data: { label: "p3" } },
-					},
-				},
-			],
-			activeTabId: "t1",
+		const store = makeStore();
+		store.getState().addTab({ id: "t1", panes: [tp("p1")] });
+		store.getState().splitPane({
+			tabId: "t1",
+			paneId: "p1",
+			position: "right",
+			newPane: tp("p2"),
 		});
+		store.getState().addTab({ id: "t2", panes: [tp("p3")] });
 
 		store.getState().movePaneToSplit({
 			sourcePaneId: "p1",
@@ -673,31 +524,10 @@ describe("movePaneToSplit", () => {
 		expect(store.getState().activeTabId).toBe("t2");
 	});
 
-	it("removes source tab when last pane is moved out", () => {
-		const store = makeStore();
-		store.getState().addTab({ id: "t1", panes: [tp("p1")] });
-		store.getState().addTab({ id: "t2", panes: [tp("p2")] });
-
-		const tab1 = store.getState().tabs[0] as Tab<TestData>;
-		const tab2 = store.getState().tabs[1] as Tab<TestData>;
-		const p1Id = Object.keys(tab1.panes)[0] as string;
-		const p2Id = Object.keys(tab2.panes)[0] as string;
-
-		store.getState().movePaneToSplit({
-			sourcePaneId: p1Id,
-			targetPaneId: p2Id,
-			position: "right",
-		});
-
-		expect(store.getState().tabs).toHaveLength(1);
-	});
-
 	it("is a no-op when dropping on self", () => {
 		const store = makeStore();
 		store.getState().addTab({ id: "t1", panes: [tp("p1")] });
 
-		const tab0 = store.getState().tabs[0] as Tab<TestData>;
-		const p1Id = Object.keys(tab0.panes)[0] as string;
 		const before = structuredClone({
 			version: store.getState().version,
 			tabs: store.getState().tabs,
@@ -705,8 +535,8 @@ describe("movePaneToSplit", () => {
 		});
 
 		store.getState().movePaneToSplit({
-			sourcePaneId: p1Id,
-			targetPaneId: p1Id,
+			sourcePaneId: "p1",
+			targetPaneId: "p1",
 			position: "right",
 		});
 
@@ -732,11 +562,6 @@ describe("edge cases", () => {
 		store.getState().setActiveTab("missing");
 		store.getState().setActivePane({ tabId: "t1", paneId: "missing" });
 		store.getState().closePane({ tabId: "t1", paneId: "missing" });
-		store.getState().resizeSplit({
-			tabId: "t1",
-			splitId: "missing",
-			weights: [1],
-		});
 
 		expect({
 			version: store.getState().version,
@@ -791,16 +616,6 @@ describe("reorderTab", () => {
 		expect(store.getState().tabs.map((t) => t.id)).toEqual(before);
 	});
 
-	it("is a no-op for unknown tabId", () => {
-		const store = makeStore();
-		store.getState().addTab({ id: "t1", panes: [tp("p1")] });
-
-		const before = store.getState().tabs.map((t) => t.id);
-		store.getState().reorderTab({ tabId: "missing", toIndex: 0 });
-
-		expect(store.getState().tabs.map((t) => t.id)).toEqual(before);
-	});
-
 	it("clamps toIndex to valid range", () => {
 		const store = makeStore();
 		store.getState().addTab({ id: "t1", panes: [tp("p1")] });
@@ -809,16 +624,5 @@ describe("reorderTab", () => {
 		store.getState().reorderTab({ tabId: "t1", toIndex: 100 });
 
 		expect(store.getState().tabs.map((t) => t.id)).toEqual(["t2", "t1"]);
-	});
-
-	it("preserves activeTabId", () => {
-		const store = makeStore();
-		store.getState().addTab({ id: "t1", panes: [tp("p1")] });
-		store.getState().addTab({ id: "t2", panes: [tp("p2")] });
-		store.getState().setActiveTab("t2");
-
-		store.getState().reorderTab({ tabId: "t1", toIndex: 1 });
-
-		expect(store.getState().activeTabId).toBe("t2");
 	});
 });

--- a/packages/panes/src/core/store/store.ts
+++ b/packages/panes/src/core/store/store.ts
@@ -33,7 +33,10 @@ function buildBalancedTree(
 	panes: LayoutNode[],
 	direction: "horizontal" | "vertical" = "vertical",
 ): LayoutNode {
-	if (panes.length === 1) return panes[0]!;
+	if (panes.length === 1) {
+		const [single] = panes as [LayoutNode];
+		return single;
+	}
 
 	const mid = Math.ceil(panes.length / 2);
 	const nextDirection = direction === "vertical" ? "horizontal" : "vertical";

--- a/packages/panes/src/core/store/store.ts
+++ b/packages/panes/src/core/store/store.ts
@@ -2,18 +2,21 @@ import { createStore, type StoreApi } from "zustand/vanilla";
 import type {
 	LayoutNode,
 	Pane,
+	SplitPath,
 	SplitPosition,
 	Tab,
 	WorkspaceState,
 } from "../../types";
 import {
+	equalizeAllSplits,
 	findFirstPaneId,
 	findPaneInLayout,
 	generateId,
+	positionToDirection,
 	removePaneFromLayout,
 	replacePaneIdInLayout,
 	splitPaneInLayout,
-	updateSplitInLayout,
+	updateAtPath,
 } from "./utils";
 
 function buildPane<TData>(args: CreatePaneInput<TData>): Pane<TData> {
@@ -26,6 +29,23 @@ function buildPane<TData>(args: CreatePaneInput<TData>): Pane<TData> {
 	};
 }
 
+function buildBalancedTree(
+	panes: LayoutNode[],
+	direction: "horizontal" | "vertical" = "vertical",
+): LayoutNode {
+	if (panes.length === 1) return panes[0]!;
+
+	const mid = Math.ceil(panes.length / 2);
+	const nextDirection = direction === "vertical" ? "horizontal" : "vertical";
+
+	return {
+		type: "split",
+		direction,
+		first: buildBalancedTree(panes.slice(0, mid), nextDirection),
+		second: buildBalancedTree(panes.slice(mid), nextDirection),
+	};
+}
+
 function buildTab<TData>(args: {
 	id?: string;
 	titleOverride?: string;
@@ -33,26 +53,11 @@ function buildTab<TData>(args: {
 	activePaneId?: string;
 }): Tab<TData> {
 	const panesMap: Record<string, Pane<TData>> = {};
-	let layout: LayoutNode;
+	const leaves: LayoutNode[] = [];
 
-	if (args.panes.length === 1) {
-		panesMap[args.panes[0].id] = args.panes[0];
-		layout = { type: "pane", paneId: args.panes[0].id };
-	} else {
-		const children: LayoutNode[] = [];
-		const weights: number[] = [];
-		for (const pane of args.panes) {
-			panesMap[pane.id] = pane;
-			children.push({ type: "pane", paneId: pane.id });
-			weights.push(1);
-		}
-		layout = {
-			type: "split",
-			id: generateId("split"),
-			direction: "horizontal",
-			children,
-			weights,
-		};
+	for (const pane of args.panes) {
+		panesMap[pane.id] = pane;
+		leaves.push({ type: "pane", paneId: pane.id });
 	}
 
 	return {
@@ -60,7 +65,7 @@ function buildTab<TData>(args: {
 		titleOverride: args.titleOverride,
 		createdAt: Date.now(),
 		activePaneId: args.activePaneId ?? args.panes[0].id,
-		layout,
+		layout: buildBalancedTree(leaves),
 		panes: panesMap,
 	};
 }
@@ -119,7 +124,6 @@ export interface WorkspaceStore<TData> extends WorkspaceState<TData> {
 		paneId: string;
 		position: SplitPosition;
 		newPane: CreatePaneInput<TData>;
-		weights?: number[];
 		selectNewPane?: boolean;
 	}) => void;
 	addPane: (args: {
@@ -130,16 +134,20 @@ export interface WorkspaceStore<TData> extends WorkspaceState<TData> {
 	}) => void;
 	resizeSplit: (args: {
 		tabId: string;
-		splitId: string;
-		weights: number[];
+		path: SplitPath;
+		splitPercentage: number;
 	}) => void;
-	equalizeSplit: (args: { tabId: string; splitId: string }) => void;
+	equalizeSplit: (args: { tabId: string; path: SplitPath }) => void;
+	equalizeTab: (args: { tabId: string }) => void;
 
 	movePaneToSplit: (args: {
 		sourcePaneId: string;
 		targetPaneId: string;
 		position: SplitPosition;
 	}) => void;
+
+	movePaneToTab: (args: { paneId: string; targetTabId: string }) => void;
+	movePaneToNewTab: (args: { paneId: string }) => void;
 
 	reorderTab: (args: { tabId: string; toIndex: number }) => void;
 
@@ -458,7 +466,6 @@ export function createWorkspaceStore<TData>(
 										args.paneId,
 										newPane.id,
 										args.position,
-										args.weights,
 									),
 									panes: {
 										...tab.panes,
@@ -531,22 +538,17 @@ export function createWorkspaceStore<TData>(
 					};
 				}
 
+				const direction = positionToDirection(position);
 				const newPaneLeaf: LayoutNode = {
 					type: "pane",
 					paneId: newPane.id,
 				};
+				const isFirst = position === "left" || position === "top";
 				const edgeLayout: LayoutNode = {
 					type: "split",
-					id: generateId("split"),
-					direction:
-						position === "left" || position === "right"
-							? "horizontal"
-							: "vertical",
-					children:
-						position === "left" || position === "top"
-							? [newPaneLeaf, layout]
-							: [layout, newPaneLeaf],
-					weights: [1, 1],
+					direction,
+					first: isFirst ? newPaneLeaf : layout,
+					second: isFirst ? layout : newPaneLeaf,
 				};
 
 				return {
@@ -572,20 +574,18 @@ export function createWorkspaceStore<TData>(
 				const tab = s.tabs.find((t) => t.id === args.tabId);
 				if (!tab || !tab.layout) return s;
 
-				const { layout } = tab;
-
 				return {
 					tabs: s.tabs.map((t) =>
 						t.id === args.tabId
 							? {
 									...t,
-									layout: updateSplitInLayout(
-										layout,
-										args.splitId,
-										(split) => ({
-											...split,
-											weights: args.weights,
-										}),
+									layout: updateAtPath(tab.layout, args.path, (node) =>
+										node.type === "split"
+											? {
+													...node,
+													splitPercentage: args.splitPercentage,
+												}
+											: node,
 									),
 								}
 							: t,
@@ -599,20 +599,15 @@ export function createWorkspaceStore<TData>(
 				const tab = s.tabs.find((t) => t.id === args.tabId);
 				if (!tab || !tab.layout) return s;
 
-				const { layout } = tab;
-
 				return {
 					tabs: s.tabs.map((t) =>
 						t.id === args.tabId
 							? {
 									...t,
-									layout: updateSplitInLayout(
-										layout,
-										args.splitId,
-										(split) => ({
-											...split,
-											weights: split.children.map(() => 1),
-										}),
+									layout: updateAtPath(
+										tab.layout,
+										args.path,
+										equalizeAllSplits,
 									),
 								}
 							: t,
@@ -621,9 +616,23 @@ export function createWorkspaceStore<TData>(
 			});
 		},
 
+		equalizeTab: (args) => {
+			set((s) => {
+				const tab = s.tabs.find((t) => t.id === args.tabId);
+				if (!tab?.layout) return s;
+
+				return {
+					tabs: s.tabs.map((t) =>
+						t.id === args.tabId
+							? { ...t, layout: equalizeAllSplits(tab.layout) }
+							: t,
+					),
+				};
+			});
+		},
+
 		movePaneToSplit: (args) => {
 			set((s) => {
-				// Find source and target tabs by pane ID
 				let sourceTab: Tab<TData> | undefined;
 				let sourcePane: Pane<TData> | undefined;
 				let targetTab: Tab<TData> | undefined;
@@ -639,20 +648,15 @@ export function createWorkspaceStore<TData>(
 				if (!sourceTab || !sourcePane) return s;
 				if (!targetTab || !targetTab.layout) return s;
 				if (!findPaneInLayout(targetTab.layout, args.targetPaneId)) return s;
-
-				// Don't drop on self
 				if (args.sourcePaneId === args.targetPaneId) return s;
 
-				// Remove from source layout
 				const nextSourceLayout = removePaneFromLayout(
 					sourceTab.layout,
 					args.sourcePaneId,
 				);
 				const { [args.sourcePaneId]: _, ...nextSourcePanes } = sourceTab.panes;
 
-				// Insert into target layout
 				const nextTargetLayout = splitPaneInLayout(
-					// If same tab, use the already-modified layout
 					sourceTab.id === targetTab.id && nextSourceLayout
 						? nextSourceLayout
 						: targetTab.layout,
@@ -664,8 +668,7 @@ export function createWorkspaceStore<TData>(
 				const nextTabs = s.tabs
 					.map((t) => {
 						if (sourceTab.id === targetTab.id && t.id === sourceTab.id) {
-							// Same-tab move
-							if (!nextSourceLayout) return null; // shouldn't happen since we check targetPaneId != sourcePaneId
+							if (!nextSourceLayout) return null;
 							return {
 								...t,
 								layout: nextTargetLayout,
@@ -674,8 +677,7 @@ export function createWorkspaceStore<TData>(
 							};
 						}
 						if (t.id === sourceTab.id) {
-							// Source tab — pane removed
-							if (!nextSourceLayout) return null; // last pane removed, tab will be filtered
+							if (!nextSourceLayout) return null;
 							return {
 								...t,
 								layout: nextSourceLayout,
@@ -687,7 +689,6 @@ export function createWorkspaceStore<TData>(
 							};
 						}
 						if (t.id === targetTab.id) {
-							// Target tab — pane added
 							return {
 								...t,
 								layout: nextTargetLayout,
@@ -699,10 +700,116 @@ export function createWorkspaceStore<TData>(
 					})
 					.filter((t): t is Tab<TData> => t !== null);
 
-				return {
-					tabs: nextTabs,
-					activeTabId: targetTab.id,
+				return { tabs: nextTabs, activeTabId: targetTab.id };
+			});
+		},
+
+		movePaneToTab: (args) => {
+			set((s) => {
+				let sourceTab: Tab<TData> | undefined;
+				let pane: Pane<TData> | undefined;
+				for (const t of s.tabs) {
+					if (t.panes[args.paneId]) {
+						sourceTab = t;
+						pane = t.panes[args.paneId];
+						break;
+					}
+				}
+				if (!sourceTab || !pane || !sourceTab.layout) return s;
+
+				const targetTab = s.tabs.find((t) => t.id === args.targetTabId);
+				if (!targetTab || !targetTab.layout) return s;
+				if (sourceTab.id === targetTab.id) return s;
+
+				const nextSourceLayout = removePaneFromLayout(
+					sourceTab.layout,
+					args.paneId,
+				);
+				const { [args.paneId]: _, ...nextSourcePanes } = sourceTab.panes;
+
+				const paneLeaf: LayoutNode = { type: "pane", paneId: pane.id };
+				const nextTargetLayout: LayoutNode = {
+					type: "split",
+					direction: "horizontal",
+					first: targetTab.layout,
+					second: paneLeaf,
 				};
+
+				const nextTabs = s.tabs
+					.map((t) => {
+						if (t.id === sourceTab.id) {
+							if (!nextSourceLayout) return null;
+							return {
+								...t,
+								layout: nextSourceLayout,
+								panes: nextSourcePanes,
+								activePaneId:
+									t.activePaneId === args.paneId
+										? findFirstPaneId(nextSourceLayout)
+										: t.activePaneId,
+							};
+						}
+						if (t.id === targetTab.id) {
+							return {
+								...t,
+								layout: nextTargetLayout,
+								panes: { ...t.panes, [pane.id]: pane },
+								activePaneId: pane.id,
+							};
+						}
+						return t;
+					})
+					.filter((t): t is Tab<TData> => t !== null);
+
+				return { tabs: nextTabs, activeTabId: targetTab.id };
+			});
+		},
+
+		movePaneToNewTab: (args) => {
+			set((s) => {
+				let sourceTab: Tab<TData> | undefined;
+				let pane: Pane<TData> | undefined;
+				for (const t of s.tabs) {
+					if (t.panes[args.paneId]) {
+						sourceTab = t;
+						pane = t.panes[args.paneId];
+						break;
+					}
+				}
+				if (!sourceTab || !pane || !sourceTab.layout) return s;
+
+				const nextSourceLayout = removePaneFromLayout(
+					sourceTab.layout,
+					args.paneId,
+				);
+				const { [args.paneId]: _, ...nextSourcePanes } = sourceTab.panes;
+
+				const newTab = buildTab({
+					panes: [pane],
+					activePaneId: pane.id,
+				});
+
+				const nextTabs = s.tabs
+					.map((t) => {
+						if (t.id === sourceTab.id) {
+							if (!nextSourceLayout) return null;
+							return {
+								...t,
+								layout: nextSourceLayout,
+								panes: nextSourcePanes,
+								activePaneId:
+									t.activePaneId === args.paneId
+										? findFirstPaneId(nextSourceLayout)
+										: t.activePaneId,
+							};
+						}
+						return t;
+					})
+					.filter((t): t is Tab<TData> => t !== null);
+
+				nextTabs.push(newTab);
+
+				return { tabs: nextTabs, activeTabId: newTab.id };
 			});
 		},
 

--- a/packages/panes/src/core/store/utils/index.ts
+++ b/packages/panes/src/core/store/utils/index.ts
@@ -1,9 +1,13 @@
 export {
+	equalizeAllSplits,
 	findFirstPaneId,
 	findPaneInLayout,
 	generateId,
+	getNodeAtPath,
+	getOtherBranch,
+	positionToDirection,
 	removePaneFromLayout,
 	replacePaneIdInLayout,
 	splitPaneInLayout,
-	updateSplitInLayout,
+	updateAtPath,
 } from "./utils";

--- a/packages/panes/src/core/store/utils/utils.test.ts
+++ b/packages/panes/src/core/store/utils/utils.test.ts
@@ -1,58 +1,55 @@
 import { describe, expect, it } from "bun:test";
 import type { LayoutNode } from "../../../types";
 import {
+	equalizeAllSplits,
 	findFirstPaneId,
 	findPaneInLayout,
+	getNodeAtPath,
+	getOtherBranch,
 	positionToDirection,
 	removePaneFromLayout,
 	replacePaneIdInLayout,
 	splitPaneInLayout,
-	updateSplitInLayout,
+	updateAtPath,
 } from "./utils";
 
 const SINGLE: LayoutNode = { type: "pane", paneId: "a" };
 
 const TWO_SPLIT: LayoutNode = {
 	type: "split",
-	id: "s1",
 	direction: "horizontal",
-	children: [
-		{ type: "pane", paneId: "a" },
-		{ type: "pane", paneId: "b" },
-	],
-	weights: [1, 1],
-};
-
-const THREE_SPLIT: LayoutNode = {
-	type: "split",
-	id: "s1",
-	direction: "horizontal",
-	children: [
-		{ type: "pane", paneId: "a" },
-		{ type: "pane", paneId: "b" },
-		{ type: "pane", paneId: "c" },
-	],
-	weights: [3, 2, 1],
+	first: { type: "pane", paneId: "a" },
+	second: { type: "pane", paneId: "b" },
 };
 
 const NESTED: LayoutNode = {
 	type: "split",
-	id: "s1",
 	direction: "horizontal",
-	children: [
-		{ type: "pane", paneId: "a" },
-		{
+	first: { type: "pane", paneId: "a" },
+	second: {
+		type: "split",
+		direction: "vertical",
+		first: { type: "pane", paneId: "b" },
+		second: { type: "pane", paneId: "c" },
+	},
+};
+
+const DEEP: LayoutNode = {
+	type: "split",
+	direction: "vertical",
+	first: { type: "pane", paneId: "a" },
+	second: {
+		type: "split",
+		direction: "vertical",
+		first: { type: "pane", paneId: "b" },
+		second: {
 			type: "split",
-			id: "s2",
 			direction: "vertical",
-			children: [
-				{ type: "pane", paneId: "b" },
-				{ type: "pane", paneId: "c" },
-			],
-			weights: [1, 1],
+			first: { type: "pane", paneId: "c" },
+			second: { type: "pane", paneId: "d" },
 		},
-	],
-	weights: [1, 1],
+	},
+	splitPercentage: 30,
 };
 
 describe("findPaneInLayout", () => {
@@ -92,34 +89,39 @@ describe("removePaneFromLayout", () => {
 		expect(removePaneFromLayout(SINGLE, "a")).toBeNull();
 	});
 
-	it("returns the remaining pane when removing from a 2-pane split", () => {
+	it("promotes sibling when removing from a 2-pane split", () => {
 		const result = removePaneFromLayout(TWO_SPLIT, "a");
 		expect(result).toEqual({ type: "pane", paneId: "b" });
 	});
 
-	it("preserves weights when removing from a 3-pane split", () => {
-		const result = removePaneFromLayout(THREE_SPLIT, "b");
+	it("promotes sibling (other direction)", () => {
+		const result = removePaneFromLayout(TWO_SPLIT, "b");
+		expect(result).toEqual({ type: "pane", paneId: "a" });
+	});
+
+	it("collapses nested split — sibling promotion preserves parent", () => {
+		// NESTED: { h: [a, { v: [b, c] }] } — remove b → { h: [a, c] }
+		const result = removePaneFromLayout(NESTED, "b");
 		expect(result).toMatchObject({
 			type: "split",
-			weights: [3, 1],
-			children: [
-				{ type: "pane", paneId: "a" },
-				{ type: "pane", paneId: "c" },
-			],
+			direction: "horizontal",
+			first: { type: "pane", paneId: "a" },
+			second: { type: "pane", paneId: "c" },
 		});
 	});
 
-	it("collapses nested split when child is removed", () => {
-		const result = removePaneFromLayout(NESTED, "b");
-		// s2 had [b, c], removing b leaves just c — s2 collapses
-		// s1 now has [a, c]
+	it("preserves parent splitPercentage when descendant is removed", () => {
+		// DEEP: { v(30%): [a, { v: [b, { v: [c, d] }] }] } — remove c
+		const result = removePaneFromLayout(DEEP, "c");
 		expect(result).toMatchObject({
 			type: "split",
-			id: "s1",
-			children: [
-				{ type: "pane", paneId: "a" },
-				{ type: "pane", paneId: "c" },
-			],
+			splitPercentage: 30,
+			first: { type: "pane", paneId: "a" },
+			second: {
+				type: "split",
+				first: { type: "pane", paneId: "b" },
+				second: { type: "pane", paneId: "d" },
+			},
 		});
 	});
 
@@ -139,17 +141,14 @@ describe("replacePaneIdInLayout", () => {
 	it("replaces a pane id inside a split", () => {
 		const result = replacePaneIdInLayout(TWO_SPLIT, "b", "x");
 		if (result.type === "split") {
-			expect(result.children[1]).toEqual({ type: "pane", paneId: "x" });
+			expect(result.second).toEqual({ type: "pane", paneId: "x" });
 		}
 	});
 
 	it("replaces in nested splits", () => {
 		const result = replacePaneIdInLayout(NESTED, "c", "x");
-		if (result.type === "split" && result.children[1]?.type === "split") {
-			expect(result.children[1].children[1]).toEqual({
-				type: "pane",
-				paneId: "x",
-			});
+		if (result.type === "split" && result.second.type === "split") {
+			expect(result.second.second).toEqual({ type: "pane", paneId: "x" });
 		}
 	});
 
@@ -161,20 +160,23 @@ describe("replacePaneIdInLayout", () => {
 describe("splitPaneInLayout", () => {
 	it("wraps a leaf in a new split", () => {
 		const result = splitPaneInLayout(SINGLE, "a", "b", "right");
-		expect(result.type).toBe("split");
+		expect(result).toMatchObject({
+			type: "split",
+			direction: "horizontal",
+			first: { type: "pane", paneId: "a" },
+			second: { type: "pane", paneId: "b" },
+		});
+		// splitPercentage should be absent (defaults to 50)
 		if (result.type === "split") {
-			expect(result.direction).toBe("horizontal");
-			expect(result.weights).toEqual([1, 1]);
-			expect(result.children[0]).toEqual({ type: "pane", paneId: "a" });
-			expect(result.children[1]).toEqual({ type: "pane", paneId: "b" });
+			expect(result.splitPercentage).toBeUndefined();
 		}
 	});
 
 	it("left/top puts new pane first", () => {
 		const result = splitPaneInLayout(SINGLE, "a", "b", "left");
 		if (result.type === "split") {
-			expect(result.children[0]).toEqual({ type: "pane", paneId: "b" });
-			expect(result.children[1]).toEqual({ type: "pane", paneId: "a" });
+			expect(result.first).toEqual({ type: "pane", paneId: "b" });
+			expect(result.second).toEqual({ type: "pane", paneId: "a" });
 		}
 	});
 
@@ -185,73 +187,125 @@ describe("splitPaneInLayout", () => {
 		}
 	});
 
-	it("inserts into existing same-direction split and halves weight", () => {
-		const result = splitPaneInLayout(THREE_SPLIT, "b", "d", "right");
+	it("always creates nested binary split (no flattening)", () => {
+		const result = splitPaneInLayout(TWO_SPLIT, "b", "c", "right");
 		if (result.type === "split") {
-			expect(result.children).toHaveLength(4);
-			expect(result.weights).toEqual([3, 1, 1, 1]);
-			expect(result.children[1]).toEqual({ type: "pane", paneId: "b" });
-			expect(result.children[2]).toEqual({ type: "pane", paneId: "d" });
-		}
-	});
-
-	it("inserts left into existing same-direction split", () => {
-		const result = splitPaneInLayout(THREE_SPLIT, "b", "d", "left");
-		if (result.type === "split") {
-			expect(result.children).toHaveLength(4);
-			expect(result.children[1]).toEqual({ type: "pane", paneId: "d" });
-			expect(result.children[2]).toEqual({ type: "pane", paneId: "b" });
-		}
-	});
-
-	it("creates nested split for cross-direction split", () => {
-		const result = splitPaneInLayout(TWO_SPLIT, "b", "c", "bottom");
-		if (result.type === "split") {
-			expect(result.children).toHaveLength(2);
-			expect(result.children[0]).toEqual({ type: "pane", paneId: "a" });
-			const nested = result.children[1];
-			expect(nested?.type).toBe("split");
-			if (nested?.type === "split") {
-				expect(nested.direction).toBe("vertical");
-				expect(nested.children[0]).toEqual({ type: "pane", paneId: "b" });
-				expect(nested.children[1]).toEqual({ type: "pane", paneId: "c" });
+			expect(result.first).toEqual({ type: "pane", paneId: "a" });
+			// b is now wrapped in a nested split with c
+			expect(result.second.type).toBe("split");
+			if (result.second.type === "split") {
+				expect(result.second.first).toEqual({ type: "pane", paneId: "b" });
+				expect(result.second.second).toEqual({ type: "pane", paneId: "c" });
 			}
 		}
 	});
 
-	it("uses custom weights", () => {
-		const result = splitPaneInLayout(SINGLE, "a", "b", "right", [3, 1]);
+	it("creates cross-direction nested split", () => {
+		const result = splitPaneInLayout(TWO_SPLIT, "b", "c", "bottom");
 		if (result.type === "split") {
-			expect(result.weights).toEqual([3, 1]);
+			expect(result.direction).toBe("horizontal"); // parent unchanged
+			const nested = result.second;
+			expect(nested.type).toBe("split");
+			if (nested.type === "split") {
+				expect(nested.direction).toBe("vertical");
+				expect(nested.first).toEqual({ type: "pane", paneId: "b" });
+				expect(nested.second).toEqual({ type: "pane", paneId: "c" });
+			}
 		}
 	});
 });
 
-describe("updateSplitInLayout", () => {
-	it("updates a split by id", () => {
-		const result = updateSplitInLayout(TWO_SPLIT, "s1", (split) => ({
-			...split,
-			weights: [3, 7],
-		}));
-		if (result.type === "split") {
-			expect(result.weights).toEqual([3, 7]);
-		}
+describe("getNodeAtPath", () => {
+	it("returns root for empty path", () => {
+		expect(getNodeAtPath(TWO_SPLIT, [])).toEqual(TWO_SPLIT);
 	});
 
-	it("updates a nested split", () => {
-		const result = updateSplitInLayout(NESTED, "s2", (split) => ({
-			...split,
-			weights: [3, 1],
-		}));
-		if (result.type === "split" && result.children[1]?.type === "split") {
-			expect(result.children[1].weights).toEqual([3, 1]);
-		}
+	it("returns first child", () => {
+		expect(getNodeAtPath(TWO_SPLIT, ["first"])).toEqual({
+			type: "pane",
+			paneId: "a",
+		});
 	});
 
-	it("returns unchanged layout for missing id", () => {
-		expect(updateSplitInLayout(TWO_SPLIT, "missing", (s) => s)).toEqual(
-			TWO_SPLIT,
+	it("returns nested node", () => {
+		expect(getNodeAtPath(NESTED, ["second", "first"])).toEqual({
+			type: "pane",
+			paneId: "b",
+		});
+	});
+
+	it("returns null for invalid path", () => {
+		expect(getNodeAtPath(SINGLE, ["first"])).toBeNull();
+	});
+});
+
+describe("updateAtPath", () => {
+	it("updates root", () => {
+		const result = updateAtPath(TWO_SPLIT, [], (node) =>
+			node.type === "split" ? { ...node, splitPercentage: 75 } : node,
 		);
+		if (result.type === "split") {
+			expect(result.splitPercentage).toBe(75);
+		}
+	});
+
+	it("updates nested node", () => {
+		const result = updateAtPath(NESTED, ["second"], (node) =>
+			node.type === "split" ? { ...node, splitPercentage: 30 } : node,
+		);
+		if (result.type === "split" && result.second.type === "split") {
+			expect(result.second.splitPercentage).toBe(30);
+		}
+	});
+});
+
+describe("getOtherBranch", () => {
+	it("returns second for first", () => {
+		expect(getOtherBranch("first")).toBe("second");
+	});
+
+	it("returns first for second", () => {
+		expect(getOtherBranch("second")).toBe("first");
+	});
+});
+
+describe("equalizeAllSplits", () => {
+	it("returns pane unchanged", () => {
+		expect(equalizeAllSplits(SINGLE)).toEqual(SINGLE);
+	});
+
+	it("sets splitPercentage to 50 for equal leaves", () => {
+		const result = equalizeAllSplits(TWO_SPLIT);
+		if (result.type === "split") {
+			expect(result.splitPercentage).toBe(50);
+		}
+	});
+
+	it("sets splitPercentage by leaf count ratio", () => {
+		// NESTED: [a, [b, c]] → first has 1 leaf, second has 2 → 33.33%
+		const result = equalizeAllSplits(NESTED);
+		if (result.type === "split") {
+			expect(result.splitPercentage).toBeCloseTo(33.33, 1);
+			// Nested split should be 50/50
+			if (result.second.type === "split") {
+				expect(result.second.splitPercentage).toBe(50);
+			}
+		}
+	});
+
+	it("equalizes deep tree so all panes get equal space", () => {
+		// DEEP: [a, [b, [c, d]]] → 4 panes
+		// Root: 1/4 = 25%, second: 1/3 = 33.33%, innermost: 1/2 = 50%
+		const result = equalizeAllSplits(DEEP);
+		if (result.type === "split") {
+			expect(result.splitPercentage).toBe(25);
+			if (result.second.type === "split") {
+				expect(result.second.splitPercentage).toBeCloseTo(33.33, 1);
+				if (result.second.second.type === "split") {
+					expect(result.second.second.splitPercentage).toBe(50);
+				}
+			}
+		}
 	});
 });
 

--- a/packages/panes/src/core/store/utils/utils.ts
+++ b/packages/panes/src/core/store/utils/utils.ts
@@ -96,8 +96,8 @@ export function getNodeAtPath(
 	if (path.length === 0) return node;
 	if (node.type === "pane") return null;
 
-	const branch = path[0]!;
-	return getNodeAtPath(node[branch], path.slice(1));
+	const [branch, ...rest] = path as [SplitBranch, ...SplitBranch[]];
+	return getNodeAtPath(node[branch], rest);
 }
 
 export function updateAtPath(
@@ -108,10 +108,10 @@ export function updateAtPath(
 	if (path.length === 0) return updater(node);
 	if (node.type === "pane") return node;
 
-	const branch = path[0]!;
+	const [branch, ...rest] = path as [SplitBranch, ...SplitBranch[]];
 	return {
 		...node,
-		[branch]: updateAtPath(node[branch], path.slice(1), updater),
+		[branch]: updateAtPath(node[branch], rest, updater),
 	};
 }
 

--- a/packages/panes/src/core/store/utils/utils.ts
+++ b/packages/panes/src/core/store/utils/utils.ts
@@ -1,21 +1,26 @@
-import type { LayoutNode, SplitDirection, SplitPosition } from "../../../types";
+import type {
+	LayoutNode,
+	SplitBranch,
+	SplitDirection,
+	SplitPath,
+	SplitPosition,
+} from "../../../types";
 
 export function findPaneInLayout(node: LayoutNode, paneId: string): boolean {
 	if (node.type === "pane") {
 		return node.paneId === paneId;
 	}
-	return node.children.some((child) => findPaneInLayout(child, paneId));
+	return (
+		findPaneInLayout(node.first, paneId) ||
+		findPaneInLayout(node.second, paneId)
+	);
 }
 
 export function findFirstPaneId(node: LayoutNode): string | null {
 	if (node.type === "pane") {
 		return node.paneId;
 	}
-	for (const child of node.children) {
-		const id = findFirstPaneId(child);
-		if (id) return id;
-	}
-	return null;
+	return findFirstPaneId(node.first) ?? findFirstPaneId(node.second);
 }
 
 export function removePaneFromLayout(
@@ -26,33 +31,16 @@ export function removePaneFromLayout(
 		return node.paneId === paneId ? null : node;
 	}
 
-	const nextChildren: LayoutNode[] = [];
-	const nextWeights: number[] = [];
+	const newFirst = removePaneFromLayout(node.first, paneId);
+	const newSecond = removePaneFromLayout(node.second, paneId);
 
-	for (let i = 0; i < node.children.length; i++) {
-		const child = node.children[i];
-		if (!child) continue;
+	// Both removed (shouldn't happen in practice)
+	if (!newFirst && !newSecond) return null;
+	// Sibling promotion — one child removed, promote the other
+	if (!newFirst) return newSecond;
+	if (!newSecond) return newFirst;
 
-		const result = removePaneFromLayout(child, paneId);
-		if (result) {
-			nextChildren.push(result);
-			nextWeights.push(node.weights[i] ?? 1);
-		}
-	}
-
-	if (nextChildren.length === 0) {
-		return null;
-	}
-
-	if (nextChildren.length === 1) {
-		return nextChildren[0] ?? null;
-	}
-
-	return {
-		...node,
-		children: nextChildren,
-		weights: nextWeights,
-	};
+	return { ...node, first: newFirst, second: newSecond };
 }
 
 export function replacePaneIdInLayout(
@@ -68,9 +56,8 @@ export function replacePaneIdInLayout(
 
 	return {
 		...node,
-		children: node.children.map((child) =>
-			replacePaneIdInLayout(child, oldPaneId, newPaneId),
-		),
+		first: replacePaneIdInLayout(node.first, oldPaneId, newPaneId),
+		second: replacePaneIdInLayout(node.second, oldPaneId, newPaneId),
 	};
 }
 
@@ -79,7 +66,6 @@ export function splitPaneInLayout(
 	targetPaneId: string,
 	newPaneId: string,
 	position: SplitPosition,
-	weights?: number[],
 ): LayoutNode {
 	if (node.type === "pane") {
 		if (node.paneId !== targetPaneId) return node;
@@ -90,76 +76,65 @@ export function splitPaneInLayout(
 
 		return {
 			type: "split",
-			id: generateId("split"),
 			direction,
-			children: isFirst ? [newPaneNode, node] : [node, newPaneNode],
-			weights: weights ?? [1, 1],
-		};
-	}
-
-	const parentInfo = findDirectChild(node, targetPaneId);
-
-	if (parentInfo && node.direction === positionToDirection(position)) {
-		const { childIndex } = parentInfo;
-		const currentWeight = node.weights[childIndex] ?? 1;
-		const halfWeight = currentWeight / 2;
-		const newPaneNode: LayoutNode = { type: "pane", paneId: newPaneId };
-		const isFirst = position === "left" || position === "top";
-
-		const nextChildren = [...node.children];
-		const nextWeights = [...node.weights];
-
-		nextWeights[childIndex] = halfWeight;
-
-		if (isFirst) {
-			nextChildren.splice(childIndex, 0, newPaneNode);
-			nextWeights.splice(childIndex, 0, halfWeight);
-		} else {
-			nextChildren.splice(childIndex + 1, 0, newPaneNode);
-			nextWeights.splice(childIndex + 1, 0, halfWeight);
-		}
-
-		return {
-			...node,
-			children: nextChildren,
-			weights: nextWeights,
+			first: isFirst ? newPaneNode : node,
+			second: isFirst ? node : newPaneNode,
 		};
 	}
 
 	return {
 		...node,
-		children: node.children.map((child) =>
-			splitPaneInLayout(child, targetPaneId, newPaneId, position, weights),
-		),
+		first: splitPaneInLayout(node.first, targetPaneId, newPaneId, position),
+		second: splitPaneInLayout(node.second, targetPaneId, newPaneId, position),
 	};
 }
 
-function findDirectChild(
-	split: LayoutNode & { type: "split" },
-	paneId: string,
-): { childIndex: number } | null {
-	for (let i = 0; i < split.children.length; i++) {
-		const child = split.children[i];
-		if (child?.type === "pane" && child.paneId === paneId) {
-			return { childIndex: i };
-		}
-	}
-	return null;
+export function getNodeAtPath(
+	node: LayoutNode,
+	path: SplitPath,
+): LayoutNode | null {
+	if (path.length === 0) return node;
+	if (node.type === "pane") return null;
+
+	const branch = path[0]!;
+	return getNodeAtPath(node[branch], path.slice(1));
 }
 
-export function updateSplitInLayout(
+export function updateAtPath(
 	node: LayoutNode,
-	splitId: string,
-	updater: (split: LayoutNode & { type: "split" }) => LayoutNode,
+	path: SplitPath,
+	updater: (node: LayoutNode) => LayoutNode,
 ): LayoutNode {
+	if (path.length === 0) return updater(node);
 	if (node.type === "pane") return node;
-	if (node.id === splitId) return updater(node);
+
+	const branch = path[0]!;
+	return {
+		...node,
+		[branch]: updateAtPath(node[branch], path.slice(1), updater),
+	};
+}
+
+export function getOtherBranch(branch: SplitBranch): SplitBranch {
+	return branch === "first" ? "second" : "first";
+}
+
+function countLeaves(node: LayoutNode): number {
+	if (node.type === "pane") return 1;
+	return countLeaves(node.first) + countLeaves(node.second);
+}
+
+export function equalizeAllSplits(node: LayoutNode): LayoutNode {
+	if (node.type === "pane") return node;
+
+	const firstLeaves = countLeaves(node.first);
+	const secondLeaves = countLeaves(node.second);
 
 	return {
 		...node,
-		children: node.children.map((child) =>
-			updateSplitInLayout(child, splitId, updater),
-		),
+		splitPercentage: (firstLeaves / (firstLeaves + secondLeaves)) * 100,
+		first: equalizeAllSplits(node.first),
+		second: equalizeAllSplits(node.second),
 	};
 }
 

--- a/packages/panes/src/index.ts
+++ b/packages/panes/src/index.ts
@@ -6,6 +6,7 @@ export type {
 } from "./core/store";
 export { createWorkspaceStore } from "./core/store";
 export type {
+	ContextMenuActionConfig,
 	PaneActionConfig,
 	PaneContext,
 	PaneDefinition,
@@ -18,7 +19,9 @@ export { Workspace } from "./react";
 export type {
 	LayoutNode,
 	Pane,
+	SplitBranch,
 	SplitDirection,
+	SplitPath,
 	SplitPosition,
 	Tab,
 	WorkspaceState,

--- a/packages/panes/src/react/components/Workspace/Workspace.tsx
+++ b/packages/panes/src/react/components/Workspace/Workspace.tsx
@@ -13,6 +13,7 @@ export function Workspace<TData>({
 	renderAddTabMenu,
 	onBeforeCloseTab,
 	paneActions,
+	contextMenuActions,
 }: WorkspaceProps<TData>) {
 	const tabs = useStore(store, (s) => s.tabs);
 	const activeTabId = useStore(store, (s) => s.activeTabId);
@@ -66,6 +67,7 @@ export function Workspace<TData>({
 					tab={activeTab}
 					registry={registry}
 					paneActions={paneActions}
+					contextMenuActions={contextMenuActions}
 				/>
 			) : (
 				<div className="flex min-h-0 min-w-0 flex-1 items-center justify-center text-sm text-muted-foreground">

--- a/packages/panes/src/react/components/Workspace/components/Tab/Tab.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/Tab.tsx
@@ -6,8 +6,13 @@ import {
 import { useRef } from "react";
 import type { StoreApi } from "zustand/vanilla";
 import type { WorkspaceStore } from "../../../../../core/store";
-import type { LayoutNode, Tab as TabType } from "../../../../../types";
 import type {
+	LayoutNode,
+	SplitPath,
+	Tab as TabType,
+} from "../../../../../types";
+import type {
+	ContextMenuActionConfig,
 	PaneActionConfig,
 	PaneRegistry,
 	RendererContext,
@@ -21,65 +26,75 @@ interface TabProps<TData> {
 	paneActions?:
 		| PaneActionConfig<TData>[]
 		| ((context: RendererContext<TData>) => PaneActionConfig<TData>[]);
-}
-
-function weightsToPercentages(weights: number[]): number[] {
-	const total = weights.reduce((sum, w) => sum + w, 0);
-	if (total === 0) return weights.map(() => 100 / weights.length);
-	return weights.map((w) => (w / total) * 100);
+	contextMenuActions?:
+		| ContextMenuActionConfig<TData>[]
+		| ((context: RendererContext<TData>) => ContextMenuActionConfig<TData>[]);
 }
 
 function SplitView<TData>({
 	store,
 	tab,
 	node,
+	path,
 	registry,
 	paneActions,
+	contextMenuActions,
 }: {
 	store: StoreApi<WorkspaceStore<TData>>;
 	tab: TabType<TData>;
 	node: Extract<LayoutNode, { type: "split" }>;
+	path: SplitPath;
 	registry: PaneRegistry<TData>;
 	paneActions?: TabProps<TData>["paneActions"];
+	contextMenuActions?: TabProps<TData>["contextMenuActions"];
 }) {
 	const groupRef = useRef<React.ComponentRef<typeof ResizablePanelGroup>>(null);
-	const percentages = weightsToPercentages(node.weights);
+	const firstSize = node.splitPercentage ?? 50;
+	const secondSize = 100 - firstSize;
 
 	return (
 		<ResizablePanelGroup
 			ref={groupRef}
 			direction={node.direction}
 			onLayout={(sizes) => {
-				store.getState().resizeSplit({
-					tabId: tab.id,
-					splitId: node.id,
-					weights: sizes,
-				});
+				if (sizes[0] != null) {
+					store.getState().resizeSplit({
+						tabId: tab.id,
+						path,
+						splitPercentage: sizes[0],
+					});
+				}
 			}}
 			onDoubleClick={(e) => {
 				e.stopPropagation();
-				const equal = node.children.map(() => 100 / node.children.length);
-				groupRef.current?.setLayout(equal);
+				groupRef.current?.setLayout([50, 50]);
 			}}
 		>
-			{node.children.map((child, index) => {
-				const key = child.type === "pane" ? child.paneId : child.id;
-				return (
-					<>
-						{index > 0 && <ResizableHandle key={`handle-${key}`} />}
-						<ResizablePanel key={key} defaultSize={percentages[index]}>
-							<LayoutNodeView
-								store={store}
-								tab={tab}
-								node={child}
-								registry={registry}
-								paneActions={paneActions}
-								parentDirection={node.direction}
-							/>
-						</ResizablePanel>
-					</>
-				);
-			})}
+			<ResizablePanel defaultSize={firstSize}>
+				<LayoutNodeView
+					store={store}
+					tab={tab}
+					node={node.first}
+					path={[...path, "first"]}
+					registry={registry}
+					paneActions={paneActions}
+					contextMenuActions={contextMenuActions}
+					parentDirection={node.direction}
+				/>
+			</ResizablePanel>
+			<ResizableHandle />
+			<ResizablePanel defaultSize={secondSize}>
+				<LayoutNodeView
+					store={store}
+					tab={tab}
+					node={node.second}
+					path={[...path, "second"]}
+					registry={registry}
+					paneActions={paneActions}
+					contextMenuActions={contextMenuActions}
+					parentDirection={node.direction}
+				/>
+			</ResizablePanel>
 		</ResizablePanelGroup>
 	);
 }
@@ -88,15 +103,19 @@ function LayoutNodeView<TData>({
 	store,
 	tab,
 	node,
+	path,
 	registry,
 	paneActions,
+	contextMenuActions,
 	parentDirection = null,
 }: {
 	store: StoreApi<WorkspaceStore<TData>>;
 	tab: TabType<TData>;
 	node: LayoutNode;
+	path: SplitPath;
 	registry: PaneRegistry<TData>;
 	paneActions?: TabProps<TData>["paneActions"];
+	contextMenuActions?: TabProps<TData>["contextMenuActions"];
 	parentDirection?: "horizontal" | "vertical" | null;
 }) {
 	if (node.type === "pane") {
@@ -111,6 +130,7 @@ function LayoutNodeView<TData>({
 				isActive={tab.activePaneId === pane.id}
 				registry={registry}
 				paneActions={paneActions}
+				contextMenuActions={contextMenuActions}
 				parentDirection={parentDirection}
 			/>
 		);
@@ -121,8 +141,10 @@ function LayoutNodeView<TData>({
 			store={store}
 			tab={tab}
 			node={node}
+			path={path}
 			registry={registry}
 			paneActions={paneActions}
+			contextMenuActions={contextMenuActions}
 		/>
 	);
 }
@@ -132,6 +154,7 @@ export function Tab<TData>({
 	tab,
 	registry,
 	paneActions,
+	contextMenuActions,
 }: TabProps<TData>) {
 	if (!tab.layout) {
 		return (
@@ -147,8 +170,10 @@ export function Tab<TData>({
 				store={store}
 				tab={tab}
 				node={tab.layout}
+				path={[]}
 				registry={registry}
 				paneActions={paneActions}
+				contextMenuActions={contextMenuActions}
 			/>
 		</div>
 	);

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
@@ -8,6 +8,7 @@ import type {
 	Tab,
 } from "../../../../../../../types";
 import type {
+	ContextMenuActionConfig,
 	PaneActionConfig,
 	PaneRegistry,
 	RendererContext,
@@ -15,6 +16,7 @@ import type {
 import { PaneHeaderActions } from "../../../../../PaneHeaderActions";
 import { DropZoneOverlay } from "./components/DropZoneOverlay";
 import { PaneContent } from "./components/PaneContent";
+import { PaneContextMenu } from "./components/PaneContextMenu";
 import { PANE_DRAG_TYPE, PaneHeader } from "./components/PaneHeader";
 
 interface PaneComponentProps<TData> {
@@ -27,19 +29,19 @@ interface PaneComponentProps<TData> {
 	paneActions?:
 		| PaneActionConfig<TData>[]
 		| ((context: RendererContext<TData>) => PaneActionConfig<TData>[]);
+	contextMenuActions?:
+		| ContextMenuActionConfig<TData>[]
+		| ((context: RendererContext<TData>) => ContextMenuActionConfig<TData>[]);
 }
 
-function resolveActions<TData>(
+function resolveActions<TData, TAction>(
 	config:
-		| PaneActionConfig<TData>[]
-		| ((
-				context: RendererContext<TData>,
-				defaults: PaneActionConfig<TData>[],
-		  ) => PaneActionConfig<TData>[])
+		| TAction[]
+		| ((context: RendererContext<TData>, defaults: TAction[]) => TAction[])
 		| undefined,
 	context: RendererContext<TData>,
-	defaults: PaneActionConfig<TData>[],
-): PaneActionConfig<TData>[] {
+	defaults: TAction[],
+): TAction[] {
 	if (!config) return defaults;
 	if (typeof config === "function") return config(context, defaults);
 	return config;
@@ -68,6 +70,7 @@ export function Pane<TData>({
 	registry,
 	parentDirection = null,
 	paneActions,
+	contextMenuActions,
 }: PaneComponentProps<TData>) {
 	const definition = registry[pane.kind];
 
@@ -143,6 +146,19 @@ export function Pane<TData>({
 		tabPosition,
 	]);
 
+	const resolvedContextMenuActions = useMemo(() => {
+		const workspaceResolved =
+			typeof contextMenuActions === "function"
+				? contextMenuActions(context)
+				: (contextMenuActions ?? []);
+
+		return resolveActions(
+			definition?.contextMenuActions,
+			context,
+			workspaceResolved,
+		);
+	}, [context, contextMenuActions, definition]);
+
 	const dropPositionRef = useRef<SplitPosition | null>(null);
 	const [dropPosition, setDropPosition] = useState<SplitPosition | null>(null);
 	const dropRef = useRef<HTMLDivElement>(null);
@@ -205,38 +221,40 @@ export function Pane<TData>({
 	const isDropTarget = isOver && canDrop;
 
 	return (
-		// biome-ignore lint/a11y/noStaticElementInteractions: clicking anywhere in a pane focuses it (standard IDE behavior)
-		<div
-			ref={setRefs}
-			className="relative flex h-full w-full flex-col overflow-hidden"
-			onMouseDown={context.actions.focus}
-		>
-			<PaneHeader
-				title={title}
-				icon={icon}
-				isActive={isActive}
-				titleContent={titleContent}
-				headerExtras={headerExtras}
-				toolbar={toolbar}
-				actionsContent={<context.components.PaneHeaderActions />}
-				paneId={pane.id}
-				onClick={
-					definition?.onHeaderClick
-						? () => definition.onHeaderClick?.(context)
-						: context.actions.pin
-				}
-				onMiddleClick={context.actions.close}
-			/>
-			<PaneContent>
-				{definition ? (
-					definition.renderPane(context)
-				) : (
-					<div className="flex flex-1 items-center justify-center text-xs text-muted-foreground">
-						Unknown pane kind: {pane.kind}
-					</div>
-				)}
-			</PaneContent>
-			{isDropTarget && <DropZoneOverlay position={dropPosition} />}
-		</div>
+		<PaneContextMenu actions={resolvedContextMenuActions} context={context}>
+			{/* biome-ignore lint/a11y/noStaticElementInteractions: clicking anywhere in a pane focuses it (standard IDE behavior) */}
+			<div
+				ref={setRefs}
+				className="relative flex h-full w-full flex-col overflow-hidden"
+				onMouseDown={context.actions.focus}
+			>
+				<PaneHeader
+					title={title}
+					icon={icon}
+					isActive={isActive}
+					titleContent={titleContent}
+					headerExtras={headerExtras}
+					toolbar={toolbar}
+					actionsContent={<context.components.PaneHeaderActions />}
+					paneId={pane.id}
+					onClick={
+						definition?.onHeaderClick
+							? () => definition.onHeaderClick?.(context)
+							: context.actions.pin
+					}
+					onMiddleClick={context.actions.close}
+				/>
+				<PaneContent>
+					{definition ? (
+						definition.renderPane(context)
+					) : (
+						<div className="flex flex-1 items-center justify-center text-xs text-muted-foreground">
+							Unknown pane kind: {pane.kind}
+						</div>
+					)}
+				</PaneContent>
+				{isDropTarget && <DropZoneOverlay position={dropPosition} />}
+			</div>
+		</PaneContextMenu>
 	);
 }

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneContextMenu/PaneContextMenu.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneContextMenu/PaneContextMenu.tsx
@@ -1,0 +1,98 @@
+import {
+	ContextMenu,
+	ContextMenuContent,
+	ContextMenuItem,
+	ContextMenuSeparator,
+	ContextMenuShortcut,
+	ContextMenuSub,
+	ContextMenuSubContent,
+	ContextMenuSubTrigger,
+	ContextMenuTrigger,
+} from "@superset/ui/context-menu";
+import type { ReactNode } from "react";
+import type {
+	ContextMenuActionConfig,
+	RendererContext,
+} from "../../../../../../../../types";
+
+interface PaneContextMenuProps<TData> {
+	children: ReactNode;
+	actions: ContextMenuActionConfig<TData>[];
+	context: RendererContext<TData>;
+}
+
+function ContextMenuItems<TData>({
+	actions,
+	context,
+}: {
+	actions: ContextMenuActionConfig<TData>[];
+	context: RendererContext<TData>;
+}) {
+	return (
+		<>
+			{actions.map((action) => {
+				if (action.type === "separator") {
+					return <ContextMenuSeparator key={action.key} />;
+				}
+
+				if (action.children) {
+					const childActions =
+						typeof action.children === "function"
+							? action.children(context)
+							: action.children;
+
+					return (
+						<ContextMenuSub key={action.key}>
+							<ContextMenuSubTrigger className="gap-2">
+								{action.icon}
+								{action.label}
+							</ContextMenuSubTrigger>
+							<ContextMenuSubContent>
+								<ContextMenuItems actions={childActions} context={context} />
+							</ContextMenuSubContent>
+						</ContextMenuSub>
+					);
+				}
+
+				const disabled =
+					typeof action.disabled === "function"
+						? action.disabled(context)
+						: action.disabled;
+
+				const shortcut = action.shortcut ?? action.hotkeyId;
+
+				return (
+					<ContextMenuItem
+						key={action.key}
+						disabled={disabled}
+						variant={action.variant}
+						onSelect={() => action.onSelect?.(context)}
+					>
+						{action.icon}
+						{action.label}
+						{shortcut && <ContextMenuShortcut>{shortcut}</ContextMenuShortcut>}
+					</ContextMenuItem>
+				);
+			})}
+		</>
+	);
+}
+
+export function PaneContextMenu<TData>({
+	children,
+	actions,
+	context,
+}: PaneContextMenuProps<TData>) {
+	if (actions.length === 0) {
+		return <>{children}</>;
+	}
+
+	return (
+		<ContextMenu>
+			<ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+			<ContextMenuContent>
+				<ContextMenuItems actions={actions} context={context} />
+			</ContextMenuContent>
+		</ContextMenu>
+	);
+}

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneContextMenu/index.ts
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneContextMenu/index.ts
@@ -1,0 +1,1 @@
+export { PaneContextMenu } from "./PaneContextMenu";

--- a/packages/panes/src/react/index.ts
+++ b/packages/panes/src/react/index.ts
@@ -1,5 +1,6 @@
 export { Workspace } from "./components/Workspace";
 export type {
+	ContextMenuActionConfig,
 	PaneActionConfig,
 	PaneContext,
 	PaneDefinition,

--- a/packages/panes/src/react/types.ts
+++ b/packages/panes/src/react/types.ts
@@ -10,6 +10,21 @@ export interface PaneActionConfig<TData> {
 	onClick: (context: RendererContext<TData>) => void;
 }
 
+export interface ContextMenuActionConfig<TData> {
+	key: string;
+	label?: string;
+	icon?: ReactNode;
+	hotkeyId?: string;
+	shortcut?: string;
+	onSelect?: (context: RendererContext<TData>) => void;
+	disabled?: boolean | ((context: RendererContext<TData>) => boolean);
+	variant?: "destructive";
+	type?: "item" | "separator";
+	children?:
+		| ContextMenuActionConfig<TData>[]
+		| ((context: RendererContext<TData>) => ContextMenuActionConfig<TData>[]);
+}
+
 export interface PaneContext<TData> extends Pane<TData> {
 	parentDirection: "horizontal" | "vertical" | null;
 }
@@ -56,6 +71,12 @@ export interface PaneDefinition<TData> {
 				context: RendererContext<TData>,
 				defaults: PaneActionConfig<TData>[],
 		  ) => PaneActionConfig<TData>[]);
+	contextMenuActions?:
+		| ContextMenuActionConfig<TData>[]
+		| ((
+				context: RendererContext<TData>,
+				defaults: ContextMenuActionConfig<TData>[],
+		  ) => ContextMenuActionConfig<TData>[]);
 }
 
 export type PaneRegistry<TData> = Record<string, PaneDefinition<TData>>;
@@ -75,4 +96,7 @@ export interface WorkspaceProps<TData> {
 	paneActions?:
 		| PaneActionConfig<TData>[]
 		| ((context: RendererContext<TData>) => PaneActionConfig<TData>[]);
+	contextMenuActions?:
+		| ContextMenuActionConfig<TData>[]
+		| ((context: RendererContext<TData>) => ContextMenuActionConfig<TData>[]);
 }

--- a/packages/panes/src/types.ts
+++ b/packages/panes/src/types.ts
@@ -2,14 +2,18 @@ export type SplitDirection = "horizontal" | "vertical";
 
 export type SplitPosition = "top" | "right" | "bottom" | "left";
 
+export type SplitBranch = "first" | "second";
+
+export type SplitPath = SplitBranch[];
+
 export type LayoutNode =
 	| { type: "pane"; paneId: string }
 	| {
 			type: "split";
-			id: string;
 			direction: SplitDirection;
-			children: LayoutNode[];
-			weights: number[];
+			first: LayoutNode;
+			second: LayoutNode;
+			splitPercentage?: number;
 	  };
 
 export interface Pane<TData> {


### PR DESCRIPTION
## Summary
- Add data-driven context menu system to `@superset/panes` — right-click any pane for split/move/close actions, terminal panes get copy/paste/clear/scroll
- Rewrite layout model from N-ary splits (`children[]`/`weights[]`) to strict binary tree (`first`/`second`/`splitPercentage`) matching react-mosaic's proven model
- Add `movePaneToTab`/`movePaneToNewTab` store actions for "Move to Tab" submenu
- Add terminal hotkeys (`CLEAR_TERMINAL`, `SCROLL_TO_BOTTOM`) and scroll-to-bottom button to v2 terminal pane

## Key changes

### Context menus
- `ContextMenuActionConfig<TData>` type with recursive children support for submenus
- Default actions (split h/v, split with chat/browser, equalize, move to tab, close) passed via `contextMenuActions` prop on `<Workspace>`
- Each pane kind customizes via `PaneDefinition.contextMenuActions` (same pattern as `paneActions` for header buttons)

### Binary tree layout (matching react-mosaic)
- `LayoutNode` split variant: `first`/`second`/`splitPercentage?` instead of `id`/`children[]`/`weights[]`
- Path-based addressing (`SplitPath = ("first" | "second")[]`) replaces split node IDs
- Pane removal = sibling promotion (only neighbor affected, not all siblings)
- Equalize = leaf-count-weighted `splitPercentage` recursively (all panes get equal visual space)

## Test plan
- [ ] Right-click terminal pane — Copy, Paste, Clear Terminal, Scroll to Bottom, Split ×4, Equalize, Move to Tab, Close Terminal
- [ ] Right-click chat/browser/file panes — appropriate context menu with correct close label
- [ ] Split panes horizontally and vertically — correct directions
- [ ] Close a pane — only the neighbor grows, rest of layout unaffected
- [ ] Equalize pane splits — all panes get equal visual space
- [ ] Move to Tab submenu — lists other tabs + New Tab
- [ ] Resize splits by dragging — sizes persist
- [ ] Terminal hotkeys (clear, scroll to bottom) work
- [ ] Scroll-to-bottom button appears when terminal scrolled up

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds data-driven pane context menus and rewrites `@superset/panes` layout to a react-mosaic–style binary tree with path-based resizing and equalize. Improves terminal UX with copy/paste/clear/scroll actions, hotkeys, and a scroll-to-bottom button.

- **New Features**
  - Right‑click menus on all panes with split/move/equalize/close; terminal adds Copy, Paste, Clear, Scroll to Bottom (Copy is disabled with no selection; shows shortcuts).
  - Workspace-level `contextMenuActions` and per‑pane `PaneDefinition.contextMenuActions` to customize menus; new `PaneContextMenu` component renders items, submenus, separators, and shortcuts via `ContextMenuActionConfig`.
  - “Move to Tab” submenu with `movePaneToTab` and `movePaneToNewTab` store actions.
  - New terminal hotkeys: CLEAR_TERMINAL, SCROLL_TO_BOTTOM; added scroll‑to‑bottom UI.

- **Migration**
  - Layout node shape changed from `children[]`/`weights[]`/`id` to `first`/`second`/`splitPercentage?`; split IDs removed in favor of `SplitPath`.
  - Store API updates:
    - `resizeSplit({ tabId, path, splitPercentage })` replaces `resizeSplit({ splitId, weights })`.
    - `equalizeSplit({ tabId, path })` and new `equalizeTab({ tabId })` replace split‑ID–based equalize.
    - New moves: `movePaneToTab({ paneId, targetTabId })`, `movePaneToNewTab({ paneId })`.
  - Utils renamed: `updateSplitInLayout` → `updateAtPath`; added `equalizeAllSplits`, `getNodeAtPath`, `positionToDirection`.
  - Behavior: pane close promotes its sibling only; splits always nest (no flattening).

<sup>Written for commit 6a5c7252b4c889643898274979b393eb4b3bb197. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal pane: copy, paste, clear, and scroll-to-bottom actions (menu items, shortcuts, and a scroll-to-bottom button).
  * Workspace-level, customizable context menus with per-pane overrides and nested submenu support.

* **Improvements**
  * Pane layout model updated to nested binary splits with path-based resizing and a tab-wide "equalize" action.
  * New actions to move panes between tabs or into a new tab.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->