### PR TITLE
feat(desktop): V1 project archive (local SQLite)

### DIFF
--- a/apps/desktop/docs/PR_PROJECT_ARCHIVE.md
+++ b/apps/desktop/docs/PR_PROJECT_ARCHIVE.md
@@ -1,0 +1,71 @@
+# Pull request: Project archive (V1 local SQLite)
+
+Use this as the GitHub PR description (it mirrors [`.github/pull_request_template.md`](../../.github/pull_request_template.md)).
+
+---
+
+## Description
+
+Adds a **project-level archive** flow for the desktop app’s **V1** path (local SQLite + `electronTrpc`), scoped to the local sidebar (`WorkspaceSidebar` / `getAllGrouped`). Archived projects are hidden from the main navbar (same mechanism as other hidden projects: `tabOrder: null`), but remain in the database with a dedicated **`archivedAt`** timestamp so they can be listed and restored.
+
+**Data model**
+
+- `packages/local-db`: nullable `projects.archivedAt` (epoch ms) + index; Drizzle migration `0041_vengeful_toxin.sql`.
+
+**Backend (tRPC)**
+
+- `projects.archive`: kill terminals for all workspaces in the project (same pattern as `projects.close`), set `archivedAt` and `tabOrder: null`, fix `lastActiveWorkspaceId` when needed, telemetry `project_archived`. Returns `workspaceIds` for the renderer.
+- `projects.unarchive`: clear `archivedAt`, call `activateProject` to restore `tabOrder`, telemetry `project_unarchived`. Guardrails for already-archived / not-archived.
+- `projects.getArchived`: archived projects with workspaces + `worktreePath`, ordered by `archivedAt` desc.
+
+**Renderer**
+
+- `useArchiveProject` / `useUnarchiveProject`: invalidate `workspaces.getAllGrouped`, `projects.getRecents`, `projects.getArchived`.
+- **Project header** context menu: **Archive project** (confirm dialog) + navigation away when the active workspace belongs to the archived project (mirrors close).
+- **Workspaces list** (`WorkspacesListView`): **Archived** filter segment; **Restore** per project; search works in that mode.
+- **Tabs store**: `removeTabsForWorkspaceIds` reuses `removeTab` so archived projects do not leave stale tab state.
+
+**Test / module-init fixes** (so `bun test` and related loads stay green)
+
+- `renderer/env.renderer.ts`: honor `SKIP_ENV_VALIDATION` when `NODE_ENV` is **`test`** as well as `development`, matching `apps/desktop/bunfig.toml` and `test-setup.ts`.
+- `renderer/lib/api-trpc-client.ts`: build API base URL from `process.env.NEXT_PUBLIC_API_URL` with the same default as Vite / schema, and **do not** import `renderer/env.renderer` at module top level (avoids circular init / TDZ in tests).
+
+**Out of scope (explicit)**
+
+- **V2 cloud** (`DashboardSidebar`, Electric collections, host DB): no parity in this PR; archive entry points exist on **V1** `ProjectHeader` only.
+
+## Related Issues
+
+<!-- e.g. closes #123 — replace or remove if none -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [x] New feature
+- [ ] Documentation
+- [ ] Refactor
+- [x] Other (please describe): **Test harness / module-init fixes** (`env.renderer` skip in `test`, `api-trpc-client` URL without importing `env`)
+
+## Testing
+
+**Automated**
+
+- `cd apps/desktop && bun test src/lib/trpc/routers/projects/project-archive.test.ts` (router coverage for `archive` / `unarchive` / `getArchived`).
+- `cd apps/desktop && bun test` for the full desktop suite.
+- From repo root: `bun run lint`, `bun run typecheck`, and desktop build as in CI (`bun turbo run build --filter=@superset/desktop`) when you want full parity.
+
+**Manual (V1 sidebar — V2 cloud flag off)**
+
+1. Right-click the **project row** (icon + name + workspace count), not a single workspace line → **Archive project** → confirm.
+2. Project disappears from the left nav; terminals for that project stop; if you were on a workspace in that project, navigation moves to another workspace or `/workspace`.
+3. Open workspaces list → **Archived** → see the project → **Restore** → project returns to the sidebar with sensible ordering.
+4. `projects.getRecents` still uses `tabOrder`; archived projects stay out of recents.
+
+## Screenshots (if applicable)
+
+<!-- Add before/after: project context menu with Archive; Archived list with Restore -->
+
+## Additional Notes
+
+- **Migration**: existing installs pick up `archived_at` via the new local-db migration on next app run (your normal migration path).
+- **PR process**: fork PR, allow maintainer edits — see [CONTRIBUTING.md](../../CONTRIBUTING.md).

--- a/apps/desktop/plans/done/20260422-project-archive-router-tests.md
+++ b/apps/desktop/plans/done/20260422-project-archive-router-tests.md
@@ -1,0 +1,108 @@
+# Plan: Automated tests for project archive / unarchive / getArchived
+
+## Goal
+
+Add **focused automated tests** so `projects.archive`, `projects.unarchive`, and `projects.getArchived` do not regress without pulling in Electron, a real SQLite file, or the full renderer.
+
+## Constraints (repo reality)
+
+- `apps/desktop/test-setup.ts` globally mocks `main/lib/local-db` and `@superset/local-db` with shallow stubs that are **not** stateful enough for multi-step archive flows.
+- Other desktop tests (e.g. `ai-name.test.ts`) **re-`mock.module("main/lib/local-db", …)`** inside the test file with a **small in-memory state** and fluent `select` / `update` shapes that mirror what the procedure calls.
+
+**Approach:** follow that pattern in a **dedicated test file** that installs mocks **before** importing the module under test (or uses dynamic `import()` after mocks, if load order bites).
+
+## Suggested file layout
+
+| Deliverable | Path (proposal) |
+|-------------|-----------------|
+| Router behavior tests | `apps/desktop/src/lib/trpc/routers/projects/project-archive.test.ts` |
+
+Keep the file **next to** `projects.ts` so reviewers find it quickly. If the file grows, split helpers into `project-archive.test-helpers.ts` (same folder).
+
+## Mocks to install (per test file)
+
+1. **`main/lib/local-db`** — Replace global stub with a **fake DB object** that:
+   - Stores rows for `projects`, `workspaces`, `settings` in plain JS structures (`Map` or arrays).
+   - Implements the **minimal** chain your procedures use, e.g.:
+     - `localDb.select().from(projects).where(eq(...)).get()`
+     - `localDb.select().from(workspaces).where(...).all()`
+     - `localDb.update(projects).set(...).where(...).run()`
+     - `localDb.select().from(settings).get()` (for `lastActiveWorkspaceId`)
+   - You do **not** need full Drizzle parity—only the shapes `projects.ts` actually calls for these three procedures.
+
+2. **`main/lib/workspace-runtime`** — `getWorkspaceRuntimeRegistry().getForWorkspaceId(id).terminal.killByWorkspaceId(id)`:
+   - Return `{ failed: 0 }` (and optionally assert it was called once per workspace).
+
+3. **`main/lib/analytics`** — `track` as `mock()`; assert `project_archived` / `project_unarchived` with expected payload keys (`project_id`).
+
+4. **`electron` `dialog`** — Not needed for these procedures (no `getWindow` path in archive/unarchive/getArchived).
+
+5. **Import order** — In Bun, declare `mock.module(...)` **before** importing `createProjectsRouter` or calling into `projects.archive` if you see stale mocks; otherwise use **dynamic `import()`** after all `mock.module` registrations.
+
+## Test cases (minimum set)
+
+### `getArchived`
+
+- **Empty:** no projects with `archivedAt` → `[]`.
+- **One project:** one archived project + two workspaces (one with `deletingAt` set) → result excludes deleting workspace; includes `worktreePath` string (branch workspace can use main repo path from fake project row).
+
+### `archive`
+
+- **Happy path:** project with `tabOrder: 1`, `archivedAt: null`, two workspaces → after mutation:
+  - `archivedAt` is a number (or `expect` close to `Date.now()` in a window),
+  - `tabOrder` is `null`,
+  - workspaces rows **unchanged** (still present),
+  - `killByWorkspaceId` called twice (or N times),
+  - `track("project_archived", …)` fired.
+- **Guard:** project already has `archivedAt` → `TRPCError` `BAD_REQUEST` (or whatever `projects.ts` throws).
+- **Not found:** unknown `id` → `NOT_FOUND` / `Error` per existing router style.
+- **Active workspace:** `settings.lastActiveWorkspaceId` equals one of the project’s workspace ids → after archive, setting updated to `null` or to the **next** id your fake `selectNextActiveWorkspace` would return—simplest is to mock `../workspaces/utils/db-helpers` **only** `selectNextActiveWorkspace` to return a fixed `"other-ws"` and assert `setLastActiveWorkspace` behavior via the fake `settings` row (if you mock those helpers, keep the mock narrow).
+
+**Note:** If mocking `selectNextActiveWorkspace` / `setLastActiveWorkspace` is heavy, split into a second test file that imports **only** the archive block by extracting logic (see “Refactor optional” below)—only do that if the mock graph becomes unmaintainable.
+
+### `unarchive`
+
+- **Happy path:** archived project (`archivedAt` set, `tabOrder: null`) → after mutation `archivedAt` is `null` and `tabOrder` restored per `activateProject` rules. Easiest assertion: mock `activateProject` as `mock()` and expect it called once with the refreshed project object **or** assert `tabOrder` is `max+1` if you implement full fake `getMaxProjectTabOrder` behavior in the fake DB.
+- **Guard:** `archivedAt` already null → `BAD_REQUEST`.
+- **Not found:** missing project → `NOT_FOUND`.
+
+### Terminal warning (optional)
+
+- If `killByWorkspaceId` returns `{ failed: 1 }`, archive response includes `terminalWarning` substring — one test.
+
+## Refactor (optional, only if mocks explode)
+
+If maintaining a fluent fake `localDb` for `projects.ts` is painful:
+
+1. Extract **pure** functions, e.g. `computeArchiveProjectUpdate(project, workspaces, now)` and `pickWorkspaceIdsForKill(workspaces)`, and unit-test those with plain objects.
+2. Keep the router as a thin orchestration layer.
+
+Only pursue this if the first test file becomes hundreds of lines of mock plumbing.
+
+## Renderer / hooks (phase 2, optional)
+
+Lower priority than router tests:
+
+- `useArchiveProject` / `useUnarchiveProject`: would require React Query + `electronTrpc` test doubles; usually skipped unless the repo already has a harness for hook tests.
+
+## CI / commands
+
+After implementation:
+
+```bash
+cd apps/desktop && bun test src/lib/trpc/routers/projects/project-archive.test.ts
+```
+
+Then full `bun test` under `apps/desktop` before PR update.
+
+## Definition of done
+
+- [ ] New test file runs in isolation and in full `apps/desktop` suite (`0 fail`).
+- [ ] Covers **happy path + guards** for archive and unarchive, and **shape** of `getArchived`.
+- [ ] No reliance on real network, real SQLite, or global `.env` beyond existing `test-setup` / `bunfig`.
+- [ ] PR description updated with one line: “Adds router tests for project archive.”
+
+## Out of scope
+
+- V2 / `DashboardSidebar` / Electric.
+- E2E (Playwright) unless the team already runs them for desktop flows.

