### PR TITLE
feat(desktop): rename branch from workspace hover card

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -1,6 +1,9 @@
 import { useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
 import { useDiffStats } from "renderer/hooks/host-service/useDiffStats";
+import { useOptimisticCollectionActions } from "renderer/routes/_authenticated/hooks/useOptimisticCollectionActions";
 import { useDeletingWorkspaces } from "renderer/routes/_authenticated/providers/DeletingWorkspacesProvider";
+import { RenameBranchDialog } from "renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components";
 import { useV2WorkspaceNotificationStatus } from "renderer/stores/v2-notifications";
 import type { DashboardSidebarWorkspace } from "../../types";
 import { DashboardSidebarDeleteDialog } from "../DashboardSidebarDeleteDialog";
@@ -67,6 +70,13 @@ export function DashboardSidebarWorkspaceItem({
 	});
 
 	const navigate = useNavigate();
+	const { v2Workspaces: v2WorkspaceActions } = useOptimisticCollectionActions();
+	const [renameBranchTarget, setRenameBranchTarget] = useState<string | null>(
+		null,
+	);
+	const handleAfterBranchRename = (newBranchName: string) => {
+		v2WorkspaceActions.updateWorkspace(id, { branch: newBranchName });
+	};
 	const isPending = !!creationStatus;
 	// Keep the delete dialog outside the hidden wrapper below — the destroy
 	// flow reopens it into an error pane on conflict/teardown-failed.
@@ -122,6 +132,7 @@ export function DashboardSidebarWorkspaceItem({
 								<DashboardSidebarWorkspaceHoverCardContent
 									workspace={workspace}
 									diffStats={diffStats}
+									onEditBranchClick={setRenameBranchTarget}
 								/>
 							}
 							isLocalWorkspace={hostType === "local-device"}
@@ -151,6 +162,17 @@ export function DashboardSidebarWorkspaceItem({
 						open={isDeleteDialogOpen}
 						onOpenChange={setIsDeleteDialogOpen}
 						onDeleted={handleDeleted}
+					/>
+				)}
+				{renameBranchTarget && (
+					<RenameBranchDialog
+						workspaceId={id}
+						currentBranchName={renameBranchTarget}
+						open={renameBranchTarget !== null}
+						onOpenChange={(open) => {
+							if (!open) setRenameBranchTarget(null);
+						}}
+						onAfterRename={handleAfterBranchRename}
 					/>
 				)}
 			</>
@@ -196,6 +218,7 @@ export function DashboardSidebarWorkspaceItem({
 							<DashboardSidebarWorkspaceHoverCardContent
 								workspace={workspace}
 								diffStats={diffStats}
+								onEditBranchClick={setRenameBranchTarget}
 							/>
 						}
 						onCreateSection={handleCreateSection}
@@ -225,6 +248,17 @@ export function DashboardSidebarWorkspaceItem({
 					open={isDeleteDialogOpen}
 					onOpenChange={setIsDeleteDialogOpen}
 					onDeleted={handleDeleted}
+				/>
+			)}
+			{renameBranchTarget && (
+				<RenameBranchDialog
+					workspaceId={id}
+					currentBranchName={renameBranchTarget}
+					open={renameBranchTarget !== null}
+					onOpenChange={(open) => {
+						if (!open) setRenameBranchTarget(null);
+					}}
+					onAfterRename={handleAfterBranchRename}
 				/>
 			)}
 		</>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceHoverCardContent/DashboardSidebarWorkspaceHoverCardContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceHoverCardContent/DashboardSidebarWorkspaceHoverCardContent.tsx
@@ -2,7 +2,12 @@ import { Button } from "@superset/ui/button";
 import { Kbd, KbdGroup } from "@superset/ui/kbd";
 import { formatDistanceToNow } from "date-fns";
 import { FaGithub } from "react-icons/fa";
-import { LuExternalLink, LuGlobe, LuTriangleAlert } from "react-icons/lu";
+import {
+	LuExternalLink,
+	LuGlobe,
+	LuPencil,
+	LuTriangleAlert,
+} from "react-icons/lu";
 import type { DiffStats } from "renderer/hooks/host-service/useDiffStats";
 import { useHotkeyDisplay } from "renderer/hotkeys";
 import type { DashboardSidebarWorkspace } from "../../../../types";
@@ -14,11 +19,13 @@ import { ReviewStatus } from "./components/ReviewStatus";
 interface DashboardSidebarWorkspaceHoverCardContentProps {
 	workspace: DashboardSidebarWorkspace;
 	diffStats: DiffStats | null;
+	onEditBranchClick?: (branchName: string) => void;
 }
 
 export function DashboardSidebarWorkspaceHoverCardContent({
 	workspace,
 	diffStats,
+	onEditBranchClick,
 }: DashboardSidebarWorkspaceHoverCardContentProps) {
 	const {
 		name,
@@ -59,23 +66,37 @@ export function DashboardSidebarWorkspaceHoverCardContent({
 					<span className="text-[10px] uppercase tracking-wide text-muted-foreground">
 						Branch
 					</span>
-					{repoUrl && branchExistsOnRemote ? (
-						<a
-							href={`${repoUrl}/tree/${branch}`}
-							target="_blank"
-							rel="noopener noreferrer"
-							className={`flex items-center gap-1 font-mono break-all hover:underline ${hasCustomAlias ? "text-xs" : "text-sm"}`}
-						>
-							{branch}
-							<LuExternalLink className="size-3 shrink-0" />
-						</a>
-					) : (
-						<code
-							className={`font-mono break-all block ${hasCustomAlias ? "text-xs" : "text-sm"}`}
-						>
-							{branch}
-						</code>
-					)}
+					<div className="flex items-center gap-1.5">
+						{onEditBranchClick ? (
+							<button
+								type="button"
+								onClick={() => onEditBranchClick(branch)}
+								className={`group/branch flex min-w-0 flex-1 items-center gap-1 font-mono break-all text-left hover:text-foreground hover:underline ${hasCustomAlias ? "text-xs" : "text-sm"}`}
+								title="Rename branch"
+							>
+								<span className="break-all">{branch}</span>
+								<LuPencil className="size-3 shrink-0 opacity-0 group-hover/branch:opacity-100 transition-opacity" />
+							</button>
+						) : (
+							<code
+								className={`font-mono break-all block min-w-0 flex-1 ${hasCustomAlias ? "text-xs" : "text-sm"}`}
+							>
+								{branch}
+							</code>
+						)}
+						{repoUrl && branchExistsOnRemote && (
+							<a
+								href={`${repoUrl}/tree/${branch}`}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="shrink-0 text-muted-foreground hover:text-foreground"
+								title="Open branch on GitHub"
+								onClick={(e) => e.stopPropagation()}
+							>
+								<LuExternalLink className="size-3" />
+							</a>
+						)}
+					</div>
 				</div>
 				<span className="text-xs text-muted-foreground block">
 					{formatDistanceToNow(createdAt, { addSuffix: true })}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/CollapsedWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/CollapsedWorkspaceItem.tsx
@@ -17,7 +17,11 @@ import { LuCopy, LuGitBranch, LuX } from "react-icons/lu";
 import { createContextMenuDeleteDialogCoordinator } from "renderer/react-query/workspaces/useWorkspaceDeleteHandler";
 import type { ActivePaneStatus } from "shared/tabs-types";
 import { STROKE_WIDTH } from "../constants";
-import { DeleteWorkspaceDialog, WorkspaceHoverCardContent } from "./components";
+import {
+	DeleteWorkspaceDialog,
+	RenameBranchDialog,
+	WorkspaceHoverCardContent,
+} from "./components";
 import { HOVER_CARD_CLOSE_DELAY, HOVER_CARD_OPEN_DELAY } from "./constants";
 import { WorkspaceIcon } from "./WorkspaceIcon";
 
@@ -62,6 +66,9 @@ export function CollapsedWorkspaceItem({
 		[onDeleteClick],
 	);
 	const [isContextMenuOpen, setIsContextMenuOpen] = useState(false);
+	const [renameBranchTarget, setRenameBranchTarget] = useState<string | null>(
+		null,
+	);
 
 	const collapsedButton = (
 		<button
@@ -160,7 +167,11 @@ export function CollapsedWorkspaceItem({
 					</ContextMenuContent>
 				</ContextMenu>
 				<HoverCardContent side="right" align="start" className="w-72">
-					<WorkspaceHoverCardContent workspaceId={id} workspaceAlias={name} />
+					<WorkspaceHoverCardContent
+						workspaceId={id}
+						workspaceAlias={name}
+						onEditBranchClick={setRenameBranchTarget}
+					/>
 				</HoverCardContent>
 			</HoverCard>
 			<DeleteWorkspaceDialog
@@ -170,6 +181,16 @@ export function CollapsedWorkspaceItem({
 				open={showDeleteDialog}
 				onOpenChange={setShowDeleteDialog}
 			/>
+			{renameBranchTarget && (
+				<RenameBranchDialog
+					workspaceId={id}
+					currentBranchName={renameBranchTarget}
+					open={renameBranchTarget !== null}
+					onOpenChange={(open) => {
+						if (!open) setRenameBranchTarget(null);
+					}}
+				/>
+			)}
 		</>
 	);
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceContextMenu.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceContextMenu.tsx
@@ -36,7 +36,7 @@ import {
 import { createContextMenuDeleteDialogCoordinator } from "renderer/react-query/workspaces/useWorkspaceDeleteHandler";
 import { useWorkspaceSelectionStore } from "renderer/stores/workspace-selection";
 import { STROKE_WIDTH } from "../constants";
-import { WorkspaceHoverCardContent } from "./components";
+import { RenameBranchDialog, WorkspaceHoverCardContent } from "./components";
 import { HOVER_CARD_CLOSE_DELAY, HOVER_CARD_OPEN_DELAY } from "./constants";
 
 interface WorkspaceContextMenuProps {
@@ -77,6 +77,9 @@ export function WorkspaceContextMenu({
 	children,
 }: WorkspaceContextMenuProps) {
 	const [isContextMenuOpen, setIsContextMenuOpen] = useState(false);
+	const [renameBranchTarget, setRenameBranchTarget] = useState<string | null>(
+		null,
+	);
 	const contextMenuSelectionRef = useRef<string[]>([]);
 	const selectionStore = useWorkspaceSelectionStore;
 	const moveToSection = useMoveWorkspaceToSection();
@@ -246,8 +249,22 @@ export function WorkspaceContextMenu({
 				</ContextMenuContent>
 			</ContextMenu>
 			<HoverCardContent side="right" align="start" className="w-72">
-				<WorkspaceHoverCardContent workspaceId={id} workspaceAlias={name} />
+				<WorkspaceHoverCardContent
+					workspaceId={id}
+					workspaceAlias={name}
+					onEditBranchClick={setRenameBranchTarget}
+				/>
 			</HoverCardContent>
+			{renameBranchTarget && (
+				<RenameBranchDialog
+					workspaceId={id}
+					currentBranchName={renameBranchTarget}
+					open={renameBranchTarget !== null}
+					onOpenChange={(open) => {
+						if (!open) setRenameBranchTarget(null);
+					}}
+				/>
+			)}
 		</HoverCard>
 	);
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/RenameBranchDialog/RenameBranchDialog.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/RenameBranchDialog/RenameBranchDialog.tsx
@@ -1,0 +1,140 @@
+import { Button } from "@superset/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@superset/ui/dialog";
+import { Input } from "@superset/ui/input";
+import { Label } from "@superset/ui/label";
+import { toast } from "@superset/ui/sonner";
+import { useEffect, useState } from "react";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+
+interface RenameBranchDialogProps {
+	workspaceId: string;
+	currentBranchName: string;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	onAfterRename?: (newName: string) => void;
+}
+
+export function RenameBranchDialog({
+	workspaceId,
+	currentBranchName,
+	open,
+	onOpenChange,
+	onAfterRename,
+}: RenameBranchDialogProps) {
+	const [value, setValue] = useState(currentBranchName);
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const electronUtils = electronTrpc.useUtils();
+	const { activeHostUrl } = useLocalHostService();
+
+	useEffect(() => {
+		if (open) setValue(currentBranchName);
+	}, [open, currentBranchName]);
+
+	const trimmed = value.trim();
+	const isUnchanged = trimmed === currentBranchName;
+	const isInvalid = trimmed.length === 0 || isUnchanged;
+
+	const handleSubmit = async () => {
+		if (isInvalid || isSubmitting) return;
+		if (!activeHostUrl) {
+			toast.error("Host service is not available");
+			return;
+		}
+
+		const client = getHostServiceClientByUrl(activeHostUrl);
+		const renamePromise = client.git.renameBranch.mutate({
+			workspaceId,
+			oldName: currentBranchName,
+			newName: trimmed,
+		});
+
+		toast.promise(renamePromise, {
+			loading: `Renaming branch to ${trimmed}...`,
+			success: `Branch renamed to ${trimmed}`,
+			error: (err) =>
+				err instanceof Error ? err.message : "Failed to rename branch",
+		});
+
+		setIsSubmitting(true);
+		try {
+			await renamePromise;
+			onAfterRename?.(trimmed);
+			void electronUtils.workspaces.getWorktreeInfo.invalidate({
+				workspaceId,
+			});
+			void electronUtils.workspaces.get.invalidate({ id: workspaceId });
+			void electronUtils.workspaces.getAllGrouped.invalidate();
+			onOpenChange(false);
+		} catch {
+			// toast.promise surfaced the error to the user
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange} modal>
+			<DialogContent className="max-w-[420px]">
+				<DialogHeader>
+					<DialogTitle>Rename branch</DialogTitle>
+					<DialogDescription>
+						Rename the local branch. Branches that have been pushed to remote
+						cannot be renamed.
+					</DialogDescription>
+				</DialogHeader>
+				<form
+					onSubmit={(e) => {
+						e.preventDefault();
+						void handleSubmit();
+					}}
+					className="space-y-4"
+				>
+					<div className="space-y-1.5">
+						<Label htmlFor="rename-branch-input" className="text-xs">
+							Branch name
+						</Label>
+						<Input
+							id="rename-branch-input"
+							value={value}
+							onChange={(e) => setValue(e.target.value)}
+							onKeyDown={(e) => {
+								if (e.key === "Enter") {
+									e.preventDefault();
+									e.stopPropagation();
+									void handleSubmit();
+								}
+							}}
+							autoFocus
+							disabled={isSubmitting}
+							spellCheck={false}
+							autoComplete="off"
+							className="font-mono"
+						/>
+					</div>
+					<DialogFooter>
+						<Button
+							type="button"
+							variant="ghost"
+							onClick={() => onOpenChange(false)}
+							disabled={isSubmitting}
+						>
+							Cancel
+						</Button>
+						<Button type="submit" disabled={isInvalid || isSubmitting}>
+							Rename
+						</Button>
+					</DialogFooter>
+				</form>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/RenameBranchDialog/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/RenameBranchDialog/index.ts
@@ -1,0 +1,1 @@
+export { RenameBranchDialog } from "./RenameBranchDialog";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/WorkspaceHoverCard.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/WorkspaceHoverCard.tsx
@@ -6,6 +6,7 @@ import {
 	LuExternalLink,
 	LuGlobe,
 	LuLoaderCircle,
+	LuPencil,
 	LuTriangleAlert,
 } from "react-icons/lu";
 import { useHotkeyDisplay } from "renderer/hotkeys";
@@ -20,11 +21,13 @@ import { ReviewStatus } from "./components/ReviewStatus";
 interface WorkspaceHoverCardContentProps {
 	workspaceId: string;
 	workspaceAlias?: string;
+	onEditBranchClick?: (branchName: string) => void;
 }
 
 export function WorkspaceHoverCardContent({
 	workspaceId,
 	workspaceAlias,
+	onEditBranchClick,
 }: WorkspaceHoverCardContentProps) {
 	const { data: worktreeInfo } =
 		electronTrpc.workspaces.getWorktreeInfo.useQuery(
@@ -80,26 +83,43 @@ export function WorkspaceHoverCardContent({
 						<span className="text-[10px] uppercase tracking-wide text-muted-foreground">
 							Branch
 						</span>
-						{repoUrl && branchExistsOnRemote ? (
-							<a
-								href={`${repoUrl}/tree/${branchName}`}
-								target="_blank"
-								rel="noopener noreferrer"
-								className={`flex items-center gap-1 font-mono break-all hover:underline ${hasCustomAlias ? "text-xs" : "text-sm"}`}
-							>
-								{branchName}
-								<LuExternalLink
-									className="size-3 shrink-0"
-									strokeWidth={STROKE_WIDTH}
-								/>
-							</a>
-						) : (
-							<code
-								className={`font-mono break-all block ${hasCustomAlias ? "text-xs" : "text-sm"}`}
-							>
-								{branchName}
-							</code>
-						)}
+						<div className="flex items-center gap-1.5">
+							{onEditBranchClick ? (
+								<button
+									type="button"
+									onClick={() => onEditBranchClick(branchName)}
+									className={`group/branch flex min-w-0 flex-1 items-center gap-1 font-mono break-all text-left hover:text-foreground hover:underline ${hasCustomAlias ? "text-xs" : "text-sm"}`}
+									title="Rename branch"
+								>
+									<span className="break-all">{branchName}</span>
+									<LuPencil
+										className="size-3 shrink-0 opacity-0 group-hover/branch:opacity-100 transition-opacity"
+										strokeWidth={STROKE_WIDTH}
+									/>
+								</button>
+							) : (
+								<code
+									className={`font-mono break-all block min-w-0 flex-1 ${hasCustomAlias ? "text-xs" : "text-sm"}`}
+								>
+									{branchName}
+								</code>
+							)}
+							{repoUrl && branchExistsOnRemote && (
+								<a
+									href={`${repoUrl}/tree/${branchName}`}
+									target="_blank"
+									rel="noopener noreferrer"
+									className="shrink-0 text-muted-foreground hover:text-foreground"
+									title="Open branch on GitHub"
+									onClick={(e) => e.stopPropagation()}
+								>
+									<LuExternalLink
+										className="size-3"
+										strokeWidth={STROKE_WIDTH}
+									/>
+								</a>
+							)}
+						</div>
 					</div>
 				)}
 				{worktreeInfo?.createdAt && (

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/index.ts
@@ -1,2 +1,3 @@
 export { DeleteWorkspaceDialog } from "./DeleteWorkspaceDialog";
+export { RenameBranchDialog } from "./RenameBranchDialog";
 export { WorkspaceHoverCardContent } from "./WorkspaceHoverCard";


### PR DESCRIPTION
## Summary
- Click a workspace's branch name in the hover card to open a rename modal; submit (or Enter) renames the local git branch via the host service.
- GitHub external-link is split into its own icon so the branch text itself is always the rename trigger.
- In the v2 dashboard sidebar, the rename also writes the new branch through the \`v2Workspaces\` optimistic action so the hover card reflects the new name immediately.

## Test plan
- [ ] Hover a worktree in the v2 dashboard sidebar, click the branch name, rename, verify hover card shows the new name without refresh.
- [ ] Press Enter in the rename input and confirm it submits.
- [ ] Click the GitHub external-link icon and confirm it still opens the branch on GitHub.
- [ ] Try renaming a branch that has been pushed to remote and confirm the host-service error is surfaced via toast.
- [ ] Repeat in the v1 workspace sidebar (collapsed and expanded list items) to confirm the dialog opens from both the hover card and the right-click hover surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable branch renaming directly from the workspace hover card. Clicking the branch name opens a modal to rename the local git branch, with GitHub open moved to a separate external-link icon.

- **New Features**
  - Rename from the hover card in both v1 and v2 sidebars; Enter submits.
  - Renames the local branch via the host service; errors (e.g., pushed branches) show via toast.
  - GitHub open is now a separate icon; branch text always triggers rename.
  - V2 dashboard updates branch name optimistically via `v2Workspaces`, then invalidates queries on success.

<sup>Written for commit fff69c01d5b47db9c83af53a171438641f2ff392. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added branch renaming functionality directly from workspace sidebar hover cards and context menus
  * Users can edit branch names with input validation and automatic trimming
  * Rename operations display loading and success/error notifications
  * Successfully renamed branches update immediately across the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->