### PR TITLE
improve v2 terminal drop hover animation

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -1,4 +1,5 @@
 import type { RendererContext } from "@superset/panes";
+import { cn } from "@superset/ui/utils";
 import { workspaceTrpc } from "@superset/workspace-client";
 import "@xterm/xterm/css/xterm.css";
 import {
@@ -377,7 +378,7 @@ export function TerminalPane({
 	return (
 		<div
 			role="application"
-			className="flex h-full w-full flex-col p-2"
+			className="relative flex h-full w-full flex-col p-2"
 			onDragEnter={handleDragEnter}
 			onDragOver={handleDragOver}
 			onDragLeave={handleDragLeave}
@@ -395,10 +396,13 @@ export function TerminalPane({
 					style={{ backgroundColor: appearance.background }}
 				/>
 				<ScrollToBottomButton terminal={terminal} />
-				{isDropActive && (
-					<div className="pointer-events-none absolute inset-0 rounded-sm border-2 border-primary/60 border-dashed bg-primary/10" />
-				)}
 			</div>
+			<div
+				className={cn(
+					"pointer-events-none absolute inset-0 bg-primary/10 transition-opacity duration-100",
+					isDropActive ? "opacity-75" : "opacity-0",
+				)}
+			/>
 			{connectionState === "closed" && (
 				<div className="flex items-center gap-2 border-t border-border px-3 py-1.5 text-xs text-muted-foreground">
 					<span>Disconnected</span>


### PR DESCRIPTION
## Summary
- Replace the v2 terminal drop-hover dashed border + inset overlay with a flush primary-tinted fade
- Keep the overlay mounted and toggle opacity (0 ↔ 75) so the hover state actually animates instead of popping in

## Test plan
- [ ] In a v2 workspace terminal pane, drag a file over the terminal and confirm the tint fades in across the full pane (no gap at the edges, no dashed outline)
- [ ] Drag back out and confirm it fades out smoothly
- [ ] Drop a file and confirm the path is pasted into the terminal as before

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refines the v2 terminal drag-and-drop hover to a full-bleed primary-tinted overlay that fades in/out, replacing the dashed inset outline. The overlay stays mounted and animates opacity (0 ↔ 75) for a smooth transition instead of a pop.

<sup>Written for commit 534674ed6232eada34900694729dfa8c6399374c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual feedback for drag-and-drop interactions in the terminal pane with smoother opacity transitions and refined styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->