### PR TITLE
feat(desktop): port v1 workspace-creation loader to v2 pending page

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/mapProgressToInitStep.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/mapProgressToInitStep.ts
@@ -11,15 +11,13 @@ export interface HostServiceProgressStep {
  * `WorkspaceInitStep` enum so we can reuse the v1 KeypadLoader + StepProgress
  * components on the v2 pending page.
  *
- * Host-service emits five steps that line up 1:1 with the v1 keypad's five
- * keys. `fetching_remote` only fires when the start point is a remote-tracking
- * ref — for fully-local base branches, that key passes through pressed
- * without an active beat.
+ * Host-service emits five steps, but v2's meaningful user-facing work is in
+ * the latter three: worktree creation, registration, and finalizing/opening.
+ * Keep the first two keypad beats as quick preflight/fetch lead-ins, then map
+ * those latter three states onto the final three keypad keys.
  *
- * `finalizing` active maps to `ready` (all keys pressed) so the final key
- * visibly presses down before the pending row flips to `succeeded` and
- * navigates away; finalizing is fast (local sqlite insert + optional setup-
- * terminal spawn) and the brief pressed frame is what reads as "done".
+ * Navigation does not wait for this display mapping; it is purely
+ * presentational.
  */
 export function mapProgressToInitStep(
 	steps: HostServiceProgressStep[] | undefined,
@@ -40,7 +38,7 @@ export function mapProgressToInitStep(
 			case "registering":
 				return "copying_config";
 			case "finalizing":
-				return "ready";
+				return "finalizing";
 		}
 	}
 
@@ -51,7 +49,7 @@ export function mapProgressToInitStep(
 	if (lastDoneIdx === -1) return "pending";
 	const lastDoneId = steps[lastDoneIdx].id;
 	if (lastDoneId === "ensuring_repo") return "verifying";
-	if (lastDoneId === "fetching_remote") return "fetching";
+	if (lastDoneId === "fetching_remote") return "creating_worktree";
 	if (lastDoneId === "creating_worktree") return "copying_config";
 	if (lastDoneId === "registering") return "finalizing";
 	if (lastDoneId === "finalizing") return "ready";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/mapProgressToInitStep.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/mapProgressToInitStep.ts
@@ -1,0 +1,59 @@
+import type { WorkspaceInitStep } from "shared/types/workspace-init";
+
+export interface HostServiceProgressStep {
+	id: string;
+	label: string;
+	status: "pending" | "active" | "done";
+}
+
+/**
+ * Maps the v2 host-service `workspaceCreation.getProgress` step list onto v1's
+ * `WorkspaceInitStep` enum so we can reuse the v1 KeypadLoader + StepProgress
+ * components on the v2 pending page.
+ *
+ * Host-service emits five steps that line up 1:1 with the v1 keypad's five
+ * keys. `fetching_remote` only fires when the start point is a remote-tracking
+ * ref — for fully-local base branches, that key passes through pressed
+ * without an active beat.
+ *
+ * `finalizing` active maps to `ready` (all keys pressed) so the final key
+ * visibly presses down before the pending row flips to `succeeded` and
+ * navigates away; finalizing is fast (local sqlite insert + optional setup-
+ * terminal spawn) and the brief pressed frame is what reads as "done".
+ */
+export function mapProgressToInitStep(
+	steps: HostServiceProgressStep[] | undefined,
+): WorkspaceInitStep {
+	if (!steps || steps.length === 0) return "pending";
+
+	if (steps.every((s) => s.status === "done")) return "ready";
+
+	const active = steps.find((s) => s.status === "active");
+	if (active) {
+		switch (active.id) {
+			case "ensuring_repo":
+				return "syncing";
+			case "fetching_remote":
+				return "fetching";
+			case "creating_worktree":
+				return "creating_worktree";
+			case "registering":
+				return "copying_config";
+			case "finalizing":
+				return "ready";
+		}
+	}
+
+	let lastDoneIdx = -1;
+	for (let i = 0; i < steps.length; i++) {
+		if (steps[i].status === "done") lastDoneIdx = i;
+	}
+	if (lastDoneIdx === -1) return "pending";
+	const lastDoneId = steps[lastDoneIdx].id;
+	if (lastDoneId === "ensuring_repo") return "verifying";
+	if (lastDoneId === "fetching_remote") return "fetching";
+	if (lastDoneId === "creating_worktree") return "copying_config";
+	if (lastDoneId === "registering") return "finalizing";
+	if (lastDoneId === "finalizing") return "ready";
+	return "pending";
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/page.tsx
@@ -5,7 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { GoGitBranch } from "react-icons/go";
-import { HiCheck, HiExclamationTriangle } from "react-icons/hi2";
+import { HiExclamationTriangle } from "react-icons/hi2";
 import { env } from "renderer/env.renderer";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { formatRelativeTime } from "renderer/lib/formatRelativeTime";
@@ -21,6 +21,9 @@ import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/u
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { PendingWorkspaceRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import { KeypadLoader } from "renderer/screens/main/components/WorkspaceView/WorkspaceInitializingView/KeypadLoader";
+import { StepProgress } from "renderer/screens/main/components/WorkspaceView/WorkspaceInitializingView/StepProgress";
+import type { WorkspaceInitStep } from "shared/types/workspace-init";
 import type { ResolvedPrContent } from "./buildForkAgentLaunch";
 import {
 	buildAdoptPayload,
@@ -30,6 +33,8 @@ import {
 } from "./buildIntentPayload";
 import { buildSetupPaneLayout } from "./buildSetupPaneLayout";
 import { dispatchForkLaunch } from "./dispatchForkLaunch";
+import { mapProgressToInitStep } from "./mapProgressToInitStep";
+import { useAnimatedInitStep } from "./useAnimatedInitStep";
 
 /**
  * Pending workspace progress page.
@@ -263,10 +268,12 @@ function PendingWorkspacePage() {
 		void fireIntent();
 	}, [pending, fireIntent]);
 
-	// Poll host-service for step-by-step progress (fork + checkout only;
+	// Poll host-service for step-by-step progress (create + checkout flows;
 	// adopt is fast and doesn't instrument progress).
 	const intentHasProgress =
-		pending?.intent === "fork" || pending?.intent === "checkout";
+		pending?.intent === "fork" ||
+		pending?.intent === "checkout" ||
+		pending?.intent === "pr-checkout";
 	const hostUrl = !pending
 		? activeHostUrl
 		: pending.hostTarget.kind === "local"
@@ -282,11 +289,35 @@ function PendingWorkspacePage() {
 				pendingId,
 			});
 		},
-		refetchInterval: 500,
+		// Poll tight enough to catch fast transitions between
+		// host-service steps — `getProgress` is a single in-memory Map read.
+		refetchInterval: 200,
 		enabled: pending?.status === "creating" && !!hostUrl && intentHasProgress,
 	});
 
 	const steps = progress?.steps ?? [];
+	const rawInitStep = mapProgressToInitStep(steps);
+	// Force the walker toward "ready" once the mutation itself resolves —
+	// the host-service's in-memory progress is cleared at the end, so
+	// `rawInitStep` drops back to "pending" right as we'd otherwise want to
+	// see the final keypad state. Pinning to "ready" lets the walker finish.
+	const walkerTarget: WorkspaceInitStep =
+		pending?.status === "succeeded"
+			? "ready"
+			: pending?.status === "failed"
+				? "failed"
+				: rawInitStep;
+	const displayedInitStep = useAnimatedInitStep(walkerTarget, pendingId);
+	const walkerCaughtUp =
+		displayedInitStep === "ready" || displayedInitStep === "failed";
+
+	// Honor the user's notification-mute preference + volume for the keypad
+	// click sound. Default to muted while the query loads so we never play a
+	// click for a user who has it disabled before the setting resolves.
+	const { data: notificationSoundsMuted = true } =
+		electronTrpc.settings.getNotificationSoundsMuted.useQuery();
+	const { data: notificationVolume = 100 } =
+		electronTrpc.settings.getNotificationVolume.useQuery();
 
 	const STALE_THRESHOLD_MS = 2 * 60 * 1000;
 	const [now, setNow] = useState(Date.now());
@@ -348,11 +379,18 @@ function PendingWorkspacePage() {
 		if (
 			pending?.status === "succeeded" &&
 			pending.workspaceId &&
-			workspaceSynced
+			workspaceSynced &&
+			walkerCaughtUp
 		) {
 			doNavigate();
 		}
-	}, [pending?.status, pending?.workspaceId, workspaceSynced, doNavigate]);
+	}, [
+		pending?.status,
+		pending?.workspaceId,
+		workspaceSynced,
+		walkerCaughtUp,
+		doNavigate,
+	]);
 
 	if (!pending) {
 		return (
@@ -364,10 +402,71 @@ function PendingWorkspacePage() {
 
 	const creatingLabel =
 		pending.intent === "adopt"
-			? "Adopting worktree..."
+			? "Adopting worktree"
 			: pending.intent === "checkout"
-				? "Checking out branch..."
-				: "Creating workspace...";
+				? "Checking out branch"
+				: "Setting up workspace";
+
+	// Hold the keypad view through every pre-navigation state (including
+	// walker catch-up + the Electric-sync wait). Flipping to a separate
+	// "Workspace ready — opening..." pane for a tick between walker done and
+	// `doNavigate` firing would flash a different layout before the route
+	// change — the keypad's all-keys-pressed frame already signals done.
+	const showCreatingUI =
+		pending.status === "creating" ||
+		(pending.status === "succeeded" && !syncTimedOut);
+
+	if (showCreatingUI) {
+		return (
+			<div className="flex h-full w-full flex-1 flex-col items-center justify-center px-8">
+				<div className="flex w-full max-w-md flex-col items-center space-y-5 text-center">
+					<KeypadLoader
+						currentStep={displayedInitStep}
+						muted={notificationSoundsMuted}
+						volume={0.35 * (notificationVolume / 100)}
+					/>
+
+					<div className="space-y-1">
+						<h2
+							className={`text-lg font-medium ${isStale ? "text-amber-500" : "text-foreground"}`}
+						>
+							{isStale
+								? "This is taking longer than expected..."
+								: creatingLabel}
+						</h2>
+						<p className="text-sm text-muted-foreground">{pending.name}</p>
+						<div className="flex items-center justify-center gap-1.5 text-xs text-muted-foreground">
+							<GoGitBranch className="size-3.5" />
+							<span className="font-mono">{pending.branchName}</span>
+						</div>
+					</div>
+
+					<StepProgress currentStep={displayedInitStep} animate={false} />
+
+					<div className="flex items-center gap-3">
+						<p className="text-xs text-muted-foreground/60">
+							Takes 10s to a few minutes depending on the size of your repo
+						</p>
+						<span className="text-xs tabular-nums text-muted-foreground/50">
+							{elapsedLabel}
+						</span>
+					</div>
+
+					<button
+						type="button"
+						className="rounded-md border px-3 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-foreground"
+						onClick={() => {
+							collections.pendingWorkspaces.delete(pendingId);
+							void clearAttachments(pendingId);
+							void navigate({ to: "/" });
+						}}
+					>
+						Dismiss
+					</button>
+				</div>
+			</div>
+		);
+	}
 
 	return (
 		<div className="flex h-full w-full flex-1 justify-center pt-24">
@@ -380,59 +479,30 @@ function PendingWorkspacePage() {
 					</div>
 				</div>
 
-				{pending.status === "creating" && (
-					<div className="space-y-3">
-						<div className="flex items-center justify-between">
-							<p
-								className={`text-sm ${isStale ? "text-amber-500" : "text-muted-foreground"}`}
-							>
-								{isStale
-									? "This is taking longer than expected..."
-									: creatingLabel}
-							</p>
-							<span className="text-xs tabular-nums text-muted-foreground/50">
-								{elapsedLabel}
+				{pending.status === "succeeded" && syncTimedOut && !workspaceSynced && (
+					<div className="space-y-4">
+						<div className="flex items-start gap-2 text-sm text-amber-500">
+							<HiExclamationTriangle className="size-4 mt-0.5 shrink-0" />
+							<span>
+								Workspace was created but hasn't synced to this device yet.
+								Check your connection.
 							</span>
 						</div>
-						{intentHasProgress && steps.length > 0 ? (
-							<div className="space-y-2">
-								{steps.map((step) => (
-									<div
-										key={step.id}
-										className="flex items-center gap-2.5 text-sm"
-									>
-										{step.status === "done" ? (
-											<HiCheck className="size-4 text-emerald-500" />
-										) : step.status === "active" ? (
-											<div className="size-4 flex items-center justify-center">
-												<div className="size-2.5 rounded-full bg-foreground animate-pulse" />
-											</div>
-										) : (
-											<div className="size-4 flex items-center justify-center">
-												<div className="size-2 rounded-full bg-muted-foreground/30" />
-											</div>
-										)}
-										<span
-											className={
-												step.status === "done" || step.status === "active"
-													? "text-foreground"
-													: "text-muted-foreground/50"
-											}
-										>
-											{step.label}
-										</span>
-									</div>
-								))}
-							</div>
-						) : (
-							// Adopt has no host-side progress steps — show a generic spinner.
-							<div className="flex items-center gap-2.5 text-sm text-muted-foreground">
-								<div className="size-4 flex items-center justify-center">
-									<div className="size-2.5 rounded-full bg-foreground animate-pulse" />
-								</div>
-							</div>
-						)}
-						<div className="flex gap-2 pt-1">
+						<div className="flex gap-2">
+							<button
+								type="button"
+								className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90"
+								onClick={() => setSyncTimedOut(false)}
+							>
+								Keep waiting
+							</button>
+							<button
+								type="button"
+								className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+								onClick={doNavigate}
+							>
+								Open anyway
+							</button>
 							<button
 								type="button"
 								className="rounded-md border px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground hover:bg-accent"
@@ -447,63 +517,6 @@ function PendingWorkspacePage() {
 						</div>
 					</div>
 				)}
-
-				{pending.status === "succeeded" &&
-					(syncTimedOut && !workspaceSynced ? (
-						<div className="space-y-4">
-							<div className="flex items-start gap-2 text-sm text-amber-500">
-								<HiExclamationTriangle className="size-4 mt-0.5 shrink-0" />
-								<span>
-									Workspace was created but hasn't synced to this device yet.
-									Check your connection.
-								</span>
-							</div>
-							<div className="flex gap-2">
-								<button
-									type="button"
-									className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90"
-									onClick={() => setSyncTimedOut(false)}
-								>
-									Keep waiting
-								</button>
-								<button
-									type="button"
-									className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
-									onClick={doNavigate}
-								>
-									Open anyway
-								</button>
-								<button
-									type="button"
-									className="rounded-md border px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground hover:bg-accent"
-									onClick={() => {
-										collections.pendingWorkspaces.delete(pendingId);
-										void clearAttachments(pendingId);
-										void navigate({ to: "/" });
-									}}
-								>
-									Dismiss
-								</button>
-							</div>
-						</div>
-					) : (
-						<div className="space-y-2">
-							<div className="flex items-center gap-2 text-sm text-emerald-500">
-								<HiCheck className="size-4" />
-								<span>Workspace ready — opening...</span>
-							</div>
-							{pending.warnings.length > 0 && (
-								<ul className="space-y-1 text-xs text-amber-500">
-									{pending.warnings.map((w) => (
-										<li key={w} className="flex items-start gap-1.5">
-											<HiExclamationTriangle className="size-3.5 mt-0.5 shrink-0" />
-											<span>{w}</span>
-										</li>
-									))}
-								</ul>
-							)}
-						</div>
-					))}
 
 				{pending.status === "failed" && (
 					<div className="space-y-4">

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/page.tsx
@@ -56,6 +56,30 @@ export const Route = createFileRoute(
 	component: PendingWorkspacePage,
 });
 
+const V2_PENDING_STEP_MESSAGES: Partial<Record<WorkspaceInitStep, string>> = {
+	pending: "Preparing workspace",
+	syncing: "Preparing workspace",
+	verifying: "Checking repository",
+	fetching: "Fetching latest changes",
+	creating_worktree: "Creating worktree",
+	copying_config: "Registering workspace",
+	finalizing: "Opening workspace",
+	ready: "Ready",
+	failed: "Failed",
+};
+
+const V2_PENDING_KEYPAD_LABELS: Partial<Record<WorkspaceInitStep, string>> = {
+	pending: "Preparing workspace",
+	syncing: "Preparing workspace",
+	verifying: "Checking repository",
+	fetching: "Fetching latest changes",
+	creating_worktree: "Creating worktree",
+	copying_config: "Registering workspace",
+	finalizing: "Opening workspace",
+	ready: "Ready",
+	failed: "Failed",
+};
+
 function useFireIntent(pendingId: string, pending: PendingWorkspaceRow | null) {
 	const collections = useCollections();
 	const createWorkspace = useCreateDashboardWorkspace();
@@ -219,6 +243,7 @@ function PendingWorkspacePage() {
 	const { ensureWorkspaceInSidebar } = useDashboardSidebarState();
 	const navigatedRef = useRef(false);
 	const firedRef = useRef(false);
+	const warningsToastedRef = useRef<string | null>(null);
 
 	// Route params can change under a mounted component (user navigates from
 	// one pending page to another). Reset the fire/nav guards so the new
@@ -230,6 +255,7 @@ function PendingWorkspacePage() {
 		prevPendingIdRef.current = pendingId;
 		firedRef.current = false;
 		navigatedRef.current = false;
+		warningsToastedRef.current = null;
 		setSyncTimedOut(false);
 	}
 
@@ -308,8 +334,6 @@ function PendingWorkspacePage() {
 				? "failed"
 				: rawInitStep;
 	const displayedInitStep = useAnimatedInitStep(walkerTarget, pendingId);
-	const walkerCaughtUp =
-		displayedInitStep === "ready" || displayedInitStep === "failed";
 
 	// Honor the user's notification-mute preference + volume for the keypad
 	// click sound. Default to muted while the query loads so we never play a
@@ -334,6 +358,21 @@ function PendingWorkspacePage() {
 	const elapsedLabel = formatRelativeTime(createdAtMs);
 	const isStale =
 		pending?.status === "creating" && elapsedMs > STALE_THRESHOLD_MS;
+
+	useEffect(() => {
+		if (
+			pending?.status !== "succeeded" ||
+			pending.warnings.length === 0 ||
+			warningsToastedRef.current === pendingId
+		) {
+			return;
+		}
+
+		warningsToastedRef.current = pendingId;
+		for (const warning of pending.warnings) {
+			toast.warning(warning);
+		}
+	}, [pending?.status, pending?.warnings, pendingId]);
 
 	// If sync stalls past this, swap the spinner for a recoverable stall UI
 	// rather than silently navigating into "Workspace not found". syncTimedOut
@@ -379,18 +418,11 @@ function PendingWorkspacePage() {
 		if (
 			pending?.status === "succeeded" &&
 			pending.workspaceId &&
-			workspaceSynced &&
-			walkerCaughtUp
+			workspaceSynced
 		) {
 			doNavigate();
 		}
-	}, [
-		pending?.status,
-		pending?.workspaceId,
-		workspaceSynced,
-		walkerCaughtUp,
-		doNavigate,
-	]);
+	}, [pending?.status, pending?.workspaceId, workspaceSynced, doNavigate]);
 
 	if (!pending) {
 		return (
@@ -407,11 +439,9 @@ function PendingWorkspacePage() {
 				? "Checking out branch"
 				: "Setting up workspace";
 
-	// Hold the keypad view through every pre-navigation state (including
-	// walker catch-up + the Electric-sync wait). Flipping to a separate
-	// "Workspace ready — opening..." pane for a tick between walker done and
-	// `doNavigate` firing would flash a different layout before the route
-	// change — the keypad's all-keys-pressed frame already signals done.
+	// Hold the keypad view through the real pre-navigation states. We do not wait
+	// for the animation to catch up once the workspace is synced; navigation
+	// should be gated only by workspace readiness, not loader timing.
 	const showCreatingUI =
 		pending.status === "creating" ||
 		(pending.status === "succeeded" && !syncTimedOut);
@@ -424,6 +454,7 @@ function PendingWorkspacePage() {
 						currentStep={displayedInitStep}
 						muted={notificationSoundsMuted}
 						volume={0.35 * (notificationVolume / 100)}
+						ariaLabelByStep={V2_PENDING_KEYPAD_LABELS}
 					/>
 
 					<div className="space-y-1">
@@ -441,7 +472,11 @@ function PendingWorkspacePage() {
 						</div>
 					</div>
 
-					<StepProgress currentStep={displayedInitStep} animate={false} />
+					<StepProgress
+						currentStep={displayedInitStep}
+						animate={false}
+						messages={V2_PENDING_STEP_MESSAGES}
+					/>
 
 					<div className="flex items-center gap-3">
 						<p className="text-xs text-muted-foreground/60">
@@ -454,7 +489,7 @@ function PendingWorkspacePage() {
 
 					<button
 						type="button"
-						className="rounded-md border px-3 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-foreground"
+						className="text-xs text-muted-foreground/45 transition-colors hover:text-muted-foreground"
 						onClick={() => {
 							collections.pendingWorkspaces.delete(pendingId);
 							void clearAttachments(pendingId);
@@ -463,6 +498,58 @@ function PendingWorkspacePage() {
 					>
 						Dismiss
 					</button>
+				</div>
+			</div>
+		);
+	}
+
+	if (pending.status === "failed") {
+		return (
+			<div className="flex h-full w-full flex-1 flex-col items-center justify-center px-8">
+				<div className="flex w-full max-w-md flex-col items-center space-y-5 text-center">
+					<div className="space-y-1">
+						<h2 className="text-lg font-medium text-foreground">
+							Workspace setup failed
+						</h2>
+						<p className="text-sm text-muted-foreground">{pending.name}</p>
+						<div className="flex items-center justify-center gap-1.5 text-xs text-muted-foreground">
+							<GoGitBranch className="size-3.5" />
+							<span className="font-mono">{pending.branchName}</span>
+						</div>
+					</div>
+
+					<StepProgress
+						currentStep="failed"
+						messages={{ failed: "Failed to set up workspace" }}
+					/>
+
+					<p className="max-w-sm select-text break-words text-xs leading-relaxed text-destructive/75">
+						{pending.error ?? "Failed to create workspace"}
+					</p>
+
+					<div className="flex items-center gap-4 pt-1">
+						<button
+							type="button"
+							className="rounded-md border border-foreground/15 px-3 py-1.5 text-xs text-foreground transition-colors hover:bg-foreground/[0.04]"
+							onClick={() => {
+								firedRef.current = true; // prevent the mount-effect from racing
+								void fireIntent();
+							}}
+						>
+							Retry
+						</button>
+						<button
+							type="button"
+							className="text-xs text-muted-foreground/45 transition-colors hover:text-muted-foreground"
+							onClick={() => {
+								collections.pendingWorkspaces.delete(pendingId);
+								void clearAttachments(pendingId);
+								void navigate({ to: "/" });
+							}}
+						>
+							Dismiss
+						</button>
+					</div>
 				</div>
 			</div>
 		);
@@ -506,40 +593,6 @@ function PendingWorkspacePage() {
 							<button
 								type="button"
 								className="rounded-md border px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground hover:bg-accent"
-								onClick={() => {
-									collections.pendingWorkspaces.delete(pendingId);
-									void clearAttachments(pendingId);
-									void navigate({ to: "/" });
-								}}
-							>
-								Dismiss
-							</button>
-						</div>
-					</div>
-				)}
-
-				{pending.status === "failed" && (
-					<div className="space-y-4">
-						<div className="flex items-start gap-2 text-sm text-destructive">
-							<HiExclamationTriangle className="size-4 mt-0.5 shrink-0" />
-							<span className="select-text cursor-text break-words">
-								{pending.error ?? "Failed to create workspace"}
-							</span>
-						</div>
-						<div className="flex gap-2">
-							<button
-								type="button"
-								className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90"
-								onClick={() => {
-									firedRef.current = true; // prevent the mount-effect from racing
-									void fireIntent();
-								}}
-							>
-								Retry
-							</button>
-							<button
-								type="button"
-								className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
 								onClick={() => {
 									collections.pendingWorkspaces.delete(pendingId);
 									void clearAttachments(pendingId);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/useAnimatedInitStep.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/useAnimatedInitStep.ts
@@ -5,10 +5,14 @@ import {
 	type WorkspaceInitStep,
 } from "shared/types/workspace-init";
 
-const STEP_HOLD_MS = 400;
+const STEP_HOLD_MS = 160;
+const LEAD_IN_HOLD_MS = 60;
+const READY_CATCH_UP_HOLD_MS = 60;
 
 /**
- * Advances through `INIT_STEP_ORDER` at most one step per `STEP_HOLD_MS`.
+ * Advances through `INIT_STEP_ORDER` at a readable pace. The first two keypad
+ * beats are a v2 lead-in, so move through them quickly and leave the later
+ * keys for the real worktree/register/opening states.
  *
  * v2's host-service can blow through its 5 steps in well under a poll interval
  * (the whole local-only flow is a handful of synchronous ops), so a raw
@@ -16,9 +20,8 @@ const STEP_HOLD_MS = 400;
  * instantly pressing all keypad keys with no visible progression.
  *
  * Returns a displayed step that walks forward until it catches up, so both
- * `KeypadLoader` and `StepProgress` get a visible beat per step. When the
- * backend genuinely takes longer than the hold, displayed stays pinned at
- * target (the hook adds no artificial latency to slow flows).
+ * `KeypadLoader` and `StepProgress` get a visible beat per step. Navigation
+ * must not wait on this hook; it is purely presentational.
  */
 export function useAnimatedInitStep(
 	targetStep: WorkspaceInitStep,
@@ -49,11 +52,18 @@ export function useAnimatedInitStep(
 		}
 		if (displayedIdx >= targetIdx) return;
 
+		const nextIdx = displayedIdx + 1;
+		const isLeadInStep = nextIdx <= getStepIndex("creating_worktree");
+		const holdMs =
+			targetStep === "ready"
+				? READY_CATCH_UP_HOLD_MS
+				: isLeadInStep
+					? LEAD_IN_HOLD_MS
+					: STEP_HOLD_MS;
 		const timer = window.setTimeout(() => {
-			const nextIdx = displayedIdx + 1;
 			const next = INIT_STEP_ORDER[nextIdx];
 			if (next) setDisplayed(next);
-		}, STEP_HOLD_MS);
+		}, holdMs);
 		return () => window.clearTimeout(timer);
 	}, [targetStep, displayed, resetKey]);
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/useAnimatedInitStep.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/useAnimatedInitStep.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "react";
+import {
+	getStepIndex,
+	INIT_STEP_ORDER,
+	type WorkspaceInitStep,
+} from "shared/types/workspace-init";
+
+const STEP_HOLD_MS = 400;
+
+/**
+ * Advances through `INIT_STEP_ORDER` at most one step per `STEP_HOLD_MS`.
+ *
+ * v2's host-service can blow through its 5 steps in well under a poll interval
+ * (the whole local-only flow is a handful of synchronous ops), so a raw
+ * target-step would let the renderer see e.g. `pending → ready` in one hop —
+ * instantly pressing all keypad keys with no visible progression.
+ *
+ * Returns a displayed step that walks forward until it catches up, so both
+ * `KeypadLoader` and `StepProgress` get a visible beat per step. When the
+ * backend genuinely takes longer than the hold, displayed stays pinned at
+ * target (the hook adds no artificial latency to slow flows).
+ */
+export function useAnimatedInitStep(
+	targetStep: WorkspaceInitStep,
+	resetKey?: string,
+): WorkspaceInitStep {
+	const [state, setState] = useState<{
+		displayed: WorkspaceInitStep;
+		resetKey: string | undefined;
+	}>({ displayed: "pending", resetKey });
+
+	const displayed = state.resetKey === resetKey ? state.displayed : "pending";
+
+	useEffect(() => {
+		const targetIdx = getStepIndex(targetStep);
+		const displayedIdx = getStepIndex(displayed);
+
+		const setDisplayed = (next: WorkspaceInitStep) => {
+			setState({ displayed: next, resetKey });
+		};
+
+		if (targetStep === "failed") {
+			setDisplayed("failed");
+			return;
+		}
+		if (displayedIdx < 0) {
+			setDisplayed("pending");
+			return;
+		}
+		if (displayedIdx >= targetIdx) return;
+
+		const timer = window.setTimeout(() => {
+			const nextIdx = displayedIdx + 1;
+			const next = INIT_STEP_ORDER[nextIdx];
+			if (next) setDisplayed(next);
+		}, STEP_HOLD_MS);
+		return () => window.clearTimeout(timer);
+	}, [targetStep, displayed, resetKey]);
+
+	return displayed;
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceInitializingView/KeypadLoader/KeypadLoader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceInitializingView/KeypadLoader/KeypadLoader.tsx
@@ -76,6 +76,7 @@ interface KeypadLoaderProps {
 	muted?: boolean;
 	/** 0–1 click-sound volume. Clamped and ignored if muted. */
 	volume?: number;
+	ariaLabelByStep?: Partial<Record<WorkspaceInitStep, string>>;
 }
 
 const DEFAULT_CLICK_VOLUME = 0.35;
@@ -85,6 +86,7 @@ export function KeypadLoader({
 	className,
 	muted = false,
 	volume = DEFAULT_CLICK_VOLUME,
+	ariaLabelByStep,
 }: KeypadLoaderProps) {
 	const audioRef = useRef<HTMLAudioElement | null>(null);
 	const prevStepRef = useRef<WorkspaceInitStep>(currentStep);
@@ -169,15 +171,16 @@ export function KeypadLoader({
 	}, [currentStep, effectiveMuted, clampedVolume]);
 
 	const currentIdx = getStepIndex(currentStep);
+	const currentLabel =
+		ariaLabelByStep?.[currentStep] ??
+		KEYS.find((k) => k.activeSteps.includes(currentStep))?.label ??
+		"Preparing";
 
 	return (
 		<div
 			className={cn("keypad-loader", className)}
 			role="img"
-			aria-label={`Setup in progress: ${
-				KEYS.find((k) => k.activeSteps.includes(currentStep))?.label ??
-				"Preparing"
-			}`}
+			aria-label={`Setup in progress: ${currentLabel}`}
 		>
 			<div className="keypad-loader__base">
 				<img src={keypadBaseUrl} alt="" />

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceInitializingView/StepProgress/StepProgress.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceInitializingView/StepProgress/StepProgress.tsx
@@ -22,11 +22,13 @@ type StepState = "waiting" | "progress" | "done";
 interface StepProgressProps {
 	currentStep: WorkspaceInitStep;
 	animate?: boolean;
+	messages?: Partial<Record<WorkspaceInitStep, string>>;
 }
 
 export function StepProgress({
 	currentStep,
 	animate = true,
+	messages,
 }: StepProgressProps) {
 	const targetIdx = getStepIndex(currentStep);
 	const [renderIdx, setRenderIdx] = useState(targetIdx);
@@ -57,6 +59,23 @@ export function StepProgress({
 		}, DONE_HOLD_MS);
 		return () => window.clearTimeout(t);
 	}, [animate, targetIdx, renderIdx]);
+
+	if (currentStep === "failed") {
+		return (
+			<div className="step-progress" aria-live="assertive">
+				<div className="step-progress__list">
+					<div className="step-progress__item text-destructive">
+						<span className="step-progress__icon">
+							<FailedCircle />
+						</span>
+						<span className="step-progress__title">
+							{stripEllipsis(messages?.failed ?? INIT_STEP_MESSAGES.failed)}
+						</span>
+					</div>
+				</div>
+			</div>
+		);
+	}
 
 	const activeRenderIdx = animate ? renderIdx : targetIdx;
 	const activeHoldDoneIdx = animate ? holdDoneIdx : null;
@@ -97,7 +116,7 @@ export function StepProgress({
 								<StepIcon state={state} />
 							</span>
 							<span className="step-progress__title">
-								{stripEllipsis(INIT_STEP_MESSAGES[step])}
+								{stripEllipsis(messages?.[step] ?? INIT_STEP_MESSAGES[step])}
 								{state === "progress" ? <Ellipsis /> : null}
 							</span>
 						</div>
@@ -187,6 +206,28 @@ function HalfCircle() {
 				r="7"
 			/>
 			<path fill="currentColor" d="M8 3 A5 5 0 0 1 8 13 Z" />
+		</svg>
+	);
+}
+
+function FailedCircle() {
+	return (
+		<svg
+			width="1em"
+			height="1em"
+			viewBox="0 0 16 16"
+			aria-hidden="true"
+			role="presentation"
+		>
+			<circle fill="currentColor" cx="8" cy="8" r="8" />
+			<path
+				fill="none"
+				stroke="var(--background, #fff)"
+				strokeLinecap="round"
+				strokeWidth="1.75"
+				d="M8 4.25v4.25"
+			/>
+			<circle fill="var(--background, #fff)" cx="8" cy="11.5" r="0.8" />
 		</svg>
 	);
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceInitializingView/StepProgress/StepProgress.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceInitializingView/StepProgress/StepProgress.tsx
@@ -21,14 +21,23 @@ type StepState = "waiting" | "progress" | "done";
 
 interface StepProgressProps {
 	currentStep: WorkspaceInitStep;
+	animate?: boolean;
 }
 
-export function StepProgress({ currentStep }: StepProgressProps) {
+export function StepProgress({
+	currentStep,
+	animate = true,
+}: StepProgressProps) {
 	const targetIdx = getStepIndex(currentStep);
 	const [renderIdx, setRenderIdx] = useState(targetIdx);
 	const [holdDoneIdx, setHoldDoneIdx] = useState<number | null>(null);
 
 	useEffect(() => {
+		if (!animate) {
+			setRenderIdx(targetIdx);
+			setHoldDoneIdx(null);
+			return;
+		}
 		if (targetIdx === renderIdx) {
 			setHoldDoneIdx(null);
 			return;
@@ -47,15 +56,18 @@ export function StepProgress({ currentStep }: StepProgressProps) {
 			setRenderIdx((prev) => Math.min(prev + 1, targetIdx));
 		}, DONE_HOLD_MS);
 		return () => window.clearTimeout(t);
-	}, [targetIdx, renderIdx]);
+	}, [animate, targetIdx, renderIdx]);
+
+	const activeRenderIdx = animate ? renderIdx : targetIdx;
+	const activeHoldDoneIdx = animate ? holdDoneIdx : null;
 
 	return (
 		<div className="step-progress" aria-live="polite">
 			<div className="step-progress__list">
 				{DISPLAY_STEPS.map((step) => {
 					const idx = getStepIndex(step);
-					const distance = idx - renderIdx;
-					const isHeldDone = holdDoneIdx === idx;
+					const distance = idx - activeRenderIdx;
+					const isHeldDone = activeHoldDoneIdx === idx;
 					const state: StepState = isHeldDone
 						? "done"
 						: distance < 0

--- a/packages/host-service/src/trpc/router/workspace-creation/procedures/checkout.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/procedures/checkout.ts
@@ -21,8 +21,6 @@ export const checkout = protectedProcedure
 
 		const localProject = requireLocalProject(ctx, input.projectId);
 
-		setProgress(input.pendingId, "creating_worktree");
-
 		// ── PR path ────────────────────────────────────────────────────────
 		if (input.pr) {
 			const branch = derivePrLocalBranchName(input.pr);
@@ -88,6 +86,7 @@ export const checkout = protectedProcedure
 			// Detached worktree first — `gh pr checkout` inside it creates the
 			// branch with correct fork-remote + upstream config. Mirrors v1's
 			// `createWorktreeFromPr`.
+			setProgress(input.pendingId, "creating_worktree");
 			try {
 				await git.raw(["worktree", "add", "--detach", worktreePath]);
 			} catch (err) {
@@ -207,6 +206,7 @@ export const checkout = protectedProcedure
 		}
 
 		if (resolved.kind === "remote-tracking") {
+			setProgress(input.pendingId, "fetching_remote");
 			try {
 				await git.fetch([
 					resolved.remote,
@@ -221,6 +221,8 @@ export const checkout = protectedProcedure
 				);
 			}
 		}
+
+		setProgress(input.pendingId, "creating_worktree");
 
 		try {
 			// For a remote-only branch, create a local tracking branch

--- a/packages/host-service/src/trpc/router/workspace-creation/procedures/create.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/procedures/create.ts
@@ -32,8 +32,6 @@ export const create = protectedProcedure
 
 		const localProject = requireLocalProject(ctx, input.projectId);
 
-		setProgress(input.pendingId, "creating_worktree");
-
 		// Renderer already sanitized/slugified. Host-service only validates
 		// and deduplicates — doesn't re-sanitize (which would strip case,
 		// slashes, etc. the user intended).
@@ -103,6 +101,7 @@ export const create = protectedProcedure
 		// If we resolved to a remote-tracking ref, fetch just that branch
 		// to ensure we're branching from the latest remote state.
 		if (startPoint.kind === "remote-tracking") {
+			setProgress(input.pendingId, "fetching_remote");
 			try {
 				await git.fetch([
 					startPoint.remote,
@@ -117,6 +116,8 @@ export const create = protectedProcedure
 				);
 			}
 		}
+
+		setProgress(input.pendingId, "creating_worktree");
 
 		// Always create a new branch — never check out an existing one.
 		// Checking out existing branches is a separate intent (createFromPr,
@@ -231,6 +232,8 @@ export const create = protectedProcedure
 				message: "Cloud workspace create returned no row",
 			});
 		}
+
+		setProgress(input.pendingId, "finalizing");
 
 		try {
 			ctx.db

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/finish-checkout.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/finish-checkout.ts
@@ -108,6 +108,8 @@ export async function finishCheckout(
 		});
 	}
 
+	setProgress(args.pendingId, "finalizing");
+
 	try {
 		ctx.db
 			.insert(workspaces)

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/progress-store.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/progress-store.ts
@@ -11,8 +11,10 @@ interface ProgressState {
 
 const STEP_DEFINITIONS = [
 	{ id: "ensuring_repo", label: "Ensuring local repository" },
+	{ id: "fetching_remote", label: "Fetching latest from remote" },
 	{ id: "creating_worktree", label: "Creating worktree" },
 	{ id: "registering", label: "Registering workspace" },
+	{ id: "finalizing", label: "Finalizing setup" },
 ] as const;
 
 const createProgress = new Map<string, ProgressState>();


### PR DESCRIPTION
## Summary
- Port v1's animated `KeypadLoader` + sliding `StepProgress` onto the v2 `/pending/$pendingId` route, replacing the plain dot-list.
- Split host-service progress from 3 buckets → 5 steps (`ensuring_repo` / `fetching_remote` / `creating_worktree` / `registering` / `finalizing`) so each key maps 1:1. Added `setProgress` calls are in-memory `Map` writes — **no added latency**.
- Add `useAnimatedInitStep` walker so fast local flows don't flash past the keypad animation; keypad stays mounted through the Electric-sync wait so there's no intermediate "Workspace ready — opening..." pane before `doNavigate` fires.

## Why
v2's pending page shipped with a minimal status line. v1's keypad/step UI is nicer and, with the finer host-service progress, now animates honestly — including the `git fetch` and the two cloud mutations that were previously buried inside `creating_worktree` / `registering`.

## Notes
- `StepProgress` gets an opt-out `animate` prop; v1 callers default to `animate={true}` and are unaffected.
- `fetching_remote` only fires when the start point is actually remote-tracking — local-only branches pass through that key pressed without an active beat, which matches reality.
- Walker target pins to `"ready"` on `status === "succeeded"` so the keypad reaches all-pressed even though host-service clears its progress map at the end of the mutation.

## Test plan
- [ ] Create a new workspace from a remote-tracking branch on a real repo — verify all 5 keys press sequentially with visible "active" beats.
- [ ] Create a new workspace from a local-only branch — verify key 2 (`fetching_remote`) passes through pressed without an active beat, others animate normally.
- [ ] Checkout an existing branch (non-PR) — verify same 5-key animation.
- [ ] Checkout a PR — verify key 2 is skipped (PR path uses `gh pr checkout` post-worktree-add), others animate.
- [ ] Adopt an existing worktree — verify no crash, UI still shows a sensible fallback (adopt has no host-side progress).
- [ ] Watch a slow-network create (throttle devtools) — walker should keep pace with real progress, not lag.
- [ ] On a fast local create, confirm there's no flash of a "Workspace ready — opening..." screen before route change.
- [ ] Retry after a failure — walker resets to `pending` (the `resetKey` threading via `pendingId`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports v1’s animated workspace-creation loader to the v2 pending page with a clear 5-step flow and a smoother handoff to the workspace. Navigation now opens as soon as the workspace is synced, without the “ready — opening…” flash.

- **New Features**
  - Reused `KeypadLoader` and `StepProgress` on `/pending/$pendingId`; added per-step messages and accessible labels.
  - Mapped host progress to 5 steps via `mapProgressToInitStep`; `useAnimatedInitStep` paces fast flows; keypad stays visible through sync; navigate as soon as synced.
  - Tightened progress polling to 200ms and included `pr-checkout`; keypad clicks honor mute/volume; success warnings are shown as toasts.
  - Host-service emits `fetching_remote` and `finalizing` and sets progress at each step; final keypad press is pinned when the mutation resolves.

- **Bug Fixes**
  - Removed the animation gate before navigation to avoid the intermediate “ready — opening…” screen.
  - Improved failed state with a `StepProgress` error icon, clearer copy, and a subtle Retry; walker resets when `pendingId` changes.

<sup>Written for commit 92e5e72d6e6a1f11532646691933da0b4cb63bb4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added finer-grained progress stages for workspace creation and a mapping to the visible init steps.
  * New animated step controller to drive incremental progress displays.

* **Improvements**
  * Reworked initialization UI with animated progression, failure states, per-step messages, and improved accessibility labels.
  * Faster, broader progress polling and single-show warnings; keypad sound now honors saved mute/volume settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->