### PR TITLE
fix(desktop): revert broken file icon origin fix + bundle all icon sources

### DIFF
--- a/apps/desktop/scripts/generate-file-icons.ts
+++ b/apps/desktop/scripts/generate-file-icons.ts
@@ -33,15 +33,24 @@ function run() {
 	addIcon(manifest.file);
 	addIcon(manifest.folder);
 	addIcon(manifest.folderExpanded);
+	addIcon(manifest.rootFolder);
+	addIcon(manifest.rootFolderExpanded);
 
 	// File mappings
 	for (const icon of Object.values(manifest.fileNames ?? {})) addIcon(icon);
 	for (const icon of Object.values(manifest.fileExtensions ?? {}))
 		addIcon(icon);
 
+	// Language ID mappings (VS Code languageId → icon, not covered by extensions)
+	for (const icon of Object.values(manifest.languageIds ?? {})) addIcon(icon);
+
 	// Folder mappings
 	for (const icon of Object.values(manifest.folderNames ?? {})) addIcon(icon);
 	for (const icon of Object.values(manifest.folderNamesExpanded ?? {}))
+		addIcon(icon);
+	for (const icon of Object.values(manifest.rootFolderNames ?? {}))
+		addIcon(icon);
+	for (const icon of Object.values(manifest.rootFolderNamesExpanded ?? {}))
 		addIcon(icon);
 
 	// Build condensed manifest
@@ -56,13 +65,18 @@ function run() {
 	};
 
 	// material-icon-theme relies on VS Code's languageIds for base extensions.
-	// Since Electron has no languageId system, add them explicitly.
-	const baseExtensionDefaults: Record<string, string> = {
+	// Since Electron has no languageId system, fold languageIds where the
+	// language name matches a common file extension so they resolve at runtime.
+	const languageIdExtensionMap: Record<string, string> = {
 		ts: "typescript",
 		js: "javascript",
+		php: "php",
+		tex: "tex",
+		matlab: "matlab",
+		diff: "diff",
 	};
 
-	for (const [ext, icon] of Object.entries(baseExtensionDefaults)) {
+	for (const [ext, icon] of Object.entries(languageIdExtensionMap)) {
 		if (!condensed.fileExtensions[ext]) {
 			condensed.fileExtensions[ext] = icon;
 			referencedIcons.add(icon);

--- a/apps/desktop/scripts/generate-file-icons.ts
+++ b/apps/desktop/scripts/generate-file-icons.ts
@@ -72,8 +72,9 @@ function run() {
 		js: "javascript",
 		php: "php",
 		tex: "tex",
-		matlab: "matlab",
+		m: "matlab",
 		diff: "diff",
+		patch: "diff",
 	};
 
 	for (const [ext, icon] of Object.entries(languageIdExtensionMap)) {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils/resolveFileIconAssetUrl.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils/resolveFileIconAssetUrl.ts
@@ -2,7 +2,7 @@ const FILE_ICONS_DIR = "file-icons";
 
 export function resolveFileIconAssetUrl(
 	iconName: string,
-	baseHref = globalThis.location?.origin ?? "http://localhost",
+	baseHref = globalThis.location?.href ?? "http://localhost/",
 ): string {
 	return new URL(`${FILE_ICONS_DIR}/${iconName}.svg`, baseHref).toString();
 }


### PR DESCRIPTION
## Summary
- Reverts #3199 (`resolve file icons from origin instead of href`) which broke production — `file://` URLs have a `null` origin, causing `new URL()` to throw. The original `href`-based resolution works correctly with hash routing.
- Fixes the file icon generation script to collect icons from **all** manifest sources: `languageIds` (12 previously missing icons like `angular`, `php`, `matlab`, `diff`), `rootFolder`/`rootFolderExpanded`, and `rootFolderNames`/`rootFolderNamesExpanded`.
- Expands the languageId-to-extension map (`php`, `tex`, `matlab`, `diff`) so these extensions resolve at runtime without VS Code's language detection.

Result: 1055 → 1067 SVGs bundled, 1148 → 1152 extension mappings.

## Test plan
- [ ] Run `bun dev` in `apps/desktop` and verify file icons render in the files sidebar
- [ ] Check that `.php`, `.tex`, `.m` (matlab), `.diff` files show correct icons
- [ ] Verify icons still work in packaged production build (`file://` protocol)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes file icon URL resolution in the desktop app by reverting to `href`, so icons load in `file://` builds. Also bundles icons from all manifest sources and expands extension mappings (including `.m` and `.patch`) to cover missing icons.

- **Bug Fixes**
  - Revert origin-based URL building; `file://` has a null origin and broke `new URL`.
  - Use `location.href` (with trailing slash) as the base for icon URLs.

- **New Features**
  - Collect icons from `languageIds`, `rootFolder`/`rootFolderExpanded`, and `rootFolderNames`/`rootFolderNamesExpanded`.
  - Add languageId-to-extension mappings for `php`, `tex`, `matlab` (`.m`), and `diff` (`.patch`).
  - Result: 1067 SVGs bundled (was 1055); 1152 extension mappings (was 1148).

<sup>Written for commit fd50607a98d3301eead8168e6f5fb5e7dd523cf9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded file icon coverage with new icons for root folders (both collapsed and expanded states) and additional programming languages (PHP, TeX, MATLAB, Diff)
  * Enhanced VS Code language identifiers integration for more comprehensive file type icon support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->