### PR TITLE
feat(host-service): restore AI session title generation for v2 chat

### DIFF
--- a/packages/chat/src/server/trpc/index.ts
+++ b/packages/chat/src/server/trpc/index.ts
@@ -3,4 +3,8 @@ export {
 	type ChatRuntimeServiceOptions,
 	type ChatRuntimeServiceRouter,
 } from "./service";
-export type { LifecycleEvent } from "./utils/runtime";
+export {
+	generateAndSetTitle,
+	type LifecycleEvent,
+	type TitleRuntime,
+} from "./utils/runtime";

--- a/packages/chat/src/server/trpc/utils/runtime/index.ts
+++ b/packages/chat/src/server/trpc/utils/runtime/index.ts
@@ -13,6 +13,7 @@ export {
 	runSessionStartHook,
 	subscribeToSessionEvents,
 	syncRuntimeHookSessionId,
+	type TitleRuntime,
 } from "./runtime";
 export {
 	authenticateRuntimeMcpServer,

--- a/packages/chat/src/server/trpc/utils/runtime/runtime.ts
+++ b/packages/chat/src/server/trpc/utils/runtime/runtime.ts
@@ -454,8 +454,13 @@ function extractTextContent(parts: MessageLike["content"]): string {
 		.join(" ");
 }
 
+export interface TitleRuntime {
+	sessionId: string;
+	harness: RuntimeHarness;
+}
+
 export async function generateAndSetTitle(
-	runtime: RuntimeSession,
+	runtime: TitleRuntime,
 	apiClient: ApiClient,
 	options?: {
 		submittedUserMessage?: string;

--- a/packages/host-service/src/app.ts
+++ b/packages/host-service/src/app.ts
@@ -67,6 +67,7 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 	const chatRuntime = new ChatRuntimeManager({
 		db,
 		runtimeResolver: providers.modelResolver,
+		api,
 	});
 
 	const runtime = {

--- a/packages/host-service/src/runtime/chat/chat.ts
+++ b/packages/host-service/src/runtime/chat/chat.ts
@@ -1,11 +1,13 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { generateAndSetTitle } from "@superset/chat/server/trpc";
 import { eq } from "drizzle-orm";
 import { createMastraCode } from "mastracode";
 import type { HostDb } from "../../db";
 import { workspaces } from "../../db/schema";
 import type { ModelProviderRuntimeResolver } from "../../providers/model-providers";
+import type { ApiClient } from "../../types";
 
 type RuntimeHarness = Awaited<ReturnType<typeof createMastraCode>>["harness"];
 type RuntimeMcpManager = Awaited<
@@ -147,6 +149,7 @@ interface HarnessWithConfig {
 export interface ChatRuntimeManagerOptions {
 	db: HostDb;
 	runtimeResolver: ModelProviderRuntimeResolver;
+	api: ApiClient;
 }
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
@@ -312,6 +315,7 @@ async function restartRuntimeFromUserMessage(
 export class ChatRuntimeManager {
 	private readonly db: HostDb;
 	private readonly runtimeResolver: ModelProviderRuntimeResolver;
+	private readonly api: ApiClient;
 	private readonly runtimes = new Map<string, RuntimeSession>();
 	private readonly runtimeCreations = new Map<
 		string,
@@ -321,6 +325,7 @@ export class ChatRuntimeManager {
 	constructor(options: ChatRuntimeManagerOptions) {
 		this.db = options.db;
 		this.runtimeResolver = options.runtimeResolver;
+		this.api = options.api;
 	}
 
 	private subscribeToSessionEvents(runtime: RuntimeSession): void {
@@ -528,6 +533,11 @@ When you need to ask the user ANY question — including simple yes/no, confirma
 			await runtime.harness.setState({ thinkingLevel });
 		}
 
+		const submittedUserMessage = input.payload.content.trim();
+		void generateAndSetTitle(runtime, this.api, {
+			submittedUserMessage: submittedUserMessage || undefined,
+		});
+
 		return runtime.harness.sendMessage(input.payload);
 	}
 
@@ -538,6 +548,10 @@ When you need to ask the user ANY question — including simple yes/no, confirma
 		);
 		runtime.lastErrorMessage = null;
 		await restartRuntimeFromUserMessage(runtime, input);
+		const submittedUserMessage = input.payload.content.trim();
+		void generateAndSetTitle(runtime, this.api, {
+			submittedUserMessage: submittedUserMessage || undefined,
+		});
 	}
 
 	async stop(input: { sessionId: string; workspaceId: string }): Promise<void> {


### PR DESCRIPTION
## Summary
- v1 generated AI session titles from the first user message via the chat tRPC service; v2 routes through host-service's `ChatRuntimeManager`, which never called the title generator, so v2 sessions stayed untitled in the `SessionSelector`.
- Wire `generateAndSetTitle` into host-service `sendMessage` / `restartFromMessage` so titles populate on the first user message (and re-title every 10th turn, matching v1). The title persists via `chat.updateTitle` and syncs to the v2 renderer through the existing Electric `chat_sessions` collection — no renderer changes needed.
- Loosened `generateAndSetTitle`'s first argument to a narrower `TitleRuntime` (`{ sessionId, harness }`) and re-exported it from `@superset/chat/server/trpc` so host-service's `RuntimeSession` is structurally compatible.

## Test plan
- [x] `bun run typecheck` — all 25 packages pass
- [x] `bun test packages/chat/src/server/trpc/utils/runtime/runtime.test.ts` — 10/10 pass
- [ ] Manual: open a v2 workspace, send a first message in a new chat, confirm the session title updates in the `SessionSelector` shortly after submission
- [ ] Manual: send 10 messages in a session and confirm the title re-generates on the 10th user turn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal refactoring of chat message handling and session management infrastructure to improve code organization and reduce dependency coupling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore automatic session title generation in v2 chat so new chats are titled and the SessionSelector shows names, matching v1. Titles are generated on the first user message and refreshed every 10th turn.

- **Bug Fixes**
  - Wire `generateAndSetTitle` into `host-service` `ChatRuntimeManager` `sendMessage` and `restartFromMessage`.
  - Persist titles via `chat.updateTitle` and sync through Electric `chat_sessions`; no renderer changes.
  - Re-export `generateAndSetTitle` and `TitleRuntime` from `@superset/chat/server/trpc`; update the function to accept `TitleRuntime`. `ChatRuntimeManager` now receives `api` for title generation.

<sup>Written for commit 495fc904020832feeab82e601c13d3d5d19e7139. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

