### PR TITLE
fix: allow disabling WebGL terminal renderer to prevent garbled text

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
@@ -14,12 +14,12 @@ export interface LoadAddonsResult {
 }
 
 // Once WebGL fails, skip it for all subsequent runtimes (VS Code pattern).
-// Users can also set localStorage "terminal-renderer-type" to "dom" to
-// permanently disable WebGL (workaround for GPU texture atlas corruption).
+// Users can set localStorage "terminal-renderer-type" to "dom" to permanently
+// disable WebGL (workaround for GPU texture atlas corruption). Only "dom" is
+// meaningful — any other value (including "webgl") behaves like the default.
 let suggestedRendererType: "webgl" | "dom" | undefined = (() => {
 	try {
-		const pref = localStorage.getItem("terminal-renderer-type");
-		if (pref === "dom" || pref === "webgl") return pref;
+		if (localStorage.getItem("terminal-renderer-type") === "dom") return "dom";
 	} catch {}
 	return undefined;
 })();

--- a/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
@@ -14,7 +14,15 @@ export interface LoadAddonsResult {
 }
 
 // Once WebGL fails, skip it for all subsequent runtimes (VS Code pattern).
-let suggestedRendererType: "webgl" | "dom" | undefined;
+// Users can also set localStorage "terminal-renderer-type" to "dom" to
+// permanently disable WebGL (workaround for GPU texture atlas corruption).
+let suggestedRendererType: "webgl" | "dom" | undefined = (() => {
+	try {
+		const pref = localStorage.getItem("terminal-renderer-type");
+		if (pref === "dom" || pref === "webgl") return pref;
+	} catch {}
+	return undefined;
+})();
 
 /**
  * Load optional addons onto an already-opened terminal. Returns a cleanup

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -62,12 +62,12 @@ export function getDefaultTerminalBg(): string {
  * This follows VS Code's approach: WebGL → DOM (canvas addon removed in xterm.js 6.0).
  */
 // Once WebGL fails, skip it for all subsequent terminals (VS Code pattern).
-// Users can also set localStorage "terminal-renderer-type" to "dom" to
-// permanently disable WebGL (workaround for GPU texture atlas corruption).
+// Users can set localStorage "terminal-renderer-type" to "dom" to permanently
+// disable WebGL (workaround for GPU texture atlas corruption). Only "dom" is
+// meaningful — any other value (including "webgl") behaves like the default.
 let suggestedRendererType: "webgl" | "dom" | undefined = (() => {
 	try {
-		const pref = localStorage.getItem("terminal-renderer-type");
-		if (pref === "dom" || pref === "webgl") return pref;
+		if (localStorage.getItem("terminal-renderer-type") === "dom") return "dom";
 	} catch {}
 	return undefined;
 })();

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -62,7 +62,15 @@ export function getDefaultTerminalBg(): string {
  * This follows VS Code's approach: WebGL → DOM (canvas addon removed in xterm.js 6.0).
  */
 // Once WebGL fails, skip it for all subsequent terminals (VS Code pattern).
-let suggestedRendererType: "webgl" | "dom" | undefined;
+// Users can also set localStorage "terminal-renderer-type" to "dom" to
+// permanently disable WebGL (workaround for GPU texture atlas corruption).
+let suggestedRendererType: "webgl" | "dom" | undefined = (() => {
+	try {
+		const pref = localStorage.getItem("terminal-renderer-type");
+		if (pref === "dom" || pref === "webgl") return pref;
+	} catch {}
+	return undefined;
+})();
 
 export interface CreateTerminalOptions {
 	/**


### PR DESCRIPTION
## Summary

- Adds a `localStorage`-based preference (`terminal-renderer-type`) to let users choose between WebGL and DOM rendering for the terminal
- Fixes both v1 (`helpers.ts`) and v2 (`terminal-addons.ts`) terminal initialization paths
- Users experiencing garbled characters can now run `localStorage.setItem("terminal-renderer-type", "dom")` in DevTools instead of launching the entire app with `--disable-gpu`

## Problem

The xterm.js WebGL addon's glyph texture atlas can silently become corrupted on some machines/GPUs, causing characters to render as wrong glyphs. The existing `onContextLoss` fallback only fires on **complete** context loss — partial texture corruption is not detected, so the DOM fallback never triggers.

The only current workaround is `--disable-gpu`, which disables all GPU acceleration (window compositing, CSS animations, etc.), which is too broad.

## Solution

Read a `localStorage` preference before initializing `suggestedRendererType`. If `terminal-renderer-type` is set to `"dom"`, WebGL loading is skipped entirely. The default behavior (`undefined` → try WebGL first) is unchanged for users not affected.

This is a minimal, non-breaking change. A settings UI toggle can be added in a follow-up.

## How to use

In DevTools console:
```javascript
// Disable WebGL rendering
localStorage.setItem("terminal-renderer-type", "dom");
// Re-enable WebGL rendering
localStorage.removeItem("terminal-renderer-type");
```
Then restart the app (or open a new terminal tab).

## Test plan

- [ ] Verify default behavior unchanged: new installs still use WebGL
- [ ] Set `localStorage.setItem("terminal-renderer-type", "dom")` → restart → confirm no garbled text
- [ ] Set `localStorage.setItem("terminal-renderer-type", "webgl")` → restart → confirm WebGL is used
- [ ] Remove the key → restart → confirm fallback to auto behavior

Fixes #3794

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `localStorage` preference to disable the terminal’s WebGL renderer so users with garbled text can force the DOM renderer without `--disable-gpu`. Default behavior stays the same for everyone else.

- **Bug Fixes**
  - Read `localStorage` key `terminal-renderer-type` and honor `"dom"` to skip WebGL; any other value (including `"webgl"`) is ignored.
  - Apply the check in both init paths (`helpers.ts` and `terminal-addons.ts`).
  - Workaround for `xterm.js` WebGL glyph atlas corruption by using DOM when `"dom"` is set.

<sup>Written for commit b4b59d5e13672a8ea4053fc65034ce6356646f11. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3795?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal renderer preference (DOM or WebGL) is now applied at startup by reading the local preference.
  * Previously selected renderer type persists across sessions and is applied automatically.
  * The app still falls back to the alternative renderer if compatibility or runtime errors occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->