### PR TITLE
fix(desktop): refresh v2 terminal link tooltip editor + nudge plain clicks

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -26,6 +26,7 @@ import { TerminalSearch } from "renderer/screens/main/components/WorkspaceView/C
 import { useTheme } from "renderer/stores/theme";
 import { resolveTerminalThemeType } from "renderer/stores/theme/utils";
 import { LinkHoverTooltip } from "./components/LinkHoverTooltip";
+import { useLinkClickHint } from "./hooks/useLinkClickHint";
 import { useLinkHoverState } from "./hooks/useLinkHoverState";
 import { useTerminalAppearance } from "./hooks/useTerminalAppearance";
 import { shellEscapePaths } from "./utils";
@@ -58,6 +59,7 @@ export function TerminalPane({
 		onHover: onLinkHover,
 		onLeave: onLinkLeave,
 	} = useLinkHoverState();
+	const { hint, showHint } = useLinkClickHint();
 	const paneData = ctx.pane.data as TerminalPaneData;
 	const { terminalId } = paneData;
 	const containerRef = useRef<HTMLDivElement | null>(null);
@@ -159,7 +161,10 @@ export function TerminalPane({
 				}
 			},
 			onFileLinkClick: (event, link) => {
-				if (!event.metaKey && !event.ctrlKey) return;
+				if (!event.metaKey && !event.ctrlKey) {
+					showHint(event.clientX, event.clientY);
+					return;
+				}
 				event.preventDefault();
 				if (event.shiftKey) {
 					openInExternalEditor(link.resolvedPath, {
@@ -200,6 +205,7 @@ export function TerminalPane({
 		openInExternalEditor,
 		onLinkHover,
 		onLinkLeave,
+		showHint,
 	]);
 
 	useHotkey(
@@ -312,7 +318,7 @@ export function TerminalPane({
 					<span>Disconnected</span>
 				</div>
 			)}
-			<LinkHoverTooltip hoveredLink={hoveredLink} />
+			<LinkHoverTooltip hoveredLink={hoveredLink} hint={hint} />
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/LinkHoverTooltip/LinkHoverTooltip.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/LinkHoverTooltip/LinkHoverTooltip.tsx
@@ -1,10 +1,6 @@
-import type { ExternalApp } from "@superset/local-db";
 import { AnimatePresence, motion } from "framer-motion";
-import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
-import { getAppOption } from "renderer/components/OpenInExternalDropdown/constants";
 import type { LinkHoverInfo } from "renderer/lib/terminal/terminal-runtime-registry";
-import { electronTrpcClient } from "renderer/lib/trpc-client";
 import type { LinkClickHint } from "../../hooks/useLinkClickHint";
 import type { HoveredLink } from "../../hooks/useLinkHoverState";
 
@@ -24,52 +20,15 @@ interface LinkHoverTooltipProps {
 	hint: LinkClickHint | null;
 }
 
-function getAppLabel(app: ExternalApp): string {
-	const option = getAppOption(app);
-	return option?.displayLabel ?? option?.label ?? "external editor";
-}
-
-function getLabel(
-	info: LinkHoverInfo,
-	shift: boolean,
-	defaultEditor: ExternalApp | null,
-): string {
+function getLabel(info: LinkHoverInfo, shift: boolean): string {
 	if (info.kind === "url") {
 		return shift ? "Open in external browser" : "Open in browser";
 	}
-	if (shift) {
-		return defaultEditor
-			? `Open in ${getAppLabel(defaultEditor)}`
-			: "Open externally";
-	}
-	return info.isDirectory ? "Reveal in sidebar" : "Open in editor";
+	if (shift) return "Open in external editor";
+	return info.isDirectory ? "Reveal in sidebar" : "Open in pane";
 }
 
 export function LinkHoverTooltip({ hoveredLink, hint }: LinkHoverTooltipProps) {
-	const [defaultEditor, setDefaultEditor] = useState<ExternalApp | null>(null);
-	const hovering = hoveredLink !== null;
-
-	useEffect(() => {
-		if (!hovering) return;
-		let cancelled = false;
-		electronTrpcClient.settings.getDefaultEditor
-			.query()
-			.then((editor) => {
-				if (!cancelled) setDefaultEditor(editor);
-			})
-			.catch((error) => {
-				if (cancelled) return;
-				console.warn(
-					"[LinkHoverTooltip] Failed to fetch default editor:",
-					error,
-				);
-				setDefaultEditor(null);
-			});
-		return () => {
-			cancelled = true;
-		};
-	}, [hovering]);
-
 	const showingHover = Boolean(hoveredLink?.modifier);
 
 	return createPortal(
@@ -82,7 +41,7 @@ export function LinkHoverTooltip({ hoveredLink, hint }: LinkHoverTooltipProps) {
 						top: hoveredLink.clientY + TOOLTIP_OFFSET_PX,
 					}}
 				>
-					{getLabel(hoveredLink.info, hoveredLink.shift, defaultEditor)}
+					{getLabel(hoveredLink.info, hoveredLink.shift)}
 				</div>
 			)}
 			<AnimatePresence>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/LinkHoverTooltip/LinkHoverTooltip.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/LinkHoverTooltip/LinkHoverTooltip.tsx
@@ -1,15 +1,27 @@
 import type { ExternalApp } from "@superset/local-db";
+import { AnimatePresence, motion } from "framer-motion";
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { getAppOption } from "renderer/components/OpenInExternalDropdown/constants";
 import type { LinkHoverInfo } from "renderer/lib/terminal/terminal-runtime-registry";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
+import type { LinkClickHint } from "../../hooks/useLinkClickHint";
 import type { HoveredLink } from "../../hooks/useLinkHoverState";
 
 const TOOLTIP_OFFSET_PX = 14;
+const TOOLTIP_CLASSES =
+	"pointer-events-none fixed z-50 w-fit rounded-md bg-foreground px-3 py-1.5 text-xs text-background";
+
+const isMac =
+	typeof navigator !== "undefined" &&
+	navigator.platform.toLowerCase().includes("mac");
+const MOD_LABEL = isMac ? "⌘" : "Ctrl";
+const MOD_SHIFT_LABEL = isMac ? "⌘⇧" : "Ctrl+Shift";
+const HINT_LABEL = `Hold ${MOD_LABEL} to open · ${MOD_SHIFT_LABEL} for external`;
 
 interface LinkHoverTooltipProps {
 	hoveredLink: HoveredLink | null;
+	hint: LinkClickHint | null;
 }
 
 function getAppLabel(app: ExternalApp): string {
@@ -33,10 +45,12 @@ function getLabel(
 	return info.isDirectory ? "Reveal in sidebar" : "Open in editor";
 }
 
-export function LinkHoverTooltip({ hoveredLink }: LinkHoverTooltipProps) {
+export function LinkHoverTooltip({ hoveredLink, hint }: LinkHoverTooltipProps) {
 	const [defaultEditor, setDefaultEditor] = useState<ExternalApp | null>(null);
+	const hovering = hoveredLink !== null;
 
 	useEffect(() => {
+		if (!hovering) return;
 		let cancelled = false;
 		electronTrpcClient.settings.getDefaultEditor
 			.query()
@@ -54,22 +68,42 @@ export function LinkHoverTooltip({ hoveredLink }: LinkHoverTooltipProps) {
 		return () => {
 			cancelled = true;
 		};
-	}, []);
+	}, [hovering]);
 
-	if (!hoveredLink || !hoveredLink.modifier) return null;
-
-	const label = getLabel(hoveredLink.info, hoveredLink.shift, defaultEditor);
+	const showingHover = Boolean(hoveredLink?.modifier);
 
 	return createPortal(
-		<div
-			className="pointer-events-none fixed z-50 w-fit rounded-md bg-foreground px-3 py-1.5 text-xs text-background"
-			style={{
-				left: hoveredLink.clientX + TOOLTIP_OFFSET_PX,
-				top: hoveredLink.clientY + TOOLTIP_OFFSET_PX,
-			}}
-		>
-			{label}
-		</div>,
+		<>
+			{hoveredLink?.modifier && (
+				<div
+					className={TOOLTIP_CLASSES}
+					style={{
+						left: hoveredLink.clientX + TOOLTIP_OFFSET_PX,
+						top: hoveredLink.clientY + TOOLTIP_OFFSET_PX,
+					}}
+				>
+					{getLabel(hoveredLink.info, hoveredLink.shift, defaultEditor)}
+				</div>
+			)}
+			<AnimatePresence>
+				{hint && !showingHover && (
+					<motion.div
+						key="hint"
+						initial={{ opacity: 0 }}
+						animate={{ opacity: 1 }}
+						exit={{ opacity: 0 }}
+						transition={{ duration: 0.15 }}
+						className={TOOLTIP_CLASSES}
+						style={{
+							left: hint.clientX + TOOLTIP_OFFSET_PX,
+							top: hint.clientY + TOOLTIP_OFFSET_PX,
+						}}
+					>
+						{HINT_LABEL}
+					</motion.div>
+				)}
+			</AnimatePresence>
+		</>,
 		document.body,
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/LinkHoverTooltip/LinkHoverTooltip.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/LinkHoverTooltip/LinkHoverTooltip.tsx
@@ -22,7 +22,7 @@ interface LinkHoverTooltipProps {
 
 function getLabel(info: LinkHoverInfo, shift: boolean): string {
 	if (info.kind === "url") {
-		return shift ? "Open in external browser" : "Open in browser";
+		return shift ? "Open in external browser" : "Open in pane";
 	}
 	if (shift) return "Open in external editor";
 	return info.isDirectory ? "Reveal in sidebar" : "Open in pane";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/hooks/useLinkClickHint/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/hooks/useLinkClickHint/index.ts
@@ -1,0 +1,1 @@
+export { type LinkClickHint, useLinkClickHint } from "./useLinkClickHint";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/hooks/useLinkClickHint/useLinkClickHint.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/hooks/useLinkClickHint/useLinkClickHint.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface LinkClickHint {
+	clientX: number;
+	clientY: number;
+}
+
+const HINT_DURATION_MS = 2000;
+const MAX_HINTS_PER_SESSION = 2;
+
+let hintsRemaining = MAX_HINTS_PER_SESSION;
+
+export function useLinkClickHint() {
+	const [hint, setHint] = useState<LinkClickHint | null>(null);
+	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	const showHint = useCallback((clientX: number, clientY: number) => {
+		if (hintsRemaining <= 0) return;
+		hintsRemaining -= 1;
+		if (timeoutRef.current) clearTimeout(timeoutRef.current);
+		setHint({ clientX, clientY });
+		timeoutRef.current = setTimeout(() => {
+			setHint(null);
+			timeoutRef.current = null;
+		}, HINT_DURATION_MS);
+	}, []);
+
+	useEffect(() => {
+		return () => {
+			if (timeoutRef.current) clearTimeout(timeoutRef.current);
+		};
+	}, []);
+
+	return { hint, showHint };
+}


### PR DESCRIPTION
## Summary

- **Stale editor label**: `LinkHoverTooltip` fetched the default editor in a mount-only `useEffect`, so the modifier-shift label (`Open in Cursor`, etc.) stayed frozen at whatever the setting was when the terminal pane first mounted. Now refetches on every hover-start — the tooltip uses the imperative `electronTrpcClient` (v2 workspaces hijack the `electronTrpc` React-hooks context), so there's no react-query cache to invalidate; fresh fetch-on-hover is the right primitive.
- **Discoverability nudge**: plain (no-modifier) clicks on a detected file path in the v2 terminal did nothing, which made the ⌘-click affordance effectively undiscoverable. On a plain file-link click we now flash `Hold ⌘ to open · ⌘⇧ for external` (or `Ctrl` / `Ctrl+Shift` off-mac) at the click position.
- Module-level counter caps the nudge at **two shows per renderer session** so it teaches once or twice and then gets out of the way. Suppressed while the modifier-hover tooltip is already on screen (if you held the modifier, you've graduated). Uses framer-motion's `AnimatePresence` for fade in/out.
- URL links are unchanged — plain-click already opens URLs in the in-app browser, so there's no failed attempt to nudge.

## Test plan
- [ ] In a v2 workspace terminal, hover a file path with ⌘ held and confirm the tooltip shows `Open in editor` / `Reveal in sidebar` / `Open in <editor name>`.
- [ ] Change the default editor in Settings (e.g., Cursor → VS Code) **without closing the terminal pane**, hover a file with ⌘⇧ held, and confirm the label reflects the new editor.
- [ ] Plain-click a file path in the v2 terminal; confirm the hint fades in, lingers ~2s, fades out.
- [ ] Plain-click a third file path in the same session; confirm no hint (cap honored).
- [ ] Plain-click a file path, then hold ⌘ and hover the same link; confirm the hover tooltip supersedes the hint.
- [ ] Plain-click a URL in the v2 terminal; confirm it still opens in the in-app browser and no hint appears.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes v2 terminal link tooltip labels and adds a small nudge for plain file‑link clicks. ⌘/Ctrl hover now shows clear, generic text (e.g., “Open in pane” for files and URLs, “Open in external editor” with Shift), and plain clicks briefly teach the modifier shortcuts.

- **Bug Fixes**
  - Replaced editor-specific labels and fetches with stable text: file=“Open in pane”, Shift=“Open in external editor”, URL ⌘=“Open in pane”, URL ⌘⇧=“Open in external browser”.

- **New Features**
  - Plain-clicking a file path shows “Hold ⌘ to open · ⌘⇧ for external” (Ctrl/Ctrl+Shift on non‑Mac) at the click position; fades via `framer-motion`, capped at two per session, suppressed when the modifier-hover tooltip is visible; URL behavior unchanged.

<sup>Written for commit 1196764ef919f5fcdf4cf0df9d39f69c7cdbe545. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Animated "hold modifier" hint appears at the click location when file links are clicked without modifier keys, showing platform-specific modifier key text.
  * Hover tooltips now compute labels synchronously and render smoother animations; tooltips can show either hover info or the hold-hint.

* **Bug Fixes / UX**
  * Clicking file links reliably triggers the hint (and exits) instead of doing nothing.
  * Hints auto-clear after a short duration and are rate-limited to avoid repetition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->