### PR TITLE
feat(desktop): v2 workspace discovery page

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -1,6 +1,7 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
-import { LuFolderPlus, LuPlus } from "react-icons/lu";
+import { useMatchRoute, useNavigate } from "@tanstack/react-router";
+import { LuFolderPlus, LuLayers, LuPlus } from "react-icons/lu";
 import { useHotkeyDisplay } from "renderer/hotkeys";
 import { OrganizationDropdown } from "renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown";
 import { STROKE_WIDTH_THICK } from "renderer/screens/main/components/WorkspaceSidebar/constants";
@@ -15,11 +16,36 @@ export function DashboardSidebarHeader({
 }: DashboardSidebarHeaderProps) {
 	const openModal = useOpenNewWorkspaceModal();
 	const shortcutText = useHotkeyDisplay("NEW_WORKSPACE").text;
+	const navigate = useNavigate();
+	const matchRoute = useMatchRoute();
+	const isWorkspacesListOpen = !!matchRoute({ to: "/v2-workspaces" });
+
+	const handleWorkspacesClick = () => {
+		navigate({ to: "/v2-workspaces" });
+	};
 
 	if (isCollapsed) {
 		return (
 			<div className="flex flex-col items-center gap-2 border-b border-border py-2">
 				<OrganizationDropdown variant="collapsed" />
+
+				<Tooltip delayDuration={300}>
+					<TooltipTrigger asChild>
+						<button
+							type="button"
+							onClick={handleWorkspacesClick}
+							className={cn(
+								"flex size-8 items-center justify-center rounded-md transition-colors",
+								isWorkspacesListOpen
+									? "bg-accent text-foreground"
+									: "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+							)}
+						>
+							<LuLayers className="size-4" />
+						</button>
+					</TooltipTrigger>
+					<TooltipContent side="right">Workspaces</TooltipContent>
+				</Tooltip>
 
 				<Tooltip delayDuration={300}>
 					<TooltipTrigger asChild>
@@ -69,6 +95,20 @@ export function DashboardSidebarHeader({
 					<TooltipContent side="right">Add Repository</TooltipContent>
 				</Tooltip>
 			</div>
+
+			<button
+				type="button"
+				onClick={handleWorkspacesClick}
+				className={cn(
+					"flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium transition-colors",
+					isWorkspacesListOpen
+						? "bg-accent text-foreground"
+						: "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+				)}
+			>
+				<LuLayers className="size-4 shrink-0" />
+				<span className="flex-1 text-left">Workspaces</span>
+			</button>
 
 			<button
 				type="button"

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesHeader/V2WorkspacesHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesHeader/V2WorkspacesHeader.tsx
@@ -1,0 +1,110 @@
+import {
+	InputGroup,
+	InputGroupAddon,
+	InputGroupInput,
+} from "@superset/ui/input-group";
+import { ToggleGroup, ToggleGroupItem } from "@superset/ui/toggle-group";
+import {
+	LuCloud,
+	LuLaptop,
+	LuLayers,
+	LuMonitor,
+	LuSearch,
+} from "react-icons/lu";
+import type { V2WorkspaceDeviceCounts } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces";
+import {
+	useV2WorkspacesFilterStore,
+	type V2WorkspacesDeviceFilter,
+} from "renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore";
+
+interface V2WorkspacesHeaderProps {
+	counts: V2WorkspaceDeviceCounts;
+}
+
+const DEVICE_FILTER_OPTIONS: Array<{
+	value: V2WorkspacesDeviceFilter;
+	label: string;
+	Icon: typeof LuLayers | null;
+}> = [
+	{ value: "all", label: "All", Icon: LuLayers },
+	{ value: "this-device", label: "This device", Icon: LuLaptop },
+	{ value: "other-devices", label: "Other devices", Icon: LuMonitor },
+	{ value: "cloud", label: "Cloud", Icon: LuCloud },
+];
+
+export function V2WorkspacesHeader({ counts }: V2WorkspacesHeaderProps) {
+	const searchQuery = useV2WorkspacesFilterStore((state) => state.searchQuery);
+	const setSearchQuery = useV2WorkspacesFilterStore(
+		(state) => state.setSearchQuery,
+	);
+	const deviceFilter = useV2WorkspacesFilterStore(
+		(state) => state.deviceFilter,
+	);
+	const setDeviceFilter = useV2WorkspacesFilterStore(
+		(state) => state.setDeviceFilter,
+	);
+
+	const countForFilter = (value: V2WorkspacesDeviceFilter): number => {
+		switch (value) {
+			case "all":
+				return counts.all;
+			case "this-device":
+				return counts.thisDevice;
+			case "other-devices":
+				return counts.otherDevices;
+			case "cloud":
+				return counts.cloud;
+		}
+	};
+
+	return (
+		<div className="flex flex-col gap-3 border-b border-border px-6 pt-5 pb-4">
+			<div className="flex flex-col gap-0.5">
+				<h1 className="text-lg font-semibold tracking-tight">Workspaces</h1>
+				<p className="text-sm text-muted-foreground">
+					Every workspace you can access across your devices. Open one to jump
+					in, or add it to your sidebar.
+				</p>
+			</div>
+
+			<div className="flex flex-wrap items-center gap-3">
+				<InputGroup className="w-full max-w-sm">
+					<InputGroupAddon align="inline-start">
+						<LuSearch className="size-4" />
+					</InputGroupAddon>
+					<InputGroupInput
+						type="search"
+						placeholder="Search workspace, project, branch, or device..."
+						value={searchQuery}
+						onChange={(event) => setSearchQuery(event.target.value)}
+					/>
+				</InputGroup>
+
+				<ToggleGroup
+					type="single"
+					variant="outline"
+					size="sm"
+					value={deviceFilter}
+					onValueChange={(value) => {
+						if (value) setDeviceFilter(value as V2WorkspacesDeviceFilter);
+					}}
+				>
+					{DEVICE_FILTER_OPTIONS.map(({ value, label, Icon }) => (
+						<ToggleGroupItem
+							key={value}
+							value={value}
+							aria-label={label}
+							className="gap-1.5"
+						>
+							{Icon ? <Icon className="size-3.5" /> : null}
+							<span>{label}</span>
+							<span className="tabular-nums text-muted-foreground">
+								{countForFilter(value)}
+							</span>
+						</ToggleGroupItem>
+					))}
+				</ToggleGroup>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesHeader/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesHeader/index.ts
@@ -1,0 +1,1 @@
+export { V2WorkspacesHeader } from "./V2WorkspacesHeader";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/V2WorkspacesList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/V2WorkspacesList.tsx
@@ -50,21 +50,6 @@ function matchesDeviceFilter(
 	}
 }
 
-function matchesSearch(
-	workspace: AccessibleV2Workspace,
-	searchQuery: string,
-): boolean {
-	if (!searchQuery.trim()) return true;
-	const query = searchQuery.trim().toLowerCase();
-	return (
-		workspace.name.toLowerCase().includes(query) ||
-		workspace.projectName.toLowerCase().includes(query) ||
-		workspace.branch.toLowerCase().includes(query) ||
-		workspace.hostName.toLowerCase().includes(query) ||
-		(workspace.createdByName ?? "").toLowerCase().includes(query)
-	);
-}
-
 function groupByProject(workspaces: AccessibleV2Workspace[]): ProjectGroup[] {
 	const groupsById = new Map<string, ProjectGroup>();
 	for (const workspace of workspaces) {
@@ -108,23 +93,21 @@ export function V2WorkspacesList({
 	);
 	const resetFilters = useV2WorkspacesFilterStore((state) => state.reset);
 
+	// `pinned` / `others` already have the search filter applied upstream in
+	// useAccessibleV2Workspaces, so here we only narrow by device filter.
 	const filteredPinnedGroups = useMemo(() => {
-		const filtered = pinned.filter(
-			(workspace) =>
-				matchesDeviceFilter(workspace.hostType, deviceFilter) &&
-				matchesSearch(workspace, searchQuery),
+		const filtered = pinned.filter((workspace) =>
+			matchesDeviceFilter(workspace.hostType, deviceFilter),
 		);
 		return groupByProject(filtered);
-	}, [pinned, deviceFilter, searchQuery]);
+	}, [pinned, deviceFilter]);
 
 	const filteredOtherGroups = useMemo(() => {
-		const filtered = others.filter(
-			(workspace) =>
-				matchesDeviceFilter(workspace.hostType, deviceFilter) &&
-				matchesSearch(workspace, searchQuery),
+		const filtered = others.filter((workspace) =>
+			matchesDeviceFilter(workspace.hostType, deviceFilter),
 		);
 		return groupByProject(filtered);
-	}, [others, deviceFilter, searchQuery]);
+	}, [others, deviceFilter]);
 
 	const pinnedCount = filteredPinnedGroups.reduce(
 		(total, group) => total + group.workspaces.length,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/V2WorkspacesList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/V2WorkspacesList.tsx
@@ -1,0 +1,246 @@
+import { Button } from "@superset/ui/button";
+import {
+	Empty,
+	EmptyContent,
+	EmptyDescription,
+	EmptyHeader,
+	EmptyMedia,
+	EmptyTitle,
+} from "@superset/ui/empty";
+import { ItemGroup } from "@superset/ui/item";
+import { ScrollArea } from "@superset/ui/scroll-area";
+import { useMatchRoute } from "@tanstack/react-router";
+import { useMemo } from "react";
+import { LuLayers, LuSearchX } from "react-icons/lu";
+import type {
+	AccessibleV2Workspace,
+	V2WorkspaceHostType,
+} from "renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces";
+import {
+	useV2WorkspacesFilterStore,
+	type V2WorkspacesDeviceFilter,
+} from "renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore";
+import { V2WorkspaceRow } from "./components/V2WorkspaceRow";
+
+interface V2WorkspacesListProps {
+	pinned: AccessibleV2Workspace[];
+	others: AccessibleV2Workspace[];
+	hasAnyAccessible: boolean;
+}
+
+interface ProjectGroup {
+	projectId: string;
+	projectName: string;
+	workspaces: AccessibleV2Workspace[];
+}
+
+function matchesDeviceFilter(
+	hostType: V2WorkspaceHostType,
+	deviceFilter: V2WorkspacesDeviceFilter,
+): boolean {
+	switch (deviceFilter) {
+		case "all":
+			return true;
+		case "this-device":
+			return hostType === "local-device";
+		case "other-devices":
+			return hostType === "remote-device";
+		case "cloud":
+			return hostType === "cloud";
+	}
+}
+
+function matchesSearch(
+	workspace: AccessibleV2Workspace,
+	searchQuery: string,
+): boolean {
+	if (!searchQuery.trim()) return true;
+	const query = searchQuery.trim().toLowerCase();
+	return (
+		workspace.name.toLowerCase().includes(query) ||
+		workspace.projectName.toLowerCase().includes(query) ||
+		workspace.branch.toLowerCase().includes(query) ||
+		workspace.hostName.toLowerCase().includes(query) ||
+		(workspace.createdByName ?? "").toLowerCase().includes(query)
+	);
+}
+
+function groupByProject(workspaces: AccessibleV2Workspace[]): ProjectGroup[] {
+	const groupsById = new Map<string, ProjectGroup>();
+	for (const workspace of workspaces) {
+		const existing = groupsById.get(workspace.projectId);
+		if (existing) {
+			existing.workspaces.push(workspace);
+		} else {
+			groupsById.set(workspace.projectId, {
+				projectId: workspace.projectId,
+				projectName: workspace.projectName,
+				workspaces: [workspace],
+			});
+		}
+	}
+	return Array.from(groupsById.values()).sort((a, b) => {
+		const aLatest = Math.max(
+			...a.workspaces.map((workspace) => workspace.createdAt.getTime()),
+		);
+		const bLatest = Math.max(
+			...b.workspaces.map((workspace) => workspace.createdAt.getTime()),
+		);
+		return bLatest - aLatest;
+	});
+}
+
+export function V2WorkspacesList({
+	pinned,
+	others,
+	hasAnyAccessible,
+}: V2WorkspacesListProps) {
+	const matchRoute = useMatchRoute();
+	const currentWorkspaceMatch = matchRoute({
+		to: "/v2-workspace/$workspaceId",
+	});
+	const currentWorkspaceId =
+		currentWorkspaceMatch !== false ? currentWorkspaceMatch.workspaceId : null;
+
+	const searchQuery = useV2WorkspacesFilterStore((state) => state.searchQuery);
+	const deviceFilter = useV2WorkspacesFilterStore(
+		(state) => state.deviceFilter,
+	);
+	const resetFilters = useV2WorkspacesFilterStore((state) => state.reset);
+
+	const filteredPinnedGroups = useMemo(() => {
+		const filtered = pinned.filter(
+			(workspace) =>
+				matchesDeviceFilter(workspace.hostType, deviceFilter) &&
+				matchesSearch(workspace, searchQuery),
+		);
+		return groupByProject(filtered);
+	}, [pinned, deviceFilter, searchQuery]);
+
+	const filteredOtherGroups = useMemo(() => {
+		const filtered = others.filter(
+			(workspace) =>
+				matchesDeviceFilter(workspace.hostType, deviceFilter) &&
+				matchesSearch(workspace, searchQuery),
+		);
+		return groupByProject(filtered);
+	}, [others, deviceFilter, searchQuery]);
+
+	const pinnedCount = filteredPinnedGroups.reduce(
+		(total, group) => total + group.workspaces.length,
+		0,
+	);
+	const othersCount = filteredOtherGroups.reduce(
+		(total, group) => total + group.workspaces.length,
+		0,
+	);
+	const hasAnyMatches = pinnedCount > 0 || othersCount > 0;
+	const hasActiveFilters = searchQuery.trim() !== "" || deviceFilter !== "all";
+
+	if (!hasAnyAccessible) {
+		return (
+			<Empty className="flex-1 border-0">
+				<EmptyHeader>
+					<EmptyMedia
+						variant="icon"
+						className="size-14 [&_svg:not([class*='size-'])]:size-7"
+					>
+						<LuLayers />
+					</EmptyMedia>
+					<EmptyTitle>No workspaces yet</EmptyTitle>
+					<EmptyDescription>
+						Create a workspace from the sidebar to get started. Workspaces you
+						have access to across all your devices will show up here.
+					</EmptyDescription>
+				</EmptyHeader>
+			</Empty>
+		);
+	}
+
+	if (!hasAnyMatches) {
+		return (
+			<Empty className="flex-1 border-0">
+				<EmptyHeader>
+					<EmptyMedia
+						variant="icon"
+						className="size-14 [&_svg:not([class*='size-'])]:size-7"
+					>
+						<LuSearchX />
+					</EmptyMedia>
+					<EmptyTitle>No workspaces match your filters</EmptyTitle>
+					<EmptyDescription>
+						Try a different search term or clear the device filter.
+					</EmptyDescription>
+				</EmptyHeader>
+				{hasActiveFilters ? (
+					<EmptyContent>
+						<Button variant="outline" size="sm" onClick={() => resetFilters()}>
+							Clear filters
+						</Button>
+					</EmptyContent>
+				) : null}
+			</Empty>
+		);
+	}
+
+	const renderProjectGroups = (groups: ProjectGroup[]) => (
+		<div className="flex flex-col gap-5">
+			{groups.map((group) => (
+				<div key={group.projectId} className="flex flex-col gap-2">
+					<div className="flex items-baseline gap-2 px-1">
+						<h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+							{group.projectName}
+						</h3>
+						<span className="text-xs text-muted-foreground/70">
+							{group.workspaces.length}
+						</span>
+					</div>
+					<ItemGroup className="gap-2">
+						{group.workspaces.map((workspace) => (
+							<V2WorkspaceRow
+								key={workspace.id}
+								workspace={workspace}
+								showProjectName={false}
+								isCurrentRoute={workspace.id === currentWorkspaceId}
+							/>
+						))}
+					</ItemGroup>
+				</div>
+			))}
+		</div>
+	);
+
+	return (
+		<ScrollArea className="flex-1">
+			<div className="flex flex-col gap-8 px-6 py-6">
+				{pinnedCount > 0 ? (
+					<section className="flex flex-col gap-3">
+						<div className="flex items-baseline gap-2">
+							<h2 className="text-sm font-semibold text-foreground">
+								In your sidebar
+							</h2>
+							<span className="text-xs text-muted-foreground">
+								{pinnedCount}
+							</span>
+						</div>
+						{renderProjectGroups(filteredPinnedGroups)}
+					</section>
+				) : null}
+
+				{othersCount > 0 ? (
+					<section className="flex flex-col gap-3">
+						<div className="flex items-baseline gap-2">
+							<h2 className="text-sm font-semibold text-foreground">
+								Other workspaces
+							</h2>
+							<span className="text-xs text-muted-foreground">
+								{othersCount}
+							</span>
+						</div>
+						{renderProjectGroups(filteredOtherGroups)}
+					</section>
+				) : null}
+			</div>
+		</ScrollArea>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
@@ -70,71 +70,82 @@ export function V2WorkspaceRow({
 		? "you"
 		: (workspace.createdByName ?? "unknown");
 
+	const handleRowKeyDown = useCallback(
+		(event: React.KeyboardEvent<HTMLDivElement>) => {
+			if (event.key === "Enter" || event.key === " ") {
+				event.preventDefault();
+				handleOpen();
+			}
+		},
+		[handleOpen],
+	);
+
 	return (
 		<Item
-			asChild
 			variant="outline"
 			size="sm"
-			className="cursor-pointer border-border/60 hover:bg-accent/50"
+			role="button"
+			tabIndex={0}
+			onClick={handleOpen}
+			onKeyDown={handleRowKeyDown}
+			className="cursor-pointer border-border/60 outline-none hover:bg-accent/50 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
 		>
-			<button type="button" onClick={handleOpen}>
-				<ItemMedia variant="icon">
-					<HostIcon className="size-4" />
-				</ItemMedia>
+			<ItemMedia variant="icon">
+				<HostIcon className="size-4" />
+			</ItemMedia>
 
-				<ItemContent>
-					<ItemTitle>
-						<span className="truncate">{workspace.name}</span>
-					</ItemTitle>
-					<ItemDescription className="flex flex-wrap items-center gap-2">
-						{showProjectName ? (
-							<span className="font-medium text-foreground/70">
-								{workspace.projectName}
-							</span>
-						) : null}
-						<Badge variant="secondary" className="gap-1 font-normal">
-							<LuGitBranch className="size-3" />
-							<span className="max-w-[16rem] truncate">{workspace.branch}</span>
-						</Badge>
-						<V2WorkspaceDeviceBadge
-							hostType={workspace.hostType}
-							hostName={workspace.hostName}
-							isOnline={workspace.hostIsOnline}
-						/>
-						<span className="text-xs text-muted-foreground">
-							{getRelativeTime(workspace.createdAt.getTime(), {
-								format: "compact",
-							})}{" "}
-							by {creatorLabel}
+			<ItemContent>
+				<ItemTitle>
+					<span className="truncate">{workspace.name}</span>
+				</ItemTitle>
+				<ItemDescription className="flex flex-wrap items-center gap-2">
+					{showProjectName ? (
+						<span className="font-medium text-foreground/70">
+							{workspace.projectName}
 						</span>
-					</ItemDescription>
-				</ItemContent>
+					) : null}
+					<Badge variant="secondary" className="gap-1 font-normal">
+						<LuGitBranch className="size-3" />
+						<span className="max-w-[16rem] truncate">{workspace.branch}</span>
+					</Badge>
+					<V2WorkspaceDeviceBadge
+						hostType={workspace.hostType}
+						hostName={workspace.hostName}
+						isOnline={workspace.hostIsOnline}
+					/>
+					<span className="text-xs text-muted-foreground">
+						{getRelativeTime(workspace.createdAt.getTime(), {
+							format: "compact",
+						})}{" "}
+						by {creatorLabel}
+					</span>
+				</ItemDescription>
+			</ItemContent>
 
-				<ItemActions>
-					{workspace.isInSidebar ? (
-						<Button
-							size="sm"
-							variant="outline"
-							onClick={handleRemoveFromSidebar}
-							disabled={isCurrentRoute}
-							className="gap-1.5"
-						>
-							<LuMinus className="size-3.5" />
-							Remove from sidebar
-						</Button>
-					) : (
-						<Button
-							size="sm"
-							variant="default"
-							onClick={handleAddToSidebar}
-							className="gap-1.5"
-						>
-							<LuPlus className="size-3.5" />
-							Add to sidebar
-						</Button>
-					)}
-				</ItemActions>
-			</button>
+			<ItemActions>
+				{workspace.isInSidebar ? (
+					<Button
+						size="sm"
+						variant="outline"
+						onClick={handleRemoveFromSidebar}
+						disabled={isCurrentRoute}
+						className="gap-1.5"
+					>
+						<LuMinus className="size-3.5" />
+						Remove from sidebar
+					</Button>
+				) : (
+					<Button
+						size="sm"
+						variant="default"
+						onClick={handleAddToSidebar}
+						className="gap-1.5"
+					>
+						<LuPlus className="size-3.5" />
+						Add to sidebar
+					</Button>
+				)}
+			</ItemActions>
 		</Item>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
@@ -1,0 +1,140 @@
+import { Badge } from "@superset/ui/badge";
+import { Button } from "@superset/ui/button";
+import {
+	Item,
+	ItemActions,
+	ItemContent,
+	ItemDescription,
+	ItemMedia,
+	ItemTitle,
+} from "@superset/ui/item";
+import { useNavigate } from "@tanstack/react-router";
+import { useCallback } from "react";
+import {
+	LuCloud,
+	LuGitBranch,
+	LuLaptop,
+	LuMinus,
+	LuMonitor,
+	LuPlus,
+} from "react-icons/lu";
+import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
+import type { AccessibleV2Workspace } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces";
+import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
+import { getRelativeTime } from "renderer/screens/main/components/WorkspacesListView/utils";
+import { V2WorkspaceDeviceBadge } from "./components/V2WorkspaceDeviceBadge";
+
+interface V2WorkspaceRowProps {
+	workspace: AccessibleV2Workspace;
+	showProjectName: boolean;
+	isCurrentRoute: boolean;
+}
+
+export function V2WorkspaceRow({
+	workspace,
+	showProjectName,
+	isCurrentRoute,
+}: V2WorkspaceRowProps) {
+	const navigate = useNavigate();
+	const { ensureWorkspaceInSidebar, removeWorkspaceFromSidebar } =
+		useDashboardSidebarState();
+
+	const HostIcon =
+		workspace.hostType === "cloud"
+			? LuCloud
+			: workspace.hostType === "local-device"
+				? LuLaptop
+				: LuMonitor;
+
+	const handleOpen = useCallback(() => {
+		navigateToV2Workspace(workspace.id, navigate);
+	}, [navigate, workspace.id]);
+
+	const handleAddToSidebar = useCallback(
+		(event: React.MouseEvent) => {
+			event.stopPropagation();
+			ensureWorkspaceInSidebar(workspace.id, workspace.projectId);
+		},
+		[ensureWorkspaceInSidebar, workspace.id, workspace.projectId],
+	);
+
+	const handleRemoveFromSidebar = useCallback(
+		(event: React.MouseEvent) => {
+			event.stopPropagation();
+			removeWorkspaceFromSidebar(workspace.id);
+		},
+		[removeWorkspaceFromSidebar, workspace.id],
+	);
+
+	const creatorLabel = workspace.isCreatedByCurrentUser
+		? "you"
+		: (workspace.createdByName ?? "unknown");
+
+	return (
+		<Item
+			asChild
+			variant="outline"
+			size="sm"
+			className="cursor-pointer border-border/60 hover:bg-accent/50"
+		>
+			<button type="button" onClick={handleOpen}>
+				<ItemMedia variant="icon">
+					<HostIcon className="size-4" />
+				</ItemMedia>
+
+				<ItemContent>
+					<ItemTitle>
+						<span className="truncate">{workspace.name}</span>
+					</ItemTitle>
+					<ItemDescription className="flex flex-wrap items-center gap-2">
+						{showProjectName ? (
+							<span className="font-medium text-foreground/70">
+								{workspace.projectName}
+							</span>
+						) : null}
+						<Badge variant="secondary" className="gap-1 font-normal">
+							<LuGitBranch className="size-3" />
+							<span className="max-w-[16rem] truncate">{workspace.branch}</span>
+						</Badge>
+						<V2WorkspaceDeviceBadge
+							hostType={workspace.hostType}
+							hostName={workspace.hostName}
+							isOnline={workspace.hostIsOnline}
+						/>
+						<span className="text-xs text-muted-foreground">
+							{getRelativeTime(workspace.createdAt.getTime(), {
+								format: "compact",
+							})}{" "}
+							by {creatorLabel}
+						</span>
+					</ItemDescription>
+				</ItemContent>
+
+				<ItemActions>
+					{workspace.isInSidebar ? (
+						<Button
+							size="sm"
+							variant="outline"
+							onClick={handleRemoveFromSidebar}
+							disabled={isCurrentRoute}
+							className="gap-1.5"
+						>
+							<LuMinus className="size-3.5" />
+							Remove from sidebar
+						</Button>
+					) : (
+						<Button
+							size="sm"
+							variant="default"
+							onClick={handleAddToSidebar}
+							className="gap-1.5"
+						>
+							<LuPlus className="size-3.5" />
+							Add to sidebar
+						</Button>
+					)}
+				</ItemActions>
+			</button>
+		</Item>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/components/V2WorkspaceDeviceBadge/V2WorkspaceDeviceBadge.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/components/V2WorkspaceDeviceBadge/V2WorkspaceDeviceBadge.tsx
@@ -1,0 +1,58 @@
+import { Badge } from "@superset/ui/badge";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { cn } from "@superset/ui/utils";
+import { LuCloud, LuLaptop, LuMonitor } from "react-icons/lu";
+import type { V2WorkspaceHostType } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces";
+
+interface V2WorkspaceDeviceBadgeProps {
+	hostType: V2WorkspaceHostType;
+	hostName: string;
+	isOnline: boolean;
+}
+
+export function V2WorkspaceDeviceBadge({
+	hostType,
+	hostName,
+	isOnline,
+}: V2WorkspaceDeviceBadgeProps) {
+	const Icon =
+		hostType === "cloud"
+			? LuCloud
+			: hostType === "local-device"
+				? LuLaptop
+				: LuMonitor;
+
+	// The local device is always reachable from here — ignore any stale
+	// isOnline flag on that row.
+	const treatAsOffline = !isOnline && hostType !== "local-device";
+
+	const badge = (
+		<Badge
+			variant="outline"
+			className={cn(
+				"gap-1 font-normal",
+				treatAsOffline && "text-muted-foreground/70",
+			)}
+		>
+			<Icon className="size-3" />
+			<span className="max-w-[12rem] truncate">{hostName}</span>
+			{treatAsOffline ? (
+				<span
+					aria-hidden
+					className="ml-0.5 inline-block size-1.5 rounded-full bg-muted-foreground/50"
+				/>
+			) : null}
+		</Badge>
+	);
+
+	if (!treatAsOffline) {
+		return badge;
+	}
+
+	return (
+		<Tooltip delayDuration={300}>
+			<TooltipTrigger asChild>{badge}</TooltipTrigger>
+			<TooltipContent side="top">Host is offline</TooltipContent>
+		</Tooltip>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/components/V2WorkspaceDeviceBadge/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/components/V2WorkspaceDeviceBadge/index.ts
@@ -1,0 +1,1 @@
+export { V2WorkspaceDeviceBadge } from "./V2WorkspaceDeviceBadge";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/index.ts
@@ -1,0 +1,1 @@
+export { V2WorkspaceRow } from "./V2WorkspaceRow";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/index.ts
@@ -1,0 +1,1 @@
+export { V2WorkspacesList } from "./V2WorkspacesList";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces/index.ts
@@ -1,0 +1,8 @@
+export {
+	type AccessibleV2Workspace,
+	type UseAccessibleV2WorkspacesResult,
+	useAccessibleV2Workspaces,
+	type V2WorkspaceDeviceCounts,
+	type V2WorkspaceHostType,
+	type V2WorkspaceProjectGroup,
+} from "./useAccessibleV2Workspaces";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces/useAccessibleV2Workspaces.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces/useAccessibleV2Workspaces.ts
@@ -48,7 +48,29 @@ export interface UseAccessibleV2WorkspacesResult {
 	counts: V2WorkspaceDeviceCounts;
 }
 
-export function useAccessibleV2Workspaces(): UseAccessibleV2WorkspacesResult {
+interface UseAccessibleV2WorkspacesOptions {
+	searchQuery?: string;
+}
+
+function workspaceMatchesSearch(
+	workspace: AccessibleV2Workspace,
+	searchQuery: string,
+): boolean {
+	if (!searchQuery.trim()) return true;
+	const query = searchQuery.trim().toLowerCase();
+	return (
+		workspace.name.toLowerCase().includes(query) ||
+		workspace.projectName.toLowerCase().includes(query) ||
+		workspace.branch.toLowerCase().includes(query) ||
+		workspace.hostName.toLowerCase().includes(query) ||
+		(workspace.createdByName ?? "").toLowerCase().includes(query)
+	);
+}
+
+export function useAccessibleV2Workspaces(
+	options: UseAccessibleV2WorkspacesOptions = {},
+): UseAccessibleV2WorkspacesResult {
+	const searchQuery = options.searchQuery ?? "";
 	const { data: session } = authClient.useSession();
 	const collections = useCollections();
 	const { machineId } = useLocalHostService();
@@ -141,35 +163,43 @@ export function useAccessibleV2Workspaces(): UseAccessibleV2WorkspacesResult {
 		);
 	}, [rows, machineId, currentUserId]);
 
+	const searchFiltered = useMemo(
+		() =>
+			enriched.filter((workspace) =>
+				workspaceMatchesSearch(workspace, searchQuery),
+			),
+		[enriched, searchQuery],
+	);
+
 	const pinned = useMemo(
-		() => enriched.filter((workspace) => workspace.isInSidebar),
-		[enriched],
+		() => searchFiltered.filter((workspace) => workspace.isInSidebar),
+		[searchFiltered],
 	);
 
 	const others = useMemo(
-		() => enriched.filter((workspace) => !workspace.isInSidebar),
-		[enriched],
+		() => searchFiltered.filter((workspace) => !workspace.isInSidebar),
+		[searchFiltered],
 	);
 
 	const counts = useMemo<V2WorkspaceDeviceCounts>(() => {
 		let thisDevice = 0;
 		let otherDevices = 0;
 		let cloud = 0;
-		for (const workspace of enriched) {
+		for (const workspace of searchFiltered) {
 			if (workspace.hostType === "local-device") thisDevice += 1;
 			else if (workspace.hostType === "remote-device") otherDevices += 1;
 			else cloud += 1;
 		}
 		return {
-			all: enriched.length,
+			all: searchFiltered.length,
 			thisDevice,
 			otherDevices,
 			cloud,
 		};
-	}, [enriched]);
+	}, [searchFiltered]);
 
 	return {
-		all: enriched,
+		all: searchFiltered,
 		pinned,
 		others,
 		counts,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces/useAccessibleV2Workspaces.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces/useAccessibleV2Workspaces.ts
@@ -1,0 +1,177 @@
+import { and, eq } from "@tanstack/db";
+import { useLiveQuery } from "@tanstack/react-db";
+import { useMemo } from "react";
+import { env } from "renderer/env.renderer";
+import { authClient } from "renderer/lib/auth-client";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import { MOCK_ORG_ID } from "shared/constants";
+
+export type V2WorkspaceHostType = "local-device" | "remote-device" | "cloud";
+
+export interface AccessibleV2Workspace {
+	id: string;
+	name: string;
+	branch: string;
+	createdAt: Date;
+	createdByUserId: string | null;
+	createdByName: string | null;
+	createdByImage: string | null;
+	isCreatedByCurrentUser: boolean;
+	projectId: string;
+	projectName: string;
+	hostId: string;
+	hostName: string;
+	hostMachineId: string | null;
+	hostIsOnline: boolean;
+	hostType: V2WorkspaceHostType;
+	isInSidebar: boolean;
+}
+
+export interface V2WorkspaceProjectGroup {
+	projectId: string;
+	projectName: string;
+	workspaces: AccessibleV2Workspace[];
+}
+
+export interface V2WorkspaceDeviceCounts {
+	all: number;
+	thisDevice: number;
+	otherDevices: number;
+	cloud: number;
+}
+
+export interface UseAccessibleV2WorkspacesResult {
+	all: AccessibleV2Workspace[];
+	pinned: AccessibleV2Workspace[];
+	others: AccessibleV2Workspace[];
+	counts: V2WorkspaceDeviceCounts;
+}
+
+export function useAccessibleV2Workspaces(): UseAccessibleV2WorkspacesResult {
+	const { data: session } = authClient.useSession();
+	const collections = useCollections();
+	const { machineId } = useLocalHostService();
+
+	const activeOrganizationId = env.SKIP_ENV_VALIDATION
+		? MOCK_ORG_ID
+		: (session?.session?.activeOrganizationId ?? null);
+	const currentUserId = session?.user?.id ?? null;
+
+	const { data: rows = [] } = useLiveQuery(
+		(q) =>
+			q
+				.from({ workspaces: collections.v2Workspaces })
+				.innerJoin({ hosts: collections.v2Hosts }, ({ workspaces, hosts }) =>
+					eq(workspaces.hostId, hosts.id),
+				)
+				.innerJoin(
+					{ userHosts: collections.v2UsersHosts },
+					({ hosts, userHosts }) => eq(userHosts.hostId, hosts.id),
+				)
+				.innerJoin(
+					{ projects: collections.v2Projects },
+					({ workspaces, projects }) => eq(workspaces.projectId, projects.id),
+				)
+				.leftJoin(
+					{ sidebarState: collections.v2WorkspaceLocalState },
+					({ workspaces, sidebarState }) =>
+						eq(sidebarState.workspaceId, workspaces.id),
+				)
+				.leftJoin({ creators: collections.users }, ({ workspaces, creators }) =>
+					eq(workspaces.createdByUserId, creators.id),
+				)
+				.where(({ workspaces, userHosts }) =>
+					and(
+						eq(workspaces.organizationId, activeOrganizationId ?? ""),
+						eq(userHosts.userId, currentUserId ?? ""),
+					),
+				)
+				.select(({ workspaces, hosts, projects, sidebarState, creators }) => ({
+					id: workspaces.id,
+					name: workspaces.name,
+					branch: workspaces.branch,
+					createdAt: workspaces.createdAt,
+					createdByUserId: workspaces.createdByUserId,
+					createdByName: creators?.name ?? null,
+					createdByImage: creators?.image ?? null,
+					projectId: projects.id,
+					projectName: projects.name,
+					hostId: hosts.id,
+					hostName: hosts.name,
+					hostMachineId: hosts.machineId,
+					hostIsOnline: hosts.isOnline,
+					sidebarWorkspaceId: sidebarState?.workspaceId ?? null,
+				})),
+		[activeOrganizationId, collections, currentUserId],
+	);
+
+	const enriched = useMemo<AccessibleV2Workspace[]>(() => {
+		const deduped = new Map<string, AccessibleV2Workspace>();
+		for (const row of rows) {
+			if (deduped.has(row.id)) continue;
+			const hostType: V2WorkspaceHostType =
+				row.hostMachineId == null
+					? "cloud"
+					: row.hostMachineId === machineId
+						? "local-device"
+						: "remote-device";
+			deduped.set(row.id, {
+				id: row.id,
+				name: row.name,
+				branch: row.branch,
+				createdAt: new Date(row.createdAt),
+				createdByUserId: row.createdByUserId,
+				createdByName: row.createdByName ?? null,
+				createdByImage: row.createdByImage ?? null,
+				isCreatedByCurrentUser:
+					currentUserId != null && row.createdByUserId === currentUserId,
+				projectId: row.projectId,
+				projectName: row.projectName,
+				hostId: row.hostId,
+				hostName: row.hostName,
+				hostMachineId: row.hostMachineId,
+				hostIsOnline: row.hostIsOnline,
+				hostType,
+				isInSidebar: row.sidebarWorkspaceId != null,
+			});
+		}
+		return Array.from(deduped.values()).sort(
+			(a, b) => b.createdAt.getTime() - a.createdAt.getTime(),
+		);
+	}, [rows, machineId, currentUserId]);
+
+	const pinned = useMemo(
+		() => enriched.filter((workspace) => workspace.isInSidebar),
+		[enriched],
+	);
+
+	const others = useMemo(
+		() => enriched.filter((workspace) => !workspace.isInSidebar),
+		[enriched],
+	);
+
+	const counts = useMemo<V2WorkspaceDeviceCounts>(() => {
+		let thisDevice = 0;
+		let otherDevices = 0;
+		let cloud = 0;
+		for (const workspace of enriched) {
+			if (workspace.hostType === "local-device") thisDevice += 1;
+			else if (workspace.hostType === "remote-device") otherDevices += 1;
+			else cloud += 1;
+		}
+		return {
+			all: enriched.length,
+			thisDevice,
+			otherDevices,
+			cloud,
+		};
+	}, [enriched]);
+
+	return {
+		all: enriched,
+		pinned,
+		others,
+		counts,
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/page.tsx
@@ -1,4 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { V2WorkspacesHeader } from "./components/V2WorkspacesHeader";
+import { V2WorkspacesList } from "./components/V2WorkspacesList";
+import { useAccessibleV2Workspaces } from "./hooks/useAccessibleV2Workspaces";
 
 export const Route = createFileRoute(
 	"/_authenticated/_dashboard/v2-workspaces/",
@@ -7,26 +10,17 @@ export const Route = createFileRoute(
 });
 
 function V2WorkspacesPage() {
-	return (
-		<div className="flex h-full flex-col overflow-y-auto p-6">
-			<div className="mx-auto flex w-full max-w-4xl flex-col gap-6">
-				<div className="space-y-2">
-					<h1 className="text-2xl font-semibold tracking-tight">Workspaces</h1>
-					<p className="max-w-2xl text-sm text-muted-foreground">
-						This page will become the browse surface for all accessible V2
-						workspaces, with sidebar workspaces prioritized first.
-					</p>
-				</div>
+	const { pinned, others, counts } = useAccessibleV2Workspaces();
+	const hasAnyAccessible = pinned.length > 0 || others.length > 0;
 
-				<div className="rounded-xl border border-border bg-card p-5">
-					<h2 className="text-sm font-medium">WIP</h2>
-					<p className="mt-2 text-sm text-muted-foreground">
-						Next up is splitting local sidebar workspaces from the full set of
-						accessible shared workspaces and giving this page proper search,
-						filtering, and recents.
-					</p>
-				</div>
-			</div>
+	return (
+		<div className="flex h-full w-full flex-1 flex-col overflow-hidden">
+			<V2WorkspacesHeader counts={counts} />
+			<V2WorkspacesList
+				pinned={pinned}
+				others={others}
+				hasAnyAccessible={hasAnyAccessible}
+			/>
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/page.tsx
@@ -1,7 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { useEffect } from "react";
 import { V2WorkspacesHeader } from "./components/V2WorkspacesHeader";
 import { V2WorkspacesList } from "./components/V2WorkspacesList";
 import { useAccessibleV2Workspaces } from "./hooks/useAccessibleV2Workspaces";
+import { useV2WorkspacesFilterStore } from "./stores/v2WorkspacesFilterStore";
 
 export const Route = createFileRoute(
 	"/_authenticated/_dashboard/v2-workspaces/",
@@ -10,7 +12,17 @@ export const Route = createFileRoute(
 });
 
 function V2WorkspacesPage() {
-	const { pinned, others, counts } = useAccessibleV2Workspaces();
+	const searchQuery = useV2WorkspacesFilterStore((state) => state.searchQuery);
+	const resetFilters = useV2WorkspacesFilterStore((state) => state.reset);
+
+	// Start with a fresh view every time the discovery page mounts — otherwise
+	// the zustand singleton would carry over a stale search/device filter from a
+	// previous visit with no visible indication that a filter is active.
+	useEffect(() => {
+		resetFilters();
+	}, [resetFilters]);
+
+	const { pinned, others, counts } = useAccessibleV2Workspaces({ searchQuery });
 	const hasAnyAccessible = pinned.length > 0 || others.length > 0;
 
 	return (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore/index.ts
@@ -1,0 +1,4 @@
+export {
+	useV2WorkspacesFilterStore,
+	type V2WorkspacesDeviceFilter,
+} from "./v2WorkspacesFilterStore";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore/v2WorkspacesFilterStore.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore/v2WorkspacesFilterStore.ts
@@ -1,0 +1,25 @@
+import { create } from "zustand";
+
+export type V2WorkspacesDeviceFilter =
+	| "all"
+	| "this-device"
+	| "other-devices"
+	| "cloud";
+
+interface V2WorkspacesFilterState {
+	searchQuery: string;
+	deviceFilter: V2WorkspacesDeviceFilter;
+	setSearchQuery: (searchQuery: string) => void;
+	setDeviceFilter: (deviceFilter: V2WorkspacesDeviceFilter) => void;
+	reset: () => void;
+}
+
+export const useV2WorkspacesFilterStore = create<V2WorkspacesFilterState>()(
+	(set) => ({
+		searchQuery: "",
+		deviceFilter: "all",
+		setSearchQuery: (searchQuery) => set({ searchQuery }),
+		setDeviceFilter: (deviceFilter) => set({ deviceFilter }),
+		reset: () => set({ searchQuery: "", deviceFilter: "all" }),
+	}),
+);


### PR DESCRIPTION
## Summary
- New `/v2-workspaces` page that lists every v2 workspace the current user has access to across all of their devices, grouped into "In your sidebar" and "Other workspaces" (both grouped by project).
- Each row has a single clear CTA — "Add to sidebar" / "Remove from sidebar" — plus search, device filter chips (All / This device / Other devices / Cloud), and device badges showing local vs remote vs cloud and offline state for non-local hosts.
- Dashboard sidebar header now has a "Workspaces" nav entry (mirrors the v1 `WorkspaceSidebarHeader` pattern) that lights up when the discovery page is active.

## Why / Context
The v2 sidebar only shows workspaces that have been explicitly added to `v2WorkspaceLocalState` (a per-org localStorage record), so workspaces an agent spun up in the background, workspaces a teammate created on a shared host, or workspaces the user created on another of their own machines are invisible until the user navigates to them by URL. There was a stub page at `/v2-workspaces` and a `LuLayers` "Workspaces" button pattern already in the v1 sidebar — this PR turns the stub into a real browse surface and wires up the nav entry.

Two main user journeys this serves:
1. "An agent spun up a workspace while I was away — where is it?" → recency-sorted with a pinned vs. other split.
2. "I want to check out a teammate's workspace / my own workspace on another machine" → grouped by project with device badges and a device filter.

## How It Works

Data is read entirely from Electric collections via a single `useLiveQuery` join in `useAccessibleV2Workspaces`:

```
v2Workspaces
  ⋈ v2Hosts (host lookup)
  ⋈ v2UsersHosts (access filter — currentUserId)
  ⋈ v2Projects
  leftJoin v2WorkspaceLocalState (pinned?)
  leftJoin users (creator name)
  where organizationId = activeOrganizationId
```

No new tRPC procedures — this matches the existing `useWorkspaceHostOptions` device-picker pattern. Access is gated client-side by joining `v2_users_hosts`; workspaces on hosts the user has no row for are hidden (no dead-end rows). `hostType` (`local-device` / `remote-device` / `cloud`) is computed client-side by comparing `hostMachineId` to the local `machineId`, same as `useDashboardSidebarData`.

Adding a row to the sidebar calls the existing `ensureWorkspaceInSidebar(workspaceId, projectId)` helper, which upserts both the workspace and its parent project into `v2SidebarProjects` and `v2WorkspaceLocalState` — so workspaces in un-pinned projects just work without any new pinning UI. Opening a workspace navigates to `/v2-workspace/$workspaceId`, and the existing `v2-workspace/layout.tsx` handles local-vs-relay URL resolution uniformly for local, remote, and cloud hosts.

### File layout (co-located under `v2-workspaces/` per AGENTS.md)

```
_dashboard/v2-workspaces/
├── page.tsx                                  (thin composition of hook + header + list)
├── hooks/useAccessibleV2Workspaces/          (the useLiveQuery join)
├── stores/v2WorkspacesFilterStore/           (zustand: searchQuery + deviceFilter)
└── components/
    ├── V2WorkspacesHeader/                   (title, search, ToggleGroup filter chips)
    └── V2WorkspacesList/                     (pinned + others sections, empty states)
        └── components/V2WorkspaceRow/        (Item row with single primary CTA)
            └── components/V2WorkspaceDeviceBadge/
```

All UI is built from `@superset/ui` shadcn primitives (`Item`, `ItemGroup`, `Badge`, `Empty`, `InputGroup`, `ToggleGroup`, `Button`, `ScrollArea`, `Tooltip`).

## Manual QA Checklist

### Discovery page content
- [x] Page renders with header, search, device filter chips, and correct counts
- [x] Workspaces on hosts the user has access to are visible
- [x] Pinned workspaces appear under "In your sidebar"; un-pinned under "Other workspaces"; both grouped by project
- [x] Device badge shows correct icon per host type (laptop / monitor / cloud) and host name
- [x] Local device badge never shows "offline" even if `v2_hosts.isOnline` is stale
- [x] `createdAt` renders relative time without crashing (string → Date normalization)

### Row actions
- [x] Clicking anywhere on a row opens the workspace
- [x] Unpinned row shows "+ Add to sidebar" primary button; clicking it pins the workspace and its parent project, and the row moves to "In your sidebar"
- [x] Pinned row shows "− Remove from sidebar" outline button; clicking it removes the workspace from the sidebar and the row moves to "Other workspaces"
- [x] "Remove from sidebar" is disabled when the row matches the currently-viewed workspace

### Sidebar nav entry
- [x] `DashboardSidebarHeader` shows a "Workspaces" button with `LuLayers` icon above "New Workspace" (expanded variant)
- [x] Collapsed variant shows icon-only button with tooltip
- [x] Active state highlights when on `/v2-workspaces`

### Filters + search
- [x] Search filters on workspace name, project name, branch, host name, and creator name
- [x] Device filter chips restrict to This device / Other devices / Cloud with live counts
- [x] "No matches" empty state with "Clear filters" button appears when search/filter excludes everything
- [x] "No workspaces yet" empty state appears when the user has zero accessible workspaces

### Not verified (noted for reviewer)
- [ ] Cloud host row (my test org had no cloud hosts) — code path exists and reuses the same relay routing as existing workspaces, but I couldn't exercise it directly
- [ ] Offline remote device badge + tooltip — couldn't trigger `isOnline=false` on a remote host in my dev setup

## Testing
- `bun run lint` — clean
- `bun run typecheck` — clean across all packages
- `bun run test` — `@superset/desktop` 1629 pass / 0 fail (via turbo)
- `bunx sherif` — no issues
- Manual testing in dev mode, see QA checklist above

## Design Decisions
- **Filter by `v2_users_hosts` rather than surfacing all org workspaces grayed out**: matches the create-workspace device picker (`useWorkspaceHostOptions`), keeps the UI from showing rows the user can't actually use, and avoids introducing a "can't open this" state.
- **Group pinned workspaces by project (not just a flat list)**: consistency with the "Other workspaces" section — both halves of the page share the same `renderProjectGroups` helper.
- **Single primary CTA per row, no dropdown/overflow menu**: initial design had an "Open" button + ellipsis menu next to it, which looked visually noisy. Row click already opens, so the visible button is dedicated to the sidebar pin toggle.
- **Read everything from Electric, no new tRPC procedure**: all the required tables (`v2_workspaces`, `v2_hosts`, `v2_users_hosts`, `v2_projects`, `users`) are already synced org-wide; adding a server procedure would duplicate data that's already on the client.

## Known Limitations
- Pinned-but-inaccessible workspaces (user lost host access after pinning) are hidden by the `v2_users_hosts` inner join. The stale `v2WorkspaceLocalState` entry in the sidebar is a pre-existing issue, not introduced here.
- Creator name falls back to "unknown" when `createdByUserId` is set but no matching `users` row is synced yet.

## Follow-ups
- Keyboard/command-palette entry for the page
- Surface "Created by me" as a filter chip
- Cross-org workspace discovery (current scope is active org only)

## Risks / Rollout
- **Risk:** Low. Read-only page against already-synced Electric shapes; the only mutations are the existing `ensureWorkspaceInSidebar` / `removeWorkspaceFromSidebar` helpers that write to localStorage.
- **Rollback:** Revert the commit. The stub page existed before this PR and can be restored from git history if needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a v2 workspace discovery page at `/v2-workspaces` to browse all accessible workspaces across devices with search, device filters, and an add/remove-to-sidebar flow. Adds a “Workspaces” nav button in the dashboard sidebar; improves row accessibility and makes device-filter counts reflect search, with filters reset on page load.

- **New Features**
  - New browse page split into “In your sidebar” and “Other workspaces,” grouped by project.
  - Search by workspace, project, branch, device, or creator; device filter chips (All / This device / Other devices / Cloud) with counts.
  - Device badges show local/remote/cloud and offline state for non-local hosts.
  - Row is clickable to open; single CTA: “Add to sidebar” or “Remove from sidebar” (disabled when viewing that workspace).
  - Dashboard sidebar header adds a “Workspaces” button (expanded and collapsed variants) that highlights on `/v2-workspaces`.
  - Data reads via a single `useLiveQuery` join; access filtered by `v2_users_hosts`; host type derived from local `machineId`; uses existing `ensureWorkspaceInSidebar` and `removeWorkspaceFromSidebar`.

- **Bug Fixes**
  - Fixed invalid nested buttons in rows; click/keyboard handlers moved to the row container (`role="button"`, `tabIndex=0`) for proper accessibility.
  - Device filter chip counts now reflect the active search query (`useAccessibleV2Workspaces` applies search before deriving counts).
  - Search and device filter reset on page mount to avoid stale filters when returning to the page.

<sup>Written for commit 41a5411e75216a2ea47e6bc6d9a2f44660cb45b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Workspaces" dashboard entry with active-state highlighting.
  * New Workspaces page with header (search + device filter with counts) and grouped, searchable workspace list.
  * Workspace rows show project, branch, creator, relative creation time, device badge (online/offline) and keyboard-accessible navigation.
  * Actions to add/remove workspaces from the sidebar; empty and filtered states with "Clear filters" option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->