### PR TITLE
fix(host-service): stop misattributing cross-fork PRs to local workspaces

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/pr-resolution.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/github/pr-resolution.ts
@@ -1,3 +1,8 @@
+// v1-only. Dies with the v1 UI sunset. Don't evolve this module — v2 already
+// resolves PRs via host-service (`packages/host-service/src/runtime/pull-requests`
+// backing `git.getPullRequest` + `pullRequests.getByWorkspaces`). Everything
+// under `renderer/screens/main/` + `routes/_authenticated/_dashboard/workspace/`
+// gets deleted together; no port needed.
 import type { CheckItem, GitHubStatus } from "@superset/local-db";
 import { execGitWithShellPath } from "../git-client";
 import { execWithShellEnv } from "../shell-env";
@@ -80,7 +85,10 @@ function getForkOwnerPrefix(
 
 export function prMatchesLocalBranch(
 	localBranch: string,
-	pr: Pick<GHPRResponse, "headRefName" | "headRepositoryOwner">,
+	pr: Pick<
+		GHPRResponse,
+		"headRefName" | "headRepositoryOwner" | "isCrossRepository"
+	>,
 ): boolean {
 	if (!branchMatchesPR(localBranch, pr.headRefName)) {
 		return false;
@@ -88,6 +96,9 @@ export function prMatchesLocalBranch(
 
 	const ownerPrefix = getForkOwnerPrefix(localBranch, pr.headRefName);
 	if (!ownerPrefix) {
+		// Without a fork-owner prefix in the local branch, a cross-fork PR whose
+		// headRefName collides (e.g. fork:main → base:main) would misattribute.
+		if (pr.isCrossRepository) return false;
 		return localBranch === pr.headRefName;
 	}
 

--- a/packages/host-service/drizzle/0003_workspace_upstream_ref.sql
+++ b/packages/host-service/drizzle/0003_workspace_upstream_ref.sql
@@ -1,0 +1,5 @@
+DROP INDEX `workspaces_branch_idx`;--> statement-breakpoint
+ALTER TABLE `workspaces` ADD `upstream_owner` text;--> statement-breakpoint
+ALTER TABLE `workspaces` ADD `upstream_repo` text;--> statement-breakpoint
+ALTER TABLE `workspaces` ADD `upstream_branch` text;--> statement-breakpoint
+CREATE INDEX `workspaces_upstream_ref_idx` ON `workspaces` (`upstream_owner`,`upstream_repo`,`upstream_branch`);

--- a/packages/host-service/drizzle/meta/0003_snapshot.json
+++ b/packages/host-service/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,493 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "d4171f78-422d-48d1-97c4-b803ed17fea9",
+  "prevId": "a2434e05-3865-4783-9247-7bda589c8806",
+  "tables": {
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_path": {
+          "name": "repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_provider": {
+          "name": "repo_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remote_name": {
+          "name": "remote_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_repo_path_idx": {
+          "name": "projects_repo_path_idx",
+          "columns": [
+            "repo_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pull_requests": {
+      "name": "pull_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_provider": {
+          "name": "repo_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "head_branch": {
+          "name": "head_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "review_decision": {
+          "name": "review_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checks_status": {
+          "name": "checks_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "checks_json": {
+          "name": "checks_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pull_requests_project_id_idx": {
+          "name": "pull_requests_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "pull_requests_repo_branch_idx": {
+          "name": "pull_requests_repo_branch_idx",
+          "columns": [
+            "repo_provider",
+            "repo_owner",
+            "repo_name",
+            "head_branch"
+          ],
+          "isUnique": false
+        },
+        "pull_requests_repo_pr_unique": {
+          "name": "pull_requests_repo_pr_unique",
+          "columns": [
+            "repo_provider",
+            "repo_owner",
+            "repo_name",
+            "pr_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "pull_requests_project_id_projects_id_fk": {
+          "name": "pull_requests_project_id_projects_id_fk",
+          "tableFrom": "pull_requests",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "terminal_sessions": {
+      "name": "terminal_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_workspace_id": {
+          "name": "origin_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_attached_at": {
+          "name": "last_attached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "terminal_sessions_origin_workspace_id_idx": {
+          "name": "terminal_sessions_origin_workspace_id_idx",
+          "columns": [
+            "origin_workspace_id"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_status_idx": {
+          "name": "terminal_sessions_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terminal_sessions_origin_workspace_id_workspaces_id_fk": {
+          "name": "terminal_sessions_origin_workspace_id_workspaces_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "origin_workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_owner": {
+          "name": "upstream_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_repo": {
+          "name": "upstream_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_branch": {
+          "name": "upstream_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_id": {
+          "name": "pull_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_project_id_idx": {
+          "name": "workspaces_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_upstream_ref_idx": {
+          "name": "workspaces_upstream_ref_idx",
+          "columns": [
+            "upstream_owner",
+            "upstream_repo",
+            "upstream_branch"
+          ],
+          "isUnique": false
+        },
+        "workspaces_pull_request_id_idx": {
+          "name": "workspaces_pull_request_id_idx",
+          "columns": [
+            "pull_request_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspaces_project_id_projects_id_fk": {
+          "name": "workspaces_project_id_projects_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_pull_request_id_pull_requests_id_fk": {
+          "name": "workspaces_pull_request_id_pull_requests_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "pull_requests",
+          "columnsFrom": [
+            "pull_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/host-service/drizzle/meta/_journal.json
+++ b/packages/host-service/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1775239013772,
       "tag": "0002_add_terminal_sessions",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1776814372609,
+      "tag": "0003_workspace_upstream_ref",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/host-service/src/db/schema.ts
+++ b/packages/host-service/src/db/schema.ts
@@ -102,6 +102,9 @@ export const workspaces = sqliteTable(
 		worktreePath: text("worktree_path").notNull(),
 		branch: text().notNull(),
 		headSha: text("head_sha"),
+		upstreamOwner: text("upstream_owner"),
+		upstreamRepo: text("upstream_repo"),
+		upstreamBranch: text("upstream_branch"),
 		pullRequestId: text("pull_request_id").references(() => pullRequests.id, {
 			onDelete: "set null",
 		}),
@@ -111,7 +114,11 @@ export const workspaces = sqliteTable(
 	},
 	(table) => [
 		index("workspaces_project_id_idx").on(table.projectId),
-		index("workspaces_branch_idx").on(table.branch),
+		index("workspaces_upstream_ref_idx").on(
+			table.upstreamOwner,
+			table.upstreamRepo,
+			table.upstreamBranch,
+		),
 		index("workspaces_pull_request_id_idx").on(table.pullRequestId),
 	],
 );

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -107,6 +107,12 @@ async function resolveWorkspaceUpstream(
 	}
 
 	// Fallback when `@{push}` isn't configured — mirrors gh's config chain.
+	// Require `branch.<n>.merge`; without it, `remote.pushDefault` alone would
+	// re-open the same-name collision hole on untracked branches.
+	const mergeRef = await tryConfig(git, `branch.${localBranch}.merge`);
+	const trackedBranch = mergeRef?.replace(/^refs\/heads\//, "");
+	if (!trackedBranch) return null;
+
 	const remoteValue =
 		(await tryConfig(git, `branch.${localBranch}.pushRemote`)) ??
 		(await tryConfig(git, "remote.pushDefault")) ??
@@ -120,10 +126,7 @@ async function resolveWorkspaceUpstream(
 	// `gh pr checkout` renames the local branch on collision (`main` →
 	// `quueli-main`) but the PR's headRefName stays `main`, so we key on the
 	// tracked remote branch, not the local name.
-	const mergeRef = await tryConfig(git, `branch.${localBranch}.merge`);
-	const branch = mergeRef?.replace(/^refs\/heads\//, "") || localBranch;
-
-	return { owner: parsed.owner, name: parsed.name, branch };
+	return { owner: parsed.owner, name: parsed.name, branch: trackedBranch };
 }
 
 async function tryRaw(

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -67,6 +67,93 @@ async function getHeadSha(git: Awaited<ReturnType<GitFactory>>) {
 	}
 }
 
+// `pushRemote` / `branch.remote` accept a remote name or a URL.
+async function resolveRemoteValueToUrl(
+	git: Awaited<ReturnType<GitFactory>>,
+	value: string,
+): Promise<string | null> {
+	if (/^(https?:|git@|ssh:)/.test(value)) return value;
+	try {
+		const url = await git.remote(["get-url", value]);
+		return typeof url === "string" ? url.trim() || null : null;
+	} catch {
+		return null;
+	}
+}
+
+async function resolveWorkspaceUpstream(
+	git: Awaited<ReturnType<GitFactory>>,
+	localBranch: string,
+): Promise<{ owner: string; name: string; branch: string } | null> {
+	// `@{push}` resolves remote+branch respecting all config precedence in one call.
+	const pushRef = await tryRaw(git, [
+		"rev-parse",
+		"--abbrev-ref",
+		`${localBranch}@{push}`,
+	]);
+	if (pushRef) {
+		const slash = pushRef.indexOf("/");
+		if (slash > 0) {
+			const url = await resolveRemoteValueToUrl(git, pushRef.slice(0, slash));
+			const parsed = url ? parseGitHubRemote(url) : null;
+			if (parsed) {
+				return {
+					owner: parsed.owner,
+					name: parsed.name,
+					branch: pushRef.slice(slash + 1),
+				};
+			}
+		}
+	}
+
+	// Fallback when `@{push}` isn't configured — mirrors gh's config chain.
+	const remoteValue =
+		(await tryConfig(git, `branch.${localBranch}.pushRemote`)) ??
+		(await tryConfig(git, "remote.pushDefault")) ??
+		(await tryConfig(git, `branch.${localBranch}.remote`));
+	if (!remoteValue) return null;
+
+	const url = await resolveRemoteValueToUrl(git, remoteValue);
+	const parsed = url ? parseGitHubRemote(url) : null;
+	if (!parsed) return null;
+
+	// `gh pr checkout` renames the local branch on collision (`main` →
+	// `quueli-main`) but the PR's headRefName stays `main`, so we key on the
+	// tracked remote branch, not the local name.
+	const mergeRef = await tryConfig(git, `branch.${localBranch}.merge`);
+	const branch = mergeRef?.replace(/^refs\/heads\//, "") || localBranch;
+
+	return { owner: parsed.owner, name: parsed.name, branch };
+}
+
+async function tryRaw(
+	git: Awaited<ReturnType<GitFactory>>,
+	args: string[],
+): Promise<string | null> {
+	try {
+		return (await git.raw(args)).trim() || null;
+	} catch {
+		return null;
+	}
+}
+
+async function tryConfig(
+	git: Awaited<ReturnType<GitFactory>>,
+	key: string,
+): Promise<string | null> {
+	return tryRaw(git, ["config", "--get", key]);
+}
+
+function upstreamKey(
+	owner: string | null,
+	repo: string | null,
+	branch: string,
+): string | null {
+	if (!owner || !repo) return null;
+	// GitHub owner/repo are case-insensitive; branch names are case-sensitive.
+	return `${owner.toLowerCase()}/${repo.toLowerCase()}#${branch}`;
+}
+
 type RepoProvider = "github";
 
 export interface PullRequestStateSnapshot {
@@ -213,8 +300,18 @@ export class PullRequestRuntimeManager {
 					continue;
 				}
 				const headSha = await getHeadSha(git);
+				const upstream = await resolveWorkspaceUpstream(git, branch);
+				const upstreamOwner = upstream?.owner ?? null;
+				const upstreamRepo = upstream?.name ?? null;
+				const upstreamBranch = upstream?.branch ?? null;
 
-				if (branch === workspace.branch && headSha === workspace.headSha) {
+				if (
+					branch === workspace.branch &&
+					headSha === workspace.headSha &&
+					upstreamOwner === workspace.upstreamOwner &&
+					upstreamRepo === workspace.upstreamRepo &&
+					upstreamBranch === workspace.upstreamBranch
+				) {
 					continue;
 				}
 
@@ -223,6 +320,9 @@ export class PullRequestRuntimeManager {
 					.set({
 						branch,
 						headSha,
+						upstreamOwner,
+						upstreamRepo,
+						upstreamBranch,
 					})
 					.where(eq(workspaces.id, workspace.id))
 					.run();
@@ -309,22 +409,32 @@ export class PullRequestRuntimeManager {
 			.all();
 		if (projectWorkspaces.length === 0) return;
 
-		const branchNames = [
-			...new Set(projectWorkspaces.map((workspace) => workspace.branch)),
-		];
-		const branchToPullRequest = await this.fetchRepoPullRequests(
+		const wantedKeys = new Set<string>();
+		for (const workspace of projectWorkspaces) {
+			const key = upstreamKey(
+				workspace.upstreamOwner,
+				workspace.upstreamRepo,
+				workspace.upstreamBranch ?? workspace.branch,
+			);
+			if (key) wantedKeys.add(key);
+		}
+
+		const keyToPullRequest = await this.fetchRepoPullRequests(
 			projectId,
 			repo,
-			branchNames,
+			wantedKeys,
 		);
 
 		for (const workspace of projectWorkspaces) {
-			const match = branchToPullRequest.get(workspace.branch) ?? null;
+			const key = upstreamKey(
+				workspace.upstreamOwner,
+				workspace.upstreamRepo,
+				workspace.upstreamBranch ?? workspace.branch,
+			);
+			const match = key ? keyToPullRequest.get(key) : undefined;
 			this.db
 				.update(workspaces)
-				.set({
-					pullRequestId: match?.id ?? null,
-				})
+				.set({ pullRequestId: match?.id ?? null })
 				.where(eq(workspaces.id, workspace.id))
 				.run();
 		}
@@ -391,33 +501,39 @@ export class PullRequestRuntimeManager {
 	private async fetchRepoPullRequests(
 		projectId: string,
 		repo: NormalizedRepoIdentity,
-		branches: string[],
+		wantedKeys: Set<string>,
 	): Promise<Map<string, { id: string }>> {
+		if (wantedKeys.size === 0) return new Map();
+
 		const octokit = await this.github();
 		const nodes = await fetchRepositoryPullRequests(octokit, {
 			owner: repo.owner,
 			name: repo.name,
 		});
 
-		const wantedBranches = new Set(branches);
-		const latestByBranch = new Map<string, (typeof nodes)[number]>();
+		const latestByKey = new Map<string, (typeof nodes)[number]>();
 
 		for (const node of nodes) {
-			if (!wantedBranches.has(node.headRefName)) continue;
-			const existing = latestByBranch.get(node.headRefName);
+			const key = upstreamKey(
+				node.headRepositoryOwner?.login ?? null,
+				node.headRepository?.name ?? null,
+				node.headRefName,
+			);
+			if (!key || !wantedKeys.has(key)) continue;
+			const existing = latestByKey.get(key);
 			if (
 				!existing ||
 				new Date(node.updatedAt).getTime() >
 					new Date(existing.updatedAt).getTime()
 			) {
-				latestByBranch.set(node.headRefName, node);
+				latestByKey.set(key, node);
 			}
 		}
 
-		const branchToRow = new Map<string, { id: string }>();
+		const keyToRow = new Map<string, { id: string }>();
 		const now = Date.now();
 
-		for (const [branch, node] of latestByBranch) {
+		for (const [key, node] of latestByKey) {
 			const existing = this.db.query.pullRequests
 				.findFirst({
 					where: and(
@@ -470,9 +586,9 @@ export class PullRequestRuntimeManager {
 					.run();
 			}
 
-			branchToRow.set(branch, { id: rowId });
+			keyToRow.set(key, { id: rowId });
 		}
 
-		return branchToRow;
+		return keyToRow;
 	}
 }

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/query.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/query.ts
@@ -10,6 +10,9 @@ export const PULL_REQUESTS_QUERY = `
 					isDraft
 					headRefName
 					headRefOid
+					isCrossRepository
+					headRepositoryOwner { login }
+					headRepository { name }
 					reviewDecision
 					updatedAt
 					statusCheckRollup {

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/types.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/types.ts
@@ -34,6 +34,9 @@ export interface GraphQLPullRequestNode {
 	isDraft: boolean;
 	headRefName: string;
 	headRefOid: string;
+	isCrossRepository: boolean;
+	headRepositoryOwner: { login: string } | null;
+	headRepository: { name: string } | null;
 	reviewDecision: "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | null;
 	updatedAt: string;
 	statusCheckRollup: {

--- a/packages/host-service/test/pull-requests.test.ts
+++ b/packages/host-service/test/pull-requests.test.ts
@@ -64,6 +64,9 @@ describe("PullRequestRuntimeManager branch sync", () => {
 		expect(setMock).toHaveBeenCalledWith({
 			branch: "feature/unborn",
 			headSha: null,
+			upstreamOwner: null,
+			upstreamRepo: null,
+			upstreamBranch: null,
 		});
 		expect(refreshProjectMock).toHaveBeenCalledWith("project-1", true);
 	});

--- a/plans/20260421-pr-detection-matcher-fix.md
+++ b/plans/20260421-pr-detection-matcher-fix.md
@@ -1,0 +1,37 @@
+# Plan: Fix PR → workspace matcher (cross-fork collision)
+
+Host-service matches workspaces to PRs by branch name only. Any cross-fork PR with a colliding `headRefName` gets misattributed — e.g. PR #3261 (`quueli/superset-windows:main`) attaches to every local `main` workspace.
+
+## Surface
+
+One writer, two readers:
+- **Writer** (buggy): `packages/host-service/src/runtime/pull-requests/pull-requests.ts:402-414`.
+- **Readers**: v1 sidebar (`pullRequests.getByWorkspaces`) and v2 workspace detail (`git.getPullRequest`). Both just join on `workspaces.pullRequestId`. Fixing the writer fixes both.
+
+## Changes
+
+1. **Query** (`utils/github-query/query.ts` + `types.ts`): add `headRepositoryOwner { login }`, `headRepository { name }`, `isCrossRepository`.
+
+2. **Schema** (`packages/host-service/src/db/schema.ts`): add `workspaces.upstreamOwner` + `workspaces.upstreamRepo`. Replace `workspaces_branch_idx` with composite `(upstreamOwner, upstreamRepo, branch)`. Migration via `bunx drizzle-kit generate --name="workspace_upstream_ref"` → `packages/host-service/drizzle/0003_*.sql`. Local SQLite, no Neon.
+
+3. **Populate upstream** in `syncWorkspaceBranches` (`pull-requests.ts:204`): resolve tracking remote via `branch.<name>.pushRemote` → `remote.pushDefault` → `branch.<name>.remote` (same order as `gh`), parse URL with `parseGitHubRemote`, store `(owner, name)`.
+
+4. **Rewrite matcher** (`pull-requests.ts:391-477`): key on `${owner}/${repo}#${branch}` tuples instead of branch strings. Workspaces with null upstream match nothing.
+
+## Existing infra
+
+`apps/desktop/src/lib/trpc/routers/workspaces/utils/github/pr-resolution.ts` already solves this correctly for desktop-main (shells to `gh`). Can't reuse directly — host-service uses Octokit GraphQL and may run remotely without `gh`. Follow-up PR: extract pure predicates (`prMatchesLocalBranch`, `shouldAcceptPRMatch`, `sortPRCandidates`) into `@superset/shared/pr-matching.ts` so both paths share them.
+
+## Removable
+
+- `workspaces_branch_idx` (schema.ts:114) — replaced by composite.
+
+## Verification
+
+- PR #3261 (cross-fork): workspace key `superset-sh/superset#main` vs PR key `quueli/superset-windows#main` → no match. ✅
+- Fork contributor: workspace upstream = their fork, PR head = their fork → match. ✅
+- Same branch name in two forks: tuples disambiguate. ✅
+
+## Rollout
+
+Ship all three changes in one PR. Existing workspaces get null upstream on migration; `syncWorkspaceBranches` fills within 30s — badges briefly missing, self-heals. No flag.

--- a/plans/20260421-pr-detection-matcher-fix.md
+++ b/plans/20260421-pr-detection-matcher-fix.md
@@ -1,37 +1,52 @@
-# Plan: Fix PR → workspace matcher (cross-fork collision)
+# Fix PR → workspace matcher (cross-fork collision)
 
-Host-service matches workspaces to PRs by branch name only. Any cross-fork PR with a colliding `headRefName` gets misattributed — e.g. PR #3261 (`quueli/superset-windows:main`) attaches to every local `main` workspace.
+Shipped in PR #3625.
 
-## Surface
+## The bug
 
-One writer, two readers:
-- **Writer** (buggy): `packages/host-service/src/runtime/pull-requests/pull-requests.ts:402-414`.
-- **Readers**: v1 sidebar (`pullRequests.getByWorkspaces`) and v2 workspace detail (`git.getPullRequest`). Both just join on `workspaces.pullRequestId`. Fixing the writer fixes both.
+Two workspace → PR match sites keyed on branch name alone. Any cross-fork PR whose `headRefName` collided with a local branch got attached — e.g. PR #3261 (`quueli/superset-windows:main` → `superset-sh/superset:main`) showing on every local `main` workspace.
 
-## Changes
+## Where the symptom came from
 
-1. **Query** (`utils/github-query/query.ts` + `types.ts`): add `headRepositoryOwner { login }`, `headRepository { name }`, `isCrossRepository`.
+- **v1 (`pr-resolution.ts`, visible to the user)** — powers `usePRStatus` via `workspaces.getGitHubStatus`. `prMatchesLocalBranch` accepted any PR whose `headRefName` equaled the local branch name. Cross-fork not considered. **This is what attached PR #3261 in the user's sidebar.**
+- **v2 / host-service (`pull-requests.ts`, latent)** — powers `pullRequests.getByWorkspaces` (`_dashboard` sidebar) + `git.getPullRequest` (v2 review tab). Same branch-name-only matcher. Wasn't firing in the reported environment because the host-service `workspaces` table was empty / pointing at deleted worktree paths, but the bug existed in code.
 
-2. **Schema** (`packages/host-service/src/db/schema.ts`): add `workspaces.upstreamOwner` + `workspaces.upstreamRepo`. Replace `workspaces_branch_idx` with composite `(upstreamOwner, upstreamRepo, branch)`. Migration via `bunx drizzle-kit generate --name="workspace_upstream_ref"` → `packages/host-service/drizzle/0003_*.sql`. Local SQLite, no Neon.
+## What we shipped
 
-3. **Populate upstream** in `syncWorkspaceBranches` (`pull-requests.ts:204`): resolve tracking remote via `branch.<name>.pushRemote` → `remote.pushDefault` → `branch.<name>.remote` (same order as `gh`), parse URL with `parseGitHubRemote`, store `(owner, name)`.
+### v1 (`apps/desktop/src/lib/trpc/routers/workspaces/utils/github/pr-resolution.ts`)
 
-4. **Rewrite matcher** (`pull-requests.ts:391-477`): key on `${owner}/${repo}#${branch}` tuples instead of branch strings. Workspaces with null upstream match nothing.
+- `prMatchesLocalBranch`: when the local branch has no fork-owner prefix, reject any PR with `isCrossRepository === true`. One line, uses the already-fetched and already-typed field that the predicate just never consulted.
+- Module header marks it **v1-only, dies with v1 UI sunset** — don't evolve, v2 already resolves PRs via host-service.
 
-## Existing infra
+### v2 / host-service (`packages/host-service/src/runtime/pull-requests/`)
 
-`apps/desktop/src/lib/trpc/routers/workspaces/utils/github/pr-resolution.ts` already solves this correctly for desktop-main (shells to `gh`). Can't reuse directly — host-service uses Octokit GraphQL and may run remotely without `gh`. Follow-up PR: extract pure predicates (`prMatchesLocalBranch`, `shouldAcceptPRMatch`, `sortPRCandidates`) into `@superset/shared/pr-matching.ts` so both paths share them.
+- **GraphQL query extended** with `isCrossRepository`, `headRepositoryOwner { login }`, `headRepository { name }`.
+- **Schema migration `0003_workspace_upstream_ref`** (local SQLite, not Neon): adds `upstream_owner`, `upstream_repo`, `upstream_branch` columns to `workspaces`; replaces `workspaces_branch_idx` with composite `workspaces_upstream_ref_idx`.
+- **`resolveWorkspaceUpstream`** populates those columns during `syncWorkspaceBranches`. Resolution modeled on `gh` CLI:
+  - `@{push}` happy path — single `git rev-parse --abbrev-ref <branch>@{push}` returns `remote/branch` respecting all config precedence.
+  - Fallback walks `branch.<n>.pushRemote` → `remote.pushDefault` → `branch.<n>.remote`, handling URL-valued configs in addition to remote names.
+  - Fallback requires explicit `branch.<n>.merge` — without it, a repo-wide `remote.pushDefault` would re-open the collision hole on untracked branches (coderabbit-flagged).
+  - `upstream_branch` is stored separately from local `branch` so `gh pr checkout` renames (`main` → `quueli-main`) still match the PR's `headRefName`.
+- **Matcher** keys on `(upstreamOwner, upstreamRepo, upstreamBranch)` tuples, lowercased for owner/repo (GitHub is case-insensitive there) and preserving branch casing.
 
-## Removable
+## What we didn't do
 
-- `workspaces_branch_idx` (schema.ts:114) — replaced by composite.
+- **Consolidate v1 and v2 into one path** — deferred. v1 dies with the v1 UI sunset (see `project_v1_sunset` memory). No port needed.
+- **`headRefOid` SHA-fallback in v2** — v1 has it (matches by HEAD commit when no tracking remote is set), v2 doesn't yet. Can be ported when v1 is actually deleted.
+
+## Review feedback addressed
+
+- **cubic-dev-ai** — case-sensitive owner/repo key. Fixed by lowercasing in `upstreamKey`.
+- **coderabbitai** — untracked branch could resolve via `remote.pushDefault` alone and latch onto same-named PR. Fixed by requiring `branch.<n>.merge` in fallback.
 
 ## Verification
 
-- PR #3261 (cross-fork): workspace key `superset-sh/superset#main` vs PR key `quueli/superset-windows#main` → no match. ✅
-- Fork contributor: workspace upstream = their fork, PR head = their fork → match. ✅
-- Same branch name in two forks: tuples disambiguate. ✅
+- PR #3261 (cross-fork): workspace upstream `superset-sh/superset#main` vs PR key `quueli/superset-windows#main` — no match in v2. v1 predicate returns false via `isCrossRepository` check. ✓
+- PR #3625 (this PR, same-repo): local branch `pr-3261-detection-in-v1-sidebar` tracking `origin/pr-3261-detection-in-v1-sidebar`. Tuples match in v2. v1 predicate returns true. ✓
+- Fresh untracked branch: upstream null, no match. ✓
+- `gh pr checkout` cross-fork review (local `quueli-main` tracking fork's `main`): `upstream_branch = main`, matches PR's `headRefName = main`. ✓
 
-## Rollout
+## Commit trail
 
-Ship all three changes in one PR. Existing workspaces get null upstream on migration; `syncWorkspaceBranches` fills within 30s — badges briefly missing, self-heals. No flag.
+- `aff1763bc` — main fix (both paths + schema + migration) after clean squash
+- `6811f7449` — coderabbit-flagged fallback gate


### PR DESCRIPTION
## Summary

Two workspace → PR match sites keyed on branch name alone, so any cross-fork PR whose `headRefName` collided with a local branch got attached. Example in the wild: PR #3261 (`quueli/superset-windows:main` → `superset-sh/superset:main`) showing up on every local `main` workspace.

Fixes:

- **`apps/desktop/.../pr-resolution.ts`** (v1 sidebar `usePRStatus` / `workspaces.getGitHubStatus`): `prMatchesLocalBranch` now rejects PRs with `isCrossRepository === true` when the local branch has no fork-owner prefix. One-line gate; `isCrossRepository` was already fetched and typed, just never consulted.
- **`packages/host-service/.../pull-requests.ts`** (`_dashboard` sidebar `pullRequests.getByWorkspaces` and v2 workspace review tab `git.getPullRequest`): matcher now keys on `(headRepositoryOwner, headRepository, headRefName)` tuples instead of branch strings. Adds `upstreamOwner`/`upstreamRepo` columns to the host-service `workspaces` table, populated during `syncWorkspaceBranches` by resolving the tracking remote using the same config fallback order as `gh` (`branch.<n>.pushRemote` → `remote.pushDefault` → `branch.<n>.remote`). GraphQL query extended with `isCrossRepository`, `headRepositoryOwner { login }`, `headRepository { name }`.

Migration `0003_workspace_upstream_ref` lives in `packages/host-service/drizzle/` — local SQLite only, no Neon impact. Replaces the now-unused `workspaces_branch_idx` with composite `workspaces_upstream_ref_idx` on `(upstream_owner, upstream_repo, branch)`. Auto-applies on next host-service start; existing workspaces get `null` upstream and self-heal within one 30s sync cycle.

Full design in `plans/20260421-pr-detection-matcher-fix.md`.

## Test plan

- [ ] Restart dev desktop (host-service child process needs to reload). Confirm v1 sidebar no longer shows PR #3261 on `main`.
- [ ] Same for v2 workspace detail Review tab.
- [ ] Contributor-from-fork workflow: workspace tracking a fork remote still resolves its own PR correctly.
- [ ] Workspace with no upstream (fresh branch, never pushed): no PR attached (expected).
- [ ] Two workspaces on the same branch name but different tracking remotes: each resolves its own PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops cross‑fork PRs from attaching to unrelated workspaces. We now match on upstream owner/repo + tracked branch, and the v1 sidebar ignores cross‑repo PRs when the local branch has no owner prefix.

- **Bug Fixes**
  - `apps/desktop` v1 sidebar: `prMatchesLocalBranch` rejects `isCrossRepository` when the local branch lacks a fork‑owner prefix.
  - `packages/host-service`: match on `${owner}/${repo}#${branch}` from the tracked upstream; resolve via `@{push}` first, then require `branch.<name>.merge` and fall back to `branch.<name>.pushRemote` → `remote.pushDefault` → `branch.<name>.remote`. Store `upstreamOwner`, `upstreamRepo`, `upstreamBranch`; lowercase owner/repo; GitHub query adds `isCrossRepository`, `headRepositoryOwner.login`, `headRepository.name`.

- **Migration**
  - Adds `upstream_owner`, `upstream_repo`, `upstream_branch` and replaces the branch index with composite `(upstream_owner, upstream_repo, upstream_branch)` via `0003_workspace_upstream_ref` (auto‑applies on host‑service start). Existing workspaces backfill on next sync; restart desktop in dev to reload the host‑service.

<sup>Written for commit 14587afd82736498f4e27a59b6a994b761309ef1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented incorrect PR-to-workspace matches when branch names collide across forks, improving cross-repository PR attribution.

* **New Features**
  * Workspaces now persist upstream owner/repo/branch so syncs and PR lookups use owner/repo#branch keys.
  * PR queries include cross-repository metadata for more accurate matching.

* **Documentation**
  * Added plan documenting the PR-to-workspace matching fix and verification steps.

* **Tests**
  * Updated tests to account for nullable upstream fields during branch sync.

* **Chores**
  * Added a database migration and schema snapshot to support upstream fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Related

- #2516 — same family of fork-workflow correctness bugs. That issue tracks the push-target half (`origin` hardcoded instead of tracking remote); this PR fixes the PR-matching half. Not a duplicate; both should land.
