### PR TITLE
fix(chat): cut display polling to 4fps and restore query cache defaults

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/hooks/useWorkspaceChatDisplay/useWorkspaceChatDisplay.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/hooks/useWorkspaceChatDisplay/useWorkspaceChatDisplay.ts
@@ -107,8 +107,7 @@ function getLegacyImagePayload(
 }
 
 export function useChatDisplay(options: UseChatDisplayOptions) {
-	const { sessionId, workspaceId, enabled = true, fps = 60 } = options;
-	const utils = workspaceTrpc.useUtils();
+	const { sessionId, workspaceId, enabled = true, fps = 4 } = options;
 	const [commandError, setCommandError] = useState<unknown>(null);
 	const queryInput =
 		sessionId === null ? undefined : { sessionId, workspaceId };
@@ -119,8 +118,6 @@ export function useChatDisplay(options: UseChatDisplayOptions) {
 		refetchInterval: refetchIntervalMs,
 		refetchIntervalInBackground: true,
 		refetchOnWindowFocus: false,
-		staleTime: 0,
-		gcTime: 0,
 	} as const;
 
 	const displayQuery = workspaceTrpc.chat.getDisplayState.useQuery(
@@ -350,20 +347,6 @@ export function useChatDisplay(options: UseChatDisplayOptions) {
 			workspaceId,
 		],
 	);
-
-	useEffect(() => {
-		if (!queryInput) return;
-		if (!isRunning) return;
-		void Promise.all([
-			utils.chat.getDisplayState.invalidate(queryInput),
-			utils.chat.listMessages.invalidate(queryInput),
-		]);
-	}, [
-		isRunning,
-		queryInput,
-		utils.chat.getDisplayState,
-		utils.chat.listMessages,
-	]);
 
 	return {
 		...displayState,

--- a/packages/chat/src/client/hooks/use-chat-display/use-chat-display.ts
+++ b/packages/chat/src/client/hooks/use-chat-display/use-chat-display.ts
@@ -113,7 +113,7 @@ function getLegacyImagePayload(
 }
 
 export function useChatDisplay(options: UseChatDisplayOptions) {
-	const { sessionId, cwd, enabled = true, fps = 60 } = options;
+	const { sessionId, cwd, enabled = true, fps = 4 } = options;
 	const utils = chatRuntimeServiceTrpc.useUtils();
 	const [commandError, setCommandError] = useState<unknown>(null);
 	const sessionCommandInput =
@@ -126,8 +126,6 @@ export function useChatDisplay(options: UseChatDisplayOptions) {
 		refetchInterval: refetchIntervalMs,
 		refetchIntervalInBackground: true,
 		refetchOnWindowFocus: false,
-		staleTime: 0,
-		gcTime: 0,
 	} as const;
 
 	const displayQuery = chatRuntimeServiceTrpc.session.getDisplayState.useQuery(


### PR DESCRIPTION
## Summary

Alternative, subtractive version of #3170 by @thepathmakerz. Same root cause, same bug closed, ~-21 lines instead of +36.

Credit: all diagnostic work and the root-cause analysis belongs to @thepathmakerz in #3170. This PR just takes a more aggressive deletion path — please review alongside that PR and pick whichever fits better.

## Root cause (same as #3170)

`staleTime: 0, gcTime: 0` combined with 60fps polling (`fps = 60` default, 16ms refetch) means React Query cannot dedupe or garbage-collect anything — it allocates and discards a fresh query cache entry ~60 times a second, forever. Over an hour that drifts into multi-GB heap and a CPU death spiral.

## This version

- Remove `staleTime: 0, gcTime: 0` from both hooks → React Query defaults (`gcTime: 5min`) kick back in. **This is what fixes the leak.**
- Default `fps = 60 → fps = 4` (250ms poll) → kills the CPU spiral at the source.
- Delete the v2 hook's `isRunning` invalidation `useEffect` → redundant when the query is polling anyway; also drops now-unused `utils`.

No adaptive polling, no `wasRunningRef`, no function-form `refetchInterval`, no `IDLE_*` / `GC_TIME_*` constants.

## Why 4fps doesn't hurt streaming UX

`StreamingMessageText` (`apps/desktop/.../StreamingMessageText.tsx`) already animates text reveal **client-side** at its own 16ms interval (`STREAM_TEXT_TICK_MS`), revealing 2 chars/tick from whatever buffer the server has delivered. Perceived smoothness is decoupled from the server poll rate — the poll just needs to keep the reveal buffer fed, which 4fps does with plenty of headroom vs. typical LLM token arrival (~50–200ms chunks).

## Tradeoffs vs #3170

- **Gives up:** peak 60fps active-streaming cadence and the immediate refetch on agent stop. Both unnecessary given the client-side reveal animation and the ≤250ms natural catch-up.
- **Gains:** fewer moving parts (no dual cadence, no ref-based transition detection), no asymmetry between `displayQuery`'s function-form `refetchInterval` and `messagesQuery`'s static one, no cross-session `wasRunningRef` edge case.

## Test plan

- [x] `bun run --filter @superset/chat typecheck` passes
- [x] `bun run --filter @superset/desktop typecheck` passes
- [x] `bun test src/client/hooks/use-chat-display` — 5/5 pass
- [ ] Manual: 30+ min idle with a workspace open — verify flat heap in DevTools Memory
- [ ] Manual: send a message, confirm streaming reveal still looks smooth (client-side animation drives this)
- [ ] Manual: after agent stops, confirm final state appears within ~250ms

Closes #3049

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat memory leak and CPU spikes by restoring React Query cache defaults and cutting display polling to 4fps. Streaming stays smooth because the client animates text reveal.

- **Bug Fixes**
  - Removed `staleTime: 0` and `gcTime: 0` so the default 5‑minute cache GC works.
  - Set `fps` default from 60 to 4 (250ms poll) in both chat display hooks.
  - Deleted the redundant `isRunning` invalidation effect in the desktop workspace hook.

<sup>Written for commit 16356b790c2f8d84e4150076203c7a59f0a6805d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized chat display refresh behavior to reduce polling frequency while maintaining message synchronization. These internal improvements help reduce unnecessary data requests and improve overall performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->