### PR TITLE
[codex] Fix v2 terminal OSC links

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-link-manager.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-link-manager.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { ILinkProvider, Terminal as XTerm } from "@xterm/xterm";
+import { TerminalLinkManager } from "./terminal-link-manager";
+
+function createMockTerminal() {
+	const registeredProviders: ILinkProvider[] = [];
+	const disposedProviders: ILinkProvider[] = [];
+	const terminal = {
+		options: {
+			linkHandler: null,
+		},
+		registerLinkProvider: (provider: ILinkProvider) => {
+			registeredProviders.push(provider);
+			return {
+				dispose: () => {
+					disposedProviders.push(provider);
+				},
+			};
+		},
+		buffer: {
+			active: {
+				getLine: () => null,
+			},
+		},
+		cols: 80,
+	} as unknown as XTerm;
+
+	return { terminal, registeredProviders, disposedProviders };
+}
+
+describe("TerminalLinkManager", () => {
+	it("routes OSC 8 hyperlinks through the terminal URL handler", () => {
+		const { terminal } = createMockTerminal();
+		const manager = new TerminalLinkManager(terminal);
+		const onUrlClick = mock();
+		const onLinkHover = mock();
+		const onLinkLeave = mock();
+
+		manager.setHandlers({
+			stat: async () => null,
+			onUrlClick,
+			onLinkHover,
+			onLinkLeave,
+		});
+
+		const linkHandler = terminal.options.linkHandler;
+		expect(linkHandler).toBeTruthy();
+		expect(linkHandler?.allowNonHttpProtocols).toBe(false);
+
+		const event = {} as MouseEvent;
+		linkHandler?.activate(event, "https://example.com", {
+			start: { x: 1, y: 1 },
+			end: { x: 20, y: 1 },
+		});
+		linkHandler?.hover?.(event, "https://example.com", {
+			start: { x: 1, y: 1 },
+			end: { x: 20, y: 1 },
+		});
+		linkHandler?.leave?.(event, "https://example.com", {
+			start: { x: 1, y: 1 },
+			end: { x: 20, y: 1 },
+		});
+
+		expect(onUrlClick).toHaveBeenCalledWith(event, "https://example.com");
+		expect(onLinkHover).toHaveBeenCalledWith(event, { kind: "url" });
+		expect(onLinkLeave).toHaveBeenCalled();
+	});
+
+	it("clears only the OSC link handler it installed", () => {
+		const { terminal, disposedProviders } = createMockTerminal();
+		const manager = new TerminalLinkManager(terminal);
+
+		manager.setHandlers({
+			stat: async () => null,
+			onUrlClick: mock(),
+		});
+
+		const installedHandler = terminal.options.linkHandler;
+		expect(installedHandler).toBeTruthy();
+
+		manager.dispose();
+
+		expect(terminal.options.linkHandler).toBeNull();
+		expect(disposedProviders.length).toBe(2);
+	});
+
+	it("does not clear a link handler installed by another owner", () => {
+		const { terminal } = createMockTerminal();
+		const manager = new TerminalLinkManager(terminal);
+
+		manager.setHandlers({
+			stat: async () => null,
+			onUrlClick: mock(),
+		});
+
+		const replacementHandler = {
+			activate: mock(),
+		};
+		terminal.options.linkHandler = replacementHandler;
+
+		manager.dispose();
+
+		expect(terminal.options.linkHandler).toBe(replacementHandler);
+	});
+});

--- a/apps/desktop/src/renderer/lib/terminal/terminal-link-manager.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-link-manager.ts
@@ -7,7 +7,7 @@
  *  resolver caching, and priority ordering.
  *--------------------------------------------------------------------------------------------*/
 
