### PR TITLE
[codex] Stabilize v2 terminal resize

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -18,6 +18,7 @@ const STORAGE_KEY_PREFIX = "terminal-buffer:";
 const DIMS_KEY_PREFIX = "terminal-dims:";
 const DEFAULT_COLS = 120;
 const DEFAULT_ROWS = 32;
+const RESIZE_DEBOUNCE_MS = 75;
 
 // xterm's _keyDown calls stopPropagation after processing, so any chord we
 // want the host (react-hotkeys-hook, Electron menu accelerators) or the shell
@@ -84,6 +85,7 @@ export interface TerminalRuntime {
 	wrapper: HTMLDivElement;
 	container: HTMLDivElement | null;
 	resizeObserver: ResizeObserver | null;
+	_disposeResizeObserver: (() => void) | null;
 	lastCols: number;
 	lastRows: number;
 	_disposeAddons: (() => void) | null;
@@ -204,11 +206,69 @@ function getParkingContainer(): HTMLDivElement {
 	return el;
 }
 
-function measureAndResize(runtime: TerminalRuntime) {
-	if (!hostIsVisible(runtime.container)) return;
+function measureAndResize(runtime: TerminalRuntime): boolean {
+	if (!hostIsVisible(runtime.container)) return false;
+	const { terminal } = runtime;
+	const buffer = terminal.buffer.active;
+	const wasPinnedToBottom = buffer.viewportY >= buffer.baseY;
+	const savedViewportY = buffer.viewportY;
+	const prevCols = terminal.cols;
+	const prevRows = terminal.rows;
+
 	runtime.fitAddon.fit();
-	runtime.lastCols = runtime.terminal.cols;
-	runtime.lastRows = runtime.terminal.rows;
+	runtime.lastCols = terminal.cols;
+	runtime.lastRows = terminal.rows;
+	terminal.refresh(0, Math.max(0, terminal.rows - 1));
+
+	if (wasPinnedToBottom) {
+		terminal.scrollToBottom();
+	} else {
+		const targetY = Math.min(savedViewportY, terminal.buffer.active.baseY);
+		if (terminal.buffer.active.viewportY !== targetY) {
+			terminal.scrollToLine(targetY);
+		}
+	}
+
+	return terminal.cols !== prevCols || terminal.rows !== prevRows;
+}
+
+function createResizeScheduler(
+	runtime: TerminalRuntime,
+	onResize?: () => void,
+): {
+	observe: ResizeObserverCallback;
+	dispose: () => void;
+} {
+	let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+	const dispose = () => {
+		if (timeoutId !== null) {
+			clearTimeout(timeoutId);
+			timeoutId = null;
+		}
+	};
+
+	const run = () => {
+		timeoutId = null;
+		const changed = measureAndResize(runtime);
+		if (changed) onResize?.();
+	};
+
+	const observe: ResizeObserverCallback = (entries) => {
+		if (
+			entries.some(
+				(entry) =>
+					entry.contentRect.width <= 0 || entry.contentRect.height <= 0,
+			)
+		) {
+			dispose();
+			return;
+		}
+		dispose();
+		timeoutId = setTimeout(run, RESIZE_DEBOUNCE_MS);
+	};
+
+	return { observe, dispose };
 }
 
 export function createRuntime(
@@ -252,6 +312,7 @@ export function createRuntime(
 		wrapper,
 		container: null,
 		resizeObserver: null,
+		_disposeResizeObserver: null,
 		lastCols: cols,
 		lastRows: rows,
 		_disposeAddons: addonsResult.dispose,
@@ -275,18 +336,16 @@ export function attachToContainer(
 
 	runtime.container = container;
 	container.appendChild(runtime.wrapper);
-	measureAndResize(runtime);
+	if (measureAndResize(runtime)) onResize?.();
 
-	// Renderer may have skipped frames while the wrapper was detached.
-	runtime.terminal.refresh(0, runtime.terminal.rows - 1);
-
+	runtime._disposeResizeObserver?.();
+	runtime._disposeResizeObserver = null;
 	runtime.resizeObserver?.disconnect();
-	const observer = new ResizeObserver(() => {
-		measureAndResize(runtime);
-		onResize?.();
-	});
+	const scheduler = createResizeScheduler(runtime, onResize);
+	const observer = new ResizeObserver(scheduler.observe);
 	observer.observe(container);
 	runtime.resizeObserver = observer;
+	runtime._disposeResizeObserver = scheduler.dispose;
 
 	runtime.terminal.focus();
 }
@@ -294,6 +353,8 @@ export function attachToContainer(
 export function detachFromContainer(runtime: TerminalRuntime) {
 	persistBuffer(runtime.terminalId, runtime.serializeAddon);
 	persistDimensions(runtime.terminalId, runtime.lastCols, runtime.lastRows);
+	runtime._disposeResizeObserver?.();
+	runtime._disposeResizeObserver = null;
 	runtime.resizeObserver?.disconnect();
 	runtime.resizeObserver = null;
 	// Park instead of .remove() so xterm survives the React unmount —
@@ -306,7 +367,7 @@ export function updateRuntimeAppearance(
 	runtime: TerminalRuntime,
 	appearance: TerminalAppearance,
 ) {
-	const { terminal, fitAddon } = runtime;
+	const { terminal } = runtime;
 	terminal.options.theme = appearance.theme;
 
 	const fontChanged =
@@ -317,9 +378,7 @@ export function updateRuntimeAppearance(
 		terminal.options.fontFamily = appearance.fontFamily;
 		terminal.options.fontSize = appearance.fontSize;
 		if (hostIsVisible(runtime.container)) {
-			fitAddon.fit();
-			runtime.lastCols = terminal.cols;
-			runtime.lastRows = terminal.rows;
+			measureAndResize(runtime);
 		}
 	}
 }
@@ -335,6 +394,8 @@ export function disposeRuntime(
 	}
 	runtime._disposeAddons?.();
 	runtime._disposeAddons = null;
+	runtime._disposeResizeObserver?.();
+	runtime._disposeResizeObserver = null;
 	runtime.resizeObserver?.disconnect();
 	runtime.resizeObserver = null;
 	runtime.wrapper.remove();

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -218,7 +218,6 @@ function measureAndResize(runtime: TerminalRuntime): boolean {
 	runtime.fitAddon.fit();
 	runtime.lastCols = terminal.cols;
 	runtime.lastRows = terminal.rows;
-	terminal.refresh(0, Math.max(0, terminal.rows - 1));
 
 	if (wasPinnedToBottom) {
 		terminal.scrollToBottom();
@@ -228,6 +227,8 @@ function measureAndResize(runtime: TerminalRuntime): boolean {
 			terminal.scrollToLine(targetY);
 		}
 	}
+
+	terminal.refresh(0, Math.max(0, terminal.rows - 1));
 
 	return terminal.cols !== prevCols || terminal.rows !== prevRows;
 }

--- a/plans/20260425-v2-terminal-rendering-divergences.md
+++ b/plans/20260425-v2-terminal-rendering-divergences.md
@@ -1,0 +1,240 @@
+# V2 Terminal Rendering Divergences vs VS Code / Hyper / Tabby
+
+Compares our v2 xterm.js setup against three reference Electron+xterm terminals
+and lists divergences that can plausibly cause rendering bugs (flicker, blurry
+text, cell drift, ghost glyphs, scroll jumps, GPU atlas issues).
+
+**Amended validation:** This document was reviewed against the current repo on
+2026-04-25. The points below now distinguish confirmed issues from weaker
+hypotheses and from items already handled by xterm internals.
+
+**Our code (shared by v2 via `terminal-runtime-registry`):**
+- `apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts`
+- `apps/desktop/src/renderer/lib/terminal/terminal-addons.ts`
+- v2 pane: `apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx`
+
+**References (verified locally):**
+- VS Code: `/Users/kietho/workplace/vscode/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts`
+- Tabby: `/Users/kietho/workplace/tabby/tabby-terminal/src/frontends/xtermFrontend.ts`
+- Hyper: `/Users/kietho/workplace/hyper/lib/components/term.tsx`
+
+---
+
+## 1. Font loading race on first open
+
+**Status:** Partially valid.
+
+**Us:** `terminal-runtime.ts:232` — `terminal.open(wrapper)` runs immediately
+after construction. xterm measures cell width with whatever font is resolved at
+that moment. If the final font loads after the first measurement, dimensions and
+WebGL atlas contents can diverge from the actual rendered font, causing
+mis-clipped chars, ghost glyphs, or first-paint reflow.
+
+**Correction:** The original text overemphasized JetBrains Mono. In our default
+stack, JetBrains Mono is a local/system font candidate, not an app-bundled
+`@font-face`. The stronger async risk is `SF Mono` via
+`apps/desktop/src/renderer/styles/bundled-fonts.css` (`font-display: swap`) and
+any user-selected font that is resolved through CSS font loading. Also, Tabby
+does not wait before `open()`; it opens first, waits a tick for font/layout
+settling, then configures colors/WebGL (`xtermFrontend.ts:275-306`).
+
+**Fix:** Do not make `createRuntime()` async unless the registry lifecycle is
+rewired. Prefer a bounded post-open font-settle step:
+- after `terminal.open(wrapper)`, wait for `document.fonts.ready` or
+  `document.fonts.load(\`${size}px ${family}\`)` when available;
+- then call `measureAndResize(runtime)`, `terminal.clearTextureAtlas()` if using
+  the built-in API or the WebGL addon is exposed, and `terminal.refresh(...)`;
+- apply the same settle/refit path after font changes at
+  `terminal-runtime.ts:317`.
+
+---
+
+## 2. `devicePixelRatio` / display-metrics monitoring
+
+**Status:** Mostly invalid as originally written.
+
+**Us:** Superset app code does not add its own DPR listener. However, xterm 6.1
+already monitors DPR internally:
+- `@xterm/xterm/src/browser/services/CoreBrowserService.ts` has
+  `ScreenDprMonitor`, implemented with `matchMedia("screen and (resolution:
+  ...dppx)")` and re-armed on every change.
+- `RenderService.handleDevicePixelRatioChange()` remeasures char size and
+  forwards DPR changes to the active renderer.
+- `@xterm/addon-webgl/src/WebglRenderer.ts` updates `_devicePixelRatio`, resizes
+  render dimensions, refreshes the atlas, and redraws.
+
+**Ref:** Tabby additionally subscribes to `displayMetricsChanged$` and clears
+both atlases:
+```
+xtermFrontend.ts:290  this.webGLAddon?.clearTextureAtlas()
+xtermFrontend.ts:301  this.canvasAddon?.clearTextureAtlas()
+```
+
+**Fix:** Do not add an app-level DPR listener without a reproducible Electron
+case showing xterm's built-in monitor is insufficient. If we later see stale
+atlases after monitor moves or zoom changes, expose a `forceRedraw()`/atlas-clear
+method from our addon loader and call it from the existing visibility/focus
+recovery path, not from a duplicate global DPR watcher by default.
+
+---
+
+## 3. Subpixel container sizing in v2 pane
+
+**Status:** Plausible, but overclaimed.
+
+**Us:** `TerminalPane.tsx:382-396`
+```
+className="flex h-full w-full flex-col p-2"      ← outer p-2
+  └ "relative min-h-0 flex-1 overflow-hidden"     ← flex-1 middle
+      └ "h-full w-full"                            ← xterm mounts here
+```
+
+`connectionState === "closed"` adds a real sibling row at `TerminalPane.tsx:405`.
+`TerminalSearch` is absolute positioned and does not participate in flex layout,
+so it should not be counted as a sizing sibling. The outer `p-2` and flex sizing
+can still leave the xterm parent with fractional CSS dimensions depending on the
+split/pane layout. `fitAddon.fit()` floors cols/rows based on parsed parent
+dimensions and xterm's WebGL canvas derives its own rounded CSS dimensions from
+device pixels, so this remains a plausible source of 1-2px drift or blur.
+
+**Ref:** VS Code does not pad the xterm container itself; Hyper applies padding via `term.element.style.padding` (`term.tsx:253,460`) so xterm sees and accounts for it.
+
+**Fix:** Instrument before changing layout: log/compare the container
+`contentRect`, `terminal.dimensions.css.canvas`, and actual canvas style size
+across split widths and DPR values. If confirmed, either move padding off the
+wrapper chain so xterm mounts in a stable integer-sized box, or apply padding via
+`terminal.element.style.padding` after `open()` like Hyper so the fit addon
+subtracts it intentionally.
+
+---
+
+## 4. ResizeObserver fires `fit()` undebounced
+
+**Status:** Valid.
+
+**Us:** `terminal-runtime.ts:284-285` — observer callback calls `measureAndResize` (which calls `fitAddon.fit()`) directly. Sidebar/pane animations fire 10+ times per second.
+
+**Ref:**
+- Tabby defers via `setImmediate` (`xtermFrontend.ts:508`).
+- Hyper uses `setTimeout` debounce (`term.tsx:486`).
+- VS Code uses `@debounce(100)` on refresh paths.
+
+**Fix:** Wrap the observer callback in a ~50-100ms debounce, or rAF + trailing
+edge. Skip when `entry.contentRect.width === 0 || height === 0`. Also only call
+`onResize`/send backend resize when `terminal.cols` or `terminal.rows` actually
+changed; the current callback always calls `onResize?.()` after `measureAndResize`.
+
+---
+
+## 5. No scroll-position preservation across resize
+
+**Status:** Valid.
+
+**Us:** `terminal-runtime.ts:207-212` `measureAndResize` calls `fit()` without saving viewport.
+
+**Ref:** Tabby saves and restores around resize:
+```
+xtermFrontend.ts:427  const savedViewportY = this.xterm.buffer.active.viewportY
+xtermFrontend.ts:432  // Restore scroll position — xterm internally disturbs viewportY
+xtermFrontend.ts:437  if (this.xterm.buffer.active.viewportY !== targetY) ...
+```
+
+**Fix:** Mirror Tabby's pattern in `measureAndResize`, but preserve pinned-to-bottom
+separately:
+- before `fit()`, capture `viewportY`, `baseY`, and whether the viewport is at
+  the bottom;
+- after `fit()`, if it was pinned, `scrollToBottom()`;
+- otherwise clamp the saved `viewportY` to the new `baseY` and `scrollToLine`.
+
+---
+
+## 6. Missing xterm options
+
+**Status:** Partially valid, but not all options are rendering-bug fixes.
+
+**Us:** `terminal-runtime.ts:106-108` sets `cursorBlink`, `fontFamily`, `fontSize`, theme, scrollback. Does **not** set `minimumContrastRatio`, `drawBoldTextInBrightColors`, or `allowTransparency`.
+
+**Ref:** VS Code sets all three:
+```
+xtermTerminal.ts:226  drawBoldTextInBrightColors: config.drawBoldTextInBrightColors
+xtermTerminal.ts:235  minimumContrastRatio: config.minimumContrastRatio
+xtermTerminal.ts:261  allowTransparency: config.enableImages
+```
+
+**Correction:** `drawBoldTextInBrightColors` defaults to `true` in xterm 6.1, so
+setting it explicitly is documentation more than behavior change. Built-in
+terminal backgrounds are opaque hex colors (`ember`, `monokai`, `light`, and the
+dark/light defaults), while only selection colors use alpha; therefore
+`allowTransparency: false` is currently the correct performance-oriented value.
+`minimumContrastRatio: 4.5` is valid for accessibility, but it changes colors
+dynamically and should be treated as a product/color decision rather than a
+rendering-fidelity fix.
+
+**Fix:** Optionally set `drawBoldTextInBrightColors: true` and
+`allowTransparency: false` explicitly to lock in intended behavior. Defer
+`minimumContrastRatio` to a separate accessibility/theme decision.
+
+---
+
+## 7. No PTY backpressure on the renderer side
+
+**Status:** Valid problem, incomplete proposed fix.
+
+**Us:** Stream handler calls `terminal.write(data)` without the completion callback, so xterm's internal queue can grow unbounded under bursty output (e.g. `cat large.log`).
+
+**Ref:** Tabby's `FlowControl` class blocks past N pending callbacks:
+```
+xtermFrontend.ts:25   class FlowControl {
+xtermFrontend.ts:119  this.flowControl = new FlowControl(this.xterm)
+```
+
+**Correction:** Browser `WebSocket` cannot be paused like a Node stream. Host
+service sends with `socket.send(JSON.stringify(message))` and does not currently
+have a renderer ack/backpressure protocol. A renderer-side write queue can
+prevent unbounded xterm writes, but it will not stop upstream buffering by itself.
+
+**Fix:** Short term: wrap `terminal.write(data, callback)` in a renderer queue
+with high/low watermarks so xterm is not flooded. Long term: add an explicit
+pause/resume or credit/ack protocol between renderer and host service before
+claiming end-to-end PTY backpressure.
+
+---
+
+## 8. WebGL/ligatures recreation on context loss
+
+**Status:** Partially valid, but the original wording was inaccurate.
+
+**Us:** `terminal-addons.ts:43` loads `LigaturesAddon` in try/catch. WebGL load
+at `:46-56` already registers `webglAddon.onContextLoss`, disposes the WebGL
+addon, nulls it, and refreshes. What is missing is an intentional reinitialization
+strategy after falling back to DOM and any coordination between ligatures and
+WebGL atlas recreation.
+
+**Ref:** VS Code has `_refreshLigaturesAddon()` that disposes+recreates when WebGL toggles or recovers (xtermTerminal.ts, search `_refreshLigaturesAddon`).
+
+**Fix:** Keep the existing context-loss disposal, but expose a recovery path:
+dispose/recreate WebGL and refresh ligatures when GPU rendering is re-enabled or
+on the next visibility/focus recovery. Lower priority because it only triggers on
+real GPU resets.
+
+---
+
+## Suggested fix order
+
+1. Resize handling (#4 + #5) — debounce observer callbacks, skip zero-size
+   entries, send backend resize only on cols/rows changes, and preserve
+   scroll/pinned-to-bottom state across `fit()`.
+2. Font settle/refit (#1) — add a bounded post-open and post-font-change font
+   readiness/refit path without making the registry lifecycle accidentally async.
+3. Subpixel padding investigation (#3) — instrument actual container/canvas sizes
+   first; only then move padding or apply it via `terminal.element.style.padding`.
+4. xterm option explicitness (#6) — explicitly set defaults we rely on
+   (`drawBoldTextInBrightColors: true`, `allowTransparency: false`) if desired;
+   treat `minimumContrastRatio` as a separate theme/accessibility decision.
+5. Renderer write queue / protocol backpressure (#7) — useful for heavy output,
+   but needs a renderer queue first and host-service protocol work for true
+   backpressure.
+6. WebGL/ligature recovery (#8) — separate low-priority follow-up.
+
+Do not prioritize an app-level DPR listener (#2) unless there is a concrete repro
+showing xterm 6.1's built-in DPR monitor fails in our Electron window.


### PR DESCRIPTION
## Summary
- debounce v2 terminal ResizeObserver refits and skip zero-size observer entries
- preserve scroll position and pinned-to-bottom state around xterm fit calls
- only send backend resize messages when cols or rows actually change
- document the verified terminal rendering divergence analysis and follow-up order

## Root Cause
The v2 terminal resize path called fit immediately for every ResizeObserver callback, did not preserve xterm viewport state around fit, and notified the backend even when terminal dimensions were unchanged. During pane/sidebar/window layout churn this could produce excess resize traffic and visible scroll/render instability.

## Validation
- bunx biome check --write --unsafe apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
- bun run --cwd apps/desktop typecheck
- manually validated temporary resize instrumentation across attach, split resize, disconnected-to-open socket transition, and multiple terminals

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes v2 terminal resizing to remove flicker and scroll jumps while reducing unnecessary resize messages to the backend. Also adds a plan documenting verified terminal rendering divergences and follow-ups.

- **Bug Fixes**
  - Debounced `ResizeObserver` callbacks (75ms) and ignored zero-size entries.
  - Preserved scroll position and pinned-to-bottom across `fit()`, then explicitly refreshed the viewport.
  - Sent backend resize only when `cols` or `rows` changed.
  - Disposed scheduled resize work and observers on attach, detach, and dispose.

<sup>Written for commit 505f24c907801466223680ea6156af2683976322. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Smoother terminal resizing with debounce to reduce flicker and only trigger updates when size changes.
  * Better preservation and restoration of scroll/viewport during resizes and font appearance changes.
* **Documentation**
  * Added a planning document analyzing terminal rendering behaviors and recommended fixes for stability and font/load sequencing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->