### PR TITLE
fix(qstash): pin client to US region via QSTASH_URL

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -203,6 +203,7 @@ jobs:
           GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
           GH_WEBHOOK_SECRET: ${{ secrets.GH_WEBHOOK_SECRET }}
           QSTASH_TOKEN: ${{ secrets.QSTASH_TOKEN }}
+          QSTASH_URL: ${{ secrets.QSTASH_URL }}
           QSTASH_CURRENT_SIGNING_KEY: ${{ secrets.QSTASH_CURRENT_SIGNING_KEY }}
           QSTASH_NEXT_SIGNING_KEY: ${{ secrets.QSTASH_NEXT_SIGNING_KEY }}
           ELECTRIC_URL: ${{ env.ELECTRIC_URL }}
@@ -256,6 +257,7 @@ jobs:
             --env GH_APP_PRIVATE_KEY="$GH_APP_PRIVATE_KEY" \
             --env GH_WEBHOOK_SECRET="$GH_WEBHOOK_SECRET" \
             --env QSTASH_TOKEN=$QSTASH_TOKEN \
+            --env QSTASH_URL=$QSTASH_URL \
             --env QSTASH_CURRENT_SIGNING_KEY=$QSTASH_CURRENT_SIGNING_KEY \
             --env QSTASH_NEXT_SIGNING_KEY=$QSTASH_NEXT_SIGNING_KEY \
             --env ELECTRIC_URL=$ELECTRIC_URL \

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -108,6 +108,7 @@ jobs:
           GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
           GH_WEBHOOK_SECRET: ${{ secrets.GH_WEBHOOK_SECRET }}
           QSTASH_TOKEN: ${{ secrets.QSTASH_TOKEN }}
+          QSTASH_URL: ${{ secrets.QSTASH_URL }}
           QSTASH_CURRENT_SIGNING_KEY: ${{ secrets.QSTASH_CURRENT_SIGNING_KEY }}
           QSTASH_NEXT_SIGNING_KEY: ${{ secrets.QSTASH_NEXT_SIGNING_KEY }}
           ELECTRIC_URL: ${{ secrets.ELECTRIC_URL }}
@@ -161,6 +162,7 @@ jobs:
             --env GH_APP_PRIVATE_KEY="$GH_APP_PRIVATE_KEY" \
             --env GH_WEBHOOK_SECRET="$GH_WEBHOOK_SECRET" \
             --env QSTASH_TOKEN=$QSTASH_TOKEN \
+            --env QSTASH_URL=$QSTASH_URL \
             --env QSTASH_CURRENT_SIGNING_KEY=$QSTASH_CURRENT_SIGNING_KEY \
             --env QSTASH_NEXT_SIGNING_KEY=$QSTASH_NEXT_SIGNING_KEY \
             --env ELECTRIC_URL=$ELECTRIC_URL \

--- a/.github/workflows/setup-automations-schedule.yml
+++ b/.github/workflows/setup-automations-schedule.yml
@@ -32,4 +32,5 @@ jobs:
         env:
           NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL }}
           QSTASH_TOKEN: ${{ secrets.QSTASH_TOKEN }}
+          QSTASH_URL: ${{ secrets.QSTASH_URL }}
         run: bun run apps/api/scripts/setup-automations-schedule.ts

--- a/apps/api/scripts/setup-automations-schedule.ts
+++ b/apps/api/scripts/setup-automations-schedule.ts
@@ -5,19 +5,22 @@
  * Usage:
  *   NEXT_PUBLIC_API_URL=https://api.superset.sh \
  *   QSTASH_TOKEN=... \
+ *   QSTASH_URL=https://qstash-us-east-1.upstash.io \
  *   bun run apps/api/scripts/setup-automations-schedule.ts
  */
 import { Client } from "@upstash/qstash";
 
 const token = process.env.QSTASH_TOKEN;
 const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+const baseUrl = process.env.QSTASH_URL;
 
 if (!token) throw new Error("QSTASH_TOKEN is required");
 if (!apiUrl) throw new Error("NEXT_PUBLIC_API_URL is required");
+if (!baseUrl) throw new Error("QSTASH_URL is required");
 
 const destination = `${apiUrl}/api/automations/evaluate`;
 const cron = "* * * * *";
-const qstash = new Client({ token });
+const qstash = new Client({ token, baseUrl });
 
 const existing = await qstash.schedules.list();
 const match = existing.find((s) => s.destination === destination);

--- a/apps/api/src/app/api/automations/evaluate/route.ts
+++ b/apps/api/src/app/api/automations/evaluate/route.ts
@@ -8,7 +8,10 @@ import { env } from "@/env";
 
 export const dynamic = "force-dynamic";
 
-const qstash = new Client({ token: env.QSTASH_TOKEN });
+const qstash = new Client({
+	token: env.QSTASH_TOKEN,
+	baseUrl: env.QSTASH_URL,
+});
 const receiver = new Receiver({
 	currentSigningKey: env.QSTASH_CURRENT_SIGNING_KEY,
 	nextSigningKey: env.QSTASH_NEXT_SIGNING_KEY,

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -31,6 +31,7 @@ export const env = createEnv({
 		SLACK_SIGNING_SECRET: z.string(),
 		ANTHROPIC_API_KEY: z.string(),
 		QSTASH_TOKEN: z.string().min(1),
+		QSTASH_URL: z.string().url(),
 		QSTASH_CURRENT_SIGNING_KEY: z.string().min(1),
 		QSTASH_NEXT_SIGNING_KEY: z.string().min(1),
 		RESEND_API_KEY: z.string(),


### PR DESCRIPTION
## Summary
Our prod QStash project lives in us-east-1 but Upstash's global endpoint was routing us to eu-central-1, so the first scheduler setup run 404'd with "user not found in this region." Pass an explicit baseUrl from a new \`QSTASH_URL\` secret.

- \`apps/api/src/env.ts\` — require \`QSTASH_URL\`
- \`evaluate\` route + \`setup-automations-schedule\` script — pass \`baseUrl\` to \`new Client({...})\`
- deploy-production / deploy-preview / setup-automations-schedule workflows — plumb the secret through

Once this lands:
1. Re-run Deploy Production so Vercel bakes in \`QSTASH_URL\`
2. Re-trigger Setup Automations Schedule — should register the cron on us-east-1

## Test plan
- [ ] Deploy Production completes
- [ ] \`Setup Automations Schedule\` succeeds and prints the new scheduleId
- [ ] Evaluator cron invocation lands in QStash US dashboard within a minute

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `@upstash/qstash` to our US region by introducing `QSTASH_URL` and passing it as `baseUrl`. Fixes cross‑region routing that caused "user not found in this region" 404s for schedule setup and evaluator cron.

- **Bug Fixes**
  - Require `QSTASH_URL` in `apps/api/src/env.ts`.
  - Pass `baseUrl` to `new Client({...})` in the evaluate route and `setup-automations-schedule` script.
  - Plumb `QSTASH_URL` through `deploy-production`, `deploy-preview`, and `setup-automations-schedule` workflows.

- **Migration**
  - Add `QSTASH_URL` secret pointing to the us-east-1 endpoint (e.g., https://qstash-us-east-1.upstash.io).
  - Redeploy Production, then re-run “Setup Automations Schedule” to register the cron in us-east-1.

<sup>Written for commit 78c83ca371eeb08ffa10692583b3168e62de0abb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configurable QStash endpoint support through a new environment variable across deployment workflows and automation schedules, enabling the system to use custom QStash endpoint URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->