### PR TITLE
feat(desktop): port v1 projects + workspaces into v2

### DIFF
--- a/apps/desktop/plans/20260422-2100-v1-to-v2-port.md
+++ b/apps/desktop/plans/20260422-2100-v1-to-v2-port.md
@@ -1,0 +1,253 @@
+# v1 → v2 port: migrate users' local-db projects and workspaces into v2
+
+Status: planned (2026-04-22)
+Branch: `port`
+Followup tickets: [SUPER-469](https://linear.app/superset-sh/issue/SUPER-469), [SUPER-470](https://linear.app/superset-sh/issue/SUPER-470)
+
+## Goal
+
+Give v1 users a one-click path to bring their existing projects and workspaces into v2. The script creates or links `v2_projects` in their active organization, creates `v2_workspaces` under them, and registers host-service records so the new v2 rows work immediately. Idempotent: safe to re-run.
+
+## Scope
+
+**Ported:**
+
+| v1 source | v2 destination |
+|---|---|
+| `projects` row | `v2_projects` (cloud) + host-service `projects` (local SQLite) + `dashboardSidebarProjectSchema` collection (for `defaultOpenInApp`) |
+| `workspaces` row (both types) | `v2_workspaces` (cloud) + host-service `workspaces` (local SQLite) |
+| `worktrees` row | folded into host-service `workspaces.worktree_path`; no dedicated table in v2 |
+
+**Dropped (no v2 destination or no user value):**
+
+`color`, `tab_order`, `section_id`, `default_branch`, `workspace_base_branch`, `branch_prefix_mode`, `branch_prefix_custom`, `worktree_base_dir`, `neon_project_id`, `github_owner`, `icon_url`, `hide_image`, `config_toast_dismissed`, `is_unread`, `is_unnamed`, `deleting_at`, `port_base`, all timestamps, all `workspace_sections` rows. Rationale per field is in the sanity-check exploration (2026-04-22) — most are features v2 doesn't have yet; two (`workspace_base_branch`, `branch_prefix_*`) are tracked in SUPER-469/470.
+
+## Field mapping
+
+### v1 `projects` → v2
+
+| v1 field | v2 target | Derivation |
+|---|---|---|
+| `id` | new `v2_projects.id` (uuid) | server-generated; mapping recorded in `migration_state` |
+| `name` | `v2_projects.name` | direct |
+| `main_repo_path` | host-service `projects.repo_path` | direct |
+| parsed from `main_repo_path` | `v2_projects.repo_clone_url` | call v2's `parseGitHubRemote` on the repo's `origin` remote; NULL if no remote or un-parseable |
+| parsed from `main_repo_path` | host-service `projects.{repo_provider, repo_owner, repo_name, repo_url, remote_name}` | same parser |
+| slugify(`name`) | `v2_projects.slug` | slug with conflict retry (`foo`, `foo-2`, `foo-3`, …) |
+| `default_app` | v2 `dashboardSidebarProjectSchema.defaultOpenInApp` | write to PGlite collection keyed by new v2 project id |
+
+`v2_projects.organization_id` = user's active org (resolved in preflight).
+`v2_projects.github_repository_id` = set by `v2Project.create`'s existing logic that links against `github_repositories`.
+
+### v1 `workspaces` + `worktrees` → v2
+
+| v1 field | v2 target | Derivation |
+|---|---|---|
+| `workspaces.id` | new `v2_workspaces.id` | server-generated |
+| `workspaces.project_id` | `v2_workspaces.project_id` | via mapping table |
+| `workspaces.name` | `v2_workspaces.name` | direct |
+| `workspaces.branch` | `v2_workspaces.branch` + host-service `workspaces.branch` | direct |
+| `workspaces.worktree_id` → `worktrees.path` (type=worktree) or `projects.main_repo_path` (type=branch) | host-service `workspaces.worktree_path` | folded from the worktree row |
+| — | `v2_workspaces.host_id` | current machine's `v2_hosts` row |
+| — | `v2_workspaces.organization_id` | same active org |
+| — | `v2_workspaces.created_by_user_id` | ctx.userId |
+
+`worktrees.base_branch` is already preserved by v2 via `git config branch.<name>.base` — nothing to migrate.
+
+## UI
+
+**Trigger:** Settings → "Migrate v1 data to v2" button. No auto-prompt, no silent run.
+
+**Single modal, three states:**
+
+1. **Preview**
+   - "Found N projects, M workspaces in your local v1 data."
+   - Active org picker (shown only if user is in multiple orgs; defaults to current active org).
+   - Table of v1 projects, each row flagged as "Create new" or "Link to existing '{v2 project name}' in this org".
+   - For projects without a git remote: flagged as "Create new (local-only)" with a tooltip noting each machine creates its own.
+   - "Start migration" / "Cancel" buttons.
+
+2. **In progress**
+   - Progress bar + "Porting {projectName}…" label.
+   - Disable close while running.
+
+3. **Summary**
+   - "Created X projects, linked Y to existing, M workspaces migrated. K errors."
+   - Expandable error list: one row per failed v1 record with its error message.
+   - "Close" button. Re-running shows only un-migrated + errored rows.
+
+No wizard steps, no drag-and-drop, no per-row edit UI. If users want to rename a project, they do it in v2 after migration.
+
+## Duplicate project prevention
+
+v2's schema has two uniques per org:
+- `(organization_id, slug)`
+- `(organization_id, lower(repo_clone_url))` — NULLs don't collide
+
+The migration relies on both, plus explicit dedup logic:
+
+### Happy-path flow per project
+
+```
+parsed_url = parseGitHubRemote(origin_url_from_main_repo_path)
+
+if parsed_url:
+    existing = v2Project.findByGitHubRemote({ organizationId, cloneUrl: parsed_url })
+    if existing:
+        link: record (v1_id -> existing.id) in migration_state
+        if existing.repoCloneUrl is null:
+            v2Project.linkRepoCloneUrl({ id: existing.id, cloneUrl: parsed_url })
+        continue
+    else:
+        try v2Project.create({ orgId, name, slug, repoCloneUrl: parsed_url })
+            on success: record mapping, continue
+            on UNIQUE_VIOLATION(repo_clone_url):
+                # race: someone else in the org just created it
+                existing = v2Project.findByGitHubRemote(...)  # should now hit
+                link to existing
+            on UNIQUE_VIOLATION(slug):
+                retry with slug-2, slug-3, ... (bounded: 10 attempts)
+else:
+    # local-only repo, no dedup signal
+    v2Project.create({ orgId, name, slug, repoCloneUrl: null })
+        on UNIQUE_VIOLATION(slug): retry with slug-N
+```
+
+### Trickinesses this handles
+
+1. **URL canonicalization** — reuse v2's `parseGitHubRemote` (lives in the v2 project router package). Do not re-implement in the migration package. Both paths must produce `https://github.com/acme/foo` from every input variant (`git@github.com:Acme/foo.git`, `ssh://git@github.com/acme/foo/`, trailing slashes, uppercase).
+
+2. **Create-after-lookup race** — if two users in the same org run migration simultaneously, `findByGitHubRemote` can say null for both, then one `create` wins and the other hits the unique index. The loser catches, re-looks-up, links.
+
+3. **Forks** — user A with `origin=github.com/acme/foo` and user B with `origin=github.com/userb/foo` (their fork) create *two* v2 projects. This is correct: different remotes = different projects. Not a bug to solve.
+
+4. **Local-only dupes across machines** — no remote means no dedup; accepted. Documented in the preview modal ("local-only, will create fresh").
+
+5. **Slug uglification** — slug conflicts across repos in the same org produce `api-2`, `api-3`. Acceptable; user can rename post-port.
+
+6. **Unparseable remotes** — GitLab, Bitbucket, internal Git hosts: `parseGitHubRemote` returns null → treated as local-only (no dedup, no `github_repository_id`). Future work if v2 supports non-GitHub remotes.
+
+## Script architecture
+
+**The orchestrator runs in the renderer, not main.** This is the established pattern for v1→v2 migrations in this codebase (see `useMigrateV1PresetsToV2`) and is forced by the `dashboardSidebarProjectSchema` collection being renderer-only localStorage — main has no window/localStorage and no IPC bridge for this collection. The renderer has direct access to everything it needs: `electronTrpcClient` to read v1 via main, cloud tRPC to write `v2_projects`/`v2_workspaces`, `@tanstack/db` collections for local sidebar meta, and `device.ensureV2Host` to resolve `host_id`.
+
+```
+apps/desktop/src/renderer/routes/_authenticated/settings/.../MigrateV1Data/
+  MigrateV1Data.tsx              # button + modal; hosts the orchestrator hook
+  useV1ToV2Migration.ts          # the orchestrator hook (preflight/preview/run/status)
+  readV1.ts                      # wraps electronTrpcClient calls to load v1 rows from main
+  preflight.ts                   # ensureV2Host, load migration_state, compute preview
+  migrateProject.ts              # parseOriginRemote → dedup → create-or-link → collection write
+  migrateWorkspace.ts            # v2Workspace.create → host-service workspace registration via electronTrpc
+  migrationState.ts              # CRUD via electronTrpcClient against main's local-db
+  parseRemote.ts                 # imports v2's parseGitHubRemote (do not re-implement)
+  types.ts
+  components/
+    MigrationPreview/
+    MigrationProgress/
+    MigrationSummary/
+  index.ts
+
+apps/desktop/src/main/ipc/v1-migration.ts   # thin IPC surface main exposes:
+                                             #  - readV1.{projects,workspaces,worktrees,settings}
+                                             #  - gitRemote(mainRepoPath) -> origin URL or null
+                                             #  - hostService.registerProject(projectId, ...)
+                                             #  - hostService.registerWorkspace(workspaceId, ...)
+                                             #  - migrationState.{read,upsert,list}
+
+packages/local-db/src/schema/schema.ts       # add migration_state table
+packages/local-db/drizzle/0041_v1_to_v2_migration_state.sql   # via drizzle-kit generate
+```
+
+No changes to `packages/db` (v2 cloud schema). Main process only exposes read/IPC endpoints the renderer orchestrator needs.
+
+## `migration_state` table (new v1 migration)
+
+```ts
+migrationState = sqliteTable("migration_state", {
+  v1Id: text().notNull(),
+  v2Id: text(),  // nullable: for errored/skipped rows with no v2 counterpart
+  organizationId: text().notNull(),  // scopes this migration to an org; prevents multi-org confusion
+  kind: text({ enum: ["project", "workspace"] }).notNull(),
+  status: text({ enum: ["success", "linked", "error", "skipped"] }).notNull(),
+  reason: text(),   // free-form: error message, or skip reason ("orphan_worktree", "deleting_at_set")
+  migratedAt: integer().notNull(),
+}, (table) => [
+  primaryKey({ columns: [table.v1Id, table.kind] }),
+  index("migration_state_v2_id_idx").on(table.v2Id),
+  index("migration_state_organization_id_idx").on(table.organizationId),
+]);
+```
+
+Status semantics:
+- `success` — we created a new v2 row; `v2Id` is set
+- `linked` — dedup hit; we mapped to an existing v2 row; `v2Id` is set
+- `error` — attempt failed; `v2Id` may be set (e.g. created but then something after failed) or null; retry on rerun
+- `skipped` — intentionally not migrated (orphan, `deleting_at`); `v2Id` null; don't retry
+
+Rerun logic: re-attempt `error` rows; skip `success`, `linked`, `skipped`.
+
+## Execution order per run
+
+1. **Preflight** (renderer orchestrator)
+   - Assert user is signed in. If they're in multiple orgs, show the org picker; default to current active org.
+   - Call `device.ensureV2Host({ organizationId, machineId: getHashedDeviceId(), name: getDeviceName() })` to upsert and capture `host_id`. This is idempotent — safe to run every time. On most of our own machines the row already exists.
+   - Read v1 `projects`, `workspaces` (filtering `deleting_at IS NULL`), `worktrees`, and the `default_app` per project via `electronTrpcClient`.
+   - Shell out via `electronTrpcClient.gitRemote(mainRepoPath)` to get each project's origin URL (v1 doesn't store remotes; we must discover at migration time). `parseGitHubRemote` the result. Handles: missing-repo-on-disk, non-GitHub remotes, no remote at all → all fall back to "local-only, create new".
+   - Load `migration_state`; subtract already-successful rows. If prior run was against a different `organizationId`, refuse and surface the error ("this machine has already migrated to Org X; use that org or reset the migration").
+   - Handle orphan v1 workspaces (`worktree_id` set but worktree row missing) by flagging them `skipped` with reason `orphan_worktree`. Surface in preview count as "N workspaces will be skipped due to missing worktree data".
+   - Build preview: per-project rows labelled `create-new`, `link-to-existing`, or `local-only`. Return to UI.
+
+2. **Run** (renderer, after user confirms)
+   - Loop v1 projects sequentially (not parallel — cheap throttle, avoids rate-limit surprises):
+     - `migrateProject`: dedup via `v2Project.findByGitHubRemote` → `v2Project.create` / `linkRepoCloneUrl` → `electronTrpc.hostService.registerProject` → write `defaultOpenInApp` to the `v2SidebarProjects` collection.
+     - Record mapping on success; record `status=error` with message on failure; continue.
+   - Loop v1 workspaces grouped by project, skipping workspaces whose parent project errored and orphan workspaces:
+     - `migrateWorkspace`: `v2Workspace.create` → `electronTrpc.hostService.registerWorkspace` (passes v2 workspace id + worktree path + branch).
+     - Record on success/error; continue.
+   - No global transaction — remote network writes. Per-row atomicity via `migration_state` suffices.
+
+3. **Summary**
+   - Aggregate from `migration_state`. Return counts + expandable error list.
+
+## Idempotency
+
+- Every insert path checks `migration_state` first; already-successful rows are skipped.
+- Errored rows are retried on rerun (re-attempted, may succeed this time).
+- Linked rows are stable; rerunning just no-ops them.
+
+## Not doing (in this phase)
+
+- Not migrating `workspace_sections` (user decision, 2026-04-22).
+- Not migrating `tab_order` for projects or workspaces (user decision).
+- Not migrating `color`, `icon_url`, `hide_image` (no v2 destination, minor aesthetic).
+- Not migrating `workspace_base_branch`, `branch_prefix_*` (per-project), `default_branch`, `worktree_base_dir` (per-project), `neon_project_id` (project-level): no v2 destination. Covered by SUPER-469, SUPER-470 where a v2 feature is planned; otherwise v2 intentionally diverges.
+- Not migrating anything from the v1 singleton `settings` table in this phase (see "Out of scope — settings migration" below).
+- Not migrating v1 `workspaces` rows where `deleting_at != null` — these are already being deleted; filtered out in `readV1.ts`.
+- Not deleting v1 rows post-migration — v1 local.db stays intact so users can fall back via `v2-local-override.forceV1` and consult old settings until v2 has feature parity.
+- Not building a CLI — Electron-internal only.
+
+## Out of scope — settings migration (phase 2)
+
+The v1 singleton `settings` table (`packages/local-db/src/schema/schema.ts:178-231`) holds global user state that's independent of projects/workspaces. Today only `terminal_presets` is migrated (via existing `useMigrateV1PresetsToV2` hook). A follow-up migration step should cover:
+
+**Likely worth porting** (real user customization that users would re-enter):
+- `agent_preset_overrides` — per-agent permission customizations
+- `agent_custom_definitions` — user-defined custom agents
+- `branch_prefix_mode` / `branch_prefix_custom` (global) — in addition to per-project tracked in SUPER-470
+- `worktree_base_dir` (global)
+- `default_editor` (global external-app default)
+
+**Probably ignore** (ephemeral, v2 handles differently, or low-stakes UI prefs):
+- `last_active_workspace_id`, `active_organization_id` (session state)
+- Font sizes, notification volume/ringtone, terminal link/persist behavior, `show_resource_monitor`, `confirm_on_quit`, etc.
+- Migration markers (`agent_preset_permissions_migrated_at`, `terminal_presets_initialized`)
+
+This work belongs in its own ticket after the project/workspace port ships. It has different destinations (mostly PGlite collections or v2 session/user state, not `v2_projects`/`v2_workspaces`), so bundling it would expand scope without benefit.
+
+## Followups after ship
+
+- SUPER-469: when v2 adds project-level `workspace_base_branch`, extend migration to port it.
+- SUPER-470: when v2 adds branch prefix settings, extend migration to port them.
+- When v2 adds project `color` / `icon_url` — extend if those land.
+- When v2 deprecates fallback-to-v1 (removes `v2-local-override`), add a "delete v1 data" button separate from the port action.

