### PR TITLE
fix(desktop): trigger macOS Local Network permission on startup

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -32,6 +32,7 @@ import { setWorkspaceDockIcon } from "./lib/dock-icon";
 import { loadWebviewBrowserExtension } from "./lib/extensions";
 import { getHostServiceCoordinator } from "./lib/host-service-coordinator";
 import { localDb } from "./lib/local-db";
+import { requestLocalNetworkAccess } from "./lib/local-network-permission";
 import { ensureProjectIconsDir, getProjectIconPath } from "./lib/project-icons";
 import { initSentry } from "./lib/sentry";
 import {
@@ -293,6 +294,7 @@ if (!gotTheLock) {
 		await app.whenReady();
 		registerWithMacOSNotificationCenter();
 		requestAppleEventsAccess();
+		requestLocalNetworkAccess();
 
 		// Must register on both default session and the app's custom partition
 		const iconProtocolHandler = (request: Request) => {


### PR DESCRIPTION
## Summary
- `requestLocalNetworkAccess` existed in `apps/desktop/src/main/lib/local-network-permission.ts` but was never called, so the `NSLocalNetworkUsageDescription` / `NSBonjourServices` keys wired up in `electron-builder.ts` never had a trigger.
- On macOS 15+, this silently blocks outbound connections to local-network IPs from the app and its spawned children (node, python, etc. in the workspace terminal). System binaries like `curl` escape the same TCC attribution path, which matches the reporter's symptom.
- Call the helper alongside `requestAppleEventsAccess` in the `app.whenReady` block.

Fixes #3474.

## Test plan
Dev can exercise the code path but not the production grant (bundle id, signing identity, and Info.plist keys all differ). For end-to-end verification:

- [ ] Packaged canary build on a fresh macOS 15+ profile — confirm the Local Network prompt appears on first launch.
- [ ] Approve, then in a workspace terminal run a node script that HTTP-GETs a machine on the LAN (e.g. `node -e 'require(\"http\").get(\"http://<local-ip>\", r=>console.log(r.statusCode))'`) — expect success.
- [ ] Confirm Superset now appears in System Settings → Privacy & Security → Local Network.
- [ ] Existing users who previously denied the prompt (silently or otherwise) will need to toggle it on manually; call out in release notes if relevant.

If granting permission doesn't resolve the repro, the next investigation areas are PTY subprocess TCC attribution and the `agent-setup/shell-wrappers` path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trigger the macOS Local Network permission on app startup to stop silent blocking of LAN connections on macOS 15+ for the app and its terminal child processes. Adds a call to `requestLocalNetworkAccess()` alongside `requestAppleEventsAccess()` in `app.whenReady` (fixes #3474).

<sup>Written for commit 9c2f4f092a9cc9607bb6bf74a6d964ffcc8398e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app now requests local network access permissions during startup to enable connectivity with local network resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->