### PR TITLE
fix(desktop): stop silently routing electronTrpc font-settings query through host-service

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/WorkspaceDiff/WorkspaceDiff.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/WorkspaceDiff/WorkspaceDiff.tsx
@@ -1,9 +1,9 @@
 import { MultiFileDiff } from "@pierre/diffs/react";
 import { toast } from "@superset/ui/sonner";
 import { workspaceTrpc } from "@superset/workspace-client";
+import { useQuery } from "@tanstack/react-query";
 import { memo, useMemo } from "react";
 import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
-import { electronTrpc } from "renderer/lib/electron-trpc";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import {
 	getDiffsTheme,
@@ -47,10 +47,15 @@ export const WorkspaceDiff = memo(function WorkspaceDiff({
 	onOpenFile,
 }: WorkspaceDiffProps) {
 	const activeTheme = useResolvedTheme();
-	const { data: fontSettings } = electronTrpc.settings.getFontSettings.useQuery(
-		undefined,
-		{ staleTime: 30_000 },
-	);
+	// Uses the imperative electron tRPC client rather than electronTrpc.X.useQuery
+	// because @trpc/react-query's default React context is a module-level
+	// singleton — nesting workspaceTrpc.Provider overrides it and silently
+	// routes electronTrpc hooks through the host-service HTTP link.
+	const { data: fontSettings } = useQuery({
+		queryKey: ["electron", "settings", "getFontSettings"],
+		queryFn: () => electronTrpcClient.settings.getFontSettings.query(),
+		staleTime: 30_000,
+	});
 	const shikiTheme = getDiffsTheme(activeTheme);
 	const parsedEditorFontSize =
 		typeof fontSettings?.editorFontSize === "number"

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/WorkspaceDiff/WorkspaceDiff.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/WorkspaceDiff/WorkspaceDiff.tsx
@@ -47,10 +47,6 @@ export const WorkspaceDiff = memo(function WorkspaceDiff({
 	onOpenFile,
 }: WorkspaceDiffProps) {
 	const activeTheme = useResolvedTheme();
-	// Uses the imperative electron tRPC client rather than electronTrpc.X.useQuery
-	// because @trpc/react-query's default React context is a module-level
-	// singleton — nesting workspaceTrpc.Provider overrides it and silently
-	// routes electronTrpc hooks through the host-service HTTP link.
 	const { data: fontSettings } = useQuery({
 		queryKey: ["electron", "settings", "getFontSettings"],
 		queryFn: () => electronTrpcClient.settings.getFontSettings.query(),

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/hooks/useTerminalAppearance/useTerminalAppearance.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/hooks/useTerminalAppearance/useTerminalAppearance.ts
@@ -13,10 +13,6 @@ const fallbackTheme = getDefaultTerminalAppearance().theme;
 
 export function useTerminalAppearance(): TerminalAppearance {
 	const terminalTheme = useTerminalTheme();
-	// Uses the imperative electron tRPC client rather than electronTrpc.X.useQuery
-	// because @trpc/react-query's default React context is a module-level
-	// singleton — nesting workspaceTrpc.Provider overrides it and silently
-	// routes electronTrpc hooks through the host-service HTTP link.
 	const { data: fontSettings } = useQuery({
 		queryKey: ["electron", "settings", "getFontSettings"],
 		queryFn: () => electronTrpcClient.settings.getFontSettings.query(),

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/hooks/useTerminalAppearance/useTerminalAppearance.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/hooks/useTerminalAppearance/useTerminalAppearance.ts
@@ -1,23 +1,27 @@
+import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
-import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
 	DEFAULT_TERMINAL_FONT_FAMILY,
 	DEFAULT_TERMINAL_FONT_SIZE,
 	getDefaultTerminalAppearance,
 	type TerminalAppearance,
 } from "renderer/lib/terminal/appearance";
+import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { useTerminalTheme } from "renderer/stores/theme";
 
 const fallbackTheme = getDefaultTerminalAppearance().theme;
 
 export function useTerminalAppearance(): TerminalAppearance {
 	const terminalTheme = useTerminalTheme();
-	const { data: fontSettings } = electronTrpc.settings.getFontSettings.useQuery(
-		undefined,
-		{
-			staleTime: 30_000,
-		},
-	);
+	// Uses the imperative electron tRPC client rather than electronTrpc.X.useQuery
+	// because @trpc/react-query's default React context is a module-level
+	// singleton — nesting workspaceTrpc.Provider overrides it and silently
+	// routes electronTrpc hooks through the host-service HTTP link.
+	const { data: fontSettings } = useQuery({
+		queryKey: ["electron", "settings", "getFontSettings"],
+		queryFn: () => electronTrpcClient.settings.getFontSettings.query(),
+		staleTime: 30_000,
+	});
 
 	return useMemo(() => {
 		const theme = terminalTheme ?? fallbackTheme;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/CodeEditor.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/CodeEditor.tsx
@@ -23,8 +23,9 @@ import {
 	lineNumbers,
 } from "@codemirror/view";
 import { cn } from "@superset/ui/utils";
+import { useQuery } from "@tanstack/react-query";
 import { type MutableRefObject, useEffect, useRef } from "react";
-import { electronTrpc } from "renderer/lib/electron-trpc";
+import { electronTrpcClient } from "renderer/lib/trpc-client";
 import type { CodeEditorAdapter } from "renderer/screens/main/components/WorkspaceView/ContentView/components";
 import { getCodeSyntaxHighlighting } from "renderer/screens/main/components/WorkspaceView/utils/code-theme";
 import { useResolvedTheme } from "renderer/stores/theme";
@@ -179,12 +180,16 @@ export function CodeEditor({
 	const onSaveRef = useRef(onSave);
 	// Guards against re-entrant onChange calls triggered by the value-sync effect's own dispatch.
 	const isExternalUpdateRef = useRef(false);
-	const { data: fontSettings } = electronTrpc.settings.getFontSettings.useQuery(
-		undefined,
-		{
-			staleTime: 30_000,
-		},
-	);
+	// Uses the imperative electron tRPC client rather than electronTrpc.X.useQuery
+	// because @trpc/react-query's default React context is a module-level
+	// singleton — when rendered inside v2's workspaceTrpc.Provider the nested
+	// provider overrides it and silently routes these hooks through the
+	// host-service HTTP link.
+	const { data: fontSettings } = useQuery({
+		queryKey: ["electron", "settings", "getFontSettings"],
+		queryFn: () => electronTrpcClient.settings.getFontSettings.query(),
+		staleTime: 30_000,
+	});
 	const editorFontFamily = fontSettings?.editorFontFamily ?? undefined;
 	const editorFontSize = fontSettings?.editorFontSize ?? undefined;
 	const activeTheme = useResolvedTheme();

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/CodeEditor.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/CodeEditor.tsx
@@ -180,11 +180,6 @@ export function CodeEditor({
 	const onSaveRef = useRef(onSave);
 	// Guards against re-entrant onChange calls triggered by the value-sync effect's own dispatch.
 	const isExternalUpdateRef = useRef(false);
-	// Uses the imperative electron tRPC client rather than electronTrpc.X.useQuery
-	// because @trpc/react-query's default React context is a module-level
-	// singleton — when rendered inside v2's workspaceTrpc.Provider the nested
-	// provider overrides it and silently routes these hooks through the
-	// host-service HTTP link.
 	const { data: fontSettings } = useQuery({
 		queryKey: ["electron", "settings", "getFontSettings"],
 		queryFn: () => electronTrpcClient.settings.getFontSettings.query(),


### PR DESCRIPTION
## Summary

`@trpc/react-query` uses a module-level singleton React context when `createTRPCReact()` is called without an explicit `context`. Both `electronTrpc` (`apps/desktop/src/renderer/lib/electron-trpc.ts`) and `workspaceTrpc` (`packages/workspace-client/src/workspace-trpc.ts`) do this, so nesting `<workspaceTrpc.Provider>` inside the v2 workspace layout overrides that singleton — and every `electronTrpc.*.useQuery(...)` call rendered under it silently routes through the workspace HTTP link instead of the Electron IPC link.

The visible symptom was a recurring `TRPCError: No procedure found on path "settings.getFontSettings"` coming from `host-service.js` whenever v2 workspace panes mounted (Terminal, WorkspaceDiff, FilePane code/markdown renderers).

Rather than introduce a new React context and re-test v2's provider wiring, this PR matches the pattern v2 already uses everywhere else — the imperative `electronTrpcClient` proxy — and wraps the query in a plain `@tanstack/react-query` `useQuery`. That bypasses trpc-react-query's shared context entirely.

Files touched:
- `useTerminalAppearance` — v2 terminal font/theme hook
- `WorkspaceDiff` — v2 diff pane
- `CodeEditor` (v1, reused in v2's `FilePane` code/markdown renderers)

`Terminal.tsx` and `LightDiffViewer.tsx` also use the React hook form, but neither is rendered inside v2's `WorkspaceTrpcProvider`, so they're left alone.

## Test plan
- [x] `bun run typecheck` (desktop) passes
- [x] `bun run lint:fix` clean
- [x] `bun test apps/desktop` — same baseline as `main` (1 pre-existing fail in `trpc-storage`/`useOrderedSections`, unrelated)
- [ ] Manually open a v2 workspace, mount a terminal pane, a diff pane, and a file pane with a code file; confirm no `settings.getFontSettings` 404s in logs and that editor/terminal font settings still apply

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix v2 panes routing font settings queries through the workspace HTTP link. Switch to `electronTrpcClient` wrapped in `@tanstack/react-query` `useQuery` so font settings go through Electron IPC and apply correctly in Terminal, Diff, and CodeEditor.

- **Bug Fixes**
  - Replaced `electronTrpc.settings.getFontSettings.useQuery` with `useQuery({ queryKey: ["electron","settings","getFontSettings"], queryFn: () => electronTrpcClient.settings.getFontSettings.query(), staleTime: 30_000 })`.
  - Updated `useTerminalAppearance`, `WorkspaceDiff`, and `CodeEditor`; removed inline comments from this workaround.
  - Avoids `@trpc/react-query` shared context bleed from nested `workspaceTrpc.Provider`, preventing host-service 404s/`TRPCError` on `settings.getFontSettings`.

<sup>Written for commit 03f3c3d5badc8c9cbc0a4d070a042df843fef707. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized how font settings are loaded across workspace editor, terminal, and code editor so font choices and sizes remain consistent and more reliable across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->