### PR TITLE
feat(desktop): restore Tasks link in v2 dashboard sidebar

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -1,9 +1,12 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { useMatchRoute, useNavigate } from "@tanstack/react-router";
+import { HiOutlineClipboardDocumentList } from "react-icons/hi2";
 import { LuFolderPlus, LuLayers, LuPlus } from "react-icons/lu";
+import { GATED_FEATURES, usePaywall } from "renderer/components/Paywall";
 import { useHotkeyDisplay } from "renderer/hotkeys";
 import { OrganizationDropdown } from "renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown";
+import { useTasksFilterStore } from "renderer/routes/_authenticated/_dashboard/tasks/stores/tasks-filter-state";
 import { STROKE_WIDTH_THICK } from "renderer/screens/main/components/WorkspaceSidebar/constants";
 import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
 
@@ -18,10 +21,28 @@ export function DashboardSidebarHeader({
 	const shortcutText = useHotkeyDisplay("NEW_WORKSPACE").text;
 	const navigate = useNavigate();
 	const matchRoute = useMatchRoute();
+	const { gateFeature } = usePaywall();
 	const isWorkspacesListOpen = !!matchRoute({ to: "/v2-workspaces" });
+	const isTasksOpen = !!matchRoute({ to: "/tasks", fuzzy: true });
+
+	const {
+		tab: lastTab,
+		assignee: lastAssignee,
+		search: lastSearch,
+	} = useTasksFilterStore();
 
 	const handleWorkspacesClick = () => {
 		navigate({ to: "/v2-workspaces" });
+	};
+
+	const handleTasksClick = () => {
+		gateFeature(GATED_FEATURES.TASKS, () => {
+			const search: Record<string, string> = {};
+			if (lastTab !== "all") search.tab = lastTab;
+			if (lastAssignee) search.assignee = lastAssignee;
+			if (lastSearch) search.search = lastSearch;
+			navigate({ to: "/tasks", search });
+		});
 	};
 
 	if (isCollapsed) {
@@ -45,6 +66,24 @@ export function DashboardSidebarHeader({
 						</button>
 					</TooltipTrigger>
 					<TooltipContent side="right">Workspaces</TooltipContent>
+				</Tooltip>
+
+				<Tooltip delayDuration={300}>
+					<TooltipTrigger asChild>
+						<button
+							type="button"
+							onClick={handleTasksClick}
+							className={cn(
+								"flex size-8 items-center justify-center rounded-md transition-colors",
+								isTasksOpen
+									? "bg-accent text-foreground"
+									: "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+							)}
+						>
+							<HiOutlineClipboardDocumentList className="size-4" />
+						</button>
+					</TooltipTrigger>
+					<TooltipContent side="right">Tasks</TooltipContent>
 				</Tooltip>
 
 				<Tooltip delayDuration={300}>
@@ -108,6 +147,20 @@ export function DashboardSidebarHeader({
 			>
 				<LuLayers className="size-4 shrink-0" />
 				<span className="flex-1 text-left">Workspaces</span>
+			</button>
+
+			<button
+				type="button"
+				onClick={handleTasksClick}
+				className={cn(
+					"flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium transition-colors",
+					isTasksOpen
+						? "bg-accent text-foreground"
+						: "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+				)}
+			>
+				<HiOutlineClipboardDocumentList className="size-4 shrink-0" />
+				<span className="flex-1 text-left">Tasks</span>
 			</button>
 
 			<button


### PR DESCRIPTION
## Summary
- Adds a Tasks nav entry to the v2 `DashboardSidebarHeader`, rendered alongside Workspaces in both collapsed and expanded layouts.
- Ports the v1 behavior: paywall gate via `GATED_FEATURES.TASKS`, last-used tab/assignee/search restoration from `useTasksFilterStore`, and active-route highlight using `matchRoute({ to: "/tasks", fuzzy: true })`.

## Test plan
- [ ] Open v2 dashboard in desktop, verify Tasks entry renders in both expanded and collapsed sidebars.
- [ ] Click Tasks — routes to `/tasks` with last-used filter query params.
- [ ] Active-route styling applies when on `/tasks` (including `/tasks/$taskId`).
- [ ] Paywall triggers for orgs without the Tasks feature flag.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the Tasks link in the v2 desktop dashboard sidebar to match v1 and improve navigation parity.

- **New Features**
  - Adds a Tasks nav item next to Workspaces in both collapsed and expanded sidebars.
  - Routes to /tasks with the last-used tab, assignee, and search; highlights as active on /tasks and its subroutes.
  - Gates access with the Tasks paywall for orgs without the feature.

<sup>Written for commit 8211f6bf1542e498ca9f0928595e65df2f01f824. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Tasks navigation to the dashboard sidebar with support for both collapsed and expanded modes
  * Task filter preferences (tab, assignee, search) are now preserved when navigating to the Tasks section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->