### PR TITLE
refactor(desktop): tidy v2 terminal session dropdown

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
@@ -203,10 +203,6 @@ export function TerminalSessionDropdown({
 	};
 
 	const triggerTitle = context.pane.titleOverride ?? "Terminal";
-	const currentSession = sessions.find(
-		(session) => session.terminalId === terminalId,
-	);
-	const currentCreatedAtLabel = formatCreatedAt(currentSession?.createdAt);
 
 	return (
 		<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
@@ -214,14 +210,13 @@ export function TerminalSessionDropdown({
 				<button
 					type="button"
 					aria-label="Terminal sessions"
-					className="flex min-w-0 max-w-72 items-center gap-1.5 rounded px-1.5 py-0.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+					className="flex min-w-32 max-w-96 items-center gap-1.5 rounded px-1.5 py-0.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
 					onMouseDown={(event) => event.stopPropagation()}
 					onClick={(event) => event.stopPropagation()}
 				>
 					<TerminalSquare className="size-4 shrink-0" />
-					<span className="min-w-0 truncate">{triggerTitle}</span>
-					<span className="shrink-0 text-[10px] text-muted-foreground/70">
-						{currentCreatedAtLabel}
+					<span className="min-w-0 flex-1 truncate text-left">
+						{triggerTitle}
 					</span>
 					{sessionsQuery.isFetching && isOpen ? (
 						<LoaderCircle className="size-3 shrink-0 animate-spin" />
@@ -230,7 +225,7 @@ export function TerminalSessionDropdown({
 					)}
 				</button>
 			</DropdownMenuTrigger>
-			<DropdownMenuContent align="start" className="w-80">
+			<DropdownMenuContent align="start" className="w-96">
 				<DropdownMenuLabel className="text-xs">
 					Terminal Sessions
 				</DropdownMenuLabel>
@@ -268,7 +263,7 @@ export function TerminalSessionDropdown({
 									<span className="min-w-0 flex-1 truncate text-xs">
 										{title}
 									</span>
-									<span className="shrink-0 text-[10px] text-muted-foreground/70">
+									<span className="shrink-0 text-xs text-muted-foreground/70">
 										{createdAtLabel}
 									</span>
 									<span className="shrink-0 text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary
- Drop the time-ago label from the trigger so the selected terminal title reads clean
- Widen the trigger (`min-w-32 max-w-96`) and the menu (`w-96`), and push the chevron/spinner to the trailing edge via `flex-1` on the title
- Unify dropdown row text sizes — the per-row created-at label is now `text-xs` like the rest

## Test plan
- [ ] Open a v2 workspace with multiple terminal sessions and confirm the trigger shows just the title + chevron
- [ ] Open the dropdown and verify all rows (label, title, time, status, "New Terminal") share the same text size
- [ ] Resize the pane narrow/wide and confirm the trigger respects min/max width with the chevron pinned to the right

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up the v2 terminal session dropdown for a cleaner title and consistent text. Removes the timestamp from the trigger, constrains widths, and aligns the chevron/spinner to the right.

- **Refactors**
  - Remove time-ago label from the trigger; show only the title.
  - Set trigger to min-w-32/max-w-96 and menu to w-96; make title flex-1 to push chevron/spinner to the right.
  - Standardize dropdown row text to text-xs, including the created-at label.

<sup>Written for commit e1cffca7522a38d224a936fdbf4eb3cb6283a866. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved terminal session dropdown layout with fixed width sizing for better consistency.
  * Increased dropdown menu width for improved readability.
  * Adjusted typography scaling for session metadata labels.
  * Simplified dropdown trigger display for cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->