### PR TITLE
ux(desktop): clarify cold-restore banner

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalColdRestore.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalColdRestore.ts
@@ -180,11 +180,13 @@ export function useTerminalColdRestore({
 			});
 		});
 
-		// Add visual separator. The previous session's process has terminated;
-		// only its on-disk scrollback is restored. We say so explicitly so the
-		// user does not assume the agent (Claude/Codex) is still running.
+		// Visual separator: state what we know for certain right now. The
+		// previous session's process has terminated and only its on-disk
+		// scrollback is restored. "New shell started" is written later, from
+		// the success callback — writing it here would lie if createOrAttach
+		// fails downstream.
 		xterm.write(
-			"\r\n\x1b[90m─── Scrollback restored · previous session ended ─── New shell started\x1b[0m\r\n\r\n",
+			"\r\n\x1b[90m─── Scrollback restored · previous session ended ───\x1b[0m\r\n\r\n",
 		);
 
 		// Reset state for new session
@@ -209,6 +211,14 @@ export function useTerminalColdRestore({
 			},
 			{
 				onSuccess: (result: CreateOrAttachResult) => {
+					// Shell is confirmed live — now it's safe to tell the user.
+					const currentXterm = xtermRef.current;
+					if (currentXterm) {
+						currentXterm.write(
+							"\x1b[90m─── New shell started ───\x1b[0m\r\n\r\n",
+						);
+					}
+
 					pendingInitialStateRef.current = result;
 					maybeApplyInitialState();
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalColdRestore.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalColdRestore.ts
@@ -180,8 +180,12 @@ export function useTerminalColdRestore({
 			});
 		});
 
-		// Add visual separator
-		xterm.write("\r\n\x1b[90m─── Session Contents Restored ───\x1b[0m\r\n\r\n");
+		// Add visual separator. The previous session's process has terminated;
+		// only its on-disk scrollback is restored. We say so explicitly so the
+		// user does not assume the agent (Claude/Codex) is still running.
+		xterm.write(
+			"\r\n\x1b[90m─── Scrollback restored · previous session ended ─── New shell started\x1b[0m\r\n\r\n",
+		);
 
 		// Reset state for new session
 		isStreamReadyRef.current = false;


### PR DESCRIPTION
## Summary

The "Session Contents Restored" separator that the cold-restore flow writes into the xterm buffer was misleading: it reads like the previous session has been resumed, but in reality the previous PTY has already exited and only the on-disk scrollback is being replayed. The fresh shell that drops below the separator is empty — any agent CLI (Claude Code, Codex, `gh auth login`, etc.) that was running in the previous session is gone.

Users were consistently misinterpreting the banner and typing into a prompt where their expected program was not running. This PR replaces the separator text with explicit wording that spells out the actual state of the world:

Before:
```
─── Session Contents Restored ───
```

After:
```
─── Scrollback restored · previous session ended ─── New shell started
```

## Test plan

- [x] `bun run typecheck` clean
- [x] Manual verification: force an unclean shutdown (kill the app while a pane is active), relaunch, open the affected pane, confirm the new separator text is shown above the fresh shell prompt and clearly communicates that the old process is gone.

## Notes

- A natural follow-up (separate PR) would be to pre-fill the prompt with `claude --resume <uuid>` / `codex resume` when the scrollback tail matches a known agent CLI invocation. That turns the banner from a notice into a one-keystroke resume. Out of scope here — this PR is banner-text-only and carries no runtime risk.
- Single-file change, scope <10 lines.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the desktop terminal cold-restore banner so users know the previous process is gone. Shows "─── Scrollback restored · previous session ended ───" immediately, and only writes "─── New shell started ───" after the shell successfully attaches to avoid false positives if creation fails.

<sup>Written for commit d3446d809e2019df3169716e0e2daae8a0b4627c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal restoration messages: the separator now clearly indicates restored scrollback and prior session end, and the "New shell started" message is emitted only after the shell has successfully attached, giving more accurate feedback during session restore and startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->