### PR TITLE
[codex] fix v1 split pane startup sizing

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/launch-command.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/launch-command.test.ts
@@ -4,6 +4,11 @@ import {
 	launchCommandInPane,
 	writeCommandsInPane,
 } from "./launch-command";
+import {
+	clearTerminalSessionReady,
+	markTerminalSessionReady,
+	rejectTerminalSessionReady,
+} from "./session-readiness";
 
 describe("launchCommandInPane", () => {
 	it("creates a terminal session and writes the command with a newline", async () => {
@@ -73,6 +78,57 @@ describe("launchCommandInPane", () => {
 			data: "echo hello\n",
 			throwOnError: true,
 		});
+	});
+
+	it("waits for the mounted session before writing when requested", async () => {
+		const paneId = "pane-mounted-session-ready";
+		const createOrAttach = mock(async () => ({}));
+		const write = mock(async () => ({}));
+
+		const launchPromise = launchCommandInPane({
+			paneId,
+			tabId: "tab-1",
+			workspaceId: "ws-1",
+			command: "echo hello",
+			createOrAttach,
+			write,
+			waitForMountedSession: true,
+		});
+
+		expect(createOrAttach).not.toHaveBeenCalled();
+		expect(write).not.toHaveBeenCalled();
+
+		markTerminalSessionReady(paneId);
+		await launchPromise;
+		clearTerminalSessionReady(paneId);
+
+		expect(write).toHaveBeenCalledWith({
+			paneId,
+			data: "echo hello\n",
+			throwOnError: true,
+		});
+	});
+
+	it("propagates mounted-session readiness failures", async () => {
+		const paneId = "pane-mounted-session-failure";
+		const createOrAttach = mock(async () => ({}));
+		const write = mock(async () => ({}));
+
+		const launchPromise = launchCommandInPane({
+			paneId,
+			tabId: "tab-1",
+			workspaceId: "ws-1",
+			command: "echo hello",
+			createOrAttach,
+			write,
+			waitForMountedSession: true,
+		});
+
+		rejectTerminalSessionReady(paneId, new Error("attach failed"));
+
+		await expect(launchPromise).rejects.toThrow("attach failed");
+		expect(createOrAttach).not.toHaveBeenCalled();
+		expect(write).not.toHaveBeenCalled();
 	});
 });
 

