### PR TITLE
fix(desktop): make v2 new-workspace project dropdown scrollable

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/ProjectPickerPill/ProjectPickerPill.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/ProjectPickerPill/ProjectPickerPill.tsx
@@ -45,10 +45,14 @@ export function ProjectPickerPill({
 					<HiChevronUpDown className="size-3 shrink-0" />
 				</FormPickerTrigger>
 			</PopoverTrigger>
-			<PopoverContent align="start" className="w-60 p-0">
+			<PopoverContent
+				align="start"
+				className="w-60 p-0"
+				onWheel={(event) => event.stopPropagation()}
+			>
 				<Command>
 					<CommandInput placeholder="Search projects..." />
-					<CommandList>
+					<CommandList className="max-h-[min(320px,var(--radix-popover-content-available-height))]">
 						<CommandEmpty>No projects found.</CommandEmpty>
 						<CommandGroup>
 							{projects.map((project) => (


### PR DESCRIPTION
## Summary
- The project picker in the v2 new-workspace modal didn't scroll when there were many projects — wheel events bubbled to the modal scroll area behind, and the popover had no constraint tying it to available viewport space.
- Constrains the `CommandList` to `min(320px, --radix-popover-content-available-height)` so the list always fits inside the popover's available room and scrolls internally.
- Stops `wheel` propagation on `PopoverContent` so scrolling inside the dropdown doesn't scroll the modal behind. Mirrors the existing pattern in `CompareBaseBranchPicker`.

## Test plan
- [ ] Open the v2 new-workspace modal with an org that has many projects
- [ ] Open the project picker — list should scroll internally with mouse wheel and trackpad
- [ ] Confirm the modal scroll area behind the popover does not move while scrolling inside the dropdown
- [ ] Confirm the popover stays inside the viewport when the trigger is near the bottom of the screen

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the v2 new-workspace project dropdown so it scrolls inside the popover and stays within the viewport.
Constrains the `CommandList` to `min(320px, var(--radix-popover-content-available-height))` and stops `wheel` propagation on `PopoverContent` to prevent the modal behind from scrolling.

<sup>Written for commit efaed13d1fd5d895e30170d5d6d4a786fbeb50ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scroll-wheel interactions in the project picker from affecting parent scrolling.
  * Improved layout by constraining the project picker list height relative to available space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->