--- a/apps/desktop/src/lib/trpc/routers/projects/project-archive.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/projects/project-archive.test.ts
@@ -1,0 +1,679 @@
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import { initTRPC } from "@trpc/server";
+import { eq } from "drizzle-orm";
+import superjson from "superjson";
+import * as localDbRelations from "../../../../../../../packages/local-db/src/schema/relations";
+import * as localDbSchema from "../../../../../../../packages/local-db/src/schema/schema";
+import * as localDbZod from "../../../../../../../packages/local-db/src/schema/zod";
+
+/**
+ * Human-ish SQL fragment from a Drizzle `SQL` tree (StringChunk text + column
+ * names). Used by the in-memory fake to branch on `isNotNull` / `isNull` / etc.
+ */
+function describeSqlCond(cond: unknown): string {
+	const parts: string[] = [];
+	const visit = (n: unknown) => {
+		if (n == null) return;
+		const o = n as {
+			constructor?: { name?: string };
+			value?: unknown[];
+			queryChunks?: unknown[];
+			name?: string;
+		};
+		if (o.constructor?.name === "StringChunk" && Array.isArray(o.value)) {
+			parts.push(String(o.value.join("")));
+			return;
+		}
+		if (typeof o.name === "string" && o.name) {
+			parts.push(o.name);
+			return;
+		}
+		if (Array.isArray(o.queryChunks)) {
+			for (const c of o.queryChunks) visit(c);
+		}
+	};
+	visit(cond);
+	return parts.join(" ");
+}
+
+function workspaceWhereExcludesDeleting(cond: unknown): boolean {
+	const d = describeSqlCond(cond);
+	return d.includes("deleting_at") && d.includes("is null");
+}
+
+function condIsArchivedAtNotNull(cond: unknown): boolean {
+	const d = describeSqlCond(cond);
+	return d.includes("archived_at") && d.includes("is not null");
+}
+
+function condIsTabOrderNotNull(cond: unknown): boolean {
+	const d = describeSqlCond(cond);
+	return d.includes("tab_order") && d.includes("is not null");
+}
+
+const { projects, settings, workspaces } = localDbSchema;
+
+mock.module("@superset/local-db", () => ({
+	...localDbSchema,
+	...localDbZod,
+	...localDbRelations,
+}));
+mock.module("@superset/local-db/schema", () => ({
+	...localDbSchema,
+	...localDbZod,
+	...localDbRelations,
+}));
+
+const killByWorkspaceIdMock = mock(async () => ({ failed: 0 }));
+
+mock.module("main/lib/workspace-runtime", () => ({
+	getWorkspaceRuntimeRegistry: () => ({
+		getForWorkspaceId: (_workspaceId: string) => ({
+			terminal: { killByWorkspaceId: killByWorkspaceIdMock },
+		}),
+	}),
+}));
+
+const trackMock = mock(() => {});
+
+mock.module("main/lib/analytics", () => ({
+	track: trackMock,
+	clearUserCache: mock(() => {}),
+	shutdown: mock(() => Promise.resolve()),
+}));
+
+type ProjectRow = typeof projects.$inferSelect;
+type WorkspaceRow = typeof workspaces.$inferSelect;
+type SettingsRow = typeof settings.$inferSelect;
+
+/** Collect Param values from a Drizzle SQL condition (depth-first). */
+function collectParamValues(cond: unknown): unknown[] {
+	const out: unknown[] = [];
+	const visit = (node: unknown) => {
+		if (node == null) return;
+		const n = node as {
+			constructor?: { name?: string };
+			value?: unknown;
+			queryChunks?: unknown[];
+		};
+		if (n.constructor?.name === "Param" && "value" in n) {
+			out.push(n.value);
+			return;
+		}
+		if (Array.isArray(n.queryChunks)) {
+			for (const ch of n.queryChunks) visit(ch);
+		}
+	};
+	visit(cond);
+	return out;
+}
+
+function createFakeLocalDb() {
+	const projectById = new Map<string, ProjectRow>();
+	const workspaceList: WorkspaceRow[] = [];
+	let settingsRow = {
+		id: 1,
+		lastActiveWorkspaceId: null,
+		terminalPresets: null,
+		terminalPresetsInitialized: null,
+		agentPresetOverrides: null,
+		agentCustomDefinitions: null,
+		agentPresetPermissionsMigratedAt: null,
+		selectedRingtoneId: null,
+		activeOrganizationId: null,
+		confirmOnQuit: null,
+		terminalLinkBehavior: null,
+	} as SettingsRow;
+
+	function cloneProject(p: ProjectRow): ProjectRow {
+		return { ...p };
+	}
+
+	function cloneWorkspace(w: WorkspaceRow): WorkspaceRow {
+		return { ...w };
+	}
+
+	const localDb = {
+		insert(table: unknown) {
+			return {
+				values: (row: ProjectRow | WorkspaceRow | SettingsRow) => {
+					const baseRun = () => {
+						if (table === projects) {
+							const p = row as ProjectRow;
+							projectById.set(p.id, cloneProject(p));
+						} else if (table === workspaces) {
+							workspaceList.push(cloneWorkspace(row as WorkspaceRow));
+						} else if (table === settings) {
+							settingsRow = {
+								...settingsRow,
+								...(row as SettingsRow),
+							} as SettingsRow;
+						}
+					};
+					return {
+						run: baseRun,
+						onConflictDoUpdate(opts: { set: Partial<SettingsRow> }) {
+							return {
+								run: () => {
+									if (table === settings) {
+										settingsRow = {
+											...settingsRow,
+											...(row as SettingsRow),
+											...opts.set,
+										} as SettingsRow;
+									} else {
+										baseRun();
+									}
+								},
+							};
+						},
+					};
+				},
+			};
+		},
+
+		select(_fields?: Record<string, unknown>) {
+			const isPartialSelect =
+				_fields != null &&
+				typeof _fields === "object" &&
+				!Array.isArray(_fields);
+			return {
+				from(table: unknown) {
+					if (isPartialSelect && table === workspaces) {
+						return {
+							innerJoin(_other: unknown, _on: unknown) {
+								return {
+									where(_cond: unknown) {
+										return {
+											orderBy(..._args: unknown[]) {
+												return {
+													all: (): { id: string; lastOpenedAt: number }[] => {
+														const rows: {
+															id: string;
+															lastOpenedAt: number;
+														}[] = [];
+														for (const w of workspaceList) {
+															if (w.deletingAt != null) continue;
+															const p = projectById.get(w.projectId);
+															if (!p || p.tabOrder == null) continue;
+															rows.push({
+																id: w.id,
+																lastOpenedAt: w.lastOpenedAt,
+															});
+														}
+														rows.sort(
+															(a, b) => b.lastOpenedAt - a.lastOpenedAt,
+														);
+														return rows;
+													},
+												};
+											},
+										};
+									},
+								};
+							},
+						};
+					}
+					return {
+						where(cond: unknown) {
+							return {
+								get: ():
+									| ProjectRow
+									| WorkspaceRow
+									| SettingsRow
+									| undefined => {
+									if (table === settings) {
+										return { ...settingsRow };
+									}
+									if (table === projects) {
+										const params = collectParamValues(cond);
+										for (const p of projectById.values()) {
+											if (params.includes(p.id)) return cloneProject(p);
+										}
+										if (condIsArchivedAtNotNull(cond)) {
+											for (const p of projectById.values()) {
+												if (p.archivedAt != null) return cloneProject(p);
+											}
+										}
+										return undefined;
+									}
+									return undefined;
+								},
+								all: (): ProjectRow[] | WorkspaceRow[] => {
+									if (table === projects) {
+										if (condIsTabOrderNotNull(cond)) {
+											return [...projectById.values()]
+												.filter((p) => p.tabOrder != null)
+												.map(cloneProject);
+										}
+									}
+									if (table === workspaces) {
+										const params = collectParamValues(cond);
+										const projectIdFilter = params.find(
+											(v) =>
+												typeof v === "string" && projectById.has(v as string),
+										) as string | undefined;
+										if (projectIdFilter) {
+											let list = workspaceList.filter(
+												(w) => w.projectId === projectIdFilter,
+											);
+											if (workspaceWhereExcludesDeleting(cond)) {
+												list = list.filter((w) => w.deletingAt == null);
+											}
+											return list.map(cloneWorkspace);
+										}
+										if (cond && collectParamValues(cond).length >= 1) {
+											const pid = String(params[0]);
+											let list = workspaceList.filter(
+												(w) => w.projectId === pid,
+											);
+											if (workspaceWhereExcludesDeleting(cond)) {
+												list = list.filter((w) => w.deletingAt == null);
+											}
+											return list.map(cloneWorkspace);
+										}
+									}
+									return [];
+								},
+								orderBy(..._args: unknown[]) {
+									return {
+										all: (): ProjectRow[] => {
+											let rows = [...projectById.values()];
+											if (condIsArchivedAtNotNull(cond)) {
+												rows = rows.filter((p) => p.archivedAt != null);
+												rows.sort(
+													(a, b) => (b.archivedAt ?? 0) - (a.archivedAt ?? 0),
+												);
+												return rows.map(cloneProject);
+											}
+											if (condIsTabOrderNotNull(cond)) {
+												rows = rows.filter((p) => p.tabOrder != null);
+												rows.sort((a, b) => b.lastOpenedAt - a.lastOpenedAt);
+												return rows.map(cloneProject);
+											}
+											rows.sort(
+												(a, b) => (b.archivedAt ?? 0) - (a.archivedAt ?? 0),
+											);
+											return rows.map(cloneProject);
+										},
+									};
+								},
+							};
+						},
+						get(): SettingsRow | undefined {
+							if (table === settings) return { ...settingsRow };
+							return undefined;
+						},
+					};
+				},
+			};
+		},
+
+		update(table: unknown) {
+			return {
+				set(patch: Partial<ProjectRow> | Partial<SettingsRow>) {
+					return {
+						where(cond: unknown) {
+							return {
+								run: () => {
+									if (table === projects) {
+										const params = collectParamValues(cond);
+										for (const [id, p] of projectById) {
+											if (params.includes(id)) {
+												projectById.set(id, {
+													...p,
+													...(patch as Partial<ProjectRow>),
+												} as ProjectRow);
+											}
+										}
+									} else if (table === settings) {
+										settingsRow = {
+											...settingsRow,
+											...(patch as Partial<SettingsRow>),
+										} as SettingsRow;
+									}
+								},
+							};
+						},
+					};
+				},
+			};
+		},
+	};
+
+	return {
+		localDb,
+		projectById,
+		workspaceList,
+		get settings() {
+			return settingsRow;
+		},
+	};
+}
+
+const dbHolder: {
+	current: ReturnType<typeof createFakeLocalDb> | null;
+} = { current: null };
+
+const localDbFacade = new Proxy(
+	{} as ReturnType<typeof createFakeLocalDb>["localDb"],
+	{
+		get(_target, prop, _receiver) {
+			const h = dbHolder.current;
+			if (!h) throw new Error("[project-archive.test] db not initialized");
+			const v = Reflect.get(h.localDb, prop, h.localDb);
+			return typeof v === "function" ? v.bind(h.localDb) : v;
+		},
+	},
+);
+
+mock.module("main/lib/local-db", () => ({
+	localDb: localDbFacade,
+}));
+
+const testT = initTRPC.create({ transformer: superjson, isServer: true });
+
+const { createProjectsRouter } = await import("./projects");
+
+const createCaller = testT.createCallerFactory(
+	createProjectsRouter(() => null),
+);
+
+const caller = createCaller({});
+
+const PROJECT_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const WS_ACTIVE = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const WS_DELETING = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+const OTHER_PROJECT_ID = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+const OTHER_WS = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee";
+
+const now = () => Date.now();
+
+function getFakeDb(): ReturnType<typeof createFakeLocalDb> {
+	const h = dbHolder.current;
+	if (!h) throw new Error("[project-archive.test] db not initialized");
+	return h;
+}
+
+/** Typed escape hatch: the in-memory fake matches Drizzle call shapes but is not a full `LocalDb` type. */
+function getProjectRowById(
+	h: ReturnType<typeof createFakeLocalDb>,
+	id: string,
+): ProjectRow | undefined {
+	type SelectProject = {
+		select(): {
+			from(table: unknown): {
+				where(cond: unknown): { get(): ProjectRow | undefined };
+			};
+		};
+	};
+	return (h.localDb as SelectProject)
+		.select()
+		.from(projects)
+		.where(eq(projects.id, id))
+		.get();
+}
+
+function seedActiveProject(h: ReturnType<typeof createFakeLocalDb>) {
+	const t = now();
+	h.localDb
+		.insert(projects)
+		.values({
+			id: PROJECT_ID,
+			mainRepoPath: "/tmp/archive-test-repo",
+			name: "Archive Test",
+			color: "#336699",
+			tabOrder: 0,
+			lastOpenedAt: t,
+			createdAt: t,
+			archivedAt: null,
+			defaultBranch: null,
+			configToastDismissed: null,
+			workspaceBaseBranch: null,
+			githubOwner: null,
+			branchPrefixMode: null,
+			branchPrefixCustom: null,
+			worktreeBaseDir: null,
+			hideImage: null,
+			iconUrl: null,
+			neonProjectId: null,
+			defaultApp: null,
+		} as ProjectRow)
+		.run();
+
+	h.localDb
+		.insert(settings)
+		.values({
+			id: 1,
+			lastActiveWorkspaceId: null,
+		} as SettingsRow)
+		.run();
+
+	h.localDb
+		.insert(workspaces)
+		.values({
+			id: WS_ACTIVE,
+			projectId: PROJECT_ID,
+			worktreeId: null,
+			type: "branch",
+			branch: "main",
+			name: "default",
+			tabOrder: 0,
+			createdAt: t,
+			updatedAt: t,
+			lastOpenedAt: t,
+			isUnread: false,
+			isUnnamed: false,
+			deletingAt: null,
+			sectionId: null,
+			portBase: null,
+		} as WorkspaceRow)
+		.run();
+
+	h.localDb
+		.insert(workspaces)
+		.values({
+			id: WS_DELETING,
+			projectId: PROJECT_ID,
+			worktreeId: null,
+			type: "branch",
+			branch: "side",
+			name: "side",
+			tabOrder: 1,
+			createdAt: t,
+			updatedAt: t,
+			lastOpenedAt: t,
+			isUnread: false,
+			isUnnamed: false,
+			deletingAt: t,
+			sectionId: null,
+			portBase: null,
+		} as WorkspaceRow)
+		.run();
+}
+
+describe("projects archive / unarchive / getArchived", () => {
+	beforeEach(() => {
+		killByWorkspaceIdMock.mockReset();
+		killByWorkspaceIdMock.mockResolvedValue({ failed: 0 });
+		trackMock.mockReset();
+		dbHolder.current = createFakeLocalDb();
+	});
+
+	afterAll(() => {
+		dbHolder.current = null;
+	});
+
+	it("getArchived returns [] when nothing is archived", async () => {
+		const h = getFakeDb();
+		const t = now();
+		h.localDb
+			.insert(projects)
+			.values({
+				id: PROJECT_ID,
+				mainRepoPath: "/tmp/r",
+				name: "P",
+				color: "#000",
+				tabOrder: 0,
+				lastOpenedAt: t,
+				createdAt: t,
+				archivedAt: null,
+				defaultBranch: null,
+				configToastDismissed: null,
+				workspaceBaseBranch: null,
+				githubOwner: null,
+				branchPrefixMode: null,
+				branchPrefixCustom: null,
+				worktreeBaseDir: null,
+				hideImage: null,
+				iconUrl: null,
+				neonProjectId: null,
+				defaultApp: null,
+			} as ProjectRow)
+			.run();
+
+		await expect(caller.getArchived()).resolves.toEqual([]);
+	});
+
+	it("archive sets archivedAt and tabOrder null, kills terminals, returns workspaceIds", async () => {
+		seedActiveProject(getFakeDb());
+
+		const result = await caller.archive({ id: PROJECT_ID });
+
+		expect(result.success).toBe(true);
+		expect(result.workspaceIds.sort()).toEqual([WS_ACTIVE, WS_DELETING].sort());
+		expect(killByWorkspaceIdMock).toHaveBeenCalledTimes(2);
+		expect(trackMock).toHaveBeenCalledWith("project_archived", {
+			project_id: PROJECT_ID,
+		});
+
+		const row = getProjectRowById(getFakeDb(), PROJECT_ID);
+		expect(row?.tabOrder).toBeNull();
+		expect(row?.archivedAt).toBeNumber();
+	});
+
+	it("archive updates lastActiveWorkspace when it points into the project", async () => {
+		seedActiveProject(getFakeDb());
+		getFakeDb()
+			.localDb.update(settings)
+			.set({ lastActiveWorkspaceId: WS_ACTIVE })
+			.where(eq(settings.id, 1))
+			.run();
+
+		await caller.archive({ id: PROJECT_ID });
+
+		expect(getFakeDb().settings.lastActiveWorkspaceId).toBeNull();
+	});
+
+	it("archive rejects when already archived", async () => {
+		seedActiveProject(getFakeDb());
+		await caller.archive({ id: PROJECT_ID });
+
+		await expect(caller.archive({ id: PROJECT_ID })).rejects.toMatchObject({
+			code: "BAD_REQUEST",
+		});
+	});
+
+	it("archive rejects when project missing", async () => {
+		await expect(
+			caller.archive({ id: "ffffffff-ffff-4fff-8fff-ffffffffffff" }),
+		).rejects.toMatchObject({ code: "NOT_FOUND" });
+	});
+
+	it("archive surfaces terminalWarning when kill reports failures", async () => {
+		seedActiveProject(getFakeDb());
+		killByWorkspaceIdMock.mockResolvedValue({ failed: 1 });
+
+		const result = await caller.archive({ id: PROJECT_ID });
+
+		expect(result.terminalWarning).toContain("2");
+		expect(result.terminalWarning).toContain("terminal");
+	});
+
+	it("getArchived returns archived projects with only non-deleting workspaces", async () => {
+		seedActiveProject(getFakeDb());
+		await caller.archive({ id: PROJECT_ID });
+
+		const rows = await caller.getArchived();
+		expect(rows).toHaveLength(1);
+		expect(rows[0].project.id).toBe(PROJECT_ID);
+		expect(rows[0].workspaces.map((w) => w.id)).toEqual([WS_ACTIVE]);
+		expect(rows[0].workspaces[0].worktreePath).toBe("/tmp/archive-test-repo");
+	});
+
+	it("unarchive clears archivedAt and calls activateProject path", async () => {
+		seedActiveProject(getFakeDb());
+		const h = getFakeDb();
+		const t = now();
+		h.localDb
+			.insert(projects)
+			.values({
+				id: OTHER_PROJECT_ID,
+				mainRepoPath: "/tmp/other",
+				name: "Other",
+				color: "#111",
+				tabOrder: 0,
+				lastOpenedAt: t,
+				createdAt: t,
+				archivedAt: null,
+				defaultBranch: null,
+				configToastDismissed: null,
+				workspaceBaseBranch: null,
+				githubOwner: null,
+				branchPrefixMode: null,
+				branchPrefixCustom: null,
+				worktreeBaseDir: null,
+				hideImage: null,
+				iconUrl: null,
+				neonProjectId: null,
+				defaultApp: null,
+			} as ProjectRow)
+			.run();
+
+		h.localDb
+			.insert(workspaces)
+			.values({
+				id: OTHER_WS,
+				projectId: OTHER_PROJECT_ID,
+				worktreeId: null,
+				type: "branch",
+				branch: "main",
+				name: "o",
+				tabOrder: 0,
+				createdAt: t,
+				updatedAt: t,
+				lastOpenedAt: t,
+				isUnread: false,
+				isUnnamed: false,
+				deletingAt: null,
+				sectionId: null,
+				portBase: null,
+			} as WorkspaceRow)
+			.run();
+
+		await caller.archive({ id: PROJECT_ID });
+		await caller.unarchive({ id: PROJECT_ID });
+
+		const row = getProjectRowById(h, PROJECT_ID);
+		expect(row?.archivedAt).toBeNull();
+		expect(row?.tabOrder).toBe(1);
+
+		expect(trackMock).toHaveBeenCalledWith("project_unarchived", {
+			project_id: PROJECT_ID,
+		});
+	});
+
+	it("unarchive rejects when not archived", async () => {
+		seedActiveProject(getFakeDb());
+
+		await expect(caller.unarchive({ id: PROJECT_ID })).rejects.toMatchObject({
+			code: "BAD_REQUEST",
+		});
+	});
+
+	it("unarchive rejects when project missing", async () => {
+		await expect(
+			caller.unarchive({ id: "ffffffff-ffff-4fff-8fff-ffffffffffff" }),
+		).rejects.toMatchObject({ code: "NOT_FOUND" });
+	});
+});

