### PR TITLE
fix(desktop): decouple auto-updater from repo-wide /releases/latest/

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -72,9 +72,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # --latest=false: never let CLI releases occupy the repo-wide
-          # "Latest" slot. (Also enforced at publish time by bump-homebrew.yml
-          # since --make_latest defaults to true when a draft is published.)
           gh release create "${{ github.ref_name }}" \
             release-artifacts/*.tar.gz \
             --title "Superset CLI ${{ github.ref_name }}" \

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -54,6 +54,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/cli-v')
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -72,8 +72,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # CLI releases must never occupy the repo-wide "Latest" slot.
+          # That slot is reserved for desktop-v* — /releases/latest/download/
+          # URLs would 404 against CLI tarballs, and old desktop clients
+          # still in the wild depend on those URLs for auto-updates.
+          # This is a permanent guardrail, not a temporary mitigation:
+          # keep it forever so new code that naively references
+          # /releases/latest/ can't silently break desktop.
           gh release create "${{ github.ref_name }}" \
             release-artifacts/*.tar.gz \
             --title "Superset CLI ${{ github.ref_name }}" \
             --generate-notes \
-            --draft
+            --draft \
+            --latest=false

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -72,13 +72,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # CLI releases must never occupy the repo-wide "Latest" slot.
-          # That slot is reserved for desktop-v* — /releases/latest/download/
-          # URLs would 404 against CLI tarballs, and old desktop clients
-          # still in the wild depend on those URLs for auto-updates.
-          # This is a permanent guardrail, not a temporary mitigation:
-          # keep it forever so new code that naively references
-          # /releases/latest/ can't silently break desktop.
+          # --latest=false: never let CLI releases occupy the repo-wide
+          # "Latest" slot. (Also enforced at publish time by bump-homebrew.yml
+          # since --make_latest defaults to true when a draft is published.)
           gh release create "${{ github.ref_name }}" \
             release-artifacts/*.tar.gz \
             --title "Superset CLI ${{ github.ref_name }}" \

--- a/.github/workflows/bump-homebrew.yml
+++ b/.github/workflows/bump-homebrew.yml
@@ -14,12 +14,6 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Re-assert --latest=false at publish time. `gh release create --draft
-  # --latest=false` in build-cli.yml sets the flag on the draft, but when
-  # the draft transitions to published GitHub re-evaluates make_latest and
-  # defaults it back to true. Without this step, publishing a CLI draft
-  # (via UI or gh release edit --draft=false) would re-hijack the
-  # repo-wide "Latest" slot and break desktop auto-updates.
   enforce-not-latest:
     if: startsWith(github.event.release.tag_name, 'cli-v')
     runs-on: ubuntu-latest

--- a/.github/workflows/bump-homebrew.yml
+++ b/.github/workflows/bump-homebrew.yml
@@ -14,6 +14,28 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Re-assert --latest=false at publish time. `gh release create --draft
+  # --latest=false` in build-cli.yml sets the flag on the draft, but when
+  # the draft transitions to published GitHub re-evaluates make_latest and
+  # defaults it back to true. Without this step, publishing a CLI draft
+  # (via UI or gh release edit --draft=false) would re-hijack the
+  # repo-wide "Latest" slot and break desktop auto-updates.
+  enforce-not-latest:
+    if: startsWith(github.event.release.tag_name, 'cli-v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: gh release edit --latest=false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          gh release edit "$TAG" \
+            --repo ${{ github.repository }} \
+            --latest=false
+
   bump:
     if: startsWith(github.event.release.tag_name, 'cli-v')
     runs-on: ubuntu-latest

--- a/.github/workflows/promote-desktop.yml
+++ b/.github/workflows/promote-desktop.yml
@@ -1,14 +1,9 @@
 name: Promote Desktop Release
 
-# Maintains a rolling `desktop` tag/release that always points at the latest
-# published stable desktop-v* release. Consumers (auto-updater, marketing
-# download buttons) hit /releases/download/desktop/ instead of
-# /releases/latest/, so they never depend on the repo-wide "Latest" slot
-# and can't be hijacked by releases from other products (CLI, etc).
-#
-# Mirrors the pattern used by release-desktop-canary.yml for the canary
-# channel: delete the existing release/tag, recreate with fresh assets
-# downloaded from the source release.
+# Recreates a rolling `desktop` tag+release pointing at the latest published
+# desktop-v* release, so the auto-updater and download buttons can target
+# /releases/download/desktop/ instead of the hijackable /releases/latest/.
+# Mirrors the pattern in release-desktop-canary.yml.
 
 on:
   release:
@@ -20,15 +15,12 @@ on:
         required: false
         type: string
 
-# Serialize so two concurrent desktop publishes can't race and drop a promotion.
 concurrency:
   group: desktop-promotion
   cancel-in-progress: false
 
 jobs:
   promote:
-    # Release trigger: only desktop-v* non-prerelease publishes.
-    # workflow_dispatch always runs (for manual seeding or re-promotion).
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (startsWith(github.event.release.tag_name, 'desktop-v') &&
@@ -52,9 +44,7 @@ jobs:
           elif [ -n "$INPUT_TAG" ]; then
             tag="$INPUT_TAG"
           else
-            # Pick the newest published desktop-v* release (non-draft,
-            # non-prerelease). Sorted newest-first by the API.
-            tag="$(gh api repos/${{ github.repository }}/releases \
+            tag="$(gh api --paginate repos/${{ github.repository }}/releases \
               --jq '[.[] | select(.draft==false and .prerelease==false and (.tag_name | startswith("desktop-v")))] | .[0].tag_name')"
           fi
           if ! printf '%s' "$tag" | grep -Eq '^desktop-v[0-9]+\.[0-9]+\.[0-9]+([-.][A-Za-z0-9.]+)?$'; then
@@ -74,15 +64,12 @@ jobs:
           gh release download "$SRC_TAG" \
             --repo ${{ github.repository }} \
             --dir assets
-          echo "Downloaded assets:"
-          ls -la assets/
 
       - name: Delete existing desktop release and tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          # --cleanup-tag removes the tag alongside the release.
           gh release delete desktop \
             --repo ${{ github.repository }} \
             --yes \
@@ -98,18 +85,9 @@ jobs:
           cat > release-notes.md <<NOTES
           Rolling pointer to the latest stable desktop release. Currently
           tracks [\`${SRC_TAG}\`](https://github.com/${REPO}/releases/tag/${SRC_TAG}).
-
-          This release exists so the desktop auto-updater and marketing
-          download buttons can target a stable URL
-          (\`/releases/download/desktop/\`) without depending on the
-          repo-wide "Latest" slot. Do not manually modify — it is
-          recreated on every \`desktop-v*\` publish by
-          \`.github/workflows/promote-desktop.yml\`.
+          Recreated on every \`desktop-v*\` publish by \`.github/workflows/promote-desktop.yml\`.
           NOTES
 
-          # --latest=false: the rolling tag is a consumer endpoint, not
-          # the repo's public "Latest" slot. That slot stays on the
-          # versioned desktop-v* release for GitHub UI discoverability.
           gh release create desktop assets/* \
             --repo "${REPO}" \
             --title "Superset Desktop (rolling)" \

--- a/.github/workflows/promote-desktop.yml
+++ b/.github/workflows/promote-desktop.yml
@@ -1,9 +1,7 @@
 name: Promote Desktop Release
 
 # Recreates a rolling `desktop` tag+release pointing at the latest published
-# desktop-v* release, so the auto-updater and download buttons can target
-# /releases/download/desktop/ instead of the hijackable /releases/latest/.
-# Mirrors the pattern in release-desktop-canary.yml.
+# desktop-v* release, so consumers can target /releases/download/desktop/.
 
 on:
   release:
@@ -82,14 +80,8 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          cat > release-notes.md <<NOTES
-          Rolling pointer to the latest stable desktop release. Currently
-          tracks [\`${SRC_TAG}\`](https://github.com/${REPO}/releases/tag/${SRC_TAG}).
-          Recreated on every \`desktop-v*\` publish by \`.github/workflows/promote-desktop.yml\`.
-          NOTES
-
           gh release create desktop assets/* \
             --repo "${REPO}" \
             --title "Superset Desktop (rolling)" \
-            --notes-file release-notes.md \
+            --notes "Rolling pointer to [\`${SRC_TAG}\`](https://github.com/${REPO}/releases/tag/${SRC_TAG}). Recreated by \`.github/workflows/promote-desktop.yml\`." \
             --latest=false

--- a/.github/workflows/promote-desktop.yml
+++ b/.github/workflows/promote-desktop.yml
@@ -1,0 +1,117 @@
+name: Promote Desktop Release
+
+# Maintains a rolling `desktop` tag/release that always points at the latest
+# published stable desktop-v* release. Consumers (auto-updater, marketing
+# download buttons) hit /releases/download/desktop/ instead of
+# /releases/latest/, so they never depend on the repo-wide "Latest" slot
+# and can't be hijacked by releases from other products (CLI, etc).
+#
+# Mirrors the pattern used by release-desktop-canary.yml for the canary
+# channel: delete the existing release/tag, recreate with fresh assets
+# downloaded from the source release.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      source_tag:
+        description: "Source desktop-v* tag to promote (defaults to current latest)"
+        required: false
+        type: string
+
+# Serialize so two concurrent desktop publishes can't race and drop a promotion.
+concurrency:
+  group: desktop-promotion
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    # Release trigger: only desktop-v* non-prerelease publishes.
+    # workflow_dispatch always runs (for manual seeding or re-promotion).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (startsWith(github.event.release.tag_name, 'desktop-v') &&
+       !github.event.release.prerelease)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Resolve source tag
+        id: src
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ github.event.inputs.source_tag }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "release" ]; then
+            tag="$RELEASE_TAG"
+          elif [ -n "$INPUT_TAG" ]; then
+            tag="$INPUT_TAG"
+          else
+            # Pick the newest published desktop-v* release (non-draft,
+            # non-prerelease). Sorted newest-first by the API.
+            tag="$(gh api repos/${{ github.repository }}/releases \
+              --jq '[.[] | select(.draft==false and .prerelease==false and (.tag_name | startswith("desktop-v")))] | .[0].tag_name')"
+          fi
+          if ! printf '%s' "$tag" | grep -Eq '^desktop-v[0-9]+\.[0-9]+\.[0-9]+([-.][A-Za-z0-9.]+)?$'; then
+            echo "::error::Invalid or missing source tag: '$tag'"
+            exit 1
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "Promoting source tag: $tag"
+
+      - name: Download assets from source release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SRC_TAG: ${{ steps.src.outputs.tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p assets
+          gh release download "$SRC_TAG" \
+            --repo ${{ github.repository }} \
+            --dir assets
+          echo "Downloaded assets:"
+          ls -la assets/
+
+      - name: Delete existing desktop release and tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # --cleanup-tag removes the tag alongside the release.
+          gh release delete desktop \
+            --repo ${{ github.repository }} \
+            --yes \
+            --cleanup-tag || true
+
+      - name: Recreate rolling desktop release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SRC_TAG: ${{ steps.src.outputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          cat > release-notes.md <<NOTES
+          Rolling pointer to the latest stable desktop release. Currently
+          tracks [\`${SRC_TAG}\`](https://github.com/${REPO}/releases/tag/${SRC_TAG}).
+
+          This release exists so the desktop auto-updater and marketing
+          download buttons can target a stable URL
+          (\`/releases/download/desktop/\`) without depending on the
+          repo-wide "Latest" slot. Do not manually modify — it is
+          recreated on every \`desktop-v*\` publish by
+          \`.github/workflows/promote-desktop.yml\`.
+          NOTES
+
+          # --latest=false: the rolling tag is a consumer endpoint, not
+          # the repo's public "Latest" slot. That slot stays on the
+          # versioned desktop-v* release for GitHub UI discoverability.
+          gh release create desktop assets/* \
+            --repo "${REPO}" \
+            --title "Superset Desktop (rolling)" \
+            --notes-file release-notes.md \
+            --latest=false

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -66,7 +66,10 @@ jobs:
       - name: Create stable-named copies for latest download URLs
         run: |
           cd release-artifacts
-          # Create stable-named copies (without version) for /releases/latest/download/ URLs
+          # Create stable-named copies (without version) so the rolling
+          # `desktop` release (recreated by promote-desktop.yml after this
+          # release is published) carries fixed asset names that the
+          # auto-updater and marketing download buttons can target.
           for file in *.dmg; do
             if [[ -f "$file" ]]; then
               # Extract architecture from filename (e.g., Superset-0.0.1-arm64.dmg -> arm64)

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -66,8 +66,7 @@ jobs:
       - name: Create stable-named copies for latest download URLs
         run: |
           cd release-artifacts
-          # Stable-named copies so promote-desktop.yml (fires on publish)
-          # can copy them verbatim onto the rolling `desktop` tag.
+          # Create stable-named copies (without version) for the rolling desktop tag
           for file in *.dmg; do
             if [[ -f "$file" ]]; then
               # Extract architecture from filename (e.g., Superset-0.0.1-arm64.dmg -> arm64)

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -66,10 +66,8 @@ jobs:
       - name: Create stable-named copies for latest download URLs
         run: |
           cd release-artifacts
-          # Create stable-named copies (without version) so the rolling
-          # `desktop` release (recreated by promote-desktop.yml after this
-          # release is published) carries fixed asset names that the
-          # auto-updater and marketing download buttons can target.
+          # Stable-named copies so promote-desktop.yml (fires on publish)
+          # can copy them verbatim onto the rolling `desktop` tag.
           for file in *.dmg; do
             if [[ -f "$file" ]]; then
               # Extract architecture from filename (e.g., Superset-0.0.1-arm64.dmg -> arm64)

--- a/apps/desktop/RELEASE.md
+++ b/apps/desktop/RELEASE.md
@@ -53,14 +53,21 @@ This creates a draft release. Publish it manually at GitHub Releases.
 
 ## Auto-update
 
-The app checks for updates at launch and every x hours using:
+The app checks for updates at launch and every x hours using the rolling
+`desktop` tag (maintained by `.github/workflows/promote-desktop.yml`,
+which republishes assets from every new `desktop-v*` release):
 
-- **macOS manifest**: `https://github.com/superset-sh/superset/releases/latest/download/latest-mac.yml`
-- **Linux manifest**: `https://github.com/superset-sh/superset/releases/latest/download/latest-linux.yml`
-- **macOS installer**: `https://github.com/superset-sh/superset/releases/latest/download/Superset-arm64.dmg`
-- **Linux installer**: `https://github.com/superset-sh/superset/releases/latest/download/Superset-x64.AppImage`
+- **macOS manifest**: `https://github.com/superset-sh/superset/releases/download/desktop/latest-mac.yml`
+- **Linux manifest**: `https://github.com/superset-sh/superset/releases/download/desktop/latest-linux.yml`
+- **macOS installer**: `https://github.com/superset-sh/superset/releases/download/desktop/Superset-arm64.dmg`
+- **Linux installer**: `https://github.com/superset-sh/superset/releases/download/desktop/Superset-x64.AppImage`
 
-The workflow creates stable-named copies (without version) so these URLs always point to the latest build.
+Canary follows the same pattern with the `desktop-canary` tag.
+
+**Do not** point consumers at `/releases/latest/download/`. That URL resolves
+to the repo-wide "Latest" release and can be hijacked by releases from
+other products in the monorepo (e.g. `cli-v*`). The `desktop` tag is
+owned exclusively by the promote workflow and is the only safe endpoint.
 
 ## Code Signing
 

--- a/apps/desktop/RELEASE.md
+++ b/apps/desktop/RELEASE.md
@@ -53,7 +53,7 @@ This creates a draft release. Publish it manually at GitHub Releases.
 
 ## Auto-update
 
-The app checks for updates at launch and every x hours using the rolling
+The app checks for updates at launch and every 4 hours using the rolling
 `desktop` tag (maintained by `.github/workflows/promote-desktop.yml`,
 which republishes assets from every new `desktop-v*` release):
 

--- a/apps/desktop/RELEASE.md
+++ b/apps/desktop/RELEASE.md
@@ -53,14 +53,14 @@ This creates a draft release. Publish it manually at GitHub Releases.
 
 ## Auto-update
 
-The app checks for updates at launch and every 4 hours using the rolling
-`desktop` tag (maintained by `.github/workflows/promote-desktop.yml`,
-which republishes assets from every new `desktop-v*` release):
+The app checks for updates at launch and every x hours using:
 
 - **macOS manifest**: `https://github.com/superset-sh/superset/releases/download/desktop/latest-mac.yml`
 - **Linux manifest**: `https://github.com/superset-sh/superset/releases/download/desktop/latest-linux.yml`
 - **macOS installer**: `https://github.com/superset-sh/superset/releases/download/desktop/Superset-arm64.dmg`
 - **Linux installer**: `https://github.com/superset-sh/superset/releases/download/desktop/Superset-x64.AppImage`
+
+The workflow creates stable-named copies (without version) so these URLs always point to the latest build.
 
 ## Code Signing
 

--- a/apps/desktop/RELEASE.md
+++ b/apps/desktop/RELEASE.md
@@ -62,13 +62,6 @@ which republishes assets from every new `desktop-v*` release):
 - **macOS installer**: `https://github.com/superset-sh/superset/releases/download/desktop/Superset-arm64.dmg`
 - **Linux installer**: `https://github.com/superset-sh/superset/releases/download/desktop/Superset-x64.AppImage`
 
-Canary follows the same pattern with the `desktop-canary` tag.
-
-**Do not** point consumers at `/releases/latest/download/`. That URL resolves
-to the repo-wide "Latest" release and can be hijacked by releases from
-other products in the monorepo (e.g. `cli-v*`). The `desktop` tag is
-owned exclusively by the promote workflow and is the only safe endpoint.
-
 ## Code Signing
 
 macOS code signing uses these repository secrets:

--- a/apps/desktop/src/main/lib/auto-updater.ts
+++ b/apps/desktop/src/main/lib/auto-updater.ts
@@ -23,13 +23,16 @@ function isPrereleaseBuild(): boolean {
 const IS_PRERELEASE = isPrereleaseBuild();
 const IS_AUTO_UPDATE_PLATFORM = PLATFORM.IS_MAC || PLATFORM.IS_LINUX;
 
-// Use explicit feed URLs to ensure we always fetch platform-specific manifests
-// (for example latest-mac.yml and latest-linux.yml) from the correct release.
-// - Stable: fetches from /releases/latest/download/ (latest non-prerelease)
-// - Canary: fetches from /releases/download/desktop-canary/ (rolling canary tag)
+// Use explicit rolling tags per channel so updates never depend on the
+// repo-wide "Latest" release slot (which can be hijacked by unrelated
+// releases like the CLI). Both tags are maintained automatically:
+// - Stable: rolling `desktop` tag, recreated on every desktop-v* publish
+//   by .github/workflows/promote-desktop.yml
+// - Canary: rolling `desktop-canary` tag, recreated on every canary build
+//   by .github/workflows/release-desktop-canary.yml
 const UPDATE_FEED_URL = IS_PRERELEASE
 	? "https://github.com/superset-sh/superset/releases/download/desktop-canary"
-	: "https://github.com/superset-sh/superset/releases/latest/download";
+	: "https://github.com/superset-sh/superset/releases/download/desktop";
 
 export interface AutoUpdateStatusEvent {
 	status: AutoUpdateStatus;

--- a/apps/desktop/src/main/lib/auto-updater.ts
+++ b/apps/desktop/src/main/lib/auto-updater.ts
@@ -23,13 +23,8 @@ function isPrereleaseBuild(): boolean {
 const IS_PRERELEASE = isPrereleaseBuild();
 const IS_AUTO_UPDATE_PLATFORM = PLATFORM.IS_MAC || PLATFORM.IS_LINUX;
 
-// Use explicit rolling tags per channel so updates never depend on the
-// repo-wide "Latest" release slot (which can be hijacked by unrelated
-// releases like the CLI). Both tags are maintained automatically:
-// - Stable: rolling `desktop` tag, recreated on every desktop-v* publish
-//   by .github/workflows/promote-desktop.yml
-// - Canary: rolling `desktop-canary` tag, recreated on every canary build
-//   by .github/workflows/release-desktop-canary.yml
+// Rolling tags per channel, not /releases/latest/ (which can be hijacked
+// by releases from other products in the monorepo).
 const UPDATE_FEED_URL = IS_PRERELEASE
 	? "https://github.com/superset-sh/superset/releases/download/desktop-canary"
 	: "https://github.com/superset-sh/superset/releases/download/desktop";

--- a/apps/desktop/src/main/lib/auto-updater.ts
+++ b/apps/desktop/src/main/lib/auto-updater.ts
@@ -23,8 +23,10 @@ function isPrereleaseBuild(): boolean {
 const IS_PRERELEASE = isPrereleaseBuild();
 const IS_AUTO_UPDATE_PLATFORM = PLATFORM.IS_MAC || PLATFORM.IS_LINUX;
 
-// Rolling tags per channel, not /releases/latest/ (which can be hijacked
-// by releases from other products in the monorepo).
+// Use explicit feed URLs to ensure we always fetch platform-specific manifests
+// (for example latest-mac.yml and latest-linux.yml) from the correct release.
+// - Stable: fetches from /releases/download/desktop/ (rolling desktop tag)
+// - Canary: fetches from /releases/download/desktop-canary/ (rolling canary tag)
 const UPDATE_FEED_URL = IS_PRERELEASE
 	? "https://github.com/superset-sh/superset/releases/download/desktop-canary"
 	: "https://github.com/superset-sh/superset/releases/download/desktop";

--- a/apps/marketing/public/cli/install.sh
+++ b/apps/marketing/public/cli/install.sh
@@ -48,7 +48,6 @@ detect_target() {
 }
 
 resolve_latest_cli_tag() {
-    # /releases/latest is reserved for desktop, so resolve via the API.
     api_url="https://api.github.com/repos/${REPO}/releases?per_page=100"
     resolved="$(curl -fsSL "$api_url" \
         | grep -oE '"tag_name": *"cli-v[^"]+"' \

--- a/apps/marketing/public/cli/install.sh
+++ b/apps/marketing/public/cli/install.sh
@@ -48,10 +48,8 @@ detect_target() {
 }
 
 resolve_latest_cli_tag() {
-    # /releases/latest is repo-wide and may point at a desktop release, so
-    # we can't use it. Instead, ask the releases API (newest first) and pick
-    # the first cli-v* tag. POSIX grep + sed only — no jq dependency.
-    api_url="https://api.github.com/repos/${REPO}/releases"
+    # /releases/latest is reserved for desktop, so resolve via the API.
+    api_url="https://api.github.com/repos/${REPO}/releases?per_page=100"
     resolved="$(curl -fsSL "$api_url" \
         | grep -oE '"tag_name": *"cli-v[^"]+"' \
         | head -n 1 \

--- a/apps/marketing/public/cli/install.sh
+++ b/apps/marketing/public/cli/install.sh
@@ -47,15 +47,25 @@ detect_target() {
     esac
 }
 
+resolve_latest_cli_tag() {
+    # /releases/latest is repo-wide and may point at a desktop release, so
+    # we can't use it. Instead, ask the releases API (newest first) and pick
+    # the first cli-v* tag. POSIX grep + sed only — no jq dependency.
+    api_url="https://api.github.com/repos/${REPO}/releases"
+    resolved="$(curl -fsSL "$api_url" \
+        | grep -oE '"tag_name": *"cli-v[^"]+"' \
+        | head -n 1 \
+        | sed -E 's/.*"(cli-v[^"]+)".*/\1/')"
+    if [ -z "$resolved" ]; then
+        error "Could not resolve latest cli-v* release from $api_url"
+    fi
+    echo "$resolved"
+}
+
 download_tarball() {
     target="$1"
     tarball="superset-${target}.tar.gz"
-
-    if [ "$TAG" = "latest" ]; then
-        url="https://github.com/${REPO}/releases/latest/download/${tarball}"
-    else
-        url="https://github.com/${REPO}/releases/download/${TAG}/${tarball}"
-    fi
+    url="https://github.com/${REPO}/releases/download/${TAG}/${tarball}"
 
     info "Downloading $url"
     tmp="$(mktemp -t superset-install.XXXXXX)"
@@ -130,6 +140,11 @@ main() {
 
     target="$(detect_target)"
     info "Platform: $target"
+
+    if [ "$TAG" = "latest" ]; then
+        TAG="$(resolve_latest_cli_tag)"
+        info "Resolved latest CLI release: $TAG"
+    fi
 
     tarball="$(download_tarball "$target")"
     extract_tarball "$tarball"

--- a/packages/cli/DISTRIBUTION.md
+++ b/packages/cli/DISTRIBUTION.md
@@ -149,9 +149,7 @@ Detects platform/arch, downloads tarball from GitHub Releases, extracts to `~/.s
 ### Manual
 
 ```bash
-# Download (replace cli-v0.1.0 with the desired version — see
-# https://github.com/superset-sh/superset/releases?q=cli for available tags;
-# /releases/latest/ is reserved for desktop and won't work here)
+# Download
 curl -LO https://github.com/superset-sh/superset/releases/download/cli-v0.1.0/superset-darwin-arm64.tar.gz
 
 # Extract

--- a/packages/cli/DISTRIBUTION.md
+++ b/packages/cli/DISTRIBUTION.md
@@ -149,8 +149,10 @@ Detects platform/arch, downloads tarball from GitHub Releases, extracts to `~/.s
 ### Manual
 
 ```bash
-# Download
-curl -LO https://github.com/user/superset/releases/latest/download/superset-darwin-arm64.tar.gz
+# Download (replace cli-v0.1.0 with the desired version — see
+# https://github.com/superset-sh/superset/releases?q=cli for available tags;
+# /releases/latest/ is reserved for desktop and won't work here)
+curl -LO https://github.com/superset-sh/superset/releases/download/cli-v0.1.0/superset-darwin-arm64.tar.gz
 
 # Extract
 mkdir -p ~/.superset/bin

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -32,9 +32,7 @@ export const COMPANY = {
 // Theme
 export const THEME_STORAGE_KEY = "superset-theme";
 
-// Download URLs. Points at the rolling `desktop` tag (maintained by
-// .github/workflows/promote-desktop.yml) rather than /releases/latest/ so
-// it can't be hijacked by releases from other products in this repo.
+// Download URLs
 export const DOWNLOAD_URL_MAC_ARM64 = `${COMPANY.GITHUB_URL}/releases/download/desktop/Superset-arm64.dmg`;
 
 // Auth token configuration

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -32,8 +32,10 @@ export const COMPANY = {
 // Theme
 export const THEME_STORAGE_KEY = "superset-theme";
 
-// Download URLs
-export const DOWNLOAD_URL_MAC_ARM64 = `${COMPANY.GITHUB_URL}/releases/latest/download/Superset-arm64.dmg`;
+// Download URLs. Points at the rolling `desktop` tag (maintained by
+// .github/workflows/promote-desktop.yml) rather than /releases/latest/ so
+// it can't be hijacked by releases from other products in this repo.
+export const DOWNLOAD_URL_MAC_ARM64 = `${COMPANY.GITHUB_URL}/releases/download/desktop/Superset-arm64.dmg`;
 
 // Auth token configuration
 export const TOKEN_CONFIG = {


### PR DESCRIPTION
## Summary

The desktop auto-updater broke today when `cli-v0.1.0` got promoted to the GitHub repo-wide "Latest" slot. The auto-updater was hard-coded to fetch `https://github.com/superset-sh/superset/releases/latest/download/latest-mac.yml`, which now 302s to `cli-v0.1.0/latest-mac.yml` (404 — CLI release only ships `.tar.gz`). Every stable desktop client's update check was failing silently.

This PR makes the bug unrepeatable by removing the dependency on `/releases/latest/` entirely.

### What changes

- **New `.github/workflows/promote-desktop.yml`** — fires on `release: types: [published]` for `desktop-v*` non-prerelease publishes (and `workflow_dispatch` for manual seeding). Downloads assets from the freshly-published versioned release and recreates a rolling `desktop` release+tag with `--latest=false`. Mirrors the pattern `release-desktop-canary.yml` already uses for canary.
- **`apps/desktop/src/main/lib/auto-updater.ts`** — stable feed URL switches from `/releases/latest/download` to `/releases/download/desktop`. Canary line is unchanged (already on `desktop-canary`).
- **`packages/shared/src/constants.ts`** — `DOWNLOAD_URL_MAC_ARM64` switches to `/releases/download/desktop/Superset-arm64.dmg`. Picked up automatically by every download button across `marketing`, `docs`, and `web`.
- **`apps/marketing/public/cli/install.sh`** — can no longer use `/releases/latest/` either (desktop owns that slot now). Switched to resolving the newest `cli-v*` tag via the GitHub releases API. POSIX `grep`/`sed`, no `jq` dep.
- **`.github/workflows/build-cli.yml`** — adds `--latest=false` to `gh release create` as a permanent guardrail. Old desktop clients still hit `/releases/latest/` until they roll over to this build, and we don't want to regress them. Also keeps the GitHub UI "Latest" badge on desktop releases, which is the right consumer-facing default.
- **Docs**: `apps/desktop/RELEASE.md`, `packages/cli/DISTRIBUTION.md`, and the stale comment in `release-desktop.yml` updated to reflect the new endpoints.

### Hotfix already applied

Before this PR — to unblock currently-broken stable users — I ran by hand:

```bash
gh release edit cli-v0.1.0 --latest=false
gh release edit desktop-v1.4.7 --latest=true
```

That restored `https://github.com/superset-sh/superset/releases/latest/download/latest-mac.yml` → `desktop-v1.4.7/latest-mac.yml` → 200. Stable clients recover on their next 4-hour update check. This PR makes the fix permanent and removes the fragile coupling.

### One pre-merge step

The new auto-updater feed URL (`/releases/download/desktop/latest-mac.yml`) is dead until something publishes the `desktop` tag. **Before users on the new build start arriving**, run:

```
gh workflow run promote-desktop.yml -f source_tag=desktop-v1.4.7
```

That seeds the `desktop` rolling release from the current latest stable. From then on it auto-updates on every `desktop-v*` publish.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean (25/25 passing)
- [x] All three modified workflow YAMLs parse via `js-yaml`
- [x] `sh -n install.sh` — clean
- [x] Hotfix verified live: `curl -sIL .../releases/latest/download/latest-mac.yml` resolves to `desktop-v1.4.7/latest-mac.yml` → 200, same for `latest-linux.yml` and `Superset-arm64.dmg`
- [x] `install.sh` API resolution returns `cli-v0.1.0` against the live API
- [ ] **Manual seed** of `desktop` tag via `workflow_dispatch` after merge, before next desktop release ships
- [ ] Smoke test the next `desktop-v*` publish: confirm `promote-desktop.yml` fires, the `desktop` release is recreated with current assets, and `curl -sIL .../releases/download/desktop/latest-mac.yml` returns 200
- [ ] Smoke test `curl -fsSL https://superset.sh/cli/install.sh | sh` after this lands and the marketing site redeploys — should resolve `cli-v0.1.0` and install successfully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decouples desktop auto-updates and downloads from repo-wide `/releases/latest/` by switching to a rolling `desktop` tag, and hard-pins CLI releases out of “Latest” at create and publish time. Prevents CLI releases from breaking desktop auto-updates while keeping versioned desktop releases as the public “Latest”.

- **Bug Fixes**
  - Add `.github/workflows/promote-desktop.yml` to recreate a rolling `desktop` release (`--latest=false`) on every `desktop-v*` publish or manual seed; uses `gh api --paginate` and serves manifests/installers from `/releases/download/desktop/`.
  - Point the desktop auto-updater and shared download URLs at `.../download/desktop`; canary remains on `desktop-canary`. Docs updated.
  - CLI: the installer resolves the newest `cli-v*` via the GitHub API with `?per_page=100`; `.github/workflows/build-cli.yml` creates releases with `contents: write` and `--latest=false`; `.github/workflows/bump-homebrew.yml` enforces `--latest=false` again on publish.

- **Migration**
  - Seed the rolling tag once after merge: `gh workflow run promote-desktop.yml -f source_tag=desktop-v1.4.7`

<sup>Written for commit c07b6fd756efddb865471b9da73c79bd45931cff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automation to recreate and maintain a rolling "desktop" release channel on publish or manual trigger.
  * Added enforcement to prevent CLI releases from being marked as the repository "Latest."

* **Improvements**
  * Desktop auto-updates now fetch stable assets from the dedicated rolling "desktop" release tag.
  * CLI installer now resolves and installs the latest CLI tag instead of relying on a repo-wide “latest” slot.
  * Release creation now avoids marking draft releases as “Latest.”

* **Documentation**
  * Installation and release docs updated to reflect new endpoints and version-resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->