### PR TITLE
feat(desktop/hotkeys): restore Cmd+Alt+Arrow for tab/workspace nav

### DIFF
--- a/apps/desktop/src/renderer/hotkeys/registry.ts
+++ b/apps/desktop/src/renderer/hotkeys/registry.ts
@@ -102,13 +102,21 @@ export const HOTKEYS_REGISTRY = {
 		category: "Workspace",
 	},
 	PREV_WORKSPACE: {
-		key: { mac: null, windows: null, linux: null },
+		key: {
+			mac: "meta+alt+up",
+			windows: "ctrl+shift+alt+up",
+			linux: "ctrl+shift+alt+up",
+		},
 		label: "Previous Workspace",
 		category: "Workspace",
 		description: "Navigate to the previous workspace in the sidebar",
 	},
 	NEXT_WORKSPACE: {
-		key: { mac: null, windows: null, linux: null },
+		key: {
+			mac: "meta+alt+down",
+			windows: "ctrl+shift+alt+down",
+			linux: "ctrl+shift+alt+down",
+		},
 		label: "Next Workspace",
 		category: "Workspace",
 		description: "Navigate to the next workspace in the sidebar",
@@ -321,8 +329,8 @@ export const HOTKEYS_REGISTRY = {
 	SCROLL_TO_BOTTOM: {
 		key: {
 			mac: "meta+shift+down",
-			windows: "ctrl+shift+alt+down",
-			linux: "ctrl+shift+alt+down",
+			windows: "ctrl+end",
+			linux: "ctrl+end",
 		},
 		label: "Scroll to Bottom",
 		category: "Terminal",
@@ -343,53 +351,45 @@ export const HOTKEYS_REGISTRY = {
 		category: "Terminal",
 	},
 	PREV_TAB: {
-		key: { mac: null, windows: null, linux: null },
-		label: "Previous Tab",
-		category: "Terminal",
-		description: "Focus the previous tab in the active workspace",
-	},
-	NEXT_TAB: {
-		key: { mac: null, windows: null, linux: null },
-		label: "Next Tab",
-		category: "Terminal",
-		description: "Focus the next tab in the active workspace",
-	},
-	FOCUS_PANE_LEFT: {
 		key: {
 			mac: "meta+alt+left",
 			windows: "ctrl+shift+alt+left",
 			linux: "ctrl+shift+alt+left",
 		},
-		label: "Focus Pane Left",
+		label: "Previous Tab",
 		category: "Terminal",
-		description: "Focus the pane to the left of the active pane",
+		description: "Focus the previous tab in the active workspace",
 	},
-	FOCUS_PANE_RIGHT: {
+	NEXT_TAB: {
 		key: {
 			mac: "meta+alt+right",
 			windows: "ctrl+shift+alt+right",
 			linux: "ctrl+shift+alt+right",
 		},
+		label: "Next Tab",
+		category: "Terminal",
+		description: "Focus the next tab in the active workspace",
+	},
+	FOCUS_PANE_LEFT: {
+		key: { mac: null, windows: null, linux: null },
+		label: "Focus Pane Left",
+		category: "Terminal",
+		description: "Focus the pane to the left of the active pane",
+	},
+	FOCUS_PANE_RIGHT: {
+		key: { mac: null, windows: null, linux: null },
 		label: "Focus Pane Right",
 		category: "Terminal",
 		description: "Focus the pane to the right of the active pane",
 	},
 	FOCUS_PANE_UP: {
-		key: {
-			mac: "meta+alt+up",
-			windows: "ctrl+shift+alt+up",
-			linux: "ctrl+shift+alt+up",
-		},
+		key: { mac: null, windows: null, linux: null },
 		label: "Focus Pane Up",
 		category: "Terminal",
 		description: "Focus the pane above the active pane",
 	},
 	FOCUS_PANE_DOWN: {
-		key: {
-			mac: "meta+alt+down",
-			windows: "ctrl+shift+alt+down",
-			linux: "ctrl+shift+alt+down",
-		},
+		key: { mac: null, windows: null, linux: null },
 		label: "Focus Pane Down",
 		category: "Terminal",
 		description: "Focus the pane below the active pane",


### PR DESCRIPTION
## Summary

Flip the Cmd+Alt+Arrow (mac) / Ctrl+Shift+Alt+Arrow (win/linux) chords back to tab/workspace navigation, which is how they worked before #3403 retired them in favor of directional pane focus.

- **Cmd+Alt+Left / Right** → Previous / Next Tab
- **Cmd+Alt+Up / Down** → Previous / Next Workspace
- **FOCUS_PANE_{LEFT,RIGHT,UP,DOWN}** — registered but unbound. Users who want directional pane focus rebind in Settings → Keyboard. Same shape #3422 used when it re-registered PREV/NEXT_TAB + PREV/NEXT_WORKSPACE as unbound.
- **PREV_TAB_ALT / NEXT_TAB_ALT** (Ctrl+Tab / Ctrl+Shift+Tab) — unchanged.

## The SCROLL_TO_BOTTOM collision fix

`buildRegisteredAppChords` uses a `Map` keyed by canonical chord. When two hotkeys hash to the same chord, the later entry silently overwrites the earlier one in the reverse index — no error, the loser just stops responding.

Before this PR, on Windows/Linux `SCROLL_TO_BOTTOM` and `FOCUS_PANE_DOWN` both claimed `ctrl+shift+alt+down`, silently breaking `FOCUS_PANE_DOWN` (pre-existing latent bug — see the abandoned commit `9fae2612d` which proposed the same fix). Restoring `NEXT_WORKSPACE` to `ctrl+shift+alt+down` would just move the bug from "breaks pane nav" to "breaks workspace nav".

Moving `SCROLL_TO_BOTTOM` on Windows/Linux from `ctrl+shift+alt+down` to `ctrl+end` resolves both. Mac `SCROLL_TO_BOTTOM` (`meta+shift+down`) is untouched.

## User override safety

Any user who previously overrode `PREV_TAB`, `NEXT_TAB`, `PREV_WORKSPACE`, `NEXT_WORKSPACE`, or any `FOCUS_PANE_*` keeps their override — defaults are just fallbacks. Users on stock defaults get the new (restored) values.

## Test plan

- [ ] Cmd+Alt+Left/Right cycles tabs in both v1 and v2 workspaces
- [ ] Cmd+Alt+Up/Down cycles workspaces in the sidebar
- [ ] Ctrl+Tab / Ctrl+Shift+Tab still cycles tabs (PREV_TAB_ALT / NEXT_TAB_ALT unchanged)
- [ ] FOCUS_PANE_* appear in Settings → Keyboard as Unassigned; binding one and verifying directional pane focus still works
- [ ] On Windows/Linux, SCROLL_TO_BOTTOM responds to Ctrl+End (not Ctrl+Shift+Alt+Down anymore)
- [ ] `bun run typecheck --filter @superset/desktop` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts to navigate between workspaces.
  * Added keyboard shortcuts to switch between tabs.

* **Improvements**
  * Simplified scroll-to-bottom shortcut for Windows/Linux.
  * Adjusted keyboard shortcuts for pane navigation across all platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore Cmd+Alt+Arrow on mac and Ctrl+Shift+Alt+Arrow on Windows/Linux for tab and workspace navigation. Unbind pane-focus arrows by default and move SCROLL_TO_BOTTOM to Ctrl+End on Windows/Linux to avoid a collision.

- **New Features**
  - Cmd+Alt+Left/Right → previous/next tab; Cmd+Alt+Up/Down → previous/next workspace.
  - Pane focus (FOCUS_PANE_*) is registered but unassigned; users can bind in Settings → Keyboard.
  - Ctrl+Tab / Ctrl+Shift+Tab for tab cycling unchanged.
  - Existing user overrides are preserved.

- **Bug Fixes**
  - Windows/Linux: SCROLL_TO_BOTTOM changed to Ctrl+End to remove a duplicate binding with workspace navigation.

<sup>Written for commit f643a9641cad47a182be6b89f536fd6a496c21b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

