### PR TITLE
fix(desktop): defer xterm.open() until wrapper is in live DOM container

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -99,6 +99,15 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 	searchAddon: SearchAddon;
 	wrapper: HTMLDivElement;
 	linkManager: TerminalLinkManager;
+	/**
+	 * Opens xterm into the wrapper. Must be called AFTER the wrapper is
+	 * appended to a live, sized DOM container — otherwise xterm measures
+	 * a detached node (getBoundingClientRect returns zero) and renderer
+	 * state is initialized at fallback dimensions, producing a terminal
+	 * stuck at a smaller size than the container until the next resize.
+	 * Idempotent.
+	 */
+	openOnce: () => void;
 	cleanup: () => void;
 } {
 	const {
@@ -119,13 +128,17 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 	const imageAddon = new ImageAddon();
 
 	let disposed = false;
+	let opened = false;
 	let webglAddon: WebglAddon | null = null;
+	let webglRafId: number | null = null;
 
-	// Open into a detached wrapper div — not the live container.
+	// Create the wrapper but DO NOT call xterm.open() yet — the wrapper is
+	// detached from the live DOM here, so xterm would measure zero-sized
+	// and initialize renderers at fallback dimensions. The caller invokes
+	// openOnce() after appending the wrapper to its live container.
 	const wrapper = document.createElement("div");
 	wrapper.style.width = "100%";
 	wrapper.style.height = "100%";
-	xterm.open(wrapper);
 
 	xterm.loadAddon(fitAddon);
 	xterm.loadAddon(searchAddon);
@@ -139,23 +152,29 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 		// Ligatures not supported by current font
 	}
 
-	// Defer WebGL to rAF — same pattern as v2 terminal-addons.ts.
-	const rafId = requestAnimationFrame(() => {
-		if (disposed || suggestedRendererType === "dom") return;
+	const openOnce = () => {
+		if (opened || disposed) return;
+		opened = true;
+		xterm.open(wrapper);
 
-		try {
-			webglAddon = new WebglAddon();
-			webglAddon.onContextLoss(() => {
-				webglAddon?.dispose();
+		// Defer WebGL to rAF — same pattern as v2 terminal-addons.ts.
+		webglRafId = requestAnimationFrame(() => {
+			if (disposed || suggestedRendererType === "dom") return;
+
+			try {
+				webglAddon = new WebglAddon();
+				webglAddon.onContextLoss(() => {
+					webglAddon?.dispose();
+					webglAddon = null;
+					xterm.refresh(0, xterm.rows - 1);
+				});
+				xterm.loadAddon(webglAddon);
+			} catch {
+				suggestedRendererType = "dom";
 				webglAddon = null;
-				xterm.refresh(0, xterm.rows - 1);
-			});
-			xterm.loadAddon(webglAddon);
-		} catch {
-			suggestedRendererType = "dom";
-			webglAddon = null;
-		}
-	});
+			}
+		});
+	};
 
 	const cleanupQuerySuppression = suppressQueryResponses(xterm);
 
@@ -216,9 +235,10 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 		searchAddon,
 		wrapper,
 		linkManager,
+		openOnce,
 		cleanup: () => {
 			disposed = true;
-			cancelAnimationFrame(rafId);
+			if (webglRafId !== null) cancelAnimationFrame(webglRafId);
 			cleanupQuerySuppression();
 			linkManager.dispose();
 			try {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
@@ -21,6 +21,12 @@ export interface CachedTerminal {
 	fitAddon: FitAddon;
 	searchAddon: SearchAddon;
 	wrapper: HTMLDivElement;
+	/**
+	 * Opens xterm into the wrapper. Idempotent. Called on first attach,
+	 * after the wrapper is appended to a live container, so xterm's
+	 * initial DOM measurement sees the real container size.
+	 */
+	openOnce: () => void;
 	/** Disposes renderer RAF, query suppression, GPU renderer, etc. */
 	cleanupCreation: () => void;
 	/** Last known dimensions — used to skip no-op resize events. */
@@ -75,7 +81,7 @@ export function getOrCreate(
 		console.log(`[v1-terminal-cache] Creating new terminal: ${paneId}`);
 	}
 
-	const { xterm, fitAddon, searchAddon, wrapper, cleanup } =
+	const { xterm, fitAddon, searchAddon, wrapper, openOnce, cleanup } =
 		createTerminalInWrapper(options);
 
 	const entry: CachedTerminal = {
@@ -83,6 +89,7 @@ export function getOrCreate(
 		fitAddon,
 		searchAddon,
 		wrapper,
+		openOnce,
 		cleanupCreation: cleanup,
 		subscription: null,
 		streamReady: false,
@@ -110,6 +117,11 @@ export function attachToContainer(
 	if (!entry) return;
 
 	container.appendChild(entry.wrapper);
+
+	// Open xterm now that the wrapper is in a live, sized container.
+	// On first attach this performs xterm.open(); on subsequent attaches
+	// it's a no-op (idempotent) and we rely on the existing fit below.
+	entry.openOnce();
 
 	if (container.clientWidth > 0 && container.clientHeight > 0) {
 		entry.fitAddon.fit();


### PR DESCRIPTION
## Summary

- Fixes terminals rendering at constrained dimensions (e.g. "locked at half screen height") until a window/DevTools resize triggered `ResizeObserver` and kicked `fitAddon.fit()` through a second pass.
- Likely also fixes invisible/black-text-on-black at terminal startup until selection or resize, which appears to be the same root-cause family.

## Root cause

`xterm.open(wrapper)` ran inside `createTerminalInWrapper` while `wrapper` was still detached from the live DOM. xterm measures `getBoundingClientRect()` on `open()`, got zeros, and initialised renderer buffers at fallback dimensions. Subsequent `fitAddon.fit()` calls recomputed cols/rows, but some renderer state stayed primed from that first zero-size measurement — so the terminal only snapped to the right size after a real resize event fired `ResizeObserver`.

## Fix

Defer `xterm.open()` until the wrapper is actually inside a live, sized container:

- `helpers.ts` — removed the eager `xterm.open(wrapper)` from `createTerminalInWrapper`; added an idempotent `openOnce()` that performs `xterm.open(wrapper)` and then rAF-schedules the WebGL addon. Because `openOnce()` runs after the wrapper is live, xterm's initial DOM measurement sees real dimensions, and WebGL also initialises against a properly-laid-out DOM.
- `v1-terminal-cache.ts` — `attachToContainer` calls `entry.openOnce()` right after `container.appendChild(entry.wrapper)`. First attach opens the terminal; later attaches are no-ops.

No behaviour change for any other code path — `setup*Handler` calls still run after `attachToContainer` (they already did), so `xterm.element` is populated by the time they read it.

## Test plan

- [ ] Open a new agent in a fresh workspace — terminal should fill its container from first paint (no window resize needed)
- [ ] Create a new workspace in "main" mode (where the bug reproduced previously) — same check
- [ ] Restart the desktop app — terminals should render visible text without needing to open DevTools or select text
- [ ] Split a pane horizontally/vertically — both halves fill correctly
- [ ] Tab switch between terminals — no regression on reattach sizing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers `xterm.open()` until the terminal wrapper is in a live, sized DOM container to fix incorrect initial sizing and invisible text. Terminals now render at the correct size on first paint without needing a resize.

- **Bug Fixes**
  - `helpers.ts`: Remove eager `xterm.open(wrapper)` and add idempotent `openOnce()` that opens the terminal and rAF-initializes the WebGL addon after the wrapper is live.
  - `v1-terminal-cache.ts`: Call `openOnce()` immediately after appending the wrapper in `attachToContainer`; subsequent attaches are no-ops.
  - Resolves terminals stuck at half-height and black-text-on-black on startup; splits and tab switches size correctly.

<sup>Written for commit 3044eee09908e7d5c28f91666128b355c6a13f0f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized terminal initialization to defer rendering setup until the terminal is first displayed, reducing unnecessary startup overhead and improving responsiveness when terminals are not immediately visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->