### PR TITLE
feat(desktop): focus neighbor workspace after v2 delete

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -42,7 +42,6 @@ export function DashboardSidebarWorkspaceItem({
 		handleOpenInFinder,
 		isActive,
 		isDeleteDialogOpen,
-		isDeleting,
 		isRenaming,
 		moveWorkspaceToSection,
 		removeWorkspaceFromSidebar,
@@ -129,7 +128,6 @@ export function DashboardSidebarWorkspaceItem({
 						onConfirm={handleDelete}
 						title={`Delete "${name || branch}"?`}
 						description="This will permanently delete the workspace."
-						isPending={isDeleting}
 					/>
 				)}
 			</>
@@ -191,7 +189,6 @@ export function DashboardSidebarWorkspaceItem({
 					onConfirm={handleDelete}
 					title={`Delete "${name || branch}"?`}
 					description="This will permanently delete the workspace."
-					isPending={isDeleting}
 				/>
 			)}
 		</>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
@@ -82,13 +82,6 @@ export function useDashboardSidebarWorkspaceItemActions({
 		const deletePromise = (async () => {
 			await apiTrpcClient.v2Workspace.delete.mutate({ id: workspaceId });
 			removeWorkspaceFromSidebar(workspaceId);
-			if (isActive) {
-				if (focusTargetId) {
-					await navigateToV2Workspace(focusTargetId, navigate);
-				} else {
-					await navigate({ to: "/" });
-				}
-			}
 		})();
 
 		toast.promise(deletePromise, {
@@ -96,6 +89,15 @@ export function useDashboardSidebarWorkspaceItemActions({
 			success: "Workspace deleted",
 			error: (error) =>
 				`Failed to delete: ${error instanceof Error ? error.message : "Unknown error"}`,
+		});
+
+		void deletePromise.then(() => {
+			if (!isActive) return;
+			if (focusTargetId) {
+				void navigateToV2Workspace(focusTargetId, navigate);
+			} else {
+				void navigate({ to: "/" });
+			}
 		});
 	};
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
@@ -2,7 +2,11 @@ import { toast } from "@superset/ui/sonner";
 import { useMatchRoute, useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
+import { getDeleteFocusTargetWorkspaceId } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/getDeleteFocusTargetWorkspaceId";
+import { getFlattenedV2WorkspaceIds } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/getFlattenedV2WorkspaceIds";
+import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 
 interface UseDashboardSidebarWorkspaceItemActionsOptions {
 	workspaceId: string;
@@ -17,13 +21,13 @@ export function useDashboardSidebarWorkspaceItemActions({
 }: UseDashboardSidebarWorkspaceItemActionsOptions) {
 	const navigate = useNavigate();
 	const matchRoute = useMatchRoute();
+	const collections = useCollections();
 	const { createSection, moveWorkspaceToSection, removeWorkspaceFromSidebar } =
 		useDashboardSidebarState();
 
 	const [isRenaming, setIsRenaming] = useState(false);
 	const [renameValue, setRenameValue] = useState(workspaceName);
 	const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
-	const [isDeleting, setIsDeleting] = useState(false);
 
 	const isActive = !!matchRoute({
 		to: "/v2-workspace/$workspaceId",
@@ -65,23 +69,34 @@ export function useDashboardSidebarWorkspaceItemActions({
 		}
 	};
 
-	const handleDelete = async () => {
-		setIsDeleting(true);
-		try {
+	const handleDelete = () => {
+		const focusTargetId = isActive
+			? getDeleteFocusTargetWorkspaceId(
+					getFlattenedV2WorkspaceIds(collections),
+					workspaceId,
+				)
+			: null;
+
+		setIsDeleteDialogOpen(false);
+
+		const deletePromise = (async () => {
 			await apiTrpcClient.v2Workspace.delete.mutate({ id: workspaceId });
 			removeWorkspaceFromSidebar(workspaceId);
-			setIsDeleteDialogOpen(false);
-			toast.success("Workspace deleted");
 			if (isActive) {
-				navigate({ to: "/" });
+				if (focusTargetId) {
+					await navigateToV2Workspace(focusTargetId, navigate);
+				} else {
+					await navigate({ to: "/" });
+				}
 			}
-		} catch (error) {
-			toast.error(
+		})();
+
+		toast.promise(deletePromise, {
+			loading: "Deleting workspace...",
+			success: "Workspace deleted",
+			error: (error) =>
 				`Failed to delete: ${error instanceof Error ? error.message : "Unknown error"}`,
-			);
-		} finally {
-			setIsDeleting(false);
-		}
+		});
 	};
 
 	const handleCreateSection = () => {
@@ -106,7 +121,6 @@ export function useDashboardSidebarWorkspaceItemActions({
 		handleOpenInFinder,
 		isActive,
 		isDeleteDialogOpen,
-		isDeleting,
 		isRenaming,
 		moveWorkspaceToSection,
 		removeWorkspaceFromSidebar,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/getDeleteFocusTargetWorkspaceId/getDeleteFocusTargetWorkspaceId.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/getDeleteFocusTargetWorkspaceId/getDeleteFocusTargetWorkspaceId.ts
@@ -1,0 +1,10 @@
+export function getDeleteFocusTargetWorkspaceId(
+	flattenedWorkspaceIds: readonly string[],
+	deletedWorkspaceId: string,
+): string | null {
+	const index = flattenedWorkspaceIds.indexOf(deletedWorkspaceId);
+	if (index === -1) return null;
+	return (
+		flattenedWorkspaceIds[index - 1] ?? flattenedWorkspaceIds[index + 1] ?? null
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/getDeleteFocusTargetWorkspaceId/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/getDeleteFocusTargetWorkspaceId/index.ts
@@ -1,0 +1,1 @@
+export { getDeleteFocusTargetWorkspaceId } from "./getDeleteFocusTargetWorkspaceId";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/getFlattenedV2WorkspaceIds/getFlattenedV2WorkspaceIds.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/getFlattenedV2WorkspaceIds/getFlattenedV2WorkspaceIds.ts
@@ -1,0 +1,70 @@
+import type { AppCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider/collections";
+
+type TopLevelItem =
+	| { kind: "workspace"; tabOrder: number; workspaceId: string }
+	| { kind: "section"; tabOrder: number; sectionId: string };
+
+export function getFlattenedV2WorkspaceIds(
+	collections: Pick<
+		AppCollections,
+		"v2SidebarProjects" | "v2SidebarSections" | "v2WorkspaceLocalState"
+	>,
+): string[] {
+	const projects = Array.from(
+		collections.v2SidebarProjects.state.values(),
+	).sort((left, right) => left.tabOrder - right.tabOrder);
+	const allSections = Array.from(collections.v2SidebarSections.state.values());
+	const allWorkspaces = Array.from(
+		collections.v2WorkspaceLocalState.state.values(),
+	);
+
+	const result: string[] = [];
+
+	for (const project of projects) {
+		const projectWorkspaces = allWorkspaces.filter(
+			(workspace) => workspace.sidebarState.projectId === project.projectId,
+		);
+		const projectSections = allSections.filter(
+			(section) => section.projectId === project.projectId,
+		);
+
+		const topLevelItems: TopLevelItem[] = [];
+		for (const workspace of projectWorkspaces) {
+			if (workspace.sidebarState.sectionId == null) {
+				topLevelItems.push({
+					kind: "workspace",
+					tabOrder: workspace.sidebarState.tabOrder,
+					workspaceId: workspace.workspaceId,
+				});
+			}
+		}
+		for (const section of projectSections) {
+			topLevelItems.push({
+				kind: "section",
+				tabOrder: section.tabOrder,
+				sectionId: section.sectionId,
+			});
+		}
+		topLevelItems.sort((left, right) => left.tabOrder - right.tabOrder);
+
+		for (const item of topLevelItems) {
+			if (item.kind === "workspace") {
+				result.push(item.workspaceId);
+				continue;
+			}
+			const sectionWorkspaces = projectWorkspaces
+				.filter(
+					(workspace) => workspace.sidebarState.sectionId === item.sectionId,
+				)
+				.sort(
+					(left, right) =>
+						left.sidebarState.tabOrder - right.sidebarState.tabOrder,
+				);
+			for (const workspace of sectionWorkspaces) {
+				result.push(workspace.workspaceId);
+			}
+		}
+	}
+
+	return result;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/getFlattenedV2WorkspaceIds/getFlattenedV2WorkspaceIds.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/getFlattenedV2WorkspaceIds/getFlattenedV2WorkspaceIds.ts
@@ -45,7 +45,13 @@ export function getFlattenedV2WorkspaceIds(
 				sectionId: section.sectionId,
 			});
 		}
-		topLevelItems.sort((left, right) => left.tabOrder - right.tabOrder);
+		topLevelItems.sort((left, right) => {
+			if (left.tabOrder !== right.tabOrder) {
+				return left.tabOrder - right.tabOrder;
+			}
+			if (left.kind === right.kind) return 0;
+			return left.kind === "section" ? -1 : 1;
+		});
 
 		for (const item of topLevelItems) {
 			if (item.kind === "workspace") {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/getFlattenedV2WorkspaceIds/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/getFlattenedV2WorkspaceIds/index.ts
@@ -1,0 +1,1 @@
+export { getFlattenedV2WorkspaceIds } from "./getFlattenedV2WorkspaceIds";


### PR DESCRIPTION
## Summary
- When the active v2 workspace is deleted, navigate to the previous workspace in visual order; fall back to the next, then to `/` if no neighbors exist. Matches v1 behavior (minus the wrap-around).
- Switches the delete flow to `toast.promise` so the user gets a loading → success/error toast instead of a manual try/catch.
- Drops the now-redundant `isDeleting` state since the dialog is dismissed immediately and toast owns the feedback.

Neighbor lookup reads directly from TanStack DB / ElectricSQL collection snapshots (\`v2SidebarProjects\`, \`v2SidebarSections\`, \`v2WorkspaceLocalState\`) at click time via the new \`getFlattenedV2WorkspaceIds\` util — no React context or prop drilling.

## Test plan
- [ ] Focus the middle workspace in a project with 3+ workspaces, delete → previous workspace becomes active
- [ ] Focus the first workspace in the sidebar, delete → next workspace becomes active
- [ ] Have only one workspace total, delete → navigates to \`/\`
- [ ] Focus workspace A, delete a different workspace B from the context menu → focus stays on A
- [ ] Two projects: focus the first workspace of project 2 and delete → focus jumps to the last workspace of project 1 (cross-project visual order)
- [ ] Delete the active workspace, then immediately try ⌘[ / ⌘] → prev/next hotkeys still work on the new list
- [ ] Toast shows "Deleting workspace..." → "Workspace deleted" on success, error message on failure

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Focuses the nearest neighbor workspace after deleting the active v2 workspace, falling back to `/` if none. Also switches the delete flow to `toast.promise` for clear loading/success/error feedback.

- **New Features**
  - After deleting the active v2 workspace: go to the previous in visual order; if none, the next; else `/`. No wrap-around.
  - Visual order computed at click time from `v2SidebarProjects`, `v2SidebarSections`, and `v2WorkspaceLocalState` via `getFlattenedV2WorkspaceIds`/`getDeleteFocusTargetWorkspaceId`. Delete dialog closes immediately; `isDeleting` removed. Deleting a non-active workspace doesn’t change focus.

- **Bug Fixes**
  - Navigation runs after the delete promise (outside `toast.promise`) to avoid false failure toasts; tie-breaker sets section-before-workspace when `tabOrder` matches to mirror sidebar order.

<sup>Written for commit 089f2c1e1d365f9cb3b39c4390ec6a160f5a8bfe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Workspace deletion now shows consolidated toast notifications for loading, success, and error states.
  * Post-deletion navigation automatically redirects to an appropriate remaining workspace for continuity.
  * Delete confirmation dialog no longer displays a component-level pending/disabled state.

* **New Features**
  * Added utilities to determine the best workspace to focus next and to derive an ordered list of workspace IDs for sidebar navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->