### PR TITLE
feat(desktop): add v2 projects list and detail pages

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -14,6 +14,7 @@ import { useFeatureFlagEnabled } from "posthog-js/react";
 import { HiMiniPlus, HiOutlineClipboardDocumentList } from "react-icons/hi2";
 import {
 	LuClock,
+	LuFolderGit2,
 	LuFolderInput,
 	LuFolderPlus,
 	LuLayers,
@@ -52,6 +53,7 @@ export function DashboardSidebarHeader({
 	const matchRoute = useMatchRoute();
 	const { gateFeature } = usePaywall();
 	const isWorkspacesListOpen = !!matchRoute({ to: "/v2-workspaces" });
+	const isProjectsListOpen = !!matchRoute({ to: "/v2-projects" });
 	const isTasksOpen = !!matchRoute({ to: "/tasks", fuzzy: true });
 	const isAutomationsOpen = !!matchRoute({ to: "/automations", fuzzy: true });
 
@@ -69,6 +71,10 @@ export function DashboardSidebarHeader({
 
 	const handleWorkspacesClick = () => {
 		navigate({ to: "/v2-workspaces" });
+	};
+
+	const handleProjectsClick = () => {
+		navigate({ to: "/v2-projects" });
 	};
 
 	const handleAutomationsClick = () => {
@@ -106,6 +112,24 @@ export function DashboardSidebarHeader({
 						</button>
 					</TooltipTrigger>
 					<TooltipContent side="right">Workspaces</TooltipContent>
+				</Tooltip>
+
+				<Tooltip delayDuration={300}>
+					<TooltipTrigger asChild>
+						<button
+							type="button"
+							onClick={handleProjectsClick}
+							className={cn(
+								"flex size-8 items-center justify-center rounded-md transition-colors",
+								isProjectsListOpen
+									? "bg-accent text-foreground"
+									: "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+							)}
+						>
+							<LuFolderGit2 className="size-4" />
+						</button>
+					</TooltipTrigger>
+					<TooltipContent side="right">Projects</TooltipContent>
 				</Tooltip>
 
 				<Tooltip delayDuration={300}>
@@ -243,6 +267,20 @@ export function DashboardSidebarHeader({
 			>
 				<LuLayers className="size-4 shrink-0" />
 				<span className="flex-1 text-left">Workspaces</span>
+			</button>
+
+			<button
+				type="button"
+				onClick={handleProjectsClick}
+				className={cn(
+					"flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium transition-colors",
+					isProjectsListOpen
+						? "bg-accent text-foreground"
+						: "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+				)}
+			>
+				<LuFolderGit2 className="size-4 shrink-0" />
+				<span className="flex-1 text-left">Projects</span>
 			</button>
 
 			{showAutomations && (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-project/$projectId/components/V2ProjectDetailHeader/V2ProjectDetailHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-project/$projectId/components/V2ProjectDetailHeader/V2ProjectDetailHeader.tsx
@@ -1,0 +1,233 @@
+import { Button } from "@superset/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import { Input } from "@superset/ui/input";
+import { toast } from "@superset/ui/sonner";
+import { cn } from "@superset/ui/utils";
+import { useNavigate } from "@tanstack/react-router";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { HiEllipsisHorizontal } from "react-icons/hi2";
+import {
+	LuArrowLeft,
+	LuExternalLink,
+	LuFolderGit2,
+	LuGithub,
+	LuPencil,
+	LuPlus,
+	LuSettings,
+} from "react-icons/lu";
+import { apiTrpcClient } from "renderer/lib/api-trpc-client";
+import type { AccessibleV2Project } from "renderer/routes/_authenticated/_dashboard/v2-projects/hooks/useAccessibleV2Projects";
+import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
+
+interface V2ProjectDetailHeaderProps {
+	project: AccessibleV2Project;
+}
+
+export function V2ProjectDetailHeader({ project }: V2ProjectDetailHeaderProps) {
+	const navigate = useNavigate();
+	const openNewWorkspaceModal = useOpenNewWorkspaceModal();
+
+	const [isRenaming, setIsRenaming] = useState(false);
+	const [renameValue, setRenameValue] = useState(project.name);
+	const [isSaving, setIsSaving] = useState(false);
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	useEffect(() => {
+		if (!isRenaming) setRenameValue(project.name);
+	}, [project.name, isRenaming]);
+
+	useEffect(() => {
+		if (isRenaming) {
+			inputRef.current?.focus();
+			inputRef.current?.select();
+		}
+	}, [isRenaming]);
+
+	const repoFullName =
+		project.githubFullName ??
+		(project.githubOwner && project.githubRepoName
+			? `${project.githubOwner}/${project.githubRepoName}`
+			: null);
+
+	const startRename = useCallback(() => {
+		setRenameValue(project.name);
+		setIsRenaming(true);
+	}, [project.name]);
+
+	const cancelRename = useCallback(() => {
+		setIsRenaming(false);
+		setRenameValue(project.name);
+	}, [project.name]);
+
+	const submitRename = useCallback(async () => {
+		const trimmed = renameValue.trim();
+		if (!trimmed || trimmed === project.name) {
+			cancelRename();
+			return;
+		}
+		setIsSaving(true);
+		try {
+			await apiTrpcClient.v2Project.update.mutate({
+				id: project.id,
+				name: trimmed,
+				slug: trimmed.toLowerCase().replace(/\s+/g, "-"),
+			});
+			setIsRenaming(false);
+		} catch (error) {
+			toast.error(
+				`Failed to rename: ${error instanceof Error ? error.message : "Unknown error"}`,
+			);
+		} finally {
+			setIsSaving(false);
+		}
+	}, [cancelRename, project.id, project.name, renameValue]);
+
+	const goToSettings = () => {
+		navigate({
+			to: "/settings/project/$projectId",
+			params: { projectId: project.id },
+		});
+	};
+
+	return (
+		<div className="flex flex-col gap-3 border-b border-border/50 px-4 py-3">
+			<div className="flex items-center gap-2 text-xs text-muted-foreground">
+				<Button
+					variant="ghost"
+					size="sm"
+					className="h-6 gap-1 px-1.5 text-xs"
+					onClick={() => navigate({ to: "/v2-projects" })}
+				>
+					<LuArrowLeft className="size-3.5" />
+					All projects
+				</Button>
+			</div>
+
+			<div className="flex items-start justify-between gap-3">
+				<div className="flex min-w-0 items-center gap-3">
+					<div className="flex size-9 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+						<LuFolderGit2 className="size-4" />
+					</div>
+					<div className="flex min-w-0 flex-col gap-0.5">
+						{isRenaming ? (
+							<Input
+								ref={inputRef}
+								value={renameValue}
+								onChange={(event) => setRenameValue(event.target.value)}
+								onBlur={() => {
+									void submitRename();
+								}}
+								onKeyDown={(event) => {
+									if (event.key === "Enter") {
+										event.preventDefault();
+										void submitRename();
+									} else if (event.key === "Escape") {
+										event.preventDefault();
+										cancelRename();
+									}
+								}}
+								disabled={isSaving}
+								className={cn(
+									"h-7 w-64 px-2 text-sm font-semibold",
+									isSaving && "opacity-60",
+								)}
+								aria-label="Project name"
+							/>
+						) : (
+							<button
+								type="button"
+								onClick={startRename}
+								className="group flex items-center gap-1.5 text-left text-sm font-semibold hover:text-foreground"
+							>
+								<span className="truncate">{project.name}</span>
+								<LuPencil className="size-3 opacity-0 transition-opacity group-hover:opacity-60" />
+							</button>
+						)}
+						<span className="truncate text-xs text-muted-foreground">
+							{project.slug}
+						</span>
+					</div>
+				</div>
+
+				<div className="flex shrink-0 items-center gap-2">
+					<Button
+						size="sm"
+						className="h-8 gap-1.5"
+						onClick={() => openNewWorkspaceModal(project.id)}
+					>
+						<LuPlus className="size-4" />
+						New workspace
+					</Button>
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild>
+							<Button
+								variant="outline"
+								size="icon"
+								className="size-8"
+								aria-label="Project options"
+							>
+								<HiEllipsisHorizontal className="size-4" />
+							</Button>
+						</DropdownMenuTrigger>
+						<DropdownMenuContent align="end">
+							<DropdownMenuItem onSelect={startRename}>
+								<LuPencil className="size-4" />
+								Rename
+							</DropdownMenuItem>
+							<DropdownMenuItem onSelect={goToSettings}>
+								<LuSettings className="size-4" />
+								Project settings
+							</DropdownMenuItem>
+							{repoFullName ? (
+								<>
+									<DropdownMenuSeparator />
+									<DropdownMenuItem asChild>
+										<a
+											href={`https://github.com/${repoFullName}`}
+											target="_blank"
+											rel="noopener noreferrer"
+										>
+											<LuExternalLink className="size-4" />
+											View on GitHub
+										</a>
+									</DropdownMenuItem>
+								</>
+							) : null}
+						</DropdownMenuContent>
+					</DropdownMenu>
+				</div>
+			</div>
+
+			{/* Meta row */}
+			<div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+				{repoFullName ? (
+					<a
+						href={`https://github.com/${repoFullName}`}
+						target="_blank"
+						rel="noopener noreferrer"
+						className="inline-flex items-center gap-1.5 hover:text-foreground"
+					>
+						<LuGithub className="size-3.5" />
+						<span>{repoFullName}</span>
+						<LuExternalLink className="size-3" />
+					</a>
+				) : (
+					<button
+						type="button"
+						onClick={goToSettings}
+						className="inline-flex items-center gap-1.5 text-primary hover:underline"
+					>
+						<LuGithub className="size-3.5" />
+						Connect Git Repository
+					</button>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-project/$projectId/components/V2ProjectDetailHeader/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-project/$projectId/components/V2ProjectDetailHeader/index.ts
@@ -1,0 +1,1 @@
+export { V2ProjectDetailHeader } from "./V2ProjectDetailHeader";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-project/$projectId/components/V2ProjectDetailWorkspaces/V2ProjectDetailWorkspaces.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-project/$projectId/components/V2ProjectDetailWorkspaces/V2ProjectDetailWorkspaces.tsx
@@ -1,0 +1,88 @@
+import { Button } from "@superset/ui/button";
+import {
+	Empty,
+	EmptyContent,
+	EmptyDescription,
+	EmptyHeader,
+	EmptyMedia,
+	EmptyTitle,
+} from "@superset/ui/empty";
+import { ItemGroup } from "@superset/ui/item";
+import { ScrollArea } from "@superset/ui/scroll-area";
+import { useMatchRoute } from "@tanstack/react-router";
+import { LuLayers, LuPlus } from "react-icons/lu";
+import { V2WorkspaceRow } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow";
+import type { AccessibleV2Workspace } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces";
+import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
+
+interface V2ProjectDetailWorkspacesProps {
+	projectId: string;
+	workspaces: AccessibleV2Workspace[];
+}
+
+export function V2ProjectDetailWorkspaces({
+	projectId,
+	workspaces,
+}: V2ProjectDetailWorkspacesProps) {
+	const matchRoute = useMatchRoute();
+	const currentWorkspaceMatch = matchRoute({
+		to: "/v2-workspace/$workspaceId",
+	});
+	const currentWorkspaceId =
+		currentWorkspaceMatch !== false ? currentWorkspaceMatch.workspaceId : null;
+	const openNewWorkspaceModal = useOpenNewWorkspaceModal();
+
+	if (workspaces.length === 0) {
+		return (
+			<Empty className="flex-1 border-0">
+				<EmptyHeader>
+					<EmptyMedia
+						variant="icon"
+						className="size-14 [&_svg:not([class*='size-'])]:size-7"
+					>
+						<LuLayers />
+					</EmptyMedia>
+					<EmptyTitle>No workspaces yet</EmptyTitle>
+					<EmptyDescription>
+						Create a workspace to start coding in this project.
+					</EmptyDescription>
+				</EmptyHeader>
+				<EmptyContent>
+					<Button
+						size="sm"
+						className="gap-1.5"
+						onClick={() => openNewWorkspaceModal(projectId)}
+					>
+						<LuPlus className="size-4" />
+						New workspace
+					</Button>
+				</EmptyContent>
+			</Empty>
+		);
+	}
+
+	return (
+		<ScrollArea className="min-h-0 flex-1">
+			<div className="flex flex-col gap-3 px-4 py-4">
+				<div className="flex items-baseline gap-2">
+					<h2 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+						Workspaces
+					</h2>
+					<span className="text-xs text-muted-foreground/70">
+						{workspaces.length}
+					</span>
+				</div>
+				<ItemGroup className="gap-2">
+					{workspaces.map((workspace) => (
+						<V2WorkspaceRow
+							key={workspace.id}
+							workspace={workspace}
+							showProjectName={false}
+							isCurrentRoute={workspace.id === currentWorkspaceId}
+						/>
+					))}
+				</ItemGroup>
+			</div>
+		</ScrollArea>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-project/$projectId/components/V2ProjectDetailWorkspaces/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-project/$projectId/components/V2ProjectDetailWorkspaces/index.ts
@@ -1,0 +1,1 @@
+export { V2ProjectDetailWorkspaces } from "./V2ProjectDetailWorkspaces";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-project/$projectId/hooks/useV2ProjectDetail/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-project/$projectId/hooks/useV2ProjectDetail/index.ts
@@ -1,0 +1,2 @@
+export type { UseV2ProjectDetailResult } from "./useV2ProjectDetail";
+export { useV2ProjectDetail } from "./useV2ProjectDetail";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-project/$projectId/hooks/useV2ProjectDetail/useV2ProjectDetail.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-project/$projectId/hooks/useV2ProjectDetail/useV2ProjectDetail.ts
@@ -1,0 +1,43 @@
+import { useMemo } from "react";
+import {
+	type AccessibleV2Project,
+	useAccessibleV2Projects,
+} from "renderer/routes/_authenticated/_dashboard/v2-projects/hooks/useAccessibleV2Projects";
+import {
+	type AccessibleV2Workspace,
+	useAccessibleV2Workspaces,
+} from "renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces";
+
+export interface UseV2ProjectDetailResult {
+	project: AccessibleV2Project | null;
+	workspaces: AccessibleV2Workspace[];
+	isLoading: boolean;
+}
+
+export function useV2ProjectDetail(
+	projectId: string,
+): UseV2ProjectDetailResult {
+	const allProjects = useAccessibleV2Projects();
+	const { all: allWorkspaces } = useAccessibleV2Workspaces();
+
+	const project = useMemo(
+		() => allProjects.find((p) => p.id === projectId) ?? null,
+		[allProjects, projectId],
+	);
+
+	const workspaces = useMemo(
+		() =>
+			allWorkspaces
+				.filter((w) => w.projectId === projectId)
+				.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime()),
+		[allWorkspaces, projectId],
+	);
+
+	return {
+		project,
+		workspaces,
+		// Electric collections hydrate asynchronously; treat "empty project list"
+		// as still-loading so we don't flash NotFound before sync completes.
+		isLoading: allProjects.length === 0 && project === null,
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-project/$projectId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-project/$projectId/page.tsx
@@ -1,0 +1,56 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { LuFolderGit2 } from "react-icons/lu";
+import { V2ProjectDetailHeader } from "./components/V2ProjectDetailHeader";
+import { V2ProjectDetailWorkspaces } from "./components/V2ProjectDetailWorkspaces";
+import { useV2ProjectDetail } from "./hooks/useV2ProjectDetail";
+
+export const Route = createFileRoute(
+	"/_authenticated/_dashboard/v2-project/$projectId/",
+)({
+	component: V2ProjectDetailPage,
+});
+
+function V2ProjectDetailPage() {
+	const { projectId } = Route.useParams();
+	const { project, workspaces, isLoading } = useV2ProjectDetail(projectId);
+
+	if (isLoading) {
+		return (
+			<div className="flex h-full w-full flex-1 flex-col bg-card" aria-busy>
+				<div className="flex flex-col gap-3 border-b border-border/50 px-4 py-3">
+					<div className="h-4 w-24 animate-pulse rounded bg-muted" />
+					<div className="flex items-center gap-3">
+						<div className="size-9 animate-pulse rounded-md bg-muted" />
+						<div className="flex flex-col gap-1.5">
+							<div className="h-4 w-48 animate-pulse rounded bg-muted" />
+							<div className="h-3 w-24 animate-pulse rounded bg-muted" />
+						</div>
+					</div>
+				</div>
+			</div>
+		);
+	}
+
+	if (!project) {
+		return (
+			<div className="flex h-full flex-1 flex-col items-center justify-center gap-2 bg-card p-8 text-center">
+				<LuFolderGit2 className="size-8 text-muted-foreground" />
+				<h1 className="text-base font-semibold">Project not found</h1>
+				<p className="max-w-sm text-sm text-muted-foreground">
+					This project may have been deleted, or you might not be a member of
+					the organization that owns it.
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex h-full w-full flex-1 flex-col overflow-hidden bg-card">
+			<V2ProjectDetailHeader project={project} />
+			<V2ProjectDetailWorkspaces
+				projectId={project.id}
+				workspaces={workspaces}
+			/>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-projects/components/V2ProjectRow/V2ProjectRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-projects/components/V2ProjectRow/V2ProjectRow.tsx
@@ -1,0 +1,181 @@
+import {
+	ContextMenu,
+	ContextMenuContent,
+	ContextMenuItem,
+	ContextMenuSeparator,
+	ContextMenuTrigger,
+} from "@superset/ui/context-menu";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import { cn } from "@superset/ui/utils";
+import { useNavigate } from "@tanstack/react-router";
+import { HiEllipsisHorizontal } from "react-icons/hi2";
+import {
+	LuExternalLink,
+	LuFolderGit2,
+	LuGithub,
+	LuPlus,
+	LuSettings,
+} from "react-icons/lu";
+import type { AccessibleV2Project } from "renderer/routes/_authenticated/_dashboard/v2-projects/hooks/useAccessibleV2Projects";
+import { getRelativeTime } from "renderer/screens/main/components/WorkspacesListView/utils";
+import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
+
+interface V2ProjectRowProps {
+	project: AccessibleV2Project;
+}
+
+export function V2ProjectRow({ project }: V2ProjectRowProps) {
+	const navigate = useNavigate();
+	const openNewWorkspaceModal = useOpenNewWorkspaceModal();
+
+	const goToProject = () => {
+		navigate({
+			to: "/v2-project/$projectId",
+			params: { projectId: project.id },
+		});
+	};
+
+	const goToSettings = () => {
+		navigate({
+			to: "/settings/project/$projectId",
+			params: { projectId: project.id },
+		});
+	};
+
+	const repoFullName =
+		project.githubFullName ??
+		(project.githubOwner && project.githubRepoName
+			? `${project.githubOwner}/${project.githubRepoName}`
+			: null);
+
+	return (
+		<ContextMenu>
+			<ContextMenuTrigger asChild>
+				<div className="group relative flex items-center border-b border-border/50 text-sm transition-colors hover:bg-background/50">
+					<button
+						type="button"
+						onClick={goToProject}
+						aria-label={`Open ${project.name}`}
+						className="absolute inset-0 z-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+					/>
+
+					{/* Name column */}
+					<div className="pointer-events-none relative z-10 flex min-w-0 flex-1 items-center gap-2.5 px-4 py-2">
+						<LuFolderGit2
+							className="size-4 shrink-0 text-muted-foreground"
+							aria-hidden
+						/>
+						<div className="flex min-w-0 flex-col">
+							<span className="truncate font-medium">{project.name}</span>
+							<span className="truncate text-xs text-muted-foreground">
+								{project.slug}
+							</span>
+						</div>
+					</div>
+
+					{/* Repository column */}
+					<div className="pointer-events-none relative z-10 hidden w-56 items-center gap-1.5 px-3 py-2 text-xs text-muted-foreground md:flex">
+						{repoFullName ? (
+							<>
+								<LuGithub className="size-3.5 shrink-0" />
+								<span className="truncate">{repoFullName}</span>
+							</>
+						) : (
+							<span className="italic text-muted-foreground/60">
+								No repository
+							</span>
+						)}
+					</div>
+
+					{/* Workspaces column */}
+					<div className="pointer-events-none relative z-10 w-28 px-3 py-2 text-xs tabular-nums text-muted-foreground">
+						{project.workspaceCount}{" "}
+						{project.workspaceCount === 1 ? "workspace" : "workspaces"}
+					</div>
+
+					{/* Updated column */}
+					<div className="pointer-events-none relative z-10 w-32 px-3 py-2 text-xs text-muted-foreground">
+						{getRelativeTime(project.updatedAt.getTime())}
+					</div>
+
+					{/* Actions column */}
+					<div className="relative z-10 flex w-12 items-center justify-end pr-3">
+						<DropdownMenu>
+							<DropdownMenuTrigger asChild>
+								<button
+									type="button"
+									aria-label="Project options"
+									className={cn(
+										"flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors",
+										"opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
+										"hover:bg-accent/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+									)}
+								>
+									<HiEllipsisHorizontal className="size-4" />
+								</button>
+							</DropdownMenuTrigger>
+							<DropdownMenuContent align="end">
+								<DropdownMenuItem onSelect={goToSettings}>
+									<LuSettings className="size-4" />
+									Project settings
+								</DropdownMenuItem>
+								<DropdownMenuItem
+									onSelect={() => openNewWorkspaceModal(project.id)}
+								>
+									<LuPlus className="size-4" />
+									New workspace
+								</DropdownMenuItem>
+								{repoFullName ? (
+									<>
+										<DropdownMenuSeparator />
+										<DropdownMenuItem asChild>
+											<a
+												href={`https://github.com/${repoFullName}`}
+												target="_blank"
+												rel="noopener noreferrer"
+											>
+												<LuExternalLink className="size-4" />
+												View on GitHub
+											</a>
+										</DropdownMenuItem>
+									</>
+								) : null}
+							</DropdownMenuContent>
+						</DropdownMenu>
+					</div>
+				</div>
+			</ContextMenuTrigger>
+			<ContextMenuContent>
+				<ContextMenuItem onSelect={goToSettings}>
+					<LuSettings className="size-4" />
+					Project settings
+				</ContextMenuItem>
+				<ContextMenuItem onSelect={() => openNewWorkspaceModal(project.id)}>
+					<LuPlus className="size-4" />
+					New workspace
+				</ContextMenuItem>
+				{repoFullName ? (
+					<>
+						<ContextMenuSeparator />
+						<ContextMenuItem asChild>
+							<a
+								href={`https://github.com/${repoFullName}`}
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								<LuExternalLink className="size-4" />
+								View on GitHub
+							</a>
+						</ContextMenuItem>
+					</>
+				) : null}
+			</ContextMenuContent>
+		</ContextMenu>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-projects/components/V2ProjectRow/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-projects/components/V2ProjectRow/index.ts
@@ -1,0 +1,1 @@
+export { V2ProjectRow } from "./V2ProjectRow";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-projects/components/V2ProjectsHeader/V2ProjectsHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-projects/components/V2ProjectsHeader/V2ProjectsHeader.tsx
@@ -1,0 +1,43 @@
+import { Button } from "@superset/ui/button";
+import { Input } from "@superset/ui/input";
+import { HiMiniPlus } from "react-icons/hi2";
+import { LuSearch } from "react-icons/lu";
+import { useV2ProjectsFilterStore } from "renderer/routes/_authenticated/_dashboard/v2-projects/stores/v2ProjectsFilterStore";
+import { useOpenNewProjectModal } from "renderer/stores/add-repository-modal";
+
+interface V2ProjectsHeaderProps {
+	totalCount: number;
+}
+
+export function V2ProjectsHeader({ totalCount }: V2ProjectsHeaderProps) {
+	const searchQuery = useV2ProjectsFilterStore((state) => state.searchQuery);
+	const setSearchQuery = useV2ProjectsFilterStore(
+		(state) => state.setSearchQuery,
+	);
+	const openNewProject = useOpenNewProjectModal();
+
+	return (
+		<div className="flex items-center gap-3 border-b border-border/50 px-4 py-2">
+			<div className="flex items-center gap-2">
+				<h1 className="text-sm font-semibold">Projects</h1>
+				<span className="text-xs text-muted-foreground">{totalCount}</span>
+			</div>
+
+			<div className="relative flex-1">
+				<LuSearch className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-foreground/50" />
+				<Input
+					type="search"
+					placeholder="Search projects..."
+					value={searchQuery}
+					onChange={(event) => setSearchQuery(event.target.value)}
+					className="h-8 bg-background/50 pl-9"
+				/>
+			</div>
+
+			<Button size="sm" onClick={openNewProject} className="h-8 gap-1.5">
+				<HiMiniPlus className="size-4" />
+				New project
+			</Button>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-projects/components/V2ProjectsHeader/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-projects/components/V2ProjectsHeader/index.ts
@@ -1,0 +1,1 @@
+export { V2ProjectsHeader } from "./V2ProjectsHeader";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-projects/components/V2ProjectsList/V2ProjectsList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-projects/components/V2ProjectsList/V2ProjectsList.tsx
@@ -1,0 +1,84 @@
+import { Button } from "@superset/ui/button";
+import {
+	Empty,
+	EmptyContent,
+	EmptyDescription,
+	EmptyHeader,
+	EmptyMedia,
+	EmptyTitle,
+} from "@superset/ui/empty";
+import { HiMiniPlus } from "react-icons/hi2";
+import { LuFolderGit2, LuSearchX } from "react-icons/lu";
+import { V2ProjectRow } from "renderer/routes/_authenticated/_dashboard/v2-projects/components/V2ProjectRow";
+import type { AccessibleV2Project } from "renderer/routes/_authenticated/_dashboard/v2-projects/hooks/useAccessibleV2Projects";
+import { useV2ProjectsFilterStore } from "renderer/routes/_authenticated/_dashboard/v2-projects/stores/v2ProjectsFilterStore";
+import { useOpenNewProjectModal } from "renderer/stores/add-repository-modal";
+
+interface V2ProjectsListProps {
+	projects: AccessibleV2Project[];
+}
+
+export function V2ProjectsList({ projects }: V2ProjectsListProps) {
+	const searchQuery = useV2ProjectsFilterStore((state) => state.searchQuery);
+	const resetFilters = useV2ProjectsFilterStore((state) => state.reset);
+	const openNewProject = useOpenNewProjectModal();
+
+	const hasActiveFilters = searchQuery.trim() !== "";
+
+	if (projects.length === 0) {
+		return (
+			<Empty className="flex-1 border-0">
+				<EmptyHeader>
+					<EmptyMedia
+						variant="icon"
+						className="size-14 [&_svg:not([class*='size-'])]:size-7"
+					>
+						{hasActiveFilters ? <LuSearchX /> : <LuFolderGit2 />}
+					</EmptyMedia>
+					<EmptyTitle>
+						{hasActiveFilters
+							? "No projects match your search"
+							: "No projects yet"}
+					</EmptyTitle>
+					<EmptyDescription>
+						{hasActiveFilters
+							? "Try a different search term."
+							: "Create a project to start tracking workspaces and repositories here."}
+					</EmptyDescription>
+				</EmptyHeader>
+				<EmptyContent>
+					{hasActiveFilters ? (
+						<Button variant="outline" size="sm" onClick={() => resetFilters()}>
+							Clear search
+						</Button>
+					) : (
+						<Button size="sm" onClick={openNewProject} className="gap-1.5">
+							<HiMiniPlus className="size-4" />
+							New project
+						</Button>
+					)}
+				</EmptyContent>
+			</Empty>
+		);
+	}
+
+	return (
+		<div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+			{/* Column headers */}
+			<div className="flex items-center border-b border-border/50 bg-card/95 text-xs font-medium text-muted-foreground">
+				<div className="flex-1 px-4 py-2">Name</div>
+				<div className="hidden w-56 px-3 py-2 md:block">Repository</div>
+				<div className="w-28 px-3 py-2">Workspaces</div>
+				<div className="w-32 px-3 py-2">Updated</div>
+				<div className="w-12" />
+			</div>
+
+			{/* Rows */}
+			<div className="flex-1 overflow-y-auto">
+				{projects.map((project) => (
+					<V2ProjectRow key={project.id} project={project} />
+				))}
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-projects/components/V2ProjectsList/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-projects/components/V2ProjectsList/index.ts
@@ -1,0 +1,1 @@
+export { V2ProjectsList } from "./V2ProjectsList";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-projects/hooks/useAccessibleV2Projects/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-projects/hooks/useAccessibleV2Projects/index.ts
@@ -1,0 +1,4 @@
+export {
+	type AccessibleV2Project,
+	useAccessibleV2Projects,
+} from "./useAccessibleV2Projects";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-projects/hooks/useAccessibleV2Projects/useAccessibleV2Projects.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-projects/hooks/useAccessibleV2Projects/useAccessibleV2Projects.ts
@@ -1,0 +1,125 @@
+import { eq } from "@tanstack/db";
+import { useLiveQuery } from "@tanstack/react-db";
+import { useMemo } from "react";
+import { env } from "renderer/env.renderer";
+import { authClient } from "renderer/lib/auth-client";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { MOCK_ORG_ID } from "shared/constants";
+
+export interface AccessibleV2Project {
+	id: string;
+	name: string;
+	slug: string;
+	repoCloneUrl: string | null;
+	githubOwner: string | null;
+	githubRepoName: string | null;
+	githubFullName: string | null;
+	createdAt: Date;
+	updatedAt: Date;
+	workspaceCount: number;
+}
+
+interface UseAccessibleV2ProjectsOptions {
+	searchQuery?: string;
+}
+
+function projectMatchesSearch(
+	project: AccessibleV2Project,
+	searchQuery: string,
+): boolean {
+	if (!searchQuery.trim()) return true;
+	const query = searchQuery.trim().toLowerCase();
+	return (
+		project.name.toLowerCase().includes(query) ||
+		project.slug.toLowerCase().includes(query) ||
+		(project.githubFullName ?? "").toLowerCase().includes(query)
+	);
+}
+
+export function useAccessibleV2Projects(
+	options: UseAccessibleV2ProjectsOptions = {},
+): AccessibleV2Project[] {
+	const searchQuery = options.searchQuery ?? "";
+	const { data: session } = authClient.useSession();
+	const collections = useCollections();
+
+	const activeOrganizationId = env.SKIP_ENV_VALIDATION
+		? MOCK_ORG_ID
+		: (session?.session?.activeOrganizationId ?? null);
+
+	const { data: projectRows = [] } = useLiveQuery(
+		(q) =>
+			q
+				.from({ projects: collections.v2Projects })
+				.leftJoin(
+					{ repos: collections.githubRepositories },
+					({ projects, repos }) => eq(projects.githubRepositoryId, repos.id),
+				)
+				.where(({ projects }) =>
+					eq(projects.organizationId, activeOrganizationId ?? ""),
+				)
+				.select(({ projects, repos }) => ({
+					id: projects.id,
+					name: projects.name,
+					slug: projects.slug,
+					repoCloneUrl: projects.repoCloneUrl,
+					githubOwner: repos?.owner ?? null,
+					githubRepoName: repos?.name ?? null,
+					githubFullName: repos?.fullName ?? null,
+					createdAt: projects.createdAt,
+					updatedAt: projects.updatedAt,
+				})),
+		[activeOrganizationId, collections],
+	);
+
+	const { data: workspaceRows = [] } = useLiveQuery(
+		(q) =>
+			q
+				.from({ workspaces: collections.v2Workspaces })
+				.where(({ workspaces }) =>
+					eq(workspaces.organizationId, activeOrganizationId ?? ""),
+				)
+				.select(({ workspaces }) => ({
+					projectId: workspaces.projectId,
+				})),
+		[activeOrganizationId, collections],
+	);
+
+	const workspaceCountByProject = useMemo(() => {
+		const counts = new Map<string, number>();
+		for (const row of workspaceRows) {
+			counts.set(row.projectId, (counts.get(row.projectId) ?? 0) + 1);
+		}
+		return counts;
+	}, [workspaceRows]);
+
+	const enriched = useMemo<AccessibleV2Project[]>(() => {
+		const deduped = new Map<string, AccessibleV2Project>();
+		for (const row of projectRows) {
+			if (deduped.has(row.id)) continue;
+			deduped.set(row.id, {
+				id: row.id,
+				name: row.name,
+				slug: row.slug,
+				repoCloneUrl: row.repoCloneUrl,
+				githubOwner: row.githubOwner ?? null,
+				githubRepoName: row.githubRepoName ?? null,
+				githubFullName: row.githubFullName ?? null,
+				createdAt: new Date(row.createdAt),
+				updatedAt: new Date(row.updatedAt),
+				workspaceCount: workspaceCountByProject.get(row.id) ?? 0,
+			});
+		}
+		return Array.from(deduped.values()).sort(
+			(a, b) => b.updatedAt.getTime() - a.updatedAt.getTime(),
+		);
+	}, [projectRows, workspaceCountByProject]);
+
+	const filtered = useMemo(
+		() =>
+			enriched.filter((project) => projectMatchesSearch(project, searchQuery)),
+		[enriched, searchQuery],
+	);
+
+	return filtered;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-projects/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-projects/page.tsx
@@ -1,0 +1,30 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useEffect } from "react";
+import { V2ProjectsHeader } from "./components/V2ProjectsHeader";
+import { V2ProjectsList } from "./components/V2ProjectsList";
+import { useAccessibleV2Projects } from "./hooks/useAccessibleV2Projects";
+import { useV2ProjectsFilterStore } from "./stores/v2ProjectsFilterStore";
+
+export const Route = createFileRoute("/_authenticated/_dashboard/v2-projects/")(
+	{
+		component: V2ProjectsPage,
+	},
+);
+
+function V2ProjectsPage() {
+	const searchQuery = useV2ProjectsFilterStore((state) => state.searchQuery);
+	const resetFilters = useV2ProjectsFilterStore((state) => state.reset);
+
+	useEffect(() => {
+		resetFilters();
+	}, [resetFilters]);
+
+	const projects = useAccessibleV2Projects({ searchQuery });
+
+	return (
+		<div className="flex h-full w-full flex-1 flex-col overflow-hidden bg-card">
+			<V2ProjectsHeader totalCount={projects.length} />
+			<V2ProjectsList projects={projects} />
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-projects/stores/v2ProjectsFilterStore/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-projects/stores/v2ProjectsFilterStore/index.ts
@@ -1,0 +1,1 @@
+export { useV2ProjectsFilterStore } from "./v2ProjectsFilterStore";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-projects/stores/v2ProjectsFilterStore/v2ProjectsFilterStore.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-projects/stores/v2ProjectsFilterStore/v2ProjectsFilterStore.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+
+interface V2ProjectsFilterState {
+	searchQuery: string;
+	setSearchQuery: (searchQuery: string) => void;
+	reset: () => void;
+}
+
+export const useV2ProjectsFilterStore = create<V2ProjectsFilterState>()(
+	(set) => ({
+		searchQuery: "",
+		setSearchQuery: (searchQuery) => set({ searchQuery }),
+		reset: () => set({ searchQuery: "" }),
+	}),
+);


### PR DESCRIPTION
## Summary
- New `/v2-projects` list page (V1-style row table: Name / Repository / Workspaces / Updated) with search and a sidebar entry in `DashboardSidebarHeader` (both expanded and collapsed variants).
- New `/v2-project/$projectId` detail page with inline rename (via `apiTrpcClient.v2Project.update`), Connect Git Repository affordance, kebab actions (Rename / Project settings / View on GitHub), and an embedded workspaces list that reuses `V2WorkspaceRow`.
- Data is read via Electric SQL collections (`collections.v2Projects`, `collections.v2Workspaces`, `collections.githubRepositories`) — no new tRPC procedures. Per-project workspace counts are computed client-side.

## Caveats
- "Connect Git Repository" currently routes to `/settings/project/$projectId`; there's no v2-native connect flow yet.
- `/settings/project/$projectId` still loads v1 project state from local SQLite — cloud-only v2 projects without a local worktree may 404 there. Matches existing sidebar behavior.
- Rename uses the same slug-from-name derivation as the sidebar context menu; surfacing the unique-constraint error via toast.

## Test plan
- [ ] Open `/v2-projects` — list shows v2 projects sorted by updatedAt desc, with repo name, workspace count, relative time.
- [ ] Search filters across name / slug / repo full name.
- [ ] Click a row → lands on `/v2-project/$projectId`; back link returns to list.
- [ ] Rename inline (click name → type → Enter) persists and reflects in sidebar.
- [ ] "New workspace" from detail page opens modal with project preselected.
- [ ] Sidebar Projects entry highlights when on `/v2-projects`, both expanded and collapsed.
- [ ] Empty states render for no projects and no matching search.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds v2 Projects list and detail views to the desktop app. This introduces a searchable /v2-projects table and a project detail page with inline rename, Git repo actions, and embedded workspaces, plus a new “Projects” sidebar entry.

- New Features
  - `/v2-projects`: searchable list with Name / Repository / Workspaces / Updated columns.
  - `/v2-project/$projectId`: inline rename via `apiTrpcClient.v2Project.update`, actions (Settings, View on GitHub), and “Connect Git Repository” linking to settings.
  - Detail page embeds a workspaces list reusing `V2WorkspaceRow` and supports “New workspace” with the project preselected.
  - Sidebar: adds a “Projects” item (expanded and collapsed) with route highlighting.
  - Data from Electric SQL (`collections.v2Projects`, `collections.v2Workspaces`, `collections.githubRepositories`); workspace counts computed client-side.

<sup>Written for commit 03a9976ea868e7a5fe760ac3970c1288b4249e37. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

