### PR TITLE
fix(workspace-client): release cached clients on unmount

### DIFF
--- a/packages/workspace-client/src/providers/WorkspaceClientProvider/WorkspaceClientProvider.test.ts
+++ b/packages/workspace-client/src/providers/WorkspaceClientProvider/WorkspaceClientProvider.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { __workspaceClientProviderTestUtils } from "./WorkspaceClientProvider";
+
+const TEST_HOST_URL = "http://127.0.0.1:43123";
+
+describe("Workspace client cache lifecycle", () => {
+	afterEach(() => {
+		__workspaceClientProviderTestUtils.resetCache();
+	});
+
+	it("reuses the same cache entry for the same workspace key", () => {
+		const first = __workspaceClientProviderTestUtils.getWorkspaceClients(
+			"workspace-a",
+			TEST_HOST_URL,
+		);
+		const second = __workspaceClientProviderTestUtils.getWorkspaceClients(
+			"workspace-a",
+			TEST_HOST_URL,
+		);
+
+		expect(second).toBe(first);
+		expect(__workspaceClientProviderTestUtils.getCacheSize()).toBe(1);
+	});
+
+	it("releases cached clients once the refcount reaches zero", () => {
+		const clients = __workspaceClientProviderTestUtils.getWorkspaceClients(
+			"workspace-a",
+			TEST_HOST_URL,
+		);
+		const other = __workspaceClientProviderTestUtils.getWorkspaceClients(
+			"workspace-b",
+			TEST_HOST_URL,
+		);
+
+		clients.refCount = 2;
+		other.refCount = 1;
+		expect(__workspaceClientProviderTestUtils.getCacheSize()).toBe(2);
+
+		__workspaceClientProviderTestUtils.releaseWorkspaceClients(
+			clients.clientKey,
+		);
+		expect(__workspaceClientProviderTestUtils.getCacheSize()).toBe(2);
+
+		__workspaceClientProviderTestUtils.releaseWorkspaceClients(
+			clients.clientKey,
+		);
+		expect(__workspaceClientProviderTestUtils.getCacheSize()).toBe(1);
+
+		__workspaceClientProviderTestUtils.releaseWorkspaceClients(other.clientKey);
+		expect(__workspaceClientProviderTestUtils.getCacheSize()).toBe(0);
+	});
+});

--- a/packages/workspace-client/src/providers/WorkspaceClientProvider/WorkspaceClientProvider.tsx
+++ b/packages/workspace-client/src/providers/WorkspaceClientProvider/WorkspaceClientProvider.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { httpBatchLink } from "@trpc/client";
-import { createContext, type ReactNode, useContext } from "react";
+import { createContext, type ReactNode, useContext, useEffect } from "react";
 import superjson from "superjson";
 import { workspaceTrpc } from "../../workspace-trpc";
 
@@ -22,10 +22,12 @@ interface WorkspaceClientProviderProps {
 }
 
 interface WorkspaceClients {
+	clientKey: string;
 	hostUrl: string;
 	queryClient: QueryClient;
 	trpcClient: ReturnType<typeof workspaceTrpc.createClient>;
 	getWsToken: () => string | null;
+	refCount: number;
 }
 
 const workspaceClientsCache = new Map<string, WorkspaceClients>();
@@ -67,14 +69,37 @@ function getWorkspaceClients(
 
 	const getWsToken = wsToken ?? (() => null);
 	const clients: WorkspaceClients = {
+		clientKey,
 		hostUrl,
 		queryClient,
 		trpcClient,
 		getWsToken,
+		refCount: 0,
 	};
 	workspaceClientsCache.set(clientKey, clients);
 	return clients;
 }
+
+function releaseWorkspaceClients(clientKey: string): void {
+	const cached = workspaceClientsCache.get(clientKey);
+	if (!cached) return;
+	cached.refCount = Math.max(0, cached.refCount - 1);
+	if (cached.refCount > 0) return;
+	cached.queryClient.clear();
+	workspaceClientsCache.delete(clientKey);
+}
+
+export const __workspaceClientProviderTestUtils = {
+	getWorkspaceClients,
+	releaseWorkspaceClients,
+	getCacheSize: () => workspaceClientsCache.size,
+	resetCache: () => {
+		for (const clients of workspaceClientsCache.values()) {
+			clients.queryClient.clear();
+		}
+		workspaceClientsCache.clear();
+	},
+};
 
 export function WorkspaceClientProvider({
 	cacheKey,
@@ -84,6 +109,14 @@ export function WorkspaceClientProvider({
 	children,
 }: WorkspaceClientProviderProps) {
 	const clients = getWorkspaceClients(cacheKey, hostUrl, headers, wsToken);
+
+	useEffect(() => {
+		clients.refCount++;
+		return () => {
+			releaseWorkspaceClients(clients.clientKey);
+		};
+	}, [clients]);
+
 	const contextValue: WorkspaceClientContextValue = {
 		hostUrl: clients.hostUrl,
 		queryClient: clients.queryClient,


### PR DESCRIPTION
## Summary

- add ref-counted cleanup for cached workspace tRPC/query clients
- clear and evict a cache entry once the last provider using it unmounts
- add regression coverage for cache reuse and release behavior

## Why

`WorkspaceClientProvider` caches a `QueryClient`/tRPC client pair per workspace key and host URL, but the cache entry was never released. Over time, opening and switching workspaces could accumulate stale `QueryClient` instances indefinitely.

This change keeps the cache reuse behavior, but it also gives each cached client a refcount and clears/removes it when the last provider unmounts.

## Test plan

- `bun test packages/workspace-client/src/providers/WorkspaceClientProvider/WorkspaceClientProvider.test.ts`
- `bunx biome check packages/workspace-client/src/providers/WorkspaceClientProvider/WorkspaceClientProvider.tsx packages/workspace-client/src/providers/WorkspaceClientProvider/WorkspaceClientProvider.test.ts`

Related: #3049


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Releases cached workspace `QueryClient`/tRPC clients when the last `WorkspaceClientProvider` unmounts to prevent memory growth. Keeps cache reuse; adds ref counting and clears/evicts entries when the count reaches zero.

- **Bug Fixes**
  - Added ref-counted lifecycle for cached clients (keyed by workspace and host).
  - On mount, increment refcount; on unmount, decrement, clear `QueryClient`, and remove from cache at zero.
  - Added test utilities and regression tests for cache reuse and release behavior.

<sup>Written for commit 8ae86c9e51266a4398076699ea04af7f44d2f342. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite for workspace client cache lifecycle management and cleanup validation.

* **Improvements**
  * Enhanced workspace client cache with automatic lifecycle-based resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->