### PR TITLE
docs(desktop): v2 browser architecture analysis and refactor plan

### DIFF
--- a/docs/v1-vs-v2-browser-architecture.md
+++ b/docs/v1-vs-v2-browser-architecture.md
@@ -1,0 +1,500 @@
+# V1 vs V2 Browser Architecture
+
+## Overview
+
+The Superset desktop app contains two distinct browser systems that serve different purposes. There is no feature flag or explicit naming in the codebase -- the distinction is architectural.
+
+- **V1 (Browser Pane)**: The user-facing embedded web browser. Users see and interact with it directly. Built with Electron `<webview>` tags, rendered as a workspace pane.
+- **V2 (Chat-Integrated Browser)**: The AI-accessible automation layer built on top of V1. Adds a main-process `BrowserManager`, tRPC IPC router, and MCP tool exposure so chat agents can control the browser programmatically.
+
+V2 does not replace V1 -- it wraps and extends it.
+
+---
+
+## Architecture Diagram
+
+```
+V1 (Browser Pane - Renderer)                V2 (Chat Integration - Main Process + MCP)
+================================            ==========================================
+
+React Component Tree                        BrowserManager (EventEmitter)
+  └─ BrowserPane.tsx                           ├─ register/unregister panes
+       ├─ BrowserToolbar.tsx                   ├─ navigate(paneId, url)
+       │    ├─ Back / Forward / Reload         ├─ screenshot(paneId) → base64 PNG
+       │    ├─ Address bar (2-mode)            ├─ evaluateJS(paneId, code)
+       │    └─ URL autocomplete                ├─ getConsoleLogs(paneId)
+       ├─ BrowserErrorOverlay.tsx              ├─ openDevTools(paneId)
+       └─ usePersistentWebview hook            ├─ console capture (500-entry buffer)
+            ├─ <webview> lifecycle              └─ context menu builder
+            ├─ DOM event listeners                     │
+            ├─ Hidden container parking                │ tRPC IPC
+            └─ Zustand state sync                      │
+                                                       ▼
+                                               tRPC Browser Router (15 procedures)
+                                                  ├─ Mutations: navigate, goBack,
+                                                  │  goForward, reload, screenshot,
+                                                  │  evaluateJS, openDevTools,
+                                                  │  clearBrowsingData, register,
+                                                  │  unregister
+                                                  ├─ Queries: getConsoleLogs, getPageInfo
+                                                  └─ Subscriptions: consoleStream,
+                                                     onNewWindow, onContextMenuAction
+                                                       │
+                                                       │ MCP exposure
+                                                       ▼
+                                               Chat LLM (Mastra harness)
+                                                  "Navigate to github.com"
+                                                  "Take a screenshot"
+                                                  "Run document.title in the console"
+```
+
+---
+
+## V1: Browser Pane (Renderer-Side)
+
+The user-facing browser embedded as a workspace pane. All logic runs in the Electron renderer process.
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `apps/desktop/src/renderer/.../BrowserPane/BrowserPane.tsx` | Root component -- toolbar, error overlay, blank state |
+| `apps/desktop/src/renderer/.../BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts` | Webview lifecycle, event handling, navigation methods |
+| `apps/desktop/src/renderer/.../BrowserPane/components/BrowserToolbar/BrowserToolbar.tsx` | Address bar, nav buttons, loading indicator |
+| `apps/desktop/src/renderer/.../BrowserPane/components/BrowserToolbar/hooks/useUrlAutocomplete/useUrlAutocomplete.ts` | History-powered URL suggestions |
+| `apps/desktop/src/renderer/.../BrowserPane/components/BrowserErrorOverlay/BrowserErrorOverlay.tsx` | Error display with retry |
+| `apps/desktop/src/renderer/.../BrowserPane/components/BrowserToolbar/components/BrowserOverflowMenu/BrowserOverflowMenu.tsx` | Additional browser actions |
+| `apps/desktop/src/renderer/.../BrowserPane/components/BrowserToolbar/components/UrlSuggestions/UrlSuggestions.tsx` | Autocomplete dropdown UI |
+| Renderer store (`useTabsStore`) | Per-pane browser state (URL, history, loading, error) |
+
+### How It Works
+
+**Webview Creation & Persistence** (`usePersistentWebview.ts`):
+
+The hook manages `<webview>` elements with a module-level singleton registry:
+
+```typescript
+const webviewRegistry = new Map<string, Electron.WebviewTag>();
+const registeredWebContentsIds = new Map<string, number>();
+let hiddenContainer: HTMLDivElement | null = null;
+```
+
+On mount, the hook either reclaims an existing webview or creates a new one:
+
+```typescript
+let webview = webviewRegistry.get(paneId);
+if (webview) {
+    container.appendChild(webview);        // reclaim from hidden container
+    syncStoreFromWebview(webview);
+} else {
+    webview = document.createElement("webview");
+    webview.setAttribute("partition", "persist:superset");
+    webviewRegistry.set(paneId, webview);
+    container.appendChild(webview);
+    webview.src = sanitizeUrl(initialUrl);
+}
+```
+
+On unmount, the webview is parked offscreen (not destroyed):
+
+```typescript
+return () => {
+    // remove event listeners...
+    getHiddenContainer().appendChild(wv);  // park at left:-9999px
+};
+```
+
+**Event Handling**:
+
+The hook listens to 8 webview DOM events:
+
+| Event | What V1 Does |
+|-------|-------------|
+| `dom-ready` | Registers webContentsId with main process via tRPC |
+| `did-start-loading` | Sets `isLoading: true`, clears errors |
+| `did-stop-loading` | Sets `isLoading: false`, updates URL/title in store, upserts browser history |
+| `did-navigate` | Updates store with new URL |
+| `did-navigate-in-page` | Updates store for hash/pushState navigations |
+| `page-title-updated` | Updates title in store |
+| `page-favicon-updated` | Updates favicon in store and history DB |
+| `did-fail-load` | Shows error overlay (ignores `ERR_ABORTED`) |
+
+**Navigation**:
+
+V1 manages its own history stack in Zustand (not the webview's built-in history):
+
+```typescript
+const goBack = useCallback(() => {
+    const url = navigateBrowserHistory(paneId, "back");
+    if (url) {
+        isHistoryNavigation.current = true;
+        webviewRegistry.get(paneId)?.loadURL(sanitizeUrl(url));
+    }
+}, [paneId, navigateBrowserHistory]);
+```
+
+The `isHistoryNavigation` ref prevents back/forward from creating duplicate history entries.
+
+**Drag Passthrough**:
+
+A critical renderer-level concern: `<webview>` tags create separate Chromium compositor layers that swallow drag events, breaking mosaic pane rearrangement:
+
+```typescript
+function setWebviewsDragPassthrough(passthrough: boolean) {
+    for (const webview of webviewRegistry.values()) {
+        webview.style.pointerEvents = passthrough ? "none" : "";
+    }
+}
+window.addEventListener("dragstart", () => setWebviewsDragPassthrough(true), true);
+window.addEventListener("dragend", () => setWebviewsDragPassthrough(false), true);
+```
+
+**Toolbar** (`BrowserToolbar.tsx`):
+
+Two display modes:
+1. **Display mode**: Shows URL (truncated) + page title. Click to edit.
+2. **Edit mode**: Text input with autocomplete dropdown. Submit navigates, Escape exits.
+
+Autocomplete queries the SQLite browser history via tRPC, returning the 10 most relevant matches by URL and title.
+
+**State Shape** (Zustand per pane):
+
+```typescript
+{
+    currentUrl: string;
+    history: Array<{ url: string; title: string; faviconUrl?: string }>;
+    historyIndex: number;
+    isLoading: boolean;
+    error: { code: number; description: string; url: string } | null;
+}
+```
+
+**Browser History Persistence** (Drizzle + SQLite):
+
+```sql
+url TEXT PRIMARY KEY,
+title TEXT,
+faviconUrl TEXT,
+lastVisitedAt TIMESTAMP,
+visitCount INTEGER  -- incremented on upsert conflict
+```
+
+### What V1 Can Do
+
+- Display web pages in a workspace pane
+- Navigate via address bar with URL sanitization and search fallback
+- Back/Forward/Reload with proper history management
+- Show page title and favicon
+- Autocomplete URLs from browsing history
+- Display error overlays for failed loads
+- Handle `target="_blank"` links (opens in new browser pane)
+- Handle context menu "Open in Split" (opens link in new pane)
+- Persist webview state across tab switches (offscreen parking)
+- Persist browsing history across app restarts (SQLite)
+
+### What V1 Cannot Do
+
+- Take screenshots
+- Execute JavaScript on the page
+- Read console output
+- Be controlled by AI agents
+- Programmatically interact with page elements (click, type)
+- Stream real-time events to other systems
+- Clear browsing data programmatically
+
+---
+
+## V2: Chat-Integrated Browser (Main Process + tRPC + MCP)
+
+The automation layer that makes V1's browser panes controllable by AI agents. Adds a main-process singleton, IPC bridge, and MCP tool exposure.
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `apps/desktop/src/main/lib/browser/browser-manager.ts` | Main-process singleton managing webContents instances |
+| `apps/desktop/src/lib/trpc/routers/browser/browser.ts` | tRPC router exposing 15 IPC procedures |
+| `apps/desktop/src/lib/trpc/routers/browser-history/index.ts` | tRPC router for persistent history (4 procedures) |
+| `packages/desktop-mcp/src/mcp/mcp-server.ts` | MCP server creation |
+| `packages/desktop-mcp/src/mcp/tools/navigate/navigate.ts` | MCP navigate tool |
+| `packages/desktop-mcp/src/mcp/tools/take-screenshot/take-screenshot.ts` | MCP screenshot tool |
+| `packages/desktop-mcp/src/mcp/tools/click/click.ts` | MCP click tool |
+| `packages/desktop-mcp/src/mcp/tools/type-text/type-text.ts` | MCP type tool |
+| `packages/desktop-mcp/src/mcp/tools/send-keys/send-keys.ts` | MCP keyboard tool |
+| `packages/desktop-mcp/src/mcp/tools/evaluate-js/evaluate-js.ts` | MCP JS evaluation tool |
+| `packages/desktop-mcp/src/mcp/tools/inspect-dom/inspect-dom.ts` | MCP DOM inspection tool |
+| `packages/desktop-mcp/src/mcp/tools/get-console-logs/get-console-logs.ts` | MCP console tool |
+| `packages/desktop-mcp/src/mcp/tools/get-window-info/get-window-info.ts` | MCP window info tool |
+| `packages/desktop-mcp/src/mcp/connection/connection-manager.ts` | Puppeteer CDP connection management |
+| `packages/desktop-mcp/src/mcp/focus-lock/focus-lock.ts` | Focus suppression during automation |
+| `packages/desktop-mcp/src/mcp/console-capture/console-capture.ts` | CDP-level console capture |
+
+### Layer 1: BrowserManager (Main Process)
+
+A singleton `EventEmitter` in the main process that wraps Electron's `webContents` API:
+
+```typescript
+class BrowserManager extends EventEmitter {
+    private paneWebContentsIds = new Map<string, number>();
+    private consoleLogs = new Map<string, ConsoleEntry[]>();
+    private consoleListeners = new Map<string, () => void>();
+    private contextMenuListeners = new Map<string, () => void>();
+}
+export const browserManager = new BrowserManager();
+```
+
+**Registration**: When V1's `usePersistentWebview` fires `dom-ready`, it calls `browser.register({ paneId, webContentsId })`. The BrowserManager stores the mapping and sets up:
+
+1. **Background throttling** -- prevents offscreen persistent webviews from running at full speed
+2. **Window open handler** -- blocks popups, emits `new-window:{paneId}` event
+3. **Console capture** -- listens to `console-message` events, stores in a 500-entry circular buffer, emits `console:{paneId}` per entry
+4. **Context menu** -- intercepts right-click, builds native `Menu` with custom actions
+
+**Automation Methods**:
+
+| Method | What It Does |
+|--------|-------------|
+| `navigate(paneId, url)` | `webContents.loadURL(sanitizeUrl(url))` |
+| `screenshot(paneId)` | `webContents.capturePage()` → copies to clipboard + returns base64 PNG |
+| `evaluateJS(paneId, code)` | `webContents.executeJavaScript(code)` |
+| `getConsoleLogs(paneId)` | Returns stored `ConsoleEntry[]` from circular buffer |
+| `openDevTools(paneId)` | `webContents.openDevTools({ mode: "detach" })` |
+| `getWebContents(paneId)` | Returns the raw `Electron.WebContents` or null |
+
+**Cleanup**: On unregister, all listeners and console logs for a pane are cleaned up. Try/catch guards handle cases where webContents has been destroyed.
+
+### Layer 2: tRPC Browser Router (IPC Bridge)
+
+Exposes BrowserManager to the renderer via tRPC over Electron IPC:
+
+**15 Procedures**:
+
+| Type | Procedure | What It Does |
+|------|-----------|-------------|
+| Mutation | `register` | Map paneId → webContentsId |
+| Mutation | `unregister` | Clean up pane |
+| Mutation | `navigate` | Load URL in pane |
+| Mutation | `goBack` | `webContents.goBack()` |
+| Mutation | `goForward` | `webContents.goForward()` |
+| Mutation | `reload` | `webContents.reload()` or `reloadIgnoringCache()` |
+| Mutation | `screenshot` | Capture page as base64 PNG |
+| Mutation | `evaluateJS` | Execute JS, return result |
+| Mutation | `openDevTools` | Open detached DevTools |
+| Mutation | `clearBrowsingData` | Clear cookies/cache/storage/all on `persist:superset` session |
+| Query | `getConsoleLogs` | Get buffered console entries |
+| Query | `getPageInfo` | URL, title, canGoBack, canGoForward, isLoading |
+| Subscription | `consoleStream` | Stream new console entries in real-time |
+| Subscription | `onNewWindow` | Stream `target="_blank"` / `window.open` events |
+| Subscription | `onContextMenuAction` | Stream context menu actions (e.g., "open-in-split") |
+
+**Subscription pattern** (required for trpc-electron -- async generators silently fail):
+
+```typescript
+consoleStream: publicProcedure
+    .input(z.object({ paneId: z.string() }))
+    .subscription(({ input }) => {
+        return observable<ConsoleEntry>((emit) => {
+            const handler = (entry: ConsoleEntry) => emit.next(entry);
+            browserManager.on(`console:${input.paneId}`, handler);
+            return () => browserManager.off(`console:${input.paneId}`, handler);
+        });
+    }),
+```
+
+### Layer 3: MCP Tools (AI Agent Interface)
+
+The `packages/desktop-mcp` package creates an MCP server that exposes browser automation as tools for AI agents:
+
+```typescript
+// mcp-server.ts
+export function createMcpServer(): McpServer {
+    const server = new McpServer({ name: "desktop-automation", version: "0.1.0" });
+    const connection = new ConnectionManager();
+    registerTools({
+        server,
+        getPage: () => connection.getPage(),
+        consoleCapture: connection.consoleCapture,
+    });
+    return server;
+}
+```
+
+**ConnectionManager** connects to the Electron app via CDP (Chrome DevTools Protocol) using puppeteer-core:
+
+```typescript
+export class ConnectionManager {
+    async getPage(): Promise<Page> {
+        if (this.page && this.browser?.connected) {
+            await this.focusLock.inject(this.page);
+            return this.page;
+        }
+        return this.connect();  // lazy connect via puppeteer.connect()
+    }
+
+    private async connect(): Promise<Page> {
+        this.browser = await puppeteer.connect({
+            browserURL: `http://127.0.0.1:${process.env.DESKTOP_AUTOMATION_PORT}`,
+        });
+        // Find main renderer (not browser pane webviews)
+        const appPage = pages.find(p =>
+            p.url().startsWith("http://localhost:") || p.url().startsWith("file://")
+        );
+        this.consoleCapture.attach(appPage);
+        this.focusLock.attach(appPage);
+        return appPage;
+    }
+}
+```
+
+**9 MCP Tools**:
+
+| Tool | Description | Key Detail |
+|------|------------|-----------|
+| `navigate` | Load URL or app route | Supports `url` (full URL) or `path` (hash route for in-app navigation) |
+| `take_screenshot` | Capture page as PNG | Returns base64 image, supports optional `rect` for region capture |
+| `click` | Click element at coordinates | Uses Puppeteer's `page.mouse.click()` |
+| `type_text` | Type text into focused element | Uses Puppeteer's `page.keyboard.type()` |
+| `send_keys` | Send keyboard events | For shortcuts, special keys |
+| `evaluate_js` | Execute JavaScript | Returns serialized result |
+| `inspect_dom` | Analyze page DOM structure | Returns DOM tree or element info |
+| `get_console_logs` | Read console output | From ConsoleCapture buffer |
+| `get_window_info` | Get page metadata | URL, title, viewport size |
+
+**FocusLock** (`focus-lock.ts`):
+
+A critical piece for automation stability. When Electron loses OS focus (e.g., Claude Code's terminal takes over between MCP tool calls), Radix UI components detect blur events and close dropdowns/popovers. FocusLock suppresses these:
+
+```javascript
+// Injected into the renderer
+const suppress = (e) => {
+    if (e.relatedTarget === null && !document.hasFocus()) {
+        e.stopImmediatePropagation();  // block blur before React/Radix sees it
+    }
+};
+document.addEventListener('blur', suppress, true);
+document.addEventListener('focusout', suppress, true);
+```
+
+Auto-deactivates after 5 seconds of inactivity so normal manual usage is unaffected. Re-injects on page navigation.
+
+---
+
+## Side-by-Side Comparison
+
+| Aspect | V1 (Browser Pane) | V2 (Chat-Integrated) |
+|--------|-------------------|---------------------|
+| **Process** | Renderer | Main process + MCP server |
+| **Who uses it** | Human users directly | AI agents via chat |
+| **Navigation** | Address bar + toolbar buttons | Programmatic `navigate(paneId, url)` |
+| **Screenshots** | None | `webContents.capturePage()` → base64 PNG |
+| **JS execution** | None | `webContents.executeJavaScript(code)` |
+| **Console access** | None | 500-entry circular buffer + real-time streaming |
+| **Click/Type** | User does it manually | Puppeteer `page.mouse.click()` / `page.keyboard.type()` |
+| **DOM inspection** | None (user can open DevTools manually) | `inspect_dom` MCP tool |
+| **History** | Zustand (in-memory) + SQLite (persistent) | Relies on V1's history |
+| **URL autocomplete** | Yes (from SQLite history) | N/A (agents type URLs directly) |
+| **Error handling** | Error overlay with retry | Error returned in MCP tool response |
+| **Multi-pane** | Yes (mosaic layout, webview registry) | Operates on specific paneId |
+| **Persistence** | Hidden container parking | Stateless (reconnects on demand) |
+| **Context menu** | Native Electron menu with 10+ actions | N/A |
+| **Drag handling** | Pointer-events passthrough during drags | N/A |
+| **Focus management** | Standard browser focus | FocusLock suppresses blur during automation |
+| **Availability** | Always | Dev mode only (`DESKTOP_AUTOMATION_PORT`) |
+
+---
+
+## Data Flow: How V1 and V2 Connect
+
+### User Navigates Manually (V1 only)
+
+```
+User types URL in address bar
+  → BrowserToolbar.onNavigate(url)
+  → usePersistentWebview.navigateTo(url)
+  → webview.loadURL(sanitizeUrl(url))
+  → webview fires "did-navigate" event
+  → usePersistentWebview updates Zustand store
+  → usePersistentWebview upserts SQLite history
+  → BrowserToolbar re-renders with new URL
+```
+
+### AI Agent Navigates (V2 → V1)
+
+```
+User says "go to github.com" in chat
+  → Chat LLM (Mastra harness) decides to call MCP tool
+  → MCP "navigate" tool called with { url: "https://github.com" }
+  → ConnectionManager.getPage() → Puppeteer CDP connection
+  → page.goto("https://github.com")
+  → [OR: tRPC browser.navigate({ paneId, url })]
+  → BrowserManager.navigate(paneId, url)
+  → webContents.loadURL(sanitizeUrl(url))
+  → V1's webview fires navigation events
+  → V1's usePersistentWebview syncs store from webview
+  → V1's toolbar updates to show new URL
+```
+
+### AI Agent Takes Screenshot (V2 only)
+
+```
+Chat LLM decides to call "take_screenshot"
+  → MCP tool invoked
+  → ConnectionManager.getPage()
+  → page.screenshot({ encoding: "base64", type: "png" })
+  → base64 PNG returned to LLM
+  → LLM analyzes the image and responds to user
+```
+
+### Console Streaming (V2, built on V1's webview)
+
+```
+Web page logs to console
+  → V1's <webview> fires "console-message" event
+  → V2's BrowserManager.setupConsoleCapture() handler fires
+  → Entry added to circular buffer (max 500)
+  → BrowserManager emits "console:{paneId}" event
+  → tRPC consoleStream subscription picks up event
+  → observable.emit.next(entry) sends to subscriber
+  → Chat system receives real-time console log
+```
+
+### Context Menu "Open in Split" (V1 ← V2)
+
+```
+User right-clicks a link in browser pane
+  → V2's BrowserManager.setupContextMenu() intercepts "context-menu" event
+  → Builds native Electron Menu with "Open Link as New Split"
+  → User clicks "Open Link as New Split"
+  → BrowserManager emits "context-menu-action:{paneId}" with { action: "open-in-split", url }
+  → tRPC onContextMenuAction subscription fires
+  → V1's usePersistentWebview receives event
+  → Calls tabsStore.openInBrowserPane(workspaceId, url)
+  → New V1 browser pane created with the link URL
+```
+
+---
+
+## What V2 Adds to V1
+
+V2 is not a replacement. It is an **extension layer** that makes V1 machine-readable and machine-controllable:
+
+1. **Observability**: Console capture, page info queries, and screenshot APIs let AI agents "see" what's in the browser.
+
+2. **Control**: Navigate, evaluate JS, click, type, and send keys let AI agents "act" in the browser.
+
+3. **Real-time streaming**: tRPC subscriptions (observables) let the chat system react to browser events as they happen.
+
+4. **Cross-process bridge**: V1 lives in the renderer; V2's BrowserManager lives in the main process, making browser capabilities accessible to both the renderer (via tRPC) and external agents (via MCP/CDP).
+
+5. **Automation stability**: FocusLock prevents UI components from dismissing during agent tool calls when the Electron window loses OS focus.
+
+6. **Context menus**: V2's main-process context menu builder provides actions that flow back to V1 (like "Open in Split") -- something the renderer alone couldn't do because context menu access requires main-process Electron APIs.
+
+### What V1 Provides That V2 Relies On
+
+- The `<webview>` element and its `webContentsId` (V2 registers it)
+- DOM events that trigger store updates (V2's console capture piggybacks on the same webContents)
+- The persistent webview lifecycle (V2 doesn't manage creation/destruction)
+- Zustand state that drives the UI (V2 doesn't update the store directly)
+- SQLite browser history (V2 doesn't write history)
+- URL sanitization logic (duplicated in both layers)

--- a/docs/v2-browser-gap-analysis.md
+++ b/docs/v2-browser-gap-analysis.md
@@ -1,0 +1,334 @@
+# V2 Browser Gap Analysis & Improvement Plan
+
+## Referenced Issues
+
+| Issue | Title | Status | Category |
+|-------|-------|--------|----------|
+| #3076 | Browser refreshes every 5-20 seconds | Open | Reload bug |
+| #3040 | Browser reloads when navigating between tabs | Open | Reload bug |
+| #1834 | Browser Preview does not keep alive when switching tabs | Open | Reload bug |
+| #1935 | Browser refreshes upon switching tabs | Closed (regressed) | Reload bug |
+| #1637 | Browser pane reloads page every time you switch away and back | Closed (regressed) | Reload bug |
+| #1801 | MCP server for built-in browser automation | Open | Feature request |
+| #2551 | Internal browser element selection for easier LLM targeting | Open | Feature request |
+
+---
+
+## 1. Browser Tab Reload Bug (Critical)
+
+**Impact**: Makes the browser nearly unusable. 5 issues filed, 2 closed but regressed.
+
+### Root Cause Analysis
+
+The persistence mechanism in `usePersistentWebview.ts` parks webviews in a hidden offscreen container when their pane unmounts:
+
+```typescript
+// On unmount
+return () => {
+    // remove event listeners...
+    getHiddenContainer().appendChild(wv);  // park offscreen
+};
+```
+
+Several code-level issues likely cause unwanted reloads:
+
+#### 1.1 Hidden Container Dimensions
+
+The hidden container uses full viewport dimensions while positioned offscreen:
+
+```typescript
+// usePersistentWebview.ts:14-27
+hiddenContainer.style.position = "fixed";
+hiddenContainer.style.left = "-9999px";
+hiddenContainer.style.top = "-9999px";
+hiddenContainer.style.width = "100vw";   // Problem
+hiddenContainer.style.height = "100vh";  // Problem
+```
+
+A `100vw x 100vh` div positioned at `-9999px` can trigger Chromium compositor recalculations when webviews are reparented into it. The compositor may detect the dimensional change and invalidate the webview's backing store.
+
+**Fix**: Use `1px x 1px` with `overflow: hidden`, or `visibility: hidden` on individual webviews instead of offscreen positioning.
+
+#### 1.2 webContentsId Changes on DOM Reparenting
+
+The code explicitly anticipates `webContentsId` changing after reparenting:
+
+```typescript
+// usePersistentWebview.ts:207-214
+const handleDomReady = () => {
+    const webContentsId = wv.getWebContentsId();
+    const previousId = registeredWebContentsIds.get(paneId);
+    if (previousId !== webContentsId) {
+        registeredWebContentsIds.set(paneId, webContentsId);
+        registerBrowser({ paneId, webContentsId });  // re-registers with main process
+    }
+};
+```
+
+When Electron moves a `<webview>` between DOM containers, the compositor may create a new backing store, assigning a new `webContentsId`. This triggers:
+1. Re-registration with `BrowserManager` in main process
+2. Previous console/context-menu listeners cleaned up and re-attached
+3. Potential content loss during the transition
+
+**Fix**: Investigate whether keeping the webview in the same DOM parent (using `visibility: hidden` / `display: none` instead of reparenting) avoids `webContentsId` changes entirely. If reparenting is required, add a guard that skips `loadURL` if the page is already loaded.
+
+#### 1.3 React Unmount/Remount Cycle
+
+When the user switches tabs, React unmounts `BrowserPane`, triggering the `useEffect` cleanup that parks the webview. When switching back, `BrowserPane` remounts, and the effect re-runs, reclaiming the webview. This cycle is correct in theory, but:
+
+- If the React tree remounts more aggressively than expected (e.g., key changes, parent re-renders), the webview ping-pongs between containers
+- Each reparent fires `dom-ready`, potentially triggering re-registration
+- The 5-20 second interval in #3076 suggests a parent component may be re-rendering periodically (e.g., a timer, subscription, or store update causing the mosaic layout to remount)
+
+**Fix**: Investigate what causes `BrowserPane` to unmount. Add logging to track mount/unmount frequency. If a parent re-render is the cause, memoize the component or lift the webview management above the component that remounts.
+
+#### 1.4 No Synchronization Between Store and Webview After Park
+
+When a webview is parked hidden, it can still receive navigation events (e.g., an agent navigates while the pane is hidden). On reclaim, `syncStoreFromWebview` tries to reconcile:
+
+```typescript
+// usePersistentWebview.ts:150-171
+const syncStoreFromWebview = useCallback((webview) => {
+    const url = webview.getURL();
+    const title = webview.getTitle();
+    if (url !== currentUrl) {
+        store.updateBrowserUrl(paneId, url, title, faviconUrlRef.current);
+    }
+}, [paneId]);
+```
+
+But if the sync detects a URL mismatch and updates the store, downstream effects could trigger a re-navigation, causing an unnecessary reload.
+
+**Fix**: Ensure store updates from sync don't trigger navigation side effects.
+
+#### 1.5 Hidden Container Accumulation
+
+Parked webviews are never cleaned up unless explicitly destroyed. Over a long session, the hidden container accumulates webviews, increasing memory pressure and potentially triggering garbage collection cycles that affect active webviews.
+
+**Fix**: Add a cleanup strategy (e.g., destroy webviews for tabs that have been hidden for >N minutes, or limit the total number of parked webviews).
+
+### Recommended Investigation Steps
+
+1. Add telemetry logging to `handleDomReady` to track `webContentsId` changes on tab switch
+2. Log `useEffect` mount/unmount in `usePersistentWebview` to measure reparenting frequency
+3. Test with `visibility: hidden` on individual webviews instead of offscreen container reparenting
+4. Profile whether any periodic store update or subscription causes `BrowserPane` to unmount
+
+---
+
+## 2. MCP Tools Cannot Control Browser Panes (Critical Gap)
+
+**Issue**: #1801 requests MCP browser automation. MCP tools partially exist (`packages/desktop-mcp`) but they **do not control browser pane content**.
+
+### The Problem
+
+The `ConnectionManager` in `desktop-mcp` connects via CDP to the **main Electron renderer** and explicitly filters out browser pane webviews:
+
+```typescript
+// connection-manager.ts:47-50
+const appPage = pages.find((p) => {
+    const url = p.url();
+    return url.startsWith("http://localhost:") || url.startsWith("file://");
+});
+```
+
+This means all 9 MCP tools (`navigate`, `take_screenshot`, `click`, `type_text`, `send_keys`, `evaluate_js`, `inspect_dom`, `get_console_logs`, `get_window_info`) operate on the **Superset app UI**, not on web pages loaded in browser panes.
+
+Meanwhile, the tRPC browser router (`apps/desktop/src/lib/trpc/routers/browser/browser.ts`) does control browser pane content, but only exposes basic operations (`navigate`, `screenshot`, `evaluateJS`, `goBack`, `goForward`, `reload`). It has no click, type, hover, scroll, wait, or DOM inspection capabilities.
+
+### Architecture Gap
+
+```
+Current state:
+
+MCP Tools ──→ CDP ──→ Main Renderer (Superset App UI) ✅
+                      Browser Pane Webviews             ❌ (filtered out)
+
+tRPC Router ──→ IPC ──→ BrowserManager ──→ webContents  ✅ (basic ops only)
+                                                          ❌ (no click/type/hover/DOM)
+```
+
+### What's Needed
+
+Option A: **Extend tRPC browser router** with rich automation methods and expose them as MCP tools:
+
+```
+Chat LLM ──→ MCP Tools ──→ tRPC Browser Router ──→ BrowserManager ──→ webContents
+                            (extended with click, type, hover, scroll, DOM inspection, etc.)
+```
+
+Option B: **Connect MCP directly to browser pane webContents via CDP**:
+
+```
+Chat LLM ──→ MCP Tools ──→ CDP connection to webview webContents
+                            (requires webview remote debugging)
+```
+
+Option A is simpler since `BrowserManager` already has the `webContents` reference and `executeJavaScript` capability. Click, type, hover, scroll, and DOM inspection can all be implemented via injected JS.
+
+### Missing Automation Capabilities
+
+| Capability | tRPC Router | MCP (App UI) | Needed for Browser Pane |
+|-----------|-------------|-------------|------------------------|
+| Navigate | Yes | Yes | Already works |
+| Screenshot | Yes | Yes | Already works |
+| Evaluate JS | Yes | Yes | Already works |
+| Console logs | Yes (stream) | Yes (buffer) | Already works |
+| Page info | Yes | Yes | Already works |
+| Click element | No | Yes | **Missing** |
+| Type text | No | Yes | **Missing** |
+| Hover | No | No | **Missing** |
+| Scroll | No | No | **Missing** |
+| Wait for element | No | No | **Missing** |
+| DOM inspection | No | Yes | **Missing** |
+| Form filling | No | No | **Missing** |
+| File upload | No | No | **Missing** |
+| Drag and drop | No | No | **Missing** |
+| Key sequences | No | Partial | **Missing** |
+| Element highlighting | No | No | **Missing** |
+
+---
+
+## 3. Element Selection for LLMs (Feature Gap)
+
+**Issue**: #2551 requests an element selector in the browser pane so users can inspect/select elements and provide details to LLMs. Cursor has this feature.
+
+### Current State
+
+- `inspect_dom` in `desktop-mcp` returns structured element data (selectors, text, bounds, ARIA roles) but only for the **app UI**, not browser panes
+- `take_screenshot` returns raw PNG with no element annotations
+- No mechanism for users to visually select an element and get its selector/attributes
+- No mechanism for LLMs to "see" element boundaries on screenshots
+
+### What's Needed
+
+#### 3.1 User-Facing Element Inspector
+
+An interactive overlay in the browser pane that:
+- Highlights elements on hover (like browser DevTools inspect mode)
+- On click, captures element details (CSS selector, text content, bounding box, attributes, computed styles)
+- Copies details to clipboard or inserts into chat
+- Shows a floating panel with element info
+
+Implementation: Inject JS into the webview via `webContents.executeJavaScript()` that adds a mouse-tracking overlay. On click, serialize element data and send back via `webContents.send()` / IPC.
+
+#### 3.2 LLM-Facing Annotated Screenshots
+
+Screenshots with element bounding boxes overlaid:
+- Number each interactive element
+- Draw colored rectangles around clickable/typeable elements
+- Return both the annotated image and a text manifest mapping numbers to selectors
+
+This is the approach used by tools like [SoM (Set-of-Mark)](https://github.com/anthropics/anthropic-cookbook) and is critical for vision-based LLM interaction.
+
+#### 3.3 Accessibility Tree Export
+
+Export the browser pane's accessibility tree as structured data:
+- ARIA roles, labels, names
+- Interactive element states (disabled, checked, expanded)
+- Landmark regions (nav, main, aside)
+- Tab order
+
+This gives LLMs a semantic understanding of the page without needing screenshots.
+
+---
+
+## 4. Additional Improvements
+
+### 4.1 Address Bar Sync During Agent Navigation
+
+When an AI agent navigates via tRPC/MCP, the V1 toolbar doesn't always update immediately. The `syncStoreFromWebview` function runs on reclaim, but navigation events during park may be missed.
+
+**Fix**: The `did-navigate` listener is removed on unmount. Consider keeping a minimal listener attached even while parked, or sync on every reclaim.
+
+### 4.2 Console Log Improvements
+
+Current: 500-entry circular buffer, no filtering.
+
+Needed:
+- Filter by level (error-only mode for debugging)
+- Filter by source URL (ignore third-party script noise)
+- Stack traces for errors
+- Network request logging (XHR/fetch URLs, status codes)
+- Performance entries (LCP, FCP, CLS)
+
+### 4.3 Multi-Page Browser Automation
+
+Current MCP tools have no concept of "which browser pane." The tRPC router uses `paneId`, but MCP tools don't accept a pane identifier.
+
+**Fix**: MCP browser tools should accept an optional `paneId` parameter. Default to the focused browser pane. Add a `list_browser_panes` tool that returns all active panes with their URLs.
+
+### 4.4 Navigation Completion Detection
+
+No current mechanism to wait for a page to finish loading after `navigate`. Agents must guess or poll.
+
+**Fix**: Add a `waitForNavigation` option to the navigate tool that resolves after `did-stop-loading` fires, with a configurable timeout.
+
+### 4.5 Cookie/Auth Session Management
+
+The `persist:superset` partition shares cookies across all browser panes, but there's no way for agents to:
+- Set cookies programmatically (for authenticated testing)
+- Switch between session profiles
+- Clear cookies for a specific domain
+
+**Fix**: Extend `clearBrowsingData` to support domain-scoped clearing. Add `setCookie` / `getCookies` procedures.
+
+### 4.6 Responsive Testing
+
+No way to set viewport size for a browser pane. The webview fills its pane, but agents testing responsive layouts need explicit viewport control.
+
+**Fix**: Add a `setViewport(paneId, width, height)` procedure that resizes the webview or uses `webContents.enableDeviceEmulation()`.
+
+---
+
+## Priority Matrix
+
+### P0 -- Blocking / Regression
+
+| Item | Issues | Effort | Impact |
+|------|--------|--------|--------|
+| Fix browser tab reload on switch | #3076, #3040, #1834 | Medium | Critical -- app is unusable for browser users |
+| Fix periodic auto-reload (5-20s) | #3076 | Medium | Critical -- suggests a re-render loop |
+
+### P1 -- Core Feature Gaps
+
+| Item | Issues | Effort | Impact |
+|------|--------|--------|--------|
+| MCP tools for browser pane content | #1801 | Large | Unlocks AI browser automation |
+| Element click/type/hover via MCP | #1801 | Medium | Core automation actions |
+| DOM inspection for browser panes | #1801, #2551 | Medium | LLM page understanding |
+| Wait-for-element / wait-for-navigation | #1801 | Small | Reliable automation |
+
+### P2 -- Enhancement
+
+| Item | Issues | Effort | Impact |
+|------|--------|--------|--------|
+| User-facing element inspector | #2551 | Medium | Cursor-parity feature |
+| Annotated screenshots (Set-of-Mark) | #2551 | Medium | Vision LLM effectiveness |
+| Accessibility tree export | #2551 | Small | Semantic page understanding |
+| Multi-pane MCP targeting | -- | Small | Multi-browser workflows |
+| Scroll control | -- | Small | Page automation completeness |
+| Navigation completion detection | -- | Small | Automation reliability |
+
+### P3 -- Nice to Have
+
+| Item | Issues | Effort | Impact |
+|------|--------|--------|--------|
+| Console log filtering by level/source | -- | Small | Debugging convenience |
+| Network request logging | -- | Medium | API debugging |
+| Cookie/session management | -- | Small | Auth testing |
+| Viewport/responsive emulation | -- | Small | Responsive testing |
+| File upload handling | -- | Medium | Form automation |
+| Drag-and-drop support | -- | Large | Niche use cases |
+
+---
+
+## Summary
+
+The three most impactful improvements are:
+
+1. **Fix the reload bug** (P0): The hidden container reparenting approach has several potential failure modes. Investigate `webContentsId` changes, container dimensions, and React remount frequency. This affects every browser user.
+
+2. **Bridge MCP tools to browser panes** (P1): The MCP tools exist but target the wrong thing (app UI vs browser content). Extending the tRPC browser router with click/type/hover/DOM inspection and exposing those as MCP tools would close the #1801 gap.
+
+3. **Element selection + annotated screenshots** (P2): Adding a user-facing element inspector and Set-of-Mark style annotated screenshots would close #2551 and significantly improve LLM effectiveness when working with web pages.

--- a/docs/v2-browser-refactor-plan.md
+++ b/docs/v2-browser-refactor-plan.md
@@ -1,0 +1,310 @@
+# V2 Browser Refactor Plan
+
+## Context
+
+The Superset desktop browser has three major problems: (1) browser panes reload when switching tabs (#3076, #3040, #1834), (2) MCP tools cannot control browser pane content -- they only automate the Superset app UI (#1801), and (3) there's no element selection mechanism for LLMs (#2551). This plan addresses all three with a phased refactor.
+
+---
+
+## Phase 1: Fix Browser Tab Reload Bug
+
+**Goal**: Eliminate unwanted webview reloads on tab switch.
+
+### Root Cause
+
+`TabsContent` renders only the active tab:
+
+```tsx
+// apps/desktop/src/renderer/.../TabsContent/index.tsx:92-93
+{tabToRender ? <TabView tab={tabToRender} /> : <EmptyTabView />}
+```
+
+Switching tabs unmounts the entire `TabView` → unmounts `BrowserPane` → `usePersistentWebview` cleanup parks the webview in a hidden offscreen container → switching back remounts everything → webview is reclaimed via DOM reparenting → Electron may create a new backing store (the code explicitly checks for `webContentsId` changes in `handleDomReady`).
+
+### Step 1.1: Render all workspace tabs, hide inactive ones
+
+**File**: `apps/desktop/src/renderer/.../TabsContent/index.tsx`
+
+Change from rendering a single `TabView` to rendering all tabs for the active workspace, with inactive tabs hidden via `display: none`:
+
+```tsx
+const workspaceTabs = allTabs.filter(t => t.workspaceId === activeWorkspaceId);
+
+return (
+  <div ref={contentRef} className="flex-1 min-h-0 flex overflow-hidden">
+    {workspaceTabs.length === 0 && <EmptyTabView ... />}
+    {workspaceTabs.map(tab => (
+      <div
+        key={tab.id}
+        style={{ display: tab.id === activeTabId ? 'contents' : 'none' }}
+      >
+        <TabView tab={tab} />
+      </div>
+    ))}
+  </div>
+);
+```
+
+This prevents `BrowserPane` from unmounting on tab switch. The webview stays in place -- no reparenting, no `webContentsId` change, no reload.
+
+**Memory mitigation**: Add a max-mounted-tabs threshold (e.g., 6). If exceeded, unmount the least-recently-used tabs. This bounds memory while keeping the most relevant tabs alive.
+
+### Step 1.2: Simplify `usePersistentWebview`
+
+**File**: `apps/desktop/src/renderer/.../BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts`
+
+With Step 1.1 in place, the hidden container parking becomes a fallback rather than the primary mechanism. Simplify:
+
+- Fix hidden container dimensions: `100vw x 100vh` → `1px x 1px` with `overflow: hidden`
+- The cleanup effect now only fires on pane deletion (not tab switch), making it simpler
+- Keep the registry for cross-workspace tab switches where unmounting is still necessary
+
+### Step 1.3: Add telemetry for webContentsId changes
+
+**File**: `apps/desktop/src/renderer/.../usePersistentWebview.ts` (in `handleDomReady`)
+
+Log when `webContentsId` changes to validate the fix:
+
+```typescript
+if (previousId !== webContentsId) {
+  console.warn(`[browser] webContentsId changed for pane ${paneId}: ${previousId} → ${webContentsId}`);
+  // ... existing re-registration logic
+}
+```
+
+### Files Modified (Phase 1)
+
+| File | Change |
+|------|--------|
+| `apps/desktop/src/renderer/.../TabsContent/index.tsx` | Render all workspace tabs, hide inactive |
+| `apps/desktop/src/renderer/.../usePersistentWebview.ts` | Fix hidden container to `1px x 1px`, add telemetry |
+
+---
+
+## Phase 2: Bridge MCP Tools to Browser Panes
+
+**Goal**: Let AI agents click, type, hover, scroll, inspect DOM, and wait for elements in browser pane content.
+
+### Architecture Decision
+
+**Approach**: Extend `BrowserManager` (main process) with DOM interaction methods using `webContents.executeJavaScript()` and `webContents.sendInputEvent()`. Expose via tRPC. For external agents (desktop-mcp), extend `ConnectionManager` to target browser pane CDP pages.
+
+The existing JS scripts (`FIND_ELEMENT_SCRIPT` from `click.ts`, `DOM_INSPECTOR_SCRIPT` from `dom-inspector.ts`) can be reused -- they're plain JS that works in any browser context.
+
+### Step 2.1: Extract shared browser scripts
+
+**New file**: `apps/desktop/src/shared/browser-scripts.ts`
+
+Move `FIND_ELEMENT_SCRIPT` and `DOM_INSPECTOR_SCRIPT` into a shared module importable by both `BrowserManager` and `desktop-mcp`:
+
+```typescript
+export const FIND_ELEMENT_SCRIPT = `(opts) => { ... }`;  // from click.ts
+export const DOM_INSPECTOR_SCRIPT = `function inspectDom(...) { ... }`;  // from dom-inspector.ts
+```
+
+### Step 2.2: Add DOM interaction methods to BrowserManager
+
+**File**: `apps/desktop/src/main/lib/browser/browser-manager.ts`
+
+Add methods:
+
+| Method | Implementation |
+|--------|---------------|
+| `click(paneId, opts)` | Inject `FIND_ELEMENT_SCRIPT` → get coordinates → `wc.sendInputEvent({ type: 'mouseDown' })` + `mouseUp` |
+| `type(paneId, opts)` | Optional focus via selector → `wc.insertText(text)` (or `sendInputEvent` for special keys) |
+| `hover(paneId, opts)` | Inject find script → `wc.sendInputEvent({ type: 'mouseMove', x, y })` |
+| `scroll(paneId, opts)` | `wc.sendInputEvent({ type: 'mouseWheel', deltaX, deltaY })` |
+| `waitForElement(paneId, opts)` | Poll `wc.executeJavaScript('!!document.querySelector(selector)')` with timeout |
+| `inspectDom(paneId, opts)` | Inject `DOM_INSPECTOR_SCRIPT` via `wc.executeJavaScript()` |
+| `listPanes()` | Iterate `paneWebContentsIds`, return `{ paneId, url, title }` per entry |
+
+### Step 2.3: Add tRPC procedures
+
+**File**: `apps/desktop/src/lib/trpc/routers/browser/browser.ts`
+
+Add 7 new procedures matching the BrowserManager methods above. All use Zod input validation and call through to `browserManager.*()`.
+
+### Step 2.4: Inject paneId marker into webviews
+
+**File**: `apps/desktop/src/main/lib/browser/browser-manager.ts` (in `register` method)
+
+After registering a pane, inject a global marker:
+
+```typescript
+wc.executeJavaScript(`window.__SUPERSET_PANE_ID__ = ${JSON.stringify(paneId)}`);
+```
+
+Re-inject on navigation via `wc.on('did-navigate', () => { ... })` since page loads clear globals.
+
+### Step 2.5: Extend ConnectionManager for browser pane targeting
+
+**File**: `packages/desktop-mcp/src/mcp/connection/connection-manager.ts`
+
+Add methods:
+
+```typescript
+async getBrowserPanePage(paneId: string): Promise<Page>
+// Iterates CDP pages, evaluates window.__SUPERSET_PANE_ID__ to find match
+
+async listBrowserPanes(): Promise<Array<{paneId: string; url: string; title: string}>>
+// Returns all pages with a __SUPERSET_PANE_ID__ marker
+```
+
+### Step 2.6: Add browser-pane MCP tools
+
+**New files** in `packages/desktop-mcp/src/mcp/tools/`:
+
+| Tool | File | Description |
+|------|------|-------------|
+| `list_browser_panes` | `list-browser-panes/` | List all open browser panes with URLs |
+| `browser_click` | `browser-click/` | Click element in a browser pane |
+| `browser_type` | `browser-type/` | Type text in a browser pane |
+| `browser_hover` | `browser-hover/` | Hover over element |
+| `browser_scroll` | `browser-scroll/` | Scroll viewport or element |
+| `browser_wait` | `browser-wait/` | Wait for element to appear |
+| `browser_inspect_dom` | `browser-inspect-dom/` | Inspect DOM of browser pane |
+| `browser_screenshot` | `browser-screenshot/` | Screenshot a specific browser pane |
+
+Each tool takes a `paneId` parameter and uses `getBrowserPanePage(paneId)`.
+
+Update `ToolContext` interface and `registerTools` in `packages/desktop-mcp/src/mcp/tools/index.ts`.
+
+### Files Modified (Phase 2)
+
+| File | Change |
+|------|--------|
+| `apps/desktop/src/shared/browser-scripts.ts` | **New** -- shared JS injection scripts |
+| `apps/desktop/src/main/lib/browser/browser-manager.ts` | Add 7 DOM interaction methods, paneId injection |
+| `apps/desktop/src/lib/trpc/routers/browser/browser.ts` | Add 7 tRPC procedures |
+| `packages/desktop-mcp/src/mcp/connection/connection-manager.ts` | Add `getBrowserPanePage`, `listBrowserPanes` |
+| `packages/desktop-mcp/src/mcp/tools/index.ts` | Update `ToolContext`, register new tools |
+| `packages/desktop-mcp/src/mcp/tools/browser-click/browser-click.ts` | **New** |
+| `packages/desktop-mcp/src/mcp/tools/browser-type/browser-type.ts` | **New** |
+| `packages/desktop-mcp/src/mcp/tools/browser-hover/browser-hover.ts` | **New** |
+| `packages/desktop-mcp/src/mcp/tools/browser-scroll/browser-scroll.ts` | **New** |
+| `packages/desktop-mcp/src/mcp/tools/browser-wait/browser-wait.ts` | **New** |
+| `packages/desktop-mcp/src/mcp/tools/browser-inspect-dom/browser-inspect-dom.ts` | **New** |
+| `packages/desktop-mcp/src/mcp/tools/browser-screenshot/browser-screenshot.ts` | **New** |
+| `packages/desktop-mcp/src/mcp/tools/list-browser-panes/list-browser-panes.ts` | **New** |
+
+---
+
+## Phase 3: Element Selection for LLMs
+
+**Goal**: Annotated screenshots (Set-of-Mark) and user-facing element inspector.
+
+### Step 3.1: Annotated screenshot script
+
+**New file**: `apps/desktop/src/shared/browser-scripts/annotate-elements.ts`
+
+JS injected into the webview that:
+1. Finds all interactive elements (reusing DOM_INSPECTOR_SCRIPT logic)
+2. Creates a `<div id="__superset-som-overlay">` with `position: fixed; z-index: 999999; pointer-events: none`
+3. For each element, draws a numbered badge + colored border overlay
+4. Returns the element list with assigned numbers
+
+Cleanup script removes `#__superset-som-overlay`.
+
+### Step 3.2: Add `annotatedScreenshot` to BrowserManager and tRPC
+
+**Files**: `browser-manager.ts`, `browser.ts` (tRPC router)
+
+```typescript
+async annotatedScreenshot(paneId: string): Promise<{base64: string; elements: AnnotatedElement[]}> {
+  const wc = this.getWebContents(paneId);
+  const elements = await wc.executeJavaScript(ANNOTATE_ELEMENTS_SCRIPT);
+  const image = await wc.capturePage();
+  await wc.executeJavaScript(REMOVE_ANNOTATIONS_SCRIPT);
+  return { base64: image.toPNG().toString("base64"), elements };
+}
+```
+
+### Step 3.3: Add `browser_annotated_screenshot` MCP tool
+
+**New file**: `packages/desktop-mcp/src/mcp/tools/browser-annotated-screenshot/`
+
+Returns the annotated image as MCP `image` content + text manifest mapping numbers to selectors.
+
+### Step 3.4: User-facing element inspector
+
+**New files**:
+- `apps/desktop/src/shared/browser-scripts/element-inspector.ts` -- injected JS for hover highlight + click capture
+- `.../BrowserPane/components/ElementInspectorPanel/ElementInspectorPanel.tsx` -- UI panel showing selected element info
+
+**Modified files**:
+- `browser-manager.ts` -- add `startInspector(paneId)`, `stopInspector(paneId)` methods
+- `browser.ts` (tRPC) -- add `startInspector`, `stopInspector`, `onInspectorSelection` (subscription) procedures
+- `BrowserToolbar.tsx` -- add inspector toggle button (crosshairs icon)
+
+The inspector injects JS into the webview that highlights elements on hover and captures click targets. Selection events flow back via `webContents` IPC → BrowserManager EventEmitter → tRPC subscription → UI panel.
+
+### Files Modified (Phase 3)
+
+| File | Change |
+|------|--------|
+| `apps/desktop/src/shared/browser-scripts/annotate-elements.ts` | **New** -- SoM overlay script |
+| `apps/desktop/src/shared/browser-scripts/element-inspector.ts` | **New** -- inspector overlay script |
+| `apps/desktop/src/main/lib/browser/browser-manager.ts` | Add `annotatedScreenshot`, `startInspector`, `stopInspector` |
+| `apps/desktop/src/lib/trpc/routers/browser/browser.ts` | Add 3 procedures |
+| `.../BrowserPane/components/ElementInspectorPanel/ElementInspectorPanel.tsx` | **New** -- selection UI |
+| `.../BrowserPane/components/BrowserToolbar/BrowserToolbar.tsx` | Add inspector toggle |
+| `packages/desktop-mcp/src/mcp/tools/browser-annotated-screenshot/` | **New** -- MCP tool |
+
+---
+
+## Implementation Order
+
+```
+Phase 1 (Week 1) ─────────────────────────────
+  1.1 TabsContent render-all-tabs
+  1.2 Simplify usePersistentWebview
+  1.3 Add telemetry
+  
+Phase 2 (Weeks 2-3) ──────────────────────────
+  2.1 Extract shared browser scripts
+  2.2 BrowserManager DOM methods
+  2.3 tRPC procedures
+  2.4 PaneId marker injection
+  2.5 ConnectionManager browser pane support
+  2.6 Browser-pane MCP tools
+
+Phase 3 (Week 4) ─────────────────────────────
+  3.1-3.3 Annotated screenshots
+  3.4 Element inspector UI
+```
+
+Phases 1 and 2.1-2.3 can run in parallel since they touch different files.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Rendering all tabs increases memory | Max-mounted-tabs threshold (6), LRU eviction |
+| react-mosaic may have issues with hidden instances | Disable resize on hidden tabs, block pointer events |
+| `__SUPERSET_PANE_ID__` global cleared on navigation | Re-inject via `did-navigate` listener on webContents |
+| `sendInputEvent` coordinates may differ from DOM getBoundingClientRect | Account for devicePixelRatio in coordinate translation |
+| SoM overlays affect screenshot content | Use `pointer-events: none`, `position: fixed`, clean up immediately after capture |
+
+---
+
+## Verification
+
+### Phase 1
+- Open browser pane, fill in form data, switch tabs, switch back → no reload, form preserved
+- Check console for `webContentsId` change warnings → should see none on tab switch
+- Open 8+ tabs → verify LRU eviction kicks in at threshold
+
+### Phase 2
+- `list_browser_panes` returns open panes with URLs
+- `browser_click` clicks a button in a web page loaded in a browser pane
+- `browser_type` types into an input field
+- `browser_inspect_dom` returns element tree with selectors and bounds
+- `browser_wait` resolves when a dynamically loaded element appears
+- All tools work from both chat (tRPC) and external agents (MCP)
+
+### Phase 3
+- `browser_annotated_screenshot` returns image with numbered elements + text manifest
+- Toggle inspector in toolbar → hover highlights elements → click captures selector
+- "Copy Selector" copies valid CSS selector to clipboard

