### PR TITLE
fix v2 sidebar nav-away on workspace delete

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useNavigateAwayFromWorkspace/useNavigateAwayFromWorkspace.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useNavigateAwayFromWorkspace/useNavigateAwayFromWorkspace.ts
@@ -1,4 +1,4 @@
-import { useNavigate, useParams } from "@tanstack/react-router";
+import { useMatchRoute, useNavigate } from "@tanstack/react-router";
 import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { getFlattenedV2WorkspaceIds } from "../../utils/getFlattenedV2WorkspaceIds";
@@ -11,13 +11,19 @@ import { getFlattenedV2WorkspaceIds } from "../../utils/getFlattenedV2WorkspaceI
  */
 export function useNavigateAwayFromWorkspace() {
 	const navigate = useNavigate();
-	const params = useParams({ strict: false });
+	const matchRoute = useMatchRoute();
 	const collections = useCollections();
 
 	return (workspaceId: string) => {
-		if (params.workspaceId !== workspaceId) return;
-		const ids = getFlattenedV2WorkspaceIds(collections);
-		const next = ids.find((id) => id !== workspaceId);
+		const isViewingWorkspace = !!matchRoute({
+			to: "/v2-workspace/$workspaceId",
+			params: { workspaceId },
+			fuzzy: true,
+		});
+		if (!isViewingWorkspace) return;
+		const next = getFlattenedV2WorkspaceIds(collections).find(
+			(id) => id !== workspaceId,
+		);
 		if (next) {
 			void navigateToV2Workspace(next, navigate);
 		} else {


### PR DESCRIPTION
## Summary
- When the user deletes the workspace they're currently viewing, the sidebar's "navigate away to a sibling" logic was silently no-op'ing — leaving the user stranded on the deleted workspace's URL.
- Root cause: `useNavigateAwayFromWorkspace` used `useParams({ strict: false })` from a layout-level component, which didn't reliably surface the leaf route's `workspaceId`. The early-return `if (params.workspaceId !== workspaceId) return;` was firing even when the user *was* viewing the doomed workspace.
- Switched to `useMatchRoute({ to: "/v2-workspace/\$workspaceId", params, fuzzy: true })` — the same pattern `useDashboardSidebarWorkspaceItemActions` already uses for `isActive`.
- Nav still happens at the very start of `run()` in `useDestroyDialogState` (before the dialog closes / `markDeleting` / `destroy` fires), so the user moves off the doomed URL as soon as they confirm.

## Test plan
- [ ] On v2, with 2+ workspaces, view workspace A → right-click A in sidebar → Delete → confirm. Expect to land on workspace B (next sibling) immediately, before the destroy completes.
- [ ] Same flow with only one workspace: expect to land on `/`.
- [ ] View workspace A, right-click *workspace B* in sidebar → Delete → confirm. Expect to stay on workspace A.
- [ ] Force-delete path (dirty worktree → uncommitted-changes banner → confirm anyway): nav still happens up front.
- [ ] Teardown-failed path: nav happens at start, error pane reopens after — user is on the new workspace, error pane is informational.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes v2 sidebar navigation when deleting the current workspace. We now detect the active workspace reliably and navigate to the next workspace (or `/`) immediately after confirm, so users aren’t left on a deleted URL.

- **Bug Fixes**
  - Replaced `useParams({ strict: false })` with `useMatchRoute` against `"/v2-workspace/$workspaceId"` to correctly detect the active workspace.
  - On delete, navigate early to the next available workspace via `navigateToV2Workspace`, or to `/` if none exist.

<sup>Written for commit 253cccf0a5d8e3cbeadeec59951de3155d298fbf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined workspace navigation logic to ensure more reliable switching between workspaces and proper fallback to the home view when no alternative workspace is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->