### PR TITLE
[codex] make V1 migration org-idempotent

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/migration/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/migration/index.ts
@@ -96,24 +96,5 @@ export const createMigrationRouter = () => {
 					.where(eq(v1MigrationState.organizationId, input.organizationId))
 					.run();
 			}),
-
-		findMigrationByOtherOrg: publicProcedure
-			.input(z.object({ organizationId: z.string().min(1) }))
-			.query(({ input }) => {
-				const other = localDb
-					.select({
-						organizationId: v1MigrationState.organizationId,
-						status: v1MigrationState.status,
-					})
-					.from(v1MigrationState)
-					.where(eq(v1MigrationState.kind, "project"))
-					.all()
-					.find(
-						(row) =>
-							row.organizationId !== input.organizationId &&
-							(row.status === "success" || row.status === "linked"),
-					);
-				return other?.organizationId ?? null;
-			}),
 	});
 };

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/migrate.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/migrate.test.ts
@@ -59,7 +59,6 @@ interface FakeEnv {
 	v1Worktrees: V1WorktreeRow[];
 	v1Sections: V1SectionRow[];
 	state: Map<string, StateRow>;
-	otherOrg: string | null;
 	findByPath: Map<string, PathResponse>;
 	failNextStateWriteFor: Set<string>;
 	hostProjectsByPath: Map<string, string>;
@@ -88,7 +87,6 @@ function makeFakeEnv(overrides: Partial<FakeEnv> = {}): FakeEnv {
 		v1Worktrees: [],
 		v1Sections: [],
 		state: new Map(),
-		otherOrg: null,
 		findByPath: new Map(),
 		failNextStateWriteFor: new Set(),
 		hostProjectsByPath: new Map(),
@@ -129,9 +127,6 @@ function makeElectronTrpc(env: FakeEnv): ElectronTrpcClient {
 					Array.from(env.state.values()).filter(
 						(r) => r.organizationId === organizationId,
 					),
-			},
-			findMigrationByOtherOrg: {
-				query: async (_: { organizationId: string }) => env.otherOrg,
 			},
 			upsertState: {
 				mutate: async (row: Omit<StateRow, "migratedAt">) => {
@@ -589,20 +584,35 @@ describe("migrateV1DataToV2", () => {
 		expect(env.state.get("workspace:w1")?.status).toBe("error");
 	});
 
-	test("other-org guard rejects migration", async () => {
+	test("other-org state does not block migration for the active organization", async () => {
 		const env = makeFakeEnv({
-			otherOrg: "some-other-org",
 			v1Projects: [project("p1")],
+			state: new Map([
+				[
+					"project:p1",
+					{
+						v1Id: "p1",
+						v2Id: "v2-other-org-project",
+						organizationId: "some-other-org",
+						kind: "project",
+						status: "success",
+						reason: null,
+					},
+				],
+			]),
 		});
 
-		await expect(
-			migrateV1DataToV2({
-				organizationId: ORG,
-				electronTrpc: makeElectronTrpc(env),
-				hostService: makeHostService(env),
-				collections: makeCollections(),
-			}),
-		).rejects.toThrow(/already been migrated/);
+		const summary = await migrateV1DataToV2({
+			organizationId: ORG,
+			electronTrpc: makeElectronTrpc(env),
+			hostService: makeHostService(env),
+			collections: makeCollections(),
+		});
+
+		expect(summary.projectsCreated).toBe(1);
+		expect(summary.errors).toHaveLength(0);
+		expect(env.state.get("project:p1")?.organizationId).toBe(ORG);
+		expect(env.state.get("project:p1")?.status).toBe("success");
 	});
 
 	test("rerun skips rows already in success/linked state, retries error rows and skipped workspaces", async () => {
@@ -727,6 +737,61 @@ describe("migrateV1DataToV2", () => {
 			},
 		]);
 		expect(env.adoptCalls).toHaveLength(0);
+	});
+
+	test("running a completed migration again does not create duplicate projects or workspaces", async () => {
+		const env = makeFakeEnv({
+			v1Projects: [project("p1")],
+			v1Workspaces: [
+				workspace("w1", "p1", { worktreeId: "wt1", type: "worktree" }),
+			],
+			v1Worktrees: [{ id: "wt1", path: "/worktrees/w1" }],
+		});
+		const electronTrpc = makeElectronTrpc(env);
+		const hostService = makeHostService(env);
+		const collections = makeCollections();
+
+		const first = await migrateV1DataToV2({
+			organizationId: ORG,
+			electronTrpc,
+			hostService,
+			collections,
+		});
+
+		expect(first.projectsCreated).toBe(1);
+		expect(first.workspacesCreated).toBe(1);
+		expect(env.createCalls).toHaveLength(1);
+		expect(env.adoptCalls).toHaveLength(1);
+		expect(env.createdWorkspaceIds).toHaveLength(1);
+
+		const second = await migrateV1DataToV2({
+			organizationId: ORG,
+			electronTrpc,
+			hostService,
+			collections,
+		});
+
+		expect(second.projectsCreated).toBe(0);
+		expect(second.projectsLinked).toBe(0);
+		expect(second.workspacesCreated).toBe(0);
+		expect(second.workspacesErrored).toBe(0);
+		expect(second.projects).toEqual([
+			{ name: "project-p1", status: "synced", reason: "Already imported" },
+		]);
+		expect(second.workspaces).toEqual([
+			{
+				name: "workspace-w1",
+				branch: "branch-w1",
+				status: "synced",
+				reason: "Already imported",
+			},
+		]);
+		expect(env.createCalls).toHaveLength(1);
+		expect(env.adoptCalls).toHaveLength(1);
+		expect(env.createdWorkspaceIds).toHaveLength(1);
+		expect(env.setupCalls).toEqual([
+			{ projectId: "v2-proj-1", repoPath: "/repos/p1" },
+		]);
 	});
 
 	test("project state write failure does not migrate child workspaces until rerun reconciles the project", async () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/migrate.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/migrate.ts
@@ -187,28 +187,14 @@ export async function migrateV1DataToV2(args: Args): Promise<MigrationSummary> {
 	const { organizationId, electronTrpc, hostService, collections } = args;
 	const summary = emptySummary();
 
-	const [
-		v1Projects,
-		v1Workspaces,
-		v1Worktrees,
-		v1Sections,
-		existingState,
-		otherOrg,
-	] = await Promise.all([
-		electronTrpc.migration.readV1Projects.query(),
-		electronTrpc.migration.readV1Workspaces.query(),
-		electronTrpc.migration.readV1Worktrees.query(),
-		electronTrpc.migration.readV1WorkspaceSections.query(),
-		electronTrpc.migration.listState.query({ organizationId }),
-		electronTrpc.migration.findMigrationByOtherOrg.query({ organizationId }),
-	]);
-
-	if (otherOrg) {
-		throw new Error(
-			`v1 data has already been migrated to organization ${otherOrg}. ` +
-				"Contact support if you need to migrate to a different organization.",
-		);
-	}
+	const [v1Projects, v1Workspaces, v1Worktrees, v1Sections, existingState] =
+		await Promise.all([
+			electronTrpc.migration.readV1Projects.query(),
+			electronTrpc.migration.readV1Workspaces.query(),
+			electronTrpc.migration.readV1Worktrees.query(),
+			electronTrpc.migration.readV1WorkspaceSections.query(),
+			electronTrpc.migration.listState.query({ organizationId }),
+		]);
 
 	const stateByKey = new Map<string, (typeof existingState)[number]>();
 	for (const row of existingState) {


### PR DESCRIPTION
## Summary

Make the V1 to V2 migration rerunnable when stale migration state exists for another organization.

## Root Cause

The migration state table is scoped by `organizationId`, which is useful because V2 project and workspace IDs are organization-scoped. However, the migration also had a global preflight guard that queried for any successful project migration row belonging to a different org and aborted the run. That prevented the idempotent project reconciliation path from running, including `findByPath` linking to an existing V2 project.

## Changes

- Remove the fatal cross-organization migration guard from the V1 to V2 migration.
- Remove the now-unused `findMigrationByOtherOrg` migration router endpoint.
- Update migration tests so stale state from another org is ignored and the active org can migrate normally.
- Add a completed-migration rerun regression test that verifies a second run does not create duplicate projects or workspaces.

## Rerun Safety

The rerun path now relies on the existing per-row idempotency model:

- Successful or linked project rows are reconciled with `setupProjectImport` and reported as synced instead of recreated.
- Existing V2 projects discovered by repo path are linked instead of recreated.
- Successful workspace rows are checked in the host service and reported as synced instead of re-adopted.
- Previous project/workspace error rows are retried.
- Previous recoverable workspace skips, including missing/stale worktrees and unresolved parents, are retried.
- Sidebar migration writes remain guarded by deterministic IDs and `collection.get(id)` checks, so repeated runs do not duplicate sidebar entries.

## Validation

- `bun test apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/migrate.test.ts apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/writeSidebarState.test.ts apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/normalize.test.ts`
- `bunx @biomejs/biome@2.4.2 check apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/migrate.ts apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/migrate.test.ts apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/writeSidebarState.ts apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/writeSidebarState.test.ts apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/normalize.ts apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/normalize.test.ts apps/desktop/src/lib/trpc/routers/migration/index.ts`
- `bun run --cwd apps/desktop typecheck`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Migration now proceeds successfully even if v1 data was previously migrated in another organization.
  * Migration is now idempotent—rerunning the process won't create duplicate projects or workspaces.

* **Tests**
  * Updated migration tests to cover additional scenarios and improve reliability verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->