### PR TITLE
[codex] Fix host service restart adoption

### DIFF
--- a/apps/desktop/src/main/lib/host-service-coordinator.test.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.test.ts
@@ -1,0 +1,173 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import * as actualChildProcess from "node:child_process";
+import { EventEmitter } from "node:events";
+
+interface SpawnOptions {
+	detached?: boolean;
+	stdio?: unknown;
+	windowsHide?: boolean;
+	env?: Record<string, string>;
+}
+
+interface SpawnCall {
+	command: string;
+	args: string[];
+	options: SpawnOptions;
+}
+
+interface TestManifest {
+	pid: number;
+	endpoint: string;
+	authToken: string;
+	startedAt: number;
+	organizationId: string;
+}
+
+const spawnCalls: SpawnCall[] = [];
+const unrefMock = mock(() => {});
+let currentManifest: TestManifest | null = null;
+let manifestProcessAlive = false;
+let hostInfoVersion = "0.2.0";
+
+const originalFetch = globalThis.fetch;
+const fetchMock = mock(() =>
+	Promise.resolve(
+		new Response(
+			JSON.stringify({
+				result: { data: { json: { version: hostInfoVersion } } },
+			}),
+			{ status: 200 },
+		),
+	),
+);
+
+class MockChildProcess extends EventEmitter {
+	pid = 4242;
+	stdout = new EventEmitter();
+	stderr = new EventEmitter();
+	unref = unrefMock;
+	kill = mock(() => true);
+}
+
+const spawnMock = mock(
+	(command: string, args: string[], options: SpawnOptions) => {
+		spawnCalls.push({ command, args, options });
+		return new MockChildProcess();
+	},
+);
+
+mock.module("node:child_process", () => ({
+	...actualChildProcess,
+	spawn: spawnMock,
+}));
+
+mock.module("@superset/shared/device-info", () => ({
+	getDeviceName: () => "Test Device",
+	getHashedDeviceId: () => "test-machine-id",
+}));
+
+mock.module("../../lib/trpc/routers/workspaces/utils/shell-env", () => ({
+	getProcessEnvWithShellPath: async (env: Record<string, string>) => env,
+}));
+
+mock.module("./host-service-manifest", () => ({
+	isProcessAlive: () => manifestProcessAlive,
+	listManifests: () => [],
+	manifestDir: () => "/tmp/superset-host-service-test",
+	readManifest: () => currentManifest,
+	removeManifest: () => {},
+}));
+
+mock.module("./host-service-utils", () => ({
+	findFreePort: async () => 45123,
+	HEALTH_POLL_TIMEOUT_MS: 10_000,
+	MAX_HOST_LOG_BYTES: 5 * 1024 * 1024,
+	openRotatingLogFd: () => -1,
+	pollHealthCheck: async () => true,
+}));
+
+const { HostServiceCoordinator } = await import("./host-service-coordinator");
+
+describe("HostServiceCoordinator", () => {
+	beforeEach(() => {
+		spawnCalls.length = 0;
+		currentManifest = null;
+		manifestProcessAlive = false;
+		hostInfoVersion = "0.2.0";
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+		spawnMock.mockClear();
+		unrefMock.mockClear();
+		fetchMock.mockClear();
+	});
+
+	afterAll(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	test("spawns host-service detached so v2 PTYs survive Electron restarts", async () => {
+		const coordinator = new HostServiceCoordinator();
+
+		await coordinator.start("org-1", {
+			authToken: "auth-token",
+			cloudApiUrl: "https://api.superset.test",
+		});
+
+		expect(spawnMock).toHaveBeenCalledTimes(1);
+		expect(spawnCalls[0]?.options.detached).toBe(true);
+		expect(spawnCalls[0]?.options.stdio).toEqual([
+			"ignore",
+			"ignore",
+			"ignore",
+		]);
+		expect(unrefMock).toHaveBeenCalledTimes(1);
+	});
+
+	test("adopts an existing superjson host.info service instead of killing it", async () => {
+		currentManifest = {
+			pid: 999_999,
+			endpoint: "http://127.0.0.1:45123",
+			authToken: "existing-secret",
+			startedAt: Date.now(),
+			organizationId: "org-1",
+		};
+		manifestProcessAlive = true;
+		const coordinator = new HostServiceCoordinator();
+
+		const connection = await coordinator.start("org-1", {
+			authToken: "auth-token",
+			cloudApiUrl: "https://api.superset.test",
+		});
+
+		expect(connection).toEqual({
+			port: 45123,
+			secret: "existing-secret",
+			machineId: "test-machine-id",
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(spawnMock).not.toHaveBeenCalled();
+	});
+
+	test("rejects an adopted host-service below the minimum version and spawns a replacement", async () => {
+		currentManifest = {
+			pid: 999_999,
+			endpoint: "http://127.0.0.1:45123",
+			authToken: "old-secret",
+			startedAt: Date.now(),
+			organizationId: "org-1",
+		};
+		manifestProcessAlive = true;
+		hostInfoVersion = "0.1.0";
+		const coordinator = new HostServiceCoordinator();
+
+		const connection = await coordinator.start("org-1", {
+			authToken: "auth-token",
+			cloudApiUrl: "https://api.superset.test",
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(spawnMock).toHaveBeenCalledTimes(1);
+		expect(spawnCalls[0]?.options.detached).toBe(true);
+		expect(connection.port).toBe(45123);
+		expect(connection.secret).not.toBe("old-secret");
+	});
+});

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -341,7 +341,8 @@ export class HostServiceCoordinator extends EventEmitter {
 			clearTimeout(timeout);
 			if (!response.ok) return null;
 			const data = await response.json();
-			return data?.result?.data?.version ?? null;
+			const result = data?.result?.data;
+			return result?.json?.version ?? result?.version ?? null;
 		} catch {
 			return null;
 		}
@@ -380,35 +381,21 @@ export class HostServiceCoordinator extends EventEmitter {
 		this.emitStatus(organizationId, "starting", null);
 
 		const childEnv = await this.buildEnv(organizationId, port, secret, config);
-		// Gate on app.isPackaged — the authoritative "running from an installed
-		// bundle" signal. NODE_ENV is ambient (shell, wrappers, debug launches)
-		// and could silently flip detach off in a packaged app, which would
-		// re-introduce the exact Squirrel kill-chain this file exists to fix.
-		const isPackaged = app.isPackaged;
-
-		// In packaged builds, detach so the child survives app relaunch:
-		// auto-updater's quitAndInstall would otherwise take the host-service
-		// (and its PTYs) down with the old app's process group. Stdio must
-		// point at real fds — piped stdio would EPIPE once the parent exits.
-		// Unpackaged (dev) keeps pipes so logs flow to the Electron console;
-		// enableDevReload restarts instances on rebuild, so survival isn't
-		// needed.
-		const logFd = isPackaged
-			? openRotatingLogFd(
-					path.join(manifestDir(organizationId), "host-service.log"),
-					MAX_HOST_LOG_BYTES,
-				)
-			: -1;
-		const stdio: childProcess.StdioOptions = !isPackaged
-			? ["ignore", "pipe", "pipe"]
-			: logFd >= 0
-				? ["ignore", logFd, logFd]
-				: ["ignore", "ignore", "ignore"];
+		// Host-service owns v2 PTYs, so it must survive Electron restarts in
+		// every environment. This mirrors the terminal-host daemon: detach the
+		// child and back stdio with real files so parent teardown cannot close
+		// pipes and take the service down with the app.
+		const logFd = openRotatingLogFd(
+			path.join(manifestDir(organizationId), "host-service.log"),
+			MAX_HOST_LOG_BYTES,
+		);
+		const stdio: childProcess.StdioOptions =
+			logFd >= 0 ? ["ignore", logFd, logFd] : ["ignore", "ignore", "ignore"];
 
 		let child: ReturnType<typeof childProcess.spawn>;
 		try {
 			child = childProcess.spawn(process.execPath, [this.scriptPath], {
-				detached: isPackaged,
+				detached: true,
 				stdio,
 				env: childEnv,
 				// Avoid a flashing CMD window on Windows for the detached child.
@@ -431,19 +418,6 @@ export class HostServiceCoordinator extends EventEmitter {
 		}
 
 		instance.pid = childPid;
-
-		if (!isPackaged) {
-			child.stdout?.on("data", (data: Buffer) => {
-				console.log(
-					`[host-service:${organizationId}] ${data.toString().trim()}`,
-				);
-			});
-			child.stderr?.on("data", (data: Buffer) => {
-				console.error(
-					`[host-service:${organizationId}] ${data.toString().trim()}`,
-				);
-			});
-		}
 		child.on("exit", (code) => {
 			console.log(`[host-service:${organizationId}] exited with code ${code}`);
 			const current = this.instances.get(organizationId);


### PR DESCRIPTION
## Summary

Fixes v2 host-service lifecycle across Electron quits/restarts so host-service-owned PTYs can be re-adopted instead of being killed or replaced unnecessarily.

## Root Cause

Two lifecycle paths diverged from the terminal daemon behavior:

- The coordinator parsed `host.info` as `result.data.version`, but host-service tRPC responses are superjson-wrapped under `result.data.json`. Healthy services were treated as `version unknown`, failed the minimum-version adoption gate, and were killed on restart.
- Host-service children were only detached in packaged builds. In dev/unpackaged runs, Electron parent teardown could still close stdio/process-group state and take the host service, and its PTYs, down with the app.

## Changes

- Read host-service version from both current superjson response shape and the legacy direct shape.
- Always spawn host-service detached with file-backed stdio, mirroring the terminal-host daemon survival model.
- Add coordinator regression tests for detached spawning, successful adoption of compatible services, and replacement of services below `MIN_HOST_SERVICE_VERSION`.

## Validation

- `bun test ./src/main/lib/host-service-coordinator.test.ts`
- `bun run typecheck`
- `bunx biome check --write apps/desktop/src/main/lib/host-service-coordinator.ts apps/desktop/src/main/lib/host-service-coordinator.test.ts`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the v2 host-service survives Electron restarts and is re-adopted instead of being killed, so existing PTYs persist. Fix version detection and spawn behavior to mirror the terminal-host daemon.

- **Bug Fixes**
  - Read host-service version from both `result.data.json.version` (superjson) and legacy `result.data.version`, so healthy services pass the minimum-version check.
  - Always spawn the host-service detached with file-backed stdio across all builds to prevent parent teardown from killing the service.
  - Added coordinator tests for detached spawning, adoption of compatible services, and replacement when below `MIN_HOST_SERVICE_VERSION`.

<sup>Written for commit 7d939923a0a75ed19bcfeb7c0a7cdd759b2cb199. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host version detection to handle additional response formats for better compatibility.

* **Chores**
  * Enhanced host-service process management for consistency across all environments.
  * Refined logging configuration to use optimized file descriptors for improved diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->