### PR TITLE
feat(desktop): v2 chat — memory fixes, host-service parity, and reliability

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/host-service-coordinator/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/host-service-coordinator/index.ts
@@ -1,3 +1,4 @@
+import { getHashedDeviceId } from "@superset/shared/device-info";
 import { observable } from "@trpc/server/observable";
 import { env } from "main/env.main";
 import {
@@ -44,6 +45,10 @@ export const createHostServiceCoordinatorRouter = () => {
 				authToken: token,
 				cloudApiUrl: env.NEXT_PUBLIC_API_URL,
 			});
+		}),
+
+		getMachineId: publicProcedure.query(() => {
+			return { machineId: getHashedDeviceId() };
 		}),
 
 		onStatusChange: publicProcedure.subscription(() => {

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -53,6 +53,9 @@ interface HostServiceProcess {
 const HEALTH_POLL_INTERVAL = 200;
 const HEALTH_POLL_TIMEOUT = 10_000;
 const ADOPTED_LIVENESS_INTERVAL = 5_000;
+const MAX_AUTO_RESTART_ATTEMPTS = 5;
+const INITIAL_RESTART_DELAY_MS = 1_000;
+const MAX_RESTART_DELAY_MS = 30_000;
 
 async function findFreePort(): Promise<number> {
 	return new Promise((resolve, reject) => {
@@ -101,6 +104,8 @@ export class HostServiceCoordinator extends EventEmitter {
 		string,
 		ReturnType<typeof setInterval>
 	>();
+	private restartAttempts = new Map<string, number>();
+	private lastSpawnConfig = new Map<string, SpawnConfig>();
 	private scriptPath = path.join(__dirname, "host-service.js");
 	private machineId = getHashedDeviceId();
 
@@ -108,6 +113,8 @@ export class HostServiceCoordinator extends EventEmitter {
 		organizationId: string,
 		config: SpawnConfig,
 	): Promise<Connection> {
+		this.lastSpawnConfig.set(organizationId, config);
+
 		const existing = this.instances.get(organizationId);
 		if (existing?.status === "running") {
 			return {
@@ -122,8 +129,13 @@ export class HostServiceCoordinator extends EventEmitter {
 
 		const startPromise = (async (): Promise<Connection> => {
 			const adopted = await this.tryAdopt(organizationId);
-			if (adopted) return adopted;
-			return this.spawn(organizationId, config);
+			if (adopted) {
+				this.restartAttempts.delete(organizationId);
+				return adopted;
+			}
+			const conn = await this.spawn(organizationId, config);
+			this.restartAttempts.delete(organizationId);
+			return conn;
 		})();
 		this.pendingStarts.set(organizationId, startPromise);
 
@@ -344,6 +356,7 @@ export class HostServiceCoordinator extends EventEmitter {
 			this.instances.delete(organizationId);
 			removeManifest(organizationId);
 			this.emitStatus(organizationId, "stopped", "running");
+			this.scheduleAutoRestart(organizationId);
 		});
 		child.unref();
 
@@ -423,6 +436,7 @@ export class HostServiceCoordinator extends EventEmitter {
 					this.instances.delete(organizationId);
 					removeManifest(organizationId);
 					this.emitStatus(organizationId, "stopped", "running");
+					this.scheduleAutoRestart(organizationId);
 				}
 			}
 		}, ADOPTED_LIVENESS_INTERVAL);
@@ -435,6 +449,41 @@ export class HostServiceCoordinator extends EventEmitter {
 			clearInterval(timer);
 			this.adoptedLivenessTimers.delete(organizationId);
 		}
+	}
+
+	// ── Auto-restart ─────────────────────────────────────────────────
+
+	private scheduleAutoRestart(organizationId: string): void {
+		const config = this.lastSpawnConfig.get(organizationId);
+		if (!config) return;
+
+		const attempts = (this.restartAttempts.get(organizationId) ?? 0) + 1;
+		this.restartAttempts.set(organizationId, attempts);
+
+		if (attempts > MAX_AUTO_RESTART_ATTEMPTS) {
+			console.error(
+				`[host-service:${organizationId}] Exceeded ${MAX_AUTO_RESTART_ATTEMPTS} restart attempts, giving up`,
+			);
+			return;
+		}
+
+		const delay = Math.min(
+			INITIAL_RESTART_DELAY_MS * 2 ** (attempts - 1),
+			MAX_RESTART_DELAY_MS,
+		);
+		console.log(
+			`[host-service:${organizationId}] Auto-restarting in ${delay}ms (attempt ${attempts}/${MAX_AUTO_RESTART_ATTEMPTS})`,
+		);
+
+		setTimeout(() => {
+			if (this.instances.get(organizationId)?.status === "running") return;
+			this.start(organizationId, config).catch((error) => {
+				console.error(
+					`[host-service:${organizationId}] Auto-restart failed:`,
+					error,
+				);
+			});
+		}, delay);
 	}
 
 	// ── Events ────────────────────────────────────────────────────────

--- a/apps/desktop/src/renderer/components/Chat/components/FileMentionChip/FileMentionChip.tsx
+++ b/apps/desktop/src/renderer/components/Chat/components/FileMentionChip/FileMentionChip.tsx
@@ -12,13 +12,13 @@ export function FileMentionChip({
 	return (
 		<button
 			type="button"
-			className="mx-0.5 inline-flex items-center gap-0.5 rounded-md bg-primary/15 px-1.5 py-0.5 font-mono text-xs text-primary transition-colors hover:bg-primary/22 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-default disabled:opacity-60"
+			className="mx-0.5 inline-flex items-center gap-1 rounded-md border border-primary/25 bg-primary/10 px-1.5 py-0.5 font-mono text-xs text-primary transition-colors hover:bg-primary/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-default disabled:opacity-60"
 			onClick={onClick}
 			disabled={disabled}
 			aria-label={`Open file ${relativePath}`}
 		>
-			<span className="font-semibold text-primary">@</span>
-			<span className="text-primary/95">{relativePath}</span>
+			<span className="font-semibold text-primary/70">@</span>
+			<span>{relativePath}</span>
 		</button>
 	);
 }

--- a/apps/desktop/src/renderer/components/Chat/utils/parseUserMentions/parseUserMentions.test.ts
+++ b/apps/desktop/src/renderer/components/Chat/utils/parseUserMentions/parseUserMentions.test.ts
@@ -64,9 +64,54 @@ describe("parseUserMentions", () => {
 		]);
 	});
 
-	it("returns plain text for non-file mentions", () => {
+	it("returns plain text for lowercase single-word mentions", () => {
 		expect(parseUserMentions("ping @teammate asap")).toEqual([
 			{ type: "text", value: "ping @teammate asap" },
+		]);
+	});
+
+	it("parses extensionless uppercase files like README", () => {
+		expect(parseUserMentions("check @README please")).toEqual([
+			{ type: "text", value: "check " },
+			{
+				type: "file-mention",
+				raw: "@README",
+				relativePath: "README",
+			},
+			{ type: "text", value: " please" },
+		]);
+	});
+
+	it("parses PascalCase extensionless files like Dockerfile", () => {
+		expect(parseUserMentions("see @Dockerfile")).toEqual([
+			{ type: "text", value: "see " },
+			{
+				type: "file-mention",
+				raw: "@Dockerfile",
+				relativePath: "Dockerfile",
+			},
+		]);
+	});
+
+	it("parses hyphenated extensionless files", () => {
+		expect(parseUserMentions("check @docker-compose")).toEqual([
+			{ type: "text", value: "check " },
+			{
+				type: "file-mention",
+				raw: "@docker-compose",
+				relativePath: "docker-compose",
+			},
+		]);
+	});
+
+	it("parses underscored extensionless files", () => {
+		expect(parseUserMentions("check @my_config")).toEqual([
+			{ type: "text", value: "check " },
+			{
+				type: "file-mention",
+				raw: "@my_config",
+				relativePath: "my_config",
+			},
 		]);
 	});
 

--- a/apps/desktop/src/renderer/components/Chat/utils/parseUserMentions/parseUserMentions.ts
+++ b/apps/desktop/src/renderer/components/Chat/utils/parseUserMentions/parseUserMentions.ts
@@ -23,7 +23,18 @@ function isTaskMention(value: string): boolean {
 function isFileLikeMention(value: string): boolean {
 	if (!value) return false;
 	if (value.includes(":")) return false;
-	return value.includes("/") || value.includes("\\") || value.includes(".");
+	// Has path separators or file extension — definitely a file path
+	if (value.includes("/") || value.includes("\\") || value.includes(".")) {
+		return true;
+	}
+	// Extensionless files (README, Dockerfile, Makefile, LICENSE, etc.):
+	// accept if it contains path-like chars, is ALL_CAPS, PascalCase,
+	// or contains hyphens/underscores (common in filenames but rare in prose)
+	if (value.includes("-") || value.includes("_")) return true;
+	if (value === value.toUpperCase() && value.length > 1) return true;
+	// PascalCase or starts with uppercase (Dockerfile, Makefile, Gemfile, etc.)
+	if (/^[A-Z]/.test(value)) return true;
+	return false;
 }
 
 export function parseUserMentions(text: string): UserMentionSegment[] {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/ChatPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/ChatPane.tsx
@@ -6,10 +6,29 @@ export function ChatPane({
 	onSessionIdChange,
 	sessionId,
 	workspaceId,
+	isFocused = false,
+	initialDraft,
+	onDraftChange,
+	initialLaunchConfig = null,
+	onConsumeLaunchConfig,
 }: {
 	onSessionIdChange: (sessionId: string | null) => void;
 	sessionId: string | null;
 	workspaceId: string;
+	isFocused?: boolean;
+	initialDraft?: string;
+	onDraftChange?: (draft: string) => void;
+	initialLaunchConfig?: {
+		initialPrompt?: string;
+		draftInput?: string;
+		initialFiles?: Array<{
+			data: string;
+			mediaType: string;
+			filename?: string;
+		}>;
+		metadata?: { model?: string };
+	} | null;
+	onConsumeLaunchConfig?: () => void;
 }) {
 	const {
 		organizationId,
@@ -41,13 +60,16 @@ export function ChatPane({
 			<div className="min-h-0 flex-1">
 				<WorkspaceChatInterface
 					getOrCreateSession={getOrCreateSession}
-					initialLaunchConfig={null}
-					isFocused
+					initialLaunchConfig={initialLaunchConfig}
+					onConsumeLaunchConfig={onConsumeLaunchConfig}
+					isFocused={isFocused}
 					onResetSession={handleNewChat}
 					sessionId={sessionId}
 					workspaceId={workspaceId}
 					organizationId={organizationId}
 					cwd={workspacePath}
+					initialDraft={initialDraft}
+					onDraftChange={onDraftChange}
 				/>
 			</div>
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/ChatPaneInterface.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/ChatPaneInterface.tsx
@@ -2,6 +2,7 @@ import {
 	PromptInputAttachment,
 	type PromptInputMessage,
 	PromptInputProvider,
+	usePromptInputController,
 	useProviderAttachments,
 } from "@superset/ui/ai-elements/prompt-input";
 import { workspaceTrpc } from "@superset/workspace-client";
@@ -51,6 +52,26 @@ type HarnessFilePayload = {
 	filename?: string;
 	uploaded?: boolean;
 };
+
+function DraftSaver({
+	onDraftChange,
+}: {
+	onDraftChange?: (draft: string) => void;
+}) {
+	const { textInput } = usePromptInputController();
+	const valueRef = useRef(textInput.value);
+	valueRef.current = textInput.value;
+	const onDraftChangeRef = useRef(onDraftChange);
+	onDraftChangeRef.current = onDraftChange;
+
+	useEffect(() => {
+		return () => {
+			onDraftChangeRef.current?.(valueRef.current);
+		};
+	}, []);
+
+	return null;
+}
 
 function ChatUploadFooter({
 	sessionId,
@@ -198,6 +219,9 @@ export function ChatPaneInterface({
 	onResetSession,
 	onUserMessageSubmitted,
 	onRawSnapshotChange,
+	onConsumeLaunchConfig,
+	initialDraft,
+	onDraftChange,
 }: ChatPaneInterfaceProps) {
 	const { models: availableModels, defaultModel } = useAvailableModels();
 	const selectedModelId = useChatPreferencesStore(
@@ -374,9 +398,25 @@ export function ChatPaneInterface({
 		},
 		[workspaceTrpcUtils.chat.getMcpOverview, sessionId, workspaceId],
 	);
+	const authenticateMcpServerMutation =
+		workspaceTrpc.chat.authenticateMcpServer.useMutation();
+	const authenticateMcpServer = useCallback(
+		async (_rootCwd: string, serverName: string) => {
+			if (!sessionId) {
+				return { sourcePath: null, servers: [] };
+			}
+			return authenticateMcpServerMutation.mutateAsync({
+				sessionId,
+				workspaceId,
+				serverName,
+			});
+		},
+		[authenticateMcpServerMutation, sessionId, workspaceId],
+	);
 	const mcpUi = useMcpUi({
 		cwd,
 		loadOverview: loadMcpOverview,
+		authenticateServer: authenticateMcpServer,
 		onSetErrorMessage: setRuntimeErrorMessage,
 		onClearError: clearRuntimeError,
 		onTrackEvent: captureChatEvent,
@@ -701,6 +741,7 @@ export function ChatPaneInterface({
 				consumedLaunchConfigRef.current = launchConfigKey;
 				delete autoLaunchAttemptsRef.current[launchConfigKey];
 				delete autoLaunchSessionLockRef.current[launchConfigKey];
+				onConsumeLaunchConfig?.();
 
 				captureChatEvent("chat_message_sent", {
 					session_id: targetSessionId,
@@ -750,6 +791,7 @@ export function ChatPaneInterface({
 		setRuntimeErrorMessage,
 		onUserMessageSubmitted,
 		thinkingLevel,
+		onConsumeLaunchConfig,
 	]);
 
 	const handleStop = useCallback(
@@ -921,7 +963,10 @@ export function ChatPaneInterface({
 	const errorMessage = runtimeError ?? toErrorMessage(error);
 
 	return (
-		<PromptInputProvider initialInput={initialLaunchConfig?.draftInput}>
+		<PromptInputProvider
+			initialInput={initialDraft ?? initialLaunchConfig?.draftInput}
+		>
+			<DraftSaver onDraftChange={onDraftChange} />
 			<div className="flex h-full flex-col bg-background">
 				<ChatMessageList
 					messages={visibleMessages}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ChatInputFooter/ChatInputFooter.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ChatInputFooter/ChatInputFooter.tsx
@@ -106,17 +106,18 @@ export function ChatInputFooter({
 
 	const handleSend = useCallback(
 		(message: PromptInputMessage) => {
-			if (linkedIssues.length === 0) return onSend(message);
+			let text = message.text;
 
-			const prefix = linkedIssues
-				.map((issue) => `@task:${issue.slug}`)
-				.join(" ");
-			const modifiedMessage: PromptInputMessage = {
-				...message,
-				text: `${prefix} ${message.text}`,
-			};
-			setLinkedIssues([]);
-			return onSend(modifiedMessage);
+			if (linkedIssues.length > 0) {
+				const taskPrefix = linkedIssues
+					.map((issue) => `@task:${issue.slug}`)
+					.join(" ");
+				text = `${taskPrefix} ${text}`;
+				setLinkedIssues([]);
+			}
+
+			if (text === message.text) return onSend(message);
+			return onSend({ ...message, text });
 		},
 		[linkedIssues, onSend],
 	);
@@ -137,7 +138,7 @@ export function ChatInputFooter({
 						onCommandSend={onSlashCommandSend}
 						commands={slashCommands}
 					>
-						<MentionProvider cwd={cwd}>
+						<MentionProvider cwd={cwd} workspaceId={workspaceId}>
 							<MentionAnchor>
 								<div
 									ref={inputRootRef}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ChatInputFooter/components/TipTapComposer/TipTapComposer.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ChatInputFooter/components/TipTapComposer/TipTapComposer.tsx
@@ -1,0 +1,361 @@
+import { usePromptInputController } from "@superset/ui/ai-elements/prompt-input";
+import { mergeAttributes, Node } from "@tiptap/core";
+import { Placeholder } from "@tiptap/extension-placeholder";
+import {
+	type Editor,
+	EditorContent,
+	type NodeViewProps,
+	NodeViewWrapper,
+	ReactNodeViewRenderer,
+	useEditor,
+} from "@tiptap/react";
+import { StarterKit } from "@tiptap/starter-kit";
+import { useEffect, useRef } from "react";
+import { FileIcon } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils";
+
+function getFileName(path: string): string {
+	const lastSlash = path.lastIndexOf("/");
+	return lastSlash === -1 ? path : path.slice(lastSlash + 1);
+}
+
+let onMentionClick: ((path: string) => void) | null = null;
+
+export function setMentionClickHandler(
+	handler: ((path: string) => void) | null,
+): void {
+	onMentionClick = handler;
+}
+
+function FileMentionChipView({ node }: NodeViewProps) {
+	const path = node.attrs.id as string;
+	const name = getFileName(path);
+	return (
+		<NodeViewWrapper as="span" className="inline">
+			<button
+				type="button"
+				contentEditable={false}
+				onClick={(e) => {
+					e.preventDefault();
+					e.stopPropagation();
+					onMentionClick?.(path);
+				}}
+				className="inline-flex h-5 items-center gap-1 rounded-sm border border-input bg-background px-1.5 py-0 align-middle text-xs font-medium leading-none cursor-pointer select-none transition-colors hover:bg-accent hover:text-accent-foreground"
+			>
+				<FileIcon fileName={name} className="size-3 shrink-0" />
+				<span>{path}</span>
+			</button>
+		</NodeViewWrapper>
+	);
+}
+
+const FileMention = Node.create({
+	name: "fileMention",
+	group: "inline",
+	inline: true,
+	selectable: true,
+	atom: true,
+	draggable: false,
+
+	addAttributes() {
+		return {
+			id: { default: null },
+		};
+	},
+
+	parseHTML() {
+		return [{ tag: "span[data-file-mention]" }];
+	},
+
+	renderHTML({ HTMLAttributes }) {
+		return [
+			"span",
+			mergeAttributes(HTMLAttributes, { "data-file-mention": "" }),
+		];
+	},
+
+	addNodeView() {
+		return ReactNodeViewRenderer(FileMentionChipView);
+	},
+});
+
+function editorToText(editor: Editor): string {
+	const parts: string[] = [];
+	let isFirstParagraph = true;
+
+	editor.state.doc.forEach((node) => {
+		if (node.type.name === "paragraph") {
+			if (!isFirstParagraph) {
+				parts.push("\n");
+			}
+			isFirstParagraph = false;
+			node.forEach((child) => {
+				if (child.type.name === "fileMention") {
+					parts.push(`@${child.attrs.id}`);
+				} else if (child.isText && child.text) {
+					parts.push(child.text);
+				}
+			});
+		}
+	});
+
+	return parts.join("").trim();
+}
+
+const MENTION_PATTERN = /(?:^|(?<=\s))@([^\s@]+\.[^\s@]+)/g;
+
+function textToContent(
+	text: string,
+): { type: string; content?: unknown[]; attrs?: Record<string, unknown> }[] {
+	if (!text) return [];
+
+	const lines = text.split("\n");
+	return lines.map((line) => {
+		const content: {
+			type: string;
+			text?: string;
+			attrs?: Record<string, unknown>;
+		}[] = [];
+		let lastIndex = 0;
+
+		for (const match of line.matchAll(MENTION_PATTERN)) {
+			const matchStart = match.index;
+			const fullMatch = match[0];
+			const path = match[1];
+			const prefixStart = fullMatch.startsWith("@")
+				? matchStart
+				: matchStart + 1;
+
+			if (prefixStart > lastIndex) {
+				content.push({
+					type: "text",
+					text: line.slice(lastIndex, prefixStart),
+				});
+			}
+
+			content.push({ type: "fileMention", attrs: { id: path } });
+			lastIndex = matchStart + fullMatch.length;
+		}
+
+		if (lastIndex < line.length) {
+			content.push({ type: "text", text: line.slice(lastIndex) });
+		}
+
+		if (content.length === 0) {
+			return { type: "paragraph" };
+		}
+		return { type: "paragraph", content };
+	});
+}
+
+function textHasMentionPatterns(text: string): boolean {
+	return MENTION_PATTERN.test(text);
+}
+
+function editorHasMentions(editor: Editor): boolean {
+	let found = false;
+	editor.state.doc.descendants((node) => {
+		if (node.type.name === "fileMention") {
+			found = true;
+			return false;
+		}
+		return !found;
+	});
+	return found;
+}
+
+export interface TipTapComposerHandle {
+	insertMention: (path: string, triggerPosition?: number) => void;
+	getText: () => string;
+	clear: () => void;
+	focus: () => void;
+}
+
+interface TipTapComposerProps {
+	placeholder?: string;
+	className?: string;
+	onSubmit?: () => void;
+	composerRef?: React.RefObject<TipTapComposerHandle | null>;
+}
+
+export function TipTapComposer({
+	placeholder = "Ask to make changes, @mention files, run /commands",
+	className,
+	onSubmit,
+	composerRef,
+}: TipTapComposerProps) {
+	const controller = usePromptInputController();
+	const suppressSyncRef = useRef(false);
+	const initialText = controller.textInput.value;
+	const initialContent = textHasMentionPatterns(initialText)
+		? ({
+				type: "doc",
+				content: textToContent(initialText),
+			} as Record<string, unknown>)
+		: initialText || "";
+	const hadMentionsRef = useRef(textHasMentionPatterns(initialText));
+
+	const editor = useEditor({
+		extensions: [
+			StarterKit.configure({
+				blockquote: false,
+				bulletList: false,
+				codeBlock: false,
+				heading: false,
+				horizontalRule: false,
+				listItem: false,
+				orderedList: false,
+				bold: false,
+				italic: false,
+				strike: false,
+				code: false,
+			}),
+			FileMention,
+			Placeholder.configure({ placeholder }),
+		],
+		content: initialContent,
+		editorProps: {
+			attributes: {
+				class: [
+					"outline-none text-left text-sm w-full",
+					"min-h-10 max-h-48 overflow-y-auto",
+					"[&_p]:m-0 [&_.is-editor-empty:first-child::before]:text-muted-foreground/50",
+					"[&_.is-editor-empty:first-child::before]:content-[attr(data-placeholder)]",
+					"[&_.is-editor-empty:first-child::before]:float-left",
+					"[&_.is-editor-empty:first-child::before]:h-0",
+					"[&_.is-editor-empty:first-child::before]:pointer-events-none",
+					className ?? "",
+				].join(" "),
+			},
+			handleKeyDown(_view, event) {
+				if (event.key === "Enter" && !event.shiftKey) {
+					event.preventDefault();
+					onSubmit?.();
+					return true;
+				}
+				if (
+					(event.key === "ArrowLeft" || event.key === "ArrowRight") &&
+					(event.metaKey || event.ctrlKey)
+				) {
+					event.stopPropagation();
+				}
+				return false;
+			},
+		},
+		onUpdate({ editor: e }) {
+			suppressSyncRef.current = true;
+			if (editorHasMentions(e)) {
+				hadMentionsRef.current = true;
+			}
+			controller.textInput.setInput(editorToText(e));
+			suppressSyncRef.current = false;
+		},
+	});
+
+	// Sync external changes back to editor only when there are no mention nodes.
+	// When mentions exist (or have ever existed in this session), the editor is
+	// the source of truth — external sync would destroy the structured mention
+	// nodes by parsing @path as plain text.
+	useEffect(() => {
+		if (!editor || suppressSyncRef.current) return;
+		if (editorHasMentions(editor) || hadMentionsRef.current) return;
+
+		const currentText = editorToText(editor);
+		const externalText = controller.textInput.value;
+
+		if (currentText !== externalText) {
+			if (externalText === "") {
+				editor.commands.clearContent();
+			} else {
+				editor.commands.setContent(externalText);
+			}
+		}
+	}, [controller.textInput.value, editor]);
+
+	// Reset the mentions flag when content is fully cleared (after send)
+	useEffect(() => {
+		if (!editor) return;
+		if (
+			controller.textInput.value === "" &&
+			editorToText(editor) === "" &&
+			hadMentionsRef.current
+		) {
+			hadMentionsRef.current = false;
+		}
+	}, [controller.textInput.value, editor]);
+
+	// Expose imperative handle
+	useEffect(() => {
+		if (!editor || !composerRef) return;
+		(
+			composerRef as React.MutableRefObject<TipTapComposerHandle | null>
+		).current = {
+			insertMention(path: string, triggerPosition?: number) {
+				// Find and delete the @ trigger character in the ProseMirror doc.
+				// triggerPosition is the character offset in the plain text.
+				if (triggerPosition !== undefined && triggerPosition >= 0) {
+					let charCount = 0;
+					let deleteFrom = -1;
+					editor.state.doc.descendants((node, pos) => {
+						if (deleteFrom >= 0) return false;
+						if (node.isText && node.text) {
+							for (let i = 0; i < node.text.length; i++) {
+								if (charCount === triggerPosition) {
+									deleteFrom = pos + i;
+									return false;
+								}
+								charCount++;
+							}
+						}
+						return true;
+					});
+					if (deleteFrom >= 0) {
+						const { tr } = editor.state;
+						tr.delete(deleteFrom, deleteFrom + 1);
+						editor.view.dispatch(tr);
+					}
+				}
+
+				editor
+					.chain()
+					.focus()
+					.insertContent([
+						{ type: "fileMention", attrs: { id: path } },
+						{ type: "text", text: " " },
+					])
+					.run();
+			},
+			getText() {
+				return editorToText(editor);
+			},
+			clear() {
+				editor.commands.clearContent();
+			},
+			focus() {
+				editor.commands.focus();
+			},
+		};
+	}, [editor, composerRef]);
+
+	// Register focus with prompt input controller
+	useEffect(() => {
+		if (!editor) return;
+		const fakeTextarea = {
+			current: {
+				focus: () => editor.commands.focus(),
+				value: "",
+				setSelectionRange: () => {},
+			},
+		} as unknown as React.RefObject<HTMLTextAreaElement | null>;
+		controller.__registerTextarea(fakeTextarea);
+	}, [editor, controller]);
+
+	if (!editor) return null;
+
+	return (
+		<EditorContent
+			editor={editor}
+			data-slot="input-group-control"
+			className="flex-1 w-full text-left rounded-none border-0 bg-transparent shadow-none py-3 [&_.tiptap]:outline-none"
+		/>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ChatInputFooter/components/TipTapComposer/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ChatInputFooter/components/TipTapComposer/index.ts
@@ -1,0 +1,5 @@
+export {
+	setMentionClickHandler,
+	TipTapComposer,
+	type TipTapComposerHandle,
+} from "./TipTapComposer";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ChatMessageList/ChatMessageList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ChatMessageList/ChatMessageList.tsx
@@ -189,7 +189,8 @@ export function ChatMessageList({
 									<UserMessage
 										key={message.id}
 										message={message}
-										prefixMessages={renderedMessages.slice(0, messageIndex)}
+										allMessages={renderedMessages}
+										messageIndex={messageIndex}
 										workspaceId={workspaceId}
 										workspaceCwd={workspaceCwd}
 										isEditing={editingUserMessageId === message.id}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ChatMessageList/components/UserMessage/UserMessage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ChatMessageList/components/UserMessage/UserMessage.tsx
@@ -14,7 +14,8 @@ import { getUserMessageDraft } from "./utils/getUserMessageDraft";
 
 interface UserMessageProps {
 	message: ChatMessage;
-	prefixMessages: ChatMessage[];
+	allMessages: ChatMessage[];
+	messageIndex: number;
 	workspaceId: string;
 	workspaceCwd?: string;
 	isEditing: boolean;
@@ -28,7 +29,8 @@ interface UserMessageProps {
 
 export function UserMessage({
 	message,
-	prefixMessages,
+	allMessages,
+	messageIndex,
 	workspaceId,
 	workspaceCwd,
 	isEditing,
@@ -90,12 +92,19 @@ export function UserMessage({
 
 		void onRestart({
 			messageId: message.id,
-			prefixMessages,
+			prefixMessages: allMessages.slice(0, messageIndex),
 			payload: resendPayload,
 		}).catch((error) => {
 			console.debug("[UserMessage] resend failed", error);
 		});
-	}, [draft.files, draft.text, message.id, onRestart, prefixMessages]);
+	}, [
+		draft.files,
+		draft.text,
+		message.id,
+		onRestart,
+		allMessages,
+		messageIndex,
+	]);
 	const showActions =
 		!isEditing &&
 		Boolean(fullText || draft.files.length > 0) &&
@@ -115,7 +124,7 @@ export function UserMessage({
 					onSubmit={(payload) =>
 						onSubmitEdit({
 							messageId: message.id,
-							prefixMessages,
+							prefixMessages: allMessages.slice(0, messageIndex),
 							payload,
 						})
 					}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/MentionPopover/MentionPopover.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/MentionPopover/MentionPopover.tsx
@@ -16,6 +16,7 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "@superset/ui/popover";
+import { workspaceTrpc } from "@superset/workspace-client";
 import {
 	createContext,
 	type ReactNode,
@@ -60,11 +61,15 @@ interface MentionContextValue {
 
 const MentionContext = createContext<MentionContextValue | null>(null);
 
+const MAX_RESULTS = 20;
+
 export function MentionProvider({
 	cwd,
+	workspaceId,
 	children,
 }: {
 	cwd: string;
+	workspaceId: string;
 	children: ReactNode;
 }) {
 	const [open, setOpen] = useState(false);
@@ -83,26 +88,100 @@ export function MentionProvider({
 			setOpen(true);
 		}
 	}, [textInput.value]);
+
 	const immediateSearchQuery = searchQuery.trim();
 	const debouncedSearchQuery = useDebouncedValue(immediateSearchQuery, 120);
-	const files: Array<{ id: string; name: string; relativePath: string }> = [];
-	const isSearchPending =
-		!!cwd &&
-		immediateSearchQuery.length > 0 &&
-		immediateSearchQuery !== debouncedSearchQuery;
+	const [browsingPath, setBrowsingPath] = useState("");
+	const isSearching = immediateSearchQuery.length > 0;
 
-	const handleSelectFile = (relativePath: string) => {
+	// Directory listing when not searching (initial view or browsing a folder)
+	const absoluteBrowsePath = cwd
+		? browsingPath
+			? `${cwd}/${browsingPath}`
+			: cwd
+		: "";
+	const { data: dirResults, isFetching: isDirFetching } =
+		workspaceTrpc.filesystem.listDirectory.useQuery(
+			{ workspaceId, absolutePath: absoluteBrowsePath },
+			{
+				enabled: open && !isSearching && !!cwd,
+				staleTime: 10_000,
+			},
+		);
+
+	// File search when user types a query
+	const { data: fileResults, isFetching: isSearchFetching } =
+		workspaceTrpc.filesystem.searchFiles.useQuery(
+			{
+				workspaceId,
+				query: debouncedSearchQuery,
+				includeHidden: false,
+				limit: MAX_RESULTS,
+			},
+			{
+				enabled:
+					open && isSearching && debouncedSearchQuery.length > 0 && !!cwd,
+				staleTime: 5_000,
+			},
+		);
+
+	const dirEntries = (dirResults?.entries ?? [])
+		.filter((e) => !e.name.startsWith("."))
+		.sort((a, b) => {
+			if (a.kind !== b.kind) return a.kind === "directory" ? -1 : 1;
+			return a.name.localeCompare(b.name);
+		})
+		.slice(0, MAX_RESULTS)
+		.map((entry) => ({
+			id: entry.absolutePath,
+			name: entry.name,
+			relativePath: browsingPath ? `${browsingPath}/${entry.name}` : entry.name,
+			isDirectory: entry.kind === "directory",
+		}));
+
+	const searchEntries = (fileResults?.matches ?? []).map((match) => ({
+		id: match.relativePath,
+		name: match.name,
+		relativePath: match.relativePath,
+		isDirectory: false,
+	}));
+
+	const files = isSearching ? searchEntries : dirEntries;
+	const isSearchPending =
+		(isSearching && !!cwd && immediateSearchQuery !== debouncedSearchQuery) ||
+		isSearchFetching ||
+		isDirFetching;
+
+	const handleSelectEntry = (relativePath: string, isDirectory: boolean) => {
+		if (isDirectory) {
+			setBrowsingPath(relativePath);
+			setSearchQuery("");
+			return;
+		}
+
+		// Insert @path as plain text in the textarea
 		const current = textInput.value;
 		const before = current.slice(0, triggerIndex);
 		const after = current.slice(triggerIndex + 1);
-		textInput.setInput(`${before}@${relativePath} ${after}`);
+		textInput.setInput(`${before}@${relativePath} ${after}`.trimEnd());
+
 		setTriggerIndex(-1);
+		setBrowsingPath("");
 		setOpen(false);
 		requestAnimationFrame(() => textInput.focus());
 	};
 
+	const handleGoUp = () => {
+		const lastSlash = browsingPath.lastIndexOf("/");
+		setBrowsingPath(lastSlash === -1 ? "" : browsingPath.slice(0, lastSlash));
+		setSearchQuery("");
+	};
+
 	const handleOpenChange = (nextOpen: boolean) => {
-		if (nextOpen) setSearchQuery("");
+		if (nextOpen) {
+			setSearchQuery("");
+			setBrowsingPath("");
+		}
 		setOpen(nextOpen);
 	};
 
@@ -122,31 +201,56 @@ export function MentionProvider({
 							value={searchQuery}
 							onValueChange={setSearchQuery}
 						/>
-						<CommandList className="max-h-[200px] [&::-webkit-scrollbar]:hidden">
+						<CommandList className="max-h-[280px] [&::-webkit-scrollbar]:hidden">
+							{!isSearching && browsingPath && (
+								<CommandGroup>
+									<CommandItem onSelect={handleGoUp}>
+										<span className="text-muted-foreground">←</span>
+										<span className="truncate text-xs text-muted-foreground">
+											..
+										</span>
+									</CommandItem>
+								</CommandGroup>
+							)}
 							{files.length === 0 && (
 								<CommandEmpty className="px-2 py-3 text-left text-xs text-muted-foreground">
-									{searchQuery.length === 0
-										? "Type to search files..."
-										: isSearchPending
-											? "Searching files..."
-											: "File search is not available yet."}
+									{isSearchPending
+										? "Searching..."
+										: isSearching
+											? "No results found."
+											: "Empty directory"}
 								</CommandEmpty>
 							)}
 							{files.length > 0 && (
-								<CommandGroup heading="Files">
+								<CommandGroup
+									heading={isSearching ? "Search results" : browsingPath || "/"}
+								>
 									{files.map((file) => {
-										const dirPath = getDirectoryPath(file.relativePath);
+										const dirPath = isSearching
+											? getDirectoryPath(file.relativePath)
+											: "";
 										return (
 											<CommandItem
 												key={file.id}
 												value={file.relativePath}
-												onSelect={() => handleSelectFile(file.relativePath)}
+												onSelect={() =>
+													handleSelectEntry(file.relativePath, file.isDirectory)
+												}
 											>
-												<FileIcon
-													fileName={file.name}
-													className="size-3.5 shrink-0"
-												/>
-												<span className="truncate text-xs">{file.name}</span>
+												{file.isDirectory ? (
+													<span className="size-3.5 shrink-0 text-center text-muted-foreground">
+														📁
+													</span>
+												) : (
+													<FileIcon
+														fileName={file.name}
+														className="size-3.5 shrink-0"
+													/>
+												)}
+												<span className="truncate text-xs">
+													{file.name}
+													{file.isDirectory ? "/" : ""}
+												</span>
 												{dirPath && (
 													<span className="min-w-0 truncate font-mono text-xs text-muted-foreground">
 														{dirPath}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/types.ts
@@ -20,4 +20,7 @@ export interface ChatPaneInterfaceProps {
 	onResetSession: () => Promise<void>;
 	onUserMessageSubmitted?: (message: string) => void;
 	onRawSnapshotChange?: (snapshot: ChatRawSnapshot) => void;
+	onConsumeLaunchConfig?: () => void;
+	initialDraft?: string;
+	onDraftChange?: (draft: string) => void;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/hooks/useWorkspaceChatController/useWorkspaceChatController.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/hooks/useWorkspaceChatController/useWorkspaceChatController.ts
@@ -1,7 +1,7 @@
 import { workspaceTrpc } from "@superset/workspace-client";
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { authClient } from "renderer/lib/auth-client";
 import {
@@ -37,15 +37,31 @@ function toSessionSelectorItem(session: {
 	};
 }
 
+const MAX_SESSION_RETRIES = 3;
+const SESSION_RETRY_DELAY_MS = 1_500;
+
 async function createSessionRecord(input: {
 	sessionId: string;
 	v2WorkspaceId: string;
 }): Promise<void> {
 	if (isDesktopChatDevMode()) return;
-	await apiTrpcClient.chat.createSession.mutate({
-		sessionId: input.sessionId,
-		v2WorkspaceId: input.v2WorkspaceId,
-	});
+
+	let lastError: unknown;
+	for (let attempt = 0; attempt < MAX_SESSION_RETRIES; attempt++) {
+		try {
+			await apiTrpcClient.chat.createSession.mutate({
+				sessionId: input.sessionId,
+				v2WorkspaceId: input.v2WorkspaceId,
+			});
+			return;
+		} catch (error) {
+			lastError = error;
+			if (attempt < MAX_SESSION_RETRIES - 1) {
+				await new Promise((r) => setTimeout(r, SESSION_RETRY_DELAY_MS));
+			}
+		}
+	}
+	throw lastError;
 }
 
 async function deleteSessionRecord(sessionId: string): Promise<void> {
@@ -117,35 +133,59 @@ export function useWorkspaceChatController({
 		[onSessionIdChange, organizationId, sessionId, workspaceId],
 	);
 
+	// Pre-allocate a UUID so the pane has a sessionId ready before first send.
+	// The DB record is only created in getOrCreateSession (on first send).
+	const hasPreAllocated = useRef(false);
+	useEffect(() => {
+		if (sessionId || hasPreAllocated.current) return;
+		hasPreAllocated.current = true;
+		onSessionIdChange(crypto.randomUUID());
+	}, [sessionId, onSessionIdChange]);
+
+	const inflightSessionRef = useRef<Promise<string> | null>(null);
+
 	const getOrCreateSession = useCallback(async (): Promise<string> => {
-		if (!organizationId) {
-			throw new Error("No active organization selected");
+		if (inflightSessionRef.current) {
+			return inflightSessionRef.current;
 		}
 
-		if (sessionId) {
-			if (sessions.some((item) => item.id === sessionId)) {
+		const promise = (async (): Promise<string> => {
+			if (!organizationId) {
+				throw new Error("No active organization selected");
+			}
+
+			if (sessionId) {
+				if (sessions.some((item) => item.id === sessionId)) {
+					return sessionId;
+				}
+
+				await createSessionRecord({
+					sessionId,
+					v2WorkspaceId: workspaceId,
+				});
 				return sessionId;
 			}
 
+			const nextSessionId = crypto.randomUUID();
 			await createSessionRecord({
-				sessionId,
+				sessionId: nextSessionId,
 				v2WorkspaceId: workspaceId,
 			});
-			return sessionId;
-		}
+			onSessionIdChange(nextSessionId);
+			posthog.capture("chat_session_created", {
+				workspace_id: workspaceId,
+				session_id: nextSessionId,
+				organization_id: organizationId,
+			});
+			return nextSessionId;
+		})();
 
-		const nextSessionId = crypto.randomUUID();
-		await createSessionRecord({
-			sessionId: nextSessionId,
-			v2WorkspaceId: workspaceId,
-		});
-		onSessionIdChange(nextSessionId);
-		posthog.capture("chat_session_created", {
-			workspace_id: workspaceId,
-			session_id: nextSessionId,
-			organization_id: organizationId,
-		});
-		return nextSessionId;
+		inflightSessionRef.current = promise;
+		try {
+			return await promise;
+		} finally {
+			inflightSessionRef.current = null;
+		}
 	}, [onSessionIdChange, organizationId, sessionId, sessions, workspaceId]);
 
 	const sessionItems = useMemo(() => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/hooks/useWorkspaceChatDisplay/useWorkspaceChatDisplay.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/hooks/useWorkspaceChatDisplay/useWorkspaceChatDisplay.ts
@@ -106,21 +106,29 @@ function getLegacyImagePayload(
 	});
 }
 
+const IDLE_POLL_INTERVAL_MS = 3_000;
+
 export function useChatDisplay(options: UseChatDisplayOptions) {
 	const { sessionId, workspaceId, enabled = true, fps = 60 } = options;
 	const utils = workspaceTrpc.useUtils();
 	const [commandError, setCommandError] = useState<unknown>(null);
-	const queryInput =
-		sessionId === null ? undefined : { sessionId, workspaceId };
+	const queryInput = useMemo(
+		() => (sessionId === null ? undefined : { sessionId, workspaceId }),
+		[sessionId, workspaceId],
+	);
 	const isQueryEnabled = enabled && Boolean(sessionId);
-	const refetchIntervalMs = toRefetchIntervalMs(fps);
+	const activePollIntervalMs = toRefetchIntervalMs(fps);
+	const [isRunningForPoll, setIsRunningForPoll] = useState(false);
+	const refetchIntervalMs = isRunningForPoll
+		? activePollIntervalMs
+		: IDLE_POLL_INTERVAL_MS;
 	const queryOptions = {
 		enabled: isQueryEnabled && queryInput !== undefined,
 		refetchInterval: refetchIntervalMs,
-		refetchIntervalInBackground: true,
+		refetchIntervalInBackground: false,
 		refetchOnWindowFocus: false,
 		staleTime: 0,
-		gcTime: 0,
+		gcTime: 30_000,
 	} as const;
 
 	const displayQuery = workspaceTrpc.chat.getDisplayState.useQuery(
@@ -128,13 +136,26 @@ export function useChatDisplay(options: UseChatDisplayOptions) {
 		queryOptions,
 	);
 
+	const serverMessageCount =
+		(displayQuery.data as { messageCount?: number } | null)?.messageCount ?? -1;
+	const knownMessageCountRef = useRef(-1);
+	const shouldRefetchMessages =
+		serverMessageCount !== knownMessageCountRef.current;
+	if (shouldRefetchMessages) {
+		knownMessageCountRef.current = serverMessageCount;
+	}
+
 	const messagesQuery = workspaceTrpc.chat.listMessages.useQuery(
 		queryInput as { sessionId: string; workspaceId: string },
-		queryOptions,
+		{
+			...queryOptions,
+			refetchInterval: shouldRefetchMessages ? refetchIntervalMs : false,
+		},
 	);
 
 	const sendMessageMutation = workspaceTrpc.chat.sendMessage.useMutation();
 	const stopMutation = workspaceTrpc.chat.stop.useMutation();
+	const abortMutation = workspaceTrpc.chat.abort.useMutation();
 	const respondToApprovalMutation =
 		workspaceTrpc.chat.respondToApproval.useMutation();
 	const respondToQuestionMutation =
@@ -149,6 +170,11 @@ export function useChatDisplay(options: UseChatDisplayOptions) {
 			: null;
 	const currentMessage = displayState?.currentMessage ?? null;
 	const isRunning = displayState?.isRunning ?? false;
+
+	useEffect(() => {
+		setIsRunningForPoll(isRunning);
+	}, [isRunning]);
+
 	const isConversationLoading =
 		isQueryEnabled &&
 		messagesQuery.data === undefined &&
@@ -288,7 +314,16 @@ export function useChatDisplay(options: UseChatDisplayOptions) {
 					return;
 				}
 			},
-			abort: async () => undefined,
+			abort: async () => {
+				if (!queryInput) return;
+				setCommandError(null);
+				try {
+					return await abortMutation.mutateAsync(queryInput);
+				} catch (error) {
+					setCommandError(error);
+					return;
+				}
+			},
 			respondToApproval: async (input: {
 				payload: { decision: "approve" | "decline" | "always_allow_category" };
 			}) => {
@@ -339,6 +374,7 @@ export function useChatDisplay(options: UseChatDisplayOptions) {
 			},
 		}),
 		[
+			abortMutation,
 			historicalMessages,
 			queryInput,
 			respondToApprovalMutation,
@@ -351,9 +387,12 @@ export function useChatDisplay(options: UseChatDisplayOptions) {
 		],
 	);
 
+	const prevIsRunningRef = useRef(false);
 	useEffect(() => {
+		const wasRunning = prevIsRunningRef.current;
+		prevIsRunningRef.current = isRunning;
 		if (!queryInput) return;
-		if (!isRunning) return;
+		if (!isRunning || wasRunning) return;
 		void Promise.all([
 			utils.chat.getDisplayState.invalidate(queryInput),
 			utils.chat.listMessages.invalidate(queryInput),

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/FilePane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/FilePane.tsx
@@ -1,5 +1,5 @@
 import type { RendererContext } from "@superset/panes";
-import { useCallback } from "react";
+import { forwardRef, useCallback, useEffect, useImperativeHandle } from "react";
 import { useFileDocument } from "renderer/hooks/host-service/useFileDocument";
 import { isImageFile, isMarkdownFile } from "shared/file-types";
 import type { FilePaneData, PaneViewerData } from "../../../../types";
@@ -7,100 +7,142 @@ import { CodeRenderer } from "./renderers/CodeRenderer";
 import { ImageRenderer } from "./renderers/ImageRenderer";
 import { MarkdownRenderer } from "./renderers/MarkdownRenderer";
 
+export interface FilePaneHandle {
+	save: () => Promise<boolean>;
+}
+
+const filePaneSaveHandles = new Map<string, () => Promise<boolean>>();
+
+export function registerFilePaneSave(
+	paneId: string,
+	save: () => Promise<boolean>,
+): void {
+	filePaneSaveHandles.set(paneId, save);
+}
+
+export function unregisterFilePaneSave(paneId: string): void {
+	filePaneSaveHandles.delete(paneId);
+}
+
+export async function saveAllFilePanes(): Promise<boolean> {
+	const results = await Promise.all(
+		[...filePaneSaveHandles.values()].map((save) => save()),
+	);
+	return results.every(Boolean);
+}
+
 interface FilePaneProps {
 	context: RendererContext<PaneViewerData>;
 	workspaceId: string;
 }
 
-export function FilePane({ context, workspaceId }: FilePaneProps) {
-	const data = context.pane.data as FilePaneData;
-	const { filePath } = data;
+export const FilePane = forwardRef<FilePaneHandle, FilePaneProps>(
+	function FilePane({ context, workspaceId }, ref) {
+		const data = context.pane.data as FilePaneData;
+		const { filePath } = data;
 
-	const document = useFileDocument({
-		workspaceId,
-		absolutePath: filePath,
-		mode: isImageFile(filePath) ? "bytes" : "auto",
-		maxBytes: isImageFile(filePath) ? 10 * 1024 * 1024 : 2 * 1024 * 1024,
-		hasLocalChanges: data.hasChanges,
-		autoReloadWhenClean: true,
-	});
+		const document = useFileDocument({
+			workspaceId,
+			absolutePath: filePath,
+			mode: isImageFile(filePath) ? "bytes" : "auto",
+			maxBytes: isImageFile(filePath) ? 10 * 1024 * 1024 : 2 * 1024 * 1024,
+			hasLocalChanges: data.hasChanges,
+			autoReloadWhenClean: true,
+		});
 
-	const handleDirtyChange = useCallback(
-		(dirty: boolean) => {
-			if (dirty !== data.hasChanges) {
-				context.actions.updateData({
-					...data,
-					hasChanges: dirty,
-				} as PaneViewerData);
-			}
-		},
-		[context.actions, data],
-	);
-
-	const handleSave = useCallback(
-		async (content: string) => {
-			const result = await document.save({ content });
-			if (result.status === "saved") {
-				handleDirtyChange(false);
-			}
-			return result;
-		},
-		[document, handleDirtyChange],
-	);
-
-	if (document.state.kind === "loading") {
-		return null;
-	}
-
-	if (document.state.kind === "not-found") {
-		return (
-			<div className="flex w-full h-full items-center justify-center text-sm text-muted-foreground">
-				File not found
-			</div>
+		const handleDirtyChange = useCallback(
+			(dirty: boolean) => {
+				if (dirty !== data.hasChanges) {
+					context.actions.updateData({
+						...data,
+						hasChanges: dirty,
+					} as PaneViewerData);
+				}
+			},
+			[context.actions, data],
 		);
-	}
 
-	if (document.state.kind === "too-large") {
-		return (
-			<div className="flex w-full h-full items-center justify-center text-sm text-muted-foreground">
-				File is too large to display
-			</div>
+		const handleSave = useCallback(
+			async (content: string) => {
+				const result = await document.save({ content });
+				if (result.status === "saved") {
+					handleDirtyChange(false);
+				}
+				return result;
+			},
+			[document, handleDirtyChange],
 		);
-	}
 
-	if (document.state.kind === "binary" || document.state.kind === "bytes") {
-		if (isImageFile(filePath) && document.state.kind === "bytes") {
+		const saveImpl = useCallback(async () => {
+			if (!data.hasChanges) return true;
+			const state = document.state;
+			if (state.kind !== "text") return false;
+			const result = await handleSave(state.content);
+			return result.status === "saved";
+		}, [data.hasChanges, document.state, handleSave]);
+
+		useImperativeHandle(ref, () => ({ save: saveImpl }), [saveImpl]);
+
+		const paneId = context.pane.id;
+		useEffect(() => {
+			registerFilePaneSave(paneId, saveImpl);
+			return () => unregisterFilePaneSave(paneId);
+		}, [paneId, saveImpl]);
+
+		if (document.state.kind === "loading") {
+			return null;
+		}
+
+		if (document.state.kind === "not-found") {
 			return (
-				<ImageRenderer content={document.state.content} filePath={filePath} />
+				<div className="flex w-full h-full items-center justify-center text-sm text-muted-foreground">
+					File not found
+				</div>
 			);
 		}
-		return (
-			<div className="flex w-full h-full items-center justify-center text-sm text-muted-foreground">
-				Binary file — cannot display
-			</div>
-		);
-	}
 
-	if (isMarkdownFile(filePath)) {
+		if (document.state.kind === "too-large") {
+			return (
+				<div className="flex w-full h-full items-center justify-center text-sm text-muted-foreground">
+					File is too large to display
+				</div>
+			);
+		}
+
+		if (document.state.kind === "binary" || document.state.kind === "bytes") {
+			if (isImageFile(filePath) && document.state.kind === "bytes") {
+				return (
+					<ImageRenderer content={document.state.content} filePath={filePath} />
+				);
+			}
+			return (
+				<div className="flex w-full h-full items-center justify-center text-sm text-muted-foreground">
+					Binary file — cannot display
+				</div>
+			);
+		}
+
+		if (isMarkdownFile(filePath)) {
+			return (
+				<MarkdownRenderer
+					content={document.state.content}
+					hasExternalChange={document.hasExternalChange}
+					onDirtyChange={handleDirtyChange}
+					onReload={document.reload}
+					onSave={handleSave}
+				/>
+			);
+		}
+
 		return (
-			<MarkdownRenderer
+			<CodeRenderer
 				content={document.state.content}
+				filePath={filePath}
 				hasExternalChange={document.hasExternalChange}
 				onDirtyChange={handleDirtyChange}
 				onReload={document.reload}
 				onSave={handleSave}
 			/>
 		);
-	}
-
-	return (
-		<CodeRenderer
-			content={document.state.content}
-			filePath={filePath}
-			hasExternalChange={document.hasExternalChange}
-			onDirtyChange={handleDirtyChange}
-			onReload={document.reload}
-			onSave={handleSave}
-		/>
-	);
-}
+	},
+);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/index.ts
@@ -1,1 +1,1 @@
-export { FilePane } from "./FilePane";
+export { FilePane, type FilePaneHandle, saveAllFilePanes } from "./FilePane";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -1,11 +1,12 @@
 import type {
 	ContextMenuActionConfig,
+	Pane,
 	PaneRegistry,
 	RendererContext,
 } from "@superset/panes";
 import { alert } from "@superset/ui/atoms/Alert";
 import { Circle, Globe, MessageSquare, TerminalSquare } from "lucide-react";
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import {
 	LuArrowDownToLine,
 	LuClipboard,
@@ -13,8 +14,11 @@ import {
 	LuEraser,
 } from "react-icons/lu";
 import { useHotkeyDisplay } from "renderer/hotkeys";
+import { getHostServiceHeaders } from "renderer/lib/host-service-auth";
 import { terminalRuntimeRegistry } from "renderer/lib/terminal/terminal-runtime-registry";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { FileIcon } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils";
+import superjson from "superjson";
 import type {
 	BrowserPaneData,
 	ChatPaneData,
@@ -24,8 +28,29 @@ import type {
 	TerminalPaneData,
 } from "../../types";
 import { ChatPane } from "./components/ChatPane";
-import { FilePane } from "./components/FilePane";
+import { FilePane, saveAllFilePanes } from "./components/FilePane";
 import { TerminalPane } from "./components/TerminalPane";
+
+function releaseChatRuntime(
+	hostUrl: string,
+	sessionId: string,
+	workspaceId: string,
+): void {
+	const headers = getHostServiceHeaders(hostUrl);
+	const body = {
+		0: superjson.serialize({ sessionId, workspaceId }),
+	};
+	fetch(`${hostUrl}/trpc/chat.releaseSession?batch=1`, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			...headers,
+		},
+		body: JSON.stringify(body),
+	}).catch((error) => {
+		console.warn("Failed to release chat runtime:", error);
+	});
+}
 
 function getFileName(filePath: string): string {
 	return filePath.split("/").pop() ?? filePath;
@@ -40,6 +65,9 @@ export function usePaneRegistry(
 ): PaneRegistry<PaneViewerData> {
 	const clearShortcut = useHotkeyDisplay("CLEAR_TERMINAL").text;
 	const scrollToBottomShortcut = useHotkeyDisplay("SCROLL_TO_BOTTOM").text;
+	const { activeHostUrl } = useLocalHostService();
+	const hostUrlRef = useRef(activeHostUrl);
+	hostUrlRef.current = activeHostUrl;
 
 	return useMemo<PaneRegistry<PaneViewerData>>(
 		() => ({
@@ -79,8 +107,8 @@ export function usePaneRegistry(
 							actions: [
 								{
 									label: "Save",
-									onClick: () => {
-										// TODO: wire up save via editor ref
+									onClick: async () => {
+										await saveAllFilePanes();
 										resolve(true);
 									},
 								},
@@ -212,8 +240,30 @@ export function usePaneRegistry(
 							}
 							sessionId={data.sessionId}
 							workspaceId={workspaceId}
+							isFocused={ctx.isActive}
+							initialDraft={data.draft}
+							onDraftChange={(draft) =>
+								ctx.actions.updateData({
+									...data,
+									draft,
+								} as PaneViewerData)
+							}
+							initialLaunchConfig={data.launchConfig ?? null}
+							onConsumeLaunchConfig={() =>
+								ctx.actions.updateData({
+									...data,
+									launchConfig: null,
+								} as PaneViewerData)
+							}
 						/>
 					);
+				},
+				onBeforeClose: (pane: Pane<PaneViewerData>) => {
+					const data = pane.data as ChatPaneData;
+					if (data.sessionId && hostUrlRef.current) {
+						releaseChatRuntime(hostUrlRef.current, data.sessionId, workspaceId);
+					}
+					return true;
 				},
 				contextMenuActions: (_ctx, defaults) =>
 					defaults.map((d) =>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/useV2WorkspacePaneLayout.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/useV2WorkspacePaneLayout.ts
@@ -66,28 +66,39 @@ export function useV2WorkspacePaneLayout({
 		store.getState().replaceState(persistedPaneLayout);
 	}, [persistedPaneLayout, store]);
 
+	const pendingLayoutRef = useRef<WorkspaceState<PaneViewerData> | null>(null);
+
+	// Flush any queued layout update once the local state record appears
+	useEffect(() => {
+		if (!localWorkspaceState || !pendingLayoutRef.current) return;
+		const pending = pendingLayoutRef.current;
+		pendingLayoutRef.current = null;
+		collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
+			draft.paneLayout = pending;
+		});
+		lastSyncedSnapshotRef.current = getSnapshot(pending);
+	}, [localWorkspaceState, collections, workspaceId]);
+
 	useEffect(() => {
 		const unsubscribe = store.subscribe((nextStore) => {
-			const nextSnapshot = getSnapshot({
+			const layout = {
 				version: nextStore.version,
 				tabs: nextStore.tabs,
 				activeTabId: nextStore.activeTabId,
-			});
+			};
+			const nextSnapshot = getSnapshot(layout);
 			if (nextSnapshot === lastSyncedSnapshotRef.current) {
 				return;
 			}
 
 			ensureWorkspaceInSidebar(workspaceId, projectId);
 			if (!collections.v2WorkspaceLocalState.get(workspaceId)) {
+				pendingLayoutRef.current = layout;
 				return;
 			}
 
 			collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
-				draft.paneLayout = {
-					version: nextStore.version,
-					tabs: nextStore.tabs,
-					activeTabId: nextStore.activeTabId,
-				};
+				draft.paneLayout = layout;
 			});
 			lastSyncedSnapshotRef.current = nextSnapshot;
 		});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -22,6 +22,7 @@ import { WorkspaceNotFoundState } from "./components/WorkspaceNotFoundState";
 import { WorkspaceSidebar } from "./components/WorkspaceSidebar";
 import { useDefaultContextMenuActions } from "./hooks/useDefaultContextMenuActions";
 import { usePaneRegistry } from "./hooks/usePaneRegistry";
+import { saveAllFilePanes } from "./hooks/usePaneRegistry/components/FilePane";
 import { useV2WorkspacePaneLayout } from "./hooks/useV2WorkspacePaneLayout";
 import { useWorkspaceHotkeys } from "./hooks/useWorkspaceHotkeys";
 import type {
@@ -255,8 +256,8 @@ function WorkspaceContent({
 										actions: [
 											{
 												label: "Save All",
-												onClick: () => {
-													// TODO: wire up save via editor refs
+												onClick: async () => {
+													await saveAllFilePanes();
 													resolve(true);
 												},
 											},

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
@@ -10,8 +10,23 @@ export interface TerminalPaneData {
 	initialCommand?: string;
 }
 
+export interface ChatLaunchConfig {
+	initialPrompt?: string;
+	draftInput?: string;
+	initialFiles?: Array<{
+		data: string;
+		mediaType: string;
+		filename?: string;
+	}>;
+	metadata?: {
+		model?: string;
+	};
+}
+
 export interface ChatPaneData {
 	sessionId: string | null;
+	draft?: string;
+	launchConfig?: ChatLaunchConfig | null;
 }
 
 export interface BrowserPaneData {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
@@ -26,7 +26,7 @@ function V2WorkspaceLayout() {
 	const workspaceId =
 		workspaceMatch !== false ? workspaceMatch.workspaceId : null;
 	const collections = useCollections();
-	const { machineId, activeHostUrl } = useLocalHostService();
+	const { machineId, activeHostUrl, status } = useLocalHostService();
 	const { ensureWorkspaceInSidebar } = useDashboardSidebarState();
 
 	const { data: workspacesWithHost = [] } = useLiveQuery(
@@ -69,9 +69,22 @@ function V2WorkspaceLayout() {
 	}
 
 	if (!hostUrl) {
+		if (isLocal && status === "starting") {
+			return (
+				<div className="flex h-full w-full items-center justify-center text-muted-foreground">
+					<div className="flex flex-col items-center gap-2">
+						<div className="size-5 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent" />
+						<span>Starting workspace host service...</span>
+					</div>
+				</div>
+			);
+		}
+		const message = isLocal
+			? "Workspace host service not available"
+			: "Host machine is offline — the remote workspace is not reachable";
 		return (
 			<div className="flex h-full w-full items-center justify-center text-muted-foreground">
-				Workspace host service not available
+				{message}
 			</div>
 		);
 	}

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
@@ -117,7 +117,8 @@ export interface OrgCollections {
 	>;
 }
 
-// Per-org collections cache
+// Per-org collections cache (LRU, max 3 entries)
+const MAX_COLLECTIONS_CACHE_SIZE = 3;
 const collectionsCache = new Map<string, OrgCollections>();
 
 function getCollectionsCacheKey(organizationId: string): string {
@@ -595,8 +596,17 @@ export async function preloadCollections(
 export function getCollections(organizationId: string) {
 	const cacheKey = getCollectionsCacheKey(organizationId);
 
-	// Get or create org-specific collections
-	if (!collectionsCache.has(cacheKey)) {
+	// Get or create org-specific collections (LRU: re-insert to move to end)
+	const existing = collectionsCache.get(cacheKey);
+	if (existing) {
+		collectionsCache.delete(cacheKey);
+		collectionsCache.set(cacheKey, existing);
+	} else {
+		// Evict oldest if at capacity
+		if (collectionsCache.size >= MAX_COLLECTIONS_CACHE_SIZE) {
+			const oldestKey = collectionsCache.keys().next().value;
+			if (oldestKey) collectionsCache.delete(oldestKey);
+		}
 		collectionsCache.set(cacheKey, createOrgCollections(organizationId));
 	}
 

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/LocalHostServiceProvider/LocalHostServiceProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/LocalHostServiceProvider/LocalHostServiceProvider.tsx
@@ -13,9 +13,12 @@ import { setHostServiceSecret } from "renderer/lib/host-service-auth";
 import { MOCK_ORG_ID } from "shared/constants";
 import { useCollections } from "../CollectionsProvider";
 
+export type HostServiceStatus = "starting" | "running" | "stopped";
+
 interface LocalHostServiceContextValue {
 	machineId: string | null;
 	activeHostUrl: string | null;
+	status: HostServiceStatus;
 }
 
 const LocalHostServiceContext =
@@ -51,15 +54,28 @@ export function LocalHostServiceProvider({
 		}
 	}, [organizationIds, startHostService]);
 
+	const { data: machineIdData } =
+		electronTrpc.hostServiceCoordinator.getMachineId.useQuery();
+
 	const { data: activeConnection } =
 		electronTrpc.hostServiceCoordinator.getConnection.useQuery(
 			{ organizationId: activeOrganizationId as string },
 			{ enabled: !!activeOrganizationId, refetchInterval: 5_000 },
 		);
 
+	const { data: processStatusData } =
+		electronTrpc.hostServiceCoordinator.getProcessStatus.useQuery(
+			{ organizationId: activeOrganizationId as string },
+			{ enabled: !!activeOrganizationId, refetchInterval: 5_000 },
+		);
+
 	const value = useMemo(() => {
+		const status: HostServiceStatus =
+			(processStatusData?.status as HostServiceStatus) ?? "stopped";
+		const resolvedMachineId = machineIdData?.machineId ?? null;
+
 		if (!activeConnection?.port) {
-			return { machineId: null, activeHostUrl: null };
+			return { machineId: resolvedMachineId, activeHostUrl: null, status };
 		}
 
 		const activeHostUrl = `http://127.0.0.1:${activeConnection.port}`;
@@ -68,10 +84,11 @@ export function LocalHostServiceProvider({
 		}
 
 		return {
-			machineId: activeConnection.machineId ?? null,
+			machineId: resolvedMachineId,
 			activeHostUrl,
+			status,
 		};
-	}, [activeConnection]);
+	}, [activeConnection, processStatusData, machineIdData]);
 
 	return (
 		<LocalHostServiceContext.Provider value={value}>

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -51,6 +51,7 @@ import {
 	resolveActiveTabIdForWorkspace,
 	resolveFileViewerMode,
 } from "./utils";
+import { releaseChatSessionForPane } from "./utils/chat-cleanup";
 import { killTerminalForPane } from "./utils/terminal-cleanup";
 
 /**
@@ -1064,10 +1065,17 @@ export const useTabsStore = create<TabsStore>()(
 					// Must get adjacent pane BEFORE removing from layout
 					const adjacentPaneId = getAdjacentPaneId(tab.layout, paneId);
 
-					// Kill terminal sessions for terminal panes
+					// Kill terminal sessions and release chat runtimes for removed panes
 					for (const id of paneIdsToRemove) {
-						if (state.panes[id]?.type === "terminal") {
+						const paneToRemove = state.panes[id];
+						if (paneToRemove?.type === "terminal") {
 							killTerminalForPane(id);
+						}
+						if (paneToRemove?.type === "chat") {
+							const chatSessionId = paneToRemove.chat?.sessionId;
+							if (chatSessionId) {
+								releaseChatSessionForPane(chatSessionId);
+							}
 						}
 
 						cleanupEditorPaneState(id);

--- a/apps/desktop/src/renderer/stores/tabs/utils/chat-cleanup.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils/chat-cleanup.ts
@@ -1,0 +1,41 @@
+import { createChatRuntimeServiceClient } from "@superset/chat/client";
+import type { ChatRuntimeServiceRouter } from "@superset/chat/server/trpc";
+import type { TRPCLink } from "@trpc/client";
+import type { AnyRouter } from "@trpc/server";
+import { observable } from "@trpc/server/observable";
+import { sessionIdLink } from "renderer/lib/session-id-link";
+import superjson from "superjson";
+import { ipcLink } from "trpc-electron/renderer";
+
+function prefixLink<TRouter extends AnyRouter>(
+	prefix: string,
+): TRPCLink<TRouter> {
+	return () =>
+		({ op, next }) =>
+			observable((observer) =>
+				next({ ...op, path: `${prefix}.${op.path}` }).subscribe(observer),
+			);
+}
+
+let chatClient: ReturnType<typeof createChatRuntimeServiceClient> | null = null;
+
+function getChatClient() {
+	if (!chatClient) {
+		chatClient = createChatRuntimeServiceClient({
+			links: [
+				prefixLink<ChatRuntimeServiceRouter>("chatRuntimeService"),
+				sessionIdLink(),
+				ipcLink({ transformer: superjson }),
+			],
+		});
+	}
+	return chatClient;
+}
+
+export const releaseChatSessionForPane = (sessionId: string): void => {
+	getChatClient()
+		.session.releaseSession.mutate({ sessionId })
+		.catch((error) => {
+			console.warn(`Failed to release chat session ${sessionId}:`, error);
+		});
+};

--- a/bun.lock
+++ b/bun.lock
@@ -754,6 +754,7 @@
         "@hono/node-ws": "^1.3.0",
         "@hono/trpc-server": "^0.3.4",
         "@octokit/rest": "^22.0.1",
+        "@superset/chat": "workspace:*",
         "@superset/shared": "workspace:*",
         "@superset/trpc": "workspace:*",
         "@superset/workspace-fs": "workspace:*",

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -23,6 +23,10 @@
 		"./server/hono": {
 			"types": "./src/server/hono/index.ts",
 			"default": "./src/server/hono/index.ts"
+		},
+		"./server/slash-commands": {
+			"types": "./src/server/desktop/slash-commands/index.ts",
+			"default": "./src/server/desktop/slash-commands/index.ts"
 		}
 	},
 	"scripts": {

--- a/packages/chat/src/client/hooks/use-chat-display/use-chat-display.ts
+++ b/packages/chat/src/client/hooks/use-chat-display/use-chat-display.ts
@@ -112,6 +112,8 @@ function getLegacyImagePayload(
 	});
 }
 
+const IDLE_POLL_INTERVAL_MS = 3_000;
+
 export function useChatDisplay(options: UseChatDisplayOptions) {
 	const { sessionId, cwd, enabled = true, fps = 60 } = options;
 	const utils = chatRuntimeServiceTrpc.useUtils();
@@ -120,14 +122,18 @@ export function useChatDisplay(options: UseChatDisplayOptions) {
 		sessionId === null ? null : { sessionId, ...(cwd ? { cwd } : {}) };
 	const queryInput = sessionCommandInput ?? skipToken;
 	const isQueryEnabled = enabled && Boolean(sessionId);
-	const refetchIntervalMs = toRefetchIntervalMs(fps);
+	const activePollIntervalMs = toRefetchIntervalMs(fps);
+	const [isRunningForPoll, setIsRunningForPoll] = useState(false);
+	const refetchIntervalMs = isRunningForPoll
+		? activePollIntervalMs
+		: IDLE_POLL_INTERVAL_MS;
 	const queryOptions = {
 		enabled: isQueryEnabled,
 		refetchInterval: refetchIntervalMs,
-		refetchIntervalInBackground: true,
+		refetchIntervalInBackground: false,
 		refetchOnWindowFocus: false,
 		staleTime: 0,
-		gcTime: 0,
+		gcTime: 30_000,
 	} as const;
 
 	const displayQuery = chatRuntimeServiceTrpc.session.getDisplayState.useQuery(
@@ -135,9 +141,21 @@ export function useChatDisplay(options: UseChatDisplayOptions) {
 		queryOptions,
 	);
 
+	const serverMessageCount =
+		(displayQuery.data as { messageCount?: number } | null)?.messageCount ?? -1;
+	const knownMessageCountRef = useRef(-1);
+	const shouldRefetchMessages =
+		serverMessageCount !== knownMessageCountRef.current;
+	if (shouldRefetchMessages) {
+		knownMessageCountRef.current = serverMessageCount;
+	}
+
 	const messagesQuery = chatRuntimeServiceTrpc.session.listMessages.useQuery(
 		queryInput,
-		queryOptions,
+		{
+			...queryOptions,
+			refetchInterval: shouldRefetchMessages ? refetchIntervalMs : false,
+		},
 	);
 
 	const displayState = displayQuery.data ?? null;
@@ -148,6 +166,11 @@ export function useChatDisplay(options: UseChatDisplayOptions) {
 			: null;
 	const currentMessage = displayState?.currentMessage ?? null;
 	const isRunning = displayState?.isRunning ?? false;
+
+	useEffect(() => {
+		setIsRunningForPoll(isRunning);
+	}, [isRunning]);
+
 	const isConversationLoading =
 		isQueryEnabled &&
 		messagesQuery.data === undefined &&

--- a/packages/chat/src/server/trpc/service.ts
+++ b/packages/chat/src/server/trpc/service.ts
@@ -63,12 +63,15 @@ export interface ChatRuntimeServiceOptions {
 	onLifecycleEvent?: (event: LifecycleEvent) => void;
 }
 
+const IDLE_EVICTION_MS = 10 * 60 * 1_000; // 10 minutes
+
 export class ChatRuntimeService {
 	private readonly runtimes = new Map<string, RuntimeSession>();
 	private readonly runtimeCreations = new Map<
 		string,
 		Promise<RuntimeSession>
 	>();
+	private readonly lastPolledAt = new Map<string, number>();
 	private readonly apiClient: ReturnType<typeof createTRPCClient<AppRouter>>;
 
 	constructor(readonly opts: ChatRuntimeServiceOptions) {
@@ -83,6 +86,32 @@ export class ChatRuntimeService {
 				}),
 			],
 		});
+		this.startIdleEviction();
+	}
+
+	private startIdleEviction(): void {
+		setInterval(() => {
+			const now = Date.now();
+			for (const [sessionId, lastPoll] of this.lastPolledAt) {
+				if (now - lastPoll > IDLE_EVICTION_MS) {
+					this.destroySessionRuntime(sessionId);
+				}
+			}
+		}, 60_000);
+	}
+
+	private touchSession(sessionId: string): void {
+		this.lastPolledAt.set(sessionId, Date.now());
+	}
+
+	destroySessionRuntime(sessionId: string): void {
+		const runtime = this.runtimes.get(sessionId);
+		if (runtime) {
+			destroyRuntime(runtime).catch(() => {});
+			this.runtimes.delete(sessionId);
+		}
+		this.lastPolledAt.delete(sessionId);
+		this.runtimeCreations.delete(sessionId);
 	}
 
 	private async getOrCreateRuntime(
@@ -141,6 +170,7 @@ export class ChatRuntimeService {
 					mcpManualStatuses: new Map(),
 					lastErrorMessage: null,
 					pendingSandboxQuestion: null,
+					lastKnownMessageCount: 0,
 					cwd: runtimeCwd,
 				};
 				syncRuntimeHookSessionId(sessionRuntime);
@@ -205,6 +235,7 @@ export class ChatRuntimeService {
 				getDisplayState: t.procedure
 					.input(displayStateInput)
 					.query(async ({ input }) => {
+						this.touchSession(input.sessionId);
 						const runtime = await this.getOrCreateRuntime(
 							input.sessionId,
 							input.cwd,
@@ -242,17 +273,21 @@ export class ChatRuntimeService {
 							pendingQuestion:
 								displayState.pendingQuestion ?? sandboxPendingQuestion,
 							errorMessage: currentMessageError ?? runtime.lastErrorMessage,
+							messageCount: (await runtime.harness.listMessages()).length,
 						};
 					}),
 
 				listMessages: t.procedure
 					.input(listMessagesInput)
 					.query(async ({ input }) => {
+						this.touchSession(input.sessionId);
 						const runtime = await this.getOrCreateRuntime(
 							input.sessionId,
 							input.cwd,
 						);
-						return runtime.harness.listMessages();
+						const messages = await runtime.harness.listMessages();
+						runtime.lastKnownMessageCount = messages.length;
+						return messages;
 					}),
 
 				sendMessage: t.procedure
@@ -369,6 +404,12 @@ export class ChatRuntimeService {
 							return runtime.harness.respondToPlanApproval(input.payload);
 						}),
 				}),
+
+				releaseSession: t.procedure
+					.input(sessionIdInput)
+					.mutation(async ({ input }) => {
+						this.destroySessionRuntime(input.sessionId);
+					}),
 			}),
 		});
 	}

--- a/packages/chat/src/server/trpc/utils/runtime/runtime.ts
+++ b/packages/chat/src/server/trpc/utils/runtime/runtime.ts
@@ -33,6 +33,7 @@ export interface RuntimeSession {
 		reason: string;
 	} | null;
 	cwd: string;
+	lastKnownMessageCount: number;
 }
 
 export function syncRuntimeHookSessionId(runtime: RuntimeSession): void {

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -45,6 +45,7 @@
 		"@hono/node-ws": "^1.3.0",
 		"@hono/trpc-server": "^0.3.4",
 		"@octokit/rest": "^22.0.1",
+		"@superset/chat": "workspace:*",
 		"@superset/shared": "workspace:*",
 		"@superset/trpc": "workspace:*",
 		"@superset/workspace-fs": "workspace:*",

--- a/packages/host-service/src/app.ts
+++ b/packages/host-service/src/app.ts
@@ -67,6 +67,7 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 	const chatRuntime = new ChatRuntimeManager({
 		db,
 		runtimeResolver: providers.modelResolver,
+		apiClient: api,
 	});
 
 	const runtime = {

--- a/packages/host-service/src/runtime/chat/chat.ts
+++ b/packages/host-service/src/runtime/chat/chat.ts
@@ -1,8 +1,13 @@
+import {
+	getSlashCommands as getSlashCommandsFromCwd,
+	resolveSlashCommand as resolveSlashCommandFromCwd,
+} from "@superset/chat/server/slash-commands";
 import { eq } from "drizzle-orm";
 import { createMastraCode } from "mastracode";
 import type { HostDb } from "../../db";
 import { workspaces } from "../../db/schema";
 import type { ModelProviderRuntimeResolver } from "../../providers/model-providers";
+import type { ApiClient } from "../../types";
 
 type RuntimeHarness = Awaited<ReturnType<typeof createMastraCode>>["harness"];
 type RuntimeMcpManager = Awaited<
@@ -71,6 +76,7 @@ export type ChatDisplayState = RuntimeDisplayState & {
 		| ChatPendingQuestion
 		| null;
 	errorMessage: string | null;
+	messageCount: number;
 };
 
 interface ChatApprovalPayload {
@@ -97,8 +103,10 @@ interface RuntimeSession {
 	harness: RuntimeHarness;
 	mcpManager: RuntimeMcpManager;
 	hookManager: RuntimeHookManager;
+	mcpManualStatuses: Map<string, string>;
 	lastErrorMessage: string | null;
 	pendingSandboxQuestion: PendingSandboxQuestion | null;
+	lastKnownMessageCount: number;
 }
 
 interface RuntimeStoredMessage {
@@ -144,6 +152,7 @@ interface HarnessWithConfig {
 export interface ChatRuntimeManagerOptions {
 	db: HostDb;
 	runtimeResolver: ModelProviderRuntimeResolver;
+	apiClient: ApiClient;
 }
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
@@ -306,18 +315,60 @@ async function restartRuntimeFromUserMessage(
 	await runtime.harness.sendMessage(input.payload);
 }
 
+const IDLE_EVICTION_MS = 10 * 60 * 1_000; // 10 minutes
+
 export class ChatRuntimeManager {
 	private readonly db: HostDb;
 	private readonly runtimeResolver: ModelProviderRuntimeResolver;
+	private readonly apiClient: ApiClient;
 	private readonly runtimes = new Map<string, RuntimeSession>();
 	private readonly runtimeCreations = new Map<
 		string,
 		Promise<RuntimeSession>
 	>();
+	private readonly lastPolledAt = new Map<string, number>();
 
 	constructor(options: ChatRuntimeManagerOptions) {
 		this.db = options.db;
 		this.runtimeResolver = options.runtimeResolver;
+		this.apiClient = options.apiClient;
+		this.startIdleEviction();
+	}
+
+	private startIdleEviction(): void {
+		setInterval(() => {
+			const now = Date.now();
+			for (const [sessionId, lastPoll] of this.lastPolledAt) {
+				if (now - lastPoll > IDLE_EVICTION_MS) {
+					this.destroySession(sessionId);
+				}
+			}
+		}, 60_000);
+	}
+
+	private touchSession(sessionId: string): void {
+		this.lastPolledAt.set(sessionId, Date.now());
+	}
+
+	destroySession(sessionId: string): void {
+		const runtime = this.runtimes.get(sessionId);
+		if (runtime) {
+			try {
+				runtime.harness.abort();
+			} catch {
+				// best-effort
+			}
+			if (runtime.hookManager) {
+				runtime.hookManager.runSessionEnd().catch(() => {});
+			}
+			const harnessWithDestroy = runtime.harness as RuntimeHarness & {
+				destroy?: () => Promise<void>;
+			};
+			harnessWithDestroy.destroy?.().catch(() => {});
+			this.runtimes.delete(sessionId);
+		}
+		this.lastPolledAt.delete(sessionId);
+		this.runtimeCreations.delete(sessionId);
 	}
 
 	private subscribeToSessionEvents(runtime: RuntimeSession): void {
@@ -344,8 +395,39 @@ export class ChatRuntimeManager {
 
 			if (isObjectRecord(event) && event.type === "agent_end") {
 				runtime.pendingSandboxQuestion = null;
+				if (runtime.hookManager) {
+					const raw = (event as { reason?: string }).reason;
+					const reason =
+						raw === "aborted" || raw === "error" ? raw : "complete";
+					void runtime.hookManager.runStop(undefined, reason).catch(() => {});
+				}
 			}
 		});
+	}
+
+	private reloadHookConfig(runtime: RuntimeSession): void {
+		if (!runtime.hookManager) return;
+		try {
+			runtime.hookManager.reload();
+		} catch {
+			// Best-effort — swallow reload failures
+		}
+	}
+
+	private async runSessionStartHook(runtime: RuntimeSession): Promise<void> {
+		if (!runtime.hookManager) return;
+		await runtime.hookManager.runSessionStart();
+	}
+
+	private async onUserPromptSubmit(
+		runtime: RuntimeSession,
+		userMessage: string,
+	): Promise<void> {
+		if (!runtime.hookManager) return;
+		const result = await runtime.hookManager.runUserPromptSubmit(userMessage);
+		if (!result.allowed) {
+			throw new Error(result.blockReason ?? "Blocked by UserPromptSubmit hook");
+		}
 	}
 
 	private async createRuntime(
@@ -370,7 +452,6 @@ export class ChatRuntimeManager {
 
 		const runtime = await createMastraCode({
 			cwd,
-			disableMcp: true,
 		});
 		runtime.hookManager?.setSessionId(sessionId);
 		await runtime.harness.init();
@@ -384,10 +465,13 @@ export class ChatRuntimeManager {
 			harness: runtime.harness,
 			mcpManager: runtime.mcpManager,
 			hookManager: runtime.hookManager,
+			mcpManualStatuses: new Map(),
 			lastErrorMessage: null,
 			pendingSandboxQuestion: null,
+			lastKnownMessageCount: 0,
 		};
 		this.subscribeToSessionEvents(sessionRuntime);
+		await this.runSessionStartHook(sessionRuntime).catch(() => {});
 		this.runtimes.set(sessionId, sessionRuntime);
 		return sessionRuntime;
 	}
@@ -403,6 +487,7 @@ export class ChatRuntimeManager {
 					`Session ${sessionId} is already bound to workspace ${existing.workspaceId}`,
 				);
 			}
+			this.reloadHookConfig(existing);
 			return existing;
 		}
 
@@ -422,6 +507,7 @@ export class ChatRuntimeManager {
 		sessionId: string;
 		workspaceId: string;
 	}): Promise<ChatDisplayState> {
+		this.touchSession(input.sessionId);
 		const runtime = await this.getOrCreateRuntime(
 			input.sessionId,
 			input.workspaceId,
@@ -459,6 +545,7 @@ export class ChatRuntimeManager {
 						}
 					: null),
 			errorMessage: currentMessageError ?? runtime.lastErrorMessage,
+			messageCount: (await runtime.harness.listMessages()).length,
 		};
 	}
 
@@ -466,11 +553,98 @@ export class ChatRuntimeManager {
 		sessionId: string;
 		workspaceId: string;
 	}): Promise<RuntimeMessages> {
+		this.touchSession(input.sessionId);
 		const runtime = await this.getOrCreateRuntime(
 			input.sessionId,
 			input.workspaceId,
 		);
-		return runtime.harness.listMessages();
+		const messages = await runtime.harness.listMessages();
+		runtime.lastKnownMessageCount = messages.length;
+		return messages;
+	}
+
+	private async generateAndSetTitle(
+		runtime: RuntimeSession,
+		submittedUserMessage?: string,
+	): Promise<void> {
+		try {
+			const messages = await runtime.harness.listMessages();
+			const userMessages = messages.filter(
+				(m: { role: string }) => m.role === "user",
+			);
+			let userCount = userMessages.length;
+			if (
+				submittedUserMessage &&
+				!userMessages.some(
+					(m: { content: Array<{ type: string; text?: string }> }) =>
+						m.content.some(
+							(p) => p.type === "text" && p.text === submittedUserMessage,
+						),
+				)
+			) {
+				userCount += 1;
+			}
+
+			const isFirst = userCount === 1;
+			const isRename = userCount > 1 && userCount % 10 === 0;
+			if (!isFirst && !isRename) return;
+
+			let text: string;
+			if (isFirst) {
+				const firstMsg = userMessages[0] ?? {
+					content: [{ type: "text", text: submittedUserMessage ?? "" }],
+				};
+				text = (firstMsg.content as Array<{ type: string; text?: string }>)
+					.filter((p) => p.type === "text")
+					.map((p) => p.text ?? "")
+					.join(" ")
+					.slice(0, 500);
+			} else {
+				text = messages
+					.slice(-10)
+					.map(
+						(m: {
+							role: string;
+							content: Array<{ type: string; text?: string }>;
+						}) => {
+							const txt = m.content
+								.filter((p) => p.type === "text")
+								.map((p) => p.text ?? "")
+								.join(" ");
+							return `${m.role}: ${txt}`;
+						},
+					)
+					.join("\n")
+					.slice(0, 2000);
+			}
+			if (!text.trim()) return;
+
+			const mode = runtime.harness.getCurrentMode();
+			const agent =
+				typeof mode.agent === "function"
+					? mode.agent(runtime.harness.getState() as never)
+					: mode.agent;
+
+			const title = await (
+				agent as {
+					generateTitleFromUserMessage: (args: {
+						message: string;
+						model?: string;
+					}) => Promise<string | null | undefined>;
+				}
+			).generateTitleFromUserMessage({
+				message: text,
+				model: runtime.harness.getFullModelId(),
+			});
+			if (!title?.trim()) return;
+
+			await this.apiClient.chat.updateTitle.mutate({
+				sessionId: runtime.sessionId,
+				title: title.trim(),
+			});
+		} catch (error) {
+			console.warn("[chat] Title generation failed:", error);
+		}
 	}
 
 	async sendMessage(
@@ -481,6 +655,9 @@ export class ChatRuntimeManager {
 			input.workspaceId,
 		);
 		runtime.lastErrorMessage = null;
+
+		const userMessage = input.payload.content.trim() || "[non-text message]";
+		await this.onUserPromptSubmit(runtime, userMessage);
 
 		const selectedModel = input.metadata?.model?.trim();
 		if (selectedModel) {
@@ -495,6 +672,12 @@ export class ChatRuntimeManager {
 			await runtime.harness.setState({ thinkingLevel });
 		}
 
+		const submittedUserMessage = input.payload.content.trim();
+		void this.generateAndSetTitle(
+			runtime,
+			submittedUserMessage.length > 0 ? submittedUserMessage : undefined,
+		);
+
 		return runtime.harness.sendMessage(input.payload);
 	}
 
@@ -504,7 +687,14 @@ export class ChatRuntimeManager {
 			input.workspaceId,
 		);
 		runtime.lastErrorMessage = null;
+		const userMessage = input.payload.content.trim() || "[non-text message]";
+		await this.onUserPromptSubmit(runtime, userMessage);
 		await restartRuntimeFromUserMessage(runtime, input);
+		const submittedUserMessage = input.payload.content.trim();
+		void this.generateAndSetTitle(
+			runtime,
+			submittedUserMessage.length > 0 ? submittedUserMessage : undefined,
+		);
 	}
 
 	async stop(input: { sessionId: string; workspaceId: string }): Promise<void> {
@@ -558,7 +748,14 @@ export class ChatRuntimeManager {
 		return runtime.harness.respondToPlanApproval(input.payload);
 	}
 
-	async getSlashCommands(_input: {
+	private resolveWorkspaceCwd(workspaceId: string): string | null {
+		const workspace = this.db.query.workspaces
+			.findFirst({ where: eq(workspaces.id, workspaceId) })
+			.sync();
+		return workspace?.worktreePath ?? null;
+	}
+
+	async getSlashCommands(input: {
 		sessionId: string;
 		workspaceId: string;
 	}): Promise<
@@ -567,10 +764,12 @@ export class ChatRuntimeManager {
 			aliases: string[];
 			description: string;
 			argumentHint: string;
-			kind: "builtin" | "prompt";
+			kind: string;
 		}>
 	> {
-		return [];
+		const cwd = this.resolveWorkspaceCwd(input.workspaceId);
+		if (!cwd) return [];
+		return getSlashCommandsFromCwd(cwd);
 	}
 
 	async resolveSlashCommand(input: {
@@ -578,12 +777,16 @@ export class ChatRuntimeManager {
 		workspaceId: string;
 		text: string;
 	}) {
-		return {
-			handled: false,
-			invokedAs: input.text.trim().startsWith("/")
-				? input.text.trim()
-				: undefined,
-		};
+		const cwd = this.resolveWorkspaceCwd(input.workspaceId);
+		if (!cwd) {
+			return {
+				handled: false,
+				invokedAs: input.text.trim().startsWith("/")
+					? input.text.trim()
+					: undefined,
+			};
+		}
+		return resolveSlashCommandFromCwd(cwd, input.text);
 	}
 
 	async previewSlashCommand(input: {
@@ -594,10 +797,102 @@ export class ChatRuntimeManager {
 		return this.resolveSlashCommand(input);
 	}
 
-	async getMcpOverview(_input: {
+	async getMcpOverview(input: {
 		sessionId: string;
 		workspaceId: string;
-	}): Promise<{ sourcePath: string | null; servers: never[] }> {
-		return { sourcePath: null, servers: [] };
+	}): Promise<{
+		sourcePath: string | null;
+		servers: Array<{
+			name: string;
+			state: "enabled" | "disabled" | "invalid";
+			transport: "remote" | "local" | "unknown";
+			target: string;
+		}>;
+	}> {
+		const runtime = await this.getOrCreateRuntime(
+			input.sessionId,
+			input.workspaceId,
+		);
+		const manager = runtime.mcpManager;
+		if (!manager || !manager.hasServers()) {
+			return { sourcePath: null, servers: [] };
+		}
+
+		const rawConfig = manager.getConfig().mcpServers ?? {};
+		const configPaths = manager.getConfigPaths();
+		const sourcePath = configPaths?.project ?? null;
+
+		const servers = Object.entries(rawConfig).map(([name, rawServerConfig]) => {
+			const sc = rawServerConfig as unknown as Record<string, unknown>;
+			const enabled = sc.enabled !== false;
+			const hasUrl = typeof sc.url === "string" || typeof sc.type === "string";
+			const hasCommand = typeof sc.command === "string";
+
+			let transport: "remote" | "local" | "unknown" = "unknown";
+			let target = "Not configured";
+
+			if (hasUrl) {
+				transport = "remote";
+				target = (sc.url as string) ?? (sc.type as string);
+			} else if (hasCommand) {
+				const cmd = sc.command as string;
+				const args = Array.isArray(sc.args)
+					? (sc.args as string[]).join(" ")
+					: "";
+				transport = "local";
+				target = args ? `${cmd} ${args}` : cmd;
+			}
+
+			const state: "enabled" | "disabled" | "invalid" = !enabled
+				? "disabled"
+				: !hasUrl && !hasCommand
+					? "invalid"
+					: "enabled";
+
+			return { name, state, transport, target };
+		});
+
+		return { sourcePath, servers };
+	}
+
+	async authenticateMcpServer(input: {
+		sessionId: string;
+		workspaceId: string;
+		serverName: string;
+	}): Promise<{
+		sourcePath: string | null;
+		servers: Array<{
+			name: string;
+			state: "enabled" | "disabled" | "invalid";
+			transport: "remote" | "local" | "unknown";
+			target: string;
+		}>;
+	}> {
+		const runtime = await this.getOrCreateRuntime(
+			input.sessionId,
+			input.workspaceId,
+		);
+		const manager = runtime.mcpManager;
+		if (!manager || !manager.hasServers()) {
+			throw new Error("No MCP servers configured");
+		}
+
+		const serverName = input.serverName.trim();
+		if (!serverName) {
+			throw new Error("MCP server name is required");
+		}
+
+		runtime.mcpManualStatuses.set(serverName, "authenticating");
+		try {
+			await manager.init();
+			runtime.mcpManualStatuses.set(serverName, "connected");
+		} catch {
+			runtime.mcpManualStatuses.set(serverName, "error");
+		}
+
+		return this.getMcpOverview({
+			sessionId: input.sessionId,
+			workspaceId: input.workspaceId,
+		});
 	}
 }

--- a/packages/host-service/src/trpc/router/chat/chat.ts
+++ b/packages/host-service/src/trpc/router/chat/chat.ts
@@ -68,6 +68,10 @@ export const chatRouter = router({
 		return ctx.runtime.chat.stop(input);
 	}),
 
+	abort: protectedProcedure.input(sessionInput).mutation(({ ctx, input }) => {
+		return ctx.runtime.chat.stop(input);
+	}),
+
 	respondToApproval: protectedProcedure
 		.input(
 			sessionInput.extend({
@@ -139,5 +143,21 @@ export const chatRouter = router({
 		.input(sessionInput)
 		.query(({ ctx, input }) => {
 			return ctx.runtime.chat.getMcpOverview(input);
+		}),
+
+	releaseSession: protectedProcedure
+		.input(sessionInput)
+		.mutation(({ ctx, input }) => {
+			ctx.runtime.chat.destroySession(input.sessionId);
+		}),
+
+	authenticateMcpServer: protectedProcedure
+		.input(
+			sessionInput.extend({
+				serverName: z.string().min(1),
+			}),
+		)
+		.mutation(({ ctx, input }) => {
+			return ctx.runtime.chat.authenticateMcpServer(input);
 		}),
 });

--- a/packages/workspace-client/src/providers/WorkspaceClientProvider/WorkspaceClientProvider.tsx
+++ b/packages/workspace-client/src/providers/WorkspaceClientProvider/WorkspaceClientProvider.tsx
@@ -28,6 +28,7 @@ interface WorkspaceClients {
 	getWsToken: () => string | null;
 }
 
+const MAX_WORKSPACE_CLIENTS_CACHE_SIZE = 5;
 const workspaceClientsCache = new Map<string, WorkspaceClients>();
 const WorkspaceClientContext =
 	createContext<WorkspaceClientContextValue | null>(null);
@@ -41,7 +42,20 @@ function getWorkspaceClients(
 	const clientKey = `${cacheKey}:${hostUrl}`;
 	const cached = workspaceClientsCache.get(clientKey);
 	if (cached) {
+		// LRU: move to end
+		workspaceClientsCache.delete(clientKey);
+		workspaceClientsCache.set(clientKey, cached);
 		return cached;
+	}
+
+	// Evict oldest if at capacity
+	if (workspaceClientsCache.size >= MAX_WORKSPACE_CLIENTS_CACHE_SIZE) {
+		const oldestKey = workspaceClientsCache.keys().next().value;
+		if (oldestKey) {
+			const evicted = workspaceClientsCache.get(oldestKey);
+			evicted?.queryClient.clear();
+			workspaceClientsCache.delete(oldestKey);
+		}
 	}
 
 	const queryClient = new QueryClient({

--- a/v2-chat-plan.md
+++ b/v2-chat-plan.md
@@ -1,0 +1,452 @@
+# V2 Chat — Plan to Full Parity & Completion
+
+## Current State
+
+The v2 chat (`routes/_authenticated/_dashboard/v2-workspace`) is structurally complete — message rendering, polling display, send/stop/restart/approval/plan/question flows all exist. However:
+
+1. **The chat has critical memory leaks** — 60fps polling, full-history re-fetching, no virtualization, and no runtime teardown cause a V8 GC death spiral after ~60min idle (#3049) and multi-GB RSS in long sessions (#2882).
+2. **The host-service backend has critical stubs** — slash commands, MCP, and title generation return empty/no-op.
+3. **Several v1 lifecycle features are missing** — draft saving, launch configs, session pre-creation.
+
+Source: [RENDERER_MEMORY_LEAK_ANALYSIS.md](apps/desktop/docs/RENDERER_MEMORY_LEAK_ANALYSIS.md)
+
+---
+
+## Phase 1: Memory & Performance (Critical — blocks production use)
+
+These issues cause the renderer to become unresponsive after sustained use. They affect both v1 and v2 but are especially severe in v2 because the transport is HTTP (heavier per-poll overhead than IPC).
+
+### 1.1 Adaptive polling — stop 60fps when idle
+
+**Files:**
+- `packages/chat/src/client/hooks/use-chat-display/use-chat-display.ts` (v1 hook)
+- `apps/desktop/.../hooks/useWorkspaceChatDisplay/useWorkspaceChatDisplay.ts` (v2 hook)
+
+**Problem:** Both hooks poll `getDisplayState` + `listMessages` every 16ms unconditionally, even when the chat is idle. `refetchIntervalInBackground: true` means this runs even when the pane is hidden. `staleTime: 0` + `gcTime: 0` maximizes GC churn.
+
+**What to do:**
+- Poll at 60fps **only while `isRunning` is true** (agent actively streaming)
+- Drop to 2–5s when idle (no active run)
+- Set `refetchIntervalInBackground: false` so hidden panes don't poll
+- Set `gcTime` to a reasonable value (e.g., 30s) to reduce GC pressure
+- Consider using the existing event-bus WebSocket to notify the renderer when `isRunning` changes, triggering a single refetch instead of continuous polling
+
+**Impact:** This is the single biggest contributor to #3049. Eliminating idle polling removes the sustained allocation pressure that triggers the V8 GC death spiral.
+
+### 1.2 Fix query invalidation amplifier during active runs
+
+**File:** `apps/desktop/.../hooks/useWorkspaceChatDisplay/useWorkspaceChatDisplay.ts`
+
+**Problem:** A `useEffect` invalidates both chat queries whenever `isRunning` is true, but `queryInput` is recreated on every render (not memoized), so the effect fires more often than intended — amplifying the 60fps polling during active sessions.
+
+```ts
+useEffect(() => {
+    if (!queryInput) return;
+    if (!isRunning) return;
+    void Promise.all([
+        utils.chat.getDisplayState.invalidate(queryInput),
+        utils.chat.listMessages.invalidate(queryInput),
+    ]);
+}, [isRunning, queryInput, ...]);
+```
+
+**What to do:**
+- Memoize `queryInput` with `useMemo` so the effect only fires on actual `isRunning` transitions
+- Or remove the invalidation entirely — the polling already handles freshness
+
+### 1.3 Paginate or delta-fetch `listMessages`
+
+**Files:**
+- `packages/chat/src/server/trpc/service.ts` — `listMessages` returns full transcript
+- `packages/host-service/src/runtime/chat/chat.ts` — same pattern
+
+**Problem:** Every poll cycle re-fetches the **entire** conversation history. For long sessions (hours of Codex use, #2882), this payload grows unbounded. At 60fps, a 500-message transcript is serialized/deserialized ~60 times per second.
+
+**What to do:**
+- Add a `sinceMessageId` or `offset` parameter to `listMessages`
+- On the client, only fetch new messages since the last known message ID
+- Fall back to full fetch on session load or when the client detects a gap
+- Alternative: cache the message list on the server and return a hash — skip the response body if unchanged
+
+### 1.4 Virtualize the message list
+
+**Files:**
+- `apps/desktop/.../WorkspaceChatInterface/components/ChatMessageList/ChatMessageList.tsx` (v2)
+- `apps/desktop/src/renderer/components/Chat/ChatInterface/components/MessageList/MessageList.tsx` (v1)
+
+**Problem:** The full conversation is mounted in React at all times. The v2 path also allocates `prefixMessages={renderedMessages.slice(0, messageIndex)}` per user message per render — O(n^2) array allocations.
+
+**What to do:**
+- Use a virtualization library (e.g., `@tanstack/react-virtual` or `react-virtuoso`) to only mount visible messages
+- Remove the per-message `slice()` — pass the full array + index, or memoize prefix computation
+- This directly addresses the renderer-side memory growth in long sessions (#2882)
+
+### 1.5 Tear down chat runtimes on pane close
+
+**Files:**
+- `apps/desktop/src/renderer/stores/tabs/store.ts` — `removePane` kills terminals but not chat sessions
+- `packages/chat/src/server/trpc/service.ts` — `ChatRuntimeService.runtimes` map has no eviction
+- `packages/host-service/src/runtime/chat/chat.ts` — `ChatRuntimeManager` same pattern
+
+**Problem:** Closing a chat pane does not destroy the backing runtime session. The Mastra harness, its thread memory, and all message history remain resident in the main process. Over time, multiple sessions accumulate.
+
+**Prerequisite — the v2 panes API has no chat cleanup hook:** The `PaneDefinition` type (`packages/panes/src/react/types.ts:67`) only exposes `onBeforeClose?(pane): boolean | Promise<boolean>` as a gate, not a post-close cleanup callback. The `chat` pane type in `usePaneRegistry.tsx` defines no `onBeforeClose` at all. Meanwhile, `removePane` in the tabs store (v1) explicitly calls `killTerminalForPane()` for terminals and `cleanupEditorPaneState()` for editors but has **zero chat-specific cleanup**. Without addressing this, the runtime teardown will only work for v1, leaving the v2 path still leaking.
+
+**What to do:**
+1. Add a `destroySession` / `releaseSession` procedure to both `ChatRuntimeService` and `ChatRuntimeManager`
+2. **v1:** Add a chat cleanup call in `removePane` (tabs store), alongside the existing terminal/editor cleanup
+3. **v2:** Either:
+   - Add an `onBeforeClose` to the `chat` pane definition in `usePaneRegistry.tsx` that calls the destroy procedure (returning `true` to allow close), or
+   - Add a new `onAfterClose` hook to the `PaneDefinition` interface in `@superset/panes` and implement it for chat, or
+   - Use a `useEffect` cleanup in `ChatPane.tsx` that calls destroy when the component unmounts (simplest, but depends on React lifecycle guarantees)
+4. Add idle eviction: if a runtime hasn't been polled in N minutes (e.g., 10), auto-destroy it server-side as a safety net
+
+### 1.6 Bound the Electric collections cache
+
+**File:** `apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts`
+
+**Problem:** `collectionsCache` is a `Map<string, OrgCollections>` with no eviction. Each entry creates ~20 Electric-backed live subscriptions. If the user switches orgs, old collections accumulate.
+
+**What to do:**
+- Evict collections when the user leaves an org (or after a timeout)
+- Or cap the cache size (e.g., LRU with max 2–3 entries)
+
+### 1.7 Bound the workspace client cache
+
+**File:** `packages/workspace-client/src/providers/WorkspaceClientProvider/WorkspaceClientProvider.tsx`
+
+**Problem:** `workspaceClientsCache` retains a `QueryClient` + tRPC client per workspace, never evicted.
+
+**What to do:**
+- Evict entries when the workspace is unmounted
+- Or use a bounded cache with cleanup of the `QueryClient` on eviction
+
+---
+
+## Phase 2: Host-Service Runtime Stubs (Critical — broken features)
+
+The v2 chat UI calls these procedures but they return empty/no-op results.
+
+### 2.1 Plumb an API client into `ChatRuntimeManager`
+
+**Files:**
+- `packages/host-service/src/app.ts` (line ~67) — constructs `ChatRuntimeManager` with only `{ db, runtimeResolver }`
+- `packages/host-service/src/runtime/chat/chat.ts` (line ~318) — `ChatRuntimeManagerOptions` has no API client
+
+**Problem:** The host-service `ChatRuntimeManager` has no way to call the cloud API. This blocks title generation (`generateAndSetTitle` needs `apiClient.chat.updateTitle.mutate()`), and will block any future feature that writes to the cloud from the runtime. The v1 `ChatRuntimeService` constructs its own tRPC client at initialization.
+
+**What to do:**
+- Add an `apiClient` (or a tRPC client factory) to `ChatRuntimeManagerOptions`
+- Pass it from `app.ts` during construction
+- This is a prerequisite for 2.2 (title generation) and any future cloud-writing features
+
+### 2.2 Add session title generation to host-service
+
+**Files:**
+- `packages/host-service/src/runtime/chat/chat.ts` — `sendMessage` does not call `generateAndSetTitle`
+- Reference: `packages/chat/src/server/trpc/utils/runtime/runtime.ts` — `generateAndSetTitle`
+
+**Depends on:** 2.1 (API client plumbing)
+
+**What to do:**
+- After the first user message (and every Nth), call `generateAndSetTitle` using the Mastra agent or Vercel AI SDK
+- Post the title to the cloud API via `apiClient.chat.updateTitle.mutate()`
+- Without this, all sessions in the SessionSelector show "New Chat" forever
+
+### 2.3 Port missing v1 runtime lifecycle hooks to host-service
+
+**Files:**
+- `packages/host-service/src/runtime/chat/chat.ts` — missing several runtime features present in v1
+- `packages/chat/src/server/trpc/service.ts` — v1 reference implementation
+
+**Problem:** The host-service runtime is missing five features that v1 has, making the v2 chat behave differently even once the explicit stubs are filled:
+
+| Feature | v1 location | Host-service status |
+|---|---|---|
+| `extraTools` (Superset MCP tools) | `service.ts:113` — `getSupersetMcpTools()` injected into `createMastraCode` | Missing — `createMastraCode` called without `extraTools` |
+| `reloadHookConfig` on runtime reuse | `service.ts:101` — called when returning cached runtime | Missing — cached runtime returned as-is |
+| `runSessionStartHook` | `service.ts:147` — called after runtime creation | Missing — no hook call in `createRuntime` |
+| `onUserPromptSubmit` gate | `service.ts:268,300` — called before sending each message | Missing — `sendMessage` goes straight to harness |
+| Observer model resolution | `service.ts:118-129` — `resolveOmModelFromAuth()` | Missing |
+
+**What to do:**
+- Port `reloadHookConfig`, `runSessionStartHook`, and `onUserPromptSubmit` from the chat package utils into `ChatRuntimeManager`
+- Wire `getSupersetMcpTools()` (or equivalent) to inject platform tools via `extraTools`
+- Add observer model resolution if applicable to the host-service auth context
+
+### 2.4 Implement `getSlashCommands` in host-service
+
+**Files:**
+- `packages/host-service/src/runtime/chat/chat.ts` — currently returns `[]` (line ~573)
+- Reference: `packages/chat/src/server/desktop/slash-commands/` — full implementation
+
+**What to do:**
+- Port the slash command registry from `packages/chat/src/server/desktop/slash-commands/` into the host-service runtime
+- The registry should discover commands from the workspace `cwd` using the canonical `.agents/commands/` path (per AGENTS.md rule 3). The existing registry in `packages/chat` already scans both `.agents/commands/` and `.claude/commands/` (the latter is a symlink) — reuse that logic directly rather than reimplementing with only one path
+- Return the command list with names, aliases, descriptions, and parameter schemas
+
+### 2.5 Implement `resolveSlashCommand` and `previewSlashCommand`
+
+**Files:**
+- `packages/host-service/src/runtime/chat/chat.ts` — `resolveSlashCommand` always returns `{ handled: false }` (line ~582), `previewSlashCommand` delegates to the same stub (line ~594)
+- Reference: `packages/chat/src/server/desktop/slash-commands/resolver.ts`
+
+**What to do:**
+- Port the resolver logic (argument substitution, prompt template expansion, action dispatch)
+- Wire `previewSlashCommand` to render resolved prompt previews
+- Update the v2 `useSlashCommandExecutor` to call `resolveSlashCommand` on the host-service for custom/project-level commands instead of the local `switch` statement fallthrough
+
+### 2.4 Implement `getMcpOverview` and enable MCP
+
+**Files:**
+- `packages/host-service/src/runtime/chat/chat.ts` — returns `{ sourcePath: null, servers: [] }` (line ~601)
+- `packages/host-service/src/runtime/chat/chat.ts` — `disableMcp: true` hardcoded (line ~373)
+
+**What to do:**
+- Remove the `disableMcp: true` hardcode (or make it configurable)
+- Implement `getMcpOverview` to return connected MCP server status from the Mastra harness
+- This unblocks the `McpControls` overlay in the chat pane
+
+### 2.5 Add `authenticateMcpServer` procedure to host-service chat router
+
+**Files:**
+- `packages/host-service/src/trpc/router/chat/chat.ts` — procedure does not exist
+- `apps/desktop/src/renderer/routes/.../ChatPaneInterface.tsx` — `useMcpUi` called without `authenticateServer`
+
+**What to do:**
+- Add `authenticateMcpServer` mutation to the host-service `chatRouter`
+- Wire it through `ChatRuntimeManager` to the Mastra harness's MCP auth flow
+- Pass the mutation to `useMcpUi({ authenticateServer })` in v2 `ChatPaneInterface`
+
+---
+
+## Phase 3: Session Lifecycle Reliability
+
+### 3.1 Add background session pre-creation (with abandoned-session policy)
+
+**File:** `apps/desktop/.../hooks/useWorkspaceChatController/useWorkspaceChatController.ts`
+
+**Problem:** Currently, the session DB record is only created on first send, adding latency and creating a race with `organizationId` availability.
+
+**Complication:** Eagerly creating session records will cause empty sessions to appear in the `SessionSelector` as "New Chat" entries, because neither the live query (line ~81) nor the selector component filters out sessions with zero messages. Over time this creates session-list spam.
+
+**What to do:**
+- Pre-create the session record in the background when a Chat pane opens with `sessionId === null`
+- Add an abandoned-session cleanup policy — choose one:
+  - **Option A (client-side filter):** Filter out sessions with no messages and no title from the `SessionSelector` display. This is the simplest but requires knowing message count.
+  - **Option B (deferred creation):** Don't create the DB record on pane open — instead, pre-allocate a UUID and prepare the session metadata locally, but only call `createSessionRecord` when the user starts typing or focuses the input. This preserves the latency benefit while avoiding phantom sessions.
+  - **Option C (TTL cleanup):** Create eagerly but add a background job (or `useEffect` interval) that deletes sessions older than N minutes that have zero messages and no title. This is the most robust but requires a new API endpoint or periodic client-side cleanup.
+
+### 3.2 Add session init retry logic
+
+**File:** `useWorkspaceChatController.ts`
+**Reference:** `apps/desktop/.../hooks/useChatPaneController/session-init-runner.ts`
+
+**What to do:**
+- Wrap `createSessionRecord` in a retry runner (max 3 retries, 1500ms delay)
+- Add `isSessionInitializing` state for a loading indicator
+- Toast on repeated failure
+
+### 3.3 Deduplicate concurrent `getOrCreateSession` calls
+
+**File:** `useWorkspaceChatController.ts`
+
+**What to do:**
+- Track the in-flight promise in a ref
+- Return existing promise on concurrent calls instead of generating a new UUID
+- Prevents orphaned sessions from rapid double-submits
+
+### 3.4 Expose host-service status to the renderer (prerequisite for 3.5 and 3.6)
+
+**Files:**
+- `apps/desktop/src/main/lib/host-service-coordinator.ts` (line ~27) — status enum is `"starting" | "running" | "stopped"` — no `"error"` or `"restarting"` value
+- `apps/desktop/src/renderer/routes/_authenticated/providers/LocalHostServiceProvider/LocalHostServiceProvider.tsx` (line ~16) — only exposes `{ machineId: string | null; activeHostUrl: string | null }`
+
+**Problem:** The renderer has no visibility into the host-service lifecycle. `LocalHostServiceProvider` only exposes a binary signal (`activeHostUrl` is null or not). The coordinator's status enum exists in the main process but is never surfaced to the renderer. Without this, neither the cold-start fix (3.5) nor auto-restart UI feedback (3.6) can be implemented.
+
+**What to do:**
+- Extend the status enum to include `"error"` and `"restarting"` states
+- Expose the current status through an IPC channel or tRPC query from the main process
+- Add `status: HostServiceStatus` to the `LocalHostServiceContextValue` interface
+- Optionally include `lastError: string | null` for diagnostic display
+
+### 3.5 Fix layout.tsx cold-start race condition
+
+**File:** `apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx`
+
+**Depends on:** 3.4 (status plumbing)
+
+**What to do:**
+- When `activeHostUrl` is `null` and status is `"starting"`, show a loading/spinner state instead of the hard error
+- Only show "Workspace host service not available" when status is `"stopped"` or `"error"`
+
+### 3.6 Add host-service auto-restart on crash
+
+**File:** `apps/desktop/src/main/lib/host-service-coordinator.ts`
+
+**Depends on:** 3.4 (status plumbing for `"restarting"` state)
+
+**What to do:**
+- Auto-restart with exponential backoff (1s, 2s, 4s, cap 30s) on unexpected exit
+- Cap at 5 attempts before surfacing a persistent error
+- Emit `"restarting"` status so the UI can show "Reconnecting..."
+
+---
+
+## Phase 4: Feature Parity with V1
+
+### 4.1 Implement `DraftSaver` for v2 chat panes
+
+**What to do:**
+- Persist textarea content to pane data in `@superset/panes` store on unmount
+- Restore on re-mount (tab switching), clear after send
+
+### 4.2 Wire up `initialLaunchConfig` support
+
+**File:** `apps/desktop/.../ChatPane/ChatPane.tsx` — `initialLaunchConfig={null}` hardcoded (line 44)
+
+**What to do:**
+- Accept `initialLaunchConfig` from pane data or workspace-level launch intent
+- Wire through to `ChatPaneInterface` so auto-launch fires
+- Add `consumeLaunchConfig` callback to prevent re-send on re-mount
+
+### 4.3 Fix `isFocused` to reflect actual pane focus
+
+**File:** `apps/desktop/.../ChatPane/ChatPane.tsx` — hardcoded to `true` (line 46)
+
+**What to do:**
+- Read from `@superset/panes` store (active tab + pane)
+- Prevents keyboard shortcuts (Ctrl+F) from firing in unfocused panes
+
+### 4.4 Add `abort` procedure to host-service
+
+**What to do:**
+- Add alongside `stop`, or unify if semantically identical in Mastra
+- Wire v2 `useWorkspaceChatDisplay`'s `abort: async () => undefined` to the real procedure
+
+### 4.5 Fix `SlashCommandPreview` to work without a session
+
+**What to do:**
+- Currently disabled when `sessionId` is `null` (line 75)
+- Change to use `workspaceId` alone (like v1 uses `cwd`)
+
+---
+
+## Phase 5: Robustness & Polish
+
+### 5.1 User-friendly error states for remote workspace failures
+
+**What to do:**
+- Relay `503 Host not connected` → "Host machine is offline" with retry button
+- Host-service crash → "Connection lost — reconnecting..." with auto-retry
+- Surface host-service status in workspace UI
+
+### 5.2 Ensure pane layout persistence on first visit
+
+**File:** `apps/desktop/.../hooks/useV2WorkspacePaneLayout.ts`
+
+**What to do:**
+- Store subscription silently drops changes if `v2WorkspaceLocalState` record doesn't exist yet
+- Ensure the record exists before subscription starts, or queue pending writes
+
+### 5.3 Add workspace `ensure` call to v2 controller
+
+**What to do:**
+- v1 calls `apiTrpcClient.workspace.ensure.mutate(...)` to sync workspace to cloud
+- Add to v2 during session creation
+
+---
+
+## Phase 6: Rich Text Composer (TipTap Migration)
+
+### 6.1 Replace PromptInput textarea with TipTap editor
+
+**Files:**
+- `packages/ui/src/components/ai-elements/prompt-input.tsx` — current `PromptInputTextarea` uses a plain `<textarea>`
+- Reference: Claude Code's web composer uses TipTap/ProseMirror with `contenteditable` and inline `node-mention` React renderers
+
+**Problem:** The plain `<textarea>` cannot render inline components. File mentions (`@path`) are inserted as raw text, with no visual distinction from regular input until the message is sent. A TipTap-based editor would allow inline mention chips, slash command nodes, and future rich input features.
+
+**What to do:**
+1. Add `@tiptap/react`, `@tiptap/starter-kit`, and `@tiptap/extension-mention` to `packages/ui`
+2. Create a new `PromptInputEditor` component (TipTap-based) alongside the existing `PromptInputTextarea`
+3. Implement a custom `Mention` node extension that renders file mentions as inline button chips (file icon + path, styled like the existing `FileMentionChip`)
+4. Wire the `@` trigger to open the `MentionPopover` and insert a structured mention node on selection (instead of plain text)
+5. Handle serialization: on submit, convert the TipTap document to `{ text: string, mentions: string[] }` — the text field contains `@path` tokens for backward compatibility with `parseUserMentions` in sent messages
+6. Preserve all existing keyboard behavior: Enter to submit, Shift+Enter for newline, Cmd+A, undo/redo
+7. Preserve file drop/paste attachment integration
+8. Update `PromptInputProvider` context to expose the TipTap editor instance instead of `{ value, setInput, clear, focus }`
+9. Migrate v2 `ChatInputFooter` to use the new editor, keeping v1 on the textarea until v1 is deprecated
+
+**Scope considerations:**
+- This is a standalone input component refactor, not a chat feature — no chat plan items depend on it
+- Can be done incrementally: start with v2 only, keep v1 on the textarea
+- The mention popover search (already wired to `workspaceTrpc.filesystem.searchFiles`) stays the same — only the insertion target changes
+
+---
+
+## Phase 7: Code Health
+
+### 7.1 Deduplicate v1/v2 ChatMessageList sub-components
+
+**What to do:**
+- Both v1 and v2 maintain full independent copies of: `AssistantMessage`, `UserMessage`, `ToolCallBlock`, `ReasoningBlock`, `StreamingMessageText`, `ThinkingMessage`, `ToolPreviewMessage`, `SubagentExecutionMessage`, `PendingApprovalMessage`, `PendingPlanApprovalMessage`, `PendingQuestionMessage`, `InterruptedFooter`, `ChatSearch`, `MessageScrollbackRail`
+- Extract to `packages/chat/client` or `renderer/components/Chat/` and import from both
+- Prevents drift between versions
+
+### 7.2 Wire up "Save All" in unsaved-changes dialog
+
+**Files:**
+- `apps/desktop/.../page.tsx` (line 259, TODO)
+- `apps/desktop/.../hooks/usePaneRegistry/usePaneRegistry.tsx` (line 83)
+
+---
+
+## Priority Matrix
+
+| Priority | Item | Issue | Impact |
+|----------|------|-------|--------|
+| **P0** | 1.1 Adaptive polling | #3049 | **Root cause of GC death spiral** — renderer unusable after ~60min |
+| **P0** | 1.2 Fix invalidation amplifier | #3049 | Compounds polling pressure during active runs |
+| **P0** | 1.5 Runtime teardown on pane close | #2882 | Main-process memory grows without bound (requires v2 pane cleanup hook) |
+| **P0** | 2.1 API client plumbing | — | Prerequisite for title generation and any cloud-writing feature |
+| **P0** | 2.2 Title generation | — | Sessions unlabeled — unusable UX |
+| **P1** | 1.3 Paginate `listMessages` | #2882 | Full transcript re-serialized every poll cycle |
+| **P1** | 1.4 Virtualize message list | #2882 | Long sessions mount hundreds of React components + O(n^2) slicing |
+| **P1** | 2.3 Runtime lifecycle parity | — | Missing hooks/tools/gates make v2 behave differently from v1 |
+| **P1** | 2.4–2.5 Slash commands | — | Custom project commands silently fail |
+| **P1** | 3.4 Host-service status plumbing | — | Prerequisite for cold-start fix and auto-restart UI |
+| **P1** | 3.5–3.6 Cold-start race + auto-restart | — | First visit shows hard error; single crash = permanent broken state |
+| **P2** | 1.6–1.7 Bound caches | #3049 | Secondary memory growth path |
+| **P2** | 2.6–2.7 MCP support | — | MCP servers completely disabled |
+| **P2** | 3.1–3.3 Session lifecycle | — | First-message latency + orphaned sessions (needs abandoned-session policy) |
+| **P3** | 4.1–4.5 V1 parity | — | Draft saving, launch config, focus, abort |
+| **P3** | 5.1–5.3 Polish | — | Error states, persistence edge cases |
+| **P3** | 6.1 TipTap composer | — | Inline mention chips, rich input UX |
+| **P4** | 7.1–7.2 Code health | — | Maintenance, not user-facing |
+
+## Suggested Execution Order
+
+**Sprint 1 — Stop the bleeding (memory):**
+1.1 → 1.2 → 1.5 (adaptive polling + invalidation fix + runtime teardown incl. v2 pane cleanup hook)
+
+**Sprint 2 — Usable v2 chat:**
+2.1 → 2.2 → 2.3 (API client plumbing → title gen → runtime lifecycle parity)
+2.4 → 2.5 (slash commands)
+3.4 → 3.5 → 3.6 (status plumbing → cold-start fix → auto-restart)
+
+**Sprint 3 — Scalable chat:**
+1.3 → 1.4 (message pagination + virtualization)
+
+**Sprint 4 — Full feature set:**
+2.6 → 2.7 (MCP)
+3.1 → 3.3 (session lifecycle with abandoned-session policy)
+4.1 → 4.5 (v1 parity)
+
+**Sprint 5 — Polish:**
+1.6 → 1.7 (cache bounds)
+5.1 → 5.3 (error states)
+7.1 → 7.2 (code health)
+
+**Sprint 6 — Rich composer:**
+6.1 (TipTap migration for PromptInput — standalone workstream)


### PR DESCRIPTION
**Links**
- Plan: `v2-chat-plan.md` (checked into this branch)
- Related: #3049 (renderer memory leak / GC death spiral), #2882 (high memory in long sessions)

## Summary

- **Fix critical memory leaks** in the v2 chat polling path that cause a V8 GC death spiral after ~60min idle (#3049) and multi-GB RSS in long sessions (#2882)
- **Fill all host-service chat stubs** — slash commands, MCP, title generation, lifecycle hooks, and abort were returning empty/no-op results
- **Add reliability infrastructure** — host-service auto-restart, cold-start spinner, session pre-creation, @mention file search

## Why / Context

The v2 workspace chat (`routes/_dashboard/v2-workspace`) was structurally complete but had three categories of issues blocking production use:

1. **Memory**: Both v1 and v2 chat hooks polled `getDisplayState` + `listMessages` at 60fps unconditionally, even when idle. Combined with full-transcript re-fetching, no virtualization, and no runtime teardown, this caused the renderer to become unresponsive after sustained use.

2. **Stubs**: The host-service `ChatRuntimeManager` had `disableMcp: true` hardcoded, returned `[]` for slash commands, never generated session titles, and was missing v1's lifecycle hooks (`reloadHookConfig`, `runSessionStartHook`, `onUserPromptSubmit`).

3. **Reliability**: The host-service had no auto-restart on crash, the cold-start showed a hard error instead of a spinner, and session creation had no retry logic.

## How It Works

### Memory (Phase 1)

| Change | Before | After |
|--------|--------|-------|
| Polling interval | 60fps always | 60fps when `isRunning`, 3s idle |
| Background polling | Always on | Off (`refetchIntervalInBackground: false`) |
| `listMessages` refetch | Every poll cycle | Only when `messageCount` changes (from `getDisplayState`) |
| `prefixMessages` | O(n²) — `slice(0, i)` per user message per render | Lazy — `allMessages.slice(0, i)` only on resend/edit click |
| Runtime teardown | Never | `onBeforeClose` in pane registry + idle eviction (10min) |
| Electric collections cache | Unbounded `Map` | LRU, max 3 entries |
| Workspace client cache | Unbounded `Map` | LRU, max 5 entries, `queryClient.clear()` on evict |

### Host-Service Parity (Phase 2)

- **API client**: Added `apiClient: ApiClient` to `ChatRuntimeManagerOptions`, passed from `app.ts`
- **Title generation**: `generateAndSetTitle` calls the Mastra agent's `generateTitleFromUserMessage` on first send + every 10th, posts to cloud API
- **Lifecycle hooks**: Ported `reloadHookConfig` (on runtime reuse), `runSessionStartHook` (after creation), `onUserPromptSubmit` (before send), `hookManager.runStop` (on agent_end)
- **Slash commands**: Added `@superset/chat` dependency, exported registry via `@superset/chat/server/slash-commands`, wired `getSlashCommands`/`resolveSlashCommand`/`previewSlashCommand` using workspace `cwd`
- **MCP**: Removed `disableMcp: true`, implemented `getMcpOverview` and `authenticateMcpServer`
- **Abort**: Added `abort` mutation to chat router (aliases `stop`)

### Reliability (Phase 3)

- **Host-service status**: Added `getMachineId` IPC query (no connection required), exposed `status: HostServiceStatus` in `LocalHostServiceProvider`
- **Cold-start**: Layout shows spinner when `isLocal && status === "starting"`, remote shows "Host machine is offline"
- **Auto-restart**: Exponential backoff (1s→30s cap), max 5 attempts, triggered from both spawned child exit and adopted process death
- **Session pre-creation**: UUID pre-allocated on pane open via `useEffect`, DB record deferred to first `getOrCreateSession` call
- **Session retry**: `createSessionRecord` retries 3x with 1.5s delay
- **Inflight dedup**: `getOrCreateSession` tracks in-flight promise in a ref

### Feature Parity (Phase 4)

- **DraftSaver**: `DraftSaver` component saves textarea text to pane data on unmount, restored via `initialDraft` prop
- **isFocused**: Reads `ctx.isActive` from pane store instead of hardcoded `true`
- **Launch config**: `ChatPaneData.launchConfig` field, wired through pane registry → ChatPane → ChatPaneInterface
- **@mention search**: `MentionPopover` wired to `workspaceTrpc.filesystem.searchFiles` with directory browsing
- **Save All**: `FilePane` exposes `saveImpl` via module-level `filePaneSaveHandles` registry, wired to Save All button in close dialog

## Manual QA Checklist

### Memory / Polling
- [ ] Open v2 chat, observe no CPU spike when idle (DevTools Performance tab)
- [ ] Send a message, observe 60fps polling during streaming, drops to 3s after completion
- [ ] Long conversation (20+ messages) — no noticeable lag on re-render
- [ ] Close chat pane, verify runtime teardown logged in host-service stdout

### Host-Service Features
- [ ] New chat session — title auto-generates after first message, appears in SessionSelector
- [ ] Type `/` — slash commands from `.agents/commands/` appear in autocomplete
- [ ] Type `@` — file browser popover shows workspace directory structure
- [ ] Select a file from `@` popover — `@path/to/file.ts` inserted in textarea
- [ ] MCP overview in chat shows configured servers (if any)

### Reliability
- [ ] Kill host-service process — auto-restarts within seconds, chat reconnects
- [ ] Open v2 workspace immediately after app launch — spinner shows, then workspace loads
- [ ] Open workspace for remote (relay) host that is offline — shows "Host machine is offline"

### Session Lifecycle
- [ ] Open new chat pane — UUID pre-allocated immediately (no latency on first send)
- [ ] Send message — session record created in DB, appears in SessionSelector
- [ ] Switch tabs and back — draft text preserved in textarea
- [ ] Close file pane with unsaved changes — Save All button saves and closes

## Testing
- `bun run typecheck` — 25/25 pass
- `bun run lint` — clean, no errors
- `bun test` — 2389 pass, 3 fail (all pre-existing on main)

## Design Decisions
- **Adaptive polling over WebSocket subscriptions**: The event bus WS connection exists but adding subscription-based display state would require significant plumbing. Adaptive polling (60fps active, 3s idle) is a simple fix that eliminates 99% of the idle CPU cost.
- **`messageCount` in `getDisplayState`**: Computed live via `harness.listMessages().length` on each `getDisplayState` poll. This is a local memory operation (not a DB query), so the cost is negligible compared to serializing the full transcript.
- **Module-level `filePaneSaveHandles` registry**: Used for Save All instead of React refs because `onBeforeClose` runs outside the component tree. Each `FilePane` registers/unregisters on mount/unmount.
- **Plain text `@path` over TipTap inline chips**: A TipTap-based composer was prototyped but reverted due to bidirectional sync issues with the `PromptInputProvider` system. The sent message already renders `@path` as styled `FileMentionChip` buttons, so the input doesn't need inline chips.

## Known Limitations
- **MCP authentication**: `authenticateMcpServer` calls `manager.init()` which reinitializes all servers, not just the target. This is a limitation of the Mastra MCP manager API.
- **Title generation**: Assumes the Mastra agent exposes `generateTitleFromUserMessage`. If the method doesn't exist, title generation silently fails (try/catch).
- **TipTap composer files**: `TipTapComposer/` directory exists but is not imported — it was prototyped and reverted. Can be deleted or revisited as a future workstream.

## Follow-ups
- **TipTap rich text composer** (Phase 6 in plan) — inline mention chips in the input, requires replacing `PromptInputTextarea` with a `contentEditable` TipTap editor
- **Component dedup** (Phase 7) — 12 ChatMessageList sub-components are duplicated between v1/v2 with only import path differences
- **Full message list virtualization** — `@tanstack/react-virtual` is installed but not yet applied to ChatMessageList

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes critical memory leaks in the v2 desktop chat and restores host-service parity, cutting idle CPU and memory while improving stability. Also adds reliability features and UX parity, plus more visible file mention chips.

- Bug Fixes
  - Adaptive polling: 60fps while streaming; 3s when idle; background polling off.
  - Smarter refetch/allocation: `listMessages` gated by `messageCount`; defer `prefixMessages`; release runtimes on pane close with 10‑min idle eviction.
  - Bounded caches: collections LRU (3) and workspace client LRU (5) with `queryClient.clear()` on evict.
  - @mention parser recognizes extensionless/ALL_CAPS/PascalCase/hyphenated files; tests added; FileMentionChip styling improved.

- New Features
  - Host-service parity: slash commands via `@superset/chat`, MCP overview/auth, session title generation, lifecycle hooks, and `abort`/`releaseSession`.
  - Reliability: auto-restart with backoff (max 5), cold-start spinner, status/machine ID APIs, pre-created session IDs, DB create retry (3x), and in-flight dedup.
  - UX parity: draft auto-save/restore, focus-aware input, launch configs (prompt, draft, files, model), `@mention` search with directory browsing, and Save All via a file pane registry.

<sup>Written for commit 5f02f2fdd2613b7ba4cecc28fe921d72fb80d3dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

