### PR TITLE
fix(ci): grant contents: write to CLI release job

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -54,6 +54,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/cli-v')
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Matrix builds succeeded for cli-v0.1.0 but the release-creation step failed with `HTTP 403: Resource not accessible by integration`. Default GITHUB_TOKEN permissions don't allow release creation; adding an explicit `permissions: contents: write` block to the release job scoped to just that job.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CLI release workflow by granting `contents: write` to the job-specific `GITHUB_TOKEN`. This unblocks Release creation for `cli-v*` tags (previously failing with 403).

<sup>Written for commit 95f3e6c6f7bf87b97164ebd6f1e12b6a7cb8cabb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to enhance release process permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->