### PR TITLE
fix automation list flicker on initial load

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/page.tsx
@@ -105,7 +105,7 @@ function AutomationsPage() {
 			),
 	});
 
-	const { data: automationRows = [] } = useLiveQuery(
+	const { data: automationRows = [], isReady: automationsReady } = useLiveQuery(
 		(q) =>
 			q
 				.from({ a: collections.automations })
@@ -228,7 +228,7 @@ function AutomationsPage() {
 			</header>
 
 			<div className="flex-1 overflow-y-auto px-8 py-6">
-				{automations.length === 0 ? (
+				{!automationsReady ? null : automations.length === 0 ? (
 					<AutomationsEmptyState onSelectTemplate={handleSelectTemplate} />
 				) : (
 					<>


### PR DESCRIPTION
## Summary
- Gate the automations page body on the Electric SQL collection's `isReady` so the empty-state placeholder doesn't flash for a frame or two before rows hydrate.

## Test plan
- [ ] Open Automations with existing automations: no `AutomationsEmptyState` flash before the table renders.
- [ ] Open Automations with zero automations: empty state appears once, no flicker.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes initial flicker on the Automations page by gating rendering on the Electric SQL automations collection’s `isReady`. The empty state no longer flashes before data hydrates; it only appears when there are no automations.

<sup>Written for commit 3e300bf7115e0113d17274a78ae9347cdad5eb51. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed automations list displaying an empty state during initial data load, preventing confusing UI transitions while data is being fetched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->