### PR TITLE
Fix stale persisted tab state on startup

### DIFF
--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -52,6 +52,7 @@ import {
 	removePaneFromLayout,
 	resolveActiveTabIdForWorkspace,
 	resolveFileViewerMode,
+	sanitizePersistedTabState,
 } from "./utils";
 import { killTerminalForPane } from "./utils/terminal-cleanup";
 
@@ -2301,65 +2302,11 @@ export const useTabsStore = create<TabsStore>()(
 					}
 
 					const mergedState = { ...currentState, ...persisted };
-
-					// Sanitize persisted tab pointers to be workspace-scoped.
-					// This prevents cross-workspace rendering when state is stale/corrupt.
-					const tabIds = new Set(mergedState.tabs.map((t) => t.id));
-					const workspaceTabIdSets = new Map<string, Set<string>>();
-					for (const tab of mergedState.tabs) {
-						let setForWorkspace = workspaceTabIdSets.get(tab.workspaceId);
-						if (!setForWorkspace) {
-							setForWorkspace = new Set();
-							workspaceTabIdSets.set(tab.workspaceId, setForWorkspace);
-						}
-						setForWorkspace.add(tab.id);
-					}
-
-					const workspaceIds = new Set<string>([
-						...Object.keys(mergedState.activeTabIds),
-						...Object.keys(mergedState.tabHistoryStacks),
-					]);
-					for (const tab of mergedState.tabs) {
-						workspaceIds.add(tab.workspaceId);
-					}
-
-					const nextActiveTabIds = { ...mergedState.activeTabIds };
-					const nextHistoryStacks = { ...mergedState.tabHistoryStacks };
-
-					for (const workspaceId of workspaceIds) {
-						nextActiveTabIds[workspaceId] = resolveActiveTabIdForWorkspace({
-							workspaceId,
-							tabs: mergedState.tabs,
-							activeTabIds: mergedState.activeTabIds,
-							tabHistoryStacks: mergedState.tabHistoryStacks,
-						});
-
-						const workspaceTabIds = workspaceTabIdSets.get(workspaceId);
-						const history = nextHistoryStacks[workspaceId] ?? [];
-						if (workspaceTabIds && Array.isArray(history)) {
-							nextHistoryStacks[workspaceId] = history.filter((id) =>
-								workspaceTabIds.has(id),
-							);
-						}
-					}
-
-					const nextFocusedPaneIds = { ...mergedState.focusedPaneIds };
-					for (const [tabId, paneId] of Object.entries(nextFocusedPaneIds)) {
-						if (!tabIds.has(tabId)) {
-							delete nextFocusedPaneIds[tabId];
-							continue;
-						}
-						const pane = mergedState.panes[paneId];
-						if (!pane || pane.tabId !== tabId) {
-							delete nextFocusedPaneIds[tabId];
-						}
-					}
+					const sanitized = sanitizePersistedTabState(mergedState);
 
 					return {
 						...mergedState,
-						activeTabIds: nextActiveTabIds,
-						tabHistoryStacks: nextHistoryStacks,
-						focusedPaneIds: nextFocusedPaneIds,
+						...sanitized,
 					};
 				},
 			},

