### PR TITLE
fix(desktop): unbreak safe-url test on bun by splitting pure helpers

### DIFF
--- a/apps/desktop/src/main/lib/safe-url/index.ts
+++ b/apps/desktop/src/main/lib/safe-url/index.ts
@@ -1,5 +1,2 @@
-export {
-	externalUrlLogLabel,
-	isSafeExternalUrl,
-	safeOpenExternal,
-} from "./safe-url";
+export { safeOpenExternal } from "./safe-url";
+export { externalUrlLogLabel, isSafeExternalUrl } from "./scheme";

--- a/apps/desktop/src/main/lib/safe-url/safe-url.test.ts
+++ b/apps/desktop/src/main/lib/safe-url/safe-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { externalUrlLogLabel, isSafeExternalUrl } from "./safe-url";
+import { externalUrlLogLabel, isSafeExternalUrl } from "./scheme";
 
 describe("isSafeExternalUrl", () => {
 	it("allows http, https, and mailto URLs", () => {

--- a/apps/desktop/src/main/lib/safe-url/safe-url.ts
+++ b/apps/desktop/src/main/lib/safe-url/safe-url.ts
@@ -1,29 +1,5 @@
 import { shell } from "electron";
-
-/**
- * Schemes safe to hand to Electron's `shell.openExternal`.
- * Anything else (file:, javascript:, custom handlers, etc.) can execute
- * binaries or scripts via the OS URL handler registry.
- */
-const ALLOWED_SCHEMES = new Set(["http:", "https:", "mailto:"]);
-
-export function isSafeExternalUrl(url: string): boolean {
-	if (typeof url !== "string" || url.length === 0) return false;
-	try {
-		return ALLOWED_SCHEMES.has(new URL(url).protocol);
-	} catch {
-		return false;
-	}
-}
-
-export function externalUrlLogLabel(url: string): string {
-	if (typeof url !== "string" || url.length === 0) return "empty";
-	try {
-		return new URL(url).protocol || "unknown:";
-	} catch {
-		return "malformed";
-	}
-}
+import { externalUrlLogLabel, isSafeExternalUrl } from "./scheme";
 
 /**
  * Wraps `shell.openExternal` with a scheme allowlist. Returns false and

--- a/apps/desktop/src/main/lib/safe-url/scheme.ts
+++ b/apps/desktop/src/main/lib/safe-url/scheme.ts
@@ -1,0 +1,24 @@
+/**
+ * Schemes safe to hand to Electron's `shell.openExternal`.
+ * Anything else (file:, javascript:, custom handlers, etc.) can execute
+ * binaries or scripts via the OS URL handler registry.
+ */
+const ALLOWED_SCHEMES = new Set(["http:", "https:", "mailto:"]);
+
+export function isSafeExternalUrl(url: string): boolean {
+	if (typeof url !== "string" || url.length === 0) return false;
+	try {
+		return ALLOWED_SCHEMES.has(new URL(url).protocol);
+	} catch {
+		return false;
+	}
+}
+
+export function externalUrlLogLabel(url: string): string {
+	if (typeof url !== "string" || url.length === 0) return "empty";
+	try {
+		return new URL(url).protocol || "unknown:";
+	} catch {
+		return "malformed";
+	}
+}


### PR DESCRIPTION
## Summary
- `apps/desktop/src/main/lib/safe-url/safe-url.ts` imports `shell` from `electron` at the module top level, so bun's test runner (CI) fails loading the module with `SyntaxError: Export named 'shell' not found in module '.../electron/index.js'`. This broke the desktop test job on main after #3650 merged (see run [24802754721](https://github.com/superset-sh/superset/actions/runs/24802754721)).
- Moved the pure URL helpers (`isSafeExternalUrl`, `externalUrlLogLabel`) into `scheme.ts`. They have no electron dependency and are what the test actually exercises.
- `safeOpenExternal` stays in `safe-url.ts` with the electron import; it imports the pure helpers from `scheme.ts`. The `safe-url/index.ts` barrel keeps the same three exports, so no callers need to change.
- Updated the test to import from `./scheme` so loading it doesn't pull electron.

## Test plan
- [x] `bun test src/main/lib/safe-url/` — 5 pass locally
- [x] `bun run typecheck` in apps/desktop
- [x] `bun run lint apps/desktop`
- [ ] CI green on this PR (it should also unstick any open branch that has been failing on this test since #3650 landed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Bun test failures in desktop by splitting pure URL helpers from Electron code in safe-url. Tests now import the pure module to avoid loading `electron`, while the public API stays the same.

- **Bug Fixes**
  - Moved `isSafeExternalUrl` and `externalUrlLogLabel` to `scheme.ts` (no `electron`).
  - Kept `safeOpenExternal` in `safe-url.ts` and reused the helpers.
  - Updated the barrel to export helpers from `scheme`; tests import `./scheme`.

<sup>Written for commit 43305336f93f2e4456c65a55eab8af15ddcec3db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal URL validation logic for improved code structure and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->