### PR TITLE
fix(desktop): adopt Ghostty keyboard model in v2 terminal

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -73,6 +73,16 @@ function createKeyEventHandler(terminal: XTerm) {
 	};
 }
 
+/** True when `mod` is the only non-shift modifier held. */
+function onlyMod(event: KeyboardEvent, mod: "meta" | "alt" | "ctrl"): boolean {
+	return (
+		event.metaKey === (mod === "meta") &&
+		event.altKey === (mod === "alt") &&
+		event.ctrlKey === (mod === "ctrl") &&
+		!event.shiftKey
+	);
+}
+
 /**
  * Translate Mac Cmd+/Option+ and Windows Ctrl+ arrow / backspace chords into
  * the escape sequences shells expect. Returns the bytes to send, or null if
@@ -87,84 +97,21 @@ function translateLineEditChord(
 	options: { isMac: boolean; isWindows: boolean },
 ): string | null {
 	const { isMac, isWindows } = options;
+	const { key } = event;
 
-	if (
-		isMac &&
-		event.key === "Backspace" &&
-		event.metaKey &&
-		!event.ctrlKey &&
-		!event.altKey &&
-		!event.shiftKey
-	) {
-		return "\x15\x1b[D";
+	if (isMac && onlyMod(event, "meta")) {
+		if (key === "Backspace") return "\x15\x1b[D";
+		if (key === "ArrowLeft") return "\x01";
+		if (key === "ArrowRight") return "\x05";
 	}
-
-	if (
-		isMac &&
-		event.key === "ArrowLeft" &&
-		event.metaKey &&
-		!event.ctrlKey &&
-		!event.altKey &&
-		!event.shiftKey
-	) {
-		return "\x01";
+	if (isMac && onlyMod(event, "alt")) {
+		if (key === "ArrowLeft") return "\x1bb";
+		if (key === "ArrowRight") return "\x1bf";
 	}
-
-	if (
-		isMac &&
-		event.key === "ArrowRight" &&
-		event.metaKey &&
-		!event.ctrlKey &&
-		!event.altKey &&
-		!event.shiftKey
-	) {
-		return "\x05";
+	if (isWindows && onlyMod(event, "ctrl")) {
+		if (key === "ArrowLeft") return "\x1bb";
+		if (key === "ArrowRight") return "\x1bf";
 	}
-
-	if (
-		isMac &&
-		event.key === "ArrowLeft" &&
-		event.altKey &&
-		!event.metaKey &&
-		!event.ctrlKey &&
-		!event.shiftKey
-	) {
-		return "\x1bb";
-	}
-
-	if (
-		isMac &&
-		event.key === "ArrowRight" &&
-		event.altKey &&
-		!event.metaKey &&
-		!event.ctrlKey &&
-		!event.shiftKey
-	) {
-		return "\x1bf";
-	}
-
-	if (
-		isWindows &&
-		event.key === "ArrowLeft" &&
-		event.ctrlKey &&
-		!event.metaKey &&
-		!event.altKey &&
-		!event.shiftKey
-	) {
-		return "\x1bb";
-	}
-
-	if (
-		isWindows &&
-		event.key === "ArrowRight" &&
-		event.ctrlKey &&
-		!event.metaKey &&
-		!event.altKey &&
-		!event.shiftKey
-	) {
-		return "\x1bf";
-	}
-
 	return null;
 }
 

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -61,11 +61,11 @@ function createKeyEventHandler(terminal: XTerm) {
 				hasSelection: terminal.hasSelection(),
 			})
 		) {
-			// Prevent browser default from double-firing against the Electron
-			// `role: 'paste'`/`'copy'` accelerator (src/main/lib/menu.ts).
-			if (event.type === "keydown") {
-				event.preventDefault();
-			}
+			// Do NOT preventDefault — the browser's keydown → paste-command pipeline
+			// is what fires the `paste` event on xterm's textarea. VS Code and Tabby
+			// preventDefault here only because they implement paste themselves via
+			// the command system / ClipboardAddon; we rely on xterm's built-in paste
+			// listener, so the default must run.
 			return false;
 		}
 

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -4,6 +4,10 @@ import type { SearchAddon } from "@xterm/addon-search";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { resolveHotkeyFromEvent } from "renderer/hotkeys";
+import {
+	shouldBubbleClipboardShortcut,
+	shouldSelectAllShortcut,
+} from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/clipboardShortcuts";
 import { DEFAULT_TERMINAL_SCROLLBACK } from "shared/constants";
 import type { TerminalAppearance } from "./appearance";
 import { loadAddons } from "./terminal-addons";
@@ -14,12 +18,149 @@ const DIMS_KEY_PREFIX = "terminal-dims:";
 const DEFAULT_COLS = 120;
 const DEFAULT_ROWS = 32;
 
-// xterm's _keyDown calls stopPropagation after processing, which kills the
-// bubble to react-hotkeys-hook. Returning false from the custom handler makes
-// xterm bail before that, so app hotkeys reach document. (VSCode pattern:
-// terminalInstance.ts:1116-1175)
-function isAppHotkey(event: KeyboardEvent): boolean {
-	return resolveHotkeyFromEvent(event) !== null;
+// xterm's _keyDown calls stopPropagation after processing, so any chord we
+// want the host (react-hotkeys-hook, Electron menu accelerators) or the shell
+// (Ctrl+A/E/U escape sequences for line edit) to see must short-circuit xterm
+// before it runs. (VSCode pattern: terminalInstance.ts:1116-1175.)
+//
+// Kitty keyboard protocol is enabled, which means every Mac Cmd chord xterm
+// sees gets CSI-u encoded and leaks into TUIs as a literal char. Ghostty
+// sidesteps this by suppressing all super/Cmd chords on macOS before the
+// encoder runs (ghostty/src/input/key_encode.zig:534-545). We do the same via
+// shouldBubbleClipboardShortcut's Mac branch.
+function createKeyEventHandler(terminal: XTerm) {
+	const platform =
+		typeof navigator !== "undefined" ? navigator.platform.toLowerCase() : "";
+	const isMac = platform.includes("mac");
+	const isWindows = platform.includes("win");
+
+	return (event: KeyboardEvent): boolean => {
+		if (resolveHotkeyFromEvent(event) !== null) return false;
+
+		const translation = translateLineEditChord(event, { isMac, isWindows });
+		if (translation !== null) {
+			if (event.type === "keydown") {
+				event.preventDefault();
+				terminal.input(translation, true);
+			}
+			return false;
+		}
+
+		if (shouldSelectAllShortcut(event, isMac)) {
+			if (event.type === "keydown") {
+				event.preventDefault();
+				terminal.selectAll();
+			}
+			return false;
+		}
+
+		if (
+			shouldBubbleClipboardShortcut(event, {
+				isMac,
+				isWindows,
+				hasSelection: terminal.hasSelection(),
+			})
+		) {
+			return false;
+		}
+
+		return true;
+	};
+}
+
+/**
+ * Translate Mac Cmd+/Option+ and Windows Ctrl+ arrow / backspace chords into
+ * the escape sequences shells expect. Returns the bytes to send, or null if
+ * this chord isn't a line-edit translation.
+ *
+ * Mirrors v1 helpers.ts:319-427. These translations only exist because xterm's
+ * default encoding (with kitty on) would send a CSI-u sequence that most
+ * shells don't map to line-edit commands.
+ */
+function translateLineEditChord(
+	event: KeyboardEvent,
+	options: { isMac: boolean; isWindows: boolean },
+): string | null {
+	const { isMac, isWindows } = options;
+
+	if (
+		isMac &&
+		event.key === "Backspace" &&
+		event.metaKey &&
+		!event.ctrlKey &&
+		!event.altKey &&
+		!event.shiftKey
+	) {
+		return "\x15\x1b[D";
+	}
+
+	if (
+		isMac &&
+		event.key === "ArrowLeft" &&
+		event.metaKey &&
+		!event.ctrlKey &&
+		!event.altKey &&
+		!event.shiftKey
+	) {
+		return "\x01";
+	}
+
+	if (
+		isMac &&
+		event.key === "ArrowRight" &&
+		event.metaKey &&
+		!event.ctrlKey &&
+		!event.altKey &&
+		!event.shiftKey
+	) {
+		return "\x05";
+	}
+
+	if (
+		isMac &&
+		event.key === "ArrowLeft" &&
+		event.altKey &&
+		!event.metaKey &&
+		!event.ctrlKey &&
+		!event.shiftKey
+	) {
+		return "\x1bb";
+	}
+
+	if (
+		isMac &&
+		event.key === "ArrowRight" &&
+		event.altKey &&
+		!event.metaKey &&
+		!event.ctrlKey &&
+		!event.shiftKey
+	) {
+		return "\x1bf";
+	}
+
+	if (
+		isWindows &&
+		event.key === "ArrowLeft" &&
+		event.ctrlKey &&
+		!event.metaKey &&
+		!event.altKey &&
+		!event.shiftKey
+	) {
+		return "\x1bb";
+	}
+
+	if (
+		isWindows &&
+		event.key === "ArrowRight" &&
+		event.ctrlKey &&
+		!event.metaKey &&
+		!event.altKey &&
+		!event.shiftKey
+	) {
+		return "\x1bf";
+	}
+
+	return null;
 }
 
 export interface TerminalRuntime {
@@ -178,7 +319,7 @@ export function createRuntime(
 	wrapper.style.height = "100%";
 	terminal.open(wrapper);
 
-	terminal.attachCustomKeyEventHandler((event) => !isAppHotkey(event));
+	terminal.attachCustomKeyEventHandler(createKeyEventHandler(terminal));
 
 	// Activate Unicode 11 widths (inside loadAddons) before restoring the buffer,
 	// else CJK/emoji/ZWJ widths get baked wrong into the replay. (#3572)

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -61,6 +61,11 @@ function createKeyEventHandler(terminal: XTerm) {
 				hasSelection: terminal.hasSelection(),
 			})
 		) {
+			// Prevent browser default from double-firing against the Electron
+			// `role: 'paste'`/`'copy'` accelerator (src/main/lib/menu.ts).
+			if (event.type === "keydown") {
+				event.preventDefault();
+			}
 			return false;
 		}
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/clipboardShortcuts.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/clipboardShortcuts.test.ts
@@ -24,90 +24,120 @@ function makeEvent(
 }
 
 describe("shouldBubbleClipboardShortcut", () => {
-	it("matches the VS Code terminal clipboard bindings", () => {
+	it("bubbles every Mac Cmd chord, Ghostty-style", () => {
 		const cases = [
 			{
-				name: "macOS Cmd+V",
-				event: makeEvent({ code: "KeyV", metaKey: true }),
-				options: { isMac: true, isWindows: false, hasSelection: false },
-				expected: true,
-			},
-			{
-				name: "macOS Cmd+C with selection",
+				name: "Cmd+C (no selection)",
 				event: makeEvent({ code: "KeyC", metaKey: true }),
-				options: { isMac: true, isWindows: false, hasSelection: true },
-				expected: true,
+			},
+			{ name: "Cmd+V", event: makeEvent({ code: "KeyV", metaKey: true }) },
+			{ name: "Cmd+Enter", event: makeEvent({ code: "Enter", metaKey: true }) },
+			{ name: "Cmd+W", event: makeEvent({ code: "KeyW", metaKey: true }) },
+			{
+				name: "Cmd+Shift+K",
+				event: makeEvent({ code: "KeyK", metaKey: true, shiftKey: true }),
 			},
 			{
-				name: "windows Ctrl+V",
+				name: "Cmd+Alt+Left",
+				event: makeEvent({ code: "ArrowLeft", metaKey: true, altKey: true }),
+			},
+		];
+
+		for (const { name, event } of cases) {
+			expect(
+				shouldBubbleClipboardShortcut(event, {
+					isMac: true,
+					isWindows: false,
+					hasSelection: false,
+				}),
+				name,
+			).toBe(true);
+		}
+	});
+
+	it("does not bubble non-Cmd chords on Mac", () => {
+		const cases = [
+			{ name: "plain c", event: makeEvent({ code: "KeyC" }) },
+			{
+				name: "Ctrl+C (not a Mac idiom)",
+				event: makeEvent({ code: "KeyC", ctrlKey: true }),
+			},
+			{
+				name: "Shift+Insert",
+				event: makeEvent({ code: "Insert", shiftKey: true }),
+			},
+			{
+				name: "Ctrl+Shift+V (linux chord on mac)",
+				event: makeEvent({ code: "KeyV", ctrlKey: true, shiftKey: true }),
+			},
+		];
+
+		for (const { name, event } of cases) {
+			expect(
+				shouldBubbleClipboardShortcut(event, {
+					isMac: true,
+					isWindows: false,
+					hasSelection: false,
+				}),
+				name,
+			).toBe(false);
+		}
+	});
+
+	it("matches standard Windows / Linux clipboard bindings", () => {
+		const cases = [
+			{
+				name: "Windows Ctrl+V",
 				event: makeEvent({ code: "KeyV", ctrlKey: true }),
 				options: { isMac: false, isWindows: true, hasSelection: false },
 				expected: true,
 			},
 			{
-				name: "windows Ctrl+Shift+V",
+				name: "Windows Ctrl+Shift+V",
 				event: makeEvent({ code: "KeyV", ctrlKey: true, shiftKey: true }),
 				options: { isMac: false, isWindows: true, hasSelection: false },
 				expected: true,
 			},
 			{
-				name: "windows Ctrl+C with selection",
+				name: "Windows Ctrl+C with selection",
 				event: makeEvent({ code: "KeyC", ctrlKey: true }),
 				options: { isMac: false, isWindows: true, hasSelection: true },
 				expected: true,
 			},
 			{
-				name: "linux Ctrl+Shift+C with selection",
-				event: makeEvent({ code: "KeyC", ctrlKey: true, shiftKey: true }),
-				options: { isMac: false, isWindows: false, hasSelection: true },
-				expected: true,
-			},
-			{
-				name: "linux Ctrl+Shift+V",
-				event: makeEvent({ code: "KeyV", ctrlKey: true, shiftKey: true }),
-				options: { isMac: false, isWindows: false, hasSelection: false },
-				expected: true,
-			},
-			{
-				name: "linux Shift+Insert",
-				event: makeEvent({ code: "Insert", shiftKey: true }),
-				options: { isMac: false, isWindows: false, hasSelection: false },
-				expected: true,
-			},
-			{
-				name: "macOS Cmd+C without selection",
-				event: makeEvent({ code: "KeyC", metaKey: true }),
-				options: { isMac: true, isWindows: false, hasSelection: false },
-				expected: false,
-			},
-			{
-				name: "windows Ctrl+C without selection",
+				name: "Windows Ctrl+C without selection stays with PTY (SIGINT)",
 				event: makeEvent({ code: "KeyC", ctrlKey: true }),
 				options: { isMac: false, isWindows: true, hasSelection: false },
 				expected: false,
 			},
 			{
-				name: "linux Ctrl+Shift+C without selection",
+				name: "Windows Ctrl+Shift+C without selection still bubbles",
+				event: makeEvent({ code: "KeyC", ctrlKey: true, shiftKey: true }),
+				options: { isMac: false, isWindows: true, hasSelection: false },
+				expected: true,
+			},
+			{
+				name: "Linux Ctrl+Shift+V",
+				event: makeEvent({ code: "KeyV", ctrlKey: true, shiftKey: true }),
+				options: { isMac: false, isWindows: false, hasSelection: false },
+				expected: true,
+			},
+			{
+				name: "Linux Shift+Insert",
+				event: makeEvent({ code: "Insert", shiftKey: true }),
+				options: { isMac: false, isWindows: false, hasSelection: false },
+				expected: true,
+			},
+			{
+				name: "Linux Ctrl+Shift+C without selection still bubbles",
 				event: makeEvent({ code: "KeyC", ctrlKey: true, shiftKey: true }),
 				options: { isMac: false, isWindows: false, hasSelection: false },
-				expected: false,
+				expected: true,
 			},
 			{
-				name: "linux Ctrl+Insert stays with the PTY",
+				name: "Linux Ctrl+Insert stays with the PTY",
 				event: makeEvent({ code: "Insert", ctrlKey: true }),
 				options: { isMac: false, isWindows: false, hasSelection: false },
-				expected: false,
-			},
-			{
-				name: "macOS does not inherit linux fallback chords",
-				event: makeEvent({ code: "KeyV", ctrlKey: true, shiftKey: true }),
-				options: { isMac: true, isWindows: false, hasSelection: false },
-				expected: false,
-			},
-			{
-				name: "macOS Shift+Insert stays with the PTY",
-				event: makeEvent({ code: "Insert", shiftKey: true }),
-				options: { isMac: true, isWindows: false, hasSelection: false },
 				expected: false,
 			},
 		];

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/clipboardShortcuts.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/clipboardShortcuts.ts
@@ -28,8 +28,17 @@ export function shouldSelectAllShortcut(
 }
 
 /**
- * Mirror VS Code terminal clipboard bindings so host copy/paste can run before
- * xterm's kitty keyboard handler turns the chord into CSI-u input.
+ * Decide whether a chord should bubble to the host (Electron menu accelerators,
+ * OS clipboard handlers, etc.) instead of reaching xterm's kitty encoder and
+ * leaking into the PTY as a CSI-u sequence.
+ *
+ * On macOS we follow Ghostty's rule (ghostty/src/input/key_encode.zig:534-545:
+ * "on macOS, command+keys do not encode text"): every Cmd chord bubbles. Specific
+ * chords the terminal wants to intercept (Cmd+Left/Right/Backspace, Cmd+A, etc.)
+ * must run before this check in the caller.
+ *
+ * Windows/Linux have standard copy/paste keybinds that bubble selectively:
+ * Ctrl+C only bubbles with a selection because it doubles as SIGINT.
  */
 export function shouldBubbleClipboardShortcut(
 	event: ClipboardShortcutEvent,
@@ -37,8 +46,10 @@ export function shouldBubbleClipboardShortcut(
 ): boolean {
 	const { isMac, isWindows, hasSelection } = options;
 
-	const onlyMeta =
-		event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey;
+	if (isMac) {
+		return event.metaKey;
+	}
+
 	const onlyCtrl =
 		event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey;
 	const ctrlShiftOnly =
@@ -46,29 +57,16 @@ export function shouldBubbleClipboardShortcut(
 	const onlyShift =
 		event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey;
 
-	if (isMac && onlyMeta) {
-		return event.code === "KeyV" || (hasSelection && event.code === "KeyC");
-	}
-
 	if (isWindows) {
-		if (event.code === "KeyV" && (onlyCtrl || ctrlShiftOnly)) {
-			return true;
-		}
-
-		if (hasSelection && event.code === "KeyC" && (onlyCtrl || ctrlShiftOnly)) {
-			return true;
-		}
-
+		if (event.code === "KeyV" && (onlyCtrl || ctrlShiftOnly)) return true;
+		if (event.code === "KeyC" && ctrlShiftOnly) return true;
+		if (event.code === "KeyC" && onlyCtrl && hasSelection) return true;
 		return false;
 	}
 
-	if (!isMac) {
-		return (
-			(event.code === "KeyV" && ctrlShiftOnly) ||
-			(event.code === "Insert" && onlyShift) ||
-			(hasSelection && event.code === "KeyC" && ctrlShiftOnly)
-		);
-	}
-
-	return false;
+	return (
+		(event.code === "KeyV" && ctrlShiftOnly) ||
+		(event.code === "Insert" && onlyShift) ||
+		(event.code === "KeyC" && ctrlShiftOnly)
+	);
 }


### PR DESCRIPTION
## Summary

v2 terminal runtime only filtered app hotkeys, so with kitty keyboard protocol enabled (required for Shift+Enter disambiguation in claude-code, modifier reporting in neovim/helix), every Mac Cmd chord xterm saw got CSI-u encoded and leaked into TUIs as a literal char — Cmd+V → `v`, Cmd+C → `c`. Line-edit niceties that v1 handles (Cmd+←/→/⌫, Option+←/→) never worked in v2 at all.

Mirrors Ghostty's approach (`src/input/key_encode.zig:534-545`: *"on macOS, command+keys do not encode text"*): bubble every Mac Cmd chord out to the host before xterm's kitty encoder runs, then port v1's line-edit chord translators so shell navigation is identical in both renderers.

- Broaden `shouldBubbleClipboardShortcut`'s Mac branch: bubble all Cmd chords (not just Cmd+C/V with selection gating). v1 benefits too.
- Port v1's line-edit translators into v2's custom key handler: Cmd+←/→/⌫, Option+←/→, Windows Ctrl+←/→. Duplicates v1 for now; a follow-up can share the handler.
- Wire `shouldSelectAllShortcut` into v2 so Cmd+A selects the terminal buffer.
- Use `xterm.input(data, true)` to inject translated sequences into the PTY (fires `onData`, forwarded by terminal-ws-transport).
- Restructure tests around the new Mac rule.

This is a cherry-pick of 70bd19167 from the debug branch — the fix is complementary to the TERM_PROGRAM=kitty change that already landed (TERM_PROGRAM=kitty lets TUIs parse CSI-u; this stops us from sending CSI-u for chords the host should own).

Related upstream fix against codex: https://github.com/openai/codex/pull/new/fix/cmd-key-text-insertion-on-macos — widens codex's "is this key text?" gate to treat SUPER as a shortcut modifier. Not needed once Cmd chords are bubbled at the xterm layer, but defends against other kitty-speaking terminals that don't.

## Test plan

- [x] `bun test` for `clipboardShortcuts.test.ts` — 4 pass, 22 assertions.
- [x] `bun typecheck` for `@superset/desktop` — clean.
- [ ] Manual smoke: inside a v2 terminal pane, run codex / claude-code / vim / less:
  - [ ] Cmd+V pastes from host clipboard (no `v` leak).
  - [ ] Cmd+C copies selection (no `c` leak when nothing selected).
  - [ ] Cmd+← / Cmd+→ / Cmd+⌫ behave in shell like v1.
  - [ ] Option+← / Option+→ word-navigate in shell.
  - [ ] Cmd+A selects terminal buffer.
  - [ ] Shift+Enter still disambiguates correctly in claude-code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopts Ghostty’s keyboard model in the v2 terminal so macOS Cmd chords never become CSI‑u input and v1 shell navigation matches. Restores reliable copy/paste, Select All, and line‑edit shortcuts across platforms.

- **Bug Fixes**
  - macOS: bubble all Cmd chords to the host before kitty encoding; no more Cmd+V/C leaks into TUIs. Do not `preventDefault` on bubbled clipboard chords so the browser paste pipeline runs.
  - Translate line‑edit chords (Cmd+←/→/⌫, Option+←/→, Windows Ctrl+←/→) and inject via `xterm.input(..., true)` so shells respond correctly.
  - Cmd+A selects the terminal buffer.
  - Windows/Linux: standard clipboard rules—Ctrl+V and Ctrl+Shift+V paste; Ctrl+C bubbles only with selection; Ctrl+Shift+C always bubbles; Shift+Insert pastes on Linux. Tests updated.

- **Refactors**
  - Collapsed line‑edit translation into a grouped form with a small `onlyMod` helper; behavior unchanged and easier to extend.

<sup>Written for commit cd821a5bb6d110c878634926b27358b9db4b1914. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal keyboard handling improved: host hotkeys take precedence, Select All is consistently honored, platform-specific line-edit chords are delivered correctly, and clipboard shortcuts follow clearer macOS/Windows/Linux bubbling rules to avoid duplicate or suppressed copy/paste actions.

* **Tests**
  * Clipboard shortcut tests updated to reflect the new platform-specific behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->