### PR TITLE
[codex] Show PR icons for remote workspaces

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -93,6 +93,7 @@ export function DashboardSidebarWorkspaceItem({
 					workspaceStatus={workspaceStatus}
 					onClick={isPending ? handlePendingClick : handleClick}
 					creationStatus={creationStatus}
+					pullRequestState={workspace.pullRequest?.state ?? null}
 					disabled={isPending}
 					aria-label={
 						creationStatus ? `Creating workspace: ${name}` : undefined

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarCollapsedWorkspaceButton/DashboardSidebarCollapsedWorkspaceButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarCollapsedWorkspaceButton/DashboardSidebarCollapsedWorkspaceButton.tsx
@@ -1,7 +1,10 @@
 import { cn } from "@superset/ui/utils";
 import { type ComponentPropsWithoutRef, forwardRef } from "react";
 import type { ActivePaneStatus } from "shared/tabs-types";
-import type { DashboardSidebarWorkspaceHostType } from "../../../../types";
+import type {
+	DashboardSidebarWorkspaceHostType,
+	DashboardSidebarWorkspacePullRequest,
+} from "../../../../types";
 import { DashboardSidebarWorkspaceIcon } from "../DashboardSidebarWorkspaceIcon";
 
 interface DashboardSidebarCollapsedWorkspaceButtonProps
@@ -11,6 +14,7 @@ interface DashboardSidebarCollapsedWorkspaceButtonProps
 	isActive: boolean;
 	workspaceStatus?: ActivePaneStatus | null;
 	creationStatus?: "preparing" | "generating-branch" | "creating" | "failed";
+	pullRequestState?: DashboardSidebarWorkspacePullRequest["state"] | null;
 }
 
 export const DashboardSidebarCollapsedWorkspaceButton = forwardRef<
@@ -24,6 +28,7 @@ export const DashboardSidebarCollapsedWorkspaceButton = forwardRef<
 			isActive,
 			workspaceStatus = null,
 			creationStatus,
+			pullRequestState = null,
 			className,
 			...props
 		},
@@ -48,6 +53,7 @@ export const DashboardSidebarCollapsedWorkspaceButton = forwardRef<
 					variant="collapsed"
 					workspaceStatus={workspaceStatus}
 					creationStatus={creationStatus}
+					pullRequestState={pullRequestState}
 				/>
 			</button>
 		);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -1,3 +1,4 @@
+import type { SelectGithubPullRequest } from "@superset/db/schema";
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useQuery } from "@tanstack/react-query";
@@ -14,6 +15,8 @@ import type {
 	DashboardSidebarProjectChild,
 	DashboardSidebarSection,
 	DashboardSidebarWorkspace,
+	DashboardSidebarWorkspacePullRequest,
+	DashboardSidebarWorkspacePullRequestCheck,
 } from "../../types";
 
 // Sits above every real workspace so the pending row lines up with the real one,
@@ -141,6 +144,133 @@ function useStableDashboardSidebarProjects(
 	}, [projects]);
 }
 
