### PR TITLE
Show terminal sessions from all workspaces in dropdown

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -46,7 +46,6 @@ export function TerminalPane({
 	onOpenFile,
 	onRevealPath,
 }: TerminalPaneProps) {
-	const openInExternalEditor = useOpenInExternalEditor(workspaceId);
 	const { getFileAction, getUrlAction } = useTerminalLinkActions();
 	const {
 		hoveredLink,
@@ -56,6 +55,8 @@ export function TerminalPane({
 	const { hint, showHint } = useLinkClickHint();
 	const paneData = ctx.pane.data as TerminalPaneData;
 	const { terminalId } = paneData;
+	const sessionWorkspaceId = paneData.workspaceId ?? workspaceId;
+	const openInExternalEditor = useOpenInExternalEditor(sessionWorkspaceId);
 	const terminalInstanceId = ctx.pane.id;
 	const containerRef = useRef<HTMLDivElement | null>(null);
 	const activeTheme = useTheme();
@@ -77,8 +78,8 @@ export function TerminalPane({
 	const websocketUrl = useWorkspaceWsUrl(`/terminal/${terminalId}`);
 	const websocketUrlRef = useRef(websocketUrl);
 	websocketUrlRef.current = websocketUrl;
-	const workspaceIdRef = useRef(workspaceId);
-	workspaceIdRef.current = workspaceId;
+	const sessionWorkspaceIdRef = useRef(sessionWorkspaceId);
+	sessionWorkspaceIdRef.current = sessionWorkspaceId;
 
 	const ensureSession = workspaceTrpc.terminal.ensureSession.useMutation();
 	const ensureSessionRef = useRef(ensureSession);
@@ -123,7 +124,7 @@ export function TerminalPane({
 	//      "Session not found."
 	// Deps narrowed to [terminalId] so provider key remount churn (workspaceId
 	// briefly flipping while pane data catches up) doesn't re-run this effect.
-	// workspaceId / websocketUrl are read through refs.
+	// sessionWorkspaceId / websocketUrl are read through refs.
 	useEffect(() => {
 		const container = containerRef.current;
 		if (!container) return;
@@ -136,7 +137,7 @@ export function TerminalPane({
 		);
 
 		let cancelled = false;
-		const sessionWorkspaceId = workspaceIdRef.current;
+		const activeSessionWorkspaceId = sessionWorkspaceIdRef.current;
 
 		// Always connect after ensureSession settles, even on error: if the
 		// session actually exists on the server (e.g. we raced another client),
@@ -146,14 +147,12 @@ export function TerminalPane({
 		ensureSessionRef.current
 			.mutateAsync({
 				terminalId,
-				workspaceId: sessionWorkspaceId,
+				workspaceId: activeSessionWorkspaceId,
 				themeType: initialThemeTypeRef.current,
 			})
 			.then((result) => {
 				if (result.status === "active") {
-					void invalidateTerminalSessionsRef.current({
-						workspaceId: sessionWorkspaceId,
-					});
+					void invalidateTerminalSessionsRef.current();
 				}
 			})
 			.catch((err) => {
@@ -209,7 +208,7 @@ export function TerminalPane({
 				stat: async (path) => {
 					try {
 						const result = await statPathRef.current({
-							workspaceId,
+							workspaceId: sessionWorkspaceId,
 							path,
 						});
 						if (!result) return null;
@@ -280,7 +279,7 @@ export function TerminalPane({
 	}, [
 		terminalId,
 		terminalInstanceId,
-		workspaceId,
+		sessionWorkspaceId,
 		ctx.store,
 		onOpenFile,
 		onRevealPath,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
@@ -277,12 +277,15 @@ export function TerminalSessionDropdown({
 	};
 
 	const removeTerminalSession = async (session: VisibleTerminalSession) => {
-		await killTerminalSession.mutateAsync({
-			terminalId: session.terminalId,
-			workspaceId: session.workspaceId,
-		});
-		closePanesForTerminal(session.terminalId);
-		await utils.terminal.listSessions.invalidate();
+		try {
+			await killTerminalSession.mutateAsync({
+				terminalId: session.terminalId,
+				workspaceId: session.workspaceId,
+			});
+			closePanesForTerminal(session.terminalId);
+		} finally {
+			await utils.terminal.listSessions.invalidate();
+		}
 	};
 
 	const handleRemoveTerminal = (session: VisibleTerminalSession) => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
@@ -1,5 +1,4 @@
 import type { RendererContext } from "@superset/panes";
-import { alert } from "@superset/ui/atoms/Alert";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -10,6 +9,8 @@ import {
 } from "@superset/ui/dropdown-menu";
 import { toast } from "@superset/ui/sonner";
 import { workspaceTrpc } from "@superset/workspace-client";
+import { useLiveQuery } from "@tanstack/react-db";
+import { useNavigate } from "@tanstack/react-router";
 import {
 	Check,
 	ChevronDown,
@@ -18,13 +19,20 @@ import {
 	TerminalSquare,
 	Trash2,
 } from "lucide-react";
-import { useCallback, useMemo, useState, useSyncExternalStore } from "react";
+import {
+	Fragment,
+	useCallback,
+	useMemo,
+	useState,
+	useSyncExternalStore,
+} from "react";
 import { markTerminalForBackground } from "renderer/lib/terminal/terminal-background-intents";
 import { terminalRuntimeRegistry } from "renderer/lib/terminal/terminal-runtime-registry";
 import type {
 	PaneViewerData,
 	TerminalPaneData,
 } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { getRelativeTime } from "renderer/screens/main/components/WorkspacesListView/utils";
 
 interface TerminalSessionDropdownProps {
@@ -47,6 +55,12 @@ interface TerminalPaneLocation {
 	tabId: string;
 	paneId: string;
 	titleOverride?: string;
+}
+
+interface TerminalSessionGroup {
+	workspaceId: string;
+	label: string;
+	sessions: VisibleTerminalSession[];
 }
 
 const EMPTY_TERMINAL_PANE_LOCATIONS = new Map<string, TerminalPaneLocation[]>();
@@ -86,16 +100,38 @@ export function TerminalSessionDropdown({
 	const [isOpen, setIsOpen] = useState(false);
 	const data = context.pane.data as TerminalPaneData;
 	const { terminalId } = data;
+	const sessionWorkspaceId = data.workspaceId ?? workspaceId;
 	const terminalInstanceId = context.pane.id;
+	const navigate = useNavigate();
+	const collections = useCollections();
 	const utils = workspaceTrpc.useUtils();
 	const killTerminalSession = workspaceTrpc.terminal.killSession.useMutation();
 	const sessionsQuery = workspaceTrpc.terminal.listSessions.useQuery(
-		{ workspaceId },
+		{},
 		{
 			refetchInterval: isOpen ? 2_000 : false,
 			refetchOnWindowFocus: true,
 		},
 	);
+	const { data: workspaceRows = [] } = useLiveQuery(
+		(q) =>
+			q
+				.from({ v2Workspaces: collections.v2Workspaces })
+				.select(({ v2Workspaces }) => ({
+					id: v2Workspaces.id,
+					name: v2Workspaces.name,
+					branch: v2Workspaces.branch,
+				})),
+		[collections],
+	);
+
+	const workspaceLabels = useMemo(() => {
+		const labels = new Map<string, string>();
+		for (const row of workspaceRows) {
+			labels.set(row.id, row.name || row.branch || "Workspace");
+		}
+		return labels;
+	}, [workspaceRows]);
 
 	const sessions = useMemo<VisibleTerminalSession[]>(() => {
 		const liveSessions = sessionsQuery.data?.sessions ?? [];
@@ -105,7 +141,7 @@ export function TerminalSessionDropdown({
 		return [
 			{
 				terminalId,
-				workspaceId,
+				workspaceId: sessionWorkspaceId,
 				exited: false,
 				exitCode: 0,
 				attached: false,
@@ -114,10 +150,48 @@ export function TerminalSessionDropdown({
 			},
 			...liveSessions,
 		];
-	}, [sessionsQuery.data?.sessions, terminalId, workspaceId]);
+	}, [sessionsQuery.data?.sessions, terminalId, sessionWorkspaceId]);
 	const currentSession = sessions.find(
 		(session) => session.terminalId === terminalId,
 	);
+	const sessionGroups = useMemo<TerminalSessionGroup[]>(() => {
+		const groupsByWorkspaceId = new Map<string, VisibleTerminalSession[]>();
+		for (const session of sessions) {
+			const group = groupsByWorkspaceId.get(session.workspaceId) ?? [];
+			group.push(session);
+			groupsByWorkspaceId.set(session.workspaceId, group);
+		}
+
+		return [...groupsByWorkspaceId.entries()]
+			.map(([groupWorkspaceId, groupSessions]) => ({
+				workspaceId: groupWorkspaceId,
+				label:
+					groupWorkspaceId === workspaceId
+						? "Current workspace"
+						: (workspaceLabels.get(groupWorkspaceId) ?? "Unknown workspace"),
+				sessions: [...groupSessions].sort((a, b) => {
+					if (a.terminalId === terminalId) return -1;
+					if (b.terminalId === terminalId) return 1;
+					return (b.createdAt ?? 0) - (a.createdAt ?? 0);
+				}),
+			}))
+			.sort((a, b) => {
+				const aHasCurrent = a.sessions.some(
+					(session) => session.terminalId === terminalId,
+				);
+				const bHasCurrent = b.sessions.some(
+					(session) => session.terminalId === terminalId,
+				);
+				if (aHasCurrent !== bHasCurrent) return aHasCurrent ? -1 : 1;
+				if (a.workspaceId === workspaceId && b.workspaceId !== workspaceId) {
+					return -1;
+				}
+				if (b.workspaceId === workspaceId && a.workspaceId !== workspaceId) {
+					return 1;
+				}
+				return a.label.localeCompare(b.label);
+			});
+	}, [sessions, terminalId, workspaceId, workspaceLabels]);
 	const subscribeTitle = useCallback(
 		(callback: () => void) =>
 			terminalRuntimeRegistry.onTitleChange(
@@ -136,7 +210,8 @@ export function TerminalSessionDropdown({
 		? getTerminalPaneLocations(context)
 		: EMPTY_TERMINAL_PANE_LOCATIONS;
 
-	const handleSelectSession = (nextTerminalId: string) => {
+	const handleSelectSession = (session: VisibleTerminalSession) => {
+		const nextTerminalId = session.terminalId;
 		if (nextTerminalId === terminalId) {
 			setIsOpen(false);
 			return;
@@ -145,18 +220,44 @@ export function TerminalSessionDropdown({
 		const state = context.store.getState();
 		const terminalPaneLocations = getTerminalPaneLocations(context);
 		const existingLocation = terminalPaneLocations.get(nextTerminalId)?.[0];
+		if (existingLocation) {
+			state.setActiveTab(existingLocation.tabId);
+			state.setActivePane({
+				tabId: existingLocation.tabId,
+				paneId: existingLocation.paneId,
+			});
+			setIsOpen(false);
+			return;
+		}
+
+		if (session.attached && session.workspaceId !== workspaceId) {
+			void navigate({
+				to: "/v2-workspace/$workspaceId",
+				params: { workspaceId: session.workspaceId },
+				search: {
+					terminalId: session.terminalId,
+					focusRequestId: crypto.randomUUID(),
+				},
+			});
+			setIsOpen(false);
+			return;
+		}
+
 		if ((terminalPaneLocations.get(terminalId)?.length ?? 0) === 0) {
 			markTerminalForBackground(terminalId);
 		}
 
 		state.setPaneData({
 			paneId: context.pane.id,
-			data: { terminalId: nextTerminalId } as PaneViewerData,
+			data: {
+				terminalId: nextTerminalId,
+				workspaceId: session.workspaceId,
+			} as PaneViewerData,
 		});
 		state.setPaneTitleOverride({
 			tabId: context.tab.id,
 			paneId: context.pane.id,
-			titleOverride: existingLocation?.titleOverride,
+			titleOverride: undefined,
 		});
 		setIsOpen(false);
 	};
@@ -175,34 +276,20 @@ export function TerminalSessionDropdown({
 		}
 	};
 
-	const removeTerminalSession = async (targetTerminalId: string) => {
+	const removeTerminalSession = async (session: VisibleTerminalSession) => {
 		await killTerminalSession.mutateAsync({
-			terminalId: targetTerminalId,
-			workspaceId,
+			terminalId: session.terminalId,
+			workspaceId: session.workspaceId,
 		});
-		closePanesForTerminal(targetTerminalId);
-		await utils.terminal.listSessions.invalidate({ workspaceId });
+		closePanesForTerminal(session.terminalId);
+		await utils.terminal.listSessions.invalidate();
 	};
 
-	const handleRemoveTerminal = (targetTerminalId: string) => {
-		alert({
-			title: "Remove terminal session?",
-			description:
-				"This will terminate the underlying process. Use Move terminal to background to keep it running without a pane.",
-			actions: [
-				{ label: "Cancel", variant: "outline", onClick: () => {} },
-				{
-					label: "Remove Terminal",
-					variant: "destructive",
-					onClick: () => {
-						toast.promise(removeTerminalSession(targetTerminalId), {
-							loading: "Removing terminal...",
-							success: "Terminal removed",
-							error: "Failed to remove terminal",
-						});
-					},
-				},
-			],
+	const handleRemoveTerminal = (session: VisibleTerminalSession) => {
+		toast.promise(removeTerminalSession(session), {
+			loading: "Removing terminal...",
+			success: "Terminal removed",
+			error: "Failed to remove terminal",
 		});
 	};
 
@@ -216,6 +303,7 @@ export function TerminalSessionDropdown({
 			paneId: context.pane.id,
 			data: {
 				terminalId: crypto.randomUUID(),
+				workspaceId,
 			} as PaneViewerData,
 		});
 		state.setPaneTitleOverride({
@@ -223,7 +311,7 @@ export function TerminalSessionDropdown({
 			paneId: context.pane.id,
 			titleOverride: undefined,
 		});
-		void utils.terminal.listSessions.invalidate({ workspaceId });
+		void utils.terminal.listSessions.invalidate();
 		setIsOpen(false);
 	};
 
@@ -255,76 +343,100 @@ export function TerminalSessionDropdown({
 				</button>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent align="start" className="w-96">
-				<DropdownMenuLabel className="text-xs">
-					Terminal Sessions
+				<DropdownMenuLabel className="flex items-center gap-2 text-xs">
+					<span className="min-w-0 flex-1 truncate">Terminal Sessions</span>
+					<button
+						type="button"
+						aria-label="New terminal"
+						title="New terminal"
+						className="flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+						onClick={(event) => {
+							event.preventDefault();
+							event.stopPropagation();
+							handleNewTerminal();
+						}}
+					>
+						<Plus className="size-3.5" />
+					</button>
 				</DropdownMenuLabel>
 				<DropdownMenuSeparator />
 				<div className="max-h-80 overflow-y-auto">
-					{sessions.length > 0 ? (
-						sessions.map((session) => {
-							const isCurrent = session.terminalId === terminalId;
-							const location = renderTerminalPaneLocations.get(
-								session.terminalId,
-							)?.[0];
-							const createdAtLabel = formatCreatedAt(session.createdAt);
-							const status = isCurrent
-								? "Current"
-								: session.pending
-									? "Starting"
-									: session.attached
-										? "Attached"
-										: "Detached";
-							const title = isCurrent
-								? triggerTitle
-								: (session.title ?? location?.titleOverride ?? "Terminal");
-
-							return (
-								<DropdownMenuItem
-									key={session.terminalId}
-									className="group flex items-center gap-2"
-									onSelect={(_event) => {
-										handleSelectSession(session.terminalId);
-									}}
+					{sessionGroups.length > 0 ? (
+						sessionGroups.map((group, groupIndex) => (
+							<Fragment key={group.workspaceId}>
+								{groupIndex > 0 && <DropdownMenuSeparator />}
+								<div
+									className="flex min-w-0 items-center gap-2 px-2 pt-2 pb-1 text-muted-foreground text-xs"
+									title={group.label}
 								>
-									<span className="w-4 shrink-0">
-										{isCurrent && <Check className="size-3.5" />}
+									<span className="min-w-0 flex-1 truncate font-medium">
+										{group.label}
 									</span>
-									<span className="min-w-0 flex-1 truncate text-xs">
-										{title}
+									<span className="shrink-0 text-muted-foreground/60 tabular-nums">
+										{group.sessions.length}
 									</span>
-									<span className="shrink-0 text-xs text-muted-foreground/70">
-										{createdAtLabel}
-									</span>
-									<span className="shrink-0 text-xs text-muted-foreground">
-										{status}
-									</span>
-									<button
-										type="button"
-										aria-label={`Remove terminal ${session.createdAt ? createdAtLabel : "session"}`}
-										disabled={killTerminalSession.isPending}
-										className="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive disabled:pointer-events-none disabled:opacity-30 group-hover:opacity-100"
-										onClick={(event) => {
-											event.preventDefault();
-											event.stopPropagation();
-											handleRemoveTerminal(session.terminalId);
-										}}
-									>
-										<Trash2 className="size-3" />
-									</button>
-								</DropdownMenuItem>
-							);
-						})
+								</div>
+								{group.sessions.map((session) => {
+									const isCurrent = session.terminalId === terminalId;
+									const location = renderTerminalPaneLocations.get(
+										session.terminalId,
+									)?.[0];
+									const createdAtLabel = formatCreatedAt(session.createdAt);
+									const status = isCurrent
+										? "Current"
+										: session.pending
+											? "Starting"
+											: session.attached
+												? "Attached"
+												: "Detached";
+									const title = isCurrent
+										? triggerTitle
+										: (session.title ?? location?.titleOverride ?? "Terminal");
+
+									return (
+										<DropdownMenuItem
+											key={session.terminalId}
+											className="group flex items-center gap-2"
+											onSelect={(_event) => {
+												handleSelectSession(session);
+											}}
+										>
+											<span className="w-4 shrink-0">
+												{isCurrent && <Check className="size-3.5" />}
+											</span>
+											<span className="min-w-0 flex-1 truncate text-xs">
+												{title}
+											</span>
+											<span className="shrink-0 text-xs text-muted-foreground/70">
+												{createdAtLabel}
+											</span>
+											<span className="shrink-0 text-xs text-muted-foreground">
+												{status}
+											</span>
+											<button
+												type="button"
+												aria-label={`Remove terminal ${session.createdAt ? createdAtLabel : "session"}`}
+												disabled={killTerminalSession.isPending}
+												className="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive disabled:pointer-events-none disabled:opacity-30 group-hover:opacity-100"
+												onClick={(event) => {
+													event.preventDefault();
+													event.stopPropagation();
+													handleRemoveTerminal(session);
+												}}
+											>
+												<Trash2 className="size-3" />
+											</button>
+										</DropdownMenuItem>
+									);
+								})}
+							</Fragment>
+						))
 					) : (
 						<div className="px-2 py-1.5 text-xs text-muted-foreground">
 							No live sessions
 						</div>
 					)}
 				</div>
-				<DropdownMenuSeparator />
-				<DropdownMenuItem onSelect={handleNewTerminal}>
-					<Plus className="mr-1.5 size-3.5" />
-					<span className="text-xs">New Terminal</span>
-				</DropdownMenuItem>
 			</DropdownMenuContent>
 		</DropdownMenu>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -168,9 +168,7 @@ export function usePaneRegistry(
 		workspaceTrpc.terminal.killSession.useMutation({
 			onSuccess: () => {
 				toast.success("Terminal session killed");
-				void workspaceTrpcUtils.terminal.listSessions.invalidate({
-					workspaceId,
-				});
+				void workspaceTrpcUtils.terminal.listSessions.invalidate();
 			},
 			onError: (error) => {
 				toast.error("Failed to kill terminal session", {
@@ -377,24 +375,10 @@ export function usePaneRegistry(
 						variant: "destructive",
 						disabled: isKillingTerminalSession,
 						onSelect: (ctx) => {
-							const { terminalId } = ctx.pane.data as TerminalPaneData;
-							alert({
-								title: "Kill terminal session?",
-								description:
-									"This will terminate the underlying process. Move the terminal to background to keep it running without a pane.",
-								actions: [
-									{ label: "Cancel", variant: "outline", onClick: () => {} },
-									{
-										label: "Kill Session",
-										variant: "destructive",
-										onClick: () => {
-											killTerminalSession({
-												terminalId,
-												workspaceId,
-											});
-										},
-									},
-								],
+							const data = ctx.pane.data as TerminalPaneData;
+							killTerminalSession({
+								terminalId: data.terminalId,
+								workspaceId: data.workspaceId ?? workspaceId,
 							});
 						},
 					};

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
@@ -8,6 +8,7 @@ export interface FilePaneData {
 
 export interface TerminalPaneData {
 	terminalId: string;
+	workspaceId?: string;
 }
 
 export interface ChatPaneData {

--- a/apps/desktop/src/renderer/routes/_authenticated/components/GlobalTerminalLifecycle/hooks/useGlobalTerminalLifecycle/useGlobalTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/GlobalTerminalLifecycle/hooks/useGlobalTerminalLifecycle/useGlobalTerminalLifecycle.ts
@@ -20,10 +20,23 @@ const RELEASE_DELAY_MS = 500;
 
 interface TerminalPaneData {
 	terminalId: string;
+	workspaceId?: string;
+}
+
+interface TerminalLocation {
+	ownerWorkspaceId: string;
+	sessionWorkspaceId: string;
+}
+
+interface RemovedTerminalLocation {
+	terminalId: string;
+	ownerWorkspaceId: string;
+	sessionWorkspaceId: string;
 }
 
 interface PendingTerminalCleanup {
-	workspaceId: string;
+	ownerWorkspaceId: string;
+	sessionWorkspaceId: string;
 	timer: ReturnType<typeof setTimeout> | null;
 }
 
@@ -40,6 +53,17 @@ function getTerminalId(
 	if (!pane.data || typeof pane.data !== "object") return null;
 	const data = pane.data as Partial<TerminalPaneData>;
 	return typeof data.terminalId === "string" ? data.terminalId : null;
+}
+
+function getTerminalSessionWorkspaceId(
+	pane: WorkspaceState<unknown>["tabs"][number]["panes"][string],
+	fallbackWorkspaceId: string,
+): string {
+	if (!pane.data || typeof pane.data !== "object") return fallbackWorkspaceId;
+	const data = pane.data as Partial<TerminalPaneData>;
+	return typeof data.workspaceId === "string"
+		? data.workspaceId
+		: fallbackWorkspaceId;
 }
 
 function getTerminalInstanceKey(
@@ -62,14 +86,57 @@ function parseTerminalInstanceKey(
 
 function extractTerminalLocations(
 	rows: PaneLifecycleRow[],
-): Map<string, string> {
-	return extractPaneLocations(rows, getTerminalId);
+): Map<string, TerminalLocation> {
+	const locations = new Map<string, TerminalLocation>();
+
+	for (const row of rows) {
+		if (typeof row.workspaceId !== "string") continue;
+
+		const layout = row.paneLayout as WorkspaceState<unknown> | undefined;
+		if (!layout?.tabs) continue;
+
+		for (const tab of layout.tabs) {
+			for (const pane of Object.values(tab.panes)) {
+				const terminalId = getTerminalId(pane);
+				if (!terminalId) continue;
+				locations.set(terminalId, {
+					ownerWorkspaceId: row.workspaceId,
+					sessionWorkspaceId: getTerminalSessionWorkspaceId(
+						pane,
+						row.workspaceId,
+					),
+				});
+			}
+		}
+	}
+
+	return locations;
 }
 
 function extractTerminalInstanceLocations(
 	rows: PaneLifecycleRow[],
 ): Map<string, string> {
 	return extractPaneLocations(rows, getTerminalInstanceKey);
+}
+
+function getRemovedTerminalLocations({
+	previousLocations,
+	currentLocations,
+	currentWorkspaceIds,
+}: {
+	previousLocations: Map<string, TerminalLocation>;
+	currentLocations: Map<string, TerminalLocation>;
+	currentWorkspaceIds: Set<string>;
+}): RemovedTerminalLocation[] {
+	const removed: RemovedTerminalLocation[] = [];
+
+	for (const [terminalId, location] of previousLocations) {
+		if (currentLocations.has(terminalId)) continue;
+		if (!currentWorkspaceIds.has(location.ownerWorkspaceId)) continue;
+		removed.push({ terminalId, ...location });
+	}
+
+	return removed;
 }
 
 function cleanupRemovedTerminal({
@@ -109,7 +176,9 @@ function cleanupRemovedTerminal({
 export function useGlobalTerminalLifecycle() {
 	const collections = useCollections();
 	const { machineId, activeHostUrl } = useLocalHostService();
-	const prevTerminalLocationsRef = useRef<Map<string, string>>(new Map());
+	const prevTerminalLocationsRef = useRef<Map<string, TerminalLocation>>(
+		new Map(),
+	);
 	const prevTerminalInstanceLocationsRef = useRef<Map<string, string>>(
 		new Map(),
 	);
@@ -197,11 +266,11 @@ export function useGlobalTerminalLifecycle() {
 		// while still cleaning up when the post-removal layout comes back.
 		for (const [terminalId, pending] of pendingCleanups.current) {
 			if (pending.timer) continue;
-			if (currentWorkspaceIds.has(pending.workspaceId)) {
+			if (currentWorkspaceIds.has(pending.ownerWorkspaceId)) {
 				pendingCleanups.current.delete(terminalId);
 				cleanupRemovedTerminal({
 					terminalId,
-					workspaceId: pending.workspaceId,
+					workspaceId: pending.sessionWorkspaceId,
 					hostUrlByWorkspaceId: hostUrlByWorkspaceIdRef.current,
 				});
 			}
@@ -262,13 +331,17 @@ export function useGlobalTerminalLifecycle() {
 			});
 		}
 
-		const removedLocations = getRemovedPaneLocations({
+		const removedLocations = getRemovedTerminalLocations({
 			previousLocations: prevTerminalLocations,
 			currentLocations: currentTerminalLocations,
 			currentWorkspaceIds,
 		});
 
-		for (const { id: terminalId, workspaceId } of removedLocations) {
+		for (const {
+			terminalId,
+			ownerWorkspaceId,
+			sessionWorkspaceId,
+		} of removedLocations) {
 			if (pendingCleanups.current.has(terminalId)) continue;
 
 			const timer = setTimeout(() => {
@@ -283,11 +356,11 @@ export function useGlobalTerminalLifecycle() {
 					return;
 				}
 
-				if (freshWorkspaceIds.has(workspaceId)) {
+				if (freshWorkspaceIds.has(ownerWorkspaceId)) {
 					pendingCleanups.current.delete(terminalId);
 					cleanupRemovedTerminal({
 						terminalId,
-						workspaceId,
+						workspaceId: sessionWorkspaceId,
 						hostUrlByWorkspaceId: hostUrlByWorkspaceIdRef.current,
 					});
 					return;
@@ -299,7 +372,11 @@ export function useGlobalTerminalLifecycle() {
 				}
 			}, RELEASE_DELAY_MS);
 
-			pendingCleanups.current.set(terminalId, { workspaceId, timer });
+			pendingCleanups.current.set(terminalId, {
+				ownerWorkspaceId,
+				sessionWorkspaceId,
+				timer,
+			});
 		}
 
 		prevTerminalLocationsRef.current = currentTerminalLocations;

--- a/packages/host-service/src/trpc/router/terminal/terminal.ts
+++ b/packages/host-service/src/trpc/router/terminal/terminal.ts
@@ -44,7 +44,7 @@ export const terminalRouter = router({
 	listSessions: protectedProcedure
 		.input(
 			z.object({
-				workspaceId: z.string(),
+				workspaceId: z.string().optional(),
 			}),
 		)
 		.query(({ input }) => ({


### PR DESCRIPTION
## Summary
- Terminal pane data now carries the session's owning `workspaceId`, so a pane attached to a session from another workspace stays correctly wired (ensureSession, statPath, external editor, lifecycle cleanup all use the session's workspace).
- The terminal session dropdown lists sessions across all workspaces, grouped by workspace. Selecting an attached session in a different workspace navigates there with the terminal focused; otherwise the current pane swaps to that session.
- `terminal.listSessions` no longer requires `workspaceId` — clients fetch all sessions and group client-side.
- Removed the confirmation dialogs on kill/remove; toast feedback is sufficient and the alert variant was inconsistent with other destructive pane actions.

## Test plan
- [ ] Open two v2 workspaces; verify the terminal dropdown in workspace A shows sessions from workspace B grouped under B's label.
- [ ] Select a detached session from workspace B in workspace A's pane — pane attaches to that session, lifecycle cleanup still targets B.
- [ ] Select an attached session from workspace B — navigates to workspace B with that terminal focused.
- [ ] Kill / remove from the dropdown still works (no confirmation prompt, toast appears).
- [ ] Closing a pane that owns a session in a different workspace still releases the session correctly after the release delay.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show terminal sessions from all workspaces in the dropdown and keep panes tied to the session’s owning workspace for lifecycle, file ops, and navigation. Selecting an attached session in another workspace navigates there and focuses the terminal; selecting a detached session swaps the current pane.

- New Features
  - Dropdown lists sessions from all workspaces, grouped with labels and counts.
  - Selecting an attached session in a different workspace navigates to it; selecting a detached session attaches in the current pane. If the session is already open elsewhere, we focus that pane instead of duplicating.
  - Terminal panes store the session `workspaceId`, so ensure-session, stat/open-in-editor, and cleanup target the right workspace.
  - Removed confirmation dialogs for kill/remove; show toasts instead, and always refresh the session list even if kill fails.

- Migration
  - `terminal.listSessions` now takes an optional `workspaceId`. Callers should fetch all sessions (no param) and group client-side.

<sup>Written for commit ee4be5900c8bf322e05af187b8b92345785f4027. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions are now grouped and labeled by workspace in the dropdown; “Current workspace” is highlighted.
  * Selecting a session will activate it, navigate to its workspace if needed, or open it in the correct workspace.

* **Bug Fixes**
  * Terminal lifecycle and session invalidation now correctly handle sessions across multiple workspaces.

* **Improvements**
  * “New terminal” moved to the dropdown label for quicker access.
  * Terminal removal uses immediate action with toast feedback instead of a blocking confirmation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->