### PR TITLE
feat(desktop): route non-setup projects to settings from new workspace modal

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -13,9 +13,11 @@ import {
 	PromptInputTools,
 	useProviderAttachments,
 } from "@superset/ui/ai-elements/prompt-input";
+import { Button } from "@superset/ui/button";
 import { Input } from "@superset/ui/input";
 import { isEnterSubmit } from "@superset/ui/lib/keyboard";
 import { cn } from "@superset/ui/utils";
+import { useNavigate } from "@tanstack/react-router";
 import type { FileUIPart } from "ai";
 import { AnimatePresence, motion } from "framer-motion";
 import { ArrowUpIcon } from "lucide-react";
@@ -41,7 +43,10 @@ import { PRLinkCommand } from "./components/PRLinkCommand";
 import { ProjectPickerPill } from "./components/ProjectPickerPill";
 import { useBranchPickerController } from "./hooks/useBranchPickerController";
 import { useLinkedContext } from "./hooks/useLinkedContext";
-import { useSubmitWorkspace } from "./hooks/useSubmitWorkspace";
+import {
+	type SubmitAttachment,
+	useSubmitWorkspace,
+} from "./hooks/useSubmitWorkspace";
 import {
 	AGENT_STORAGE_KEY,
 	PILL_BUTTON_CLASS,
@@ -65,7 +70,18 @@ export function PromptGroup({
 	const modKey = PLATFORM === "mac" ? "⌘" : "Ctrl";
 	const isNewWorkspaceModalOpen = useNewWorkspaceModalOpen();
 	const { closeModal, draft, updateDraft } = useDashboardNewWorkspaceDraft();
+	const navigate = useNavigate();
 	const attachments = useProviderAttachments();
+	const needsSetup = selectedProject?.needsSetup === true;
+	const handleGoToSetup = useCallback(() => {
+		if (!selectedProject?.id) return;
+		const targetProjectId = selectedProject.id;
+		closeModal();
+		void navigate({
+			to: "/settings/projects/$projectId",
+			params: { projectId: targetProjectId },
+		});
+	}, [closeModal, navigate, selectedProject?.id]);
 	const {
 		baseBranch,
 		hostTarget,
@@ -126,7 +142,17 @@ export function PromptGroup({
 	});
 
 	// ── Submit (fork) ────────────────────────────────────────────────
-	const handleCreate = useSubmitWorkspace(projectId);
+	const createWorkspace = useSubmitWorkspace(projectId);
+	const handleSubmit = useCallback(
+		(files: SubmitAttachment[] = []) => {
+			if (needsSetup) {
+				handleGoToSetup();
+				return;
+			}
+			void createWorkspace(files);
+		},
+		[createWorkspace, handleGoToSetup, needsSetup],
+	);
 	const handlePromptSubmit = useCallback(
 		(message: { text?: string; files?: FileUIPart[] }) => {
 			// Library converts blob: → data: URLs before calling us; pass them
@@ -140,9 +166,9 @@ export function PromptGroup({
 					mediaType: f.mediaType,
 					filename: f.filename,
 				}));
-			void handleCreate(files);
+			handleSubmit(files);
 		},
-		[handleCreate],
+		[handleSubmit],
 	);
 
 	useEffect(() => {
@@ -153,11 +179,11 @@ export function PromptGroup({
 			// Keyboard fallback: submit without attachments. Inside the
 			// modal's form focus, PromptInput's own Enter handler fires
 			// instead and routes through handlePromptSubmit with files.
-			void handleCreate();
+			handleSubmit();
 		};
 		window.addEventListener("keydown", handler);
 		return () => window.removeEventListener("keydown", handler);
-	}, [isNewWorkspaceModalOpen, handleCreate]);
+	}, [isNewWorkspaceModalOpen, handleSubmit]);
 
 	// ── Linked issues / PR ───────────────────────────────────────────
 	const {
@@ -349,9 +375,10 @@ export function PromptGroup({
 						/>
 						<PromptInputSubmit
 							className="size-[22px] rounded-full border border-transparent bg-foreground/10 shadow-none p-[5px] hover:bg-foreground/20"
+							disabled={needsSetup}
 							onClick={(e) => {
 								e.preventDefault();
-								void handleCreate();
+								handleSubmit();
 							}}
 						>
 							<ArrowUpIcon className="size-3.5 text-muted-foreground" />
@@ -400,14 +427,21 @@ export function PromptGroup({
 					</AnimatePresence>
 				</div>
 				<div className="flex items-center gap-1.5">
-					{selectedProject?.needsSetup === true && (
-						<span className="text-[11px] text-amber-500">
-							Project needs to be set up
+					{needsSetup ? (
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							className="h-6 px-2 text-[11px] text-amber-500 hover:text-amber-500"
+							onClick={handleGoToSetup}
+						>
+							Set up project…
+						</Button>
+					) : (
+						<span className="text-[11px] text-muted-foreground/50">
+							{modKey}↵
 						</span>
 					)}
-					<span className="text-[11px] text-muted-foreground/50">
-						{modKey}↵
-					</span>
 				</div>
 			</div>
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/index.ts
@@ -1,1 +1,4 @@
-export { useSubmitWorkspace } from "./useSubmitWorkspace";
+export {
+	type SubmitAttachment,
+	useSubmitWorkspace,
+} from "./useSubmitWorkspace";


### PR DESCRIPTION
## Summary

- When a user picks a project that isn't set up on the chosen host, the new-workspace modal now sends them to `/settings/projects/$projectId` (which renders `V2ProjectSettings` with clone / import / relocate UX) instead of firing a workspace creation that would blow up at "ensure local project."
- Replaces the tiny advisory "Project needs to be set up" amber text with a clickable **Set up project…** button in the modal footer.
- Disables the submit-arrow and unifies submit / ⌘↵ / form-submit through one `handleSubmit` wrapper that branches on `needsSetup`.

## Why this approach

The merged-in `V2ProjectSettings` page already owns the full setup flow — pick location, import existing, clone here, relocate, backfill-conflict detection — all calling the same `project.setup` mutation. Reusing it (instead of inlining setup UX into the modal) keeps one source of truth for setup and avoids schema/pending-row churn.

## Test plan

- [ ] Open new-workspace modal, select a project that's set up → submit works as before (fork / ⌘↵ / Enter).
- [ ] Switch to a project that isn't set up on the current host → footer shows **Set up project…** button, submit arrow is disabled.
- [ ] Click **Set up project…** → modal closes, navigates to `/settings/projects/<id>`, renders V2 project settings with the Location section.
- [ ] With a non-setup project selected, press ⌘↵ → same navigation as button click.
- [ ] After setting up the project in settings, reopen the new-workspace modal → project is "Available", submit works normally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route projects that aren’t set up to the V2 project settings from the new workspace modal, preventing failed workspace creation. Adds a clear “Set up project…” action and disables submit until setup is complete.

- **New Features**
  - Redirects non-setup selections to `/settings/projects/$projectId` (V2 Project Settings) and closes the modal.
  - Replaces amber advisory text with a “Set up project…” button in the modal footer.
  - Disables the prompt submit arrow when setup is needed; ⌘↵/Ctrl+Enter and form submit also route to settings.

- **Refactors**
  - Consolidates submit logic into a single `handleSubmit` that branches on `needsSetup`.
  - Re-exports `SubmitAttachment` from `useSubmitWorkspace` index.

<sup>Written for commit ffbc4ddd8a69a6492c06a8d98c27f2f8ce2bbf69. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced workspace creation flow to detect when a project requires setup and redirect users to the setup screen instead of proceeding with workspace creation.
  * Added a dedicated "Set up project" button in the workspace creation modal for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->