--- a/apps/desktop/src/renderer/stores/tabs/utils.test.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils.test.ts
@@ -12,6 +12,7 @@ import {
 	getAdjacentPaneId,
 	resolveActiveTabIdForWorkspace,
 	resolveFileViewerMode,
+	sanitizePersistedTabState,
 } from "./utils";
 
 describe("findPanePath", () => {
@@ -295,6 +296,108 @@ describe("resolveActiveTabIdForWorkspace", () => {
 				tabHistoryStacks: { "ws-1": ["tab-x"] },
 			}),
 		).toBeNull();
+	});
+});
+
+describe("sanitizePersistedTabState", () => {
+	const terminalPane = (id: string, tabId: string): Pane => ({
+		id,
+		tabId,
+		type: "terminal",
+		name: id,
+	});
+
+	it("falls focusedPaneIds back to the first valid pane in the tab layout", () => {
+		const tabs: Tab[] = [
+			{
+				id: "tab-a",
+				name: "Terminal",
+				workspaceId: "ws-1",
+				layout: "pane-a",
+				createdAt: 0,
+			},
+		];
+		const panes = {
+			"pane-a": terminalPane("pane-a", "tab-a"),
+		};
+
+		const result = sanitizePersistedTabState({
+			tabs,
+			panes,
+			activeTabIds: { "ws-1": "tab-a" },
+			focusedPaneIds: { "tab-a": "pane-missing" },
+			tabHistoryStacks: {},
+		});
+
+		expect(result.focusedPaneIds["tab-a"]).toBe("pane-a");
+	});
+
+	it("removes stale pane references from layouts before resolving active tabs", () => {
+		const tabs: Tab[] = [
+			{
+				id: "tab-a",
+				name: "Terminal",
+				workspaceId: "ws-1",
+				layout: {
+					direction: "row",
+					first: "pane-missing",
+					second: "pane-a",
+				},
+				createdAt: 0,
+			},
+		];
+		const panes = {
+			"pane-a": terminalPane("pane-a", "tab-a"),
+		};
+
+		const result = sanitizePersistedTabState({
+			tabs,
+			panes,
+			activeTabIds: { "ws-1": "tab-a" },
+			focusedPaneIds: {},
+			tabHistoryStacks: { "ws-1": ["tab-missing", "tab-a"] },
+		});
+
+		expect(result.tabs).toHaveLength(1);
+		expect(result.tabs[0].layout).toBe("pane-a");
+		expect(result.activeTabIds["ws-1"]).toBe("tab-a");
+		expect(result.focusedPaneIds["tab-a"]).toBe("pane-a");
+		expect(result.tabHistoryStacks["ws-1"]).toEqual(["tab-a"]);
+	});
+
+	it("drops tabs whose layouts contain no valid panes", () => {
+		const tabs: Tab[] = [
+			{
+				id: "tab-stale",
+				name: "Stale",
+				workspaceId: "ws-1",
+				layout: "pane-missing",
+				createdAt: 0,
+			},
+			{
+				id: "tab-good",
+				name: "Good",
+				workspaceId: "ws-1",
+				layout: "pane-good",
+				createdAt: 0,
+			},
+		];
+		const panes = {
+			"pane-good": terminalPane("pane-good", "tab-good"),
+		};
+
+		const result = sanitizePersistedTabState({
+			tabs,
+			panes,
+			activeTabIds: { "ws-1": "tab-stale" },
+			focusedPaneIds: { "tab-stale": "pane-missing" },
+			tabHistoryStacks: { "ws-1": ["tab-good", "tab-stale"] },
+		});
+
+		expect(result.tabs.map((tab) => tab.id)).toEqual(["tab-good"]);
+		expect(result.activeTabIds["ws-1"]).toBe("tab-good");
+		expect(result.focusedPaneIds).toEqual({ "tab-good": "pane-good" });
+		expect(result.tabHistoryStacks["ws-1"]).toEqual(["tab-good"]);
 	});
 });
 

--- a/apps/desktop/src/renderer/stores/tabs/utils.test.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils.test.ts
@@ -307,7 +307,7 @@ describe("sanitizePersistedTabState", () => {
 		name: id,
 	});
 
