### PR TITLE
fix(desktop): gate v2 workspace children on collection readiness

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
@@ -29,7 +29,7 @@ function V2WorkspaceLayout() {
 	const { machineId, activeHostUrl } = useLocalHostService();
 	const { ensureWorkspaceInSidebar } = useDashboardSidebarState();
 
-	const { data: workspacesWithHost = [] } = useLiveQuery(
+	const { data: workspacesWithHost = [], isReady } = useLiveQuery(
 		(q) =>
 			q
 				.from({ v2Workspaces: collections.v2Workspaces })
@@ -64,22 +64,14 @@ function V2WorkspaceLayout() {
 		ensureWorkspaceInSidebar(workspace.id, workspace.projectId);
 	}, [ensureWorkspaceInSidebar, workspace]);
 
-	// TODO: This renders child routes without WorkspaceTrpcProvider when
-	// the workspace hasn't loaded from collections yet, or during route
-	// transitions (e.g. navigating away from a workspace). If the outgoing
-	// workspace page hasn't fully unmounted, its components (TerminalPane,
-	// etc.) will crash with "useWorkspaceClient must be used within
-	// WorkspaceClientProvider". Either the layout should never render
-	// children without the provider, or the provider should move to the
-	// page level so each page owns its own context.
-	if (!workspaceId || !workspace) {
-		return <Outlet />;
+	if (!workspaceId || !isReady) {
+		return null;
 	}
 
-	if (!hostUrl) {
+	if (!workspace || !hostUrl) {
 		return (
 			<div className="flex h-full w-full items-center justify-center text-muted-foreground">
-				Workspace host service not available
+				Workspace not found
 			</div>
 		);
 	}


### PR DESCRIPTION
## Summary
- Fixes a race where switching workspaces (or first-load) would crash with `useWorkspaceClient must be used within WorkspaceClientProvider`. The `v2-workspace` layout was rendering `<Outlet />` without `WorkspaceTrpcProvider` during the tick between `workspaceId` changing and the `useLiveQuery` join resolving — the outgoing page's hooks (TerminalPane, `useGitChangeEvents`, etc.) would call `useWorkspaceClient()` against an empty context.
- Now holds the render until `useLiveQuery` reports `isReady`, so the new workspace always mounts into a valid provider on the same tick.
- Adds an explicit "Workspace not found" state for the case where the collection has hydrated but the id doesn't resolve, instead of silently falling through to a provider-less `<Outlet />`.

## Test plan
- [ ] Open a v2 workspace, rapidly switch between workspaces, confirm no error overlay
- [ ] Open a v2 workspace URL directly on cold start, confirm it loads without flashing the error
- [ ] Navigate to `/v2-workspace/<bogus-id>` and confirm the "Workspace not found" message shows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race that crashed v2 workspace pages by delaying child rendering until the workspace collection is ready. Child routes now mount only when data is ready and a workspace exists, preventing provider-less renders.

- **Bug Fixes**
  - Gate rendering on `useLiveQuery.isReady` and a valid `workspaceId` to avoid the "useWorkspaceClient must be used within WorkspaceClientProvider" crash.
  - Return `null` during loading to prevent `<Outlet />` without `WorkspaceTrpcProvider`.
  - Show "Workspace not found" when the collection is hydrated but the workspace or host URL is missing.

<sup>Written for commit 37e6eff5939a734bb9de9f7b8e5d26bc0190d39c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rendering of workspace content before data is fully loaded, preventing incomplete display states
  * Improved error messaging to accurately indicate when a workspace is not found

<!-- end of auto-generated comment: release notes by coderabbit.ai -->