### PR TITLE
feat(desktop): git decoration in v2 file tree

### DIFF
--- a/apps/desktop/src/renderer/globals.css
+++ b/apps/desktop/src/renderer/globals.css
@@ -53,11 +53,6 @@
 	--sidebar-ring: #3a3837;
 	--highlight-match: rgba(224, 120, 80, 0.2);
 	--highlight-active: rgba(224, 120, 80, 0.5);
-	--diff-added: oklch(0.77 0.2 155);
-	--diff-modified: oklch(0.82 0.2 95);
-	--diff-deleted: oklch(0.65 0.2 25);
-	--diff-renamed: oklch(0.7 0.17 260);
-	--diff-copied: oklch(0.7 0.2 300);
 }
 
 /* Light theme fallback values - applied before hydration if user has light theme saved */
@@ -98,11 +93,6 @@
 	--sidebar-ring: oklch(0.708 0 0);
 	--highlight-match: rgba(255, 211, 61, 0.35);
 	--highlight-active: rgba(255, 150, 50, 0.55);
-	--diff-added: oklch(0.55 0.18 155);
-	--diff-modified: oklch(0.65 0.18 85);
-	--diff-deleted: oklch(0.52 0.22 25);
-	--diff-renamed: oklch(0.52 0.2 260);
-	--diff-copied: oklch(0.5 0.22 300);
 }
 
 @theme inline {
@@ -144,11 +134,6 @@
 	--color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
 	--color-sidebar-border: var(--sidebar-border);
 	--color-sidebar-ring: var(--sidebar-ring);
-	--color-diff-added: var(--diff-added);
-	--color-diff-modified: var(--diff-modified);
-	--color-diff-deleted: var(--diff-deleted);
-	--color-diff-renamed: var(--diff-renamed);
-	--color-diff-copied: var(--diff-copied);
 }
 
 @layer base {

--- a/apps/desktop/src/renderer/hooks/host-service/useGitStatus/index.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useGitStatus/index.ts
@@ -1,0 +1,1 @@
+export { useGitStatus } from "./useGitStatus";

--- a/apps/desktop/src/renderer/hooks/host-service/useGitStatus/useGitStatus.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useGitStatus/useGitStatus.ts
@@ -29,7 +29,6 @@ export function useGitStatus(workspaceId: string) {
 
 	const invalidate = useCallback(() => {
 		void utils.git.getStatus.invalidate({ workspaceId });
-		void utils.git.listCommits.invalidate({ workspaceId });
 	}, [utils, workspaceId]);
 
 	useWorkspaceEvent("git:changed", workspaceId, invalidate);

--- a/apps/desktop/src/renderer/hooks/host-service/useGitStatus/useGitStatus.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useGitStatus/useGitStatus.ts
@@ -1,0 +1,38 @@
+import { workspaceTrpc } from "@superset/workspace-client";
+import { useCallback } from "react";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useWorkspaceEvent } from "../useWorkspaceEvent";
+
+/**
+ * Fetches workspace git status and keeps it live against server events.
+ *
+ * Single owner of the `git.getStatus` query + `git:changed` subscription for
+ * a workspace. Consumers (Changes tab UI, file tree decoration, anything
+ * else) receive the query result as data and do not re-fetch.
+ *
+ * `git:changed` is already debounced server-side in `GitWatcher` and covers
+ * both `.git/` metadata writes and worktree file edits — no client-side
+ * debounce needed.
+ */
+export function useGitStatus(workspaceId: string) {
+	const collections = useCollections();
+	const baseBranch: string | null =
+		collections.v2WorkspaceLocalState.get(workspaceId)?.sidebarState
+			?.baseBranch ?? null;
+
+	const utils = workspaceTrpc.useUtils();
+
+	const query = workspaceTrpc.git.getStatus.useQuery(
+		{ workspaceId, baseBranch: baseBranch ?? undefined },
+		{ refetchOnWindowFocus: true, enabled: Boolean(workspaceId) },
+	);
+
+	const invalidate = useCallback(() => {
+		void utils.git.getStatus.invalidate({ workspaceId });
+		void utils.git.listCommits.invalidate({ workspaceId });
+	}, [utils, workspaceId]);
+
+	useWorkspaceEvent("git:changed", workspaceId, invalidate);
+
+	return query;
+}

--- a/apps/desktop/src/renderer/hooks/host-service/useGitStatusMap/index.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useGitStatusMap/index.ts
@@ -1,6 +1,5 @@
 export {
 	type FileStatus,
-	type UseGitStatusMapParams,
 	type UseGitStatusMapResult,
 	useGitStatusMap,
 } from "./useGitStatusMap";

--- a/apps/desktop/src/renderer/hooks/host-service/useGitStatusMap/index.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useGitStatusMap/index.ts
@@ -1,0 +1,6 @@
+export {
+	type FileStatus,
+	type UseGitStatusMapParams,
+	type UseGitStatusMapResult,
+	useGitStatusMap,
+} from "./useGitStatusMap";

--- a/apps/desktop/src/renderer/hooks/host-service/useGitStatusMap/useGitStatusMap.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useGitStatusMap/useGitStatusMap.ts
@@ -34,11 +34,13 @@ const STATUS_SEVERITY: Record<FileStatus, number> = {
 	copied: 0,
 };
 
-const EMPTY_RESULT: UseGitStatusMapResult = {
-	fileStatusByPath: new Map(),
-	folderStatusByPath: new Map(),
-	ignoredPaths: new Set(),
-};
+function emptyResult(): UseGitStatusMapResult {
+	return {
+		fileStatusByPath: new Map(),
+		folderStatusByPath: new Map(),
+		ignoredPaths: new Set(),
+	};
+}
 
 /**
  * Pure derivation over `git.getStatus` data. Returns lookup maps for
@@ -48,7 +50,7 @@ export function useGitStatusMap(
 	status: GitStatusData | undefined,
 ): UseGitStatusMapResult {
 	return useMemo(() => {
-		if (!status) return EMPTY_RESULT;
+		if (!status) return emptyResult();
 
 		// Union of all changes — later writes win so uncommitted state
 		// overrides committed state. Same pattern as useChangesTab's "all" filter.

--- a/apps/desktop/src/renderer/hooks/host-service/useGitStatusMap/useGitStatusMap.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useGitStatusMap/useGitStatusMap.ts
@@ -85,6 +85,11 @@ export function useGitStatusMap({
 		const changedAncestors = new Set<string>();
 		const worstStatusByFolder = new Map<string, FileStatus>();
 		for (const [path, fileStatus] of merged) {
+			// Deleted files don't appear in the tree, so propagating a
+			// dot to ancestor folders is misleading — users expand the
+			// folder expecting to find something but there's nothing there.
+			if (fileStatus === "deleted") continue;
+
 			const segments = path.split("/");
 			for (let i = 1; i < segments.length; i++) {
 				const ancestor = segments.slice(0, i).join("/");

--- a/apps/desktop/src/renderer/hooks/host-service/useGitStatusMap/useGitStatusMap.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useGitStatusMap/useGitStatusMap.ts
@@ -1,27 +1,28 @@
 import type { AppRouter } from "@superset/host-service";
-import { workspaceTrpc } from "@superset/workspace-client";
 import type { inferRouterOutputs } from "@trpc/server";
 import { useMemo } from "react";
-import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 
-type ChangedFile =
-	inferRouterOutputs<AppRouter>["git"]["getStatus"]["againstBase"][number];
+type GitStatusData = inferRouterOutputs<AppRouter>["git"]["getStatus"];
+type ChangedFile = GitStatusData["againstBase"][number];
 export type FileStatus = ChangedFile["status"];
 
-export interface UseGitStatusMapParams {
-	workspaceId: string;
-}
-
 export interface UseGitStatusMapResult {
-	statusByPath: Map<string, FileStatus>;
-	changedAncestors: Set<string>;
-	worstStatusByFolder: Map<string, FileStatus>;
+	/** Changed files keyed by repo-relative POSIX path. */
+	fileStatusByPath: Map<string, FileStatus>;
+	/**
+	 * Folder decoration status keyed by repo-relative POSIX path. For each
+	 * folder that (transitively) contains a changed file, the value is the
+	 * highest-severity status among its descendants — used to color the
+	 * roll-up dot in the file tree.
+	 */
+	folderStatusByPath: Map<string, FileStatus>;
+	/** Repo-relative POSIX paths reported as gitignored, normalized. */
 	ignoredPaths: Set<string>;
 }
 
 /**
- * Precedence used when a folder has descendants with multiple statuses — the
- * folder takes the "worst" (most severe) status for its dot color.
+ * Status severity used when rolling up a folder's decoration from its
+ * descendants — the folder takes the "worst" status under it.
  */
 const STATUS_SEVERITY: Record<FileStatus, number> = {
 	deleted: 5,
@@ -34,88 +35,65 @@ const STATUS_SEVERITY: Record<FileStatus, number> = {
 };
 
 const EMPTY_RESULT: UseGitStatusMapResult = {
-	statusByPath: new Map(),
-	changedAncestors: new Set(),
-	worstStatusByFolder: new Map(),
+	fileStatusByPath: new Map(),
+	folderStatusByPath: new Map(),
 	ignoredPaths: new Set(),
 };
 
 /**
- * Pure derivation hook over the existing `git.getStatus` query cache. Returns
- * lookup maps for decorating the file tree with git status + gitignored
- * muting.
- *
- * Deliberately does NOT subscribe to `git:changed` or `fs:events`:
- * `useChangesTab` is mounted unconditionally in `WorkspaceSidebar` and already
- * owns the debounced invalidate. Because this hook calls the query with the
- * same key, React Query shares one cache entry — when `useChangesTab`
- * invalidates, our `useMemo` re-derives automatically. Adding another
- * subscription here would cause duplicate event handlers and duplicate
- * refetches.
+ * Pure derivation over `git.getStatus` data. Returns lookup maps for
+ * decorating the file tree with git status + gitignored muting.
  */
-export function useGitStatusMap({
-	workspaceId,
-}: UseGitStatusMapParams): UseGitStatusMapResult {
-	const collections = useCollections();
-	const localState = collections.v2WorkspaceLocalState.get(workspaceId);
-	const baseBranch: string | null =
-		localState?.sidebarState?.baseBranch ?? null;
-
-	const status = workspaceTrpc.git.getStatus.useQuery(
-		{ workspaceId, baseBranch: baseBranch ?? undefined },
-		{ refetchOnWindowFocus: true, enabled: Boolean(workspaceId) },
-	);
-
+export function useGitStatusMap(
+	status: GitStatusData | undefined,
+): UseGitStatusMapResult {
 	return useMemo(() => {
-		if (!status.data) return EMPTY_RESULT;
+		if (!status) return EMPTY_RESULT;
 
 		// Union of all changes — later writes win so uncommitted state
 		// overrides committed state. Same pattern as useChangesTab's "all" filter.
-		const merged = new Map<string, FileStatus>();
-		for (const file of status.data.againstBase) {
-			merged.set(normalizePath(file.path), file.status);
+		const fileStatusByPath = new Map<string, FileStatus>();
+		for (const file of status.againstBase) {
+			fileStatusByPath.set(normalizePath(file.path), file.status);
 		}
-		for (const file of status.data.staged) {
-			merged.set(normalizePath(file.path), file.status);
+		for (const file of status.staged) {
+			fileStatusByPath.set(normalizePath(file.path), file.status);
 		}
-		for (const file of status.data.unstaged) {
-			merged.set(normalizePath(file.path), file.status);
+		for (const file of status.unstaged) {
+			fileStatusByPath.set(normalizePath(file.path), file.status);
 		}
 
-		const changedAncestors = new Set<string>();
-		const worstStatusByFolder = new Map<string, FileStatus>();
-		for (const [path, fileStatus] of merged) {
-			// Deleted files don't appear in the tree, so propagating a
-			// dot to ancestor folders is misleading — users expand the
-			// folder expecting to find something but there's nothing there.
+		const folderStatusByPath = new Map<string, FileStatus>();
+		for (const [path, fileStatus] of fileStatusByPath) {
+			// Deleted files don't appear in the tree, so propagating a dot to
+			// ancestor folders is misleading — users expand the folder expecting
+			// to find something but there's nothing there.
 			if (fileStatus === "deleted") continue;
 
 			const segments = path.split("/");
 			for (let i = 1; i < segments.length; i++) {
 				const ancestor = segments.slice(0, i).join("/");
-				changedAncestors.add(ancestor);
-				const existing = worstStatusByFolder.get(ancestor);
+				const existing = folderStatusByPath.get(ancestor);
 				if (
 					!existing ||
 					STATUS_SEVERITY[fileStatus] > STATUS_SEVERITY[existing]
 				) {
-					worstStatusByFolder.set(ancestor, fileStatus);
+					folderStatusByPath.set(ancestor, fileStatus);
 				}
 			}
 		}
 
 		const ignoredPaths = new Set<string>();
-		for (const entry of status.data.ignoredPaths) {
+		for (const entry of status.ignoredPaths) {
 			ignoredPaths.add(normalizePath(entry).replace(/\/$/, ""));
 		}
 
 		return {
-			statusByPath: merged,
-			changedAncestors,
-			worstStatusByFolder,
+			fileStatusByPath,
+			folderStatusByPath,
 			ignoredPaths,
 		};
-	}, [status.data]);
+	}, [status]);
 }
 
 function normalizePath(path: string): string {

--- a/apps/desktop/src/renderer/hooks/host-service/useGitStatusMap/useGitStatusMap.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useGitStatusMap/useGitStatusMap.ts
@@ -1,0 +1,118 @@
+import type { AppRouter } from "@superset/host-service";
+import { workspaceTrpc } from "@superset/workspace-client";
+import type { inferRouterOutputs } from "@trpc/server";
+import { useMemo } from "react";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+
+type ChangedFile =
+	inferRouterOutputs<AppRouter>["git"]["getStatus"]["againstBase"][number];
+export type FileStatus = ChangedFile["status"];
+
+export interface UseGitStatusMapParams {
+	workspaceId: string;
+}
+
+export interface UseGitStatusMapResult {
+	statusByPath: Map<string, FileStatus>;
+	changedAncestors: Set<string>;
+	worstStatusByFolder: Map<string, FileStatus>;
+	ignoredPaths: Set<string>;
+}
+
+/**
+ * Precedence used when a folder has descendants with multiple statuses — the
+ * folder takes the "worst" (most severe) status for its dot color.
+ */
+const STATUS_SEVERITY: Record<FileStatus, number> = {
+	deleted: 5,
+	modified: 4,
+	changed: 4,
+	added: 3,
+	untracked: 2,
+	renamed: 1,
+	copied: 0,
+};
+
+const EMPTY_RESULT: UseGitStatusMapResult = {
+	statusByPath: new Map(),
+	changedAncestors: new Set(),
+	worstStatusByFolder: new Map(),
+	ignoredPaths: new Set(),
+};
+
+/**
+ * Pure derivation hook over the existing `git.getStatus` query cache. Returns
+ * lookup maps for decorating the file tree with git status + gitignored
+ * muting.
+ *
+ * Deliberately does NOT subscribe to `git:changed` or `fs:events`:
+ * `useChangesTab` is mounted unconditionally in `WorkspaceSidebar` and already
+ * owns the debounced invalidate. Because this hook calls the query with the
+ * same key, React Query shares one cache entry — when `useChangesTab`
+ * invalidates, our `useMemo` re-derives automatically. Adding another
+ * subscription here would cause duplicate event handlers and duplicate
+ * refetches.
+ */
+export function useGitStatusMap({
+	workspaceId,
+}: UseGitStatusMapParams): UseGitStatusMapResult {
+	const collections = useCollections();
+	const localState = collections.v2WorkspaceLocalState.get(workspaceId);
+	const baseBranch: string | null =
+		localState?.sidebarState?.baseBranch ?? null;
+
+	const status = workspaceTrpc.git.getStatus.useQuery(
+		{ workspaceId, baseBranch: baseBranch ?? undefined },
+		{ refetchOnWindowFocus: true, enabled: Boolean(workspaceId) },
+	);
+
+	return useMemo(() => {
+		if (!status.data) return EMPTY_RESULT;
+
+		// Union of all changes — later writes win so uncommitted state
+		// overrides committed state. Same pattern as useChangesTab's "all" filter.
+		const merged = new Map<string, FileStatus>();
+		for (const file of status.data.againstBase) {
+			merged.set(normalizePath(file.path), file.status);
+		}
+		for (const file of status.data.staged) {
+			merged.set(normalizePath(file.path), file.status);
+		}
+		for (const file of status.data.unstaged) {
+			merged.set(normalizePath(file.path), file.status);
+		}
+
+		const changedAncestors = new Set<string>();
+		const worstStatusByFolder = new Map<string, FileStatus>();
+		for (const [path, fileStatus] of merged) {
+			const segments = path.split("/");
+			for (let i = 1; i < segments.length; i++) {
+				const ancestor = segments.slice(0, i).join("/");
+				changedAncestors.add(ancestor);
+				const existing = worstStatusByFolder.get(ancestor);
+				if (
+					!existing ||
+					STATUS_SEVERITY[fileStatus] > STATUS_SEVERITY[existing]
+				) {
+					worstStatusByFolder.set(ancestor, fileStatus);
+				}
+			}
+		}
+
+		const ignoredPaths = new Set<string>();
+		for (const entry of status.data.ignoredPaths) {
+			ignoredPaths.add(normalizePath(entry).replace(/\/$/, ""));
+		}
+
+		return {
+			statusByPath: merged,
+			changedAncestors,
+			worstStatusByFolder,
+			ignoredPaths,
+		};
+	}, [status.data]);
+}
+
+function normalizePath(path: string): string {
+	return path.replace(/\\/g, "/");
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -2,6 +2,7 @@ import { Button } from "@superset/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { Search } from "lucide-react";
 import { useMemo, useState } from "react";
+import { useGitStatus } from "renderer/hooks/host-service/useGitStatus";
 import { FilesTab } from "./components/FilesTab";
 import { SidebarHeader } from "./components/SidebarHeader";
 import { useChangesTab } from "./hooks/useChangesTab";
@@ -55,8 +56,11 @@ export function WorkspaceSidebar({
 }: WorkspaceSidebarProps) {
 	const [activeTab, setActiveTab] = useState("files");
 
+	const gitStatus = useGitStatus(workspaceId);
+
 	const changesTab = useChangesTab({
 		workspaceId,
+		gitStatus,
 		onSelectFile: onSelectDiffFile,
 	});
 
@@ -71,10 +75,18 @@ export function WorkspaceSidebar({
 					selectedFilePath={selectedFilePath}
 					workspaceId={workspaceId}
 					workspaceName={workspaceName}
+					gitStatus={gitStatus.data}
 				/>
 			),
 		}),
-		[onSearch, onSelectFile, selectedFilePath, workspaceId, workspaceName],
+		[
+			gitStatus.data,
+			onSearch,
+			onSelectFile,
+			selectedFilePath,
+			workspaceId,
+			workspaceName,
+		],
 	);
 
 	const checksTab: SidebarTabDefinition = useMemo(

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
@@ -533,7 +533,9 @@ export function FilesTab({
 					</div>
 				</div>
 
-				{fileTree.rootEntries.length === 0 && !isCreatingAtRoot ? (
+				{fileTree.rootEntries.length === 0 &&
+				!fileTree.isLoadingRoot &&
+				!isCreatingAtRoot ? (
 					<div className="px-2 py-3 text-sm text-muted-foreground">
 						No files found
 					</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
@@ -1,8 +1,10 @@
+import type { AppRouter } from "@superset/host-service";
 import { alert } from "@superset/ui/atoms/Alert";
 import { Button } from "@superset/ui/button";
 import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { workspaceTrpc } from "@superset/workspace-client";
+import type { inferRouterOutputs } from "@trpc/server";
 import { FilePlus, FolderPlus, FoldVertical, RefreshCw } from "lucide-react";
 import { Fragment, useCallback, useEffect, useRef, useState } from "react";
 import {
@@ -21,6 +23,8 @@ import {
 import { NewItemInput } from "./components/NewItemInput";
 import { WorkspaceFilesTreeItem } from "./components/WorkspaceFilesTreeItem";
 
+type GitStatusData = inferRouterOutputs<AppRouter>["git"]["getStatus"];
+
 type InlineEditState =
 	| { kind: "create"; mode: "file" | "folder"; parentPath: string }
 	| { kind: "rename"; absolutePath: string; name: string; isDirectory: boolean }
@@ -31,6 +35,7 @@ interface FilesTabProps {
 	selectedFilePath?: string;
 	workspaceId: string;
 	workspaceName?: string;
+	gitStatus: GitStatusData | undefined;
 }
 
 function toPosix(path: string): string {
@@ -46,8 +51,8 @@ function TreeNode({
 	hoveredPath,
 	inlineEdit,
 	isMuted,
-	statusByPath,
-	worstStatusByFolder,
+	fileStatusByPath,
+	folderStatusByPath,
 	ignoredPaths,
 	onSelectFile,
 	onToggleDirectory,
@@ -66,8 +71,8 @@ function TreeNode({
 	hoveredPath?: string | null;
 	inlineEdit: InlineEditState;
 	isMuted: boolean;
-	statusByPath: Map<string, FileStatus>;
-	worstStatusByFolder: Map<string, FileStatus>;
+	fileStatusByPath: Map<string, FileStatus>;
+	folderStatusByPath: Map<string, FileStatus>;
 	ignoredPaths: Set<string>;
 	onSelectFile: (absolutePath: string) => void;
 	onToggleDirectory: (absolutePath: string) => void;
@@ -94,10 +99,10 @@ function TreeNode({
 	const posixRelativePath = toPosix(node.relativePath);
 	const isFolder = node.kind === "directory";
 	const fileStatus = !isFolder
-		? statusByPath.get(posixRelativePath)
+		? fileStatusByPath.get(posixRelativePath)
 		: undefined;
 	const folderStatus = isFolder
-		? worstStatusByFolder.get(posixRelativePath)
+		? folderStatusByPath.get(posixRelativePath)
 		: undefined;
 	const decoration = isMuted ? undefined : (fileStatus ?? folderStatus);
 
@@ -153,8 +158,8 @@ function TreeNode({
 									hoveredPath={hoveredPath}
 									inlineEdit={inlineEdit}
 									isMuted={childIsMuted}
-									statusByPath={statusByPath}
-									worstStatusByFolder={worstStatusByFolder}
+									fileStatusByPath={fileStatusByPath}
+									folderStatusByPath={folderStatusByPath}
 									ignoredPaths={ignoredPaths}
 									onSelectFile={onSelectFile}
 									onToggleDirectory={onToggleDirectory}
@@ -195,6 +200,7 @@ export function FilesTab({
 	selectedFilePath,
 	workspaceId,
 	workspaceName,
+	gitStatus,
 }: FilesTabProps) {
 	const [_isRefreshing, setIsRefreshing] = useState(false);
 	const [hoveredPath, setHoveredPath] = useState<string | null>(null);
@@ -212,9 +218,8 @@ export function FilesTab({
 
 	const fileTree = useFileTree({ workspaceId, rootPath });
 
-	const { statusByPath, worstStatusByFolder, ignoredPaths } = useGitStatusMap({
-		workspaceId,
-	});
+	const { fileStatusByPath, folderStatusByPath, ignoredPaths } =
+		useGitStatusMap(gitStatus);
 
 	useWorkspaceEvent(
 		"fs:events",
@@ -555,8 +560,8 @@ export function FilesTab({
 										hoveredPath={hoveredPath}
 										inlineEdit={inlineEdit}
 										isMuted={nodeIsMuted}
-										statusByPath={statusByPath}
-										worstStatusByFolder={worstStatusByFolder}
+										fileStatusByPath={fileStatusByPath}
+										folderStatusByPath={folderStatusByPath}
 										ignoredPaths={ignoredPaths}
 										onSelectFile={onSelectFile}
 										onToggleDirectory={(absolutePath) =>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
@@ -528,11 +528,7 @@ export function FilesTab({
 					</div>
 				</div>
 
-				{fileTree.isLoadingRoot && fileTree.rootEntries.length === 0 ? (
-					<div className="px-2 py-3 text-sm text-muted-foreground">
-						Loading files...
-					</div>
-				) : fileTree.rootEntries.length === 0 && !isCreatingAtRoot ? (
+				{fileTree.rootEntries.length === 0 && !isCreatingAtRoot ? (
 					<div className="px-2 py-3 text-sm text-muted-foreground">
 						No files found
 					</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
@@ -9,6 +9,10 @@ import {
 	type FileTreeNode,
 	useFileTree,
 } from "renderer/hooks/host-service/useFileTree";
+import {
+	type FileStatus,
+	useGitStatusMap,
+} from "renderer/hooks/host-service/useGitStatusMap";
 import { useWorkspaceEvent } from "renderer/hooks/host-service/useWorkspaceEvent";
 import {
 	ROW_HEIGHT,
@@ -29,6 +33,10 @@ interface FilesTabProps {
 	workspaceName?: string;
 }
 
+function toPosix(path: string): string {
+	return path.replace(/\\/g, "/");
+}
+
 function TreeNode({
 	node,
 	depth,
@@ -37,6 +45,10 @@ function TreeNode({
 	selectedFilePath,
 	hoveredPath,
 	inlineEdit,
+	isMuted,
+	statusByPath,
+	worstStatusByFolder,
+	ignoredPaths,
 	onSelectFile,
 	onToggleDirectory,
 	onInlineEditSubmit,
@@ -53,6 +65,10 @@ function TreeNode({
 	selectedFilePath?: string;
 	hoveredPath?: string | null;
 	inlineEdit: InlineEditState;
+	isMuted: boolean;
+	statusByPath: Map<string, FileStatus>;
+	worstStatusByFolder: Map<string, FileStatus>;
+	ignoredPaths: Set<string>;
 	onSelectFile: (absolutePath: string) => void;
 	onToggleDirectory: (absolutePath: string) => void;
 	onInlineEditSubmit: (name: string) => void;
@@ -73,6 +89,18 @@ function TreeNode({
 		(n) => n.kind === "directory",
 	);
 
+	// Resolve decoration once per node. Muted wins over change status so
+	// gitignored paths stay quiet even in the `git add -f` edge case.
+	const posixRelativePath = toPosix(node.relativePath);
+	const isFolder = node.kind === "directory";
+	const fileStatus = !isFolder
+		? statusByPath.get(posixRelativePath)
+		: undefined;
+	const folderStatus = isFolder
+		? worstStatusByFolder.get(posixRelativePath)
+		: undefined;
+	const decoration = isMuted ? undefined : (fileStatus ?? folderStatus);
+
 	return (
 		<div>
 			{isRenaming ? (
@@ -91,6 +119,8 @@ function TreeNode({
 					rowHeight={rowHeight}
 					selectedFilePath={selectedFilePath}
 					isHovered={hoveredPath === node.absolutePath}
+					decoration={decoration}
+					isMuted={isMuted}
 					onSelectFile={onSelectFile}
 					onToggleDirectory={onToggleDirectory}
 					onNewFile={onNewFile}
@@ -109,35 +139,43 @@ function TreeNode({
 							onCancel={onInlineEditCancel}
 						/>
 					)}
-					{node.children.map((child, index) => (
-						<Fragment key={child.absolutePath}>
-							<TreeNode
-								node={child}
-								depth={depth + 1}
-								indent={indent}
-								rowHeight={rowHeight}
-								selectedFilePath={selectedFilePath}
-								hoveredPath={hoveredPath}
-								inlineEdit={inlineEdit}
-								onSelectFile={onSelectFile}
-								onToggleDirectory={onToggleDirectory}
-								onInlineEditSubmit={onInlineEditSubmit}
-								onInlineEditCancel={onInlineEditCancel}
-								onNewFile={onNewFile}
-								onNewFolder={onNewFolder}
-								onRename={onRename}
-								onDelete={onDelete}
-							/>
-							{isCreatingFile && index === lastFolderIndex && (
-								<NewItemInput
-									mode="file"
+					{node.children.map((child, index) => {
+						const childIsMuted =
+							isMuted || ignoredPaths.has(toPosix(child.relativePath));
+						return (
+							<Fragment key={child.absolutePath}>
+								<TreeNode
+									node={child}
 									depth={depth + 1}
-									onSubmit={onInlineEditSubmit}
-									onCancel={onInlineEditCancel}
+									indent={indent}
+									rowHeight={rowHeight}
+									selectedFilePath={selectedFilePath}
+									hoveredPath={hoveredPath}
+									inlineEdit={inlineEdit}
+									isMuted={childIsMuted}
+									statusByPath={statusByPath}
+									worstStatusByFolder={worstStatusByFolder}
+									ignoredPaths={ignoredPaths}
+									onSelectFile={onSelectFile}
+									onToggleDirectory={onToggleDirectory}
+									onInlineEditSubmit={onInlineEditSubmit}
+									onInlineEditCancel={onInlineEditCancel}
+									onNewFile={onNewFile}
+									onNewFolder={onNewFolder}
+									onRename={onRename}
+									onDelete={onDelete}
 								/>
-							)}
-						</Fragment>
-					))}
+								{isCreatingFile && index === lastFolderIndex && (
+									<NewItemInput
+										mode="file"
+										depth={depth + 1}
+										onSubmit={onInlineEditSubmit}
+										onCancel={onInlineEditCancel}
+									/>
+								)}
+							</Fragment>
+						);
+					})}
 					{isCreatingFile && lastFolderIndex === -1 && (
 						<NewItemInput
 							mode="file"
@@ -173,6 +211,10 @@ export function FilesTab({
 	const movePath = workspaceTrpc.filesystem.movePath.useMutation();
 
 	const fileTree = useFileTree({ workspaceId, rootPath });
+
+	const { statusByPath, worstStatusByFolder, ignoredPaths } = useGitStatusMap({
+		workspaceId,
+	});
 
 	useWorkspaceEvent(
 		"fs:events",
@@ -504,43 +546,50 @@ export function FilesTab({
 								onCancel={handleInlineEditCancel}
 							/>
 						)}
-						{fileTree.rootEntries.map((node, index) => (
-							<Fragment key={node.absolutePath}>
-								<TreeNode
-									node={node}
-									depth={1}
-									indent={TREE_INDENT}
-									rowHeight={ROW_HEIGHT}
-									selectedFilePath={selectedFilePath}
-									hoveredPath={hoveredPath}
-									inlineEdit={inlineEdit}
-									onSelectFile={onSelectFile}
-									onToggleDirectory={(absolutePath) =>
-										void fileTree.toggle(absolutePath)
-									}
-									onInlineEditSubmit={handleInlineEditSubmit}
-									onInlineEditCancel={handleInlineEditCancel}
-									onNewFile={(parentPath) =>
-										void startCreating("file", parentPath)
-									}
-									onNewFolder={(parentPath) =>
-										void startCreating("folder", parentPath)
-									}
-									onRename={(absolutePath, name, isDirectory) =>
-										startRenaming(absolutePath, name, isDirectory)
-									}
-									onDelete={handleDelete}
-								/>
-								{isCreatingFileAtRoot && index === rootLastFolderIndex && (
-									<NewItemInput
-										mode="file"
+						{fileTree.rootEntries.map((node, index) => {
+							const nodeIsMuted = ignoredPaths.has(toPosix(node.relativePath));
+							return (
+								<Fragment key={node.absolutePath}>
+									<TreeNode
+										node={node}
 										depth={1}
-										onSubmit={handleInlineEditSubmit}
-										onCancel={handleInlineEditCancel}
+										indent={TREE_INDENT}
+										rowHeight={ROW_HEIGHT}
+										selectedFilePath={selectedFilePath}
+										hoveredPath={hoveredPath}
+										inlineEdit={inlineEdit}
+										isMuted={nodeIsMuted}
+										statusByPath={statusByPath}
+										worstStatusByFolder={worstStatusByFolder}
+										ignoredPaths={ignoredPaths}
+										onSelectFile={onSelectFile}
+										onToggleDirectory={(absolutePath) =>
+											void fileTree.toggle(absolutePath)
+										}
+										onInlineEditSubmit={handleInlineEditSubmit}
+										onInlineEditCancel={handleInlineEditCancel}
+										onNewFile={(parentPath) =>
+											void startCreating("file", parentPath)
+										}
+										onNewFolder={(parentPath) =>
+											void startCreating("folder", parentPath)
+										}
+										onRename={(absolutePath, name, isDirectory) =>
+											startRenaming(absolutePath, name, isDirectory)
+										}
+										onDelete={handleDelete}
 									/>
-								)}
-							</Fragment>
-						))}
+									{isCreatingFileAtRoot && index === rootLastFolderIndex && (
+										<NewItemInput
+											mode="file"
+											depth={1}
+											onSubmit={handleInlineEditSubmit}
+											onCancel={handleInlineEditCancel}
+										/>
+									)}
+								</Fragment>
+							);
+						})}
 						{isCreatingFileAtRoot && rootLastFolderIndex === -1 && (
 							<NewItemInput
 								mode="file"

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/WorkspaceFilesTreeItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/WorkspaceFilesTreeItem.tsx
@@ -9,16 +9,14 @@ import { FileIcon } from "renderer/screens/main/components/WorkspaceView/RightSi
 import { FileContextMenu } from "./components/FileContextMenu";
 import { FolderContextMenu } from "./components/FolderContextMenu";
 
-// Tailwind classes mirroring ChangesFileList.tsx:19-27 so the tree and the
-// Changes tab stay visually consistent.
 const STATUS_TEXT_CLASS: Record<FileStatus, string> = {
-	added: "text-diff-added",
-	copied: "text-diff-copied",
-	changed: "text-diff-modified",
-	deleted: "text-diff-deleted",
-	modified: "text-diff-modified",
-	renamed: "text-diff-renamed",
-	untracked: "text-diff-added",
+	added: "text-green-600 dark:text-green-400",
+	copied: "text-purple-700 dark:text-purple-400",
+	changed: "text-amber-600 dark:text-amber-300",
+	deleted: "text-red-600 dark:text-red-400",
+	modified: "text-amber-600 dark:text-amber-300",
+	renamed: "text-blue-700 dark:text-blue-400",
+	untracked: "text-green-600 dark:text-green-400",
 };
 
 // Single-letter badge shown on the right of changed file rows, VS Code style.

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/WorkspaceFilesTreeItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/WorkspaceFilesTreeItem.tsx
@@ -12,9 +12,9 @@ import { FolderContextMenu } from "./components/FolderContextMenu";
 const STATUS_TEXT_CLASS: Record<FileStatus, string> = {
 	added: "text-green-700 dark:text-green-400",
 	copied: "text-purple-700 dark:text-purple-400",
-	changed: "text-yellow-600 dark:text-amber-300",
+	changed: "text-yellow-600 dark:text-yellow-400",
 	deleted: "text-red-700 dark:text-red-500",
-	modified: "text-yellow-600 dark:text-amber-300",
+	modified: "text-yellow-600 dark:text-yellow-400",
 	renamed: "text-blue-600 dark:text-blue-400",
 	untracked: "text-green-700 dark:text-green-400",
 };

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/WorkspaceFilesTreeItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/WorkspaceFilesTreeItem.tsx
@@ -100,7 +100,7 @@ function WorkspaceFilesTreeItemComponent({
 							? {
 									position: "sticky" as const,
 									top: (depth - 1) * rowHeight,
-									zIndex: 50 - depth,
+									zIndex: Math.max(1, 50 - depth),
 								}
 							: {}),
 					}}
@@ -166,7 +166,4 @@ function WorkspaceFilesTreeItemComponent({
 	);
 }
 
-// Memoized so that after a git-status refresh, only rows whose `decoration`
-// or `isMuted` actually changed re-render. Other props (node, callbacks,
-// selectedFilePath) are stable across renders in practice.
 export const WorkspaceFilesTreeItem = memo(WorkspaceFilesTreeItemComponent);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/WorkspaceFilesTreeItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/WorkspaceFilesTreeItem.tsx
@@ -10,13 +10,13 @@ import { FileContextMenu } from "./components/FileContextMenu";
 import { FolderContextMenu } from "./components/FolderContextMenu";
 
 const STATUS_TEXT_CLASS: Record<FileStatus, string> = {
-	added: "text-green-600 dark:text-green-400",
+	added: "text-green-700 dark:text-green-400",
 	copied: "text-purple-700 dark:text-purple-400",
-	changed: "text-amber-600 dark:text-amber-300",
-	deleted: "text-red-600 dark:text-red-400",
-	modified: "text-amber-600 dark:text-amber-300",
-	renamed: "text-blue-700 dark:text-blue-400",
-	untracked: "text-green-600 dark:text-green-400",
+	changed: "text-yellow-600 dark:text-amber-300",
+	deleted: "text-red-700 dark:text-red-500",
+	modified: "text-yellow-600 dark:text-amber-300",
+	renamed: "text-blue-600 dark:text-blue-400",
+	untracked: "text-green-700 dark:text-green-400",
 };
 
 // Single-letter badge shown on the right of changed file rows, VS Code style.

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/WorkspaceFilesTreeItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/WorkspaceFilesTreeItem.tsx
@@ -81,7 +81,7 @@ function WorkspaceFilesTreeItemComponent({
 					data-filepath={node.absolutePath}
 					aria-expanded={isFolder ? node.isExpanded : undefined}
 					className={cn(
-						"flex w-full cursor-pointer select-none items-center gap-1 pr-2 text-left transition-colors",
+						"flex w-full cursor-pointer select-none items-center gap-1 pr-4 text-left transition-colors",
 						isFolder ? "bg-background" : undefined,
 						isHovered && !isSelected
 							? isFolder

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/WorkspaceFilesTreeItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/WorkspaceFilesTreeItem.tsx
@@ -1,11 +1,36 @@
 import { ContextMenu, ContextMenuTrigger } from "@superset/ui/context-menu";
 import { cn } from "@superset/ui/utils";
+import { memo } from "react";
 import { LuChevronDown, LuChevronRight } from "react-icons/lu";
 import type { FileTreeNode } from "renderer/hooks/host-service/useFileTree";
+import type { FileStatus } from "renderer/hooks/host-service/useGitStatusMap";
 import { FileIcon } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils";
 
 import { FileContextMenu } from "./components/FileContextMenu";
 import { FolderContextMenu } from "./components/FolderContextMenu";
+
+// Tailwind classes mirroring ChangesFileList.tsx:19-27 so the tree and the
+// Changes tab stay visually consistent.
+const STATUS_TEXT_CLASS: Record<FileStatus, string> = {
+	added: "text-diff-added",
+	copied: "text-diff-copied",
+	changed: "text-diff-modified",
+	deleted: "text-diff-deleted",
+	modified: "text-diff-modified",
+	renamed: "text-diff-renamed",
+	untracked: "text-diff-added",
+};
+
+// Single-letter badge shown on the right of changed file rows, VS Code style.
+const STATUS_LETTER: Record<FileStatus, string> = {
+	added: "A",
+	copied: "C",
+	changed: "M",
+	deleted: "D",
+	modified: "M",
+	renamed: "R",
+	untracked: "U",
+};
 
 interface WorkspaceFilesTreeItemProps {
 	node: FileTreeNode;
@@ -14,6 +39,8 @@ interface WorkspaceFilesTreeItemProps {
 	indent: number;
 	selectedFilePath?: string;
 	isHovered?: boolean;
+	decoration?: FileStatus;
+	isMuted?: boolean;
 	onSelectFile: (absolutePath: string) => void;
 	onToggleDirectory: (absolutePath: string) => void;
 	onNewFile: (parentPath: string) => void;
@@ -22,13 +49,15 @@ interface WorkspaceFilesTreeItemProps {
 	onDelete: (absolutePath: string, name: string, isDirectory: boolean) => void;
 }
 
-export function WorkspaceFilesTreeItem({
+function WorkspaceFilesTreeItemComponent({
 	node,
 	depth,
 	rowHeight,
 	indent,
 	selectedFilePath,
 	isHovered,
+	decoration,
+	isMuted,
 	onSelectFile,
 	onToggleDirectory,
 	onNewFile,
@@ -38,6 +67,12 @@ export function WorkspaceFilesTreeItem({
 }: WorkspaceFilesTreeItemProps) {
 	const isFolder = node.kind === "directory";
 	const isSelected = selectedFilePath === node.absolutePath;
+
+	const nameColorClass = isMuted
+		? "text-muted-foreground"
+		: decoration
+			? STATUS_TEXT_CLASS[decoration]
+			: undefined;
 
 	return (
 		<ContextMenu>
@@ -90,7 +125,22 @@ export function WorkspaceFilesTreeItem({
 						isOpen={node.isExpanded}
 					/>
 
-					<span className="min-w-0 flex-1 truncate text-xs">{node.name}</span>
+					<span
+						className={cn("min-w-0 flex-1 truncate text-xs", nameColorClass)}
+					>
+						{node.name}
+					</span>
+
+					{decoration && !isMuted && (
+						<span
+							className={cn(
+								"ml-auto shrink-0 text-[10px] font-semibold leading-none",
+								STATUS_TEXT_CLASS[decoration],
+							)}
+						>
+							{isFolder ? "•" : STATUS_LETTER[decoration]}
+						</span>
+					)}
 				</button>
 			</ContextMenuTrigger>
 			{isFolder ? (
@@ -113,3 +163,8 @@ export function WorkspaceFilesTreeItem({
 		</ContextMenu>
 	);
 }
+
+// Memoized so that after a git-status refresh, only rows whose `decoration`
+// or `isMuted` actually changed re-render. Other props (node, callbacks,
+// selectedFilePath) are stable across renders in practice.
+export const WorkspaceFilesTreeItem = memo(WorkspaceFilesTreeItemComponent);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/WorkspaceFilesTreeItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/WorkspaceFilesTreeItem.tsx
@@ -1,7 +1,7 @@
 import { ContextMenu, ContextMenuTrigger } from "@superset/ui/context-menu";
 import { cn } from "@superset/ui/utils";
 import { memo } from "react";
-import { LuChevronDown, LuChevronRight } from "react-icons/lu";
+import { LuChevronDown, LuChevronRight, LuCircle } from "react-icons/lu";
 import type { FileTreeNode } from "renderer/hooks/host-service/useFileTree";
 import type { FileStatus } from "renderer/hooks/host-service/useGitStatusMap";
 import { FileIcon } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils";
@@ -97,12 +97,12 @@ function WorkspaceFilesTreeItemComponent({
 					}
 					style={{
 						height: rowHeight,
-						paddingLeft: 4 + depth * indent,
+						paddingLeft: 8 + (depth - 1) * indent,
 						...(isFolder
 							? {
 									position: "sticky" as const,
-									top: depth * rowHeight,
-									zIndex: 10 - depth,
+									top: (depth - 1) * rowHeight,
+									zIndex: 50 - depth,
 								}
 							: {}),
 					}}
@@ -138,7 +138,11 @@ function WorkspaceFilesTreeItemComponent({
 								STATUS_TEXT_CLASS[decoration],
 							)}
 						>
-							{isFolder ? "•" : STATUS_LETTER[decoration]}
+							{isFolder ? (
+								<LuCircle className="size-2 fill-current opacity-50" />
+							) : (
+								STATUS_LETTER[decoration]
+							)}
 						</span>
 					)}
 				</button>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/ChangesFileList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/ChangesFileList.tsx
@@ -17,13 +17,13 @@ type FileStatus = ChangedFile["status"];
 type ChangeCategory = "against-base" | "staged" | "unstaged";
 
 const STATUS_COLORS: Record<FileStatus, string> = {
-	added: "text-diff-added",
-	copied: "text-diff-copied",
-	changed: "text-diff-modified",
-	deleted: "text-diff-deleted",
-	modified: "text-diff-modified",
-	renamed: "text-diff-renamed",
-	untracked: "text-diff-added",
+	added: "text-green-600 dark:text-green-400",
+	copied: "text-purple-700 dark:text-purple-400",
+	changed: "text-amber-600 dark:text-amber-300",
+	deleted: "text-red-600 dark:text-red-400",
+	modified: "text-amber-600 dark:text-amber-300",
+	renamed: "text-blue-700 dark:text-blue-400",
+	untracked: "text-green-600 dark:text-green-400",
 };
 
 function getStatusIcon(status: FileStatus): ReactNode {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/ChangesFileList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/ChangesFileList.tsx
@@ -19,9 +19,9 @@ type ChangeCategory = "against-base" | "staged" | "unstaged";
 const STATUS_COLORS: Record<FileStatus, string> = {
 	added: "text-green-700 dark:text-green-400",
 	copied: "text-purple-700 dark:text-purple-400",
-	changed: "text-yellow-600 dark:text-amber-300",
+	changed: "text-yellow-600 dark:text-yellow-400",
 	deleted: "text-red-700 dark:text-red-500",
-	modified: "text-yellow-600 dark:text-amber-300",
+	modified: "text-yellow-600 dark:text-yellow-400",
 	renamed: "text-blue-600 dark:text-blue-400",
 	untracked: "text-green-700 dark:text-green-400",
 };

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/ChangesFileList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/ChangesFileList.tsx
@@ -17,13 +17,13 @@ type FileStatus = ChangedFile["status"];
 type ChangeCategory = "against-base" | "staged" | "unstaged";
 
 const STATUS_COLORS: Record<FileStatus, string> = {
-	added: "text-green-600 dark:text-green-400",
+	added: "text-green-700 dark:text-green-400",
 	copied: "text-purple-700 dark:text-purple-400",
-	changed: "text-amber-600 dark:text-amber-300",
-	deleted: "text-red-600 dark:text-red-400",
-	modified: "text-amber-600 dark:text-amber-300",
-	renamed: "text-blue-700 dark:text-blue-400",
-	untracked: "text-green-600 dark:text-green-400",
+	changed: "text-yellow-600 dark:text-amber-300",
+	deleted: "text-red-700 dark:text-red-500",
+	modified: "text-yellow-600 dark:text-amber-300",
+	renamed: "text-blue-600 dark:text-blue-400",
+	untracked: "text-green-700 dark:text-green-400",
 };
 
 function getStatusIcon(status: FileStatus): ReactNode {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
@@ -1,7 +1,7 @@
 import { toast } from "@superset/ui/sonner";
 import { workspaceTrpc } from "@superset/workspace-client";
 import { useCallback, useMemo } from "react";
-import { useWorkspaceEvent } from "renderer/hooks/host-service/useWorkspaceEvent";
+import type { useGitStatus } from "renderer/hooks/host-service/useGitStatus";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { ChangesFilter } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
 import type { SidebarTabDefinition } from "../../types";
@@ -11,6 +11,7 @@ export type { ChangesFilter };
 
 interface UseChangesTabParams {
 	workspaceId: string;
+	gitStatus: ReturnType<typeof useGitStatus>;
 	onSelectFile?: (
 		path: string,
 		category: "against-base" | "staged" | "unstaged",
@@ -19,6 +20,7 @@ interface UseChangesTabParams {
 
 export function useChangesTab({
 	workspaceId,
+	gitStatus: status,
 	onSelectFile,
 }: UseChangesTabParams): SidebarTabDefinition {
 	const collections = useCollections();
@@ -49,13 +51,6 @@ export function useChangesTab({
 		[collections, workspaceId],
 	);
 
-	const statusUtils = workspaceTrpc.useUtils();
-
-	const status = workspaceTrpc.git.getStatus.useQuery(
-		{ workspaceId, baseBranch: baseBranch ?? undefined },
-		{ refetchOnWindowFocus: true },
-	);
-
 	const commits = workspaceTrpc.git.listCommits.useQuery(
 		{ workspaceId, baseBranch: baseBranch ?? undefined },
 		{ refetchOnWindowFocus: true },
@@ -65,18 +60,6 @@ export function useChangesTab({
 		{ workspaceId },
 		{ refetchInterval: 30_000, refetchOnWindowFocus: true },
 	);
-
-	const invalidateGitQueries = useCallback(() => {
-		void statusUtils.git.getStatus.invalidate({ workspaceId });
-		void statusUtils.git.listCommits.invalidate({ workspaceId });
-	}, [statusUtils, workspaceId]);
-
-	// `git:changed` is the single source of truth for "something that affects
-	// git status just happened" — debounced server-side in `GitWatcher`,
-	// which coalesces both `.git/` metadata writes and worktree file edits
-	// into one emit per workspace per debounce window. No client debounce
-	// needed.
-	useWorkspaceEvent("git:changed", workspaceId, invalidateGitQueries);
 
 	const renameBranchMutation = workspaceTrpc.git.renameBranch.useMutation();
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
@@ -1,6 +1,6 @@
 import { toast } from "@superset/ui/sonner";
 import { workspaceTrpc } from "@superset/workspace-client";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useMemo } from "react";
 import { useWorkspaceEvent } from "renderer/hooks/host-service/useWorkspaceEvent";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { ChangesFilter } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
@@ -71,25 +71,12 @@ export function useChangesTab({
 		void statusUtils.git.listCommits.invalidate({ workspaceId });
 	}, [statusUtils, workspaceId]);
 
-	// Shared debounce for git:changed and fs:events — batches rapid events
-	// from either source into a single git status refresh.
-	const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-	const debouncedInvalidate = useCallback(() => {
-		if (debounceRef.current) clearTimeout(debounceRef.current);
-		debounceRef.current = setTimeout(() => {
-			debounceRef.current = null;
-			invalidateGitQueries();
-		}, 300);
-	}, [invalidateGitQueries]);
-	// biome-ignore lint/correctness/useExhaustiveDependencies: clear pending timer on workspace change
-	useEffect(() => {
-		return () => {
-			if (debounceRef.current) clearTimeout(debounceRef.current);
-		};
-	}, [workspaceId]);
-
-	useWorkspaceEvent("git:changed", workspaceId, debouncedInvalidate);
-	useWorkspaceEvent("fs:events", workspaceId, debouncedInvalidate);
+	// `git:changed` is the single source of truth for "something that affects
+	// git status just happened" — debounced server-side in `GitWatcher`,
+	// which coalesces both `.git/` metadata writes and worktree file edits
+	// into one emit per workspace per debounce window. No client debounce
+	// needed.
+	useWorkspaceEvent("git:changed", workspaceId, invalidateGitQueries);
 
 	const renameBranchMutation = workspaceTrpc.git.renameBranch.useMutation();
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/FilePane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/FilePane.tsx
@@ -54,7 +54,7 @@ export function FilePane({ context, workspaceId }: FilePaneProps) {
 
 	if (document.state.kind === "not-found") {
 		return (
-			<div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+			<div className="flex w-full h-full items-center justify-center text-sm text-muted-foreground">
 				File not found
 			</div>
 		);
@@ -62,7 +62,7 @@ export function FilePane({ context, workspaceId }: FilePaneProps) {
 
 	if (document.state.kind === "too-large") {
 		return (
-			<div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+			<div className="flex w-full h-full items-center justify-center text-sm text-muted-foreground">
 				File is too large to display
 			</div>
 		);
@@ -75,7 +75,7 @@ export function FilePane({ context, workspaceId }: FilePaneProps) {
 			);
 		}
 		return (
-			<div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+			<div className="flex w-full h-full items-center justify-center text-sm text-muted-foreground">
 				Binary file — cannot display
 			</div>
 		);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/constants.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/constants.ts
@@ -1,6 +1,6 @@
 export const ROW_HEIGHT = 28;
 export const SEARCH_RESULT_ROW_HEIGHT = 40;
-export const TREE_INDENT = 16;
+export const TREE_INDENT = 10;
 export const OVERSCAN_COUNT = 10;
 export const SEARCH_DEBOUNCE_MS = 150;
 export const SEARCH_RESULT_LIMIT = 200;

--- a/packages/host-service/src/events/event-bus.ts
+++ b/packages/host-service/src/events/event-bus.ts
@@ -66,7 +66,7 @@ export class EventBus {
 
 	constructor(options: EventBusOptions) {
 		this.filesystem = options.filesystem;
-		this.gitWatcher = new GitWatcher(options.db);
+		this.gitWatcher = new GitWatcher(options.db, options.filesystem);
 	}
 
 	start(): void {

--- a/packages/host-service/src/events/git-watcher.ts
+++ b/packages/host-service/src/events/git-watcher.ts
@@ -164,30 +164,31 @@ export class GitWatcher {
 
 		if (this.closed || this.watched.has(workspaceId)) return;
 
+		// Start the worktree watch first so we have a dispose handle to capture
+		// in the .git watcher's error handler closure. This avoids a race where
+		// the error handler could fire before `this.watched.set(...)` runs.
+		const disposeWorktreeWatch = this.startWorktreeWatch(
+			workspaceId,
+			worktreePath,
+		);
+
 		let watcher: FSWatcher;
 		try {
 			watcher = watch(gitDir, { recursive: true }, () => {
 				this.debouncedEmit(workspaceId);
 			});
-
-			watcher.on("error", () => {
-				// Watcher died — remove it so rescan can re-add
-				const entry = this.watched.get(workspaceId);
-				if (entry) {
-					entry.disposeWorktreeWatch();
-					this.watched.delete(workspaceId);
-				}
-				watcher.close();
-			});
 		} catch {
 			// fs.watch failed (e.g. directory doesn't exist)
+			disposeWorktreeWatch();
 			return;
 		}
 
-		const disposeWorktreeWatch = this.startWorktreeWatch(
-			workspaceId,
-			worktreePath,
-		);
+		watcher.on("error", () => {
+			// Watcher died — clean up so rescan can re-add
+			disposeWorktreeWatch();
+			this.watched.delete(workspaceId);
+			watcher.close();
+		});
 
 		this.watched.set(workspaceId, {
 			workspaceId,

--- a/packages/host-service/src/events/git-watcher.ts
+++ b/packages/host-service/src/events/git-watcher.ts
@@ -3,6 +3,7 @@ import { type FSWatcher, watch } from "node:fs";
 import { promisify } from "node:util";
 import type { HostDb } from "../db";
 import { workspaces } from "../db/schema";
+import type { WorkspaceFilesystemManager } from "../runtime/filesystem";
 
 const execFileAsync = promisify(execFile);
 
@@ -16,15 +17,34 @@ interface WatchedWorkspace {
 	worktreePath: string;
 	gitDir: string;
 	watcher: FSWatcher;
+	disposeWorktreeWatch: () => void;
 }
 
 /**
- * Watches `.git` directories for all workspaces in the host-service DB.
- * Emits workspace IDs when git state changes (commits, staging, branch switches, etc).
- * Auto-discovers new workspaces and stops watching removed ones every 30s.
+ * Watches git state for all workspaces in the host-service DB and emits a
+ * coalesced `changed` signal when anything that could affect `git status`
+ * output happens. Auto-discovers new workspaces and drops removed ones every
+ * 30s.
+ *
+ * Two sources feed into the same debounced emit per workspace:
+ *
+ * 1. `.git/` directory (via `node:fs.watch`) — catches commits, staging,
+ *    branch switches, fetches — anything that writes git metadata, including
+ *    operations from an external terminal.
+ * 2. Worktree root (via `@superset/workspace-fs` watcher manager) — catches
+ *    working-tree file edits that change `git status` output. The underlying
+ *    watcher honors `DEFAULT_IGNORE_PATTERNS`, which excludes `.git/`,
+ *    `node_modules/`, `dist/`, etc. — exactly the paths that don't affect
+ *    `git status`, so we don't waste refetches on them. Subscription is
+ *    multiplexed by `FsWatcherManager` per absolute path, so this shares the
+ *    underlying native watcher with any client-owned `fs:watch` subscriptions.
+ *
+ * Consumers therefore only need to subscribe to `git:changed` for refetch
+ * purposes — no separate client-side debounce over `fs:events`.
  */
 export class GitWatcher {
 	private readonly db: HostDb;
+	private readonly filesystem: WorkspaceFilesystemManager;
 	private readonly listeners = new Set<GitChangedListener>();
 	private readonly watched = new Map<string, WatchedWorkspace>();
 	private readonly debounceTimers = new Map<
@@ -34,8 +54,9 @@ export class GitWatcher {
 	private rescanTimer: ReturnType<typeof setInterval> | null = null;
 	private closed = false;
 
-	constructor(db: HostDb) {
+	constructor(db: HostDb, filesystem: WorkspaceFilesystemManager) {
 		this.db = db;
+		this.filesystem = filesystem;
 	}
 
 	start(): void {
@@ -65,6 +86,7 @@ export class GitWatcher {
 		this.debounceTimers.clear();
 		for (const entry of this.watched.values()) {
 			entry.watcher.close();
+			entry.disposeWorktreeWatch();
 		}
 		this.watched.clear();
 	}
@@ -105,6 +127,7 @@ export class GitWatcher {
 		for (const [id, entry] of this.watched) {
 			if (!currentIds.has(id)) {
 				entry.watcher.close();
+				entry.disposeWorktreeWatch();
 				this.watched.delete(id);
 			}
 		}
@@ -141,25 +164,91 @@ export class GitWatcher {
 
 		if (this.closed || this.watched.has(workspaceId)) return;
 
+		let watcher: FSWatcher;
 		try {
-			const watcher = watch(gitDir, { recursive: true }, () => {
+			watcher = watch(gitDir, { recursive: true }, () => {
 				this.debouncedEmit(workspaceId);
 			});
 
 			watcher.on("error", () => {
 				// Watcher died — remove it so rescan can re-add
-				this.watched.delete(workspaceId);
+				const entry = this.watched.get(workspaceId);
+				if (entry) {
+					entry.disposeWorktreeWatch();
+					this.watched.delete(workspaceId);
+				}
 				watcher.close();
-			});
-
-			this.watched.set(workspaceId, {
-				workspaceId,
-				worktreePath,
-				gitDir,
-				watcher,
 			});
 		} catch {
 			// fs.watch failed (e.g. directory doesn't exist)
+			return;
 		}
+
+		const disposeWorktreeWatch = this.startWorktreeWatch(
+			workspaceId,
+			worktreePath,
+		);
+
+		this.watched.set(workspaceId, {
+			workspaceId,
+			worktreePath,
+			gitDir,
+			watcher,
+			disposeWorktreeWatch,
+		});
+	}
+
+	/**
+	 * Subscribe to worktree fs events via the shared workspace-fs watcher
+	 * manager. Each batch of events feeds into the existing `debouncedEmit`,
+	 * so bursts of file edits collapse into a single `git:changed` per
+	 * workspace per debounce window.
+	 */
+	private startWorktreeWatch(
+		workspaceId: string,
+		worktreePath: string,
+	): () => void {
+		let disposed = false;
+		let iterator: AsyncIterator<unknown> | null = null;
+
+		try {
+			const service = this.filesystem.getServiceForWorkspace(workspaceId);
+			const stream = service.watchPath({
+				absolutePath: worktreePath,
+				recursive: true,
+			});
+			iterator = stream[Symbol.asyncIterator]();
+		} catch (error) {
+			console.error("[git-watcher] failed to start worktree watch:", {
+				workspaceId,
+				error,
+			});
+			return () => {};
+		}
+
+		void (async () => {
+			try {
+				while (!disposed && iterator) {
+					const next = await iterator.next();
+					if (disposed || next.done) return;
+					// Any batch of events may have touched paths that affect
+					// `git status` output. Let the debounced emit coalesce bursts.
+					this.debouncedEmit(workspaceId);
+				}
+			} catch (error) {
+				if (!disposed) {
+					console.error("[git-watcher] worktree watch stream failed:", {
+						workspaceId,
+						error,
+					});
+				}
+			}
+		})();
+
+		return () => {
+			disposed = true;
+			void iterator?.return?.().catch(() => {});
+			iterator = null;
+		};
 	}
 }

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -86,13 +86,31 @@ export const gitRouter = router({
 				? `origin/${defaultBranchName}`
 				: "HEAD";
 
-			const [currentBranch, defaultBranch, status] = await Promise.all([
-				buildBranch(git, currentBranchName, true, baseRef),
-				defaultBranchName
-					? buildBranch(git, defaultBranchName, false)
-					: buildBranch(git, currentBranchName, true),
-				git.status(),
-			]);
+			const [currentBranch, defaultBranch, status, ignoredRaw] =
+				await Promise.all([
+					buildBranch(git, currentBranchName, true, baseRef),
+					defaultBranchName
+						? buildBranch(git, defaultBranchName, false)
+						: buildBranch(git, currentBranchName, true),
+					git.status(),
+					git
+						.raw([
+							"ls-files",
+							"--others",
+							"--ignored",
+							"--exclude-standard",
+							"--directory",
+						])
+						.catch(() => ""),
+				]);
+
+			// Top-level gitignored paths. `--directory` collapses entirely-ignored
+			// folders to a single entry (e.g. `node_modules`) instead of
+			// enumerating every file inside, so this stays cheap in large repos.
+			const ignoredPaths = ignoredRaw
+				.split("\n")
+				.map((line) => line.trim().replace(/\/$/, ""))
+				.filter(Boolean);
 
 			const againstBase = await getChangedFilesForDiff(git, [baseRef, "HEAD"]);
 
@@ -145,7 +163,14 @@ export const gitRouter = router({
 				}
 			}
 
-			return { currentBranch, defaultBranch, againstBase, staged, unstaged };
+			return {
+				currentBranch,
+				defaultBranch,
+				againstBase,
+				staged,
+				unstaged,
+				ignoredPaths,
+			};
 		}),
 
 	listCommits: protectedProcedure


### PR DESCRIPTION
## Summary
- Adds VS Code-style git decoration to the v2 workspace "All files" tree: colored filenames, single-letter status badges (M/A/U/D/R/C), and roll-up dots on ancestor folders
- Gitignored paths (node_modules, dist, .turbo, etc.) render muted via `text-muted-foreground`
- Backend: `git.getStatus` gains an `ignoredPaths` field (via `git ls-files --others --ignored --exclude-standard --directory`, run inside the existing `Promise.all` for zero added latency)
- New `useGitStatusMap` hook is a pure derivation over the shared `git.getStatus` query cache — zero extra subscriptions, zero extra event handlers
- Unifies server-side dirty signal: `GitWatcher` now watches both `.git/` and the worktree (via multiplexed `@superset/workspace-fs` watcher), coalescing both into one debounced `git:changed` per workspace. `useChangesTab` drops its `fs:events` subscription and client-side 300ms debounce
- File tree polish: reduced indent (10px), fixed sticky z-index overflow at deep nesting, right padding for badges, folder dots via `LuCircle` icon

## Test plan
- [ ] Open a v2 workspace, modify a file → gold `M` badge + colored filename, ancestor folders show gold dot
- [ ] Add an untracked file → green `U` badge
- [ ] Delete a tracked file → no dot propagated to ancestor folders (deleted files are excluded from roll-up since they don't appear in the tree)
- [ ] Verify `node_modules`, `.turbo`, `dist` render muted when visible
- [ ] Switch to Changes tab and back — decorations persist, no extra network requests
- [ ] Edit a file from terminal → decoration updates within ~300ms
- [ ] Expand a deeply nested folder (depth > 10) → folders render correctly (z-index fix)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds VS Code–style git decorations to the v2 “All files” tree and mutes gitignored paths. Consolidates git-change signals across `.git/` and the worktree for fewer, faster renders.

- **New Features**
  - Colored filenames and single-letter badges (M/A/U/D/R/C) for changed files.
  - Ancestor folders show a roll-up dot using the worst descendant status; deleted files don’t roll up.
  - Gitignored paths render muted; `git.getStatus` now returns `ignoredPaths` (via `git ls-files --others --ignored --exclude-standard --directory`).

- **Refactors**
  - Introduced `useGitStatus` as the single owner of the `git.getStatus` query and `git:changed` subscription; `useChangesTab` consumes injected status; `useGitStatusMap` derives `fileStatusByPath` and `folderStatusByPath`.
  - Server `GitWatcher` watches both `.git/` and the worktree via `@superset/workspace-fs`, coalescing into one debounced `git:changed` per workspace; client drops `fs:events` and the 300ms debounce, and stops refetching `listCommits` on `git:changed`.
  - File tree polish: 10px indent, right padding for badges, stable sticky z-index at deep nesting, folder dots via `LuCircle`; switched from custom `--diff-*` tokens to Tailwind colors (modified uses yellow); “No files found” only shows when the root is loaded.

<sup>Written for commit fafcee6b6bf650ab2e1ed55a3a0570cca5e47c54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File tree shows git-status decorations for files and folders (status badges/indicators).
  * Git status is fetched and provided to workspace UI for consistent status display.

* **Improvements**
  * Ignored paths are respected and muted entries are visually dimmed.
  * Updated status color palette, tighter tree indentation/spacing, and “No files found” shown when empty.
  * Improved repository change detection so workspace status updates more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->