### PR TITLE
fix(desktop): don't nuke host services on app update

### DIFF
--- a/apps/desktop/src/main/host-service/index.ts
+++ b/apps/desktop/src/main/host-service/index.ts
@@ -18,7 +18,7 @@ import {
 	resolveTerminalBaseEnv,
 } from "@superset/host-service/terminal-env";
 import { connectRelay } from "@superset/host-service/tunnel";
-import { removeManifest, writeManifest } from "main/lib/host-service-manifest";
+import { writeManifest } from "main/lib/host-service-manifest";
 import { env } from "./env";
 
 async function main(): Promise<void> {
@@ -81,10 +81,8 @@ async function main(): Promise<void> {
 	);
 	injectWebSocket(server);
 
+	// Manifest lifecycle belongs to the coordinator, not the child.
 	const shutdown = () => {
-		if (env.ORGANIZATION_ID) {
-			removeManifest(env.ORGANIZATION_ID);
-		}
 		server.close();
 		process.exit(0);
 	};

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -55,6 +55,18 @@ const HEALTH_POLL_INTERVAL = 200;
 const HEALTH_POLL_TIMEOUT = 10_000;
 const ADOPTED_LIVENESS_INTERVAL = 5_000;
 
+function openLogFile(organizationId: string): number {
+	try {
+		const dir = manifestDir(organizationId);
+		if (!fs.existsSync(dir)) {
+			fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+		}
+		return fs.openSync(path.join(dir, "host-service.log"), "a", 0o600);
+	} catch {
+		return -1;
+	}
+}
+
 async function findFreePort(): Promise<number> {
 	return new Promise((resolve, reject) => {
 		const server = createServer();
@@ -402,10 +414,25 @@ export class HostServiceCoordinator extends EventEmitter {
 		this.emitStatus(organizationId, "starting", null);
 
 		const env = await this.buildEnv(organizationId, port, secret, config);
-		const child = childProcess.spawn(process.execPath, [this.scriptPath], {
-			stdio: ["ignore", "pipe", "pipe"],
-			env,
-		});
+
+		// Detached + file-backed stdio so the child outlives the parent's process
+		// group (Squirrel.Mac SIGTERMs it during updates) and doesn't depend on
+		// parent-held stdout/stderr pipes.
+		const logFd = openLogFile(organizationId);
+		let child: childProcess.ChildProcess;
+		try {
+			child = childProcess.spawn(process.execPath, [this.scriptPath], {
+				detached: true,
+				stdio: logFd >= 0 ? ["ignore", logFd, logFd] : "ignore",
+				env,
+			});
+		} finally {
+			if (logFd >= 0) {
+				try {
+					fs.closeSync(logFd);
+				} catch {}
+			}
+		}
 
 		const childPid = child.pid;
 		if (!childPid) {
@@ -415,14 +442,6 @@ export class HostServiceCoordinator extends EventEmitter {
 
 		instance.pid = childPid;
 
-		child.stdout?.on("data", (data: Buffer) => {
-			console.log(`[host-service:${organizationId}] ${data.toString().trim()}`);
-		});
-		child.stderr?.on("data", (data: Buffer) => {
-			console.error(
-				`[host-service:${organizationId}] ${data.toString().trim()}`,
-			);
-		});
 		child.on("exit", (code) => {
 			console.log(`[host-service:${organizationId}] exited with code ${code}`);
 			const current = this.instances.get(organizationId);


### PR DESCRIPTION
## Summary

On macOS update, Squirrel.Mac SIGTERMs the old app's process group. That reached the host-service child in two destructive ways:

1. The child's own SIGTERM handler (`apps/desktop/src/main/host-service/index.ts`) called `removeManifest()` on shutdown — wiping the file the new app needed to re-adopt the service.
2. The coordinator spawned the child without `detached: true`, so the child sat in the parent's process group and died alongside the app.

On relaunch, `coordinator.discoverAll()` found no manifests and spawned fresh host-services, losing all in-memory state (PTYs, watchers, chat streams, etc.).

## Fixes

- **Child shutdown** — drop `removeManifest` from the SIGTERM handler. The coordinator already owns manifest lifecycle: `stop()` removes it on intentional stops, and `child.on("exit")` removes it on observed crashes.
- **Spawn isolation** — `detached: true` + file-backed stdio at `<manifestDir>/host-service.log`. Child gets its own process group, so Squirrel's group-wide SIGTERM doesn't reach it, and it no longer depends on parent-held pipes. Mirrors the existing terminal-daemon pattern at `terminal-host/client.ts:1191`.

Tray "Stop" and "Quit & Stop Services" are unchanged — `coordinator.stop()` signals by pid, independent of process group.

## Test plan

- [ ] Install a prior canary build, trigger an update, and verify host-service pids survive across the update (`ps` before and after, same pids).
- [ ] Confirm `~/.superset/host/<orgId>/manifest.json` is still present after update completes.
- [ ] After new app launches, confirm `discoverAll()` adopts the surviving service (check logs for "Adopted pid=…" rather than "listening on port …").
- [ ] Tray "Stop" still terminates a running service.
- [ ] Tray "Quit & Stop Services" still terminates services before exit.
- [ ] `bun dev` still hot-reloads via `enableDevReload` (kills + respawns per org).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent host services from being killed and their manifests deleted during macOS app updates, so they survive and are re-adopted on relaunch. This preserves in-memory state (PTYs, watchers, chat streams) across updates.

- **Bug Fixes**
  - Removed manifest deletion from the child’s SIGTERM handler; the coordinator now solely manages manifest lifecycle on stop/exit.
  - Spawn the host-service with `detached: true` and file-backed stdio at `<manifestDir>/host-service.log` to isolate it from the app’s process group and parent-held pipes.
  - Tray “Stop” and “Quit & Stop Services” are unchanged; dev hot-reload still works.

<sup>Written for commit 87d8deb2640652f765581aee58dbbf0fe9bf3c01. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated host service process lifecycle management including initialization, execution, and shutdown procedures
  * Service logs are now persisted to dedicated log files instead of console output for better long-term accessibility
  * Enhanced resource cleanup and process coordination mechanisms
  * Refined service startup and process handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->