### PR TITLE
im a widdle big baby

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -110,7 +110,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.5.10",
+      "version": "1.6.1",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.43",
         "@ai-sdk/openai": "3.0.36",


### PR DESCRIPTION
## Summary
- Sync `bun.lock` so the `apps/desktop` workspace version matches `apps/desktop/package.json` at `1.6.1`.

## Validation
- `bun install --frozen-lockfile`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Synced the `bun.lock` entry for `apps/desktop` (`@superset/desktop`) to version 1.6.1 to match `apps/desktop/package.json`. Ensures `bun install --frozen-lockfile` succeeds.

<sup>Written for commit bf0aa88706fb5869fac0793d92790b2697fe359c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

