### PR TITLE
fix: v2 tui hotkey forwarding

### DIFF
--- a/apps/desktop/plans/20260409-tui-hotkey-forwarding.md
+++ b/apps/desktop/plans/20260409-tui-hotkey-forwarding.md
@@ -1,0 +1,195 @@
+# TUI hotkey forwarding (v2 terminals)
+
+## Problem
+
+Since enabling `vtExtensions: { kittyKeyboard: true }` on v2 terminals
+(`Terminal/config.ts:36`, commit 89d79037e), app-level hotkeys like `Cmd+T`,
+`Cmd+K`, `Cmd+F`, `Ctrl+1`, `Ctrl+Tab` stop working while focus is inside a
+terminal running a TUI. The TUI program "swallows" them — they end up in the
+PTY instead of firing the Superset action.
+
+## Root cause
+
+**v2 `TerminalPane.tsx` does not install a `customKeyEventHandler` on the
+xterm instance.** Grep for `attachCustomKeyEventHandler` across v2 returns
+only the v1 path (`Terminal/helpers.ts:684`, called from
+`useTerminalLifecycle.ts:713`). The v2 runtime wires xterm through
+`terminal-runtime.ts` with no keyboard gate.
+
+Here is xterm.js's `_keyDown`
+(`node_modules/@xterm/xterm/src/browser/CoreBrowserTerminal.ts:843-929`),
+reduced to the parts that matter:
+
+```ts
+protected _keyDown(event: KeyboardEvent): boolean | undefined {
+  if (this._customKeyEventHandler && this._customKeyEventHandler(event) === false) {
+    return false; // ← bails before evaluateKeyDown, no preventDefault
+  }
+  // ...
+  const result = this._keyboardService.evaluateKeyDown(event);
+  // With vtExtensions.kittyKeyboard + PTY having enabled kitty protocol via CSI,
+  // KeyboardService.evaluateKeyDown() returns a CSI u encoded sequence for
+  // nearly every modifier chord (see KeyboardService.ts:42-43).
+  // ...
+  this.coreService.triggerDataEvent(result.key, !wasModifierOnly); // → PTY
+  // ...
+  if (!this.optionsService.rawOptions.screenReaderMode || event.altKey || event.ctrlKey) {
+    event.preventDefault();    // ← kills bubbling to document
+    event.stopPropagation();
+    return false;
+  }
+}
+```
+
+Without a custom handler, every modifier chord follows the bottom path:
+xterm encodes it via the Kitty protocol, delivers the CSI u sequence to the
+PTY, then calls `preventDefault + stopPropagation`. The event never reaches
+`document`, so `react-hotkeys-hook` (which powers `useHotkey`) never fires.
+
+This matches the behavior VSCode describes verbatim in
+`terminalInstance.ts:1136-1139`:
+
+> The metaKey check is needed because when a shell like fish enables the kitty
+> keyboard protocol, xterm.js encodes Meta-modified keys as CSI u sequences
+> and consumes them via preventDefault. The (non-kitty) traditional xterm.js
+> handler already skips Meta keys so they bubble up naturally, but the kitty
+> handler does not.
+
+Before the Kitty flag landed, xterm.js's traditional path also eats chords,
+but macOS `Cmd+*` happened to fall into the "bubble up naturally" branch
+(`_isThirdLevelShift` / composing checks), masking the missing gate on v2.
+Turning on Kitty made the break visible everywhere.
+
+## How VSCode handles it
+
+Verified against
+`vscode/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts:1116-1175`.
+The key event handler is an **allow-list gate**:
+
+```ts
+xterm.raw.attachCustomKeyEventHandler((event) => {
+  if (this._isExiting) return false;
+
+  const resolveResult = this._keybindingService.softDispatch(event, target);
+
+  if (this._keybindingService.inChordMode || isValidChord) {
+    event.preventDefault();
+    return false;
+  }
+
+  // Eat the chord iff it resolves to a registered command AND that command
+  // is on the skip list (or Meta/Cmd — always belongs to app).
+  if (!sendKeybindingsToShell
+      && resolveResult.kind === KbFound
+      && resolveResult.commandId
+      && (event.metaKey || this._skipTerminalCommands.includes(resolveResult.commandId))) {
+    event.preventDefault();
+    return false;
+  }
+
+  // ...mnemonics, tab focus, shift+tab, alt+f4...
+  return true; // default: forward to PTY (kitty encoder etc.)
+});
+```
+
+Supporting pieces:
+
+- **`softDispatch`** (`abstractKeybindingService.ts:143-160`) is read-only.
+  It asks the keybinding registry "does this chord resolve to a command
+  right now?" and returns `{ kind: KbFound, commandId }` without firing.
+- **Returning `false`** from the handler is what makes xterm.js bail at
+  line 847 — no kitty encoding, no `preventDefault`, event bubbles to
+  document, the normal keybinding dispatch runs the command.
+- **`DEFAULT_COMMANDS_TO_SKIP_SHELL`** (`common/terminal.ts:499-646`) is a
+  hardcoded allow-list of ~150 command IDs: Command Palette, zoom, editor
+  focus, tab navigation, terminal focus-next, debug start/stop, etc. User
+  `commandsToSkipShell` merges on top; `-command` entries remove defaults
+  (`terminalInstance.ts:1929-1934`).
+- Config defaults: `sendKeybindingsToShell = false`, `allowChords = true`,
+  `allowMnemonics = false`.
+- `terminalAltBufferActive` is a context key refreshed on
+  `xterm.raw.buffer.onBufferChange` (`terminalInstance.ts:854, 1264-1266`).
+  It is **not** consulted in the custom key handler — only exposed for
+  individual bindings to opt out via `when` clauses.
+
+## Recommendation
+
+Mirror VSCode. In concrete Superset terms:
+
+### 1. Install a `customKeyEventHandler` on the v2 terminal
+
+In `apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts` (or wherever
+the v2 xterm instance is created), call `xterm.attachCustomKeyEventHandler`
+with a handler whose default is `return true` and that returns `false` only
+for chords Superset owns. Without this, the v1 gate can never apply to v2.
+
+### 2. Build a `chord → HotkeyId` reverse index from `HOTKEYS_REGISTRY`
+
+`apps/desktop/src/renderer/hotkeys/registry.ts` already owns the canonical
+definitions. At registry init, flatten `HOTKEYS[id].key` into a
+`Map<normalizedChord, HotkeyId>` once. Expose `resolveHotkeyFromEvent(event)`
+that normalizes an event into the same chord format and returns the matching
+`HotkeyId | null` — this is Superset's `softDispatch`.
+
+### 3. Gate in the handler
+
+```ts
+const handler = (event: KeyboardEvent): boolean => {
+  if (event.type !== "keydown") return true;
+
+  // existing macOS ANSI translations (Cmd+Left → \x01, etc.) run first
+
+  // Terminal-reserved chords must reach the PTY regardless
+  if (isTerminalReservedEvent(event)) return true;
+
+  // Always skip on Meta — matches VSCode's line 1140, and covers the kitty
+  // case where Cmd+letter would otherwise get CSI-u encoded.
+  if (event.metaKey) {
+    const id = resolveHotkeyFromEvent(event);
+    return id ? false : false; // bubble either way; Cmd almost never belongs to a TUI
+  }
+
+  // Non-Meta: only eat if it resolves to an app hotkey
+  const id = resolveHotkeyFromEvent(event);
+  if (id) return false;
+
+  return true; // default → PTY (kitty encoder runs, TUI gets the key)
+};
+xterm.attachCustomKeyEventHandler(handler);
+```
+
+Nothing else changes — existing `useHotkey(...)` registrations keep working
+because the event bubbles to document the moment the handler returns `false`.
+No direct `softDispatch`-style command execution needed.
+
+### 4. Keep the v1 handler (`Terminal/helpers.ts:530`)
+
+The v1 handler has the same bug structurally (`line 677-679` bubbles on the
+denylist), but v1 was working before Kitty because xterm's traditional path
+let Meta keys bubble. Now that Kitty is on for v1 too (`config.ts:36`), v1
+should migrate to the same resolver-based gate. Share the implementation.
+
+### 5. Optional escape hatches (later)
+
+- `sendKeybindingsToShell`-style preference: disables every non-Meta skip
+  entry, for users who want everything to reach the shell.
+- Use `isAlternateScreenRef` from `useTerminalModes.ts:33` (or subscribe to
+  `xterm.buffer.onBufferChange` — VSCode's approach at
+  `terminalInstance.ts:854`) to shrink the skip list while a TUI owns the
+  alt screen, so e.g. `FIND_IN_TERMINAL` (`Cmd+F`) can still reach `nvim`.
+
+## Minimum viable fix
+
+1. In `terminal-runtime.ts`, wire `xterm.attachCustomKeyEventHandler((event) => {
+   if (event.type !== "keydown") return true;
+   if (isTerminalReservedEvent(event)) return true;
+   if (event.metaKey) return false;
+   if (resolveHotkeyFromEvent(event)) return false;
+   return true;
+   });` after the xterm instance is created.
+2. Add `resolveHotkeyFromEvent` to `renderer/hotkeys` — ~30 lines to build the
+   reverse index at module load and match events against it.
+
+That restores all `Cmd+*` hotkeys in v2 terminals under Kitty, and any
+`Ctrl+*`/`Alt+*` chords that resolve to a registered Superset hotkey. Steps
+4-5 generalize from v2 to v1 and add escape hatches.

