### PR TITLE
fix(auth): auto-refresh expired Anthropic OAuth tokens

### DIFF
--- a/apps/desktop/src/lib/ai/call-small-model.ts
+++ b/apps/desktop/src/lib/ai/call-small-model.ts
@@ -73,7 +73,7 @@ export async function callSmallModel<TResult>({
 	const attempts: SmallModelAttempt[] = [];
 
 	for (const provider of orderProviders(providers, providerOrder)) {
-		const credentials = provider.resolveCredentials();
+		const credentials = await provider.resolveCredentials();
 		if (!credentials) {
 			attempts.push({
 				providerId: provider.id,

--- a/packages/chat/src/server/desktop/auth/anthropic/anthropic.ts
+++ b/packages/chat/src/server/desktop/auth/anthropic/anthropic.ts
@@ -168,7 +168,7 @@ export function getCredentialsFromKeychain(): ClaudeCredentials | null {
 	return null;
 }
 
-export function getCredentialsFromAuthStorage(): ClaudeCredentials | null {
+export async function getCredentialsFromAuthStorage(): Promise<ClaudeCredentials | null> {
 	try {
 		const authStorage = createAuthStorage();
 		authStorage.reload();
@@ -187,18 +187,22 @@ export function getCredentialsFromAuthStorage(): ClaudeCredentials | null {
 			};
 		}
 
-		if (
-			credential.type === "oauth" &&
-			typeof credential.access === "string" &&
-			credential.access.trim().length > 0
-		) {
+		if (credential.type === "oauth") {
+			// mastracode's getApiKey triggers refreshToken() when expires <= now,
+			// and persists the refreshed credential back into auth storage.
+			const accessToken = await authStorage.getApiKey(
+				ANTHROPIC_AUTH_PROVIDER_ID,
+			);
+			if (!accessToken || accessToken.trim().length === 0) return null;
+			authStorage.reload();
+			const refreshed = authStorage.get(ANTHROPIC_AUTH_PROVIDER_ID);
 			return {
-				apiKey: credential.access.trim(),
+				apiKey: accessToken.trim(),
 				source: "auth-storage",
 				kind: "oauth",
 				expiresAt:
-					typeof credential.expires === "number"
-						? credential.expires
+					refreshed?.type === "oauth" && typeof refreshed.expires === "number"
+						? refreshed.expires
 						: undefined,
 			};
 		}
@@ -209,24 +213,22 @@ export function getCredentialsFromAuthStorage(): ClaudeCredentials | null {
 	return null;
 }
 
-export function getCredentialsFromAnySource(): ClaudeCredentials | null {
-	const resolvers = [
-		getCredentialsFromConfig,
-		getCredentialsFromKeychain,
-		getCredentialsFromAuthStorage,
-	];
+export async function getCredentialsFromAnySource(): Promise<ClaudeCredentials | null> {
+	const syncResolvers = [getCredentialsFromConfig, getCredentialsFromKeychain];
 	let firstExpired: ClaudeCredentials | null = null;
 
-	for (const resolve of resolvers) {
+	for (const resolve of syncResolvers) {
 		const credential = resolve();
-		if (!credential) {
-			continue;
-		}
-		if (!isClaudeCredentialExpired(credential)) {
-			return credential;
-		}
+		if (!credential) continue;
+		if (!isClaudeCredentialExpired(credential)) return credential;
 		firstExpired ??= credential;
 	}
+
+	const storageCredential = await getCredentialsFromAuthStorage();
+	if (storageCredential && !isClaudeCredentialExpired(storageCredential)) {
+		return storageCredential;
+	}
+	firstExpired ??= storageCredential ?? null;
 
 	return firstExpired;
 }

--- a/packages/chat/src/server/desktop/chat-service/chat-service.test.ts
+++ b/packages/chat/src/server/desktop/chat-service/chat-service.test.ts
@@ -102,8 +102,8 @@ mock.module("mastracode", () => ({
 mock.module("../auth/anthropic", () => ({
 	getCredentialsFromConfig: () => anthropicConfigCredential,
 	getCredentialsFromKeychain: () => anthropicKeychainCredential,
-	getCredentialsFromAnySource: () => null,
-	getCredentialsFromAuthStorage: () => null,
+	getCredentialsFromAnySource: async () => null,
+	getCredentialsFromAuthStorage: async () => null,
 	getAnthropicProviderOptions: () => ({}),
 	isClaudeCredentialExpired: (credential: {
 		kind: "apiKey" | "oauth";
@@ -243,7 +243,7 @@ describe("ChatService OpenAI auth storage", () => {
 			}),
 		);
 		expect(result.expiresAt).toBe(oauthExpiresAt);
-		expect(chatService.getAnthropicAuthStatus().method).toBe("oauth");
+		expect((await chatService.getAnthropicAuthStatus()).method).toBe("oauth");
 	});
 
 	it("switches Anthropic status from oauth to api key when api key is saved", async () => {
@@ -264,10 +264,10 @@ describe("ChatService OpenAI auth storage", () => {
 
 		await chatService.startAnthropicOAuth();
 		await chatService.completeAnthropicOAuth({ code: "auth-code#state" });
-		expect(chatService.getAnthropicAuthStatus().method).toBe("oauth");
+		expect((await chatService.getAnthropicAuthStatus()).method).toBe("oauth");
 
 		await chatService.setAnthropicApiKey({ apiKey: " api-key " });
-		expect(chatService.getAnthropicAuthStatus().method).toBe("api_key");
+		expect((await chatService.getAnthropicAuthStatus()).method).toBe("api_key");
 	});
 
 	it("prefers a managed Anthropic API key over env-config credentials", async () => {
@@ -284,7 +284,7 @@ describe("ChatService OpenAI auth storage", () => {
 		);
 		expect(process.env.ANTHROPIC_API_KEY).toBeUndefined();
 		expect(process.env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
-		expect(chatService.getAnthropicAuthStatus()).toEqual({
+		expect(await chatService.getAnthropicAuthStatus()).toEqual({
 			authenticated: true,
 			method: "api_key",
 			source: "managed",
@@ -292,12 +292,12 @@ describe("ChatService OpenAI auth storage", () => {
 		});
 	});
 
-	it("ignores Anthropic runtime env credentials without managed auth", () => {
+	it("ignores Anthropic runtime env credentials without managed auth", async () => {
 		const chatService = new ChatService();
 
 		process.env.ANTHROPIC_AUTH_TOKEN = "external-oauth-token";
 
-		expect(chatService.getAnthropicAuthStatus()).toEqual({
+		expect(await chatService.getAnthropicAuthStatus()).toEqual({
 			authenticated: false,
 			method: null,
 			source: null,
@@ -305,7 +305,7 @@ describe("ChatService OpenAI auth storage", () => {
 		});
 	});
 
-	it("prefers external Anthropic credentials over managed auth", () => {
+	it("prefers external Anthropic credentials over managed auth", async () => {
 		const chatService = new ChatService();
 
 		anthropicConfigCredential = {
@@ -318,7 +318,7 @@ describe("ChatService OpenAI auth storage", () => {
 			key: "managed-api-key",
 		});
 
-		expect(chatService.getAnthropicAuthStatus()).toEqual({
+		expect(await chatService.getAnthropicAuthStatus()).toEqual({
 			authenticated: true,
 			method: "oauth",
 			source: "external",
@@ -326,7 +326,7 @@ describe("ChatService OpenAI auth storage", () => {
 		});
 	});
 
-	it("surfaces hidden managed Anthropic OAuth when external Claude auth wins", () => {
+	it("surfaces hidden managed Anthropic OAuth when external Claude auth wins", async () => {
 		const chatService = new ChatService();
 
 		anthropicConfigCredential = {
@@ -340,7 +340,7 @@ describe("ChatService OpenAI auth storage", () => {
 			expires: Date.now() + 60 * 60 * 1000,
 		});
 
-		expect(chatService.getAnthropicAuthStatus()).toEqual({
+		expect(await chatService.getAnthropicAuthStatus()).toEqual({
 			authenticated: true,
 			method: "oauth",
 			source: "external",
@@ -349,7 +349,7 @@ describe("ChatService OpenAI auth storage", () => {
 		});
 	});
 
-	it("prefers managed Anthropic auth over runtime env credentials", () => {
+	it("prefers managed Anthropic auth over runtime env credentials", async () => {
 		const chatService = new ChatService();
 
 		process.env.ANTHROPIC_AUTH_TOKEN = "external-oauth-token";
@@ -358,7 +358,7 @@ describe("ChatService OpenAI auth storage", () => {
 			key: "managed-api-key",
 		});
 
-		expect(chatService.getAnthropicAuthStatus()).toEqual({
+		expect(await chatService.getAnthropicAuthStatus()).toEqual({
 			authenticated: true,
 			method: "api_key",
 			source: "managed",
@@ -366,7 +366,7 @@ describe("ChatService OpenAI auth storage", () => {
 		});
 	});
 
-	it("marks expired external Anthropic OAuth as expired", () => {
+	it("marks expired external Anthropic OAuth as expired", async () => {
 		const chatService = new ChatService();
 
 		anthropicConfigCredential = {
@@ -376,7 +376,7 @@ describe("ChatService OpenAI auth storage", () => {
 			expiresAt: Date.now() - 1_000,
 		};
 
-		expect(chatService.getAnthropicAuthStatus()).toEqual({
+		expect(await chatService.getAnthropicAuthStatus()).toEqual({
 			authenticated: false,
 			method: "oauth",
 			source: "external",
@@ -384,7 +384,7 @@ describe("ChatService OpenAI auth storage", () => {
 		});
 	});
 
-	it("falls back to managed Anthropic auth when external OAuth is expired", () => {
+	it("falls back to managed Anthropic auth when external OAuth is expired", async () => {
 		const chatService = new ChatService();
 
 		anthropicConfigCredential = {
@@ -398,7 +398,7 @@ describe("ChatService OpenAI auth storage", () => {
 			key: "managed-api-key",
 		});
 
-		expect(chatService.getAnthropicAuthStatus()).toEqual({
+		expect(await chatService.getAnthropicAuthStatus()).toEqual({
 			authenticated: true,
 			method: "api_key",
 			source: "managed",
@@ -415,7 +415,7 @@ describe("ChatService OpenAI auth storage", () => {
 			expires: Date.now() + 60 * 60 * 1000,
 		});
 
-		expect(chatService.getAnthropicAuthStatus()).toEqual({
+		expect(await chatService.getAnthropicAuthStatus()).toEqual({
 			authenticated: true,
 			method: "oauth",
 			source: "managed",
@@ -426,7 +426,7 @@ describe("ChatService OpenAI auth storage", () => {
 		await chatService.disconnectAnthropicOAuth();
 
 		expect(fakeAuthStorage.remove).toHaveBeenCalledWith("anthropic");
-		expect(chatService.getAnthropicAuthStatus()).toEqual({
+		expect(await chatService.getAnthropicAuthStatus()).toEqual({
 			authenticated: false,
 			method: null,
 			source: null,
@@ -459,7 +459,7 @@ describe("ChatService OpenAI auth storage", () => {
 				ANTHROPIC_AUTH_TOKEN: "gateway-token",
 			},
 		});
-		expect(chatService.getAnthropicAuthStatus()).toEqual({
+		expect(await chatService.getAnthropicAuthStatus()).toEqual({
 			authenticated: true,
 			method: "api_key",
 			source: "managed",
@@ -474,7 +474,7 @@ describe("ChatService OpenAI auth storage", () => {
 			access: "oauth-access-token",
 			expires: Date.now() + 60 * 60 * 1000,
 		});
-		expect(chatService.getAnthropicAuthStatus().method).toBe("oauth");
+		expect((await chatService.getAnthropicAuthStatus()).method).toBe("oauth");
 
 		await chatService.setAnthropicEnvConfig({
 			envText:
@@ -482,7 +482,7 @@ describe("ChatService OpenAI auth storage", () => {
 		});
 
 		expect(fakeAuthStorage.remove).toHaveBeenCalledWith("anthropic");
-		expect(chatService.getAnthropicAuthStatus().method).toBe("api_key");
+		expect((await chatService.getAnthropicAuthStatus()).method).toBe("api_key");
 	});
 
 	it("persists Anthropic env config without API key/token", async () => {
@@ -498,7 +498,7 @@ describe("ChatService OpenAI auth storage", () => {
 				ANTHROPIC_BASE_URL: "https://ai-gateway.vercel.sh",
 			},
 		});
-		expect(chatService.getAnthropicAuthStatus()).toEqual({
+		expect(await chatService.getAnthropicAuthStatus()).toEqual({
 			authenticated: false,
 			method: null,
 			source: null,
@@ -526,7 +526,7 @@ describe("ChatService OpenAI auth storage", () => {
 			type: "api_key",
 			key: "gateway-token",
 		});
-		expect(chatService.getAnthropicAuthStatus()).toEqual({
+		expect(await chatService.getAnthropicAuthStatus()).toEqual({
 			authenticated: true,
 			method: "api_key",
 			source: "managed",
@@ -577,7 +577,7 @@ describe("ChatService OpenAI auth storage", () => {
 			envText: "",
 			variables: {},
 		});
-		expect(chatService.getAnthropicAuthStatus().method).toBeNull();
+		expect((await chatService.getAnthropicAuthStatus()).method).toBeNull();
 	});
 
 	it("deletes previously applied pass-through env keys when settings change", async () => {

--- a/packages/chat/src/server/desktop/chat-service/chat-service.ts
+++ b/packages/chat/src/server/desktop/chat-service/chat-service.ts
@@ -78,11 +78,28 @@ export class ChatService {
 		);
 	}
 
-	getAnthropicAuthStatus(): AuthStatus {
+	async getAnthropicAuthStatus(): Promise<AuthStatus> {
 		const authStorage = this.getAuthStorage();
 		authStorage.reload();
-		const storedCredential = authStorage.get(ANTHROPIC_AUTH_PROVIDER_ID);
+		let storedCredential = authStorage.get(ANTHROPIC_AUTH_PROVIDER_ID);
 		const hasManagedOAuth = storedCredential?.type === "oauth";
+
+		// If managed OAuth is past its expiry, give mastracode a chance to
+		// refresh it before downgrading status to "expired". Mastracode's
+		// getApiKey uses the stored refresh token via the anthropic provider.
+		if (
+			storedCredential?.type === "oauth" &&
+			typeof storedCredential.expires === "number" &&
+			storedCredential.expires <= Date.now()
+		) {
+			try {
+				await authStorage.getApiKey(ANTHROPIC_AUTH_PROVIDER_ID);
+				authStorage.reload();
+				storedCredential = authStorage.get(ANTHROPIC_AUTH_PROVIDER_ID);
+			} catch {
+				// Refresh failed; fall through to expired-state handling below.
+			}
+		}
 		const configCredential = getAnthropicCredentialsFromConfig();
 		const keychainCredential = getAnthropicCredentialsFromKeychain();
 		const externalCandidates = [configCredential, keychainCredential].filter(

--- a/packages/chat/src/server/desktop/small-model/small-model.ts
+++ b/packages/chat/src/server/desktop/small-model/small-model.ts
@@ -26,7 +26,10 @@ export interface SmallModelCredential {
 export interface SmallModelProvider {
 	id: SmallModelProviderId;
 	name: string;
-	resolveCredentials: () => SmallModelCredential | null;
+	resolveCredentials: () =>
+		| SmallModelCredential
+		| null
+		| Promise<SmallModelCredential | null>;
 	isSupported: (credentials: SmallModelCredential) => {
 		supported: boolean;
 		reason?: string;

--- a/packages/host-service/src/providers/model-providers/LocalModelProvider/LocalModelProvider.ts
+++ b/packages/host-service/src/providers/model-providers/LocalModelProvider/LocalModelProvider.ts
@@ -30,12 +30,12 @@ export class LocalModelProvider implements ModelProviderRuntimeResolver {
 		this.anthropicEnvConfigPath = options?.anthropicEnvConfigPath;
 	}
 
-	private resolveRuntimeEnv(): {
+	private async resolveRuntimeEnv(): Promise<{
 		env: Record<string, string>;
 		cleanupKeys: string[];
 		hasUsableRuntimeEnv: boolean;
-	} {
-		const anthropicCredential = resolveAnthropicCredential();
+	}> {
+		const anthropicCredential = await resolveAnthropicCredential();
 		const openaiCredential = resolveOpenAICredential();
 		const anthropicEnvConfig = getAnthropicEnvConfig({
 			configPath: this.anthropicEnvConfigPath,
@@ -54,11 +54,11 @@ export class LocalModelProvider implements ModelProviderRuntimeResolver {
 	}
 
 	async hasUsableRuntimeEnv(): Promise<boolean> {
-		return this.resolveRuntimeEnv().hasUsableRuntimeEnv;
+		return (await this.resolveRuntimeEnv()).hasUsableRuntimeEnv;
 	}
 
 	async prepareRuntimeEnv(): Promise<void> {
-		const runtimeEnv = this.resolveRuntimeEnv();
+		const runtimeEnv = await this.resolveRuntimeEnv();
 		this.currentRuntimeEnv = applyRuntimeEnv(
 			runtimeEnv.env,
 			runtimeEnv.cleanupKeys,

--- a/packages/host-service/src/providers/model-providers/LocalModelProvider/utils/resolveAnthropicCredential.ts
+++ b/packages/host-service/src/providers/model-providers/LocalModelProvider/utils/resolveAnthropicCredential.ts
@@ -82,7 +82,7 @@ function getAnthropicCredentialFromKeychain(): LocalResolvedCredential | null {
 	return null;
 }
 
-function getAnthropicCredentialFromAuthStorage(): LocalResolvedCredential | null {
+async function getAnthropicCredentialFromAuthStorage(): Promise<LocalResolvedCredential | null> {
 	try {
 		const authStorage = createAuthStorage();
 		authStorage.reload();
@@ -97,18 +97,39 @@ function getAnthropicCredentialFromAuthStorage(): LocalResolvedCredential | null
 			return { kind: "api_key" };
 		}
 
-		if (
-			credential.type === "oauth" &&
-			typeof credential.access === "string" &&
-			credential.access.trim().length > 0
-		) {
-			return {
-				kind: "oauth",
-				expiresAt:
-					typeof credential.expires === "number"
-						? credential.expires
-						: undefined,
-			};
+		if (credential.type === "oauth") {
+			const expiresAt =
+				typeof credential.expires === "number" ? credential.expires : undefined;
+			if (typeof expiresAt === "number" && Date.now() >= expiresAt) {
+				try {
+					await authStorage.getApiKey(ANTHROPIC_PROVIDER_ID);
+					authStorage.reload();
+					const refreshed = authStorage.get(ANTHROPIC_PROVIDER_ID);
+					if (
+						isObjectRecord(refreshed) &&
+						refreshed.type === "oauth" &&
+						typeof refreshed.access === "string" &&
+						refreshed.access.trim().length > 0
+					) {
+						return {
+							kind: "oauth",
+							expiresAt:
+								typeof refreshed.expires === "number"
+									? refreshed.expires
+									: undefined,
+						};
+					}
+					return { kind: "oauth", expiresAt };
+				} catch {
+					return { kind: "oauth", expiresAt };
+				}
+			}
+			if (
+				typeof credential.access === "string" &&
+				credential.access.trim().length > 0
+			) {
+				return { kind: "oauth", expiresAt };
+			}
 		}
 	} catch {
 		// Ignore auth storage read failures for now.
@@ -117,10 +138,10 @@ function getAnthropicCredentialFromAuthStorage(): LocalResolvedCredential | null
 	return null;
 }
 
-export function resolveAnthropicCredential(): LocalResolvedCredential | null {
+export async function resolveAnthropicCredential(): Promise<LocalResolvedCredential | null> {
 	return (
 		getAnthropicCredentialFromConfig() ??
 		getAnthropicCredentialFromKeychain() ??
-		getAnthropicCredentialFromAuthStorage()
+		(await getAnthropicCredentialFromAuthStorage())
 	);
 }


### PR DESCRIPTION
## Summary
- Anthropic OAuth credentials were read via `authStorage.get()` everywhere, which never triggered mastracode's built-in refresh flow. When the 1-hour access token expired, the UI flipped to **Reconnect** and forced a full PKCE re-auth — even though a valid refresh token was already stored.
- Resolvers now call `authStorage.getApiKey("anthropic")` on expired oauth creds, which triggers mastracode's `refreshToken()` against `console.anthropic.com/v1/oauth/token` and persists the refreshed credential. `getAnthropicAuthStatus` does the same before declaring `issue: "expired"`.
- Mirrors the pattern already used for OpenAI small-model auth (`small-model.ts`).

## Files changed
- `packages/chat/src/server/desktop/auth/anthropic/anthropic.ts` — `getCredentialsFromAuthStorage` / `getCredentialsFromAnySource` now `async`; refreshes via `getApiKey` when oauth cred is past expiry.
- `packages/chat/src/server/desktop/chat-service/chat-service.ts` — `getAnthropicAuthStatus` now `async`; attempts refresh before downgrading managed OAuth to `issue: "expired"`.
- `packages/host-service/.../resolveAnthropicCredential.ts` — same pattern; `LocalModelProvider.resolveRuntimeEnv` cascaded to `async`.
- `packages/chat/src/server/desktop/small-model/small-model.ts` — `SmallModelProvider.resolveCredentials` type widened to allow `Promise`.
- `apps/desktop/src/lib/ai/call-small-model.ts` — awaits `resolveCredentials()`.
- Tests updated (`chat-service.test.ts`): mocks return async, expired-OAuth callsites now `await`.

## Test plan
- [x] `bun run typecheck` — passes across all 25 packages.
- [x] `bun run lint` — clean.
- [x] `bun test` — chat (122), host-service (112), call-small-model (9) all pass.
- [ ] Sign in to Anthropic in desktop app, wait ~1 hour (or force-expire the stored `expires`), send a chat message — should succeed silently without a Reconnect prompt.
- [ ] Invalidate the refresh token — should fall through to the existing expired-state UX (Reconnect button).
- [ ] Confirm OpenAI flow still works end-to-end (no regression).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-refresh expired Anthropic OAuth tokens to prevent “Reconnect” prompts and avoid full re-auth. This uses `mastracode`’s refresh flow via `authStorage.getApiKey("anthropic")` and persists the refreshed token.

- **Bug Fixes**
  - Trigger refresh on expiry in Anthropic resolvers and auth status, using `authStorage.getApiKey("anthropic")`.
  - Made Anthropic credential resolution async; `ChatService.getAnthropicAuthStatus()` is now async and refreshes before marking expired.
  - `SmallModelProvider.resolveCredentials` now supports `Promise`; `call-small-model` awaits provider creds.
  - `LocalModelProvider` runtime env resolution is async; `resolveAnthropicCredential` attempts refresh on expired OAuth.
  - Tests updated to await new async paths.

- **Migration**
  - Await `ChatService.getAnthropicAuthStatus()` in callers.
  - If implementing `SmallModelProvider`, you can now return a `Promise` from `resolveCredentials`; ensure callers `await` it.

<sup>Written for commit e467666191a60236ad3971619f6c959c2178cf63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Credential resolution process is now asynchronous for improved authentication reliability.
  * OAuth credentials now automatically refresh when expired, reducing authentication failures.
  * Enhanced credential handling and error propagation timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->