### PR TITLE
feat(desktop): polish v2 sidebar — minimal layout + colored PR state icons

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
@@ -134,7 +134,7 @@ export function DashboardSidebar({
 		<div className="flex h-full flex-col border-r border-border bg-muted/45 dark:bg-muted/35">
 			<DashboardSidebarHeader isCollapsed={isCollapsed} />
 
-			<div className="flex-1 overflow-y-auto hide-scrollbar">
+			<div className="flex flex-1 flex-col gap-3 overflow-y-auto hide-scrollbar pt-3">
 				<DndContext
 					sensors={sensors}
 					collisionDetection={closestCenter}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/DashboardSidebarProjectSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/DashboardSidebarProjectSection.tsx
@@ -2,7 +2,6 @@ import type {
 	DraggableAttributes,
 	DraggableSyntheticListeners,
 } from "@dnd-kit/core";
-import { cn } from "@superset/ui/utils";
 import { AnimatePresence, motion } from "framer-motion";
 import { useMemo } from "react";
 import type { DashboardSidebarProject } from "../../types";
@@ -69,7 +68,7 @@ export function DashboardSidebarProjectSection({
 				onRemoveFromSidebar={confirmRemoveFromSidebar}
 				onRename={startRename}
 			>
-				<div className={cn("border-b border-border last:border-b-0")}>
+				<div>
 					<DashboardSidebarCollapsedProjectContent
 						projectName={project.name}
 						githubOwner={project.githubOwner}
@@ -86,7 +85,7 @@ export function DashboardSidebarProjectSection({
 	}
 
 	return (
-		<div className={cn("border-b border-border last:border-b-0")}>
+		<div>
 			<DashboardSidebarProjectContextMenu
 				onCreateSection={handleNewSection}
 				onOpenInFinder={handleOpenInFinder}
@@ -97,6 +96,7 @@ export function DashboardSidebarProjectSection({
 				<DashboardSidebarProjectRow
 					projectName={project.name}
 					githubOwner={project.githubOwner}
+					githubRepoName={project.githubRepoName}
 					totalWorkspaceCount={totalWorkspaceCount}
 					isCollapsed={project.isCollapsed}
 					isRenaming={isRenaming}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
@@ -60,7 +60,7 @@ export function DashboardSidebarExpandedProjectContent({
 					transition={{ duration: 0.15, ease: "easeOut" }}
 					className="overflow-hidden"
 				>
-					<div className="pb-1">
+					<div>
 						<DndContext
 							sensors={sensors}
 							collisionDetection={collisionDetection}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarProjectRow/DashboardSidebarProjectRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarProjectRow/DashboardSidebarProjectRow.tsx
@@ -2,13 +2,13 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { type ComponentPropsWithoutRef, forwardRef } from "react";
 import { HiChevronRight, HiMiniPlus } from "react-icons/hi2";
-import { ProjectThumbnail } from "renderer/routes/_authenticated/components/ProjectThumbnail";
 import { RenameInput } from "renderer/screens/main/components/WorkspaceSidebar/RenameInput";
 
 interface DashboardSidebarProjectRowProps
 	extends ComponentPropsWithoutRef<"div"> {
 	projectName: string;
 	githubOwner: string | null;
+	githubRepoName?: string | null;
 	totalWorkspaceCount: number;
 	isCollapsed: boolean;
 	isRenaming: boolean;
@@ -29,6 +29,7 @@ export const DashboardSidebarProjectRow = forwardRef<
 		{
 			projectName,
 			githubOwner,
+			githubRepoName,
 			totalWorkspaceCount,
 			isCollapsed,
 			isRenaming,
@@ -63,42 +64,45 @@ export const DashboardSidebarProjectRow = forwardRef<
 							}
 				}
 				className={cn(
-					"group flex min-h-10 w-full items-center pl-3 pr-2 py-1.5 text-sm font-medium",
-					"hover:bg-muted/50 transition-colors",
+					"group relative flex h-7 w-full items-center pl-4 pr-2 transition-colors",
 					className,
 				)}
 				{...props}
 			>
-				<div className="flex min-w-0 flex-1 items-center gap-2 py-0.5">
-					<div className="relative shrink-0 size-5 flex items-center justify-center">
-						<span className="group-hover:opacity-0 transition-opacity duration-150">
-							<ProjectThumbnail
-								projectName={projectName}
-								githubOwner={githubOwner}
-								className="size-4"
-							/>
-						</span>
-						<HiChevronRight
-							className={cn(
-								"absolute inset-0 m-auto size-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-all duration-150",
-								!isCollapsed && "rotate-90",
-							)}
-						/>
-					</div>
+				<HiChevronRight
+					className={cn(
+						"absolute left-0.5 top-1/2 size-3 -translate-y-1/2 text-muted-foreground/60 opacity-0 transition-all duration-150 group-hover:opacity-100",
+						!isCollapsed && "rotate-90",
+					)}
+				/>
+				<div className="flex min-w-0 flex-1 items-center gap-2">
 					{isRenaming ? (
 						<RenameInput
 							value={renameValue}
 							onChange={onRenameValueChange}
 							onSubmit={onSubmitRename}
 							onCancel={onCancelRename}
-							className="-ml-1 h-6 min-w-0 flex-1 bg-transparent border-none px-1 py-0 text-sm font-medium outline-none"
+							className="h-5 min-w-0 flex-1 bg-transparent border-none px-0 py-0 text-[14px] font-normal tracking-normal outline-none"
 						/>
 					) : (
-						<span className="truncate">{projectName}</span>
+						<span className="truncate text-[14px] font-normal lowercase tracking-normal">
+							{githubOwner ? (
+								<>
+									<span className="text-muted-foreground/60">
+										{githubOwner}/
+									</span>
+									<span className="text-foreground/80">
+										{githubRepoName ?? projectName.toLowerCase()}
+									</span>
+								</>
+							) : (
+								<span className="text-foreground/80">{projectName}</span>
+							)}
+						</span>
 					)}
 					{!isRenaming && (
-						<span className="shrink-0 text-xs font-normal tabular-nums text-muted-foreground">
-							({totalWorkspaceCount})
+						<span className="shrink-0 text-[10px] font-normal tabular-nums text-muted-foreground/40 transition-opacity group-hover:opacity-0">
+							{totalWorkspaceCount}
 						</span>
 					)}
 				</div>
@@ -112,9 +116,9 @@ export const DashboardSidebarProjectRow = forwardRef<
 								onNewWorkspace();
 							}}
 							onContextMenu={(event) => event.stopPropagation()}
-							className="p-1 rounded hover:bg-muted transition-colors shrink-0 ml-1"
+							className="ml-1 shrink-0 rounded p-0.5 text-muted-foreground/60 opacity-0 transition hover:bg-muted hover:text-foreground group-hover:opacity-100"
 						>
-							<HiMiniPlus className="size-4 text-muted-foreground" />
+							<HiMiniPlus className="size-3.5" />
 						</button>
 					</TooltipTrigger>
 					<TooltipContent side="bottom" sideOffset={4}>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarProjectRow/DashboardSidebarProjectRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarProjectRow/DashboardSidebarProjectRow.tsx
@@ -116,7 +116,8 @@ export const DashboardSidebarProjectRow = forwardRef<
 								onNewWorkspace();
 							}}
 							onContextMenu={(event) => event.stopPropagation()}
-							className="ml-1 shrink-0 rounded p-0.5 text-muted-foreground/60 opacity-0 transition hover:bg-muted hover:text-foreground group-hover:opacity-100"
+							aria-label="New workspace"
+							className="ml-1 shrink-0 rounded p-0.5 text-muted-foreground/60 opacity-0 transition hover:bg-muted hover:text-foreground group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 						>
 							<HiMiniPlus className="size-3.5" />
 						</button>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarProjectRow/DashboardSidebarProjectRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarProjectRow/DashboardSidebarProjectRow.tsx
@@ -92,7 +92,7 @@ export const DashboardSidebarProjectRow = forwardRef<
 										{githubOwner}/
 									</span>
 									<span className="text-foreground/80">
-										{githubRepoName ?? projectName.toLowerCase()}
+										{githubRepoName ?? projectName}
 									</span>
 								</>
 							) : (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -118,22 +118,55 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 
 				<Tooltip delayDuration={500}>
 					<TooltipTrigger asChild>
-						<div className="relative mr-2.5 flex size-5 shrink-0 items-center justify-center">
-							<DashboardSidebarWorkspaceIcon
-								hostType={hostType}
-								isActive={isActive}
-								variant="expanded"
-								workspaceStatus={null}
-								creationStatus={creationStatus}
-								pullRequest={pullRequest}
-							/>
-						</div>
+						{pullRequest ? (
+							<a
+								href={pullRequest.url}
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={(event) => event.stopPropagation()}
+								aria-label={`Open pull request #${pullRequest.number}`}
+								className="relative mr-2.5 flex size-5 shrink-0 items-center justify-center rounded transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+							>
+								<DashboardSidebarWorkspaceIcon
+									hostType={hostType}
+									isActive={isActive}
+									variant="expanded"
+									workspaceStatus={null}
+									creationStatus={creationStatus}
+									pullRequest={pullRequest}
+								/>
+							</a>
+						) : (
+							<div className="relative mr-2.5 flex size-5 shrink-0 items-center justify-center">
+								<DashboardSidebarWorkspaceIcon
+									hostType={hostType}
+									isActive={isActive}
+									variant="expanded"
+									workspaceStatus={null}
+									creationStatus={creationStatus}
+									pullRequest={pullRequest}
+								/>
+							</div>
+						)}
 					</TooltipTrigger>
 					<TooltipContent side="right" sideOffset={8}>
-						<p className="text-xs font-medium">Worktree workspace</p>
-						<p className="text-xs text-muted-foreground">
-							Isolated copy for parallel development
-						</p>
+						{pullRequest ? (
+							<>
+								<p className="text-xs font-medium">
+									#{pullRequest.number} · {pullRequest.state}
+								</p>
+								<p className="text-xs text-muted-foreground">
+									{pullRequest.title}
+								</p>
+							</>
+						) : (
+							<>
+								<p className="text-xs font-medium">Worktree workspace</p>
+								<p className="text-xs text-muted-foreground">
+									Isolated copy for parallel development
+								</p>
+							</>
+						)}
 					</TooltipContent>
 				</Tooltip>
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -15,7 +15,6 @@ import type { DashboardSidebarWorkspace } from "../../../../types";
 import { getCreationStatusText } from "../../utils/getCreationStatusText";
 import { DashboardSidebarWorkspaceDiffStats } from "../DashboardSidebarWorkspaceDiffStats";
 import { DashboardSidebarWorkspaceIcon } from "../DashboardSidebarWorkspaceIcon";
-import { DashboardSidebarWorkspaceStatusBadge } from "../DashboardSidebarWorkspaceStatusBadge";
 
 interface DashboardSidebarExpandedWorkspaceRowProps
 	extends ComponentPropsWithoutRef<"div"> {
@@ -101,10 +100,10 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 				}}
 				onDoubleClick={onDoubleClick}
 				className={cn(
-					"relative flex w-full items-center pl-3 pr-2 text-left text-sm",
+					"relative flex w-full items-center pl-6 pr-2 text-left text-sm",
 					onClick && "cursor-pointer hover:bg-muted/50",
 					"group",
-					"py-1.5",
+					"py-1",
 					isActive && "bg-muted",
 					className,
 				)}
@@ -126,6 +125,7 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 								variant="expanded"
 								workspaceStatus={null}
 								creationStatus={creationStatus}
+								pullRequest={pullRequest}
 							/>
 						</div>
 					</TooltipTrigger>
@@ -138,7 +138,7 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 				</Tooltip>
 
 				<div className="flex min-w-0 flex-1 flex-col justify-center">
-					<div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] grid-rows-2 items-center gap-x-1.5 gap-y-0.5">
+					<div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-1.5">
 						{isRenaming ? (
 							<RenameInput
 								value={renameValue}
@@ -214,18 +214,7 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 							)}
 						</div>
 
-						<span className="col-start-1 row-start-2 truncate font-mono text-[11px] leading-tight text-muted-foreground/60">
-							{branch}
-						</span>
-
-						{pullRequest && (
-							<DashboardSidebarWorkspaceStatusBadge
-								state={pullRequest.state}
-								prNumber={pullRequest.number}
-								prUrl={pullRequest.url}
-								className="col-start-2 row-start-2 justify-self-end"
-							/>
-						)}
+						{/* branch + PR badge hidden — PR state shown via colored icon on the left */}
 					</div>
 				</div>
 			</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/DashboardSidebarWorkspaceIcon.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/DashboardSidebarWorkspaceIcon.tsx
@@ -2,13 +2,13 @@ import { cn } from "@superset/ui/utils";
 import { CircleDot } from "lucide-react";
 import { HiExclamationTriangle } from "react-icons/hi2";
 import { LuCloud, LuLaptop } from "react-icons/lu";
-import { AsciiSpinner } from "renderer/screens/main/components/AsciiSpinner";
-import { StatusIndicator } from "renderer/screens/main/components/StatusIndicator";
-import type { ActivePaneStatus } from "shared/tabs-types";
 import type {
 	DashboardSidebarWorkspaceHostType,
 	DashboardSidebarWorkspacePullRequest,
-} from "../../../../types";
+} from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/types";
+import { AsciiSpinner } from "renderer/screens/main/components/AsciiSpinner";
+import { StatusIndicator } from "renderer/screens/main/components/StatusIndicator";
+import type { ActivePaneStatus } from "shared/tabs-types";
 import { PullRequestStatusIcon } from "./components/PullRequestStatusIcon";
 
 interface DashboardSidebarWorkspaceIconProps {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/DashboardSidebarWorkspaceIcon.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/DashboardSidebarWorkspaceIcon.tsx
@@ -1,10 +1,20 @@
 import { cn } from "@superset/ui/utils";
+import {
+	CircleDot,
+	GitMerge,
+	GitPullRequest,
+	GitPullRequestClosed,
+	GitPullRequestDraft,
+} from "lucide-react";
 import { HiExclamationTriangle } from "react-icons/hi2";
-import { LuCloud, LuFolderGit2, LuLaptop } from "react-icons/lu";
+import { LuCloud, LuLaptop } from "react-icons/lu";
 import { AsciiSpinner } from "renderer/screens/main/components/AsciiSpinner";
 import { StatusIndicator } from "renderer/screens/main/components/StatusIndicator";
 import type { ActivePaneStatus } from "shared/tabs-types";
-import type { DashboardSidebarWorkspaceHostType } from "../../../../types";
+import type {
+	DashboardSidebarWorkspaceHostType,
+	DashboardSidebarWorkspacePullRequest,
+} from "../../../../types";
 
 interface DashboardSidebarWorkspaceIconProps {
 	hostType: DashboardSidebarWorkspaceHostType;
@@ -12,6 +22,7 @@ interface DashboardSidebarWorkspaceIconProps {
 	variant: "collapsed" | "expanded";
 	workspaceStatus?: ActivePaneStatus | null;
 	creationStatus?: "preparing" | "generating-branch" | "creating" | "failed";
+	pullRequest?: DashboardSidebarWorkspacePullRequest | null;
 }
 
 const OVERLAY_POSITION = {
@@ -19,12 +30,58 @@ const OVERLAY_POSITION = {
 	expanded: "-top-0.5 -right-0.5",
 } as const;
 
+function PullRequestStatusIcon({
+	pr,
+}: {
+	pr: DashboardSidebarWorkspacePullRequest;
+}) {
+	const className = "size-3.5";
+	const strokeWidth = 1.75;
+	if (pr.state === "merged") {
+		return (
+			<GitMerge
+				className={cn(className, "text-violet-400/80")}
+				strokeWidth={strokeWidth}
+			/>
+		);
+	}
+	if (pr.state === "closed") {
+		return (
+			<GitPullRequestClosed
+				className={cn(className, "text-rose-400/70")}
+				strokeWidth={strokeWidth}
+			/>
+		);
+	}
+	if (pr.state === "draft") {
+		return (
+			<GitPullRequestDraft
+				className={cn(className, "text-muted-foreground/70")}
+				strokeWidth={strokeWidth}
+			/>
+		);
+	}
+	const openColor =
+		pr.reviewDecision === "approved"
+			? "text-emerald-400/80"
+			: pr.reviewDecision === "changes_requested"
+				? "text-amber-400/80"
+				: "text-emerald-400/70";
+	return (
+		<GitPullRequest
+			className={cn(className, openColor)}
+			strokeWidth={strokeWidth}
+		/>
+	);
+}
+
 export function DashboardSidebarWorkspaceIcon({
 	hostType,
 	isActive,
 	variant,
 	workspaceStatus = null,
 	creationStatus,
+	pullRequest = null,
 }: DashboardSidebarWorkspaceIconProps) {
 	const overlayPosition = OVERLAY_POSITION[variant];
 
@@ -34,11 +91,12 @@ export function DashboardSidebarWorkspaceIcon({
 				<HiExclamationTriangle className="size-4 text-destructive" />
 			) : creationStatus || workspaceStatus === "working" ? (
 				<AsciiSpinner className="text-base" />
+			) : pullRequest ? (
+				<PullRequestStatusIcon pr={pullRequest} />
 			) : hostType === "cloud" ? (
 				<LuCloud
 					className={cn(
 						"size-4 transition-colors",
-						variant === "expanded" && "transition-colors",
 						isActive ? "text-foreground" : "text-muted-foreground",
 					)}
 					strokeWidth={1.75}
@@ -47,17 +105,15 @@ export function DashboardSidebarWorkspaceIcon({
 				<LuLaptop
 					className={cn(
 						"size-4 transition-colors",
-						variant === "expanded" && "transition-colors",
 						isActive ? "text-foreground" : "text-muted-foreground",
 					)}
 					strokeWidth={1.75}
 				/>
 			) : (
-				<LuFolderGit2
+				<CircleDot
 					className={cn(
 						"size-4 transition-colors",
-						variant === "expanded" && "transition-colors",
-						isActive ? "text-foreground" : "text-muted-foreground",
+						isActive ? "text-foreground" : "text-muted-foreground/60",
 					)}
 					strokeWidth={1.75}
 				/>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/DashboardSidebarWorkspaceIcon.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/DashboardSidebarWorkspaceIcon.tsx
@@ -1,11 +1,5 @@
 import { cn } from "@superset/ui/utils";
-import {
-	CircleDot,
-	GitMerge,
-	GitPullRequest,
-	GitPullRequestClosed,
-	GitPullRequestDraft,
-} from "lucide-react";
+import { CircleDot } from "lucide-react";
 import { HiExclamationTriangle } from "react-icons/hi2";
 import { LuCloud, LuLaptop } from "react-icons/lu";
 import { AsciiSpinner } from "renderer/screens/main/components/AsciiSpinner";
@@ -15,6 +9,7 @@ import type {
 	DashboardSidebarWorkspaceHostType,
 	DashboardSidebarWorkspacePullRequest,
 } from "../../../../types";
+import { PullRequestStatusIcon } from "./components/PullRequestStatusIcon";
 
 interface DashboardSidebarWorkspaceIconProps {
 	hostType: DashboardSidebarWorkspaceHostType;
@@ -29,51 +24,6 @@ const OVERLAY_POSITION = {
 	collapsed: "top-1 right-1",
 	expanded: "-top-0.5 -right-0.5",
 } as const;
-
-function PullRequestStatusIcon({
-	pr,
-}: {
-	pr: DashboardSidebarWorkspacePullRequest;
-}) {
-	const className = "size-4";
-	const strokeWidth = 1.75;
-	if (pr.state === "merged") {
-		return (
-			<GitMerge
-				className={cn(className, "text-violet-400/80")}
-				strokeWidth={strokeWidth}
-			/>
-		);
-	}
-	if (pr.state === "closed") {
-		return (
-			<GitPullRequestClosed
-				className={cn(className, "text-rose-400/70")}
-				strokeWidth={strokeWidth}
-			/>
-		);
-	}
-	if (pr.state === "draft") {
-		return (
-			<GitPullRequestDraft
-				className={cn(className, "text-muted-foreground/70")}
-				strokeWidth={strokeWidth}
-			/>
-		);
-	}
-	const openColor =
-		pr.reviewDecision === "approved"
-			? "text-emerald-400/80"
-			: pr.reviewDecision === "changes_requested"
-				? "text-amber-400/80"
-				: "text-emerald-400/70";
-	return (
-		<GitPullRequest
-			className={cn(className, openColor)}
-			strokeWidth={strokeWidth}
-		/>
-	);
-}
 
 export function DashboardSidebarWorkspaceIcon({
 	hostType,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/DashboardSidebarWorkspaceIcon.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/DashboardSidebarWorkspaceIcon.tsx
@@ -35,7 +35,7 @@ function PullRequestStatusIcon({
 }: {
 	pr: DashboardSidebarWorkspacePullRequest;
 }) {
-	const className = "size-3.5";
+	const className = "size-4";
 	const strokeWidth = 1.75;
 	if (pr.state === "merged") {
 		return (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/components/PullRequestStatusIcon/PullRequestStatusIcon.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/components/PullRequestStatusIcon/PullRequestStatusIcon.tsx
@@ -43,12 +43,19 @@ export function PullRequestStatusIcon({
 			/>
 		);
 	}
+	// Open PR color by review decision:
+	// - approved          → bright emerald (good to go)
+	// - changes_requested → amber (needs author attention)
+	// - pending           → sky blue (waiting on reviewers)
+	// - null (no review)  → soft emerald (open, fresh)
 	const openColor =
 		pr.reviewDecision === "approved"
 			? "text-emerald-400/80"
 			: pr.reviewDecision === "changes_requested"
 				? "text-amber-400/80"
-				: "text-emerald-400/70";
+				: pr.reviewDecision === "pending"
+					? "text-sky-400/70"
+					: "text-emerald-400/70";
 	return (
 		<GitPullRequest
 			className={cn(baseClass, openColor)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/components/PullRequestStatusIcon/PullRequestStatusIcon.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/components/PullRequestStatusIcon/PullRequestStatusIcon.tsx
@@ -5,7 +5,7 @@ import {
 	GitPullRequestClosed,
 	GitPullRequestDraft,
 } from "lucide-react";
-import type { DashboardSidebarWorkspacePullRequest } from "../../../../../../types";
+import type { DashboardSidebarWorkspacePullRequest } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/types";
 
 interface PullRequestStatusIconProps {
 	pr: DashboardSidebarWorkspacePullRequest;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/components/PullRequestStatusIcon/PullRequestStatusIcon.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/components/PullRequestStatusIcon/PullRequestStatusIcon.tsx
@@ -1,0 +1,58 @@
+import { cn } from "@superset/ui/utils";
+import {
+	GitMerge,
+	GitPullRequest,
+	GitPullRequestClosed,
+	GitPullRequestDraft,
+} from "lucide-react";
+import type { DashboardSidebarWorkspacePullRequest } from "../../../../../../types";
+
+interface PullRequestStatusIconProps {
+	pr: DashboardSidebarWorkspacePullRequest;
+	className?: string;
+}
+
+export function PullRequestStatusIcon({
+	pr,
+	className,
+}: PullRequestStatusIconProps) {
+	const baseClass = cn("size-4", className);
+	const strokeWidth = 1.75;
+
+	if (pr.state === "merged") {
+		return (
+			<GitMerge
+				className={cn(baseClass, "text-violet-400/80")}
+				strokeWidth={strokeWidth}
+			/>
+		);
+	}
+	if (pr.state === "closed") {
+		return (
+			<GitPullRequestClosed
+				className={cn(baseClass, "text-rose-400/70")}
+				strokeWidth={strokeWidth}
+			/>
+		);
+	}
+	if (pr.state === "draft") {
+		return (
+			<GitPullRequestDraft
+				className={cn(baseClass, "text-muted-foreground/70")}
+				strokeWidth={strokeWidth}
+			/>
+		);
+	}
+	const openColor =
+		pr.reviewDecision === "approved"
+			? "text-emerald-400/80"
+			: pr.reviewDecision === "changes_requested"
+				? "text-amber-400/80"
+				: "text-emerald-400/70";
+	return (
+		<GitPullRequest
+			className={cn(baseClass, openColor)}
+			strokeWidth={strokeWidth}
+		/>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/components/PullRequestStatusIcon/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/components/PullRequestStatusIcon/index.ts
@@ -1,0 +1,1 @@
+export { PullRequestStatusIcon } from "./PullRequestStatusIcon";

--- a/apps/desktop/src/renderer/routes/_authenticated/components/ProjectThumbnail/ProjectThumbnail.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/ProjectThumbnail/ProjectThumbnail.tsx
@@ -24,7 +24,7 @@ export function ProjectThumbnail({
 		return (
 			<div
 				className={cn(
-					"relative size-6 rounded overflow-hidden flex-shrink-0 bg-muted border-[1.5px] border-border",
+					"relative size-6 rounded overflow-hidden flex-shrink-0 bg-muted",
 					className,
 				)}
 			>
@@ -42,7 +42,7 @@ export function ProjectThumbnail({
 		<div
 			className={cn(
 				"size-6 rounded flex items-center justify-center flex-shrink-0",
-				"text-xs font-medium bg-muted text-muted-foreground border-[1.5px] border-border",
+				"text-xs font-medium bg-muted text-muted-foreground",
 				className,
 			)}
 		>


### PR DESCRIPTION
## Summary

Tightens the v2 dashboard sidebar to a more minimal, Linear-style layout, and surfaces PR state directly as a colored icon on each workspace row. Pure visual cleanup — no data-model or behavior changes.

## Before / After



**Project mode (default)**

| Before | After |
| --- | --- |
| 
<img width="2420" height="2622" alt="CleanShot 2026-04-15 at 14 03 13@2x" src="https://github.com/user-attachments/assets/17d9d50b-0ec2-4540-a6f8-601bf06a582c" />
 | 
<img width="1984" height="2298" alt="nalchiore" src="https://github.com/user-attachments/assets/d4f78e9c-3980-4189-8745-ede502c756b6" />
 |

## What changed

- **Project headers** — lowercase `owner/repo` in muted text, hover-only chevron and `+` button. The avatar/letter thumbnail is no longer shown by default in the project row (it felt redundant in a tight sidebar; still used in collapsed mode and other surfaces).
- **Workspace items** — single line, indented under the project header, tighter vertical rhythm (`py-1`, `h-7`).
- **PR state via colored icon** on the workspace row, replacing the generic folder icon and the inline PR `#` badge:

| State | Icon | Color |
| --- | --- | --- |
| open · pending review | `GitPullRequest` | emerald |
| open · changes requested | `GitPullRequest` | amber |
| open · approved | `GitPullRequest` | emerald |
| draft | `GitPullRequestDraft` | muted |
| merged | `GitMerge` | violet |
| closed | `GitPullRequestClosed` | rose |
| no PR | `CircleDot` | muted |

- **Removed** the 1.5px borders around `ProjectThumbnail` and the dividers between project sections. Vertical rhythm is now a single \`flex gap-3\` on the scroll container, so first/last spacing matches between-project spacing.

## What I deliberately did NOT change

- Drag-and-drop reordering (intact)
- Context menu, rename, workspace deletion flows (intact)
- Hover card content (still shows full PR details, branch, checks, preview)
- \`ProjectThumbnail\` is still used in the collapsed sidebar mode, \`RunInWorkspacePopover\`, tasks views — only the visible-by-default usage in the expanded project row was removed.
- No new packages, no migrations, no API changes.

## Test plan

- [ ] Project list renders with new minimal style (light + dark mode)
- [ ] Hover a project header → chevron and \`+\` appear
- [ ] Click chevron → project collapses/expands
- [ ] Workspaces with various PR states show the right colored icon
- [ ] Drag-and-drop a project still works
- [ ] Hover-over delete \`×\` still triggers the destroy dialog
- [ ] Rename a project (double-click) still works
- [ ] Hover card on a workspace still shows PR details, checks, preview button

## Follow-ups (separate PRs)

Happy to ship as separate, smaller PRs once this lands:
- "Group by PR status" toggle (in-progress / in-review / ready to merge / done / canceled / backlog) with a filter popover.
- "Pin workspace to top" — would love to align with maintainers on the data model first (per-device local store vs synced \`pinnedAt\` on \`v2_workspaces\`).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes the v2 dashboard sidebar to a tighter, Linear-style layout and adds color‑coded PR state icons on workspace rows for quick scanning. No data‑model changes.

- **New Features**
  - PR status via colored icons: `GitPullRequest` (emerald for approved/no review, amber for changes requested, sky blue for pending), `GitPullRequestDraft` (muted), `GitMerge` (violet), `GitPullRequestClosed` (rose), `CircleDot` when no PR. Icon size matches host icons, is clickable to open the PR, and tooltip shows `#<number> · <state>` and title.
  - Minimal project headers: lowercase `owner/repo`, hover-only chevron and `+`; avatar removed from default row. `+` has an aria-label and focus ring for keyboard users.
  - Workspace rows: single-line, indented under project with tighter spacing; branch text and inline PR badge removed. Consistent spacing via scroll container `flex gap-3 pt-3`; section dividers removed.

- **Refactors**
  - Extracted `PullRequestStatusIcon`; switched type imports to `renderer/...` aliases.

<sup>Written for commit d7f133d1506b24d84f4217a11f6ddf5b676e2e64. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspaces show pull-request status icons (merged, closed, draft, open) with contextual colors.

* **Enhancements**
  * Project rows display GitHub-style name (owner/repo) when available; repo name surfaced for actions.
  * Sidebar spacing, padding, and column layout refined for clearer grouping and consistent scrolling.
  * Workspace rows and icons redesigned (smaller counts, repositioned controls); tooltips show PR details when present.

* **Style**
  * Project thumbnails and avatar borders simplified; chevron and action button placement/hover behavior adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->