### PR TITLE
fix(desktop): v2 Open In editor is per-project, not per-workspace

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/V2OpenInMenuButton/V2OpenInMenuButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/V2OpenInMenuButton/V2OpenInMenuButton.tsx
@@ -18,6 +18,7 @@ import {
 } from "renderer/components/OpenInExternalDropdown";
 import { HotkeyLabel, useHotkey, useHotkeyDisplay } from "renderer/hotkeys";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useThemeStore } from "renderer/stores";
 
@@ -33,6 +34,7 @@ export function V2OpenInMenuButton({
 	projectId,
 }: V2OpenInMenuButtonProps) {
 	const collections = useCollections();
+	const { ensureProjectInSidebar } = useDashboardSidebarState();
 	const activeTheme = useThemeStore((state) => state.activeTheme);
 
 	const { data: sidebarProjectRows = [] } = useLiveQuery(
@@ -48,21 +50,12 @@ export function V2OpenInMenuButton({
 
 	const persistDefaultApp = useCallback(
 		(app: ExternalApp) => {
-			if (collections.v2SidebarProjects.get(projectId)) {
-				collections.v2SidebarProjects.update(projectId, (draft) => {
-					draft.defaultOpenInApp = app;
-				});
-				return;
-			}
-			collections.v2SidebarProjects.insert({
-				projectId,
-				createdAt: new Date(),
-				tabOrder: 0,
-				isCollapsed: false,
-				defaultOpenInApp: app,
+			ensureProjectInSidebar(projectId);
+			collections.v2SidebarProjects.update(projectId, (draft) => {
+				draft.defaultOpenInApp = app;
 			});
 		},
-		[collections, projectId],
+		[collections, ensureProjectInSidebar, projectId],
 	);
 
 	const openInApp = electronTrpc.external.openInApp.useMutation({

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/V2OpenInMenuButton/V2OpenInMenuButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/V2OpenInMenuButton/V2OpenInMenuButton.tsx
@@ -8,7 +8,9 @@ import {
 import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
-import { useCallback, useMemo, useState } from "react";
+import { eq } from "@tanstack/db";
+import { useLiveQuery } from "@tanstack/react-db";
+import { useCallback, useMemo } from "react";
 import { HiChevronDown } from "react-icons/hi2";
 import {
 	getAppOption,
@@ -22,35 +24,50 @@ import { useThemeStore } from "renderer/stores";
 interface V2OpenInMenuButtonProps {
 	worktreePath: string;
 	branch: string;
-	workspaceId: string;
+	projectId: string;
 }
 
 export function V2OpenInMenuButton({
 	worktreePath,
 	branch,
-	workspaceId,
+	projectId,
 }: V2OpenInMenuButtonProps) {
 	const collections = useCollections();
 	const activeTheme = useThemeStore((state) => state.activeTheme);
 
-	const localState = collections.v2WorkspaceLocalState.get(workspaceId);
-	const [defaultApp, setDefaultApp] = useState<ExternalApp>(
-		(localState?.defaultOpenInApp as ExternalApp) ?? "finder",
+	const { data: sidebarProjectRows = [] } = useLiveQuery(
+		(q) =>
+			q
+				.from({ sp: collections.v2SidebarProjects })
+				.where(({ sp }) => eq(sp.projectId, projectId))
+				.select(({ sp }) => ({ defaultOpenInApp: sp.defaultOpenInApp })),
+		[collections, projectId],
 	);
+	const resolvedApp: ExternalApp =
+		(sidebarProjectRows[0]?.defaultOpenInApp as ExternalApp | null) ?? "finder";
 
-	const handleDefaultAppChange = useCallback(
+	const persistDefaultApp = useCallback(
 		(app: ExternalApp) => {
-			setDefaultApp(app);
-			collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
-				draft.defaultOpenInApp = app;
+			if (collections.v2SidebarProjects.get(projectId)) {
+				collections.v2SidebarProjects.update(projectId, (draft) => {
+					draft.defaultOpenInApp = app;
+				});
+				return;
+			}
+			collections.v2SidebarProjects.insert({
+				projectId,
+				createdAt: new Date(),
+				tabOrder: 0,
+				isCollapsed: false,
+				defaultOpenInApp: app,
 			});
 		},
-		[collections, workspaceId],
+		[collections, projectId],
 	);
 
 	const openInApp = electronTrpc.external.openInApp.useMutation({
 		onSuccess: (_data, variables) => {
-			handleDefaultAppChange(variables.app);
+			persistDefaultApp(variables.app);
 		},
 		onError: (error) => toast.error(`Failed to open: ${error.message}`),
 	});
@@ -60,8 +77,8 @@ export function V2OpenInMenuButton({
 	});
 
 	const currentApp = useMemo(
-		() => getAppOption(defaultApp) ?? null,
-		[defaultApp],
+		() => getAppOption(resolvedApp) ?? null,
+		[resolvedApp],
 	);
 	const openInDisplay = useHotkeyDisplay("OPEN_IN_APP");
 	const copyPathDisplay = useHotkeyDisplay("COPY_PATH");
@@ -72,8 +89,8 @@ export function V2OpenInMenuButton({
 
 	const handleOpenInEditor = useCallback(() => {
 		if (openInApp.isPending || copyPath.isPending) return;
-		openInApp.mutate({ path: worktreePath, app: defaultApp });
-	}, [worktreePath, defaultApp, openInApp, copyPath.isPending]);
+		openInApp.mutate({ path: worktreePath, app: resolvedApp });
+	}, [worktreePath, resolvedApp, openInApp, copyPath.isPending]);
 
 	const handleOpenInOtherApp = useCallback(
 		(appId: ExternalApp) => {
@@ -162,12 +179,12 @@ export function V2OpenInMenuButton({
 				<DropdownMenuContent align="end" className="w-48">
 					<OpenInExternalDropdownItems
 						isDark={isDark}
-						activeApp={defaultApp}
+						activeApp={resolvedApp}
 						onOpenIn={handleOpenInOtherApp}
 						onCopyPath={handleCopyPath}
 						renderAppTrailing={(appId, group) => {
 							if (
-								appId !== defaultApp ||
+								appId !== resolvedApp ||
 								!showOpenInShortcut ||
 								group === "jetbrains"
 							) {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/V2WorkspaceOpenInButton/V2WorkspaceOpenInButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/V2WorkspaceOpenInButton/V2WorkspaceOpenInButton.tsx
@@ -27,6 +27,7 @@ export function V2WorkspaceOpenInButton({
 				.select(({ workspaces, hosts }) => ({
 					id: workspaces.id,
 					branch: workspaces.branch,
+					projectId: workspaces.projectId,
 					hostMachineId: hosts?.machineId ?? null,
 				})),
 		[collections, workspaceId],
@@ -56,7 +57,7 @@ export function V2WorkspaceOpenInButton({
 		<V2OpenInMenuButton
 			branch={workspace.branch}
 			worktreePath={workspaceQuery.data.worktreePath}
-			workspaceId={workspace.id}
+			projectId={workspace.projectId}
 		/>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -10,6 +10,7 @@ export const dashboardSidebarProjectSchema = z.object({
 	createdAt: persistedDateSchema,
 	isCollapsed: z.boolean().default(false),
 	tabOrder: z.number().int().default(0),
+	defaultOpenInApp: z.string().nullable().default(null),
 });
 
 const paneWorkspaceStateSchema = z.custom<WorkspaceState<unknown>>();
@@ -39,7 +40,6 @@ export const workspaceLocalStateSchema = z.object({
 	}),
 	paneLayout: paneWorkspaceStateSchema,
 	rightSidebarOpen: z.boolean().default(false),
-	defaultOpenInApp: z.string().nullable().default(null),
 	viewedFiles: z.array(z.string()).default([]),
 });
 


### PR DESCRIPTION
## Summary
- v2 top-bar "Open In <editor>" picker was writing to `v2WorkspaceLocalState.defaultOpenInApp` (per-workspace localStorage), so switching workspaces inside the same project silently reset the picker.
- Move the setting to the per-project `v2SidebarProjects` collection: read reactively via `useLiveQuery`, persist via `collections.v2SidebarProjects.update(projectId, ...)` with a defensive insert fallback. The choice is now shared across every workspace in a project.
- Plumb `projectId` through `V2WorkspaceOpenInButton` and drop the now-unused `workspaceId` prop. `openInApp` mutations no longer pass `projectId`, so persistence lives entirely on the client-side react-db collection and the server-side `projects.defaultApp` SQLite column is left alone.
- Remove the dead `defaultOpenInApp` field from `workspaceLocalStateSchema`. Stale values in existing localStorage entries are silently dropped by Zod on next parse.

## Test plan
- [x] `bun run lint`
- [x] `bunx turbo typecheck --filter @superset/desktop`
- [x] `bunx turbo test --filter @superset/desktop` (1593 pass)
- [ ] Manual: pick Cursor in workspace A of project X → switch to workspace B in the same project → picker still shows Cursor.
- [ ] Manual: switch to a workspace in a different project Y that has never had a choice made → picker falls back to Finder / the global seed.
- [ ] Manual: quit and relaunch → per-project choice persists.

Note: v2 file-tree / diff-pane clicks still resolve `openFileInEditor` through `resolveDefaultEditor(projectId)` in the main process, which reads the SQLite `projects.defaultApp` column (now unwritten by the v2 path) and falls back to `settings.defaultEditor`. Making those call sites honor the per-project react-db choice is a follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the v2 top-bar “Open In <editor>” setting per-project, so the choice persists across workspaces in the same project. Persistence lives in the per-project sidebar collection and uses the sidebar state helper to create rows correctly.

- **Bug Fixes**
  - Persist selection in `v2SidebarProjects` (read via `useLiveQuery`); call `ensureProjectInSidebar` before `update(...)` to avoid phantom rows and keep tab order.
  - Pass `projectId` to `V2WorkspaceOpenInButton`/`V2OpenInMenuButton` and remove `workspaceId`; do not send `projectId` to `openInApp`.
  - Add `defaultOpenInApp` to `dashboardSidebarProjectSchema`; remove it from `workspaceLocalStateSchema` and ignore stale localStorage values.

<sup>Written for commit d2722b8a259e9fe1bf10bfac0525e84d14b129e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Default "Open In" preference is now scoped per project instead of per workspace.
  * Project-level preference is persisted live to the database so changes are retained across sessions.
  * UI and shortcuts now respect the resolved project preference with a sensible fallback when none is set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->