### PR TITLE
fix(desktop): prevent keyboard shortcuts from leaking characters into chat input

### DIFF
--- a/apps/desktop/src/renderer/hotkeys/hooks/useHotkey/useHotkey.ts
+++ b/apps/desktop/src/renderer/hotkeys/hooks/useHotkey/useHotkey.ts
@@ -16,7 +16,10 @@ export function useHotkey(
 	callbackRef.current = callback;
 	useHotkeys(
 		keys ?? "",
-		(e, _h) => callbackRef.current(e),
+		(e, _h) => {
+			e.preventDefault();
+			callbackRef.current(e);
+		},
 		{ enableOnFormTags: true, enableOnContentEditable: true, ...options },
 		[keys],
 	);

--- a/apps/desktop/src/renderer/hotkeys/hooks/useHotkey/useHotkey.ts
+++ b/apps/desktop/src/renderer/hotkeys/hooks/useHotkey/useHotkey.ts
@@ -17,7 +17,9 @@ export function useHotkey(
 	useHotkeys(
 		keys ?? "",
 		(e, _h) => {
-			e.preventDefault();
+			if (options?.preventDefault !== false) {
+				e.preventDefault();
+			}
 			callbackRef.current(e);
 		},
 		{ enableOnFormTags: true, enableOnContentEditable: true, ...options },


### PR DESCRIPTION
## Summary

- Keyboard shortcuts (e.g. Option+J/K for workspace navigation) were inserting the resulting special character into the chat input of the newly focused workspace
- Root cause: `useHotkey` called the handler but never called `e.preventDefault()`, so the browser still processed the key event and typed the character
- Fix: call `e.preventDefault()` in the central `useHotkey` wrapper before invoking the callback, covering all registered shortcuts

## Test plan

- [ ] Use Option+J / Option+K (or Cmd+Alt+Up/Down) to switch between workspaces — no stray characters should appear in the chat input
- [ ] Verify other hotkeys (new workspace, toggle sidebar, close workspace, jump-to shortcuts) still work correctly
- [ ] Verify chat input typing is unaffected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents hotkey combos from inserting characters into inputs when switching workspaces. Hotkeys now block default key actions so the browser doesn’t type stray characters.

- **Bug Fixes**
  - In the central `useHotkey` hook, call `e.preventDefault()` before the callback; this is default-on and can be disabled via `options.preventDefault = false`.

<sup>Written for commit 1b95c65234c8713a776d3ef10b4d4e2612ce2ea7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hotkeys in the desktop app now suppress default browser actions by default, preventing unintended behaviors when shortcuts are triggered.
  * Hotkey callbacks continue to receive the original keyboard event, and there is an option to allow default browser behavior when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->