### PR TITLE
fix(desktop): keep v2 terminals and browsers stable across workspace switches

### DIFF
--- a/apps/desktop/plans/20260423-1226-v2-pane-persistence-across-workspace-switch.md
+++ b/apps/desktop/plans/20260423-1226-v2-pane-persistence-across-workspace-switch.md
@@ -1,0 +1,130 @@
+# v2 pane persistence across workspace switch
+
+## Context
+
+Switching v2 workspaces unmounts the entire `<WorkspaceTrpcProvider>` subtree
+(`layout.tsx:79` uses `key={`${workspace.id}:${hostUrl}`}`). Every pane React
+component for the outgoing workspace is torn down and recreated for the
+incoming one. Load-bearing long-lived state (xterm instance + WebSocket,
+webview guest process, CodeMirror `EditorView`) must live OUTSIDE the
+remounting subtree to survive. This note captures the root cause for each
+pane kind and the fix pattern so we don't have to re-derive it.
+
+## Shared root cause
+
+The `key` on `WorkspaceTrpcProvider` is load-bearing — it exists
+(commit `57557f806`) to prevent crashes from hook calls bleeding across
+trpc clients during transitions. We cannot remove it. Any pane that wants
+to survive workspace switches must:
+
+1. Hold its long-lived state in a module-level registry singleton.
+2. Own a DOM node (or native handle) parented *outside* the React
+   workspace subtree (body-level `<div>` is the simplest).
+3. Let the React component be a thin placeholder that only drives
+   position/visibility of the registry-owned node.
+
+Think "VSCode `TerminalInstance` + `setVisible`" or the existing
+`browserRuntimeRegistry` root-container pattern.
+
+## Terminal — fixed in PR #3687
+
+Was broken: `registry.attach()` fused DOM attach with WebSocket open and was
+gated on `ensureSession`. The wrapper was `wrapper.remove()`'d on every
+React unmount, so workspace switch was visible detach + reattach. The
+`ensureSession` gate also added tRPC latency on warm returns, and opened
+the WS against a nonexistent session on cold mount → "Session not found".
+
+Fixed by:
+- Park wrapper in a hidden body-level `#v2-terminal-parking` div on
+  detach instead of `.remove()`.
+- Split `attach` into `mount` (sync DOM) and `connect` (called only after
+  `ensureSession` resolves).
+- Narrow `TerminalPane` effect deps to `[terminalId]`; read `workspaceId`
+  and `websocketUrl` through refs. `websocketUrl` changes go through a
+  separate `registry.reconnect` that no-ops on a cold transport.
+
+Refs: `terminal-runtime.ts`, `terminal-runtime-registry.ts`,
+`TerminalPane.tsx`.
+
+## Browser — fixed
+
+### Symptom
+
+Switching workspaces destroyed the browser webview (and the guest page
+along with it) instead of preserving state across the switch.
+
+### Root cause
+
+Confirmed via instrumentation: `browserRuntimeRegistry.destroy` was
+being called on workspace switch with a stack rooted in React commit.
+The only caller was `usePaneRegistry.tsx`'s `onRemoved` wiring:
+
+```ts
+onRemoved: (pane) => browserRuntimeRegistry.destroy(pane.id),
+```
+
+`onRemoved` comes from `packages/panes/.../Workspace.tsx`, which diffs
+`previousPanesRef` against `current` in a `useEffect` and calls
+`registry[kind].onRemoved` for any id that disappeared. The diff lives
+inside a single Workspace component instance. Under ideal conditions —
+the v2 layout's `key={`${workspace.id}:${hostUrl}`}` remounts on every
+switch — this diff should never observe cross-workspace "removal"
+because each workspace has its own Workspace component.
+
+But the remount isn't always prompt: layout.tsx's `useLiveQuery` can
+return stale WS-A data for a tick while `page.tsx`'s query has already
+flipped to WS-B. During that tick the `key` hasn't changed yet, so the
+existing `WorkspaceContent` stays mounted, `useV2WorkspacePaneLayout`
+calls `store.replaceState(WS-B panes)` on the *same* store instance,
+and the Panes library's diff correctly observes "the browser pane from
+WS-A is gone now" → fires `onRemoved` → destroys the webview. By the
+time the user returns to WS-A, the entry is gone; `attach()` runs the
+`createEntry()` cold path and the webview is recreated with its
+`initialUrl`, losing state.
+
+The terminal never hit this because terminal destruction goes through
+`useGlobalTerminalLifecycle`, which sweeps against *all* workspaces'
+persisted `paneLayout` rows and only destroys ids that are provably
+absent everywhere. Cross-workspace "removal" isn't a real removal from
+that sweep's perspective.
+
+### Fix
+
+Mirrored the terminal pattern: added `useGlobalBrowserLifecycle` under
+`_authenticated/components/GlobalBrowserLifecycle/`, mounted it next to
+`<GlobalTerminalLifecycle />` in `_authenticated/layout.tsx`, and
+removed the `onRemoved` wiring from `usePaneRegistry.tsx`. The new hook
+extracts browser `pane.id`s from every workspace's `paneLayout`, diffs
+against the previous set, and schedules `browserRuntimeRegistry.destroy`
+on a 500 ms grace delay (same timing as the terminal sweep) so
+cross-workspace pane moves don't trigger premature teardown.
+
+Hypothesis #1 (placeholder-rect race) and #3 (webview recycling on
+`visibility: hidden`) from the original list did not reproduce once #2
+was fixed — the instrumentation showed `updateLayout` applying correct
+non-zero rects and the webview surviving detach as long as no `destroy`
+call fired. Left in place as known-good; will revisit if a future
+regression points at either.
+
+## File / Code editor — lower priority
+
+File-viewer panes use CodeMirror `EditorView` created in a `useEffect([])`
+inside `CodeEditor.tsx:153-171`, disposed on unmount. Workspace switch
+therefore loses: undo history, cursor position, scroll position, any
+unsaved viewport scroll. Not reported yet but predictable; users may
+complain after terminal/browser are solid.
+
+Fix pattern is identical: a module-level `codeEditorRegistry` keyed by
+`${workspaceId}:${filePath}` (or pane id, if file viewer panes are
+per-workspace) that owns the `EditorView` and its host div, with a body-
+level root container. `CodeEditor` becomes a placeholder that registers
+a rect.
+
+Defer until it's a reported problem — the migration is mechanical but
+the value is speculative and CodeMirror re-init is already fast.
+
+## Not in scope
+
+- v1 terminal. Sunset per CLAUDE.md / memory.
+- v2 chat pane. Currently a "temporarily disabled" stub.
+- Diff / comment / devtools. No long-lived state.

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -11,7 +11,6 @@ import {
 	createRuntime,
 	detachFromContainer,
 	disposeRuntime,
-	termLog,
 	type TerminalRuntime,
 	updateRuntimeAppearance,
 } from "./terminal-runtime";
