### PR TITLE
feat(terminal): port vscode resize debouncer for v2 terminal

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/resize-debouncer.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/resize-debouncer.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+	DebounceMs,
+	type ResizeDebouncerCallbacks,
+	StartDebouncingThreshold,
+	TerminalResizeDebouncer,
+} from "./resize-debouncer";
+
+// Upstream VSCode (terminalResizeDebouncer.ts) ships without dedicated unit
+// tests. These tests pin the documented behavior so a future vendor refresh
+// surfaces any semantic drift.
+
+interface Harness {
+	debouncer: TerminalResizeDebouncer;
+	cb: {
+		isVisible: ReturnType<typeof mock>;
+		getBufferLength: ReturnType<typeof mock>;
+		resizeBoth: ReturnType<typeof mock>;
+		resizeX: ReturnType<typeof mock>;
+		resizeY: ReturnType<typeof mock>;
+	};
+}
+
+function createHarness(opts: {
+	visible?: boolean;
+	bufferLength?: number;
+	debounceMs?: number;
+}): Harness {
+	const cb = {
+		isVisible: mock(() => opts.visible ?? true),
+		getBufferLength: mock(() => opts.bufferLength ?? 1000),
+		resizeBoth: mock(),
+		resizeX: mock(),
+		resizeY: mock(),
+	};
+	const debouncer = new TerminalResizeDebouncer(
+		cb as unknown as ResizeDebouncerCallbacks,
+		{ debounceMs: opts.debounceMs ?? 5 },
+	);
+	return { debouncer, cb };
+}
+
+function wait(ms: number) {
+	return new Promise((r) => setTimeout(r, ms));
+}
+
+describe("TerminalResizeDebouncer — immediate path", () => {
+	test("resizes immediately when `immediate: true` regardless of buffer size", () => {
+		const { debouncer, cb } = createHarness({ bufferLength: 100_000 });
+		debouncer.resize(80, 24, true);
+		expect(cb.resizeBoth).toHaveBeenCalledTimes(1);
+		expect(cb.resizeBoth).toHaveBeenCalledWith(80, 24);
+		expect(cb.resizeX).not.toHaveBeenCalled();
+		expect(cb.resizeY).not.toHaveBeenCalled();
+	});
+
+	test("resizes immediately when buffer is below StartDebouncingThreshold", () => {
+		const { debouncer, cb } = createHarness({
+			bufferLength: StartDebouncingThreshold - 1,
+		});
+		debouncer.resize(80, 24, false);
+		expect(cb.resizeBoth).toHaveBeenCalledWith(80, 24);
+	});
+
+	test("does not take immediate path at exactly StartDebouncingThreshold (strictly-less-than)", () => {
+		// Upstream uses `< StartDebouncingThreshold`, not `<=`.
+		const { debouncer, cb } = createHarness({
+			bufferLength: StartDebouncingThreshold,
+		});
+		debouncer.resize(80, 24, false);
+		expect(cb.resizeBoth).not.toHaveBeenCalled();
+		expect(cb.resizeY).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("TerminalResizeDebouncer — visible large-buffer path", () => {
+	test("applies Y immediately and debounces X", async () => {
+		const { debouncer, cb } = createHarness({
+			visible: true,
+			bufferLength: 10_000,
+			debounceMs: 5,
+		});
+		debouncer.resize(80, 24, false);
+		expect(cb.resizeY).toHaveBeenCalledWith(24);
+		expect(cb.resizeX).not.toHaveBeenCalled();
+		expect(cb.resizeBoth).not.toHaveBeenCalled();
+		await wait(20);
+		expect(cb.resizeX).toHaveBeenCalledWith(80);
+	});
+
+	test("coalesces rapid X resizes to the last value", async () => {
+		const { debouncer, cb } = createHarness({
+			visible: true,
+			bufferLength: 10_000,
+			debounceMs: 10,
+		});
+		debouncer.resize(80, 24, false);
+		debouncer.resize(90, 25, false);
+		debouncer.resize(100, 26, false);
+		// Each Y fires immediately — that's intentional (cheap).
+		expect(cb.resizeY.mock.calls.map((c) => c[0])).toEqual([24, 25, 26]);
+		expect(cb.resizeX).not.toHaveBeenCalled();
+		await wait(25);
+		// Only the last X fires.
+		expect(cb.resizeX).toHaveBeenCalledTimes(1);
+		expect(cb.resizeX).toHaveBeenCalledWith(100);
+	});
+});
+
+describe("TerminalResizeDebouncer — hidden path", () => {
+	test("schedules X and Y via idle callback when not visible", async () => {
+		const { debouncer, cb } = createHarness({
+			visible: false,
+			bufferLength: 10_000,
+		});
+		debouncer.resize(80, 24, false);
+		// Neither should fire synchronously.
+		expect(cb.resizeBoth).not.toHaveBeenCalled();
+		expect(cb.resizeX).not.toHaveBeenCalled();
+		expect(cb.resizeY).not.toHaveBeenCalled();
+		// After idle (setTimeout(0) fallback in node/bun), both fire.
+		await wait(20);
+		expect(cb.resizeX).toHaveBeenCalledWith(80);
+		expect(cb.resizeY).toHaveBeenCalledWith(24);
+	});
+
+	test("coalesces multiple hidden resizes to latest values", async () => {
+		const { debouncer, cb } = createHarness({
+			visible: false,
+			bufferLength: 10_000,
+		});
+		debouncer.resize(80, 24, false);
+		debouncer.resize(90, 25, false);
+		debouncer.resize(100, 26, false);
+		await wait(20);
+		// Upstream uses a MutableDisposable that refuses to re-schedule while
+		// pending — so only the latest X/Y fire, once each.
+		expect(cb.resizeX).toHaveBeenCalledTimes(1);
+		expect(cb.resizeX).toHaveBeenCalledWith(100);
+		expect(cb.resizeY).toHaveBeenCalledTimes(1);
+		expect(cb.resizeY).toHaveBeenCalledWith(26);
+	});
+});
+
+describe("TerminalResizeDebouncer — flush", () => {
+	test("flush applies latest X and Y via resizeBoth when work is pending", async () => {
+		const { debouncer, cb } = createHarness({
+			visible: true,
+			bufferLength: 10_000,
+			debounceMs: 1000,
+		});
+		debouncer.resize(80, 24, false);
+		debouncer.resize(100, 40, false);
+		expect(cb.resizeX).not.toHaveBeenCalled();
+		debouncer.flush();
+		expect(cb.resizeBoth).toHaveBeenCalledTimes(1);
+		expect(cb.resizeBoth).toHaveBeenCalledWith(100, 40);
+		// Pending X should no longer fire after flush.
+		await wait(20);
+		expect(cb.resizeX).not.toHaveBeenCalled();
+	});
+
+	test("flush is a no-op when nothing is pending", () => {
+		const { debouncer, cb } = createHarness({
+			visible: true,
+			bufferLength: 10_000,
+		});
+		debouncer.flush();
+		expect(cb.resizeBoth).not.toHaveBeenCalled();
+		expect(cb.resizeX).not.toHaveBeenCalled();
+		expect(cb.resizeY).not.toHaveBeenCalled();
+	});
+});
+
+describe("TerminalResizeDebouncer — dispose", () => {
+	test("dispose cancels pending X debounce without firing", async () => {
+		const { debouncer, cb } = createHarness({
+			visible: true,
+			bufferLength: 10_000,
+			debounceMs: 10,
+		});
+		debouncer.resize(80, 24, false);
+		debouncer.dispose();
+		await wait(25);
+		expect(cb.resizeX).not.toHaveBeenCalled();
+	});
+
+	test("dispose cancels pending idle jobs without firing", async () => {
+		const { debouncer, cb } = createHarness({
+			visible: false,
+			bufferLength: 10_000,
+		});
+		debouncer.resize(80, 24, false);
+		debouncer.dispose();
+		await wait(20);
+		expect(cb.resizeX).not.toHaveBeenCalled();
+		expect(cb.resizeY).not.toHaveBeenCalled();
+	});
+});
+
+describe("Constants", () => {
+	test("match upstream VSCode values", () => {
+		expect(StartDebouncingThreshold).toBe(200);
+		expect(DebounceMs).toBe(100);
+	});
+});

--- a/apps/desktop/src/renderer/lib/terminal/resize-debouncer.ts
+++ b/apps/desktop/src/renderer/lib/terminal/resize-debouncer.ts
@@ -1,0 +1,263 @@
+/*---------------------------------------------------------------------------------------------
+ *  Adapted from VSCode:
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See https://github.com/microsoft/vscode/blob/main/LICENSE.txt
+ *--------------------------------------------------------------------------------------------*/
+
+// Ported from VSCode:
+//   src/vs/workbench/contrib/terminal/browser/terminalResizeDebouncer.ts
+//
+// Upstream depends on VSCode's Disposable / MutableDisposable lifecycle,
+// getWindow + runWhenWindowIdle DOM utilities, and a `@debounce(100)` TS
+// decorator. This port preserves the three-tier algorithm and upstream
+// rationale comments, but uses native browser primitives so it stays
+// self-contained. Upstream source is preserved in the JSDoc on each method
+// for diffability against future VSCode revisions.
+
+/**
+ * The _normal_ buffer length threshold at which point resizing starts being debounced.
+ *
+ * Upstream (VSCode terminalResizeDebouncer.ts):
+ *
+ *   const enum Constants {
+ *       StartDebouncingThreshold = 200,
+ *   }
+ */
+export const StartDebouncingThreshold = 200;
+
+/**
+ * Debounce interval for horizontal (reflow-heavy) resizes. Matches upstream's
+ * `@debounce(100)` decorator on `_debounceResizeX`.
+ */
+export const DebounceMs = 100;
+
+export interface ResizeDebouncerCallbacks {
+	/** Whether the host container is currently visible on screen. */
+	isVisible: () => boolean;
+	/**
+	 * Length of xterm's _normal_ buffer (not the alternate-screen buffer).
+	 * Read as `xterm.buffer.normal.length`.
+	 */
+	getBufferLength: () => number;
+	/** Apply both dimensions now. */
+	resizeBoth: (cols: number, rows: number) => void;
+	/** Apply only the horizontal dimension (reflow). */
+	resizeX: (cols: number) => void;
+	/** Apply only the vertical dimension (cheap). */
+	resizeY: (rows: number) => void;
+}
+
+export interface ResizeDebouncerOptions {
+	/** Override the debounce interval (default: {@link DebounceMs}). */
+	debounceMs?: number;
+	/** Override the small-buffer threshold (default: {@link StartDebouncingThreshold}). */
+	bufferThreshold?: number;
+}
+
+/**
+ * Debounces horizontal terminal resizes (expensive reflow) while applying
+ * vertical resizes immediately (cheap). Short-circuits on small buffers or
+ * when the terminal is hidden.
+ *
+ * Upstream (VSCode terminalResizeDebouncer.ts):
+ *
+ *   export class TerminalResizeDebouncer extends Disposable {
+ *       private _latestX: number = 0;
+ *       private _latestY: number = 0;
+ *       private readonly _resizeXJob = this._register(new MutableDisposable());
+ *       private readonly _resizeYJob = this._register(new MutableDisposable());
+ *       // ...
+ *   }
+ */
+export class TerminalResizeDebouncer {
+	private _latestX = 0;
+	private _latestY = 0;
+	private _debounceTimer: ReturnType<typeof setTimeout> | null = null;
+	private _idleXHandle: IdleHandle | null = null;
+	private _idleYHandle: IdleHandle | null = null;
+
+	private readonly _debounceMs: number;
+	private readonly _bufferThreshold: number;
+
+	constructor(
+		private readonly _cb: ResizeDebouncerCallbacks,
+		options: ResizeDebouncerOptions = {},
+	) {
+		this._debounceMs = options.debounceMs ?? DebounceMs;
+		this._bufferThreshold = options.bufferThreshold ?? StartDebouncingThreshold;
+	}
+
+	/**
+	 * Upstream (VSCode terminalResizeDebouncer.ts):
+	 *
+	 *   async resize(cols: number, rows: number, immediate: boolean): Promise<void> {
+	 *       this._latestX = cols;
+	 *       this._latestY = rows;
+	 *
+	 *       // Resize immediately if requested explicitly or if the buffer is small
+	 *       if (immediate || this._getXterm()!.raw.buffer.normal.length < Constants.StartDebouncingThreshold) {
+	 *           this._resizeXJob.clear();
+	 *           this._resizeYJob.clear();
+	 *           this._resizeBothCallback(cols, rows);
+	 *           return;
+	 *       }
+	 *
+	 *       // Resize in an idle callback if the terminal is not visible
+	 *       const win = getWindow(this._getXterm()!.raw.element);
+	 *       if (win && !this._isVisible()) {
+	 *           if (!this._resizeXJob.value) {
+	 *               this._resizeXJob.value = runWhenWindowIdle(win, async () => {
+	 *                   this._resizeXCallback(this._latestX);
+	 *                   this._resizeXJob.clear();
+	 *               });
+	 *           }
+	 *           if (!this._resizeYJob.value) {
+	 *               this._resizeYJob.value = runWhenWindowIdle(win, async () => {
+	 *                   this._resizeYCallback(this._latestY);
+	 *                   this._resizeYJob.clear();
+	 *               });
+	 *           }
+	 *           return;
+	 *       }
+	 *
+	 *       // Update dimensions independently as vertical resize is cheap and horizontal resize is
+	 *       // expensive due to reflow.
+	 *       this._resizeYCallback(rows);
+	 *       this._latestX = cols;
+	 *       this._debounceResizeX(cols);
+	 *   }
+	 */
+	resize(cols: number, rows: number, immediate: boolean): void {
+		this._latestX = cols;
+		this._latestY = rows;
+
+		// Resize immediately if requested explicitly or if the buffer is small
+		if (immediate || this._cb.getBufferLength() < this._bufferThreshold) {
+			this._clearX();
+			this._clearY();
+			this._cb.resizeBoth(cols, rows);
+			return;
+		}
+
+		// Resize in an idle callback if the terminal is not visible
+		if (!this._cb.isVisible()) {
+			if (this._idleXHandle === null) {
+				this._idleXHandle = scheduleIdle(() => {
+					this._idleXHandle = null;
+					this._cb.resizeX(this._latestX);
+				});
+			}
+			if (this._idleYHandle === null) {
+				this._idleYHandle = scheduleIdle(() => {
+					this._idleYHandle = null;
+					this._cb.resizeY(this._latestY);
+				});
+			}
+			return;
+		}
+
+		// Update dimensions independently as vertical resize is cheap and horizontal resize is
+		// expensive due to reflow.
+		this._cb.resizeY(rows);
+		this._debounceResizeX(cols);
+	}
+
+	/**
+	 * Upstream (VSCode terminalResizeDebouncer.ts):
+	 *
+	 *   flush(): void {
+	 *       if (this._resizeXJob.value || this._resizeYJob.value) {
+	 *           this._resizeXJob.clear();
+	 *           this._resizeYJob.clear();
+	 *           this._resizeBothCallback(this._latestX, this._latestY);
+	 *       }
+	 *   }
+	 */
+	flush(): void {
+		if (
+			this._debounceTimer !== null ||
+			this._idleXHandle !== null ||
+			this._idleYHandle !== null
+		) {
+			this._clearX();
+			this._clearY();
+			this._cb.resizeBoth(this._latestX, this._latestY);
+		}
+	}
+
+	/** Cancel any pending work without firing callbacks. Upstream: via `Disposable.dispose()`. */
+	dispose(): void {
+		this._clearX();
+		this._clearY();
+	}
+
+	/**
+	 * Upstream (VSCode terminalResizeDebouncer.ts):
+	 *
+	 *   @debounce(100)
+	 *   private _debounceResizeX(cols: number) {
+	 *       this._resizeXCallback(cols);
+	 *   }
+	 */
+	private _debounceResizeX(cols: number): void {
+		if (this._debounceTimer !== null) clearTimeout(this._debounceTimer);
+		this._debounceTimer = setTimeout(() => {
+			this._debounceTimer = null;
+			this._cb.resizeX(cols);
+		}, this._debounceMs);
+	}
+
+	private _clearX(): void {
+		if (this._debounceTimer !== null) {
+			clearTimeout(this._debounceTimer);
+			this._debounceTimer = null;
+		}
+		if (this._idleXHandle !== null) {
+			cancelIdle(this._idleXHandle);
+			this._idleXHandle = null;
+		}
+	}
+
+	private _clearY(): void {
+		if (this._idleYHandle !== null) {
+			cancelIdle(this._idleYHandle);
+			this._idleYHandle = null;
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Idle-callback shim. Upstream uses VSCode's `runWhenWindowIdle`, which wraps
+// `requestIdleCallback` with a setTimeout fallback for browsers that lack it
+// (historically Safari). We mirror that here.
+// ---------------------------------------------------------------------------
+
+type IdleHandle =
+	| { kind: "idle"; handle: number }
+	| { kind: "timeout"; handle: ReturnType<typeof setTimeout> };
+
+function scheduleIdle(cb: () => void): IdleHandle {
+	if (
+		typeof globalThis !== "undefined" &&
+		typeof (globalThis as { requestIdleCallback?: unknown })
+			.requestIdleCallback === "function"
+	) {
+		return {
+			kind: "idle",
+			handle: (
+				globalThis as { requestIdleCallback: (cb: () => void) => number }
+			).requestIdleCallback(cb),
+		};
+	}
+	return { kind: "timeout", handle: setTimeout(cb, 0) };
+}
+
+function cancelIdle(handle: IdleHandle): void {
+	if (handle.kind === "idle") {
+		(
+			globalThis as { cancelIdleCallback?: (h: number) => void }
+		).cancelIdleCallback?.(handle.handle);
+		return;
+	}
+	clearTimeout(handle.handle);
+}

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -6,6 +6,7 @@ import { Terminal as XTerm } from "@xterm/xterm";
 import { resolveHotkeyFromEvent } from "renderer/hotkeys";
 import { DEFAULT_TERMINAL_SCROLLBACK } from "shared/constants";
 import type { TerminalAppearance } from "./appearance";
+import { TerminalResizeDebouncer } from "./resize-debouncer";
 import { loadAddons } from "./terminal-addons";
 
 const SERIALIZE_SCROLLBACK = 1000;
@@ -32,6 +33,8 @@ export interface TerminalRuntime {
 	wrapper: HTMLDivElement;
 	container: HTMLDivElement | null;
 	resizeObserver: ResizeObserver | null;
+	/** Debounces the expensive horizontal reflow during rapid container resizes. */
+	resizeDebouncer: TerminalResizeDebouncer;
 	lastCols: number;
 	lastRows: number;
 	_disposeAddons: (() => void) | null;
@@ -124,11 +127,21 @@ function hostIsVisible(container: HTMLDivElement | null): boolean {
 	return container.clientWidth > 0 && container.clientHeight > 0;
 }
 
-function measureAndResize(runtime: TerminalRuntime) {
+function measureAndResize(runtime: TerminalRuntime, immediate: boolean) {
 	if (!hostIsVisible(runtime.container)) return;
-	runtime.fitAddon.fit();
-	runtime.lastCols = runtime.terminal.cols;
-	runtime.lastRows = runtime.terminal.rows;
+	// Split what `fitAddon.fit()` would do into propose → apply so the debouncer
+	// can coalesce the apply step (expensive reflow on cols change).
+	const dims = runtime.fitAddon.proposeDimensions();
+	if (!dims) return;
+	// Skip no-change ticks — ResizeObserver fires on subpixel layout shifts
+	// that often don't change the cell grid.
+	if (
+		dims.cols === runtime.terminal.cols &&
+		dims.rows === runtime.terminal.rows
+	) {
+		return;
+	}
+	runtime.resizeDebouncer.resize(dims.cols, dims.rows, immediate);
 }
 
 export function createRuntime(
@@ -157,7 +170,7 @@ export function createRuntime(
 	const addonsResult = loadAddons(terminal);
 	restoreBuffer(terminalId, terminal);
 
-	return {
+	const runtime: TerminalRuntime = {
 		terminalId,
 		terminal,
 		fitAddon,
@@ -167,10 +180,33 @@ export function createRuntime(
 		wrapper,
 		container: null,
 		resizeObserver: null,
+		// Assigned immediately below — declared non-null here since the debouncer
+		// closes over `runtime` and would otherwise need a placeholder.
+		resizeDebouncer: null as unknown as TerminalResizeDebouncer,
 		lastCols: cols,
 		lastRows: rows,
 		_disposeAddons: addonsResult.dispose,
 	};
+
+	runtime.resizeDebouncer = new TerminalResizeDebouncer({
+		isVisible: () => hostIsVisible(runtime.container),
+		getBufferLength: () => terminal.buffer.normal.length,
+		resizeBoth: (c, r) => {
+			terminal.resize(c, r);
+			runtime.lastCols = c;
+			runtime.lastRows = r;
+		},
+		resizeX: (c) => {
+			terminal.resize(c, terminal.rows);
+			runtime.lastCols = c;
+		},
+		resizeY: (r) => {
+			terminal.resize(terminal.cols, r);
+			runtime.lastRows = r;
+		},
+	});
+
+	return runtime;
 }
 
 export function attachToContainer(
@@ -180,14 +216,17 @@ export function attachToContainer(
 ) {
 	runtime.container = container;
 	container.appendChild(runtime.wrapper);
-	measureAndResize(runtime);
+	// Initial attach: apply dimensions now so the first frame isn't stale.
+	measureAndResize(runtime, true);
 
 	// Renderer may have skipped frames while the wrapper was detached.
 	runtime.terminal.refresh(0, runtime.terminal.rows - 1);
 
 	runtime.resizeObserver?.disconnect();
 	const observer = new ResizeObserver(() => {
-		measureAndResize(runtime);
+		// Subsequent resizes go through the debouncer (splitter drags,
+		// window resizes, sidebar toggles fire this many times per frame).
+		measureAndResize(runtime, false);
 		onResize?.();
 	});
 	observer.observe(container);
@@ -197,6 +236,9 @@ export function attachToContainer(
 }
 
 export function detachFromContainer(runtime: TerminalRuntime) {
+	// Flush any pending debounced resize so `lastCols`/`lastRows` reflect the
+	// latest intended dimensions before we persist them.
+	runtime.resizeDebouncer.flush();
 	persistBuffer(runtime.terminalId, runtime.serializeAddon);
 	persistDimensions(runtime.terminalId, runtime.lastCols, runtime.lastRows);
 	runtime.resizeObserver?.disconnect();
@@ -209,7 +251,7 @@ export function updateRuntimeAppearance(
 	runtime: TerminalRuntime,
 	appearance: TerminalAppearance,
 ) {
-	const { terminal, fitAddon } = runtime;
+	const { terminal } = runtime;
 	terminal.options.theme = appearance.theme;
 
 	const fontChanged =
@@ -219,11 +261,8 @@ export function updateRuntimeAppearance(
 	if (fontChanged) {
 		terminal.options.fontFamily = appearance.fontFamily;
 		terminal.options.fontSize = appearance.fontSize;
-		if (hostIsVisible(runtime.container)) {
-			fitAddon.fit();
-			runtime.lastCols = terminal.cols;
-			runtime.lastRows = terminal.rows;
-		}
+		// Font change is an explicit user action → apply immediately.
+		measureAndResize(runtime, true);
 	}
 }
 
@@ -232,6 +271,7 @@ export function disposeRuntime(runtime: TerminalRuntime) {
 	runtime._disposeAddons = null;
 	runtime.resizeObserver?.disconnect();
 	runtime.resizeObserver = null;
+	runtime.resizeDebouncer.dispose();
 	runtime.wrapper.remove();
 	runtime.terminal.dispose();
 	clearPersistedBuffer(runtime.terminalId);


### PR DESCRIPTION
## Summary

- Ports VSCode's [`TerminalResizeDebouncer`](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/terminal/browser/terminalResizeDebouncer.ts) to avoid reflow churn when the terminal container resizes rapidly (splitter drags, window resize, sidebar toggle). The three-tier algorithm:
  - **Small buffer / explicit immediate** → apply both cols and rows now
  - **Hidden** → defer to `requestIdleCallback` (with `setTimeout(0)` fallback)
  - **Visible + large buffer** → apply rows immediately (cheap), debounce cols 100ms (expensive reflow)
- Why a *port* and not an exact vendor like #3648's flow-control units: upstream depends on five VSCode base modules (`Disposable` / `MutableDisposable` from `base/common/lifecycle`, `getWindow` + `runWhenWindowIdle` from `base/browser/dom`, `@debounce(100)` from `base/common/decorators`). Exact vendoring would pull in ~500 lines of VSCode infrastructure and require TS experimental decorators. The port uses native `setTimeout` + `requestIdleCallback` and keeps the original source as JSDoc on each method for diffability against future VSCode revisions.
- **Not wired up yet.** Current `terminal-runtime.ts:189` calls `fitAddon.fit()` synchronously on every `ResizeObserver` tick. Follow-up will split that into propose-dimensions + `TerminalResizeDebouncer.resize(cols, rows, immediate)`.

## Test plan

- [x] `bun test apps/desktop/src/renderer/lib/terminal/resize-debouncer.test.ts` — 12 pass (36 expects)
- [x] `bun run typecheck` — 25/25 workspaces pass
- [x] `biome check` clean
- [ ] Manual smoke during splitter drag, once wired up in follow-up

## Notes

- Tests pin VSCode semantics explicitly: strict-`<` on the 200-line threshold, X-coalescing to last value under debounce, hidden-path coalescing via single-slot idle handle, `flush()` applies latest X/Y via `resizeBoth`, `dispose()` cancels pending without firing.
- Upstream ships no unit tests for this file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports VSCode’s terminal resize debouncer and wires it into the v2 terminal to cut reflow churn during fast resizes. Rows apply immediately, columns debounce for 100ms, and hidden resizes schedule via idle.

- **New Features**
  - Integrated into `terminal-runtime`: split `fitAddon.fit()` into `proposeDimensions()` + debounced apply with an early-out when dims are unchanged.
  - Initial attach and font changes use the immediate path; `ResizeObserver` ticks use the debouncer.
  - Flush on detach to persist the latest cols/rows; dispose cancels pending work.
  - Self-contained utility using native timers and `requestIdleCallback`, with unit tests pinning upstream semantics.

<sup>Written for commit 17823ac269322945204920cc09def10ee88b7ca1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved terminal resize behavior: smarter debouncing that coalesces rapid resizes, applies immediate sizing when appropriate, avoids redundant work when hidden, and ensures initial and detach-time sizing are handled reliably.

* **Tests**
  * Added thorough tests covering immediate vs deferred resize paths, visibility-based scheduling, coalescing, flush behavior, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->