### PR TITLE
chore(desktop): drop --enable codex_hooks from codex wrapper

### DIFF
--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -198,7 +198,7 @@ describe("agent-wrappers copilot", () => {
 		expect(wrapper).toContain('_superset_emit_event "Start"');
 		expect(wrapper).toContain('_superset_emit_event "PermissionRequest"');
 		expect(wrapper).toContain(
-			`"$REAL_BIN" --enable codex_hooks -c 'notify=["bash","${path.join(TEST_HOOKS_DIR, "notify.sh")}"]' "$@"`,
+			`"$REAL_BIN" -c 'notify=["bash","${path.join(TEST_HOOKS_DIR, "notify.sh")}"]' "$@"`,
 		);
 		expect(wrapper).toContain("SUPERSET_CODEX_START_WATCHER_PID");
 		expect(wrapper).toContain('kill "$SUPERSET_CODEX_START_WATCHER_PID"');
@@ -210,7 +210,7 @@ describe("agent-wrappers copilot", () => {
 		expect(wrapper).toContain(execLine);
 	});
 
-	it("forwards codex_hooks enablement through the codex wrapper for manual launches", () => {
+	it("forwards notify configuration through the codex wrapper for manual launches", () => {
 		const realBinDir = path.join(TEST_ROOT, "real-bin");
 		const realCodex = path.join(realBinDir, "codex");
 		const wrapperPath = path.join(TEST_BIN_DIR, "codex");
@@ -240,8 +240,6 @@ exit 0
 
 		expect(readFileSync(argsFile, "utf-8")).toBe(
 			`${[
-				"--enable",
-				"codex_hooks",
 				"-c",
 				`notify=["bash","${path.join(TEST_HOOKS_DIR, "notify.sh")}"]`,
 				"exec",

--- a/apps/desktop/src/main/lib/agent-setup/templates/codex-wrapper-exec.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/codex-wrapper-exec.template.sh
@@ -72,7 +72,7 @@ if [ -n "$SUPERSET_TAB_ID" ] && [ -f "{{NOTIFY_PATH}}" ]; then
   SUPERSET_CODEX_START_WATCHER_PID=$!
 fi
 
-"$REAL_BIN" --enable codex_hooks -c 'notify=["bash","{{NOTIFY_PATH}}"]' "$@"
+"$REAL_BIN" -c 'notify=["bash","{{NOTIFY_PATH}}"]' "$@"
 SUPERSET_CODEX_STATUS=$?
 
 if [ -n "$SUPERSET_CODEX_START_WATCHER_PID" ]; then


### PR DESCRIPTION
## Summary
- Removed `--enable codex_hooks` from the codex exec wrapper template and its tests
- `codex_hooks` defaults to `true` in current codex versions, so the explicit flag is redundant
- Keeping it risks breaking older codex versions that don't recognize the flag, and future versions where the feature graduates to stable and the flag is removed

## Test plan
- [x] `bun test src/main/lib/agent-setup/agent-wrappers.test.ts` passes (25/25)
- [ ] Manual smoke test: launch codex via the desktop wrapper and confirm notify hooks still fire

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `--enable codex_hooks` flag from the desktop codex wrapper to rely on the default and avoid breaking older/future codex versions. Notify hooks continue to work; tests updated.

- **Refactors**
  - Dropped the flag in `codex-wrapper-exec.template.sh`, keeping only `-c 'notify=...'`.
  - Updated wrapper tests to match the new invocation and clarify notify forwarding.

<sup>Written for commit b7eb24a146b7999af0163c04b6619bad55fd9732. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated agent wrapper configuration handling to modify how notification settings are passed during initialization. Updated corresponding test cases to reflect the new configuration approach, ensuring proper validation of the updated notification delivery mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->