### PR TITLE
feat(desktop): add Copy Branch Name to v1 and v2 sidebar context menus

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -38,6 +38,7 @@ export function DashboardSidebarWorkspaceItem({
 		cancelRename,
 		handleClick,
 		handleCopyPath,
+		handleCopyBranchName,
 		handleCreateSection,
 		handleDeleted,
 		handleOpenInFinder,
@@ -55,6 +56,7 @@ export function DashboardSidebarWorkspaceItem({
 		workspaceId: id,
 		projectId,
 		workspaceName: name,
+		branch,
 	});
 
 	const navigate = useNavigate();
@@ -119,6 +121,7 @@ export function DashboardSidebarWorkspaceItem({
 							}
 							onOpenInFinder={handleOpenInFinder}
 							onCopyPath={handleCopyPath}
+							onCopyBranchName={handleCopyBranchName}
 							onRemoveFromSidebar={() => removeWorkspaceFromSidebar(id)}
 							onRename={startRename}
 							onDelete={() => setIsDeleteDialogOpen(true)}
@@ -183,6 +186,7 @@ export function DashboardSidebarWorkspaceItem({
 						isLocalWorkspace={hostType === "local-device"}
 						onOpenInFinder={handleOpenInFinder}
 						onCopyPath={handleCopyPath}
+						onCopyBranchName={handleCopyBranchName}
 						onRemoveFromSidebar={() => removeWorkspaceFromSidebar(id)}
 						onRename={startRename}
 						onDelete={() => setIsDeleteDialogOpen(true)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
@@ -22,6 +22,7 @@ import {
 	LuCopy,
 	LuFolderOpen,
 	LuFolderPlus,
+	LuGitBranch,
 	LuPencil,
 	LuTrash2,
 	LuX,
@@ -38,6 +39,7 @@ interface DashboardSidebarWorkspaceContextMenuProps {
 	onMoveToSection: (sectionId: string | null) => void;
 	onOpenInFinder: () => void;
 	onCopyPath: () => void;
+	onCopyBranchName: () => void;
 	onRemoveFromSidebar: () => void;
 	onRename: () => void;
 	onDelete: () => void;
@@ -54,6 +56,7 @@ export function DashboardSidebarWorkspaceContextMenu({
 	onMoveToSection,
 	onOpenInFinder,
 	onCopyPath,
+	onCopyBranchName,
 	onRemoveFromSidebar,
 	onRename,
 	onDelete,
@@ -96,6 +99,11 @@ export function DashboardSidebarWorkspaceContextMenu({
 					</ContextMenuItem>
 				</>
 			)}
+			{!isLocalWorkspace && <ContextMenuSeparator />}
+			<ContextMenuItem onSelect={onCopyBranchName}>
+				<LuGitBranch className="size-4 mr-2" />
+				Copy Branch Name
+			</ContextMenuItem>
 			<ContextMenuSeparator />
 			<ContextMenuItem onSelect={onCreateSection}>
 				<LuFolderPlus className="size-4 mr-2" />

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
@@ -16,12 +16,14 @@ interface UseDashboardSidebarWorkspaceItemActionsOptions {
 	workspaceId: string;
 	projectId: string;
 	workspaceName: string;
+	branch: string;
 }
 
 export function useDashboardSidebarWorkspaceItemActions({
 	workspaceId,
 	projectId,
 	workspaceName,
+	branch,
 }: UseDashboardSidebarWorkspaceItemActionsOptions) {
 	const navigate = useNavigate();
 	const matchRoute = useMatchRoute();
@@ -144,10 +146,26 @@ export function useDashboardSidebarWorkspaceItemActions({
 		}
 	};
 
+	const handleCopyBranchName = async () => {
+		if (!branch) {
+			toast.error("Branch name is not available");
+			return;
+		}
+		try {
+			await copyToClipboard(branch);
+			toast.success("Branch name copied");
+		} catch (error) {
+			toast.error(
+				`Failed to copy branch name: ${error instanceof Error ? error.message : "Unknown error"}`,
+			);
+		}
+	};
+
 	return {
 		cancelRename,
 		handleClick,
 		handleCopyPath,
+		handleCopyBranchName,
 		handleCreateSection,
 		handleDeleted,
 		handleOpenInFinder,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
@@ -147,8 +147,18 @@ export function useDashboardSidebarWorkspaceItemActions({
 	};
 
 	const handleCopyBranchName = async () => {
-		if (!branch) return;
-		await copyToClipboard(branch);
+		if (!branch) {
+			toast.error("Branch name is not available");
+			return;
+		}
+		try {
+			await copyToClipboard(branch);
+			toast.success("Branch name copied");
+		} catch (error) {
+			toast.error(
+				`Failed to copy branch name: ${error instanceof Error ? error.message : "Unknown error"}`,
+			);
+		}
 	};
 
 	return {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
@@ -147,18 +147,8 @@ export function useDashboardSidebarWorkspaceItemActions({
 	};
 
 	const handleCopyBranchName = async () => {
-		if (!branch) {
-			toast.error("Branch name is not available");
-			return;
-		}
-		try {
-			await copyToClipboard(branch);
-			toast.success("Branch name copied");
-		} catch (error) {
-			toast.error(
-				`Failed to copy branch name: ${error instanceof Error ? error.message : "Unknown error"}`,
-			);
-		}
+		if (!branch) return;
+		await copyToClipboard(branch);
 	};
 
 	return {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/CollapsedWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/CollapsedWorkspaceItem.tsx
@@ -13,7 +13,7 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { type RefObject, useMemo, useState } from "react";
-import { LuCopy, LuX } from "react-icons/lu";
+import { LuCopy, LuGitBranch, LuX } from "react-icons/lu";
 import { createContextMenuDeleteDialogCoordinator } from "renderer/react-query/workspaces/useWorkspaceDeleteHandler";
 import type { ActivePaneStatus } from "shared/tabs-types";
 import { STROKE_WIDTH } from "../constants";
@@ -36,6 +36,7 @@ interface CollapsedWorkspaceItemProps {
 	onClick: () => void;
 	onDeleteClick: () => void;
 	onCopyPath: () => void;
+	onCopyBranchName: () => void;
 }
 
 export function CollapsedWorkspaceItem({
@@ -53,6 +54,7 @@ export function CollapsedWorkspaceItem({
 	onClick,
 	onDeleteClick,
 	onCopyPath,
+	onCopyBranchName,
 }: CollapsedWorkspaceItemProps) {
 	const isBranchWorkspace = type === "branch";
 	const deleteDialogCoordinator = useMemo(
@@ -131,6 +133,10 @@ export function CollapsedWorkspaceItem({
 						<ContextMenuItem onSelect={onCopyPath}>
 							<LuCopy className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />
 							Copy Path
+						</ContextMenuItem>
+						<ContextMenuItem onSelect={onCopyBranchName}>
+							<LuGitBranch className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />
+							Copy Branch Name
 						</ContextMenuItem>
 						<ContextMenuSeparator />
 						<ContextMenuItem

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/CollapsedWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/CollapsedWorkspaceItem.tsx
@@ -94,15 +94,27 @@ export function CollapsedWorkspaceItem({
 	if (isBranchWorkspace) {
 		return (
 			<>
-				<Tooltip delayDuration={300}>
-					<TooltipTrigger asChild>{collapsedButton}</TooltipTrigger>
-					<TooltipContent side="right" className="flex flex-col gap-0.5">
-						<span className="font-medium">local</span>
-						<span className="text-xs text-muted-foreground font-mono">
-							{branch}
-						</span>
-					</TooltipContent>
-				</Tooltip>
+				<ContextMenu>
+					<Tooltip delayDuration={300}>
+						<TooltipTrigger asChild>
+							<ContextMenuTrigger asChild>
+								{collapsedButton}
+							</ContextMenuTrigger>
+						</TooltipTrigger>
+						<TooltipContent side="right" className="flex flex-col gap-0.5">
+							<span className="font-medium">local</span>
+							<span className="text-xs text-muted-foreground font-mono">
+								{branch}
+							</span>
+						</TooltipContent>
+					</Tooltip>
+					<ContextMenuContent>
+						<ContextMenuItem onSelect={onCopyBranchName}>
+							<LuGitBranch className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />
+							Copy Branch Name
+						</ContextMenuItem>
+					</ContextMenuContent>
+				</ContextMenu>
 				<DeleteWorkspaceDialog
 					workspaceId={id}
 					workspaceName={name}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/CollapsedWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/CollapsedWorkspaceItem.tsx
@@ -97,9 +97,7 @@ export function CollapsedWorkspaceItem({
 				<ContextMenu>
 					<Tooltip delayDuration={300}>
 						<TooltipTrigger asChild>
-							<ContextMenuTrigger asChild>
-								{collapsedButton}
-							</ContextMenuTrigger>
+							<ContextMenuTrigger asChild>{collapsedButton}</ContextMenuTrigger>
 						</TooltipTrigger>
 						<TooltipContent side="right" className="flex flex-col gap-0.5">
 							<span className="font-medium">local</span>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceContextMenu.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceContextMenu.tsx
@@ -23,6 +23,7 @@ import {
 	LuEyeOff,
 	LuFolderOpen,
 	LuFolderPlus,
+	LuGitBranch,
 	LuMinus,
 	LuPencil,
 	LuX,
@@ -50,6 +51,7 @@ interface WorkspaceContextMenuProps {
 	onOpenInFinder: () => void;
 	onOpenInEditor: () => void;
 	onCopyPath: () => void;
+	onCopyBranchName: () => void;
 	onSetUnread: (isUnread: boolean) => void;
 	onResetStatus: () => void;
 	onDelete: () => void;
@@ -68,6 +70,7 @@ export function WorkspaceContextMenu({
 	onOpenInFinder,
 	onOpenInEditor,
 	onCopyPath,
+	onCopyBranchName,
 	onSetUnread,
 	onResetStatus,
 	onDelete,
@@ -149,6 +152,10 @@ export function WorkspaceContextMenu({
 			<ContextMenuItem onSelect={onCopyPath}>
 				<LuCopy className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />
 				Copy Path
+			</ContextMenuItem>
+			<ContextMenuItem onSelect={onCopyBranchName}>
+				<LuGitBranch className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />
+				Copy Branch Name
 			</ContextMenuItem>
 			<ContextMenuSeparator />
 			<ContextMenuSub>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -243,6 +243,11 @@ export function WorkspaceListItem({
 		await copyToClipboard(worktreePath);
 		toast.success("Path copied to clipboard");
 	};
+	const handleCopyBranchName = async () => {
+		if (!branch) return;
+		await copyToClipboard(branch);
+		toast.success("Branch name copied to clipboard");
+	};
 
 	const pr = githubStatus?.pr;
 	const diffStats =
@@ -270,6 +275,7 @@ export function WorkspaceListItem({
 				onClick={handleClick}
 				onDeleteClick={handleDeleteClick}
 				onCopyPath={handleCopyPath}
+				onCopyBranchName={handleCopyBranchName}
 			/>
 		);
 	}
@@ -467,6 +473,7 @@ export function WorkspaceListItem({
 				onOpenInFinder={handleOpenInFinder}
 				onOpenInEditor={handleOpenInEditor}
 				onCopyPath={handleCopyPath}
+				onCopyBranchName={handleCopyBranchName}
 				onSetUnread={(unread) => setUnread.mutate({ id, isUnread: unread })}
 				onResetStatus={() => resetWorkspaceStatus(id)}
 				onDelete={handleDeleteClick}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -246,7 +246,6 @@ export function WorkspaceListItem({
 	const handleCopyBranchName = async () => {
 		if (!branch) return;
 		await copyToClipboard(branch);
-		toast.success("Branch name copied to clipboard");
 	};
 
 	const pr = githubStatus?.pr;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -246,6 +246,7 @@ export function WorkspaceListItem({
 	const handleCopyBranchName = async () => {
 		if (!branch) return;
 		await copyToClipboard(branch);
+		toast.success("Branch name copied to clipboard");
 	};
 
 	const pr = githubStatus?.pr;


### PR DESCRIPTION
## Summary
- Adds a **Copy Branch Name** option to the right-click context menu on workspace items in both the v1 and v2 dashboard sidebars (expanded and collapsed views).
- Copies the workspace's git branch to the clipboard via the existing `useCopyToClipboard` hook and surfaces a success toast.

## Test plan
- [ ] v1 sidebar: right-click a worktree workspace (expanded) → Copy Branch Name → paste elsewhere matches the branch
- [ ] v1 sidebar: right-click a local ("branch") workspace → Copy Branch Name works
- [ ] v1 sidebar: collapse the sidebar, right-click a worktree item → Copy Branch Name works
- [ ] v2 sidebar: right-click a local-device workspace → Copy Branch Name works
- [ ] v2 sidebar: right-click a remote/cloud workspace → Copy Branch Name still appears and works
- [ ] v2 sidebar: collapsed variant → Copy Branch Name works
- [ ] Success toast "Branch name copied" shows each time

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Copy Branch Name to workspace context menus in v1 and v2 sidebars (expanded and collapsed) for local and remote/cloud workspaces. Copies the current git branch to the clipboard with a success toast; missing branch is a no-op in v1 and shows an error in v2.

- **Bug Fixes**
  - v1 collapsed local branch workspaces: right-click now opens a context menu, making Copy Branch Name accessible.

<sup>Written for commit 4238f88ea96d1671067b893f76e31e0d13df6ed7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Copy Branch Name" action to workspace context menus, enabling users to quickly copy branch names to clipboard with automatic success and error notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->