### PR TITLE
feat(desktop): modifier+click in file tree — external editor / new tab

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -9,7 +9,7 @@ import { useChangesTab } from "./hooks/useChangesTab";
 import type { SidebarTabDefinition } from "./types";
 
 interface WorkspaceSidebarProps {
-	onSelectFile: (absolutePath: string) => void;
+	onSelectFile: (absolutePath: string, openInNewTab?: boolean) => void;
 	onSelectDiffFile?: (path: string) => void;
 	onSearch?: () => void;
 	selectedFilePath?: string;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
@@ -4,6 +4,8 @@ import { Button } from "@superset/ui/button";
 import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { workspaceTrpc } from "@superset/workspace-client";
+import { eq } from "@tanstack/db";
+import { useLiveQuery } from "@tanstack/react-db";
 import type { inferRouterOutputs } from "@trpc/server";
 import { FilePlus, FolderPlus, FoldVertical, RefreshCw } from "lucide-react";
 import { Fragment, useCallback, useEffect, useRef, useState } from "react";
@@ -16,6 +18,9 @@ import {
 	useGitStatusMap,
 } from "renderer/hooks/host-service/useGitStatusMap";
 import { useWorkspaceEvent } from "renderer/hooks/host-service/useWorkspaceEvent";
+import { electronTrpcClient } from "renderer/lib/trpc-client";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import {
 	ROW_HEIGHT,
 	TREE_INDENT,
@@ -31,7 +36,7 @@ type InlineEditState =
 	| null;
 
 interface FilesTabProps {
-	onSelectFile: (absolutePath: string) => void;
+	onSelectFile: (absolutePath: string, openInNewTab?: boolean) => void;
 	selectedFilePath?: string;
 	workspaceId: string;
 	workspaceName?: string;
@@ -55,6 +60,7 @@ function TreeNode({
 	folderStatusByPath,
 	ignoredPaths,
 	onSelectFile,
+	onOpenInEditor,
 	onToggleDirectory,
 	onInlineEditSubmit,
 	onInlineEditCancel,
@@ -74,7 +80,8 @@ function TreeNode({
 	fileStatusByPath: Map<string, FileStatus>;
 	folderStatusByPath: Map<string, FileStatus>;
 	ignoredPaths: Set<string>;
-	onSelectFile: (absolutePath: string) => void;
+	onSelectFile: (absolutePath: string, openInNewTab?: boolean) => void;
+	onOpenInEditor: (absolutePath: string) => void;
 	onToggleDirectory: (absolutePath: string) => void;
 	onInlineEditSubmit: (name: string) => void;
 	onInlineEditCancel: () => void;
@@ -127,6 +134,7 @@ function TreeNode({
 					decoration={decoration}
 					isMuted={isMuted}
 					onSelectFile={onSelectFile}
+					onOpenInEditor={onOpenInEditor}
 					onToggleDirectory={onToggleDirectory}
 					onNewFile={onNewFile}
 					onNewFolder={onNewFolder}
@@ -162,6 +170,7 @@ function TreeNode({
 									folderStatusByPath={folderStatusByPath}
 									ignoredPaths={ignoredPaths}
 									onSelectFile={onSelectFile}
+									onOpenInEditor={onOpenInEditor}
 									onToggleDirectory={onToggleDirectory}
 									onInlineEditSubmit={onInlineEditSubmit}
 									onInlineEditCancel={onInlineEditCancel}
@@ -210,6 +219,45 @@ export function FilesTab({
 		id: workspaceId,
 	});
 	const rootPath = workspaceQuery.data?.worktreePath ?? "";
+	const projectId = workspaceQuery.data?.projectId;
+
+	const collections = useCollections();
+	const { machineId } = useLocalHostService();
+	const { data: workspacesWithHost = [] } = useLiveQuery(
+		(q) =>
+			q
+				.from({ workspaces: collections.v2Workspaces })
+				.leftJoin({ hosts: collections.v2Hosts }, ({ workspaces, hosts }) =>
+					eq(workspaces.hostId, hosts.id),
+				)
+				.where(({ workspaces }) => eq(workspaces.id, workspaceId))
+				.select(({ hosts }) => ({
+					hostMachineId: hosts?.machineId ?? null,
+				})),
+		[collections, workspaceId],
+	);
+	const isLocalWorkspace = workspacesWithHost[0]?.hostMachineId === machineId;
+
+	const handleOpenInEditor = useCallback(
+		(absolutePath: string) => {
+			if (!isLocalWorkspace) {
+				toast.error("Opening in editor is only supported on local workspaces");
+				return;
+			}
+			electronTrpcClient.external.openFileInEditor
+				.mutate({
+					path: absolutePath,
+					cwd: rootPath || undefined,
+					projectId,
+				})
+				.catch((err) => {
+					toast.error("Couldn't open file", {
+						description: err instanceof Error ? err.message : String(err),
+					});
+				});
+		},
+		[isLocalWorkspace, rootPath, projectId],
+	);
 
 	const writeFile = workspaceTrpc.filesystem.writeFile.useMutation();
 	const createDirectory =
@@ -566,6 +614,7 @@ export function FilesTab({
 										folderStatusByPath={folderStatusByPath}
 										ignoredPaths={ignoredPaths}
 										onSelectFile={onSelectFile}
+										onOpenInEditor={handleOpenInEditor}
 										onToggleDirectory={(absolutePath) =>
 											void fileTree.toggle(absolutePath)
 										}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
@@ -1,4 +1,5 @@
 import type { AppRouter } from "@superset/host-service";
+import type { ExternalApp } from "@superset/local-db";
 import { alert } from "@superset/ui/atoms/Alert";
 import { Button } from "@superset/ui/button";
 import { toast } from "@superset/ui/sonner";
@@ -238,25 +239,32 @@ export function FilesTab({
 	);
 	const isLocalWorkspace = workspacesWithHost[0]?.hostMachineId === machineId;
 
+	const { data: sidebarProjectRows = [] } = useLiveQuery(
+		(q) =>
+			q
+				.from({ sp: collections.v2SidebarProjects })
+				.where(({ sp }) => eq(sp.projectId, projectId ?? ""))
+				.select(({ sp }) => ({ defaultOpenInApp: sp.defaultOpenInApp })),
+		[collections, projectId],
+	);
+	const resolvedOpenInApp: ExternalApp =
+		(sidebarProjectRows[0]?.defaultOpenInApp as ExternalApp | null) ?? "finder";
+
 	const handleOpenInEditor = useCallback(
 		(absolutePath: string) => {
 			if (!isLocalWorkspace) {
 				toast.error("Opening in editor is only supported on local workspaces");
 				return;
 			}
-			electronTrpcClient.external.openFileInEditor
-				.mutate({
-					path: absolutePath,
-					cwd: rootPath || undefined,
-					projectId,
-				})
+			electronTrpcClient.external.openInApp
+				.mutate({ path: absolutePath, app: resolvedOpenInApp })
 				.catch((err) => {
 					toast.error("Couldn't open file", {
 						description: err instanceof Error ? err.message : String(err),
 					});
 				});
 		},
-		[isLocalWorkspace, rootPath, projectId],
+		[isLocalWorkspace, resolvedOpenInApp],
 	);
 
 	const writeFile = workspaceTrpc.filesystem.writeFile.useMutation();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
@@ -237,7 +237,7 @@ export function FilesTab({
 				})),
 		[collections, workspaceId],
 	);
-	const isLocalWorkspace = workspacesWithHost[0]?.hostMachineId === machineId;
+	const workspaceHost = workspacesWithHost[0];
 
 	const { data: sidebarProjectRows = [] } = useLiveQuery(
 		(q) =>
@@ -252,7 +252,8 @@ export function FilesTab({
 
 	const handleOpenInEditor = useCallback(
 		(absolutePath: string) => {
-			if (!isLocalWorkspace) {
+			if (!workspaceHost) return;
+			if (workspaceHost.hostMachineId !== machineId) {
 				toast.error("Opening in editor is only supported on local workspaces");
 				return;
 			}
@@ -264,7 +265,7 @@ export function FilesTab({
 					});
 				});
 		},
-		[isLocalWorkspace, resolvedOpenInApp],
+		[workspaceHost, machineId, resolvedOpenInApp],
 	);
 
 	const writeFile = workspaceTrpc.filesystem.writeFile.useMutation();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/WorkspaceFilesTreeItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/WorkspaceFilesTreeItem.tsx
@@ -39,7 +39,8 @@ interface WorkspaceFilesTreeItemProps {
 	isHovered?: boolean;
 	decoration?: FileStatus;
 	isMuted?: boolean;
-	onSelectFile: (absolutePath: string) => void;
+	onSelectFile: (absolutePath: string, openInNewTab?: boolean) => void;
+	onOpenInEditor: (absolutePath: string) => void;
 	onToggleDirectory: (absolutePath: string) => void;
 	onNewFile: (parentPath: string) => void;
 	onNewFolder: (parentPath: string) => void;
@@ -57,6 +58,7 @@ function WorkspaceFilesTreeItemComponent({
 	decoration,
 	isMuted,
 	onSelectFile,
+	onOpenInEditor,
 	onToggleDirectory,
 	onNewFile,
 	onNewFolder,
@@ -88,11 +90,17 @@ function WorkspaceFilesTreeItemComponent({
 							: undefined,
 						isSelected ? "!bg-accent" : undefined,
 					)}
-					onClick={() =>
-						isFolder
-							? onToggleDirectory(node.absolutePath)
-							: onSelectFile(node.absolutePath)
-					}
+					onClick={(e) => {
+						if (e.metaKey || e.ctrlKey) {
+							onOpenInEditor(node.absolutePath);
+						} else if (isFolder) {
+							onToggleDirectory(node.absolutePath);
+						} else if (e.shiftKey) {
+							onSelectFile(node.absolutePath, true);
+						} else {
+							onSelectFile(node.absolutePath);
+						}
+					}}
 					style={{
 						height: rowHeight,
 						paddingLeft: 8 + (depth - 1) * indent,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -108,7 +108,7 @@ function WorkspaceContent({
 			const state = store.getState();
 			if (openInNewTab) {
 				state.addTab({
-					titleOverride: filePath.split("/").pop(),
+					titleOverride: filePath.split(/[/\\]/).pop(),
 					panes: [
 						{
 							kind: "file",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -104,8 +104,24 @@ function WorkspaceContent({
 	});
 
 	const openFilePane = useCallback(
-		(filePath: string) => {
+		(filePath: string, openInNewTab?: boolean) => {
 			const state = store.getState();
+			if (openInNewTab) {
+				state.addTab({
+					titleOverride: filePath.split("/").pop(),
+					panes: [
+						{
+							kind: "file",
+							data: {
+								filePath,
+								mode: "editor",
+								hasChanges: false,
+							} as FilePaneData,
+						},
+					],
+				});
+				return;
+			}
 			const active = state.getActivePane();
 			if (
 				active?.pane.kind === "file" &&

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileSearchResultItem/FileSearchResultItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileSearchResultItem/FileSearchResultItem.tsx
@@ -85,7 +85,9 @@ export function FileSearchResultItem({
 
 	const handleClick = (e: React.MouseEvent) => {
 		if (!entry.isDirectory) {
-			if (e.metaKey || e.ctrlKey) {
+			if (e.shiftKey) {
+				onActivate(entry, true);
+			} else if (e.metaKey || e.ctrlKey) {
 				onOpenInEditor(entry);
 			} else {
 				onActivate(entry);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileTreeItem/FileTreeItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/components/FileTreeItem/FileTreeItem.tsx
@@ -72,14 +72,16 @@ export function FileTreeItem({
 
 	const handleClick = (e: React.MouseEvent) => {
 		e.stopPropagation();
-		if (isFolder) {
+		if (e.metaKey || e.ctrlKey) {
+			onOpenInEditor(entry);
+		} else if (isFolder) {
 			if (isExpanded) {
 				item.collapse();
 			} else {
 				item.expand();
 			}
-		} else if (e.metaKey || e.ctrlKey) {
-			onOpenInEditor(entry);
+		} else if (e.shiftKey) {
+			onActivate(entry, true);
 		} else {
 			onActivate(entry);
 		}


### PR DESCRIPTION
## Summary
- **Meta/Ctrl+click** a file or folder in the file tree → opens in the configured external editor (Finder fallback if none set)
- **Shift+click** a file → opens it in a new internal tab
- Plain click / double-click / keyboard behavior unchanged

Wired up in **both** v1 (`FileTreeItem`, `FileSearchResultItem`) and v2 (`WorkspaceFilesTreeItem`) file trees — v2 had no modifier-key handling at all before, so Meta+click on a remote-host workspace would otherwise call local electron IPC against a path that doesn't exist on the user's machine. v2's `handleOpenInEditor` guards on `hostMachineId === machineId` (same pattern as `layout.tsx` and `V2WorkspaceOpenInButton`) and toasts "only supported on local workspaces" otherwise.

v2 also gains a real "open in new tab" pathway — `openFilePane` now accepts `openInNewTab?` and calls `store.addTab(...)` when true.

## Test plan
- [ ] v1 workspace: plain click a file → previews; Shift+click → new tab; Meta+click a file → external editor; Meta+click a folder → folder opens in editor/Finder
- [ ] v2 local workspace: same four gestures work
- [ ] v2 remote workspace: Meta+click shows "Opening in editor is only supported on local workspaces" toast; plain and Shift+click still work
- [ ] Search results list (v1) mirrors the file-row behavior
- [ ] Cmd+Enter on a keyboard-focused file still opens a new tab (regression check)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add modifier-clicks to the desktop file tree: Meta/Ctrl+click opens items in the external app, and Shift+click opens a file in a new tab. Works in v1 and v2; v2 respects the per-project “Open In” setting and handles remote workspaces safely.

- **New Features**
  - Meta/Ctrl+click opens files and folders via `electronTrpcClient.external.openInApp`; v2 resolves the app from `v2SidebarProjects.defaultOpenInApp` (fallback `finder`) and toasts on remote hosts.
  - Shift+click opens a new tab through `openFilePane(filePath, openInNewTab?)`; plain click, double-click, and keyboard shortcuts are unchanged.

- **Bug Fixes**
  - v2: defer the local/remote check until the host query resolves; Meta/Ctrl+click before it settles no-ops instead of showing a misleading toast.
  - New-tab titles use a separator-safe split, so Windows paths show only the filename.

<sup>Written for commit 444a897ddc6d4c6ec87d951a629c97e5887c8d95. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shift-click opens files in a new tab; Meta/Ctrl-click opens files in the external editor.
  * File selection across workspace sidebar, file tree and search results supports the "open in new tab" option.
  * New "open in editor" action attempts to open files in the workspace's external app and shows an error when not permitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->