### PR TITLE
[codex] Improve terminal connection diagnostics

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -100,6 +100,22 @@ function cancelReconnect(transport: TerminalTransport) {
 	}
 }
 
+function formatWsEndpoint(wsUrl: string | null): string {
+	if (!wsUrl) return "unknown endpoint";
+	try {
+		const url = new URL(wsUrl);
+		return `${url.protocol}//${url.host}${url.pathname}`;
+	} catch {
+		return "invalid terminal WebSocket URL";
+	}
+}
+
+function formatCloseDetails(event: CloseEvent): string {
+	const code = event.code || "unknown";
+	const reason = event.reason ? `, reason: ${event.reason}` : "";
+	return `code: ${code}${reason}`;
+}
+
 export function connect(
 	transport: TerminalTransport,
 	terminal: XTerm,
@@ -165,17 +181,28 @@ export function connect(
 		}
 	});
 
-	socket.addEventListener("close", () => {
+	socket.addEventListener("close", (event) => {
 		if (transport.socket !== socket) return;
 		setConnectionState(transport, "closed");
 		transport.socket = null;
+		if (!transport._exited && event.code !== 1000) {
+			const willReconnect =
+				!transport._reconnectTimer &&
+				Boolean(transport.currentUrl && transport._terminal) &&
+				transport._reconnectAttempt < MAX_RECONNECT_ATTEMPTS;
+			terminal.writeln(
+				`\r\n[terminal] WebSocket closed while connected to ${formatWsEndpoint(transport.currentUrl)} (${formatCloseDetails(event)}). ${willReconnect ? "Reconnecting..." : "Max reconnect attempts reached."}`,
+			);
+		}
 		// Auto-reconnect on unexpected close (host-service restart, network blip)
 		scheduleReconnect(transport);
 	});
 
 	socket.addEventListener("error", () => {
 		if (transport.socket !== socket) return;
-		terminal.writeln("\r\n[terminal] websocket error");
+		terminal.writeln(
+			`\r\n[terminal] WebSocket error while connecting to ${formatWsEndpoint(transport.currentUrl)}. Check host-service or relay connectivity.`,
+		);
 	});
 
 	transport.onDataDisposable?.dispose();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -155,10 +155,27 @@ export function TerminalPane({
 					void invalidateTerminalSessionsRef.current({
 						workspaceId: sessionWorkspaceId,
 					});
+					return;
 				}
+				if (cancelled) return;
+				const details = result.error
+					? `: ${result.error}`
+					: " for an unknown reason";
+				terminalRuntimeRegistry
+					.getTerminal(terminalId, terminalInstanceId)
+					?.writeln(
+						`\r\n[terminal] Failed to create terminal session${details}`,
+					);
 			})
 			.catch((err) => {
 				console.error("[TerminalPane] ensureSession failed:", err);
+				if (cancelled) return;
+				const message = err instanceof Error ? err.message : String(err);
+				terminalRuntimeRegistry
+					.getTerminal(terminalId, terminalInstanceId)
+					?.writeln(
+						`\r\n[terminal] terminal.ensureSession request failed: ${message}`,
+					);
 			})
 			.finally(() => {
 				if (cancelled) return;

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -602,10 +602,9 @@ export function registerWorkspaceTerminalRoute({
 						if (!workspaceId) {
 							sendMessage(ws, {
 								type: "error",
-								message:
-									"Session not found. Call terminal.ensureSession first.",
+								message: `Terminal session "${terminalId}" not found; use terminal.ensureSession or workspaceId.`,
 							});
-							ws.close(1011, "Session not found");
+							ws.close(1011, "Terminal session not found");
 							return;
 						}
 


### PR DESCRIPTION
## Summary
- surface `terminal.ensureSession` failures directly in the v2 terminal
- include sanitized terminal WebSocket endpoint and close code/reason in visible terminal connection errors
- make host-service "session not found" terminal attach error explain missing session and workspaceId context

## Root Cause
The terminal startup path could collapse distinct failures into generic messages like `[terminal] websocket error` or `Session not found`, hiding whether the failure came from `ensureSession`, host-service session lookup, or the WebSocket transport.

## Impact
No terminal startup/control-flow behavior changed. This is diagnostics-only; v2 still waits for `ensureSession` before connecting.

## Validation
- `bun run lint:fix`
- `bun run test`
- `bun run --cwd packages/host-service typecheck`
- `bun run --cwd apps/desktop typecheck`

## Notes
- Raw root `bun test` fails because it does not load the desktop package Bun preload setup (`apps/desktop/bunfig.toml`); the repo test script `bun run test` passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves terminal connection diagnostics in the v2 terminal. Errors now identify the failing step and show a sanitized WebSocket endpoint with close details; runtime behavior is unchanged.

- **New Features**
  - Surface `terminal.ensureSession` failures in-terminal, including session creation errors and request failures.
  - On WebSocket error or abnormal close, show sanitized endpoint and close code/reason, and whether reconnecting or max retries reached.
  - In `host-service`, replace generic “Session not found” with a `terminalId`-aware message suggesting `terminal.ensureSession` or `workspaceId`, and use a clearer close reason.

<sup>Written for commit a290a00a67f1c47820174a4c6195bae4f568d7b6. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3801?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal now displays clear failure messages when session creation fails or is rejected.
  * WebSocket error logs include the target endpoint and actionable guidance instead of generic text.
  * Close events produce detailed terminal logs with close code, optional reason, and reconnection outcome messages.
  * Server-side connection errors now return a more specific "Terminal session not found" error with instructions to retry with proper session info.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->