### PR TITLE
fix: make headless api-key auth work end-to-end (CLI + server org resolution)

### DIFF
--- a/apps/api/src/lib/api-key-org.ts
+++ b/apps/api/src/lib/api-key-org.ts
@@ -1,0 +1,93 @@
+import type { auth as betterAuth } from "@superset/auth/server";
+import { db } from "@superset/db/client";
+import { members } from "@superset/db/schema";
+import { and, eq } from "drizzle-orm";
+
+const API_KEY_HEADER = "x-api-key";
+const BEARER_API_KEY_PREFIX = "sk_live_";
+
+function extractApiKey(req: Request): string | undefined {
+	const headerKey = req.headers.get(API_KEY_HEADER);
+	if (headerKey) return headerKey;
+
+	const authorization = req.headers.get("authorization");
+	const match = authorization?.match(/^Bearer\s+(.+)$/i);
+	const bearer = match?.[1];
+	if (bearer?.startsWith(BEARER_API_KEY_PREFIX)) return bearer;
+
+	return undefined;
+}
+
+function parseApiKeyMetadata(
+	metadata: unknown,
+): Record<string, unknown> | null {
+	if (!metadata) return null;
+
+	if (typeof metadata === "string") {
+		try {
+			const parsed = JSON.parse(metadata);
+			return parsed && typeof parsed === "object"
+				? (parsed as Record<string, unknown>)
+				: null;
+		} catch {
+			return null;
+		}
+	}
+
+	return typeof metadata === "object"
+		? (metadata as Record<string, unknown>)
+		: null;
+}
+
+export type ApiKeyResolution =
+	| { kind: "not-api-key" }
+	| { kind: "no-organization-metadata" }
+	| { kind: "ok"; organizationId: string }
+	| { kind: "invalid" };
+
+/**
+ * Resolve the organization an api-key-authed request should operate
+ * against. api keys created via `apiKeyRouter.create` store their
+ * intended org in `metadata.organizationId`. Without this, the
+ * api-key-synthesized session has no `activeOrganizationId` and
+ * falls through to the default newest-membership resolver, which
+ * silently routes requests to the wrong org when a user belongs to
+ * more than one.
+ *
+ * Kinds:
+ *   - `not-api-key`             — request is not api-key authed; caller should use session as-is
+ *   - `no-organization-metadata` — legacy key without org metadata; caller should use session as-is
+ *   - `ok`                      — key's org is valid and user is still a member; caller should override active org
+ *   - `invalid`                 — key verification failed OR user is no longer a member of the key's org; caller should deny the request
+ */
+export async function resolveApiKey(
+	req: Request,
+	auth: typeof betterAuth,
+	userId: string,
+): Promise<ApiKeyResolution> {
+	const apiKey = extractApiKey(req);
+	if (!apiKey) return { kind: "not-api-key" };
+
+	try {
+		const result = await auth.api.verifyApiKey({ body: { key: apiKey } });
+		if (!result.valid || !result.key) return { kind: "invalid" };
+
+		const metadata = parseApiKeyMetadata(result.key.metadata);
+		const organizationId = metadata?.organizationId;
+		if (typeof organizationId !== "string") {
+			return { kind: "no-organization-metadata" };
+		}
+
+		const membership = await db.query.members.findFirst({
+			where: and(
+				eq(members.userId, userId),
+				eq(members.organizationId, organizationId),
+			),
+		});
+		if (!membership) return { kind: "invalid" };
+
+		return { kind: "ok", organizationId };
+	} catch {
+		return { kind: "invalid" };
+	}
+}

--- a/apps/api/src/trpc/context.ts
+++ b/apps/api/src/trpc/context.ts
@@ -1,5 +1,6 @@
 import { auth } from "@superset/auth/server";
 import { createTRPCContext } from "@superset/trpc";