--- a/docs/vscode-vs-superset-browser-architecture.md
+++ b/docs/vscode-vs-superset-browser-architecture.md
@@ -1,0 +1,565 @@
+# VS Code vs Superset: Browser Architecture Comparison
+
+## Executive Summary
+
+VS Code and Superset take fundamentally different approaches to embedding browsers. VS Code treats webviews as sandboxed content containers for extensions, with its "Simple Browser" being a minimal iframe-in-a-webview utility (~400 lines). Superset treats the browser as a first-class AI-controllable workspace pane with full automation capabilities. The architectural differences stem from their core missions: VS Code is an editor that occasionally shows web content; Superset is an AI agent orchestrator where browsing is a primary interaction mode.
+
+---
+
+## 1. Embedding Technology
+
+### VS Code: Iframes (Double-Nested)
+
+VS Code uses **standard HTML `<iframe>` elements** -- not Electron's `<webview>` tag. This is a deliberate cross-platform choice so the same code works in both Electron desktop and vscode.dev (web).
+
+The architecture uses a **three-layer nesting model**:
+
+```
+VS Code Window (Electron BrowserWindow)
+  └─ Outer iframe (pre/index.html) -- unique SHA-256 origin per webview
+       └─ Inner iframe (fake.html → document.write) -- extension HTML content
+            └─ [Simple Browser only] Content iframe -- the actual web page
+```
+
+Each webview gets a **cryptographically unique origin** derived from `SHA-256(parentOrigin + salt)`. This gives every webview its own browsing context, localStorage, and process isolation in Chromium.
+
+The inner iframe is loaded via `fake.html` then populated with `document.write()` -- a technique that establishes the correct origin before injecting content.
+
+**Source**: `src/vs/workbench/contrib/webview/browser/webviewElement.ts`, `src/vs/workbench/contrib/webview/browser/pre/index.html`
+
+### Superset: Electron `<webview>` Tags
+
+Superset uses **Electron's native `<webview>` tag** directly in the renderer process:
+
+```
+Electron BrowserWindow (Main Window)
+  └─ React App (renderer)
+       └─ BrowserPane component
+            └─ <webview partition="persist:superset"> -- the web page
+```
+
+The webview is created as a DOM element in the renderer:
+
+```typescript
+// usePersistentWebview.ts
+webview = document.createElement("webview") as Electron.WebviewTag;
+webview.setAttribute("partition", "persist:superset");
+webview.setAttribute("allowpopups", "");
+```
+
+Each webview gets its own renderer process (Chromium's out-of-process iframe model), with a persistent session partition (`persist:superset`) that shares cookies/storage across all browser panes.
+
+**Source**: `apps/desktop/src/renderer/.../BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts`
+
+### Comparison
+
+| Aspect | VS Code | Superset |
+|--------|---------|----------|
+| **Element type** | `<iframe>` (3 layers deep) | `<webview>` (1 layer) |
+| **Cross-platform** | Yes (works in browser + Electron) | Electron-only |
+| **Process isolation** | Via unique origins (Chromium site isolation) | Electron webview process isolation |
+| **Session/cookies** | Per-webview (unique origins) | Shared via `persist:superset` partition |
+| **Complexity** | High (origin hashing, service workers, fake.html) | Low (direct DOM element) |
+
+---
+
+## 2. Persistence & Lifecycle
+
+### VS Code: Claim/Release with Optional Retention
+
+VS Code uses an **`OverlayWebview`** system with a `claim()`/`release()` ownership model:
+
+- **`retainContextWhenHidden: false`** (default): When a tab is hidden, the iframe is **destroyed**. On re-show, HTML is re-injected, but all JS state, DOM, and in-memory data are lost. Extension-managed state survives via `acquireVsCodeApi().setState()`.
+- **`retainContextWhenHidden: true`**: The iframe stays alive but is hidden via `visibility: hidden`. JS keeps running, timers fire, DOM is preserved. Costs more memory.
+
+Overlay webviews are mounted at the **workbench root level** with absolute positioning, avoiding DOM reparenting (which would destroy the iframe):
+
+```typescript
+// overlayWebview.ts
+node.style.position = 'absolute';
+node.style.overflow = 'hidden';
+root.appendChild(node);  // mounted at top level, not inside the tab
+```
+
+For serialization across VS Code restarts, a `WebviewPanelSerializer` + `RevivalPool` pattern lazily restores webviews when their extension activates.
+
+### Superset: Hidden Container Parking
+
+Superset uses a simpler but effective **offscreen parking** strategy:
+
+```typescript
+// usePersistentWebview.ts
+function getHiddenContainer(): HTMLDivElement {
+    hiddenContainer = document.createElement("div");
+    hiddenContainer.style.position = "fixed";
+    hiddenContainer.style.left = "-9999px";
+    hiddenContainer.style.top = "-9999px";
+    // ...
+    document.body.appendChild(hiddenContainer);
+}
+```
+
+When a browser pane unmounts (e.g., tab switch), the `<webview>` is moved to this offscreen container instead of being destroyed. When the pane remounts, the webview is reclaimed from the hidden container:
+
+```typescript
+// On mount
+let webview = webviewRegistry.get(paneId);
+if (webview) {
+    container.appendChild(webview);  // reclaim from hidden container
+    syncStoreFromWebview(webview);
+} else {
+    webview = document.createElement("webview");  // create new
+}
+
+// On unmount (cleanup function)
+return () => {
+    getHiddenContainer().appendChild(wv);  // park offscreen
+};
+```
+
+A **module-level singleton registry** (`Map<string, Electron.WebviewTag>`) tracks all live webviews across the entire application.
+
+### Comparison
+
+| Aspect | VS Code | Superset |
+|--------|---------|----------|
+| **Default behavior** | Destroy on hide, recreate on show | Park offscreen, reclaim on show |
+| **State preservation** | Opt-in (`retainContextWhenHidden`) | Always preserved (webview stays alive) |
+| **Memory cost** | Low by default (destroy unused) | Higher (all webviews stay alive) |
+| **Implementation** | Overlay system with absolute positioning | Offscreen container at `-9999px` |
+| **Registry** | Per-service tracking with disposal | Module-level `Map` singleton |
+| **Cross-restart** | Serializer + RevivalPool | Browser history in SQLite |
+
+---
+
+## 3. IPC & Communication
+
+### VS Code: MessagePort + Typed Protocol
+
+VS Code uses the **MessageChannel API** (high-performance, avoids origin checking on every message):
+
+1. Outer iframe creates a `MessageChannel`
+2. Sends `port2` to parent via `window.parent.postMessage({ channel: 'webview-ready' }, origin, [port2])`
+3. Host stores `port1` as the communication channel
+4. All subsequent messages flow through `MessagePort.postMessage()`
+
+Messages are strongly typed via `FromWebviewMessage` (25+ types) and `ToWebviewMessage` (15+ types):
+
+```typescript
+// FromWebviewMessage examples
+'onmessage'          // extension-to-extension messages
+'did-click-link'     // link navigation
+'did-scroll'         // scroll position (throttled)
+'load-resource'      // local file access request
+'did-keydown'        // keyboard events for rebinding
+'did-context-menu'   // right-click
+```
+
+A state machine queues messages during initialization and flushes them when the webview signals readiness.
+
+### Superset: tRPC over Electron IPC
+
+Superset uses **tRPC** (with `trpc-electron`) for all communication between renderer and main process:
+
+```typescript
+// Renderer calls main process
+electronTrpc.browser.navigate.useMutation();
+electronTrpc.browser.register.useMutation();
+electronTrpc.browserHistory.upsert.useMutation();
+
+// Subscriptions use observable pattern (required for trpc-electron)
+electronTrpc.browser.onNewWindow.useSubscription({ paneId }, {
+    onData: ({ url }) => { /* handle new window */ }
+});
+```
+
+The tRPC router exposes 15 procedures (mutations, queries, subscriptions). Subscriptions **must** use the `observable()` pattern -- async generators silently fail with `trpc-electron`.
+
+Webview events are captured directly via DOM event listeners in the renderer:
+
+```typescript
+wv.addEventListener("dom-ready", handleDomReady);
+wv.addEventListener("did-navigate", handleDidNavigate);
+wv.addEventListener("page-title-updated", handlePageTitleUpdated);
+wv.addEventListener("page-favicon-updated", handlePageFaviconUpdated);
+wv.addEventListener("did-fail-load", handleDidFailLoad);
+```
+
+### Comparison
+
+| Aspect | VS Code | Superset |
+|--------|---------|----------|
+| **Channel** | MessagePort (browser API) | tRPC over Electron IPC |
+| **Type safety** | TypeScript interfaces (`FromWebviewMessage`) | Zod schemas on tRPC procedures |
+| **Real-time** | MessagePort events | tRPC subscriptions (observables) |
+| **Direction** | Bidirectional through same port | Renderer→Main (mutations/queries), Main→Renderer (subscriptions) |
+| **Queuing** | State machine with pending messages | tRPC handles internally |
+| **Overhead** | Minimal (direct port) | Higher (serialization, Zod validation) |
+
+---
+
+## 4. Navigation & Browser Chrome
+
+### VS Code Simple Browser: Minimal Chrome
+
+The Simple Browser generates HTML with a basic toolbar:
+
+```html
+<header class="header">
+    <nav class="controls">
+        <button class="back-button">←</button>
+        <button class="forward-button">→</button>
+        <button class="reload-button">↻</button>
+    </nav>
+    <input class="url-input" type="text">
+    <nav class="controls">
+        <button class="open-external-button">↗</button>
+    </nav>
+</header>
+<div class="content">
+    <iframe sandbox="allow-scripts allow-forms allow-same-origin allow-downloads"></iframe>
+</div>
+```
+
+**Known limitations** (acknowledged in source comments):
+- **Address bar doesn't sync**: Cross-origin restrictions prevent reading `iframe.contentWindow.location`. If the user clicks a link inside the page, the URL bar becomes stale.
+- **Back/Forward uses webview history, not iframe history**: Only navigations triggered by `navigateTo()` (which changes `iframe.src`) appear in the history. In-page link clicks are invisible.
+- **Reload is broken**: `history.go(0)` doesn't work, so it re-navigates to the address bar value (which may not match the current page). This also pollutes the history stack.
+- **No DevTools, no console, no tabs**: By design -- it's a utility, not a browser.
+
+### Superset: Full Browser Chrome with Autocomplete
+
+Superset's `BrowserToolbar` is a React component with:
+- Back/Forward/Reload buttons with loading state indicators
+- **Two-mode address bar**: Display mode (shows URL + page title) and Edit mode (text input with autocomplete)
+- **URL autocomplete** from browsing history (SQLite-backed, with `useUrlAutocomplete` hook)
+- DevTools button (opens Chromium DevTools in detached mode)
+- Overflow menu with additional actions
+- Error overlay for failed page loads
+- Blank state UI ("Enter a URL above, or instruct an agent to navigate and use the browser")
+
+Because Superset uses `<webview>` instead of cross-origin iframes, it has **full access to navigation state**:
+
+```typescript
+// Can read URL and title directly from the webview
+const url = wv.getURL();
+const title = wv.getTitle();
+
+// Navigation events fire reliably
+wv.addEventListener("did-navigate", handleDidNavigate);
+wv.addEventListener("did-navigate-in-page", handleDidNavigateInPage);
+```
+
+**URL sanitization** handles edge cases intelligently:
+
+```typescript
+function sanitizeUrl(url: string): string {
+    if (/^https?:\/\//i.test(url)) return url;           // Already valid
+    if (url.startsWith("localhost")) return `http://${url}`;  // Local dev
+    if (url.includes(".")) return `https://${url}`;        // Domain-like
+    return `https://www.google.com/search?q=${encodeURIComponent(url)}`;  // Search fallback
+}
+```
+
+### Comparison
+
+| Aspect | VS Code Simple Browser | Superset Browser Pane |
+|--------|----------------------|---------------------|
+| **Address bar sync** | Broken (cross-origin restriction) | Works (webview API access) |
+| **Back/Forward** | Partial (webview history only) | Full (manages own history stack in Zustand store) |
+| **Reload** | Broken (acknowledged in comments) | Works (`webview.reload()`) |
+| **URL autocomplete** | None | SQLite-backed history search |
+| **DevTools** | None | Chromium DevTools (detached mode) |
+| **Tabs/multi-instance** | Single instance (manager reuses) | Multiple panes via mosaic layout |
+| **Error handling** | None (iframe failures are silent) | Error overlay with retry button |
+| **URL intelligence** | Basic (just sets iframe.src) | Sanitization with search fallback |
+
+---
+
+## 5. Security Model
+
+### VS Code: Defense in Depth
+
+VS Code's security model is exceptionally thorough, with **7 layers**:
+
+1. **Origin isolation**: SHA-256 unique origin per webview
+2. **Sandbox attributes**: Granular (`allow-scripts`, `allow-same-origin`, `allow-forms`, `allow-pointer-lock`, `allow-downloads`)
+3. **Content Security Policy**: Strict CSP at both outer and inner frame levels; CSP-less webviews trigger developer warnings
+4. **Resource allowlisting**: `localResourceRoots` -- only explicitly declared directories are accessible via service worker
+5. **Protocol allowlisting**: Electron's `vscode-webview://` protocol handler only serves exactly 3 files (`index.html`, `fake.html`, `service-worker.js`)
+6. **Parent frame isolation**: `window.parent = window; window.top = window; window.frameElement = null;` prevents webview content from accessing the host
+7. **Menu shortcut isolation**: `setIgnoreMenuShortcuts` prevents webview keystrokes from triggering VS Code menu accelerators
+
+The `acquireVsCodeApi()` bridge is **frozen** (`Object.freeze()`) and **single-use** (can only be acquired once per webview).
+
+### Superset: Practical Security
+
+Superset's security model is simpler, relying on Electron's built-in webview isolation:
+
+1. **Process isolation**: `<webview>` tags run in separate renderer processes
+2. **Session partitioning**: `persist:superset` partition separates browser pane cookies/storage from the app
+3. **Window open blocking**: `setWindowOpenHandler` denies all popups, emitting events instead
+4. **Background throttling**: Enabled to prevent offscreen webviews from consuming resources
+5. **Browsing data clearing**: Explicit API to clear cookies, cache, and storage
+
+```typescript
+wc.setWindowOpenHandler(({ url }) => {
+    this.emit(`new-window:${paneId}`, url);
+    return { action: "deny" };  // block all popups
+});
+```
+
+### Comparison
+
+| Aspect | VS Code | Superset |
+|--------|---------|----------|
+| **Isolation model** | Unique origins via SHA-256 + iframes | Electron webview process isolation |
+| **CSP enforcement** | Strict, multi-layer, developer warnings | None on browser pane content |
+| **Resource access** | Allowlisted via `localResourceRoots` | Full web access (it's a browser) |
+| **Parent access** | Blocked (`window.parent = window`) | Blocked by Electron webview boundary |
+| **Popup handling** | `allow-popups` omitted from sandbox | `setWindowOpenHandler` denies, emits event |
+| **Complexity** | Very high (7 layers) | Low (Electron defaults + session partition) |
+
+This difference makes sense: VS Code webviews run arbitrary extension code that could be malicious, so defense-in-depth is critical. Superset's browser panes load user-requested web pages -- the threat model is different.
+
+---
+
+## 6. AI/Automation Integration
+
+### VS Code: None (in Simple Browser)
+
+The Simple Browser has **zero automation capabilities**. It is a passive content viewer. There is no API for:
+- Programmatic navigation from extensions (beyond opening a URL)
+- Screenshot capture
+- DOM inspection or JS evaluation
+- Click/type simulation
+- Console log access
+
+Extensions can only `show(url)` -- after that, the browser is a black box.
+
+VS Code does have separate extension APIs for webview manipulation, but these operate on the webview's extension-provided HTML, not on web pages loaded in iframes.
+
+### Superset: Two-Layer Automation
+
+Superset has **two independent automation systems**:
+
+#### Layer 1: Browser Pane Automation (tRPC + BrowserManager)
+
+The chat system's MCP tools call tRPC procedures that operate on the embedded `<webview>`:
+
+```
+Chat LLM → MCP tool call → tRPC mutation → BrowserManager → webContents API
+```
+
+Capabilities:
+- `navigate(paneId, url)` -- load URLs
+- `screenshot(paneId)` -- capture page as base64 PNG
+- `evaluateJS(paneId, code)` -- execute arbitrary JavaScript
+- `getConsoleLogs(paneId)` -- read console output (500-entry circular buffer)
+- `getPageInfo(paneId)` -- URL, title, loading state, navigation capability
+- `openDevTools(paneId)` -- open Chromium DevTools
+- `clearBrowsingData(type)` -- clear cookies/cache/storage
+
+#### Layer 2: App UI Automation (desktop-mcp + Puppeteer/CDP)
+
+A separate MCP server automates the Superset desktop app itself via Chrome DevTools Protocol:
+
+```
+External AI Agent → MCP → Puppeteer → CDP → Electron Renderer
+```
+
+This connects to the Electron app's debug port and provides:
+- `navigate` -- app route navigation (`window.location.hash`)
+- `take_screenshot` -- capture the entire Superset window
+- `click` / `type_text` / `send_keys` -- interact with the IDE UI
+- `inspect_dom` -- analyze the app's DOM
+- `evaluate_js` -- run JS in the app context
+- `get_console_logs` -- app console output
+
+A **FocusLock** mechanism prevents Radix UI dropdowns from closing when Electron loses OS focus during automation:
+
+```javascript
+// Suppresses blur/focusout when document.hasFocus() is false
+const suppress = (e) => {
+    if (e.relatedTarget === null && !document.hasFocus()) {
+        e.stopImmediatePropagation();
+    }
+};
+```
+
+### Comparison
+
+| Aspect | VS Code | Superset |
+|--------|---------|----------|
+| **Browser automation** | None | Full (navigate, screenshot, JS eval, click, type) |
+| **AI integration** | None | MCP tools exposed to chat LLM |
+| **Console capture** | None | 500-entry circular buffer, streamed via subscriptions |
+| **Screenshot** | None | `webContents.capturePage()` → base64 PNG |
+| **JS evaluation** | None | `webContents.executeJavaScript()` |
+| **IDE automation** | Extension API (limited) | Puppeteer/CDP (full app control) |
+| **Focus management** | None needed | FocusLock to prevent UI dismissal during automation |
+
+---
+
+## 7. Multi-Instance & Layout
+
+### VS Code: Single Instance, Editor Grid
+
+The Simple Browser manager enforces **one active browser** at a time:
+
+```typescript
+// simpleBrowserManager.ts
+if (this._activeView) {
+    this._activeView.show(url);  // reuse existing
+} else {
+    const view = SimpleBrowserView.create(...);
+    this._activeView = view;
+}
+```
+
+The browser panel integrates with VS Code's editor grid system (split editors, tab groups), but there is no built-in way to have multiple Simple Browser instances side by side.
+
+### Superset: Multi-Pane Mosaic
+
+Superset supports **unlimited concurrent browser panes** managed by `react-mosaic-component`:
+
+- Each pane has its own `<webview>`, toolbar, and state
+- Panes can be split horizontally or vertically
+- Context menu offers "Open Link as New Split"
+- Drag-and-drop rearrangement with drop target handling
+
+The webview registry handles **drag passthrough** -- a non-trivial problem:
+
+```typescript
+// Electron <webview> tags create compositor layers that swallow drag events.
+// Disable pointer-events during any drag so mosaic drop targets work.
+window.addEventListener("dragstart", () => setWebviewsDragPassthrough(true), true);
+window.addEventListener("dragend", () => setWebviewsDragPassthrough(false), true);
+```
+
+### Comparison
+
+| Aspect | VS Code | Superset |
+|--------|---------|----------|
+| **Instances** | 1 (singleton manager) | Unlimited (per-pane webview registry) |
+| **Layout** | Editor grid (shared with code tabs) | Dedicated mosaic layout |
+| **Split support** | Via editor split (generic) | First-class ("Open Link as New Split") |
+| **Drag-and-drop** | Editor tab system | Custom drag passthrough for webview compositor |
+| **State per instance** | URL only (via setState) | Full state (URL, history stack, loading, error, favicon) |
+
+---
+
+## 8. Context Menus
+
+### VS Code: None
+
+The Simple Browser provides no custom context menu. Right-clicking in the iframe shows the browser's default context menu (which is limited due to sandboxing).
+
+### Superset: Full Custom Context Menu
+
+Superset builds a native Electron menu on right-click:
+
+```typescript
+// browser-manager.ts
+const menuItems = [];
+if (linkURL) {
+    menuItems.push(
+        { label: "Open Link in Default Browser", click: () => shell.openExternal(linkURL) },
+        { label: "Open Link as New Split", click: () => this.emit('context-menu-action:...') },
+        { label: "Copy Link Address", click: () => clipboard.writeText(linkURL) },
+    );
+}
+// + Copy, Paste, Select All, Back, Forward, Reload, Open Page in Browser, Copy Page URL
+```
+
+---
+
+## 9. History & State Management
+
+### VS Code: Minimal (URL Only)
+
+```typescript
+// Simple Browser persists only the URL
+vscode.setState({ url: rawUrl });
+```
+
+No browsing history, no visit counts, no autocomplete. Back/Forward relies on the webview's (not iframe's) `history` API.
+
+### Superset: Full History Stack + SQLite Persistence
+
+**In-memory** (Zustand store per pane):
+```typescript
+// Per-pane browser state
+{
+    currentUrl: string;
+    history: Array<{ url: string; title: string; faviconUrl?: string }>;
+    historyIndex: number;
+    isLoading: boolean;
+    error: { code: number; description: string; url: string } | null;
+}
+```
+
+**Persistent** (Drizzle ORM + SQLite):
+```sql
+-- Browser history table
+url TEXT PRIMARY KEY,
+title TEXT,
+faviconUrl TEXT,
+lastVisitedAt TIMESTAMP,
+visitCount INTEGER  -- incremented on conflict
+```
+
+History powers **URL autocomplete** in the address bar, searching across URL and title with the 10 most relevant results.
+
+---
+
+## 10. Resource Loading
+
+### VS Code: Service Worker Proxy
+
+Because webview iframes run on unique origins, they cannot access local files directly. VS Code uses a **service worker** to intercept fetch requests and proxy them through the host:
+
+```
+Webview content requests image.png
+  → Service Worker intercepts fetch
+  → Posts "load-resource" to outer iframe
+  → Outer iframe forwards to host via MessagePort
+  → Host validates against localResourceRoots
+  → Host reads file, sends back as ArrayBuffer
+  → Service Worker constructs Response, returns to webview
+```
+
+Features: ETag caching, 304 Not Modified, Range request support (for video seeking), 30s timeout, Cross-Origin Isolation headers.
+
+### Superset: Direct Web Access
+
+Since Superset's browser panes load actual web pages, resource loading is handled natively by Chromium. The `<webview>` with `partition: "persist:superset"` has a standard network stack with cookies, caching, and full HTTP support. No proxying needed.
+
+---
+
+## 11. Summary: Architectural Philosophy
+
+| Dimension | VS Code | Superset |
+|-----------|---------|----------|
+| **Mission** | Editor that occasionally embeds web content | AI agent workspace where browsing is primary |
+| **Browser role** | Utility for extensions (secondary) | First-class workspace pane (primary) |
+| **Complexity** | Very high (cross-platform, security-hardened) | Moderate (Electron-native, practical) |
+| **Automation** | None | Full AI-driven browser control |
+| **Security** | 7-layer defense-in-depth | Electron defaults + session isolation |
+| **History** | URL-only persistence | Full SQLite-backed history with autocomplete |
+| **Multi-instance** | Single | Unlimited with mosaic layout |
+| **Navigation fidelity** | Broken (cross-origin iframe limits) | Full (webview API access) |
+| **Platform** | Desktop + Web | Desktop only |
+| **LOC (browser feature)** | ~400 (Simple Browser extension) | ~1200+ (BrowserManager + BrowserPane + tRPC + MCP) |
+
+### Key Takeaways
+
+1. **VS Code's iframe approach trades capability for portability**: The same code works in the browser (vscode.dev), but cross-origin restrictions make the Simple Browser fundamentally limited (no URL sync, broken back/forward, broken reload).
+
+2. **Superset's `<webview>` approach trades portability for capability**: By using Electron-native webviews, Superset gets full navigation state access, reliable history, console capture, screenshot APIs, and JS evaluation -- all of which are impossible with cross-origin iframes.
+
+3. **VS Code's security model is vastly more sophisticated**: This is necessary because VS Code webviews run arbitrary extension code. Superset's browser loads user-requested web pages, a fundamentally different threat model.
+
+4. **Superset's AI automation layer has no VS Code equivalent**: The combination of tRPC browser procedures + MCP tool exposure + console streaming gives AI agents full browser control. VS Code has no mechanism for extensions (or AI) to interact with web content loaded in Simple Browser.
+
+5. **Persistence strategies reflect different priorities**: VS Code optimizes for memory (destroy by default, retain opt-in). Superset optimizes for continuity (always park, never destroy), accepting higher memory usage for seamless tab switching.


