### PR TITLE
fix(automations): deduplicationId separator for us-east-1 QStash

### DIFF
--- a/apps/api/src/app/api/automations/evaluate/route.ts
+++ b/apps/api/src/app/api/automations/evaluate/route.ts
@@ -62,7 +62,7 @@ export async function POST(request: Request): Promise<Response> {
 					automationId: automation.id,
 					scheduledFor: scheduledFor.toISOString(),
 				},
-				deduplicationId: `${automation.id}:${scheduledFor.toISOString()}`,
+				deduplicationId: `${automation.id}_${scheduledFor.getTime()}`,
 				retries: 2,
 				failureCallback: `${env.NEXT_PUBLIC_API_URL}/api/automations/run-failed`,
 			};


### PR DESCRIPTION
## Summary
Our prod QStash project (us-east-1) rejects \`:\` in \`deduplicationId\`:
\`{"error":"DeduplicationId cannot contain ':'"}\` — 400 from batchJSON.

Swap the separator to \`_\` and switch from ISO8601 to epoch ms so the whole key is \`[a-zA-Z0-9_-]\`. Idempotency semantics (minute-bucket uniqueness per automation) are unchanged.

## Test plan
- [ ] Deploy goes green
- [ ] Evaluator fires without the DeduplicationId error; downstream dispatch messages appear in Upstash
- [ ] Idempotency still holds — force a double-evaluator-tick and verify only one \`automation_runs\` row per \`(automation_id, scheduled_for)\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes QStash 400s in us-east-1 by changing the deduplicationId from `${automation.id}:${scheduledFor.toISOString()}` to `${automation.id}_${scheduledFor.getTime()}`. Uses `_` and epoch ms so the key is alphanumeric/`_`/`-` only; idempotency is unchanged.

<sup>Written for commit 937f56a49cbe5ce048d75fd197e00fdd2e3c3ace. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal deduplication mechanism for automation dispatches to improve processing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->