### PR TITLE
fix(desktop): sync v1 terminal dimensions to backend on connect

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
@@ -260,6 +260,17 @@ export function useTerminalLifecycle({
 
 		const { xterm, fitAddon, searchAddon } = cached;
 
+		// Called after createOrAttach resolves: re-fit against the now-settled
+		// container and push dims to the backend. Guards against stale sizes
+		// from attachToContainer's fit running before flex layout resolved
+		// (e.g. preset tabs, new workspace bulk creation). Mirrors v2's
+		// terminal-ws-transport sendResize-on-open.
+		const syncBackendDimensions = () => {
+			if (container.clientWidth === 0 || container.clientHeight === 0) return;
+			fitAddon.fit();
+			resizeRef.current({ paneId, cols: xterm.cols, rows: xterm.rows });
+		};
+
 		// Attach the wrapper div to the live container.
 		// The cache creates a ResizeObserver that calls fitAddon.fit() and
 		// forwards resize events to the backend — no separate resize handler needed.
@@ -383,6 +394,7 @@ export function useTerminalLifecycle({
 									return;
 								}
 								setConnectionError(null);
+								syncBackendDimensions();
 								pendingInitialStateRef.current = result;
 								maybeApplyInitialState();
 								if (!command) {
@@ -595,6 +607,7 @@ export function useTerminalLifecycle({
 									v1TerminalCache.startStream(paneId);
 									v1TerminalCache.setStreamReady(paneId);
 									markTerminalSessionReady(paneId);
+									syncBackendDimensions();
 
 									const storedColdRestore = coldRestoreState.get(paneId);
 									if (storedColdRestore?.isRestored) {


### PR DESCRIPTION
## Summary

- When panes mount during new-workspace / preset flows, `attachToContainer`'s `fitAddon.fit()` can run before flex layout resolves. The backend PTY gets spawned at stale (often default) dimensions, so the initial shell prompt wraps at the wrong column until the user manually resizes.
- Fix mirrors v2's pattern in `terminal-ws-transport.ts` (`sendResize` on WebSocket `open`): once `createOrAttach` succeeds, re-fit against the now-settled container and push the real dims to the backend.
- Applied at both `onSuccess` sites — initial attach and `restartTerminalSession` — via a small `syncBackendDimensions` helper.

## Test plan

- [ ] Create a new workspace with a preset that auto-spawns terminals; confirm `tput cols; tput lines` matches the visible grid immediately, with no manual resize.
- [ ] Run `printf '=%.0s' {1..$(tput cols)}; echo` — line fills exactly one row (no early wrap / overflow).
- [ ] Restart a running workspace-run pane; dims should re-sync on the restart path too.
- [ ] Switch between workspaces rapidly — fresh terminals render at correct size on first paint.
- [ ] Sanity-check an existing workspace cold-restore still works.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync v1 terminal cols/rows to the backend right after connect to prevent shells spawning at stale sizes. Re-fit after layout settles so the PTY starts with correct dimensions and prompts don’t wrap.

- **Bug Fixes**
  - Add `syncBackendDimensions` to call `fitAddon.fit()` and send resize after `createOrAttach` and on `restartTerminalSession`, mirroring v2’s send-resize-on-open and guarding against zero-sized containers.

<sup>Written for commit 7e785d594354b0d57e0b0bda319400438bff2e27. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal display sizing after restart and initial connection to ensure dimensions are properly applied and functioning correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->