### PR TITLE
feat(desktop): add zen mode for distraction-free view

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/window.ts
+++ b/apps/desktop/src/lib/trpc/routers/window.ts
@@ -39,6 +39,15 @@ export const createWindowRouter = (getWindow: () => BrowserWindow | null) => {
 			return window.isMaximized();
 		}),
 
+		setFullScreen: publicProcedure
+			.input(z.object({ fullScreen: z.boolean() }))
+			.mutation(({ input }) => {
+				const window = getWindow();
+				if (!window) return { success: false };
+				window.setFullScreen(input.fullScreen);
+				return { success: true };
+			}),
+
 		getPlatform: publicProcedure.query(() => {
 			return process.platform;
 		}),

--- a/apps/desktop/src/renderer/hotkeys/registry.ts
+++ b/apps/desktop/src/renderer/hotkeys/registry.ts
@@ -202,6 +202,16 @@ export const HOTKEYS_REGISTRY = {
 		label: "Toggle Workspaces Sidebar",
 		category: "Layout",
 	},
+	TOGGLE_ZEN_MODE: {
+		key: {
+			mac: "meta+period",
+			windows: "ctrl+shift+period",
+			linux: "ctrl+shift+period",
+		},
+		label: "Toggle Zen Mode",
+		category: "Layout",
+		description: "Hide all chrome for a distraction-free view",
+	},
 	SPLIT_RIGHT: {
 		key: { mac: "meta+d", windows: "ctrl+shift+d", linux: "ctrl+shift+d" },
 		label: "Split Right",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -1,10 +1,12 @@
+import { toast } from "@superset/ui/sonner";
 import {
 	createFileRoute,
 	Outlet,
 	useMatchRoute,
 	useNavigate,
 } from "@tanstack/react-router";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { useHotkey } from "renderer/hotkeys";
 import { electronTrpc } from "renderer/lib/electron-trpc";
@@ -19,6 +21,7 @@ import {
 	MAX_WORKSPACE_SIDEBAR_WIDTH,
 	useWorkspaceSidebarStore,
 } from "renderer/stores/workspace-sidebar-state";
+import { useZenModeStore } from "renderer/stores/zen-mode";
 import { AddRepositoryModals } from "./components/AddRepositoryModals";
 import { TopBar } from "./components/TopBar";
 
@@ -55,16 +58,68 @@ function DashboardLayout() {
 		isCollapsed: isWorkspaceSidebarCollapsed,
 	} = useWorkspaceSidebarStore();
 
+	const isZenMode = useZenModeStore((s) => s.isZenMode);
+	const toggleZenMode = useZenModeStore((s) => s.toggleZenMode);
+	const setZenMode = useZenModeStore((s) => s.setZenMode);
+	const hasShownZenHint = useZenModeStore((s) => s.hasShownHint);
+	const markZenHintShown = useZenModeStore((s) => s.markHintShown);
+	useHotkey("TOGGLE_ZEN_MODE", () => toggleZenMode());
+	const setFullScreen = electronTrpc.window.setFullScreen.useMutation();
+
+	const didMountRef = useRef(false);
+	const skipNextSyncRef = useRef(false);
+	// biome-ignore lint/correctness/useExhaustiveDependencies: setFullScreen mutation is stable
+	useEffect(() => {
+		if (!didMountRef.current) {
+			didMountRef.current = true;
+			return;
+		}
+		if (skipNextSyncRef.current) {
+			skipNextSyncRef.current = false;
+			return;
+		}
+		const revert = () => {
+			skipNextSyncRef.current = true;
+			setZenMode(!isZenMode);
+		};
+		setFullScreen.mutate(
+			{ fullScreen: isZenMode },
+			{
+				onSuccess: (result) => {
+					if (!result.success) revert();
+				},
+				onError: revert,
+			},
+		);
+	}, [isZenMode]);
+
+	useEffect(() => {
+		if (isZenMode && !hasShownZenHint) {
+			toast("Zen Mode — Esc to exit", { duration: 2000 });
+			markZenHintShown();
+		}
+	}, [isZenMode, hasShownZenHint, markZenHintShown]);
+
+	useHotkeys("esc", () => setZenMode(false), {
+		enabled: isZenMode,
+		enableOnFormTags: false,
+		enableOnContentEditable: false,
+	});
+
 	// Global hotkeys for dashboard
 	useHotkey("OPEN_SETTINGS", () => navigate({ to: "/settings/account" }));
 	useHotkey("SHOW_HOTKEYS", () => navigate({ to: "/settings/keyboard" }));
-	useHotkey("TOGGLE_WORKSPACE_SIDEBAR", () => {
-		if (!isWorkspaceSidebarOpen) {
-			setWorkspaceSidebarOpen(true);
-		} else {
-			toggleWorkspaceSidebarCollapsed();
-		}
-	});
+	useHotkey(
+		"TOGGLE_WORKSPACE_SIDEBAR",
+		() => {
+			if (!isWorkspaceSidebarOpen) {
+				setWorkspaceSidebarOpen(true);
+			} else {
+				toggleWorkspaceSidebarCollapsed();
+			}
+		},
+		{ enabled: !isZenMode },
+	);
 	useHotkey("NEW_WORKSPACE", () =>
 		openNewWorkspaceModal(currentWorkspace?.projectId),
 	);
@@ -90,10 +145,12 @@ function DashboardLayout() {
 	);
 
 	return (
-		<div className="flex flex-col h-full w-full">
-			<TopBar />
+		<div
+			className={`flex flex-col h-full w-full${isZenMode ? " zen-mode" : ""}`}
+		>
+			{!isZenMode && <TopBar />}
 			<div className="flex flex-1 min-h-0 min-w-0 overflow-hidden">
-				{isWorkspaceSidebarOpen && (
+				{!isZenMode && isWorkspaceSidebarOpen && (
 					<ResizablePanel
 						width={workspaceSidebarWidth}
 						onWidthChange={setWorkspaceSidebarWidth}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/mosaic-theme.css
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/mosaic-theme.css
@@ -88,6 +88,13 @@
 	overflow: hidden;
 }
 
+.zen-mode .mosaic-window .mosaic-window-toolbar {
+	display: none;
+}
+.zen-mode .mosaic-window .mosaic-window-body {
+	top: 0;
+}
+
 .mosaic-window-content {
 	outline: none;
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/index.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/index.tsx
@@ -1,6 +1,7 @@
 import type { ExternalApp } from "@superset/local-db";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useSidebarStore } from "renderer/stores/sidebar-state";
+import { useZenModeStore } from "renderer/stores/zen-mode";
 import { SidebarControl } from "../../SidebarControl";
 import { ContentHeader } from "./ContentHeader";
 import { PresetsBar } from "./components/PresetsBar";
@@ -19,17 +20,20 @@ export function ContentView({
 	onOpenQuickOpen,
 }: ContentViewProps) {
 	const isSidebarOpen = useSidebarStore((s) => s.isSidebarOpen);
+	const isZenMode = useZenModeStore((s) => s.isZenMode);
 	const { data: showPresetsBar } =
 		electronTrpc.settings.getShowPresetsBar.useQuery();
 
 	return (
 		<div className="h-full flex flex-col overflow-hidden">
-			<ContentHeader
-				trailingAction={!isSidebarOpen ? <SidebarControl /> : undefined}
-			>
-				<GroupStrip />
-			</ContentHeader>
-			{showPresetsBar && <PresetsBar />}
+			{!isZenMode && (
+				<ContentHeader
+					trailingAction={!isSidebarOpen ? <SidebarControl /> : undefined}
+				>
+					<GroupStrip />
+				</ContentHeader>
+			)}
+			{!isZenMode && showPresetsBar && <PresetsBar />}
 			<TabsContent
 				defaultExternalApp={defaultExternalApp}
 				onOpenInApp={onOpenInApp}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceLayout/WorkspaceLayout.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceLayout/WorkspaceLayout.tsx
@@ -6,6 +6,7 @@ import {
 	SidebarMode,
 	useSidebarStore,
 } from "renderer/stores/sidebar-state";
+import { useZenModeStore } from "renderer/stores/zen-mode";
 import { ResizablePanel } from "../../ResizablePanel";
 import { ChangesContent, ScrollProvider } from "../ChangesContent";
 import { ContentView } from "../ContentView";
@@ -30,6 +31,7 @@ export function WorkspaceLayout({
 	const isResizing = useSidebarStore((s) => s.isResizing);
 	const setIsResizing = useSidebarStore((s) => s.setIsResizing);
 	const currentMode = useSidebarStore((s) => s.currentMode);
+	const isZenMode = useZenModeStore((s) => s.isZenMode);
 
 	const isExpanded = currentMode === SidebarMode.Changes;
 
@@ -46,7 +48,7 @@ export function WorkspaceLayout({
 					/>
 				)}
 			</div>
-			{isSidebarOpen && (
+			{!isZenMode && isSidebarOpen && (
 				<ResizablePanel
 					width={sidebarWidth}
 					onWidthChange={setSidebarWidth}

--- a/apps/desktop/src/renderer/stores/zen-mode.ts
+++ b/apps/desktop/src/renderer/stores/zen-mode.ts
@@ -1,0 +1,29 @@
+import { create } from "zustand";
+import { devtools, persist } from "zustand/middleware";
+
+interface ZenModeState {
+	isZenMode: boolean;
+	hasShownHint: boolean;
+	toggleZenMode: () => void;
+	setZenMode: (value: boolean) => void;
+	markHintShown: () => void;
+}
+
+export const useZenModeStore = create<ZenModeState>()(
+	devtools(
+		persist(
+			(set) => ({
+				isZenMode: false,
+				hasShownHint: false,
+				toggleZenMode: () => set((s) => ({ isZenMode: !s.isZenMode })),
+				setZenMode: (value) => set({ isZenMode: value }),
+				markHintShown: () => set({ hasShownHint: true }),
+			}),
+			{
+				name: "zen-mode-store",
+				partialize: (state) => ({ hasShownHint: state.hasShownHint }),
+			},
+		),
+		{ name: "ZenModeStore" },
+	),
+);


### PR DESCRIPTION
I love running 100 agents and multitasking, but sometimes I'm locked in on one agent and want to go zen mode. :)

## Screenshots (zen mode active)

Terminal, fullscreen, no chrome:

![Zen mode — terminal](https://raw.githubusercontent.com/Roshvan/superset/assets/zen-mode-screenshots/zen-mode-terminal.png)

Claude Code tab, fullscreen, no chrome:

![Zen mode — Claude Code](https://raw.githubusercontent.com/Roshvan/superset/assets/zen-mode-screenshots/zen-mode-claude-code.png)

Workspace launcher, fullscreen, no chrome:

![Zen mode — workspace](https://raw.githubusercontent.com/Roshvan/superset/assets/zen-mode-screenshots/zen-mode-workspace.png)

## Summary
- Adds a Zen Mode that hides all chrome (top bar, sidebars, content headers, mosaic toolbars) and enters OS fullscreen for a distraction-free workspace view
- Toggle with Cmd+. (macOS) / Ctrl+Shift+. (Windows/Linux), or exit with Escape
- Shows a one-time toast hint with the exit hotkey on first entry (persisted across restarts)

## Test plan
- [x] Toggle zen mode via hotkey — chrome hides and window enters fullscreen
- [x] Press Escape — exits zen mode and fullscreen
- [ ] Escape while focused in an input/textarea does not exit zen mode
- [ ] Workspace sidebar toggle hotkey is disabled while in zen mode
- [x] Mosaic window toolbars are hidden in zen mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Zen Mode: distraction-free view that hides top chrome and workspace sidebar.
  * Keyboard shortcut to toggle Zen Mode: meta+period (macOS) or ctrl+shift+period (Windows/Linux).
  * Toggle also attempts to enter native fullscreen; if fullscreen cannot be set the app will revert Zen Mode.
  * Escape key exits Zen Mode.
  * One-time hint toast shown on first use (hint state is persisted).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->