### PR TITLE
fix(desktop): persist v2 sidebar open state globally across workspaces

### DIFF
--- a/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
+++ b/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
@@ -9,11 +9,14 @@ import {
 	type V2UserPreferencesRow,
 } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
 
+export type RightSidebarTab = V2UserPreferencesRow["rightSidebarTab"];
+
 export interface V2UserPreferencesApi {
 	preferences: V2UserPreferencesRow;
 	setFileLinks: (next: LinkTierMap) => void;
 	setUrlLinks: (next: LinkTierMap) => void;
 	setRightSidebarOpen: (next: boolean | ((prev: boolean) => boolean)) => void;
+	setRightSidebarTab: (next: RightSidebarTab) => void;
 }
 
 export function useV2UserPreferences(): V2UserPreferencesApi {
@@ -79,5 +82,30 @@ export function useV2UserPreferences(): V2UserPreferencesApi {
 		[collections],
 	);
 
-	return { preferences, setFileLinks, setUrlLinks, setRightSidebarOpen };
+	const setRightSidebarTab = useCallback(
+		(next: RightSidebarTab) => {
+			const existing = collections.v2UserPreferences.get(
+				V2_USER_PREFERENCES_ID,
+			);
+			if (!existing) {
+				collections.v2UserPreferences.insert({
+					...DEFAULT_V2_USER_PREFERENCES,
+					rightSidebarTab: next,
+				});
+				return;
+			}
+			collections.v2UserPreferences.update(V2_USER_PREFERENCES_ID, (draft) => {
+				draft.rightSidebarTab = next;
+			});
+		},
+		[collections],
+	);
+
+	return {
+		preferences,
+		setFileLinks,
+		setUrlLinks,
+		setRightSidebarOpen,
+		setRightSidebarTab,
+	};
 }

--- a/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
+++ b/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
@@ -13,6 +13,7 @@ export interface V2UserPreferencesApi {
 	preferences: V2UserPreferencesRow;
 	setFileLinks: (next: LinkTierMap) => void;
 	setUrlLinks: (next: LinkTierMap) => void;
+	setRightSidebarOpen: (next: boolean | ((prev: boolean) => boolean)) => void;
 }
 
 export function useV2UserPreferences(): V2UserPreferencesApi {
@@ -57,5 +58,26 @@ export function useV2UserPreferences(): V2UserPreferencesApi {
 		[upsertTierMap],
 	);
 
-	return { preferences, setFileLinks, setUrlLinks };
+	const setRightSidebarOpen = useCallback(
+		(next: boolean | ((prev: boolean) => boolean)) => {
+			const existing = collections.v2UserPreferences.get(
+				V2_USER_PREFERENCES_ID,
+			);
+			const prev = existing?.rightSidebarOpen ?? false;
+			const value = typeof next === "function" ? next(prev) : next;
+			if (!existing) {
+				collections.v2UserPreferences.insert({
+					...DEFAULT_V2_USER_PREFERENCES,
+					rightSidebarOpen: value,
+				});
+				return;
+			}
+			collections.v2UserPreferences.update(V2_USER_PREFERENCES_ID, (draft) => {
+				draft.rightSidebarOpen = value;
+			});
+		},
+		[collections],
+	);
+
+	return { preferences, setFileLinks, setUrlLinks, setRightSidebarOpen };
 }

