### PR TITLE
fix(desktop): wrap and truncate long workspace names in v1 hover card

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/WorkspaceHoverCard.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/WorkspaceHoverCard.tsx
@@ -71,7 +71,9 @@ export function WorkspaceHoverCardContent({
 		<div className="space-y-3">
 			<div className="space-y-1.5">
 				{hasCustomAlias && (
-					<div className="text-sm font-medium">{workspaceAlias}</div>
+					<div className="text-sm font-medium break-words line-clamp-2">
+						{workspaceAlias}
+					</div>
 				)}
 				{branchName && (
 					<div className="space-y-0.5">


### PR DESCRIPTION
## Summary
- Long workspace aliases overflowed the v1 `WorkspaceHoverCard` because the name div had no wrapping or clamp.
- Added `break-words line-clamp-2` to the alias div so names wrap inside the `w-72` hover card and truncate with an ellipsis after 2 lines.

## Test plan
- [x] Create/rename a workspace with a very long alias and hover its sidebar item in v1
- [x] Confirm the hover card no longer overflows horizontally
- [x] Confirm names longer than 2 lines are truncated with an ellipsis

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent long workspace aliases from overflowing the v1 Workspace hover card. Alias text now wraps inside the card and truncates after two lines with an ellipsis.

<sup>Written for commit 4c6373824a52f5d9b390c6cb64a856820c0e0334. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved workspace alias display by enabling text wrapping and limiting custom aliases to two lines for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->