### PR TITLE
feat(desktop): render mermaid diagrams in markdown pane

### DIFF
--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/components/EditableCodeBlockView/EditableCodeBlockView.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/components/EditableCodeBlockView/EditableCodeBlockView.tsx
@@ -1,3 +1,4 @@
+import { mermaid } from "@streamdown/mermaid";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -13,6 +14,10 @@ import {
 	FILE_VIEW_CODE_BLOCK_LANGUAGES,
 	getCodeBlockLanguageLabel,
 } from "renderer/lib/tiptap/code-block-languages";
+import { useTheme } from "renderer/stores";
+import { Streamdown } from "streamdown";
+
+const mermaidPlugins = { mermaid };
 
 export function EditableCodeBlockView({
 	node,
@@ -20,6 +25,8 @@ export function EditableCodeBlockView({
 	extension,
 }: NodeViewProps) {
 	const [menuOpen, setMenuOpen] = useState(false);
+	const theme = useTheme();
+	const isDark = theme?.type !== "light";
 
 	const attrs = node.attrs as { language?: string };
 	const htmlAttrs = extension.options.HTMLAttributes as { class?: string };
@@ -29,6 +36,10 @@ export function EditableCodeBlockView({
 		FILE_VIEW_CODE_BLOCK_LANGUAGES,
 		currentLanguage,
 	);
+
+	const isMermaid = currentLanguage === "mermaid";
+	const mermaidSource = node.textContent;
+	const showMermaidPreview = isMermaid && mermaidSource.trim().length > 0;
 
 	const { copyToClipboard, copied } = useCopyToClipboard();
 	const handleCopy = () => {
@@ -88,6 +99,21 @@ export function EditableCodeBlockView({
 					)}
 				</button>
 			</div>
+
+			{showMermaidPreview && (
+				<div
+					contentEditable={false}
+					className="mb-3 flex justify-center rounded-md bg-background p-3"
+				>
+					<Streamdown
+						mode="static"
+						plugins={mermaidPlugins}
+						mermaid={{ config: { theme: isDark ? "dark" : "default" } }}
+					>
+						{`\`\`\`mermaid\n${mermaidSource}\n\`\`\``}
+					</Streamdown>
+				</div>
+			)}
 
 			<code className="hljs block !bg-transparent">
 				<NodeViewContent />

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/components/EditableCodeBlockView/EditableCodeBlockView.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/components/EditableCodeBlockView/EditableCodeBlockView.tsx
@@ -66,10 +66,10 @@ export function EditableCodeBlockView({
 	return (
 		<NodeViewWrapper
 			as="pre"
-			className={`${htmlAttrs.class} relative group ${showMermaidPreview ? "!bg-transparent !p-0 !font-sans !text-base" : ""}`}
+			className={`${htmlAttrs.class} relative group ${showMermaidPreview ? "!bg-transparent !p-0" : ""}`}
 		>
 			<div
-				className={`absolute top-2 right-2 z-10 flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 ${menuOpen ? "opacity-100" : ""}`}
+				className={`absolute top-2 z-10 flex items-center gap-1 rounded-md border border-border bg-background/80 p-1 opacity-0 backdrop-blur-sm transition-opacity supports-[backdrop-filter]:bg-background/70 group-hover:opacity-100 group-focus-within:opacity-100 ${menuOpen ? "opacity-100" : ""} ${showMermaidPreview ? "left-2" : "right-2"}`}
 			>
 				{showMermaidToggle && (
 					<button
@@ -87,7 +87,7 @@ export function EditableCodeBlockView({
 								? "Edit mermaid source"
 								: "View mermaid diagram"
 						}
-						className="flex h-6 w-6 items-center justify-center rounded border border-border bg-background/80 backdrop-blur transition-colors hover:bg-accent"
+						className="flex items-center justify-center rounded p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
 					>
 						{mermaidMode === "preview" ? (
 							<HiOutlineCodeBracket className="h-3.5 w-3.5" />
@@ -100,7 +100,7 @@ export function EditableCodeBlockView({
 					<DropdownMenuTrigger asChild>
 						<button
 							type="button"
-							className="flex h-6 items-center gap-1 rounded border border-border bg-background/80 px-2 text-xs backdrop-blur transition-colors hover:bg-accent"
+							className="flex items-center gap-1 rounded px-2 py-1 text-muted-foreground text-xs transition-colors hover:bg-muted hover:text-foreground"
 						>
 							{currentLabel}
 							<HiChevronDown className="h-3 w-3" />
@@ -130,7 +130,7 @@ export function EditableCodeBlockView({
 					onClick={handleCopy}
 					aria-label={copied ? "Copied code block" : "Copy code block"}
 					title={copied ? "Copied code block" : "Copy code block"}
-					className="flex h-6 w-6 items-center justify-center rounded border border-border bg-background/80 backdrop-blur transition-colors hover:bg-accent"
+					className="flex items-center justify-center rounded p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
 				>
 					{copied ? (
 						<HiCheck className="h-3.5 w-3.5 text-green-500" />
@@ -141,13 +141,7 @@ export function EditableCodeBlockView({
 			</div>
 
 			{showMermaidPreview && (
-				<button
-					type="button"
-					contentEditable={false}
-					onClick={() => setMermaidMode("source")}
-					aria-label="Edit mermaid source"
-					className="flex w-full justify-center rounded-md bg-muted p-4 cursor-pointer hover:bg-muted/80 transition-colors"
-				>
+				<div contentEditable={false} className="w-full [&_.min-h-28]:min-h-80">
 					<Streamdown
 						mode="static"
 						plugins={mermaidPlugins}
@@ -155,11 +149,12 @@ export function EditableCodeBlockView({
 					>
 						{`\`\`\`mermaid\n${mermaidSource}\n\`\`\``}
 					</Streamdown>
-				</button>
+				</div>
 			)}
 
 			<code
-				className={`hljs block !bg-transparent ${showMermaidPreview ? "hidden" : ""}`}
+				className="hljs block !bg-transparent"
+				style={showMermaidPreview ? { display: "none" } : undefined}
 			>
 				<NodeViewContent />
 			</code>

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/components/EditableCodeBlockView/EditableCodeBlockView.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/components/EditableCodeBlockView/EditableCodeBlockView.tsx
@@ -8,7 +8,13 @@ import {
 import type { NodeViewProps } from "@tiptap/react";
 import { NodeViewContent, NodeViewWrapper } from "@tiptap/react";
 import { useState } from "react";
-import { HiCheck, HiChevronDown, HiOutlineClipboard } from "react-icons/hi2";
+import {
+	HiCheck,
+	HiChevronDown,
+	HiOutlineClipboard,
+	HiOutlineCodeBracket,
+	HiOutlineEye,
+} from "react-icons/hi2";
 import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import {
 	FILE_VIEW_CODE_BLOCK_LANGUAGES,
@@ -39,7 +45,13 @@ export function EditableCodeBlockView({
 
 	const isMermaid = currentLanguage === "mermaid";
 	const mermaidSource = node.textContent;
-	const showMermaidPreview = isMermaid && mermaidSource.trim().length > 0;
+	const mermaidHasContent = mermaidSource.trim().length > 0;
+	const [mermaidMode, setMermaidMode] = useState<"preview" | "source">(() =>
+		mermaidHasContent ? "preview" : "source",
+	);
+	const showMermaidPreview =
+		isMermaid && mermaidMode === "preview" && mermaidHasContent;
+	const showMermaidToggle = isMermaid && mermaidHasContent;
 
 	const { copyToClipboard, copied } = useCopyToClipboard();
 	const handleCopy = () => {
@@ -52,10 +64,38 @@ export function EditableCodeBlockView({
 	};
 
 	return (
-		<NodeViewWrapper as="pre" className={`${htmlAttrs.class} relative group`}>
+		<NodeViewWrapper
+			as="pre"
+			className={`${htmlAttrs.class} relative group ${showMermaidPreview ? "!bg-transparent !p-0 !font-sans !text-base" : ""}`}
+		>
 			<div
-				className={`absolute top-2 right-2 flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 ${menuOpen ? "opacity-100" : ""}`}
+				className={`absolute top-2 right-2 z-10 flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 ${menuOpen ? "opacity-100" : ""}`}
 			>
+				{showMermaidToggle && (
+					<button
+						type="button"
+						onClick={() =>
+							setMermaidMode(mermaidMode === "preview" ? "source" : "preview")
+						}
+						aria-label={
+							mermaidMode === "preview"
+								? "Edit mermaid source"
+								: "View mermaid diagram"
+						}
+						title={
+							mermaidMode === "preview"
+								? "Edit mermaid source"
+								: "View mermaid diagram"
+						}
+						className="flex h-6 w-6 items-center justify-center rounded border border-border bg-background/80 backdrop-blur transition-colors hover:bg-accent"
+					>
+						{mermaidMode === "preview" ? (
+							<HiOutlineCodeBracket className="h-3.5 w-3.5" />
+						) : (
+							<HiOutlineEye className="h-3.5 w-3.5" />
+						)}
+					</button>
+				)}
 				<DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
 					<DropdownMenuTrigger asChild>
 						<button
@@ -101,9 +141,12 @@ export function EditableCodeBlockView({
 			</div>
 
 			{showMermaidPreview && (
-				<div
+				<button
+					type="button"
 					contentEditable={false}
-					className="mb-3 flex justify-center rounded-md bg-background p-3"
+					onClick={() => setMermaidMode("source")}
+					aria-label="Edit mermaid source"
+					className="flex w-full justify-center rounded-md bg-muted p-4 cursor-pointer hover:bg-muted/80 transition-colors"
 				>
 					<Streamdown
 						mode="static"
@@ -112,10 +155,12 @@ export function EditableCodeBlockView({
 					>
 						{`\`\`\`mermaid\n${mermaidSource}\n\`\`\``}
 					</Streamdown>
-				</div>
+				</button>
 			)}
 
-			<code className="hljs block !bg-transparent">
+			<code
+				className={`hljs block !bg-transparent ${showMermaidPreview ? "hidden" : ""}`}
+			>
 				<NodeViewContent />
 			</code>
 		</NodeViewWrapper>

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/components/EditableCodeBlockView/EditableCodeBlockView.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/components/EditableCodeBlockView/EditableCodeBlockView.tsx
@@ -147,7 +147,7 @@ export function EditableCodeBlockView({
 						plugins={mermaidPlugins}
 						mermaid={{ config: { theme: isDark ? "dark" : "default" } }}
 					>
-						{`\`\`\`mermaid\n${mermaidSource}\n\`\`\``}
+						{`\`\`\`\`mermaid\n${mermaidSource}\n\`\`\`\``}
 					</Streamdown>
 				</div>
 			)}


### PR DESCRIPTION
## Summary
- Add live mermaid preview to the editable TipTap code-block node view (`EditableCodeBlockView`) in the markdown pane, rendered above the editable source via `Streamdown` + `@streamdown/mermaid` with theme-aware config.
- Closes the gap between v1 (editable rendered view, previously only syntax-highlighted mermaid source) and v2 (read-only path, already rendered via the shared `CodeBlock`).
- Only the editable view changed; the read-only path continues to route through `CodeBlock.tsx` unchanged.

## Test plan
- [ ] Open a markdown file in the v1 file viewer, switch to rendered view, paste a ```` ```mermaid ```` fenced block (e.g. `graph TD; A-->B`) and confirm the diagram renders above the source.
- [ ] Edit the mermaid source and confirm the diagram re-renders live.
- [ ] Toggle app theme between light and dark; confirm the diagram restyles.
- [ ] Open a markdown file in the v2 `MarkdownPreviewView` and confirm mermaid still renders (regression check on the read-only path).
- [ ] Non-mermaid code blocks (ts, py, etc.) render unchanged with the hljs source view.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render Mermaid diagrams in the markdown pane’s editable code blocks with a live preview and toggle. Aligns the v1 editable view with v2; read-only rendering remains unchanged.

- New Features
  - Live preview in `EditableCodeBlockView` for `mermaid`, with a toolbar/diagram toggle; keeps the source mounted and hidden so TipTap tracks content and raw code never shows.
  - Defaults: non-empty Mermaid blocks open in preview; empty blocks open in source.
  - Uses `Streamdown` with `@streamdown/mermaid`, theme-aware config, and a 4‑backtick fence to guard backticks in source; removes the extra frame, moves the hover toolbar to top-left in preview to avoid overlapping `Streamdown` controls, and increases default diagram height; other languages unchanged.

<sup>Written for commit 3062a1f7b63846fbffa500f986e51b9c0ff490eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mermaid diagram rendering inside code blocks with dark/light theme-aware previews.
  * Toggle to switch between static diagram preview and editable source for Mermaid blocks.
* **Style**
  * Layout and toolbar/button styling improved for better alignment and presentation when previews are shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->