### PR TITLE
feat(desktop): drag-and-drop reordering for v2 sidebar

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
@@ -167,13 +167,7 @@ export function DashboardSidebar({
 					</SortableContext>
 
 					{createPortal(
-						<DragOverlay
-							dropAnimation={{
-								sideEffects: defaultDropAnimationSideEffects({
-									styles: { active: { opacity: "0.5" } },
-								}),
-							}}
-						>
+						<DragOverlay dropAnimation={null}>
 							{activeProject && (
 								<div className="bg-background shadow-lg border-b border-border">
 									<DashboardSidebarProjectSection

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
@@ -3,7 +3,6 @@ import {
 	DndContext,
 	type DragEndEvent,
 	DragOverlay,
-	defaultDropAnimationSideEffects,
 	KeyboardSensor,
 	MeasuringStrategy,
 	MouseSensor,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
@@ -1,10 +1,82 @@
+import {
+	closestCenter,
+	DndContext,
+	type DragEndEvent,
+	DragOverlay,
+	defaultDropAnimationSideEffects,
+	KeyboardSensor,
+	MeasuringStrategy,
+	MouseSensor,
+	TouchSensor,
+	useSensor,
+	useSensors,
+} from "@dnd-kit/core";
+import {
+	arrayMove,
+	SortableContext,
+	sortableKeyboardCoordinates,
+	useSortable,
+	verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { DashboardSidebarHeader } from "./components/DashboardSidebarHeader";
 import { DashboardSidebarProjectSection } from "./components/DashboardSidebarProjectSection";
 import { useDashboardSidebarData } from "./hooks/useDashboardSidebarData";
 import { useDashboardSidebarShortcuts } from "./hooks/useDashboardSidebarShortcuts";
+import type { DashboardSidebarProject } from "./types";
 
 interface DashboardSidebarProps {
 	isCollapsed?: boolean;
+}
+
+function SortableProjectWrapper({
+	project,
+	isCollapsed,
+	isDraggingProject,
+	workspaceShortcutLabels,
+	onWorkspaceHover,
+	onToggleCollapse,
+}: {
+	project: DashboardSidebarProject;
+	isCollapsed: boolean;
+	isDraggingProject: boolean;
+	workspaceShortcutLabels: Map<string, string>;
+	onWorkspaceHover: (workspaceId: string) => void | Promise<void>;
+	onToggleCollapse: (projectId: string) => void;
+}) {
+	const {
+		attributes,
+		listeners,
+		setNodeRef,
+		transform,
+		transition,
+		isDragging,
+	} = useSortable({ id: project.id });
+
+	return (
+		<div
+			ref={setNodeRef}
+			style={{
+				transform: CSS.Translate.toString(transform),
+				transition,
+				opacity: isDragging ? 0.5 : undefined,
+			}}
+		>
+			<DashboardSidebarProjectSection
+				project={project}
+				isSidebarCollapsed={isCollapsed}
+				isDraggingProject={isDraggingProject}
+				workspaceShortcutLabels={workspaceShortcutLabels}
+				onWorkspaceHover={onWorkspaceHover}
+				onToggleCollapse={onToggleCollapse}
+				dragHandleListeners={listeners}
+				dragHandleAttributes={attributes}
+			/>
+		</div>
+	);
 }
 
 export function DashboardSidebar({
@@ -13,22 +85,111 @@ export function DashboardSidebar({
 	const { groups, refreshWorkspacePullRequest, toggleProjectCollapsed } =
 		useDashboardSidebarData();
 	const workspaceShortcutLabels = useDashboardSidebarShortcuts(groups);
+	const { reorderProjects } = useDashboardSidebarState();
+
+	const sensors = useSensors(
+		useSensor(MouseSensor, { activationConstraint: { distance: 8 } }),
+		useSensor(TouchSensor, {
+			activationConstraint: { delay: 200, tolerance: 5 },
+		}),
+		useSensor(KeyboardSensor, {
+			coordinateGetter: sortableKeyboardCoordinates,
+		}),
+	);
+
+	const [activeProject, setActiveProject] =
+		useState<DashboardSidebarProject | null>(null);
+
+	// Local project order — syncs from groups, updated on drag end
+	const [projectOrder, setProjectOrder] = useState(() =>
+		groups.map((p) => p.id),
+	);
+	useEffect(() => {
+		setProjectOrder(groups.map((p) => p.id));
+	}, [groups]);
+
+	const orderedGroups = useMemo(() => {
+		const byId = new Map(groups.map((g) => [g.id, g]));
+		return projectOrder
+			.map((id) => byId.get(id))
+			.filter((g): g is DashboardSidebarProject => g != null);
+	}, [groups, projectOrder]);
+
+	const handleDragEnd = useCallback(
+		({ active, over }: DragEndEvent) => {
+			if (over && active.id !== over.id) {
+				const oldIndex = projectOrder.indexOf(String(active.id));
+				const newIndex = projectOrder.indexOf(String(over.id));
+				if (oldIndex !== -1 && newIndex !== -1) {
+					const reordered = arrayMove(projectOrder, oldIndex, newIndex);
+					setProjectOrder(reordered);
+					reorderProjects(reordered);
+				}
+			}
+			setActiveProject(null);
+		},
+		[projectOrder, reorderProjects],
+	);
 
 	return (
 		<div className="flex h-full flex-col border-r border-border bg-muted/45 dark:bg-muted/35">
 			<DashboardSidebarHeader isCollapsed={isCollapsed} />
 
 			<div className="flex-1 overflow-y-auto hide-scrollbar">
-				{groups.map((project) => (
-					<DashboardSidebarProjectSection
-						key={project.id}
-						project={project}
-						isSidebarCollapsed={isCollapsed}
-						workspaceShortcutLabels={workspaceShortcutLabels}
-						onWorkspaceHover={refreshWorkspacePullRequest}
-						onToggleCollapse={toggleProjectCollapsed}
-					/>
-				))}
+				<DndContext
+					sensors={sensors}
+					collisionDetection={closestCenter}
+					measuring={{
+						droppable: { strategy: MeasuringStrategy.Always },
+					}}
+					onDragStart={({ active }) => {
+						const project = groups.find((p) => p.id === active.id);
+						setActiveProject(project ?? null);
+					}}
+					onDragEnd={handleDragEnd}
+					onDragCancel={() => setActiveProject(null)}
+				>
+					<SortableContext
+						items={projectOrder}
+						strategy={verticalListSortingStrategy}
+					>
+						{orderedGroups.map((project) => (
+							<SortableProjectWrapper
+								key={project.id}
+								project={project}
+								isCollapsed={isCollapsed}
+								isDraggingProject={activeProject != null}
+								workspaceShortcutLabels={workspaceShortcutLabels}
+								onWorkspaceHover={refreshWorkspacePullRequest}
+								onToggleCollapse={toggleProjectCollapsed}
+							/>
+						))}
+					</SortableContext>
+
+					{createPortal(
+						<DragOverlay
+							dropAnimation={{
+								sideEffects: defaultDropAnimationSideEffects({
+									styles: { active: { opacity: "0.5" } },
+								}),
+							}}
+						>
+							{activeProject && (
+								<div className="bg-background shadow-lg border-b border-border">
+									<DashboardSidebarProjectSection
+										project={activeProject}
+										isSidebarCollapsed={isCollapsed}
+										isDraggingProject
+										workspaceShortcutLabels={workspaceShortcutLabels}
+										onWorkspaceHover={() => {}}
+										onToggleCollapse={() => {}}
+									/>
+								</div>
+							)}
+						</DragOverlay>,
+						document.body,
+					)}
+				</DndContext>
 			</div>
 		</div>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/DashboardSidebarProjectSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/DashboardSidebarProjectSection.tsx
@@ -26,7 +26,7 @@ export function DashboardSidebarProjectSection({
 	onWorkspaceHover,
 	onToggleCollapse,
 }: DashboardSidebarProjectSectionProps) {
-	const allSections = useMemo(
+	const _allSections = useMemo(
 		() => getProjectChildrenSections(project.children),
 		[project.children],
 	);
@@ -108,9 +108,9 @@ export function DashboardSidebarProjectSection({
 			</DashboardSidebarProjectContextMenu>
 
 			<DashboardSidebarExpandedProjectContent
+				projectId={project.id}
 				isCollapsed={project.isCollapsed}
 				projectChildren={project.children}
-				allSections={allSections}
 				workspaceShortcutLabels={workspaceShortcutLabels}
 				onWorkspaceHover={onWorkspaceHover}
 				onDeleteSection={deleteSection}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/DashboardSidebarProjectSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/DashboardSidebarProjectSection.tsx
@@ -1,10 +1,12 @@
+import type {
+	DraggableAttributes,
+	DraggableSyntheticListeners,
+} from "@dnd-kit/core";
 import { cn } from "@superset/ui/utils";
+import { AnimatePresence, motion } from "framer-motion";
 import { useMemo } from "react";
 import type { DashboardSidebarProject } from "../../types";
-import {
-	getProjectChildrenSections,
-	getProjectChildrenWorkspaces,
-} from "../../utils/projectChildren";
+import { getProjectChildrenWorkspaces } from "../../utils/projectChildren";
 import { DashboardSidebarCollapsedProjectContent } from "./components/DashboardSidebarCollapsedProjectContent";
 import { DashboardSidebarExpandedProjectContent } from "./components/DashboardSidebarExpandedProjectContent";
 import { DashboardSidebarProjectContextMenu } from "./components/DashboardSidebarProjectContextMenu";
@@ -14,23 +16,24 @@ import { useDashboardSidebarProjectSectionActions } from "./hooks/useDashboardSi
 interface DashboardSidebarProjectSectionProps {
 	project: DashboardSidebarProject;
 	isSidebarCollapsed?: boolean;
+	isDraggingProject?: boolean;
 	workspaceShortcutLabels: Map<string, string>;
 	onWorkspaceHover: (workspaceId: string) => void | Promise<void>;
 	onToggleCollapse: (projectId: string) => void;
+	dragHandleListeners?: DraggableSyntheticListeners;
+	dragHandleAttributes?: DraggableAttributes;
 }
 
 export function DashboardSidebarProjectSection({
 	project,
 	isSidebarCollapsed = false,
+	isDraggingProject = false,
 	workspaceShortcutLabels,
 	onWorkspaceHover,
 	onToggleCollapse,
+	dragHandleListeners,
+	dragHandleAttributes,
 }: DashboardSidebarProjectSectionProps) {
-	const _allSections = useMemo(
-		() => getProjectChildrenSections(project.children),
-		[project.children],
-	);
-
 	const flattenedCollapsedWorkspaces = useMemo(
 		() => getProjectChildrenWorkspaces(project.children),
 		[project.children],
@@ -104,19 +107,33 @@ export function DashboardSidebarProjectSection({
 					onStartRename={startRename}
 					onToggleCollapse={() => onToggleCollapse(project.id)}
 					onNewWorkspace={handleNewWorkspace}
+					{...(dragHandleAttributes ?? {})}
+					{...(dragHandleListeners ?? {})}
 				/>
 			</DashboardSidebarProjectContextMenu>
 
-			<DashboardSidebarExpandedProjectContent
-				projectId={project.id}
-				isCollapsed={project.isCollapsed}
-				projectChildren={project.children}
-				workspaceShortcutLabels={workspaceShortcutLabels}
-				onWorkspaceHover={onWorkspaceHover}
-				onDeleteSection={deleteSection}
-				onRenameSection={renameSection}
-				onToggleSectionCollapse={toggleSectionCollapsed}
-			/>
+			<AnimatePresence initial={false}>
+				{!isDraggingProject && (
+					<motion.div
+						initial={{ height: 0, opacity: 0 }}
+						animate={{ height: "auto", opacity: 1 }}
+						exit={{ height: 0, opacity: 0 }}
+						transition={{ duration: 0.15, ease: "easeOut" }}
+						className="overflow-hidden"
+					>
+						<DashboardSidebarExpandedProjectContent
+							projectId={project.id}
+							isCollapsed={project.isCollapsed}
+							projectChildren={project.children}
+							workspaceShortcutLabels={workspaceShortcutLabels}
+							onWorkspaceHover={onWorkspaceHover}
+							onDeleteSection={deleteSection}
+							onRenameSection={renameSection}
+							onToggleSectionCollapse={toggleSectionCollapsed}
+						/>
+					</motion.div>
+				)}
+			</AnimatePresence>
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
@@ -92,23 +92,36 @@ export function DashboardSidebarExpandedProjectContent({
 										);
 									}
 
-									// During section drag, hide workspaces that belong to a section
-									if (activeType === "section" && groupInfo.has(parsed.realId))
-										return null;
-
 									const workspace = workspacesById.get(parsed.realId);
 									if (!workspace) return null;
 									const group = groupInfo.get(parsed.realId);
+									const isInSection = groupInfo.has(parsed.realId);
+									const hiddenBySectionDrag =
+										activeType === "section" && isInSection;
 
 									return (
-										<SortableWorkspaceItem
-											key={String(id)}
-											sortableId={String(id)}
-											workspace={workspace}
-											accentColor={group?.color}
-											onHoverCardOpen={() => onWorkspaceHover(parsed.realId)}
-											shortcutLabel={workspaceShortcutLabels.get(parsed.realId)}
-										/>
+										<AnimatePresence key={String(id)} initial={false}>
+											{!hiddenBySectionDrag && (
+												<motion.div
+													initial={{ height: 0, opacity: 0 }}
+													animate={{ height: "auto", opacity: 1 }}
+													exit={{ height: 0, opacity: 0 }}
+													transition={{ duration: 0.15, ease: "easeOut" }}
+												>
+													<SortableWorkspaceItem
+														sortableId={String(id)}
+														workspace={workspace}
+														accentColor={group?.color}
+														onHoverCardOpen={() =>
+															onWorkspaceHover(parsed.realId)
+														}
+														shortcutLabel={workspaceShortcutLabels.get(
+															parsed.realId,
+														)}
+													/>
+												</motion.div>
+											)}
+										</AnimatePresence>
 									);
 								})}
 							</SortableContext>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
@@ -1,8 +1,4 @@
-import {
-	DndContext,
-	DragOverlay,
-	defaultDropAnimationSideEffects,
-} from "@dnd-kit/core";
+import { DndContext, DragOverlay } from "@dnd-kit/core";
 import {
 	SortableContext,
 	verticalListSortingStrategy,
@@ -46,6 +42,7 @@ export function DashboardSidebarExpandedProjectContent({
 		activeId,
 		activeType,
 		activeItem,
+		predictedColor,
 		groupInfo,
 		workspacesById,
 		sectionsById,
@@ -111,7 +108,9 @@ export function DashboardSidebarExpandedProjectContent({
 													<SortableWorkspaceItem
 														sortableId={String(id)}
 														workspace={workspace}
-														accentColor={group?.color}
+														accentColor={
+															activeId === id ? predictedColor : group?.color
+														}
 														onHoverCardOpen={() =>
 															onWorkspaceHover(parsed.realId)
 														}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
@@ -96,7 +96,8 @@ export function DashboardSidebarExpandedProjectContent({
 									if (!workspace) return null;
 									const group = groupInfo.get(parsed.realId);
 									const isInSection = groupInfo.has(parsed.realId);
-									const hiddenBySectionDrag = activeType === "section";
+									const hiddenBySectionDrag =
+										activeType === "section" && isInSection;
 
 									return (
 										<AnimatePresence key={String(id)} initial={false}>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
@@ -127,13 +127,7 @@ export function DashboardSidebarExpandedProjectContent({
 							</SortableContext>
 
 							{createPortal(
-								<DragOverlay
-									dropAnimation={{
-										sideEffects: defaultDropAnimationSideEffects({
-											styles: { active: { opacity: "0.5" } },
-										}),
-									}}
-								>
+								<DragOverlay dropAnimation={null}>
 									{activeId ? (
 										<SidebarDragOverlay activeItem={activeItem} />
 									) : null}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
@@ -44,6 +44,7 @@ export function DashboardSidebarExpandedProjectContent({
 		activeItem,
 		predictedColor,
 		groupInfo,
+		collapsedSectionIds,
 		workspacesById,
 		sectionsById,
 		handlers,
@@ -92,13 +93,16 @@ export function DashboardSidebarExpandedProjectContent({
 									const workspace = workspacesById.get(parsed.realId);
 									if (!workspace) return null;
 									const group = groupInfo.get(parsed.realId);
-									const isInSection = groupInfo.has(parsed.realId);
-									const hiddenBySectionDrag =
-										activeType === "section" && isInSection;
+									const isInSection = !!group;
+									const isInCollapsedSection =
+										isInSection && collapsedSectionIds.has(group.sectionId);
+									const hidden =
+										isInCollapsedSection ||
+										(activeType === "section" && isInSection);
 
 									return (
 										<AnimatePresence key={String(id)} initial={false}>
-											{!hiddenBySectionDrag && (
+											{!hidden && (
 												<motion.div
 													initial={{ height: 0, opacity: 0 }}
 													animate={{ height: "auto", opacity: 1 }}
@@ -111,6 +115,7 @@ export function DashboardSidebarExpandedProjectContent({
 														accentColor={
 															activeId === id ? predictedColor : group?.color
 														}
+														isInSection={groupInfo.has(parsed.realId)}
 														onHoverCardOpen={() =>
 															onWorkspaceHover(parsed.realId)
 														}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
@@ -96,8 +96,7 @@ export function DashboardSidebarExpandedProjectContent({
 									if (!workspace) return null;
 									const group = groupInfo.get(parsed.realId);
 									const isInSection = groupInfo.has(parsed.realId);
-									const hiddenBySectionDrag =
-										activeType === "section" && isInSection;
+									const hiddenBySectionDrag = activeType === "section";
 
 									return (
 										<AnimatePresence key={String(id)} initial={false}>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
@@ -1,12 +1,25 @@
+import {
+	DndContext,
+	DragOverlay,
+	defaultDropAnimationSideEffects,
+} from "@dnd-kit/core";
+import {
+	SortableContext,
+	verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
 import { AnimatePresence, motion } from "framer-motion";
+import { createPortal } from "react-dom";
+import { useSidebarDnd } from "../../../../hooks/useSidebarDnd";
+import { parseId } from "../../../../hooks/useSidebarDnd/useSidebarDnd";
 import type { DashboardSidebarProjectChild } from "../../../../types";
-import { DashboardSidebarSection as DashboardSidebarSectionComponent } from "../../../DashboardSidebarSection";
-import { DashboardSidebarWorkspaceItem } from "../../../DashboardSidebarWorkspaceItem";
+import { SidebarDragOverlay } from "../../../SidebarDragOverlay";
+import { SortableSectionHeader } from "../../../SortableSectionHeader";
+import { SortableWorkspaceItem } from "../../../SortableWorkspaceItem";
 
 interface DashboardSidebarExpandedProjectContentProps {
+	projectId: string;
 	isCollapsed: boolean;
 	projectChildren: DashboardSidebarProjectChild[];
-	allSections: Array<{ id: string; name: string }>;
 	workspaceShortcutLabels: Map<string, string>;
 	onWorkspaceHover: (workspaceId: string) => void | Promise<void>;
 	onDeleteSection: (sectionId: string) => void;
@@ -15,15 +28,28 @@ interface DashboardSidebarExpandedProjectContentProps {
 }
 
 export function DashboardSidebarExpandedProjectContent({
+	projectId,
 	isCollapsed,
 	projectChildren,
-	allSections,
 	workspaceShortcutLabels,
 	onWorkspaceHover,
 	onDeleteSection,
 	onRenameSection,
 	onToggleSectionCollapse,
 }: DashboardSidebarExpandedProjectContentProps) {
+	const {
+		sensors,
+		measuring,
+		collisionDetection,
+		flatItems,
+		activeId,
+		activeItem,
+		groupInfo,
+		workspacesById,
+		sectionsById,
+		handlers,
+	} = useSidebarDnd({ projectId, projectChildren });
+
 	return (
 		<AnimatePresence initial={false}>
 			{!isCollapsed && (
@@ -35,30 +61,67 @@ export function DashboardSidebarExpandedProjectContent({
 					className="overflow-hidden"
 				>
 					<div className="pb-1">
-						{projectChildren.map((child) =>
-							child.type === "workspace" ? (
-								<DashboardSidebarWorkspaceItem
-									key={child.workspace.id}
-									workspace={child.workspace}
-									onHoverCardOpen={() => onWorkspaceHover(child.workspace.id)}
-									shortcutLabel={workspaceShortcutLabels.get(
-										child.workspace.id,
-									)}
-								/>
-							) : (
-								<DashboardSidebarSectionComponent
-									key={child.section.id}
-									projectId={child.section.projectId}
-									section={child.section}
-									allSections={allSections}
-									workspaceShortcutLabels={workspaceShortcutLabels}
-									onWorkspaceHover={onWorkspaceHover}
-									onDelete={onDeleteSection}
-									onRename={onRenameSection}
-									onToggleCollapse={onToggleSectionCollapse}
-								/>
-							),
-						)}
+						<DndContext
+							sensors={sensors}
+							collisionDetection={collisionDetection}
+							measuring={measuring}
+							{...handlers}
+						>
+							<SortableContext
+								items={flatItems}
+								strategy={verticalListSortingStrategy}
+							>
+								{flatItems.map((id) => {
+									const parsed = parseId(id);
+									if (!parsed) return null;
+
+									if (parsed.type === "section") {
+										const section = sectionsById.get(parsed.realId);
+										if (!section) return null;
+										return (
+											<SortableSectionHeader
+												key={String(id)}
+												sortableId={String(id)}
+												section={section}
+												onDelete={onDeleteSection}
+												onRename={onRenameSection}
+												onToggleCollapse={onToggleSectionCollapse}
+											/>
+										);
+									}
+
+									const workspace = workspacesById.get(parsed.realId);
+									if (!workspace) return null;
+									const group = groupInfo.get(parsed.realId);
+
+									return (
+										<SortableWorkspaceItem
+											key={String(id)}
+											sortableId={String(id)}
+											workspace={workspace}
+											accentColor={group?.color}
+											onHoverCardOpen={() => onWorkspaceHover(parsed.realId)}
+											shortcutLabel={workspaceShortcutLabels.get(parsed.realId)}
+										/>
+									);
+								})}
+							</SortableContext>
+
+							{createPortal(
+								<DragOverlay
+									dropAnimation={{
+										sideEffects: defaultDropAnimationSideEffects({
+											styles: { active: { opacity: "0.5" } },
+										}),
+									}}
+								>
+									{activeId ? (
+										<SidebarDragOverlay activeItem={activeItem} />
+									) : null}
+								</DragOverlay>,
+								document.body,
+							)}
+						</DndContext>
 					</div>
 				</motion.div>
 			)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
@@ -42,7 +42,9 @@ export function DashboardSidebarExpandedProjectContent({
 		measuring,
 		collisionDetection,
 		flatItems,
+		sortableItems,
 		activeId,
+		activeType,
 		activeItem,
 		groupInfo,
 		workspacesById,
@@ -68,7 +70,7 @@ export function DashboardSidebarExpandedProjectContent({
 							{...handlers}
 						>
 							<SortableContext
-								items={flatItems}
+								items={sortableItems}
 								strategy={verticalListSortingStrategy}
 							>
 								{flatItems.map((id) => {
@@ -89,6 +91,10 @@ export function DashboardSidebarExpandedProjectContent({
 											/>
 										);
 									}
+
+									// During section drag, hide workspaces that belong to a section
+									if (activeType === "section" && groupInfo.has(parsed.realId))
+										return null;
 
 									const workspace = workspacesById.get(parsed.realId);
 									if (!workspace) return null;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
@@ -90,25 +90,24 @@ export const DashboardSidebarSectionHeader = forwardRef<
 					<span className="shrink-0 truncate">{section.name}</span>
 				)}
 
-				{isRenaming ? (
-					<div className="h-px w-4 bg-border shrink-0" />
-				) : null}
-				<div className={cn("grid shrink-0 items-center [&>*]:col-start-1 [&>*]:row-start-1", isRenaming && "hidden")}>
-					<span className="pointer-events-none text-[10px] font-normal tabular-nums transition-opacity duration-150 group-hover:opacity-0">
-						({section.workspaces.length})
-					</span>
-					<button
-						type="button"
-						onClick={(event) => {
-							event.stopPropagation();
-							onStartRename();
-						}}
-						className="flex items-center justify-center opacity-0 text-muted-foreground transition-[opacity,color] duration-150 group-hover:opacity-100 hover:text-foreground"
-						aria-label="Rename section"
-					>
-						<LuPencil className="size-3.5" />
-					</button>
-				</div>
+				{!isRenaming && (
+					<div className="grid shrink-0 items-center [&>*]:col-start-1 [&>*]:row-start-1">
+						<span className="pointer-events-none text-[10px] font-normal tabular-nums transition-opacity duration-150 group-hover:opacity-0">
+							({section.workspaces.length})
+						</span>
+						<button
+							type="button"
+							onClick={(event) => {
+								event.stopPropagation();
+								onStartRename();
+							}}
+							className="flex items-center justify-center opacity-0 text-muted-foreground transition-[opacity,color] duration-150 group-hover:opacity-100 hover:text-foreground"
+							aria-label="Rename section"
+						>
+							<LuPencil className="size-3.5" />
+						</button>
+					</div>
+				)}
 
 				<div className="h-px flex-1 bg-border" />
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
@@ -1,7 +1,3 @@
-import type {
-	DraggableAttributes,
-	DraggableSyntheticListeners,
-} from "@dnd-kit/core";
 import { cn } from "@superset/ui/utils";
 import { type ComponentPropsWithoutRef, forwardRef } from "react";
 import { HiChevronRight } from "react-icons/hi2";
@@ -19,8 +15,6 @@ interface DashboardSidebarSectionHeaderProps
 	onCancelRename: () => void;
 	onStartRename: () => void;
 	onToggleCollapse: () => void;
-	dragHandleListeners?: DraggableSyntheticListeners;
-	dragHandleAttributes?: DraggableAttributes;
 }
 
 export const DashboardSidebarSectionHeader = forwardRef<
@@ -37,15 +31,11 @@ export const DashboardSidebarSectionHeader = forwardRef<
 			onCancelRename,
 			onStartRename,
 			onToggleCollapse,
-			dragHandleListeners,
-			dragHandleAttributes,
 			className,
 			...props
 		},
 		ref,
 	) => {
-		const sectionColor = section.color;
-
 		return (
 			// biome-ignore lint/a11y/noStaticElementInteractions: The header acts as a single toggle target in view mode while preserving nested inline controls.
 			<div
@@ -64,49 +54,30 @@ export const DashboardSidebarSectionHeader = forwardRef<
 							}
 				}
 				className={cn(
-					"group flex min-h-7 w-full items-center gap-1.5 px-1 py-1 text-[11px] font-medium",
+					"group flex min-h-8 w-full items-center pl-0.5 pr-2 py-1.5 text-[11px] font-medium",
 					"text-muted-foreground hover:bg-muted/50 transition-colors",
 					className,
 				)}
 				{...props}
 			>
-				<button
-					type="button"
-					className="flex shrink-0 items-center justify-center w-5 h-5 opacity-0 group-hover:opacity-60 hover:!opacity-100 transition-opacity cursor-grab active:cursor-grabbing touch-none"
-					onClick={(e) => e.stopPropagation()}
-					{...(dragHandleListeners ?? {})}
-					{...(dragHandleAttributes ?? {})}
-				>
+				<div className="flex shrink-0 items-center justify-center w-5 h-5 opacity-0 group-hover:opacity-60 transition-opacity cursor-grab active:cursor-grabbing">
 					<LuGripVertical className="size-3" />
-				</button>
+				</div>
 
-				<div className="h-px flex-1 bg-border" />
-
-				<div className="flex shrink-0 items-center gap-1.5">
-					{sectionColor && (
-						<span
-							className="size-2 shrink-0 rounded-full"
-							style={{ backgroundColor: sectionColor }}
-						/>
-					)}
-
+				<div className="flex min-w-0 flex-1 items-center gap-1.5">
 					{isRenaming ? (
 						<RenameInput
 							value={renameValue}
 							onChange={onRenameValueChange}
 							onSubmit={onSubmitRename}
 							onCancel={onCancelRename}
-							className="-ml-1 -mr-1 h-5 min-w-0 px-1 py-0 text-[11px] font-medium bg-transparent border-none outline-none text-muted-foreground [field-sizing:content]"
+							className="-ml-1 h-5 w-full min-w-0 px-1 py-0 text-[11px] font-medium bg-transparent border-none outline-none text-muted-foreground"
 						/>
 					) : (
-						<span className="shrink-0 truncate">{section.name}</span>
+						<span className="truncate">{section.name}</span>
 					)}
 
-					{isRenaming ? (
-						<span className="text-[10px] font-normal tabular-nums shrink-0 text-muted-foreground">
-							({section.workspaces.length})
-						</span>
-					) : (
+					{!isRenaming && (
 						<div className="grid shrink-0 items-center [&>*]:col-start-1 [&>*]:row-start-1">
 							<span className="pointer-events-none text-[10px] font-normal tabular-nums transition-opacity duration-150 group-hover:opacity-0">
 								({section.workspaces.length})
@@ -117,7 +88,7 @@ export const DashboardSidebarSectionHeader = forwardRef<
 									event.stopPropagation();
 									onStartRename();
 								}}
-								className="flex items-center justify-center opacity-0 text-muted-foreground transition-[opacity,color] duration-150 group-hover:opacity-100 hover:text-foreground"
+								className="z-10 flex items-center justify-center opacity-0 text-muted-foreground transition-[opacity,color] duration-150 group-hover:opacity-100 hover:text-foreground"
 								aria-label="Rename section"
 							>
 								<LuPencil className="size-3.5" />
@@ -125,8 +96,6 @@ export const DashboardSidebarSectionHeader = forwardRef<
 						</div>
 					)}
 				</div>
-
-				<div className="h-px flex-1 bg-border" />
 
 				<button
 					type="button"
@@ -136,7 +105,7 @@ export const DashboardSidebarSectionHeader = forwardRef<
 					}}
 					onContextMenu={(event) => event.stopPropagation()}
 					aria-expanded={!section.isCollapsed}
-					className="p-0.5 rounded hover:bg-muted transition-colors shrink-0"
+					className="p-1 rounded hover:bg-muted transition-colors shrink-0 ml-1"
 				>
 					<HiChevronRight
 						className={cn(

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
@@ -74,13 +74,18 @@ export const DashboardSidebarSectionHeader = forwardRef<
 				)}
 
 				{isRenaming ? (
-					<RenameInput
-						value={renameValue}
-						onChange={onRenameValueChange}
-						onSubmit={onSubmitRename}
-						onCancel={onCancelRename}
-						className="h-5 w-auto shrink px-1 py-0 text-[11px] font-medium text-center bg-transparent border-none outline-none text-muted-foreground"
-					/>
+					<div
+						className="shrink min-w-0"
+						style={{ width: `${Math.max(renameValue.length + 2, 4)}ch` }}
+					>
+						<RenameInput
+							value={renameValue}
+							onChange={onRenameValueChange}
+							onSubmit={onSubmitRename}
+							onCancel={onCancelRename}
+							className="h-5 w-full px-1 py-0 text-[11px] font-medium text-center bg-transparent border-none outline-none text-muted-foreground"
+						/>
+					</div>
 				) : (
 					<span className="shrink-0 truncate">{section.name}</span>
 				)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
@@ -66,48 +66,49 @@ export const DashboardSidebarSectionHeader = forwardRef<
 
 				<div className="h-px flex-1 bg-border" />
 
-				{sectionColor && (
-					<span
-						className="size-2 shrink-0 rounded-full"
-						style={{ backgroundColor: sectionColor }}
-					/>
-				)}
+				<div className="flex shrink-0 items-center gap-1.5">
+					{sectionColor && (
+						<span
+							className="size-2 shrink-0 rounded-full"
+							style={{ backgroundColor: sectionColor }}
+						/>
+					)}
 
-				{isRenaming ? (
-					<div
-						className="shrink min-w-0"
-						style={{ width: `${Math.max(renameValue.length + 1, 3)}ch` }}
-					>
+					{isRenaming ? (
 						<RenameInput
 							value={renameValue}
 							onChange={onRenameValueChange}
 							onSubmit={onSubmitRename}
 							onCancel={onCancelRename}
-							className="h-5 w-full py-0 text-[11px] font-medium text-center bg-transparent border-none outline-none text-muted-foreground"
+							className="-ml-1 h-5 min-w-0 px-1 py-0 text-[11px] font-medium bg-transparent border-none outline-none text-muted-foreground"
 						/>
-					</div>
-				) : (
-					<span className="shrink-0 truncate">{section.name}</span>
-				)}
+					) : (
+						<span className="shrink-0 truncate">{section.name}</span>
+					)}
 
-				{!isRenaming && (
-					<div className="grid shrink-0 items-center [&>*]:col-start-1 [&>*]:row-start-1">
-						<span className="pointer-events-none text-[10px] font-normal tabular-nums transition-opacity duration-150 group-hover:opacity-0">
+					{isRenaming ? (
+						<span className="text-[10px] font-normal tabular-nums shrink-0 text-muted-foreground">
 							({section.workspaces.length})
 						</span>
-						<button
-							type="button"
-							onClick={(event) => {
-								event.stopPropagation();
-								onStartRename();
-							}}
-							className="flex items-center justify-center opacity-0 text-muted-foreground transition-[opacity,color] duration-150 group-hover:opacity-100 hover:text-foreground"
-							aria-label="Rename section"
-						>
-							<LuPencil className="size-3.5" />
-						</button>
-					</div>
-				)}
+					) : (
+						<div className="grid shrink-0 items-center [&>*]:col-start-1 [&>*]:row-start-1">
+							<span className="pointer-events-none text-[10px] font-normal tabular-nums transition-opacity duration-150 group-hover:opacity-0">
+								({section.workspaces.length})
+							</span>
+							<button
+								type="button"
+								onClick={(event) => {
+									event.stopPropagation();
+									onStartRename();
+								}}
+								className="flex items-center justify-center opacity-0 text-muted-foreground transition-[opacity,color] duration-150 group-hover:opacity-100 hover:text-foreground"
+								aria-label="Rename section"
+							>
+								<LuPencil className="size-3.5" />
+							</button>
+						</div>
+					)}
+				</div>
 
 				<div className="h-px flex-1 bg-border" />
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@superset/ui/utils";
 import { type ComponentPropsWithoutRef, forwardRef } from "react";
 import { HiChevronRight } from "react-icons/hi2";
-import { LuPencil } from "react-icons/lu";
+import { LuGripVertical, LuPencil } from "react-icons/lu";
 import { RenameInput } from "renderer/screens/main/components/WorkspaceSidebar/RenameInput";
 import type { DashboardSidebarSection } from "../../../../types";
 
@@ -36,6 +36,8 @@ export const DashboardSidebarSectionHeader = forwardRef<
 		},
 		ref,
 	) => {
+		const sectionColor = section.color;
+
 		return (
 			// biome-ignore lint/a11y/noStaticElementInteractions: The header acts as a single toggle target in view mode while preserving nested inline controls.
 			<div
@@ -54,44 +56,55 @@ export const DashboardSidebarSectionHeader = forwardRef<
 							}
 				}
 				className={cn(
-					"group flex min-h-8 w-full items-center pl-2 pr-2 py-1.5 text-[11px] font-medium",
+					"group flex min-h-7 w-full items-center gap-1.5 px-1 py-1 text-[11px] font-medium",
 					"text-muted-foreground hover:bg-muted/50 transition-colors",
 					className,
 				)}
 				{...props}
 			>
-				<div className="flex min-w-0 flex-1 items-center gap-1.5">
-					{isRenaming ? (
-						<RenameInput
-							value={renameValue}
-							onChange={onRenameValueChange}
-							onSubmit={onSubmitRename}
-							onCancel={onCancelRename}
-							className="-ml-1 h-5 w-full min-w-0 px-1 py-0 text-[11px] font-medium bg-transparent border-none outline-none text-muted-foreground"
-						/>
-					) : (
-						<span className="truncate">{section.name}</span>
-					)}
+				<LuGripVertical className="size-3 shrink-0 opacity-0 group-hover:opacity-60 transition-opacity cursor-grab active:cursor-grabbing" />
 
-					{!isRenaming && (
-						<div className="grid shrink-0 items-center [&>*]:col-start-1 [&>*]:row-start-1">
-							<span className="pointer-events-none text-[10px] font-normal tabular-nums transition-opacity duration-150 group-hover:opacity-0">
-								({section.workspaces.length})
-							</span>
-							<button
-								type="button"
-								onClick={(event) => {
-									event.stopPropagation();
-									onStartRename();
-								}}
-								className="z-10 flex items-center justify-center opacity-0 text-muted-foreground transition-[opacity,color] duration-150 group-hover:opacity-100 hover:text-foreground"
-								aria-label="Rename section"
-							>
-								<LuPencil className="size-3.5" />
-							</button>
-						</div>
-					)}
-				</div>
+				<div className="h-px flex-1 bg-border" />
+
+				{sectionColor && (
+					<span
+						className="size-2 shrink-0 rounded-full"
+						style={{ backgroundColor: sectionColor }}
+					/>
+				)}
+
+				{isRenaming ? (
+					<RenameInput
+						value={renameValue}
+						onChange={onRenameValueChange}
+						onSubmit={onSubmitRename}
+						onCancel={onCancelRename}
+						className="h-5 w-auto shrink px-1 py-0 text-[11px] font-medium text-center bg-transparent border-none outline-none text-muted-foreground"
+					/>
+				) : (
+					<span className="shrink-0 truncate">{section.name}</span>
+				)}
+
+				{!isRenaming && (
+					<div className="grid shrink-0 items-center [&>*]:col-start-1 [&>*]:row-start-1">
+						<span className="pointer-events-none text-[10px] font-normal tabular-nums transition-opacity duration-150 group-hover:opacity-0">
+							({section.workspaces.length})
+						</span>
+						<button
+							type="button"
+							onClick={(event) => {
+								event.stopPropagation();
+								onStartRename();
+							}}
+							className="flex items-center justify-center opacity-0 text-muted-foreground transition-[opacity,color] duration-150 group-hover:opacity-100 hover:text-foreground"
+							aria-label="Rename section"
+						>
+							<LuPencil className="size-3.5" />
+						</button>
+					</div>
+				)}
+
+				<div className="h-px flex-1 bg-border" />
 
 				<button
 					type="button"
@@ -101,7 +114,7 @@ export const DashboardSidebarSectionHeader = forwardRef<
 					}}
 					onContextMenu={(event) => event.stopPropagation()}
 					aria-expanded={!section.isCollapsed}
-					className="p-1 rounded hover:bg-muted transition-colors shrink-0 ml-1"
+					className="p-0.5 rounded hover:bg-muted transition-colors shrink-0"
 				>
 					<HiChevronRight
 						className={cn(

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
@@ -76,38 +76,36 @@ export const DashboardSidebarSectionHeader = forwardRef<
 				{isRenaming ? (
 					<div
 						className="shrink min-w-0"
-						style={{ width: `${Math.max(renameValue.length + 2, 4)}ch` }}
+						style={{ width: `${Math.max(renameValue.length + 1, 3)}ch` }}
 					>
 						<RenameInput
 							value={renameValue}
 							onChange={onRenameValueChange}
 							onSubmit={onSubmitRename}
 							onCancel={onCancelRename}
-							className="h-5 w-full px-1 py-0 text-[11px] font-medium text-center bg-transparent border-none outline-none text-muted-foreground"
+							className="h-5 w-full py-0 text-[11px] font-medium text-center bg-transparent border-none outline-none text-muted-foreground"
 						/>
 					</div>
 				) : (
 					<span className="shrink-0 truncate">{section.name}</span>
 				)}
 
-				{!isRenaming && (
-					<div className="grid shrink-0 items-center [&>*]:col-start-1 [&>*]:row-start-1">
-						<span className="pointer-events-none text-[10px] font-normal tabular-nums transition-opacity duration-150 group-hover:opacity-0">
-							({section.workspaces.length})
-						</span>
-						<button
-							type="button"
-							onClick={(event) => {
-								event.stopPropagation();
-								onStartRename();
-							}}
-							className="flex items-center justify-center opacity-0 text-muted-foreground transition-[opacity,color] duration-150 group-hover:opacity-100 hover:text-foreground"
-							aria-label="Rename section"
-						>
-							<LuPencil className="size-3.5" />
-						</button>
-					</div>
-				)}
+				<div className={cn("grid shrink-0 items-center [&>*]:col-start-1 [&>*]:row-start-1", isRenaming && "invisible")}>
+					<span className="pointer-events-none text-[10px] font-normal tabular-nums transition-opacity duration-150 group-hover:opacity-0">
+						({section.workspaces.length})
+					</span>
+					<button
+						type="button"
+						onClick={(event) => {
+							event.stopPropagation();
+							onStartRename();
+						}}
+						className="flex items-center justify-center opacity-0 text-muted-foreground transition-[opacity,color] duration-150 group-hover:opacity-100 hover:text-foreground"
+						aria-label="Rename section"
+					>
+						<LuPencil className="size-3.5" />
+					</button>
+				</div>
 
 				<div className="h-px flex-1 bg-border" />
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
@@ -1,3 +1,7 @@
+import type {
+	DraggableAttributes,
+	DraggableSyntheticListeners,
+} from "@dnd-kit/core";
 import { cn } from "@superset/ui/utils";
 import { type ComponentPropsWithoutRef, forwardRef } from "react";
 import { HiChevronRight } from "react-icons/hi2";
@@ -15,6 +19,8 @@ interface DashboardSidebarSectionHeaderProps
 	onCancelRename: () => void;
 	onStartRename: () => void;
 	onToggleCollapse: () => void;
+	dragHandleListeners?: DraggableSyntheticListeners;
+	dragHandleAttributes?: DraggableAttributes;
 }
 
 export const DashboardSidebarSectionHeader = forwardRef<
@@ -31,6 +37,8 @@ export const DashboardSidebarSectionHeader = forwardRef<
 			onCancelRename,
 			onStartRename,
 			onToggleCollapse,
+			dragHandleListeners,
+			dragHandleAttributes,
 			className,
 			...props
 		},
@@ -62,7 +70,15 @@ export const DashboardSidebarSectionHeader = forwardRef<
 				)}
 				{...props}
 			>
-				<LuGripVertical className="size-3 shrink-0 opacity-0 group-hover:opacity-60 transition-opacity cursor-grab active:cursor-grabbing" />
+				<button
+					type="button"
+					className="flex shrink-0 items-center justify-center w-5 h-5 opacity-0 group-hover:opacity-60 hover:!opacity-100 transition-opacity cursor-grab active:cursor-grabbing touch-none"
+					onClick={(e) => e.stopPropagation()}
+					{...(dragHandleListeners ?? {})}
+					{...(dragHandleAttributes ?? {})}
+				>
+					<LuGripVertical className="size-3" />
+				</button>
 
 				<div className="h-px flex-1 bg-border" />
 
@@ -80,7 +96,7 @@ export const DashboardSidebarSectionHeader = forwardRef<
 							onChange={onRenameValueChange}
 							onSubmit={onSubmitRename}
 							onCancel={onCancelRename}
-							className="-ml-1 h-5 min-w-0 px-1 py-0 text-[11px] font-medium bg-transparent border-none outline-none text-muted-foreground"
+							className="-ml-1 -mr-1 h-5 min-w-0 px-1 py-0 text-[11px] font-medium bg-transparent border-none outline-none text-muted-foreground [field-sizing:content]"
 						/>
 					) : (
 						<span className="shrink-0 truncate">{section.name}</span>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
@@ -90,7 +90,10 @@ export const DashboardSidebarSectionHeader = forwardRef<
 					<span className="shrink-0 truncate">{section.name}</span>
 				)}
 
-				<div className={cn("grid shrink-0 items-center [&>*]:col-start-1 [&>*]:row-start-1", isRenaming && "invisible")}>
+				{isRenaming ? (
+					<div className="h-px w-4 bg-border shrink-0" />
+				) : null}
+				<div className={cn("grid shrink-0 items-center [&>*]:col-start-1 [&>*]:row-start-1", isRenaming && "hidden")}>
 					<span className="pointer-events-none text-[10px] font-normal tabular-nums transition-opacity duration-150 group-hover:opacity-0">
 						({section.workspaces.length})
 					</span>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -12,6 +12,7 @@ interface DashboardSidebarWorkspaceItemProps {
 	onHoverCardOpen?: () => void;
 	shortcutLabel?: string;
 	isCollapsed?: boolean;
+	isInSection?: boolean;
 }
 
 export function DashboardSidebarWorkspaceItem({
@@ -19,6 +20,7 @@ export function DashboardSidebarWorkspaceItem({
 	onHoverCardOpen,
 	shortcutLabel,
 	isCollapsed = false,
+	isInSection = false,
 }: DashboardSidebarWorkspaceItemProps) {
 	const {
 		id,
@@ -88,6 +90,7 @@ export function DashboardSidebarWorkspaceItem({
 				) : (
 					<DashboardSidebarWorkspaceContextMenu
 						projectId={projectId}
+						isInSection={isInSection}
 						onHoverCardOpen={
 							hostType === "local-device" ? onHoverCardOpen : undefined
 						}
@@ -149,6 +152,7 @@ export function DashboardSidebarWorkspaceItem({
 			) : (
 				<DashboardSidebarWorkspaceContextMenu
 					projectId={projectId}
+					isInSection={isInSection}
 					onHoverCardOpen={
 						hostType === "local-device" ? onHoverCardOpen : undefined
 					}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -1,6 +1,12 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
-import { type ComponentPropsWithoutRef, forwardRef, useMemo } from "react";
+import {
+	type ComponentPropsWithoutRef,
+	forwardRef,
+	useEffect,
+	useMemo,
+	useRef,
+} from "react";
 import { HiMiniXMark } from "react-icons/hi2";
 import { HotkeyLabel } from "renderer/hotkeys";
 import { RenameInput } from "renderer/screens/main/components/WorkspaceSidebar/RenameInput";
@@ -58,9 +64,17 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 			pullRequest,
 			creationStatus,
 		} = workspace;
-		const showBranchSubtitle = !!name && name !== branch;
-		const showSubtitle = showBranchSubtitle || !!pullRequest;
 		const showsStandaloneActiveStripe = accentColor == null;
+		const localRef = useRef<HTMLDivElement>(null);
+
+		useEffect(() => {
+			if (isActive) {
+				localRef.current?.scrollIntoView({
+					block: "nearest",
+					behavior: "smooth",
+				});
+			}
+		}, [isActive]);
 
 		const creationStatusText = useMemo(
 			() => getCreationStatusText(creationStatus),
@@ -73,7 +87,11 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 				role={onClick ? "button" : undefined}
 				tabIndex={onClick ? 0 : undefined}
 				aria-disabled={creationStatus ? true : undefined}
-				ref={ref}
+				ref={(node) => {
+					localRef.current = node;
+					if (typeof ref === "function") ref(node);
+					else if (ref) ref.current = node;
+				}}
 				onClick={onClick}
 				onKeyDown={(event) => {
 					if (onClick && (event.key === "Enter" || event.key === " ")) {
@@ -85,8 +103,8 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 				className={cn(
 					"relative flex w-full items-center pl-3 pr-2 text-left text-sm",
 					onClick && "cursor-pointer hover:bg-muted/50",
-					"transition-colors group",
-					showSubtitle ? "py-1.5" : "py-2",
+					"group",
+					"py-1.5",
 					isActive && "bg-muted",
 					className,
 				)}
@@ -120,160 +138,85 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 				</Tooltip>
 
 				<div className="flex min-w-0 flex-1 flex-col justify-center">
-					{showSubtitle ? (
-						<div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] grid-rows-2 items-center gap-x-1.5 gap-y-0.5">
-							{isRenaming ? (
-								<RenameInput
-									value={renameValue}
-									onChange={onRenameValueChange}
-									onSubmit={onSubmitRename}
-									onCancel={onCancelRename}
-									className={cn(
-										"h-5 w-full -ml-1 border-none bg-transparent px-1 py-0 text-[13px] leading-tight outline-none",
-										!showBranchSubtitle && "row-span-2 self-center",
-									)}
-								/>
-							) : (
-								<span
-									className={cn(
-										"truncate text-[13px] leading-tight transition-colors",
-										isActive
-											? "text-foreground font-medium"
-											: "text-foreground/80",
-										!showBranchSubtitle && "row-span-2 self-center",
-									)}
-								>
-									{name || branch}
-								</span>
-							)}
-
-							<div className="col-start-2 row-start-1 grid h-5 shrink-0 items-center [&>*]:col-start-1 [&>*]:row-start-1">
-								{creationStatusText ? (
-									<span className="text-[11px] text-muted-foreground">
-										{creationStatusText}
-									</span>
-								) : (
-									<>
-										<DashboardSidebarWorkspaceDiffStats
-											additions={mockData.diffStats.additions}
-											deletions={mockData.diffStats.deletions}
-											isActive={isActive}
-										/>
-										<div className="invisible flex items-center justify-end gap-1.5 opacity-0 transition-[opacity,visibility] group-hover:visible group-hover:opacity-100">
-											{shortcutLabel && (
-												<span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground">
-													{shortcutLabel}
-												</span>
-											)}
-											<Tooltip delayDuration={300}>
-												<TooltipTrigger asChild>
-													<button
-														type="button"
-														onClick={(event) => {
-															event.stopPropagation();
-															onDeleteClick();
-														}}
-														className="flex items-center justify-center text-muted-foreground hover:text-foreground"
-														aria-label="Close workspace"
-													>
-														<HiMiniXMark className="size-3.5" />
-													</button>
-												</TooltipTrigger>
-												<TooltipContent side="top" sideOffset={4}>
-													<HotkeyLabel
-														label="Close workspace"
-														id={isActive ? "CLOSE_WORKSPACE" : undefined}
-													/>
-												</TooltipContent>
-											</Tooltip>
-										</div>
-									</>
+					<div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] grid-rows-2 items-center gap-x-1.5 gap-y-0.5">
+						{isRenaming ? (
+							<RenameInput
+								value={renameValue}
+								onChange={onRenameValueChange}
+								onSubmit={onSubmitRename}
+								onCancel={onCancelRename}
+								className={cn(
+									"h-5 w-full -ml-1 border-none bg-transparent px-1 py-0 text-[13px] leading-tight outline-none",
 								)}
-							</div>
+							/>
+						) : (
+							<span
+								className={cn(
+									"truncate text-[13px] leading-tight transition-colors",
+									isActive ? "text-foreground" : "text-foreground/80",
+								)}
+							>
+								{name || branch}
+							</span>
+						)}
 
-							{showBranchSubtitle && (
-								<span className="col-start-1 row-start-2 truncate font-mono text-[11px] leading-tight text-muted-foreground/60">
-									{branch}
+						<div className="col-start-2 row-start-1 grid h-5 shrink-0 items-center [&>*]:col-start-1 [&>*]:row-start-1">
+							{creationStatusText ? (
+								<span className="text-[11px] text-muted-foreground">
+									{creationStatusText}
 								</span>
-							)}
-
-							{pullRequest && (
-								<DashboardSidebarWorkspaceStatusBadge
-									state={pullRequest.state}
-									prNumber={pullRequest.number}
-									prUrl={pullRequest.url}
-									className="col-start-2 row-start-2 justify-self-end"
-								/>
+							) : (
+								<>
+									<DashboardSidebarWorkspaceDiffStats
+										additions={mockData.diffStats.additions}
+										deletions={mockData.diffStats.deletions}
+										isActive={isActive}
+									/>
+									<div className="invisible flex items-center justify-end gap-1.5 opacity-0 transition-[opacity,visibility] group-hover:visible group-hover:opacity-100">
+										{shortcutLabel && (
+											<span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground">
+												{shortcutLabel}
+											</span>
+										)}
+										<Tooltip delayDuration={300}>
+											<TooltipTrigger asChild>
+												<button
+													type="button"
+													onClick={(event) => {
+														event.stopPropagation();
+														onDeleteClick();
+													}}
+													className="flex items-center justify-center text-muted-foreground hover:text-foreground"
+													aria-label="Close workspace"
+												>
+													<HiMiniXMark className="size-3.5" />
+												</button>
+											</TooltipTrigger>
+											<TooltipContent side="top" sideOffset={4}>
+												<HotkeyLabel
+													label="Close workspace"
+													id={isActive ? "CLOSE_WORKSPACE" : undefined}
+												/>
+											</TooltipContent>
+										</Tooltip>
+									</div>
+								</>
 							)}
 						</div>
-					) : (
-						<div className="flex min-h-5 items-center gap-1.5">
-							{isRenaming ? (
-								<RenameInput
-									value={renameValue}
-									onChange={onRenameValueChange}
-									onSubmit={onSubmitRename}
-									onCancel={onCancelRename}
-									className="h-5 w-full flex-1 -ml-1 border-none bg-transparent px-1 py-0 text-[13px] leading-tight outline-none"
-								/>
-							) : (
-								<span
-									className={cn(
-										"truncate text-[13px] leading-tight transition-colors flex-1",
-										isActive
-											? "text-foreground font-medium"
-											: "text-foreground/80",
-									)}
-								>
-									{name || branch}
-								</span>
-							)}
 
-							<div className="grid h-5 shrink-0 items-center [&>*]:col-start-1 [&>*]:row-start-1">
-								{creationStatusText ? (
-									<span className="text-[11px] text-muted-foreground">
-										{creationStatusText}
-									</span>
-								) : (
-									<>
-										<DashboardSidebarWorkspaceDiffStats
-											additions={mockData.diffStats.additions}
-											deletions={mockData.diffStats.deletions}
-											isActive={isActive}
-										/>
-										<div className="invisible flex items-center justify-end gap-1.5 opacity-0 transition-[opacity,visibility] group-hover:visible group-hover:opacity-100">
-											{shortcutLabel && (
-												<span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground">
-													{shortcutLabel}
-												</span>
-											)}
-											<Tooltip delayDuration={300}>
-												<TooltipTrigger asChild>
-													<button
-														type="button"
-														onClick={(event) => {
-															event.stopPropagation();
-															onDeleteClick();
-														}}
-														className="flex items-center justify-center text-muted-foreground hover:text-foreground"
-														aria-label="Close workspace"
-													>
-														<HiMiniXMark className="size-3.5" />
-													</button>
-												</TooltipTrigger>
-												<TooltipContent side="top" sideOffset={4}>
-													<HotkeyLabel
-														label="Close workspace"
-														id={isActive ? "CLOSE_WORKSPACE" : undefined}
-													/>
-												</TooltipContent>
-											</Tooltip>
-										</div>
-									</>
-								)}
-							</div>
-						</div>
-					)}
+						<span className="col-start-1 row-start-2 truncate font-mono text-[11px] leading-tight text-muted-foreground/60">
+							{branch}
+						</span>
+
+						{pullRequest && (
+							<DashboardSidebarWorkspaceStatusBadge
+								state={pullRequest.state}
+								prNumber={pullRequest.number}
+								prUrl={pullRequest.url}
+								className="col-start-2 row-start-2 justify-self-end"
+							/>
+						)}
+					</div>
 				</div>
 			</div>
 		);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
@@ -18,10 +18,10 @@ import { useLiveQuery } from "@tanstack/react-db";
 import { useState } from "react";
 import {
 	LuArrowRightLeft,
+	LuArrowUp,
 	LuCopy,
 	LuFolderOpen,
 	LuFolderPlus,
-	LuMinus,
 	LuPencil,
 	LuTrash2,
 	LuX,
@@ -31,6 +31,7 @@ import { useCollections } from "renderer/routes/_authenticated/providers/Collect
 interface DashboardSidebarWorkspaceContextMenuProps {
 	hoverCardContent?: React.ReactNode;
 	projectId: string;
+	isInSection?: boolean;
 	onHoverCardOpen?: () => void;
 	onCreateSection: () => void;
 	onMoveToSection: (sectionId: string | null) => void;
@@ -44,6 +45,7 @@ interface DashboardSidebarWorkspaceContextMenuProps {
 
 export function DashboardSidebarWorkspaceContextMenu({
 	projectId,
+	isInSection,
 	onHoverCardOpen,
 	hoverCardContent,
 	onCreateSection,
@@ -68,6 +70,7 @@ export function DashboardSidebarWorkspaceContextMenu({
 				.select(({ sidebarSections }) => ({
 					id: sidebarSections.sectionId,
 					name: sidebarSections.name,
+					color: sidebarSections.color,
 				})),
 		[collections, projectId],
 	);
@@ -98,20 +101,29 @@ export function DashboardSidebarWorkspaceContextMenu({
 						<LuFolderPlus className="size-4 mr-2" />
 						New Section
 					</ContextMenuItem>
-					<ContextMenuItem onSelect={() => onMoveToSection(null)}>
-						<LuMinus className="size-4 mr-2" />
-						Ungrouped
-					</ContextMenuItem>
+					{sections.length > 0 && <ContextMenuSeparator />}
 					{sections.map((section) => (
 						<ContextMenuItem
 							key={section.id}
 							onSelect={() => onMoveToSection(section.id)}
 						>
+							{section.color && (
+								<span
+									className="size-2 shrink-0 rounded-full mr-2"
+									style={{ backgroundColor: section.color }}
+								/>
+							)}
 							{section.name}
 						</ContextMenuItem>
 					))}
 				</ContextMenuSubContent>
 			</ContextMenuSub>
+			{isInSection && (
+				<ContextMenuItem onSelect={() => onMoveToSection(null)}>
+					<LuArrowUp className="size-4 mr-2" />
+					Remove from Group
+				</ContextMenuItem>
+			)}
 			<ContextMenuSeparator />
 			<ContextMenuItem
 				onSelect={onRemoveFromSidebar}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SidebarDragOverlay/SidebarDragOverlay.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SidebarDragOverlay/SidebarDragOverlay.tsx
@@ -29,22 +29,19 @@ export function SidebarDragOverlay({ activeItem }: SidebarDragOverlayProps) {
 		section.color != null && section.color !== PROJECT_COLOR_DEFAULT;
 
 	return (
-		<div className="bg-background shadow-lg">
-			<div className="flex min-h-7 w-full items-center gap-1.5 px-1 py-1 text-[11px] font-medium text-muted-foreground">
-				<div className="h-px flex-1 bg-border" />
-				<div className="flex shrink-0 items-center gap-1.5">
-					{hasColor && (
-						<span
-							className="size-2 shrink-0 rounded-full"
-							style={{ backgroundColor: section.color! }}
-						/>
-					)}
-					<span className="truncate">{section.name}</span>
-					<span className="text-[10px] font-normal tabular-nums shrink-0">
-						({section.workspaces.length})
-					</span>
-				</div>
-				<div className="h-px flex-1 bg-border" />
+		<div
+			className="bg-background shadow-lg"
+			style={{
+				borderLeft: hasColor
+					? `2px solid ${section.color}`
+					: "2px solid var(--color-border)",
+			}}
+		>
+			<div className="flex min-h-8 w-full items-center gap-1.5 pl-2 pr-2 py-1.5 text-[11px] font-medium text-muted-foreground">
+				<span className="truncate">{section.name}</span>
+				<span className="text-[10px] font-normal tabular-nums shrink-0">
+					({section.workspaces.length})
+				</span>
 			</div>
 		</div>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SidebarDragOverlay/SidebarDragOverlay.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SidebarDragOverlay/SidebarDragOverlay.tsx
@@ -1,0 +1,48 @@
+import { PROJECT_COLOR_DEFAULT } from "shared/constants/project-colors";
+import type {
+	DashboardSidebarSection,
+	DashboardSidebarWorkspace,
+} from "../../types";
+import { DashboardSidebarWorkspaceItem } from "../DashboardSidebarWorkspaceItem";
+
+type ActiveItem =
+	| { type: "workspace"; workspace: DashboardSidebarWorkspace }
+	| { type: "section"; section: DashboardSidebarSection };
+
+interface SidebarDragOverlayProps {
+	activeItem: ActiveItem | null;
+}
+
+export function SidebarDragOverlay({ activeItem }: SidebarDragOverlayProps) {
+	if (!activeItem) return null;
+
+	if (activeItem.type === "workspace") {
+		return (
+			<div className="bg-background shadow-lg">
+				<DashboardSidebarWorkspaceItem workspace={activeItem.workspace} />
+			</div>
+		);
+	}
+
+	const { section } = activeItem;
+	const hasColor =
+		section.color != null && section.color !== PROJECT_COLOR_DEFAULT;
+
+	return (
+		<div
+			className="bg-background shadow-lg"
+			style={{
+				borderLeft: hasColor
+					? `2px solid ${section.color}`
+					: "2px solid var(--color-border)",
+			}}
+		>
+			<div className="flex min-h-8 w-full items-center gap-1.5 pl-2 pr-2 py-1.5 text-[11px] font-medium text-muted-foreground">
+				<span className="truncate">{section.name}</span>
+				<span className="text-[10px] font-normal tabular-nums shrink-0">
+					({section.workspaces.length})
+				</span>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SidebarDragOverlay/SidebarDragOverlay.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SidebarDragOverlay/SidebarDragOverlay.tsx
@@ -29,19 +29,22 @@ export function SidebarDragOverlay({ activeItem }: SidebarDragOverlayProps) {
 		section.color != null && section.color !== PROJECT_COLOR_DEFAULT;
 
 	return (
-		<div
-			className="bg-background shadow-lg"
-			style={{
-				borderLeft: hasColor
-					? `2px solid ${section.color}`
-					: "2px solid var(--color-border)",
-			}}
-		>
-			<div className="flex min-h-8 w-full items-center gap-1.5 pl-2 pr-2 py-1.5 text-[11px] font-medium text-muted-foreground">
-				<span className="truncate">{section.name}</span>
-				<span className="text-[10px] font-normal tabular-nums shrink-0">
-					({section.workspaces.length})
-				</span>
+		<div className="bg-background shadow-lg">
+			<div className="flex min-h-7 w-full items-center gap-1.5 px-1 py-1 text-[11px] font-medium text-muted-foreground">
+				<div className="h-px flex-1 bg-border" />
+				<div className="flex shrink-0 items-center gap-1.5">
+					{hasColor && (
+						<span
+							className="size-2 shrink-0 rounded-full"
+							style={{ backgroundColor: section.color! }}
+						/>
+					)}
+					<span className="truncate">{section.name}</span>
+					<span className="text-[10px] font-normal tabular-nums shrink-0">
+						({section.workspaces.length})
+					</span>
+				</div>
+				<div className="h-px flex-1 bg-border" />
 			</div>
 		</div>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SidebarDragOverlay/SidebarDragOverlay.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SidebarDragOverlay/SidebarDragOverlay.tsx
@@ -1,3 +1,4 @@
+import { LuGripVertical } from "react-icons/lu";
 import { PROJECT_COLOR_DEFAULT } from "shared/constants/project-colors";
 import type {
 	DashboardSidebarSection,
@@ -37,7 +38,10 @@ export function SidebarDragOverlay({ activeItem }: SidebarDragOverlayProps) {
 					: "2px solid var(--color-border)",
 			}}
 		>
-			<div className="flex min-h-8 w-full items-center gap-1.5 pl-2 pr-2 py-1.5 text-[11px] font-medium text-muted-foreground">
+			<div className="flex min-h-8 w-full items-center gap-1.5 pl-0.5 pr-2 py-1.5 text-[11px] font-medium text-muted-foreground">
+				<div className="flex shrink-0 items-center justify-center w-5 h-5 opacity-60">
+					<LuGripVertical className="size-3" />
+				</div>
 				<span className="truncate">{section.name}</span>
 				<span className="text-[10px] font-normal tabular-nums shrink-0">
 					({section.workspaces.length})

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SidebarDragOverlay/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SidebarDragOverlay/index.ts
@@ -1,0 +1,1 @@
+export { SidebarDragOverlay } from "./SidebarDragOverlay";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableSectionHeader/SortableSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableSectionHeader/SortableSectionHeader.tsx
@@ -2,6 +2,7 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useState } from "react";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
+import { PROJECT_COLOR_DEFAULT } from "shared/constants/project-colors";
 import type { DashboardSidebarSection } from "../../types";
 import { DashboardSidebarSectionContextMenu } from "../DashboardSidebarSection/components/DashboardSidebarSectionContextMenu";
 import { DashboardSidebarSectionHeader } from "../DashboardSidebarSection/components/DashboardSidebarSectionHeader";
@@ -34,6 +35,9 @@ export function SortableSectionHeader({
 		isDragging,
 	} = useSortable({ id: sortableId });
 
+	const hasColor =
+		section.color != null && section.color !== PROJECT_COLOR_DEFAULT;
+
 	const handleSubmitRename = () => {
 		const trimmed = renameValue.trim();
 		if (trimmed) onRename(section.id, trimmed);
@@ -47,6 +51,9 @@ export function SortableSectionHeader({
 				transform: CSS.Translate.toString(transform),
 				transition,
 				opacity: isDragging ? 0.5 : undefined,
+				borderLeft: hasColor
+					? `2px solid ${section.color}`
+					: "2px solid var(--color-border)",
 			}}
 		>
 			<DashboardSidebarSectionContextMenu
@@ -70,8 +77,8 @@ export function SortableSectionHeader({
 						setIsRenaming(true);
 					}}
 					onToggleCollapse={() => onToggleCollapse(section.id)}
-					dragHandleListeners={listeners}
-					dragHandleAttributes={attributes}
+					{...attributes}
+					{...listeners}
 				/>
 			</DashboardSidebarSectionContextMenu>
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableSectionHeader/SortableSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableSectionHeader/SortableSectionHeader.tsx
@@ -1,0 +1,86 @@
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { useState } from "react";
+import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
+import { PROJECT_COLOR_DEFAULT } from "shared/constants/project-colors";
+import type { DashboardSidebarSection } from "../../types";
+import { DashboardSidebarSectionContextMenu } from "../DashboardSidebarSection/components/DashboardSidebarSectionContextMenu";
+import { DashboardSidebarSectionHeader } from "../DashboardSidebarSection/components/DashboardSidebarSectionHeader";
+
+interface SortableSectionHeaderProps {
+	sortableId: string;
+	section: DashboardSidebarSection;
+	onDelete: (sectionId: string) => void;
+	onRename: (sectionId: string, name: string) => void;
+	onToggleCollapse: (sectionId: string) => void;
+}
+
+export function SortableSectionHeader({
+	sortableId,
+	section,
+	onDelete,
+	onRename,
+	onToggleCollapse,
+}: SortableSectionHeaderProps) {
+	const { setSectionColor } = useDashboardSidebarState();
+	const [isRenaming, setIsRenaming] = useState(false);
+	const [renameValue, setRenameValue] = useState(section.name);
+
+	const {
+		attributes,
+		listeners,
+		setNodeRef,
+		transform,
+		transition,
+		isDragging,
+	} = useSortable({ id: sortableId });
+
+	const hasColor =
+		section.color != null && section.color !== PROJECT_COLOR_DEFAULT;
+
+	const handleSubmitRename = () => {
+		const trimmed = renameValue.trim();
+		if (trimmed) onRename(section.id, trimmed);
+		setIsRenaming(false);
+	};
+
+	return (
+		<div
+			ref={setNodeRef}
+			style={{
+				transform: CSS.Translate.toString(transform),
+				transition,
+				opacity: isDragging ? 0.5 : undefined,
+				borderLeft: hasColor
+					? `2px solid ${section.color}`
+					: "2px solid var(--color-border)",
+			}}
+		>
+			<DashboardSidebarSectionContextMenu
+				color={section.color}
+				onRename={() => setIsRenaming(true)}
+				onSetColor={(color) => setSectionColor(section.id, color)}
+				onDelete={() => onDelete(section.id)}
+			>
+				<DashboardSidebarSectionHeader
+					section={section}
+					isRenaming={isRenaming}
+					renameValue={renameValue}
+					onRenameValueChange={setRenameValue}
+					onSubmitRename={handleSubmitRename}
+					onCancelRename={() => {
+						setRenameValue(section.name);
+						setIsRenaming(false);
+					}}
+					onStartRename={() => {
+						setRenameValue(section.name);
+						setIsRenaming(true);
+					}}
+					onToggleCollapse={() => onToggleCollapse(section.id)}
+					{...attributes}
+					{...listeners}
+				/>
+			</DashboardSidebarSectionContextMenu>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableSectionHeader/SortableSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableSectionHeader/SortableSectionHeader.tsx
@@ -2,7 +2,6 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useState } from "react";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
-import { PROJECT_COLOR_DEFAULT } from "shared/constants/project-colors";
 import type { DashboardSidebarSection } from "../../types";
 import { DashboardSidebarSectionContextMenu } from "../DashboardSidebarSection/components/DashboardSidebarSectionContextMenu";
 import { DashboardSidebarSectionHeader } from "../DashboardSidebarSection/components/DashboardSidebarSectionHeader";
@@ -35,9 +34,6 @@ export function SortableSectionHeader({
 		isDragging,
 	} = useSortable({ id: sortableId });
 
-	const hasColor =
-		section.color != null && section.color !== PROJECT_COLOR_DEFAULT;
-
 	const handleSubmitRename = () => {
 		const trimmed = renameValue.trim();
 		if (trimmed) onRename(section.id, trimmed);
@@ -51,9 +47,6 @@ export function SortableSectionHeader({
 				transform: CSS.Translate.toString(transform),
 				transition,
 				opacity: isDragging ? 0.5 : undefined,
-				borderLeft: hasColor
-					? `2px solid ${section.color}`
-					: "2px solid var(--color-border)",
 			}}
 		>
 			<DashboardSidebarSectionContextMenu

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableSectionHeader/SortableSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableSectionHeader/SortableSectionHeader.tsx
@@ -70,8 +70,8 @@ export function SortableSectionHeader({
 						setIsRenaming(true);
 					}}
 					onToggleCollapse={() => onToggleCollapse(section.id)}
-					{...attributes}
-					{...listeners}
+					dragHandleListeners={listeners}
+					dragHandleAttributes={attributes}
 				/>
 			</DashboardSidebarSectionContextMenu>
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableSectionHeader/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableSectionHeader/index.ts
@@ -1,0 +1,1 @@
+export { SortableSectionHeader } from "./SortableSectionHeader";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableWorkspaceItem/SortableWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableWorkspaceItem/SortableWorkspaceItem.tsx
@@ -20,8 +20,14 @@ export function SortableWorkspaceItem({
 	onHoverCardOpen,
 	shortcutLabel,
 }: SortableWorkspaceItemProps) {
-	const { setNodeRef, listeners, isDragging, transform, transition } =
-		useSortable({ id: sortableId });
+	const {
+		setNodeRef,
+		attributes,
+		listeners,
+		isDragging,
+		transform,
+		transition,
+	} = useSortable({ id: sortableId });
 
 	return (
 		<div
@@ -32,6 +38,7 @@ export function SortableWorkspaceItem({
 				opacity: isDragging ? 0.5 : undefined,
 				borderLeft: accentColor ? `2px solid ${accentColor}` : undefined,
 			}}
+			{...attributes}
 			{...listeners}
 		>
 			<DashboardSidebarWorkspaceItem

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableWorkspaceItem/SortableWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableWorkspaceItem/SortableWorkspaceItem.tsx
@@ -7,6 +7,7 @@ interface SortableWorkspaceItemProps {
 	sortableId: string;
 	workspace: DashboardSidebarWorkspace;
 	accentColor?: string | null;
+	isInSection?: boolean;
 	onHoverCardOpen?: () => void;
 	shortcutLabel?: string;
 }
@@ -15,6 +16,7 @@ export function SortableWorkspaceItem({
 	sortableId,
 	workspace,
 	accentColor,
+	isInSection,
 	onHoverCardOpen,
 	shortcutLabel,
 }: SortableWorkspaceItemProps) {
@@ -36,6 +38,7 @@ export function SortableWorkspaceItem({
 				workspace={workspace}
 				onHoverCardOpen={onHoverCardOpen}
 				shortcutLabel={shortcutLabel}
+				isInSection={isInSection}
 			/>
 		</div>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableWorkspaceItem/SortableWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableWorkspaceItem/SortableWorkspaceItem.tsx
@@ -1,0 +1,42 @@
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import type { DashboardSidebarWorkspace } from "../../types";
+import { DashboardSidebarWorkspaceItem } from "../DashboardSidebarWorkspaceItem";
+
+interface SortableWorkspaceItemProps {
+	sortableId: string;
+	workspace: DashboardSidebarWorkspace;
+	accentColor?: string | null;
+	onHoverCardOpen?: () => void;
+	shortcutLabel?: string;
+}
+
+export function SortableWorkspaceItem({
+	sortableId,
+	workspace,
+	accentColor,
+	onHoverCardOpen,
+	shortcutLabel,
+}: SortableWorkspaceItemProps) {
+	const { setNodeRef, listeners, isDragging, transform, transition } =
+		useSortable({ id: sortableId });
+
+	return (
+		<div
+			ref={setNodeRef}
+			style={{
+				transform: CSS.Translate.toString(transform),
+				transition,
+				opacity: isDragging ? 0.5 : undefined,
+				borderLeft: accentColor ? `2px solid ${accentColor}` : undefined,
+			}}
+			{...listeners}
+		>
+			<DashboardSidebarWorkspaceItem
+				workspace={workspace}
+				onHoverCardOpen={onHoverCardOpen}
+				shortcutLabel={shortcutLabel}
+			/>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableWorkspaceItem/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableWorkspaceItem/index.ts
@@ -1,0 +1,1 @@
+export { SortableWorkspaceItem } from "./SortableWorkspaceItem";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/index.ts
@@ -1,0 +1,1 @@
+export { useSidebarDnd } from "./useSidebarDnd";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
@@ -1,6 +1,7 @@
 import {
 	closestCenter,
 	type DragEndEvent,
+	type DragOverEvent,
 	type DragStartEvent,
 	KeyboardSensor,
 	MeasuringStrategy,
@@ -127,6 +128,7 @@ export function useSidebarDnd({
 			? "section"
 			: "workspace"
 		: null;
+	const [overId, setOverId] = useState<UniqueIdentifier | null>(null);
 	const clonedRef = useRef<UniqueIdentifier[] | null>(null);
 
 	// When dragging a section, SortableContext only has section IDs.
@@ -214,6 +216,22 @@ export function useSidebarDnd({
 		return sec ? { type: "section" as const, section: sec } : null;
 	}, [activeId, workspacesById, sectionsById]);
 
+	// Color the active workspace's ghost should show based on where it would land
+	const predictedColor = useMemo(() => {
+		if (!activeId || !overId || activeType !== "workspace") return null;
+		const overIndex = flatItems.indexOf(overId);
+		if (overIndex === -1) return null;
+		// Walk backwards from the over position to find the nearest section header
+		for (let i = overIndex; i >= 0; i--) {
+			const p = parseId(flatItems[i]);
+			if (p?.type === "section") {
+				const sec = sectionsById.get(p.realId);
+				return sec?.color ?? null;
+			}
+		}
+		return null; // ungrouped — no section above
+	}, [activeId, overId, activeType, flatItems, sectionsById]);
+
 	// ── Persistence ──────────────────────────────────────────────────
 
 	const commitToDb = useCallback(
@@ -243,9 +261,14 @@ export function useSidebarDnd({
 		[flatItems],
 	);
 
+	const onDragOver = useCallback(({ over }: DragOverEvent) => {
+		setOverId(over?.id ?? null);
+	}, []);
+
 	const onDragEnd = useCallback(
 		({ active, over }: DragEndEvent) => {
 			setActiveId(null);
+			setOverId(null);
 
 			if (!over || active.id === over.id) return;
 
@@ -306,6 +329,7 @@ export function useSidebarDnd({
 			setFlatItems(clonedRef.current);
 		}
 		setActiveId(null);
+		setOverId(null);
 		clonedRef.current = null;
 	}, []);
 
@@ -318,9 +342,10 @@ export function useSidebarDnd({
 		activeId,
 		activeType,
 		activeItem,
+		predictedColor,
 		groupInfo,
 		workspacesById,
 		sectionsById,
-		handlers: { onDragStart, onDragEnd, onDragCancel },
+		handlers: { onDragStart, onDragOver, onDragEnd, onDragCancel },
 	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
@@ -141,6 +141,7 @@ export function useSidebarDnd({
 	// Sync from external data when items or their order/membership changes
 	const prevFingerprintRef = useRef("");
 	useEffect(() => {
+		if (activeId) return; // Don't reset during active drag
 		const fingerprint = projectChildren
 			.map((c) =>
 				c.type === "workspace"
@@ -152,7 +153,7 @@ export function useSidebarDnd({
 			prevFingerprintRef.current = fingerprint;
 			setFlatItems(buildFlatItems(projectChildren));
 		}
-	}, [projectChildren]);
+	}, [projectChildren, activeId]);
 
 	const collapsedSectionIds = useMemo(() => {
 		const set = new Set<string>();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
@@ -1,0 +1,297 @@
+import {
+	closestCenter,
+	type DragEndEvent,
+	type DragStartEvent,
+	KeyboardSensor,
+	MeasuringStrategy,
+	MouseSensor,
+	TouchSensor,
+	type UniqueIdentifier,
+	useSensor,
+	useSensors,
+} from "@dnd-kit/core";
+import { arrayMove, sortableKeyboardCoordinates } from "@dnd-kit/sortable";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
+import type {
+	DashboardSidebarProjectChild,
+	DashboardSidebarSection,
+	DashboardSidebarWorkspace,
+} from "../../types";
+
+// ── ID helpers ───────────────────────────────────────────────────────
+
+const WS = "ws::";
+const SEC = "sec::";
+
+export const wsId = (id: string) => `${WS}${id}`;
+export const secId = (id: string) => `${SEC}${id}`;
+export const isSec = (id: UniqueIdentifier) => String(id).startsWith(SEC);
+
+export const parseId = (id: UniqueIdentifier) => {
+	const s = String(id);
+	if (s.startsWith(WS))
+		return { type: "workspace" as const, realId: s.slice(WS.length) };
+	if (s.startsWith(SEC))
+		return { type: "section" as const, realId: s.slice(SEC.length) };
+	return null;
+};
+
+// ── Measuring config ─────────────────────────────────────────────────
+
+export const measuring = {
+	droppable: { strategy: MeasuringStrategy.Always as const },
+};
+
+// ── Build flat list from project children ────────────────────────────
+
+function buildFlatItems(
+	children: DashboardSidebarProjectChild[],
+): UniqueIdentifier[] {
+	const items: UniqueIdentifier[] = [];
+	for (const child of children) {
+		if (child.type === "workspace") {
+			items.push(wsId(child.workspace.id));
+		} else {
+			items.push(secId(child.section.id));
+			// Only include workspaces if section is expanded
+			if (!child.section.isCollapsed) {
+				for (const ws of child.section.workspaces) {
+					items.push(wsId(ws.id));
+				}
+			}
+		}
+	}
+	return items;
+}
+
+// ── Parse flat list to determine section membership ──────────────────
+
+interface ParsedFlatItems {
+	topLevel: Array<{ type: "workspace" | "section"; id: string }>;
+	sections: Record<string, string[]>;
+}
+
+function parseFlatItems(items: UniqueIdentifier[]): ParsedFlatItems {
+	const result: ParsedFlatItems = { topLevel: [], sections: {} };
+	let currentSection: string | null = null;
+
+	for (const id of items) {
+		const parsed = parseId(id);
+		if (!parsed) continue;
+		if (parsed.type === "section") {
+			currentSection = parsed.realId;
+			result.topLevel.push({ type: "section", id: parsed.realId });
+			result.sections[parsed.realId] = [];
+		} else if (parsed.type === "workspace") {
+			if (currentSection) {
+				result.sections[currentSection].push(parsed.realId);
+			} else {
+				result.topLevel.push({ type: "workspace", id: parsed.realId });
+			}
+		}
+	}
+	return result;
+}
+
+// ── Hook ─────────────────────────────────────────────────────────────
+
+interface UseSidebarDndOptions {
+	projectId: string;
+	projectChildren: DashboardSidebarProjectChild[];
+}
+
+export function useSidebarDnd({
+	projectId,
+	projectChildren,
+}: UseSidebarDndOptions) {
+	const { reorderProjectChildren, moveWorkspaceToSectionAtIndex } =
+		useDashboardSidebarState();
+
+	const sensors = useSensors(
+		useSensor(MouseSensor, { activationConstraint: { distance: 8 } }),
+		useSensor(TouchSensor, {
+			activationConstraint: { delay: 200, tolerance: 5 },
+		}),
+		useSensor(KeyboardSensor, {
+			coordinateGetter: sortableKeyboardCoordinates,
+		}),
+	);
+
+	const [flatItems, setFlatItems] = useState<UniqueIdentifier[]>(() =>
+		buildFlatItems(projectChildren),
+	);
+	const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null);
+	const clonedRef = useRef<UniqueIdentifier[] | null>(null);
+
+	// Sync from external data only when items are added/removed
+	const prevFingerprintRef = useRef("");
+	useEffect(() => {
+		const fingerprint = projectChildren
+			.map((c) =>
+				c.type === "workspace"
+					? c.workspace.id
+					: `s:${c.section.id}:${c.section.isCollapsed}`,
+			)
+			.sort()
+			.join(",");
+		if (fingerprint !== prevFingerprintRef.current) {
+			prevFingerprintRef.current = fingerprint;
+			setFlatItems(buildFlatItems(projectChildren));
+		}
+	}, [projectChildren]);
+
+	// ── Lookups ──────────────────────────────────────────────────────
+
+	const workspacesById = useMemo(() => {
+		const map = new Map<string, DashboardSidebarWorkspace>();
+		for (const child of projectChildren) {
+			if (child.type === "workspace") {
+				map.set(child.workspace.id, child.workspace);
+			} else {
+				for (const ws of child.section.workspaces) {
+					map.set(ws.id, ws);
+				}
+			}
+		}
+		return map;
+	}, [projectChildren]);
+
+	const sectionsById = useMemo(() => {
+		const map = new Map<string, DashboardSidebarSection>();
+		for (const child of projectChildren) {
+			if (child.type === "section") {
+				map.set(child.section.id, child.section);
+			}
+		}
+		return map;
+	}, [projectChildren]);
+
+	// Which section does each workspace belong to? (for visual grouping)
+	const groupInfo = useMemo(() => {
+		const map = new Map<string, { sectionId: string; color: string | null }>();
+		let currentSection: { id: string; color: string | null } | null = null;
+
+		for (const id of flatItems) {
+			const parsed = parseId(id);
+			if (!parsed) continue;
+			if (parsed.type === "section") {
+				const sec = sectionsById.get(parsed.realId);
+				currentSection = sec ? { id: sec.id, color: sec.color } : null;
+			} else if (parsed.type === "workspace" && currentSection) {
+				map.set(parsed.realId, {
+					sectionId: currentSection.id,
+					color: currentSection.color,
+				});
+			}
+		}
+		return map;
+	}, [flatItems, sectionsById]);
+
+	const activeItem = useMemo(() => {
+		if (!activeId) return null;
+		const parsed = parseId(activeId);
+		if (!parsed) return null;
+		if (parsed.type === "workspace") {
+			const ws = workspacesById.get(parsed.realId);
+			return ws ? { type: "workspace" as const, workspace: ws } : null;
+		}
+		const sec = sectionsById.get(parsed.realId);
+		return sec ? { type: "section" as const, section: sec } : null;
+	}, [activeId, workspacesById, sectionsById]);
+
+	// ── Persistence ──────────────────────────────────────────────────
+
+	const commitToDb = useCallback(
+		(items: UniqueIdentifier[]) => {
+			const parsed = parseFlatItems(items);
+
+			// Top-level order (ungrouped workspaces + sections interleaved)
+			reorderProjectChildren(projectId, parsed.topLevel);
+
+			// Each section's workspace order
+			for (const [sectionId, wsIds] of Object.entries(parsed.sections)) {
+				for (let i = 0; i < wsIds.length; i++) {
+					moveWorkspaceToSectionAtIndex(wsIds[i], projectId, sectionId, i);
+				}
+			}
+		},
+		[projectId, reorderProjectChildren, moveWorkspaceToSectionAtIndex],
+	);
+
+	// ── Handlers ─────────────────────────────────────────────────────
+
+	const onDragStart = useCallback(
+		({ active }: DragStartEvent) => {
+			setActiveId(active.id);
+			clonedRef.current = [...flatItems];
+		},
+		[flatItems],
+	);
+
+	const onDragEnd = useCallback(
+		({ active, over }: DragEndEvent) => {
+			setActiveId(null);
+
+			if (!over || active.id === over.id) return;
+
+			const oldIndex = flatItems.indexOf(active.id);
+			const overIndex = flatItems.indexOf(over.id);
+			if (oldIndex === -1 || overIndex === -1) return;
+
+			let newItems: UniqueIdentifier[];
+
+			if (isSec(active.id)) {
+				// Section drag: move the header AND all its workspaces as a group
+				const groupStart = oldIndex;
+				let groupEnd = groupStart + 1;
+				while (groupEnd < flatItems.length && !isSec(flatItems[groupEnd])) {
+					groupEnd++;
+				}
+				const group = flatItems.slice(groupStart, groupEnd);
+				const without = [
+					...flatItems.slice(0, groupStart),
+					...flatItems.slice(groupEnd),
+				];
+
+				// Find insertion point in the array without the group
+				const newOverIndex = without.indexOf(over.id);
+				const insertAt = newOverIndex >= 0 ? newOverIndex : without.length;
+
+				newItems = [
+					...without.slice(0, insertAt),
+					...group,
+					...without.slice(insertAt),
+				];
+			} else {
+				// Workspace drag: simple arrayMove
+				newItems = arrayMove(flatItems, oldIndex, overIndex);
+			}
+
+			setFlatItems(newItems);
+			commitToDb(newItems);
+		},
+		[flatItems, commitToDb],
+	);
+
+	const onDragCancel = useCallback(() => {
+		if (clonedRef.current) {
+			setFlatItems(clonedRef.current);
+		}
+		setActiveId(null);
+		clonedRef.current = null;
+	}, []);
+
+	return {
+		sensors,
+		measuring,
+		collisionDetection: closestCenter,
+		flatItems,
+		activeId,
+		activeItem,
+		groupInfo,
+		workspacesById,
+		sectionsById,
+		handlers: { onDragStart, onDragEnd, onDragCancel },
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
@@ -122,7 +122,21 @@ export function useSidebarDnd({
 		buildFlatItems(projectChildren),
 	);
 	const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null);
+	const activeType: "workspace" | "section" | null = activeId
+		? isSec(activeId)
+			? "section"
+			: "workspace"
+		: null;
 	const clonedRef = useRef<UniqueIdentifier[] | null>(null);
+
+	// When dragging a section, SortableContext only has section IDs.
+	// When dragging a workspace (or idle), SortableContext has everything.
+	const sortableItems = useMemo(() => {
+		if (activeType === "section") {
+			return flatItems.filter((id) => isSec(id));
+		}
+		return flatItems;
+	}, [flatItems, activeType]);
 
 	// Sync from external data only when items are added/removed
 	const prevFingerprintRef = useRef("");
@@ -235,41 +249,54 @@ export function useSidebarDnd({
 
 			if (!over || active.id === over.id) return;
 
-			const oldIndex = flatItems.indexOf(active.id);
-			const overIndex = flatItems.indexOf(over.id);
-			if (oldIndex === -1 || overIndex === -1) return;
-
-			let newItems: UniqueIdentifier[];
-
 			if (isSec(active.id)) {
-				// Section drag: move the header AND all its workspaces as a group
-				const groupStart = oldIndex;
-				let groupEnd = groupStart + 1;
-				while (groupEnd < flatItems.length && !isSec(flatItems[groupEnd])) {
-					groupEnd++;
+				// Section drag: only section IDs were in the SortableContext.
+				// Reorder sections, then rebuild the full flat list with
+				// workspaces in their original positions under each section.
+				const sectionIds = flatItems.filter((id) => isSec(id));
+				const oldIdx = sectionIds.indexOf(active.id);
+				const newIdx = sectionIds.indexOf(over.id);
+				if (oldIdx === -1 || newIdx === -1 || oldIdx === newIdx) return;
+
+				const reorderedSections = arrayMove(sectionIds, oldIdx, newIdx);
+
+				// Rebuild flat list: ungrouped workspaces first, then
+				// each section with its workspaces in new section order
+				const ungrouped: UniqueIdentifier[] = [];
+				const sectionGroups = new Map<string, UniqueIdentifier[]>();
+
+				let currentSec: string | null = null;
+				for (const id of flatItems) {
+					if (isSec(id)) {
+						currentSec = String(id);
+						sectionGroups.set(currentSec, []);
+					} else if (currentSec) {
+						sectionGroups.get(currentSec)?.push(id);
+					} else {
+						ungrouped.push(id);
+					}
 				}
-				const group = flatItems.slice(groupStart, groupEnd);
-				const without = [
-					...flatItems.slice(0, groupStart),
-					...flatItems.slice(groupEnd),
-				];
 
-				// Find insertion point in the array without the group
-				const newOverIndex = without.indexOf(over.id);
-				const insertAt = newOverIndex >= 0 ? newOverIndex : without.length;
+				const newItems: UniqueIdentifier[] = [...ungrouped];
+				for (const secSortId of reorderedSections) {
+					newItems.push(secSortId);
+					const wsInSec = sectionGroups.get(String(secSortId)) ?? [];
+					newItems.push(...wsInSec);
+				}
 
-				newItems = [
-					...without.slice(0, insertAt),
-					...group,
-					...without.slice(insertAt),
-				];
+				setFlatItems(newItems);
+				commitToDb(newItems);
 			} else {
-				// Workspace drag: simple arrayMove
-				newItems = arrayMove(flatItems, oldIndex, overIndex);
-			}
+				// Workspace drag: simple arrayMove in the full flat list
+				const oldIndex = flatItems.indexOf(active.id);
+				const overIndex = flatItems.indexOf(over.id);
+				if (oldIndex === -1 || overIndex === -1 || oldIndex === overIndex)
+					return;
 
-			setFlatItems(newItems);
-			commitToDb(newItems);
+				const newItems = arrayMove(flatItems, oldIndex, overIndex);
+				setFlatItems(newItems);
+				commitToDb(newItems);
+			}
 		},
 		[flatItems, commitToDb],
 	);
@@ -287,7 +314,9 @@ export function useSidebarDnd({
 		measuring,
 		collisionDetection: closestCenter,
 		flatItems,
+		sortableItems,
 		activeId,
+		activeType,
 		activeItem,
 		groupInfo,
 		workspacesById,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
@@ -221,8 +221,10 @@ export function useSidebarDnd({
 		if (!activeId || !overId || activeType !== "workspace") return null;
 		const overIndex = flatItems.indexOf(overId);
 		if (overIndex === -1) return null;
-		// Walk backwards from the over position to find the nearest section header
-		for (let i = overIndex; i >= 0; i--) {
+		// If over is a section header, the workspace lands ABOVE it,
+		// so look for the section above the over position (skip the over itself)
+		const startFrom = isSec(overId) ? overIndex - 1 : overIndex;
+		for (let i = startFrom; i >= 0; i--) {
 			const p = parseId(flatItems[i]);
 			if (p?.type === "section") {
 				const sec = sectionsById.get(p.realId);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
@@ -138,14 +138,15 @@ export function useSidebarDnd({
 		return flatItems;
 	}, [flatItems, activeType]);
 
-	// Sync from external data only when items are added/removed
+	// Sync from external data when items or their order/membership changes
 	const prevFingerprintRef = useRef("");
 	useEffect(() => {
 		const fingerprint = projectChildren
 			.map((c) =>
-				c.type === "workspace" ? c.workspace.id : `s:${c.section.id}`,
+				c.type === "workspace"
+					? c.workspace.id
+					: `s:${c.section.id}:${c.section.workspaces.map((w) => w.id).join("|")}`,
 			)
-			.sort()
 			.join(",");
 		if (fingerprint !== prevFingerprintRef.current) {
 			prevFingerprintRef.current = fingerprint;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
@@ -55,11 +55,9 @@ function buildFlatItems(
 			items.push(wsId(child.workspace.id));
 		} else {
 			items.push(secId(child.section.id));
-			// Only include workspaces if section is expanded
-			if (!child.section.isCollapsed) {
-				for (const ws of child.section.workspaces) {
-					items.push(wsId(ws.id));
-				}
+			// Always include workspaces so AnimatePresence can animate collapse
+			for (const ws of child.section.workspaces) {
+				items.push(wsId(ws.id));
 			}
 		}
 	}
@@ -145,9 +143,7 @@ export function useSidebarDnd({
 	useEffect(() => {
 		const fingerprint = projectChildren
 			.map((c) =>
-				c.type === "workspace"
-					? c.workspace.id
-					: `s:${c.section.id}:${c.section.isCollapsed}`,
+				c.type === "workspace" ? c.workspace.id : `s:${c.section.id}`,
 			)
 			.sort()
 			.join(",");
@@ -155,6 +151,16 @@ export function useSidebarDnd({
 			prevFingerprintRef.current = fingerprint;
 			setFlatItems(buildFlatItems(projectChildren));
 		}
+	}, [projectChildren]);
+
+	const collapsedSectionIds = useMemo(() => {
+		const set = new Set<string>();
+		for (const child of projectChildren) {
+			if (child.type === "section" && child.section.isCollapsed) {
+				set.add(child.section.id);
+			}
+		}
+		return set;
 	}, [projectChildren]);
 
 	// ── Lookups ──────────────────────────────────────────────────────
@@ -346,6 +352,7 @@ export function useSidebarDnd({
 		activeItem,
 		predictedColor,
 		groupInfo,
+		collapsedSectionIds,
 		workspacesById,
 		sectionsById,
 		handlers: { onDragStart, onDragOver, onDragEnd, onDragCancel },

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
@@ -260,8 +260,18 @@ export function useDashboardSidebarState() {
 
 				let newTabOrder: number;
 				if (firstSectionOrder != null) {
-					// Place just before the first section
-					newTabOrder = firstSectionOrder - 1;
+					// Place right before the first section, after existing ungrouped
+					const ungroupedOrders = Array.from(
+						collections.v2WorkspaceLocalState.state.values(),
+					)
+						.filter(
+							(item) =>
+								item.sidebarState.projectId === projectId &&
+								item.workspaceId !== workspaceId &&
+								item.sidebarState.sectionId === null,
+						)
+						.map((item) => ({ tabOrder: item.sidebarState.tabOrder }));
+					newTabOrder = getNextTabOrder(ungroupedOrders);
 				} else {
 					// No sections — append to end
 					const ungroupedOrders = Array.from(

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
@@ -123,6 +123,63 @@ export function useDashboardSidebarState() {
 		[collections],
 	);
 
+	const reorderProjectChildren = useCallback(
+		(
+			projectId: string,
+			orderedItems: Array<{ type: "workspace" | "section"; id: string }>,
+		) => {
+			orderedItems.forEach((item, index) => {
+				const tabOrder = index + 1;
+				if (item.type === "workspace") {
+					if (!collections.v2WorkspaceLocalState.get(item.id)) return;
+					collections.v2WorkspaceLocalState.update(item.id, (draft) => {
+						draft.sidebarState.tabOrder = tabOrder;
+						draft.sidebarState.sectionId = null;
+						draft.sidebarState.projectId = projectId;
+					});
+				} else {
+					if (!collections.v2SidebarSections.get(item.id)) return;
+					collections.v2SidebarSections.update(item.id, (draft) => {
+						draft.tabOrder = tabOrder;
+					});
+				}
+			});
+		},
+		[collections],
+	);
+
+	const moveWorkspaceToSectionAtIndex = useCallback(
+		(
+			workspaceId: string,
+			projectId: string,
+			sectionId: string,
+			index: number,
+		) => {
+			const existing = collections.v2WorkspaceLocalState.get(workspaceId);
+			if (!existing) return;
+			const siblings = Array.from(
+				collections.v2WorkspaceLocalState.state.values(),
+			)
+				.filter(
+					(item) =>
+						item.sidebarState.projectId === projectId &&
+						item.workspaceId !== workspaceId &&
+						item.sidebarState.sectionId === sectionId,
+				)
+				.sort((a, b) => a.sidebarState.tabOrder - b.sidebarState.tabOrder);
+			const reordered = [...siblings];
+			reordered.splice(index, 0, existing);
+			reordered.forEach((item, i) => {
+				collections.v2WorkspaceLocalState.update(item.workspaceId, (draft) => {
+					draft.sidebarState.tabOrder = i + 1;
+					draft.sidebarState.sectionId = sectionId;
+					draft.sidebarState.projectId = projectId;
+				});
+			});
+		},
+		[collections],
+	);
+
 	const createSection = useCallback(
 		(projectId: string, name = "New Section") => {
 			ensureSidebarProjectRecord(collections, projectId);
@@ -274,7 +331,9 @@ export function useDashboardSidebarState() {
 		ensureProjectInSidebar,
 		ensureWorkspaceInSidebar,
 		moveWorkspaceToSection,
+		moveWorkspaceToSectionAtIndex,
 		removeProjectFromSidebar,
+		reorderProjectChildren,
 		removeWorkspaceFromSidebar,
 		reorderProjects,
 		reorderWorkspaces,

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
@@ -2,6 +2,7 @@ import type { WorkspaceState } from "@superset/panes";
 import { useCallback } from "react";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { AppCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider/collections";
+import { PROJECT_CUSTOM_COLORS } from "shared/constants/project-colors";
 
 function getNextTabOrder(items: Array<{ tabOrder: number }>): number {
 	const maxTabOrder = items.reduce(
@@ -189,6 +190,11 @@ export function useDashboardSidebarState() {
 				collections.v2SidebarSections.state.values(),
 			).filter((item) => item.projectId === projectId);
 
+			const randomColor =
+				PROJECT_CUSTOM_COLORS[
+					Math.floor(Math.random() * PROJECT_CUSTOM_COLORS.length)
+				].value;
+
 			collections.v2SidebarSections.insert({
 				sectionId,
 				projectId,
@@ -196,7 +202,7 @@ export function useDashboardSidebarState() {
 				createdAt: new Date(),
 				tabOrder: getNextTabOrder(sectionOrders),
 				isCollapsed: false,
-				color: null,
+				color: randomColor,
 			});
 
 			return sectionId;
@@ -238,6 +244,45 @@ export function useDashboardSidebarState() {
 		(workspaceId: string, projectId: string, sectionId: string | null) => {
 			const existing = collections.v2WorkspaceLocalState.get(workspaceId);
 			if (!existing) return;
+
+			if (sectionId === null) {
+				// "Remove from group" — place right above the first section.
+				// Find the lowest section tabOrder, then use tabOrder - 1.
+				// If no sections exist, append to end of ungrouped workspaces.
+				const sectionOrders = Array.from(
+					collections.v2SidebarSections.state.values(),
+				)
+					.filter((s) => s.projectId === projectId)
+					.map((s) => s.tabOrder);
+
+				const firstSectionOrder =
+					sectionOrders.length > 0 ? Math.min(...sectionOrders) : null;
+
+				let newTabOrder: number;
+				if (firstSectionOrder != null) {
+					// Place just before the first section
+					newTabOrder = firstSectionOrder - 1;
+				} else {
+					// No sections — append to end
+					const ungroupedOrders = Array.from(
+						collections.v2WorkspaceLocalState.state.values(),
+					)
+						.filter(
+							(item) =>
+								item.sidebarState.projectId === projectId &&
+								item.workspaceId !== workspaceId &&
+								item.sidebarState.sectionId === null,
+						)
+						.map((item) => ({ tabOrder: item.sidebarState.tabOrder }));
+					newTabOrder = getNextTabOrder(ungroupedOrders);
+				}
+
+				collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
+					draft.sidebarState.sectionId = null;
+					draft.sidebarState.tabOrder = newTabOrder;
+				});
+				return;
+			}
 
 			const siblingRows = Array.from(
 				collections.v2WorkspaceLocalState.state.values(),

--- a/apps/desktop/src/shared/constants/project-colors.test.ts
+++ b/apps/desktop/src/shared/constants/project-colors.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import {
-	PROJECT_COLOR_DEFAULT,
-	PROJECT_COLORS,
-	PROJECT_CUSTOM_COLORS,
-} from "./project-colors";
+import { PROJECT_COLORS, PROJECT_CUSTOM_COLORS } from "./project-colors";
 
 function hexToRgb(hex: string) {
 	const normalizedHex = hex.replace("#", "");
@@ -32,7 +28,7 @@ describe("PROJECT_COLORS", () => {
 
 		expect(new Set(colorNames).size).toBe(colorNames.length);
 		expect(new Set(colorValues).size).toBe(colorValues.length);
-		expect(PROJECT_COLORS[0]?.value).toBe(PROJECT_COLOR_DEFAULT);
+		expect(PROJECT_COLORS.length).toBeGreaterThan(0);
 	});
 
 	it("keeps custom swatches visually distinct", () => {

--- a/apps/desktop/src/shared/constants/project-colors.ts
+++ b/apps/desktop/src/shared/constants/project-colors.ts
@@ -2,7 +2,6 @@
 export const PROJECT_COLOR_DEFAULT = "default";
 
 export const PROJECT_COLORS = [
-	{ name: "Default", value: PROJECT_COLOR_DEFAULT },
 	{ name: "Red", value: "#ef4444" },
 	{ name: "Orange", value: "#f97316" },
 	{ name: "Yellow", value: "#eab308" },
@@ -17,9 +16,7 @@ export const PROJECT_COLORS = [
 	{ name: "Slate", value: "#64748b" },
 ] as const;
 
-export const PROJECT_CUSTOM_COLORS = PROJECT_COLORS.filter(
-	(color) => color.value !== PROJECT_COLOR_DEFAULT,
-);
+export const PROJECT_CUSTOM_COLORS = PROJECT_COLORS;
 
 export const PROJECT_COLOR_VALUES: string[] = PROJECT_COLORS.map(
 	(color) => color.value,


### PR DESCRIPTION
## Summary

- Implement drag-and-drop for workspaces, sections, and projects in the v2 dashboard sidebar using @dnd-kit
- Uses a flat list approach: sections are just header dividers, position determines section membership
- Workspace drag and section drag are separate modes — sections collapse their workspaces during section drag
- Project-level drag reordering with content collapse animation

## Key design decisions

- **Flat list, not multi-container**: Sections are dividers in a single `SortableContext`, not containers. This eliminates all multi-container complexity (no `onDragOver`, no `findContainer`, no custom collision detection)
- **Two drag modes**: When dragging a workspace, sections are disabled sortable items (static dividers). When dragging a section, workspaces are hidden and only sections participate
- **Position = membership**: Workspaces before the first section are ungrouped. Workspaces after a section header belong to that section
- **Predicted color**: Ghost shows the accent color of the section it would land in during drag

## Changes

- New `useSidebarDnd` hook with flat list state management
- New `SortableSectionHeader`, `SortableWorkspaceItem`, `SidebarDragOverlay` components
- `reorderProjectChildren` and `moveWorkspaceToSectionAtIndex` mutations
- Project-level `DndContext` in `DashboardSidebar.tsx`
- Section header grip icon, context menu improvements (Remove from Group, color dots)
- Always show workspace name + branch, scroll active into view
- Remove Default from color palette, sections always get random color

## Test plan

- [ ] Drag workspace to reorder among ungrouped workspaces
- [ ] Drag workspace below a section header → joins section (gets accent color)
- [ ] Drag workspace above all sections → becomes ungrouped
- [ ] Drag section via grip → workspaces collapse, sections reorder
- [ ] Drag project → content collapses, projects reorder
- [ ] Collapse/expand sections with animation
- [ ] Move to Section via context menu
- [ ] Remove from Group via context menu
- [ ] Cancel drag (ESC) restores original order

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds drag-and-drop reordering for projects, sections, and workspaces in the v2 sidebar using `@dnd-kit` with a flat list model where position defines group membership. This simplifies DnD, improves keyboard accessibility, and smooths reordering animations.

- **New Features**
  - Flat list DnD: sections are headers; position = membership (above first section = ungrouped).
  - Two drag modes: workspace reorders across/into sections; section drag via grip moves as a group with collapsed contents.
  - Project-level reordering with a drag handle and overlay; order persists.
  - Drag overlay: workspace ghost shows predicted section color; section overlay with grip and count.
  - Context menu polish: Move to Section shows color dots; “Remove from Group” appears only when grouped.
  - UX: always show workspace name + branch; active workspace scrolls into view; ESC cancels and restores; sections get a random color (no “Default”).

- **Bug Fixes**
  - Fixed tabOrder collisions when removing multiple workspaces from groups by using next-available ordering for ungrouped items.
  - Guarded flat-list sync with active drag to avoid overwriting local drag state.
  - Added missing `useSortable` attributes to workspace items for full keyboard DnD support.

<sup>Written for commit 5a615255b9989f7fc11d18c2c40d450918e18963. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drag-and-drop reordering for projects, sections, and workspaces in the dashboard sidebar.
  * Move workspaces into/out of groups with precise placement.

* **UI/UX Improvements**
  * Visual drag preview overlay and grip handles while dragging.
  * Smooth animations for expanding/collapsing sections and reordering feedback.
  * Group color support and color indicators in menus and headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->