### PR TITLE
feat(desktop): add bulk workspace delete from context menu

### DIFF
--- a/apps/desktop/src/renderer/react-query/workspaces/index.ts
+++ b/apps/desktop/src/renderer/react-query/workspaces/index.ts
@@ -1,4 +1,5 @@
 export { useCloseWorkspace } from "./useCloseWorkspace";
+export { useCloseWorkspaces } from "./useCloseWorkspaces";
 export { useCreateFromPr } from "./useCreateFromPr";
 export { useCreateSectionFromWorkspaces } from "./useCreateSectionFromWorkspaces";
 export { useCreateWorkspace } from "./useCreateWorkspace";

--- a/apps/desktop/src/renderer/react-query/workspaces/index.ts
+++ b/apps/desktop/src/renderer/react-query/workspaces/index.ts
@@ -3,6 +3,7 @@ export { useCreateFromPr } from "./useCreateFromPr";
 export { useCreateSectionFromWorkspaces } from "./useCreateSectionFromWorkspaces";
 export { useCreateWorkspace } from "./useCreateWorkspace";
 export { useDeleteWorkspace } from "./useDeleteWorkspace";
+export { useDeleteWorkspaces } from "./useDeleteWorkspaces";
 export { useDeleteWorktree } from "./useDeleteWorktree";
 export { useHandleOpenedWorktree } from "./useHandleOpenedWorktree";
 export { useImportAllWorktrees } from "./useImportAllWorktrees";

