### PR TITLE
fix(desktop): honor agent selection in new-workspace modal

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/buildForkAgentLaunch.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/buildForkAgentLaunch.test.ts
@@ -122,9 +122,12 @@ describe("buildForkAgentLaunch", () => {
 		expect(build).toBeNull();
 	});
 
-	test("prompt-only → terminal launch via default agent (claude)", async () => {
+	test("selected claude agent → terminal launch", async () => {
 		const build = await buildForkAgentLaunch({
-			pending: pendingBase({ prompt: "refactor the auth middleware" }),
+			pending: pendingBase({
+				prompt: "refactor the auth middleware",
+				agentId: "claude",
+			}),
 			attachments: undefined,
 			agentConfigs,
 		});
@@ -141,6 +144,7 @@ describe("buildForkAgentLaunch", () => {
 		const build = await buildForkAgentLaunch({
 			pending: pendingBase({
 				prompt: "do it",
+				agentId: "claude",
 				linkedIssues: [
 					{
 						source: "internal",
@@ -159,7 +163,7 @@ describe("buildForkAgentLaunch", () => {
 
 	test("attachments produce disk-ready bytes + matching names", async () => {
 		const build = await buildForkAgentLaunch({
-			pending: pendingBase({ prompt: "fix" }),
+			pending: pendingBase({ prompt: "fix", agentId: "claude" }),
 			attachments: [
 				{
 					data: "data:text/plain;base64,AQID", // [1,2,3]
@@ -179,13 +183,11 @@ describe("buildForkAgentLaunch", () => {
 	});
 
 	test("chat agent → chat launch with initialPrompt + files", async () => {
-		const chatOnlyConfigs = agentConfigs.map((c) =>
-			c.id === "superset-chat"
-				? { ...c, enabled: true }
-				: { ...c, enabled: false },
-		);
 		const build = await buildForkAgentLaunch({
-			pending: pendingBase({ prompt: "help me refactor" }),
+			pending: pendingBase({
+				prompt: "help me refactor",
+				agentId: "superset-chat",
+			}),
 			attachments: [
 				{
 					data: "data:text/plain;base64,AQID",
@@ -193,7 +195,7 @@ describe("buildForkAgentLaunch", () => {
 					filename: "logs.txt",
 				},
 			],
-			agentConfigs: chatOnlyConfigs,
+			agentConfigs,
 		});
 		expect(build?.kind).toBe("chat");
 		if (build?.kind !== "chat") throw new Error("wrong kind");
@@ -208,9 +210,27 @@ describe("buildForkAgentLaunch", () => {
 	test("disabled agent → null", async () => {
 		const disabled = agentConfigs.map((c) => ({ ...c, enabled: false }));
 		const build = await buildForkAgentLaunch({
-			pending: pendingBase({ prompt: "hi" }),
+			pending: pendingBase({ prompt: "hi", agentId: "claude" }),
 			attachments: undefined,
 			agentConfigs: disabled,
+		});
+		expect(build).toBeNull();
+	});
+
+	test("agentId null → null (no user selection, no launch)", async () => {
+		const build = await buildForkAgentLaunch({
+			pending: pendingBase({ prompt: "hi", agentId: null }),
+			attachments: undefined,
+			agentConfigs,
+		});
+		expect(build).toBeNull();
+	});
+
+	test('agentId "none" → null (explicit opt-out)', async () => {
+		const build = await buildForkAgentLaunch({
+			pending: pendingBase({ prompt: "hi", agentId: "none" }),
+			attachments: undefined,
+			agentConfigs,
 		});
 		expect(build).toBeNull();
 	});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/buildForkAgentLaunch.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/buildForkAgentLaunch.test.ts
@@ -15,6 +15,7 @@ function pendingBase(
 		prompt: "",
 		linkedIssues: [],
 		linkedPR: null,
+		agentId: null,
 		...overrides,
 	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/buildForkAgentLaunch.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/buildForkAgentLaunch.ts
@@ -1,8 +1,10 @@
-import { isTerminalAgentDefinition } from "@superset/shared/agent-catalog";
+import {
+	type AgentDefinitionId,
+	isTerminalAgentDefinition,
+} from "@superset/shared/agent-catalog";
 import {
 	buildPromptCommandFromAgentConfig,
 	getCommandFromAgentConfig,
-	getFallbackAgentId,
 	indexResolvedAgentConfigs,
 	type ResolvedAgentConfig,
 } from "@superset/shared/agent-settings";
@@ -40,7 +42,7 @@ export interface ResolvedPrContent {
 export interface BuildForkAgentLaunchInputs {
 	pending: Pick<
 		PendingWorkspaceRow,
-		"projectId" | "prompt" | "linkedIssues" | "linkedPR"
+		"projectId" | "prompt" | "linkedIssues" | "linkedPR" | "agentId"
 	>;
 	attachments: LoadedAttachment[] | undefined;
 	agentConfigs: ResolvedAgentConfig[];
@@ -124,7 +126,7 @@ export type PendingLaunchBuild =
 export async function buildForkAgentLaunch(
 	inputs: BuildForkAgentLaunchInputs,
 ): Promise<PendingLaunchBuild | null> {
-	const agentId = getFallbackAgentId(inputs.agentConfigs);
+	const agentId = resolveAgentId(inputs.pending.agentId, inputs.agentConfigs);
 	if (!agentId) return null;
 
 	const agentConfig = indexResolvedAgentConfigs(inputs.agentConfigs).get(
@@ -160,6 +162,17 @@ export async function buildForkAgentLaunch(
 		return buildTerminalLaunch(spec, agentConfig);
 	}
 	return buildChatLaunch(spec, agentConfig);
+}
+
+function resolveAgentId(
+	selected: string | null,
+	configs: ResolvedAgentConfig[],
+): AgentDefinitionId | null {
+	if (!selected || selected === "none") return null;
+	const match = indexResolvedAgentConfigs(configs).get(
+		selected as AgentDefinitionId,
+	);
+	return match?.enabled ? match.id : null;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/buildIntentPayload.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/buildIntentPayload.test.ts
@@ -34,6 +34,7 @@ function makePending(
 		runSetupScript: true,
 		terminalLaunch: null,
 		chatLaunch: null,
+		agentId: null,
 		...overrides,
 	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/dispatchForkLaunch.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/dispatchForkLaunch.ts
@@ -17,7 +17,12 @@ export interface DispatchForkLaunchInputs {
 	workspaceId: string;
 	pending: Pick<
 		PendingWorkspaceRow,
-		"projectId" | "prompt" | "linkedIssues" | "linkedPR" | "hostTarget"
+		| "projectId"
+		| "prompt"
+		| "linkedIssues"
+		| "linkedPR"
+		| "hostTarget"
+		| "agentId"
 	>;
 	loadedAttachments: LoadedAttachment[] | undefined;
 	agentConfigs: ResolvedAgentConfig[];

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -139,7 +139,7 @@ export function PromptGroup({
 	});
 
 	// ── Submit (fork) ────────────────────────────────────────────────
-	const createWorkspace = useSubmitWorkspace(projectId);
+	const createWorkspace = useSubmitWorkspace(projectId, selectedAgent);
 	const handleSubmit = useCallback(
 		(files: SubmitAttachment[] = []) => {
 			if (needsSetup) {

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
@@ -4,6 +4,7 @@ import { useCallback } from "react";
 import { storeAttachments } from "renderer/lib/pending-attachment-store";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useDashboardNewWorkspaceDraft } from "../../../../../DashboardNewWorkspaceDraftContext";
+import type { WorkspaceCreateAgent } from "../../types";
 import { resolveNames } from "./resolveNames";
 
 export interface SubmitAttachment {
@@ -24,7 +25,10 @@ export interface SubmitAttachment {
  * the library clears provider state + revokes blob URLs *before*
  * invoking onSubmit, so the ref is stale by the time we'd see it.
  */
-export function useSubmitWorkspace(projectId: string | null) {
+export function useSubmitWorkspace(
+	projectId: string | null,
+	selectedAgent: WorkspaceCreateAgent,
+) {
 	const navigate = useNavigate();
 	const { closeAndResetDraft, draft } = useDashboardNewWorkspaceDraft();
 	const collections = useCollections();
@@ -83,6 +87,7 @@ export function useSubmitWorkspace(projectId: string | null) {
 				linkedPR: draft.linkedPR,
 				hostTarget: draft.hostTarget,
 				attachmentCount: files.length,
+				agentId: selectedAgent,
 				status: "creating",
 				error: null,
 				workspaceId: null,
@@ -93,6 +98,13 @@ export function useSubmitWorkspace(projectId: string | null) {
 			closeAndResetDraft();
 			void navigate({ to: `/pending/${pendingId}` as string });
 		},
-		[closeAndResetDraft, collections, draft, navigate, projectId],
+		[
+			closeAndResetDraft,
+			collections,
+			draft,
+			navigate,
+			projectId,
+			selectedAgent,
+		],
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -185,6 +185,10 @@ export const pendingWorkspaceSchema = z.object({
 	linkedIssues: z.array(pendingLinkedIssueSchema).default([]),
 	linkedPR: pendingLinkedPRSchema.nullable().default(null),
 	attachmentCount: z.number().int().default(0),
+	// User-selected agent from the modal. `"none"` = user explicitly chose not
+	// to launch; any other string = `AgentDefinitionId`; null = legacy rows
+	// (predating this field), treated as "use fallback".
+	agentId: z.string().nullable().default(null),
 
 	// fork + checkout (irrelevant for adopt — worktree already exists).
 	runSetupScript: z.boolean().default(true),


### PR DESCRIPTION
## Summary
- The dashboard new-workspace modal's agent picker was cosmetic — `selectedAgent` was read from localStorage for the UI but never written into the pending row.
- `buildForkAgentLaunch` always resolved via `getFallbackAgentId`, which hard-prefers `claude`, so selecting codex/cursor/etc. silently launched claude.
- Threaded the selected agent through the pending row into the launch build. `"none"` now genuinely skips agent launch instead of falling back to claude.

## Test plan
- [ ] Open new-workspace modal, pick Codex, submit → Codex terminal launches (not Claude)
- [ ] Pick Claude → Claude launches
- [ ] Pick "No agent" → workspace creates, no agent launches, existing warning toast fires if prompt/files were submitted
- [ ] Existing in-flight pending rows (null `agentId`) don't crash on retry — they just no-op the launch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the new-workspace modal so the agent you pick actually launches. Selecting "No agent" now truly skips agent launch; no silent fallback.

- **Bug Fixes**
  - Persist `selectedAgent` as `agentId` on the pending row and thread it through `dispatchForkLaunch` and `buildForkAgentLaunch`.
  - Resolve the agent from `agentId` only; remove fallback to Claude. Launch only if the chosen agent is enabled, otherwise skip.
  - Handle legacy pending rows (`agentId: null`) safely; retries no-op without errors.

<sup>Written for commit 9bc6c38da4098972f1ffa2ea77da41d2603393b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Agent selection is now preserved and reliably applied when creating or launching workspaces; disabled or unselected agents prevent launches.
* **New Features**
  * Workspace creation and launch flows respect an explicit "no agent" option and the currently selected agent, improving predictability when forking or starting workspaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->