### PR TITLE
fix(desktop): hide v2 sidebar LOC badge when workspace has no changes

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -174,13 +174,14 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 								</span>
 							) : (
 								<>
-									{diffStats && (
-										<DashboardSidebarWorkspaceDiffStats
-											additions={diffStats.additions}
-											deletions={diffStats.deletions}
-											isActive={isActive}
-										/>
-									)}
+									{diffStats &&
+										(diffStats.additions > 0 || diffStats.deletions > 0) && (
+											<DashboardSidebarWorkspaceDiffStats
+												additions={diffStats.additions}
+												deletions={diffStats.deletions}
+												isActive={isActive}
+											/>
+										)}
 									<div className="invisible flex items-center justify-end gap-1.5 opacity-0 transition-[opacity,visibility] group-hover:visible group-hover:opacity-100">
 										{shortcutLabel && (
 											<span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground">


### PR DESCRIPTION
## Summary
- In the v2 dashboard sidebar, suppress the `+0 −0` diff-stats badge when a workspace has no additions and no deletions.

## Test plan
- [ ] Open a clean v2 workspace — badge should not render.
- [ ] Make edits — badge appears with correct counts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the +0 −0 diff-stats badge in the v2 dashboard sidebar when a workspace has no additions or deletions. The badge now appears only when there are actual changes to reduce visual noise.

<sup>Written for commit c4babb1714cf4ebd63ca4212de3d2896853cc76f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diff statistics display in the workspace sidebar by preventing empty statistics (with no additions or deletions) from appearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->