### PR TITLE
feat(marketing): simplify product menu and show yearly discount

### DIFF
--- a/apps/marketing/src/app/components/Header/components/DesktopNav/DesktopNav.tsx
+++ b/apps/marketing/src/app/components/Header/components/DesktopNav/DesktopNav.tsx
@@ -17,7 +17,6 @@ import {
 	RESOURCE_LINKS,
 	TOP_LEVEL_LINKS,
 } from "../../constants";
-import { SupersetLogo } from "../SupersetLogo";
 
 const triggerClass = cn(
 	navigationMenuTriggerStyle(),
@@ -33,14 +32,11 @@ export function DesktopNav() {
 						Product
 					</NavigationMenuTrigger>
 					<NavigationMenuContent>
-						<div className="grid w-[560px] grid-cols-[0.9fr_1fr] gap-2 p-2">
-							<FeatureCard />
-							<ul className="flex flex-col gap-1">
-								{PRODUCT_LINKS.map((link) => (
-									<NavListItem key={link.href} link={link} />
-								))}
-							</ul>
-						</div>
+						<ul className="flex w-[320px] flex-col gap-1 p-2">
+							{PRODUCT_LINKS.map((link) => (
+								<NavListItem key={link.href} link={link} />
+							))}
+						</ul>
 					</NavigationMenuContent>
 				</NavigationMenuItem>
 
@@ -66,30 +62,6 @@ export function DesktopNav() {
 				))}
 			</NavigationMenuList>
 		</NavigationMenu>
-	);
-}
-
-function FeatureCard() {
-	return (
-		<NavigationMenuLink asChild className="h-full p-0 hover:bg-transparent">
-			<Link
-				href="/"
-				className="group flex h-full flex-col justify-between rounded-md border border-border bg-gradient-to-br from-accent/60 to-accent/10 p-5 no-underline outline-none transition-colors hover:border-foreground/20"
-			>
-				<div className="text-foreground">
-					<SupersetLogo />
-				</div>
-				<div className="space-y-2">
-					<p className="text-sm font-medium text-foreground">
-						The terminal for coding agents
-					</p>
-					<p className="text-xs leading-relaxed text-muted-foreground">
-						Run 10+ parallel coding agents on your machine and switch between
-						tasks as they need your attention.
-					</p>
-				</div>
-			</Link>
-		</NavigationMenuLink>
 	);
 }
 

--- a/apps/marketing/src/app/pricing/components/PricingTiers/components/PricingCard/PricingCard.tsx
+++ b/apps/marketing/src/app/pricing/components/PricingTiers/components/PricingCard/PricingCard.tsx
@@ -10,7 +10,10 @@ interface PricingCardProps {
 }
 
 export function PricingCard({ tier, isYearly }: PricingCardProps) {
-	const { display, note, cadence } = resolvePrice(tier, isYearly);
+	const { display, strikethrough, note, cadence } = resolvePrice(
+		tier,
+		isYearly,
+	);
 
 	return (
 		<div
@@ -34,12 +37,19 @@ export function PricingCard({ tier, isYearly }: PricingCardProps) {
 			</div>
 
 			<div className="flex flex-col gap-1">
-				<div className="flex items-baseline gap-2">
-					<span className="text-4xl font-medium tracking-tight text-foreground">
+				<div className="flex h-10 items-baseline gap-2">
+					{strikethrough && (
+						<span className="text-2xl font-medium tracking-tight leading-none text-muted-foreground line-through">
+							{strikethrough}
+						</span>
+					)}
+					<span className="text-4xl font-medium tracking-tight leading-none text-foreground">
 						{display}
 					</span>
 					{note && (
-						<span className="text-sm text-muted-foreground">{note}</span>
+						<span className="text-sm leading-none text-muted-foreground">
+							{note}
+						</span>
 					)}
 				</div>
 				{cadence && <p className="text-xs text-muted-foreground">{cadence}</p>}
@@ -72,11 +82,26 @@ export function PricingCard({ tier, isYearly }: PricingCardProps) {
 
 function resolvePrice(tier: PricingTier, isYearly: boolean) {
 	if (tier.price.kind === "fixed") {
-		return { display: tier.price.display, note: "", cadence: tier.price.note };
+		return {
+			display: tier.price.display,
+			strikethrough: null,
+			note: "",
+			cadence: tier.price.note,
+		};
 	}
 	if (tier.price.kind === "custom") {
-		return { display: tier.price.display, note: "", cadence: tier.price.note };
+		return {
+			display: tier.price.display,
+			strikethrough: null,
+			note: "",
+			cadence: tier.price.note,
+		};
 	}
 	const entry = isYearly ? tier.price.yearly : tier.price.monthly;
-	return { display: entry.display, note: entry.note, cadence: entry.cadence };
+	return {
+		display: entry.display,
+		strikethrough: isYearly ? tier.price.monthly.display : null,
+		note: entry.note,
+		cadence: entry.cadence,
+	};
 }


### PR DESCRIPTION
## Summary
- Remove the "The terminal for coding agents" feature card from the Product nav dropdown; menu now just lists Overview and Changelog.
- Show `$20` struck through next to `$15` on the Pro pricing card when Yearly is selected, making the 25% discount explicit.
- Pin the price row to a fixed height with `leading-none` so toggling Monthly/Yearly doesn't cause a vertical shift.

## Test plan
- [ ] Open marketing site, hover Product — only the two link items render, no card.
- [ ] Open /pricing — Pro card on Monthly shows "$20 per user/month".
- [ ] Toggle to Yearly — Pro card shows "~~$20~~ $15 per user/month" with `$20` at the left edge, no height change on the card or billing toggle.
- [ ] Free and Enterprise cards unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies the Product dropdown to two links and makes the Pro yearly discount explicit. Locks the price row height so switching Monthly/Yearly doesn't shift the card.

- **New Features**
  - Product nav: removed the feature card; dropdown now lists Overview and Changelog.
  - Pricing: when Yearly is selected, shows "$20" struck through next to "$15" on Pro.
  - UI polish: fixed price row height with leading-none to prevent vertical jump.

<sup>Written for commit 58d22a841f2215b5d000536c5c95b739aecb1a28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added strikethrough pricing to display monthly rates when viewing annual billing options.

* **Style**
  * Simplified the Product navigation dropdown menu layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->