### PR TITLE
fix(desktop): improve keyboard shortcuts page focus behavior

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/keyboard/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/keyboard/page.tsx
@@ -11,7 +11,8 @@ import { Input } from "@superset/ui/input";
 import { Kbd, KbdGroup } from "@superset/ui/kbd";
 import { toast } from "@superset/ui/sonner";
 import { createFileRoute } from "@tanstack/react-router";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
 import { HiMagnifyingGlass } from "react-icons/hi2";
 import {
 	formatHotkeyDisplay,
@@ -116,6 +117,7 @@ const hotkeysByCategory = getHotkeysByCategory();
 function KeyboardShortcutsPage() {
 	const [searchQuery, setSearchQuery] = useState("");
 	const [recordingId, setRecordingId] = useState<HotkeyId | null>(null);
+	const searchRef = useRef<HTMLInputElement>(null);
 	const [pendingConflict, setPendingConflict] = useState<{
 		targetId: HotkeyId;
 		keys: string;
@@ -125,6 +127,14 @@ function KeyboardShortcutsPage() {
 	const resetOverride = useHotkeyOverridesStore((s) => s.resetOverride);
 	const resetAll = useHotkeyOverridesStore((s) => s.resetAll);
 	const setOverride = useHotkeyOverridesStore((s) => s.setOverride);
+
+	useHotkeys(
+		"/",
+		() => {
+			searchRef.current?.focus();
+		},
+		{ enableOnFormTags: false, preventDefault: true },
+	);
 
 	useRecordHotkeys(recordingId, {
 		onSave: () => setRecordingId(null),
@@ -204,10 +214,18 @@ function KeyboardShortcutsPage() {
 			<div className="relative mb-6">
 				<HiMagnifyingGlass className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
 				<Input
+					ref={searchRef}
 					type="text"
 					placeholder="Search"
 					value={searchQuery}
 					onChange={(e) => setSearchQuery(e.target.value)}
+					onKeyDown={(e) => {
+						if (e.key === "Escape") {
+							e.stopPropagation();
+							searchRef.current?.blur();
+						}
+					}}
+					autoFocus
 					className="pl-9 bg-accent/30 border-transparent focus:border-accent"
 				/>
 			</div>


### PR DESCRIPTION
## Summary
- Search input is now first-focused on open via `autoFocus` + `ref` (also fixes tab order)
- Pressing Escape while the search input is focused blurs it (without closing the page); a second Escape closes via the existing layout handler
- Pressing `/` while on the page focuses the search input without inserting a literal `/`

Closes ss-37w

## Test plan
- [ ] Open settings → keyboard shortcuts; search input is focused
- [ ] Type into search; press Escape — input blurs, page stays open
- [ ] Press Escape again — page closes
- [ ] With page open and focus elsewhere, press `/` — search focuses, no `/` inserted
- [ ] Inside focused search, typing `/` still inserts a literal `/`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves focus handling on the Keyboard Shortcuts settings page to make search faster and prevent accidental closes. Closes ss-37w.

- **Bug Fixes**
  - Search input auto-focuses on open and fixes tab order.
  - Escape in the search field blurs it without closing the page; a second Escape closes via the existing handler.
  - Pressing “/” focuses the search without inserting “/”; inside the search, “/” types normally.

<sup>Written for commit c3d0c38b8adad560588753d42a249ba53516c701. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut (/) to quickly focus the search input in settings
  * Added Escape key support to dismiss focus from the search input

<!-- end of auto-generated comment: release notes by coderabbit.ai -->