### PR TITLE
chore(desktop): auto-restart host-service on bundle change in dev

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -13,9 +13,11 @@ import {
 import { makeAppSetup } from "lib/electron-app/factories/app/setup";
 import {
 	handleAuthCallback,
+	loadToken,
 	parseAuthDeepLink,
 } from "lib/trpc/routers/auth/utils/auth-functions";
 import { applyShellEnvToProcess } from "lib/trpc/routers/workspaces/utils/shell-env";
+import { env as mainEnv } from "main/env.main";
 import {
 	DEFAULT_CONFIRM_ON_QUIT,
 	PLATFORM,
@@ -357,6 +359,14 @@ if (!gotTheLock) {
 		// Discover and adopt host-services that survived a previous quit
 		// before the tray initializes, so it shows accurate status immediately.
 		await getHostServiceCoordinator().discoverAll();
+
+		if (IS_DEV) {
+			getHostServiceCoordinator().enableDevReload(async () => {
+				const { token } = await loadToken();
+				if (!token) return null;
+				return { authToken: token, cloudApiUrl: mainEnv.NEXT_PUBLIC_API_URL };
+			});
+		}
 
 		await makeAppSetup(() => MainWindow());
 		setupAutoUpdater();

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -1,6 +1,7 @@
 import * as childProcess from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { EventEmitter } from "node:events";
+import * as fs from "node:fs";
 import { createServer } from "node:net";
 import path from "node:path";
 import { settings } from "@superset/local-db";
@@ -103,6 +104,7 @@ export class HostServiceCoordinator extends EventEmitter {
 	>();
 	private scriptPath = path.join(__dirname, "host-service.js");
 	private machineId = getHashedDeviceId();
+	private devReloadWatcher: fs.FSWatcher | null = null;
 
 	async start(
 		organizationId: string,
@@ -220,6 +222,63 @@ export class HostServiceCoordinator extends EventEmitter {
 				this.restart(orgId, config),
 			),
 		);
+	}
+
+	/**
+	 * Dev-only: watch the built host-service bundle and restart running
+	 * instances when it changes. Gives a fast edit→reload loop for code
+	 * under packages/host-service and src/main/host-service without
+	 * restarting Electron. In-memory host-service state (PTYs, watchers,
+	 * chat streams) is torn down on each reload — this is not true HMR.
+	 */
+	enableDevReload(
+		configProvider: () => Promise<SpawnConfig | null>,
+	): () => void {
+		if (this.devReloadWatcher) return () => {};
+
+		const scriptDir = path.dirname(this.scriptPath);
+		const scriptFile = path.basename(this.scriptPath);
+		let debounce: ReturnType<typeof setTimeout> | null = null;
+		let reloading = false;
+
+		const trigger = () => {
+			if (debounce) clearTimeout(debounce);
+			debounce = setTimeout(() => {
+				void (async () => {
+					if (reloading) return;
+					if (this.getActiveOrganizationIds().length === 0) return;
+					const config = await configProvider();
+					if (!config) return;
+					reloading = true;
+					try {
+						console.log(
+							"[host-service] bundle changed, restarting running instances",
+						);
+						await this.restartAll(config);
+					} catch (error) {
+						console.error("[host-service] dev reload failed:", error);
+					} finally {
+						reloading = false;
+					}
+				})();
+			}, 250);
+		};
+
+		try {
+			this.devReloadWatcher = fs.watch(scriptDir, (_event, filename) => {
+				if (filename && filename !== scriptFile) return;
+				trigger();
+			});
+		} catch (error) {
+			console.error("[host-service] failed to enable dev reload:", error);
+			return () => {};
+		}
+
+		return () => {
+			if (debounce) clearTimeout(debounce);
+			this.devReloadWatcher?.close();
+			this.devReloadWatcher = null;
+		};
 	}
 
 	// ── Adoption ──────────────────────────────────────────────────────

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -241,16 +241,45 @@ export class HostServiceCoordinator extends EventEmitter {
 		let debounce: ReturnType<typeof setTimeout> | null = null;
 		let reloading = false;
 
+		const waitForStableBundle = async (): Promise<boolean> => {
+			const deadline = Date.now() + 5_000;
+			let lastSize = -1;
+			let stableSince = 0;
+			while (Date.now() < deadline) {
+				try {
+					const stat = fs.statSync(this.scriptPath);
+					if (stat.size > 0 && stat.size === lastSize) {
+						if (Date.now() - stableSince >= 150) return true;
+					} else {
+						lastSize = stat.size;
+						stableSince = Date.now();
+					}
+				} catch {
+					lastSize = -1;
+					stableSince = 0;
+				}
+				await new Promise((r) => setTimeout(r, 50));
+			}
+			return false;
+		};
+
 		const trigger = () => {
 			if (debounce) clearTimeout(debounce);
 			debounce = setTimeout(() => {
 				void (async () => {
 					if (reloading) return;
 					if (this.getActiveOrganizationIds().length === 0) return;
-					const config = await configProvider();
-					if (!config) return;
 					reloading = true;
 					try {
+						const ready = await waitForStableBundle();
+						if (!ready) {
+							console.warn(
+								"[host-service] bundle did not stabilize, skipping reload",
+							);
+							return;
+						}
+						const config = await configProvider();
+						if (!config) return;
 						console.log(
 							"[host-service] bundle changed, restarting running instances",
 						);

--- a/bun.lock
+++ b/bun.lock
@@ -110,7 +110,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.5.1",
+      "version": "1.5.3",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.43",
         "@ai-sdk/openai": "3.0.36",


### PR DESCRIPTION
## Summary
- In `NODE_ENV=development`, watches the built `host-service.js` bundle and restarts running host-service instances via the coordinator when electron-vite rewrites it.
- New `HostServiceCoordinator.enableDevReload(configProvider)` debounces file events (250ms) and calls `restartAll` with the current auth token; no-ops when no instances are running or the user isn't signed in.
- Wired up from `main/index.ts` after `discoverAll()`.

Not true HMR — workspace-scoped in-memory state (PTYs, watchers, chat streams) is torn down on each reload. Edit → rebuild → respawn is close enough for iterating on `packages/host-service` and `src/main/host-service` without restarting Electron.

## Test plan
- [ ] `bun dev` in `apps/desktop`, sign in, open a workspace so a host-service instance is running.
- [ ] Edit a file under `packages/host-service/src` (e.g. add a `console.log` in `serve.ts` or a router); confirm electron-vite rebuilds and the main-process log shows `[host-service] bundle changed, restarting running instances`.
- [ ] Confirm the renderer reconnects and the host-service resumes serving tRPC within ~1s.
- [ ] Sign out / kill all instances and touch `host-service.js`; confirm no reload attempt happens (no-op path).
- [ ] Production build: verify the watcher does not run (gated on `IS_DEV`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-restart the host-service in development when the built `host-service.js` changes, waiting for the bundle to stabilize before restart. Enables a fast edit→reload loop without restarting Electron; dev-only and not HMR—host-service in-memory state resets on each reload.

- **New Features**
  - Added `HostServiceCoordinator.enableDevReload(configProvider)` to watch the built bundle, wait for a stable file size (~150ms, 5s deadline), debounce events (250ms), and restart running instances with the current auth token; avoids respawn errors during Rollup’s unlink+rewrite.
  - Wired up in `main/index.ts` after `discoverAll()` using `loadToken()` and `mainEnv.NEXT_PUBLIC_API_URL`.
  - No-op when no instances are running or the user is signed out.

<sup>Written for commit e6ae2c59c8eca13c60b0d5f3a3c8438ad6be2b28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added development-only automatic reload for host-service bundles to restart background instances when builds change; includes safe debounce, teardown, and error handling.
  * Startup now supports loading a development auth token and dev environment API URL used by the dev reload flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->