### PR TITLE
fix(desktop): wire v2 sidebar project settings to settings route

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/hooks/useDashboardSidebarProjectSectionActions/useDashboardSidebarProjectSectionActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/hooks/useDashboardSidebarProjectSectionActions/useDashboardSidebarProjectSectionActions.ts
@@ -1,5 +1,6 @@
 import { alert } from "@superset/ui/atoms/Alert";
 import { toast } from "@superset/ui/sonner";
+import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
@@ -14,6 +15,7 @@ export function useDashboardSidebarProjectSectionActions({
 	project,
 }: UseDashboardSidebarProjectSectionActionsOptions) {
 	const openModal = useOpenNewWorkspaceModal();
+	const navigate = useNavigate();
 	const {
 		createSection,
 		deleteSection,
@@ -57,7 +59,10 @@ export function useDashboardSidebarProjectSectionActions({
 	};
 
 	const handleOpenSettings = () => {
-		toast.info("Project settings are coming soon");
+		navigate({
+			to: "/settings/project/$projectId",
+			params: { projectId: project.id },
+		});
 	};
 
 	const confirmRemoveFromSidebar = () => {


### PR DESCRIPTION
## Summary
- The v2 dashboard sidebar's project context-menu \"Project Settings\" item was showing a \"coming soon\" toast. Navigate to `/settings/project/$projectId` instead, matching v1's `ProjectHeader.handleOpenSettings` logic.

## Test plan
- [ ] Right-click a project in the v2 dashboard sidebar → click **Project Settings** → verify it navigates to the project settings page (general tab)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clicking Project Settings in the v2 dashboard sidebar now opens the project settings page for the selected project. We navigate to `/settings/project/$projectId` using `@tanstack/react-router`, replacing the “coming soon” toast and matching v1 behavior.

<sup>Written for commit 1a0df5b1819ea2a3d628e68d1f6d61255e4bff60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed project settings access in the dashboard sidebar - users can now navigate to project settings directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->