--- a/apps/desktop/plans/20260409-tui-hotkey-forwarding.md
+++ b/apps/desktop/plans/20260409-tui-hotkey-forwarding.md
@@ -1,195 +1,60 @@
-# TUI hotkey forwarding (v2 terminals)
+# TUI hotkey forwarding
 
 ## Problem
 
-Since enabling `vtExtensions: { kittyKeyboard: true }` on v2 terminals
-(`Terminal/config.ts:36`, commit 89d79037e), app-level hotkeys like `Cmd+T`,
-`Cmd+K`, `Cmd+F`, `Ctrl+1`, `Ctrl+Tab` stop working while focus is inside a
-terminal running a TUI. The TUI program "swallows" them — they end up in the
-PTY instead of firing the Superset action.
+App-level hotkeys (Cmd+T, Cmd+D, Ctrl+1, etc.) don't fire while focus is in a
+v2 terminal running a TUI. The TUI swallows them — they reach the PTY but
+never bubble to `react-hotkeys-hook`.
 
 ## Root cause
 
-**v2 `TerminalPane.tsx` does not install a `customKeyEventHandler` on the
-xterm instance.** Grep for `attachCustomKeyEventHandler` across v2 returns
-only the v1 path (`Terminal/helpers.ts:684`, called from
-`useTerminalLifecycle.ts:713`). The v2 runtime wires xterm through
-`terminal-runtime.ts` with no keyboard gate.
+v2's `terminal-runtime.ts` never installed a `customKeyEventHandler` on xterm.
+Without one, xterm's `_keyDown` runs to completion for every modifier chord:
+it encodes the key, delivers it to the PTY, then calls `event.preventDefault();
+event.stopPropagation();` (CoreBrowserTerminal.ts:925-928). The event dies at
+target phase and `react-hotkeys-hook`'s document-bubble listener never sees it.
 
