### PR TITLE
fix(desktop): v2 sidebar section count matches visual grouping

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -324,9 +324,31 @@ export function useDashboardSidebarData() {
 				sectionMap: _sectionMap,
 				...sidebarProject
 			} = resolvedProject;
-			sidebarProject.children = childEntries
+
+			const sortedChildren = childEntries
 				.sort((left, right) => left.tabOrder - right.tabOrder)
 				.map(({ child }) => child);
+
+			// Ungrouped workspaces rendered after a section header are visually
+			// grouped with that section (shared accent, collapse-together) and will
+			// be committed into it on next DnD. Reparent them here so section counts
+			// match what the user sees.
+			const children: DashboardSidebarProjectChild[] = [];
+			let currentSection: DashboardSidebarSection | null = null;
+			for (const child of sortedChildren) {
+				if (child.type === "section") {
+					currentSection = child.section;
+					children.push(child);
+				} else if (currentSection) {
+					currentSection.workspaces.push({
+						...child.workspace,
+						accentColor: currentSection.color,
+					});
+				} else {
+					children.push(child);
+				}
+			}
+			sidebarProject.children = children;
 			return [sidebarProject];
 		});
 	}, [


### PR DESCRIPTION
## Summary

- v2 sidebar sections were showing `(0)` while N workspaces visually rendered under them.
- Root cause: section `tabOrder` can land before ungrouped workspaces' `tabOrder`, so those workspaces render after the section header. `groupInfo` in `useSidebarDnd.ts` already treats them as in-section (for accent color + collapse), and `commitToDb` reassigns their `sectionId` on next drag — but `section.workspaces` only included DB-matched members, so the count stayed at 0.
- Fix: in `useDashboardSidebarData.ts`, after sorting children by `tabOrder`, reparent ungrouped workspaces following a section into that section's `workspaces` array. Count, visual grouping, and DnD commit now agree.

## Test plan

- [ ] Create a new section in a project that already has ungrouped workspaces — count shows total workspaces beneath it
- [ ] Collapse the section — all workspaces visually grouped under it hide (unchanged)
- [ ] Drag a workspace across the section boundary — `commitToDb` still assigns `sectionId` correctly (unchanged)
- [ ] Sections with only DB-matched members still report the right count (unchanged)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the v2 sidebar so section counts include workspaces that appear under a section. Counts now match the visual grouping and DnD behavior.

- **Bug Fixes**
  - In `useDashboardSidebarData`, after sorting by `tabOrder`, reparent ungrouped workspaces that follow a section into that section’s `workspaces`.
  - Section counts now reflect what’s shown; DnD still assigns `sectionId` as before.

<sup>Written for commit 549f6c3df3df9784d2d30ef8da45957833a05af9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dashboard sidebar workspace grouping logic to properly organize workspaces that appear after section headers under their designated sections, improving the visual hierarchy of the sidebar
  * Workspace counts within sections now accurately reflect the grouped content, ensuring the displayed numbers match the actual layout shown to users in the interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->