### PR TITLE
ci: default triage workflow PRs to draft

### DIFF
--- a/.github/prompts/triage-issue.md
+++ b/.github/prompts/triage-issue.md
@@ -22,8 +22,9 @@ You are triaging GitHub issue `$ISSUE_NUMBER`. Your goal is to:
    - Run any nearby targeted tests needed to validate the fix.
    - If a safe fix is not clear, keep this as reproduction-only and continue to step 6A.
 
-6. **Open exactly one PR** — Run `bun run lint:fix`, then commit, push, and create a PR:
-   - **6A: Reproduction-only PR (reproducible but not solved)**
+6. **Open exactly one PR** — Run `bun run lint:fix`, then commit, push, and create a PR.
+   **Default to draft** (`gh pr create --draft`) unless the issue is high priority (labeled `priority: high` or `priority: critical`, or the issue describes data loss, security, or a production outage) **and** you are highly confident in the fix (clear root cause, minimal scoped change, all relevant tests pass). Only in that case, create as ready for review (omit `--draft`).
+   - **6A: Reproduction-only PR (reproducible but not solved)** — always draft.
      - Title: `test: reproduce #$ISSUE_NUMBER — <short bug description>`
      - Body should include:
        - What the bug is (in your own words, based on the issue)


### PR DESCRIPTION
## Summary
- Triage workflow now creates **draft PRs by default** to reduce review noise
- Reproduction-only PRs (6A) are always draft
- Solve PRs (6B) are marked ready for review only when the issue is **high priority** (`priority: high`/`priority: critical`, data loss, security, or production outage) **and** the fix is **high confidence** (clear root cause, minimal change, all tests pass)

## Test plan
- [ ] Trigger triage workflow on a normal issue — PR should be created as draft
- [ ] Trigger triage workflow on a `priority: critical` issue with a clear fix — PR should be created as ready for review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default triage PRs to draft to cut noisy review requests; only create ready-for-review PRs for high-priority issues with high-confidence fixes.

- **Refactors**
  - Updated `.github/prompts/triage-issue.md` to use `gh pr create --draft` by default.
  - Reproduction-only PRs (6A) are always draft.
  - Omit `--draft` only when the issue is labeled `priority: high`/`priority: critical` (or involves data loss, security, or production outage) and the fix is clearly scoped with passing tests.

<sup>Written for commit 5e95d754bd385d7cb46d7a671021d4a5d35973f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

