### PR TITLE
feat(desktop): ⌘⇧L opens diff viewer in v2 workspace

### DIFF
--- a/apps/desktop/src/renderer/hotkeys/registry.ts
+++ b/apps/desktop/src/renderer/hotkeys/registry.ts
@@ -186,14 +186,16 @@ export const HOTKEYS_REGISTRY = {
 		label: "Toggle Changes Tab",
 		category: "Layout",
 	},
-	TOGGLE_EXPAND_SIDEBAR: {
+	OPEN_DIFF_VIEWER: {
 		key: {
 			mac: "meta+shift+l",
 			windows: "ctrl+shift+alt+l",
 			linux: "ctrl+shift+alt+l",
 		},
-		label: "Toggle Expand Sidebar",
+		label: "Open Diff Viewer",
 		category: "Layout",
+		description:
+			"Open the diff viewer in a new tab, or focus the existing diff viewer",
 	},
 	TOGGLE_WORKSPACE_SIDEBAR: {
 		key: { mac: "meta+b", windows: "ctrl+shift+b", linux: "ctrl+shift+b" },

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
@@ -12,6 +12,7 @@ import type { StoreApi } from "zustand";
 import type {
 	BrowserPaneData,
 	ChatPaneData,
+	DiffPaneData,
 	PaneViewerData,
 	TerminalPaneData,
 } from "../../types";
@@ -65,6 +66,33 @@ export function useWorkspaceHotkeys({
 					data: {
 						url: "about:blank",
 					} as BrowserPaneData,
+				},
+			],
+		});
+	});
+
+	useHotkey("OPEN_DIFF_VIEWER", () => {
+		if (collections.v2WorkspaceLocalState.get(workspaceId)) {
+			collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
+				draft.rightSidebarOpen = true;
+				draft.sidebarState.activeTab = "changes";
+			});
+		}
+
+		const state = store.getState();
+		for (const tab of state.tabs) {
+			for (const pane of Object.values(tab.panes)) {
+				if (pane.kind !== "diff") continue;
+				state.setActiveTab(tab.id);
+				state.setActivePane({ tabId: tab.id, paneId: pane.id });
+				return;
+			}
+		}
+		state.addTab({
+			panes: [
+				{
+					kind: "diff",
+					data: { path: "", collapsedFiles: [] } as DiffPaneData,
 				},
 			],
 		});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/workspace/$workspaceId/page.tsx
@@ -330,8 +330,8 @@ function WorkspacePage() {
 	// Toggle changes sidebar (⌘L)
 	useHotkey("TOGGLE_SIDEBAR", () => toggleSidebar());
 
-	// Toggle expand/collapse sidebar (⌘⇧L)
-	useHotkey("TOGGLE_EXPAND_SIDEBAR", () => {
+	// Open diff viewer (⌘⇧L)
+	useHotkey("OPEN_DIFF_VIEWER", () => {
 		if (!isSidebarOpen) {
 			setSidebarOpen(true);
 			setSidebarMode(SidebarMode.Changes);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/index.tsx
@@ -198,7 +198,7 @@ export function RightSidebar() {
 						<TooltipContent side="bottom" showArrow={false}>
 							<HotkeyLabel
 								label={isExpanded ? "Collapse sidebar" : "Expand sidebar"}
-								id="TOGGLE_EXPAND_SIDEBAR"
+								id="OPEN_DIFF_VIEWER"
 							/>
 						</TooltipContent>
 					</Tooltip>


### PR DESCRIPTION
## Summary
- Rename `TOGGLE_EXPAND_SIDEBAR` → `OPEN_DIFF_VIEWER` (same ⌘⇧L / Ctrl+Shift+Alt+L binding) — the v1 action was effectively "open the diff viewer," so unifying the ID.
- In v2, the hotkey focuses any existing diff pane (and its tab), or opens a new tab with a diff pane. It also flips the workspace sidebar to the Changes tab.
- V1 keeps its existing expand-sidebar-to-Changes behavior under the new ID.

## Test plan
- [ ] V2 workspace: ⌘⇧L with no diff pane open → new tab with diff viewer, sidebar opens on Changes tab
- [ ] V2 workspace: ⌘⇧L with diff pane in another tab → focuses that tab + pane
- [ ] V2 workspace: ⌘⇧L with diff pane in current tab → focuses the pane
- [ ] V1 workspace: ⌘⇧L still toggles Changes / Tabs sidebar modes as before
- [ ] RightSidebar expand/collapse tooltip still shows correct hotkey

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
⌘⇧L (Ctrl+Shift+Alt+L) now opens or focuses the diff viewer in the v2 workspace. v1 behavior is unchanged.

- **New Features**
  - In v2, focus an existing diff pane (and its tab) if present; otherwise open a new tab with a diff pane.

- **Refactors**
  - Renamed hotkey ID `TOGGLE_EXPAND_SIDEBAR` to `OPEN_DIFF_VIEWER` and updated labels, registry, and tooltip.

<sup>Written for commit 6fea6da7e4dab593c254d8daeb112fb9922fe937. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new "Open Diff Viewer" hotkey (⌘⇧L) that opens the diff viewer in a new tab or focuses an existing one
  * The diff viewer displays changes with an organized sidebar interface for easy navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->