### PR TITLE
[codex] Add diff pane file viewer action

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
@@ -41,9 +41,10 @@ function ScrollToFile({ path }: { path: string }) {
 interface DiffPaneProps {
 	context: RendererContext<PaneViewerData>;
 	workspaceId: string;
+	onOpenFile: (path: string, openInNewTab?: boolean) => void;
 }
 
-export function DiffPane({ context, workspaceId }: DiffPaneProps) {
+export function DiffPane({ context, workspaceId, onOpenFile }: DiffPaneProps) {
 	const data = context.pane.data as DiffPaneData;
 
 	const diffStyle = useSettings((s) => s.diffStyle);
@@ -104,7 +105,8 @@ export function DiffPane({ context, workspaceId }: DiffPaneProps) {
 					onSetCollapsed={setCollapsed}
 					viewed={viewedSet.has(file.path)}
 					onSetViewed={setViewed}
-					onOpenFile={openInExternalEditor}
+					onOpenFile={onOpenFile}
+					onOpenInExternalEditor={openInExternalEditor}
 				/>
 			))}
 		</Virtualizer>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileEntry/DiffFileEntry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileEntry/DiffFileEntry.tsx
@@ -35,7 +35,8 @@ interface DiffFileEntryProps {
 	onSetCollapsed: (path: string, value: boolean) => void;
 	viewed: boolean;
 	onSetViewed: (path: string, next: boolean) => void;
-	onOpenFile: (path: string) => void;
+	onOpenFile: (path: string, openInNewTab?: boolean) => void;
+	onOpenInExternalEditor: (path: string) => void;
 }
 
 export const DiffFileEntry = memo(function DiffFileEntry({
@@ -47,6 +48,7 @@ export const DiffFileEntry = memo(function DiffFileEntry({
 	viewed,
 	onSetViewed,
 	onOpenFile,
+	onOpenInExternalEditor,
 }: DiffFileEntryProps) {
 	const wrapperRef = useRef<HTMLDivElement>(null);
 	const isNear = useInView(wrapperRef, { rootMargin: "2000px 0px" });
@@ -66,15 +68,28 @@ export const DiffFileEntry = memo(function DiffFileEntry({
 		onSetViewed(file.path, next);
 		onSetCollapsed(file.path, next);
 	}, [viewed, file.path, onSetViewed, onSetCollapsed]);
-	const handleOpenFile = useCallback(() => {
+	const showDeletedFileToast = useCallback(() => {
+		toast.error("File no longer exists", {
+			description: `${file.path} was deleted in this change.`,
+		});
+	}, [file.path]);
+	const handleOpenFile = useCallback(
+		(openInNewTab?: boolean) => {
+			if (file.status === "deleted") {
+				showDeletedFileToast();
+				return;
+			}
+			onOpenFile(file.path, openInNewTab);
+		},
+		[file.status, file.path, onOpenFile, showDeletedFileToast],
+	);
+	const handleOpenInExternalEditor = useCallback(() => {
 		if (file.status === "deleted") {
-			toast.error("File no longer exists", {
-				description: `${file.path} was deleted in this change.`,
-			});
+			showDeletedFileToast();
 			return;
 		}
-		onOpenFile(file.path);
-	}, [file.status, file.path, onOpenFile]);
+		onOpenInExternalEditor(file.path);
+	}, [file.status, file.path, onOpenInExternalEditor, showDeletedFileToast]);
 	const handleShowFullDiff = useCallback(() => setShowFullDiff(true), []);
 	const handleToggleExpandUnchanged = useCallback(
 		() => setExpandUnchanged((prev) => !prev),
@@ -103,6 +118,7 @@ export const DiffFileEntry = memo(function DiffFileEntry({
 					viewed={viewed}
 					onToggleViewed={handleToggleViewed}
 					onOpenFile={handleOpenFile}
+					onOpenInExternalEditor={handleOpenInExternalEditor}
 				/>
 			</div>
 		);
@@ -134,6 +150,7 @@ export const DiffFileEntry = memo(function DiffFileEntry({
 					viewed={viewed}
 					onToggleViewed={handleToggleViewed}
 					onOpenFile={handleOpenFile}
+					onOpenInExternalEditor={handleOpenInExternalEditor}
 				/>
 			) : null}
 		</div>
@@ -148,7 +165,8 @@ interface DeferredDiffPlaceholderProps {
 	onToggleCollapsed: () => void;
 	viewed: boolean;
 	onToggleViewed: () => void;
-	onOpenFile?: () => void;
+	onOpenFile?: (openInNewTab?: boolean) => void;
+	onOpenInExternalEditor?: () => void;
 }
 
 function DeferredDiffPlaceholder({
@@ -160,6 +178,7 @@ function DeferredDiffPlaceholder({
 	viewed,
 	onToggleViewed,
 	onOpenFile,
+	onOpenInExternalEditor,
 }: DeferredDiffPlaceholderProps) {
 	const isDeleted = reason === "deleted";
 	const fullHeight = isDeleted
@@ -185,6 +204,7 @@ function DeferredDiffPlaceholder({
 				viewed={viewed}
 				onToggleViewed={onToggleViewed}
 				onOpenFile={onOpenFile}
+				onOpenInExternalEditor={onOpenInExternalEditor}
 			/>
 			{!collapsed && (
 				<div

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileHeader/DiffFileHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileHeader/DiffFileHeader.tsx
@@ -1,9 +1,17 @@
 import { Checkbox } from "@superset/ui/checkbox";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
-import { ChevronDown, ChevronRight, Eye, EyeOff } from "lucide-react";
+import {
+	ChevronDown,
+	ChevronRight,
+	ExternalLink,
+	Eye,
+	EyeOff,
+} from "lucide-react";
 import { useId } from "react";
 import { LuCopy, LuUndo2 } from "react-icons/lu";
 import { StatusIndicator } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/StatusIndicator";
+import { CLICK_HINT_TOOLTIP } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/clickModifierLabels";
+import { getSidebarClickIntent } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/getSidebarClickIntent";
 import { FileIcon } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils";
 
 interface DiffFileHeaderProps {
@@ -17,7 +25,8 @@ interface DiffFileHeaderProps {
 	onToggleCollapsed: () => void;
 	viewed: boolean;
 	onToggleViewed: () => void;
-	onOpenFile?: () => void;
+	onOpenFile?: (openInNewTab?: boolean) => void;
+	onOpenInExternalEditor?: () => void;
 	onCopyContents?: () => void;
 	onDiscard?: () => void;
 }
@@ -34,6 +43,7 @@ export function DiffFileHeader({
 	viewed,
 	onToggleViewed,
 	onOpenFile,
+	onOpenInExternalEditor,
 	onCopyContents,
 	onDiscard,
 }: DiffFileHeaderProps) {
@@ -58,8 +68,16 @@ export function DiffFileHeader({
 				<TooltipTrigger asChild>
 					<button
 						type="button"
-						onClick={onOpenFile}
-						disabled={!onOpenFile}
+						onClick={(event) => {
+							const intent = getSidebarClickIntent(event);
+							if (intent === "openInEditor") {
+								onOpenInExternalEditor?.();
+								return;
+							}
+							onOpenFile?.(intent === "openInNewTab");
+						}}
+						disabled={!onOpenFile && !onOpenInExternalEditor}
+						aria-label="Open in file viewer"
 						className="flex min-w-0 flex-1 items-center gap-2 rounded border border-border px-2 py-1 text-left transition-colors hover:bg-accent disabled:pointer-events-none disabled:opacity-60"
 					>
 						<FileIcon fileName={path} className="size-4 shrink-0" />
@@ -82,11 +100,32 @@ export function DiffFileHeader({
 					</button>
 				</TooltipTrigger>
 				<TooltipContent side="bottom" showArrow={false}>
-					Open {path}
+					Open in file viewer. {CLICK_HINT_TOOLTIP}
 				</TooltipContent>
 			</Tooltip>
 
 			<div className="flex shrink-0 items-center gap-2">
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<span className="inline-flex rounded">
+							<button
+								type="button"
+								onClick={onOpenInExternalEditor}
+								disabled={!onOpenInExternalEditor}
+								aria-label="Open in editor"
+								className="rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-40"
+							>
+								<ExternalLink className="size-3.5" />
+							</button>
+						</span>
+					</TooltipTrigger>
+					<TooltipContent side="bottom" showArrow={false}>
+						{onOpenInExternalEditor
+							? "Open in editor"
+							: "Open in editor unavailable"}
+					</TooltipContent>
+				</Tooltip>
+
 				<div className="flex items-center gap-1.5">
 					<Checkbox
 						id={viewedId}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/WorkspaceDiff/WorkspaceDiff.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/WorkspaceDiff/WorkspaceDiff.tsx
@@ -27,7 +27,8 @@ interface WorkspaceDiffProps {
 	onToggleCollapsed: () => void;
 	viewed: boolean;
 	onToggleViewed: () => void;
-	onOpenFile?: () => void;
+	onOpenFile?: (openInNewTab?: boolean) => void;
+	onOpenInExternalEditor?: () => void;
 }
 
 export const WorkspaceDiff = memo(function WorkspaceDiff({
@@ -45,6 +46,7 @@ export const WorkspaceDiff = memo(function WorkspaceDiff({
 	viewed,
 	onToggleViewed,
 	onOpenFile,
+	onOpenInExternalEditor,
 }: WorkspaceDiffProps) {
 	const activeTheme = useResolvedTheme();
 	const { data: fontSettings } = useQuery({
@@ -151,6 +153,7 @@ export const WorkspaceDiff = memo(function WorkspaceDiff({
 				viewed={viewed}
 				onToggleViewed={onToggleViewed}
 				onOpenFile={onOpenFile}
+				onOpenInExternalEditor={onOpenInExternalEditor}
 				onCopyContents={handleCopyContents}
 				onDiscard={handleDiscard}
 			/>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -225,7 +225,11 @@ export function usePaneRegistry(
 				getIcon: () => <GitCompareArrows className="size-4" />,
 				getTitle: () => "Changes",
 				renderPane: (ctx: RendererContext<PaneViewerData>) => (
-					<DiffPane context={ctx} workspaceId={workspaceId} />
+					<DiffPane
+						context={ctx}
+						workspaceId={workspaceId}
+						onOpenFile={onOpenFile}
+					/>
 				),
 				renderHeaderExtras: () => <DiffViewModeToggle />,
 				contextMenuActions: (_ctx, defaults) =>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -177,11 +177,16 @@ function WorkspaceContent({
 
 	const openFilePane = useCallback(
 		(filePath: string, openInNewTab?: boolean) => {
+			const absoluteFilePath = worktreePath
+				? toAbsoluteWorkspacePath(worktreePath, filePath)
+				: filePath;
 			if (worktreePath) {
-				const absolutePath = toAbsoluteWorkspacePath(worktreePath, filePath);
-				const relativePath = toRelativeWorkspacePath(worktreePath, filePath);
+				const relativePath = toRelativeWorkspacePath(
+					worktreePath,
+					absoluteFilePath,
+				);
 				if (relativePath && relativePath !== ".") {
-					recordView({ relativePath, absolutePath });
+					recordView({ relativePath, absolutePath: absoluteFilePath });
 				}
 			}
 			const state = store.getState();
@@ -191,7 +196,7 @@ function WorkspaceContent({
 						{
 							kind: "file",
 							data: {
-								filePath,
+								filePath: absoluteFilePath,
 								mode: "editor",
 							} as FilePaneData,
 						},
@@ -202,7 +207,7 @@ function WorkspaceContent({
 			const active = state.getActivePane();
 			if (
 				active?.pane.kind === "file" &&
-				(active.pane.data as FilePaneData).filePath === filePath
+				(active.pane.data as FilePaneData).filePath === absoluteFilePath
 			) {
 				state.setPanePinned({ paneId: active.pane.id, pinned: true });
 				return;
@@ -211,7 +216,7 @@ function WorkspaceContent({
 				pane: {
 					kind: "file",
 					data: {
-						filePath,
+						filePath: absoluteFilePath,
 						mode: "editor",
 					} as FilePaneData,
 				},


### PR DESCRIPTION
## Summary
- Make the v2 diff file path chip open files in Superset's built-in file viewer.
- Preserve Shift-click behavior by opening the file viewer in a new tab.
- Add a separate external-link action for opening the changed file in the configured editor.
- Normalize v2 file-pane opens to absolute paths so relative diff paths work with the shared file document store.

## Validation
- `bunx @biomejs/biome@2.4.2 check <touched files>`
- `bun run --cwd apps/desktop typecheck`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clicking a file in the v2 Diff pane now opens it in the built‑in file viewer, with Shift‑click opening in a new tab. An external‑link button and modifier‑click open the file in your editor; opens use absolute paths for consistent view history, deleted files show a clear toast, and reopening an already‑active file pins its pane.

<sup>Written for commit 457516a9067413cddb87e8bfd340250497bdc682. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modifier-click (e.g., Shift+click) opens diff files in a new viewer tab.
  * “Open in file viewer” control added; separate “Open in editor” control launches external editor.
  * External-editor action exposed so the app can route opens to external editors when available.

* **Bug Fixes**
  * Unified handling for deleted files shows “File no longer exists” and blocks opens.
  * File paths normalized to prevent mixed-path mismatches when opening or pinning panes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->