### PR TITLE
fix(desktop): Cmd+O firing open-in twice on v1 workspace route

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -301,7 +301,6 @@ function WorkspacePage() {
 			});
 		}
 	}, [workspace?.worktreePath, resolvedDefaultApp, mutateOpenInApp, projectId]);
-	useHotkey("OPEN_IN_APP", handleOpenInApp);
 
 	// Copy path shortcut
 	const { copyToClipboard } = useCopyToClipboard();


### PR DESCRIPTION
## Summary
- `OPEN_IN_APP` was registered in two places on the v1 workspace route — `OpenInMenuButton` and the page component — each with its own `electronTrpc.external.openInApp.useMutation()` instance. `react-hotkeys-hook` fires every registered listener, so Cmd+O triggered two mutations while clicking the button triggered one, causing the external app to be opened twice (and racing `projects.getDefaultApp` invalidation).
- Remove the page-level `useHotkey("OPEN_IN_APP", handleOpenInApp)` in `workspace/$workspaceId/page.tsx` so the shortcut is handled only by `OpenInMenuButton`, matching the click path exactly.
- `resolvedDefaultApp` / `handleOpenInApp` stay in the page because `WorkspaceLayout` still uses them (`defaultExternalApp`, `onOpenInApp`) for EmptyTabView etc.

## Test plan
- [ ] On a v1 workspace route, press Cmd+O — the configured external app opens exactly once.
- [ ] Click the Open In button — the configured external app still opens exactly once.
- [ ] Open the dropdown and choose a different app — it opens once and becomes the new default.
- [ ] EmptyTabView's "Open in app" link still works (uses `onOpenInApp` from the page).
- [ ] v2 workspace route: Cmd+O and the V2 Open In button continue to behave the same (untouched).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cmd+O on the v1 workspace route opening the external app twice by removing the duplicate `OPEN_IN_APP` hotkey listener so the shortcut uses the same handler as the Open In button.

- **Bug Fixes**
  - Removed `useHotkey("OPEN_IN_APP", handleOpenInApp)` from `workspace/$workspaceId/page.tsx`; `OpenInMenuButton` now exclusively handles the shortcut.
  - Left `resolvedDefaultApp`/`onOpenInApp` on the page for `WorkspaceLayout`/EmptyTabView; v2 workspace route unchanged.

<sup>Written for commit 753fdf20d2a4935ff13a58bb854e1f270540236b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed hotkey trigger for opening items in app; the feature continues to work through alternative methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->