### PR TITLE
fix(desktop): handle OSC 8 hyperlinks in terminal

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -237,7 +237,7 @@ export function createTerminalInstance(
 
 	const cleanupQuerySuppression = suppressQueryResponses(xterm);
 
-	const urlLinkProvider = new UrlLinkProvider(xterm, (_event, uri) => {
+	const openUrl = (_event: MouseEvent, uri: string) => {
 		const handler = urlClickRef?.current;
 		if (handler) {
 			handler(uri);
@@ -252,7 +252,13 @@ export function createTerminalInstance(
 						: "Could not open URL in browser",
 			});
 		});
-	});
+	};
+
+	// Handle OSC 8 hyperlinks (terminal escape sequences from CLIs like Claude Code, git, etc.)
+	// Without this, xterm's default handler shows a scary confirm() dialog that doesn't work in Electron.
+	xterm.options.linkHandler = { activate: openUrl };
+
+	const urlLinkProvider = new UrlLinkProvider(xterm, openUrl);
 	xterm.registerLinkProvider(urlLinkProvider);
 
 	const filePathLinkProvider = new FilePathLinkProvider(

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -256,7 +256,14 @@ export function createTerminalInstance(
 
 	// Handle OSC 8 hyperlinks (terminal escape sequences from CLIs like Claude Code, git, etc.)
 	// Without this, xterm's default handler shows a scary confirm() dialog that doesn't work in Electron.
-	xterm.options.linkHandler = { activate: openUrl };
+	// Only handle http(s) URIs — OSC 8 can carry any protocol (javascript:, file://, etc.).
+	xterm.options.linkHandler = {
+		activate: (event, uri) => {
+			if (/^https?:\/\//i.test(uri)) {
+				openUrl(event, uri);
+			}
+		},
+	};
 
 	const urlLinkProvider = new UrlLinkProvider(xterm, openUrl);
 	xterm.registerLinkProvider(urlLinkProvider);


### PR DESCRIPTION
## Summary
- CLI tools like Claude Code and git emit OSC 8 terminal escape sequences to create clickable hyperlinks
- xterm's built-in `OscLinkProvider` has a `defaultActivate` handler that shows a `confirm()` dialog ("This link could potentially be dangerous") and then calls `window.open()`, which returns `null` in Electron — so the URL never actually opens
- Set xterm's `linkHandler` option to route OSC 8 hyperlinks through the same `shell.openExternal` / in-app-browser path as regular URL clicks

<img width="1198" height="584" alt="CleanShot 2026-04-08 at 11 16 23@2x" src="https://github.com/user-attachments/assets/0707cae2-d95b-419b-bbd4-fdec2e8d8ee4" />
<img width="674" height="106" alt="CleanShot 2026-04-08 at 11 17 46@2x" src="https://github.com/user-attachments/assets/93bbeb2c-7ed1-4691-a1dd-adfc62c399be" />

Previously OSC 8 links would show:
<img width="506" height="350" alt="CleanShot 2026-04-08 at 11 17 51@2x" src="https://github.com/user-attachments/assets/1bbe4b8c-00b5-4576-b111-3441d5ea3a8c" />

and ok did nothing...

Now the link opens in browser!

Tip set FORCE_HYPERLINK=1 to try this with Claude Code

## Test plan
- [ ] Click an OSC 8 hyperlink in the terminal (e.g. a PR URL from Claude Code output)
- [ ] Verify it opens directly in the system browser (or in-app browser if that setting is enabled) without a confirm dialog
- [ ] Verify regular URL detection still works (non-OSC links like plain `https://...` text)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency in terminal link handling by consolidating URL-opening logic for all link types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->