### PR TITLE
Revert "[codex] Refit v2 terminal after font settle"

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
@@ -10,12 +10,7 @@ import type { Terminal as XTerm } from "@xterm/xterm";
 export interface LoadAddonsResult {
 	searchAddon: SearchAddon;
 	progressAddon: ProgressAddon;
-	clearTextureAtlas: () => void;
 	dispose: () => void;
-}
-
-interface LoadAddonsOptions {
-	onRendererChange?: () => void;
 }
 
 // Once WebGL fails, skip it for all subsequent runtimes (VS Code pattern).
@@ -26,10 +21,7 @@ let suggestedRendererType: "webgl" | "dom" | undefined;
  * function and addon instances. WebGL is deferred to rAF to avoid
  * racing with xterm's post-open viewport sync.
  */
-export function loadAddons(
-	terminal: XTerm,
-	options: LoadAddonsOptions = {},
-): LoadAddonsResult {
+export function loadAddons(terminal: XTerm): LoadAddonsResult {
 	let disposed = false;
 	let webglAddon: WebglAddon | null = null;
 
@@ -59,11 +51,9 @@ export function loadAddons(
 			webglAddon.onContextLoss(() => {
 				webglAddon?.dispose();
 				webglAddon = null;
-				options.onRendererChange?.();
 				terminal.refresh(0, terminal.rows - 1);
 			});
 			terminal.loadAddon(webglAddon);
-			options.onRendererChange?.();
 		} catch {
 			suggestedRendererType = "dom";
 			webglAddon = null;
@@ -73,11 +63,6 @@ export function loadAddons(
 	return {
 		searchAddon,
 		progressAddon,
-		clearTextureAtlas: () => {
-			try {
-				webglAddon?.clearTextureAtlas();
-			} catch {}
-		},
 		dispose: () => {
 			disposed = true;
 			cancelAnimationFrame(rafId);

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -19,8 +19,6 @@ const DIMS_KEY_PREFIX = "terminal-dims:";
 const DEFAULT_COLS = 120;
 const DEFAULT_ROWS = 32;
 const RESIZE_DEBOUNCE_MS = 75;
-const FONT_SETTLE_TIMEOUT_MS = 1000;
-const FONT_LOAD_SAMPLE_TEXT = "W";
 
 // xterm's _keyDown calls stopPropagation after processing, so any chord we
 // want the host (react-hotkeys-hook, Electron menu accelerators) or the shell
@@ -88,10 +86,6 @@ export interface TerminalRuntime {
 	container: HTMLDivElement | null;
 	resizeObserver: ResizeObserver | null;
 	_disposeResizeObserver: (() => void) | null;
-	_disposeFontSettle: (() => void) | null;
-	_onResize: (() => void) | null;
-	_clearTextureAtlas: (() => void) | null;
-	_fontSettleToken: number;
 	lastCols: number;
 	lastRows: number;
 	_disposeAddons: (() => void) | null;
@@ -184,53 +178,6 @@ function hostIsVisible(container: HTMLDivElement | null): boolean {
 	return container.clientWidth > 0 && container.clientHeight > 0;
 }
 
-function waitForNextFrame(): Promise<void> {
-	if (typeof requestAnimationFrame !== "function") {
-		return Promise.resolve();
-	}
-	return new Promise((resolve) => requestAnimationFrame(() => resolve()));
-}
-
-function waitForTerminalFont(
-	terminal: XTerm,
-	timeoutMs = FONT_SETTLE_TIMEOUT_MS,
-): Promise<void> {
-	const fontFamily = terminal.options.fontFamily;
-	const fontSize = terminal.options.fontSize;
-	if (
-		typeof document === "undefined" ||
-		!("fonts" in document) ||
-		typeof fontFamily !== "string" ||
-		typeof fontSize !== "number"
-	) {
-		return waitForNextFrame();
-	}
-
-	const fontSpec = `${fontSize}px ${fontFamily}`;
-	let timeoutId: ReturnType<typeof setTimeout> | null = null;
-	const timeout = new Promise<void>((resolve) => {
-		timeoutId = setTimeout(resolve, timeoutMs);
-	});
-	let fontLoad: Promise<void>;
-	try {
-		fontLoad = document.fonts
-			.load(fontSpec, FONT_LOAD_SAMPLE_TEXT)
-			.catch(() => document.fonts.ready)
-			.then(() => undefined)
-			.catch(() => undefined);
-	} catch {
-		fontLoad = document.fonts.ready
-			.then(() => undefined)
-			.catch(() => undefined);
-	}
-
-	return Promise.race([fontLoad, timeout])
-		.then(() => waitForNextFrame())
-		.finally(() => {
-			if (timeoutId !== null) clearTimeout(timeoutId);
-		});
-}
-
 // Body-level hidden container that owns wrapper divs of terminals whose
 // React component is currently unmounted (e.g. workspace switch). Keeps
 // xterm attached to the document so it survives provider remounts without
@@ -284,33 +231,6 @@ function measureAndResize(runtime: TerminalRuntime): boolean {
 	terminal.refresh(0, Math.max(0, terminal.rows - 1));
 
 	return terminal.cols !== prevCols || terminal.rows !== prevRows;
-}
-
-function scheduleFontSettleRefit(runtime: TerminalRuntime) {
-	runtime._disposeFontSettle?.();
-
-	let disposed = false;
-	const token = runtime._fontSettleToken + 1;
-	runtime._fontSettleToken = token;
-
-	runtime._disposeFontSettle = () => {
-		disposed = true;
-		if (runtime._fontSettleToken === token) {
-			runtime._disposeFontSettle = null;
-		}
-	};
-
-	void waitForTerminalFont(runtime.terminal).then(() => {
-		if (disposed || runtime._fontSettleToken !== token) return;
-		runtime._disposeFontSettle = null;
-		if (!hostIsVisible(runtime.container)) return;
-
-		// A late-loading font can change cell metrics after xterm's first fit.
-		runtime._clearTextureAtlas?.();
-		if (measureAndResize(runtime)) {
-			runtime._onResize?.();
-		}
-	});
 }
 
 function createResizeScheduler(
@@ -376,19 +296,14 @@ export function createRuntime(
 
 	// Activate Unicode 11 widths (inside loadAddons) before restoring the buffer,
 	// else CJK/emoji/ZWJ widths get baked wrong into the replay. (#3572)
-	let runtime: TerminalRuntime | null = null;
-	const addonsResult = loadAddons(terminal, {
-		onRendererChange: () => {
-			if (runtime) scheduleFontSettleRefit(runtime);
-		},
-	});
+	const addonsResult = loadAddons(terminal);
 	if (options.initialBuffer !== undefined) {
 		terminal.write(options.initialBuffer);
 	} else {
 		restoreBuffer(terminalId, terminal);
 	}
 
-	runtime = {
+	return {
 		terminalId,
 		terminal,
 		fitAddon,
@@ -399,15 +314,10 @@ export function createRuntime(
 		container: null,
 		resizeObserver: null,
 		_disposeResizeObserver: null,
-		_disposeFontSettle: null,
-		_onResize: null,
-		_clearTextureAtlas: addonsResult.clearTextureAtlas,
-		_fontSettleToken: 0,
 		lastCols: cols,
 		lastRows: rows,
 		_disposeAddons: addonsResult.dispose,
 	};
-	return runtime;
 }
 
 export function attachToContainer(
@@ -418,7 +328,6 @@ export function attachToContainer(
 	// If we're already attached to this exact container, do nothing. Prevents
 	// redundant refresh/focus/fit from transient remounts during provider key
 	// churn — VSCode setVisible() is idempotent for the same host element.
-	runtime._onResize = onResize ?? null;
 	const sameContainer =
 		runtime.container === container &&
 		runtime.wrapper.parentElement === container;
@@ -429,7 +338,6 @@ export function attachToContainer(
 	runtime.container = container;
 	container.appendChild(runtime.wrapper);
 	if (measureAndResize(runtime)) onResize?.();
-	scheduleFontSettleRefit(runtime);
 
 	runtime._disposeResizeObserver?.();
 	runtime._disposeResizeObserver = null;
@@ -448,9 +356,6 @@ export function detachFromContainer(runtime: TerminalRuntime) {
 	persistDimensions(runtime.terminalId, runtime.lastCols, runtime.lastRows);
 	runtime._disposeResizeObserver?.();
 	runtime._disposeResizeObserver = null;
-	runtime._disposeFontSettle?.();
-	runtime._disposeFontSettle = null;
-	runtime._onResize = null;
 	runtime.resizeObserver?.disconnect();
 	runtime.resizeObserver = null;
 	// Park instead of .remove() so xterm survives the React unmount —
@@ -475,7 +380,6 @@ export function updateRuntimeAppearance(
 		terminal.options.fontSize = appearance.fontSize;
 		if (hostIsVisible(runtime.container)) {
 			measureAndResize(runtime);
-			scheduleFontSettleRefit(runtime);
 		}
 	}
 }
@@ -493,9 +397,6 @@ export function disposeRuntime(
 	runtime._disposeAddons = null;
 	runtime._disposeResizeObserver?.();
 	runtime._disposeResizeObserver = null;
-	runtime._disposeFontSettle?.();
-	runtime._disposeFontSettle = null;
-	runtime._onResize = null;
 	runtime.resizeObserver?.disconnect();
 	runtime.resizeObserver = null;
 	runtime.wrapper.remove();

--- a/plans/20260425-v2-terminal-rendering-divergences.md
+++ b/plans/20260425-v2-terminal-rendering-divergences.md
@@ -22,7 +22,7 @@ hypotheses and from items already handled by xterm internals.
 
 ## 1. Font loading race on first open
 
-**Status:** Implemented after PR #3739.
+**Status:** Partially valid.
 
 **Us:** `terminal-runtime.ts:232` — `terminal.open(wrapper)` runs immediately
 after construction. xterm measures cell width with whatever font is resolved at
@@ -38,17 +38,14 @@ any user-selected font that is resolved through CSS font loading. Also, Tabby
 does not wait before `open()`; it opens first, waits a tick for font/layout
 settling, then configures colors/WebGL (`xtermFrontend.ts:275-306`).
 
-**Fix:** Implemented without making `createRuntime()` async. The runtime now
-stores the active resize sender, exposes WebGL atlas clearing from
-`terminal-addons.ts`, and schedules a bounded font-settle refit after attach,
-after font changes, and after WebGL renderer changes:
-- wait for `document.fonts.load(\`${size}px ${family}\`)` when available, capped
-  by `FONT_SETTLE_TIMEOUT_MS`, then wait one animation frame for layout to
-  settle;
-- clear the WebGL texture atlas when present;
-- run the existing `measureAndResize(runtime)` path, which preserves viewport
-  state, refreshes the terminal, and sends backend resize only when cols/rows
-  change.
+**Fix:** Do not make `createRuntime()` async unless the registry lifecycle is
+rewired. Prefer a bounded post-open font-settle step:
+- after `terminal.open(wrapper)`, wait for `document.fonts.ready` or
+  `document.fonts.load(\`${size}px ${family}\`)` when available;
+- then call `measureAndResize(runtime)`, `terminal.clearTextureAtlas()` if using
+  the built-in API or the WebGL addon is exposed, and `terminal.refresh(...)`;
+- apply the same settle/refit path after font changes at
+  `terminal-runtime.ts:317`.
 
 ---
 


### PR DESCRIPTION
Reverts superset-sh/superset#3742

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the font-settle refit for the v2 terminal to restore the previous attach/resize behavior and simplify the runtime. Removes the post-open font loading wait, renderer-change hooks, and WebGL atlas clearing.

- **Refactors**
  - Removed font-settle wait/resize logic and related constants/utilities from the runtime.
  - Simplified `loadAddons(terminal)` by dropping the `onRendererChange` option and `clearTextureAtlas`.
  - Deleted runtime fields and cleanup hooks tied to font-settle scheduling.
  - Updated the plan doc to mark the font race as partially valid and note a non-async approach for any future fix.

<sup>Written for commit f18f36e2563c3003afc518a9b8feaaa5e200c1fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified terminal addon initialization by removing unnecessary options and callbacks.
  * Optimized font-loading behavior in the terminal runtime, removing redundant settlement logic while maintaining core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->