### PR TITLE
feat(desktop): add local v1/v2 version toggle in top bar

### DIFF
--- a/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts
+++ b/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts
@@ -1,0 +1,20 @@
+import { FEATURE_FLAGS } from "@superset/shared/constants";
+import { useFeatureFlagEnabled } from "posthog-js/react";
+import { useV2LocalOverrideStore } from "renderer/stores/v2-local-override";
+
+/**
+ * Returns effective v2 state: remote PostHog flag AND local override.
+ * Also returns the raw remote flag so the toggle can be shown conditionally.
+ */
+export function useIsV2CloudEnabled() {
+	const remoteV2Enabled =
+		useFeatureFlagEnabled(FEATURE_FLAGS.V2_CLOUD) ?? false;
+	const forceV1 = useV2LocalOverrideStore((s) => s.forceV1);
+
+	return {
+		/** The effective value — use this wherever you previously checked the flag directly. */
+		isV2CloudEnabled: remoteV2Enabled && !forceV1,
+		/** Whether the remote PostHog flag is on (for showing the toggle). */
+		isRemoteV2Enabled: remoteV2Enabled,
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
@@ -1,7 +1,6 @@
-import { FEATURE_FLAGS } from "@superset/shared/constants";
 import { useMatchRoute, useParams } from "@tanstack/react-router";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { HiOutlineWifi } from "react-icons/hi2";
+import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { useOnlineStatus } from "renderer/hooks/useOnlineStatus";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { getWorkspaceDisplayName } from "renderer/lib/getWorkspaceDisplayName";
@@ -14,6 +13,7 @@ import { SearchBarTrigger } from "./components/SearchBarTrigger";
 import { SidebarToggle } from "./components/SidebarToggle";
 import { V2WorkspaceOpenInButton } from "./components/V2WorkspaceOpenInButton";
 import { V2WorkspaceSearchBarTrigger } from "./components/V2WorkspaceSearchBarTrigger";
+import { VersionToggle } from "./components/VersionToggle";
 import { WindowControls } from "./components/WindowControls";
 
 export function TopBar() {
@@ -31,8 +31,7 @@ export function TopBar() {
 		{ enabled: !!workspaceId && !isV2WorkspaceRoute },
 	);
 	const isOnline = useOnlineStatus();
-	const isV2CloudEnabled =
-		useFeatureFlagEnabled(FEATURE_FLAGS.V2_CLOUD) ?? false;
+	const { isV2CloudEnabled, isRemoteV2Enabled } = useIsV2CloudEnabled();
 	// Default to Mac layout while loading to avoid overlap with traffic lights
 	const isMac = platform === undefined || platform === "darwin";
 
@@ -47,6 +46,7 @@ export function TopBar() {
 				<SidebarToggle />
 				<NavigationControls />
 				<ResourceConsumption />
+				{isRemoteV2Enabled && <VersionToggle />}
 			</div>
 
 			{isV2WorkspaceRoute ? (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/VersionToggle/VersionToggle.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/VersionToggle/VersionToggle.tsx
@@ -37,10 +37,10 @@ export function VersionToggle() {
 				</button>
 			</TooltipTrigger>
 			<TooltipContent>
-			{forceV1
-				? "Early Access: Switch to Superset V2"
-				: "Switch to Superset V1"}
-		</TooltipContent>
+				{forceV1
+					? "Early Access: Switch to Superset V2"
+					: "Switch to Superset V1"}
+			</TooltipContent>
 		</Tooltip>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/VersionToggle/VersionToggle.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/VersionToggle/VersionToggle.tsx
@@ -1,0 +1,46 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { cn } from "@superset/ui/utils";
+import { useV2LocalOverrideStore } from "renderer/stores/v2-local-override";
+
+export function VersionToggle() {
+	const { forceV1, toggle } = useV2LocalOverrideStore();
+	const activeVersion = forceV1 ? "v1" : "v2";
+
+	return (
+		<Tooltip delayDuration={300}>
+			<TooltipTrigger asChild>
+				<button
+					type="button"
+					onClick={toggle}
+					className="no-drag flex items-center h-6 rounded-full bg-muted border border-border text-[11px] font-medium overflow-hidden transition-colors"
+				>
+					<span
+						className={cn(
+							"px-2 py-0.5 rounded-full transition-colors",
+							activeVersion === "v1"
+								? "bg-foreground text-background"
+								: "text-muted-foreground hover:text-foreground",
+						)}
+					>
+						v1
+					</span>
+					<span
+						className={cn(
+							"px-2 py-0.5 rounded-full transition-colors",
+							activeVersion === "v2"
+								? "bg-foreground text-background"
+								: "text-muted-foreground hover:text-foreground",
+						)}
+					>
+						v2
+					</span>
+				</button>
+			</TooltipTrigger>
+			<TooltipContent>
+			{forceV1
+				? "Early Access: Switch to Superset V2"
+				: "Switch to Superset V1"}
+		</TooltipContent>
+		</Tooltip>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/VersionToggle/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/VersionToggle/index.ts
@@ -1,0 +1,1 @@
+export { VersionToggle } from "./VersionToggle";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -1,12 +1,11 @@
-import { FEATURE_FLAGS } from "@superset/shared/constants";
 import {
 	createFileRoute,
 	Outlet,
 	useMatchRoute,
 	useNavigate,
 } from "@tanstack/react-router";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useState } from "react";
+import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { useHotkey } from "renderer/hotkeys";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { DashboardSidebar } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar";
@@ -29,8 +28,7 @@ export const Route = createFileRoute("/_authenticated/_dashboard")({
 function DashboardLayout() {
 	const navigate = useNavigate();
 	const openNewWorkspaceModal = useOpenNewWorkspaceModal();
-	const isV2CloudEnabled =
-		useFeatureFlagEnabled(FEATURE_FLAGS.V2_CLOUD) ?? false;
+	const { isV2CloudEnabled } = useIsV2CloudEnabled();
 	// Get current workspace from route to pre-select project in new workspace modal
 	const matchRoute = useMatchRoute();
 	const currentWorkspaceMatch = matchRoute({

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -8,13 +8,13 @@ import {
 	useNavigate,
 } from "@tanstack/react-router";
 import { useEffect, useRef } from "react";
-import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { DndProvider } from "react-dnd";
 import { HiOutlineWifi } from "react-icons/hi2";
 import { NewWorkspaceModal } from "renderer/components/NewWorkspaceModal";
 import { Paywall } from "renderer/components/Paywall";
 import { useUpdateListener } from "renderer/components/UpdateToast";
 import { env } from "renderer/env.renderer";
+import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { useOnlineStatus } from "renderer/hooks/useOnlineStatus";
 import { migrateHotkeyOverrides } from "renderer/hotkeys/migrate";
 import { authClient, getAuthToken } from "renderer/lib/auth-client";

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -1,4 +1,3 @@
-import { FEATURE_FLAGS } from "@superset/shared/constants";
 import { Button } from "@superset/ui/button";
 import { Spinner } from "@superset/ui/spinner";
 import {
@@ -8,8 +7,8 @@ import {
 	useLocation,
 	useNavigate,
 } from "@tanstack/react-router";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useEffect, useRef } from "react";
+import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { DndProvider } from "react-dnd";
 import { HiOutlineWifi } from "react-icons/hi2";
 import { NewWorkspaceModal } from "renderer/components/NewWorkspaceModal";
@@ -55,8 +54,7 @@ function AuthenticatedLayout() {
 	const setOriginRoute = useSettingsStore((s) => s.setOriginRoute);
 	const utils = electronTrpc.useUtils();
 	const shownWorkspaceInitWarningsRef = useRef(new Set<string>());
-	const isV2CloudEnabled =
-		useFeatureFlagEnabled(FEATURE_FLAGS.V2_CLOUD) ?? false;
+	const { isV2CloudEnabled } = useIsV2CloudEnabled();
 
 	const isSignedIn = env.SKIP_ENV_VALIDATION || !!session?.user;
 	const activeOrganizationId = env.SKIP_ENV_VALIDATION

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/TerminalSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/TerminalSettings.tsx
@@ -1,6 +1,5 @@
-import { FEATURE_FLAGS } from "@superset/shared/constants";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import type { ReactNode } from "react";
+import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import {
 	isItemVisible,
 	SETTING_ITEM_ID,
@@ -47,8 +46,7 @@ export function TerminalSettings({
 	pendingCreateProjectId,
 	onPendingCreateProjectIdChange,
 }: TerminalSettingsProps) {
-	const isV2CloudEnabled =
-		useFeatureFlagEnabled(FEATURE_FLAGS.V2_CLOUD) ?? false;
+	const { isV2CloudEnabled } = useIsV2CloudEnabled();
 	const showPresets = isItemVisible(
 		SETTING_ITEM_ID.TERMINAL_PRESETS,
 		visibleItems,

--- a/apps/desktop/src/renderer/stores/v2-local-override.ts
+++ b/apps/desktop/src/renderer/stores/v2-local-override.ts
@@ -1,0 +1,21 @@
+import { create } from "zustand";
+import { devtools, persist } from "zustand/middleware";
+
+interface V2LocalOverrideState {
+	/** When true, forces v1 mode locally even though v2 is enabled remotely. */
+	forceV1: boolean;
+	toggle: () => void;
+}
+
+export const useV2LocalOverrideStore = create<V2LocalOverrideState>()(
+	devtools(
+		persist(
+			(set, get) => ({
+				forceV1: false,
+				toggle: () => set({ forceV1: !get().forceV1 }),
+			}),
+			{ name: "v2-local-override" },
+		),
+		{ name: "V2LocalOverrideStore" },
+	),
+);


### PR DESCRIPTION
## Summary
- Adds a segmented v1/v2 toggle pill in the top bar (next to resource consumption) that appears when the v2 feature flag is enabled remotely
- Lets you switch between v1 and v2 locally without changing the PostHog flag — preference persists in localStorage
- Centralizes all V2_CLOUD flag checks into a single `useIsV2CloudEnabled` hook

## Test plan
- [ ] Enable v2-cloud flag in PostHog → toggle appears in top bar
- [ ] Click toggle to v1 → sidebar, modals, and settings switch to v1 mode
- [ ] Click toggle back to v2 → everything returns to v2 mode
- [ ] Restart app → toggle state persists
- [ ] Disable v2-cloud flag in PostHog → toggle is hidden, app is v1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a local v1/v2 toggle in the desktop top bar that appears only when the remote V2 flag is on. Users can switch versions locally and the choice persists across restarts.

- **New Features**
  - Segmented v1/v2 pill in the top bar; click to switch versions without changing PostHog.
  - Local override store `useV2LocalOverrideStore` using `zustand` `persist` to save preference in localStorage.
  - New hook `useIsV2CloudEnabled` exposing `isV2CloudEnabled` and `isRemoteV2Enabled`.

- **Refactors**
  - Centralized `V2_CLOUD` checks into `useIsV2CloudEnabled` and updated TopBar, dashboard layout, authenticated layout, and terminal settings to use it.

<sup>Written for commit 7ef3d28044da0945d8746ee28b990caff0efcbe7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a version toggle button allowing users to switch between V1 and V2 interfaces.
  * Local preference for version selection is now persisted across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->