### PR TITLE
fix(desktop): keep unbound terminal chords inside the PTY

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.test.ts
@@ -1,0 +1,77 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+
+let setupKeyboardHandler!: typeof import("./helpers").setupKeyboardHandler;
+
+beforeAll(async () => {
+	Object.defineProperty(globalThis, "window", {
+		value: {
+			addEventListener() {},
+			removeEventListener() {},
+		},
+		configurable: true,
+	});
+	Object.defineProperty(globalThis, "electronTRPC", {
+		value: {
+			sendMessage() {},
+			onMessage() {},
+		},
+		configurable: true,
+	});
+	setupKeyboardHandler = (await import("./helpers")).setupKeyboardHandler;
+});
+
+function installKeyboardHandler(): (event: KeyboardEvent) => boolean {
+	let currentHandler: ((event: KeyboardEvent) => boolean) | null = null;
+	setupKeyboardHandler({
+		attachCustomKeyEventHandler: (
+			handler: (event: KeyboardEvent) => boolean,
+		) => {
+			currentHandler = handler;
+		},
+	} as never);
+	if (!currentHandler) {
+		throw new Error("Keyboard handler was not attached");
+	}
+	return currentHandler;
+}
+
+function makeKeyEvent(
+	input: Partial<KeyboardEventInit> & { key: string; code?: string },
+): KeyboardEvent {
+	return {
+		type: "keydown",
+		key: input.key,
+		code: input.code ?? `Key${input.key.toUpperCase()}`,
+		ctrlKey: input.ctrlKey ?? false,
+		metaKey: input.metaKey ?? false,
+		altKey: input.altKey ?? false,
+		shiftKey: input.shiftKey ?? false,
+		preventDefault() {},
+		stopPropagation() {},
+	} as KeyboardEvent;
+}
+
+describe("setupKeyboardHandler", () => {
+	it("keeps unbound Ctrl chords inside the terminal", () => {
+		const handler = installKeyboardHandler();
+
+		expect(handler(makeKeyEvent({ key: "b", ctrlKey: true }))).toBe(true);
+		expect(handler(makeKeyEvent({ key: "o", ctrlKey: true }))).toBe(true);
+		expect(handler(makeKeyEvent({ key: "a", ctrlKey: true }))).toBe(true);
+		expect(handler(makeKeyEvent({ key: "e", ctrlKey: true }))).toBe(true);
+	});
+
+	it("still lets registered app hotkeys bubble out of the terminal", () => {
+		const handler = installKeyboardHandler();
+
+		expect(
+			handler(
+				makeKeyEvent({
+					key: "o",
+					code: "KeyO",
+					metaKey: true,
+				}),
+			),
+		).toBe(false);
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -8,7 +8,11 @@ import { WebglAddon } from "@xterm/addon-webgl";
 import type { ITheme } from "@xterm/xterm";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { debounce } from "lodash";
-import { getBinding, isTerminalReservedEvent } from "renderer/hotkeys";
+import {
+	getBinding,
+	isTerminalReservedEvent,
+	resolveHotkeyFromEvent,
+} from "renderer/hotkeys";
 import { electronTrpcClient as trpcClient } from "renderer/lib/trpc-client";
 import { toXtermTheme } from "renderer/stores/theme/utils";
 import {
@@ -674,9 +678,10 @@ export function setupKeyboardHandler(
 			return false;
 		}
 
-		// Any other ctrl/meta combo → let it bubble to document for react-hotkeys-hook
-		if (event.type === "keydown" && (event.metaKey || event.ctrlKey))
-			return false;
+		// Only registered app hotkeys should bubble out of the terminal.
+		// Unbound ctrl/meta chords must stay inside the PTY so shell bindings
+		// and TUIs keep their native behavior.
+		if (resolveHotkeyFromEvent(event) !== null) return false;
 
 		return true;
 	};


### PR DESCRIPTION
## Summary

- only bubble terminal key events when they resolve to a registered app hotkey
- keep unbound `Ctrl` / `Cmd` chords inside xterm so shells and TUIs receive them
- add regression coverage for unbound chords vs registered app shortcuts

## Why

The current terminal keyboard handler correctly preserves a few reserved terminal chords, but it still sends any other modifier chord up to the app layer. That breaks normal PTY behavior for shell bindings and TUIs, including cases like `Ctrl+A`, `Ctrl+E`, `Ctrl+B`, and `Ctrl+O`.

The real distinction is not "modifier chord or not". It is:
- registered app hotkey -> bubble
- terminal-reserved chord -> keep in xterm
- unbound chord -> keep in xterm

## Test plan

- `bun test apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.test.ts`
- `bunx biome check apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.test.ts`

Closes #3337


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unbound Ctrl/Cmd chords now stay inside the terminal PTY so shells and TUIs receive them. Only registered app hotkeys bubble to the app layer, restoring bindings like Ctrl+A/E/B/O.

- **Bug Fixes**
  - Use `resolveHotkeyFromEvent` to bubble only registered shortcuts; keep unbound chords in `xterm`.
  - Add regression tests for unbound chords vs registered app shortcuts.

<sup>Written for commit 77a815e2df7394473e816f66955a89c2b09437d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for keyboard event handling in the terminal, validating both standard key combinations and registered app hotkeys.

* **Bug Fixes**
  * Enhanced keyboard hotkey detection in the terminal, allowing the app to more intelligently distinguish between application hotkeys and terminal-specific keyboard commands for more reliable keyboard behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->