### PR TITLE
fix(cli): match host service PORT env var name in spawn

### DIFF
--- a/packages/cli/src/lib/host/spawn.ts
+++ b/packages/cli/src/lib/host/spawn.ts
@@ -108,6 +108,7 @@ export async function spawnHostService(
 			AUTH_TOKEN: options.sessionToken,
 			CLOUD_API_URL: env.CLOUD_API_URL,
 			RELAY_URL: env.RELAY_URL,
+			PORT: String(port),
 			HOST_SERVICE_PORT: String(port),
 			HOST_SERVICE_SECRET: secret,
 			HOST_DB_PATH: hostDbPath(options.organizationId),


### PR DESCRIPTION
## Summary

- `packages/cli/src/lib/host/spawn.ts` passed the spawned host service port as `HOST_SERVICE_PORT`, but `packages/host-service/src/env.ts` reads `PORT`, so the CLI's `--port` flag (and the random free port chosen by `findFreePort()`) was silently ignored. The host always listened on the default `4879` while the CLI polled a different port, causing `host start` to fail with `Host service failed to start within 10000ms`.
- Emit `PORT` alongside `HOST_SERVICE_PORT` so the host service picks up the CLI-selected port. Keeping the old name preserves backwards compatibility for any external reader.

Linear: https://linear.app/superset-sh/issue/SUPER-448

## Test plan

- [ ] `bun run lint:fix && bun run format:check` clean
- [ ] `bun --filter @superset/cli --filter @superset/host-service typecheck` passes
- [ ] Rebuild CLI (`cd packages/cli && bun run scripts/build-dist.ts --target=linux-x64`), extract tarball, run `SUPERSET_HOST_BIN=<scratch>/bin/superset-host <scratch>/bin/superset host start` — completes health check without `--port`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `PORT` when `@superset/cli` spawns the host service so it matches what `@superset/host-service` reads, fixing host start failures. The host now binds to the CLI-selected port (`--port` or a free port) instead of 4879, while keeping `HOST_SERVICE_PORT` for compatibility; aligns with Linear SUPER-448.

<sup>Written for commit c3aad6301b812d1c27d20412548ca43ce4b2906f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed host service initialization to properly configure the port environment variable when starting the runtime service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->