--- a/apps/desktop/src/lib/trpc/routers/projects/projects.ts
+++ b/apps/desktop/src/lib/trpc/routers/projects/projects.ts
@@ -44,6 +44,7 @@ import {
 } from "../workspaces/utils/git";
 import { getSimpleGitWithShellPath } from "../workspaces/utils/git-client";
 import { execWithShellEnv } from "../workspaces/utils/shell-env";
+import { getWorkspacePath } from "../workspaces/utils/worktree";
 import { getDefaultProjectColor } from "./utils/colors";
 import { discoverAndSaveProjectIcon } from "./utils/favicon-discovery";
 import { fetchGitHubOwner, getGitHubAvatarUrl } from "./utils/github";
@@ -337,6 +338,173 @@ export const createProjectsRouter = (getWindow: () => BrowserWindow | null) => {
 				.orderBy(desc(projects.lastOpenedAt))
 				.all();
 		}),
+
+		getArchived: publicProcedure.query(() => {
+			const archivedProjects = localDb
+				.select()
+				.from(projects)
+				.where(isNotNull(projects.archivedAt))
+				.orderBy(desc(projects.archivedAt))
+				.all();
+
+			return archivedProjects.map((project) => {
+				const projectWorkspaces = localDb
+					.select()
+					.from(workspaces)
+					.where(
+						and(
+							eq(workspaces.projectId, project.id),
+							isNull(workspaces.deletingAt),
+						),
+					)
+					.all()
+					.sort((a, b) => a.tabOrder - b.tabOrder);
+
+				const workspaceItems = projectWorkspaces.map((ws) => ({
+					id: ws.id,
+					projectId: ws.projectId,
+					sectionId: ws.sectionId ?? null,
+					worktreeId: ws.worktreeId,
+					type: ws.type as "worktree" | "branch",
+					branch: ws.branch,
+					name: ws.name,
+					tabOrder: ws.tabOrder,
+					createdAt: ws.createdAt,
+					updatedAt: ws.updatedAt,
+					lastOpenedAt: ws.lastOpenedAt,
+					isUnread: ws.isUnread ?? false,
+					isUnnamed: ws.isUnnamed ?? false,
+					worktreePath: getWorkspacePath(ws) ?? "",
+				}));
+
+				return {
+					project: {
+						id: project.id,
+						name: project.name,
+						color: project.color,
+						mainRepoPath: project.mainRepoPath,
+						// biome-ignore lint/style/noNonNullAssertion: query filters archivedAt non-null
+						archivedAt: project.archivedAt!,
+					},
+					workspaces: workspaceItems,
+				};
+			});
+		}),
+
+		archive: publicProcedure
+			.input(z.object({ id: z.string() }))
+			.mutation(async ({ input }) => {
+				const project = localDb
+					.select()
+					.from(projects)
+					.where(eq(projects.id, input.id))
+					.get();
+
+				if (!project) {
+					throw new TRPCError({
+						code: "NOT_FOUND",
+						message: "Project not found",
+					});
+				}
+				if (project.archivedAt != null) {
+					throw new TRPCError({
+						code: "BAD_REQUEST",
+						message: "Project is already archived",
+					});
+				}
+
+				const projectWorkspaces = localDb
+					.select()
+					.from(workspaces)
+					.where(eq(workspaces.projectId, input.id))
+					.all();
+
+				let totalFailed = 0;
+				const registry = getWorkspaceRuntimeRegistry();
+				for (const workspace of projectWorkspaces) {
+					const terminal = registry.getForWorkspaceId(workspace.id).terminal;
+					const terminalResult = await terminal.killByWorkspaceId(workspace.id);
+					totalFailed += terminalResult.failed;
+				}
+
+				const now = Date.now();
+				localDb
+					.update(projects)
+					.set({ archivedAt: now, tabOrder: null })
+					.where(eq(projects.id, input.id))
+					.run();
+
+				const workspaceIds = projectWorkspaces.map((w) => w.id);
+
+				const currentSettings = localDb.select().from(settings).get();
+				if (
+					currentSettings?.lastActiveWorkspaceId &&
+					workspaceIds.includes(currentSettings.lastActiveWorkspaceId)
+				) {
+					setLastActiveWorkspace(selectNextActiveWorkspace());
+				}
+
+				const terminalWarning =
+					totalFailed > 0
+						? `${totalFailed} terminal process(es) may still be running`
+						: undefined;
+
+				track("project_archived", { project_id: input.id });
+
+				return {
+					success: true as const,
+					workspaceIds,
+					terminalWarning,
+				};
+			}),
+
+		unarchive: publicProcedure
+			.input(z.object({ id: z.string() }))
+			.mutation(({ input }) => {
+				const project = localDb
+					.select()
+					.from(projects)
+					.where(eq(projects.id, input.id))
+					.get();
+
+				if (!project) {
+					throw new TRPCError({
+						code: "NOT_FOUND",
+						message: "Project not found",
+					});
+				}
+				if (project.archivedAt == null) {
+					throw new TRPCError({
+						code: "BAD_REQUEST",
+						message: "Project is not archived",
+					});
+				}
+
+				localDb
+					.update(projects)
+					.set({ archivedAt: null })
+					.where(eq(projects.id, input.id))
+					.run();
+
+				const refreshed = localDb
+					.select()
+					.from(projects)
+					.where(eq(projects.id, input.id))
+					.get();
+
+				if (!refreshed) {
+					throw new TRPCError({
+						code: "NOT_FOUND",
+						message: "Project not found",
+					});
+				}
+
+				activateProject(refreshed);
+
+				track("project_unarchived", { project_id: input.id });
+
+				return { success: true as const };
+			}),
 
 		listPullRequests: publicProcedure
 			.input(z.object({ projectId: z.string() }))

