### PR TITLE
fix(v2): switch host-service cloud calls to jwtProcedure

### DIFF
--- a/packages/host-service/src/trpc/router/workspace/workspace.ts
+++ b/packages/host-service/src/trpc/router/workspace/workspace.ts
@@ -48,6 +48,7 @@ export const workspaceRouter = router({
 
 			if (!localProject) {
 				const cloudProject = await ctx.api.v2Project.get.query({
+					organizationId: ctx.organizationId,
 					id: input.projectId,
 				});
 
@@ -98,6 +99,7 @@ export const workspaceRouter = router({
 
 			const cloudRow = await ctx.api.v2Workspace.create
 				.mutate({
+					organizationId: ctx.organizationId,
 					projectId: input.projectId,
 					name: input.name,
 					branch: input.branch,

--- a/packages/trpc/src/router/v2-project/v2-project.ts
+++ b/packages/trpc/src/router/v2-project/v2-project.ts
@@ -4,7 +4,7 @@ import type { TRPCRouterRecord } from "@trpc/server";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
-import { protectedProcedure } from "../../trpc";
+import { jwtProcedure, protectedProcedure } from "../../trpc";
 import {
 	requireActiveOrgId,
 	requireActiveOrgMembership,
@@ -79,15 +79,22 @@ async function getProjectAccess(
 }
 
 export const v2ProjectRouter = {
-	get: protectedProcedure
-		.input(z.object({ id: z.string().uuid() }))
+	get: jwtProcedure
+		.input(
+			z.object({
+				organizationId: z.string().uuid(),
+				id: z.string().uuid(),
+			}),
+		)
 		.query(async ({ ctx, input }) => {
-			const organizationId = requireActiveOrgId(
-				ctx.session,
-				"No active organization",
-			);
+			if (!ctx.organizationIds.includes(input.organizationId)) {
+				throw new TRPCError({
+					code: "FORBIDDEN",
+					message: "Not a member of this organization",
+				});
+			}
 			const row = await requireOrgResourceAccess(
-				ctx.session.user.id,
+				ctx.userId,
 				() =>
 					dbWs.query.v2Projects.findFirst({
 						where: eq(v2Projects.id, input.id),
@@ -95,7 +102,7 @@ export const v2ProjectRouter = {
 					}),
 				{
 					message: "Project not found",
-					organizationId,
+					organizationId: input.organizationId,
 				},
 			);
 			const repoCloneUrl = row.githubRepository

--- a/packages/trpc/src/router/v2-project/v2-project.ts
+++ b/packages/trpc/src/router/v2-project/v2-project.ts
@@ -93,8 +93,7 @@ export const v2ProjectRouter = {
 					message: "Not a member of this organization",
 				});
 			}
-			const row = await requireOrgResourceAccess(
-				ctx.userId,
+			const row = await requireOrgScopedResource(
 				() =>
 					dbWs.query.v2Projects.findFirst({
 						where: eq(v2Projects.id, input.id),

--- a/packages/trpc/src/router/v2-workspace/v2-workspace.ts
+++ b/packages/trpc/src/router/v2-workspace/v2-workspace.ts
@@ -4,7 +4,7 @@ import type { TRPCRouterRecord } from "@trpc/server";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
-import { protectedProcedure } from "../../trpc";
+import { jwtProcedure, protectedProcedure } from "../../trpc";
 import {
 	requireActiveOrgId,
 	requireActiveOrgMembership,
@@ -94,9 +94,10 @@ async function getWorkspaceAccess(
 }
 
 export const v2WorkspaceRouter = {
-	create: protectedProcedure
+	create: jwtProcedure
 		.input(
 			z.object({
+				organizationId: z.string().uuid(),
 				projectId: z.string().uuid(),
 				name: z.string().min(1),
 				branch: z.string().min(1),
@@ -104,13 +105,18 @@ export const v2WorkspaceRouter = {
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
-			const organizationId = await requireActiveOrgMembership(
-				ctx.session,
-				"No active organization",
-			);
+			if (!ctx.organizationIds.includes(input.organizationId)) {
+				throw new TRPCError({
+					code: "FORBIDDEN",
+					message: "Not a member of this organization",
+				});
+			}
 
-			const project = await getScopedProject(organizationId, input.projectId);
-			const host = await getScopedHost(organizationId, input.hostId);
+			const project = await getScopedProject(
+				input.organizationId,
+				input.projectId,
+			);
+			const host = await getScopedHost(input.organizationId, input.hostId);
 
 			const [workspace] = await dbWs
 				.insert(v2Workspaces)
@@ -120,7 +126,7 @@ export const v2WorkspaceRouter = {
 					name: input.name,
 					branch: input.branch,
 					hostId: host.id,
-					createdByUserId: ctx.session.user.id,
+					createdByUserId: ctx.userId,
 				})
 				.returning();
 			return workspace;


### PR DESCRIPTION
## Summary

- Fixes `Not authenticated. Please sign in.` when creating a v2 workspace in the desktop app.
- Root cause: after the relay refactor (#3250), the host-service calls the cloud API with a JWT bearer via `JwtApiAuthProvider`, but `v2Workspace.create` and `v2Project.get` were still `protectedProcedure`. `protectedProcedure` resolves the session via `auth.api.getSession(headers)`, which doesn't recognize JWTs — so `ctx.session` was `null` and the procedure rejected.
- This mirrors the same fix already applied to `ensureV2Host` (ed98b2944, 58e4c6745, eb047e2d3). These two procedures were simply missed.

## What changed

- `packages/trpc/src/router/v2-workspace/v2-workspace.ts` — `create` → `jwtProcedure`, takes `organizationId` in input, validates via `ctx.organizationIds.includes(...)`, uses `ctx.userId`.
- `packages/trpc/src/router/v2-project/v2-project.ts` — `get` → same treatment.
- `packages/host-service/src/trpc/router/workspace/workspace.ts` — passes `ctx.organizationId` through on both cloud calls.

## Audit of all host-service → cloud calls

| Call | Procedure (before) | Status |
|---|---|---|
| `v2Project.get` | protected | fixed → jwt |
| `v2Workspace.create` | protected | fixed → jwt |
| `device.ensureV2Host` | jwt | ok |
| `organization.getActiveFromJwt` | jwt | ok |
| `v2Workspace.delete` | protected | **not touched** — host-service endpoint is orphaned (the renderer calls cloud directly with a session bearer). Switching to jwt would break the working renderer path. Follow-up. |
| `user.me` | protected | **not touched** — `cloud.whoami` is marked `TODO: Remove this test router`, and the CLI also calls `user.me` with an OAuth access token. Follow-up. |

## Test plan

- [ ] Sign into the desktop app
- [ ] Create a new v2 workspace on a project you've never cloned locally (exercises `v2Project.get`)
- [ ] Create a second v2 workspace on the same project (exercises only `v2Workspace.create`)
- [ ] Confirm both succeed without `Not authenticated. Please sign in.`
- [ ] Typecheck: `bun run typecheck` (already verified clean across trpc, host-service, api, web, desktop)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch v2 cloud procedures to JWT auth with explicit organization scoping to fix “Not authenticated. Please sign in.” when creating v2 workspaces from the desktop app. The host-service now forwards `organizationId`, and both procedures validate org membership via the JWT.

- **Bug Fixes**
  - Switched `v2Workspace.create` and `v2Project.get` from `protectedProcedure` to `jwtProcedure`; inputs now include `organizationId`, validated against `ctx.organizationIds`; `v2Workspace.create` uses `ctx.userId`.
  - Updated `v2Project.get` to use `requireOrgScopedResource` (trusts JWT claim) instead of re-checking DB membership.
  - Host-service forwards `ctx.organizationId` to `v2Project.get` and `v2Workspace.create`.

<sup>Written for commit d44c6d56f46df9656324988fa6511f1156763644. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened organization membership validation for workspace and project operations; requests now include explicit organization context when interacting with cloud services.

* **Refactor**
  * Updated authentication/authorization flow to require and enforce an explicit organization identifier for workspace creation and project retrieval, improving access control and error scoping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->