### PR TITLE
fix(desktop): allow hotkeys to trigger in editable content

### DIFF
--- a/apps/desktop/src/renderer/hotkeys/hooks/useHotkey/useHotkey.ts
+++ b/apps/desktop/src/renderer/hotkeys/hooks/useHotkey/useHotkey.ts
@@ -17,7 +17,7 @@ export function useHotkey(
 	useHotkeys(
 		keys ?? "",
 		(e, _h) => callbackRef.current(e),
-		{ enableOnFormTags: true, ...options },
+		{ enableOnFormTags: true, enableOnContentEditable: true, ...options },
 		[keys],
 	);
 	return formatHotkeyDisplay(keys, PLATFORM);


### PR DESCRIPTION
## Summary
- `react-hotkeys-hook` skips keydown events whose target is `contentEditable` unless `enableOnContentEditable` is set. CodeMirror 6 (v1 file editor) uses a `contenteditable` editor area, so cmd+w never reached the `CLOSE_TERMINAL` handler at `workspace/$workspaceId/page.tsx:220` while the editor was focused.
- Default `enableOnContentEditable: true` in `useHotkey`, mirroring the existing `enableOnFormTags: true` default. Callers can still opt out via `options`.

## Test plan
- [ ] Focus a file in the v1 file editor, press cmd+w → pane closes.
- [ ] Unsaved changes prompt still triggers on cmd+w in a dirty file editor.
- [ ] Other app chords (cmd+s save, cmd+f find) still behave as before inside the editor.
- [ ] cmd+w still closes terminal / chat / browser panes when those are focused.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore cmd+w to close the focused pane when the v1 file editor (CodeMirror) is focused by allowing app hotkeys to fire inside contentEditable editors.

- **Bug Fixes**
  - Default `enableOnContentEditable: true` in `useHotkey` (mirrors `enableOnFormTags: true`); callers can override via `options`.
  - Addresses `react-hotkeys-hook` skipping keydown on contentEditable (CodeMirror), so cmd+w reaches the close handler again without changing other shortcuts.

<sup>Written for commit 45d877b27155a0def326bec1c944da86a88437e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled hotkey handling on content-editable elements, allowing keyboard shortcuts to function properly in editable text areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->