### PR TITLE
fix(desktop): focus xterm when v2 pane becomes active via FOCUS_PANE_* hotkey

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -191,6 +191,12 @@ export function TerminalPane({ ctx, workspaceId }: TerminalPaneProps) {
 		[terminalId, connectionState],
 	);
 
+	// Physically move keyboard focus when this pane becomes active via hotkey (e.g. FOCUS_PANE_*)
+	useEffect(() => {
+		if (!ctx.isActive || !terminal) return;
+		terminal.focus();
+	}, [ctx.isActive, terminal]);
+
 	// biome-ignore lint/correctness/useExhaustiveDependencies: connectionState is intentionally included to trigger re-derive
 	const searchAddon = useMemo(
 		() => terminalRuntimeRegistry.getSearchAddon(terminalId),


### PR DESCRIPTION
## Summary

- `FOCUS_PANE_*` hotkeys (`Cmd+Alt+Arrow`, added in #3460) visually moved the active pane indicator in v2 workspaces but never transferred actual keyboard focus to the new terminal
- Root cause: `setActivePane` updates the store (`ctx.isActive`) but there was no effect to call `xterm.focus()` — unlike v1, which has this in `useTerminalHotkeys`
- Fix: add a `useEffect` in `TerminalPane` that calls `terminal.focus()` when `ctx.isActive` becomes true, mirroring the v1 pattern

## Context

- `PREV_WORKSPACE` / `NEXT_WORKSPACE` are also reported as broken — this is intentional: their `Cmd+Alt+Up/Down` bindings were freed for `FOCUS_PANE_UP/DOWN` in c925f4d. Users can rebind them in Settings → Keyboard.

## Test plan

- [ ] Open a v2 workspace with 2+ split terminal panes
- [ ] Focus one terminal (click into it, type something)
- [ ] Press `Cmd+Alt+→` — confirm keyboard focus moves to the right pane (cursor blinks there, typing goes there)
- [ ] Press `Cmd+Alt+←` — confirm focus returns

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes v2 pane focus hotkeys so keyboard focus moves to the selected terminal when using Cmd+Alt+Arrow, not just the visual highlight.

- **Bug Fixes**
  - Root cause: `setActivePane` updated `ctx.isActive` but never called `xterm.focus()`.
  - Fix: added a `useEffect` in `TerminalPane` to call `terminal.focus()` when `ctx.isActive` becomes true, matching v1 behavior.

<sup>Written for commit 1da365fc15be57b4b8fe36936740e460ab1b4f68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal panes now automatically receive keyboard focus when activated via hotkeys, improving workflow efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->