### PR TITLE
fix(desktop): retry terminal repaint after focus restore

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.test.ts
@@ -39,6 +39,7 @@ type SchedulerState = {
 
 function makeScheduler(runRecovery: (forceResize: boolean) => void): {
 	schedule: (forceResize: boolean) => void;
+	scheduleBurst: (forceResize: boolean) => void;
 	flush: () => void;
 	state: SchedulerState;
 } {
@@ -150,16 +151,11 @@ describe("scheduleReattachRecovery throttle — issue #1873", () => {
 	});
 
 	/**
-	 * REPRODUCTION TEST — this test currently FAILS, demonstrating the bug.
+	 * Regression test for the recovery throttle bug.
 	 *
-	 * Expected behaviour: when a recovery call is throttled, a retry should be
-	 * scheduled to run after the remaining throttle window expires. Without a
-	 * retry the terminal is permanently blank until the user resizes the window.
-	 *
-	 * Fix: in scheduleReattachRecovery (useTerminalLifecycle.ts), when the
-	 * throttle fires, add:
-	 *   const remaining = reattachRecovery.throttleMs - (now - reattachRecovery.lastRunAt);
-	 *   setTimeout(() => { if (!isUnmounted) scheduleReattachRecovery(reattachRecovery.pendingForceResize); }, remaining + 1);
+	 * Verifies that when a recovery request lands inside the 120ms throttle
+	 * window, the terminal schedules a retry after the remaining throttle delay
+	 * instead of silently dropping the repaint request.
 	 */
 	it("throttled recovery is retried after throttle window expires", async () => {
 		let calls = 0;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.test.ts
@@ -34,6 +34,7 @@ type SchedulerState = {
 	pendingFrame: number | null;
 	lastRunAt: number;
 	pendingForceResize: boolean;
+	burstTimeouts: number[];
 };
 
 function makeScheduler(runRecovery: (forceResize: boolean) => void): {
@@ -46,6 +47,7 @@ function makeScheduler(runRecovery: (forceResize: boolean) => void): {
 		pendingFrame: null,
 		lastRunAt: 0,
 		pendingForceResize: false,
+		burstTimeouts: [],
 	};
 
 	const pendingRafs: Array<() => void> = [];
@@ -84,6 +86,21 @@ function makeScheduler(runRecovery: (forceResize: boolean) => void): {
 		}) as unknown as number;
 	};
 
+	const scheduleRecoveryBurst = (forceResize: boolean) => {
+		scheduleReattachRecovery(forceResize);
+		for (const timeoutId of reattachRecovery.burstTimeouts) {
+			clearTimeout(timeoutId);
+		}
+		reattachRecovery.burstTimeouts = [120, 260].map(
+			(delay) =>
+				setTimeout(() => {
+					if (!isUnmounted) {
+						scheduleReattachRecovery(forceResize);
+					}
+				}, delay) as unknown as number,
+		);
+	};
+
 	const flushRafs = () => {
 		while (pendingRafs.length > 0) {
 			const cb = pendingRafs.shift();
@@ -93,6 +110,7 @@ function makeScheduler(runRecovery: (forceResize: boolean) => void): {
 
 	return {
 		schedule: scheduleReattachRecovery,
+		scheduleBurst: scheduleRecoveryBurst,
 		flush: flushRafs,
 		state: reattachRecovery,
 	};
@@ -166,5 +184,24 @@ describe("scheduleReattachRecovery throttle — issue #1873", () => {
 		// FAILS with current code: calls is still 0 because no retry was scheduled
 		// PASSES after fix: the retry fires and recovery runs
 		expect(calls).toBe(1);
+	});
+
+	it("focus recovery burst runs follow-up repaint attempts after the initial recovery", async () => {
+		let calls = 0;
+		const { scheduleBurst, flush } = makeScheduler(() => {
+			calls++;
+		});
+
+		scheduleBurst(false);
+		flush();
+		expect(calls).toBe(1);
+
+		await new Promise((r) => setTimeout(r, 140));
+		flush();
+		expect(calls).toBe(2);
+
+		await new Promise((r) => setTimeout(r, 180));
+		flush();
+		expect(calls).toBe(3);
 	});
 });

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
@@ -760,6 +760,7 @@ export function useTerminalLifecycle({
 			pendingFrame: null as number | null,
 			lastRunAt: 0,
 			pendingForceResize: false,
+			burstTimeouts: [] as number[],
 		};
 
 		const isCurrentTerminalRenderable = () => {
@@ -837,12 +838,25 @@ export function useTerminalLifecycle({
 			reattachRecovery.pendingFrame = null;
 		};
 
+		const scheduleRecoveryBurst = (forceResize: boolean) => {
+			scheduleReattachRecovery(forceResize);
+			for (const timeoutId of reattachRecovery.burstTimeouts) {
+				window.clearTimeout(timeoutId);
+			}
+			reattachRecovery.burstTimeouts = [120, 260].map((delay) =>
+				window.setTimeout(() => {
+					if (isUnmounted) return;
+					scheduleReattachRecovery(forceResize);
+				}, delay),
+			);
+		};
+
 		const handleVisibilityChange = () => {
 			if (document.hidden) return;
-			scheduleReattachRecovery(isFocusedRef.current);
+			scheduleRecoveryBurst(isFocusedRef.current);
 		};
 		const handleWindowFocus = () => {
-			scheduleReattachRecovery(isFocusedRef.current);
+			scheduleRecoveryBurst(isFocusedRef.current);
 		};
 
 		document.addEventListener("visibilitychange", handleVisibilityChange);
@@ -870,6 +884,10 @@ export function useTerminalLifecycle({
 			clearAttachInFlight(paneId, cleanupAttachId);
 			if (firstRenderFallback) clearTimeout(firstRenderFallback);
 			cancelReattachRecovery();
+			for (const timeoutId of reattachRecovery.burstTimeouts) {
+				window.clearTimeout(timeoutId);
+			}
+			reattachRecovery.burstTimeouts = [];
 			document.removeEventListener("visibilitychange", handleVisibilityChange);
 			window.removeEventListener("focus", handleWindowFocus);
 			inputDisposable.dispose();


### PR DESCRIPTION
## Summary

- add a short recovery burst when a terminal becomes visible again after focus / visibility changes
- keep the existing throttle logic, but retry repaint/fit twice after the initial restore attempt
- add a regression test that models the new burst behavior

## Why

The existing terminal restore path already does the right kinds of work on refocus:

- clear the WebGL texture atlas
- re-fit the terminal to its container
- force an xterm refresh

The remaining problem is timing. In practice, one refocus recovery can still happen slightly before the terminal container has fully settled after the app/window/workspace becomes visible again. That leaves stale blank space or stale terminal/TUI styling until some later repaint happens.

Running a short recovery burst fixed the repro locally:

- immediate restore
- second restore after ~120ms
- third restore after ~260ms

This keeps the change small and local to the focus/visibility recovery path, while giving xterm another chance to repaint once layout has actually stabilized.

## Test plan

- `bun test ./src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.test.ts`

## Related

- Closes #3321
- Related: #1830
- Related: #1873
- Related: #2507
- Related: #2968
- Related: #3080
- Related: #3208
- Related: #3309


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal reconnection reliability with an immediate recovery attempt plus additional quick follow-up retries.
  * Enhanced cleanup to cancel pending recovery retries when the component unmounts.

* **Tests**
  * Added test coverage verifying burst-style recovery triggers the immediate attempt plus follow-up retries.
  * Updated a throttle test description to label it as a regression test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->