### PR TITLE
feat(terminal): ack-based flow control + resize debouncing for v2 terminal

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/flow-control.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/flow-control.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, mock, test } from "bun:test";
+import { AckDataBufferer, FlowControlConstants } from "./flow-control";
+
+// Upstream VSCode (terminalProcessManager.ts) ships `AckDataBufferer` without
+// dedicated unit tests. The tests below pin the documented behavior so we
+// notice if a future vendor refresh changes semantics.
+
+describe("AckDataBufferer", () => {
+	test("does not fire below CharCountAckSize", () => {
+		const cb = mock();
+		const bufferer = new AckDataBufferer(cb);
+		bufferer.ack(100);
+		bufferer.ack(1000);
+		bufferer.ack(3899);
+		expect(cb).not.toHaveBeenCalled();
+	});
+
+	test("does not fire at exactly CharCountAckSize (strictly-greater-than)", () => {
+		// Upstream uses `while (count > CharCountAckSize)`, not `>=`.
+		const cb = mock();
+		const bufferer = new AckDataBufferer(cb);
+		bufferer.ack(FlowControlConstants.CharCountAckSize);
+		expect(cb).not.toHaveBeenCalled();
+	});
+
+	test("fires once when crossing CharCountAckSize by a single char", () => {
+		const cb = mock();
+		const bufferer = new AckDataBufferer(cb);
+		bufferer.ack(FlowControlConstants.CharCountAckSize + 1);
+		expect(cb).toHaveBeenCalledTimes(1);
+		expect(cb).toHaveBeenCalledWith(FlowControlConstants.CharCountAckSize);
+	});
+
+	test("accumulates across multiple acks", () => {
+		const cb = mock();
+		const bufferer = new AckDataBufferer(cb);
+		bufferer.ack(3000);
+		expect(cb).not.toHaveBeenCalled();
+		bufferer.ack(3000);
+		expect(cb).toHaveBeenCalledTimes(1);
+		expect(cb).toHaveBeenCalledWith(FlowControlConstants.CharCountAckSize);
+	});
+
+	test("fires multiple times for a single large ack", () => {
+		const cb = mock();
+		const bufferer = new AckDataBufferer(cb);
+		// 15001 chars: 3 full batches of 5000 should drain.
+		bufferer.ack(FlowControlConstants.CharCountAckSize * 3 + 1);
+		expect(cb).toHaveBeenCalledTimes(3);
+		for (let i = 0; i < 3; i++) {
+			expect(cb).toHaveBeenNthCalledWith(
+				i + 1,
+				FlowControlConstants.CharCountAckSize,
+			);
+		}
+	});
+
+	test("always passes exactly CharCountAckSize to the callback (never partial)", () => {
+		const cb = mock();
+		const bufferer = new AckDataBufferer(cb);
+		bufferer.ack(13_337);
+		for (const call of cb.mock.calls) {
+			expect(call[0]).toBe(FlowControlConstants.CharCountAckSize);
+		}
+	});
+
+	test("retains leftover chars across multiple ack rounds", () => {
+		const cb = mock();
+		const bufferer = new AckDataBufferer(cb);
+		// 7000 → 1 fire, 2000 left.
+		bufferer.ack(7000);
+		expect(cb).toHaveBeenCalledTimes(1);
+		// 3001 → combined 5001 → 1 more fire.
+		bufferer.ack(3001);
+		expect(cb).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe("FlowControlConstants", () => {
+	test("matches VSCode upstream values", () => {
+		expect(FlowControlConstants.HighWatermarkChars).toBe(100_000);
+		expect(FlowControlConstants.LowWatermarkChars).toBe(5_000);
+		expect(FlowControlConstants.CharCountAckSize).toBe(5_000);
+	});
+
+	test("CharCountAckSize <= LowWatermarkChars (upstream invariant)", () => {
+		// Documented in upstream source: "This must be less than or equal to
+		// LowWatermarkChars or the terminal may never unpause."
+		expect(FlowControlConstants.CharCountAckSize).toBeLessThanOrEqual(
+			FlowControlConstants.LowWatermarkChars,
+		);
+	});
+});

--- a/apps/desktop/src/renderer/lib/terminal/flow-control.ts
+++ b/apps/desktop/src/renderer/lib/terminal/flow-control.ts
@@ -1,0 +1,77 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See https://github.com/microsoft/vscode/blob/main/LICENSE.txt
+ *--------------------------------------------------------------------------------------------*/
+
+// Vendored from VSCode:
+//   - FlowControlConstants: src/vs/platform/terminal/common/terminal.ts
+//   - AckDataBufferer:      src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts
+// Upstream uses `const enum`; rewritten as a `const` object below because our
+// tsconfig has `isolatedModules: true` (const enums are not preserved across
+// module boundaries under isolatedModules).
+
+/**
+ * Upstream (VSCode terminal.ts):
+ *
+ *   export const enum FlowControlConstants {
+ *       HighWatermarkChars = 100000,
+ *       LowWatermarkChars = 5000,
+ *       CharCountAckSize = 5000
+ *   }
+ */
+export const FlowControlConstants = {
+	/**
+	 * The number of _unacknowledged_ chars to have been sent before the pty is paused in order for
+	 * the client to catch up.
+	 */
+	HighWatermarkChars: 100000,
+	/**
+	 * After flow control pauses the pty for the client the catch up, this is the number of
+	 * _unacknowledged_ chars to have been caught up to on the client before resuming the pty again.
+	 * This is used to attempt to prevent pauses in the flowing data; ideally while the pty is
+	 * paused the number of unacknowledged chars would always be greater than 0 or the client will
+	 * appear to stutter. In reality this balance is hard to accomplish though so heavy commands
+	 * will likely pause as latency grows, not flooding the connection is the important thing as
+	 * it's shared with other core functionality.
+	 */
+	LowWatermarkChars: 5000,
+	/**
+	 * The number characters that are accumulated on the client side before sending an ack event.
+	 * This must be less than or equal to LowWatermarkChars or the terminal max never unpause.
+	 */
+	CharCountAckSize: 5000,
+} as const;
+
+/**
+ * Upstream (VSCode terminalProcessManager.ts):
+ *
+ *   class AckDataBufferer {
+ *       private _unsentCharCount: number = 0;
+ *
+ *       constructor(
+ *           private readonly _callback: (charCount: number) => void
+ *       ) {
+ *       }
+ *
+ *       ack(charCount: number) {
+ *           this._unsentCharCount += charCount;
+ *           while (this._unsentCharCount > FlowControlConstants.CharCountAckSize) {
+ *               this._unsentCharCount -= FlowControlConstants.CharCountAckSize;
+ *               this._callback(FlowControlConstants.CharCountAckSize);
+ *           }
+ *       }
+ *   }
+ */
+export class AckDataBufferer {
+	private _unsentCharCount = 0;
+
+	constructor(private readonly _callback: (charCount: number) => void) {}
+
+	ack(charCount: number) {
+		this._unsentCharCount += charCount;
+		while (this._unsentCharCount > FlowControlConstants.CharCountAckSize) {
+			this._unsentCharCount -= FlowControlConstants.CharCountAckSize;
+			this._callback(FlowControlConstants.CharCountAckSize);
+		}
+	}
+}

--- a/apps/desktop/src/renderer/lib/terminal/flow-control.ts
+++ b/apps/desktop/src/renderer/lib/terminal/flow-control.ts
@@ -4,43 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 // Vendored from VSCode:
-//   - FlowControlConstants: src/vs/platform/terminal/common/terminal.ts
-//   - AckDataBufferer:      src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts
-// Upstream uses `const enum`; rewritten as a `const` object below because our
-// tsconfig has `isolatedModules: true` (const enums are not preserved across
-// module boundaries under isolatedModules).
+//   - AckDataBufferer: src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts
+//
+// FlowControlConstants live in @superset/shared/terminal-flow-control so the
+// client and server cannot drift apart on watermark values.
 
-/**
- * Upstream (VSCode terminal.ts):
- *
- *   export const enum FlowControlConstants {
- *       HighWatermarkChars = 100000,
- *       LowWatermarkChars = 5000,
- *       CharCountAckSize = 5000
- *   }
- */
-export const FlowControlConstants = {
-	/**
-	 * The number of _unacknowledged_ chars to have been sent before the pty is paused in order for
-	 * the client to catch up.
-	 */
-	HighWatermarkChars: 100000,
-	/**
-	 * After flow control pauses the pty for the client the catch up, this is the number of
-	 * _unacknowledged_ chars to have been caught up to on the client before resuming the pty again.
-	 * This is used to attempt to prevent pauses in the flowing data; ideally while the pty is
-	 * paused the number of unacknowledged chars would always be greater than 0 or the client will
-	 * appear to stutter. In reality this balance is hard to accomplish though so heavy commands
-	 * will likely pause as latency grows, not flooding the connection is the important thing as
-	 * it's shared with other core functionality.
-	 */
-	LowWatermarkChars: 5000,
-	/**
-	 * The number characters that are accumulated on the client side before sending an ack event.
-	 * This must be less than or equal to LowWatermarkChars or the terminal max never unpause.
-	 */
-	CharCountAckSize: 5000,
-} as const;
+import { FlowControlConstants } from "@superset/shared/terminal-flow-control";
+
+export { FlowControlConstants } from "@superset/shared/terminal-flow-control";
 
 /**
  * Upstream (VSCode terminalProcessManager.ts):

--- a/apps/desktop/src/renderer/lib/terminal/resize-debouncer.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/resize-debouncer.test.ts
@@ -70,6 +70,7 @@ describe("TerminalResizeDebouncer — immediate path", () => {
 		debouncer.resize(80, 24, false);
 		expect(cb.resizeBoth).not.toHaveBeenCalled();
 		expect(cb.resizeY).toHaveBeenCalledTimes(1);
+		debouncer.dispose();
 	});
 });
 

--- a/apps/desktop/src/renderer/lib/terminal/resize-debouncer.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/resize-debouncer.test.ts
@@ -198,6 +198,62 @@ describe("TerminalResizeDebouncer — dispose", () => {
 	});
 });
 
+describe("TerminalResizeDebouncer — path switching", () => {
+	test("visible→hidden cancels the pending X debounce", async () => {
+		const harness = createHarness({
+			visible: true,
+			bufferLength: 10_000,
+			debounceMs: 10,
+		});
+		const { debouncer, cb } = harness;
+
+		// 1. Visible resize schedules a debounced X with cols=80.
+		debouncer.resize(80, 24, false);
+		expect(cb.resizeX).not.toHaveBeenCalled();
+
+		// 2. Terminal becomes hidden; a new resize enters the idle path with cols=90.
+		cb.isVisible.mockImplementation(() => false);
+		debouncer.resize(90, 25, false);
+
+		// 3. Idle callback fires (setTimeout(0) fallback in node/bun) and applies 90.
+		// The debounce timer, had it been left pending, would fire 10ms later
+		// with the stale closure value 80 and revert us.
+		await wait(30);
+
+		// Only the latest (90) should have been applied — no revert to 80.
+		expect(cb.resizeX.mock.calls).toEqual([[90]]);
+	});
+
+	test("hidden→visible cancels the pending idle X/Y jobs", async () => {
+		const harness = createHarness({
+			visible: false,
+			bufferLength: 10_000,
+			debounceMs: 10,
+		});
+		const { debouncer, cb } = harness;
+
+		// 1. Hidden resize schedules idle X=80, Y=24.
+		debouncer.resize(80, 24, false);
+		expect(cb.resizeX).not.toHaveBeenCalled();
+		expect(cb.resizeY).not.toHaveBeenCalled();
+
+		// 2. Terminal becomes visible; new resize should apply Y immediately
+		// and debounce X — without letting the stale idle jobs fire after.
+		cb.isVisible.mockImplementation(() => true);
+		debouncer.resize(90, 25, false);
+		expect(cb.resizeY).toHaveBeenCalledTimes(1);
+		expect(cb.resizeY).toHaveBeenCalledWith(25);
+
+		// Wait past both idle and debounce.
+		await wait(30);
+
+		// Y fired exactly once (from the visible path) — no stale idle Y.
+		expect(cb.resizeY.mock.calls).toEqual([[25]]);
+		// X fired exactly once (from the debounce) — no stale idle X.
+		expect(cb.resizeX.mock.calls).toEqual([[90]]);
+	});
+});
+
 describe("Constants", () => {
 	test("match upstream VSCode values", () => {
 		expect(StartDebouncingThreshold).toBe(200);

--- a/apps/desktop/src/renderer/lib/terminal/resize-debouncer.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/resize-debouncer.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+	DebounceMs,
+	type ResizeDebouncerCallbacks,
+	StartDebouncingThreshold,
+	TerminalResizeDebouncer,
+} from "./resize-debouncer";
+
+// Upstream VSCode (terminalResizeDebouncer.ts) ships without dedicated unit
+// tests. These tests pin the documented behavior so a future vendor refresh
+// surfaces any semantic drift.
+
+interface Harness {
+	debouncer: TerminalResizeDebouncer;
+	cb: {
+		isVisible: ReturnType<typeof mock>;
+		getBufferLength: ReturnType<typeof mock>;
+		resizeBoth: ReturnType<typeof mock>;
+		resizeX: ReturnType<typeof mock>;
+		resizeY: ReturnType<typeof mock>;
+	};
+}
+
+function createHarness(opts: {
+	visible?: boolean;
+	bufferLength?: number;
+	debounceMs?: number;
+}): Harness {
+	const cb = {
+		isVisible: mock(() => opts.visible ?? true),
+		getBufferLength: mock(() => opts.bufferLength ?? 1000),
+		resizeBoth: mock(),
+		resizeX: mock(),
+		resizeY: mock(),
+	};
+	const debouncer = new TerminalResizeDebouncer(
+		cb as unknown as ResizeDebouncerCallbacks,
+		{ debounceMs: opts.debounceMs ?? 5 },
+	);
+	return { debouncer, cb };
+}
+
+function wait(ms: number) {
+	return new Promise((r) => setTimeout(r, ms));
+}
+
+describe("TerminalResizeDebouncer — immediate path", () => {
+	test("resizes immediately when `immediate: true` regardless of buffer size", () => {
+		const { debouncer, cb } = createHarness({ bufferLength: 100_000 });
+		debouncer.resize(80, 24, true);
+		expect(cb.resizeBoth).toHaveBeenCalledTimes(1);
+		expect(cb.resizeBoth).toHaveBeenCalledWith(80, 24);
+		expect(cb.resizeX).not.toHaveBeenCalled();
+		expect(cb.resizeY).not.toHaveBeenCalled();
+	});
+
+	test("resizes immediately when buffer is below StartDebouncingThreshold", () => {
+		const { debouncer, cb } = createHarness({
+			bufferLength: StartDebouncingThreshold - 1,
+		});
+		debouncer.resize(80, 24, false);
+		expect(cb.resizeBoth).toHaveBeenCalledWith(80, 24);
+	});
+
+	test("does not take immediate path at exactly StartDebouncingThreshold (strictly-less-than)", () => {
+		// Upstream uses `< StartDebouncingThreshold`, not `<=`.
+		const { debouncer, cb } = createHarness({
+			bufferLength: StartDebouncingThreshold,
+		});
+		debouncer.resize(80, 24, false);
+		expect(cb.resizeBoth).not.toHaveBeenCalled();
+		expect(cb.resizeY).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("TerminalResizeDebouncer — visible large-buffer path", () => {
+	test("applies Y immediately and debounces X", async () => {
+		const { debouncer, cb } = createHarness({
+			visible: true,
+			bufferLength: 10_000,
+			debounceMs: 5,
+		});
+		debouncer.resize(80, 24, false);
+		expect(cb.resizeY).toHaveBeenCalledWith(24);
+		expect(cb.resizeX).not.toHaveBeenCalled();
+		expect(cb.resizeBoth).not.toHaveBeenCalled();
+		await wait(20);
+		expect(cb.resizeX).toHaveBeenCalledWith(80);
+	});
+
+	test("coalesces rapid X resizes to the last value", async () => {
+		const { debouncer, cb } = createHarness({
+			visible: true,
+			bufferLength: 10_000,
+			debounceMs: 10,
+		});
+		debouncer.resize(80, 24, false);
+		debouncer.resize(90, 25, false);
+		debouncer.resize(100, 26, false);
+		// Each Y fires immediately — that's intentional (cheap).
+		expect(cb.resizeY.mock.calls.map((c) => c[0])).toEqual([24, 25, 26]);
+		expect(cb.resizeX).not.toHaveBeenCalled();
+		await wait(25);
+		// Only the last X fires.
+		expect(cb.resizeX).toHaveBeenCalledTimes(1);
+		expect(cb.resizeX).toHaveBeenCalledWith(100);
+	});
+});
+
+describe("TerminalResizeDebouncer — hidden path", () => {
+	test("schedules X and Y via idle callback when not visible", async () => {
+		const { debouncer, cb } = createHarness({
+			visible: false,
+			bufferLength: 10_000,
+		});
+		debouncer.resize(80, 24, false);
+		// Neither should fire synchronously.
+		expect(cb.resizeBoth).not.toHaveBeenCalled();
+		expect(cb.resizeX).not.toHaveBeenCalled();
+		expect(cb.resizeY).not.toHaveBeenCalled();
+		// After idle (setTimeout(0) fallback in node/bun), both fire.
+		await wait(20);
+		expect(cb.resizeX).toHaveBeenCalledWith(80);
+		expect(cb.resizeY).toHaveBeenCalledWith(24);
+	});
+
+	test("coalesces multiple hidden resizes to latest values", async () => {
+		const { debouncer, cb } = createHarness({
+			visible: false,
+			bufferLength: 10_000,
+		});
+		debouncer.resize(80, 24, false);
+		debouncer.resize(90, 25, false);
+		debouncer.resize(100, 26, false);
+		await wait(20);
+		// Upstream uses a MutableDisposable that refuses to re-schedule while
+		// pending — so only the latest X/Y fire, once each.
+		expect(cb.resizeX).toHaveBeenCalledTimes(1);
+		expect(cb.resizeX).toHaveBeenCalledWith(100);
+		expect(cb.resizeY).toHaveBeenCalledTimes(1);
+		expect(cb.resizeY).toHaveBeenCalledWith(26);
+	});
+});
+
+describe("TerminalResizeDebouncer — flush", () => {
+	test("flush applies latest X and Y via resizeBoth when work is pending", async () => {
+		const { debouncer, cb } = createHarness({
+			visible: true,
+			bufferLength: 10_000,
+			debounceMs: 1000,
+		});
+		debouncer.resize(80, 24, false);
+		debouncer.resize(100, 40, false);
+		expect(cb.resizeX).not.toHaveBeenCalled();
+		debouncer.flush();
+		expect(cb.resizeBoth).toHaveBeenCalledTimes(1);
+		expect(cb.resizeBoth).toHaveBeenCalledWith(100, 40);
+		// Pending X should no longer fire after flush.
+		await wait(20);
+		expect(cb.resizeX).not.toHaveBeenCalled();
+	});
+
+	test("flush is a no-op when nothing is pending", () => {
+		const { debouncer, cb } = createHarness({
+			visible: true,
+			bufferLength: 10_000,
+		});
+		debouncer.flush();
+		expect(cb.resizeBoth).not.toHaveBeenCalled();
+		expect(cb.resizeX).not.toHaveBeenCalled();
+		expect(cb.resizeY).not.toHaveBeenCalled();
+	});
+});
+
+describe("TerminalResizeDebouncer — dispose", () => {
+	test("dispose cancels pending X debounce without firing", async () => {
+		const { debouncer, cb } = createHarness({
+			visible: true,
+			bufferLength: 10_000,
+			debounceMs: 10,
+		});
+		debouncer.resize(80, 24, false);
+		debouncer.dispose();
+		await wait(25);
+		expect(cb.resizeX).not.toHaveBeenCalled();
+	});
+
+	test("dispose cancels pending idle jobs without firing", async () => {
+		const { debouncer, cb } = createHarness({
+			visible: false,
+			bufferLength: 10_000,
+		});
+		debouncer.resize(80, 24, false);
+		debouncer.dispose();
+		await wait(20);
+		expect(cb.resizeX).not.toHaveBeenCalled();
+		expect(cb.resizeY).not.toHaveBeenCalled();
+	});
+});
+
+describe("Constants", () => {
+	test("match upstream VSCode values", () => {
+		expect(StartDebouncingThreshold).toBe(200);
+		expect(DebounceMs).toBe(100);
+	});
+});

--- a/apps/desktop/src/renderer/lib/terminal/resize-debouncer.ts
+++ b/apps/desktop/src/renderer/lib/terminal/resize-debouncer.ts
@@ -1,0 +1,263 @@
+/*---------------------------------------------------------------------------------------------
+ *  Adapted from VSCode:
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See https://github.com/microsoft/vscode/blob/main/LICENSE.txt
+ *--------------------------------------------------------------------------------------------*/
+
+// Ported from VSCode:
+//   src/vs/workbench/contrib/terminal/browser/terminalResizeDebouncer.ts
+//
+// Upstream depends on VSCode's Disposable / MutableDisposable lifecycle,
+// getWindow + runWhenWindowIdle DOM utilities, and a `@debounce(100)` TS
+// decorator. This port preserves the three-tier algorithm and upstream
+// rationale comments, but uses native browser primitives so it stays
+// self-contained. Upstream source is preserved in the JSDoc on each method
+// for diffability against future VSCode revisions.
+
+/**
+ * The _normal_ buffer length threshold at which point resizing starts being debounced.
+ *
+ * Upstream (VSCode terminalResizeDebouncer.ts):
+ *
+ *   const enum Constants {
+ *       StartDebouncingThreshold = 200,
+ *   }
+ */
+export const StartDebouncingThreshold = 200;
+
+/**
+ * Debounce interval for horizontal (reflow-heavy) resizes. Matches upstream's
+ * `@debounce(100)` decorator on `_debounceResizeX`.
+ */
+export const DebounceMs = 100;
+
+export interface ResizeDebouncerCallbacks {
+	/** Whether the host container is currently visible on screen. */
+	isVisible: () => boolean;
+	/**
+	 * Length of xterm's _normal_ buffer (not the alternate-screen buffer).
+	 * Read as `xterm.buffer.normal.length`.
+	 */
+	getBufferLength: () => number;
+	/** Apply both dimensions now. */
+	resizeBoth: (cols: number, rows: number) => void;
+	/** Apply only the horizontal dimension (reflow). */
+	resizeX: (cols: number) => void;
+	/** Apply only the vertical dimension (cheap). */
+	resizeY: (rows: number) => void;
+}
+
+export interface ResizeDebouncerOptions {
+	/** Override the debounce interval (default: {@link DebounceMs}). */
+	debounceMs?: number;
+	/** Override the small-buffer threshold (default: {@link StartDebouncingThreshold}). */
+	bufferThreshold?: number;
+}
+
+/**
+ * Debounces horizontal terminal resizes (expensive reflow) while applying
+ * vertical resizes immediately (cheap). Short-circuits on small buffers or
+ * when the terminal is hidden.
+ *
+ * Upstream (VSCode terminalResizeDebouncer.ts):
+ *
+ *   export class TerminalResizeDebouncer extends Disposable {
+ *       private _latestX: number = 0;
+ *       private _latestY: number = 0;
+ *       private readonly _resizeXJob = this._register(new MutableDisposable());
+ *       private readonly _resizeYJob = this._register(new MutableDisposable());
+ *       // ...
+ *   }
+ */
+export class TerminalResizeDebouncer {
+	private _latestX = 0;
+	private _latestY = 0;
+	private _debounceTimer: ReturnType<typeof setTimeout> | null = null;
+	private _idleXHandle: IdleHandle | null = null;
+	private _idleYHandle: IdleHandle | null = null;
+
+	private readonly _debounceMs: number;
+	private readonly _bufferThreshold: number;
+
+	constructor(
+		private readonly _cb: ResizeDebouncerCallbacks,
+		options: ResizeDebouncerOptions = {},
+	) {
+		this._debounceMs = options.debounceMs ?? DebounceMs;
+		this._bufferThreshold = options.bufferThreshold ?? StartDebouncingThreshold;
+	}
+
+	/**
+	 * Upstream (VSCode terminalResizeDebouncer.ts):
+	 *
+	 *   async resize(cols: number, rows: number, immediate: boolean): Promise<void> {
+	 *       this._latestX = cols;
+	 *       this._latestY = rows;
+	 *
+	 *       // Resize immediately if requested explicitly or if the buffer is small
+	 *       if (immediate || this._getXterm()!.raw.buffer.normal.length < Constants.StartDebouncingThreshold) {
+	 *           this._resizeXJob.clear();
+	 *           this._resizeYJob.clear();
+	 *           this._resizeBothCallback(cols, rows);
+	 *           return;
+	 *       }
+	 *
+	 *       // Resize in an idle callback if the terminal is not visible
+	 *       const win = getWindow(this._getXterm()!.raw.element);
+	 *       if (win && !this._isVisible()) {
+	 *           if (!this._resizeXJob.value) {
+	 *               this._resizeXJob.value = runWhenWindowIdle(win, async () => {
+	 *                   this._resizeXCallback(this._latestX);
+	 *                   this._resizeXJob.clear();
+	 *               });
+	 *           }
+	 *           if (!this._resizeYJob.value) {
+	 *               this._resizeYJob.value = runWhenWindowIdle(win, async () => {
+	 *                   this._resizeYCallback(this._latestY);
+	 *                   this._resizeYJob.clear();
+	 *               });
+	 *           }
+	 *           return;
+	 *       }
+	 *
+	 *       // Update dimensions independently as vertical resize is cheap and horizontal resize is
+	 *       // expensive due to reflow.
+	 *       this._resizeYCallback(rows);
+	 *       this._latestX = cols;
+	 *       this._debounceResizeX(cols);
+	 *   }
+	 */
+	resize(cols: number, rows: number, immediate: boolean): void {
+		this._latestX = cols;
+		this._latestY = rows;
+
+		// Resize immediately if requested explicitly or if the buffer is small
+		if (immediate || this._cb.getBufferLength() < this._bufferThreshold) {
+			this._clearX();
+			this._clearY();
+			this._cb.resizeBoth(cols, rows);
+			return;
+		}
+
+		// Resize in an idle callback if the terminal is not visible
+		if (!this._cb.isVisible()) {
+			if (this._idleXHandle === null) {
+				this._idleXHandle = scheduleIdle(() => {
+					this._idleXHandle = null;
+					this._cb.resizeX(this._latestX);
+				});
+			}
+			if (this._idleYHandle === null) {
+				this._idleYHandle = scheduleIdle(() => {
+					this._idleYHandle = null;
+					this._cb.resizeY(this._latestY);
+				});
+			}
+			return;
+		}
+
+		// Update dimensions independently as vertical resize is cheap and horizontal resize is
+		// expensive due to reflow.
+		this._cb.resizeY(rows);
+		this._debounceResizeX(cols);
+	}
+
+	/**
+	 * Upstream (VSCode terminalResizeDebouncer.ts):
+	 *
+	 *   flush(): void {
+	 *       if (this._resizeXJob.value || this._resizeYJob.value) {
+	 *           this._resizeXJob.clear();
+	 *           this._resizeYJob.clear();
+	 *           this._resizeBothCallback(this._latestX, this._latestY);
+	 *       }
+	 *   }
+	 */
+	flush(): void {
+		if (
+			this._debounceTimer !== null ||
+			this._idleXHandle !== null ||
+			this._idleYHandle !== null
+		) {
+			this._clearX();
+			this._clearY();
+			this._cb.resizeBoth(this._latestX, this._latestY);
+		}
+	}
+
+	/** Cancel any pending work without firing callbacks. Upstream: via `Disposable.dispose()`. */
+	dispose(): void {
+		this._clearX();
+		this._clearY();
+	}
+
+	/**
+	 * Upstream (VSCode terminalResizeDebouncer.ts):
+	 *
+	 *   @debounce(100)
+	 *   private _debounceResizeX(cols: number) {
+	 *       this._resizeXCallback(cols);
+	 *   }
+	 */
+	private _debounceResizeX(cols: number): void {
+		if (this._debounceTimer !== null) clearTimeout(this._debounceTimer);
+		this._debounceTimer = setTimeout(() => {
+			this._debounceTimer = null;
+			this._cb.resizeX(cols);
+		}, this._debounceMs);
+	}
+
+	private _clearX(): void {
+		if (this._debounceTimer !== null) {
+			clearTimeout(this._debounceTimer);
+			this._debounceTimer = null;
+		}
+		if (this._idleXHandle !== null) {
+			cancelIdle(this._idleXHandle);
+			this._idleXHandle = null;
+		}
+	}
+
+	private _clearY(): void {
+		if (this._idleYHandle !== null) {
+			cancelIdle(this._idleYHandle);
+			this._idleYHandle = null;
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Idle-callback shim. Upstream uses VSCode's `runWhenWindowIdle`, which wraps
+// `requestIdleCallback` with a setTimeout fallback for browsers that lack it
+// (historically Safari). We mirror that here.
+// ---------------------------------------------------------------------------
+
+type IdleHandle =
+	| { kind: "idle"; handle: number }
+	| { kind: "timeout"; handle: ReturnType<typeof setTimeout> };
+
+function scheduleIdle(cb: () => void): IdleHandle {
+	if (
+		typeof globalThis !== "undefined" &&
+		typeof (globalThis as { requestIdleCallback?: unknown })
+			.requestIdleCallback === "function"
+	) {
+		return {
+			kind: "idle",
+			handle: (
+				globalThis as { requestIdleCallback: (cb: () => void) => number }
+			).requestIdleCallback(cb),
+		};
+	}
+	return { kind: "timeout", handle: setTimeout(cb, 0) };
+}
+
+function cancelIdle(handle: IdleHandle): void {
+	if (handle.kind === "idle") {
+		(
+			globalThis as { cancelIdleCallback?: (h: number) => void }
+		).cancelIdleCallback?.(handle.handle);
+		return;
+	}
+	clearTimeout(handle.handle);
+}

--- a/apps/desktop/src/renderer/lib/terminal/resize-debouncer.ts
+++ b/apps/desktop/src/renderer/lib/terminal/resize-debouncer.ts
@@ -141,6 +141,15 @@ export class TerminalResizeDebouncer {
 
 		// Resize in an idle callback if the terminal is not visible
 		if (!this._cb.isVisible()) {
+			// A previous visible tick may have left a debounced X reflow
+			// pending. Cancel it — otherwise it will fire later with the old
+			// (closed-over) cols and revert the idle-applied value. Upstream
+			// avoids this implicitly by storing both the debounce job and the
+			// idle job in a single `MutableDisposable` slot.
+			if (this._debounceTimer !== null) {
+				clearTimeout(this._debounceTimer);
+				this._debounceTimer = null;
+			}
 			if (this._idleXHandle === null) {
 				this._idleXHandle = scheduleIdle(() => {
 					this._idleXHandle = null;
@@ -154,6 +163,18 @@ export class TerminalResizeDebouncer {
 				});
 			}
 			return;
+		}
+
+		// Symmetric to the hidden-path cleanup: drop any still-pending idle
+		// jobs that were queued while hidden — they'd fire after this visible
+		// tick and clobber state we just set.
+		if (this._idleXHandle !== null) {
+			cancelIdle(this._idleXHandle);
+			this._idleXHandle = null;
+		}
+		if (this._idleYHandle !== null) {
+			cancelIdle(this._idleYHandle);
+			this._idleYHandle = null;
 		}
 
 		// Update dimensions independently as vertical resize is cheap and horizontal resize is

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -6,6 +6,7 @@ import { Terminal as XTerm } from "@xterm/xterm";
 import { resolveHotkeyFromEvent } from "renderer/hotkeys";
 import { DEFAULT_TERMINAL_SCROLLBACK } from "shared/constants";
 import type { TerminalAppearance } from "./appearance";
+import { TerminalResizeDebouncer } from "./resize-debouncer";
 import { loadAddons } from "./terminal-addons";
 
 const SERIALIZE_SCROLLBACK = 1000;
@@ -32,6 +33,8 @@ export interface TerminalRuntime {
 	wrapper: HTMLDivElement;
 	container: HTMLDivElement | null;
 	resizeObserver: ResizeObserver | null;
+	/** Debounces the expensive horizontal reflow during rapid container resizes. */
+	resizeDebouncer: TerminalResizeDebouncer;
 	lastCols: number;
 	lastRows: number;
 	_disposeAddons: (() => void) | null;
@@ -124,11 +127,21 @@ function hostIsVisible(container: HTMLDivElement | null): boolean {
 	return container.clientWidth > 0 && container.clientHeight > 0;
 }
 
-function measureAndResize(runtime: TerminalRuntime) {
+function measureAndResize(runtime: TerminalRuntime, immediate: boolean) {
 	if (!hostIsVisible(runtime.container)) return;
-	runtime.fitAddon.fit();
-	runtime.lastCols = runtime.terminal.cols;
-	runtime.lastRows = runtime.terminal.rows;
+	// Split what `fitAddon.fit()` would do into propose → apply so the debouncer
+	// can coalesce the apply step (expensive reflow on cols change).
+	const dims = runtime.fitAddon.proposeDimensions();
+	if (!dims) return;
+	// Skip no-change ticks — ResizeObserver fires on subpixel layout shifts
+	// that often don't change the cell grid.
+	if (
+		dims.cols === runtime.terminal.cols &&
+		dims.rows === runtime.terminal.rows
+	) {
+		return;
+	}
+	runtime.resizeDebouncer.resize(dims.cols, dims.rows, immediate);
 }
 
 export function createRuntime(
@@ -157,7 +170,7 @@ export function createRuntime(
 	const addonsResult = loadAddons(terminal);
 	restoreBuffer(terminalId, terminal);
 
-	return {
+	const runtime: TerminalRuntime = {
 		terminalId,
 		terminal,
 		fitAddon,
@@ -167,10 +180,33 @@ export function createRuntime(
 		wrapper,
 		container: null,
 		resizeObserver: null,
+		// Assigned immediately below — declared non-null here since the debouncer
+		// closes over `runtime` and would otherwise need a placeholder.
+		resizeDebouncer: null as unknown as TerminalResizeDebouncer,
 		lastCols: cols,
 		lastRows: rows,
 		_disposeAddons: addonsResult.dispose,
 	};
+
+	runtime.resizeDebouncer = new TerminalResizeDebouncer({
+		isVisible: () => hostIsVisible(runtime.container),
+		getBufferLength: () => terminal.buffer.normal.length,
+		resizeBoth: (c, r) => {
+			terminal.resize(c, r);
+			runtime.lastCols = c;
+			runtime.lastRows = r;
+		},
+		resizeX: (c) => {
+			terminal.resize(c, terminal.rows);
+			runtime.lastCols = c;
+		},
+		resizeY: (r) => {
+			terminal.resize(terminal.cols, r);
+			runtime.lastRows = r;
+		},
+	});
+
+	return runtime;
 }
 
 export function attachToContainer(
@@ -180,14 +216,17 @@ export function attachToContainer(
 ) {
 	runtime.container = container;
 	container.appendChild(runtime.wrapper);
-	measureAndResize(runtime);
+	// Initial attach: apply dimensions now so the first frame isn't stale.
+	measureAndResize(runtime, true);
 
 	// Renderer may have skipped frames while the wrapper was detached.
 	runtime.terminal.refresh(0, runtime.terminal.rows - 1);
 
 	runtime.resizeObserver?.disconnect();
 	const observer = new ResizeObserver(() => {
-		measureAndResize(runtime);
+		// Subsequent resizes go through the debouncer (splitter drags,
+		// window resizes, sidebar toggles fire this many times per frame).
+		measureAndResize(runtime, false);
 		onResize?.();
 	});
 	observer.observe(container);
@@ -197,6 +236,9 @@ export function attachToContainer(
 }
 
 export function detachFromContainer(runtime: TerminalRuntime) {
+	// Flush any pending debounced resize so `lastCols`/`lastRows` reflect the
+	// latest intended dimensions before we persist them.
+	runtime.resizeDebouncer.flush();
 	persistBuffer(runtime.terminalId, runtime.serializeAddon);
 	persistDimensions(runtime.terminalId, runtime.lastCols, runtime.lastRows);
 	runtime.resizeObserver?.disconnect();
@@ -209,7 +251,7 @@ export function updateRuntimeAppearance(
 	runtime: TerminalRuntime,
 	appearance: TerminalAppearance,
 ) {
-	const { terminal, fitAddon } = runtime;
+	const { terminal } = runtime;
 	terminal.options.theme = appearance.theme;
 
 	const fontChanged =
@@ -219,11 +261,8 @@ export function updateRuntimeAppearance(
 	if (fontChanged) {
 		terminal.options.fontFamily = appearance.fontFamily;
 		terminal.options.fontSize = appearance.fontSize;
-		if (hostIsVisible(runtime.container)) {
-			fitAddon.fit();
-			runtime.lastCols = terminal.cols;
-			runtime.lastRows = terminal.rows;
-		}
+		// Font change is an explicit user action → apply immediately.
+		measureAndResize(runtime, true);
 	}
 }
 
@@ -232,6 +271,7 @@ export function disposeRuntime(runtime: TerminalRuntime) {
 	runtime._disposeAddons = null;
 	runtime.resizeObserver?.disconnect();
 	runtime.resizeObserver = null;
+	runtime.resizeDebouncer.dispose();
 	runtime.wrapper.remove();
 	runtime.terminal.dispose();
 	clearPersistedBuffer(runtime.terminalId);

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -1,4 +1,5 @@
 import type { Terminal as XTerm } from "@xterm/xterm";
+import { AckDataBufferer } from "./flow-control";
 
 export type ConnectionState = "disconnected" | "connecting" | "open" | "closed";
 
@@ -23,6 +24,12 @@ export interface TerminalTransport {
 	_terminal: XTerm | null;
 	/** Set when the server sends an exit message — no reconnect after this. */
 	_exited: boolean;
+	/**
+	 * Batches per-chunk ack counts before flushing over the wire as an
+	 * `{type:"ack",charCount}` message. Re-created per connection so a stale
+	 * buffer from a prior socket can't ack into a fresh one.
+	 */
+	_ackBufferer: AckDataBufferer | null;
 }
 
 function setConnectionState(
@@ -50,6 +57,7 @@ export function createTransport(): TerminalTransport {
 		_reconnectAttempt: 0,
 		_terminal: null,
 		_exited: false,
+		_ackBufferer: null,
 	};
 }
 
@@ -108,6 +116,16 @@ export function connect(
 	const socket = new WebSocket(wsUrl);
 	transport.socket = socket;
 
+	// Ack-based flow control: batches acks into CharCountAckSize chunks and
+	// sends `{type:"ack",charCount}` upstream so the server can pause/resume
+	// the pty. See apps/desktop/src/renderer/lib/terminal/flow-control.ts.
+	const ackBufferer = new AckDataBufferer((charCount) => {
+		if (socket.readyState === WebSocket.OPEN) {
+			socket.send(JSON.stringify({ type: "ack", charCount }));
+		}
+	});
+	transport._ackBufferer = ackBufferer;
+
 	socket.addEventListener("open", () => {
 		if (transport.socket !== socket) return;
 		transport._reconnectAttempt = 0;
@@ -126,7 +144,13 @@ export function connect(
 		}
 
 		if (message.type === "data" || message.type === "replay") {
-			terminal.write(message.data);
+			// Ack after xterm has *parsed* (not merely received) this chunk —
+			// matches VSCode's write-callback pattern so the server only
+			// resumes once the renderer has actually caught up.
+			const len = message.data.length;
+			terminal.write(message.data, () => {
+				ackBufferer.ack(len);
+			});
 			return;
 		}
 
@@ -176,6 +200,7 @@ export function disconnect(transport: TerminalTransport) {
 	setConnectionState(transport, "disconnected");
 	transport.onDataDisposable?.dispose();
 	transport.onDataDisposable = null;
+	transport._ackBufferer = null;
 }
 
 export function sendResize(

--- a/packages/host-service/src/terminal/flow-control.test.ts
+++ b/packages/host-service/src/terminal/flow-control.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from "bun:test";
+import {
+	clearUnacknowledged,
+	createFlowControlState,
+	FlowControlConstants,
+	recordAck,
+	recordOutput,
+} from "./flow-control";
+
+// Upstream VSCode (terminalProcess.ts) carries this logic inline without unit
+// tests. These tests pin the documented behavior so a future vendor refresh
+// surfaces any semantic drift.
+
+describe("recordOutput", () => {
+	test("does not request pause below HighWatermarkChars", () => {
+		const state = createFlowControlState();
+		const shouldPause = recordOutput(
+			state,
+			FlowControlConstants.HighWatermarkChars - 1,
+		);
+		expect(shouldPause).toBe(false);
+		expect(state.isPaused).toBe(false);
+	});
+
+	test("does not request pause at exactly HighWatermarkChars (strictly-greater-than)", () => {
+		// Upstream uses `> HighWatermarkChars`, not `>=`.
+		const state = createFlowControlState();
+		const shouldPause = recordOutput(
+			state,
+			FlowControlConstants.HighWatermarkChars,
+		);
+		expect(shouldPause).toBe(false);
+		expect(state.isPaused).toBe(false);
+	});
+
+	test("requests pause once on crossing HighWatermarkChars", () => {
+		const state = createFlowControlState();
+		const shouldPause = recordOutput(
+			state,
+			FlowControlConstants.HighWatermarkChars + 1,
+		);
+		expect(shouldPause).toBe(true);
+		expect(state.isPaused).toBe(true);
+	});
+
+	test("does not re-request pause while already paused", () => {
+		const state = createFlowControlState();
+		recordOutput(state, FlowControlConstants.HighWatermarkChars + 1);
+		const shouldPauseAgain = recordOutput(state, 50_000);
+		expect(shouldPauseAgain).toBe(false);
+		expect(state.isPaused).toBe(true);
+	});
+
+	test("accumulates across multiple small outputs", () => {
+		const state = createFlowControlState();
+		for (let i = 0; i < 10; i++) {
+			expect(recordOutput(state, 9_000)).toBe(false);
+		}
+		// 90k so far, still under.
+		expect(state.unacknowledgedCharCount).toBe(90_000);
+		expect(recordOutput(state, 10_001)).toBe(true);
+	});
+});
+
+describe("recordAck", () => {
+	test("does not request resume when not paused", () => {
+		const state = createFlowControlState();
+		state.unacknowledgedCharCount = 1_000;
+		const shouldResume = recordAck(state, 500);
+		expect(shouldResume).toBe(false);
+		expect(state.isPaused).toBe(false);
+		expect(state.unacknowledgedCharCount).toBe(500);
+	});
+
+	test("does not request resume when still above LowWatermarkChars", () => {
+		const state = createFlowControlState();
+		recordOutput(state, FlowControlConstants.HighWatermarkChars + 1);
+		// Ack enough to go under HighWatermark but still above LowWatermark.
+		const shouldResume = recordAck(state, 50_000);
+		expect(shouldResume).toBe(false);
+		expect(state.isPaused).toBe(true);
+	});
+
+	test("requests resume when dropping below LowWatermarkChars", () => {
+		const state = createFlowControlState();
+		recordOutput(state, FlowControlConstants.HighWatermarkChars + 1);
+		const before = state.unacknowledgedCharCount;
+		const shouldResume = recordAck(
+			state,
+			before - (FlowControlConstants.LowWatermarkChars - 1),
+		);
+		expect(shouldResume).toBe(true);
+		expect(state.isPaused).toBe(false);
+		expect(state.unacknowledgedCharCount).toBe(
+			FlowControlConstants.LowWatermarkChars - 1,
+		);
+	});
+
+	test("does not request resume at exactly LowWatermarkChars (strictly-less-than)", () => {
+		// Upstream uses `< LowWatermarkChars`, not `<=`.
+		const state = createFlowControlState();
+		recordOutput(state, FlowControlConstants.HighWatermarkChars + 1);
+		const before = state.unacknowledgedCharCount;
+		const shouldResume = recordAck(
+			state,
+			before - FlowControlConstants.LowWatermarkChars,
+		);
+		expect(shouldResume).toBe(false);
+		expect(state.isPaused).toBe(true);
+	});
+
+	test("clamps unacknowledgedCharCount at 0 on over-ack", () => {
+		// Upstream comment: "Prevent lower than 0 to heal from errors".
+		const state = createFlowControlState();
+		state.unacknowledgedCharCount = 1_000;
+		recordAck(state, 5_000);
+		expect(state.unacknowledgedCharCount).toBe(0);
+	});
+
+	test("requests resume exactly once when draining past LowWatermarkChars", () => {
+		const state = createFlowControlState();
+		recordOutput(state, FlowControlConstants.HighWatermarkChars + 1);
+		// First ack leaves us above LowWatermark — no resume.
+		expect(recordAck(state, 90_000)).toBe(false);
+		// Second ack crosses under — resume.
+		expect(recordAck(state, 10_000)).toBe(true);
+		// Subsequent acks must not fire resume again.
+		expect(recordAck(state, 100)).toBe(false);
+	});
+});
+
+describe("clearUnacknowledged", () => {
+	test("resets count and requests resume when paused", () => {
+		const state = createFlowControlState();
+		recordOutput(state, FlowControlConstants.HighWatermarkChars + 1);
+		const shouldResume = clearUnacknowledged(state);
+		expect(shouldResume).toBe(true);
+		expect(state.unacknowledgedCharCount).toBe(0);
+		expect(state.isPaused).toBe(false);
+	});
+
+	test("resets count without requesting resume when not paused", () => {
+		const state = createFlowControlState();
+		state.unacknowledgedCharCount = 1_234;
+		const shouldResume = clearUnacknowledged(state);
+		expect(shouldResume).toBe(false);
+		expect(state.unacknowledgedCharCount).toBe(0);
+		expect(state.isPaused).toBe(false);
+	});
+});
+
+describe("FlowControlConstants", () => {
+	test("matches VSCode upstream values", () => {
+		expect(FlowControlConstants.HighWatermarkChars).toBe(100_000);
+		expect(FlowControlConstants.LowWatermarkChars).toBe(5_000);
+		expect(FlowControlConstants.CharCountAckSize).toBe(5_000);
+	});
+});

--- a/packages/host-service/src/terminal/flow-control.ts
+++ b/packages/host-service/src/terminal/flow-control.ts
@@ -1,0 +1,116 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See https://github.com/microsoft/vscode/blob/main/LICENSE.txt
+ *--------------------------------------------------------------------------------------------*/
+
+// Vendored from VSCode:
+//   - FlowControlConstants:            src/vs/platform/terminal/common/terminal.ts
+//   - _unacknowledgedCharCount / _isPtyPaused / acknowledgeDataEvent / clearUnacknowledgedChars:
+//     src/vs/platform/terminal/node/terminalProcess.ts (inline fields/methods on TerminalProcess)
+//
+// Upstream puts this logic directly on the TerminalProcess class. It is factored
+// here as a tiny state helper so it can be unit-tested without spawning a real pty.
+// The observable behaviour (thresholds, clamp-to-zero on over-ack, force-resume
+// on clear) mirrors upstream byte-for-byte.
+
+/**
+ * Upstream (VSCode terminal.ts):
+ *
+ *   export const enum FlowControlConstants {
+ *       HighWatermarkChars = 100000,
+ *       LowWatermarkChars = 5000,
+ *       CharCountAckSize = 5000
+ *   }
+ */
+export const FlowControlConstants = {
+	HighWatermarkChars: 100000,
+	LowWatermarkChars: 5000,
+	CharCountAckSize: 5000,
+} as const;
+
+export interface FlowControlState {
+	unacknowledgedCharCount: number;
+	isPaused: boolean;
+}
+
+export function createFlowControlState(): FlowControlState {
+	return { unacknowledgedCharCount: 0, isPaused: false };
+}
+
+/**
+ * Upstream (VSCode terminalProcess.ts, inside the `ptyProcess.onData` handler):
+ *
+ *   this._unacknowledgedCharCount += data.length;
+ *   if (!this._isPtyPaused && this._unacknowledgedCharCount > FlowControlConstants.HighWatermarkChars) {
+ *       this._isPtyPaused = true;
+ *       ptyProcess.pause();
+ *   }
+ *
+ * Returns `true` when the caller should invoke `ptyProcess.pause()`.
+ */
+export function recordOutput(
+	state: FlowControlState,
+	charCount: number,
+): boolean {
+	state.unacknowledgedCharCount += charCount;
+	if (
+		!state.isPaused &&
+		state.unacknowledgedCharCount > FlowControlConstants.HighWatermarkChars
+	) {
+		state.isPaused = true;
+		return true;
+	}
+	return false;
+}
+
+/**
+ * Upstream (VSCode terminalProcess.ts `acknowledgeDataEvent`):
+ *
+ *   acknowledgeDataEvent(charCount: number): void {
+ *       // Prevent lower than 0 to heal from errors
+ *       this._unacknowledgedCharCount = Math.max(this._unacknowledgedCharCount - charCount, 0);
+ *       if (this._isPtyPaused && this._unacknowledgedCharCount < FlowControlConstants.LowWatermarkChars) {
+ *           this._ptyProcess?.resume();
+ *           this._isPtyPaused = false;
+ *       }
+ *   }
+ *
+ * Returns `true` when the caller should invoke `ptyProcess.resume()`.
+ */
+export function recordAck(state: FlowControlState, charCount: number): boolean {
+	// Prevent lower than 0 to heal from errors
+	state.unacknowledgedCharCount = Math.max(
+		state.unacknowledgedCharCount - charCount,
+		0,
+	);
+	if (
+		state.isPaused &&
+		state.unacknowledgedCharCount < FlowControlConstants.LowWatermarkChars
+	) {
+		state.isPaused = false;
+		return true;
+	}
+	return false;
+}
+
+/**
+ * Upstream (VSCode terminalProcess.ts `clearUnacknowledgedChars`):
+ *
+ *   clearUnacknowledgedChars(): void {
+ *       this._unacknowledgedCharCount = 0;
+ *       if (this._isPtyPaused) {
+ *           this._ptyProcess?.resume();
+ *           this._isPtyPaused = false;
+ *       }
+ *   }
+ *
+ * Returns `true` when the caller should invoke `ptyProcess.resume()`.
+ */
+export function clearUnacknowledged(state: FlowControlState): boolean {
+	state.unacknowledgedCharCount = 0;
+	if (state.isPaused) {
+		state.isPaused = false;
+		return true;
+	}
+	return false;
+}

--- a/packages/host-service/src/terminal/flow-control.ts
+++ b/packages/host-service/src/terminal/flow-control.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 // Vendored from VSCode:
-//   - FlowControlConstants:            src/vs/platform/terminal/common/terminal.ts
 //   - _unacknowledgedCharCount / _isPtyPaused / acknowledgeDataEvent / clearUnacknowledgedChars:
 //     src/vs/platform/terminal/node/terminalProcess.ts (inline fields/methods on TerminalProcess)
 //
@@ -12,21 +11,13 @@
 // here as a tiny state helper so it can be unit-tested without spawning a real pty.
 // The observable behaviour (thresholds, clamp-to-zero on over-ack, force-resume
 // on clear) mirrors upstream byte-for-byte.
+//
+// FlowControlConstants live in @superset/shared/terminal-flow-control so the
+// client and server cannot drift apart on watermark values.
 
-/**
- * Upstream (VSCode terminal.ts):
- *
- *   export const enum FlowControlConstants {
- *       HighWatermarkChars = 100000,
- *       LowWatermarkChars = 5000,
- *       CharCountAckSize = 5000
- *   }
- */
-export const FlowControlConstants = {
-	HighWatermarkChars: 100000,
-	LowWatermarkChars: 5000,
-	CharCountAckSize: 5000,
-} as const;
+import { FlowControlConstants } from "@superset/shared/terminal-flow-control";
+
+export { FlowControlConstants } from "@superset/shared/terminal-flow-control";
 
 export interface FlowControlState {
 	unacknowledgedCharCount: number;

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -17,6 +17,13 @@ import {
 	getTerminalBaseEnv,
 	resolveLaunchShell,
 } from "./env";
+import {
+	clearUnacknowledged,
+	createFlowControlState,
+	type FlowControlState,
+	recordAck,
+	recordOutput,
+} from "./flow-control";
 
 interface RegisterWorkspaceTerminalRouteOptions {
 	app: Hono;
@@ -33,7 +40,8 @@ export function parseThemeType(
 type TerminalClientMessage =
 	| { type: "input"; data: string }
 	| { type: "resize"; cols: number; rows: number }
-	| { type: "dispose" };
+	| { type: "dispose" }
+	| { type: "ack"; charCount: number };
 
 type TerminalServerMessage =
 	| { type: "data"; data: string }
@@ -84,6 +92,9 @@ interface TerminalSession {
 	shellReadyPromise: Promise<void>;
 	shellReadyTimeoutId: ReturnType<typeof setTimeout> | null;
 	scanState: ShellReadyScanState;
+
+	/** Ack-based flow control. See packages/host-service/src/terminal/flow-control.ts. */
+	flowControl: FlowControlState;
 }
 
 /** PTY lifetime is independent of socket lifetime — sockets detach/reattach freely. */
@@ -95,6 +106,22 @@ function sendMessage(
 ) {
 	if (socket.readyState !== 1) return;
 	socket.send(JSON.stringify(message));
+}
+
+/**
+ * Reset flow control when the client detaches. Without this, a pty paused at
+ * the high-watermark would stay paused forever — the detached socket can't
+ * ack, and the in-memory buffer is capped by MAX_BUFFER_BYTES anyway so
+ * there's no need to keep backpressure applied while nobody is consuming.
+ */
+function detachFlowControl(session: TerminalSession) {
+	if (clearUnacknowledged(session.flowControl)) {
+		try {
+			session.pty.resume();
+		} catch {
+			// node-pty may reject resume() post-exit; ignore.
+		}
+	}
 }
 
 function bufferOutput(session: TerminalSession, data: string) {
@@ -321,6 +348,7 @@ export function createTerminalSessionInternal({
 		shellReadyPromise,
 		shellReadyTimeoutId: null,
 		scanState: createScanState(),
+		flowControl: createFlowControlState(),
 	};
 	sessions.set(terminalId, session);
 
@@ -348,6 +376,17 @@ export function createTerminalSessionInternal({
 			sendMessage(session.socket, { type: "data", data });
 		} else {
 			bufferOutput(session, data);
+		}
+
+		// Flow control: pause the pty when too many chars are unacked. The
+		// client acks after xterm has *parsed* each write (not merely received
+		// it), so this bounds how far ahead of the renderer we get.
+		if (recordOutput(session.flowControl, data.length)) {
+			try {
+				pty.pause();
+			} catch {
+				// node-pty may reject pause() post-exit; ignore.
+			}
 		}
 	});
 
@@ -544,6 +583,17 @@ export function registerWorkspaceTerminalRoute({
 						const cols = Math.max(20, Math.floor(message.cols));
 						const rows = Math.max(5, Math.floor(message.rows));
 						session.pty.resize(cols, rows);
+						return;
+					}
+
+					if (message.type === "ack") {
+						if (recordAck(session.flowControl, message.charCount)) {
+							try {
+								session.pty.resume();
+							} catch {
+								// node-pty may reject resume() post-exit; ignore.
+							}
+						}
 					}
 				},
 
@@ -551,6 +601,7 @@ export function registerWorkspaceTerminalRoute({
 					const session = sessions.get(terminalId ?? "");
 					if (session?.socket === ws) {
 						session.socket = null;
+						detachFlowControl(session);
 					}
 				},
 
@@ -558,6 +609,7 @@ export function registerWorkspaceTerminalRoute({
 					const session = sessions.get(terminalId ?? "");
 					if (session?.socket === ws) {
 						session.socket = null;
+						detachFlowControl(session);
 					}
 				},
 			};

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -587,7 +587,19 @@ export function registerWorkspaceTerminalRoute({
 					}
 
 					if (message.type === "ack") {
-						if (recordAck(session.flowControl, message.charCount)) {
+						// charCount is untrusted JSON — reject anything that
+						// would corrupt the flow-control counter (NaN poisons
+						// all future arithmetic and permanently disables
+						// pause/resume for the session).
+						const charCount = message.charCount;
+						if (
+							typeof charCount !== "number" ||
+							!Number.isFinite(charCount) ||
+							charCount <= 0
+						) {
+							return;
+						}
+						if (recordAck(session.flowControl, Math.floor(charCount))) {
 							try {
 								session.pty.resume();
 							} catch {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -16,6 +16,10 @@
 			"types": "./src/terminal-link-parsing/index.ts",
 			"default": "./src/terminal-link-parsing/index.ts"
 		},
+		"./terminal-flow-control": {
+			"types": "./src/terminal-flow-control.ts",
+			"default": "./src/terminal-flow-control.ts"
+		},
 		"./auth": {
 			"types": "./src/auth/index.ts",
 			"default": "./src/auth/index.ts"

--- a/packages/shared/src/terminal-flow-control.ts
+++ b/packages/shared/src/terminal-flow-control.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See https://github.com/microsoft/vscode/blob/main/LICENSE.txt
+ *--------------------------------------------------------------------------------------------*/
+
+// Vendored from VSCode: src/vs/platform/terminal/common/terminal.ts
+//
+// Single source of truth for ack-based terminal flow-control thresholds,
+// imported by both sides of the WS transport so they cannot drift apart
+// (a protocol mismatch here would silently disable pause/resume).
+//
+// Upstream uses `const enum`; rewritten as a `const` object below because our
+// tsconfig has `isolatedModules: true` (const enums are not preserved across
+// module boundaries under isolatedModules).
+
+/**
+ * Upstream (VSCode terminal.ts):
+ *
+ *   export const enum FlowControlConstants {
+ *       HighWatermarkChars = 100000,
+ *       LowWatermarkChars = 5000,
+ *       CharCountAckSize = 5000
+ *   }
+ */
+export const FlowControlConstants = {
+	/**
+	 * The number of _unacknowledged_ chars to have been sent before the pty is paused in order for
+	 * the client to catch up.
+	 */
+	HighWatermarkChars: 100000,
+	/**
+	 * After flow control pauses the pty for the client the catch up, this is the number of
+	 * _unacknowledged_ chars to have been caught up to on the client before resuming the pty again.
+	 * This is used to attempt to prevent pauses in the flowing data; ideally while the pty is
+	 * paused the number of unacknowledged chars would always be greater than 0 or the client will
+	 * appear to stutter. In reality this balance is hard to accomplish though so heavy commands
+	 * will likely pause as latency grows, not flooding the connection is the important thing as
+	 * it's shared with other core functionality.
+	 */
+	LowWatermarkChars: 5000,
+	/**
+	 * The number characters that are accumulated on the client side before sending an ack event.
+	 * This must be less than or equal to LowWatermarkChars or the terminal may never unpause.
+	 */
+	CharCountAckSize: 5000,
+} as const;


### PR DESCRIPTION
## Summary

Two VSCode-derived performance improvements for the v2 terminal (PTY relayed over WebSocket). Both address pain points under network relay: bursty output floods the WS queue, and container drags cause repeated expensive reflows.

### 1. Ack-based flow control (vendored)

Without this, a fast producer (`npm install`, `find /`, big `cat`) queues unbounded frames in the WS buffer — Ctrl-C / typing lag spikes that don't recover until the producer stops.

- **Client** (`apps/desktop/src/renderer/lib/terminal/flow-control.ts`): `AckDataBufferer` + `FlowControlConstants`, byte-identical to VSCode's [`terminalProcessManager.ts`](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts) / [`terminal.ts`](https://github.com/microsoft/vscode/blob/main/src/vs/platform/terminal/common/terminal.ts). `const enum` → `const` object because our tsconfig has `isolatedModules: true`.
- **Server** (`packages/host-service/src/terminal/flow-control.ts`): pause/resume state from [`terminalProcess.ts`](https://github.com/microsoft/vscode/blob/main/src/vs/platform/terminal/node/terminalProcess.ts), factored from inline fields into `createFlowControlState` / `recordOutput` / `recordAck` / `clearUnacknowledged` so it's unit-testable without spawning a real pty. Upstream snippets preserved in JSDoc for diffability.
- **Wiring**:
  - Client creates a per-connection `AckDataBufferer`; `terminal.write(data, cb)` acks by `data.length` after xterm parses (matches VSCode's ack-after-parse pattern). The callback sends `{type:"ack",charCount}` upstream.
  - Server `pty.onData` calls `recordOutput` and pauses on crossing `HighWatermarkChars` (100k). New `"ack"` message calls `recordAck` and resumes below `LowWatermarkChars` (5k).
  - Socket disconnect clears unacked and force-resumes so a paused pty can't get stuck when the client vanishes (in-memory buffer already bounded by `MAX_BUFFER_BYTES`).

### 2. Resize debouncer (ported)

Currently the `ResizeObserver` calls `fitAddon.fit()` synchronously on every tick — during splitter/window drags this reflows the xterm grid on every frame.

- **Port** (`apps/desktop/src/renderer/lib/terminal/resize-debouncer.ts`): [`TerminalResizeDebouncer`](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/terminal/browser/terminalResizeDebouncer.ts)'s three-tier algorithm — immediate if buffer < 200 lines, `requestIdleCallback` if hidden, otherwise Y-immediate + X-debounced-100ms.
- Not an *exact* vendor because upstream depends on five VSCode base modules (`Disposable`/`MutableDisposable`, `getWindow`/`runWhenWindowIdle`, `@debounce(100)` decorator). Exact vendoring would pull ~500 lines of infrastructure and require TS experimental decorators. The port uses native `setTimeout` + `requestIdleCallback` and keeps the original source as JSDoc on each method for diffability.
- **Wiring**: `measureAndResize` splits `fitAddon.fit()` into `proposeDimensions()` + a debounced apply, with a no-change early-out. Initial attach / font change use `immediate: true`; ResizeObserver ticks use `immediate: false`. `detachFromContainer` flushes pending work so persisted dims are current.

## Test plan

- [x] `bun test` on new files — 35 pass across the three test files (flow-control client 9, flow-control server 14, resize debouncer 12)
- [x] `bun run typecheck` — 25/25 workspaces pass
- [x] `biome check` clean
- [ ] Manual smoke: `yes | head -n 1000000` stays responsive during, Ctrl-C bounded after
- [ ] Manual smoke: splitter drag across a terminal no longer reflows on every frame

## Notes

- Tests are fresh — VSCode ships no unit tests for either set of code (only empty `acknowledgeDataEvent() {}` stubs in mocks).
- Originally split across #3648 + #3657 (now closed); folded into one PR per request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ack-based terminal flow control with batched client acknowledgements and a resize debouncer to reduce redundant/expensive terminal reflows.

* **Bug Fixes**
  * Prevents terminals from remaining paused after disconnects and fixes edge cases around pause/resume thresholds and ack rounding.

* **Tests**
  * Added comprehensive tests for ack batching, pause/resume behavior, watermark constants, and resize debouncing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->