### PR TITLE
fix(desktop): use task title as workspace name when opening a task

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/OpenInWorkspace/OpenInWorkspace.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/OpenInWorkspace/OpenInWorkspace.tsx
@@ -121,7 +121,7 @@ export function OpenInWorkspace({ task }: OpenInWorkspaceProps) {
 			const result = await createWorkspace.mutateAsyncWithPendingSetup(
 				{
 					projectId,
-					name: task.slug,
+					name: task.title,
 					branchName,
 				},
 				{ agentLaunchRequest: launchRequestTemplate ?? undefined },

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/RunInWorkspacePopover/RunInWorkspacePopover.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/RunInWorkspacePopover/RunInWorkspacePopover.tsx
@@ -174,7 +174,7 @@ export function RunInWorkspacePopover({
 				const result = await createWorkspace.mutateAsyncWithPendingSetup(
 					{
 						projectId: effectiveProjectId,
-						name: task.slug,
+						name: task.title,
 						branchName,
 					},
 					{ agentLaunchRequest: launchRequestTemplate ?? undefined },


### PR DESCRIPTION
## Summary
- Task→workspace entry points (Properties sidebar "Open in workspace" and bulk "Run in workspace") now set the workspace name to `task.title` instead of `task.slug`, so the sidebar shows e.g. "Fix auth middleware" rather than "SUPER-172".
- Branch names are unchanged — still derived via `deriveBranchName({slug, title})` (e.g. `super-172-fix-auth-middleware`), so the Linear/GitHub identifier stays in the branch for traceability.

## Test plan
- [ ] Open a synced Linear task via the task properties sidebar → new workspace shows the task title in the sidebar, branch still prefixed with the Linear identifier.
- [ ] Bulk-select Linear tasks and use "Run in workspace" → each created workspace uses its task's title.
- [ ] Open a local (non-external) task → workspace name matches its title; branch still prefixed with the local slug.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the task title as the workspace name when opening a task, so users see a human-readable name instead of the slug. Branch names are unchanged and still include the Linear/GitHub identifier via `deriveBranchName({ slug, title })`.

<sup>Written for commit 21e0284dbe8a179016862d992bfece63161ea8f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspaces created when opening tasks now use the full task title instead of the slug, providing more descriptive and user-friendly workspace names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->