### PR TITLE
[codex] Improve v2 pane header responsiveness

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarCollapsedWorkspaceButton/DashboardSidebarCollapsedWorkspaceButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarCollapsedWorkspaceButton/DashboardSidebarCollapsedWorkspaceButton.tsx
@@ -36,7 +36,7 @@ export const DashboardSidebarCollapsedWorkspaceButton = forwardRef<
 				className={cn(
 					"relative flex items-center justify-center size-8 rounded-md",
 					"transition-colors cursor-pointer",
-					isActive ? "bg-border/30 hover:bg-border/30" : "hover:bg-muted/50",
+					isActive ? "bg-muted hover:bg-muted" : "hover:bg-muted/50",
 					className,
 				)}
 				{...props}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarCollapsedWorkspaceButton/DashboardSidebarCollapsedWorkspaceButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarCollapsedWorkspaceButton/DashboardSidebarCollapsedWorkspaceButton.tsx
@@ -35,8 +35,8 @@ export const DashboardSidebarCollapsedWorkspaceButton = forwardRef<
 				ref={ref}
 				className={cn(
 					"relative flex items-center justify-center size-8 rounded-md",
-					"hover:bg-muted/50 transition-colors cursor-pointer",
-					isActive && "bg-muted",
+					"transition-colors cursor-pointer",
+					isActive ? "bg-border/30 hover:bg-border/30" : "hover:bg-muted/50",
 					className,
 				)}
 				{...props}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -120,10 +120,13 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 				onDoubleClick={onDoubleClick}
 				className={cn(
 					"relative flex w-full items-center pl-3 pr-2 text-left text-sm",
-					onClick && "cursor-pointer hover:bg-muted/50",
+					onClick &&
+						(isActive
+							? "cursor-pointer hover:bg-border/30"
+							: "cursor-pointer hover:bg-muted/50"),
 					"group",
 					"py-2",
-					isActive && "bg-muted",
+					isActive && "bg-border/30",
 					className,
 				)}
 				{...props}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -122,11 +122,11 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 					"relative flex w-full items-center pl-3 pr-2 text-left text-sm",
 					onClick &&
 						(isActive
-							? "cursor-pointer hover:bg-border/30"
+							? "cursor-pointer hover:bg-muted"
 							: "cursor-pointer hover:bg-muted/50"),
 					"group",
 					"py-2",
-					isActive && "bg-border/30",
+					isActive && "bg-muted",
 					className,
 				)}
 				{...props}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/V2PresetsBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/V2PresetsBar.tsx
@@ -13,8 +13,9 @@ import {
 } from "@superset/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useNavigate } from "@tanstack/react-router";
