### PR TITLE
fix(desktop): render pending workspaces at top of sidebar

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -16,8 +16,8 @@ import type {
 	DashboardSidebarWorkspace,
 } from "../../types";
 
-// Pending workspaces render at the top of the project's workspace list, matching where
-// the real workspace is inserted (getPrependTabOrder) once creation succeeds.
+// Sits above every real workspace so the pending row lines up with the real one,
+// which is inserted via getPrependTabOrder.
 const PENDING_WORKSPACE_TAB_ORDER = Number.MIN_SAFE_INTEGER;
 
 export function useDashboardSidebarData() {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -16,8 +16,9 @@ import type {
 	DashboardSidebarWorkspace,
 } from "../../types";
 
-// Pending workspaces are always rendered at the end of the project's workspace list
-const PENDING_WORKSPACE_TAB_ORDER = Number.MAX_SAFE_INTEGER;
+// Pending workspaces render at the top of the project's workspace list, matching where
+// the real workspace is inserted (getPrependTabOrder) once creation succeeds.
+const PENDING_WORKSPACE_TAB_ORDER = Number.MIN_SAFE_INTEGER;
 
 export function useDashboardSidebarData() {
 	const { data: session } = authClient.useSession();


### PR DESCRIPTION
## Summary
- New workspaces are inserted at the top via `getPrependTabOrder`, but pending placeholders were pinned to `Number.MAX_SAFE_INTEGER` — so the "creating"/"failed" row appeared at the bottom while the real workspace showed up at the top.
- Flip `PENDING_WORKSPACE_TAB_ORDER` to `Number.MIN_SAFE_INTEGER` so pending rows render at the top, right where the real workspace will land once creation succeeds.

## Test plan
- [ ] Create a new workspace; confirm the pending indicator appears at the top of the project list (not the bottom).
- [ ] After creation finishes, the pending row is replaced in-place by the real workspace (no visual jump from bottom to top).
- [ ] Trigger a failed creation; the failed pending row stays at the top until dismissed.
- [ ] Projects with sections still render pending above any sections as an ungrouped top-level row.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sidebar ordering so pending workspace rows (“creating/failed”) render at the top, matching where the new workspace is inserted and preventing a bottom-to-top jump. Changes `PENDING_WORKSPACE_TAB_ORDER` from `Number.MAX_SAFE_INTEGER` to `Number.MIN_SAFE_INTEGER` and clarifies the inline comment.

<sup>Written for commit db66c92df8d8a1f2494489b7bf11b94d93498e8b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the ordering of pending workspaces in the dashboard sidebar. Pending workspaces now appear at the top of the workspace list instead of at the bottom.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->