### PR TITLE
[codex] simplify workspace controls

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/V2WorkspacesList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/V2WorkspacesList.tsx
@@ -226,7 +226,6 @@ export function V2WorkspacesList({ workspaces }: V2WorkspacesListProps) {
 				sortDirection={sortDirection}
 				onSort={handleSort}
 			/>
-			<span />
 		</div>
 	);
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
@@ -66,9 +66,13 @@ export function V2WorkspaceRow({
 	const handleRemoveFromSidebar = useCallback(
 		(event: React.MouseEvent) => {
 			event.stopPropagation();
+			if (isCurrentRoute) {
+				event.preventDefault();
+				return;
+			}
 			removeWorkspaceFromSidebar(workspace.id);
 		},
-		[removeWorkspaceFromSidebar, workspace.id],
+		[isCurrentRoute, removeWorkspaceFromSidebar, workspace.id],
 	);
 
 	const creatorLabel = workspace.isCreatedByCurrentUser
@@ -139,9 +143,12 @@ export function V2WorkspaceRow({
 									size="icon"
 									variant="ghost"
 									onClick={handleRemoveFromSidebar}
-									disabled={isCurrentRoute}
+									aria-disabled={isCurrentRoute}
 									aria-label="Remove from sidebar"
-									className="size-7"
+									className={cn(
+										"size-7",
+										isCurrentRoute && "cursor-not-allowed opacity-50",
+									)}
 								>
 									<LuMinus className="size-3.5" />
 								</Button>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
@@ -131,16 +131,44 @@ export function V2WorkspaceRow({
 					isCurrentRoute && "bg-accent/40",
 				)}
 			>
-				<span className="flex items-center justify-center">
+				<div className="flex items-center justify-center">
 					{workspace.isInSidebar ? (
-						<span
-							role="img"
-							aria-label="In your sidebar"
-							title="In your sidebar"
-							className="size-1.5 rounded-full bg-primary"
-						/>
-					) : null}
-				</span>
+						<Tooltip delayDuration={300}>
+							<TooltipTrigger asChild>
+								<Button
+									size="icon"
+									variant="ghost"
+									onClick={handleRemoveFromSidebar}
+									disabled={isCurrentRoute}
+									aria-label="Remove from sidebar"
+									className="size-7"
+								>
+									<LuMinus className="size-3.5" />
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent side="right">
+								{isCurrentRoute
+									? "Can't remove the current workspace"
+									: "Remove from sidebar"}
+							</TooltipContent>
+						</Tooltip>
+					) : (
+						<Tooltip delayDuration={300}>
+							<TooltipTrigger asChild>
+								<Button
+									size="icon"
+									variant="ghost"
+									onClick={handleAddToSidebar}
+									aria-label="Add to sidebar"
+									className="size-7"
+								>
+									<LuPlus className="size-3.5" />
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent side="right">Add to sidebar</TooltipContent>
+						</Tooltip>
+					)}
+				</div>
 
 				<span className="flex min-w-0 items-center">
 					<span
@@ -176,45 +204,6 @@ export function V2WorkspaceRow({
 				>
 					{timeLabel} · {creatorLabel}
 				</span>
-
-				<div className="flex justify-end">
-					{workspace.isInSidebar ? (
-						<Tooltip delayDuration={300}>
-							<TooltipTrigger asChild>
-								<Button
-									size="icon"
-									variant="ghost"
-									onClick={handleRemoveFromSidebar}
-									disabled={isCurrentRoute}
-									aria-label="Remove from sidebar"
-									className="size-7 opacity-0 transition-opacity group-hover/row:opacity-100 focus-visible:opacity-100 data-[state=open]:opacity-100"
-								>
-									<LuMinus className="size-3.5" />
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent side="left">
-								{isCurrentRoute
-									? "Can't remove the current workspace"
-									: "Remove from sidebar"}
-							</TooltipContent>
-						</Tooltip>
-					) : (
-						<Tooltip delayDuration={300}>
-							<TooltipTrigger asChild>
-								<Button
-									size="icon"
-									variant="ghost"
-									onClick={handleAddToSidebar}
-									aria-label="Add to sidebar"
-									className="size-7 opacity-0 transition-opacity group-hover/row:opacity-100 focus-visible:opacity-100"
-								>
-									<LuPlus className="size-3.5" />
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent side="left">Add to sidebar</TooltipContent>
-						</Tooltip>
-					)}
-				</div>
 			</div>
 		</li>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/constants.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/constants.ts
@@ -1,5 +1,5 @@
 // Shared grid template used by the column header row and every workspace row
-// so the Sidebar / Name / Host / Branch / Created / Action columns align
-// across the whole view. Columns hide progressively on narrower viewports.
+// so the Sidebar action / Name / Host / Branch / Created columns align across
+// the whole view. Columns hide progressively on narrower viewports.
 export const V2_WORKSPACES_ROW_GRID =
-	"grid grid-cols-[1.25rem_minmax(0,1fr)_2.5rem] gap-4 md:grid-cols-[1.25rem_minmax(0,1fr)_12rem_2.5rem] lg:grid-cols-[1.25rem_minmax(0,1fr)_12rem_14rem_2.5rem] xl:grid-cols-[1.25rem_minmax(0,1fr)_12rem_14rem_11rem_2.5rem] items-center";
+	"grid grid-cols-[2.5rem_minmax(0,1fr)] gap-4 md:grid-cols-[2.5rem_minmax(0,1fr)_12rem] lg:grid-cols-[2.5rem_minmax(0,1fr)_12rem_14rem] xl:grid-cols-[2.5rem_minmax(0,1fr)_12rem_14rem_11rem] items-center";


### PR DESCRIPTION
## What changed
- Replaced the workspace list sidebar dot with always-visible add/remove icon buttons in the same leading column.
- Removed the trailing action column from the workspace list grid and header.

## Why
This keeps the add/remove sidebar control in the position where the sidebar indicator previously appeared and removes the extra row-end action target.

## Validation
- `bunx biome check --write apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/constants.ts apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/V2WorkspacesList.tsx apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx`
- `bun run --cwd apps/desktop typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the sidebar dot with always-visible add/remove buttons in the first column and removed the trailing action column. Fixed the tooltip and disabled state when trying to remove the current workspace.

- **Refactors**
  - Added +/– icon buttons with tooltips in the leading column; disable remove on the current workspace and show a clear “Can’t remove the current workspace” message.
  - Updated the shared grid layout to drop the action column and widen the first column; cleaned up the header markup.

<sup>Written for commit 7149187dcf835c29f6494dd715ea7ecd4a6997c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Simplified the workspaces list header by removing an unnecessary spacer.
  * Moved sidebar action controls (add/remove workspace buttons) to the left of each workspace row for improved visual consistency.
  * Adjusted grid column sizing to optimize list layout.

* **Bug Fixes**
  * Prevented removal action when a workspace is the currently active route.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->