### PR TITLE
feat(desktop): enable Kitty keyboard protocol for v2 terminal

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -47,6 +47,7 @@ function createTerminal(
 		macOptionIsMeta: false,
 		cursorStyle: "block",
 		cursorInactiveStyle: "outline",
+		vtExtensions: { kittyKeyboard: true },
 		scrollbar: { showScrollbar: false },
 	});
 	terminal.loadAddon(fitAddon);


### PR DESCRIPTION
## Summary
- Enables the [Kitty keyboard protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/) on the v2 terminal runtime via `vtExtensions: { kittyKeyboard: true }`
- Programs like neovim, fish 4+, and others will auto-detect and use enhanced keyboard reporting (modifier disambiguation, key release events, distinguishing Enter from Ctrl+M, etc.)
- Matches VS Code's terminal behavior

## Test plan
- [ ] Open a v2 workspace terminal
- [ ] Run `cat -v` and press modifier combos (Ctrl+Shift+A, etc.) — should see enhanced CSI u sequences
- [ ] Run neovim and verify modifier-aware keybindings work
- [ ] Run fish 4+ and verify enhanced key handling
- [ ] Verify basic terminal input (typing, Enter, Backspace, arrow keys) still works normally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the Kitty keyboard protocol in the v2 terminal runtime via `vtExtensions: { kittyKeyboard: true }` for enhanced keyboard reporting. Tools like neovim and fish 4+ now get modifier-aware keys, key release events, and distinct Enter vs Ctrl+M, matching VS Code’s terminal behavior.

<sup>Written for commit 7c27d89d105de3fe2e05b7bce40ab8be7f4a4e4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for kitty keyboard protocol extensions in the terminal, enabling improved keyboard input handling and compatibility with advanced terminal emulators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->