### PR TITLE
feat(desktop): add dropdown chevron to agent settings rows

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/AgentsSettings/components/AgentCard/components/AgentCardHeader/AgentCardHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/AgentsSettings/components/AgentCard/components/AgentCardHeader/AgentCardHeader.tsx
@@ -1,5 +1,7 @@
 import { CardDescription, CardHeader, CardTitle } from "@superset/ui/card";
 import { Switch } from "@superset/ui/switch";
+import { cn } from "@superset/ui/utils";
+import { ChevronDownIcon } from "lucide-react";
 import {
 	getPresetIcon,
 	useIsDarkTheme,
@@ -58,7 +60,7 @@ export function AgentCardHeader({
 						</CardDescription>
 					</div>
 				</div>
-				<div className="flex shrink-0 items-center">
+				<div className="flex shrink-0 items-center gap-3">
 					{showEnabled && (
 						<div className="flex items-center">
 							<Switch
@@ -72,6 +74,13 @@ export function AgentCardHeader({
 							/>
 						</div>
 					)}
+					<ChevronDownIcon
+						aria-hidden="true"
+						className={cn(
+							"size-4 text-muted-foreground transition-transform duration-200",
+							isOpen && "rotate-180",
+						)}
+					/>
 				</div>
 			</div>
 		</CardHeader>


### PR DESCRIPTION
## Summary
- Each row on Settings > Agents is a collapsible card but had no visual dropdown affordance — users didn't realize clicking the row expanded it to reveal agent configuration.
- Adds a rotating `ChevronDownIcon` next to the enable switch in `AgentCardHeader` that flips 180° when the row is open.

## Test plan
- [ ] Open Settings > Agents; each row shows a chevron next to its switch
- [ ] Click a row — chevron rotates, row expands
- [ ] Toggling the switch still works without expanding the row

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a dropdown chevron to each agent row in Settings > Agents to show the row is expandable. The chevron sits next to the enable switch and rotates 180° when open; switch behavior is unchanged.

<sup>Written for commit 98dc822944e9b4448c57fa3dcf7c222c2922dae3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a chevron icon to agent card headers that visually indicates the expand/collapse state. The icon rotates smoothly when cards are toggled, providing clear visual feedback during agent configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->