### PR TITLE
fix(desktop): forward macOS XPC bootstrap env vars to v2 terminal shells

### DIFF
--- a/packages/host-service/src/terminal/clean-shell-env.ts
+++ b/packages/host-service/src/terminal/clean-shell-env.ts
@@ -4,7 +4,7 @@ const SHELL_ENV_TIMEOUT_MS = 8_000;
 const CACHE_TTL_MS = 60_000;
 const DELIMITER = "__SUPERSET_SHELL_ENV__";
 
-const SHELL_BOOTSTRAP_KEYS = [
+export const SHELL_BOOTSTRAP_KEYS = [
 	"HOME",
 	"USER",
 	"LOGNAME",

--- a/packages/host-service/src/terminal/clean-shell-env.ts
+++ b/packages/host-service/src/terminal/clean-shell-env.ts
@@ -17,6 +17,14 @@ const SHELL_BOOTSTRAP_KEYS = [
 	"LC_CTYPE",
 	"__CF_USER_TEXT_ENCODING",
 	"Apple_PubSub_Socket_Render",
+	// macOS XPC bootstrap — without these, the helper shell (and every PTY
+	// downstream) loses its Mach handles to securityd/opendirectoryd, which
+	// breaks getpwuid_r (whoami → uid; OpenSSH "No user exists for uid N")
+	// and SecTrustEvaluateWithError (gh, terraform: "x509: OSStatus -26276").
+	"__CFBundleIdentifier",
+	"XPC_SERVICE_NAME",
+	"XPC_FLAGS",
+	"MallocNanoZone",
 	"COMSPEC",
 	"USERPROFILE",
 	"SYSTEMROOT",

--- a/packages/host-service/src/terminal/env.test.ts
+++ b/packages/host-service/src/terminal/env.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { SHELL_BOOTSTRAP_KEYS } from "./clean-shell-env";
 import {
 	buildV2TerminalEnv,
 	getShellBootstrapEnv,
@@ -215,6 +216,31 @@ describe("stripTerminalRuntimeEnv", () => {
 		expect(result.PYENV_ROOT).toBe("/Users/dev/.pyenv");
 		expect(result.GOPATH).toBe("/Users/dev/go");
 		expect(result.SSH_AUTH_SOCK).toBe("/tmp/ssh-agent.sock");
+	});
+
+	test("macOS XPC bootstrap keys flow seed → PTY env unmolested", () => {
+		// Seed: buildMinimalEnv() copies SHELL_BOOTSTRAP_KEYS from process.env
+		// into the helper shell, so the keys must be on this list.
+		expect(SHELL_BOOTSTRAP_KEYS).toContain("__CFBundleIdentifier");
+		expect(SHELL_BOOTSTRAP_KEYS).toContain("XPC_SERVICE_NAME");
+		expect(SHELL_BOOTSTRAP_KEYS).toContain("XPC_FLAGS");
+		expect(SHELL_BOOTSTRAP_KEYS).toContain("MallocNanoZone");
+
+		// Strip pass: none of these match a denylist prefix or exact key, so
+		// they survive stripTerminalRuntimeEnv into the PTY base env.
+		resetTerminalBaseEnvForTests();
+		initTerminalBaseEnv({
+			__CFBundleIdentifier: "com.example.app",
+			XPC_SERVICE_NAME: "0",
+			XPC_FLAGS: "0x1",
+			MallocNanoZone: "0",
+			HOME: "/Users/test",
+		});
+		const env = getTerminalBaseEnv();
+		expect(env.__CFBundleIdentifier).toBe("com.example.app");
+		expect(env.XPC_SERVICE_NAME).toBe("0");
+		expect(env.XPC_FLAGS).toBe("0x1");
+		expect(env.MallocNanoZone).toBe("0");
 	});
 });
 

--- a/packages/host-service/src/terminal/env.ts
+++ b/packages/host-service/src/terminal/env.ts
@@ -181,8 +181,9 @@ export function buildV2TerminalEnv(
 		env.SUPERSET_HOME_DIR = supersetHomeDir;
 	}
 
-	// Electron child processes can't access macOS Keychain for TLS cert verification,
-	// causing "x509: OSStatus -26276" in Go binaries like `gh`. File-based fallback.
+	// Belt-and-suspenders for tools that prefer file-based trust roots even
+	// when the macOS Security framework is reachable (clean-shell-env now
+	// forwards the XPC bootstrap vars, so trust evaluation works directly).
 	if (
 		os.platform() === "darwin" &&
 		!env.SSL_CERT_FILE &&


### PR DESCRIPTION
# Title

`fix(desktop): forward macOS XPC bootstrap env vars to v2 terminal shells`

# Body

## Summary

- forward `__CFBundleIdentifier`, `XPC_SERVICE_NAME`, `XPC_FLAGS`, and `MallocNanoZone` through the strict-shell snapshot in `clean-shell-env.ts`
- demote the `SSL_CERT_FILE` shim in `env.ts` to belt-and-suspenders (it stays in for tools that prefer file-based trust roots)
- restore the env parity with what `Terminal.app` and `iTerm` shells inherit, so anything that calls into Directory Services, Keychain, or the Security framework just works

## Root Cause

`spawnCleanShellEnv()` seeds the helper shell with `buildMinimalEnv()` — a small allowlist of keys to forward (`HOME`, `USER`, `PATH`, `TERM`, …, `Apple_PubSub_Socket_Render`, etc.) — and then snapshots whatever `command env` produces. The four XPC bootstrap variables aren't on that list, so the helper shell starts without them, the snapshot doesn't capture them, and every PTY downstream inherits a base env that's missing them.

When those identifiers are stripped, the shell is technically running as the right user (the kernel still knows the uid) but anything that does a `getpwuid_r(3)` or a `SecTrustEvaluateWithError` call gets routed to a `kCFErrorDomainOSStatus`-backed error because the system service can't be reached. From the shell's perspective the failure surfaces as:

```
$ whoami
501                                     # numeric UID — getpwuid_r returned eServerError
$ dscl . -read /Users/$(id -un) UniqueID
Operation failed with error: eServerError
$ git push                              # over SSH; OpenSSH calls getpwuid()
No user exists for uid 501
fatal: Could not read from remote repository.
$ gh api repos/cli/cli
Get "https://api.github.com/repos/cli/cli": tls: failed to verify certificate: x509: OSStatus -26276
```

The `OSStatus -26276` in that last line is what Go's `crypto/x509/internal/macos.SecTrustEvaluateWithError` reports when `CFErrorCopyDescription` falls back to printing the raw `kCFErrorDomainOSStatus` code — `CFCopyLocalizedString` is also affected by the missing services, so even the human-readable string is unavailable. The exact code isn't in any public `SecBase.h`; what matters is that `SecTrustEvaluate` itself is failing at the framework level, not at the cert level.

`curl` was unaffected because the existing `SSL_CERT_FILE` shim feeds it a file-based trust root. Anything that goes through the macOS Security framework — Go binaries (`gh`, `terraform`, `helm`), Apple's own command-line tools (`security`, `dscl`), OpenSSH's user-resolution path — failed until those env vars came back.

The four variables this PR forwards are the minimal set that fixes the symptoms above without weakening the existing runtime-strip allowlist:

| Variable | What it anchors |
|---|---|
| `__CFBundleIdentifier` | CoreFoundation client identification; `libsecinit` uses it to bind to `securityd` |
| `XPC_SERVICE_NAME` | XPC bootstrap port assigned by `launchd`; required by `securityd` and `opendirectoryd` clients |
| `XPC_FLAGS` | XPC initialization flags inherited from `launchd` |
| `MallocNanoZone` | nano-allocator handshake; some libsystem paths early-out when it's missing |

I considered a more permissive "forward everything `launchd` would seed" approach, but it's hard to enumerate that set portably across macOS versions, and the four above are sufficient on 14.x and 15.x.

The runtime-strip allowlist (`stripTerminalRuntimeEnv` in `env-strip.ts`) is innocent — none of these four keys match its prefixes (`npm_`, `ELECTRON_`, `VITE_`, `NEXT_PUBLIC_`, `TURBO_`, `HOST_`) or its exact-key set. So adding them to `SHELL_BOOTSTRAP_KEYS` is sufficient; the strip step leaves them alone naturally.

## Validation

```sh
# typecheck + lint
bun run --cwd packages/host-service typecheck
bunx @biomejs/biome@2.4.2 check --write --unsafe packages/host-service/src/terminal/

# unit tests for the env builder
bun test packages/host-service/src/terminal/env.test.ts
```

Manual repro on macOS 14.6:

1. Open a fresh v2 terminal pane in Superset.
2. Confirm the symptoms before the patch:
   ```sh
   whoami                       # → "501"
   git -c core.sshCommand="ssh -v" ls-remote git@github.com:cli/cli.git 2>&1 | grep "No user"
   gh api repos/cli/cli         # → tls: failed to verify certificate: x509: OSStatus -26276
   ```
3. Apply the patch, restart Superset, open a fresh terminal pane.
4. Confirm:
   ```sh
   whoami                       # → the username, e.g. "wadeseidule"
   git ls-remote git@github.com:cli/cli.git    # succeeds
   gh api repos/cli/cli         # returns JSON
   security find-internet-password -s github.com    # responds normally
   ```
5. Spot-check that previously-stripped categories are still stripped:
   ```sh
   env | grep -E '^(ELECTRON_|npm_|VITE_|HOST_)'    # no matches
   ```

## Diff

```diff
--- a/packages/host-service/src/terminal/clean-shell-env.ts
+++ b/packages/host-service/src/terminal/clean-shell-env.ts
@@ -16,6 +16,14 @@ const SHELL_BOOTSTRAP_KEYS = [
 	"LC_CTYPE",
 	"__CF_USER_TEXT_ENCODING",
 	"Apple_PubSub_Socket_Render",
+	// macOS XPC bootstrap — without these, the helper shell (and every PTY
+	// downstream) loses its Mach handles to securityd/opendirectoryd, which
+	// breaks getpwuid_r (whoami → uid; OpenSSH "No user exists for uid N")
+	// and SecTrustEvaluateWithError (gh, terraform: "x509: OSStatus -26276").
+	"__CFBundleIdentifier",
+	"XPC_SERVICE_NAME",
+	"XPC_FLAGS",
+	"MallocNanoZone",
 	"COMSPEC",
 	"USERPROFILE",
 	"SYSTEMROOT",

--- a/packages/host-service/src/terminal/env.ts
+++ b/packages/host-service/src/terminal/env.ts
@@ -181,8 +181,9 @@ export function buildV2TerminalEnv(
 		env.SUPERSET_HOME_DIR = supersetHomeDir;
 	}
 
-	// Electron child processes can't access macOS Keychain for TLS cert verification,
-	// causing "x509: OSStatus -26276" in Go binaries like `gh`. File-based fallback.
+	// Belt-and-suspenders for tools that prefer file-based trust roots even
+	// when the macOS Security framework is reachable (clean-shell-env now
+	// forwards the XPC bootstrap vars, so trust evaluation works directly).
 	if (
 		os.platform() === "darwin" &&
 		!env.SSL_CERT_FILE &&
```

## Notes

- This restores behavior to what users had pre-#3184 for these specific variables only; everything else the allowlist filters stays filtered.
- The four variables are low-risk to forward: `__CFBundleIdentifier` is just the parent's bundle ID, `XPC_SERVICE_NAME` and `XPC_FLAGS` are launchd-assigned identifiers, and `MallocNanoZone` is a runtime allocator handshake. None of them carry user data, credentials, or workspace state.
- If there's a desire to be even more conservative, dropping `MallocNanoZone` still fixes `whoami`, `gh`, and `git push` over SSH on the macOS versions I tested. I'd keep it in to avoid an unrelated nano-allocator warning that some libsystem paths emit.
- Left the `SSL_CERT_FILE` shim in place. It's redundant once the XPC vars flow, but it's also harmless and protects tools that explicitly prefer file-based trust roots (`curl`, anything with `OPENSSL_CONF`-driven trust resolution).

# Commit message

```
fix(desktop): forward macOS XPC bootstrap env vars to v2 terminal shells

Forward __CFBundleIdentifier, XPC_SERVICE_NAME, XPC_FLAGS, and
MallocNanoZone through the strict-shell snapshot on Darwin.

Without these, the helper shell that buildMinimalEnv() seeds for
spawnCleanShellEnv() loses its Mach handles to securityd and
opendirectoryd. That propagates into every PTY downstream and breaks
getpwuid_r (whoami returns the uid; OpenSSH fails with "No user exists
for uid N") and SecTrustEvaluateWithError (Go binaries like gh report
"x509: OSStatus -26276"). curl was unaffected because of the
SSL_CERT_FILE shim, which is now belt-and-suspenders rather than the
primary fix.

The rest of the runtime-strip allowlist stays as-is; Electron, npm,
Vite, and host runtime variables remain stripped.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Allowlist for shell bootstrap environment made publicly accessible and extended to include additional macOS XPC/bootstrap variables.

* **Tests**
  * Added tests to verify the extended macOS bootstrap keys are preserved in the terminal base environment.

* **Chores**
  * Clarified macOS SSL certificate rationale in terminal environment docs/comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward critical macOS XPC bootstrap env vars to v2 terminal shells so Keychain, Directory Services, and TLS trust evaluation work as expected. Restores parity with Terminal/iTerm and keeps the `SSL_CERT_FILE` shim as a fallback. Adds a test to prevent regressions.

- **Bug Fixes**
  - Forward `__CFBundleIdentifier`, `XPC_SERVICE_NAME`, `XPC_FLAGS`, and `MallocNanoZone` in `clean-shell-env.ts`.
  - Demote `SSL_CERT_FILE` in `env.ts` to a fallback for tools that prefer file-based trust.
  - Export `SHELL_BOOTSTRAP_KEYS` and add a unit test to ensure the XPC keys flow from seed to PTY env unchanged.
  - Fixes: `whoami` shows username (not UID), OpenSSH/Git “No user exists for uid N”, Go tools TLS `x509: OSStatus -26276`, and `security`/`dscl` errors.

<sup>Written for commit 35c7019a413e610a2c3620afdd583226df3acf50. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3799?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

