### PR TITLE
feat(desktop/hotkeys): unbound defaults + restore prev/next tab & workspace

### DIFF
--- a/apps/desktop/src/renderer/hotkeys/hooks/useRecordHotkeys/useRecordHotkeys.ts
+++ b/apps/desktop/src/renderer/hotkeys/hooks/useRecordHotkeys/useRecordHotkeys.ts
@@ -136,7 +136,10 @@ export function useRecordHotkeys(
 			}
 
 			const defaultKey = HOTKEYS[recordingId].key;
-			if (canonicalizeChord(captured) === canonicalizeChord(defaultKey)) {
+			if (
+				defaultKey &&
+				canonicalizeChord(captured) === canonicalizeChord(defaultKey)
+			) {
 				resetOverride(recordingId);
 			} else {
 				setOverride(recordingId, captured);

--- a/apps/desktop/src/renderer/hotkeys/registry.ts
+++ b/apps/desktop/src/renderer/hotkeys/registry.ts
@@ -101,6 +101,18 @@ export const HOTKEYS_REGISTRY = {
 		label: "Switch to Workspace 9",
 		category: "Workspace",
 	},
+	PREV_WORKSPACE: {
+		key: { mac: null, windows: null, linux: null },
+		label: "Previous Workspace",
+		category: "Workspace",
+		description: "Navigate to the previous workspace in the sidebar",
+	},
+	NEXT_WORKSPACE: {
+		key: { mac: null, windows: null, linux: null },
+		label: "Next Workspace",
+		category: "Workspace",
+		description: "Navigate to the next workspace in the sidebar",
+	},
 	CLOSE_WORKSPACE: {
 		key: {
 			mac: "meta+shift+backspace",
@@ -329,6 +341,18 @@ export const HOTKEYS_REGISTRY = {
 		key: { mac: "ctrl+tab", windows: "ctrl+tab", linux: "ctrl+tab" },
 		label: "Next Tab (Alt)",
 		category: "Terminal",
+	},
+	PREV_TAB: {
+		key: { mac: null, windows: null, linux: null },
+		label: "Previous Tab",
+		category: "Terminal",
+		description: "Focus the previous tab in the active workspace",
+	},
+	NEXT_TAB: {
+		key: { mac: null, windows: null, linux: null },
+		label: "Next Tab",
+		category: "Terminal",
+		description: "Focus the next tab in the active workspace",
 	},
 	FOCUS_PANE_LEFT: {
 		key: {

--- a/apps/desktop/src/renderer/hotkeys/types.ts
+++ b/apps/desktop/src/renderer/hotkeys/types.ts
@@ -1,6 +1,10 @@
 export type Platform = "mac" | "windows" | "linux";
 
-export type PlatformKey = { mac: string; windows: string; linux: string };
+export type PlatformKey = {
+	mac: string | null;
+	windows: string | null;
+	linux: string | null;
+};
 
 export type HotkeyCategory =
 	| "Navigation"
@@ -18,7 +22,7 @@ export interface HotkeyDisplay {
 }
 
 export interface HotkeyDefinition {
-	key: string;
+	key: string | null;
 	label: string;
 	category: HotkeyCategory;
 	description?: string;

--- a/apps/desktop/src/renderer/hotkeys/utils/resolveHotkeyFromEvent.test.ts
+++ b/apps/desktop/src/renderer/hotkeys/utils/resolveHotkeyFromEvent.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { HOTKEYS } from "../registry";
+import { HOTKEYS, type HotkeyId } from "../registry";
 import { useHotkeyOverridesStore } from "../stores/hotkeyOverridesStore";
+import type { HotkeyDefinition } from "../types";
 import {
 	canonicalizeChord,
 	eventToChord,
@@ -148,10 +149,13 @@ describe("resolveHotkeyFromEvent — live override index", () => {
 	});
 
 	// Resolve once so registry reorders / removals surface as a test failure
-	// here instead of silently skipping the cases below.
-	const sampleEntry = (
-		Object.entries(HOTKEYS) as [keyof typeof HOTKEYS, { key: string }][]
-	).find(([, hotkey]) => !!hotkey.key);
+	// here instead of silently skipping the cases below. The type predicate
+	// narrows to a HotkeyDefinition whose .key is guaranteed non-null after
+	// the filter, so sampleDef.key can be passed to string-only helpers below.
+	const sampleEntry = Object.entries(HOTKEYS).find(
+		(entry): entry is [HotkeyId, HotkeyDefinition & { key: string }] =>
+			entry[1].key !== null,
+	);
 	if (!sampleEntry) throw new Error("HOTKEYS has no bound default");
 	const [sampleId, sampleDef] = sampleEntry;
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarShortcuts/useDashboardSidebarShortcuts.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarShortcuts/useDashboardSidebarShortcuts.ts
@@ -61,6 +61,7 @@ export function useDashboardSidebarShortcuts(
 		const index = flattenedWorkspaces.findIndex(
 			(w) => w.id === currentWorkspaceId,
 		);
+		if (index === -1) return;
 		const prevIndex = index <= 0 ? flattenedWorkspaces.length - 1 : index - 1;
 		navigateToV2Workspace(flattenedWorkspaces[prevIndex].id, navigate);
 	});
@@ -70,8 +71,8 @@ export function useDashboardSidebarShortcuts(
 		const index = flattenedWorkspaces.findIndex(
 			(w) => w.id === currentWorkspaceId,
 		);
-		const nextIndex =
-			index >= flattenedWorkspaces.length - 1 || index === -1 ? 0 : index + 1;
+		if (index === -1) return;
+		const nextIndex = index >= flattenedWorkspaces.length - 1 ? 0 : index + 1;
 		navigateToV2Workspace(flattenedWorkspaces[nextIndex].id, navigate);
 	});
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarShortcuts/useDashboardSidebarShortcuts.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarShortcuts/useDashboardSidebarShortcuts.ts
@@ -1,4 +1,4 @@
-import { useNavigate } from "@tanstack/react-router";
+import { useMatchRoute, useNavigate } from "@tanstack/react-router";
 import { useCallback, useMemo } from "react";
 import { useHotkey } from "renderer/hotkeys";
 import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
@@ -47,6 +47,33 @@ export function useDashboardSidebarShortcuts(
 	useHotkey("JUMP_TO_WORKSPACE_7", () => switchToWorkspace(6));
 	useHotkey("JUMP_TO_WORKSPACE_8", () => switchToWorkspace(7));
 	useHotkey("JUMP_TO_WORKSPACE_9", () => switchToWorkspace(8));
+
+	const matchRoute = useMatchRoute();
+	const currentWorkspaceMatch = matchRoute({
+		to: "/v2-workspace/$workspaceId",
+		fuzzy: true,
+	});
+	const currentWorkspaceId =
+		currentWorkspaceMatch !== false ? currentWorkspaceMatch.workspaceId : null;
+
+	useHotkey("PREV_WORKSPACE", () => {
+		if (!currentWorkspaceId || flattenedWorkspaces.length === 0) return;
+		const index = flattenedWorkspaces.findIndex(
+			(w) => w.id === currentWorkspaceId,
+		);
+		const prevIndex = index <= 0 ? flattenedWorkspaces.length - 1 : index - 1;
+		navigateToV2Workspace(flattenedWorkspaces[prevIndex].id, navigate);
+	});
+
+	useHotkey("NEXT_WORKSPACE", () => {
+		if (!currentWorkspaceId || flattenedWorkspaces.length === 0) return;
+		const index = flattenedWorkspaces.findIndex(
+			(w) => w.id === currentWorkspaceId,
+		);
+		const nextIndex =
+			index >= flattenedWorkspaces.length - 1 || index === -1 ? 0 : index + 1;
+		navigateToV2Workspace(flattenedWorkspaces[nextIndex].id, navigate);
+	});
 
 	return workspaceShortcutLabels;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
@@ -87,6 +87,23 @@ export function useWorkspaceHotkeys({
 		}
 	});
 
+	useHotkey("PREV_TAB", () => {
+		const state = store.getState();
+		if (!state.activeTabId || state.tabs.length === 0) return;
+		const index = state.tabs.findIndex((t) => t.id === state.activeTabId);
+		const prevIndex = index <= 0 ? state.tabs.length - 1 : index - 1;
+		state.setActiveTab(state.tabs[prevIndex].id);
+	});
+
+	useHotkey("NEXT_TAB", () => {
+		const state = store.getState();
+		if (!state.activeTabId || state.tabs.length === 0) return;
+		const index = state.tabs.findIndex((t) => t.id === state.activeTabId);
+		const nextIndex =
+			index >= state.tabs.length - 1 || index === -1 ? 0 : index + 1;
+		state.setActiveTab(state.tabs[nextIndex].id);
+	});
+
 	useHotkey("PREV_TAB_ALT", () => {
 		const state = store.getState();
 		if (!state.activeTabId || state.tabs.length === 0) return;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -1,5 +1,5 @@
 import type { ExternalApp } from "@superset/local-db";
-import { createFileRoute, notFound } from "@tanstack/react-router";
+import { createFileRoute, notFound, useNavigate } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import { useFileOpenMode } from "renderer/hooks/useFileOpenMode";
@@ -8,6 +8,7 @@ import { electronTrpc } from "renderer/lib/electron-trpc";
 import { electronTrpcClient as trpcClient } from "renderer/lib/trpc-client";
 import { usePresets } from "renderer/react-query/presets";
 import type { WorkspaceSearchParams } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
+import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { usePresetHotkeys } from "renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/usePresetHotkeys";
 import { useWorkspaceRunCommand } from "renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/useWorkspaceRunCommand";
 import { NotFound } from "renderer/routes/not-found";
@@ -90,6 +91,7 @@ function WorkspacePage() {
 		worktreePath: workspace?.worktreePath,
 		enabled: Boolean(workspace?.worktreePath),
 	});
+	const navigate = useNavigate();
 	const routeNavigate = Route.useNavigate();
 	const { tabId: searchTabId, paneId: searchPaneId } = Route.useSearch();
 
@@ -222,6 +224,20 @@ function WorkspacePage() {
 		if (activeTabId) {
 			requestTabClose(activeTabId);
 		}
+	});
+
+	useHotkey("PREV_TAB", () => {
+		if (!activeTabId || tabs.length === 0) return;
+		const index = tabs.findIndex((t) => t.id === activeTabId);
+		const prevIndex = index <= 0 ? tabs.length - 1 : index - 1;
+		setActiveTab(workspaceId, tabs[prevIndex].id);
+	});
+
+	useHotkey("NEXT_TAB", () => {
+		if (!activeTabId || tabs.length === 0) return;
+		const index = tabs.findIndex((t) => t.id === activeTabId);
+		const nextIndex = index >= tabs.length - 1 || index === -1 ? 0 : index + 1;
+		setActiveTab(workspaceId, tabs[nextIndex].id);
 	});
 
 	useHotkey("PREV_TAB_ALT", () => {
@@ -390,6 +406,29 @@ function WorkspacePage() {
 	useHotkey("EQUALIZE_PANE_SPLITS", () => {
 		if (activeTabId) {
 			equalizePaneSplits(activeTabId);
+		}
+	});
+
+	const getPreviousWorkspace =
+		electronTrpc.workspaces.getPreviousWorkspace.useQuery(
+			{ id: workspaceId },
+			{ enabled: !!workspaceId },
+		);
+	useHotkey("PREV_WORKSPACE", () => {
+		const prevWorkspaceId = getPreviousWorkspace.data;
+		if (prevWorkspaceId) {
+			navigateToWorkspace(prevWorkspaceId, navigate);
+		}
+	});
+
+	const getNextWorkspace = electronTrpc.workspaces.getNextWorkspace.useQuery(
+		{ id: workspaceId },
+		{ enabled: !!workspaceId },
+	);
+	useHotkey("NEXT_WORKSPACE", () => {
+		const nextWorkspaceId = getNextWorkspace.data;
+		if (nextWorkspaceId) {
+			navigateToWorkspace(nextWorkspaceId, navigate);
 		}
 	});
 


### PR DESCRIPTION
## Summary

- Widens `PlatformKey` and `HotkeyDefinition.key` to `string | null` so registry entries can declare an **unbound default** per platform. All downstream consumers were already null-safe from #3391, so this is a surgical schema change.
- Re-introduces `PREV_TAB`, `NEXT_TAB`, `PREV_WORKSPACE`, `NEXT_WORKSPACE` as registered-but-unbound entries with their v1/v2 handlers restored. Users can rebind them in Settings → Keyboard.
- Fixes one null-deref in `useRecordHotkeys` (`canonicalizeChord(defaultKey)` previously threw when a hotkey had no default) and replaces a type-assertion lie in `resolveHotkeyFromEvent.test.ts` with a proper type predicate so the sample picker narrows honestly against the widened schema.

Follow-up to #3403, which retired these four hotkey IDs to free `Cmd+Alt+Arrow` for directional pane focus. Some users still want linear tab/workspace nav — they just don't need a default chord at install time. Users whose pre-#3403 overrides for these IDs survived in localStorage will transparently get their bindings back when this lands.

## Test plan

- [ ] `bun run typecheck` clean
- [ ] `bun run lint` clean
- [ ] Hotkey unit tests pass (63/63)
- [ ] Open Settings → Keyboard, confirm the four new rows appear (Previous/Next Tab in Terminal, Previous/Next Workspace in Workspace) displayed as "Unassigned"
- [ ] Record a chord (e.g. `Cmd+Ctrl+Left`) for one of the unbound entries; confirm it persists, renders correctly, and the action actually fires in both v1 and v2 workspaces
- [ ] Clear the override via the reset button; confirm it returns to "Unassigned" and the handler goes inert
- [ ] Smoke test: `Cmd+Alt+Arrow` directional pane nav (from #3403) still works
- [ ] Inside a terminal pane, confirm unbound hotkeys do not intercept keystrokes (Intel HD screen-rotation scenario is moot because there's no default chord to suppress PTY forwarding)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable unassigned default hotkeys per platform and restore Previous/Next Tab and Workspace as registered-but-unbound entries. Users can bind them in Settings, and any existing overrides are restored automatically.

- **New Features**
  - Widen `PlatformKey` and `HotkeyDefinition.key` to `string | null` to support unbound defaults.
  - Re-register `PREV_TAB`, `NEXT_TAB`, `PREV_WORKSPACE`, `NEXT_WORKSPACE` with null defaults; handlers work in both v1 and v2 workspaces.
  - Add wrap-around prev/next navigation for tabs and workspaces in the sidebar and workspace views.

- **Bug Fixes**
  - Guard `canonicalizeChord(defaultKey)` in `useRecordHotkeys` and fix v2 `PREV_WORKSPACE` to use the correct `prevIndex`, preventing crashes and ensuring wrap-around works.
  - Replace a force-cast in `resolveHotkeyFromEvent.test.ts` with a type predicate to align with the widened schema.

<sup>Written for commit 80eabc903cbdf2e96de041d428d05cad54a2a56b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hotkeys to navigate between workspaces (Previous/Next Workspace) with wrap-around cycling
  * Added hotkeys to switch between tabs (Previous/Next Tab) with wrap-around cycling

* **Bug Fixes**
  * Hotkey override logic now correctly handles missing default key mappings to avoid unintended resets
<!-- end of auto-generated comment: release notes by coderabbit.ai -->