### PR TITLE
fix(desktop): restore cmd+click for v1 terminal file links

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -169,6 +169,9 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 			}
 		},
 		onFileLinkClick: (event, link) => {
+			if (!event.metaKey && !event.ctrlKey) {
+				return;
+			}
 			if (onFileLinkClick) {
 				onFileLinkClick(event, link);
 				return;


### PR DESCRIPTION
## Summary
- v1 terminal file-path links reverted to opening on plain click after #3382 ported v1 to the shared `TerminalLinkManager`. The old `FilePathLinkProvider` required cmd/ctrl; the shared `LinkDetectorAdapter` (also used by v2) activates on plain click.
- Gate `onFileLinkClick` behind `metaKey`/`ctrlKey` in v1's `helpers.ts` so v1 requires the modifier again without changing v2 behavior.
- Web URLs were already correctly gated in `UrlLinkProvider`; this fix aligns file-path links with that.

## Test plan
- [ ] In v1 terminal, plain-click a file path in output — nothing happens.
- [ ] Cmd/Ctrl+click a file path — opens in file viewer / external editor per setting.
- [ ] Cmd/Ctrl+click a URL — still opens in browser.
- [ ] v2 terminal file-link click behavior unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore Cmd/Ctrl+click requirement for file-path links in the v1 terminal; plain clicks no longer open files. URL clicks and v2 terminal behavior are unchanged.

<sup>Written for commit 7c67db1c7f1b90df57d0f607110c28ca1bdfa4e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Terminal**
  * File links in the Terminal now require pressing a modifier key (Ctrl or Cmd) to open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->