### PR TITLE
fix(hotkeys): match terminal Ctrl chords by event.code under non-Latin IME

### DIFF
--- a/apps/desktop/src/shared/hotkeys.test.ts
+++ b/apps/desktop/src/shared/hotkeys.test.ts
@@ -91,4 +91,32 @@ describe("isTerminalReservedEvent", () => {
 			}),
 		).toBe(true);
 	});
+
+	// Regression: superset-sh/superset#3365 — ctrl+c/d/z fail under non-Latin IME
+	// (Turkish, Korean, Russian) because event.key reflects IME-transformed char.
+	it("detects ctrl+c via event.code when IME mangles event.key (Turkish)", () => {
+		expect(
+			isTerminalReservedEvent({
+				key: "ç", // Turkish IME emits 'ç' instead of 'c'
+				code: "KeyC",
+				ctrlKey: true,
+				shiftKey: false,
+				altKey: false,
+				metaKey: false,
+			}),
+		).toBe(true);
+	});
+
+	it("detects ctrl+d via event.code when IME mangles event.key (Korean)", () => {
+		expect(
+			isTerminalReservedEvent({
+				key: "ㅇ", // Korean 2-Set IME emits Hangul jamo for 'd'
+				code: "KeyD",
+				ctrlKey: true,
+				shiftKey: false,
+				altKey: false,
+				metaKey: false,
+			}),
+		).toBe(true);
+	});
 });

--- a/apps/desktop/src/shared/hotkeys.ts
+++ b/apps/desktop/src/shared/hotkeys.ts
@@ -271,6 +271,15 @@ export function matchesHotkeyEvent(
 	// Use event.code to match digit keys when alt is pressed
 	if (/^[1-9]$/.test(key) && eventCode === `digit${key}`) return true;
 
+	// IME / non-Latin keyboard layout fallback (e.g. Turkish, Korean, Russian):
+	// `event.key` reflects the IME-transformed character (e.g. Turkish dead keys
+	// or Korean 2-Set), while `event.code` always reports the physical key.
+	// Without this, Ctrl+C, Ctrl+V, Ctrl+D, Ctrl+Z etc. fail to match when a
+	// non-Latin layout is active. Fixes superset-sh/superset#3365.
+	if (key.length === 1 && /^[a-z]$/.test(key) && eventCode === `key${key}`) {
+		return true;
+	}
+
 	return eventKey === key;
 }
 


### PR DESCRIPTION
## Summary / What changed
- `matchesHotkeyEvent` (`apps/desktop/src/shared/hotkeys.ts`): when the parsed hotkey is a single letter `a–z`, also match against `event.code` (`KeyA`–`KeyZ`). Mirrors the existing digit-key fallback at line 272.
- Two new regression tests in `hotkeys.test.ts` cover Turkish (`ç` + `KeyC`) and Korean (`ㅇ` + `KeyD`).

## Why
Originally reported by @eungkyu in #3365 for Korean 2-Set IME. Same bug reproduces on Turkish layout: `Ctrl+C` emits `event.key = "ç"` while `event.code` stays `"KeyC"`. Without the fallback, terminal-reserved chords (Ctrl+C/D/Z/V…) stop reaching the PTY whenever a non-Latin IME is active.

The patch is intentionally narrow: only single-letter `a–z` hotkeys gain the `event.code` fallback. This keeps existing matching behavior for everything else and follows the same pattern the code already uses for digits and `slash`.

## Tests
- `bun test apps/desktop/src/shared/hotkeys.test.ts`
- 15/15 pass (13 existing + 2 new IME regressions).

## Real-world validation
- Reproduced on Superset Desktop **v1.5.1** macOS, Turkish keyboard layout: before the patch `Ctrl+C` is swallowed; after the patch SIGINT reaches the PTY normally.
- Issue #3365 reporter (@eungkyu) confirms the same root cause for Korean 2-Set; the new test for `ㅇ` + `KeyD` matches their reproduction.

## Issue
Fixes #3365.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes terminal Ctrl letter chords failing under non-Latin IMEs by matching single-letter hotkeys against `event.code` (`KeyA`–`KeyZ`) in `matchesHotkeyEvent` (fixes #3365). Adds regression tests for Turkish (`ç` + `KeyC`) and Korean (`ㅇ` + `KeyD`).

<sup>Written for commit c4f5db08caa4b67a96d25a86d51d01ebec3bb614. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hotkey detection reliability when using non-Latin keyboard layouts or IME input methods. Hotkeys like Ctrl+C and Ctrl+D now work correctly even when keyboard input transforms key values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->