--- a/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
+++ b/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
@@ -66,7 +66,9 @@ export function useV2UserPreferences(): V2UserPreferencesApi {
 			const existing = collections.v2UserPreferences.get(
 				V2_USER_PREFERENCES_ID,
 			);
-			const prev = existing?.rightSidebarOpen ?? false;
+			const prev =
+				existing?.rightSidebarOpen ??
+				DEFAULT_V2_USER_PREFERENCES.rightSidebarOpen;
 			const value = typeof next === "function" ? next(prev) : next;
 			if (!existing) {
 				collections.v2UserPreferences.insert({

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/TopBar.tsx
@@ -88,9 +88,7 @@ export function TopBar() {
 					/>
 				) : null}
 				{!isV2CloudEnabled && <OrganizationDropdown />}
-				{isV2WorkspaceRoute && (
-					<RightSidebarToggle workspaceId={v2WorkspaceId} />
-				)}
+				{isV2WorkspaceRoute && <RightSidebarToggle />}
 				{!isMac && <WindowControls />}
 			</div>
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/RightSidebarToggle/RightSidebarToggle.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/RightSidebarToggle/RightSidebarToggle.tsx
@@ -1,32 +1,17 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
-import { eq } from "@tanstack/db";
-import { useLiveQuery } from "@tanstack/react-db";
 import {
 	LuPanelRight,
 	LuPanelRightClose,
 	LuPanelRightOpen,
 } from "react-icons/lu";
+import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences";
 import { HotkeyLabel } from "renderer/hotkeys";
-import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 
-export function RightSidebarToggle({ workspaceId }: { workspaceId: string }) {
-	const collections = useCollections();
-	const { data: localStateRows = [] } = useLiveQuery(
-		(query) =>
-			query
-				.from({ v2WorkspaceLocalState: collections.v2WorkspaceLocalState })
-				.where(({ v2WorkspaceLocalState }) =>
-					eq(v2WorkspaceLocalState.workspaceId, workspaceId),
-				),
-		[collections, workspaceId],
-	);
-	const isOpen = localStateRows[0]?.rightSidebarOpen ?? false;
+export function RightSidebarToggle() {
+	const { preferences, setRightSidebarOpen } = useV2UserPreferences();
+	const isOpen = preferences.rightSidebarOpen;
 
-	const toggle = () => {
-		collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
-			draft.rightSidebarOpen = !draft.rightSidebarOpen;
-		});
-	};
+	const toggle = () => setRightSidebarOpen((prev) => !prev);
 
 	const getToggleIcon = (isHovering: boolean) => {
 		if (!isOpen) {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -6,6 +6,7 @@ import { Search } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { LuFile, LuGitCompareArrows } from "react-icons/lu";
 import { useGitStatus } from "renderer/hooks/host-service/useGitStatus";
+import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { sidebarHeaderTabTriggerClassName } from "renderer/screens/main/components/WorkspaceView/RightSidebar/headerTabStyles";
 import type { CommentPaneData } from "../../types";
@@ -68,16 +69,14 @@ export function WorkspaceSidebar({
 	workspaceName,
 }: WorkspaceSidebarProps) {
 	const collections = useCollections();
+	const { preferences, setRightSidebarTab } = useV2UserPreferences();
+	const activeTab = preferences.rightSidebarTab;
 	const localState = collections.v2WorkspaceLocalState.get(workspaceId);
-	const activeTab = localState?.sidebarState?.activeTab ?? "changes";
 	const changesSubtab = localState?.sidebarState?.changesSubtab ?? "diffs";
 
 	function setActiveTab(tab: string) {
 		if (tab !== "changes" && tab !== "files") return;
-		if (!collections.v2WorkspaceLocalState.get(workspaceId)) return;
-		collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
-			draft.sidebarState.activeTab = tab;
-		});
+		setRightSidebarTab(tab);
 	}
 
 	function setChangesSubtab(subtab: "diffs" | "review") {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/useV2WorkspacePaneLayout.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/useV2WorkspacePaneLayout.ts
@@ -97,8 +97,5 @@ export function useV2WorkspacePaneLayout({
 		};
 	}, [collections, ensureWorkspaceInSidebar, projectId, store, workspaceId]);
 
-	return {
-		localWorkspaceState,
-		store,
-	};
+	return { store };
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
@@ -7,7 +7,6 @@ import {
 import { useCallback, useRef } from "react";
 import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences";
 import { useHotkey } from "renderer/hotkeys";
-import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
 import type { StoreApi } from "zustand";
 import type {
@@ -20,19 +19,16 @@ import type {
 
 export function useWorkspaceHotkeys({
 	store,
-	workspaceId,
 	matchedPresets,
 	executePreset,
 	paneRegistry,
 }: {
 	store: StoreApi<WorkspaceStore<PaneViewerData>>;
-	workspaceId: string;
 	matchedPresets: V2TerminalPresetRow[];
 	executePreset: (preset: V2TerminalPresetRow) => void;
 	paneRegistry: PaneRegistry<PaneViewerData>;
 }) {
-	const collections = useCollections();
-	const { setRightSidebarOpen } = useV2UserPreferences();
+	const { setRightSidebarOpen, setRightSidebarTab } = useV2UserPreferences();
 
 	useHotkey("TOGGLE_SIDEBAR", () => {
 		setRightSidebarOpen((prev) => !prev);
@@ -72,11 +68,7 @@ export function useWorkspaceHotkeys({
 
 	useHotkey("OPEN_DIFF_VIEWER", () => {
 		setRightSidebarOpen(true);
-		if (collections.v2WorkspaceLocalState.get(workspaceId)) {
-			collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
-				draft.sidebarState.activeTab = "changes";
-			});
-		}
+		setRightSidebarTab("changes");
 
 		const state = store.getState();
 		for (const tab of state.tabs) {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
@@ -5,6 +5,7 @@ import {
 	type WorkspaceStore,
 } from "@superset/panes";
 import { useCallback, useRef } from "react";
+import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences";
 import { useHotkey } from "renderer/hotkeys";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
@@ -31,12 +32,10 @@ export function useWorkspaceHotkeys({
 	paneRegistry: PaneRegistry<PaneViewerData>;
 }) {
 	const collections = useCollections();
+	const { setRightSidebarOpen } = useV2UserPreferences();
 
 	useHotkey("TOGGLE_SIDEBAR", () => {
-		if (!collections.v2WorkspaceLocalState.get(workspaceId)) return;
-		collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
-			draft.rightSidebarOpen = !draft.rightSidebarOpen;
-		});
+		setRightSidebarOpen((prev) => !prev);
 	});
 
 	// --- Tab creation ---
@@ -72,9 +71,9 @@ export function useWorkspaceHotkeys({
 	});
 
 	useHotkey("OPEN_DIFF_VIEWER", () => {
+		setRightSidebarOpen(true);
 		if (collections.v2WorkspaceLocalState.get(workspaceId)) {
 			collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
-				draft.rightSidebarOpen = true;
 				draft.sidebarState.activeTab = "changes";
 			});
 		}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -12,6 +12,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { HiMiniXMark } from "react-icons/hi2";
 import { TbLayoutColumns, TbLayoutRows } from "react-icons/tb";
+import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences";
 import { HotkeyLabel, useHotkey } from "renderer/hotkeys";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { CommandPalette } from "renderer/screens/main/components/CommandPalette";
@@ -111,7 +112,9 @@ function WorkspaceContent({
 	chatSessionId?: string;
 }) {
 	const collections = useCollections();
-	const { localWorkspaceState, store } = useV2WorkspacePaneLayout({
+	const { preferences: v2UserPreferences, setRightSidebarOpen } =
+		useV2UserPreferences();
+	const { store } = useV2WorkspacePaneLayout({
 		projectId,
 		workspaceId,
 	});
@@ -217,14 +220,14 @@ function WorkspaceContent({
 
 	const revealPath = useCallback(
 		(path: string, options?: { isDirectory?: boolean }) => {
+			setRightSidebarOpen(true);
 			collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
-				draft.rightSidebarOpen = true;
 				draft.sidebarState.activeTab = "files";
 			});
 			setSelectedFilePath(path);
 			setPendingReveal({ path, isDirectory: options?.isDirectory === true });
 		},
-		[collections, workspaceId],
+		[collections, workspaceId, setRightSidebarOpen],
 	);
 
 	const paneRegistry = usePaneRegistry(workspaceId, {
@@ -366,7 +369,7 @@ function WorkspaceContent({
 		[],
 	);
 
-	const sidebarOpen = localWorkspaceState?.rightSidebarOpen ?? false;
+	const sidebarOpen = v2UserPreferences.rightSidebarOpen;
 
 	useWorkspaceHotkeys({
 		store,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -111,9 +111,11 @@ function WorkspaceContent({
 	terminalId?: string;
 	chatSessionId?: string;
 }) {
-	const collections = useCollections();
-	const { preferences: v2UserPreferences, setRightSidebarOpen } =
-		useV2UserPreferences();
+	const {
+		preferences: v2UserPreferences,
+		setRightSidebarOpen,
+		setRightSidebarTab,
+	} = useV2UserPreferences();
 	const { store } = useV2WorkspacePaneLayout({
 		projectId,
 		workspaceId,
@@ -221,13 +223,11 @@ function WorkspaceContent({
 	const revealPath = useCallback(
 		(path: string, options?: { isDirectory?: boolean }) => {
 			setRightSidebarOpen(true);
-			collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
-				draft.sidebarState.activeTab = "files";
-			});
+			setRightSidebarTab("files");
 			setSelectedFilePath(path);
 			setPendingReveal({ path, isDirectory: options?.isDirectory === true });
 		},
-		[collections, workspaceId, setRightSidebarOpen],
+		[setRightSidebarOpen, setRightSidebarTab],
 	);
 
 	const paneRegistry = usePaneRegistry(workspaceId, {
@@ -373,7 +373,6 @@ function WorkspaceContent({
 
 	useWorkspaceHotkeys({
 		store,
-		workspaceId,
 		matchedPresets,
 		executePreset,
 		paneRegistry,

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -40,7 +40,6 @@ export const workspaceLocalStateSchema = z.object({
 		changesSubtab: z.enum(["diffs", "review"]).default("diffs"),
 	}),
 	paneLayout: paneWorkspaceStateSchema,
-	rightSidebarOpen: z.boolean().default(false),
 	viewedFiles: z.array(z.string()).default([]),
 	recentlyViewedFiles: z
 		.array(
@@ -238,6 +237,7 @@ export const v2UserPreferencesSchema = z.object({
 	id: z.literal("preferences"),
 	fileLinks: linkTierMapSchema.default(DEFAULT_LINK_TIER_MAP),
 	urlLinks: linkTierMapSchema.default(DEFAULT_LINK_TIER_MAP),
+	rightSidebarOpen: z.boolean().default(false),
 });
 
 export type V2UserPreferencesRow = z.infer<typeof v2UserPreferencesSchema>;
@@ -248,4 +248,5 @@ export const DEFAULT_V2_USER_PREFERENCES: V2UserPreferencesRow = {
 	id: V2_USER_PREFERENCES_ID,
 	fileLinks: DEFAULT_LINK_TIER_MAP,
 	urlLinks: DEFAULT_LINK_TIER_MAP,
+	rightSidebarOpen: false,
 };

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -36,7 +36,6 @@ export const workspaceLocalStateSchema = z.object({
 		tabOrder: z.number().int().default(0),
 		sectionId: z.string().uuid().nullable().default(null),
 		changesFilter: changesFilterSchema.default({ kind: "all" }),
-		activeTab: z.enum(["changes", "files"]).default("changes"),
 		changesSubtab: z.enum(["diffs", "review"]).default("diffs"),
 	}),
 	paneLayout: paneWorkspaceStateSchema,
@@ -238,6 +237,7 @@ export const v2UserPreferencesSchema = z.object({
 	fileLinks: linkTierMapSchema.default(DEFAULT_LINK_TIER_MAP),
 	urlLinks: linkTierMapSchema.default(DEFAULT_LINK_TIER_MAP),
 	rightSidebarOpen: z.boolean().default(false),
+	rightSidebarTab: z.enum(["changes", "files"]).default("changes"),
 });
 
 export type V2UserPreferencesRow = z.infer<typeof v2UserPreferencesSchema>;
@@ -249,4 +249,5 @@ export const DEFAULT_V2_USER_PREFERENCES: V2UserPreferencesRow = {
 	fileLinks: DEFAULT_LINK_TIER_MAP,
 	urlLinks: DEFAULT_LINK_TIER_MAP,
 	rightSidebarOpen: false,
+	rightSidebarTab: "changes",
 };

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -236,7 +236,7 @@ export const v2UserPreferencesSchema = z.object({
 	id: z.literal("preferences"),
 	fileLinks: linkTierMapSchema.default(DEFAULT_LINK_TIER_MAP),
 	urlLinks: linkTierMapSchema.default(DEFAULT_LINK_TIER_MAP),
-	rightSidebarOpen: z.boolean().default(false),
+	rightSidebarOpen: z.boolean().default(true),
 	rightSidebarTab: z.enum(["changes", "files"]).default("changes"),
 });
 
@@ -248,6 +248,6 @@ export const DEFAULT_V2_USER_PREFERENCES: V2UserPreferencesRow = {
 	id: V2_USER_PREFERENCES_ID,
 	fileLinks: DEFAULT_LINK_TIER_MAP,
 	urlLinks: DEFAULT_LINK_TIER_MAP,
-	rightSidebarOpen: false,
+	rightSidebarOpen: true,
 	rightSidebarTab: "changes",
 };


### PR DESCRIPTION
## Summary
- Move `rightSidebarOpen` out of per-workspace `v2WorkspaceLocalState` into the global `v2UserPreferences` singleton so the v2 right sidebar open/closed state persists across reloads and stays consistent across all projects and workspaces.
- Expose `setRightSidebarOpen` (supports `boolean` or updater fn) on `useV2UserPreferences` and route the toggle button, `TOGGLE_SIDEBAR` / `OPEN_DIFF_VIEWER` hotkeys, and `revealPath` through it.
- `RightSidebarToggle` no longer needs a `workspaceId` prop; `TopBar` drops it.

## Test plan
- [ ] Open v2 workspace, toggle the right sidebar open, switch to a workspace in a different project — sidebar stays open.
- [ ] Reload the app — sidebar remembers its last open/closed state.
- [ ] `TOGGLE_SIDEBAR` hotkey still toggles; `OPEN_DIFF_VIEWER` still opens the sidebar on the Changes tab; ⌘-click reveal still opens the sidebar on the Files tab.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the v2 right sidebar open state and active tab globally across all workspaces/projects, and default the sidebar to open on first load. Moved both into `v2UserPreferences` and routed toggles, hotkeys, and reveal actions through the new global setters.

- **Bug Fixes**
  - Store `rightSidebarOpen` and `rightSidebarTab` in `v2UserPreferences` (sidebar defaults to open).
  - Added `setRightSidebarOpen` and `setRightSidebarTab` to `useV2UserPreferences`.
  - Routed the toggle button, `TOGGLE_SIDEBAR`, `OPEN_DIFF_VIEWER` (tab "changes"), and `revealPath` (tab "files") through the global setters.
  - Dropped `workspaceId` prop from `RightSidebarToggle`; updated `TopBar` and schemas to remove per-workspace fields.

- **Refactors**
  - Removed unused `localWorkspaceState` return from `useV2WorkspacePaneLayout`.

<sup>Written for commit c0102c7b67f6f2e51f75d37f0f86872e8d8a05ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Right sidebar visibility and active tab are now stored as global user preferences (defaults: open, "changes").
  * Hotkeys now control the global sidebar and can open the sidebar on the "changes" or "files" tab.

* **Bug Fixes**
  * Sidebar open state and selected tab persist across workspace switches for a consistent experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->