--- a/apps/desktop/src/lib/trpc/routers/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/index.ts
@@ -14,6 +14,7 @@ import { createExternalRouter } from "./external";
 import { createFilesystemRouter } from "./filesystem";
 import { createHostServiceCoordinatorRouter } from "./host-service-coordinator";
 import { createMenuRouter } from "./menu";
+import { createMigrationRouter } from "./migration";
 import { createNotificationsRouter } from "./notifications";
 import { createPermissionsRouter } from "./permissions";
 import { createPortsRouter } from "./ports";
@@ -53,6 +54,7 @@ export const createAppRouter = (getWindow: () => BrowserWindow | null) => {
 		uiState: createUiStateRouter(),
 		ringtone: createRingtoneRouter(getWindow),
 		hostServiceCoordinator: createHostServiceCoordinatorRouter(),
+		migration: createMigrationRouter(),
 	});
 };
 

--- a/apps/desktop/src/lib/trpc/routers/migration/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/migration/index.ts
@@ -1,0 +1,114 @@
+import {
+	projects,
+	v1MigrationState,
+	workspaceSections,
+	workspaces,
+	worktrees,
+} from "@superset/local-db";
+import { and, eq, isNotNull, isNull } from "drizzle-orm";
+import { localDb } from "main/lib/local-db";
+import { z } from "zod";
+import { publicProcedure, router } from "../..";
+
+const migrationStateRowSchema = z.object({
+	v1Id: z.string().min(1),
+	kind: z.enum(["project", "workspace"]),
+	v2Id: z.string().nullable(),
+	organizationId: z.string().min(1),
+	status: z.enum(["success", "linked", "error", "skipped"]),
+	reason: z.string().nullable().optional(),
+});
+
+export const createMigrationRouter = () => {
+	return router({
+		readV1Projects: publicProcedure.query(() => {
+			// Only migrate pinned projects. v1's `hideProject` nulls tab_order when
+			// the last workspace in a project is deleted, effectively abandoning the
+			// project — don't resurrect those in v2.
+			return localDb
+				.select()
+				.from(projects)
+				.where(isNotNull(projects.tabOrder))
+				.all();
+		}),
+
+		readV1Workspaces: publicProcedure.query(() => {
+			return localDb
+				.select()
+				.from(workspaces)
+				.where(isNull(workspaces.deletingAt))
+				.all();
+		}),
+
+		readV1Worktrees: publicProcedure.query(() => {
+			return localDb.select().from(worktrees).all();
+		}),
+
+		readV1WorkspaceSections: publicProcedure.query(() => {
+			return localDb.select().from(workspaceSections).all();
+		}),
+
+		listState: publicProcedure
+			.input(z.object({ organizationId: z.string().min(1) }))
+			.query(({ input }) => {
+				return localDb
+					.select()
+					.from(v1MigrationState)
+					.where(eq(v1MigrationState.organizationId, input.organizationId))
+					.all();
+			}),
+
+		upsertState: publicProcedure
+			.input(migrationStateRowSchema)
+			.mutation(({ input }) => {
+				localDb
+					.insert(v1MigrationState)
+					.values({
+						v1Id: input.v1Id,
+						kind: input.kind,
+						v2Id: input.v2Id,
+						organizationId: input.organizationId,
+						status: input.status,
+						reason: input.reason ?? null,
+						migratedAt: Date.now(),
+					})
+					.onConflictDoUpdate({
+						target: [v1MigrationState.v1Id, v1MigrationState.kind],
+						set: {
+							v2Id: input.v2Id,
+							organizationId: input.organizationId,
+							status: input.status,
+							reason: input.reason ?? null,
+							migratedAt: Date.now(),
+						},
+					})
+					.run();
+			}),
+
+		clearState: publicProcedure
+			.input(z.object({ organizationId: z.string().min(1) }))
+			.mutation(({ input }) => {
+				localDb
+					.delete(v1MigrationState)
+					.where(eq(v1MigrationState.organizationId, input.organizationId))
+					.run();
+			}),
+
+		findMigrationByOtherOrg: publicProcedure
+			.input(z.object({ organizationId: z.string().min(1) }))
+			.query(({ input }) => {
+				const other = localDb
+					.select({ organizationId: v1MigrationState.organizationId })
+					.from(v1MigrationState)
+					.where(
+						and(
+							eq(v1MigrationState.kind, "project"),
+							eq(v1MigrationState.status, "success"),
+						),
+					)
+					.all()
+					.find((row) => row.organizationId !== input.organizationId);
+				return other?.organizationId ?? null;
+			}),
+	});
+};