-Here is xterm.js's `_keyDown`
-(`node_modules/@xterm/xterm/src/browser/CoreBrowserTerminal.ts:843-929`),
-reduced to the parts that matter:
+Confirmed via instrumentation: Cmd+D in a Codex TUI produced capture-phase
+logs but zero bubble-phase logs — `stopPropagation` was the culprit.
 
-```ts
-protected _keyDown(event: KeyboardEvent): boolean | undefined {
-  if (this._customKeyEventHandler && this._customKeyEventHandler(event) === false) {
-    return false; // ← bails before evaluateKeyDown, no preventDefault
-  }
-  // ...
-  const result = this._keyboardService.evaluateKeyDown(event);
-  // With vtExtensions.kittyKeyboard + PTY having enabled kitty protocol via CSI,
-  // KeyboardService.evaluateKeyDown() returns a CSI u encoded sequence for
-  // nearly every modifier chord (see KeyboardService.ts:42-43).
-  // ...
-  this.coreService.triggerDataEvent(result.key, !wasModifierOnly); // → PTY
-  // ...
-  if (!this.optionsService.rawOptions.screenReaderMode || event.altKey || event.ctrlKey) {
-    event.preventDefault();    // ← kills bubbling to document
-    event.stopPropagation();
-    return false;
-  }
-}
-```
+## Fix (done)
 
-Without a custom handler, every modifier chord follows the bottom path:
-xterm encodes it via the Kitty protocol, delivers the CSI u sequence to the
-PTY, then calls `preventDefault + stopPropagation`. The event never reaches
-`document`, so `react-hotkeys-hook` (which powers `useHotkey`) never fires.
+Mirrors VSCode's pattern (terminalInstance.ts:1116-1175): install a
+`customKeyEventHandler` that returns `false` for chords bound to app hotkeys.
+Returning `false` makes xterm bail at the top of `_keyDown` (line 847-849),
+skipping the `stopPropagation` at the bottom. The event bubbles normally and
+`react-hotkeys-hook` fires the app action.
 
