### PR TITLE
fix(desktop): tray shows correct org name for each host-service

### DIFF
--- a/packages/host-service/src/trpc/router/host/host.ts
+++ b/packages/host-service/src/trpc/router/host/host.ts
@@ -14,19 +14,23 @@ let cachedOrganization: {
 
 async function getOrganization(
 	api: ApiClient,
+	organizationId: string,
 ): Promise<{ id: string; name: string; slug: string }> {
 	if (
 		cachedOrganization &&
+		cachedOrganization.data.id === organizationId &&
 		Date.now() - cachedOrganization.cachedAt < ORGANIZATION_CACHE_TTL_MS
 	) {
 		return cachedOrganization.data;
 	}
 
-	const organization = await api.organization.getActiveFromJwt.query();
+	const organization = await api.organization.getByIdFromJwt.query({
+		id: organizationId,
+	});
 	if (!organization) {
 		throw new TRPCError({
 			code: "PRECONDITION_FAILED",
-			message: "No active organization",
+			message: "Organization not found or not accessible from JWT",
 		});
 	}
 
@@ -36,8 +40,7 @@ async function getOrganization(
 
 export const hostRouter = router({
 	info: protectedProcedure.query(async ({ ctx }) => {
-		const api = (ctx as { api: ApiClient }).api;
-		const organization = await getOrganization(api);
+		const organization = await getOrganization(ctx.api, ctx.organizationId);
 
 		return {
 			hostId: getHashedDeviceId(),

--- a/packages/trpc/src/router/organization/organization.ts
+++ b/packages/trpc/src/router/organization/organization.ts
@@ -92,6 +92,26 @@ export const organizationRouter = {
 		return org ?? null;
 	}),
 
+	getByIdFromJwt: jwtProcedure
+		.input(z.object({ id: z.string() }))
+		.query(async ({ ctx, input }) => {
+			if (!ctx.organizationIds.includes(input.id)) return null;
+
+			const membership = await db.query.members.findFirst({
+				where: and(
+					eq(members.userId, ctx.userId),
+					eq(members.organizationId, input.id),
+				),
+			});
+			if (!membership) return null;
+
+			const org = await db.query.organizations.findFirst({
+				where: eq(organizations.id, input.id),
+				columns: { id: true, name: true, slug: true },
+			});
+			return org ?? null;
+		}),
+
 	getInvitation: protectedProcedure
 		.input(z.uuid())
 		.query(async ({ ctx, input }) => {


### PR DESCRIPTION
## Summary

- `host.info` was calling `organization.getActiveFromJwt`, which resolves to `organizationIds[0]` on the JWT regardless of which org the host-service is configured for. Users in multiple orgs saw the same (first) membership name for every Host Service entry in the tray submenu.
- Added `organization.getByIdFromJwt({ id })` that verifies the requested id is in the JWT's `organizationIds` and that the membership row still exists, then returns `{ id, name, slug }`.
- Host-service `host.info` now passes `ctx.organizationId` (the per-process configured org) so each instance reports its own org. Cache key now includes orgId.

## Test plan

- [ ] Sign in as a user who belongs to 2+ orgs.
- [ ] Start host-services for each org (create/open workspaces in both).
- [ ] Open the macOS menu-bar tray, hover "Host Service (N)": each submenu entry shows the correct org name, not a duplicate of the first one.
- [ ] Remove user from org B (leaving JWT stale), reopen tray — entry for org B should now fail cleanly instead of returning the wrong name.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the tray showing the wrong organization name for users in multiple orgs. Each Host Service entry now displays its own org, and stale JWTs no longer return a misleading name.

- **Bug Fixes**
  - Added `organization.getByIdFromJwt({ id })` to validate the org against the JWT and active membership, returning `{ id, name, slug }`.
  - Updated `host.info` to use `ctx.organizationId` and fetch via the new method; cache now keys by orgId.
  - When the user no longer belongs to an org, the tray entry fails cleanly instead of showing the first org’s name.

<sup>Written for commit 837f8ec9a79cbeebfa6649be909b9abc3e840b08. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Strengthened organization access controls with improved validation and clearer error messaging when organizations are not accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->