+type SyncedPullRequestCheck = NonNullable<
+	SelectGithubPullRequest["checks"]
+>[number];
+
+interface SyncedPullRequestCandidate {
+	repositoryId: string;
+	headBranch: string;
+	authorLogin: string;
+	updatedAtMs: number;
+	pullRequest: DashboardSidebarWorkspacePullRequest;
+}
+
+const NORMALIZED_CHECK_STATUSES = new Set<
+	DashboardSidebarWorkspacePullRequestCheck["status"]
+>(["success", "failure", "pending", "skipped", "cancelled"]);
+
+function getTimestampMs(value: unknown): number {
+	if (value instanceof Date) return value.getTime();
+	if (typeof value === "string" || typeof value === "number") {
+		const timestamp = new Date(value).getTime();
+		return Number.isNaN(timestamp) ? 0 : timestamp;
+	}
+	return 0;
+}
+
+function normalizeSyncedPullRequestState(
+	pr: Pick<SelectGithubPullRequest, "state" | "isDraft" | "mergedAt">,
+): DashboardSidebarWorkspacePullRequest["state"] {
+	if (pr.state === "merged" || pr.mergedAt) return "merged";
+	if (pr.state === "closed") return "closed";
+	if (pr.isDraft) return "draft";
+	return "open";
+}
+
+function normalizeSyncedReviewDecision(
+	value: SelectGithubPullRequest["reviewDecision"],
+): DashboardSidebarWorkspacePullRequest["reviewDecision"] {
+	if (value === "approved" || value === "APPROVED") return "approved";
+	if (value === "changes_requested" || value === "CHANGES_REQUESTED") {
+		return "changes_requested";
+	}
+	if (value === "pending" || value === "REVIEW_REQUIRED") return "pending";
+	return null;
+}
+
+function normalizeSyncedCheckStatus(
+	check: SyncedPullRequestCheck,
+): DashboardSidebarWorkspacePullRequestCheck["status"] {
+	const status = check.status.toLowerCase();
+	if (
+		NORMALIZED_CHECK_STATUSES.has(
+			status as DashboardSidebarWorkspacePullRequestCheck["status"],
+		)
+	) {
+		return status as DashboardSidebarWorkspacePullRequestCheck["status"];
+	}
+
+	if (status !== "completed") return "pending";
+
+	const conclusion = check.conclusion?.toLowerCase() ?? null;
+	if (conclusion === "success" || conclusion === "neutral") return "success";
+	if (conclusion === "skipped") return "skipped";
+	if (conclusion === "cancelled") return "cancelled";
+	if (!conclusion) return "pending";
+	return "failure";
+}
+
+function computeSyncedChecksStatus(
+	checks: DashboardSidebarWorkspacePullRequestCheck[],
+	fallback: SelectGithubPullRequest["checksStatus"],
+): DashboardSidebarWorkspacePullRequest["checksStatus"] {
+	let hasFailure = false;
+	let hasPending = false;
+	let relevantCount = 0;
+
+	for (const check of checks) {
+		if (check.status === "skipped" || check.status === "cancelled") continue;
+		relevantCount++;
+		if (check.status === "failure") hasFailure = true;
+		if (check.status === "pending") hasPending = true;
+	}
+
+	if (relevantCount > 0) {
+		if (hasFailure) return "failure";
+		if (hasPending) return "pending";
+		return "success";
+	}
+
+	if (
+		fallback === "success" ||
+		fallback === "failure" ||
+		fallback === "pending"
+	) {
+		return fallback;
+	}
+
+	return "none";
+}
+
+function normalizeSyncedPullRequest(
+	pr: SelectGithubPullRequest,
+): DashboardSidebarWorkspacePullRequest {
+	const checks = (pr.checks ?? []).map((check) => ({
+		name: check.name,
+		status: normalizeSyncedCheckStatus(check),
+		url: check.detailsUrl ?? null,
+	}));
+
+	return {
+		url: pr.url,
+		number: pr.prNumber,
+		title: pr.title,
+		state: normalizeSyncedPullRequestState(pr),
+		reviewDecision: normalizeSyncedReviewDecision(pr.reviewDecision),
+		checksStatus: computeSyncedChecksStatus(checks, pr.checksStatus),
+		checks,
+	};
+}
+
+function pullRequestMatchesWorkspaceBranch(
+	workspaceBranch: string,
+	pr: Pick<SyncedPullRequestCandidate, "headBranch" | "authorLogin">,
+) {
+	if (workspaceBranch === pr.headBranch) return true;
+	return workspaceBranch === `${pr.authorLogin.toLowerCase()}/${pr.headBranch}`;
+}
+
 export function useDashboardSidebarData() {
 	const { data: session } = authClient.useSession();
 	const collections = useCollections();
@@ -253,6 +383,14 @@ export function useDashboardSidebarData() {
 		[collections],
 	);
 
+	const { data: syncedPullRequests = [] } = useLiveQuery(
+		(q) =>
+			q
+				.from({ pullRequests: collections.githubPullRequests })
+				.select(({ pullRequests }) => pullRequests),
+		[collections],
+	);
+
 	const computedLocalWorkspaceIds = useMemo(
 		() =>
 			sidebarWorkspaces
@@ -298,6 +436,28 @@ export function useDashboardSidebarData() {
 
 	const localPullRequestsByWorkspaceId =
 		useStableLocalPullRequestsByWorkspaceId(pullRequestData?.workspaces);
+
+	const syncedPullRequestsByRepositoryId = useMemo(() => {
+		const map = new Map<string, SyncedPullRequestCandidate[]>();
+
+		for (const pr of syncedPullRequests) {
+			const candidates = map.get(pr.repositoryId) ?? [];
+			candidates.push({
+				repositoryId: pr.repositoryId,
+				headBranch: pr.headBranch,
+				authorLogin: pr.authorLogin,
+				updatedAtMs: getTimestampMs(pr.updatedAt),
+				pullRequest: normalizeSyncedPullRequest(pr),
+			});
+			map.set(pr.repositoryId, candidates);
+		}
+
+		for (const candidates of map.values()) {
+			candidates.sort((left, right) => right.updatedAtMs - left.updatedAtMs);
+		}
+
+		return map;
+	}, [syncedPullRequests]);
 
 	const computedGroups = useMemo<DashboardSidebarProject[]>(() => {
 		const projectsById = new Map<
@@ -349,6 +509,14 @@ export function useDashboardSidebarData() {
 					: workspace.hostMachineId === machineId
 						? "local-device"
 						: "remote-device";
+			const syncedPullRequest =
+				project.githubRepositoryId === null
+					? null
+					: (syncedPullRequestsByRepositoryId
+							.get(project.githubRepositoryId)
+							?.find((pr) =>
+								pullRequestMatchesWorkspaceBranch(workspace.branch, pr),
+							)?.pullRequest ?? null);
 
 			const sidebarWorkspace: DashboardSidebarWorkspace = {
 				id: workspace.id,
@@ -364,8 +532,9 @@ export function useDashboardSidebarData() {
 				branch: workspace.branch,
 				pullRequest:
 					hostType === "local-device"
-						? (localPullRequestsByWorkspaceId.get(workspace.id) ?? null)
-						: null,
+						? (localPullRequestsByWorkspaceId.get(workspace.id) ??
+							syncedPullRequest)
+						: syncedPullRequest,
 				repoUrl:
 					project.githubOwner && project.githubRepoName
 						? `https://github.com/${project.githubOwner}/${project.githubRepoName}`
@@ -479,6 +648,7 @@ export function useDashboardSidebarData() {
 		sidebarProjects,
 		sidebarSections,
 		sidebarWorkspaces,
+		syncedPullRequestsByRepositoryId,
 	]);
 	const groups = useStableDashboardSidebarProjects(computedGroups);
 

--- a/plans/20260426-remote-workspace-pr-sidebar-icons.md
+++ b/plans/20260426-remote-workspace-pr-sidebar-icons.md
@@ -1,0 +1,100 @@
+# Remote Workspace PR Sidebar Icons
+
+## Why
+
+The dashboard sidebar icon is supposed to communicate the most specific workspace state available:
+
+1. creation or working state
+2. pull request state
+3. host fallback state
+
+That priority already exists inside `DashboardSidebarWorkspaceIcon`, but remote and cloud workspaces often never receive pull request metadata. When a remote workspace has a matching PR, the row can still fall back to the host icon because the sidebar data layer sets `pullRequest` to `null` for every non-local workspace.
+
+This makes remote and cloud PR workspaces look like plain cloud/remote workspaces, which hides useful review context and makes the sidebar inconsistent with local workspace rows.
+
+## Root Cause
+
+`useDashboardSidebarData` currently fetches PR metadata from the active local host service by workspace ID. That path only works for workspaces hosted by the current machine.
+
+For non-local workspaces:
+
+- `localWorkspaceIds` excludes them.
+- `pullRequestData` never includes them.
+- `sidebarWorkspace.pullRequest` is explicitly set to `null`.
+
+There is a second display gap in the collapsed sidebar path: `DashboardSidebarWorkspaceItem` passes PR state to expanded rows, but `DashboardSidebarCollapsedWorkspaceButton` does not accept or forward `pullRequestState`, so collapsed rows cannot show PR icons even if the workspace has PR metadata.
+
+## Intended Behavior
+
+For every dashboard sidebar workspace:
+
+- Failed creation shows the error icon.
+- Creating or working shows the spinner.
+- A linked PR shows the PR icon for its state.
+- Only workspaces without PR state fall back to the host icon.
+
+PR icon mapping should stay unchanged:
+
+- `open`: pull request icon
+- `draft`: draft pull request icon
+- `merged`: merge icon
+- `closed`: closed pull request icon
+
+Host fallback icons should stay unchanged from the icon PR:
+
+- local device: dot icon
+- remote offline: offline cloud icon
+- cloud or reachable remote: cloud icon
+
+## Proposed Fix
+
+Use the synced `githubPullRequests` collection as the cross-host PR metadata source for sidebar rows.
+
+For each workspace:
+
+1. Determine the workspace project repository ID.
+2. Find synced PRs for that repository.
+3. Match a PR to the workspace branch.
+4. Attach normalized PR metadata to `sidebarWorkspace.pullRequest`.
+
+Local workspaces should continue to prefer host-service PR data because it is workspace-specific and refreshed by the local runtime. Synced GitHub PR data should be used as a fallback for local workspaces and as the primary source for remote/cloud workspaces.
+
+The collapsed sidebar path should also accept and forward `pullRequestState` to `DashboardSidebarWorkspaceIcon`.
+
+## Branch Matching
+
+The sidebar can match the common branch forms already used by PR checkout:
+
+- same-repo PR: `workspace.branch === pr.headBranch`
+- fork PR: `workspace.branch === lowercasedAuthorLogin + "/" + pr.headBranch`
+
+This mirrors the local branch naming used for cross-repository PR checkouts.
+
+## Timestamp Handling
+
+Electric collection rows may provide timestamps as serialized strings even when the TypeScript model says `Date`. Any sorting or recency comparison should normalize timestamps first instead of calling `Date#getTime()` directly on collection values.
+
+## Test Plan
+
+Static checks:
+
+```bash
+bunx biome check apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarCollapsedWorkspaceButton/DashboardSidebarCollapsedWorkspaceButton.tsx
+bun run --cwd apps/desktop typecheck
+```
+
+Manual checks:
+
+1. Use a project with a synced GitHub repository and at least one PR.
+2. Open a remote or cloud workspace whose branch matches that PR.
+3. Confirm the expanded sidebar row shows the PR icon instead of the cloud icon.
+4. Collapse the sidebar and confirm the collapsed row also shows the PR icon.
+5. Confirm a remote/cloud workspace without a matching PR still shows the host fallback icon.
+6. Confirm failed, creating, and working states still override the PR icon.
+7. Confirm the dashboard no longer crashes when PR timestamps arrive as strings.
+
+## Risks
+
+Branch-name matching can produce false negatives if a workspace branch was renamed after checkout or uses a custom fork prefix. The fix intentionally avoids broad fuzzy matching to prevent showing the wrong PR on a workspace.
+
+Synced GitHub PR data may lag behind host-service data. Local workspaces should keep preferring host-service data to preserve the fresher runtime path.


### PR DESCRIPTION
## Summary
- Attach synced GitHub PR metadata to remote and cloud dashboard sidebar workspaces by repository and branch.
- Preserve local host-service PR data as the preferred source for local workspaces.
- Forward PR state through the collapsed sidebar icon path.
- Add a plan note documenting the root cause, matching behavior, timestamp handling, and test plan.

## Validation
- `bunx biome check apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarCollapsedWorkspaceButton/DashboardSidebarCollapsedWorkspaceButton.tsx`
- `bun run --cwd apps/desktop typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show PR icons for remote and cloud workspaces in the dashboard sidebar by attaching synced GitHub PR metadata matched by repository and branch. Local workspaces still prefer host-service PR data; the collapsed sidebar now also shows PR state.

- **New Features**
  - Attach normalized PR data from synced `githubPullRequests` to remote/cloud workspaces; use as fallback for local when host data is missing.
  - Match PRs by repo and branch (supports `author/branch` for forks) and select the most recently updated PR.
  - Keep existing icon priority: creation/working > PR state > host icon.

- **Bug Fixes**
  - Collapsed sidebar now receives `pullRequestState`, so PR icons render there.
  - Normalize timestamps to safely handle string/number values when sorting PRs.

<sup>Written for commit b63ccf54a8831231ce2fd17bc90b7057893adcd1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

