### PR TITLE
feat(chat): add Opus 4.7 model option

### DIFF
--- a/apps/desktop/src/renderer/lib/dev-chat.ts
+++ b/apps/desktop/src/renderer/lib/dev-chat.ts
@@ -4,6 +4,11 @@ import { MOCK_ORG_ID } from "shared/constants";
 
 export const DEV_CHAT_MODELS: ModelOption[] = [
 	{
+		id: "anthropic/claude-opus-4-7",
+		name: "Opus 4.7",
+		provider: "Anthropic",
+	},
+	{
 		id: "anthropic/claude-opus-4-6",
 		name: "Opus 4.6",
 		provider: "Anthropic",

--- a/packages/trpc/src/router/chat/chat.ts
+++ b/packages/trpc/src/router/chat/chat.ts
@@ -9,6 +9,11 @@ import { uploadChatAttachment } from "./utils/upload-chat-attachment";
 
 const AVAILABLE_MODELS = [
 	{
+		id: "anthropic/claude-opus-4-7",
+		name: "Opus 4.7",
+		provider: "Anthropic",
+	},
+	{
 		id: "anthropic/claude-opus-4-6",
 		name: "Opus 4.6",
 		provider: "Anthropic",


### PR DESCRIPTION
## Summary
- Add `anthropic/claude-opus-4-7` (Opus 4.7) to the chat model picker in the web tRPC router and desktop dev chat list.

## Test plan
- [ ] Open chat GUI and confirm Opus 4.7 appears at top of Anthropic models
- [ ] Select Opus 4.7 and send a message to confirm it routes correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `anthropic/claude-opus-4-7` (Opus 4.7) to the chat model picker in the web tRPC router and the desktop dev chat. This makes Opus 4.7 selectable and routes messages to it.

<sup>Written for commit d20303e289233b3c03aa4eb0241e14ed81ab628f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Claude Opus 4.7 from Anthropic as a new available chat model option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->