### PR TITLE
fix: add restart policy to Electric SQL containers

### DIFF
--- a/.superset/lib/setup/steps.sh
+++ b/.superset/lib/setup/steps.sh
@@ -259,6 +259,7 @@ step_start_electric() {
 
   if ! docker run -d \
       --name "$ELECTRIC_CONTAINER" \
+      --restart unless-stopped \
       $port_flag \
       -e DATABASE_URL="$DIRECT_URL" \
       -e ELECTRIC_SECRET="$ELECTRIC_SECRET" \


### PR DESCRIPTION
## Summary
- Add `--restart unless-stopped` to the Electric SQL `docker run` command in workspace setup.

## Why / Context
Electric SQL containers die whenever the laptop sleeps and wakes. Docker Desktop's Resource Saver pauses the Linux VM on idle/sleep, and when it resumes, containers with no restart policy (the default `no`) stay dead — exiting with code 137 (SIGKILL) or code 1 (lost DB connection on resume).

This affects every developer workspace since each one spins up its own Electric container.

## How It Works
Single flag addition: `--restart unless-stopped` tells Docker to automatically restart the container after any non-manual stop (VM pause/resume, OOM, crash). Containers explicitly stopped via `docker stop` (e.g., during teardown) remain stopped as expected.

## Testing
- Verified `docker inspect --format '{{json .HostConfig.RestartPolicy}}'` shows `{"Name":"unless-stopped","MaximumRetryCount":0}` on newly created containers
- Existing teardown (`docker stop` + `docker rm`) still works — `unless-stopped` does not interfere with explicit stops

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the `--restart unless-stopped` policy to the Electric SQL container in workspace setup so it auto-restarts after sleep/resume. Prevents containers from staying dead after Docker Desktop pauses the VM, without affecting explicit `docker stop` teardown.

<sup>Written for commit fca446575fc768f8f9230e0b4a951603bc53a497. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Electric SQL container's restart policy to automatically recover from unexpected stops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->