### PR TITLE
[codex] Update sidebar main workspace icons

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -191,11 +191,8 @@ export function DashboardSidebarWorkspaceItem({
 			workspaceStatus={workspaceStatus}
 			onClick={isPending ? handlePendingClick : handleClick}
 			onDoubleClick={isPending ? undefined : startRename}
-			onDeleteClick={
-				isMainWorkspace
-					? handleRemoveFromSidebar
-					: () => setIsDeleteDialogOpen(true)
-			}
+			onRemoveFromSidebarClick={handleRemoveFromSidebar}
+			onCloseWorkspaceClick={() => setIsDeleteDialogOpen(true)}
 			onRenameValueChange={setRenameValue}
 			onSubmitRename={submitRename}
 			onCancelRename={cancelRename}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -102,6 +102,7 @@ export function DashboardSidebarWorkspaceItem({
 				)}
 				<DashboardSidebarCollapsedWorkspaceButton
 					hostType={hostType}
+					workspaceType={workspace.type}
 					hostIsOnline={hostIsOnline}
 					isActive={isActive}
 					workspaceStatus={workspaceStatus}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarCollapsedWorkspaceButton/DashboardSidebarCollapsedWorkspaceButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarCollapsedWorkspaceButton/DashboardSidebarCollapsedWorkspaceButton.tsx
@@ -1,12 +1,16 @@
 import { cn } from "@superset/ui/utils";
 import { type ComponentPropsWithoutRef, forwardRef } from "react";
 import type { ActivePaneStatus } from "shared/tabs-types";
-import type { DashboardSidebarWorkspaceHostType } from "../../../../types";
+import type {
+	DashboardSidebarWorkspaceHostType,
+	DashboardSidebarWorkspaceType,
+} from "../../../../types";
 import { DashboardSidebarWorkspaceIcon } from "../DashboardSidebarWorkspaceIcon";
 
 interface DashboardSidebarCollapsedWorkspaceButtonProps
 	extends ComponentPropsWithoutRef<"button"> {
 	hostType: DashboardSidebarWorkspaceHostType;
+	workspaceType: DashboardSidebarWorkspaceType;
 	hostIsOnline: boolean | null;
 	isActive: boolean;
 	workspaceStatus?: ActivePaneStatus | null;
@@ -20,6 +24,7 @@ export const DashboardSidebarCollapsedWorkspaceButton = forwardRef<
 	(
 		{
 			hostType,
+			workspaceType,
 			hostIsOnline,
 			isActive,
 			workspaceStatus = null,
@@ -43,6 +48,7 @@ export const DashboardSidebarCollapsedWorkspaceButton = forwardRef<
 			>
 				<DashboardSidebarWorkspaceIcon
 					hostType={hostType}
+					workspaceType={workspaceType}
 					hostIsOnline={hostIsOnline}
 					isActive={isActive}
 					variant="collapsed"

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -42,7 +42,8 @@ interface DashboardSidebarExpandedWorkspaceRowProps
 	workspaceStatus?: ActivePaneStatus | null;
 	onClick?: () => void;
 	onDoubleClick?: () => void;
-	onDeleteClick: () => void;
+	onCloseWorkspaceClick: () => void;
+	onRemoveFromSidebarClick: () => void;
 	onRenameValueChange: (value: string) => void;
 	onSubmitRename: () => void;
 	onCancelRename: () => void;
@@ -63,7 +64,8 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 			workspaceStatus = null,
 			onClick,
 			onDoubleClick,
-			onDeleteClick,
+			onCloseWorkspaceClick,
+			onRemoveFromSidebarClick,
 			onRenameValueChange,
 			onSubmitRename,
 			onCancelRename,
@@ -105,9 +107,6 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 		const workspaceKindDescription = isMainWorkspace
 			? "Uses the repository checkout on this host"
 			: "Isolated copy for parallel development";
-		const closeLabel = isMainWorkspace
-			? "Remove from sidebar"
-			: "Close workspace";
 
 		return (
 			// biome-ignore lint/a11y/noStaticElementInteractions: Mirrors the legacy sidebar row UI, which includes nested action buttons.
@@ -280,35 +279,48 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 											{shortcutLabel}
 										</span>
 									)}
-									<Tooltip delayDuration={300}>
-										<TooltipTrigger asChild>
-											<button
-												type="button"
-												onClick={(event) => {
-													event.stopPropagation();
-													onDeleteClick();
-												}}
-												className="flex items-center justify-center text-muted-foreground hover:text-foreground"
-												aria-label={closeLabel}
-											>
-												{isMainWorkspace ? (
+									{isMainWorkspace ? (
+										<Tooltip delayDuration={300}>
+											<TooltipTrigger asChild>
+												<button
+													type="button"
+													onClick={(event) => {
+														event.stopPropagation();
+														onRemoveFromSidebarClick();
+													}}
+													className="flex items-center justify-center text-muted-foreground hover:text-foreground"
+													aria-label="Remove from sidebar"
+												>
 													<HiMiniMinus className="size-3.5" />
-												) : (
+												</button>
+											</TooltipTrigger>
+											<TooltipContent side="top" sideOffset={4}>
+												<HotkeyLabel label="Remove from sidebar" />
+											</TooltipContent>
+										</Tooltip>
+									) : (
+										<Tooltip delayDuration={300}>
+											<TooltipTrigger asChild>
+												<button
+													type="button"
+													onClick={(event) => {
+														event.stopPropagation();
+														onCloseWorkspaceClick();
+													}}
+													className="flex items-center justify-center text-muted-foreground hover:text-foreground"
+													aria-label="Close workspace"
+												>
 													<HiMiniXMark className="size-3.5" />
-												)}
-											</button>
-										</TooltipTrigger>
-										<TooltipContent side="top" sideOffset={4}>
-											<HotkeyLabel
-												label={closeLabel}
-												id={
-													isActive && !isMainWorkspace
-														? "CLOSE_WORKSPACE"
-														: undefined
-												}
-											/>
-										</TooltipContent>
-									</Tooltip>
+												</button>
+											</TooltipTrigger>
+											<TooltipContent side="top" sideOffset={4}>
+												<HotkeyLabel
+													label="Close workspace"
+													id={isActive ? "CLOSE_WORKSPACE" : undefined}
+												/>
+											</TooltipContent>
+										</Tooltip>
+									)}
 								</div>
 							</>
 						)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -288,6 +288,15 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 														event.stopPropagation();
 														onRemoveFromSidebarClick();
 													}}
+													onKeyDown={(event) => {
+														if (
+															event.key === "Enter" ||
+															event.key === " " ||
+															event.key === "Spacebar"
+														) {
+															event.stopPropagation();
+														}
+													}}
 													className="flex items-center justify-center text-muted-foreground hover:text-foreground"
 													aria-label="Remove from sidebar"
 												>
@@ -306,6 +315,15 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 													onClick={(event) => {
 														event.stopPropagation();
 														onCloseWorkspaceClick();
+													}}
+													onKeyDown={(event) => {
+														if (
+															event.key === "Enter" ||
+															event.key === " " ||
+															event.key === "Spacebar"
+														) {
+															event.stopPropagation();
+														}
 													}}
 													className="flex items-center justify-center text-muted-foreground hover:text-foreground"
 													aria-label="Close workspace"

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -7,7 +7,7 @@ import {
 	useMemo,
 	useRef,
 } from "react";
-import { HiMiniXMark } from "react-icons/hi2";
+import { HiMiniMinus, HiMiniXMark } from "react-icons/hi2";
 import type { DiffStats } from "renderer/hooks/host-service/useDiffStats";
 import { HotkeyLabel } from "renderer/hotkeys";
 import { electronTrpc } from "renderer/lib/electron-trpc";
@@ -167,6 +167,7 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 							>
 								<DashboardSidebarWorkspaceIcon
 									hostType={hostType}
+									workspaceType={workspace.type}
 									hostIsOnline={hostIsOnline}
 									isActive={isActive}
 									variant="expanded"
@@ -179,6 +180,7 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 							<div className="relative mr-2.5 flex size-5 shrink-0 items-center justify-center">
 								<DashboardSidebarWorkspaceIcon
 									hostType={hostType}
+									workspaceType={workspace.type}
 									hostIsOnline={hostIsOnline}
 									isActive={isActive}
 									variant="expanded"
@@ -289,7 +291,11 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 												className="flex items-center justify-center text-muted-foreground hover:text-foreground"
 												aria-label={closeLabel}
 											>
-												<HiMiniXMark className="size-3.5" />
+												{isMainWorkspace ? (
+													<HiMiniMinus className="size-3.5" />
+												) : (
+													<HiMiniXMark className="size-3.5" />
+												)}
 											</button>
 										</TooltipTrigger>
 										<TooltipContent side="top" sideOffset={4}>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/DashboardSidebarWorkspaceIcon.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/DashboardSidebarWorkspaceIcon.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@superset/ui/utils";
+import { CgLaptop } from "react-icons/cg";
 import { HiExclamationTriangle } from "react-icons/hi2";
 import {
 	LuGitMerge,
@@ -14,10 +15,12 @@ import type { ActivePaneStatus } from "shared/tabs-types";
 import type {
 	DashboardSidebarWorkspaceHostType,
 	DashboardSidebarWorkspacePullRequest,
+	DashboardSidebarWorkspaceType,
 } from "../../../../types";
 
 interface DashboardSidebarWorkspaceIconProps {
 	hostType: DashboardSidebarWorkspaceHostType;
+	workspaceType: DashboardSidebarWorkspaceType;
 	hostIsOnline: boolean | null;
 	isActive: boolean;
 	variant: "collapsed" | "expanded";
@@ -47,6 +50,7 @@ const PR_COLOR_BY_STATE = {
 
 export function DashboardSidebarWorkspaceIcon({
 	hostType,
+	workspaceType,
 	hostIsOnline,
 	isActive,
 	variant,
@@ -68,6 +72,10 @@ export function DashboardSidebarWorkspaceIcon({
 					strokeWidth={1.75}
 				/>
 			);
+		}
+
+		if (workspaceType === "main") {
+			return <CgLaptop className={cn("size-4 transition-colors", iconColor)} />;
 		}
 
 		if (hostType === "local-device") {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/DashboardSidebarWorkspaceIcon.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceIcon/DashboardSidebarWorkspaceIcon.tsx
@@ -74,11 +74,13 @@ export function DashboardSidebarWorkspaceIcon({
 			);
 		}
 
-		if (workspaceType === "main") {
-			return <CgLaptop className={cn("size-4 transition-colors", iconColor)} />;
-		}
-
 		if (hostType === "local-device") {
+			if (workspaceType === "main") {
+				return (
+					<CgLaptop className={cn("size-4 transition-colors", iconColor)} />
+				);
+			}
+
 			return <RxDot className={cn("size-4 transition-colors", iconColor)} />;
 		}
 


### PR DESCRIPTION
## Summary

- Use `CgLaptop` for local main workspace sidebar icons.
- Pass workspace type into collapsed and expanded sidebar icon rendering.
- Split the expanded sidebar row into separate remove-from-sidebar and close-workspace action buttons with distinct icons, handlers, aria labels, and tooltips.
- Preserve existing remote/cloud/offline host icon behavior for main workspaces outside the local-device path.

## Validation

- `bun run --cwd apps/desktop typecheck`
- `bunx @biomejs/biome@2.4.2 check` on the changed sidebar files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Sidebar shows distinct workspace-type indicators, including a laptop icon for main local workspaces.
  * Collapsed workspace button now conveys workspace type so icons match expanded and collapsed states.
  * Action behavior clarified: main workspaces use a "Remove from sidebar" control (minus icon), other workspaces use a "Close workspace" control (X), each with appropriate tooltip and hotkey behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->