### PR TITLE
fix(desktop): drop branch row from v2 sidebar workspace item

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -122,7 +122,7 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 					"relative flex w-full items-center pl-3 pr-2 text-left text-sm",
 					onClick && "cursor-pointer hover:bg-muted/50",
 					"group",
-					"py-1.5",
+					"py-2",
 					isActive && "bg-muted",
 					className,
 				)}
@@ -211,86 +211,80 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 					</TooltipContent>
 				</Tooltip>
 
-				<div className="flex min-w-0 flex-1 flex-col justify-center">
-					<div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] grid-rows-2 items-center gap-x-1.5 gap-y-0.5">
-						{isRenaming ? (
-							<RenameInput
-								value={renameValue}
-								onChange={onRenameValueChange}
-								onSubmit={onSubmitRename}
-								onCancel={onCancelRename}
-								className={cn(
-									"h-5 w-full -ml-1 border-none bg-transparent px-1 py-0 text-[13px] leading-tight outline-none",
-								)}
-							/>
-						) : (
+				<div className="grid min-w-0 flex-1 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-1.5">
+					{isRenaming ? (
+						<RenameInput
+							value={renameValue}
+							onChange={onRenameValueChange}
+							onSubmit={onSubmitRename}
+							onCancel={onCancelRename}
+							className={cn(
+								"h-5 w-full -ml-1 border-none bg-transparent px-1 py-0 text-[13px] leading-tight outline-none",
+							)}
+						/>
+					) : (
+						<span
+							className={cn(
+								"truncate text-[13px] leading-tight transition-colors",
+								isActive ? "text-foreground" : "text-foreground/80",
+							)}
+						>
+							{name || branch}
+						</span>
+					)}
+
+					<div className="col-start-2 row-start-1 grid h-5 shrink-0 items-center [&>*]:col-start-1 [&>*]:row-start-1">
+						{creationStatusText ? (
 							<span
 								className={cn(
-									"truncate text-[13px] leading-tight transition-colors",
-									isActive ? "text-foreground" : "text-foreground/80",
+									"text-[11px]",
+									creationStatus === "failed"
+										? "text-destructive"
+										: "text-muted-foreground",
 								)}
 							>
-								{name || branch}
+								{creationStatusText}
 							</span>
-						)}
-
-						<div className="col-start-2 row-start-1 grid h-5 shrink-0 items-center [&>*]:col-start-1 [&>*]:row-start-1">
-							{creationStatusText ? (
-								<span
-									className={cn(
-										"text-[11px]",
-										creationStatus === "failed"
-											? "text-destructive"
-											: "text-muted-foreground",
+						) : (
+							<>
+								{diffStats &&
+									(diffStats.additions > 0 || diffStats.deletions > 0) && (
+										<DashboardSidebarWorkspaceDiffStats
+											additions={diffStats.additions}
+											deletions={diffStats.deletions}
+											isActive={isActive}
+										/>
 									)}
-								>
-									{creationStatusText}
-								</span>
-							) : (
-								<>
-									{diffStats &&
-										(diffStats.additions > 0 || diffStats.deletions > 0) && (
-											<DashboardSidebarWorkspaceDiffStats
-												additions={diffStats.additions}
-												deletions={diffStats.deletions}
-												isActive={isActive}
+								<div className="invisible flex items-center justify-end gap-1.5 opacity-0 transition-[opacity,visibility] group-hover:visible group-hover:opacity-100">
+									{shortcutLabel && (
+										<span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground">
+											{shortcutLabel}
+										</span>
+									)}
+									<Tooltip delayDuration={300}>
+										<TooltipTrigger asChild>
+											<button
+												type="button"
+												onClick={(event) => {
+													event.stopPropagation();
+													onDeleteClick();
+												}}
+												className="flex items-center justify-center text-muted-foreground hover:text-foreground"
+												aria-label="Close workspace"
+											>
+												<HiMiniXMark className="size-3.5" />
+											</button>
+										</TooltipTrigger>
+										<TooltipContent side="top" sideOffset={4}>
+											<HotkeyLabel
+												label="Close workspace"
+												id={isActive ? "CLOSE_WORKSPACE" : undefined}
 											/>
-										)}
-									<div className="invisible flex items-center justify-end gap-1.5 opacity-0 transition-[opacity,visibility] group-hover:visible group-hover:opacity-100">
-										{shortcutLabel && (
-											<span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground">
-												{shortcutLabel}
-											</span>
-										)}
-										<Tooltip delayDuration={300}>
-											<TooltipTrigger asChild>
-												<button
-													type="button"
-													onClick={(event) => {
-														event.stopPropagation();
-														onDeleteClick();
-													}}
-													className="flex items-center justify-center text-muted-foreground hover:text-foreground"
-													aria-label="Close workspace"
-												>
-													<HiMiniXMark className="size-3.5" />
-												</button>
-											</TooltipTrigger>
-											<TooltipContent side="top" sideOffset={4}>
-												<HotkeyLabel
-													label="Close workspace"
-													id={isActive ? "CLOSE_WORKSPACE" : undefined}
-												/>
-											</TooltipContent>
-										</Tooltip>
-									</div>
-								</>
-							)}
-						</div>
-
-						<span className="col-start-1 row-start-2 truncate font-mono text-[11px] leading-tight text-muted-foreground/60">
-							{branch}
-						</span>
+										</TooltipContent>
+									</Tooltip>
+								</div>
+							</>
+						)}
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
## Summary
- Removes the second row (branch name) from each v2 sidebar workspace item; the first row already falls back to `branch` when `name` is missing.
- Collapses the now-redundant `flex-col` wrapper into the inner grid.
- Bumps row vertical padding from `py-1.5` to `py-2` for a touch more breathing room.

## Test plan
- [ ] Sidebar workspace rows show a single line with the workspace name
- [ ] Workspaces without a custom name still display their branch
- [ ] Hover, active state, rename input, diff stats, close button, and creation status text still render correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies the v2 sidebar workspace row by removing the redundant branch line; the main label already falls back to the branch when no name is set. Cleans up the layout and slightly increases vertical padding for better readability, with no functional changes.

- **Refactors**
  - Dropped the second-line branch text; keep a single-line label (name or branch).
  - Merged the outer flex column into the inner grid.
  - Increased row padding from py-1.5 to py-2.
  - Preserved hover, active, rename, diff stats, close, and creation status behaviors.

<sup>Written for commit e386c69048be534d7c72b29c03d2f11a2a62f8c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved workspace sidebar row layout with adjusted spacing and better organization of workspace information display for enhanced visual hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->