### PR TITLE
fix(desktop): pass file attachments through PromptInput onSubmit

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
@@ -726,174 +726,177 @@ function PromptGroupInner({
 		[],
 	);
 
-	const handleCreate = useCallback(async (preConvertedFiles?: ConvertedFile[]) => {
-		if (!projectId) {
-			toast.error("Select a project first");
-			return;
-		}
-
-		if (submitStartedRef.current) {
-			return;
-		}
-		submitStartedRef.current = true;
-
-		const displayName =
-			workspaceNameEdited && workspaceName.trim()
-				? workspaceName.trim()
-				: trimmedPrompt || "New workspace";
-		const willGenerateAIName =
-			!branchNameEdited && !!trimmedPrompt && !linkedPR;
-		const pendingWorkspaceId = crypto.randomUUID();
-		const detachedFiles = preConvertedFiles ? [] : attachments.takeFiles();
-
-		setPendingWorkspace({
-			id: pendingWorkspaceId,
-			projectId,
-			name: displayName,
-			status: willGenerateAIName ? "generating-branch" : "preparing",
-		});
-		closeAndResetDraft();
-
-		try {
-			let aiBranchName: string | null = null;
-			if (willGenerateAIName) {
-				let timeoutId: NodeJS.Timeout | null = null;
-				try {
-					const AI_GENERATION_TIMEOUT_MS = 30000;
-					const timeoutPromise = new Promise<never>((_, reject) => {
-						timeoutId = setTimeout(
-							() => reject(new Error("AI generation timeout")),
-							AI_GENERATION_TIMEOUT_MS,
-						);
-					});
-
-					const result = await Promise.race([
-						generateBranchNameMutation.mutateAsync({
-							prompt: trimmedPrompt,
-							projectId,
-						}),
-						timeoutPromise,
-					]);
-
-					if (timeoutId) clearTimeout(timeoutId);
-					aiBranchName = result.branchName;
-				} catch (error) {
-					if (timeoutId) clearTimeout(timeoutId);
-
-					const errorMessage =
-						error instanceof Error ? error.message : String(error);
-					if (errorMessage.includes("timeout")) {
-						console.warn("[PromptGroup] AI generation timeout");
-						toast.info("Using random branch name (AI generation timed out)");
-					} else if (
-						errorMessage.toLowerCase().includes("auth") ||
-						errorMessage.includes("401") ||
-						errorMessage.includes("403")
-					) {
-						console.error("[PromptGroup] AI auth error:", error);
-						toast.error(
-							"AI authentication failed. Please check your AI settings.",
-						);
-						clearPendingWorkspace(pendingWorkspaceId);
-						return;
-					} else {
-						console.warn("[PromptGroup] AI generation failed:", error);
-						toast.info("Using random branch name (AI generation unavailable)");
-					}
-				} finally {
-					setPendingWorkspaceStatus(pendingWorkspaceId, "preparing");
-				}
+	const handleCreate = useCallback(
+		async (preConvertedFiles?: ConvertedFile[]) => {
+			if (!projectId) {
+				toast.error("Select a project first");
+				return;
 			}
 
-			let convertedFiles: ConvertedFile[] = preConvertedFiles ?? [];
-			if (!preConvertedFiles && detachedFiles.length > 0) {
-				try {
-					convertedFiles = await Promise.all(
-						detachedFiles.map(async (file) => ({
-							data: await convertBlobUrlToDataUrl(file.url),
-							mediaType: file.mediaType,
-							filename: file.filename,
-						})),
-					);
-				} catch (err) {
-					clearPendingWorkspace(pendingWorkspaceId);
-					toast.error(
-						err instanceof Error
-							? err.message
-							: "Failed to process attachments",
-					);
-					return;
-				}
+			if (submitStartedRef.current) {
+				return;
 			}
+			submitStartedRef.current = true;
 
-			// Fetch and attach GitHub issue content
-			const githubIssues = linkedIssues.filter(
-				(issue): issue is typeof issue & { number: number } =>
-					issue.source === "github" && typeof issue.number === "number",
-			);
-			if (githubIssues.length > 0 && projectId) {
-				try {
-					// Helper to add timeout to promises
-					const fetchWithTimeout = <T,>(
-						promise: Promise<T>,
-						timeoutMs: number,
-					): Promise<T> => {
-						return Promise.race([
-							promise,
-							new Promise<T>((_, reject) =>
-								setTimeout(
-									() => reject(new Error("Request timeout")),
-									timeoutMs,
-								),
-							),
+			const displayName =
+				workspaceNameEdited && workspaceName.trim()
+					? workspaceName.trim()
+					: trimmedPrompt || "New workspace";
+			const willGenerateAIName =
+				!branchNameEdited && !!trimmedPrompt && !linkedPR;
+			const pendingWorkspaceId = crypto.randomUUID();
+			const detachedFiles = preConvertedFiles ? [] : attachments.takeFiles();
+
+			setPendingWorkspace({
+				id: pendingWorkspaceId,
+				projectId,
+				name: displayName,
+				status: willGenerateAIName ? "generating-branch" : "preparing",
+			});
+			closeAndResetDraft();
+
+			try {
+				let aiBranchName: string | null = null;
+				if (willGenerateAIName) {
+					let timeoutId: NodeJS.Timeout | null = null;
+					try {
+						const AI_GENERATION_TIMEOUT_MS = 30000;
+						const timeoutPromise = new Promise<never>((_, reject) => {
+							timeoutId = setTimeout(
+								() => reject(new Error("AI generation timeout")),
+								AI_GENERATION_TIMEOUT_MS,
+							);
+						});
+
+						const result = await Promise.race([
+							generateBranchNameMutation.mutateAsync({
+								prompt: trimmedPrompt,
+								projectId,
+							}),
+							timeoutPromise,
 						]);
-					};
 
-					const issueContents = await Promise.all(
-						githubIssues.map(async (issue) => {
-							try {
-								const content = await fetchWithTimeout(
-									utils.client.projects.getIssueContent.query({
-										projectId,
-										issueNumber: issue.number,
-									}),
-									10000, // 10 second timeout per issue
-								);
+						if (timeoutId) clearTimeout(timeoutId);
+						aiBranchName = result.branchName;
+					} catch (error) {
+						if (timeoutId) clearTimeout(timeoutId);
 
-								// Sanitize user-generated content to prevent injection
-								const sanitizeText = (str: string) =>
-									str.replace(/[&<>"']/g, (char) => {
-										const entities: Record<string, string> = {
-											"&": "&amp;",
-											"<": "&lt;",
-											">": "&gt;",
-											'"': "&quot;",
-											"'": "&#39;",
-										};
-										return entities[char] || char;
-									});
+						const errorMessage =
+							error instanceof Error ? error.message : String(error);
+						if (errorMessage.includes("timeout")) {
+							console.warn("[PromptGroup] AI generation timeout");
+							toast.info("Using random branch name (AI generation timed out)");
+						} else if (
+							errorMessage.toLowerCase().includes("auth") ||
+							errorMessage.includes("401") ||
+							errorMessage.includes("403")
+						) {
+							console.error("[PromptGroup] AI auth error:", error);
+							toast.error(
+								"AI authentication failed. Please check your AI settings.",
+							);
+							clearPendingWorkspace(pendingWorkspaceId);
+							return;
+						} else {
+							console.warn("[PromptGroup] AI generation failed:", error);
+							toast.info(
+								"Using random branch name (AI generation unavailable)",
+							);
+						}
+					} finally {
+						setPendingWorkspaceStatus(pendingWorkspaceId, "preparing");
+					}
+				}
 
-								const sanitizeUrl = (url: string) => {
-									try {
-										const parsed = new URL(url);
-										// Only allow http/https protocols
-										if (!["http:", "https:"].includes(parsed.protocol)) {
+				let convertedFiles: ConvertedFile[] = preConvertedFiles ?? [];
+				if (!preConvertedFiles && detachedFiles.length > 0) {
+					try {
+						convertedFiles = await Promise.all(
+							detachedFiles.map(async (file) => ({
+								data: await convertBlobUrlToDataUrl(file.url),
+								mediaType: file.mediaType,
+								filename: file.filename,
+							})),
+						);
+					} catch (err) {
+						clearPendingWorkspace(pendingWorkspaceId);
+						toast.error(
+							err instanceof Error
+								? err.message
+								: "Failed to process attachments",
+						);
+						return;
+					}
+				}
+
+				// Fetch and attach GitHub issue content
+				const githubIssues = linkedIssues.filter(
+					(issue): issue is typeof issue & { number: number } =>
+						issue.source === "github" && typeof issue.number === "number",
+				);
+				if (githubIssues.length > 0 && projectId) {
+					try {
+						// Helper to add timeout to promises
+						const fetchWithTimeout = <T,>(
+							promise: Promise<T>,
+							timeoutMs: number,
+						): Promise<T> => {
+							return Promise.race([
+								promise,
+								new Promise<T>((_, reject) =>
+									setTimeout(
+										() => reject(new Error("Request timeout")),
+										timeoutMs,
+									),
+								),
+							]);
+						};
+
+						const issueContents = await Promise.all(
+							githubIssues.map(async (issue) => {
+								try {
+									const content = await fetchWithTimeout(
+										utils.client.projects.getIssueContent.query({
+											projectId,
+											issueNumber: issue.number,
+										}),
+										10000, // 10 second timeout per issue
+									);
+
+									// Sanitize user-generated content to prevent injection
+									const sanitizeText = (str: string) =>
+										str.replace(/[&<>"']/g, (char) => {
+											const entities: Record<string, string> = {
+												"&": "&amp;",
+												"<": "&lt;",
+												">": "&gt;",
+												'"': "&quot;",
+												"'": "&#39;",
+											};
+											return entities[char] || char;
+										});
+
+									const sanitizeUrl = (url: string) => {
+										try {
+											const parsed = new URL(url);
+											// Only allow http/https protocols
+											if (!["http:", "https:"].includes(parsed.protocol)) {
+												return "#invalid-url";
+											}
+											return url;
+										} catch {
 											return "#invalid-url";
 										}
-										return url;
-									} catch {
-										return "#invalid-url";
-									}
-								};
+									};
 
-								// Limit body size to prevent memory issues
-								const MAX_BODY_LENGTH = 50000; // 50KB
-								const truncatedBody =
-									content.body.length > MAX_BODY_LENGTH
-										? `${content.body.slice(0, MAX_BODY_LENGTH)}\n\n[... content truncated due to length ...]`
-										: content.body;
+									// Limit body size to prevent memory issues
+									const MAX_BODY_LENGTH = 50000; // 50KB
+									const truncatedBody =
+										content.body.length > MAX_BODY_LENGTH
+											? `${content.body.slice(0, MAX_BODY_LENGTH)}\n\n[... content truncated due to length ...]`
+											: content.body;
 
-								const markdown = `# GitHub Issue #${content.number}: ${sanitizeText(content.title)}
+									const markdown = `# GitHub Issue #${content.number}: ${sanitizeText(content.title)}
 
 **URL:** ${sanitizeUrl(content.url)}
 **State:** ${content.state}
@@ -905,151 +908,155 @@ function PromptGroupInner({
 
 ${sanitizeText(truncatedBody)}`;
 
-								// Convert markdown to base64 data URL
-								const base64 = btoa(
-									encodeURIComponent(markdown).replace(
-										/%([0-9A-F]{2})/g,
-										(_, p1) => String.fromCharCode(Number.parseInt(p1, 16)),
-									),
-								);
+									// Convert markdown to base64 data URL
+									const base64 = btoa(
+										encodeURIComponent(markdown).replace(
+											/%([0-9A-F]{2})/g,
+											(_, p1) => String.fromCharCode(Number.parseInt(p1, 16)),
+										),
+									);
 
-								return {
-									data: `data:text/markdown;base64,${base64}`,
-									mediaType: "text/markdown",
-									filename: `github-issue-${content.number}.md`,
-								};
-							} catch (err) {
-								console.warn(
-									`Failed to fetch GitHub issue #${issue.number}:`,
-									err,
-								);
-								return null;
-							}
-						}),
-					);
+									return {
+										data: `data:text/markdown;base64,${base64}`,
+										mediaType: "text/markdown",
+										filename: `github-issue-${content.number}.md`,
+									};
+								} catch (err) {
+									console.warn(
+										`Failed to fetch GitHub issue #${issue.number}:`,
+										err,
+									);
+									return null;
+								}
+							}),
+						);
 
-					// Add successfully fetched issues to convertedFiles
-					const validIssueFiles = issueContents.filter(
-						(file) => file !== null,
-					) as ConvertedFile[];
-					convertedFiles = [...convertedFiles, ...validIssueFiles];
-				} catch (err) {
-					console.warn("Failed to fetch GitHub issue contents:", err);
-					// Don't block workspace creation if issue fetching fails
+						// Add successfully fetched issues to convertedFiles
+						const validIssueFiles = issueContents.filter(
+							(file) => file !== null,
+						) as ConvertedFile[];
+						convertedFiles = [...convertedFiles, ...validIssueFiles];
+					} catch (err) {
+						console.warn("Failed to fetch GitHub issue contents:", err);
+						// Don't block workspace creation if issue fetching fails
+					}
 				}
-			}
 
-			let launchRequest: AgentLaunchRequest | null = null;
-			try {
-				launchRequest = buildLaunchRequest(
-					trimmedPrompt,
-					convertedFiles.length > 0 ? convertedFiles : undefined,
-				);
-			} catch (error) {
-				clearPendingWorkspace(pendingWorkspaceId);
-				toast.error(
-					error instanceof Error
-						? error.message
-						: "Failed to prepare agent launch",
-				);
-				return;
-			}
+				let launchRequest: AgentLaunchRequest | null = null;
+				try {
+					launchRequest = buildLaunchRequest(
+						trimmedPrompt,
+						convertedFiles.length > 0 ? convertedFiles : undefined,
+					);
+				} catch (error) {
+					clearPendingWorkspace(pendingWorkspaceId);
+					toast.error(
+						error instanceof Error
+							? error.message
+							: "Failed to prepare agent launch",
+					);
+					return;
+				}
 
-			setPendingWorkspaceStatus(pendingWorkspaceId, "creating");
+				setPendingWorkspaceStatus(pendingWorkspaceId, "creating");
 
-			if (linkedPR) {
+				if (linkedPR) {
+					void runAsyncAction(
+						createFromPr.mutateAsyncWithSetup(
+							{ projectId, prUrl: linkedPR.url },
+							launchRequest ?? undefined,
+						),
+						{
+							loading: `Creating workspace from PR #${linkedPR.prNumber}...`,
+							success: "Workspace created from PR",
+							error: (err) =>
+								err instanceof Error
+									? err.message
+									: "Failed to create workspace from PR",
+						},
+						{ closeAndReset: false },
+					).finally(() => {
+						clearPendingWorkspace(pendingWorkspaceId);
+					});
+					return;
+				}
+
 				void runAsyncAction(
-					createFromPr.mutateAsyncWithSetup(
-						{ projectId, prUrl: linkedPR.url },
-						launchRequest ?? undefined,
+					createWorkspace.mutateAsyncWithPendingSetup(
+						{
+							projectId,
+							name:
+								workspaceNameEdited && workspaceName.trim()
+									? workspaceName.trim()
+									: undefined,
+							prompt: trimmedPrompt || undefined,
+							branchName:
+								(branchNameEdited && branchName.trim()
+									? sanitizeBranchNameWithMaxLength(
+											branchName.trim(),
+											undefined,
+											{
+												preserveCase: true,
+											},
+										)
+									: aiBranchName) || undefined,
+							compareBaseBranch: compareBaseBranch || undefined,
+						},
+						{
+							agentLaunchRequest: launchRequest ?? undefined,
+							resolveInitialCommands: runSetupScript
+								? (commands) => commands
+								: () => null,
+						},
 					),
 					{
-						loading: `Creating workspace from PR #${linkedPR.prNumber}...`,
-						success: "Workspace created from PR",
+						loading: "Creating workspace...",
+						success: "Workspace created",
 						error: (err) =>
-							err instanceof Error
-								? err.message
-								: "Failed to create workspace from PR",
+							err instanceof Error ? err.message : "Failed to create workspace",
 					},
 					{ closeAndReset: false },
 				).finally(() => {
 					clearPendingWorkspace(pendingWorkspaceId);
 				});
-				return;
-			}
-
-			void runAsyncAction(
-				createWorkspace.mutateAsyncWithPendingSetup(
-					{
-						projectId,
-						name:
-							workspaceNameEdited && workspaceName.trim()
-								? workspaceName.trim()
-								: undefined,
-						prompt: trimmedPrompt || undefined,
-						branchName:
-							(branchNameEdited && branchName.trim()
-								? sanitizeBranchNameWithMaxLength(
-										branchName.trim(),
-										undefined,
-										{
-											preserveCase: true,
-										},
-									)
-								: aiBranchName) || undefined,
-						compareBaseBranch: compareBaseBranch || undefined,
-					},
-					{
-						agentLaunchRequest: launchRequest ?? undefined,
-						resolveInitialCommands: runSetupScript
-							? (commands) => commands
-							: () => null,
-					},
-				),
-				{
-					loading: "Creating workspace...",
-					success: "Workspace created",
-					error: (err) =>
-						err instanceof Error ? err.message : "Failed to create workspace",
-				},
-				{ closeAndReset: false },
-			).finally(() => {
-				clearPendingWorkspace(pendingWorkspaceId);
-			});
-		} finally {
-			for (const file of detachedFiles) {
-				if (file.url?.startsWith("blob:")) {
-					URL.revokeObjectURL(file.url);
+			} finally {
+				for (const file of detachedFiles) {
+					if (file.url?.startsWith("blob:")) {
+						URL.revokeObjectURL(file.url);
+					}
 				}
 			}
-		}
-	}, [
-		attachments,
-		compareBaseBranch,
-		branchName,
-		branchNameEdited,
-		buildLaunchRequest,
-		closeAndResetDraft,
-		clearPendingWorkspace,
-		convertBlobUrlToDataUrl,
-		createFromPr,
-		createWorkspace,
-		generateBranchNameMutation,
-		linkedIssues,
-		linkedPR,
-		projectId,
-		runAsyncAction,
-		runSetupScript,
-		setPendingWorkspace,
-		setPendingWorkspaceStatus,
-		trimmedPrompt,
-		utils,
-		workspaceName,
-		workspaceNameEdited,
-	]);
+		},
+		[
+			attachments,
+			compareBaseBranch,
+			branchName,
+			branchNameEdited,
+			buildLaunchRequest,
+			closeAndResetDraft,
+			clearPendingWorkspace,
+			convertBlobUrlToDataUrl,
+			createFromPr,
+			createWorkspace,
+			generateBranchNameMutation,
+			linkedIssues,
+			linkedPR,
+			projectId,
+			runAsyncAction,
+			runSetupScript,
+			setPendingWorkspace,
+			setPendingWorkspaceStatus,
+			trimmedPrompt,
+			utils,
+			workspaceName,
+			workspaceNameEdited,
+		],
+	);
 
 	const handlePromptSubmit = useCallback(
-		(message: { files: Array<{ url: string; mediaType: string; filename?: string }> }) => {
+		(message: {
+			files: Array<{ url: string; mediaType: string; filename?: string }>;
+		}) => {
 			const converted: ConvertedFile[] = message.files
 				.filter((f) => f.url)
 				.map((f) => ({

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
@@ -726,7 +726,7 @@ function PromptGroupInner({
 		[],
 	);
 
-	const handleCreate = useCallback(async () => {
+	const handleCreate = useCallback(async (preConvertedFiles?: ConvertedFile[]) => {
 		if (!projectId) {
 			toast.error("Select a project first");
 			return;
@@ -744,7 +744,7 @@ function PromptGroupInner({
 		const willGenerateAIName =
 			!branchNameEdited && !!trimmedPrompt && !linkedPR;
 		const pendingWorkspaceId = crypto.randomUUID();
-		const detachedFiles = attachments.takeFiles();
+		const detachedFiles = preConvertedFiles ? [] : attachments.takeFiles();
 
 		setPendingWorkspace({
 			id: pendingWorkspaceId,
@@ -805,8 +805,8 @@ function PromptGroupInner({
 				}
 			}
 
-			let convertedFiles: ConvertedFile[] = [];
-			if (detachedFiles.length > 0) {
+			let convertedFiles: ConvertedFile[] = preConvertedFiles ?? [];
+			if (!preConvertedFiles && detachedFiles.length > 0) {
 				try {
 					convertedFiles = await Promise.all(
 						detachedFiles.map(async (file) => ({
@@ -1048,9 +1048,19 @@ ${sanitizeText(truncatedBody)}`;
 		workspaceNameEdited,
 	]);
 
-	const handlePromptSubmit = useCallback(() => {
-		void handleCreate();
-	}, [handleCreate]);
+	const handlePromptSubmit = useCallback(
+		(message: { files: Array<{ url: string; mediaType: string; filename?: string }> }) => {
+			const converted: ConvertedFile[] = message.files
+				.filter((f) => f.url)
+				.map((f) => ({
+					data: f.url,
+					mediaType: f.mediaType,
+					filename: f.filename,
+				}));
+			void handleCreate(converted.length > 0 ? converted : undefined);
+		},
+		[handleCreate],
+	);
 
 	useEffect(() => {
 		if (!isNewWorkspaceModalOpen) return;


### PR DESCRIPTION
## Summary
- `handlePromptSubmit` was ignoring the `message` argument from `PromptInput`'s `onSubmit`, so file attachments were lost when submitting via Enter
- Now converts `message.files` (already-available `FileUIPart[]`) into `ConvertedFile[]` and passes them directly to `handleCreate`, bypassing the redundant `attachments.takeFiles()` path

## Test plan
- [x] Open new workspace modal, attach file(s), press Enter to submit — verify files are included in the workspace creation
- [x] Open new workspace modal, attach file(s), press Ctrl/Cmd+Enter — verify files still work via the keyboard shortcut path
- [x] Submit with no attachments — verify no regression

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lost attachments when submitting the New Workspace modal with Enter by wiring `PromptInput`’s `onSubmit(message)` to pass files into `handleCreate`. Converts `message.files` to `ConvertedFile[]`, skipping `attachments.takeFiles()` when provided; also formats `PromptGroup` with Biome.

- **Bug Fixes**
  - Enter now submits with attached files; Ctrl/Cmd+Enter still works.
  - `handleCreate(preConvertedFiles?)` accepts pre-converted files to avoid duplicate detaching.

<sup>Written for commit bfcb26f2987a33c6fa47ed9ab7477360f841bec4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved workspace prompt submission to better handle attachments: callers can now supply already-prepared files to skip extra conversion steps, while existing submit actions still run the original conversion flow. This makes file uploads more flexible and reduces redundant processing in some submission paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->