### PR TITLE
fix(desktop): refresh terminal renderer after reattach

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
@@ -6,10 +6,12 @@ import { SearchAddon } from "@xterm/addon-search";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebglAddon } from "@xterm/addon-webgl";
 import type { Terminal as XTerm } from "@xterm/xterm";
+import { refreshTerminalRenderer } from "./terminal-renderer";
 
 export interface LoadAddonsResult {
 	searchAddon: SearchAddon;
 	progressAddon: ProgressAddon;
+	refreshRenderer: () => void;
 	dispose: () => void;
 }
 
@@ -24,6 +26,7 @@ let suggestedRendererType: "webgl" | "dom" | undefined;
 export function loadAddons(terminal: XTerm): LoadAddonsResult {
 	let disposed = false;
 	let webglAddon: WebglAddon | null = null;
+	const refreshRenderer = () => refreshTerminalRenderer(terminal, webglAddon);
 
 	terminal.loadAddon(new ClipboardAddon());
 
@@ -51,7 +54,7 @@ export function loadAddons(terminal: XTerm): LoadAddonsResult {
 			webglAddon.onContextLoss(() => {
 				webglAddon?.dispose();
 				webglAddon = null;
-				terminal.refresh(0, terminal.rows - 1);
+				refreshRenderer();
 			});
 			terminal.loadAddon(webglAddon);
 		} catch {
@@ -63,6 +66,7 @@ export function loadAddons(terminal: XTerm): LoadAddonsResult {
 	return {
 		searchAddon,
 		progressAddon,
+		refreshRenderer,
 		dispose: () => {
 			disposed = true;
 			cancelAnimationFrame(rafId);

--- a/apps/desktop/src/renderer/lib/terminal/terminal-renderer.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-renderer.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, mock } from "bun:test";
+import { refreshTerminalRenderer } from "./terminal-renderer";
+
+describe("refreshTerminalRenderer", () => {
+	it("clears the WebGL texture atlas before forcing a repaint", () => {
+		const terminal = {
+			rows: 4,
+			refresh: mock(() => {}),
+		};
+		const webglAddon = {
+			clearTextureAtlas: mock(() => {}),
+		};
+
+		refreshTerminalRenderer(terminal, webglAddon);
+
+		expect(webglAddon.clearTextureAtlas).toHaveBeenCalledTimes(1);
+		expect(terminal.refresh).toHaveBeenCalledWith(0, 3);
+	});
+
+	it("still refreshes when clearing the atlas throws", () => {
+		const terminal = {
+			rows: 1,
+			refresh: mock(() => {}),
+		};
+		const webglAddon = {
+			clearTextureAtlas: mock(() => {
+				throw new Error("atlas reset failed");
+			}),
+		};
+
+		refreshTerminalRenderer(terminal, webglAddon);
+
+		expect(webglAddon.clearTextureAtlas).toHaveBeenCalledTimes(1);
+		expect(terminal.refresh).toHaveBeenCalledWith(0, 0);
+	});
+});

--- a/apps/desktop/src/renderer/lib/terminal/terminal-renderer.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-renderer.ts
@@ -1,0 +1,18 @@
+export interface RefreshableTerminal {
+	rows: number;
+	refresh: (start: number, end: number) => void;
+}
+
+export interface TextureAtlasResettable {
+	clearTextureAtlas: () => void;
+}
+
+export function refreshTerminalRenderer(
+	terminal: RefreshableTerminal,
+	webglAddon: TextureAtlasResettable | null,
+): void {
+	try {
+		webglAddon?.clearTextureAtlas();
+	} catch {}
+	terminal.refresh(0, Math.max(0, terminal.rows - 1));
+}

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -34,6 +34,7 @@ export interface TerminalRuntime {
 	resizeObserver: ResizeObserver | null;
 	lastCols: number;
 	lastRows: number;
+	_refreshRenderer: (() => void) | null;
 	_disposeAddons: (() => void) | null;
 }
 
@@ -167,6 +168,7 @@ export function createRuntime(
 		resizeObserver: null,
 		lastCols: cols,
 		lastRows: rows,
+		_refreshRenderer: addonsResult.refreshRenderer,
 		_disposeAddons: addonsResult.dispose,
 	};
 }
@@ -180,12 +182,13 @@ export function attachToContainer(
 	container.appendChild(runtime.wrapper);
 	measureAndResize(runtime);
 
-	// Renderer may have skipped frames while the wrapper was detached.
-	runtime.terminal.refresh(0, runtime.terminal.rows - 1);
+	// Renderer may have skipped frames while the wrapper was detached or occluded.
+	runtime._refreshRenderer?.();
 
 	runtime.resizeObserver?.disconnect();
 	const observer = new ResizeObserver(() => {
 		measureAndResize(runtime);
+		runtime._refreshRenderer?.();
 		onResize?.();
 	});
 	observer.observe(container);
@@ -221,6 +224,7 @@ export function updateRuntimeAppearance(
 			fitAddon.fit();
 			runtime.lastCols = terminal.cols;
 			runtime.lastRows = terminal.rows;
+			runtime._refreshRenderer?.();
 		}
 	}
 }
@@ -228,6 +232,7 @@ export function updateRuntimeAppearance(
 export function disposeRuntime(runtime: TerminalRuntime) {
 	runtime._disposeAddons?.();
 	runtime._disposeAddons = null;
+	runtime._refreshRenderer = null;
 	runtime.resizeObserver?.disconnect();
 	runtime.resizeObserver = null;
 	runtime.wrapper.remove();

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -23,6 +23,7 @@ import {
 	DEFAULT_THEME_ID,
 	getTerminalColors,
 } from "shared/themes";
+import { refreshTerminalRenderer } from "renderer/lib/terminal/terminal-renderer";
 import {
 	shouldBubbleClipboardShortcut,
 	shouldSelectAllShortcut,
@@ -99,6 +100,7 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 	searchAddon: SearchAddon;
 	wrapper: HTMLDivElement;
 	linkManager: TerminalLinkManager;
+	refreshRenderer: () => void;
 	cleanup: () => void;
 } {
 	const {
@@ -120,6 +122,7 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 
 	let disposed = false;
 	let webglAddon: WebglAddon | null = null;
+	const refreshRenderer = () => refreshTerminalRenderer(xterm, webglAddon);
 
 	// Open into a detached wrapper div — not the live container.
 	const wrapper = document.createElement("div");
@@ -148,7 +151,7 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 			webglAddon.onContextLoss(() => {
 				webglAddon?.dispose();
 				webglAddon = null;
-				xterm.refresh(0, xterm.rows - 1);
+				refreshRenderer();
 			});
 			xterm.loadAddon(webglAddon);
 		} catch {
@@ -216,6 +219,7 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 		searchAddon,
 		wrapper,
 		linkManager,
+		refreshRenderer,
 		cleanup: () => {
 			disposed = true;
 			cancelAnimationFrame(rafId);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
@@ -21,6 +21,7 @@ export interface CachedTerminal {
 	fitAddon: FitAddon;
 	searchAddon: SearchAddon;
 	wrapper: HTMLDivElement;
+	refreshRenderer: () => void;
 	/** Disposes renderer RAF, query suppression, GPU renderer, etc. */
 	cleanupCreation: () => void;
 	/** Last known dimensions — used to skip no-op resize events. */
@@ -75,7 +76,7 @@ export function getOrCreate(
 		console.log(`[v1-terminal-cache] Creating new terminal: ${paneId}`);
 	}
 
-	const { xterm, fitAddon, searchAddon, wrapper, cleanup } =
+	const { xterm, fitAddon, searchAddon, wrapper, refreshRenderer, cleanup } =
 		createTerminalInWrapper(options);
 
 	const entry: CachedTerminal = {
@@ -83,6 +84,7 @@ export function getOrCreate(
 		fitAddon,
 		searchAddon,
 		wrapper,
+		refreshRenderer,
 		cleanupCreation: cleanup,
 		subscription: null,
 		streamReady: false,
@@ -117,8 +119,8 @@ export function attachToContainer(
 		entry.lastRows = entry.xterm.rows;
 	}
 
-	// Renderer may have skipped frames while the wrapper was detached.
-	entry.xterm.refresh(0, Math.max(0, entry.xterm.rows - 1));
+	// Renderer may have skipped frames while the wrapper was detached or occluded.
+	entry.refreshRenderer();
 
 	// Manage ResizeObserver lifecycle in the cache, not in React.
 	entry.resizeObserver?.disconnect();
@@ -129,6 +131,7 @@ export function attachToContainer(
 		entry.fitAddon.fit();
 		entry.lastCols = entry.xterm.cols;
 		entry.lastRows = entry.xterm.rows;
+		entry.refreshRenderer();
 		if (entry.lastCols !== prevCols || entry.lastRows !== prevRows) {
 			onResize?.();
 		}
@@ -178,6 +181,7 @@ export function updateAppearance(
 	fitAddon.fit();
 	entry.lastCols = xterm.cols;
 	entry.lastRows = xterm.rows;
+	entry.refreshRenderer();
 
 	return {
 		cols: xterm.cols,


### PR DESCRIPTION
## Summary

- add a shared terminal renderer refresh helper that clears the WebGL texture atlas before repaint
- call that helper after terminal reattach, resize, font changes, and WebGL context loss
- use the same recovery path in both terminal lifecycle implementations
- add a focused unit test for the renderer refresh helper

## Why

This keeps the terminal redraw path consistent after a pane was detached, reattached, resized, or occluded on macOS.

The goal is narrow. This PR does not disable WebGL, does not disable ligatures, and does not change renderer selection. It only makes the existing WebGL path refresh from a clean texture atlas before repainting.

Nearby risk: the app has two terminal lifecycle paths. This change updates both so the recovery logic does not drift between them.

## Tests

- `bun test apps/desktop/src/renderer/lib/terminal/terminal-renderer.test.ts`
- `bun test apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/**/*.test.ts apps/desktop/src/renderer/lib/terminal/terminal-renderer.test.ts apps/desktop/src/renderer/lib/terminal/*.test.ts`
- `cd apps/desktop && bun run typecheck`

## Real-world validation

- linked from the macOS rendering issue
- local source inspection matched the shipped app versions involved in the bug report
- fullscreen still acts as an immediate recovery in the reported broken state, which is consistent with this repaint path

## Issue

Fixes #3504


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale or blank terminal frames on macOS by clearing the WebGL texture atlas and forcing a repaint after reattach, resize, font changes, or context loss. Unifies the recovery path across both terminal lifecycles and adds a focused test. Fixes #3504.

- **Bug Fixes**
  - Added `refreshTerminalRenderer` helper that clears the WebGL texture atlas (via `@xterm/addon-webgl`) and calls a full `refresh`.
  - Invoked the helper after attach, resize, font updates, and WebGL context loss in both terminal lifecycle paths.
  - Added a unit test for the helper; no change to renderer selection or ligatures.

<sup>Written for commit 9c2328722899d5af375e521c0d85dc43adaf9b00. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

