### PR TITLE
fix(desktop): keep terminal-host daemon alive across app quit

### DIFF
--- a/apps/desktop/src/main/terminal-host/index.ts
+++ b/apps/desktop/src/main/terminal-host/index.ts
@@ -826,6 +826,14 @@ async function main() {
 	log("info", `Environment: ${process.env.NODE_ENV || "production"}`);
 	log("info", `Home directory: ${SUPERSET_HOME_DIR}`);
 
+	// Belt-and-suspenders SIGHUP guard against the race window where the
+	// macOS login session tears down between process boot and
+	// setupSignalHandlers() registration. Without a registered listener,
+	// Node's default action for SIGHUP is to terminate the process — which
+	// would kill the daemon during Electron's exit before we can install our
+	// no-op handler in setupSignalHandlers().
+	process.on("SIGHUP", () => {});
+
 	setupSignalHandlers();
 
 	try {

--- a/apps/desktop/src/main/terminal-host/index.ts
+++ b/apps/desktop/src/main/terminal-host/index.ts
@@ -822,19 +822,24 @@ function setupSignalHandlers() {
 // =============================================================================
 
 async function main() {
+	// Belt-and-suspenders SIGHUP guard, installed before anything else (log
+	// calls included). Without a registered listener, Node's default action
+	// for SIGHUP is to terminate the process — so if Electron tears down the
+	// macOS login session during our startup logging, the daemon dies before
+	// setupSignalHandlers() can install the definitive listener.
+	//
+	// We remove this temporary guard after setupSignalHandlers() to keep the
+	// listener set clean — `process.on` adds rather than replaces, so leaving
+	// it in place would leave two SIGHUP listeners for the daemon's lifetime.
+	const earlyHupGuard = (): void => {};
+	process.on("SIGHUP", earlyHupGuard);
+
 	log("info", "Terminal Host Daemon starting...");
 	log("info", `Environment: ${process.env.NODE_ENV || "production"}`);
 	log("info", `Home directory: ${SUPERSET_HOME_DIR}`);
 
-	// Belt-and-suspenders SIGHUP guard against the race window where the
-	// macOS login session tears down between process boot and
-	// setupSignalHandlers() registration. Without a registered listener,
-	// Node's default action for SIGHUP is to terminate the process — which
-	// would kill the daemon during Electron's exit before we can install our
-	// no-op handler in setupSignalHandlers().
-	process.on("SIGHUP", () => {});
-
 	setupSignalHandlers();
+	process.removeListener("SIGHUP", earlyHupGuard);
 
 	try {
 		await startServer();

--- a/apps/desktop/src/main/terminal-host/signal-handlers.ts
+++ b/apps/desktop/src/main/terminal-host/signal-handlers.ts
@@ -127,13 +127,18 @@ export function setupTerminalHostSignalHandlers({
 			timeoutMessage: "Forced exit after SIGTERM shutdown timeout",
 		});
 	});
+	// SIGHUP: intentionally ignored (nohup semantics).
+	//
+	// The daemon is spawned with `detached: true` + `child.unref()` so it can
+	// outlive Electron's exit — see marketing blog terminal-daemon-deep-dive
+	// "Terminal survives app restart". On macOS, `setsid()` isolates the Unix
+	// SID but the daemon still shares the Mach bootstrap / login Security
+	// Session with its parent. When Electron calls `app.exit(0)` and tears
+	// down that login session, SIGHUP propagates to the daemon and kills it
+	// unless explicitly ignored. Registering a no-op listener prevents the
+	// default terminate action without triggering our shutdownOnce path.
 	process.on("SIGHUP", () => {
-		shutdownOnce({
-			exitCode: 0,
-			message: "Received SIGHUP, shutting down...",
-			stopServerErrorMessage: "Error during stopServer in SIGHUP shutdown",
-			timeoutMessage: "Forced exit after SIGHUP shutdown timeout",
-		});
+		log("info", "Received SIGHUP; ignoring (nohup semantics for daemon survival)");
 	});
 
 	process.on("uncaughtException", (error) => {

--- a/apps/desktop/src/main/terminal-host/signal-handlers.ts
+++ b/apps/desktop/src/main/terminal-host/signal-handlers.ts
@@ -138,7 +138,19 @@ export function setupTerminalHostSignalHandlers({
 	// unless explicitly ignored. Registering a no-op listener prevents the
 	// default terminate action without triggering our shutdownOnce path.
 	process.on("SIGHUP", () => {
-		log("info", "Received SIGHUP; ignoring (nohup semantics for daemon survival)");
+		// Protect the nohup semantics even if logging fails. If the daemon's
+		// stdout/stderr pipe closes (e.g. Electron exits first and we were
+		// spawned with stdio:"pipe"/"inherit"), writing to it throws EPIPE
+		// — an uncaught exception would flow into shutdownOnce and defeat
+		// the entire purpose of this handler.
+		try {
+			log(
+				"info",
+				"Received SIGHUP; ignoring (nohup semantics for daemon survival)",
+			);
+		} catch {
+			// Preserve ignore semantics unconditionally.
+		}
 	});
 
 	process.on("uncaughtException", (error) => {


### PR DESCRIPTION
## Summary

The terminal-host daemon is spawned `detached: true` + `unref()` so it can outlive the Electron main process, which is the mechanism behind the "Terminal That (Almost) Never Dies" promise in the [terminal-daemon-deep-dive blog post](../blob/main/apps/marketing/content/blog/terminal-daemon-deep-dive.mdx). In practice, on macOS, Cmd+Q still tore the daemon down along with every active terminal session.

Root cause is a macOS-specific signal propagation path. `setsid()` (implicit from Node's `detached: true`) isolates the daemon's Unix SID, but the daemon still shares the Mach bootstrap / login Security Session with its parent. When Electron's `app.exit(0)` tears down that login session, macOS propagates SIGHUP to the daemon — and the existing signal handler called `shutdownOnce()`, killing every PTY subprocess with it.

Fix: register a SIGHUP listener that is a logging no-op (nohup semantics). The daemon now survives a Cmd+Q quit. Intentional daemon shutdown still goes through `killDaemonFromPidFile()` (SIGKILL, which this handler cannot intercept) and the explicit `shutdown` RPC path.

Fixes #2501.

## Test plan

- [x] `bun run typecheck` clean
- [x] Manual verification on macOS: open Superset with terminals open, Cmd+Q, verify `pgrep -f terminal-host.js` still shows the same daemon PID, relaunch, verify sessions hot-reattach with `Session ... attached` log line (not `created`).
- [x] Confirmed on 2026-04-19: same daemon PID survived 5+ quit-relaunch cycles; PTY subprocess PID remained unchanged across the cycle.

## Notes

- Tested in combination with #<PR4_NUM> (fresh-spawn PTY spawn in daemon). That PR ensures PTY subprocesses are spawned as daemon's children rather than Electron main's, so daemon survival translates to session survival end-to-end.
- A defensive SIGTERM no-op and a process-group-aware rewrite are possible follow-ups if observed SIGHUP handling proves insufficient on other macOS versions, but the SIGHUP-only patch was sufficient in all tested configurations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the terminal-host daemon alive after Cmd+Q on macOS by ignoring SIGHUP, so terminal sessions persist across app restarts. Fixes #2501.

- **Bug Fixes**
  - Treat SIGHUP as a no-op (nohup semantics) instead of calling `shutdownOnce`; wrap the log in try/catch to avoid EPIPE if stdio is closed.
  - Add a temporary SIGHUP guard at the first line of daemon startup (before any logs), then remove it after `setupSignalHandlers()` to close the race and avoid duplicate listeners; intentional shutdown paths remain unchanged.

<sup>Written for commit 920432c102a2a4b8a8c45f276254e20523efefa3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unexpected termination from SIGHUP during early startup so the app can continue running.
  * Treat SIGHUP as ignored at runtime and record an informational message; logging is made resilient so logging failures won't trigger shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->