### PR TITLE
fix(desktop): guard installUpdate against repeat clicks on macOS

### DIFF
--- a/apps/desktop/src/main/lib/auto-updater.test.ts
+++ b/apps/desktop/src/main/lib/auto-updater.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { EventEmitter } from "node:events";
+
+class FakeAutoUpdater extends EventEmitter {
+	autoDownload = false;
+	autoInstallOnAppQuit = false;
+	disableDifferentialDownload = false;
+	allowDowngrade = false;
+	setFeedURL = mock(() => {});
+	checkForUpdates = mock(() => Promise.resolve(null));
+	quitAndInstall = mock(() => {});
+}
+
+const fakeAutoUpdater = new FakeAutoUpdater();
+
+mock.module("electron-updater", () => ({
+	autoUpdater: fakeAutoUpdater,
+}));
+
+mock.module("electron", () => ({
+	app: {
+		getPath: mock(() => ""),
+		getName: mock(() => "test-app"),
+		getVersion: mock(() => "1.0.0"),
+		getAppPath: mock(() => ""),
+		isPackaged: false,
+		isReady: mock(() => true),
+		whenReady: mock(() => Promise.resolve()),
+	},
+	dialog: {
+		showMessageBox: mock(() => Promise.resolve({ response: 0 })),
+	},
+}));
+
+mock.module("main/index", () => ({
+	setSkipQuitConfirmation: mock(() => {}),
+}));
+
+const autoUpdater = await import("./auto-updater");
+const { AUTO_UPDATE_STATUS } = await import("shared/auto-update");
+
+describe("installUpdate", () => {
+	beforeEach(() => {
+		fakeAutoUpdater.removeAllListeners();
+		fakeAutoUpdater.quitAndInstall.mockClear();
+		fakeAutoUpdater.checkForUpdates.mockClear();
+		fakeAutoUpdater.setFeedURL.mockClear();
+		autoUpdater.setupAutoUpdater();
+		// The module is a singleton; emit an error to reset isInstalling
+		// between tests (the error handler clears it).
+		fakeAutoUpdater.emit("error", new Error("reset"));
+	});
+
+	test("ignores install requests when no update is ready", () => {
+		expect(autoUpdater.getUpdateStatus().status).not.toBe(
+			AUTO_UPDATE_STATUS.READY,
+		);
+
+		autoUpdater.installUpdate();
+
+		expect(fakeAutoUpdater.quitAndInstall).not.toHaveBeenCalled();
+	});
+
+	test("collapses repeat install clicks into a single quitAndInstall call", () => {
+		fakeAutoUpdater.emit("update-downloaded", { version: "9.9.9" });
+		expect(autoUpdater.getUpdateStatus().status).toBe(AUTO_UPDATE_STATUS.READY);
+
+		autoUpdater.installUpdate();
+		autoUpdater.installUpdate();
+		autoUpdater.installUpdate();
+
+		expect(fakeAutoUpdater.quitAndInstall).toHaveBeenCalledTimes(1);
+	});
+
+	test("clears the in-flight guard when Squirrel surfaces an error", () => {
+		fakeAutoUpdater.emit("update-downloaded", { version: "9.9.9" });
+		autoUpdater.installUpdate();
+		expect(fakeAutoUpdater.quitAndInstall).toHaveBeenCalledTimes(1);
+
+		fakeAutoUpdater.emit("error", new Error("squirrel failed"));
+		fakeAutoUpdater.emit("update-downloaded", { version: "9.9.9" });
+		autoUpdater.installUpdate();
+
+		expect(fakeAutoUpdater.quitAndInstall).toHaveBeenCalledTimes(2);
+	});
+});

--- a/apps/desktop/src/main/lib/auto-updater.test.ts
+++ b/apps/desktop/src/main/lib/auto-updater.test.ts
@@ -36,6 +36,12 @@ mock.module("main/index", () => ({
 	setSkipQuitConfirmation: mock(() => {}),
 }));
 
+// auto-updater short-circuits setupAutoUpdater on non-mac/linux hosts, so
+// pin the platform here to keep the tests portable across CI runners.
+mock.module("shared/constants", () => ({
+	PLATFORM: { IS_MAC: true, IS_WINDOWS: false, IS_LINUX: false },
+}));
+
 const autoUpdater = await import("./auto-updater");
 const { AUTO_UPDATE_STATUS } = await import("shared/auto-update");
 
