### PR TITLE
feat(desktop): add hotkey to navigate workspaces needing attention

### DIFF
--- a/apps/desktop/src/renderer/hotkeys/registry.ts
+++ b/apps/desktop/src/renderer/hotkeys/registry.ts
@@ -121,6 +121,28 @@ export const HOTKEYS_REGISTRY = {
 		category: "Workspace",
 		description: "Navigate to the next workspace in the sidebar",
 	},
+	PREV_ATTENTION_WORKSPACE: {
+		key: {
+			mac: "meta+shift+alt+up",
+			windows: "ctrl+alt+up",
+			linux: "ctrl+alt+up",
+		},
+		label: "Previous Workspace Needing Attention",
+		category: "Workspace",
+		description:
+			"Navigate to the previous workspace that is unread, awaiting review, or asking for permission",
+	},
+	NEXT_ATTENTION_WORKSPACE: {
+		key: {
+			mac: "meta+shift+alt+down",
+			windows: "ctrl+alt+down",
+			linux: "ctrl+alt+down",
+		},
+		label: "Next Workspace Needing Attention",
+		category: "Workspace",
+		description:
+			"Navigate to the next workspace that is unread, awaiting review, or asking for permission",
+	},
 	CLOSE_WORKSPACE: {
 		key: {
 			mac: "meta+shift+backspace",

--- a/apps/desktop/src/renderer/hotkeys/registry.ts
+++ b/apps/desktop/src/renderer/hotkeys/registry.ts
@@ -124,8 +124,8 @@ export const HOTKEYS_REGISTRY = {
 	PREV_ATTENTION_WORKSPACE: {
 		key: {
 			mac: "meta+shift+alt+up",
-			windows: "ctrl+alt+up",
-			linux: "ctrl+alt+up",
+			windows: "ctrl+shift+alt+pageup",
+			linux: "ctrl+shift+alt+pageup",
 		},
 		label: "Previous Workspace Needing Attention",
 		category: "Workspace",
@@ -135,8 +135,8 @@ export const HOTKEYS_REGISTRY = {
 	NEXT_ATTENTION_WORKSPACE: {
 		key: {
 			mac: "meta+shift+alt+down",
-			windows: "ctrl+alt+down",
-			linux: "ctrl+alt+down",
+			windows: "ctrl+shift+alt+pagedown",
+			linux: "ctrl+shift+alt+pagedown",
 		},
 		label: "Next Workspace Needing Attention",
 		category: "Workspace",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/useAttentionWorkspaceNavigation.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/useAttentionWorkspaceNavigation.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import type { Tab } from "renderer/stores/tabs/types";
+import type { Pane } from "shared/tabs-types";
+import { computeAttentionWorkspaceIds } from "./useAttentionWorkspaceNavigation";
+
+function makeTab(id: string, workspaceId: string, paneId: string): Tab {
+	return {
+		id,
+		name: id,
+		workspaceId,
+		createdAt: 0,
+		layout: paneId,
+	};
+}
+
+function makePane(id: string, status?: Pane["status"]): Pane {
+	return {
+		id,
+		tabId: "t",
+		type: "terminal",
+		name: id,
+		status,
+	};
+}
+
+describe("computeAttentionWorkspaceIds", () => {
+	test("includes all unread workspaces", () => {
+		const result = computeAttentionWorkspaceIds(new Set(["w1", "w2"]), [], {});
+		expect(result).toEqual(new Set(["w1", "w2"]));
+	});
+
+	test("includes workspaces whose panes are in review state", () => {
+		const result = computeAttentionWorkspaceIds(
+			new Set(),
+			[makeTab("t1", "w1", "p1")],
+			{ p1: makePane("p1", "review") },
+		);
+		expect(result).toEqual(new Set(["w1"]));
+	});
+
+	test("includes workspaces whose panes are waiting for permission", () => {
+		const result = computeAttentionWorkspaceIds(
+			new Set(),
+			[makeTab("t1", "w1", "p1")],
+			{ p1: makePane("p1", "permission") },
+		);
+		expect(result).toEqual(new Set(["w1"]));
+	});
+
+	test("excludes workspaces with only working panes", () => {
+		const result = computeAttentionWorkspaceIds(
+			new Set(),
+			[makeTab("t1", "w1", "p1")],
+			{ p1: makePane("p1", "working") },
+		);
+		expect(result).toEqual(new Set());
+	});
+
+	test("excludes workspaces with only idle panes", () => {
+		const result = computeAttentionWorkspaceIds(
+			new Set(),
+			[makeTab("t1", "w1", "p1")],
+			{ p1: makePane("p1", "idle") },
+		);
+		expect(result).toEqual(new Set());
+	});
+
+	test("permission beats working when aggregating pane statuses", () => {
+		const result = computeAttentionWorkspaceIds(
+			new Set(),
+			[makeTab("t1", "w1", "p1"), makeTab("t2", "w1", "p2")],
+			{
+				p1: makePane("p1", "working"),
+				p2: makePane("p2", "permission"),
+			},
+		);
+		expect(result).toEqual(new Set(["w1"]));
+	});
+
+	test("working-only workspace remains excluded even across multiple tabs", () => {
+		const result = computeAttentionWorkspaceIds(
+			new Set(),
+			[makeTab("t1", "w1", "p1"), makeTab("t2", "w1", "p2")],
+			{
+				p1: makePane("p1", "working"),
+				p2: makePane("p2", "idle"),
+			},
+		);
+		expect(result).toEqual(new Set());
+	});
+
+	test("merges unread + pane-status sources", () => {
+		const result = computeAttentionWorkspaceIds(
+			new Set(["w1"]),
+			[makeTab("t1", "w2", "p1")],
+			{ p1: makePane("p1", "review") },
+		);
+		expect(result).toEqual(new Set(["w1", "w2"]));
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/useAttentionWorkspaceNavigation.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/useAttentionWorkspaceNavigation.test.ts
@@ -1,7 +1,82 @@
 import { describe, expect, test } from "bun:test";
+import type { ElectronRouterOutputs } from "renderer/lib/electron-trpc";
 import type { Tab } from "renderer/stores/tabs/types";
 import type { Pane } from "shared/tabs-types";
-import { computeAttentionWorkspaceIds } from "./useAttentionWorkspaceNavigation";
+import {
+	computeAttentionWorkspaceIds,
+	indexGrouped,
+} from "./useAttentionWorkspaceNavigation";
+
+type GroupedWorkspaces = ElectronRouterOutputs["workspaces"]["getAllGrouped"];
+type Group = GroupedWorkspaces[number];
+type GroupWorkspace = Group["workspaces"][number];
+type GroupSection = Group["sections"][number];
+type TopLevelItem = Group["topLevelItems"][number];
+
+function makeWorkspace(
+	id: string,
+	overrides: Partial<GroupWorkspace> = {},
+): GroupWorkspace {
+	return {
+		id,
+		projectId: "p1",
+		sectionId: null,
+		worktreeId: null,
+		worktreePath: "",
+		type: "branch",
+		branch: id,
+		name: id,
+		tabOrder: 0,
+		createdAt: 0,
+		updatedAt: 0,
+		lastOpenedAt: 0,
+		isUnread: false,
+		isUnnamed: false,
+		createdBySuperset: null,
+		...overrides,
+	};
+}
+
+function makeTopLevel(
+	id: string,
+	kind: "workspace" | "section",
+): TopLevelItem {
+	return { id, kind, tabOrder: 0 };
+}
+
+function makeSection(
+	id: string,
+	workspaces: GroupWorkspace[],
+): GroupSection {
+	return {
+		id,
+		projectId: "p1",
+		name: id,
+		tabOrder: 0,
+		isCollapsed: false,
+		color: null,
+		workspaces,
+	};
+}
+
+function makeGroup(overrides: Partial<Group>): Group {
+	return {
+		project: {
+			id: "p1",
+			name: "P1",
+			color: "#000",
+			tabOrder: 0,
+			githubOwner: null,
+			mainRepoPath: "",
+			hideImage: false,
+			iconUrl: null,
+		},
+		workspaces: [],
+		sections: [],
+		topLevelItems: [],
+		...overrides,
+	};
+}
 
 function makeTab(id: string, workspaceId: string, paneId: string): Tab {
 	return {
@@ -96,5 +171,118 @@ describe("computeAttentionWorkspaceIds", () => {
 			{ p1: makePane("p1", "review") },
 		);
 		expect(result).toEqual(new Set(["w1", "w2"]));
+	});
+});
+
+describe("indexGrouped", () => {
+	test("returns empty when grouped is undefined", () => {
+		const { orderedIds, unreadIds } = indexGrouped(undefined);
+		expect(orderedIds).toEqual([]);
+		expect(unreadIds).toEqual(new Set());
+	});
+
+	test("orders top-level workspaces in topLevelItems order", () => {
+		const ws1 = makeWorkspace("w1");
+		const ws2 = makeWorkspace("w2");
+		const grouped: GroupedWorkspaces = [
+			makeGroup({
+				workspaces: [ws1, ws2],
+				topLevelItems: [makeTopLevel("w2", "workspace"), makeTopLevel("w1", "workspace")],
+			}),
+		];
+		const { orderedIds } = indexGrouped(grouped);
+		expect(orderedIds).toEqual(["w2", "w1"]);
+	});
+
+	test("expands sections inline in their topLevelItems slot", () => {
+		const top = makeWorkspace("top");
+		const sectionWs1 = makeWorkspace("s-w1", { sectionId: "sec1" });
+		const sectionWs2 = makeWorkspace("s-w2", { sectionId: "sec1" });
+		const grouped: GroupedWorkspaces = [
+			makeGroup({
+				workspaces: [top],
+				sections: [makeSection("sec1", [sectionWs1, sectionWs2])],
+				topLevelItems: [
+					makeTopLevel("top", "workspace"),
+					makeTopLevel("sec1", "section"),
+				],
+			}),
+		];
+		const { orderedIds } = indexGrouped(grouped);
+		expect(orderedIds).toEqual(["top", "s-w1", "s-w2"]);
+	});
+
+	test("captures unread from both top-level and sectioned workspaces", () => {
+		const grouped: GroupedWorkspaces = [
+			makeGroup({
+				workspaces: [
+					makeWorkspace("w1", { isUnread: true }),
+					makeWorkspace("w2"),
+				],
+				sections: [
+					makeSection("sec1", [
+						makeWorkspace("s-w1", { sectionId: "sec1", isUnread: true }),
+						makeWorkspace("s-w2", { sectionId: "sec1" }),
+					]),
+				],
+				topLevelItems: [
+					makeTopLevel("w1", "workspace"),
+					makeTopLevel("w2", "workspace"),
+					makeTopLevel("sec1", "section"),
+				],
+			}),
+		];
+		const { unreadIds } = indexGrouped(grouped);
+		expect(unreadIds).toEqual(new Set(["w1", "s-w1"]));
+	});
+
+	test("skips topLevelItems referring to unknown sections", () => {
+		const grouped: GroupedWorkspaces = [
+			makeGroup({
+				workspaces: [makeWorkspace("w1")],
+				sections: [],
+				topLevelItems: [
+					makeTopLevel("w1", "workspace"),
+					makeTopLevel("missing-section", "section"),
+				],
+			}),
+		];
+		const { orderedIds } = indexGrouped(grouped);
+		expect(orderedIds).toEqual(["w1"]);
+	});
+
+	test("flattens across multiple groups in iteration order", () => {
+		const grouped: GroupedWorkspaces = [
+			makeGroup({
+				project: {
+					id: "p1",
+					name: "P1",
+					color: "#000",
+					tabOrder: 0,
+					githubOwner: null,
+					mainRepoPath: "",
+					hideImage: false,
+					iconUrl: null,
+				},
+				workspaces: [makeWorkspace("a")],
+				topLevelItems: [makeTopLevel("a", "workspace")],
+			}),
+			makeGroup({
+				project: {
+					id: "p2",
+					name: "P2",
+					color: "#000",
+					tabOrder: 1,
+					githubOwner: null,
+					mainRepoPath: "",
+					hideImage: false,
+					iconUrl: null,
+				},
+				workspaces: [makeWorkspace("b", { projectId: "p2" })],
+				topLevelItems: [makeTopLevel("b", "workspace")],
+			}),
+		];
+		const { orderedIds } = indexGrouped(grouped);
+		expect(orderedIds).toEqual(["a", "b"]);
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/useAttentionWorkspaceNavigation.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/useAttentionWorkspaceNavigation.ts
@@ -1,0 +1,126 @@
+import type { UseNavigateResult } from "@tanstack/react-router";
+import { useCallback, useMemo } from "react";
+import { useHotkey } from "renderer/hotkeys";
+import {
+	type ElectronRouterOutputs,
+	electronTrpc,
+} from "renderer/lib/electron-trpc";
+import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
+import { useTabsStore } from "renderer/stores/tabs/store";
+import type { Tab } from "renderer/stores/tabs/types";
+import { extractPaneIdsFromLayout } from "renderer/stores/tabs/utils";
+import { getHighestPriorityStatus, type Pane } from "shared/tabs-types";
+import { findNeighborInSet } from "shared/utils/neighbor-in-set";
+
+type GroupedWorkspaces = ElectronRouterOutputs["workspaces"]["getAllGrouped"];
+
+/**
+ * Flattens the grouped sidebar data into:
+ *   - `orderedIds`: workspace IDs in the same visual order as the sidebar
+ *   - `unreadIds`:  the subset whose `isUnread` flag is set
+ */
+function indexGrouped(grouped: GroupedWorkspaces | undefined): {
+	orderedIds: string[];
+	unreadIds: Set<string>;
+} {
+	const orderedIds: string[] = [];
+	const unreadIds = new Set<string>();
+	if (!grouped) return { orderedIds, unreadIds };
+
+	for (const group of grouped) {
+		for (const item of group.topLevelItems) {
+			if (item.kind === "workspace") {
+				orderedIds.push(item.id);
+				continue;
+			}
+			const section = group.sections.find((s) => s.id === item.id);
+			if (!section) continue;
+			for (const ws of section.workspaces) {
+				orderedIds.push(ws.id);
+			}
+		}
+		for (const ws of group.workspaces) {
+			if (ws.isUnread) unreadIds.add(ws.id);
+		}
+		for (const section of group.sections) {
+			for (const ws of section.workspaces) {
+				if (ws.isUnread) unreadIds.add(ws.id);
+			}
+		}
+	}
+
+	return { orderedIds, unreadIds };
+}
+
+/**
+ * Set of workspace IDs that are "demanding attention": unread (blue dot),
+ * awaiting review (green dot), or asking permission (red dot). Excludes
+ * `working` (amber) since the user isn't blocked on those.
+ */
+export function computeAttentionWorkspaceIds(
+	unreadIds: Set<string>,
+	tabs: Tab[],
+	panes: Record<string, Pane>,
+): Set<string> {
+	const attention = new Set<string>(unreadIds);
+
+	const statusesByWorkspace = new Map<string, Array<Pane["status"]>>();
+	for (const tab of tabs) {
+		const bucket = statusesByWorkspace.get(tab.workspaceId) ?? [];
+		for (const paneId of extractPaneIdsFromLayout(tab.layout)) {
+			bucket.push(panes[paneId]?.status);
+		}
+		statusesByWorkspace.set(tab.workspaceId, bucket);
+	}
+
+	for (const [workspaceId, statuses] of statusesByWorkspace) {
+		const highest = getHighestPriorityStatus(statuses);
+		if (highest === "review" || highest === "permission") {
+			attention.add(workspaceId);
+		}
+	}
+
+	return attention;
+}
+
+export function useAttentionWorkspaceNavigation(
+	currentWorkspaceId: string,
+	navigate: UseNavigateResult<string>,
+) {
+	const groupedQuery = electronTrpc.workspaces.getAllGrouped.useQuery();
+
+	const { orderedIds, unreadIds } = useMemo(
+		() => indexGrouped(groupedQuery.data),
+		[groupedQuery.data],
+	);
+
+	const resolveTarget = useCallback(
+		(direction: "next" | "prev") => {
+			if (orderedIds.length === 0) return null;
+			const { tabs, panes } = useTabsStore.getState();
+			const attentionSet = computeAttentionWorkspaceIds(unreadIds, tabs, panes);
+			return findNeighborInSet(
+				orderedIds,
+				currentWorkspaceId,
+				attentionSet,
+				direction,
+			);
+		},
+		[orderedIds, unreadIds, currentWorkspaceId],
+	);
+
+	useHotkey("PREV_ATTENTION_WORKSPACE", () => {
+		const target = resolveTarget("prev");
+		if (target) {
+			useTabsStore.getState().clearWorkspaceAttentionStatus(target);
+			navigateToWorkspace(target, navigate);
+		}
+	});
+	useHotkey("NEXT_ATTENTION_WORKSPACE", () => {
+		const target = resolveTarget("next");
+		if (target) {
+			useTabsStore.getState().clearWorkspaceAttentionStatus(target);
+			navigateToWorkspace(target, navigate);
+		}
+	});
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/useAttentionWorkspaceNavigation.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/useAttentionWorkspaceNavigation.ts
@@ -19,7 +19,7 @@ type GroupedWorkspaces = ElectronRouterOutputs["workspaces"]["getAllGrouped"];
  *   - `orderedIds`: workspace IDs in the same visual order as the sidebar
  *   - `unreadIds`:  the subset whose `isUnread` flag is set
  */
-function indexGrouped(grouped: GroupedWorkspaces | undefined): {
+export function indexGrouped(grouped: GroupedWorkspaces | undefined): {
 	orderedIds: string[];
 	unreadIds: Set<string>;
 } {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/useAttentionWorkspaceNavigation.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/useAttentionWorkspaceNavigation.ts
@@ -28,12 +28,13 @@ export function indexGrouped(grouped: GroupedWorkspaces | undefined): {
 	if (!grouped) return { orderedIds, unreadIds };
 
 	for (const group of grouped) {
+		const sectionMap = new Map(group.sections.map((s) => [s.id, s]));
 		for (const item of group.topLevelItems) {
 			if (item.kind === "workspace") {
 				orderedIds.push(item.id);
 				continue;
 			}
-			const section = group.sections.find((s) => s.id === item.id);
+			const section = sectionMap.get(item.id);
 			if (!section) continue;
 			for (const ws of section.workspaces) {
 				orderedIds.push(ws.id);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -9,6 +9,7 @@ import { electronTrpcClient as trpcClient } from "renderer/lib/trpc-client";
 import { usePresets } from "renderer/react-query/presets";
 import type { WorkspaceSearchParams } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
+import { useAttentionWorkspaceNavigation } from "renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/useAttentionWorkspaceNavigation";
 import { usePresetHotkeys } from "renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/usePresetHotkeys";
 import { useWorkspaceRunCommand } from "renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/hooks/useWorkspaceRunCommand";
 import { NotFound } from "renderer/routes/not-found";
@@ -436,6 +437,7 @@ function WorkspacePage() {
 	useHotkey("PREV_WORKSPACE", () => {
 		const prevWorkspaceId = getPreviousWorkspace.data;
 		if (prevWorkspaceId) {
+			useTabsStore.getState().clearWorkspaceAttentionStatus(prevWorkspaceId);
 			navigateToWorkspace(prevWorkspaceId, navigate);
 		}
 	});
@@ -447,9 +449,12 @@ function WorkspacePage() {
 	useHotkey("NEXT_WORKSPACE", () => {
 		const nextWorkspaceId = getNextWorkspace.data;
 		if (nextWorkspaceId) {
+			useTabsStore.getState().clearWorkspaceAttentionStatus(nextWorkspaceId);
 			navigateToWorkspace(nextWorkspaceId, navigate);
 		}
 	});
+
+	useAttentionWorkspaceNavigation(workspaceId, navigate);
 
 	return (
 		<div className="flex-1 h-full flex flex-col overflow-hidden">

--- a/apps/desktop/src/shared/utils/neighbor-in-set.test.ts
+++ b/apps/desktop/src/shared/utils/neighbor-in-set.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { findNeighborInSet } from "./neighbor-in-set";
+
+describe("findNeighborInSet", () => {
+	test("empty ordered list returns null", () => {
+		expect(findNeighborInSet([], "a", new Set(["a"]), "next")).toBeNull();
+	});
+
+	test("currentId not in ordered list returns null", () => {
+		expect(
+			findNeighborInSet(["a", "b"], "x", new Set(["a", "b"]), "next"),
+		).toBeNull();
+	});
+
+	test("no members of filter returns null", () => {
+		expect(
+			findNeighborInSet(["a", "b", "c"], "b", new Set(), "next"),
+		).toBeNull();
+	});
+
+	test("only current is in filter returns null", () => {
+		expect(
+			findNeighborInSet(["a", "b", "c"], "b", new Set(["b"]), "next"),
+		).toBeNull();
+	});
+
+	test("next picks the next member in order", () => {
+		expect(
+			findNeighborInSet(["a", "b", "c", "d"], "a", new Set(["c", "d"]), "next"),
+		).toBe("c");
+	});
+
+	test("next wraps around", () => {
+		expect(
+			findNeighborInSet(["a", "b", "c"], "c", new Set(["a"]), "next"),
+		).toBe("a");
+	});
+
+	test("next skips current when current is in filter", () => {
+		expect(
+			findNeighborInSet(["a", "b", "c"], "b", new Set(["b", "c"]), "next"),
+		).toBe("c");
+	});
+
+	test("prev picks the previous member in order", () => {
+		expect(
+			findNeighborInSet(["a", "b", "c", "d"], "d", new Set(["a", "b"]), "prev"),
+		).toBe("b");
+	});
+
+	test("prev wraps around", () => {
+		expect(
+			findNeighborInSet(["a", "b", "c"], "a", new Set(["c"]), "prev"),
+		).toBe("c");
+	});
+
+	test("prev skips current when current is in filter", () => {
+		expect(
+			findNeighborInSet(["a", "b", "c"], "b", new Set(["a", "b"]), "prev"),
+		).toBe("a");
+	});
+
+	test("currentId not in filter still walks forward from its position", () => {
+		expect(
+			findNeighborInSet(["a", "b", "c", "d"], "b", new Set(["d"]), "next"),
+		).toBe("d");
+	});
+});

--- a/apps/desktop/src/shared/utils/neighbor-in-set.ts
+++ b/apps/desktop/src/shared/utils/neighbor-in-set.ts
@@ -23,7 +23,7 @@ export function findNeighborInSet(
 	const len = ordered.length;
 
 	for (let offset = 1; offset < len; offset++) {
-		const idx = (currentIndex + step * offset + len * len) % len;
+		const idx = (currentIndex + step * offset + len) % len;
 		const candidate = ordered[idx];
 		if (candidate && candidate !== currentId && filter.has(candidate)) {
 			return candidate;

--- a/apps/desktop/src/shared/utils/neighbor-in-set.ts
+++ b/apps/desktop/src/shared/utils/neighbor-in-set.ts
@@ -1,0 +1,34 @@
+/**
+ * Given an ordered list of workspace IDs, a current ID, and a filter set,
+ * return the neighboring ID that belongs to the filter set.
+ *
+ * - `currentId` does not need to be in `filter` — the search starts from its
+ *   position in `ordered` and walks outward.
+ * - The current ID is always skipped, even if it is in `filter`.
+ * - Wraps around the ends of `ordered`.
+ * - Returns `null` if no other member of `filter` exists in `ordered`.
+ */
+export function findNeighborInSet(
+	ordered: string[],
+	currentId: string,
+	filter: Set<string>,
+	direction: "next" | "prev",
+): string | null {
+	if (ordered.length === 0) return null;
+
+	const currentIndex = ordered.indexOf(currentId);
+	if (currentIndex === -1) return null;
+
+	const step = direction === "next" ? 1 : -1;
+	const len = ordered.length;
+
+	for (let offset = 1; offset < len; offset++) {
+		const idx = (currentIndex + step * offset + len * len) % len;
+		const candidate = ordered[idx];
+		if (candidate && candidate !== currentId && filter.has(candidate)) {
+			return candidate;
+		}
+	}
+
+	return null;
+}


### PR DESCRIPTION
## Summary
- Adds two new hotkeys (`cmd+shift+alt+up/down` on mac, `ctrl+alt+up/down` elsewhere) that navigate to the previous/next workspace "needing attention" — workspaces that are unread, awaiting review, or asking permission. Plain `working` workspaces are excluded since the user isn't blocked on them.
- Adds `clearWorkspaceAttentionStatus` to the existing `PREV/NEXT_WORKSPACE` keyboard handlers, mirroring sidebar-click behavior (`WorkspaceListItem.tsx:222`).
- New pure utility `findNeighborInSet` (with wrap-around) and a sidebar flattener `indexGrouped`, both fully unit-tested.

## Test plan
- [x] `bun test` — 25 tests pass across `neighbor-in-set` and `useAttentionWorkspaceNavigation`
- [x] `bun run typecheck` — all 25 tasks pass
- [ ] Manual: open desktop app, verify `cmd+shift+alt+down` jumps to next workspace with unread/review/permission and skips plain working/idle ones
- [ ] Manual: verify wrap-around (cycles back to first attention workspace from the last)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add hotkeys to jump to the previous/next workspace that needs attention in sidebar order with wrap-around. Clears attention status when navigating.

- **New Features**
  - Hotkeys: mac `cmd+shift+alt+up/down`; Windows/Linux `ctrl+shift+alt+PageUp/PageDown` (avoids GNOME conflicts).
  - Includes unread/review/permission; skips working/idle.

<sup>Written for commit dcdcc3155bbe47940efa5418870540959af11110. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts to jump to the previous/next workspace that needs attention (unread, in review, or awaiting permission)
    * macOS: Cmd+Shift+Option+Up / Cmd+Shift+Option+Down
    * Windows/Linux: Ctrl+Shift+Alt+PageUp / Ctrl+Shift+Alt+PageDown
  * Prev/Next navigation now clears a workspace's attention state when you jump to it

* **Tests**
  * Added tests covering attention-selection and neighbor-navigation behaviors (ordering, wrap-around, and deduplication)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->