@@ -41,12 +40,6 @@ class TerminalRuntimeRegistryImpl {
 		let entry = this.entries.get(terminalId);
 		if (entry) return entry;
 
-		termLog("registry:entry-create", {
-			terminalId,
-			registrySize: this.entries.size,
-			stack: new Error().stack?.split("\n").slice(2, 6).join(" <- "),
-		});
-
 		entry = {
 			runtime: null,
 			transport: createTransport(),
@@ -75,14 +68,7 @@ class TerminalRuntimeRegistryImpl {
 		container: HTMLDivElement,
 		appearance: TerminalAppearance,
 	) {
-		const existed = this.entries.has(terminalId);
 		const entry = this.getOrCreateEntry(terminalId);
-		termLog("registry:mount", {
-			terminalId,
-			entryExisted: existed,
-			hadRuntime: !!entry.runtime,
-			registrySize: this.entries.size,
-		});
 
 		if (!entry.runtime) {
 			entry.runtime = createRuntime(terminalId, appearance);
@@ -111,12 +97,6 @@ class TerminalRuntimeRegistryImpl {
 	connect(terminalId: string, wsUrl: string) {
 		const entry = this.entries.get(terminalId);
 		if (!entry?.runtime) return;
-		termLog("registry:connect", {
-			terminalId,
-			prevState: entry.transport.connectionState,
-			prevUrl: entry.transport.currentUrl,
-			nextUrl: wsUrl,
-		});
 		connect(entry.transport, entry.runtime.terminal, wsUrl);
 	}
 
@@ -129,20 +109,8 @@ class TerminalRuntimeRegistryImpl {
 	reconnect(terminalId: string, wsUrl: string) {
 		const entry = this.entries.get(terminalId);
 		if (!entry?.runtime) return;
-		const state = entry.transport.connectionState;
-		if (state === "disconnected") {
-			termLog("registry:reconnect-skip", { terminalId, reason: "no-transport" });
-			return;
-		}
-		if (entry.transport.currentUrl === wsUrl) {
-			termLog("registry:reconnect-skip", { terminalId, reason: "same-url" });
-			return;
-		}
-		termLog("registry:reconnect", {
-			terminalId,
-			prevUrl: entry.transport.currentUrl,
-			nextUrl: wsUrl,
-		});
+		if (entry.transport.connectionState === "disconnected") return;
+		if (entry.transport.currentUrl === wsUrl) return;
 		connect(entry.transport, entry.runtime.terminal, wsUrl);
 	}
 
@@ -166,11 +134,6 @@ class TerminalRuntimeRegistryImpl {
 	 */
 	detach(terminalId: string) {
 		const entry = this.entries.get(terminalId);
-		termLog("registry:detach", {
-			terminalId,
-			found: !!entry,
-			hadRuntime: !!entry?.runtime,
-		});
 		if (!entry?.runtime) return;
 
 		detachFromContainer(entry.runtime);
@@ -193,11 +156,6 @@ class TerminalRuntimeRegistryImpl {
 
 	dispose(terminalId: string) {
 		const entry = this.entries.get(terminalId);
-		termLog("registry:dispose", {
-			terminalId,
-			found: !!entry,
-			stack: new Error().stack?.split("\n").slice(1, 6).join(" <- "),
-		});
 		if (!entry) return;
 
 		entry.linkManager?.dispose();

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -11,6 +11,7 @@ import {
 	createRuntime,
 	detachFromContainer,
 	disposeRuntime,
+	termLog,
 	type TerminalRuntime,
 	updateRuntimeAppearance,
 } from "./terminal-runtime";
@@ -29,7 +30,7 @@ interface RegistryEntry {
 	runtime: TerminalRuntime | null;
 	transport: TerminalTransport;
 	linkManager: TerminalLinkManager | null;
-	/** Stored until linkManager is created (attach called after setLinkHandlers). */
+	/** Stored until linkManager is created (mount called after setLinkHandlers). */
 	pendingLinkHandlers: TerminalLinkHandlers | null;
 }
 
@@ -39,6 +40,12 @@ class TerminalRuntimeRegistryImpl {
 	private getOrCreateEntry(terminalId: string): RegistryEntry {
 		let entry = this.entries.get(terminalId);
 		if (entry) return entry;
+
+		termLog("registry:entry-create", {
+			terminalId,
+			registrySize: this.entries.size,
+			stack: new Error().stack?.split("\n").slice(2, 6).join(" <- "),
+		});
 
 		entry = {
 			runtime: null,
@@ -51,18 +58,35 @@ class TerminalRuntimeRegistryImpl {
 		return entry;
 	}
 
-	attach(
+	/**
+	 * Ensure the xterm runtime exists and attach it to `container`.
+	 * Synchronous. DOM-only — the WebSocket transport is untouched.
+	 *
+	 * Matches VSCode's pattern (`TerminalInstance.attachToElement`) and
+	 * Tabby's (`XTermFrontend.attach`): the terminal renders immediately
+	 * with a blank cursor, the backend pipe catches up via `connect()` once
+	 * the caller has confirmed the server session exists. Decoupling the
+	 * DOM from the transport is what lets a terminal survive workspace
+	 * switches without an in-flight WebSocket being opened against a
+	 * nonexistent session.
+	 */
+	mount(
 		terminalId: string,
 		container: HTMLDivElement,
-		wsUrl: string,
 		appearance: TerminalAppearance,
 	) {
+		const existed = this.entries.has(terminalId);
 		const entry = this.getOrCreateEntry(terminalId);
+		termLog("registry:mount", {
+			terminalId,
+			entryExisted: existed,
+			hadRuntime: !!entry.runtime,
+			registrySize: this.entries.size,
+		});
 
 		if (!entry.runtime) {
 			entry.runtime = createRuntime(terminalId, appearance);
 			entry.linkManager = new TerminalLinkManager(entry.runtime.terminal);
-			// Apply pending handlers if setLinkHandlers was called before attach
 			if (entry.pendingLinkHandlers) {
 				entry.linkManager.setHandlers(entry.pendingLinkHandlers);
 				entry.pendingLinkHandlers = null;
@@ -72,17 +96,59 @@ class TerminalRuntimeRegistryImpl {
 		}
 
 		const { runtime, transport } = entry;
-
 		attachToContainer(runtime, container, () => {
 			sendResize(transport, runtime.terminal.cols, runtime.terminal.rows);
 		});
+	}
 
-		connect(transport, runtime.terminal, wsUrl);
+	/**
+	 * Open (or re-use) the WebSocket transport for this terminal.
+	 * Caller is responsible for ensuring the server session exists before
+	 * calling — otherwise the server replies "Session not found".
+	 *
+	 * Idempotent: no-op if already connected/connecting to the same URL.
+	 */
+	connect(terminalId: string, wsUrl: string) {
+		const entry = this.entries.get(terminalId);
+		if (!entry?.runtime) return;
+		termLog("registry:connect", {
+			terminalId,
+			prevState: entry.transport.connectionState,
+			prevUrl: entry.transport.currentUrl,
+			nextUrl: wsUrl,
+		});
+		connect(entry.transport, entry.runtime.terminal, wsUrl);
+	}
+
+	/**
+	 * Swap the transport onto a new URL *only if* it's already live.
+	 * Used by effects watching `websocketUrl` — they fire on initial mount
+	 * when the transport hasn't been opened yet (ensureSession is still
+	 * in-flight), and we must not pre-empt that with a premature connect.
+	 */
+	reconnect(terminalId: string, wsUrl: string) {
+		const entry = this.entries.get(terminalId);
+		if (!entry?.runtime) return;
+		const state = entry.transport.connectionState;
+		if (state === "disconnected") {
+			termLog("registry:reconnect-skip", { terminalId, reason: "no-transport" });
+			return;
+		}
+		if (entry.transport.currentUrl === wsUrl) {
+			termLog("registry:reconnect-skip", { terminalId, reason: "same-url" });
+			return;
+		}
+		termLog("registry:reconnect", {
+			terminalId,
+			prevUrl: entry.transport.currentUrl,
+			nextUrl: wsUrl,
+		});
+		connect(entry.transport, entry.runtime.terminal, wsUrl);
 	}
 
 	/**
 	 * Set link handler callbacks for a terminal. Safe to call before or after
-	 * attach(). If the runtime already exists, link providers are re-registered.
+	 * mount(). If the runtime already exists, link providers are re-registered.
 	 */
 	setLinkHandlers(terminalId: string, handlers: TerminalLinkHandlers) {
 		const entry = this.getOrCreateEntry(terminalId);
@@ -93,8 +159,18 @@ class TerminalRuntimeRegistryImpl {
 		}
 	}
 
+	/**
+	 * Park the wrapper in the hidden body-level container. Runtime and
+	 * transport stay alive; DOM is moved off the React-controlled tree so
+	 * it survives the parent unmount without re-entering xterm.open().
+	 */
 	detach(terminalId: string) {
 		const entry = this.entries.get(terminalId);
+		termLog("registry:detach", {
+			terminalId,
+			found: !!entry,
+			hadRuntime: !!entry?.runtime,
+		});
 		if (!entry?.runtime) return;
 
 		detachFromContainer(entry.runtime);
@@ -117,6 +193,11 @@ class TerminalRuntimeRegistryImpl {
 
 	dispose(terminalId: string) {
 		const entry = this.entries.get(terminalId);
+		termLog("registry:dispose", {
+			terminalId,
+			found: !!entry,
+			stack: new Error().stack?.split("\n").slice(1, 6).join(" <- "),
+		});
 		if (!entry) return;
 
 		entry.linkManager?.dispose();

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -101,10 +101,16 @@ class TerminalRuntimeRegistryImpl {
 	}
 
 	/**
-	 * Swap the transport onto a new URL *only if* it's already live.
-	 * Used by effects watching `websocketUrl` — they fire on initial mount
-	 * when the transport hasn't been opened yet (ensureSession is still
-	 * in-flight), and we must not pre-empt that with a premature connect.
+	 * Swap the transport onto a new URL when it's already been brought up
+	 * once. Used by effects watching `websocketUrl` — they fire on initial
+	 * mount when the transport is still `"disconnected"` and ensureSession
+	 * is in-flight, and we must not pre-empt that with a premature connect.
+	 *
+	 * Skipped states: `"disconnected"` (never opened; caller should use
+	 * `connect()` via the ensureSession path). Allowed states: `"connecting"`
+	 * (connect() cleanly aborts the in-flight socket), `"open"` (standard
+	 * swap), and `"closed"` (previously live and mid-auto-reconnect — swap
+	 * the URL so the reconnect targets the new endpoint).
 	 */
 	reconnect(terminalId: string, wsUrl: string) {
 		const entry = this.entries.get(terminalId);

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -14,16 +14,6 @@ const DIMS_KEY_PREFIX = "terminal-dims:";
 const DEFAULT_COLS = 120;
 const DEFAULT_ROWS = 32;
 
-// Temporary instrumentation — filter with `[term]` in DevTools console.
-// Remove once workspace-switch reattach is confirmed stable.
-export function termLog(action: string, detail?: Record<string, unknown>) {
-	if (detail) {
-		console.log(`[term] ${action}`, detail);
-	} else {
-		console.log(`[term] ${action}`);
-	}
-}
-
 // xterm's _keyDown calls stopPropagation after processing, which kills the
 // bubble to react-hotkeys-hook. Returning false from the custom handler makes
 // xterm bail before that, so app hotkeys reach document. (VSCode pattern:
@@ -168,7 +158,6 @@ export function createRuntime(
 	terminalId: string,
 	appearance: TerminalAppearance,
 ): TerminalRuntime {
-	termLog("runtime:create", { terminalId });
 	const savedDims = loadSavedDimensions(terminalId);
 	const cols = savedDims?.cols ?? DEFAULT_COLS;
 	const rows = savedDims?.rows ?? DEFAULT_ROWS;
@@ -212,22 +201,12 @@ export function attachToContainer(
 	container: HTMLDivElement,
 	onResize?: () => void,
 ) {
-	const prevParent = runtime.wrapper.parentElement;
-	const sameContainer = runtime.container === container && prevParent === container;
-	termLog("runtime:attach", {
-		terminalId: runtime.terminalId,
-		prevParent: prevParent?.id || prevParent?.tagName || "none",
-		wasParked: prevParent?.id === PARKING_CONTAINER_ID,
-		sameContainer,
-		containerW: container.clientWidth,
-		containerH: container.clientHeight,
-		cols: runtime.terminal.cols,
-		rows: runtime.terminal.rows,
-	});
-
 	// If we're already attached to this exact container, do nothing. Prevents
 	// redundant refresh/focus/fit from transient remounts during provider key
 	// churn — VSCode setVisible() is idempotent for the same host element.
+	const sameContainer =
+		runtime.container === container &&
+		runtime.wrapper.parentElement === container;
 	if (sameContainer && runtime.resizeObserver) {
 		return;
 	}
@@ -251,11 +230,6 @@ export function attachToContainer(
 }
 
 export function detachFromContainer(runtime: TerminalRuntime) {
-	termLog("runtime:detach", {
-		terminalId: runtime.terminalId,
-		lastCols: runtime.lastCols,
-		lastRows: runtime.lastRows,
-	});
 	persistBuffer(runtime.terminalId, runtime.serializeAddon);
 	persistDimensions(runtime.terminalId, runtime.lastCols, runtime.lastRows);
 	runtime.resizeObserver?.disconnect();
@@ -292,7 +266,6 @@ export function updateRuntimeAppearance(
 }
 
 export function disposeRuntime(runtime: TerminalRuntime) {
-	termLog("runtime:dispose", { terminalId: runtime.terminalId });
 	runtime._disposeAddons?.();
 	runtime._disposeAddons = null;
 	runtime.resizeObserver?.disconnect();

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -14,6 +14,16 @@ const DIMS_KEY_PREFIX = "terminal-dims:";
 const DEFAULT_COLS = 120;
 const DEFAULT_ROWS = 32;
 
+// Temporary instrumentation — filter with `[term]` in DevTools console.
+// Remove once workspace-switch reattach is confirmed stable.
+export function termLog(action: string, detail?: Record<string, unknown>) {
+	if (detail) {
+		console.log(`[term] ${action}`, detail);
+	} else {
+		console.log(`[term] ${action}`);
+	}
+}
+
 // xterm's _keyDown calls stopPropagation after processing, which kills the
 // bubble to react-hotkeys-hook. Returning false from the custom handler makes
 // xterm bail before that, so app hotkeys reach document. (VSCode pattern:
@@ -124,6 +134,29 @@ function hostIsVisible(container: HTMLDivElement | null): boolean {
 	return container.clientWidth > 0 && container.clientHeight > 0;
 }
 
+// Body-level hidden container that owns wrapper divs of terminals whose
+// React component is currently unmounted (e.g. workspace switch). Keeps
+// xterm attached to the document so it survives provider remounts without
+// a detach/reattach flash — VSCode's setVisible(false) model. Looked up
+// by DOM id so it's HMR-safe (module-level `let` would leak on re-eval).
+const PARKING_CONTAINER_ID = "v2-terminal-parking";
+function getParkingContainer(): HTMLDivElement {
+	const existing = document.getElementById(PARKING_CONTAINER_ID);
+	if (existing) return existing as HTMLDivElement;
+
+	const el = document.createElement("div");
+	el.id = PARKING_CONTAINER_ID;
+	el.style.position = "fixed";
+	el.style.left = "-9999px";
+	el.style.top = "-9999px";
+	el.style.width = "100vw";
+	el.style.height = "100vh";
+	el.style.overflow = "hidden";
+	el.style.pointerEvents = "none";
+	document.body.appendChild(el);
+	return el;
+}
+
 function measureAndResize(runtime: TerminalRuntime) {
 	if (!hostIsVisible(runtime.container)) return;
 	runtime.fitAddon.fit();
@@ -135,6 +168,7 @@ export function createRuntime(
 	terminalId: string,
 	appearance: TerminalAppearance,
 ): TerminalRuntime {
+	termLog("runtime:create", { terminalId });
 	const savedDims = loadSavedDimensions(terminalId);
 	const cols = savedDims?.cols ?? DEFAULT_COLS;
 	const rows = savedDims?.rows ?? DEFAULT_ROWS;
@@ -178,6 +212,26 @@ export function attachToContainer(
 	container: HTMLDivElement,
 	onResize?: () => void,
 ) {
+	const prevParent = runtime.wrapper.parentElement;
+	const sameContainer = runtime.container === container && prevParent === container;
+	termLog("runtime:attach", {
+		terminalId: runtime.terminalId,
+		prevParent: prevParent?.id || prevParent?.tagName || "none",
+		wasParked: prevParent?.id === PARKING_CONTAINER_ID,
+		sameContainer,
+		containerW: container.clientWidth,
+		containerH: container.clientHeight,
+		cols: runtime.terminal.cols,
+		rows: runtime.terminal.rows,
+	});
+
+	// If we're already attached to this exact container, do nothing. Prevents
+	// redundant refresh/focus/fit from transient remounts during provider key
+	// churn — VSCode setVisible() is idempotent for the same host element.
+	if (sameContainer && runtime.resizeObserver) {
+		return;
+	}
+
 	runtime.container = container;
 	container.appendChild(runtime.wrapper);
 	measureAndResize(runtime);
@@ -197,11 +251,21 @@ export function attachToContainer(
 }
 
 export function detachFromContainer(runtime: TerminalRuntime) {
+	termLog("runtime:detach", {
+		terminalId: runtime.terminalId,
+		lastCols: runtime.lastCols,
+		lastRows: runtime.lastRows,
+	});
 	persistBuffer(runtime.terminalId, runtime.serializeAddon);
 	persistDimensions(runtime.terminalId, runtime.lastCols, runtime.lastRows);
 	runtime.resizeObserver?.disconnect();
 	runtime.resizeObserver = null;
-	runtime.wrapper.remove();
+	// Move the wrapper into a hidden body-level container instead of removing
+	// it. xterm stays attached to the document, so a subsequent attachToContainer
+	// is a DOM move (no renderer teardown, no flicker) — matching VSCode's
+	// setVisible(false) behavior under our constraint that the React subtree
+	// must unmount across workspace switches.
+	getParkingContainer().appendChild(runtime.wrapper);
 	runtime.container = null;
 }
 
@@ -228,6 +292,7 @@ export function updateRuntimeAppearance(
 }
 
 export function disposeRuntime(runtime: TerminalRuntime) {
+	termLog("runtime:dispose", { terminalId: runtime.terminalId });
 	runtime._disposeAddons?.();
 	runtime._disposeAddons = null;
 	runtime.resizeObserver?.disconnect();

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -129,6 +129,9 @@ function hostIsVisible(container: HTMLDivElement | null): boolean {
 // xterm attached to the document so it survives provider remounts without
 // a detach/reattach flash — VSCode's setVisible(false) model. Looked up
 // by DOM id so it's HMR-safe (module-level `let` would leak on re-eval).
+// `inert` removes the whole subtree from the tab order and the accessibility
+// tree, and also moves focus out of it — so a parked terminal's internal
+// <textarea> can't receive keystrokes meant for the active pane.
 const PARKING_CONTAINER_ID = "v2-terminal-parking";
 function getParkingContainer(): HTMLDivElement {
 	const existing = document.getElementById(PARKING_CONTAINER_ID);
@@ -136,6 +139,8 @@ function getParkingContainer(): HTMLDivElement {
 
 	const el = document.createElement("div");
 	el.id = PARKING_CONTAINER_ID;
+	el.setAttribute("inert", "");
+	el.setAttribute("aria-hidden", "true");
 	el.style.position = "fixed";
 	el.style.left = "-9999px";
 	el.style.top = "-9999px";

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -239,11 +239,8 @@ export function detachFromContainer(runtime: TerminalRuntime) {
 	persistDimensions(runtime.terminalId, runtime.lastCols, runtime.lastRows);
 	runtime.resizeObserver?.disconnect();
 	runtime.resizeObserver = null;
-	// Move the wrapper into a hidden body-level container instead of removing
-	// it. xterm stays attached to the document, so a subsequent attachToContainer
-	// is a DOM move (no renderer teardown, no flicker) — matching VSCode's
-	// setVisible(false) behavior under our constraint that the React subtree
-	// must unmount across workspace switches.
+	// Park instead of .remove() so xterm survives the React unmount —
+	// see getParkingContainer.
 	getParkingContainer().appendChild(runtime.wrapper);
 	runtime.container = null;
 }

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -1,4 +1,5 @@
 import type { Terminal as XTerm } from "@xterm/xterm";
+import { termLog } from "./terminal-runtime";
 
 export type ConnectionState = "disconnected" | "connecting" | "open" | "closed";
 
@@ -29,7 +30,9 @@ function setConnectionState(
 	transport: TerminalTransport,
 	state: ConnectionState,
 ) {
+	const prev = transport.connectionState;
 	transport.connectionState = state;
+	termLog("transport:state", { prev, next: state, url: transport.currentUrl });
 	for (const listener of transport.stateListeners) {
 		listener();
 	}
@@ -93,7 +96,20 @@ export function connect(
 	const isActive =
 		transport.connectionState === "open" ||
 		transport.connectionState === "connecting";
-	if (isActive && transport.currentUrl === wsUrl) return;
+	if (isActive && transport.currentUrl === wsUrl) {
+		termLog("transport:connect-skip", {
+			reason: "idempotent",
+			state: transport.connectionState,
+			url: wsUrl,
+		});
+		return;
+	}
+	termLog("transport:connect", {
+		prevState: transport.connectionState,
+		prevUrl: transport.currentUrl,
+		nextUrl: wsUrl,
+		willCloseSocket: !!transport.socket,
+	});
 
 	if (transport.socket) {
 		transport.socket.close();
@@ -201,6 +217,10 @@ export function sendDispose(transport: TerminalTransport) {
 }
 
 export function disposeTransport(transport: TerminalTransport) {
+	termLog("transport:dispose", {
+		state: transport.connectionState,
+		url: transport.currentUrl,
+	});
 	cancelReconnect(transport);
 	if (transport.socket) {
 		transport.socket.close();

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -1,5 +1,4 @@
 import type { Terminal as XTerm } from "@xterm/xterm";
-import { termLog } from "./terminal-runtime";
 
 export type ConnectionState = "disconnected" | "connecting" | "open" | "closed";
 
@@ -30,9 +29,7 @@ function setConnectionState(
 	transport: TerminalTransport,
 	state: ConnectionState,
 ) {
-	const prev = transport.connectionState;
 	transport.connectionState = state;
-	termLog("transport:state", { prev, next: state, url: transport.currentUrl });
 	for (const listener of transport.stateListeners) {
 		listener();
 	}
@@ -96,20 +93,7 @@ export function connect(
 	const isActive =
 		transport.connectionState === "open" ||
 		transport.connectionState === "connecting";
-	if (isActive && transport.currentUrl === wsUrl) {
-		termLog("transport:connect-skip", {
-			reason: "idempotent",
-			state: transport.connectionState,
-			url: wsUrl,
-		});
-		return;
-	}
-	termLog("transport:connect", {
-		prevState: transport.connectionState,
-		prevUrl: transport.currentUrl,
-		nextUrl: wsUrl,
-		willCloseSocket: !!transport.socket,
-	});
+	if (isActive && transport.currentUrl === wsUrl) return;
 
 	if (transport.socket) {
 		transport.socket.close();
@@ -217,10 +201,6 @@ export function sendDispose(transport: TerminalTransport) {
 }
 
 export function disposeTransport(transport: TerminalTransport) {
-	termLog("transport:dispose", {
-		state: transport.connectionState,
-		url: transport.currentUrl,
-	});
 	cancelReconnect(transport);
 	if (transport.socket) {
 		transport.socket.close();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -2,6 +2,7 @@ import type { RendererContext } from "@superset/panes";
 import { workspaceTrpc } from "@superset/workspace-client";
 import "@xterm/xterm/css/xterm.css";
 import {
+	useCallback,
 	useEffect,
 	useMemo,
 	useRef,
@@ -37,15 +38,6 @@ interface TerminalPaneProps {
 	workspaceId: string;
 	onOpenFile: (path: string, openInNewTab?: boolean) => void;
 	onRevealPath: (path: string, options?: { isDirectory?: boolean }) => void;
-}
-
-function subscribeToState(terminalId: string) {
-	return (callback: () => void) =>
-		terminalRuntimeRegistry.onStateChange(terminalId, callback);
-}
-
-function getConnectionState(terminalId: string): ConnectionState {
-	return terminalRuntimeRegistry.getConnectionState(terminalId);
 }
 
 export function TerminalPane({
@@ -91,10 +83,21 @@ export function TerminalPane({
 	const ensureSessionRef = useRef(ensureSession);
 	ensureSessionRef.current = ensureSession;
 
-	const connectionState = useSyncExternalStore(
-		subscribeToState(terminalId),
-		() => getConnectionState(terminalId),
+	// useCallback so useSyncExternalStore doesn't re-subscribe every render —
+	// otherwise every keystroke-triggered re-render unsubscribes and
+	// re-subscribes the registry listener. See React's useSyncExternalStore
+	// docs ("If you don't memoize the subscribe function…").
+	const subscribe = useCallback(
+		(callback: () => void) =>
+			terminalRuntimeRegistry.onStateChange(terminalId, callback),
+		[terminalId],
 	);
+	const getSnapshot = useCallback(
+		(): ConnectionState =>
+			terminalRuntimeRegistry.getConnectionState(terminalId),
+		[terminalId],
+	);
+	const connectionState = useSyncExternalStore(subscribe, getSnapshot);
 
 	// DOM-first lifecycle (VSCode/Tabby pattern):
 	//   1. mount() attaches xterm to the container synchronously — terminal

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -10,7 +10,6 @@ import {
 } from "react";
 import { useTerminalLinkActions } from "renderer/hooks/useV2UserPreferences";
 import { useHotkey } from "renderer/hotkeys";
-import { termLog } from "renderer/lib/terminal/terminal-runtime";
 import {
 	type ConnectionState,
 	terminalRuntimeRegistry,
@@ -113,21 +112,9 @@ export function TerminalPane({
 		const container = containerRef.current;
 		if (!container) return;
 
-		termLog("pane:effect-mount", {
-			terminalId,
-			workspaceId: workspaceIdRef.current,
-			wsUrl: websocketUrlRef.current,
-			containerW: container.clientWidth,
-			containerH: container.clientHeight,
-		});
-
 		// DOM first — synchronous. Empty cursor visible immediately on cold
 		// mount; on warm return this unparks the wrapper.
-		terminalRuntimeRegistry.mount(
-			terminalId,
-			container,
-			appearanceRef.current,
-		);
+		terminalRuntimeRegistry.mount(terminalId, container, appearanceRef.current);
 
 		let cancelled = false;
 
@@ -141,39 +128,21 @@ export function TerminalPane({
 				themeType: initialThemeTypeRef.current,
 			})
 			.then(() => {
-				if (cancelled) {
-					termLog("pane:ensureSession-cancelled", { terminalId });
-					return;
-				}
-				termLog("pane:ensureSession-ok", { terminalId });
-				terminalRuntimeRegistry.connect(
-					terminalId,
-					websocketUrlRef.current,
-				);
+				if (cancelled) return;
+				terminalRuntimeRegistry.connect(terminalId, websocketUrlRef.current);
 			})
 			.catch((err) => {
 				if (cancelled) return;
-				termLog("pane:ensureSession-err", {
-					terminalId,
-					err: err instanceof Error ? err.message : String(err),
-				});
 				console.error("[TerminalPane] ensureSession failed:", err);
 				// Try connecting anyway — if the session actually exists (we
 				// raced another client), it'll succeed; otherwise the server's
 				// "Session not found" surfaces in-terminal as an error line,
 				// which is the same failure mode as before.
-				terminalRuntimeRegistry.connect(
-					terminalId,
-					websocketUrlRef.current,
-				);
+				terminalRuntimeRegistry.connect(terminalId, websocketUrlRef.current);
 			});
 
 		return () => {
 			cancelled = true;
-			termLog("pane:effect-cleanup", {
-				terminalId,
-				workspaceId: workspaceIdRef.current,
-			});
 			terminalRuntimeRegistry.detach(terminalId);
 		};
 	}, [terminalId]);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 import { useTerminalLinkActions } from "renderer/hooks/useV2UserPreferences";
 import { useHotkey } from "renderer/hotkeys";
+import { termLog } from "renderer/lib/terminal/terminal-runtime";
 import {
 	type ConnectionState,
 	terminalRuntimeRegistry,
@@ -78,11 +79,14 @@ export function TerminalPane({
 			activeThemeType: activeTheme?.type,
 		}),
 	);
-	const initialThemeType = initialThemeTypeRef.current;
 
 	// URL is stable — no workspaceId/themeType in query params.
 	// Session is created via tRPC before WebSocket connects.
 	const websocketUrl = useWorkspaceWsUrl(`/terminal/${terminalId}`);
+	const websocketUrlRef = useRef(websocketUrl);
+	websocketUrlRef.current = websocketUrl;
+	const workspaceIdRef = useRef(workspaceId);
+	workspaceIdRef.current = workspaceId;
 
 	const ensureSession = workspaceTrpc.terminal.ensureSession.useMutation();
 	const ensureSessionRef = useRef(ensureSession);
@@ -93,45 +97,94 @@ export function TerminalPane({
 		() => getConnectionState(terminalId),
 	);
 
+	// DOM-first lifecycle (VSCode/Tabby pattern):
+	//   1. mount() attaches xterm to the container synchronously — terminal
+	//      is visible immediately, even on cold start. For a warm return
+	//      (workspace switch) this reparents the wrapper from the parking
+	//      container back into the live tree, preserving the buffer.
+	//   2. ensureSession guarantees the server session exists, then connect()
+	//      opens the WebSocket. Never before — otherwise the server replies
+	//      "Session not found."
+	// Deps narrowed to [terminalId] so provider key remount churn (workspaceId
+	// briefly flipping while pane data catches up) doesn't re-run this effect.
+	// workspaceId / websocketUrl are read through refs.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional — see comment above
 	useEffect(() => {
 		const container = containerRef.current;
 		if (!container) return;
 
+		termLog("pane:effect-mount", {
+			terminalId,
+			workspaceId: workspaceIdRef.current,
+			wsUrl: websocketUrlRef.current,
+			containerW: container.clientWidth,
+			containerH: container.clientHeight,
+		});
+
+		// DOM first — synchronous. Empty cursor visible immediately on cold
+		// mount; on warm return this unparks the wrapper.
+		terminalRuntimeRegistry.mount(
+			terminalId,
+			container,
+			appearanceRef.current,
+		);
+
 		let cancelled = false;
 
-		// Create session via tRPC, then connect WebSocket as data pipe.
+		// Ensure the server session exists, then connect the transport.
+		// connect() is idempotent — for a warm terminal whose WS is already
+		// open against the same URL, this is a no-op.
 		ensureSessionRef.current
 			.mutateAsync({
 				terminalId,
-				workspaceId,
-				themeType: initialThemeType,
+				workspaceId: workspaceIdRef.current,
+				themeType: initialThemeTypeRef.current,
 			})
 			.then(() => {
-				if (cancelled) return;
-				terminalRuntimeRegistry.attach(
+				if (cancelled) {
+					termLog("pane:ensureSession-cancelled", { terminalId });
+					return;
+				}
+				termLog("pane:ensureSession-ok", { terminalId });
+				terminalRuntimeRegistry.connect(
 					terminalId,
-					container,
-					websocketUrl,
-					appearanceRef.current,
+					websocketUrlRef.current,
 				);
 			})
 			.catch((err) => {
 				if (cancelled) return;
-				console.error("[TerminalPane] ensureSession failed:", err);
-				// Still try to connect — WS handler has fallback for existing sessions
-				terminalRuntimeRegistry.attach(
+				termLog("pane:ensureSession-err", {
 					terminalId,
-					container,
-					websocketUrl,
-					appearanceRef.current,
+					err: err instanceof Error ? err.message : String(err),
+				});
+				console.error("[TerminalPane] ensureSession failed:", err);
+				// Try connecting anyway — if the session actually exists (we
+				// raced another client), it'll succeed; otherwise the server's
+				// "Session not found" surfaces in-terminal as an error line,
+				// which is the same failure mode as before.
+				terminalRuntimeRegistry.connect(
+					terminalId,
+					websocketUrlRef.current,
 				);
 			});
 
 		return () => {
 			cancelled = true;
+			termLog("pane:effect-cleanup", {
+				terminalId,
+				workspaceId: workspaceIdRef.current,
+			});
 			terminalRuntimeRegistry.detach(terminalId);
 		};
-	}, [terminalId, websocketUrl, initialThemeType, workspaceId]);
+	}, [terminalId]);
+
+	// WS URL can change while the terminal stays mounted (token refresh, host
+	// URL re-resolution on provider remount). Reconnect only if the transport
+	// is already live — on initial mount the transport is "disconnected" and
+	// we let the ensureSession path above open it.
+	useEffect(() => {
+		terminalRuntimeRegistry.reconnect(terminalId, websocketUrl);
+	}, [terminalId, websocketUrl]);
 
 	useEffect(() => {
 		terminalRuntimeRegistry.updateAppearance(terminalId, appearance);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -111,32 +111,26 @@ export function TerminalPane({
 		const container = containerRef.current;
 		if (!container) return;
 
-		// DOM first — synchronous. Empty cursor visible immediately on cold
-		// mount; on warm return this unparks the wrapper.
 		terminalRuntimeRegistry.mount(terminalId, container, appearanceRef.current);
 
 		let cancelled = false;
 
-		// Ensure the server session exists, then connect the transport.
-		// connect() is idempotent — for a warm terminal whose WS is already
-		// open against the same URL, this is a no-op.
+		// Always connect after ensureSession settles, even on error: if the
+		// session actually exists on the server (e.g. we raced another client),
+		// connect() succeeds; otherwise "Session not found" surfaces in-terminal
+		// as an error line. connect() is idempotent, so a warm terminal whose
+		// WS is already open against the same URL is a no-op.
 		ensureSessionRef.current
 			.mutateAsync({
 				terminalId,
 				workspaceId: workspaceIdRef.current,
 				themeType: initialThemeTypeRef.current,
 			})
-			.then(() => {
-				if (cancelled) return;
-				terminalRuntimeRegistry.connect(terminalId, websocketUrlRef.current);
-			})
 			.catch((err) => {
-				if (cancelled) return;
 				console.error("[TerminalPane] ensureSession failed:", err);
-				// Try connecting anyway — if the session actually exists (we
-				// raced another client), it'll succeed; otherwise the server's
-				// "Session not found" surfaces in-terminal as an error line,
-				// which is the same failure mode as before.
+			})
+			.finally(() => {
+				if (cancelled) return;
 				terminalRuntimeRegistry.connect(terminalId, websocketUrlRef.current);
 			});
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -107,7 +107,6 @@ export function TerminalPane({
 	// Deps narrowed to [terminalId] so provider key remount churn (workspaceId
 	// briefly flipping while pane data catches up) doesn't re-run this effect.
 	// workspaceId / websocketUrl are read through refs.
-	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional — see comment above
 	useEffect(() => {
 		const container = containerRef.current;
 		if (!container) return;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -40,11 +40,7 @@ import type {
 	PaneViewerData,
 	TerminalPaneData,
 } from "../../types";
-import {
-	BrowserPane,
-	BrowserPaneToolbar,
-	browserRuntimeRegistry,
-} from "./components/BrowserPane";
+import { BrowserPane, BrowserPaneToolbar } from "./components/BrowserPane";
 import { CommentPane } from "./components/CommentPane";
 import { DiffPane } from "./components/DiffPane";
 import { FilePane } from "./components/FilePane";
@@ -334,7 +330,11 @@ export function usePaneRegistry(
 				renderToolbar: (ctx: RendererContext<PaneViewerData>) => (
 					<BrowserPaneToolbar ctx={ctx} />
 				),
-				onRemoved: (pane) => browserRuntimeRegistry.destroy(pane.id),
+				// Destruction is handled by useGlobalBrowserLifecycle instead —
+				// the Panes library's onRemoved diff fires on transient workspace-
+				// switch churn (when the pane store replaceState's in place rather
+				// than remounting) and would prematurely destroy webviews whose
+				// owning workspace is still present.
 				contextMenuActions: (_ctx, defaults) =>
 					defaults.map((d) =>
 						d.key === "close-pane" ? { ...d, label: "Close Browser" } : d,

--- a/apps/desktop/src/renderer/routes/_authenticated/components/GlobalBrowserLifecycle/GlobalBrowserLifecycle.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/GlobalBrowserLifecycle/GlobalBrowserLifecycle.tsx
@@ -1,0 +1,6 @@
+import { useGlobalBrowserLifecycle } from "./hooks/useGlobalBrowserLifecycle";
+
+export function GlobalBrowserLifecycle() {
+	useGlobalBrowserLifecycle();
+	return null;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/GlobalBrowserLifecycle/hooks/useGlobalBrowserLifecycle/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/GlobalBrowserLifecycle/hooks/useGlobalBrowserLifecycle/index.ts
@@ -1,0 +1,1 @@
+export { useGlobalBrowserLifecycle } from "./useGlobalBrowserLifecycle";

--- a/apps/desktop/src/renderer/routes/_authenticated/components/GlobalBrowserLifecycle/hooks/useGlobalBrowserLifecycle/useGlobalBrowserLifecycle.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/GlobalBrowserLifecycle/hooks/useGlobalBrowserLifecycle/useGlobalBrowserLifecycle.ts
@@ -1,0 +1,102 @@
+import type { WorkspaceState } from "@superset/panes";
+import { useLiveQuery } from "@tanstack/react-db";
+import { useEffect, useRef } from "react";
+import { browserRuntimeRegistry } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+
+/**
+ * Grace period for cross-workspace pane moves / renames before destroying.
+ * Matches the terminal-side timing so the two runtimes behave consistently.
+ */
+const DESTROY_DELAY_MS = 500;
+
+function extractBrowserPaneIds(rows: { paneLayout: unknown }[]): Set<string> {
+	const ids = new Set<string>();
+	for (const row of rows) {
+		const layout = row.paneLayout as WorkspaceState<unknown> | undefined;
+		if (!layout?.tabs) continue;
+		for (const tab of layout.tabs) {
+			for (const pane of Object.values(tab.panes)) {
+				if (pane.kind === "browser") {
+					ids.add(pane.id);
+				}
+			}
+		}
+	}
+	return ids;
+}
+
+/**
+ * Global sweeper that destroys browser registry entries whose paneId is no
+ * longer present in ANY workspace's persisted layout. Replaces the Panes
+ * library's `onRemoved` hook for browsers — `onRemoved` fires on transient
+ * "missing from previous render" diffs during v2 workspace switches (the
+ * provider key doesn't always remount promptly, so the pane store gets
+ * `replaceState`'d in place and the diff looks like a removal), which
+ * prematurely tore down webviews. Comparing against the persisted store is
+ * authoritative.
+ *
+ * Mirrors useGlobalTerminalLifecycle by design.
+ */
+export function useGlobalBrowserLifecycle() {
+	const collections = useCollections();
+	const prevBrowserIdsRef = useRef<Set<string>>(new Set());
+	const pendingDestruction = useRef<Map<string, ReturnType<typeof setTimeout>>>(
+		new Map(),
+	);
+
+	const { data: allWorkspaceRows = [] } = useLiveQuery(
+		(query) =>
+			query.from({
+				v2WorkspaceLocalState: collections.v2WorkspaceLocalState,
+			}),
+		[collections],
+	);
+
+	useEffect(() => {
+		const currentBrowserIds = extractBrowserPaneIds(allWorkspaceRows);
+		const prevBrowserIds = prevBrowserIdsRef.current;
+
+		// Cancel any pending destruction for ids that reappeared (e.g. pane
+		// moved between workspaces, user undo, or the transient replaceState
+		// churn we were fighting in the first place).
+		for (const browserId of currentBrowserIds) {
+			const timer = pendingDestruction.current.get(browserId);
+			if (timer) {
+				clearTimeout(timer);
+				pendingDestruction.current.delete(browserId);
+			}
+		}
+
+		for (const browserId of prevBrowserIds) {
+			if (currentBrowserIds.has(browserId)) continue;
+			if (pendingDestruction.current.has(browserId)) continue;
+
+			const timer = setTimeout(() => {
+				pendingDestruction.current.delete(browserId);
+
+				const freshRows = Array.from(
+					collections.v2WorkspaceLocalState.state.values(),
+				);
+				const freshIds = extractBrowserPaneIds(freshRows);
+
+				if (!freshIds.has(browserId)) {
+					browserRuntimeRegistry.destroy(browserId);
+				}
+			}, DESTROY_DELAY_MS);
+
+			pendingDestruction.current.set(browserId, timer);
+		}
+
+		prevBrowserIdsRef.current = currentBrowserIds;
+	}, [allWorkspaceRows, collections]);
+
+	useEffect(() => {
+		return () => {
+			for (const timer of pendingDestruction.current.values()) {
+				clearTimeout(timer);
+			}
+			pendingDestruction.current.clear();
+		};
+	}, []);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/GlobalBrowserLifecycle/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/GlobalBrowserLifecycle/index.ts
@@ -1,0 +1,1 @@
+export { GlobalBrowserLifecycle } from "./GlobalBrowserLifecycle";

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -32,6 +32,7 @@ import { setPaneWorkspaceRunState } from "renderer/stores/tabs/workspace-run";
 import { useWorkspaceInitStore } from "renderer/stores/workspace-init";
 import { MOCK_ORG_ID, NOTIFICATION_EVENTS } from "shared/constants";
 import { AgentHooks } from "./components/AgentHooks";
+import { GlobalBrowserLifecycle } from "./components/GlobalBrowserLifecycle";
 import { GlobalTerminalLifecycle } from "./components/GlobalTerminalLifecycle";
 import { TeardownLogsDialog } from "./components/TeardownLogsDialog";
 import { createPierreWorker } from "./lib/pierreWorker";
@@ -183,6 +184,7 @@ function AuthenticatedLayout() {
 		<DndProvider manager={dragDropManager}>
 			<CollectionsProvider>
 				<GlobalTerminalLifecycle />
+				<GlobalBrowserLifecycle />
 				<LocalHostServiceProvider>
 					<DeletingWorkspacesProvider>
 						<WorkerPoolContextProvider


### PR DESCRIPTION
## Summary

Both v2 terminals and browsers were visibly rebuilt on every workspace switch. Root cause is a shared lifecycle hazard — the v2 layout's `WorkspaceTrpcProvider` `key` remount + the way `useLiveQuery` updates can propagate — but the fixes are different for each runtime.

### Terminal (commit `e56992653`)
- Park the xterm wrapper in a hidden body-level `#v2-terminal-parking` div on detach instead of `wrapper.remove()`, so xterm stays in the document and the next mount is a DOM move back.
- Split `registry.attach` into `mount` (synchronous DOM) and `connect` (called only after `ensureSession`). Matches VSCode `TerminalInstance.attachToElement` + `_createProcess` and Tabby's `XTermFrontend.attach` + `setSession`. Eliminates the "Session not found" race on cold mount and the tRPC-gated delay on warm return.
- Narrow `TerminalPane`'s attach effect deps to `[terminalId]`; `workspaceId` / `websocketUrl` go through refs. `websocketUrl` changes route through `registry.reconnect()`, which hard-guards on the transport already being live.

### Browser (commit `3b88c0207`)
- `onRemoved: (pane) => browserRuntimeRegistry.destroy(pane.id)` in `usePaneRegistry` was firing during workspace switches when the provider key didn't remount promptly: the existing `WorkspaceContent` stayed mounted, `useV2WorkspacePaneLayout` called `store.replaceState(WS-B panes)` on the same store, and the Panes library's diff correctly observed "WS-A's browser is gone now" → destroyed the webview. Return trip ran the cold `createEntry` path, losing state.
- Fix: new `useGlobalBrowserLifecycle` sweeper, mirrors `useGlobalTerminalLifecycle` — diffs browser pane ids across every workspace's persisted `paneLayout` and destroys with a 500 ms grace delay. The `onRemoved` wiring is gone.

### Reference
`apps/desktop/plans/20260423-1226-v2-pane-persistence-across-workspace-switch.md` captures full root-cause analysis for both runtimes, the shared "register state outside the remounting subtree" pattern, and a note on the code editor (same class of risk, not reported yet).

## Test plan

- [ ] Two workspaces each with a terminal — switch back and forth, output and cursor preserved, no flicker, no "Session not found"
- [ ] New terminal in a new tab — xterm frame appears instantly, prompt streams in
- [ ] Two workspaces each with a browser pane — switch back and forth, page stays loaded (URL, scroll, history preserved)
- [ ] Close a terminal pane — actually disposed after grace
- [ ] Close a browser pane — actually disposed after grace
- [ ] `#v2-terminal-parking` and `#browser-runtime-root` visible on `document.body` in DevTools as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed terminal flicker during pane remounts by preserving terminal UI between React remounts.
  * Prevented premature browser/webview teardown during workspace switches.

* **Improvements**
  * Mounts terminal UI immediately and starts socket transport separately for faster, steadier terminal display.
  * Transport updates now reuse existing connections when endpoints change to avoid pane recreation.

* **New Features**
  * Global browser lifecycle manager that defers and debounces webview destruction.

* **Documentation**
  * Added notes on pane persistence and lifecycle strategies across workspace switches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->