### PR TITLE
feat(desktop): add fade-edge mask utilities

### DIFF
--- a/apps/desktop/src/renderer/globals.css
+++ b/apps/desktop/src/renderer/globals.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "streamdown/styles.css";
+@import "./styles/fade-edge.css";
 
 @source "./**/*.{ts,tsx}";
 @source "../../../../packages/ui/src/**/*.{ts,tsx}";

--- a/apps/desktop/src/renderer/styles/fade-edge.css
+++ b/apps/desktop/src/renderer/styles/fade-edge.css
@@ -20,6 +20,7 @@
 		--fade-edge-r-size: 0px;
 		--fade-edge-b-size: 0px;
 		--fade-edge-l-size: 0px;
+
 		mask-image:
 			linear-gradient(
 				to bottom,

--- a/apps/desktop/src/renderer/styles/fade-edge.css
+++ b/apps/desktop/src/renderer/styles/fade-edge.css
@@ -1,0 +1,69 @@
+/**
+ * Edge-fade mask utilities.
+ *
+ * Fades out one or more edges of an element via a linear-gradient mask.
+ * Composable: `class="fade-edge-r fade-edge-b"` fades both edges.
+ * Override the fade size per element with `[--fade-edge-size:2rem]`.
+ *
+ * NOTE: This is a generic, app-agnostic utility. When a second consumer
+ * outside `apps/desktop` needs it, promote this file to
+ * `packages/ui/src/styles/fade-edge.css` and update consumers' imports.
+ */
+
+@layer utilities {
+	.fade-edge-t,
+	.fade-edge-r,
+	.fade-edge-b,
+	.fade-edge-l {
+		--fade-edge-size: 1.5rem;
+		--fade-edge-t-size: 0px;
+		--fade-edge-r-size: 0px;
+		--fade-edge-b-size: 0px;
+		--fade-edge-l-size: 0px;
+		mask-image:
+			linear-gradient(
+				to bottom,
+				transparent,
+				black var(--fade-edge-t-size),
+				black calc(100% - var(--fade-edge-b-size)),
+				transparent
+			),
+			linear-gradient(
+				to right,
+				transparent,
+				black var(--fade-edge-l-size),
+				black calc(100% - var(--fade-edge-r-size)),
+				transparent
+			);
+		-webkit-mask-image:
+			linear-gradient(
+				to bottom,
+				transparent,
+				black var(--fade-edge-t-size),
+				black calc(100% - var(--fade-edge-b-size)),
+				transparent
+			),
+			linear-gradient(
+				to right,
+				transparent,
+				black var(--fade-edge-l-size),
+				black calc(100% - var(--fade-edge-r-size)),
+				transparent
+			);
+		mask-composite: intersect;
+		-webkit-mask-composite: source-in;
+	}
+
+	.fade-edge-t {
+		--fade-edge-t-size: var(--fade-edge-size);
+	}
+	.fade-edge-r {
+		--fade-edge-r-size: var(--fade-edge-size);
+	}
+	.fade-edge-b {
+		--fade-edge-b-size: var(--fade-edge-size);
+	}
+	.fade-edge-l {
+		--fade-edge-l-size: var(--fade-edge-size);
+	}
+}


### PR DESCRIPTION
## Summary

Adds composable `.fade-edge-{t,r,b,l}` utility classes that fade out one or more edges of an element via a linear-gradient mask. Useful for indicating scroll affordance on horizontally / vertically overflowing containers.

- Combine sides freely: `class=\"fade-edge-r fade-edge-b\"` fades both edges.
- Override fade size per element with `[--fade-edge-size:2rem]`.
- Lives in `apps/desktop/src/renderer/styles/fade-edge.css` and is imported once from `globals.css`. The file header documents the promotion path: when a second consumer outside `apps/desktop` needs it, move to `packages/ui/src/styles/fade-edge.css` and update imports.

No consumers in this PR — a follow-up PR (the v2 sidebar ports work) is the first consumer.

## Test plan

- [ ] App builds and styles compile
- [ ] Apply `class=\"fade-edge-r\"` to a horizontally scrolling element and verify the right edge fades out
- [ ] Apply combined sides (e.g. `fade-edge-r fade-edge-b`) and verify both fade

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds composable edge-fade utilities `.fade-edge-{t,r,b,l}` that use a linear-gradient mask to fade edges and hint overflow scrolling. Included once in the desktop renderer via `globals.css`; first consumer will follow.

- **New Features**
  - Combine sides (e.g., `fade-edge-r fade-edge-b`).
  - Override fade size with `--fade-edge-size` (default 1.5rem).
  - Lives in `apps/desktop/src/renderer/styles/fade-edge.css`, imported from `apps/desktop/src/renderer/globals.css` (promote to `packages/ui` when shared).

<sup>Written for commit 84934a233c4beb089aae5909cab03eba8b502e54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added edge-fade utility classes to create adjustable fade effects on element edges (top, right, bottom, left) with a configurable fade distance.
  * Global styles now include the new fade-edge utilities so they’re available across the desktop renderer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->