### PR TITLE
fix(desktop): disable xterm.js automatic contrast color adjustment

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -62,6 +62,7 @@ function createTerminal(
 		cursorInactiveStyle: "outline",
 		vtExtensions: { kittyKeyboard: true },
 		scrollbar: { showScrollbar: false },
+		minimumContrastRatio: 1,
 	});
 	terminal.loadAddon(fitAddon);
 	terminal.loadAddon(serializeAddon);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/config.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/config.ts
@@ -40,4 +40,5 @@ export const TERMINAL_OPTIONS: ITerminalOptions = {
 	scrollbar: {
 		showScrollbar: false,
 	},
+	minimumContrastRatio: 1,
 };


### PR DESCRIPTION
## Problem

xterm.js 6.x beta changed the default `minimumContrastRatio` from `1` (no enforcement) to a higher value to improve accessibility. This causes the built-in contrast adjustment algorithm to boost low-contrast foreground colors — grey text that tools like Copilot emit for chat messages gets pushed to white, making it visually indistinguishable from normal terminal output.

## Solution

Explicitly set `minimumContrastRatio: 1` in both terminal construction sites to restore the previous behavior and preserve original ANSI colors.

## Why not keep the higher default?

The contrast enforcement is well-intentioned (WCAG AA recommends 4.5:1 for normal text), but it's too aggressive for a terminal that relies on subtle color distinctions. Our themes already have good contrast for primary text; the issue is specifically with intentionally dim/grey text being boosted.

## Changes

- `apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts` — added `minimumContrastRatio: 1`
- `apps/desktop/.../Terminal/config.ts` — added `minimumContrastRatio: 1`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable `xterm.js` automatic contrast adjustment by setting `minimumContrastRatio: 1` in the terminal runtime and config. Restores previous behavior so dim/grey ANSI text (e.g., Copilot chat) isn’t boosted to white.

<sup>Written for commit b262c846f1bc76d28287ae3a1ce75f6fe43363d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted terminal rendering configuration settings to refine visual display characteristics in the terminal component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->