### PR TITLE
Fix long workspace titles on creation error page

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceInitializingView/WorkspaceInitializingView.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceInitializingView/WorkspaceInitializingView.tsx
@@ -120,7 +120,12 @@ export function WorkspaceInitializingView({
 							<h2 className="text-lg font-medium text-foreground">
 								Setup incomplete
 							</h2>
-							<p className="text-sm text-muted-foreground">{workspaceName}</p>
+							<p
+								className="line-clamp-3 max-w-full break-words text-sm text-muted-foreground [overflow-wrap:anywhere]"
+								title={workspaceName}
+							>
+								{workspaceName}
+							</p>
 							<p className="text-xs text-muted-foreground/80 mt-2">
 								Workspace setup didn't finish. You can retry or remove it.
 							</p>
@@ -211,7 +216,12 @@ export function WorkspaceInitializingView({
 							<h2 className="text-lg font-medium text-foreground">
 								Workspace setup failed
 							</h2>
-							<p className="text-sm text-muted-foreground">{workspaceName}</p>
+							<p
+								className="line-clamp-3 max-w-full break-words text-sm text-muted-foreground [overflow-wrap:anywhere]"
+								title={workspaceName}
+							>
+								{workspaceName}
+							</p>
 							{progress?.error && (
 								<p className="text-xs text-destructive/80 mt-2 bg-destructive/5 rounded-md px-3 py-2 select-text cursor-text break-words">
 									{progress.error}


### PR DESCRIPTION
## Summary
- Clamp long workspace names on the setup incomplete and setup failed states
- Preserve the full title in the native tooltip

Fixes SUPER-440

## Verification
- bunx biome check --write apps/desktop/src/renderer/screens/main/components/WorkspaceView/WorkspaceInitializingView/WorkspaceInitializingView.tsx
- bun --cwd apps/desktop typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes overflow from long workspace names on the "Setup incomplete" and "Workspace setup failed" views by clamping to 3 lines and breaking long words. The full name is still shown on hover via the title tooltip. Addresses SUPER-440.

<sup>Written for commit e7ee21a3c8247c3ab2df3290ce1b44ca139ad771. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace name display during initialization errors and interruptions with enhanced text wrapping and truncation handling.
  * Added hover tooltip support to reveal full workspace name when truncated in error states.

* **Style**
  * Refined visual presentation of workspace name rendering for edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->