### PR TITLE
feat(desktop): Recently Viewed section in v2 Quick Open

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useRecentlyViewedFiles/constants.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useRecentlyViewedFiles/constants.ts
@@ -1,0 +1,2 @@
+export const RECENT_STORE_LIMIT = 25;
+export const RECENT_DISPLAY_LIMIT = 10;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useRecentlyViewedFiles/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useRecentlyViewedFiles/index.ts
@@ -1,0 +1,6 @@
+export { RECENT_DISPLAY_LIMIT, RECENT_STORE_LIMIT } from "./constants";
+export {
+	type RecentFile,
+	type RecentlyViewedFilesApi,
+	useRecentlyViewedFiles,
+} from "./useRecentlyViewedFiles";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useRecentlyViewedFiles/useRecentlyViewedFiles.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useRecentlyViewedFiles/useRecentlyViewedFiles.ts
@@ -1,0 +1,59 @@
+import { eq } from "@tanstack/db";
+import { useLiveQuery } from "@tanstack/react-db";
+import { useCallback, useMemo } from "react";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { RECENT_STORE_LIMIT } from "./constants";
+
+export interface RecentFile {
+	relativePath: string;
+	absolutePath: string;
+	lastAccessedAt: number;
+}
+
+interface RecentFileInput {
+	relativePath: string;
+	absolutePath: string;
+}
+
+export interface RecentlyViewedFilesApi {
+	recentFiles: RecentFile[];
+	recordView: (file: RecentFileInput) => void;
+}
+
+export function useRecentlyViewedFiles(
+	workspaceId: string,
+): RecentlyViewedFilesApi {
+	const collections = useCollections();
+
+	const { data: rows = [] } = useLiveQuery(
+		(query) =>
+			query
+				.from({ state: collections.v2WorkspaceLocalState })
+				.where(({ state }) => eq(state.workspaceId, workspaceId)),
+		[collections, workspaceId],
+	);
+	const recentFiles = useMemo(() => rows[0]?.recentlyViewedFiles ?? [], [rows]);
+
+	const recordView = useCallback(
+		(file: RecentFileInput) => {
+			if (!collections.v2WorkspaceLocalState.get(workspaceId)) return;
+			collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
+				const current = draft.recentlyViewedFiles ?? [];
+				const withoutDup = current.filter(
+					(f) => f.relativePath !== file.relativePath,
+				);
+				draft.recentlyViewedFiles = [
+					{
+						relativePath: file.relativePath,
+						absolutePath: file.absolutePath,
+						lastAccessedAt: Date.now(),
+					},
+					...withoutDup,
+				].slice(0, RECENT_STORE_LIMIT);
+			});
+		},
+		[collections, workspaceId],
+	);
+
+	return { recentFiles, recordView };
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -5,6 +5,7 @@ import {
 	ResizablePanel,
 	ResizablePanelGroup,
 } from "@superset/ui/resizable";
+import { workspaceTrpc } from "@superset/workspace-client";
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { createFileRoute } from "@tanstack/react-router";
@@ -14,6 +15,10 @@ import { TbLayoutColumns, TbLayoutRows } from "react-icons/tb";
 import { HotkeyLabel, useHotkey } from "renderer/hotkeys";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { CommandPalette } from "renderer/screens/main/components/CommandPalette";
+import {
+	toAbsoluteWorkspacePath,
+	toRelativeWorkspacePath,
+} from "shared/absolute-paths";
 import { useStore } from "zustand";
 import { AddTabMenu } from "./components/AddTabMenu";
 import { V2PresetsBar } from "./components/V2PresetsBar";
@@ -23,6 +28,7 @@ import { WorkspaceSidebar } from "./components/WorkspaceSidebar";
 import { useDefaultContextMenuActions } from "./hooks/useDefaultContextMenuActions";
 import { usePaneRegistry } from "./hooks/usePaneRegistry";
 import { renderBrowserTabIcon } from "./hooks/usePaneRegistry/components/BrowserPane";
+import { useRecentlyViewedFiles } from "./hooks/useRecentlyViewedFiles";
 import { useV2PresetExecution } from "./hooks/useV2PresetExecution";
 import { useV2WorkspacePaneLayout } from "./hooks/useV2WorkspacePaneLayout";
 import { useWorkspaceHotkeys } from "./hooks/useWorkspaceHotkeys";
