### PR TITLE
fix(desktop): prevent automations empty-state flicker on load

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/page.tsx
@@ -105,14 +105,15 @@ function AutomationsPage() {
 			),
 	});
 
-	const { data: automationRows = [] } = useLiveQuery(
-		(q) =>
-			q
-				.from({ a: collections.automations })
-				.orderBy(({ a }) => a.createdAt, "desc")
-				.select(({ a }) => ({ ...a })),
-		[collections.automations],
-	);
+	const { data: automationRows = [], isLoading: automationsLoading } =
+		useLiveQuery(
+			(q) =>
+				q
+					.from({ a: collections.automations })
+					.orderBy(({ a }) => a.createdAt, "desc")
+					.select(({ a }) => ({ ...a })),
+			[collections.automations],
+		);
 	const automations = automationRows as SelectAutomation[];
 
 	const { data: userRows = [] } = useLiveQuery(
@@ -228,7 +229,7 @@ function AutomationsPage() {
 			</header>
 
 			<div className="flex-1 overflow-y-auto px-8 py-6">
-				{automations.length === 0 ? (
+				{automationsLoading ? null : automations.length === 0 ? (
 					<AutomationsEmptyState onSelectTemplate={handleSelectTemplate} />
 				) : (
 					<>


### PR DESCRIPTION
## Summary
- The automations page rendered `AutomationsEmptyState` whenever `automations.length === 0`, including the brief window before the live query had results — causing the empty state to flash before the table populated.
- Now reads `isLoading` from `useLiveQuery` and renders nothing in the body while loading; the header (title + "New automation") still renders immediately.

## Test plan
- [ ] Open the Automations tab on an account with existing automations — table should appear without the empty state flashing first.
- [ ] Open it on an account with no automations — empty state still renders once the query settles.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the Automations page empty-state from flashing by hiding the body until `useLiveQuery` finishes loading. The header renders immediately; the empty state only appears after load when there are no automations.

<sup>Written for commit cea0ae13e317c3bcab7e5c6d80d03e4ec941f942. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Automations page loading behavior by displaying a loading indicator while fetching data, instead of prematurely showing an empty state. This provides clearer feedback to users during the data retrieval process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->