### PR TITLE
feat(desktop): Cmd+Alt+Arrow moves focus between v2 panes

### DIFF
--- a/apps/desktop/src/renderer/hotkeys/registry.ts
+++ b/apps/desktop/src/renderer/hotkeys/registry.ts
@@ -101,24 +101,6 @@ export const HOTKEYS_REGISTRY = {
 		label: "Switch to Workspace 9",
 		category: "Workspace",
 	},
-	PREV_WORKSPACE: {
-		key: {
-			mac: "meta+alt+up",
-			windows: "ctrl+shift+alt+up",
-			linux: "ctrl+shift+alt+up",
-		},
-		label: "Previous Workspace",
-		category: "Workspace",
-	},
-	NEXT_WORKSPACE: {
-		key: {
-			mac: "meta+alt+down",
-			windows: "ctrl+shift+alt+down",
-			linux: "ctrl+shift+alt+down",
-		},
-		label: "Next Workspace",
-		category: "Workspace",
-	},
 	CLOSE_WORKSPACE: {
 		key: {
 			mac: "meta+shift+backspace",
@@ -334,24 +316,6 @@ export const HOTKEYS_REGISTRY = {
 		category: "Terminal",
 		description: "Scroll the active terminal to the bottom",
 	},
-	PREV_TAB: {
-		key: {
-			mac: "meta+alt+left",
-			windows: "ctrl+shift+alt+left",
-			linux: "ctrl+shift+alt+left",
-		},
-		label: "Previous Tab",
-		category: "Terminal",
-	},
-	NEXT_TAB: {
-		key: {
-			mac: "meta+alt+right",
-			windows: "ctrl+shift+alt+right",
-			linux: "ctrl+shift+alt+right",
-		},
-		label: "Next Tab",
-		category: "Terminal",
-	},
 	PREV_TAB_ALT: {
 		key: {
 			mac: "ctrl+shift+tab",
@@ -385,6 +349,46 @@ export const HOTKEYS_REGISTRY = {
 		label: "Next Pane",
 		category: "Terminal",
 		description: "Focus the next pane in the current tab",
+	},
+	FOCUS_PANE_LEFT: {
+		key: {
+			mac: "meta+alt+left",
+			windows: "ctrl+alt+left",
+			linux: "ctrl+alt+left",
+		},
+		label: "Focus Pane Left",
+		category: "Terminal",
+		description: "Focus the pane to the left of the active pane",
+	},
+	FOCUS_PANE_RIGHT: {
+		key: {
+			mac: "meta+alt+right",
+			windows: "ctrl+alt+right",
+			linux: "ctrl+alt+right",
+		},
+		label: "Focus Pane Right",
+		category: "Terminal",
+		description: "Focus the pane to the right of the active pane",
+	},
+	FOCUS_PANE_UP: {
+		key: {
+			mac: "meta+alt+up",
+			windows: "ctrl+alt+up",
+			linux: "ctrl+alt+up",
+		},
+		label: "Focus Pane Up",
+		category: "Terminal",
+		description: "Focus the pane above the active pane",
+	},
+	FOCUS_PANE_DOWN: {
+		key: {
+			mac: "meta+alt+down",
+			windows: "ctrl+alt+down",
+			linux: "ctrl+alt+down",
+		},
+		label: "Focus Pane Down",
+		category: "Terminal",
+		description: "Focus the pane below the active pane",
 	},
 	JUMP_TO_TAB_1: {
 		key: {

--- a/apps/desktop/src/renderer/hotkeys/registry.ts
+++ b/apps/desktop/src/renderer/hotkeys/registry.ts
@@ -330,31 +330,11 @@ export const HOTKEYS_REGISTRY = {
 		label: "Next Tab (Alt)",
 		category: "Terminal",
 	},
-	PREV_PANE: {
-		key: {
-			mac: "meta+shift+left",
-			windows: "ctrl+shift+alt+left",
-			linux: "ctrl+shift+alt+left",
-		},
-		label: "Previous Pane",
-		category: "Terminal",
-		description: "Focus the previous pane in the current tab",
-	},
-	NEXT_PANE: {
-		key: {
-			mac: "meta+shift+right",
-			windows: "ctrl+shift+alt+right",
-			linux: "ctrl+shift+alt+right",
-		},
-		label: "Next Pane",
-		category: "Terminal",
-		description: "Focus the next pane in the current tab",
-	},
 	FOCUS_PANE_LEFT: {
 		key: {
 			mac: "meta+alt+left",
-			windows: "ctrl+alt+left",
-			linux: "ctrl+alt+left",
+			windows: "ctrl+shift+alt+left",
+			linux: "ctrl+shift+alt+left",
 		},
 		label: "Focus Pane Left",
 		category: "Terminal",
@@ -363,8 +343,8 @@ export const HOTKEYS_REGISTRY = {
 	FOCUS_PANE_RIGHT: {
 		key: {
 			mac: "meta+alt+right",
-			windows: "ctrl+alt+right",
-			linux: "ctrl+alt+right",
+			windows: "ctrl+shift+alt+right",
+			linux: "ctrl+shift+alt+right",
 		},
 		label: "Focus Pane Right",
 		category: "Terminal",
@@ -373,8 +353,8 @@ export const HOTKEYS_REGISTRY = {
 	FOCUS_PANE_UP: {
 		key: {
 			mac: "meta+alt+up",
-			windows: "ctrl+alt+up",
-			linux: "ctrl+alt+up",
+			windows: "ctrl+shift+alt+up",
+			linux: "ctrl+shift+alt+up",
 		},
 		label: "Focus Pane Up",
 		category: "Terminal",
@@ -383,8 +363,8 @@ export const HOTKEYS_REGISTRY = {
 	FOCUS_PANE_DOWN: {
 		key: {
 			mac: "meta+alt+down",
-			windows: "ctrl+alt+down",
-			linux: "ctrl+alt+down",
+			windows: "ctrl+shift+alt+down",
+			linux: "ctrl+shift+alt+down",
 		},
 		label: "Focus Pane Down",
 		category: "Terminal",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarShortcuts/useDashboardSidebarShortcuts.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarShortcuts/useDashboardSidebarShortcuts.ts
@@ -1,4 +1,4 @@
-import { useMatchRoute, useNavigate } from "@tanstack/react-router";
+import { useNavigate } from "@tanstack/react-router";
 import { useCallback, useMemo } from "react";
 import { useHotkey } from "renderer/hotkeys";
 import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
@@ -47,34 +47,6 @@ export function useDashboardSidebarShortcuts(
 	useHotkey("JUMP_TO_WORKSPACE_7", () => switchToWorkspace(6));
 	useHotkey("JUMP_TO_WORKSPACE_8", () => switchToWorkspace(7));
 	useHotkey("JUMP_TO_WORKSPACE_9", () => switchToWorkspace(8));
-
-	// Prev/next workspace navigation (cycles)
-	const matchRoute = useMatchRoute();
-	const currentWorkspaceMatch = matchRoute({
-		to: "/v2-workspace/$workspaceId",
-		fuzzy: true,
-	});
-	const currentWorkspaceId =
-		currentWorkspaceMatch !== false ? currentWorkspaceMatch.workspaceId : null;
-
-	useHotkey("PREV_WORKSPACE", () => {
-		if (!currentWorkspaceId || flattenedWorkspaces.length === 0) return;
-		const index = flattenedWorkspaces.findIndex(
-			(w) => w.id === currentWorkspaceId,
-		);
-		const prevIndex = index <= 0 ? flattenedWorkspaces.length - 1 : index - 1;
-		navigateToV2Workspace(flattenedWorkspaces[prevIndex].id, navigate);
-	});
-
-	useHotkey("NEXT_WORKSPACE", () => {
-		if (!currentWorkspaceId || flattenedWorkspaces.length === 0) return;
-		const index = flattenedWorkspaces.findIndex(
-			(w) => w.id === currentWorkspaceId,
-		);
-		const nextIndex =
-			index >= flattenedWorkspaces.length - 1 || index === -1 ? 0 : index + 1;
-		navigateToV2Workspace(flattenedWorkspaces[nextIndex].id, navigate);
-	});
 
 	return workspaceShortcutLabels;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
@@ -1,4 +1,8 @@
-import type { WorkspaceStore } from "@superset/panes";
+import {
+	type FocusDirection,
+	getSpatialNeighborPaneId,
+	type WorkspaceStore,
+} from "@superset/panes";
 import { useCallback } from "react";
 import { useHotkey } from "renderer/hotkeys";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
@@ -83,23 +87,6 @@ export function useWorkspaceHotkeys({
 		}
 	});
 
-	useHotkey("PREV_TAB", () => {
-		const state = store.getState();
-		if (!state.activeTabId || state.tabs.length === 0) return;
-		const index = state.tabs.findIndex((t) => t.id === state.activeTabId);
-		const prevIndex = index <= 0 ? state.tabs.length - 1 : index - 1;
-		state.setActiveTab(state.tabs[prevIndex].id);
-	});
-
-	useHotkey("NEXT_TAB", () => {
-		const state = store.getState();
-		if (!state.activeTabId || state.tabs.length === 0) return;
-		const index = state.tabs.findIndex((t) => t.id === state.activeTabId);
-		const nextIndex =
-			index >= state.tabs.length - 1 || index === -1 ? 0 : index + 1;
-		state.setActiveTab(state.tabs[nextIndex].id);
-	});
-
 	useHotkey("PREV_TAB_ALT", () => {
 		const state = store.getState();
 		if (!state.activeTabId || state.tabs.length === 0) return;
@@ -157,6 +144,26 @@ export function useWorkspaceHotkeys({
 		const nextIndex = index >= paneIds.length - 1 ? 0 : index + 1;
 		state.setActivePane({ tabId: tab.id, paneId: paneIds[nextIndex] });
 	});
+
+	const moveFocusDirectional = useCallback(
+		(dir: FocusDirection) => {
+			const state = store.getState();
+			const tab = state.getActiveTab();
+			if (!tab || !tab.activePaneId) return;
+			const neighbor = getSpatialNeighborPaneId(
+				tab.layout,
+				tab.activePaneId,
+				dir,
+			);
+			if (neighbor) state.setActivePane({ tabId: tab.id, paneId: neighbor });
+		},
+		[store],
+	);
+
+	useHotkey("FOCUS_PANE_LEFT", () => moveFocusDirectional("left"));
+	useHotkey("FOCUS_PANE_RIGHT", () => moveFocusDirectional("right"));
+	useHotkey("FOCUS_PANE_UP", () => moveFocusDirectional("up"));
+	useHotkey("FOCUS_PANE_DOWN", () => moveFocusDirectional("down"));
 
 	useHotkey("SPLIT_AUTO", () => {
 		const state = store.getState();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
@@ -125,26 +125,6 @@ export function useWorkspaceHotkeys({
 
 	// --- Pane management ---
 
-	useHotkey("PREV_PANE", () => {
-		const state = store.getState();
-		const tab = state.getActiveTab();
-		if (!tab || !tab.activePaneId) return;
-		const paneIds = Object.keys(tab.panes);
-		const index = paneIds.indexOf(tab.activePaneId);
-		const prevIndex = index <= 0 ? paneIds.length - 1 : index - 1;
-		state.setActivePane({ tabId: tab.id, paneId: paneIds[prevIndex] });
-	});
-
-	useHotkey("NEXT_PANE", () => {
-		const state = store.getState();
-		const tab = state.getActiveTab();
-		if (!tab || !tab.activePaneId) return;
-		const paneIds = Object.keys(tab.panes);
-		const index = paneIds.indexOf(tab.activePaneId);
-		const nextIndex = index >= paneIds.length - 1 ? 0 : index + 1;
-		state.setActivePane({ tabId: tab.id, paneId: paneIds[nextIndex] });
-	});
-
 	const moveFocusDirectional = useCallback(
 		(dir: FocusDirection) => {
 			const state = store.getState();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -1,5 +1,5 @@
 import type { ExternalApp } from "@superset/local-db";
-import { createFileRoute, notFound, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, notFound } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import { useFileOpenMode } from "renderer/hooks/useFileOpenMode";
@@ -8,7 +8,6 @@ import { electronTrpc } from "renderer/lib/electron-trpc";
 import { electronTrpcClient as trpcClient } from "renderer/lib/trpc-client";
 import { usePresets } from "renderer/react-query/presets";
 import type { WorkspaceSearchParams } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
-import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { usePresetHotkeys } from "renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/usePresetHotkeys";
 import { useWorkspaceRunCommand } from "renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/useWorkspaceRunCommand";
 import { NotFound } from "renderer/routes/not-found";
@@ -93,7 +92,6 @@ function WorkspacePage() {
 		worktreePath: workspace?.worktreePath,
 		enabled: Boolean(workspace?.worktreePath),
 	});
-	const navigate = useNavigate();
 	const routeNavigate = Route.useNavigate();
 	const { tabId: searchTabId, paneId: searchPaneId } = Route.useSearch();
 
@@ -226,20 +224,6 @@ function WorkspacePage() {
 		if (activeTabId) {
 			requestTabClose(activeTabId);
 		}
-	});
-
-	useHotkey("PREV_TAB", () => {
-		if (!activeTabId || tabs.length === 0) return;
-		const index = tabs.findIndex((t) => t.id === activeTabId);
-		const prevIndex = index <= 0 ? tabs.length - 1 : index - 1;
-		setActiveTab(workspaceId, tabs[prevIndex].id);
-	});
-
-	useHotkey("NEXT_TAB", () => {
-		if (!activeTabId || tabs.length === 0) return;
-		const index = tabs.findIndex((t) => t.id === activeTabId);
-		const nextIndex = index >= tabs.length - 1 || index === -1 ? 0 : index + 1;
-		setActiveTab(workspaceId, tabs[nextIndex].id);
 	});
 
 	useHotkey("PREV_TAB_ALT", () => {
@@ -424,31 +408,6 @@ function WorkspacePage() {
 	useHotkey("EQUALIZE_PANE_SPLITS", () => {
 		if (activeTabId) {
 			equalizePaneSplits(activeTabId);
-		}
-	});
-
-	// Navigate to previous workspace (⌘↑)
-	const getPreviousWorkspace =
-		electronTrpc.workspaces.getPreviousWorkspace.useQuery(
-			{ id: workspaceId },
-			{ enabled: !!workspaceId },
-		);
-	useHotkey("PREV_WORKSPACE", () => {
-		const prevWorkspaceId = getPreviousWorkspace.data;
-		if (prevWorkspaceId) {
-			navigateToWorkspace(prevWorkspaceId, navigate);
-		}
-	});
-
-	// Navigate to next workspace (⌘↓)
-	const getNextWorkspace = electronTrpc.workspaces.getNextWorkspace.useQuery(
-		{ id: workspaceId },
-		{ enabled: !!workspaceId },
-	);
-	useHotkey("NEXT_WORKSPACE", () => {
-		const nextWorkspaceId = getNextWorkspace.data;
-		if (nextWorkspaceId) {
-			navigateToWorkspace(nextWorkspaceId, navigate);
 		}
 	});
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -34,8 +34,6 @@ import { useTabsWithPresets } from "renderer/stores/tabs/useTabsWithPresets";
 import {
 	findPanePath,
 	getFirstPaneId,
-	getNextPaneId,
-	getPreviousPaneId,
 	resolveActiveTabIdForWorkspace,
 } from "renderer/stores/tabs/utils";
 import {
@@ -259,22 +257,6 @@ function WorkspacePage() {
 	useHotkey("JUMP_TO_TAB_7", () => switchToTab(6));
 	useHotkey("JUMP_TO_TAB_8", () => switchToTab(7));
 	useHotkey("JUMP_TO_TAB_9", () => switchToTab(8));
-
-	useHotkey("PREV_PANE", () => {
-		if (!activeTabId || !activeTab?.layout || !focusedPaneId) return;
-		const prevPaneId = getPreviousPaneId(activeTab.layout, focusedPaneId);
-		if (prevPaneId) {
-			setFocusedPane(activeTabId, prevPaneId);
-		}
-	});
-
-	useHotkey("NEXT_PANE", () => {
-		if (!activeTabId || !activeTab?.layout || !focusedPaneId) return;
-		const nextPaneId = getNextPaneId(activeTab.layout, focusedPaneId);
-		if (nextPaneId) {
-			setFocusedPane(activeTabId, nextPaneId);
-		}
-	});
 
 	// Open in last used app shortcut
 	const projectId = workspace?.projectId;

--- a/apps/desktop/src/renderer/stores/tabs/utils.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils.ts
@@ -507,42 +507,6 @@ export const getFirstPaneId = (layout: MosaicNode<string>): string => {
 };
 
 /**
- * Gets the next pane ID in visual order (left-to-right, top-to-bottom),
- * wrapping around to the first if at the end.
- */
-export const getNextPaneId = (
-	layout: MosaicNode<string>,
-	currentPaneId: string,
-): string | null => {
-	const paneIds = getPaneIdsInVisualOrder(layout);
-	if (paneIds.length <= 1) return null;
-
-	const currentIndex = paneIds.indexOf(currentPaneId);
-	if (currentIndex === -1) return paneIds[0];
-
-	const nextIndex = (currentIndex + 1) % paneIds.length;
-	return paneIds[nextIndex];
-};
-
-/**
- * Gets the previous pane ID in visual order (right-to-left, bottom-to-top),
- * wrapping around to the last if at the beginning.
- */
-export const getPreviousPaneId = (
-	layout: MosaicNode<string>,
-	currentPaneId: string,
-): string | null => {
-	const paneIds = getPaneIdsInVisualOrder(layout);
-	if (paneIds.length <= 1) return null;
-
-	const currentIndex = paneIds.indexOf(currentPaneId);
-	if (currentIndex === -1) return paneIds[paneIds.length - 1];
-
-	const prevIndex = (currentIndex - 1 + paneIds.length) % paneIds.length;
-	return paneIds[prevIndex];
-};
-
-/**
  * Gets the adjacent pane ID for focus fallback when a pane is closed.
  * Prefers the next pane in visual order, falls back to previous if at the end.
  * Returns null only if the pane is the only one in the layout.

--- a/packages/panes/src/core/store/utils/index.ts
+++ b/packages/panes/src/core/store/utils/index.ts
@@ -1,11 +1,14 @@
+export type { FocusDirection } from "./utils";
 export {
 	equalizeAllSplits,
 	findFirstPaneId,
 	findPaneInLayout,
+	findPanePath,
 	findSiblingPaneId,
 	generateId,
 	getNodeAtPath,
 	getOtherBranch,
+	getSpatialNeighborPaneId,
 	positionToDirection,
 	removePaneFromLayout,
 	replacePaneIdInLayout,

--- a/packages/panes/src/core/store/utils/utils.test.ts
+++ b/packages/panes/src/core/store/utils/utils.test.ts
@@ -6,6 +6,7 @@ import {
 	findPaneInLayout,
 	getNodeAtPath,
 	getOtherBranch,
+	getSpatialNeighborPaneId,
 	positionToDirection,
 	removePaneFromLayout,
 	replacePaneIdInLayout,
@@ -318,5 +319,137 @@ describe("positionToDirection", () => {
 	it("maps top/bottom to vertical", () => {
 		expect(positionToDirection("top")).toBe("vertical");
 		expect(positionToDirection("bottom")).toBe("vertical");
+	});
+});
+
+describe("getSpatialNeighborPaneId", () => {
+	//   +---+
+	//   | a |
+	//   +---+
+	it("returns null when there is only one pane", () => {
+		const layout: LayoutNode = { type: "pane", paneId: "a" };
+		expect(getSpatialNeighborPaneId(layout, "a", "left")).toBeNull();
+		expect(getSpatialNeighborPaneId(layout, "a", "right")).toBeNull();
+		expect(getSpatialNeighborPaneId(layout, "a", "up")).toBeNull();
+		expect(getSpatialNeighborPaneId(layout, "a", "down")).toBeNull();
+	});
+
+	//   +---+---+
+	//   | a | b |
+	//   +---+---+
+	it("moves between siblings in a horizontal split", () => {
+		const layout: LayoutNode = {
+			type: "split",
+			direction: "horizontal",
+			first: { type: "pane", paneId: "a" },
+			second: { type: "pane", paneId: "b" },
+		};
+		expect(getSpatialNeighborPaneId(layout, "a", "right")).toBe("b");
+		expect(getSpatialNeighborPaneId(layout, "b", "left")).toBe("a");
+		expect(getSpatialNeighborPaneId(layout, "a", "up")).toBeNull();
+		expect(getSpatialNeighborPaneId(layout, "a", "down")).toBeNull();
+	});
+
+	//   +---+
+	//   | a |
+	//   +---+
+	//   | b |
+	//   +---+
+	it("moves between siblings in a vertical split", () => {
+		const layout: LayoutNode = {
+			type: "split",
+			direction: "vertical",
+			first: { type: "pane", paneId: "a" },
+			second: { type: "pane", paneId: "b" },
+		};
+		expect(getSpatialNeighborPaneId(layout, "a", "down")).toBe("b");
+		expect(getSpatialNeighborPaneId(layout, "b", "up")).toBe("a");
+		expect(getSpatialNeighborPaneId(layout, "a", "right")).toBeNull();
+	});
+
+	//   +---+---+
+	//   | a | b |
+	//   +---+---+
+	it("does not wrap around at the layout edge", () => {
+		const layout: LayoutNode = {
+			type: "split",
+			direction: "horizontal",
+			first: { type: "pane", paneId: "a" },
+			second: { type: "pane", paneId: "b" },
+		};
+		expect(getSpatialNeighborPaneId(layout, "a", "left")).toBeNull();
+		expect(getSpatialNeighborPaneId(layout, "b", "right")).toBeNull();
+	});
+
+	// 2x2 grid built "rows first":
+	//   outer = vertical split { top row / bot row }
+	//     top row = horizontal split { a | b }
+	//     bot row = horizontal split { c | d }
+	//
+	//   +---+---+
+	//   | a | b |
+	//   +---+---+
+	//   | c | d |
+	//   +---+---+
+	it("preserves column alignment in a rows-first 2x2", () => {
+		const layout: LayoutNode = {
+			type: "split",
+			direction: "vertical",
+			first: {
+				type: "split",
+				direction: "horizontal",
+				first: { type: "pane", paneId: "a" },
+				second: { type: "pane", paneId: "b" },
+			},
+			second: {
+				type: "split",
+				direction: "horizontal",
+				first: { type: "pane", paneId: "c" },
+				second: { type: "pane", paneId: "d" },
+			},
+		};
+		expect(getSpatialNeighborPaneId(layout, "b", "down")).toBe("d");
+		expect(getSpatialNeighborPaneId(layout, "d", "up")).toBe("b");
+		expect(getSpatialNeighborPaneId(layout, "c", "up")).toBe("a");
+		expect(getSpatialNeighborPaneId(layout, "a", "down")).toBe("c");
+		expect(getSpatialNeighborPaneId(layout, "a", "right")).toBe("b");
+		expect(getSpatialNeighborPaneId(layout, "d", "left")).toBe("c");
+		expect(getSpatialNeighborPaneId(layout, "a", "left")).toBeNull();
+		expect(getSpatialNeighborPaneId(layout, "b", "up")).toBeNull();
+	});
+
+	// 2x2 grid built "columns first":
+	//   outer = horizontal split { left col / right col }
+	//     left col = vertical split { a / c }
+	//     right col = vertical split { b / d }
+	//
+	//   +---+---+
+	//   | a | b |
+	//   +---+---+
+	//   | c | d |
+	//   +---+---+
+	it("preserves row alignment in a columns-first 2x2", () => {
+		const layout: LayoutNode = {
+			type: "split",
+			direction: "horizontal",
+			first: {
+				type: "split",
+				direction: "vertical",
+				first: { type: "pane", paneId: "a" },
+				second: { type: "pane", paneId: "c" },
+			},
+			second: {
+				type: "split",
+				direction: "vertical",
+				first: { type: "pane", paneId: "b" },
+				second: { type: "pane", paneId: "d" },
+			},
+		};
+		expect(getSpatialNeighborPaneId(layout, "c", "right")).toBe("d");
+		expect(getSpatialNeighborPaneId(layout, "d", "left")).toBe("c");
+		expect(getSpatialNeighborPaneId(layout, "a", "right")).toBe("b");
+		expect(getSpatialNeighborPaneId(layout, "b", "left")).toBe("a");
+		expect(getSpatialNeighborPaneId(layout, "a", "down")).toBe("c");
+		expect(getSpatialNeighborPaneId(layout, "b", "down")).toBe("d");
 	});
 });

--- a/packages/panes/src/core/store/utils/utils.ts
+++ b/packages/panes/src/core/store/utils/utils.ts
@@ -169,3 +169,58 @@ export function positionToDirection(position: SplitPosition): SplitDirection {
 export function generateId(prefix: string): string {
 	return `${prefix}-${crypto.randomUUID()}`;
 }
+
+export type FocusDirection = "left" | "right" | "up" | "down";
+
+export function findPanePath(
+	node: LayoutNode,
+	paneId: string,
+	currentPath: SplitBranch[] = [],
+): SplitPath | null {
+	if (node.type === "pane") {
+		return node.paneId === paneId ? currentPath : null;
+	}
+	const firstPath = findPanePath(node.first, paneId, [...currentPath, "first"]);
+	if (firstPath) return firstPath;
+	return findPanePath(node.second, paneId, [...currentPath, "second"]);
+}
+
+function findEdgePaneId(node: LayoutNode, dir: FocusDirection): string | null {
+	if (node.type === "pane") return node.paneId;
+	const axis: SplitDirection =
+		dir === "left" || dir === "right" ? "horizontal" : "vertical";
+	// If the descent hits a split on the matching axis, pick the near edge:
+	// for "right"/"down" the near edge is `first`, for "left"/"up" it's `second`.
+	// For perpendicular splits there is no spatial preference, default to `first`.
+	if (node.direction === axis) {
+		const nearEdge: SplitBranch =
+			dir === "right" || dir === "down" ? "first" : "second";
+		return findEdgePaneId(node[nearEdge], dir);
+	}
+	return findEdgePaneId(node.first, dir);
+}
+
+export function getSpatialNeighborPaneId(
+	root: LayoutNode,
+	paneId: string,
+	dir: FocusDirection,
+): string | null {
+	const path = findPanePath(root, paneId);
+	if (!path) return null;
+
+	const axis: SplitDirection =
+		dir === "left" || dir === "right" ? "horizontal" : "vertical";
+	const wantSecond = dir === "right" || dir === "down";
+
+	for (let i = path.length - 1; i >= 0; i--) {
+		const ancestor = getNodeAtPath(root, path.slice(0, i));
+		if (!ancestor || ancestor.type !== "split") continue;
+		if (ancestor.direction !== axis) continue;
+		const cameFrom = path[i];
+		if (wantSecond && cameFrom !== "first") continue;
+		if (!wantSecond && cameFrom !== "second") continue;
+		const siblingBranch: SplitBranch = wantSecond ? "second" : "first";
+		return findEdgePaneId(ancestor[siblingBranch], dir);
+	}
+	return null;
+}

--- a/packages/panes/src/core/store/utils/utils.ts
+++ b/packages/panes/src/core/store/utils/utils.ts
@@ -185,19 +185,27 @@ export function findPanePath(
 	return findPanePath(node.second, paneId, [...currentPath, "second"]);
 }
 
-function findEdgePaneId(node: LayoutNode, dir: FocusDirection): string | null {
+// Descent into a sibling subtree once a pivot split has been chosen.
+// - On splits matching the arrow axis: pick the near edge (first for
+//   right/down, second for left/up), preserving alignmentPath.
+// - On perpendicular splits: consume one entry from alignmentPath to
+//   preserve the source pane's cross-axis position; if exhausted, fall
+//   back to `first`.
+function findEdgePaneId(
+	node: LayoutNode,
+	dir: FocusDirection,
+	alignmentPath: SplitPath = [],
+): string | null {
 	if (node.type === "pane") return node.paneId;
 	const axis: SplitDirection =
 		dir === "left" || dir === "right" ? "horizontal" : "vertical";
-	// If the descent hits a split on the matching axis, pick the near edge:
-	// for "right"/"down" the near edge is `first`, for "left"/"up" it's `second`.
-	// For perpendicular splits there is no spatial preference, default to `first`.
 	if (node.direction === axis) {
 		const nearEdge: SplitBranch =
 			dir === "right" || dir === "down" ? "first" : "second";
-		return findEdgePaneId(node[nearEdge], dir);
+		return findEdgePaneId(node[nearEdge], dir, alignmentPath);
 	}
-	return findEdgePaneId(node.first, dir);
+	const [alignedBranch = "first", ...rest] = alignmentPath;
+	return findEdgePaneId(node[alignedBranch], dir, rest);
 }
 
 export function getSpatialNeighborPaneId(
@@ -220,7 +228,7 @@ export function getSpatialNeighborPaneId(
 		if (wantSecond && cameFrom !== "first") continue;
 		if (!wantSecond && cameFrom !== "second") continue;
 		const siblingBranch: SplitBranch = wantSecond ? "second" : "first";
-		return findEdgePaneId(ancestor[siblingBranch], dir);
+		return findEdgePaneId(ancestor[siblingBranch], dir, path.slice(i + 1));
 	}
 	return null;
 }

--- a/packages/panes/src/index.ts
+++ b/packages/panes/src/index.ts
@@ -5,6 +5,8 @@ export type {
 	WorkspaceStore,
 } from "./core/store";
 export { createWorkspaceStore } from "./core/store";
+export type { FocusDirection } from "./core/store/utils";
+export { getSpatialNeighborPaneId } from "./core/store/utils";
 export type {
 	ContextMenuActionConfig,
 	PaneActionConfig,


### PR DESCRIPTION
## Summary

- Cmd+Alt+Arrow now jumps focus to the visually adjacent pane in v2 workspaces (like tmux/iTerm), with no wrap at edges
- Reclaims Cmd+Alt+Arrow from the retired PREV/NEXT_TAB and PREV/NEXT_WORKSPACE shortcuts; tabs still cycle via Ctrl+Tab / Ctrl+Shift+Tab and both keep Cmd+Alt+1..9 jump-to-N
- Adds `getSpatialNeighborPaneId` to `@superset/panes` — walks up the `LayoutNode` path to find the deepest ancestor split whose axis matches the arrow, then descends into the sibling subtree picking the near-edge leaf
- v1 workspaces intentionally do **not** get directional pane nav (the shortcut retirement still applies to v1 handlers)

## Test plan

- [ ] `bun run typecheck` clean
- [ ] `bun run lint` clean
- [ ] `packages/panes` tests pass (71/71)
- [ ] Open a v2 workspace, build a 2×2 pane grid (split right, split down in each column)
- [ ] Cmd+Alt+{Left,Right,Up,Down} land on the expected adjacent pane from each of the four corners
- [ ] Pressing an arrow at the outer edge is a no-op (no wrap, no focus loss)
- [ ] Cmd+Shift+Left/Right still cycles panes linearly
- [ ] Ctrl+Tab / Ctrl+Shift+Tab still cycle tabs
- [ ] Cmd+Alt+1..9 still jumps tabs and workspaces
- [ ] Inside a terminal pane, Cmd+Alt+Arrow triggers focus move and does not leak to the terminal

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cmd+Alt+Arrow now moves focus to the adjacent pane in v2 workspaces with no wrap at edges. We removed linear pane cycling and reclaimed these keys from tab/workspace switching; Ctrl+Tab and Cmd+Alt+1..9 stay the same.

- **New Features**
  - Directional pane focus: Cmd+Alt+Arrow (macOS) / Ctrl+Shift+Alt+Arrow (Windows/Linux); no wrap.
  - `@superset/panes`: add `getSpatialNeighborPaneId`, `findPanePath`, and `FocusDirection`; register `FOCUS_PANE_{LEFT,RIGHT,UP,DOWN}`; remove `PREV/NEXT_TAB`, `PREV/NEXT_WORKSPACE`, and linear `PREV/NEXT_PANE`.

- **Bug Fixes**
  - Preserve cross-axis alignment when descending into neighbor subtrees so focus lands on the expected pane in 2×2 layouts; add unit tests for single-pane, simple splits, edges, and both 2×2 groupings.

<sup>Written for commit 4025c598c29ef4b8e8f9c3359021657795fafe00. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added directional pane-focus hotkeys (left/right/up/down) for spatial pane navigation.

* **Chores**
  * Removed previous/next workspace and previous/next tab hotkeys (numeric jump-to-workspace 1–9 remain).
  * Replaced older pane-cycling shortcuts with directional focus behavior.
  * Simplified/removed some pane-ordering helpers and expanded spatial navigation API surface.

* **Tests**
  * Added unit tests covering spatial neighbor resolution and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->