### PR TITLE
fix(ci): drop darwin-x64, bump actions to v5

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -14,15 +14,13 @@ jobs:
         include:
           - os: macos-14
             target: darwin-arm64
-          - os: macos-13
-            target: darwin-x64
           - os: ubuntu-latest
             target: linux-x64
 
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -30,7 +28,7 @@ jobs:
           bun-version-file: .bun-version
 
       - name: Setup Node.js (for native addon compilation)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
 
@@ -45,7 +43,7 @@ jobs:
         run: bun run build:dist --target=${{ matrix.target }}
 
       - name: Upload tarball
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: superset-${{ matrix.target }}
           path: packages/cli/dist/superset-${{ matrix.target }}.tar.gz
@@ -59,10 +57,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: release-artifacts
           pattern: superset-*

--- a/.github/workflows/bump-homebrew.yml
+++ b/.github/workflows/bump-homebrew.yml
@@ -39,7 +39,7 @@ jobs:
           TAG: ${{ steps.version.outputs.tag }}
         run: |
           set -euo pipefail
-          for target in darwin-arm64 darwin-x64 linux-x64; do
+          for target in darwin-arm64 linux-x64; do
             url="https://github.com/superset-sh/superset/releases/download/${TAG}/superset-${target}.tar.gz"
             echo "Fetching SHA for $url"
             tmp=$(mktemp)
@@ -54,7 +54,7 @@ jobs:
           done
 
       - name: Checkout homebrew-tap
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: superset-sh/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
@@ -64,7 +64,6 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
           DARWIN_ARM64_SHA: ${{ steps.shas.outputs.darwin_arm64_sha }}
-          DARWIN_X64_SHA: ${{ steps.shas.outputs.darwin_x64_sha }}
           LINUX_X64_SHA: ${{ steps.shas.outputs.linux_x64_sha }}
         run: |
           set -euo pipefail
@@ -80,10 +79,6 @@ jobs:
               on_arm do
                 url "https://github.com/superset-sh/superset/releases/download/cli-v#{{version}}/superset-darwin-arm64.tar.gz"
                 sha256 "{darwin_arm64}"
-              end
-              on_intel do
-                url "https://github.com/superset-sh/superset/releases/download/cli-v#{{version}}/superset-darwin-x64.tar.gz"
-                sha256 "{darwin_x64}"
               end
             end
 
@@ -108,7 +103,6 @@ jobs:
           print(template.format(
               version=os.environ["VERSION"],
               darwin_arm64=os.environ["DARWIN_ARM64_SHA"],
-              darwin_x64=os.environ["DARWIN_X64_SHA"],
               linux_x64=os.environ["LINUX_X64_SHA"],
           ), end="")
           PYEOF

--- a/apps/marketing/public/cli/install.sh
+++ b/apps/marketing/public/cli/install.sh
@@ -31,7 +31,7 @@ detect_target() {
         Darwin)
             case "$arch" in
                 arm64) echo "darwin-arm64" ;;
-                x86_64) echo "darwin-x64" ;;
+                x86_64) error "Intel Macs are not supported. Apple Silicon (arm64) only." ;;
                 *) error "Unsupported macOS architecture: $arch" ;;
             esac
             ;;

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,9 +10,8 @@
 		"dev": "dotenv -e ../../.env -- sh -c 'SUPERSET_API_URL=$NEXT_PUBLIC_API_URL bun src/bin.ts $@' --",
 		"build": "bun build --compile src/bin.ts --outfile dist/superset",
 		"build:darwin-arm64": "bun build --compile --target=bun-darwin-arm64 src/bin.ts --outfile dist/superset-darwin-arm64",
-		"build:darwin-x64": "bun build --compile --target=bun-darwin-x64 src/bin.ts --outfile dist/superset-darwin-x64",
 		"build:linux-x64": "bun build --compile --target=bun-linux-x64 src/bin.ts --outfile dist/superset-linux-x64",
-		"build:all": "bun run build:darwin-arm64 && bun run build:darwin-x64 && bun run build:linux-x64",
+		"build:all": "bun run build:darwin-arm64 && bun run build:linux-x64",
 		"build:dist": "bun run scripts/build-dist.ts",
 		"typecheck": "tsc --noEmit"
 	},

--- a/packages/cli/scripts/build-dist.ts
+++ b/packages/cli/scripts/build-dist.ts
@@ -31,9 +31,9 @@ import {
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
-type Target = "darwin-arm64" | "darwin-x64" | "linux-x64";
+type Target = "darwin-arm64" | "linux-x64";
 
-const VALID_TARGETS: Target[] = ["darwin-arm64", "darwin-x64", "linux-x64"];
+const VALID_TARGETS: Target[] = ["darwin-arm64", "linux-x64"];
 const NODE_VERSION = "22.13.0";
 
 /**
@@ -64,7 +64,7 @@ function parseArgs(): { target: Target } {
 
 function nodeArchiveName(target: Target): string {
 	const arch = target === "darwin-arm64" ? "arm64" : "x64";
-	const platform = target.startsWith("darwin") ? "darwin" : "linux";
+	const platform = target === "darwin-arm64" ? "darwin" : "linux";
 	return `node-v${NODE_VERSION}-${platform}-${arch}`;
 }
 


### PR DESCRIPTION
## Summary

- GitHub retired macos-13 public runners, so our Intel Mac build from cli-v0.1.0 failed with `The configuration 'macos-13-us-default' is not supported`. Dropping darwin-x64 from the release matrix.
- Also removes darwin-x64 from install.sh (now errors clearly on Intel Macs), build-dist.ts, package.json scripts, and the Homebrew formula template.
- Bumps actions/checkout, setup-node, upload-artifact, download-artifact from v4 → v5 to silence the Node 20 deprecation warnings on the linux-x64 and darwin-arm64 builds.

Intel Macs are EOL (Apple stopped selling them in 2023). If demand appears we can cross-compile from macos-14 later via prebuild-install for native addons.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, re-tag `cli-v0.1.0` and verify build-cli.yml produces draft release with 2 tarballs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `darwin-x64` from CLI releases and CI due to GitHub retiring macOS-13 runners. Upgrade GitHub Actions to v5 to silence Node 20 deprecation warnings.

- **Refactors**
  - Drop `darwin-x64` from release matrix and `install.sh`; update `build-dist.ts`, `package.json` scripts, and Homebrew bump workflow.
  - Installer now exits with a clear error on Intel macOS.

- **Dependencies**
  - Bump `actions/checkout`, `actions/setup-node`, `actions/upload-artifact`, and `actions/download-artifact` to v5.

<sup>Written for commit 5d706eb3d0e6b2a2bdeed56675d655762eef5ef8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed support for Intel-based macOS (x86_64) builds. The CLI now supports only Apple Silicon (arm64) and Linux platforms.
  * Updated build infrastructure and GitHub Actions to latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->