### PR TITLE
fix(desktop): create a workspace after importing a project

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.test.ts
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, mock } from "bun:test";
+import { openProjectsAndWorkspaces } from "./open-projects";
+
+describe("openProjectsAndWorkspaces", () => {
+	it("opens a main workspace for every imported project", async () => {
+		const openNew = mock(async () => [
+			{ id: "project-1", name: "Project One" },
+			{ id: "project-2", name: "Project Two" },
+		]);
+		const openMainRepoWorkspace = mock(async () => ({}));
+		const onProjectOpenError = mock(() => {});
+
+		await openProjectsAndWorkspaces({
+			openNew,
+			openMainRepoWorkspace,
+			onProjectOpenError,
+		});
+
+		expect(openMainRepoWorkspace).toHaveBeenCalledTimes(2);
+		expect(openMainRepoWorkspace).toHaveBeenNthCalledWith(1, {
+			projectId: "project-1",
+		});
+		expect(openMainRepoWorkspace).toHaveBeenNthCalledWith(2, {
+			projectId: "project-2",
+		});
+		expect(onProjectOpenError).not.toHaveBeenCalled();
+	});
+
+	it("continues opening remaining projects when one workspace creation fails", async () => {
+		const openNew = mock(async () => [
+			{ id: "project-1", name: "Project One" },
+			{ id: "project-2", name: "Project Two" },
+		]);
+		const expectedError = new Error("workspace create failed");
+		const openMainRepoWorkspace = mock(
+			async ({ projectId }: { projectId: string }) => {
+				if (projectId === "project-1") {
+					throw expectedError;
+				}
+				return {};
+			},
+		);
+		const onProjectOpenError = mock(() => {});
+
+		await openProjectsAndWorkspaces({
+			openNew,
+			openMainRepoWorkspace,
+			onProjectOpenError,
+		});
+
+		expect(openMainRepoWorkspace).toHaveBeenCalledTimes(2);
+		expect(onProjectOpenError).toHaveBeenCalledTimes(1);
+		expect(onProjectOpenError).toHaveBeenCalledWith(
+			"Project One",
+			expectedError,
+		);
+	});
+});

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -14,6 +14,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { useEffect, useRef } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useOpenProject } from "renderer/react-query/projects";
+import { useOpenMainRepoWorkspace } from "renderer/react-query/workspaces";
 import {
 	useCloseNewWorkspaceModal,
 	useNewWorkspaceModalOpen,
@@ -24,6 +25,7 @@ import {
 	NewWorkspaceModalDraftProvider,
 	useNewWorkspaceModalDraft,
 } from "./NewWorkspaceModalDraftContext";
+import { openProjectsAndWorkspaces } from "./open-projects";
 
 /** Clears the PromptInputProvider text & attachments when the draft resets. */
 function PromptInputResetSync() {
@@ -47,6 +49,7 @@ export function NewWorkspaceModal() {
 	const closeModal = useCloseNewWorkspaceModal();
 	const navigate = useNavigate();
 	const { openNew } = useOpenProject();
+	const openMainRepoWorkspace = useOpenMainRepoWorkspace();
 	const preSelectedProjectId = usePreSelectedProjectId();
 
 	// Prevents AgentSelect from flashing "No agent" while presets load after refresh.
@@ -55,7 +58,18 @@ export function NewWorkspaceModal() {
 	const handleImportRepo = async () => {
 		closeModal();
 		try {
-			await openNew();
+			await openProjectsAndWorkspaces({
+				openNew,
+				openMainRepoWorkspace: openMainRepoWorkspace.mutateAsync,
+				onProjectOpenError: (projectName, error) => {
+					toast.error(`Failed to open ${projectName}`, {
+						description:
+							error instanceof Error
+								? error.message
+								: "Failed to create workspace",
+					});
+				},
+			});
 		} catch (error) {
 			toast.error("Failed to open project", {
 				description:

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/open-projects.ts
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/open-projects.ts
@@ -1,0 +1,20 @@
+export async function openProjectsAndWorkspaces({
+	openNew,
+	openMainRepoWorkspace,
+	onProjectOpenError,
+}: {
+	openNew: () => Promise<Array<{ id: string; name: string }>>;
+	openMainRepoWorkspace: (input: { projectId: string }) => Promise<unknown>;
+	onProjectOpenError: (projectName: string, error: unknown) => void;
+}): Promise<void> {
+	const projects = await openNew();
+	for (const project of projects) {
+		try {
+			await openMainRepoWorkspace({
+				projectId: project.id,
+			});
+		} catch (error) {
+			onProjectOpenError(project.name, error);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- create/open the main repo workspace for each project imported from the New Workspace modal
- keep the import flow resilient when one workspace creation fails
- add regression coverage around the modal import helper

## Why

`New Workspace -> Open project` imported the project, but it did not follow through with the main-workspace creation step used elsewhere in the app. That left the imported project without a visible workspace in the sidebar until the app was restarted.

This change makes the modal import path match the existing open-project behavior by immediately creating/opening the main repo workspace for every imported project.

## Test plan

- `bun test apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.test.ts`
- `bunx biome check apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.test.ts apps/desktop/src/renderer/components/NewWorkspaceModal/open-projects.ts`

Closes #3336


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Importing a project from the New Workspace modal now creates/opens its main repo workspace so it shows in the sidebar immediately. Aligns the modal flow with the existing open-project behavior and fixes Linear #3336.

- **Bug Fixes**
  - Create/open the main workspace for each imported project.
  - Keep importing other projects if one workspace creation fails; show a toast error per failure.
  - Add `open-projects.ts` helper and regression tests for the modal import path.

<sup>Written for commit 0689f0900bb54773dd4bcea10567525af98d88fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced project import error handling to display specific error messages for each project that fails to open, allowing the import process to continue for remaining projects.

* **Tests**
  * Added test coverage for project import functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->