### PR TITLE
fix(desktop): activate newly created v2 workspace tabs

### DIFF
--- a/packages/panes/src/core/store/store.ts
+++ b/packages/panes/src/core/store/store.ts
@@ -182,7 +182,7 @@ export function createWorkspaceStore<TData>(
 			const tab = buildTab({ ...args, panes: builtPanes });
 			set((s) => ({
 				tabs: [...s.tabs, tab],
-				activeTabId: s.activeTabId ?? tab.id,
+				activeTabId: tab.id,
 			}));
 		},
 


### PR DESCRIPTION
## Summary
- In v2 workspaces, creating a new tab (terminal / chat / browser via the Add Tab menu or `NEW_GROUP` / `NEW_CHAT` / `NEW_BROWSER` hotkeys) now selects it instead of silently appending it behind the current tab.

## Why / Context
`addTab` in `@superset/panes` only set `activeTabId` when no tab was active (`s.activeTabId ?? tab.id`), so any subsequent `addTab` would append a tab without switching to it. Users had to manually click the new tab after creating it, which was surprising and inconsistent with every other "create new" flow in the store.

## How It Works
Change `addTab` to unconditionally set `activeTabId` to the new tab's id. This matches the existing convention in `movePaneToNewTab` (`store.ts:820`), which already activates the tab it creates. `@superset/panes` is only consumed by v2-workspace, so the behavior change is scoped to v2.

## Manual QA Checklist
- [ ] In a v2 workspace with at least one existing tab, use the Add Tab menu → new Terminal tab is focused
- [ ] Same for Add Chat and Add Browser
- [ ] `NEW_GROUP` / `NEW_CHAT` / `NEW_BROWSER` hotkeys focus the new tab
- [ ] Creating the first tab in an empty workspace still works (unchanged path)
- [ ] `movePaneToNewTab` still focuses the destination tab (unchanged)

## Testing
- `bun test packages/panes/src/core/store/store.test.ts` — 37 pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Newly created v2 workspace tabs are now auto-selected instead of being added in the background. This makes Add Tab actions and hotkeys feel consistent and faster.

- **Bug Fixes**
  - Changed `addTab` in `@superset/panes` to always set `activeTabId` to the new tab’s id, matching `movePaneToNewTab` and affecting only v2 workspaces.

<sup>Written for commit 7c13a3eb5ddf092772a27ae8da2424bab32d2dd6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Newly created tabs now automatically become the active tab, providing more consistent and predictable workspace behavior. Previously, the active tab might not change when adding a new tab. This ensures you always see your newly created tabs immediately without requiring manual navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->