### PR TITLE
fix(desktop): spread dev dock-icon colors across full hue range

### DIFF
--- a/apps/desktop/src/main/lib/dock-icon.ts
+++ b/apps/desktop/src/main/lib/dock-icon.ts
@@ -4,24 +4,20 @@ import { app, nativeImage } from "electron";
 import { env } from "main/env.main";
 import { prerelease } from "semver";
 import { getWorkspaceName } from "shared/env.shared";
-import twColors from "tailwindcss/colors";
 
 type RGB = [number, number, number];
 
 type Bounds = { top: number; left: number; bottom: number; right: number };
 
 /**
- * Deterministic workspace-name → RGB picker using Tailwind's 500-level palette.
+ * Deterministic workspace-name → RGB picker. Hashes the name to a hue via the
+ * golden angle (137.508°) so successive workspaces land far apart on the color
+ * wheel, then converts a fixed-lightness/chroma OKLCH point to sRGB.
  */
 const pickWorkspaceColor = (() => {
-	const FALLBACK: RGB = [59, 130, 246]; // blue-500
-
-	function parseOklch(str: string): { l: number; c: number; h: number } | null {
-		const m = str.match(/oklch\(([\d.]+)%\s+([\d.]+)\s+([\d.]+)\)/);
-		return m
-			? { l: Number(m[1]) / 100, c: Number(m[2]), h: Number(m[3]) }
-			: null;
-	}
+	const L = 0.68;
+	const C = 0.18;
+	const GOLDEN_ANGLE = 137.508;
 
 	function oklchToRgb(l: number, c: number, h: number): RGB {
 		const hRad = (h * Math.PI) / 180;
@@ -47,14 +43,6 @@ const pickWorkspaceColor = (() => {
 		];
 	}
 
-	const skip = new Set(["inherit", "current", "transparent", "black", "white"]);
-	const palette: RGB[] = [];
-	for (const [name, val] of Object.entries(twColors)) {
-		if (skip.has(name) || typeof val !== "object" || !("500" in val)) continue;
-		const parsed = parseOklch((val as Record<string, string>)["500"]);
-		if (parsed) palette.push(oklchToRgb(parsed.l, parsed.c, parsed.h));
-	}
-
 	function hash(seed: string): number {
 		let h = 0;
 		for (let i = 0; i < seed.length; i++) {
@@ -64,8 +52,10 @@ const pickWorkspaceColor = (() => {
 		return Math.abs(h);
 	}
 
-	return (workspaceName: string): RGB =>
-		palette[hash(workspaceName) % palette.length] ?? FALLBACK;
+	return (workspaceName: string): RGB => {
+		const hue = (hash(workspaceName) * GOLDEN_ANGLE) % 360;
+		return oklchToRgb(L, C, hue);
+	};
 })();
 
 /**


### PR DESCRIPTION
## Summary
- Replace the Tailwind `-500` palette used to tint the dev dock-icon corner fold with a golden-angle hue generator in OKLCH (fixed L=0.68, C=0.18).
- The old palette had ~22 entries, of which ~5 were grey families (slate/gray/zinc/neutral/stone) and several more were near-duplicate hue neighbors (teal/cyan/sky, indigo/violet/purple, pink/rose/fuchsia), leaving only ~8–10 visually distinguishable slots — collisions between concurrent dev workspaces showed up around 3–4 workspaces in practice.
- Hashing to `hue = (hash * 137.508) % 360` spreads successive names evenly around the color wheel with effectively unlimited distinct hues, at roughly Tailwind-500 vibrancy.

## Test plan
- [ ] Run `bun dev` for the desktop app with a couple of workspace names (e.g. via worktrees) and confirm each dock icon gets a distinct, vibrant corner fold.
- [ ] Sanity-check a handful of workspace names produce colors that aren't muddy/grey and aren't near-duplicates of each other.
- [ ] `bun run typecheck` in `apps/desktop`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make dev dock icon colors unique and vibrant for each workspace by replacing the limited Tailwind `-500` palette with a golden-angle OKLCH hue generator. This eliminates frequent color collisions across multiple dev workspaces.

- **Refactors**
  - Removed `tailwindcss/colors` palette usage and parsing.
  - Generate hue with `(hash(name) * 137.508) % 360` and convert fixed `L=0.68`, `C=0.18` OKLCH to sRGB.

<sup>Written for commit 63ceae49e1acc91ca3710b36e716b630d8939f63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved workspace color assignment algorithm for more consistent color rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->