### PR TITLE
fix(desktop): stop excessive lsof spawning from port scanner (#3372)

### DIFF
--- a/apps/desktop/plans/20260417-1830-lsof-excessive-spawning-3372.md
+++ b/apps/desktop/plans/20260417-1830-lsof-excessive-spawning-3372.md
@@ -1,0 +1,210 @@
+# Stop Excessive `lsof` Process Spawning (Issue #3372)
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Reference: This plan follows conventions from AGENTS.md and the ExecPlan template at `.agents/commands/create-plan.md`.
+
+## Purpose / Big Picture
+
+Users report ([#3372](https://github.com/superset-sh/superset/issues/3372)) that Superset spawns a growing pile of `lsof` processes. Symptoms:
+
+- CPU pinned to 100% after upgrades.
+- Number of `lsof` processes grows with number of open workspaces.
+- Closing workspaces does not help.
+- Even **quitting Superset** leaves `lsof` processes behind.
+
+After this change, opening N workspaces produces at most a bounded number of concurrent `lsof` invocations; closing all workspaces stops all port scanning; quitting Superset terminates every child process it started. The left-sidebar "Ports" feature continues to detect listening ports from terminal child processes with no user-visible regression.
+
+Related ticket: [#3235](https://github.com/superset-sh/superset/issues/3235) (EDR/security agent CPU from idle terminals) — same kernel-level observation pattern: our background polling multiplies EDR inspection cost. Fixing this reduces EDR impact as well.
+
+## Assumptions
+
+1. All affected code paths live in `apps/desktop/src/main/lib/terminal/` (`port-manager.ts`, `port-scanner.ts`) plus their wiring in `daemon-manager.ts`. No renderer-side changes required.
+2. The Ports sidebar feature is still desired; removing it is out of scope. We are optimizing, not deleting.
+3. Users run macOS/Linux (the `lsof` path). Windows uses `netstat` and is not implicated in the bug report, but the same lifecycle fixes apply to its code path.
+4. `pidtree` (used by `getProcessTree`) itself spawns `ps` children on macOS/Linux. Its cost counts too and must be considered when measuring scan frequency.
+5. The periodic 2.5s interval is tolerable if bounded and lifecycle-correct; we do not need to eliminate polling entirely. A future enhancement could switch to event-driven scanning triggered only on PTY spawn/exit, but that is out of scope.
+
+## Open Questions
+
+1. Should we keep the hint-triggered scans at all? They were added to catch fast-starting dev servers between the 2.5s ticks. If we tighten regexes and guard concurrency, they stay useful. If they remain noisy, we can delete them entirely and rely on the periodic scan. **Proposal: tighten and keep.**
+2. Do we want to switch from `exec` (shell-wrapped) to `execFile` / `spawn` with `detached: false` and direct signal delivery? **Proposal: yes — it fixes the orphan-on-timeout class of bugs for everyone.**
+3. Does the existing auto-generated PR [#3373](https://github.com/superset-sh/superset/pull/3373) (by github-actions bot, commit `8a6b19b04`, branch `triage/issue-3372-24302327902`) get merged as-is, rebased, or superseded? **Proposal: supersede.** It fixes ~60% of the problem (lifecycle + concurrency) but leaves the orphan-on-timeout and loose-regex issues unaddressed. Cherry-pick its lifecycle changes into a fuller fix.
+
+## Background: Prior Attempt
+
+- **Who:** auto-created by the repo's triage workflow (`github-actions[bot]`) on 2026-04-12.
+- **Where:** PR [#3373](https://github.com/superset-sh/superset/pull/3373), branch `triage/issue-3372-24302327902`, single commit `8a6b19b04`.
+- **What it does:**
+  1. Removes `startPeriodicScan()` from the `PortManager` constructor; starts the 2.5s interval lazily on first `registerSession`/`upsertDaemonSession`, stops it on the last `unregister*`.
+  2. Adds `if (this.isScanning) return;` at the top of `scanPane()` so hint-triggered scans do not pile up on top of bulk scans.
+  3. Early-exit in `scanAllSessions()` when no sessions exist.
+- **What it does not fix:**
+  - Orphaned `lsof` on `exec` timeout (root cause of "quitting Superset keeps the process open").
+  - Over-eager hint regexes that fire on normal terminal output (`/port\s+(\d+)/i`, `/:(\d{4,5})\s*$/`).
+  - Hint scans for different panes still run concurrently with each other (the `isScanning` guard only serializes hints vs. bulk).
+
+## Root Cause Analysis
+
+All three causes compound: the interval never stops, each tick may be joined by hint scans, and each resulting `lsof` can outlive its parent.
+
+### Cause 1 — Interval started at module load, never stopped
+
+`apps/desktop/src/main/lib/terminal/port-manager.ts:68-71`
+
+```ts
+constructor() {
+  super();
+  this.startPeriodicScan();
+}
+```
+
+`PortManager` is exported as a module-level singleton (`port-manager.ts:504`). The 2.5s `setInterval` starts the instant the module is imported and has no call site that stops it. Closing all workspaces leaves the interval ticking, each tick running `scanAllSessions` → `buildPortsByPane` → `getListeningPortsForPids` → `exec("sh -c 'lsof …'")`.
+
+### Cause 2 — No concurrency guard between hint scans and bulk scans
+
+`port-manager.ts:187-212` (`scanPane`) has no check on `this.isScanning`. Every terminal data chunk flows through `daemon-manager.ts:194` → `portManager.checkOutputForHint(data, paneId)`. Matching regexes:
+
+```ts
+/listening\s+on\s+(?:port\s+)?(\d+)/i,
+/server\s+(?:started|running)\s+(?:on|at)\s+(?:http:\/\/)?(?:localhost|127\.0\.0\.1|0\.0\.0\.0)?:?(\d+)/i,
+/ready\s+on\s+(?:http:\/\/)?(?:localhost|127\.0\.0\.1|0\.0\.0\.0)?:?(\d+)/i,
+/port\s+(\d+)/i,          // matches "port 22" in any log line
+/:(\d{4,5})\s*$/,          // matches any line ending in :NNNN / :NNNNN
+```
+
+The last two are so loose they match routine `git`, `curl`, `ls -la`, `ssh` output. Each match schedules a 500ms-debounced hint scan per pane. With the bulk scan also running, multiple `lsof` invocations can overlap.
+
+### Cause 3 — Orphan `lsof` processes outlive Superset
+
+`port-scanner.ts:65-68`
+
+```ts
+await execAsync(
+  `lsof -p ${pidArg} -iTCP -sTCP:LISTEN -P -n 2>/dev/null || true`,
+  { maxBuffer: 10 * 1024 * 1024, timeout: EXEC_TIMEOUT_MS },
+);
+```
+
+Two compounding issues:
+1. `child_process.exec` launches `/bin/sh -c "<command>"`. On timeout, Node sends `SIGTERM` to the shell; the shell does **not** forward the signal to its `lsof` child. The `lsof` gets reparented to `init`/`launchd` and keeps running until it completes on its own — which on a busy macOS machine with many open FDs can take tens of seconds or longer.
+2. When the Electron main process exits, any outstanding `lsof` (not yet reaped) is also reparented and survives. This matches the user's "exiting Superset keeps the process open" observation verbatim.
+
+`lsof` on macOS walks every process's file table and every mounted volume; it is **expensive** and slow, which maximizes the window for both problems above.
+
+## Design / Potential Solutions
+
+We need all three classes of fix to close this issue correctly. Below are options per class with a recommendation.
+
+### A. Lifecycle: stop the interval when idle
+
+| Option | Pros | Cons | Pick |
+| --- | --- | --- | --- |
+| **A1.** Lazy start/stop keyed on session count (what PR #3373 does) | Small diff, correct, easy to test | None material | ✅ |
+| A2. Move interval start into an explicit `PortManager.start()` called from app-ready, stop from app-quit | More explicit lifecycle | More touch points, no material win over A1 | — |
+| A3. Event-driven only (no interval): scan on PTY spawn, on process exit, on hint | Removes polling entirely | Misses child processes that open ports without producing diagnostic output; more code paths | defer |
+
+### B. Concurrency: bound the number of simultaneous `lsof` invocations
+
+| Option | Pros | Cons | Pick |
+| --- | --- | --- | --- |
+| **B1.** Single shared `isScanning` flag covers both bulk and hint scans (extend PR #3373) | Trivial | Serializes unrelated panes behind one lock | ✅ as floor |
+| **B2.** Coalesce hint scans into the next bulk scan (schedule a flag, not a scan) | At most one `lsof` in flight at a time; simplest correctness | Slight latency increase for detection (bounded by 2.5s) | ✅ preferred |
+| B3. Per-pane `isScanning` + global semaphore of N=1 | More granular | More state to manage, same result as B2 | — |
+
+Recommendation: **B2** — replace hint scans with a "pending full scan" flag. If a hint arrives while `isScanning`, set `scanRequested = true`. When bulk scan finishes, if `scanRequested` is set, immediately run another. This guarantees at most one `lsof` in flight and still catches events between ticks.
+
+### C. Process lifecycle: no orphan `lsof`
+
+| Option | Pros | Cons | Pick |
+| --- | --- | --- | --- |
+| **C1.** Switch `exec` → `execFile` (direct exec, no shell) + replace shell `|| true` with a try/catch on non-zero exit | Timeout sends SIGTERM directly to `lsof`; no orphan | Need to handle `exit code != 0` in JS instead of shell | ✅ |
+| **C2.** Also wire an `AbortController` and call `abort()` on `app.before-quit` / scanner teardown to kill in-flight children | Belt-and-suspenders for app quit | More code | ✅ |
+| C3. Keep `exec`, set `killSignal: "SIGKILL"` on timeout | Forces kill of shell, but child still reparents (shell is already dead) | Does not solve orphan | — |
+| C4. Add a global `child_process` registry, kill all on quit | Works, but heavy | Same effect as C1 + C2, more invasive | — |
+
+Recommendation: **C1 + C2**. `execFile` avoids the shell wrapper entirely; an `AbortController` stored on the `PortManager` tears down any in-flight scan when `stopPeriodicScan` runs or on app quit.
+
+### D. Hint regex noise
+
+| Option | Pros | Cons | Pick |
+| --- | --- | --- | --- |
+| **D1.** Delete `/port\s+(\d+)/i` and `/:(\d{4,5})\s*$/`. Keep only the three "listening/server/ready" patterns that actually imply a listener opened | Eliminates ~99% of spurious hints; remaining patterns still cover real dev servers | None — the loose patterns are false positives by design | ✅ |
+| D2. Keep all patterns but require anchor at line start | Marginal improvement | Still matches lots of noise | — |
+| D3. Delete hints entirely, rely on 2.5s bulk | Simplest | Loses fast-detection for dev servers (visible UX regression) | — |
+| D4. Gate hints behind a feature flag | Reversible | Adds surface area without removing the bug | — |
+
+Recommendation: **D1**.
+
+### E. (Optional, follow-up) Reduce per-scan cost
+
+Not required to close #3372 but cheap wins:
+- Skip `lsof` entirely when all registered sessions have an empty process tree (check sizes before exec).
+- Cache the previous result for ≤1 tick and diff only if PID set changed.
+- Consider `/proc/net/tcp` on Linux as a faster alternative to `lsof` (out of scope for this plan).
+
+## Recommended Plan of Action
+
+A combined fix that supersedes PR #3373:
+
+1. **Lifecycle (A1):** move `startPeriodicScan()` out of the constructor; add `ensurePeriodicScanRunning()` / `pausePeriodicScanIfEmpty()` driven by `registerSession`/`upsertDaemonSession`/`unregister*`.
+2. **Concurrency (B2):** replace hint-triggered individual `scanPane` invocations with a "request one follow-up bulk scan" flag coalesced into `scanAllSessions`. Delete `forceScanPane`.
+3. **Process lifecycle (C1 + C2):** rewrite `getListeningPortsLsof` (and `getListeningPortsWindows`) to use `execFile` with an `AbortSignal`. Store a shared `AbortController` on `PortManager`; abort on `stopPeriodicScan`. Register a `before-quit` handler in the main entry point to call `portManager.stopPeriodicScan()`.
+4. **Regex noise (D1):** delete the two over-broad patterns from `containsPortHint`.
+5. **Tests:** extend `port-manager.test.ts` to cover: interval stops when last session unregisters; restarts on re-register; a hint during an in-flight scan schedules exactly one follow-up; aborting the controller does not leak promises.
+6. **Manual smoke:** open 10 workspaces, idle for 5 minutes, check `ps -ef | grep -c lsof` stays bounded; close all workspaces, confirm zero `lsof`; quit Superset, confirm zero `lsof`.
+
+## Progress
+
+- [x] (2026-04-17) Rewrite `PortManager` lifecycle (A1) — interval starts on first register, stops on last unregister
+- [x] (2026-04-17) Coalesce hint → follow-up flag (B2) — `scanRequested` + debounced `scheduleHintScan`; deleted `scanPane`, `scanPidTreeAndUpdate`, `pendingHintScans`
+- [x] (2026-04-17) Rewrite `port-scanner.ts` to use `execFile` + `AbortSignal` (C1) — `runTolerant` helper accepts lsof exit 1 as empty
+- [x] (2026-04-17) Wire `AbortController` teardown on `stopPeriodicScan` (C2) — aborts in-flight lsof so it cannot outlive us
+- [x] (2026-04-17) Delete over-broad patterns from `containsPortHint` (D1)
+- [x] (2026-04-17) Unit tests (`port-manager.test.ts`) — 13 tests covering lifecycle, coalescing, regex narrowing, abort teardown; A/B-verified (8 fail on main)
+- [x] (2026-04-17) Delete dead `getProcessName` export and unused `paneId` parameter
+- [x] (2026-04-17) `bun run typecheck` + `bun run lint:fix` clean; 127/127 terminal tests pass
+- [ ] Close/supersede PR #3373
+- [ ] Manual validation on macOS with 10 workspaces
+- [ ] PR opened, issue #3372 closed by merge
+
+## Surprises & Discoveries
+
+- Observation: `execFile` with `promisify` rejects on non-zero exit codes; `lsof` exits 1 when its `-p` filter matches no PIDs, which is a legitimate empty result. Added `runTolerant` helper that reads `err.stdout` off the rejection and returns it instead of throwing. Mirrors what the old `|| true` shell trick did, but without the shell wrapper.
+  Evidence: `apps/desktop/src/main/lib/terminal/port-scanner.ts` `runTolerant`.
+
+- Observation: The production `getListeningPortsLsof` has a top-level `try/catch` that swallows all errors and returns `[]`. The mock in tests must match this — our first pass had the mock reject on abort, which propagated up and broke `forceScan`'s contract.
+  Evidence: `apps/desktop/src/main/lib/terminal/port-manager.test.ts` — `getListeningPortsForPids` mock resolves on abort.
+
+- Observation: `getProcessName` was exported but had zero in-repo call sites (likely left behind when the hint-scan path was last refactored). Deleted along with the other changes.
+  Evidence: `grep getProcessName apps/desktop` — only self-reference.
+
+## Decision Log
+
+- Decision: Supersede PR #3373 rather than merge it.
+  Rationale: #3373 addresses lifecycle + concurrency (A1, B1) but leaves the orphan-on-timeout and noisy-regex causes intact. Closing the issue requires all three; a single PR is easier to review and revert than a stack of small ones.
+  Date/Author: 2026-04-17 / Planning
+
+- Decision: Coalesce hints into the bulk scan (B2) rather than gating with a shared flag (B1).
+  Rationale: B1 silently drops hint scans during bulk scans, causing a detection gap up to 2.5s anyway. B2 guarantees a follow-up without concurrent `lsof`, same correctness, same worst-case latency.
+  Date/Author: 2026-04-17 / Planning
+
+- Decision: `execFile` + `AbortController`, not shell `exec`.
+  Rationale: Removes the `sh -c` wrapper that strands `lsof` on timeout and on app exit. Makes signal delivery deterministic.
+  Date/Author: 2026-04-17 / Planning
+
+- Decision: Delete `/port\s+(\d+)/i` and `/:(\d{4,5})\s*$/` outright.
+  Rationale: Both match routine non-port text (git logs, ssh banners, timestamps). The three remaining "listening/server/ready" patterns cover real dev-server startup lines. If users report missed detections we can add more-specific patterns.
+  Date/Author: 2026-04-17 / Planning
+
+## Outcomes & Retrospective
+
+Implementation landed as a single focused change to `port-manager.ts` and `port-scanner.ts`:
+
+- **port-manager.ts**: +36 / −110 lines. Lifecycle gated on session count; hint scans coalesced via a single debounced timer + `scanRequested` follow-up flag; private `AbortController` aborted on teardown.
+- **port-scanner.ts**: +52 / −40 lines net. `execFile` instead of `exec` everywhere; `AbortSignal` threaded through the public surface; `runTolerant` helper for the lsof-exits-1 case; dead `getProcessName` export removed.
+- **port-manager.test.ts**: +255 lines new. 13 tests covering lifecycle, coalescing, regex narrowing, and abort teardown. A/B-proven: stashing the port-manager/port-scanner changes and rerunning shows 8 of 13 tests fail on `main`.
+
+A/B measurement (mocked `lsof`): a flood of 100 hint-matching data chunks during a 30 ms in-flight scan produces ≤2 total `lsof` calls and `maxInFlight === 1`. On `main`, the same inputs would produce many concurrent calls because hint scans bypassed the `isScanning` guard.
+
+Supersedes PR #3373 (auto-generated by `github-actions[bot]`), which addressed lifecycle + a weaker concurrency guard but left the orphan-on-timeout and regex-noise causes unaddressed.

--- a/apps/desktop/plans/20260417-1830-lsof-excessive-spawning-3372.md
+++ b/apps/desktop/plans/20260417-1830-lsof-excessive-spawning-3372.md
@@ -1,210 +1,74 @@
 # Stop Excessive `lsof` Process Spawning (Issue #3372)
 
-This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+## Problem
 
-Reference: This plan follows conventions from AGENTS.md and the ExecPlan template at `.agents/commands/create-plan.md`.
+[#3372](https://github.com/superset-sh/superset/issues/3372): Superset spawns a growing pile of `lsof` processes. Symptoms: CPU pinned at 100%, count grows with open workspaces, closing workspaces doesn't help, quitting Superset leaves `lsof` behind.
 
-## Purpose / Big Picture
+Related: [#3235](https://github.com/superset-sh/superset/issues/3235) — EDR agents amplify every spawn, so fixing this also reduces their CPU.
 
-Users report ([#3372](https://github.com/superset-sh/superset/issues/3372)) that Superset spawns a growing pile of `lsof` processes. Symptoms:
+## Root Causes (three, compounding)
 
-- CPU pinned to 100% after upgrades.
-- Number of `lsof` processes grows with number of open workspaces.
-- Closing workspaces does not help.
-- Even **quitting Superset** leaves `lsof` processes behind.
+All in `apps/desktop/src/main/lib/terminal/`.
 
-After this change, opening N workspaces produces at most a bounded number of concurrent `lsof` invocations; closing all workspaces stops all port scanning; quitting Superset terminates every child process it started. The left-sidebar "Ports" feature continues to detect listening ports from terminal child processes with no user-visible regression.
+1. **Interval never stops.** `PortManager` constructor called `startPeriodicScan()` at module load. The 2.5s `setInterval` kept firing forever — zero sessions, closed workspaces, whatever.
+2. **Hint scans run concurrently with the bulk scan.** `scanPane` had no `isScanning` guard. Hint regexes `/port\s+(\d+)/i` and `/:(\d{4,5})\s*$/` were so loose they matched routine `git`/`ssh` output, firing spurious scans on top of the periodic ones.
+3. **`lsof` children outlive us.** Code ran `exec("sh -c 'lsof … || true'")`. On timeout, Node SIGTERMs the shell; the shell doesn't forward to `lsof`; the child gets reparented to `launchd`/`init` and survives even app quit.
 
-Related ticket: [#3235](https://github.com/superset-sh/superset/issues/3235) (EDR/security agent CPU from idle terminals) — same kernel-level observation pattern: our background polling multiplies EDR inspection cost. Fixing this reduces EDR impact as well.
+## Fix (minimum-churn, one PR)
 
-## Assumptions
+1. **Lifecycle:** interval starts on first `registerSession`/`upsertDaemonSession`, stops on the last unregister.
+2. **Coalesce:** one debounced hint timer + a `scanRequested` flag. If a hint or tick fires mid-scan, queue exactly one follow-up. `maxInFlight == 1` guaranteed.
+3. **No orphans:** `execFile` instead of `exec` (no shell wrapper). `AbortController` on `PortManager`; `stopPeriodicScan` aborts the in-flight child.
+4. **Regex noise:** delete the two over-broad patterns; keep the three that imply a real listener (`listening on`, `server started`, `ready on`).
 
-1. All affected code paths live in `apps/desktop/src/main/lib/terminal/` (`port-manager.ts`, `port-scanner.ts`) plus their wiring in `daemon-manager.ts`. No renderer-side changes required.
-2. The Ports sidebar feature is still desired; removing it is out of scope. We are optimizing, not deleting.
-3. Users run macOS/Linux (the `lsof` path). Windows uses `netstat` and is not implicated in the bug report, but the same lifecycle fixes apply to its code path.
-4. `pidtree` (used by `getProcessTree`) itself spawns `ps` children on macOS/Linux. Its cost counts too and must be considered when measuring scan frequency.
-5. The periodic 2.5s interval is tolerable if bounded and lifecycle-correct; we do not need to eliminate polling entirely. A future enhancement could switch to event-driven scanning triggered only on PTY spawn/exit, but that is out of scope.
+## Alternatives Considered (and why rejected)
 
-## Open Questions
+- **A3, event-driven only (no interval):** misses silent port openers. Deferred.
+- **B1, shared `isScanning` flag only:** still drops detection for up to 2.5s with no follow-up guarantee. B2 is strictly better for the same worst-case latency.
+- **B3, per-pane `isScanning` + semaphore:** more state, same behavior as B2.
+- **C3, `killSignal: "SIGKILL"`:** kills the shell, child still orphans. Doesn't address the root issue.
+- **D3, delete all hints:** loses fast-detection for dev servers (UX regression).
+- **Option 1: delete the whole dynamic-port subsystem and rely on `.superset/ports.json`:** attractive (-1500 lines) but regresses feature for users without a static config.
+- **Option 2: delete periodic scan, hint-only:** halves the code but misses silent port openers.
+- **Option 4: delete `lsof` entirely, parse ports from terminal output:** most elegant (-700 lines) but loses PID info (Kill Port), still has edge cases.
 
-1. Should we keep the hint-triggered scans at all? They were added to catch fast-starting dev servers between the 2.5s ticks. If we tighten regexes and guard concurrency, they stay useful. If they remain noisy, we can delete them entirely and rely on the periodic scan. **Proposal: tighten and keep.**
-2. Do we want to switch from `exec` (shell-wrapped) to `execFile` / `spawn` with `detached: false` and direct signal delivery? **Proposal: yes — it fixes the orphan-on-timeout class of bugs for everyone.**
-3. Does the existing auto-generated PR [#3373](https://github.com/superset-sh/superset/pull/3373) (by github-actions bot, commit `8a6b19b04`, branch `triage/issue-3372-24302327902`) get merged as-is, rebased, or superseded? **Proposal: supersede.** It fixes ~60% of the problem (lifecycle + concurrency) but leaves the orphan-on-timeout and loose-regex issues unaddressed. Cherry-pick its lifecycle changes into a fuller fix.
+Chose minimum-churn because the real cost isn't `lsof`'s per-call expense (~100 ms on the fast path) — it's the three lifecycle bugs multiplying it. Fix those and the feature works fine.
 
-## Background: Prior Attempt
+## Prior Attempt — Superseded
 
-- **Who:** auto-created by the repo's triage workflow (`github-actions[bot]`) on 2026-04-12.
-- **Where:** PR [#3373](https://github.com/superset-sh/superset/pull/3373), branch `triage/issue-3372-24302327902`, single commit `8a6b19b04`.
-- **What it does:**
-  1. Removes `startPeriodicScan()` from the `PortManager` constructor; starts the 2.5s interval lazily on first `registerSession`/`upsertDaemonSession`, stops it on the last `unregister*`.
-  2. Adds `if (this.isScanning) return;` at the top of `scanPane()` so hint-triggered scans do not pile up on top of bulk scans.
-  3. Early-exit in `scanAllSessions()` when no sessions exist.
-- **What it does not fix:**
-  - Orphaned `lsof` on `exec` timeout (root cause of "quitting Superset keeps the process open").
-  - Over-eager hint regexes that fire on normal terminal output (`/port\s+(\d+)/i`, `/:(\d{4,5})\s*$/`).
-  - Hint scans for different panes still run concurrently with each other (the `isScanning` guard only serializes hints vs. bulk).
-
-## Root Cause Analysis
-
-All three causes compound: the interval never stops, each tick may be joined by hint scans, and each resulting `lsof` can outlive its parent.
-
-### Cause 1 — Interval started at module load, never stopped
-
-`apps/desktop/src/main/lib/terminal/port-manager.ts:68-71`
-
-```ts
-constructor() {
-  super();
-  this.startPeriodicScan();
-}
-```
-
-`PortManager` is exported as a module-level singleton (`port-manager.ts:504`). The 2.5s `setInterval` starts the instant the module is imported and has no call site that stops it. Closing all workspaces leaves the interval ticking, each tick running `scanAllSessions` → `buildPortsByPane` → `getListeningPortsForPids` → `exec("sh -c 'lsof …'")`.
-
-### Cause 2 — No concurrency guard between hint scans and bulk scans
-
-`port-manager.ts:187-212` (`scanPane`) has no check on `this.isScanning`. Every terminal data chunk flows through `daemon-manager.ts:194` → `portManager.checkOutputForHint(data, paneId)`. Matching regexes:
-
-```ts
-/listening\s+on\s+(?:port\s+)?(\d+)/i,
-/server\s+(?:started|running)\s+(?:on|at)\s+(?:http:\/\/)?(?:localhost|127\.0\.0\.1|0\.0\.0\.0)?:?(\d+)/i,
-/ready\s+on\s+(?:http:\/\/)?(?:localhost|127\.0\.0\.1|0\.0\.0\.0)?:?(\d+)/i,
-/port\s+(\d+)/i,          // matches "port 22" in any log line
-/:(\d{4,5})\s*$/,          // matches any line ending in :NNNN / :NNNNN
-```
-
-The last two are so loose they match routine `git`, `curl`, `ls -la`, `ssh` output. Each match schedules a 500ms-debounced hint scan per pane. With the bulk scan also running, multiple `lsof` invocations can overlap.
-
-### Cause 3 — Orphan `lsof` processes outlive Superset
-
-`port-scanner.ts:65-68`
-
-```ts
-await execAsync(
-  `lsof -p ${pidArg} -iTCP -sTCP:LISTEN -P -n 2>/dev/null || true`,
-  { maxBuffer: 10 * 1024 * 1024, timeout: EXEC_TIMEOUT_MS },
-);
-```
-
-Two compounding issues:
-1. `child_process.exec` launches `/bin/sh -c "<command>"`. On timeout, Node sends `SIGTERM` to the shell; the shell does **not** forward the signal to its `lsof` child. The `lsof` gets reparented to `init`/`launchd` and keeps running until it completes on its own — which on a busy macOS machine with many open FDs can take tens of seconds or longer.
-2. When the Electron main process exits, any outstanding `lsof` (not yet reaped) is also reparented and survives. This matches the user's "exiting Superset keeps the process open" observation verbatim.
-
-`lsof` on macOS walks every process's file table and every mounted volume; it is **expensive** and slow, which maximizes the window for both problems above.
-
-## Design / Potential Solutions
-
-We need all three classes of fix to close this issue correctly. Below are options per class with a recommendation.
-
-### A. Lifecycle: stop the interval when idle
-
-| Option | Pros | Cons | Pick |
-| --- | --- | --- | --- |
-| **A1.** Lazy start/stop keyed on session count (what PR #3373 does) | Small diff, correct, easy to test | None material | ✅ |
-| A2. Move interval start into an explicit `PortManager.start()` called from app-ready, stop from app-quit | More explicit lifecycle | More touch points, no material win over A1 | — |
-| A3. Event-driven only (no interval): scan on PTY spawn, on process exit, on hint | Removes polling entirely | Misses child processes that open ports without producing diagnostic output; more code paths | defer |
-
-### B. Concurrency: bound the number of simultaneous `lsof` invocations
-
-| Option | Pros | Cons | Pick |
-| --- | --- | --- | --- |
-| **B1.** Single shared `isScanning` flag covers both bulk and hint scans (extend PR #3373) | Trivial | Serializes unrelated panes behind one lock | ✅ as floor |
-| **B2.** Coalesce hint scans into the next bulk scan (schedule a flag, not a scan) | At most one `lsof` in flight at a time; simplest correctness | Slight latency increase for detection (bounded by 2.5s) | ✅ preferred |
-| B3. Per-pane `isScanning` + global semaphore of N=1 | More granular | More state to manage, same result as B2 | — |
-
-Recommendation: **B2** — replace hint scans with a "pending full scan" flag. If a hint arrives while `isScanning`, set `scanRequested = true`. When bulk scan finishes, if `scanRequested` is set, immediately run another. This guarantees at most one `lsof` in flight and still catches events between ticks.
-
-### C. Process lifecycle: no orphan `lsof`
-
-| Option | Pros | Cons | Pick |
-| --- | --- | --- | --- |
-| **C1.** Switch `exec` → `execFile` (direct exec, no shell) + replace shell `|| true` with a try/catch on non-zero exit | Timeout sends SIGTERM directly to `lsof`; no orphan | Need to handle `exit code != 0` in JS instead of shell | ✅ |
-| **C2.** Also wire an `AbortController` and call `abort()` on `app.before-quit` / scanner teardown to kill in-flight children | Belt-and-suspenders for app quit | More code | ✅ |
-| C3. Keep `exec`, set `killSignal: "SIGKILL"` on timeout | Forces kill of shell, but child still reparents (shell is already dead) | Does not solve orphan | — |
-| C4. Add a global `child_process` registry, kill all on quit | Works, but heavy | Same effect as C1 + C2, more invasive | — |
-
-Recommendation: **C1 + C2**. `execFile` avoids the shell wrapper entirely; an `AbortController` stored on the `PortManager` tears down any in-flight scan when `stopPeriodicScan` runs or on app quit.
-
-### D. Hint regex noise
-
-| Option | Pros | Cons | Pick |
-| --- | --- | --- | --- |
-| **D1.** Delete `/port\s+(\d+)/i` and `/:(\d{4,5})\s*$/`. Keep only the three "listening/server/ready" patterns that actually imply a listener opened | Eliminates ~99% of spurious hints; remaining patterns still cover real dev servers | None — the loose patterns are false positives by design | ✅ |
-| D2. Keep all patterns but require anchor at line start | Marginal improvement | Still matches lots of noise | — |
-| D3. Delete hints entirely, rely on 2.5s bulk | Simplest | Loses fast-detection for dev servers (visible UX regression) | — |
-| D4. Gate hints behind a feature flag | Reversible | Adds surface area without removing the bug | — |
-
-Recommendation: **D1**.
-
-### E. (Optional, follow-up) Reduce per-scan cost
-
-Not required to close #3372 but cheap wins:
-- Skip `lsof` entirely when all registered sessions have an empty process tree (check sizes before exec).
-- Cache the previous result for ≤1 tick and diff only if PID set changed.
-- Consider `/proc/net/tcp` on Linux as a faster alternative to `lsof` (out of scope for this plan).
-
-## Recommended Plan of Action
-
-A combined fix that supersedes PR #3373:
-
-1. **Lifecycle (A1):** move `startPeriodicScan()` out of the constructor; add `ensurePeriodicScanRunning()` / `pausePeriodicScanIfEmpty()` driven by `registerSession`/`upsertDaemonSession`/`unregister*`.
-2. **Concurrency (B2):** replace hint-triggered individual `scanPane` invocations with a "request one follow-up bulk scan" flag coalesced into `scanAllSessions`. Delete `forceScanPane`.
-3. **Process lifecycle (C1 + C2):** rewrite `getListeningPortsLsof` (and `getListeningPortsWindows`) to use `execFile` with an `AbortSignal`. Store a shared `AbortController` on `PortManager`; abort on `stopPeriodicScan`. Register a `before-quit` handler in the main entry point to call `portManager.stopPeriodicScan()`.
-4. **Regex noise (D1):** delete the two over-broad patterns from `containsPortHint`.
-5. **Tests:** extend `port-manager.test.ts` to cover: interval stops when last session unregisters; restarts on re-register; a hint during an in-flight scan schedules exactly one follow-up; aborting the controller does not leak promises.
-6. **Manual smoke:** open 10 workspaces, idle for 5 minutes, check `ps -ef | grep -c lsof` stays bounded; close all workspaces, confirm zero `lsof`; quit Superset, confirm zero `lsof`.
+Auto-generated PR [#3373](https://github.com/superset-sh/superset/pull/3373) by `github-actions[bot]` addresses lifecycle + a weaker `isScanning` guard on `scanPane`. Leaves the orphan-on-timeout and noisy-regex causes untouched. This PR addresses all three.
 
 ## Progress
 
-- [x] (2026-04-17) Rewrite `PortManager` lifecycle (A1) — interval starts on first register, stops on last unregister
-- [x] (2026-04-17) Coalesce hint → follow-up flag (B2) — `scanRequested` + debounced `scheduleHintScan`; deleted `scanPane`, `scanPidTreeAndUpdate`, `pendingHintScans`
-- [x] (2026-04-17) Rewrite `port-scanner.ts` to use `execFile` + `AbortSignal` (C1) — `runTolerant` helper accepts lsof exit 1 as empty
-- [x] (2026-04-17) Wire `AbortController` teardown on `stopPeriodicScan` (C2) — aborts in-flight lsof so it cannot outlive us
-- [x] (2026-04-17) Delete over-broad patterns from `containsPortHint` (D1)
-- [x] (2026-04-17) Unit tests (`port-manager.test.ts`) — 13 tests covering lifecycle, coalescing, regex narrowing, abort teardown; A/B-verified (8 fail on main)
-- [x] (2026-04-17) Delete dead `getProcessName` export and unused `paneId` parameter
+- [x] (2026-04-17) Lifecycle: lazy start/stop via `ensurePeriodicScanRunning` / `stopPeriodicScanIfIdle`
+- [x] (2026-04-17) Concurrency: `scanRequested` follow-up flag; deleted `scanPane`, `scanPidTreeAndUpdate`, `pendingHintScans`
+- [x] (2026-04-17) `execFile` + `AbortSignal`; `runTolerant` helper for lsof exit-1
+- [x] (2026-04-17) `AbortController` aborted on `stopPeriodicScan`
+- [x] (2026-04-17) Deleted the two over-broad hint regexes
+- [x] (2026-04-17) Deleted dead `getProcessName` export and unused `paneId` parameter
+- [x] (2026-04-17) 13 regression tests in `port-manager.test.ts`; A/B verified (8 fail on `main`)
 - [x] (2026-04-17) `bun run typecheck` + `bun run lint:fix` clean; 127/127 terminal tests pass
-- [ ] Close/supersede PR #3373
+- [x] (2026-04-17) PR [#3547](https://github.com/superset-sh/superset/pull/3547) opened
 - [ ] Manual validation on macOS with 10 workspaces
-- [ ] PR opened, issue #3372 closed by merge
+- [ ] #3547 merged, #3372 and #3373 closed
 
-## Surprises & Discoveries
+## Surprises
 
-- Observation: `execFile` with `promisify` rejects on non-zero exit codes; `lsof` exits 1 when its `-p` filter matches no PIDs, which is a legitimate empty result. Added `runTolerant` helper that reads `err.stdout` off the rejection and returns it instead of throwing. Mirrors what the old `|| true` shell trick did, but without the shell wrapper.
-  Evidence: `apps/desktop/src/main/lib/terminal/port-scanner.ts` `runTolerant`.
+- `execFile` via `promisify` rejects on non-zero exit codes. `lsof` exits 1 when its `-p` filter matches no PIDs — legitimate empty result. Added `runTolerant` helper that reads `err.stdout` off the rejection.
+- The production `getListeningPortsLsof` swallows all errors and returns `[]`. The initial test mock rejected on abort, which broke `forceScan`'s contract; fixed by mirroring production (resolve on abort).
+- `getProcessName` was exported but had zero in-repo call sites. Likely dead since a prior hint-scan refactor.
 
-- Observation: The production `getListeningPortsLsof` has a top-level `try/catch` that swallows all errors and returns `[]`. The mock in tests must match this — our first pass had the mock reject on abort, which propagated up and broke `forceScan`'s contract.
-  Evidence: `apps/desktop/src/main/lib/terminal/port-manager.test.ts` — `getListeningPortsForPids` mock resolves on abort.
+## Decisions
 
-- Observation: `getProcessName` was exported but had zero in-repo call sites (likely left behind when the hint-scan path was last refactored). Deleted along with the other changes.
-  Evidence: `grep getProcessName apps/desktop` — only self-reference.
+- **Supersede #3373.** It fixes ~60% of the bug. Three causes → one PR is easier to review and revert.
+- **Coalesce (B2) over shared-flag (B1).** B1 silently drops hint scans; B2 guarantees a follow-up at the same worst-case latency.
+- **`execFile` + `AbortController`, not shell `exec`.** Removes the `sh -c` wrapper that strands children. Signal delivery becomes deterministic.
+- **Delete the two over-broad regexes.** Routine non-port text shouldn't trigger scans.
 
-## Decision Log
+## Outcome
 
-- Decision: Supersede PR #3373 rather than merge it.
-  Rationale: #3373 addresses lifecycle + concurrency (A1, B1) but leaves the orphan-on-timeout and noisy-regex causes intact. Closing the issue requires all three; a single PR is easier to review and revert than a stack of small ones.
-  Date/Author: 2026-04-17 / Planning
+- `port-manager.ts`: +36 / −110
+- `port-scanner.ts`: +52 / −40
+- `port-manager.test.ts`: +255 (new, 13 tests)
 
-- Decision: Coalesce hints into the bulk scan (B2) rather than gating with a shared flag (B1).
-  Rationale: B1 silently drops hint scans during bulk scans, causing a detection gap up to 2.5s anyway. B2 guarantees a follow-up without concurrent `lsof`, same correctness, same worst-case latency.
-  Date/Author: 2026-04-17 / Planning
-
-- Decision: `execFile` + `AbortController`, not shell `exec`.
-  Rationale: Removes the `sh -c` wrapper that strands `lsof` on timeout and on app exit. Makes signal delivery deterministic.
-  Date/Author: 2026-04-17 / Planning
-
-- Decision: Delete `/port\s+(\d+)/i` and `/:(\d{4,5})\s*$/` outright.
-  Rationale: Both match routine non-port text (git logs, ssh banners, timestamps). The three remaining "listening/server/ready" patterns cover real dev-server startup lines. If users report missed detections we can add more-specific patterns.
-  Date/Author: 2026-04-17 / Planning
-
-## Outcomes & Retrospective
-
-Implementation landed as a single focused change to `port-manager.ts` and `port-scanner.ts`:
-
-- **port-manager.ts**: +36 / −110 lines. Lifecycle gated on session count; hint scans coalesced via a single debounced timer + `scanRequested` follow-up flag; private `AbortController` aborted on teardown.
-- **port-scanner.ts**: +52 / −40 lines net. `execFile` instead of `exec` everywhere; `AbortSignal` threaded through the public surface; `runTolerant` helper for the lsof-exits-1 case; dead `getProcessName` export removed.
-- **port-manager.test.ts**: +255 lines new. 13 tests covering lifecycle, coalescing, regex narrowing, and abort teardown. A/B-proven: stashing the port-manager/port-scanner changes and rerunning shows 8 of 13 tests fail on `main`.
-
-A/B measurement (mocked `lsof`): a flood of 100 hint-matching data chunks during a 30 ms in-flight scan produces ≤2 total `lsof` calls and `maxInFlight === 1`. On `main`, the same inputs would produce many concurrent calls because hint scans bypassed the `isScanning` guard.
-
-Supersedes PR #3373 (auto-generated by `github-actions[bot]`), which addressed lifecycle + a weaker concurrency guard but left the orphan-on-timeout and regex-noise causes unaddressed.
+A/B (mocked `lsof`): 100 hint-matching chunks during a 30 ms scan → ≤2 `lsof` calls, `maxInFlight == 1`. On `main`: unbounded concurrency.

--- a/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts
+++ b/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts
@@ -191,7 +191,7 @@ export class DaemonTerminalManager extends EventEmitter {
 				session.lastActive = Date.now();
 			}
 
-			portManager.checkOutputForHint(data, paneId);
+			portManager.checkOutputForHint(data);
 			this.historyManager.writeToHistory(paneId, data, () =>
 				this.sessions.get(paneId),
 			);

--- a/apps/desktop/src/main/lib/terminal/port-manager.test.ts
+++ b/apps/desktop/src/main/lib/terminal/port-manager.test.ts
@@ -1,0 +1,254 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { TerminalSession } from "./types";
+
+/**
+ * Regression tests for #3372 ("excessive lsof spawning").
+ *
+ * Three behaviors the fix guarantees:
+ *   1. No scans run when there are no registered sessions (lifecycle).
+ *   2. At most one scan is in flight at any moment, even under a flood of
+ *      hint-matching output (concurrency / coalescing).
+ *   3. stopPeriodicScan aborts any in-flight child so it cannot outlive us
+ *      (no orphan lsof).
+ *
+ * The hint regexes that previously matched routine log noise ("port 22",
+ * trailing ":12345") must no longer trigger scans; the three "listening on …"
+ * patterns still must.
+ */
+
+interface ScannerSpy {
+	getProcessTree: number;
+	getListeningPortsForPids: number;
+	inFlight: number;
+	maxInFlight: number;
+	lastSignal: AbortSignal | undefined;
+	aborted: number;
+}
+
+const spy: ScannerSpy = {
+	getProcessTree: 0,
+	getListeningPortsForPids: 0,
+	inFlight: 0,
+	maxInFlight: 0,
+	lastSignal: undefined,
+	aborted: 0,
+};
+
+let lsofDelayMs = 0;
+
+mock.module("./port-scanner", () => ({
+	getProcessTree: async (pid: number) => {
+		spy.getProcessTree++;
+		return [pid, pid + 1];
+	},
+	getListeningPortsForPids: async (_pids: number[], signal?: AbortSignal) => {
+		spy.getListeningPortsForPids++;
+		spy.inFlight++;
+		spy.maxInFlight = Math.max(spy.maxInFlight, spy.inFlight);
+		spy.lastSignal = signal;
+		try {
+			if (lsofDelayMs > 0) {
+				// Match production: getListeningPortsLsof catches all errors and
+				// returns []. If we get aborted we just resolve with [] early.
+				await new Promise<void>((resolve) => {
+					const timer = setTimeout(resolve, lsofDelayMs);
+					signal?.addEventListener("abort", () => {
+						clearTimeout(timer);
+						spy.aborted++;
+						resolve();
+					});
+				});
+			}
+			return [];
+		} finally {
+			spy.inFlight--;
+		}
+	},
+}));
+
+mock.module("../tree-kill", () => ({
+	treeKillWithEscalation: async () => ({ success: true }),
+}));
+
+const { portManager } = await import("./port-manager");
+
+const HINT_DEBOUNCE_MS = 500;
+const PAST_DEBOUNCE_MS = HINT_DEBOUNCE_MS + 50;
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+const makeSession = (paneId: string, pid: number): TerminalSession =>
+	({ paneId, isAlive: true, pty: { pid } }) as unknown as TerminalSession;
+
+// biome-ignore lint/suspicious/noExplicitAny: reach into private singleton state
+const pmInternals = () => portManager as any;
+
+function resetSpy(): void {
+	spy.getProcessTree = 0;
+	spy.getListeningPortsForPids = 0;
+	spy.inFlight = 0;
+	spy.maxInFlight = 0;
+	spy.lastSignal = undefined;
+	spy.aborted = 0;
+	lsofDelayMs = 0;
+}
+
+function resetManager(): void {
+	const internals = pmInternals();
+	for (const paneId of Array.from<string>(internals.sessions.keys())) {
+		portManager.unregisterSession(paneId);
+	}
+	for (const paneId of Array.from<string>(internals.daemonSessions.keys())) {
+		portManager.unregisterDaemonSession(paneId);
+	}
+	portManager.stopPeriodicScan();
+}
+
+beforeEach(() => {
+	resetSpy();
+	resetManager();
+});
+
+afterEach(() => {
+	resetManager();
+});
+
+describe("PortManager — #3372 lifecycle (interval runs only with sessions)", () => {
+	it("forceScan is a no-op when no sessions are registered", async () => {
+		await portManager.forceScan();
+		expect(spy.getProcessTree).toBe(0);
+		expect(spy.getListeningPortsForPids).toBe(0);
+	});
+
+	it("first registered session starts the interval; last unregister stops it", () => {
+		expect(pmInternals().scanInterval).toBeNull();
+
+		portManager.registerSession(makeSession("p1", 1000), "ws1");
+		expect(pmInternals().scanInterval).not.toBeNull();
+
+		portManager.unregisterSession("p1");
+		expect(pmInternals().scanInterval).toBeNull();
+	});
+
+	it("daemon sessions control the interval the same way", () => {
+		portManager.upsertDaemonSession("pd1", "ws1", 2000);
+		expect(pmInternals().scanInterval).not.toBeNull();
+
+		portManager.unregisterDaemonSession("pd1");
+		expect(pmInternals().scanInterval).toBeNull();
+	});
+
+	it("mixed session types: interval stops only when all are gone", () => {
+		portManager.registerSession(makeSession("p1", 1000), "ws1");
+		portManager.upsertDaemonSession("pd1", "ws2", 2000);
+
+		portManager.unregisterSession("p1");
+		expect(pmInternals().scanInterval).not.toBeNull();
+
+		portManager.unregisterDaemonSession("pd1");
+		expect(pmInternals().scanInterval).toBeNull();
+	});
+
+	it("re-registering after idle restarts the interval", () => {
+		portManager.registerSession(makeSession("p1", 1000), "ws1");
+		portManager.unregisterSession("p1");
+		expect(pmInternals().scanInterval).toBeNull();
+
+		portManager.registerSession(makeSession("p2", 1001), "ws1");
+		expect(pmInternals().scanInterval).not.toBeNull();
+	});
+});
+
+describe("PortManager — #3372 concurrency (at most one lsof in flight)", () => {
+	it("bulk scan batches every session into a single lsof call", async () => {
+		for (let i = 0; i < 10; i++) {
+			portManager.registerSession(makeSession(`p${i}`, 1000 + i), `ws${i}`);
+		}
+		await portManager.forceScan();
+
+		expect(spy.getListeningPortsForPids).toBe(1);
+		expect(spy.maxInFlight).toBe(1);
+	});
+
+	it("a flood of hints coalesces into one follow-up, never concurrent", async () => {
+		lsofDelayMs = 30;
+		portManager.registerSession(makeSession("p1", 1000), "ws1");
+
+		const firstScan = portManager.forceScan();
+
+		// 100 hints while the first scan is running — all on the hot path.
+		for (let i = 0; i < 100; i++) {
+			portManager.checkOutputForHint("listening on port 3000\n");
+		}
+
+		await firstScan;
+		await sleep(PAST_DEBOUNCE_MS); // let the single debounced follow-up run
+
+		expect(spy.maxInFlight).toBe(1);
+		expect(spy.getListeningPortsForPids).toBeLessThanOrEqual(2);
+	});
+});
+
+describe("PortManager — #3372 hint regex narrowing", () => {
+	beforeEach(() => {
+		portManager.registerSession(makeSession("p1", 1000), "ws1");
+		resetSpy();
+	});
+
+	it("does NOT scan on a bare 'port 22' (old loose pattern)", async () => {
+		portManager.checkOutputForHint("connection reached port 22\n");
+		await sleep(PAST_DEBOUNCE_MS);
+		expect(spy.getListeningPortsForPids).toBe(0);
+	});
+
+	it("does NOT scan on a trailing ':12345' (old loose pattern)", async () => {
+		portManager.checkOutputForHint("commit abc123def:12345\n");
+		await sleep(PAST_DEBOUNCE_MS);
+		expect(spy.getListeningPortsForPids).toBe(0);
+	});
+
+	it("DOES scan on 'listening on port 3000'", async () => {
+		portManager.checkOutputForHint("listening on port 3000\n");
+		await sleep(PAST_DEBOUNCE_MS);
+		expect(spy.getListeningPortsForPids).toBe(1);
+	});
+
+	it("DOES scan on 'server running at http://localhost:3000'", async () => {
+		portManager.checkOutputForHint("server running at http://localhost:3000\n");
+		await sleep(PAST_DEBOUNCE_MS);
+		expect(spy.getListeningPortsForPids).toBe(1);
+	});
+});
+
+describe("PortManager — #3372 teardown (no orphan children)", () => {
+	it("stopPeriodicScan aborts any in-flight lsof", async () => {
+		lsofDelayMs = 200;
+		portManager.registerSession(makeSession("p1", 1000), "ws1");
+
+		const scanPromise = portManager.forceScan();
+		// Wait for the lsof stub to start.
+		await sleep(10);
+		expect(spy.inFlight).toBe(1);
+
+		portManager.stopPeriodicScan();
+
+		// The promise resolves (port-scanner swallows its own errors).
+		await scanPromise;
+
+		expect(spy.aborted).toBeGreaterThanOrEqual(1);
+		expect(spy.inFlight).toBe(0);
+	});
+
+	it("in-flight lsof receives the AbortSignal from the manager", async () => {
+		lsofDelayMs = 50;
+		portManager.registerSession(makeSession("p1", 1000), "ws1");
+
+		const scanPromise = portManager.forceScan();
+		await sleep(10);
+
+		expect(spy.lastSignal).toBeDefined();
+		expect(spy.lastSignal?.aborted).toBe(false);
+
+		await scanPromise;
+	});
+});

--- a/apps/desktop/src/main/lib/terminal/port-manager.test.ts
+++ b/apps/desktop/src/main/lib/terminal/port-manager.test.ts
@@ -218,6 +218,12 @@ describe("PortManager — #3372 hint regex narrowing", () => {
 		await sleep(PAST_DEBOUNCE_MS);
 		expect(spy.getListeningPortsForPids).toBe(1);
 	});
+
+	it("DOES scan on 'ready on http://localhost:5173' (Vite-style)", async () => {
+		portManager.checkOutputForHint("ready on http://localhost:5173\n");
+		await sleep(PAST_DEBOUNCE_MS);
+		expect(spy.getListeningPortsForPids).toBe(1);
+	});
 });
 
 describe("PortManager — #3372 teardown (no orphan children)", () => {

--- a/apps/desktop/src/main/lib/terminal/port-manager.test.ts
+++ b/apps/desktop/src/main/lib/terminal/port-manager.test.ts
@@ -185,7 +185,8 @@ describe("PortManager — #3372 concurrency (at most one lsof in flight)", () =>
 		await sleep(PAST_DEBOUNCE_MS); // let the single debounced follow-up run
 
 		expect(spy.maxInFlight).toBe(1);
-		expect(spy.getListeningPortsForPids).toBeLessThanOrEqual(2);
+		// Exact — one initial scan + one coalesced follow-up, never more, never fewer.
+		expect(spy.getListeningPortsForPids).toBe(2);
 	});
 });
 

--- a/apps/desktop/src/main/lib/terminal/port-manager.ts
+++ b/apps/desktop/src/main/lib/terminal/port-manager.ts
@@ -19,16 +19,16 @@ const IGNORED_PORTS = new Set([22, 80, 443, 5432, 3306, 6379, 27017]);
 
 /**
  * Check if terminal output contains hints that a port may have been opened.
- * Common patterns from dev servers, test frameworks, etc.
+ * Restricted to phrases that strongly imply a server just started listening;
+ * looser patterns like a bare "port 22" or trailing ":12345" are omitted
+ * because they match routine log output (ssh banners, timestamps, etc.) and
+ * triggered excessive lsof scans — see issue #3372.
  */
 function containsPortHint(data: string): boolean {
-	// Common patterns: "listening on port X", "server started on :X", etc.
 	const portPatterns = [
 		/listening\s+on\s+(?:port\s+)?(\d+)/i,
 		/server\s+(?:started|running)\s+(?:on|at)\s+(?:http:\/\/)?(?:localhost|127\.0\.0\.1|0\.0\.0\.0)?:?(\d+)/i,
 		/ready\s+on\s+(?:http:\/\/)?(?:localhost|127\.0\.0\.1|0\.0\.0\.0)?:?(\d+)/i,
-		/port\s+(\d+)/i,
-		/:(\d{4,5})\s*$/,
 	];
 	return portPatterns.some((pattern) => pattern.test(data));
 }
@@ -62,19 +62,19 @@ class PortManager extends EventEmitter {
 	/** Daemon-mode sessions: paneId → { workspaceId, pid } */
 	private daemonSessions = new Map<string, DaemonSession>();
 	private scanInterval: ReturnType<typeof setInterval> | null = null;
-	private pendingHintScans = new Map<string, ReturnType<typeof setTimeout>>();
+	private hintScanTimeout: ReturnType<typeof setTimeout> | null = null;
 	private isScanning = false;
-
-	constructor() {
-		super();
-		this.startPeriodicScan();
-	}
+	/** Set when a hint arrives during a scan; triggers one follow-up scan. */
+	private scanRequested = false;
+	/** Aborts any in-flight scan children (lsof/netstat) on teardown. */
+	private scanAbort: AbortController | null = null;
 
 	/**
 	 * Register a terminal session for port scanning
 	 */
 	registerSession(session: TerminalSession, workspaceId: string): void {
 		this.sessions.set(session.paneId, { session, workspaceId });
+		this.ensurePeriodicScanRunning();
 	}
 
 	/**
@@ -83,7 +83,7 @@ class PortManager extends EventEmitter {
 	unregisterSession(paneId: string): void {
 		this.sessions.delete(paneId);
 		this.removePortsForPane(paneId);
-		this.clearPendingHintScan(paneId);
+		this.stopPeriodicScanIfIdle();
 	}
 
 	/**
@@ -97,6 +97,7 @@ class PortManager extends EventEmitter {
 		pid: number | null,
 	): void {
 		this.daemonSessions.set(paneId, { workspaceId, pid });
+		this.ensurePeriodicScanRunning();
 	}
 
 	/**
@@ -105,17 +106,22 @@ class PortManager extends EventEmitter {
 	unregisterDaemonSession(paneId: string): void {
 		this.daemonSessions.delete(paneId);
 		this.removePortsForPane(paneId);
-		this.clearPendingHintScan(paneId);
+		this.stopPeriodicScanIfIdle();
 	}
 
-	checkOutputForHint(data: string, paneId: string): void {
+	checkOutputForHint(data: string): void {
 		if (!containsPortHint(data)) return;
-		this.scheduleHintScan(paneId);
+		this.scheduleHintScan();
 	}
 
-	private startPeriodicScan(): void {
+	private hasAnySessions(): boolean {
+		return this.sessions.size > 0 || this.daemonSessions.size > 0;
+	}
+
+	private ensurePeriodicScanRunning(): void {
 		if (this.scanInterval) return;
 
+		this.scanAbort = new AbortController();
 		this.scanInterval = setInterval(() => {
 			this.scanAllSessions().catch((error) => {
 				console.error("[PortManager] Scan error:", error);
@@ -126,89 +132,42 @@ class PortManager extends EventEmitter {
 		this.scanInterval.unref();
 	}
 
+	private stopPeriodicScanIfIdle(): void {
+		if (!this.hasAnySessions()) this.stopPeriodicScan();
+	}
+
 	stopPeriodicScan(): void {
 		if (this.scanInterval) {
 			clearInterval(this.scanInterval);
 			this.scanInterval = null;
 		}
 
-		for (const timeout of this.pendingHintScans.values()) {
-			clearTimeout(timeout);
+		if (this.hintScanTimeout) {
+			clearTimeout(this.hintScanTimeout);
+			this.hintScanTimeout = null;
 		}
-		this.pendingHintScans.clear();
+
+		// Kill any in-flight lsof/netstat so it can't outlive us.
+		if (this.scanAbort) {
+			this.scanAbort.abort();
+			this.scanAbort = null;
+		}
+
+		this.scanRequested = false;
 	}
 
-	private clearPendingHintScan(paneId: string): void {
-		const pendingTimeout = this.pendingHintScans.get(paneId);
-		if (pendingTimeout) {
-			clearTimeout(pendingTimeout);
-			this.pendingHintScans.delete(paneId);
-		}
-	}
+	/**
+	 * Debounce hint-triggered scans into a single follow-up bulk scan.
+	 * Hints arrive on every PTY data chunk; we only need one scan per burst.
+	 */
+	private scheduleHintScan(): void {
+		if (this.hintScanTimeout) return;
 
-	private scheduleHintScan(paneId: string): void {
-		this.clearPendingHintScan(paneId);
-
-		const timeout = setTimeout(() => {
-			this.pendingHintScans.delete(paneId);
-			this.scanPane(paneId).catch(() => {});
+		this.hintScanTimeout = setTimeout(() => {
+			this.hintScanTimeout = null;
+			this.scanAllSessions().catch(() => {});
 		}, HINT_SCAN_DELAY_MS);
-		// Don't keep Electron alive just for port scanning
-		timeout.unref();
-
-		this.pendingHintScans.set(paneId, timeout);
-	}
-
-	private async scanPidTreeAndUpdate({
-		paneId,
-		workspaceId,
-		pid,
-		errorContext,
-	}: {
-		paneId: string;
-		workspaceId: string;
-		pid: number;
-		errorContext: string;
-	}): Promise<void> {
-		try {
-			const pids = await getProcessTree(pid);
-			if (pids.length === 0) {
-				this.removePortsForPane(paneId);
-				return;
-			}
-
-			const portInfos = await getListeningPortsForPids(pids);
-			this.updatePortsForPane({ paneId, workspaceId, portInfos });
-		} catch (error) {
-			console.error(`[PortManager] Error scanning ${errorContext}:`, error);
-		}
-	}
-
-	private async scanPane(paneId: string): Promise<void> {
-		const registered = this.sessions.get(paneId);
-		if (registered) {
-			const { session, workspaceId } = registered;
-			if (!session.isAlive) return;
-			await this.scanPidTreeAndUpdate({
-				paneId,
-				workspaceId,
-				pid: session.pty.pid,
-				errorContext: `pane ${paneId}`,
-			});
-			return;
-		}
-
-		const daemonSession = this.daemonSessions.get(paneId);
-		if (daemonSession) {
-			const { workspaceId, pid } = daemonSession;
-			if (pid === null) return;
-			await this.scanPidTreeAndUpdate({
-				paneId,
-				workspaceId,
-				pid,
-				errorContext: `daemon pane ${paneId}`,
-			});
-		}
+		this.hintScanTimeout.unref();
 	}
 
 	private createScanState(): ScanState {
@@ -307,7 +266,10 @@ class PortManager extends EventEmitter {
 		const allPidList = Array.from(allPids);
 		if (allPidList.length === 0) return portsByPane;
 
-		const portInfos = await getListeningPortsForPids(allPidList);
+		const portInfos = await getListeningPortsForPids(
+			allPidList,
+			this.scanAbort?.signal,
+		);
 		for (const info of portInfos) {
 			const owner = pidOwnerMap.get(info.pid);
 			if (!owner) continue;
@@ -353,7 +315,12 @@ class PortManager extends EventEmitter {
 	}
 
 	private async scanAllSessions(): Promise<void> {
-		if (this.isScanning) return;
+		if (this.isScanning) {
+			// A hint or tick fired mid-scan; queue exactly one follow-up.
+			this.scanRequested = true;
+			return;
+		}
+		if (!this.hasAnySessions()) return;
 		this.isScanning = true;
 
 		try {
@@ -374,6 +341,11 @@ class PortManager extends EventEmitter {
 			this.cleanupUnregisteredPorts();
 		} finally {
 			this.isScanning = false;
+		}
+
+		if (this.scanRequested && this.hasAnySessions()) {
+			this.scanRequested = false;
+			await this.scanAllSessions();
 		}
 	}
 

--- a/apps/desktop/src/main/lib/terminal/port-scanner.ts
+++ b/apps/desktop/src/main/lib/terminal/port-scanner.ts
@@ -180,7 +180,7 @@ async function getListeningPortsWindows(
 		const nameResults = await Promise.all(
 			pidsToLookup.map(async (pid) => ({
 				pid,
-				name: await getProcessNameWindows(pid),
+				name: await getProcessNameWindows(pid, signal),
 			})),
 		);
 		for (const { pid, name } of nameResults) {
@@ -226,12 +226,15 @@ async function getListeningPortsWindows(
 /**
  * Get process name for a PID on Windows
  */
-async function getProcessNameWindows(pid: number): Promise<string> {
+async function getProcessNameWindows(
+	pid: number,
+	signal?: AbortSignal,
+): Promise<string> {
 	try {
 		const { stdout: output } = await execFileAsync(
 			"wmic",
 			["process", "where", `processid=${pid}`, "get", "name"],
-			{ timeout: EXEC_TIMEOUT_MS },
+			{ timeout: EXEC_TIMEOUT_MS, signal },
 		);
 		const lines = output.trim().split("\n");
 		if (lines.length >= 2) {
@@ -244,7 +247,7 @@ async function getProcessNameWindows(pid: number): Promise<string> {
 			const { stdout: output } = await execFileAsync(
 				"powershell",
 				["-Command", `(Get-Process -Id ${pid}).ProcessName`],
-				{ timeout: EXEC_TIMEOUT_MS },
+				{ timeout: EXEC_TIMEOUT_MS, signal },
 			);
 			return output.trim() || "unknown";
 		} catch {}

--- a/apps/desktop/src/main/lib/terminal/port-scanner.ts
+++ b/apps/desktop/src/main/lib/terminal/port-scanner.ts
@@ -1,9 +1,31 @@
-import { exec } from "node:child_process";
+import { execFile } from "node:child_process";
 import os from "node:os";
 import { promisify } from "node:util";
 import pidtree from "pidtree";
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
+
+/**
+ * Run execFile and tolerate a non-zero exit code by returning its stdout.
+ * lsof exits 1 when no PIDs match the filter — that is a legitimate "empty"
+ * result, not an error. Using execFile (not exec) avoids a `/bin/sh -c` wrapper
+ * that would strand the child on SIGTERM/timeout.
+ */
+async function runTolerant(
+	file: string,
+	args: string[],
+	options: { maxBuffer: number; timeout: number; signal?: AbortSignal },
+): Promise<string> {
+	try {
+		const { stdout } = await execFileAsync(file, args, options);
+		return stdout;
+	} catch (err) {
+		if (err && typeof err === "object" && "stdout" in err) {
+			return String((err as { stdout: string }).stdout ?? "");
+		}
+		throw err;
+	}
+}
 
 /** Timeout for shell commands to prevent hanging (ms) */
 const EXEC_TIMEOUT_MS = 5000;
@@ -33,16 +55,17 @@ export async function getProcessTree(pid: number): Promise<number[]> {
  */
 export async function getListeningPortsForPids(
 	pids: number[],
+	signal?: AbortSignal,
 ): Promise<PortInfo[]> {
 	if (pids.length === 0) return [];
 
 	const platform = os.platform();
 
 	if (platform === "darwin" || platform === "linux") {
-		return getListeningPortsLsof(pids);
+		return getListeningPortsLsof(pids, signal);
 	}
 	if (platform === "win32") {
-		return getListeningPortsWindows(pids);
+		return getListeningPortsWindows(pids, signal);
 	}
 
 	return [];
@@ -51,7 +74,10 @@ export async function getListeningPortsForPids(
 /**
  * macOS/Linux implementation using lsof
  */
-async function getListeningPortsLsof(pids: number[]): Promise<PortInfo[]> {
+async function getListeningPortsLsof(
+	pids: number[],
+	signal?: AbortSignal,
+): Promise<PortInfo[]> {
 	try {
 		const pidArg = pids.join(",");
 		const pidSet = new Set(pids);
@@ -62,9 +88,10 @@ async function getListeningPortsLsof(pids: number[]): Promise<PortInfo[]> {
 		// -n: don't resolve hostnames
 		// Note: lsof may ignore -p filter if PIDs don't exist or have no matches,
 		// so we must validate PIDs in the output against our requested set
-		const { stdout: output } = await execAsync(
-			`lsof -p ${pidArg} -iTCP -sTCP:LISTEN -P -n 2>/dev/null || true`,
-			{ maxBuffer: 10 * 1024 * 1024, timeout: EXEC_TIMEOUT_MS },
+		const output = await runTolerant(
+			"lsof",
+			["-p", pidArg, "-iTCP", "-sTCP:LISTEN", "-P", "-n"],
+			{ maxBuffer: 10 * 1024 * 1024, timeout: EXEC_TIMEOUT_MS, signal },
 		);
 
 		if (!output.trim()) return [];
@@ -116,11 +143,15 @@ async function getListeningPortsLsof(pids: number[]): Promise<PortInfo[]> {
 /**
  * Windows implementation using netstat
  */
-async function getListeningPortsWindows(pids: number[]): Promise<PortInfo[]> {
+async function getListeningPortsWindows(
+	pids: number[],
+	signal?: AbortSignal,
+): Promise<PortInfo[]> {
 	try {
-		const { stdout: output } = await execAsync("netstat -ano", {
+		const { stdout: output } = await execFileAsync("netstat", ["-ano"], {
 			maxBuffer: 10 * 1024 * 1024,
 			timeout: EXEC_TIMEOUT_MS,
+			signal,
 		});
 
 		const pidSet = new Set(pids);
@@ -197,8 +228,9 @@ async function getListeningPortsWindows(pids: number[]): Promise<PortInfo[]> {
  */
 async function getProcessNameWindows(pid: number): Promise<string> {
 	try {
-		const { stdout: output } = await execAsync(
-			`wmic process where processid=${pid} get name 2>nul`,
+		const { stdout: output } = await execFileAsync(
+			"wmic",
+			["process", "where", `processid=${pid}`, "get", "name"],
 			{ timeout: EXEC_TIMEOUT_MS },
 		);
 		const lines = output.trim().split("\n");
@@ -209,37 +241,13 @@ async function getProcessNameWindows(pid: number): Promise<string> {
 	} catch {
 		// wmic is deprecated, try PowerShell as fallback
 		try {
-			const { stdout: output } = await execAsync(
-				`powershell -Command "(Get-Process -Id ${pid}).ProcessName"`,
+			const { stdout: output } = await execFileAsync(
+				"powershell",
+				["-Command", `(Get-Process -Id ${pid}).ProcessName`],
 				{ timeout: EXEC_TIMEOUT_MS },
 			);
 			return output.trim() || "unknown";
 		} catch {}
 	}
 	return "unknown";
-}
-
-/**
- * Get process name for a PID (cross-platform)
- */
-export async function getProcessName(pid: number): Promise<string> {
-	const platform = os.platform();
-
-	if (platform === "win32") {
-		return getProcessNameWindows(pid);
-	}
-
-	// macOS/Linux
-	try {
-		const { stdout: output } = await execAsync(
-			`ps -p ${pid} -o comm= 2>/dev/null || true`,
-			{ timeout: EXEC_TIMEOUT_MS },
-		);
-		const name = output.trim();
-		// On macOS, comm may be truncated. The full path can be gotten with -o command=
-		// but comm is usually sufficient for display purposes
-		return name || "unknown";
-	} catch {
-		return "unknown";
-	}
 }

--- a/apps/desktop/src/main/lib/terminal/port-scanner.ts
+++ b/apps/desktop/src/main/lib/terminal/port-scanner.ts
@@ -6,10 +6,11 @@ import pidtree from "pidtree";
 const execFileAsync = promisify(execFile);
 
 /**
- * Run execFile and tolerate a non-zero exit code by returning its stdout.
- * lsof exits 1 when no PIDs match the filter — that is a legitimate "empty"
- * result, not an error. Using execFile (not exec) avoids a `/bin/sh -c` wrapper
- * that would strand the child on SIGTERM/timeout.
+ * Run execFile and tolerate a plain non-zero exit by returning its stdout.
+ * lsof exits 1 when no PIDs match the filter — a legitimate "empty" result.
+ * Aborts, timeouts, and signal-kills are NOT tolerated: partial stdout from a
+ * killed child is not a trustworthy snapshot, so rethrow and let the caller's
+ * outer catch turn it into `[]`.
  */
 async function runTolerant(
 	file: string,
@@ -20,8 +21,25 @@ async function runTolerant(
 		const { stdout } = await execFileAsync(file, args, options);
 		return stdout;
 	} catch (err) {
-		if (err && typeof err === "object" && "stdout" in err) {
-			return String((err as { stdout: string }).stdout ?? "");
+		if (err && typeof err === "object") {
+			const execErr = err as {
+				stdout?: string | Buffer;
+				code?: unknown;
+				killed?: boolean;
+				signal?: unknown;
+				name?: string;
+			};
+			if (
+				execErr.name === "AbortError" ||
+				execErr.code === "ABORT_ERR" ||
+				execErr.killed ||
+				execErr.signal
+			) {
+				throw err;
+			}
+			if ("stdout" in execErr) {
+				return String(execErr.stdout ?? "");
+			}
 		}
 		throw err;
 	}


### PR DESCRIPTION
Closes #3372. Supersedes #3373.

## Summary

`PortManager` was spawning `lsof` every 2.5s forever and leaving orphaned children behind on timeout / app-quit. Three compounding root causes, fixed together:

1. **Lifecycle** — the 2.5s `setInterval` started at module load and was never stopped. Closing all workspaces kept it ticking; quitting Superset left the final interval's children running.
2. **Concurrency** — hint-triggered scans (from terminal output matching port patterns) bypassed the `isScanning` guard and piled up alongside the bulk periodic scan.
3. **Orphaned children** — each call ran `exec("sh -c 'lsof ... || true'")`. On timeout, Node SIGTERM'd the shell wrapper but the shell didn't forward the signal, so `lsof` got reparented to `launchd`/`init` and outlived the app.

## Fix

- **Lifecycle-gated interval**: starts on first `registerSession` / `upsertDaemonSession`, stops on the last unregister (`port-manager.ts`).
- **Coalesced scans**: hints are debounced into a single global timer; if a tick or hint fires mid-scan, a `scanRequested` flag triggers exactly one follow-up. `maxInFlight` is guaranteed to be 1.
- **No orphans**: swapped `exec` (shell wrapper) for `execFile`, threaded an `AbortSignal` through the scanner, and wired `stopPeriodicScan` to abort any in-flight child (`port-scanner.ts`, `port-manager.ts`).
- **Narrower hint regexes**: dropped `/port\s+(\d+)/i` and `/:(\d{4,5})\s*$/` which matched routine log noise (ssh banners, timestamps, commit hashes) and forced spurious scans. Kept the three `listening/server/ready` patterns that imply a real listener.
- **Dead code**: removed exported `getProcessName` (no in-repo callers) and the unused `paneId` parameter on `checkOutputForHint`.

## Test plan

- [x] New `apps/desktop/src/main/lib/terminal/port-manager.test.ts` — 13 tests covering lifecycle, coalescing, regex narrowing, and abort teardown. **A/B-proven: 8 of 13 fail on `main` with the old code, all 13 pass on this branch.**
- [x] `bun test apps/desktop/src/main/lib/terminal/` — 127/127 pass
- [x] `bun run typecheck` — clean
- [x] `bun run lint:fix` — clean
- [ ] Manual validation on macOS: open ~10 workspaces, idle 2 minutes, confirm `ps -ef | grep -c '[l]sof'` stays bounded; close all workspaces and confirm it drops to zero; quit Superset and confirm no surviving `lsof` children.

## Design doc

Full root-cause analysis, options considered, and tradeoffs in `apps/desktop/plans/20260417-1830-lsof-excessive-spawning-3372.md`.

## Supersedes #3373

The auto-generated PR #3373 addressed lifecycle + a weaker concurrency guard but left the orphan-on-timeout and regex-noise causes unfixed. This PR addresses all three.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop excessive `lsof` spawning in the desktop port scanner by tying scans to the session lifecycle, coalescing hint-driven scans, and aborting in-flight children on teardown. Also forwards abort signals on Windows helpers to avoid lingering processes; reduces CPU and keeps port detection accurate.

- **Bug Fixes**
  - Lifecycle: start the 2.5s scan loop on first `registerSession`/`upsertDaemonSession`, stop on last unregister; no sessions = no scans.
  - Concurrency: debounce hints into one timer; if a hint/tick fires mid-scan, queue exactly one follow-up; max in-flight `lsof` is 1.
  - Process handling: use `execFile` with an `AbortSignal`; `stopPeriodicScan` aborts children. `runTolerant` only treats plain non-zero exits (e.g., `lsof` exit 1) as empty, and rethrows on abort/kill to avoid parsing partial stdout. On Windows, forward the signal to `wmic`/`powershell` process-name lookups.
  - Regex: remove noisy `/port\s+(\d+)/i` and `/:(\d{4,5})\s*$/`; keep the “listening/server/ready” patterns only.
  - Cleanup/tests: remove unused `getProcessName`; `checkOutputForHint` no longer takes `paneId`. Added tests for lifecycle, coalescing (assert exactly one follow-up), regex (incl. “ready on …”/Vite), and teardown.

<sup>Written for commit 5e8dd2a41f26ef5c3f620b175f92746c98a5c4c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Greatly reduced excessive background process spawning by bounding concurrent port scans, aborting in-flight scans on shutdown, and replacing fragile shell-based execution to prevent orphaned helper processes.
  * Start/stop periodic scanning only while sessions exist; debounce and coalesce hint-triggered scans into a single follow-up.
  * Tightened hint matching to cut false positives.

* **Documentation**
  * Added a plan describing the end-to-end approach and validation notes for port-detection fixes.

* **Tests**
  * Added regression tests covering lifecycle, concurrency/coalescing, hint patterns, and teardown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->