### PR TITLE
fix(desktop): match VS Code terminal clipboard handling (originally by @AytuncYildizli)

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/clipboardShortcuts.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/clipboardShortcuts.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "bun:test";
+import { shouldBubbleClipboardShortcut } from "./clipboardShortcuts";
+
+function makeEvent(
+	overrides: Partial<{
+		code: string;
+		metaKey: boolean;
+		ctrlKey: boolean;
+		altKey: boolean;
+		shiftKey: boolean;
+	}>,
+) {
+	return {
+		code: "KeyC",
+		metaKey: false,
+		ctrlKey: false,
+		altKey: false,
+		shiftKey: false,
+		...overrides,
+	};
+}
+
+describe("shouldBubbleClipboardShortcut", () => {
+	it("matches VS Code macOS terminal paste", () => {
+		expect(
+			shouldBubbleClipboardShortcut(
+				makeEvent({ code: "KeyV", metaKey: true }),
+				{
+					isMac: true,
+					isWindows: false,
+					hasSelection: false,
+				},
+			),
+		).toBe(true);
+	});
+
+	it("matches VS Code macOS terminal copy only when selection exists", () => {
+		expect(
+			shouldBubbleClipboardShortcut(
+				makeEvent({ code: "KeyC", metaKey: true }),
+				{
+					isMac: true,
+					isWindows: false,
+					hasSelection: true,
+				},
+			),
+		).toBe(true);
+
+		expect(
+			shouldBubbleClipboardShortcut(
+				makeEvent({ code: "KeyC", metaKey: true }),
+				{
+					isMac: true,
+					isWindows: false,
+					hasSelection: false,
+				},
+			),
+		).toBe(false);
+	});
+
+	it("matches VS Code Windows terminal copy and paste bindings", () => {
+		expect(
+			shouldBubbleClipboardShortcut(
+				makeEvent({ code: "KeyV", ctrlKey: true }),
+				{
+					isMac: false,
+					isWindows: true,
+					hasSelection: false,
+				},
+			),
+		).toBe(true);
+
+		expect(
+			shouldBubbleClipboardShortcut(
+				makeEvent({ code: "KeyV", ctrlKey: true, shiftKey: true }),
+				{
+					isMac: false,
+					isWindows: true,
+					hasSelection: false,
+				},
+			),
+		).toBe(true);
+
+		expect(
+			shouldBubbleClipboardShortcut(
+				makeEvent({ code: "KeyC", ctrlKey: true }),
+				{
+					isMac: false,
+					isWindows: true,
+					hasSelection: true,
+				},
+			),
+		).toBe(true);
+
+		expect(
+			shouldBubbleClipboardShortcut(
+				makeEvent({ code: "KeyC", ctrlKey: true, shiftKey: true }),
+				{
+					isMac: false,
+					isWindows: true,
+					hasSelection: true,
+				},
+			),
+		).toBe(true);
+	});
+
+	it("keeps Windows Ctrl+C going to the PTY when nothing is selected", () => {
+		expect(
+			shouldBubbleClipboardShortcut(
+				makeEvent({ code: "KeyC", ctrlKey: true }),
+				{
+					isMac: false,
+					isWindows: true,
+					hasSelection: false,
+				},
+			),
+		).toBe(false);
+	});
+
+	it("matches VS Code Linux terminal copy and paste bindings", () => {
+		expect(
+			shouldBubbleClipboardShortcut(
+				makeEvent({ code: "KeyC", ctrlKey: true, shiftKey: true }),
+				{
+					isMac: false,
+					isWindows: false,
+					hasSelection: true,
+				},
+			),
+		).toBe(true);
+
+		expect(
+			shouldBubbleClipboardShortcut(
+				makeEvent({ code: "KeyV", ctrlKey: true, shiftKey: true }),
+				{
+					isMac: false,
+					isWindows: false,
+					hasSelection: false,
+				},
+			),
+		).toBe(true);
+
+		expect(
+			shouldBubbleClipboardShortcut(
+				makeEvent({ code: "Insert", shiftKey: true }),
+				{
+					isMac: false,
+					isWindows: false,
+					hasSelection: false,
+				},
+			),
+		).toBe(true);
+	});
+
+	it("does not widen clipboard bubbling beyond VS Code's bindings", () => {
+		expect(
+			shouldBubbleClipboardShortcut(
+				makeEvent({ code: "KeyA", metaKey: true }),
+				{
+					isMac: true,
+					isWindows: false,
+					hasSelection: true,
+				},
+			),
+		).toBe(false);
+
+		expect(
+			shouldBubbleClipboardShortcut(
+				makeEvent({ code: "KeyV", ctrlKey: true }),
+				{
+					isMac: false,
+					isWindows: false,
+					hasSelection: false,
+				},
+			),
+		).toBe(false);
+
+		expect(
+			shouldBubbleClipboardShortcut(
+				makeEvent({ code: "Insert", ctrlKey: true }),
+				{
+					isMac: false,
+					isWindows: false,
+					hasSelection: false,
+				},
+			),
+		).toBe(false);
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/clipboardShortcuts.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/clipboardShortcuts.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import { shouldBubbleClipboardShortcut } from "./clipboardShortcuts";
+import {
+	shouldBubbleClipboardShortcut,
+	shouldSelectAllShortcut,
+} from "./clipboardShortcuts";
 
 function makeEvent(
 	overrides: Partial<{
@@ -21,169 +24,127 @@ function makeEvent(
 }
 
 describe("shouldBubbleClipboardShortcut", () => {
-	it("matches VS Code macOS terminal paste", () => {
-		expect(
-			shouldBubbleClipboardShortcut(
-				makeEvent({ code: "KeyV", metaKey: true }),
-				{
-					isMac: true,
-					isWindows: false,
-					hasSelection: false,
-				},
-			),
-		).toBe(true);
+	it("matches the VS Code terminal clipboard bindings", () => {
+		const cases = [
+			{
+				name: "macOS Cmd+V",
+				event: makeEvent({ code: "KeyV", metaKey: true }),
+				options: { isMac: true, isWindows: false, hasSelection: false },
+				expected: true,
+			},
+			{
+				name: "macOS Cmd+C with selection",
+				event: makeEvent({ code: "KeyC", metaKey: true }),
+				options: { isMac: true, isWindows: false, hasSelection: true },
+				expected: true,
+			},
+			{
+				name: "windows Ctrl+V",
+				event: makeEvent({ code: "KeyV", ctrlKey: true }),
+				options: { isMac: false, isWindows: true, hasSelection: false },
+				expected: true,
+			},
+			{
+				name: "windows Ctrl+Shift+V",
+				event: makeEvent({ code: "KeyV", ctrlKey: true, shiftKey: true }),
+				options: { isMac: false, isWindows: true, hasSelection: false },
+				expected: true,
+			},
+			{
+				name: "windows Ctrl+C with selection",
+				event: makeEvent({ code: "KeyC", ctrlKey: true }),
+				options: { isMac: false, isWindows: true, hasSelection: true },
+				expected: true,
+			},
+			{
+				name: "linux Ctrl+Shift+C with selection",
+				event: makeEvent({ code: "KeyC", ctrlKey: true, shiftKey: true }),
+				options: { isMac: false, isWindows: false, hasSelection: true },
+				expected: true,
+			},
+			{
+				name: "linux Ctrl+Shift+V",
+				event: makeEvent({ code: "KeyV", ctrlKey: true, shiftKey: true }),
+				options: { isMac: false, isWindows: false, hasSelection: false },
+				expected: true,
+			},
+			{
+				name: "linux Shift+Insert",
+				event: makeEvent({ code: "Insert", shiftKey: true }),
+				options: { isMac: false, isWindows: false, hasSelection: false },
+				expected: true,
+			},
+			{
+				name: "macOS Cmd+C without selection",
+				event: makeEvent({ code: "KeyC", metaKey: true }),
+				options: { isMac: true, isWindows: false, hasSelection: false },
+				expected: false,
+			},
+			{
+				name: "windows Ctrl+C without selection",
+				event: makeEvent({ code: "KeyC", ctrlKey: true }),
+				options: { isMac: false, isWindows: true, hasSelection: false },
+				expected: false,
+			},
+			{
+				name: "linux Ctrl+Shift+C without selection",
+				event: makeEvent({ code: "KeyC", ctrlKey: true, shiftKey: true }),
+				options: { isMac: false, isWindows: false, hasSelection: false },
+				expected: false,
+			},
+			{
+				name: "linux Ctrl+Insert stays with the PTY",
+				event: makeEvent({ code: "Insert", ctrlKey: true }),
+				options: { isMac: false, isWindows: false, hasSelection: false },
+				expected: false,
+			},
+			{
+				name: "macOS does not inherit linux fallback chords",
+				event: makeEvent({ code: "KeyV", ctrlKey: true, shiftKey: true }),
+				options: { isMac: true, isWindows: false, hasSelection: false },
+				expected: false,
+			},
+			{
+				name: "macOS Shift+Insert stays with the PTY",
+				event: makeEvent({ code: "Insert", shiftKey: true }),
+				options: { isMac: true, isWindows: false, hasSelection: false },
+				expected: false,
+			},
+		];
+
+		for (const { name, event, options, expected } of cases) {
+			expect(shouldBubbleClipboardShortcut(event, options), name).toBe(
+				expected,
+			);
+		}
 	});
+});
 
-	it("matches VS Code macOS terminal copy only when selection exists", () => {
-		expect(
-			shouldBubbleClipboardShortcut(
-				makeEvent({ code: "KeyC", metaKey: true }),
-				{
-					isMac: true,
-					isWindows: false,
-					hasSelection: true,
-				},
-			),
-		).toBe(true);
+describe("shouldSelectAllShortcut", () => {
+	it("matches only the VS Code macOS terminal select-all binding", () => {
+		const cases = [
+			{
+				name: "macOS Cmd+A",
+				event: makeEvent({ code: "KeyA", metaKey: true }),
+				isMac: true,
+				expected: true,
+			},
+			{
+				name: "windows Ctrl+A is not intercepted",
+				event: makeEvent({ code: "KeyA", ctrlKey: true }),
+				isMac: false,
+				expected: false,
+			},
+			{
+				name: "macOS Cmd+Shift+A is not intercepted",
+				event: makeEvent({ code: "KeyA", metaKey: true, shiftKey: true }),
+				isMac: true,
+				expected: false,
+			},
+		];
 
-		expect(
-			shouldBubbleClipboardShortcut(
-				makeEvent({ code: "KeyC", metaKey: true }),
-				{
-					isMac: true,
-					isWindows: false,
-					hasSelection: false,
-				},
-			),
-		).toBe(false);
-	});
-
-	it("matches VS Code Windows terminal copy and paste bindings", () => {
-		expect(
-			shouldBubbleClipboardShortcut(
-				makeEvent({ code: "KeyV", ctrlKey: true }),
-				{
-					isMac: false,
-					isWindows: true,
-					hasSelection: false,
-				},
-			),
-		).toBe(true);
-
-		expect(
-			shouldBubbleClipboardShortcut(
-				makeEvent({ code: "KeyV", ctrlKey: true, shiftKey: true }),
-				{
-					isMac: false,
-					isWindows: true,
-					hasSelection: false,
-				},
-			),
-		).toBe(true);
-
-		expect(
-			shouldBubbleClipboardShortcut(
-				makeEvent({ code: "KeyC", ctrlKey: true }),
-				{
-					isMac: false,
-					isWindows: true,
-					hasSelection: true,
-				},
-			),
-		).toBe(true);
-
-		expect(
-			shouldBubbleClipboardShortcut(
-				makeEvent({ code: "KeyC", ctrlKey: true, shiftKey: true }),
-				{
-					isMac: false,
-					isWindows: true,
-					hasSelection: true,
-				},
-			),
-		).toBe(true);
-	});
-
-	it("keeps Windows Ctrl+C going to the PTY when nothing is selected", () => {
-		expect(
-			shouldBubbleClipboardShortcut(
-				makeEvent({ code: "KeyC", ctrlKey: true }),
-				{
-					isMac: false,
-					isWindows: true,
-					hasSelection: false,
-				},
-			),
-		).toBe(false);
-	});
-
-	it("matches VS Code Linux terminal copy and paste bindings", () => {
-		expect(
-			shouldBubbleClipboardShortcut(
-				makeEvent({ code: "KeyC", ctrlKey: true, shiftKey: true }),
-				{
-					isMac: false,
-					isWindows: false,
-					hasSelection: true,
-				},
-			),
-		).toBe(true);
-
-		expect(
-			shouldBubbleClipboardShortcut(
-				makeEvent({ code: "KeyV", ctrlKey: true, shiftKey: true }),
-				{
-					isMac: false,
-					isWindows: false,
-					hasSelection: false,
-				},
-			),
-		).toBe(true);
-
-		expect(
-			shouldBubbleClipboardShortcut(
-				makeEvent({ code: "Insert", shiftKey: true }),
-				{
-					isMac: false,
-					isWindows: false,
-					hasSelection: false,
-				},
-			),
-		).toBe(true);
-	});
-
-	it("does not widen clipboard bubbling beyond VS Code's bindings", () => {
-		expect(
-			shouldBubbleClipboardShortcut(
-				makeEvent({ code: "KeyA", metaKey: true }),
-				{
-					isMac: true,
-					isWindows: false,
-					hasSelection: true,
-				},
-			),
-		).toBe(false);
-
-		expect(
-			shouldBubbleClipboardShortcut(
-				makeEvent({ code: "KeyV", ctrlKey: true }),
-				{
-					isMac: false,
-					isWindows: false,
-					hasSelection: false,
-				},
-			),
-		).toBe(false);
-
-		expect(
-			shouldBubbleClipboardShortcut(
-				makeEvent({ code: "Insert", ctrlKey: true }),
-				{
-					isMac: false,
-					isWindows: false,
-					hasSelection: false,
-				},
-			),
-		).toBe(false);
+		for (const { name, event, isMac, expected } of cases) {
+			expect(shouldSelectAllShortcut(event, isMac), name).toBe(expected);
+		}
 	});
 });

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/clipboardShortcuts.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/clipboardShortcuts.ts
@@ -12,6 +12,21 @@ export interface ClipboardShortcutOptions {
 	hasSelection: boolean;
 }
 
+/** Match VS Code's macOS terminal `Cmd+A` binding. */
+export function shouldSelectAllShortcut(
+	event: ClipboardShortcutEvent,
+	isMac: boolean,
+): boolean {
+	return (
+		isMac &&
+		event.code === "KeyA" &&
+		event.metaKey &&
+		!event.ctrlKey &&
+		!event.altKey &&
+		!event.shiftKey
+	);
+}
+
 /**
  * Mirror VS Code terminal clipboard bindings so host copy/paste can run before
  * xterm's kitty keyboard handler turns the chord into CSI-u input.
@@ -47,9 +62,13 @@ export function shouldBubbleClipboardShortcut(
 		return false;
 	}
 
-	return (
-		(event.code === "KeyV" && ctrlShiftOnly) ||
-		(event.code === "Insert" && onlyShift) ||
-		(hasSelection && event.code === "KeyC" && ctrlShiftOnly)
-	);
+	if (!isMac) {
+		return (
+			(event.code === "KeyV" && ctrlShiftOnly) ||
+			(event.code === "Insert" && onlyShift) ||
+			(hasSelection && event.code === "KeyC" && ctrlShiftOnly)
+		);
+	}
+
+	return false;
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/clipboardShortcuts.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/clipboardShortcuts.ts
@@ -1,0 +1,55 @@
+export interface ClipboardShortcutEvent {
+	code: string;
+	metaKey: boolean;
+	ctrlKey: boolean;
+	altKey: boolean;
+	shiftKey: boolean;
+}
+
+export interface ClipboardShortcutOptions {
+	isMac: boolean;
+	isWindows: boolean;
+	hasSelection: boolean;
+}
+
+/**
+ * Mirror VS Code terminal clipboard bindings so host copy/paste can run before
+ * xterm's kitty keyboard handler turns the chord into CSI-u input.
+ */
+export function shouldBubbleClipboardShortcut(
+	event: ClipboardShortcutEvent,
+	options: ClipboardShortcutOptions,
+): boolean {
+	const { isMac, isWindows, hasSelection } = options;
+
+	const onlyMeta =
+		event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey;
+	const onlyCtrl =
+		event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey;
+	const ctrlShiftOnly =
+		event.ctrlKey && event.shiftKey && !event.metaKey && !event.altKey;
+	const onlyShift =
+		event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey;
+
+	if (isMac && onlyMeta) {
+		return event.code === "KeyV" || (hasSelection && event.code === "KeyC");
+	}
+
+	if (isWindows) {
+		if (event.code === "KeyV" && (onlyCtrl || ctrlShiftOnly)) {
+			return true;
+		}
+
+		if (hasSelection && event.code === "KeyC" && (onlyCtrl || ctrlShiftOnly)) {
+			return true;
+		}
+
+		return false;
+	}
+
+	return (
+		(event.code === "KeyV" && ctrlShiftOnly) ||
+		(event.code === "Insert" && onlyShift) ||
+		(hasSelection && event.code === "KeyC" && ctrlShiftOnly)
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -574,6 +574,22 @@ export function setupKeyboardHandler(
 			return false;
 		}
 
+		// Copy/paste (Cmd+C/V on Mac, Ctrl+V elsewhere): let the browser fire
+		// the native copy/paste events into setupCopyHandler/setupPasteHandler.
+		// When a TUI enables the Kitty keyboard protocol (opencode, helix, …),
+		// xterm encodes these chords as CSI u and calls preventDefault(), which
+		// would otherwise suppress the browser events our handlers rely on.
+		// Ctrl+C on non-Mac is interrupt (handled by isTerminalReservedEvent below).
+		const isPlainModCombo =
+			!event.altKey &&
+			!event.shiftKey &&
+			(isMac
+				? event.metaKey && !event.ctrlKey
+				: event.ctrlKey && !event.metaKey);
+		const isCopyShortcut = isMac && isPlainModCombo && event.key === "c";
+		const isPasteShortcut = isPlainModCombo && event.key === "v";
+		if (isCopyShortcut || isPasteShortcut) return false;
+
 		// Terminal-reserved chords (ctrl+c/d/z/s/q) always go to xterm
 		if (isTerminalReservedEvent(event)) return true;
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -23,7 +23,10 @@ import {
 	DEFAULT_THEME_ID,
 	getTerminalColors,
 } from "shared/themes";
-import { shouldBubbleClipboardShortcut } from "./clipboardShortcuts";
+import {
+	shouldBubbleClipboardShortcut,
+	shouldSelectAllShortcut,
+} from "./clipboardShortcuts";
 import { TERMINAL_OPTIONS } from "./config";
 import { suppressQueryResponses } from "./suppressQueryResponses";
 
@@ -571,6 +574,14 @@ export function setupKeyboardHandler(
 		if (isCtrlRight) {
 			if (event.type === "keydown" && options.onWrite) {
 				options.onWrite("\x1bf"); // Meta+F - forward word
+			}
+			return false;
+		}
+
+		if (shouldSelectAllShortcut(event, isMac)) {
+			if (event.type === "keydown") {
+				event.preventDefault();
+				xterm.selectAll();
 			}
 			return false;
 		}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -23,6 +23,7 @@ import {
 	DEFAULT_THEME_ID,
 	getTerminalColors,
 } from "shared/themes";
+import { shouldBubbleClipboardShortcut } from "./clipboardShortcuts";
 import { TERMINAL_OPTIONS } from "./config";
 import { suppressQueryResponses } from "./suppressQueryResponses";
 
@@ -574,21 +575,17 @@ export function setupKeyboardHandler(
 			return false;
 		}
 
-		// Copy/paste (Cmd+C/V on Mac, Ctrl+V elsewhere): let the browser fire
-		// the native copy/paste events into setupCopyHandler/setupPasteHandler.
-		// When a TUI enables the Kitty keyboard protocol (opencode, helix, …),
-		// xterm encodes these chords as CSI u and calls preventDefault(), which
-		// would otherwise suppress the browser events our handlers rely on.
-		// Ctrl+C on non-Mac is interrupt (handled by isTerminalReservedEvent below).
-		const isPlainModCombo =
-			!event.altKey &&
-			!event.shiftKey &&
-			(isMac
-				? event.metaKey && !event.ctrlKey
-				: event.ctrlKey && !event.metaKey);
-		const isCopyShortcut = isMac && isPlainModCombo && event.key === "c";
-		const isPasteShortcut = isPlainModCombo && event.key === "v";
-		if (isCopyShortcut || isPasteShortcut) return false;
+		// Mirror VS Code terminal clipboard bindings so host copy/paste happens
+		// before kitty CSI-u handling in xterm consumes the command chord.
+		if (
+			shouldBubbleClipboardShortcut(event, {
+				isMac,
+				isWindows,
+				hasSelection: xterm.hasSelection(),
+			})
+		) {
+			return false;
+		}
 
 		// Terminal-reserved chords (ctrl+c/d/z/s/q) always go to xterm
 		if (isTerminalReservedEvent(event)) return true;

--- a/bun.lock
+++ b/bun.lock
@@ -110,7 +110,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.43",
         "@ai-sdk/openai": "3.0.36",


### PR DESCRIPTION
Reported and fixed from: https://github.com/superset-sh/superset/pull/3407

## Summary
- forward the v1 terminal clipboard chords the same way VS Code does so xterm's kitty keyboard handling does not swallow host copy and paste
- add macOS terminal select-all (`Cmd+A`) to match VS Code's terminal action behavior
- tighten the platform guard so Linux fallback chords do not leak onto macOS
- replace the verbose shortcut tests with a compact boundary-focused matrix

## Root Cause
`#3390` changed the v1 terminal so unregistered chords fall through to the PTY. That fixed TUI shortcut forwarding in general, but it also let xterm consume host clipboard chords as CSI-u input before Electron/browser copy-paste handling could run. On macOS this broke `Cmd+C` and `Cmd+V`; the follow-up implementation also needed an explicit guard so Linux fallback bindings like `Ctrl+Shift+V` and `Shift+Insert` would not be intercepted on macOS.

## Behavior
- macOS: `Cmd+C` copies only when there is a terminal selection, `Cmd+V` pastes, `Cmd+A` selects all
- Windows: `Ctrl+V`, `Ctrl+Shift+V`, and copy chords with a selection bubble to the host
- Linux: `Ctrl+Shift+C`, `Ctrl+Shift+V`, and `Shift+Insert` follow VS Code's terminal bindings
- terminal-reserved PTY chords still go to xterm when they should

## Validation
- `bun test apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/clipboardShortcuts.test.ts`
- `bun run typecheck --filter=@superset/desktop`
- `bunx biome check apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/clipboardShortcuts.ts apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/clipboardShortcuts.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for clipboard shortcuts across macOS, Windows, and Linux platforms.

* **New Features**
  * Enhanced clipboard shortcut handling in the terminal, ensuring consistent copy, paste, and select-all functionality across all operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->