### PR TITLE
feat(desktop): close settings with Escape key

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
@@ -5,10 +5,12 @@ import {
 	useNavigate,
 } from "@tanstack/react-router";
 import { useEffect } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
 	type SettingsSection,
 	useSetSettingsSearchQuery,
+	useSettingsOriginRoute,
 	useSettingsSearchQuery,
 } from "renderer/stores/settings-state";
 import { SearchResultsBanner } from "./components/SearchResultsBanner";
@@ -88,6 +90,7 @@ function SettingsLayout() {
 	const isMac = platform === undefined || platform === "darwin";
 	const searchQuery = useSettingsSearchQuery();
 	const setSearchQuery = useSetSettingsSearchQuery();
+	const originRoute = useSettingsOriginRoute();
 	const location = useLocation();
 	const navigate = useNavigate();
 	const normalizedSearchQuery = searchQuery.trim();
@@ -116,6 +119,17 @@ function SettingsLayout() {
 			}
 		}
 	}, [isSearchActive, location.pathname, navigate, normalizedSearchQuery]);
+
+	useHotkeys(
+		"escape",
+		(event) => {
+			if (document.querySelector('[data-state="open"]')) return;
+			event.preventDefault();
+			navigate({ to: originRoute });
+		},
+		{ enableOnFormTags: false, enableOnContentEditable: false },
+		[navigate, originRoute],
+	);
 
 	return (
 		<div className="flex flex-col h-screen w-screen bg-tertiary">


### PR DESCRIPTION
## Summary
- Press Escape on any settings page to navigate back to where settings was opened from (`originRoute`).
- Uses `react-hotkeys-hook` with `enableOnFormTags: false` and `enableOnContentEditable: false`, so Escape inside inputs, textareas, selects, and contenteditable fields is left to the browser/component.
- Skips navigation if any Radix overlay is open (`[data-state="open"]`), so Escape-to-close on dialogs/popovers/dropdowns/sheets keeps working as expected.

## Test plan
- [ ] Open settings from main, press Escape → returns to origin route.
- [ ] Type in the search input, press Escape → does not navigate (input keeps focus).
- [ ] Open a dialog (e.g. Invite Member, Edit Secret), press Escape → dialog closes, settings stays.
- [ ] Open a dropdown/popover (e.g. Volume, Font Family), press Escape → popover closes, settings stays.
- [ ] Press Escape with focus in a textarea (e.g. Scripts editor) → does not navigate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Close Settings with Escape in the desktop app. Pressing Escape on any Settings page returns you to where Settings was opened.

- **New Features**
  - Uses `react-hotkeys-hook` with form and contenteditable inputs excluded, so Escape inside fields is not intercepted.
  - Skips navigation when any Radix overlay is open, preserving Escape-to-close for dialogs, popovers, dropdowns, and sheets.

<sup>Written for commit 6206829e73d5a5092ddb27c53bc3be78a5cd94ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Escape key behavior in Settings: Pressing Escape now intelligently closes any open dialogs or panels before navigating back to the previous page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->