### PR TITLE
feat(desktop): v2 workspace setup script execution

### DIFF
--- a/apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts
@@ -839,10 +839,7 @@ export SUPERSET_WORKSPACE_PATH="/wrong/path"
 			expect(args[0]).toBe("-l");
 			expect(args[1]).toBe("--init-command");
 			expect(args[2]).toContain(`set -l _superset_bin "${TEST_BIN_DIR}"`);
-			expect(args[2]).toContain("133;A");
-			expect(args[2]).toContain("133;C");
-			expect(args[2]).toContain("133;D");
-			expect(args[2]).not.toContain("777");
+			expect(args[2]).toContain("\\033]133;A\\007");
 		});
 
 		it("escapes fish init-command BIN_DIR safely", () => {

--- a/apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts
@@ -836,11 +836,13 @@ export SUPERSET_WORKSPACE_PATH="/wrong/path"
 		it("uses --init-command to prepend BIN_DIR to PATH for fish", () => {
 			const args = getShellArgs("/opt/homebrew/bin/fish", TEST_PATHS);
 
-			expect(args).toEqual([
-				"-l",
-				"--init-command",
-				`set -l _superset_bin "${TEST_BIN_DIR}"; contains -- "$_superset_bin" $PATH; or set -gx PATH "$_superset_bin" $PATH; function _superset_shell_ready --on-event fish_prompt; printf '\\033]777;superset-shell-ready\\007'; functions -e _superset_shell_ready; end`,
-			]);
+			expect(args[0]).toBe("-l");
+			expect(args[1]).toBe("--init-command");
+			expect(args[2]).toContain(`set -l _superset_bin "${TEST_BIN_DIR}"`);
+			expect(args[2]).toContain("133;A");
+			expect(args[2]).toContain("133;C");
+			expect(args[2]).toContain("133;D");
+			expect(args[2]).not.toContain("777");
 		});
 
 		it("escapes fish init-command BIN_DIR safely", () => {
@@ -850,11 +852,12 @@ export SUPERSET_WORKSPACE_PATH="/wrong/path"
 				BIN_DIR: fishPath,
 			});
 
-			expect(args).toEqual([
-				"-l",
-				"--init-command",
-				`set -l _superset_bin "/tmp/with space/quote\\"buck\\$slash\\\\bin"; contains -- "$_superset_bin" $PATH; or set -gx PATH "$_superset_bin" $PATH; function _superset_shell_ready --on-event fish_prompt; printf '\\033]777;superset-shell-ready\\007'; functions -e _superset_shell_ready; end`,
-			]);
+			expect(args[0]).toBe("-l");
+			expect(args[1]).toBe("--init-command");
+			expect(args[2]).toContain(
+				'set -l _superset_bin "/tmp/with space/quote\\"buck\\$slash\\\\bin"',
+			);
+			expect(args[2]).toContain("133;A");
 		});
 	});
 });

--- a/apps/desktop/src/main/lib/agent-setup/shell-wrappers.ts
+++ b/apps/desktop/src/main/lib/agent-setup/shell-wrappers.ts
@@ -218,26 +218,13 @@ ${SUPERSET_ENV_RESTORE}
 ${buildZshPrecmdHook(paths.BIN_DIR)}
 ${buildPathPrependFunction(paths.BIN_DIR)}
 rehash 2>/dev/null || true
-# OSC 133 semantic prompt markers (FinalTerm standard).
-# Enables shell readiness detection and command exit code tracking.
+# OSC 133;A prompt marker (FinalTerm standard) — signals shell readiness.
 # Protocol ref: https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md
