### PR TITLE
[codex] Fix v2 workspace sidebar sync

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/page.tsx
@@ -62,6 +62,7 @@ function useFireIntent(pendingId: string, pending: PendingWorkspaceRow | null) {
 	const hostUrl = useHostTargetUrl(pending?.hostTarget ?? null);
 	const { data: session } = authClient.useSession();
 	const activeOrganizationId = session?.session?.activeOrganizationId ?? null;
+	const { ensureWorkspaceInSidebar } = useDashboardSidebarState();
 
 	const fire = useCallback(async () => {
 		if (!pending) return;
@@ -144,6 +145,15 @@ function useFireIntent(pendingId: string, pending: PendingWorkspaceRow | null) {
 				}
 			}
 
+			// Register in the sidebar as soon as the workspace exists. The
+			// post-create navigate effect also calls this, but only fires while
+			// the user is still on the pending page and after workspace sync
+			// completes — calling it here guarantees the row appears even if the
+			// user has navigated away or sync is slow.
+			if (result.workspace?.id) {
+				ensureWorkspaceInSidebar(result.workspace.id, pending.projectId);
+			}
+
 			// V2 dispatch: after host-service.create resolves, build the launch
 			// plan and stash it on the pending row. The V2 workspace page's
 			// useConsumePendingLaunch mount-effect picks it up and opens the
@@ -198,6 +208,7 @@ function useFireIntent(pendingId: string, pending: PendingWorkspaceRow | null) {
 		createWorkspace,
 		checkoutWorkspace,
 		adoptWorktree,
+		ensureWorkspaceInSidebar,
 		pending,
 		pendingId,
 		trpcUtils,


### PR DESCRIPTION
## Summary

- Register newly created v2 workspaces in local sidebar state as soon as host-service returns a workspace id.
- Keep succeeded pending rows visible as a `Syncing...` placeholder until the Electric workspace row is renderable.
- Treat optional sidebar/pane-layout/agent-launch follow-up failures as warnings after workspace creation, instead of marking the create as failed.

## Root Cause

V2 workspace creation is split between host-service and renderer-owned, device-local sidebar state. Host-service can successfully create the worktree/cloud/local workspace rows, but the renderer pending route was the only place that added the new workspace to local sidebar state. If that route unmounted, reloaded, or failed during optional post-create launch setup, the workspace could exist without appearing in the sidebar.

## Validation

- `bunx @biomejs/biome@2.4.2 check apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarCollapsedWorkspaceButton/DashboardSidebarCollapsedWorkspaceButton.tsx apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/DashboardSidebarWorkspaceIcon.tsx apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/utils/getCreationStatusText.ts apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/types.ts apps/desktop/src/renderer/routes/_authenticated/_dashboard/pending/$pendingId/page.tsx`
- `bun run --cwd apps/desktop typecheck`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Syncing..." workspace status for post-creation/succeeded pending items.
  * Delete dialogs now fire an immediate "delete started" event to trigger pre-delete actions.
  * Sidebar exposes a cleanup action to remove pending entries for a workspace.

* **Improvements**
  * Newly created workspaces auto-register in the sidebar; failures surface as non-blocking warnings/toasts.
  * Safer pending-workspace handling: conditional updates/deletes, deduplication, richer host metadata, and automatic cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->