-This matches the behavior VSCode describes verbatim in
-`terminalInstance.ts:1136-1139`:
+Implementation:
 
-> The metaKey check is needed because when a shell like fish enables the kitty
-> keyboard protocol, xterm.js encodes Meta-modified keys as CSI u sequences
-> and consumes them via preventDefault. The (non-kitty) traditional xterm.js
-> handler already skips Meta keys so they bubble up naturally, but the kitty
-> handler does not.
+- **`renderer/hotkeys/utils/resolveHotkeyFromEvent.ts`** — reverse-indexes
+  `HOTKEYS_REGISTRY` into a `Map<normalizedChord, HotkeyId>` at module load.
+  Uses the same `event.code` normalization as react-hotkeys-hook's internal
+  `K` function so the index can't drift from the matcher. Returns `HotkeyId |
+  null`.
+- **`renderer/lib/terminal/terminal-runtime.ts`** — one-liner handler:
+  ```ts
+  terminal.attachCustomKeyEventHandler((event) => !isAppHotkey(event));
+  ```
+  Registered chords bubble to the app. Unregistered chords (Ctrl+R, Ctrl+L,
+  Alt+letter, etc.) still reach the TUI.
 
-Before the Kitty flag landed, xterm.js's traditional path also eats chords,
-but macOS `Cmd+*` happened to fall into the "bubble up naturally" branch
-(`_isThirdLevelShift` / composing checks), masking the missing gate on v2.
-Turning on Kitty made the break visible everywhere.
+## Remaining work
 
-## How VSCode handles it
+### Migrate v1 to the same resolver
 
-Verified against
-`vscode/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts:1116-1175`.
-The key event handler is an **allow-list gate**:
+v1's handler in `Terminal/helpers.ts:677-679` takes the opposite approach: it
+returns `false` for **all** `ctrl/meta` chords, starving TUIs of unbound
+chords like Ctrl+R. Replacing that catch-all with `resolveHotkeyFromEvent`
+would give v1 the same precision as v2 — only registered app hotkeys bubble,
+everything else reaches the PTY.
 
-```ts
-xterm.raw.attachCustomKeyEventHandler((event) => {
-  if (this._isExiting) return false;
+### Escape hatches (optional, later)
 
-  const resolveResult = this._keybindingService.softDispatch(event, target);
-
-  if (this._keybindingService.inChordMode || isValidChord) {
-    event.preventDefault();
-    return false;
-  }
-
-  // Eat the chord iff it resolves to a registered command AND that command
-  // is on the skip list (or Meta/Cmd — always belongs to app).
-  if (!sendKeybindingsToShell
-      && resolveResult.kind === KbFound
-      && resolveResult.commandId
-      && (event.metaKey || this._skipTerminalCommands.includes(resolveResult.commandId))) {
-    event.preventDefault();
-    return false;
-  }
-
-  // ...mnemonics, tab focus, shift+tab, alt+f4...
-  return true; // default: forward to PTY (kitty encoder etc.)
-});
-```
-
-Supporting pieces:
-
-- **`softDispatch`** (`abstractKeybindingService.ts:143-160`) is read-only.
-  It asks the keybinding registry "does this chord resolve to a command
-  right now?" and returns `{ kind: KbFound, commandId }` without firing.
-- **Returning `false`** from the handler is what makes xterm.js bail at
-  line 847 — no kitty encoding, no `preventDefault`, event bubbles to
-  document, the normal keybinding dispatch runs the command.
-- **`DEFAULT_COMMANDS_TO_SKIP_SHELL`** (`common/terminal.ts:499-646`) is a
-  hardcoded allow-list of ~150 command IDs: Command Palette, zoom, editor
-  focus, tab navigation, terminal focus-next, debug start/stop, etc. User
-  `commandsToSkipShell` merges on top; `-command` entries remove defaults
-  (`terminalInstance.ts:1929-1934`).
-- Config defaults: `sendKeybindingsToShell = false`, `allowChords = true`,
-  `allowMnemonics = false`.
-- `terminalAltBufferActive` is a context key refreshed on
-  `xterm.raw.buffer.onBufferChange` (`terminalInstance.ts:854, 1264-1266`).
-  It is **not** consulted in the custom key handler — only exposed for
-  individual bindings to opt out via `when` clauses.
-
-## Recommendation
-
-Mirror VSCode. In concrete Superset terms:
-
-### 1. Install a `customKeyEventHandler` on the v2 terminal
-
-In `apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts` (or wherever
-the v2 xterm instance is created), call `xterm.attachCustomKeyEventHandler`
-with a handler whose default is `return true` and that returns `false` only
-for chords Superset owns. Without this, the v1 gate can never apply to v2.
-
-### 2. Build a `chord → HotkeyId` reverse index from `HOTKEYS_REGISTRY`
-
-`apps/desktop/src/renderer/hotkeys/registry.ts` already owns the canonical
-definitions. At registry init, flatten `HOTKEYS[id].key` into a
-`Map<normalizedChord, HotkeyId>` once. Expose `resolveHotkeyFromEvent(event)`
-that normalizes an event into the same chord format and returns the matching
-`HotkeyId | null` — this is Superset's `softDispatch`.
-
-### 3. Gate in the handler
-
-```ts
-const handler = (event: KeyboardEvent): boolean => {
-  if (event.type !== "keydown") return true;
-
-  // existing macOS ANSI translations (Cmd+Left → \x01, etc.) run first
-
-  // Terminal-reserved chords must reach the PTY regardless
-  if (isTerminalReservedEvent(event)) return true;
-
-  // Always skip on Meta — matches VSCode's line 1140, and covers the kitty
-  // case where Cmd+letter would otherwise get CSI-u encoded.
-  if (event.metaKey) {
-    const id = resolveHotkeyFromEvent(event);
-    return id ? false : false; // bubble either way; Cmd almost never belongs to a TUI
-  }
-
-  // Non-Meta: only eat if it resolves to an app hotkey
-  const id = resolveHotkeyFromEvent(event);
-  if (id) return false;
-
-  return true; // default → PTY (kitty encoder runs, TUI gets the key)
-};
-xterm.attachCustomKeyEventHandler(handler);
-```
-
-Nothing else changes — existing `useHotkey(...)` registrations keep working
-because the event bubbles to document the moment the handler returns `false`.
-No direct `softDispatch`-style command execution needed.
-
-### 4. Keep the v1 handler (`Terminal/helpers.ts:530`)
-
-The v1 handler has the same bug structurally (`line 677-679` bubbles on the
-denylist), but v1 was working before Kitty because xterm's traditional path
-let Meta keys bubble. Now that Kitty is on for v1 too (`config.ts:36`), v1
-should migrate to the same resolver-based gate. Share the implementation.
-
-### 5. Optional escape hatches (later)
-
-- `sendKeybindingsToShell`-style preference: disables every non-Meta skip
-  entry, for users who want everything to reach the shell.
-- Use `isAlternateScreenRef` from `useTerminalModes.ts:33` (or subscribe to
-  `xterm.buffer.onBufferChange` — VSCode's approach at
-  `terminalInstance.ts:854`) to shrink the skip list while a TUI owns the
-  alt screen, so e.g. `FIND_IN_TERMINAL` (`Cmd+F`) can still reach `nvim`.
-
-## Minimum viable fix
-
-1. In `terminal-runtime.ts`, wire `xterm.attachCustomKeyEventHandler((event) => {
-   if (event.type !== "keydown") return true;
-   if (isTerminalReservedEvent(event)) return true;
-   if (event.metaKey) return false;
-   if (resolveHotkeyFromEvent(event)) return false;
-   return true;
-   });` after the xterm instance is created.
-2. Add `resolveHotkeyFromEvent` to `renderer/hotkeys` — ~30 lines to build the
-   reverse index at module load and match events against it.
-
-That restores all `Cmd+*` hotkeys in v2 terminals under Kitty, and any
-`Ctrl+*`/`Alt+*` chords that resolve to a registered Superset hotkey. Steps
-4-5 generalize from v2 to v1 and add escape hatches.
+- **`sendKeybindingsToShell`** user preference (VSCode pattern): disables
+  every non-Meta skip entry so power users running tmux/emacs can forward
+  everything to the shell.
+- **Alt-buffer gate**: use `isAlternateScreenRef` from `useTerminalModes.ts`
+  (or `xterm.buffer.onBufferChange`) to shrink the skip list while a TUI owns
+  the alt screen, so chords like Cmd+F can reach nvim instead of triggering
+  `FIND_IN_TERMINAL`.

--- a/apps/desktop/src/renderer/hotkeys/index.ts
+++ b/apps/desktop/src/renderer/hotkeys/index.ts
@@ -10,4 +10,4 @@ export type {
 	HotkeyDisplay,
 	Platform,
 } from "./types";
-export { isTerminalReservedEvent } from "./utils";
+export { isTerminalReservedEvent, resolveHotkeyFromEvent } from "./utils";

--- a/apps/desktop/src/renderer/hotkeys/utils/index.ts
+++ b/apps/desktop/src/renderer/hotkeys/utils/index.ts
@@ -1,1 +1,2 @@
+export { resolveHotkeyFromEvent } from "./resolveHotkeyFromEvent";
 export { isTerminalReservedEvent } from "./utils";

--- a/apps/desktop/src/renderer/hotkeys/utils/resolveHotkeyFromEvent.ts
+++ b/apps/desktop/src/renderer/hotkeys/utils/resolveHotkeyFromEvent.ts
@@ -1,0 +1,75 @@
+import { HOTKEYS, type HotkeyId } from "../registry";
+
+/**
+ * Resolves a KeyboardEvent to a registered {@link HotkeyId}, or `null` if the
+ * chord is not bound. Uses the same `event.code` normalization as
+ * react-hotkeys-hook (its internal `K` function) so the reverse index
+ * cannot drift from the matcher.
+ */
+export function resolveHotkeyFromEvent(event: KeyboardEvent): HotkeyId | null {
+	if (event.type !== "keydown") return null;
+	const chord = eventToChord(event);
+	if (!chord) return null;
+	return REGISTERED_APP_CHORDS.get(chord) ?? null;
+}
+
+// Mirrors react-hotkeys-hook's alias table (react-hotkeys-hook/dist/index.js:3-19)
+const CODE_ALIASES: Record<string, string> = {
+	esc: "escape",
+	return: "enter",
+	left: "arrowleft",
+	right: "arrowright",
+	up: "arrowup",
+	down: "arrowdown",
+	MetaLeft: "meta",
+	MetaRight: "meta",
+	ShiftLeft: "shift",
+	ShiftRight: "shift",
+	AltLeft: "alt",
+	AltRight: "alt",
+	OSLeft: "meta",
+	OSRight: "meta",
+	ControlLeft: "ctrl",
+	ControlRight: "ctrl",
+};
+
+const MODIFIERS = new Set(["meta", "ctrl", "control", "alt", "shift"]);
+
+function normalizeToken(token: string): string {
+	const aliased = CODE_ALIASES[token.trim()] ?? token.trim();
+	return aliased.toLowerCase().replace(/key|digit|numpad/, "");
+}
+
+function normalizeChord(chord: string): string {
+	const parts = chord.toLowerCase().split("+").map(normalizeToken);
+	const mods: string[] = [];
+	const keys: string[] = [];
+	for (const part of parts) {
+		if (MODIFIERS.has(part)) {
+			mods.push(part === "control" ? "ctrl" : part);
+		} else {
+			keys.push(part);
+		}
+	}
+	mods.sort();
+	return [...mods, ...keys].join("+");
+}
+
+function eventToChord(event: KeyboardEvent): string | null {
+	const key = normalizeToken(event.code);
+	if (!key || MODIFIERS.has(key)) return null;
+	const mods: string[] = [];
+	if (event.metaKey) mods.push("meta");
+	if (event.ctrlKey) mods.push("ctrl");
+	if (event.altKey) mods.push("alt");
+	if (event.shiftKey) mods.push("shift");
+	mods.sort();
+	return [...mods, key].join("+");
+}
+
+const REGISTERED_APP_CHORDS: Map<string, HotkeyId> = new Map(
+	(Object.keys(HOTKEYS) as HotkeyId[]).map((id) => [
+		normalizeChord(HOTKEYS[id].key),
+		id,
+	]),
+);

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -14,17 +14,11 @@ const DIMS_KEY_PREFIX = "terminal-dims:";
 const DEFAULT_COLS = 120;
 const DEFAULT_ROWS = 32;
 
-/**
- * Returning `false` here makes xterm bail at the top of `_keyDown`
- * (CoreBrowserTerminal.ts:847-849) before it can run `preventDefault` +
- * `stopPropagation` at line 925-928. The event keeps propagating, bubbles
- * to `document`, and `react-hotkeys-hook` fires the matching app action.
- * Without this gate, every modifier chord is delivered to the PTY AND
- * killed at target phase — which is why app hotkeys silently stopped
- * working in v2 terminals running a TUI (same situation as VSCode's
- * `terminalInstance.ts:1116-1175`).
- */
-function shouldBubbleToApp(event: KeyboardEvent): boolean {
+// xterm's _keyDown calls stopPropagation after processing, which kills the
+// bubble to react-hotkeys-hook. Returning false from the custom handler makes
+// xterm bail before that, so app hotkeys reach document. (VSCode pattern:
+// terminalInstance.ts:1116-1175)
+function isAppHotkey(event: KeyboardEvent): boolean {
 	return resolveHotkeyFromEvent(event) !== null;
 }
 
@@ -157,7 +151,7 @@ export function createRuntime(
 	terminal.open(wrapper);
 	restoreBuffer(terminalId, terminal);
 
-	terminal.attachCustomKeyEventHandler((event) => !shouldBubbleToApp(event));
+	terminal.attachCustomKeyEventHandler((event) => !isAppHotkey(event));
 
 	const addonsResult = loadAddons(terminal);
 

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -3,6 +3,7 @@ import type { ProgressAddon } from "@xterm/addon-progress";
 import type { SearchAddon } from "@xterm/addon-search";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import { Terminal as XTerm } from "@xterm/xterm";
+import { resolveHotkeyFromEvent } from "renderer/hotkeys";
 import { DEFAULT_TERMINAL_SCROLLBACK } from "shared/constants";
 import type { TerminalAppearance } from "./appearance";
 import { loadAddons } from "./terminal-addons";
@@ -12,6 +13,20 @@ const STORAGE_KEY_PREFIX = "terminal-buffer:";
 const DIMS_KEY_PREFIX = "terminal-dims:";
 const DEFAULT_COLS = 120;
 const DEFAULT_ROWS = 32;
+
+/**
+ * Returning `false` here makes xterm bail at the top of `_keyDown`
+ * (CoreBrowserTerminal.ts:847-849) before it can run `preventDefault` +
+ * `stopPropagation` at line 925-928. The event keeps propagating, bubbles
+ * to `document`, and `react-hotkeys-hook` fires the matching app action.
+ * Without this gate, every modifier chord is delivered to the PTY AND
+ * killed at target phase — which is why app hotkeys silently stopped
+ * working in v2 terminals running a TUI (same situation as VSCode's
+ * `terminalInstance.ts:1116-1175`).
+ */
+function shouldBubbleToApp(event: KeyboardEvent): boolean {
+	return resolveHotkeyFromEvent(event) !== null;
+}
 
 export interface TerminalRuntime {
 	terminalId: string;
@@ -141,6 +156,8 @@ export function createRuntime(
 	wrapper.style.height = "100%";
 	terminal.open(wrapper);
 	restoreBuffer(terminalId, terminal);
+
+	terminal.attachCustomKeyEventHandler((event) => !shouldBubbleToApp(event));
 
 	const addonsResult = loadAddons(terminal);
 

--- a/packages/panes/src/core/store/store.ts
+++ b/packages/panes/src/core/store/store.ts
@@ -182,7 +182,7 @@ export function createWorkspaceStore<TData>(
 			const tab = buildTab({ ...args, panes: builtPanes });
 			set((s) => ({
 				tabs: [...s.tabs, tab],
-				activeTabId: s.activeTabId ?? tab.id,
+				activeTabId: tab.id,
 			}));
 		},
 


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore app hotkeys in v2 terminals by letting registered chords bubble past TUIs, so shortcuts like Cmd+T/Cmd+K work again while unbound chords still go to the shell. Also activate newly created v2 workspace tabs by default, including tabs opened via Add Tab or `NEW_GROUP`/`NEW_CHAT`/`NEW_BROWSER`.

<sup>Written for commit e9c778fd7e102cbdbb8d10210423620561ec7421. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved hotkey forwarding in terminal-based UIs so app-level shortcuts reliably trigger while focus is inside embedded terminals.

* **Documentation**
  * Added a technical plan documenting terminal hotkey behavior, the new forwarding approach, and migration/compatibility notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->