### PR TITLE
[codex] remove pending launch log

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useConsumePendingLaunch/useConsumePendingLaunch.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useConsumePendingLaunch/useConsumePendingLaunch.ts
@@ -62,9 +62,6 @@ export function useConsumePendingLaunch({
 
 	useEffect(() => {
 		if (!pending) {
-			console.log("[v2-launch] useConsumePendingLaunch: no pending row yet", {
-				workspaceId,
-			});
 			return;
 		}
 


### PR DESCRIPTION
## Summary

Remove the noisy `[v2-launch] useConsumePendingLaunch: no pending row yet` console log from the V2 workspace pending-launch consumer.

## Impact

This reduces console noise while preserving the remaining launch diagnostics for actual pending rows and consumption events.

## Validation

- `rg "\[v2-launch\] useConsumePendingLaunch: no pending row yet|no pending row yet"`
- `bun run lint`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the noisy “[v2-launch] useConsumePendingLaunch: no pending row yet” console log in the V2 workspace pending-launch consumer. This reduces console noise while keeping diagnostics for actual pending rows.

<sup>Written for commit a6b69e5c5f4e1a286778cf7e9bd94eeed0b7d30b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor internal optimization and cleanup to enhance application stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->