--- a/apps/desktop/src/renderer/react-query/workspaces/useCloseWorkspaces.ts
+++ b/apps/desktop/src/renderer/react-query/workspaces/useCloseWorkspaces.ts
@@ -12,16 +12,20 @@ export function useCloseWorkspaces() {
 
 	const closeWorkspaces = useCallback(
 		async (ids: string[]) => {
+			const idsSet = new Set(ids);
+
 			// Navigate away if currently-viewed workspace is in selection
-			if (params.workspaceId && ids.includes(params.workspaceId)) {
+			if (params.workspaceId && idsSet.has(params.workspaceId)) {
 				const prevId = await utils.workspaces.getPreviousWorkspace.fetch({
-					id: ids[0],
+					id: params.workspaceId,
 				});
 				const nextId = await utils.workspaces.getNextWorkspace.fetch({
-					id: ids[ids.length - 1],
+					id: params.workspaceId,
 				});
-				const target = prevId ?? nextId;
-				if (target && !ids.includes(target)) {
+				const target =
+					(prevId && !idsSet.has(prevId) ? prevId : null) ??
+					(nextId && !idsSet.has(nextId) ? nextId : null);
+				if (target) {
 					navigateToWorkspace(target, navigate);
 				} else {
 					navigate({ to: "/workspace" });
@@ -36,7 +40,7 @@ export function useCloseWorkspaces() {
 
 			const previousGrouped = utils.workspaces.getAllGrouped.getData();
 			const previousAll = utils.workspaces.getAll.getData();
-			const idsSet = new Set(ids);
+			const idsSetForFilter = idsSet;
 
 			if (previousGrouped) {
 				utils.workspaces.getAllGrouped.setData(
@@ -44,13 +48,17 @@ export function useCloseWorkspaces() {
 					previousGrouped
 						.map((group) => ({
 							...group,
-							workspaces: group.workspaces.filter((w) => !idsSet.has(w.id)),
+							workspaces: group.workspaces.filter(
+								(w) => !idsSetForFilter.has(w.id),
+							),
 							sections: group.sections.map((section) => ({
 								...section,
-								workspaces: section.workspaces.filter((w) => !idsSet.has(w.id)),
+								workspaces: section.workspaces.filter(
+									(w) => !idsSetForFilter.has(w.id),
+								),
 							})),
 							topLevelItems: group.topLevelItems.filter(
-								(item) => !idsSet.has(item.id),
+								(item) => !idsSetForFilter.has(item.id),
 							),
 						}))
 						.filter(
@@ -67,7 +75,7 @@ export function useCloseWorkspaces() {
 			if (previousAll) {
 				utils.workspaces.getAll.setData(
 					undefined,
-					previousAll.filter((w) => !idsSet.has(w.id)),
+					previousAll.filter((w) => !idsSetForFilter.has(w.id)),
 				);
 			}
 
@@ -76,12 +84,23 @@ export function useCloseWorkspaces() {
 			let successCount = 0;
 			let failCount = 0;
 
-			for (const id of ids) {
-				try {
-					await closeMutation.mutateAsync({ id });
-					successCount++;
-				} catch {
-					failCount++;
+			try {
+				for (const id of ids) {
+					try {
+						await closeMutation.mutateAsync({ id });
+						successCount++;
+					} catch (error) {
+						console.warn("Failed to close workspace", { id, error });
+						failCount++;
+					}
+				}
+			} catch {
+				// Rollback optimistic updates on unexpected failure
+				if (previousGrouped !== undefined) {
+					utils.workspaces.getAllGrouped.setData(undefined, previousGrouped);
+				}
+				if (previousAll !== undefined) {
+					utils.workspaces.getAll.setData(undefined, previousAll);
 				}
 			}
 

--- a/apps/desktop/src/renderer/react-query/workspaces/useCloseWorkspaces.ts
+++ b/apps/desktop/src/renderer/react-query/workspaces/useCloseWorkspaces.ts
@@ -1,0 +1,105 @@
+import { toast } from "@superset/ui/sonner";
+import { useNavigate, useParams } from "@tanstack/react-router";
+import { useCallback } from "react";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
+
+export function useCloseWorkspaces() {
+  const utils = electronTrpc.useUtils();
+  const navigate = useNavigate();
+  const params = useParams({ strict: false });
+  const closeMutation = electronTrpc.workspaces.close.useMutation({
+    onSettled: () => utils.workspaces.invalidate(),
+  });
+
+  const closeWorkspaces = useCallback(
+    async (ids: string[]) => {
+      // Navigate away if currently-viewed workspace is in selection
+      if (params.workspaceId && ids.includes(params.workspaceId)) {
+        const prevId = await utils.workspaces.getPreviousWorkspace.fetch({
+          id: ids[0],
+        });
+        const nextId = await utils.workspaces.getNextWorkspace.fetch({
+          id: ids[ids.length - 1],
+        });
+        const target = prevId ?? nextId;
+        if (target && !ids.includes(target)) {
+          navigateToWorkspace(target, navigate);
+        } else {
+          navigate({ to: "/workspace" });
+        }
+      }
+
+      // Optimistically remove all workspaces from cache
+      await Promise.all([
+        utils.workspaces.getAll.cancel(),
+        utils.workspaces.getAllGrouped.cancel(),
+      ]);
+
+      const previousGrouped = utils.workspaces.getAllGrouped.getData();
+      const previousAll = utils.workspaces.getAll.getData();
+      const idsSet = new Set(ids);
+
+      if (previousGrouped) {
+        utils.workspaces.getAllGrouped.setData(
+          undefined,
+          previousGrouped
+            .map((group) => ({
+              ...group,
+              workspaces: group.workspaces.filter((w) => !idsSet.has(w.id)),
+              sections: group.sections.map((section) => ({
+                ...section,
+                workspaces: section.workspaces.filter((w) => !idsSet.has(w.id)),
+              })),
+              topLevelItems: group.topLevelItems.filter(
+                (item) => !idsSet.has(item.id)
+              ),
+            }))
+            .filter(
+              (group) =>
+                group.workspaces.length +
+                  group.sections.reduce(
+                    (sum, s) => sum + s.workspaces.length,
+                    0
+                  ) >
+                0
+            )
+        );
+      }
+      if (previousAll) {
+        utils.workspaces.getAll.setData(
+          undefined,
+          previousAll.filter((w) => !idsSet.has(w.id))
+        );
+      }
+
+      // Close sequentially
+      const toastId = toast.loading(`Hiding ${ids.length} workspaces...`);
+      let successCount = 0;
+      let failCount = 0;
+
+      for (const id of ids) {
+        try {
+          await closeMutation.mutateAsync({ id });
+          successCount++;
+        } catch {
+          failCount++;
+        }
+      }
+
+      if (failCount === 0) {
+        toast.success(`Hidden ${successCount} workspaces`, { id: toastId });
+      } else {
+        toast.warning(
+          `Hidden ${successCount}, failed ${failCount} workspaces`,
+          { id: toastId }
+        );
+      }
+
+      await utils.workspaces.invalidate();
+    },
+    [utils, navigate, params.workspaceId, closeMutation]
+  );
+
+  return { closeWorkspaces };
+}

--- a/apps/desktop/src/renderer/react-query/workspaces/useCloseWorkspaces.ts
+++ b/apps/desktop/src/renderer/react-query/workspaces/useCloseWorkspaces.ts
@@ -8,9 +8,7 @@ export function useCloseWorkspaces() {
 	const utils = electronTrpc.useUtils();
 	const navigate = useNavigate();
 	const params = useParams({ strict: false });
-	const closeMutation = electronTrpc.workspaces.close.useMutation({
-		onSettled: () => utils.workspaces.invalidate(),
-	});
+	const closeMutation = electronTrpc.workspaces.close.useMutation();
 
 	const closeWorkspaces = useCallback(
 		async (ids: string[]) => {

--- a/apps/desktop/src/renderer/react-query/workspaces/useCloseWorkspaces.ts
+++ b/apps/desktop/src/renderer/react-query/workspaces/useCloseWorkspaces.ts
@@ -5,101 +5,101 @@ import { electronTrpc } from "renderer/lib/electron-trpc";
 import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 
 export function useCloseWorkspaces() {
-  const utils = electronTrpc.useUtils();
-  const navigate = useNavigate();
-  const params = useParams({ strict: false });
-  const closeMutation = electronTrpc.workspaces.close.useMutation({
-    onSettled: () => utils.workspaces.invalidate(),
-  });
+	const utils = electronTrpc.useUtils();
+	const navigate = useNavigate();
+	const params = useParams({ strict: false });
+	const closeMutation = electronTrpc.workspaces.close.useMutation({
+		onSettled: () => utils.workspaces.invalidate(),
+	});
 
-  const closeWorkspaces = useCallback(
-    async (ids: string[]) => {
-      // Navigate away if currently-viewed workspace is in selection
-      if (params.workspaceId && ids.includes(params.workspaceId)) {
-        const prevId = await utils.workspaces.getPreviousWorkspace.fetch({
-          id: ids[0],
-        });
-        const nextId = await utils.workspaces.getNextWorkspace.fetch({
-          id: ids[ids.length - 1],
-        });
-        const target = prevId ?? nextId;
-        if (target && !ids.includes(target)) {
-          navigateToWorkspace(target, navigate);
-        } else {
-          navigate({ to: "/workspace" });
-        }
-      }
+	const closeWorkspaces = useCallback(
+		async (ids: string[]) => {
+			// Navigate away if currently-viewed workspace is in selection
+			if (params.workspaceId && ids.includes(params.workspaceId)) {
+				const prevId = await utils.workspaces.getPreviousWorkspace.fetch({
+					id: ids[0],
+				});
+				const nextId = await utils.workspaces.getNextWorkspace.fetch({
+					id: ids[ids.length - 1],
+				});
+				const target = prevId ?? nextId;
+				if (target && !ids.includes(target)) {
+					navigateToWorkspace(target, navigate);
+				} else {
+					navigate({ to: "/workspace" });
+				}
+			}
 
-      // Optimistically remove all workspaces from cache
-      await Promise.all([
-        utils.workspaces.getAll.cancel(),
-        utils.workspaces.getAllGrouped.cancel(),
-      ]);
+			// Optimistically remove all workspaces from cache
+			await Promise.all([
+				utils.workspaces.getAll.cancel(),
+				utils.workspaces.getAllGrouped.cancel(),
+			]);
 
-      const previousGrouped = utils.workspaces.getAllGrouped.getData();
-      const previousAll = utils.workspaces.getAll.getData();
-      const idsSet = new Set(ids);
+			const previousGrouped = utils.workspaces.getAllGrouped.getData();
+			const previousAll = utils.workspaces.getAll.getData();
+			const idsSet = new Set(ids);
 
-      if (previousGrouped) {
-        utils.workspaces.getAllGrouped.setData(
-          undefined,
-          previousGrouped
-            .map((group) => ({
-              ...group,
-              workspaces: group.workspaces.filter((w) => !idsSet.has(w.id)),
-              sections: group.sections.map((section) => ({
-                ...section,
-                workspaces: section.workspaces.filter((w) => !idsSet.has(w.id)),
-              })),
-              topLevelItems: group.topLevelItems.filter(
-                (item) => !idsSet.has(item.id)
-              ),
-            }))
-            .filter(
-              (group) =>
-                group.workspaces.length +
-                  group.sections.reduce(
-                    (sum, s) => sum + s.workspaces.length,
-                    0
-                  ) >
-                0
-            )
-        );
-      }
-      if (previousAll) {
-        utils.workspaces.getAll.setData(
-          undefined,
-          previousAll.filter((w) => !idsSet.has(w.id))
-        );
-      }
+			if (previousGrouped) {
+				utils.workspaces.getAllGrouped.setData(
+					undefined,
+					previousGrouped
+						.map((group) => ({
+							...group,
+							workspaces: group.workspaces.filter((w) => !idsSet.has(w.id)),
+							sections: group.sections.map((section) => ({
+								...section,
+								workspaces: section.workspaces.filter((w) => !idsSet.has(w.id)),
+							})),
+							topLevelItems: group.topLevelItems.filter(
+								(item) => !idsSet.has(item.id),
+							),
+						}))
+						.filter(
+							(group) =>
+								group.workspaces.length +
+									group.sections.reduce(
+										(sum, s) => sum + s.workspaces.length,
+										0,
+									) >
+								0,
+						),
+				);
+			}
+			if (previousAll) {
+				utils.workspaces.getAll.setData(
+					undefined,
+					previousAll.filter((w) => !idsSet.has(w.id)),
+				);
+			}
 
-      // Close sequentially
-      const toastId = toast.loading(`Hiding ${ids.length} workspaces...`);
-      let successCount = 0;
-      let failCount = 0;
+			// Close sequentially
+			const toastId = toast.loading(`Hiding ${ids.length} workspaces...`);
+			let successCount = 0;
+			let failCount = 0;
 
-      for (const id of ids) {
-        try {
-          await closeMutation.mutateAsync({ id });
-          successCount++;
-        } catch {
-          failCount++;
-        }
-      }
+			for (const id of ids) {
+				try {
+					await closeMutation.mutateAsync({ id });
+					successCount++;
+				} catch {
+					failCount++;
+				}
+			}
 
-      if (failCount === 0) {
-        toast.success(`Hidden ${successCount} workspaces`, { id: toastId });
-      } else {
-        toast.warning(
-          `Hidden ${successCount}, failed ${failCount} workspaces`,
-          { id: toastId }
-        );
-      }
+			if (failCount === 0) {
+				toast.success(`Hidden ${successCount} workspaces`, { id: toastId });
+			} else {
+				toast.warning(
+					`Hidden ${successCount}, failed ${failCount} workspaces`,
+					{ id: toastId },
+				);
+			}
 
-      await utils.workspaces.invalidate();
-    },
-    [utils, navigate, params.workspaceId, closeMutation]
-  );
+			await utils.workspaces.invalidate();
+		},
+		[utils, navigate, params.workspaceId, closeMutation],
+	);
 
-  return { closeWorkspaces };
+	return { closeWorkspaces };
 }

--- a/apps/desktop/src/renderer/react-query/workspaces/useDeleteWorkspaces.ts
+++ b/apps/desktop/src/renderer/react-query/workspaces/useDeleteWorkspaces.ts
@@ -5,108 +5,108 @@ import { electronTrpc } from "renderer/lib/electron-trpc";
 import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 
 export function useDeleteWorkspaces() {
-  const utils = electronTrpc.useUtils();
-  const navigate = useNavigate();
-  const params = useParams({ strict: false });
-  const deleteMutation = electronTrpc.workspaces.delete.useMutation({
-    onSettled: () => utils.workspaces.invalidate(),
-  });
+	const utils = electronTrpc.useUtils();
+	const navigate = useNavigate();
+	const params = useParams({ strict: false });
+	const deleteMutation = electronTrpc.workspaces.delete.useMutation({
+		onSettled: () => utils.workspaces.invalidate(),
+	});
 
-  const deleteWorkspaces = useCallback(
-    async (ids: string[], deleteLocalBranch: boolean) => {
-      // Navigate away if currently-viewed workspace is in selection
-      if (params.workspaceId && ids.includes(params.workspaceId)) {
-        const prevId = await utils.workspaces.getPreviousWorkspace.fetch({
-          id: ids[0],
-        });
-        const nextId = await utils.workspaces.getNextWorkspace.fetch({
-          id: ids[ids.length - 1],
-        });
-        const target = prevId ?? nextId;
-        if (target && !ids.includes(target)) {
-          navigateToWorkspace(target, navigate);
-        } else {
-          navigate({ to: "/workspace" });
-        }
-      }
+	const deleteWorkspaces = useCallback(
+		async (ids: string[], deleteLocalBranch: boolean) => {
+			// Navigate away if currently-viewed workspace is in selection
+			if (params.workspaceId && ids.includes(params.workspaceId)) {
+				const prevId = await utils.workspaces.getPreviousWorkspace.fetch({
+					id: ids[0],
+				});
+				const nextId = await utils.workspaces.getNextWorkspace.fetch({
+					id: ids[ids.length - 1],
+				});
+				const target = prevId ?? nextId;
+				if (target && !ids.includes(target)) {
+					navigateToWorkspace(target, navigate);
+				} else {
+					navigate({ to: "/workspace" });
+				}
+			}
 
-      // Optimistically remove all workspaces from cache
-      await Promise.all([
-        utils.workspaces.getAll.cancel(),
-        utils.workspaces.getAllGrouped.cancel(),
-      ]);
+			// Optimistically remove all workspaces from cache
+			await Promise.all([
+				utils.workspaces.getAll.cancel(),
+				utils.workspaces.getAllGrouped.cancel(),
+			]);
 
-      const previousGrouped = utils.workspaces.getAllGrouped.getData();
-      const previousAll = utils.workspaces.getAll.getData();
-      const idsSet = new Set(ids);
+			const previousGrouped = utils.workspaces.getAllGrouped.getData();
+			const previousAll = utils.workspaces.getAll.getData();
+			const idsSet = new Set(ids);
 
-      if (previousGrouped) {
-        utils.workspaces.getAllGrouped.setData(
-          undefined,
-          previousGrouped
-            .map((group) => ({
-              ...group,
-              workspaces: group.workspaces.filter((w) => !idsSet.has(w.id)),
-              sections: group.sections.map((section) => ({
-                ...section,
-                workspaces: section.workspaces.filter((w) => !idsSet.has(w.id)),
-              })),
-              topLevelItems: group.topLevelItems.filter(
-                (item) => !idsSet.has(item.id)
-              ),
-            }))
-            .filter(
-              (group) =>
-                group.workspaces.length +
-                  group.sections.reduce(
-                    (sum, s) => sum + s.workspaces.length,
-                    0
-                  ) >
-                0
-            )
-        );
-      }
-      if (previousAll) {
-        utils.workspaces.getAll.setData(
-          undefined,
-          previousAll.filter((w) => !idsSet.has(w.id))
-        );
-      }
+			if (previousGrouped) {
+				utils.workspaces.getAllGrouped.setData(
+					undefined,
+					previousGrouped
+						.map((group) => ({
+							...group,
+							workspaces: group.workspaces.filter((w) => !idsSet.has(w.id)),
+							sections: group.sections.map((section) => ({
+								...section,
+								workspaces: section.workspaces.filter((w) => !idsSet.has(w.id)),
+							})),
+							topLevelItems: group.topLevelItems.filter(
+								(item) => !idsSet.has(item.id),
+							),
+						}))
+						.filter(
+							(group) =>
+								group.workspaces.length +
+									group.sections.reduce(
+										(sum, s) => sum + s.workspaces.length,
+										0,
+									) >
+								0,
+						),
+				);
+			}
+			if (previousAll) {
+				utils.workspaces.getAll.setData(
+					undefined,
+					previousAll.filter((w) => !idsSet.has(w.id)),
+				);
+			}
 
-      // Delete sequentially
-      const toastId = toast.loading(`Deleting ${ids.length} workspaces...`);
-      let successCount = 0;
-      let failCount = 0;
+			// Delete sequentially
+			const toastId = toast.loading(`Deleting ${ids.length} workspaces...`);
+			let successCount = 0;
+			let failCount = 0;
 
-      for (const id of ids) {
-        try {
-          const result = await deleteMutation.mutateAsync({
-            id,
-            deleteLocalBranch,
-          });
-          if (result.success) {
-            successCount++;
-          } else {
-            failCount++;
-          }
-        } catch {
-          failCount++;
-        }
-      }
+			for (const id of ids) {
+				try {
+					const result = await deleteMutation.mutateAsync({
+						id,
+						deleteLocalBranch,
+					});
+					if (result.success) {
+						successCount++;
+					} else {
+						failCount++;
+					}
+				} catch {
+					failCount++;
+				}
+			}
 
-      if (failCount === 0) {
-        toast.success(`Deleted ${successCount} workspaces`, { id: toastId });
-      } else {
-        toast.warning(
-          `Deleted ${successCount}, failed ${failCount} workspaces`,
-          { id: toastId }
-        );
-      }
+			if (failCount === 0) {
+				toast.success(`Deleted ${successCount} workspaces`, { id: toastId });
+			} else {
+				toast.warning(
+					`Deleted ${successCount}, failed ${failCount} workspaces`,
+					{ id: toastId },
+				);
+			}
 
-      await utils.workspaces.invalidate();
-    },
-    [utils, navigate, params.workspaceId, deleteMutation]
-  );
+			await utils.workspaces.invalidate();
+		},
+		[utils, navigate, params.workspaceId, deleteMutation],
+	);
 
-  return { deleteWorkspaces };
+	return { deleteWorkspaces };
 }

--- a/apps/desktop/src/renderer/react-query/workspaces/useDeleteWorkspaces.ts
+++ b/apps/desktop/src/renderer/react-query/workspaces/useDeleteWorkspaces.ts
@@ -12,16 +12,20 @@ export function useDeleteWorkspaces() {
 
 	const deleteWorkspaces = useCallback(
 		async (ids: string[], deleteLocalBranch: boolean) => {
+			const idsSet = new Set(ids);
+
 			// Navigate away if currently-viewed workspace is in selection
-			if (params.workspaceId && ids.includes(params.workspaceId)) {
+			if (params.workspaceId && idsSet.has(params.workspaceId)) {
 				const prevId = await utils.workspaces.getPreviousWorkspace.fetch({
-					id: ids[0],
+					id: params.workspaceId,
 				});
 				const nextId = await utils.workspaces.getNextWorkspace.fetch({
-					id: ids[ids.length - 1],
+					id: params.workspaceId,
 				});
-				const target = prevId ?? nextId;
-				if (target && !ids.includes(target)) {
+				const target =
+					(prevId && !idsSet.has(prevId) ? prevId : null) ??
+					(nextId && !idsSet.has(nextId) ? nextId : null);
+				if (target) {
 					navigateToWorkspace(target, navigate);
 				} else {
 					navigate({ to: "/workspace" });
@@ -36,7 +40,6 @@ export function useDeleteWorkspaces() {
 
 			const previousGrouped = utils.workspaces.getAllGrouped.getData();
 			const previousAll = utils.workspaces.getAll.getData();
-			const idsSet = new Set(ids);
 
 			if (previousGrouped) {
 				utils.workspaces.getAllGrouped.setData(
@@ -76,19 +79,30 @@ export function useDeleteWorkspaces() {
 			let successCount = 0;
 			let failCount = 0;
 
-			for (const id of ids) {
-				try {
-					const result = await deleteMutation.mutateAsync({
-						id,
-						deleteLocalBranch,
-					});
-					if (result.success) {
-						successCount++;
-					} else {
+			try {
+				for (const id of ids) {
+					try {
+						const result = await deleteMutation.mutateAsync({
+							id,
+							deleteLocalBranch,
+						});
+						if (result.success) {
+							successCount++;
+						} else {
+							failCount++;
+						}
+					} catch (error) {
+						console.warn("Failed to delete workspace", { id, error });
 						failCount++;
 					}
-				} catch {
-					failCount++;
+				}
+			} catch {
+				// Rollback optimistic updates on unexpected failure
+				if (previousGrouped !== undefined) {
+					utils.workspaces.getAllGrouped.setData(undefined, previousGrouped);
+				}
+				if (previousAll !== undefined) {
+					utils.workspaces.getAll.setData(undefined, previousAll);
 				}
 			}
 

--- a/apps/desktop/src/renderer/react-query/workspaces/useDeleteWorkspaces.ts
+++ b/apps/desktop/src/renderer/react-query/workspaces/useDeleteWorkspaces.ts
@@ -8,9 +8,7 @@ export function useDeleteWorkspaces() {
 	const utils = electronTrpc.useUtils();
 	const navigate = useNavigate();
 	const params = useParams({ strict: false });
-	const deleteMutation = electronTrpc.workspaces.delete.useMutation({
-		onSettled: () => utils.workspaces.invalidate(),
-	});
+	const deleteMutation = electronTrpc.workspaces.delete.useMutation();
 
 	const deleteWorkspaces = useCallback(
 		async (ids: string[], deleteLocalBranch: boolean) => {

--- a/apps/desktop/src/renderer/react-query/workspaces/useDeleteWorkspaces.ts
+++ b/apps/desktop/src/renderer/react-query/workspaces/useDeleteWorkspaces.ts
@@ -1,0 +1,112 @@
+import { toast } from "@superset/ui/sonner";
+import { useNavigate, useParams } from "@tanstack/react-router";
+import { useCallback } from "react";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
+
+export function useDeleteWorkspaces() {
+  const utils = electronTrpc.useUtils();
+  const navigate = useNavigate();
+  const params = useParams({ strict: false });
+  const deleteMutation = electronTrpc.workspaces.delete.useMutation({
+    onSettled: () => utils.workspaces.invalidate(),
+  });
+
+  const deleteWorkspaces = useCallback(
+    async (ids: string[], deleteLocalBranch: boolean) => {
+      // Navigate away if currently-viewed workspace is in selection
+      if (params.workspaceId && ids.includes(params.workspaceId)) {
+        const prevId = await utils.workspaces.getPreviousWorkspace.fetch({
+          id: ids[0],
+        });
+        const nextId = await utils.workspaces.getNextWorkspace.fetch({
+          id: ids[ids.length - 1],
+        });
+        const target = prevId ?? nextId;
+        if (target && !ids.includes(target)) {
+          navigateToWorkspace(target, navigate);
+        } else {
+          navigate({ to: "/workspace" });
+        }
+      }
+
+      // Optimistically remove all workspaces from cache
+      await Promise.all([
+        utils.workspaces.getAll.cancel(),
+        utils.workspaces.getAllGrouped.cancel(),
+      ]);
+
+      const previousGrouped = utils.workspaces.getAllGrouped.getData();
+      const previousAll = utils.workspaces.getAll.getData();
+      const idsSet = new Set(ids);
+
+      if (previousGrouped) {
+        utils.workspaces.getAllGrouped.setData(
+          undefined,
+          previousGrouped
+            .map((group) => ({
+              ...group,
+              workspaces: group.workspaces.filter((w) => !idsSet.has(w.id)),
+              sections: group.sections.map((section) => ({
+                ...section,
+                workspaces: section.workspaces.filter((w) => !idsSet.has(w.id)),
+              })),
+              topLevelItems: group.topLevelItems.filter(
+                (item) => !idsSet.has(item.id)
+              ),
+            }))
+            .filter(
+              (group) =>
+                group.workspaces.length +
+                  group.sections.reduce(
+                    (sum, s) => sum + s.workspaces.length,
+                    0
+                  ) >
+                0
+            )
+        );
+      }
+      if (previousAll) {
+        utils.workspaces.getAll.setData(
+          undefined,
+          previousAll.filter((w) => !idsSet.has(w.id))
+        );
+      }
+
+      // Delete sequentially
+      const toastId = toast.loading(`Deleting ${ids.length} workspaces...`);
+      let successCount = 0;
+      let failCount = 0;
+
+      for (const id of ids) {
+        try {
+          const result = await deleteMutation.mutateAsync({
+            id,
+            deleteLocalBranch,
+          });
+          if (result.success) {
+            successCount++;
+          } else {
+            failCount++;
+          }
+        } catch {
+          failCount++;
+        }
+      }
+
+      if (failCount === 0) {
+        toast.success(`Deleted ${successCount} workspaces`, { id: toastId });
+      } else {
+        toast.warning(
+          `Deleted ${successCount}, failed ${failCount} workspaces`,
+          { id: toastId }
+        );
+      }
+
+      await utils.workspaces.invalidate();
+    },
+    [utils, navigate, params.workspaceId, deleteMutation]
+  );
+
+  return { deleteWorkspaces };
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceContextMenu.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceContextMenu.tsx
@@ -53,6 +53,7 @@ interface WorkspaceContextMenuProps {
 	onSetUnread: (isUnread: boolean) => void;
 	onResetStatus: () => void;
 	onDelete: () => void;
+	onBulkDelete: (workspaceIds: string[]) => void;
 	children: React.ReactNode;
 }
 
@@ -71,6 +72,7 @@ export function WorkspaceContextMenu({
 	onSetUnread,
 	onResetStatus,
 	onDelete,
+	onBulkDelete,
 	children,
 }: WorkspaceContextMenuProps) {
 	const [isContextMenuOpen, setIsContextMenuOpen] = useState(false);
@@ -191,11 +193,20 @@ export function WorkspaceContextMenu({
 			<ContextMenuSeparator />
 			<ContextMenuItem
 				onSelect={() => {
-					deleteDialogCoordinator.requestOpenDeleteDialog();
+					const captured = contextMenuSelectionRef.current;
+					if (captured.length > 1) {
+						onBulkDelete(captured);
+					} else {
+						deleteDialogCoordinator.requestOpenDeleteDialog();
+					}
 				}}
 			>
 				<LuX className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />
-				{isBranchWorkspace ? "Close Workspace" : "Close Worktree"}
+				{contextMenuSelectionRef.current.length > 1
+					? `Close ${contextMenuSelectionRef.current.length} Workspaces`
+					: isBranchWorkspace
+						? "Close Workspace"
+						: "Close Worktree"}
 			</ContextMenuItem>
 		</>
 	);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -3,7 +3,7 @@ import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { useMatchRoute, useNavigate } from "@tanstack/react-router";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { HiMiniXMark } from "react-icons/hi2";
 import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import { HotkeyLabel } from "renderer/hotkeys";
@@ -21,7 +21,10 @@ import { extractPaneIdsFromLayout } from "renderer/stores/tabs/utils";
 import { useWorkspaceSelectionStore } from "renderer/stores/workspace-selection";
 import { getHighestPriorityStatus } from "shared/tabs-types";
 import { CollapsedWorkspaceItem } from "./CollapsedWorkspaceItem";
-import { DeleteWorkspaceDialog } from "./components";
+import {
+	BulkDeleteWorkspacesDialog,
+	DeleteWorkspaceDialog,
+} from "./components";
 import {
 	GITHUB_STATUS_STALE_TIME,
 	MAX_KEYBOARD_SHORTCUT_INDEX,
@@ -155,6 +158,8 @@ export function WorkspaceListItem({
 
 	const { showDeleteDialog, setShowDeleteDialog, handleDeleteClick } =
 		useWorkspaceDeleteHandler();
+	const [bulkDeleteIds, setBulkDeleteIds] = useState<string[]>([]);
+	const showBulkDeleteDialog = bulkDeleteIds.length > 0;
 	const { status: localChanges } = useGitChangesStatus({
 		worktreePath,
 		enabled: hasHovered && !!worktreePath,
@@ -242,6 +247,10 @@ export function WorkspaceListItem({
 		if (!worktreePath) return;
 		await copyToClipboard(worktreePath);
 		toast.success("Path copied to clipboard");
+	};
+
+	const handleBulkDelete = (workspaceIds: string[]) => {
+		setBulkDeleteIds(workspaceIds);
 	};
 
 	const pr = githubStatus?.pr;
@@ -470,6 +479,7 @@ export function WorkspaceListItem({
 				onSetUnread={(unread) => setUnread.mutate({ id, isUnread: unread })}
 				onResetStatus={() => resetWorkspaceStatus(id)}
 				onDelete={handleDeleteClick}
+				onBulkDelete={handleBulkDelete}
 			>
 				{content}
 			</WorkspaceContextMenu>
@@ -479,6 +489,13 @@ export function WorkspaceListItem({
 				workspaceType={type}
 				open={showDeleteDialog}
 				onOpenChange={setShowDeleteDialog}
+			/>
+			<BulkDeleteWorkspacesDialog
+				workspaceIds={bulkDeleteIds}
+				open={showBulkDeleteDialog}
+				onOpenChange={(open) => {
+					if (!open) setBulkDeleteIds([]);
+				}}
 			/>
 		</>
 	);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/BulkDeleteWorkspacesDialog/BulkDeleteWorkspacesDialog.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/BulkDeleteWorkspacesDialog/BulkDeleteWorkspacesDialog.tsx
@@ -74,7 +74,11 @@ export function BulkDeleteWorkspacesDialog({
 				try {
 					const result = await utils.workspaces.canDelete.fetch({ id });
 					return [id, result] as const;
-				} catch {
+				} catch (error) {
+					console.warn("Failed to check workspace delete status", {
+						id,
+						error,
+					});
 					return [
 						id,
 						{ hasChanges: false, hasUnpushedCommits: false, canDelete: false },
@@ -127,7 +131,11 @@ export function BulkDeleteWorkspacesDialog({
 		onOpenChange(false);
 		clearSelection();
 		setDeleteLocalBranchSetting.mutate({ enabled: deleteLocalBranchChecked });
-		void deleteWorkspaces(workspaceIds, deleteLocalBranchChecked);
+		// Only delete workspaces that passed the canDelete check
+		const deletableIds = workspaceIds.filter(
+			(id) => canDeleteStatuses.get(id)?.canDelete !== false,
+		);
+		void deleteWorkspaces(deletableIds, deleteLocalBranchChecked);
 	}, [
 		onOpenChange,
 		clearSelection,
@@ -135,6 +143,7 @@ export function BulkDeleteWorkspacesDialog({
 		deleteLocalBranchChecked,
 		deleteWorkspaces,
 		workspaceIds,
+		canDeleteStatuses,
 	]);
 
 	// Handle Enter key press to trigger delete action

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/BulkDeleteWorkspacesDialog/BulkDeleteWorkspacesDialog.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/BulkDeleteWorkspacesDialog/BulkDeleteWorkspacesDialog.tsx
@@ -1,0 +1,212 @@
+import { focusPrimaryDialogAction } from "../DeleteWorkspaceDialog/focus-primary-dialog-action";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@superset/ui/alert-dialog";
+import { Button } from "@superset/ui/button";
+import { Checkbox } from "@superset/ui/checkbox";
+import { Label } from "@superset/ui/label";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import {
+  useCloseWorkspaces,
+  useDeleteWorkspaces,
+} from "renderer/react-query/workspaces";
+import { useWorkspaceSelectionStore } from "renderer/stores/workspace-selection";
+
+interface BulkDeleteWorkspacesDialogProps {
+  workspaceIds: string[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function BulkDeleteWorkspacesDialog({
+  workspaceIds,
+  open,
+  onOpenChange,
+}: BulkDeleteWorkspacesDialogProps) {
+  const { deleteWorkspaces } = useDeleteWorkspaces();
+  const { closeWorkspaces } = useCloseWorkspaces();
+  const clearSelection = useWorkspaceSelectionStore((s) => s.clearSelection);
+
+  const setDeleteLocalBranchSetting =
+    electronTrpc.settings.setDeleteLocalBranch.useMutation();
+  const { data: deleteLocalBranchDefault } =
+    electronTrpc.settings.getDeleteLocalBranch.useQuery(undefined, {
+      enabled: open,
+    });
+  const [deleteLocalBranch, setDeleteLocalBranch] = useState<boolean | null>(
+    null
+  );
+  const deleteLocalBranchChecked =
+    deleteLocalBranch ?? deleteLocalBranchDefault ?? false;
+  const hideAllButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  // Aggregate canDelete status across all workspaces
+  const canDeleteQueries = workspaceIds.map((id) =>
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    electronTrpc.workspaces.canDelete.useQuery(
+      { id },
+      { enabled: open, staleTime: 5_000, refetchOnWindowFocus: false }
+    )
+  );
+
+  const isLoading = canDeleteQueries.some((q) => q.isLoading);
+  const withChanges = canDeleteQueries.filter((q) => q.data?.hasChanges).length;
+  const withUnpushed = canDeleteQueries.filter(
+    (q) => q.data?.hasUnpushedCommits
+  ).length;
+  const cannotDelete = canDeleteQueries.filter(
+    (q) => q.data && !q.data.canDelete
+  ).length;
+  const hasWarnings = withChanges > 0 || withUnpushed > 0;
+  const count = workspaceIds.length;
+
+  const handleClose = useCallback(() => {
+    onOpenChange(false);
+    clearSelection();
+    void closeWorkspaces(workspaceIds);
+  }, [onOpenChange, clearSelection, closeWorkspaces, workspaceIds]);
+
+  const handleDelete = useCallback(() => {
+    onOpenChange(false);
+    clearSelection();
+    setDeleteLocalBranchSetting.mutate({ enabled: deleteLocalBranchChecked });
+    void deleteWorkspaces(workspaceIds, deleteLocalBranchChecked);
+  }, [
+    onOpenChange,
+    clearSelection,
+    setDeleteLocalBranchSetting,
+    deleteLocalBranchChecked,
+    deleteWorkspaces,
+    workspaceIds,
+  ]);
+
+  // Handle Enter key press to trigger delete action
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key === "Enter" &&
+        !event.shiftKey &&
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !event.altKey
+      ) {
+        event.preventDefault();
+        if (!isLoading && cannotDelete < count) {
+          handleDelete();
+        }
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [open, isLoading, cannotDelete, count, handleDelete]);
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent
+        className="max-w-[340px] gap-0 p-0"
+        onOpenAutoFocus={(event) => {
+          focusPrimaryDialogAction(event, hideAllButtonRef.current);
+        }}
+      >
+        <AlertDialogHeader className="px-4 pt-4 pb-2">
+          <AlertDialogTitle className="font-medium">
+            Close {count} workspaces?
+          </AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="text-muted-foreground space-y-1.5">
+              {isLoading ? (
+                "Checking status..."
+              ) : cannotDelete > 0 ? (
+                <span className="text-destructive">
+                  {cannotDelete} of {count} cannot be deleted right now.
+                </span>
+              ) : (
+                <span className="block">
+                  Deleting will permanently remove worktrees from disk. You can
+                  hide instead to keep files.
+                </span>
+              )}
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        {!isLoading && hasWarnings && (
+          <div className="px-4 pb-2">
+            <div className="text-xs text-yellow-700 dark:text-yellow-400 bg-yellow-50 dark:bg-yellow-500/10 border border-yellow-200 dark:border-yellow-500/20 rounded-md px-2.5 py-1.5">
+              {withChanges > 0 && withUnpushed > 0
+                ? `${withChanges} of ${count} have uncommitted changes, ${withUnpushed} have unpushed commits`
+                : withChanges > 0
+                ? `${withChanges} of ${count} have uncommitted changes`
+                : `${withUnpushed} of ${count} have unpushed commits`}
+            </div>
+          </div>
+        )}
+
+        {!isLoading && cannotDelete < count && (
+          <div className="px-4 pb-2">
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="bulk-delete-local-branch"
+                checked={deleteLocalBranchChecked}
+                onCheckedChange={(checked) =>
+                  setDeleteLocalBranch(checked === true)
+                }
+              />
+              <Label
+                htmlFor="bulk-delete-local-branch"
+                className="text-xs text-muted-foreground cursor-pointer select-none"
+              >
+                Also delete local branches
+              </Label>
+            </div>
+          </div>
+        )}
+
+        <AlertDialogFooter className="px-4 pb-4 pt-2 flex-row justify-end gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 px-3 text-xs"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            ref={hideAllButtonRef}
+            variant="secondary"
+            size="sm"
+            className="h-7 px-3 text-xs"
+            onClick={handleClose}
+          >
+            Hide All
+          </Button>
+          <Tooltip delayDuration={400}>
+            <TooltipTrigger asChild>
+              <Button
+                variant="destructive"
+                size="sm"
+                className="h-7 px-3 text-xs"
+                onClick={handleDelete}
+                disabled={isLoading || cannotDelete >= count}
+              >
+                Delete All
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="top" className="text-xs max-w-[200px]">
+              Permanently delete {count} workspaces and their git worktrees from
+              disk.
+            </TooltipContent>
+          </Tooltip>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/BulkDeleteWorkspacesDialog/BulkDeleteWorkspacesDialog.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/BulkDeleteWorkspacesDialog/BulkDeleteWorkspacesDialog.tsx
@@ -52,7 +52,7 @@ export function BulkDeleteWorkspacesDialog({
 	);
 	const deleteLocalBranchChecked =
 		deleteLocalBranch ?? deleteLocalBranchDefault ?? false;
-	const hideAllButtonRef = useRef<HTMLButtonElement | null>(null);
+	const deleteAllButtonRef = useRef<HTMLButtonElement | null>(null);
 
 	// Fetch canDelete status for all workspaces imperatively
 	const [canDeleteStatuses, setCanDeleteStatuses] = useState<
@@ -71,22 +71,34 @@ export function BulkDeleteWorkspacesDialog({
 
 		Promise.all(
 			workspaceIds.map(async (id) => {
-				const result = await utils.workspaces.canDelete.fetch({ id });
-				return [id, result] as const;
+				try {
+					const result = await utils.workspaces.canDelete.fetch({ id });
+					return [id, result] as const;
+				} catch {
+					return [
+						id,
+						{ hasChanges: false, hasUnpushedCommits: false, canDelete: false },
+					] as const;
+				}
 			}),
-		).then((results) => {
-			if (cancelled) return;
-			const map = new Map<string, CanDeleteStatus>();
-			for (const [id, result] of results) {
-				map.set(id, {
-					hasChanges: result.hasChanges ?? false,
-					hasUnpushedCommits: result.hasUnpushedCommits ?? false,
-					canDelete: result.canDelete ?? true,
-				});
-			}
-			setCanDeleteStatuses(map);
-			setIsLoading(false);
-		});
+		)
+			.then((results) => {
+				if (cancelled) return;
+				const map = new Map<string, CanDeleteStatus>();
+				for (const [id, result] of results) {
+					map.set(id, {
+						hasChanges: result.hasChanges ?? false,
+						hasUnpushedCommits: result.hasUnpushedCommits ?? false,
+						canDelete: result.canDelete ?? true,
+					});
+				}
+				setCanDeleteStatuses(map);
+				setIsLoading(false);
+			})
+			.catch(() => {
+				if (cancelled) return;
+				setIsLoading(false);
+			});
 
 		return () => {
 			cancelled = true;
@@ -151,7 +163,7 @@ export function BulkDeleteWorkspacesDialog({
 			<AlertDialogContent
 				className="max-w-[340px] gap-0 p-0"
 				onOpenAutoFocus={(event) => {
-					focusPrimaryDialogAction(event, hideAllButtonRef.current);
+					focusPrimaryDialogAction(event, deleteAllButtonRef.current);
 				}}
 			>
 				<AlertDialogHeader className="px-4 pt-4 pb-2">
@@ -218,7 +230,6 @@ export function BulkDeleteWorkspacesDialog({
 						Cancel
 					</Button>
 					<Button
-						ref={hideAllButtonRef}
 						variant="secondary"
 						size="sm"
 						className="h-7 px-3 text-xs"
@@ -229,6 +240,7 @@ export function BulkDeleteWorkspacesDialog({
 					<Tooltip delayDuration={400}>
 						<TooltipTrigger asChild>
 							<Button
+								ref={deleteAllButtonRef}
 								variant="destructive"
 								size="sm"
 								className="h-7 px-3 text-xs"

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/BulkDeleteWorkspacesDialog/BulkDeleteWorkspacesDialog.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/BulkDeleteWorkspacesDialog/BulkDeleteWorkspacesDialog.tsx
@@ -1,11 +1,10 @@
-import { focusPrimaryDialogAction } from "../DeleteWorkspaceDialog/focus-primary-dialog-action";
 import {
-  AlertDialog,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
+	AlertDialog,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
 } from "@superset/ui/alert-dialog";
 import { Button } from "@superset/ui/button";
 import { Checkbox } from "@superset/ui/checkbox";
@@ -14,199 +13,238 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
-  useCloseWorkspaces,
-  useDeleteWorkspaces,
+	useCloseWorkspaces,
+	useDeleteWorkspaces,
 } from "renderer/react-query/workspaces";
 import { useWorkspaceSelectionStore } from "renderer/stores/workspace-selection";
+import { focusPrimaryDialogAction } from "../DeleteWorkspaceDialog/focus-primary-dialog-action";
+
+interface CanDeleteStatus {
+	hasChanges: boolean;
+	hasUnpushedCommits: boolean;
+	canDelete: boolean;
+}
 
 interface BulkDeleteWorkspacesDialogProps {
-  workspaceIds: string[];
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
+	workspaceIds: string[];
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
 }
 
 export function BulkDeleteWorkspacesDialog({
-  workspaceIds,
-  open,
-  onOpenChange,
+	workspaceIds,
+	open,
+	onOpenChange,
 }: BulkDeleteWorkspacesDialogProps) {
-  const { deleteWorkspaces } = useDeleteWorkspaces();
-  const { closeWorkspaces } = useCloseWorkspaces();
-  const clearSelection = useWorkspaceSelectionStore((s) => s.clearSelection);
+	const { deleteWorkspaces } = useDeleteWorkspaces();
+	const { closeWorkspaces } = useCloseWorkspaces();
+	const clearSelection = useWorkspaceSelectionStore((s) => s.clearSelection);
+	const utils = electronTrpc.useUtils();
 
-  const setDeleteLocalBranchSetting =
-    electronTrpc.settings.setDeleteLocalBranch.useMutation();
-  const { data: deleteLocalBranchDefault } =
-    electronTrpc.settings.getDeleteLocalBranch.useQuery(undefined, {
-      enabled: open,
-    });
-  const [deleteLocalBranch, setDeleteLocalBranch] = useState<boolean | null>(
-    null
-  );
-  const deleteLocalBranchChecked =
-    deleteLocalBranch ?? deleteLocalBranchDefault ?? false;
-  const hideAllButtonRef = useRef<HTMLButtonElement | null>(null);
+	const setDeleteLocalBranchSetting =
+		electronTrpc.settings.setDeleteLocalBranch.useMutation();
+	const { data: deleteLocalBranchDefault } =
+		electronTrpc.settings.getDeleteLocalBranch.useQuery(undefined, {
+			enabled: open,
+		});
+	const [deleteLocalBranch, setDeleteLocalBranch] = useState<boolean | null>(
+		null,
+	);
+	const deleteLocalBranchChecked =
+		deleteLocalBranch ?? deleteLocalBranchDefault ?? false;
+	const hideAllButtonRef = useRef<HTMLButtonElement | null>(null);
 
-  // Aggregate canDelete status across all workspaces
-  const canDeleteQueries = workspaceIds.map((id) =>
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    electronTrpc.workspaces.canDelete.useQuery(
-      { id },
-      { enabled: open, staleTime: 5_000, refetchOnWindowFocus: false }
-    )
-  );
+	// Fetch canDelete status for all workspaces imperatively
+	const [canDeleteStatuses, setCanDeleteStatuses] = useState<
+		Map<string, CanDeleteStatus>
+	>(new Map());
+	const [isLoading, setIsLoading] = useState(false);
 
-  const isLoading = canDeleteQueries.some((q) => q.isLoading);
-  const withChanges = canDeleteQueries.filter((q) => q.data?.hasChanges).length;
-  const withUnpushed = canDeleteQueries.filter(
-    (q) => q.data?.hasUnpushedCommits
-  ).length;
-  const cannotDelete = canDeleteQueries.filter(
-    (q) => q.data && !q.data.canDelete
-  ).length;
-  const hasWarnings = withChanges > 0 || withUnpushed > 0;
-  const count = workspaceIds.length;
+	useEffect(() => {
+		if (!open || workspaceIds.length === 0) {
+			setCanDeleteStatuses(new Map());
+			return;
+		}
 
-  const handleClose = useCallback(() => {
-    onOpenChange(false);
-    clearSelection();
-    void closeWorkspaces(workspaceIds);
-  }, [onOpenChange, clearSelection, closeWorkspaces, workspaceIds]);
+		setIsLoading(true);
+		let cancelled = false;
 
-  const handleDelete = useCallback(() => {
-    onOpenChange(false);
-    clearSelection();
-    setDeleteLocalBranchSetting.mutate({ enabled: deleteLocalBranchChecked });
-    void deleteWorkspaces(workspaceIds, deleteLocalBranchChecked);
-  }, [
-    onOpenChange,
-    clearSelection,
-    setDeleteLocalBranchSetting,
-    deleteLocalBranchChecked,
-    deleteWorkspaces,
-    workspaceIds,
-  ]);
+		Promise.all(
+			workspaceIds.map(async (id) => {
+				const result = await utils.workspaces.canDelete.fetch({ id });
+				return [id, result] as const;
+			}),
+		).then((results) => {
+			if (cancelled) return;
+			const map = new Map<string, CanDeleteStatus>();
+			for (const [id, result] of results) {
+				map.set(id, {
+					hasChanges: result.hasChanges ?? false,
+					hasUnpushedCommits: result.hasUnpushedCommits ?? false,
+					canDelete: result.canDelete ?? true,
+				});
+			}
+			setCanDeleteStatuses(map);
+			setIsLoading(false);
+		});
 
-  // Handle Enter key press to trigger delete action
-  useEffect(() => {
-    if (!open) return;
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (
-        event.key === "Enter" &&
-        !event.shiftKey &&
-        !event.metaKey &&
-        !event.ctrlKey &&
-        !event.altKey
-      ) {
-        event.preventDefault();
-        if (!isLoading && cannotDelete < count) {
-          handleDelete();
-        }
-      }
-    };
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [open, isLoading, cannotDelete, count, handleDelete]);
+		return () => {
+			cancelled = true;
+		};
+	}, [open, workspaceIds, utils]);
 
-  return (
-    <AlertDialog open={open} onOpenChange={onOpenChange}>
-      <AlertDialogContent
-        className="max-w-[340px] gap-0 p-0"
-        onOpenAutoFocus={(event) => {
-          focusPrimaryDialogAction(event, hideAllButtonRef.current);
-        }}
-      >
-        <AlertDialogHeader className="px-4 pt-4 pb-2">
-          <AlertDialogTitle className="font-medium">
-            Close {count} workspaces?
-          </AlertDialogTitle>
-          <AlertDialogDescription asChild>
-            <div className="text-muted-foreground space-y-1.5">
-              {isLoading ? (
-                "Checking status..."
-              ) : cannotDelete > 0 ? (
-                <span className="text-destructive">
-                  {cannotDelete} of {count} cannot be deleted right now.
-                </span>
-              ) : (
-                <span className="block">
-                  Deleting will permanently remove worktrees from disk. You can
-                  hide instead to keep files.
-                </span>
-              )}
-            </div>
-          </AlertDialogDescription>
-        </AlertDialogHeader>
+	const withChanges = [...canDeleteStatuses.values()].filter(
+		(s) => s.hasChanges,
+	).length;
+	const withUnpushed = [...canDeleteStatuses.values()].filter(
+		(s) => s.hasUnpushedCommits,
+	).length;
+	const cannotDelete = [...canDeleteStatuses.values()].filter(
+		(s) => !s.canDelete,
+	).length;
+	const hasWarnings = withChanges > 0 || withUnpushed > 0;
+	const count = workspaceIds.length;
 
-        {!isLoading && hasWarnings && (
-          <div className="px-4 pb-2">
-            <div className="text-xs text-yellow-700 dark:text-yellow-400 bg-yellow-50 dark:bg-yellow-500/10 border border-yellow-200 dark:border-yellow-500/20 rounded-md px-2.5 py-1.5">
-              {withChanges > 0 && withUnpushed > 0
-                ? `${withChanges} of ${count} have uncommitted changes, ${withUnpushed} have unpushed commits`
-                : withChanges > 0
-                ? `${withChanges} of ${count} have uncommitted changes`
-                : `${withUnpushed} of ${count} have unpushed commits`}
-            </div>
-          </div>
-        )}
+	const handleClose = useCallback(() => {
+		onOpenChange(false);
+		clearSelection();
+		void closeWorkspaces(workspaceIds);
+	}, [onOpenChange, clearSelection, closeWorkspaces, workspaceIds]);
 
-        {!isLoading && cannotDelete < count && (
-          <div className="px-4 pb-2">
-            <div className="flex items-center gap-2">
-              <Checkbox
-                id="bulk-delete-local-branch"
-                checked={deleteLocalBranchChecked}
-                onCheckedChange={(checked) =>
-                  setDeleteLocalBranch(checked === true)
-                }
-              />
-              <Label
-                htmlFor="bulk-delete-local-branch"
-                className="text-xs text-muted-foreground cursor-pointer select-none"
-              >
-                Also delete local branches
-              </Label>
-            </div>
-          </div>
-        )}
+	const handleDelete = useCallback(() => {
+		onOpenChange(false);
+		clearSelection();
+		setDeleteLocalBranchSetting.mutate({ enabled: deleteLocalBranchChecked });
+		void deleteWorkspaces(workspaceIds, deleteLocalBranchChecked);
+	}, [
+		onOpenChange,
+		clearSelection,
+		setDeleteLocalBranchSetting,
+		deleteLocalBranchChecked,
+		deleteWorkspaces,
+		workspaceIds,
+	]);
 
-        <AlertDialogFooter className="px-4 pb-4 pt-2 flex-row justify-end gap-2">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 px-3 text-xs"
-            onClick={() => onOpenChange(false)}
-          >
-            Cancel
-          </Button>
-          <Button
-            ref={hideAllButtonRef}
-            variant="secondary"
-            size="sm"
-            className="h-7 px-3 text-xs"
-            onClick={handleClose}
-          >
-            Hide All
-          </Button>
-          <Tooltip delayDuration={400}>
-            <TooltipTrigger asChild>
-              <Button
-                variant="destructive"
-                size="sm"
-                className="h-7 px-3 text-xs"
-                onClick={handleDelete}
-                disabled={isLoading || cannotDelete >= count}
-              >
-                Delete All
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="top" className="text-xs max-w-[200px]">
-              Permanently delete {count} workspaces and their git worktrees from
-              disk.
-            </TooltipContent>
-          </Tooltip>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
-  );
+	// Handle Enter key press to trigger delete action
+	useEffect(() => {
+		if (!open) return;
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (
+				event.key === "Enter" &&
+				!event.shiftKey &&
+				!event.metaKey &&
+				!event.ctrlKey &&
+				!event.altKey
+			) {
+				event.preventDefault();
+				if (!isLoading && cannotDelete < count) {
+					handleDelete();
+				}
+			}
+		};
+		window.addEventListener("keydown", handleKeyDown);
+		return () => window.removeEventListener("keydown", handleKeyDown);
+	}, [open, isLoading, cannotDelete, count, handleDelete]);
+
+	return (
+		<AlertDialog open={open} onOpenChange={onOpenChange}>
+			<AlertDialogContent
+				className="max-w-[340px] gap-0 p-0"
+				onOpenAutoFocus={(event) => {
+					focusPrimaryDialogAction(event, hideAllButtonRef.current);
+				}}
+			>
+				<AlertDialogHeader className="px-4 pt-4 pb-2">
+					<AlertDialogTitle className="font-medium">
+						Close {count} workspaces?
+					</AlertDialogTitle>
+					<AlertDialogDescription asChild>
+						<div className="text-muted-foreground space-y-1.5">
+							{isLoading ? (
+								"Checking status..."
+							) : cannotDelete > 0 ? (
+								<span className="text-destructive">
+									{cannotDelete} of {count} cannot be deleted right now.
+								</span>
+							) : (
+								<span className="block">
+									Deleting will permanently remove worktrees from disk. You can
+									hide instead to keep files.
+								</span>
+							)}
+						</div>
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+
+				{!isLoading && hasWarnings && (
+					<div className="px-4 pb-2">
+						<div className="text-xs text-yellow-700 dark:text-yellow-400 bg-yellow-50 dark:bg-yellow-500/10 border border-yellow-200 dark:border-yellow-500/20 rounded-md px-2.5 py-1.5">
+							{withChanges > 0 && withUnpushed > 0
+								? `${withChanges} of ${count} have uncommitted changes, ${withUnpushed} have unpushed commits`
+								: withChanges > 0
+									? `${withChanges} of ${count} have uncommitted changes`
+									: `${withUnpushed} of ${count} have unpushed commits`}
+						</div>
+					</div>
+				)}
+
+				{!isLoading && cannotDelete < count && (
+					<div className="px-4 pb-2">
+						<div className="flex items-center gap-2">
+							<Checkbox
+								id="bulk-delete-local-branch"
+								checked={deleteLocalBranchChecked}
+								onCheckedChange={(checked) =>
+									setDeleteLocalBranch(checked === true)
+								}
+							/>
+							<Label
+								htmlFor="bulk-delete-local-branch"
+								className="text-xs text-muted-foreground cursor-pointer select-none"
+							>
+								Also delete local branches
+							</Label>
+						</div>
+					</div>
+				)}
+
+				<AlertDialogFooter className="px-4 pb-4 pt-2 flex-row justify-end gap-2">
+					<Button
+						variant="ghost"
+						size="sm"
+						className="h-7 px-3 text-xs"
+						onClick={() => onOpenChange(false)}
+					>
+						Cancel
+					</Button>
+					<Button
+						ref={hideAllButtonRef}
+						variant="secondary"
+						size="sm"
+						className="h-7 px-3 text-xs"
+						onClick={handleClose}
+					>
+						Hide All
+					</Button>
+					<Tooltip delayDuration={400}>
+						<TooltipTrigger asChild>
+							<Button
+								variant="destructive"
+								size="sm"
+								className="h-7 px-3 text-xs"
+								onClick={handleDelete}
+								disabled={isLoading || cannotDelete >= count}
+							>
+								Delete All
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent side="top" className="text-xs max-w-[200px]">
+							Permanently delete {count} workspaces and their git worktrees from
+							disk.
+						</TooltipContent>
+					</Tooltip>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	);
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/BulkDeleteWorkspacesDialog/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/BulkDeleteWorkspacesDialog/index.ts
@@ -1,0 +1,1 @@
+export { BulkDeleteWorkspacesDialog } from "./BulkDeleteWorkspacesDialog";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/index.ts
@@ -1,2 +1,3 @@
+export { BulkDeleteWorkspacesDialog } from "./BulkDeleteWorkspacesDialog";
 export { DeleteWorkspaceDialog } from "./DeleteWorkspaceDialog";
 export { WorkspaceHoverCardContent } from "./WorkspaceHoverCard";


### PR DESCRIPTION
## Summary

- Adds multi-workspace delete/close functionality to the workspace sidebar context menu
- When multiple workspaces are selected (Cmd+click, Shift+click), right-clicking shows "Close N Workspaces" instead of the single-workspace option
- Opens a `BulkDeleteWorkspacesDialog` with aggregated git status warnings (uncommitted changes, unpushed commits), a global "delete local branches" checkbox, and Cancel / Hide All / Delete All buttons
- Reuses existing single-workspace `workspaces.delete` and `workspaces.close` tRPC procedures sequentially — **no backend changes needed**
- Optimistic UI: all selected workspaces are removed from the sidebar immediately, with cache rollback on failure

## Motivation

Currently, users with many workspaces must delete them one-by-one via the X icon or context menu, each requiring its own confirmation dialog. This is tedious when cleaning up 10+ stale workspaces.

## Changes

| File | Change |
|------|--------|
| `useDeleteWorkspaces.ts` | **New** — bulk delete hook with batch optimistic cache updates |
| `useCloseWorkspaces.ts` | **New** — bulk close (hide) hook with batch optimistic cache updates |
| `BulkDeleteWorkspacesDialog.tsx` | **New** — confirmation dialog with aggregated git warnings |
| `WorkspaceContextMenu.tsx` | Branch on multi-select for delete item, show count in label |
| `WorkspaceListItem.tsx` | Manage bulk dialog state, pass `onBulkDelete` callback |
| `index.ts` (2 files) | Export new hooks and component |

## Test plan

- [ ] Select multiple workspaces with Cmd+click, right-click → context menu shows "Close N Workspaces"
- [ ] Click "Close N Workspaces" → bulk dialog opens with correct count
- [ ] Verify git warning aggregation: select workspaces with uncommitted changes, confirm warning banner appears
- [ ] Click "Delete All" → all selected workspaces removed from sidebar immediately (optimistic)
- [ ] Click "Hide All" → all selected workspaces hidden (files kept on disk)
- [ ] Click "Cancel" → dialog closes, no changes
- [ ] Verify "delete local branches" checkbox persists preference via settings
- [ ] Single-select right-click still shows original "Close Workspace" / "Close Worktree" behavior
- [ ] If currently-viewed workspace is in selection, app navigates to nearest remaining workspace
- [ ] Enter key triggers Delete All action

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add bulk delete/close for workspaces from the sidebar context menu to speed up cleanup of multiple worktrees. No backend changes; reuses existing `tRPC` endpoints with optimistic UI, safe navigation, and batched cache invalidation.

- **New Features**
  - Multi-select workspaces and right-click to “Close N Workspaces” to open a bulk dialog.
  - Dialog aggregates git warnings, has a global “delete local branches” checkbox (preference persisted), and Cancel / Hide All / Delete All; Enter confirms Delete All.
  - Added `useDeleteWorkspaces` and `useCloseWorkspaces` for sequential `workspaces.delete` / `workspaces.close` with optimistic removal and one cache invalidate.
  - If the active workspace is selected, navigate to the nearest remaining workspace not being deleted.

- **Bug Fixes**
  - Handle `canDelete` fetch failures; show partial counts instead of blocking.
  - Auto-focus Delete All to match Enter; drop per-item refetches in favor of a single post-batch invalidate.
  - Filter out non-deletable IDs before delete and roll back cache on unexpected batch failure.

<sup>Written for commit 1d842bbbc070bff73824e8959b412edc08ebf18b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk close/delete of multiple workspaces from the sidebar.
  * Confirmation dialog performs eligibility checks, shows warnings for uncommitted changes and unpushed commits, and includes an “Also delete local branches” checkbox.
  * Context menu supports batch operations with dynamic labeling based on selection size.
  * Dialog supports Enter to confirm, shows progress and success/warning toasts, and navigates away if the current workspace is closed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->