--- a/apps/desktop/src/renderer/lib/terminal/launch-command.ts
+++ b/apps/desktop/src/renderer/lib/terminal/launch-command.ts
@@ -1,4 +1,4 @@
-import { waitForStreamReady } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache";
+import { waitForTerminalSessionReady } from "./session-readiness";
 
 interface TerminalCreateOrAttachInput {
 	paneId: string;
@@ -23,6 +23,10 @@ interface LaunchCommandInPaneOptions {
 	createOrAttach: (input: TerminalCreateOrAttachInput) => Promise<unknown>;
 	write: (input: TerminalWriteInput) => Promise<unknown>;
 	noExecute?: boolean;
+	/**
+	 * Only use this for panes that will mount immediately in the active tab.
+	 * Background tabs must use the helper-side attach path instead.
+	 */
 	waitForMountedSession?: boolean;
 }
 
@@ -86,7 +90,7 @@ export async function launchCommandInPane({
 	waitForMountedSession,
 }: LaunchCommandInPaneOptions): Promise<void> {
 	if (waitForMountedSession) {
-		await waitForStreamReady(paneId);
+		await waitForTerminalSessionReady(paneId);
 		await writeCommandInPane({ paneId, command, write, noExecute });
 		return;
 	}

--- a/apps/desktop/src/renderer/lib/terminal/launch-command.ts
+++ b/apps/desktop/src/renderer/lib/terminal/launch-command.ts
@@ -1,3 +1,5 @@
+import { waitForStreamReady } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache";
+
 interface TerminalCreateOrAttachInput {
 	paneId: string;
 	tabId: string;
@@ -21,6 +23,7 @@ interface LaunchCommandInPaneOptions {
 	createOrAttach: (input: TerminalCreateOrAttachInput) => Promise<unknown>;
 	write: (input: TerminalWriteInput) => Promise<unknown>;
 	noExecute?: boolean;
+	waitForMountedSession?: boolean;
 }
 
 function normalizeTerminalCommand(command: string): string {
@@ -80,7 +83,14 @@ export async function launchCommandInPane({
 	createOrAttach,
 	write,
 	noExecute,
+	waitForMountedSession,
 }: LaunchCommandInPaneOptions): Promise<void> {
+	if (waitForMountedSession) {
+		await waitForStreamReady(paneId);
+		await writeCommandInPane({ paneId, command, write, noExecute });
+		return;
+	}
+
 	await ensureTerminalAttached({
 		paneId,
 		tabId,

--- a/apps/desktop/src/renderer/lib/terminal/session-readiness.ts
+++ b/apps/desktop/src/renderer/lib/terminal/session-readiness.ts
@@ -1,0 +1,54 @@
+type SessionReadyWaiter = {
+	resolve: () => void;
+	reject: (error: Error) => void;
+};
+
+const readyPaneIds = new Set<string>();
+const waitersByPaneId = new Map<string, Set<SessionReadyWaiter>>();
+
+function resolveWaiters(paneId: string): void {
+	const waiters = waitersByPaneId.get(paneId);
+	if (!waiters) return;
+	waitersByPaneId.delete(paneId);
+	for (const waiter of waiters) {
+		waiter.resolve();
+	}
+}
+
+function rejectWaiters(paneId: string, error: Error): void {
+	const waiters = waitersByPaneId.get(paneId);
+	if (!waiters) return;
+	waitersByPaneId.delete(paneId);
+	for (const waiter of waiters) {
+		waiter.reject(error);
+	}
+}
+
+export function clearTerminalSessionReady(paneId: string): void {
+	readyPaneIds.delete(paneId);
+}
+
+export function markTerminalSessionReady(paneId: string): void {
+	readyPaneIds.add(paneId);
+	resolveWaiters(paneId);
+}
+
+export function rejectTerminalSessionReady(paneId: string, error: Error): void {
+	readyPaneIds.delete(paneId);
+	rejectWaiters(paneId, error);
+}
+
+export function waitForTerminalSessionReady(paneId: string): Promise<void> {
+	if (readyPaneIds.has(paneId)) {
+		return Promise.resolve();
+	}
+
+	return new Promise<void>((resolve, reject) => {
+		let waiters = waitersByPaneId.get(paneId);
+		if (!waiters) {
+			waiters = new Set();
+			waitersByPaneId.set(paneId, waiters);
+		}
+		waiters.add({ resolve, reject });
+	});
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
@@ -5,6 +5,11 @@ import type { MutableRefObject, RefObject } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { writeCommandInPane } from "renderer/lib/terminal/launch-command";
 import type { DetectedLink } from "renderer/lib/terminal/links";
+import {
+	clearTerminalSessionReady,
+	markTerminalSessionReady,
+	rejectTerminalSessionReady,
+} from "renderer/lib/terminal/session-readiness";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import { killTerminalForPane } from "renderer/stores/tabs/utils/terminal-cleanup";
@@ -359,6 +364,7 @@ export function useTerminalLifecycle({
 					const requestId = nextAttachRequestId();
 					cancelAttachRequest(activeAttachRequestId);
 					activeAttachRequestId = requestId;
+					clearTerminalSessionReady(paneId);
 					createOrAttachRef.current(
 						{
 							paneId,
@@ -553,6 +559,7 @@ export function useTerminalLifecycle({
 							!isUnmounted && !attachCanceled && attachId === activeAttachId;
 
 						markAttachInFlight(paneId, attachId);
+						clearTerminalSessionReady(paneId);
 
 						const finishAttach = () => {
 							clearAttachInFlight(paneId, attachId);
@@ -587,6 +594,7 @@ export function useTerminalLifecycle({
 									// flow through the component's registered handler.
 									v1TerminalCache.startStream(paneId);
 									v1TerminalCache.setStreamReady(paneId);
+									markTerminalSessionReady(paneId);
 
 									const storedColdRestore = coldRestoreState.get(paneId);
 									if (storedColdRestore?.isRestored) {
@@ -653,7 +661,7 @@ export function useTerminalLifecycle({
 									}
 									const workspaceRun = getPaneWorkspaceRun(paneId);
 									if (error.message?.includes("TERMINAL_SESSION_KILLED")) {
-										v1TerminalCache.failStreamReady(
+										rejectTerminalSessionReady(
 											paneId,
 											new Error(error.message || "Terminal session killed"),
 										);
@@ -668,7 +676,7 @@ export function useTerminalLifecycle({
 										return;
 									}
 									console.error("[Terminal] Failed to create/attach:", error);
-									v1TerminalCache.failStreamReady(
+									rejectTerminalSessionReady(
 										paneId,
 										new Error(error.message || "Failed to connect to terminal"),
 									);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
@@ -653,6 +653,10 @@ export function useTerminalLifecycle({
 									}
 									const workspaceRun = getPaneWorkspaceRun(paneId);
 									if (error.message?.includes("TERMINAL_SESSION_KILLED")) {
+										v1TerminalCache.failStreamReady(
+											paneId,
+											new Error(error.message || "Terminal session killed"),
+										);
 										if (workspaceRun) {
 											setPaneWorkspaceRunState(paneId, "stopped-by-user");
 										}
@@ -664,6 +668,10 @@ export function useTerminalLifecycle({
 										return;
 									}
 									console.error("[Terminal] Failed to create/attach:", error);
+									v1TerminalCache.failStreamReady(
+										paneId,
+										new Error(error.message || "Failed to connect to terminal"),
+									);
 									if (workspaceRun) {
 										setPaneWorkspaceRunState(paneId, "stopped-by-exit");
 									}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
@@ -55,6 +55,28 @@ export interface CachedTerminal {
 }
 
 const cache = new Map<string, CachedTerminal>();
+const streamReadyWaiters = new Map<
+	string,
+	Set<{ resolve: () => void; reject: (error: Error) => void }>
+>();
+
+function resolveStreamReadyWaiters(paneId: string): void {
+	const waiters = streamReadyWaiters.get(paneId);
+	if (!waiters) return;
+	streamReadyWaiters.delete(paneId);
+	for (const waiter of waiters) {
+		waiter.resolve();
+	}
+}
+
+function rejectStreamReadyWaiters(paneId: string, error: Error): void {
+	const waiters = streamReadyWaiters.get(paneId);
+	if (!waiters) return;
+	streamReadyWaiters.delete(paneId);
+	for (const waiter of waiters) {
+		waiter.reject(error);
+	}
+}
 
 export function has(paneId: string): boolean {
 	return cache.has(paneId);
@@ -62,6 +84,21 @@ export function has(paneId: string): boolean {
 
 export function get(paneId: string): CachedTerminal | undefined {
 	return cache.get(paneId);
+}
+
+export function waitForStreamReady(paneId: string): Promise<void> {
+	if (cache.get(paneId)?.streamReady) {
+		return Promise.resolve();
+	}
+
+	return new Promise<void>((resolve, reject) => {
+		let waiters = streamReadyWaiters.get(paneId);
+		if (!waiters) {
+			waiters = new Set();
+			streamReadyWaiters.set(paneId, waiters);
+		}
+		waiters.add({ resolve, reject });
+	});
 }
 
 export function getOrCreate(
@@ -259,10 +296,15 @@ export function setStreamReady(paneId: string): void {
 	}
 
 	entry.streamReady = true;
+	resolveStreamReadyWaiters(paneId);
 	const pending = entry.pendingStreamEvents.splice(0);
 	for (const event of pending) {
 		routeEvent(entry, event);
 	}
+}
+
+export function failStreamReady(paneId: string, error: Error): void {
+	rejectStreamReadyWaiters(paneId, error);
 }
 
 /**
@@ -314,6 +356,10 @@ export function dispose(paneId: string): void {
 	entry.cleanupCreation();
 	entry.xterm.dispose();
 	cache.delete(paneId);
+	rejectStreamReadyWaiters(
+		paneId,
+		new Error("Terminal disposed before reaching stream-ready state"),
+	);
 }
 
 // Preserve cache across Vite HMR in dev so active terminals aren't orphaned.

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
@@ -55,28 +55,6 @@ export interface CachedTerminal {
 }
 
 const cache = new Map<string, CachedTerminal>();
-const streamReadyWaiters = new Map<
-	string,
-	Set<{ resolve: () => void; reject: (error: Error) => void }>
->();
-
-function resolveStreamReadyWaiters(paneId: string): void {
-	const waiters = streamReadyWaiters.get(paneId);
-	if (!waiters) return;
-	streamReadyWaiters.delete(paneId);
-	for (const waiter of waiters) {
-		waiter.resolve();
-	}
-}
-
-function rejectStreamReadyWaiters(paneId: string, error: Error): void {
-	const waiters = streamReadyWaiters.get(paneId);
-	if (!waiters) return;
-	streamReadyWaiters.delete(paneId);
-	for (const waiter of waiters) {
-		waiter.reject(error);
-	}
-}
 
 export function has(paneId: string): boolean {
 	return cache.has(paneId);
@@ -84,21 +62,6 @@ export function has(paneId: string): boolean {
 
 export function get(paneId: string): CachedTerminal | undefined {
 	return cache.get(paneId);
-}
-
-export function waitForStreamReady(paneId: string): Promise<void> {
-	if (cache.get(paneId)?.streamReady) {
-		return Promise.resolve();
-	}
-
-	return new Promise<void>((resolve, reject) => {
-		let waiters = streamReadyWaiters.get(paneId);
-		if (!waiters) {
-			waiters = new Set();
-			streamReadyWaiters.set(paneId, waiters);
-		}
-		waiters.add({ resolve, reject });
-	});
 }
 
 export function getOrCreate(
@@ -296,15 +259,10 @@ export function setStreamReady(paneId: string): void {
 	}
 
 	entry.streamReady = true;
-	resolveStreamReadyWaiters(paneId);
 	const pending = entry.pendingStreamEvents.splice(0);
 	for (const event of pending) {
 		routeEvent(entry, event);
 	}
-}
-
-export function failStreamReady(paneId: string, error: Error): void {
-	rejectStreamReadyWaiters(paneId, error);
 }
 
 /**
@@ -356,10 +314,6 @@ export function dispose(paneId: string): void {
 	entry.cleanupCreation();
 	entry.xterm.dispose();
 	cache.delete(paneId);
-	rejectStreamReadyWaiters(
-		paneId,
-		new Error("Terminal disposed before reaching stream-ready state"),
-	);
 }
 
 // Preserve cache across Vite HMR in dev so active terminals aren't orphaned.

--- a/apps/desktop/src/renderer/stores/tabs/useTabsWithPresets.ts
+++ b/apps/desktop/src/renderer/stores/tabs/useTabsWithPresets.ts
@@ -103,13 +103,17 @@ export function useTabsWithPresets(projectId?: string | null) {
 	}, []);
 
 	const launchPresetCommand = useCallback(
-		({ paneId, tabId, workspaceId, command, cwd }: PresetPaneLaunch) => {
+		(
+			{ paneId, tabId, workspaceId, command, cwd }: PresetPaneLaunch,
+			options?: { waitForMountedSession?: boolean },
+		) => {
 			void launchCommandInPane({
 				paneId,
 				tabId,
 				workspaceId,
 				command,
 				cwd,
+				waitForMountedSession: options?.waitForMountedSession,
 				createOrAttach: (input) => createOrAttach.mutateAsync(input),
 				write: (input) => writeToTerminal.mutateAsync(input),
 			}).catch((error) => {
@@ -125,9 +129,12 @@ export function useTabsWithPresets(projectId?: string | null) {
 	);
 
 	const launchPresetCommands = useCallback(
-		(launches: PresetPaneLaunch[]) => {
+		(
+			launches: PresetPaneLaunch[],
+			options?: { waitForMountedSession?: boolean },
+		) => {
 			for (const launch of launches) {
-				launchPresetCommand(launch);
+				launchPresetCommand(launch, options);
 			}
 		},
 		[launchPresetCommand],
@@ -145,13 +152,16 @@ export function useTabsWithPresets(projectId?: string | null) {
 			if (firstPresetCommand === null) return;
 			const workspaceId = resolveWorkspaceIdForTab(tabId);
 			if (!workspaceId) return;
-			launchPresetCommand({
-				paneId,
-				tabId,
-				workspaceId,
-				command: firstPresetCommand,
-				cwd: firstPreset?.cwd || undefined,
-			});
+			launchPresetCommand(
+				{
+					paneId,
+					tabId,
+					workspaceId,
+					command: firstPresetCommand,
+					cwd: firstPreset?.cwd || undefined,
+				},
+				{ waitForMountedSession: true },
+			);
 		},
 		[
 			firstPreset,
@@ -162,20 +172,27 @@ export function useTabsWithPresets(projectId?: string | null) {
 	);
 
 	const launchFirstPresetInFocusedPane = useCallback(
-		(tabId: string, previousFocusedPaneId: string | undefined) => {
+		(
+			tabId: string,
+			previousFocusedPaneId: string | undefined,
+			options?: { waitForMountedSession?: boolean },
+		) => {
 			if (firstPresetCommand === null) return;
 			const state = useTabsStore.getState();
 			const paneId = state.focusedPaneIds[tabId];
 			if (!paneId || paneId === previousFocusedPaneId) return;
 			const tab = state.tabs.find((tabItem) => tabItem.id === tabId);
 			if (!tab) return;
-			launchPresetCommand({
-				paneId,
-				tabId,
-				workspaceId: tab.workspaceId,
-				command: firstPresetCommand,
-				cwd: firstPreset?.cwd || undefined,
-			});
+			launchPresetCommand(
+				{
+					paneId,
+					tabId,
+					workspaceId: tab.workspaceId,
+					command: firstPresetCommand,
+					cwd: firstPreset?.cwd || undefined,
+				},
+				options,
+			);
 		},
 		[firstPreset, firstPresetCommand, launchPresetCommand],
 	);
@@ -237,7 +254,7 @@ export function useTabsWithPresets(projectId?: string | null) {
 						];
 					},
 				);
-				launchPresetCommands(launches);
+				launchPresetCommands(launches, { waitForMountedSession: true });
 				applyTabName(multiPane.tabId, preset.name);
 				return { tabId: multiPane.tabId, paneId: multiPane.paneIds[0] };
 			}
@@ -302,7 +319,7 @@ export function useTabsWithPresets(projectId?: string | null) {
 							];
 						},
 					);
-					launchPresetCommands(launches);
+					launchPresetCommands(launches, { waitForMountedSession: true });
 					return { tabId: activeTabId, paneId: paneIds[0] };
 				}
 				return executePresetInNewTab(workspaceId, preset);
@@ -315,13 +332,16 @@ export function useTabsWithPresets(projectId?: string | null) {
 				});
 				if (paneId) {
 					if (command !== null) {
-						launchPresetCommand({
-							paneId,
-							tabId: activeTabId,
-							workspaceId,
-							command,
-							cwd: preset.initialCwd,
-						});
+						launchPresetCommand(
+							{
+								paneId,
+								tabId: activeTabId,
+								workspaceId,
+								command,
+								cwd: preset.initialCwd,
+							},
+							{ waitForMountedSession: true },
+						);
 					}
 					return { tabId: activeTabId, paneId };
 				}
@@ -436,7 +456,9 @@ export function useTabsWithPresets(projectId?: string | null) {
 			const previousFocusedPaneId =
 				useTabsStore.getState().focusedPaneIds[tabId];
 			storeSplitPaneVertical(tabId, sourcePaneId, path, firstPresetOptions);
-			launchFirstPresetInFocusedPane(tabId, previousFocusedPaneId);
+			launchFirstPresetInFocusedPane(tabId, previousFocusedPaneId, {
+				waitForMountedSession: true,
+			});
 		},
 		[
 			storeSplitPaneVertical,
@@ -458,7 +480,9 @@ export function useTabsWithPresets(projectId?: string | null) {
 			const previousFocusedPaneId =
 				useTabsStore.getState().focusedPaneIds[tabId];
 			storeSplitPaneHorizontal(tabId, sourcePaneId, path, firstPresetOptions);
-			launchFirstPresetInFocusedPane(tabId, previousFocusedPaneId);
+			launchFirstPresetInFocusedPane(tabId, previousFocusedPaneId, {
+				waitForMountedSession: true,
+			});
 		},
 		[
 			storeSplitPaneHorizontal,
@@ -493,7 +517,9 @@ export function useTabsWithPresets(projectId?: string | null) {
 				path,
 				firstPresetOptions,
 			);
-			launchFirstPresetInFocusedPane(tabId, previousFocusedPaneId);
+			launchFirstPresetInFocusedPane(tabId, previousFocusedPaneId, {
+				waitForMountedSession: true,
+			});
 		},
 		[storeSplitPaneAuto, firstPresetOptions, launchFirstPresetInFocusedPane],
 	);

--- a/apps/desktop/src/renderer/stores/tabs/useTabsWithPresets.ts
+++ b/apps/desktop/src/renderer/stores/tabs/useTabsWithPresets.ts
@@ -254,7 +254,7 @@ export function useTabsWithPresets(projectId?: string | null) {
 						];
 					},
 				);
-				launchPresetCommands(launches, { waitForMountedSession: true });
+				launchPresetCommands(launches);
 				applyTabName(multiPane.tabId, preset.name);
 				return { tabId: multiPane.tabId, paneId: multiPane.paneIds[0] };
 			}

--- a/apps/desktop/src/renderer/stores/tabs/utils/terminal-cleanup.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils/terminal-cleanup.ts
@@ -1,9 +1,14 @@
+import { rejectTerminalSessionReady } from "../../../lib/terminal/session-readiness";
 import { electronTrpcClient } from "../../../lib/trpc-client";
 
 /**
  * Uses standalone tRPC client to avoid React hook dependencies
  */
 export const killTerminalForPane = (paneId: string): void => {
+	rejectTerminalSessionReady(
+		paneId,
+		new Error("Terminal pane was closed before the session became ready"),
+	);
 	electronTrpcClient.terminal.kill.mutate({ paneId }).catch((error) => {
 		console.warn(`Failed to kill terminal for pane ${paneId}:`, error);
 	});


### PR DESCRIPTION
## Summary
Fixes a v1 terminal race where opening a split pane and launching an initial command at the same time could start the terminal session at fallback dimensions, causing TUIs to initialize with the wrong size.

## Root Cause
The helper-side launch path could create or attach the daemon session before the newly-created split pane had mounted and finished its first real attach. In that case the backend could start from fallback sizing, and the initial command would run before the mounted terminal had established the correct dimensions.

## What Changed
- Added a `streamReady` waiter to the v1 terminal cache so callers can wait for the mounted terminal attach to complete.
- Updated `launchCommandInPane` to optionally wait for the mounted session instead of issuing a helper-side attach first.
- Wired the v1 split-pane preset launch paths to use that mounted-session readiness path before writing the initial command.
- Propagated initial attach failures into the readiness waiter so it does not hang on attach errors.

## Impact
- Split-pane terminal launches in v1 now wait for the pane's real fitted session before sending the startup command.
- TUIs opened via preset-driven split panes should start with the correct size instead of briefly booting at fallback dimensions.

## Validation
- `bunx biome check apps/desktop/src/renderer/lib/terminal/launch-command.ts apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts apps/desktop/src/renderer/stores/tabs/useTabsWithPresets.ts`
- `bun test apps/desktop/src/renderer/lib/terminal/launch-command.test.ts`

## Notes
I also checked the v2 terminal path for inspiration. V2 gates initial commands on shell readiness, but the v1 bug here was specifically about pane sizing, so the correct fix was to wait on v1's mounted-session readiness instead of copying the v2 shell-ready flow directly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in v1 split panes where the initial command ran before the pane mounted, causing fallback terminal sizes. Launches now wait for the mounted, fitted session before sending startup commands; background tabs still use the helper-side attach.

- **Bug Fixes**
  - Added a session-readiness tracker (`waitForTerminalSessionReady` with `mark/clear/reject`) and integrated it into the v1 terminal lifecycle.
  - Added a `waitForMountedSession` option to `launchCommandInPane`; preset and split-pane flows use it only when panes mount in the active tab.
  - Propagate attach errors and pane closes to reject waiters and prevent hangs; clear readiness on re-attach.

<sup>Written for commit b28c69b63a98939895335be8b81a66748720231a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved terminal command execution reliability by ensuring sessions are properly ready before launching commands
  * Enhanced handling of multi-pane and preset command launches to wait for terminal initialization
  * Fixed potential issues with command execution timing in newly created or split terminal panes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->