### PR TITLE
chore(desktop): sync bun.lock to package version 1.5.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -110,7 +110,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.5.1",
+      "version": "1.5.3",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.43",
         "@ai-sdk/openai": "3.0.36",


### PR DESCRIPTION
## Summary
- Sync `bun.lock` workspace entry for `@superset/desktop` from 1.5.1 → 1.5.3, matching the `package.json` bump in #3419.

## Why / Context
#3419 bumped `apps/desktop/package.json` to 1.5.3 but the lockfile workspace entry was still resolved at 1.5.1. `bun install` in a fresh worktree re-resolved it to 1.5.3.

## Testing
- `bun install` succeeds with updated lockfile
- `bun dev` starts full stack cleanly (web + api + desktop + electric-proxy + caddy)

## Notes
- Local dev setup artifacts (`Caddyfile`, `.env`, `SUPERSET_WORKSPACE_NAME=local`) are gitignored — not included in this PR.