### PR TITLE
fix(desktop): center file status messages in v2 pane viewer

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/FilePane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/FilePane.tsx
@@ -54,7 +54,7 @@ export function FilePane({ context, workspaceId }: FilePaneProps) {
 
 	if (document.state.kind === "not-found") {
 		return (
-			<div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+			<div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
 				File not found
 			</div>
 		);
@@ -62,7 +62,7 @@ export function FilePane({ context, workspaceId }: FilePaneProps) {
 
 	if (document.state.kind === "too-large") {
 		return (
-			<div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+			<div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
 				File is too large to display
 			</div>
 		);
@@ -75,7 +75,7 @@ export function FilePane({ context, workspaceId }: FilePaneProps) {
 			);
 		}
 		return (
-			<div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+			<div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
 				Binary file — cannot display
 			</div>
 		);


### PR DESCRIPTION
## Summary
- "File not found", "File is too large", and "Binary file" messages were left-aligned instead of centered in the v2 workspace pane
- `PaneContent` is a row-direction flex container, so children need explicit `w-full` for `justify-center` to work
- Added `w-full` to all three placeholder states

## Test plan
- [ ] Open a file that doesn't exist (e.g., deleted file still in a tab) and verify "File not found" is centered
- [ ] Verify "File is too large" and "Binary file" messages are also centered

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centers file status messages in the v2 pane viewer so placeholders align properly across the full pane. Adds `w-full` to the not-found, too-large, and binary states so `justify-center` works in the row flex container.

<sup>Written for commit aa88678bfed0830ff2a1e79a3d747fc0c6d90900. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved styling for empty and error state displays in the file viewer, including not-found, oversized file, and binary file scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->