### PR TITLE
fix(desktop): enable modal focus trap on v1 + v2 workspace dialogs

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -73,7 +73,7 @@ export function NewWorkspaceModal() {
 		<NewWorkspaceModalDraftProvider onClose={closeModal}>
 			<PromptInputProvider>
 				<PromptInputResetSync />
-				<Dialog open={isOpen} onOpenChange={(open) => !open && closeModal()}>
+				<Dialog modal open={isOpen} onOpenChange={(open) => !open && closeModal()}>
 					<DialogHeader className="sr-only">
 						<DialogTitle>New Workspace</DialogTitle>
 						<DialogDescription>Create a new workspace</DialogDescription>

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -73,7 +73,11 @@ export function NewWorkspaceModal() {
 		<NewWorkspaceModalDraftProvider onClose={closeModal}>
 			<PromptInputProvider>
 				<PromptInputResetSync />
-				<Dialog modal open={isOpen} onOpenChange={(open) => !open && closeModal()}>
+				<Dialog
+					modal
+					open={isOpen}
+					onOpenChange={(open) => !open && closeModal()}
+				>
 					<DialogHeader className="sr-only">
 						<DialogTitle>New Workspace</DialogTitle>
 						<DialogDescription>Create a new workspace</DialogDescription>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceModal.tsx
@@ -51,7 +51,11 @@ export function DashboardNewWorkspaceModal() {
 		<DashboardNewWorkspaceDraftProvider onClose={closeModal}>
 			<PromptInputProvider>
 				<PromptInputResetSync />
-				<Dialog modal open={isOpen} onOpenChange={(open) => !open && closeModal()}>
+				<Dialog
+					modal
+					open={isOpen}
+					onOpenChange={(open) => !open && closeModal()}
+				>
 					<DialogHeader className="sr-only">
 						<DialogTitle>New Workspace</DialogTitle>
 						<DialogDescription>Create a new workspace</DialogDescription>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceModal.tsx
@@ -51,7 +51,7 @@ export function DashboardNewWorkspaceModal() {
 		<DashboardNewWorkspaceDraftProvider onClose={closeModal}>
 			<PromptInputProvider>
 				<PromptInputResetSync />
-				<Dialog open={isOpen} onOpenChange={(open) => !open && closeModal()}>
+				<Dialog modal open={isOpen} onOpenChange={(open) => !open && closeModal()}>
 					<DialogHeader className="sr-only">
 						<DialogTitle>New Workspace</DialogTitle>
 						<DialogDescription>Create a new workspace</DialogDescription>


### PR DESCRIPTION
## Summary
Supersedes #3276 (credit @kkjcheng) — applies the same focus-trap fix to both v1 (`NewWorkspaceModal`) and v2 (`DashboardNewWorkspaceModal`) Dialogs on the `sync-ws-v1-v2` branch.

The monorepo's `Dialog` wrapper (`packages/ui/src/components/ui/dialog.tsx`) overrides Radix's default and sets `modal = false`, so dialogs must opt in to get Radix's focus trap. Without `modal`, alt-tabbing away and back drops focus outside the dialog.

## Changes
- Add `modal` prop to `Dialog` in `NewWorkspaceModal.tsx` (v1)
- Add `modal` prop to `Dialog` in `DashboardNewWorkspaceModal.tsx` (v2)
- Both files already had `onFocusOutside={(e) => e.preventDefault()}` from earlier work

## Test plan
- [ ] Open the v1 new workspace modal, alt-tab away and back — typing lands in the prompt input
- [ ] Open the v2 dashboard new workspace modal, alt-tab away and back — typing lands in the prompt input
- [ ] Escape still closes both modals
- [ ] Overlay click still closes both modals