### PR TITLE
feat(desktop): v2 Changes file list shift/cmd-click policy

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -23,7 +23,7 @@ export interface PendingReveal {
 
 interface WorkspaceSidebarProps {
 	onSelectFile: (absolutePath: string, openInNewTab?: boolean) => void;
-	onSelectDiffFile?: (path: string) => void;
+	onSelectDiffFile?: (path: string, openInNewTab?: boolean) => void;
 	onOpenComment?: (comment: CommentPaneData) => void;
 	onSearch?: () => void;
 	selectedFilePath?: string;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/WorkspaceFilesTreeItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/WorkspaceFilesTreeItem.tsx
@@ -1,9 +1,11 @@
 import { ContextMenu, ContextMenuTrigger } from "@superset/ui/context-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { memo } from "react";
 import { LuChevronDown, LuChevronRight, LuCircle } from "react-icons/lu";
 import type { FileTreeNode } from "renderer/hooks/host-service/useFileTree";
 import type { FileStatus } from "renderer/hooks/host-service/useGitStatusMap";
+import { CLICK_HINT_TOOLTIP } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/clickModifierLabels";
 import { getSidebarClickIntent } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/getSidebarClickIntent";
 import { FileIcon } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils";
 
@@ -75,83 +77,92 @@ function WorkspaceFilesTreeItemComponent({
 			? STATUS_TEXT_CLASS[decoration]
 			: undefined;
 
+	const rowButton = (
+		<button
+			data-filepath={node.absolutePath}
+			aria-expanded={isFolder ? node.isExpanded : undefined}
+			className={cn(
+				"flex w-full cursor-pointer select-none items-center gap-1 pr-4 text-left transition-colors",
+				isFolder ? "bg-background" : undefined,
+				isHovered && !isSelected
+					? isFolder
+						? "!bg-muted"
+						: "!bg-accent/50"
+					: undefined,
+				isSelected ? "!bg-accent" : undefined,
+			)}
+			onClick={(e) => {
+				const intent = getSidebarClickIntent(e);
+				if (intent === "openInEditor") {
+					onOpenInEditor(node.absolutePath);
+				} else if (isFolder) {
+					onToggleDirectory(node.absolutePath);
+				} else {
+					onSelectFile(node.absolutePath, intent === "openInNewTab");
+				}
+			}}
+			style={{
+				height: rowHeight,
+				paddingLeft: 8 + (depth - 1) * indent,
+				...(isFolder
+					? {
+							position: "sticky" as const,
+							top: (depth - 1) * rowHeight,
+							zIndex: Math.max(1, 50 - depth),
+						}
+					: {}),
+			}}
+			type="button"
+		>
+			<span className="flex h-4 w-4 shrink-0 items-center justify-center">
+				{isFolder ? (
+					node.isExpanded ? (
+						<LuChevronDown className="size-3.5 text-muted-foreground" />
+					) : (
+						<LuChevronRight className="size-3.5 text-muted-foreground" />
+					)
+				) : null}
+			</span>
+
+			<FileIcon
+				className="size-4 shrink-0"
+				fileName={node.name}
+				isDirectory={isFolder}
+				isOpen={node.isExpanded}
+			/>
+
+			<span className={cn("min-w-0 flex-1 truncate text-xs", nameColorClass)}>
+				{node.name}
+			</span>
+
+			{decoration && !isMuted && (
+				<span
+					className={cn(
+						"ml-auto shrink-0 text-[10px] font-semibold leading-none",
+						STATUS_TEXT_CLASS[decoration],
+					)}
+				>
+					{isFolder ? (
+						<LuCircle className="size-2 fill-current opacity-50" />
+					) : (
+						STATUS_LETTER[decoration]
+					)}
+				</span>
+			)}
+		</button>
+	);
+
 	return (
 		<ContextMenu>
 			<ContextMenuTrigger asChild>
-				<button
-					data-filepath={node.absolutePath}
-					aria-expanded={isFolder ? node.isExpanded : undefined}
-					className={cn(
-						"flex w-full cursor-pointer select-none items-center gap-1 pr-4 text-left transition-colors",
-						isFolder ? "bg-background" : undefined,
-						isHovered && !isSelected
-							? isFolder
-								? "!bg-muted"
-								: "!bg-accent/50"
-							: undefined,
-						isSelected ? "!bg-accent" : undefined,
-					)}
-					onClick={(e) => {
-						const intent = getSidebarClickIntent(e);
-						if (intent === "openInEditor") {
-							onOpenInEditor(node.absolutePath);
-						} else if (isFolder) {
-							onToggleDirectory(node.absolutePath);
-						} else {
-							onSelectFile(node.absolutePath, intent === "openInNewTab");
-						}
-					}}
-					style={{
-						height: rowHeight,
-						paddingLeft: 8 + (depth - 1) * indent,
-						...(isFolder
-							? {
-									position: "sticky" as const,
-									top: (depth - 1) * rowHeight,
-									zIndex: Math.max(1, 50 - depth),
-								}
-							: {}),
-					}}
-					type="button"
-				>
-					<span className="flex h-4 w-4 shrink-0 items-center justify-center">
-						{isFolder ? (
-							node.isExpanded ? (
-								<LuChevronDown className="size-3.5 text-muted-foreground" />
-							) : (
-								<LuChevronRight className="size-3.5 text-muted-foreground" />
-							)
-						) : null}
-					</span>
-
-					<FileIcon
-						className="size-4 shrink-0"
-						fileName={node.name}
-						isDirectory={isFolder}
-						isOpen={node.isExpanded}
-					/>
-
-					<span
-						className={cn("min-w-0 flex-1 truncate text-xs", nameColorClass)}
-					>
-						{node.name}
-					</span>
-
-					{decoration && !isMuted && (
-						<span
-							className={cn(
-								"ml-auto shrink-0 text-[10px] font-semibold leading-none",
-								STATUS_TEXT_CLASS[decoration],
-							)}
-						>
-							{isFolder ? (
-								<LuCircle className="size-2 fill-current opacity-50" />
-							) : (
-								STATUS_LETTER[decoration]
-							)}
-						</span>
-					)}
-				</button>
+				{isFolder ? (
+					rowButton
+				) : (
+					<Tooltip>
+						<TooltipTrigger asChild>{rowButton}</TooltipTrigger>
+						<TooltipContent side="right">{CLICK_HINT_TOOLTIP}</TooltipContent>
+					</Tooltip>
+				)}
 			</ContextMenuTrigger>
 			{isFolder ? (
 				<FolderContextMenu
@@ -166,6 +177,9 @@ function WorkspaceFilesTreeItemComponent({
 				<FileContextMenu
 					absolutePath={node.absolutePath}
 					relativePath={node.relativePath}
+					onOpen={() => onSelectFile(node.absolutePath)}
+					onOpenInNewTab={() => onSelectFile(node.absolutePath, true)}
+					onOpenInEditor={() => onOpenInEditor(node.absolutePath)}
 					onRename={() => onRename(node.absolutePath, node.name, false)}
 					onDelete={() => onDelete(node.absolutePath, node.name, false)}
 				/>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/WorkspaceFilesTreeItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/WorkspaceFilesTreeItem.tsx
@@ -93,10 +93,10 @@ function WorkspaceFilesTreeItemComponent({
 			)}
 			onClick={(e) => {
 				const intent = getSidebarClickIntent(e);
-				if (intent === "openInEditor") {
-					onOpenInEditor(node.absolutePath);
-				} else if (isFolder) {
+				if (isFolder) {
 					onToggleDirectory(node.absolutePath);
+				} else if (intent === "openInEditor") {
+					onOpenInEditor(node.absolutePath);
 				} else {
 					onSelectFile(node.absolutePath, intent === "openInNewTab");
 				}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/WorkspaceFilesTreeItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/WorkspaceFilesTreeItem.tsx
@@ -154,16 +154,16 @@ function WorkspaceFilesTreeItemComponent({
 
 	return (
 		<ContextMenu>
-			<ContextMenuTrigger asChild>
-				{isFolder ? (
-					rowButton
-				) : (
-					<Tooltip>
+			{isFolder ? (
+				<ContextMenuTrigger asChild>{rowButton}</ContextMenuTrigger>
+			) : (
+				<Tooltip>
+					<ContextMenuTrigger asChild>
 						<TooltipTrigger asChild>{rowButton}</TooltipTrigger>
-						<TooltipContent side="right">{CLICK_HINT_TOOLTIP}</TooltipContent>
-					</Tooltip>
-				)}
-			</ContextMenuTrigger>
+					</ContextMenuTrigger>
+					<TooltipContent side="right">{CLICK_HINT_TOOLTIP}</TooltipContent>
+				</Tooltip>
+			)}
 			{isFolder ? (
 				<FolderContextMenu
 					absolutePath={node.absolutePath}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/WorkspaceFilesTreeItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/WorkspaceFilesTreeItem.tsx
@@ -5,6 +5,7 @@ import { LuChevronDown, LuChevronRight, LuCircle } from "react-icons/lu";
 import type { FileTreeNode } from "renderer/hooks/host-service/useFileTree";
 import type { FileStatus } from "renderer/hooks/host-service/useGitStatusMap";
 import { FileIcon } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils";
+import { getSidebarClickIntent } from "../../../../../../utils/getSidebarClickIntent";
 
 import { FileContextMenu } from "./components/FileContextMenu";
 import { FolderContextMenu } from "./components/FolderContextMenu";
@@ -91,14 +92,13 @@ function WorkspaceFilesTreeItemComponent({
 						isSelected ? "!bg-accent" : undefined,
 					)}
 					onClick={(e) => {
-						if (e.metaKey || e.ctrlKey) {
+						const intent = getSidebarClickIntent(e);
+						if (intent === "openInEditor") {
 							onOpenInEditor(node.absolutePath);
 						} else if (isFolder) {
 							onToggleDirectory(node.absolutePath);
-						} else if (e.shiftKey) {
-							onSelectFile(node.absolutePath, true);
 						} else {
-							onSelectFile(node.absolutePath);
+							onSelectFile(node.absolutePath, intent === "openInNewTab");
 						}
 					}}
 					style={{

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/WorkspaceFilesTreeItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/WorkspaceFilesTreeItem.tsx
@@ -4,8 +4,8 @@ import { memo } from "react";
 import { LuChevronDown, LuChevronRight, LuCircle } from "react-icons/lu";
 import type { FileTreeNode } from "renderer/hooks/host-service/useFileTree";
 import type { FileStatus } from "renderer/hooks/host-service/useGitStatusMap";
+import { getSidebarClickIntent } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/getSidebarClickIntent";
 import { FileIcon } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils";
-import { getSidebarClickIntent } from "../../../../../../utils/getSidebarClickIntent";
 
 import { FileContextMenu } from "./components/FileContextMenu";
 import { FolderContextMenu } from "./components/FolderContextMenu";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/FileContextMenu/FileContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/FileContextMenu/FileContextMenu.tsx
@@ -2,12 +2,20 @@ import {
 	ContextMenuContent,
 	ContextMenuItem,
 	ContextMenuSeparator,
+	ContextMenuShortcut,
 } from "@superset/ui/context-menu";
+import {
+	MOD_CLICK_LABEL,
+	SHIFT_CLICK_LABEL,
+} from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/clickModifierLabels";
 import { PathActionsMenuItems } from "../PathActionsMenuItems";
 
 interface FileContextMenuProps {
 	absolutePath: string;
 	relativePath?: string;
+	onOpen: () => void;
+	onOpenInNewTab: () => void;
+	onOpenInEditor: () => void;
 	onRename: () => void;
 	onDelete: () => void;
 }
@@ -15,12 +23,23 @@ interface FileContextMenuProps {
 export function FileContextMenu({
 	absolutePath,
 	relativePath,
+	onOpen,
+	onOpenInNewTab,
+	onOpenInEditor,
 	onRename,
 	onDelete,
 }: FileContextMenuProps) {
 	return (
 		<ContextMenuContent className="w-56">
-			<ContextMenuItem>Open to the Side</ContextMenuItem>
+			<ContextMenuItem onSelect={onOpen}>Open</ContextMenuItem>
+			<ContextMenuItem onSelect={onOpenInNewTab}>
+				Open in New Tab
+				<ContextMenuShortcut>{SHIFT_CLICK_LABEL}</ContextMenuShortcut>
+			</ContextMenuItem>
+			<ContextMenuItem onSelect={onOpenInEditor}>
+				Open in Editor
+				<ContextMenuShortcut>{MOD_CLICK_LABEL}</ContextMenuShortcut>
+			</ContextMenuItem>
 			<ContextMenuSeparator />
 			<PathActionsMenuItems
 				absolutePath={absolutePath}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/ChangesFileList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/ChangesFileList.tsx
@@ -5,6 +5,7 @@ import { FileRow } from "./components/FileRow";
 interface ChangesFileListProps {
 	files: ChangesetFile[];
 	isLoading?: boolean;
+	worktreePath?: string;
 	onSelectFile?: (path: string, openInNewTab?: boolean) => void;
 	onOpenInEditor?: (path: string) => void;
 }
@@ -12,6 +13,7 @@ interface ChangesFileListProps {
 export const ChangesFileList = memo(function ChangesFileList({
 	files,
 	isLoading,
+	worktreePath,
 	onSelectFile,
 	onOpenInEditor,
 }: ChangesFileListProps) {
@@ -37,6 +39,7 @@ export const ChangesFileList = memo(function ChangesFileList({
 				<FileRow
 					key={`${file.source.kind}:${file.path}`}
 					file={file}
+					worktreePath={worktreePath}
 					onSelect={onSelectFile}
 					onOpenInEditor={onOpenInEditor}
 				/>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/ChangesFileList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/ChangesFileList.tsx
@@ -5,13 +5,15 @@ import { FileRow } from "./components/FileRow";
 interface ChangesFileListProps {
 	files: ChangesetFile[];
 	isLoading?: boolean;
-	onSelectFile?: (path: string) => void;
+	onSelectFile?: (path: string, openInNewTab?: boolean) => void;
+	onOpenInEditor?: (path: string) => void;
 }
 
 export const ChangesFileList = memo(function ChangesFileList({
 	files,
 	isLoading,
 	onSelectFile,
+	onOpenInEditor,
 }: ChangesFileListProps) {
 	if (isLoading) {
 		return (
@@ -36,6 +38,7 @@ export const ChangesFileList = memo(function ChangesFileList({
 					key={`${file.source.kind}:${file.path}`}
 					file={file}
 					onSelect={onSelectFile}
+					onOpenInEditor={onOpenInEditor}
 				/>
 			))}
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
@@ -86,12 +86,12 @@ export const FileRow = memo(function FileRow({
 
 	return (
 		<ContextMenu>
-			<ContextMenuTrigger asChild>
-				<Tooltip>
+			<Tooltip>
+				<ContextMenuTrigger asChild>
 					<TooltipTrigger asChild>{rowButton}</TooltipTrigger>
-					<TooltipContent side="right">{CLICK_HINT_TOOLTIP}</TooltipContent>
-				</Tooltip>
-			</ContextMenuTrigger>
+				</ContextMenuTrigger>
+				<TooltipContent side="right">{CLICK_HINT_TOOLTIP}</TooltipContent>
+			</Tooltip>
 			<ContextMenuContent className="w-56">
 				<ContextMenuItem onSelect={() => onSelect?.(file.path)}>
 					Open Diff

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
@@ -14,17 +14,30 @@ function splitPath(path: string): { dir: string; basename: string } {
 
 interface FileRowProps {
 	file: ChangesetFile;
-	onSelect?: (path: string) => void;
+	onSelect?: (path: string, openInNewTab?: boolean) => void;
+	onOpenInEditor?: (path: string) => void;
 }
 
-export const FileRow = memo(function FileRow({ file, onSelect }: FileRowProps) {
+export const FileRow = memo(function FileRow({
+	file,
+	onSelect,
+	onOpenInEditor,
+}: FileRowProps) {
 	const { dir, basename } = splitPath(file.path);
 
 	return (
 		<button
 			type="button"
 			className="flex w-full items-center gap-1.5 py-1 pr-3 pl-3 text-left text-xs hover:bg-accent/50"
-			onClick={() => onSelect?.(file.path)}
+			onClick={(e) => {
+				if (e.metaKey || e.ctrlKey) {
+					onOpenInEditor?.(file.path);
+				} else if (e.shiftKey) {
+					onSelect?.(file.path, true);
+				} else {
+					onSelect?.(file.path);
+				}
+			}}
 		>
 			<FileIcon fileName={basename} className="size-3.5 shrink-0" />
 			<span className="flex min-w-0 flex-1 items-baseline overflow-hidden">

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
@@ -1,8 +1,24 @@
+import {
+	ContextMenu,
+	ContextMenuContent,
+	ContextMenuItem,
+	ContextMenuSeparator,
+	ContextMenuShortcut,
+	ContextMenuTrigger,
+} from "@superset/ui/context-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { memo } from "react";
 import { StatusIndicator } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/StatusIndicator";
+import { PathActionsMenuItems } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/PathActionsMenuItems";
+import type { ChangesetFile } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset";
+import {
+	CLICK_HINT_TOOLTIP,
+	MOD_CLICK_LABEL,
+	SHIFT_CLICK_LABEL,
+} from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/clickModifierLabels";
 import { getSidebarClickIntent } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/getSidebarClickIntent";
 import { FileIcon } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils";
-import type { ChangesetFile } from "../../../../../../../../hooks/useChangeset";
+import { toAbsoluteWorkspacePath } from "shared/absolute-paths";
 
 function splitPath(path: string): { dir: string; basename: string } {
 	const lastSlash = path.lastIndexOf("/");
@@ -15,18 +31,23 @@ function splitPath(path: string): { dir: string; basename: string } {
 
 interface FileRowProps {
 	file: ChangesetFile;
+	worktreePath?: string;
 	onSelect?: (path: string, openInNewTab?: boolean) => void;
 	onOpenInEditor?: (path: string) => void;
 }
 
 export const FileRow = memo(function FileRow({
 	file,
+	worktreePath,
 	onSelect,
 	onOpenInEditor,
 }: FileRowProps) {
 	const { dir, basename } = splitPath(file.path);
+	const absolutePath = worktreePath
+		? toAbsoluteWorkspacePath(worktreePath, file.path)
+		: undefined;
 
-	return (
+	const rowButton = (
 		<button
 			type="button"
 			className="flex w-full items-center gap-1.5 py-1 pr-3 pl-3 text-left text-xs hover:bg-accent/50"
@@ -61,5 +82,41 @@ export const FileRow = memo(function FileRow({
 				<StatusIndicator status={file.status} />
 			</span>
 		</button>
+	);
+
+	return (
+		<ContextMenu>
+			<ContextMenuTrigger asChild>
+				<Tooltip>
+					<TooltipTrigger asChild>{rowButton}</TooltipTrigger>
+					<TooltipContent side="right">{CLICK_HINT_TOOLTIP}</TooltipContent>
+				</Tooltip>
+			</ContextMenuTrigger>
+			<ContextMenuContent className="w-56">
+				<ContextMenuItem onSelect={() => onSelect?.(file.path)}>
+					Open Diff
+				</ContextMenuItem>
+				<ContextMenuItem onSelect={() => onSelect?.(file.path, true)}>
+					Open Diff in New Tab
+					<ContextMenuShortcut>{SHIFT_CLICK_LABEL}</ContextMenuShortcut>
+				</ContextMenuItem>
+				<ContextMenuItem
+					onSelect={() => onOpenInEditor?.(file.path)}
+					disabled={!onOpenInEditor}
+				>
+					Open in Editor
+					<ContextMenuShortcut>{MOD_CLICK_LABEL}</ContextMenuShortcut>
+				</ContextMenuItem>
+				{absolutePath && (
+					<>
+						<ContextMenuSeparator />
+						<PathActionsMenuItems
+							absolutePath={absolutePath}
+							relativePath={file.path}
+						/>
+					</>
+				)}
+			</ContextMenuContent>
+		</ContextMenu>
 	);
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
@@ -1,5 +1,6 @@
 import { memo } from "react";
 import { StatusIndicator } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/StatusIndicator";
+import { getSidebarClickIntent } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/getSidebarClickIntent";
 import { FileIcon } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils";
 import type { ChangesetFile } from "../../../../../../../../hooks/useChangeset";
 
@@ -30,12 +31,11 @@ export const FileRow = memo(function FileRow({
 			type="button"
 			className="flex w-full items-center gap-1.5 py-1 pr-3 pl-3 text-left text-xs hover:bg-accent/50"
 			onClick={(e) => {
-				if (e.metaKey || e.ctrlKey) {
+				const intent = getSidebarClickIntent(e);
+				if (intent === "openInEditor") {
 					onOpenInEditor?.(file.path);
-				} else if (e.shiftKey) {
-					onSelect?.(file.path, true);
 				} else {
-					onSelect?.(file.path);
+					onSelect?.(file.path, intent === "openInNewTab");
 				}
 			}}
 		>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesTabContent/ChangesTabContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesTabContent/ChangesTabContent.tsx
@@ -22,6 +22,7 @@ interface ChangesTabContentProps {
 	totalChanges: number;
 	totalAdditions: number;
 	totalDeletions: number;
+	worktreePath?: string;
 	onSelectFile?: (path: string, openInNewTab?: boolean) => void;
 	onOpenInEditor?: (path: string) => void;
 	onFilterChange: (filter: ChangesFilter) => void;
@@ -41,6 +42,7 @@ export const ChangesTabContent = memo(function ChangesTabContent({
 	totalChanges,
 	totalAdditions,
 	totalDeletions,
+	worktreePath,
 	onSelectFile,
 	onOpenInEditor,
 	onFilterChange,
@@ -89,6 +91,7 @@ export const ChangesTabContent = memo(function ChangesTabContent({
 				<ChangesFileList
 					files={files}
 					isLoading={isLoading}
+					worktreePath={worktreePath}
 					onSelectFile={onSelectFile}
 					onOpenInEditor={onOpenInEditor}
 				/>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesTabContent/ChangesTabContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesTabContent/ChangesTabContent.tsx
@@ -22,7 +22,8 @@ interface ChangesTabContentProps {
 	totalChanges: number;
 	totalAdditions: number;
 	totalDeletions: number;
-	onSelectFile?: (path: string) => void;
+	onSelectFile?: (path: string, openInNewTab?: boolean) => void;
+	onOpenInEditor?: (path: string) => void;
 	onFilterChange: (filter: ChangesFilter) => void;
 	onBaseBranchChange: (branchName: string) => void;
 	onRenameBranch: (newName: string) => void;
@@ -41,6 +42,7 @@ export const ChangesTabContent = memo(function ChangesTabContent({
 	totalAdditions,
 	totalDeletions,
 	onSelectFile,
+	onOpenInEditor,
 	onFilterChange,
 	onBaseBranchChange,
 	onRenameBranch,
@@ -88,6 +90,7 @@ export const ChangesTabContent = memo(function ChangesTabContent({
 					files={files}
 					isLoading={isLoading}
 					onSelectFile={onSelectFile}
+					onOpenInEditor={onOpenInEditor}
 				/>
 			</div>
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
@@ -131,6 +131,7 @@ export function useChangesTab({
 			totalChanges={totalChanges}
 			totalAdditions={totalAdditions}
 			totalDeletions={totalDeletions}
+			worktreePath={worktreePath}
 			onSelectFile={onSelectFile}
 			onOpenInEditor={handleOpenInEditor}
 			onFilterChange={setFilter}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
@@ -4,7 +4,9 @@ import { useCallback } from "react";
 import type { useGitStatus } from "renderer/hooks/host-service/useGitStatus";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { ChangesFilter } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
+import { toAbsoluteWorkspacePath } from "shared/absolute-paths";
 import { useChangeset } from "../../../../hooks/useChangeset";
+import { useOpenInExternalEditor } from "../../../../hooks/useOpenInExternalEditor";
 import { useSidebarDiffRef } from "../../../../hooks/useSidebarDiffRef";
 import type { SidebarTabDefinition } from "../../types";
 import { ChangesTabContent } from "./components/ChangesTabContent";
@@ -14,7 +16,7 @@ export type { ChangesFilter };
 interface UseChangesTabParams {
 	workspaceId: string;
 	gitStatus: ReturnType<typeof useGitStatus>;
-	onSelectFile?: (path: string) => void;
+	onSelectFile?: (path: string, openInNewTab?: boolean) => void;
 }
 
 export function useChangesTab({
@@ -37,6 +39,20 @@ export function useChangesTab({
 
 	const ref = useSidebarDiffRef(workspaceId);
 	const { files, isLoading } = useChangeset({ workspaceId, ref });
+
+	const workspaceQuery = workspaceTrpc.workspace.get.useQuery({
+		id: workspaceId,
+	});
+	const worktreePath = workspaceQuery.data?.worktreePath;
+	const openInExternalEditor = useOpenInExternalEditor(workspaceId);
+
+	const handleOpenInEditor = useCallback(
+		(relativePath: string) => {
+			if (!worktreePath) return;
+			openInExternalEditor(toAbsoluteWorkspacePath(worktreePath, relativePath));
+		},
+		[worktreePath, openInExternalEditor],
+	);
 
 	const setFilter = useCallback(
 		(next: ChangesFilter) => {
@@ -116,6 +132,7 @@ export function useChangesTab({
 			totalAdditions={totalAdditions}
 			totalDeletions={totalDeletions}
 			onSelectFile={onSelectFile}
+			onOpenInEditor={handleOpenInEditor}
 			onFilterChange={setFilter}
 			onBaseBranchChange={setBaseBranch}
 			onRenameBranch={handleRenameBranch}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
@@ -2,12 +2,12 @@ import { toast } from "@superset/ui/sonner";
 import { workspaceTrpc } from "@superset/workspace-client";
 import { useCallback } from "react";
 import type { useGitStatus } from "renderer/hooks/host-service/useGitStatus";
+import { useChangeset } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset";
+import { useOpenInExternalEditor } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useOpenInExternalEditor";
+import { useSidebarDiffRef } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useSidebarDiffRef";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { ChangesFilter } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
 import { toAbsoluteWorkspacePath } from "shared/absolute-paths";
-import { useChangeset } from "../../../../hooks/useChangeset";
-import { useOpenInExternalEditor } from "../../../../hooks/useOpenInExternalEditor";
-import { useSidebarDiffRef } from "../../../../hooks/useSidebarDiffRef";
 import type { SidebarTabDefinition } from "../../types";
 import { ChangesTabContent } from "./components/ChangesTabContent";
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -237,8 +237,22 @@ function WorkspaceContent({
 	const defaultContextMenuActions = useDefaultContextMenuActions(paneRegistry);
 
 	const openDiffPane = useCallback(
-		(filePath: string) => {
+		(filePath: string, openInNewTab?: boolean) => {
 			const state = store.getState();
+			if (openInNewTab) {
+				state.addTab({
+					panes: [
+						{
+							kind: "diff",
+							data: {
+								path: filePath,
+								collapsedFiles: [],
+							} as DiffPaneData,
+						},
+					],
+				});
+				return;
+			}
 			for (const tab of state.tabs) {
 				for (const pane of Object.values(tab.panes)) {
 					if (pane.kind !== "diff") continue;
@@ -255,16 +269,14 @@ function WorkspaceContent({
 					return;
 				}
 			}
-			state.addTab({
-				panes: [
-					{
-						kind: "diff",
-						data: {
-							path: filePath,
-							collapsedFiles: [],
-						} as DiffPaneData,
-					},
-				],
+			state.openPane({
+				pane: {
+					kind: "diff",
+					data: {
+						path: filePath,
+						collapsedFiles: [],
+					} as DiffPaneData,
+				},
 			});
 		},
 		[store],

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/clickModifierLabels/clickModifierLabels.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/clickModifierLabels/clickModifierLabels.ts
@@ -1,0 +1,8 @@
+const isMac =
+	typeof navigator !== "undefined" &&
+	navigator.platform.toLowerCase().includes("mac");
+
+export const SHIFT_CLICK_LABEL = isMac ? "⇧ click" : "Shift+click";
+export const MOD_CLICK_LABEL = isMac ? "⌘ click" : "Ctrl+click";
+
+export const CLICK_HINT_TOOLTIP = `${SHIFT_CLICK_LABEL}: new tab · ${MOD_CLICK_LABEL}: editor`;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/clickModifierLabels/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/clickModifierLabels/index.ts
@@ -1,0 +1,5 @@
+export {
+	CLICK_HINT_TOOLTIP,
+	MOD_CLICK_LABEL,
+	SHIFT_CLICK_LABEL,
+} from "./clickModifierLabels";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/getSidebarClickIntent/getSidebarClickIntent.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/getSidebarClickIntent/getSidebarClickIntent.ts
@@ -1,0 +1,11 @@
+import type { MouseEvent } from "react";
+
+export type SidebarClickIntent = "openInEditor" | "openInNewTab" | "select";
+
+export function getSidebarClickIntent(
+	e: MouseEvent<unknown>,
+): SidebarClickIntent {
+	if (e.metaKey || e.ctrlKey) return "openInEditor";
+	if (e.shiftKey) return "openInNewTab";
+	return "select";
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/getSidebarClickIntent/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/getSidebarClickIntent/index.ts
@@ -1,0 +1,4 @@
+export {
+	getSidebarClickIntent,
+	type SidebarClickIntent,
+} from "./getSidebarClickIntent";


### PR DESCRIPTION
## Summary
- Mirror the v2 Files tab click policy on the Changes sidebar `FileRow`: plain click reuses an existing diff pane (or smart-places via `openPane` into the active tab instead of forcing a new tab), shift+click opens the diff in a new tab, cmd/ctrl+click opens the file in the external editor.
- Thread `onSelectFile(path, openInNewTab?)` and a new `onOpenInEditor` callback through `ChangesFileList` → `ChangesTabContent` → `useChangesTab`; `useChangesTab` now calls `useOpenInExternalEditor` and resolves the absolute path from the workspace's `worktreePath`.
- Update `openDiffPane` in `v2-workspace/$workspaceId/page.tsx` to accept `openInNewTab?`. New tab path goes straight to `addTab`. Default path still reuses any existing diff pane; when none exists, falls back to `openPane` (matching the Files tab behavior) instead of always creating a new tab.

## Test plan
- [ ] With no diff pane open, click a file in the Changes sidebar → diff renders in the active tab (no new tab spawned).
- [ ] With a diff pane already open, click another file in the Changes sidebar → same diff pane updates.
- [ ] Shift+click a file in the Changes sidebar → a new tab opens with a diff pane for that file.
- [ ] Cmd+click (macOS) / Ctrl+click (Win/Linux) a file in the Changes sidebar → file opens in the configured external editor.
- [ ] Files tab behavior unchanged (plain click / shift+click / cmd+click still work as before).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Changes sidebar with the v2 Files tab: plain click reuses or smart-places a diff pane, Shift+click opens a new tab, and Cmd/Ctrl+click opens the file in the external editor. Adds hover tooltips and a right‑click menu on file rows with shortcut hints.

- **New Features**
  - Centralized modifier‑click handling in `getSidebarClickIntent` (used by Files and Changes); `WorkspaceSidebar` now accepts `onSelectDiffFile(path, openInNewTab?)`.
  - `openDiffPane(filePath, openInNewTab?)`: Shift opens via `addTab`; otherwise reuse an existing diff pane, or `openPane` into the active tab.
  - Changes list wires `onSelectFile(path, openInNewTab?)` and `onOpenInEditor(path)` via `useChangesTab`; resolves `worktreePath` and uses the external editor. Added tooltip and context menu (Open, Open in New Tab, Open in Editor) with shortcut hints; replaces the unwired “Open to the Side” in Files.

- **Bug Fixes**
  - Right‑click now works on Files and Changes rows by nesting Tooltip inside `ContextMenuTrigger`.
  - Cmd/Ctrl‑click is gated to files only in the v2 Files sidebar; folders toggle instead of opening the editor.

<sup>Written for commit f61730499598c9f0ae07d4652d9a3cb640a3b58f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modifier-key click actions on sidebar items: Ctrl/Cmd opens in external editor, Shift opens in a new tab, plain click selects.
  * Context menu now offers distinct "Open", "Open in New Tab" and "Open in Editor" actions with shortcut hints and click-hint tooltip.
  * Optional "Open in Editor" action and worktree-aware paths enable opening files directly in an external editor.

* **Improvements**
  * Selection handlers distinguish normal select vs. "open in new tab" and can force new diff tabs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->