### PR TITLE
feat(setup): clone v2 host-service DBs alongside v1 local DB

### DIFF
--- a/.superset/lib/setup/main.sh
+++ b/.superset/lib/setup/main.sh
@@ -36,7 +36,12 @@ setup_main() {
     step_failed "Seed local DB"
   fi
 
-  # Step 5: Seed auth token into superset-dev-data/
+  # Step 5: Seed host-service DBs into superset-dev-data/host/
+  if ! step_seed_host_dbs; then
+    step_failed "Seed host-service DBs"
+  fi
+
+  # Step 6: Seed auth token into superset-dev-data/
   if ! step_seed_auth_token; then
     step_failed "Seed auth token"
   fi

--- a/.superset/lib/setup/main.sh
+++ b/.superset/lib/setup/main.sh
@@ -41,7 +41,12 @@ setup_main() {
     step_failed "Seed host-service DBs"
   fi
 
-  # Step 6: Seed auth token into superset-dev-data/
+  # Step 6: Seed Electron renderer Local Storage from prod userData
+  if ! step_seed_renderer_state; then
+    step_failed "Seed renderer state"
+  fi
+
+  # Step 7: Seed auth token into superset-dev-data/
   if ! step_seed_auth_token; then
     step_failed "Seed auth token"
   fi

--- a/.superset/lib/setup/main.sh
+++ b/.superset/lib/setup/main.sh
@@ -41,12 +41,7 @@ setup_main() {
     step_failed "Seed host-service DBs"
   fi
 
-  # Step 6: Seed Electron renderer Local Storage from prod userData
-  if ! step_seed_renderer_state; then
-    step_failed "Seed renderer state"
-  fi
-
-  # Step 7: Seed auth token into superset-dev-data/
+  # Step 6: Seed auth token into superset-dev-data/
   if ! step_seed_auth_token; then
     step_failed "Seed auth token"
   fi

--- a/.superset/lib/setup/steps.sh
+++ b/.superset/lib/setup/steps.sh
@@ -692,6 +692,64 @@ step_seed_host_dbs() {
   return 0
 }
 
+step_seed_renderer_state() {
+  echo "🪟 Seeding Electron renderer state (Local Storage) from prod userData..."
+
+  # Renderer localStorage holds v2 sidebar pins, sections, terminal presets, etc.
+  # Without this, a fresh dev build boots with an empty sidebar even when the
+  # cloud + host.db clones have plenty of accessible workspaces.
+
+  if [ "$(uname)" != "Darwin" ]; then
+    warn "Renderer state seeding only implemented for macOS — skipping"
+    step_skipped "Seed renderer state (non-darwin)"
+    return 0
+  fi
+
+  local app_support="$HOME/Library/Application Support"
+  local source_userdata="$app_support/Superset"
+  local source_local_storage="$source_userdata/Local Storage"
+  local workspace_name="${SUPERSET_WORKSPACE_NAME:-$(basename "$PWD")}"
+  local dest_userdata="$app_support/Superset (${workspace_name})"
+  local dest_local_storage="$dest_userdata/Local Storage"
+  local force_overwrite="$FORCE_OVERWRITE_DATA"
+
+  if [ ! -d "$source_local_storage" ]; then
+    warn "No prod Local Storage found at $source_local_storage — skipping (dev sidebar will start empty)"
+    step_skipped "Seed renderer state (no source)"
+    return 0
+  fi
+
+  if [ -d "$dest_local_storage" ] && [ "$force_overwrite" != "1" ]; then
+    warn "Renderer state already exists at $dest_local_storage — skipping (use -f/--force)"
+    step_skipped "Seed renderer state (already exists)"
+    return 0
+  fi
+
+  mkdir -p "$dest_userdata"
+
+  if [ -d "$dest_local_storage" ] && [ "$force_overwrite" = "1" ]; then
+    rm -rf "$dest_local_storage"
+  fi
+
+  # APFS clonefile (cp -c) snapshots each file atomically, so prod can keep
+  # running. Worst case is the leveldb log loses its trailing partial record
+  # on first dev open — i.e. a pin you clicked seconds before setup may not
+  # carry over. Fall back to plain cp on non-APFS filesystems.
+  if ! cp -cR "$source_local_storage" "$dest_userdata/" 2>/dev/null; then
+    if ! cp -R "$source_local_storage" "$dest_userdata/"; then
+      error "Failed to copy $source_local_storage to $dest_userdata/"
+      return 1
+    fi
+  fi
+
+  # The flock guard from prod must not be inherited — its presence wouldn't
+  # block dev (different inode), but removing it keeps the snapshot tidy.
+  rm -f "$dest_local_storage/leveldb/LOCK"
+
+  success "Renderer state seeded from $source_local_storage"
+  return 0
+}
+
 step_seed_local_db() {
   echo "💾 Seeding local DB into superset-dev-data/..."
 

--- a/.superset/lib/setup/steps.sh
+++ b/.superset/lib/setup/steps.sh
@@ -618,7 +618,6 @@ step_seed_host_dbs() {
     return 0
   fi
 
-  # Collect org dirs that actually have a host.db
   local org_dirs=()
   for org_dir in "$source_root"/*/; do
     [ -d "$org_dir" ] || continue

--- a/.superset/lib/setup/steps.sh
+++ b/.superset/lib/setup/steps.sh
@@ -676,6 +676,9 @@ step_seed_host_dbs() {
     done
 
     if [ "$copy_failed" = "1" ]; then
+      # A lone host.db without its -wal/-shm siblings would make the next
+      # non-force run think this org is already seeded and skip it.
+      rm -f "$dest_db" "${dest_db}-shm" "${dest_db}-wal"
       return 1
     fi
 

--- a/.superset/lib/setup/steps.sh
+++ b/.superset/lib/setup/steps.sh
@@ -692,64 +692,6 @@ step_seed_host_dbs() {
   return 0
 }
 
-step_seed_renderer_state() {
-  echo "🪟 Seeding Electron renderer state (Local Storage) from prod userData..."
-
-  # Renderer localStorage holds v2 sidebar pins, sections, terminal presets, etc.
-  # Without this, a fresh dev build boots with an empty sidebar even when the
-  # cloud + host.db clones have plenty of accessible workspaces.
-
-  if [ "$(uname)" != "Darwin" ]; then
-    warn "Renderer state seeding only implemented for macOS — skipping"
-    step_skipped "Seed renderer state (non-darwin)"
-    return 0
-  fi
-
-  local app_support="$HOME/Library/Application Support"
-  local source_userdata="$app_support/Superset"
-  local source_local_storage="$source_userdata/Local Storage"
-  local workspace_name="${SUPERSET_WORKSPACE_NAME:-$(basename "$PWD")}"
-  local dest_userdata="$app_support/Superset (${workspace_name})"
-  local dest_local_storage="$dest_userdata/Local Storage"
-  local force_overwrite="$FORCE_OVERWRITE_DATA"
-
-  if [ ! -d "$source_local_storage" ]; then
-    warn "No prod Local Storage found at $source_local_storage — skipping (dev sidebar will start empty)"
-    step_skipped "Seed renderer state (no source)"
-    return 0
-  fi
-
-  if [ -d "$dest_local_storage" ] && [ "$force_overwrite" != "1" ]; then
-    warn "Renderer state already exists at $dest_local_storage — skipping (use -f/--force)"
-    step_skipped "Seed renderer state (already exists)"
-    return 0
-  fi
-
-  mkdir -p "$dest_userdata"
-
-  if [ -d "$dest_local_storage" ] && [ "$force_overwrite" = "1" ]; then
-    rm -rf "$dest_local_storage"
-  fi
-
-  # APFS clonefile (cp -c) snapshots each file atomically, so prod can keep
-  # running. Worst case is the leveldb log loses its trailing partial record
-  # on first dev open — i.e. a pin you clicked seconds before setup may not
-  # carry over. Fall back to plain cp on non-APFS filesystems.
-  if ! cp -cR "$source_local_storage" "$dest_userdata/" 2>/dev/null; then
-    if ! cp -R "$source_local_storage" "$dest_userdata/"; then
-      error "Failed to copy $source_local_storage to $dest_userdata/"
-      return 1
-    fi
-  fi
-
-  # The flock guard from prod must not be inherited — its presence wouldn't
-  # block dev (different inode), but removing it keeps the snapshot tidy.
-  rm -f "$dest_local_storage/leveldb/LOCK"
-
-  success "Renderer state seeded from $source_local_storage"
-  return 0
-}
-
 step_seed_local_db() {
   echo "💾 Seeding local DB into superset-dev-data/..."
 

--- a/.superset/lib/setup/steps.sh
+++ b/.superset/lib/setup/steps.sh
@@ -604,6 +604,94 @@ step_seed_auth_token() {
   return 0
 }
 
+step_seed_host_dbs() {
+  echo "🛰️  Seeding host-service DBs into superset-dev-data/host/..."
+
+  local source_root="$HOME/.superset/host"
+  local dev_data_dir="superset-dev-data"
+  local dest_root="$dev_data_dir/host"
+  local force_overwrite="$FORCE_OVERWRITE_DATA"
+
+  if [ ! -d "$source_root" ]; then
+    warn "No host-service DBs found at $source_root — skipping (host-service will create fresh DBs per org)"
+    step_skipped "Seed host-service DBs (no source dir)"
+    return 0
+  fi
+
+  # Collect org dirs that actually have a host.db
+  local org_dirs=()
+  for org_dir in "$source_root"/*/; do
+    [ -d "$org_dir" ] || continue
+    local org_id
+    org_id="$(basename "$org_dir")"
+    if [ -f "${org_dir}host.db" ]; then
+      org_dirs+=("$org_id")
+    fi
+  done
+
+  if [ ${#org_dirs[@]} -eq 0 ]; then
+    warn "No host.db files under $source_root — skipping"
+    step_skipped "Seed host-service DBs (no host.db files)"
+    return 0
+  fi
+
+  mkdir -p "$dest_root"
+  chmod 700 "$dev_data_dir" "$dest_root"
+
+  local seeded=0
+  local skipped=0
+  for org_id in "${org_dirs[@]}"; do
+    local source_db="$source_root/$org_id/host.db"
+    local dest_org_dir="$dest_root/$org_id"
+    local dest_db="$dest_org_dir/host.db"
+
+    if [ -f "$dest_db" ] && [ "$force_overwrite" != "1" ]; then
+      warn "Host DB already exists at $dest_db — skipping (use -f/--force)"
+      skipped=$((skipped + 1))
+      continue
+    fi
+
+    mkdir -p "$dest_org_dir"
+    chmod 700 "$dest_org_dir"
+
+    # Clear stale WAL siblings when overwriting so we don't mix old WAL
+    # data with a freshly-copied DB (their page pointers won't match).
+    if [ "$force_overwrite" = "1" ]; then
+      rm -f "$dest_db" "${dest_db}-shm" "${dest_db}-wal"
+    fi
+
+    # Copy all SQLite files so WAL data isn't lost when source is held open.
+    local copy_failed=0
+    for ext in "" "-shm" "-wal"; do
+      local source_file="${source_db}${ext}"
+      local dest_file="${dest_db}${ext}"
+
+      if [ -f "$source_file" ]; then
+        if ! cp "$source_file" "$dest_file"; then
+          error "Failed to copy $source_file to $dest_file"
+          copy_failed=1
+          break
+        fi
+        chmod 600 "$dest_file"
+      fi
+    done
+
+    if [ "$copy_failed" = "1" ]; then
+      return 1
+    fi
+
+    # Checkpoint the copy's WAL (no lock contention since nothing else has it open).
+    if command -v sqlite3 &> /dev/null; then
+      sqlite3 "$dest_db" "PRAGMA wal_checkpoint(TRUNCATE);" &> /dev/null || true
+    fi
+
+    seeded=$((seeded + 1))
+  done
+
+  success "Host-service DBs seeded ($seeded copied, $skipped skipped) from $source_root"
+  return 0
+}
+
 step_seed_local_db() {
   echo "💾 Seeding local DB into superset-dev-data/..."
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -9,6 +9,7 @@ import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { useHotkey } from "renderer/hotkeys";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { DashboardSidebar } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar";
+import { useDevSeedV2Sidebar } from "renderer/routes/_authenticated/hooks/useDevSeedV2Sidebar";
 import { ResizablePanel } from "renderer/screens/main/components/ResizablePanel";
 import { WorkspaceSidebar } from "renderer/screens/main/components/WorkspaceSidebar";
 import { DeleteWorkspaceDialog } from "renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components";
@@ -30,6 +31,7 @@ function DashboardLayout() {
 	const navigate = useNavigate();
 	const openNewWorkspaceModal = useOpenNewWorkspaceModal();
 	const { isV2CloudEnabled } = useIsV2CloudEnabled();
+	useDevSeedV2Sidebar();
 	// Get current workspace from route to pre-select project in new workspace modal
 	const matchRoute = useMatchRoute();
 	const currentWorkspaceMatch = matchRoute({

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDevSeedV2Sidebar/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDevSeedV2Sidebar/index.ts
@@ -1,0 +1,1 @@
+export { useDevSeedV2Sidebar } from "./useDevSeedV2Sidebar";

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDevSeedV2Sidebar/useDevSeedV2Sidebar.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDevSeedV2Sidebar/useDevSeedV2Sidebar.ts
@@ -1,0 +1,40 @@
+import { useEffect } from "react";
+import { env } from "renderer/env.renderer";
+import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
+import { useAccessibleV2Workspaces } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+
+const SEED_FLAG_KEY = "superset:dev:v2-sidebar-seeded";
+
+/**
+ * On first dev launch in a fresh worktree, the v2 sidebar localStorage
+ * (`v2WorkspaceLocalState`) is empty even when the cloud has plenty of
+ * accessible workspaces — Chromium localStorage is per-origin and the dev
+ * Vite origin (`http://localhost:<port>`) doesn't share data with the
+ * packaged-app `file://` origin. Seeding the leveldb file from prod userData
+ * doesn't help for the same reason.
+ *
+ * This hook auto-pins every accessible workspace once per worktree's dev
+ * userData so the sidebar isn't blank. The flag in localStorage prevents
+ * re-pinning workspaces the user has explicitly unpinned later.
+ */
+export function useDevSeedV2Sidebar(): void {
+	const collections = useCollections();
+	const { ensureWorkspaceInSidebar } = useDashboardSidebarState();
+	const { all: accessibleWorkspaces } = useAccessibleV2Workspaces();
+
+	useEffect(() => {
+		if (env.NODE_ENV !== "development") return;
+		if (window.localStorage.getItem(SEED_FLAG_KEY) === "1") return;
+		if (accessibleWorkspaces.length === 0) return;
+		if (collections.v2WorkspaceLocalState.state.size > 0) {
+			window.localStorage.setItem(SEED_FLAG_KEY, "1");
+			return;
+		}
+
+		for (const workspace of accessibleWorkspaces) {
+			ensureWorkspaceInSidebar(workspace.id, workspace.projectId);
+		}
+		window.localStorage.setItem(SEED_FLAG_KEY, "1");
+	}, [accessibleWorkspaces, collections, ensureWorkspaceInSidebar]);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDevSeedV2Sidebar/useDevSeedV2Sidebar.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDevSeedV2Sidebar/useDevSeedV2Sidebar.ts
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { env } from "renderer/env.renderer";
-import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useAccessibleV2Workspaces } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces";
+import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 
 const SEED_FLAG_KEY = "superset:dev:v2-sidebar-seeded";

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDevSeedV2Sidebar/useDevSeedV2Sidebar.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDevSeedV2Sidebar/useDevSeedV2Sidebar.ts
@@ -7,16 +7,12 @@ import { useCollections } from "renderer/routes/_authenticated/providers/Collect
 const SEED_FLAG_KEY = "superset:dev:v2-sidebar-seeded";
 
 /**
- * On first dev launch in a fresh worktree, the v2 sidebar localStorage
- * (`v2WorkspaceLocalState`) is empty even when the cloud has plenty of
- * accessible workspaces — Chromium localStorage is per-origin and the dev
- * Vite origin (`http://localhost:<port>`) doesn't share data with the
- * packaged-app `file://` origin. Seeding the leveldb file from prod userData
- * doesn't help for the same reason.
- *
- * This hook auto-pins every accessible workspace once per worktree's dev
- * userData so the sidebar isn't blank. The flag in localStorage prevents
- * re-pinning workspaces the user has explicitly unpinned later.
+ * Auto-pins accessible v2 workspaces in dev so a fresh worktree's sidebar
+ * isn't blank. Chromium's localStorage is per-origin: the dev Vite origin
+ * (`http://localhost:<port>`) can't share data with the packaged `file://`
+ * origin, so copying prod's leveldb seeds the wrong namespace. We pin at
+ * runtime instead. The flag prevents re-pinning workspaces the user later
+ * unpins.
  */
 export function useDevSeedV2Sidebar(): void {
 	const collections = useCollections();


### PR DESCRIPTION
## Summary
- Adds `step_seed_host_dbs` to `.superset/setup.sh` that clones every `~/.superset/host/<orgId>/host.db` into `superset-dev-data/host/<orgId>/host.db` so v2 workspaces open with host-service state prefilled (projects, workspaces, terminals, PRs).
- Mirrors the existing v1 `local.db` clone: copies `-shm`/`-wal` siblings, checkpoints the WAL on the copy, respects `-f/--force`, skips when source is absent.
- Runs after `step_seed_local_db` and before `step_seed_auth_token` in `main.sh` (so the force-overwrite `rm -rf superset-dev-data/` from the v1 seed happens first).

## Test plan
- [x] Ran `step_seed_host_dbs` in this worktree — 3 orgs copied, resulting DBs open with expected host-service tables (`projects`, `workspaces`, `terminal_sessions`, `pull_requests`, `__drizzle_migrations`).
- [x] Clean-env smoke test: orgs missing a `host.db` are skipped; rerun without `-f` skips existing destinations; rerun with `-f` overwrites and clears stale WAL siblings.
- [ ] End-to-end: create a v2 workspace from the desktop app and confirm the dev host-service sees the seeded org data.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clone v2 host-service DBs and auto-pin accessible v2 workspaces in dev so v2 opens with prefilled data and a populated sidebar.

- **New Features**
  - Added `step_seed_host_dbs` to clone per-org `host.db` from `~/.superset/host/<orgId>/` to `superset-dev-data/host/<orgId>/`; copies `-shm/-wal`, WAL checkpoints, and runs after the v1 local DB seed and before auth token seeding.
  - Added dev-only `useDevSeedV2Sidebar` to pin all accessible v2 workspaces once per worktree using a localStorage flag, avoiding per-origin localStorage issues.

- **Bug Fixes**
  - Clean up partial host DB copies on failure so a lone `host.db` isn’t left behind, preventing false “already seeded” skips on the next run.

<sup>Written for commit 91d5f10775a1d6e3ef16bf0139b49d6218baebdb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Setup seeds per-organization host databases during initialization.
  * Dev desktop seeds/pins V2 workspaces into the dashboard sidebar on first run in development.

* **Improvements**
  * Per-org overwrite control and safe-skip when source data is missing.
  * Robust DB copy handling, companion-file support, and WAL checkpointing after copy.

* **Bug Fixes**
  * Setup step sequencing updated to include the new seeding phase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->