### PR TITLE
fix(relay): terminal WS URL prefix + pin to one fly machine

### DIFF
--- a/apps/relay/fly.toml
+++ b/apps/relay/fly.toml
@@ -13,6 +13,7 @@ primary_region = "sjc"
   auto_stop_machines = "off"
   auto_start_machines = true
   min_machines_running = 1
+  max_machines_running = 1
 
 [http_service.concurrency]
   type = "connections"

--- a/packages/workspace-client/src/providers/WorkspaceClientProvider/WorkspaceClientProvider.tsx
+++ b/packages/workspace-client/src/providers/WorkspaceClientProvider/WorkspaceClientProvider.tsx
@@ -126,7 +126,7 @@ export function useWorkspaceWsUrl(
 	params?: Record<string, string>,
 ): string {
 	const { hostUrl, getWsToken } = useWorkspaceClient();
-	const url = new URL(path, hostUrl);
+	const url = new URL(`${hostUrl}${path}`);
 	url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
 	if (params) {
 		for (const [key, value] of Object.entries(params)) {


### PR DESCRIPTION
## Summary

Two fixes from a relay debugging session (details in SUPER-427).

- **`fix(workspace-client)`**: `useWorkspaceWsUrl` was building terminal WS URLs with `new URL(path, hostUrl)`. WHATWG URL semantics resolve absolute paths against the origin, so with `hostUrl = "https://relay.superset.sh/hosts/<hostId>"` and `path = "/terminal/<id>"`, the result was `wss://relay.superset.sh/terminal/<id>` — the `/hosts/<hostId>` prefix got stripped, and the relay returned 404 because it only routes `/hosts/:hostId/*`. Observed in fly logs: `GET /terminal/<id> 404` back-to-back with a successful `POST /hosts/<hostId>/trpc/terminal.ensureSession 200`. Swap to `${hostUrl}${path}` so the prefix survives.
- **`fix(relay)`**: `TunnelManager.tunnels` is a per-process `Map`, so with 2+ fly replicas, `/hosts/:hostId/*` requests landing on a machine that doesn't own the tunnel return `503 "Host not connected"`. Prod was running 2 machines and failing ~50% of proxy traffic. Scaled live (`fly scale count 1`); this commit adds `max_machines_running = 1` so a future deploy doesn't resurrect the second machine. Proper fix (shared tunnel state over Redis/NATS) is SUPER-427.

## Test plan
- [x] `bun run lint` clean
- [x] `bun run --cwd packages/workspace-client typecheck` clean
- [x] `bun run --cwd apps/relay typecheck` clean
- [ ] Manual: after desktop release, open a v2 remote workspace terminal — fly logs should show `GET /hosts/<hostId>/terminal/<id> 101` (WS upgrade) instead of `GET /terminal/<id> 404`
- [ ] Manual: confirm prod relay stays at 1 machine across next deploy (`fly status -a superset-relay`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix terminal WebSocket routing by preserving the `/hosts/:hostId` prefix and pin the relay to a single Fly machine to prevent 404/503s. Mitigation for SUPER-427.

- **Bug Fixes**
  - `packages/workspace-client`: Build WS URLs via string concat so `/hosts/:hostId` is preserved; avoids 404s from dropped prefixes.
  - `apps/relay`: Set `max_machines_running = 1` in `fly.toml` to keep a single replica and prevent 503s from split in-memory tunnel state.

<sup>Written for commit 59fd75619e0f9949a112f217bede3e1572406104. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment infrastructure configuration to ensure stable operation with controlled resource allocation.
  * Improved internal WebSocket connection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->