### PR TITLE
[codex] clear v2 ready notification on workspace click

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
@@ -9,6 +9,7 @@ import { useNavigateAwayFromWorkspace } from "renderer/routes/_authenticated/_da
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useOptimisticCollectionActions } from "renderer/routes/_authenticated/hooks/useOptimisticCollectionActions";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import { useV2NotificationStore } from "renderer/stores/v2-notifications";
 
 interface UseDashboardSidebarWorkspaceItemActionsOptions {
 	workspaceId: string;
@@ -30,6 +31,9 @@ export function useDashboardSidebarWorkspaceItemActions({
 	const { copyToClipboard } = useCopyToClipboard();
 	const { v2Workspaces: workspaceActions } = useOptimisticCollectionActions();
 	const { requestSectionRename } = useDashboardSidebarSectionRename();
+	const clearWorkspaceAttention = useV2NotificationStore(
+		(s) => s.clearWorkspaceAttention,
+	);
 	const { createSection, moveWorkspaceToSection, removeWorkspaceFromSidebar } =
 		useDashboardSidebarState();
 
@@ -45,6 +49,7 @@ export function useDashboardSidebarWorkspaceItemActions({
 
 	const handleClick = () => {
 		if (isRenaming) return;
+		clearWorkspaceAttention(workspaceId);
 		navigate({
 			to: "/v2-workspace/$workspaceId",
 			params: { workspaceId },

--- a/apps/desktop/src/renderer/stores/v2-notifications/store.test.ts
+++ b/apps/desktop/src/renderer/stores/v2-notifications/store.test.ts
@@ -112,4 +112,20 @@ describe("v2 notification store", () => {
 		expect(state.sources["terminal:terminal-1"]).toBeUndefined();
 		expect(state.sources["terminal:terminal-2"]?.status).toBe("permission");
 	});
+
+	it("clears only review attention for a workspace", () => {
+		const store = useV2NotificationStore.getState();
+		store.setTerminalStatus("terminal-1", "workspace-1", "review", 100);
+		store.setTerminalStatus("terminal-2", "workspace-1", "working", 101);
+		store.setChatStatus("session-1", "workspace-1", "permission", 102);
+		store.setTerminalStatus("terminal-3", "workspace-2", "review", 103);
+
+		store.clearWorkspaceAttention("workspace-1");
+
+		const state = useV2NotificationStore.getState();
+		expect(state.sources["terminal:terminal-1"]).toBeUndefined();
+		expect(state.sources["terminal:terminal-2"]?.status).toBe("working");
+		expect(state.sources["chat:session-1"]?.status).toBe("permission");
+		expect(state.sources["terminal:terminal-3"]?.status).toBe("review");
+	});
 });


### PR DESCRIPTION
## Summary

- Clear v2 workspace review attention when a workspace item is clicked, matching the v1 sidebar behavior for ready/completed notifications.
- Add coverage that workspace-level attention clearing removes only `review` sources while preserving `working`, `permission`, and other-workspace statuses.

## Impact

Clicking a v2 workspace row now acknowledges the ready notification immediately, without hiding active work or permission-request indicators.

## Validation

- `bun test apps/desktop/src/renderer/stores/v2-notifications/store.test.ts`
- `bunx biome check apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts apps/desktop/src/renderer/stores/v2-notifications/store.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clicking a v2 workspace in the sidebar now clears its ready/review notification, matching the v1 behavior. Active work and permission indicators remain, and other workspaces are unaffected; tests cover this.

<sup>Written for commit 3438569955738e28224afbb13bbcac743ab5eeb5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Workspace attention state now automatically clears when you select and navigate to a workspace.

* **Tests**
  * Added tests to validate notification clearing behavior within workspace scope, ensuring that only notifications in the targeted workspace are affected while preserving notifications in other workspaces and different notification statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->