### PR TITLE
fix(desktop): dedupe DevicePicker in new-workspace modal and match ProjectPickerPill styling

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -400,11 +400,6 @@ export function PromptGroup({
 					</AnimatePresence>
 				</div>
 				<div className="flex items-center gap-1.5">
-					<DevicePicker
-						className="w-[160px]"
-						hostTarget={hostTarget}
-						onSelectHostTarget={(t) => updateDraft({ hostTarget: t })}
-					/>
 					{selectedProject?.needsSetup === true && (
 						<span className="text-[11px] text-amber-500">
 							Project needs to be set up

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/DevicePicker/DevicePicker.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/DevicePicker/DevicePicker.tsx
@@ -11,11 +11,12 @@ import {
 import { cn } from "@superset/ui/utils";
 import {
 	HiCheck,
+	HiChevronUpDown,
 	HiOutlineCloud,
 	HiOutlineComputerDesktop,
 	HiOutlineServer,
 } from "react-icons/hi2";
-import { PickerTrigger } from "renderer/components/PickerTrigger";
+import { FormPickerTrigger } from "../../PromptGroup/components/FormPickerTrigger";
 import {
 	useWorkspaceHostOptions,
 	type WorkspaceHostOption,
@@ -65,7 +66,7 @@ function getSelectedIcon(
 	otherHosts: WorkspaceHostOption[],
 ) {
 	if (hostTarget.kind === "local") {
-		return <HiOutlineComputerDesktop className="size-3 shrink-0" />;
+		return <HiOutlineComputerDesktop className="size-4 shrink-0" />;
 	}
 
 	const host = otherHosts.find((h) => h.id === hostTarget.hostId);
@@ -98,16 +99,18 @@ export function DevicePicker({
 	return (
 		<DropdownMenu>
 			<DropdownMenuTrigger asChild>
-				<PickerTrigger
-					className={className}
-					icon={getSelectedIcon(hostTarget, otherHosts)}
-					label={selectedLabel}
-					endAdornment={
-						selectedRemoteOnline !== null ? (
-							<OnlineDot online={selectedRemoteOnline} />
-						) : null
-					}
-				/>
+				<FormPickerTrigger
+					className={cn("max-w-[140px]", className)}
+					aria-label={`Device: ${selectedLabel}`}
+					title={selectedLabel}
+				>
+					{getSelectedIcon(hostTarget, otherHosts)}
+					<span className="truncate">{selectedLabel}</span>
+					{selectedRemoteOnline !== null && (
+						<OnlineDot online={selectedRemoteOnline} />
+					)}
+					<HiChevronUpDown className="size-3 shrink-0" />
+				</FormPickerTrigger>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent align="start" className="w-72">
 				<DropdownMenuItem


### PR DESCRIPTION
## Summary
- Removed the duplicate `DevicePicker` that #3576 added to the right side of the new-workspace modal footer; both instances bound to the same `hostTarget` draft state so users saw two pickers that toggled together.
- Restyled the remaining `DevicePicker` to use `FormPickerTrigger` (same primitive `ProjectPickerPill` uses) so the Device / Project / Branch pickers read as one segmented control — matching text size (`text-[11px]`), color (`text-muted-foreground` → `foreground` on hover), icon size (`size-4`), and `size-3` chevron.
- Unified the local-host icon to `size-4` (was `size-3`) so it no longer looks smaller than the remote/cloud icons.

## Test plan
- [ ] Open the new-workspace modal — only one `DevicePicker` renders in the footer
- [ ] Picker sits flush next to `ProjectPickerPill` with matching type scale and color
- [ ] Selecting a remote host still shows the online/offline dot
- [ ] Switching between Local Device and a long host name doesn't reflow the footer

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed a duplicate device picker in the new-workspace modal and updated the remaining picker to match the project/branch pickers. This fixes the mirrored toggles and makes the footer read as one segmented control.

- **Bug Fixes**
  - Removed the extra `DevicePicker` bound to the same `hostTarget`.
  - Restyled the remaining `DevicePicker` using `FormPickerTrigger` to match `ProjectPickerPill` (11px text, `size-4` icons, `size-3` chevron), kept the online/offline dot, and truncated long host names to avoid footer reflow.

<sup>Written for commit 06b61f9a23b249a0afdd5c28a4db7fa700ed9bd4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX Improvements**
  * Removed redundant device picker from workspace setup modal for a cleaner interface.
  * Enhanced device picker component with improved visual styling and accessibility features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->