### PR TITLE
feat(desktop): safer defaults for builtin terminal agent presets

### DIFF
--- a/apps/desktop/src/shared/utils/agent-launch-request.test.ts
+++ b/apps/desktop/src/shared/utils/agent-launch-request.test.ts
@@ -46,7 +46,7 @@ describe("buildPromptAgentLaunchRequest", () => {
 			agentType: "codex",
 			terminal: {
 				command:
-					'codex -c model_reasoning_effort="high" --dangerously-bypass-approvals-and-sandbox -c model_reasoning_summary="detailed" -c model_supports_reasoning_summaries=true',
+					'codex -c model_reasoning_effort="high" -c model_reasoning_summary="detailed" -c model_supports_reasoning_summaries=true --full-auto',
 			},
 		});
 	});

--- a/apps/docs/content/docs/terminal-presets.mdx
+++ b/apps/docs/content/docs/terminal-presets.mdx
@@ -41,15 +41,17 @@ Presets are parallel by default.
 
 ## Quick-Add Templates
 
-Pre-configured presets for popular AI agents:
+Pre-configured presets for popular AI agents. Defaults are safe-by-default — agents can read and edit files, but still prompt before running shell commands or touching files outside your workspace. Edit any preset to opt into a more permissive mode.
 
 - **amp** - `amp`
-- **claude** - `claude --dangerously-skip-permissions`
-- **codex** - Full danger mode with high reasoning effort
-- **gemini** - `gemini --yolo`
-- **pi** - `pi`
+- **claude** - `claude --permission-mode acceptEdits`
+- **codex** - Workspace-sandboxed with high reasoning effort (`--full-auto`)
+- **gemini** - `gemini --approval-mode=auto_edit`
+- **copilot** - `copilot --allow-all-tools`
 - **cursor-agent** - Cursor AI agent
-- **opencode** - Open-source AI coding agent
+- **mastracode** - Mastra's coding agent (opt-in: YOLO by default at the CLI level)
+- **opencode** - Open-source AI coding agent (opt-in: full-access by default at the CLI level)
+- **pi** - Minimal terminal coding harness (opt-in: YOLO by default at the CLI level)
 
 ## Preset Bar
 

--- a/apps/docs/content/docs/terminal-presets.mdx
+++ b/apps/docs/content/docs/terminal-presets.mdx
@@ -43,15 +43,15 @@ Presets are parallel by default.
 
 Pre-configured presets for popular AI agents. Defaults are safe-by-default — agents can read and edit files, but still prompt before running shell commands or touching files outside your workspace. Edit any preset to opt into a more permissive mode.
 
-- **amp** - `amp`
+- **amp** - `amp` (built-in permission rules auto-deny destructive ops)
 - **claude** - `claude --permission-mode acceptEdits`
-- **codex** - Workspace-sandboxed with high reasoning effort (`--full-auto`)
+- **codex** - `codex ... --full-auto` (workspace-sandboxed)
 - **gemini** - `gemini --approval-mode=auto_edit`
-- **copilot** - `copilot --allow-all-tools`
-- **cursor-agent** - Cursor AI agent
-- **mastracode** - Mastra's coding agent (opt-in: YOLO by default at the CLI level)
-- **opencode** - Open-source AI coding agent (opt-in: full-access by default at the CLI level)
-- **pi** - Minimal terminal coding harness (opt-in: YOLO by default at the CLI level)
+- **copilot** - `copilot --allow-tool=write`
+- **cursor-agent** - `cursor-agent` (prompts for every action)
+- **mastracode** - Mastra's coding agent (opt-in: auto-approves all actions by default at the CLI; no startup flag to restrict)
+- **opencode** - Open-source AI coding agent (opt-in: full file and shell access by default at the CLI; no startup flag to restrict)
+- **pi** - Minimal terminal coding harness (opt-in: auto-approves all actions by default at the CLI; no startup flag to restrict)
 
 ## Preset Bar
 

--- a/packages/shared/src/agent-command.test.ts
+++ b/packages/shared/src/agent-command.test.ts
@@ -13,7 +13,7 @@ describe("buildAgentPromptCommand", () => {
 		});
 
 		expect(command).toContain(
-			"model_supports_reasoning_summaries=true -- \"$(cat <<'SUPERSET_PROMPT_12345678'",
+			"model_supports_reasoning_summaries=true --full-auto -- \"$(cat <<'SUPERSET_PROMPT_12345678'",
 		);
 		expect(command).toContain("- Only modified file: runtime.ts");
 	});
