### PR TITLE
fix(desktop): make v2 right sidebar toggle reactive

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/RightSidebarToggle/RightSidebarToggle.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/RightSidebarToggle/RightSidebarToggle.tsx
@@ -1,4 +1,6 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { eq } from "@tanstack/db";
+import { useLiveQuery } from "@tanstack/react-db";
 import {
 	LuPanelRight,
 	LuPanelRightClose,
@@ -9,8 +11,16 @@ import { useCollections } from "renderer/routes/_authenticated/providers/Collect
 
 export function RightSidebarToggle({ workspaceId }: { workspaceId: string }) {
 	const collections = useCollections();
-	const localState = collections.v2WorkspaceLocalState.get(workspaceId);
-	const isOpen = localState?.rightSidebarOpen ?? false;
+	const { data: localStateRows = [] } = useLiveQuery(
+		(query) =>
+			query
+				.from({ v2WorkspaceLocalState: collections.v2WorkspaceLocalState })
+				.where(({ v2WorkspaceLocalState }) =>
+					eq(v2WorkspaceLocalState.workspaceId, workspaceId),
+				),
+		[collections, workspaceId],
+	);
+	const isOpen = localStateRows[0]?.rightSidebarOpen ?? false;
 
 	const toggle = () => {
 		collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {


### PR DESCRIPTION
## Summary
- The v2 right sidebar toggle's hover icon swap (`LuPanelRight` → `LuPanelRightOpen`/`LuPanelRightClose`) was silently broken: `isOpen` was read via a one-shot `collections.v2WorkspaceLocalState.get(workspaceId)` call, so the component never re-rendered when `rightSidebarOpen` changed.
- Switched to `useLiveQuery` (matching `useV2WorkspacePaneLayout`) so the toggle reactively reflects the current state, and the hover icon now matches the left sidebar toggle's behavior.

## Test plan
- [ ] Open a v2 workspace, confirm right sidebar toggle icon swaps on hover when sidebar is closed (shows open-arrow) vs open (shows close-arrow)
- [ ] Toggle via hotkey (⌘L) and confirm the top-bar icon updates without needing a remount

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the v2 right sidebar toggle reactive so the hover icon reflects the current open state. Replaced a one-off state read with a live query tied to `v2WorkspaceLocalState`.

- **Bug Fixes**
  - Switched to `useLiveQuery` from `@tanstack/react-db` with `eq` from `@tanstack/db` to subscribe to per-workspace `v2WorkspaceLocalState`.
  - Hover icon now correctly shows open/close state and updates on hotkey toggle (⌘L), matching the left sidebar behavior.

<sup>Written for commit 94efc23e58f9f34eb1f153209307fbe70066eafe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The right sidebar open/closed state now updates in real-time as database state changes, replacing previous locally-cached state handling to ensure consistent sidebar behavior throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->