### PR TITLE
fix(desktop): use Alerter for automation detail delete confirm

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/page.tsx
@@ -3,6 +3,7 @@ import type {
 	SelectAutomationRun,
 } from "@superset/db/schema";
 import { alert } from "@superset/ui/atoms/Alert";
+import { toast } from "@superset/ui/sonner";
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useMutation } from "@tanstack/react-query";
@@ -89,8 +90,15 @@ function AutomationDetailPage() {
 								{
 									label: "Delete",
 									variant: "destructive",
-									onClick: async () => {
-										await deleteMutation.mutateAsync();
+									onClick: () => {
+										toast.promise(deleteMutation.mutateAsync(), {
+											loading: "Deleting automation...",
+											success: `"${automation.name}" deleted`,
+											error: (err) =>
+												err instanceof Error
+													? err.message
+													: "Failed to delete automation",
+										});
 									},
 								},
 							],

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/page.tsx
@@ -2,6 +2,7 @@ import type {
 	SelectAutomation,
 	SelectAutomationRun,
 } from "@superset/db/schema";
+import { alert } from "@superset/ui/atoms/Alert";
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useMutation } from "@tanstack/react-query";
@@ -80,13 +81,20 @@ function AutomationDetailPage() {
 					onBack={() => navigate({ to: "/automations" })}
 					onToggleEnabled={() => setEnabledMutation.mutate(!automation.enabled)}
 					onDelete={() => {
-						if (
-							confirm(
-								`Delete "${automation.name}"? This removes the automation and its run history.`,
-							)
-						) {
-							deleteMutation.mutate();
-						}
+						alert({
+							title: "Delete automation?",
+							description: `"${automation.name}" will stop firing and its run history will be removed. This can't be undone.`,
+							actions: [
+								{ label: "Cancel", variant: "outline", onClick: () => {} },
+								{
+									label: "Delete",
+									variant: "destructive",
+									onClick: async () => {
+										await deleteMutation.mutateAsync();
+									},
+								},
+							],
+						});
 					}}
 					onRunNow={() => runNowMutation.mutate()}
 					toggleDisabled={setEnabledMutation.isPending}


### PR DESCRIPTION
## Summary
- Replaces the native `window.confirm()` on the automation detail page with the shared `alert()` helper from `@superset/ui/atoms/Alert`, matching the rest of the app's delete-confirm UX.

Closes [SUPER-436](https://linear.app/superset-sh/issue/SUPER-436/schedule-automation-delete-button-uses-native-menu-instead-of-shadcn).

## Test plan
- [ ] Open an automation detail page, click Delete, confirm the shadcn dialog appears (not a native browser dialog)
- [ ] Cancel dismisses without deleting; Delete removes the automation and navigates back to `/automations`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces native `window.confirm()` on the automation detail page with the shared `alert()` from `@superset/ui/atoms/Alert` so delete confirmations use the app’s shadcn dialog on desktop. Wraps `deleteMutation.mutateAsync()` in `toast.promise` from `@superset/ui/sonner` to show loading, success, and error states; closes SUPER-436.

<sup>Written for commit f7f6388fa52d4858c45ecb3479ae6228ed680363. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced browser confirm prompt with an in-app alert dialog for automation deletion, offering "Cancel" and destructive "Delete" actions.
  * Added user feedback during deletion with loading, success, and error toasts to improve clarity and responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->