### PR TITLE
fix(cli): match host service PORT env var name in spawn

### DIFF
--- a/packages/cli/src/lib/host/spawn.ts
+++ b/packages/cli/src/lib/host/spawn.ts
@@ -108,6 +108,7 @@ export async function spawnHostService(
 			AUTH_TOKEN: options.sessionToken,
 			CLOUD_API_URL: env.CLOUD_API_URL,
 			RELAY_URL: env.RELAY_URL,
+			PORT: String(port),
 			HOST_SERVICE_PORT: String(port),
 			HOST_SERVICE_SECRET: secret,
 			HOST_DB_PATH: hostDbPath(options.organizationId),


### PR DESCRIPTION
## Summary

- `packages/cli/src/lib/host/spawn.ts` set `HOST_SERVICE_PORT` in the child env, but `packages/host-service/src/env.ts` reads `PORT`. The mismatch meant the `--port` flag was silently ignored and `host start` always failed the 10s health check because the CLI polled a random `findFreePort()` port while the host actually listened on the default `4879`.
- Emit both `PORT` (what host-service reads) and `HOST_SERVICE_PORT` (preserved for any external readers of the old name).

Linear: https://linear.app/superset-sh/issue/SUPER-448

## Test plan

- [x] `bun --filter @superset/cli --filter @superset/host-service typecheck`
- [x] `bun run lint:fix && bun run format:check`
- [ ] Smoke test: build CLI dist, extract tarball, run `SUPERSET_HOST_BIN=<scratch>/bin/superset-host <scratch>/bin/superset host start` and confirm the health check passes without `--port`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CLI-host service port env var mismatch so `--port` is respected and `host start` health checks pass. The `@superset/cli` spawn now sets both `PORT` (read by `@superset/host-service`) and `HOST_SERVICE_PORT` for backward compatibility; addresses Linear SUPER-448.

<sup>Written for commit c200087c20030c65118e82bc36500efdbec68b2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved environment variable configuration in the CLI to ensure the host service properly receives port settings during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->