### PR TITLE
fix(desktop): unblock v1 terminal user input during shell init (#3478)

### DIFF
--- a/apps/desktop/src/main/terminal-host/session-shell-ready.test.ts
+++ b/apps/desktop/src/main/terminal-host/session-shell-ready.test.ts
@@ -121,24 +121,22 @@ function spawnAndReady(
 // Tests
 // =============================================================================
 
-describe("Session shell-ready: write buffering", () => {
-	it("buffers writes while shell is pending and flushes after marker", () => {
+describe("Session shell-ready: write pass-through", () => {
+	it("passes writes through immediately while shell is pending (#3478)", () => {
 		const { session, proc } = createTestSession("/bin/zsh");
 		spawnAndReady(session, proc);
 
-		// Write before shell is ready — should be buffered
-		session.write("echo hello\n");
-		session.write("echo world\n");
+		// User keystrokes answering a shell-init prompt (e.g. fnm's
+		// "install missing Node version?") must reach the PTY without
+		// waiting for OSC 133;A.
+		session.write("y\n");
+		session.write("echo ready\n");
 
-		// No write frames should have been sent yet
-		expect(getWrittenData(proc)).toEqual([]);
+		expect(getWrittenData(proc)).toEqual(["y\n", "echo ready\n"]);
 
-		// Shell emits the ready marker
+		// The ready marker arriving later must not re-emit anything.
 		sendData(proc, `direnv output...${SHELL_READY_MARKER}prompt$ `);
-
-		// Now the buffered writes should be flushed in order
-		const writes = getWrittenData(proc);
-		expect(writes).toEqual(["echo hello\n", "echo world\n"]);
+		expect(getWrittenData(proc)).toEqual(["y\n", "echo ready\n"]);
 	});
 
 	it("passes writes through immediately for unsupported shells (sh)", () => {
@@ -168,32 +166,28 @@ describe("Session shell-ready: write buffering", () => {
 		session.write("\x1b[?62;4;9;22c");
 		// Simulate cursor position report
 		session.write("\x1b[1;1R");
-		// Queue a real preset command
+		// Regular command also arriving during pending
 		session.write("claude\n");
 
-		// Only the preset command should be in the queue
-		expect(getWrittenData(proc)).toEqual([]);
+		// Escape sequences are dropped; the command passes through.
+		expect(getWrittenData(proc)).toEqual(["claude\n"]);
 
 		sendData(proc, SHELL_READY_MARKER);
 
-		// Only the command should flush — escape sequences dropped
+		// Nothing new to emit after the marker.
 		expect(getWrittenData(proc)).toEqual(["claude\n"]);
 	});
 
-	it("flushes buffered writes on subprocess exit", async () => {
+	it("forwards escape sequences once shell is ready", () => {
 		const { session, proc } = createTestSession("/bin/zsh");
 		spawnAndReady(session, proc);
 
-		session.write("echo delayed\n");
-		expect(getWrittenData(proc)).toEqual([]);
+		sendData(proc, SHELL_READY_MARKER);
 
-		// Simulate exit which resolves shell readiness as timed_out
-		sendExit(proc, 0);
-		proc.emit("exit", 0);
-
-		// Buffered write should now be flushed
-		const writes = getWrittenData(proc);
-		expect(writes).toEqual(["echo delayed\n"]);
+		// After the marker, escape sequences are no longer stale init noise,
+		// so they pass through (e.g. user pressing arrow keys).
+		session.write("\x1b[A");
+		expect(getWrittenData(proc)).toEqual(["\x1b[A"]);
 	});
 });
 
@@ -222,14 +216,16 @@ describe("Session shell-ready: marker detection", () => {
 		// Send first half — shell should still be pending
 		sendData(proc, `output${firstHalf}`);
 
-		session.write("buffered\n");
-		expect(getWrittenData(proc)).toEqual([]);
+		// Writes pass through even while pending
+		session.write("first\n");
+		expect(getWrittenData(proc)).toEqual(["first\n"]);
 
 		// Send second half — should complete the marker
 		sendData(proc, `${secondHalf}prompt`);
 
-		// Now writes should flush
-		expect(getWrittenData(proc)).toEqual(["buffered\n"]);
+		// Post-marker writes still pass through
+		session.write("second\n");
+		expect(getWrittenData(proc)).toEqual(["first\n", "second\n"]);
 	});
 
 	it("handles marker at start of data frame", () => {
@@ -260,13 +256,13 @@ describe("Session shell-ready: marker detection", () => {
 		const partialMarker = SHELL_READY_MARKER.slice(0, 5);
 		sendData(proc, `${partialMarker}not-a-marker`);
 
-		// Shell should still be pending
-		session.write("buffered\n");
-		expect(getWrittenData(proc)).toEqual([]);
+		// Writes pass through regardless of marker state.
+		session.write("first\n");
+		expect(getWrittenData(proc)).toEqual(["first\n"]);
 
-		// Now send the real marker
+		// Now send the real marker — no backlog to flush.
 		sendData(proc, SHELL_READY_MARKER);
-		expect(getWrittenData(proc)).toEqual(["buffered\n"]);
+		expect(getWrittenData(proc)).toEqual(["first\n"]);
 	});
 
 	// Wrappers now emit both the legacy OSC 777 and the current OSC 133;A in
@@ -280,45 +276,46 @@ describe("Session shell-ready: marker detection", () => {
 		const { session, proc } = createTestSession("/bin/zsh");
 		spawnAndReady(session, proc);
 
-		session.write("buffered\n");
-		expect(getWrittenData(proc)).toEqual([]);
-
 		const COMBINED_MARKER = "\x1b]777;superset-shell-ready\x07\x1b]133;A\x07";
 		sendData(proc, `direnv output...${COMBINED_MARKER}prompt$ `);
 
-		expect(getWrittenData(proc)).toEqual(["buffered\n"]);
+		// Writes after the combined marker pass through (marker detection
+		// guards future behaviors that may depend on the ready state).
+		session.write("test\n");
+		expect(getWrittenData(proc)).toEqual(["test\n"]);
 	});
 });
 
 describe("Session shell-ready: kill/exit before readiness", () => {
-	it("flushes queue when subprocess exits before marker", () => {
+	it("accepts writes when subprocess exits before marker", () => {
 		const { session, proc } = createTestSession("/bin/bash");
 		spawnAndReady(session, proc);
 
+		// Writes pass through even during pending.
 		session.write("echo pending\n");
-		expect(getWrittenData(proc)).toEqual([]);
+		expect(getWrittenData(proc)).toEqual(["echo pending\n"]);
 
-		// Subprocess exits without ever sending the marker
+		// Subprocess exits without ever sending the marker — no replay,
+		// no duplicate writes.
 		sendExit(proc, 1);
 		proc.emit("exit", 1);
 
-		// Queue should be flushed on exit
 		expect(getWrittenData(proc)).toEqual(["echo pending\n"]);
 	});
 
-	it("resolves readiness when session is killed", () => {
+	it("accepts writes when session is killed before marker", () => {
 		const { session, proc } = createTestSession("/bin/zsh");
 		spawnAndReady(session, proc);
 
 		session.write("echo pending\n");
-		expect(getWrittenData(proc)).toEqual([]);
+		expect(getWrittenData(proc)).toEqual(["echo pending\n"]);
 
-		// Kill triggers termination → subprocess exit → readiness resolved
+		// Kill triggers termination → subprocess exit → readiness resolved.
+		// No buffered replay on exit.
 		session.kill();
 		sendExit(proc, 0);
 		proc.emit("exit", 0);
 
-		// Writes should be flushed
 		expect(getWrittenData(proc)).toEqual(["echo pending\n"]);
 	});
 });
@@ -330,12 +327,12 @@ describe("Session shell-ready: supported shells", () => {
 		"/bin/bash",
 		"/usr/local/bin/fish",
 	]) {
-		it(`buffers writes for supported shell: ${shell}`, () => {
+		it(`passes writes through while pending for supported shell: ${shell}`, () => {
 			const { session, proc } = createTestSession(shell);
 			spawnAndReady(session, proc);
 
 			session.write("test\n");
-			expect(getWrittenData(proc)).toEqual([]);
+			expect(getWrittenData(proc)).toEqual(["test\n"]);
 
 			sendData(proc, SHELL_READY_MARKER);
 			expect(getWrittenData(proc)).toEqual(["test\n"]);

--- a/apps/desktop/src/main/terminal-host/session.ts
+++ b/apps/desktop/src/main/terminal-host/session.ts
@@ -83,9 +83,9 @@ const SHELL_READY_TIMEOUT_MS = 15_000;
 
 /**
  * Shell readiness lifecycle:
- * - `pending`     — shell is initializing; user writes are buffered, escape sequences dropped
- * - `ready`       — marker detected; buffered writes have been flushed
- * - `timed_out`   — marker never arrived within timeout; writes unblocked
+ * - `pending`     — shell is initializing; escape sequences dropped, other writes pass through
+ * - `ready`       — marker detected; writes pass through
+ * - `timed_out`   — marker never arrived within timeout; writes pass through
  * - `unsupported` — shell has no marker (sh, ksh); writes pass through from the start
  */
 type ShellReadyState = "pending" | "ready" | "timed_out" | "unsupported";
@@ -159,11 +159,12 @@ export class Session {
 	private ptyReadyPromise: Promise<void>;
 	private ptyReadyResolve: (() => void) | null = null;
 
-	// Shell readiness — gates write() until the shell's first prompt.
+	// Shell readiness — tracks the shell's init lifecycle. User input and
+	// preset commands pass through regardless; only stale xterm terminal-query
+	// responses (DA/DSR) are filtered while `pending`.
 	// See ShellReadyState for lifecycle docs.
 	private shellReadyState: ShellReadyState;
 	private shellReadyTimeoutId: ReturnType<typeof setTimeout> | null = null;
-	private preReadyStdinQueue: string[] = [];
 	// OSC 133;A scanner state — shared with v2 host-service via @superset/shared
 	private scanState: ShellReadyScanState = createScanState();
 
@@ -844,21 +845,23 @@ export class Session {
 	/**
 	 * Write data to the PTY's stdin.
 	 *
-	 * While the shell is initializing (`pending` state), writes are triaged:
-	 * - **Escape sequences** (`\x1b`-prefixed) are dropped. These are stale
-	 *   responses from the renderer's xterm to terminal queries the shell
-	 *   sent during startup (DA, DSR). If queued and flushed later they
-	 *   appear as typed text like `?62;4;9;22c`.
-	 * - **Everything else** (preset commands, user input) is buffered and
-	 *   flushed in FIFO order once readiness resolves.
+	 * Escape-sequence responses (`\x1b`-prefixed) are dropped while the shell
+	 * is still initializing — these are stale DA/DSR replies from the
+	 * renderer's xterm to terminal queries the shell sent during startup. If
+	 * forwarded, they appear as typed text like `?62;4;9;22c` at the shell
+	 * prompt. The headless emulator answers those queries directly (see
+	 * constructor), so dropping the renderer's duplicate is safe.
+	 *
+	 * All other data — user keystrokes and preset commands alike — passes
+	 * through immediately. Buffering here previously froze workspaces when
+	 * shell init commands (e.g. fnm's `use-on-cd` hook) opened an interactive
+	 * prompt before the OSC 133;A marker fired. See #3478.
 	 */
 	write(data: string): void {
 		if (!this.subprocess || !this.subprocessReady) {
 			throw new Error("PTY not spawned");
 		}
-		if (this.shellReadyState === "pending") {
-			if (data.startsWith("\x1b")) return;
-			this.preReadyStdinQueue.push(data);
+		if (this.shellReadyState === "pending" && data.startsWith("\x1b")) {
 			return;
 		}
 		this.sendWriteToSubprocess(data);
@@ -992,7 +995,6 @@ export class Session {
 			clearTimeout(this.shellReadyTimeoutId);
 			this.shellReadyTimeoutId = null;
 		}
-		this.preReadyStdinQueue = [];
 		this.scanState = createScanState();
 		this.subprocessStdinQueue = [];
 		this.subprocessStdinQueuedBytes = 0;
@@ -1026,8 +1028,7 @@ export class Session {
 
 	/**
 	 * Transition out of `pending`. Flushes any partially-matched marker
-	 * bytes as terminal output (they weren't a real marker), then sends
-	 * all buffered stdin writes to the PTY in order. Idempotent.
+	 * bytes as terminal output (they weren't a real marker). Idempotent.
 	 */
 	private resolveShellReady(state: "ready" | "timed_out"): void {
 		if (this.shellReadyState !== "pending") return;
@@ -1046,12 +1047,6 @@ export class Session {
 			this.scanState.heldBytes = "";
 		}
 		this.scanState.matchPos = 0;
-		// Flush queued writes in FIFO order
-		const queue = this.preReadyStdinQueue;
-		this.preReadyStdinQueue = [];
-		for (const data of queue) {
-			this.sendWriteToSubprocess(data);
-		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Fixes #3478 — workspace froze when a `.nvmrc`-pinned Node version was missing and the shell-init `fnm use-on-cd` hook asked `"Do you want to install it? answer [y/N]:"`.
- Root cause: `Session.write()` in the v1 terminal host queued *all* stdin writes (user keystrokes included) until OSC 133;A. The prompt blocks init, so the marker never fires and typed `y/N` sits buffered for the 15s timeout.
- Fix: pass writes straight through to the PTY, keep only the escape-sequence drop for stale DA/DSR replies from the renderer's xterm. This matches v2 (`packages/host-service/src/terminal/terminal.ts`), which has always written user input directly.

## Test plan
- [x] `bun test apps/desktop/src/main/terminal-host/` — 37 pass, including a new `#3478` regression test asserting writes reach the PTY while `shellReadyState === "pending"`.
- [x] `bun run typecheck` clean.
- [x] `bun run lint` clean.
- [ ] Manual: open a repo pinned to an uninstalled Node version, verify the fnm prompt accepts `y/N` immediately instead of freezing for 15s.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3478 by letting the v1 desktop terminal send user input to the PTY during shell init, so prompts like fnm’s “install missing Node version?” accept answers immediately. We now drop only stale escape-sequence replies and otherwise pass input through, matching v2 behavior.

- **Bug Fixes**
  - Pass stdin through while `shellReadyState === 'pending'`; removed the pre-ready stdin queue and replay on marker/exit/timeout.
  - Drop only `\x1b`-prefixed DA/DSR responses from the renderer during pending; after ready, forward all input (e.g., arrow keys).
  - Added a regression test for #3478 and updated tests across shells and marker edge cases.

<sup>Written for commit 05e2d7b96ec88fe3570d17a1c9a57252acf739f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal input responsiveness by changing how write commands are handled during shell initialization; commands now pass through immediately instead of being delayed until the shell is ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->