### PR TITLE
feat(desktop): promote "Create Section Below" to top-level on workspace menu

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
@@ -101,6 +101,7 @@ export function DashboardSidebarWorkspaceContextMenu({
 				<LuFolderPlus className="size-4 mr-2" />
 				Create Section Below
 			</ContextMenuItem>
+			{(sections.length > 0 || isInSection) && <ContextMenuSeparator />}
 			{sections.length > 0 && (
 				<ContextMenuSub>
 					<ContextMenuSubTrigger>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
@@ -97,33 +97,34 @@ export function DashboardSidebarWorkspaceContextMenu({
 				</>
 			)}
 			<ContextMenuSeparator />
-			<ContextMenuSub>
-				<ContextMenuSubTrigger>
-					<LuArrowRightLeft className="size-4 mr-2" />
-					Move to Section
-				</ContextMenuSubTrigger>
-				<ContextMenuSubContent>
-					<ContextMenuItem onSelect={onCreateSection}>
-						<LuFolderPlus className="size-4 mr-2" />
-						New Section
-					</ContextMenuItem>
-					{sections.length > 0 && <ContextMenuSeparator />}
-					{sections.map((section) => (
-						<ContextMenuItem
-							key={section.id}
-							onSelect={() => onMoveToSection(section.id)}
-						>
-							{section.color && (
-								<span
-									className="size-2 shrink-0 rounded-full mr-2"
-									style={{ backgroundColor: section.color }}
-								/>
-							)}
-							{section.name}
-						</ContextMenuItem>
-					))}
-				</ContextMenuSubContent>
-			</ContextMenuSub>
+			<ContextMenuItem onSelect={onCreateSection}>
+				<LuFolderPlus className="size-4 mr-2" />
+				Create Section Below
+			</ContextMenuItem>
+			{sections.length > 0 && (
+				<ContextMenuSub>
+					<ContextMenuSubTrigger>
+						<LuArrowRightLeft className="size-4 mr-2" />
+						Move to Section
+					</ContextMenuSubTrigger>
+					<ContextMenuSubContent>
+						{sections.map((section) => (
+							<ContextMenuItem
+								key={section.id}
+								onSelect={() => onMoveToSection(section.id)}
+							>
+								{section.color && (
+									<span
+										className="size-2 shrink-0 rounded-full mr-2"
+										style={{ backgroundColor: section.color }}
+									/>
+								)}
+								{section.name}
+							</ContextMenuItem>
+						))}
+					</ContextMenuSubContent>
+				</ContextMenuSub>
+			)}
 			{isInSection && (
 				<ContextMenuItem onSelect={() => onMoveToSection(null)}>
 					<LuArrowUp className="size-4 mr-2" />

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
@@ -99,8 +99,9 @@ export function useDashboardSidebarWorkspaceItemActions({
 	};
 
 	const handleCreateSection = () => {
-		const newSectionId = createSection(projectId);
-		moveWorkspaceToSection(workspaceId, projectId, newSectionId);
+		createSection(projectId, {
+			insertAfterWorkspaceId: workspaceId,
+		});
 	};
 
 	const resolveWorktreePath = async (): Promise<string | null> => {

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
@@ -182,25 +182,71 @@ export function useDashboardSidebarState() {
 	);
 
 	const createSection = useCallback(
-		(projectId: string, name = "New Section") => {
+		(
+			projectId: string,
+			options: { name?: string; insertAfterWorkspaceId?: string } = {},
+		) => {
+			const { name = "New Section", insertAfterWorkspaceId } = options;
 			ensureSidebarProjectRecord(collections, projectId);
 
 			const sectionId = crypto.randomUUID();
-			const sectionOrders = Array.from(
-				collections.v2SidebarSections.state.values(),
-			).filter((item) => item.projectId === projectId);
-
 			const randomColor =
 				PROJECT_CUSTOM_COLORS[
 					Math.floor(Math.random() * PROJECT_CUSTOM_COLORS.length)
 				].value;
+
+			let tabOrder: number;
+			if (insertAfterWorkspaceId) {
+				const anchorWorkspace = collections.v2WorkspaceLocalState.get(
+					insertAfterWorkspaceId,
+				);
+				const anchorTabOrder = anchorWorkspace?.sidebarState.sectionId
+					? (collections.v2SidebarSections.get(
+							anchorWorkspace.sidebarState.sectionId,
+						)?.tabOrder ?? 0)
+					: (anchorWorkspace?.sidebarState.tabOrder ?? 0);
+
+				for (const workspace of collections.v2WorkspaceLocalState.state.values()) {
+					if (
+						workspace.sidebarState.projectId === projectId &&
+						workspace.sidebarState.sectionId === null &&
+						workspace.sidebarState.tabOrder > anchorTabOrder
+					) {
+						const nextOrder = workspace.sidebarState.tabOrder + 1;
+						collections.v2WorkspaceLocalState.update(
+							workspace.workspaceId,
+							(draft) => {
+								draft.sidebarState.tabOrder = nextOrder;
+							},
+						);
+					}
+				}
+				for (const section of collections.v2SidebarSections.state.values()) {
+					if (
+						section.projectId === projectId &&
+						section.tabOrder > anchorTabOrder
+					) {
+						const nextOrder = section.tabOrder + 1;
+						collections.v2SidebarSections.update(section.sectionId, (draft) => {
+							draft.tabOrder = nextOrder;
+						});
+					}
+				}
+
+				tabOrder = anchorTabOrder + 1;
+			} else {
+				const sectionOrders = Array.from(
+					collections.v2SidebarSections.state.values(),
+				).filter((item) => item.projectId === projectId);
+				tabOrder = getNextTabOrder(sectionOrders);
+			}
 
 			collections.v2SidebarSections.insert({
 				sectionId,
 				projectId,
 				name,
 				createdAt: new Date(),
-				tabOrder: getNextTabOrder(sectionOrders),
+				tabOrder,
 				isCollapsed: false,
 				color: randomColor,
 			});


### PR DESCRIPTION
## Summary

- Section creation from a workspace's right-click menu was previously buried inside **Move to Section → New Section**, and the resulting section always appended to the end of the project. That made "create" and "move" feel like the same action and put the new section far from the workspace you acted on.
- Promote **Create Section Below** to a top-level item on the workspace context menu. It inserts an empty section directly below the right-clicked workspace (or its parent section, if the workspace is already grouped), so the position matches the label.
- The **Move to Section** submenu now only lists existing sections, and is hidden entirely when none exist. No more empty submenu.
- `useDashboardSidebarState.createSection` gained an `insertAfterWorkspaceId` option that bumps subsequent top-level items (ungrouped workspaces + sections) by +1 to make room. Default append-at-end behavior preserved for the project-level menu.

## Test plan

- [ ] Right-click a top-level workspace → "Create Section Below" places an empty section directly below it
- [ ] Right-click a workspace inside a section → new section appears below that parent section, workspace stays put
- [ ] With no existing sections, "Move to Section" submenu does not render
- [ ] Existing "Move to Section → {section}" and "Remove from Group" still work
- [ ] Project context menu → "New Section" still appends at the end

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promote section creation to a top-level “Create Section Below” in the workspace context menu. New sections appear directly under the clicked workspace (or its parent section) for predictable placement.

- **New Features**
  - Added “Create Section Below” to the workspace menu; inserts a blank section beneath the clicked workspace or its parent section.
  - “Move to Section” now lists only existing sections, is separated from create with a divider, and is hidden when none exist.
  - `useDashboardSidebarState.createSection` accepts `insertAfterWorkspaceId` to insert after a workspace and shift following top-level items; default append remains for the project menu.

<sup>Written for commit 43b8268317e751b87f9ed7ba1da49277005ee543. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Made "Create Section Below" a top-level action in the workspace context menu.
  * Always show the "Create Section Below" item and add a separator when relevant for clearer menu structure.
  * Only display the "Move to Section" submenu when sections exist, and simplified its contents to list available sections.
  * New sections are positioned directly after the selected workspace for more intuitive placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->