### PR TITLE
fix(desktop): show spinner on install update button while pending

### DIFF
--- a/apps/desktop/src/renderer/components/UpdateRequiredPage/UpdateRequiredPage.tsx
+++ b/apps/desktop/src/renderer/components/UpdateRequiredPage/UpdateRequiredPage.tsx
@@ -90,7 +90,11 @@ export function UpdateRequiredPage({
 							<Button
 								onClick={handleInstall}
 								disabled={installMutation.isPending}
+								className="gap-2"
 							>
+								{installMutation.isPending && (
+									<HiArrowPath className="h-4 w-4 animate-spin" />
+								)}
 								{installMutation.isPending
 									? "Installing..."
 									: "Install & Restart"}

--- a/apps/desktop/src/renderer/components/UpdateToast/UpdateToast.tsx
+++ b/apps/desktop/src/renderer/components/UpdateToast/UpdateToast.tsx
@@ -1,7 +1,7 @@
 import { COMPANY } from "@superset/shared/constants";
 import { Button } from "@superset/ui/button";
 import { toast } from "@superset/ui/sonner";
-import { HiMiniXMark } from "react-icons/hi2";
+import { HiArrowPath, HiMiniXMark } from "react-icons/hi2";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { AUTO_UPDATE_STATUS } from "shared/auto-update";
 
@@ -93,6 +93,9 @@ export function UpdateToast({
 						onClick={handleInstall}
 						disabled={installMutation.isPending}
 					>
+						{installMutation.isPending && (
+							<HiArrowPath className="size-3.5 animate-spin" />
+						)}
 						{installMutation.isPending ? "Installing..." : "Install"}
 					</Button>
 				</div>


### PR DESCRIPTION
## Summary
- Install update buttons in `UpdateToast` and `UpdateRequiredPage` now show a spinning `HiArrowPath` icon while the mutation is pending, alongside the existing disabled (dimmed) state and "Installing..." label
- Disabled state alone didn't feel responsive — click registered without obvious acknowledgement

## Test plan
- [ ] Trigger update flow, click **Install** in the toast — verify the button dims and shows a spinning icon until the app restarts
- [ ] On the Update Required page, click **Install & Restart** — verify the same visual feedback

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a spinning icon on the update Install buttons while the install mutation is pending to acknowledge the click and improve feedback. Applies to the Install button in the update toast and the Install & Restart button on the Update Required page, alongside the existing disabled state and "Installing..." label.

<sup>Written for commit 035437b251be185bc0cf29f53396534597ba0991. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced animated loading indicators on install buttons during software update installation
  * Spinning icon now visible on both update notification toasts and the update dialog screens
  * Enhanced button spacing and visual alignment when updates are being installed
  * Clearer visual state indicators when the system is actively processing updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->