### PR TITLE
hide terminals from other workspaces in session dropdown

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -54,10 +54,9 @@ export function TerminalPane({
 		onLeave: onLinkLeave,
 	} = useLinkHoverState();
 	const { hint, showHint } = useLinkClickHint();
+	const openInExternalEditor = useOpenInExternalEditor(workspaceId);
 	const paneData = ctx.pane.data as TerminalPaneData;
 	const { terminalId } = paneData;
-	const sessionWorkspaceId = paneData.workspaceId ?? workspaceId;
-	const openInExternalEditor = useOpenInExternalEditor(sessionWorkspaceId);
 	const terminalInstanceId = ctx.pane.id;
 	const containerRef = useRef<HTMLDivElement | null>(null);
 	const activeTheme = useTheme();
@@ -79,8 +78,8 @@ export function TerminalPane({
 	const websocketUrl = useWorkspaceWsUrl(`/terminal/${terminalId}`);
 	const websocketUrlRef = useRef(websocketUrl);
 	websocketUrlRef.current = websocketUrl;
-	const sessionWorkspaceIdRef = useRef(sessionWorkspaceId);
-	sessionWorkspaceIdRef.current = sessionWorkspaceId;
+	const workspaceIdRef = useRef(workspaceId);
+	workspaceIdRef.current = workspaceId;
 
 	const ensureSession = workspaceTrpc.terminal.ensureSession.useMutation();
 	const ensureSessionRef = useRef(ensureSession);
@@ -125,7 +124,7 @@ export function TerminalPane({
 	//      "Session not found."
 	// Deps narrowed to [terminalId] so provider key remount churn (workspaceId
 	// briefly flipping while pane data catches up) doesn't re-run this effect.
-	// sessionWorkspaceId / websocketUrl are read through refs.
+	// workspaceId / websocketUrl are read through refs.
 	useEffect(() => {
 		const container = containerRef.current;
 		if (!container) return;
@@ -138,7 +137,7 @@ export function TerminalPane({
 		);
 
 		let cancelled = false;
-		const activeSessionWorkspaceId = sessionWorkspaceIdRef.current;
+		const sessionWorkspaceId = workspaceIdRef.current;
 
 		// Always connect after ensureSession settles, even on error: if the
 		// session actually exists on the server (e.g. we raced another client),
@@ -148,12 +147,14 @@ export function TerminalPane({
 		ensureSessionRef.current
 			.mutateAsync({
 				terminalId,
-				workspaceId: activeSessionWorkspaceId,
+				workspaceId: sessionWorkspaceId,
 				themeType: initialThemeTypeRef.current,
 			})
 			.then((result) => {
 				if (result.status === "active") {
-					void invalidateTerminalSessionsRef.current();
+					void invalidateTerminalSessionsRef.current({
+						workspaceId: sessionWorkspaceId,
+					});
 				}
 			})
 			.catch((err) => {
@@ -209,7 +210,7 @@ export function TerminalPane({
 				stat: async (path) => {
 					try {
 						const result = await statPathRef.current({
-							workspaceId: sessionWorkspaceId,
+							workspaceId,
 							path,
 						});
 						if (!result) return null;
@@ -280,7 +281,7 @@ export function TerminalPane({
 	}, [
 		terminalId,
 		terminalInstanceId,
-		sessionWorkspaceId,
+		workspaceId,
 		ctx.store,
 		onOpenFile,
 		onRevealPath,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
@@ -9,8 +9,6 @@ import {
 } from "@superset/ui/dropdown-menu";
 import { toast } from "@superset/ui/sonner";
 import { workspaceTrpc } from "@superset/workspace-client";
-import { useLiveQuery } from "@tanstack/react-db";
-import { useNavigate } from "@tanstack/react-router";
 import {
 	Check,
 	ChevronDown,
@@ -19,20 +17,13 @@ import {
 	TerminalSquare,
 	Trash2,
 } from "lucide-react";
-import {
-	Fragment,
-	useCallback,
-	useMemo,
-	useState,
-	useSyncExternalStore,
-} from "react";
+import { useCallback, useMemo, useState, useSyncExternalStore } from "react";
 import { markTerminalForBackground } from "renderer/lib/terminal/terminal-background-intents";
 import { terminalRuntimeRegistry } from "renderer/lib/terminal/terminal-runtime-registry";
 import type {
 	PaneViewerData,
 	TerminalPaneData,
 } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
-import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { getRelativeTime } from "renderer/screens/main/components/WorkspacesListView/utils";
 
 interface TerminalSessionDropdownProps {
@@ -42,7 +33,6 @@ interface TerminalSessionDropdownProps {
 
 interface VisibleTerminalSession {
 	terminalId: string;
-	workspaceId: string;
 	createdAt?: number;
 	exited: boolean;
 	exitCode: number;
@@ -55,12 +45,6 @@ interface TerminalPaneLocation {
 	tabId: string;
 	paneId: string;
 	titleOverride?: string;
-}
-
-interface TerminalSessionGroup {
-	workspaceId: string;
-	label: string;
-	sessions: VisibleTerminalSession[];
 }
 
 const EMPTY_TERMINAL_PANE_LOCATIONS = new Map<string, TerminalPaneLocation[]>();
@@ -98,100 +82,43 @@ export function TerminalSessionDropdown({
 	workspaceId,
 }: TerminalSessionDropdownProps) {
 	const [isOpen, setIsOpen] = useState(false);
-	const data = context.pane.data as TerminalPaneData;
-	const { terminalId } = data;
-	const sessionWorkspaceId = data.workspaceId ?? workspaceId;
+	const { terminalId } = context.pane.data as TerminalPaneData;
 	const terminalInstanceId = context.pane.id;
-	const navigate = useNavigate();
-	const collections = useCollections();
 	const utils = workspaceTrpc.useUtils();
 	const killTerminalSession = workspaceTrpc.terminal.killSession.useMutation();
 	const sessionsQuery = workspaceTrpc.terminal.listSessions.useQuery(
-		{},
+		{ workspaceId },
 		{
 			refetchInterval: isOpen ? 2_000 : false,
 			refetchOnWindowFocus: true,
 		},
 	);
-	const { data: workspaceRows = [] } = useLiveQuery(
-		(q) =>
-			q
-				.from({ v2Workspaces: collections.v2Workspaces })
-				.select(({ v2Workspaces }) => ({
-					id: v2Workspaces.id,
-					name: v2Workspaces.name,
-					branch: v2Workspaces.branch,
-				})),
-		[collections],
-	);
-
-	const workspaceLabels = useMemo(() => {
-		const labels = new Map<string, string>();
-		for (const row of workspaceRows) {
-			labels.set(row.id, row.name || row.branch || "Workspace");
-		}
-		return labels;
-	}, [workspaceRows]);
 
 	const sessions = useMemo<VisibleTerminalSession[]>(() => {
 		const liveSessions = sessionsQuery.data?.sessions ?? [];
-		if (liveSessions.some((session) => session.terminalId === terminalId)) {
-			return liveSessions;
+		const ordered = [...liveSessions].sort((a, b) => {
+			if (a.terminalId === terminalId) return -1;
+			if (b.terminalId === terminalId) return 1;
+			return (b.createdAt ?? 0) - (a.createdAt ?? 0);
+		});
+		if (ordered.some((session) => session.terminalId === terminalId)) {
+			return ordered;
 		}
 		return [
 			{
 				terminalId,
-				workspaceId: sessionWorkspaceId,
 				exited: false,
 				exitCode: 0,
 				attached: false,
 				title: null,
 				pending: true,
 			},
-			...liveSessions,
+			...ordered,
 		];
-	}, [sessionsQuery.data?.sessions, terminalId, sessionWorkspaceId]);
+	}, [sessionsQuery.data?.sessions, terminalId]);
 	const currentSession = sessions.find(
 		(session) => session.terminalId === terminalId,
 	);
-	const sessionGroups = useMemo<TerminalSessionGroup[]>(() => {
-		const groupsByWorkspaceId = new Map<string, VisibleTerminalSession[]>();
-		for (const session of sessions) {
-			const group = groupsByWorkspaceId.get(session.workspaceId) ?? [];
-			group.push(session);
-			groupsByWorkspaceId.set(session.workspaceId, group);
-		}
-
-		return [...groupsByWorkspaceId.entries()]
-			.map(([groupWorkspaceId, groupSessions]) => ({
-				workspaceId: groupWorkspaceId,
-				label:
-					groupWorkspaceId === workspaceId
-						? "Current workspace"
-						: (workspaceLabels.get(groupWorkspaceId) ?? "Unknown workspace"),
-				sessions: [...groupSessions].sort((a, b) => {
-					if (a.terminalId === terminalId) return -1;
-					if (b.terminalId === terminalId) return 1;
-					return (b.createdAt ?? 0) - (a.createdAt ?? 0);
-				}),
-			}))
-			.sort((a, b) => {
-				const aHasCurrent = a.sessions.some(
-					(session) => session.terminalId === terminalId,
-				);
-				const bHasCurrent = b.sessions.some(
-					(session) => session.terminalId === terminalId,
-				);
-				if (aHasCurrent !== bHasCurrent) return aHasCurrent ? -1 : 1;
-				if (a.workspaceId === workspaceId && b.workspaceId !== workspaceId) {
-					return -1;
-				}
-				if (b.workspaceId === workspaceId && a.workspaceId !== workspaceId) {
-					return 1;
-				}
-				return a.label.localeCompare(b.label);
-			});
-	}, [sessions, terminalId, workspaceId, workspaceLabels]);
 	const subscribeTitle = useCallback(
 		(callback: () => void) =>
 			terminalRuntimeRegistry.onTitleChange(
@@ -230,19 +157,6 @@ export function TerminalSessionDropdown({
 			return;
 		}
 
-		if (session.attached && session.workspaceId !== workspaceId) {
-			void navigate({
-				to: "/v2-workspace/$workspaceId",
-				params: { workspaceId: session.workspaceId },
-				search: {
-					terminalId: session.terminalId,
-					focusRequestId: crypto.randomUUID(),
-				},
-			});
-			setIsOpen(false);
-			return;
-		}
-
 		if ((terminalPaneLocations.get(terminalId)?.length ?? 0) === 0) {
 			markTerminalForBackground(terminalId);
 		}
@@ -251,7 +165,6 @@ export function TerminalSessionDropdown({
 			paneId: context.pane.id,
 			data: {
 				terminalId: nextTerminalId,
-				workspaceId: session.workspaceId,
 			} as PaneViewerData,
 		});
 		state.setPaneTitleOverride({
@@ -280,11 +193,11 @@ export function TerminalSessionDropdown({
 		try {
 			await killTerminalSession.mutateAsync({
 				terminalId: session.terminalId,
-				workspaceId: session.workspaceId,
+				workspaceId,
 			});
 			closePanesForTerminal(session.terminalId);
 		} finally {
-			await utils.terminal.listSessions.invalidate();
+			await utils.terminal.listSessions.invalidate({ workspaceId });
 		}
 	};
 
@@ -306,7 +219,6 @@ export function TerminalSessionDropdown({
 			paneId: context.pane.id,
 			data: {
 				terminalId: crypto.randomUUID(),
-				workspaceId,
 			} as PaneViewerData,
 		});
 		state.setPaneTitleOverride({
@@ -314,7 +226,7 @@ export function TerminalSessionDropdown({
 			paneId: context.pane.id,
 			titleOverride: undefined,
 		});
-		void utils.terminal.listSessions.invalidate();
+		void utils.terminal.listSessions.invalidate({ workspaceId });
 		setIsOpen(false);
 	};
 
@@ -364,76 +276,60 @@ export function TerminalSessionDropdown({
 				</DropdownMenuLabel>
 				<DropdownMenuSeparator />
 				<div className="max-h-80 overflow-y-auto">
-					{sessionGroups.length > 0 ? (
-						sessionGroups.map((group, groupIndex) => (
-							<Fragment key={group.workspaceId}>
-								{groupIndex > 0 && <DropdownMenuSeparator />}
-								<div
-									className="flex min-w-0 items-center gap-2 px-2 pt-2 pb-1 text-muted-foreground text-xs"
-									title={group.label}
-								>
-									<span className="min-w-0 flex-1 truncate font-medium">
-										{group.label}
-									</span>
-									<span className="shrink-0 text-muted-foreground/60 tabular-nums">
-										{group.sessions.length}
-									</span>
-								</div>
-								{group.sessions.map((session) => {
-									const isCurrent = session.terminalId === terminalId;
-									const location = renderTerminalPaneLocations.get(
-										session.terminalId,
-									)?.[0];
-									const createdAtLabel = formatCreatedAt(session.createdAt);
-									const status = isCurrent
-										? "Current"
-										: session.pending
-											? "Starting"
-											: session.attached
-												? "Attached"
-												: "Detached";
-									const title = isCurrent
-										? triggerTitle
-										: (session.title ?? location?.titleOverride ?? "Terminal");
+					{sessions.length > 0 ? (
+						sessions.map((session) => {
+							const isCurrent = session.terminalId === terminalId;
+							const location = renderTerminalPaneLocations.get(
+								session.terminalId,
+							)?.[0];
+							const createdAtLabel = formatCreatedAt(session.createdAt);
+							const status = isCurrent
+								? "Current"
+								: session.pending
+									? "Starting"
+									: session.attached
+										? "Attached"
+										: "Detached";
+							const title = isCurrent
+								? triggerTitle
+								: (session.title ?? location?.titleOverride ?? "Terminal");
 
-									return (
-										<DropdownMenuItem
-											key={session.terminalId}
-											className="group flex items-center gap-2"
-											onSelect={(_event) => {
-												handleSelectSession(session);
-											}}
-										>
-											<span className="w-4 shrink-0">
-												{isCurrent && <Check className="size-3.5" />}
-											</span>
-											<span className="min-w-0 flex-1 truncate text-xs">
-												{title}
-											</span>
-											<span className="shrink-0 text-xs text-muted-foreground/70">
-												{createdAtLabel}
-											</span>
-											<span className="shrink-0 text-xs text-muted-foreground">
-												{status}
-											</span>
-											<button
-												type="button"
-												aria-label={`Remove terminal ${session.createdAt ? createdAtLabel : "session"}`}
-												disabled={killTerminalSession.isPending}
-												className="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive disabled:pointer-events-none disabled:opacity-30 group-hover:opacity-100"
-												onClick={(event) => {
-													event.preventDefault();
-													event.stopPropagation();
-													handleRemoveTerminal(session);
-												}}
-											>
-												<Trash2 className="size-3" />
-											</button>
-										</DropdownMenuItem>
-									);
-								})}
-							</Fragment>
-						))
+							return (
+								<DropdownMenuItem
+									key={session.terminalId}
+									className="group flex items-center gap-2"
+									onSelect={(_event) => {
+										handleSelectSession(session);
+									}}
+								>
+									<span className="w-4 shrink-0">
+										{isCurrent && <Check className="size-3.5" />}
+									</span>
+									<span className="min-w-0 flex-1 truncate text-xs">
+										{title}
+									</span>
+									<span className="shrink-0 text-xs text-muted-foreground/70">
+										{createdAtLabel}
+									</span>
+									<span className="shrink-0 text-xs text-muted-foreground">
+										{status}
+									</span>
+									<button
+										type="button"
+										aria-label={`Remove terminal ${session.createdAt ? createdAtLabel : "session"}`}
+										disabled={killTerminalSession.isPending}
+										className="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive disabled:pointer-events-none disabled:opacity-30 group-hover:opacity-100"
+										onClick={(event) => {
+											event.preventDefault();
+											event.stopPropagation();
+											handleRemoveTerminal(session);
+										}}
+									>
+										<Trash2 className="size-3" />
+									</button>
+								</DropdownMenuItem>
+							);
+						})
 					) : (
 						<div className="px-2 py-1.5 text-xs text-muted-foreground">
 							No live sessions

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -168,7 +168,9 @@ export function usePaneRegistry(
 		workspaceTrpc.terminal.killSession.useMutation({
 			onSuccess: () => {
 				toast.success("Terminal session killed");
-				void workspaceTrpcUtils.terminal.listSessions.invalidate();
+				void workspaceTrpcUtils.terminal.listSessions.invalidate({
+					workspaceId,
+				});
 			},
 			onError: (error) => {
 				toast.error("Failed to kill terminal session", {
@@ -375,10 +377,10 @@ export function usePaneRegistry(
 						variant: "destructive",
 						disabled: isKillingTerminalSession,
 						onSelect: (ctx) => {
-							const data = ctx.pane.data as TerminalPaneData;
+							const { terminalId } = ctx.pane.data as TerminalPaneData;
 							killTerminalSession({
-								terminalId: data.terminalId,
-								workspaceId: data.workspaceId ?? workspaceId,
+								terminalId,
+								workspaceId,
 							});
 						},
 					};

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
@@ -8,7 +8,6 @@ export interface FilePaneData {
 
 export interface TerminalPaneData {
 	terminalId: string;
-	workspaceId?: string;
 }
 
 export interface ChatPaneData {

--- a/apps/desktop/src/renderer/routes/_authenticated/components/GlobalTerminalLifecycle/hooks/useGlobalTerminalLifecycle/useGlobalTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/GlobalTerminalLifecycle/hooks/useGlobalTerminalLifecycle/useGlobalTerminalLifecycle.ts
@@ -20,23 +20,10 @@ const RELEASE_DELAY_MS = 500;
 
 interface TerminalPaneData {
 	terminalId: string;
-	workspaceId?: string;
-}
-
-interface TerminalLocation {
-	ownerWorkspaceId: string;
-	sessionWorkspaceId: string;
-}
-
-interface RemovedTerminalLocation {
-	terminalId: string;
-	ownerWorkspaceId: string;
-	sessionWorkspaceId: string;
 }
 
 interface PendingTerminalCleanup {
-	ownerWorkspaceId: string;
-	sessionWorkspaceId: string;
+	workspaceId: string;
 	timer: ReturnType<typeof setTimeout> | null;
 }
 
@@ -53,17 +40,6 @@ function getTerminalId(
 	if (!pane.data || typeof pane.data !== "object") return null;
 	const data = pane.data as Partial<TerminalPaneData>;
 	return typeof data.terminalId === "string" ? data.terminalId : null;
-}
-
-function getTerminalSessionWorkspaceId(
-	pane: WorkspaceState<unknown>["tabs"][number]["panes"][string],
-	fallbackWorkspaceId: string,
-): string {
-	if (!pane.data || typeof pane.data !== "object") return fallbackWorkspaceId;
-	const data = pane.data as Partial<TerminalPaneData>;
-	return typeof data.workspaceId === "string"
-		? data.workspaceId
-		: fallbackWorkspaceId;
 }
 
 function getTerminalInstanceKey(
@@ -86,57 +62,14 @@ function parseTerminalInstanceKey(
 
 function extractTerminalLocations(
 	rows: PaneLifecycleRow[],
-): Map<string, TerminalLocation> {
-	const locations = new Map<string, TerminalLocation>();
-
-	for (const row of rows) {
-		if (typeof row.workspaceId !== "string") continue;
-
-		const layout = row.paneLayout as WorkspaceState<unknown> | undefined;
-		if (!layout?.tabs) continue;
-
-		for (const tab of layout.tabs) {
-			for (const pane of Object.values(tab.panes)) {
-				const terminalId = getTerminalId(pane);
-				if (!terminalId) continue;
-				locations.set(terminalId, {
-					ownerWorkspaceId: row.workspaceId,
-					sessionWorkspaceId: getTerminalSessionWorkspaceId(
-						pane,
-						row.workspaceId,
-					),
-				});
-			}
-		}
-	}
-
-	return locations;
+): Map<string, string> {
+	return extractPaneLocations(rows, getTerminalId);
 }
 
 function extractTerminalInstanceLocations(
 	rows: PaneLifecycleRow[],
 ): Map<string, string> {
 	return extractPaneLocations(rows, getTerminalInstanceKey);
-}
-
-function getRemovedTerminalLocations({
-	previousLocations,
-	currentLocations,
-	currentWorkspaceIds,
-}: {
-	previousLocations: Map<string, TerminalLocation>;
-	currentLocations: Map<string, TerminalLocation>;
-	currentWorkspaceIds: Set<string>;
-}): RemovedTerminalLocation[] {
-	const removed: RemovedTerminalLocation[] = [];
-
-	for (const [terminalId, location] of previousLocations) {
-		if (currentLocations.has(terminalId)) continue;
-		if (!currentWorkspaceIds.has(location.ownerWorkspaceId)) continue;
-		removed.push({ terminalId, ...location });
-	}
-
-	return removed;
 }
 
 function cleanupRemovedTerminal({
@@ -176,9 +109,7 @@ function cleanupRemovedTerminal({
 export function useGlobalTerminalLifecycle() {
 	const collections = useCollections();
 	const { machineId, activeHostUrl } = useLocalHostService();
-	const prevTerminalLocationsRef = useRef<Map<string, TerminalLocation>>(
-		new Map(),
-	);
+	const prevTerminalLocationsRef = useRef<Map<string, string>>(new Map());
 	const prevTerminalInstanceLocationsRef = useRef<Map<string, string>>(
 		new Map(),
 	);
@@ -266,11 +197,11 @@ export function useGlobalTerminalLifecycle() {
 		// while still cleaning up when the post-removal layout comes back.
 		for (const [terminalId, pending] of pendingCleanups.current) {
 			if (pending.timer) continue;
-			if (currentWorkspaceIds.has(pending.ownerWorkspaceId)) {
+			if (currentWorkspaceIds.has(pending.workspaceId)) {
 				pendingCleanups.current.delete(terminalId);
 				cleanupRemovedTerminal({
 					terminalId,
-					workspaceId: pending.sessionWorkspaceId,
+					workspaceId: pending.workspaceId,
 					hostUrlByWorkspaceId: hostUrlByWorkspaceIdRef.current,
 				});
 			}
@@ -331,17 +262,13 @@ export function useGlobalTerminalLifecycle() {
 			});
 		}
 
-		const removedLocations = getRemovedTerminalLocations({
+		const removedLocations = getRemovedPaneLocations({
 			previousLocations: prevTerminalLocations,
 			currentLocations: currentTerminalLocations,
 			currentWorkspaceIds,
 		});
 
-		for (const {
-			terminalId,
-			ownerWorkspaceId,
-			sessionWorkspaceId,
-		} of removedLocations) {
+		for (const { id: terminalId, workspaceId } of removedLocations) {
 			if (pendingCleanups.current.has(terminalId)) continue;
 
 			const timer = setTimeout(() => {
@@ -356,11 +283,11 @@ export function useGlobalTerminalLifecycle() {
 					return;
 				}
 
-				if (freshWorkspaceIds.has(ownerWorkspaceId)) {
+				if (freshWorkspaceIds.has(workspaceId)) {
 					pendingCleanups.current.delete(terminalId);
 					cleanupRemovedTerminal({
 						terminalId,
-						workspaceId: sessionWorkspaceId,
+						workspaceId,
 						hostUrlByWorkspaceId: hostUrlByWorkspaceIdRef.current,
 					});
 					return;
@@ -372,11 +299,7 @@ export function useGlobalTerminalLifecycle() {
 				}
 			}, RELEASE_DELAY_MS);
 
-			pendingCleanups.current.set(terminalId, {
-				ownerWorkspaceId,
-				sessionWorkspaceId,
-				timer,
-			});
+			pendingCleanups.current.set(terminalId, { workspaceId, timer });
 		}
 
 		prevTerminalLocationsRef.current = currentTerminalLocations;

--- a/packages/host-service/src/trpc/router/terminal/terminal.ts
+++ b/packages/host-service/src/trpc/router/terminal/terminal.ts
@@ -44,7 +44,7 @@ export const terminalRouter = router({
 	listSessions: protectedProcedure
 		.input(
 			z.object({
-				workspaceId: z.string().optional(),
+				workspaceId: z.string(),
 			}),
 		)
 		.query(({ input }) => ({


### PR DESCRIPTION
## Summary
- Filter `terminal.listSessions` to the current workspace so the dropdown only surfaces sessions in the active workspace.
- Drop the cross-workspace grouping/navigation UI added in #3751 (workspace headers, "navigate to other workspace" branch in `handleSelectSession`).
- Collapse the now-unused workspace plumbing: `TerminalPaneData.workspaceId`, the `ownerWorkspaceId` / `sessionWorkspaceId` split in `useGlobalTerminalLifecycle`, and the optional `workspaceId` on the host-service `listSessions` input. Plumbing files (`types.ts`, `useGlobalTerminalLifecycle.ts`, host-service router) are byte-identical to pre-#3751.
- Keeps the dropdown rewrite from #3751 (status labels, sorted list, pending placeholder, trash icon, kill-error invalidation).

## Test plan
- [ ] Open a v2 workspace with a terminal pane; dropdown lists only sessions from this workspace.
- [ ] Open a second workspace with its own terminals; switching between them shows each workspace's own session list, never the other's.
- [ ] Trash icon on a session removes it and the toast surfaces success/failure.
- [ ] "+" creates a fresh terminal scoped to the current workspace.
- [ ] Closing/moving terminal panes still triggers the global cleanup grace period correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide terminal sessions from other workspaces in the dropdown so users only see sessions from the active workspace. Simplifies terminal lifecycle while keeping the improved dropdown UX from #3751.

- **Refactors**
  - Filter `terminal.listSessions` by the current `workspaceId` and remove cross-workspace grouping/navigation.
  - Remove `TerminalPaneData.workspaceId` and collapse owner/session tracking in `useGlobalTerminalLifecycle` to a single workspace identity.
  - Scope session invalidation and kill actions to the current `workspaceId`.
  - Keep status labels, sorting, pending placeholder, and trash/kill error handling.

- **Migration**
  - Calls to `terminal.listSessions` must include `{ workspaceId }`.

<sup>Written for commit 05124bfcaba3539d6e69d163b8e8ac713e42438b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal session management to properly scope sessions to the current workspace.
  * Prevented unintended cross-workspace navigation when selecting terminal sessions.

* **Refactor**
  * Simplified terminal session display to show a flat list instead of workspace-grouped sections.
  * Streamlined internal terminal state tracking and session invalidation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->