### PR TITLE
docs(readme): add caddy trust step to setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ echo 'SKIP_ENV_VALIDATION=1' >> .env
 ```bash
 # Install caddy: brew install caddy (macOS) or see https://caddyserver.com/docs/install
 cp Caddyfile.example Caddyfile
+
+# Without this, Chromium rejects https://localhost:* with ERR_CERT_AUTHORITY_INVALID.
+# Prompts for sudo once.
+caddy trust
 ```
 
 **4. Install dependencies and run**


### PR DESCRIPTION
## Summary
- Adds `caddy trust` to the README setup instructions so new machines install Caddy's local root CA into the System Keychain with trust flags.
- Without this step, Chromium in the desktop app rejects `https://localhost:*` (the Caddy HTTPS proxy in front of the Electric SSE streams) with `ERR_CERT_AUTHORITY_INVALID` / `net_error -202`.

## Test plan
- [ ] On a fresh Mac (or one where `caddy trust` was never run), follow the README steps and confirm the desktop app loads Electric streams without SSL handshake errors in the Electron logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions with explicit `caddy trust` command step to enable local HTTPS access and update certificate trust state. Note: May require elevated permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `caddy trust` to the setup so new machines install Caddy’s local root CA with trust flags. This prevents Chromium from rejecting https://localhost:* and fixes ERR_CERT_AUTHORITY_INVALID in the desktop app’s Electric SSE streams.

- **Migration**
  - Run `caddy trust` once during setup (may prompt for sudo) before starting the app.

<sup>Written for commit 52c9218d0d5792886d24147bce2ca07ed29fa6f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

