### PR TITLE
fix(desktop): hide v2 workspace rows while destroy is in flight

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/hooks/useDestroyDialogState/useDestroyDialogState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/hooks/useDestroyDialogState/useDestroyDialogState.ts
@@ -4,6 +4,7 @@ import {
 	type DestroyWorkspaceError,
 	useDestroyWorkspace,
 } from "renderer/hooks/host-service/useDestroyWorkspace";
+import { useDeletingWorkspaces } from "renderer/routes/_authenticated/providers/DeletingWorkspacesProvider";
 
 interface UseDestroyDialogStateOptions {
 	workspaceId: string;
@@ -15,11 +16,16 @@ interface UseDestroyDialogStateOptions {
 /**
  * Drives the delete flow for `DashboardSidebarDeleteDialog`.
  *
- * UX pattern (mirrors v1's deleteWithToast):
- *   - On confirm, close the dialog immediately and run the destroy
- *     in the background under a toast.loading → success/error.
- *   - For decision-required errors (CONFLICT, TEARDOWN_FAILED) we
- *     reopen the dialog in the matching error pane so the user can
+ * UX pattern:
+ *   - On confirm, close the dialog immediately, mark the workspace as
+ *     deleting (sidebar row hides optimistically), and run destroy in
+ *     the background silently. No loading toast — destroy can take
+ *     10–20s and a persistent toast across that window feels bad. The
+ *     hidden row is the feedback.
+ *   - On success, `onDeleted` removes the row from sidebar state.
+ *   - On error, `clearDeleting` runs in the `finally` block so the row
+ *     reappears. For decision-required errors (CONFLICT, TEARDOWN_FAILED)
+ *     we reopen the dialog in the matching error pane so the user can
  *     force-retry with full context. The branch opt-in is preserved.
  *   - For unknown errors we just toast.error — no reopen.
  */
@@ -30,6 +36,7 @@ export function useDestroyDialogState({
 	onDeleted,
 }: UseDestroyDialogStateOptions) {
 	const { destroy } = useDestroyWorkspace(workspaceId);
+	const { markDeleting, clearDeleting } = useDeletingWorkspaces();
 
 	const [deleteBranch, setDeleteBranch] = useState(false);
 	const [error, setError] = useState<DestroyWorkspaceError | null>(null);
@@ -60,29 +67,36 @@ export function useDestroyDialogState({
 			// on a decision-required error.
 			setError(null);
 			onOpenChange(false);
-
-			const loadingId = toast.loading(`Deleting ${workspaceName}...`);
+			markDeleting(workspaceId);
 
 			try {
 				const result = await destroy({ deleteBranch, force });
-				toast.success(`Deleted ${workspaceName}`, { id: loadingId });
 				for (const warning of result.warnings) toast.warning(warning);
 				setDeleteBranch(false);
 				onDeleted?.();
 			} catch (err) {
 				const e = err as DestroyWorkspaceError;
 				if (e.kind === "conflict" || e.kind === "teardown-failed") {
-					toast.dismiss(loadingId);
 					setError(e);
 					onOpenChange(true);
 				} else {
-					toast.error(`Failed to delete: ${e.message}`, { id: loadingId });
+					toast.error(`Failed to delete ${workspaceName}: ${e.message}`);
 				}
 			} finally {
+				clearDeleting(workspaceId);
 				inFlight.current = false;
 			}
 		},
-		[destroy, deleteBranch, workspaceName, onOpenChange, onDeleted],
+		[
+			destroy,
+			deleteBranch,
+			workspaceName,
+			workspaceId,
+			onOpenChange,
+			onDeleted,
+			markDeleting,
+			clearDeleting,
+		],
 	);
 
 	return {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "@tanstack/react-router";
 import { useDiffStats } from "renderer/hooks/host-service/useDiffStats";
+import { useDeletingWorkspaces } from "renderer/routes/_authenticated/providers/DeletingWorkspacesProvider";
 import type { DashboardSidebarWorkspace } from "../../types";
 import { DashboardSidebarDeleteDialog } from "../DashboardSidebarDeleteDialog";
 import { DashboardSidebarCollapsedWorkspaceButton } from "./components/DashboardSidebarCollapsedWorkspaceButton";
@@ -58,6 +59,9 @@ export function DashboardSidebarWorkspaceItem({
 
 	const navigate = useNavigate();
 	const isPending = !!creationStatus;
+	// Keep the delete dialog outside the hidden wrapper below — the destroy
+	// flow reopens it into an error pane on conflict/teardown-failed.
+	const isDeleting = useDeletingWorkspaces().isDeleting(id);
 	const handlePendingClick = isPending
 		? () => {
 				void navigate({
@@ -92,35 +96,37 @@ export function DashboardSidebarWorkspaceItem({
 
 		return (
 			<>
-				{isPending ? (
-					content
-				) : (
-					<DashboardSidebarWorkspaceContextMenu
-						projectId={projectId}
-						isInSection={isInSection}
-						onHoverCardOpen={
-							hostType === "local-device" ? onHoverCardOpen : undefined
-						}
-						hoverCardContent={
-							<DashboardSidebarWorkspaceHoverCardContent
-								workspace={workspace}
-								diffStats={diffStats}
-							/>
-						}
-						isLocalWorkspace={hostType === "local-device"}
-						onCreateSection={handleCreateSection}
-						onMoveToSection={(targetSectionId) =>
-							moveWorkspaceToSection(id, projectId, targetSectionId)
-						}
-						onOpenInFinder={handleOpenInFinder}
-						onCopyPath={handleCopyPath}
-						onRemoveFromSidebar={() => removeWorkspaceFromSidebar(id)}
-						onRename={startRename}
-						onDelete={() => setIsDeleteDialogOpen(true)}
-					>
-						{content}
-					</DashboardSidebarWorkspaceContextMenu>
-				)}
+				<div hidden={isDeleting}>
+					{isPending ? (
+						content
+					) : (
+						<DashboardSidebarWorkspaceContextMenu
+							projectId={projectId}
+							isInSection={isInSection}
+							onHoverCardOpen={
+								hostType === "local-device" ? onHoverCardOpen : undefined
+							}
+							hoverCardContent={
+								<DashboardSidebarWorkspaceHoverCardContent
+									workspace={workspace}
+									diffStats={diffStats}
+								/>
+							}
+							isLocalWorkspace={hostType === "local-device"}
+							onCreateSection={handleCreateSection}
+							onMoveToSection={(targetSectionId) =>
+								moveWorkspaceToSection(id, projectId, targetSectionId)
+							}
+							onOpenInFinder={handleOpenInFinder}
+							onCopyPath={handleCopyPath}
+							onRemoveFromSidebar={() => removeWorkspaceFromSidebar(id)}
+							onRename={startRename}
+							onDelete={() => setIsDeleteDialogOpen(true)}
+						>
+							{content}
+						</DashboardSidebarWorkspaceContextMenu>
+					)}
+				</div>
 
 				{!isPending && (
 					<DashboardSidebarDeleteDialog
@@ -154,35 +160,37 @@ export function DashboardSidebarWorkspaceItem({
 
 	return (
 		<>
-			{isPending ? (
-				expandedContent
-			) : (
-				<DashboardSidebarWorkspaceContextMenu
-					projectId={projectId}
-					isInSection={isInSection}
-					onHoverCardOpen={
-						hostType === "local-device" ? onHoverCardOpen : undefined
-					}
-					hoverCardContent={
-						<DashboardSidebarWorkspaceHoverCardContent
-							workspace={workspace}
-							diffStats={diffStats}
-						/>
-					}
-					onCreateSection={handleCreateSection}
-					onMoveToSection={(targetSectionId) =>
-						moveWorkspaceToSection(id, projectId, targetSectionId)
-					}
-					isLocalWorkspace={hostType === "local-device"}
-					onOpenInFinder={handleOpenInFinder}
-					onCopyPath={handleCopyPath}
-					onRemoveFromSidebar={() => removeWorkspaceFromSidebar(id)}
-					onRename={startRename}
-					onDelete={() => setIsDeleteDialogOpen(true)}
-				>
-					{expandedContent}
-				</DashboardSidebarWorkspaceContextMenu>
-			)}
+			<div hidden={isDeleting}>
+				{isPending ? (
+					expandedContent
+				) : (
+					<DashboardSidebarWorkspaceContextMenu
+						projectId={projectId}
+						isInSection={isInSection}
+						onHoverCardOpen={
+							hostType === "local-device" ? onHoverCardOpen : undefined
+						}
+						hoverCardContent={
+							<DashboardSidebarWorkspaceHoverCardContent
+								workspace={workspace}
+								diffStats={diffStats}
+							/>
+						}
+						onCreateSection={handleCreateSection}
+						onMoveToSection={(targetSectionId) =>
+							moveWorkspaceToSection(id, projectId, targetSectionId)
+						}
+						isLocalWorkspace={hostType === "local-device"}
+						onOpenInFinder={handleOpenInFinder}
+						onCopyPath={handleCopyPath}
+						onRemoveFromSidebar={() => removeWorkspaceFromSidebar(id)}
+						onRename={startRename}
+						onDelete={() => setIsDeleteDialogOpen(true)}
+					>
+						{expandedContent}
+					</DashboardSidebarWorkspaceContextMenu>
+				)}
+			</div>
 
 			{!isPending && (
 				<DashboardSidebarDeleteDialog

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -36,6 +36,7 @@ import { GlobalTerminalLifecycle } from "./components/GlobalTerminalLifecycle";
 import { TeardownLogsDialog } from "./components/TeardownLogsDialog";
 import { createPierreWorker } from "./lib/pierreWorker";
 import { CollectionsProvider } from "./providers/CollectionsProvider";
+import { DeletingWorkspacesProvider } from "./providers/DeletingWorkspacesProvider";
 import { LocalHostServiceProvider } from "./providers/LocalHostServiceProvider";
 
 export const Route = createFileRoute("/_authenticated")({
@@ -183,22 +184,24 @@ function AuthenticatedLayout() {
 			<CollectionsProvider>
 				<GlobalTerminalLifecycle />
 				<LocalHostServiceProvider>
-					<WorkerPoolContextProvider
-						poolOptions={{ workerFactory: createPierreWorker, poolSize: 8 }}
-						highlighterOptions={{ preferredHighlighter: "shiki-wasm" }}
-					>
-						<AgentHooks />
-						<Outlet />
-						<WorkspaceInitEffects />
-						{isV2CloudEnabled ? (
-							<DashboardNewWorkspaceModal />
-						) : (
-							<NewWorkspaceModal />
-						)}
-						<InitGitDialog />
-						<TeardownLogsDialog />
-						<Paywall />
-					</WorkerPoolContextProvider>
+					<DeletingWorkspacesProvider>
+						<WorkerPoolContextProvider
+							poolOptions={{ workerFactory: createPierreWorker, poolSize: 8 }}
+							highlighterOptions={{ preferredHighlighter: "shiki-wasm" }}
+						>
+							<AgentHooks />
+							<Outlet />
+							<WorkspaceInitEffects />
+							{isV2CloudEnabled ? (
+								<DashboardNewWorkspaceModal />
+							) : (
+								<NewWorkspaceModal />
+							)}
+							<InitGitDialog />
+							<TeardownLogsDialog />
+							<Paywall />
+						</WorkerPoolContextProvider>
+					</DeletingWorkspacesProvider>
 				</LocalHostServiceProvider>
 			</CollectionsProvider>
 		</DndProvider>

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/DeletingWorkspacesProvider/DeletingWorkspacesProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/DeletingWorkspacesProvider/DeletingWorkspacesProvider.tsx
@@ -1,0 +1,76 @@
+import {
+	createContext,
+	type ReactNode,
+	useCallback,
+	useContext,
+	useMemo,
+	useState,
+} from "react";
+
+interface DeletingWorkspacesContextValue {
+	isDeleting: (workspaceId: string) => boolean;
+	markDeleting: (workspaceId: string) => void;
+	clearDeleting: (workspaceId: string) => void;
+}
+
+const DeletingWorkspacesContext =
+	createContext<DeletingWorkspacesContextValue | null>(null);
+
+/**
+ * Tracks workspaces whose `workspaceCleanup.destroy` call is in flight.
+ * The sidebar hides these rows optimistically so users get instant feedback
+ * instead of watching the row sit there during the 10–20s destroy window.
+ * On error the caller calls `clearDeleting` and the row reappears; on
+ * success the row is naturally unmounted via `v2WorkspaceLocalState.delete`.
+ */
+export function DeletingWorkspacesProvider({
+	children,
+}: {
+	children: ReactNode;
+}) {
+	const [ids, setIds] = useState<ReadonlySet<string>>(() => new Set());
+
+	const isDeleting = useCallback(
+		(workspaceId: string) => ids.has(workspaceId),
+		[ids],
+	);
+
+	const markDeleting = useCallback((workspaceId: string) => {
+		setIds((prev) => {
+			if (prev.has(workspaceId)) return prev;
+			const next = new Set(prev);
+			next.add(workspaceId);
+			return next;
+		});
+	}, []);
+
+	const clearDeleting = useCallback((workspaceId: string) => {
+		setIds((prev) => {
+			if (!prev.has(workspaceId)) return prev;
+			const next = new Set(prev);
+			next.delete(workspaceId);
+			return next;
+		});
+	}, []);
+
+	const value = useMemo(
+		() => ({ isDeleting, markDeleting, clearDeleting }),
+		[isDeleting, markDeleting, clearDeleting],
+	);
+
+	return (
+		<DeletingWorkspacesContext.Provider value={value}>
+			{children}
+		</DeletingWorkspacesContext.Provider>
+	);
+}
+
+export function useDeletingWorkspaces() {
+	const ctx = useContext(DeletingWorkspacesContext);
+	if (!ctx) {
+		throw new Error(
+			"useDeletingWorkspaces must be used within DeletingWorkspacesProvider",
+		);
+	}
+	return ctx;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/DeletingWorkspacesProvider/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/DeletingWorkspacesProvider/index.ts
@@ -1,0 +1,4 @@
+export {
+	DeletingWorkspacesProvider,
+	useDeletingWorkspaces,
+} from "./DeletingWorkspacesProvider";


### PR DESCRIPTION
## Summary

- `workspaceCleanup.destroy` can take 10–20s. The previous `toast.loading → success` sat onscreen the whole time and the sidebar row stayed put, so clicking Delete felt like nothing was happening.
- On confirm we now optimistically hide the row and drop the loading toast entirely. The hidden row is the feedback. On success, `onDeleted` removes the `v2WorkspaceLocalState` entry and the row unmounts naturally. On error the row reappears.
- Error panes (Conflict / Teardown-failed / Unknown) are preserved — the dialog lives as a sibling of the hidden wrapper, so decision-required errors still reopen into the matching pane for force-retry.

Mechanism: a new `DeletingWorkspacesProvider` tracks in-flight deletions with `{ isDeleting, markDeleting, clearDeleting }`. `useDestroyDialogState` marks on confirm and clears in `finally`; `DashboardSidebarWorkspaceItem` wraps its visible content in `<div hidden={isDeleting}>`.

## Test plan

- [ ] Delete a v2 workspace from the sidebar context menu → row disappears instantly, no loading toast, workspace gone after destroy completes.
- [ ] Delete with uncommitted changes / unpushed commits → conflict pane reopens, row reappears behind it, force-retry works.
- [ ] Delete a workspace whose teardown script fails → teardown-failed pane reopens, row reappears, force-retry works.
- [ ] Delete an unknown-error case (e.g. host-service down) → toast.error names the workspace, row reappears.
- [ ] Delete the currently-active workspace → navigates away immediately (existing `handleDeleted` flow, unchanged).
- [ ] Warnings emitted by destroy still surface as individual `toast.warning`s.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimistically hide v2 workspace rows during deletion and remove the loading toast for faster, clearer feedback. Rows reappear on error, and the delete dialog reopens for conflict/teardown cases.

- **Bug Fixes**
  - Added `DeletingWorkspacesProvider` with `isDeleting`, `markDeleting`, and `clearDeleting` to track in-flight destroys.
  - Updated `DashboardSidebarWorkspaceItem` to hide visible content with `hidden={isDeleting}`; keep the delete dialog outside the wrapper so errors can reopen correctly.
  - Changed `useDestroyDialogState` to mark/clear deleting, drop `toast.loading`, keep `toast.warning` for destroy warnings, and show `toast.error` for unknown errors; on success, the row unmounts via existing state.
  - Wrapped the app with `DeletingWorkspacesProvider` in `_authenticated/layout.tsx`.

<sup>Written for commit bd0edda75e1d49b8cac8dff6ab24562cbc1e9fed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced workspace deletion experience: the sidebar item is now hidden during deletion processing and reappears if deletion fails.
  * Deletion dialog closes immediately after confirming for instant feedback.

* **User Experience**
  * Reduced notification volume during workspace deletion operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->