### PR TITLE
feat(desktop): port v2 hide-attach xterm pattern to v1 terminal

### DIFF
--- a/apps/desktop/plans/20260410-port-v2-hide-attach-to-v1.md
+++ b/apps/desktop/plans/20260410-port-v2-hide-attach-to-v1.md
@@ -1,0 +1,158 @@
+# Port v2 "Hide Attach" Terminal Pattern into v1 Renderer
+
+## Context
+
+When switching tabs in v1, `TabsContent` renders only the active tab (`TabsContent/index.tsx:92`). The old `TabView` unmounts entirely, cascading to all `Terminal` components. The cleanup in `useTerminalLifecycle.ts` (lines 854-916) **disposes the entire xterm instance**, sends a backend detach, and nulls all refs. On remount, a brand new xterm is created from scratch, `createOrAttach` restores scrollback from the backend, and all addons/handlers re-initialize. This causes a visible flash and delay.
+
+V2 solves this with `terminal-runtime.ts` + `terminal-runtime-registry.ts`: xterm is opened into a persistent wrapper `<div>`, and tab switching just moves the wrapper in/out of the DOM. The xterm stays alive in memory, so reattach is instant.
+
+The existing **Terminal Persistence DX Hardening plan** (`apps/desktop/plans/20260107-1107-terminal-persistence-dx-hardening.md`) already identifies this problem and proposes an LRU warm set with `visibility: hidden`. Our approach is a cleaner alternative: DOM detach/reattach (the v2 pattern), which avoids WebGL texture atlas corruption issues that come from CSS-hidden terminals.
+
+## Approach
+
+Create a **v1 terminal instance cache** — a module-level `Map<paneId, CachedTerminal>` that stores xterm instances across React mount/unmount cycles. This borrows the wrapper-div pattern from `terminal-runtime.ts` but stays v1-specific (v1's tRPC communication, link providers, keyboard handling, and addon loading are different from v2's WebSocket-based registry).
+
+### Duplication is fine
+
+V1 and v2 will diverge wildly. This is a hotfix for v1 while v2 is still coming out. We freely duplicate whatever we need from v2's runtime code into v1's Terminal directory — no shared abstractions or imports from `renderer/lib/terminal/`.
+
+## File Changes
+
+### 1. NEW: `Terminal/v1-terminal-cache.ts`
+
+Module-level singleton cache managing xterm instance lifecycle independently from React.
+
+```typescript
+interface CachedTerminal {
+  xterm: XTerm;
+  fitAddon: FitAddon;
+  searchAddon: SearchAddon;
+  rendererRef: TerminalRendererRef;
+  wrapper: HTMLDivElement;
+  cleanupCreation: () => void;  // disposes renderer RAF, query suppression, etc.
+}
+
+const cache = new Map<string, CachedTerminal>();
+```
+
+Methods:
+- **`has(paneId)`** — check for existing instance
+- **`getOrCreate(paneId, options)`** — returns existing or creates new xterm in a wrapper div
+- **`attachToContainer(paneId, container)`** — `container.appendChild(wrapper)`, fit, refresh, clear texture atlas
+- **`detachFromContainer(paneId)`** — `wrapper.remove()` (keeps xterm alive in memory)
+- **`dispose(paneId)`** — full cleanup: `cleanupCreation()`, `xterm.dispose()`, delete from cache
+
+### 2. MODIFY: `Terminal/helpers.ts` — `createTerminalInstance`
+
+Split into two phases:
+- **Phase 1** (`createTerminalInWrapper`): Creates XTerm, opens into a new wrapper `<div>` (not the container), loads addons. Returns `{ xterm, fitAddon, rendererRef, wrapper, cleanup }`.
+- **Phase 2**: Caller appends wrapper to container.
+
+The existing `createTerminalInstance(container, options)` becomes a convenience wrapper that calls Phase 1 + appends to container, so no other callers break.
+
+Key change: line 209 `xterm.open(container)` becomes `xterm.open(wrapper)` in the new function.
+
+### 3. MODIFY: `Terminal/hooks/useTerminalLifecycle.ts` — Main lifecycle hook
+
+This is the largest change, concentrated in the single `useEffect` body.
+
+**Mount (lines ~221-280) — replace xterm creation with cache:**
+
+```typescript
+const isReattach = v1TerminalCache.has(paneId);
+const cached = v1TerminalCache.getOrCreate(paneId, { ... });
+const { xterm, fitAddon, rendererRef: renderer } = cached;
+
+// Attach wrapper to live container
+v1TerminalCache.attachToContainer(paneId, container);
+```
+
+On reattach:
+- Set `didFirstRenderRef.current = true` immediately (xterm already rendered)
+- Set `searchAddonRef.current` from cache instead of creating new
+- Still call `createOrAttach` via `scheduleTerminalAttach` to re-establish backend session (tRPC subscription was killed on unmount)
+- Skip writing scrollback to xterm in the `onSuccess` handler since buffer is already in memory
+
+Event handler setup (keyboard, paste, copy, focus, resize, click-to-move) still runs fresh each mount — these are ephemeral and depend on React refs.
+
+**Unmount cleanup (lines 854-916):**
+
+Replace pane-not-destroyed path:
+```typescript
+if (paneDestroyed) {
+  killTerminalForPane(paneId);
+  coldRestoreState.delete(paneId);
+  pendingDetaches.delete(paneId);
+  v1TerminalCache.dispose(paneId);  // full disposal
+} else {
+  v1TerminalCache.detachFromContainer(paneId);  // keep xterm alive
+  // Still send backend detach after 50ms (existing pendingDetaches pattern)
+  const detachTimeout = setTimeout(() => {
+    detachRef.current({ paneId });
+    pendingDetaches.delete(paneId);
+    coldRestoreState.delete(paneId);
+  }, 50);
+  pendingDetaches.set(paneId, detachTimeout);
+}
+```
+
+Remove: `setTimeout(() => xterm.dispose(), 0)` — the cache owns disposal now.
+
+### 4. NO CHANGES to `Terminal/hooks/useTerminalRestore.ts`
+
+The reattach skip is handled entirely in `useTerminalLifecycle.ts`'s `createOrAttach` `onSuccess` handler. On reattach, instead of setting `pendingInitialStateRef.current = result` and calling `maybeApplyInitialState()`, we directly:
+- Set `isStreamReadyRef.current = true`
+- Call `flushPendingEvents()`
+- Skip scrollback writing (buffer already in xterm memory)
+
+Cold restore still goes through the normal `maybeApplyInitialState` path since the cache is empty on fresh app start.
+
+### 5. NO CHANGES to `Terminal/Terminal.tsx`
+
+The tRPC subscription (`electronTrpc.terminal.stream.useSubscription`) still ties to React lifecycle — stops on unmount, restarts on remount. The backend buffers data during the gap, and `createOrAttach` returns it. Theme/font changes already apply on mount via existing `useEffect` hooks.
+
+### 6. NO CHANGES to `Terminal/state.ts`
+
+`pendingDetaches` and `coldRestoreState` continue working as before. The `pendingDetaches` cancel-on-remount pattern (lines 229-234) is still needed for React StrictMode.
+
+## Edge Cases
+
+| Case | Handling |
+|------|----------|
+| **Theme change while detached** | Existing `useEffect` in Terminal.tsx sets `xterm.options.theme` on mount |
+| **Font change while detached** | Existing `useEffect` applies font settings + refits on mount |
+| **WebGL context loss while detached** | `attachToContainer` calls `clearTextureAtlas()` + `refresh()` |
+| **React StrictMode double-mount** | `pendingDetaches` cancel-on-remount handles this (existing pattern) |
+| **Stream data gap** | Backend buffers; `createOrAttach` sends scrollback (discarded on reattach since buffer is in memory); stream subscription resumes |
+| **Container resize while detached** | `fitAddon.fit()` runs during `attachToContainer` |
+| **Many cached terminals (memory)** | Same tradeoff v2 makes. Browsers limit WebGL contexts (~8-16); existing context-loss handler falls back to DOM rendering |
+| **Cold restore after reboot** | Not a reattach case — cache is empty on fresh start. Handled normally. |
+| **Workspace-run pane restart** | `restartTerminalSession` in useTerminalLifecycle works the same — it uses the cached xterm |
+
+## Verification
+
+1. **Tab switch**: switch away and back — terminal should not flash/flicker
+2. **Buffer preservation**: scroll up in terminal, switch tab, switch back — scroll position preserved
+3. **Theme change**: switch tab, change theme, switch back — terminal has new theme
+4. **Close pane**: close a terminal pane — fully disposed (no memory leak)
+5. **StrictMode**: dev mode double-mount/unmount should not cause issues
+6. **Cold restore**: restart the app — cold restore still works (cache empty on fresh start)
+7. **Heavy splits**: 4-way split tab, switch away and back — all terminals reattach
+
+```bash
+bun run typecheck
+bun run lint:fix
+bun test
+```
+
+## Critical Files
+
+- `apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts`
+- `apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts`
+- NEW: `apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts`
+
+## Reference Implementation
+
+- `apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts` — wrapper div pattern, `attachToContainer`, `detachFromContainer`, `disposeRuntime`
+- `apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts` — singleton registry pattern
+- `apps/desktop/src/renderer/lib/terminal/terminal-addons.ts` — v2 addon loading (reference for WebGL handling)