--- a/apps/desktop/src/renderer/env.renderer.ts
+++ b/apps/desktop/src/renderer/env.renderer.ts
@@ -50,9 +50,11 @@ const rawEnv = {
 	RELAY_URL: process.env.RELAY_URL,
 };
 
-// Only allow skipping validation in development (never in production)
+// Allow skipping validation in development and in Bun tests (never in production)
 const SKIP_ENV_VALIDATION =
-	process.env.NODE_ENV === "development" && !!process.env.SKIP_ENV_VALIDATION;
+	(process.env.NODE_ENV === "development" ||
+		process.env.NODE_ENV === "test") &&
+	!!process.env.SKIP_ENV_VALIDATION;
 
 export const env = {
 	...(SKIP_ENV_VALIDATION

--- a/apps/desktop/src/renderer/lib/api-trpc-client.ts
+++ b/apps/desktop/src/renderer/lib/api-trpc-client.ts
@@ -1,8 +1,16 @@
 import type { AppRouter } from "@superset/trpc";
 import { createTRPCProxyClient, httpBatchLink } from "@trpc/client";
-import { env } from "renderer/env.renderer";
 import superjson from "superjson";
 import { getAuthToken } from "./auth-client";
+
+/** Base API URL without trailing slash (avoid importing `env` here — breaks circular init in tests). */
+function getApiTrpcBaseUrl(): string {
+	const u = process.env.NEXT_PUBLIC_API_URL;
+	if (typeof u === "string" && u.length > 0) {
+		return u.replace(/\/$/, "");
+	}
+	return "https://api.superset.sh";
+}
 
 /**
  * HTTP tRPC client for calling the API server.
@@ -12,7 +20,7 @@ import { getAuthToken } from "./auth-client";
 export const apiTrpcClient = createTRPCProxyClient<AppRouter>({
 	links: [
 		httpBatchLink({
-			url: `${env.NEXT_PUBLIC_API_URL}/api/trpc`,
+			url: `${getApiTrpcBaseUrl()}/api/trpc`,
 			transformer: superjson,
 			headers: () => {
 				const token = getAuthToken();

--- a/apps/desktop/src/renderer/react-query/projects/useArchiveProject.ts
+++ b/apps/desktop/src/renderer/react-query/projects/useArchiveProject.ts
@@ -1,0 +1,25 @@
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useTabsStore } from "renderer/stores/tabs/store";
+
+/**
+ * Archive project: invalidates sidebar queries, strips local tabs for its workspaces.
+ */
+export function useArchiveProject(
+	options?: Parameters<typeof electronTrpc.projects.archive.useMutation>[0],
+) {
+	const utils = electronTrpc.useUtils();
+
+	return electronTrpc.projects.archive.useMutation({
+		...options,
+		onSuccess: async (...args) => {
+			const [data] = args;
+			useTabsStore.getState().removeTabsForWorkspaceIds(data.workspaceIds);
+			await Promise.all([
+				utils.workspaces.getAllGrouped.invalidate(),
+				utils.projects.getRecents.invalidate(),
+				utils.projects.getArchived.invalidate(),
+			]);
+			await options?.onSuccess?.(...args);
+		},
+	});
+}

--- a/apps/desktop/src/renderer/react-query/projects/useUnarchiveProject.ts
+++ b/apps/desktop/src/renderer/react-query/projects/useUnarchiveProject.ts
@@ -1,0 +1,19 @@
+import { electronTrpc } from "renderer/lib/electron-trpc";
+
+export function useUnarchiveProject(
+	options?: Parameters<typeof electronTrpc.projects.unarchive.useMutation>[0],
+) {
+	const utils = electronTrpc.useUtils();
+
+	return electronTrpc.projects.unarchive.useMutation({
+		...options,
+		onSuccess: async (...args) => {
+			await Promise.all([
+				utils.workspaces.getAllGrouped.invalidate(),
+				utils.projects.getRecents.invalidate(),
+				utils.projects.getArchived.invalidate(),
+			]);
+			await options?.onSuccess?.(...args);
+		},
+	});
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ArchiveProjectDialog.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ArchiveProjectDialog.tsx
@@ -1,0 +1,70 @@
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	EnterEnabledAlertDialogContent,
+} from "@superset/ui/alert-dialog";
+import { Button } from "@superset/ui/button";
+
+interface ArchiveProjectDialogProps {
+	projectName: string;
+	workspaceCount: number;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	onConfirm: () => void;
+}
+
+export function ArchiveProjectDialog({
+	projectName,
+	workspaceCount,
+	open,
+	onOpenChange,
+	onConfirm,
+}: ArchiveProjectDialogProps) {
+	return (
+		<AlertDialog open={open} onOpenChange={onOpenChange}>
+			<EnterEnabledAlertDialogContent className="max-w-[340px] gap-0 p-0">
+				<AlertDialogHeader className="px-4 pt-4 pb-2">
+					<AlertDialogTitle className="font-medium">
+						Archive project "{projectName}"?
+					</AlertDialogTitle>
+					<AlertDialogDescription asChild>
+						<div className="text-muted-foreground space-y-1.5">
+							<span className="block">
+								This will hide the project from the sidebar, kill terminals for{" "}
+								{workspaceCount} workspace
+								{workspaceCount !== 1 ? "s" : ""}, and close their editor tabs
+								here. Workspaces stay in your database so you can restore later.
+							</span>
+							<span className="block">
+								Your files and git history will remain on disk.
+							</span>
+						</div>
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+
+				<AlertDialogFooter className="px-4 pb-4 pt-2 flex-row justify-end gap-2">
+					<Button
+						variant="ghost"
+						size="sm"
+						className="h-7 px-3 text-xs"
+						onClick={() => onOpenChange(false)}
+					>
+						Cancel
+					</Button>
+					<AlertDialogAction
+						variant="default"
+						size="sm"
+						className="h-7 px-3 text-xs"
+						onClick={onConfirm}
+					>
+						Archive
+					</AlertDialogAction>
+				</AlertDialogFooter>
+			</EnterEnabledAlertDialogContent>
+		</AlertDialog>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectHeader.tsx
@@ -15,6 +15,7 @@ import { useNavigate, useParams } from "@tanstack/react-router";
 import { useState } from "react";
 import { HiChevronRight, HiMiniPlus } from "react-icons/hi2";
 import {
+	LuArchive,
 	LuFolderOpen,
 	LuImage,
 	LuImageOff,
@@ -26,11 +27,13 @@ import {
 } from "react-icons/lu";
 import { ColorSelector } from "renderer/components/ColorSelector";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useArchiveProject } from "renderer/react-query/projects/useArchiveProject";
 import { useUpdateProject } from "renderer/react-query/projects/useUpdateProject";
 import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { useProjectRename } from "renderer/screens/main/hooks/useProjectRename";
 import { STROKE_WIDTH } from "../constants";
 import { RenameInput } from "../RenameInput";
+import { ArchiveProjectDialog } from "./ArchiveProjectDialog";
 import { CloseProjectDialog } from "./CloseProjectDialog";
 import { ProjectThumbnail } from "./ProjectThumbnail";
 
@@ -69,6 +72,7 @@ export function ProjectHeader({
 	const navigate = useNavigate();
 	const params = useParams({ strict: false }) as { workspaceId?: string };
 	const [isCloseDialogOpen, setIsCloseDialogOpen] = useState(false);
+	const [isArchiveDialogOpen, setIsArchiveDialogOpen] = useState(false);
 	const rename = useProjectRename(projectId, projectName);
 
 	const closeProject = electronTrpc.projects.close.useMutation({
@@ -117,6 +121,54 @@ export function ProjectHeader({
 		},
 	});
 
+	const archiveProject = useArchiveProject({
+		onMutate: async ({ id }) => {
+			let shouldNavigate = false;
+
+			if (params.workspaceId) {
+				try {
+					const currentWorkspace = await utils.workspaces.get.fetch({
+						id: params.workspaceId,
+					});
+					shouldNavigate = currentWorkspace?.projectId === id;
+				} catch (error) {
+					console.warn(
+						"[ProjectHeader] Failed to resolve current workspace before archiving project",
+						error,
+					);
+				}
+			}
+
+			return { shouldNavigate };
+		},
+		onSuccess: async (data, { id }, context) => {
+			const navigateAway = (context as { shouldNavigate?: boolean } | undefined)
+				?.shouldNavigate;
+			if (navigateAway) {
+				const groups = await utils.workspaces.getAllGrouped.fetch();
+				const otherWorkspace = groups
+					.flatMap((group) => group.workspaces)
+					.find((w) => w.projectId !== id);
+
+				if (otherWorkspace) {
+					navigateToWorkspace(otherWorkspace.id, navigate);
+				} else {
+					navigate({ to: "/workspace" });
+				}
+			}
+
+			if (data.terminalWarning) {
+				toast.warning(data.terminalWarning);
+			}
+		},
+		onError: (error) => {
+			toast.error(`Failed to archive project: ${error.message}`);
+		},
+		onSettled: () => {
+			setIsArchiveDialogOpen(false);
+		},
+	});
+
 	const openInFinder = electronTrpc.external.openInFinder.useMutation({
 		onError: (error) => toast.error(`Failed to open: ${error.message}`),
 	});
@@ -125,8 +177,16 @@ export function ProjectHeader({
 		setIsCloseDialogOpen(true);
 	};
 
+	const handleArchiveProject = () => {
+		setIsArchiveDialogOpen(true);
+	};
+
 	const handleConfirmClose = () => {
 		closeProject.mutate({ id: projectId });
+	};
+
+	const handleConfirmArchive = () => {
+		archiveProject.mutate({ id: projectId });
 	};
 
 	const handleOpenInFinder = () => {
@@ -232,6 +292,13 @@ export function ProjectHeader({
 						</ContextMenuItem>
 						<ContextMenuSeparator />
 						<ContextMenuItem
+							onSelect={handleArchiveProject}
+							disabled={archiveProject.isPending}
+						>
+							<LuArchive className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />
+							{archiveProject.isPending ? "Archiving..." : "Archive Project"}
+						</ContextMenuItem>
+						<ContextMenuItem
 							onSelect={handleCloseProject}
 							disabled={closeProject.isPending}
 							className="text-destructive focus:text-destructive"
@@ -244,6 +311,14 @@ export function ProjectHeader({
 						</ContextMenuItem>
 					</ContextMenuContent>
 				</ContextMenu>
+
+				<ArchiveProjectDialog
+					projectName={projectName}
+					workspaceCount={workspaceCount}
+					open={isArchiveDialogOpen}
+					onOpenChange={setIsArchiveDialogOpen}
+					onConfirm={handleConfirmArchive}
+				/>
 
 				<CloseProjectDialog
 					projectName={projectName}
@@ -370,6 +445,13 @@ export function ProjectHeader({
 					</ContextMenuItem>
 					<ContextMenuSeparator />
 					<ContextMenuItem
+						onSelect={handleArchiveProject}
+						disabled={archiveProject.isPending}
+					>
+						<LuArchive className="size-4 mr-2" strokeWidth={STROKE_WIDTH} />
+						{archiveProject.isPending ? "Archiving..." : "Archive Project"}
+					</ContextMenuItem>
+					<ContextMenuItem
 						onSelect={handleCloseProject}
 						disabled={closeProject.isPending}
 						className="text-destructive focus:text-destructive"
@@ -382,6 +464,14 @@ export function ProjectHeader({
 					</ContextMenuItem>
 				</ContextMenuContent>
 			</ContextMenu>
+
+			<ArchiveProjectDialog
+				projectName={projectName}
+				workspaceCount={workspaceCount}
+				open={isArchiveDialogOpen}
+				onOpenChange={setIsArchiveDialogOpen}
+				onConfirm={handleConfirmArchive}
+			/>
 
 			<CloseProjectDialog
 				projectName={projectName}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspacesListView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspacesListView.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { useMemo, useState } from "react";
 import { LuSearch, LuX } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useUnarchiveProject } from "renderer/react-query/projects/useUnarchiveProject";
 import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import type { FilterMode, ProjectGroup, WorkspaceItem } from "./types";
 import { WorkspaceRow } from "./WorkspaceRow";
@@ -14,6 +15,7 @@ const FILTER_OPTIONS: { value: FilterMode; label: string }[] = [
 	{ value: "all", label: "All" },
 	{ value: "active", label: "Active" },
 	{ value: "closed", label: "Closed" },
+	{ value: "archived", label: "Archived" },
 ];
 
 export function WorkspacesListView() {
@@ -27,6 +29,13 @@ export function WorkspacesListView() {
 		electronTrpc.workspaces.getAllGrouped.useQuery();
 	const { data: allProjects = [] } =
 		electronTrpc.projects.getRecents.useQuery();
+	const { data: archivedGroups = [] } =
+		electronTrpc.projects.getArchived.useQuery();
+
+	const unarchiveProject = useUnarchiveProject({
+		onError: (error) =>
+			toast.error(`Failed to restore project: ${error.message}`),
+	});
 
 	// Fetch worktrees for all projects
 	const worktreeQueries = electronTrpc.useQueries((t) =>
@@ -105,6 +114,28 @@ export function WorkspacesListView() {
 		return items;
 	}, [groups, allProjects, worktreeQueries]);
 
+	const archivedProjectGroups = useMemo<ProjectGroup[]>(() => {
+		return archivedGroups.map((g) => ({
+			projectId: g.project.id,
+			projectName: g.project.name,
+			workspaces: g.workspaces.map((ws) => ({
+				uniqueId: ws.id,
+				workspaceId: ws.id,
+				worktreeId: ws.worktreeId,
+				projectId: g.project.id,
+				projectName: g.project.name,
+				worktreePath: ws.worktreePath,
+				type: ws.type,
+				branch: ws.branch,
+				name: ws.name,
+				lastOpenedAt: ws.lastOpenedAt,
+				createdAt: ws.createdAt,
+				isUnread: ws.isUnread,
+				isOpen: true,
+			})),
+		}));
+	}, [archivedGroups]);
+
 	// Filter by search query and filter mode
 	const filteredItems = useMemo(() => {
 		let items = allItems;
@@ -114,6 +145,8 @@ export function WorkspacesListView() {
 			items = items.filter((ws) => ws.isOpen);
 		} else if (filterMode === "closed") {
 			items = items.filter((ws) => !ws.isOpen);
+		} else if (filterMode === "archived") {
+			items = [];
 		}
 
 		// Apply search filter
@@ -132,6 +165,25 @@ export function WorkspacesListView() {
 
 	// Group by project
 	const projectGroups = useMemo<ProjectGroup[]>(() => {
+		if (filterMode === "archived") {
+			let groups = archivedProjectGroups;
+			if (searchQuery.trim()) {
+				const query = searchQuery.toLowerCase();
+				groups = groups
+					.map((g) => ({
+						...g,
+						workspaces: g.workspaces.filter(
+							(ws) =>
+								ws.name.toLowerCase().includes(query) ||
+								g.projectName.toLowerCase().includes(query) ||
+								ws.branch.toLowerCase().includes(query),
+						),
+					}))
+					.filter((g) => g.workspaces.length > 0);
+			}
+			return groups;
+		}
+
 		const groupsMap = new Map<string, ProjectGroup>();
 
 		for (const item of filteredItems) {
@@ -161,7 +213,7 @@ export function WorkspacesListView() {
 			const bRecent = Math.max(...b.workspaces.map((w) => w.lastOpenedAt));
 			return bRecent - aRecent;
 		});
-	}, [filteredItems]);
+	}, [filteredItems, filterMode, archivedProjectGroups, searchQuery]);
 
 	const handleSwitch = (item: WorkspaceItem) => {
 		if (item.workspaceId) {
@@ -178,6 +230,7 @@ export function WorkspacesListView() {
 	// Count stats for filter badges
 	const activeCount = allItems.filter((w) => w.isOpen).length;
 	const closedCount = allItems.filter((w) => !w.isOpen).length;
+	const archivedCount = archivedGroups.length;
 
 	return (
 		<div className="flex-1 flex flex-col bg-card overflow-hidden">
@@ -191,7 +244,9 @@ export function WorkspacesListView() {
 								? allItems.length
 								: option.value === "active"
 									? activeCount
-									: closedCount;
+									: option.value === "closed"
+										? closedCount
+										: archivedCount;
 						return (
 							<button
 								key={option.value}
@@ -239,13 +294,31 @@ export function WorkspacesListView() {
 				{projectGroups.map((group) => (
 					<div key={group.projectId}>
 						{/* Project header */}
-						<div className="sticky top-0 bg-card/95 backdrop-blur-sm px-4 py-2 border-b border-border/50">
-							<span className="text-xs font-medium text-foreground/70">
-								{group.projectName}
-							</span>
-							<span className="text-xs text-foreground/40 ml-2">
-								{group.workspaces.length}
-							</span>
+						<div className="sticky top-0 bg-card/95 backdrop-blur-sm px-4 py-2 border-b border-border/50 flex items-center justify-between gap-2">
+							<div className="min-w-0">
+								<span className="text-xs font-medium text-foreground/70">
+									{group.projectName}
+								</span>
+								<span className="text-xs text-foreground/40 ml-2">
+									{group.workspaces.length}
+								</span>
+							</div>
+							{filterMode === "archived" && (
+								<Button
+									variant="outline"
+									size="sm"
+									className="h-7 shrink-0 text-xs"
+									disabled={unarchiveProject.isPending}
+									onClick={() =>
+										unarchiveProject.mutate({ id: group.projectId })
+									}
+								>
+									{unarchiveProject.isPending &&
+									unarchiveProject.variables?.id === group.projectId
+										? "Restoring..."
+										: "Restore"}
+								</Button>
+							)}
 						</div>
 
 						{/* Workspaces in this project */}
@@ -264,7 +337,7 @@ export function WorkspacesListView() {
 					</div>
 				))}
 
-				{filteredItems.length === 0 && (
+				{projectGroups.length === 0 && (
 					<div className="flex items-center justify-center h-32 text-foreground/50 text-sm">
 						{searchQuery
 							? "No workspaces match your search"
@@ -272,7 +345,9 @@ export function WorkspacesListView() {
 								? "No active workspaces"
 								: filterMode === "closed"
 									? "No closed workspaces"
-									: "No workspaces yet"}
+									: filterMode === "archived"
+										? "No archived projects"
+										: "No workspaces yet"}
 					</div>
 				)}
 			</div>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/types.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/types.ts
@@ -23,4 +23,4 @@ export interface ProjectGroup {
 	workspaces: WorkspaceItem[];
 }
 
-export type FilterMode = "all" | "active" | "closed";
+export type FilterMode = "all" | "active" | "closed" | "archived";

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -354,6 +354,16 @@ export const useTabsStore = create<TabsStore>()(
 					return { tabId: tab.id, paneIds };
 				},
 
+				removeTabsForWorkspaceIds: (workspaceIds) => {
+					const idSet = new Set(workspaceIds);
+					const tabIds = get()
+						.tabs.filter((t) => idSet.has(t.workspaceId))
+						.map((t) => t.id);
+					for (const tabId of tabIds) {
+						get().removeTab(tabId);
+					}
+				},
+
 				removeTab: (tabId) => {
 					const state = get();
 					const tabToRemove = state.tabs.find((t) => t.id === tabId);

--- a/apps/desktop/src/renderer/stores/tabs/types.ts
+++ b/apps/desktop/src/renderer/stores/tabs/types.ts
@@ -116,6 +116,8 @@ export interface TabsStore extends TabsState {
 		options: AddTabWithMultiplePanesOptions,
 	) => { tabId: string; paneIds: string[] };
 	removeTab: (tabId: string) => void;
+	/** Remove all tabs (and panes) for the given workspace IDs; reuses removeTab terminal cleanup. */
+	removeTabsForWorkspaceIds: (workspaceIds: string[]) => void;
 	renameTab: (tabId: string, newName: string) => void;
 	setTabAutoTitle: (tabId: string, title: string) => void;
 	setActiveTab: (workspaceId: string, tabId: string) => void;

--- a/packages/local-db/drizzle/0041_vengeful_toxin.sql
+++ b/packages/local-db/drizzle/0041_vengeful_toxin.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `projects` ADD `archived_at` integer;--> statement-breakpoint
+CREATE INDEX `projects_archived_at_idx` ON `projects` (`archived_at`);

--- a/packages/local-db/drizzle/meta/0041_snapshot.json
+++ b/packages/local-db/drizzle/meta/0041_snapshot.json
@@ -1,0 +1,1425 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "d55b4813-8814-42de-91a3-943d24dd43fe",
+  "prevId": "ecc4c8b8-883e-4e25-8ae4-d4d6298d1030",
+  "tables": {
+    "browser_history": {
+      "name": "browser_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_visited_at": {
+          "name": "last_visited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visit_count": {
+          "name": "visit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "browser_history_url_unique": {
+          "name": "browser_history_url_unique",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "browser_history_url_idx": {
+          "name": "browser_history_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": false
+        },
+        "browser_history_last_visited_at_idx": {
+          "name": "browser_history_last_visited_at_idx",
+          "columns": [
+            "last_visited_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_organization_id_idx": {
+          "name": "organization_members_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_user_id_idx": {
+          "name": "organization_members_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_users_id_fk": {
+          "name": "organization_members_user_id_users_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_org": {
+          "name": "github_org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_clerk_org_id_unique": {
+          "name": "organizations_clerk_org_id_unique",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_idx": {
+          "name": "organizations_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "organizations_clerk_org_id_idx": {
+          "name": "organizations_clerk_org_id_idx",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "main_repo_path": {
+          "name": "main_repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_toast_dismissed": {
+          "name": "config_toast_dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_base_branch": {
+          "name": "workspace_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_owner": {
+          "name": "github_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hide_image": {
+          "name": "hide_image",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_project_id": {
+          "name": "neon_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_app": {
+          "name": "default_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_main_repo_path_idx": {
+          "name": "projects_main_repo_path_idx",
+          "columns": [
+            "main_repo_path"
+          ],
+          "isUnique": false
+        },
+        "projects_last_opened_at_idx": {
+          "name": "projects_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        },
+        "projects_archived_at_idx": {
+          "name": "projects_archived_at_idx",
+          "columns": [
+            "archived_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_active_workspace_id": {
+          "name": "last_active_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets": {
+          "name": "terminal_presets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets_initialized": {
+          "name": "terminal_presets_initialized",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_preset_overrides": {
+          "name": "agent_preset_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_custom_definitions": {
+          "name": "agent_custom_definitions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_preset_permissions_migrated_at": {
+          "name": "agent_preset_permissions_migrated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_ringtone_id": {
+          "name": "selected_ringtone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirm_on_quit": {
+          "name": "confirm_on_quit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_link_behavior": {
+          "name": "terminal_link_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "persist_terminal": {
+          "name": "persist_terminal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_apply_default_preset": {
+          "name": "auto_apply_default_preset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_sounds_muted": {
+          "name": "notification_sounds_muted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_volume": {
+          "name": "notification_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delete_local_branch": {
+          "name": "delete_local_branch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_open_mode": {
+          "name": "file_open_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_presets_bar": {
+          "name": "show_presets_bar",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_compact_terminal_add_button": {
+          "name": "use_compact_terminal_add_button",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_family": {
+          "name": "terminal_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_size": {
+          "name": "terminal_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_family": {
+          "name": "editor_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_size": {
+          "name": "editor_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_resource_monitor": {
+          "name": "show_resource_monitor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "open_links_in_app": {
+          "name": "open_links_in_app",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_editor": {
+          "name": "default_editor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expose_host_service_via_relay": {
+          "name": "expose_host_service_via_relay",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_color": {
+          "name": "status_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_type": {
+          "name": "status_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_position": {
+          "name": "status_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "estimate": {
+          "name": "estimate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_provider": {
+          "name": "external_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tasks_slug_unique": {
+          "name": "tasks_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "tasks_slug_idx": {
+          "name": "tasks_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "tasks_organization_id_idx": {
+          "name": "tasks_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_assignee_id_idx": {
+          "name": "tasks_assignee_id_idx",
+          "columns": [
+            "assignee_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_status_idx": {
+          "name": "tasks_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "tasks_created_at_idx": {
+          "name": "tasks_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_organization_id_organizations_id_fk": {
+          "name": "tasks_organization_id_organizations_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_assignee_id_users_id_fk": {
+          "name": "tasks_assignee_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tasks_creator_id_users_id_fk": {
+          "name": "tasks_creator_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": true
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "users_clerk_id_idx": {
+          "name": "users_clerk_id_idx",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_sections": {
+      "name": "workspace_sections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_collapsed": {
+          "name": "is_collapsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspace_sections_project_id_idx": {
+          "name": "workspace_sections_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_sections_project_id_projects_id_fk": {
+          "name": "workspace_sections_project_id_projects_id_fk",
+          "tableFrom": "workspace_sections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_id": {
+          "name": "worktree_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_unread": {
+          "name": "is_unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_unnamed": {
+          "name": "is_unnamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "deleting_at": {
+          "name": "deleting_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "port_base": {
+          "name": "port_base",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_project_id_idx": {
+          "name": "workspaces_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_worktree_id_idx": {
+          "name": "workspaces_worktree_id_idx",
+          "columns": [
+            "worktree_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_last_opened_at_idx": {
+          "name": "workspaces_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        },
+        "workspaces_section_id_idx": {
+          "name": "workspaces_section_id_idx",
+          "columns": [
+            "section_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspaces_project_id_projects_id_fk": {
+          "name": "workspaces_project_id_projects_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_worktree_id_worktrees_id_fk": {
+          "name": "workspaces_worktree_id_worktrees_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "worktrees",
+          "columnsFrom": [
+            "worktree_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_section_id_workspace_sections_id_fk": {
+          "name": "workspaces_section_id_workspace_sections_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "workspace_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "worktrees": {
+      "name": "worktrees",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_status": {
+          "name": "git_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_status": {
+          "name": "github_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_superset": {
+          "name": "created_by_superset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "worktrees_project_id_idx": {
+          "name": "worktrees_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "worktrees_branch_idx": {
+          "name": "worktrees_branch_idx",
+          "columns": [
+            "branch"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "worktrees_project_id_projects_id_fk": {
+          "name": "worktrees_project_id_projects_id_fk",
+          "tableFrom": "worktrees",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/local-db/drizzle/meta/_journal.json
+++ b/packages/local-db/drizzle/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1776796221146,
       "tag": "0040_agent_preset_permissions_migrated_at",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "6",
+      "when": 1776869869873,
+      "tag": "0041_vengeful_toxin",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/local-db/src/schema/schema.ts
+++ b/packages/local-db/src/schema/schema.ts
@@ -30,6 +30,8 @@ export const projects = sqliteTable(
 		lastOpenedAt: integer("last_opened_at")
 			.notNull()
 			.$defaultFn(() => Date.now()),
+		/** When set, project is archived (sidebar hidden via tabOrder null). */
+		archivedAt: integer("archived_at"),
 		createdAt: integer("created_at")
 			.notNull()
 			.$defaultFn(() => Date.now()),
@@ -50,6 +52,7 @@ export const projects = sqliteTable(
 	(table) => [
 		index("projects_main_repo_path_idx").on(table.mainRepoPath),
 		index("projects_last_opened_at_idx").on(table.lastOpenedAt),
+		index("projects_archived_at_idx").on(table.archivedAt),
 	],
 );
 


### PR DESCRIPTION
# Pull request: Project archive (V1 local SQLite)

Use this as the GitHub PR description (it mirrors [`.github/pull_request_template.md`](../../.github/pull_request_template.md)).

---

## Description

Adds a **project-level archive** flow for the desktop app’s **V1** path (local SQLite + `electronTrpc`), scoped to the local sidebar (`WorkspaceSidebar` / `getAllGrouped`). Archived projects are hidden from the main navbar (same mechanism as other hidden projects: `tabOrder: null`), but remain in the database with a dedicated **`archivedAt`** timestamp so they can be listed and restored.

**Data model**

- `packages/local-db`: nullable `projects.archivedAt` (epoch ms) + index; Drizzle migration `0041_vengeful_toxin.sql`.

**Backend (tRPC)**

- `projects.archive`: kill terminals for all workspaces in the project (same pattern as `projects.close`), set `archivedAt` and `tabOrder: null`, fix `lastActiveWorkspaceId` when needed, telemetry `project_archived`. Returns `workspaceIds` for the renderer.
- `projects.unarchive`: clear `archivedAt`, call `activateProject` to restore `tabOrder`, telemetry `project_unarchived`. Guardrails for already-archived / not-archived.
- `projects.getArchived`: archived projects with workspaces + `worktreePath`, ordered by `archivedAt` desc.

**Renderer**

- `useArchiveProject` / `useUnarchiveProject`: invalidate `workspaces.getAllGrouped`, `projects.getRecents`, `projects.getArchived`.
- **Project header** context menu: **Archive project** (confirm dialog) + navigation away when the active workspace belongs to the archived project (mirrors close).
- **Workspaces list** (`WorkspacesListView`): **Archived** filter segment; **Restore** per project; search works in that mode.
- **Tabs store**: `removeTabsForWorkspaceIds` reuses `removeTab` so archived projects do not leave stale tab state.

**Test / module-init fixes** (so `bun test` and related loads stay green)

- `renderer/env.renderer.ts`: honor `SKIP_ENV_VALIDATION` when `NODE_ENV` is **`test`** as well as `development`, matching `apps/desktop/bunfig.toml` and `test-setup.ts`.
- `renderer/lib/api-trpc-client.ts`: build API base URL from `process.env.NEXT_PUBLIC_API_URL` with the same default as Vite / schema, and **do not** import `renderer/env.renderer` at module top level (avoids circular init / TDZ in tests).

**Out of scope (explicit)**

- **V2 cloud** (`DashboardSidebar`, Electric collections, host DB): no parity in this PR; archive entry points exist on **V1** `ProjectHeader` only.

## Related Issues

<!-- e.g. closes #123 — replace or remove if none -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Other (please describe): **Test harness / module-init fixes** (`env.renderer` skip in `test`, `api-trpc-client` URL without importing `env`)

## Testing

**Automated**

- `cd apps/desktop && bun test src/lib/trpc/routers/projects/project-archive.test.ts` (router coverage for `archive` / `unarchive` / `getArchived`).
- `cd apps/desktop && bun test` for the full desktop suite.
- From repo root: `bun run lint`, `bun run typecheck`, and desktop build as in CI (`bun turbo run build --filter=@superset/desktop`) when you want full parity.

**Manual (V1 sidebar — V2 cloud flag off)**

1. Right-click the **project row** (icon + name + workspace count), not a single workspace line → **Archive project** → confirm.
2. Project disappears from the left nav; terminals for that project stop; if you were on a workspace in that project, navigation moves to another workspace or `/workspace`.
3. Open workspaces list → **Archived** → see the project → **Restore** → project returns to the sidebar with sensible ordering.
4. `projects.getRecents` still uses `tabOrder`; archived projects stay out of recents.

## Screenshots (if applicable)

<!-- Add before/after: project context menu with Archive; Archived list with Restore -->

## Additional Notes

- **Migration**: existing installs pick up `archived_at` via the new local-db migration on next app run (your normal migration path).
- **PR process**: fork PR, allow maintainer edits — see [CONTRIBUTING.md](../../CONTRIBUTING.md).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds project archive/unarchive for the desktop V1 path (local SQLite). Archived projects are hidden from the sidebar, kept in the DB, and can be restored from the Workspaces list.

- New Features
  - Data model: `projects.archivedAt` (+ index) in `packages/local-db` via migration `0041_vengeful_toxin.sql`.
  - tRPC: `projects.archive`, `projects.unarchive`, and `projects.getArchived` (kills project terminals, sets `tabOrder: null`, returns `workspaceIds`, restores on unarchive).
  - UI: Project header adds “Archive project” with confirm and safe navigation; Workspaces list adds “Archived” view with per-project “Restore” and search support.
  - Tabs: `removeTabsForWorkspaceIds` to clean up editor tabs when a project is archived.
  - Tests: Router tests cover archive/unarchive/getArchived.

- Bug Fixes
  - `renderer/env.renderer.ts`: allow `SKIP_ENV_VALIDATION` in `test` to match Bun setup.
  - `renderer/lib/api-trpc-client.ts`: build base URL from `NEXT_PUBLIC_API_URL` and avoid importing `env` to prevent circular init in tests.

<sup>Written for commit e048630a8ceb8b180ca4633561711297ec8955a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project archive functionality—archive projects to hide them from the sidebar while preserving workspace data in the database.
  * Introduced an "Archived" filter view to display archived projects with per-project restore options and search support.
  * Added confirmation dialog for archiving projects, displaying affected workspace count.

* **Bug Fixes**
  * Fixed test environment initialization to prevent failures in test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->