### PR TITLE
perf(desktop): increase port scan interval and skip scan when no sessions

### DIFF
--- a/apps/desktop/src/main/lib/terminal/port-manager.ts
+++ b/apps/desktop/src/main/lib/terminal/port-manager.ts
@@ -8,8 +8,10 @@ import {
 } from "./port-scanner";
 import type { TerminalSession } from "./types";
 
-// How often to poll for port changes (in ms)
-const SCAN_INTERVAL_MS = 2500;
+// How often to poll for port changes (in ms).
+// The hint scan handles prompt detection — this is a safety-net sweep, so a
+// longer interval is fine and reduces process-spawn noise for security agents.
+const SCAN_INTERVAL_MS = 10_000;
 
 // Delay before scanning after a port hint is detected (in ms)
 const HINT_SCAN_DELAY_MS = 500;
@@ -354,6 +356,8 @@ class PortManager extends EventEmitter {
 
 	private async scanAllSessions(): Promise<void> {
 		if (this.isScanning) return;
+		// Nothing to scan — skip to avoid spawning ps/lsof unnecessarily.
+		if (this.sessions.size === 0 && this.daemonSessions.size === 0) return;
 		this.isScanning = true;
 
 		try {


### PR DESCRIPTION
## Summary

- Increase the periodic port scan interval from 2,500ms to 10,000ms. The hint-based scan already fires within 500ms of detecting "listening on port X" in terminal output, so the periodic sweep is just a safety net and a longer interval is fine.
- Skip the scan entirely when no sessions are registered, avoiding unnecessary `ps`/`lsof` spawns on startup or after all terminals are closed.

Each scan spawns `ps` (via `pidtree`) per session plus one `lsof` call. These process spawns are intercepted by kernel-level security agents (e.g. Elastic Endpoint), which inspect every file those processes open. Reducing scan frequency directly reduces EDR CPU load.

Part of #3235

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the desktop port scan interval to 10s and skip scans when no sessions exist. The hint-based scan still triggers within 500ms; this reduces background `ps`/`lsof` spawns and CPU load with security agents, addressing Linear #3235.

<sup>Written for commit a4431b21d0c5ef2692d593d530cc14c68ddbaa37. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized port scanning behavior to improve efficiency and reduce system resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->