### PR TITLE
[codex] Refactor v2 workspace page

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useClearActivePaneAttention/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useClearActivePaneAttention/index.ts
@@ -1,0 +1,1 @@
+export { useClearActivePaneAttention } from "./useClearActivePaneAttention";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useClearActivePaneAttention/useClearActivePaneAttention.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useClearActivePaneAttention/useClearActivePaneAttention.ts
@@ -1,0 +1,36 @@
+import type { WorkspaceStore } from "@superset/panes";
+import { useEffect } from "react";
+import {
+	getV2NotificationSourcesForPane,
+	useV2NotificationStore,
+	useV2PaneNotificationStatus,
+} from "renderer/stores/v2-notifications";
+import { useStore } from "zustand";
+import type { StoreApi } from "zustand/vanilla";
+import type { PaneViewerData } from "../../types";
+
+export function useClearActivePaneAttention({
+	workspaceId,
+	store,
+}: {
+	workspaceId: string;
+	store: StoreApi<WorkspaceStore<PaneViewerData>>;
+}): void {
+	const activePane = useStore(store, (state) => {
+		const tab = state.tabs.find(
+			(candidate) => candidate.id === state.activeTabId,
+		);
+		return tab?.activePaneId ? tab.panes[tab.activePaneId] : undefined;
+	});
+	const activePaneStatus = useV2PaneNotificationStatus(workspaceId, activePane);
+	const clearSourceAttention = useV2NotificationStore(
+		(state) => state.clearSourceAttention,
+	);
+
+	useEffect(() => {
+		if (activePaneStatus !== "review") return;
+		for (const source of getV2NotificationSourcesForPane(activePane)) {
+			clearSourceAttention(source, workspaceId);
+		}
+	}, [activePane, activePaneStatus, clearSourceAttention, workspaceId]);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useDefaultPaneActions/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useDefaultPaneActions/index.ts
@@ -1,0 +1,1 @@
+export { useDefaultPaneActions } from "./useDefaultPaneActions";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useDefaultPaneActions/useDefaultPaneActions.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useDefaultPaneActions/useDefaultPaneActions.tsx
@@ -1,0 +1,40 @@
+import type { PaneActionConfig } from "@superset/panes";
+import { useMemo } from "react";
+import { HiMiniXMark } from "react-icons/hi2";
+import { TbLayoutColumns, TbLayoutRows } from "react-icons/tb";
+import { HotkeyLabel } from "renderer/hotkeys";
+import type { PaneViewerData, TerminalPaneData } from "../../types";
+
+export function useDefaultPaneActions(): PaneActionConfig<PaneViewerData>[] {
+	return useMemo<PaneActionConfig<PaneViewerData>[]>(
+		() => [
+			{
+				key: "split",
+				icon: (ctx) =>
+					ctx.pane.parentDirection === "horizontal" ? (
+						<TbLayoutRows className="size-3.5" />
+					) : (
+						<TbLayoutColumns className="size-3.5" />
+					),
+				tooltip: <HotkeyLabel label="Split pane" id="SPLIT_AUTO" />,
+				onClick: (ctx) => {
+					const position =
+						ctx.pane.parentDirection === "horizontal" ? "down" : "right";
+					ctx.actions.split(position, {
+						kind: "terminal",
+						data: {
+							terminalId: crypto.randomUUID(),
+						} as TerminalPaneData,
+					});
+				},
+			},
+			{
+				key: "close",
+				icon: <HiMiniXMark className="size-3.5" />,
+				tooltip: <HotkeyLabel label="Close pane" id="CLOSE_PANE" />,
+				onClick: (ctx) => ctx.actions.close(),
+			},
+		],
+		[],
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useDirtyTabCloseGuard/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useDirtyTabCloseGuard/index.ts
@@ -1,0 +1,1 @@
+export { useDirtyTabCloseGuard } from "./useDirtyTabCloseGuard";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useDirtyTabCloseGuard/useDirtyTabCloseGuard.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useDirtyTabCloseGuard/useDirtyTabCloseGuard.ts
@@ -1,0 +1,76 @@
+import type { WorkspaceProps } from "@superset/panes";
+import { alert } from "@superset/ui/atoms/Alert";
+import { useCallback } from "react";
+import { getBaseName } from "renderer/lib/pathBasename";
+import { getDocument } from "../../state/fileDocumentStore";
+import type { FilePaneData, PaneViewerData } from "../../types";
+
+type OnBeforeCloseTab = NonNullable<
+	WorkspaceProps<PaneViewerData>["onBeforeCloseTab"]
+>;
+
+export function useDirtyTabCloseGuard({
+	workspaceId,
+}: {
+	workspaceId: string;
+}): OnBeforeCloseTab {
+	return useCallback<OnBeforeCloseTab>(
+		(tab) => {
+			const dirtyPanes = Object.values(tab.panes).filter((pane) => {
+				if (pane.kind !== "file") return false;
+				const filePath = (pane.data as FilePaneData).filePath;
+				return getDocument(workspaceId, filePath)?.dirty === true;
+			});
+			const dirtyFileNames = dirtyPanes.map((pane) =>
+				getBaseName((pane.data as FilePaneData).filePath),
+			);
+			if (dirtyPanes.length === 0) return true;
+			const title =
+				dirtyPanes.length === 1
+					? `Do you want to save the changes you made to ${dirtyFileNames[0]}?`
+					: `Do you want to save changes to ${dirtyPanes.length} files?`;
+			return new Promise<boolean>((resolve) => {
+				alert({
+					title,
+					description: "Your changes will be lost if you don't save them.",
+					actions: [
+						{
+							label: "Save All",
+							onClick: async () => {
+								for (const pane of dirtyPanes) {
+									const filePath = (pane.data as FilePaneData).filePath;
+									const doc = getDocument(workspaceId, filePath);
+									if (!doc) continue;
+									const result = await doc.save();
+									if (result.status !== "saved") {
+										resolve(false);
+										return;
+									}
+								}
+								resolve(true);
+							},
+						},
+						{
+							label: "Don't Save",
+							variant: "secondary",
+							onClick: async () => {
+								for (const pane of dirtyPanes) {
+									const filePath = (pane.data as FilePaneData).filePath;
+									const doc = getDocument(workspaceId, filePath);
+									if (doc) await doc.reload();
+								}
+								resolve(true);
+							},
+						},
+						{
+							label: "Cancel",
+							variant: "ghost",
+							onClick: () => resolve(false),
+						},
+					],
+				});
+			});
+		},
+		[workspaceId],
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceFileNavigation/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceFileNavigation/index.ts
@@ -1,0 +1,1 @@
+export { useWorkspaceFileNavigation } from "./useWorkspaceFileNavigation";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceFileNavigation/useWorkspaceFileNavigation.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceFileNavigation/useWorkspaceFileNavigation.ts
@@ -1,0 +1,161 @@
+import type { WorkspaceStore } from "@superset/panes";
+import { workspaceTrpc } from "@superset/workspace-client";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { V2UserPreferencesApi } from "renderer/hooks/useV2UserPreferences";
+import {
+	toAbsoluteWorkspacePath,
+	toRelativeWorkspacePath,
+} from "shared/absolute-paths";
+import { useStore } from "zustand";
+import type { StoreApi } from "zustand/vanilla";
+import type { FilePaneData, PaneViewerData } from "../../types";
+import {
+	type RecentFile,
+	useRecentlyViewedFiles,
+} from "../useRecentlyViewedFiles";
+
+interface PendingReveal {
+	path: string;
+	isDirectory: boolean;
+}
+
+export function useWorkspaceFileNavigation({
+	workspaceId,
+	store,
+	setRightSidebarOpen,
+	setRightSidebarTab,
+}: {
+	workspaceId: string;
+	store: StoreApi<WorkspaceStore<PaneViewerData>>;
+	setRightSidebarOpen: V2UserPreferencesApi["setRightSidebarOpen"];
+	setRightSidebarTab: V2UserPreferencesApi["setRightSidebarTab"];
+}): {
+	openFilePane: (filePath: string, openInNewTab?: boolean) => void;
+	revealPath: (
+		path: string,
+		options?: {
+			isDirectory?: boolean;
+		},
+	) => void;
+	selectedFilePath: string | undefined;
+	pendingReveal: PendingReveal | null;
+	recentFiles: RecentFile[];
+	openFilePaths: Set<string>;
+} {
+	const workspaceQuery = workspaceTrpc.workspace.get.useQuery({
+		id: workspaceId,
+	});
+	const worktreePath = workspaceQuery.data?.worktreePath ?? "";
+
+	const { recentFiles, recordView } = useRecentlyViewedFiles(workspaceId);
+
+	const activeFilePanePath = useStore(store, (state) => {
+		const tab = state.tabs.find(
+			(candidate) => candidate.id === state.activeTabId,
+		);
+		if (!tab?.activePaneId) return undefined;
+		const pane = tab.panes[tab.activePaneId];
+		if (pane?.kind === "file") return (pane.data as FilePaneData).filePath;
+		return undefined;
+	});
+
+	const [selectedFilePath, setSelectedFilePath] = useState<string | undefined>(
+		activeFilePanePath,
+	);
+	// Every reveal request is a fresh object, so the FilesTab effect keyed on
+	// `pendingReveal` re-runs even when the path is the same (for example, the
+	// user collapsed a folder and re-requested it from the terminal).
+	const [pendingReveal, setPendingReveal] = useState<PendingReveal | null>(
+		null,
+	);
+
+	useEffect(() => {
+		if (activeFilePanePath !== undefined) {
+			setSelectedFilePath(activeFilePanePath);
+			setPendingReveal({ path: activeFilePanePath, isDirectory: false });
+		}
+	}, [activeFilePanePath]);
+
+	const openFilePathsKey = useStore(store, (state) =>
+		state.tabs
+			.flatMap((tab) =>
+				Object.values(tab.panes)
+					.filter((pane) => pane.kind === "file")
+					.map((pane) => (pane.data as FilePaneData).filePath),
+			)
+			.join("\u0000"),
+	);
+	const openFilePaths = useMemo(
+		() => new Set(openFilePathsKey ? openFilePathsKey.split("\u0000") : []),
+		[openFilePathsKey],
+	);
+
+	const openFilePane = useCallback(
+		(filePath: string, openInNewTab?: boolean) => {
+			const absoluteFilePath = worktreePath
+				? toAbsoluteWorkspacePath(worktreePath, filePath)
+				: filePath;
+			if (worktreePath) {
+				const relativePath = toRelativeWorkspacePath(
+					worktreePath,
+					absoluteFilePath,
+				);
+				if (relativePath && relativePath !== ".") {
+					recordView({ relativePath, absolutePath: absoluteFilePath });
+				}
+			}
+			const state = store.getState();
+			if (openInNewTab) {
+				state.addTab({
+					panes: [
+						{
+							kind: "file",
+							data: {
+								filePath: absoluteFilePath,
+								mode: "editor",
+							} as FilePaneData,
+						},
+					],
+				});
+				return;
+			}
+			const active = state.getActivePane();
+			if (
+				active?.pane.kind === "file" &&
+				(active.pane.data as FilePaneData).filePath === absoluteFilePath
+			) {
+				state.setPanePinned({ paneId: active.pane.id, pinned: true });
+				return;
+			}
+			state.openPane({
+				pane: {
+					kind: "file",
+					data: {
+						filePath: absoluteFilePath,
+						mode: "editor",
+					} as FilePaneData,
+				},
+			});
+		},
+		[store, worktreePath, recordView],
+	);
+
+	const revealPath = useCallback(
+		(path: string, options?: { isDirectory?: boolean }) => {
+			setRightSidebarOpen(true);
+			setRightSidebarTab("files");
+			setSelectedFilePath(path);
+			setPendingReveal({ path, isDirectory: options?.isDirectory === true });
+		},
+		[setRightSidebarOpen, setRightSidebarTab],
+	);
+
+	return {
+		openFilePane,
+		revealPath,
+		selectedFilePath,
+		pendingReveal,
+		recentFiles,
+		openFilePaths,
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspacePaneOpeners/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspacePaneOpeners/index.ts
@@ -1,0 +1,1 @@
+export { useWorkspacePaneOpeners } from "./useWorkspacePaneOpeners";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspacePaneOpeners/useWorkspacePaneOpeners.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspacePaneOpeners/useWorkspacePaneOpeners.ts
@@ -1,0 +1,141 @@
+import type { WorkspaceStore } from "@superset/panes";
+import { useCallback } from "react";
+import type { StoreApi } from "zustand/vanilla";
+import type {
+	BrowserPaneData,
+	ChatPaneData,
+	CommentPaneData,
+	DiffPaneData,
+	PaneViewerData,
+	TerminalPaneData,
+} from "../../types";
+
+export function useWorkspacePaneOpeners({
+	store,
+}: {
+	store: StoreApi<WorkspaceStore<PaneViewerData>>;
+}): {
+	openDiffPane: (filePath: string, openInNewTab?: boolean) => void;
+	addTerminalTab: () => void;
+	addChatTab: () => void;
+	addBrowserTab: () => void;
+	openCommentPane: (comment: CommentPaneData) => void;
+} {
+	const openDiffPane = useCallback(
+		(filePath: string, openInNewTab?: boolean) => {
+			const state = store.getState();
+			if (openInNewTab) {
+				state.addTab({
+					panes: [
+						{
+							kind: "diff",
+							data: {
+								path: filePath,
+								collapsedFiles: [],
+							} as DiffPaneData,
+						},
+					],
+				});
+				return;
+			}
+			for (const tab of state.tabs) {
+				for (const pane of Object.values(tab.panes)) {
+					if (pane.kind !== "diff") continue;
+					const prev = pane.data as DiffPaneData;
+					state.setPaneData({
+						paneId: pane.id,
+						data: {
+							...prev,
+							path: filePath,
+						} as PaneViewerData,
+					});
+					state.setActiveTab(tab.id);
+					state.setActivePane({ tabId: tab.id, paneId: pane.id });
+					return;
+				}
+			}
+			state.openPane({
+				pane: {
+					kind: "diff",
+					data: {
+						path: filePath,
+						collapsedFiles: [],
+					} as DiffPaneData,
+				},
+			});
+		},
+		[store],
+	);
+
+	const addTerminalTab = useCallback(() => {
+		store.getState().addTab({
+			panes: [
+				{
+					kind: "terminal",
+					data: {
+						terminalId: crypto.randomUUID(),
+					} as TerminalPaneData,
+				},
+			],
+		});
+	}, [store]);
+
+	const addChatTab = useCallback(() => {
+		store.getState().addTab({
+			panes: [
+				{
+					kind: "chat",
+					data: { sessionId: null } as ChatPaneData,
+				},
+			],
+		});
+	}, [store]);
+
+	const addBrowserTab = useCallback(() => {
+		store.getState().addTab({
+			panes: [
+				{
+					kind: "browser",
+					data: {
+						url: "about:blank",
+					} as BrowserPaneData,
+				},
+			],
+		});
+	}, [store]);
+
+	const openCommentPane = useCallback(
+		(comment: CommentPaneData) => {
+			const state = store.getState();
+			for (const tab of state.tabs) {
+				for (const pane of Object.values(tab.panes)) {
+					if (pane.kind !== "comment") continue;
+					state.setPaneData({
+						paneId: pane.id,
+						data: comment as PaneViewerData,
+					});
+					state.setActiveTab(tab.id);
+					state.setActivePane({ tabId: tab.id, paneId: pane.id });
+					return;
+				}
+			}
+			state.addTab({
+				panes: [
+					{
+						kind: "comment",
+						data: comment as PaneViewerData,
+					},
+				],
+			});
+		},
+		[store],
+	);
+
+	return {
+		openDiffPane,
+		addTerminalTab,
+		addChatTab,
+		addBrowserTab,
+		openCommentPane,
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -1,38 +1,18 @@
-import {
-	type PaneActionConfig,
-	Workspace,
-	type WorkspaceStore,
-} from "@superset/panes";
-import { alert } from "@superset/ui/atoms/Alert";
+import { Workspace } from "@superset/panes";
 import {
 	ResizableHandle,
 	ResizablePanel,
 	ResizablePanelGroup,
 } from "@superset/ui/resizable";
-import { workspaceTrpc } from "@superset/workspace-client";
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { createFileRoute } from "@tanstack/react-router";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { HiMiniXMark } from "react-icons/hi2";
-import { TbLayoutColumns, TbLayoutRows } from "react-icons/tb";
+import { useCallback, useState } from "react";
 import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences";
-import { HotkeyLabel, useHotkey } from "renderer/hotkeys";
-import { getBaseName } from "renderer/lib/pathBasename";
+import { useHotkey } from "renderer/hotkeys";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { CommandPalette } from "renderer/screens/main/components/CommandPalette";
-import {
-	getV2NotificationSourcesForPane,
-	getV2NotificationSourcesForTab,
-	useV2NotificationStore,
-	useV2PaneNotificationStatus,
-} from "renderer/stores/v2-notifications";
-import {
-	toAbsoluteWorkspacePath,
-	toRelativeWorkspacePath,
-} from "shared/absolute-paths";
-import { useStore } from "zustand";
-import type { StoreApi } from "zustand/vanilla";
+import { getV2NotificationSourcesForTab } from "renderer/stores/v2-notifications";
 import { WorkspaceNotFoundState } from "../components/WorkspaceNotFoundState";
 import { AddTabMenu } from "./components/AddTabMenu";
 import { V2NotificationStatusIndicator } from "./components/V2NotificationStatusIndicator";
@@ -40,29 +20,22 @@ import { V2PresetsBar } from "./components/V2PresetsBar";
 import { WorkspaceEmptyState } from "./components/WorkspaceEmptyState";
 import { WorkspaceSidebar } from "./components/WorkspaceSidebar";
 import { useBrowserShellInteractionPassthrough } from "./hooks/useBrowserShellInteractionPassthrough";
+import { useClearActivePaneAttention } from "./hooks/useClearActivePaneAttention";
 import { useConsumeAutomationRunLink } from "./hooks/useConsumeAutomationRunLink";
 import { useConsumeOpenUrlRequest } from "./hooks/useConsumeOpenUrlRequest";
 import { useConsumePendingLaunch } from "./hooks/useConsumePendingLaunch";
 import { useDefaultContextMenuActions } from "./hooks/useDefaultContextMenuActions";
+import { useDefaultPaneActions } from "./hooks/useDefaultPaneActions";
+import { useDirtyTabCloseGuard } from "./hooks/useDirtyTabCloseGuard";
 import { usePaneRegistry } from "./hooks/usePaneRegistry";
 import { renderBrowserTabIcon } from "./hooks/usePaneRegistry/components/BrowserPane";
-import { useRecentlyViewedFiles } from "./hooks/useRecentlyViewedFiles";
 import { useV2PresetExecution } from "./hooks/useV2PresetExecution";
 import { useV2WorkspacePaneLayout } from "./hooks/useV2WorkspacePaneLayout";
+import { useWorkspaceFileNavigation } from "./hooks/useWorkspaceFileNavigation";
 import { useWorkspaceHotkeys } from "./hooks/useWorkspaceHotkeys";
-import {
-	FileDocumentStoreProvider,
-	getDocument,
-} from "./state/fileDocumentStore";
-import type {
-	BrowserPaneData,
-	ChatPaneData,
-	CommentPaneData,
-	DiffPaneData,
-	FilePaneData,
-	PaneViewerData,
-	TerminalPaneData,
-} from "./types";
+import { useWorkspacePaneOpeners } from "./hooks/useWorkspacePaneOpeners";
+import { FileDocumentStoreProvider } from "./state/fileDocumentStore";
+import type { PaneViewerData } from "./types";
 import type { V2WorkspaceUrlOpenTarget } from "./utils/openUrlInV2Workspace";
 
 interface WorkspaceSearch {
@@ -143,37 +116,6 @@ function V2WorkspacePage() {
 	);
 }
 
-/**
- * Clear post-completion attention only for the pane the user is actually
- * viewing. Clearing every review status on route entry would drop background
- * tab attention before the user has looked at that pane.
- */
-function useClearActivePaneAttention({
-	workspaceId,
-	store,
-}: {
-	workspaceId: string;
-	store: StoreApi<WorkspaceStore<PaneViewerData>>;
-}): void {
-	const activePane = useStore(store, (state) => {
-		const tab = state.tabs.find(
-			(candidate) => candidate.id === state.activeTabId,
-		);
-		return tab?.activePaneId ? tab.panes[tab.activePaneId] : undefined;
-	});
-	const activePaneStatus = useV2PaneNotificationStatus(workspaceId, activePane);
-	const clearSourceAttention = useV2NotificationStore(
-		(state) => state.clearSourceAttention,
-	);
-
-	useEffect(() => {
-		if (activePaneStatus !== "review") return;
-		for (const source of getV2NotificationSourcesForPane(activePane)) {
-			clearSourceAttention(source, workspaceId);
-		}
-	}, [activePane, activePaneStatus, clearSourceAttention, workspaceId]);
-}
-
 function WorkspaceContent({
 	projectId,
 	workspaceId,
@@ -224,263 +166,37 @@ function WorkspaceContent({
 		requestId: openUrlRequestId,
 	});
 
-	const workspaceQuery = workspaceTrpc.workspace.get.useQuery({
-		id: workspaceId,
+	const {
+		openFilePane,
+		revealPath,
+		selectedFilePath,
+		pendingReveal,
+		recentFiles,
+		openFilePaths,
+	} = useWorkspaceFileNavigation({
+		workspaceId,
+		store,
+		setRightSidebarOpen,
+		setRightSidebarTab,
 	});
-	const worktreePath = workspaceQuery.data?.worktreePath ?? "";
-
-	const { recentFiles, recordView } = useRecentlyViewedFiles(workspaceId);
-
-	const activeFilePanePath = useStore(store, (s) => {
-		const tab = s.tabs.find((t) => t.id === s.activeTabId);
-		if (!tab?.activePaneId) return undefined;
-		const pane = tab.panes[tab.activePaneId];
-		if (pane?.kind === "file") return (pane.data as FilePaneData).filePath;
-		return undefined;
-	});
-
-	const [selectedFilePath, setSelectedFilePath] = useState<string | undefined>(
-		activeFilePanePath,
-	);
-	// Every reveal request is a fresh object, so the FilesTab effect keyed on
-	// `pendingReveal` re-runs even when the path is the same (e.g. user
-	// collapsed a folder and re-⌘-clicked it in the terminal).
-	const [pendingReveal, setPendingReveal] = useState<{
-		path: string;
-		isDirectory: boolean;
-	} | null>(null);
-
-	useEffect(() => {
-		if (activeFilePanePath !== undefined) {
-			setSelectedFilePath(activeFilePanePath);
-			setPendingReveal({ path: activeFilePanePath, isDirectory: false });
-		}
-	}, [activeFilePanePath]);
-
-	const openFilePathsKey = useStore(store, (s) =>
-		s.tabs
-			.flatMap((t) =>
-				Object.values(t.panes)
-					.filter((p) => p.kind === "file")
-					.map((p) => (p.data as FilePaneData).filePath),
-			)
-			.join("\u0000"),
-	);
-	const openFilePaths = useMemo(
-		() => new Set(openFilePathsKey ? openFilePathsKey.split("\u0000") : []),
-		[openFilePathsKey],
-	);
-
-	const openFilePane = useCallback(
-		(filePath: string, openInNewTab?: boolean) => {
-			const absoluteFilePath = worktreePath
-				? toAbsoluteWorkspacePath(worktreePath, filePath)
-				: filePath;
-			if (worktreePath) {
-				const relativePath = toRelativeWorkspacePath(
-					worktreePath,
-					absoluteFilePath,
-				);
-				if (relativePath && relativePath !== ".") {
-					recordView({ relativePath, absolutePath: absoluteFilePath });
-				}
-			}
-			const state = store.getState();
-			if (openInNewTab) {
-				state.addTab({
-					panes: [
-						{
-							kind: "file",
-							data: {
-								filePath: absoluteFilePath,
-								mode: "editor",
-							} as FilePaneData,
-						},
-					],
-				});
-				return;
-			}
-			const active = state.getActivePane();
-			if (
-				active?.pane.kind === "file" &&
-				(active.pane.data as FilePaneData).filePath === absoluteFilePath
-			) {
-				state.setPanePinned({ paneId: active.pane.id, pinned: true });
-				return;
-			}
-			state.openPane({
-				pane: {
-					kind: "file",
-					data: {
-						filePath: absoluteFilePath,
-						mode: "editor",
-					} as FilePaneData,
-				},
-			});
-		},
-		[store, worktreePath, recordView],
-	);
-
-	const revealPath = useCallback(
-		(path: string, options?: { isDirectory?: boolean }) => {
-			setRightSidebarOpen(true);
-			setRightSidebarTab("files");
-			setSelectedFilePath(path);
-			setPendingReveal({ path, isDirectory: options?.isDirectory === true });
-		},
-		[setRightSidebarOpen, setRightSidebarTab],
-	);
 
 	const paneRegistry = usePaneRegistry(workspaceId, {
 		onOpenFile: openFilePane,
 		onRevealPath: revealPath,
 	});
 	const defaultContextMenuActions = useDefaultContextMenuActions(paneRegistry);
-
-	const openDiffPane = useCallback(
-		(filePath: string, openInNewTab?: boolean) => {
-			const state = store.getState();
-			if (openInNewTab) {
-				state.addTab({
-					panes: [
-						{
-							kind: "diff",
-							data: {
-								path: filePath,
-								collapsedFiles: [],
-							} as DiffPaneData,
-						},
-					],
-				});
-				return;
-			}
-			for (const tab of state.tabs) {
-				for (const pane of Object.values(tab.panes)) {
-					if (pane.kind !== "diff") continue;
-					const prev = pane.data as DiffPaneData;
-					state.setPaneData({
-						paneId: pane.id,
-						data: {
-							...prev,
-							path: filePath,
-						} as PaneViewerData,
-					});
-					state.setActiveTab(tab.id);
-					state.setActivePane({ tabId: tab.id, paneId: pane.id });
-					return;
-				}
-			}
-			state.openPane({
-				pane: {
-					kind: "diff",
-					data: {
-						path: filePath,
-						collapsedFiles: [],
-					} as DiffPaneData,
-				},
-			});
-		},
-		[store],
-	);
-
-	const addTerminalTab = useCallback(() => {
-		store.getState().addTab({
-			panes: [
-				{
-					kind: "terminal",
-					data: {
-						terminalId: crypto.randomUUID(),
-					} as TerminalPaneData,
-				},
-			],
-		});
-	}, [store]);
-
-	const addChatTab = useCallback(() => {
-		store.getState().addTab({
-			panes: [
-				{
-					kind: "chat",
-					data: { sessionId: null } as ChatPaneData,
-				},
-			],
-		});
-	}, [store]);
-
-	const addBrowserTab = useCallback(() => {
-		store.getState().addTab({
-			panes: [
-				{
-					kind: "browser",
-					data: {
-						url: "about:blank",
-					} as BrowserPaneData,
-				},
-			],
-		});
-	}, [store]);
-
-	const openCommentPane = useCallback(
-		(comment: CommentPaneData) => {
-			const state = store.getState();
-			for (const tab of state.tabs) {
-				for (const pane of Object.values(tab.panes)) {
-					if (pane.kind !== "comment") continue;
-					state.setPaneData({
-						paneId: pane.id,
-						data: comment as PaneViewerData,
-					});
-					state.setActiveTab(tab.id);
-					state.setActivePane({ tabId: tab.id, paneId: pane.id });
-					return;
-				}
-			}
-			state.addTab({
-				panes: [
-					{
-						kind: "comment",
-						data: comment as PaneViewerData,
-					},
-				],
-			});
-		},
-		[store],
-	);
+	const {
+		openDiffPane,
+		addTerminalTab,
+		addChatTab,
+		addBrowserTab,
+		openCommentPane,
+	} = useWorkspacePaneOpeners({ store });
 
 	const [quickOpenOpen, setQuickOpenOpen] = useState(false);
 	const handleQuickOpen = useCallback(() => setQuickOpenOpen(true), []);
-
-	const defaultPaneActions = useMemo<PaneActionConfig<PaneViewerData>[]>(
-		() => [
-			{
-				key: "split",
-				icon: (ctx) =>
-					ctx.pane.parentDirection === "horizontal" ? (
-						<TbLayoutRows className="size-3.5" />
-					) : (
-						<TbLayoutColumns className="size-3.5" />
-					),
-				tooltip: <HotkeyLabel label="Split pane" id="SPLIT_AUTO" />,
-				onClick: (ctx) => {
-					const position =
-						ctx.pane.parentDirection === "horizontal" ? "down" : "right";
-					ctx.actions.split(position, {
-						kind: "terminal",
-						data: {
-							terminalId: crypto.randomUUID(),
-						} as TerminalPaneData,
-					});
-				},
-			},
-			{
-				key: "close",
-				icon: <HiMiniXMark className="size-3.5" />,
-				tooltip: <HotkeyLabel label="Close pane" id="CLOSE_PANE" />,
-				onClick: (ctx) => ctx.actions.close(),
-			},
-		],
-		[],
-	);
+	const defaultPaneActions = useDefaultPaneActions();
+	const onBeforeCloseTab = useDirtyTabCloseGuard({ workspaceId });
 
 	const sidebarOpen = v2UserPreferences.rightSidebarOpen;
 	const { onSidebarResizeDragging, onWorkspaceInteractionStateChange } =
@@ -537,65 +253,7 @@ function WorkspaceContent({
 									onOpenTerminal={addTerminalTab}
 								/>
 							)}
-							onBeforeCloseTab={(tab) => {
-								const dirtyPanes = Object.values(tab.panes).filter((p) => {
-									if (p.kind !== "file") return false;
-									const filePath = (p.data as FilePaneData).filePath;
-									return getDocument(workspaceId, filePath)?.dirty === true;
-								});
-								const dirtyFileNames = dirtyPanes.map((p) =>
-									getBaseName((p.data as FilePaneData).filePath),
-								);
-								if (dirtyPanes.length === 0) return true;
-								const title =
-									dirtyPanes.length === 1
-										? `Do you want to save the changes you made to ${dirtyFileNames[0]}?`
-										: `Do you want to save changes to ${dirtyPanes.length} files?`;
-								return new Promise<boolean>((resolve) => {
-									alert({
-										title,
-										description:
-											"Your changes will be lost if you don't save them.",
-										actions: [
-											{
-												label: "Save All",
-												onClick: async () => {
-													for (const pane of dirtyPanes) {
-														const filePath = (pane.data as FilePaneData)
-															.filePath;
-														const doc = getDocument(workspaceId, filePath);
-														if (!doc) continue;
-														const result = await doc.save();
-														if (result.status !== "saved") {
-															resolve(false);
-															return;
-														}
-													}
-													resolve(true);
-												},
-											},
-											{
-												label: "Don't Save",
-												variant: "secondary",
-												onClick: async () => {
-													for (const pane of dirtyPanes) {
-														const filePath = (pane.data as FilePaneData)
-															.filePath;
-														const doc = getDocument(workspaceId, filePath);
-														if (doc) await doc.reload();
-													}
-													resolve(true);
-												},
-											},
-											{
-												label: "Cancel",
-												variant: "ghost",
-												onClick: () => resolve(false),
-											},
-										],
-									});
-								});
-							}}
+							onBeforeCloseTab={onBeforeCloseTab}
 							onInteractionStateChange={onWorkspaceInteractionStateChange}
 							store={store}
 						/>


### PR DESCRIPTION
## Summary
- Split v2 workspace page responsibilities into focused route-local hooks.
- Moved active-pane notification clearing, file navigation state, pane openers, default pane actions, and dirty-tab close guarding out of `page.tsx`.
- Kept the page as orchestration for route data, layout, and wiring without changing behavior.
- Passed the existing sidebar preference setters into file navigation to avoid adding a duplicate preferences live-query subscription.

## Regression Review
- Local semantic diff review against `origin/main`: no behavior changes found.
- Independent subagent review: no actionable regressions found; PR safe to keep as-is.

## Validation
- `bunx biome check --write` on touched files
- `bunx biome check` on touched files
- `bun --filter @superset/desktop typecheck`
- `bun --filter @superset/desktop test` — 1821 pass, 0 fail


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic clearing of attention badges when reviewing a pane.
  * Quick actions to open terminals, chats, browsers, diffs, and comment panes.
  * File open/reveal controls with improved recent/opened-file tracking.

* **Refactor**
  * Workspace page logic split into dedicated hooks for pane actions, navigation, and close-guarding.
  * Tab closing now prompts to save/reload dirty files with clear choices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->