--- a/apps/desktop/plans/20260411-v1-terminal-resize-simplification.md
+++ b/apps/desktop/plans/20260411-v1-terminal-resize-simplification.md
@@ -1,0 +1,260 @@
+# Simplify v1 Terminal Resize to Match v2 Behavior
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Reference: This plan follows conventions from AGENTS.md and the ExecPlan template at `.agents/commands/create-plan.md`. It continues the work started in `apps/desktop/plans/20260410-port-v2-hide-attach-to-v1.md`, which ported the wrapper-div pattern and terminal cache from v2 into v1.
+
+## Purpose / Big Picture
+
+After the hide-attach pattern was ported from v2 to v1, v1 terminals still carry legacy resize infrastructure that v2 never needed. V1 debounces resize events at 150ms, listens to both `ResizeObserver` and `window.resize`, does scroll preservation in the resize handler, runs `fitAddon.fit()` twice on reattach, and manages the `ResizeObserver` lifecycle from the React component instead of the cache. V2 does none of this: it creates a plain `ResizeObserver` in `attachToContainer()`, tears it down in `detachFromContainer()`, and calls `measureAndResize()` with no debounce, no window listener, and no scroll logic.
+
+After this change, v1 resize behavior will match v2: a single undebounced `ResizeObserver` managed by the cache, one `fitAddon.fit()` call on reattach, and no scroll preservation in the resize path. The user-visible effect is a simpler, more responsive resize that eliminates the 150ms lag on every pane or window resize.
+
+## Assumptions
+
+1. The `ResizeObserver` fires on all container size changes, including those caused by window resize. Therefore the separate `window.addEventListener("resize")` listener in v1 is redundant. (This is well-established browser behavior and is what v2 relies on.)
+
+2. Scroll preservation on resize (the `wasAtBottom` check in v1's `setupResizeHandlers`) is not needed. V2 ships without it and no regressions have been reported. Xterm.js itself may handle this internally in recent versions.
+
+3. Removing the 150ms debounce will not cause excessive backend resize IPC calls. V2 runs without debounce and the PTY backend handles rapid resize fine. If needed, a much smaller debounce (e.g. via `requestAnimationFrame` coalescing like v2's `measureAndResize`) can be added later.
+
+## Open Questions
+
+None at this time. The v2 implementation serves as a proven reference.
+
+## Progress
+
+- [ ] Milestone 1: Move ResizeObserver into the cache (attach/detach)
+- [ ] Milestone 2: Remove duplicate reattach resize from useTerminalLifecycle
+- [ ] Milestone 3: Remove setupResizeHandlers and window resize listener
+- [ ] Milestone 4: Validation
+
+## Surprises & Discoveries
+
+(None yet.)
+
+## Decision Log
+
+- Decision: Duplication from v2 is acceptable.
+  Rationale: Per the hide-attach plan, v1 and v2 will diverge. We copy the pattern rather than share code across `renderer/lib/terminal/` and the v1 Terminal directory.
+  Date/Author: 2026-04-11
+
+## Outcomes & Retrospective
+
+(To be filled on completion.)
+
+## Context and Orientation
+
+This work affects only the desktop app (`apps/desktop`), specifically the v1 terminal renderer.
+
+### Key files
+
+**V1 terminal (what we are changing):**
+
+- `apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts` — The module-level cache that stores xterm instances across React mount/unmount cycles. Currently its `attachToContainer()` calls `fitAddon.fit()` and `xterm.refresh()` but does NOT create a `ResizeObserver`. After this plan, it will own the `ResizeObserver` lifecycle.
+
+- `apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts` — Contains `setupResizeHandlers()` (lines 730-755), which creates a debounced `ResizeObserver` + `window.resize` listener. This function will be removed.
+
+- `apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts` — The React lifecycle hook. Currently calls `setupResizeHandlers()` on mount (line 781) and does a duplicate `fitAddon.fit()` on reattach (lines 522-535). Both will be removed.
+
+- `apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/config.ts` — Defines `RESIZE_DEBOUNCE_MS = 150`. This constant will be removed.
+
+**V2 terminal (reference implementation, no changes):**
+
+- `apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts` — V2's `attachToContainer()` (lines 174-195) is the model. It creates a `ResizeObserver` inline, calls `measureAndResize()`, and stores the observer on the runtime. `detachFromContainer()` disconnects it. No debounce. No window listener. No scroll preservation.
+
+### Terminology
+
+- **ResizeObserver**: A browser API that fires a callback whenever a DOM element's size changes. It detects container resizes regardless of cause (window resize, pane drag, sidebar toggle).
+- **FitAddon**: An xterm.js addon that recalculates terminal column/row dimensions to fill its container. `fitAddon.fit()` reads the container's pixel dimensions and updates the xterm grid accordingly.
+- **Reattach**: When a cached v1 terminal is moved back into the DOM after a tab switch. The xterm instance was never disposed — only its wrapper `<div>` was removed from the DOM.
+
+## Plan of Work
+
+### Milestone 1: Move ResizeObserver into the cache
+
+Add a `resizeObserver` field to `CachedTerminal` in `v1-terminal-cache.ts` and an `onResize` callback field. Create the observer in `attachToContainer()` and disconnect it in `detachFromContainer()`, matching v2's `terminal-runtime.ts` pattern.
+
+**File: `v1-terminal-cache.ts`**
+
+Add to `CachedTerminal` interface:
+
+    resizeObserver: ResizeObserver | null;
+
+In `getOrCreate()`, initialize:
+
+    resizeObserver: null,
+
+Rewrite `attachToContainer()` to accept an `onResize` callback and create a `ResizeObserver`:
+
+    export function attachToContainer(
+      paneId: string,
+      container: HTMLDivElement,
+      onResize?: () => void,
+    ): void {
+      const entry = cache.get(paneId);
+      if (!entry) return;
+
+      container.appendChild(entry.wrapper);
+      entry.fitAddon.fit();
+      entry.xterm.refresh(0, Math.max(0, entry.xterm.rows - 1));
+      entry.rendererRef.current.clearTextureAtlas?.();
+
+      // Manage ResizeObserver lifecycle in the cache, not in React.
+      entry.resizeObserver?.disconnect();
+      const observer = new ResizeObserver(() => {
+        if (container.clientWidth === 0 && container.clientHeight === 0) return;
+        entry.fitAddon.fit();
+        onResize?.();
+      });
+      observer.observe(container);
+      entry.resizeObserver = observer;
+    }
+
+Update `detachFromContainer()` to disconnect the observer:
+
+    export function detachFromContainer(paneId: string): void {
+      const entry = cache.get(paneId);
+      if (!entry) return;
+
+      entry.resizeObserver?.disconnect();
+      entry.resizeObserver = null;
+      entry.wrapper.remove();
+    }
+
+Update `dispose()` to also disconnect:
+
+    export function dispose(paneId: string): void {
+      const entry = cache.get(paneId);
+      if (!entry) return;
+
+      entry.resizeObserver?.disconnect();
+      entry.subscription?.unsubscribe();
+      entry.cleanupCreation();
+      entry.xterm.dispose();
+      cache.delete(paneId);
+    }
+
+### Milestone 2: Remove duplicate reattach resize from useTerminalLifecycle
+
+In `useTerminalLifecycle.ts`, the reattach branch (lines 518-535) currently does:
+
+    if (isReattach) {
+      isStreamReadyRef.current = true;
+      requestAnimationFrame(() => {
+        if (isUnmounted) return;
+        const prevCols = xterm.cols;
+        const prevRows = xterm.rows;
+        fitAddon.fit();
+        if (xterm.cols !== prevCols || xterm.rows !== prevRows) {
+          resizeRef.current({ paneId, cols: xterm.cols, rows: xterm.rows });
+        }
+      });
+    }
+
+This is redundant because `attachToContainer()` already calls `fitAddon.fit()` and the new `ResizeObserver` will fire immediately if the container size differs. Remove the `requestAnimationFrame` block. The reattach branch becomes:
+
+    if (isReattach) {
+      isStreamReadyRef.current = true;
+    }
+
+Similarly, in the first-mount `onSuccess` handler (lines 626-637), there is another rAF block that calls `fitAddon.fit()` after `createOrAttach` succeeds. This is also redundant since `attachToContainer()` already fitted and the `ResizeObserver` handles subsequent changes. Remove it.
+
+### Milestone 3: Remove setupResizeHandlers and window resize listener
+
+**File: `helpers.ts`**
+
+Delete the `setupResizeHandlers()` function (lines 730-755) entirely. It is no longer called by any code.
+
+Remove the `debounce` import from lodash if it becomes unused. Remove the `RESIZE_DEBOUNCE_MS` import from `./config`.
+
+**File: `config.ts`**
+
+Remove the `RESIZE_DEBOUNCE_MS` constant (line 45). If it is not imported anywhere else, this is safe.
+
+**File: `useTerminalLifecycle.ts`**
+
+Remove the call to `setupResizeHandlers()` (lines 781-786):
+
+    const cleanupResize = setupResizeHandlers(
+      container,
+      xterm,
+      fitAddon,
+      (cols, rows) => resizeRef.current({ paneId, cols, rows }),
+    );
+
+Remove `cleanupResize()` from the unmount cleanup (line 825).
+
+Remove the `setupResizeHandlers` import from the helpers import block.
+
+Update the `attachToContainer` call (line 260) to pass the resize callback:
+
+    v1TerminalCache.attachToContainer(paneId, container, () => {
+      resizeRef.current({ paneId, cols: xterm.cols, rows: xterm.rows });
+    });
+
+Remove the `scrollToBottom` import from `../utils` if it becomes unused in this file (it may still be used elsewhere in the file for `scheduleScrollToBottom`).
+
+### Milestone 4: Validation
+
+Run:
+
+    cd apps/desktop
+    bun run typecheck   # No type errors
+    bun run lint:fix    # No lint errors
+    bun test            # All tests pass
+
+Manual testing:
+
+1. **Window resize**: Drag the app window larger and smaller. Terminal content should reflow immediately with no 150ms lag.
+2. **Pane resize via splitter**: Drag a split pane divider. Terminal should reflow smoothly.
+3. **Tab switch + resize**: Switch to another tab, resize the window, switch back. Terminal should show correct dimensions.
+4. **Close pane**: Close a terminal pane. No console errors, no leaked observers.
+5. **Multiple terminals**: Open 3+ terminals in splits. Resize window. All terminals reflow correctly.
+
+## Concrete Steps
+
+    cd apps/desktop
+
+    # After all edits:
+    bun run typecheck
+    # Expected: No errors
+
+    bun run lint:fix
+    # Expected: No lint errors (or only auto-fixed)
+
+    bun test
+    # Expected: All tests pass
+
+## Validation and Acceptance
+
+Start the desktop app in dev mode and verify:
+
+    bun dev
+
+1. Open a terminal, run a command that produces output (e.g. `ls -la`). Resize the window by dragging. Terminal content should reflow immediately — there should be no perceptible 150ms delay.
+2. Split the terminal pane. Drag the splitter. Both terminals should resize smoothly.
+3. Switch to a different tab, resize the window, switch back. The terminal should display at the correct size.
+4. Close a terminal pane. Check the console for errors — there should be no "ResizeObserver" related warnings.
+5. Open DevTools, check that no `window.resize` event listeners are registered by terminal code.
+
+## Idempotence and Recovery
+
+All changes are code deletions and refactors. They can be reverted with `git checkout` on the affected files. No migrations, no schema changes, no state format changes.
+
+## Interfaces and Dependencies
+
+No new dependencies. The `ResizeObserver` is a standard browser API available in all Electron versions Superset targets.
+
+The `lodash.debounce` import in `helpers.ts` may become unused after removing `setupResizeHandlers`. If so, it should be removed. The `lodash` package itself is used elsewhere and should not be uninstalled.
+
+## Critical Files
+
+- `apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts`
+- `apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts`
+- `apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts`
+- `apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/config.ts`
+
+## Reference Implementation
+
+- `apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts` — V2's `attachToContainer()` (lines 174-195), `detachFromContainer()` (lines 197-204), and `measureAndResize()` (lines 127-132) are the model for the simplified v1 approach.

--- a/apps/desktop/plans/20260411-v1-terminal-resize-simplification.md
+++ b/apps/desktop/plans/20260411-v1-terminal-resize-simplification.md
@@ -24,14 +24,16 @@ None at this time. The v2 implementation serves as a proven reference.
 
 ## Progress
 
-- [ ] Milestone 1: Move ResizeObserver into the cache (attach/detach)
-- [ ] Milestone 2: Remove duplicate reattach resize from useTerminalLifecycle
-- [ ] Milestone 3: Remove setupResizeHandlers and window resize listener
-- [ ] Milestone 4: Validation
+- [x] (2026-04-11) Milestone 1: Move ResizeObserver into the cache (attach/detach)
+- [x] (2026-04-11) Milestone 2: Remove duplicate reattach resize from useTerminalLifecycle
+- [x] (2026-04-11) Milestone 3: Remove setupResizeHandlers and window resize listener
+- [x] (2026-04-11) Milestone 4: Validation (typecheck, lint pass)
+- [x] (2026-04-11) Milestone 5: Wrap Terminal in React.memo to prevent re-renders during split resize
 
 ## Surprises & Discoveries
 
-(None yet.)
+- Observation: V1 split resize goes through React state on every mouse-move pixel (store update → full component tree re-render → Mosaic repositioning), unlike v2 which is CSS-only via ResizablePanel. The terminal component doesn't remount (Mosaic uses stable `key={paneId}` in `MosaicRoot.js:72`), but it re-renders through the entire tree. Wrapping Terminal in `React.memo` prevents the xterm subtree from re-rendering since its props (`paneId`, `tabId`, `workspaceId`) are stable strings.
+  Evidence: react-mosaic-component `MosaicRoot.renderRecursively()` calls `renderTile()` on every render but uses `key: node` (the pane ID string) on tile divs, preserving component identity. The reverted commit 918e8f062 tried stabilizing `layoutPaneIds` but that only cut one link — `Mosaic value={}` still gets a new prop per pixel.
 
 ## Decision Log
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
@@ -1,7 +1,7 @@
 import "react-mosaic-component/react-mosaic-component.css";
 import "./mosaic-theme.css";
 
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import {
 	Mosaic,
 	type MosaicBranch,
@@ -58,21 +58,11 @@ export function TabView({ tab }: TabViewProps) {
 		[allTabs, tab.workspaceId],
 	);
 
-	// Extract pane IDs from layout. Stabilize the reference so it only changes
-	// when the actual set of IDs changes — not on every split resize, which
-	// only changes splitPercentage values in the layout tree. Without this,
-	// every resize pixel cascades through tabPanes → renderPane → Mosaic and
-	// unmounts/remounts all terminal components.
-	const prevLayoutPaneIdsRef = useRef<string[]>([]);
-	const layoutPaneIds = useMemo(() => {
-		const next = extractPaneIdsFromLayout(tab.layout);
-		const prev = prevLayoutPaneIdsRef.current;
-		if (prev.length === next.length && prev.every((id, i) => id === next[i])) {
-			return prev;
-		}
-		prevLayoutPaneIdsRef.current = next;
-		return next;
-	}, [tab.layout]);
+	// Extract pane IDs from layout
+	const layoutPaneIds = useMemo(
+		() => extractPaneIdsFromLayout(tab.layout),
+		[tab.layout],
+	);
 
 	// Memoize the filtered panes to avoid creating new objects on every render
 	const tabPanes = useMemo(() => {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/index.tsx
@@ -1,7 +1,7 @@
 import "react-mosaic-component/react-mosaic-component.css";
 import "./mosaic-theme.css";
 
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import {
 	Mosaic,
 	type MosaicBranch,
@@ -58,11 +58,21 @@ export function TabView({ tab }: TabViewProps) {
 		[allTabs, tab.workspaceId],
 	);
 
-	// Extract pane IDs from layout
-	const layoutPaneIds = useMemo(
-		() => extractPaneIdsFromLayout(tab.layout),
-		[tab.layout],
-	);
+	// Extract pane IDs from layout. Stabilize the reference so it only changes
+	// when the actual set of IDs changes — not on every split resize, which
+	// only changes splitPercentage values in the layout tree. Without this,
+	// every resize pixel cascades through tabPanes → renderPane → Mosaic and
+	// unmounts/remounts all terminal components.
+	const prevLayoutPaneIdsRef = useRef<string[]>([]);
+	const layoutPaneIds = useMemo(() => {
+		const next = extractPaneIdsFromLayout(tab.layout);
+		const prev = prevLayoutPaneIdsRef.current;
+		if (prev.length === next.length && prev.every((id, i) => id === next[i])) {
+			return prev;
+		}
+		prevLayoutPaneIdsRef.current = next;
+		return next;
+	}, [tab.layout]);
 
 	// Memoize the filtered panes to avoid creating new objects on every render
 	const tabPanes = useMemo(() => {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -2,7 +2,7 @@ import type { FitAddon } from "@xterm/addon-fit";
 import type { SearchAddon } from "@xterm/addon-search";
 import type { Terminal as XTerm } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
-import { useEffect, useRef, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { buildTerminalCommand } from "renderer/lib/terminal/launch-command";
 import { useTabsStore } from "renderer/stores/tabs/store";
@@ -12,7 +12,7 @@ import {
 	DEFAULT_TERMINAL_FONT_FAMILY,
 	DEFAULT_TERMINAL_FONT_SIZE,
 } from "./config";
-import { getDefaultTerminalBg, type TerminalRendererRef } from "./helpers";
+import { getDefaultTerminalBg } from "./helpers";
 import {
 	useFileLinkClick,
 	useTerminalColdRestore,
@@ -38,7 +38,11 @@ import * as v1TerminalCache from "./v1-terminal-cache";
 const stripLeadingEmoji = (text: string) =>
 	text.trim().replace(/^[\p{Emoji}\p{Symbol}]\s*/u, "");
 
-export const Terminal = ({ paneId, tabId, workspaceId }: TerminalProps) => {
+export const Terminal = memo(function Terminal({
+	paneId,
+	tabId,
+	workspaceId,
+}: TerminalProps) {
 	const pane = useTabsStore((s) => s.panes[paneId]);
 	const isWorkspaceRunPane = Boolean(pane?.workspaceRun?.workspaceId);
 	const paneInitialCwd = pane?.initialCwd;
@@ -86,7 +90,6 @@ export const Terminal = ({ paneId, tabId, workspaceId }: TerminalProps) => {
 	const xtermRef = useRef<XTerm | null>(null);
 	const fitAddonRef = useRef<FitAddon | null>(null);
 	const searchAddonRef = useRef<SearchAddon | null>(null);
-	const rendererRef = useRef<TerminalRendererRef | null>(null);
 	const isExitedRef = useRef(false);
 	const [exitStatus, setExitStatus] = useState<"killed" | "exited" | null>(
 		null,
@@ -110,7 +113,6 @@ export const Terminal = ({ paneId, tabId, workspaceId }: TerminalProps) => {
 			createOrAttach: createOrAttachRef,
 			write: writeRef,
 			resize: resizeRef,
-			detach: detachRef,
 			cancelCreateOrAttach: cancelCreateOrAttachRef,
 			clearScrollback: clearScrollbackRef,
 		},
@@ -343,7 +345,6 @@ export const Terminal = ({ paneId, tabId, workspaceId }: TerminalProps) => {
 		xtermRef,
 		fitAddonRef,
 		searchAddonRef,
-		rendererRef,
 		isExitedRef,
 		wasKilledByUserRef,
 		commandBufferRef,
@@ -363,7 +364,6 @@ export const Terminal = ({ paneId, tabId, workspaceId }: TerminalProps) => {
 		createOrAttachRef,
 		writeRef,
 		resizeRef,
-		detachRef,
 		cancelCreateOrAttachRef,
 		clearScrollbackRef,
 		isStreamReadyRef,
@@ -402,21 +402,15 @@ export const Terminal = ({ paneId, tabId, workspaceId }: TerminalProps) => {
 	);
 
 	useEffect(() => {
-		const xterm = xtermRef.current;
-		if (!xterm || !fontSettings) return;
+		if (!fontSettings) return;
 		const family =
 			fontSettings.terminalFontFamily || DEFAULT_TERMINAL_FONT_FAMILY;
 		const size = fontSettings.terminalFontSize ?? DEFAULT_TERMINAL_FONT_SIZE;
-		if (
-			xterm.options.fontFamily === family &&
-			xterm.options.fontSize === size
-		) {
-			return;
+		const result = v1TerminalCache.updateAppearance(paneId, family, size);
+		if (result?.changed) {
+			resizeRef.current({ paneId, cols: result.cols, rows: result.rows });
 		}
-		xterm.options.fontFamily = family;
-		xterm.options.fontSize = size;
-		fitAddonRef.current?.fit();
-	}, [fontSettings]);
+	}, [paneId, fontSettings, resizeRef.current]);
 
 	const terminalBg = terminalTheme?.background ?? getDefaultTerminalBg();
 
@@ -469,4 +463,4 @@ export const Terminal = ({ paneId, tabId, workspaceId }: TerminalProps) => {
 			</div>
 		</div>
 	);
-};
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -33,6 +33,7 @@ import type {
 	TerminalStreamEvent,
 } from "./types";
 import { shellEscapePaths } from "./utils";
+import * as v1TerminalCache from "./v1-terminal-cache";
 
 const stripLeadingEmoji = (text: string) =>
 	text.trim().replace(/^[\p{Emoji}\p{Symbol}]\s*/u, "");
@@ -271,26 +272,41 @@ export const Terminal = ({ paneId, tabId, workspaceId }: TerminalProps) => {
 	handleTerminalExitRef.current = handleTerminalExit;
 	handleStreamErrorRef.current = handleStreamError;
 
-	// Stream subscription
-	electronTrpc.terminal.stream.useSubscription(paneId, {
-		onData: (event) => {
-			if (connectionErrorRef.current && event.type === "data") {
-				setConnectionError(null);
-				retryCountRef.current = 0;
-			}
+	// Stream event handler registration — the subscription itself lives in
+	// v1TerminalCache and stays alive across mount/unmount cycles so data
+	// keeps flowing to xterm even while the tab is hidden.
+	useEffect(() => {
+		const queuedEvents = v1TerminalCache.registerHandlers(paneId, {
+			onEvent: (event) => {
+				if (connectionErrorRef.current && event.type === "data") {
+					setConnectionError(null);
+					retryCountRef.current = 0;
+				}
+				handleStreamData(event);
+			},
+			onError: (error) => {
+				console.error("[Terminal] Stream subscription error:", {
+					paneId,
+					error: error instanceof Error ? error.message : String(error),
+				});
+				setConnectionError(
+					error instanceof Error
+						? error.message
+						: "Connection to terminal lost",
+				);
+			},
+		});
+
+		// Process lifecycle events (exit, error, disconnect) that arrived
+		// while this component was unmounted.
+		for (const event of queuedEvents) {
 			handleStreamData(event);
-		},
-		onError: (error) => {
-			console.error("[Terminal] Stream subscription error:", {
-				paneId,
-				error: error instanceof Error ? error.message : String(error),
-			});
-			setConnectionError(
-				error instanceof Error ? error.message : "Connection to terminal lost",
-			);
-		},
-		enabled: true,
-	});
+		}
+
+		return () => {
+			v1TerminalCache.unregisterHandlers(paneId);
+		};
+	}, [paneId, handleStreamData, setConnectionError]);
 
 	// Auto-retry when connection error is set
 	useEffect(() => {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -401,6 +401,7 @@ export const Terminal = memo(function Terminal({
 		},
 	);
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: resizeRef is a stable MutableRefObject — .current is read inside the effect, not a dependency
 	useEffect(() => {
 		if (!fontSettings) return;
 		const family =
@@ -410,7 +411,7 @@ export const Terminal = memo(function Terminal({
 		if (result?.changed) {
 			resizeRef.current({ paneId, cols: result.cols, rows: result.rows });
 		}
-	}, [paneId, fontSettings, resizeRef.current]);
+	}, [paneId, fontSettings]);
 
 	const terminalBg = terminalTheme?.background ?? getDefaultTerminalBg();
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -274,42 +274,6 @@ export const Terminal = memo(function Terminal({
 	handleTerminalExitRef.current = handleTerminalExit;
 	handleStreamErrorRef.current = handleStreamError;
 
-	// Stream event handler registration — the subscription itself lives in
-	// v1TerminalCache and stays alive across mount/unmount cycles so data
-	// keeps flowing to xterm even while the tab is hidden.
-	useEffect(() => {
-		const queuedEvents = v1TerminalCache.registerHandlers(paneId, {
-			onEvent: (event) => {
-				if (connectionErrorRef.current && event.type === "data") {
-					setConnectionError(null);
-					retryCountRef.current = 0;
-				}
-				handleStreamData(event);
-			},
-			onError: (error) => {
-				console.error("[Terminal] Stream subscription error:", {
-					paneId,
-					error: error instanceof Error ? error.message : String(error),
-				});
-				setConnectionError(
-					error instanceof Error
-						? error.message
-						: "Connection to terminal lost",
-				);
-			},
-		});
-
-		// Process lifecycle events (exit, error, disconnect) that arrived
-		// while this component was unmounted.
-		for (const event of queuedEvents) {
-			handleStreamData(event);
-		}
-
-		return () => {
-			v1TerminalCache.unregisterHandlers(paneId);
-		};
-	}, [paneId, handleStreamData, setConnectionError]);
-
 	// Auto-retry when connection error is set
 	useEffect(() => {
 		if (!connectionError) return;
@@ -387,6 +351,46 @@ export const Terminal = memo(function Terminal({
 		unregisterPasteCallbackRef,
 		defaultRestartCommandRef,
 	});
+
+	// Stream event handler registration — the subscription itself lives in
+	// v1TerminalCache and stays alive across mount/unmount cycles so data
+	// keeps flowing to xterm even while the tab is hidden.
+	// Placed after useTerminalLifecycle so the cache entry exists on cold mount.
+	// Gated on xtermInstance so it re-runs once the lifecycle hook creates it.
+	useEffect(() => {
+		if (!xtermInstance) return;
+
+		const queuedEvents = v1TerminalCache.registerHandlers(paneId, {
+			onEvent: (event) => {
+				if (connectionErrorRef.current && event.type === "data") {
+					setConnectionError(null);
+					retryCountRef.current = 0;
+				}
+				handleStreamData(event);
+			},
+			onError: (error) => {
+				console.error("[Terminal] Stream subscription error:", {
+					paneId,
+					error: error instanceof Error ? error.message : String(error),
+				});
+				setConnectionError(
+					error instanceof Error
+						? error.message
+						: "Connection to terminal lost",
+				);
+			},
+		});
+
+		// Process lifecycle events (exit, error, disconnect) that arrived
+		// while this component was unmounted.
+		for (const event of queuedEvents) {
+			handleStreamData(event);
+		}
+
+		return () => {
+			v1TerminalCache.unregisterHandlers(paneId);
+		};
+	}, [paneId, xtermInstance, handleStreamData, setConnectionError]);
 
 	useEffect(() => {
 		const xterm = xtermRef.current;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/config.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/config.ts
@@ -41,5 +41,3 @@ export const TERMINAL_OPTIONS: ITerminalOptions = {
 		showScrollbar: false,
 	},
 };
-
-export const RESIZE_DEBOUNCE_MS = 150;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -8,7 +8,6 @@ import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebglAddon } from "@xterm/addon-webgl";
 import type { ITheme } from "@xterm/xterm";
 import { Terminal as XTerm } from "@xterm/xterm";
-import { debounce } from "lodash";
 import { getBinding, isTerminalReservedEvent } from "renderer/hotkeys";
 import { electronTrpcClient as trpcClient } from "renderer/lib/trpc-client";
 import { toXtermTheme } from "renderer/stores/theme/utils";
@@ -17,10 +16,9 @@ import {
 	DEFAULT_THEME_ID,
 	getTerminalColors,
 } from "shared/themes";
-import { RESIZE_DEBOUNCE_MS, TERMINAL_OPTIONS } from "./config";
+import { TERMINAL_OPTIONS } from "./config";
 import { FilePathLinkProvider, UrlLinkProvider } from "./link-providers";
 import { suppressQueryResponses } from "./suppressQueryResponses";
-import { scrollToBottom } from "./utils";
 
 /**
  * Get the default terminal theme from localStorage cache.
@@ -724,33 +722,6 @@ export function setupFocusListener(
 
 	return () => {
 		textarea.removeEventListener("focus", onFocus);
-	};
-}
-
-export function setupResizeHandlers(
-	container: HTMLDivElement,
-	xterm: XTerm,
-	fitAddon: FitAddon,
-	onResize: (cols: number, rows: number) => void,
-): () => void {
-	const debouncedHandleResize = debounce(() => {
-		const buffer = xterm.buffer.active;
-		const wasAtBottom = buffer.viewportY >= buffer.baseY;
-		fitAddon.fit();
-		onResize(xterm.cols, xterm.rows);
-		if (wasAtBottom) {
-			requestAnimationFrame(() => scrollToBottom(xterm));
-		}
-	}, RESIZE_DEBOUNCE_MS);
-
-	const resizeObserver = new ResizeObserver(debouncedHandleResize);
-	resizeObserver.observe(container);
-	window.addEventListener("resize", debouncedHandleResize);
-
-	return () => {
-		window.removeEventListener("resize", debouncedHandleResize);
-		resizeObserver.disconnect();
-		debouncedHandleResize.cancel();
 	};
 }
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -3,6 +3,7 @@ import { ClipboardAddon } from "@xterm/addon-clipboard";
 import { FitAddon } from "@xterm/addon-fit";
 import { ImageAddon } from "@xterm/addon-image";
 import { LigaturesAddon } from "@xterm/addon-ligatures";
+import { SearchAddon } from "@xterm/addon-search";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebglAddon } from "@xterm/addon-webgl";
 import type { ITheme } from "@xterm/xterm";
@@ -166,13 +167,19 @@ export interface TerminalRendererRef {
 	current: TerminalRenderer;
 }
 
-export function createTerminalInstance(
-	container: HTMLDivElement,
-	options: CreateTerminalOptions = {},
-): {
+/**
+ * Create an xterm instance opened into a detached wrapper div (not a live container).
+ * The wrapper can be moved between DOM containers via appendChild without
+ * disposing the terminal — this is the "hide attach" pattern from v2.
+ *
+ * Used by v1-terminal-cache.ts to keep xterm alive across React mount/unmount.
+ */
+export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 	xterm: XTerm;
 	fitAddon: FitAddon;
+	searchAddon: SearchAddon;
 	renderer: TerminalRendererRef;
+	wrapper: HTMLDivElement;
 	cleanup: () => void;
 } {
 	const {
@@ -182,22 +189,19 @@ export function createTerminalInstance(
 		onUrlClickRef: urlClickRef,
 	} = options;
 
-	// Use provided theme, or fall back to localStorage-based default to prevent flash
 	const theme = initialTheme ?? getDefaultTerminalTheme();
 	const terminalOptions = { ...TERMINAL_OPTIONS, theme };
 	const xterm = new XTerm(terminalOptions);
 	const fitAddon = new FitAddon();
+	const searchAddon = new SearchAddon();
 
 	const clipboardAddon = new ClipboardAddon();
 	const unicode11Addon = new Unicode11Addon();
 	const imageAddon = new ImageAddon();
 
-	// Track cleanup state to prevent operations on disposed terminal
 	let isDisposed = false;
 	let rafId: number | null = null;
 
-	// Use a ref pattern so the renderer can be updated after rAF.
-	// Start with a no-op DOM renderer - the actual GPU renderer is loaded async.
 	const rendererRef: TerminalRendererRef = {
 		current: {
 			kind: "dom",
@@ -206,21 +210,19 @@ export function createTerminalInstance(
 		},
 	};
 
-	xterm.open(container);
+	// Open into a detached wrapper div — not the live container.
+	const wrapper = document.createElement("div");
+	wrapper.style.width = "100%";
+	wrapper.style.height = "100%";
+	xterm.open(wrapper);
 
-	// Load non-renderer addons synchronously - these are safe and needed immediately
 	xterm.loadAddon(fitAddon);
+	xterm.loadAddon(searchAddon);
 	xterm.loadAddon(clipboardAddon);
 	xterm.loadAddon(unicode11Addon);
 	xterm.loadAddon(imageAddon);
 
 	// Defer GPU renderer loading to next animation frame.
-	// xterm.open() schedules a setTimeout for Viewport.syncScrollArea which expects
-	// the renderer to be ready. Loading WebGL immediately after open() can cause a
-	// race condition where the setTimeout fires during addon initialization, when
-	// _renderer is temporarily undefined (old renderer disposed, new not yet set).
-	// Deferring to rAF ensures xterm's internal setTimeout completes first with the
-	// default DOM renderer, then we safely swap to WebGL.
 	rafId = requestAnimationFrame(() => {
 		rafId = null;
 		if (isDisposed) return;
@@ -261,7 +263,6 @@ export function createTerminalInstance(
 			if (onFileLinkClick) {
 				onFileLinkClick(path, line, column);
 			} else {
-				// Fallback to default behavior (external editor)
 				trpcClient.external.openFileInEditor
 					.mutate({
 						path,
@@ -282,12 +283,13 @@ export function createTerminalInstance(
 	xterm.registerLinkProvider(filePathLinkProvider);
 
 	xterm.unicode.activeVersion = "11";
-	fitAddon.fit();
 
 	return {
 		xterm,
 		fitAddon,
+		searchAddon,
 		renderer: rendererRef,
+		wrapper,
 		cleanup: () => {
 			isDisposed = true;
 			if (rafId !== null) {
@@ -296,6 +298,29 @@ export function createTerminalInstance(
 			cleanupQuerySuppression();
 			rendererRef.current.dispose();
 		},
+	};
+}
+
+export function createTerminalInstance(
+	container: HTMLDivElement,
+	options: CreateTerminalOptions = {},
+): {
+	xterm: XTerm;
+	fitAddon: FitAddon;
+	renderer: TerminalRendererRef;
+	cleanup: () => void;
+} {
+	const result = createTerminalInWrapper(options);
+
+	// Move wrapper into the live container
+	container.appendChild(result.wrapper);
+	result.fitAddon.fit();
+
+	return {
+		xterm: result.xterm,
+		fitAddon: result.fitAddon,
+		renderer: result.renderer,
+		cleanup: result.cleanup,
 	};
 }
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -61,108 +61,14 @@ export function getDefaultTerminalBg(): string {
  * Tries WebGL first, falls back to DOM if WebGL fails.
  * This follows VS Code's approach: WebGL → DOM (canvas addon removed in xterm.js 6.0).
  */
-export type TerminalRenderer = {
-	kind: "webgl" | "dom";
-	dispose: () => void;
-	clearTextureAtlas?: () => void;
-};
-
-type PreferredRenderer = TerminalRenderer["kind"] | "auto";
-
-// Track WebGL failures globally to avoid repeated initialization attempts (VS Code pattern)
-let suggestedRendererType: TerminalRenderer["kind"] | undefined;
-
-function getPreferredRenderer(): PreferredRenderer {
-	// If WebGL previously failed, don't try again
-	if (suggestedRendererType === "dom") {
-		return "dom";
-	}
-
-	try {
-		const stored = localStorage.getItem("terminal-renderer");
-		if (stored === "webgl" || stored === "dom") {
-			return stored;
-		}
-		if (stored === "canvas") {
-			// Canvas renderer was removed in xterm.js 6.0; fall back to DOM.
-			try {
-				localStorage.setItem("terminal-renderer", "dom");
-			} catch {
-				// ignore storage errors
-			}
-			return "dom";
-		}
-	} catch {
-		// ignore
-	}
-
-	return "auto";
-}
-
-function loadRenderer(xterm: XTerm): TerminalRenderer {
-	let webglAddon: WebglAddon | null = null;
-	let kind: TerminalRenderer["kind"] = "dom";
-
-	const preferred = getPreferredRenderer();
-
-	if (preferred === "dom") {
-		return { kind: "dom", dispose: () => {}, clearTextureAtlas: undefined };
-	}
-
-	try {
-		webglAddon = new WebglAddon();
-
-		webglAddon.onContextLoss(() => {
-			console.warn(
-				"[Terminal] WebGL context lost, falling back to DOM renderer",
-			);
-			webglAddon?.dispose();
-			webglAddon = null;
-			kind = "dom";
-			// Force refresh after context loss
-			xterm.refresh(0, xterm.rows - 1);
-		});
-
-		xterm.loadAddon(webglAddon);
-		kind = "webgl";
-	} catch (e) {
-		console.warn(
-			"[Terminal] WebGL could not be loaded, falling back to DOM renderer",
-			e,
-		);
-		suggestedRendererType = "dom";
-		webglAddon = null;
-		kind = "dom";
-	}
-
-	return {
-		kind,
-		dispose: () => webglAddon?.dispose(),
-		clearTextureAtlas: webglAddon
-			? () => {
-					try {
-						webglAddon?.clearTextureAtlas();
-					} catch (error) {
-						console.warn("[Terminal] WebGL clearTextureAtlas() failed:", error);
-					}
-				}
-			: undefined,
-	};
-}
+// Once WebGL fails, skip it for all subsequent terminals (VS Code pattern).
+let suggestedRendererType: "webgl" | "dom" | undefined;
 
 export interface CreateTerminalOptions {
 	cwd?: string;
 	initialTheme?: ITheme | null;
 	onFileLinkClick?: (path: string, line?: number, column?: number) => void;
 	onUrlClickRef?: { current: ((url: string) => void) | undefined };
-}
-
-/**
- * Mutable reference to the terminal renderer.
- * Used because the GPU renderer is loaded asynchronously after the terminal is created.
- */
-export interface TerminalRendererRef {
-	current: TerminalRenderer;
 }
 
 /**
@@ -176,7 +82,6 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 	xterm: XTerm;
 	fitAddon: FitAddon;
 	searchAddon: SearchAddon;
-	renderer: TerminalRendererRef;
 	wrapper: HTMLDivElement;
 	cleanup: () => void;
 } {
@@ -197,16 +102,8 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 	const unicode11Addon = new Unicode11Addon();
 	const imageAddon = new ImageAddon();
 
-	let isDisposed = false;
-	let rafId: number | null = null;
-
-	const rendererRef: TerminalRendererRef = {
-		current: {
-			kind: "dom",
-			dispose: () => {},
-			clearTextureAtlas: undefined,
-		},
-	};
+	let disposed = false;
+	let webglAddon: WebglAddon | null = null;
 
 	// Open into a detached wrapper div — not the live container.
 	const wrapper = document.createElement("div");
@@ -220,20 +117,29 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 	xterm.loadAddon(unicode11Addon);
 	xterm.loadAddon(imageAddon);
 
-	// Defer GPU renderer loading to next animation frame.
-	rafId = requestAnimationFrame(() => {
-		rafId = null;
-		if (isDisposed) return;
-		rendererRef.current = loadRenderer(xterm);
-	});
-
 	try {
-		if (!isDisposed) {
-			xterm.loadAddon(new LigaturesAddon());
-		}
+		xterm.loadAddon(new LigaturesAddon());
 	} catch {
 		// Ligatures not supported by current font
 	}
+
+	// Defer WebGL to rAF — same pattern as v2 terminal-addons.ts.
+	const rafId = requestAnimationFrame(() => {
+		if (disposed || suggestedRendererType === "dom") return;
+
+		try {
+			webglAddon = new WebglAddon();
+			webglAddon.onContextLoss(() => {
+				webglAddon?.dispose();
+				webglAddon = null;
+				xterm.refresh(0, xterm.rows - 1);
+			});
+			xterm.loadAddon(webglAddon);
+		} catch {
+			suggestedRendererType = "dom";
+			webglAddon = null;
+		}
+	});
 
 	const cleanupQuerySuppression = suppressQueryResponses(xterm);
 
@@ -286,39 +192,16 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 		xterm,
 		fitAddon,
 		searchAddon,
-		renderer: rendererRef,
 		wrapper,
 		cleanup: () => {
-			isDisposed = true;
-			if (rafId !== null) {
-				cancelAnimationFrame(rafId);
-			}
+			disposed = true;
+			cancelAnimationFrame(rafId);
 			cleanupQuerySuppression();
-			rendererRef.current.dispose();
+			try {
+				webglAddon?.dispose();
+			} catch {}
+			webglAddon = null;
 		},
-	};
-}
-
-export function createTerminalInstance(
-	container: HTMLDivElement,
-	options: CreateTerminalOptions = {},
-): {
-	xterm: XTerm;
-	fitAddon: FitAddon;
-	renderer: TerminalRendererRef;
-	cleanup: () => void;
-} {
-	const result = createTerminalInWrapper(options);
-
-	// Move wrapper into the live container
-	container.appendChild(result.wrapper);
-	result.fitAddon.fit();
-
-	return {
-		xterm: result.xterm,
-		fitAddon: result.fitAddon,
-		renderer: result.renderer,
-		cleanup: result.cleanup,
 	};
 }
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
@@ -551,8 +551,11 @@ export function useTerminalLifecycle({
 						done();
 					};
 
+					const createOrAttachStartedAt = performance.now();
 					if (DEBUG_TERMINAL) {
-						console.log(`[Terminal] createOrAttach start: ${paneId}`);
+						console.log(
+							`[Terminal] createOrAttach start: ${paneId} (isReattach=${isReattach}, elapsed since mount=${(createOrAttachStartedAt - mountStartedAt).toFixed(1)}ms)`,
+						);
 					}
 					createOrAttachRef.current(
 						{
@@ -582,7 +585,7 @@ export function useTerminalLifecycle({
 											performance.now() - mountStartedAt
 										).toFixed(1);
 										console.log(
-											`[Terminal] Reattach fast-path: ${paneId} (total ${reattachElapsed}ms, skipped scrollback=${result.scrollback?.length ?? 0} bytes, pendingEvents=${pendingEventsRef.current.length})`,
+											`[Terminal] Reattach fast-path: ${paneId} (total ${reattachElapsed}ms, skipped scrollback=${result.scrollback?.length ?? 0} bytes)`,
 										);
 									}
 									requestAnimationFrame(() => {
@@ -668,6 +671,18 @@ export function useTerminalLifecycle({
 										});
 									}
 								});
+
+								if (DEBUG_TERMINAL) {
+									const attachElapsed = (
+										performance.now() - createOrAttachStartedAt
+									).toFixed(1);
+									const totalElapsed = (
+										performance.now() - mountStartedAt
+									).toFixed(1);
+									console.log(
+										`[Terminal] Fresh attach complete: ${paneId} (createOrAttach=${attachElapsed}ms, total=${totalElapsed}ms, scrollback=${result.scrollback?.length ?? 0} bytes, isNew=${result.isNew}, wasRecovered=${result.wasRecovered})`,
+									);
+								}
 
 								pendingInitialStateRef.current = result;
 								maybeApplyInitialState();
@@ -981,9 +996,7 @@ export function useTerminalLifecycle({
 				pendingDetaches.set(paneId, detachTimeout);
 
 				if (DEBUG_TERMINAL) {
-					const elapsed = (
-						performance.now() - unmountStartedAt
-					).toFixed(1);
+					const elapsed = (performance.now() - unmountStartedAt).toFixed(1);
 					console.log(
 						`[Terminal] Detached from DOM (cached for reattach): ${paneId} (cleanup took ${elapsed}ms)`,
 					);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
@@ -1,5 +1,5 @@
 import type { FitAddon } from "@xterm/addon-fit";
-import { SearchAddon } from "@xterm/addon-search";
+import type { SearchAddon } from "@xterm/addon-search";
 import type { IDisposable, ITheme, Terminal as XTerm } from "@xterm/xterm";
 import type { MutableRefObject, RefObject } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -12,7 +12,6 @@ import { scheduleTerminalAttach } from "../attach-scheduler";
 import { isCommandEchoed, sanitizeForTitle } from "../commandBuffer";
 import { DEBUG_TERMINAL, FIRST_RENDER_RESTORE_FALLBACK_MS } from "../config";
 import {
-	createTerminalInstance,
 	setupClickToMoveCursor,
 	setupCopyHandler,
 	setupFocusListener,
@@ -33,6 +32,7 @@ import type {
 	TerminalWriteMutate,
 } from "../types";
 import { scrollToBottom } from "../utils";
+import * as v1TerminalCache from "../v1-terminal-cache";
 import { createAttachRequestId } from "./attach-request-id";
 import {
 	getPaneWorkspaceRun,
@@ -222,6 +222,8 @@ export function useTerminalLifecycle({
 		const container = terminalRef.current;
 		if (!container) return;
 
+		const mountStartedAt = performance.now();
+
 		if (DEBUG_TERMINAL) {
 			console.log(`[Terminal] Mount: ${paneId}`);
 		}
@@ -231,6 +233,11 @@ export function useTerminalLifecycle({
 		if (pendingDetach) {
 			clearTimeout(pendingDetach);
 			pendingDetaches.delete(paneId);
+			if (DEBUG_TERMINAL) {
+				console.log(
+					`[Terminal] Cancelled pending detach (StrictMode or fast tab switch): ${paneId}`,
+				);
+			}
 		}
 
 		let isUnmounted = false;
@@ -240,18 +247,28 @@ export function useTerminalLifecycle({
 		let activeAttachRequestId: string | null = null;
 		let cancelAttachWait: (() => void) | null = null;
 
-		const {
-			xterm,
-			fitAddon,
-			renderer,
-			cleanup: cleanupQuerySuppression,
-		} = createTerminalInstance(container, {
+		// Use the v1 terminal cache: reuse existing xterm instance across tab
+		// switches instead of creating/disposing each time (v2 "hide attach" pattern).
+		const isReattach = v1TerminalCache.has(paneId);
+		const cached = v1TerminalCache.getOrCreate(paneId, {
 			cwd: workspaceCwdRef.current ?? undefined,
 			initialTheme: initialThemeRef.current,
 			onFileLinkClick: (path, line, column) =>
 				handleFileLinkClickRef.current(path, line, column),
 			onUrlClickRef: handleUrlClickRef,
 		});
+
+		const { xterm, fitAddon, rendererRef: renderer, searchAddon } = cached;
+
+		// Attach the wrapper div to the live container
+		v1TerminalCache.attachToContainer(paneId, container);
+
+		if (DEBUG_TERMINAL) {
+			const elapsed = (performance.now() - mountStartedAt).toFixed(1);
+			console.log(
+				`[Terminal] ${isReattach ? "Reattach" : "Fresh mount"}: ${paneId} (DOM attach took ${elapsed}ms, buffer lines=${xterm.buffer.active.length})`,
+			);
+		}
 
 		const scheduleScrollToBottom = () => {
 			requestAnimationFrame(() => {
@@ -263,42 +280,43 @@ export function useTerminalLifecycle({
 		xtermRef.current = xterm;
 		fitAddonRef.current = fitAddon;
 		rendererRef.current = renderer;
+		searchAddonRef.current = searchAddon;
 		isExitedRef.current = false;
 		setXtermInstance(xterm);
 		isStreamReadyRef.current = false;
-		didFirstRenderRef.current = false;
 		pendingInitialStateRef.current = null;
 
 		if (isFocusedRef.current) {
 			xterm.focus();
 		}
 
-		if (!isUnmounted) {
-			const searchAddon = new SearchAddon();
-			xterm.loadAddon(searchAddon);
-			searchAddonRef.current = searchAddon;
-		}
-
-		// Wait for first render before applying restoration
+		// Wait for first render before applying restoration.
+		// On reattach, xterm is already rendered so skip the render gate.
 		let renderDisposable: IDisposable | null = null;
 		let firstRenderFallback: ReturnType<typeof setTimeout> | null = null;
 
-		renderDisposable = xterm.onRender(() => {
-			if (firstRenderFallback) {
-				clearTimeout(firstRenderFallback);
-				firstRenderFallback = null;
-			}
-			renderDisposable?.dispose();
-			renderDisposable = null;
+		if (isReattach) {
 			didFirstRenderRef.current = true;
-			maybeApplyInitialState();
-		});
+		} else {
+			didFirstRenderRef.current = false;
 
-		firstRenderFallback = setTimeout(() => {
-			if (isUnmounted || didFirstRenderRef.current) return;
-			didFirstRenderRef.current = true;
-			maybeApplyInitialState();
-		}, FIRST_RENDER_RESTORE_FALLBACK_MS);
+			renderDisposable = xterm.onRender(() => {
+				if (firstRenderFallback) {
+					clearTimeout(firstRenderFallback);
+					firstRenderFallback = null;
+				}
+				renderDisposable?.dispose();
+				renderDisposable = null;
+				didFirstRenderRef.current = true;
+				maybeApplyInitialState();
+			});
+
+			firstRenderFallback = setTimeout(() => {
+				if (isUnmounted || didFirstRenderRef.current) return;
+				didFirstRenderRef.current = true;
+				maybeApplyInitialState();
+			}, FIRST_RENDER_RESTORE_FALLBACK_MS);
+		}
 
 		const nextAttachRequestId = () => createAttachRequestId(paneId);
 		const cancelAttachRequest = (requestId: string | null) => {
@@ -555,6 +573,56 @@ export function useTerminalLifecycle({
 								if (activeAttachRequestId !== requestId) return;
 								setConnectionError(null);
 								clearPaneInitialDataRef.current(paneId);
+
+								// Reattach fast-path: xterm buffer is already in memory,
+								// skip scrollback restoration and just open the stream gate.
+								if (isReattach && !result.isColdRestore) {
+									if (DEBUG_TERMINAL) {
+										const reattachElapsed = (
+											performance.now() - mountStartedAt
+										).toFixed(1);
+										console.log(
+											`[Terminal] Reattach fast-path: ${paneId} (total ${reattachElapsed}ms, skipped scrollback=${result.scrollback?.length ?? 0} bytes, pendingEvents=${pendingEventsRef.current.length})`,
+										);
+									}
+									requestAnimationFrame(() => {
+										if (!isAttachActive()) return;
+										const prevCols = xterm.cols;
+										const prevRows = xterm.rows;
+										fitAddon.fit();
+										if (xterm.cols !== prevCols || xterm.rows !== prevRows) {
+											resizeRef.current({
+												paneId,
+												cols: xterm.cols,
+												rows: xterm.rows,
+											});
+										}
+									});
+									isStreamReadyRef.current = true;
+									flushPendingEvents();
+
+									if (!commandToRunAfterAttach) {
+										return;
+									}
+
+									void writeWorkspaceRunCommand(commandToRunAfterAttach).catch(
+										(error) => {
+											console.error(
+												"[Terminal] Failed to write workspace run command after reattach:",
+												error,
+											);
+											if (paneWorkspaceRun) {
+												setPaneWorkspaceRunState(paneId, "stopped-by-exit");
+											}
+											setConnectionError(
+												error instanceof Error
+													? error.message
+													: "Failed to write workspace run command",
+											);
+										},
+									);
+									return;
+								}
 
 								const storedColdRestore = coldRestoreState.get(paneId);
 								if (storedColdRestore?.isRestored) {
@@ -852,10 +920,13 @@ export function useTerminalLifecycle({
 			isPaneDestroyed(useTabsStore.getState().panes, paneId);
 
 		return () => {
-			if (DEBUG_TERMINAL) {
-				console.log(`[Terminal] Unmount: ${paneId}`);
-			}
+			const unmountStartedAt = performance.now();
 			const paneDestroyed = isPaneDestroyedInStore();
+			if (DEBUG_TERMINAL) {
+				console.log(
+					`[Terminal] Unmount: ${paneId} (paneDestroyed=${paneDestroyed}, isReattach=${isReattach})`,
+				);
+			}
 			cancelInitialAttach();
 			isUnmounted = true;
 			attachCanceled = true;
@@ -881,24 +952,42 @@ export function useTerminalLifecycle({
 			cleanupResize();
 			cleanupPaste();
 			cleanupCopy();
-			cleanupQuerySuppression();
 			unregisterClearCallbackRef.current(paneId);
 			unregisterScrollToBottomCallbackRef.current(paneId);
 			unregisterGetSelectionCallbackRef.current(paneId);
 			unregisterPasteCallbackRef.current(paneId);
 
 			if (paneDestroyed) {
-				// Pane was explicitly destroyed, so kill the session.
+				// Pane was explicitly destroyed — full cleanup.
+				if (DEBUG_TERMINAL) {
+					console.log(
+						`[Terminal] Pane destroyed — killing session and disposing cache: ${paneId}`,
+					);
+				}
 				killTerminalForPane(paneId);
 				coldRestoreState.delete(paneId);
 				pendingDetaches.delete(paneId);
+				v1TerminalCache.dispose(paneId);
 			} else {
+				// Pane hidden (tab switch) — detach wrapper from DOM but keep
+				// xterm alive in the cache for instant reattach.
+				v1TerminalCache.detachFromContainer(paneId);
+
 				const detachTimeout = setTimeout(() => {
 					detachRef.current({ paneId });
 					pendingDetaches.delete(paneId);
 					coldRestoreState.delete(paneId);
 				}, 50);
 				pendingDetaches.set(paneId, detachTimeout);
+
+				if (DEBUG_TERMINAL) {
+					const elapsed = (
+						performance.now() - unmountStartedAt
+					).toFixed(1);
+					console.log(
+						`[Terminal] Detached from DOM (cached for reattach): ${paneId} (cleanup took ${elapsed}ms)`,
+					);
+				}
 			}
 
 			isStreamReadyRef.current = false;
@@ -907,7 +996,8 @@ export function useTerminalLifecycle({
 			resetModes();
 			renderDisposable?.dispose();
 
-			setTimeout(() => xterm.dispose(), 0);
+			// Do NOT dispose xterm here — the cache owns the lifecycle.
+			// xterm will be disposed when the pane is destroyed (above).
 
 			xtermRef.current = null;
 			searchAddonRef.current = null;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
@@ -508,61 +508,118 @@ export function useTerminalLifecycle({
 			restartCommand: workspaceRunRestartCommand,
 		} = resolveWorkspaceRunAttachMode(paneId, defaultRestartCommandRef.current);
 
-		const cancelInitialAttach = scheduleTerminalAttach({
-			paneId,
-			priority: isFocusedRef.current ? 0 : 1,
-			run: (done) => {
-				const startAttach = (commandToRunAfterAttach?: string) => {
-					if (attachCanceled) return;
-					if (attachInFlightByPane.has(paneId)) {
-						cancelAttachWait = waitForAttachClear(paneId, () => {
-							if (attachCanceled || isUnmounted) return;
-							startAttach(commandToRunAfterAttach);
-						});
-						return;
-					}
+		// On reattach: stream is already running and xterm buffer is current.
+		// Skip the entire createOrAttach + stream setup.
+		let cancelInitialAttach: (() => void) | null = null;
 
-					const requestId = nextAttachRequestId();
-					cancelAttachRequest(activeAttachRequestId);
-					activeAttachRequestId = requestId;
-					activeAttachId = ++attachSequence;
-					const attachId = activeAttachId;
-					const isAttachActive = () =>
-						!isUnmounted && !attachCanceled && attachId === activeAttachId;
+		if (isReattach) {
+			// Stream is ready — the cache has been writing data to xterm.
+			isStreamReadyRef.current = true;
 
-					markAttachInFlight(paneId, attachId);
+			// Resize in case the container dimensions changed while hidden.
+			requestAnimationFrame(() => {
+				if (isUnmounted) return;
+				const prevCols = xterm.cols;
+				const prevRows = xterm.rows;
+				fitAddon.fit();
+				if (xterm.cols !== prevCols || xterm.rows !== prevRows) {
+					resizeRef.current({
+						paneId,
+						cols: xterm.cols,
+						rows: xterm.rows,
+					});
+				}
+			});
+		} else {
+			cancelInitialAttach = scheduleTerminalAttach({
+				paneId,
+				priority: isFocusedRef.current ? 0 : 1,
+				run: (done) => {
+					const startAttach = (commandToRunAfterAttach?: string) => {
+						if (attachCanceled) return;
+						if (attachInFlightByPane.has(paneId)) {
+							cancelAttachWait = waitForAttachClear(paneId, () => {
+								if (attachCanceled || isUnmounted) return;
+								startAttach(commandToRunAfterAttach);
+							});
+							return;
+						}
 
-					const finishAttach = () => {
-						clearAttachInFlight(paneId, attachId);
-						done();
-					};
+						const requestId = nextAttachRequestId();
+						cancelAttachRequest(activeAttachRequestId);
+						activeAttachRequestId = requestId;
+						activeAttachId = ++attachSequence;
+						const attachId = activeAttachId;
+						const isAttachActive = () =>
+							!isUnmounted && !attachCanceled && attachId === activeAttachId;
 
-					if (DEBUG_TERMINAL) {
-						console.log(`[Terminal] createOrAttach start: ${paneId}`);
-					}
-					createOrAttachRef.current(
-						{
-							paneId,
-							requestId,
-							tabId: tabIdRef.current,
-							workspaceId,
-							cols: xterm.cols,
-							rows: xterm.rows,
-							cwd: initialCwd,
-							...((isNewWorkspaceRun || Boolean(commandToRunAfterAttach)) && {
-								skipColdRestore: true,
-							}),
-						},
-						{
-							onSuccess: (result) => {
-								if (!isAttachActive()) return;
-								if (activeAttachRequestId !== requestId) return;
-								setConnectionError(null);
-								clearPaneInitialDataRef.current(paneId);
+						markAttachInFlight(paneId, attachId);
 
-								// Reattach fast-path: xterm buffer is already in memory,
-								// skip scrollback restoration and just open the stream gate.
-								if (isReattach && !result.isColdRestore) {
+						const finishAttach = () => {
+							clearAttachInFlight(paneId, attachId);
+							done();
+						};
+
+						if (DEBUG_TERMINAL) {
+							console.log(`[Terminal] createOrAttach start: ${paneId}`);
+						}
+						createOrAttachRef.current(
+							{
+								paneId,
+								requestId,
+								tabId: tabIdRef.current,
+								workspaceId,
+								cols: xterm.cols,
+								rows: xterm.rows,
+								cwd: initialCwd,
+								...((isNewWorkspaceRun || Boolean(commandToRunAfterAttach)) && {
+									skipColdRestore: true,
+								}),
+							},
+							{
+								onSuccess: (result) => {
+									if (!isAttachActive()) return;
+									if (activeAttachRequestId !== requestId) return;
+									setConnectionError(null);
+									clearPaneInitialDataRef.current(paneId);
+
+									// Start the cache-owned stream subscription now that the
+									// backend session exists, and mark it ready so events
+									// flow through the component's registered handler.
+									v1TerminalCache.startStream(paneId);
+									v1TerminalCache.setStreamReady(paneId);
+
+									const storedColdRestore = coldRestoreState.get(paneId);
+									if (storedColdRestore?.isRestored) {
+										setIsRestoredMode(true);
+										setRestoredCwd(storedColdRestore.cwd);
+										if (storedColdRestore.scrollback && xterm) {
+											xterm.write(
+												storedColdRestore.scrollback,
+												scheduleScrollToBottom,
+											);
+										}
+										didFirstRenderRef.current = true;
+										return;
+									}
+
+									if (result.isColdRestore) {
+										const scrollback =
+											result.snapshot?.snapshotAnsi ?? result.scrollback;
+										coldRestoreState.set(paneId, {
+											isRestored: true,
+											cwd: result.previousCwd || null,
+											scrollback,
+										});
+										setIsRestoredMode(true);
+										setRestoredCwd(result.previousCwd || null);
+										if (scrollback && xterm) {
+											xterm.write(scrollback, scheduleScrollToBottom);
+										}
+										didFirstRenderRef.current = true;
+										return;
+									}
+
 									requestAnimationFrame(() => {
 										if (!isAttachActive()) return;
 										const prevCols = xterm.cols;
@@ -576,8 +633,9 @@ export function useTerminalLifecycle({
 											});
 										}
 									});
-									isStreamReadyRef.current = true;
-									flushPendingEvents();
+
+									pendingInitialStateRef.current = result;
+									maybeApplyInitialState();
 
 									if (!commandToRunAfterAttach) {
 										return;
@@ -586,7 +644,7 @@ export function useTerminalLifecycle({
 									void writeWorkspaceRunCommand(commandToRunAfterAttach).catch(
 										(error) => {
 											console.error(
-												"[Terminal] Failed to write workspace run command after reattach:",
+												"[Terminal] Failed to write workspace run command after attach:",
 												error,
 											);
 											if (paneWorkspaceRun) {
@@ -597,143 +655,73 @@ export function useTerminalLifecycle({
 													? error.message
 													: "Failed to write workspace run command",
 											);
+											isStreamReadyRef.current = true;
+											flushPendingEvents();
 										},
 									);
-									return;
-								}
-
-								const storedColdRestore = coldRestoreState.get(paneId);
-								if (storedColdRestore?.isRestored) {
-									setIsRestoredMode(true);
-									setRestoredCwd(storedColdRestore.cwd);
-									if (storedColdRestore.scrollback && xterm) {
-										xterm.write(
-											storedColdRestore.scrollback,
-											scheduleScrollToBottom,
-										);
-									}
-									didFirstRenderRef.current = true;
-									return;
-								}
-
-								if (result.isColdRestore) {
-									const scrollback =
-										result.snapshot?.snapshotAnsi ?? result.scrollback;
-									coldRestoreState.set(paneId, {
-										isRestored: true,
-										cwd: result.previousCwd || null,
-										scrollback,
-									});
-									setIsRestoredMode(true);
-									setRestoredCwd(result.previousCwd || null);
-									if (scrollback && xterm) {
-										xterm.write(scrollback, scheduleScrollToBottom);
-									}
-									didFirstRenderRef.current = true;
-									return;
-								}
-
-								requestAnimationFrame(() => {
+								},
+								onError: (error) => {
 									if (!isAttachActive()) return;
-									const prevCols = xterm.cols;
-									const prevRows = xterm.rows;
-									fitAddon.fit();
-									if (xterm.cols !== prevCols || xterm.rows !== prevRows) {
-										resizeRef.current({
-											paneId,
-											cols: xterm.cols,
-											rows: xterm.rows,
-										});
+									if (activeAttachRequestId !== requestId) return;
+									if (isTerminalAttachCanceledMessage(error.message)) {
+										return;
 									}
-								});
-
-								pendingInitialStateRef.current = result;
-								maybeApplyInitialState();
-
-								if (!commandToRunAfterAttach) {
-									return;
-								}
-
-								void writeWorkspaceRunCommand(commandToRunAfterAttach).catch(
-									(error) => {
-										console.error(
-											"[Terminal] Failed to write workspace run command after attach:",
-											error,
-										);
-										if (paneWorkspaceRun) {
-											setPaneWorkspaceRunState(paneId, "stopped-by-exit");
+									const workspaceRun = getPaneWorkspaceRun(paneId);
+									if (error.message?.includes("TERMINAL_SESSION_KILLED")) {
+										if (workspaceRun) {
+											setPaneWorkspaceRunState(paneId, "stopped-by-user");
 										}
-										setConnectionError(
-											error instanceof Error
-												? error.message
-												: "Failed to write workspace run command",
-										);
-										isStreamReadyRef.current = true;
-										flushPendingEvents();
-									},
-								);
-							},
-							onError: (error) => {
-								if (!isAttachActive()) return;
-								if (activeAttachRequestId !== requestId) return;
-								if (isTerminalAttachCanceledMessage(error.message)) {
-									return;
-								}
-								const workspaceRun = getPaneWorkspaceRun(paneId);
-								if (error.message?.includes("TERMINAL_SESSION_KILLED")) {
-									if (workspaceRun) {
-										setPaneWorkspaceRunState(paneId, "stopped-by-user");
+										wasKilledByUserRef.current = true;
+										isExitedRef.current = true;
+										isStreamReadyRef.current = false;
+										setExitStatus("killed");
+										setConnectionError(null);
+										return;
 									}
-									wasKilledByUserRef.current = true;
-									isExitedRef.current = true;
-									isStreamReadyRef.current = false;
-									setExitStatus("killed");
-									setConnectionError(null);
-									return;
-								}
-								console.error("[Terminal] Failed to create/attach:", error);
-								if (workspaceRun) {
-									setPaneWorkspaceRunState(paneId, "stopped-by-exit");
-								}
-								setConnectionError(
-									error.message || "Failed to connect to terminal",
-								);
-								isStreamReadyRef.current = true;
-								flushPendingEvents();
+									console.error("[Terminal] Failed to create/attach:", error);
+									if (workspaceRun) {
+										setPaneWorkspaceRunState(paneId, "stopped-by-exit");
+									}
+									setConnectionError(
+										error.message || "Failed to connect to terminal",
+									);
+									isStreamReadyRef.current = true;
+									flushPendingEvents();
+								},
+								onSettled: () => {
+									if (activeAttachRequestId === requestId) {
+										activeAttachRequestId = null;
+									}
+									finishAttach();
+								},
 							},
-							onSettled: () => {
-								if (activeAttachRequestId === requestId) {
-									activeAttachRequestId = null;
-								}
-								finishAttach();
-							},
-						},
-					);
-				};
+						);
+					};
 
-				// Handle workspace-run panes that need recovery (stopped or stale "running" after restart)
-				if (paneWorkspaceRun && !isNewWorkspaceRun) {
-					void recoverWorkspaceRunPane({
-						paneId,
-						workspaceRun: paneWorkspaceRun,
-						isNewWorkspaceRun,
-						xterm,
-						shouldAbort: () => isUnmounted || attachCanceled,
-						startAttach,
-						done,
-						isExitedRef,
-						wasKilledByUserRef,
-						isStreamReadyRef,
-						setExitStatus,
-						restartCommand: workspaceRunRestartCommand,
-					});
+					// Handle workspace-run panes that need recovery (stopped or stale "running" after restart)
+					if (paneWorkspaceRun && !isNewWorkspaceRun) {
+						void recoverWorkspaceRunPane({
+							paneId,
+							workspaceRun: paneWorkspaceRun,
+							isNewWorkspaceRun,
+							xterm,
+							shouldAbort: () => isUnmounted || attachCanceled,
+							startAttach,
+							done,
+							isExitedRef,
+							wasKilledByUserRef,
+							isStreamReadyRef,
+							setExitStatus,
+							restartCommand: workspaceRunRestartCommand,
+						});
+						return;
+					}
+
+					startAttach();
 					return;
-				}
-
-				startAttach();
-				return;
-			},
-		});
+				},
+			});
+		} // end if (!isReattach)
 
 		const inputDisposable = xterm.onData(handleTerminalInput);
 		const keyDisposable = xterm.onKey(handleKeyPress);
@@ -902,7 +890,7 @@ export function useTerminalLifecycle({
 				console.log(`[Terminal] Unmount: ${paneId}`);
 			}
 			const paneDestroyed = isPaneDestroyedInStore();
-			cancelInitialAttach();
+			cancelInitialAttach?.();
 			isUnmounted = true;
 			attachCanceled = true;
 			cancelAttachRequest(activeAttachRequestId);
@@ -940,25 +928,18 @@ export function useTerminalLifecycle({
 				v1TerminalCache.dispose(paneId);
 			} else {
 				// Pane hidden (tab switch) — detach wrapper from DOM but keep
-				// xterm alive in the cache for instant reattach.
+				// xterm AND stream subscription alive in the cache.
+				// No backend detach — the session stays connected so data
+				// continues flowing to xterm while hidden.
 				v1TerminalCache.detachFromContainer(paneId);
-
-				const detachTimeout = setTimeout(() => {
-					detachRef.current({ paneId });
-					pendingDetaches.delete(paneId);
-					coldRestoreState.delete(paneId);
-				}, 50);
-				pendingDetaches.set(paneId, detachTimeout);
 			}
 
-			isStreamReadyRef.current = false;
-			didFirstRenderRef.current = false;
 			pendingInitialStateRef.current = null;
 			resetModes();
 			renderDisposable?.dispose();
 
-			// Do NOT dispose xterm here — the cache owns the lifecycle.
-			// xterm will be disposed when the pane is destroyed (above).
+			// Do NOT dispose xterm or reset stream state — the cache owns
+			// both the xterm lifecycle and the stream subscription.
 
 			xtermRef.current = null;
 			searchAddonRef.current = null;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
@@ -222,7 +222,9 @@ export function useTerminalLifecycle({
 		const container = terminalRef.current;
 		if (!container) return;
 
-		console.log(`[Terminal] Mount: ${paneId}`, new Error().stack?.split("\n").slice(1, 4).join("\n"));
+		if (DEBUG_TERMINAL) {
+			console.log(`[Terminal] Mount: ${paneId}`);
+		}
 
 		// Cancel pending detach from previous unmount
 		const pendingDetach = pendingDetaches.get(paneId);
@@ -241,7 +243,9 @@ export function useTerminalLifecycle({
 		// Use the v1 terminal cache: reuse existing xterm instance across tab
 		// switches instead of creating/disposing each time (v2 "hide attach" pattern).
 		const isReattach = v1TerminalCache.has(paneId);
-		console.log(`[Terminal] isReattach=${isReattach} paneId=${paneId}`);
+		if (DEBUG_TERMINAL) {
+			console.log(`[Terminal] isReattach=${isReattach} paneId=${paneId}`);
+		}
 		const cached = v1TerminalCache.getOrCreate(paneId, {
 			cwd: workspaceCwdRef.current ?? undefined,
 			initialTheme: initialThemeRef.current,
@@ -794,7 +798,9 @@ export function useTerminalLifecycle({
 
 		return () => {
 			const paneDestroyed = isPaneDestroyedInStore();
-			console.log(`[Terminal] Unmount: ${paneId}, paneDestroyed=${paneDestroyed}`, new Error().stack?.split("\n").slice(1, 4).join("\n"));
+			if (DEBUG_TERMINAL) {
+				console.log(`[Terminal] Unmount: ${paneId}, paneDestroyed=${paneDestroyed}`);
+			}
 			cancelInitialAttach?.();
 			isUnmounted = true;
 			attachCanceled = true;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
@@ -17,7 +17,6 @@ import {
 	setupFocusListener,
 	setupKeyboardHandler,
 	setupPasteHandler,
-	type TerminalRendererRef,
 } from "../helpers";
 import { isPaneDestroyed } from "../pane-guards";
 import { coldRestoreState, pendingDetaches } from "../state";
@@ -26,7 +25,6 @@ import type {
 	CreateOrAttachResult,
 	TerminalCancelCreateOrAttachMutate,
 	TerminalClearScrollbackMutate,
-	TerminalDetachMutate,
 	TerminalResizeMutate,
 	TerminalWriteMutate,
 } from "../types";
@@ -95,7 +93,6 @@ export interface UseTerminalLifecycleOptions {
 	xtermRef: MutableRefObject<XTerm | null>;
 	fitAddonRef: MutableRefObject<FitAddon | null>;
 	searchAddonRef: MutableRefObject<SearchAddon | null>;
-	rendererRef: MutableRefObject<TerminalRendererRef | null>;
 	isExitedRef: MutableRefObject<boolean>;
 	wasKilledByUserRef: MutableRefObject<boolean>;
 	commandBufferRef: MutableRefObject<string>;
@@ -117,7 +114,6 @@ export interface UseTerminalLifecycleOptions {
 	createOrAttachRef: MutableRefObject<CreateOrAttachMutate>;
 	writeRef: MutableRefObject<TerminalWriteMutate>;
 	resizeRef: MutableRefObject<TerminalResizeMutate>;
-	detachRef: MutableRefObject<TerminalDetachMutate>;
 	cancelCreateOrAttachRef: MutableRefObject<TerminalCancelCreateOrAttachMutate>;
 	clearScrollbackRef: MutableRefObject<TerminalClearScrollbackMutate>;
 	isStreamReadyRef: MutableRefObject<boolean>;
@@ -162,7 +158,6 @@ export function useTerminalLifecycle({
 	xtermRef,
 	fitAddonRef,
 	searchAddonRef,
-	rendererRef,
 	isExitedRef,
 	wasKilledByUserRef,
 	commandBufferRef,
@@ -182,7 +177,6 @@ export function useTerminalLifecycle({
 	createOrAttachRef,
 	writeRef,
 	resizeRef,
-	detachRef,
 	cancelCreateOrAttachRef,
 	clearScrollbackRef,
 	isStreamReadyRef,
@@ -253,7 +247,7 @@ export function useTerminalLifecycle({
 			onUrlClickRef: handleUrlClickRef,
 		});
 
-		const { xterm, fitAddon, rendererRef: renderer, searchAddon } = cached;
+		const { xterm, fitAddon, searchAddon } = cached;
 
 		// Attach the wrapper div to the live container.
 		// The cache creates a ResizeObserver that calls fitAddon.fit() and
@@ -271,7 +265,6 @@ export function useTerminalLifecycle({
 
 		xtermRef.current = xterm;
 		fitAddonRef.current = fitAddon;
-		rendererRef.current = renderer;
 		searchAddonRef.current = searchAddon;
 		isExitedRef.current = false;
 		setXtermInstance(xterm);
@@ -821,7 +814,6 @@ export function useTerminalLifecycle({
 
 			xtermRef.current = null;
 			searchAddonRef.current = null;
-			rendererRef.current = null;
 			setXtermInstance(null);
 		};
 	}, [

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
@@ -222,9 +222,7 @@ export function useTerminalLifecycle({
 		const container = terminalRef.current;
 		if (!container) return;
 
-		if (DEBUG_TERMINAL) {
-			console.log(`[Terminal] Mount: ${paneId}`);
-		}
+		console.log(`[Terminal] Mount: ${paneId}`, new Error().stack?.split("\n").slice(1, 4).join("\n"));
 
 		// Cancel pending detach from previous unmount
 		const pendingDetach = pendingDetaches.get(paneId);
@@ -243,6 +241,7 @@ export function useTerminalLifecycle({
 		// Use the v1 terminal cache: reuse existing xterm instance across tab
 		// switches instead of creating/disposing each time (v2 "hide attach" pattern).
 		const isReattach = v1TerminalCache.has(paneId);
+		console.log(`[Terminal] isReattach=${isReattach} paneId=${paneId}`);
 		const cached = v1TerminalCache.getOrCreate(paneId, {
 			cwd: workspaceCwdRef.current ?? undefined,
 			initialTheme: initialThemeRef.current,
@@ -789,107 +788,13 @@ export function useTerminalLifecycle({
 			isBracketedPasteEnabled: () => isBracketedPasteRef.current,
 		});
 		const cleanupCopy = setupCopyHandler(xterm);
-		const reattachRecovery = {
-			throttleMs: 120,
-			pendingFrame: null as number | null,
-			lastRunAt: 0,
-			pendingForceResize: false,
-		};
-
-		const isCurrentTerminalRenderable = () => {
-			if (isUnmounted || xtermRef.current !== xterm) return false;
-			if (!container.isConnected) return false;
-
-			const style = window.getComputedStyle(container);
-			if (style.display === "none" || style.visibility === "hidden") {
-				return false;
-			}
-
-			const rect = container.getBoundingClientRect();
-			return rect.width > 1 && rect.height > 1;
-		};
-
-		const runReattachRecovery = (forceResize: boolean) => {
-			if (!isCurrentTerminalRenderable()) return;
-
-			const prevCols = xterm.cols;
-			const prevRows = xterm.rows;
-			const wasAtBottom =
-				xterm.buffer.active.viewportY >= xterm.buffer.active.baseY;
-
-			// Rebuild stale WebGL glyph cache after occlusion and force a paint pass.
-			rendererRef.current?.current.clearTextureAtlas?.();
-
-			fitAddon.fit();
-			xterm.refresh(0, Math.max(0, xterm.rows - 1));
-
-			if (forceResize || xterm.cols !== prevCols || xterm.rows !== prevRows) {
-				resizeRef.current({ paneId, cols: xterm.cols, rows: xterm.rows });
-			}
-
-			if (isFocusedRef.current && document.hasFocus()) {
-				xterm.focus();
-			}
-
-			if (!wasAtBottom) return;
-			requestAnimationFrame(() => {
-				if (isUnmounted || xtermRef.current !== xterm) return;
-				scrollToBottom(xterm);
-			});
-		};
-
-		const scheduleReattachRecovery = (forceResize: boolean) => {
-			reattachRecovery.pendingForceResize ||= forceResize;
-			if (reattachRecovery.pendingFrame !== null) return;
-
-			reattachRecovery.pendingFrame = requestAnimationFrame(() => {
-				reattachRecovery.pendingFrame = null;
-
-				const now = Date.now();
-				if (now - reattachRecovery.lastRunAt < reattachRecovery.throttleMs) {
-					// Schedule a retry after the remaining throttle window so the recovery
-					// is not permanently lost when focus events fire in rapid succession.
-					const remaining =
-						reattachRecovery.throttleMs - (now - reattachRecovery.lastRunAt);
-					setTimeout(() => {
-						if (!isUnmounted)
-							scheduleReattachRecovery(reattachRecovery.pendingForceResize);
-					}, remaining + 1);
-					return;
-				}
-				reattachRecovery.lastRunAt = now;
-
-				const shouldForceResize = reattachRecovery.pendingForceResize;
-				reattachRecovery.pendingForceResize = false;
-				runReattachRecovery(shouldForceResize);
-			});
-		};
-
-		const cancelReattachRecovery = () => {
-			if (reattachRecovery.pendingFrame === null) return;
-			cancelAnimationFrame(reattachRecovery.pendingFrame);
-			reattachRecovery.pendingFrame = null;
-		};
-
-		const handleVisibilityChange = () => {
-			if (document.hidden) return;
-			scheduleReattachRecovery(isFocusedRef.current);
-		};
-		const handleWindowFocus = () => {
-			scheduleReattachRecovery(isFocusedRef.current);
-		};
-
-		document.addEventListener("visibilitychange", handleVisibilityChange);
-		window.addEventListener("focus", handleWindowFocus);
 
 		const isPaneDestroyedInStore = () =>
 			isPaneDestroyed(useTabsStore.getState().panes, paneId);
 
 		return () => {
-			if (DEBUG_TERMINAL) {
-				console.log(`[Terminal] Unmount: ${paneId}`);
-			}
 			const paneDestroyed = isPaneDestroyedInStore();
+			console.log(`[Terminal] Unmount: ${paneId}, paneDestroyed=${paneDestroyed}`, new Error().stack?.split("\n").slice(1, 4).join("\n"));
 			cancelInitialAttach?.();
 			isUnmounted = true;
 			attachCanceled = true;
@@ -903,9 +808,6 @@ export function useTerminalLifecycle({
 			}
 			clearAttachInFlight(paneId, cleanupAttachId);
 			if (firstRenderFallback) clearTimeout(firstRenderFallback);
-			cancelReattachRecovery();
-			document.removeEventListener("visibilitychange", handleVisibilityChange);
-			window.removeEventListener("focus", handleWindowFocus);
 			inputDisposable.dispose();
 			keyDisposable.dispose();
 			titleDisposable.dispose();

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
@@ -222,8 +222,6 @@ export function useTerminalLifecycle({
 		const container = terminalRef.current;
 		if (!container) return;
 
-		const mountStartedAt = performance.now();
-
 		if (DEBUG_TERMINAL) {
 			console.log(`[Terminal] Mount: ${paneId}`);
 		}
@@ -233,11 +231,6 @@ export function useTerminalLifecycle({
 		if (pendingDetach) {
 			clearTimeout(pendingDetach);
 			pendingDetaches.delete(paneId);
-			if (DEBUG_TERMINAL) {
-				console.log(
-					`[Terminal] Cancelled pending detach (StrictMode or fast tab switch): ${paneId}`,
-				);
-			}
 		}
 
 		let isUnmounted = false;
@@ -262,13 +255,6 @@ export function useTerminalLifecycle({
 
 		// Attach the wrapper div to the live container
 		v1TerminalCache.attachToContainer(paneId, container);
-
-		if (DEBUG_TERMINAL) {
-			const elapsed = (performance.now() - mountStartedAt).toFixed(1);
-			console.log(
-				`[Terminal] ${isReattach ? "Reattach" : "Fresh mount"}: ${paneId} (DOM attach took ${elapsed}ms, buffer lines=${xterm.buffer.active.length})`,
-			);
-		}
 
 		const scheduleScrollToBottom = () => {
 			requestAnimationFrame(() => {
@@ -551,11 +537,8 @@ export function useTerminalLifecycle({
 						done();
 					};
 
-					const createOrAttachStartedAt = performance.now();
 					if (DEBUG_TERMINAL) {
-						console.log(
-							`[Terminal] createOrAttach start: ${paneId} (isReattach=${isReattach}, elapsed since mount=${(createOrAttachStartedAt - mountStartedAt).toFixed(1)}ms)`,
-						);
+						console.log(`[Terminal] createOrAttach start: ${paneId}`);
 					}
 					createOrAttachRef.current(
 						{
@@ -580,14 +563,6 @@ export function useTerminalLifecycle({
 								// Reattach fast-path: xterm buffer is already in memory,
 								// skip scrollback restoration and just open the stream gate.
 								if (isReattach && !result.isColdRestore) {
-									if (DEBUG_TERMINAL) {
-										const reattachElapsed = (
-											performance.now() - mountStartedAt
-										).toFixed(1);
-										console.log(
-											`[Terminal] Reattach fast-path: ${paneId} (total ${reattachElapsed}ms, skipped scrollback=${result.scrollback?.length ?? 0} bytes)`,
-										);
-									}
 									requestAnimationFrame(() => {
 										if (!isAttachActive()) return;
 										const prevCols = xterm.cols;
@@ -671,18 +646,6 @@ export function useTerminalLifecycle({
 										});
 									}
 								});
-
-								if (DEBUG_TERMINAL) {
-									const attachElapsed = (
-										performance.now() - createOrAttachStartedAt
-									).toFixed(1);
-									const totalElapsed = (
-										performance.now() - mountStartedAt
-									).toFixed(1);
-									console.log(
-										`[Terminal] Fresh attach complete: ${paneId} (createOrAttach=${attachElapsed}ms, total=${totalElapsed}ms, scrollback=${result.scrollback?.length ?? 0} bytes, isNew=${result.isNew}, wasRecovered=${result.wasRecovered})`,
-									);
-								}
 
 								pendingInitialStateRef.current = result;
 								maybeApplyInitialState();
@@ -935,13 +898,10 @@ export function useTerminalLifecycle({
 			isPaneDestroyed(useTabsStore.getState().panes, paneId);
 
 		return () => {
-			const unmountStartedAt = performance.now();
-			const paneDestroyed = isPaneDestroyedInStore();
 			if (DEBUG_TERMINAL) {
-				console.log(
-					`[Terminal] Unmount: ${paneId} (paneDestroyed=${paneDestroyed}, isReattach=${isReattach})`,
-				);
+				console.log(`[Terminal] Unmount: ${paneId}`);
 			}
+			const paneDestroyed = isPaneDestroyedInStore();
 			cancelInitialAttach();
 			isUnmounted = true;
 			attachCanceled = true;
@@ -974,11 +934,6 @@ export function useTerminalLifecycle({
 
 			if (paneDestroyed) {
 				// Pane was explicitly destroyed — full cleanup.
-				if (DEBUG_TERMINAL) {
-					console.log(
-						`[Terminal] Pane destroyed — killing session and disposing cache: ${paneId}`,
-					);
-				}
 				killTerminalForPane(paneId);
 				coldRestoreState.delete(paneId);
 				pendingDetaches.delete(paneId);
@@ -994,13 +949,6 @@ export function useTerminalLifecycle({
 					coldRestoreState.delete(paneId);
 				}, 50);
 				pendingDetaches.set(paneId, detachTimeout);
-
-				if (DEBUG_TERMINAL) {
-					const elapsed = (performance.now() - unmountStartedAt).toFixed(1);
-					console.log(
-						`[Terminal] Detached from DOM (cached for reattach): ${paneId} (cleanup took ${elapsed}ms)`,
-					);
-				}
 			}
 
 			isStreamReadyRef.current = false;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
@@ -252,9 +252,17 @@ export function useTerminalLifecycle({
 		// Attach the wrapper div to the live container.
 		// The cache creates a ResizeObserver that calls fitAddon.fit() and
 		// forwards resize events to the backend — no separate resize handler needed.
+		const prevCols = xterm.cols;
+		const prevRows = xterm.rows;
 		v1TerminalCache.attachToContainer(paneId, container, () => {
 			resizeRef.current({ paneId, cols: xterm.cols, rows: xterm.rows });
 		});
+		// If dimensions changed during attach (container resized while hidden),
+		// notify the backend PTY immediately — the ResizeObserver only fires on
+		// subsequent changes, not the initial fit.
+		if (xterm.cols !== prevCols || xterm.rows !== prevRows) {
+			resizeRef.current({ paneId, cols: xterm.cols, rows: xterm.rows });
+		}
 
 		const scheduleScrollToBottom = () => {
 			requestAnimationFrame(() => {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
@@ -17,7 +17,6 @@ import {
 	setupFocusListener,
 	setupKeyboardHandler,
 	setupPasteHandler,
-	setupResizeHandlers,
 	type TerminalRendererRef,
 } from "../helpers";
 import { isPaneDestroyed } from "../pane-guards";
@@ -256,8 +255,12 @@ export function useTerminalLifecycle({
 
 		const { xterm, fitAddon, rendererRef: renderer, searchAddon } = cached;
 
-		// Attach the wrapper div to the live container
-		v1TerminalCache.attachToContainer(paneId, container);
+		// Attach the wrapper div to the live container.
+		// The cache creates a ResizeObserver that calls fitAddon.fit() and
+		// forwards resize events to the backend — no separate resize handler needed.
+		v1TerminalCache.attachToContainer(paneId, container, () => {
+			resizeRef.current({ paneId, cols: xterm.cols, rows: xterm.rows });
+		});
 
 		const scheduleScrollToBottom = () => {
 			requestAnimationFrame(() => {
@@ -517,22 +520,8 @@ export function useTerminalLifecycle({
 
 		if (isReattach) {
 			// Stream is ready — the cache has been writing data to xterm.
+			// Resize is handled by attachToContainer's ResizeObserver above.
 			isStreamReadyRef.current = true;
-
-			// Resize in case the container dimensions changed while hidden.
-			requestAnimationFrame(() => {
-				if (isUnmounted) return;
-				const prevCols = xterm.cols;
-				const prevRows = xterm.rows;
-				fitAddon.fit();
-				if (xterm.cols !== prevCols || xterm.rows !== prevRows) {
-					resizeRef.current({
-						paneId,
-						cols: xterm.cols,
-						rows: xterm.rows,
-					});
-				}
-			});
 		} else {
 			cancelInitialAttach = scheduleTerminalAttach({
 				paneId,
@@ -622,20 +611,6 @@ export function useTerminalLifecycle({
 										didFirstRenderRef.current = true;
 										return;
 									}
-
-									requestAnimationFrame(() => {
-										if (!isAttachActive()) return;
-										const prevCols = xterm.cols;
-										const prevRows = xterm.rows;
-										fitAddon.fit();
-										if (xterm.cols !== prevCols || xterm.rows !== prevRows) {
-											resizeRef.current({
-												paneId,
-												cols: xterm.cols,
-												rows: xterm.rows,
-											});
-										}
-									});
 
 									pendingInitialStateRef.current = result;
 									maybeApplyInitialState();
@@ -778,12 +753,6 @@ export function useTerminalLifecycle({
 		const cleanupFocus = setupFocusListener(xterm, () =>
 			handleTerminalFocusRef.current(),
 		);
-		const cleanupResize = setupResizeHandlers(
-			container,
-			xterm,
-			fitAddon,
-			(cols, rows) => resizeRef.current({ paneId, cols, rows }),
-		);
 		const cleanupPaste = setupPasteHandler(xterm, {
 			onPaste: (text) => {
 				commandBufferRef.current += text;
@@ -799,7 +768,9 @@ export function useTerminalLifecycle({
 		return () => {
 			const paneDestroyed = isPaneDestroyedInStore();
 			if (DEBUG_TERMINAL) {
-				console.log(`[Terminal] Unmount: ${paneId}, paneDestroyed=${paneDestroyed}`);
+				console.log(
+					`[Terminal] Unmount: ${paneId}, paneDestroyed=${paneDestroyed}`,
+				);
 			}
 			cancelInitialAttach?.();
 			isUnmounted = true;
@@ -820,7 +791,6 @@ export function useTerminalLifecycle({
 			cleanupKeyboard();
 			cleanupClickToMove();
 			cleanupFocus?.();
-			cleanupResize();
 			cleanupPaste();
 			cleanupCopy();
 			unregisterClearCallbackRef.current(paneId);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalRestore.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalRestore.ts
@@ -120,11 +120,10 @@ export function useTerminalRestore({
 		++restoreSequenceRef.current;
 		const restoreSequence = restoreSequenceRef.current;
 		try {
-			const scheduleFitAndScroll = () => {
+			const scheduleScrollToBottom = () => {
 				requestAnimationFrame(() => {
 					if (xtermRef.current !== xterm) return;
 					if (restoreSequenceRef.current !== restoreSequence) return;
-					fitAddon.fit();
 					scrollToBottom(xterm);
 				});
 			};
@@ -185,7 +184,7 @@ export function useTerminalRestore({
 					}
 					flushPendingEvents();
 
-					scheduleFitAndScroll();
+					scheduleScrollToBottom();
 				});
 
 				if (result.snapshot?.cwd) {
@@ -200,7 +199,7 @@ export function useTerminalRestore({
 
 			const finalizeRestore = () => {
 				isStreamReadyRef.current = true;
-				scheduleFitAndScroll();
+				scheduleScrollToBottom();
 				if (DEBUG_TERMINAL) {
 					console.log(
 						`[Terminal] isStreamReady=true (finalizeRestore): ${paneId}, pendingEvents=${pendingEventsRef.current.length}`,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
@@ -117,7 +117,7 @@ export function detachFromContainer(paneId: string): void {
 	if (!entry) return;
 
 	if (DEBUG_TERMINAL) {
-		console.log(`[v1-terminal-cache] Detaching from DOM: ${paneId}`);
+		console.log(`[v1-terminal-cache] detachFromContainer: ${paneId}`);
 	}
 	entry.wrapper.remove();
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
@@ -1,17 +1,24 @@
+import type { Unsubscribable } from "@trpc/server/observable";
 import type { FitAddon } from "@xterm/addon-fit";
 import type { SearchAddon } from "@xterm/addon-search";
 import type { Terminal as XTerm } from "@xterm/xterm";
+import { electronTrpcClient } from "renderer/lib/trpc-client";
+import { DEBUG_TERMINAL } from "./config";
 import {
 	type CreateTerminalOptions,
 	createTerminalInWrapper,
 	type TerminalRendererRef,
 } from "./helpers";
+import type { TerminalStreamEvent } from "./types";
 
 /**
  * Cached xterm instance that survives React mount/unmount cycles.
  * Borrows the wrapper-div pattern from v2's terminal-runtime.ts:
  * xterm is opened into a persistent wrapper <div> that can be
  * moved between DOM containers without disposing the terminal.
+ *
+ * Also owns the tRPC stream subscription so data continues flowing
+ * to xterm even while the React component is unmounted (tab hidden).
  */
 export interface CachedTerminal {
 	xterm: XTerm;
@@ -21,6 +28,30 @@ export interface CachedTerminal {
 	wrapper: HTMLDivElement;
 	/** Disposes renderer RAF, query suppression, GPU renderer, etc. */
 	cleanupCreation: () => void;
+
+	// --- Stream management ---
+
+	/** The live tRPC subscription. Null until startStream() is called. */
+	subscription: Unsubscribable | null;
+	/** True once the first createOrAttach succeeds and the stream gate opens. */
+	streamReady: boolean;
+	/** Events queued before streamReady (first mount only). */
+	pendingStreamEvents: TerminalStreamEvent[];
+	/** Non-data events queued while no component is mounted. */
+	pendingLifecycleEvents: TerminalStreamEvent[];
+	/**
+	 * Handler provided by the mounted Terminal component.
+	 * When set, ALL events are forwarded here so the component can
+	 * update React state (exit status, connection error, modes, cwd, etc.).
+	 * When null (component unmounted), data events write directly to xterm
+	 * and non-data events are queued.
+	 */
+	eventHandler: ((event: TerminalStreamEvent) => void) | null;
+	/**
+	 * Error handler for tRPC subscription-level errors (distinct from
+	 * terminal stream error events).
+	 */
+	subscriptionErrorHandler: ((error: unknown) => void) | null;
 }
 
 const cache = new Map<string, CachedTerminal>();
@@ -40,6 +71,10 @@ export function getOrCreate(
 	const existing = cache.get(paneId);
 	if (existing) return existing;
 
+	if (DEBUG_TERMINAL) {
+		console.log(`[v1-terminal-cache] Creating new terminal: ${paneId}`);
+	}
+
 	const { xterm, fitAddon, searchAddon, renderer, wrapper, cleanup } =
 		createTerminalInWrapper(options);
 
@@ -50,16 +85,20 @@ export function getOrCreate(
 		rendererRef: renderer,
 		wrapper,
 		cleanupCreation: cleanup,
+		subscription: null,
+		streamReady: false,
+		pendingStreamEvents: [],
+		pendingLifecycleEvents: [],
+		eventHandler: null,
+		subscriptionErrorHandler: null,
 	};
 
 	cache.set(paneId, entry);
 	return entry;
 }
 
-/**
- * Append the cached terminal's wrapper div to a live DOM container.
- * Re-fits, refreshes rendering, and clears stale WebGL texture atlas.
- */
+// --- DOM attach / detach ---
+
 export function attachToContainer(
 	paneId: string,
 	container: HTMLDivElement,
@@ -69,31 +108,140 @@ export function attachToContainer(
 
 	container.appendChild(entry.wrapper);
 	entry.fitAddon.fit();
-	// Repaint after reattach — critical for WebGL renderer which may have
-	// skipped frames while the wrapper was detached from the DOM.
 	entry.xterm.refresh(0, Math.max(0, entry.xterm.rows - 1));
 	entry.rendererRef.current.clearTextureAtlas?.();
 }
 
-/**
- * Remove the wrapper from its current DOM container but keep the
- * xterm instance alive in memory. Buffer and scroll position are
- * preserved.
- */
 export function detachFromContainer(paneId: string): void {
 	const entry = cache.get(paneId);
 	if (!entry) return;
+
+	if (DEBUG_TERMINAL) {
+		console.log(`[v1-terminal-cache] Detaching from DOM: ${paneId}`);
+	}
 	entry.wrapper.remove();
 }
 
+// --- Stream subscription ---
+
+function routeEvent(entry: CachedTerminal, event: TerminalStreamEvent): void {
+	// Before stream is ready: queue everything (first-mount gating).
+	if (!entry.streamReady) {
+		entry.pendingStreamEvents.push(event);
+		return;
+	}
+
+	// Component mounted — forward all events there.
+	if (entry.eventHandler) {
+		entry.eventHandler(event);
+		return;
+	}
+
+	// Component unmounted — write data directly to xterm, queue the rest.
+	if (event.type === "data") {
+		entry.xterm.write(event.data);
+	} else {
+		entry.pendingLifecycleEvents.push(event);
+	}
+}
+
 /**
- * Fully dispose the cached terminal: cleanup creation resources,
- * dispose xterm, and remove from cache.
+ * Start the tRPC stream subscription for this terminal.
+ * Called once on first mount after createOrAttach succeeds.
+ * The subscription stays alive across component mount/unmount cycles
+ * and is only stopped on dispose().
  */
+export function startStream(paneId: string): void {
+	const entry = cache.get(paneId);
+	if (!entry || entry.subscription) return;
+
+	if (DEBUG_TERMINAL) {
+		console.log(`[v1-terminal-cache] Starting stream: ${paneId}`);
+	}
+
+	entry.subscription = electronTrpcClient.terminal.stream.subscribe(paneId, {
+		onData: (event: TerminalStreamEvent) => {
+			routeEvent(entry, event);
+		},
+		onError: (error: unknown) => {
+			if (entry.subscriptionErrorHandler) {
+				entry.subscriptionErrorHandler(error);
+			} else if (DEBUG_TERMINAL) {
+				console.error(
+					`[v1-terminal-cache] Stream error (no handler): ${paneId}`,
+					error,
+				);
+			}
+		},
+	});
+}
+
+/**
+ * Mark the stream as ready and flush any events queued during the
+ * first-mount gating period (before createOrAttach completed).
+ */
+export function setStreamReady(paneId: string): void {
+	const entry = cache.get(paneId);
+	if (!entry || entry.streamReady) return;
+
+	if (DEBUG_TERMINAL) {
+		console.log(
+			`[v1-terminal-cache] Stream ready: ${paneId}, flushing ${entry.pendingStreamEvents.length} queued events`,
+		);
+	}
+
+	entry.streamReady = true;
+	const pending = entry.pendingStreamEvents.splice(0);
+	for (const event of pending) {
+		routeEvent(entry, event);
+	}
+}
+
+/**
+ * Register event handlers from the mounted Terminal component.
+ * Returns any lifecycle events (exit, error, disconnect) that were
+ * queued while the component was unmounted.
+ */
+export function registerHandlers(
+	paneId: string,
+	handlers: {
+		onEvent: (event: TerminalStreamEvent) => void;
+		onError: (error: unknown) => void;
+	},
+): TerminalStreamEvent[] {
+	const entry = cache.get(paneId);
+	if (!entry) return [];
+
+	entry.eventHandler = handlers.onEvent;
+	entry.subscriptionErrorHandler = handlers.onError;
+
+	// Drain and return queued lifecycle events
+	return entry.pendingLifecycleEvents.splice(0);
+}
+
+/**
+ * Unregister the component's event handlers (component unmounting).
+ * The subscription stays alive; data events write directly to xterm.
+ */
+export function unregisterHandlers(paneId: string): void {
+	const entry = cache.get(paneId);
+	if (!entry) return;
+
+	entry.eventHandler = null;
+	entry.subscriptionErrorHandler = null;
+}
+
+// --- Disposal ---
+
 export function dispose(paneId: string): void {
 	const entry = cache.get(paneId);
 	if (!entry) return;
 
+	if (DEBUG_TERMINAL) {
+		console.log(`[v1-terminal-cache] Disposing: ${paneId}`);
+	}
+
+	entry.subscription?.unsubscribe();
 	entry.cleanupCreation();
 	entry.xterm.dispose();
 	cache.delete(paneId);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
@@ -4,11 +4,7 @@ import type { SearchAddon } from "@xterm/addon-search";
 import type { Terminal as XTerm } from "@xterm/xterm";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { DEBUG_TERMINAL } from "./config";
-import {
-	type CreateTerminalOptions,
-	createTerminalInWrapper,
-	type TerminalRendererRef,
-} from "./helpers";
+import { type CreateTerminalOptions, createTerminalInWrapper } from "./helpers";
 import type { TerminalStreamEvent } from "./types";
 
 /**
@@ -24,10 +20,12 @@ export interface CachedTerminal {
 	xterm: XTerm;
 	fitAddon: FitAddon;
 	searchAddon: SearchAddon;
-	rendererRef: TerminalRendererRef;
 	wrapper: HTMLDivElement;
 	/** Disposes renderer RAF, query suppression, GPU renderer, etc. */
 	cleanupCreation: () => void;
+	/** Last known dimensions — used to skip no-op resize events. */
+	lastCols: number;
+	lastRows: number;
 
 	// --- Stream management ---
 
@@ -77,14 +75,13 @@ export function getOrCreate(
 		console.log(`[v1-terminal-cache] Creating new terminal: ${paneId}`);
 	}
 
-	const { xterm, fitAddon, searchAddon, renderer, wrapper, cleanup } =
+	const { xterm, fitAddon, searchAddon, wrapper, cleanup } =
 		createTerminalInWrapper(options);
 
 	const entry: CachedTerminal = {
 		xterm,
 		fitAddon,
 		searchAddon,
-		rendererRef: renderer,
 		wrapper,
 		cleanupCreation: cleanup,
 		subscription: null,
@@ -94,6 +91,8 @@ export function getOrCreate(
 		eventHandler: null,
 		subscriptionErrorHandler: null,
 		resizeObserver: null,
+		lastCols: xterm.cols,
+		lastRows: xterm.rows,
 	};
 
 	cache.set(paneId, entry);
@@ -111,16 +110,28 @@ export function attachToContainer(
 	if (!entry) return;
 
 	container.appendChild(entry.wrapper);
-	entry.fitAddon.fit();
+
+	if (container.clientWidth > 0 && container.clientHeight > 0) {
+		entry.fitAddon.fit();
+		entry.lastCols = entry.xterm.cols;
+		entry.lastRows = entry.xterm.rows;
+	}
+
+	// Renderer may have skipped frames while the wrapper was detached.
 	entry.xterm.refresh(0, Math.max(0, entry.xterm.rows - 1));
-	entry.rendererRef.current.clearTextureAtlas?.();
 
 	// Manage ResizeObserver lifecycle in the cache, not in React.
 	entry.resizeObserver?.disconnect();
 	const observer = new ResizeObserver(() => {
 		if (container.clientWidth === 0 && container.clientHeight === 0) return;
+		const prevCols = entry.lastCols;
+		const prevRows = entry.lastRows;
 		entry.fitAddon.fit();
-		onResize?.();
+		entry.lastCols = entry.xterm.cols;
+		entry.lastRows = entry.xterm.rows;
+		if (entry.lastCols !== prevCols || entry.lastRows !== prevRows) {
+			onResize?.();
+		}
 	});
 	observer.observe(container);
 	entry.resizeObserver = observer;
@@ -136,6 +147,43 @@ export function detachFromContainer(paneId: string): void {
 	entry.resizeObserver?.disconnect();
 	entry.resizeObserver = null;
 	entry.wrapper.remove();
+}
+
+// --- Appearance ---
+
+/**
+ * Update font settings on a cached terminal. If font changed and the
+ * terminal is visible, re-fit and return true so the caller can send
+ * a backend resize if needed.
+ */
+export function updateAppearance(
+	paneId: string,
+	fontFamily: string,
+	fontSize: number,
+): { cols: number; rows: number; changed: boolean } | null {
+	const entry = cache.get(paneId);
+	if (!entry) return null;
+
+	const { xterm, fitAddon } = entry;
+	const fontChanged =
+		xterm.options.fontFamily !== fontFamily ||
+		xterm.options.fontSize !== fontSize;
+	if (!fontChanged) return null;
+
+	xterm.options.fontFamily = fontFamily;
+	xterm.options.fontSize = fontSize;
+
+	const prevCols = entry.lastCols;
+	const prevRows = entry.lastRows;
+	fitAddon.fit();
+	entry.lastCols = xterm.cols;
+	entry.lastRows = xterm.rows;
+
+	return {
+		cols: xterm.cols,
+		rows: xterm.rows,
+		changed: xterm.cols !== prevCols || xterm.rows !== prevRows,
+	};
 }
 
 // --- Stream subscription ---

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
@@ -1,0 +1,133 @@
+import type { FitAddon } from "@xterm/addon-fit";
+import type { SearchAddon } from "@xterm/addon-search";
+import type { Terminal as XTerm } from "@xterm/xterm";
+import { DEBUG_TERMINAL } from "./config";
+import {
+	type CreateTerminalOptions,
+	createTerminalInWrapper,
+	type TerminalRendererRef,
+} from "./helpers";
+
+/**
+ * Cached xterm instance that survives React mount/unmount cycles.
+ * Borrows the wrapper-div pattern from v2's terminal-runtime.ts:
+ * xterm is opened into a persistent wrapper <div> that can be
+ * moved between DOM containers without disposing the terminal.
+ */
+export interface CachedTerminal {
+	xterm: XTerm;
+	fitAddon: FitAddon;
+	searchAddon: SearchAddon;
+	rendererRef: TerminalRendererRef;
+	wrapper: HTMLDivElement;
+	/** Disposes renderer RAF, query suppression, GPU renderer, etc. */
+	cleanupCreation: () => void;
+}
+
+const cache = new Map<string, CachedTerminal>();
+
+export function has(paneId: string): boolean {
+	return cache.has(paneId);
+}
+
+export function get(paneId: string): CachedTerminal | undefined {
+	return cache.get(paneId);
+}
+
+export function getOrCreate(
+	paneId: string,
+	options: CreateTerminalOptions,
+): CachedTerminal {
+	const existing = cache.get(paneId);
+	if (existing) {
+		if (DEBUG_TERMINAL) {
+			console.log(`[v1-terminal-cache] Reusing cached terminal: ${paneId}`);
+		}
+		return existing;
+	}
+
+	if (DEBUG_TERMINAL) {
+		console.log(`[v1-terminal-cache] Creating new terminal: ${paneId}`);
+	}
+
+	const { xterm, fitAddon, searchAddon, renderer, wrapper, cleanup } =
+		createTerminalInWrapper(options);
+
+	const entry: CachedTerminal = {
+		xterm,
+		fitAddon,
+		searchAddon,
+		rendererRef: renderer,
+		wrapper,
+		cleanupCreation: cleanup,
+	};
+
+	cache.set(paneId, entry);
+	return entry;
+}
+
+/**
+ * Append the cached terminal's wrapper div to a live DOM container.
+ * Re-fits, refreshes rendering, and clears stale WebGL texture atlas.
+ */
+export function attachToContainer(
+	paneId: string,
+	container: HTMLDivElement,
+): void {
+	const entry = cache.get(paneId);
+	if (!entry) return;
+
+	container.appendChild(entry.wrapper);
+	entry.fitAddon.fit();
+	// Repaint after reattach — critical for WebGL renderer which may have
+	// skipped frames while the wrapper was detached from the DOM.
+	entry.xterm.refresh(0, Math.max(0, entry.xterm.rows - 1));
+	entry.rendererRef.current.clearTextureAtlas?.();
+}
+
+/**
+ * Remove the wrapper from its current DOM container but keep the
+ * xterm instance alive in memory. Buffer and scroll position are
+ * preserved.
+ */
+export function detachFromContainer(paneId: string): void {
+	const entry = cache.get(paneId);
+	if (!entry) return;
+
+	if (DEBUG_TERMINAL) {
+		console.log(`[v1-terminal-cache] Detaching from DOM: ${paneId}`);
+	}
+
+	entry.wrapper.remove();
+}
+
+/**
+ * Fully dispose the cached terminal: cleanup creation resources,
+ * dispose xterm, and remove from cache.
+ */
+export function dispose(paneId: string): void {
+	const entry = cache.get(paneId);
+	if (!entry) return;
+
+	if (DEBUG_TERMINAL) {
+		console.log(`[v1-terminal-cache] Disposing: ${paneId}`);
+	}
+
+	entry.cleanupCreation();
+	entry.xterm.dispose();
+	cache.delete(paneId);
+}
+
+// Preserve cache across Vite HMR in dev so active terminals aren't orphaned.
+const hot = import.meta.hot;
+if (hot) {
+	const existing = hot.data.v1TerminalCache as
+		| Map<string, CachedTerminal>
+		| undefined;
+	if (existing) {
+		for (const [k, v] of existing) {
+			cache.set(k, v);
+		}
+	}
+	hot.data.v1TerminalCache = cache;
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
@@ -123,7 +123,7 @@ export function attachToContainer(
 	// Manage ResizeObserver lifecycle in the cache, not in React.
 	entry.resizeObserver?.disconnect();
 	const observer = new ResizeObserver(() => {
-		if (container.clientWidth === 0 && container.clientHeight === 0) return;
+		if (container.clientWidth === 0 || container.clientHeight === 0) return;
 		const prevCols = entry.lastCols;
 		const prevRows = entry.lastRows;
 		entry.fitAddon.fit();
@@ -228,6 +228,10 @@ export function startStream(paneId: string): void {
 			routeEvent(entry, event);
 		},
 		onError: (error: unknown) => {
+			// Subscription is dead after onError — null it so startStream()
+			// can create a replacement on remount.
+			entry.subscription = null;
+
 			if (entry.subscriptionErrorHandler) {
 				entry.subscriptionErrorHandler(error);
 			} else if (DEBUG_TERMINAL) {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
@@ -52,6 +52,8 @@ export interface CachedTerminal {
 	 * terminal stream error events).
 	 */
 	subscriptionErrorHandler: ((error: unknown) => void) | null;
+	/** ResizeObserver for the attached container. Managed by attach/detach. */
+	resizeObserver: ResizeObserver | null;
 }
 
 const cache = new Map<string, CachedTerminal>();
@@ -91,6 +93,7 @@ export function getOrCreate(
 		pendingLifecycleEvents: [],
 		eventHandler: null,
 		subscriptionErrorHandler: null,
+		resizeObserver: null,
 	};
 
 	cache.set(paneId, entry);
@@ -102,6 +105,7 @@ export function getOrCreate(
 export function attachToContainer(
 	paneId: string,
 	container: HTMLDivElement,
+	onResize?: () => void,
 ): void {
 	const entry = cache.get(paneId);
 	if (!entry) return;
@@ -110,6 +114,16 @@ export function attachToContainer(
 	entry.fitAddon.fit();
 	entry.xterm.refresh(0, Math.max(0, entry.xterm.rows - 1));
 	entry.rendererRef.current.clearTextureAtlas?.();
+
+	// Manage ResizeObserver lifecycle in the cache, not in React.
+	entry.resizeObserver?.disconnect();
+	const observer = new ResizeObserver(() => {
+		if (container.clientWidth === 0 && container.clientHeight === 0) return;
+		entry.fitAddon.fit();
+		onResize?.();
+	});
+	observer.observe(container);
+	entry.resizeObserver = observer;
 }
 
 export function detachFromContainer(paneId: string): void {
@@ -119,6 +133,8 @@ export function detachFromContainer(paneId: string): void {
 	if (DEBUG_TERMINAL) {
 		console.log(`[v1-terminal-cache] detachFromContainer: ${paneId}`);
 	}
+	entry.resizeObserver?.disconnect();
+	entry.resizeObserver = null;
 	entry.wrapper.remove();
 }
 
@@ -241,6 +257,7 @@ export function dispose(paneId: string): void {
 		console.log(`[v1-terminal-cache] Disposing: ${paneId}`);
 	}
 
+	entry.resizeObserver?.disconnect();
 	entry.subscription?.unsubscribe();
 	entry.cleanupCreation();
 	entry.xterm.dispose();

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
@@ -26,6 +26,11 @@ export interface CachedTerminal {
 
 const cache = new Map<string, CachedTerminal>();
 
+/** Number of times a cached terminal was reused instead of created. */
+let reattachCount = 0;
+/** Number of fresh terminal creations. */
+let createCount = 0;
+
 export function has(paneId: string): boolean {
 	return cache.has(paneId);
 }
@@ -34,21 +39,32 @@ export function get(paneId: string): CachedTerminal | undefined {
 	return cache.get(paneId);
 }
 
+/** Return current cache size and lifetime hit/miss stats. */
+export function stats(): {
+	size: number;
+	creates: number;
+	reattaches: number;
+} {
+	return { size: cache.size, creates: createCount, reattaches: reattachCount };
+}
+
 export function getOrCreate(
 	paneId: string,
 	options: CreateTerminalOptions,
 ): CachedTerminal {
 	const existing = cache.get(paneId);
 	if (existing) {
+		reattachCount++;
 		if (DEBUG_TERMINAL) {
-			console.log(`[v1-terminal-cache] Reusing cached terminal: ${paneId}`);
+			const { size, creates, reattaches } = stats();
+			console.log(
+				`[v1-terminal-cache] Reusing cached terminal: ${paneId} (cache size=${size}, creates=${creates}, reattaches=${reattaches})`,
+			);
 		}
 		return existing;
 	}
 
-	if (DEBUG_TERMINAL) {
-		console.log(`[v1-terminal-cache] Creating new terminal: ${paneId}`);
-	}
+	const t0 = performance.now();
 
 	const { xterm, fitAddon, searchAddon, renderer, wrapper, cleanup } =
 		createTerminalInWrapper(options);
@@ -63,6 +79,16 @@ export function getOrCreate(
 	};
 
 	cache.set(paneId, entry);
+	createCount++;
+
+	if (DEBUG_TERMINAL) {
+		const elapsed = (performance.now() - t0).toFixed(1);
+		const { size, creates, reattaches } = stats();
+		console.log(
+			`[v1-terminal-cache] Created new terminal: ${paneId} (${elapsed}ms, cache size=${size}, creates=${creates}, reattaches=${reattaches})`,
+		);
+	}
+
 	return entry;
 }
 
@@ -77,12 +103,23 @@ export function attachToContainer(
 	const entry = cache.get(paneId);
 	if (!entry) return;
 
+	const t0 = performance.now();
+	const bufferLinesBefore = entry.xterm.buffer.active.length;
+	const scrollPosBefore = entry.xterm.buffer.active.viewportY;
+
 	container.appendChild(entry.wrapper);
 	entry.fitAddon.fit();
 	// Repaint after reattach — critical for WebGL renderer which may have
 	// skipped frames while the wrapper was detached from the DOM.
 	entry.xterm.refresh(0, Math.max(0, entry.xterm.rows - 1));
 	entry.rendererRef.current.clearTextureAtlas?.();
+
+	if (DEBUG_TERMINAL) {
+		const elapsed = (performance.now() - t0).toFixed(1);
+		console.log(
+			`[v1-terminal-cache] attachToContainer: ${paneId} (${elapsed}ms, cols=${entry.xterm.cols}x${entry.xterm.rows}, renderer=${entry.rendererRef.current.kind}, bufferLines=${bufferLinesBefore}, scrollY=${scrollPosBefore})`,
+		);
+	}
 }
 
 /**
@@ -95,7 +132,10 @@ export function detachFromContainer(paneId: string): void {
 	if (!entry) return;
 
 	if (DEBUG_TERMINAL) {
-		console.log(`[v1-terminal-cache] Detaching from DOM: ${paneId}`);
+		const buf = entry.xterm.buffer.active;
+		console.log(
+			`[v1-terminal-cache] Detaching from DOM: ${paneId} (bufferLines=${buf.length}, scrollY=${buf.viewportY}, baseY=${buf.baseY})`,
+		);
 	}
 
 	entry.wrapper.remove();
@@ -109,13 +149,16 @@ export function dispose(paneId: string): void {
 	const entry = cache.get(paneId);
 	if (!entry) return;
 
-	if (DEBUG_TERMINAL) {
-		console.log(`[v1-terminal-cache] Disposing: ${paneId}`);
-	}
-
 	entry.cleanupCreation();
 	entry.xterm.dispose();
 	cache.delete(paneId);
+
+	if (DEBUG_TERMINAL) {
+		const { size, creates, reattaches } = stats();
+		console.log(
+			`[v1-terminal-cache] Disposed: ${paneId} (remaining cache size=${size}, lifetime creates=${creates}, reattaches=${reattaches})`,
+		);
+	}
 }
 
 // Preserve cache across Vite HMR in dev so active terminals aren't orphaned.

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
@@ -1,7 +1,6 @@
 import type { FitAddon } from "@xterm/addon-fit";
 import type { SearchAddon } from "@xterm/addon-search";
 import type { Terminal as XTerm } from "@xterm/xterm";
-import { DEBUG_TERMINAL } from "./config";
 import {
 	type CreateTerminalOptions,
 	createTerminalInWrapper,
@@ -26,11 +25,6 @@ export interface CachedTerminal {
 
 const cache = new Map<string, CachedTerminal>();
 
-/** Number of times a cached terminal was reused instead of created. */
-let reattachCount = 0;
-/** Number of fresh terminal creations. */
-let createCount = 0;
-
 export function has(paneId: string): boolean {
 	return cache.has(paneId);
 }
@@ -39,32 +33,12 @@ export function get(paneId: string): CachedTerminal | undefined {
 	return cache.get(paneId);
 }
 
-/** Return current cache size and lifetime hit/miss stats. */
-export function stats(): {
-	size: number;
-	creates: number;
-	reattaches: number;
-} {
-	return { size: cache.size, creates: createCount, reattaches: reattachCount };
-}
-
 export function getOrCreate(
 	paneId: string,
 	options: CreateTerminalOptions,
 ): CachedTerminal {
 	const existing = cache.get(paneId);
-	if (existing) {
-		reattachCount++;
-		if (DEBUG_TERMINAL) {
-			const { size, creates, reattaches } = stats();
-			console.log(
-				`[v1-terminal-cache] Reusing cached terminal: ${paneId} (cache size=${size}, creates=${creates}, reattaches=${reattaches})`,
-			);
-		}
-		return existing;
-	}
-
-	const t0 = performance.now();
+	if (existing) return existing;
 
 	const { xterm, fitAddon, searchAddon, renderer, wrapper, cleanup } =
 		createTerminalInWrapper(options);
@@ -79,16 +53,6 @@ export function getOrCreate(
 	};
 
 	cache.set(paneId, entry);
-	createCount++;
-
-	if (DEBUG_TERMINAL) {
-		const elapsed = (performance.now() - t0).toFixed(1);
-		const { size, creates, reattaches } = stats();
-		console.log(
-			`[v1-terminal-cache] Created new terminal: ${paneId} (${elapsed}ms, cache size=${size}, creates=${creates}, reattaches=${reattaches})`,
-		);
-	}
-
 	return entry;
 }
 
@@ -103,23 +67,12 @@ export function attachToContainer(
 	const entry = cache.get(paneId);
 	if (!entry) return;
 
-	const t0 = performance.now();
-	const bufferLinesBefore = entry.xterm.buffer.active.length;
-	const scrollPosBefore = entry.xterm.buffer.active.viewportY;
-
 	container.appendChild(entry.wrapper);
 	entry.fitAddon.fit();
 	// Repaint after reattach — critical for WebGL renderer which may have
 	// skipped frames while the wrapper was detached from the DOM.
 	entry.xterm.refresh(0, Math.max(0, entry.xterm.rows - 1));
 	entry.rendererRef.current.clearTextureAtlas?.();
-
-	if (DEBUG_TERMINAL) {
-		const elapsed = (performance.now() - t0).toFixed(1);
-		console.log(
-			`[v1-terminal-cache] attachToContainer: ${paneId} (${elapsed}ms, cols=${entry.xterm.cols}x${entry.xterm.rows}, renderer=${entry.rendererRef.current.kind}, bufferLines=${bufferLinesBefore}, scrollY=${scrollPosBefore})`,
-		);
-	}
 }
 
 /**
@@ -130,14 +83,6 @@ export function attachToContainer(
 export function detachFromContainer(paneId: string): void {
 	const entry = cache.get(paneId);
 	if (!entry) return;
-
-	if (DEBUG_TERMINAL) {
-		const buf = entry.xterm.buffer.active;
-		console.log(
-			`[v1-terminal-cache] Detaching from DOM: ${paneId} (bufferLines=${buf.length}, scrollY=${buf.viewportY}, baseY=${buf.baseY})`,
-		);
-	}
-
 	entry.wrapper.remove();
 }
 
@@ -152,13 +97,6 @@ export function dispose(paneId: string): void {
 	entry.cleanupCreation();
 	entry.xterm.dispose();
 	cache.delete(paneId);
-
-	if (DEBUG_TERMINAL) {
-		const { size, creates, reattaches } = stats();
-		console.log(
-			`[v1-terminal-cache] Disposed: ${paneId} (remaining cache size=${size}, lifetime creates=${creates}, reattaches=${reattaches})`,
-		);
-	}
 }
 
 // Preserve cache across Vite HMR in dev so active terminals aren't orphaned.


### PR DESCRIPTION
## Summary

- Ports the v2 "hide attach" terminal pattern into the v1 renderer so tab switches no longer destroy/recreate xterm instances
- Introduces a `v1-terminal-cache.ts` module-level singleton that keeps xterm instances alive across React mount/unmount cycles
- Extracts `createTerminalInWrapper()` from `helpers.ts` to open xterm into a detached wrapper `<div>` that can be moved between DOM containers
- Modifies `useTerminalLifecycle` to use cache on mount (reattach existing xterm) and detach on unmount (keep alive) instead of dispose
- Adds a reattach fast-path in `createOrAttach` onSuccess that skips scrollback restoration since the buffer is already in memory

The change boundary is entirely UI/renderer-side — no backend, tRPC, or protocol changes.

## Test plan

Enable debug logging: `localStorage.setItem('SUPERSET_TERMINAL_DEBUG', '1')`

- [ ] Switch tabs — terminal should not flash/flicker, console shows `Reattach` instead of `Fresh mount`
- [ ] Scroll up in terminal, switch tab, switch back — scroll position preserved
- [ ] Change theme while on a different tab, switch back — terminal has new theme
- [ ] Close a terminal pane — console shows `Pane destroyed` and `Disposing`
- [ ] Cold restore (restart app) — still works normally (cache is empty on fresh start)
- [ ] 4-way split tab, switch away and back — all terminals reattach
- [ ] `bun run typecheck` passes
- [ ] `bun run lint:fix` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports the v2 “hide attach” pattern to the v1 terminal and aligns resize with v2. `xterm` and the tRPC stream now stay alive in a cache across tab switches; an undebounced `ResizeObserver` handles sizing to remove flicker, reconnects, and lag.

- **Refactors**
  - Added `v1-terminal-cache.ts` to keep `xterm`, addons, and the live tRPC stream alive across mounts; attaches/detaches a wrapper, owns an undebounced `ResizeObserver`, tracks `lastCols/rows` to skip no-op resizes, queues lifecycle events while unmounted, and fully disposes on pane destroy.
  - Extracted `createTerminalInWrapper()` with v2-style WebGL addon loading; removed the local renderer preference and debounce code.
  - Updated `Terminal.tsx` to register/unregister stream handlers with the cache (subscription lives in the cache), apply font changes via `updateAppearance` and only resize when needed, and wrapped the component in `React.memo`.
  - Updated `useTerminalLifecycle` to attach from cache, skip `createOrAttach` on reattach (stream stays alive), start the stream and mark it ready only on first attach, remove reattach-recovery and all resize handlers, and skip backend detach on tab switches (only detach the wrapper).
  - Simplified `useTerminalRestore` to only scroll to bottom; centralized all `fit()` calls in the cache and removed `RESIZE_DEBOUNCE_MS`/`setupResizeHandlers`.

- **Bug Fixes**
  - Fixed font settings effect to avoid unnecessary reruns by removing `resizeRef.current` from deps.
  - Ensured stream reconnect by nulling the cache subscription on `onError`.
  - Guarded resize to skip `fit()` when either container dimension is zero.
  - On reattach, notify the backend PTY if cols/rows changed while hidden.
  - Moved handler registration after lifecycle initialization and gated on `xtermInstance` to avoid cold-mount races.

<sup>Written for commit ddc93c899769c1ac9e04a36b3f04f03d713bc7d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-terminal search added for finding text within sessions.
  * Terminals now persist across tab switches (buffer and addons preserved).

* **Improvements**
  * Faster, smoother reattachment with less backend work when reopening tabs.
  * Streaming remains active while a pane is hidden; events are queued and replayed on reattach.

* **Behavior**
  * Hiding a pane detaches its DOM but keeps terminal state; full disposal happens only on pane destroy.
  * Resuming skips re-writing scrollback since the buffer remains in memory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->