### PR TITLE
feat(desktop): add hideUnmapped option to ports.json

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/ports/ports.ts
+++ b/apps/desktop/src/lib/trpc/routers/ports/ports.ts
@@ -13,7 +13,12 @@ type PortEvent =
 	| { type: "add"; port: DetectedPort }
 	| { type: "remove"; port: DetectedPort };
 
-function getLabelsForPath(worktreePath: string): Map<number, string> | null {
+interface PortLabels {
+	labels: Map<number, string>;
+	hideUnmapped: boolean;
+}
+
+function getLabelsForPath(worktreePath: string): PortLabels | null {
 	const result = loadStaticPorts(worktreePath);
 	if (!result.exists || result.error || !result.ports) return null;
 
@@ -21,7 +26,7 @@ function getLabelsForPath(worktreePath: string): Map<number, string> | null {
 	for (const p of result.ports) {
 		labels.set(p.port, p.label);
 	}
-	return labels;
+	return { labels, hideUnmapped: result.hideUnmapped };
 }
 
 export const createPortsRouter = () => {
@@ -29,9 +34,11 @@ export const createPortsRouter = () => {
 		getAll: publicProcedure.query((): EnrichedPort[] => {
 			const detectedPorts = portManager.getAllPorts();
 
-			const labelCache = new Map<string, Map<number, string> | null>();
+			const labelCache = new Map<string, PortLabels | null>();
 
-			return detectedPorts.map((port) => {
+			const enriched: EnrichedPort[] = [];
+
+			for (const port of detectedPorts) {
 				if (!labelCache.has(port.workspaceId)) {
 					const ws = localDb
 						.select()
@@ -45,9 +52,16 @@ export const createPortsRouter = () => {
 					);
 				}
 
-				const labels = labelCache.get(port.workspaceId);
-				return { ...port, label: labels?.get(port.port) ?? null };
-			});
+				const portLabels = labelCache.get(port.workspaceId);
+				const label = portLabels?.labels.get(port.port) ?? null;
+
+				// If hideUnmapped is enabled, skip ports not listed in ports.json
+				if (portLabels?.hideUnmapped && label == null) continue;
+
+				enriched.push({ ...port, label });
+			}
+
+			return enriched;
 		}),
 
 		subscribe: publicProcedure.subscription(() => {

--- a/apps/desktop/src/main/lib/static-ports/loader.test.ts
+++ b/apps/desktop/src/main/lib/static-ports/loader.test.ts
@@ -293,6 +293,18 @@ describe("loadStaticPorts", () => {
 		expect(result.ports).toBeNull();
 		expect(result.error).toBe("'hideUnmapped' field must be a boolean");
 	});
+
+	test("returns error when hideUnmapped is null", () => {
+		writeFileSync(
+			PORTS_FILE,
+			JSON.stringify({ hideUnmapped: null, ports: [{ port: 3000, label: "Dev" }] }),
+		);
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result.exists).toBe(true);
+		expect(result.ports).toBeNull();
+		expect(result.error).toBe("'hideUnmapped' field must be a boolean");
+	});
 });
 
 describe("hasStaticPortsConfig", () => {

--- a/apps/desktop/src/main/lib/static-ports/loader.test.ts
+++ b/apps/desktop/src/main/lib/static-ports/loader.test.ts
@@ -23,7 +23,7 @@ describe("loadStaticPorts", () => {
 	test("returns exists: false when ports.json does not exist", () => {
 		rmSync(PORTS_FILE, { force: true });
 		const result = loadStaticPorts(WORKTREE_PATH);
-		expect(result).toEqual({ exists: false, ports: null, error: null });
+		expect(result).toEqual({ exists: false, ports: null, hideUnmapped: false, error: null });
 	});
 
 	test("loads valid ports.json with single port", () => {
@@ -36,6 +36,7 @@ describe("loadStaticPorts", () => {
 		expect(result).toEqual({
 			exists: true,
 			ports: [{ port: 3000, label: "Frontend" }],
+			hideUnmapped: false,
 			error: null,
 		});
 	});
@@ -58,6 +59,7 @@ describe("loadStaticPorts", () => {
 				{ port: 8080, label: "API Server" },
 				{ port: 5432, label: "PostgreSQL" },
 			],
+			hideUnmapped: false,
 			error: null,
 		});
 	});
@@ -255,7 +257,41 @@ describe("loadStaticPorts", () => {
 		writeFileSync(PORTS_FILE, JSON.stringify({ ports: [] }));
 
 		const result = loadStaticPorts(WORKTREE_PATH);
-		expect(result).toEqual({ exists: true, ports: [], error: null });
+		expect(result).toEqual({ exists: true, ports: [], hideUnmapped: false, error: null });
+	});
+
+	test("parses hideUnmapped: true", () => {
+		writeFileSync(
+			PORTS_FILE,
+			JSON.stringify({ hideUnmapped: true, ports: [{ port: 3000, label: "Dev" }] }),
+		);
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result.hideUnmapped).toBe(true);
+		expect(result.ports).toHaveLength(1);
+		expect(result.error).toBeNull();
+	});
+
+	test("defaults hideUnmapped to false when omitted", () => {
+		writeFileSync(
+			PORTS_FILE,
+			JSON.stringify({ ports: [{ port: 3000, label: "Dev" }] }),
+		);
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result.hideUnmapped).toBe(false);
+	});
+
+	test("returns error when hideUnmapped is not a boolean", () => {
+		writeFileSync(
+			PORTS_FILE,
+			JSON.stringify({ hideUnmapped: "true", ports: [{ port: 3000, label: "Dev" }] }),
+		);
+
+		const result = loadStaticPorts(WORKTREE_PATH);
+		expect(result.exists).toBe(true);
+		expect(result.ports).toBeNull();
+		expect(result.error).toBe("'hideUnmapped' field must be a boolean");
 	});
 });
 

--- a/apps/desktop/src/main/lib/static-ports/loader.ts
+++ b/apps/desktop/src/main/lib/static-ports/loader.ts
@@ -10,6 +10,7 @@ interface PortEntry {
 
 interface PortsConfig {
 	ports: unknown;
+	hideUnmapped?: unknown;
 }
 
 /**
@@ -81,7 +82,7 @@ export function loadStaticPorts(worktreePath: string): StaticPortsResult {
 	);
 
 	if (!existsSync(portsPath)) {
-		return { exists: false, ports: null, error: null };
+		return { exists: false, ports: null, hideUnmapped: false, error: null };
 	}
 
 	let content: string;
@@ -92,6 +93,7 @@ export function loadStaticPorts(worktreePath: string): StaticPortsResult {
 		return {
 			exists: true,
 			ports: null,
+			hideUnmapped: false,
 			error: `Failed to read ports.json: ${message}`,
 		};
 	}
@@ -104,6 +106,7 @@ export function loadStaticPorts(worktreePath: string): StaticPortsResult {
 		return {
 			exists: true,
 			ports: null,
+			hideUnmapped: false,
 			error: `Invalid JSON in ports.json: ${message}`,
 		};
 	}
@@ -112,6 +115,7 @@ export function loadStaticPorts(worktreePath: string): StaticPortsResult {
 		return {
 			exists: true,
 			ports: null,
+			hideUnmapped: false,
 			error: "ports.json must contain a JSON object",
 		};
 	}
@@ -120,6 +124,7 @@ export function loadStaticPorts(worktreePath: string): StaticPortsResult {
 		return {
 			exists: true,
 			ports: null,
+			hideUnmapped: false,
 			error: "ports.json is missing required field 'ports'",
 		};
 	}
@@ -128,6 +133,7 @@ export function loadStaticPorts(worktreePath: string): StaticPortsResult {
 		return {
 			exists: true,
 			ports: null,
+			hideUnmapped: false,
 			error: "'ports' field must be an array",
 		};
 	}
@@ -139,13 +145,23 @@ export function loadStaticPorts(worktreePath: string): StaticPortsResult {
 		const result = validatePortEntry(entry, i);
 
 		if (!result.valid) {
-			return { exists: true, ports: null, error: result.error };
+			return { exists: true, ports: null, hideUnmapped: false, error: result.error };
 		}
 
 		validatedPorts.push({ port: result.port, label: result.label });
 	}
 
-	return { exists: true, ports: validatedPorts, error: null };
+	const hideUnmapped = parsed.hideUnmapped ?? false;
+	if (typeof hideUnmapped !== "boolean") {
+		return {
+			exists: true,
+			ports: null,
+			hideUnmapped: false,
+			error: "'hideUnmapped' field must be a boolean",
+		};
+	}
+
+	return { exists: true, ports: validatedPorts, hideUnmapped, error: null };
 }
 
 /**

--- a/apps/desktop/src/main/lib/static-ports/loader.ts
+++ b/apps/desktop/src/main/lib/static-ports/loader.ts
@@ -151,8 +151,8 @@ export function loadStaticPorts(worktreePath: string): StaticPortsResult {
 		validatedPorts.push({ port: result.port, label: result.label });
 	}
 
-	const hideUnmapped = parsed.hideUnmapped ?? false;
-	if (typeof hideUnmapped !== "boolean") {
+	const rawHideUnmapped = parsed.hideUnmapped;
+	if (rawHideUnmapped !== undefined && typeof rawHideUnmapped !== "boolean") {
 		return {
 			exists: true,
 			ports: null,
@@ -160,6 +160,7 @@ export function loadStaticPorts(worktreePath: string): StaticPortsResult {
 			error: "'hideUnmapped' field must be a boolean",
 		};
 	}
+	const hideUnmapped = rawHideUnmapped ?? false;
 
 	return { exists: true, ports: validatedPorts, hideUnmapped, error: null };
 }

--- a/apps/desktop/src/shared/types/ports.ts
+++ b/apps/desktop/src/shared/types/ports.ts
@@ -17,6 +17,7 @@ export interface StaticPort {
 export interface StaticPortsResult {
 	exists: boolean;
 	ports: Omit<StaticPort, "workspaceId">[] | null;
+	hideUnmapped: boolean;
 	error: string | null;
 }
 


### PR DESCRIPTION
## Summary
- Adds `hideUnmapped` boolean flag to `.superset/ports.json` config
- When enabled, only ports explicitly listed in `ports.json` appear in the sidebar — unlabeled ports (e.g. Docker-internal ports like 4406, 4506) are hidden
- Defaults to `false` for backwards compatibility
- Validates the field type and returns a config error for non-boolean values

## Test plan
- [x] Typecheck passes
- [x] 27/27 loader tests pass (3 new tests for `hideUnmapped`)
- [x] Local Codex review approved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `hideUnmapped` flag to `.superset/ports.json` to hide unlabeled ports in the desktop sidebar. Defaults to false; non-boolean values (including null) are rejected.

- **New Features**
  - When `hideUnmapped` is true, only ports listed in `ports.json` are returned by `getAll` and shown; other detected ports are hidden.
  - Loader returns `hideUnmapped` (default false) and validates it as a boolean; non-boolean or null values return a config error.

- **Migration**
  - Optional: add `"hideUnmapped": true` to `.superset/ports.json` and list the ports you want under `ports`.
  - Do nothing to keep the current behavior.

<sup>Written for commit df769885d172f93a7ce708f363a3ff3decaa2017. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a configuration option to hide ports that lack labels; when enabled, unlabeled ports are omitted from listings.

* **Behavior**
  * Default behavior unchanged when no configuration is present (unlabeled ports remain visible).

* **Tests**
  * Expanded tests covering the new hide-unmapped option, defaulting behavior, and validation error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->