### PR TITLE
fix: fall back to FETCH_HEAD when gh pr checkout fails for branch names with /

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
@@ -1777,18 +1777,42 @@ export async function createWorktreeFromPr({
 			});
 		}
 
-		await execWithShellEnv(
-			"gh",
-			[
-				"pr",
-				"checkout",
-				String(prInfo.number),
-				"--branch",
-				localBranchName,
-				"--force",
-			],
-			{ cwd: worktreePath, timeout: 120_000 },
-		);
+		try {
+			await execWithShellEnv(
+				"gh",
+				[
+					"pr",
+					"checkout",
+					String(prInfo.number),
+					"--branch",
+					localBranchName,
+					"--force",
+				],
+				{ cwd: worktreePath, timeout: 120_000 },
+			);
+		} catch (ghError) {
+			const ghMsg = ghError instanceof Error ? ghError.message : String(ghError);
+			// `gh pr checkout` can fail with "is not a branch" when the branch name
+			// contains '/' (e.g. "user/feature-branch"). Git has trouble resolving
+			// "origin/user/feature-branch" as a tracking ref inside a worktree.
+			// gh already fetched the remote successfully, so FETCH_HEAD points to
+			// the right commit — fall back to creating the branch without tracking.
+			if (!ghMsg.includes("is not a branch")) {
+				throw ghError;
+			}
+			await execGitWithShellPath(
+				[
+					"-C",
+					worktreePath,
+					"checkout",
+					"-b",
+					localBranchName,
+					"--no-track",
+					"FETCH_HEAD",
+				],
+				{ timeout: 30_000 },
+			);
+		}
 
 		// Enable autoSetupRemote so `git push` just works without -u flag.
 		await execGitWithShellPath(

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
@@ -1805,7 +1805,7 @@ export async function createWorktreeFromPr({
 					"-C",
 					worktreePath,
 					"checkout",
-					"-b",
+					"-B",
 					localBranchName,
 					"--no-track",
 					"FETCH_HEAD",

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
@@ -1800,6 +1800,9 @@ export async function createWorktreeFromPr({
 			if (!ghMsg.includes("is not a branch")) {
 				throw ghError;
 			}
+			console.log(
+				`[git] gh pr checkout failed with tracking error for PR #${prInfo.number}, falling back to FETCH_HEAD checkout`,
+			);
 			await execGitWithShellPath(
 				[
 					"-C",


### PR DESCRIPTION
Closes #3231

## What

When creating a workspace linked to a PR whose branch name contains `/` (e.g. `user/feature-branch`), `gh pr checkout` internally runs `git checkout -b <branch> --track origin/<branch>`. Inside a freshly created detached worktree, git cannot resolve the remote tracking ref when the branch name has a `/`, producing:

> fatal: cannot set up tracking information; starting point 'origin/user/feature-branch' is not a branch

The fetch itself succeeds — only the `--track` setup fails.

## Fix

Wrap the `gh pr checkout` call in a try/catch. When the error contains "is not a branch", fall back to:

```bash
git checkout -b <localBranchName> --no-track FETCH_HEAD
```

Since `gh pr checkout` already fetched the remote before failing, `FETCH_HEAD` points to the correct commit. `push.autoSetupRemote = true` (already configured after worktree creation) handles push tracking without needing `--track`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PR checkout when branch names contain "/" by falling back to a local `FETCH_HEAD` checkout if `gh pr checkout` fails. Restores workspace creation and logs the fallback path for easier debugging (fixes #3231).

- **Bug Fixes**
  - Try/catch `gh pr checkout`; on "is not a branch", run `git checkout -B <localBranchName> --no-track FETCH_HEAD` to create/replace the local branch.
  - Reuses the fetch done by `gh`; `FETCH_HEAD` points to the right commit.
  - Logs a clear message when using the fallback to aid troubleshooting.
  - Keeps `push.autoSetupRemote=true` so `git push` sets upstream without `--track`.

<sup>Written for commit 919665d8907be59df741db917ef449f83e6c5cbe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of branch checkout in workspace management: when the primary checkout method fails with a specific error, the system falls back to an alternative checkout to ensure the branch is created reliably, reducing failed branch setup scenarios and improving developer workflow continuity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->