### PR TITLE
feat(desktop): directional pane focus navigation

### DIFF
--- a/apps/desktop/src/renderer/hotkeys/hooks/useRecordHotkeys/useRecordHotkeys.ts
+++ b/apps/desktop/src/renderer/hotkeys/hooks/useRecordHotkeys/useRecordHotkeys.ts
@@ -8,15 +8,28 @@ import type { Platform } from "../../types";
 // ---------------------------------------------------------------------------
 
 const MODIFIER_ORDER = ["meta", "ctrl", "alt", "shift"] as const;
+const NORMALIZED_KEYS = {
+	arrowup: "up",
+	arrowdown: "down",
+	arrowleft: "left",
+	arrowright: "right",
+} as const;
+const ARROW_KEYS = ["up", "down", "left", "right"] as const;
 
 function captureHotkeyFromEvent(event: KeyboardEvent): string | null {
-	const key = event.key.toLowerCase();
+	const rawKey = event.key.toLowerCase();
+	const key = NORMALIZED_KEYS[rawKey as keyof typeof NORMALIZED_KEYS] ?? rawKey;
 	if (["shift", "ctrl", "alt", "meta", "dead", "unidentified"].includes(key))
 		return null;
 
 	// Must include ctrl or meta (or be F1-F12)
 	const isFKey = /^f([1-9]|1[0-2])$/.test(key);
-	if (!isFKey && !event.ctrlKey && !event.metaKey) return null;
+	const isModifiedArrow =
+		ARROW_KEYS.includes(key as (typeof ARROW_KEYS)[number]) &&
+		event.altKey &&
+		event.shiftKey;
+	if (!isFKey && !isModifiedArrow && !event.ctrlKey && !event.metaKey)
+		return null;
 
 	// Reject meta on non-Mac
 	if (PLATFORM !== "mac" && event.metaKey) return null;

--- a/apps/desktop/src/renderer/hotkeys/registry.ts
+++ b/apps/desktop/src/renderer/hotkeys/registry.ts
@@ -386,6 +386,46 @@ export const HOTKEYS_REGISTRY = {
 		category: "Terminal",
 		description: "Focus the next pane in the current tab",
 	},
+	FOCUS_PANE_UP: {
+		key: {
+			mac: "meta+ctrl+up",
+			windows: "ctrl+alt+up",
+			linux: "ctrl+alt+up",
+		},
+		label: "Focus Pane Up",
+		category: "Terminal",
+		description: "Focus the pane above the current pane",
+	},
+	FOCUS_PANE_DOWN: {
+		key: {
+			mac: "meta+ctrl+down",
+			windows: "ctrl+alt+down",
+			linux: "ctrl+alt+down",
+		},
+		label: "Focus Pane Down",
+		category: "Terminal",
+		description: "Focus the pane below the current pane",
+	},
+	FOCUS_PANE_LEFT: {
+		key: {
+			mac: "meta+ctrl+left",
+			windows: "ctrl+alt+left",
+			linux: "ctrl+alt+left",
+		},
+		label: "Focus Pane Left",
+		category: "Terminal",
+		description: "Focus the pane to the left of the current pane",
+	},
+	FOCUS_PANE_RIGHT: {
+		key: {
+			mac: "meta+ctrl+right",
+			windows: "ctrl+alt+right",
+			linux: "ctrl+alt+right",
+		},
+		label: "Focus Pane Right",
+		category: "Terminal",
+		description: "Focus the pane to the right of the current pane",
+	},
 	JUMP_TO_TAB_1: {
 		key: {
 			mac: "meta+alt+1",

--- a/apps/desktop/src/renderer/hotkeys/registry.ts
+++ b/apps/desktop/src/renderer/hotkeys/registry.ts
@@ -389,7 +389,7 @@ export const HOTKEYS_REGISTRY = {
 	FOCUS_PANE_UP: {
 		key: {
 			mac: "meta+ctrl+up",
-			windows: "ctrl+alt+up",
+			windows: "alt+shift+up",
 			linux: "ctrl+alt+up",
 		},
 		label: "Focus Pane Up",
@@ -399,7 +399,7 @@ export const HOTKEYS_REGISTRY = {
 	FOCUS_PANE_DOWN: {
 		key: {
 			mac: "meta+ctrl+down",
-			windows: "ctrl+alt+down",
+			windows: "alt+shift+down",
 			linux: "ctrl+alt+down",
 		},
 		label: "Focus Pane Down",
@@ -409,7 +409,7 @@ export const HOTKEYS_REGISTRY = {
 	FOCUS_PANE_LEFT: {
 		key: {
 			mac: "meta+ctrl+left",
-			windows: "ctrl+alt+left",
+			windows: "alt+shift+left",
 			linux: "ctrl+alt+left",
 		},
 		label: "Focus Pane Left",
@@ -419,7 +419,7 @@ export const HOTKEYS_REGISTRY = {
 	FOCUS_PANE_RIGHT: {
 		key: {
 			mac: "meta+ctrl+right",
-			windows: "ctrl+alt+right",
+			windows: "alt+shift+right",
 			linux: "ctrl+alt+right",
 		},
 		label: "Focus Pane Right",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
@@ -1,4 +1,8 @@
-import type { WorkspaceStore } from "@superset/panes";
+import {
+	findPaneIdInDirection,
+	type PaneFocusDirection,
+	type WorkspaceStore,
+} from "@superset/panes";
 import { useCallback } from "react";
 import { useHotkey } from "renderer/hotkeys";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
@@ -153,6 +157,29 @@ export function useWorkspaceHotkeys({
 		const nextIndex = index >= paneIds.length - 1 ? 0 : index + 1;
 		state.setActivePane({ tabId: tab.id, paneId: paneIds[nextIndex] });
 	});
+
+	const focusPaneInDirection = useCallback(
+		(direction: PaneFocusDirection) => {
+			const state = store.getState();
+			const tab = state.getActiveTab();
+			if (!tab || !tab.activePaneId) return;
+
+			const targetPaneId = findPaneIdInDirection(
+				tab.layout,
+				tab.activePaneId,
+				direction,
+			);
+			if (!targetPaneId) return;
+
+			state.setActivePane({ tabId: tab.id, paneId: targetPaneId });
+		},
+		[store],
+	);
+
+	useHotkey("FOCUS_PANE_UP", () => focusPaneInDirection("up"));
+	useHotkey("FOCUS_PANE_DOWN", () => focusPaneInDirection("down"));
+	useHotkey("FOCUS_PANE_LEFT", () => focusPaneInDirection("left"));
+	useHotkey("FOCUS_PANE_RIGHT", () => focusPaneInDirection("right"));
 
 	useHotkey("SPLIT_AUTO", () => {
 		const state = store.getState();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -36,6 +36,7 @@ import {
 	findPanePath,
 	getFirstPaneId,
 	getNextPaneId,
+	getPaneIdInDirection,
 	getPreviousPaneId,
 	resolveActiveTabIdForWorkspace,
 } from "renderer/stores/tabs/utils";
@@ -289,6 +290,50 @@ function WorkspacePage() {
 		const nextPaneId = getNextPaneId(activeTab.layout, focusedPaneId);
 		if (nextPaneId) {
 			setFocusedPane(activeTabId, nextPaneId);
+		}
+	});
+
+	useHotkey("FOCUS_PANE_UP", () => {
+		if (!activeTabId || !activeTab?.layout || !focusedPaneId) return;
+		const paneId = getPaneIdInDirection(activeTab.layout, focusedPaneId, "up");
+		if (paneId) {
+			setFocusedPane(activeTabId, paneId);
+		}
+	});
+
+	useHotkey("FOCUS_PANE_DOWN", () => {
+		if (!activeTabId || !activeTab?.layout || !focusedPaneId) return;
+		const paneId = getPaneIdInDirection(
+			activeTab.layout,
+			focusedPaneId,
+			"down",
+		);
+		if (paneId) {
+			setFocusedPane(activeTabId, paneId);
+		}
+	});
+
+	useHotkey("FOCUS_PANE_LEFT", () => {
+		if (!activeTabId || !activeTab?.layout || !focusedPaneId) return;
+		const paneId = getPaneIdInDirection(
+			activeTab.layout,
+			focusedPaneId,
+			"left",
+		);
+		if (paneId) {
+			setFocusedPane(activeTabId, paneId);
+		}
+	});
+
+	useHotkey("FOCUS_PANE_RIGHT", () => {
+		if (!activeTabId || !activeTab?.layout || !focusedPaneId) return;
+		const paneId = getPaneIdInDirection(
+			activeTab.layout,
+			focusedPaneId,
+			"right",
+		);
+		if (paneId) {
+			setFocusedPane(activeTabId, paneId);
 		}
 	});
 

--- a/apps/desktop/src/renderer/stores/tabs/utils.test.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils.test.ts
@@ -10,6 +10,7 @@ import {
 	findPanePath,
 	findReusableFileViewerPane,
 	getAdjacentPaneId,
+	getPaneIdInDirection,
 	resolveActiveTabIdForWorkspace,
 	resolveFileViewerMode,
 } from "./utils";
@@ -199,6 +200,63 @@ describe("getAdjacentPaneId", () => {
 		expect(getAdjacentPaneId(layout, "pane-2")).toBe("pane-3");
 		expect(getAdjacentPaneId(layout, "pane-3")).toBe("pane-4");
 		expect(getAdjacentPaneId(layout, "pane-4")).toBe("pane-3"); // Last pane goes to previous
+	});
+});
+
+describe("getPaneIdInDirection", () => {
+	it("moves around a 2x2 grid using spatial directions", () => {
+		const layout: MosaicNode<string> = {
+			direction: "column",
+			first: {
+				direction: "row",
+				first: "pane-1",
+				second: "pane-2",
+			},
+			second: {
+				direction: "row",
+				first: "pane-3",
+				second: "pane-4",
+			},
+		};
+
+		expect(getPaneIdInDirection(layout, "pane-1", "right")).toBe("pane-2");
+		expect(getPaneIdInDirection(layout, "pane-1", "down")).toBe("pane-3");
+		expect(getPaneIdInDirection(layout, "pane-4", "left")).toBe("pane-3");
+		expect(getPaneIdInDirection(layout, "pane-4", "up")).toBe("pane-2");
+	});
+
+	it("returns null when there is no pane in that direction", () => {
+		const layout: MosaicNode<string> = {
+			direction: "row",
+			first: "pane-1",
+			second: "pane-2",
+		};
+
+		expect(getPaneIdInDirection(layout, "pane-1", "left")).toBeNull();
+		expect(getPaneIdInDirection(layout, "pane-1", "up")).toBeNull();
+		expect(getPaneIdInDirection(layout, "pane-2", "right")).toBeNull();
+	});
+
+	it("prefers overlapping panes in uneven layouts", () => {
+		const layout: MosaicNode<string> = {
+			direction: "row",
+			first: "pane-left",
+			second: {
+				direction: "column",
+				first: "pane-top-right",
+				second: "pane-bottom-right",
+			},
+		};
+
+		expect(getPaneIdInDirection(layout, "pane-top-right", "left")).toBe(
+			"pane-left",
+		);
+		expect(getPaneIdInDirection(layout, "pane-bottom-right", "left")).toBe(
+			"pane-left",
+		);
+		expect(getPaneIdInDirection(layout, "pane-left", "right")).toBe(
+			"pane-top-right",
+		);
 	});
 });
 

--- a/apps/desktop/src/renderer/stores/tabs/utils.test.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils.test.ts
@@ -258,6 +258,21 @@ describe("getPaneIdInDirection", () => {
 			"pane-top-right",
 		);
 	});
+
+	it("does not move to diagonal panes when no pane exists in that direction", () => {
+		const layout: MosaicNode<string> = {
+			direction: "row",
+			first: "pane-left",
+			second: {
+				direction: "column",
+				first: "pane-top-right",
+				second: "pane-bottom-right",
+			},
+		};
+
+		expect(getPaneIdInDirection(layout, "pane-left", "up")).toBeNull();
+		expect(getPaneIdInDirection(layout, "pane-left", "down")).toBeNull();
+	});
 });
 
 describe("resolveActiveTabIdForWorkspace", () => {

--- a/apps/desktop/src/renderer/stores/tabs/utils.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils.ts
@@ -28,6 +28,18 @@ import type {
 	TabsState,
 } from "./types";
 
+export type PaneFocusDirection = "up" | "down" | "left" | "right";
+
+interface PaneBounds {
+	paneId: string;
+	left: number;
+	top: number;
+	right: number;
+	bottom: number;
+	centerX: number;
+	centerY: number;
+}
+
 export const resolveFileViewerMode = ({
 	filePath,
 	diffCategory,
@@ -540,6 +552,229 @@ export const getPreviousPaneId = (
 
 	const prevIndex = (currentIndex - 1 + paneIds.length) % paneIds.length;
 	return paneIds[prevIndex];
+};
+
+function collectPaneBounds(
+	layout: MosaicNode<string>,
+	bounds: { left: number; top: number; right: number; bottom: number },
+	result: PaneBounds[],
+): void {
+	if (typeof layout === "string") {
+		result.push({
+			paneId: layout,
+			left: bounds.left,
+			top: bounds.top,
+			right: bounds.right,
+			bottom: bounds.bottom,
+			centerX: (bounds.left + bounds.right) / 2,
+			centerY: (bounds.top + bounds.bottom) / 2,
+		});
+		return;
+	}
+
+	const splitPercentage = (layout.splitPercentage ?? 50) / 100;
+
+	if (layout.direction === "row") {
+		const splitX = bounds.left + (bounds.right - bounds.left) * splitPercentage;
+		collectPaneBounds(
+			layout.first,
+			{
+				left: bounds.left,
+				top: bounds.top,
+				right: splitX,
+				bottom: bounds.bottom,
+			},
+			result,
+		);
+		collectPaneBounds(
+			layout.second,
+			{
+				left: splitX,
+				top: bounds.top,
+				right: bounds.right,
+				bottom: bounds.bottom,
+			},
+			result,
+		);
+		return;
+	}
+
+	const splitY = bounds.top + (bounds.bottom - bounds.top) * splitPercentage;
+	collectPaneBounds(
+		layout.first,
+		{
+			left: bounds.left,
+			top: bounds.top,
+			right: bounds.right,
+			bottom: splitY,
+		},
+		result,
+	);
+	collectPaneBounds(
+		layout.second,
+		{
+			left: bounds.left,
+			top: splitY,
+			right: bounds.right,
+			bottom: bounds.bottom,
+		},
+		result,
+	);
+}
+
+function getPaneBounds(layout: MosaicNode<string>): PaneBounds[] {
+	const result: PaneBounds[] = [];
+	collectPaneBounds(layout, { left: 0, top: 0, right: 1, bottom: 1 }, result);
+	return result;
+}
+
+function getOrthogonalOverlap(
+	current: PaneBounds,
+	candidate: PaneBounds,
+	direction: PaneFocusDirection,
+): number {
+	if (direction === "left" || direction === "right") {
+		return Math.max(
+			0,
+			Math.min(current.bottom, candidate.bottom) -
+				Math.max(current.top, candidate.top),
+		);
+	}
+
+	return Math.max(
+		0,
+		Math.min(current.right, candidate.right) -
+			Math.max(current.left, candidate.left),
+	);
+}
+
+function isInDirectionByEdge(
+	current: PaneBounds,
+	candidate: PaneBounds,
+	direction: PaneFocusDirection,
+): boolean {
+	switch (direction) {
+		case "up":
+			return candidate.bottom <= current.top;
+		case "down":
+			return candidate.top >= current.bottom;
+		case "left":
+			return candidate.right <= current.left;
+		case "right":
+			return candidate.left >= current.right;
+	}
+}
+
+function isInDirectionByCenter(
+	current: PaneBounds,
+	candidate: PaneBounds,
+	direction: PaneFocusDirection,
+): boolean {
+	switch (direction) {
+		case "up":
+			return candidate.centerY < current.centerY;
+		case "down":
+			return candidate.centerY > current.centerY;
+		case "left":
+			return candidate.centerX < current.centerX;
+		case "right":
+			return candidate.centerX > current.centerX;
+	}
+}
+
+function getDirectionalGap(
+	current: PaneBounds,
+	candidate: PaneBounds,
+	direction: PaneFocusDirection,
+	useCenters: boolean,
+): number {
+	if (useCenters) {
+		switch (direction) {
+			case "up":
+				return current.centerY - candidate.centerY;
+			case "down":
+				return candidate.centerY - current.centerY;
+			case "left":
+				return current.centerX - candidate.centerX;
+			case "right":
+				return candidate.centerX - current.centerX;
+		}
+	}
+
+	switch (direction) {
+		case "up":
+			return current.top - candidate.bottom;
+		case "down":
+			return candidate.top - current.bottom;
+		case "left":
+			return current.left - candidate.right;
+		case "right":
+			return candidate.left - current.right;
+	}
+}
+
+function getCrossAxisDistance(
+	current: PaneBounds,
+	candidate: PaneBounds,
+	direction: PaneFocusDirection,
+): number {
+	if (direction === "left" || direction === "right") {
+		return Math.abs(candidate.centerY - current.centerY);
+	}
+
+	return Math.abs(candidate.centerX - current.centerX);
+}
+
+export const getPaneIdInDirection = (
+	layout: MosaicNode<string>,
+	currentPaneId: string,
+	direction: PaneFocusDirection,
+): string | null => {
+	const paneBounds = getPaneBounds(layout);
+	const current = paneBounds.find((pane) => pane.paneId === currentPaneId);
+	if (!current) return null;
+
+	const edgeCandidates = paneBounds.filter(
+		(candidate) =>
+			candidate.paneId !== currentPaneId &&
+			isInDirectionByEdge(current, candidate, direction),
+	);
+	const candidates =
+		edgeCandidates.length > 0
+			? edgeCandidates
+			: paneBounds.filter(
+					(candidate) =>
+						candidate.paneId !== currentPaneId &&
+						isInDirectionByCenter(current, candidate, direction),
+				);
+
+	if (candidates.length === 0) return null;
+
+	const overlappingCandidates = candidates.filter(
+		(candidate) => getOrthogonalOverlap(current, candidate, direction) > 0,
+	);
+	const preferredCandidates =
+		overlappingCandidates.length > 0 ? overlappingCandidates : candidates;
+	const useCenters = edgeCandidates.length === 0;
+
+	return (
+		preferredCandidates.slice().sort((a, b) => {
+			const gapDifference =
+				getDirectionalGap(current, a, direction, useCenters) -
+				getDirectionalGap(current, b, direction, useCenters);
+			if (gapDifference !== 0) return gapDifference;
+
+			const crossAxisDifference =
+				getCrossAxisDistance(current, a, direction) -
+				getCrossAxisDistance(current, b, direction);
+			if (crossAxisDifference !== 0) return crossAxisDifference;
+
+			const topDifference = a.top - b.top;
+			if (topDifference !== 0) return topDifference;
+
+			return a.left - b.left;
+		})[0]?.paneId ?? null
+	);
 };
 
 /**

--- a/apps/desktop/src/renderer/stores/tabs/utils.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils.ts
@@ -665,42 +665,11 @@ function isInDirectionByEdge(
 	}
 }
 
-function isInDirectionByCenter(
-	current: PaneBounds,
-	candidate: PaneBounds,
-	direction: PaneFocusDirection,
-): boolean {
-	switch (direction) {
-		case "up":
-			return candidate.centerY < current.centerY;
-		case "down":
-			return candidate.centerY > current.centerY;
-		case "left":
-			return candidate.centerX < current.centerX;
-		case "right":
-			return candidate.centerX > current.centerX;
-	}
-}
-
 function getDirectionalGap(
 	current: PaneBounds,
 	candidate: PaneBounds,
 	direction: PaneFocusDirection,
-	useCenters: boolean,
 ): number {
-	if (useCenters) {
-		switch (direction) {
-			case "up":
-				return current.centerY - candidate.centerY;
-			case "down":
-				return candidate.centerY - current.centerY;
-			case "left":
-				return current.centerX - candidate.centerX;
-			case "right":
-				return candidate.centerX - current.centerX;
-		}
-	}
-
 	switch (direction) {
 		case "up":
 			return current.top - candidate.bottom;
@@ -739,29 +708,18 @@ export const getPaneIdInDirection = (
 			candidate.paneId !== currentPaneId &&
 			isInDirectionByEdge(current, candidate, direction),
 	);
-	const candidates =
-		edgeCandidates.length > 0
-			? edgeCandidates
-			: paneBounds.filter(
-					(candidate) =>
-						candidate.paneId !== currentPaneId &&
-						isInDirectionByCenter(current, candidate, direction),
-				);
+	if (edgeCandidates.length === 0) return null;
 
-	if (candidates.length === 0) return null;
-
-	const overlappingCandidates = candidates.filter(
+	const overlappingCandidates = edgeCandidates.filter(
 		(candidate) => getOrthogonalOverlap(current, candidate, direction) > 0,
 	);
-	const preferredCandidates =
-		overlappingCandidates.length > 0 ? overlappingCandidates : candidates;
-	const useCenters = edgeCandidates.length === 0;
+	if (overlappingCandidates.length === 0) return null;
 
 	return (
-		preferredCandidates.slice().sort((a, b) => {
+		overlappingCandidates.slice().sort((a, b) => {
 			const gapDifference =
-				getDirectionalGap(current, a, direction, useCenters) -
-				getDirectionalGap(current, b, direction, useCenters);
+				getDirectionalGap(current, a, direction) -
+				getDirectionalGap(current, b, direction);
 			if (gapDifference !== 0) return gapDifference;
 
 			const crossAxisDifference =

--- a/packages/panes/src/core/store/utils/index.ts
+++ b/packages/panes/src/core/store/utils/index.ts
@@ -1,6 +1,8 @@
+export type { PaneFocusDirection } from "./utils";
 export {
 	equalizeAllSplits,
 	findFirstPaneId,
+	findPaneIdInDirection,
 	findPaneInLayout,
 	findSiblingPaneId,
 	generateId,

--- a/packages/panes/src/core/store/utils/utils.test.ts
+++ b/packages/panes/src/core/store/utils/utils.test.ts
@@ -3,6 +3,7 @@ import type { LayoutNode } from "../../../types";
 import {
 	equalizeAllSplits,
 	findFirstPaneId,
+	findPaneIdInDirection,
 	findPaneInLayout,
 	getNodeAtPath,
 	getOtherBranch,
@@ -52,6 +53,35 @@ const DEEP: LayoutNode = {
 	splitPercentage: 30,
 };
 
+const GRID: LayoutNode = {
+	type: "split",
+	direction: "vertical",
+	first: {
+		type: "split",
+		direction: "horizontal",
+		first: { type: "pane", paneId: "a" },
+		second: { type: "pane", paneId: "b" },
+	},
+	second: {
+		type: "split",
+		direction: "horizontal",
+		first: { type: "pane", paneId: "c" },
+		second: { type: "pane", paneId: "d" },
+	},
+};
+
+const T_SPLIT: LayoutNode = {
+	type: "split",
+	direction: "horizontal",
+	first: { type: "pane", paneId: "left" },
+	second: {
+		type: "split",
+		direction: "vertical",
+		first: { type: "pane", paneId: "top-right" },
+		second: { type: "pane", paneId: "bottom-right" },
+	},
+};
+
 describe("findPaneInLayout", () => {
 	it("finds a pane in a single leaf", () => {
 		expect(findPaneInLayout(SINGLE, "a")).toBe(true);
@@ -81,6 +111,31 @@ describe("findFirstPaneId", () => {
 
 	it("returns the first pane in nested splits", () => {
 		expect(findFirstPaneId(NESTED)).toBe("a");
+	});
+});
+
+describe("findPaneIdInDirection", () => {
+	it("moves around a 2x2 grid using spatial directions", () => {
+		expect(findPaneIdInDirection(GRID, "a", "right")).toBe("b");
+		expect(findPaneIdInDirection(GRID, "a", "down")).toBe("c");
+		expect(findPaneIdInDirection(GRID, "d", "left")).toBe("c");
+		expect(findPaneIdInDirection(GRID, "d", "up")).toBe("b");
+	});
+
+	it("returns null when there is no pane in that direction", () => {
+		expect(findPaneIdInDirection(GRID, "a", "up")).toBeNull();
+		expect(findPaneIdInDirection(GRID, "b", "right")).toBeNull();
+	});
+
+	it("prefers the overlapping pane on the requested side in uneven layouts", () => {
+		expect(findPaneIdInDirection(T_SPLIT, "top-right", "left")).toBe("left");
+		expect(findPaneIdInDirection(T_SPLIT, "bottom-right", "left")).toBe("left");
+		expect(findPaneIdInDirection(T_SPLIT, "left", "right")).toBe("top-right");
+	});
+
+	it("does not move to diagonal panes when no pane exists in that direction", () => {
+		expect(findPaneIdInDirection(T_SPLIT, "left", "up")).toBeNull();
+		expect(findPaneIdInDirection(T_SPLIT, "left", "down")).toBeNull();
 	});
 });
 

--- a/packages/panes/src/core/store/utils/utils.ts
+++ b/packages/panes/src/core/store/utils/utils.ts
@@ -6,6 +6,18 @@ import type {
 	SplitPosition,
 } from "../../../types";
 
+export type PaneFocusDirection = "up" | "down" | "left" | "right";
+
+interface PaneBounds {
+	paneId: string;
+	left: number;
+	top: number;
+	right: number;
+	bottom: number;
+	centerX: number;
+	centerY: number;
+}
+
 export function findPaneInLayout(node: LayoutNode, paneId: string): boolean {
 	if (node.type === "pane") {
 		return node.paneId === paneId;
@@ -21,6 +33,187 @@ export function findFirstPaneId(node: LayoutNode): string | null {
 		return node.paneId;
 	}
 	return findFirstPaneId(node.first) ?? findFirstPaneId(node.second);
+}
+
+function collectPaneBounds(
+	node: LayoutNode,
+	bounds: { left: number; top: number; right: number; bottom: number },
+	result: PaneBounds[],
+): void {
+	if (node.type === "pane") {
+		result.push({
+			paneId: node.paneId,
+			left: bounds.left,
+			top: bounds.top,
+			right: bounds.right,
+			bottom: bounds.bottom,
+			centerX: (bounds.left + bounds.right) / 2,
+			centerY: (bounds.top + bounds.bottom) / 2,
+		});
+		return;
+	}
+
+	const splitPercentage = (node.splitPercentage ?? 50) / 100;
+
+	if (node.direction === "horizontal") {
+		const splitX = bounds.left + (bounds.right - bounds.left) * splitPercentage;
+		collectPaneBounds(
+			node.first,
+			{
+				left: bounds.left,
+				top: bounds.top,
+				right: splitX,
+				bottom: bounds.bottom,
+			},
+			result,
+		);
+		collectPaneBounds(
+			node.second,
+			{
+				left: splitX,
+				top: bounds.top,
+				right: bounds.right,
+				bottom: bounds.bottom,
+			},
+			result,
+		);
+		return;
+	}
+
+	const splitY = bounds.top + (bounds.bottom - bounds.top) * splitPercentage;
+	collectPaneBounds(
+		node.first,
+		{
+			left: bounds.left,
+			top: bounds.top,
+			right: bounds.right,
+			bottom: splitY,
+		},
+		result,
+	);
+	collectPaneBounds(
+		node.second,
+		{
+			left: bounds.left,
+			top: splitY,
+			right: bounds.right,
+			bottom: bounds.bottom,
+		},
+		result,
+	);
+}
+
+function getPaneBounds(node: LayoutNode): PaneBounds[] {
+	const result: PaneBounds[] = [];
+	collectPaneBounds(node, { left: 0, top: 0, right: 1, bottom: 1 }, result);
+	return result;
+}
+
+function getOrthogonalOverlap(
+	current: PaneBounds,
+	candidate: PaneBounds,
+	direction: PaneFocusDirection,
+): number {
+	if (direction === "left" || direction === "right") {
+		return Math.max(
+			0,
+			Math.min(current.bottom, candidate.bottom) -
+				Math.max(current.top, candidate.top),
+		);
+	}
+
+	return Math.max(
+		0,
+		Math.min(current.right, candidate.right) -
+			Math.max(current.left, candidate.left),
+	);
+}
+
+function isInDirectionByEdge(
+	current: PaneBounds,
+	candidate: PaneBounds,
+	direction: PaneFocusDirection,
+): boolean {
+	switch (direction) {
+		case "up":
+			return candidate.bottom <= current.top;
+		case "down":
+			return candidate.top >= current.bottom;
+		case "left":
+			return candidate.right <= current.left;
+		case "right":
+			return candidate.left >= current.right;
+	}
+}
+
+function getDirectionalGap(
+	current: PaneBounds,
+	candidate: PaneBounds,
+	direction: PaneFocusDirection,
+): number {
+	switch (direction) {
+		case "up":
+			return current.top - candidate.bottom;
+		case "down":
+			return candidate.top - current.bottom;
+		case "left":
+			return current.left - candidate.right;
+		case "right":
+			return candidate.left - current.right;
+	}
+}
+
+function getCrossAxisDistance(
+	current: PaneBounds,
+	candidate: PaneBounds,
+	direction: PaneFocusDirection,
+): number {
+	if (direction === "left" || direction === "right") {
+		return Math.abs(candidate.centerY - current.centerY);
+	}
+
+	return Math.abs(candidate.centerX - current.centerX);
+}
+
+export function findPaneIdInDirection(
+	node: LayoutNode,
+	currentPaneId: string,
+	direction: PaneFocusDirection,
+): string | null {
+	const paneBounds = getPaneBounds(node);
+	const current = paneBounds.find((pane) => pane.paneId === currentPaneId);
+	if (!current) return null;
+
+	const edgeCandidates = paneBounds.filter(
+		(candidate) =>
+			candidate.paneId !== currentPaneId &&
+			isInDirectionByEdge(current, candidate, direction),
+	);
+	if (edgeCandidates.length === 0) return null;
+
+	const overlappingCandidates = edgeCandidates.filter(
+		(candidate) => getOrthogonalOverlap(current, candidate, direction) > 0,
+	);
+	if (overlappingCandidates.length === 0) return null;
+
+	return (
+		overlappingCandidates.slice().sort((a, b) => {
+			const gapDifference =
+				getDirectionalGap(current, a, direction) -
+				getDirectionalGap(current, b, direction);
+			if (gapDifference !== 0) return gapDifference;
+
+			const crossAxisDifference =
+				getCrossAxisDistance(current, a, direction) -
+				getCrossAxisDistance(current, b, direction);
+			if (crossAxisDifference !== 0) return crossAxisDifference;
+
+			const topDifference = a.top - b.top;
+			if (topDifference !== 0) return topDifference;
+
+			return a.left - b.left;
+		})[0]?.paneId ?? null
+	);
 }
 
 export function findSiblingPaneId(

--- a/packages/panes/src/index.ts
+++ b/packages/panes/src/index.ts
@@ -5,6 +5,8 @@ export type {
 	WorkspaceStore,
 } from "./core/store";
 export { createWorkspaceStore } from "./core/store";
+export type { PaneFocusDirection } from "./core/store/utils";
+export { findPaneIdInDirection } from "./core/store/utils";
 export type {
 	ContextMenuActionConfig,
 	PaneActionConfig,


### PR DESCRIPTION
## Summary
- Adds directional pane navigation hotkeys (Cmd+Ctrl+Arrow on Mac, Ctrl+Alt+Arrow on Win/Linux) for focusing panes spatially (up/down/left/right)
- Uses a bounds-based algorithm that computes virtual pane positions from the mosaic layout tree and finds the nearest pane in the requested direction, preferring candidates with orthogonal overlap
- Includes tests for 2x2 grid navigation, boundary cases, and uneven layouts

Fixes https://github.com/superset-sh/superset/issues/3271

## Test plan
- [ ] Open a workspace with 2+ split panes in a grid layout
- [ ] Verify Cmd+Ctrl+Arrow (Mac) moves focus to the correct directional pane
- [ ] Verify edge cases: no pane in direction does nothing, uneven splits pick the overlapping pane
- [ ] Run `bun test` to confirm unit tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds directional pane focus shortcuts to navigate between panes (Cmd+Ctrl+Arrow on macOS, Alt+Shift+Arrow on Windows, Ctrl+Alt+Arrow on Linux). Uses a bounds-based search to select the nearest pane in the chosen direction, favoring orthogonal overlap.

- **New Features**
  - Registers `FOCUS_PANE_{UP,DOWN,LEFT,RIGHT}` and wires them in the workspace to focus the target pane via `findPaneIdInDirection`.
  - Exposes `findPaneIdInDirection` and `PaneFocusDirection` from `@superset/panes`; normalizes Arrow keys in hotkey recording.
  - Adds unit tests for 2x2 grids, no-op edges, and uneven splits.

- **Bug Fixes**
  - Finalizes platform bindings with Alt+Shift+Arrow on Windows and supports modified Arrow keys in hotkey capture.

<sup>Written for commit 0123ae9556246fae53a6a98ca999c1ef3c84a222. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added directional pane navigation hotkeys to improve workspace navigation. Users can now move focus between terminal panes in all directions (up, down, left, and right) using platform-specific keyboard shortcuts (macOS: Cmd+Ctrl+Direction; Windows/Linux: Alt+Shift or Ctrl+Alt+Direction), enabling faster terminal workflow navigation without using the mouse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->