### PR TITLE
Fix auto update

### DIFF
--- a/apps/desktop/src/main/lib/auto-updater.ts
+++ b/apps/desktop/src/main/lib/auto-updater.ts
@@ -1,8 +1,8 @@
 import { EventEmitter } from "node:events";
-import { app, dialog } from "electron";
+import { BrowserWindow, app, dialog } from "electron";
 import { autoUpdater } from "electron-updater";
 import { env } from "main/env.main";
-import { exitImmediately } from "main/index";
+import { quitApp } from "main/index";
 import { prerelease } from "semver";
 import { AUTO_UPDATE_STATUS, type AutoUpdateStatus } from "shared/auto-update";
 import { PLATFORM } from "shared/constants";
@@ -91,10 +91,8 @@ export function installUpdate(): void {
 		emitStatus(AUTO_UPDATE_STATUS.IDLE);
 		return;
 	}
+	setSkipQuitConfirmation();
 	autoUpdater.quitAndInstall(false, true);
-	// MacUpdater.quitAndInstall() may not quit if Squirrel hasn't
-	// finished its internal download from the localhost proxy.
-	exitImmediately();
 }
 
 export function dismissUpdate(): void {


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash during auto-update by removing the forced immediate exit and skipping quit confirmation so `autoUpdater.quitAndInstall` can restart the app cleanly.

- **Bug Fixes**
  - Call `setSkipQuitConfirmation()` before `quitAndInstall` to avoid quit prompts.
  - Remove the forced exit after `quitAndInstall`, preventing macOS crashes/hangs.
  - Minor import cleanup in `auto-updater.ts`.

<sup>Written for commit 427076c541376bc44a444f5c61bfcfc28d9a47d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update installation handling to ensure proper application shutdown during updates. The update process now uses a more reliable confirmation mechanism, eliminating a workaround previously needed for consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->