### PR TITLE
chore(host-service): bump version to 0.2.0 + raise min version

### DIFF
--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -28,8 +28,15 @@ import {
 import { localDb } from "./local-db";
 import { HOOK_PROTOCOL_VERSION } from "./terminal/env";
 
-/** Minimum host-service version this app can work with. */
-const MIN_HOST_SERVICE_VERSION = "0.1.0";
+/**
+ * Minimum host-service version this app can work with. Bumping this forces
+ * the coordinator to kill + respawn any adopted service older than this,
+ * which is how we prevent the renderer from talking to a stale host-service
+ * that's missing newly-added procedures/params.
+ *
+ * 0.2.0: `workspaceCreation.adopt` gained optional `worktreePath`.
+ */
+const MIN_HOST_SERVICE_VERSION = "0.2.0";
 
 export type HostServiceStatus = "starting" | "running" | "stopped";
 

--- a/packages/host-service/src/trpc/router/host/host.ts
+++ b/packages/host-service/src/trpc/router/host/host.ts
@@ -4,7 +4,11 @@ import { TRPCError } from "@trpc/server";
 import type { ApiClient } from "../../../types";
 import { protectedProcedure, router } from "../../index";
 
-const HOST_SERVICE_VERSION = "0.1.0";
+// 0.2.0: `workspaceCreation.adopt` accepts optional `worktreePath` for
+// adopting worktrees at arbitrary paths (not just <repoPath>/.worktrees/).
+// The v1→v2 migration depends on this to adopt legacy ~/.superset/worktrees
+// paths. Clients using the new param must refuse to adopt an older service.
+const HOST_SERVICE_VERSION = "0.2.0";
 const ORGANIZATION_CACHE_TTL_MS = 60 * 60 * 1000;
 
 let cachedOrganization: {


### PR DESCRIPTION
## Summary

Bumps \`HOST_SERVICE_VERSION\` and \`MIN_HOST_SERVICE_VERSION\` to \`0.2.0\`. Forces the desktop coordinator to kill any adopted host-service older than 0.2.0 and respawn from the current app bundle.

## Why

When a user updates their Superset app, the new binary's renderer can end up talking to an older host-service process that was adopted from a shared manifest (\`~/.superset/host/<org>/manifest.json\`). The older service silently strips unknown zod fields, so any newly-added tRPC procedure params land in the old happy-path — causing subtle correctness bugs with no stack trace.

This happened in practice during v1→v2 migration testing: a zombie Superset Canary host-service was adopted by a freshly-built Superset.app and the new \`workspaceCreation.adopt({ worktreePath })\` param was silently dropped, causing all legacy-path worktrees to fail adoption. Covered in detail in #3670 investigation.

## Policy going forward

Bump both constants together any time we add a new tRPC procedure or param to host-service that a matching-version renderer depends on. The guard is cheap (one HTTP ping, one kill + respawn) and eliminates the silent-drop class of bug.

## Test plan

- [x] \`bun run typecheck\` green
- [x] \`bun run lint\` green
- [ ] Manual: install an older Superset build, leave its host-service running, then launch a Superset.app with this change → verify coordinator kills the old process and spawns a fresh one

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise `HOST_SERVICE_VERSION` and `MIN_HOST_SERVICE_VERSION` to 0.2.0. This forces the desktop coordinator to kill any adopted host-service older than 0.2.0 and respawn from the current app bundle, preventing stale services from dropping new tRPC params (e.g., `workspaceCreation.adopt({ worktreePath })`) and ensuring v1→v2 legacy worktree adoption works.

<sup>Written for commit dd4753bdff309fcbf1275cc082051c4a9bcc764c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated host-service version to 0.2.0 with minimum compatibility gating.

* **Documentation**
  * Updated documentation regarding host-service version compatibility requirements and automatic system initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->