### PR TITLE
fix(relay): unbreak fly deploy

### DIFF
--- a/apps/relay/Dockerfile
+++ b/apps/relay/Dockerfile
@@ -4,12 +4,11 @@ WORKDIR /app
 # Stage 1: Prune monorepo to relay's dependency graph
 FROM base AS prune
 COPY . .
-RUN bunx turbo prune @superset/relay --docker
+RUN bunx turbo@2.8.7 prune @superset/relay --docker
 
 # Stage 2: Install deps + copy full source
 FROM base AS builder
 COPY --from=prune /app/out/json/ ./
-COPY patches patches
 RUN bun install --frozen-lockfile --ignore-scripts
 COPY --from=prune /app/out/full/ ./
 

--- a/apps/relay/fly.toml
+++ b/apps/relay/fly.toml
@@ -28,6 +28,6 @@ primary_region = "sjc"
   path = "/health"
 
 [[vm]]
-  memory = "2gb"
+  memory = "4gb"
   cpu_kind = "performance"
   cpus = 2


### PR DESCRIPTION
## Summary

Three independent breakages that all surfaced when redeploying the relay tonight to ship the org-scoped routing-key fix from #3784. Already validated end-to-end — the relay is live at v4 in `sjc` running off this exact image+config (built with these fixes applied locally).

- **Pin `bunx turbo@2.8.7` in the prune stage.** Previously unpinned, so the Docker build fetched whatever was latest on npm (2.9.6). That version generates a pruned `bun.lock` that's inconsistent with its own pruned `package.json`s, so the next stage's `bun install --frozen-lockfile` fails with "lockfile had changes". Reproduced both with bun 1.3.11 and 1.3.12 inside the image — it's a turbo-prune bug, not a bun version issue. Pinning to the project's installed turbo version eliminates the drift.
- **Drop dead `COPY patches patches`.** The directory hasn't existed since #3509 dropped the durable-streams patch. Any redeploy from a clean Docker cache failed at this `COPY`.
- **Bump VM memory 2GB → 4GB.** Fly now requires ≥4096 MiB for `cpu_kind = "performance"`. The existing machine was grandfathered but `fly deploy` rejects new configs that violate this. Keeping perf CPUs since the relay proxies WS tunnels and shared-CPU noise would hurt latency.

## Test plan

- [x] `fly deploy` against `superset-relay` builds and rolls out cleanly with these changes
- [x] Machine reaches `started` state, `/health` returns 200
- [ ] Reviewer can sanity-check the turbo pin matches `package.json` (`"turbo": "2.8.7"`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the relay Fly deploy by pinning the prune tool and updating VM settings. Prevents lockfile drift and meets Fly’s performance CPU memory requirement.

- **Bug Fixes**
  - Pin `turbo` to `2.8.7` during Docker prune to stop pruned lockfile drift that broke `bun install --frozen-lockfile`.
  - Remove stale `COPY patches` line; the directory no longer exists.
  - Bump Fly VM memory from 2GB to 4GB to satisfy `cpu_kind = "performance"`.

<sup>Written for commit c057555491e77909e713604e90569da61ec91adc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration with pinned CLI version for improved build consistency.
  * Increased relay service memory allocation from 2GB to 4GB to enhance performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->