### PR TITLE
[codex] Fix v2 terminal lifecycle after sleep

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-background-intents.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-background-intents.ts
@@ -1,0 +1,9 @@
+const backgroundTerminalIds = new Set<string>();
+
+export function markTerminalForBackground(terminalId: string): void {
+	backgroundTerminalIds.add(terminalId);
+}
+
+export function consumeTerminalBackgroundIntent(terminalId: string): boolean {
+	return backgroundTerminalIds.delete(terminalId);
+}

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -26,6 +26,8 @@ import {
 } from "./terminal-ws-transport";
 
 interface RegistryEntry {
+	terminalId: string;
+	instanceId: string;
 	runtime: TerminalRuntime | null;
 	transport: TerminalTransport;
 	linkManager: TerminalLinkManager | null;
@@ -35,20 +37,90 @@ interface RegistryEntry {
 
 class TerminalRuntimeRegistryImpl {
 	private entries = new Map<string, RegistryEntry>();
+	private entryKeysByTerminalId = new Map<string, Set<string>>();
 
-	private getOrCreateEntry(terminalId: string): RegistryEntry {
-		let entry = this.entries.get(terminalId);
+	private getEntryKey(terminalId: string, instanceId = terminalId): string {
+		return `${terminalId}\u0000${instanceId}`;
+	}
+
+	private getOrCreateEntry(
+		terminalId: string,
+		instanceId = terminalId,
+	): RegistryEntry {
+		const key = this.getEntryKey(terminalId, instanceId);
+		let entry = this.entries.get(key);
 		if (entry) return entry;
 
 		entry = {
+			terminalId,
+			instanceId,
 			runtime: null,
 			transport: createTransport(),
 			linkManager: null,
 			pendingLinkHandlers: null,
 		};
 
-		this.entries.set(terminalId, entry);
+		this.entries.set(key, entry);
+		let keys = this.entryKeysByTerminalId.get(terminalId);
+		if (!keys) {
+			keys = new Set();
+			this.entryKeysByTerminalId.set(terminalId, keys);
+		}
+		keys.add(key);
 		return entry;
+	}
+
+	private getEntry(
+		terminalId: string,
+		instanceId?: string,
+	): RegistryEntry | null {
+		if (instanceId) {
+			return this.entries.get(this.getEntryKey(terminalId, instanceId)) ?? null;
+		}
+		return this.getPrimaryEntry(terminalId);
+	}
+
+	private getPrimaryEntry(terminalId: string): RegistryEntry | null {
+		const defaultEntry = this.entries.get(this.getEntryKey(terminalId));
+		if (defaultEntry) return defaultEntry;
+
+		const keys = this.entryKeysByTerminalId.get(terminalId);
+		const firstKey = keys?.values().next().value;
+		return firstKey ? (this.entries.get(firstKey) ?? null) : null;
+	}
+
+	private getEntries(terminalId: string): RegistryEntry[] {
+		const keys = this.entryKeysByTerminalId.get(terminalId);
+		if (!keys) return [];
+		return Array.from(keys)
+			.map((key) => this.entries.get(key))
+			.filter((entry): entry is RegistryEntry => Boolean(entry));
+	}
+
+	private deleteEntry(entry: RegistryEntry) {
+		const key = this.getEntryKey(entry.terminalId, entry.instanceId);
+		this.entries.delete(key);
+		const keys = this.entryKeysByTerminalId.get(entry.terminalId);
+		if (!keys) return;
+		keys.delete(key);
+		if (keys.size === 0) {
+			this.entryKeysByTerminalId.delete(entry.terminalId);
+		}
+	}
+
+	private serializeExistingRuntime(
+		terminalId: string,
+		excludedInstanceId: string,
+	): string | undefined {
+		for (const entry of this.getEntries(terminalId)) {
+			if (entry.instanceId === excludedInstanceId || !entry.runtime) continue;
+			try {
+				return entry.runtime.serializeAddon.serialize({ scrollback: 1000 });
+			} catch {
+				return undefined;
+			}
+		}
+		return undefined;
 	}
 
 	/**
@@ -67,11 +139,14 @@ class TerminalRuntimeRegistryImpl {
 		terminalId: string,
 		container: HTMLDivElement,
 		appearance: TerminalAppearance,
+		instanceId = terminalId,
 	) {
-		const entry = this.getOrCreateEntry(terminalId);
+		const entry = this.getOrCreateEntry(terminalId, instanceId);
 
 		if (!entry.runtime) {
-			entry.runtime = createRuntime(terminalId, appearance);
+			entry.runtime = createRuntime(terminalId, appearance, {
+				initialBuffer: this.serializeExistingRuntime(terminalId, instanceId),
+			});
 			entry.linkManager = new TerminalLinkManager(entry.runtime.terminal);
 			if (entry.pendingLinkHandlers) {
 				entry.linkManager.setHandlers(entry.pendingLinkHandlers);
@@ -94,8 +169,8 @@ class TerminalRuntimeRegistryImpl {
 	 *
 	 * Idempotent: no-op if already connected/connecting to the same URL.
 	 */
-	connect(terminalId: string, wsUrl: string) {
-		const entry = this.entries.get(terminalId);
+	connect(terminalId: string, wsUrl: string, instanceId = terminalId) {
+		const entry = this.getEntry(terminalId, instanceId);
 		if (!entry?.runtime) return;
 		connect(entry.transport, entry.runtime.terminal, wsUrl);
 	}
@@ -112,8 +187,8 @@ class TerminalRuntimeRegistryImpl {
 	 * swap), and `"closed"` (previously live and mid-auto-reconnect — swap
 	 * the URL so the reconnect targets the new endpoint).
 	 */
-	reconnect(terminalId: string, wsUrl: string) {
-		const entry = this.entries.get(terminalId);
+	reconnect(terminalId: string, wsUrl: string, instanceId = terminalId) {
+		const entry = this.getEntry(terminalId, instanceId);
 		if (!entry?.runtime) return;
 		if (entry.transport.connectionState === "disconnected") return;
 		if (entry.transport.currentUrl === wsUrl) return;
@@ -124,8 +199,12 @@ class TerminalRuntimeRegistryImpl {
 	 * Set link handler callbacks for a terminal. Safe to call before or after
 	 * mount(). If the runtime already exists, link providers are re-registered.
 	 */
-	setLinkHandlers(terminalId: string, handlers: TerminalLinkHandlers) {
-		const entry = this.getOrCreateEntry(terminalId);
+	setLinkHandlers(
+		terminalId: string,
+		handlers: TerminalLinkHandlers,
+		instanceId = terminalId,
+	) {
+		const entry = this.getOrCreateEntry(terminalId, instanceId);
 		if (entry.linkManager) {
 			entry.linkManager.setHandlers(handlers);
 		} else {
@@ -138,15 +217,19 @@ class TerminalRuntimeRegistryImpl {
 	 * transport stay alive; DOM is moved off the React-controlled tree so
 	 * it survives the parent unmount without re-entering xterm.open().
 	 */
-	detach(terminalId: string) {
-		const entry = this.entries.get(terminalId);
+	detach(terminalId: string, instanceId = terminalId) {
+		const entry = this.getEntry(terminalId, instanceId);
 		if (!entry?.runtime) return;
 
 		detachFromContainer(entry.runtime);
 	}
 
-	updateAppearance(terminalId: string, appearance: TerminalAppearance) {
-		const entry = this.entries.get(terminalId);
+	updateAppearance(
+		terminalId: string,
+		appearance: TerminalAppearance,
+		instanceId = terminalId,
+	) {
+		const entry = this.getEntry(terminalId, instanceId);
 		if (!entry?.runtime) return;
 
 		const prevCols = entry.runtime.terminal.cols;
@@ -161,7 +244,6 @@ class TerminalRuntimeRegistryImpl {
 	}
 
 	private disposeEntry(
-		terminalId: string,
 		entry: RegistryEntry,
 		options: { clearPersistedState?: boolean } = {},
 	) {
@@ -170,7 +252,7 @@ class TerminalRuntimeRegistryImpl {
 		if (entry.runtime) {
 			disposeRuntime(entry.runtime, options);
 		}
-		this.entries.delete(terminalId);
+		this.deleteEntry(entry);
 	}
 
 	/**
@@ -178,10 +260,15 @@ class TerminalRuntimeRegistryImpl {
 	 * view and closes the WebSocket, but it does not tell host-service to kill
 	 * the underlying PTY. Use this for pane/sidebar lifecycle cleanup.
 	 */
-	release(terminalId: string) {
-		const entry = this.entries.get(terminalId);
-		if (!entry) return;
-		this.disposeEntry(terminalId, entry, { clearPersistedState: false });
+	release(terminalId: string, instanceId?: string) {
+		const entries = instanceId
+			? [this.getEntry(terminalId, instanceId)].filter(
+					(entry): entry is RegistryEntry => Boolean(entry),
+				)
+			: this.getEntries(terminalId);
+		for (const entry of entries) {
+			this.disposeEntry(entry, { clearPersistedState: false });
+		}
 	}
 
 	/**
@@ -189,83 +276,96 @@ class TerminalRuntimeRegistryImpl {
 	 * This is destructive and should only be used from explicit kill actions.
 	 */
 	dispose(terminalId: string) {
-		const entry = this.entries.get(terminalId);
-		if (!entry) return;
-
-		sendDispose(entry.transport);
-		this.disposeEntry(terminalId, entry);
+		for (const entry of this.getEntries(terminalId)) {
+			sendDispose(entry.transport);
+			this.disposeEntry(entry);
+		}
 	}
 
-	getSelection(terminalId: string): string {
-		const entry = this.entries.get(terminalId);
+	getSelection(terminalId: string, instanceId?: string): string {
+		const entry = this.getEntry(terminalId, instanceId);
 		return entry?.runtime?.terminal.getSelection() ?? "";
 	}
 
-	clear(terminalId: string): void {
-		const entry = this.entries.get(terminalId);
+	clear(terminalId: string, instanceId?: string): void {
+		const entry = this.getEntry(terminalId, instanceId);
 		entry?.runtime?.terminal.clear();
 	}
 
-	scrollToBottom(terminalId: string): void {
-		const entry = this.entries.get(terminalId);
+	scrollToBottom(terminalId: string, instanceId?: string): void {
+		const entry = this.getEntry(terminalId, instanceId);
 		entry?.runtime?.terminal.scrollToBottom();
 	}
 
-	paste(terminalId: string, text: string): void {
-		const entry = this.entries.get(terminalId);
+	paste(terminalId: string, text: string, instanceId?: string): void {
+		const entry = this.getEntry(terminalId, instanceId);
 		entry?.runtime?.terminal.paste(text);
 	}
 
 	/** Send raw input to the terminal via the WebSocket transport (bypasses xterm). */
-	writeInput(terminalId: string, data: string): void {
-		const entry = this.entries.get(terminalId);
+	writeInput(terminalId: string, data: string, instanceId?: string): void {
+		const entry = this.getEntry(terminalId, instanceId);
 		if (!entry) return;
 		sendInput(entry.transport, data);
 	}
 
-	findNext(terminalId: string, query: string): boolean {
-		const entry = this.entries.get(terminalId);
+	findNext(terminalId: string, query: string, instanceId?: string): boolean {
+		const entry = this.getEntry(terminalId, instanceId);
 		return entry?.runtime?.searchAddon?.findNext(query) ?? false;
 	}
 
-	findPrevious(terminalId: string, query: string): boolean {
-		const entry = this.entries.get(terminalId);
+	findPrevious(
+		terminalId: string,
+		query: string,
+		instanceId?: string,
+	): boolean {
+		const entry = this.getEntry(terminalId, instanceId);
 		return entry?.runtime?.searchAddon?.findPrevious(query) ?? false;
 	}
 
-	clearSearch(terminalId: string): void {
-		const entry = this.entries.get(terminalId);
+	clearSearch(terminalId: string, instanceId?: string): void {
+		const entry = this.getEntry(terminalId, instanceId);
 		entry?.runtime?.searchAddon?.clearDecorations();
 	}
 
-	getTerminal(terminalId: string) {
-		return this.entries.get(terminalId)?.runtime?.terminal ?? null;
+	getTerminal(terminalId: string, instanceId?: string) {
+		return this.getEntry(terminalId, instanceId)?.runtime?.terminal ?? null;
 	}
 
-	getSearchAddon(terminalId: string): SearchAddon | null {
-		return this.entries.get(terminalId)?.runtime?.searchAddon ?? null;
+	getSearchAddon(terminalId: string, instanceId?: string): SearchAddon | null {
+		return this.getEntry(terminalId, instanceId)?.runtime?.searchAddon ?? null;
 	}
 
-	getProgressAddon(terminalId: string): ProgressAddon | null {
-		return this.entries.get(terminalId)?.runtime?.progressAddon ?? null;
-	}
-
-	getAllTerminalIds(): Set<string> {
-		return new Set(this.entries.keys());
-	}
-
-	has(terminalId: string): boolean {
-		return this.entries.has(terminalId);
-	}
-
-	getConnectionState(terminalId: string): ConnectionState {
+	getProgressAddon(
+		terminalId: string,
+		instanceId?: string,
+	): ProgressAddon | null {
 		return (
-			this.entries.get(terminalId)?.transport.connectionState ?? "disconnected"
+			this.getEntry(terminalId, instanceId)?.runtime?.progressAddon ?? null
 		);
 	}
 
-	onStateChange(terminalId: string, listener: () => void): () => void {
-		const entry = this.getOrCreateEntry(terminalId);
+	getAllTerminalIds(): Set<string> {
+		return new Set(this.entryKeysByTerminalId.keys());
+	}
+
+	has(terminalId: string): boolean {
+		return this.entryKeysByTerminalId.has(terminalId);
+	}
+
+	getConnectionState(terminalId: string, instanceId?: string): ConnectionState {
+		return (
+			this.getEntry(terminalId, instanceId)?.transport.connectionState ??
+			"disconnected"
+		);
+	}
+
+	onStateChange(
+		terminalId: string,
+		listener: () => void,
+		instanceId = terminalId,
+	): () => void {
+		const entry = this.getOrCreateEntry(terminalId, instanceId);
 		entry.transport.stateListeners.add(listener);
 		return () => {
 			entry.transport.stateListeners.delete(listener);

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -160,17 +160,40 @@ class TerminalRuntimeRegistryImpl {
 		}
 	}
 
+	private disposeEntry(
+		terminalId: string,
+		entry: RegistryEntry,
+		options: { clearPersistedState?: boolean } = {},
+	) {
+		entry.linkManager?.dispose();
+		disposeTransport(entry.transport);
+		if (entry.runtime) {
+			disposeRuntime(entry.runtime, options);
+		}
+		this.entries.delete(terminalId);
+	}
+
+	/**
+	 * Release the renderer-side terminal runtime only. This detaches the xterm
+	 * view and closes the WebSocket, but it does not tell host-service to kill
+	 * the underlying PTY. Use this for pane/sidebar lifecycle cleanup.
+	 */
+	release(terminalId: string) {
+		const entry = this.entries.get(terminalId);
+		if (!entry) return;
+		this.disposeEntry(terminalId, entry, { clearPersistedState: false });
+	}
+
+	/**
+	 * Kill the host-service terminal session and remove all renderer-side state.
+	 * This is destructive and should only be used from explicit kill actions.
+	 */
 	dispose(terminalId: string) {
 		const entry = this.entries.get(terminalId);
 		if (!entry) return;
 
-		entry.linkManager?.dispose();
-
 		sendDispose(entry.transport);
-		disposeTransport(entry.transport);
-		if (entry.runtime) disposeRuntime(entry.runtime);
-
-		this.entries.delete(terminalId);
+		this.disposeEntry(terminalId, entry);
 	}
 
 	getSelection(terminalId: string): string {

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -277,7 +277,7 @@ export function createRuntime(
 	// Activate Unicode 11 widths (inside loadAddons) before restoring the buffer,
 	// else CJK/emoji/ZWJ widths get baked wrong into the replay. (#3572)
 	const addonsResult = loadAddons(terminal);
-	if (options.initialBuffer) {
+	if (options.initialBuffer !== undefined) {
 		terminal.write(options.initialBuffer);
 	} else {
 		restoreBuffer(terminalId, terminal);

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -255,6 +255,7 @@ function measureAndResize(runtime: TerminalRuntime) {
 export function createRuntime(
 	terminalId: string,
 	appearance: TerminalAppearance,
+	options: { initialBuffer?: string } = {},
 ): TerminalRuntime {
 	const savedDims = loadSavedDimensions(terminalId);
 	const cols = savedDims?.cols ?? DEFAULT_COLS;
@@ -276,7 +277,11 @@ export function createRuntime(
 	// Activate Unicode 11 widths (inside loadAddons) before restoring the buffer,
 	// else CJK/emoji/ZWJ widths get baked wrong into the replay. (#3572)
 	const addonsResult = loadAddons(terminal);
-	restoreBuffer(terminalId, terminal);
+	if (options.initialBuffer) {
+		terminal.write(options.initialBuffer);
+	} else {
+		restoreBuffer(terminalId, terminal);
+	}
 
 	return {
 		terminalId,

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -360,13 +360,23 @@ export function updateRuntimeAppearance(
 	}
 }
 
-export function disposeRuntime(runtime: TerminalRuntime) {
+export function disposeRuntime(
+	runtime: TerminalRuntime,
+	options: { clearPersistedState?: boolean } = {},
+) {
+	const clearPersistedState = options.clearPersistedState ?? true;
+	if (!clearPersistedState) {
+		persistBuffer(runtime.terminalId, runtime.serializeAddon);
+		persistDimensions(runtime.terminalId, runtime.lastCols, runtime.lastRows);
+	}
 	runtime._disposeAddons?.();
 	runtime._disposeAddons = null;
 	runtime.resizeObserver?.disconnect();
 	runtime.resizeObserver = null;
 	runtime.wrapper.remove();
 	runtime.terminal.dispose();
-	clearPersistedBuffer(runtime.terminalId);
-	clearPersistedDimensions(runtime.terminalId);
+	if (clearPersistedState) {
+		clearPersistedBuffer(runtime.terminalId);
+		clearPersistedDimensions(runtime.terminalId);
+	}
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -82,6 +82,12 @@ export function TerminalPane({
 	const ensureSession = workspaceTrpc.terminal.ensureSession.useMutation();
 	const ensureSessionRef = useRef(ensureSession);
 	ensureSessionRef.current = ensureSession;
+	const workspaceTrpcUtils = workspaceTrpc.useUtils();
+	const invalidateTerminalSessionsRef = useRef(
+		workspaceTrpcUtils.terminal.listSessions.invalidate,
+	);
+	invalidateTerminalSessionsRef.current =
+		workspaceTrpcUtils.terminal.listSessions.invalidate;
 
 	// useCallback so useSyncExternalStore doesn't re-subscribe every render —
 	// otherwise every keystroke-triggered re-render unsubscribes and
@@ -128,6 +134,13 @@ export function TerminalPane({
 				terminalId,
 				workspaceId: workspaceIdRef.current,
 				themeType: initialThemeTypeRef.current,
+			})
+			.then((result) => {
+				if (result.status === "active") {
+					void invalidateTerminalSessionsRef.current({
+						workspaceId: workspaceIdRef.current,
+					});
+				}
 			})
 			.catch((err) => {
 				console.error("[TerminalPane] ensureSession failed:", err);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -56,6 +56,7 @@ export function TerminalPane({
 	const { hint, showHint } = useLinkClickHint();
 	const paneData = ctx.pane.data as TerminalPaneData;
 	const { terminalId } = paneData;
+	const terminalInstanceId = ctx.pane.id;
 	const containerRef = useRef<HTMLDivElement | null>(null);
 	const activeTheme = useTheme();
 	const [isSearchOpen, setIsSearchOpen] = useState(false);
@@ -95,13 +96,20 @@ export function TerminalPane({
 	// docs ("If you don't memoize the subscribe function…").
 	const subscribe = useCallback(
 		(callback: () => void) =>
-			terminalRuntimeRegistry.onStateChange(terminalId, callback),
-		[terminalId],
+			terminalRuntimeRegistry.onStateChange(
+				terminalId,
+				callback,
+				terminalInstanceId,
+			),
+		[terminalId, terminalInstanceId],
 	);
 	const getSnapshot = useCallback(
 		(): ConnectionState =>
-			terminalRuntimeRegistry.getConnectionState(terminalId),
-		[terminalId],
+			terminalRuntimeRegistry.getConnectionState(
+				terminalId,
+				terminalInstanceId,
+			),
+		[terminalId, terminalInstanceId],
 	);
 	const connectionState = useSyncExternalStore(subscribe, getSnapshot);
 
@@ -120,7 +128,12 @@ export function TerminalPane({
 		const container = containerRef.current;
 		if (!container) return;
 
-		terminalRuntimeRegistry.mount(terminalId, container, appearanceRef.current);
+		terminalRuntimeRegistry.mount(
+			terminalId,
+			container,
+			appearanceRef.current,
+			terminalInstanceId,
+		);
 
 		let cancelled = false;
 
@@ -147,26 +160,38 @@ export function TerminalPane({
 			})
 			.finally(() => {
 				if (cancelled) return;
-				terminalRuntimeRegistry.connect(terminalId, websocketUrlRef.current);
+				terminalRuntimeRegistry.connect(
+					terminalId,
+					websocketUrlRef.current,
+					terminalInstanceId,
+				);
 			});
 
 		return () => {
 			cancelled = true;
-			terminalRuntimeRegistry.detach(terminalId);
+			terminalRuntimeRegistry.detach(terminalId, terminalInstanceId);
 		};
-	}, [terminalId]);
+	}, [terminalId, terminalInstanceId]);
 
 	// WS URL can change while the terminal stays mounted (token refresh, host
 	// URL re-resolution on provider remount). Reconnect only if the transport
 	// is already live — on initial mount the transport is "disconnected" and
 	// we let the ensureSession path above open it.
 	useEffect(() => {
-		terminalRuntimeRegistry.reconnect(terminalId, websocketUrl);
-	}, [terminalId, websocketUrl]);
+		terminalRuntimeRegistry.reconnect(
+			terminalId,
+			websocketUrl,
+			terminalInstanceId,
+		);
+	}, [terminalId, terminalInstanceId, websocketUrl]);
 
 	useEffect(() => {
-		terminalRuntimeRegistry.updateAppearance(terminalId, appearance);
-	}, [terminalId, appearance]);
+		terminalRuntimeRegistry.updateAppearance(
+			terminalId,
+			appearance,
+			terminalInstanceId,
+		);
+	}, [terminalId, terminalInstanceId, appearance]);
 
 	// --- Link handlers ---
 	// All filesystem operations go through the host service.
@@ -177,79 +202,84 @@ export function TerminalPane({
 	statPathRef.current = statPathMutation.mutateAsync;
 
 	useEffect(() => {
-		terminalRuntimeRegistry.setLinkHandlers(terminalId, {
-			stat: async (path) => {
-				try {
-					const result = await statPathRef.current({
-						workspaceId,
-						path,
-					});
-					if (!result) return null;
-					return {
-						isDirectory: result.isDirectory,
-						resolvedPath: result.resolvedPath,
-					};
-				} catch {
-					return null;
-				}
-			},
-			onFileLinkClick: (event, link) => {
-				// Folders are not settings-controlled: ⌘ reveals in sidebar,
-				// ⌘⇧ falls through to the external editor path, plain = hint.
-				if (link.isDirectory) {
-					if (!event.metaKey && !event.ctrlKey) {
+		terminalRuntimeRegistry.setLinkHandlers(
+			terminalId,
+			{
+				stat: async (path) => {
+					try {
+						const result = await statPathRef.current({
+							workspaceId,
+							path,
+						});
+						if (!result) return null;
+						return {
+							isDirectory: result.isDirectory,
+							resolvedPath: result.resolvedPath,
+						};
+					} catch {
+						return null;
+					}
+				},
+				onFileLinkClick: (event, link) => {
+					// Folders are not settings-controlled: ⌘ reveals in sidebar,
+					// ⌘⇧ falls through to the external editor path, plain = hint.
+					if (link.isDirectory) {
+						if (!event.metaKey && !event.ctrlKey) {
+							showHint(event.clientX, event.clientY);
+							return;
+						}
+						event.preventDefault();
+						if (event.shiftKey) {
+							openInExternalEditor(link.resolvedPath);
+						} else {
+							onRevealPath(link.resolvedPath, { isDirectory: true });
+						}
+						return;
+					}
+
+					const action = getFileAction(event);
+					if (action === null) {
 						showHint(event.clientX, event.clientY);
 						return;
 					}
 					event.preventDefault();
-					if (event.shiftKey) {
-						openInExternalEditor(link.resolvedPath);
+					if (action === "external") {
+						openInExternalEditor(link.resolvedPath, {
+							line: link.row,
+							column: link.col,
+						});
 					} else {
-						onRevealPath(link.resolvedPath, { isDirectory: true });
+						onOpenFile(link.resolvedPath);
 					}
-					return;
-				}
-
-				const action = getFileAction(event);
-				if (action === null) {
-					showHint(event.clientX, event.clientY);
-					return;
-				}
-				event.preventDefault();
-				if (action === "external") {
-					openInExternalEditor(link.resolvedPath, {
-						line: link.row,
-						column: link.col,
-					});
-				} else {
-					onOpenFile(link.resolvedPath);
-				}
+				},
+				onUrlClick: (event, url) => {
+					const action = getUrlAction(event);
+					if (action === null) {
+						showHint(event.clientX, event.clientY);
+						return;
+					}
+					event.preventDefault();
+					if (action === "external") {
+						electronTrpcClient.external.openUrl.mutate(url).catch((error) => {
+							console.error("[v2 Terminal] Failed to open URL:", url, error);
+						});
+					} else {
+						ctx.store.getState().openPane({
+							pane: {
+								kind: "browser",
+								data: { url } satisfies BrowserPaneData,
+							},
+						});
+					}
+				},
+				onLinkHover,
+				onLinkLeave,
 			},
-			onUrlClick: (event, url) => {
-				const action = getUrlAction(event);
-				if (action === null) {
-					showHint(event.clientX, event.clientY);
-					return;
-				}
-				event.preventDefault();
-				if (action === "external") {
-					electronTrpcClient.external.openUrl.mutate(url).catch((error) => {
-						console.error("[v2 Terminal] Failed to open URL:", url, error);
-					});
-				} else {
-					ctx.store.getState().openPane({
-						pane: {
-							kind: "browser",
-							data: { url } satisfies BrowserPaneData,
-						},
-					});
-				}
-			},
-			onLinkHover,
-			onLinkLeave,
-		});
+			terminalInstanceId,
+		);
 	}, [
 		terminalId,
+		terminalInstanceId,
 		workspaceId,
 		ctx.store,
 		onOpenFile,
@@ -265,7 +295,7 @@ export function TerminalPane({
 	useHotkey(
 		"CLEAR_TERMINAL",
 		() => {
-			terminalRuntimeRegistry.clear(terminalId);
+			terminalRuntimeRegistry.clear(terminalId, terminalInstanceId);
 		},
 		{ enabled: ctx.isActive },
 	);
@@ -273,7 +303,7 @@ export function TerminalPane({
 	useHotkey(
 		"SCROLL_TO_BOTTOM",
 		() => {
-			terminalRuntimeRegistry.scrollToBottom(terminalId);
+			terminalRuntimeRegistry.scrollToBottom(terminalId, terminalInstanceId);
 		},
 		{ enabled: ctx.isActive },
 	);
@@ -286,14 +316,15 @@ export function TerminalPane({
 	// connectionState in deps ensures terminal ref re-derives after connect/disconnect
 	// biome-ignore lint/correctness/useExhaustiveDependencies: connectionState is intentionally included to trigger re-derive
 	const terminal = useMemo(
-		() => terminalRuntimeRegistry.getTerminal(terminalId),
-		[terminalId, connectionState],
+		() => terminalRuntimeRegistry.getTerminal(terminalId, terminalInstanceId),
+		[terminalId, terminalInstanceId, connectionState],
 	);
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: connectionState is intentionally included to trigger re-derive
 	const searchAddon = useMemo(
-		() => terminalRuntimeRegistry.getSearchAddon(terminalId),
-		[terminalId, connectionState],
+		() =>
+			terminalRuntimeRegistry.getSearchAddon(terminalId, terminalInstanceId),
+		[terminalId, terminalInstanceId, connectionState],
 	);
 
 	const [isDropActive, setIsDropActive] = useState(false);
@@ -338,8 +369,10 @@ export function TerminalPane({
 		if (connectionState === "closed") return;
 		const text = resolveDroppedText(event.dataTransfer);
 		if (!text) return;
-		terminalRuntimeRegistry.getTerminal(terminalId)?.focus();
-		terminalRuntimeRegistry.paste(terminalId, text);
+		terminalRuntimeRegistry
+			.getTerminal(terminalId, terminalInstanceId)
+			?.focus();
+		terminalRuntimeRegistry.paste(terminalId, text, terminalInstanceId);
 	};
 
 	return (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -136,6 +136,7 @@ export function TerminalPane({
 		);
 
 		let cancelled = false;
+		const sessionWorkspaceId = workspaceIdRef.current;
 
 		// Always connect after ensureSession settles, even on error: if the
 		// session actually exists on the server (e.g. we raced another client),
@@ -145,13 +146,13 @@ export function TerminalPane({
 		ensureSessionRef.current
 			.mutateAsync({
 				terminalId,
-				workspaceId: workspaceIdRef.current,
+				workspaceId: sessionWorkspaceId,
 				themeType: initialThemeTypeRef.current,
 			})
 			.then((result) => {
 				if (result.status === "active") {
 					void invalidateTerminalSessionsRef.current({
-						workspaceId: workspaceIdRef.current,
+						workspaceId: sessionWorkspaceId,
 					});
 				}
 			})

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalHeaderExtras/TerminalHeaderExtras.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalHeaderExtras/TerminalHeaderExtras.tsx
@@ -1,0 +1,42 @@
+import type { RendererContext } from "@superset/panes";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { Archive } from "lucide-react";
+import { markTerminalForBackground } from "renderer/lib/terminal/terminal-background-intents";
+import type {
+	PaneViewerData,
+	TerminalPaneData,
+} from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
+
+interface TerminalHeaderExtrasProps {
+	context: RendererContext<PaneViewerData>;
+}
+
+export function TerminalHeaderExtras({ context }: TerminalHeaderExtrasProps) {
+	const data = context.pane.data as TerminalPaneData;
+
+	const handleMoveToBackground = () => {
+		markTerminalForBackground(data.terminalId);
+		void context.actions.close();
+	};
+
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<button
+					type="button"
+					aria-label="Move terminal to background"
+					onClick={(event) => {
+						event.stopPropagation();
+						handleMoveToBackground();
+					}}
+					className="rounded p-1 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
+				>
+					<Archive className="size-3.5" />
+				</button>
+			</TooltipTrigger>
+			<TooltipContent side="bottom" showArrow={false}>
+				Move terminal to background
+			</TooltipContent>
+		</Tooltip>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalHeaderExtras/TerminalHeaderExtras.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalHeaderExtras/TerminalHeaderExtras.tsx
@@ -12,6 +12,8 @@ interface TerminalHeaderExtrasProps {
 }
 
 export function TerminalHeaderExtras({ context }: TerminalHeaderExtrasProps) {
+	if (context.pane.kind !== "terminal") return null;
+
 	const data = context.pane.data as TerminalPaneData;
 
 	const handleMoveToBackground = () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalHeaderExtras/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalHeaderExtras/index.ts
@@ -1,0 +1,1 @@
+export { TerminalHeaderExtras } from "./TerminalHeaderExtras";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
@@ -32,6 +32,7 @@ interface TerminalSessionDropdownProps {
 interface VisibleTerminalSession {
 	terminalId: string;
 	workspaceId: string;
+	createdAt?: number;
 	exited: boolean;
 	exitCode: number;
 	attached: boolean;
@@ -44,8 +45,26 @@ interface TerminalPaneLocation {
 	titleOverride?: string;
 }
 
-function getShortTerminalId(terminalId: string): string {
-	return terminalId.length <= 8 ? terminalId : terminalId.slice(0, 8);
+function isSameCalendarDay(date: Date, reference: Date): boolean {
+	return (
+		date.getFullYear() === reference.getFullYear() &&
+		date.getMonth() === reference.getMonth() &&
+		date.getDate() === reference.getDate()
+	);
+}
+
+function formatCreatedAt(createdAt: number | undefined): string {
+	if (!createdAt) return "Creating";
+
+	const date = new Date(createdAt);
+	if (Number.isNaN(date.getTime())) return "Creating";
+
+	const today = new Date();
+	const options: Intl.DateTimeFormatOptions = isSameCalendarDay(date, today)
+		? { hour: "numeric", minute: "2-digit" }
+		: { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" };
+
+	return new Intl.DateTimeFormat(undefined, options).format(date);
 }
 
 function findTerminalPaneLocation(
@@ -80,7 +99,6 @@ export function TerminalSessionDropdown({
 	const sessionsQuery = workspaceTrpc.terminal.listSessions.useQuery(
 		{ workspaceId },
 		{
-			enabled: isOpen,
 			refetchInterval: isOpen ? 2_000 : false,
 			refetchOnWindowFocus: true,
 		},
@@ -197,6 +215,10 @@ export function TerminalSessionDropdown({
 	};
 
 	const triggerTitle = context.pane.titleOverride ?? "Terminal";
+	const currentSession = sessions.find(
+		(session) => session.terminalId === terminalId,
+	);
+	const currentCreatedAtLabel = formatCreatedAt(currentSession?.createdAt);
 
 	return (
 		<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
@@ -210,8 +232,10 @@ export function TerminalSessionDropdown({
 				>
 					<TerminalSquare className="size-4 shrink-0" />
 					<span className="min-w-0 truncate">{triggerTitle}</span>
-					<span className="shrink-0 font-mono text-[10px] text-muted-foreground/70">
-						{getShortTerminalId(terminalId)}
+					<span className="shrink-0 text-[10px] text-muted-foreground/70">
+						{currentSession?.createdAt
+							? `Created ${currentCreatedAtLabel}`
+							: currentCreatedAtLabel}
 					</span>
 					{sessionsQuery.isFetching && isOpen ? (
 						<LoaderCircle className="size-3 shrink-0 animate-spin" />
@@ -235,6 +259,7 @@ export function TerminalSessionDropdown({
 							);
 							const canSelect =
 								isCurrent || !session.attached || location !== null;
+							const createdAtLabel = formatCreatedAt(session.createdAt);
 							const status = isCurrent
 								? "Current"
 								: location
@@ -266,15 +291,17 @@ export function TerminalSessionDropdown({
 									<span className="min-w-0 flex-1 truncate text-xs">
 										{title}
 									</span>
-									<span className="shrink-0 font-mono text-[10px] text-muted-foreground/70">
-										{getShortTerminalId(session.terminalId)}
+									<span className="shrink-0 text-[10px] text-muted-foreground/70">
+										{session.createdAt
+											? `Created ${createdAtLabel}`
+											: createdAtLabel}
 									</span>
 									<span className="shrink-0 text-xs text-muted-foreground">
 										{status}
 									</span>
 									<button
 										type="button"
-										aria-label={`Remove terminal ${getShortTerminalId(session.terminalId)}`}
+										aria-label={`Remove terminal ${session.createdAt ? `created ${createdAtLabel}` : "session"}`}
 										disabled={killTerminalSession.isPending}
 										className="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive disabled:pointer-events-none disabled:opacity-30 group-hover:opacity-100"
 										onClick={(event) => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
@@ -1,4 +1,5 @@
 import type { RendererContext } from "@superset/panes";
+import { alert } from "@superset/ui/atoms/Alert";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -7,6 +8,7 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
+import { toast } from "@superset/ui/sonner";
 import { workspaceTrpc } from "@superset/workspace-client";
 import {
 	Check,
@@ -14,6 +16,7 @@ import {
 	LoaderCircle,
 	Plus,
 	TerminalSquare,
+	Trash2,
 } from "lucide-react";
 import { useMemo, useState } from "react";
 import type {
@@ -73,6 +76,7 @@ export function TerminalSessionDropdown({
 	const data = context.pane.data as TerminalPaneData;
 	const { terminalId } = data;
 	const utils = workspaceTrpc.useUtils();
+	const killTerminalSession = workspaceTrpc.terminal.killSession.useMutation();
 	const sessionsQuery = workspaceTrpc.terminal.listSessions.useQuery(
 		{ workspaceId },
 		{
@@ -130,6 +134,49 @@ export function TerminalSessionDropdown({
 			titleOverride: existingLocation?.titleOverride,
 		});
 		setIsOpen(false);
+	};
+
+	const closePaneForTerminal = (targetTerminalId: string) => {
+		if (targetTerminalId === terminalId) {
+			void context.actions.close();
+			return;
+		}
+
+		const location = findTerminalPaneLocation(context, targetTerminalId);
+		if (!location) return;
+
+		context.store.getState().closePane({
+			tabId: location.tabId,
+			paneId: location.paneId,
+		});
+	};
+
+	const removeTerminalSession = async (targetTerminalId: string) => {
+		await killTerminalSession.mutateAsync({ terminalId: targetTerminalId });
+		closePaneForTerminal(targetTerminalId);
+		await utils.terminal.listSessions.invalidate({ workspaceId });
+	};
+
+	const handleRemoveTerminal = (targetTerminalId: string) => {
+		alert({
+			title: "Remove terminal session?",
+			description:
+				"This will terminate the underlying process. Use Move terminal to background to keep it running without a pane.",
+			actions: [
+				{ label: "Cancel", variant: "outline", onClick: () => {} },
+				{
+					label: "Remove Terminal",
+					variant: "destructive",
+					onClick: () => {
+						toast.promise(removeTerminalSession(targetTerminalId), {
+							loading: "Removing terminal...",
+							success: "Terminal removed",
+							error: "Failed to remove terminal",
+						});
+					},
+				},
+			],
+		});
 	};
 
 	const handleNewTerminal = () => {
@@ -204,9 +251,14 @@ export function TerminalSessionDropdown({
 							return (
 								<DropdownMenuItem
 									key={session.terminalId}
-									disabled={!canSelect}
-									className="flex items-center gap-2"
-									onSelect={() => handleSelectSession(session.terminalId)}
+									className={`group flex items-center gap-2 ${!canSelect ? "text-muted-foreground/50" : ""}`}
+									onSelect={(event) => {
+										if (!canSelect) {
+											event.preventDefault();
+											return;
+										}
+										handleSelectSession(session.terminalId);
+									}}
 								>
 									<span className="w-4 shrink-0">
 										{isCurrent && <Check className="size-3.5" />}
@@ -220,6 +272,19 @@ export function TerminalSessionDropdown({
 									<span className="shrink-0 text-xs text-muted-foreground">
 										{status}
 									</span>
+									<button
+										type="button"
+										aria-label={`Remove terminal ${getShortTerminalId(session.terminalId)}`}
+										disabled={killTerminalSession.isPending}
+										className="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive disabled:pointer-events-none disabled:opacity-30 group-hover:opacity-100"
+										onClick={(event) => {
+											event.preventDefault();
+											event.stopPropagation();
+											handleRemoveTerminal(session.terminalId);
+										}}
+									>
+										<Trash2 className="size-3" />
+									</button>
 								</DropdownMenuItem>
 							);
 						})

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
@@ -53,24 +53,26 @@ function formatCreatedAt(createdAt: number | undefined): string {
 	return getRelativeTime(createdAt, { format: "compact" });
 }
 
-function findTerminalPaneLocation(
+function getTerminalPaneLocations(
 	context: RendererContext<PaneViewerData>,
-	terminalId: string,
-): TerminalPaneLocation | null {
+): Map<string, TerminalPaneLocation[]> {
+	const locations = new Map<string, TerminalPaneLocation[]>();
 	for (const tab of context.store.getState().tabs) {
 		for (const pane of Object.values(tab.panes)) {
 			if (pane.id === context.pane.id || pane.kind !== "terminal") continue;
 			const data = pane.data as Partial<TerminalPaneData>;
-			if (data.terminalId === terminalId) {
-				return {
+			if (data.terminalId) {
+				const terminalLocations = locations.get(data.terminalId) ?? [];
+				terminalLocations.push({
 					tabId: tab.id,
 					paneId: pane.id,
 					titleOverride: pane.titleOverride,
-				};
+				});
+				locations.set(data.terminalId, terminalLocations);
 			}
 		}
 	}
-	return null;
+	return locations;
 }
 
 export function TerminalSessionDropdown({
@@ -107,6 +109,7 @@ export function TerminalSessionDropdown({
 			...liveSessions,
 		];
 	}, [sessionsQuery.data?.sessions, terminalId, workspaceId]);
+	const terminalPaneLocations = getTerminalPaneLocations(context);
 
 	const handleSelectSession = (nextTerminalId: string) => {
 		if (nextTerminalId === terminalId) {
@@ -115,8 +118,8 @@ export function TerminalSessionDropdown({
 		}
 
 		const state = context.store.getState();
-		const existingLocation = findTerminalPaneLocation(context, nextTerminalId);
-		if (!findTerminalPaneLocation(context, terminalId)) {
+		const existingLocation = terminalPaneLocations.get(nextTerminalId)?.[0];
+		if ((terminalPaneLocations.get(terminalId)?.length ?? 0) === 0) {
 			markTerminalForBackground(terminalId);
 		}
 
@@ -132,24 +135,25 @@ export function TerminalSessionDropdown({
 		setIsOpen(false);
 	};
 
-	const closePaneForTerminal = (targetTerminalId: string) => {
-		if (targetTerminalId === terminalId) {
-			void context.actions.close();
-			return;
+	const closePanesForTerminal = (targetTerminalId: string) => {
+		for (const location of terminalPaneLocations.get(targetTerminalId) ?? []) {
+			context.store.getState().closePane({
+				tabId: location.tabId,
+				paneId: location.paneId,
+			});
 		}
 
-		const location = findTerminalPaneLocation(context, targetTerminalId);
-		if (!location) return;
-
-		context.store.getState().closePane({
-			tabId: location.tabId,
-			paneId: location.paneId,
-		});
+		if (targetTerminalId === terminalId) {
+			void context.actions.close();
+		}
 	};
 
 	const removeTerminalSession = async (targetTerminalId: string) => {
-		await killTerminalSession.mutateAsync({ terminalId: targetTerminalId });
-		closePaneForTerminal(targetTerminalId);
+		await killTerminalSession.mutateAsync({
+			terminalId: targetTerminalId,
+			workspaceId,
+		});
+		closePanesForTerminal(targetTerminalId);
 		await utils.terminal.listSessions.invalidate({ workspaceId });
 	};
 
@@ -177,7 +181,7 @@ export function TerminalSessionDropdown({
 
 	const handleNewTerminal = () => {
 		const state = context.store.getState();
-		if (!findTerminalPaneLocation(context, terminalId)) {
+		if ((terminalPaneLocations.get(terminalId)?.length ?? 0) === 0) {
 			markTerminalForBackground(terminalId);
 		}
 		state.setPaneData({
@@ -232,10 +236,9 @@ export function TerminalSessionDropdown({
 					{sessions.length > 0 ? (
 						sessions.map((session) => {
 							const isCurrent = session.terminalId === terminalId;
-							const location = findTerminalPaneLocation(
-								context,
+							const location = terminalPaneLocations.get(
 								session.terminalId,
-							);
+							)?.[0];
 							const createdAtLabel = formatCreatedAt(session.createdAt);
 							const status = isCurrent
 								? "Current"

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
@@ -19,10 +19,12 @@ import {
 	Trash2,
 } from "lucide-react";
 import { useMemo, useState } from "react";
+import { markTerminalForBackground } from "renderer/lib/terminal/terminal-background-intents";
 import type {
 	PaneViewerData,
 	TerminalPaneData,
 } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
+import { getRelativeTime } from "renderer/screens/main/components/WorkspacesListView/utils";
 
 interface TerminalSessionDropdownProps {
 	context: RendererContext<PaneViewerData>;
@@ -45,26 +47,10 @@ interface TerminalPaneLocation {
 	titleOverride?: string;
 }
 
-function isSameCalendarDay(date: Date, reference: Date): boolean {
-	return (
-		date.getFullYear() === reference.getFullYear() &&
-		date.getMonth() === reference.getMonth() &&
-		date.getDate() === reference.getDate()
-	);
-}
-
 function formatCreatedAt(createdAt: number | undefined): string {
 	if (!createdAt) return "Creating";
 
-	const date = new Date(createdAt);
-	if (Number.isNaN(date.getTime())) return "Creating";
-
-	const today = new Date();
-	const options: Intl.DateTimeFormatOptions = isSameCalendarDay(date, today)
-		? { hour: "numeric", minute: "2-digit" }
-		: { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" };
-
-	return new Intl.DateTimeFormat(undefined, options).format(date);
+	return getRelativeTime(createdAt, { format: "compact" });
 }
 
 function findTerminalPaneLocation(
@@ -199,6 +185,9 @@ export function TerminalSessionDropdown({
 
 	const handleNewTerminal = () => {
 		const state = context.store.getState();
+		if (!findTerminalPaneLocation(context, terminalId)) {
+			markTerminalForBackground(terminalId);
+		}
 		state.setPaneData({
 			paneId: context.pane.id,
 			data: {
@@ -233,9 +222,7 @@ export function TerminalSessionDropdown({
 					<TerminalSquare className="size-4 shrink-0" />
 					<span className="min-w-0 truncate">{triggerTitle}</span>
 					<span className="shrink-0 text-[10px] text-muted-foreground/70">
-						{currentSession?.createdAt
-							? `Created ${currentCreatedAtLabel}`
-							: currentCreatedAtLabel}
+						{currentCreatedAtLabel}
 					</span>
 					{sessionsQuery.isFetching && isOpen ? (
 						<LoaderCircle className="size-3 shrink-0 animate-spin" />
@@ -260,15 +247,6 @@ export function TerminalSessionDropdown({
 							const canSelect =
 								isCurrent || !session.attached || location !== null;
 							const createdAtLabel = formatCreatedAt(session.createdAt);
-							const status = isCurrent
-								? "Current"
-								: location
-									? "Swap"
-									: session.pending
-										? "Starting"
-										: session.attached
-											? "Attached"
-											: "Detached";
 							const title = isCurrent
 								? triggerTitle
 								: (location?.titleOverride ?? "Terminal");
@@ -292,16 +270,11 @@ export function TerminalSessionDropdown({
 										{title}
 									</span>
 									<span className="shrink-0 text-[10px] text-muted-foreground/70">
-										{session.createdAt
-											? `Created ${createdAtLabel}`
-											: createdAtLabel}
-									</span>
-									<span className="shrink-0 text-xs text-muted-foreground">
-										{status}
+										{createdAtLabel}
 									</span>
 									<button
 										type="button"
-										aria-label={`Remove terminal ${session.createdAt ? `created ${createdAtLabel}` : "session"}`}
+										aria-label={`Remove terminal ${session.createdAt ? createdAtLabel : "session"}`}
 										disabled={killTerminalSession.isPending}
 										className="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive disabled:pointer-events-none disabled:opacity-30 group-hover:opacity-100"
 										onClick={(event) => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
@@ -116,16 +116,8 @@ export function TerminalSessionDropdown({
 
 		const state = context.store.getState();
 		const existingLocation = findTerminalPaneLocation(context, nextTerminalId);
-		if (existingLocation) {
-			state.setPaneData({
-				paneId: existingLocation.paneId,
-				data: { terminalId } as PaneViewerData,
-			});
-			state.setPaneTitleOverride({
-				tabId: existingLocation.tabId,
-				paneId: existingLocation.paneId,
-				titleOverride: context.pane.titleOverride,
-			});
+		if (!findTerminalPaneLocation(context, terminalId)) {
+			markTerminalForBackground(terminalId);
 		}
 
 		state.setPaneData({
@@ -244,9 +236,14 @@ export function TerminalSessionDropdown({
 								context,
 								session.terminalId,
 							);
-							const canSelect =
-								isCurrent || !session.attached || location !== null;
 							const createdAtLabel = formatCreatedAt(session.createdAt);
+							const status = isCurrent
+								? "Current"
+								: session.pending
+									? "Starting"
+									: session.attached
+										? "Attached"
+										: "Detached";
 							const title = isCurrent
 								? triggerTitle
 								: (location?.titleOverride ?? "Terminal");
@@ -254,12 +251,8 @@ export function TerminalSessionDropdown({
 							return (
 								<DropdownMenuItem
 									key={session.terminalId}
-									className={`group flex items-center gap-2 ${!canSelect ? "text-muted-foreground/50" : ""}`}
-									onSelect={(event) => {
-										if (!canSelect) {
-											event.preventDefault();
-											return;
-										}
+									className="group flex items-center gap-2"
+									onSelect={(_event) => {
 										handleSelectSession(session.terminalId);
 									}}
 								>
@@ -271,6 +264,9 @@ export function TerminalSessionDropdown({
 									</span>
 									<span className="shrink-0 text-[10px] text-muted-foreground/70">
 										{createdAtLabel}
+									</span>
+									<span className="shrink-0 text-xs text-muted-foreground">
+										{status}
 									</span>
 									<button
 										type="button"

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
@@ -1,0 +1,240 @@
+import type { RendererContext } from "@superset/panes";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import { workspaceTrpc } from "@superset/workspace-client";
+import {
+	Check,
+	ChevronDown,
+	LoaderCircle,
+	Plus,
+	TerminalSquare,
+} from "lucide-react";
+import { useMemo, useState } from "react";
+import type {
+	PaneViewerData,
+	TerminalPaneData,
+} from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
+
+interface TerminalSessionDropdownProps {
+	context: RendererContext<PaneViewerData>;
+	workspaceId: string;
+}
+
+interface VisibleTerminalSession {
+	terminalId: string;
+	workspaceId: string;
+	exited: boolean;
+	exitCode: number;
+	attached: boolean;
+	pending?: boolean;
+}
+
+interface TerminalPaneLocation {
+	tabId: string;
+	paneId: string;
+	titleOverride?: string;
+}
+
+function getShortTerminalId(terminalId: string): string {
+	return terminalId.length <= 8 ? terminalId : terminalId.slice(0, 8);
+}
+
+function findTerminalPaneLocation(
+	context: RendererContext<PaneViewerData>,
+	terminalId: string,
+): TerminalPaneLocation | null {
+	for (const tab of context.store.getState().tabs) {
+		for (const pane of Object.values(tab.panes)) {
+			if (pane.id === context.pane.id || pane.kind !== "terminal") continue;
+			const data = pane.data as Partial<TerminalPaneData>;
+			if (data.terminalId === terminalId) {
+				return {
+					tabId: tab.id,
+					paneId: pane.id,
+					titleOverride: pane.titleOverride,
+				};
+			}
+		}
+	}
+	return null;
+}
+
+export function TerminalSessionDropdown({
+	context,
+	workspaceId,
+}: TerminalSessionDropdownProps) {
+	const [isOpen, setIsOpen] = useState(false);
+	const data = context.pane.data as TerminalPaneData;
+	const { terminalId } = data;
+	const utils = workspaceTrpc.useUtils();
+	const sessionsQuery = workspaceTrpc.terminal.listSessions.useQuery(
+		{ workspaceId },
+		{
+			enabled: isOpen,
+			refetchInterval: isOpen ? 2_000 : false,
+			refetchOnWindowFocus: true,
+		},
+	);
+
+	const sessions = useMemo<VisibleTerminalSession[]>(() => {
+		const liveSessions = sessionsQuery.data?.sessions ?? [];
+		if (liveSessions.some((session) => session.terminalId === terminalId)) {
+			return liveSessions;
+		}
+		return [
+			{
+				terminalId,
+				workspaceId,
+				exited: false,
+				exitCode: 0,
+				attached: false,
+				pending: true,
+			},
+			...liveSessions,
+		];
+	}, [sessionsQuery.data?.sessions, terminalId, workspaceId]);
+
+	const handleSelectSession = (nextTerminalId: string) => {
+		if (nextTerminalId === terminalId) {
+			setIsOpen(false);
+			return;
+		}
+
+		const state = context.store.getState();
+		const existingLocation = findTerminalPaneLocation(context, nextTerminalId);
+		if (existingLocation) {
+			state.setPaneData({
+				paneId: existingLocation.paneId,
+				data: { terminalId } as PaneViewerData,
+			});
+			state.setPaneTitleOverride({
+				tabId: existingLocation.tabId,
+				paneId: existingLocation.paneId,
+				titleOverride: context.pane.titleOverride,
+			});
+		}
+
+		state.setPaneData({
+			paneId: context.pane.id,
+			data: { terminalId: nextTerminalId } as PaneViewerData,
+		});
+		state.setPaneTitleOverride({
+			tabId: context.tab.id,
+			paneId: context.pane.id,
+			titleOverride: existingLocation?.titleOverride,
+		});
+		setIsOpen(false);
+	};
+
+	const handleNewTerminal = () => {
+		const state = context.store.getState();
+		state.setPaneData({
+			paneId: context.pane.id,
+			data: {
+				terminalId: crypto.randomUUID(),
+			} as PaneViewerData,
+		});
+		state.setPaneTitleOverride({
+			tabId: context.tab.id,
+			paneId: context.pane.id,
+			titleOverride: undefined,
+		});
+		void utils.terminal.listSessions.invalidate({ workspaceId });
+		setIsOpen(false);
+	};
+
+	const triggerTitle = context.pane.titleOverride ?? "Terminal";
+
+	return (
+		<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+			<DropdownMenuTrigger asChild>
+				<button
+					type="button"
+					aria-label="Terminal sessions"
+					className="flex min-w-0 max-w-72 items-center gap-1.5 rounded px-1.5 py-0.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+					onMouseDown={(event) => event.stopPropagation()}
+					onClick={(event) => event.stopPropagation()}
+				>
+					<TerminalSquare className="size-4 shrink-0" />
+					<span className="min-w-0 truncate">{triggerTitle}</span>
+					<span className="shrink-0 font-mono text-[10px] text-muted-foreground/70">
+						{getShortTerminalId(terminalId)}
+					</span>
+					{sessionsQuery.isFetching && isOpen ? (
+						<LoaderCircle className="size-3 shrink-0 animate-spin" />
+					) : (
+						<ChevronDown className="size-3 shrink-0" />
+					)}
+				</button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="start" className="w-80">
+				<DropdownMenuLabel className="text-xs">
+					Terminal Sessions
+				</DropdownMenuLabel>
+				<DropdownMenuSeparator />
+				<div className="max-h-80 overflow-y-auto">
+					{sessions.length > 0 ? (
+						sessions.map((session) => {
+							const isCurrent = session.terminalId === terminalId;
+							const location = findTerminalPaneLocation(
+								context,
+								session.terminalId,
+							);
+							const canSelect =
+								isCurrent || !session.attached || location !== null;
+							const status = isCurrent
+								? "Current"
+								: location
+									? "Swap"
+									: session.pending
+										? "Starting"
+										: session.attached
+											? "Attached"
+											: "Detached";
+							const title = isCurrent
+								? triggerTitle
+								: (location?.titleOverride ?? "Terminal");
+
+							return (
+								<DropdownMenuItem
+									key={session.terminalId}
+									disabled={!canSelect}
+									className="flex items-center gap-2"
+									onSelect={() => handleSelectSession(session.terminalId)}
+								>
+									<span className="w-4 shrink-0">
+										{isCurrent && <Check className="size-3.5" />}
+									</span>
+									<span className="min-w-0 flex-1 truncate text-xs">
+										{title}
+									</span>
+									<span className="shrink-0 font-mono text-[10px] text-muted-foreground/70">
+										{getShortTerminalId(session.terminalId)}
+									</span>
+									<span className="shrink-0 text-xs text-muted-foreground">
+										{status}
+									</span>
+								</DropdownMenuItem>
+							);
+						})
+					) : (
+						<div className="px-2 py-1.5 text-xs text-muted-foreground">
+							No live sessions
+						</div>
+					)}
+				</div>
+				<DropdownMenuSeparator />
+				<DropdownMenuItem onSelect={handleNewTerminal}>
+					<Plus className="mr-1.5 size-3.5" />
+					<span className="text-xs">New Terminal</span>
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
@@ -109,7 +109,7 @@ export function TerminalSessionDropdown({
 			...liveSessions,
 		];
 	}, [sessionsQuery.data?.sessions, terminalId, workspaceId]);
-	const terminalPaneLocations = getTerminalPaneLocations(context);
+	const renderTerminalPaneLocations = getTerminalPaneLocations(context);
 
 	const handleSelectSession = (nextTerminalId: string) => {
 		if (nextTerminalId === terminalId) {
@@ -118,6 +118,7 @@ export function TerminalSessionDropdown({
 		}
 
 		const state = context.store.getState();
+		const terminalPaneLocations = getTerminalPaneLocations(context);
 		const existingLocation = terminalPaneLocations.get(nextTerminalId)?.[0];
 		if ((terminalPaneLocations.get(terminalId)?.length ?? 0) === 0) {
 			markTerminalForBackground(terminalId);
@@ -136,6 +137,7 @@ export function TerminalSessionDropdown({
 	};
 
 	const closePanesForTerminal = (targetTerminalId: string) => {
+		const terminalPaneLocations = getTerminalPaneLocations(context);
 		for (const location of terminalPaneLocations.get(targetTerminalId) ?? []) {
 			context.store.getState().closePane({
 				tabId: location.tabId,
@@ -181,6 +183,7 @@ export function TerminalSessionDropdown({
 
 	const handleNewTerminal = () => {
 		const state = context.store.getState();
+		const terminalPaneLocations = getTerminalPaneLocations(context);
 		if ((terminalPaneLocations.get(terminalId)?.length ?? 0) === 0) {
 			markTerminalForBackground(terminalId);
 		}
@@ -236,7 +239,7 @@ export function TerminalSessionDropdown({
 					{sessions.length > 0 ? (
 						sessions.map((session) => {
 							const isCurrent = session.terminalId === terminalId;
-							const location = terminalPaneLocations.get(
+							const location = renderTerminalPaneLocations.get(
 								session.terminalId,
 							)?.[0];
 							const createdAtLabel = formatCreatedAt(session.createdAt);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/index.ts
@@ -1,0 +1,1 @@
+export { TerminalSessionDropdown } from "./TerminalSessionDropdown";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -4,8 +4,10 @@ import type {
 	RendererContext,
 } from "@superset/panes";
 import { alert } from "@superset/ui/atoms/Alert";
+import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
+import { workspaceTrpc } from "@superset/workspace-client";
 import {
 	Circle,
 	GitCompareArrows,
@@ -22,6 +24,7 @@ import {
 	LuClipboard,
 	LuClipboardCopy,
 	LuEraser,
+	LuPower,
 } from "react-icons/lu";
 import { TbScan } from "react-icons/tb";
 import { useHotkeyDisplay } from "renderer/hotkeys";
@@ -145,6 +148,16 @@ export function usePaneRegistry(
 ): PaneRegistry<PaneViewerData> {
 	const clearShortcut = useHotkeyDisplay("CLEAR_TERMINAL").text;
 	const scrollToBottomShortcut = useHotkeyDisplay("SCROLL_TO_BOTTOM").text;
+	const killTerminalSession = workspaceTrpc.terminal.killSession.useMutation({
+		onSuccess: () => {
+			toast.success("Terminal session killed");
+		},
+		onError: (error) => {
+			toast.error("Failed to kill terminal session", {
+				description: error.message,
+			});
+		},
+	});
 
 	return useMemo<PaneRegistry<PaneViewerData>>(
 		() => ({
@@ -306,10 +319,41 @@ export function usePaneRegistry(
 
 					// Update close label
 					const modifiedDefaults = defaults.map((d) =>
-						d.key === "close-pane" ? { ...d, label: "Close Terminal" } : d,
+						d.key === "close-pane" ? { ...d, label: "Close Terminal Pane" } : d,
 					);
 
-					return [...terminalActions, ...modifiedDefaults];
+					const killAction: ContextMenuActionConfig<PaneViewerData> = {
+						key: "kill-terminal-session",
+						label: "Kill Terminal Session",
+						icon: <LuPower />,
+						variant: "destructive",
+						disabled: killTerminalSession.isPending,
+						onSelect: (ctx) => {
+							const { terminalId } = ctx.pane.data as TerminalPaneData;
+							alert({
+								title: "Kill terminal session?",
+								description:
+									"This will terminate the underlying process. Closing the pane only detaches the view.",
+								actions: [
+									{ label: "Cancel", variant: "outline", onClick: () => {} },
+									{
+										label: "Kill Session",
+										variant: "destructive",
+										onClick: () => {
+											killTerminalSession.mutate({ terminalId });
+										},
+									},
+								],
+							});
+						},
+					};
+
+					return [
+						...terminalActions,
+						...modifiedDefaults,
+						{ key: "sep-terminal-kill", type: "separator" },
+						killAction,
+					];
 				},
 			},
 			browser: {
@@ -409,6 +453,7 @@ export function usePaneRegistry(
 			workspaceId,
 			clearShortcut,
 			scrollToBottomShortcut,
+			killTerminalSession,
 			onOpenFile,
 			onRevealPath,
 		],

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -49,6 +49,7 @@ import { DiffPane } from "./components/DiffPane";
 import { FilePane } from "./components/FilePane";
 import { FilePaneHeaderExtras } from "./components/FilePane/components/FilePaneHeaderExtras";
 import { TerminalPane } from "./components/TerminalPane";
+import { TerminalSessionDropdown } from "./components/TerminalPane/components/TerminalSessionDropdown";
 
 function getFileName(filePath: string): string {
 	return filePath.split("/").pop() ?? filePath;
@@ -148,9 +149,11 @@ export function usePaneRegistry(
 ): PaneRegistry<PaneViewerData> {
 	const clearShortcut = useHotkeyDisplay("CLEAR_TERMINAL").text;
 	const scrollToBottomShortcut = useHotkeyDisplay("SCROLL_TO_BOTTOM").text;
+	const workspaceTrpcUtils = workspaceTrpc.useUtils();
 	const killTerminalSession = workspaceTrpc.terminal.killSession.useMutation({
 		onSuccess: () => {
 			toast.success("Terminal session killed");
+			void workspaceTrpcUtils.terminal.listSessions.invalidate({ workspaceId });
 		},
 		onError: (error) => {
 			toast.error("Failed to kill terminal session", {
@@ -249,6 +252,9 @@ export function usePaneRegistry(
 			terminal: {
 				getIcon: () => <TerminalSquare className="size-4" />,
 				getTitle: () => "Terminal",
+				renderTitle: (ctx: RendererContext<PaneViewerData>) => (
+					<TerminalSessionDropdown context={ctx} workspaceId={workspaceId} />
+				),
 				renderPane: (ctx: RendererContext<PaneViewerData>) => (
 					<TerminalPane
 						ctx={ctx}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -49,6 +49,7 @@ import { DiffPane } from "./components/DiffPane";
 import { FilePane } from "./components/FilePane";
 import { FilePaneHeaderExtras } from "./components/FilePane/components/FilePaneHeaderExtras";
 import { TerminalPane } from "./components/TerminalPane";
+import { TerminalHeaderExtras } from "./components/TerminalPane/components/TerminalHeaderExtras";
 import { TerminalSessionDropdown } from "./components/TerminalPane/components/TerminalSessionDropdown";
 
 function getFileName(filePath: string): string {
@@ -255,6 +256,9 @@ export function usePaneRegistry(
 				renderTitle: (ctx: RendererContext<PaneViewerData>) => (
 					<TerminalSessionDropdown context={ctx} workspaceId={workspaceId} />
 				),
+				renderHeaderExtras: (ctx: RendererContext<PaneViewerData>) => (
+					<TerminalHeaderExtras context={ctx} />
+				),
 				renderPane: (ctx: RendererContext<PaneViewerData>) => (
 					<TerminalPane
 						ctx={ctx}
@@ -323,9 +327,8 @@ export function usePaneRegistry(
 						{ key: "sep-terminal-defaults", type: "separator" },
 					];
 
-					// Update close label
 					const modifiedDefaults = defaults.map((d) =>
-						d.key === "close-pane" ? { ...d, label: "Close Terminal Pane" } : d,
+						d.key === "close-pane" ? { ...d, label: "Close Terminal" } : d,
 					);
 
 					const killAction: ContextMenuActionConfig<PaneViewerData> = {
@@ -339,7 +342,7 @@ export function usePaneRegistry(
 							alert({
 								title: "Kill terminal session?",
 								description:
-									"This will terminate the underlying process. Closing the pane only detaches the view.",
+									"This will terminate the underlying process. Move the terminal to background to keep it running without a pane.",
 								actions: [
 									{ label: "Cancel", variant: "outline", onClick: () => {} },
 									{

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -151,17 +151,20 @@ export function usePaneRegistry(
 	const clearShortcut = useHotkeyDisplay("CLEAR_TERMINAL").text;
 	const scrollToBottomShortcut = useHotkeyDisplay("SCROLL_TO_BOTTOM").text;
 	const workspaceTrpcUtils = workspaceTrpc.useUtils();
-	const killTerminalSession = workspaceTrpc.terminal.killSession.useMutation({
-		onSuccess: () => {
-			toast.success("Terminal session killed");
-			void workspaceTrpcUtils.terminal.listSessions.invalidate({ workspaceId });
-		},
-		onError: (error) => {
-			toast.error("Failed to kill terminal session", {
-				description: error.message,
-			});
-		},
-	});
+	const { mutate: killTerminalSession, isPending: isKillingTerminalSession } =
+		workspaceTrpc.terminal.killSession.useMutation({
+			onSuccess: () => {
+				toast.success("Terminal session killed");
+				void workspaceTrpcUtils.terminal.listSessions.invalidate({
+					workspaceId,
+				});
+			},
+			onError: (error) => {
+				toast.error("Failed to kill terminal session", {
+					description: error.message,
+				});
+			},
+		});
 
 	return useMemo<PaneRegistry<PaneViewerData>>(
 		() => ({
@@ -348,7 +351,7 @@ export function usePaneRegistry(
 						label: "Kill Terminal Session",
 						icon: <LuPower />,
 						variant: "destructive",
-						disabled: killTerminalSession.isPending,
+						disabled: isKillingTerminalSession,
 						onSelect: (ctx) => {
 							const { terminalId } = ctx.pane.data as TerminalPaneData;
 							alert({
@@ -361,7 +364,10 @@ export function usePaneRegistry(
 										label: "Kill Session",
 										variant: "destructive",
 										onClick: () => {
-											killTerminalSession.mutate({ terminalId });
+											killTerminalSession({
+												terminalId,
+												workspaceId,
+											});
 										},
 									},
 								],
@@ -475,6 +481,7 @@ export function usePaneRegistry(
 			clearShortcut,
 			scrollToBottomShortcut,
 			killTerminalSession,
+			isKillingTerminalSession,
 			onOpenFile,
 			onRevealPath,
 		],

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -276,11 +276,17 @@ export function usePaneRegistry(
 							shortcut: `${MOD_KEY}C`,
 							disabled: (ctx) => {
 								const { terminalId } = ctx.pane.data as TerminalPaneData;
-								return !terminalRuntimeRegistry.getSelection(terminalId);
+								return !terminalRuntimeRegistry.getSelection(
+									terminalId,
+									ctx.pane.id,
+								);
 							},
 							onSelect: (ctx) => {
 								const { terminalId } = ctx.pane.data as TerminalPaneData;
-								const text = terminalRuntimeRegistry.getSelection(terminalId);
+								const text = terminalRuntimeRegistry.getSelection(
+									terminalId,
+									ctx.pane.id,
+								);
 								if (text) navigator.clipboard.writeText(text);
 							},
 						},
@@ -293,7 +299,13 @@ export function usePaneRegistry(
 								const { terminalId } = ctx.pane.data as TerminalPaneData;
 								try {
 									const text = await navigator.clipboard.readText();
-									if (text) terminalRuntimeRegistry.paste(terminalId, text);
+									if (text) {
+										terminalRuntimeRegistry.paste(
+											terminalId,
+											text,
+											ctx.pane.id,
+										);
+									}
 								} catch {
 									// Clipboard access denied
 								}
@@ -308,7 +320,7 @@ export function usePaneRegistry(
 								clearShortcut !== "Unassigned" ? clearShortcut : undefined,
 							onSelect: (ctx) => {
 								const { terminalId } = ctx.pane.data as TerminalPaneData;
-								terminalRuntimeRegistry.clear(terminalId);
+								terminalRuntimeRegistry.clear(terminalId, ctx.pane.id);
 							},
 						},
 						{
@@ -321,7 +333,7 @@ export function usePaneRegistry(
 									: undefined,
 							onSelect: (ctx) => {
 								const { terminalId } = ctx.pane.data as TerminalPaneData;
-								terminalRuntimeRegistry.scrollToBottom(terminalId);
+								terminalRuntimeRegistry.scrollToBottom(terminalId, ctx.pane.id);
 							},
 						},
 						{ key: "sep-terminal-defaults", type: "separator" },

--- a/apps/desktop/src/renderer/routes/_authenticated/components/GlobalBrowserLifecycle/hooks/useGlobalBrowserLifecycle/useGlobalBrowserLifecycle.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/GlobalBrowserLifecycle/hooks/useGlobalBrowserLifecycle/useGlobalBrowserLifecycle.ts
@@ -3,6 +3,12 @@ import { useLiveQuery } from "@tanstack/react-db";
 import { useEffect, useRef } from "react";
 import { browserRuntimeRegistry } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import {
+	extractPaneLocations,
+	extractWorkspaceIds,
+	getRemovedPaneLocations,
+	type PaneLifecycleRow,
+} from "../../../utils/paneLifecycleRows";
 
 /**
  * Grace period for cross-workspace pane moves / renames before destroying.
@@ -10,20 +16,21 @@ import { useCollections } from "renderer/routes/_authenticated/providers/Collect
  */
 const DESTROY_DELAY_MS = 500;
 
-function extractBrowserPaneIds(rows: { paneLayout: unknown }[]): Set<string> {
-	const ids = new Set<string>();
-	for (const row of rows) {
-		const layout = row.paneLayout as WorkspaceState<unknown> | undefined;
-		if (!layout?.tabs) continue;
-		for (const tab of layout.tabs) {
-			for (const pane of Object.values(tab.panes)) {
-				if (pane.kind === "browser") {
-					ids.add(pane.id);
-				}
-			}
-		}
-	}
-	return ids;
+interface PendingBrowserDestruction {
+	workspaceId: string;
+	timer: ReturnType<typeof setTimeout> | null;
+}
+
+function getBrowserPaneId(
+	pane: WorkspaceState<unknown>["tabs"][number]["panes"][string],
+): string | null {
+	return pane.kind === "browser" ? pane.id : null;
+}
+
+function extractBrowserLocations(
+	rows: PaneLifecycleRow[],
+): Map<string, string> {
+	return extractPaneLocations(rows, getBrowserPaneId);
 }
 
 /**
@@ -40,8 +47,8 @@ function extractBrowserPaneIds(rows: { paneLayout: unknown }[]): Set<string> {
  */
 export function useGlobalBrowserLifecycle() {
 	const collections = useCollections();
-	const prevBrowserIdsRef = useRef<Set<string>>(new Set());
-	const pendingDestruction = useRef<Map<string, ReturnType<typeof setTimeout>>>(
+	const prevBrowserLocationsRef = useRef<Map<string, string>>(new Map());
+	const pendingDestruction = useRef<Map<string, PendingBrowserDestruction>>(
 		new Map(),
 	);
 
@@ -54,47 +61,79 @@ export function useGlobalBrowserLifecycle() {
 	);
 
 	useEffect(() => {
-		const currentBrowserIds = extractBrowserPaneIds(allWorkspaceRows);
-		const prevBrowserIds = prevBrowserIdsRef.current;
+		const rows = allWorkspaceRows as PaneLifecycleRow[];
+		const currentBrowserLocations = extractBrowserLocations(rows);
+		const currentWorkspaceIds = extractWorkspaceIds(rows);
+		const prevBrowserLocations = prevBrowserLocationsRef.current;
 
 		// Cancel any pending destruction for ids that reappeared (e.g. pane
 		// moved between workspaces, user undo, or the transient replaceState
 		// churn we were fighting in the first place).
-		for (const browserId of currentBrowserIds) {
-			const timer = pendingDestruction.current.get(browserId);
-			if (timer) {
-				clearTimeout(timer);
+		for (const browserId of currentBrowserLocations.keys()) {
+			const pending = pendingDestruction.current.get(browserId);
+			if (pending?.timer) {
+				clearTimeout(pending.timer);
+			}
+			pendingDestruction.current.delete(browserId);
+		}
+
+		// If a pane was authoritatively removed but the owner row disappeared
+		// before the grace timer fired, keep waiting until that row is present
+		// again. That avoids destroying webviews during sleep/wake while still
+		// cleaning up when the post-removal layout comes back.
+		for (const [browserId, pending] of pendingDestruction.current) {
+			if (pending.timer) continue;
+			if (currentWorkspaceIds.has(pending.workspaceId)) {
 				pendingDestruction.current.delete(browserId);
+				browserRuntimeRegistry.destroy(browserId);
 			}
 		}
 
-		for (const browserId of prevBrowserIds) {
-			if (currentBrowserIds.has(browserId)) continue;
+		const removedLocations = getRemovedPaneLocations({
+			previousLocations: prevBrowserLocations,
+			currentLocations: currentBrowserLocations,
+			currentWorkspaceIds,
+		});
+
+		for (const { id: browserId, workspaceId } of removedLocations) {
 			if (pendingDestruction.current.has(browserId)) continue;
 
 			const timer = setTimeout(() => {
-				pendingDestruction.current.delete(browserId);
-
 				const freshRows = Array.from(
 					collections.v2WorkspaceLocalState.state.values(),
-				);
-				const freshIds = extractBrowserPaneIds(freshRows);
+				) as PaneLifecycleRow[];
+				const freshLocations = extractBrowserLocations(freshRows);
+				const freshWorkspaceIds = extractWorkspaceIds(freshRows);
 
-				if (!freshIds.has(browserId)) {
+				if (freshLocations.has(browserId)) {
+					pendingDestruction.current.delete(browserId);
+					return;
+				}
+
+				if (freshWorkspaceIds.has(workspaceId)) {
+					pendingDestruction.current.delete(browserId);
 					browserRuntimeRegistry.destroy(browserId);
+					return;
+				}
+
+				const pending = pendingDestruction.current.get(browserId);
+				if (pending) {
+					pending.timer = null;
 				}
 			}, DESTROY_DELAY_MS);
 
-			pendingDestruction.current.set(browserId, timer);
+			pendingDestruction.current.set(browserId, { workspaceId, timer });
 		}
 
-		prevBrowserIdsRef.current = currentBrowserIds;
+		prevBrowserLocationsRef.current = currentBrowserLocations;
 	}, [allWorkspaceRows, collections]);
 
 	useEffect(() => {
 		return () => {
-			for (const timer of pendingDestruction.current.values()) {
-				clearTimeout(timer);
+			for (const pending of pendingDestruction.current.values()) {
+				if (pending.timer) {
+					clearTimeout(pending.timer);
+				}
 			}
 			pendingDestruction.current.clear();
 		};

--- a/apps/desktop/src/renderer/routes/_authenticated/components/GlobalTerminalLifecycle/hooks/useGlobalTerminalLifecycle/useGlobalTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/GlobalTerminalLifecycle/hooks/useGlobalTerminalLifecycle/useGlobalTerminalLifecycle.ts
@@ -27,6 +27,12 @@ interface PendingTerminalCleanup {
 	timer: ReturnType<typeof setTimeout> | null;
 }
 
+interface PendingTerminalInstanceRelease {
+	terminalId: string;
+	workspaceId: string;
+	timer: ReturnType<typeof setTimeout> | null;
+}
+
 function getTerminalId(
 	pane: WorkspaceState<unknown>["tabs"][number]["panes"][string],
 ): string | null {
@@ -36,10 +42,34 @@ function getTerminalId(
 	return typeof data.terminalId === "string" ? data.terminalId : null;
 }
 
+function getTerminalInstanceKey(
+	pane: WorkspaceState<unknown>["tabs"][number]["panes"][string],
+): string | null {
+	const terminalId = getTerminalId(pane);
+	return terminalId ? `${terminalId}\u0000${pane.id}` : null;
+}
+
+function parseTerminalInstanceKey(
+	key: string,
+): { terminalId: string; instanceId: string } | null {
+	const separatorIndex = key.indexOf("\u0000");
+	if (separatorIndex === -1) return null;
+	return {
+		terminalId: key.slice(0, separatorIndex),
+		instanceId: key.slice(separatorIndex + 1),
+	};
+}
+
 function extractTerminalLocations(
 	rows: PaneLifecycleRow[],
 ): Map<string, string> {
 	return extractPaneLocations(rows, getTerminalId);
+}
+
+function extractTerminalInstanceLocations(
+	rows: PaneLifecycleRow[],
+): Map<string, string> {
+	return extractPaneLocations(rows, getTerminalInstanceKey);
 }
 
 function cleanupRemovedTerminal({
@@ -80,9 +110,15 @@ export function useGlobalTerminalLifecycle() {
 	const collections = useCollections();
 	const { machineId, activeHostUrl } = useLocalHostService();
 	const prevTerminalLocationsRef = useRef<Map<string, string>>(new Map());
+	const prevTerminalInstanceLocationsRef = useRef<Map<string, string>>(
+		new Map(),
+	);
 	const pendingCleanups = useRef<Map<string, PendingTerminalCleanup>>(
 		new Map(),
 	);
+	const pendingInstanceReleases = useRef<
+		Map<string, PendingTerminalInstanceRelease>
+	>(new Map());
 
 	const { data: allWorkspaceRows = [] } = useLiveQuery(
 		(query) =>
@@ -130,8 +166,12 @@ export function useGlobalTerminalLifecycle() {
 	useEffect(() => {
 		const rows = allWorkspaceRows as PaneLifecycleRow[];
 		const currentTerminalLocations = extractTerminalLocations(rows);
+		const currentTerminalInstanceLocations =
+			extractTerminalInstanceLocations(rows);
 		const currentWorkspaceIds = extractWorkspaceIds(rows);
 		const prevTerminalLocations = prevTerminalLocationsRef.current;
+		const prevTerminalInstanceLocations =
+			prevTerminalInstanceLocationsRef.current;
 
 		for (const terminalId of currentTerminalLocations.keys()) {
 			const pending = pendingCleanups.current.get(terminalId);
@@ -139,6 +179,14 @@ export function useGlobalTerminalLifecycle() {
 				clearTimeout(pending.timer);
 			}
 			pendingCleanups.current.delete(terminalId);
+		}
+
+		for (const instanceKey of currentTerminalInstanceLocations.keys()) {
+			const pending = pendingInstanceReleases.current.get(instanceKey);
+			if (pending?.timer) {
+				clearTimeout(pending.timer);
+			}
+			pendingInstanceReleases.current.delete(instanceKey);
 		}
 
 		// If a pane was authoritatively removed but the owner row disappeared
@@ -155,6 +203,61 @@ export function useGlobalTerminalLifecycle() {
 					hostUrlByWorkspaceId,
 				});
 			}
+		}
+
+		for (const [instanceKey, pending] of pendingInstanceReleases.current) {
+			if (pending.timer) continue;
+			if (currentWorkspaceIds.has(pending.workspaceId)) {
+				pendingInstanceReleases.current.delete(instanceKey);
+				const parsed = parseTerminalInstanceKey(instanceKey);
+				if (parsed) {
+					terminalRuntimeRegistry.release(parsed.terminalId, parsed.instanceId);
+				}
+			}
+		}
+
+		const removedInstanceLocations = getRemovedPaneLocations({
+			previousLocations: prevTerminalInstanceLocations,
+			currentLocations: currentTerminalInstanceLocations,
+			currentWorkspaceIds,
+		});
+
+		for (const { id: instanceKey, workspaceId } of removedInstanceLocations) {
+			if (pendingInstanceReleases.current.has(instanceKey)) continue;
+
+			const parsed = parseTerminalInstanceKey(instanceKey);
+			if (!parsed) continue;
+
+			const timer = setTimeout(() => {
+				const freshRows = Array.from(
+					collections.v2WorkspaceLocalState.state.values(),
+				) as PaneLifecycleRow[];
+				const freshInstanceLocations =
+					extractTerminalInstanceLocations(freshRows);
+				const freshWorkspaceIds = extractWorkspaceIds(freshRows);
+
+				if (freshInstanceLocations.has(instanceKey)) {
+					pendingInstanceReleases.current.delete(instanceKey);
+					return;
+				}
+
+				if (freshWorkspaceIds.has(workspaceId)) {
+					pendingInstanceReleases.current.delete(instanceKey);
+					terminalRuntimeRegistry.release(parsed.terminalId, parsed.instanceId);
+					return;
+				}
+
+				const pending = pendingInstanceReleases.current.get(instanceKey);
+				if (pending) {
+					pending.timer = null;
+				}
+			}, RELEASE_DELAY_MS);
+
+			pendingInstanceReleases.current.set(instanceKey, {
+				terminalId: parsed.terminalId,
+				workspaceId,
+				timer,
+			});
 		}
 
 		const removedLocations = getRemovedPaneLocations({
@@ -198,6 +301,7 @@ export function useGlobalTerminalLifecycle() {
 		}
 
 		prevTerminalLocationsRef.current = currentTerminalLocations;
+		prevTerminalInstanceLocationsRef.current = currentTerminalInstanceLocations;
 	}, [allWorkspaceRows, collections, hostUrlByWorkspaceId]);
 
 	useEffect(() => {
@@ -208,6 +312,12 @@ export function useGlobalTerminalLifecycle() {
 				}
 			}
 			pendingCleanups.current.clear();
+			for (const pending of pendingInstanceReleases.current.values()) {
+				if (pending.timer) {
+					clearTimeout(pending.timer);
+				}
+			}
+			pendingInstanceReleases.current.clear();
 		};
 	}, []);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/components/GlobalTerminalLifecycle/hooks/useGlobalTerminalLifecycle/useGlobalTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/GlobalTerminalLifecycle/hooks/useGlobalTerminalLifecycle/useGlobalTerminalLifecycle.ts
@@ -1,8 +1,13 @@
 import type { WorkspaceState } from "@superset/panes";
+import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
+import { env } from "renderer/env.renderer";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { consumeTerminalBackgroundIntent } from "renderer/lib/terminal/terminal-background-intents";
 import { terminalRuntimeRegistry } from "renderer/lib/terminal/terminal-runtime-registry";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import {
 	extractPaneLocations,
 	extractWorkspaceIds,
@@ -10,14 +15,14 @@ import {
 	type PaneLifecycleRow,
 } from "../../../utils/paneLifecycleRows";
 
-/** Grace period for cross-workspace pane moves before releasing renderer state. */
+/** Grace period for cross-workspace pane moves before terminal cleanup. */
 const RELEASE_DELAY_MS = 500;
 
 interface TerminalPaneData {
 	terminalId: string;
 }
 
-interface PendingTerminalRelease {
+interface PendingTerminalCleanup {
 	workspaceId: string;
 	timer: ReturnType<typeof setTimeout> | null;
 }
@@ -37,10 +42,45 @@ function extractTerminalLocations(
 	return extractPaneLocations(rows, getTerminalId);
 }
 
+function cleanupRemovedTerminal({
+	terminalId,
+	workspaceId,
+	hostUrlByWorkspaceId,
+}: {
+	terminalId: string;
+	workspaceId: string;
+	hostUrlByWorkspaceId: Map<string, string>;
+}) {
+	if (consumeTerminalBackgroundIntent(terminalId)) {
+		terminalRuntimeRegistry.release(terminalId);
+		return;
+	}
+
+	terminalRuntimeRegistry.dispose(terminalId);
+	const hostUrl = hostUrlByWorkspaceId.get(workspaceId);
+	if (!hostUrl) {
+		console.warn(
+			"[GlobalTerminalLifecycle] Missing host URL while killing removed terminal",
+			{ terminalId, workspaceId },
+		);
+		return;
+	}
+
+	getHostServiceClientByUrl(hostUrl)
+		.terminal.killSession.mutate({ terminalId })
+		.catch((error) => {
+			console.warn(
+				"[GlobalTerminalLifecycle] Failed to kill removed terminal",
+				{ terminalId, workspaceId, error },
+			);
+		});
+}
+
 export function useGlobalTerminalLifecycle() {
 	const collections = useCollections();
+	const { machineId, activeHostUrl } = useLocalHostService();
 	const prevTerminalLocationsRef = useRef<Map<string, string>>(new Map());
-	const pendingReleases = useRef<Map<string, PendingTerminalRelease>>(
+	const pendingCleanups = useRef<Map<string, PendingTerminalCleanup>>(
 		new Map(),
 	);
 
@@ -52,6 +92,41 @@ export function useGlobalTerminalLifecycle() {
 		[collections],
 	);
 
+	const { data: workspacesWithHosts = [] } = useLiveQuery(
+		(query) =>
+			query
+				.from({ v2Workspaces: collections.v2Workspaces })
+				.leftJoin({ hosts: collections.v2Hosts }, ({ v2Workspaces, hosts }) =>
+					eq(v2Workspaces.hostId, hosts.id),
+				)
+				.select(({ v2Workspaces, hosts }) => ({
+					workspaceId: v2Workspaces.id,
+					hostId: v2Workspaces.hostId,
+					hostMachineId: hosts?.machineId ?? null,
+				})),
+		[collections],
+	);
+
+	const hostUrlByWorkspaceId = useMemo(() => {
+		const urls = new Map<string, string>();
+		for (const workspace of workspacesWithHosts) {
+			if (workspace.hostMachineId === machineId) {
+				if (activeHostUrl) {
+					urls.set(workspace.workspaceId, activeHostUrl);
+				}
+				continue;
+			}
+
+			if (workspace.hostId) {
+				urls.set(
+					workspace.workspaceId,
+					`${env.RELAY_URL}/hosts/${workspace.hostId}`,
+				);
+			}
+		}
+		return urls;
+	}, [activeHostUrl, machineId, workspacesWithHosts]);
+
 	useEffect(() => {
 		const rows = allWorkspaceRows as PaneLifecycleRow[];
 		const currentTerminalLocations = extractTerminalLocations(rows);
@@ -59,22 +134,26 @@ export function useGlobalTerminalLifecycle() {
 		const prevTerminalLocations = prevTerminalLocationsRef.current;
 
 		for (const terminalId of currentTerminalLocations.keys()) {
-			const pending = pendingReleases.current.get(terminalId);
+			const pending = pendingCleanups.current.get(terminalId);
 			if (pending?.timer) {
 				clearTimeout(pending.timer);
 			}
-			pendingReleases.current.delete(terminalId);
+			pendingCleanups.current.delete(terminalId);
 		}
 
 		// If a pane was authoritatively removed but the owner row disappeared
 		// before the grace timer fired, keep waiting until that row is present
 		// again. That avoids releasing active renderer state during sleep/wake
 		// while still cleaning up when the post-removal layout comes back.
-		for (const [terminalId, pending] of pendingReleases.current) {
+		for (const [terminalId, pending] of pendingCleanups.current) {
 			if (pending.timer) continue;
 			if (currentWorkspaceIds.has(pending.workspaceId)) {
-				pendingReleases.current.delete(terminalId);
-				terminalRuntimeRegistry.release(terminalId);
+				pendingCleanups.current.delete(terminalId);
+				cleanupRemovedTerminal({
+					terminalId,
+					workspaceId: pending.workspaceId,
+					hostUrlByWorkspaceId,
+				});
 			}
 		}
 
@@ -85,7 +164,7 @@ export function useGlobalTerminalLifecycle() {
 		});
 
 		for (const { id: terminalId, workspaceId } of removedLocations) {
-			if (pendingReleases.current.has(terminalId)) continue;
+			if (pendingCleanups.current.has(terminalId)) continue;
 
 			const timer = setTimeout(() => {
 				const freshRows = Array.from(
@@ -95,36 +174,40 @@ export function useGlobalTerminalLifecycle() {
 				const freshWorkspaceIds = extractWorkspaceIds(freshRows);
 
 				if (freshLocations.has(terminalId)) {
-					pendingReleases.current.delete(terminalId);
+					pendingCleanups.current.delete(terminalId);
 					return;
 				}
 
 				if (freshWorkspaceIds.has(workspaceId)) {
-					pendingReleases.current.delete(terminalId);
-					terminalRuntimeRegistry.release(terminalId);
+					pendingCleanups.current.delete(terminalId);
+					cleanupRemovedTerminal({
+						terminalId,
+						workspaceId,
+						hostUrlByWorkspaceId,
+					});
 					return;
 				}
 
-				const pending = pendingReleases.current.get(terminalId);
+				const pending = pendingCleanups.current.get(terminalId);
 				if (pending) {
 					pending.timer = null;
 				}
 			}, RELEASE_DELAY_MS);
 
-			pendingReleases.current.set(terminalId, { workspaceId, timer });
+			pendingCleanups.current.set(terminalId, { workspaceId, timer });
 		}
 
 		prevTerminalLocationsRef.current = currentTerminalLocations;
-	}, [allWorkspaceRows, collections]);
+	}, [allWorkspaceRows, collections, hostUrlByWorkspaceId]);
 
 	useEffect(() => {
 		return () => {
-			for (const pending of pendingReleases.current.values()) {
+			for (const pending of pendingCleanups.current.values()) {
 				if (pending.timer) {
 					clearTimeout(pending.timer);
 				}
 			}
-			pendingReleases.current.clear();
+			pendingCleanups.current.clear();
 		};
 	}, []);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/components/GlobalTerminalLifecycle/hooks/useGlobalTerminalLifecycle/useGlobalTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/GlobalTerminalLifecycle/hooks/useGlobalTerminalLifecycle/useGlobalTerminalLifecycle.ts
@@ -3,37 +3,44 @@ import { useLiveQuery } from "@tanstack/react-db";
 import { useEffect, useRef } from "react";
 import { terminalRuntimeRegistry } from "renderer/lib/terminal/terminal-runtime-registry";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import {
+	extractPaneLocations,
+	extractWorkspaceIds,
+	getRemovedPaneLocations,
+	type PaneLifecycleRow,
+} from "../../../utils/paneLifecycleRows";
 
-/** Grace period for cross-workspace pane moves before disposing. */
-const DISPOSE_DELAY_MS = 500;
+/** Grace period for cross-workspace pane moves before releasing renderer state. */
+const RELEASE_DELAY_MS = 500;
 
 interface TerminalPaneData {
 	terminalId: string;
 }
 
-function extractTerminalIds(rows: { paneLayout: unknown }[]): Set<string> {
-	const ids = new Set<string>();
-	for (const row of rows) {
-		const layout = row.paneLayout as WorkspaceState<unknown> | undefined;
-		if (!layout?.tabs) continue;
-		for (const tab of layout.tabs) {
-			for (const pane of Object.values(tab.panes)) {
-				if (pane.kind === "terminal") {
-					const data = pane.data as TerminalPaneData;
-					if (data.terminalId) {
-						ids.add(data.terminalId);
-					}
-				}
-			}
-		}
-	}
-	return ids;
+interface PendingTerminalRelease {
+	workspaceId: string;
+	timer: ReturnType<typeof setTimeout> | null;
+}
+
+function getTerminalId(
+	pane: WorkspaceState<unknown>["tabs"][number]["panes"][string],
+): string | null {
+	if (pane.kind !== "terminal") return null;
+	if (!pane.data || typeof pane.data !== "object") return null;
+	const data = pane.data as Partial<TerminalPaneData>;
+	return typeof data.terminalId === "string" ? data.terminalId : null;
+}
+
+function extractTerminalLocations(
+	rows: PaneLifecycleRow[],
+): Map<string, string> {
+	return extractPaneLocations(rows, getTerminalId);
 }
 
 export function useGlobalTerminalLifecycle() {
 	const collections = useCollections();
-	const prevTerminalIdsRef = useRef<Set<string>>(new Set());
-	const pendingDisposals = useRef<Map<string, ReturnType<typeof setTimeout>>>(
+	const prevTerminalLocationsRef = useRef<Map<string, string>>(new Map());
+	const pendingReleases = useRef<Map<string, PendingTerminalRelease>>(
 		new Map(),
 	);
 
@@ -46,46 +53,78 @@ export function useGlobalTerminalLifecycle() {
 	);
 
 	useEffect(() => {
-		const currentTerminalIds = extractTerminalIds(allWorkspaceRows);
-		const prevTerminalIds = prevTerminalIdsRef.current;
+		const rows = allWorkspaceRows as PaneLifecycleRow[];
+		const currentTerminalLocations = extractTerminalLocations(rows);
+		const currentWorkspaceIds = extractWorkspaceIds(rows);
+		const prevTerminalLocations = prevTerminalLocationsRef.current;
 
-		for (const terminalId of currentTerminalIds) {
-			const timer = pendingDisposals.current.get(terminalId);
-			if (timer) {
-				clearTimeout(timer);
-				pendingDisposals.current.delete(terminalId);
+		for (const terminalId of currentTerminalLocations.keys()) {
+			const pending = pendingReleases.current.get(terminalId);
+			if (pending?.timer) {
+				clearTimeout(pending.timer);
+			}
+			pendingReleases.current.delete(terminalId);
+		}
+
+		// If a pane was authoritatively removed but the owner row disappeared
+		// before the grace timer fired, keep waiting until that row is present
+		// again. That avoids releasing active renderer state during sleep/wake
+		// while still cleaning up when the post-removal layout comes back.
+		for (const [terminalId, pending] of pendingReleases.current) {
+			if (pending.timer) continue;
+			if (currentWorkspaceIds.has(pending.workspaceId)) {
+				pendingReleases.current.delete(terminalId);
+				terminalRuntimeRegistry.release(terminalId);
 			}
 		}
 
-		for (const terminalId of prevTerminalIds) {
-			if (currentTerminalIds.has(terminalId)) continue;
-			if (pendingDisposals.current.has(terminalId)) continue;
+		const removedLocations = getRemovedPaneLocations({
+			previousLocations: prevTerminalLocations,
+			currentLocations: currentTerminalLocations,
+			currentWorkspaceIds,
+		});
+
+		for (const { id: terminalId, workspaceId } of removedLocations) {
+			if (pendingReleases.current.has(terminalId)) continue;
 
 			const timer = setTimeout(() => {
-				pendingDisposals.current.delete(terminalId);
-
 				const freshRows = Array.from(
 					collections.v2WorkspaceLocalState.state.values(),
-				);
-				const freshIds = extractTerminalIds(freshRows);
+				) as PaneLifecycleRow[];
+				const freshLocations = extractTerminalLocations(freshRows);
+				const freshWorkspaceIds = extractWorkspaceIds(freshRows);
 
-				if (!freshIds.has(terminalId)) {
-					terminalRuntimeRegistry.dispose(terminalId);
+				if (freshLocations.has(terminalId)) {
+					pendingReleases.current.delete(terminalId);
+					return;
 				}
-			}, DISPOSE_DELAY_MS);
 
-			pendingDisposals.current.set(terminalId, timer);
+				if (freshWorkspaceIds.has(workspaceId)) {
+					pendingReleases.current.delete(terminalId);
+					terminalRuntimeRegistry.release(terminalId);
+					return;
+				}
+
+				const pending = pendingReleases.current.get(terminalId);
+				if (pending) {
+					pending.timer = null;
+				}
+			}, RELEASE_DELAY_MS);
+
+			pendingReleases.current.set(terminalId, { workspaceId, timer });
 		}
 
-		prevTerminalIdsRef.current = currentTerminalIds;
+		prevTerminalLocationsRef.current = currentTerminalLocations;
 	}, [allWorkspaceRows, collections]);
 
 	useEffect(() => {
 		return () => {
-			for (const timer of pendingDisposals.current.values()) {
-				clearTimeout(timer);
+			for (const pending of pendingReleases.current.values()) {
+				if (pending.timer) {
+					clearTimeout(pending.timer);
+				}
 			}
-			pendingDisposals.current.clear();
+			pendingReleases.current.clear();
 		};
 	}, []);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/components/GlobalTerminalLifecycle/hooks/useGlobalTerminalLifecycle/useGlobalTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/GlobalTerminalLifecycle/hooks/useGlobalTerminalLifecycle/useGlobalTerminalLifecycle.ts
@@ -97,7 +97,7 @@ function cleanupRemovedTerminal({
 	}
 
 	getHostServiceClientByUrl(hostUrl)
-		.terminal.killSession.mutate({ terminalId })
+		.terminal.killSession.mutate({ terminalId, workspaceId })
 		.catch((error) => {
 			console.warn(
 				"[GlobalTerminalLifecycle] Failed to kill removed terminal",
@@ -162,6 +162,8 @@ export function useGlobalTerminalLifecycle() {
 		}
 		return urls;
 	}, [activeHostUrl, machineId, workspacesWithHosts]);
+	const hostUrlByWorkspaceIdRef = useRef(hostUrlByWorkspaceId);
+	hostUrlByWorkspaceIdRef.current = hostUrlByWorkspaceId;
 
 	useEffect(() => {
 		const rows = allWorkspaceRows as PaneLifecycleRow[];
@@ -200,7 +202,7 @@ export function useGlobalTerminalLifecycle() {
 				cleanupRemovedTerminal({
 					terminalId,
 					workspaceId: pending.workspaceId,
-					hostUrlByWorkspaceId,
+					hostUrlByWorkspaceId: hostUrlByWorkspaceIdRef.current,
 				});
 			}
 		}
@@ -286,7 +288,7 @@ export function useGlobalTerminalLifecycle() {
 					cleanupRemovedTerminal({
 						terminalId,
 						workspaceId,
-						hostUrlByWorkspaceId,
+						hostUrlByWorkspaceId: hostUrlByWorkspaceIdRef.current,
 					});
 					return;
 				}
@@ -302,7 +304,7 @@ export function useGlobalTerminalLifecycle() {
 
 		prevTerminalLocationsRef.current = currentTerminalLocations;
 		prevTerminalInstanceLocationsRef.current = currentTerminalInstanceLocations;
-	}, [allWorkspaceRows, collections, hostUrlByWorkspaceId]);
+	}, [allWorkspaceRows, collections]);
 
 	useEffect(() => {
 		return () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/components/utils/paneLifecycleRows/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/utils/paneLifecycleRows/index.ts
@@ -1,0 +1,8 @@
+export {
+	extractPaneIds,
+	extractPaneLocations,
+	extractWorkspaceIds,
+	getRemovedPaneLocations,
+	type PaneLifecycleRow,
+	type RemovedPaneLocation,
+} from "./paneLifecycleRows";

--- a/apps/desktop/src/renderer/routes/_authenticated/components/utils/paneLifecycleRows/paneLifecycleRows.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/utils/paneLifecycleRows/paneLifecycleRows.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import {
+	extractPaneIds,
+	extractPaneLocations,
+	extractWorkspaceIds,
+	getRemovedPaneLocations,
+	type PaneLifecycleRow,
+} from "./paneLifecycleRows";
+
+function row(
+	workspaceId: string,
+	panes: Record<string, unknown>,
+): PaneLifecycleRow {
+	return {
+		workspaceId,
+		paneLayout: {
+			tabs: [
+				{
+					id: `${workspaceId}-tab`,
+					title: "Tab",
+					panes,
+					layout: null,
+					activePaneId: null,
+				},
+			],
+			activeTabId: `${workspaceId}-tab`,
+		},
+	};
+}
+
+function terminalPane(id: string) {
+	return {
+		id: `pane-${id}`,
+		kind: "terminal",
+		data: { terminalId: id },
+	};
+}
+
+function terminalIdForPane(pane: {
+	kind: string;
+	data: unknown;
+}): string | null {
+	if (pane.kind !== "terminal") return null;
+	const data = pane.data as { terminalId?: unknown };
+	return typeof data.terminalId === "string" ? data.terminalId : null;
+}
+
+describe("paneLifecycleRows", () => {
+	test("extracts workspace IDs and tracked pane locations", () => {
+		const rows = [
+			row("workspace-a", {
+				"pane-term-1": terminalPane("term-1"),
+				"pane-file-1": { id: "pane-file-1", kind: "file", data: {} },
+			}),
+			row("workspace-b", {
+				"pane-term-2": terminalPane("term-2"),
+			}),
+		];
+
+		expect([...extractWorkspaceIds(rows)]).toEqual([
+			"workspace-a",
+			"workspace-b",
+		]);
+		expect([
+			...extractPaneLocations(rows, terminalIdForPane).entries(),
+		]).toEqual([
+			["term-1", "workspace-a"],
+			["term-2", "workspace-b"],
+		]);
+		expect([...extractPaneIds(rows, terminalIdForPane)]).toEqual([
+			"term-1",
+			"term-2",
+		]);
+	});
+
+	test("marks a pane removed only when its owner workspace row is present", () => {
+		const previousLocations = new Map([
+			["term-1", "workspace-a"],
+			["term-2", "workspace-b"],
+		]);
+		const currentLocations = new Map([["term-2", "workspace-b"]]);
+		const currentWorkspaceIds = new Set(["workspace-a", "workspace-b"]);
+
+		expect(
+			getRemovedPaneLocations({
+				previousLocations,
+				currentLocations,
+				currentWorkspaceIds,
+			}),
+		).toEqual([{ id: "term-1", workspaceId: "workspace-a" }]);
+	});
+
+	test("ignores panes whose owner workspace row disappeared", () => {
+		const previousLocations = new Map([
+			["term-1", "workspace-a"],
+			["term-2", "workspace-b"],
+		]);
+		const currentLocations = new Map([["term-2", "workspace-b"]]);
+		const currentWorkspaceIds = new Set(["workspace-b"]);
+
+		expect(
+			getRemovedPaneLocations({
+				previousLocations,
+				currentLocations,
+				currentWorkspaceIds,
+			}),
+		).toEqual([]);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/components/utils/paneLifecycleRows/paneLifecycleRows.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/utils/paneLifecycleRows/paneLifecycleRows.ts
@@ -1,0 +1,93 @@
+import type { Pane, WorkspaceState } from "@superset/panes";
+
+export interface PaneLifecycleRow {
+	workspaceId: unknown;
+	paneLayout: unknown;
+}
+
+export interface RemovedPaneLocation {
+	id: string;
+	workspaceId: string;
+}
+
+export function extractWorkspaceIds(rows: PaneLifecycleRow[]): Set<string> {
+	const workspaceIds = new Set<string>();
+	for (const row of rows) {
+		if (typeof row.workspaceId === "string") {
+			workspaceIds.add(row.workspaceId);
+		}
+	}
+	return workspaceIds;
+}
+
+export function extractPaneLocations(
+	rows: PaneLifecycleRow[],
+	getTrackedPaneId: (pane: Pane<unknown>) => string | null,
+): Map<string, string> {
+	const locations = new Map<string, string>();
+
+	for (const row of rows) {
+		if (typeof row.workspaceId !== "string") continue;
+
+		const layout = row.paneLayout as WorkspaceState<unknown> | undefined;
+		if (!layout?.tabs) continue;
+
+		for (const tab of layout.tabs) {
+			for (const pane of Object.values(tab.panes)) {
+				const trackedPaneId = getTrackedPaneId(pane);
+				if (trackedPaneId) {
+					locations.set(trackedPaneId, row.workspaceId);
+				}
+			}
+		}
+	}
+
+	return locations;
+}
+
+export function extractPaneIds(
+	rows: PaneLifecycleRow[],
+	getTrackedPaneId: (pane: Pane<unknown>) => string | null,
+): Set<string> {
+	const ids = new Set<string>();
+
+	for (const row of rows) {
+		const layout = row.paneLayout as WorkspaceState<unknown> | undefined;
+		if (!layout?.tabs) continue;
+
+		for (const tab of layout.tabs) {
+			for (const pane of Object.values(tab.panes)) {
+				const trackedPaneId = getTrackedPaneId(pane);
+				if (trackedPaneId) {
+					ids.add(trackedPaneId);
+				}
+			}
+		}
+	}
+
+	return ids;
+}
+
+export function getRemovedPaneLocations({
+	previousLocations,
+	currentLocations,
+	currentWorkspaceIds,
+}: {
+	previousLocations: Map<string, string>;
+	currentLocations: Map<string, string>;
+	currentWorkspaceIds: Set<string>;
+}): RemovedPaneLocation[] {
+	const removed: RemovedPaneLocation[] = [];
+
+	for (const [id, workspaceId] of previousLocations) {
+		if (currentLocations.has(id)) continue;
+		// A missing owner row means the collection snapshot is not authoritative
+		// for this pane. This happens during org/provider churn and can happen
+		// briefly after laptop sleep/wake. Intentional sidebar-row removals clean
+		// up their pane runtimes before deleting the row.
+		if (!currentWorkspaceIds.has(workspaceId)) continue;
+		removed.push({ id, workspaceId });
+	}
+
+	return removed;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
@@ -1,5 +1,11 @@
-import type { WorkspaceState } from "@superset/panes";
+import type { Pane, WorkspaceState } from "@superset/panes";
 import { useCallback } from "react";
+import { terminalRuntimeRegistry } from "renderer/lib/terminal/terminal-runtime-registry";
+import { browserRuntimeRegistry } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry";
+import {
+	extractPaneIds,
+	type PaneLifecycleRow,
+} from "renderer/routes/_authenticated/components/utils/paneLifecycleRows";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { AppCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider/collections";
 import { PROJECT_CUSTOM_COLORS } from "shared/constants/project-colors";
@@ -78,6 +84,26 @@ function ensureSidebarWorkspaceRecord(
 			activeTabId: null,
 		} satisfies WorkspaceState<unknown>,
 	});
+}
+
+function getTerminalRuntimeId(pane: Pane<unknown>): string | null {
+	if (pane.kind !== "terminal") return null;
+	if (!pane.data || typeof pane.data !== "object") return null;
+	const data = pane.data as { terminalId?: unknown };
+	return typeof data.terminalId === "string" ? data.terminalId : null;
+}
+
+function getBrowserRuntimeId(pane: Pane<unknown>): string | null {
+	return pane.kind === "browser" ? pane.id : null;
+}
+
+function cleanupWorkspacePaneRuntimes(rows: PaneLifecycleRow[]): void {
+	for (const terminalId of extractPaneIds(rows, getTerminalRuntimeId)) {
+		terminalRuntimeRegistry.release(terminalId);
+	}
+	for (const browserId of extractPaneIds(rows, getBrowserRuntimeId)) {
+		browserRuntimeRegistry.destroy(browserId);
+	}
 }
 
 export function useDashboardSidebarState() {
@@ -403,7 +429,9 @@ export function useDashboardSidebarState() {
 
 	const removeWorkspaceFromSidebar = useCallback(
 		(workspaceId: string) => {
-			if (!collections.v2WorkspaceLocalState.get(workspaceId)) return;
+			const workspace = collections.v2WorkspaceLocalState.get(workspaceId);
+			if (!workspace) return;
+			cleanupWorkspacePaneRuntimes([workspace]);
 			collections.v2WorkspaceLocalState.delete(workspaceId);
 		},
 		[collections],
@@ -411,11 +439,10 @@ export function useDashboardSidebarState() {
 
 	const removeProjectFromSidebar = useCallback(
 		(projectId: string) => {
-			const workspaceIds = Array.from(
+			const workspaceRows = Array.from(
 				collections.v2WorkspaceLocalState.state.values(),
-			)
-				.filter((item) => item.sidebarState.projectId === projectId)
-				.map((item) => item.workspaceId);
+			).filter((item) => item.sidebarState.projectId === projectId);
+			const workspaceIds = workspaceRows.map((item) => item.workspaceId);
 			const sectionIds = Array.from(
 				collections.v2SidebarSections.state.values(),
 			)
@@ -423,6 +450,7 @@ export function useDashboardSidebarState() {
 				.map((item) => item.sectionId);
 
 			if (workspaceIds.length > 0) {
+				cleanupWorkspacePaneRuntimes(workspaceRows);
 				collections.v2WorkspaceLocalState.delete(workspaceIds);
 			}
 			if (sectionIds.length > 0) {

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -183,9 +183,9 @@ function AuthenticatedLayout() {
 	return (
 		<DndProvider manager={dragDropManager}>
 			<CollectionsProvider>
-				<GlobalTerminalLifecycle />
 				<GlobalBrowserLifecycle />
 				<LocalHostServiceProvider>
+					<GlobalTerminalLifecycle />
 					<DeletingWorkspacesProvider>
 						<WorkerPoolContextProvider
 							poolOptions={{ workerFactory: createPierreWorker, poolSize: 8 }}

--- a/packages/host-service/src/runtime/teardown/teardown.ts
+++ b/packages/host-service/src/runtime/teardown/teardown.ts
@@ -61,6 +61,7 @@ export async function runTeardown({
 		workspaceId,
 		db,
 		initialCommand,
+		listed: false,
 	});
 	if ("error" in session) {
 		return {

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -43,6 +43,12 @@ type TerminalServerMessage =
 
 const MAX_BUFFER_BYTES = 64 * 1024;
 
+type TerminalSocket = {
+	send: (data: string) => void;
+	close: (code?: number, reason?: string) => void;
+	readyState: number;
+};
+
 // ---------------------------------------------------------------------------
 // OSC 133 shell readiness detection (FinalTerm semantic prompt standard).
 // Scanner logic lives in @superset/shared/shell-ready-scanner.
@@ -68,11 +74,7 @@ interface TerminalSession {
 	terminalId: string;
 	workspaceId: string;
 	pty: IPty;
-	socket: {
-		send: (data: string) => void;
-		close: (code?: number, reason?: string) => void;
-		readyState: number;
-	} | null;
+	sockets: Set<TerminalSocket>;
 	buffer: string[];
 	bufferBytes: number;
 	createdAt: number;
@@ -120,7 +122,7 @@ export function listTerminalSessions(
 			createdAt: session.createdAt,
 			exited: session.exited,
 			exitCode: session.exitCode,
-			attached: session.socket !== null,
+			attached: session.sockets.size > 0,
 		}));
 }
 
@@ -130,6 +132,15 @@ function sendMessage(
 ) {
 	if (socket.readyState !== 1) return;
 	socket.send(JSON.stringify(message));
+}
+
+function broadcastMessage(
+	session: TerminalSession,
+	message: TerminalServerMessage,
+) {
+	for (const socket of session.sockets) {
+		sendMessage(socket, message);
+	}
 }
 
 function bufferOutput(session: TerminalSession, data: string) {
@@ -193,6 +204,10 @@ export function disposeSession(terminalId: string, db: HostDb) {
 			clearTimeout(session.shellReadyTimeoutId);
 			session.shellReadyTimeoutId = null;
 		}
+		for (const socket of session.sockets) {
+			socket.close(1000, "Session disposed");
+		}
+		session.sockets.clear();
 		if (!session.exited) {
 			try {
 				session.pty.kill();
@@ -353,7 +368,7 @@ export function createTerminalSessionInternal({
 		terminalId,
 		workspaceId,
 		pty,
-		socket: null,
+		sockets: new Set(),
 		buffer: [],
 		bufferBytes: 0,
 		createdAt,
@@ -389,8 +404,8 @@ export function createTerminalSessionInternal({
 		}
 		if (data.length === 0) return;
 
-		if (session.socket?.readyState === 1) {
-			sendMessage(session.socket, { type: "data", data });
+		if (session.sockets.size > 0) {
+			broadcastMessage(session, { type: "data", data });
 		} else {
 			bufferOutput(session, data);
 		}
@@ -406,13 +421,11 @@ export function createTerminalSessionInternal({
 			.where(eq(terminalSessions.id, terminalId))
 			.run();
 
-		if (session.socket?.readyState === 1) {
-			sendMessage(session.socket, {
-				type: "exit",
-				exitCode: session.exitCode,
-				signal: session.exitSignal,
-			});
-		}
+		broadcastMessage(session, {
+			type: "exit",
+			exitCode: session.exitCode,
+			signal: session.exitSignal,
+		});
 	});
 
 	if (initialCommand) {
@@ -524,7 +537,7 @@ export function registerWorkspaceTerminalRoute({
 							return;
 						}
 
-						result.socket = ws;
+						result.sockets.add(ws);
 
 						db.update(terminalSessions)
 							.set({ lastAttachedAt: Date.now() })
@@ -533,10 +546,7 @@ export function registerWorkspaceTerminalRoute({
 						return;
 					}
 
-					if (existing.socket && existing.socket !== ws) {
-						existing.socket.close(4000, "Displaced by new connection");
-					}
-					existing.socket = ws;
+					existing.sockets.add(ws);
 
 					db.update(terminalSessions)
 						.set({ lastAttachedAt: Date.now() })
@@ -555,18 +565,16 @@ export function registerWorkspaceTerminalRoute({
 
 				onMessage: (event, ws) => {
 					const session = sessions.get(terminalId ?? "");
-					if (!session || session.socket !== ws) return;
+					if (!session || !session.sockets.has(ws)) return;
 
 					let message: TerminalClientMessage;
 					try {
 						message = JSON.parse(String(event.data)) as TerminalClientMessage;
 					} catch {
-						if (session.socket) {
-							sendMessage(session.socket, {
-								type: "error",
-								message: "Invalid terminal message payload",
-							});
-						}
+						sendMessage(ws, {
+							type: "error",
+							message: "Invalid terminal message payload",
+						});
 						return;
 					}
 
@@ -591,16 +599,12 @@ export function registerWorkspaceTerminalRoute({
 
 				onClose: (_event, ws) => {
 					const session = sessions.get(terminalId ?? "");
-					if (session?.socket === ws) {
-						session.socket = null;
-					}
+					session?.sockets.delete(ws);
 				},
 
 				onError: (_event, ws) => {
 					const session = sessions.get(terminalId ?? "");
-					if (session?.socket === ws) {
-						session.socket = null;
-					}
+					session?.sockets.delete(ws);
 				},
 			};
 		}),

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -75,6 +75,7 @@ interface TerminalSession {
 	} | null;
 	buffer: string[];
 	bufferBytes: number;
+	createdAt: number;
 	exited: boolean;
 	exitCode: number;
 	exitSignal: number;
@@ -94,6 +95,7 @@ const sessions = new Map<string, TerminalSession>();
 export interface TerminalSessionSummary {
 	terminalId: string;
 	workspaceId: string;
+	createdAt: number;
 	exited: boolean;
 	exitCode: number;
 	attached: boolean;
@@ -115,6 +117,7 @@ export function listTerminalSessions(
 		.map((session) => ({
 			terminalId: session.terminalId,
 			workspaceId: session.workspaceId,
+			createdAt: session.createdAt,
 			exited: session.exited,
 			exitCode: session.exitCode,
 			attached: session.socket !== null,
@@ -320,15 +323,18 @@ export function createTerminalSessionInternal({
 		};
 	}
 
+	const createdAt = Date.now();
+
 	db.insert(terminalSessions)
 		.values({
 			id: terminalId,
 			originWorkspaceId: workspaceId,
 			status: "active",
+			createdAt,
 		})
 		.onConflictDoUpdate({
 			target: terminalSessions.id,
-			set: { status: "active", endedAt: null },
+			set: { status: "active", createdAt, endedAt: null },
 		})
 		.run();
 
@@ -350,6 +356,7 @@ export function createTerminalSessionInternal({
 		socket: null,
 		buffer: [],
 		bufferBytes: 0,
+		createdAt,
 		exited: false,
 		exitCode: 0,
 		exitSignal: 0,

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -42,6 +42,9 @@ type TerminalServerMessage =
 	| { type: "replay"; data: string };
 
 const MAX_BUFFER_BYTES = 64 * 1024;
+const SOCKET_OPEN = 1;
+const SOCKET_CLOSING = 2;
+const SOCKET_CLOSED = 3;
 
 type TerminalSocket = {
 	send: (data: string) => void;
@@ -94,6 +97,21 @@ interface TerminalSession {
 /** PTY lifetime is independent of socket lifetime — sockets detach/reattach freely. */
 const sessions = new Map<string, TerminalSession>();
 
+function pruneAndCountOpenSockets(session: TerminalSession): number {
+	let openSockets = 0;
+	for (const socket of session.sockets) {
+		if (socket.readyState === SOCKET_OPEN) {
+			openSockets += 1;
+		} else if (
+			socket.readyState === SOCKET_CLOSING ||
+			socket.readyState === SOCKET_CLOSED
+		) {
+			session.sockets.delete(socket);
+		}
+	}
+	return openSockets;
+}
+
 export interface TerminalSessionSummary {
 	terminalId: string;
 	workspaceId: string;
@@ -122,7 +140,7 @@ export function listTerminalSessions(
 			createdAt: session.createdAt,
 			exited: session.exited,
 			exitCode: session.exitCode,
-			attached: session.sockets.size > 0,
+			attached: pruneAndCountOpenSockets(session) > 0,
 		}));
 }
 
@@ -130,17 +148,29 @@ function sendMessage(
 	socket: { send: (data: string) => void; readyState: number },
 	message: TerminalServerMessage,
 ) {
-	if (socket.readyState !== 1) return;
+	if (socket.readyState !== SOCKET_OPEN) return;
 	socket.send(JSON.stringify(message));
 }
 
 function broadcastMessage(
 	session: TerminalSession,
 	message: TerminalServerMessage,
-) {
+): number {
+	let sent = 0;
 	for (const socket of session.sockets) {
+		if (socket.readyState !== SOCKET_OPEN) {
+			if (
+				socket.readyState === SOCKET_CLOSING ||
+				socket.readyState === SOCKET_CLOSED
+			) {
+				session.sockets.delete(socket);
+			}
+			continue;
+		}
 		sendMessage(socket, message);
+		sent += 1;
 	}
+	return sent;
 }
 
 function bufferOutput(session: TerminalSession, data: string) {
@@ -404,9 +434,7 @@ export function createTerminalSessionInternal({
 		}
 		if (data.length === 0) return;
 
-		if (session.sockets.size > 0) {
-			broadcastMessage(session, { type: "data", data });
-		} else {
+		if (broadcastMessage(session, { type: "data", data }) === 0) {
 			bufferOutput(session, data);
 		}
 	});

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -66,6 +66,7 @@ type ShellReadyState = "pending" | "ready" | "timed_out" | "unsupported";
 
 interface TerminalSession {
 	terminalId: string;
+	workspaceId: string;
 	pty: IPty;
 	socket: {
 		send: (data: string) => void;
@@ -77,6 +78,7 @@ interface TerminalSession {
 	exited: boolean;
 	exitCode: number;
 	exitSignal: number;
+	listed: boolean;
 
 	// Shell readiness (OSC 133)
 	shellReadyState: ShellReadyState;
@@ -88,6 +90,36 @@ interface TerminalSession {
 
 /** PTY lifetime is independent of socket lifetime — sockets detach/reattach freely. */
 const sessions = new Map<string, TerminalSession>();
+
+export interface TerminalSessionSummary {
+	terminalId: string;
+	workspaceId: string;
+	exited: boolean;
+	exitCode: number;
+	attached: boolean;
+}
+
+export function listTerminalSessions(
+	options: { workspaceId?: string; includeExited?: boolean } = {},
+): TerminalSessionSummary[] {
+	const includeExited = options.includeExited ?? true;
+
+	return Array.from(sessions.values())
+		.filter((session) => session.listed)
+		.filter(
+			(session) =>
+				options.workspaceId === undefined ||
+				session.workspaceId === options.workspaceId,
+		)
+		.filter((session) => includeExited || !session.exited)
+		.map((session) => ({
+			terminalId: session.terminalId,
+			workspaceId: session.workspaceId,
+			exited: session.exited,
+			exitCode: session.exitCode,
+			attached: session.socket !== null,
+		}));
+}
 
 function sendMessage(
 	socket: { send: (data: string) => void; readyState: number },
@@ -213,6 +245,8 @@ interface CreateTerminalSessionOptions {
 	db: HostDb;
 	/** Command to run after the shell is ready. Queued behind shellReadyPromise. */
 	initialCommand?: string;
+	/** Hidden sessions are process-internal and should not appear in user pickers. */
+	listed?: boolean;
 }
 
 export function createTerminalSessionInternal({
@@ -221,9 +255,11 @@ export function createTerminalSessionInternal({
 	themeType,
 	db,
 	initialCommand,
+	listed = true,
 }: CreateTerminalSessionOptions): TerminalSession | { error: string } {
 	const existing = sessions.get(terminalId);
 	if (existing) {
+		if (listed) existing.listed = true;
 		return existing;
 	}
 
@@ -309,6 +345,7 @@ export function createTerminalSessionInternal({
 
 	const session: TerminalSession = {
 		terminalId,
+		workspaceId,
 		pty,
 		socket: null,
 		buffer: [],
@@ -316,6 +353,7 @@ export function createTerminalSessionInternal({
 		exited: false,
 		exitCode: 0,
 		exitSignal: 0,
+		listed,
 		shellReadyState: shellSupportsReady ? "pending" : "unsupported",
 		shellReadyResolve,
 		shellReadyPromise,
@@ -432,13 +470,10 @@ export function registerWorkspaceTerminalRoute({
 
 	// REST list — enumerate live terminal sessions
 	app.get("/terminal/sessions", (c) => {
-		const result = Array.from(sessions.values()).map((s) => ({
-			terminalId: s.terminalId,
-			exited: s.exited,
-			exitCode: s.exitCode,
-			attached: s.socket !== null,
-		}));
-		return c.json({ sessions: result });
+		const workspaceId = c.req.query("workspaceId") || undefined;
+		return c.json({
+			sessions: listTerminalSessions({ workspaceId, includeExited: true }),
+		});
 	});
 
 	app.get(

--- a/packages/host-service/src/trpc/router/terminal/terminal.ts
+++ b/packages/host-service/src/trpc/router/terminal/terminal.ts
@@ -1,4 +1,7 @@
+import { TRPCError } from "@trpc/server";
+import { eq } from "drizzle-orm";
 import { z } from "zod";
+import { terminalSessions, workspaces } from "../../../db/schema";
 import {
 	createTerminalSessionInternal,
 	disposeSession,
@@ -54,9 +57,39 @@ export const terminalRouter = router({
 		.input(
 			z.object({
 				terminalId: z.string(),
+				workspaceId: z.string(),
 			}),
 		)
 		.mutation(({ ctx, input }) => {
+			const workspace = ctx.db.query.workspaces
+				.findFirst({ where: eq(workspaces.id, input.workspaceId) })
+				.sync();
+
+			if (!workspace) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Workspace not found",
+				});
+			}
+
+			const session = ctx.db.query.terminalSessions
+				.findFirst({ where: eq(terminalSessions.id, input.terminalId) })
+				.sync();
+
+			if (!session) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Terminal session not found",
+				});
+			}
+
+			if (session.originWorkspaceId !== input.workspaceId) {
+				throw new TRPCError({
+					code: "FORBIDDEN",
+					message: "Terminal session does not belong to this workspace",
+				});
+			}
+
 			disposeSession(input.terminalId, ctx.db);
 			return { terminalId: input.terminalId, status: "disposed" as const };
 		}),

--- a/packages/host-service/src/trpc/router/terminal/terminal.ts
+++ b/packages/host-service/src/trpc/router/terminal/terminal.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import {
 	createTerminalSessionInternal,
+	disposeSession,
 	parseThemeType,
 } from "../../../terminal/terminal";
 import { protectedProcedure, router } from "../../index";
@@ -33,5 +34,16 @@ export const terminalRouter = router({
 			}
 
 			return { terminalId: result.terminalId, status: "active" as const };
+		}),
+
+	killSession: protectedProcedure
+		.input(
+			z.object({
+				terminalId: z.string(),
+			}),
+		)
+		.mutation(({ ctx, input }) => {
+			disposeSession(input.terminalId, ctx.db);
+			return { terminalId: input.terminalId, status: "disposed" as const };
 		}),
 });

--- a/packages/host-service/src/trpc/router/terminal/terminal.ts
+++ b/packages/host-service/src/trpc/router/terminal/terminal.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import {
 	createTerminalSessionInternal,
 	disposeSession,
+	listTerminalSessions,
 	parseThemeType,
 } from "../../../terminal/terminal";
 import { protectedProcedure, router } from "../../index";
@@ -35,6 +36,19 @@ export const terminalRouter = router({
 
 			return { terminalId: result.terminalId, status: "active" as const };
 		}),
+
+	listSessions: protectedProcedure
+		.input(
+			z.object({
+				workspaceId: z.string(),
+			}),
+		)
+		.query(({ input }) => ({
+			sessions: listTerminalSessions({
+				workspaceId: input.workspaceId,
+				includeExited: false,
+			}),
+		})),
 
 	killSession: protectedProcedure
 		.input(


### PR DESCRIPTION
## Summary
- guard global terminal/browser cleanup against transient missing workspace-local rows during sleep/wake or provider churn
- preserve already-authoritative pane removals across owner-row churn so terminal cleanup is not forgotten and sleep/wake churn still does not kill live PTYs
- make terminal pane removal destructive again: once a pane is authoritatively removed, the renderer disposes its runtime and host-service kills the PTY
- add a terminal top-bar "Move terminal to background" action that marks the next pane removal as a non-destructive detach/release
- add a v2 terminal pane dropdown for live session switching, starting a new terminal from the same pane, and removing terminal sessions explicitly
- allow multiple panes to connect to the same live terminal session instead of swapping pane assignments
- show terminal session age using the existing relative-time helper instead of exposing the terminal id hash, while keeping session states like Current/Attached/Detached
- make New Terminal detach the current terminal into the background before switching the pane to a new terminal
- add an explicit destructive terminal pane action to kill the underlying terminal session
- keep browser runtime cleanup on pane/sidebar removal, since browser panes are renderer-owned

## Validation
- bun test apps/desktop/src/renderer/routes/_authenticated/components/utils/paneLifecycleRows/paneLifecycleRows.test.ts
- bun run --cwd apps/desktop typecheck
- bun run --cwd packages/host-service typecheck
- bunx biome check --write --unsafe apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts apps/desktop/src/renderer/routes/_authenticated/components/GlobalTerminalLifecycle/hooks/useGlobalTerminalLifecycle/useGlobalTerminalLifecycle.ts packages/host-service/src/terminal/terminal.ts `apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx` `apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx` `apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx`
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser and terminal lifecycle to avoid accidental teardown during sleep/wake or cross-workspace moves; pending disposals now respect workspace presence and grace timers.
  * More reliable cleanup when removing workspaces or projects and when sessions are removed; host-side session kill is invoked when appropriate.

* **New Features**
  * Terminal session dropdown for switching/creating sessions, a "Kill Terminal Session" action with confirmation, and a "Move terminal to background" header action.

* **Tests**
  * Added tests validating pane/terminal tracking and removal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->