### PR TITLE
fix(mcp): respect device-specific agent settings in MCP-triggered sessions

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/start-agent-session.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/start-agent-session.ts
@@ -1,12 +1,18 @@
+import type { AgentDefinitionId } from "@superset/shared/agent-catalog";
 import {
 	chatLaunchConfigSchema,
 	normalizeAgentLaunchRequest,
 	STARTABLE_AGENT_TYPES,
 } from "@superset/shared/agent-launch";
 import {
+	buildFileCommandFromAgentConfig,
+	type ResolvedAgentConfig,
+} from "shared/utils/agent-settings";
+import {
 	launchAgentSession,
 	queueAgentSessionLaunch,
 } from "renderer/lib/agent-session-orchestrator";
+import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { z } from "zod";
 import type { CommandResult, ToolContext, ToolDefinition } from "./types";
 
@@ -56,6 +62,35 @@ async function execute(
 				? { ...fallbackRequest, ...(params.request as Record<string, unknown>) }
 				: fallbackRequest;
 		const request = normalizeAgentLaunchRequest(mergedRequest);
+
+		// Rebuild terminal command using device-local agent settings when possible.
+		// The MCP server sends a fallback command built from hardcoded builtins, but
+		// the user may have overridden agent settings on this device.
+		if (
+			request.kind === "terminal" &&
+			request.terminal.taskPromptFileName &&
+			request.agentType
+		) {
+			try {
+				const presets =
+					await electronTrpcClient.settings.getAgentPresets.query();
+				const agentId = request.agentType as AgentDefinitionId;
+				const config = presets.find(
+					(p: ResolvedAgentConfig) => p.id === agentId,
+				);
+				if (config && config.kind === "terminal" && config.enabled) {
+					const rebuilt = buildFileCommandFromAgentConfig({
+						filePath: `.superset/${request.terminal.taskPromptFileName}`,
+						config,
+					});
+					if (rebuilt) {
+						request.terminal.command = rebuilt;
+					}
+				}
+			} catch {
+				// Fall back to the MCP-provided command
+			}
+		}
 
 		if (request.workspaceId !== params.workspaceId) {
 			return {

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/start-agent-session.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/tools/start-agent-session.ts
@@ -6,6 +6,7 @@ import {
 } from "@superset/shared/agent-launch";
 import {
 	buildFileCommandFromAgentConfig,
+	renderTaskPromptTemplate,
 	type ResolvedAgentConfig,
 } from "shared/utils/agent-settings";
 import {
@@ -63,7 +64,7 @@ async function execute(
 				: fallbackRequest;
 		const request = normalizeAgentLaunchRequest(mergedRequest);
 
-		// Rebuild terminal command using device-local agent settings when possible.
+		// Rebuild terminal command and prompt using device-local agent settings.
 		// The MCP server sends a fallback command built from hardcoded builtins, but
 		// the user may have overridden agent settings on this device.
 		if (
@@ -78,13 +79,27 @@ async function execute(
 				const config = presets.find(
 					(p: ResolvedAgentConfig) => p.id === agentId,
 				);
-				if (config && config.kind === "terminal" && config.enabled) {
+				if (config && !config.enabled) {
+					return {
+						success: false,
+						error: `Agent "${request.agentType}" is disabled on this device`,
+					};
+				}
+				if (config && config.kind === "terminal") {
 					const rebuilt = buildFileCommandFromAgentConfig({
 						filePath: `.superset/${request.terminal.taskPromptFileName}`,
 						config,
 					});
 					if (rebuilt) {
 						request.terminal.command = rebuilt;
+					}
+					// Re-render prompt with local template when task data is available
+					if (request.terminal.taskInput) {
+						request.terminal.taskPromptContent =
+							renderTaskPromptTemplate(
+								config.taskPromptTemplate,
+								request.terminal.taskInput,
+							);
 					}
 				}
 			} catch {

--- a/packages/mcp/src/tools/devices/start-agent-session/shared.ts
+++ b/packages/mcp/src/tools/devices/start-agent-session/shared.ts
@@ -2,8 +2,7 @@ import { db } from "@superset/db/client";
 import { taskStatuses, tasks } from "@superset/db/schema";
 import {
 	type AGENT_TYPES,
-	buildAgentCommand,
-	buildAgentPromptCommand,
+	buildAgentFileCommand,
 	buildAgentTaskPrompt,
 } from "@superset/shared/agent-command";
 import {
@@ -161,18 +160,21 @@ export function buildTaskLaunchRequest({
 		};
 	}
 
+	const prompt = buildAgentTaskPrompt(task);
+	const taskPromptFileName = `task-${task.slug}.md`;
 	return {
 		kind: "terminal",
 		workspaceId,
 		agentType: agent,
 		source: "mcp",
 		terminal: {
-			command: buildAgentCommand({
-				task,
-				randomId: crypto.randomUUID(),
+			command: buildAgentFileCommand({
+				filePath: `.superset/${taskPromptFileName}`,
 				agent: agent as (typeof AGENT_TYPES)[number],
 			}),
 			name: task.slug,
+			taskPromptContent: prompt,
+			taskPromptFileName,
 			...(paneId ? { paneId } : {}),
 		},
 	};
@@ -203,18 +205,20 @@ export function buildPromptLaunchRequest({
 		};
 	}
 
+	const taskPromptFileName = `prompt-${crypto.randomUUID().slice(0, 8)}.md`;
 	return {
 		kind: "terminal",
 		workspaceId,
 		agentType: agent,
 		source: "mcp",
 		terminal: {
-			command: buildAgentPromptCommand({
-				prompt,
-				randomId: crypto.randomUUID(),
+			command: buildAgentFileCommand({
+				filePath: `.superset/${taskPromptFileName}`,
 				agent: agent as (typeof AGENT_TYPES)[number],
 			}),
 			name: STARTABLE_AGENT_LABELS[agent],
+			taskPromptContent: prompt,
+			taskPromptFileName,
 			...(paneId ? { paneId } : {}),
 		},
 	};

--- a/packages/mcp/src/tools/devices/start-agent-session/shared.ts
+++ b/packages/mcp/src/tools/devices/start-agent-session/shared.ts
@@ -175,6 +175,7 @@ export function buildTaskLaunchRequest({
 			name: task.slug,
 			taskPromptContent: prompt,
 			taskPromptFileName,
+			taskInput: task,
 			...(paneId ? { paneId } : {}),
 		},
 	};

--- a/packages/mcp/src/tools/devices/start-agent-session/start-agent-session.test.ts
+++ b/packages/mcp/src/tools/devices/start-agent-session/start-agent-session.test.ts
@@ -114,6 +114,7 @@ describe("session launch MCP tools", () => {
 						command: string;
 						taskPromptContent?: string;
 						taskPromptFileName?: string;
+						taskInput?: typeof TASK;
 					};
 				};
 			};
@@ -125,6 +126,7 @@ describe("session launch MCP tools", () => {
 			terminal: {
 				name: "demo-task",
 				taskPromptFileName: "task-demo-task.md",
+				taskInput: TASK,
 			},
 		});
 		// Prompt delivered via file, not inlined into the command

--- a/packages/mcp/src/tools/devices/start-agent-session/start-agent-session.test.ts
+++ b/packages/mcp/src/tools/devices/start-agent-session/start-agent-session.test.ts
@@ -109,7 +109,12 @@ describe("session launch MCP tools", () => {
 			params: {
 				request: {
 					kind: string;
-					terminal?: { name?: string; command: string };
+					terminal?: {
+						name?: string;
+						command: string;
+						taskPromptContent?: string;
+						taskPromptFileName?: string;
+					};
 				};
 			};
 		};
@@ -119,8 +124,16 @@ describe("session launch MCP tools", () => {
 			kind: "terminal",
 			terminal: {
 				name: "demo-task",
+				taskPromptFileName: "task-demo-task.md",
 			},
 		});
+		// Prompt delivered via file, not inlined into the command
+		expect(
+			launchInput.params.request.terminal?.taskPromptContent,
+		).toBeTruthy();
+		expect(launchInput.params.request.terminal?.command).toContain(
+			".superset/task-demo-task.md",
+		);
 	});
 
 	it("launches prompt-only terminal sessions without fetching a task", async () => {
@@ -146,7 +159,12 @@ describe("session launch MCP tools", () => {
 				request: {
 					kind: string;
 					agentType: string;
-					terminal?: { name?: string; command: string };
+					terminal?: {
+						name?: string;
+						command: string;
+						taskPromptContent?: string;
+						taskPromptFileName?: string;
+					};
 				};
 			};
 		};
@@ -160,11 +178,15 @@ describe("session launch MCP tools", () => {
 				name: "Codex",
 			},
 		});
-		expect(launchInput.params.request.terminal?.command).toContain(
+		// Prompt is delivered via file, not baked into the command
+		expect(launchInput.params.request.terminal?.taskPromptContent).toBe(
 			"Fix the failing tests",
 		);
-		expect(launchInput.params.request.terminal?.command).not.toContain(
-			"  Fix the failing tests  ",
+		expect(launchInput.params.request.terminal?.taskPromptFileName).toMatch(
+			/^prompt-.+\.md$/,
+		);
+		expect(launchInput.params.request.terminal?.command).toContain(
+			`.superset/${launchInput.params.request.terminal?.taskPromptFileName}`,
 		);
 	});
 

--- a/packages/shared/src/agent-launch.ts
+++ b/packages/shared/src/agent-launch.ts
@@ -47,12 +47,23 @@ const baseAgentLaunchSchema = z.object({
 	source: launchSourceSchema.optional(),
 });
 
+export const taskInputSchema = z.object({
+	id: z.string(),
+	slug: z.string(),
+	title: z.string(),
+	description: z.string().nullable(),
+	priority: z.string(),
+	statusName: z.string().nullable(),
+	labels: z.array(z.string()).nullable(),
+});
+
 export const terminalLaunchConfigSchema = z.object({
 	command: z.string().min(1),
 	name: z.string().min(1).optional(),
 	paneId: z.string().min(1).optional(),
 	taskPromptContent: z.string().min(1).optional(),
 	taskPromptFileName: z.string().min(1).optional(),
+	taskInput: taskInputSchema.optional(),
 	autoExecute: z.boolean().optional(),
 	initialFiles: z
 		.array(


### PR DESCRIPTION
## Summary
- MCP agent launches (e.g. via Slackbot) previously baked the prompt into the command using hardcoded builtin agent definitions, ignoring user overrides configured in the desktop app's agent settings
- Switch MCP to file-based prompt delivery (`taskPromptFileName` + `taskPromptContent`) matching the pattern already used by `packages/shared/src/agent-launch.ts`
- Desktop command watcher now rebuilds the terminal command from local agent presets when available, falling back to the MCP-provided command for backward compatibility

## Test plan
- [ ] Configure a custom agent command override in desktop settings (e.g. remove `--dangerously-skip-permissions` from claude's command)
- [ ] Trigger `start_agent_session` via MCP (Slack bot or direct MCP call)
- [ ] Verify the spawned terminal uses the overridden command, not the hardcoded builtin
- [ ] Verify agents with no local overrides still work (fallback command from MCP)
- [ ] Verify old desktop clients still work with new MCP server (backward compat via `params.command`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
MCP-triggered agent sessions (e.g., via Slackbot) now honor device-specific agent settings, including disabled agents and local prompt templates. Prompts are delivered via files, and the desktop rebuilds commands from local presets with a safe fallback.

- **Bug Fixes**
  - MCP sends taskPromptFileName/taskPromptContent, uses buildAgentFileCommand, and passes taskInput to enable local template rendering; tests updated for file-based prompts.
  - Desktop rebuilds terminal commands from local presets (buildFileCommandFromAgentConfig), re-renders prompts with the device’s taskPromptTemplate, rejects disabled agents, and falls back to the MCP command when no override exists.

<sup>Written for commit e39faf12e4643a20702abca79c247fec1ca846ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agent sessions now validate against device-local preset settings, preventing launch of disabled agents.
  * Task input metadata is now included with session launch requests.
  * Agent commands are now constructed from local device configuration files.

* **Improvements**
  * Enhanced error handling with automatic fallback to server-provided configuration when local setup is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->