### PR TITLE
feat(desktop): Security setting to disable relay exposure of host service

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/settings/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/index.ts
@@ -617,14 +617,18 @@ export const createSettingsRouter = () => {
 				// Restart active host-service children so they pick up the new
 				// RELAY_URL from buildEnv(). No-op if the user isn't signed in.
 				const { token } = await loadToken();
-				if (token) {
-					await getHostServiceCoordinator().restartAll({
-						authToken: token,
-						cloudApiUrl: env.NEXT_PUBLIC_API_URL,
-					});
+				if (!token) {
+					return { restartedOrgCount: 0 };
 				}
 
-				return { success: true };
+				const coordinator = getHostServiceCoordinator();
+				const restartedOrgCount = coordinator.getActiveOrganizationIds().length;
+				await coordinator.restartAll({
+					authToken: token,
+					cloudApiUrl: env.NEXT_PUBLIC_API_URL,
+				});
+
+				return { restartedOrgCount };
 			}),
 
 		getShowPresetsBar: publicProcedure.query(() => {

--- a/apps/desktop/src/lib/trpc/routers/settings/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/index.ts
@@ -17,12 +17,15 @@ import {
 } from "@superset/shared/agent-command";
 import { TRPCError } from "@trpc/server";
 import { app } from "electron";
+import { env } from "main/env.main";
 import { exitImmediately } from "main/index";
 import { hasCustomRingtone } from "main/lib/custom-ringtones";
+import { getHostServiceCoordinator } from "main/lib/host-service-coordinator";
 import { localDb } from "main/lib/local-db";
 import {
 	DEFAULT_AUTO_APPLY_DEFAULT_PRESET,
 	DEFAULT_CONFIRM_ON_QUIT,
+	DEFAULT_EXPOSE_HOST_SERVICE_VIA_RELAY,
 	DEFAULT_FILE_OPEN_MODE,
 	DEFAULT_OPEN_LINKS_IN_APP,
 	DEFAULT_SHOW_PRESETS_BAR,
@@ -51,6 +54,7 @@ import {
 } from "shared/utils/agent-settings";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
+import { loadToken } from "../auth/utils/auth-functions";
 import { getGitAuthorName, getGitHubUsername } from "../workspaces/utils/git";
 import {
 	createCustomAgentInputSchema,
@@ -587,6 +591,38 @@ export const createSettingsRouter = () => {
 						set: { confirmOnQuit: input.enabled },
 					})
 					.run();
+
+				return { success: true };
+			}),
+
+		getExposeHostServiceViaRelay: publicProcedure.query(() => {
+			const row = getSettings();
+			return (
+				row.exposeHostServiceViaRelay ?? DEFAULT_EXPOSE_HOST_SERVICE_VIA_RELAY
+			);
+		}),
+
+		setExposeHostServiceViaRelay: publicProcedure
+			.input(z.object({ enabled: z.boolean() }))
+			.mutation(async ({ input }) => {
+				localDb
+					.insert(settings)
+					.values({ id: 1, exposeHostServiceViaRelay: input.enabled })
+					.onConflictDoUpdate({
+						target: settings.id,
+						set: { exposeHostServiceViaRelay: input.enabled },
+					})
+					.run();
+
+				// Restart active host-service children so they pick up the new
+				// RELAY_URL from buildEnv(). No-op if the user isn't signed in.
+				const { token } = await loadToken();
+				if (token) {
+					await getHostServiceCoordinator().restartAll({
+						authToken: token,
+						cloudApiUrl: env.NEXT_PUBLIC_API_URL,
+					});
+				}
 
 				return { success: true };
 			}),

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -3,6 +3,7 @@ import { randomBytes } from "node:crypto";
 import { EventEmitter } from "node:events";
 import { createServer } from "node:net";
 import path from "node:path";
+import { settings } from "@superset/local-db";
 import { getDeviceName, getHashedDeviceId } from "@superset/shared/device-info";
 import { app } from "electron";
 import { env } from "main/env.main";
@@ -17,6 +18,7 @@ import {
 	readManifest,
 	removeManifest,
 } from "./host-service-manifest";
+import { localDb } from "./local-db";
 import { HOOK_PROTOCOL_VERSION } from "./terminal/env";
 
 /** Minimum host-service version this app can work with. */
@@ -212,6 +214,14 @@ export class HostServiceCoordinator extends EventEmitter {
 			.map(([id]) => id);
 	}
 
+	async restartAll(config: SpawnConfig): Promise<void> {
+		await Promise.all(
+			this.getActiveOrganizationIds().map((orgId) =>
+				this.restart(orgId, config),
+			),
+		);
+	}
+
 	// ── Adoption ──────────────────────────────────────────────────────
 
 	private async tryAdopt(organizationId: string): Promise<Connection | null> {
@@ -361,8 +371,10 @@ export class HostServiceCoordinator extends EventEmitter {
 		config: SpawnConfig,
 	): Promise<Record<string, string>> {
 		const organizationDir = manifestDir(organizationId);
+		const row = localDb.select().from(settings).get();
+		const exposeViaRelay = row?.exposeHostServiceViaRelay ?? false;
 
-		return getProcessEnvWithShellPath({
+		const childEnv = await getProcessEnvWithShellPath({
 			...(process.env as Record<string, string>),
 			ELECTRON_RUN_AS_NODE: "1",
 			ORGANIZATION_ID: organizationId,
@@ -381,8 +393,18 @@ export class HostServiceCoordinator extends EventEmitter {
 			SUPERSET_AGENT_HOOK_VERSION: HOOK_PROTOCOL_VERSION,
 			AUTH_TOKEN: config.authToken,
 			CLOUD_API_URL: config.cloudApiUrl,
-			RELAY_URL: env.RELAY_URL,
 		});
+
+		// `getProcessEnvWithShellPath` merges in the user's interactive shell env,
+		// which in dev has `RELAY_URL` set. Enforce the toggle *after* that merge
+		// so the child definitely doesn't see a relay URL when disabled.
+		if (exposeViaRelay && env.RELAY_URL) {
+			childEnv.RELAY_URL = env.RELAY_URL;
+		} else {
+			delete childEnv.RELAY_URL;
+		}
+
+		return childEnv;
 	}
 
 	// ── Liveness ──────────────────────────────────────────────────────

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/GeneralSettings.tsx
@@ -7,6 +7,7 @@ import {
 	HiOutlineCpuChip,
 	HiOutlineCreditCard,
 	HiOutlineKey,
+	HiOutlineLockClosed,
 	HiOutlinePaintBrush,
 	HiOutlinePuzzlePiece,
 	HiOutlineShieldCheck,
@@ -35,6 +36,7 @@ type SettingsRoute =
 	| "/settings/integrations"
 	| "/settings/billing"
 	| "/settings/api-keys"
+	| "/settings/security"
 	| "/settings/permissions";
 
 interface SectionItem {
@@ -147,6 +149,12 @@ const SECTION_GROUPS: SectionGroup[] = [
 	{
 		label: "System",
 		items: [
+			{
+				id: "/settings/security",
+				section: "security",
+				label: "Security",
+				icon: <HiOutlineLockClosed className="h-4 w-4" />,
+			},
 			{
 				id: "/settings/permissions",
 				section: "permissions",

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/security/components/SecuritySettings/SecuritySettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/security/components/SecuritySettings/SecuritySettings.tsx
@@ -32,14 +32,13 @@ export function SecuritySettings({ visibleItems }: SecuritySettingsProps) {
 				utils.settings.getExposeHostServiceViaRelay.setData(undefined, enabled);
 				return { previous };
 			},
-			onError: (err, _vars, context) => {
+			onError: (_err, _vars, context) => {
 				if (context?.previous !== undefined) {
 					utils.settings.getExposeHostServiceViaRelay.setData(
 						undefined,
 						context.previous,
 					);
 				}
-				toast.error(err.message ?? "Failed to update setting");
 			},
 			onSettled: () => {
 				utils.settings.getExposeHostServiceViaRelay.invalidate();
@@ -48,11 +47,22 @@ export function SecuritySettings({ visibleItems }: SecuritySettingsProps) {
 
 	const [confirmOpen, setConfirmOpen] = useState(false);
 
+	const runToggle = (enabled: boolean) => {
+		toast.promise(setExpose.mutateAsync({ enabled }), {
+			loading: "Restarting host services…",
+			success: ({ restartedOrgCount }) =>
+				restartedOrgCount > 0
+					? `Restarted ${restartedOrgCount} host service${restartedOrgCount === 1 ? "" : "s"}`
+					: "Setting saved",
+			error: (err: Error) => err.message ?? "Failed to update setting",
+		});
+	};
+
 	const handleChange = (next: boolean) => {
 		if (next) {
 			setConfirmOpen(true);
 		} else {
-			setExpose.mutate({ enabled: false });
+			runToggle(false);
 		}
 	};
 
@@ -94,7 +104,7 @@ export function SecuritySettings({ visibleItems }: SecuritySettingsProps) {
 				onOpenChange={setConfirmOpen}
 				onConfirm={() => {
 					setConfirmOpen(false);
-					setExpose.mutate({ enabled: true });
+					runToggle(true);
 				}}
 			/>
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/security/components/SecuritySettings/SecuritySettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/security/components/SecuritySettings/SecuritySettings.tsx
@@ -1,0 +1,102 @@
+import { Label } from "@superset/ui/label";
+import { toast } from "@superset/ui/sonner";
+import { Switch } from "@superset/ui/switch";
+import { useState } from "react";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import {
+	isItemVisible,
+	SETTING_ITEM_ID,
+	type SettingItemId,
+} from "../../../utils/settings-search";
+import { ExposeViaRelayConfirmDialog } from "./components/ExposeViaRelayConfirmDialog";
+
+interface SecuritySettingsProps {
+	visibleItems?: SettingItemId[] | null;
+}
+
+export function SecuritySettings({ visibleItems }: SecuritySettingsProps) {
+	const showRelayToggle = isItemVisible(
+		SETTING_ITEM_ID.SECURITY_EXPOSE_HOST_SERVICE_VIA_RELAY,
+		visibleItems,
+	);
+
+	const utils = electronTrpc.useUtils();
+	const { data: exposeEnabled, isLoading } =
+		electronTrpc.settings.getExposeHostServiceViaRelay.useQuery();
+
+	const setExpose =
+		electronTrpc.settings.setExposeHostServiceViaRelay.useMutation({
+			onMutate: async ({ enabled }) => {
+				await utils.settings.getExposeHostServiceViaRelay.cancel();
+				const previous = utils.settings.getExposeHostServiceViaRelay.getData();
+				utils.settings.getExposeHostServiceViaRelay.setData(undefined, enabled);
+				return { previous };
+			},
+			onError: (err, _vars, context) => {
+				if (context?.previous !== undefined) {
+					utils.settings.getExposeHostServiceViaRelay.setData(
+						undefined,
+						context.previous,
+					);
+				}
+				toast.error(err.message ?? "Failed to update setting");
+			},
+			onSettled: () => {
+				utils.settings.getExposeHostServiceViaRelay.invalidate();
+			},
+		});
+
+	const [confirmOpen, setConfirmOpen] = useState(false);
+
+	const handleChange = (next: boolean) => {
+		if (next) {
+			setConfirmOpen(true);
+		} else {
+			setExpose.mutate({ enabled: false });
+		}
+	};
+
+	return (
+		<div className="p-6 max-w-4xl w-full">
+			<div className="mb-8">
+				<h2 className="text-xl font-semibold">Security</h2>
+				<p className="text-sm text-muted-foreground mt-1">
+					Control how your local machine is reachable from remote workspaces
+				</p>
+			</div>
+
+			{showRelayToggle && (
+				<div className="flex items-start justify-between gap-6">
+					<div className="space-y-1 flex-1">
+						<Label
+							htmlFor="expose-host-service-via-relay"
+							className="text-sm font-medium"
+						>
+							Allow remote workspaces to access this device via relay
+						</Label>
+						<p className="text-xs text-muted-foreground">
+							When off, your local tools and files cannot be reached from any
+							remote workspace through the Superset relay. This does not affect
+							your ability to connect out to remote sandboxes from this device.
+						</p>
+					</div>
+					<Switch
+						id="expose-host-service-via-relay"
+						checked={exposeEnabled ?? false}
+						onCheckedChange={handleChange}
+						disabled={isLoading || setExpose.isPending}
+					/>
+				</div>
+			)}
+
+			<ExposeViaRelayConfirmDialog
+				open={confirmOpen}
+				onOpenChange={setConfirmOpen}
+				onConfirm={() => {
+					setConfirmOpen(false);
+					setExpose.mutate({ enabled: true });
+				}}
+			/>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/security/components/SecuritySettings/components/ExposeViaRelayConfirmDialog/ExposeViaRelayConfirmDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/security/components/SecuritySettings/components/ExposeViaRelayConfirmDialog/ExposeViaRelayConfirmDialog.tsx
@@ -1,0 +1,97 @@
+import {
+	AlertDialog,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@superset/ui/alert-dialog";
+import { Button } from "@superset/ui/button";
+import { Input } from "@superset/ui/input";
+import { Label } from "@superset/ui/label";
+import { useEffect, useState } from "react";
+
+const CONFIRM_PHRASE = "I understand";
+
+interface ExposeViaRelayConfirmDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	onConfirm: () => void;
+}
+
+export function ExposeViaRelayConfirmDialog({
+	open,
+	onOpenChange,
+	onConfirm,
+}: ExposeViaRelayConfirmDialogProps) {
+	const [typed, setTyped] = useState("");
+
+	// Reset the typed confirmation whenever the dialog closes so reopening
+	// always starts from an empty input.
+	useEffect(() => {
+		if (!open) setTyped("");
+	}, [open]);
+
+	const canConfirm = typed === CONFIRM_PHRASE;
+
+	return (
+		<AlertDialog open={open} onOpenChange={onOpenChange}>
+			<AlertDialogContent className="max-w-[480px]">
+				<AlertDialogHeader>
+					<AlertDialogTitle>
+						Expose this device to Superset Relay?
+					</AlertDialogTitle>
+					<AlertDialogDescription asChild>
+						<div className="space-y-3 text-sm text-muted-foreground">
+							<p>
+								Turning this on allows any remote device which you grant access
+								to — and anything that can compromise the Superset Relay — to
+								reach into this device to run commands. They will be able to
+								read and write files in your configured project directories, run
+								shell commands as you, and access any tools the host service
+								exposes.
+							</p>
+							<p>
+								Only enable this if you are okay with the risk that this
+								entails. Most users should leave this off.
+							</p>
+						</div>
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+
+				<div className="space-y-2 pt-2">
+					<Label htmlFor="expose-relay-confirm" className="text-xs">
+						Type{" "}
+						<span className="font-mono font-medium text-foreground">
+							{CONFIRM_PHRASE}
+						</span>{" "}
+						to continue
+					</Label>
+					<Input
+						id="expose-relay-confirm"
+						autoFocus
+						value={typed}
+						onChange={(event) => setTyped(event.target.value)}
+						placeholder={CONFIRM_PHRASE}
+						autoComplete="off"
+						spellCheck={false}
+					/>
+				</div>
+
+				<AlertDialogFooter>
+					<Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
+						Cancel
+					</Button>
+					<Button
+						variant="destructive"
+						size="sm"
+						disabled={!canConfirm}
+						onClick={onConfirm}
+					>
+						Enable
+					</Button>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/security/components/SecuritySettings/components/ExposeViaRelayConfirmDialog/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/security/components/SecuritySettings/components/ExposeViaRelayConfirmDialog/index.ts
@@ -1,0 +1,1 @@
+export { ExposeViaRelayConfirmDialog } from "./ExposeViaRelayConfirmDialog";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/security/components/SecuritySettings/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/security/components/SecuritySettings/index.ts
@@ -1,0 +1,1 @@
+export { SecuritySettings } from "./SecuritySettings";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/security/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/security/page.tsx
@@ -1,0 +1,22 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useMemo } from "react";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
+import { getMatchingItemsForSection } from "../utils/settings-search";
+import { SecuritySettings } from "./components/SecuritySettings";
+
+export const Route = createFileRoute("/_authenticated/settings/security/")({
+	component: SecuritySettingsPage,
+});
+
+function SecuritySettingsPage() {
+	const searchQuery = useSettingsSearchQuery();
+
+	const visibleItems = useMemo(() => {
+		if (!searchQuery) return null;
+		return getMatchingItemsForSection(searchQuery, "security").map(
+			(item) => item.id,
+		);
+	}, [searchQuery]);
+
+	return <SecuritySettings visibleItems={visibleItems} />;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -67,6 +67,9 @@ export const SETTING_ITEM_ID = {
 	PERMISSIONS_MICROPHONE: "permissions-microphone",
 	PERMISSIONS_APPLE_EVENTS: "permissions-apple-events",
 	PERMISSIONS_LOCAL_NETWORK: "permissions-local-network",
+
+	SECURITY_EXPOSE_HOST_SERVICE_VIA_RELAY:
+		"security-expose-host-service-via-relay",
 } as const;
 
 export type SettingItemId =
@@ -982,6 +985,26 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"security",
 			"privacy",
 			"development servers",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.SECURITY_EXPOSE_HOST_SERVICE_VIA_RELAY,
+		section: "security",
+		title: "Allow remote workspaces to access this device via relay",
+		description:
+			"Controls whether remote workspaces can reach your local host service through the Superset relay",
+		keywords: [
+			"security",
+			"relay",
+			"remote",
+			"workspace",
+			"expose",
+			"lockdown",
+			"network",
+			"inbound",
+			"host service",
+			"tunnel",
+			"attack surface",
 		],
 	},
 ];

--- a/apps/desktop/src/renderer/stores/settings-state.ts
+++ b/apps/desktop/src/renderer/stores/settings-state.ts
@@ -16,6 +16,7 @@ export type SettingsSection =
 	| "billing"
 	| "apikeys"
 	| "permissions"
+	| "security"
 	| "project";
 
 interface SettingsState {

--- a/apps/desktop/src/shared/constants.ts
+++ b/apps/desktop/src/shared/constants.ts
@@ -50,6 +50,7 @@ export const DEFAULT_USE_COMPACT_TERMINAL_ADD_BUTTON = true;
 export const DEFAULT_TELEMETRY_ENABLED = true;
 export const DEFAULT_SHOW_RESOURCE_MONITOR = true;
 export const DEFAULT_OPEN_LINKS_IN_APP = false;
+export const DEFAULT_EXPOSE_HOST_SERVICE_VIA_RELAY = false;
 
 // External links (documentation, help resources, etc.)
 export const EXTERNAL_LINKS = {

--- a/packages/local-db/drizzle/0039_add_expose_host_service_via_relay_setting.sql
+++ b/packages/local-db/drizzle/0039_add_expose_host_service_via_relay_setting.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `settings` ADD `expose_host_service_via_relay` integer;

--- a/packages/local-db/drizzle/meta/0039_snapshot.json
+++ b/packages/local-db/drizzle/meta/0039_snapshot.json
@@ -1,0 +1,1404 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "5a8d1776-f90b-4bf8-b6a0-c6142deecfc2",
+  "prevId": "1cf43ce9-9e0f-44c4-b4cf-5cafe80bf78d",
+  "tables": {
+    "browser_history": {
+      "name": "browser_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_visited_at": {
+          "name": "last_visited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visit_count": {
+          "name": "visit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "browser_history_url_unique": {
+          "name": "browser_history_url_unique",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "browser_history_url_idx": {
+          "name": "browser_history_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": false
+        },
+        "browser_history_last_visited_at_idx": {
+          "name": "browser_history_last_visited_at_idx",
+          "columns": [
+            "last_visited_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_organization_id_idx": {
+          "name": "organization_members_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_user_id_idx": {
+          "name": "organization_members_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_users_id_fk": {
+          "name": "organization_members_user_id_users_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_org": {
+          "name": "github_org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_clerk_org_id_unique": {
+          "name": "organizations_clerk_org_id_unique",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_idx": {
+          "name": "organizations_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "organizations_clerk_org_id_idx": {
+          "name": "organizations_clerk_org_id_idx",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "main_repo_path": {
+          "name": "main_repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_toast_dismissed": {
+          "name": "config_toast_dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_base_branch": {
+          "name": "workspace_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_owner": {
+          "name": "github_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hide_image": {
+          "name": "hide_image",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_project_id": {
+          "name": "neon_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_app": {
+          "name": "default_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_main_repo_path_idx": {
+          "name": "projects_main_repo_path_idx",
+          "columns": [
+            "main_repo_path"
+          ],
+          "isUnique": false
+        },
+        "projects_last_opened_at_idx": {
+          "name": "projects_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_active_workspace_id": {
+          "name": "last_active_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets": {
+          "name": "terminal_presets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets_initialized": {
+          "name": "terminal_presets_initialized",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_preset_overrides": {
+          "name": "agent_preset_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_custom_definitions": {
+          "name": "agent_custom_definitions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_ringtone_id": {
+          "name": "selected_ringtone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirm_on_quit": {
+          "name": "confirm_on_quit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_link_behavior": {
+          "name": "terminal_link_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "persist_terminal": {
+          "name": "persist_terminal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_apply_default_preset": {
+          "name": "auto_apply_default_preset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_sounds_muted": {
+          "name": "notification_sounds_muted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_volume": {
+          "name": "notification_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delete_local_branch": {
+          "name": "delete_local_branch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_open_mode": {
+          "name": "file_open_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_presets_bar": {
+          "name": "show_presets_bar",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_compact_terminal_add_button": {
+          "name": "use_compact_terminal_add_button",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_family": {
+          "name": "terminal_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_size": {
+          "name": "terminal_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_family": {
+          "name": "editor_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_size": {
+          "name": "editor_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_resource_monitor": {
+          "name": "show_resource_monitor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "open_links_in_app": {
+          "name": "open_links_in_app",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_editor": {
+          "name": "default_editor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expose_host_service_via_relay": {
+          "name": "expose_host_service_via_relay",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_color": {
+          "name": "status_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_type": {
+          "name": "status_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_position": {
+          "name": "status_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "estimate": {
+          "name": "estimate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_provider": {
+          "name": "external_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tasks_slug_unique": {
+          "name": "tasks_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "tasks_slug_idx": {
+          "name": "tasks_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "tasks_organization_id_idx": {
+          "name": "tasks_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_assignee_id_idx": {
+          "name": "tasks_assignee_id_idx",
+          "columns": [
+            "assignee_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_status_idx": {
+          "name": "tasks_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "tasks_created_at_idx": {
+          "name": "tasks_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_organization_id_organizations_id_fk": {
+          "name": "tasks_organization_id_organizations_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_assignee_id_users_id_fk": {
+          "name": "tasks_assignee_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tasks_creator_id_users_id_fk": {
+          "name": "tasks_creator_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": true
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "users_clerk_id_idx": {
+          "name": "users_clerk_id_idx",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_sections": {
+      "name": "workspace_sections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_collapsed": {
+          "name": "is_collapsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspace_sections_project_id_idx": {
+          "name": "workspace_sections_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_sections_project_id_projects_id_fk": {
+          "name": "workspace_sections_project_id_projects_id_fk",
+          "tableFrom": "workspace_sections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_id": {
+          "name": "worktree_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_unread": {
+          "name": "is_unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_unnamed": {
+          "name": "is_unnamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "deleting_at": {
+          "name": "deleting_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "port_base": {
+          "name": "port_base",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_project_id_idx": {
+          "name": "workspaces_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_worktree_id_idx": {
+          "name": "workspaces_worktree_id_idx",
+          "columns": [
+            "worktree_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_last_opened_at_idx": {
+          "name": "workspaces_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        },
+        "workspaces_section_id_idx": {
+          "name": "workspaces_section_id_idx",
+          "columns": [
+            "section_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspaces_project_id_projects_id_fk": {
+          "name": "workspaces_project_id_projects_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_worktree_id_worktrees_id_fk": {
+          "name": "workspaces_worktree_id_worktrees_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "worktrees",
+          "columnsFrom": [
+            "worktree_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_section_id_workspace_sections_id_fk": {
+          "name": "workspaces_section_id_workspace_sections_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "workspace_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "worktrees": {
+      "name": "worktrees",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_status": {
+          "name": "git_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_status": {
+          "name": "github_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_superset": {
+          "name": "created_by_superset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "worktrees_project_id_idx": {
+          "name": "worktrees_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "worktrees_branch_idx": {
+          "name": "worktrees_branch_idx",
+          "columns": [
+            "branch"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "worktrees_project_id_projects_id_fk": {
+          "name": "worktrees_project_id_projects_id_fk",
+          "tableFrom": "worktrees",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/local-db/drizzle/meta/_journal.json
+++ b/packages/local-db/drizzle/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1774995017185,
       "tag": "0038_quick_star_brand",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "6",
+      "when": 1775765690176,
+      "tag": "0039_add_expose_host_service_via_relay_setting",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/local-db/src/schema/schema.ts
+++ b/packages/local-db/src/schema/schema.ts
@@ -222,6 +222,9 @@ export const settings = sqliteTable("settings", {
 	worktreeBaseDir: text("worktree_base_dir"),
 	openLinksInApp: integer("open_links_in_app", { mode: "boolean" }),
 	defaultEditor: text("default_editor").$type<ExternalApp>(),
+	exposeHostServiceViaRelay: integer("expose_host_service_via_relay", {
+		mode: "boolean",
+	}),
 });
 
 export type InsertSettings = typeof settings.$inferInsert;


### PR DESCRIPTION
## Summary

Adds a new **Settings → Security** page with a single toggle, `exposeHostServiceViaRelay`, that controls whether remote workspaces can reach into this device through the Superset relay. **Defaults to off.** When the user flips it on they must type `I understand` in a confirmation dialog spelling out the risk (any remote workspace in the org — or anything that compromises the relay — gets read/write access to configured project dirs and shell execution as the user).

Under the hood:

- New `expose_host_service_via_relay` column on the local-db `settings` table (migration `0039`).
- `host-service-coordinator.buildEnv()` reads the setting and only includes `RELAY_URL` in the spawned child env when enabled. When disabled, `connectRelay()` is never called by the child (`host-service/index.ts:70` guards on `env.RELAY_URL`), so no outbound tunnel is opened.
- Toggling either direction calls a new `coordinator.restartAll(config)` from the `setExposeHostServiceViaRelay` mutation, which restarts every active host-service child so they pick up the new env on next spawn. No-op if the user isn't signed in.

### One gotcha worth reading

\`getProcessEnvWithShellPath\` (used by \`buildEnv\`) merges in the user's interactive shell env to give child processes login-shell PATH etc. In dev, the user's shell typically has \`RELAY_URL=http://localhost:3114\` set, which caused the shell-env merge to *re-inject* \`RELAY_URL\` into the child env even after we stripped it. Fix: enforce the toggle **after** the shell merge by \`delete childEnv.RELAY_URL\` when disabled. In packaged builds, \`RELAY_URL\` is baked into the main bundle by vite's \`define\` plugin and the shell env typically doesn't have it set, but we don't want to rely on that.

### What this doesn't change

- Host-service continues binding \`127.0.0.1\` unconditionally (no user-facing toggle around that — same as before).
- \`packages/host-service/src/serve.ts\` (dev-only \`workspace-host\` entry) binds \`0.0.0.0\`. Not touched here; follow-up.
- Relay URL is still a build-time config via vite's define (sourced from the \`RELAY_URL\` CI secret).

## Test plan

All verified against this worktree's dev build with 3 active orgs (3 host-service children):

- [x] Fresh install, setting defaults to off. All three children listen on \`127.0.0.1:<port>\` only, zero outbound to \`:3114\`.
- [x] Flip **on**: typed-confirm dialog blocks the Enable button until \`I understand\` is typed exactly. Mutation restarts all 3 children (new PIDs); each new child gains an outbound \`[::1]:XXXXX -> [::1]:3114 (ESTABLISHED)\` tunnel. Verified via \`lsof -a -p <pid> -i -P -n\`.
- [x] Flip **off**: new PIDs, outbound \`:3114\` connections gone. (Initially failed here due to the shell-env leak; fixed by post-merge \`delete\`.)
- [x] Setting persists across mutations: \`sqlite3 ... "SELECT expose_host_service_via_relay FROM settings"\` matches UI state.
- [x] \`bun run lint:fix\` + \`bun run typecheck\` — clean across all 25 packages.
- [ ] Verify behavior persists across full app restart (setting saved in local.db, default-off semantics hold on first launch after upgrade).
- [ ] Verify in a packaged (non-dev) build that shell env doesn't have \`RELAY_URL\` at all, so the post-merge delete is belt-and-suspenders rather than load-bearing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Security setting to control whether the host service exposes this device via the Superset relay. Defaults to off; enabling requires typing “I understand,” restarts host-service processes immediately, and shows a toast with restart progress and count.

- **New Features**
  - New Settings → Security page with toggle `exposeHostServiceViaRelay` (default off).
  - When off, child processes spawn without `RELAY_URL` so no relay tunnel is opened.
  - Enabling shows a typed-confirm dialog; exact phrase required.
  - Toggling restarts all active host-service children and shows toast feedback (“Restarting host services…”, then success with restarted count).
  - Enforced after shell-env merge by deleting `RELAY_URL` when disabled to prevent dev-shell leakage.
  - Added sidebar entry and settings search item for Security.

- **Migration**
  - Adds `expose_host_service_via_relay` to the `settings` table (`0039`); existing installs default to off.

<sup>Written for commit ad731864bead8534797eaea3298f51a813defb67. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Security settings section with a "Relay access" toggle and sidebar link.
  * Enabling relay requires a confirmation dialog; toggling shows progress and success messages including how many orgs were restarted.

* **Chores**
  * Persist relay exposure setting to local storage/db and added a default value.
  * Host service now respects the relay setting when starting/restarting services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->