-	it("falls focusedPaneIds back to the first valid pane in the tab layout", () => {
+	it("falls back focusedPaneIds to the first valid pane in the tab layout", () => {
 		const tabs: Tab[] = [
 			{
 				id: "tab-a",
@@ -360,6 +360,7 @@ describe("sanitizePersistedTabState", () => {
 
 		expect(result.tabs).toHaveLength(1);
 		expect(result.tabs[0].layout).toBe("pane-a");
+		expect(result.panes).toEqual({ "pane-a": panes["pane-a"] });
 		expect(result.activeTabIds["ws-1"]).toBe("tab-a");
 		expect(result.focusedPaneIds["tab-a"]).toBe("pane-a");
 		expect(result.tabHistoryStacks["ws-1"]).toEqual(["tab-a"]);
@@ -395,9 +396,62 @@ describe("sanitizePersistedTabState", () => {
 		});
 
 		expect(result.tabs.map((tab) => tab.id)).toEqual(["tab-good"]);
+		expect(result.panes).toEqual({ "pane-good": panes["pane-good"] });
 		expect(result.activeTabIds["ws-1"]).toBe("tab-good");
 		expect(result.focusedPaneIds).toEqual({ "tab-good": "pane-good" });
 		expect(result.tabHistoryStacks["ws-1"]).toEqual(["tab-good"]);
+	});
+
+	it("ignores focused panes that are not present in the sanitized layout", () => {
+		const tabs: Tab[] = [
+			{
+				id: "tab-a",
+				name: "Terminal",
+				workspaceId: "ws-1",
+				layout: "pane-a",
+				createdAt: 0,
+			},
+		];
+		const panes = {
+			"pane-a": terminalPane("pane-a", "tab-a"),
+			"pane-orphan": terminalPane("pane-orphan", "tab-a"),
+		};
+
+		const result = sanitizePersistedTabState({
+			tabs,
+			panes,
+			activeTabIds: { "ws-1": "tab-a" },
+			focusedPaneIds: { "tab-a": "pane-orphan" },
+			tabHistoryStacks: {},
+		});
+
+		expect(result.focusedPaneIds["tab-a"]).toBe("pane-a");
+		expect(result.panes).toEqual({ "pane-a": panes["pane-a"] });
+	});
+
+	it("clears tab history when all tabs for a workspace are dropped", () => {
+		const tabs: Tab[] = [
+			{
+				id: "tab-stale",
+				name: "Stale",
+				workspaceId: "ws-1",
+				layout: "pane-missing",
+				createdAt: 0,
+			},
+		];
+
+		const result = sanitizePersistedTabState({
+			tabs,
+			panes: {},
+			activeTabIds: { "ws-1": "tab-stale" },
+			focusedPaneIds: { "tab-stale": "pane-missing" },
+			tabHistoryStacks: { "ws-1": ["tab-stale"] },
+		});
+
+		expect(result.tabs).toEqual([]);
+		expect(result.activeTabIds["ws-1"]).toBeNull();
+		expect(result.focusedPaneIds).toEqual({});
+		expect(result.tabHistoryStacks["ws-1"]).toEqual([]);
 	});
 });
 

--- a/apps/desktop/src/renderer/stores/tabs/utils.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils.ts
@@ -533,6 +533,88 @@ export const cleanLayout = (
 	};
 };
 
+export const sanitizePersistedTabState = (
+	state: Pick<
+		TabsState,
+		"tabs" | "panes" | "activeTabIds" | "focusedPaneIds" | "tabHistoryStacks"
+	>,
+): Pick<
+	TabsState,
+	"tabs" | "activeTabIds" | "focusedPaneIds" | "tabHistoryStacks"
+> => {
+	const nextTabs: Tab[] = [];
+
+	for (const tab of state.tabs) {
+		const validPaneIds = new Set(
+			extractPaneIdsFromLayout(tab.layout).filter((paneId) => {
+				const pane = state.panes[paneId];
+				return pane && pane.tabId === tab.id;
+			}),
+		);
+		const layout = cleanLayout(tab.layout, validPaneIds);
+
+		if (!layout) {
+			continue;
+		}
+
+		nextTabs.push(layout === tab.layout ? tab : { ...tab, layout });
+	}
+
+	const nextActiveTabIds = { ...state.activeTabIds };
+	const nextHistoryStacks = { ...state.tabHistoryStacks };
+
+	const workspaceTabIdSets = new Map<string, Set<string>>();
+	const workspaceIds = new Set<string>([
+		...Object.keys(state.activeTabIds),
+		...Object.keys(state.tabHistoryStacks),
+	]);
+	for (const tab of nextTabs) {
+		workspaceIds.add(tab.workspaceId);
+		let setForWorkspace = workspaceTabIdSets.get(tab.workspaceId);
+		if (!setForWorkspace) {
+			setForWorkspace = new Set();
+			workspaceTabIdSets.set(tab.workspaceId, setForWorkspace);
+		}
+		setForWorkspace.add(tab.id);
+	}
+
+	for (const workspaceId of workspaceIds) {
+		nextActiveTabIds[workspaceId] = resolveActiveTabIdForWorkspace({
+			workspaceId,
+			tabs: nextTabs,
+			activeTabIds: state.activeTabIds,
+			tabHistoryStacks: state.tabHistoryStacks,
+		});
+
+		const workspaceTabIds = workspaceTabIdSets.get(workspaceId);
+		const history = nextHistoryStacks[workspaceId] ?? [];
+		if (workspaceTabIds && Array.isArray(history)) {
+			nextHistoryStacks[workspaceId] = history.filter((id) =>
+				workspaceTabIds.has(id),
+			);
+		}
+	}
+
+	const nextFocusedPaneIds: TabsState["focusedPaneIds"] = {};
+	for (const tab of nextTabs) {
+		const currentFocusedPaneId = state.focusedPaneIds[tab.id];
+		const currentFocusedPane = currentFocusedPaneId
+			? state.panes[currentFocusedPaneId]
+			: null;
+		nextFocusedPaneIds[tab.id] =
+			currentFocusedPane?.tabId === tab.id
+				? currentFocusedPaneId
+				: getFirstPaneId(tab.layout);
+	}
+
+	return {
+		tabs: nextTabs,
+		activeTabIds: nextActiveTabIds,
+		focusedPaneIds: nextFocusedPaneIds,
+		tabHistoryStacks: nextHistoryStacks,
+	};
+};
+
 /**
  * Gets the first pane ID from a layout (useful for focus fallback)
  */

--- a/apps/desktop/src/renderer/stores/tabs/utils.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils.ts
@@ -540,7 +540,7 @@ export const sanitizePersistedTabState = (
 	>,
 ): Pick<
 	TabsState,
-	"tabs" | "activeTabIds" | "focusedPaneIds" | "tabHistoryStacks"
+	"tabs" | "panes" | "activeTabIds" | "focusedPaneIds" | "tabHistoryStacks"
 > => {
 	const nextTabs: Tab[] = [];
 
@@ -558,6 +558,16 @@ export const sanitizePersistedTabState = (
 		}
 
 		nextTabs.push(layout === tab.layout ? tab : { ...tab, layout });
+	}
+
+	const nextPanes: TabsState["panes"] = {};
+	for (const tab of nextTabs) {
+		for (const paneId of extractPaneIdsFromLayout(tab.layout)) {
+			const pane = state.panes[paneId];
+			if (pane?.tabId === tab.id) {
+				nextPanes[paneId] = pane;
+			}
+		}
 	}
 
 	const nextActiveTabIds = { ...state.activeTabIds };
@@ -579,6 +589,7 @@ export const sanitizePersistedTabState = (
 	}
 
 	for (const workspaceId of workspaceIds) {
+		// Resolve against sanitized tabs while reusing original pointers as candidates.
 		nextActiveTabIds[workspaceId] = resolveActiveTabIdForWorkspace({
 			workspaceId,
 			tabs: nextTabs,
@@ -592,6 +603,8 @@ export const sanitizePersistedTabState = (
 			nextHistoryStacks[workspaceId] = history.filter((id) =>
 				workspaceTabIds.has(id),
 			);
+		} else {
+			nextHistoryStacks[workspaceId] = [];
 		}
 	}
 
@@ -599,16 +612,20 @@ export const sanitizePersistedTabState = (
 	for (const tab of nextTabs) {
 		const currentFocusedPaneId = state.focusedPaneIds[tab.id];
 		const currentFocusedPane = currentFocusedPaneId
-			? state.panes[currentFocusedPaneId]
+			? nextPanes[currentFocusedPaneId]
 			: null;
+		const sanitizedPaneIds = new Set(extractPaneIdsFromLayout(tab.layout));
 		nextFocusedPaneIds[tab.id] =
-			currentFocusedPane?.tabId === tab.id
+			currentFocusedPaneId &&
+			currentFocusedPane?.tabId === tab.id &&
+			sanitizedPaneIds.has(currentFocusedPaneId)
 				? currentFocusedPaneId
 				: getFirstPaneId(tab.layout);
 	}
 
 	return {
 		tabs: nextTabs,
+		panes: nextPanes,
 		activeTabIds: nextActiveTabIds,
 		focusedPaneIds: nextFocusedPaneIds,
 		tabHistoryStacks: nextHistoryStacks,


### PR DESCRIPTION
## Summary
- sanitize persisted tab layouts during startup merge so stale pane IDs are removed before rendering
- drop tabs whose layouts no longer reference valid panes
- restore active tab, focused pane, and tab history pointers to valid workspace-scoped values

## Why
A stale persisted tab layout can point at panes that are missing or no longer belong to the tab. When that state is restored, the workspace chrome can render while the central workspace content is blank until a full reload rebuilds state.

## Testing
- bun test apps/desktop/src/renderer/stores/tabs/utils.test.ts
- bun run --cwd apps/desktop typecheck
- git diff --check

Also manually verified the desktop dev app restores workspace content without needing Cmd+R after reopening workspaces.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes persisted tab state on startup to remove stale pane and tab pointers, preventing blank workspace content after reopening. Focus, active tab, and history are rebuilt per workspace with safe fallbacks.

- **Bug Fixes**
  - Use `sanitizePersistedTabState` during startup merge to clean layouts, drop tabs with no valid panes, and recompute `activeTabIds`.
  - Prune orphan panes and filter tab history by existing tabs; clear history and set `activeTabIds[ws]` to null when a workspace has no tabs.
  - Harden focus: ignore invalid focused panes and fall back to the first pane in each tab.

<sup>Written for commit fc7b7e7e274e362afd6c83fc679682070f399542. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust startup restoration: persisted tab/pane state is now sanitized so only valid tabs, panes, focused panes, active tabs, and tab history are restored.
  * Handles workspaces where all tabs were dropped by resetting active/focused state appropriately.

* **Tests**
  * Added comprehensive tests to verify persisted-state sanitization and correct recovery behavior across edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->