@@ -46,9 +52,10 @@ describe("installUpdate", () => {
 		fakeAutoUpdater.checkForUpdates.mockClear();
 		fakeAutoUpdater.setFeedURL.mockClear();
 		autoUpdater.setupAutoUpdater();
-		// The module is a singleton; emit an error to reset isInstalling
-		// between tests (the error handler clears it).
-		fakeAutoUpdater.emit("error", new Error("reset"));
+		// The module is a singleton; emit a network-shaped error so the
+		// handler resets isInstalling and maps status back to IDLE without
+		// tripping the real ERROR path (which would also clear the cache).
+		fakeAutoUpdater.emit("error", new Error("ECONNRESET reset"));
 	});
 
 	test("ignores install requests when no update is ready", () => {

--- a/apps/desktop/src/main/lib/auto-updater.ts
+++ b/apps/desktop/src/main/lib/auto-updater.ts
@@ -82,6 +82,7 @@ function isNetworkError(error: Error | string): boolean {
 let currentStatus: AutoUpdateStatus = AUTO_UPDATE_STATUS.IDLE;
 let currentVersion: string | undefined;
 let isDismissed = false;
+let isInstalling = false;
 
 function emitStatus(
 	status: AutoUpdateStatus,
@@ -111,6 +112,24 @@ export function installUpdate(): void {
 		emitStatus(AUTO_UPDATE_STATUS.IDLE);
 		return;
 	}
+	// MacUpdater.quitAndInstall() registers a fresh native-updater
+	// `update-downloaded` listener each time it runs before Squirrel.Mac has
+	// finished staging. Without this guard, repeat clicks fan out into
+	// parallel quitAndInstall calls once Squirrel fires — racing to swap
+	// the binary and leaving the app on the old version.
+	if (isInstalling) {
+		console.info(
+			"[auto-updater] Install already in progress, ignoring duplicate request",
+		);
+		return;
+	}
+	if (currentStatus !== AUTO_UPDATE_STATUS.READY) {
+		console.warn(
+			`[auto-updater] Install ignored: update not ready (status=${currentStatus})`,
+		);
+		return;
+	}
+	isInstalling = true;
 	setSkipQuitConfirmation();
 	autoUpdater.quitAndInstall(false, true);
 }
@@ -242,6 +261,8 @@ export function setupAutoUpdater(): void {
 	);
 
 	autoUpdater.on("error", (error) => {
+		// Allow retry if Squirrel surfaces an error instead of actually quitting.
+		isInstalling = false;
 		if (isNetworkError(error)) {
 			console.info("[auto-updater] Network unavailable, will retry later");
 			emitStatus(AUTO_UPDATE_STATUS.IDLE);


### PR DESCRIPTION
## Summary
- Repeat clicks on the Update button on macOS closed the app but left it on the old version.
- Root cause: `MacUpdater.quitAndInstall()` registers a fresh `update-downloaded` listener on the native autoUpdater every call while Squirrel.Mac is still staging. Each extra click stacked another listener; when Squirrel finally fired, N parallel `nativeUpdater.quitAndInstall()` calls raced to swap the binary.
- Fix: add an `isInstalling` guard + `status === READY` precondition in `installUpdate`, and clear the guard in the `error` handler so retries are possible.

Verified against `electron-updater@6.8.3` source (`MacUpdater.js` lines 236–252) and cross-checked with [t3code's equivalent `updateInstallInFlight` pattern](https://github.com/pingdotgg/t3code/blob/main/apps/desktop/src/main.ts).

Supersedes draft PR #3508 (same root-cause analysis, tightened comments to project conventions).

Closes #3507

## Test plan
- [x] `bun test src/main/lib/auto-updater.test.ts` — 3 new tests pass (ignores when not READY, collapses repeats, resets guard on error)
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean on changed files
- [ ] Manual: install a prior build, publish a newer release, click Update repeatedly, confirm only one `quitAndInstall` fires and the app relaunches on the new version

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a macOS auto-update bug where repeat Update clicks quit the app but relaunch on the old version. We now gate install requests and ignore duplicates until the install completes.

- **Bug Fixes**
  - Gate `installUpdate()` with `isInstalling` and require `status === READY` to prevent parallel `quitAndInstall` calls from `electron-updater` on macOS.
  - Reset the in-flight flag on `error` so users can retry if the install fails.
  - Tests: add cases for not-ready ignores, repeat-click collapse, and guard reset on error; make the suite portable by mocking `shared/constants` to pin macOS and use a network-shaped error in reset to avoid clearing the cached update.

<sup>Written for commit f5893265bbf344d7aa4c12fca8c0e83369a45dc6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests that verify update installation flow, ensure only one install triggers after download, and validate retry behavior after errors.

* **Bug Fixes**
  * Prevented duplicate or concurrent update installation attempts.
  * Cleared the install guard on update errors so subsequent installs can proceed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->