-import type { Terminal as XTerm } from "@xterm/xterm";
+import type { ILinkHandler, Terminal as XTerm } from "@xterm/xterm";
 import { UrlLinkProvider } from "../../screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers";
 import type { DetectedLink } from "./links";
 import {
@@ -57,6 +57,7 @@ export class TerminalLinkManager {
 	private _disposables: LinkProviderDisposable[] = [];
 	private _resolver: TerminalLinkResolver | null = null;
 	private _handlers: TerminalLinkHandlers | null = null;
+	private _oscLinkHandler: ILinkHandler | null = null;
 
 	constructor(private readonly _terminal: XTerm) {}
 
@@ -83,9 +84,17 @@ export class TerminalLinkManager {
 	dispose(): void {
 		for (const d of this._disposables) d.dispose();
 		this._disposables = [];
+		this._clearOscLinkHandler();
 		this._resolver?.clearCache();
 		this._resolver = null;
 		this._handlers = null;
+	}
+
+	private _clearOscLinkHandler(): void {
+		if (this._terminal.options.linkHandler === this._oscLinkHandler) {
+			this._terminal.options.linkHandler = null;
+		}
+		this._oscLinkHandler = null;
 	}
 
 	private _register(): void {
@@ -95,6 +104,7 @@ export class TerminalLinkManager {
 		// Dispose old providers to prevent duplicates
 		for (const d of this._disposables) d.dispose();
 		this._disposables = [];
+		this._clearOscLinkHandler();
 
 		// Reuse resolver to preserve stat cache across re-registrations.
 		if (!this._resolver) {
@@ -135,6 +145,21 @@ export class TerminalLinkManager {
 				onLinkLeave,
 			);
 			this._disposables.push(this._terminal.registerLinkProvider(urlProvider));
+
+			// xterm always registers its own OSC 8 hyperlink provider first. Without
+			// this, OSC 8 links use xterm's default confirm() + window.open() path,
+			// which is blocked in Electron and also bypasses our link preferences.
+			this._oscLinkHandler = {
+				allowNonHttpProtocols: false,
+				activate: (event, uri) => {
+					onUrlClick(event, uri);
+				},
+				hover: onLinkHover
+					? (event) => onLinkHover(event, { kind: "url" })
+					: undefined,
+				leave: onLinkLeave ? () => onLinkLeave() : undefined,
+			};
+			this._terminal.options.linkHandler = this._oscLinkHandler;
 		}
 
 		// 3. SUPERSET ADDITION: Word link detector (lowest priority).


### PR DESCRIPTION
## Summary

Fixes OSC 8 hyperlinks in the desktop terminal by wiring xterm's built-in `linkHandler` into Superset's existing URL link action path.

## Root Cause

xterm 6 always registers its own `OscLinkProvider` before custom providers. When `options.linkHandler` is unset, OSC 8 links fall back to xterm's default `confirm(...)` + `window.open()` behavior. In Electron this shows the warning dialog, but allowing it does not open the link reliably and bypasses Superset's terminal link preferences.

## What Changed

- Keep Superset's existing URL provider for visible/plain/wrapped URLs.
- Add an OSC 8 `linkHandler` in `TerminalLinkManager` that delegates activation and hover events to the same URL callbacks.
- Preserve the existing modifier behavior and internal-vs-external link preference because the consumer callback still owns activation decisions.
- Clean up only the handler installed by `TerminalLinkManager`, so another owner is not clobbered if it replaces `terminal.options.linkHandler`.
- Add focused tests for OSC 8 routing and link-handler lifecycle cleanup.

## Design Notes

I checked the vendored/upstream behavior again:

- xterm's built-in OSC 8 provider is the source of the warning/no-op path.
- VS Code handles this by setting `xterm.options.linkHandler` and routing to its terminal URL opener.
- Tabby also sets `xterm.options.linkHandler` for OSC links and uses web-link detection separately for printed URLs.

This PR follows that split: use our detector for printed URLs, use xterm's handler hook for OSC 8 links.

## Validation

- `bun test apps/desktop/src/renderer/lib/terminal/terminal-link-manager.test.ts apps/desktop/src/renderer/lib/terminal/links/link-detector-adapter.test.ts apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/link-providers/url-link-provider.test.ts`
- `bunx biome check apps/desktop/src/renderer/lib/terminal/terminal-link-manager.ts apps/desktop/src/renderer/lib/terminal/terminal-link-manager.test.ts`
- `bun run --cwd apps/desktop typecheck`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OSC 8 hyperlinks in the desktop terminal by handling them via `@xterm/xterm`’s `linkHandler` and routing to our URL opener. Links now open reliably in Electron and respect modifier keys and internal/external link preferences.

- **Bug Fixes**
  - Use `terminal.options.linkHandler` for OSC 8 and keep existing detector for printed URLs.
  - Delegate activate/hover/leave to existing URL callbacks and disallow non-HTTP protocols.
  - Only clear the handler installed by `TerminalLinkManager` on dispose to avoid clobbering others.
  - Add focused tests for OSC 8 routing and handler lifecycle.

<sup>Written for commit 7609a7de2e2460c1afdbb616b7e75403bc645090. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal hyperlink handling to ensure consistent routing through the application's link handler.
  * Fixed handler cleanup to prevent stale or duplicate handlers in the terminal.

* **Tests**
  * Added comprehensive test coverage for terminal link management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->