### PR TITLE
feat(setup): write .envrc so direnv loads workspace .env on cd

### DIFF
--- a/.superset/lib/setup/main.sh
+++ b/.superset/lib/setup/main.sh
@@ -61,7 +61,12 @@ setup_main() {
     step_failed "Write .env file"
   fi
 
-  # Step 10: Setup local MCP in .mcp.json (opt-in)
+  # Step 10: Write .envrc file (loads .env via direnv on cd)
+  if ! step_write_envrc; then
+    step_failed "Write .envrc file"
+  fi
+
+  # Step 11: Setup local MCP in .mcp.json (opt-in)
   if [ "$SETUP_LOCAL_MCP" = "1" ]; then
     if ! step_setup_local_mcp; then
       step_failed "Setup local MCP"

--- a/.superset/lib/setup/steps.sh
+++ b/.superset/lib/setup/steps.sh
@@ -536,6 +536,21 @@ DEVVARS
   return 0
 }
 
+step_write_envrc() {
+  echo "📝 Writing .envrc file..."
+
+  cat > .envrc <<'ENVRC'
+dotenv
+ENVRC
+
+  if command -v direnv &> /dev/null; then
+    direnv allow . &> /dev/null || true
+  fi
+
+  success ".envrc written"
+  return 0
+}
+
 step_setup_local_mcp() {
   echo "🔌 Setting up local MCP server in .mcp.json..."
 


### PR DESCRIPTION
## Summary

- Adds a new `step_write_envrc` step to `.superset/lib/setup/steps.sh` that writes `.envrc` (contents: `dotenv`) into the workspace, so direnv auto-loads the per-workspace `.env` on `cd`
- Calls it from `main.sh` as Step 10, right after `step_write_env` (existing MCP step bumped to Step 11)
- If `direnv` is installed, the step also runs `direnv allow .` so the user doesn't have to

`step_write_env` already copies the root `.env` into each workspace and appends workspace-specific overrides (Neon branch URLs, ports, etc.), but direnv users still had to create `.envrc` manually to actually load it on `cd`. This closes that gap. `.envrc` is already in `.gitignore`, and devs who don't use direnv get a harmless 7-byte file.

## Test plan

- [ ] Run `.superset/setup.sh` in a fresh Conductor workspace — verify `.envrc` is created with contents `dotenv`
- [ ] With direnv installed, `cd` into the workspace in a new shell — verify direnv loads the workspace's `.env` (e.g. `NEON_BRANCH_ID` should be set)
- [ ] Without direnv installed, verify setup still completes successfully (the `direnv allow` call is guarded by `command -v direnv`)
- [ ] Verify existing setup behavior is unchanged (all other steps still run in order)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a setup step that writes `.envrc` so `direnv` auto-loads each workspace `.env` on cd. If `direnv` is present, it also auto-allows the file; otherwise, no impact.

- **New Features**
  - Added `step_write_envrc` and called it as Step 10 in `main.sh`; MCP setup moves to Step 11.
  - Creates `.envrc` with `dotenv` and runs `direnv allow .` when `direnv` is installed.

<sup>Written for commit 15e1f7c4691ee0718b17fdc8442b19e8e2482467. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved local development setup process with automatic environment configuration file generation to streamline development environment initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->