### PR TITLE
fix(desktop): fail closed when adopted host-service has no version

### DIFF
--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -38,6 +38,22 @@ import { HOOK_PROTOCOL_VERSION } from "./terminal/env";
  */
 const MIN_HOST_SERVICE_VERSION = "0.2.0";
 
+function isHostServiceVersionSupported(version: string | null): boolean {
+	if (!version) return false;
+	const current = version.split(".").map((n) => Number.parseInt(n, 10));
+	const minimum = MIN_HOST_SERVICE_VERSION.split(".").map((n) =>
+		Number.parseInt(n, 10),
+	);
+	for (let i = 0; i < Math.max(current.length, minimum.length); i++) {
+		const a = current[i] ?? 0;
+		const b = minimum[i] ?? 0;
+		if (!Number.isFinite(a)) return false;
+		if (a > b) return true;
+		if (a < b) return false;
+	}
+	return true;
+}
+
 export type HostServiceStatus = "starting" | "running" | "stopped";
 
 export interface Connection {
@@ -294,11 +310,12 @@ export class HostServiceCoordinator extends EventEmitter {
 			manifest.endpoint,
 			manifest.authToken,
 		);
-		if (!version || version < MIN_HOST_SERVICE_VERSION) {
+		if (!isHostServiceVersionSupported(version)) {
+			const reason = version
+				? `version ${version} < ${MIN_HOST_SERVICE_VERSION}`
+				: "version unknown";
 			console.log(
-				`[host-service:${organizationId}] Adopted service version ${
-					version ?? "unknown"
-				} < ${MIN_HOST_SERVICE_VERSION}, killing`,
+				`[host-service:${organizationId}] Adopted service ${reason}, killing`,
 			);
 			try {
 				process.kill(manifest.pid, "SIGTERM");

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -7,6 +7,7 @@ import { settings } from "@superset/local-db";
 import { getDeviceName, getHashedDeviceId } from "@superset/shared/device-info";
 import { app } from "electron";
 import { env } from "main/env.main";
+import semver from "semver";
 import { env as sharedEnv } from "shared/env.shared";
 import { getProcessEnvWithShellPath } from "../../lib/trpc/routers/workspaces/utils/shell-env";
 import { SUPERSET_HOME_DIR } from "./app-environment";
@@ -39,19 +40,9 @@ import { HOOK_PROTOCOL_VERSION } from "./terminal/env";
 const MIN_HOST_SERVICE_VERSION = "0.2.0";
 
 function isHostServiceVersionSupported(version: string | null): boolean {
-	if (!version) return false;
-	const current = version.split(".").map((n) => Number.parseInt(n, 10));
-	const minimum = MIN_HOST_SERVICE_VERSION.split(".").map((n) =>
-		Number.parseInt(n, 10),
+	return (
+		!!version && semver.satisfies(version, `>=${MIN_HOST_SERVICE_VERSION}`)
 	);
-	for (let i = 0; i < Math.max(current.length, minimum.length); i++) {
-		const a = current[i] ?? 0;
-		const b = minimum[i] ?? 0;
-		if (!Number.isFinite(a)) return false;
-		if (a > b) return true;
-		if (a < b) return false;
-	}
-	return true;
 }
 
 export type HostServiceStatus = "starting" | "running" | "stopped";

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -294,9 +294,11 @@ export class HostServiceCoordinator extends EventEmitter {
 			manifest.endpoint,
 			manifest.authToken,
 		);
-		if (version && version < MIN_HOST_SERVICE_VERSION) {
+		if (!version || version < MIN_HOST_SERVICE_VERSION) {
 			console.log(
-				`[host-service:${organizationId}] Adopted service version ${version} < ${MIN_HOST_SERVICE_VERSION}, killing`,
+				`[host-service:${organizationId}] Adopted service version ${
+					version ?? "unknown"
+				} < ${MIN_HOST_SERVICE_VERSION}, killing`,
 			);
 			try {
 				process.kill(manifest.pid, "SIGTERM");

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -39,12 +39,6 @@ import { HOOK_PROTOCOL_VERSION } from "./terminal/env";
  */
 const MIN_HOST_SERVICE_VERSION = "0.2.0";
 
-function isHostServiceVersionSupported(version: string | null): boolean {
-	return (
-		!!version && semver.satisfies(version, `>=${MIN_HOST_SERVICE_VERSION}`)
-	);
-}
-
 export type HostServiceStatus = "starting" | "running" | "stopped";
 
 export interface Connection {
@@ -301,7 +295,10 @@ export class HostServiceCoordinator extends EventEmitter {
 			manifest.endpoint,
 			manifest.authToken,
 		);
-		if (!isHostServiceVersionSupported(version)) {
+		if (
+			!version ||
+			!semver.satisfies(version, `>=${MIN_HOST_SERVICE_VERSION}`)
+		) {
 			const reason = version
 				? `version ${version} < ${MIN_HOST_SERVICE_VERSION}`
 				: "version unknown";


### PR DESCRIPTION
## Summary
- Version gate only killed adopted hosts when `fetchHostVersion` returned a string below `MIN_HOST_SERVICE_VERSION`. If the host predated `host.info` entirely, the helper returned `null` and we silently kept the stale service, producing 404s on newer routes (`project.findByPath`, etc).
- Flip the guard to fail-closed so any host that can't prove it meets the minimum is killed and its manifest removed; next spawn brings up a compatible service.

## Test plan
- [ ] Start app with a manifest pointing at a pre-`host.info` host-service binary → confirm it gets killed and respawned (log: `Adopted service version unknown < 0.2.0, killing`).
- [ ] Start app with a matching host-service → confirm it adopts cleanly with no respawn.
- [ ] Confirm `project.findByPath` works on a fresh launch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail closed when adopting a host-service that can’t prove it meets the minimum version, preventing 404s on routes like `project.findByPath`.

- **Bug Fixes**
  - Fail-closed adoption: if version is missing or below the minimum (`semver` check), kill the process and remove its manifest so the next spawn is compatible.
  - Logs now show “version unknown” when not reported.

- **Refactors**
  - Use `semver` for version checks; malformed versions are treated as unsupported.
  - Inline the version check to simplify control flow and logging.

<sup>Written for commit 8ec6d077fc9a774a120d487a971a8089bac8661c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host service version handling: reported versions are now validated against the supported range using semantic versioning. Adopted services with missing/unknown versions or versions outside the supported range are terminated and their manifests removed. Termination logs now include a clear reason (e.g., actual version mismatch or "unknown"). Valid services continue to be marked running and monitored for liveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->