### PR TITLE
fix(auth): bypass free-plan member limit for domain-allowlisted users

### DIFF
--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -329,7 +329,23 @@ export const auth = betterAuth({
 					});
 				},
 
-				beforeAddMember: async ({ organization }) => {
+				beforeAddMember: async ({ organization, user }) => {
+					// Domain-allowlisted users bypass the free-plan member limit.
+					// If an admin put the user's domain in allowedDomains, they've
+					// already explicitly opted in to letting those users join.
+					// (allowedDomains isn't on the hook's organization arg because
+					// it isn't declared as a better-auth additionalField — fetch it.)
+					const userDomain = user.email.split("@")[1]?.toLowerCase();
+					if (userDomain) {
+						const orgRow = await db.query.organizations.findFirst({
+							where: eq(authSchema.organizations.id, organization.id),
+							columns: { allowedDomains: true },
+						});
+						if (orgRow?.allowedDomains?.includes(userDomain)) {
+							return;
+						}
+					}
+
 					const subscription = await db.query.subscriptions.findFirst({
 						where: and(
 							eq(subscriptions.referenceId, organization.id),


### PR DESCRIPTION
## Summary

Free-plan orgs with `allowed_domains` configured were silently broken for auto-enrollment. Any new signup whose email domain matched would land in an orphaned solo `X's Team` org instead of the org they were supposed to join.

### What was happening

1. Admin puts a domain in their org's `allowedDomains`.
2. New user with that email domain signs up.
3. `databaseHooks.user.create.after` calls `auth.api.addMember(...)` to auto-enroll.
4. `beforeAddMember` throws `"Free plan is limited to 1 user. Upgrade to add more members."` because the org already has 1 member.
5. The auto-enroll hook's try/catch logs the error and falls through to creating a personal solo org.
6. User is orphaned; no amount of token-clearing on the client can fix a user who was never made a member.

Every free-plan customer with a domain allowlist hit this for every teammate after the first. Since free-plan is the tier customers are on before deciding to upgrade, the domain allowlist feature was effectively broken during the exact window where it matters most.

### Fix

In `beforeAddMember`: if the user's email domain is in the org's `allowedDomains`, return early and skip the free-plan limit check. The admin has already explicitly opted those users in.

`allowedDomains` is not declared as a better-auth `additionalField`, so the hook's `organization` argument doesn't carry it at runtime (only the base `id/name/slug/logo/metadata/createdAt` are populated, even though the TypeScript type is `Organization & Record<string, any>`). We fetch it from the DB by `organization.id` — one small query, only on the write path, only on free-plan orgs.

### Why this approach

Semantic fix purely in `beforeAddMember`:

- No changes to the auto-enroll call site or schema config.
- Automatically covers any future call path that adds domain-matched users, not just `user.create.after`.
- Paid plans are unaffected: they already short-circuit via `if (subscription) return;`.
- Invites/manual adds to a free-plan org with no allowlist still throw the limit error as before.

### Retroactive fix

After this lands, a sweep over prod can find any existing orphans whose email domain matches an existing org's `allowed_domains` but who aren't members of that org:

```sql
SELECT u.id, u.email, o.id AS should_join_org, o.name
FROM auth.users u
JOIN auth.organizations o
  ON lower(split_part(u.email, '@', 2)) = ANY(o.allowed_domains)
LEFT JOIN auth.members m
  ON m.user_id = u.id AND m.organization_id = o.id
WHERE m.id IS NULL;
```

### Abuse note

A free-plan org could add `gmail.com` to `allowed_domains` and auto-enroll unlimited users for free. If this becomes a concern, a follow-up can block common public-email domains at the point where an admin configures `allowed_domains`. Out of scope here.

## Test plan

- [x] `bun run --filter=@superset/auth typecheck`
- [x] `bun run typecheck` (full repo, 24/24)
- [x] `bun run --filter=@superset/auth test`
- [x] `bun run lint:fix` (no changes)
- [x] End-to-end verified on a dev neon branch: free-plan org with `allowed_domains = {superset.sh}` and 2 existing members; deleted my user; signed up fresh with Google → landed in the org, not a solo team.
- [ ] Post-merge: run the orphan-detection SQL against prod and repair any affected users.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organizations can now configure allowed email domains when adding members to control access based on email domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->