### PR TITLE
Fix terminal panes after session exit

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -22,6 +22,7 @@ import {
 	sendDispose,
 	sendInput,
 	sendResize,
+	type TerminalExitEvent,
 	type TerminalTransport,
 } from "./terminal-ws-transport";
 
@@ -248,6 +249,17 @@ class TerminalRuntimeRegistryImpl {
 			entry.transport.stateListeners.delete(listener);
 		};
 	}
+
+	onExit(
+		terminalId: string,
+		listener: (event: TerminalExitEvent) => void,
+	): () => void {
+		const entry = this.getOrCreateEntry(terminalId);
+		entry.transport.exitListeners.add(listener);
+		return () => {
+			entry.transport.exitListeners.delete(listener);
+		};
+	}
 }
 
 // In dev, preserve the singleton across Vite HMR so active WebSocket
@@ -262,4 +274,9 @@ if (import.meta.hot) {
 	import.meta.hot.data.registry = terminalRuntimeRegistry;
 }
 
-export type { ConnectionState, LinkHoverInfo, TerminalLinkHandlers };
+export type {
+	ConnectionState,
+	LinkHoverInfo,
+	TerminalExitEvent,
+	TerminalLinkHandlers,
+};

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import type { Terminal as XTerm } from "@xterm/xterm";
+import {
+	connect,
+	createTransport,
+	disposeTransport,
+	type TerminalExitEvent,
+} from "./terminal-ws-transport";
+
+type FakeSocketEvent = { data?: string };
+type FakeSocketListener = (event: FakeSocketEvent) => void;
+
+class FakeWebSocket {
+	static readonly OPEN = 1;
+	static instances: FakeWebSocket[] = [];
+
+	readyState = FakeWebSocket.OPEN;
+	readonly listeners = new Map<string, FakeSocketListener[]>();
+	readonly sent: string[] = [];
+
+	constructor(readonly url: string) {
+		FakeWebSocket.instances.push(this);
+	}
+
+	addEventListener(type: string, listener: FakeSocketListener) {
+		const listeners = this.listeners.get(type) ?? [];
+		listeners.push(listener);
+		this.listeners.set(type, listeners);
+	}
+
+	close() {
+		this.readyState = 3;
+	}
+
+	send(data: string) {
+		this.sent.push(data);
+	}
+
+	emit(type: string, event: FakeSocketEvent = {}) {
+		for (const listener of this.listeners.get(type) ?? []) {
+			listener(event);
+		}
+	}
+}
+
+const originalWebSocket = globalThis.WebSocket;
+
+function installFakeWebSocket() {
+	(globalThis as { WebSocket: typeof WebSocket }).WebSocket =
+		FakeWebSocket as unknown as typeof WebSocket;
+}
+
+function createTerminal() {
+	return {
+		cols: 80,
+		rows: 24,
+		write: mock(() => {}),
+		writeln: mock(() => {}),
+		onData: mock(() => ({ dispose: mock(() => {}) })),
+	} as unknown as XTerm;
+}
+
+describe("terminal-ws-transport", () => {
+	afterEach(() => {
+		(globalThis as { WebSocket: typeof WebSocket }).WebSocket =
+			originalWebSocket;
+		FakeWebSocket.instances = [];
+	});
+
+	it("notifies exit listeners when the server reports terminal exit", () => {
+		installFakeWebSocket();
+		const transport = createTransport();
+		const exitEvents: TerminalExitEvent[] = [];
+		const onExit = mock((event: TerminalExitEvent) => {
+			exitEvents.push(event);
+		});
+		transport.exitListeners.add(onExit);
+
+		connect(transport, createTerminal(), "ws://terminal.test/session");
+		const socket = FakeWebSocket.instances[0];
+		expect(socket).toBeDefined();
+
+		socket?.emit("message", {
+			data: JSON.stringify({ type: "exit", exitCode: 0, signal: 0 }),
+		});
+
+		expect(onExit).toHaveBeenCalledTimes(1);
+		expect(exitEvents).toEqual([{ exitCode: 0, signal: 0 }]);
+
+		disposeTransport(transport);
+	});
+});

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -2,6 +2,11 @@ import type { Terminal as XTerm } from "@xterm/xterm";
 
 export type ConnectionState = "disconnected" | "connecting" | "open" | "closed";
 
+export interface TerminalExitEvent {
+	exitCode: number;
+	signal: number;
+}
+
 type TerminalServerMessage =
 	| { type: "data"; data: string }
 	| { type: "error"; message: string }