@@ -26,7 +26,7 @@ describe("buildAgentPromptCommand", () => {
 		});
 
 		expect(command).toStartWith(
-			"claude --dangerously-skip-permissions \"$(cat <<'SUPERSET_PROMPT_abcdefgh'",
+			"claude --permission-mode acceptEdits \"$(cat <<'SUPERSET_PROMPT_abcdefgh'",
 		);
 	});
 

--- a/packages/shared/src/builtin-terminal-agents.ts
+++ b/packages/shared/src/builtin-terminal-agents.ts
@@ -62,7 +62,7 @@ export const BUILTIN_TERMINAL_AGENTS = [
 		label: "Claude",
 		description:
 			"Anthropic's coding agent for reading code, editing files, and running terminal workflows.",
-		command: "claude --dangerously-skip-permissions",
+		command: "claude --permission-mode acceptEdits",
 		includeInDefaultTerminalPresets: true,
 	}),
 	createBuiltinTerminalAgent({
@@ -80,9 +80,9 @@ export const BUILTIN_TERMINAL_AGENTS = [
 		description:
 			"OpenAI's coding agent for reading, modifying, and running code across tasks.",
 		command:
-			'codex -c model_reasoning_effort="high" --dangerously-bypass-approvals-and-sandbox -c model_reasoning_summary="detailed" -c model_supports_reasoning_summaries=true',
+			'codex -c model_reasoning_effort="high" -c model_reasoning_summary="detailed" -c model_supports_reasoning_summaries=true --full-auto',
 		promptCommand:
-			'codex -c model_reasoning_effort="high" --dangerously-bypass-approvals-and-sandbox -c model_reasoning_summary="detailed" -c model_supports_reasoning_summaries=true --',
+			'codex -c model_reasoning_effort="high" -c model_reasoning_summary="detailed" -c model_supports_reasoning_summaries=true --full-auto --',
 		includeInDefaultTerminalPresets: true,
 	}),
 	createBuiltinTerminalAgent({
@@ -90,9 +90,8 @@ export const BUILTIN_TERMINAL_AGENTS = [
 		label: "Gemini",
 		description:
 			"Google's open-source terminal agent for coding, problem-solving, and task work.",
-		command: "gemini --yolo",
+		command: "gemini --approval-mode=auto_edit",
 		promptCommand: "gemini",
-		promptCommandSuffix: "--yolo",
 		includeInDefaultTerminalPresets: true,
 	}),
 	createBuiltinTerminalAgent({
@@ -101,7 +100,6 @@ export const BUILTIN_TERMINAL_AGENTS = [
 		description:
 			"Mastra's coding agent for building, debugging, and shipping code from the terminal.",
 		command: "mastracode",
-		includeInDefaultTerminalPresets: true,
 	}),
 	createBuiltinTerminalAgent({
 		id: "opencode",
@@ -109,7 +107,6 @@ export const BUILTIN_TERMINAL_AGENTS = [
 		description: "Open-source coding agent for the terminal, IDE, and desktop.",
 		command: "opencode",
 		promptCommand: "opencode --prompt",
-		includeInDefaultTerminalPresets: true,
 	}),
 	createBuiltinTerminalAgent({
 		id: "pi",
@@ -117,16 +114,14 @@ export const BUILTIN_TERMINAL_AGENTS = [
 		description:
 			"Minimal terminal coding harness for flexible coding workflows.",
 		command: "pi",
-		includeInDefaultTerminalPresets: true,
 	}),
 	createBuiltinTerminalAgent({
 		id: "copilot",
 		label: "Copilot",
 		description:
 			"GitHub's coding agent for planning, editing, and building in your repo.",
-		command: "copilot --allow-all",
-		promptCommand: "copilot -i --allow-all",
-		promptCommandSuffix: "--yolo",
+		command: "copilot --allow-all-tools",
+		promptCommand: "copilot -i --allow-all-tools",
 		includeInDefaultTerminalPresets: true,
 	}),
 	createBuiltinTerminalAgent({
@@ -135,7 +130,6 @@ export const BUILTIN_TERMINAL_AGENTS = [
 		description:
 			"Cursor's coding agent for editing, running, and debugging code in parallel.",
 		command: "cursor-agent",
-		promptCommandSuffix: "--yolo",
 	}),
 ] as const;
 

--- a/packages/shared/src/builtin-terminal-agents.ts
+++ b/packages/shared/src/builtin-terminal-agents.ts
@@ -91,7 +91,7 @@ export const BUILTIN_TERMINAL_AGENTS = [
 		description:
 			"Google's open-source terminal agent for coding, problem-solving, and task work.",
 		command: "gemini --approval-mode=auto_edit",
-		promptCommand: "gemini",
+		promptCommand: "gemini --approval-mode=auto_edit",
 		includeInDefaultTerminalPresets: true,
 	}),
 	createBuiltinTerminalAgent({
@@ -120,8 +120,8 @@ export const BUILTIN_TERMINAL_AGENTS = [
 		label: "Copilot",
 		description:
 			"GitHub's coding agent for planning, editing, and building in your repo.",
-		command: "copilot --allow-all-tools",
-		promptCommand: "copilot -i --allow-all-tools",
+		command: "copilot --allow-tool=write",
+		promptCommand: "copilot -i --allow-tool=write",
 		includeInDefaultTerminalPresets: true,
 	}),
 	createBuiltinTerminalAgent({


### PR DESCRIPTION
## Summary

- Swap permission-bypass flags on each builtin terminal agent for the CLI's intended safe-but-useful mode: claude → `--permission-mode acceptEdits`, codex → `--full-auto` (workspace sandbox), gemini → `--approval-mode=auto_edit`, copilot → `--allow-all-tools` (instead of the footgun `--allow-all`).
- Drop `mastracode` / `opencode` / `pi` from the default-seeded preset bar since they are YOLO-by-default at the CLI level with no safe-startup flag. They remain available under Quick-Add for users who want to opt in.
- Remove the `--yolo` suffix on `cursor-agent` (silent no-op — the flag does not exist on the real CLI) and on `gemini` / `copilot` prompt commands (redundant with the new safe flag).

**Existing users preserved.** No migration code needed:
- v1: `initializeDefaultPresets()` early-returns on `terminalPresetsInitialized`; stored command strings are returned verbatim through `getNormalizedTerminalPresets` (which only normalizes `executionMode`/`projectIds`/`isDefault`).
- v2: `useMigrateV1PresetsToV2` is gated by the `v2-terminal-presets-migrated-{orgId}` localStorage marker, and copies `commands` field-by-field from the preserved v1 row.
- Only fresh profiles and explicit Quick-Add clicks see the new safe defaults.

## Test plan

- [x] `bun test packages/shared` — 482/482 pass with updated claude + codex assertions
- [x] `bun run lint` — clean
- [ ] Fresh-install smoke: blow away local-db, launch desktop, confirm claude/codex/gemini/copilot/amp seeded with new safe flags and no mastracode/opencode/pi in the seeded bar
- [ ] Existing-user smoke: start from a profile with `terminalPresetsInitialized=1` and old dangerous commands; confirm rows untouched after launch
- [ ] Spot-check each safe default against a toy project (claude asks before `rm`, codex writes only inside workspace, gemini auto-edits without per-write prompts, copilot path verification fires on out-of-workspace targets)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make built-in terminal agent presets safe by default by swapping dangerous flags for each CLI’s safe mode. Stop seeding YOLO-by-default agents; existing users’ saved presets are unchanged.

- **New Features**
  - Switch defaults: `claude --permission-mode acceptEdits`, `codex --full-auto`, `gemini --approval-mode=auto_edit`, `copilot --allow-tool=write` (prompt commands match these modes).
  - Stop seeding `mastracode`, `opencode`, `pi`; still available via Quick-Add.
  - Remove `--yolo` suffix from `cursor-agent`.
  - Update docs and tests to match the new defaults.

<sup>Written for commit 0fd1e4f821c689007917ac2b050fbb31c696883f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated quick-add agent templates to be safe-by-default: agents now require explicit approval or permission modes before running shell commands or accessing files. Added a new Copilot preset, revised several coding-agent presets, and removed a few agents from the default preset list.

* **Tests**
  * Updated test expectations to match the revised command/preset behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->