### PR TITLE
fix(desktop): make pending failure error messages selectable

### DIFF
--- a/apps/desktop/src/renderer/components/UpdateRequiredPage/UpdateRequiredPage.tsx
+++ b/apps/desktop/src/renderer/components/UpdateRequiredPage/UpdateRequiredPage.tsx
@@ -80,7 +80,7 @@ export function UpdateRequiredPage({
 					</p>
 
 					{isError && (
-						<p className="text-sm text-destructive">
+						<p className="text-sm text-destructive select-text cursor-text break-words">
 							{updateStatus.error || "Update check failed. Please try again."}
 						</p>
 					)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/page.tsx
@@ -314,7 +314,9 @@ function PendingWorkspacePage() {
 					<div className="space-y-4">
 						<div className="flex items-start gap-2 text-sm text-destructive">
 							<HiExclamationTriangle className="size-4 mt-0.5 shrink-0" />
-							<span>{pending.error ?? "Failed to create workspace"}</span>
+							<span className="select-text cursor-text break-words">
+								{pending.error ?? "Failed to create workspace"}
+							</span>
 						</div>
 						<div className="flex gap-2">
 							<button


### PR DESCRIPTION
## Summary
- Adds `select-text cursor-text break-words` to the error message on the pending workspace failure page so users can copy failure details
- Same fix for `UpdateRequiredPage` error text
- Global `user-select: none` on body (globals.css) blocks copy on full-page error states; this matches the pattern already used by v1 `WorkspaceInitializingView`

## Test plan
- [ ] Trigger a workspace creation failure, confirm the error text on `/pending/$pendingId` can be selected and copied
- [ ] Trigger the update-required error state, confirm the error text can be selected and copied

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make failure error messages selectable and copyable on the pending workspace and update-required pages so users can copy error details.

- **Bug Fixes**
  - Added `select-text cursor-text break-words` to error text on `UpdateRequiredPage` and `/pending/$pendingId`.
  - Works around global `user-select: none` so full-page errors can be copied; aligns with v1 WorkspaceInitializingView.

<sup>Written for commit 4ac6accab9714898d6ee4f4f9304926205422f8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages in update notifications and failed workspace screens are now selectable and copyable, allowing users to easily share error details with support teams.
  * Improved error message display with proper text wrapping and visual feedback when hovering over long error messages for a better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->