### PR TITLE
fix(desktop): stop spurious folder picker on settings → dashboard nav

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/AddRepositoryModals.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/AddRepositoryModals.tsx
@@ -1,59 +1,22 @@
 import { toast } from "@superset/ui/sonner";
-import { useEffect, useRef } from "react";
 import {
 	useAddRepositoryModalActive,
 	useCloseAddRepositoryModal,
-	useFolderImportTrigger,
 } from "renderer/stores/add-repository-modal";
-import { FolderFirstImportModal } from "./components/FolderFirstImportModal";
 import { NewProjectModal } from "./components/NewProjectModal";
-import { useFolderFirstImport } from "./hooks/useFolderFirstImport";
 
-// Mounted once at the dashboard layout so modal state lives in one place
-// and concurrent triggers can't race the folder-first state machine.
 export function AddRepositoryModals() {
 	const active = useAddRepositoryModalActive();
 	const close = useCloseAddRepositoryModal();
-	const folderImportTrigger = useFolderImportTrigger();
-
-	const folderImport = useFolderFirstImport({
-		onSuccess: () => {
-			toast.success("Project ready — open it from the sidebar.");
-		},
-		onError: (message) => {
-			toast.error(`Import failed: ${message}`);
-		},
-	});
-
-	// A counter (not boolean) so successive clicks re-invoke. Depend only on
-	// the counter — folderImport.start's identity changes every render, so
-	// including it would refire the effect mid-flow and re-open the picker.
-	const startRef = useRef(folderImport.start);
-	startRef.current = folderImport.start;
-	useEffect(() => {
-		if (folderImportTrigger === 0) return;
-		startRef.current().catch((err) => {
-			toast.error(
-				`Import failed: ${err instanceof Error ? err.message : String(err)}`,
-			);
-		});
-	}, [folderImportTrigger]);
 
 	return (
-		<>
-			<NewProjectModal
-				open={active.kind === "new-project"}
-				onOpenChange={(open) => {
-					if (!open) close();
-				}}
-				onSuccess={() => toast.success("Project created.")}
-				onError={(message) => toast.error(`Create failed: ${message}`)}
-			/>
-			<FolderFirstImportModal
-				state={folderImport.state}
-				onCancel={folderImport.cancel}
-				onConfirmCreateAsNew={folderImport.confirmCreateAsNew}
-			/>
-		</>
+		<NewProjectModal
+			open={active.kind === "new-project"}
+			onOpenChange={(open) => {
+				if (!open) close();
+			}}
+			onSuccess={() => toast.success("Project created.")}
+			onError={(message) => toast.error(`Create failed: ${message}`)}
+		/>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -47,13 +47,6 @@ export function DashboardSidebarHeader({
 			toast.error(`Import failed: ${message}`);
 		},
 	});
-	const handleImportFolder = () => {
-		folderImport.start().catch((err) => {
-			toast.error(
-				`Import failed: ${err instanceof Error ? err.message : String(err)}`,
-			);
-		});
-	};
 	const shortcutText = useHotkeyDisplay("NEW_WORKSPACE").text;
 	const navigate = useNavigate();
 	const matchRoute = useMatchRoute();
@@ -153,7 +146,7 @@ export function DashboardSidebarHeader({
 							<HiMiniPlus className="size-4" />
 							New project
 						</DropdownMenuItem>
-						<DropdownMenuItem onSelect={handleImportFolder}>
+						<DropdownMenuItem onSelect={() => folderImport.start()}>
 							<LuFolderInput className="size-4" />
 							Import existing folder
 						</DropdownMenuItem>
@@ -230,7 +223,7 @@ export function DashboardSidebarHeader({
 							<HiMiniPlus className="size-4" />
 							New project
 						</DropdownMenuItem>
-						<DropdownMenuItem onSelect={handleImportFolder}>
+						<DropdownMenuItem onSelect={() => folderImport.start()}>
 							<LuFolderInput className="size-4" />
 							Import existing folder
 						</DropdownMenuItem>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -6,6 +6,7 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
+import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { useMatchRoute, useNavigate } from "@tanstack/react-router";
@@ -21,13 +22,12 @@ import {
 import { GATED_FEATURES, usePaywall } from "renderer/components/Paywall";
 import { useCurrentPlan } from "renderer/hooks/useCurrentPlan";
 import { useHotkeyDisplay } from "renderer/hotkeys";
+import { FolderFirstImportModal } from "renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/components/FolderFirstImportModal";
+import { useFolderFirstImport } from "renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport";
 import { OrganizationDropdown } from "renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown";
 import { useTasksFilterStore } from "renderer/routes/_authenticated/_dashboard/tasks/stores/tasks-filter-state";
 import { STROKE_WIDTH_THICK } from "renderer/screens/main/components/WorkspaceSidebar/constants";
-import {
-	useOpenNewProjectModal,
-	useTriggerFolderImport,
-} from "renderer/stores/add-repository-modal";
+import { useOpenNewProjectModal } from "renderer/stores/add-repository-modal";
 import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
 
 interface DashboardSidebarHeaderProps {
@@ -39,7 +39,21 @@ export function DashboardSidebarHeader({
 }: DashboardSidebarHeaderProps) {
 	const openModal = useOpenNewWorkspaceModal();
 	const openNewProject = useOpenNewProjectModal();
-	const triggerFolderImport = useTriggerFolderImport();
+	const folderImport = useFolderFirstImport({
+		onSuccess: () => {
+			toast.success("Project ready — open it from the sidebar.");
+		},
+		onError: (message) => {
+			toast.error(`Import failed: ${message}`);
+		},
+	});
+	const handleImportFolder = () => {
+		folderImport.start().catch((err) => {
+			toast.error(
+				`Import failed: ${err instanceof Error ? err.message : String(err)}`,
+			);
+		});
+	};
 	const shortcutText = useHotkeyDisplay("NEW_WORKSPACE").text;
 	const navigate = useNavigate();
 	const matchRoute = useMatchRoute();
@@ -139,7 +153,7 @@ export function DashboardSidebarHeader({
 							<HiMiniPlus className="size-4" />
 							New project
 						</DropdownMenuItem>
-						<DropdownMenuItem onSelect={triggerFolderImport}>
+						<DropdownMenuItem onSelect={handleImportFolder}>
 							<LuFolderInput className="size-4" />
 							Import existing folder
 						</DropdownMenuItem>
@@ -180,6 +194,12 @@ export function DashboardSidebarHeader({
 						New Workspace ({shortcutText})
 					</TooltipContent>
 				</Tooltip>
+
+				<FolderFirstImportModal
+					state={folderImport.state}
+					onCancel={folderImport.cancel}
+					onConfirmCreateAsNew={folderImport.confirmCreateAsNew}
+				/>
 			</div>
 		);
 	}
@@ -210,7 +230,7 @@ export function DashboardSidebarHeader({
 							<HiMiniPlus className="size-4" />
 							New project
 						</DropdownMenuItem>
-						<DropdownMenuItem onSelect={triggerFolderImport}>
+						<DropdownMenuItem onSelect={handleImportFolder}>
 							<LuFolderInput className="size-4" />
 							Import existing folder
 						</DropdownMenuItem>
@@ -278,6 +298,12 @@ export function DashboardSidebarHeader({
 					{shortcutText}
 				</span>
 			</button>
+
+			<FolderFirstImportModal
+				state={folderImport.state}
+				onCancel={folderImport.cancel}
+				onConfirmCreateAsNew={folderImport.confirmCreateAsNew}
+			/>
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/stores/add-repository-modal.ts
+++ b/apps/desktop/src/renderer/stores/add-repository-modal.ts
@@ -5,13 +5,7 @@ type ActiveModal = { kind: "none" } | { kind: "new-project" };
 
 interface AddRepositoryModalState {
 	active: ActiveModal;
-	// Monotonically increasing counter; bumping it signals the host
-	// component to run the folder-first import flow (which is owned by a
-	// useFolderFirstImport hook — hooks can't live in a zustand store, so we
-	// use a trigger pulse instead).
-	folderImportTrigger: number;
 	openNewProject: () => void;
-	triggerFolderImport: () => void;
 	close: () => void;
 }
 
@@ -19,12 +13,7 @@ export const useAddRepositoryModalStore = create<AddRepositoryModalState>()(
 	devtools(
 		(set) => ({
 			active: { kind: "none" },
-			folderImportTrigger: 0,
 			openNewProject: () => set({ active: { kind: "new-project" } }),
-			triggerFolderImport: () =>
-				set((state) => ({
-					folderImportTrigger: state.folderImportTrigger + 1,
-				})),
 			close: () => set({ active: { kind: "none" } }),
 		}),
 		{ name: "add-repository-modal" },
@@ -33,11 +22,7 @@ export const useAddRepositoryModalStore = create<AddRepositoryModalState>()(
 
 export const useAddRepositoryModalActive = () =>
 	useAddRepositoryModalStore((state) => state.active);
-export const useFolderImportTrigger = () =>
-	useAddRepositoryModalStore((state) => state.folderImportTrigger);
 export const useOpenNewProjectModal = () =>
 	useAddRepositoryModalStore((state) => state.openNewProject);
-export const useTriggerFolderImport = () =>
-	useAddRepositoryModalStore((state) => state.triggerFolderImport);
 export const useCloseAddRepositoryModal = () =>
 	useAddRepositoryModalStore((state) => state.close);


### PR DESCRIPTION
## Summary
- Folder picker was opening unprompted every time the user navigated from Settings back to the dashboard, once they had ever used "Import existing folder" in the session.
- Root cause: folder-first import was wired through a zustand counter + `useEffect` in `AddRepositoryModals`. Settings lives outside `_dashboard`, so returning to the dashboard remounted `AddRepositoryModals`, and the effect fired again with the already-incremented counter.
- Fix: delete the pulse. `DashboardSidebarHeader` now owns `useFolderFirstImport` and renders `FolderFirstImportModal`; the dropdown item calls `folderImport.start()` directly on click.

## Why / Context
The "pulse via counter + effect" pattern is the wrong shape for "invoke this imperative thing on user click." `useEffect` fires on every mount regardless of whether the dep actually changed since last render — it has no memory of the prior mount's value. A module-scoped counter that outlives the component is therefore indistinguishable from an increment on remount, and the existing `=== 0` guard only caught the pristine initial-load case.

The only reason the indirection existed was that the header didn't have a reference to the hook instance owned by `AddRepositoryModals`. Collapsing both into the header removes that coupling entirely.

## How It Works
- `DashboardSidebarHeader` calls `useFolderFirstImport({ onSuccess, onError })` directly and renders `<FolderFirstImportModal>` (Dialog portals, so DOM position doesn't matter).
- Both "Import existing folder" dropdown items (collapsed + expanded variants) use `onSelect={handleImportFolder}`, which calls `folderImport.start()` and toasts on rejection.
- `AddRepositoryModals` now only owns `NewProjectModal`.
- `folderImportTrigger`, `triggerFolderImport`, `useFolderImportTrigger`, `useTriggerFolderImport` removed from the zustand store.

## Manual QA Checklist
- [ ] Click "Import existing folder" in the sidebar dropdown — native directory picker opens.
- [ ] Cancel picker — no modal, no toast.
- [ ] Pick a folder with no matching project — "Create as new" modal appears.
- [ ] Pick a folder with a single matching project — setup runs, success toast.
- [ ] After importing once, navigate to Settings and back — **picker does not open**.
- [ ] Repeat the settings → dashboard round-trip several times — still no picker.
- [ ] "New project" dropdown item still opens `NewProjectModal`.
- [ ] Both collapsed and expanded sidebar variants behave the same.

## Testing
- `bun run typecheck` ✅

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the folder picker opening unexpectedly when returning from Settings to the dashboard. The folder import flow is now triggered directly on click in the sidebar header, so remounts no longer reopen the picker.

- **Bug Fixes**
  - Stop the native directory picker from reopening on dashboard remounts.
  - Replace the zustand counter + `useEffect` trigger with direct `folderImport.start()` on dropdown item click.
  - Move `useFolderFirstImport` and `FolderFirstImportModal` into the dashboard sidebar header.

- **Refactors**
  - `AddRepositoryModals` now only renders `NewProjectModal`.
  - Remove `folderImportTrigger` and related selectors from the `add-repository-modal` store.
  - Handle success/error toasts in the header.
  - Drop redundant promise catch around `folderImport.start()`; errors are handled by the hook.

<sup>Written for commit 30a9b0ea722cd923f8695fbdd50184b1c621a268. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added success and error toast notifications for folder import actions.

* **Bug Fixes**
  * Fixed duplicate/errant folder-import triggers and improved error handling during imports.

* **Refactor**
  * Moved the folder-first import flow out of the Add Repository modal into the sidebar and simplified modal behavior; cleaned up related state management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->