### PR TITLE
feat(desktop): v2 diff viewer opens in its own tab + collapsed tab/pane title resolution

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/buildSetupPaneLayout.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/buildSetupPaneLayout.ts
@@ -17,7 +17,6 @@ export function buildSetupPaneLayout(
 		const tabId = `tab-${crypto.randomUUID()}`;
 		return {
 			id: tabId,
-			titleOverride: t.label,
 			createdAt: Date.now(),
 			activePaneId: paneId,
 			layout: { type: "pane" as const, paneId },
@@ -25,6 +24,7 @@ export function buildSetupPaneLayout(
 				[paneId]: {
 					id: paneId,
 					kind: "terminal",
+					titleOverride: t.label,
 					data: { terminalId: t.id } as TerminalPaneData,
 				},
 			},

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useDefaultContextMenuActions/useDefaultContextMenuActions.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useDefaultContextMenuActions/useDefaultContextMenuActions.tsx
@@ -1,4 +1,9 @@
-import type { ContextMenuActionConfig, RendererContext } from "@superset/panes";
+import {
+	type ContextMenuActionConfig,
+	type PaneRegistry,
+	type RendererContext,
+	resolveTabTitle,
+} from "@superset/panes";
 import { useMemo } from "react";
 import {
 	LuColumns2,
@@ -18,7 +23,9 @@ import type {
 	TerminalPaneData,
 } from "../../types";
 
-export function useDefaultContextMenuActions(): ContextMenuActionConfig<PaneViewerData>[] {
+export function useDefaultContextMenuActions(
+	paneRegistry: PaneRegistry<PaneViewerData>,
+): ContextMenuActionConfig<PaneViewerData>[] {
 	const splitDownShortcut = useHotkeyDisplay("SPLIT_DOWN").text;
 	const splitRightShortcut = useHotkeyDisplay("SPLIT_RIGHT").text;
 	const splitWithChatShortcut = useHotkeyDisplay("SPLIT_WITH_CHAT").text;
@@ -115,7 +122,7 @@ export function useDefaultContextMenuActions(): ContextMenuActionConfig<PaneView
 					const items: ContextMenuActionConfig<PaneViewerData>[] =
 						otherTabs.map((tab) => ({
 							key: `move-to-${tab.id}`,
-							label: tab.titleOverride ?? tab.id,
+							label: resolveTabTitle(tab, tabs, paneRegistry),
 							onSelect: () => {
 								ctx.store
 									.getState()
@@ -154,6 +161,7 @@ export function useDefaultContextMenuActions(): ContextMenuActionConfig<PaneView
 			splitWithBrowserShortcut,
 			equalizePaneSplitsShortcut,
 			closePaneShortcut,
+			paneRegistry,
 		],
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/BrowserPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/BrowserPane.tsx
@@ -22,20 +22,6 @@ function getSingleBrowserPane(
 	return { id: pane.id, data: pane.data as BrowserPaneData };
 }
 
-export function getBrowserTabTitle(
-	tab: Tab<PaneViewerData>,
-): string | undefined {
-	const browser = getSingleBrowserPane(tab);
-	if (!browser) return undefined;
-	if (browser.data.pageTitle) return browser.data.pageTitle;
-	if (browser.data.url && browser.data.url !== "about:blank") {
-		try {
-			return new URL(browser.data.url).hostname;
-		} catch {}
-	}
-	return undefined;
-}
-
 export function renderBrowserTabIcon(tab: Tab<PaneViewerData>) {
 	const browser = getSingleBrowserPane(tab);
 	if (!browser?.data.faviconUrl) return null;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/index.ts
@@ -1,7 +1,6 @@
 export {
 	BrowserPane,
 	BrowserPaneToolbar,
-	getBrowserTabTitle,
 	renderBrowserTabIcon,
 } from "./BrowserPane";
 export { browserRuntimeRegistry } from "./browserRuntimeRegistry";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -271,7 +271,7 @@ export function usePaneRegistry(
 							return new URL(data.url).hostname;
 						} catch {}
 					}
-					return undefined;
+					return "Browser";
 				},
 				renderPane: (ctx: RendererContext<PaneViewerData>) => (
 					<BrowserPane ctx={ctx} />

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -120,7 +120,8 @@ export function usePaneRegistry(
 					const name = getFileName(data.filePath);
 					return <FileIcon fileName={name} className="size-4" />;
 				},
-				getTitle: (ctx: RendererContext<PaneViewerData>) => {
+				getTitle: (pane) => getFileName((pane.data as FilePaneData).filePath),
+				renderTitle: (ctx: RendererContext<PaneViewerData>) => {
 					const data = ctx.pane.data as FilePaneData;
 					const name = getFileName(data.filePath);
 					return (
@@ -262,9 +263,15 @@ export function usePaneRegistry(
 			},
 			browser: {
 				getIcon: () => <Globe className="size-4" />,
-				getTitle: (ctx: RendererContext<PaneViewerData>) => {
-					const data = ctx.pane.data as BrowserPaneData;
-					return data.pageTitle || data.url;
+				getTitle: (pane) => {
+					const data = pane.data as BrowserPaneData;
+					if (data.pageTitle) return data.pageTitle;
+					if (data.url && data.url !== "about:blank") {
+						try {
+							return new URL(data.url).hostname;
+						} catch {}
+					}
+					return undefined;
 				},
 				renderPane: (ctx: RendererContext<PaneViewerData>) => (
 					<BrowserPane ctx={ctx} />

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -268,7 +268,7 @@ export function usePaneRegistry(
 					if (data.pageTitle) return data.pageTitle;
 					if (data.url && data.url !== "about:blank") {
 						try {
-							return new URL(data.url).hostname;
+							return new URL(data.url).host;
 						} catch {}
 					}
 					return "Browser";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/useV2PresetExecution.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/useV2PresetExecution.ts
@@ -84,7 +84,7 @@ export function useV2PresetExecution({
 							preset.commands[0] as string,
 						);
 						state.addTab({
-							titleOverride: preset.name || "Terminal",
+							titleOverride: preset.name || undefined,
 							panes: [makeTerminalPane(id)],
 						});
 						break;
@@ -96,7 +96,7 @@ export function useV2PresetExecution({
 						);
 						const panes = ids.map((id) => makeTerminalPane(id));
 						state.addTab({
-							titleOverride: preset.name || "Terminal",
+							titleOverride: preset.name || undefined,
 							panes:
 								panes.length > 0
 									? (panes as [
@@ -114,7 +114,7 @@ export function useV2PresetExecution({
 						);
 						for (let i = 0; i < ids.length; i++) {
 							state.addTab({
-								titleOverride: preset.name || "Terminal",
+								titleOverride: preset.name || undefined,
 								panes: [makeTerminalPane(ids[i] as string)],
 							});
 						}
@@ -127,7 +127,7 @@ export function useV2PresetExecution({
 						);
 						if (!activeTabId) {
 							state.addTab({
-								titleOverride: preset.name || "Terminal",
+								titleOverride: preset.name || undefined,
 								panes: [makeTerminalPane(id)],
 							});
 							break;
@@ -146,7 +146,7 @@ export function useV2PresetExecution({
 						if (!activeTabId) {
 							const panes = ids.map((id) => makeTerminalPane(id));
 							state.addTab({
-								titleOverride: preset.name || "Terminal",
+								titleOverride: preset.name || undefined,
 								panes:
 									panes.length > 0
 										? (panes as [

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/useV2PresetExecution.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2PresetExecution/useV2PresetExecution.ts
@@ -10,9 +10,13 @@ import { filterMatchingPresetsForProject } from "shared/preset-project-targeting
 import type { StoreApi } from "zustand/vanilla";
 import type { PaneViewerData, TerminalPaneData } from "../../types";
 
-function makeTerminalPane(terminalId: string): CreatePaneInput<PaneViewerData> {
+function makeTerminalPane(
+	terminalId: string,
+	titleOverride?: string,
+): CreatePaneInput<PaneViewerData> {
 	return {
 		kind: "terminal",
+		titleOverride,
 		data: { terminalId } as TerminalPaneData,
 	};
 }
@@ -84,8 +88,7 @@ export function useV2PresetExecution({
 							preset.commands[0] as string,
 						);
 						state.addTab({
-							titleOverride: preset.name || undefined,
-							panes: [makeTerminalPane(id)],
+							panes: [makeTerminalPane(id, preset.name || undefined)],
 						});
 						break;
 					}
@@ -94,16 +97,22 @@ export function useV2PresetExecution({
 						const ids = await Promise.all(
 							preset.commands.map((cmd) => createSessionWithCommand(cmd)),
 						);
-						const panes = ids.map((id) => makeTerminalPane(id));
+						const panes = ids.map((id) =>
+							makeTerminalPane(id, preset.name || undefined),
+						);
 						state.addTab({
-							titleOverride: preset.name || undefined,
 							panes:
 								panes.length > 0
 									? (panes as [
 											CreatePaneInput<PaneViewerData>,
 											...CreatePaneInput<PaneViewerData>[],
 										])
-									: [makeTerminalPane(crypto.randomUUID())],
+									: [
+											makeTerminalPane(
+												crypto.randomUUID(),
+												preset.name || undefined,
+											),
+										],
 						});
 						break;
 					}
@@ -114,8 +123,9 @@ export function useV2PresetExecution({
 						);
 						for (let i = 0; i < ids.length; i++) {
 							state.addTab({
-								titleOverride: preset.name || undefined,
-								panes: [makeTerminalPane(ids[i] as string)],
+								panes: [
+									makeTerminalPane(ids[i] as string, preset.name || undefined),
+								],
 							});
 						}
 						break;
@@ -127,14 +137,13 @@ export function useV2PresetExecution({
 						);
 						if (!activeTabId) {
 							state.addTab({
-								titleOverride: preset.name || undefined,
-								panes: [makeTerminalPane(id)],
+								panes: [makeTerminalPane(id, preset.name || undefined)],
 							});
 							break;
 						}
 						state.addPane({
 							tabId: activeTabId,
-							pane: makeTerminalPane(id),
+							pane: makeTerminalPane(id, preset.name || undefined),
 						});
 						break;
 					}
@@ -144,23 +153,29 @@ export function useV2PresetExecution({
 							preset.commands.map((cmd) => createSessionWithCommand(cmd)),
 						);
 						if (!activeTabId) {
-							const panes = ids.map((id) => makeTerminalPane(id));
+							const panes = ids.map((id) =>
+								makeTerminalPane(id, preset.name || undefined),
+							);
 							state.addTab({
-								titleOverride: preset.name || undefined,
 								panes:
 									panes.length > 0
 										? (panes as [
 												CreatePaneInput<PaneViewerData>,
 												...CreatePaneInput<PaneViewerData>[],
 											])
-										: [makeTerminalPane(crypto.randomUUID())],
+										: [
+												makeTerminalPane(
+													crypto.randomUUID(),
+													preset.name || undefined,
+												),
+											],
 							});
 							break;
 						}
 						for (const id of ids) {
 							state.addPane({
 								tabId: activeTabId,
-								pane: makeTerminalPane(id),
+								pane: makeTerminalPane(id, preset.name || undefined),
 							});
 						}
 						break;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
@@ -39,7 +39,6 @@ export function useWorkspaceHotkeys({
 
 	useHotkey("NEW_GROUP", () => {
 		store.getState().addTab({
-			titleOverride: "Terminal",
 			panes: [
 				{
 					kind: "terminal",
@@ -51,14 +50,12 @@ export function useWorkspaceHotkeys({
 
 	useHotkey("NEW_CHAT", () => {
 		store.getState().addTab({
-			titleOverride: "Chat",
 			panes: [{ kind: "chat", data: { sessionId: null } as ChatPaneData }],
 		});
 	});
 
 	useHotkey("NEW_BROWSER", () => {
 		store.getState().addTab({
-			titleOverride: "Browser",
 			panes: [
 				{
 					kind: "browser",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -22,10 +22,7 @@ import { WorkspaceNotFoundState } from "./components/WorkspaceNotFoundState";
 import { WorkspaceSidebar } from "./components/WorkspaceSidebar";
 import { useDefaultContextMenuActions } from "./hooks/useDefaultContextMenuActions";
 import { usePaneRegistry } from "./hooks/usePaneRegistry";
-import {
-	getBrowserTabTitle,
-	renderBrowserTabIcon,
-} from "./hooks/usePaneRegistry/components/BrowserPane";
+import { renderBrowserTabIcon } from "./hooks/usePaneRegistry/components/BrowserPane";
 import { useV2PresetExecution } from "./hooks/useV2PresetExecution";
 import { useV2WorkspacePaneLayout } from "./hooks/useV2WorkspacePaneLayout";
 import { useWorkspaceHotkeys } from "./hooks/useWorkspaceHotkeys";
@@ -93,7 +90,7 @@ function WorkspaceContent({
 		projectId,
 	});
 	const paneRegistry = usePaneRegistry(workspaceId);
-	const defaultContextMenuActions = useDefaultContextMenuActions();
+	const defaultContextMenuActions = useDefaultContextMenuActions(paneRegistry);
 
 	const selectedFilePath = useStore(store, (s) => {
 		const tab = s.tabs.find((t) => t.id === s.activeTabId);
@@ -108,7 +105,6 @@ function WorkspaceContent({
 			const state = store.getState();
 			if (openInNewTab) {
 				state.addTab({
-					titleOverride: filePath.split(/[/\\]/).pop(),
 					panes: [
 						{
 							kind: "file",
@@ -139,7 +135,6 @@ function WorkspaceContent({
 						hasChanges: false,
 					} as FilePaneData,
 				},
-				tabTitle: "Files",
 			});
 		},
 		[store],
@@ -148,9 +143,8 @@ function WorkspaceContent({
 	const openDiffPane = useCallback(
 		(filePath: string) => {
 			const state = store.getState();
-			const activeTab = state.tabs.find((t) => t.id === state.activeTabId);
-			if (activeTab) {
-				for (const pane of Object.values(activeTab.panes)) {
+			for (const tab of state.tabs) {
+				for (const pane of Object.values(tab.panes)) {
 					if (pane.kind !== "diff") continue;
 					const prev = pane.data as DiffPaneData;
 					state.setPaneData({
@@ -160,19 +154,21 @@ function WorkspaceContent({
 							path: filePath,
 						} as PaneViewerData,
 					});
-					state.setActivePane({ tabId: activeTab.id, paneId: pane.id });
+					state.setActiveTab(tab.id);
+					state.setActivePane({ tabId: tab.id, paneId: pane.id });
 					return;
 				}
 			}
-			state.openPane({
-				pane: {
-					kind: "diff",
-					data: {
-						path: filePath,
-						collapsedFiles: [],
-					} as DiffPaneData,
-				},
-				tabTitle: "Changes",
+			state.addTab({
+				panes: [
+					{
+						kind: "diff",
+						data: {
+							path: filePath,
+							collapsedFiles: [],
+						} as DiffPaneData,
+					},
+				],
 			});
 		},
 		[store],
@@ -180,7 +176,6 @@ function WorkspaceContent({
 
 	const addTerminalTab = useCallback(() => {
 		store.getState().addTab({
-			titleOverride: "Terminal",
 			panes: [
 				{
 					kind: "terminal",
@@ -194,7 +189,6 @@ function WorkspaceContent({
 
 	const addChatTab = useCallback(() => {
 		store.getState().addTab({
-			titleOverride: "Chat",
 			panes: [
 				{
 					kind: "chat",
@@ -206,7 +200,6 @@ function WorkspaceContent({
 
 	const addBrowserTab = useCallback(() => {
 		store.getState().addTab({
-			titleOverride: "Browser",
 			panes: [
 				{
 					kind: "browser",
@@ -270,7 +263,6 @@ function WorkspaceContent({
 							registry={paneRegistry}
 							paneActions={defaultPaneActions}
 							contextMenuActions={defaultContextMenuActions}
-							getTabTitle={getBrowserTabTitle}
 							renderTabIcon={renderBrowserTabIcon}
 							renderBelowTabBar={() => (
 								<V2PresetsBar

--- a/packages/panes/src/core/store/store.test.ts
+++ b/packages/panes/src/core/store/store.test.ts
@@ -433,11 +433,9 @@ describe("openPane", () => {
 
 		store.getState().openPane({
 			pane: tp("p1", "opened"),
-			tabTitle: "My Tab",
 		});
 
 		expect(store.getState().tabs).toHaveLength(1);
-		expect(store.getState().tabs[0]?.titleOverride).toBe("My Tab");
 		expect(store.getState().getActivePane()?.pane.data.label).toBe("opened");
 	});
 

--- a/packages/panes/src/core/store/store.ts
+++ b/packages/panes/src/core/store/store.ts
@@ -121,7 +121,7 @@ export interface WorkspaceStore<TData> extends WorkspaceState<TData> {
 		newPane: CreatePaneInput<TData>;
 	}) => void;
 
-	openPane: (args: { pane: CreatePaneInput<TData>; tabTitle?: string }) => void;
+	openPane: (args: { pane: CreatePaneInput<TData> }) => void;
 
 	splitPane: (args: {
 		tabId: string;
@@ -406,7 +406,6 @@ export function createWorkspaceStore<TData>(
 			// No tab → create one
 			if (!tab || !activeTabId) {
 				get().addTab({
-					titleOverride: args.tabTitle,
 					panes: [args.pane],
 				});
 				return;

--- a/packages/panes/src/index.ts
+++ b/packages/panes/src/index.ts
@@ -17,7 +17,7 @@ export type {
 	TabContext,
 	WorkspaceProps,
 } from "./react";
-export { Workspace } from "./react";
+export { resolveTabTitle, Workspace } from "./react";
 export type {
 	LayoutNode,
 	Pane,

--- a/packages/panes/src/react/components/Workspace/Workspace.tsx
+++ b/packages/panes/src/react/components/Workspace/Workspace.tsx
@@ -5,6 +5,7 @@ import type { Pane } from "../../../types";
 import type { WorkspaceProps } from "../../types";
 import { Tab } from "./components/Tab";
 import { TabBar } from "./components/TabBar";
+import { resolveTabTitle } from "./utils/resolveTabTitle";
 
 export function Workspace<TData>({
 	store,
@@ -12,7 +13,6 @@ export function Workspace<TData>({
 	className,
 	renderTabAccessory,
 	renderTabIcon,
-	getTabTitle,
 	renderEmptyState,
 	renderAddTabMenu,
 	renderBelowTabBar,
@@ -78,7 +78,7 @@ export function Workspace<TData>({
 				onReorderTab={(tabId, toIndex) =>
 					store.getState().reorderTab({ tabId, toIndex })
 				}
-				getTabTitle={(tab) => tab.titleOverride ?? getTabTitle?.(tab) ?? tab.id}
+				getTabTitle={(tab) => resolveTabTitle(tab, tabs, registry)}
 				renderTabIcon={renderTabIcon}
 				renderAddTabMenu={renderAddTabMenu}
 				renderTabAccessory={renderTabAccessory}

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
@@ -211,7 +211,7 @@ export function Pane<TData>({
 	}
 
 	const title = definition
-		? (pane.titleOverride ?? definition.getTitle?.(context) ?? pane.id)
+		? (pane.titleOverride ?? definition.getTitle?.(pane) ?? pane.id)
 		: `Unknown: ${pane.kind}`;
 	const icon = definition?.getIcon?.(context);
 	const titleContent = definition?.renderTitle?.(context);

--- a/packages/panes/src/react/components/Workspace/index.ts
+++ b/packages/panes/src/react/components/Workspace/index.ts
@@ -1,1 +1,2 @@
+export { resolveTabTitle } from "./utils/resolveTabTitle";
 export { Workspace } from "./Workspace";

--- a/packages/panes/src/react/components/Workspace/utils/resolveTabTitle.ts
+++ b/packages/panes/src/react/components/Workspace/utils/resolveTabTitle.ts
@@ -1,0 +1,17 @@
+import type { Tab } from "../../../../types";
+import type { PaneRegistry } from "../../../types";
+
+export function resolveTabTitle<TData>(
+	tab: Tab<TData>,
+	tabs: Tab<TData>[],
+	registry: PaneRegistry<TData>,
+): string {
+	if (tab.titleOverride) return tab.titleOverride;
+	const panes = Object.values(tab.panes);
+	const onlyPane = panes.length === 1 ? panes[0] : undefined;
+	if (onlyPane) {
+		const fromRegistry = registry[onlyPane.kind]?.getTitle?.(onlyPane);
+		if (fromRegistry) return fromRegistry;
+	}
+	return `Tab ${tabs.indexOf(tab) + 1}`;
+}

--- a/packages/panes/src/react/components/Workspace/utils/resolveTabTitle.ts
+++ b/packages/panes/src/react/components/Workspace/utils/resolveTabTitle.ts
@@ -10,8 +10,9 @@ export function resolveTabTitle<TData>(
 	const panes = Object.values(tab.panes);
 	const onlyPane = panes.length === 1 ? panes[0] : undefined;
 	if (onlyPane) {
-		const fromRegistry = registry[onlyPane.kind]?.getTitle?.(onlyPane);
-		if (fromRegistry) return fromRegistry;
+		const fromPane =
+			onlyPane.titleOverride ?? registry[onlyPane.kind]?.getTitle?.(onlyPane);
+		if (fromPane) return fromPane;
 	}
 	return `Tab ${tabs.indexOf(tab) + 1}`;
 }

--- a/packages/panes/src/react/index.ts
+++ b/packages/panes/src/react/index.ts
@@ -1,4 +1,4 @@
-export { Workspace } from "./components/Workspace";
+export { resolveTabTitle, Workspace } from "./components/Workspace";
 export type {
 	ContextMenuActionConfig,
 	PaneActionConfig,

--- a/packages/panes/src/react/types.ts
+++ b/packages/panes/src/react/types.ts
@@ -58,7 +58,7 @@ export interface RendererContext<TData> {
 
 export interface PaneDefinition<TData> {
 	renderPane(context: RendererContext<TData>): ReactNode;
-	getTitle?(context: RendererContext<TData>): ReactNode;
+	getTitle?(pane: Pane<TData>): string | undefined;
 	getIcon?(context: RendererContext<TData>): ReactNode;
 	renderTitle?(context: RendererContext<TData>): ReactNode;
 	renderHeaderExtras?(context: RendererContext<TData>): ReactNode;
@@ -88,7 +88,6 @@ export interface WorkspaceProps<TData> {
 	className?: string;
 	renderTabAccessory?: (tab: Tab<TData>) => ReactNode;
 	renderTabIcon?: (tab: Tab<TData>) => ReactNode;
-	getTabTitle?: (tab: Tab<TData>) => string | undefined;
 	renderEmptyState?: () => ReactNode;
 	renderAddTabMenu?: () => ReactNode;
 	renderBelowTabBar?: () => ReactNode;


### PR DESCRIPTION
## Summary

- **Diff viewer opens in its own tab.** Clicking a file in the Changes sidebar no longer hijacks the focused editor. `openDiffPane` scans all tabs for an existing diff pane (focuses + scrolls to the clicked file) and otherwise falls through to `addTab` directly. Manual splits still work; re-clicking from the sidebar finds a split-out diff pane in any tab rather than duplicating.
- **Collapsed tab/pane title resolution onto one canonical field.** `PaneDefinition.getTitle` is tightened from `(ctx) => ReactNode` to `(pane) => string | undefined`. The file pane's rich JSX (italic-when-unpinned + has-changes dot) moves into the existing `renderTitle` hook where it belongs; 5 of 6 pane kinds already returned strings. A new `resolveTabTitle(tab, tabs, registry)` helper powers both the tab bar (`Workspace.tsx`) and the "Move to Tab" context menu (`useDefaultContextMenuActions`) — so `tab-<uuid>` labels are gone from everywhere they used to leak.
- **`tab.titleOverride` is reserved for user renames only.** Every auto-default caller stripped: `openFilePane` / `addTerminalTab` / `addChatTab` / `addBrowserTab`, the three `useWorkspaceHotkeys` openers, the `|| "Terminal"` fallback in `useV2PresetExecution`, preset execution's `preset.name` (now lives on the pane), and `buildSetupPaneLayout`'s `t.label` (now lives on the pane). `resolveTabTitle` reads `pane.titleOverride ?? registry[kind].getTitle(pane)` for single-pane tabs, user rename wins over everything, and multi-pane tabs fall back to `Tab N` by LTR index.
- **Cleanup:** `getBrowserTabTitle` free function deleted (duplicated `browser.getTitle`), `tabTitle` parameter dropped from `store.openPane` and its test updated, `WorkspaceProps.getTabTitle` prop deleted.

## Test plan

- [x] `bun run typecheck` — all 25 packages pass
- [x] `bun run lint:fix` — clean
- [x] `bun test packages/panes` — 71/71
- [ ] Click a file in the Changes sidebar from a focused file-editor tab → new "Changes" tab is created; the editor tab is untouched
- [ ] Click a second changed file → no new tab; existing "Changes" tab focuses and scrolls to the new file
- [ ] Rename the "Changes" tab to "My diff" → sticks through further sidebar clicks and splits (user rename wins)
- [ ] Open a terminal / chat / file / browser tab → each shows its derived name, never `tab-<uuid>`
- [ ] Split a Terminal tab with a Browser pane → tab label flips from "Terminal" to "Tab N"; reorder tabs → numbers track position
- [ ] Run a named preset → tab + pane header show the preset name; split the tab → tab becomes "Tab N", pane header keeps the preset name
- [ ] Bootstrap a fresh v2 workspace with labeled terminals → each tab shows its label, split → "Tab N", pane header keeps label
- [ ] Right-click a pane → "Move to Tab" submenu lists resolved titles (no `tab-<uuid>`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The v2 diff viewer opens in its own tab and never steals focus. Tab titles are pane‑derived and consistent; user renames win, “about:blank” shows “Browser”, and browser titles now preserve ports.

- **New Features**
  - Clicking a changed file opens or focuses a dedicated diff tab; it reuses any existing diff pane across tabs and scrolls to the file, otherwise creates a new tab.
  - Tab titles are resolved via `resolveTabTitle` in `@superset/panes` (user rename > single‑pane pane title > “Tab N”); the “Move to Tab” menu uses the same logic, removing `tab-<uuid>` labels. Browser tabs use the page title or URL host (keeps port), falling back to “Browser”.

- **Migration**
  - `PaneDefinition.getTitle` now accepts `(pane) => string | undefined`. Use `renderTitle(ctx)` for rich JSX.
  - `WorkspaceProps.getTabTitle` is removed and `openPane` no longer accepts `tabTitle`. Use `resolveTabTitle` and set auto names on `pane.titleOverride`; keep `tab.titleOverride` for user renames only.

<sup>Written for commit 7effd34fb9ce0dbc019187a4fe5497590f950b82. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized tab title resolution so titles are consistently derived (prefers explicit per-pane overrides, otherwise derives from pane content or a default "Tab X").
  * Pane title providers now accept a pane object and return plain text titles.
  * Workspace no longer accepts a custom external getTabTitle prop.

* **Chores**
  * New title-resolution utility exposed for workspace components.

* **Tests**
  * Adjusted tests to reflect removal of forced tab-title overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->