### PR TITLE
feat(desktop): make v2 cloud opt-in instead of opt-out

### DIFF
--- a/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts
+++ b/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts
@@ -3,17 +3,17 @@ import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useV2LocalOverrideStore } from "renderer/stores/v2-local-override";
 
 /**
- * Returns effective v2 state: remote PostHog flag AND local override.
+ * Returns effective v2 state: remote PostHog flag AND local opt-in.
  * Also returns the raw remote flag so the toggle can be shown conditionally.
  */
 export function useIsV2CloudEnabled() {
 	const remoteV2Enabled =
 		useFeatureFlagEnabled(FEATURE_FLAGS.V2_CLOUD) ?? false;
-	const forceV1 = useV2LocalOverrideStore((s) => s.forceV1);
+	const optInV2 = useV2LocalOverrideStore((s) => s.optInV2);
 
 	return {
 		/** The effective value — use this wherever you previously checked the flag directly. */
-		isV2CloudEnabled: remoteV2Enabled && !forceV1,
+		isV2CloudEnabled: remoteV2Enabled && optInV2,
 		/** Whether the remote PostHog flag is on (for showing the toggle). */
 		isRemoteV2Enabled: remoteV2Enabled,
 	};

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/experimental/components/ExperimentalSettings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/experimental/components/ExperimentalSettings/ExperimentalSettings.tsx
@@ -30,7 +30,7 @@ export function ExperimentalSettings({
 	);
 	const { isV2CloudEnabled, isRemoteV2Enabled } = useIsV2CloudEnabled();
 	const { rerun, isRunning } = useMigrateV1DataToV2({ autoRun: false });
-	const setForceV1 = useV2LocalOverrideStore((state) => state.setForceV1);
+	const setOptInV2 = useV2LocalOverrideStore((state) => state.setOptInV2);
 
 	async function rerunMigration() {
 		const result = await rerun();
@@ -74,7 +74,7 @@ export function ExperimentalSettings({
 						<Switch
 							id="superset-v2"
 							checked={isV2CloudEnabled}
-							onCheckedChange={(enabled) => setForceV1(!enabled)}
+							onCheckedChange={(enabled) => setOptInV2(enabled)}
 							disabled={!isRemoteV2Enabled}
 						/>
 					</div>

--- a/apps/desktop/src/renderer/stores/v2-local-override.ts
+++ b/apps/desktop/src/renderer/stores/v2-local-override.ts
@@ -2,19 +2,19 @@ import { create } from "zustand";
 import { devtools, persist } from "zustand/middleware";
 
 interface V2LocalOverrideState {
-	/** When true, forces v1 mode locally even though v2 is enabled remotely. */
-	forceV1: boolean;
-	setForceV1: (forceV1: boolean) => void;
+	/** When true, the user has opted into v2. v2 is gated behind both the remote flag and this opt-in. */
+	optInV2: boolean;
+	setOptInV2: (optInV2: boolean) => void;
 }
 
 export const useV2LocalOverrideStore = create<V2LocalOverrideState>()(
 	devtools(
 		persist(
 			(set) => ({
-				forceV1: false,
-				setForceV1: (forceV1) => set({ forceV1 }),
+				optInV2: false,
+				setOptInV2: (optInV2) => set({ optInV2 }),
 			}),
-			{ name: "v2-local-override" },
+			{ name: "v2-local-override-v2" },
 		),
 		{ name: "V2LocalOverrideStore" },
 	),


### PR DESCRIPTION
## Summary
- Inverts the v2 local override so users with the `v2-cloud` PostHog flag default to v1 and must opt in via Settings → Experimental. Previously, the flag flipping on auto-migrated users into v2 — opt-out, not opt-in.
- Renames `forceV1` → `optInV2` in `v2-local-override` store, bumps the persisted key (`v2-local-override-v2`) so old hydrated state is dropped cleanly — users who had explicitly set `forceV1=true` keep getting v1; users who were defaulting through `forceV1=false` correctly reset to v1 (no longer auto-jump to v2).
- Updates `useIsV2CloudEnabled` to `remoteV2Enabled && optInV2`, and wires the Experimental Settings switch directly to `setOptInV2`.

## Why
We're shipping 1.6.3 with the v2 cloud project rollout. The PostHog `v2-cloud` flag has been updated to include a `desktop_version semver_gte 1.6.3` release group at 100%, so every 1.6.3+ user will see the toggle — but they need to choose to flip it. This change has to land in 1.6.3 itself, otherwise the flag turning on would auto-migrate everyone instead of gating behind opt-in.

Migration auto-run (`useMigrateV1DataToV2` from `_dashboard/layout.tsx`) is gated on `isV2CloudEnabled` and idempotent across launches, so it correctly fires once when a user opts in — no change needed there.

## Heads up for internal testers
Because the persist key is bumped, anyone currently on v2 (Superset team, "All Access" cohort, named early-access users) will land on v1 on first launch of 1.6.3 and need to re-flip the switch in Settings → Experimental. The PostHog flag's existing release groups are preserved so the toggle is still available to them.

## Test plan
- [ ] Fresh install on 1.6.3: PostHog flag evaluates true → toggle appears in Settings → Experimental, defaults OFF, user is on v1
- [ ] Flip toggle ON → `isV2CloudEnabled` becomes true → migration auto-runs once, user lands in v2
- [ ] Flip toggle OFF → user returns to v1
- [ ] Existing internal user upgrading to 1.6.3: lands on v1 (because of persist key bump), can re-opt in
- [ ] User without flag (e.g. ≤1.6.2 or non-team email): toggle is disabled with "Early access is not enabled" copy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make v2 cloud opt-in on desktop. Users with the `v2-cloud` flag now stay on v1 by default and must enable v2 in Settings → Experimental.

- **New Features**
  - Effective gate is the remote flag AND a local opt-in.
  - Experimental toggle writes `optInV2`; `useIsV2CloudEnabled` evaluates `remoteV2Enabled && optInV2`.
  - Renamed `forceV1` to `optInV2` and bumped persist key to `v2-local-override-v2`.

- **Migration**
  - Users currently on v2 will land on v1 after upgrading to 1.6.3 and need to re-enable v2.
  - Data migration runs once after opting in; no manual steps.

<sup>Written for commit 2fb63c5e2f619adfa2478f5618a25d6fa1c6deb0. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3802?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the V2 Cloud experimental feature toggle to use an explicit opt-in model instead of an opt-out approach. The toggle behavior in experimental settings now directly enables or disables V2 Cloud participation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->