@@ -15,6 +20,7 @@ export interface TerminalTransport {
 	currentUrl: string | null;
 	onDataDisposable: { dispose(): void } | null;
 	stateListeners: Set<() => void>;
+	exitListeners: Set<(event: TerminalExitEvent) => void>;
 	/** Internal: auto-reconnect timer. */
 	_reconnectTimer: ReturnType<typeof setTimeout> | null;
 	/** Internal: reconnect attempt count for backoff. */
@@ -35,6 +41,12 @@ function setConnectionState(
 	}
 }
 
+function emitExit(transport: TerminalTransport, event: TerminalExitEvent) {
+	for (const listener of Array.from(transport.exitListeners)) {
+		listener(event);
+	}
+}
+
 const MAX_RECONNECT_DELAY = 10_000;
 const BASE_RECONNECT_DELAY = 500;
 const MAX_RECONNECT_ATTEMPTS = 10;
@@ -46,6 +58,7 @@ export function createTransport(): TerminalTransport {
 		currentUrl: null,
 		onDataDisposable: null,
 		stateListeners: new Set(),
+		exitListeners: new Set(),
 		_reconnectTimer: null,
 		_reconnectAttempt: 0,
 		_terminal: null,
@@ -141,6 +154,10 @@ export function connect(
 			terminal.writeln(
 				`\r\n[terminal] exited with code ${message.exitCode} (signal ${message.signal})`,
 			);
+			emitExit(transport, {
+				exitCode: message.exitCode,
+				signal: message.signal,
+			});
 		}
 	});
 
@@ -212,4 +229,5 @@ export function disposeTransport(transport: TerminalTransport) {
 	transport.onDataDisposable?.dispose();
 	transport.onDataDisposable = null;
 	transport.stateListeners.clear();
+	transport.exitListeners.clear();
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -82,6 +82,8 @@ export function TerminalPane({
 	const ensureSession = workspaceTrpc.terminal.ensureSession.useMutation();
 	const ensureSessionRef = useRef(ensureSession);
 	ensureSessionRef.current = ensureSession;
+	const updatePaneDataRef = useRef(ctx.actions.updateData);
+	updatePaneDataRef.current = ctx.actions.updateData;
 
 	// useCallback so useSyncExternalStore doesn't re-subscribe every render —
 	// otherwise every keystroke-triggered re-render unsubscribes and
@@ -98,6 +100,15 @@ export function TerminalPane({
 		[terminalId],
 	);
 	const connectionState = useSyncExternalStore(subscribe, getSnapshot);
+
+	useEffect(() => {
+		return terminalRuntimeRegistry.onExit(terminalId, () => {
+			terminalRuntimeRegistry.dispose(terminalId);
+			updatePaneDataRef.current({
+				terminalId: crypto.randomUUID(),
+			} as PaneViewerData);
+		});
+	}, [terminalId]);
 
 	// DOM-first lifecycle (VSCode/Tabby pattern):
 	//   1. mount() attaches xterm to the container synchronously — terminal


### PR DESCRIPTION
## Description

Refresh v2 terminal panes when the underlying terminal session exits. The terminal transport now emits explicit exit events, the runtime registry exposes an `onExit` subscription, and `TerminalPane` disposes the dead runtime before replacing its pane data with a fresh `terminalId`.

This keeps killed or naturally exited terminal sessions from leaving a dead pane attached to the old session.

## Related Issues

Fixes https://linear.app/superset-sh/issue/SUPER-483/killing-a-terminal-pane-doesnt-clean-it-up-refresh-it-with-a-new

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

- `bun test apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts`
- `bun run --cwd apps/desktop typecheck`
- `bunx @biomejs/biome@2.4.2 check --write apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts`
- `bunx react-doctor@latest . --verbose --diff` (99/100; only existing TerminalPane size/map-filter warnings)

## Screenshots (if applicable)

N/A

## Additional Notes

The pane refresh happens from the backend `exit` message while the pane is still mounted. Closing a terminal pane still removes the pane normally and does not recreate it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Terminal panes now auto-refresh when the underlying session exits, replacing dead panes with a new `terminalId`. Fixes Linear SUPER-483.

- **Bug Fixes**
  - `terminal-ws-transport`: emit `exit` events via `TerminalExitEvent` and notify listeners.
  - `terminal-runtime-registry`: add `onExit(terminalId, listener)` to subscribe to exit events.
  - `TerminalPane`: on exit, dispose the old runtime and update pane data with a new `terminalId`.
  - Added tests to verify exit notifications and cleanup behavior.

<sup>Written for commit 98fea9528295ab3644da4ce65b098b0c978d6c0f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal sessions now automatically cleanup and refresh when they exit.
  * Introduced exit event subscription API for monitoring terminal session lifecycle changes.

* **Tests**
  * Added comprehensive test coverage for terminal exit event handling and proper disposal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->