### PR TITLE
fix(mcp): stop classifying devices as offline in list_devices

### DIFF
--- a/apps/api/MCP_TOOLS.md
+++ b/apps/api/MCP_TOOLS.md
@@ -161,12 +161,10 @@ const listTaskStatusesOutput = z.object({
 These tools write to `agent_commands` table and poll for results.
 
 #### `list_devices`
-List online devices in the organization.
+List registered devices in the organization.
 
 ```typescript
-const listDevicesInput = z.object({
-  includeOffline: z.boolean().default(false).describe("Include recently offline devices"),
-});
+const listDevicesInput = z.object({});
 
 const listDevicesOutput = z.object({
   devices: z.array(z.object({
@@ -176,7 +174,6 @@ const listDevicesOutput = z.object({
     ownerId: z.string().uuid().describe("User who owns this device"),
     ownerName: z.string().describe("Name of device owner"),
     lastSeenAt: z.string().datetime(),
-    isOnline: z.boolean(),
   })),
 });
 ```

--- a/apps/api/src/app/api/integrations/slack/events/utils/run-agent/run-agent.ts
+++ b/apps/api/src/app/api/integrations/slack/events/utils/run-agent/run-agent.ts
@@ -370,7 +370,7 @@ async function fetchAgentContext({
 		mcpClient.callTool({ name: "list_task_statuses", arguments: {} }),
 		mcpClient.callTool({
 			name: "list_devices",
-			arguments: { includeOffline: true },
+			arguments: {},
 		}),
 	]);
 
@@ -409,13 +409,12 @@ async function fetchAgentContext({
 			deviceName: string | null;
 			ownerName: string | null;
 			ownerEmail: string;
-			isOnline: boolean;
 		}[];
 	} | null;
 	if (devicesData?.devices?.length) {
 		const lines = devicesData.devices.map(
 			(d) =>
-				`- ${d.deviceName ?? "Unknown"} (id: ${d.deviceId}, owner: ${d.ownerName ?? d.ownerEmail}, status: ${d.isOnline ? "online" : "offline"})`,
+				`- ${d.deviceName ?? "Unknown"} (id: ${d.deviceId}, owner: ${d.ownerName ?? d.ownerEmail})`,
 		);
 		sections.push(`Devices:\n${lines.join("\n")}`);
 	}

--- a/apps/docs/content/docs/mcp.mdx
+++ b/apps/docs/content/docs/mcp.mdx
@@ -248,7 +248,7 @@ API keys grant full access to your organization. Keep them secret and never comm
 
 | Tool | Description |
 |------|-------------|
-| `list_devices` | List online devices in your organization |
+| `list_devices` | List registered devices in your organization |
 | `list_projects` | List all projects on a device |
 | `get_app_context` | Get current app state (active workspace, pathname) |
 | `list_members` | List organization members |

--- a/packages/cli/src/commands/devices/list/command.ts
+++ b/packages/cli/src/commands/devices/list/command.ts
@@ -1,15 +1,12 @@
-import { boolean, CLIError, command, table } from "@superset/cli-framework";
+import { CLIError, command, table } from "@superset/cli-framework";
 
 export default command({
 	description: "List all devices in the org",
-	options: {
-		includeOffline: boolean().desc("Include offline devices"),
-	},
+	options: {},
 	display: (data) =>
 		table(data as Record<string, unknown>[], [
 			"deviceName",
 			"deviceType",
-			"status",
 			"lastSeen",
 		]),
 	run: async () => {

--- a/packages/mcp/src/tools/devices/list-devices/list-devices.test.ts
+++ b/packages/mcp/src/tools/devices/list-devices/list-devices.test.ts
@@ -5,7 +5,7 @@ const getMcpContextMock = mock(() => ({ organizationId: "org-1" }));
 
 let fetchedDevices = [
 	{
-		deviceId: "device-online",
+		deviceId: "device-a",
 		deviceName: "Ada's MacBook",
 		deviceType: "desktop",
 		lastSeenAt: new Date(Date.now() - 30_000),
@@ -14,7 +14,7 @@ let fetchedDevices = [
 		ownerEmail: "ada@example.com",
 	},
 	{
-		deviceId: "device-offline",
+		deviceId: "device-b",
 		deviceName: "Grace's iPhone",
 		deviceType: "mobile",
 		lastSeenAt: new Date(Date.now() - 120_000),
@@ -40,7 +40,12 @@ mock.module("@superset/db/client", () => ({
 	},
 }));
 
+// mock.module is process-global in bun test. Preserve every real export
+// (notably executeOnDevice, which start-agent-session.test.ts imports after
+// this file mounts its mocks) so sibling test files don't break.
+const realUtils = await import("../../utils");
 mock.module("../../utils", () => ({
+	...realUtils,
 	getMcpContext: getMcpContextMock,
 }));
 
@@ -61,7 +66,6 @@ type RegisteredToolHandler = (
 			ownerId: string;
 			ownerName: string | null;
 			ownerEmail: string;
-			isOnline: boolean;
 		}>;
 	};
 }>;
@@ -102,7 +106,7 @@ describe("list_devices MCP tool", () => {
 	beforeEach(() => {
 		fetchedDevices = [
 			{
-				deviceId: "device-online",
+				deviceId: "device-a",
 				deviceName: "Ada's MacBook",
 				deviceType: "desktop",
 				lastSeenAt: new Date(Date.now() - 30_000),
@@ -111,7 +115,7 @@ describe("list_devices MCP tool", () => {
 				ownerEmail: "ada@example.com",
 			},
 			{
-				deviceId: "device-offline",
+				deviceId: "device-b",
 				deviceName: "Grace's iPhone",
 				deviceType: "mobile",
 				lastSeenAt: new Date(Date.now() - 120_000),
@@ -124,22 +128,16 @@ describe("list_devices MCP tool", () => {
 		selectMock.mockClear();
 	});
 
-	it("registers input and output schemas that validate includeOffline and isOnline", async () => {
+	it("registers an output schema that validates the device list", async () => {
 		const { config, handler } = createTool();
-		const inputSchema = z.object(config.inputSchema);
 		const outputSchema = z.object(config.outputSchema);
 
-		expect(inputSchema.parse({})).toEqual({ includeOffline: false });
-		expect(inputSchema.parse({ includeOffline: true })).toEqual({
-			includeOffline: true,
-		});
-
-		const result = await handler({ includeOffline: true }, {});
+		const result = await handler({}, {});
 
 		expect(() => outputSchema.parse(result.structuredContent)).not.toThrow();
 	});
 
-	it("returns only online devices by default", async () => {
+	it("returns every registered device regardless of lastSeenAt", async () => {
 		const { handler } = createTool();
 
 		const result = await handler({}, {});
@@ -148,35 +146,23 @@ describe("list_devices MCP tool", () => {
 		expect(selectMock).toHaveBeenCalledTimes(1);
 		expect(result.structuredContent?.devices).toEqual([
 			{
-				deviceId: "device-online",
+				deviceId: "device-a",
 				deviceName: "Ada's MacBook",
 				deviceType: "desktop",
 				lastSeenAt: expect.any(String),
 				ownerId: "user-1",
 				ownerName: "Ada",
 				ownerEmail: "ada@example.com",
-				isOnline: true,
+			},
+			{
+				deviceId: "device-b",
+				deviceName: "Grace's iPhone",
+				deviceType: "mobile",
+				lastSeenAt: expect.any(String),
+				ownerId: "user-2",
+				ownerName: "Grace",
+				ownerEmail: "grace@example.com",
 			},
 		]);
-	});
-
-	it("includes offline devices when requested and marks them offline", async () => {
-		const { handler } = createTool();
-
-		const result = await handler({ includeOffline: true }, {});
-
-		expect(result.structuredContent?.devices).toHaveLength(2);
-		expect(result.structuredContent?.devices).toEqual(
-			expect.arrayContaining([
-				expect.objectContaining({
-					deviceId: "device-online",
-					isOnline: true,
-				}),
-				expect.objectContaining({
-					deviceId: "device-offline",
-					isOnline: false,
-				}),
-			]),
-		);
 	});
 });

--- a/packages/mcp/src/tools/devices/list-devices/list-devices.ts
+++ b/packages/mcp/src/tools/devices/list-devices/list-devices.ts
@@ -5,20 +5,12 @@ import { desc, eq } from "drizzle-orm";
 import { z } from "zod";
 import { getMcpContext } from "../../utils";
 
-const DEVICE_ONLINE_WINDOW_MS = 60_000;
-
 export function register(server: McpServer) {
 	server.registerTool(
 		"list_devices",
 		{
-			description:
-				"List devices in the organization. By default, only devices seen within the last 60 seconds are returned.",
-			inputSchema: {
-				includeOffline: z
-					.boolean()
-					.default(false)
-					.describe("Include devices that have not checked in recently"),
-			},
+			description: "List registered devices in the organization.",
+			inputSchema: {},
 			outputSchema: {
 				devices: z.array(
 					z.object({
@@ -29,15 +21,12 @@ export function register(server: McpServer) {
 						ownerId: z.string(),
 						ownerName: z.string().nullable(),
 						ownerEmail: z.string(),
-						isOnline: z.boolean(),
 					}),
 				),
 			},
 		},
-		async (args, extra) => {
+		async (_args, extra) => {
 			const ctx = getMcpContext(extra);
-			const includeOffline = args.includeOffline === true;
-			const onlineCutoff = Date.now() - DEVICE_ONLINE_WINDOW_MS;
 
 			const devices = await db
 				.select({
@@ -54,17 +43,10 @@ export function register(server: McpServer) {
 				.where(eq(devicePresence.organizationId, ctx.organizationId))
 				.orderBy(desc(devicePresence.lastSeenAt));
 
-			const result = devices
-				.map((d) => {
-					const isOnline = d.lastSeenAt.getTime() >= onlineCutoff;
-
-					return {
-						...d,
-						lastSeenAt: d.lastSeenAt.toISOString(),
-						isOnline,
-					};
-				})
-				.filter((device) => includeOffline || device.isOnline);
+			const result = devices.map((d) => ({
+				...d,
+				lastSeenAt: d.lastSeenAt.toISOString(),
+			}));
 
 			return {
 				structuredContent: { devices: result },


### PR DESCRIPTION
## Summary
- Bug: device reported offline ~60 seconds after the desktop app started, regardless of whether the user was on a non-main worktree. Juston's Slack repro narrowed it to the Slack agent rendering `status: offline` for his device.
- Root cause: PR #2904 deliberately removed the 30s device heartbeat (desktop now calls `device.registerDevice` once at startup) because `executeOnDevice` already handles unreachable devices via its command-poll timeout. PR #2988 ("fix list_devices MCP schema") reintroduced an `isOnline` field computed from a 60s `lastSeenAt` window without restoring heartbeats, so every device always looked offline after ~60s of runtime.
- Fix: revert the `isOnline`/`includeOffline` reintroduction in `list_devices` (keep PR #2988's schema hardening — `datetime`, `deviceTypeValues` enum, nullable `deviceName`). Update the Slack integration's `fetchAgentContext` to stop rendering the removed status, and refresh `apps/api/MCP_TOOLS.md`, `apps/docs/content/docs/mcp.mdx`, and the stubbed `superset devices list` CLI flag to match.
- Drive-by: `packages/mcp/src/tools/devices/list-devices/list-devices.test.ts` had a `mock.module("../../utils", ...)` that replaced the module with a partial stub. Because `mock.module` is process-global in bun test, it bled into `start-agent-session.test.ts` and stripped the `executeOnDevice` export. The test file now spreads the real module before overriding `getMcpContext`.

## Test plan
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` (all 8 turbo tasks green; `@superset/mcp` 7/7 pass including the previously-broken `start-agent-session` suite)
- [ ] Manual: with a desktop device registered and the app idle >60s, ask the Slack bot to list devices — the response should no longer say "offline"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop marking devices as offline. `list_devices` now returns all registered devices without an online status, so Slack no longer shows “status: offline” after ~60s.

- **Bug Fixes**
  - Removed `isOnline` and `includeOffline` from `list_devices`; continue returning `lastSeenAt`.
  - Slack agent: call `list_devices` with `{}` and stop rendering status text.
  - Docs and CLI: updated descriptions; removed CLI `includeOffline` flag and the “status” column.
  - Tests: fixed `mock.module` bleed by preserving real exports when overriding `getMcpContext`.

<sup>Written for commit 8e376e813219e71f63d0ee02277fabb432541fc9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Device lists now display all registered devices in your organization instead of limiting to online devices only.
  * Removed online/offline status indicators from device displays across all interfaces.
  * Simplified device listing by removing filtering options.

* **Documentation**
  * Updated device tool documentation to reflect the new device listing scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->