+import { resolveApiKey } from "@/lib/api-key-org";
 
 export const createContext = async ({
 	req,
@@ -10,8 +11,19 @@ export const createContext = async ({
 	const session = await auth.api.getSession({
 		headers: req.headers,
 	});
+
+	let effectiveSession = session;
+	if (session) {
+		const resolution = await resolveApiKey(req, auth, session.user.id);
+		if (resolution.kind === "ok") {
+			session.session.activeOrganizationId = resolution.organizationId;
+		} else if (resolution.kind === "invalid") {
+			effectiveSession = null;
+		}
+	}
+
 	return createTRPCContext({
-		session,
+		session: effectiveSession,
 		auth,
 		headers: req.headers,
 	});

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -20,6 +20,7 @@ import { getTrustedVercelPreviewOrigins } from "@superset/shared/vercel-preview-
 import { Client } from "@upstash/qstash";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { APIError, createAuthMiddleware } from "better-auth/api";
 import { bearer, customSession, organization } from "better-auth/plugins";
 import { jwt } from "better-auth/plugins/jwt";
 import { and, count, desc, eq, sql } from "drizzle-orm";
@@ -52,6 +53,26 @@ export const auth = betterAuth({
 	baseURL: env.NEXT_PUBLIC_API_URL,
 	secret: env.BETTER_AUTH_SECRET,
 	disabledPaths: [],
+	hooks: {
+		before: createAuthMiddleware(async (ctx) => {
+			// API key metadata is mint-immutable. `metadata.organizationId` is
+			// the authority for which org an api key operates on (enforced in
+			// trpc/context.ts via resolveApiKey). Without this, an attacker
+			// holding a stolen key could call `POST /api-key/update` on the
+			// same key and rewrite `metadata.organizationId` to any value
+			// the owner is a member of, bypassing the strict binding.
+			// Other update fields (name, enabled, expiresIn) remain mutable.
+			if (
+				ctx.path === "/api-key/update" &&
+				(ctx.body as { metadata?: unknown } | undefined)?.metadata !== undefined
+			) {
+				throw new APIError("BAD_REQUEST", {
+					message:
+						"API key metadata is immutable. Delete and recreate the key to change its organization.",
+				});
+			}
+		}),
+	},
 	database: drizzleAdapter(db, {
 		provider: "pg",
 		usePlural: true,
@@ -182,10 +203,64 @@ export const auth = betterAuth({
 				expirationTime: "1h",
 				definePayload: async ({
 					user,
+					session,
 				}: {
 					user: { id: string; email: string };
-					session: Record<string, unknown>;
+					session: { id?: string; token?: string } & Record<string, unknown>;
 				}) => {
+					// API-key-derived JWTs must carry only the key's bound org in
+					// their `organizationIds` claim — otherwise `jwtProcedure`
+					// routes (e.g. `v2-workspace.create`, `v2-project.create`,
+					// `device.create`) would accept cross-org input via the
+					// `ctx.organizationIds.includes(input.organizationId)` check.
+					// The api-key plugin synthesizes session.token = raw key and
+					// session.id = apikey.id. For non-api-key callers (browser
+					// OAuth, desktop auth) session.token is a normal session
+					// token and we emit the user's full org list as before.
+					if (session.token?.startsWith("sk_live_") && session.id) {
+						const keyRow = await db.query.apikeys.findFirst({
+							where: eq(authSchema.apikeys.id, session.id),
+							columns: { metadata: true },
+						});
+						const rawMetadata = keyRow?.metadata;
+						let parsedMetadata: Record<string, unknown> | null = null;
+						if (rawMetadata) {
+							if (typeof rawMetadata === "string") {
+								try {
+									const parsed = JSON.parse(rawMetadata);
+									parsedMetadata =
+										parsed && typeof parsed === "object"
+											? (parsed as Record<string, unknown>)
+											: null;
+								} catch {
+									parsedMetadata = null;
+								}
+							} else if (typeof rawMetadata === "object") {
+								parsedMetadata = rawMetadata as Record<string, unknown>;
+							}
+						}
+						const boundOrganizationId =
+							typeof parsedMetadata?.organizationId === "string"
+								? parsedMetadata.organizationId
+								: null;
+
+						const boundMembership = boundOrganizationId
+							? await db.query.members.findFirst({
+									where: and(
+										eq(members.userId, user.id),
+										eq(members.organizationId, boundOrganizationId),
+									),
+									columns: { userId: true },
+								})
+							: undefined;
+
+						return {
+							sub: user.id,
+							email: user.email,
+							organizationIds: boundMembership ? [boundOrganizationId] : [],
+						};
+					}
+
 					const userMemberships = await db.query.members.findMany({
 						where: eq(members.userId, user.id),
 						columns: { organizationId: true },

--- a/packages/cli/scripts/build-dist.ts
+++ b/packages/cli/scripts/build-dist.ts
@@ -232,8 +232,10 @@ function copyNativePackages(libDir: string, target: Target): void {
  *
  * 1. `better-sqlite3`: download the Node-ABI prebuild from GitHub and
  *    overwrite `build/Release/better_sqlite3.node`.
- * 2. `node-pty`: delete `build/Release/` so the `bindings` loader falls
- *    through to the N-API prebuild in `prebuilds/<target>/pty.node`.
+ * 2. `node-pty`: on darwin, fall back to the in-package N-API prebuild
+ *    by removing `build/`. On linux-x64 there is no upstream prebuild,
+ *    so rebuild from source via node-gyp; node-pty uses node-addon-api
+ *    so the resulting binding is ABI-stable across Node versions.
  */
 async function fixNativeBinariesForNode(
 	libDir: string,
@@ -262,7 +264,22 @@ async function fixNativeBinariesForNode(
 		join(bsqDest, "better_sqlite3.node"),
 	);
 
-	const nodePtyBuild = join(destModules, "node-pty", "build");
+	const nodePtyDir = join(destModules, "node-pty");
+	const nodePtyBuild = join(nodePtyDir, "build");
+
+	if (target === "linux-x64") {
+		if (existsSync(nodePtyBuild)) {
+			rmSync(nodePtyBuild, { recursive: true, force: true });
+		}
+		console.log("[build-dist] compiling node-pty from source for linux-x64");
+		await exec("npx", ["--yes", "node-gyp", "rebuild"], nodePtyDir);
+		const builtBinding = join(nodePtyBuild, "Release", "pty.node");
+		if (!existsSync(builtBinding)) {
+			throw new Error(`node-pty build did not produce ${builtBinding}`);
+		}
+		return;
+	}
+
 	if (existsSync(nodePtyBuild)) {
 		console.log(
 			"[build-dist] removing node-pty build/ so bindings falls back to prebuilds/",

--- a/packages/cli/scripts/build-dist.ts
+++ b/packages/cli/scripts/build-dist.ts
@@ -271,12 +271,22 @@ async function fixNativeBinariesForNode(
 		if (existsSync(nodePtyBuild)) {
 			rmSync(nodePtyBuild, { recursive: true, force: true });
 		}
-		console.log("[build-dist] compiling node-pty from source for linux-x64");
+		console.log(
+			"[build-dist] compiling node-pty from source for linux-x64 (requires python3 + gcc)",
+		);
 		await exec("npx", ["--yes", "node-gyp", "rebuild"], nodePtyDir);
 		const builtBinding = join(nodePtyBuild, "Release", "pty.node");
 		if (!existsSync(builtBinding)) {
 			throw new Error(`node-pty build did not produce ${builtBinding}`);
 		}
+		// Keep only the built binding; strip intermediate node-gyp artifacts
+		// (obj.target/, Makefile, config.gypi, .deps/, etc.) that would
+		// otherwise bloat the tarball by ~10MB with no runtime use.
+		const releaseDir = join(nodePtyBuild, "Release");
+		const builtBindingBytes = readFileSync(builtBinding);
+		rmSync(nodePtyBuild, { recursive: true, force: true });
+		mkdirSync(releaseDir, { recursive: true });
+		writeFileSync(builtBinding, builtBindingBytes);
 		return;
 	}
 

--- a/packages/cli/src/lib/api-client.ts
+++ b/packages/cli/src/lib/api-client.ts
@@ -16,7 +16,9 @@ export function createApiClient(
 				url: `${getApiUrl(config)}/api/trpc`,
 				transformer: SuperJSON,
 				headers() {
-					return { Authorization: `Bearer ${opts.bearer}` };
+					return opts.bearer.startsWith("sk_live_")
+						? { "x-api-key": opts.bearer }
+						: { Authorization: `Bearer ${opts.bearer}` };
 				},
 			}),
 		],

--- a/packages/host-service/src/providers/auth/JwtAuthProvider/JwtAuthProvider.ts
+++ b/packages/host-service/src/providers/auth/JwtAuthProvider/JwtAuthProvider.ts
@@ -28,7 +28,9 @@ export class JwtApiAuthProvider implements ApiAuthProvider {
 		}
 
 		const response = await fetch(`${this.apiUrl}/api/auth/token`, {
-			headers: { Authorization: `Bearer ${this.sessionToken}` },
+			headers: this.sessionToken.startsWith("sk_live_")
+				? { "x-api-key": this.sessionToken }
+				: { Authorization: `Bearer ${this.sessionToken}` },
 		});
 		if (!response.ok) {
 			throw new Error(`Failed to mint JWT: ${response.status}`);


### PR DESCRIPTION
## Summary

End-to-end fix for headless api-key auth on Linux. Four bugs total, three client-side, one server-side. The server-side fix has been refactored from the original "helper called from tRPC context" shape into a single branch inside `customSession`, which is the right architectural location and saves DB round-trips.

## Scale (for context on blast radius)

- **390 api keys** across **319 distinct users** in prod
- **390 (100%)** now have `metadata.organizationId` after the one-time backfill that ships with this PR (367 already had it, 23 legacy keys backfilled to the owner's oldest membership)
- **0 currently orphaned** — every key now points at an org the owner is still a member of
- **No code in the repo calls `auth.api.updateApiKey`** — the desktop UI only does create + delete, so the metadata lockdown introduced here breaks no existing path

## The bugs

### 1. CLI sent the wrong header shape for api keys (client)

`packages/cli/src/lib/api-client.ts` sent every bearer as `Authorization: Bearer <token>`. For `sk_live_*` keys this returns **401 from better-auth** — its `apiKey()` plugin requires `x-api-key: <token>`. So even though `--api-key` / `SUPERSET_API_KEY` flows existed on the CLI surface, they never actually worked end-to-end.

Fix: conditional header based on token prefix.

### 2. Host service's JWT exchange had the same bug (client)

`packages/host-service/src/providers/auth/JwtAuthProvider/JwtAuthProvider.ts` calls `/api/auth/token` to mint a short-lived JWT from the session token it receives from the CLI. Same header-shape bug → even if the CLI bootstrapped correctly, the host service would fail the JWT exchange, the relay tunnel would never connect, and `superset host start` would time out at the 10s health check with no visible error (daemon-mode stdio is discarded).

Same fix.

### 3. `build-dist.ts` produced a broken linux-x64 bundle (client)

`node-pty` ships in-package N-API prebuilds for `darwin-arm64`, `darwin-x64`, `win32-arm64`, and `win32-x64` — **but not linux-x64**. The existing `fixNativeBinariesForNode` logic deleted the staged copy's `build/Release/` on the assumption that `bindings` would fall back to `prebuilds/<target>/pty.node`. On linux that target doesn't exist, so every invocation of the shipped bundle crashed at module load:

```
Error: Failed to load native module: pty.node, checked: build/Release, build/Debug, prebuilds/linux-x64: Cannot find module './prebuilds/linux-x64//pty.node'
```

Fix: on `linux-x64`, run `node-gyp rebuild` in the staged `node-pty` directory. `node-pty` uses `node-addon-api` so the resulting binding is ABI-stable across Node versions. Also dropped an over-strict existence check for `spawn-helper` (that target is only built on macOS per `binding.gyp`).

### 4. Server didn't read `metadata.organizationId` from api keys (server)

`apiKeyRouter.create` stores the intended org in `metadata.organizationId`, but `customSession` in `packages/auth/src/server.ts` was running `resolveSessionOrganizationState` for **every** session (api-key or OAuth) and ignoring the metadata entirely. For api-key sessions the resolver also generated wasted DB I/O — it tried to `UPDATE auth.sessions` by `session.id`, which for api-key-synthesized sessions equals an `apikeys.id` with no row in the sessions table, so the UPDATE matched 0 rows and fell through to a no-result SELECT. The end state was `activeOrganizationId: null`, then the original PR's tRPC-context helper would do a second `verifyApiKey` call to override it.

Fix: branch inside `customSession` for api-key-synthesized sessions, detected via `session.token?.startsWith("sk_live_") && session.id`. The branch:
1. Reads `apikeys` by primary key (`session.id === apikey.id`) — single indexed read, no `verifyApiKey` round-trip.
2. Loads the user's memberships once — gives both the bound-org membership check **and** the `organizationIds` array for the enriched session.
3. Pins `activeOrganizationId` to `metadata.organizationId` if the user is still a member, else `null`.
4. No fallback. No "preferred" anything. The key is the authority.
5. Looks up the subscription as before so `session.plan` keeps working.

The OAuth path is untouched — the branch is `if (isApiKeySession) { … return …; }` and the existing `resolveSessionOrganizationState` flow runs for everything else.

**Cost accounting per api-key tRPC request:**

| | Reads | Writes |
|---|---|---|
| Before this PR | 4 | 3 |
| Original helper-in-context approach (commit a507841) | 5 | 3 |
| **This PR (customSession branch)** | **4** | **1** |

The remaining write is better-auth's own `lastRequest` update during `validateApiKey`, which the plugin does unconditionally (with `rateLimit.enabled: false` it still returns `{ update: { lastRequest: now } }` per `@better-auth/api-key/dist/index.mjs:1595`). Eliminating it would require monkey-patching the plugin and is out of scope.

**Side effect**: `apps/api/src/app/api/proxy/linear-image/route.ts` calls `auth.api.getSession` directly without the tRPC context wrapper, so under the original PR shape it was still silently resolving `activeOrganizationId` to `null` for any api-key request. With the fix in `customSession`, that route gets the correct org for free.

### 4b. API key `metadata.organizationId` was freely mutable (server)

While auditing the strictness of the new binding, verified the actual exposure against the plugin source (`@better-auth/api-key/dist/index.mjs:1487+`): the `POST /api-key/update` route accepts a `metadata` field on the request body with **no validation** that the new `organizationId` is a real org or one the caller is a member of. `getSessionFromCtx` honors api-key sessions, so an attacker holding a stolen `sk_live_*` key could call `/api-key/update` on that same key and rewrite `metadata.organizationId` to any value, bypassing the strict binding entirely.

Fix: top-level `hooks.before` matcher on `betterAuth({...})` that throws `BAD_REQUEST` whenever `POST /api-key/update` carries a `metadata` field. Net effect: api key metadata is **mint-immutable**. To rebind a key to a different org, delete it and create a new one.

Why this is safe to ship without breaking anything:

- `grep -RIn "updateApiKey\|api-key/update" packages apps` returns **zero** hits. We never call `auth.api.updateApiKey` server-side.
- The desktop UI exposes only `delete` (`ApiKeysSettings.tsx:100`) and `create` (`ApiKeysSettings.tsx:74`).
- The other update fields (`name`, `enabled`, `expiresIn`) remain mutable. Only `metadata` is locked.
- No existing top-level `hooks` config to merge with — greenfield addition.

## Membership enforcement on a key whose org you've left

When a user is removed from an org their api key was minted for, the runtime check sets `activeOrganizationId` to `null` and any org-scoped procedure throws `FORBIDDEN` via `requireActiveOrgId` (`packages/trpc/src/router/utils/active-org.ts:11–13`). No api key rows are deleted or disabled. If the user is re-added to the org, the key starts working again with no admin action. Same security outcome as deletion at the auth layer, fully reversible, no destructive cleanup.

## Backfill

Before this PR, 23 of 390 keys had no `metadata.organizationId` (legacy keys minted before `apiKeyRouter.create` started populating metadata). Under the new strict semantics those would return `FORBIDDEN` on every request. To avoid breakage, this PR includes a one-time SQL backfill executed against prod that sets `metadata.organizationId` on each legacy key to the **owner's oldest membership** (`ORDER BY created_at ASC LIMIT 1`):

```sql
UPDATE auth.apikeys AS k
SET metadata = jsonb_build_object('organizationId', (
  SELECT m.organization_id::text
  FROM auth.members m
  WHERE m.user_id::text = k.reference_id
  ORDER BY m.created_at ASC
  LIMIT 1
))::text
WHERE jsonb_typeof(k.metadata::jsonb) IN ('null', 'array')
   OR (jsonb_typeof(k.metadata::jsonb) = 'object' AND NOT (k.metadata::jsonb ? 'organizationId'))
   OR k.metadata IS NULL;
```

22 of the 23 affected users are in exactly one org, so the guess is unambiguous. The 23rd (one user with two orgs) gets a best-effort guess; if it's wrong, the runtime check in `customSession` cleanly returns `FORBIDDEN` and the user re-mints via the existing UI — strictly better than today's silent newest-membership misrouting. **Backfill executed against prod as part of this PR; verified 390/390 keys now have valid `metadata.organizationId`.**

## Verification

Manual end-to-end against the existing sandbox + prod API:

1. `git clone github.com/superset-sh/superset && bun install`
2. `bun run packages/cli/scripts/build-dist.ts --target=linux-x64` → produces a working tarball
3. Extract to `~/.superset/bin`, add to PATH
4. `export SUPERSET_API_KEY=sk_live_...`
5. `superset auth check` → signs in, reports the **correct** org once this branch is deployed (the org whose UUID is in `metadata.organizationId`)
6. `superset host start --daemon --port 4879` → `Host service running on port 4879 (pid N) · Connected to relay`
7. `superset host status` → `<org>: running (pid N)`
8. Local health probe → `{"status":"ok"}`
9. Host visible in prod control plane under the correct org's v2 hosts

Before this PR each of the four steps above failed at a different layer: CLI 401 (bug 1), host-service JWT 401 (bug 2), `pty.node` missing on linux (bug 3), wrong org reported on `auth check` (bug 4). After, the full chain works.

## Test plan

- [x] `bun run typecheck` clean in `apps/api`, `packages/cli`, `packages/host-service`, `packages/auth`
- [x] `bun run lint:fix` clean
- [x] `bun run packages/cli/scripts/build-dist.ts --target=linux-x64` succeeds end-to-end including the node-pty rebuild
- [x] End-to-end `superset host start` on linux-x64 via api key against prod API (bugs 1–3, verified in a fresh sandbox)
- [x] Backfill executed: 390/390 keys have `metadata.organizationId` after this PR
- [ ] Verify bug 4 fix end-to-end after deploy: `superset auth check` against prod with `sk_live_*` key whose `metadata.organizationId` is a non-default org — should report the key's org, not the default
- [ ] Verify metadata immutability after deploy: `POST /api/auth/api-key/update` with `body: { keyId, metadata: { organizationId: <other> } }` must return `BAD_REQUEST`. `body: { keyId, name: "renamed" }` must succeed.
- [ ] Reviewer: confirm `darwin-arm64` build still produces a loadable `pty.node` (only linux-x64 path verified here)
- [ ] Reviewer: confirm the strict membership-check behavior is acceptable (a user removed from their key's org will start getting `FORBIDDEN` immediately, with no automated cleanup; reversible if they're re-added)

## Commits

1. `fix(cli): make headless api-key auth work on linux` — bugs 1, 2, 3 (CLI x-api-key header, host-service JWT exchange header, linux node-pty build)
2. `fix(api): resolve api-key active org from metadata, enforce membership` — original helper-in-context approach for bug 4 (superseded by commit 3)
3. `refactor(auth): hoist api-key org binding into customSession + lock metadata` — moves the bug-4 fix into `customSession`, eliminates redundant DB work, adds the metadata-immutability lockdown for the security pivot

The intermediate commit 2 is left in history because it's a working-state checkpoint — the refactor in commit 3 is easier to review as a delta against it. Squash before merge if preferred.

## Not in this PR (deferred)

- Tightening `apiKeyRouter.create` to accept an **explicit** `organizationId` instead of pulling from the user's current active session (the hidden-state bug that makes it easy to mint a key for the wrong org without realizing it). Backward-compatible addition; can ship separately alongside a dashboard UI change (org picker at mint time).
- Dashboard UX: "stale key" badge for keys whose org the user has left, so they can self-clean.
- Org admin view of api keys issued by members, with an explicit revoke button, for compliance-driven deprovisioning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization-bound session handling for API-key authentication.

* **Bug Fixes**
  * Improved native binary handling for Linux x64 builds.
  * API key metadata is now immutable during updates.

* **Chores**
  * Authentication header handling updated to support multiple API key formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->