### PR TITLE
feat(panes): prefer sibling pane when closing active pane

### DIFF
--- a/packages/panes/src/core/store/store.ts
+++ b/packages/panes/src/core/store/store.ts
@@ -11,6 +11,7 @@ import {
 	equalizeAllSplits,
 	findFirstPaneId,
 	findPaneInLayout,
+	findSiblingPaneId,
 	generateId,
 	positionToDirection,
 	removePaneFromLayout,
@@ -281,7 +282,8 @@ export function createWorkspaceStore<TData>(
 									panes: nextPanes,
 									activePaneId:
 										tab.activePaneId === args.paneId
-											? findFirstPaneId(nextLayout)
+											? (findSiblingPaneId(tab.layout, args.paneId) ??
+												findFirstPaneId(nextLayout))
 											: tab.activePaneId,
 								}
 							: t,
@@ -687,7 +689,8 @@ export function createWorkspaceStore<TData>(
 								panes: nextSourcePanes,
 								activePaneId:
 									t.activePaneId === args.sourcePaneId
-										? findFirstPaneId(nextSourceLayout)
+										? (findSiblingPaneId(sourceTab.layout, args.sourcePaneId) ??
+											findFirstPaneId(nextSourceLayout))
 										: t.activePaneId,
 							};
 						}
@@ -748,7 +751,8 @@ export function createWorkspaceStore<TData>(
 								panes: nextSourcePanes,
 								activePaneId:
 									t.activePaneId === args.paneId
-										? findFirstPaneId(nextSourceLayout)
+										? (findSiblingPaneId(sourceTab.layout, args.paneId) ??
+											findFirstPaneId(nextSourceLayout))
 										: t.activePaneId,
 							};
 						}
@@ -802,7 +806,8 @@ export function createWorkspaceStore<TData>(
 								panes: nextSourcePanes,
 								activePaneId:
 									t.activePaneId === args.paneId
-										? findFirstPaneId(nextSourceLayout)
+										? (findSiblingPaneId(sourceTab.layout, args.paneId) ??
+											findFirstPaneId(nextSourceLayout))
 										: t.activePaneId,
 							};
 						}

--- a/packages/panes/src/core/store/utils/index.ts
+++ b/packages/panes/src/core/store/utils/index.ts
@@ -2,6 +2,7 @@ export {
 	equalizeAllSplits,
 	findFirstPaneId,
 	findPaneInLayout,
+	findSiblingPaneId,
 	generateId,
 	getNodeAtPath,
 	getOtherBranch,

--- a/packages/panes/src/core/store/utils/utils.ts
+++ b/packages/panes/src/core/store/utils/utils.ts
@@ -23,6 +23,28 @@ export function findFirstPaneId(node: LayoutNode): string | null {
 	return findFirstPaneId(node.first) ?? findFirstPaneId(node.second);
 }
 
+export function findSiblingPaneId(
+	node: LayoutNode,
+	paneId: string,
+): string | null {
+	if (node.type === "pane") return null;
+
+	const inFirst = findPaneInLayout(node.first, paneId);
+	const inSecond = findPaneInLayout(node.second, paneId);
+
+	if (inFirst && !inSecond) {
+		// Target is in the first branch — sibling is the nearest pane in second
+		const deeper = findSiblingPaneId(node.first, paneId);
+		return deeper ?? findFirstPaneId(node.second);
+	}
+	if (inSecond && !inFirst) {
+		const deeper = findSiblingPaneId(node.second, paneId);
+		return deeper ?? findFirstPaneId(node.first);
+	}
+
+	return null;
+}
+
 export function removePaneFromLayout(
 	node: LayoutNode,
 	paneId: string,


### PR DESCRIPTION
## Summary
- When closing the active pane, activate its **peer/sibling** in the binary layout tree instead of always jumping to the first (top-left) pane
- Adds `findSiblingPaneId` utility that walks the original layout tree to locate the nearest pane in the sibling branch
- Applied consistently across `closePane`, `movePaneToSplit`, `movePaneToTab`, and `movePaneToNewTab`

## Test plan
- [x] All 71 existing panes tests pass
- [x] Lint + typecheck clean
- [ ] Manual: split 3+ panes, close the active one — verify the adjacent pane activates instead of the top-left

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closing an active pane now activates its nearest sibling in the layout tree instead of jumping to the first pane. The same focus behavior applies after moving panes.

- **New Features**
  - Added `findSiblingPaneId` to select the nearest sibling; falls back to `findFirstPaneId` if none.
  - Applied to `closePane`, `movePaneToSplit`, `movePaneToTab`, and `movePaneToNewTab` for consistent focus.

<sup>Written for commit 83f66215c98423182fdbc1379527ecce558f61f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved active pane selection when closing or moving panes. The system now intelligently selects an adjacent pane instead of always defaulting to the first available pane in the layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->