### PR TITLE
fix(desktop): handle IME composition in new-workspace Enter handlers

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
@@ -22,6 +22,7 @@ import {
 	CommandSeparator,
 } from "@superset/ui/command";
 import { Input } from "@superset/ui/input";
+import { isEnterSubmit } from "@superset/ui/lib/keyboard";
 import { Popover, PopoverContent, PopoverTrigger } from "@superset/ui/popover";
 import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
@@ -1072,10 +1073,9 @@ ${sanitizeText(truncatedBody)}`;
 	useEffect(() => {
 		if (!isNewWorkspaceModalOpen) return;
 		const handler = (e: KeyboardEvent) => {
-			if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-				e.preventDefault();
-				void handleCreate();
-			}
+			if (!isEnterSubmit(e, { requireMod: true })) return;
+			e.preventDefault();
+			void handleCreate();
 		};
 		window.addEventListener("keydown", handler);
 		return () => window.removeEventListener("keydown", handler);

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
@@ -1073,7 +1073,7 @@ ${sanitizeText(truncatedBody)}`;
 	useEffect(() => {
 		if (!isNewWorkspaceModalOpen) return;
 		const handler = (e: KeyboardEvent) => {
-			if (!isEnterSubmit(e, { requireMod: true, allowShift: true })) return;
+			if (!isEnterSubmit(e, { requireMod: true })) return;
 			e.preventDefault();
 			void handleCreate();
 		};

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
@@ -1073,7 +1073,7 @@ ${sanitizeText(truncatedBody)}`;
 	useEffect(() => {
 		if (!isNewWorkspaceModalOpen) return;
 		const handler = (e: KeyboardEvent) => {
-			if (!isEnterSubmit(e, { requireMod: true })) return;
+			if (!isEnterSubmit(e, { requireMod: true, allowShift: true })) return;
 			e.preventDefault();
 			void handleCreate();
 		};

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -9,6 +9,7 @@ import {
 	useProviderAttachments,
 } from "@superset/ui/ai-elements/prompt-input";
 import { Input } from "@superset/ui/input";
+import { isEnterSubmit } from "@superset/ui/lib/keyboard";
 import { cn } from "@superset/ui/utils";
 import { AnimatePresence, motion } from "framer-motion";
 import { ArrowUpIcon } from "lucide-react";
@@ -135,10 +136,9 @@ export function PromptGroup({
 	useEffect(() => {
 		if (!isNewWorkspaceModalOpen) return;
 		const handler = (e: KeyboardEvent) => {
-			if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-				e.preventDefault();
-				void handleCreate();
-			}
+			if (!isEnterSubmit(e, { requireMod: true })) return;
+			e.preventDefault();
+			void handleCreate();
 		};
 		window.addEventListener("keydown", handler);
 		return () => window.removeEventListener("keydown", handler);

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -136,7 +136,7 @@ export function PromptGroup({
 	useEffect(() => {
 		if (!isNewWorkspaceModalOpen) return;
 		const handler = (e: KeyboardEvent) => {
-			if (!isEnterSubmit(e, { requireMod: true })) return;
+			if (!isEnterSubmit(e, { requireMod: true, allowShift: true })) return;
 			e.preventDefault();
 			void handleCreate();
 		};

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -136,7 +136,7 @@ export function PromptGroup({
 	useEffect(() => {
 		if (!isNewWorkspaceModalOpen) return;
 		const handler = (e: KeyboardEvent) => {
-			if (!isEnterSubmit(e, { requireMod: true, allowShift: true })) return;
+			if (!isEnterSubmit(e, { requireMod: true })) return;
 			e.preventDefault();
 			void handleCreate();
 		};

--- a/packages/ui/src/components/ai-elements/prompt-input.tsx
+++ b/packages/ui/src/components/ai-elements/prompt-input.tsx
@@ -34,6 +34,7 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { isEnterSubmit } from "../../lib/keyboard";
 import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
 import {
@@ -973,12 +974,8 @@ export const PromptInputTextarea = ({
 		}
 
 		if (e.key === "Enter") {
-			if (isComposing || e.nativeEvent.isComposing) {
-				return;
-			}
-			if (e.shiftKey) {
-				return;
-			}
+			if (isComposing) return;
+			if (!isEnterSubmit(e)) return;
 			e.preventDefault();
 
 			// Check if the submit button is disabled before submitting

--- a/packages/ui/src/lib/keyboard.ts
+++ b/packages/ui/src/lib/keyboard.ts
@@ -1,0 +1,31 @@
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
+
+type AnyKeyboardEvent = KeyboardEvent | ReactKeyboardEvent;
+
+// True while an IME (Japanese/Chinese/Korean) composition is in progress.
+// `keyCode === 229` is the legacy signal some browsers still emit during
+// composition even when `isComposing` is not set.
+export const isImeComposing = (e: AnyKeyboardEvent): boolean => {
+	const native = "nativeEvent" in e ? e.nativeEvent : e;
+	return native.isComposing || native.keyCode === 229;
+};
+
+export type IsEnterSubmitOptions = {
+	// Require Cmd (mac) / Ctrl (other) to be held. Defaults to false.
+	requireMod?: boolean;
+	// Treat Shift+Enter as submit. Defaults to false (Shift+Enter = newline).
+	allowShift?: boolean;
+};
+
+// Returns true only for an Enter press that should trigger a submit:
+// not during IME composition, and matching the modifier policy.
+export const isEnterSubmit = (
+	e: AnyKeyboardEvent,
+	{ requireMod = false, allowShift = false }: IsEnterSubmitOptions = {},
+): boolean => {
+	if (e.key !== "Enter") return false;
+	if (isImeComposing(e)) return false;
+	if (!allowShift && e.shiftKey) return false;
+	if (requireMod && !(e.metaKey || e.ctrlKey)) return false;
+	return true;
+};


### PR DESCRIPTION
## Summary
- Japanese/Chinese IME users reported that pressing Enter to confirm a conversion candidate in the new-workspace modal was sometimes interpreted as a submit. The v1 and v2 new-workspace `PromptGroup`s register window-level Cmd/Ctrl+Enter keydown listeners that didn't guard against IME composition.
- Adds a shared helper `packages/ui/src/lib/keyboard.ts` exporting `isImeComposing(e)` and `isEnterSubmit(e, { requireMod?, allowShift? })`. Handles both native and React `KeyboardEvent` and checks `nativeEvent.isComposing || keyCode === 229` — the standard convention.
- Migrates both `NewWorkspaceModal`/`DashboardNewWorkspaceModal` `PromptGroup`s and the shared `PromptInputTextarea` to use the helper, so any future keyboard handlers have one place to import from instead of re-implementing the guard.

## Test plan
- [ ] macOS + Japanese IME: open "New Workspace" (v1 and v2), type in the prompt, press Enter to confirm a conversion candidate — modal should NOT submit.
- [ ] macOS + Japanese IME: Cmd+Enter during active composition should NOT submit (Enter only confirms).
- [ ] macOS + Japanese IME: after composition ends, Cmd+Enter still submits as before.
- [ ] English input: Enter in prompt textarea submits; Shift+Enter inserts newline; Cmd/Ctrl+Enter from anywhere in the modal submits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized Enter-key submit behavior across workspace modals and text inputs by centralizing keyboard handling. Improves consistency for Enter-with-modifier, Shift, and IME composition cases so keyboard submission is more reliable and predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Enter handling for Japanese/Chinese IME in the new-workspace modals. Confirming a conversion no longer submits; Cmd/Ctrl+Enter still submits after composition ends; Cmd/Ctrl+Shift+Enter no longer submits.

- **Bug Fixes**
  - Added `isImeComposing` and `isEnterSubmit` in `@superset/ui/lib/keyboard` to centralize IME-safe Enter detection.
  - Updated v1/v2 new-workspace `PromptGroup`s to use the helpers and require Cmd/Ctrl+Enter (Shift ignored); updated `PromptInputTextarea` to use the helpers and keep Shift+Enter as a newline.

<sup>Written for commit c961c6e3b5725a4e14e50cf8340a64d18ff13931. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

