### PR TITLE
fix(desktop): wire drag-and-drop for files in v2 terminal panes

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -25,7 +25,7 @@ import { TerminalSearch } from "renderer/screens/main/components/WorkspaceView/C
 import { useTheme } from "renderer/stores/theme";
 import { resolveTerminalThemeType } from "renderer/stores/theme/utils";
 import { useTerminalAppearance } from "./hooks/useTerminalAppearance";
-import { shellEscapePath } from "./utils";
+import { shellEscapePaths } from "./utils";
 
 interface TerminalPaneProps {
 	ctx: RendererContext<PaneViewerData>;
@@ -201,13 +201,16 @@ export function TerminalPane({ ctx, workspaceId }: TerminalPaneProps) {
 	const [isDropActive, setIsDropActive] = useState(false);
 	const dragCounterRef = useRef(0);
 
-	const resolveDroppedPath = (dataTransfer: DataTransfer): string | null => {
+	const resolveDroppedText = (dataTransfer: DataTransfer): string | null => {
+		const files = Array.from(dataTransfer.files);
+		if (files.length > 0) {
+			const paths = files
+				.map((file) => window.webUtils.getPathForFile(file))
+				.filter(Boolean);
+			return paths.length > 0 ? shellEscapePaths(paths) : null;
+		}
 		const plainText = dataTransfer.getData("text/plain");
-		if (plainText) return plainText;
-		const file = dataTransfer.files[0];
-		if (!file) return null;
-		const path = window.webUtils.getPathForFile(file);
-		return path || null;
+		return plainText ? shellEscapePaths([plainText]) : null;
 	};
 
 	const handleDragEnter = (event: React.DragEvent) => {
@@ -235,10 +238,10 @@ export function TerminalPane({ ctx, workspaceId }: TerminalPaneProps) {
 		dragCounterRef.current = 0;
 		setIsDropActive(false);
 		if (connectionState === "closed") return;
-		const path = resolveDroppedPath(event.dataTransfer);
-		if (!path) return;
+		const text = resolveDroppedText(event.dataTransfer);
+		if (!text) return;
 		terminalRuntimeRegistry.getTerminal(terminalId)?.focus();
-		terminalRuntimeRegistry.paste(terminalId, shellEscapePath(path));
+		terminalRuntimeRegistry.paste(terminalId, text);
 	};
 
 	return (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -25,6 +25,7 @@ import { TerminalSearch } from "renderer/screens/main/components/WorkspaceView/C
 import { useTheme } from "renderer/stores/theme";
 import { resolveTerminalThemeType } from "renderer/stores/theme/utils";
 import { useTerminalAppearance } from "./hooks/useTerminalAppearance";
+import { shellEscapePath } from "./utils";
 
 interface TerminalPaneProps {
 	ctx: RendererContext<PaneViewerData>;
@@ -197,8 +198,58 @@ export function TerminalPane({ ctx, workspaceId }: TerminalPaneProps) {
 		[terminalId, connectionState],
 	);
 
+	const [isDropActive, setIsDropActive] = useState(false);
+	const dragCounterRef = useRef(0);
+
+	const resolveDroppedPath = (dataTransfer: DataTransfer): string | null => {
+		const plainText = dataTransfer.getData("text/plain");
+		if (plainText) return plainText;
+		const file = dataTransfer.files[0];
+		if (!file) return null;
+		const path = window.webUtils.getPathForFile(file);
+		return path || null;
+	};
+
+	const handleDragEnter = (event: React.DragEvent) => {
+		event.preventDefault();
+		dragCounterRef.current += 1;
+		setIsDropActive(true);
+	};
+
+	const handleDragOver = (event: React.DragEvent) => {
+		event.preventDefault();
+		event.dataTransfer.dropEffect = "copy";
+	};
+
+	const handleDragLeave = (event: React.DragEvent) => {
+		event.preventDefault();
+		dragCounterRef.current -= 1;
+		if (dragCounterRef.current <= 0) {
+			dragCounterRef.current = 0;
+			setIsDropActive(false);
+		}
+	};
+
+	const handleDrop = (event: React.DragEvent) => {
+		event.preventDefault();
+		dragCounterRef.current = 0;
+		setIsDropActive(false);
+		if (connectionState === "closed") return;
+		const path = resolveDroppedPath(event.dataTransfer);
+		if (!path) return;
+		terminalRuntimeRegistry.getTerminal(terminalId)?.focus();
+		terminalRuntimeRegistry.paste(terminalId, shellEscapePath(path));
+	};
+
 	return (
-		<div className="flex h-full w-full flex-col p-2">
+		<div
+			role="application"
+			className="flex h-full w-full flex-col p-2"
+			onDragEnter={handleDragEnter}
+			onDragOver={handleDragOver}
+			onDragLeave={handleDragLeave}
+			onDrop={handleDrop}
+		>
 			<div className="relative min-h-0 flex-1 overflow-hidden">
 				<TerminalSearch
 					searchAddon={searchAddon}
@@ -211,6 +262,9 @@ export function TerminalPane({ ctx, workspaceId }: TerminalPaneProps) {
 					style={{ backgroundColor: appearance.background }}
 				/>
 				<ScrollToBottomButton terminal={terminal} />
+				{isDropActive && (
+					<div className="pointer-events-none absolute inset-0 rounded-sm border-2 border-primary/60 border-dashed bg-primary/10" />
+				)}
 			</div>
 			{connectionState === "closed" && (
 				<div className="flex items-center gap-2 border-t border-border px-3 py-1.5 text-xs text-muted-foreground">

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/utils.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/utils.ts
@@ -1,0 +1,5 @@
+import { quote } from "shell-quote";
+
+export function shellEscapePath(path: string): string {
+	return quote([path]);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/utils.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/utils.ts
@@ -1,5 +1,5 @@
 import { quote } from "shell-quote";
 
-export function shellEscapePath(path: string): string {
-	return quote([path]);
+export function shellEscapePaths(paths: string[]): string {
+	return quote(paths);
 }


### PR DESCRIPTION
## Summary
- V2 terminal panes were missing the drag-and-drop handlers that v1 had, so dropping a file from Finder or the file tree did nothing.
- Adds `onDragEnter/Over/Leave/Drop` handlers on the pane wrapper. On drop, the terminal is focused and the shell-escaped path is pasted at the cursor.
- Shows a dashed primary-border overlay while a drag is active for visual feedback.

## Test plan
- [ ] Open a v2 workspace, drag a file from Finder into a terminal pane → the escaped path is pasted.
- [ ] Drag a file from the v2 file tree into a terminal pane → the escaped path is pasted.
- [ ] Drag over a terminal pane → dashed overlay appears; leaving cancels it.
- [ ] Dropping while the terminal is disconnected is a no-op.
- [ ] Paths with spaces / special chars are correctly quoted so the shell sees a single argument.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores drag-and-drop in v2 terminal panes. Dropping from Finder or the v2 file tree now focuses the terminal and pastes shell-escaped path(s) at the cursor.

- **Bug Fixes**
  - Support multi-file drops; escape each path with `shell-quote` via `shellEscapePaths`.
  - Prefer `dataTransfer.files` over `text/plain` to match v1 behavior.
  - No-op when the terminal is disconnected.
  - Show a dashed primary-border overlay during drag.

<sup>Written for commit 073baea0735db18f9a55a292351ed39454a499ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added drag-and-drop support to the terminal pane. Files can be dragged from your file system into the terminal, with file paths automatically inserted and safely escaped for shell usage. A visual indicator appears while dragging, and drops are ignored if the terminal is closed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->