+import { Settings } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { HiMiniCog6Tooth, HiMiniCommandLine } from "react-icons/hi2";
+import { HiMiniCommandLine } from "react-icons/hi2";
 import { LuCirclePlus, LuPin } from "react-icons/lu";
 import {
 	getPresetIcon,
@@ -270,12 +271,28 @@ export function V2PresetsBar({
 			className="flex h-8 min-w-0 shrink-0 items-center gap-0.5 overflow-x-auto overflow-y-hidden border-b border-border bg-background px-2"
 			style={{ scrollbarWidth: "none" }}
 		>
+			{pinnedPresets.map(({ preset, index }, pinnedIndex) => {
+				const hotkeyId = PRESET_HOTKEY_IDS[index];
+				return (
+					<V2PresetBarItem
+						key={preset.id}
+						preset={preset}
+						pinnedIndex={pinnedIndex}
+						hotkeyId={hotkeyId}
+						isDark={isDark}
+						onExecutePreset={executePreset}
+						onEdit={(presetToEdit) => handleEditPreset(presetToEdit.id)}
+						onLocalReorder={handleLocalPinnedReorder}
+						onPersistReorder={handlePersistPinnedReorder}
+					/>
+				);
+			})}
 			<DropdownMenu>
 				<Tooltip>
 					<TooltipTrigger asChild>
 						<DropdownMenuTrigger asChild>
 							<Button variant="ghost" size="icon" className="size-6 shrink-0">
-								<HiMiniCog6Tooth className="size-3.5" />
+								<Settings className="size-3.5" />
 							</Button>
 						</DropdownMenuTrigger>
 					</TooltipTrigger>
@@ -283,7 +300,7 @@ export function V2PresetsBar({
 						Manage Presets
 					</TooltipContent>
 				</Tooltip>
-				<DropdownMenuContent align="start" className="w-56">
+				<DropdownMenuContent align="end" className="w-56">
 					{managedPresets.map((item) => {
 						const icon = getPresetIcon(item.iconName, isDark);
 						const isPinned = item.preset
@@ -339,28 +356,11 @@ export function V2PresetsBar({
 						className="gap-2"
 						onClick={() => navigate({ to: "/settings/terminal" })}
 					>
-						<HiMiniCog6Tooth className="size-4" />
+						<Settings className="size-4" />
 						<span>Manage Presets</span>
 					</DropdownMenuItem>
 				</DropdownMenuContent>
 			</DropdownMenu>
-			<div className="h-4 w-px bg-border mx-1 shrink-0" />
-			{pinnedPresets.map(({ preset, index }, pinnedIndex) => {
-				const hotkeyId = PRESET_HOTKEY_IDS[index];
-				return (
-					<V2PresetBarItem
-						key={preset.id}
-						preset={preset}
-						pinnedIndex={pinnedIndex}
-						hotkeyId={hotkeyId}
-						isDark={isDark}
-						onExecutePreset={executePreset}
-						onEdit={(presetToEdit) => handleEditPreset(presetToEdit.id)}
-						onLocalReorder={handleLocalPinnedReorder}
-						onPersistReorder={handlePersistPinnedReorder}
-					/>
-				);
-			})}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/V2PresetsBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/V2PresetsBar.tsx
@@ -164,8 +164,12 @@ export function V2PresetsBar({
 				.filter((preset) => !visibleSet.has(preset.id))
 				.map((preset) => preset.id);
 			const finalOrder = [...reorderedVisiblePresetIds, ...hidden];
+			const currentTabOrderById = new Map(
+				matchedPresets.map((preset) => [preset.id, preset.tabOrder]),
+			);
 
 			for (const [index, id] of finalOrder.entries()) {
+				if (currentTabOrderById.get(id) === index) continue;
 				collections.v2TerminalPresets.update(id, (draft) => {
 					draft.tabOrder = index;
 				});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/V2PresetsBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/V2PresetsBar.tsx
@@ -267,7 +267,7 @@ export function V2PresetsBar({
 
 	return (
 		<div
-			className="flex items-center h-8 border-b border-border bg-background px-2 gap-0.5 overflow-x-auto shrink-0"
+			className="flex h-8 min-w-0 shrink-0 items-center gap-0.5 overflow-x-auto overflow-y-hidden border-b border-border bg-background px-2"
 			style={{ scrollbarWidth: "none" }}
 		>
 			<DropdownMenu>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/V2PresetsBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/V2PresetsBar.tsx
@@ -1,8 +1,3 @@
-import {
-	AGENT_PRESET_COMMANDS,
-	AGENT_PRESET_DESCRIPTIONS,
-	AGENT_TYPES,
-} from "@superset/shared/agent-command";
 import { Button } from "@superset/ui/button";
 import {
 	DropdownMenu,
@@ -13,10 +8,9 @@ import {
 } from "@superset/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useNavigate } from "@tanstack/react-router";
-import { Settings } from "lucide-react";
+import { Eye, EyeOff, Settings } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { HiMiniCommandLine } from "react-icons/hi2";
-import { LuCirclePlus, LuPin } from "react-icons/lu";
 import {
 	getPresetIcon,
 	useIsDarkTheme,
@@ -35,7 +29,7 @@ interface V2PresetsBarProps {
 
 // Co-located to keep v2 self-contained. Mirrors the v1 array in
 // renderer/hotkeys/registry.ts; order matches the registry OPEN_PRESET_{n}
-// definitions so PRESET_HOTKEY_IDS[i] targets the i-th pinned preset.
+// definitions so PRESET_HOTKEY_IDS[i] targets the i-th visible preset.
 const PRESET_HOTKEY_IDS: HotkeyId[] = [
 	"OPEN_PRESET_1",
 	"OPEN_PRESET_2",
@@ -48,24 +42,9 @@ const PRESET_HOTKEY_IDS: HotkeyId[] = [
 	"OPEN_PRESET_9",
 ];
 
-interface PresetTemplate {
-	name: string;
-	description: string;
-	cwd: string;
-	commands: string[];
-}
-
-const QUICK_ADD_PRESET_TEMPLATES: PresetTemplate[] = AGENT_TYPES.map(
-	(agent) => ({
-		name: agent,
-		description: AGENT_PRESET_DESCRIPTIONS[agent],
-		cwd: "",
-		commands: AGENT_PRESET_COMMANDS[agent],
-	}),
-);
-
-function isPresetPinnedToBar(pinnedToBar: boolean | undefined): boolean {
-	// Backward-compatibility rule mirroring v1: undefined defaults to pinned.
+function isPresetVisibleInBar(pinnedToBar: boolean | undefined): boolean {
+	// The persisted field is legacy "pinned" wording; the v2 UI treats it as
+	// show/hide visibility. Undefined defaults to visible for compatibility.
 	return pinnedToBar !== false;
 }
 
@@ -74,11 +53,11 @@ function areStringArraysEqual(left: string[], right: string[]): boolean {
 	return left.every((value, index) => value === right[index]);
 }
 
-function getPinnedPresetOrder(
+function getVisiblePresetOrder(
 	presets: ReadonlyArray<{ id: string; pinnedToBar?: boolean }>,
 ): string[] {
 	return presets.flatMap((preset) =>
-		isPresetPinnedToBar(preset.pinnedToBar) ? [preset.id] : [],
+		isPresetVisibleInBar(preset.pinnedToBar) ? [preset.id] : [],
 	);
 }
 
@@ -91,96 +70,56 @@ export function V2PresetsBar({
 	const collections = useCollections();
 	useMigrateV1PresetsToV2();
 
-	const [localPinnedPresetIds, setLocalPinnedPresetIds] = useState<string[]>(
-		() => getPinnedPresetOrder(matchedPresets),
+	const [localVisiblePresetIds, setLocalVisiblePresetIds] = useState<string[]>(
+		() => getVisiblePresetOrder(matchedPresets),
 	);
 
 	useEffect(() => {
-		const serverPinnedPresetIds = getPinnedPresetOrder(matchedPresets);
-		setLocalPinnedPresetIds((current) =>
-			areStringArraysEqual(current, serverPinnedPresetIds)
+		const serverVisiblePresetIds = getVisiblePresetOrder(matchedPresets);
+		setLocalVisiblePresetIds((current) =>
+			areStringArraysEqual(current, serverVisiblePresetIds)
 				? current
-				: serverPinnedPresetIds,
+				: serverVisiblePresetIds,
 		);
 	}, [matchedPresets]);
 
-	const presetsByName = useMemo(() => {
-		const map = new Map<string, V2TerminalPresetRow[]>();
-		for (const preset of matchedPresets) {
-			const existing = map.get(preset.name);
-			if (existing) {
-				existing.push(preset);
-				continue;
-			}
-			map.set(preset.name, [preset]);
-		}
-		return map;
-	}, [matchedPresets]);
-
-	const pinnedPresets = useMemo(() => {
+	const visiblePresets = useMemo(() => {
 		const presetById = new Map(
 			matchedPresets.map((preset, index) => [preset.id, { preset, index }]),
 		);
-		const orderedPinnedPresets: Array<{
+		const orderedVisiblePresets: Array<{
 			preset: V2TerminalPresetRow;
 			index: number;
 		}> = [];
 		const seenIds = new Set<string>();
 
-		for (const presetId of localPinnedPresetIds) {
+		for (const presetId of localVisiblePresetIds) {
 			const item = presetById.get(presetId);
 			if (!item) continue;
-			if (!isPresetPinnedToBar(item.preset.pinnedToBar)) continue;
-			orderedPinnedPresets.push(item);
+			if (!isPresetVisibleInBar(item.preset.pinnedToBar)) continue;
+			orderedVisiblePresets.push(item);
 			seenIds.add(presetId);
 		}
 
 		for (const [index, preset] of matchedPresets.entries()) {
-			if (!isPresetPinnedToBar(preset.pinnedToBar)) continue;
+			if (!isPresetVisibleInBar(preset.pinnedToBar)) continue;
 			if (seenIds.has(preset.id)) continue;
-			orderedPinnedPresets.push({ preset, index });
+			orderedVisiblePresets.push({ preset, index });
 		}
 
-		return orderedPinnedPresets;
-	}, [matchedPresets, localPinnedPresetIds]);
+		return orderedVisiblePresets;
+	}, [matchedPresets, localVisiblePresetIds]);
 
-	const presetIndexById = useMemo(
-		() => new Map(matchedPresets.map((preset, index) => [preset.id, index])),
-		[matchedPresets],
+	const visiblePresetIndexById = useMemo(
+		() =>
+			new Map(
+				visiblePresets.map(({ preset }, visibleIndex) => [
+					preset.id,
+					visibleIndex,
+				]),
+			),
+		[visiblePresets],
 	);
-
-	const managedPresets = useMemo(() => {
-		const templateNames = new Set(
-			QUICK_ADD_PRESET_TEMPLATES.map((t) => t.name),
-		);
-		const primaryTemplatePresetIds = new Set(
-			QUICK_ADD_PRESET_TEMPLATES.flatMap((template) => {
-				const match = presetsByName.get(template.name)?.[0];
-				return match ? [match.id] : [];
-			}),
-		);
-		const fromTemplates = QUICK_ADD_PRESET_TEMPLATES.map((template) => ({
-			key: `template:${template.name}`,
-			name: template.name,
-			preset: presetsByName.get(template.name)?.[0],
-			template,
-			iconName: template.name,
-		}));
-		const customExisting = matchedPresets
-			.filter(
-				(preset) =>
-					!templateNames.has(preset.name) ||
-					!primaryTemplatePresetIds.has(preset.id),
-			)
-			.map((preset) => ({
-				key: `preset:${preset.id}`,
-				name: preset.name || "default",
-				preset: preset as V2TerminalPresetRow | undefined,
-				template: null as PresetTemplate | null,
-				iconName: preset.name,
-			}));
-		return [...fromTemplates, ...customExisting];
-	}, [matchedPresets, presetsByName]);
 
 	const handleEditPreset = useCallback(
 		(presetId: string) => {
@@ -192,9 +131,9 @@ export function V2PresetsBar({
 		[navigate],
 	);
 
-	const handleLocalPinnedReorder = useCallback(
+	const handleLocalVisibleReorder = useCallback(
 		(fromIndex: number, toIndex: number) => {
-			setLocalPinnedPresetIds((current) => {
+			setLocalVisiblePresetIds((current) => {
 				if (
 					fromIndex < 0 ||
 					fromIndex >= current.length ||
@@ -212,19 +151,19 @@ export function V2PresetsBar({
 		[],
 	);
 
-	const handlePersistPinnedReorder = useCallback(
-		(presetId: string, targetPinnedIndex: number) => {
-			const reorderedPinnedPresetIds = [...localPinnedPresetIds];
-			const currentPinnedIndex = reorderedPinnedPresetIds.indexOf(presetId);
-			if (currentPinnedIndex === -1) return;
-			const [moved] = reorderedPinnedPresetIds.splice(currentPinnedIndex, 1);
-			reorderedPinnedPresetIds.splice(targetPinnedIndex, 0, moved);
+	const handlePersistVisibleReorder = useCallback(
+		(presetId: string, targetVisibleIndex: number) => {
+			const reorderedVisiblePresetIds = [...localVisiblePresetIds];
+			const currentVisibleIndex = reorderedVisiblePresetIds.indexOf(presetId);
+			if (currentVisibleIndex === -1) return;
+			const [moved] = reorderedVisiblePresetIds.splice(currentVisibleIndex, 1);
+			reorderedVisiblePresetIds.splice(targetVisibleIndex, 0, moved);
 
-			const pinnedSet = new Set(reorderedPinnedPresetIds);
-			const unpinned = matchedPresets
-				.filter((preset) => !pinnedSet.has(preset.id))
+			const visibleSet = new Set(reorderedVisiblePresetIds);
+			const hidden = matchedPresets
+				.filter((preset) => !visibleSet.has(preset.id))
 				.map((preset) => preset.id);
-			const finalOrder = [...reorderedPinnedPresetIds, ...unpinned];
+			const finalOrder = [...reorderedVisiblePresetIds, ...hidden];
 
 			for (const [index, id] of finalOrder.entries()) {
 				collections.v2TerminalPresets.update(id, (draft) => {
@@ -232,38 +171,16 @@ export function V2PresetsBar({
 				});
 			}
 		},
-		[collections.v2TerminalPresets, localPinnedPresetIds, matchedPresets],
+		[collections.v2TerminalPresets, localVisiblePresetIds, matchedPresets],
 	);
 
-	const handleTogglePinned = useCallback(
-		(presetId: string, nextPinned: boolean) => {
+	const handleTogglePresetVisibility = useCallback(
+		(presetId: string, nextVisible: boolean) => {
 			collections.v2TerminalPresets.update(presetId, (draft) => {
-				draft.pinnedToBar = nextPinned;
+				draft.pinnedToBar = nextVisible;
 			});
 		},
 		[collections.v2TerminalPresets],
-	);
-
-	const handleCreateFromTemplate = useCallback(
-		(template: PresetTemplate) => {
-			const maxTabOrder = matchedPresets.reduce(
-				(max, preset) => Math.max(max, preset.tabOrder),
-				-1,
-			);
-			collections.v2TerminalPresets.insert({
-				id: crypto.randomUUID(),
-				name: template.name,
-				description: template.description,
-				cwd: template.cwd,
-				commands: template.commands,
-				projectIds: null,
-				pinnedToBar: true,
-				executionMode: "new-tab",
-				tabOrder: maxTabOrder + 1,
-				createdAt: new Date(),
-			});
-		},
-		[collections.v2TerminalPresets, matchedPresets],
 	);
 
 	return (
@@ -271,19 +188,19 @@ export function V2PresetsBar({
 			className="flex h-8 min-w-0 shrink-0 items-center gap-0.5 overflow-x-auto overflow-y-hidden border-b border-border bg-background px-2"
 			style={{ scrollbarWidth: "none" }}
 		>
-			{pinnedPresets.map(({ preset, index }, pinnedIndex) => {
-				const hotkeyId = PRESET_HOTKEY_IDS[index];
+			{visiblePresets.map(({ preset }, visibleIndex) => {
+				const hotkeyId = PRESET_HOTKEY_IDS[visibleIndex];
 				return (
 					<V2PresetBarItem
 						key={preset.id}
 						preset={preset}
-						pinnedIndex={pinnedIndex}
+						visibleIndex={visibleIndex}
 						hotkeyId={hotkeyId}
 						isDark={isDark}
 						onExecutePreset={executePreset}
 						onEdit={(presetToEdit) => handleEditPreset(presetToEdit.id)}
-						onLocalReorder={handleLocalPinnedReorder}
-						onPersistReorder={handlePersistPinnedReorder}
+						onLocalReorder={handleLocalVisibleReorder}
+						onPersistReorder={handlePersistVisibleReorder}
 					/>
 				);
 			})}
@@ -301,31 +218,21 @@ export function V2PresetsBar({
 					</TooltipContent>
 				</Tooltip>
 				<DropdownMenuContent align="end" className="w-56">
-					{managedPresets.map((item) => {
-						const icon = getPresetIcon(item.iconName, isDark);
-						const isPinned = item.preset
-							? isPresetPinnedToBar(item.preset.pinnedToBar)
-							: false;
-						const hasPreset = !!item.preset;
-						const presetIndex = item.preset
-							? presetIndexById.get(item.preset.id)
-							: undefined;
+					{matchedPresets.map((preset) => {
+						const icon = getPresetIcon(preset.name, isDark);
+						const isVisible = isPresetVisibleInBar(preset.pinnedToBar);
+						const visibleIndex = visiblePresetIndexById.get(preset.id);
 						const hotkeyId =
-							typeof presetIndex === "number"
-								? PRESET_HOTKEY_IDS[presetIndex]
+							typeof visibleIndex === "number"
+								? PRESET_HOTKEY_IDS[visibleIndex]
 								: undefined;
 						return (
 							<DropdownMenuItem
-								key={item.key}
+								key={preset.id}
 								className="gap-2"
 								onSelect={(event) => {
 									event.preventDefault();
-									if (hasPreset && item.preset) {
-										handleTogglePinned(item.preset.id, !isPinned);
-										return;
-									}
-									if (!item.template) return;
-									handleCreateFromTemplate(item.template);
+									handleTogglePresetVisibility(preset.id, !isVisible);
 								}}
 							>
 								{icon ? (
@@ -333,19 +240,20 @@ export function V2PresetsBar({
 								) : (
 									<HiMiniCommandLine className="size-4" />
 								)}
-								<span className="truncate">{item.name || "default"}</span>
+								<span className="min-w-0 flex-1 truncate">
+									{preset.name || "default"}
+								</span>
 								<div className="ml-auto flex items-center gap-2">
-									{hotkeyId ? <HotkeyMenuShortcut hotkeyId={hotkeyId} /> : null}
-									{hasPreset ? (
-										<LuPin
-											className={`size-3.5 ${
-												isPinned
-													? "text-foreground"
-													: "text-muted-foreground/60"
-											}`}
-										/>
+									{isVisible && hotkeyId ? (
+										<HotkeyMenuShortcut hotkeyId={hotkeyId} />
+									) : null}
+									<span className="text-[10px] text-muted-foreground">
+										{isVisible ? "Shown" : "Hidden"}
+									</span>
+									{isVisible ? (
+										<Eye className="size-3.5 text-foreground" />
 									) : (
-										<LuCirclePlus className="size-3.5 text-muted-foreground" />
+										<EyeOff className="size-3.5 text-muted-foreground/60" />
 									)}
 								</div>
 							</DropdownMenuItem>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/V2PresetsBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/V2PresetsBar.tsx
@@ -188,22 +188,6 @@ export function V2PresetsBar({
 			className="flex h-8 min-w-0 shrink-0 items-center gap-0.5 overflow-x-auto overflow-y-hidden border-b border-border bg-background px-2"
 			style={{ scrollbarWidth: "none" }}
 		>
-			{visiblePresets.map(({ preset }, visibleIndex) => {
-				const hotkeyId = PRESET_HOTKEY_IDS[visibleIndex];
-				return (
-					<V2PresetBarItem
-						key={preset.id}
-						preset={preset}
-						visibleIndex={visibleIndex}
-						hotkeyId={hotkeyId}
-						isDark={isDark}
-						onExecutePreset={executePreset}
-						onEdit={(presetToEdit) => handleEditPreset(presetToEdit.id)}
-						onLocalReorder={handleLocalVisibleReorder}
-						onPersistReorder={handlePersistVisibleReorder}
-					/>
-				);
-			})}
 			<DropdownMenu>
 				<Tooltip>
 					<TooltipTrigger asChild>
@@ -247,9 +231,6 @@ export function V2PresetsBar({
 									{isVisible && hotkeyId ? (
 										<HotkeyMenuShortcut hotkeyId={hotkeyId} />
 									) : null}
-									<span className="text-[10px] text-muted-foreground">
-										{isVisible ? "Shown" : "Hidden"}
-									</span>
 									{isVisible ? (
 										<Eye className="size-3.5 text-foreground" />
 									) : (
@@ -269,6 +250,22 @@ export function V2PresetsBar({
 					</DropdownMenuItem>
 				</DropdownMenuContent>
 			</DropdownMenu>
+			{visiblePresets.map(({ preset }, visibleIndex) => {
+				const hotkeyId = PRESET_HOTKEY_IDS[visibleIndex];
+				return (
+					<V2PresetBarItem
+						key={preset.id}
+						preset={preset}
+						visibleIndex={visibleIndex}
+						hotkeyId={hotkeyId}
+						isDark={isDark}
+						onExecutePreset={executePreset}
+						onEdit={(presetToEdit) => handleEditPreset(presetToEdit.id)}
+						onLocalReorder={handleLocalVisibleReorder}
+						onPersistReorder={handlePersistVisibleReorder}
+					/>
+				);
+			})}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/components/V2PresetBarItem/V2PresetBarItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/components/V2PresetBarItem/V2PresetBarItem.tsx
@@ -19,18 +19,18 @@ const V2_PRESET_BAR_ITEM_TYPE = "V2_PRESET_BAR_ITEM";
 
 interface V2PresetBarItemProps {
 	preset: V2TerminalPresetRow;
-	pinnedIndex: number;
+	visibleIndex: number;
 	hotkeyId?: HotkeyId;
 	isDark: boolean;
 	onExecutePreset: (preset: V2TerminalPresetRow) => void;
 	onEdit: (preset: V2TerminalPresetRow) => void;
 	onLocalReorder: (fromIndex: number, toIndex: number) => void;
-	onPersistReorder: (presetId: string, targetPinnedIndex: number) => void;
+	onPersistReorder: (presetId: string, targetVisibleIndex: number) => void;
 }
 
 export function V2PresetBarItem({
 	preset,
-	pinnedIndex,
+	visibleIndex,
 	hotkeyId,
 	isDark,
 	onExecutePreset,
@@ -47,22 +47,22 @@ export function V2PresetBarItem({
 			type: V2_PRESET_BAR_ITEM_TYPE,
 			item: {
 				id: preset.id,
-				index: pinnedIndex,
-				originalIndex: pinnedIndex,
+				index: visibleIndex,
+				originalIndex: visibleIndex,
 			},
 			collect: (monitor) => ({
 				isDragging: monitor.isDragging(),
 			}),
 		}),
-		[preset.id, pinnedIndex],
+		[preset.id, visibleIndex],
 	);
 
 	const [, drop] = useDrop({
 		accept: V2_PRESET_BAR_ITEM_TYPE,
 		hover: (item: { id: string; index: number; originalIndex: number }) => {
-			if (item.index !== pinnedIndex) {
-				onLocalReorder(item.index, pinnedIndex);
-				item.index = pinnedIndex;
+			if (item.index !== visibleIndex) {
+				onLocalReorder(item.index, visibleIndex);
+				item.index = visibleIndex;
 			}
 		},
 		drop: (item: { id: string; index: number; originalIndex: number }) => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/components/V2PresetBarItem/V2PresetBarItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/V2PresetsBar/components/V2PresetBarItem/V2PresetBarItem.tsx
@@ -89,15 +89,19 @@ export function V2PresetBarItem({
 							<Button
 								variant="ghost"
 								size="sm"
-								className="h-6 px-2 gap-1.5 text-xs shrink-0"
+								className="h-6 max-w-36 min-w-0 shrink-0 gap-1.5 px-2 text-xs"
 								onClick={() => onExecutePreset(preset)}
 							>
 								{icon ? (
-									<img src={icon} alt="" className="size-3.5 object-contain" />
+									<img
+										src={icon}
+										alt=""
+										className="size-3.5 shrink-0 object-contain"
+									/>
 								) : (
-									<HiMiniCommandLine className="size-3.5" />
+									<HiMiniCommandLine className="size-3.5 shrink-0" />
 								)}
-								<span className="truncate max-w-[120px]">
+								<span className="min-w-0 truncate">
 									{preset.name || "default"}
 								</span>
 							</Button>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/BrowserPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/BrowserPane.tsx
@@ -111,7 +111,7 @@ export function BrowserPaneToolbar({ ctx }: BrowserPaneToolbarProps) {
 	const PaneHeaderActions = ctx.components.PaneHeaderActions;
 
 	return (
-		<div className="flex h-full w-full items-center justify-between min-w-0">
+		<div className="flex h-full w-full min-w-0 items-center justify-between">
 			<BrowserToolbar
 				currentUrl={state.currentUrl}
 				pageTitle={state.pageTitle}
@@ -123,7 +123,7 @@ export function BrowserPaneToolbar({ ctx }: BrowserPaneToolbarProps) {
 				onReload={handleReload}
 				onNavigate={handleNavigate}
 			/>
-			<div className="flex items-center shrink-0 pr-1">
+			<div className="flex shrink-0 items-center pr-1">
 				<div className="mx-1.5 h-3.5 w-px bg-muted-foreground/60" />
 				<Tooltip>
 					<TooltipTrigger asChild>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserToolbar/BrowserToolbar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserToolbar/BrowserToolbar.tsx
@@ -107,8 +107,8 @@ export function BrowserToolbar({
 	);
 
 	return (
-		<div className="flex h-full flex-1 min-w-0 items-center px-2">
-			<div className="flex items-center gap-0.5 shrink-0">
+		<div className="flex h-full min-w-0 flex-1 items-center px-2">
+			<div className="flex shrink-0 items-center gap-0.5">
 				<Tooltip>
 					<TooltipTrigger asChild>
 						<button
@@ -158,8 +158,8 @@ export function BrowserToolbar({
 					</TooltipContent>
 				</Tooltip>
 			</div>
-			<div className="mx-1.5 h-3.5 w-px bg-muted-foreground/60" />
-			<div className="relative flex flex-1 min-w-0 items-center">
+			<div className="mx-1.5 h-3.5 w-px shrink-0 bg-muted-foreground/60" />
+			<div className="relative flex min-w-0 flex-1 items-center">
 				{isEditing ? (
 					<form
 						onSubmit={handleSubmit}
@@ -181,20 +181,21 @@ export function BrowserToolbar({
 				) : (
 					<button
 						type="button"
+						title={isBlank ? undefined : url}
 						onClick={enterEditMode}
-						className="group flex w-full min-w-0 items-baseline rounded-sm border border-transparent px-2 py-0.5 text-left text-xs"
+						className="group flex w-full min-w-0 items-center rounded-sm border border-transparent px-2 py-0.5 text-left text-xs"
 					>
 						{isBlank ? (
-							<span className="text-muted-foreground/40">
+							<span className="min-w-0 truncate text-muted-foreground/40">
 								Enter URL or search...
 							</span>
 						) : (
 							<>
-								<span className="min-w-0 truncate text-muted-foreground/60 transition-colors group-hover:text-foreground">
+								<span className="min-w-0 shrink truncate text-muted-foreground/60 transition-colors group-hover:text-foreground">
 									{url}
 								</span>
 								{pageTitle && (
-									<span className="min-w-0 ml-1 truncate text-muted-foreground/40 transition-opacity group-hover:opacity-0">
+									<span className="ml-1 min-w-0 flex-1 truncate text-muted-foreground/40 transition-opacity group-hover:opacity-0">
 										/ {pageTitle}
 									</span>
 								)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/ChatPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/ChatPane.tsx
@@ -32,7 +32,7 @@ export function ChatPane({
 
 	return (
 		<div className="flex h-full w-full min-h-0 flex-col">
-			<div className="border-b border-border px-4 py-3">
+			<div className="flex h-8 shrink-0 items-center border-b border-border px-2">
 				<SessionSelector
 					currentSessionId={sessionId}
 					sessions={sessionItems}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/SessionSelector/SessionSelector.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/SessionSelector/SessionSelector.tsx
@@ -115,9 +115,10 @@ export function SessionSelector({
 			<DropdownMenuTrigger asChild>
 				<button
 					type="button"
+					title={currentTitle}
 					className="flex min-w-0 flex-1 items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
 				>
-					<HiMiniChevronDown className="size-3" />
+					<HiMiniChevronDown className="size-3 shrink-0" />
 					<span className="min-w-0 flex-1 truncate text-left">
 						{currentTitle}
 					</span>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileHeader/DiffFileHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileHeader/DiffFileHeader.tsx
@@ -50,17 +50,17 @@ export function DiffFileHeader({
 	const viewedId = useId();
 
 	return (
-		<div className="flex items-center justify-between gap-2 px-3 py-2">
+		<div className="flex min-w-0 items-center justify-between gap-1 px-2 py-1.5">
 			<button
 				type="button"
 				onClick={onToggleCollapsed}
 				aria-label={collapsed ? "Expand file" : "Collapse file"}
-				className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground"
+				className="shrink-0 rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground"
 			>
 				{collapsed ? (
-					<ChevronRight className="size-4" />
+					<ChevronRight className="size-3.5" />
 				) : (
-					<ChevronDown className="size-4" />
+					<ChevronDown className="size-3.5" />
 				)}
 			</button>
 			<StatusIndicator status={status} />
@@ -78,13 +78,14 @@ export function DiffFileHeader({
 						}}
 						disabled={!onOpenFile && !onOpenInExternalEditor}
 						aria-label="Open in file viewer"
-						className="flex min-w-0 flex-1 items-center gap-2 rounded border border-border px-2 py-1 text-left transition-colors hover:bg-accent disabled:pointer-events-none disabled:opacity-60"
+						title={path}
+						className="flex h-6 min-w-0 flex-1 items-center gap-1.5 rounded border border-border px-1.5 py-0.5 text-left transition-colors hover:bg-accent disabled:pointer-events-none disabled:opacity-60"
 					>
-						<FileIcon fileName={path} className="size-4 shrink-0" />
-						<span className="truncate font-mono text-xs text-foreground">
+						<FileIcon fileName={path} className="size-3.5 shrink-0" />
+						<span className="min-w-0 flex-1 truncate font-mono text-xs text-foreground">
 							{path}
 						</span>
-						<span className="ml-1 shrink-0 font-mono text-[11px] text-muted-foreground">
+						<span className="shrink-0 font-mono text-[10px] text-muted-foreground">
 							{additions > 0 && (
 								<span className="text-green-700 dark:text-green-400">
 									+{additions}
@@ -104,7 +105,7 @@ export function DiffFileHeader({
 				</TooltipContent>
 			</Tooltip>
 
-			<div className="flex shrink-0 items-center gap-2">
+			<div className="flex shrink-0 items-center gap-1">
 				<Tooltip>
 					<TooltipTrigger asChild>
 						<span className="inline-flex rounded">
@@ -113,7 +114,7 @@ export function DiffFileHeader({
 								onClick={onOpenInExternalEditor}
 								disabled={!onOpenInExternalEditor}
 								aria-label="Open in editor"
-								className="rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-40"
+								className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-40"
 							>
 								<ExternalLink className="size-3.5" />
 							</button>
@@ -126,16 +127,16 @@ export function DiffFileHeader({
 					</TooltipContent>
 				</Tooltip>
 
-				<div className="flex items-center gap-1.5">
+				<div className="flex items-center gap-1">
 					<Checkbox
 						id={viewedId}
 						checked={viewed}
 						onCheckedChange={() => onToggleViewed()}
-						className="size-3.5 border-muted-foreground/50"
+						className="size-3 border-muted-foreground/50"
 					/>
 					<label
 						htmlFor={viewedId}
-						className="cursor-pointer select-none text-[11px] text-muted-foreground"
+						className="cursor-pointer select-none text-[10px] text-muted-foreground"
 					>
 						Viewed
 					</label>
@@ -150,7 +151,7 @@ export function DiffFileHeader({
 							aria-label={
 								expandUnchanged ? "Hide unchanged regions" : "Show all lines"
 							}
-							className="rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-40"
+							className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-40"
 						>
 							{expandUnchanged ? (
 								<EyeOff className="size-3.5" />
@@ -171,7 +172,7 @@ export function DiffFileHeader({
 							onClick={onCopyContents}
 							disabled={!onCopyContents}
 							aria-label="Copy file contents"
-							className="rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-40"
+							className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-40"
 						>
 							<LuCopy className="size-3.5" />
 						</button>
@@ -188,7 +189,7 @@ export function DiffFileHeader({
 							onClick={onDiscard}
 							disabled={!onDiscard}
 							aria-label="Discard changes"
-							className="rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-destructive disabled:pointer-events-none disabled:opacity-40"
+							className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-destructive disabled:pointer-events-none disabled:opacity-40"
 						>
 							<LuUndo2 className="size-3.5" />
 						</button>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileHeader/DiffFileHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileHeader/DiffFileHeader.tsx
@@ -50,7 +50,7 @@ export function DiffFileHeader({
 	const viewedId = useId();
 
 	return (
-		<div className="flex min-w-0 items-center justify-between gap-1 px-2 py-1.5">
+		<div className="@container/diff-file-header flex min-w-0 flex-wrap items-center justify-between gap-1 px-2 py-1.5">
 			<button
 				type="button"
 				onClick={onToggleCollapsed}
@@ -79,13 +79,13 @@ export function DiffFileHeader({
 						disabled={!onOpenFile && !onOpenInExternalEditor}
 						aria-label="Open in file viewer"
 						title={path}
-						className="flex h-6 min-w-0 flex-1 items-center gap-1.5 rounded border border-border px-1.5 py-0.5 text-left transition-colors hover:bg-accent disabled:pointer-events-none disabled:opacity-60"
+						className="flex h-6 min-w-20 flex-[1_1_10rem] items-center gap-1.5 rounded border border-border px-1.5 py-0.5 text-left transition-colors hover:bg-accent disabled:pointer-events-none disabled:opacity-60"
 					>
 						<FileIcon fileName={path} className="size-3.5 shrink-0" />
 						<span className="min-w-0 flex-1 truncate font-mono text-xs text-foreground">
 							{path}
 						</span>
-						<span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+						<span className="hidden shrink-0 font-mono text-[10px] text-muted-foreground @min-[300px]/diff-file-header:inline">
 							{additions > 0 && (
 								<span className="text-green-700 dark:text-green-400">
 									+{additions}
@@ -105,7 +105,7 @@ export function DiffFileHeader({
 				</TooltipContent>
 			</Tooltip>
 
-			<div className="flex shrink-0 items-center gap-1">
+			<div className="ml-auto flex shrink-0 items-center gap-1">
 				<Tooltip>
 					<TooltipTrigger asChild>
 						<span className="inline-flex rounded">
@@ -136,7 +136,7 @@ export function DiffFileHeader({
 					/>
 					<label
 						htmlFor={viewedId}
-						className="cursor-pointer select-none text-[10px] text-muted-foreground"
+						className="hidden cursor-pointer select-none text-[10px] text-muted-foreground @min-[380px]/diff-file-header:inline"
 					>
 						Viewed
 					</label>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileHeader/DiffFileHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileHeader/DiffFileHeader.tsx
@@ -78,7 +78,6 @@ export function DiffFileHeader({
 						}}
 						disabled={!onOpenFile && !onOpenInExternalEditor}
 						aria-label="Open in file viewer"
-						title={path}
 						className="flex h-6 min-w-20 flex-[1_1_10rem] items-center gap-1.5 rounded border border-border px-1.5 py-0.5 text-left transition-colors hover:bg-accent disabled:pointer-events-none disabled:opacity-60"
 					>
 						<FileIcon fileName={path} className="size-3.5 shrink-0" />
@@ -100,8 +99,17 @@ export function DiffFileHeader({
 						</span>
 					</button>
 				</TooltipTrigger>
-				<TooltipContent side="bottom" showArrow={false}>
-					Open in file viewer. {CLICK_HINT_TOOLTIP}
+				<TooltipContent
+					side="bottom"
+					showArrow={false}
+					className="max-w-[80vw]"
+				>
+					<div className="space-y-1">
+						<div>Open in file viewer. {CLICK_HINT_TOOLTIP}</div>
+						<div className="break-all font-mono text-[10px] text-muted-foreground">
+							{path}
+						</div>
+					</div>
 				</TooltipContent>
 			</Tooltip>
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/FilePane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/FilePane.tsx
@@ -1,6 +1,7 @@
 import type { RendererContext } from "@superset/panes";
 import { alert } from "@superset/ui/atoms/Alert";
 import { useCallback, useEffect } from "react";
+import { getBaseName } from "renderer/lib/pathBasename";
 import { useSharedFileDocument } from "../../../../state/fileDocumentStore";
 import type { FilePaneData, PaneViewerData } from "../../../../types";
 import { ErrorState } from "./components/ErrorState";
@@ -44,7 +45,7 @@ export function FilePane({ context, workspaceId }: FilePaneProps) {
 	const hasConflict = document.conflict !== null;
 	useEffect(() => {
 		if (!hasConflict) return;
-		const name = filePath.split("/").pop();
+		const name = getBaseName(filePath);
 		alert({
 			title: `Do you want to save the changes you made to ${name}?`,
 			description: "Your changes will be lost if you don't save them.",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/components/FilePaneHeaderExtras/FilePaneHeaderExtras.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/components/FilePaneHeaderExtras/FilePaneHeaderExtras.tsx
@@ -45,7 +45,7 @@ export function FilePaneHeaderExtras({
 	}, [filePath, openInExternalEditor]);
 
 	return (
-		<div className="flex items-center gap-1">
+		<div className="flex min-w-0 items-center gap-1">
 			{shouldShowToggle && activeView && (
 				<FileViewToggle
 					views={orderForToggle(views)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/components/FileViewToggle/FileViewToggle.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/components/FileViewToggle/FileViewToggle.tsx
@@ -15,22 +15,27 @@ export function FileViewToggle({
 	onChange,
 }: FileViewToggleProps) {
 	return (
-		<div className="inline-flex items-center gap-0.5 rounded bg-muted p-0.5 text-xs">
-			{views.map((view) => (
-				<button
-					key={view.id}
-					type="button"
-					className={cn(
-						"rounded px-2 py-0.5 transition-colors",
-						view.id === activeViewId
-							? "bg-background text-foreground shadow-sm"
-							: "text-muted-foreground hover:text-foreground",
-					)}
-					onClick={() => onChange(view.id)}
-				>
-					{resolveViewLabel(view, filePath)}
-				</button>
-			))}
+		<div className="inline-flex h-5 min-w-0 items-center gap-0.5 rounded-md bg-muted/50 p-0.5">
+			{views.map((view) => {
+				const label = resolveViewLabel(view, filePath);
+
+				return (
+					<button
+						key={view.id}
+						type="button"
+						title={label}
+						className={cn(
+							"flex h-4 min-w-0 max-w-20 items-center rounded px-1.5 text-[10px] leading-none transition-colors",
+							view.id === activeViewId
+								? "bg-background text-foreground shadow-sm"
+								: "text-muted-foreground hover:text-foreground",
+						)}
+						onClick={() => onChange(view.id)}
+					>
+						<span className="min-w-0 truncate">{label}</span>
+					</button>
+				);
+			})}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/ImageView/ImageView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/ImageView/ImageView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { getBaseName } from "renderer/lib/pathBasename";
 import { getImageMimeType } from "shared/file-types";
 import type { ViewProps } from "../../types";
 
@@ -34,7 +35,7 @@ export function ImageView({ document, filePath }: ViewProps) {
 			>
 				<img
 					src={objectUrl}
-					alt={filePath.split("/").pop() ?? ""}
+					alt={getBaseName(filePath)}
 					className="block max-h-full max-w-full object-contain"
 					draggable={false}
 				/>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
@@ -215,13 +215,13 @@ export function TerminalSessionDropdown({
 					type="button"
 					aria-label="Terminal sessions"
 					title={triggerTitle}
-					className="flex min-w-0 max-w-full flex-1 items-center gap-1.5 rounded px-1.5 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+					className="@container/terminal-session flex min-w-0 max-w-full flex-1 items-center gap-1.5 rounded px-1.5 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
 					onMouseDown={(event) => event.stopPropagation()}
 					onClick={(event) => event.stopPropagation()}
 				>
 					<TerminalSquare className="size-3.5 shrink-0" />
 					<span className="min-w-0 truncate">{triggerTitle}</span>
-					<span className="shrink-0 text-[10px] text-muted-foreground/70">
+					<span className="hidden shrink-0 text-[10px] text-muted-foreground/70 @min-[160px]/terminal-session:inline">
 						{currentCreatedAtLabel}
 					</span>
 					{sessionsQuery.isFetching && isOpen ? (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
@@ -214,11 +214,12 @@ export function TerminalSessionDropdown({
 				<button
 					type="button"
 					aria-label="Terminal sessions"
-					className="flex min-w-0 max-w-72 items-center gap-1.5 rounded px-1.5 py-0.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+					title={triggerTitle}
+					className="flex min-w-0 max-w-full flex-1 items-center gap-1.5 rounded px-1.5 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
 					onMouseDown={(event) => event.stopPropagation()}
 					onClick={(event) => event.stopPropagation()}
 				>
-					<TerminalSquare className="size-4 shrink-0" />
+					<TerminalSquare className="size-3.5 shrink-0" />
 					<span className="min-w-0 truncate">{triggerTitle}</span>
 					<span className="shrink-0 text-[10px] text-muted-foreground/70">
 						{currentCreatedAtLabel}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -60,10 +60,12 @@ function getFileName(filePath: string): string {
 
 function FilePaneTabTitle({
 	filePath,
+	isActive,
 	pinned,
 	workspaceId,
 }: {
 	filePath: string;
+	isActive: boolean;
 	pinned: boolean;
 	workspaceId: string;
 }) {
@@ -73,9 +75,17 @@ function FilePaneTabTitle({
 	});
 	const name = getFileName(filePath);
 	return (
-		<div className="flex items-center space-x-2">
-			<FileIcon fileName={name} className="size-4 shrink-0" />
-			<span className={pinned ? undefined : "italic"}>{name}</span>
+		<div
+			className={cn(
+				"flex min-w-0 items-center gap-1.5 text-xs transition-colors duration-150",
+				isActive ? "text-foreground" : "text-muted-foreground",
+			)}
+			title={filePath}
+		>
+			<FileIcon fileName={name} className="size-3.5 shrink-0" />
+			<span className={cn("min-w-0 truncate", !pinned && "italic")}>
+				{name}
+			</span>
 			{document.dirty && (
 				<Circle className="size-2 shrink-0 fill-current text-muted-foreground" />
 			)}
@@ -93,7 +103,7 @@ function DiffViewModeToggle() {
 
 	const buttonClass = (active: boolean) =>
 		cn(
-			"flex size-6 items-center justify-center transition-colors",
+			"flex size-5 items-center justify-center transition-colors",
 			active
 				? "bg-secondary text-foreground"
 				: "text-muted-foreground hover:text-foreground",
@@ -134,7 +144,7 @@ function DiffViewModeToggle() {
 				</TooltipContent>
 			</Tooltip>
 			<div
-				className="mx-1.5 h-4 w-px bg-muted-foreground/30"
+				className="mx-1 h-3.5 w-px bg-muted-foreground/30"
 				aria-hidden="true"
 			/>
 		</div>
@@ -182,6 +192,7 @@ export function usePaneRegistry(
 					return (
 						<FilePaneTabTitle
 							filePath={data.filePath}
+							isActive={ctx.isActive}
 							pinned={Boolean(ctx.pane.pinned)}
 							workspaceId={workspaceId}
 						/>
@@ -244,7 +255,7 @@ export function usePaneRegistry(
 					),
 			},
 			diff: {
-				getIcon: () => <GitCompareArrows className="size-4" />,
+				getIcon: () => <GitCompareArrows className="size-3.5" />,
 				getTitle: () => "Changes",
 				renderPane: (ctx: RendererContext<PaneViewerData>) => (
 					<DiffPane
@@ -260,16 +271,16 @@ export function usePaneRegistry(
 					),
 			},
 			terminal: {
-				getIcon: () => <TerminalSquare className="size-4" />,
+				getIcon: () => <TerminalSquare className="size-3.5" />,
 				getTitle: () => "Terminal",
 				renderTitle: (ctx: RendererContext<PaneViewerData>) => (
-					<>
+					<div className="flex min-w-0 flex-1 items-center gap-1.5">
 						<TerminalSessionDropdown context={ctx} workspaceId={workspaceId} />
 						<V2NotificationStatusIndicator
 							workspaceId={workspaceId}
 							sources={getV2NotificationSourcesForPane(ctx.pane)}
 						/>
-					</>
+					</div>
 				),
 				renderHeaderExtras: (ctx: RendererContext<PaneViewerData>) => (
 					<TerminalHeaderExtras context={ctx} />
@@ -396,7 +407,7 @@ export function usePaneRegistry(
 				},
 			},
 			browser: {
-				getIcon: () => <Globe className="size-4" />,
+				getIcon: () => <Globe className="size-3.5" />,
 				getTitle: (pane) => {
 					const data = pane.data as BrowserPaneData;
 					if (data.pageTitle) return data.pageTitle;
@@ -424,14 +435,14 @@ export function usePaneRegistry(
 					),
 			},
 			chat: {
-				getIcon: () => <MessageSquare className="size-4" />,
+				getIcon: () => <MessageSquare className="size-3.5" />,
 				getTitle: () => "Chat",
 				renderTitle: (ctx: RendererContext<PaneViewerData>) => (
-					<>
-						<MessageSquare className="size-4 shrink-0" />
+					<div className="flex min-w-0 flex-1 items-center gap-1.5">
+						<MessageSquare className="size-3.5 shrink-0" />
 						<span
 							className={cn(
-								"truncate text-sm transition-colors duration-150",
+								"min-w-0 flex-1 truncate text-xs transition-colors duration-150",
 								ctx.isActive ? "text-foreground" : "text-muted-foreground",
 							)}
 						>
@@ -441,7 +452,7 @@ export function usePaneRegistry(
 							workspaceId={workspaceId}
 							sources={getV2NotificationSourcesForPane(ctx.pane)}
 						/>
-					</>
+					</div>
 				),
 				// Disabled until ChatServiceProvider is wired above v2 panes —
 				// TiptapPromptEditor needs its tRPC context.
@@ -459,10 +470,14 @@ export function usePaneRegistry(
 				getIcon: (ctx: RendererContext<PaneViewerData>) => {
 					const data = ctx.pane.data as CommentPaneData;
 					if (!data.avatarUrl) {
-						return <MessageSquare className="size-4" />;
+						return <MessageSquare className="size-3.5" />;
 					}
 					return (
-						<img src={data.avatarUrl} alt="" className="size-4 rounded-full" />
+						<img
+							src={data.avatarUrl}
+							alt=""
+							className="size-3.5 rounded-full"
+						/>
 					);
 				},
 				getTitle: (pane) => {
@@ -480,10 +495,10 @@ export function usePaneRegistry(
 							href={data.url}
 							target="_blank"
 							rel="noopener noreferrer"
-							className="flex items-center gap-0.5 text-muted-foreground hover:text-foreground"
+							className="flex shrink-0 items-center gap-0.5 rounded p-0.5 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
 							aria-label="View on GitHub"
 						>
-							<FaGithub className="size-4" />
+							<FaGithub className="size-3.5" />
 							<LuArrowUpRight className="size-3" />
 						</a>
 					);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -28,6 +28,7 @@ import {
 } from "react-icons/lu";
 import { TbScan } from "react-icons/tb";
 import { useHotkeyDisplay } from "renderer/hotkeys";
+import { getBaseName } from "renderer/lib/pathBasename";
 import { terminalRuntimeRegistry } from "renderer/lib/terminal/terminal-runtime-registry";
 import { FileIcon } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils";
 import { useSettings } from "renderer/stores/settings";
@@ -55,7 +56,7 @@ import { TerminalHeaderExtras } from "./components/TerminalPane/components/Termi
 import { TerminalSessionDropdown } from "./components/TerminalPane/components/TerminalSessionDropdown";
 
 function getFileName(filePath: string): string {
-	return filePath.split("/").pop() ?? filePath;
+	return getBaseName(filePath);
 }
 
 function FilePaneTabTitle({
@@ -210,7 +211,7 @@ export function usePaneRegistry(
 					const data = pane.data as FilePaneData;
 					const doc = getDocument(workspaceId, data.filePath);
 					if (!doc?.dirty) return true;
-					const name = data.filePath.split("/").pop();
+					const name = getFileName(data.filePath);
 					return new Promise<boolean>((resolve) => {
 						alert({
 							title: `Do you want to save the changes you made to ${name}?`,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
@@ -4,7 +4,7 @@ import {
 	type PaneRegistry,
 	type WorkspaceStore,
 } from "@superset/panes";
-import { useCallback, useRef } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences";
 import { useHotkey } from "renderer/hotkeys";
 import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
@@ -29,6 +29,10 @@ export function useWorkspaceHotkeys({
 	paneRegistry: PaneRegistry<PaneViewerData>;
 }) {
 	const { setRightSidebarOpen, setRightSidebarTab } = useV2UserPreferences();
+	const visiblePresets = useMemo(
+		() => matchedPresets.filter((preset) => preset.pinnedToBar !== false),
+		[matchedPresets],
+	);
 
 	useHotkey("TOGGLE_SIDEBAR", () => {
 		setRightSidebarOpen((prev) => !prev);
@@ -280,10 +284,10 @@ export function useWorkspaceHotkeys({
 
 	const openPresetByIndex = useCallback(
 		(index: number) => {
-			const preset = matchedPresets[index];
+			const preset = visiblePresets[index];
 			if (preset) executePreset(preset);
 		},
-		[matchedPresets, executePreset],
+		[visiblePresets, executePreset],
 	);
 
 	useHotkey("OPEN_PRESET_1", () => openPresetByIndex(0));

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -453,8 +453,11 @@ function WorkspaceContent({
 
 	return (
 		<FileDocumentStoreProvider workspaceId={workspaceId}>
-			<ResizablePanelGroup direction="horizontal" className="flex-1">
-				<ResizablePanel defaultSize={80} minSize={30}>
+			<ResizablePanelGroup
+				direction="horizontal"
+				className="min-h-0 min-w-0 flex-1 overflow-auto"
+			>
+				<ResizablePanel className="min-w-[320px]" defaultSize={80} minSize={30}>
 					<div
 						className="flex min-h-0 min-w-0 h-full flex-col overflow-hidden"
 						data-workspace-id={workspaceId}
@@ -557,7 +560,12 @@ function WorkspaceContent({
 				{sidebarOpen && (
 					<>
 						<ResizableHandle />
-						<ResizablePanel defaultSize={20} minSize={15} maxSize={40}>
+						<ResizablePanel
+							className="min-w-[220px]"
+							defaultSize={20}
+							minSize={15}
+							maxSize={40}
+						>
 							<WorkspaceSidebar
 								workspaceId={workspaceId}
 								workspaceName={workspaceName}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -18,6 +18,7 @@ import { HiMiniXMark } from "react-icons/hi2";
 import { TbLayoutColumns, TbLayoutRows } from "react-icons/tb";
 import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences";
 import { HotkeyLabel, useHotkey } from "renderer/hotkeys";
+import { getBaseName } from "renderer/lib/pathBasename";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { CommandPalette } from "renderer/screens/main/components/CommandPalette";
 import {
@@ -501,7 +502,7 @@ function WorkspaceContent({
 									return getDocument(workspaceId, filePath)?.dirty === true;
 								});
 								const dirtyFileNames = dirtyPanes.map((p) =>
-									(p.data as FilePaneData).filePath.split("/").pop(),
+									getBaseName((p.data as FilePaneData).filePath),
 								);
 								if (dirtyPanes.length === 0) return true;
 								const title =

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
@@ -130,9 +130,11 @@ export function V2WorkspaceRow({
 				className={cn(
 					V2_WORKSPACES_ROW_GRID,
 					"group/row relative min-w-0 px-6 py-2 text-sm outline-none",
-					"cursor-pointer transition-colors hover:bg-accent/50",
-					"focus-visible:bg-accent/50 focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:ring-inset",
-					isCurrentRoute && "bg-accent/40",
+					"cursor-pointer transition-colors",
+					"focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:ring-inset",
+					isCurrentRoute
+						? "bg-border/30 hover:bg-border/30 focus-visible:bg-border/30"
+						: "hover:bg-accent/50 focus-visible:bg-accent/50",
 				)}
 			>
 				<div className="flex items-center justify-center">

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
@@ -133,7 +133,7 @@ export function V2WorkspaceRow({
 					"cursor-pointer transition-colors",
 					"focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:ring-inset",
 					isCurrentRoute
-						? "bg-border/30 hover:bg-border/30 focus-visible:bg-border/30"
+						? "bg-muted hover:bg-muted focus-visible:bg-muted"
 						: "hover:bg-accent/50 focus-visible:bg-accent/50",
 				)}
 			>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetRow/PresetRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetRow/PresetRow.tsx
@@ -1,8 +1,9 @@
 import { normalizeExecutionMode } from "@superset/local-db";
 import { Badge } from "@superset/ui/badge";
+import { Eye, EyeOff } from "lucide-react";
 import { useEffect, useRef } from "react";
 import { useDrag, useDrop } from "react-dnd";
-import { LuGripVertical, LuPin } from "react-icons/lu";
+import { LuGripVertical } from "react-icons/lu";
 import type { TerminalPreset } from "renderer/routes/_authenticated/settings/presets/types";
 import {
 	getPresetProjectTargetLabel,
@@ -19,7 +20,7 @@ interface PresetRowProps {
 	onEdit: (presetId: string) => void;
 	onLocalReorder: (fromIndex: number, toIndex: number) => void;
 	onPersistReorder: (presetId: string, targetIndex: number) => void;
-	onTogglePin: (presetId: string, pinned: boolean) => void;
+	onToggleVisibility: (presetId: string, visible: boolean) => void;
 }
 
 export function PresetRow({
@@ -30,7 +31,7 @@ export function PresetRow({
 	onEdit,
 	onLocalReorder,
 	onPersistReorder,
-	onTogglePin,
+	onToggleVisibility,
 }: PresetRowProps) {
 	const rowRef = useRef<HTMLDivElement>(null);
 	const dragHandleRef = useRef<HTMLDivElement>(null);
@@ -68,6 +69,7 @@ export function PresetRow({
 
 	const isWorkspaceCreation = !!preset.applyOnWorkspaceCreated;
 	const isNewTab = !!preset.applyOnNewTab;
+	const isVisibleInBar = preset.pinnedToBar !== false;
 	const modeValue = normalizeExecutionMode(preset.executionMode);
 	const modeLabel =
 		modeValue === "new-tab"
@@ -163,22 +165,17 @@ export function PresetRow({
 					className="p-1 rounded hover:bg-accent/50 transition-colors"
 					onClick={(e) => {
 						e.stopPropagation();
-						const isPinned = preset.pinnedToBar !== false;
-						onTogglePin(preset.id, !isPinned);
+						onToggleVisibility(preset.id, !isVisibleInBar);
 					}}
-					title={preset.pinnedToBar !== false ? "Unpin from bar" : "Pin to bar"}
-					aria-label={
-						preset.pinnedToBar !== false ? "Unpin from bar" : "Pin to bar"
-					}
-					aria-pressed={preset.pinnedToBar !== false}
+					title={isVisibleInBar ? "Hide from bar" : "Show in bar"}
+					aria-label={isVisibleInBar ? "Hide from bar" : "Show in bar"}
+					aria-pressed={isVisibleInBar}
 				>
-					<LuPin
-						className={`size-3.5 ${
-							preset.pinnedToBar !== false
-								? "text-foreground"
-								: "text-muted-foreground/40"
-						}`}
-					/>
+					{isVisibleInBar ? (
+						<Eye className="size-3.5 text-foreground" />
+					) : (
+						<EyeOff className="size-3.5 text-muted-foreground/40" />
+					)}
 				</button>
 			</div>
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/PresetsSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/PresetsSection.tsx
@@ -312,11 +312,11 @@ export function PresetsSection({
 		[setPresetAutoApply],
 	);
 
-	const handleTogglePin = useCallback(
-		(presetId: string, pinned: boolean) => {
+	const handleToggleVisibility = useCallback(
+		(presetId: string, visible: boolean) => {
 			updatePreset.mutate({
 				id: presetId,
-				patch: { pinnedToBar: pinned },
+				patch: { pinnedToBar: visible },
 			});
 		},
 		[updatePreset],
@@ -485,7 +485,7 @@ export function PresetsSection({
 						onEdit={setEditingPreset}
 						onLocalReorder={handleLocalReorder}
 						onPersistReorder={handlePersistReorder}
-						onTogglePin={handleTogglePin}
+						onToggleVisibility={handleToggleVisibility}
 					/>
 					<p className="text-xs text-muted-foreground">
 						Click a preset row to edit details.

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/components/PresetsTable/PresetsTable.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/components/PresetsTable/PresetsTable.tsx
@@ -11,7 +11,7 @@ interface PresetsTableProps {
 	onEdit: (presetId: string) => void;
 	onLocalReorder: (fromIndex: number, toIndex: number) => void;
 	onPersistReorder: (presetId: string, targetIndex: number) => void;
-	onTogglePin: (presetId: string, pinned: boolean) => void;
+	onToggleVisibility: (presetId: string, visible: boolean) => void;
 }
 
 export function PresetsTable({
@@ -22,7 +22,7 @@ export function PresetsTable({
 	onEdit,
 	onLocalReorder,
 	onPersistReorder,
-	onTogglePin,
+	onToggleVisibility,
 }: PresetsTableProps) {
 	return (
 		<div className="rounded-lg border border-border overflow-hidden">
@@ -33,7 +33,7 @@ export function PresetsTable({
 				<div className="w-40 shrink-0">Applies to</div>
 				<div className="w-32 shrink-0">Mode</div>
 				<div className="w-36 shrink-0">Auto-run</div>
-				<div className="w-16 shrink-0 text-center">Pinned</div>
+				<div className="w-16 shrink-0 text-center">Visibility</div>
 			</div>
 
 			<div
@@ -55,7 +55,7 @@ export function PresetsTable({
 							onEdit={onEdit}
 							onLocalReorder={onLocalReorder}
 							onPersistReorder={onPersistReorder}
-							onTogglePin={onTogglePin}
+							onToggleVisibility={onToggleVisibility}
 						/>
 					))
 				) : (

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/V2PresetsSection/V2PresetsSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/V2PresetsSection/V2PresetsSection.tsx
@@ -393,9 +393,9 @@ export function V2PresetsSection({
 		[updateV2Preset],
 	);
 
-	const handleTogglePin = useCallback(
-		(presetId: string, pinned: boolean) => {
-			updateV2Preset(presetId, { pinnedToBar: pinned });
+	const handleToggleVisibility = useCallback(
+		(presetId: string, visible: boolean) => {
+			updateV2Preset(presetId, { pinnedToBar: visible });
 		},
 		[updateV2Preset],
 	);
@@ -557,7 +557,7 @@ export function V2PresetsSection({
 						onEdit={setEditingPreset}
 						onLocalReorder={handleLocalReorder}
 						onPersistReorder={handlePersistReorder}
-						onTogglePin={handleTogglePin}
+						onToggleVisibility={handleToggleVisibility}
 					/>
 					<p className="text-xs text-muted-foreground">
 						Click a preset row to edit details.

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/CollapsedWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/CollapsedWorkspaceItem.tsx
@@ -78,7 +78,7 @@ export function CollapsedWorkspaceItem({
 			className={cn(
 				"relative flex items-center justify-center size-8 rounded-md",
 				"transition-colors",
-				isActive ? "bg-border/30 hover:bg-border/30" : "hover:bg-muted/50",
+				isActive ? "bg-muted hover:bg-muted" : "hover:bg-muted/50",
 			)}
 		>
 			<WorkspaceIcon

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/CollapsedWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/CollapsedWorkspaceItem.tsx
@@ -77,8 +77,8 @@ export function CollapsedWorkspaceItem({
 			onMouseEnter={onMouseEnter}
 			className={cn(
 				"relative flex items-center justify-center size-8 rounded-md",
-				"hover:bg-muted/50 transition-colors",
-				isActive && "bg-muted",
+				"transition-colors",
+				isActive ? "bg-border/30 hover:bg-border/30" : "hover:bg-muted/50",
 			)}
 		>
 			<WorkspaceIcon

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -303,10 +303,11 @@ export function WorkspaceListItem({
 			onDoubleClick={isBranchWorkspace ? undefined : rename.startRename}
 			className={cn(
 				"flex w-full pl-3 pr-2 text-sm",
-				"hover:bg-muted/50 transition-colors text-left cursor-pointer",
+				"transition-colors text-left cursor-pointer",
+				isActive ? "hover:bg-border/30" : "hover:bg-muted/50",
 				"group relative",
 				showBranchSubtitle ? "py-1.5" : "py-2 items-center",
-				isActive && "bg-muted",
+				isActive && "bg-border/30",
 				isSelected && "bg-primary/10 ring-1 ring-inset ring-primary/30",
 				(isDragging || isMultiDragging) && "opacity-30",
 			)}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -304,10 +304,10 @@ export function WorkspaceListItem({
 			className={cn(
 				"flex w-full pl-3 pr-2 text-sm",
 				"transition-colors text-left cursor-pointer",
-				isActive ? "hover:bg-border/30" : "hover:bg-muted/50",
+				isActive ? "hover:bg-muted" : "hover:bg-muted/50",
 				"group relative",
 				showBranchSubtitle ? "py-1.5" : "py-2 items-center",
-				isActive && "bg-border/30",
+				isActive && "bg-muted",
 				isSelected && "bg-primary/10 ring-1 ring-inset ring-primary/30",
 				(isDragging || isMultiDragging) && "opacity-30",
 			)}

--- a/packages/panes/src/react/components/Workspace/components/Tab/Tab.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/Tab.tsx
@@ -18,6 +18,7 @@ import type {
 	RendererContext,
 } from "../../../../types";
 import { Pane } from "./components/Pane";
+import { PANE_MIN_SIZE_CLASS_NAME } from "./constants";
 
 interface TabProps<TData> {
 	store: StoreApi<WorkspaceStore<TData>>;
@@ -51,7 +52,6 @@ function SplitView<TData>({
 	const groupRef = useRef<React.ComponentRef<typeof ResizablePanelGroup>>(null);
 	const firstSize = node.splitPercentage ?? 50;
 	const secondSize = 100 - firstSize;
-	const panelMinSizeClassName = "min-h-[160px] min-w-[260px]";
 
 	return (
 		<ResizablePanelGroup
@@ -72,7 +72,10 @@ function SplitView<TData>({
 				groupRef.current?.setLayout([50, 50]);
 			}}
 		>
-			<ResizablePanel className={panelMinSizeClassName} defaultSize={firstSize}>
+			<ResizablePanel
+				className={PANE_MIN_SIZE_CLASS_NAME}
+				defaultSize={firstSize}
+			>
 				<LayoutNodeView
 					store={store}
 					tab={tab}
@@ -86,7 +89,7 @@ function SplitView<TData>({
 			</ResizablePanel>
 			<ResizableHandle />
 			<ResizablePanel
-				className={panelMinSizeClassName}
+				className={PANE_MIN_SIZE_CLASS_NAME}
 				defaultSize={secondSize}
 			>
 				<LayoutNodeView

--- a/packages/panes/src/react/components/Workspace/components/Tab/Tab.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/Tab.tsx
@@ -51,10 +51,12 @@ function SplitView<TData>({
 	const groupRef = useRef<React.ComponentRef<typeof ResizablePanelGroup>>(null);
 	const firstSize = node.splitPercentage ?? 50;
 	const secondSize = 100 - firstSize;
+	const panelMinSizeClassName = "min-h-[160px] min-w-[260px]";
 
 	return (
 		<ResizablePanelGroup
 			ref={groupRef}
+			className="min-h-full min-w-full overflow-auto"
 			direction={node.direction}
 			onLayout={(sizes) => {
 				if (sizes[0] != null) {
@@ -70,7 +72,7 @@ function SplitView<TData>({
 				groupRef.current?.setLayout([50, 50]);
 			}}
 		>
-			<ResizablePanel defaultSize={firstSize}>
+			<ResizablePanel className={panelMinSizeClassName} defaultSize={firstSize}>
 				<LayoutNodeView
 					store={store}
 					tab={tab}
@@ -83,7 +85,10 @@ function SplitView<TData>({
 				/>
 			</ResizablePanel>
 			<ResizableHandle />
-			<ResizablePanel defaultSize={secondSize}>
+			<ResizablePanel
+				className={panelMinSizeClassName}
+				defaultSize={secondSize}
+			>
 				<LayoutNodeView
 					store={store}
 					tab={tab}
@@ -165,7 +170,7 @@ export function Tab<TData>({
 	}
 
 	return (
-		<div className="flex h-full w-full min-h-0 min-w-0 overflow-hidden">
+		<div className="flex h-full w-full min-h-0 min-w-0 flex-1 overflow-auto">
 			<LayoutNodeView
 				store={store}
 				tab={tab}

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
@@ -14,6 +14,7 @@ import type {
 	RendererContext,
 } from "../../../../../../types";
 import { PaneHeaderActions } from "../../../../../PaneHeaderActions";
+import { PANE_MIN_SIZE_CLASS_NAME } from "../../constants";
 import { DropZoneOverlay } from "./components/DropZoneOverlay";
 import { PaneContent } from "./components/PaneContent";
 import { PaneContextMenu } from "./components/PaneContextMenu";
@@ -225,7 +226,7 @@ export function Pane<TData>({
 			{/* biome-ignore lint/a11y/noStaticElementInteractions: clicking anywhere in a pane focuses it (standard IDE behavior) */}
 			<div
 				ref={setRefs}
-				className="relative flex h-full min-h-[160px] w-full min-w-[260px] flex-col overflow-hidden"
+				className={`relative flex h-full w-full ${PANE_MIN_SIZE_CLASS_NAME} flex-col overflow-hidden`}
 				onMouseDown={context.actions.focus}
 			>
 				<PaneHeader

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
@@ -225,7 +225,7 @@ export function Pane<TData>({
 			{/* biome-ignore lint/a11y/noStaticElementInteractions: clicking anywhere in a pane focuses it (standard IDE behavior) */}
 			<div
 				ref={setRefs}
-				className="relative flex h-full w-full flex-col overflow-hidden"
+				className="relative flex h-full min-h-[160px] w-full min-w-[260px] flex-col overflow-hidden"
 				onMouseDown={context.actions.focus}
 			>
 				<PaneHeader

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/PaneHeader.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/PaneHeader.tsx
@@ -58,7 +58,7 @@ export function PaneHeader({
 			ref={setRef}
 			className={cn(
 				"flex h-7 shrink-0 items-center transition-[background-color] duration-150 cursor-grab",
-				isActive ? "bg-secondary" : "bg-tertiary",
+				isActive ? "bg-border/30" : "bg-transparent",
 				isDragging && "opacity-30",
 			)}
 			onClick={onClick}

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/PaneHeader.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/PaneHeader.tsx
@@ -58,7 +58,7 @@ export function PaneHeader({
 			ref={setRef}
 			className={cn(
 				"flex h-7 shrink-0 items-center transition-[background-color] duration-150 cursor-grab",
-				isActive ? "bg-border/30" : "bg-transparent",
+				isActive ? "bg-muted" : "bg-transparent",
 				isDragging && "opacity-30",
 			)}
 			onClick={onClick}

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/components/DefaultHeaderContent/DefaultHeaderContent.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/components/DefaultHeaderContent/DefaultHeaderContent.tsx
@@ -19,16 +19,17 @@ export function DefaultHeaderContent({
 	actionsContent,
 }: DefaultHeaderContentProps) {
 	return (
-		<div className="flex h-full w-full items-center justify-between px-3">
-			<div className="flex min-w-0 items-center gap-2">
+		<div className="flex h-full w-full min-w-0 items-center gap-2 px-3">
+			<div className="flex min-w-0 flex-1 items-center gap-2">
 				{titleContent ?? (
 					<>
 						{icon && <span className="shrink-0">{icon}</span>}
 						<span
 							className={cn(
-								"truncate text-sm transition-colors duration-150",
+								"truncate text-xs transition-colors duration-150",
 								isActive ? "text-foreground" : "text-muted-foreground",
 							)}
+							title={typeof title === "string" ? title : undefined}
 						>
 							{title}
 						</span>

--- a/packages/panes/src/react/components/Workspace/components/Tab/constants.ts
+++ b/packages/panes/src/react/components/Workspace/components/Tab/constants.ts
@@ -1,0 +1,1 @@
+export const PANE_MIN_SIZE_CLASS_NAME = "min-h-[160px] min-w-[260px]";

--- a/packages/panes/src/react/components/Workspace/components/TabBar/TabBar.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/TabBar.tsx
@@ -173,7 +173,7 @@ export function TabBar<TData>({
 
 	if (tabs.length === 0) {
 		return (
-			<div className="group/root-tabs flex h-10 min-w-0 shrink-0 items-stretch bg-background">
+			<div className="group/root-tabs flex h-10 min-w-0 shrink-0 items-stretch border-b border-border bg-background">
 				<div className="flex h-full w-10 shrink-0 items-stretch bg-background">
 					<AddTabButton renderAddTabMenu={renderAddTabMenu} />
 				</div>
@@ -183,7 +183,7 @@ export function TabBar<TData>({
 	}
 
 	return (
-		<div className="group/root-tabs flex h-10 min-w-0 shrink-0 items-stretch bg-background">
+		<div className="group/root-tabs flex h-10 min-w-0 shrink-0 items-stretch border-b border-border bg-background">
 			<div
 				ref={setScrollContainerRef}
 				className={cn(

--- a/packages/panes/src/react/components/Workspace/components/TabBar/TabBar.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/TabBar.tsx
@@ -173,7 +173,7 @@ export function TabBar<TData>({
 
 	if (tabs.length === 0) {
 		return (
-			<div className="group/root-tabs flex h-10 min-w-0 shrink-0 items-stretch border-b border-border bg-background">
+			<div className="group/root-tabs flex h-10 min-w-0 shrink-0 items-stretch bg-background">
 				<div className="flex h-full w-10 shrink-0 items-stretch bg-background">
 					<AddTabButton renderAddTabMenu={renderAddTabMenu} />
 				</div>
@@ -183,7 +183,7 @@ export function TabBar<TData>({
 	}
 
 	return (
-		<div className="group/root-tabs flex h-10 min-w-0 shrink-0 items-stretch border-b border-border bg-background">
+		<div className="group/root-tabs flex h-10 min-w-0 shrink-0 items-stretch bg-background">
 			<div
 				ref={setScrollContainerRef}
 				className={cn(

--- a/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
@@ -119,7 +119,7 @@ export function TabItem<TData>({
 					{isEditing ? (
 						<div className="flex h-full w-full shrink-0 items-center px-2">
 							<TabRenameInput
-								className="text-sm w-full min-w-0 rounded border border-border bg-background px-1 py-0.5 text-foreground outline-none focus:ring-1 focus:ring-ring"
+								className="w-full min-w-0 rounded border border-border bg-background px-1 py-0.5 text-xs text-foreground outline-none focus:ring-1 focus:ring-ring"
 								maxLength={64}
 								onCancel={stopEditing}
 								onChange={setEditValue}
@@ -136,7 +136,7 @@ export function TabItem<TData>({
 								<TooltipTrigger asChild>
 									<button
 										className={cn(
-											"flex h-full w-full shrink-0 items-center gap-2 pl-3 pr-8 text-left text-sm transition-all",
+											"flex h-full min-w-0 flex-1 items-center gap-1.5 pl-3 pr-1 text-left text-xs transition-all",
 											isActive
 												? "bg-border/30 text-foreground"
 												: "text-muted-foreground/70 hover:bg-tertiary/20 hover:text-muted-foreground",
@@ -151,20 +151,22 @@ export function TabItem<TData>({
 										onDoubleClick={startEditing}
 										type="button"
 									>
-										{icon}
-										<span className="flex-1 truncate">{title}</span>
-										{accessory}
+										{icon && <span className="shrink-0">{icon}</span>}
+										<span className="min-w-0 flex-1 truncate">{title}</span>
+										{accessory && (
+											<span className="shrink-0 leading-none">{accessory}</span>
+										)}
 									</button>
 								</TooltipTrigger>
 								<TooltipContent side="bottom" showArrow={false}>
 									{title}
 								</TooltipContent>
 							</Tooltip>
-							<div className="absolute right-1 top-1/2 hidden -translate-y-1/2 items-center gap-0.5 group-hover:flex">
+							<div className="flex h-full w-7 shrink-0 items-center justify-center opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
 								<Tooltip delayDuration={500}>
 									<TooltipTrigger asChild>
 										<Button
-											className="size-6 cursor-pointer hover:bg-muted"
+											className="size-5 cursor-pointer hover:bg-muted"
 											onClick={(event) => {
 												event.stopPropagation();
 												onClose();

--- a/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
@@ -164,7 +164,10 @@ export function TabItem<TData>({
 								<Tooltip delayDuration={500}>
 									<TooltipTrigger asChild>
 										<Button
-											className="size-5 cursor-pointer text-current hover:bg-muted"
+											className={cn(
+												"size-5 cursor-pointer text-current",
+												isActive ? "hover:bg-foreground/10" : "hover:bg-muted",
+											)}
 											onClick={(event) => {
 												event.stopPropagation();
 												onClose();

--- a/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
@@ -110,7 +110,10 @@ export function TabItem<TData>({
 				<div
 					ref={setRef}
 					className={cn(
-						"group relative flex h-full w-full items-center border-r border-border",
+						"group relative flex h-full w-full items-center border-r border-border transition-colors",
+						isActive
+							? "bg-border/30 text-foreground"
+							: "text-muted-foreground/70 hover:bg-tertiary/20 hover:text-muted-foreground",
 						isPaneOver && "bg-primary/5",
 						isDragging && "opacity-30",
 					)}
@@ -135,12 +138,7 @@ export function TabItem<TData>({
 							>
 								<TooltipTrigger asChild>
 									<button
-										className={cn(
-											"flex h-full min-w-0 flex-1 items-center gap-1.5 pl-3 pr-1 text-left text-xs transition-all",
-											isActive
-												? "bg-border/30 text-foreground"
-												: "text-muted-foreground/70 hover:bg-tertiary/20 hover:text-muted-foreground",
-										)}
+										className="flex h-full min-w-0 flex-1 items-center gap-1.5 pl-3 pr-1 text-left text-xs transition-colors"
 										onAuxClick={(event) => {
 											if (event.button === 1) {
 												event.preventDefault();
@@ -166,7 +164,7 @@ export function TabItem<TData>({
 								<Tooltip delayDuration={500}>
 									<TooltipTrigger asChild>
 										<Button
-											className="size-5 cursor-pointer hover:bg-muted"
+											className="size-5 cursor-pointer text-current hover:bg-muted"
 											onClick={(event) => {
 												event.stopPropagation();
 												onClose();

--- a/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
@@ -112,7 +112,7 @@ export function TabItem<TData>({
 					className={cn(
 						"group relative flex h-full w-full items-center border-r border-border transition-colors",
 						isActive
-							? "bg-border/30 text-foreground"
+							? "bg-muted text-foreground"
 							: "text-muted-foreground/70 hover:bg-tertiary/20 hover:text-muted-foreground",
 						isPaneOver && "bg-primary/5",
 						isDragging && "opacity-30",


### PR DESCRIPTION
## Summary

Updates the v2 workspace pane headers and sizing behavior so compact pane layouts remain readable and usable.

- Adds truncation-friendly header layouts for file, diff, terminal, browser, chat, comment, and default pane titles.
- Handles long diff file paths with compact typography, smaller controls, and a full-path hover title.
- Adds responsive minimum pane sizing and overflow handling so small windows scroll instead of crushing pane content.

## Why

Small or heavily split v2 workspaces could cause pane header text and controls to crowd each other, especially with long file paths. The file viewer and diff file headers needed the same compact behavior as existing v1 examples.

## Impact

Users should see more consistent pane headers across v2, with long labels truncated cleanly and controls remaining accessible when panes are narrow.

## Manual testing

1. Run `bun run --cwd apps/desktop dev`.
2. Open a v2 workspace.
3. Open file, diff, terminal, browser, chat, comment, and devtools panes.
4. In the file pane, open a long file path and confirm the header text truncates without overlapping controls.
5. In the diff pane, use a file with a long path and confirm the diff file header truncates, counts stay visible, and collapse/viewed/action buttons still work.
6. Split panes horizontally and vertically, then shrink the app window until space is tight.
7. Confirm panes keep usable minimum sizing and scroll instead of crushing headers or hiding controls.

## Validation

- `bun run --cwd packages/panes typecheck`
- `bun run --cwd apps/desktop typecheck`
- `bunx @biomejs/biome@2.4.2 check $(git diff --name-only)`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Tightened layout, spacing, and icon/text sizes across toolbars, panes, tabs, headers and lists for a more compact UI
  * Improved truncation and added title/tooltips for long filenames, URLs, sessions and view labels
  * Enforced minimum panel dimensions and enabled sensible scrolling/overflow for better responsiveness
  * Adjusted button, divider and control spacing/visibility for more predictable alignment and compression across breakpoints

* **New Features**
  * Presets bar now shows "visible" presets (replaces pinned workflow) and settings expose a visibility toggle for presets
<!-- end of auto-generated comment: release notes by coderabbit.ai -->