### PR DESCRIPTION
## Summary

- **V1 vs V2 architecture doc**: Maps the browser pane (renderer) and chat-integrated browser (main process + MCP) systems, data flows, and how they connect
- **Gap analysis**: Root cause analysis for the tab reload bug (#3076, #3040, #1834), identifies that MCP tools target the app UI instead of browser pane content (#1801), and scopes the element selection feature (#2551)
- **Refactor plan**: 3-phase implementation — Phase 1 fixes tab reload by rendering all workspace tabs and hiding inactive ones; Phase 2 bridges MCP tools to browser pane webContents; Phase 3 adds annotated screenshots (Set-of-Mark) and a user-facing element inspector
- **VS Code comparison**: Side-by-side analysis of embedding tech, persistence, IPC, security, and automation between VS Code Simple Browser and Superset's browser pane

## Related Issues

- #3076 — browser refreshes every 5-20 seconds
- #3040 — browser reloads when navigating between tabs
- #1834 — browser preview does not keep alive when switching tabs
- #1801 — MCP server for built-in browser automation
- #2551 — internal browser element selection for easier LLM targeting

## Test plan

- [ ] Review architecture docs for accuracy against current codebase
- [ ] Validate root cause hypotheses for reload bug
- [ ] Confirm refactor plan phases are feasible and correctly scoped

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds documentation mapping the desktop browser V1/V2 architecture, diagnosing the tab reload bug, and proposing a 3‑phase refactor to stabilize tabs and enable agent control and element selection. Aligns the plan to issues #3076, #3040, #1834, #1801, and #2551.

- **Refactors**
  - V1 vs V2 architecture and data flows documented, including renderer, main process, tRPC, and `desktop-mcp`.
  - Gap analysis: root causes for tab reloads; MCP tools currently target the app UI instead of browser panes; scope for element selection.
  - 3-phase plan: Phase 1 renders all tabs and hides inactive to stop reloads; Phase 2 bridges MCP tools to browser pane `webContents` with click/type/hover/inspect/wait; Phase 3 adds annotated screenshots and a user-facing inspector.
  - VS Code comparison covering embedding, persistence, IPC, security, and automation to inform tradeoffs.

<sup>Written for commit 85e45490b38bdea6575de4b62dcec1d214918109. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive technical documentation covering browser architecture systems, design comparisons with similar tools, gap analysis of current capabilities, and planned improvement phases to help developers and administrators understand system design and optimization opportunities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->