### PR TITLE
feat(desktop): support viewing local HTML files in browser tabs

### DIFF
--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -10,7 +10,7 @@ interface ConsoleEntry {
 const MAX_CONSOLE_ENTRIES = 500;
 
 function sanitizeUrl(url: string): string {
-	if (/^https?:\/\//i.test(url) || url.startsWith("about:")) {
+	if (/^https?:\/\//i.test(url) || url.startsWith("about:") || url.startsWith("file://")) {
 		return url;
 	}
 	if (url.startsWith("localhost") || url.startsWith("127.0.0.1")) {

--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -14,10 +14,10 @@
       - connect-src 'self' data: blob: ws: wss: http://127.0.0.1:* %NEXT_PUBLIC_API_URL% %NEXT_PUBLIC_ELECTRIC_URL% https://*.posthog.com https://*.sentry.io sentry-ipc: Allow WebSocket + API + Electric proxy + PostHog + Sentry + data URIs (file attachment upload via data URL) + blob URIs + localhost host-service
       - img-src 'self' data: blob: https: http:: Allow images from any source (needed for favicons, browser pane webview content, and file attachment previews)
       - font-src 'self': Allow fonts from same origin
-      - frame-src https: http: data: blob:: Allow webview browser pane to load any URL
+      - frame-src https: http: data: blob: file:: Allow webview browser pane to load any URL (including local files)
       - child-src 'self' blob:: Allow workers from same origin + blob workers
     -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://*.posthog.com; style-src 'self' 'unsafe-inline'; connect-src 'self' data: blob: ws: wss: http://127.0.0.1:* %NEXT_PUBLIC_API_URL% %NEXT_PUBLIC_ELECTRIC_URL% https://*.posthog.com https://*.sentry.io sentry-ipc:; img-src 'self' data: blob: https: http:; font-src 'self'; frame-src https: http: data: blob:; child-src 'self' blob:;" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://*.posthog.com; style-src 'self' 'unsafe-inline'; connect-src 'self' data: blob: ws: wss: http://127.0.0.1:* %NEXT_PUBLIC_API_URL% %NEXT_PUBLIC_ELECTRIC_URL% https://*.posthog.com https://*.sentry.io sentry-ipc:; img-src 'self' data: blob: https: http:; font-src 'self'; frame-src https: http: data: blob: file:; child-src 'self' blob:;" />
   </head>
 
   <body>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
@@ -71,7 +71,7 @@ export function destroyPersistentWebview(paneId: string): void {
 // ---------------------------------------------------------------------------
 
 function sanitizeUrl(url: string): string {
-	if (/^https?:\/\//i.test(url) || url.startsWith("about:")) {
+	if (/^https?:\/\//i.test(url) || url.startsWith("about:") || url.startsWith("file://")) {
 		return url;
 	}
 	if (url.startsWith("localhost") || url.startsWith("127.0.0.1")) {


### PR DESCRIPTION
## Description

Allow `file://` URLs to be loaded in browser tabs. Previously, entering a `file://` URL was treated as a Google search query due to URL sanitization logic that only allowed `http://`, `https://`, and `about:` schemes.

Closes #3286

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

1. Open a browser tab and navigate to `file:///tmp/test.html` (or any local HTML file)
2. Verify the file renders correctly with styles, scripts, and images
3. Verify relative links between local files work
4. Verify `http://` and `https://` URLs still work as before

## Screenshots

**Before** — `file://` URL treated as a failed search, showing "Name Not Resolved":

<img width="1031" height="840" alt="Before: file URL shows Name Not Resolved error" src="https://github.com/user-attachments/assets/d1a7cef9-48f9-4d04-a31b-4c693b6a8541" />

**After** — local HTML file loads correctly with CSS, JS, and images:

<img width="981" height="842" alt="After: local HTML file renders correctly" src="https://github.com/user-attachments/assets/76c6d45a-a64d-4c0b-ac6a-4f6016a6c518" />

## Additional Notes

Three changes:
- Both `sanitizeUrl()` functions (main process + renderer) now pass through `file://` URLs
- CSP `frame-src` directive updated to include `file:` protocol

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow file:// URLs to load in browser tabs. Local HTML files now render correctly with styles, scripts, images, and relative links.

- **New Features**
  - Pass file:// through URL sanitization in main and renderer.
  - Add file: to CSP frame-src to allow loading local files.

<sup>Written for commit f5260f91aba714d02e06b84caebff6f98950e020. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled support for navigating to local files using the `file://` protocol; file:// URLs are now treated as safe inputs and passed through directly in browser navigation instead of being rewritten.
  * Updated security policy to explicitly allow file: sources in frame rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->