### PR TITLE
fix(desktop): resolve file icons from origin instead of href

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils/resolveFileIconAssetUrl.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils/resolveFileIconAssetUrl.ts
@@ -2,7 +2,7 @@ const FILE_ICONS_DIR = "file-icons";
 
 export function resolveFileIconAssetUrl(
 	iconName: string,
-	baseHref = globalThis.location?.href ?? "http://localhost/",
+	baseHref = globalThis.location?.origin ?? "http://localhost",
 ): string {
 	return new URL(`${FILE_ICONS_DIR}/${iconName}.svg`, baseHref).toString();
 }


### PR DESCRIPTION
## Summary
- File icons in the v2 workspace file viewer were broken because `resolveFileIconAssetUrl` used `location.href` as the base URL
- On nested routes like `/v2-workspace/$workspaceId/`, icon paths resolved to `/v2-workspace/abc123/file-icons/icon.svg` instead of `/file-icons/icon.svg`
- Fix: use `location.origin` so icons always resolve from the root

## Test plan
- [ ] Open a v2 workspace and verify file/folder icons render correctly in the sidebar
- [ ] Verify icons also work in the old workspace view

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix broken file and folder icons in the v2 workspace file viewer by resolving icon URLs from location.origin instead of location.href. Icons now always load from the root /file-icons path, avoiding broken paths on nested routes.

<sup>Written for commit f55bd45dc68d006ee38565f2a30355de8cd124a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file icon loading by improving URL path resolution for better compatibility across different page contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->