### PR TITLE
[codex] Update dashboard sidebar workspace icons

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/DashboardSidebarWorkspaceIcon.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/DashboardSidebarWorkspaceIcon.tsx
@@ -1,13 +1,13 @@
 import { cn } from "@superset/ui/utils";
 import { HiExclamationTriangle } from "react-icons/hi2";
 import {
-	LuCloud,
-	LuCloudOff,
 	LuGitMerge,
 	LuGitPullRequest,
 	LuGitPullRequestClosed,
 	LuGitPullRequestDraft,
 } from "react-icons/lu";
+import { RxDot } from "react-icons/rx";
+import { TbCloud, TbCloudOff } from "react-icons/tb";
 import { AsciiSpinner } from "renderer/screens/main/components/AsciiSpinner";
 import { StatusIndicator } from "renderer/screens/main/components/StatusIndicator";
 import type { ActivePaneStatus } from "shared/tabs-types";
@@ -71,19 +71,12 @@ export function DashboardSidebarWorkspaceIcon({
 		}
 
 		if (hostType === "local-device") {
-			return (
-				<span
-					className={cn(
-						"size-1.5 rounded-full transition-colors",
-						isActive ? "bg-foreground" : "bg-muted-foreground",
-					)}
-				/>
-			);
+			return <RxDot className={cn("size-4 transition-colors", iconColor)} />;
 		}
 
 		if (isRemoteDeviceOffline) {
 			return (
-				<LuCloudOff
+				<TbCloudOff
 					className={cn("size-4 transition-colors", iconColor, "opacity-60")}
 					strokeWidth={1.75}
 				/>
@@ -91,7 +84,7 @@ export function DashboardSidebarWorkspaceIcon({
 		}
 
 		return (
-			<LuCloud
+			<TbCloud
 				className={cn("size-4 transition-colors", iconColor)}
 				strokeWidth={1.75}
 			/>


### PR DESCRIPTION
## Summary
- Replace the dashboard sidebar local workspace dot with the current icon glyph.
- Replace cloud and offline-cloud workspace icons with Tabler cloud icons.
- Keep existing PR-state and workspace-state icon priority intact.

## Validation
- `bunx biome check apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/DashboardSidebarWorkspaceIcon.tsx`

Note: PR-state/data fixes are intentionally not included in this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated dashboard sidebar workspace icons for clearer, consistent visuals. Local workspaces now use `RxDot`, and remote workspaces use Tabler `TbCloud`/`TbCloudOff`; existing PR/workspace icon priority remains unchanged.

- **Refactors**
  - Replaced `LuCloud`/`LuCloudOff` with `TbCloud`/`TbCloudOff`.
  - Swapped custom span dot for `RxDot` and unified size/color classes.
  - No PR-state or workspace-state logic changes.

<sup>Written for commit d2be1e8ddfca2f7871747b83b27d0cbb3ab85152. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated cloud and local storage status icons in the dashboard workspace panel for improved visual consistency and better design alignment with the rest of the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->