### PR TITLE
fix(desktop): drop red failed-host indicator from v2 ports dropdown

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/DashboardSidebarPortsList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/DashboardSidebarPortsList.tsx
@@ -1,5 +1,4 @@
-import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
-import { LuChevronRight, LuCircleAlert, LuRadioTower } from "react-icons/lu";
+import { LuChevronRight, LuRadioTower } from "react-icons/lu";
 import { STROKE_WIDTH } from "renderer/screens/main/components/WorkspaceSidebar/constants";
 import { usePortsStore } from "renderer/stores";
 import { DashboardSidebarPortGroup } from "./components/DashboardSidebarPortGroup";
@@ -8,11 +7,10 @@ import { useDashboardSidebarPortsData } from "./hooks/useDashboardSidebarPortsDa
 export function DashboardSidebarPortsList() {
 	const isCollapsed = usePortsStore((state) => state.isListCollapsed);
 	const toggleCollapsed = usePortsStore((state) => state.toggleListCollapsed);
-	const { totalPortCount, workspacePortGroups, portLoadErrors } =
+	const { totalPortCount, workspacePortGroups } =
 		useDashboardSidebarPortsData();
-	const failedHostCount = portLoadErrors.length;
 
-	if (totalPortCount === 0 && failedHostCount === 0) {
+	if (totalPortCount === 0) {
 		return null;
 	}
 
@@ -38,33 +36,7 @@ export function DashboardSidebarPortsList() {
 					Ports
 				</button>
 
-				{failedHostCount > 0 && (
-					<Tooltip delayDuration={200}>
-						<TooltipTrigger asChild>
-							<span
-								className="ml-auto rounded p-0.5 text-destructive/80"
-								role="img"
-								aria-label={`Could not load ports from ${failedHostCount} host${failedHostCount === 1 ? "" : "s"}`}
-							>
-								<LuCircleAlert className="size-3" strokeWidth={STROKE_WIDTH} />
-							</span>
-						</TooltipTrigger>
-						<TooltipContent side="top" sideOffset={4}>
-							<p className="text-xs">
-								{failedHostCount === 1
-									? "Could not load ports from 1 host"
-									: `Could not load ports from ${failedHostCount} hosts`}
-							</p>
-						</TooltipContent>
-					</Tooltip>
-				)}
-				<span
-					className={
-						failedHostCount > 0
-							? "text-[10px] font-normal"
-							: "ml-auto text-[10px] font-normal"
-					}
-				>
+				<span className="ml-auto text-[10px] font-normal">
 					{totalPortCount}
 				</span>
 			</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/DashboardSidebarPortsList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/DashboardSidebarPortsList.tsx
@@ -1,8 +1,12 @@
-import { LuChevronRight, LuRadioTower } from "react-icons/lu";
+import { COMPANY } from "@superset/shared/constants";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { LuChevronRight, LuCircleHelp, LuRadioTower } from "react-icons/lu";
 import { STROKE_WIDTH } from "renderer/screens/main/components/WorkspaceSidebar/constants";
 import { usePortsStore } from "renderer/stores";
 import { DashboardSidebarPortGroup } from "./components/DashboardSidebarPortGroup";
 import { useDashboardSidebarPortsData } from "./hooks/useDashboardSidebarPortsData";
+
+const PORTS_DOCS_URL = `${COMPANY.DOCS_URL}/ports`;
 
 export function DashboardSidebarPortsList() {
 	const isCollapsed = usePortsStore((state) => state.isListCollapsed);
@@ -13,6 +17,11 @@ export function DashboardSidebarPortsList() {
 	if (totalPortCount === 0) {
 		return null;
 	}
+
+	const handleOpenPortsDocs = (e: React.MouseEvent) => {
+		e.stopPropagation();
+		window.open(PORTS_DOCS_URL, "_blank");
+	};
 
 	return (
 		<div className="border-t border-border pt-3">
@@ -36,9 +45,21 @@ export function DashboardSidebarPortsList() {
 					Ports
 				</button>
 
-				<span className="ml-auto text-[10px] font-normal">
-					{totalPortCount}
-				</span>
+				<Tooltip delayDuration={300}>
+					<TooltipTrigger asChild>
+						<button
+							type="button"
+							onClick={handleOpenPortsDocs}
+							className="ml-auto rounded p-0.5 opacity-0 transition-opacity hover:bg-muted/50 group-hover:opacity-100"
+						>
+							<LuCircleHelp className="size-3" strokeWidth={STROKE_WIDTH} />
+						</button>
+					</TooltipTrigger>
+					<TooltipContent side="top" sideOffset={4}>
+						<p className="text-xs">Learn about port labels</p>
+					</TooltipContent>
+				</Tooltip>
+				<span className="text-[10px] font-normal">{totalPortCount}</span>
 			</div>
 			{!isCollapsed && (
 				<div className="max-h-72 space-y-2 overflow-y-auto pb-1 hide-scrollbar">


### PR DESCRIPTION
## Summary
- Removes the red `LuCircleAlert` indicator (and its tooltip) from the v2 dashboard sidebar Ports header
- Cleans up now-unused imports and the `failedHostCount`/`portLoadErrors` branching in `DashboardSidebarPortsList`
- Simplifies the port-count badge to always sit on the right

## Test plan
- [ ] Open a v2 workspace dashboard with at least one unreachable host and confirm no red indicator appears next to "Ports"
- [ ] Confirm the port total still renders right-aligned when ports load successfully
- [ ] `bun run typecheck` and `bun run lint` pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the red failed-host `LuCircleAlert` indicator and its tooltip from the v2 dashboard sidebar Ports header. Added a subtle `LuCircleHelp` button with a tooltip that opens the Ports docs in a new tab, kept the port total right-aligned, and removed unused error-handling code and imports.

<sup>Written for commit 207ccce6464784bb5c567a327ef7302eb0705a84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed error alerts and failure-host tooltips from the ports list, streamlining the sidebar UI.

* **New Features / UX**
  * Replaced the error indicator near the port count with a help icon tooltip that opens the ports documentation in a new tab.
  * Port-count display now uses consistent styling; the ports list only renders when there is at least one port.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->