### PR TITLE
Fix(marketing): serve correct download link for Intel Mac users

### DIFF
--- a/apps/marketing/src/app/components/CTAButtons/HeaderCTA.tsx
+++ b/apps/marketing/src/app/components/CTAButtons/HeaderCTA.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-import { DOWNLOAD_URL_MAC_ARM64 } from "@superset/shared/constants";
+import {
+	DOWNLOAD_URL_MAC_ARM64,
+	DOWNLOAD_URL_MAC_X64,
+} from "@superset/shared/constants";
 import { Download } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
@@ -16,7 +19,9 @@ interface HeaderCTAProps {
 }
 
 export function HeaderCTA({ isLoggedIn, dashboardUrl }: HeaderCTAProps) {
-	const { os, isMobile } = usePlatform();
+	const { os, isMobile, macArch } = usePlatform();
+	const downloadUrl =
+		macArch === "x64" ? DOWNLOAD_URL_MAC_X64 : DOWNLOAD_URL_MAC_ARM64;
 	const [isWaitlistOpen, setIsWaitlistOpen] = useState(false);
 	const portalRef = useRef<HTMLElement | null>(null);
 
@@ -63,9 +68,9 @@ export function HeaderCTA({ isLoggedIn, dashboardUrl }: HeaderCTAProps) {
 			{dashboardLink}
 			{showDownload ? (
 				<a
-					href={DOWNLOAD_URL_MAC_ARM64}
+					href={downloadUrl}
 					className="px-4 py-2 text-sm font-normal bg-foreground text-background hover:bg-foreground/90 transition-colors flex items-center justify-center gap-2"
-					onClick={() => track("download_clicked")}
+					onClick={() => track("download_clicked", { arch: macArch })}
 				>
 					Download for macOS
 					<Download className="size-4" aria-hidden="true" />

--- a/apps/marketing/src/app/components/DownloadButton/DownloadButton.tsx
+++ b/apps/marketing/src/app/components/DownloadButton/DownloadButton.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { COMPANY, DOWNLOAD_URL_MAC_ARM64 } from "@superset/shared/constants";
+import {
+	COMPANY,
+	DOWNLOAD_URL_MAC_ARM64,
+	DOWNLOAD_URL_MAC_X64,
+} from "@superset/shared/constants";
 import { HiMiniArrowDownTray, HiMiniClock } from "react-icons/hi2";
 import { track } from "@/lib/analytics";
 import { usePlatform } from "../../hooks/useOS";
@@ -17,7 +21,16 @@ export function DownloadButton({
 	className = "",
 	onJoinWaitlist,
 }: DownloadButtonProps) {
-	const { os, isMobile } = usePlatform();
+	const { os, isMobile, macArch } = usePlatform();
+
+	const primaryUrl =
+		macArch === "x64" ? DOWNLOAD_URL_MAC_X64 : DOWNLOAD_URL_MAC_ARM64;
+	const primaryLabel =
+		macArch === "x64" ? "Apple Intel" : "Apple Silicon";
+	const altUrl =
+		macArch === "x64" ? DOWNLOAD_URL_MAC_ARM64 : DOWNLOAD_URL_MAC_X64;
+	const altLabel =
+		macArch === "x64" ? "Apple Silicon" : "Apple Intel";
 
 	const sizeClasses =
 		size === "sm"
@@ -26,54 +39,65 @@ export function DownloadButton({
 
 	const buttonClasses = `bg-foreground text-background ${sizeClasses} font-normal hover:bg-foreground/80 transition-colors flex items-center gap-2 ${className}`;
 
+	const appleIcon = (
+		<svg
+			width="20"
+			height="20"
+			viewBox="0 0 24 24"
+			fill="currentColor"
+			xmlns="http://www.w3.org/2000/svg"
+			aria-label="Apple logo"
+		>
+			<title>Apple logo</title>
+			<path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
+		</svg>
+	);
+
+	const githubIcon = (
+		<svg
+			width="16"
+			height="16"
+			viewBox="0 0 24 24"
+			fill="currentColor"
+			xmlns="http://www.w3.org/2000/svg"
+			aria-label="GitHub logo"
+		>
+			<title>GitHub logo</title>
+			<path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z" />
+		</svg>
+	);
+
 	if (isMobile) {
-		const appleIcon = (
-			<svg
-				width="20"
-				height="20"
-				viewBox="0 0 24 24"
-				fill="currentColor"
-				xmlns="http://www.w3.org/2000/svg"
-				aria-label="Apple logo"
-			>
-				<title>Apple logo</title>
-				<path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
-			</svg>
-		);
-
-		const githubIcon = (
-			<svg
-				width="16"
-				height="16"
-				viewBox="0 0 24 24"
-				fill="currentColor"
-				xmlns="http://www.w3.org/2000/svg"
-				aria-label="GitHub logo"
-			>
-				<title>GitHub logo</title>
-				<path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z" />
-			</svg>
-		);
-
 		const sections: DropdownSection[] = [
 			{
 				items: [
 					{
-						id: "mac-download",
+						id: "mac-download-primary",
 						label: "Download for Mac",
-						description: "APPLE SILICON",
+						description: primaryLabel.toUpperCase(),
 						icon: appleIcon,
 						onClick: () => {
-							track("download_clicked");
-							window.open(DOWNLOAD_URL_MAC_ARM64, "_blank");
+							track("download_clicked", { arch: macArch });
+							window.open(primaryUrl, "_blank");
 						},
 						variant: "primary",
 					},
 				],
 			},
 			{
-				title: "Other platforms",
+				title: "Other options",
 				items: [
+					{
+						id: "mac-download-alt",
+						label: `Download for Mac (${altLabel})`,
+						icon: appleIcon,
+						onClick: () => {
+							track("download_clicked", {
+								arch: macArch === "x64" ? "arm64" : "x64",
+							});
+							window.open(altUrl, "_blank");
+						},
+					},
 					{
 						id: "waitlist",
 						label: "Join waitlist for Windows & Linux",
@@ -106,19 +130,56 @@ export function DownloadButton({
 	}
 
 	if (os === "macos" || os === "unknown") {
-		return (
-			<button
-				type="button"
-				className={buttonClasses}
-				onClick={() => {
-					track("download_clicked");
-					window.open(DOWNLOAD_URL_MAC_ARM64, "_blank");
-				}}
-			>
+		const sections: DropdownSection[] = [
+			{
+				items: [
+					{
+						id: "mac-download-primary",
+						label: "Download for Mac",
+						description: primaryLabel.toUpperCase(),
+						icon: appleIcon,
+						onClick: () => {
+							track("download_clicked", { arch: macArch });
+							window.open(primaryUrl, "_blank");
+						},
+						variant: "primary",
+					},
+				],
+			},
+			{
+				title: "Other options",
+				items: [
+					{
+						id: "mac-download-alt",
+						label: `Download for Mac (${altLabel})`,
+						icon: appleIcon,
+						onClick: () => {
+							track("download_clicked", {
+								arch: macArch === "x64" ? "arm64" : "x64",
+							});
+							window.open(altUrl, "_blank");
+						},
+					},
+					{
+						id: "build-from-source",
+						label: "Build from source on GitHub",
+						icon: githubIcon,
+						onClick: () => window.open(COMPANY.GITHUB_URL, "_blank"),
+					},
+				],
+			},
+		];
+
+		const trigger = (
+			<button type="button" className={buttonClasses}>
 				<span className="hidden sm:inline">Download for macOS</span>
 				<span className="sm:hidden">Download</span>
 				<HiMiniArrowDownTray className="size-4" />
 			</button>
+		);
+
+		return (
+			<PlatformDropdown trigger={trigger} sections={sections} align="end" />
 		);
 	}
 

--- a/apps/marketing/src/app/hooks/useOS/index.ts
+++ b/apps/marketing/src/app/hooks/useOS/index.ts
@@ -1,1 +1,1 @@
-export { type OS, type PlatformInfo, usePlatform } from "./useOS";
+export { type MacArch, type OS, type PlatformInfo, usePlatform } from "./useOS";

--- a/apps/marketing/src/app/hooks/useOS/useOS.ts
+++ b/apps/marketing/src/app/hooks/useOS/useOS.ts
@@ -2,15 +2,17 @@ import { useEffect, useState } from "react";
 import { UAParser } from "ua-parser-js";
 
 export type OS = "macos" | "windows" | "linux" | "unknown";
+export type MacArch = "arm64" | "x64" | "unknown";
 
 export interface PlatformInfo {
 	os: OS;
 	isMobile: boolean;
+	macArch: MacArch;
 }
 
 function detectPlatform(): PlatformInfo {
 	if (typeof navigator === "undefined") {
-		return { os: "unknown", isMobile: false };
+		return { os: "unknown", isMobile: false, macArch: "unknown" };
 	}
 
 	const parser = new UAParser(navigator.userAgent);
@@ -24,16 +26,75 @@ function detectPlatform(): PlatformInfo {
 	else if (osName.includes("windows")) os = "windows";
 	else if (osName.includes("linux")) os = "linux";
 
-	return { os, isMobile };
+	return { os, isMobile, macArch: "unknown" };
 }
 
-const DEFAULT_PLATFORM: PlatformInfo = { os: "unknown", isMobile: false };
+async function detectMacArch(): Promise<MacArch> {
+	if (typeof navigator === "undefined") return "unknown";
+
+	// Chromium browsers: use high-entropy UA data
+	if ("userAgentData" in navigator && navigator.userAgentData) {
+		try {
+			const ua = navigator.userAgentData as NavigatorUABrandVersion;
+			const values = await ua.getHighEntropyValues(["architecture"]);
+			if (values.architecture === "arm") return "arm64";
+			if (values.architecture === "x86") return "x64";
+		} catch {
+			// Fall through to WebGL detection
+		}
+	}
+
+	// Safari / fallback: check WebGL renderer for Apple Silicon vs Intel
+	try {
+		const canvas = document.createElement("canvas");
+		const gl =
+			canvas.getContext("webgl2") || canvas.getContext("webgl");
+		if (gl) {
+			const debugExt = gl.getExtension("WEBGL_debug_renderer_info");
+			if (debugExt) {
+				const renderer = gl.getParameter(
+					debugExt.UNMASKED_RENDERER_WEBGL,
+				) as string;
+				if (/apple m\d/i.test(renderer) || /apple gpu/i.test(renderer)) {
+					return "arm64";
+				}
+				if (/intel/i.test(renderer)) {
+					return "x64";
+				}
+			}
+		}
+	} catch {
+		// WebGL not available
+	}
+
+	// Default to arm64 — most modern Macs are Apple Silicon
+	return "arm64";
+}
+
+interface NavigatorUABrandVersion {
+	getHighEntropyValues(
+		hints: string[],
+	): Promise<{ architecture?: string }>;
+}
+
+const DEFAULT_PLATFORM: PlatformInfo = {
+	os: "unknown",
+	isMobile: false,
+	macArch: "unknown",
+};
 
 export function usePlatform(): PlatformInfo {
 	const [platform, setPlatform] = useState<PlatformInfo>(DEFAULT_PLATFORM);
 
 	useEffect(() => {
-		setPlatform(detectPlatform());
+		const info = detectPlatform();
+		setPlatform(info);
+
+		if (info.os === "macos") {
+			detectMacArch().then((arch) => {
+				setPlatform((prev) => ({ ...prev, macArch: arch }));
+			});
+		}
 	}, []);
 
 	return platform;

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -34,6 +34,7 @@ export const THEME_STORAGE_KEY = "superset-theme";
 
 // Download URLs
 export const DOWNLOAD_URL_MAC_ARM64 = `${COMPANY.GITHUB_URL}/releases/latest/download/Superset-arm64.dmg`;
+export const DOWNLOAD_URL_MAC_X64 = `${COMPANY.GITHUB_URL}/releases/latest/download/Superset-x64.dmg`;
 
 // Auth token configuration
 export const TOKEN_CONFIG = {


### PR DESCRIPTION
## Description

Intel Mac users were always receiving the ARM64 `.dmg` download link, which won't install on their machines. Added CPU architecture detection to distinguish Apple Silicon vs Intel, so the download button auto-selects the correct `.dmg`. A dropdown now provides both options so users can manually switch if needed.

**Detection strategy:**
1. **Chromium** — `navigator.userAgentData.getHighEntropyValues(['architecture'])`
2. **Safari fallback** — WebGL `UNMASKED_RENDERER_WEBGL` (Apple M* → arm64, Intel* → x64)
3. **Unknown** — defaults to arm64 (majority of modern Macs), dropdown provides Intel option

**Files changed:**
- `packages/shared/src/constants.ts` — Added `DOWNLOAD_URL_MAC_X64`
- `apps/marketing/src/app/hooks/useOS/useOS.ts` — Added `MacArch` type and async `detectMacArch()`
- `apps/marketing/src/app/hooks/useOS/index.ts` — Exported `MacArch` type
- `apps/marketing/src/app/components/DownloadButton/DownloadButton.tsx` — Architecture-aware dropdown
- `apps/marketing/src/app/components/CTAButtons/HeaderCTA.tsx` — Header link uses detected arch

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

- [x] Open on Intel Mac (or emulate via Chrome DevTools UA override) → primary download should be x64
- [x] Verify dropdown shows both architecture options with correct labels
- [x] Verify header CTA download link matches detected architecture

## Screenshots (if applicable)

<img width="2505" height="1138" alt="image" src="https://github.com/user-attachments/assets/0694f66d-d304-4c7f-bb1d-742040889aa0" />

## Additional Notes

Analytics events now include `{ arch }` to track download distribution by architecture.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes macOS downloads so Intel users get the x64 `.dmg` instead of the ARM build. Updates the header CTA and download button to auto-pick the right link.

- **Bug Fixes**
  - Detects Apple Silicon vs Intel via `navigator.userAgentData.getHighEntropyValues(['architecture'])` (Chromium) with a Safari WebGL renderer fallback; defaults to arm64 if unknown.
  - Routes Intel to `DOWNLOAD_URL_MAC_X64` and Apple Silicon to `DOWNLOAD_URL_MAC_ARM64`.

- **New Features**
  - Download button is now a dropdown with both architectures; `download_clicked` analytics include `{ arch }`.
  - Added “Build from source on GitHub” as an alternative in the macOS dropdown.

<sup>Written for commit d144b96248eb71c61d6471eb9894a9fc70f0ca4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mac downloads now detect processor type (Intel vs Apple Silicon) and pick the appropriate installer.
  * Added dropdown options to choose primary or alternate Mac download and a “Build from source” link.
  * Download tracking now records the detected Mac architecture for analytics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->