### PR TITLE
feat(chat): add GPT-5.5 to v2 chat pane

### DIFF
--- a/apps/desktop/src/renderer/lib/dev-chat.ts
+++ b/apps/desktop/src/renderer/lib/dev-chat.ts
@@ -24,6 +24,11 @@ export const DEV_CHAT_MODELS: ModelOption[] = [
 		provider: "Anthropic",
 	},
 	{
+		id: "openai/gpt-5.5",
+		name: "GPT-5.5",
+		provider: "OpenAI",
+	},
+	{
 		id: "openai/gpt-5.4",
 		name: "GPT-5.4",
 		provider: "OpenAI",

--- a/packages/trpc/src/router/chat/chat.ts
+++ b/packages/trpc/src/router/chat/chat.ts
@@ -30,6 +30,11 @@ const AVAILABLE_MODELS = [
 		provider: "Anthropic",
 	},
 	{
+		id: "openai/gpt-5.5",
+		name: "GPT-5.5",
+		provider: "OpenAI",
+	},
+	{
 		id: "openai/gpt-5.4",
 		name: "GPT-5.4",
 		provider: "OpenAI",


### PR DESCRIPTION
## Summary
- Add `openai/gpt-5.5` (GPT-5.5) as the newest OpenAI option in the v2 chat pane model picker
- Updated both the server-side `chat.getModels` registry and the desktop dev fallback list

## Test plan
- [ ] Open v2 chat pane, confirm GPT-5.5 appears at the top of the OpenAI section in the model picker
- [ ] Send a message with GPT-5.5 selected and verify the response routes correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `openai/gpt-5.5` to the v2 chat pane model picker and server-side model registry. Also updates the desktop dev fallback list so GPT-5.5 appears at the top of the OpenAI section and routes messages correctly.

<sup>Written for commit 0732aed163eac1e950f22e2fb8b2a6ba563cb263. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3808?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPT-5.5 model as a new chat option, now available in the desktop chat interface during development mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->