### PR TITLE
fix(desktop): restore focus to new workspace modal after alt-tab

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -73,7 +73,7 @@ export function NewWorkspaceModal() {
 		<NewWorkspaceModalDraftProvider onClose={closeModal}>
 			<PromptInputProvider>
 				<PromptInputResetSync />
-				<Dialog open={isOpen} onOpenChange={(open) => !open && closeModal()}>
+				<Dialog modal open={isOpen} onOpenChange={(open) => !open && closeModal()}>
 					<DialogHeader className="sr-only">
 						<DialogTitle>New Workspace</DialogTitle>
 						<DialogDescription>Create a new workspace</DialogDescription>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceModal.tsx
@@ -29,6 +29,7 @@ export function DashboardNewWorkspaceModal() {
 				</DialogHeader>
 				<DialogContent
 					showCloseButton={false}
+					onFocusOutside={(e) => e.preventDefault()}
 					className="bg-popover text-popover-foreground sm:max-w-[560px] max-h-[min(70vh,600px)] !top-[calc(50%-min(35vh,300px))] !-translate-y-0 flex flex-col overflow-hidden p-0"
 				>
 					<DashboardNewWorkspaceForm

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceModal.tsx
@@ -20,7 +20,7 @@ export function DashboardNewWorkspaceModal() {
 
 	return (
 		<DashboardNewWorkspaceDraftProvider onClose={closeModal}>
-			<Dialog open={isOpen} onOpenChange={(open) => !open && closeModal()}>
+			<Dialog modal open={isOpen} onOpenChange={(open) => !open && closeModal()}>
 				<DialogHeader className="sr-only">
 					<DialogTitle>New Workspace</DialogTitle>
 					<DialogDescription>


### PR DESCRIPTION
## Summary
- The new workspace modal Dialog used non-modal mode (`modal={false}` default), so Radix UI did not trap focus
- When alt-tabbing away and back, focus landed on the window body instead of returning to the modal
- Enabled `modal` on both `NewWorkspaceModal` and `DashboardNewWorkspaceModal` Dialog variants to activate Radix's built-in focus trap

## Test plan
- [ ] Open the new workspace modal
- [ ] Alt-tab to another application, then alt-tab back
- [ ] Verify focus returns to the modal (e.g. typing should land in the prompt input, not behind the modal)
- [ ] Verify Escape still closes the modal
- [ ] Verify clicking the overlay still closes the modal

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores focus and keeps the New Workspace dialogs open after alt-tab by enabling `modal` on the `Dialog` and preventing focus-outside dismiss in `DashboardNewWorkspaceModal`.

- **Bug Fixes**
  - After alt-tab, focus returns to the modal and it stays open (no unintended dismiss).
  - Escape and overlay click still close the modal.

<sup>Written for commit bdf35f2deeeef039e5e992dde3cfbdfa4dd53769. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace creation dialogs now prevent interaction with other interface elements while open, ensuring true modal behavior.
  * Dialog content now blocks focus from leaving the modal, improving accessibility and preventing accidental focus loss during workspace creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->