### PR TITLE
Fix/patched terminal recovery

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,6 +1,7 @@
 [mcp_servers.superset]
 type = "sse"
 url = "https://api.superset.sh/api/agent/mcp"
+enabled = false
 
 [mcp_servers.expo-mcp]
 type = "sse"
@@ -10,20 +11,25 @@ enabled = false
 [mcp_servers.maestro]
 command = "maestro"
 args = ["mcp"]
+enabled = false
 
 [mcp_servers.neon]
 type = "sse"
 url = "https://mcp.neon.tech/mcp"
+enabled = false
 
 [mcp_servers.linear]
 type = "sse"
 url = "https://mcp.linear.app/mcp"
+enabled = false
 
 [mcp_servers.sentry]
 type = "sse"
 url = "https://mcp.sentry.dev/mcp"
+enabled = false
 
 
 [mcp_servers.desktop-automation]
 command = "bun"
 args = ["run", "packages/desktop-mcp/src/bin.ts"]
+enabled = false

--- a/LOCAL_PATCHES.md
+++ b/LOCAL_PATCHES.md
@@ -1,0 +1,32 @@
+# Superset Local Investigation Notes
+
+This directory contains a workspace-local copy of the Superset Desktop source used to investigate terminal/TUI corruption and repaint issues.
+
+## Local-only patches kept here
+
+These changes were useful for local validation but are not intended to be sent upstream as-is:
+
+- local packaging identity changes for `Superset Patched.app`
+- local app-home / userData isolation experiments
+- forced DOM renderer in terminal helpers
+- local sidebar sync fix after `Open project`
+
+## Upstream candidate patches
+
+The current upstream candidate focuses on the terminal visibility/focus restore path:
+
+- `apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts`
+- `apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.test.ts`
+
+## Existing local terminal-host patch context
+
+This copy also includes the `Session.attach()` snapshot/socket ordering fix and tests:
+
+- `apps/desktop/src/main/terminal-host/session.ts`
+- `apps/desktop/src/main/terminal-host/session.test.ts`
+- `apps/desktop/src/main/terminal-host/session-attach-overlap.test.ts`
+
+That area appears to overlap with the already-open upstream PRs:
+
+- #3081
+- #3310

--- a/UPSTREAM_ISSUE_terminal_refocus_repaint.md
+++ b/UPSTREAM_ISSUE_terminal_refocus_repaint.md
@@ -1,0 +1,62 @@
+## Summary
+
+Returning to a terminal pane after switching app focus / window / workspace can still leave the terminal in a partially stale visual state even after the underlying text content has recovered.
+
+In my local repro with Codex CLI running inside Superset Desktop on macOS, the most visible symptom was that the TUI content could repaint, but some terminal chrome remained stale for a beat longer than the text layer. In practice this showed up as blank strips / stale repaint artifacts, and in some runs the Codex input box styling lagged behind the recovered content.
+
+This looks like a separate renderer lifecycle problem from the attach-time snapshot/socket overlap bug. The pane content itself may no longer be duplicated or shifted, but a single focus-time `fit() + refresh()` pass can still miss the final settled layout after the window becomes visible again.
+
+## Environment
+
+- Superset Desktop: built from current `main` as of 2026-04-10
+- macOS: Apple Silicon
+- Repro app inside terminal: Codex CLI
+
+## Reproduction
+
+1. Open a terminal pane in Superset Desktop.
+2. Start Codex CLI or another full-screen / dense TUI.
+3. Switch away from the app or switch workspaces/tabs long enough for the pane to fully unmount/occlude.
+4. Return to the same terminal pane.
+5. Observe that the text content may recover, but the terminal can still briefly retain stale visual state from before focus returned.
+
+## Expected behavior
+
+When the terminal becomes visible again, the entire pane should repaint into a fully consistent final state in one restore cycle, including terminal background/chrome and TUI styling.
+
+## Actual behavior
+
+- content can recover first
+- stale blank space or stale visual styling can remain briefly afterward
+- a single recovery pass on `window.focus` / `visibilitychange` does not always seem to be enough once layout finishes settling
+
+## Suspected area
+
+`apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts`
+
+Specifically the focus / visibility recovery path around:
+
+- `clearTextureAtlas()`
+- `fitAddon.fit()`
+- `xterm.refresh()`
+- resize reporting after refocus
+
+My local patched build stopped reproducing once I changed the restore path to run a short recovery burst instead of a single pass:
+
+- immediately on visibility/focus restore
+- again after ~120ms
+- again after ~260ms
+
+That suggests the terminal container is still settling for a short period after focus is restored, so a single repaint can happen too early.
+
+## Related issues
+
+- #1830
+- #1873
+- #2507
+- #2968
+- #3080
+- #3208
+- #3309
+
+I am opening a PR with the small recovery-burst change that fixed the repro locally.

--- a/UPSTREAM_PR_terminal_refocus_repaint.md
+++ b/UPSTREAM_PR_terminal_refocus_repaint.md
@@ -1,0 +1,38 @@
+## Summary
+
+- add a short recovery burst when a terminal becomes visible again after focus / visibility changes
+- keep the existing throttle logic, but retry repaint/fit twice after the initial restore attempt
+- add a regression test that models the new burst behavior
+
+## Why
+
+The existing terminal restore path already does the right kinds of work on refocus:
+
+- clear the WebGL texture atlas
+- re-fit the terminal to its container
+- force an xterm refresh
+
+The remaining problem is timing. In practice, one refocus recovery can still happen slightly before the terminal container has fully settled after the app/window/workspace becomes visible again. That leaves stale blank space or stale terminal/TUI styling until some later repaint happens.
+
+Running a short recovery burst fixed the repro locally:
+
+- immediate restore
+- second restore after ~120ms
+- third restore after ~260ms
+
+This keeps the change small and local to the focus/visibility recovery path, while giving xterm another chance to repaint once layout has actually stabilized.
+
+## Test plan
+
+- `bun test ./src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.test.ts`
+
+## Related
+
+- Closes #3321
+- Related: #1830
+- Related: #1873
+- Related: #2507
+- Related: #2968
+- Related: #3080
+- Related: #3208
+- Related: #3309

