### PR TITLE
feat(desktop): show PR state as sidebar workspace icon

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -10,12 +10,12 @@ import {
 import { HiMiniXMark } from "react-icons/hi2";
 import type { DiffStats } from "renderer/hooks/host-service/useDiffStats";
 import { HotkeyLabel } from "renderer/hotkeys";
+import { electronTrpc } from "renderer/lib/electron-trpc";
 import { RenameInput } from "renderer/screens/main/components/WorkspaceSidebar/RenameInput";
 import type { DashboardSidebarWorkspace } from "../../../../types";
 import { getCreationStatusText } from "../../utils/getCreationStatusText";
 import { DashboardSidebarWorkspaceDiffStats } from "../DashboardSidebarWorkspaceDiffStats";
 import { DashboardSidebarWorkspaceIcon } from "../DashboardSidebarWorkspaceIcon";
-import { DashboardSidebarWorkspaceStatusBadge } from "../DashboardSidebarWorkspaceStatusBadge";
 
 interface DashboardSidebarExpandedWorkspaceRowProps
 	extends ComponentPropsWithoutRef<"div"> {
@@ -67,6 +67,7 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 		} = workspace;
 		const showsStandaloneActiveStripe = accentColor == null;
 		const localRef = useRef<HTMLDivElement>(null);
+		const openUrl = electronTrpc.external.openUrl.useMutation();
 
 		useEffect(() => {
 			if (isActive) {
@@ -120,36 +121,72 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 
 				<Tooltip delayDuration={500}>
 					<TooltipTrigger asChild>
-						<div className="relative mr-2.5 flex size-5 shrink-0 items-center justify-center">
-							<DashboardSidebarWorkspaceIcon
-								hostType={hostType}
-								hostIsOnline={hostIsOnline}
-								isActive={isActive}
-								variant="expanded"
-								workspaceStatus={null}
-								creationStatus={creationStatus}
-							/>
-						</div>
+						{pullRequest ? (
+							<button
+								type="button"
+								onClick={(event) => {
+									event.stopPropagation();
+									openUrl.mutate(pullRequest.url);
+								}}
+								aria-label={`Open pull request #${pullRequest.number}`}
+								className="relative mr-2.5 flex size-5 shrink-0 cursor-pointer items-center justify-center rounded hover:bg-muted"
+							>
+								<DashboardSidebarWorkspaceIcon
+									hostType={hostType}
+									hostIsOnline={hostIsOnline}
+									isActive={isActive}
+									variant="expanded"
+									workspaceStatus={null}
+									creationStatus={creationStatus}
+									pullRequestState={pullRequest.state}
+								/>
+							</button>
+						) : (
+							<div className="relative mr-2.5 flex size-5 shrink-0 items-center justify-center">
+								<DashboardSidebarWorkspaceIcon
+									hostType={hostType}
+									hostIsOnline={hostIsOnline}
+									isActive={isActive}
+									variant="expanded"
+									workspaceStatus={null}
+									creationStatus={creationStatus}
+									pullRequestState={null}
+								/>
+							</div>
+						)}
 					</TooltipTrigger>
 					<TooltipContent side="right" sideOffset={8}>
-						<p className="text-xs font-medium">
-							{hostType === "local-device"
-								? "Local workspace"
-								: hostType === "remote-device"
-									? hostIsOnline === false
-										? "Remote workspace — device offline"
-										: "Remote workspace"
-									: "Cloud workspace"}
-						</p>
-						<p className="text-xs text-muted-foreground">
-							{hostType === "local-device"
-								? "Running on this device"
-								: hostType === "remote-device"
-									? hostIsOnline === false
-										? "The associated device isn't reachable right now"
-										: "Running on a paired device"
-									: "Hosted in the cloud"}
-						</p>
+						{pullRequest ? (
+							<>
+								<p className="text-xs font-medium">
+									PR #{pullRequest.number} — {pullRequest.state}
+								</p>
+								<p className="text-xs text-muted-foreground">
+									Click to open on GitHub
+								</p>
+							</>
+						) : (
+							<>
+								<p className="text-xs font-medium">
+									{hostType === "local-device"
+										? "Local workspace"
+										: hostType === "remote-device"
+											? hostIsOnline === false
+												? "Remote workspace — device offline"
+												: "Remote workspace"
+											: "Cloud workspace"}
+								</p>
+								<p className="text-xs text-muted-foreground">
+									{hostType === "local-device"
+										? "Running on this device"
+										: hostType === "remote-device"
+											? hostIsOnline === false
+												? "The associated device isn't reachable right now"
+												: "Running on a paired device"
+											: "Hosted in the cloud"}
+								</p>
+							</>
+						)}
 					</TooltipContent>
 				</Tooltip>
 
@@ -233,15 +270,6 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 						<span className="col-start-1 row-start-2 truncate font-mono text-[11px] leading-tight text-muted-foreground/60">
 							{branch}
 						</span>
-
-						{pullRequest && (
-							<DashboardSidebarWorkspaceStatusBadge
-								state={pullRequest.state}
-								prNumber={pullRequest.number}
-								prUrl={pullRequest.url}
-								className="col-start-2 row-start-2 justify-self-end"
-							/>
-						)}
 					</div>
 				</div>
 			</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -12,10 +12,23 @@ import type { DiffStats } from "renderer/hooks/host-service/useDiffStats";
 import { HotkeyLabel } from "renderer/hotkeys";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { RenameInput } from "renderer/screens/main/components/WorkspaceSidebar/RenameInput";
-import type { DashboardSidebarWorkspace } from "../../../../types";
+import type {
+	DashboardSidebarWorkspace,
+	DashboardSidebarWorkspacePullRequest,
+} from "../../../../types";
 import { getCreationStatusText } from "../../utils/getCreationStatusText";
 import { DashboardSidebarWorkspaceDiffStats } from "../DashboardSidebarWorkspaceDiffStats";
 import { DashboardSidebarWorkspaceIcon } from "../DashboardSidebarWorkspaceIcon";
+
+const PR_STATE_LABEL: Record<
+	DashboardSidebarWorkspacePullRequest["state"],
+	string
+> = {
+	open: "Open",
+	merged: "Merged",
+	closed: "Closed",
+	draft: "Draft",
+};
 
 interface DashboardSidebarExpandedWorkspaceRowProps
 	extends ComponentPropsWithoutRef<"div"> {
@@ -128,8 +141,13 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 									event.stopPropagation();
 									openUrl.mutate(pullRequest.url);
 								}}
+								onKeyDown={(event) => {
+									if (event.key === "Enter" || event.key === " ") {
+										event.stopPropagation();
+									}
+								}}
 								aria-label={`Open pull request #${pullRequest.number}`}
-								className="relative mr-2.5 flex size-5 shrink-0 cursor-pointer items-center justify-center rounded hover:bg-muted"
+								className="relative mr-2.5 flex size-5 shrink-0 cursor-pointer items-center justify-center rounded hover:bg-foreground/10"
 							>
 								<DashboardSidebarWorkspaceIcon
 									hostType={hostType}
@@ -159,7 +177,7 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 						{pullRequest ? (
 							<>
 								<p className="text-xs font-medium">
-									PR #{pullRequest.number} — {pullRequest.state}
+									PR #{pullRequest.number} — {PR_STATE_LABEL[pullRequest.state]}
 								</p>
 								<p className="text-xs text-muted-foreground">
 									Click to open on GitHub

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDiffStats/DashboardSidebarWorkspaceDiffStats.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDiffStats/DashboardSidebarWorkspaceDiffStats.tsx
@@ -1,5 +1,3 @@
-import { cn } from "@superset/ui/utils";
-
 interface DashboardSidebarWorkspaceDiffStatsProps {
 	additions: number;
 	deletions: number;
@@ -13,14 +11,15 @@ export function DashboardSidebarWorkspaceDiffStats({
 }: DashboardSidebarWorkspaceDiffStatsProps) {
 	return (
 		<div
-			className={cn(
-				"flex h-5 w-fit shrink-0 items-center justify-self-end rounded px-1.5 text-[10px] font-mono tabular-nums transition-[opacity,visibility] group-hover:opacity-0 group-hover:invisible",
-				isActive ? "bg-foreground/10" : "bg-muted/50",
-			)}
+			className="flex h-5 w-fit shrink-0 items-center justify-self-end rounded px-1.5 text-[10px] font-mono tabular-nums transition-[opacity,visibility] group-hover:opacity-0 group-hover:invisible"
 		>
 			<div className="flex items-center gap-1.5 leading-none">
-				<span className="text-emerald-500/90">+{additions}</span>
-				<span className="text-red-400/90">−{deletions}</span>
+				<span className={isActive ? "text-emerald-500/90" : "text-muted-foreground"}>
+					+{additions}
+				</span>
+				<span className={isActive ? "text-red-400/90" : "text-muted-foreground"}>
+					−{deletions}
+				</span>
 			</div>
 		</div>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDiffStats/DashboardSidebarWorkspaceDiffStats.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDiffStats/DashboardSidebarWorkspaceDiffStats.tsx
@@ -11,7 +11,7 @@ export function DashboardSidebarWorkspaceDiffStats({
 }: DashboardSidebarWorkspaceDiffStatsProps) {
 	return (
 		<div
-			className="flex h-5 w-fit shrink-0 items-center justify-self-end rounded px-1.5 text-[10px] font-mono tabular-nums transition-[opacity,visibility] group-hover:opacity-0 group-hover:invisible"
+			className="flex h-5 w-fit shrink-0 items-center justify-self-end text-[10px] font-mono tabular-nums transition-[opacity,visibility] group-hover:opacity-0 group-hover:invisible"
 		>
 			<div className="flex items-center gap-1.5 leading-none">
 				<span className={isActive ? "text-emerald-500/90" : "text-muted-foreground"}>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDiffStats/DashboardSidebarWorkspaceDiffStats.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceDiffStats/DashboardSidebarWorkspaceDiffStats.tsx
@@ -10,14 +10,16 @@ export function DashboardSidebarWorkspaceDiffStats({
 	isActive,
 }: DashboardSidebarWorkspaceDiffStatsProps) {
 	return (
-		<div
-			className="flex h-5 w-fit shrink-0 items-center justify-self-end text-[10px] font-mono tabular-nums transition-[opacity,visibility] group-hover:opacity-0 group-hover:invisible"
-		>
+		<div className="flex h-5 w-fit shrink-0 items-center justify-self-end text-[10px] font-mono tabular-nums transition-[opacity,visibility] group-hover:opacity-0 group-hover:invisible">
 			<div className="flex items-center gap-1.5 leading-none">
-				<span className={isActive ? "text-emerald-500/90" : "text-muted-foreground"}>
+				<span
+					className={isActive ? "text-emerald-500/90" : "text-muted-foreground"}
+				>
 					+{additions}
 				</span>
-				<span className={isActive ? "text-red-400/90" : "text-muted-foreground"}>
+				<span
+					className={isActive ? "text-red-400/90" : "text-muted-foreground"}
+				>
 					−{deletions}
 				</span>
 			</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/DashboardSidebarWorkspaceIcon.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/DashboardSidebarWorkspaceIcon.tsx
@@ -1,11 +1,11 @@
 import { cn } from "@superset/ui/utils";
 import { HiExclamationTriangle } from "react-icons/hi2";
 import {
-	LuCircleDot,
 	LuCloud,
 	LuCloudOff,
 	LuGitMerge,
 	LuGitPullRequest,
+	LuGitPullRequestClosed,
 	LuGitPullRequestDraft,
 } from "react-icons/lu";
 import { AsciiSpinner } from "renderer/screens/main/components/AsciiSpinner";
@@ -34,7 +34,7 @@ const OVERLAY_POSITION = {
 const PR_ICON_BY_STATE = {
 	open: LuGitPullRequest,
 	merged: LuGitMerge,
-	closed: LuCircleDot,
+	closed: LuGitPullRequestClosed,
 	draft: LuGitPullRequestDraft,
 } as const;
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/DashboardSidebarWorkspaceIcon.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/DashboardSidebarWorkspaceIcon.tsx
@@ -1,10 +1,20 @@
 import { cn } from "@superset/ui/utils";
 import { HiExclamationTriangle } from "react-icons/hi2";
-import { LuCloud, LuCloudOff } from "react-icons/lu";
+import {
+	LuCircleDot,
+	LuCloud,
+	LuCloudOff,
+	LuGitMerge,
+	LuGitPullRequest,
+	LuGitPullRequestDraft,
+} from "react-icons/lu";
 import { AsciiSpinner } from "renderer/screens/main/components/AsciiSpinner";
 import { StatusIndicator } from "renderer/screens/main/components/StatusIndicator";
 import type { ActivePaneStatus } from "shared/tabs-types";
-import type { DashboardSidebarWorkspaceHostType } from "../../../../types";
+import type {
+	DashboardSidebarWorkspaceHostType,
+	DashboardSidebarWorkspacePullRequest,
+} from "../../../../types";
 
 interface DashboardSidebarWorkspaceIconProps {
 	hostType: DashboardSidebarWorkspaceHostType;
@@ -13,11 +23,26 @@ interface DashboardSidebarWorkspaceIconProps {
 	variant: "collapsed" | "expanded";
 	workspaceStatus?: ActivePaneStatus | null;
 	creationStatus?: "preparing" | "generating-branch" | "creating" | "failed";
+	pullRequestState?: DashboardSidebarWorkspacePullRequest["state"] | null;
 }
 
 const OVERLAY_POSITION = {
 	collapsed: "top-1 right-1",
 	expanded: "-top-0.5 -right-0.5",
+} as const;
+
+const PR_ICON_BY_STATE = {
+	open: LuGitPullRequest,
+	merged: LuGitMerge,
+	closed: LuCircleDot,
+	draft: LuGitPullRequestDraft,
+} as const;
+
+const PR_COLOR_BY_STATE = {
+	open: "text-emerald-500",
+	merged: "text-purple-500",
+	closed: "text-destructive",
+	draft: "text-muted-foreground",
 } as const;
 
 export function DashboardSidebarWorkspaceIcon({
@@ -27,13 +52,24 @@ export function DashboardSidebarWorkspaceIcon({
 	variant,
 	workspaceStatus = null,
 	creationStatus,
+	pullRequestState = null,
 }: DashboardSidebarWorkspaceIconProps) {
 	const overlayPosition = OVERLAY_POSITION[variant];
 	const iconColor = isActive ? "text-foreground" : "text-muted-foreground";
 	const isRemoteDeviceOffline =
 		hostType === "remote-device" && hostIsOnline === false;
 
-	const renderHostIcon = () => {
+	const renderPrimaryIcon = () => {
+		if (pullRequestState) {
+			const PrIcon = PR_ICON_BY_STATE[pullRequestState];
+			return (
+				<PrIcon
+					className={cn("size-3.5", PR_COLOR_BY_STATE[pullRequestState])}
+					strokeWidth={1.75}
+				/>
+			);
+		}
+
 		if (hostType === "local-device") {
 			return (
 				<span
@@ -69,7 +105,7 @@ export function DashboardSidebarWorkspaceIcon({
 			) : creationStatus || workspaceStatus === "working" ? (
 				<AsciiSpinner className="text-base" />
 			) : (
-				renderHostIcon()
+				renderPrimaryIcon()
 			)}
 			{workspaceStatus && workspaceStatus !== "working" && (
 				<span className={cn("absolute", overlayPosition)}>


### PR DESCRIPTION
## Summary
- Replace the host-type icon in the v2 dashboard sidebar with a PR state icon (open/merged/closed/draft) colored by state when the workspace has a PR; falls back to the host icon otherwise.
- Clicking the icon opens the PR on GitHub (same behavior the old status badge had). The bottom-right PR badge has been removed since it's now redundant.
- Diff stats (`+N -M`) only colorize green/red when the workspace is active; inactive rows use muted text with no pill background.

## Test plan
- [ ] Workspace with an open PR shows a green pull-request icon; clicking opens the PR URL.
- [ ] Merged PR shows purple merge icon; closed shows red dot; draft shows muted draft icon.
- [ ] Workspace with no PR still shows the local-device dot / cloud / cloud-off icon and tooltip.
- [ ] Inactive rows have muted `+/-` numbers and transparent background; active row has colored numbers.
- [ ] Clicking the PR icon does not also trigger the row's workspace click.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show PR state as the workspace icon in the sidebar, color-coded by state, and open the PR on click. Removes the old PR badge and makes diff stats only colorize for the active workspace.

- **New Features**
  - PR icon replaces host icon when a PR exists (open/merged/closed/draft); clicking opens GitHub; falls back to host icon otherwise.
  - Tooltip shows “PR #<number> — <state>” with a “Click to open on GitHub” hint; otherwise shows host details.

- **Bug Fixes**
  - Prevent Enter/Space on the PR icon from triggering the row click.
  - Show hover highlight on the PR icon even when the row is active, and use human-friendly state labels in the tooltip.

<sup>Written for commit 59559284ee84b2abe16d92497f75af2aad526eda. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull request indicator in the workspace sidebar is now clickable and keyboard-accessible to open the PR on GitHub.

* **UI Changes**
  * Sidebar shows PR-specific icon, color and tooltip ("PR #… — <state>" and "Click to open on GitHub") when a PR exists; workspace status badge is hidden in that case.
  * Workspace diff stats styling simplified; additions/deletions use emphasized colors when active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->