### PR TITLE
fix(desktop): auto-use existing branch instead of failing worktree creation

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
@@ -379,6 +379,26 @@ export const createCreateProcedures = () => {
 					});
 				}
 
+				// If the requested new branch name already exists in git, route to the
+				// existing-branch path instead of letting `git worktree add -b` fail.
+				let effectiveUseExistingBranch = input.useExistingBranch ?? false;
+				if (
+					!existingBranchName &&
+					input.branchName?.trim() &&
+					existingBranches.includes(branch)
+				) {
+					const existingWorktreePath = await getBranchWorktreePath({
+						mainRepoPath: project.mainRepoPath,
+						branch,
+					});
+					if (existingWorktreePath) {
+						throw new Error(
+							`Branch "${branch}" is already checked out in another worktree at: ${existingWorktreePath}. Open that workspace instead.`,
+						);
+					}
+					effectiveUseExistingBranch = true;
+				}
+
 				if (input.branchName?.trim()) {
 					const existing = findWorktreeWorkspaceByBranch({
 						projectId: input.projectId,
@@ -501,7 +521,7 @@ export const createCreateProcedures = () => {
 					project_id: project.id,
 					branch: branch,
 					base_branch: compareBaseBranch,
-					use_existing_branch: input.useExistingBranch ?? false,
+					use_existing_branch: effectiveUseExistingBranch,
 				});
 
 				await setBranchBaseConfig({
@@ -521,7 +541,7 @@ export const createCreateProcedures = () => {
 					mainRepoPath: project.mainRepoPath,
 					startPointBranch: sourceWorkspace?.branch,
 					namingPrompt: input.prompt,
-					useExistingBranch: input.useExistingBranch,
+					useExistingBranch: effectiveUseExistingBranch,
 				});
 
 				const setupConfig = loadSetupConfig({


### PR DESCRIPTION
## Problem

When creating a workspace with a branch name that already exists in git (but isn't tracked by Superset), the flow would:
1. Insert a workspace record into the DB
2. Navigate to the pending page
3. Run the async init job, which fires `git worktree add -b <branch>`
4. Git fails: `fatal: a branch named '<branch>' already exists`
5. User sees an opaque error on the pending page after a delay

This could happen if a previous creation attempt partially succeeded (branch created, worktree setup failed), or if the user had the branch from an existing workflow.

## Fix

In `create.ts`, after computing the final branch name for new-branch creation, we now check whether it already exists in `existingBranches` (which was already fetched). If it does:

- **Not checked out anywhere** → transparently route to `createWorktreeFromExistingBranch`. The workspace is created successfully from the existing branch. No error shown.
- **Already checked out in another worktree** → throw a clear error immediately, before any DB insertion or navigation, with a message pointing to the existing workspace.

## Test

1. Create a branch manually: `git branch my-feature`
2. In Superset, create a new workspace named `my-feature` (without using "open existing branch")
3. **Before**: navigation to pending page → failure after async delay
4. **After**: workspace opens successfully using the existing `my-feature` branch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents workspace creation from failing when the requested branch already exists. We now use the existing branch when safe, and show an immediate, clear error if it’s checked out elsewhere.

- Bug Fixes
  - Detect existing branch via `existingBranches`; set `effectiveUseExistingBranch` and route to `createWorktreeFromExistingBranch` when not checked out.
  - If the branch is checked out in another worktree, abort early with an error that includes the worktree path (before any DB insert/navigation).

<sup>Written for commit 5c85778183a879d2a8f8db7f76712b8f7446afca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace creation to handle existing branches more intelligently. When attempting to create a workspace with a branch name already checked out elsewhere, users are now prompted to use the existing workspace instead of creating a duplicate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->