--- a/apps/desktop/electron-builder.ts
+++ b/apps/desktop/electron-builder.ts
@@ -14,13 +14,13 @@ import {
 
 const currentYear = new Date().getFullYear();
 const author = pkg.author?.name ?? pkg.author;
-const productName = pkg.productName;
+const productName = "Superset Patched";
 const macIconPath = join(pkg.resources, "build/icons/icon.icns");
 const linuxIconPath = join(pkg.resources, "build/icons");
 const winIconPath = join(pkg.resources, "build/icons/icon.ico");
 
 const config: Configuration = {
-	appId: "com.superset.desktop",
+	appId: "com.superset.desktop.patched",
 	productName,
 	copyright: `Copyright © ${currentYear} — ${author}`,
 	electronVersion: pkg.devDependencies.electron.replace(/^\^/, ""),
@@ -91,9 +91,9 @@ const config: Configuration = {
 		...(existsSync(macIconPath) ? { icon: macIconPath } : {}),
 		category: "public.app-category.utilities",
 		target: "default",
-		hardenedRuntime: true,
+		hardenedRuntime: false,
 		gatekeeperAssess: false,
-		notarize: true,
+		notarize: false,
 		entitlements: join(pkg.resources, "build/entitlements.mac.plist"),
 		entitlementsInherit: join(
 			pkg.resources,

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -251,6 +251,17 @@ export default defineConfig({
 			outDir: resolve(devPath, "renderer"),
 
 			rollupOptions: {
+				output: {
+					manualChunks(id) {
+						if (
+							id.includes("/better-auth/") ||
+							id.includes("/@better-auth/") ||
+							id.includes("/packages/auth/src/client.ts")
+						) {
+							return "better-auth-client";
+						}
+					},
+				},
 				plugins: [
 					injectProcessEnvPlugin({
 						NODE_ENV: "production",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -251,6 +251,7 @@
 		"rollup-plugin-inject-process-env": "^1.3.1",
 		"tailwindcss": "^4.1.18",
 		"tsx": "^4.19.3",
+		"turbo": "^2.9.3",
 		"typescript": "^5.9.3",
 		"vite": "^7.1.3",
 		"vite-tsconfig-paths": "^5.1.4"

--- a/apps/desktop/src/lib/trpc/routers/window.ts
+++ b/apps/desktop/src/lib/trpc/routers/window.ts
@@ -26,12 +26,12 @@ export const createWindowRouter = (getWindow: () => BrowserWindow | null) => {
 			return { success: true, isMaximized: window.isMaximized() };
 		}),
 
-		close: publicProcedure.mutation(() => {
-			const window = getWindow();
-			if (!window) return { success: false };
-			window.close();
-			return { success: true };
-		}),
+			close: publicProcedure.mutation(() => {
+				const window = getWindow();
+				if (!window) return { success: false };
+				window.close();
+				return { success: true };
+			}),
 
 		isMaximized: publicProcedure.query(() => {
 			const window = getWindow();

--- a/apps/desktop/src/lib/window-loader.ts
+++ b/apps/desktop/src/lib/window-loader.ts
@@ -1,3 +1,4 @@
+import { pathToFileURL } from "node:url";
 import type { BrowserWindow } from "electron";
 import { env } from "shared/env.shared";
 
@@ -25,10 +26,14 @@ export function registerRoute(props: {
 		console.log("[window-loader] Loading development URL:", url);
 		props.browserWindow.loadURL(url);
 	} else {
-		// Production: load from file with hash routing
-		// TanStack Router uses hash-based routing, so we always start at #/
+		// Production: explicitly construct the file:// URL with hash routing.
+		// Electron's loadFile(..., { hash }) can transiently resolve to Chromium's
+		// internal error page for packaged app.asar paths, leaving a white window.
+		const url = pathToFileURL(props.htmlFile);
+		url.hash = "/";
 		console.log("[window-loader] Loading file:", props.htmlFile);
-		props.browserWindow.loadFile(props.htmlFile, { hash: "/" });
+		console.log("[window-loader] Loading production URL:", url.toString());
+		props.browserWindow.loadURL(url.toString());
 	}
 
 	// Log successful loads

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -22,8 +22,11 @@ import {
 	PROTOCOL_SCHEME,
 } from "shared/constants";
 import { setupAgentHooks } from "./lib/agent-setup";
+import {
+	resetPatchedBrowserStateIfNeeded,
+	SUPERSET_HOME_DIR,
+} from "./lib/app-environment";
 import { initAppState } from "./lib/app-state";
-import { SUPERSET_HOME_DIR } from "./lib/app-environment";
 import { requestAppleEventsAccess } from "./lib/apple-events-permission";
 import { setupAutoUpdater } from "./lib/auto-updater";
 import { resolveDevWorkspaceName } from "./lib/dev-workspace-name";
@@ -50,6 +53,7 @@ void applyShellEnvToProcess().catch((error) => {
 // Keep userData and the app's own home directory aligned so single-instance
 // locks and process-scoped state do not collide with the stock Superset app.
 app.setPath("userData", SUPERSET_HOME_DIR);
+resetPatchedBrowserStateIfNeeded();
 
 // Dev mode: label the app with the workspace name so multiple worktrees are distinguishable
 if (IS_DEV) {
@@ -292,9 +296,9 @@ if (!gotTheLock) {
 		}
 	});
 
-	(async () => {
-		await app.whenReady();
-		registerWithMacOSNotificationCenter();
+		(async () => {
+			await app.whenReady();
+			registerWithMacOSNotificationCenter();
 		requestAppleEventsAccess();
 
 		// Must register on both default session and the app's custom partition
@@ -376,6 +380,6 @@ if (!gotTheLock) {
 			pendingDeepLinkUrl = null;
 		}
 
-		appReady = true;
-	})();
+			appReady = true;
+		})();
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -23,6 +23,7 @@ import {
 } from "shared/constants";
 import { setupAgentHooks } from "./lib/agent-setup";
 import { initAppState } from "./lib/app-state";
+import { SUPERSET_HOME_DIR } from "./lib/app-environment";
 import { requestAppleEventsAccess } from "./lib/apple-events-permission";
 import { setupAutoUpdater } from "./lib/auto-updater";
 import { resolveDevWorkspaceName } from "./lib/dev-workspace-name";
@@ -45,6 +46,10 @@ const IS_DEV = process.env.NODE_ENV === "development";
 void applyShellEnvToProcess().catch((error) => {
 	console.error("[main] Failed to apply shell environment:", error);
 });
+
+// Keep userData and the app's own home directory aligned so single-instance
+// locks and process-scoped state do not collide with the stock Superset app.
+app.setPath("userData", SUPERSET_HOME_DIR);
 
 // Dev mode: label the app with the workspace name so multiple worktrees are distinguishable
 if (IS_DEV) {

--- a/apps/desktop/src/main/lib/app-environment.test.ts
+++ b/apps/desktop/src/main/lib/app-environment.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import {
+	isPatchedDesktopBuild,
+	resetPatchedBrowserStateIfNeeded,
+} from "./app-environment";
+
+describe("app-environment patched browser state reset", () => {
+	const tempDirs: string[] = [];
+
+	afterEach(() => {
+		for (const dir of tempDirs) {
+			rmSync(dir, { recursive: true, force: true });
+		}
+		tempDirs.length = 0;
+	});
+
+	it("detects patched desktop builds from the app bundle path", () => {
+		expect(
+			isPatchedDesktopBuild(
+				"/Applications/Superset Patched.app/Contents/MacOS/Superset Patched",
+			),
+		).toBe(true);
+		expect(
+			isPatchedDesktopBuild(
+				"/Applications/Superset.app/Contents/MacOS/Superset",
+			),
+		).toBe(false);
+	});
+
+	it("clears browser-only persisted state once for patched builds", () => {
+		const homeDir = mkdtempSync("/tmp/superset-patched-browser-reset-");
+		tempDirs.push(homeDir);
+		mkdirSync(join(homeDir, "Local Storage"), { recursive: true });
+		mkdirSync(join(homeDir, "Partitions"), { recursive: true });
+		writeFileSync(join(homeDir, "Preferences"), '{"foo":true}', "utf8");
+		writeFileSync(join(homeDir, "app-state.json"), '{"tabsState":{}}', "utf8");
+
+		resetPatchedBrowserStateIfNeeded(
+			homeDir,
+			"/Applications/Superset Patched.app/Contents/MacOS/Superset Patched",
+		);
+
+		expect(existsSync(join(homeDir, "Local Storage"))).toBe(false);
+		expect(existsSync(join(homeDir, "Partitions"))).toBe(false);
+		expect(existsSync(join(homeDir, "Preferences"))).toBe(false);
+		expect(existsSync(join(homeDir, "app-state.json"))).toBe(true);
+		expect(
+			readFileSync(join(homeDir, ".patched-browser-state-reset-v1"), "utf8")
+				.length,
+		).toBeGreaterThan(0);
+	});
+});

--- a/apps/desktop/src/main/lib/app-environment.ts
+++ b/apps/desktop/src/main/lib/app-environment.ts
@@ -1,9 +1,30 @@
-import { chmodSync, existsSync, mkdirSync } from "node:fs";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	rmSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { SUPERSET_DIR_NAME } from "shared/constants";
 
 const SUPERSET_HOME_DIR_ENV = "SUPERSET_HOME_DIR";
+const PATCHED_BROWSER_STATE_MARKER = ".patched-browser-state-reset-v1";
+const PATCHED_BROWSER_STATE_PATHS = [
+	"Cache",
+	"Code Cache",
+	"blob_storage",
+	"Local Storage",
+	"Partitions",
+	"Shared Dictionary",
+	"SharedStorage",
+	"Trust Tokens",
+	"Trust Tokens-journal",
+	"Network Persistent State",
+	"Preferences",
+] as const;
 
 function getDefaultSupersetHomeDir(): string {
 	if (process.execPath.includes("Superset Patched.app")) {
@@ -34,6 +55,52 @@ export function ensureSupersetHomeDirExists(): void {
 		console.warn(
 			"[app-environment] Failed to chmod Superset home dir (best-effort):",
 			SUPERSET_HOME_DIR,
+			error,
+		);
+	}
+}
+
+export function isPatchedDesktopBuild(
+	execPath: string = process.execPath,
+): boolean {
+	return execPath.includes("Superset Patched.app");
+}
+
+export function resetPatchedBrowserStateIfNeeded(
+	homeDir: string = SUPERSET_HOME_DIR,
+	execPath: string = process.execPath,
+): void {
+	if (!isPatchedDesktopBuild(execPath)) return;
+
+	const markerPath = join(homeDir, PATCHED_BROWSER_STATE_MARKER);
+	if (existsSync(markerPath)) return;
+
+	ensureSupersetHomeDirExists();
+
+	for (const relativePath of PATCHED_BROWSER_STATE_PATHS) {
+		const targetPath = join(homeDir, relativePath);
+		if (!existsSync(targetPath)) continue;
+		try {
+			rmSync(targetPath, { recursive: true, force: true });
+		} catch {
+			try {
+				unlinkSync(targetPath);
+			} catch (error) {
+				console.warn(
+					"[app-environment] Failed to reset patched browser state:",
+					targetPath,
+					error,
+				);
+			}
+		}
+	}
+
+	try {
+		writeFileSync(markerPath, `${new Date().toISOString()}\n`, "utf8");
+	} catch (error) {
+		console.warn(
+			"[app-environment] Failed to write patched browser state marker:",
+			markerPath,
 			error,
 		);
 	}

--- a/apps/desktop/src/main/lib/app-environment.ts
+++ b/apps/desktop/src/main/lib/app-environment.ts
@@ -5,8 +5,15 @@ import { SUPERSET_DIR_NAME } from "shared/constants";
 
 const SUPERSET_HOME_DIR_ENV = "SUPERSET_HOME_DIR";
 
+function getDefaultSupersetHomeDir(): string {
+	if (process.execPath.includes("Superset Patched.app")) {
+		return join(homedir(), ".superset-patched");
+	}
+	return join(homedir(), SUPERSET_DIR_NAME);
+}
+
 export const SUPERSET_HOME_DIR =
-	process.env[SUPERSET_HOME_DIR_ENV] || join(homedir(), SUPERSET_DIR_NAME);
+	process.env[SUPERSET_HOME_DIR_ENV] || getDefaultSupersetHomeDir();
 process.env[SUPERSET_HOME_DIR_ENV] = SUPERSET_HOME_DIR;
 
 export const SUPERSET_HOME_DIR_MODE = 0o700;

--- a/apps/desktop/src/main/lib/terminal-host/client.ts
+++ b/apps/desktop/src/main/lib/terminal-host/client.ts
@@ -70,7 +70,8 @@ enum ConnectionState {
 const DEBUG_CLIENT = process.env.SUPERSET_TERMINAL_DEBUG === "1";
 
 // Get from shared constants for multi-worktree support (imported at top of file)
-const SUPERSET_HOME_DIR = join(homedir(), SUPERSET_DIR_NAME);
+const SUPERSET_HOME_DIR =
+	process.env.SUPERSET_HOME_DIR || join(homedir(), SUPERSET_DIR_NAME);
 
 const SOCKET_PATH = join(SUPERSET_HOME_DIR, "terminal-host.sock");
 const TOKEN_PATH = join(SUPERSET_HOME_DIR, "terminal-host.token");

--- a/apps/desktop/src/main/terminal-host/index.ts
+++ b/apps/desktop/src/main/terminal-host/index.ts
@@ -57,7 +57,8 @@ const DAEMON_VERSION = "1.0.0";
 
 // SUPERSET_DIR_NAME is imported from shared/constants for multi-worktree support
 // This allows workspace-specific home directories (e.g., ~/.superset-my-feature)
-const SUPERSET_HOME_DIR = join(homedir(), SUPERSET_DIR_NAME);
+const SUPERSET_HOME_DIR =
+	process.env.SUPERSET_HOME_DIR || join(homedir(), SUPERSET_DIR_NAME);
 
 // Socket and token paths
 const SOCKET_PATH = join(SUPERSET_HOME_DIR, "terminal-host.sock");

--- a/apps/desktop/src/main/terminal-host/session-attach-overlap.test.ts
+++ b/apps/desktop/src/main/terminal-host/session-attach-overlap.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+
+import { createFrameHeader, PtySubprocessIpcType } from "./pty-subprocess-ipc";
+import "./xterm-env-polyfill";
+
+const { Session } = await import("./session");
+
+class FakeStdout extends EventEmitter {
+	pause(): this {
+		return this;
+	}
+
+	resume(): this {
+		return this;
+	}
+}
+
+class FakeStdin extends EventEmitter {
+	readonly writes: Buffer[] = [];
+
+	write(chunk: Buffer | string): boolean {
+		this.writes.push(
+			Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, "utf8"),
+		);
+		return true;
+	}
+}
+
+class FakeChildProcess extends EventEmitter {
+	readonly stdout = new FakeStdout();
+	readonly stdin = new FakeStdin();
+	pid = 4242;
+
+	kill(): boolean {
+		return true;
+	}
+}
+
+function sendFrame(
+	proc: FakeChildProcess,
+	type: PtySubprocessIpcType,
+	payload?: Buffer,
+): void {
+	const buf = payload ?? Buffer.alloc(0);
+	const header = createFrameHeader(type, buf.length);
+	proc.stdout.emit("data", Buffer.concat([header, buf]));
+}
+
+function sendReady(proc: FakeChildProcess): void {
+	sendFrame(proc, PtySubprocessIpcType.Ready);
+}
+
+function sendSpawned(proc: FakeChildProcess, pid = 1234): void {
+	const buf = Buffer.allocUnsafe(4);
+	buf.writeUInt32LE(pid, 0);
+	sendFrame(proc, PtySubprocessIpcType.Spawned, buf);
+}
+
+function sendData(proc: FakeChildProcess, data: string): void {
+	sendFrame(proc, PtySubprocessIpcType.Data, Buffer.from(data, "utf8"));
+}
+
+function spawnAndReadySession(session: InstanceType<typeof Session>): void {
+	session.spawn({
+		cwd: "/tmp",
+		cols: 80,
+		rows: 24,
+		env: { PATH: "/usr/bin" },
+	});
+	sendReady(fakeChildProcess);
+	sendSpawned(fakeChildProcess);
+}
+
+let fakeChildProcess: FakeChildProcess;
+
+beforeEach(() => {
+	fakeChildProcess = new FakeChildProcess();
+});
+
+describe("Session attach snapshot/broadcast overlap", () => {
+	it("does not stream in-flight attach data before the snapshot resolves", async () => {
+		const session = new Session({
+			sessionId: "session-overlap",
+			workspaceId: "workspace-1",
+			paneId: "pane-1",
+			tabId: "tab-1",
+			cols: 80,
+			rows: 24,
+			cwd: "/tmp",
+			shell: "/bin/bash",
+			spawnProcess: () => fakeChildProcess as unknown as ChildProcess,
+		});
+
+		spawnAndReadySession(session);
+		sendData(fakeChildProcess, "line-before-attach\r\n");
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		await new Promise<void>((resolve) => setImmediate(resolve));
+
+		let resolveBoundary!: (value: boolean) => void;
+		const boundaryPromise = new Promise<boolean>((resolve) => {
+			resolveBoundary = resolve;
+		});
+		(
+			session as unknown as {
+				flushToSnapshotBoundary: (_timeoutMs: number) => Promise<boolean>;
+			}
+		).flushToSnapshotBoundary = () => boundaryPromise;
+
+		const socketWrites: string[] = [];
+		const socket = {
+			write(message: string) {
+				socketWrites.push(message);
+				return true;
+			},
+		} as unknown as import("node:net").Socket;
+
+		const attachPromise = session.attach(socket);
+		await Promise.resolve();
+
+		sendData(fakeChildProcess, "data-during-attach\r\n");
+
+		const dataBroadcastsDuringAttach = socketWrites.filter((message) =>
+			message.includes("data-during-attach"),
+		);
+		expect(dataBroadcastsDuringAttach).toHaveLength(0);
+
+		resolveBoundary(true);
+		const snapshot = await attachPromise;
+		expect(snapshot.snapshotAnsi).toContain("line-before-attach");
+
+		sendData(fakeChildProcess, "data-after-attach\r\n");
+		const postAttachBroadcasts = socketWrites.filter((message) =>
+			message.includes("data-after-attach"),
+		);
+		expect(postAttachBroadcasts).toHaveLength(1);
+	});
+
+	it("does not leak a canceled attach into attachedClients", async () => {
+		const session = new Session({
+			sessionId: "session-overlap-cancel",
+			workspaceId: "workspace-1",
+			paneId: "pane-1",
+			tabId: "tab-1",
+			cols: 80,
+			rows: 24,
+			cwd: "/tmp",
+			shell: "/bin/bash",
+			spawnProcess: () => fakeChildProcess as unknown as ChildProcess,
+		});
+
+		spawnAndReadySession(session);
+
+		let resolveBoundary!: (value: boolean) => void;
+		const boundaryPromise = new Promise<boolean>((resolve) => {
+			resolveBoundary = resolve;
+		});
+		(
+			session as unknown as {
+				flushToSnapshotBoundary: (_timeoutMs: number) => Promise<boolean>;
+			}
+		).flushToSnapshotBoundary = () => boundaryPromise;
+
+		const socket = {
+			write() {
+				return true;
+			},
+		} as unknown as import("node:net").Socket;
+
+		const controller = new AbortController();
+		const attachPromise = session.attach(socket, controller.signal);
+		await Promise.resolve();
+
+		controller.abort();
+		await expect(attachPromise).rejects.toThrow();
+		expect(session.clientCount).toBe(0);
+
+		resolveBoundary(true);
+	});
+});

--- a/apps/desktop/src/main/terminal-host/session.test.ts
+++ b/apps/desktop/src/main/terminal-host/session.test.ts
@@ -246,10 +246,11 @@ describe("Terminal Host Session shell args", () => {
 
 		firstController.abort();
 		await expect(firstAttach).rejects.toThrow(TERMINAL_ATTACH_CANCELED_MESSAGE);
-		expect(session.clientCount).toBe(1);
+		expect(session.clientCount).toBe(0);
 
 		resolveBoundary(true);
 		await expect(secondAttach).resolves.toBeDefined();
+		expect(session.clientCount).toBe(1);
 
 		(
 			session as unknown as {

--- a/apps/desktop/src/main/terminal-host/session.ts
+++ b/apps/desktop/src/main/terminal-host/session.ts
@@ -808,17 +808,16 @@ export class Session {
 		}
 		throwIfAborted(signal);
 
-		const attachedClient: AttachedClient = {
-			socket,
-			attachedAt: Date.now(),
-			attachToken: Symbol("attach"),
-		};
-		this.attachedClients.set(socket, attachedClient);
 		this.lastAttachedAt = new Date();
 
 		// Use snapshot boundary flush for consistent state with continuous output.
 		// This ensures we capture all data received BEFORE attach was called,
 		// even if new data continues to arrive during the flush.
+		//
+		// Register the client only after the snapshot is captured. If the socket
+		// is added before the async flush/serialize window, in-flight PTY output
+		// is both broadcast as stream data and included in the snapshot, which
+		// causes the renderer to write overlapping content twice on reattach.
 		try {
 			const reachedBoundary = await raceWithAbort(
 				this.flushToSnapshotBoundary(ATTACH_FLUSH_TIMEOUT_MS),
@@ -833,10 +832,16 @@ export class Session {
 
 			await raceWithAbort(this.emulator.flush(), signal);
 			throwIfAborted(signal);
-			return this.emulator.getSnapshot();
+			const snapshot = this.emulator.getSnapshot();
+			const attachedClient: AttachedClient = {
+				socket,
+				attachedAt: Date.now(),
+				attachToken: Symbol("attach"),
+			};
+			this.attachedClients.set(socket, attachedClient);
+			return snapshot;
 		} catch (error) {
 			if (isTerminalAttachCanceledError(error)) {
-				this.detachAttachedClient(socket, attachedClient);
 				throw error;
 			}
 			throw error;

--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -266,14 +266,14 @@ export async function MainWindow() {
 		}
 
 		if (!hasCompletedFirstLoad) {
-			if (initialBounds.isMaximized) {
-				window.maximize();
+				if (initialBounds.isMaximized) {
+					window.maximize();
+				}
+				window.show();
+				initialized = true;
+				hasCompletedFirstLoad = true;
 			}
-			window.show();
-			initialized = true;
-			hasCompletedFirstLoad = true;
-		}
-	});
+		});
 
 	window.webContents.on(
 		"did-fail-load",

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.test.ts
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, mock } from "bun:test";
+import { openProjectsAndWorkspaces } from "./open-projects";
+
+describe("openProjectsAndWorkspaces", () => {
+	it("opens a main workspace for every imported project", async () => {
+		const openNew = mock(async () => [
+			{ id: "project-1", name: "Project One" },
+			{ id: "project-2", name: "Project Two" },
+		]);
+		const openMainRepoWorkspace = mock(async () => ({}));
+		const onProjectOpenError = mock(() => {});
+
+		await openProjectsAndWorkspaces({
+			openNew,
+			openMainRepoWorkspace,
+			onProjectOpenError,
+		});
+
+		expect(openMainRepoWorkspace).toHaveBeenCalledTimes(2);
+		expect(openMainRepoWorkspace).toHaveBeenNthCalledWith(1, {
+			projectId: "project-1",
+		});
+		expect(openMainRepoWorkspace).toHaveBeenNthCalledWith(2, {
+			projectId: "project-2",
+		});
+		expect(onProjectOpenError).not.toHaveBeenCalled();
+	});
+
+	it("continues opening remaining projects when one workspace creation fails", async () => {
+		const openNew = mock(async () => [
+			{ id: "project-1", name: "Project One" },
+			{ id: "project-2", name: "Project Two" },
+		]);
+		const expectedError = new Error("workspace create failed");
+		const openMainRepoWorkspace = mock(
+			async ({ projectId }: { projectId: string }) => {
+				if (projectId === "project-1") {
+					throw expectedError;
+				}
+				return {};
+			},
+		);
+		const onProjectOpenError = mock(() => {});
+
+		await openProjectsAndWorkspaces({
+			openNew,
+			openMainRepoWorkspace,
+			onProjectOpenError,
+		});
+
+		expect(openMainRepoWorkspace).toHaveBeenCalledTimes(2);
+		expect(onProjectOpenError).toHaveBeenCalledTimes(1);
+		expect(onProjectOpenError).toHaveBeenCalledWith(
+			"Project One",
+			expectedError,
+		);
+	});
+});

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -14,6 +14,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { useEffect, useRef } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useOpenProject } from "renderer/react-query/projects";
+import { useOpenMainRepoWorkspace } from "renderer/react-query/workspaces";
 import {
 	useCloseNewWorkspaceModal,
 	useNewWorkspaceModalOpen,
@@ -24,6 +25,7 @@ import {
 	NewWorkspaceModalDraftProvider,
 	useNewWorkspaceModalDraft,
 } from "./NewWorkspaceModalDraftContext";
+import { openProjectsAndWorkspaces } from "./open-projects";
 
 /** Clears the PromptInputProvider text & attachments when the draft resets. */
 function PromptInputResetSync() {
@@ -47,6 +49,7 @@ export function NewWorkspaceModal() {
 	const closeModal = useCloseNewWorkspaceModal();
 	const navigate = useNavigate();
 	const { openNew } = useOpenProject();
+	const openMainRepoWorkspace = useOpenMainRepoWorkspace();
 	const preSelectedProjectId = usePreSelectedProjectId();
 
 	// Prevents AgentSelect from flashing "No agent" while presets load after refresh.
@@ -55,7 +58,18 @@ export function NewWorkspaceModal() {
 	const handleImportRepo = async () => {
 		closeModal();
 		try {
-			await openNew();
+			await openProjectsAndWorkspaces({
+				openNew,
+				openMainRepoWorkspace: openMainRepoWorkspace.mutateAsync,
+				onProjectOpenError: (projectName, error) => {
+					toast.error(`Failed to open ${projectName}`, {
+						description:
+							error instanceof Error
+								? error.message
+								: "Failed to create workspace",
+					});
+				},
+			});
 		} catch (error) {
 			toast.error("Failed to open project", {
 				description:

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/open-projects.ts
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/open-projects.ts
@@ -1,0 +1,20 @@
+export async function openProjectsAndWorkspaces({
+	openNew,
+	openMainRepoWorkspace,
+	onProjectOpenError,
+}: {
+	openNew: () => Promise<Array<{ id: string; name: string }>>;
+	openMainRepoWorkspace: (input: { projectId: string }) => Promise<unknown>;
+	onProjectOpenError: (projectName: string, error: unknown) => void;
+}): Promise<void> {
+	const projects = await openNew();
+	for (const project of projects) {
+		try {
+			await openMainRepoWorkspace({
+				projectId: project.id,
+			});
+		} catch (error) {
+			onProjectOpenError(project.name, error);
+		}
+	}
+}

--- a/apps/desktop/src/renderer/components/PostHogUserIdentifier/PostHogUserIdentifier.tsx
+++ b/apps/desktop/src/renderer/components/PostHogUserIdentifier/PostHogUserIdentifier.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { track } from "renderer/lib/analytics";
 import { authClient } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
-import { posthog } from "../../lib/posthog";
+import { isPostHogEnabled, posthog } from "../../lib/posthog";
 
 const AUTH_COMPLETED_KEY = "superset_auth_completed";
 const ACTIVE_ORG_ID_KEY = "active_organization_id";
@@ -14,6 +14,8 @@ export function PostHogUserIdentifier() {
 	const { mutate: setUserId } = electronTrpc.analytics.setUserId.useMutation();
 
 	useEffect(() => {
+		if (!isPostHogEnabled()) return;
+
 		if (user) {
 			posthog.identify(user.id, {
 				email: user.email,

--- a/apps/desktop/src/renderer/globals.css
+++ b/apps/desktop/src/renderer/globals.css
@@ -16,7 +16,7 @@
  */
 :root {
 	/* Default to dark (ember) theme colors as fallback */
-	--background: #151110;
+	--background: #0b0b0c;
 	--foreground: #eae8e6;
 	--card: #201e1c;
 	--card-foreground: #eae8e6;

--- a/apps/desktop/src/renderer/hooks/host-service/useGitStatus/useGitStatus.test.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useGitStatus/useGitStatus.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, mock } from "bun:test";
+import {
+	getGitStatusQueryInput,
+	invalidateGitStatusQuery,
+} from "./useGitStatus";
+
+describe("useGitStatus helpers", () => {
+	it("preserves baseBranch in the git status query key", () => {
+		expect(getGitStatusQueryInput("workspace-1", "main")).toEqual({
+			workspaceId: "workspace-1",
+			baseBranch: "main",
+		});
+		expect(getGitStatusQueryInput("workspace-1", null)).toEqual({
+			workspaceId: "workspace-1",
+			baseBranch: undefined,
+		});
+	});
+
+	it("invalidates git status with the full branch-aware query input", () => {
+		const invalidate = mock(async () => undefined);
+		const queryInput = getGitStatusQueryInput("workspace-1", "develop");
+
+		invalidateGitStatusQuery(invalidate, queryInput);
+
+		expect(invalidate).toHaveBeenCalledTimes(1);
+		expect(invalidate).toHaveBeenCalledWith({
+			workspaceId: "workspace-1",
+			baseBranch: "develop",
+		});
+	});
+});

--- a/apps/desktop/src/renderer/hooks/host-service/useGitStatus/useGitStatus.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useGitStatus/useGitStatus.ts
@@ -1,7 +1,30 @@
 import { workspaceTrpc } from "@superset/workspace-client";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useWorkspaceEvent } from "../useWorkspaceEvent";
+
+export function getGitStatusQueryInput(
+	workspaceId: string,
+	baseBranch: string | null,
+) {
+	return {
+		workspaceId,
+		baseBranch: baseBranch ?? undefined,
+	};
+}
+
+export function invalidateGitStatusQuery(
+	invalidate: (input: {
+		workspaceId: string;
+		baseBranch?: string;
+	}) => Promise<unknown> | unknown,
+	queryInput: {
+		workspaceId: string;
+		baseBranch?: string;
+	},
+): void {
+	void invalidate(queryInput);
+}
 
 /**
  * Fetches workspace git status and keeps it live against server events.
@@ -19,17 +42,21 @@ export function useGitStatus(workspaceId: string) {
 	const baseBranch: string | null =
 		collections.v2WorkspaceLocalState.get(workspaceId)?.sidebarState
 			?.baseBranch ?? null;
+	const queryInput = useMemo(
+		() => getGitStatusQueryInput(workspaceId, baseBranch),
+		[baseBranch, workspaceId],
+	);
 
 	const utils = workspaceTrpc.useUtils();
 
-	const query = workspaceTrpc.git.getStatus.useQuery(
-		{ workspaceId, baseBranch: baseBranch ?? undefined },
-		{ refetchOnWindowFocus: true, enabled: Boolean(workspaceId) },
-	);
+	const query = workspaceTrpc.git.getStatus.useQuery(queryInput, {
+		refetchOnWindowFocus: true,
+		enabled: Boolean(workspaceId),
+	});
 
 	const invalidate = useCallback(() => {
-		void utils.git.getStatus.invalidate({ workspaceId });
-	}, [utils, workspaceId]);
+		invalidateGitStatusQuery(utils.git.getStatus.invalidate, queryInput);
+	}, [queryInput, utils]);
 
 	useWorkspaceEvent("git:changed", workspaceId, invalidate);
 

--- a/apps/desktop/src/renderer/index.tsx
+++ b/apps/desktop/src/renderer/index.tsx
@@ -13,7 +13,7 @@ import {
 	reportBootError,
 } from "./lib/boot-errors";
 import { persistentHistory } from "./lib/persistent-hash-history";
-import { posthog } from "./lib/posthog";
+import { isPostHogEnabled, posthog } from "./lib/posthog";
 import { electronQueryClient } from "./providers/ElectronTRPCProvider";
 import { routeTree } from "./routeTree.gen";
 
@@ -33,6 +33,7 @@ const router = createRouter({
 });
 
 const unsubscribe = router.subscribe("onResolved", (event) => {
+	if (!isPostHogEnabled()) return;
 	posthog.capture("$pageview", {
 		$current_url: event.toLocation.pathname,
 	});
@@ -70,7 +71,35 @@ declare module "@tanstack/react-router" {
 if (!rootElement) {
 	reportBootError("Missing <app> root element");
 } else if (!isBootErrorReported()) {
-	ReactDom.createRoot(rootElement).render(
+	ReactDom.createRoot(rootElement, {
+		onCaughtError: (error, errorInfo) => {
+			console.error("[renderer] React caught error:", error);
+			if (errorInfo.componentStack) {
+				console.error(
+					"[renderer] React component stack:",
+					errorInfo.componentStack,
+				);
+			}
+		},
+		onUncaughtError: (error, errorInfo) => {
+			console.error("[renderer] React uncaught error:", error);
+			if (errorInfo.componentStack) {
+				console.error(
+					"[renderer] React uncaught component stack:",
+					errorInfo.componentStack,
+				);
+			}
+		},
+		onRecoverableError: (error, errorInfo) => {
+			console.error("[renderer] React recoverable error:", error);
+			if (errorInfo.componentStack) {
+				console.error(
+					"[renderer] React recoverable component stack:",
+					errorInfo.componentStack,
+				);
+			}
+		},
+	}).render(
 		<BootErrorBoundary
 			onError={(error) => reportBootError("Render failed", error)}
 		>

--- a/apps/desktop/src/renderer/lib/analytics/index.ts
+++ b/apps/desktop/src/renderer/lib/analytics/index.ts
@@ -1,8 +1,9 @@
-import { posthog } from "renderer/lib/posthog";
+import { isPostHogEnabled, posthog } from "renderer/lib/posthog";
 
 export function track(
 	event: string,
 	properties?: Record<string, unknown>,
 ): void {
+	if (!isPostHogEnabled()) return;
 	posthog.capture(event, properties);
 }

--- a/apps/desktop/src/renderer/lib/boot-errors.ts
+++ b/apps/desktop/src/renderer/lib/boot-errors.ts
@@ -68,11 +68,23 @@ export const reportBootError = (message: string, error?: unknown) => {
 };
 
 const handleGlobalError = (event: ErrorEvent) => {
+	console.error("[renderer] Global error event:", {
+		message: event.message,
+		filename: event.filename,
+		lineno: event.lineno,
+		colno: event.colno,
+		error: event.error,
+		stack: event.error instanceof Error ? event.error.stack : undefined,
+	});
 	if (hasMounted) return;
 	reportBootError(event.message || "Unhandled error", event.error);
 };
 
 const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
+	console.error("[renderer] Unhandled promise rejection:", {
+		reason: event.reason,
+		stack: event.reason instanceof Error ? event.reason.stack : undefined,
+	});
 	if (hasMounted) return;
 	reportBootError("Unhandled promise rejection", event.reason);
 };

--- a/apps/desktop/src/renderer/lib/posthog.ts
+++ b/apps/desktop/src/renderer/lib/posthog.ts
@@ -1,16 +1,23 @@
 import posthogFull from "posthog-js/dist/module.full.no-external";
-import type { PostHog } from "posthog-js/react";
+import type { PostHog } from "posthog-js";
 import { env } from "../env.renderer";
 
 // Cast to standard PostHog type for compatibility with posthog-js/react
 export const posthog = posthogFull as unknown as PostHog;
+let posthogEnabled = false;
+
+export function isPostHogEnabled() {
+	return posthogEnabled;
+}
 
 export function initPostHog() {
 	if (!env.NEXT_PUBLIC_POSTHOG_KEY) {
+		posthogEnabled = false;
 		console.log("[posthog] No key configured, skipping");
 		return;
 	}
 
+	posthogEnabled = true;
 	posthogFull.init(env.NEXT_PUBLIC_POSTHOG_KEY, {
 		api_host: env.NEXT_PUBLIC_POSTHOG_HOST,
 		defaults: "2025-11-30",

--- a/apps/desktop/src/renderer/lib/useDesktopFeatureFlagEnabled.ts
+++ b/apps/desktop/src/renderer/lib/useDesktopFeatureFlagEnabled.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import { isPostHogEnabled, posthog } from "./posthog";
+
+type PostHogWithFeatureFlags = typeof posthog & {
+	isFeatureEnabled?: (flag: string) => boolean | undefined;
+	onFeatureFlags?: (callback: () => void) => void;
+};
+
+export function useDesktopFeatureFlagEnabled(flag: string): boolean {
+	const [enabled, setEnabled] = useState(false);
+
+	useEffect(() => {
+		if (!isPostHogEnabled()) {
+			setEnabled(false);
+			return;
+		}
+
+		let disposed = false;
+		const client = posthog as PostHogWithFeatureFlags;
+		const sync = () => {
+			if (disposed) return;
+			setEnabled(client.isFeatureEnabled?.(flag) ?? false);
+		};
+
+		sync();
+		client.onFeatureFlags?.(sync);
+
+		return () => {
+			disposed = true;
+		};
+	}, [flag]);
+
+	return enabled;
+}

--- a/apps/desktop/src/renderer/lib/workspace-client-provider-cache.test.ts
+++ b/apps/desktop/src/renderer/lib/workspace-client-provider-cache.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { __workspaceClientProviderTestUtils } from "../../../../../packages/workspace-client/src/providers/WorkspaceClientProvider/WorkspaceClientProvider";
+
+const TEST_HOST_URL = "http://127.0.0.1:43123";
+
+describe("Workspace client cache lifecycle", () => {
+	afterEach(() => {
+		__workspaceClientProviderTestUtils.resetCache();
+	});
+
+	it("reuses the same cache entry for the same workspace key", () => {
+		const first = __workspaceClientProviderTestUtils.getWorkspaceClients(
+			"workspace-a",
+			TEST_HOST_URL,
+		);
+		const second = __workspaceClientProviderTestUtils.getWorkspaceClients(
+			"workspace-a",
+			TEST_HOST_URL,
+		);
+
+		expect(second).toBe(first);
+		expect(__workspaceClientProviderTestUtils.getCacheSize()).toBe(1);
+	});
+
+	it("releases cached clients once the refcount reaches zero", () => {
+		const clients = __workspaceClientProviderTestUtils.getWorkspaceClients(
+			"workspace-a",
+			TEST_HOST_URL,
+		);
+		const other = __workspaceClientProviderTestUtils.getWorkspaceClients(
+			"workspace-b",
+			TEST_HOST_URL,
+		);
+
+		clients.refCount = 2;
+		other.refCount = 1;
+		expect(__workspaceClientProviderTestUtils.getCacheSize()).toBe(2);
+
+		__workspaceClientProviderTestUtils.releaseWorkspaceClients(
+			clients.clientKey,
+		);
+		expect(__workspaceClientProviderTestUtils.getCacheSize()).toBe(2);
+
+		__workspaceClientProviderTestUtils.releaseWorkspaceClients(
+			clients.clientKey,
+		);
+		expect(__workspaceClientProviderTestUtils.getCacheSize()).toBe(1);
+
+		__workspaceClientProviderTestUtils.releaseWorkspaceClients(other.clientKey);
+		expect(__workspaceClientProviderTestUtils.getCacheSize()).toBe(0);
+	});
+});

--- a/apps/desktop/src/renderer/providers/PostHogProvider/PostHogProvider.tsx
+++ b/apps/desktop/src/renderer/providers/PostHogProvider/PostHogProvider.tsx
@@ -1,8 +1,7 @@
-import { PostHogProvider as PHProvider } from "posthog-js/react";
 import type React from "react";
 import { useEffect, useState } from "react";
 import { track } from "renderer/lib/analytics";
-import { initPostHog, posthog } from "renderer/lib/posthog";
+import { initPostHog } from "renderer/lib/posthog";
 
 interface PostHogProviderProps {
 	children: React.ReactNode;
@@ -25,6 +24,5 @@ export function PostHogProvider({ children }: PostHogProviderProps) {
 	if (!isInitialized) {
 		return null;
 	}
-
-	return <PHProvider client={posthog}>{children}</PHProvider>;
+	return <>{children}</>;
 }

--- a/apps/desktop/src/renderer/react-query/workspaces/useOpenMainRepoWorkspace.ts
+++ b/apps/desktop/src/renderer/react-query/workspaces/useOpenMainRepoWorkspace.ts
@@ -1,6 +1,11 @@
 import { useNavigate } from "@tanstack/react-router";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
+import {
+	useClearPendingWorkspace,
+	useSetPendingWorkspace,
+} from "renderer/stores/new-workspace-modal";
 import { useWorkspaceInitStore } from "renderer/stores/workspace-init";
 import type { WorkspaceInitProgress } from "shared/types/workspace-init";
 
@@ -11,17 +16,30 @@ export function useOpenMainRepoWorkspace(
 ) {
 	const navigate = useNavigate();
 	const utils = electronTrpc.useUtils();
+	const { ensureWorkspaceInSidebar } = useDashboardSidebarState();
 	const addPendingTerminalSetup = useWorkspaceInitStore(
 		(s) => s.addPendingTerminalSetup,
 	);
 	const updateProgress = useWorkspaceInitStore((s) => s.updateProgress);
+	const setPendingWorkspace = useSetPendingWorkspace();
+	const clearPendingWorkspace = useClearPendingWorkspace();
 
 	return electronTrpc.workspaces.openMainRepoWorkspace.useMutation({
 		...options,
 		onSuccess: async (data, ...rest) => {
 			await utils.workspaces.invalidate();
+			ensureWorkspaceInSidebar(data.workspace.id, data.projectId);
 
+			// Set pending workspace to show in sidebar while Electric sync completes
+			// This ensures the workspace appears immediately in the sidebar
 			if (!data.wasExisting) {
+				setPendingWorkspace({
+					id: data.workspace.id,
+					projectId: data.projectId,
+					name: data.workspace.name || data.workspace.branch,
+					status: "creating",
+				});
+
 				let setupData = null;
 				try {
 					setupData = await utils.workspaces.getSetupCommands.fetch({
@@ -49,6 +67,12 @@ export function useOpenMainRepoWorkspace(
 					message: "Ready",
 				};
 				updateProgress(readyProgress);
+
+				// Clear pending workspace after a short delay to allow Electric sync to complete
+				// The Electric sync should bring the real workspace data into sidebarWorkspaces
+				setTimeout(() => {
+					clearPendingWorkspace(data.workspace.id);
+				}, 2000);
 			}
 
 			navigateToWorkspace(data.workspace.id, navigate);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -1,4 +1,6 @@
 import { useDiffStats } from "renderer/hooks/host-service/useDiffStats";
+import { useTabsStore } from "renderer/stores/tabs/store";
+import { getHighestPriorityStatus } from "shared/tabs-types";
 import type { DashboardSidebarWorkspace } from "../../types";
 import { DashboardSidebarDeleteDialog } from "../DashboardSidebarDeleteDialog";
 import { DashboardSidebarCollapsedWorkspaceButton } from "./components/DashboardSidebarCollapsedWorkspaceButton";
@@ -32,6 +34,18 @@ export function DashboardSidebarWorkspaceItem({
 		creationStatus,
 	} = workspace;
 	const diffStats = useDiffStats(id);
+
+	// Get workspace pane status from tabs store to show working indicator
+	const workspaceStatus = useTabsStore((state) => {
+		const tabs = state.tabs.filter((tab) => tab.workspaceId === id);
+		const paneIds = tabs.flatMap((tab) =>
+			Object.values(state.panes)
+				.filter((pane) => pane.tabId === tab.id)
+				.map((pane) => pane.status),
+		);
+		return getHighestPriorityStatus(paneIds);
+	});
+
 	const {
 		cancelRename,
 		handleClick,
@@ -74,6 +88,7 @@ export function DashboardSidebarWorkspaceItem({
 					isActive={isActive}
 					onClick={isCreating ? undefined : handleClick}
 					creationStatus={creationStatus}
+					workspaceStatus={workspaceStatus}
 					disabled={isCreating}
 					aria-label={
 						creationStatus ? `Creating workspace: ${name}` : undefined
@@ -135,6 +150,7 @@ export function DashboardSidebarWorkspaceItem({
 			renameValue={renameValue}
 			shortcutLabel={shortcutLabel}
 			diffStats={isCreating ? null : diffStats}
+			workspaceStatus={workspaceStatus}
 			onClick={isCreating ? undefined : handleClick}
 			onDoubleClick={isCreating ? undefined : startRename}
 			onDeleteClick={() => setIsDeleteDialogOpen(true)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -11,6 +11,7 @@ import { HiMiniXMark } from "react-icons/hi2";
 import type { DiffStats } from "renderer/hooks/host-service/useDiffStats";
 import { HotkeyLabel } from "renderer/hotkeys";
 import { RenameInput } from "renderer/screens/main/components/WorkspaceSidebar/RenameInput";
+import type { ActivePaneStatus } from "shared/tabs-types";
 import type { DashboardSidebarWorkspace } from "../../../../types";
 import { getCreationStatusText } from "../../utils/getCreationStatusText";
 import { DashboardSidebarWorkspaceDiffStats } from "../DashboardSidebarWorkspaceDiffStats";
@@ -25,6 +26,7 @@ interface DashboardSidebarExpandedWorkspaceRowProps
 	renameValue: string;
 	shortcutLabel?: string;
 	diffStats: DiffStats | null;
+	workspaceStatus?: ActivePaneStatus | null;
 	onClick?: () => void;
 	onDoubleClick?: () => void;
 	onDeleteClick: () => void;
@@ -45,6 +47,7 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 			renameValue,
 			shortcutLabel,
 			diffStats,
+			workspaceStatus,
 			onClick,
 			onDoubleClick,
 			onDeleteClick,
@@ -124,7 +127,7 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 								hostType={hostType}
 								isActive={isActive}
 								variant="expanded"
-								workspaceStatus={null}
+								workspaceStatus={workspaceStatus}
 								creationStatus={creationStatus}
 							/>
 						</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
@@ -1,10 +1,10 @@
 import { FEATURE_FLAGS } from "@superset/shared/constants";
 import { useMatchRoute, useParams } from "@tanstack/react-router";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { HiOutlineWifi } from "react-icons/hi2";
 import { useOnlineStatus } from "renderer/hooks/useOnlineStatus";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { getWorkspaceDisplayName } from "renderer/lib/getWorkspaceDisplayName";
+import { useDesktopFeatureFlagEnabled } from "renderer/lib/useDesktopFeatureFlagEnabled";
 import { NavigationControls } from "./components/NavigationControls";
 import { OpenInMenuButton } from "./components/OpenInMenuButton";
 import { OrganizationDropdown } from "./components/OrganizationDropdown";
@@ -31,8 +31,7 @@ export function TopBar() {
 		{ enabled: !!workspaceId && !isV2WorkspaceRoute },
 	);
 	const isOnline = useOnlineStatus();
-	const isV2CloudEnabled =
-		useFeatureFlagEnabled(FEATURE_FLAGS.V2_CLOUD) ?? false;
+	const isV2CloudEnabled = useDesktopFeatureFlagEnabled(FEATURE_FLAGS.V2_CLOUD);
 	// Default to Mac layout while loading to avoid overlap with traffic lights
 	const isMac = platform === undefined || platform === "darwin";
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -5,10 +5,10 @@ import {
 	useMatchRoute,
 	useNavigate,
 } from "@tanstack/react-router";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useState } from "react";
 import { useHotkey } from "renderer/hotkeys";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useDesktopFeatureFlagEnabled } from "renderer/lib/useDesktopFeatureFlagEnabled";
 import { DashboardSidebar } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar";
 import { ResizablePanel } from "renderer/screens/main/components/ResizablePanel";
 import { WorkspaceSidebar } from "renderer/screens/main/components/WorkspaceSidebar";
@@ -29,8 +29,7 @@ export const Route = createFileRoute("/_authenticated/_dashboard")({
 function DashboardLayout() {
 	const navigate = useNavigate();
 	const openNewWorkspaceModal = useOpenNewWorkspaceModal();
-	const isV2CloudEnabled =
-		useFeatureFlagEnabled(FEATURE_FLAGS.V2_CLOUD) ?? false;
+	const isV2CloudEnabled = useDesktopFeatureFlagEnabled(FEATURE_FLAGS.V2_CLOUD);
 	// Get current workspace from route to pre-select project in new workspace modal
 	const matchRoute = useMatchRoute();
 	const currentWorkspaceMatch = matchRoute({

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesHeader/ChangesHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesHeader/ChangesHeader.tsx
@@ -9,6 +9,7 @@ interface ChangesHeaderProps {
 	currentBranch: { name: string; aheadCount: number; behindCount: number };
 	defaultBranchName: string;
 	commitCount: number;
+	showBaseComparison: boolean;
 	totalFiles: number;
 	totalAdditions: number;
 	totalDeletions: number;
@@ -26,6 +27,7 @@ export function ChangesHeader({
 	currentBranch,
 	defaultBranchName,
 	commitCount,
+	showBaseComparison,
 	totalFiles,
 	totalAdditions,
 	totalDeletions,
@@ -100,12 +102,23 @@ export function ChangesHeader({
 			</div>
 
 			<div className="text-[11px] text-muted-foreground">
-				{commitCount} {commitCount === 1 ? "commit" : "commits"} from{" "}
-				<BaseBranchSelector
-					branches={branches}
-					currentValue={defaultBranchName}
-					onChange={onBaseBranchChange}
-				/>
+				{showBaseComparison ? (
+					<>
+						{commitCount} {commitCount === 1 ? "commit" : "commits"} from{" "}
+						<BaseBranchSelector
+							branches={branches}
+							currentValue={defaultBranchName}
+							onChange={onBaseBranchChange}
+						/>
+					</>
+				) : (
+					<>
+						Up to date with{" "}
+						<span className="font-medium text-foreground">
+							{currentBranch.name}
+						</span>
+					</>
+				)}
 			</div>
 
 			{currentBranch.aheadCount > 0 && currentBranch.behindCount > 0 && (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesTabContent/ChangesTabContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesTabContent/ChangesTabContent.tsx
@@ -19,6 +19,7 @@ interface ChangesTabContentProps {
 		data: { files: ChangedFile[] } | undefined;
 		isLoading: boolean;
 	};
+	shouldShowCommittedChanges: boolean;
 	filter: ChangesFilter;
 	filteredFiles: ChangedFile[];
 	fileCategory: "against-base" | "staged" | "unstaged";
@@ -40,6 +41,7 @@ export const ChangesTabContent = memo(function ChangesTabContent({
 	commits,
 	branches,
 	commitFiles,
+	shouldShowCommittedChanges,
 	filter,
 	filteredFiles,
 	fileCategory,
@@ -73,7 +75,10 @@ export const ChangesTabContent = memo(function ChangesTabContent({
 			<ChangesHeader
 				currentBranch={status.data.currentBranch}
 				defaultBranchName={status.data.defaultBranch.name}
-				commitCount={commits.data?.commits.length ?? 0}
+				commitCount={
+					shouldShowCommittedChanges ? (commits.data?.commits.length ?? 0) : 0
+				}
+				showBaseComparison={shouldShowCommittedChanges}
 				totalFiles={totalChanges}
 				totalAdditions={totalAdditions}
 				totalDeletions={totalDeletions}
@@ -96,6 +101,11 @@ export const ChangesTabContent = memo(function ChangesTabContent({
 					}
 					unstaged={
 						filter.kind === "uncommitted" ? status.data.unstaged : undefined
+					}
+					defaultBranchName={
+						shouldShowCommittedChanges
+							? status.data.defaultBranch.name
+							: undefined
 					}
 					isLoading={
 						filter.kind === "commit" || filter.kind === "range"

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
@@ -98,20 +98,34 @@ export function useChangesTab({
 		{ enabled: filter.kind === "commit" || filter.kind === "range" },
 	);
 
+	const shouldShowCommittedChanges = useMemo(() => {
+		const currentBranch = status.data?.currentBranch;
+		if (!currentBranch) return true;
+		if (!currentBranch.upstream) return true;
+		return currentBranch.aheadCount > 0 || currentBranch.behindCount > 0;
+	}, [status.data?.currentBranch]);
+
 	const filteredFiles = useMemo(() => {
 		if (!status.data) return [];
 		if (filter.kind === "uncommitted") {
 			return [...status.data.staged, ...status.data.unstaged];
 		}
 		if (filter.kind === "commit" || filter.kind === "range") {
-			return commitFiles.data?.files ?? [];
+			return shouldShowCommittedChanges ? (commitFiles.data?.files ?? []) : [];
 		}
 		const map = new Map<string, (typeof status.data.againstBase)[number]>();
-		for (const f of status.data.againstBase) map.set(f.path, f);
+		if (shouldShowCommittedChanges) {
+			for (const f of status.data.againstBase) map.set(f.path, f);
+		}
 		for (const f of status.data.staged) map.set(f.path, f);
 		for (const f of status.data.unstaged) map.set(f.path, f);
 		return Array.from(map.values());
-	}, [status.data, filter.kind, commitFiles.data?.files]);
+	}, [
+		status.data,
+		filter.kind,
+		commitFiles.data?.files,
+		shouldShowCommittedChanges,
+	]);
 
 	const totalChanges = filteredFiles.length;
 	const totalAdditions = filteredFiles.reduce((sum, f) => sum + f.additions, 0);
@@ -126,6 +140,7 @@ export function useChangesTab({
 			commits={commits}
 			branches={branches}
 			commitFiles={commitFiles}
+			shouldShowCommittedChanges={shouldShowCommittedChanges}
 			filter={filter}
 			filteredFiles={filteredFiles}
 			fileCategory={fileCategory}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/useCommandWatcher.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCommandWatcher/useCommandWatcher.ts
@@ -1,10 +1,10 @@
 import { FEATURE_FLAGS } from "@superset/shared/constants";
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { authClient } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useDesktopFeatureFlagEnabled } from "renderer/lib/useDesktopFeatureFlagEnabled";
 import { useCreateWorkspace } from "renderer/react-query/workspaces/useCreateWorkspace";
 import { useDeleteWorkspace } from "renderer/react-query/workspaces/useDeleteWorkspace";
 import { useUpdateWorkspace } from "renderer/react-query/workspaces/useUpdateWorkspace";
@@ -34,7 +34,7 @@ export function useCommandWatcher() {
 	);
 
 	const organizationId = session?.session?.activeOrganizationId;
-	const remoteAgentDisabled = useFeatureFlagEnabled(
+	const remoteAgentDisabled = useDesktopFeatureFlagEnabled(
 		FEATURE_FLAGS.DISABLE_REMOTE_AGENT,
 	);
 	const shouldWatch = !!deviceInfo && !!organizationId && !remoteAgentDisabled;

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -8,7 +8,6 @@ import {
 	useLocation,
 	useNavigate,
 } from "@tanstack/react-router";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useEffect, useRef } from "react";
 import { DndProvider } from "react-dnd";
 import { HiOutlineWifi } from "react-icons/hi2";
@@ -21,6 +20,7 @@ import { migrateHotkeyOverrides } from "renderer/hotkeys/migrate";
 import { authClient, getAuthToken } from "renderer/lib/auth-client";
 import { dragDropManager } from "renderer/lib/dnd";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useDesktopFeatureFlagEnabled } from "renderer/lib/useDesktopFeatureFlagEnabled";
 import { showWorkspaceAutoNameWarningToast } from "renderer/lib/workspaces/showWorkspaceAutoNameWarningToast";
 import { InitGitDialog } from "renderer/react-query/projects/InitGitDialog";
 import { DashboardNewWorkspaceModal } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal";
@@ -55,8 +55,7 @@ function AuthenticatedLayout() {
 	const setOriginRoute = useSettingsStore((s) => s.setOriginRoute);
 	const utils = electronTrpc.useUtils();
 	const shownWorkspaceInitWarningsRef = useRef(new Set<string>());
-	const isV2CloudEnabled =
-		useFeatureFlagEnabled(FEATURE_FLAGS.V2_CLOUD) ?? false;
+	const isV2CloudEnabled = useDesktopFeatureFlagEnabled(FEATURE_FLAGS.V2_CLOUD);
 
 	const isSignedIn = env.SKIP_ENV_VALIDATION || !!session?.user;
 	const activeOrganizationId = env.SKIP_ENV_VALIDATION

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/ProjectsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsSidebar/ProjectsSettings.tsx
@@ -1,9 +1,9 @@
 import { FEATURE_FLAGS } from "@superset/shared/constants";
 import { cn } from "@superset/ui/utils";
 import { Link, useMatchRoute } from "@tanstack/react-router";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { HiOutlineFolder } from "react-icons/hi2";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useDesktopFeatureFlagEnabled } from "renderer/lib/useDesktopFeatureFlagEnabled";
 import type { SettingsSection } from "renderer/stores/settings-state";
 
 interface ProjectsSettingsProps {
@@ -18,7 +18,9 @@ export function ProjectsSettings({
 	const { data: groups = [] } =
 		electronTrpc.workspaces.getAllGrouped.useQuery();
 	const matchRoute = useMatchRoute();
-	const hasCloudAccess = useFeatureFlagEnabled(FEATURE_FLAGS.CLOUD_ACCESS);
+	const hasCloudAccess = useDesktopFeatureFlagEnabled(
+		FEATURE_FLAGS.CLOUD_ACCESS,
+	);
 
 	const hasProjectMatches = (matchCounts?.project ?? 0) > 0;
 

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/integrations/components/IntegrationsSettings/IntegrationsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/integrations/components/IntegrationsSettings/IntegrationsSettings.tsx
@@ -9,7 +9,6 @@ import {
 } from "@superset/ui/card";
 import { Skeleton } from "@superset/ui/skeleton";
 import { useLiveQuery } from "@tanstack/react-db";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useCallback, useEffect, useState } from "react";
 import { FaGithub, FaSlack } from "react-icons/fa";
 import { HiCheckCircle, HiOutlineArrowTopRightOnSquare } from "react-icons/hi2";
@@ -18,6 +17,7 @@ import { GATED_FEATURES, usePaywall } from "renderer/components/Paywall";
 import { env } from "renderer/env.renderer";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { authClient } from "renderer/lib/auth-client";
+import { useDesktopFeatureFlagEnabled } from "renderer/lib/useDesktopFeatureFlagEnabled";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import {
 	isItemVisible,
@@ -60,7 +60,7 @@ export function IntegrationsSettings({
 		useState<GithubInstallation | null>(null);
 	const [isLoadingGithub, setIsLoadingGithub] = useState(true);
 
-	const hasSlackAccess = useFeatureFlagEnabled(
+	const hasSlackAccess = useDesktopFeatureFlagEnabled(
 		FEATURE_FLAGS.SLACK_INTEGRATION_ACCESS,
 	);
 

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/cloud/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/cloud/page.tsx
@@ -1,6 +1,6 @@
 import { FEATURE_FLAGS } from "@superset/shared/constants";
 import { createFileRoute, Navigate } from "@tanstack/react-router";
-import { useFeatureFlagEnabled } from "posthog-js/react";
+import { useDesktopFeatureFlagEnabled } from "renderer/lib/useDesktopFeatureFlagEnabled";
 
 export const Route = createFileRoute(
 	"/_authenticated/settings/project/$projectId/cloud/",
@@ -10,7 +10,9 @@ export const Route = createFileRoute(
 
 function CloudSettingsIndex() {
 	const { projectId } = Route.useParams();
-	const hasCloudAccess = useFeatureFlagEnabled(FEATURE_FLAGS.CLOUD_ACCESS);
+	const hasCloudAccess = useDesktopFeatureFlagEnabled(
+		FEATURE_FLAGS.CLOUD_ACCESS,
+	);
 
 	if (!hasCloudAccess) {
 		return (

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/cloud/secrets/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/project/$projectId/cloud/secrets/page.tsx
@@ -1,7 +1,7 @@
 import { FEATURE_FLAGS } from "@superset/shared/constants";
 import { createFileRoute, Navigate, notFound } from "@tanstack/react-router";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
+import { useDesktopFeatureFlagEnabled } from "renderer/lib/useDesktopFeatureFlagEnabled";
 import { NotFound } from "renderer/routes/not-found";
 import { SecretsSettings } from "./components/SecretsSettings";
 
@@ -33,7 +33,9 @@ export const Route = createFileRoute(
 
 function SecretsSettingsPage() {
 	const { projectId } = Route.useParams();
-	const hasCloudAccess = useFeatureFlagEnabled(FEATURE_FLAGS.CLOUD_ACCESS);
+	const hasCloudAccess = useDesktopFeatureFlagEnabled(
+		FEATURE_FLAGS.CLOUD_ACCESS,
+	);
 
 	if (!hasCloudAccess) {
 		return (

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/TerminalSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/TerminalSettings.tsx
@@ -1,6 +1,6 @@
 import { FEATURE_FLAGS } from "@superset/shared/constants";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import type { ReactNode } from "react";
+import { useDesktopFeatureFlagEnabled } from "renderer/lib/useDesktopFeatureFlagEnabled";
 import {
 	isItemVisible,
 	SETTING_ITEM_ID,
@@ -47,8 +47,7 @@ export function TerminalSettings({
 	pendingCreateProjectId,
 	onPendingCreateProjectIdChange,
 }: TerminalSettingsProps) {
-	const isV2CloudEnabled =
-		useFeatureFlagEnabled(FEATURE_FLAGS.V2_CLOUD) ?? false;
+	const isV2CloudEnabled = useDesktopFeatureFlagEnabled(FEATURE_FLAGS.V2_CLOUD);
 	const showPresets = isItemVisible(
 		SETTING_ITEM_ID.TERMINAL_PRESETS,
 		visibleItems,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -179,8 +179,12 @@ export function WorkspaceListItem({
 
 	const localDiffStats = useMemo(() => {
 		if (!localChanges) return null;
+		const shouldShowCommittedChanges =
+			!localChanges.hasUpstream ||
+			localChanges.pushCount > 0 ||
+			localChanges.pullCount > 0;
 		const allFiles =
-			localChanges.againstBase.length > 0
+			shouldShowCommittedChanges && localChanges.againstBase.length > 0
 				? localChanges.againstBase
 				: [
 						...localChanges.staged,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -156,6 +156,7 @@ export function WorkspaceListItem({
 	const { showDeleteDialog, setShowDeleteDialog, handleDeleteClick } =
 		useWorkspaceDeleteHandler();
 	const { status: localChanges } = useGitChangesStatus({
+		workspaceId: id,
 		worktreePath,
 		enabled: hasHovered && !!worktreePath,
 		staleTime: GITHUB_STATUS_STALE_TIME,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/ChangesContent.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/ChangesContent.tsx
@@ -19,6 +19,7 @@ export function ChangesContent() {
 	const worktreePath = workspace?.worktreePath;
 
 	const { status, isLoading, effectiveBaseBranch } = useGitChangesStatus({
+		workspaceId,
 		worktreePath,
 		refetchInterval: isChangesSidebarVisible ? undefined : 2500,
 		refetchOnWindowFocus: !isChangesSidebarVisible,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/InfiniteScrollView/InfiniteScrollView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ChangesContent/components/InfiniteScrollView/InfiniteScrollView.tsx
@@ -43,15 +43,21 @@ export function InfiniteScrollView({
 
 	const { stageFileMutation, unstageFileMutation, handleDiscard, isActioning } =
 		useFileMutations({ worktreePath, baseBranch });
+	const shouldShowCommittedChanges =
+		!status.hasUpstream || status.pushCount > 0 || status.pullCount > 0;
+	const visibleAgainstBase = shouldShowCommittedChanges
+		? status.againstBase
+		: [];
+	const visibleCommits = shouldShowCommittedChanges ? status.commits : [];
 
 	const totals = useMemo(() => {
 		const allFiles = [
-			...status.againstBase,
+			...visibleAgainstBase,
 			...status.staged,
 			...status.unstaged,
 			...status.untracked,
 		];
-		const commitFileCount = status.commits.reduce(
+		const commitFileCount = visibleCommits.reduce(
 			(acc, commit) => acc + commit.files.length,
 			0,
 		);
@@ -63,7 +69,7 @@ export function InfiniteScrollView({
 			totalAdditions += file.additions;
 			totalDeletions += file.deletions;
 		}
-		for (const commit of status.commits) {
+		for (const commit of visibleCommits) {
 			for (const file of commit.files) {
 				totalAdditions += file.additions;
 				totalDeletions += file.deletions;
@@ -75,7 +81,13 @@ export function InfiniteScrollView({
 			additions: totalAdditions,
 			deletions: totalDeletions,
 		};
-	}, [status]);
+	}, [
+		status.staged,
+		status.unstaged,
+		status.untracked,
+		visibleAgainstBase,
+		visibleCommits,
+	]);
 
 	const toggleFile = useCallback((key: string) => {
 		setCollapsedFiles((prev) => {
@@ -90,8 +102,8 @@ export function InfiniteScrollView({
 	}, []);
 
 	const sortedAgainstBase = useMemo(
-		() => sortFiles(status.againstBase, fileListViewMode),
-		[status.againstBase, fileListViewMode],
+		() => sortFiles(visibleAgainstBase, fileListViewMode),
+		[visibleAgainstBase, fileListViewMode],
 	);
 	const sortedStaged = useMemo(
 		() => sortFiles(status.staged, fileListViewMode),
@@ -118,7 +130,7 @@ export function InfiniteScrollView({
 		getFocusedFileActions,
 	} = useFocusMode({
 		sortedAgainstBase,
-		commits: status.commits,
+		commits: visibleCommits,
 		sortedStaged,
 		sortedUnstaged,
 		sectionOrder,
@@ -131,7 +143,7 @@ export function InfiniteScrollView({
 
 	const hasChanges =
 		sortedAgainstBase.length > 0 ||
-		status.commits.length > 0 ||
+		visibleCommits.length > 0 ||
 		sortedStaged.length > 0 ||
 		sortedUnstaged.length > 0;
 	const orderedSections = useOrderedSections({
@@ -144,7 +156,7 @@ export function InfiniteScrollView({
 		expandedSections: expandedCategories,
 		toggleSection: toggleCategory,
 		againstBaseFiles: sortedAgainstBase,
-		commits: status.commits,
+		commits: visibleCommits,
 		stagedFiles: sortedStaged,
 		unstagedFiles: sortedUnstaged,
 		onUnstageFile: (file) =>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.test.ts
@@ -1,0 +1,77 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+
+let setupKeyboardHandler!: typeof import("./helpers").setupKeyboardHandler;
+
+beforeAll(async () => {
+	Object.defineProperty(globalThis, "window", {
+		value: {
+			addEventListener() {},
+			removeEventListener() {},
+		},
+		configurable: true,
+	});
+	Object.defineProperty(globalThis, "electronTRPC", {
+		value: {
+			sendMessage() {},
+			onMessage() {},
+		},
+		configurable: true,
+	});
+	setupKeyboardHandler = (await import("./helpers")).setupKeyboardHandler;
+});
+
+function installKeyboardHandler(): (event: KeyboardEvent) => boolean {
+	let currentHandler: ((event: KeyboardEvent) => boolean) | null = null;
+	setupKeyboardHandler({
+		attachCustomKeyEventHandler: (
+			handler: (event: KeyboardEvent) => boolean,
+		) => {
+			currentHandler = handler;
+		},
+	} as never);
+	if (!currentHandler) {
+		throw new Error("Keyboard handler was not attached");
+	}
+	return currentHandler;
+}
+
+function makeKeyEvent(
+	input: Partial<KeyboardEventInit> & { key: string; code?: string },
+): KeyboardEvent {
+	return {
+		type: "keydown",
+		key: input.key,
+		code: input.code ?? `Key${input.key.toUpperCase()}`,
+		ctrlKey: input.ctrlKey ?? false,
+		metaKey: input.metaKey ?? false,
+		altKey: input.altKey ?? false,
+		shiftKey: input.shiftKey ?? false,
+		preventDefault() {},
+		stopPropagation() {},
+	} as KeyboardEvent;
+}
+
+describe("setupKeyboardHandler", () => {
+	it("keeps unbound Ctrl chords inside the terminal", () => {
+		const handler = installKeyboardHandler();
+
+		expect(handler(makeKeyEvent({ key: "b", ctrlKey: true }))).toBe(true);
+		expect(handler(makeKeyEvent({ key: "o", ctrlKey: true }))).toBe(true);
+		expect(handler(makeKeyEvent({ key: "a", ctrlKey: true }))).toBe(true);
+		expect(handler(makeKeyEvent({ key: "e", ctrlKey: true }))).toBe(true);
+	});
+
+	it("still lets registered app hotkeys bubble out of the terminal", () => {
+		const handler = installKeyboardHandler();
+
+		expect(
+			handler(
+				makeKeyEvent({
+					key: "o",
+					code: "KeyO",
+					metaKey: true,
+				}),
+			),
+		).toBe(false);
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -74,6 +74,10 @@ type PreferredRenderer = TerminalRenderer["kind"] | "auto";
 let suggestedRendererType: TerminalRenderer["kind"] | undefined;
 
 function getPreferredRenderer(): PreferredRenderer {
+	// Local patched build: force DOM renderer to avoid Electron/WebGL repaint
+	// corruption on window/tab re-focus while we verify the root cause.
+	return "dom";
+
 	// If WebGL previously failed, don't try again
 	if (suggestedRendererType === "dom") {
 		return "dom";
@@ -660,6 +664,34 @@ export function setupKeyboardHandler(
 				options.onWrite("\x1bf"); // Meta+F - forward word
 			}
 			return false;
+		}
+
+		// Ctrl+A: Move cursor to beginning of line (sends Ctrl+A sequence to shell)
+		// Note: This is different from Mac's Cmd+Left which also sends Ctrl+A
+		// On all platforms, Ctrl+A should go directly to the shell for line navigation
+		const isCtrlA =
+			event.key === "a" &&
+			event.ctrlKey &&
+			!event.metaKey &&
+			!event.altKey &&
+			!event.shiftKey;
+
+		if (isCtrlA) {
+			// Return true to let xterm handle it (sends to shell)
+			return true;
+		}
+
+		// Ctrl+E: Move cursor to end of line (sends Ctrl+E sequence to shell)
+		const isCtrlE =
+			event.key === "e" &&
+			event.ctrlKey &&
+			!event.metaKey &&
+			!event.altKey &&
+			!event.shiftKey;
+
+		if (isCtrlE) {
+			// Return true to let xterm handle it (sends to shell)
+			return true;
 		}
 
 		// Terminal-reserved chords (ctrl+c/d/z/s/q) always go to xterm

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -8,7 +8,11 @@ import { WebglAddon } from "@xterm/addon-webgl";
 import type { ITheme } from "@xterm/xterm";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { debounce } from "lodash";
-import { getBinding, isTerminalReservedEvent } from "renderer/hotkeys";
+import {
+	getBinding,
+	isTerminalReservedEvent,
+	resolveHotkeyFromEvent,
+} from "renderer/hotkeys";
 import { electronTrpcClient as trpcClient } from "renderer/lib/trpc-client";
 import { toXtermTheme } from "renderer/stores/theme/utils";
 import {
@@ -706,9 +710,10 @@ export function setupKeyboardHandler(
 			return false;
 		}
 
-		// Any other ctrl/meta combo → let it bubble to document for react-hotkeys-hook
-		if (event.type === "keydown" && (event.metaKey || event.ctrlKey))
-			return false;
+		// Only chords that are actually registered app hotkeys should bubble to
+		// react-hotkeys-hook. Unbound Ctrl/Meta chords must still reach the PTY so
+		// readline, shell bindings, and TUIs keep their native behavior.
+		if (resolveHotkeyFromEvent(event) !== null) return false;
 
 		return true;
 	};

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.test.ts
@@ -34,6 +34,7 @@ type SchedulerState = {
 	pendingFrame: number | null;
 	lastRunAt: number;
 	pendingForceResize: boolean;
+	burstTimeouts: number[];
 };
 
 function makeScheduler(runRecovery: (forceResize: boolean) => void): {
@@ -46,6 +47,7 @@ function makeScheduler(runRecovery: (forceResize: boolean) => void): {
 		pendingFrame: null,
 		lastRunAt: 0,
 		pendingForceResize: false,
+		burstTimeouts: [],
 	};
 
 	const pendingRafs: Array<() => void> = [];
@@ -84,6 +86,20 @@ function makeScheduler(runRecovery: (forceResize: boolean) => void): {
 		}) as unknown as number;
 	};
 
+	const scheduleRecoveryBurst = (forceResize: boolean) => {
+		scheduleReattachRecovery(forceResize);
+		for (const timeoutId of reattachRecovery.burstTimeouts) {
+			clearTimeout(timeoutId);
+		}
+		reattachRecovery.burstTimeouts = [120, 260].map((delay) =>
+			setTimeout(() => {
+				if (!isUnmounted) {
+					scheduleReattachRecovery(forceResize);
+				}
+			}, delay) as unknown as number,
+		);
+	};
+
 	const flushRafs = () => {
 		while (pendingRafs.length > 0) {
 			const cb = pendingRafs.shift();
@@ -93,6 +109,7 @@ function makeScheduler(runRecovery: (forceResize: boolean) => void): {
 
 	return {
 		schedule: scheduleReattachRecovery,
+		scheduleBurst: scheduleRecoveryBurst,
 		flush: flushRafs,
 		state: reattachRecovery,
 	};
@@ -166,5 +183,24 @@ describe("scheduleReattachRecovery throttle — issue #1873", () => {
 		// FAILS with current code: calls is still 0 because no retry was scheduled
 		// PASSES after fix: the retry fires and recovery runs
 		expect(calls).toBe(1);
+	});
+
+	it("focus recovery burst runs follow-up repaint attempts after the initial recovery", async () => {
+		let calls = 0;
+		const { scheduleBurst, flush } = makeScheduler(() => {
+			calls++;
+		});
+
+		scheduleBurst(false);
+		flush();
+		expect(calls).toBe(1);
+
+		await new Promise((r) => setTimeout(r, 140));
+		flush();
+		expect(calls).toBe(2);
+
+		await new Promise((r) => setTimeout(r, 180));
+		flush();
+		expect(calls).toBe(3);
 	});
 });

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
@@ -755,12 +755,13 @@ export function useTerminalLifecycle({
 			isBracketedPasteEnabled: () => isBracketedPasteRef.current,
 		});
 		const cleanupCopy = setupCopyHandler(xterm);
-		const reattachRecovery = {
-			throttleMs: 120,
-			pendingFrame: null as number | null,
-			lastRunAt: 0,
-			pendingForceResize: false,
-		};
+			const reattachRecovery = {
+				throttleMs: 120,
+				pendingFrame: null as number | null,
+				lastRunAt: 0,
+				pendingForceResize: false,
+				burstTimeouts: [] as number[],
+			};
 
 		const isCurrentTerminalRenderable = () => {
 			if (isUnmounted || xtermRef.current !== xterm) return false;
@@ -831,19 +832,32 @@ export function useTerminalLifecycle({
 			});
 		};
 
-		const cancelReattachRecovery = () => {
-			if (reattachRecovery.pendingFrame === null) return;
-			cancelAnimationFrame(reattachRecovery.pendingFrame);
-			reattachRecovery.pendingFrame = null;
-		};
+			const cancelReattachRecovery = () => {
+				if (reattachRecovery.pendingFrame === null) return;
+				cancelAnimationFrame(reattachRecovery.pendingFrame);
+				reattachRecovery.pendingFrame = null;
+			};
 
-		const handleVisibilityChange = () => {
-			if (document.hidden) return;
-			scheduleReattachRecovery(isFocusedRef.current);
-		};
-		const handleWindowFocus = () => {
-			scheduleReattachRecovery(isFocusedRef.current);
-		};
+			const scheduleRecoveryBurst = (forceResize: boolean) => {
+				scheduleReattachRecovery(forceResize);
+				for (const timeoutId of reattachRecovery.burstTimeouts) {
+					window.clearTimeout(timeoutId);
+				}
+				reattachRecovery.burstTimeouts = [120, 260].map((delay) =>
+					window.setTimeout(() => {
+						if (isUnmounted) return;
+						scheduleReattachRecovery(forceResize);
+					}, delay),
+				);
+			};
+
+			const handleVisibilityChange = () => {
+				if (document.hidden) return;
+				scheduleRecoveryBurst(isFocusedRef.current);
+			};
+			const handleWindowFocus = () => {
+				scheduleRecoveryBurst(isFocusedRef.current);
+			};
 
 		document.addEventListener("visibilitychange", handleVisibilityChange);
 		window.addEventListener("focus", handleWindowFocus);
@@ -868,9 +882,13 @@ export function useTerminalLifecycle({
 				cancelAttachWait = null;
 			}
 			clearAttachInFlight(paneId, cleanupAttachId);
-			if (firstRenderFallback) clearTimeout(firstRenderFallback);
-			cancelReattachRecovery();
-			document.removeEventListener("visibilitychange", handleVisibilityChange);
+				if (firstRenderFallback) clearTimeout(firstRenderFallback);
+				cancelReattachRecovery();
+				for (const timeoutId of reattachRecovery.burstTimeouts) {
+					window.clearTimeout(timeoutId);
+				}
+				reattachRecovery.burstTimeouts = [];
+				document.removeEventListener("visibilitychange", handleVisibilityChange);
 			window.removeEventListener("focus", handleWindowFocus);
 			inputDisposable.dispose();
 			keyDisposable.dispose();

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
@@ -499,8 +499,14 @@ export function ChangesView({
 		});
 	};
 
-	const againstBaseFiles = status?.againstBase ?? [];
-	const commits = status?.commits ?? [];
+	const shouldShowCommittedChanges =
+		!status?.hasUpstream ||
+		(status?.pushCount ?? 0) > 0 ||
+		(status?.pullCount ?? 0) > 0;
+	const againstBaseFiles = shouldShowCommittedChanges
+		? (status?.againstBase ?? [])
+		: [];
+	const commits = shouldShowCommittedChanges ? (status?.commits ?? []) : [];
 	const stagedFiles = status?.staged ?? [];
 	const unstagedFiles = status?.unstaged ?? [];
 	const untrackedFiles = status?.untracked ?? [];
@@ -680,7 +686,7 @@ export function ChangesView({
 		);
 	}
 
-	const againstMainCount = status.againstBase.length;
+	const againstMainCount = againstBaseFiles.length;
 	const reviewCommentCount = activePullRequest
 		? countOpenPullRequestComments(githubComments)
 		: 0;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/ChangesView/ChangesView.tsx
@@ -101,6 +101,7 @@ export function ChangesView({
 
 	const { status, isLoading, effectiveBaseBranch, branchData, refetch } =
 		useGitChangesStatus({
+			workspaceId,
 			worktreePath,
 			refetchInterval: isActive ? 2500 : undefined,
 			refetchOnWindowFocus: isActive,

--- a/apps/desktop/src/renderer/screens/main/hooks/useGitChangesStatus/useGitChangesStatus.ts
+++ b/apps/desktop/src/renderer/screens/main/hooks/useGitChangesStatus/useGitChangesStatus.ts
@@ -1,7 +1,9 @@
+import { useWorkspaceEvent } from "renderer/hooks/host-service/useWorkspaceEvent";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import type { GitChangesStatus } from "shared/changes-types";
 
 interface UseGitChangesStatusOptions {
+	workspaceId?: string;
 	worktreePath: string | undefined;
 	enabled?: boolean;
 	refetchInterval?: number;
@@ -17,6 +19,7 @@ const STATUS_QUERY_STALE_TIME_MS = 2_000;
 const BRANCH_QUERY_STALE_TIME_MS = 10_000;
 
 export function useGitChangesStatus({
+	workspaceId,
 	worktreePath,
 	enabled = true,
 	refetchInterval,
@@ -25,6 +28,7 @@ export function useGitChangesStatus({
 	branchRefetchInterval,
 	branchRefetchOnWindowFocus,
 }: UseGitChangesStatusOptions) {
+	const utils = electronTrpc.useUtils();
 	const { data: branchData } = electronTrpc.changes.getBranches.useQuery(
 		{ worktreePath: worktreePath || "" },
 		{
@@ -69,6 +73,20 @@ export function useGitChangesStatus({
 			refetchOnWindowFocus,
 			staleTime: staleTime ?? STATUS_QUERY_STALE_TIME_MS,
 		},
+	);
+
+	useWorkspaceEvent(
+		"git:changed",
+		workspaceId ?? "",
+		() => {
+			if (!worktreePath) return;
+			void utils.changes.getBranches.invalidate({ worktreePath });
+			void utils.changes.getStatus.invalidate({
+				worktreePath,
+				defaultBranch: effectiveBaseBranch,
+			});
+		},
+		Boolean(enabled && workspaceId && worktreePath),
 	);
 
 	return { status, isLoading, effectiveBaseBranch, branchData, refetch };

--- a/apps/desktop/src/shared/env.shared.ts
+++ b/apps/desktop/src/shared/env.shared.ts
@@ -41,10 +41,16 @@ export const env = envSchema.parse({
 
 export function getWorkspaceName(): string | undefined {
 	let name = env.SUPERSET_WORKSPACE_NAME;
+	const execPath =
+		typeof process.execPath === "string" ? process.execPath : undefined;
+	const argv = Array.isArray(process.argv) ? process.argv : [];
 	if (
 		name === "superset" &&
-		(process.execPath.includes("Superset Patched.app") ||
-			process.argv.some((arg) => arg.includes("Superset Patched.app")))
+		(execPath?.includes("Superset Patched.app") ||
+			argv.some(
+				(arg): arg is string =>
+					typeof arg === "string" && arg.includes("Superset Patched.app"),
+			))
 	) {
 		name = "patched";
 	}

--- a/apps/desktop/src/shared/env.shared.ts
+++ b/apps/desktop/src/shared/env.shared.ts
@@ -40,7 +40,14 @@ export const env = envSchema.parse({
 });
 
 export function getWorkspaceName(): string | undefined {
-	const name = env.SUPERSET_WORKSPACE_NAME;
+	let name = env.SUPERSET_WORKSPACE_NAME;
+	if (
+		name === "superset" &&
+		(process.execPath.includes("Superset Patched.app") ||
+			process.argv.some((arg) => arg.includes("Superset Patched.app")))
+	) {
+		name = "patched";
+	}
 	if (name === "superset") return undefined;
 	return name
 		.toLowerCase()

--- a/apps/desktop/src/shared/themes/built-in/ember.ts
+++ b/apps/desktop/src/shared/themes/built-in/ember.ts
@@ -2,7 +2,7 @@ import type { Theme } from "../types";
 
 /**
  * Dark theme - Warm dark theme inspired by the Figma start screen design
- * Features a warm, slightly reddish dark background (#151110)
+ * Features a near-black background while preserving the warm ember surfaces
  */
 export const darkTheme: Theme = {
 	id: "dark",
@@ -13,7 +13,7 @@ export const darkTheme: Theme = {
 
 	ui: {
 		// Core - warm dark tones
-		background: "#151110",
+		background: "#0b0b0c",
 		foreground: "#eae8e6",
 		card: "#201E1C",
 		cardForeground: "#eae8e6",
@@ -72,7 +72,7 @@ export const darkTheme: Theme = {
 	},
 
 	terminal: {
-		background: "#151110",
+		background: "#0b0b0c",
 		foreground: "#eae8e6",
 		cursor: "#e07850",
 		cursorAccent: "#151110",

--- a/bun.lock
+++ b/bun.lock
@@ -6,9 +6,11 @@
       "name": "@superset/repo",
       "devDependencies": {
         "@biomejs/biome": "2.4.2",
+        "app-builder-bin": "^4.2.0",
         "dotenv-cli": "^11.0.0",
         "sherif": "^1.10.0",
         "turbo": "2.8.7",
+        "yocto-queue": "^1.2.2",
       },
     },
     "apps/admin": {
@@ -328,6 +330,7 @@
         "rollup-plugin-inject-process-env": "^1.3.1",
         "tailwindcss": "^4.1.18",
         "tsx": "^4.19.3",
+        "turbo": "^2.9.3",
         "typescript": "^5.9.3",
         "vite": "^7.1.3",
         "vite-tsconfig-paths": "^5.1.4",
@@ -2623,6 +2626,18 @@
 
     "@trpc/tanstack-react-query": ["@trpc/tanstack-react-query@11.16.0", "", { "peerDependencies": { "@tanstack/react-query": "^5.80.3", "@trpc/client": "11.16.0", "@trpc/server": "11.16.0", "react": ">=18.2.0", "typescript": ">=5.7.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-kfNYJ5NCk67tmRCO/QWCycJmRamuEKmZf1HRG8yCBl8aTJdTwVq7l6AffFIMab3Q+NmQzwP8XXkAEK/EelKYOA=="],
 
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.9.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-P8foouaP+y/p+hhEGBoZpzMbpVvUMwPjDpcy6wN7EYfvvyISD1USuV27qWkczecihwuPJzQ1lDBuL8ERcavTyg=="],
+
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-SIzEkvtNdzdI50FJDaIQ6kQGqgSSdFPcdn0wqmmONN6iGKjy6hsT+EH99GP65FsfV7DLZTh2NmtTIRl2kdoz5Q=="],
+
+    "@turbo/linux-64": ["@turbo/linux-64@2.9.3", "", { "os": "linux", "cpu": "x64" }, "sha512-pLRwFmcHHNBvsCySLS6OFabr/07kDT2pxEt/k6eBf/3asiVQZKJ7Rk88AafQx2aYA641qek4RsXvYO3JYpiBug=="],
+
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.9.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-gy6ApUroC2Nzv+qjGtE/uPNkhHAFU4c8God+zd5Aiv9L9uBgHlxVJpHT3XWl5xwlJZ2KWuMrlHTaS5kmNB+q1Q=="],
+
+    "@turbo/windows-64": ["@turbo/windows-64@2.9.3", "", { "os": "win32", "cpu": "x64" }, "sha512-d0YelTX6hAsB7kIEtGB3PzIzSfAg3yDoUlHwuwJc3adBXUsyUIs0YLG+1NNtuhcDOUGnWQeKUoJ2pGWvbpRj7w=="],
+
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-/08CwpKJl3oRY8nOlh2YgilZVJDHsr60XTNxRhuDeuFXONpUZ5X+Nv65izbG/xBew9qxcJFbDX9/sAmAX+ITcQ=="],
+
     "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
 
     "@types/aws-lambda": ["@types/aws-lambda@8.10.161", "", {}, "sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ=="],
@@ -2985,7 +3000,7 @@
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
-    "app-builder-bin": ["app-builder-bin@5.0.0-alpha.12", "", {}, "sha512-j87o0j6LqPL3QRr8yid6c+Tt5gC7xNfYo6uQIQkorAC6MpeayVMZrEDzKmJJ/Hlv7EnOQpaRm53k6ktDYZyB6w=="],
+    "app-builder-bin": ["app-builder-bin@4.2.0", "", {}, "sha512-PGXlkukQnroTgAaDZnnppdLzsRJmab6Rh/rJ5fKyYaYhd+FfaORH59/ArkB5dr2cAeYQU5lCeHFEwURaoBO8BA=="],
 
     "app-builder-lib": ["app-builder-lib@26.8.1", "", { "dependencies": { "@develar/schema-utils": "~2.6.5", "@electron/asar": "3.4.1", "@electron/fuses": "^1.8.0", "@electron/get": "^3.0.0", "@electron/notarize": "2.5.0", "@electron/osx-sign": "1.3.3", "@electron/rebuild": "^4.0.3", "@electron/universal": "2.0.3", "@malept/flatpak-bundler": "^0.4.0", "@types/fs-extra": "9.0.13", "async-exit-hook": "^2.0.1", "builder-util": "26.8.1", "builder-util-runtime": "9.5.1", "chromium-pickle-js": "^0.2.0", "ci-info": "4.3.1", "debug": "^4.3.4", "dotenv": "^16.4.5", "dotenv-expand": "^11.0.6", "ejs": "^3.1.8", "electron-publish": "26.8.1", "fs-extra": "^10.1.0", "hosted-git-info": "^4.1.0", "isbinaryfile": "^5.0.0", "jiti": "^2.4.2", "js-yaml": "^4.1.0", "json5": "^2.2.3", "lazy-val": "^1.0.5", "minimatch": "^10.0.3", "plist": "3.1.0", "proper-lockfile": "^4.1.2", "resedit": "^1.7.0", "semver": "~7.7.3", "tar": "^7.5.7", "temp-file": "^3.4.0", "tiny-async-pool": "1.3.0", "which": "^5.0.0" }, "peerDependencies": { "dmg-builder": "26.8.1", "electron-builder-squirrel-windows": "26.8.1" } }, "sha512-p0Im/Dx5C4tmz8QEE1Yn4MkuPC8PrnlRneMhWJj7BBXQfNTJUshM/bp3lusdEsDbvvfJZpXWnYesgSLvwtM2Zw=="],
 
@@ -5647,7 +5662,7 @@
 
     "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
 
-    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+    "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
 
     "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
 
@@ -5949,6 +5964,8 @@
 
     "@slack/web-api/eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
+    "@superset/desktop/turbo": ["turbo@2.9.3", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.3", "@turbo/darwin-arm64": "2.9.3", "@turbo/linux-64": "2.9.3", "@turbo/linux-arm64": "2.9.3", "@turbo/windows-64": "2.9.3", "@turbo/windows-arm64": "2.9.3" }, "bin": { "turbo": "bin/turbo" } }, "sha512-J/VUvsGRykPb9R8Kh8dHVBOqioDexLk9BhLCU/ZybRR+HN9UR3cURdazFvNgMDt9zPP8TF6K73Z+tplfmi0PqQ=="],
+
     "@tailwindcss/node/jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "@tailwindcss/node/lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
@@ -6022,6 +6039,8 @@
     "better-opn/open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
     "bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+
+    "builder-util/app-builder-bin": ["app-builder-bin@5.0.0-alpha.12", "", {}, "sha512-j87o0j6LqPL3QRr8yid6c+Tt5gC7xNfYo6uQIQkorAC6MpeayVMZrEDzKmJJ/Hlv7EnOQpaRm53k6ktDYZyB6w=="],
 
     "builder-util/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -6290,6 +6309,8 @@
     "ora/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "p-event/p-timeout": ["p-timeout@5.1.0", "", {}, "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew=="],
+
+    "p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
@@ -7490,8 +7511,6 @@
     "cacache/glob/jackspeak/@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "chromium-edge-launcher/rimraf/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
-    "pkg-conf/find-up/locate-path/p-locate/p-limit/yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
 
     "temp/rimraf/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/package.json
+++ b/package.json
@@ -6,9 +6,11 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.4.2",
+		"app-builder-bin": "^4.2.0",
 		"dotenv-cli": "^11.0.0",
 		"sherif": "^1.10.0",
-		"turbo": "2.8.7"
+		"turbo": "2.8.7",
+		"yocto-queue": "^1.2.2"
 	},
 	"description": "Superset Monorepo",
 	"homepage": "https://superset.sh",

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -86,23 +86,29 @@ export const gitRouter = router({
 				? `origin/${defaultBranchName}`
 				: "HEAD";
 
-			const [currentBranch, defaultBranch, status, ignoredRaw] =
-				await Promise.all([
-					buildBranch(git, currentBranchName, true, baseRef),
-					defaultBranchName
-						? buildBranch(git, defaultBranchName, false)
-						: buildBranch(git, currentBranchName, true),
-					git.status(),
-					git
-						.raw([
-							"ls-files",
-							"--others",
-							"--ignored",
-							"--exclude-standard",
-							"--directory",
-						])
-						.catch(() => ""),
-				]);
+			const currentBranchBase = await buildBranch(git, currentBranchName, true);
+			const currentBranch = await buildBranch(
+				git,
+				currentBranchName,
+				true,
+				currentBranchBase.upstream ?? baseRef,
+			);
+
+			const [defaultBranch, status, ignoredRaw] = await Promise.all([
+				defaultBranchName
+					? buildBranch(git, defaultBranchName, false)
+					: buildBranch(git, currentBranchName, true),
+				git.status(),
+				git
+					.raw([
+						"ls-files",
+						"--others",
+						"--ignored",
+						"--exclude-standard",
+						"--directory",
+					])
+					.catch(() => ""),
+			]);
 
 			// Top-level gitignored paths. `--directory` collapses entirely-ignored
 			// folders to a single entry (e.g. `node_modules`) instead of

--- a/packages/workspace-client/src/providers/WorkspaceClientProvider/WorkspaceClientProvider.tsx
+++ b/packages/workspace-client/src/providers/WorkspaceClientProvider/WorkspaceClientProvider.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { httpBatchLink } from "@trpc/client";
-import { createContext, type ReactNode, useContext } from "react";
+import { createContext, type ReactNode, useContext, useEffect } from "react";
 import superjson from "superjson";
 import { workspaceTrpc } from "../../workspace-trpc";
 
@@ -22,10 +22,12 @@ interface WorkspaceClientProviderProps {
 }
 
 interface WorkspaceClients {
+	clientKey: string;
 	hostUrl: string;
 	queryClient: QueryClient;
 	trpcClient: ReturnType<typeof workspaceTrpc.createClient>;
 	getWsToken: () => string | null;
+	refCount: number;
 }
 
 const workspaceClientsCache = new Map<string, WorkspaceClients>();
@@ -67,14 +69,37 @@ function getWorkspaceClients(
 
 	const getWsToken = wsToken ?? (() => null);
 	const clients: WorkspaceClients = {
+		clientKey,
 		hostUrl,
 		queryClient,
 		trpcClient,
 		getWsToken,
+		refCount: 0,
 	};
 	workspaceClientsCache.set(clientKey, clients);
 	return clients;
 }
+
+function releaseWorkspaceClients(clientKey: string): void {
+	const cached = workspaceClientsCache.get(clientKey);
+	if (!cached) return;
+	cached.refCount = Math.max(0, cached.refCount - 1);
+	if (cached.refCount > 0) return;
+	cached.queryClient.clear();
+	workspaceClientsCache.delete(clientKey);
+}
+
+export const __workspaceClientProviderTestUtils = {
+	getWorkspaceClients,
+	releaseWorkspaceClients,
+	getCacheSize: () => workspaceClientsCache.size,
+	resetCache: () => {
+		for (const clients of workspaceClientsCache.values()) {
+			clients.queryClient.clear();
+		}
+		workspaceClientsCache.clear();
+	},
+};
 
 export function WorkspaceClientProvider({
 	cacheKey,
@@ -84,6 +109,14 @@ export function WorkspaceClientProvider({
 	children,
 }: WorkspaceClientProviderProps) {
 	const clients = getWorkspaceClients(cacheKey, hostUrl, headers, wsToken);
+
+	useEffect(() => {
+		clients.refCount++;
+		return () => {
+			releaseWorkspaceClients(clients.clientKey);
+		};
+	}, [clients]);
+
 	const contextValue: WorkspaceClientContextValue = {
 		hostUrl: clients.hostUrl,
 		queryClient: clients.queryClient,


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves terminal stability when refocusing and isolates the patched desktop build to its own app data, reducing repaint glitches and avoiding conflicts with the stock app. Also tightens analytics/feature-flag behavior and smooths workspace and Git changes UX.

- Bug Fixes
  - Terminal: add a short refocus recovery burst (immediate + 120ms + 260ms) with throttle to fully repaint after visibility/focus; force DOM renderer in the patched build; add tests.
  - Terminal attach: register client after snapshot to prevent duplicate/overlapping output; ensure canceled attaches don’t leak; add tests.
  - Keyboard: keep Ctrl+A/E in the terminal; only bubble chords that match registered app hotkeys; add tests.
  - Packaged load: switch to explicit file URL for production to avoid white-screen loads.
  - Git status: include baseBranch in query keys and invalidations; add tests.

- Refactors
  - Patched build isolation: rename product/appId, use `~/.superset-patched`, align `userData`, and clear browser-only state once via marker; terminal host reads `SUPERSET_HOME_DIR`.
  - Analytics/flags: gate PostHog init/events behind `isPostHogEnabled`, replace `posthog-js/react` with a lightweight `useDesktopFeatureFlagEnabled`, and guard `$pageview`/identify calls.
  - Git UI: hide “against base” commits/files when the branch is up to date with upstream; headers/counts adapt accordingly; `useGitChangesStatus` listens to `git:changed` and invalidates precisely.
  - New workspace: after importing projects, auto-create/open each main repo workspace and show a pending sidebar row until sync completes.
  - Client cache: add ref-counted cache for `@superset/workspace-client` providers with cleanup on unmount; add tests.
  - Misc: split a `better-auth` client chunk, adjust theme background, improve React error logging, and disable unused `.codex` MCP servers by default.

<sup>Written for commit 70b15dc8a5167face73b0e0b4fc0e5c4f1b86aa0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Terminal rendering recovery system with automatic refocus/repaint restoration on macOS after focus transitions.
  * Desktop-specific feature flag evaluation system replacing cloud-based configuration.
  * Workspace client reference counting and cache management.
  * Terminal keyboard handler improvements for better input handling.

* **Bug Fixes**
  * Fixed terminal content display lag after app focus/window switching.
  * Patched build isolation with dedicated home directory and browser state reset.

* **Style**
  * Updated dark theme background color to near-black for improved appearance.

* **Tests**
  * Added comprehensive test coverage for terminal recovery, workspace caching, and git status tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->