--- a/apps/desktop/src/lib/trpc/routers/migration/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/migration/index.ts
@@ -73,10 +73,13 @@ export const createMigrationRouter = () => {
 						migratedAt: Date.now(),
 					})
 					.onConflictDoUpdate({
-						target: [v1MigrationState.v1Id, v1MigrationState.kind],
+						target: [
+							v1MigrationState.organizationId,
+							v1MigrationState.v1Id,
+							v1MigrationState.kind,
+						],
 						set: {
 							v2Id: input.v2Id,
-							organizationId: input.organizationId,
 							status: input.status,
 							reason: input.reason ?? null,
 							migratedAt: Date.now(),

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -9,7 +9,9 @@ import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { useHotkey } from "renderer/hotkeys";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { DashboardSidebar } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar";
+import { V1MigrationSummaryModal } from "renderer/routes/_authenticated/components/V1MigrationSummaryModal";
 import { useDevSeedV2Sidebar } from "renderer/routes/_authenticated/hooks/useDevSeedV2Sidebar";
+import { useMigrateV1DataToV2 } from "renderer/routes/_authenticated/hooks/useMigrateV1DataToV2";
 import { ResizablePanel } from "renderer/screens/main/components/ResizablePanel";
 import { WorkspaceSidebar } from "renderer/screens/main/components/WorkspaceSidebar";
 import { DeleteWorkspaceDialog } from "renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components";
@@ -32,6 +34,7 @@ function DashboardLayout() {
 	const openNewWorkspaceModal = useOpenNewWorkspaceModal();
 	const { isV2CloudEnabled } = useIsV2CloudEnabled();
 	useDevSeedV2Sidebar();
+	useMigrateV1DataToV2();
 	// Get current workspace from route to pre-select project in new workspace modal
 	const matchRoute = useMatchRoute();
 	const currentWorkspaceMatch = matchRoute({
@@ -124,6 +127,7 @@ function DashboardLayout() {
 					<Outlet />
 				</div>
 				<AddRepositoryModals />
+				<V1MigrationSummaryModal />
 				{deleteTarget && (
 					<DeleteWorkspaceDialog
 						workspaceId={deleteTarget.workspaceId}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1MigrationSummaryModal/V1MigrationSummaryModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1MigrationSummaryModal/V1MigrationSummaryModal.tsx
@@ -1,0 +1,394 @@
+import { Badge } from "@superset/ui/badge";
+import { Button } from "@superset/ui/button";
+import { Dialog, DialogContent } from "@superset/ui/dialog";
+import { MeshGradient } from "@superset/ui/mesh-gradient";
+import { cn } from "@superset/ui/utils";
+import { useEffect, useState } from "react";
+import {
+	LuCheck,
+	LuChevronDown,
+	LuChevronRight,
+	LuFolder,
+	LuLayoutGrid,
+	LuTriangle,
+} from "react-icons/lu";
+import { env } from "renderer/env.renderer";
+import { authClient } from "renderer/lib/auth-client";
+import { V1_MIGRATION_SUMMARY_EVENT } from "renderer/routes/_authenticated/hooks/useMigrateV1DataToV2";
+import { MOCK_ORG_ID } from "shared/constants";
+
+type ProjectStatus = "created" | "linked" | "error";
+type WorkspaceStatus = "adopted" | "skipped" | "error";
+
+interface ProjectEntry {
+	name: string;
+	status: ProjectStatus;
+	reason?: string;
+}
+
+interface WorkspaceEntry {
+	name: string;
+	branch: string;
+	status: WorkspaceStatus;
+	reason?: string;
+}
+
+interface MigrationSummary {
+	projectsCreated: number;
+	projectsLinked: number;
+	projectsErrored: number;
+	workspacesCreated: number;
+	workspacesSkipped: number;
+	workspacesErrored: number;
+	projects: ProjectEntry[];
+	workspaces: WorkspaceEntry[];
+	errors: Array<{ kind: string; name: string; message: string }>;
+}
+
+interface StoredEntry {
+	summary: MigrationSummary;
+	createdAt: number;
+}
+
+const GRADIENT_COLORS = [
+	"#3b82f6",
+	"#6366f1",
+	"#8b5cf6",
+	"#1e1b4b",
+] as const satisfies readonly [string, string, string, string];
+
+function summaryKey(organizationId: string): string {
+	return `v1-migration-summary-${organizationId}`;
+}
+
+function readSummary(organizationId: string): MigrationSummary | null {
+	const raw = localStorage.getItem(summaryKey(organizationId));
+	if (!raw) return null;
+	try {
+		const parsed = JSON.parse(raw) as StoredEntry;
+		return parsed.summary ?? null;
+	} catch {
+		localStorage.removeItem(summaryKey(organizationId));
+		return null;
+	}
+}
+
+export function V1MigrationSummaryModal() {
+	const { data: session } = authClient.useSession();
+	const organizationId = env.SKIP_ENV_VALIDATION
+		? MOCK_ORG_ID
+		: (session?.session?.activeOrganizationId ?? null);
+	const [summary, setSummary] = useState<MigrationSummary | null>(null);
+	const [expandedSection, setExpandedSection] = useState<
+		"projects" | "workspaces" | null
+	>(null);
+
+	useEffect(() => {
+		if (!organizationId) {
+			setSummary(null);
+			return;
+		}
+		setSummary(readSummary(organizationId));
+
+		const onUpdate = (event: Event) => {
+			const detail = (event as CustomEvent<{ organizationId: string }>).detail;
+			if (detail?.organizationId === organizationId) {
+				setSummary(readSummary(organizationId));
+			}
+		};
+		window.addEventListener(V1_MIGRATION_SUMMARY_EVENT, onUpdate);
+
+		return () => {
+			window.removeEventListener(V1_MIGRATION_SUMMARY_EVENT, onUpdate);
+		};
+	}, [organizationId]);
+
+	const dismiss = () => {
+		if (organizationId) localStorage.removeItem(summaryKey(organizationId));
+		setSummary(null);
+		setExpandedSection(null);
+	};
+
+	const toggleSection = (section: "projects" | "workspaces") => {
+		setExpandedSection((current) => (current === section ? null : section));
+	};
+
+	if (!summary) return null;
+
+	const projectsTotal = summary.projectsCreated + summary.projectsLinked;
+	const workspacesTotal = summary.workspacesCreated;
+	const hasErrors = summary.errors.length > 0;
+
+	return (
+		<Dialog open={!!summary}>
+			<DialogContent
+				className="!w-[480px] !max-w-[480px] p-0 gap-0 overflow-hidden"
+				showCloseButton={false}
+				onEscapeKeyDown={(event) => event.preventDefault()}
+				onPointerDownOutside={(event) => event.preventDefault()}
+				onInteractOutside={(event) => event.preventDefault()}
+			>
+				<div className="relative h-[180px] overflow-hidden">
+					<MeshGradient
+						colors={GRADIENT_COLORS}
+						className="absolute inset-0 w-full h-full"
+					/>
+					<div className="absolute inset-0 flex flex-col items-center justify-center px-6 text-center">
+						<div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-white/15 backdrop-blur-sm">
+							<LuCheck className="h-5 w-5 text-white" strokeWidth={2.5} />
+						</div>
+						<div className="text-xl font-semibold text-white">
+							Welcome to Superset v2
+						</div>
+						<div className="mt-1 text-sm text-white/80">
+							We imported your v1 data
+						</div>
+					</div>
+				</div>
+
+				<div className="flex max-h-[340px] flex-col gap-1 overflow-y-auto px-3 py-3">
+					<ExpandableSummaryRow
+						icon={LuFolder}
+						label="Projects"
+						count={projectsTotal}
+						detail={[
+							summary.projectsLinked > 0
+								? `${summary.projectsLinked} linked`
+								: null,
+							summary.projectsCreated > 0
+								? `${summary.projectsCreated} created`
+								: null,
+						]
+							.filter(Boolean)
+							.join(" · ")}
+						expanded={expandedSection === "projects"}
+						onToggle={
+							summary.projects.length > 0
+								? () => toggleSection("projects")
+								: undefined
+						}
+					>
+						<EntryList>
+							{summary.projects.map((p) => (
+								<Entry
+									key={`project-${p.name}`}
+									primary={p.name}
+									statusLabel={p.status}
+									statusTone={entryTone(p.status)}
+									detail={p.reason}
+								/>
+							))}
+						</EntryList>
+					</ExpandableSummaryRow>
+					<ExpandableSummaryRow
+						icon={LuLayoutGrid}
+						label="Workspaces"
+						count={workspacesTotal}
+						detail={
+							summary.workspacesSkipped > 0
+								? `${summary.workspacesSkipped} skipped`
+								: undefined
+						}
+						expanded={expandedSection === "workspaces"}
+						onToggle={
+							summary.workspaces.length > 0
+								? () => toggleSection("workspaces")
+								: undefined
+						}
+					>
+						<EntryList>
+							{summary.workspaces.map((w) => (
+								<Entry
+									key={`workspace-${w.name}-${w.branch}`}
+									primary={w.name}
+									secondary={w.branch}
+									statusLabel={w.status}
+									statusTone={entryTone(w.status)}
+									detail={w.reason}
+								/>
+							))}
+						</EntryList>
+					</ExpandableSummaryRow>
+					{hasErrors && (
+						<SummaryRow
+							icon={LuTriangle}
+							label="Errors"
+							count={summary.errors.length}
+							detail="Details in devtools console"
+							variant="error"
+						/>
+					)}
+				</div>
+
+				<div className="flex items-center justify-between border-t bg-background px-5 py-4">
+					<span className="text-xs text-muted-foreground">
+						v1 data is preserved
+					</span>
+					<Button onClick={dismiss}>Got it</Button>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+function entryTone(
+	status: ProjectStatus | WorkspaceStatus,
+): "success" | "muted" | "error" {
+	if (status === "error") return "error";
+	if (status === "skipped") return "muted";
+	return "success";
+}
+
+interface SummaryRowProps {
+	icon: React.ComponentType<{ className?: string; strokeWidth?: number }>;
+	label: string;
+	count: number;
+	detail?: string;
+	variant?: "default" | "error";
+}
+
+function SummaryRow({
+	icon: Icon,
+	label,
+	count,
+	detail,
+	variant = "default",
+}: SummaryRowProps) {
+	return (
+		<div className="flex items-center gap-3 rounded-md px-3 py-2">
+			<div
+				className={cn(
+					"flex h-8 w-8 items-center justify-center rounded-md",
+					variant === "error"
+						? "bg-destructive/10 text-destructive"
+						: "bg-muted text-foreground",
+				)}
+			>
+				<Icon className="h-4 w-4" strokeWidth={2} />
+			</div>
+			<div className="flex flex-1 items-center justify-between">
+				<div className="flex items-baseline gap-2">
+					<span className="text-sm font-medium text-foreground">{label}</span>
+					<Badge variant="secondary" className="px-1.5 py-0 text-xs">
+						{count}
+					</Badge>
+				</div>
+				{detail && (
+					<span className="text-xs text-muted-foreground">{detail}</span>
+				)}
+			</div>
+		</div>
+	);
+}
+
+interface ExpandableSummaryRowProps extends SummaryRowProps {
+	expanded: boolean;
+	onToggle?: () => void;
+	children: React.ReactNode;
+}
+
+function ExpandableSummaryRow({
+	icon: Icon,
+	label,
+	count,
+	detail,
+	expanded,
+	onToggle,
+	children,
+}: ExpandableSummaryRowProps) {
+	const clickable = onToggle !== undefined;
+	return (
+		<div className="flex flex-col">
+			<button
+				type="button"
+				disabled={!clickable}
+				onClick={onToggle}
+				className={cn(
+					"flex items-center gap-3 rounded-md px-3 py-2 text-left",
+					clickable && "cursor-pointer hover:bg-muted/50",
+					!clickable && "cursor-default",
+				)}
+			>
+				<div className="flex h-8 w-8 items-center justify-center rounded-md bg-muted text-foreground">
+					<Icon className="h-4 w-4" strokeWidth={2} />
+				</div>
+				<div className="flex flex-1 items-center justify-between">
+					<div className="flex items-baseline gap-2">
+						<span className="text-sm font-medium text-foreground">{label}</span>
+						<Badge variant="secondary" className="px-1.5 py-0 text-xs">
+							{count}
+						</Badge>
+					</div>
+					<div className="flex items-center gap-2">
+						{detail && (
+							<span className="text-xs text-muted-foreground">{detail}</span>
+						)}
+						{clickable &&
+							(expanded ? (
+								<LuChevronDown
+									className="h-3.5 w-3.5 text-muted-foreground"
+									strokeWidth={2}
+								/>
+							) : (
+								<LuChevronRight
+									className="h-3.5 w-3.5 text-muted-foreground"
+									strokeWidth={2}
+								/>
+							))}
+					</div>
+				</div>
+			</button>
+			{expanded && <div className="pb-1 pl-14 pr-3">{children}</div>}
+		</div>
+	);
+}
+
+function EntryList({ children }: { children: React.ReactNode }) {
+	return <div className="flex flex-col gap-0.5 py-1">{children}</div>;
+}
+
+interface EntryProps {
+	primary: string;
+	secondary?: string;
+	statusLabel: string;
+	statusTone: "success" | "muted" | "error";
+	detail?: string;
+}
+
+function Entry({
+	primary,
+	secondary,
+	statusLabel,
+	statusTone,
+	detail,
+}: EntryProps) {
+	return (
+		<div className="flex items-center justify-between gap-3 py-1">
+			<div className="flex min-w-0 flex-1 flex-col">
+				<span className="truncate text-xs font-medium text-foreground">
+					{primary}
+				</span>
+				{secondary && (
+					<span className="truncate font-mono text-[10px] text-muted-foreground">
+						{secondary}
+					</span>
+				)}
+				{detail && (
+					<span className="truncate text-[10px] text-muted-foreground">
+						{detail}
+					</span>
+				)}
+			</div>
+			<span
+				className={cn(
+					"shrink-0 text-[10px] font-medium uppercase tracking-wide",
+					statusTone === "success" && "text-emerald-600 dark:text-emerald-400",
+					statusTone === "muted" && "text-muted-foreground",
+					statusTone === "error" && "text-destructive",
+				)}
+			>
+				{statusLabel}
+			</span>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1MigrationSummaryModal/V1MigrationSummaryModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1MigrationSummaryModal/V1MigrationSummaryModal.tsx
@@ -1,6 +1,11 @@
 import { Badge } from "@superset/ui/badge";
 import { Button } from "@superset/ui/button";
-import { Dialog, DialogContent } from "@superset/ui/dialog";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogTitle,
+} from "@superset/ui/dialog";
 import { MeshGradient } from "@superset/ui/mesh-gradient";
 import { cn } from "@superset/ui/utils";
 import { useEffect, useState } from "react";
@@ -128,6 +133,11 @@ export function V1MigrationSummaryModal() {
 				onPointerDownOutside={(event) => event.preventDefault()}
 				onInteractOutside={(event) => event.preventDefault()}
 			>
+				<DialogTitle className="sr-only">Welcome to Superset v2</DialogTitle>
+				<DialogDescription className="sr-only">
+					We imported your v1 data. Review the summary and click Got it to
+					continue.
+				</DialogDescription>
 				<div className="relative h-[180px] overflow-hidden">
 					<MeshGradient
 						colors={GRADIENT_COLORS}
@@ -169,9 +179,9 @@ export function V1MigrationSummaryModal() {
 						}
 					>
 						<EntryList>
-							{summary.projects.map((p) => (
+							{summary.projects.map((p, index) => (
 								<Entry
-									key={`project-${p.name}`}
+									key={`project-${index}-${p.name}`}
 									primary={p.name}
 									statusLabel={p.status}
 									statusTone={entryTone(p.status)}
@@ -197,9 +207,9 @@ export function V1MigrationSummaryModal() {
 						}
 					>
 						<EntryList>
-							{summary.workspaces.map((w) => (
+							{summary.workspaces.map((w, index) => (
 								<Entry
-									key={`workspace-${w.name}-${w.branch}`}
+									key={`workspace-${index}-${w.name}-${w.branch}`}
 									primary={w.name}
 									secondary={w.branch}
 									statusLabel={w.status}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1MigrationSummaryModal/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1MigrationSummaryModal/index.ts
@@ -1,0 +1,1 @@
+export { V1MigrationSummaryModal } from "./V1MigrationSummaryModal";

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/index.ts
@@ -1,0 +1,4 @@
+export {
+	useMigrateV1DataToV2,
+	V1_MIGRATION_SUMMARY_EVENT,
+} from "./useMigrateV1DataToV2";

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/migrate.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/migrate.test.ts
@@ -1,0 +1,510 @@
+import { describe, expect, test } from "bun:test";
+import type { HostServiceClient } from "renderer/lib/host-service-client";
+import type { electronTrpcClient } from "renderer/lib/trpc-client";
+import type { OrgCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider/collections";
+import { migrateV1DataToV2 } from "./migrate";
+
+type ElectronTrpcClient = typeof electronTrpcClient;
+
+interface V1ProjectRow {
+	id: string;
+	name: string;
+	mainRepoPath: string;
+	tabOrder: number | null;
+	defaultApp: string | null;
+}
+
+interface V1WorkspaceRow {
+	id: string;
+	projectId: string;
+	worktreeId: string | null;
+	type: "branch" | "worktree";
+	branch: string;
+	name: string;
+	sectionId: string | null;
+	tabOrder: number;
+}
+
+interface V1WorktreeRow {
+	id: string;
+	path: string;
+}
+
+interface V1SectionRow {
+	id: string;
+	projectId: string;
+	name: string;
+	tabOrder: number;
+	isCollapsed: boolean | null;
+	color: string | null;
+}
+
+interface StateRow {
+	v1Id: string;
+	v2Id: string | null;
+	organizationId: string;
+	kind: "project" | "workspace";
+	status: "success" | "linked" | "error" | "skipped";
+	reason: string | null;
+}
+
+type PathResponse =
+	| { candidates: Array<{ id: string }> }
+	| { err: "path-missing" };
+
+interface FakeEnv {
+	v1Projects: V1ProjectRow[];
+	v1Workspaces: V1WorkspaceRow[];
+	v1Worktrees: V1WorktreeRow[];
+	v1Sections: V1SectionRow[];
+	state: Map<string, StateRow>;
+	otherOrg: string | null;
+	findByPath: Map<string, PathResponse>;
+	setupThrowsFor: Set<string>;
+	createThrowsFor: Set<string>;
+	adoptThrowsFor: Map<string, { code: string; message?: string }>;
+}
+
+function makeFakeEnv(overrides: Partial<FakeEnv> = {}): FakeEnv {
+	return {
+		v1Projects: [],
+		v1Workspaces: [],
+		v1Worktrees: [],
+		v1Sections: [],
+		state: new Map(),
+		otherOrg: null,
+		findByPath: new Map(),
+		setupThrowsFor: new Set(),
+		createThrowsFor: new Set(),
+		adoptThrowsFor: new Map(),
+		...overrides,
+	};
+}
+
+function trpcErr(code: string, message = code) {
+	return Object.assign(new Error(message), { data: { code } });
+}
+
+function makeElectronTrpc(env: FakeEnv): ElectronTrpcClient {
+	const createdV2s: string[] = [];
+	const hostProjects = new Set<string>();
+	const hostWorkspaces = new Set<string>();
+	void createdV2s;
+	void hostProjects;
+	void hostWorkspaces;
+
+	const stub = {
+		migration: {
+			readV1Projects: { query: async () => env.v1Projects },
+			readV1Workspaces: { query: async () => env.v1Workspaces },
+			readV1Worktrees: { query: async () => env.v1Worktrees },
+			readV1WorkspaceSections: { query: async () => env.v1Sections },
+			listState: {
+				query: async ({ organizationId }: { organizationId: string }) =>
+					Array.from(env.state.values()).filter(
+						(r) => r.organizationId === organizationId,
+					),
+			},
+			findMigrationByOtherOrg: {
+				query: async (_: { organizationId: string }) => env.otherOrg,
+			},
+			upsertState: {
+				mutate: async (row: Omit<StateRow, "migratedAt">) => {
+					env.state.set(`${row.kind}:${row.v1Id}`, {
+						v1Id: row.v1Id,
+						v2Id: row.v2Id,
+						organizationId: row.organizationId,
+						kind: row.kind,
+						status: row.status,
+						reason: row.reason ?? null,
+					});
+				},
+			},
+		},
+	};
+	return stub as unknown as ElectronTrpcClient;
+}
+
+function makeHostService(env: FakeEnv): HostServiceClient {
+	const idCounter = { n: 0 };
+	const nextId = (prefix: string) => `${prefix}-${++idCounter.n}`;
+
+	const stub = {
+		project: {
+			findByPath: {
+				query: async ({ repoPath }: { repoPath: string }) => {
+					const result = env.findByPath.get(repoPath);
+					if (!result) return { candidates: [] };
+					if ("err" in result) {
+						throw new Error(`path not a git repo: ${repoPath}`);
+					}
+					return result;
+				},
+			},
+			setup: {
+				mutate: async ({ projectId }: { projectId: string }) => {
+					if (env.setupThrowsFor.has(projectId)) {
+						throw trpcErr("CONFLICT", "already set up elsewhere");
+					}
+					return { repoPath: "/fake" };
+				},
+			},
+			create: {
+				mutate: async ({ name }: { name: string }) => {
+					if (env.createThrowsFor.has(name)) {
+						throw new Error(`cloud create failed for ${name}`);
+					}
+					return { projectId: nextId("v2-proj"), repoPath: "/fake" };
+				},
+			},
+		},
+		workspaceCreation: {
+			adopt: {
+				mutate: async ({ branch }: { branch: string }) => {
+					const behavior = env.adoptThrowsFor.get(branch);
+					if (behavior) throw trpcErr(behavior.code, behavior.message);
+					return {
+						workspace: { id: nextId("v2-ws"), branch },
+						terminals: [],
+						warnings: [],
+					};
+				},
+			},
+		},
+	};
+	return stub as unknown as HostServiceClient;
+}
+
+function makeCollections(): OrgCollections {
+	const make = <T extends Record<string, unknown>>(keyOf: (v: T) => string) => {
+		const store = new Map<string, T>();
+		return {
+			get: (k: string) => store.get(k),
+			insert: (v: T) => {
+				store.set(keyOf(v), v);
+			},
+		};
+	};
+	return {
+		// Only the 3 collections migrate.ts + writeSidebarState touch matter.
+		v2SidebarProjects: make((v: { projectId: string }) => v.projectId),
+		v2SidebarSections: make((v: { sectionId: string }) => v.sectionId),
+		v2WorkspaceLocalState: make((v: { workspaceId: string }) => v.workspaceId),
+	} as unknown as OrgCollections;
+}
+
+const ORG = "org-1";
+
+function project(
+	id: string,
+	overrides: Partial<V1ProjectRow> = {},
+): V1ProjectRow {
+	return {
+		id,
+		name: `project-${id}`,
+		mainRepoPath: `/repos/${id}`,
+		tabOrder: 0,
+		defaultApp: null,
+		...overrides,
+	};
+}
+
+function workspace(
+	id: string,
+	projectId: string,
+	overrides: Partial<V1WorkspaceRow> = {},
+): V1WorkspaceRow {
+	return {
+		id,
+		projectId,
+		worktreeId: null,
+		type: "branch",
+		branch: `branch-${id}`,
+		name: `workspace-${id}`,
+		sectionId: null,
+		tabOrder: 0,
+		...overrides,
+	};
+}
+
+describe("migrateV1DataToV2", () => {
+	test("happy path: creates projects and adopts workspaces", async () => {
+		const env = makeFakeEnv({
+			v1Projects: [project("p1"), project("p2")],
+			v1Workspaces: [
+				workspace("w1", "p1", { worktreeId: "wt1", type: "worktree" }),
+				workspace("w2", "p2", { worktreeId: "wt2", type: "worktree" }),
+			],
+			v1Worktrees: [
+				{ id: "wt1", path: "/worktrees/w1" },
+				{ id: "wt2", path: "/worktrees/w2" },
+			],
+		});
+
+		const summary = await migrateV1DataToV2({
+			organizationId: ORG,
+			electronTrpc: makeElectronTrpc(env),
+			hostService: makeHostService(env),
+			collections: makeCollections(),
+		});
+
+		expect(summary.projectsCreated).toBe(2);
+		expect(summary.projectsLinked).toBe(0);
+		expect(summary.workspacesCreated).toBe(2);
+		expect(summary.workspacesSkipped).toBe(0);
+		expect(summary.errors).toHaveLength(0);
+		expect(env.state.size).toBe(4);
+	});
+
+	test("findByPath hit links to existing v2 project", async () => {
+		const env = makeFakeEnv({
+			v1Projects: [project("p1")],
+			v1Workspaces: [],
+			findByPath: new Map([
+				["/repos/p1", { candidates: [{ id: "v2-existing" }] }],
+			]),
+		});
+
+		const summary = await migrateV1DataToV2({
+			organizationId: ORG,
+			electronTrpc: makeElectronTrpc(env),
+			hostService: makeHostService(env),
+			collections: makeCollections(),
+		});
+
+		expect(summary.projectsLinked).toBe(1);
+		expect(summary.projectsCreated).toBe(0);
+		expect(env.state.get("project:p1")?.v2Id).toBe("v2-existing");
+		expect(env.state.get("project:p1")?.status).toBe("linked");
+	});
+
+	test("CONFLICT on setup after link is swallowed (already set up elsewhere)", async () => {
+		const env = makeFakeEnv({
+			v1Projects: [project("p1")],
+			findByPath: new Map([
+				["/repos/p1", { candidates: [{ id: "v2-existing" }] }],
+			]),
+			setupThrowsFor: new Set(["v2-existing"]),
+		});
+
+		const summary = await migrateV1DataToV2({
+			organizationId: ORG,
+			electronTrpc: makeElectronTrpc(env),
+			hostService: makeHostService(env),
+			collections: makeCollections(),
+		});
+
+		expect(summary.projectsLinked).toBe(1);
+		expect(summary.errors).toHaveLength(0);
+	});
+
+	test("project create failure records error and skips its workspaces", async () => {
+		const env = makeFakeEnv({
+			v1Projects: [project("p-bad"), project("p-good")],
+			v1Workspaces: [
+				workspace("w1", "p-bad", { worktreeId: "wt1", type: "worktree" }),
+				workspace("w2", "p-good", { worktreeId: "wt2", type: "worktree" }),
+			],
+			v1Worktrees: [
+				{ id: "wt1", path: "/a" },
+				{ id: "wt2", path: "/b" },
+			],
+			createThrowsFor: new Set(["project-p-bad"]),
+		});
+
+		const summary = await migrateV1DataToV2({
+			organizationId: ORG,
+			electronTrpc: makeElectronTrpc(env),
+			hostService: makeHostService(env),
+			collections: makeCollections(),
+		});
+
+		expect(summary.projectsErrored).toBe(1);
+		expect(summary.projectsCreated).toBe(1);
+		expect(summary.workspacesCreated).toBe(1); // w2 only
+		expect(summary.workspacesSkipped).toBe(1); // w1 skipped (parent error)
+		expect(env.state.get("workspace:w1")?.reason).toBe(
+			"parent_project_unresolved",
+		);
+	});
+
+	test("orphan workspace (missing worktree row) is skipped", async () => {
+		const env = makeFakeEnv({
+			v1Projects: [project("p1")],
+			v1Workspaces: [
+				workspace("w-orphan", "p1", {
+					type: "worktree",
+					worktreeId: "missing",
+				}),
+			],
+			v1Worktrees: [],
+		});
+
+		const summary = await migrateV1DataToV2({
+			organizationId: ORG,
+			electronTrpc: makeElectronTrpc(env),
+			hostService: makeHostService(env),
+			collections: makeCollections(),
+		});
+
+		expect(summary.workspacesSkipped).toBe(1);
+		expect(summary.workspacesCreated).toBe(0);
+		expect(env.state.get("workspace:w-orphan")?.reason).toBe("orphan_worktree");
+	});
+
+	test("adopt NOT_FOUND is skipped, not errored", async () => {
+		const env = makeFakeEnv({
+			v1Projects: [project("p1")],
+			v1Workspaces: [
+				workspace("w1", "p1", {
+					branch: "gone",
+					worktreeId: "wt1",
+					type: "worktree",
+				}),
+			],
+			v1Worktrees: [{ id: "wt1", path: "/gone" }],
+			adoptThrowsFor: new Map([["gone", { code: "NOT_FOUND" }]]),
+		});
+
+		const summary = await migrateV1DataToV2({
+			organizationId: ORG,
+			electronTrpc: makeElectronTrpc(env),
+			hostService: makeHostService(env),
+			collections: makeCollections(),
+		});
+
+		expect(summary.workspacesSkipped).toBe(1);
+		expect(summary.workspacesErrored).toBe(0);
+		expect(env.state.get("workspace:w1")?.reason).toBe(
+			"worktree_not_registered",
+		);
+	});
+
+	test("adopt non-NOT_FOUND error is recorded as error", async () => {
+		const env = makeFakeEnv({
+			v1Projects: [project("p1")],
+			v1Workspaces: [
+				workspace("w1", "p1", {
+					branch: "boom",
+					worktreeId: "wt1",
+					type: "worktree",
+				}),
+			],
+			v1Worktrees: [{ id: "wt1", path: "/x" }],
+			adoptThrowsFor: new Map([
+				["boom", { code: "INTERNAL_SERVER_ERROR", message: "cloud down" }],
+			]),
+		});
+
+		const summary = await migrateV1DataToV2({
+			organizationId: ORG,
+			electronTrpc: makeElectronTrpc(env),
+			hostService: makeHostService(env),
+			collections: makeCollections(),
+		});
+
+		expect(summary.workspacesErrored).toBe(1);
+		expect(summary.errors).toHaveLength(1);
+		expect(env.state.get("workspace:w1")?.status).toBe("error");
+	});
+
+	test("other-org guard rejects migration", async () => {
+		const env = makeFakeEnv({
+			otherOrg: "some-other-org",
+			v1Projects: [project("p1")],
+		});
+
+		await expect(
+			migrateV1DataToV2({
+				organizationId: ORG,
+				electronTrpc: makeElectronTrpc(env),
+				hostService: makeHostService(env),
+				collections: makeCollections(),
+			}),
+		).rejects.toThrow(/already been migrated/);
+	});
+
+	test("rerun skips rows already in success/linked state, retries error rows", async () => {
+		// Pre-populate state as if a prior run completed p1 but errored on p2.
+		const prior = new Map<string, StateRow>([
+			[
+				"project:p1",
+				{
+					v1Id: "p1",
+					v2Id: "v2-p1",
+					organizationId: ORG,
+					kind: "project",
+					status: "success",
+					reason: null,
+				},
+			],
+			[
+				"project:p2",
+				{
+					v1Id: "p2",
+					v2Id: null,
+					organizationId: ORG,
+					kind: "project",
+					status: "error",
+					reason: "prior failure",
+				},
+			],
+		]);
+		const env = makeFakeEnv({
+			v1Projects: [project("p1"), project("p2")],
+			state: prior,
+		});
+
+		const summary = await migrateV1DataToV2({
+			organizationId: ORG,
+			electronTrpc: makeElectronTrpc(env),
+			hostService: makeHostService(env),
+			collections: makeCollections(),
+		});
+
+		// p1 was success → skipped. p2 was error → retried and succeeded this run.
+		expect(summary.projectsCreated).toBe(1);
+		expect(env.state.get("project:p2")?.status).toBe("success");
+		expect(env.state.get("project:p1")?.status).toBe("success"); // unchanged
+	});
+
+	test("workspace with sectionId that lacks a v1 section record lands at top level", async () => {
+		const env = makeFakeEnv({
+			v1Projects: [project("p1")],
+			v1Workspaces: [
+				workspace("w1", "p1", {
+					worktreeId: "wt1",
+					type: "worktree",
+					sectionId: "sec-missing",
+				}),
+			],
+			v1Worktrees: [{ id: "wt1", path: "/a" }],
+			v1Sections: [],
+		});
+
+		const summary = await migrateV1DataToV2({
+			organizationId: ORG,
+			electronTrpc: makeElectronTrpc(env),
+			hostService: makeHostService(env),
+			collections: makeCollections(),
+		});
+
+		expect(summary.workspacesCreated).toBe(1);
+		expect(env.state.get("workspace:w1")?.status).toBe("success");
+	});
+
+	test("no v1 data → no-op, no errors, empty summary", async () => {
+		const env = makeFakeEnv({});
+		const summary = await migrateV1DataToV2({
+			organizationId: ORG,
+			electronTrpc: makeElectronTrpc(env),
+			hostService: makeHostService(env),
+			collections: makeCollections(),
+		});
+
+		expect(summary.projectsCreated).toBe(0);
+		expect(summary.projectsLinked).toBe(0);
+		expect(summary.workspacesCreated).toBe(0);
+		expect(summary.errors).toHaveLength(0);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/migrate.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/migrate.ts
@@ -1,0 +1,333 @@
+import type { HostServiceClient } from "renderer/lib/host-service-client";
+import type { electronTrpcClient } from "renderer/lib/trpc-client";
+import type { OrgCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider/collections";
+import { writeV2SidebarState } from "./writeSidebarState";
+
+type ElectronTrpcClient = typeof electronTrpcClient;
+
+export type ProjectStatus = "created" | "linked" | "error";
+export type WorkspaceStatus = "adopted" | "skipped" | "error";
+
+export interface ProjectEntry {
+	name: string;
+	status: ProjectStatus;
+	reason?: string;
+}
+
+export interface WorkspaceEntry {
+	name: string;
+	branch: string;
+	status: WorkspaceStatus;
+	reason?: string;
+}
+
+export interface MigrationSummary {
+	projectsCreated: number;
+	projectsLinked: number;
+	projectsErrored: number;
+	workspacesCreated: number;
+	workspacesSkipped: number;
+	workspacesErrored: number;
+	projects: ProjectEntry[];
+	workspaces: WorkspaceEntry[];
+	errors: Array<{
+		kind: "project" | "workspace";
+		name: string;
+		message: string;
+	}>;
+}
+
+const emptySummary = (): MigrationSummary => ({
+	projectsCreated: 0,
+	projectsLinked: 0,
+	projectsErrored: 0,
+	workspacesCreated: 0,
+	workspacesSkipped: 0,
+	workspacesErrored: 0,
+	projects: [],
+	workspaces: [],
+	errors: [],
+});
+
+function trpcCode(err: unknown): string | null {
+	if (typeof err !== "object" || err === null) return null;
+	const data = (err as { data?: unknown }).data;
+	if (typeof data !== "object" || data === null) return null;
+	const code = (data as { code?: unknown }).code;
+	return typeof code === "string" ? code : null;
+}
+
+function errorMessage(err: unknown): string {
+	if (err instanceof Error) return err.message;
+	return String(err);
+}
+
+interface Args {
+	organizationId: string;
+	electronTrpc: ElectronTrpcClient;
+	hostService: HostServiceClient;
+	collections: OrgCollections;
+}
+
+export async function migrateV1DataToV2(args: Args): Promise<MigrationSummary> {
+	const { organizationId, electronTrpc, hostService, collections } = args;
+	const summary = emptySummary();
+
+	const [
+		v1Projects,
+		v1Workspaces,
+		v1Worktrees,
+		v1Sections,
+		existingState,
+		otherOrg,
+	] = await Promise.all([
+		electronTrpc.migration.readV1Projects.query(),
+		electronTrpc.migration.readV1Workspaces.query(),
+		electronTrpc.migration.readV1Worktrees.query(),
+		electronTrpc.migration.readV1WorkspaceSections.query(),
+		electronTrpc.migration.listState.query({ organizationId }),
+		electronTrpc.migration.findMigrationByOtherOrg.query({ organizationId }),
+	]);
+
+	if (otherOrg) {
+		throw new Error(
+			`v1 data has already been migrated to organization ${otherOrg}. ` +
+				"Contact support if you need to migrate to a different organization.",
+		);
+	}
+
+	const stateByKey = new Map<string, (typeof existingState)[number]>();
+	for (const row of existingState) {
+		stateByKey.set(`${row.kind}:${row.v1Id}`, row);
+	}
+
+	const worktreesById = new Map<string, (typeof v1Worktrees)[number]>();
+	for (const wt of v1Worktrees) worktreesById.set(wt.id, wt);
+
+	const projectV1ToV2 = new Map<string, string>();
+	for (const row of existingState) {
+		if (row.kind === "project" && row.v2Id) {
+			projectV1ToV2.set(row.v1Id, row.v2Id);
+		}
+	}
+
+	const workspaceV1ToV2 = new Map<string, string>();
+	for (const row of existingState) {
+		if (row.kind === "workspace" && row.v2Id && row.status === "success") {
+			workspaceV1ToV2.set(row.v1Id, row.v2Id);
+		}
+	}
+
+	for (const project of v1Projects) {
+		const key = `project:${project.id}`;
+		const existing = stateByKey.get(key);
+		if (existing && existing.status !== "error") {
+			continue;
+		}
+
+		try {
+			const found = await hostService.project.findByPath.query({
+				repoPath: project.mainRepoPath,
+			});
+
+			let v2ProjectId: string;
+			let status: "success" | "linked";
+
+			if (found.candidates.length > 0) {
+				const candidate = found.candidates[0];
+				if (!candidate) throw new Error("findByPath returned empty candidate");
+				v2ProjectId = candidate.id;
+				status = "linked";
+				try {
+					await hostService.project.setup.mutate({
+						projectId: candidate.id,
+						mode: { kind: "import", repoPath: project.mainRepoPath },
+					});
+				} catch (err) {
+					if (trpcCode(err) !== "CONFLICT") throw err;
+				}
+			} else {
+				const created = await hostService.project.create.mutate({
+					name: project.name,
+					mode: {
+						kind: "importLocal",
+						repoPath: project.mainRepoPath,
+					},
+				});
+				v2ProjectId = created.projectId;
+				status = "success";
+			}
+
+			projectV1ToV2.set(project.id, v2ProjectId);
+			await electronTrpc.migration.upsertState.mutate({
+				v1Id: project.id,
+				kind: "project",
+				v2Id: v2ProjectId,
+				organizationId,
+				status,
+				reason: null,
+			});
+			if (status === "success") {
+				summary.projectsCreated += 1;
+				summary.projects.push({ name: project.name, status: "created" });
+			} else {
+				summary.projectsLinked += 1;
+				summary.projects.push({ name: project.name, status: "linked" });
+			}
+		} catch (err) {
+			const message = errorMessage(err);
+			await electronTrpc.migration.upsertState.mutate({
+				v1Id: project.id,
+				kind: "project",
+				v2Id: null,
+				organizationId,
+				status: "error",
+				reason: message,
+			});
+			summary.projectsErrored += 1;
+			summary.projects.push({
+				name: project.name,
+				status: "error",
+				reason: message,
+			});
+			summary.errors.push({
+				kind: "project",
+				name: project.name,
+				message,
+			});
+			console.error("[v1-migration] project failed", project.name, err);
+		}
+	}
+
+	for (const workspace of v1Workspaces) {
+		const key = `workspace:${workspace.id}`;
+		const existing = stateByKey.get(key);
+		if (existing && existing.status !== "error") {
+			continue;
+		}
+
+		const v2ProjectId = projectV1ToV2.get(workspace.projectId);
+		if (!v2ProjectId) {
+			await electronTrpc.migration.upsertState.mutate({
+				v1Id: workspace.id,
+				kind: "workspace",
+				v2Id: null,
+				organizationId,
+				status: "skipped",
+				reason: "parent_project_unresolved",
+			});
+			summary.workspacesSkipped += 1;
+			summary.workspaces.push({
+				name: workspace.name,
+				branch: workspace.branch,
+				status: "skipped",
+				reason: "parent project did not migrate",
+			});
+			continue;
+		}
+
+		if (workspace.type === "worktree") {
+			if (!workspace.worktreeId || !worktreesById.has(workspace.worktreeId)) {
+				await electronTrpc.migration.upsertState.mutate({
+					v1Id: workspace.id,
+					kind: "workspace",
+					v2Id: null,
+					organizationId,
+					status: "skipped",
+					reason: "orphan_worktree",
+				});
+				summary.workspacesSkipped += 1;
+				summary.workspaces.push({
+					name: workspace.name,
+					branch: workspace.branch,
+					status: "skipped",
+					reason: "worktree record missing",
+				});
+				continue;
+			}
+		}
+
+		const v1WorktreePath = workspace.worktreeId
+			? worktreesById.get(workspace.worktreeId)?.path
+			: undefined;
+
+		try {
+			const result = await hostService.workspaceCreation.adopt.mutate({
+				projectId: v2ProjectId,
+				workspaceName: workspace.name,
+				branch: workspace.branch,
+				worktreePath: v1WorktreePath,
+			});
+			await electronTrpc.migration.upsertState.mutate({
+				v1Id: workspace.id,
+				kind: "workspace",
+				v2Id: result.workspace.id,
+				organizationId,
+				status: "success",
+				reason: null,
+			});
+			workspaceV1ToV2.set(workspace.id, result.workspace.id);
+			summary.workspacesCreated += 1;
+			summary.workspaces.push({
+				name: workspace.name,
+				branch: workspace.branch,
+				status: "adopted",
+			});
+		} catch (err) {
+			if (trpcCode(err) === "NOT_FOUND") {
+				await electronTrpc.migration.upsertState.mutate({
+					v1Id: workspace.id,
+					kind: "workspace",
+					v2Id: null,
+					organizationId,
+					status: "skipped",
+					reason: "worktree_not_registered",
+				});
+				summary.workspacesSkipped += 1;
+				summary.workspaces.push({
+					name: workspace.name,
+					branch: workspace.branch,
+					status: "skipped",
+					reason: "worktree no longer exists",
+				});
+				continue;
+			}
+			const message = errorMessage(err);
+			await electronTrpc.migration.upsertState.mutate({
+				v1Id: workspace.id,
+				kind: "workspace",
+				v2Id: null,
+				organizationId,
+				status: "error",
+				reason: message,
+			});
+			summary.workspacesErrored += 1;
+			summary.workspaces.push({
+				name: workspace.name,
+				branch: workspace.branch,
+				status: "error",
+				reason: message,
+			});
+			summary.errors.push({
+				kind: "workspace",
+				name: workspace.name,
+				message,
+			});
+			console.error("[v1-migration] workspace failed", workspace.name, err);
+		}
+	}
+
+	// Translate all sidebar state (project order, sections, workspace order +
+	// section membership) in one pass. Main loop above only handles cloud +
+	// host-service creates and records migration_state; renderer-side
+	// collection writes live entirely in writeV2SidebarState.
+	writeV2SidebarState(collections, {
+		projectV1ToV2,
+		workspaceV1ToV2,
+		v1Projects,
+		v1Sections,
+		v1Workspaces,
+	});
+
+	return summary;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/migrate.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/migrate.ts
@@ -136,6 +136,14 @@ export async function migrateV1DataToV2(args: Args): Promise<MigrationSummary> {
 			if (found.candidates.length > 0) {
 				const candidate = found.candidates[0];
 				if (!candidate) throw new Error("findByPath returned empty candidate");
+				if (found.candidates.length > 1) {
+					// Shouldn't happen — v2 has a unique index on
+					// (organization_id, lower(repo_clone_url)). Log so it's
+					// diagnosable if the constraint ever slips.
+					console.warn(
+						`[v1-migration] findByPath for ${project.mainRepoPath} returned ${found.candidates.length} candidates; linking to first (${candidate.id})`,
+					);
+				}
 				v2ProjectId = candidate.id;
 				status = "linked";
 				try {

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/normalize.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/normalize.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test";
+import { computeNormalizedOrders } from "./normalize";
+
+const project = "p-1";
+
+function workspace(
+	id: string,
+	tabOrder: number,
+	sectionId: string | null = null,
+	projectId: string = project,
+) {
+	return { id, projectId, sectionId, tabOrder };
+}
+
+function section(id: string, tabOrder: number, projectId: string = project) {
+	return { id, projectId, tabOrder };
+}
+
+describe("computeNormalizedOrders", () => {
+	test("empty input returns empty maps", () => {
+		const result = computeNormalizedOrders({ workspaces: [], sections: [] });
+		expect(result.workspaceTabOrder.size).toBe(0);
+		expect(result.sectionTabOrder.size).toBe(0);
+	});
+
+	test("top-level workspaces only — preserve relative order", () => {
+		const { workspaceTabOrder } = computeNormalizedOrders({
+			workspaces: [workspace("a", 5), workspace("b", 2), workspace("c", 9)],
+			sections: [],
+		});
+		expect(workspaceTabOrder.get("b")).toBe(0);
+		expect(workspaceTabOrder.get("a")).toBe(1);
+		expect(workspaceTabOrder.get("c")).toBe(2);
+	});
+
+	test("sections only — preserve relative order", () => {
+		const { sectionTabOrder } = computeNormalizedOrders({
+			workspaces: [],
+			sections: [section("s1", 10), section("s2", 3)],
+		});
+		expect(sectionTabOrder.get("s2")).toBe(0);
+		expect(sectionTabOrder.get("s1")).toBe(1);
+	});
+
+	test("workspaces placed before sections in combined space", () => {
+		const { workspaceTabOrder, sectionTabOrder } = computeNormalizedOrders({
+			workspaces: [workspace("a", 0), workspace("b", 1)],
+			sections: [section("s1", 2)],
+		});
+		expect(workspaceTabOrder.get("a")).toBe(0);
+		expect(workspaceTabOrder.get("b")).toBe(1);
+		expect(sectionTabOrder.get("s1")).toBe(2);
+	});
+
+	test("interleaved v1 layout flattens to workspaces-then-sections", () => {
+		// v1: [Section A (0), Workspace X (1), Section B (2), Workspace Y (3)]
+		const { workspaceTabOrder, sectionTabOrder } = computeNormalizedOrders({
+			workspaces: [workspace("X", 1), workspace("Y", 3)],
+			sections: [section("A", 0), section("B", 2)],
+		});
+		// Top-level workspaces first: X (was 1), Y (was 3) → 0, 1
+		expect(workspaceTabOrder.get("X")).toBe(0);
+		expect(workspaceTabOrder.get("Y")).toBe(1);
+		// Sections after: A (was 0), B (was 2) → 2, 3
+		expect(sectionTabOrder.get("A")).toBe(2);
+		expect(sectionTabOrder.get("B")).toBe(3);
+	});
+
+	test("workspaces inside a section keep within-section order", () => {
+		const { workspaceTabOrder } = computeNormalizedOrders({
+			workspaces: [
+				workspace("inner-a", 5, "sec-1"),
+				workspace("inner-b", 1, "sec-1"),
+				workspace("inner-c", 3, "sec-1"),
+			],
+			sections: [section("sec-1", 0)],
+		});
+		expect(workspaceTabOrder.get("inner-b")).toBe(0);
+		expect(workspaceTabOrder.get("inner-c")).toBe(1);
+		expect(workspaceTabOrder.get("inner-a")).toBe(2);
+	});
+
+	test("mixed top-level + in-section workspaces are independent", () => {
+		const { workspaceTabOrder, sectionTabOrder } = computeNormalizedOrders({
+			workspaces: [
+				workspace("top-1", 0),
+				workspace("top-2", 1),
+				workspace("in-a", 7, "sec-1"),
+				workspace("in-b", 2, "sec-1"),
+			],
+			sections: [section("sec-1", 5)],
+		});
+		// Top-level: top-1=0, top-2=1
+		expect(workspaceTabOrder.get("top-1")).toBe(0);
+		expect(workspaceTabOrder.get("top-2")).toBe(1);
+		// Section tabOrder = 2 (after the 2 top-level workspaces)
+		expect(sectionTabOrder.get("sec-1")).toBe(2);
+		// In-section: in-b (v1 tabOrder=2) before in-a (v1 tabOrder=7)
+		expect(workspaceTabOrder.get("in-b")).toBe(0);
+		expect(workspaceTabOrder.get("in-a")).toBe(1);
+	});
+
+	test("multiple projects are independent", () => {
+		const { workspaceTabOrder, sectionTabOrder } = computeNormalizedOrders({
+			workspaces: [
+				workspace("p1-w1", 0, null, "p1"),
+				workspace("p2-w1", 0, null, "p2"),
+			],
+			sections: [section("p1-sec", 1, "p1"), section("p2-sec", 1, "p2")],
+		});
+		expect(workspaceTabOrder.get("p1-w1")).toBe(0);
+		expect(sectionTabOrder.get("p1-sec")).toBe(1);
+		expect(workspaceTabOrder.get("p2-w1")).toBe(0);
+		expect(sectionTabOrder.get("p2-sec")).toBe(1);
+	});
+
+	test("sparse/gapped v1 values still produce contiguous output", () => {
+		const { workspaceTabOrder, sectionTabOrder } = computeNormalizedOrders({
+			workspaces: [workspace("a", 0), workspace("b", 100), workspace("c", 250)],
+			sections: [section("s1", 500)],
+		});
+		expect(workspaceTabOrder.get("a")).toBe(0);
+		expect(workspaceTabOrder.get("b")).toBe(1);
+		expect(workspaceTabOrder.get("c")).toBe(2);
+		expect(sectionTabOrder.get("s1")).toBe(3);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/normalize.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/normalize.ts
@@ -1,0 +1,79 @@
+/**
+ * v1 → v2 sidebar order translation.
+ *
+ * v1 allowed arbitrary interleaving of top-level workspaces and sections.
+ * v2 doesn't — if a top-level workspace appears after a section in sort
+ * order, v2's render absorbs it into that section's display group
+ * (useDashboardSidebarData.ts:343-357). A direct copy of v1 tab_order
+ * values would surprise users whose v1 layout had post-section orphans.
+ *
+ * Translation: put all top-level workspaces first (in their original
+ * v1 order), then sections (in their original v1 order). Preserves
+ * relative ordering within each group; sacrifices interleaving (which
+ * v2 can't express anyway). Workspaces inside a section keep their
+ * within-section order.
+ */
+export interface V1TabOrderInput {
+	workspaces: Array<{
+		id: string;
+		projectId: string;
+		sectionId: string | null;
+		tabOrder: number;
+	}>;
+	sections: Array<{ id: string; projectId: string; tabOrder: number }>;
+}
+
+export interface V1TabOrderOutput {
+	workspaceTabOrder: Map<string, number>;
+	sectionTabOrder: Map<string, number>;
+}
+
+export function computeNormalizedOrders(
+	input: V1TabOrderInput,
+): V1TabOrderOutput {
+	const workspaceTabOrder = new Map<string, number>();
+	const sectionTabOrder = new Map<string, number>();
+
+	const projectIds = new Set<string>();
+	for (const w of input.workspaces) projectIds.add(w.projectId);
+	for (const s of input.sections) projectIds.add(s.projectId);
+
+	for (const projectId of projectIds) {
+		const topLevelWorkspaces = input.workspaces
+			.filter((w) => w.projectId === projectId && w.sectionId === null)
+			.sort((a, b) => a.tabOrder - b.tabOrder);
+
+		const sections = input.sections
+			.filter((s) => s.projectId === projectId)
+			.sort((a, b) => a.tabOrder - b.tabOrder);
+
+		topLevelWorkspaces.forEach((w, index) => {
+			workspaceTabOrder.set(w.id, index);
+		});
+
+		sections.forEach((s, index) => {
+			sectionTabOrder.set(s.id, topLevelWorkspaces.length + index);
+		});
+
+		// Workspaces inside sections: keep order relative to their section peers.
+		const workspacesBySection = new Map<
+			string,
+			Array<(typeof input.workspaces)[number]>
+		>();
+		for (const w of input.workspaces) {
+			if (w.projectId !== projectId || w.sectionId === null) continue;
+			const group = workspacesBySection.get(w.sectionId) ?? [];
+			group.push(w);
+			workspacesBySection.set(w.sectionId, group);
+		}
+		for (const [, group] of workspacesBySection) {
+			group
+				.sort((a, b) => a.tabOrder - b.tabOrder)
+				.forEach((w, index) => {
+					workspaceTabOrder.set(w.id, index);
+				});
+		}
+	}
+
+	return { workspaceTabOrder, sectionTabOrder };
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/useMigrateV1DataToV2.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/useMigrateV1DataToV2.ts
@@ -1,0 +1,101 @@
+import { useEffect, useRef } from "react";
+import { env } from "renderer/env.renderer";
+import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
+import { authClient } from "renderer/lib/auth-client";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { electronTrpcClient } from "renderer/lib/trpc-client";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import { MOCK_ORG_ID } from "shared/constants";
+import { type MigrationSummary, migrateV1DataToV2 } from "./migrate";
+
+function getAttemptKey(organizationId: string): string {
+	return `v1-migration-attempted-${organizationId}`;
+}
+
+function getSummaryKey(organizationId: string): string {
+	return `v1-migration-summary-${organizationId}`;
+}
+
+export const V1_MIGRATION_SUMMARY_EVENT = "v1-migration-summary-updated";
+
+function persistSummary(organizationId: string, summary: MigrationSummary) {
+	localStorage.setItem(
+		getSummaryKey(organizationId),
+		JSON.stringify({ summary, createdAt: Date.now() }),
+	);
+	window.dispatchEvent(
+		new CustomEvent(V1_MIGRATION_SUMMARY_EVENT, { detail: { organizationId } }),
+	);
+}
+
+/**
+ * Fires v1→v2 migration once per app launch when the dashboard first mounts
+ * with v2 enabled. Idempotent by design:
+ * - sessionStorage marker dedups within a session (blocks strict-mode double-invoke)
+ * - migration_state in the local DB tracks completed rows; subsequent runs
+ *   skip rows already recorded as success/linked/skipped and retry error rows
+ *
+ * Reruns happen implicitly on app relaunch. No automatic retry timer or online
+ * listener — v2 requires the cloud to be reachable anyway, so a transient
+ * offline error resolves on the next launch.
+ */
+export function useMigrateV1DataToV2() {
+	const { data: session } = authClient.useSession();
+	const { activeHostUrl } = useLocalHostService();
+	const { isV2CloudEnabled } = useIsV2CloudEnabled();
+	const collections = useCollections();
+	const organizationId = env.SKIP_ENV_VALIDATION
+		? MOCK_ORG_ID
+		: (session?.session?.activeOrganizationId ?? null);
+	const attemptedRef = useRef<string | null>(null);
+
+	useEffect(() => {
+		if (!isV2CloudEnabled) return;
+		if (!organizationId || !activeHostUrl) return;
+		if (attemptedRef.current === organizationId) return;
+
+		const attemptKey = getAttemptKey(organizationId);
+		if (sessionStorage.getItem(attemptKey) === "1") {
+			attemptedRef.current = organizationId;
+			return;
+		}
+
+		attemptedRef.current = organizationId;
+		sessionStorage.setItem(attemptKey, "1");
+
+		void (async () => {
+			try {
+				const hostService = getHostServiceClientByUrl(activeHostUrl);
+				const summary = await migrateV1DataToV2({
+					organizationId,
+					electronTrpc: electronTrpcClient,
+					hostService,
+					collections,
+				});
+
+				// Persist summary unconditionally before any early-return paths — it's
+				// an idempotent side effect and must survive strict-mode effect
+				// teardowns that can happen between migration completion and here.
+				const didAnything =
+					summary.projectsCreated +
+						summary.projectsLinked +
+						summary.workspacesCreated >
+					0;
+				if (didAnything) {
+					persistSummary(organizationId, summary);
+				}
+
+				if (summary.errors.length > 0) {
+					console.error("[v1-migration] errors", summary.errors);
+				}
+			} catch (err) {
+				// Clear marker so a relaunch can retry (e.g., transient cloud unreach
+				// before session fully hydrated).
+				sessionStorage.removeItem(attemptKey);
+				attemptedRef.current = null;
+				console.error("[v1-migration] fatal", err);
+			}
+		})();
+	}, [isV2CloudEnabled, organizationId, activeHostUrl, collections]);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/writeSidebarState.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/writeSidebarState.test.ts
@@ -1,0 +1,353 @@
+import { describe, expect, test } from "bun:test";
+import type { OrgCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider/collections";
+import {
+	type SidebarInput,
+	type V1ProjectLike,
+	type V1SectionLike,
+	type V1WorkspaceLike,
+	writeV2SidebarState,
+} from "./writeSidebarState";
+
+interface InMemoryCollection<TValue, TKey extends string = string> {
+	get: (key: TKey) => TValue | undefined;
+	insert: (value: TValue) => void;
+	_values: () => TValue[];
+}
+
+function createCollection<TValue extends Record<string, unknown>>(
+	getKey: (v: TValue) => string,
+): InMemoryCollection<TValue> {
+	const store = new Map<string, TValue>();
+	return {
+		get: (key: string) => store.get(key),
+		insert: (value: TValue) => {
+			store.set(getKey(value), value);
+		},
+		_values: () => Array.from(store.values()),
+	};
+}
+
+function makeCollections() {
+	const v2SidebarProjects = createCollection<{
+		projectId: string;
+		tabOrder: number;
+		defaultOpenInApp: string | null;
+		isCollapsed: boolean;
+		createdAt: Date;
+	}>((v) => v.projectId);
+	const v2SidebarSections = createCollection<{
+		sectionId: string;
+		projectId: string;
+		name: string;
+		tabOrder: number;
+		isCollapsed: boolean;
+		color: string | null;
+		createdAt: Date;
+	}>((v) => v.sectionId);
+	const v2WorkspaceLocalState = createCollection<{
+		workspaceId: string;
+		sidebarState: {
+			projectId: string;
+			tabOrder: number;
+			sectionId: string | null;
+			changesFilter: { kind: string };
+			changesSubtab: string;
+		};
+		paneLayout: unknown;
+		viewedFiles: string[];
+		recentlyViewedFiles: unknown[];
+		createdAt: Date;
+	}>((v) => v.workspaceId);
+
+	const collections = {
+		v2SidebarProjects,
+		v2SidebarSections,
+		v2WorkspaceLocalState,
+	} as unknown as OrgCollections;
+
+	return {
+		collections,
+		v2SidebarProjects,
+		v2SidebarSections,
+		v2WorkspaceLocalState,
+	};
+}
+
+function project(
+	id: string,
+	tabOrder: number | null = 0,
+	defaultApp: string | null = null,
+): V1ProjectLike {
+	return { id, tabOrder, defaultApp };
+}
+
+function section(
+	id: string,
+	projectId: string,
+	tabOrder: number,
+	overrides: Partial<V1SectionLike> = {},
+): V1SectionLike {
+	return {
+		id,
+		projectId,
+		tabOrder,
+		name: `section-${id}`,
+		isCollapsed: false,
+		color: null,
+		...overrides,
+	};
+}
+
+function workspace(
+	id: string,
+	projectId: string,
+	tabOrder: number,
+	sectionId: string | null = null,
+): V1WorkspaceLike {
+	return { id, projectId, tabOrder, sectionId };
+}
+
+function buildInput(partial: Partial<SidebarInput>): SidebarInput {
+	return {
+		projectV1ToV2: partial.projectV1ToV2 ?? new Map(),
+		workspaceV1ToV2: partial.workspaceV1ToV2 ?? new Map(),
+		v1Projects: partial.v1Projects ?? [],
+		v1Sections: partial.v1Sections ?? [],
+		v1Workspaces: partial.v1Workspaces ?? [],
+	};
+}
+
+describe("writeV2SidebarState", () => {
+	test("empty input writes nothing", () => {
+		const c = makeCollections();
+		writeV2SidebarState(c.collections, buildInput({}));
+		expect(c.v2SidebarProjects._values()).toHaveLength(0);
+		expect(c.v2SidebarSections._values()).toHaveLength(0);
+		expect(c.v2WorkspaceLocalState._values()).toHaveLength(0);
+	});
+
+	test("migrated projects get sidebar entries with tabOrder + defaultApp", () => {
+		const c = makeCollections();
+		writeV2SidebarState(
+			c.collections,
+			buildInput({
+				projectV1ToV2: new Map([
+					["v1-p1", "v2-p1"],
+					["v1-p2", "v2-p2"],
+				]),
+				v1Projects: [project("v1-p1", 2, "cursor"), project("v1-p2", 5, null)],
+			}),
+		);
+		const values = c.v2SidebarProjects._values();
+		expect(values).toHaveLength(2);
+		const p1 = values.find((v) => v.projectId === "v2-p1");
+		expect(p1?.tabOrder).toBe(2);
+		expect(p1?.defaultOpenInApp).toBe("cursor");
+		const p2 = values.find((v) => v.projectId === "v2-p2");
+		expect(p2?.tabOrder).toBe(5);
+		expect(p2?.defaultOpenInApp).toBe(null);
+	});
+
+	test("null tabOrder on v1 project falls back to 0", () => {
+		const c = makeCollections();
+		writeV2SidebarState(
+			c.collections,
+			buildInput({
+				projectV1ToV2: new Map([["v1", "v2"]]),
+				v1Projects: [project("v1", null)],
+			}),
+		);
+		expect(c.v2SidebarProjects._values()[0]?.tabOrder).toBe(0);
+	});
+
+	test("empty v1 section under a migrated project still migrates", () => {
+		const c = makeCollections();
+		writeV2SidebarState(
+			c.collections,
+			buildInput({
+				projectV1ToV2: new Map([["v1-p", "v2-p"]]),
+				v1Projects: [project("v1-p")],
+				v1Sections: [
+					section("sec-empty", "v1-p", 0, {
+						name: "Empty Group",
+						color: "#ff0000",
+					}),
+				],
+			}),
+		);
+		const sections = c.v2SidebarSections._values();
+		expect(sections).toHaveLength(1);
+		expect(sections[0]?.name).toBe("Empty Group");
+		expect(sections[0]?.projectId).toBe("v2-p");
+		expect(sections[0]?.color).toBe("#ff0000");
+	});
+
+	test("sections under un-migrated projects are skipped", () => {
+		const c = makeCollections();
+		writeV2SidebarState(
+			c.collections,
+			buildInput({
+				projectV1ToV2: new Map([["v1-p1", "v2-p1"]]),
+				v1Projects: [project("v1-p1")],
+				v1Sections: [
+					section("sec-a", "v1-p1", 0),
+					section("sec-b", "v1-untracked", 0),
+				],
+			}),
+		);
+		const sections = c.v2SidebarSections._values();
+		expect(sections).toHaveLength(1);
+		expect(sections[0]?.projectId).toBe("v2-p1");
+	});
+
+	test("workspace sectionId gets remapped to v2 section uuid", () => {
+		const c = makeCollections();
+		writeV2SidebarState(
+			c.collections,
+			buildInput({
+				projectV1ToV2: new Map([["v1-p", "v2-p"]]),
+				workspaceV1ToV2: new Map([["v1-w", "v2-w"]]),
+				v1Projects: [project("v1-p")],
+				v1Sections: [section("v1-sec", "v1-p", 0)],
+				v1Workspaces: [workspace("v1-w", "v1-p", 0, "v1-sec")],
+			}),
+		);
+		const ws = c.v2WorkspaceLocalState._values()[0];
+		const sec = c.v2SidebarSections._values()[0];
+		expect(ws?.sidebarState.sectionId).toBe(sec?.sectionId ?? "missing");
+		// v2 section id is a fresh UUID, not the v1 id
+		expect(ws?.sidebarState.sectionId).not.toBe("v1-sec");
+	});
+
+	test("workspace pointing to non-existent v1 section ends up at top level", () => {
+		const c = makeCollections();
+		writeV2SidebarState(
+			c.collections,
+			buildInput({
+				projectV1ToV2: new Map([["v1-p", "v2-p"]]),
+				workspaceV1ToV2: new Map([["v1-w", "v2-w"]]),
+				v1Projects: [project("v1-p")],
+				v1Sections: [],
+				v1Workspaces: [workspace("v1-w", "v1-p", 0, "v1-sec-missing")],
+			}),
+		);
+		const ws = c.v2WorkspaceLocalState._values()[0];
+		expect(ws?.sidebarState.sectionId).toBe(null);
+	});
+
+	test("only adopted workspaces (in workspaceV1ToV2) get sidebar entries", () => {
+		const c = makeCollections();
+		writeV2SidebarState(
+			c.collections,
+			buildInput({
+				projectV1ToV2: new Map([["v1-p", "v2-p"]]),
+				workspaceV1ToV2: new Map([["v1-w1", "v2-w1"]]),
+				v1Projects: [project("v1-p")],
+				v1Workspaces: [
+					workspace("v1-w1", "v1-p", 0),
+					workspace("v1-w2", "v1-p", 1), // not adopted
+				],
+			}),
+		);
+		const values = c.v2WorkspaceLocalState._values();
+		expect(values).toHaveLength(1);
+		expect(values[0]?.workspaceId).toBe("v2-w1");
+	});
+
+	test("workspace under un-migrated project is skipped", () => {
+		const c = makeCollections();
+		writeV2SidebarState(
+			c.collections,
+			buildInput({
+				projectV1ToV2: new Map([["v1-p-ok", "v2-p-ok"]]),
+				workspaceV1ToV2: new Map([
+					["v1-w-ok", "v2-w-ok"],
+					["v1-w-orphan", "v2-w-orphan"],
+				]),
+				v1Projects: [project("v1-p-ok"), project("v1-p-missing")],
+				v1Workspaces: [
+					workspace("v1-w-ok", "v1-p-ok", 0),
+					workspace("v1-w-orphan", "v1-p-missing", 0),
+				],
+			}),
+		);
+		const values = c.v2WorkspaceLocalState._values();
+		expect(values).toHaveLength(1);
+		expect(values[0]?.workspaceId).toBe("v2-w-ok");
+	});
+
+	test("tab orders apply the normalization rules", () => {
+		// v1: [Section A (0), Workspace X (1), Section B (2), Workspace Y (3)]
+		const c = makeCollections();
+		writeV2SidebarState(
+			c.collections,
+			buildInput({
+				projectV1ToV2: new Map([["p", "v2-p"]]),
+				workspaceV1ToV2: new Map([
+					["X", "v2-X"],
+					["Y", "v2-Y"],
+				]),
+				v1Projects: [project("p")],
+				v1Sections: [section("A", "p", 0), section("B", "p", 2)],
+				v1Workspaces: [workspace("X", "p", 1), workspace("Y", "p", 3)],
+			}),
+		);
+		const sections = c.v2SidebarSections._values();
+		const workspaces = c.v2WorkspaceLocalState._values();
+		// Top-level workspaces normalize to 0, 1; sections follow at 2, 3.
+		const xState = workspaces.find((w) => w.workspaceId === "v2-X");
+		const yState = workspaces.find((w) => w.workspaceId === "v2-Y");
+		expect(xState?.sidebarState.tabOrder).toBe(0);
+		expect(yState?.sidebarState.tabOrder).toBe(1);
+		const aSec = sections.find((s) => s.name === "section-A");
+		const bSec = sections.find((s) => s.name === "section-B");
+		expect(aSec?.tabOrder).toBe(2);
+		expect(bSec?.tabOrder).toBe(3);
+	});
+
+	test("idempotent: re-running with same input does not duplicate entries", () => {
+		const c = makeCollections();
+		const input = buildInput({
+			projectV1ToV2: new Map([["v1-p", "v2-p"]]),
+			workspaceV1ToV2: new Map([["v1-w", "v2-w"]]),
+			v1Projects: [project("v1-p")],
+			v1Sections: [section("sec", "v1-p", 0)],
+			v1Workspaces: [workspace("v1-w", "v1-p", 0)],
+		});
+		writeV2SidebarState(c.collections, input);
+		writeV2SidebarState(c.collections, input);
+		expect(c.v2SidebarProjects._values()).toHaveLength(1);
+		// Note: section UUID is generated fresh per call; idempotency for sections
+		// relies on the outer migration calling writeV2SidebarState exactly once.
+		// Workspace entries re-use the same workspaceV1ToV2 mapping so they dedup.
+		expect(c.v2WorkspaceLocalState._values()).toHaveLength(1);
+	});
+
+	test("workspaces inside a section preserve within-section order", () => {
+		const c = makeCollections();
+		writeV2SidebarState(
+			c.collections,
+			buildInput({
+				projectV1ToV2: new Map([["p", "v2-p"]]),
+				workspaceV1ToV2: new Map([
+					["w1", "v2-w1"],
+					["w2", "v2-w2"],
+					["w3", "v2-w3"],
+				]),
+				v1Projects: [project("p")],
+				v1Sections: [section("sec", "p", 0)],
+				v1Workspaces: [
+					workspace("w1", "p", 7, "sec"),
+					workspace("w2", "p", 1, "sec"),
+					workspace("w3", "p", 4, "sec"),
+				],
+			}),
+		);
+		const workspaces = c.v2WorkspaceLocalState._values();
+		const byId = new Map(workspaces.map((w) => [w.workspaceId, w]));
+		// w2 (v1 tabOrder=1) should come first, then w3 (4), then w1 (7)
+		expect(byId.get("v2-w2")?.sidebarState.tabOrder).toBe(0);
+		expect(byId.get("v2-w3")?.sidebarState.tabOrder).toBe(1);
+		expect(byId.get("v2-w1")?.sidebarState.tabOrder).toBe(2);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/writeSidebarState.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/writeSidebarState.test.ts
@@ -200,7 +200,7 @@ describe("writeV2SidebarState", () => {
 		expect(sections[0]?.projectId).toBe("v2-p1");
 	});
 
-	test("workspace sectionId gets remapped to v2 section uuid", () => {
+	test("workspace sectionId matches the v2 section id (deterministic from v1)", () => {
 		const c = makeCollections();
 		writeV2SidebarState(
 			c.collections,
@@ -215,8 +215,21 @@ describe("writeV2SidebarState", () => {
 		const ws = c.v2WorkspaceLocalState._values()[0];
 		const sec = c.v2SidebarSections._values()[0];
 		expect(ws?.sidebarState.sectionId).toBe(sec?.sectionId ?? "missing");
-		// v2 section id is a fresh UUID, not the v1 id
-		expect(ws?.sidebarState.sectionId).not.toBe("v1-sec");
+		// Reuses v1 id so reruns don't duplicate sections
+		expect(sec?.sectionId).toBe("v1-sec");
+	});
+
+	test("rerun does not duplicate sections (idempotency)", () => {
+		const c = makeCollections();
+		const input = buildInput({
+			projectV1ToV2: new Map([["v1-p", "v2-p"]]),
+			v1Projects: [project("v1-p")],
+			v1Sections: [section("s1", "v1-p", 0), section("s2", "v1-p", 1)],
+		});
+		writeV2SidebarState(c.collections, input);
+		writeV2SidebarState(c.collections, input);
+		writeV2SidebarState(c.collections, input);
+		expect(c.v2SidebarSections._values()).toHaveLength(2);
 	});
 
 	test("workspace pointing to non-existent v1 section ends up at top level", () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/writeSidebarState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/writeSidebarState.ts
@@ -1,0 +1,143 @@
+import type { WorkspaceState } from "@superset/panes";
+import type { OrgCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider/collections";
+import { computeNormalizedOrders } from "./normalize";
+
+const EMPTY_PANE_LAYOUT = {
+	version: 1,
+	tabs: [],
+	activeTabId: null,
+} satisfies WorkspaceState<unknown>;
+
+/**
+ * v1 project row shape consumed by sidebar translation. Structural so callers
+ * can pass drizzle rows without coupling.
+ */
+export interface V1ProjectLike {
+	id: string;
+	tabOrder: number | null;
+	defaultApp: string | null;
+}
+
+export interface V1SectionLike {
+	id: string;
+	projectId: string;
+	name: string;
+	tabOrder: number;
+	isCollapsed: boolean | null;
+	color: string | null;
+}
+
+export interface V1WorkspaceLike {
+	id: string;
+	projectId: string;
+	sectionId: string | null;
+	tabOrder: number;
+}
+
+export interface SidebarInput {
+	/** v1 project id → v2 project id, for projects that successfully migrated. */
+	projectV1ToV2: Map<string, string>;
+	/** v1 workspace id → v2 workspace id, for workspaces that successfully adopted. */
+	workspaceV1ToV2: Map<string, string>;
+	v1Projects: V1ProjectLike[];
+	v1Sections: V1SectionLike[];
+	v1Workspaces: V1WorkspaceLike[];
+}
+
+/**
+ * Translates v1 sidebar state (project order, sections, workspace order +
+ * section membership) into the three v2 collections that back the dashboard
+ * sidebar. Single entry point so the main migration loop only deals with
+ * cloud/host-service creates; all renderer-side collection writes live here.
+ *
+ * Tab orders are normalized via computeNormalizedOrders so top-level
+ * workspaces always sort before sections in v2 (v2 absorbs post-section
+ * top-level workspaces into the preceding section at render time — see
+ * useDashboardSidebarData.ts:343-357).
+ *
+ * Idempotent: each write checks collection.get(id) first, so rerunning over
+ * an already-populated sidebar is a no-op.
+ */
+export function writeV2SidebarState(
+	collections: OrgCollections,
+	input: SidebarInput,
+): void {
+	const { workspaceTabOrder, sectionTabOrder } = computeNormalizedOrders({
+		workspaces: input.v1Workspaces.map((w) => ({
+			id: w.id,
+			projectId: w.projectId,
+			sectionId: w.sectionId,
+			tabOrder: w.tabOrder,
+		})),
+		sections: input.v1Sections.map((s) => ({
+			id: s.id,
+			projectId: s.projectId,
+			tabOrder: s.tabOrder,
+		})),
+	});
+
+	// 1. Projects: write per-project sidebar meta (pin order + default app).
+	const v1ProjectsById = new Map(input.v1Projects.map((p) => [p.id, p]));
+	for (const [v1ProjectId, v2ProjectId] of input.projectV1ToV2) {
+		if (collections.v2SidebarProjects.get(v2ProjectId)) continue;
+		const v1Project = v1ProjectsById.get(v1ProjectId);
+		collections.v2SidebarProjects.insert({
+			projectId: v2ProjectId,
+			createdAt: new Date(),
+			isCollapsed: false,
+			tabOrder: v1Project?.tabOrder ?? 0,
+			defaultOpenInApp: v1Project?.defaultApp ?? null,
+		});
+	}
+
+	// 2. Sections: create v2 sections for every v1 section under a migrated
+	//    project. Fresh UUIDs per section. Empty sections are preserved —
+	//    v1 supports them as an organizational primitive and the user may
+	//    have intentionally created one ahead of filling it.
+	const sectionV1ToV2 = new Map<string, string>();
+	for (const v1Section of input.v1Sections) {
+		const v2ProjectId = input.projectV1ToV2.get(v1Section.projectId);
+		if (!v2ProjectId) continue;
+		const v2SectionId = crypto.randomUUID();
+		sectionV1ToV2.set(v1Section.id, v2SectionId);
+		if (collections.v2SidebarSections.get(v2SectionId)) continue;
+		collections.v2SidebarSections.insert({
+			sectionId: v2SectionId,
+			projectId: v2ProjectId,
+			name: v1Section.name,
+			createdAt: new Date(),
+			tabOrder: sectionTabOrder.get(v1Section.id) ?? v1Section.tabOrder,
+			isCollapsed: v1Section.isCollapsed ?? false,
+			color: v1Section.color ?? null,
+		});
+	}
+
+	// 3. Workspaces: per-workspace sidebar state (tab order + section
+	//    membership + empty pane layout). Only adopted workspaces are
+	//    included — skipped/errored workspaces have no v2 counterpart.
+	const v1WorkspacesById = new Map(input.v1Workspaces.map((w) => [w.id, w]));
+	for (const [v1WorkspaceId, v2WorkspaceId] of input.workspaceV1ToV2) {
+		if (collections.v2WorkspaceLocalState.get(v2WorkspaceId)) continue;
+		const v1Workspace = v1WorkspacesById.get(v1WorkspaceId);
+		if (!v1Workspace) continue;
+		const v2ProjectId = input.projectV1ToV2.get(v1Workspace.projectId);
+		if (!v2ProjectId) continue;
+		const v2SectionId = v1Workspace.sectionId
+			? (sectionV1ToV2.get(v1Workspace.sectionId) ?? null)
+			: null;
+		collections.v2WorkspaceLocalState.insert({
+			workspaceId: v2WorkspaceId,
+			createdAt: new Date(),
+			sidebarState: {
+				projectId: v2ProjectId,
+				tabOrder: workspaceTabOrder.get(v1WorkspaceId) ?? v1Workspace.tabOrder,
+				sectionId: v2SectionId,
+				changesFilter: { kind: "all" },
+				changesSubtab: "diffs",
+			},
+			paneLayout: EMPTY_PANE_LAYOUT,
+			viewedFiles: [],
+			recentlyViewedFiles: [],
+		});
+	}
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/writeSidebarState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/writeSidebarState.ts
@@ -91,14 +91,16 @@ export function writeV2SidebarState(
 	}
 
 	// 2. Sections: create v2 sections for every v1 section under a migrated
-	//    project. Fresh UUIDs per section. Empty sections are preserved —
-	//    v1 supports them as an organizational primitive and the user may
-	//    have intentionally created one ahead of filling it.
+	//    project. Reuse the v1 section id (already a UUID) as the v2 section
+	//    id — deterministic mapping makes reruns idempotent and lets the
+	//    `get(id)` guard actually dedup. Empty sections are preserved — v1
+	//    supports them as an organizational primitive and the user may have
+	//    intentionally created one ahead of filling it.
 	const sectionV1ToV2 = new Map<string, string>();
 	for (const v1Section of input.v1Sections) {
 		const v2ProjectId = input.projectV1ToV2.get(v1Section.projectId);
 		if (!v2ProjectId) continue;
-		const v2SectionId = crypto.randomUUID();
+		const v2SectionId = v1Section.id;
 		sectionV1ToV2.set(v1Section.id, v2SectionId);
 		if (collections.v2SidebarSections.get(v2SectionId)) continue;
 		collections.v2SidebarSections.insert({

--- a/bun.lock
+++ b/bun.lock
@@ -110,7 +110,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.5.6",
+      "version": "1.5.8",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.43",
         "@ai-sdk/openai": "3.0.36",

--- a/packages/host-service/src/trpc/router/workspace-creation/workspace-creation.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/workspace-creation.ts
@@ -209,6 +209,41 @@ async function listWorktreeBranches(
 	return { worktreeMap, checkedOutBranches };
 }
 
+/**
+ * Check whether a git worktree is registered at `worktreePath` with the given
+ * branch checked out. Used by adopt when the caller provides an explicit path
+ * (e.g. v1→v2 migration) rather than a Superset-managed `.worktrees/<branch>`
+ * path discovered via `listWorktreeBranches`.
+ */
+async function findWorktreeAtPath(
+	git: GitClient,
+	worktreePath: string,
+	expectedBranch: string,
+): Promise<boolean> {
+	const targetPath = resolve(worktreePath);
+	try {
+		const raw = await git.raw(["worktree", "list", "--porcelain"]);
+		let currentPath: string | null = null;
+		for (const line of raw.split("\n")) {
+			if (line.startsWith("worktree ")) {
+				currentPath = line.slice("worktree ".length).trim();
+			} else if (line.startsWith("branch refs/heads/") && currentPath) {
+				if (resolve(currentPath) !== targetPath) continue;
+				const branch = line.slice("branch refs/heads/".length).trim();
+				return branch === expectedBranch;
+			} else if (line === "") {
+				currentPath = null;
+			}
+		}
+	} catch (err) {
+		console.warn(
+			"[workspace-creation] git worktree list failed in findWorktreeAtPath:",
+			err,
+		);
+	}
+	return false;
+}
+
 // Parses `git log -g` to return {branchName: ordinal} where 0 = most recent.
 async function getRecentBranchOrder(
 	git: GitClient,
@@ -1332,6 +1367,12 @@ export const workspaceCreationRouter = router({
 				projectId: z.string(),
 				workspaceName: z.string(),
 				branch: z.string(),
+				// When provided, adopt the worktree at this explicit path instead
+				// of looking one up under <repoPath>/.worktrees/<branch>. Used by
+				// the v1→v2 migration to adopt worktrees at legacy paths (e.g.
+				// ~/.superset/worktrees/...) that aren't under the picker's
+				// Superset-managed prefix.
+				worktreePath: z.string().optional(),
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
@@ -1354,16 +1395,30 @@ export const workspaceCreationRouter = router({
 			}
 
 			const git = await ctx.git(localProject.repoPath);
-			const { worktreeMap } = await listWorktreeBranches(
-				git,
-				localProject.repoPath,
-			);
-			const worktreePath = worktreeMap.get(branch);
-			if (!worktreePath) {
-				throw new TRPCError({
-					code: "NOT_FOUND",
-					message: `No existing worktree for branch "${branch}"`,
-				});
+
+			let worktreePath: string;
+			if (input.worktreePath) {
+				const found = await findWorktreeAtPath(git, input.worktreePath, branch);
+				if (!found) {
+					throw new TRPCError({
+						code: "NOT_FOUND",
+						message: `No git worktree registered at "${input.worktreePath}" on branch "${branch}"`,
+					});
+				}
+				worktreePath = input.worktreePath;
+			} else {
+				const { worktreeMap } = await listWorktreeBranches(
+					git,
+					localProject.repoPath,
+				);
+				const found = worktreeMap.get(branch);
+				if (!found) {
+					throw new TRPCError({
+						code: "NOT_FOUND",
+						message: `No existing worktree for branch "${branch}"`,
+					});
+				}
+				worktreePath = found;
 			}
 
 			// We used to short-circuit on an existing local `workspaces` row

--- a/packages/local-db/drizzle/0041_v1_migration_state.sql
+++ b/packages/local-db/drizzle/0041_v1_migration_state.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `v1_migration_state` (
+	`v1_id` text NOT NULL,
+	`kind` text NOT NULL,
+	`v2_id` text,
+	`organization_id` text NOT NULL,
+	`status` text NOT NULL,
+	`reason` text,
+	`migrated_at` integer NOT NULL,
+	PRIMARY KEY(`v1_id`, `kind`)
+);
+--> statement-breakpoint
+CREATE INDEX `v1_migration_state_v2_id_idx` ON `v1_migration_state` (`v2_id`);--> statement-breakpoint
+CREATE INDEX `v1_migration_state_organization_id_idx` ON `v1_migration_state` (`organization_id`);

--- a/packages/local-db/drizzle/0041_v1_migration_state.sql
+++ b/packages/local-db/drizzle/0041_v1_migration_state.sql
@@ -6,8 +6,7 @@ CREATE TABLE `v1_migration_state` (
 	`status` text NOT NULL,
 	`reason` text,
 	`migrated_at` integer NOT NULL,
-	PRIMARY KEY(`v1_id`, `kind`)
+	PRIMARY KEY(`organization_id`, `v1_id`, `kind`)
 );
 --> statement-breakpoint
-CREATE INDEX `v1_migration_state_v2_id_idx` ON `v1_migration_state` (`v2_id`);--> statement-breakpoint
-CREATE INDEX `v1_migration_state_organization_id_idx` ON `v1_migration_state` (`organization_id`);
+CREATE INDEX `v1_migration_state_v2_id_idx` ON `v1_migration_state` (`v2_id`);

--- a/packages/local-db/drizzle/meta/0041_snapshot.json
+++ b/packages/local-db/drizzle/meta/0041_snapshot.json
@@ -1,0 +1,1493 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a0dc640e-ec2b-4a4d-b337-44f1465cbde4",
+  "prevId": "ecc4c8b8-883e-4e25-8ae4-d4d6298d1030",
+  "tables": {
+    "browser_history": {
+      "name": "browser_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_visited_at": {
+          "name": "last_visited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visit_count": {
+          "name": "visit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "browser_history_url_unique": {
+          "name": "browser_history_url_unique",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "browser_history_url_idx": {
+          "name": "browser_history_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": false
+        },
+        "browser_history_last_visited_at_idx": {
+          "name": "browser_history_last_visited_at_idx",
+          "columns": [
+            "last_visited_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_organization_id_idx": {
+          "name": "organization_members_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_user_id_idx": {
+          "name": "organization_members_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_users_id_fk": {
+          "name": "organization_members_user_id_users_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_org": {
+          "name": "github_org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_clerk_org_id_unique": {
+          "name": "organizations_clerk_org_id_unique",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organizations_slug_idx": {
+          "name": "organizations_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "organizations_clerk_org_id_idx": {
+          "name": "organizations_clerk_org_id_idx",
+          "columns": [
+            "clerk_org_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "main_repo_path": {
+          "name": "main_repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_toast_dismissed": {
+          "name": "config_toast_dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_base_branch": {
+          "name": "workspace_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_owner": {
+          "name": "github_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hide_image": {
+          "name": "hide_image",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "neon_project_id": {
+          "name": "neon_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_app": {
+          "name": "default_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_main_repo_path_idx": {
+          "name": "projects_main_repo_path_idx",
+          "columns": [
+            "main_repo_path"
+          ],
+          "isUnique": false
+        },
+        "projects_last_opened_at_idx": {
+          "name": "projects_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_active_workspace_id": {
+          "name": "last_active_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets": {
+          "name": "terminal_presets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_presets_initialized": {
+          "name": "terminal_presets_initialized",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_preset_overrides": {
+          "name": "agent_preset_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_custom_definitions": {
+          "name": "agent_custom_definitions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_preset_permissions_migrated_at": {
+          "name": "agent_preset_permissions_migrated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_ringtone_id": {
+          "name": "selected_ringtone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirm_on_quit": {
+          "name": "confirm_on_quit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_link_behavior": {
+          "name": "terminal_link_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "persist_terminal": {
+          "name": "persist_terminal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_apply_default_preset": {
+          "name": "auto_apply_default_preset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_sounds_muted": {
+          "name": "notification_sounds_muted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_volume": {
+          "name": "notification_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delete_local_branch": {
+          "name": "delete_local_branch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_open_mode": {
+          "name": "file_open_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_presets_bar": {
+          "name": "show_presets_bar",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_compact_terminal_add_button": {
+          "name": "use_compact_terminal_add_button",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_family": {
+          "name": "terminal_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_font_size": {
+          "name": "terminal_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_family": {
+          "name": "editor_font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_font_size": {
+          "name": "editor_font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_resource_monitor": {
+          "name": "show_resource_monitor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "open_links_in_app": {
+          "name": "open_links_in_app",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_editor": {
+          "name": "default_editor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expose_host_service_via_relay": {
+          "name": "expose_host_service_via_relay",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_color": {
+          "name": "status_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_type": {
+          "name": "status_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_position": {
+          "name": "status_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "estimate": {
+          "name": "estimate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_provider": {
+          "name": "external_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tasks_slug_unique": {
+          "name": "tasks_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "tasks_slug_idx": {
+          "name": "tasks_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "tasks_organization_id_idx": {
+          "name": "tasks_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_assignee_id_idx": {
+          "name": "tasks_assignee_id_idx",
+          "columns": [
+            "assignee_id"
+          ],
+          "isUnique": false
+        },
+        "tasks_status_idx": {
+          "name": "tasks_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "tasks_created_at_idx": {
+          "name": "tasks_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_organization_id_organizations_id_fk": {
+          "name": "tasks_organization_id_organizations_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_assignee_id_users_id_fk": {
+          "name": "tasks_assignee_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tasks_creator_id_users_id_fk": {
+          "name": "tasks_creator_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": true
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "users_clerk_id_idx": {
+          "name": "users_clerk_id_idx",
+          "columns": [
+            "clerk_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "v1_migration_state": {
+      "name": "v1_migration_state",
+      "columns": {
+        "v1_id": {
+          "name": "v1_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "v2_id": {
+          "name": "v2_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "migrated_at": {
+          "name": "migrated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "v1_migration_state_v2_id_idx": {
+          "name": "v1_migration_state_v2_id_idx",
+          "columns": [
+            "v2_id"
+          ],
+          "isUnique": false
+        },
+        "v1_migration_state_organization_id_idx": {
+          "name": "v1_migration_state_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "v1_migration_state_v1_id_kind_pk": {
+          "columns": [
+            "v1_id",
+            "kind"
+          ],
+          "name": "v1_migration_state_v1_id_kind_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_sections": {
+      "name": "workspace_sections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_collapsed": {
+          "name": "is_collapsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspace_sections_project_id_idx": {
+          "name": "workspace_sections_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_sections_project_id_projects_id_fk": {
+          "name": "workspace_sections_project_id_projects_id_fk",
+          "tableFrom": "workspace_sections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_id": {
+          "name": "worktree_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_unread": {
+          "name": "is_unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_unnamed": {
+          "name": "is_unnamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "deleting_at": {
+          "name": "deleting_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "port_base": {
+          "name": "port_base",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_project_id_idx": {
+          "name": "workspaces_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_worktree_id_idx": {
+          "name": "workspaces_worktree_id_idx",
+          "columns": [
+            "worktree_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_last_opened_at_idx": {
+          "name": "workspaces_last_opened_at_idx",
+          "columns": [
+            "last_opened_at"
+          ],
+          "isUnique": false
+        },
+        "workspaces_section_id_idx": {
+          "name": "workspaces_section_id_idx",
+          "columns": [
+            "section_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspaces_project_id_projects_id_fk": {
+          "name": "workspaces_project_id_projects_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_worktree_id_worktrees_id_fk": {
+          "name": "workspaces_worktree_id_worktrees_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "worktrees",
+          "columnsFrom": [
+            "worktree_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_section_id_workspace_sections_id_fk": {
+          "name": "workspaces_section_id_workspace_sections_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "workspace_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "worktrees": {
+      "name": "worktrees",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_status": {
+          "name": "git_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_status": {
+          "name": "github_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_superset": {
+          "name": "created_by_superset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "worktrees_project_id_idx": {
+          "name": "worktrees_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "worktrees_branch_idx": {
+          "name": "worktrees_branch_idx",
+          "columns": [
+            "branch"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "worktrees_project_id_projects_id_fk": {
+          "name": "worktrees_project_id_projects_id_fk",
+          "tableFrom": "worktrees",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/local-db/drizzle/meta/0041_snapshot.json
+++ b/packages/local-db/drizzle/meta/0041_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "a0dc640e-ec2b-4a4d-b337-44f1465cbde4",
+  "id": "3d1d0ce7-6731-4286-970a-304b4e0a1f6a",
   "prevId": "ecc4c8b8-883e-4e25-8ae4-d4d6298d1030",
   "tables": {
     "browser_history": {
@@ -1086,23 +1086,17 @@
             "v2_id"
           ],
           "isUnique": false
-        },
-        "v1_migration_state_organization_id_idx": {
-          "name": "v1_migration_state_organization_id_idx",
-          "columns": [
-            "organization_id"
-          ],
-          "isUnique": false
         }
       },
       "foreignKeys": {},
       "compositePrimaryKeys": {
-        "v1_migration_state_v1_id_kind_pk": {
+        "v1_migration_state_organization_id_v1_id_kind_pk": {
           "columns": [
+            "organization_id",
             "v1_id",
             "kind"
           ],
-          "name": "v1_migration_state_v1_id_kind_pk"
+          "name": "v1_migration_state_organization_id_v1_id_kind_pk"
         }
       },
       "uniqueConstraints": {},

--- a/packages/local-db/drizzle/meta/_journal.json
+++ b/packages/local-db/drizzle/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1776796221146,
       "tag": "0040_agent_preset_permissions_migrated_at",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "6",
+      "when": 1776919645407,
+      "tag": "0041_v1_migration_state",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/local-db/drizzle/meta/_journal.json
+++ b/packages/local-db/drizzle/meta/_journal.json
@@ -292,7 +292,7 @@
     {
       "idx": 41,
       "version": "6",
-      "when": 1776919645407,
+      "when": 1776928440569,
       "tag": "0041_v1_migration_state",
       "breakpoints": true
     }

--- a/packages/local-db/src/schema/schema.ts
+++ b/packages/local-db/src/schema/schema.ts
@@ -1,4 +1,10 @@
-import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import {
+	index,
+	integer,
+	primaryKey,
+	sqliteTable,
+	text,
+} from "drizzle-orm/sqlite-core";
 import { v4 as uuidv4 } from "uuid";
 
 import type {
@@ -232,6 +238,32 @@ export const settings = sqliteTable("settings", {
 
 export type InsertSettings = typeof settings.$inferInsert;
 export type SelectSettings = typeof settings.$inferSelect;
+
+export type V1MigrationKind = "project" | "workspace";
+export type V1MigrationStatus = "success" | "linked" | "error" | "skipped";
+
+export const v1MigrationState = sqliteTable(
+	"v1_migration_state",
+	{
+		v1Id: text("v1_id").notNull(),
+		kind: text("kind").notNull().$type<V1MigrationKind>(),
+		v2Id: text("v2_id"),
+		organizationId: text("organization_id").notNull(),
+		status: text("status").notNull().$type<V1MigrationStatus>(),
+		reason: text("reason"),
+		migratedAt: integer("migrated_at")
+			.notNull()
+			.$defaultFn(() => Date.now()),
+	},
+	(table) => [
+		primaryKey({ columns: [table.v1Id, table.kind] }),
+		index("v1_migration_state_v2_id_idx").on(table.v2Id),
+		index("v1_migration_state_organization_id_idx").on(table.organizationId),
+	],
+);
+
+export type InsertV1MigrationState = typeof v1MigrationState.$inferInsert;
+export type SelectV1MigrationState = typeof v1MigrationState.$inferSelect;
 
 // =============================================================================
 // Synced tables - mirrored from cloud Postgres via Electric SQL

--- a/packages/local-db/src/schema/schema.ts
+++ b/packages/local-db/src/schema/schema.ts
@@ -256,9 +256,10 @@ export const v1MigrationState = sqliteTable(
 			.$defaultFn(() => Date.now()),
 	},
 	(table) => [
-		primaryKey({ columns: [table.v1Id, table.kind] }),
+		primaryKey({
+			columns: [table.organizationId, table.v1Id, table.kind],
+		}),
 		index("v1_migration_state_v2_id_idx").on(table.v2Id),
-		index("v1_migration_state_organization_id_idx").on(table.organizationId),
 	],
 );
 


### PR DESCRIPTION
## Summary

First-time v2 launch now migrates the user's v1 local data into v2 cloud + local stores and shows a branded summary modal.

**Migrated:**
- **Projects** (pinned only, `tab_order IS NOT NULL`) — dedup via GitHub remote (`v2Project.findByGitHubRemote`), then either link to existing v2 project or create new. Host-service registration handled via `project.create importLocal` / `project.setup import`.
- **Workspaces** (excluding v1 rows with `deleting_at` set) — adopted into v2 via a new `worktreePath` argument on `workspaceCreation.adopt`, so legacy v1 worktree paths (`~/.superset/worktrees/...`) work in addition to v2's `.worktrees/` convention.
- **Sections** — all v1 `workspace_sections` under a migrated project, fresh UUIDs, empty sections preserved.
- **Sidebar order** — project pin order + workspace/section ordering, normalized to v2's model (top-level workspaces before sections to avoid v2's post-section visual absorption).
- **Per-project default app** — `projects.default_app` → `v2SidebarProjects.defaultOpenInApp`.

**Architecture:**
- Renderer-side orchestrator (`useMigrateV1DataToV2` hook) — follows the `useMigrateV1PresetsToV2` precedent since PGlite sidebar collections are localStorage-only.
- New `migration` tRPC router on the main process for v1 reads + migration_state CRUD.
- Single `writeV2SidebarState` function owns all sidebar collection writes; the main orchestrator only does cloud + host-service calls.
- New `v1_migration_state` table in `packages/local-db` (migration `0041`) tracks per-row outcome for idempotent reruns.
- Branded `V1MigrationSummaryModal` shows counts + expandable per-row breakdown on first-run only. Non-dismissable (must click "Got it"), persisted via localStorage + custom event.

**Tab-order translation:** v2 doesn't support interleaving sections and top-level workspaces at arbitrary positions (post-section workspaces get visually absorbed). Migration normalizes v1 layouts to `[top-level workspaces] → [sections]` with relative order preserved within each group.

**Followups tracked:**
- [SUPER-469](https://linear.app/superset-sh/issue/SUPER-469) — v2 `workspace_base_branch` setting
- [SUPER-470](https://linear.app/superset-sh/issue/SUPER-470) — v2 branch prefix mode
- [SUPER-471](https://linear.app/superset-sh/issue/SUPER-471) — phase-2 settings migration (agent presets etc.)
- Implementation plan: `apps/desktop/plans/20260422-2100-v1-to-v2-port.md`

## Test plan

- [x] Lint + typecheck green
- [x] Unit tests (32 passing): normalize, writeSidebarState, migrate orchestrator
- [ ] Fresh v2 launch with real v1 data → modal appears, counts match
- [ ] Dismiss via "Got it" → modal goes away, doesn't reappear on next launch
- [ ] Rerun with all-already-migrated state → no modal, no duplicate cloud rows
- [ ] Rerun after manually clearing one project's state → only that project re-migrates
- [ ] Verify adopted workspaces open cleanly in v2 sidebar
- [ ] Verify sections + per-project order preserved in v2 sidebar

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
On first v2 launch, migrate v1 pinned projects and workspaces into v2 cloud and local stores, preserve sections and sidebar order, and show a one-time summary modal. Migration is idempotent, dedupes projects by GitHub remote, and tracks state per org.

- **New Features**
  - Migrate v1 data: pinned projects (link-or-create via GitHub remote), non-deleted workspaces, sections (reuse v1 section IDs), and per-project default app.
  - Adopt legacy worktrees using a new `worktreePath` on `workspaceCreation.adopt` (supports v1 paths and v2 `.worktrees/`).
  - Normalize sidebar order to `[top-level workspaces] → [sections]`, preserving relative order within each group.
  - Add main-process `migration` tRPC router for v1 reads and state CRUD, a renderer orchestrator `useMigrateV1DataToV2`, and a single `writeV2SidebarState` writer for sidebar collections.
  - Add `v1_migration_state` table in `packages/local-db` for idempotent reruns; show results in `V1MigrationSummaryModal` on first run only.

- **Bug Fixes**
  - Scope `v1_migration_state` primary key to `(organization_id, v1_id, kind)` for per-org idempotence.
  - Reuse v1 section IDs in v2 to prevent duplicates on reruns; add sr-only dialog title/description and stable list keys in the summary modal; warn when multiple projects match a GitHub remote.

Follow-ups: SUPER-469 (workspace base branch), SUPER-470 (branch prefix mode), SUPER-471 (phase-2 settings).

<sup>Written for commit b77991e03cab76a89d93a253ad4672676a291dd0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Migrate v1 projects and workspaces to v2 with a dashboard-triggered summary modal showing per-item status and errors; successful summaries persist for the org.
  * Projects may be linked to existing v2 projects or created; workspaces can be adopted (with branch/worktree verification) and sidebar ordering/sections are preserved.

* **Tests**
  * Extensive tests covering migration flows, ordering normalization, idempotency, reruns, and error/skip scenarios.

* **Chores**
  * Added persistent migration-state storage and DB schema to track progress and avoid duplicate migrations.
* **Documentation**
  * Added a migration plan/spec describing scope, mappings, and UI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->