### PR TITLE
fix(desktop): use native clipboard for copy path in v2 sidebar

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -54,7 +54,6 @@ export function DashboardSidebarWorkspaceItem({
 		workspaceId: id,
 		projectId,
 		workspaceName: name,
-		hostType,
 	});
 
 	const navigate = useNavigate();
@@ -108,6 +107,7 @@ export function DashboardSidebarWorkspaceItem({
 								diffStats={diffStats}
 							/>
 						}
+						isLocalWorkspace={hostType === "local-device"}
 						onCreateSection={handleCreateSection}
 						onMoveToSection={(targetSectionId) =>
 							moveWorkspaceToSection(id, projectId, targetSectionId)
@@ -173,6 +173,7 @@ export function DashboardSidebarWorkspaceItem({
 					onMoveToSection={(targetSectionId) =>
 						moveWorkspaceToSection(id, projectId, targetSectionId)
 					}
+					isLocalWorkspace={hostType === "local-device"}
 					onOpenInFinder={handleOpenInFinder}
 					onCopyPath={handleCopyPath}
 					onRemoveFromSidebar={() => removeWorkspaceFromSidebar(id)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -54,6 +54,7 @@ export function DashboardSidebarWorkspaceItem({
 		workspaceId: id,
 		projectId,
 		workspaceName: name,
+		hostType,
 	});
 
 	const navigate = useNavigate();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
@@ -32,6 +32,7 @@ interface DashboardSidebarWorkspaceContextMenuProps {
 	hoverCardContent?: React.ReactNode;
 	projectId: string;
 	isInSection?: boolean;
+	isLocalWorkspace: boolean;
 	onHoverCardOpen?: () => void;
 	onCreateSection: () => void;
 	onMoveToSection: (sectionId: string | null) => void;
@@ -46,6 +47,7 @@ interface DashboardSidebarWorkspaceContextMenuProps {
 export function DashboardSidebarWorkspaceContextMenu({
 	projectId,
 	isInSection,
+	isLocalWorkspace,
 	onHoverCardOpen,
 	hoverCardContent,
 	onCreateSection,
@@ -81,15 +83,19 @@ export function DashboardSidebarWorkspaceContextMenu({
 				<LuPencil className="size-4 mr-2" />
 				Rename
 			</ContextMenuItem>
-			<ContextMenuSeparator />
-			<ContextMenuItem onSelect={onOpenInFinder}>
-				<LuFolderOpen className="size-4 mr-2" />
-				Open in Finder
-			</ContextMenuItem>
-			<ContextMenuItem onSelect={onCopyPath}>
-				<LuCopy className="size-4 mr-2" />
-				Copy Path
-			</ContextMenuItem>
+			{isLocalWorkspace && (
+				<>
+					<ContextMenuSeparator />
+					<ContextMenuItem onSelect={onOpenInFinder}>
+						<LuFolderOpen className="size-4 mr-2" />
+						Open in Finder
+					</ContextMenuItem>
+					<ContextMenuItem onSelect={onCopyPath}>
+						<LuCopy className="size-4 mr-2" />
+						Copy Path
+					</ContextMenuItem>
+				</>
+			)}
 			<ContextMenuSeparator />
 			<ContextMenuSub>
 				<ContextMenuSubTrigger>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
@@ -11,20 +11,17 @@ import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
-import type { DashboardSidebarWorkspaceHostType } from "../../../../types";
 
 interface UseDashboardSidebarWorkspaceItemActionsOptions {
 	workspaceId: string;
 	projectId: string;
 	workspaceName: string;
-	hostType: DashboardSidebarWorkspaceHostType;
 }
 
 export function useDashboardSidebarWorkspaceItemActions({
 	workspaceId,
 	projectId,
 	workspaceName,
-	hostType,
 }: UseDashboardSidebarWorkspaceItemActionsOptions) {
 	const navigate = useNavigate();
 	const matchRoute = useMatchRoute();
@@ -116,10 +113,6 @@ export function useDashboardSidebarWorkspaceItemActions({
 	};
 
 	const resolveWorktreePath = async (): Promise<string | null> => {
-		if (hostType !== "local-device") {
-			toast.error("Only available for local workspaces");
-			return null;
-		}
 		if (!activeHostUrl) {
 			toast.error("Host service is not available");
 			return null;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { getDeleteFocusTargetWorkspaceId } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/getDeleteFocusTargetWorkspaceId";
 import { getFlattenedV2WorkspaceIds } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/getFlattenedV2WorkspaceIds";
 import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
@@ -114,28 +115,42 @@ export function useDashboardSidebarWorkspaceItemActions({
 		moveWorkspaceToSection(workspaceId, projectId, newSectionId);
 	};
 
-	const handleOpenInFinder = () => {
-		toast.info("Open in Finder is coming soon");
-	};
-
-	const handleCopyPath = async () => {
+	const resolveWorktreePath = async (): Promise<string | null> => {
 		if (hostType !== "local-device") {
-			toast.error("Copy Path is only available for local workspaces");
-			return;
+			toast.error("Only available for local workspaces");
+			return null;
 		}
 		if (!activeHostUrl) {
 			toast.error("Host service is not available");
-			return;
+			return null;
 		}
+		const workspace = await getHostServiceClientByUrl(
+			activeHostUrl,
+		).workspace.get.query({ id: workspaceId });
+		if (!workspace?.worktreePath) {
+			toast.error("Workspace path is not available");
+			return null;
+		}
+		return workspace.worktreePath;
+	};
+
+	const handleOpenInFinder = async () => {
 		try {
-			const workspace = await getHostServiceClientByUrl(
-				activeHostUrl,
-			).workspace.get.query({ id: workspaceId });
-			if (!workspace?.worktreePath) {
-				toast.error("Workspace path is not available");
-				return;
-			}
-			await copyToClipboard(workspace.worktreePath);
+			const path = await resolveWorktreePath();
+			if (!path) return;
+			await electronTrpcClient.external.openInFinder.mutate(path);
+		} catch (error) {
+			toast.error(
+				`Failed to open in Finder: ${error instanceof Error ? error.message : "Unknown error"}`,
+			);
+		}
+	};
+
+	const handleCopyPath = async () => {
+		try {
+			const path = await resolveWorktreePath();
+			if (!path) return;
+			await copyToClipboard(path);
 			toast.success("Path copied");
 		} catch (error) {
 			toast.error(

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
@@ -1,27 +1,35 @@
 import { toast } from "@superset/ui/sonner";
 import { useMatchRoute, useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
+import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { getDeleteFocusTargetWorkspaceId } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/getDeleteFocusTargetWorkspaceId";
 import { getFlattenedV2WorkspaceIds } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/getFlattenedV2WorkspaceIds";
 import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import type { DashboardSidebarWorkspaceHostType } from "../../../../types";
 
 interface UseDashboardSidebarWorkspaceItemActionsOptions {
 	workspaceId: string;
 	projectId: string;
 	workspaceName: string;
+	hostType: DashboardSidebarWorkspaceHostType;
 }
 
 export function useDashboardSidebarWorkspaceItemActions({
 	workspaceId,
 	projectId,
 	workspaceName,
+	hostType,
 }: UseDashboardSidebarWorkspaceItemActionsOptions) {
 	const navigate = useNavigate();
 	const matchRoute = useMatchRoute();
 	const collections = useCollections();
+	const { activeHostUrl } = useLocalHostService();
+	const { copyToClipboard } = useCopyToClipboard();
 	const { createSection, moveWorkspaceToSection, removeWorkspaceFromSidebar } =
 		useDashboardSidebarState();
 
@@ -110,8 +118,30 @@ export function useDashboardSidebarWorkspaceItemActions({
 		toast.info("Open in Finder is coming soon");
 	};
 
-	const handleCopyPath = () => {
-		toast.info("Copy Path is coming soon");
+	const handleCopyPath = async () => {
+		if (hostType !== "local-device") {
+			toast.error("Copy Path is only available for local workspaces");
+			return;
+		}
+		if (!activeHostUrl) {
+			toast.error("Host service is not available");
+			return;
+		}
+		try {
+			const workspace = await getHostServiceClientByUrl(
+				activeHostUrl,
+			).workspace.get.query({ id: workspaceId });
+			if (!workspace?.worktreePath) {
+				toast.error("Workspace path is not available");
+				return;
+			}
+			await copyToClipboard(workspace.worktreePath);
+			toast.success("Path copied");
+		} catch (error) {
+			toast.error(
+				`Failed to copy path: ${error instanceof Error ? error.message : "Unknown error"}`,
+			);
+		}
 	};
 
 	return {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/FileContextMenu/FileContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/FileContextMenu/FileContextMenu.tsx
@@ -4,6 +4,7 @@ import {
 	ContextMenuSeparator,
 } from "@superset/ui/context-menu";
 import { toast } from "@superset/ui/sonner";
+import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 
 interface FileContextMenuProps {
@@ -19,6 +20,8 @@ export function FileContextMenu({
 	onRename,
 	onDelete,
 }: FileContextMenuProps) {
+	const { copyToClipboard } = useCopyToClipboard();
+
 	return (
 		<ContextMenuContent className="w-56">
 			<ContextMenuItem>Open to the Side</ContextMenuItem>
@@ -32,8 +35,8 @@ export function FileContextMenu({
 			</ContextMenuItem>
 			<ContextMenuSeparator />
 			<ContextMenuItem
-				onSelect={() => {
-					navigator.clipboard.writeText(absolutePath);
+				onSelect={async () => {
+					await copyToClipboard(absolutePath);
 					toast.success("Path copied");
 				}}
 			>
@@ -41,8 +44,8 @@ export function FileContextMenu({
 			</ContextMenuItem>
 			{relativePath && (
 				<ContextMenuItem
-					onSelect={() => {
-						navigator.clipboard.writeText(relativePath);
+					onSelect={async () => {
+						await copyToClipboard(relativePath);
 						toast.success("Relative path copied");
 					}}
 				>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/FileContextMenu/FileContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/FileContextMenu/FileContextMenu.tsx
@@ -3,9 +3,7 @@ import {
 	ContextMenuItem,
 	ContextMenuSeparator,
 } from "@superset/ui/context-menu";
-import { toast } from "@superset/ui/sonner";
-import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
-import { electronTrpcClient } from "renderer/lib/trpc-client";
+import { PathActionsMenuItems } from "../PathActionsMenuItems";
 
 interface FileContextMenuProps {
 	absolutePath: string;
@@ -20,38 +18,14 @@ export function FileContextMenu({
 	onRename,
 	onDelete,
 }: FileContextMenuProps) {
-	const { copyToClipboard } = useCopyToClipboard();
-
 	return (
 		<ContextMenuContent className="w-56">
 			<ContextMenuItem>Open to the Side</ContextMenuItem>
 			<ContextMenuSeparator />
-			<ContextMenuItem
-				onSelect={() =>
-					electronTrpcClient.external.openInFinder.mutate(absolutePath)
-				}
-			>
-				Reveal in Finder
-			</ContextMenuItem>
-			<ContextMenuSeparator />
-			<ContextMenuItem
-				onSelect={async () => {
-					await copyToClipboard(absolutePath);
-					toast.success("Path copied");
-				}}
-			>
-				Copy Path
-			</ContextMenuItem>
-			{relativePath && (
-				<ContextMenuItem
-					onSelect={async () => {
-						await copyToClipboard(relativePath);
-						toast.success("Relative path copied");
-					}}
-				>
-					Copy Relative Path
-				</ContextMenuItem>
-			)}
+			<PathActionsMenuItems
+				absolutePath={absolutePath}
+				relativePath={relativePath}
+			/>
 			<ContextMenuSeparator />
 			<ContextMenuItem onSelect={() => setTimeout(onRename, 0)}>
 				Rename...

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/FolderContextMenu/FolderContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/FolderContextMenu/FolderContextMenu.tsx
@@ -4,6 +4,7 @@ import {
 	ContextMenuSeparator,
 } from "@superset/ui/context-menu";
 import { toast } from "@superset/ui/sonner";
+import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 
 interface FolderContextMenuProps {
@@ -23,6 +24,8 @@ export function FolderContextMenu({
 	onRename,
 	onDelete,
 }: FolderContextMenuProps) {
+	const { copyToClipboard } = useCopyToClipboard();
+
 	return (
 		<ContextMenuContent className="w-56">
 			<ContextMenuItem onSelect={() => setTimeout(onNewFile, 0)}>
@@ -41,8 +44,8 @@ export function FolderContextMenu({
 			</ContextMenuItem>
 			<ContextMenuSeparator />
 			<ContextMenuItem
-				onSelect={() => {
-					navigator.clipboard.writeText(absolutePath);
+				onSelect={async () => {
+					await copyToClipboard(absolutePath);
 					toast.success("Path copied");
 				}}
 			>
@@ -50,8 +53,8 @@ export function FolderContextMenu({
 			</ContextMenuItem>
 			{relativePath && (
 				<ContextMenuItem
-					onSelect={() => {
-						navigator.clipboard.writeText(relativePath);
+					onSelect={async () => {
+						await copyToClipboard(relativePath);
 						toast.success("Relative path copied");
 					}}
 				>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/FolderContextMenu/FolderContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/FolderContextMenu/FolderContextMenu.tsx
@@ -3,9 +3,7 @@ import {
 	ContextMenuItem,
 	ContextMenuSeparator,
 } from "@superset/ui/context-menu";
-import { toast } from "@superset/ui/sonner";
-import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
-import { electronTrpcClient } from "renderer/lib/trpc-client";
+import { PathActionsMenuItems } from "../PathActionsMenuItems";
 
 interface FolderContextMenuProps {
 	absolutePath: string;
@@ -24,8 +22,6 @@ export function FolderContextMenu({
 	onRename,
 	onDelete,
 }: FolderContextMenuProps) {
-	const { copyToClipboard } = useCopyToClipboard();
-
 	return (
 		<ContextMenuContent className="w-56">
 			<ContextMenuItem onSelect={() => setTimeout(onNewFile, 0)}>
@@ -35,32 +31,10 @@ export function FolderContextMenu({
 				New Folder...
 			</ContextMenuItem>
 			<ContextMenuSeparator />
-			<ContextMenuItem
-				onSelect={() =>
-					electronTrpcClient.external.openInFinder.mutate(absolutePath)
-				}
-			>
-				Reveal in Finder
-			</ContextMenuItem>
-			<ContextMenuSeparator />
-			<ContextMenuItem
-				onSelect={async () => {
-					await copyToClipboard(absolutePath);
-					toast.success("Path copied");
-				}}
-			>
-				Copy Path
-			</ContextMenuItem>
-			{relativePath && (
-				<ContextMenuItem
-					onSelect={async () => {
-						await copyToClipboard(relativePath);
-						toast.success("Relative path copied");
-					}}
-				>
-					Copy Relative Path
-				</ContextMenuItem>
-			)}
+			<PathActionsMenuItems
+				absolutePath={absolutePath}
+				relativePath={relativePath}
+			/>
 			<ContextMenuSeparator />
 			<ContextMenuItem onSelect={() => setTimeout(onRename, 0)}>
 				Rename...

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/PathActionsMenuItems/PathActionsMenuItems.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/PathActionsMenuItems/PathActionsMenuItems.tsx
@@ -28,13 +28,19 @@ export function PathActionsMenuItems({
 		}
 	};
 
+	const handleRevealInFinder = async () => {
+		try {
+			await electronTrpcClient.external.openInFinder.mutate(absolutePath);
+		} catch (error) {
+			toast.error(
+				`Failed to reveal in Finder: ${error instanceof Error ? error.message : "Unknown error"}`,
+			);
+		}
+	};
+
 	return (
 		<>
-			<ContextMenuItem
-				onSelect={() =>
-					electronTrpcClient.external.openInFinder.mutate(absolutePath)
-				}
-			>
+			<ContextMenuItem onSelect={handleRevealInFinder}>
 				Reveal in Finder
 			</ContextMenuItem>
 			<ContextMenuSeparator />

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/PathActionsMenuItems/PathActionsMenuItems.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/PathActionsMenuItems/PathActionsMenuItems.tsx
@@ -1,0 +1,53 @@
+import {
+	ContextMenuItem,
+	ContextMenuSeparator,
+} from "@superset/ui/context-menu";
+import { toast } from "@superset/ui/sonner";
+import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
+import { electronTrpcClient } from "renderer/lib/trpc-client";
+
+interface PathActionsMenuItemsProps {
+	absolutePath: string;
+	relativePath?: string;
+}
+
+export function PathActionsMenuItems({
+	absolutePath,
+	relativePath,
+}: PathActionsMenuItemsProps) {
+	const { copyToClipboard } = useCopyToClipboard();
+
+	const handleCopy = async (path: string, successMessage: string) => {
+		try {
+			await copyToClipboard(path);
+			toast.success(successMessage);
+		} catch (error) {
+			toast.error(
+				`Failed to copy path: ${error instanceof Error ? error.message : "Unknown error"}`,
+			);
+		}
+	};
+
+	return (
+		<>
+			<ContextMenuItem
+				onSelect={() =>
+					electronTrpcClient.external.openInFinder.mutate(absolutePath)
+				}
+			>
+				Reveal in Finder
+			</ContextMenuItem>
+			<ContextMenuSeparator />
+			<ContextMenuItem onSelect={() => handleCopy(absolutePath, "Path copied")}>
+				Copy Path
+			</ContextMenuItem>
+			{relativePath && (
+				<ContextMenuItem
+					onSelect={() => handleCopy(relativePath, "Relative path copied")}
+				>
+					Copy Relative Path
+				</ContextMenuItem>
+			)}
+		</>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/PathActionsMenuItems/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/PathActionsMenuItems/index.ts
@@ -1,0 +1,1 @@
+export { PathActionsMenuItems } from "./PathActionsMenuItems";


### PR DESCRIPTION
## Summary
- v2 sidebar's file/folder context menu "Copy Path" and "Copy Relative Path" used `navigator.clipboard.writeText`, which silently fails when focus is on another element (e.g., the terminal) — the toast showed but nothing was actually copied.
- Switch both menus to the `useCopyToClipboard` hook, which routes through Electron's native clipboard via tRPC. Matches the v1 pathway.

## Test plan
- [ ] Right-click a file in the v2 workspace sidebar → Copy Path → verify absolute path is on the system clipboard (paste elsewhere).
- [ ] Right-click a folder in the v2 workspace sidebar → Copy Path and Copy Relative Path → verify both land on the clipboard.
- [ ] Focus a terminal pane, then repeat the above from the sidebar → verify the clipboard still receives the path (the bug this fixes).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Uses the native clipboard via `useCopyToClipboard` to make copy actions reliable in the v2 sidebar. Adds working “Copy Path” and “Open in Finder” to the dashboard for local workspaces, and hides these options for non-local workspaces.

- **New Features**
  - Dashboard sidebar: show “Copy Path” and “Open in Finder” only for local workspaces; resolve `worktreePath` via the local host service and call native actions.

- **Bug Fixes**
  - File/folder menus: use `useCopyToClipboard` (Electron via `tRPC`), await completion, and toast errors; extract shared `PathActionsMenuItems`; wrap “Reveal/Open in Finder” in try/catch.

<sup>Written for commit 53804218827bdfc018afcf1443e34094afd26f80. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace sidebar actions now respect workspace host type, showing "Open in Finder" and "Copy Path" only for local workspaces.
  * Added a consolidated "Path actions" menu reused by file and folder context menus.

* **Bug Fixes**
  * Centralized and improved copy-to-clipboard flow for "Copy Path" / "Copy Relative Path" with reliable success/error feedback.
  * More reliable "Reveal in Finder" handling with unified error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->