### PR TITLE
[codex] Use dynamic footer copyright years

### DIFF
--- a/apps/web/src/app/(dashboard-legacy)/components/Footer/Footer.tsx
+++ b/apps/web/src/app/(dashboard-legacy)/components/Footer/Footer.tsx
@@ -4,7 +4,7 @@ export function Footer() {
 	return (
 		<footer className="mt-auto w-full border-t border-border/50 py-5">
 			<div className="mx-auto flex w-[95vw] max-w-screen-2xl items-center justify-between">
-				<p className="text-sm text-muted-foreground">© 2025 Superset</p>
+				<p className="text-sm text-muted-foreground">© 2026 Superset</p>
 				<div className="flex items-center gap-4">
 					<a
 						href={`${env.NEXT_PUBLIC_MARKETING_URL}/terms`}

--- a/apps/web/src/app/(dashboard-legacy)/components/Footer/Footer.tsx
+++ b/apps/web/src/app/(dashboard-legacy)/components/Footer/Footer.tsx
@@ -1,10 +1,14 @@
 import { env } from "@/env";
 
 export function Footer() {
+	const currentYear = new Date().getFullYear();
+
 	return (
 		<footer className="mt-auto w-full border-t border-border/50 py-5">
 			<div className="mx-auto flex w-[95vw] max-w-screen-2xl items-center justify-between">
-				<p className="text-sm text-muted-foreground">© 2026 Superset</p>
+				<p className="text-sm text-muted-foreground">
+					© {currentYear} Superset
+				</p>
 				<div className="flex items-center gap-4">
 					<a
 						href={`${env.NEXT_PUBLIC_MARKETING_URL}/terms`}

--- a/packages/email/src/components/layout/StandardLayout/components/Footer/Footer.tsx
+++ b/packages/email/src/components/layout/StandardLayout/components/Footer/Footer.tsx
@@ -6,6 +6,8 @@ interface FooterProps {
 }
 
 export function Footer({ showSocial = true }: FooterProps) {
+	const currentYear = new Date().getFullYear();
+
 	const socialIcons = {
 		x: `${env.NEXT_PUBLIC_MARKETING_URL}/assets/emails/x.png`,
 		instagram: `${env.NEXT_PUBLIC_MARKETING_URL}/assets/emails/instagram.png`,
@@ -96,7 +98,7 @@ export function Footer({ showSocial = true }: FooterProps) {
 
 			{/* Company Info */}
 			<Text className="text-muted text-xs leading-none m-0">
-				© 2026 Superset. All rights reserved.
+				© {currentYear} Superset. All rights reserved.
 			</Text>
 		</Section>
 	);


### PR DESCRIPTION
## Summary

- Replaces the legacy web footer hardcoded copyright year with `new Date().getFullYear()`.
- Replaces the shared email footer hardcoded copyright year with `new Date().getFullYear()`.
- Leaves historical/legal dates and vendor/license copyright notices unchanged.

## Root Cause

The legacy web footer used a static year string, which would require another manual update when the year changes. The shared email footer had the same rolling-year issue.

## Impact

Website and email footer copyright years now stay current without annual manual patches.

## Validation

- `bunx @biomejs/biome@2.4.2 check 'apps/web/src/app/(dashboard-legacy)/components/Footer/Footer.tsx' packages/email/src/components/layout/StandardLayout/components/Footer/Footer.tsx`
- Scanned footer copyright output for remaining hardcoded `© 20xx` strings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Footer now displays the current year dynamically instead of a fixed year, ensuring copyright stays up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->