### PR TITLE
fix(desktop): wrap terminal file drops in bracketed paste sequences

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -432,7 +432,13 @@ export const Terminal = memo(function Terminal({
 			text = shellEscapePaths([plainText]);
 		}
 		if (!isExitedRef.current) {
-			writeRef.current({ paneId, data: text });
+			// Wrap in bracketed paste sequences when BPM is enabled so TUI apps
+			// (OpenCode, vim, etc.) can distinguish drops from typed input and
+			// handle file paths as attachments/images.
+			const data = isBracketedPasteRef.current
+				? `\x1b[200~${text}\x1b[201~`
+				: text;
+			writeRef.current({ paneId, data });
 		}
 	};
 


### PR DESCRIPTION
## Problem

Dragging an image into a terminal pane running OpenCode (or any TUI that uses bracketed paste mode) inserts the raw file path as typed text instead of being handled as an image attachment. This prevents OpenCode from parsing images, breaking a core documented feature:

> Drag and drop images into the terminal to add them to the prompt. OpenCode can scan any images you give it and add them to the prompt.
> — [OpenCode docs](https://opencode.ai/docs/)

In native terminal emulators (iTerm2, WezTerm, Kitty, Ghostty), dropping a file onto the terminal wraps the path in bracketed paste mode (BPM) escape sequences (`\x1b[200~` ... `\x1b[201~`) when the running application has enabled the mode. TUIs use these markers to distinguish pasted/dropped content from typed input, and OpenCode specifically uses this signal to detect image paths and attach them.

## Root cause

In `apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx`, the `handleDrop` function was writing dropped file paths directly to the PTY as raw text:

```ts
writeRef.current({ paneId, data: text });
```

The paste handler (`helpers.ts` `setupPasteHandler`) already wraps pasted content in BPM sequences when the mode is active, but the drop handler bypassed this. OpenCode received dropped paths character-by-character as if typed, so its image-detection logic never fired.

## Fix

Wrap dropped content in BPM sequences when the running TUI has enabled the mode, matching the existing paste-handler behavior and native terminal behavior. When BPM is not active (plain shell), the path is written as raw text (unchanged behavior).

The `isBracketedPasteRef` state is already tracked by `useTerminalModes` by scanning terminal output for `\x1b[?2004h` / `\x1b[?2004l` toggles.

```ts
const data = isBracketedPasteRef.current
    ? `\x1b[200~${text}\x1b[201~`
    : text;
writeRef.current({ paneId, data });
```

## Testing

Tested locally with OpenCode running in a terminal pane:

- **Before**: dragged image path appears as typed text (`/Users/.../screenshot.png `), OpenCode treats it as literal prompt text.
- **After**: OpenCode detects the dropped image path and attaches it (shows `[Image #1]` in the prompt composer).

Also verified:
- Plain shell (no BPM): drops still work, path is inserted as shell-escaped text (unchanged).
- Internal file-tree drag: still works (goes through the same `text/plain` path).
- vim/less (alt screen + BPM): drops now arrive as pastes, which is the intended behavior.

## Scope

Single 6-line change in `Terminal.tsx` `handleDrop`. No new dependencies, no new abstractions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wrap terminal file drops in bracketed paste sequences when bracketed paste mode is enabled, matching native terminals so TUIs like OpenCode detect dropped image paths and attach them correctly. When BPM is off, paths are sent as raw text (unchanged).

<sup>Written for commit a04b783b8f98fcefa4b2e15d89139486f98b920c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag-and-drop input handling in the terminal to properly support bracketed paste mode, ensuring dropped content is processed correctly when this setting is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->