### PR TITLE
fix(desktop): preserve multiline terminal paste in TUIs

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/external/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/index.ts
@@ -148,6 +148,11 @@ export const createExternalRouter = () => {
 			clipboard.writeText(input);
 		}),
 
+		readClipboard: publicProcedure.query(() => ({
+			text: clipboard.readText(),
+			hasData: clipboard.availableFormats().length > 0,
+		})),
+
 		resolvePath: publicProcedure
 			.input(
 				z.object({

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/clipboardShortcuts.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/clipboardShortcuts.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, mock } from "bun:test";
+import {
+	handleTerminalClipboardShortcut,
+	isTerminalCopyShortcut,
+	isTerminalPasteShortcut,
+} from "./clipboardShortcuts";
+
+describe("terminal clipboard shortcuts", () => {
+	it("detects plain Cmd+C and Cmd+V on macOS", () => {
+		expect(
+			isTerminalCopyShortcut(
+				{
+					key: "c",
+					metaKey: true,
+					ctrlKey: false,
+					altKey: false,
+					shiftKey: false,
+				},
+				"macintel",
+			),
+		).toBe(true);
+		expect(
+			isTerminalPasteShortcut(
+				{
+					key: "v",
+					metaKey: true,
+					ctrlKey: false,
+					altKey: false,
+					shiftKey: false,
+				},
+				"macintel",
+			),
+		).toBe(true);
+	});
+
+	it("does not treat Cmd+Shift+C as a terminal clipboard shortcut", () => {
+		expect(
+			isTerminalCopyShortcut(
+				{
+					key: "c",
+					metaKey: true,
+					ctrlKey: false,
+					altKey: false,
+					shiftKey: true,
+				},
+				"macintel",
+			),
+		).toBe(false);
+	});
+
+	it("handles copy by preventing default and invoking the copy callback", () => {
+		const preventDefault = mock(() => {});
+		const stopPropagation = mock(() => {});
+		const onCopy = mock(() => {});
+		const onPaste = mock(() => {});
+
+		const handled = handleTerminalClipboardShortcut(
+			{
+				key: "c",
+				metaKey: true,
+				ctrlKey: false,
+				altKey: false,
+				shiftKey: false,
+				preventDefault,
+				stopPropagation,
+			},
+			"macintel",
+			{ onCopy, onPaste },
+		);
+
+		expect(handled).toBe(true);
+		expect(preventDefault).toHaveBeenCalledTimes(1);
+		expect(stopPropagation).toHaveBeenCalledTimes(1);
+		expect(onCopy).toHaveBeenCalledTimes(1);
+		expect(onPaste).not.toHaveBeenCalled();
+	});
+
+	it("handles paste by preventing default and invoking the paste callback", () => {
+		const preventDefault = mock(() => {});
+		const stopPropagation = mock(() => {});
+		const onCopy = mock(() => {});
+		const onPaste = mock(() => {});
+
+		const handled = handleTerminalClipboardShortcut(
+			{
+				key: "v",
+				metaKey: true,
+				ctrlKey: false,
+				altKey: false,
+				shiftKey: false,
+				preventDefault,
+				stopPropagation,
+			},
+			"macintel",
+			{ onCopy, onPaste },
+		);
+
+		expect(handled).toBe(true);
+		expect(preventDefault).toHaveBeenCalledTimes(1);
+		expect(stopPropagation).toHaveBeenCalledTimes(1);
+		expect(onPaste).toHaveBeenCalledTimes(1);
+		expect(onCopy).not.toHaveBeenCalled();
+	});
+
+	it("does not change non-mac ctrl shortcuts", () => {
+		const handled = handleTerminalClipboardShortcut(
+			{
+				key: "c",
+				metaKey: false,
+				ctrlKey: true,
+				altKey: false,
+				shiftKey: false,
+				preventDefault: () => {},
+				stopPropagation: () => {},
+			},
+			"linux x86_64",
+			{ onCopy: () => {}, onPaste: () => {} },
+		);
+
+		expect(handled).toBe(false);
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/clipboardShortcuts.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/clipboardShortcuts.ts
@@ -1,0 +1,73 @@
+type ClipboardShortcutEvent = Pick<
+	KeyboardEvent,
+	| "key"
+	| "metaKey"
+	| "ctrlKey"
+	| "altKey"
+	| "shiftKey"
+	| "preventDefault"
+	| "stopPropagation"
+>;
+
+function isPlainMacShortcut(
+	event: Pick<
+		ClipboardShortcutEvent,
+		"key" | "metaKey" | "ctrlKey" | "altKey" | "shiftKey"
+	>,
+	platform: string,
+	key: "c" | "v",
+): boolean {
+	if (event.key.toLowerCase() !== key) return false;
+	if (event.altKey) return false;
+	if (!platform.includes("mac")) return false;
+	return event.metaKey && !event.ctrlKey && !event.shiftKey;
+}
+
+export function isTerminalCopyShortcut(
+	event: Pick<
+		ClipboardShortcutEvent,
+		"key" | "metaKey" | "ctrlKey" | "altKey" | "shiftKey"
+	>,
+	platform: string,
+): boolean {
+	return isPlainMacShortcut(event, platform, "c");
+}
+
+export function isTerminalPasteShortcut(
+	event: Pick<
+		ClipboardShortcutEvent,
+		"key" | "metaKey" | "ctrlKey" | "altKey" | "shiftKey"
+	>,
+	platform: string,
+): boolean {
+	return isPlainMacShortcut(event, platform, "v");
+}
+
+/**
+ * Handle terminal clipboard shortcuts directly so copy/paste does not depend on
+ * the browser generating native clipboard events for the focused textarea.
+ */
+export function handleTerminalClipboardShortcut(
+	event: ClipboardShortcutEvent,
+	platform: string,
+	handlers: {
+		onCopy: () => void | Promise<void>;
+		onPaste: () => void | Promise<void>;
+	},
+): boolean {
+	if (isTerminalCopyShortcut(event, platform)) {
+		event.preventDefault();
+		event.stopPropagation();
+		void Promise.resolve(handlers.onCopy()).catch(() => {});
+		return true;
+	}
+
+	if (isTerminalPasteShortcut(event, platform)) {
+		event.preventDefault();
+		event.stopPropagation();
+		void Promise.resolve(handlers.onPaste()).catch(() => {});
+		return true;
+	}
+
+	return false;
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -22,6 +22,7 @@ import {
 	DEFAULT_THEME_ID,
 	getTerminalColors,
 } from "shared/themes";
+import { handleTerminalClipboardShortcut } from "./clipboardShortcuts";
 import { RESIZE_DEBOUNCE_MS, TERMINAL_OPTIONS } from "./config";
 import { FilePathLinkProvider, UrlLinkProvider } from "./link-providers";
 import { suppressQueryResponses } from "./suppressQueryResponses";
@@ -310,6 +311,8 @@ export interface KeyboardHandlerOptions {
 	onShiftEnter?: () => void;
 	/** Callback for the configured clear terminal shortcut */
 	onClear?: () => void;
+	onCopy?: () => void | Promise<void>;
+	onPaste?: () => void | Promise<void>;
 	onWrite?: (data: string) => void;
 }
 
@@ -682,6 +685,14 @@ export function setupKeyboardHandler(
 			// The original event bubbles to document where useAppHotkey handles it.
 			return false;
 		}
+
+		if (
+			handleTerminalClipboardShortcut(event, platform, {
+				onCopy: () => options.onCopy?.(),
+				onPaste: () => options.onPaste?.(),
+			})
+		)
+			return false;
 
 		return true;
 	};

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
@@ -737,7 +737,6 @@ export function useTerminalLifecycle({
 			onPaste: (text) => {
 				commandBufferRef.current += text;
 			},
-			onWrite: handleWrite,
 			isBracketedPasteEnabled: () => isBracketedPasteRef.current,
 		});
 		const cleanupCopy = setupCopyHandler(xterm);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
@@ -696,17 +696,6 @@ export function useTerminalLifecycle({
 			writeRef.current({ paneId, data });
 		};
 
-		const cleanupKeyboard = setupKeyboardHandler(xterm, {
-			onShiftEnter: () => handleWrite("\x1b\r"),
-			onClear: handleClear,
-			onWrite: handleWrite,
-		});
-		const cleanupClickToMove = setupClickToMoveCursor(xterm, {
-			onWrite: handleWrite,
-		});
-		registerClearCallbackRef.current(paneId, handleClear);
-		registerScrollToBottomCallbackRef.current(paneId, handleScrollToBottom);
-
 		const handleGetSelection = () => {
 			const selection = xterm.getSelection();
 			if (!selection) return "";
@@ -715,6 +704,46 @@ export function useTerminalLifecycle({
 				.map((line) => line.trimEnd())
 				.join("\n");
 		};
+
+		const handleCopyShortcut = async () => {
+			const selection = handleGetSelection();
+			if (!selection) return;
+			try {
+				await electronTrpcClient.external.copyText.mutate(selection);
+			} catch {
+				// Clipboard access failed
+			}
+		};
+
+		const handlePasteShortcut = async () => {
+			if (isExitedRef.current) return;
+			try {
+				const clipboard =
+					await electronTrpcClient.external.readClipboard.query();
+				if (clipboard.text) {
+					xterm.paste(clipboard.text);
+					return;
+				}
+				if (clipboard.hasData) {
+					handleWrite("\x16");
+				}
+			} catch {
+				// Clipboard access failed
+			}
+		};
+
+		const cleanupKeyboard = setupKeyboardHandler(xterm, {
+			onShiftEnter: () => handleWrite("\x1b\r"),
+			onClear: handleClear,
+			onCopy: handleCopyShortcut,
+			onPaste: handlePasteShortcut,
+			onWrite: handleWrite,
+		});
+		const cleanupClickToMove = setupClickToMoveCursor(xterm, {
+			onWrite: handleWrite,
+		});
+		registerClearCallbackRef.current(paneId, handleClear);
+		registerScrollToBottomCallbackRef.current(paneId, handleScrollToBottom);
 
 		const handlePaste = (text: string) => {
 			if (isExitedRef.current) return;


### PR DESCRIPTION
## Description

Keyboard paste in the desktop terminal currently takes a different path than the terminal context menu paste action. In `useTerminalLifecycle`, the browser paste flow wires `setupPasteHandler` with `onWrite`, which makes Superset write pasted text directly to the PTY and only add bracketed-paste wrappers when Superset's local `isBracketedPasteEnabled` tracking says bracketed paste is on.

That creates a mismatch for terminal TUIs that rely on bracketed paste to distinguish typed input from pasted input. In my local repro, multi-line `Cmd+V` paste into pi inside a Superset terminal failed while right-click → Paste worked. The context menu path already goes through `xterm.paste(text)`, so it preserves xterm's normal paste handling instead of depending on Superset's bracketed-paste mode tracking.

This change makes the keyboard/browser paste flow use the same xterm paste path by stopping `useTerminalLifecycle` from passing `onWrite` into `setupPasteHandler`.

## Related Issues

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

Ran:

- `bunx @biomejs/biome check apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts`
- `git diff --check`

Manual repro for reviewers:

1. Open Superset Desktop and start a terminal pane.
2. Launch a TUI that uses bracketed paste, such as `pi`.
3. Copy multi-line text.
4. Paste with `Cmd+V` (or the platform keyboard paste shortcut).
5. Verify the TUI receives the paste as a paste event rather than submitting or typing it line-by-line.

## Screenshots (if applicable)

N/A

## Additional Notes

I did not add a regression test here because the change is in the `useTerminalLifecycle` wiring rather than `setupPasteHandler` itself, and the existing terminal tests in this area do not currently exercise that hook-to-helper configuration boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal now handles copy/paste keyboard shortcuts directly and integrates with the system clipboard for more reliable copy and paste behavior.
* **Tests**
  * Added automated tests validating terminal copy/paste shortcut recognition and handling.
* **Refactor**
  * Simplified internal paste handling flow for more consistent terminal paste behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->