### PR TITLE
fix(desktop): v2 file tree no longer waits on git.getStatus in shared tRPC batch

### DIFF
--- a/apps/desktop/src/renderer/hooks/host-service/useFileTree/useFileTree.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useFileTree/useFileTree.ts
@@ -215,10 +215,10 @@ export function useFileTree({
 			});
 
 			try {
-				const result = await utils.filesystem.listDirectory.fetch(
-					{ workspaceId, absolutePath },
-					{ staleTime: 0 },
-				);
+				const result = await utils.filesystem.listDirectory.fetch({
+					workspaceId,
+					absolutePath,
+				});
 
 				updateState((current) => {
 					const nextEntries = new Map(current.entriesByPath);

--- a/packages/host-service/src/app.ts
+++ b/packages/host-service/src/app.ts
@@ -81,7 +81,7 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 		"*",
 		cors({
 			origin: config.allowedOrigins,
-			allowHeaders: ["Content-Type", "Authorization"],
+			allowHeaders: ["Content-Type", "Authorization", "trpc-accept"],
 		}),
 	);
 

--- a/packages/workspace-client/src/providers/WorkspaceClientProvider/WorkspaceClientProvider.tsx
+++ b/packages/workspace-client/src/providers/WorkspaceClientProvider/WorkspaceClientProvider.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { httpBatchLink } from "@trpc/client";
+import { httpBatchStreamLink } from "@trpc/client";
 import { createContext, type ReactNode, useContext } from "react";
 import superjson from "superjson";
 import { workspaceTrpc } from "../../workspace-trpc";
@@ -57,7 +57,7 @@ function getWorkspaceClients(
 
 	const trpcClient = workspaceTrpc.createClient({
 		links: [
-			httpBatchLink({
+			httpBatchStreamLink({
 				url: `${hostUrl}/trpc`,
 				transformer: superjson,
 				headers: headers ?? (() => ({})),


### PR DESCRIPTION
## Summary

- **Root cause**: the workspace tRPC client used `httpBatchLink`, which returns a batched response only after *every* procedure in the batch resolves. On v2 workspace switch, `FilesTab`'s `filesystem.listDirectory` (a few ms of `fs.readdir`) was batched with `WorkspaceSidebar`'s `git.getStatus` (5–10s on a large monorepo: runs `git.status()`, `ls-files --others --ignored`, `buildBranch` ×2, `getChangedFilesForDiff`, and `git diff --numstat --cached` in parallel). Result: the file tree stalled behind git for every workspace switch even though its own work was done in ms.
- **Fix**: swap `httpBatchLink` → `httpBatchStreamLink` in `WorkspaceClientProvider`. Same batching, but responses stream as each procedure completes, so fast calls return immediately and slow calls stream later on the same connection. No per-procedure routing needed.
- Allow the `trpc-accept` header through the host-service CORS config (`httpBatchStreamLink` sends it to negotiate streamed responses; the existing `allowHeaders` list was rejecting it at preflight).
- Drop a now-unnecessary `staleTime: 0` override on `listDirectory.fetch` in `useFileTree` so React Query's default 5s stale window can serve rapid re-fetches from cache.

Explains all observations: v1 is unaffected (IPC, no HTTP batching), the Changes tab was fast because it re-used the already-cached git status, and the delay hit every switch because each new `workspaceId` warms a fresh git status.

## Test plan

- [ ] `bun dev` desktop, open a large monorepo workspace
- [ ] Open DevTools Network panel filtered to `/trpc`
- [ ] Switch between two v2 workspaces — file tree should render within the cost of one localhost round-trip while `git.getStatus` is still streaming
- [ ] Click Changes tab — still populates correctly once git finishes
- [ ] Switch back and forth a few times to confirm the fix holds on every switch
- [ ] Confirm `fs:events` invalidation still refreshes the file tree after on-disk changes
- [ ] `bun run typecheck` ✅
- [ ] `bun run lint` ✅

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the v2 file tree render immediately on workspace switch by streaming tRPC batch responses. Fixes long delays in large monorepos where `git.getStatus` was blocking `filesystem.listDirectory`.

- **Bug Fixes**
  - Swapped `httpBatchLink` → `httpBatchStreamLink` in `WorkspaceClientProvider` (`@trpc/client`) so each procedure streams back independently.
  - Allowed `trpc-accept` in host-service CORS to enable streamed responses.
  - Removed `staleTime: 0` override on `filesystem.listDirectory.fetch` to use the default cache window.

<sup>Written for commit 4898520f5f60a0efaaff97b9921fdeb698b3661d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CORS configuration to accept `trpc-accept` headers, improving request compatibility.
  * Refactored directory listing fetch behavior for consistency.
  * Updated data transport configuration to support streaming, enabling better performance for large data transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->