### PR TITLE
fix(desktop): forward unregistered ctrl/meta chords to v1 terminal PTY

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -8,7 +8,11 @@ import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebglAddon } from "@xterm/addon-webgl";
 import type { ITheme } from "@xterm/xterm";
 import { Terminal as XTerm } from "@xterm/xterm";
-import { getBinding, isTerminalReservedEvent } from "renderer/hotkeys";
+import {
+	getBinding,
+	isTerminalReservedEvent,
+	resolveHotkeyFromEvent,
+} from "renderer/hotkeys";
 import type { DetectedLink } from "renderer/lib/terminal/links";
 import { TerminalLinkManager } from "renderer/lib/terminal/terminal-link-manager";
 import { electronTrpcClient as trpcClient } from "renderer/lib/trpc-client";
@@ -592,9 +596,9 @@ export function setupKeyboardHandler(
 			return false;
 		}
 
-		// Any other ctrl/meta combo → let it bubble to document for react-hotkeys-hook
-		if (event.type === "keydown" && (event.metaKey || event.ctrlKey))
-			return false;
+		// Only bubble chords registered as app hotkeys; everything else reaches the PTY.
+		// Mirrors v2 terminal-runtime.ts:21 (VSCode terminalInstance pattern).
+		if (resolveHotkeyFromEvent(event) !== null) return false;
 
 		return true;
 	};


### PR DESCRIPTION
## Summary

- Fixes #3385. v1 terminal swallowed every ctrl/meta chord, so TUIs (Claude Code, Codex, vim, tmux) and shell readline shortcuts (Ctrl+R, Ctrl+W, Ctrl+U) never reached the PTY.
- Mirrors the v2 pattern at `terminal-runtime.ts:21`: use `resolveHotkeyFromEvent` to only bubble chords actually registered as app hotkeys; everything else reaches the PTY.
- One-line change in `helpers.ts:597`.

## Before / after

Before: `if (event.metaKey || event.ctrlKey) return false;` — any modifier chord was blocked from xterm.
After: `if (resolveHotkeyFromEvent(event) !== null) return false;` — only registered app hotkeys bubble.

Registered app hotkeys (FIND_IN_TERMINAL, SCROLL_TO_BOTTOM, CLEAR_TERMINAL, QUICK_OPEN, …) still work. Reserved chords (Ctrl+C/D/Z/S/Q) still go to xterm as before.

## Test plan

- [ ] In a v1 terminal, press **Ctrl+R** at a bash/zsh prompt → `(reverse-i-search)` appears
- [ ] Ctrl+W / Ctrl+U / Ctrl+T / Ctrl+K behave normally in the shell
- [ ] Run `claude` in a v1 terminal → Ctrl+P (model switcher) and Ctrl+O (extended output) work
- [ ] FIND_IN_TERMINAL, SCROLL_TO_BOTTOM, CLEAR_TERMINAL, QUICK_OPEN still fire
- [ ] Ctrl+C / Ctrl+D / Ctrl+Z still reach xterm (SIGINT / EOF / SIGTSTP)
- [ ] Line/word motion unchanged: Cmd+←/→ and Opt+←/→ on mac, Ctrl+←/→ on Windows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward unregistered Ctrl/Meta chords to the v1 terminal PTY so TUIs and shell shortcuts work again. Only registered app hotkeys bubble to the app; everything else reaches xterm.

- **Bug Fixes**
  - Replaced the broad ctrl/meta check with resolveHotkeyFromEvent to match v2 behavior.
  - Restores shell readline and TUI shortcuts (Ctrl+R/W/U/T/K, Claude Code Ctrl+P/Ctrl+O). App hotkeys (FIND_IN_TERMINAL, SCROLL_TO_BOTTOM, CLEAR_TERMINAL, QUICK_OPEN) and reserved chords (Ctrl+C/D/Z/S/Q) stay unchanged.

<sup>Written for commit d5f06cedfbf64d83b73a1bd57f211535025a9cdd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved terminal keyboard input handling to ensure application hotkeys are properly recognized while allowing other keystrokes to flow through to the terminal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->