@@ -93,6 +99,13 @@ function WorkspaceContent({
 	const paneRegistry = usePaneRegistry(workspaceId);
 	const defaultContextMenuActions = useDefaultContextMenuActions(paneRegistry);
 
+	const workspaceQuery = workspaceTrpc.workspace.get.useQuery({
+		id: workspaceId,
+	});
+	const worktreePath = workspaceQuery.data?.worktreePath ?? "";
+
+	const { recentFiles, recordView } = useRecentlyViewedFiles(workspaceId);
+
 	const selectedFilePath = useStore(store, (s) => {
 		const tab = s.tabs.find((t) => t.id === s.activeTabId);
 		if (!tab?.activePaneId) return undefined;
@@ -101,8 +114,29 @@ function WorkspaceContent({
 		return undefined;
 	});
 
+	const openFilePathsKey = useStore(store, (s) =>
+		s.tabs
+			.flatMap((t) =>
+				Object.values(t.panes)
+					.filter((p) => p.kind === "file")
+					.map((p) => (p.data as FilePaneData).filePath),
+			)
+			.join("\u0000"),
+	);
+	const openFilePaths = useMemo(
+		() => new Set(openFilePathsKey ? openFilePathsKey.split("\u0000") : []),
+		[openFilePathsKey],
+	);
+
 	const openFilePane = useCallback(
 		(filePath: string, openInNewTab?: boolean) => {
+			if (worktreePath) {
+				const absolutePath = toAbsoluteWorkspacePath(worktreePath, filePath);
+				const relativePath = toRelativeWorkspacePath(worktreePath, filePath);
+				if (relativePath && relativePath !== ".") {
+					recordView({ relativePath, absolutePath });
+				}
+			}
 			const state = store.getState();
 			if (openInNewTab) {
 				state.addTab({
@@ -138,7 +172,7 @@ function WorkspaceContent({
 				},
 			});
 		},
-		[store],
+		[store, worktreePath, recordView],
 	);
 
 	const openDiffPane = useCallback(
@@ -381,6 +415,8 @@ function WorkspaceContent({
 				onOpenChange={setQuickOpenOpen}
 				onSelectFile={openFilePane}
 				variant="v2"
+				recentlyViewedFiles={recentFiles}
+				openFilePaths={openFilePaths}
 			/>
 		</>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -41,6 +41,15 @@ export const workspaceLocalStateSchema = z.object({
 	paneLayout: paneWorkspaceStateSchema,
 	rightSidebarOpen: z.boolean().default(false),
 	viewedFiles: z.array(z.string()).default([]),
+	recentlyViewedFiles: z
+		.array(
+			z.object({
+				relativePath: z.string(),
+				absolutePath: z.string(),
+				lastAccessedAt: z.number(),
+			}),
+		)
+		.default([]),
 });
 
 export const dashboardSidebarSectionSchema = z.object({

--- a/apps/desktop/src/renderer/screens/main/components/CommandPalette/CommandPalette.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/CommandPalette/CommandPalette.tsx
@@ -1,10 +1,12 @@
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { CommandPrimitive } from "@superset/ui/command";
+import { CommandPrimitive, CommandSeparator } from "@superset/ui/command";
 import { SearchIcon } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { LuChevronDown, LuChevronRight } from "react-icons/lu";
+import type { RecentFile } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useRecentlyViewedFiles";
+import { RECENT_DISPLAY_LIMIT } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useRecentlyViewedFiles";
 import { useFileSearch } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/hooks/useFileSearch/useFileSearch";
-import { FileIcon } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils";
+import { FileResultItem } from "./components/FileResultItem";
 import { useV2FileSearch } from "./hooks/useV2FileSearch";
 
 // 48px input + 10 * 40px items
@@ -17,6 +19,13 @@ export interface CommandPaletteProps {
 	onOpenChange: (open: boolean) => void;
 	onSelectFile: (filePath: string) => void;
 	variant?: "v1" | "v2";
+	recentlyViewedFiles?: RecentFile[];
+	openFilePaths?: Set<string>;
+}
+
+function getFileName(relativePath: string): string {
+	const segments = relativePath.split("/");
+	return segments[segments.length - 1] ?? relativePath;
 }
 
 export function CommandPalette({
@@ -25,6 +34,8 @@ export function CommandPalette({
 	onOpenChange,
 	onSelectFile,
 	variant = "v1",
+	recentlyViewedFiles,
+	openFilePaths,
 }: CommandPaletteProps) {
 	const [query, setQuery] = useState("");
 	const [filtersOpen, setFiltersOpen] = useState(false);
@@ -45,7 +56,45 @@ export function CommandPalette({
 		variant === "v2" ? query : "",
 	);
 
-	const results = variant === "v2" ? v2Search.results : v1Search.searchResults;
+	const rawResults =
+		variant === "v2" ? v2Search.results : v1Search.searchResults;
+	const trimmedQuery = query.trim();
+	const hasQuery = trimmedQuery.length > 0;
+	const showRecentSection = variant === "v2" && Boolean(recentlyViewedFiles);
+
+	const orderedRecent = useMemo<RecentFile[]>(() => {
+		if (!showRecentSection || !recentlyViewedFiles) return [];
+		const openSet = openFilePaths ?? new Set<string>();
+		const openFiles: RecentFile[] = [];
+		const rest: RecentFile[] = [];
+		for (const file of recentlyViewedFiles) {
+			if (openSet.has(file.absolutePath)) {
+				openFiles.push(file);
+			} else {
+				rest.push(file);
+			}
+		}
+		return [...openFiles, ...rest].slice(0, RECENT_DISPLAY_LIMIT);
+	}, [showRecentSection, recentlyViewedFiles, openFilePaths]);
+
+	const filteredRecent = useMemo<RecentFile[]>(() => {
+		if (!showRecentSection) return [];
+		if (!hasQuery) return orderedRecent;
+		const needle = trimmedQuery.toLowerCase();
+		return orderedRecent.filter((file) =>
+			file.relativePath.toLowerCase().includes(needle),
+		);
+	}, [showRecentSection, hasQuery, trimmedQuery, orderedRecent]);
+
+	const recentAbsSet = useMemo(
+		() => new Set(filteredRecent.map((f) => f.absolutePath)),
+		[filteredRecent],
+	);
+
+	const dedupedResults = useMemo(() => {
+		if (!showRecentSection) return rawResults;
+		return rawResults.filter((r) => !recentAbsSet.has(r.path));
+	}, [showRecentSection, rawResults, recentAbsSet]);
 
 	const handleOpenChange = useCallback(
 		(nextOpen: boolean) => {
@@ -66,6 +115,12 @@ export function CommandPalette({
 	useEffect(() => {
 		if (open) requestAnimationFrame(() => inputRef.current?.focus());
 	}, [open]);
+
+	const showHeading = showRecentSection && filteredRecent.length > 0;
+	const showSeparator =
+		showRecentSection && filteredRecent.length > 0 && dedupedResults.length > 0;
+	const showEmptyState =
+		filteredRecent.length === 0 && dedupedResults.length === 0;
 
 	return (
 		<DialogPrimitive.Root open={open} onOpenChange={handleOpenChange} modal>
@@ -129,32 +184,40 @@ export function CommandPalette({
 						)}
 
 						<CommandPrimitive.List className="max-h-[400px] overflow-x-hidden overflow-y-auto scroll-py-1 p-1">
-							{results.length === 0 && (
+							{showEmptyState && (
 								<CommandPrimitive.Empty className="py-6 text-center text-sm text-muted-foreground">
 									No files found.
 								</CommandPrimitive.Empty>
 							)}
-							{results.map((file) => (
-								<CommandPrimitive.Item
+
+							{showHeading && (
+								<div className="px-2 pt-2 pb-1 text-muted-foreground text-xs">
+									Recently Viewed
+								</div>
+							)}
+
+							{filteredRecent.map((file) => (
+								<FileResultItem
+									key={`recent:${file.absolutePath}`}
+									value={`recent:${file.absolutePath}`}
+									fileName={getFileName(file.relativePath)}
+									relativePath={file.relativePath}
+									onSelect={() => handleSelectFile(file.absolutePath)}
+								/>
+							))}
+
+							{showSeparator && (
+								<CommandSeparator alwaysRender className="my-1" />
+							)}
+
+							{dedupedResults.map((file) => (
+								<FileResultItem
 									key={file.id}
 									value={file.path}
+									fileName={file.name}
+									relativePath={file.relativePath}
 									onSelect={() => handleSelectFile(file.path)}
-									className="group data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-2 text-sm outline-hidden select-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
-								>
-									<FileIcon
-										fileName={file.name}
-										className="size-3.5 shrink-0"
-									/>
-									<span className="max-w-[252px] truncate font-medium">
-										{file.name}
-									</span>
-									<span className="truncate text-muted-foreground text-xs">
-										{file.relativePath}
-									</span>
-									<kbd className="ml-auto hidden shrink-0 text-xs text-muted-foreground group-data-[selected=true]:block">
-										↵
-									</kbd>
-								</CommandPrimitive.Item>
+								/>
 							))}
 						</CommandPrimitive.List>
 					</CommandPrimitive>

--- a/apps/desktop/src/renderer/screens/main/components/CommandPalette/components/FileResultItem/FileResultItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/CommandPalette/components/FileResultItem/FileResultItem.tsx
@@ -1,0 +1,33 @@
+import { CommandPrimitive } from "@superset/ui/command";
+import { FileIcon } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils";
+
+interface FileResultItemProps {
+	value: string;
+	fileName: string;
+	relativePath: string;
+	onSelect: () => void;
+}
+
+export function FileResultItem({
+	value,
+	fileName,
+	relativePath,
+	onSelect,
+}: FileResultItemProps) {
+	return (
+		<CommandPrimitive.Item
+			value={value}
+			onSelect={onSelect}
+			className="group data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-2 text-sm outline-hidden select-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+		>
+			<FileIcon fileName={fileName} className="size-3.5 shrink-0" />
+			<span className="max-w-[252px] truncate font-medium">{fileName}</span>
+			<span className="truncate text-muted-foreground text-xs">
+				{relativePath}
+			</span>
+			<kbd className="ml-auto hidden shrink-0 text-xs text-muted-foreground group-data-[selected=true]:block">
+				↵
+			</kbd>
+		</CommandPrimitive.Item>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/CommandPalette/components/FileResultItem/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/CommandPalette/components/FileResultItem/index.ts
@@ -1,0 +1,1 @@
+export { FileResultItem } from "./FileResultItem";

--- a/bun.lock
+++ b/bun.lock
@@ -110,7 +110,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.5.3",
+      "version": "1.5.5",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.43",
         "@ai-sdk/openai": "3.0.36",


### PR DESCRIPTION
## Summary

- Adds a **Recently Viewed** section pinned above the fuzzy results in the v2 workspace command palette (`Cmd+P` / Quick Open).
- Tracks files the user explicitly opens (Quick Open or sidebar). Files currently open in a tab are sorted to the top of the section.
- Persists per-workspace via the existing `v2WorkspaceLocalState` localStorage collection — store cap 25, display cap 10.
- Empty-query state shows only the Recently Viewed section (with a muted empty-row when nothing is recorded yet). Non-empty queries substring-match the recents to the top, with a separator before the fuzzy results, and dedupe recents out of the fuzzy list.
- Extracts the duplicated row markup into a shared `FileResultItem` component.

## Test plan
- [ ] Open the v2 workspace command palette with no entries → "Recently Viewed" heading + "No recently viewed files yet" row.
- [ ] Open a few files via Quick Open → reopen palette empty-query → those files appear in the section, MRU first.
- [ ] Open files in tabs, then open more unrelated files → reopen palette → tab files stay above other recents.
- [ ] Type "pack" with `package.json` recently viewed → it appears once under the heading and is removed from the fuzzy list below the separator.
- [ ] Relaunch the desktop app → Recently Viewed list persists.
- [ ] Open a gitignored file (e.g. `.env.local`) via the sidebar → it appears in Recently Viewed (spec: views are kept regardless of gitignore).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recently viewed files now appear in the command palette, prioritizing currently open files for quick access.
  * The app automatically records file accesses and shows up to 10 recent items alongside search results.
  * Search results are deduplicated against recent items for a cleaner navigation list.
  * Improved command palette item layout and selection behavior for recent and search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Recently Viewed section to the v2 Quick Open (Cmd+P). It shows your last opened files at the top, prefers files currently open, and persists per workspace.

- **New Features**
  - Records file opens from Quick Open and the sidebar; stores up to 25 and shows up to 10.
  - Empty query shows only recents; typed queries filter recents, separate them from fuzzy results, and dedupe duplicates.

- **Refactors**
  - Added `useRecentlyViewedFiles` and `recentlyViewedFiles` in `v2WorkspaceLocalState`.
  - Extracted a shared `FileResultItem` for the file row UI.

<sup>Written for commit c86af4e1cedaf2c908521daf3dab596c6e30ca3c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

