### PR TITLE
fix(desktop): new v2 workspaces appear at top of their project in sidebar

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
@@ -12,6 +12,15 @@ function getNextTabOrder(items: Array<{ tabOrder: number }>): number {
 	return maxTabOrder + 1;
 }
 
+function getPrependTabOrder(items: Array<{ tabOrder: number }>): number {
+	if (items.length === 0) return 0;
+	const minTabOrder = items.reduce(
+		(minValue, item) => Math.min(minValue, item.tabOrder),
+		Number.POSITIVE_INFINITY,
+	);
+	return minTabOrder - 1;
+}
+
 function ensureSidebarProjectRecord(
 	collections: Pick<AppCollections, "v2SidebarProjects">,
 	projectId: string,
@@ -60,7 +69,7 @@ function ensureSidebarWorkspaceRecord(
 		createdAt: new Date(),
 		sidebarState: {
 			projectId,
-			tabOrder: getNextTabOrder(topLevelOrders),
+			tabOrder: getPrependTabOrder(topLevelOrders),
 			sectionId: null,
 		},
 		paneLayout: {

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
@@ -13,7 +13,7 @@ function getNextTabOrder(items: Array<{ tabOrder: number }>): number {
 }
 
 function getPrependTabOrder(items: Array<{ tabOrder: number }>): number {
-	if (items.length === 0) return 0;
+	if (items.length === 0) return 1;
 	const minTabOrder = items.reduce(
 		(minValue, item) => Math.min(minValue, item.tabOrder),
 		Number.POSITIVE_INFINITY,


### PR DESCRIPTION
## Summary
- New v2 workspaces were being inserted at the bottom of their project's sidebar list because `ensureSidebarWorkspaceRecord` used `getNextTabOrder` (max + 1).
- Added a `getPrependTabOrder` helper that returns `min - 1` and switched the insert to use it, so newly created workspaces land at the top of the project.
- Existing reorder ops normalize tabOrders back to positive sequential values on drag, so negative seeds from prepended inserts are transient.

## Test plan
- [ ] Create a new v2 workspace in a project that already has workspaces — verify it appears at the top of that project, not the bottom
- [ ] Create a project that contains a section at the top; create a workspace — verify it appears above the section
- [ ] Drag-reorder workspaces after creation and confirm order persists

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
New v2 workspaces now appear at the top of their project in the desktop sidebar. This makes new workspaces visible right away without changing existing order.

- **Bug Fixes**
  - Added `getPrependTabOrder` (min − 1) and used it when creating a workspace to prepend it in the project list.
  - For empty projects, seed `tabOrder` at 1 to match reorder helpers; drag-reorder still normalizes values, so any negative seeds are temporary.

<sup>Written for commit 067526af378065f90f8d540f080abcbe7ef42f07. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workspace ordering in the sidebar: newly created top-level (ungrouped) workspaces now appear at the top of the list instead of at the bottom.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->