### PR TITLE
fix(desktop): force WebGL repaint on load and fall back to DOM after context loss

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
@@ -51,9 +51,13 @@ export function loadAddons(terminal: XTerm): LoadAddonsResult {
 			webglAddon.onContextLoss(() => {
 				webglAddon?.dispose();
 				webglAddon = null;
+				suggestedRendererType = "dom";
 				terminal.refresh(0, terminal.rows - 1);
 			});
 			terminal.loadAddon(webglAddon);
+			// Force a full repaint so the WebGL renderer renders all
+			// existing content, including wide/CJK characters.
+			terminal.refresh(0, terminal.rows - 1);
 		} catch {
 			suggestedRendererType = "dom";
 			webglAddon = null;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -148,9 +148,13 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 			webglAddon.onContextLoss(() => {
 				webglAddon?.dispose();
 				webglAddon = null;
+				suggestedRendererType = "dom";
 				xterm.refresh(0, xterm.rows - 1);
 			});
 			xterm.loadAddon(webglAddon);
+			// Force a full repaint so the WebGL renderer renders all
+			// existing content, including wide/CJK characters.
+			xterm.refresh(0, xterm.rows - 1);
 		} catch {
 			suggestedRendererType = "dom";
 			webglAddon = null;


### PR DESCRIPTION
## Description

Fixes intermittent garbling of CJK (and occasionally Latin) characters in the terminal that resolves when the text is selected with the mouse.

After #3252 (`54e8a1c8`), terminal attachment calls `ensureSession` via tRPC before connecting the WebSocket. This creates a timing window where the terminal can receive data — including wide/CJK characters — before the WebGL renderer has initialized (WebGL is deferred to `requestAnimationFrame`). During that window, cells are rendered by the DOM renderer. When WebGL takes over, it does not automatically repaint those pre-rendered cells, leaving wide characters in an inconsistent state in the texture atlas. Selecting the text forces a repaint which corrects the display.

Two fixes in `terminal-addons.ts` and `helpers.ts`:

1. **Force a full repaint after WebGL loads** — call `terminal.refresh(0, terminal.rows - 1)` immediately after `terminal.loadAddon(webglAddon)` so all buffered cells are re-rendered through the WebGL renderer.
2. **Mark renderer as DOM after context loss** — set `suggestedRendererType = "dom"` in the `onContextLoss` handler so subsequent terminals skip WebGL after a GPU context loss.

## Related Issues

Fixes #3406

## Type of Change

- [x] Bug fix

## Testing

Run the desktop app and output CJK characters in the terminal (e.g. `echo "こんにちは 你好"`). Verify no garbling occurs on initial render and after switching workspaces/tabs.

## Screenshots (if applicable)

## Additional Notes

The garbling was intermittent and depended on timing between WebSocket data delivery and WebGL initialization, making it more likely to occur on slower machines or under load.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes intermittent CJK and wide-character garbling in the desktop terminal by forcing a full repaint when WebGL initializes and falling back to the DOM renderer after GPU context loss. Ensures correct rendering on first load and after context issues.

- **Bug Fixes**
  - After loading the WebGL addon, call `terminal.refresh(0, terminal.rows - 1)` to repaint all buffered cells through WebGL.
  - On WebGL context loss, dispose the addon and set `suggestedRendererType = "dom"` so subsequent terminals skip WebGL.

<sup>Written for commit c9ee0647667b07503341ac53dc32f36c35eb2d48. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal rendering reliability by properly handling WebGL context loss with graceful fallback and display refresh.
  * Fixed rendering issues with wide and CJK characters to ensure complete and accurate display in the terminal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->