### PR TITLE
fix(desktop): allowlist URL schemes before shell.openExternal

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/external/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/index.ts
@@ -9,7 +9,7 @@ import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import { clipboard, shell } from "electron";
 import { localDb } from "main/lib/local-db";
-import { isSafeExternalUrl } from "main/lib/safe-url";
+import { externalUrlLogLabel, isSafeExternalUrl } from "main/lib/safe-url";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
 import { getWorkspace } from "../workspaces/utils/db-helpers";
@@ -95,7 +95,10 @@ export const createExternalRouter = () => {
 	return router({
 		openUrl: publicProcedure.input(z.string()).mutation(async ({ input }) => {
 			if (!isSafeExternalUrl(input)) {
-				console.error("[external/openUrl] Blocked unsafe URL scheme:", input);
+				console.warn(
+					"[external/openUrl] Blocked unsafe URL scheme:",
+					externalUrlLogLabel(input),
+				);
 				throw new TRPCError({
 					code: "BAD_REQUEST",
 					message: "URL scheme not allowed",
@@ -106,7 +109,11 @@ export const createExternalRouter = () => {
 			} catch (error) {
 				const errorMessage =
 					error instanceof Error ? error.message : "Unknown error";
-				console.error("[external/openUrl] Failed to open URL:", input, error);
+				console.error(
+					"[external/openUrl] Failed to open URL:",
+					externalUrlLogLabel(input),
+					error,
+				);
 				throw new TRPCError({
 					code: "INTERNAL_SERVER_ERROR",
 					message: errorMessage,

--- a/apps/desktop/src/lib/trpc/routers/external/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/index.ts
@@ -9,6 +9,7 @@ import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import { clipboard, shell } from "electron";
 import { localDb } from "main/lib/local-db";
+import { isSafeExternalUrl } from "main/lib/safe-url";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
 import { getWorkspace } from "../workspaces/utils/db-helpers";
@@ -93,6 +94,13 @@ async function openPathInApp(
 export const createExternalRouter = () => {
 	return router({
 		openUrl: publicProcedure.input(z.string()).mutation(async ({ input }) => {
+			if (!isSafeExternalUrl(input)) {
+				console.error("[external/openUrl] Blocked unsafe URL scheme:", input);
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "URL scheme not allowed",
+				});
+			}
 			try {
 				await shell.openExternal(input);
 			} catch (error) {

--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
-import { clipboard, Menu, shell, webContents } from "electron";
+import { clipboard, Menu, webContents } from "electron";
+import { safeOpenExternal } from "main/lib/safe-url";
 
 interface ConsoleEntry {
 	level: "log" | "warn" | "error" | "info" | "debug";
@@ -126,7 +127,9 @@ class BrowserManager extends EventEmitter {
 				menuItems.push(
 					{
 						label: "Open Link in Default Browser",
-						click: () => shell.openExternal(linkURL),
+						click: () => {
+							void safeOpenExternal(linkURL);
+						},
 					},
 					{
 						label: "Open Link as New Split",
@@ -194,7 +197,7 @@ class BrowserManager extends EventEmitter {
 						label: "Open Page in Default Browser",
 						click: () => {
 							if (pageURL && pageURL !== "about:blank") {
-								shell.openExternal(pageURL);
+								void safeOpenExternal(pageURL);
 							}
 						},
 						enabled: !!pageURL && pageURL !== "about:blank",

--- a/apps/desktop/src/main/lib/safe-url/index.ts
+++ b/apps/desktop/src/main/lib/safe-url/index.ts
@@ -1,1 +1,5 @@
-export { isSafeExternalUrl, safeOpenExternal } from "./safe-url";
+export {
+	externalUrlLogLabel,
+	isSafeExternalUrl,
+	safeOpenExternal,
+} from "./safe-url";

--- a/apps/desktop/src/main/lib/safe-url/index.ts
+++ b/apps/desktop/src/main/lib/safe-url/index.ts
@@ -1,0 +1,1 @@
+export { isSafeExternalUrl, safeOpenExternal } from "./safe-url";

--- a/apps/desktop/src/main/lib/safe-url/safe-url.test.ts
+++ b/apps/desktop/src/main/lib/safe-url/safe-url.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+import { isSafeExternalUrl } from "./safe-url";
+
+describe("isSafeExternalUrl", () => {
+	it("allows http, https, and mailto URLs", () => {
+		expect(isSafeExternalUrl("http://example.com")).toBe(true);
+		expect(isSafeExternalUrl("https://example.com/path?q=1")).toBe(true);
+		expect(isSafeExternalUrl("mailto:user@example.com")).toBe(true);
+		expect(isSafeExternalUrl("HTTPS://EXAMPLE.COM")).toBe(true);
+	});
+
+	it("blocks file, javascript, data, and custom-scheme URLs", () => {
+		expect(
+			isSafeExternalUrl("file:///System/Applications/Calculator.app"),
+		).toBe(false);
+		expect(isSafeExternalUrl("file:///etc/passwd")).toBe(false);
+		expect(isSafeExternalUrl("javascript:alert(1)")).toBe(false);
+		expect(isSafeExternalUrl("data:text/html,<script>alert(1)</script>")).toBe(
+			false,
+		);
+		expect(isSafeExternalUrl("vscode://open?url=evil")).toBe(false);
+		expect(isSafeExternalUrl("ssh://user@host")).toBe(false);
+		expect(isSafeExternalUrl("ftp://example.com")).toBe(false);
+	});
+
+	it("blocks malformed input", () => {
+		expect(isSafeExternalUrl("")).toBe(false);
+		expect(isSafeExternalUrl("not a url")).toBe(false);
+		expect(isSafeExternalUrl("/etc/passwd")).toBe(false);
+	});
+});

--- a/apps/desktop/src/main/lib/safe-url/safe-url.test.ts
+++ b/apps/desktop/src/main/lib/safe-url/safe-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { isSafeExternalUrl } from "./safe-url";
+import { externalUrlLogLabel, isSafeExternalUrl } from "./safe-url";
 
 describe("isSafeExternalUrl", () => {
 	it("allows http, https, and mailto URLs", () => {
@@ -27,5 +27,20 @@ describe("isSafeExternalUrl", () => {
 		expect(isSafeExternalUrl("")).toBe(false);
 		expect(isSafeExternalUrl("not a url")).toBe(false);
 		expect(isSafeExternalUrl("/etc/passwd")).toBe(false);
+	});
+});
+
+describe("externalUrlLogLabel", () => {
+	it("returns only the scheme, never the full URL", () => {
+		expect(externalUrlLogLabel("https://example.com/path?token=secret")).toBe(
+			"https:",
+		);
+		expect(externalUrlLogLabel("file:///etc/passwd")).toBe("file:");
+		expect(externalUrlLogLabel("mailto:user@example.com")).toBe("mailto:");
+	});
+
+	it("returns sentinels for empty and malformed input", () => {
+		expect(externalUrlLogLabel("")).toBe("empty");
+		expect(externalUrlLogLabel("not a url")).toBe("malformed");
 	});
 });

--- a/apps/desktop/src/main/lib/safe-url/safe-url.ts
+++ b/apps/desktop/src/main/lib/safe-url/safe-url.ts
@@ -1,0 +1,30 @@
+import { shell } from "electron";
+
+/**
+ * Schemes safe to hand to Electron's `shell.openExternal`.
+ * Anything else (file:, javascript:, custom handlers, etc.) can execute
+ * binaries or scripts via the OS URL handler registry.
+ */
+const ALLOWED_SCHEMES = new Set(["http:", "https:", "mailto:"]);
+
+export function isSafeExternalUrl(url: string): boolean {
+	if (typeof url !== "string" || url.length === 0) return false;
+	try {
+		return ALLOWED_SCHEMES.has(new URL(url).protocol);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Wraps `shell.openExternal` with a scheme allowlist. Returns false and
+ * refuses to dispatch when the URL is not http(s)/mailto.
+ */
+export async function safeOpenExternal(url: string): Promise<boolean> {
+	if (!isSafeExternalUrl(url)) {
+		console.warn("[safeOpenExternal] blocked unsafe URL:", url);
+		return false;
+	}
+	await shell.openExternal(url);
+	return true;
+}

--- a/apps/desktop/src/main/lib/safe-url/safe-url.ts
+++ b/apps/desktop/src/main/lib/safe-url/safe-url.ts
@@ -16,15 +16,38 @@ export function isSafeExternalUrl(url: string): boolean {
 	}
 }
 
+export function externalUrlLogLabel(url: string): string {
+	if (typeof url !== "string" || url.length === 0) return "empty";
+	try {
+		return new URL(url).protocol || "unknown:";
+	} catch {
+		return "malformed";
+	}
+}
+
 /**
  * Wraps `shell.openExternal` with a scheme allowlist. Returns false and
- * refuses to dispatch when the URL is not http(s)/mailto.
+ * refuses to dispatch when the URL is not http(s)/mailto. Catches
+ * `shell.openExternal` rejections so callers can fire-and-forget without
+ * risking an unhandled rejection in the Electron main process.
  */
 export async function safeOpenExternal(url: string): Promise<boolean> {
 	if (!isSafeExternalUrl(url)) {
-		console.warn("[safeOpenExternal] blocked unsafe URL:", url);
+		console.warn(
+			"[safeOpenExternal] blocked unsafe URL scheme:",
+			externalUrlLogLabel(url),
+		);
 		return false;
 	}
-	await shell.openExternal(url);
-	return true;
+	try {
+		await shell.openExternal(url);
+		return true;
+	} catch (error) {
+		console.error(
+			"[safeOpenExternal] openExternal failed:",
+			externalUrlLogLabel(url),
+			error,
+		);
+		return false;
+	}
 }


### PR DESCRIPTION
## Summary
- Gate every `shell.openExternal` call reachable from untrusted content behind an `{http, https, mailto}` scheme allowlist
- Fix browser-pane context menu (`Open Link / Page in Default Browser`) so a `file://` href on a page loaded in the pane can no longer launch arbitrary apps
- Reject disallowed schemes at the `external.openUrl` tRPC boundary with `BAD_REQUEST`

## Test plan
- [x] `bun test src/main/lib/safe-url/` — 3 passed, covers http/https/mailto allow + file/javascript/data/custom-scheme/malformed block
- [x] `bun run typecheck` in `apps/desktop` — clean
- [x] `bun run lint:fix` — clean
- [ ] Manual: load `exploit_0.html` (anchor href = `file:///System/Applications/Calculator.app`) in a browser pane, right-click → "Open Link in Default Browser", confirm Calculator does not launch and a warning is logged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allowlisted `http`, `https`, and `mailto` before `shell.openExternal` to block unsafe URL handlers. Prevents `file://` links from launching apps, rejects disallowed schemes in `external.openUrl` with `BAD_REQUEST`, and logs only the URL scheme.

- **Bug Fixes**
  - Added `main/lib/safe-url` with `isSafeExternalUrl`, `safeOpenExternal`, and `externalUrlLogLabel`; unit tests cover allowlist, blocked schemes, and redacted logging.
  - Routed browser-pane “Open Link/Page in Default Browser” actions through `safeOpenExternal` to avoid unhandled rejections.
  - Validated and redacted URLs in `external.openUrl`; disallowed schemes return `BAD_REQUEST`.

<sup>Written for commit bc5ce110d5e0fba76564e391dd260a923479a047. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Safer external URL handling: the app now validates and gates external-open requests and uses a safe open routine.

* **Bug Fixes**
  * Disallowed URL schemes (non-http/https/mailto) are blocked and cause a warning instead of attempting to open.
  * Error logging no longer exposes raw URLs and failures are handled gracefully to avoid crashes.

* **Tests**
  * Added tests covering URL validation and log labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->