### PR TITLE
fix(desktop): reap stale notify.sh paths from in-repo dev worktrees

### DIFF
--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers-common.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers-common.ts
@@ -6,7 +6,11 @@ import { BIN_DIR } from "./paths";
 export const WRAPPER_MARKER = "# Superset agent-wrapper v1";
 export { SUPERSET_MANAGED_BINARIES };
 
-const SUPERSET_MANAGED_HOOK_PATH_PATTERN = /\/\.superset(?:-[^/'"\s\\]+)?\//;
+// Dev setup (.superset/lib/setup/steps.sh) points SUPERSET_HOME_DIR at
+// $PWD/superset-dev-data — without a leading dot — so we must recognize that
+// variant to reap stale notify.sh paths from deleted worktrees.
+const SUPERSET_MANAGED_HOOK_PATH_PATTERN =
+	/\/(?:\.superset(?:-[^/'"\s\\]+)?|superset-dev-data)\//;
 
 export function writeFileIfChanged(
 	filePath: string,

--- a/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts
@@ -1193,6 +1193,71 @@ describe("agent-wrappers codex hooks.json", () => {
 		).toBe(true);
 	});
 
+	it("reaps stale notify.sh paths from in-repo dev worktrees", () => {
+		const codexHooksPath = path.join(mockedHomeDir, ".codex", "hooks.json");
+		// Real-world layout: a dev worktree lives under <repo>/.worktrees/<name>
+		// and its dev setup writes SUPERSET_HOME_DIR=<worktree>/superset-dev-data.
+		// There is no /.superset/ segment anywhere in the path.
+		const staleHookPath =
+			"/Users/test/code/superset/.worktrees/old-branch/superset-dev-data/hooks/notify.sh";
+		const currentHookPath = "/tmp/.superset-new/hooks/notify.sh";
+
+		mkdirSync(path.dirname(codexHooksPath), { recursive: true });
+		writeFileSync(
+			codexHooksPath,
+			JSON.stringify(
+				{
+					hooks: {
+						SessionStart: [
+							{ hooks: [{ type: "command", command: staleHookPath }] },
+						],
+						UserPromptSubmit: [
+							{ hooks: [{ type: "command", command: staleHookPath }] },
+						],
+						Stop: [
+							{ hooks: [{ type: "command", command: staleHookPath }] },
+						],
+					},
+				},
+				null,
+				2,
+			),
+		);
+
+		const content = getCodexGlobalHooksJsonContent(currentHookPath);
+		expect(content).not.toBeNull();
+		if (content === null) throw new Error("Expected content");
+
+		const parsed = JSON.parse(content) as {
+			hooks: Record<
+				string,
+				Array<{
+					matcher?: string;
+					hooks: Array<{ type: string; command: string }>;
+				}>
+			>;
+		};
+
+		for (const eventName of [
+			"SessionStart",
+			"UserPromptSubmit",
+			"Stop",
+		] as const) {
+			const hooks = parsed.hooks[eventName];
+			expect(Array.isArray(hooks)).toBe(true);
+			expect(
+				hooks.some((def) =>
+					def.hooks.some((hook) => hook.command === currentHookPath),
+				),
+			).toBe(true);
+			expect(
+				hooks.some((def) =>
+					def.hooks.some((hook) => hook.command === staleHookPath),
+				),
+			).toBe(false);
+		}
+	});
+
 	it("skips Codex hooks writes when existing JSON is invalid", () => {
 		const codexHooksPath = path.join(mockedHomeDir, ".codex", "hooks.json");
 		const invalidJson = "{not-json";


### PR DESCRIPTION
## Summary

- Dev setup (`.superset/lib/setup/steps.sh`) points `SUPERSET_HOME_DIR` at `$PWD/superset-dev-data` — without a leading dot — so the managed-hook regex `/\.superset(?:-[^/'"\s\\]+)?\//` never matched those paths.
- Result: after deleting a dev worktree, its `notify.sh` path stayed in `~/.codex/hooks.json` forever, even though the file was gone.
- Widen the pattern to also recognize `superset-dev-data/` so the reaper can swap in the current hook path. Added a regression test covering the in-repo `.worktrees/<name>/superset-dev-data/` layout.

## Test plan

- [x] `bun test apps/desktop/src/main/lib/agent-setup/agent-wrappers.test.ts`
- [ ] Verify stale notify.sh entries from deleted dev worktrees are replaced with the current path on desktop startup

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale `notify.sh` entries in `~/.codex/hooks.json` when deleting in-repo dev worktrees by recognizing `superset-dev-data` paths used by the dev setup. On desktop startup, the reaper now replaces old paths with the current hook path.

- **Bug Fixes**
  - Expanded managed-hook regex to match both `/.superset.../` and `/superset-dev-data/` paths.
  - Added a regression test for `.worktrees/<name>/superset-dev-data/` to ensure stale paths are removed and replaced.

<sup>Written for commit 12b4319da4e74fc4927a9dad3c2f7aeb6a0c80a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of managed hook paths in development configurations, now supporting additional directory layouts.
* **Tests**
  * Added test coverage for stale hook paths in development worktrees, verifying proper cleanup and path management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->