-# Vendored from WezTerm (MIT, Copyright 2018-Present Wez Furlong).
-__superset_semantic_precmd_executing=""
-__superset_semantic_precmd() {
-  local ret="$?"
-  if [[ "$__superset_semantic_precmd_executing" != "" ]]; then
-    printf "\\033]133;D;%s\\007" "$ret"
-  fi
+__superset_prompt_mark() {
   printf "\\033]133;A\\007"
-  __superset_semantic_precmd_executing=0
 }
-__superset_semantic_preexec() {
-  printf "\\033]133;C;\\007"
-  __superset_semantic_precmd_executing=1
-}
-# Keep our hooks LAST so they fire after direnv and other precmd hooks complete.
-precmd_functions=(\${precmd_functions[@]} __superset_semantic_precmd)
-preexec_functions=(\${preexec_functions[@]} __superset_semantic_preexec)
+# Keep our hook LAST so it fires after direnv and other precmd hooks complete.
+precmd_functions=(\${precmd_functions[@]} __superset_prompt_mark)
 export ZDOTDIR="$_superset_home"
 `;
 	const wroteZlogin = writeFileIfChanged(zloginPath, zloginScript, 0o644);
@@ -281,41 +268,22 @@ ${buildPathPrependFunction(paths.BIN_DIR)}
 hash -r 2>/dev/null || true
 # Minimal prompt (path/env shown in toolbar) - emerald to match app theme
 export PS1=$'\\[\\e[1;38;2;52;211;153m\\]❯\\[\\e[0m\\] '
-# OSC 133 semantic prompt markers (FinalTerm standard).
-# Enables shell readiness detection and command exit code tracking.
+# OSC 133;A prompt marker (FinalTerm standard) — signals shell readiness.
 # Protocol ref: https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md
-# Vendored from WezTerm (MIT, Copyright 2018-Present Wez Furlong).
-__superset_semantic_precmd_executing=""
-__superset_semantic_precmd() {
-  local ret="$?"
-  if [[ "$__superset_semantic_precmd_executing" != "" ]]; then
-    printf "\\033]133;D;%s\\007" "$ret"
-  fi
+__superset_prompt_mark() {
   printf "\\033]133;A\\007"
-  __superset_semantic_precmd_executing=0
 }
-__superset_semantic_preexec() {
-  printf "\\033]133;C;\\007"
-  __superset_semantic_precmd_executing=1
-}
-# Hook precmd via PROMPT_COMMAND. Supports both scalar and array forms (Bash 5.1+).
+# Hook via PROMPT_COMMAND. Supports both scalar and array forms (Bash 5.1+).
 if [[ "$(declare -p PROMPT_COMMAND 2>/dev/null)" == "declare -a"* ]]; then
-  PROMPT_COMMAND=("\${PROMPT_COMMAND[@]}" "__superset_semantic_precmd")
+  PROMPT_COMMAND=("\${PROMPT_COMMAND[@]}" "__superset_prompt_mark")
 else
   _superset_orig_prompt_cmd="\${PROMPT_COMMAND}"
   if [[ -n "\${_superset_orig_prompt_cmd}" ]]; then
-    PROMPT_COMMAND="\${_superset_orig_prompt_cmd};__superset_semantic_precmd"
+    PROMPT_COMMAND="\${_superset_orig_prompt_cmd};__superset_prompt_mark"
   else
-    PROMPT_COMMAND="__superset_semantic_precmd"
+    PROMPT_COMMAND="__superset_prompt_mark"
   fi
 fi
-# Hook preexec via DEBUG trap (bash doesn't have native preexec).
-__superset_bash_preexec() {
-  if [[ "$__superset_semantic_precmd_executing" == "0" ]]; then
-    __superset_semantic_preexec
-  fi
-}
-trap '__superset_bash_preexec' DEBUG
 `;
 	const changed = writeFileIfChanged(rcfilePath, script, 0o644);
 	console.log(`[agent-setup] ${changed ? "Updated" : "Verified"} bash wrapper`);
@@ -347,7 +315,7 @@ export function getShellArgs(
 	if (shellName === "fish") {
 		// Use --init-command to prepend BIN_DIR to PATH after config is loaded.
 		// Use fish list-aware checks to avoid duplicate PATH entries across nested shells.
-		// OSC 133 markers vendored from WezTerm (MIT, Copyright 2018-Present Wez Furlong).
+		// OSC 133;A emitted on fish_prompt — signals shell readiness.
 		const escapedBinDir = escapeFishDoubleQuoted(paths.BIN_DIR);
 		return [
 			"-l",
@@ -358,12 +326,6 @@ export function getShellArgs(
 				`or set -gx PATH "$_superset_bin" $PATH`,
 				`function _superset_prompt_mark --on-event fish_prompt`,
 				`printf '\\033]133;A\\007'`,
-				`end`,
-				`function _superset_preexec --on-event fish_preexec`,
-				`printf '\\033]133;C\\007'`,
-				`end`,
-				`function _superset_postexec --on-event fish_postexec`,
-				`printf '\\033]133;D;%s\\007' $status`,
 				`end`,
 			].join("; "),
 		];

--- a/apps/desktop/src/main/lib/agent-setup/shell-wrappers.ts
+++ b/apps/desktop/src/main/lib/agent-setup/shell-wrappers.ts
@@ -218,15 +218,26 @@ ${SUPERSET_ENV_RESTORE}
 ${buildZshPrecmdHook(paths.BIN_DIR)}
 ${buildPathPrependFunction(paths.BIN_DIR)}
 rehash 2>/dev/null || true
-# One-shot shell-ready marker for preset command timing.
-# Uses precmd so it fires AFTER direnv and other hooks complete,
-# right before the first prompt is displayed.
-_superset_shell_ready() {
-  precmd_functions=(\${precmd_functions:#_superset_shell_ready})
-  printf '\\033]777;superset-shell-ready\\007'
+# OSC 133 semantic prompt markers (FinalTerm standard).
+# Enables shell readiness detection and command exit code tracking.
+# Protocol ref: https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md
+# Vendored from WezTerm (MIT, Copyright 2018-Present Wez Furlong).
+__superset_semantic_precmd_executing=""
+__superset_semantic_precmd() {
+  local ret="$?"
+  if [[ "$__superset_semantic_precmd_executing" != "" ]]; then
+    printf "\\033]133;D;%s\\007" "$ret"
+  fi
+  printf "\\033]133;A\\007"
+  __superset_semantic_precmd_executing=0
 }
-# Keep our hook LAST so it fires after direnv and other precmd hooks complete.
-precmd_functions=(\${precmd_functions[@]} _superset_shell_ready)
+__superset_semantic_preexec() {
+  printf "\\033]133;C;\\007"
+  __superset_semantic_precmd_executing=1
+}
+# Keep our hooks LAST so they fire after direnv and other precmd hooks complete.
+precmd_functions=(\${precmd_functions[@]} __superset_semantic_precmd)
+preexec_functions=(\${preexec_functions[@]} __superset_semantic_preexec)
 export ZDOTDIR="$_superset_home"
 `;
 	const wroteZlogin = writeFileIfChanged(zloginPath, zloginScript, 0o644);
@@ -270,33 +281,41 @@ ${buildPathPrependFunction(paths.BIN_DIR)}
 hash -r 2>/dev/null || true
 # Minimal prompt (path/env shown in toolbar) - emerald to match app theme
 export PS1=$'\\[\\e[1;38;2;52;211;153m\\]❯\\[\\e[0m\\] '
-# One-shot shell-ready marker for preset command timing.
-# Uses PROMPT_COMMAND so it fires AFTER direnv and other hooks complete.
-# Supports both scalar and array PROMPT_COMMAND (Bash 5.1+).
-_superset_shell_ready() {
-  printf '\\033]777;superset-shell-ready\\007'
-  if [[ "$(declare -p PROMPT_COMMAND 2>/dev/null)" == "declare -a"* ]]; then
-    local -a _new=()
-    for _cmd in "\${PROMPT_COMMAND[@]}"; do
-      [[ "$_cmd" != "_superset_shell_ready" ]] && _new+=("$_cmd")
-    done
-    PROMPT_COMMAND=("\${_new[@]}")
-  else
-    PROMPT_COMMAND="\${_superset_orig_prompt_cmd}"
-    unset _superset_orig_prompt_cmd
+# OSC 133 semantic prompt markers (FinalTerm standard).
+# Enables shell readiness detection and command exit code tracking.
+# Protocol ref: https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md
+# Vendored from WezTerm (MIT, Copyright 2018-Present Wez Furlong).
+__superset_semantic_precmd_executing=""
+__superset_semantic_precmd() {
+  local ret="$?"
+  if [[ "$__superset_semantic_precmd_executing" != "" ]]; then
+    printf "\\033]133;D;%s\\007" "$ret"
   fi
-  unset -f _superset_shell_ready
+  printf "\\033]133;A\\007"
+  __superset_semantic_precmd_executing=0
 }
+__superset_semantic_preexec() {
+  printf "\\033]133;C;\\007"
+  __superset_semantic_precmd_executing=1
+}
+# Hook precmd via PROMPT_COMMAND. Supports both scalar and array forms (Bash 5.1+).
 if [[ "$(declare -p PROMPT_COMMAND 2>/dev/null)" == "declare -a"* ]]; then
-  PROMPT_COMMAND=("\${PROMPT_COMMAND[@]}" "_superset_shell_ready")
+  PROMPT_COMMAND=("\${PROMPT_COMMAND[@]}" "__superset_semantic_precmd")
 else
   _superset_orig_prompt_cmd="\${PROMPT_COMMAND}"
   if [[ -n "\${_superset_orig_prompt_cmd}" ]]; then
-    PROMPT_COMMAND="\${_superset_orig_prompt_cmd};_superset_shell_ready"
+    PROMPT_COMMAND="\${_superset_orig_prompt_cmd};__superset_semantic_precmd"
   else
-    PROMPT_COMMAND="_superset_shell_ready"
+    PROMPT_COMMAND="__superset_semantic_precmd"
   fi
 fi
+# Hook preexec via DEBUG trap (bash doesn't have native preexec).
+__superset_bash_preexec() {
+  if [[ "$__superset_semantic_precmd_executing" == "0" ]]; then
+    __superset_semantic_preexec
+  fi
+}
+trap '__superset_bash_preexec' DEBUG
 `;
 	const changed = writeFileIfChanged(rcfilePath, script, 0o644);
 	console.log(`[agent-setup] ${changed ? "Updated" : "Verified"} bash wrapper`);
@@ -328,11 +347,25 @@ export function getShellArgs(
 	if (shellName === "fish") {
 		// Use --init-command to prepend BIN_DIR to PATH after config is loaded.
 		// Use fish list-aware checks to avoid duplicate PATH entries across nested shells.
+		// OSC 133 markers vendored from WezTerm (MIT, Copyright 2018-Present Wez Furlong).
 		const escapedBinDir = escapeFishDoubleQuoted(paths.BIN_DIR);
 		return [
 			"-l",
 			"--init-command",
-			`set -l _superset_bin "${escapedBinDir}"; contains -- "$_superset_bin" $PATH; or set -gx PATH "$_superset_bin" $PATH; function _superset_shell_ready --on-event fish_prompt; printf '\\033]777;superset-shell-ready\\007'; functions -e _superset_shell_ready; end`,
+			[
+				`set -l _superset_bin "${escapedBinDir}"`,
+				`contains -- "$_superset_bin" $PATH`,
+				`or set -gx PATH "$_superset_bin" $PATH`,
+				`function _superset_prompt_mark --on-event fish_prompt`,
+				`printf '\\033]133;A\\007'`,
+				`end`,
+				`function _superset_preexec --on-event fish_preexec`,
+				`printf '\\033]133;C\\007'`,
+				`end`,
+				`function _superset_postexec --on-event fish_postexec`,
+				`printf '\\033]133;D;%s\\007' $status`,
+				`end`,
+			].join("; "),
 		];
 	}
 	if (["zsh", "sh", "ksh"].includes(shellName)) {

--- a/apps/desktop/src/main/terminal-host/pty-subprocess-ipc.ts
+++ b/apps/desktop/src/main/terminal-host/pty-subprocess-ipc.ts
@@ -128,14 +128,4 @@ export class PtySubprocessFrameDecoder {
 	}
 }
 
-/**
- * OSC 777 escape sequence emitted once by shell prompt hooks (precmd in
- * zsh, PROMPT_COMMAND in bash, fish_prompt in fish) right before the
- * first interactive prompt is displayed. {@link Session} scans PTY
- * output for this marker to know when the shell is ready for stdin,
- * then strips it so it never reaches the terminal renderer.
- *
- * Uses the private-use OSC 777 code to avoid conflicts with VS Code
- * (OSC 133), iTerm2 (OSC 1337), or Warp (OSC 9001).
- */
-export const SHELL_READY_MARKER = "\x1b]777;superset-shell-ready\x07";
+

--- a/apps/desktop/src/main/terminal-host/pty-subprocess-ipc.ts
+++ b/apps/desktop/src/main/terminal-host/pty-subprocess-ipc.ts
@@ -127,5 +127,3 @@ export class PtySubprocessFrameDecoder {
 		return frames;
 	}
 }
-
-

--- a/apps/desktop/src/main/terminal-host/session-shell-ready.test.ts
+++ b/apps/desktop/src/main/terminal-host/session-shell-ready.test.ts
@@ -5,8 +5,10 @@ import {
 	createFrameHeader,
 	PtySubprocessFrameDecoder,
 	PtySubprocessIpcType,
-	SHELL_READY_MARKER,
 } from "./pty-subprocess-ipc";
+
+/** OSC 133;A marker emitted by shell wrappers (FinalTerm standard). */
+const SHELL_READY_MARKER = "\x1b]133;A\x07";
 import "./xterm-env-polyfill";
 
 const { Session } = await import("./session");

--- a/apps/desktop/src/main/terminal-host/session.ts
+++ b/apps/desktop/src/main/terminal-host/session.ts
@@ -81,8 +81,6 @@ const EMULATOR_WRITE_QUEUE_LOW_WATERMARK_BYTES = 250_000;
  */
 const SHELL_READY_TIMEOUT_MS = 15_000;
 
-// SHELLS_WITH_READY_MARKER imported from @superset/shared/shell-ready-scanner
-
 /**
  * Shell readiness lifecycle:
  * - `pending`     — shell is initializing; user writes are buffered, escape sequences dropped

--- a/apps/desktop/src/main/terminal-host/session.ts
+++ b/apps/desktop/src/main/terminal-host/session.ts
@@ -11,6 +11,12 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import type { Socket } from "node:net";
 import * as path from "node:path";
+import {
+	createScanState,
+	SHELLS_WITH_READY_MARKER,
+	type ShellReadyScanState,
+	scanForShellReady,
+} from "@superset/shared/shell-ready-scanner";
 import { DEFAULT_TERMINAL_SCROLLBACK } from "shared/constants";
 import {
 	getCommandShellArgs,
@@ -30,12 +36,6 @@ import type {
 	TerminalSnapshot,
 } from "../lib/terminal-host/types";
 import { treeKillAsync } from "../lib/tree-kill";
-import {
-	type ShellReadyScanState,
-	SHELLS_WITH_READY_MARKER,
-	createScanState,
-	scanForShellReady,
-} from "@superset/shared/shell-ready-scanner";
 import {
 	createFrameHeader,
 	PtySubprocessFrameDecoder,

--- a/apps/desktop/src/main/terminal-host/session.ts
+++ b/apps/desktop/src/main/terminal-host/session.ts
@@ -31,10 +31,15 @@ import type {
 } from "../lib/terminal-host/types";
 import { treeKillAsync } from "../lib/tree-kill";
 import {
+	type ShellReadyScanState,
+	SHELLS_WITH_READY_MARKER,
+	createScanState,
+	scanForShellReady,
+} from "@superset/shared/shell-ready-scanner";
+import {
 	createFrameHeader,
 	PtySubprocessFrameDecoder,
 	PtySubprocessIpcType,
-	SHELL_READY_MARKER,
 } from "./pty-subprocess-ipc";
 
 // =============================================================================
@@ -76,8 +81,7 @@ const EMULATOR_WRITE_QUEUE_LOW_WATERMARK_BYTES = 250_000;
  */
 const SHELL_READY_TIMEOUT_MS = 15_000;
 
-/** Shells whose wrapper files inject a {@link SHELL_READY_MARKER}. */
-const SHELLS_WITH_READY_MARKER = new Set(["zsh", "bash", "fish"]);
+// SHELLS_WITH_READY_MARKER imported from @superset/shared/shell-ready-scanner
 
 /**
  * Shell readiness lifecycle:
@@ -162,13 +166,8 @@ export class Session {
 	private shellReadyState: ShellReadyState;
 	private shellReadyTimeoutId: ReturnType<typeof setTimeout> | null = null;
 	private preReadyStdinQueue: string[] = [];
-	// Marker scanner — tracks how many characters of SHELL_READY_MARKER
-	// we've matched so far. Held bytes are withheld from terminal output
-	// until we confirm a full match (discard them) or a mismatch (flush
-	// them as regular output). This prevents partial OSC sequences from
-	// ever reaching the renderer, even when the marker spans two Data frames.
-	private markerMatchPos = 0;
-	private markerHeldBytes = "";
+	// OSC 133;A scanner state — shared with v2 host-service via @superset/shared
+	private scanState: ShellReadyScanState = createScanState();
 
 	private emulatorWriteQueue: string[] = [];
 	private emulatorWriteQueuedBytes = 0;
@@ -364,32 +363,13 @@ export class Session {
 				if (payload.length === 0) break;
 				let data = payload.toString("utf8");
 
-				// Scan for SHELL_READY_MARKER one character at a time.
-				// Matching bytes are held back from output; on full match
-				// they're discarded and readiness resolves. On mismatch
-				// they're flushed as regular terminal output.
+				// Scan for OSC 133;A (shell ready) and strip from output.
 				if (this.shellReadyState === "pending") {
-					let output = "";
-					for (let i = 0; i < data.length; i++) {
-						if (data[i] === SHELL_READY_MARKER[this.markerMatchPos]) {
-							this.markerHeldBytes += data[i];
-							this.markerMatchPos++;
-							if (this.markerMatchPos === SHELL_READY_MARKER.length) {
-								// Full match — discard held bytes, resolve
-								this.markerHeldBytes = "";
-								this.markerMatchPos = 0;
-								this.resolveShellReady("ready");
-								output += data.slice(i + 1);
-								break;
-							}
-						} else {
-							// Mismatch — flush held bytes as regular output
-							output += this.markerHeldBytes + data[i];
-							this.markerHeldBytes = "";
-							this.markerMatchPos = 0;
-						}
+					const result = scanForShellReady(this.scanState, data);
+					data = result.output;
+					if (result.matched) {
+						this.resolveShellReady("ready");
 					}
-					data = output;
 				}
 
 				if (data.length === 0) break;
@@ -1015,8 +995,7 @@ export class Session {
 			this.shellReadyTimeoutId = null;
 		}
 		this.preReadyStdinQueue = [];
-		this.markerMatchPos = 0;
-		this.markerHeldBytes = "";
+		this.scanState = createScanState();
 		this.subprocessStdinQueue = [];
 		this.subprocessStdinQueuedBytes = 0;
 		this.subprocessStdinDrainArmed = false;
@@ -1060,15 +1039,15 @@ export class Session {
 			this.shellReadyTimeoutId = null;
 		}
 		// Flush held marker bytes — they weren't part of a full marker
-		if (this.markerHeldBytes.length > 0) {
-			this.enqueueEmulatorWrite(this.markerHeldBytes);
+		if (this.scanState.heldBytes.length > 0) {
+			this.enqueueEmulatorWrite(this.scanState.heldBytes);
 			this.broadcastEvent("data", {
 				type: "data",
-				data: this.markerHeldBytes,
+				data: this.scanState.heldBytes,
 			} satisfies TerminalDataEvent);
-			this.markerHeldBytes = "";
+			this.scanState.heldBytes = "";
 		}
-		this.markerMatchPos = 0;
+		this.scanState.matchPos = 0;
 		// Flush queued writes in FIFO order
 		const queue = this.preReadyStdinQueue;
 		this.preReadyStdinQueue = [];

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/buildSetupPaneLayout.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/buildSetupPaneLayout.ts
@@ -1,0 +1,39 @@
+import type { WorkspaceState } from "@superset/panes";
+import type {
+	PaneViewerData,
+	TerminalPaneData,
+} from "../../v2-workspace/$workspaceId/types";
+
+/**
+ * Build a pane layout from terminal descriptors returned by workspace creation.
+ * Each terminal becomes its own tab. The renderer just attaches — sessions are
+ * already running on the host-service.
+ */
+export function buildSetupPaneLayout(
+	terminals: Array<{ id: string; role: string; label: string }>,
+): WorkspaceState<PaneViewerData> {
+	const tabs = terminals.map((t) => {
+		const paneId = `pane-${crypto.randomUUID()}`;
+		const tabId = `tab-${crypto.randomUUID()}`;
+		return {
+			id: tabId,
+			titleOverride: t.label,
+			createdAt: Date.now(),
+			activePaneId: paneId,
+			layout: { type: "pane" as const, paneId },
+			panes: {
+				[paneId]: {
+					id: paneId,
+					kind: "terminal",
+					data: { terminalId: t.id } as TerminalPaneData,
+				},
+			},
+		};
+	});
+
+	return {
+		version: 1,
+		activeTabId: tabs[0]?.id ?? null,
+		tabs,
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/page.tsx
@@ -13,8 +13,10 @@ import {
 	loadAttachments,
 } from "renderer/lib/pending-attachment-store";
 import { useCreateDashboardWorkspace } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/hooks/useCreateDashboardWorkspace";
+import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import { buildSetupPaneLayout } from "./buildSetupPaneLayout";
 
 /**
  * Pending workspace progress page.
@@ -109,7 +111,7 @@ function useRetryCreate(
 			collections.pendingWorkspaces.update(pendingId, (draft) => {
 				draft.status = "succeeded";
 				draft.workspaceId = result.workspace?.id ?? null;
-				draft.initialCommands = result.initialCommands ?? null;
+				draft.terminals = result.terminals ?? [];
 			});
 			void clearAttachments(pendingId);
 		} catch (err) {
@@ -127,6 +129,7 @@ function PendingWorkspacePage() {
 	const navigate = useNavigate();
 	const collections = useCollections();
 	const { activeHostUrl } = useLocalHostService();
+	const { ensureWorkspaceInSidebar } = useDashboardSidebarState();
 	const navigatedRef = useRef(false);
 
 	// Read pending workspace from collection (declared early for useRetryCreate)
@@ -192,6 +195,21 @@ function PendingWorkspacePage() {
 			!navigatedRef.current
 		) {
 			navigatedRef.current = true;
+
+			// Ensure sidebar local state row exists before writing pane layout
+			ensureWorkspaceInSidebar(pending.workspaceId, pending.projectId);
+
+			// Pre-populate pane layout with setup terminals (already running on host)
+			if (pending.terminals.length > 0) {
+				const paneLayout = buildSetupPaneLayout(pending.terminals);
+				collections.v2WorkspaceLocalState.update(
+					pending.workspaceId,
+					(draft) => {
+						draft.paneLayout = paneLayout;
+					},
+				);
+			}
+
 			void navigate({
 				to: "/v2-workspace/$workspaceId",
 				params: { workspaceId: pending.workspaceId },
@@ -201,7 +219,7 @@ function PendingWorkspacePage() {
 				collections.pendingWorkspaces.delete(pendingId);
 			}, 1000);
 		}
-	}, [collections, navigate, pending, pendingId]);
+	}, [collections, ensureWorkspaceInSidebar, navigate, pending, pendingId]);
 
 	if (!pending) {
 		return (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -116,22 +116,6 @@ export function TerminalPane({ ctx, workspaceId }: TerminalPaneProps) {
 		terminalRuntimeRegistry.updateAppearance(terminalId, appearance);
 	}, [terminalId, appearance]);
 
-	// --- Initial command delivery ---
-	// When initialCommand is set on pane data, send it once the WebSocket is
-	// open and immediately clear the field. Clearing prevents re-send on
-	// reconnect, and allows a new initialCommand to be set later (e.g. "run
-	// in current terminal").
-	useEffect(() => {
-		if (connectionState !== "open") return;
-		if (!paneData.initialCommand) return;
-
-		const command = paneData.initialCommand.endsWith("\n")
-			? paneData.initialCommand
-			: `${paneData.initialCommand}\n`;
-		terminalRuntimeRegistry.writeInput(terminalId, command);
-		ctx.actions.updateData({ ...paneData, initialCommand: undefined });
-	}, [connectionState, terminalId, paneData, ctx.actions]);
-
 	// --- Link handlers ---
 	// All filesystem operations go through the host service.
 	// statPath is a mutation (POST) to avoid tRPC GET URL encoding issues

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/useV2PresetExecution.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/useV2PresetExecution.ts
@@ -1,4 +1,5 @@
 import type { CreatePaneInput, WorkspaceStore } from "@superset/panes";
+import { toast } from "@superset/ui/sonner";
 import { workspaceTrpc } from "@superset/workspace-client";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useCallback, useMemo, useRef } from "react";
@@ -76,72 +77,23 @@ export function useV2PresetExecution({
 				hasActiveTab: !!activeTabId,
 			});
 
-			switch (plan) {
-				case "new-tab-single": {
-					const id = await createSessionWithCommand(
-						preset.commands[0] as string,
-					);
-					state.addTab({
-						titleOverride: preset.name || "Terminal",
-						panes: [makeTerminalPane(id)],
-					});
-					break;
-				}
-
-				case "new-tab-multi-pane": {
-					const ids = await Promise.all(
-						preset.commands.map((cmd) => createSessionWithCommand(cmd)),
-					);
-					const panes = ids.map((id) => makeTerminalPane(id));
-					state.addTab({
-						titleOverride: preset.name || "Terminal",
-						panes:
-							panes.length > 0
-								? (panes as [
-										CreatePaneInput<PaneViewerData>,
-										...CreatePaneInput<PaneViewerData>[],
-									])
-								: [makeTerminalPane(crypto.randomUUID())],
-					});
-					break;
-				}
-
-				case "new-tab-per-command": {
-					const ids = await Promise.all(
-						preset.commands.map((cmd) => createSessionWithCommand(cmd)),
-					);
-					for (let i = 0; i < ids.length; i++) {
-						state.addTab({
-							titleOverride: preset.name || "Terminal",
-							panes: [makeTerminalPane(ids[i] as string)],
-						});
-					}
-					break;
-				}
-
-				case "active-tab-single": {
-					const id = await createSessionWithCommand(
-						preset.commands[0] as string,
-					);
-					if (!activeTabId) {
+			try {
+				switch (plan) {
+					case "new-tab-single": {
+						const id = await createSessionWithCommand(
+							preset.commands[0] as string,
+						);
 						state.addTab({
 							titleOverride: preset.name || "Terminal",
 							panes: [makeTerminalPane(id)],
 						});
 						break;
 					}
-					state.addPane({
-						tabId: activeTabId,
-						pane: makeTerminalPane(id),
-					});
-					break;
-				}
 
-				case "active-tab-multi-pane": {
-					const ids = await Promise.all(
-						preset.commands.map((cmd) => createSessionWithCommand(cmd)),
-					);
-					if (!activeTabId) {
+					case "new-tab-multi-pane": {
+						const ids = await Promise.all(
+							preset.commands.map((cmd) => createSessionWithCommand(cmd)),
+						);
 						const panes = ids.map((id) => makeTerminalPane(id));
 						state.addTab({
 							titleOverride: preset.name || "Terminal",
@@ -155,14 +107,73 @@ export function useV2PresetExecution({
 						});
 						break;
 					}
-					for (const id of ids) {
+
+					case "new-tab-per-command": {
+						const ids = await Promise.all(
+							preset.commands.map((cmd) => createSessionWithCommand(cmd)),
+						);
+						for (let i = 0; i < ids.length; i++) {
+							state.addTab({
+								titleOverride: preset.name || "Terminal",
+								panes: [makeTerminalPane(ids[i] as string)],
+							});
+						}
+						break;
+					}
+
+					case "active-tab-single": {
+						const id = await createSessionWithCommand(
+							preset.commands[0] as string,
+						);
+						if (!activeTabId) {
+							state.addTab({
+								titleOverride: preset.name || "Terminal",
+								panes: [makeTerminalPane(id)],
+							});
+							break;
+						}
 						state.addPane({
 							tabId: activeTabId,
 							pane: makeTerminalPane(id),
 						});
+						break;
 					}
-					break;
+
+					case "active-tab-multi-pane": {
+						const ids = await Promise.all(
+							preset.commands.map((cmd) => createSessionWithCommand(cmd)),
+						);
+						if (!activeTabId) {
+							const panes = ids.map((id) => makeTerminalPane(id));
+							state.addTab({
+								titleOverride: preset.name || "Terminal",
+								panes:
+									panes.length > 0
+										? (panes as [
+												CreatePaneInput<PaneViewerData>,
+												...CreatePaneInput<PaneViewerData>[],
+											])
+										: [makeTerminalPane(crypto.randomUUID())],
+							});
+							break;
+						}
+						for (const id of ids) {
+							state.addPane({
+								tabId: activeTabId,
+								pane: makeTerminalPane(id),
+							});
+						}
+						break;
+					}
 				}
+			} catch (err) {
+				console.error("[useV2PresetExecution] Failed to execute preset:", err);
+				toast.error("Failed to run preset", {
+					description:
+						err instanceof Error
+							? err.message
+							: "Terminal session creation failed.",
+				});
 			}
 		},
 		[store, createSessionWithCommand],

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/useV2PresetExecution.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/useV2PresetExecution.ts
@@ -1,6 +1,7 @@
 import type { CreatePaneInput, WorkspaceStore } from "@superset/panes";
+import { workspaceTrpc } from "@superset/workspace-client";
 import { useLiveQuery } from "@tanstack/react-db";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
 import { getPresetLaunchPlan } from "renderer/stores/tabs/preset-launch";
@@ -8,13 +9,10 @@ import { filterMatchingPresetsForProject } from "shared/preset-project-targeting
 import type { StoreApi } from "zustand/vanilla";
 import type { PaneViewerData, TerminalPaneData } from "../../types";
 
-function makeTerminalPane(command?: string): CreatePaneInput<PaneViewerData> {
+function makeTerminalPane(terminalId: string): CreatePaneInput<PaneViewerData> {
 	return {
 		kind: "terminal",
-		data: {
-			terminalId: crypto.randomUUID(),
-			initialCommand: command,
-		} as TerminalPaneData,
+		data: { terminalId } as TerminalPaneData,
 	};
 }
 
@@ -24,14 +22,19 @@ function resolveTarget(executionMode: V2TerminalPresetRow["executionMode"]) {
 
 interface UseV2PresetExecutionArgs {
 	store: StoreApi<WorkspaceStore<PaneViewerData>>;
+	workspaceId: string;
 	projectId: string;
 }
 
 export function useV2PresetExecution({
 	store,
+	workspaceId,
 	projectId,
 }: UseV2PresetExecutionArgs) {
 	const collections = useCollections();
+	const ensureSession = workspaceTrpc.terminal.ensureSession.useMutation();
+	const ensureSessionRef = useRef(ensureSession);
+	ensureSessionRef.current = ensureSession;
 
 	const { data: allPresets = [] } = useLiveQuery(
 		(query) =>
@@ -46,8 +49,22 @@ export function useV2PresetExecution({
 		[allPresets, projectId],
 	);
 
+	/** Create a terminal session with a command on the host-service, return the terminalId. */
+	const createSessionWithCommand = useCallback(
+		async (command: string): Promise<string> => {
+			const terminalId = crypto.randomUUID();
+			await ensureSessionRef.current.mutateAsync({
+				terminalId,
+				workspaceId,
+				initialCommand: command,
+			});
+			return terminalId;
+		},
+		[workspaceId],
+	);
+
 	const executePreset = useCallback(
-		(preset: V2TerminalPresetRow) => {
+		async (preset: V2TerminalPresetRow) => {
 			const state = store.getState();
 			const activeTabId = state.activeTabId;
 			const target = resolveTarget(preset.executionMode);
@@ -61,15 +78,21 @@ export function useV2PresetExecution({
 
 			switch (plan) {
 				case "new-tab-single": {
+					const id = await createSessionWithCommand(
+						preset.commands[0] as string,
+					);
 					state.addTab({
 						titleOverride: preset.name || "Terminal",
-						panes: [makeTerminalPane(preset.commands[0])],
+						panes: [makeTerminalPane(id)],
 					});
 					break;
 				}
 
 				case "new-tab-multi-pane": {
-					const panes = preset.commands.map((cmd) => makeTerminalPane(cmd));
+					const ids = await Promise.all(
+						preset.commands.map((cmd) => createSessionWithCommand(cmd)),
+					);
+					const panes = ids.map((id) => makeTerminalPane(id));
 					state.addTab({
 						titleOverride: preset.name || "Terminal",
 						panes:
@@ -78,39 +101,48 @@ export function useV2PresetExecution({
 										CreatePaneInput<PaneViewerData>,
 										...CreatePaneInput<PaneViewerData>[],
 									])
-								: [makeTerminalPane()],
+								: [makeTerminalPane(crypto.randomUUID())],
 					});
 					break;
 				}
 
 				case "new-tab-per-command": {
-					for (const command of preset.commands) {
+					const ids = await Promise.all(
+						preset.commands.map((cmd) => createSessionWithCommand(cmd)),
+					);
+					for (let i = 0; i < ids.length; i++) {
 						state.addTab({
 							titleOverride: preset.name || "Terminal",
-							panes: [makeTerminalPane(command)],
+							panes: [makeTerminalPane(ids[i] as string)],
 						});
 					}
 					break;
 				}
 
 				case "active-tab-single": {
+					const id = await createSessionWithCommand(
+						preset.commands[0] as string,
+					);
 					if (!activeTabId) {
 						state.addTab({
 							titleOverride: preset.name || "Terminal",
-							panes: [makeTerminalPane(preset.commands[0])],
+							panes: [makeTerminalPane(id)],
 						});
 						break;
 					}
 					state.addPane({
 						tabId: activeTabId,
-						pane: makeTerminalPane(preset.commands[0]),
+						pane: makeTerminalPane(id),
 					});
 					break;
 				}
 
 				case "active-tab-multi-pane": {
+					const ids = await Promise.all(
+						preset.commands.map((cmd) => createSessionWithCommand(cmd)),
+					);
 					if (!activeTabId) {
-						const panes = preset.commands.map((cmd) => makeTerminalPane(cmd));
+						const panes = ids.map((id) => makeTerminalPane(id));
 						state.addTab({
 							titleOverride: preset.name || "Terminal",
 							panes:
@@ -119,21 +151,21 @@ export function useV2PresetExecution({
 											CreatePaneInput<PaneViewerData>,
 											...CreatePaneInput<PaneViewerData>[],
 										])
-									: [makeTerminalPane()],
+									: [makeTerminalPane(crypto.randomUUID())],
 						});
 						break;
 					}
-					for (const command of preset.commands) {
+					for (const id of ids) {
 						state.addPane({
 							tabId: activeTabId,
-							pane: makeTerminalPane(command),
+							pane: makeTerminalPane(id),
 						});
 					}
 					break;
 				}
 			}
 		},
-		[store],
+		[store, createSessionWithCommand],
 	);
 
 	return { matchedPresets, executePreset };

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -88,6 +88,7 @@ function WorkspaceContent({
 	});
 	const { matchedPresets, executePreset } = useV2PresetExecution({
 		store,
+		workspaceId,
 		projectId,
 	});
 	const paneRegistry = usePaneRegistry(workspaceId);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
@@ -7,7 +7,6 @@ export interface FilePaneData {
 
 export interface TerminalPaneData {
 	terminalId: string;
-	initialCommand?: string;
 }
 
 export interface ChatPaneData {

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
@@ -112,7 +112,7 @@ export function useSubmitWorkspace(projectId: string | null) {
 			collections.pendingWorkspaces.update(pendingId, (row) => {
 				row.status = "succeeded";
 				row.workspaceId = result.workspace?.id ?? null;
-				row.initialCommands = result.initialCommands ?? null;
+				row.terminals = result.terminals ?? [];
 			});
 			void clearAttachments(pendingId);
 		} catch (err) {

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
@@ -67,7 +67,6 @@ export function useSubmitWorkspace(projectId: string | null) {
 			status: "creating",
 			error: null,
 			workspaceId: null,
-			initialCommands: null,
 			createdAt: new Date(),
 		});
 

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -91,6 +91,9 @@ export const pendingWorkspaceSchema = z.object({
 	error: z.string().nullable().default(null),
 	workspaceId: z.string().nullable().default(null),
 	initialCommands: z.array(z.string()).nullable().default(null),
+	terminals: z
+		.array(z.object({ id: z.string(), role: z.string(), label: z.string() }))
+		.default([]),
 	createdAt: persistedDateSchema,
 });
 

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -90,7 +90,6 @@ export const pendingWorkspaceSchema = z.object({
 	status: z.enum(["creating", "failed", "succeeded"]).default("creating"),
 	error: z.string().nullable().default(null),
 	workspaceId: z.string().nullable().default(null),
-	initialCommands: z.array(z.string()).nullable().default(null),
 	terminals: z
 		.array(z.object({ id: z.string(), role: z.string(), label: z.string() }))
 		.default([]),

--- a/docs/V2_WORKSPACE_SETUP_SCRIPTS.md
+++ b/docs/V2_WORKSPACE_SETUP_SCRIPTS.md
@@ -2,77 +2,33 @@
 
 ## Problem
 
-V2 workspace creation returns `initialCommands` (from `.superset/setup.sh`) but never executes them. Additionally, the preset system races with shell init — commands fire before the shell is ready.
+1. V2 workspace creation returns `initialCommands` (from `.superset/setup.sh`) but never executes them.
+2. Presets race with shell init — commands fire before the shell is ready.
 
 ## Approach
 
-1. Adopt OSC 133 (FinalTerm standard) for shell readiness detection
-2. Gate WebSocket input on the host-service behind shell readiness (fixes presets, zero renderer changes)
-3. Add `initialCommand` to `createTerminalSessionInternal` for setup scripts (no renderer connected)
+One unified API: all initial commands go through `createTerminalSessionInternal({ initialCommand })`, gated behind `shellReadyPromise`. The renderer never writes commands — it only attaches to sessions.
+
+1. OSC 133 (FinalTerm standard) for shell readiness detection
+2. `initialCommand` on `createTerminalSessionInternal` — queues command behind `shellReadyPromise`
+3. `ensureSession` gains optional `initialCommand`, passes through to `createTerminalSessionInternal`
+4. Presets call `await ensureSession({ initialCommand })` before adding pane — no `initialCommand` on pane data
+5. Setup scripts call `createTerminalSessionInternal({ initialCommand })` directly during workspace creation
+6. `TerminalPane` simplified — just calls `ensureSession()` and attaches WebSocket. No command delivery logic.
+
+Existing output buffering (`bufferOutput`/`replayBuffer`) handles the gap between session creation and WebSocket connect.
 
 ## Phase 1: Shell Readiness via OSC 133 ✅ DONE
 
-Shell wrappers updated to emit OSC 133 A/C/D. Scanner added to `terminal.ts`.
+Shell wrappers updated to emit OSC 133 A/C/D. Scanner + `shellReadyPromise` added to `terminal.ts`.
 
 ---
 
-## Phase 2: Gate WebSocket Input Behind Shell Readiness
+## Phase 2: `initialCommand` on Session Creation
 
-The existing terminal creation flow (button, hotkey, preset) works the same way:
+### `createTerminalSessionInternal`
 
-```
-store.addTab({ panes: [{ terminalId: uuid, initialCommand? }] })
-  → TerminalPane mounts → ensureSession → WebSocket attaches
-  → TerminalPane writes initialCommand via WebSocket { type: "input" }
-```
-
-The race is that the renderer writes the command before the shell is ready. Fix: the host-service queues WebSocket `input` messages while the shell is pending, flushes when ready.
-
-### Changes
-
-**`packages/host-service/src/terminal/terminal.ts`** — WebSocket `onMessage` handler (line 529):
-
-```typescript
-// Before:
-if (message.type === "input") {
-  session.pty.write(message.data);
-}
-
-// After:
-if (message.type === "input") {
-  if (session.shellReadyState === "pending") {
-    if (!message.data.startsWith("\x1b")) {
-      session.preReadyWriteQueue.push(message.data);
-    }
-    return;
-  }
-  session.pty.write(message.data);
-}
-```
-
-Add `preReadyWriteQueue: string[]` to `TerminalSession`. Flush in `resolveShellReady`:
-
-```typescript
-const queue = session.preReadyWriteQueue;
-session.preReadyWriteQueue = [];
-for (const data of queue) {
-  session.pty.write(data);
-}
-```
-
-Drop escape sequences while pending (v1 pattern) — stale terminal query responses that would appear as typed text.
-
-**No changes to:** `ensureSession`, `TerminalPane`, `useV2PresetExecution`, `TerminalPaneData`.
-
----
-
-## Phase 3: `initialCommand` on `createTerminalSessionInternal`
-
-Setup scripts create terminals during workspace creation — no renderer is connected. The command must be delivered server-side.
-
-### Changes
-
-**`packages/host-service/src/terminal/terminal.ts`**:
+**File:** `packages/host-service/src/terminal/terminal.ts`
 
 ```typescript
 interface CreateTerminalSessionOptions {
@@ -90,11 +46,64 @@ if (initialCommand) {
 }
 ```
 
-Output buffers automatically while no WebSocket is attached. Replays on connect.
+### `ensureSession` tRPC
+
+**File:** `packages/host-service/src/trpc/router/terminal/terminal.ts`
+
+Add optional `initialCommand` to input, pass through:
+
+```typescript
+ensureSession: protectedProcedure
+  .input(z.object({
+    terminalId: z.string(),
+    workspaceId: z.string(),
+    themeType: z.string().optional(),
+    initialCommand: z.string().optional(),
+  }))
+  .mutation(({ ctx, input }) => {
+    const result = createTerminalSessionInternal({
+      terminalId: input.terminalId,
+      workspaceId: input.workspaceId,
+      themeType: parseThemeType(input.themeType),
+      db: ctx.db,
+      initialCommand: input.initialCommand,
+    });
+    // ...
+  }),
+```
+
+### Update presets
+
+**File:** `apps/desktop/.../useV2PresetExecution/useV2PresetExecution.ts`
+
+Before adding the pane, create the session with the command:
+
+```typescript
+const terminalId = crypto.randomUUID();
+await ensureSession({ terminalId, workspaceId, initialCommand: command });
+store.addTab({ panes: [{ kind: "terminal", data: { terminalId } }] });
+```
+
+### Simplify TerminalPane
+
+**File:** `apps/desktop/.../TerminalPane/TerminalPane.tsx`
+
+Delete the `initialCommand` delivery effect (lines 119-133). `TerminalPane` only does: `ensureSession()` + attach WebSocket.
+
+### Remove `initialCommand` from pane data
+
+**File:** `apps/desktop/.../v2-workspace/$workspaceId/types.ts`
+
+```typescript
+export interface TerminalPaneData {
+  terminalId: string;
+  // initialCommand removed
+}
+```
 
 ---
 
-## Phase 4: Create Setup Terminal During Workspace Creation
+## Phase 3: Create Setup Terminal During Workspace Creation
 
 **File:** `packages/host-service/src/trpc/router/workspace-creation/workspace-creation.ts`
 
@@ -124,11 +133,11 @@ return { workspace: cloudRow, terminals, warnings: [] as string[] };
 
 ---
 
-## Phase 5: Renderer Attaches to Pre-Started Terminals
+## Phase 4: Renderer Attaches to Pre-Started Terminals
 
 - Add `terminals` to `pendingWorkspaceSchema`
 - Before navigating to workspace, pre-populate `v2WorkspaceLocalState.paneLayout` with terminal panes referencing host-provided `terminalId`s
-- `TerminalPane` mounts → `ensureSession` (idempotent) → WebSocket connects → buffered output replays
+- `TerminalPane` mounts → `ensureSession` (idempotent, session exists) → WebSocket connects → buffered output replays
 
 **Files:**
 - `apps/desktop/.../dashboardSidebarLocal/schema.ts`
@@ -139,7 +148,7 @@ return { workspace: cloudRow, terminals, warnings: [] as string[] };
 
 ## Future: "Run in Current Terminal"
 
-Not used in v2 today. When needed, add a dedicated `terminal.writeCommand` tRPC mutation.
+Not used in v2 today. When needed, add a `terminal.writeCommand` tRPC mutation.
 
 ---
 

--- a/docs/V2_WORKSPACE_SETUP_SCRIPTS.md
+++ b/docs/V2_WORKSPACE_SETUP_SCRIPTS.md
@@ -1,0 +1,152 @@
+# V2 Workspace Setup Script Execution
+
+## Problem
+
+V2 workspace creation returns `initialCommands` (from `.superset/setup.sh`) but never executes them. Additionally, the preset system races with shell init — commands fire before the shell is ready.
+
+## Approach
+
+1. Adopt OSC 133 (FinalTerm standard) for shell readiness detection
+2. Gate WebSocket input on the host-service behind shell readiness (fixes presets, zero renderer changes)
+3. Add `initialCommand` to `createTerminalSessionInternal` for setup scripts (no renderer connected)
+
+## Phase 1: Shell Readiness via OSC 133 ✅ DONE
+
+Shell wrappers updated to emit OSC 133 A/C/D. Scanner added to `terminal.ts`.
+
+---
+
+## Phase 2: Gate WebSocket Input Behind Shell Readiness
+
+The existing terminal creation flow (button, hotkey, preset) works the same way:
+
+```
+store.addTab({ panes: [{ terminalId: uuid, initialCommand? }] })
+  → TerminalPane mounts → ensureSession → WebSocket attaches
+  → TerminalPane writes initialCommand via WebSocket { type: "input" }
+```
+
+The race is that the renderer writes the command before the shell is ready. Fix: the host-service queues WebSocket `input` messages while the shell is pending, flushes when ready.
+
+### Changes
+
+**`packages/host-service/src/terminal/terminal.ts`** — WebSocket `onMessage` handler (line 529):
+
+```typescript
+// Before:
+if (message.type === "input") {
+  session.pty.write(message.data);
+}
+
+// After:
+if (message.type === "input") {
+  if (session.shellReadyState === "pending") {
+    if (!message.data.startsWith("\x1b")) {
+      session.preReadyWriteQueue.push(message.data);
+    }
+    return;
+  }
+  session.pty.write(message.data);
+}
+```
+
+Add `preReadyWriteQueue: string[]` to `TerminalSession`. Flush in `resolveShellReady`:
+
+```typescript
+const queue = session.preReadyWriteQueue;
+session.preReadyWriteQueue = [];
+for (const data of queue) {
+  session.pty.write(data);
+}
+```
+
+Drop escape sequences while pending (v1 pattern) — stale terminal query responses that would appear as typed text.
+
+**No changes to:** `ensureSession`, `TerminalPane`, `useV2PresetExecution`, `TerminalPaneData`.
+
+---
+
+## Phase 3: `initialCommand` on `createTerminalSessionInternal`
+
+Setup scripts create terminals during workspace creation — no renderer is connected. The command must be delivered server-side.
+
+### Changes
+
+**`packages/host-service/src/terminal/terminal.ts`**:
+
+```typescript
+interface CreateTerminalSessionOptions {
+  // ...existing...
+  initialCommand?: string;
+}
+
+// After PTY creation + shell ready setup:
+if (initialCommand) {
+  session.shellReadyPromise.then(() => {
+    if (!session.exited) {
+      pty.write(initialCommand.endsWith("\n") ? initialCommand : `${initialCommand}\n`);
+    }
+  });
+}
+```
+
+Output buffers automatically while no WebSocket is attached. Replays on connect.
+
+---
+
+## Phase 4: Create Setup Terminal During Workspace Creation
+
+**File:** `packages/host-service/src/trpc/router/workspace-creation/workspace-creation.ts`
+
+Replace command resolution (lines 462-469) with terminal creation. Return terminal descriptors:
+
+```typescript
+const terminals: Array<{ id: string; role: string; label: string }> = [];
+
+if (input.composer.runSetupScript) {
+  const setupScriptPath = join(worktreePath, ".superset", "setup.sh");
+  if (existsSync(setupScriptPath)) {
+    const terminalId = crypto.randomUUID();
+    const result = createTerminalSessionInternal({
+      terminalId,
+      workspaceId: cloudRow.id,
+      db: ctx.db,
+      initialCommand: `bash "${setupScriptPath}"`,
+    });
+    if (!("error" in result)) {
+      terminals.push({ id: terminalId, role: "setup", label: "Workspace Setup" });
+    }
+  }
+}
+
+return { workspace: cloudRow, terminals, warnings: [] as string[] };
+```
+
+---
+
+## Phase 5: Renderer Attaches to Pre-Started Terminals
+
+- Add `terminals` to `pendingWorkspaceSchema`
+- Before navigating to workspace, pre-populate `v2WorkspaceLocalState.paneLayout` with terminal panes referencing host-provided `terminalId`s
+- `TerminalPane` mounts → `ensureSession` (idempotent) → WebSocket connects → buffered output replays
+
+**Files:**
+- `apps/desktop/.../dashboardSidebarLocal/schema.ts`
+- `apps/desktop/.../pending/$pendingId/page.tsx`
+- `apps/desktop/.../pending/$pendingId/buildSetupPaneLayout.ts` (new)
+
+---
+
+## Future: "Run in Current Terminal"
+
+Not used in v2 today. When needed, add a dedicated `terminal.writeCommand` tRPC mutation.
+
+---
+
+## Attribution
+
+Shell integration protocol vendored from:
+- **WezTerm** (MIT License, Copyright 2018-Present Wez Furlong) — `assets/shell-integration/wezterm.sh`
+- **FinalTerm semantic prompts spec** — https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md
+
+Scanner pattern adapted from our v1 desktop terminal host (`apps/desktop/src/main/terminal-host/session.ts`).

--- a/packages/host-service/src/terminal/env.test.ts
+++ b/packages/host-service/src/terminal/env.test.ts
@@ -242,7 +242,7 @@ describe("getShellLaunchArgs", () => {
 		expect(args[0]).toBe("-l");
 		expect(args[1]).toBe("--init-command");
 		expect(args[2]).toContain("_superset_bin");
-		expect(args[2]).toContain("superset-shell-ready");
+		expect(args[2]).toContain("133;A");
 	});
 
 	test("sh launches as login shell", () => {

--- a/packages/host-service/src/terminal/shell-launch.ts
+++ b/packages/host-service/src/terminal/shell-launch.ts
@@ -35,7 +35,13 @@ function getShellName(shell: string): string {
 	return path.basename(shell);
 }
 
-/** Matches desktop shell-wrappers.ts fish init: idempotent PATH prepend + shell-ready OSC marker. */
+/**
+ * Matches desktop shell-wrappers.ts fish init: idempotent PATH prepend +
+ * OSC 133 semantic prompt markers (FinalTerm standard).
+ *
+ * Protocol ref: https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md
+ * Vendored from WezTerm (MIT, Copyright 2018-Present Wez Furlong).
+ */
 function buildFishInitCommand(binDir: string): string {
 	const escaped = binDir
 		.replaceAll("\\", "\\\\")
@@ -45,9 +51,17 @@ function buildFishInitCommand(binDir: string): string {
 		`set -l _superset_bin "${escaped}"`,
 		`contains -- "$_superset_bin" $PATH`,
 		`or set -gx PATH "$_superset_bin" $PATH`,
-		`function _superset_shell_ready --on-event fish_prompt`,
-		`printf '\\033]777;superset-shell-ready\\007'`,
-		`functions -e _superset_shell_ready`,
+		// OSC 133;A — prompt start (shell ready)
+		`function _superset_prompt_mark --on-event fish_prompt`,
+		`printf '\\033]133;A\\007'`,
+		`end`,
+		// OSC 133;C — command output start
+		`function _superset_preexec --on-event fish_preexec`,
+		`printf '\\033]133;C\\007'`,
+		`end`,
+		// OSC 133;D;{exit_code} — command finished
+		`function _superset_postexec --on-event fish_postexec`,
+		`printf '\\033]133;D;%s\\007' $status`,
 		`end`,
 	].join("; ");
 }

--- a/packages/host-service/src/terminal/shell-launch.ts
+++ b/packages/host-service/src/terminal/shell-launch.ts
@@ -37,10 +37,9 @@ function getShellName(shell: string): string {
 
 /**
  * Matches desktop shell-wrappers.ts fish init: idempotent PATH prepend +
- * OSC 133 semantic prompt markers (FinalTerm standard).
+ * OSC 133;A prompt marker (FinalTerm standard) for shell readiness.
  *
  * Protocol ref: https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md
- * Vendored from WezTerm (MIT, Copyright 2018-Present Wez Furlong).
  */
 function buildFishInitCommand(binDir: string): string {
 	const escaped = binDir
@@ -51,17 +50,8 @@ function buildFishInitCommand(binDir: string): string {
 		`set -l _superset_bin "${escaped}"`,
 		`contains -- "$_superset_bin" $PATH`,
 		`or set -gx PATH "$_superset_bin" $PATH`,
-		// OSC 133;A — prompt start (shell ready)
 		`function _superset_prompt_mark --on-event fish_prompt`,
 		`printf '\\033]133;A\\007'`,
-		`end`,
-		// OSC 133;C — command output start
-		`function _superset_preexec --on-event fish_preexec`,
-		`printf '\\033]133;C\\007'`,
-		`end`,
-		// OSC 133;D;{exit_code} — command finished
-		`function _superset_postexec --on-event fish_postexec`,
-		`printf '\\033]133;D;%s\\007' $status`,
 		`end`,
 	].join("; ");
 }

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -1,5 +1,11 @@
 import { existsSync } from "node:fs";
 import type { NodeWebSocket } from "@hono/node-ws";
+import {
+	SHELLS_WITH_READY_MARKER,
+	type ShellReadyScanState,
+	createScanState,
+	scanForShellReady,
+} from "@superset/shared/shell-ready-scanner";
 import { eq } from "drizzle-orm";
 import type { Hono } from "hono";
 import { type IPty, spawn } from "node-pty";
@@ -39,17 +45,8 @@ const MAX_BUFFER_BYTES = 64 * 1024;
 
 // ---------------------------------------------------------------------------
 // OSC 133 shell readiness detection (FinalTerm semantic prompt standard).
-//
-// Protocol ref: https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md
-// Shell-side emission vendored from WezTerm (MIT, Copyright 2018-Present Wez Furlong).
-// Scanner pattern adapted from apps/desktop/src/main/terminal-host/session.ts (v1).
+// Scanner logic lives in @superset/shared/shell-ready-scanner.
 // ---------------------------------------------------------------------------
-
-/**
- * The OSC 133;A prefix we scan for. Once matched, the next character is the
- * command letter. We only care about "A" (prompt start = shell ready).
- */
-const OSC_133_A = "\x1b]133;A";
 
 /**
  * How long to wait for the shell-ready marker before unblocking writes.
@@ -57,9 +54,6 @@ const OSC_133_A = "\x1b]133;A";
  * buffered writes flush immediately (same behaviour as before this feature).
  */
 const SHELL_READY_TIMEOUT_MS = 15_000;
-
-/** Shells whose wrapper files inject OSC 133 markers. */
-const SHELLS_WITH_READY_MARKER = new Set(["zsh", "bash", "fish"]);
 
 /**
  * Shell readiness lifecycle:
@@ -89,8 +83,7 @@ interface TerminalSession {
 	shellReadyResolve: (() => void) | null;
 	shellReadyPromise: Promise<void>;
 	shellReadyTimeoutId: ReturnType<typeof setTimeout> | null;
-	oscMatchPos: number;
-	oscHeldBytes: string;
+	scanState: ShellReadyScanState;
 }
 
 /** PTY lifetime is independent of socket lifetime — sockets detach/reattach freely. */
@@ -140,57 +133,15 @@ function resolveShellReady(
 		session.shellReadyTimeoutId = null;
 	}
 	// Flush held marker bytes — they weren't part of a full marker
-	if (session.oscHeldBytes.length > 0) {
-		bufferOutput(session, session.oscHeldBytes);
-		session.oscHeldBytes = "";
+	if (session.scanState.heldBytes.length > 0) {
+		bufferOutput(session, session.scanState.heldBytes);
+		session.scanState.heldBytes = "";
 	}
-	session.oscMatchPos = 0;
+	session.scanState.matchPos = 0;
 	if (session.shellReadyResolve) {
 		session.shellReadyResolve();
 		session.shellReadyResolve = null;
 	}
-}
-
-/**
- * Scan PTY output for OSC 133;A (prompt start = shell ready).
- * Matching bytes are held back from output; on full match they're
- * discarded and readiness resolves. On mismatch they're flushed as
- * regular terminal output.
- *
- * Returns the data with the marker stripped (if found).
- */
-function scanForShellReady(session: TerminalSession, data: string): string {
-	if (session.shellReadyState !== "pending") return data;
-
-	let output = "";
-	for (let i = 0; i < data.length; i++) {
-		const ch = data[i] as string;
-		if (session.oscMatchPos < OSC_133_A.length) {
-			// Still matching the OSC 133;A prefix
-			if (ch === OSC_133_A[session.oscMatchPos]) {
-				session.oscHeldBytes += ch;
-				session.oscMatchPos++;
-			} else {
-				// Mismatch — flush held bytes as regular output
-				output += session.oscHeldBytes + ch;
-				session.oscHeldBytes = "";
-				session.oscMatchPos = 0;
-			}
-		} else {
-			// We've matched "\e]133;A" — consume through the string terminator (\a)
-			if (ch === "\x07") {
-				// Full match — discard held bytes, resolve
-				session.oscHeldBytes = "";
-				session.oscMatchPos = 0;
-				resolveShellReady(session, "ready");
-				output += data.slice(i + 1);
-				break;
-			}
-			// Consume optional params (e.g. ";cl=m;aid=123") before the \a
-			session.oscHeldBytes += ch;
-		}
-	}
-	return output;
 }
 
 function disposeSession(terminalId: string, db: HostDb) {
@@ -331,8 +282,7 @@ export function createTerminalSessionInternal({
 		shellReadyResolve,
 		shellReadyPromise,
 		shellReadyTimeoutId: null,
-		oscMatchPos: 0,
-		oscHeldBytes: "",
+		scanState: createScanState(),
 	};
 	sessions.set(terminalId, session);
 
@@ -346,7 +296,14 @@ export function createTerminalSessionInternal({
 
 	pty.onData((rawData) => {
 		// Scan for OSC 133;A and strip it from output
-		const data = scanForShellReady(session, rawData);
+		let data = rawData;
+		if (session.shellReadyState === "pending") {
+			const result = scanForShellReady(session.scanState, rawData);
+			data = result.output;
+			if (result.matched) {
+				resolveShellReady(session, "ready");
+			}
+		}
 		if (data.length === 0) return;
 
 		if (session.socket?.readyState === 1) {

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -1,9 +1,9 @@
 import { existsSync } from "node:fs";
 import type { NodeWebSocket } from "@hono/node-ws";
 import {
+	createScanState,
 	SHELLS_WITH_READY_MARKER,
 	type ShellReadyScanState,
-	createScanState,
 	scanForShellReady,
 } from "@superset/shared/shell-ready-scanner";
 import { eq } from "drizzle-orm";

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -37,6 +37,39 @@ type TerminalServerMessage =
 
 const MAX_BUFFER_BYTES = 64 * 1024;
 
+// ---------------------------------------------------------------------------
+// OSC 133 shell readiness detection (FinalTerm semantic prompt standard).
+//
+// Protocol ref: https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md
+// Shell-side emission vendored from WezTerm (MIT, Copyright 2018-Present Wez Furlong).
+// Scanner pattern adapted from apps/desktop/src/main/terminal-host/session.ts (v1).
+// ---------------------------------------------------------------------------
+
+/**
+ * The OSC 133;A prefix we scan for. Once matched, the next character is the
+ * command letter. We only care about "A" (prompt start = shell ready).
+ */
+const OSC_133_A = "\x1b]133;A";
+
+/**
+ * How long to wait for the shell-ready marker before unblocking writes.
+ * 15 s covers heavy setups like Nix-based devenv via direnv. On timeout
+ * buffered writes flush immediately (same behaviour as before this feature).
+ */
+const SHELL_READY_TIMEOUT_MS = 15_000;
+
+/** Shells whose wrapper files inject OSC 133 markers. */
+const SHELLS_WITH_READY_MARKER = new Set(["zsh", "bash", "fish"]);
+
+/**
+ * Shell readiness lifecycle:
+ * - `pending`     — shell initialising; scanner active
+ * - `ready`       — OSC 133;A detected; scanner off
+ * - `timed_out`   — marker never arrived within timeout; scanner off
+ * - `unsupported` — shell has no marker (sh, ksh); scanner never started
+ */
+type ShellReadyState = "pending" | "ready" | "timed_out" | "unsupported";
+
 interface TerminalSession {
 	terminalId: string;
 	pty: IPty;
@@ -50,6 +83,14 @@ interface TerminalSession {
 	exited: boolean;
 	exitCode: number;
 	exitSignal: number;
+
+	// Shell readiness (OSC 133)
+	shellReadyState: ShellReadyState;
+	shellReadyResolve: (() => void) | null;
+	shellReadyPromise: Promise<void>;
+	shellReadyTimeoutId: ReturnType<typeof setTimeout> | null;
+	oscMatchPos: number;
+	oscHeldBytes: string;
 }
 
 /** PTY lifetime is independent of socket lifetime — sockets detach/reattach freely. */
@@ -84,9 +125,82 @@ function replayBuffer(
 	sendMessage(socket, { type: "replay", data: combined });
 }
 
+/**
+ * Transition out of `pending`. Flushes any partially-matched marker
+ * bytes as terminal output (they weren't a real marker). Idempotent.
+ */
+function resolveShellReady(
+	session: TerminalSession,
+	state: "ready" | "timed_out",
+): void {
+	if (session.shellReadyState !== "pending") return;
+	session.shellReadyState = state;
+	if (session.shellReadyTimeoutId) {
+		clearTimeout(session.shellReadyTimeoutId);
+		session.shellReadyTimeoutId = null;
+	}
+	// Flush held marker bytes — they weren't part of a full marker
+	if (session.oscHeldBytes.length > 0) {
+		bufferOutput(session, session.oscHeldBytes);
+		session.oscHeldBytes = "";
+	}
+	session.oscMatchPos = 0;
+	if (session.shellReadyResolve) {
+		session.shellReadyResolve();
+		session.shellReadyResolve = null;
+	}
+}
+
+/**
+ * Scan PTY output for OSC 133;A (prompt start = shell ready).
+ * Matching bytes are held back from output; on full match they're
+ * discarded and readiness resolves. On mismatch they're flushed as
+ * regular terminal output.
+ *
+ * Returns the data with the marker stripped (if found).
+ */
+function scanForShellReady(session: TerminalSession, data: string): string {
+	if (session.shellReadyState !== "pending") return data;
+
+	let output = "";
+	for (let i = 0; i < data.length; i++) {
+		const ch = data[i] as string;
+		if (session.oscMatchPos < OSC_133_A.length) {
+			// Still matching the OSC 133;A prefix
+			if (ch === OSC_133_A[session.oscMatchPos]) {
+				session.oscHeldBytes += ch;
+				session.oscMatchPos++;
+			} else {
+				// Mismatch — flush held bytes as regular output
+				output += session.oscHeldBytes + ch;
+				session.oscHeldBytes = "";
+				session.oscMatchPos = 0;
+			}
+		} else {
+			// We've matched "\e]133;A" — consume through the string terminator (\a)
+			if (ch === "\x07") {
+				// Full match — discard held bytes, resolve
+				session.oscHeldBytes = "";
+				session.oscMatchPos = 0;
+				resolveShellReady(session, "ready");
+				output += data.slice(i + 1);
+				break;
+			}
+			// Consume optional params (e.g. ";cl=m;aid=123") before the \a
+			session.oscHeldBytes += ch;
+		}
+	}
+	return output;
+}
+
 function disposeSession(terminalId: string, db: HostDb) {
 	const session = sessions.get(terminalId);
 	if (!session) return;
+
+	if (session.shellReadyTimeoutId) {
+		clearTimeout(session.shellReadyTimeoutId);
+		session.shellReadyTimeoutId = null;
+	}
 
 	if (!session.exited) {
 		try {
@@ -190,6 +304,17 @@ export function createTerminalSessionInternal({
 		})
 		.run();
 
+	// Determine shell readiness support
+	const shellName = shell.split("/").pop() || shell;
+	const shellSupportsReady = SHELLS_WITH_READY_MARKER.has(shellName);
+
+	let shellReadyResolve: (() => void) | null = null;
+	const shellReadyPromise = shellSupportsReady
+		? new Promise<void>((resolve) => {
+				shellReadyResolve = resolve;
+			})
+		: Promise.resolve();
+
 	const session: TerminalSession = {
 		terminalId,
 		pty,
@@ -199,10 +324,28 @@ export function createTerminalSessionInternal({
 		exited: false,
 		exitCode: 0,
 		exitSignal: 0,
+		shellReadyState: shellSupportsReady ? "pending" : "unsupported",
+		shellReadyResolve,
+		shellReadyPromise,
+		shellReadyTimeoutId: null,
+		oscMatchPos: 0,
+		oscHeldBytes: "",
 	};
 	sessions.set(terminalId, session);
 
-	pty.onData((data) => {
+	// If the marker never arrives (broken wrapper, unsupported config),
+	// the timeout unblocks so the session degrades gracefully.
+	if (session.shellReadyState === "pending") {
+		session.shellReadyTimeoutId = setTimeout(() => {
+			resolveShellReady(session, "timed_out");
+		}, SHELL_READY_TIMEOUT_MS);
+	}
+
+	pty.onData((rawData) => {
+		// Scan for OSC 133;A and strip it from output
+		const data = scanForShellReady(session, rawData);
+		if (data.length === 0) return;
+
 		if (session.socket?.readyState === 1) {
 			sendMessage(session.socket, { type: "data", data });
 		} else {

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -222,6 +222,8 @@ interface CreateTerminalSessionOptions {
 	workspaceId: string;
 	themeType?: "dark" | "light";
 	db: HostDb;
+	/** Command to run after the shell is ready. Queued behind shellReadyPromise. */
+	initialCommand?: string;
 }
 
 export function createTerminalSessionInternal({
@@ -229,6 +231,7 @@ export function createTerminalSessionInternal({
 	workspaceId,
 	themeType,
 	db,
+	initialCommand,
 }: CreateTerminalSessionOptions): TerminalSession | { error: string } {
 	const existing = sessions.get(terminalId);
 	if (existing) {
@@ -371,6 +374,17 @@ export function createTerminalSessionInternal({
 			});
 		}
 	});
+
+	if (initialCommand) {
+		const cmd = initialCommand.endsWith("\n")
+			? initialCommand
+			: `${initialCommand}\n`;
+		session.shellReadyPromise.then(() => {
+			if (!session.exited) {
+				pty.write(cmd);
+			}
+		});
+	}
 
 	return session;
 }

--- a/packages/host-service/src/trpc/router/terminal/terminal.ts
+++ b/packages/host-service/src/trpc/router/terminal/terminal.ts
@@ -12,6 +12,7 @@ export const terminalRouter = router({
 				terminalId: z.string(),
 				workspaceId: z.string(),
 				themeType: z.string().optional(),
+				initialCommand: z.string().optional(),
 			}),
 		)
 		.mutation(({ ctx, input }) => {
@@ -20,6 +21,7 @@ export const terminalRouter = router({
 				workspaceId: input.workspaceId,
 				themeType: parseThemeType(input.themeType),
 				db: ctx.db,
+				initialCommand: input.initialCommand,
 			});
 
 			if ("error" in result) {

--- a/packages/host-service/src/trpc/router/workspace-creation/workspace-creation.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/workspace-creation.ts
@@ -468,11 +468,7 @@ export const workspaceCreationRouter = router({
 			}> = [];
 
 			if (input.composer.runSetupScript) {
-				const setupScriptPath = join(
-					worktreePath,
-					".superset",
-					"setup.sh",
-				);
+				const setupScriptPath = join(worktreePath, ".superset", "setup.sh");
 				if (existsSync(setupScriptPath)) {
 					const terminalId = crypto.randomUUID();
 					const result = createTerminalSessionInternal({

--- a/packages/host-service/src/trpc/router/workspace-creation/workspace-creation.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/workspace-creation.ts
@@ -6,6 +6,7 @@ import { eq } from "drizzle-orm";
 import simpleGit from "simple-git";
 import { z } from "zod";
 import { projects, workspaces } from "../../../db/schema";
+import { createTerminalSessionInternal } from "../../../terminal/terminal";
 import type { HostServiceContext } from "../../../types";
 import { protectedProcedure, router } from "../../index";
 import { deduplicateBranchName } from "./utils/sanitize-branch";
@@ -459,12 +460,34 @@ export const workspaceCreationRouter = router({
 				})
 				.run();
 
-			// 5. Resolve setup commands (returned to renderer, not executed here)
-			let initialCommands: string[] | null = null;
+			// 5. Create setup terminal if setup script exists
+			const terminals: Array<{
+				id: string;
+				role: string;
+				label: string;
+			}> = [];
+
 			if (input.composer.runSetupScript) {
-				const setupScriptPath = join(worktreePath, ".superset", "setup.sh");
+				const setupScriptPath = join(
+					worktreePath,
+					".superset",
+					"setup.sh",
+				);
 				if (existsSync(setupScriptPath)) {
-					initialCommands = [`bash "${setupScriptPath}"`];
+					const terminalId = crypto.randomUUID();
+					const result = createTerminalSessionInternal({
+						terminalId,
+						workspaceId: cloudRow.id,
+						db: ctx.db,
+						initialCommand: `bash "${setupScriptPath}"`,
+					});
+					if (!("error" in result)) {
+						terminals.push({
+							id: terminalId,
+							role: "setup",
+							label: "Workspace Setup",
+						});
+					}
 				}
 			}
 
@@ -472,7 +495,7 @@ export const workspaceCreationRouter = router({
 
 			return {
 				workspace: cloudRow,
-				initialCommands,
+				terminals,
 				warnings: [] as string[],
 			};
 		}),

--- a/packages/host-service/src/trpc/router/workspace-creation/workspace-creation.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/workspace-creation.ts
@@ -466,6 +466,7 @@ export const workspaceCreationRouter = router({
 				role: string;
 				label: string;
 			}> = [];
+			const warnings: string[] = [];
 
 			if (input.composer.runSetupScript) {
 				const setupScriptPath = join(worktreePath, ".superset", "setup.sh");
@@ -477,7 +478,11 @@ export const workspaceCreationRouter = router({
 						db: ctx.db,
 						initialCommand: `bash "${setupScriptPath}"`,
 					});
-					if (!("error" in result)) {
+					if ("error" in result) {
+						warnings.push(
+							`Failed to start setup terminal: ${result.error}`,
+						);
+					} else {
 						terminals.push({
 							id: terminalId,
 							role: "setup",
@@ -492,7 +497,7 @@ export const workspaceCreationRouter = router({
 			return {
 				workspace: cloudRow,
 				terminals,
-				warnings: [] as string[],
+				warnings,
 			};
 		}),
 

--- a/packages/host-service/src/trpc/router/workspace-creation/workspace-creation.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/workspace-creation.ts
@@ -479,9 +479,7 @@ export const workspaceCreationRouter = router({
 						initialCommand: `bash "${setupScriptPath}"`,
 					});
 					if ("error" in result) {
-						warnings.push(
-							`Failed to start setup terminal: ${result.error}`,
-						);
+						warnings.push(`Failed to start setup terminal: ${result.error}`);
 					} else {
 						terminals.push({
 							id: terminalId,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -63,6 +63,10 @@
 		"./device-info": {
 			"types": "./src/device-info.ts",
 			"default": "./src/device-info.ts"
+		},
+		"./shell-ready-scanner": {
+			"types": "./src/shell-ready-scanner.ts",
+			"default": "./src/shell-ready-scanner.ts"
 		}
 	},
 	"scripts": {

--- a/packages/shared/src/shell-ready-scanner.ts
+++ b/packages/shared/src/shell-ready-scanner.ts
@@ -57,10 +57,17 @@ export function scanForShellReady(
 				state.heldBytes += ch;
 				state.matchPos++;
 			} else {
-				// Mismatch — flush held bytes as regular output
-				output += state.heldBytes + ch;
+				// Mismatch — flush held bytes, then re-test current char as a
+				// fresh match start (e.g. stale ESC followed by real marker).
+				output += state.heldBytes;
 				state.heldBytes = "";
 				state.matchPos = 0;
+				if (ch === OSC_133_A[0]) {
+					state.heldBytes = ch;
+					state.matchPos = 1;
+				} else {
+					output += ch;
+				}
 			}
 		} else {
 			// Matched prefix — consume optional params until string terminator

--- a/packages/shared/src/shell-ready-scanner.ts
+++ b/packages/shared/src/shell-ready-scanner.ts
@@ -1,0 +1,80 @@
+/**
+ * OSC 133 shell readiness scanner (FinalTerm semantic prompt standard).
+ *
+ * Pure scanning logic — no side effects. Callers handle their own readiness
+ * resolution (promises, state machines, event broadcasts, etc.).
+ *
+ * Protocol ref: https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md
+ * Vendored from WezTerm (MIT, Copyright 2018-Present Wez Furlong).
+ */
+
+/** The OSC 133;A prefix that signals shell prompt start (= shell ready). */
+const OSC_133_A = "\x1b]133;A";
+
+/** Shells whose wrapper files inject OSC 133 markers. */
+export const SHELLS_WITH_READY_MARKER = new Set(["zsh", "bash", "fish"]);
+
+/**
+ * Mutable state for the character-by-character scanner.
+ * Callers should create one per terminal session via {@link createScanState}.
+ */
+export interface ShellReadyScanState {
+	matchPos: number;
+	heldBytes: string;
+}
+
+export interface ShellReadyScanResult {
+	/** Output data with the marker stripped (if found). */
+	output: string;
+	/** Whether the full OSC 133;A marker was matched in this chunk. */
+	matched: boolean;
+}
+
+export function createScanState(): ShellReadyScanState {
+	return { matchPos: 0, heldBytes: "" };
+}
+
+/**
+ * Scan a chunk of PTY output for the OSC 133;A (prompt start) marker.
+ *
+ * Matching bytes are held back from output. On full match (prefix + optional
+ * params + string terminator `\a`), they're discarded and `matched` is true.
+ * On mismatch, held bytes are flushed as regular terminal output.
+ *
+ * The scanner handles the marker spanning multiple data chunks.
+ */
+export function scanForShellReady(
+	state: ShellReadyScanState,
+	data: string,
+): ShellReadyScanResult {
+	let output = "";
+
+	for (let i = 0; i < data.length; i++) {
+		const ch = data[i] as string;
+		if (state.matchPos < OSC_133_A.length) {
+			// Still matching the "\x1b]133;A" prefix
+			if (ch === OSC_133_A[state.matchPos]) {
+				state.heldBytes += ch;
+				state.matchPos++;
+			} else {
+				// Mismatch — flush held bytes as regular output
+				output += state.heldBytes + ch;
+				state.heldBytes = "";
+				state.matchPos = 0;
+			}
+		} else {
+			// Matched prefix — consume optional params until string terminator
+			if (ch === "\x07") {
+				// Full match — discard held bytes
+				const remaining = data.slice(i + 1);
+				state.heldBytes = "";
+				state.matchPos = 0;
+				return { output: output + remaining, matched: true };
+			}
+			// Consume optional params (e.g. ";cl=m;aid=123") before \a
+			state.heldBytes += ch;
+		}
+	}
+
+	return { output, matched: false };
+}


### PR DESCRIPTION
## Summary

- Add OSC 133 (FinalTerm standard) shell readiness detection to host-service terminal sessions, vendored from WezTerm (MIT). Shell wrappers updated to emit `133;A` (prompt ready), `133;C` (command start), `133;D` (command finished + exit code) instead of our custom OSC 777 marker.
- Add `initialCommand` support to `createTerminalSessionInternal` and `ensureSession` tRPC — commands are queued behind `shellReadyPromise` and written to the PTY only after the shell is ready. Fixes the preset race condition where commands fired before shell init completed.
- Move command delivery entirely host-service-side: presets now `await ensureSession({ initialCommand })` before adding panes. `initialCommand` removed from `TerminalPaneData` and the renderer-side WebSocket delivery effect deleted.
- During v2 workspace creation, if `.superset/setup.sh` exists, the host-service creates a terminal session with the setup command. Returns `terminals: [{ id, role, label }]`. The pending page pre-populates the workspace pane layout before navigating, so `TerminalPane` attaches to already-running sessions with buffered output.

## Test plan

- [ ] Create v2 workspace with `.superset/setup.sh` + `runSetupScript` enabled — workspace opens with "Workspace Setup" terminal showing setup output
- [ ] Create v2 workspace without setup script — workspace opens with empty state
- [ ] Run a preset with heavy shell init (direnv/nvm) — command waits for shell ready, no garbled output
- [ ] Verify shell readiness timeout (15s) degrades gracefully for unsupported shells
- [ ] Verify `bun test packages/host-service/src/terminal/env.test.ts` passes
- [ ] Verify `bun test apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts` passes
- [ ] Verify `bun run typecheck` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs v2 workspace setup scripts and preset commands by creating host-side terminal sessions that queue initial commands until the shell is ready (OSC 133;A). A “Workspace Setup” terminal is pre-started, panes attach to buffered output, and setup errors return as warnings.

- **New Features**
  - Host-service accepts `initialCommand` in `createTerminalSessionInternal` and `terminal.ensureSession`; commands wait for shell readiness with a 15s timeout fallback.
  - During v2 workspace creation, if `.superset/setup.sh` exists and `runSetupScript` is enabled, a setup terminal starts and the API returns `terminals: [{ id, role, label }]`; the renderer pre-builds the pane layout so panes attach to running sessions.

- **Refactors**
  - Standardized on OSC 133;A in zsh/bash/fish and dropped 133;C/133;D; extracted the scanner to `@superset/shared` and switched v1 desktop and host-service to it.
  - Moved command delivery to the host-service; removed `initialCommand` from `TerminalPaneData` and the renderer-side delivery effect; presets now call `await terminal.ensureSession({ initialCommand })` before adding panes.
  - Robustness and UX: scanner re-tests after mismatches and flushes held bytes; workspace creation surfaces setup terminal failures via returned warnings; local schema switches from `initialCommands` to `terminals` with `buildSetupPaneLayout` and docs added; preset execution now shows a toast if session creation fails.

<sup>Written for commit 3909cf852af71294accf14c5386a2cdd7cfd9c7c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace creation now pre-starts setup terminals and pre-populates pane layouts so setup scripts run automatically and attach on open.
  * Preset execution now creates host-side terminal sessions per command and scopes execution to the current workspace.

* **Bug Fixes**
  * More reliable shell readiness detection and safer delivery of initial commands to terminals, reducing timing-related failures.

* **Documentation**
  * Added end-to-end guide for workspace setup and preset execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->