### PR TITLE
[codex] Keep host service alive on errors

### DIFF
--- a/apps/desktop/src/main/host-service/index.ts
+++ b/apps/desktop/src/main/host-service/index.ts
@@ -5,16 +5,17 @@
  * The coordinator polls health.check to know when it's ready.
  */
 
-import { serve } from "@hono/node-server";
 import {
+	closeHostServiceServer,
 	createApp,
-	installHostServiceProcessGuards,
 	JwtApiAuthProvider,
 	LocalGitCredentialProvider,
 	LocalModelProvider,
 	PskHostAuthProvider,
 	reportHostServiceError,
 	runHostServiceBackgroundTask,
+	runHostServiceMain,
+	startHostServiceServer,
 } from "@superset/host-service";
 import {
 	initTerminalBaseEnv,
@@ -22,8 +23,6 @@ import {
 } from "@superset/host-service/terminal-env";
 import { connectRelay } from "@superset/host-service/tunnel";
 import { writeManifest } from "main/lib/host-service-manifest";
-
-const STARTUP_RETRY_DELAY_MS = 5_000;
 
 async function main(): Promise<void> {
 	const { env } = await import("./env");
@@ -55,9 +54,14 @@ async function main(): Promise<void> {
 	});
 
 	const startedAt = Date.now();
-	const server = serve(
-		{ fetch: app.fetch, port: env.HOST_SERVICE_PORT, hostname: "127.0.0.1" },
-		(info: { port: number }) => {
+	const server = await startHostServiceServer({
+		options: {
+			fetch: app.fetch,
+			port: env.HOST_SERVICE_PORT,
+			hostname: "127.0.0.1",
+		},
+		injectWebSocket,
+		onListen: (info) => {
 			if (env.ORGANIZATION_ID) {
 				try {
 					writeManifest({
@@ -68,7 +72,7 @@ async function main(): Promise<void> {
 						organizationId: env.ORGANIZATION_ID,
 					});
 				} catch (error) {
-					console.error("[host-service] Failed to write manifest:", error);
+					reportHostServiceError("failed to write manifest", error);
 				}
 			}
 
@@ -86,23 +90,11 @@ async function main(): Promise<void> {
 				);
 			}
 		},
-	);
-	server.on("error", (error) => {
-		reportHostServiceError("server error", error);
 	});
-	try {
-		injectWebSocket(server);
-	} catch (error) {
-		reportHostServiceError("websocket injection failed", error);
-	}
 
 	// Manifest lifecycle belongs to the coordinator, not the child.
 	const shutdown = () => {
-		try {
-			server.close();
-		} catch (error) {
-			reportHostServiceError("server close failed", error);
-		}
+		closeHostServiceServer(server);
 		process.exit(0);
 	};
 
@@ -110,13 +102,4 @@ async function main(): Promise<void> {
 	process.on("SIGINT", shutdown);
 }
 
-installHostServiceProcessGuards();
-
-function startWithRetry(): void {
-	void main().catch((error) => {
-		reportHostServiceError("failed to start", error);
-		setTimeout(startWithRetry, STARTUP_RETRY_DELAY_MS);
-	});
-}
-
-startWithRetry();
+runHostServiceMain(main);

--- a/apps/desktop/src/main/host-service/index.ts
+++ b/apps/desktop/src/main/host-service/index.ts
@@ -8,10 +8,13 @@
 import { serve } from "@hono/node-server";
 import {
 	createApp,
+	installHostServiceProcessGuards,
 	JwtApiAuthProvider,
 	LocalGitCredentialProvider,
 	LocalModelProvider,
 	PskHostAuthProvider,
+	reportHostServiceError,
+	runHostServiceBackgroundTask,
 } from "@superset/host-service";
 import {
 	initTerminalBaseEnv,
@@ -19,9 +22,11 @@ import {
 } from "@superset/host-service/terminal-env";
 import { connectRelay } from "@superset/host-service/tunnel";
 import { writeManifest } from "main/lib/host-service-manifest";
-import { env } from "./env";
+
+const STARTUP_RETRY_DELAY_MS = 5_000;
 
 async function main(): Promise<void> {
+	const { env } = await import("./env");
 	const terminalBaseEnv = await resolveTerminalBaseEnv();
 	initTerminalBaseEnv(terminalBaseEnv);
 
@@ -68,22 +73,36 @@ async function main(): Promise<void> {
 			}
 
 			if (env.RELAY_URL && env.ORGANIZATION_ID) {
-				void connectRelay({
-					api,
-					relayUrl: env.RELAY_URL,
-					localPort: info.port,
-					organizationId: env.ORGANIZATION_ID,
-					authProvider,
-					hostServiceSecret: env.HOST_SERVICE_SECRET,
-				});
+				const relayUrl = env.RELAY_URL;
+				runHostServiceBackgroundTask("relay startup failed", () =>
+					connectRelay({
+						api,
+						relayUrl,
+						localPort: info.port,
+						organizationId: env.ORGANIZATION_ID,
+						authProvider,
+						hostServiceSecret: env.HOST_SERVICE_SECRET,
+					}),
+				);
 			}
 		},
 	);
-	injectWebSocket(server);
+	server.on("error", (error) => {
+		reportHostServiceError("server error", error);
+	});
+	try {
+		injectWebSocket(server);
+	} catch (error) {
+		reportHostServiceError("websocket injection failed", error);
+	}
 
 	// Manifest lifecycle belongs to the coordinator, not the child.
 	const shutdown = () => {
-		server.close();
+		try {
+			server.close();
+		} catch (error) {
+			reportHostServiceError("server close failed", error);
+		}
 		process.exit(0);
 	};
 
@@ -91,7 +110,13 @@ async function main(): Promise<void> {
 	process.on("SIGINT", shutdown);
 }
 
-void main().catch((error) => {
-	console.error("[host-service] Failed to start:", error);
-	process.exit(1);
-});
+installHostServiceProcessGuards();
+
+function startWithRetry(): void {
+	void main().catch((error) => {
+		reportHostServiceError("failed to start", error);
+		setTimeout(startWithRetry, STARTUP_RETRY_DELAY_MS);
+	});
+}
+
+startWithRetry();

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -28,6 +28,10 @@
 			"types": "./src/trpc/index.ts",
 			"default": "./src/trpc/index.ts"
 		},
+		"./resilience": {
+			"types": "./src/resilience.ts",
+			"default": "./src/resilience.ts"
+		},
 		"./terminal-env": {
 			"types": "./src/terminal/env.ts",
 			"default": "./src/terminal/env.ts"

--- a/packages/host-service/src/app.ts
+++ b/packages/host-service/src/app.ts
@@ -153,12 +153,7 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 		trpcServer({
 			router: appRouter,
 			createContext: async (_opts, c) => {
-				let isAuthenticated = false;
-				try {
-					isAuthenticated = await providers.hostAuth.validate(c.req.raw);
-				} catch (error) {
-					reportHostServiceError("tRPC auth validation failed", error);
-				}
+				const isAuthenticated = await providers.hostAuth.validate(c.req.raw);
 				return {
 					git,
 					github,

--- a/packages/host-service/src/app.ts
+++ b/packages/host-service/src/app.ts
@@ -11,6 +11,10 @@ import { EventBus, registerEventBusRoute } from "./events";
 import type { ApiAuthProvider } from "./providers/auth";
 import type { HostAuthProvider } from "./providers/host-auth";
 import type { ModelProviderRuntimeResolver } from "./providers/model-providers";
+import {
+	reportHostServiceError,
+	runHostServiceBackgroundTask,
+} from "./resilience";
 import { ChatRuntimeManager } from "./runtime/chat";
 import { WorkspaceFilesystemManager } from "./runtime/filesystem";
 import type { GitCredentialProvider } from "./runtime/git";
@@ -64,7 +68,11 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 		git,
 		github,
 	});
-	pullRequestRuntime.start();
+	try {
+		pullRequestRuntime.start();
+	} catch (error) {
+		reportHostServiceError("pull-request runtime failed to start", error);
+	}
 	const filesystem = new WorkspaceFilesystemManager({ db });
 	const chatRuntime = new ChatRuntimeManager({
 		db,
@@ -84,6 +92,11 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 	const app = new Hono();
 	const { injectWebSocket, upgradeWebSocket } = createNodeWebSocket({ app });
 
+	app.onError((error, c) => {
+		reportHostServiceError(`${c.req.method} ${c.req.path} failed`, error);
+		return c.json({ error: "Internal host-service error" }, 500);
+	});
+
 	app.use(
 		"*",
 		cors({
@@ -93,27 +106,36 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 	);
 
 	const eventBus = new EventBus({ db, filesystem });
-	eventBus.start();
+	try {
+		eventBus.start();
+	} catch (error) {
+		reportHostServiceError("event bus failed to start", error);
+	}
 
 	// Backfill `kind='main'` v2 workspaces for projects already set up before
 	// this column shipped. Idempotent; runs in the background so it doesn't
 	// block server startup.
-	void runMainWorkspaceSweep({
-		api,
-		db,
-		git,
-		organizationId: config.organizationId,
-	}).catch((err) => {
-		console.warn("[host-service] main-workspace sweep failed:", err);
-	});
+	runHostServiceBackgroundTask("main-workspace sweep failed", () =>
+		runMainWorkspaceSweep({
+			api,
+			db,
+			git,
+			organizationId: config.organizationId,
+		}),
+	);
 
 	const wsAuth: MiddlewareHandler = async (c, next) => {
-		const token = c.req.query("token");
-		const authorized =
-			(await providers.hostAuth.validate(c.req.raw)) ||
-			(token && (await providers.hostAuth.validateToken(token)));
-		if (!authorized) return c.json({ error: "Unauthorized" }, 401);
-		return next();
+		try {
+			const token = c.req.query("token");
+			const authorized =
+				(await providers.hostAuth.validate(c.req.raw)) ||
+				(token && (await providers.hostAuth.validateToken(token)));
+			if (!authorized) return c.json({ error: "Unauthorized" }, 401);
+			return next();
+		} catch (error) {
+			reportHostServiceError("websocket auth failed", error);
+			return c.json({ error: "Unauthorized" }, 401);
+		}
 	};
 	app.use("/terminal/*", wsAuth);
 	app.use("/events", wsAuth);
@@ -131,7 +153,12 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 		trpcServer({
 			router: appRouter,
 			createContext: async (_opts, c) => {
-				const isAuthenticated = await providers.hostAuth.validate(c.req.raw);
+				let isAuthenticated = false;
+				try {
+					isAuthenticated = await providers.hostAuth.validate(c.req.raw);
+				} catch (error) {
+					reportHostServiceError("tRPC auth validation failed", error);
+				}
 				return {
 					git,
 					github,

--- a/packages/host-service/src/events/event-bus.ts
+++ b/packages/host-service/src/events/event-bus.ts
@@ -5,6 +5,7 @@ import type { Hono } from "hono";
 import type { HostDb } from "../db";
 import { portManager } from "../ports/port-manager";
 import { getLabelsForWorkspace } from "../ports/static-ports";
+import { reportHostServiceError } from "../resilience";
 import type { WorkspaceFilesystemManager } from "../runtime/filesystem";
 import { GitWatcher } from "./git-watcher";
 import type { ClientMessage, ServerMessage } from "./types";
@@ -26,7 +27,11 @@ interface ClientState {
 
 function sendMessage(socket: WsSocket, message: ServerMessage): void {
 	if (socket.readyState !== 1) return;
-	socket.send(JSON.stringify(message));
+	try {
+		socket.send(JSON.stringify(message));
+	} catch (error) {
+		reportHostServiceError("event bus websocket send failed", error);
+	}
 }
 
 function parseClientMessage(data: unknown): ClientMessage | null {
@@ -101,11 +106,23 @@ export class EventBus {
 	}
 
 	close(): void {
-		this.removeGitListener?.();
+		try {
+			this.removeGitListener?.();
+		} catch (error) {
+			reportHostServiceError("event bus git listener cleanup failed", error);
+		}
 		this.removeGitListener = null;
-		this.removePortListeners?.();
+		try {
+			this.removePortListeners?.();
+		} catch (error) {
+			reportHostServiceError("event bus port listener cleanup failed", error);
+		}
 		this.removePortListeners = null;
-		this.gitWatcher.close();
+		try {
+			this.gitWatcher.close();
+		} catch (error) {
+			reportHostServiceError("event bus git watcher cleanup failed", error);
+		}
 		for (const [socket, state] of this.clients) {
 			this.cleanupClient(socket, state);
 		}
@@ -193,14 +210,19 @@ export class EventBus {
 	}
 
 	private getPortLabel(port: DetectedPort): string | null {
-		const labels = getLabelsForWorkspace((workspaceId) => {
-			try {
-				return this.filesystem.resolveWorkspaceRoot(workspaceId);
-			} catch {
-				return null;
-			}
-		}, port.workspaceId);
-		return labels?.get(port.port) ?? null;
+		try {
+			const labels = getLabelsForWorkspace((workspaceId) => {
+				try {
+					return this.filesystem.resolveWorkspaceRoot(workspaceId);
+				} catch {
+					return null;
+				}
+			}, port.workspaceId);
+			return labels?.get(port.port) ?? null;
+		} catch (error) {
+			reportHostServiceError("event bus port label lookup failed", error);
+			return null;
+		}
 	}
 
 	private startFsWatch(
@@ -246,7 +268,7 @@ export class EventBus {
 		const dispose = () => {
 			disposed = true;
 			void iterator?.return?.().catch((error: unknown) => {
-				console.error("[event-bus] fs watcher cleanup failed:", {
+				reportHostServiceError("event bus fs watcher cleanup failed", {
 					workspaceId,
 					error,
 				});
@@ -271,7 +293,7 @@ export class EventBus {
 				}
 			} catch (error) {
 				if (disposed) return;
-				console.error("[event-bus] fs stream failed:", {
+				reportHostServiceError("event bus fs stream failed", {
 					workspaceId,
 					error,
 				});
@@ -289,14 +311,22 @@ export class EventBus {
 	private stopFsWatch(state: ClientState, workspaceId: string): void {
 		const sub = state.fsSubscriptions.get(workspaceId);
 		if (sub) {
-			sub.dispose();
+			try {
+				sub.dispose();
+			} catch (error) {
+				reportHostServiceError("event bus fs watcher dispose failed", error);
+			}
 			state.fsSubscriptions.delete(workspaceId);
 		}
 	}
 
 	private cleanupClient(_socket: WsSocket, state: ClientState): void {
 		for (const sub of state.fsSubscriptions.values()) {
-			sub.dispose();
+			try {
+				sub.dispose();
+			} catch (error) {
+				reportHostServiceError("event bus client cleanup failed", error);
+			}
 		}
 		state.fsSubscriptions.clear();
 	}
@@ -320,16 +350,35 @@ export function registerEventBusRoute({
 		upgradeWebSocket(() => {
 			return {
 				onOpen: (_event, ws) => {
-					eventBus.handleOpen(ws);
+					try {
+						eventBus.handleOpen(ws);
+					} catch (error) {
+						reportHostServiceError("event bus websocket open failed", error);
+					}
 				},
 				onMessage: (event, ws) => {
-					eventBus.handleMessage(ws, event.data);
+					try {
+						eventBus.handleMessage(ws, event.data);
+					} catch (error) {
+						reportHostServiceError("event bus websocket message failed", error);
+					}
 				},
 				onClose: (_event, ws) => {
-					eventBus.handleClose(ws);
+					try {
+						eventBus.handleClose(ws);
+					} catch (error) {
+						reportHostServiceError("event bus websocket close failed", error);
+					}
 				},
 				onError: (_event, ws) => {
-					eventBus.handleClose(ws);
+					try {
+						eventBus.handleClose(ws);
+					} catch (error) {
+						reportHostServiceError(
+							"event bus websocket error cleanup failed",
+							error,
+						);
+					}
 				},
 			};
 		}),

--- a/packages/host-service/src/events/git-watcher.ts
+++ b/packages/host-service/src/events/git-watcher.ts
@@ -4,6 +4,10 @@ import { promisify } from "node:util";
 import type { FsWatchEvent } from "@superset/workspace-fs/host";
 import type { HostDb } from "../db";
 import { workspaces } from "../db/schema";
+import {
+	reportHostServiceError,
+	runHostServiceBackgroundTask,
+} from "../resilience";
 import type { WorkspaceFilesystemManager } from "../runtime/filesystem";
 
 const execFileAsync = promisify(execFile);
@@ -79,9 +83,14 @@ export class GitWatcher {
 	}
 
 	start(): void {
-		void this.rescan();
+		runHostServiceBackgroundTask("git watcher rescan failed", () =>
+			this.rescan(),
+		);
 		this.rescanTimer = setInterval(
-			() => void this.rescan(),
+			() =>
+				runHostServiceBackgroundTask("git watcher rescan failed", () =>
+					this.rescan(),
+				),
 			RESCAN_INTERVAL_MS,
 		);
 	}
@@ -105,8 +114,16 @@ export class GitWatcher {
 		this.debounceTimers.clear();
 		this.pendingBatches.clear();
 		for (const entry of this.watched.values()) {
-			entry.watcher.close();
-			entry.disposeWorktreeWatch();
+			try {
+				entry.watcher.close();
+			} catch (error) {
+				reportHostServiceError("git watcher close failed", error);
+			}
+			try {
+				entry.disposeWorktreeWatch();
+			} catch (error) {
+				reportHostServiceError("git worktree watcher dispose failed", error);
+			}
 		}
 		this.watched.clear();
 	}
@@ -148,7 +165,11 @@ export class GitWatcher {
 						? { workspaceId }
 						: { workspaceId, paths: [...batch.paths] };
 				for (const listener of this.listeners) {
-					listener(event);
+					try {
+						listener(event);
+					} catch (error) {
+						reportHostServiceError("git watcher listener failed", error);
+					}
 				}
 			}, DEBOUNCE_MS),
 		);
@@ -175,8 +196,19 @@ export class GitWatcher {
 		// Remove watchers for workspaces that no longer exist
 		for (const [id, entry] of this.watched) {
 			if (!currentIds.has(id)) {
-				entry.watcher.close();
-				entry.disposeWorktreeWatch();
+				try {
+					entry.watcher.close();
+				} catch (error) {
+					reportHostServiceError("git watcher stale close failed", error);
+				}
+				try {
+					entry.disposeWorktreeWatch();
+				} catch (error) {
+					reportHostServiceError(
+						"git worktree stale watcher dispose failed",
+						error,
+					);
+				}
 				this.watched.delete(id);
 			}
 		}
@@ -228,15 +260,33 @@ export class GitWatcher {
 			});
 		} catch {
 			// fs.watch failed (e.g. directory doesn't exist)
-			disposeWorktreeWatch();
+			try {
+				disposeWorktreeWatch();
+			} catch (error) {
+				reportHostServiceError(
+					"git worktree watcher cleanup after fs.watch failure failed",
+					error,
+				);
+			}
 			return;
 		}
 
 		watcher.on("error", () => {
 			// Watcher died — clean up so rescan can re-add
-			disposeWorktreeWatch();
+			try {
+				disposeWorktreeWatch();
+			} catch (error) {
+				reportHostServiceError(
+					"git worktree watcher error cleanup failed",
+					error,
+				);
+			}
 			this.watched.delete(workspaceId);
-			watcher.close();
+			try {
+				watcher.close();
+			} catch (error) {
+				reportHostServiceError("git watcher error close failed", error);
+			}
 		});
 
 		this.watched.set(workspaceId, {
@@ -270,7 +320,7 @@ export class GitWatcher {
 			});
 			iterator = stream[Symbol.asyncIterator]();
 		} catch (error) {
-			console.error("[git-watcher] failed to start worktree watch:", {
+			reportHostServiceError("git watcher failed to start worktree watch", {
 				workspaceId,
 				error,
 			});
@@ -317,7 +367,7 @@ export class GitWatcher {
 				}
 			} catch (error) {
 				if (!disposed) {
-					console.error("[git-watcher] worktree watch stream failed:", {
+					reportHostServiceError("git watcher worktree stream failed", {
 						workspaceId,
 						error,
 					});
@@ -327,7 +377,12 @@ export class GitWatcher {
 
 		return () => {
 			disposed = true;
-			void iterator?.return?.().catch(() => {});
+			void iterator?.return?.().catch((error: unknown) => {
+				reportHostServiceError("git watcher worktree stream cleanup failed", {
+					workspaceId,
+					error,
+				});
+			});
 			iterator = null;
 		};
 	}

--- a/packages/host-service/src/index.ts
+++ b/packages/host-service/src/index.ts
@@ -19,12 +19,14 @@ export {
 	LocalModelProvider,
 } from "./providers/model-providers";
 export {
-	createGuardedHandler,
+	closeHostServiceServer,
 	installHostServiceProcessGuards,
 	reportHostServiceError,
 	runHostServiceBackgroundTask,
+	runHostServiceMain,
 } from "./resilience";
 export type { GitCredentialProvider, GitFactory } from "./runtime/git";
+export { startHostServiceServer } from "./server";
 export type { TeardownFailureCause } from "./trpc/error-types";
 export type { AppRouter } from "./trpc/router";
 export type { ApiClient, HostServiceContext } from "./types";

--- a/packages/host-service/src/index.ts
+++ b/packages/host-service/src/index.ts
@@ -18,6 +18,12 @@ export {
 	CloudModelProvider,
 	LocalModelProvider,
 } from "./providers/model-providers";
+export {
+	createGuardedHandler,
+	installHostServiceProcessGuards,
+	reportHostServiceError,
+	runHostServiceBackgroundTask,
+} from "./resilience";
 export type { GitCredentialProvider, GitFactory } from "./runtime/git";
 export type { TeardownFailureCause } from "./trpc/error-types";
 export type { AppRouter } from "./trpc/router";

--- a/packages/host-service/src/resilience.ts
+++ b/packages/host-service/src/resilience.ts
@@ -1,8 +1,13 @@
 const HOST_SERVICE_PREFIX = "[host-service]";
+const DEFAULT_STARTUP_RETRY_DELAY_MS = 5_000;
+const DEFAULT_STARTUP_RETRY_MAX_DELAY_MS = 60_000;
 
 let processGuardsInstalled = false;
 
 type MaybePromise<T> = T | Promise<T>;
+type ClosableServer = {
+	close: () => void;
+};
 
 export function reportHostServiceError(scope: string, error: unknown): void {
 	console.error(`${HOST_SERVICE_PREFIX} ${scope}:`, error);
@@ -32,11 +37,40 @@ export function runHostServiceBackgroundTask(
 		});
 }
 
-export function createGuardedHandler<Args extends unknown[]>(
-	scope: string,
-	handler: (...args: Args) => MaybePromise<unknown>,
-): (...args: Args) => void {
-	return (...args: Args) => {
-		runHostServiceBackgroundTask(scope, () => handler(...args));
+export function closeHostServiceServer(
+	server: ClosableServer,
+	scope = "server close failed",
+): void {
+	try {
+		server.close();
+	} catch (error) {
+		reportHostServiceError(scope, error);
+	}
+}
+
+export function runHostServiceMain(main: () => MaybePromise<void>): void {
+	installHostServiceProcessGuards();
+
+	let retryAttempt = 0;
+	const run = () => {
+		void Promise.resolve()
+			.then(main)
+			.then(() => {
+				retryAttempt = 0;
+			})
+			.catch((error: unknown) => {
+				const delayMs = Math.min(
+					DEFAULT_STARTUP_RETRY_DELAY_MS * 2 ** retryAttempt,
+					DEFAULT_STARTUP_RETRY_MAX_DELAY_MS,
+				);
+				retryAttempt += 1;
+				reportHostServiceError(
+					`failed to start; retrying in ${delayMs}ms`,
+					error,
+				);
+				setTimeout(run, delayMs);
+			});
 	};
+
+	run();
 }

--- a/packages/host-service/src/resilience.ts
+++ b/packages/host-service/src/resilience.ts
@@ -1,0 +1,42 @@
+const HOST_SERVICE_PREFIX = "[host-service]";
+
+let processGuardsInstalled = false;
+
+type MaybePromise<T> = T | Promise<T>;
+
+export function reportHostServiceError(scope: string, error: unknown): void {
+	console.error(`${HOST_SERVICE_PREFIX} ${scope}:`, error);
+}
+
+export function installHostServiceProcessGuards(): void {
+	if (processGuardsInstalled) return;
+	processGuardsInstalled = true;
+
+	process.on("uncaughtException", (error) => {
+		reportHostServiceError("recovered from uncaught exception", error);
+	});
+
+	process.on("unhandledRejection", (reason) => {
+		reportHostServiceError("recovered from unhandled rejection", reason);
+	});
+}
+
+export function runHostServiceBackgroundTask(
+	scope: string,
+	task: () => MaybePromise<unknown>,
+): void {
+	void Promise.resolve()
+		.then(task)
+		.catch((error: unknown) => {
+			reportHostServiceError(scope, error);
+		});
+}
+
+export function createGuardedHandler<Args extends unknown[]>(
+	scope: string,
+	handler: (...args: Args) => MaybePromise<unknown>,
+): (...args: Args) => void {
+	return (...args: Args) => {
+		runHostServiceBackgroundTask(scope, () => handler(...args));
+	};
+}

--- a/packages/host-service/src/runtime/chat/chat.ts
+++ b/packages/host-service/src/runtime/chat/chat.ts
@@ -10,6 +10,7 @@ import { createAuthStorage, createMastraCode } from "mastracode";
 import type { HostDb } from "../../db";
 import { workspaces } from "../../db/schema";
 import type { ModelProviderRuntimeResolver } from "../../providers/model-providers";
+import { reportHostServiceError } from "../../resilience";
 
 type RuntimeHarness = Awaited<ReturnType<typeof createMastraCode>>["harness"];
 type RuntimeMcpManager = Awaited<
@@ -411,32 +412,40 @@ export class ChatRuntimeManager {
 
 	private subscribeToSessionEvents(runtime: RuntimeSession): void {
 		runtime.harness.subscribe((event: unknown) => {
-			if (isHarnessErrorEvent(event) || isHarnessWorkspaceErrorEvent(event)) {
-				runtime.lastErrorMessage = toRuntimeErrorMessage(event.error);
-				return;
-			}
+			try {
+				if (isHarnessErrorEvent(event) || isHarnessWorkspaceErrorEvent(event)) {
+					runtime.lastErrorMessage = toRuntimeErrorMessage(event.error);
+					return;
+				}
 
-			if (isHarnessSandboxAccessRequestEvent(event)) {
-				runtime.pendingSandboxQuestion = {
-					questionId: event.questionId,
-					path: event.path,
-					reason: event.reason,
-				};
-				return;
-			}
+				if (isHarnessSandboxAccessRequestEvent(event)) {
+					runtime.pendingSandboxQuestion = {
+						questionId: event.questionId,
+						path: event.path,
+						reason: event.reason,
+					};
+					return;
+				}
 
-			if (isObjectRecord(event) && event.type === "agent_start") {
-				runtime.lastErrorMessage = null;
-				runtime.pendingSandboxQuestion = null;
-				runtime.answeredQuestionIds.clear();
-				runtime.pendingQuestionResponses.clear();
-				return;
-			}
+				if (isObjectRecord(event) && event.type === "agent_start") {
+					runtime.lastErrorMessage = null;
+					runtime.pendingSandboxQuestion = null;
+					runtime.answeredQuestionIds.clear();
+					runtime.pendingQuestionResponses.clear();
+					return;
+				}
 
-			if (isObjectRecord(event) && event.type === "agent_end") {
-				runtime.pendingSandboxQuestion = null;
-				runtime.answeredQuestionIds.clear();
-				runtime.pendingQuestionResponses.clear();
+				if (isObjectRecord(event) && event.type === "agent_end") {
+					runtime.pendingSandboxQuestion = null;
+					runtime.answeredQuestionIds.clear();
+					runtime.pendingQuestionResponses.clear();
+				}
+			} catch (error) {
+				reportHostServiceError("chat runtime event handler failed", {
+					sessionId: runtime.sessionId,
+					workspaceId: runtime.workspaceId,
+					error,
+				});
 			}
 		});
 	}

--- a/packages/host-service/src/runtime/filesystem/filesystem.ts
+++ b/packages/host-service/src/runtime/filesystem/filesystem.ts
@@ -7,6 +7,7 @@ import {
 import { eq } from "drizzle-orm";
 import type { HostDb } from "../../db";
 import { projects, workspaces } from "../../db/schema";
+import { reportHostServiceError } from "../../resilience";
 
 export interface WorkspaceFilesystemManagerOptions {
 	db: HostDb;
@@ -62,13 +63,24 @@ export class WorkspaceFilesystemManager {
 			});
 			this.serviceCache.set(rootPath, service);
 			// Pre-warm search index so first search is instant
-			getSearchIndex({ rootPath, includeHidden: false }).catch(() => {});
+			getSearchIndex({ rootPath, includeHidden: false }).catch(
+				(error: unknown) => {
+					reportHostServiceError("filesystem search index prewarm failed", {
+						rootPath,
+						error,
+					});
+				},
+			);
 		}
 		return service;
 	}
 
 	async close(): Promise<void> {
 		this.serviceCache.clear();
-		await this.watcherManager.close();
+		try {
+			await this.watcherManager.close();
+		} catch (error) {
+			reportHostServiceError("filesystem watcher manager close failed", error);
+		}
 	}
 }

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -4,6 +4,7 @@ import { parseGitHubRemote } from "@superset/shared/github-remote";
 import { and, eq, inArray } from "drizzle-orm";
 import type { HostDb } from "../../db";
 import { projects, pullRequests, workspaces } from "../../db/schema";
+import { runHostServiceBackgroundTask } from "../../resilience";
 import type { GitFactory } from "../git";
 import { fetchRepositoryPullRequests } from "./utils/github-query";
 import {
@@ -205,25 +206,37 @@ export class PullRequestRuntimeManager {
 		this.github = options.github;
 	}
 
-	start() {
+	start(): void {
 		if (this.branchSyncTimer || this.projectRefreshTimer) return;
 
 		this.branchSyncTimer = setInterval(() => {
-			void this.syncWorkspaceBranches();
+			this.runBackgroundTask("workspace branch sync failed", () =>
+				this.syncWorkspaceBranches(),
+			);
 		}, BRANCH_SYNC_INTERVAL_MS);
 		this.projectRefreshTimer = setInterval(() => {
-			void this.refreshEligibleProjects();
+			this.runBackgroundTask("project refresh failed", () =>
+				this.refreshEligibleProjects(),
+			);
 		}, PROJECT_REFRESH_INTERVAL_MS);
 
-		void this.syncWorkspaceBranches();
-		void this.refreshEligibleProjects(true);
+		this.runBackgroundTask("initial workspace branch sync failed", () =>
+			this.syncWorkspaceBranches(),
+		);
+		this.runBackgroundTask("initial project refresh failed", () =>
+			this.refreshEligibleProjects(true),
+		);
 	}
 
-	stop() {
+	stop(): void {
 		if (this.branchSyncTimer) clearInterval(this.branchSyncTimer);
 		if (this.projectRefreshTimer) clearInterval(this.projectRefreshTimer);
 		this.branchSyncTimer = null;
 		this.projectRefreshTimer = null;
+	}
+
+	private runBackgroundTask(scope: string, task: () => Promise<void>): void {
+		runHostServiceBackgroundTask(`pull-request runtime ${scope}`, task);
 	}
 
 	async getPullRequestsByWorkspaces(

--- a/packages/host-service/src/serve.ts
+++ b/packages/host-service/src/serve.ts
@@ -1,18 +1,12 @@
-import { serve } from "@hono/node-server";
 import { createApp } from "./app";
 import { JwtApiAuthProvider } from "./providers/auth";
 import { LocalGitCredentialProvider } from "./providers/git";
 import { PskHostAuthProvider } from "./providers/host-auth";
 import { LocalModelProvider } from "./providers/model-providers";
-import {
-	installHostServiceProcessGuards,
-	reportHostServiceError,
-	runHostServiceBackgroundTask,
-} from "./resilience";
+import { runHostServiceBackgroundTask, runHostServiceMain } from "./resilience";
+import { startHostServiceServer } from "./server";
 import { initTerminalBaseEnv, resolveTerminalBaseEnv } from "./terminal/env";
 import { connectRelay } from "./tunnel";
-
-const STARTUP_RETRY_DELAY_MS = 5_000;
 
 async function main(): Promise<void> {
 	const { env } = await import("./env");
@@ -40,40 +34,27 @@ async function main(): Promise<void> {
 		},
 	});
 
-	const server = serve({ fetch: app.fetch, port: env.PORT }, (info) => {
-		console.log(`[host-service] listening on http://localhost:${info.port}`);
+	await startHostServiceServer({
+		options: { fetch: app.fetch, port: env.PORT },
+		injectWebSocket,
+		onListen: (info) => {
+			console.log(`[host-service] listening on http://localhost:${info.port}`);
 
-		if (env.RELAY_URL) {
-			const relayUrl = env.RELAY_URL;
-			runHostServiceBackgroundTask("relay startup failed", () =>
-				connectRelay({
-					api,
-					relayUrl,
-					localPort: info.port,
-					organizationId: env.ORGANIZATION_ID,
-					authProvider,
-					hostServiceSecret: env.HOST_SERVICE_SECRET,
-				}),
-			);
-		}
-	});
-	server.on("error", (error) => {
-		reportHostServiceError("server error", error);
-	});
-	try {
-		injectWebSocket(server);
-	} catch (error) {
-		reportHostServiceError("websocket injection failed", error);
-	}
-}
-
-installHostServiceProcessGuards();
-
-function startWithRetry(): void {
-	void main().catch((error) => {
-		reportHostServiceError("failed to start", error);
-		setTimeout(startWithRetry, STARTUP_RETRY_DELAY_MS);
+			if (env.RELAY_URL) {
+				const relayUrl = env.RELAY_URL;
+				runHostServiceBackgroundTask("relay startup failed", () =>
+					connectRelay({
+						api,
+						relayUrl,
+						localPort: info.port,
+						organizationId: env.ORGANIZATION_ID,
+						authProvider,
+						hostServiceSecret: env.HOST_SERVICE_SECRET,
+					}),
+				);
+			}
+		},
 	});
 }
 
-startWithRetry();
+runHostServiceMain(main);

--- a/packages/host-service/src/serve.ts
+++ b/packages/host-service/src/serve.ts
@@ -1,14 +1,21 @@
 import { serve } from "@hono/node-server";
 import { createApp } from "./app";
-import { env } from "./env";
 import { JwtApiAuthProvider } from "./providers/auth";
 import { LocalGitCredentialProvider } from "./providers/git";
 import { PskHostAuthProvider } from "./providers/host-auth";
 import { LocalModelProvider } from "./providers/model-providers";
+import {
+	installHostServiceProcessGuards,
+	reportHostServiceError,
+	runHostServiceBackgroundTask,
+} from "./resilience";
 import { initTerminalBaseEnv, resolveTerminalBaseEnv } from "./terminal/env";
 import { connectRelay } from "./tunnel";
 
+const STARTUP_RETRY_DELAY_MS = 5_000;
+
 async function main(): Promise<void> {
+	const { env } = await import("./env");
 	const terminalBaseEnv = await resolveTerminalBaseEnv();
 	initTerminalBaseEnv(terminalBaseEnv);
 
@@ -37,20 +44,36 @@ async function main(): Promise<void> {
 		console.log(`[host-service] listening on http://localhost:${info.port}`);
 
 		if (env.RELAY_URL) {
-			void connectRelay({
-				api,
-				relayUrl: env.RELAY_URL,
-				localPort: info.port,
-				organizationId: env.ORGANIZATION_ID,
-				authProvider,
-				hostServiceSecret: env.HOST_SERVICE_SECRET,
-			});
+			const relayUrl = env.RELAY_URL;
+			runHostServiceBackgroundTask("relay startup failed", () =>
+				connectRelay({
+					api,
+					relayUrl,
+					localPort: info.port,
+					organizationId: env.ORGANIZATION_ID,
+					authProvider,
+					hostServiceSecret: env.HOST_SERVICE_SECRET,
+				}),
+			);
 		}
 	});
-	injectWebSocket(server);
+	server.on("error", (error) => {
+		reportHostServiceError("server error", error);
+	});
+	try {
+		injectWebSocket(server);
+	} catch (error) {
+		reportHostServiceError("websocket injection failed", error);
+	}
 }
 
-void main().catch((error) => {
-	console.error("[host-service] Failed to start:", error);
-	process.exit(1);
-});
+installHostServiceProcessGuards();
+
+function startWithRetry(): void {
+	void main().catch((error) => {
+		reportHostServiceError("failed to start", error);
+		setTimeout(startWithRetry, STARTUP_RETRY_DELAY_MS);
+	});
+}
+
+startWithRetry();

--- a/packages/host-service/src/server.ts
+++ b/packages/host-service/src/server.ts
@@ -1,0 +1,65 @@
+import type { ServerType } from "@hono/node-server";
+import { serve } from "@hono/node-server";
+import { closeHostServiceServer, reportHostServiceError } from "./resilience";
+
+type ServeOptions = Parameters<typeof serve>[0];
+type ListenInfo = Parameters<NonNullable<Parameters<typeof serve>[1]>>[0];
+
+interface StartHostServiceServerOptions {
+	options: ServeOptions;
+	injectWebSocket: (server: ServerType) => void;
+	onListen?: (info: ListenInfo) => void;
+}
+
+export function startHostServiceServer({
+	options,
+	injectWebSocket,
+	onListen,
+}: StartHostServiceServerOptions): Promise<ServerType> {
+	let server: ServerType | undefined;
+	let isListening = false;
+	let startupSettled = false;
+
+	return new Promise((resolve, reject) => {
+		const rejectStartup = (error: unknown) => {
+			if (startupSettled) {
+				return;
+			}
+			startupSettled = true;
+			if (server) {
+				closeHostServiceServer(server);
+			}
+			reject(error);
+		};
+
+		const resolveStartup = (info: ListenInfo) => {
+			if (!server || startupSettled) {
+				return;
+			}
+			isListening = true;
+			try {
+				onListen?.(info);
+			} catch (error) {
+				rejectStartup(error);
+				return;
+			}
+			startupSettled = true;
+			resolve(server);
+		};
+
+		server = serve(options, resolveStartup);
+		server.on("error", (error) => {
+			if (!isListening) {
+				rejectStartup(error);
+				return;
+			}
+			reportHostServiceError("server error", error);
+		});
+
+		try {
+			injectWebSocket(server);
+		} catch (error) {
+			rejectStartup(error);
+		}
+	});
+}

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -18,6 +18,7 @@ import type { HostDb } from "../db";
 import { projects, terminalSessions, workspaces } from "../db/schema";
 import type { EventBus } from "../events";
 import { portManager } from "../ports/port-manager";
+import { reportHostServiceError } from "../resilience";
 import {
 	buildV2TerminalEnv,
 	getShellLaunchArgs,
@@ -171,9 +172,27 @@ export function listTerminalSessions(
 function sendMessage(
 	socket: { send: (data: string) => void; readyState: number },
 	message: TerminalServerMessage,
-) {
-	if (socket.readyState !== SOCKET_OPEN) return;
-	socket.send(JSON.stringify(message));
+): boolean {
+	if (socket.readyState !== SOCKET_OPEN) return false;
+	try {
+		socket.send(JSON.stringify(message));
+		return true;
+	} catch (error) {
+		reportHostServiceError("terminal websocket send failed", error);
+		return false;
+	}
+}
+
+function closeSocket(
+	socket: { close: (code?: number, reason?: string) => void },
+	code?: number,
+	reason?: string,
+): void {
+	try {
+		socket.close(code, reason);
+	} catch (error) {
+		reportHostServiceError("terminal websocket close failed", error);
+	}
 }
 
 function broadcastMessage(
@@ -191,8 +210,9 @@ function broadcastMessage(
 			}
 			continue;
 		}
-		sendMessage(socket, message);
-		sent += 1;
+		if (sendMessage(socket, message)) {
+			sent += 1;
+		}
 	}
 	return sent;
 }
@@ -265,7 +285,7 @@ export function disposeSession(terminalId: string, db: HostDb) {
 			session.shellReadyTimeoutId = null;
 		}
 		for (const socket of session.sockets) {
-			socket.close(1000, "Session disposed");
+			closeSocket(socket, 1000, "Session disposed");
 		}
 		session.sockets.clear();
 		if (!session.exited) {
@@ -278,12 +298,20 @@ export function disposeSession(terminalId: string, db: HostDb) {
 		sessions.delete(terminalId);
 	}
 
-	portManager.unregisterSession(terminalId);
+	try {
+		portManager.unregisterSession(terminalId);
+	} catch (error) {
+		reportHostServiceError("terminal port unregister failed", error);
+	}
 
-	db.update(terminalSessions)
-		.set({ status: "disposed", endedAt: Date.now() })
-		.where(eq(terminalSessions.id, terminalId))
-		.run();
+	try {
+		db.update(terminalSessions)
+			.set({ status: "disposed", endedAt: Date.now() })
+			.where(eq(terminalSessions.id, terminalId))
+			.run();
+	} catch (error) {
+		reportHostServiceError("terminal disposed status update failed", error);
+	}
 }
 
 /**
@@ -450,77 +478,128 @@ export function createTerminalSessionInternal({
 		scanState: createScanState(),
 	};
 	sessions.set(terminalId, session);
-	portManager.upsertSession(terminalId, workspaceId, pty.pid);
+	try {
+		portManager.upsertSession(terminalId, workspaceId, pty.pid);
+	} catch (error) {
+		reportHostServiceError("terminal port registration failed", error);
+	}
 
 	// If the marker never arrives (broken wrapper, unsupported config),
 	// the timeout unblocks so the session degrades gracefully.
 	if (session.shellReadyState === "pending") {
 		session.shellReadyTimeoutId = setTimeout(() => {
-			resolveShellReady(session, "timed_out");
+			try {
+				resolveShellReady(session, "timed_out");
+			} catch (error) {
+				reportHostServiceError("terminal shell-ready timeout failed", error);
+			}
 		}, SHELL_READY_TIMEOUT_MS);
 	}
 
 	pty.onData((rawData) => {
-		const titleUpdates = scanForTerminalTitle(session.titleScanState, rawData);
-		for (const title of titleUpdates.updates) {
-			setSessionTitle(session, title);
-		}
-
-		// Scan for OSC 133;A and strip it from output
-		let data = rawData;
-		if (session.shellReadyState === "pending") {
-			const result = scanForShellReady(session.scanState, rawData);
-			data = result.output;
-			if (result.matched) {
-				resolveShellReady(session, "ready");
+		try {
+			const titleUpdates = scanForTerminalTitle(
+				session.titleScanState,
+				rawData,
+			);
+			for (const title of titleUpdates.updates) {
+				setSessionTitle(session, title);
 			}
-		}
-		if (data.length === 0) return;
 
-		portManager.checkOutputForHint(data);
+			// Scan for OSC 133;A and strip it from output
+			let data = rawData;
+			if (session.shellReadyState === "pending") {
+				const result = scanForShellReady(session.scanState, rawData);
+				data = result.output;
+				if (result.matched) {
+					resolveShellReady(session, "ready");
+				}
+			}
+			if (data.length === 0) return;
 
-		if (broadcastMessage(session, { type: "data", data }) === 0) {
-			bufferOutput(session, data);
+			try {
+				portManager.checkOutputForHint(data);
+			} catch (error) {
+				reportHostServiceError("terminal port hint scan failed", error);
+			}
+
+			if (broadcastMessage(session, { type: "data", data }) === 0) {
+				bufferOutput(session, data);
+			}
+		} catch (error) {
+			reportHostServiceError("terminal data handler failed", {
+				terminalId,
+				workspaceId,
+				error,
+			});
 		}
 	});
 
 	pty.onExit(({ exitCode, signal }) => {
-		session.exited = true;
-		session.exitCode = exitCode ?? 0;
-		session.exitSignal = signal ?? 0;
+		try {
+			session.exited = true;
+			session.exitCode = exitCode ?? 0;
+			session.exitSignal = signal ?? 0;
 
-		portManager.unregisterSession(terminalId);
+			try {
+				portManager.unregisterSession(terminalId);
+			} catch (error) {
+				reportHostServiceError("terminal exit port unregister failed", error);
+			}
 
-		db.update(terminalSessions)
-			.set({ status: "exited", endedAt: Date.now() })
-			.where(eq(terminalSessions.id, terminalId))
-			.run();
+			try {
+				db.update(terminalSessions)
+					.set({ status: "exited", endedAt: Date.now() })
+					.where(eq(terminalSessions.id, terminalId))
+					.run();
+			} catch (error) {
+				reportHostServiceError("terminal exit status update failed", error);
+			}
 
-		broadcastMessage(session, {
-			type: "exit",
-			exitCode: session.exitCode,
-			signal: session.exitSignal,
-		});
+			broadcastMessage(session, {
+				type: "exit",
+				exitCode: session.exitCode,
+				signal: session.exitSignal,
+			});
 
-		eventBus?.broadcastTerminalLifecycle({
-			workspaceId,
-			terminalId,
-			eventType: "exit",
-			exitCode: session.exitCode,
-			signal: session.exitSignal,
-			occurredAt: Date.now(),
-		});
+			try {
+				eventBus?.broadcastTerminalLifecycle({
+					workspaceId,
+					terminalId,
+					eventType: "exit",
+					exitCode: session.exitCode,
+					signal: session.exitSignal,
+					occurredAt: Date.now(),
+				});
+			} catch (error) {
+				reportHostServiceError("terminal lifecycle broadcast failed", error);
+			}
+		} catch (error) {
+			reportHostServiceError("terminal exit handler failed", {
+				terminalId,
+				workspaceId,
+				error,
+			});
+		}
 	});
 
 	if (initialCommand) {
 		const cmd = initialCommand.endsWith("\n")
 			? initialCommand
 			: `${initialCommand}\n`;
-		session.shellReadyPromise.then(() => {
-			if (!session.exited) {
-				pty.write(cmd);
-			}
-		});
+		session.shellReadyPromise
+			.then(() => {
+				if (!session.exited) {
+					pty.write(cmd);
+				}
+			})
+			.catch((error: unknown) => {
+				reportHostServiceError("terminal initial command write failed", {
+					terminalId,
+					workspaceId,
+					error,
+				});
+			});
 	}
 
 	return session;
@@ -589,110 +668,147 @@ export function registerWorkspaceTerminalRoute({
 
 			return {
 				onOpen: (_event, ws) => {
-					if (!terminalId) {
-						ws.close(1011, "Missing terminalId");
-						return;
-					}
+					try {
+						if (!terminalId) {
+							closeSocket(ws, 1011, "Missing terminalId");
+							return;
+						}
 
-					const existing = sessions.get(terminalId);
-					if (!existing) {
-						// Session must be created via tRPC terminal.ensureSession before connecting.
-						// Fall back to query params for backwards compatibility with v1 callers.
-						const workspaceId = c.req.query("workspaceId") ?? null;
-						if (!workspaceId) {
-							sendMessage(ws, {
-								type: "error",
-								message: `Terminal session "${terminalId}" not found; use terminal.ensureSession or workspaceId.`,
+						const existing = sessions.get(terminalId);
+						if (!existing) {
+							// Session must be created via tRPC terminal.ensureSession before connecting.
+							// Fall back to query params for backwards compatibility with v1 callers.
+							const workspaceId = c.req.query("workspaceId") ?? null;
+							if (!workspaceId) {
+								sendMessage(ws, {
+									type: "error",
+									message: `Terminal session "${terminalId}" not found; use terminal.ensureSession or workspaceId.`,
+								});
+								closeSocket(ws, 1011, "Terminal session not found");
+								return;
+							}
+
+							const themeType = parseThemeType(c.req.query("themeType"));
+							const result = createTerminalSessionInternal({
+								terminalId,
+								workspaceId,
+								themeType,
+								db,
+								eventBus,
 							});
-							ws.close(1011, "Terminal session not found");
+
+							if ("error" in result) {
+								sendMessage(ws, { type: "error", message: result.error });
+								closeSocket(ws, 1011, result.error);
+								return;
+							}
+
+							result.sockets.add(ws);
+							sendMessage(ws, { type: "title", title: result.title });
+
+							db.update(terminalSessions)
+								.set({ lastAttachedAt: Date.now() })
+								.where(eq(terminalSessions.id, terminalId))
+								.run();
 							return;
 						}
 
-						const themeType = parseThemeType(c.req.query("themeType"));
-						const result = createTerminalSessionInternal({
-							terminalId,
-							workspaceId,
-							themeType,
-							db,
-							eventBus,
-						});
-
-						if ("error" in result) {
-							sendMessage(ws, { type: "error", message: result.error });
-							ws.close(1011, result.error);
-							return;
-						}
-
-						result.sockets.add(ws);
-						sendMessage(ws, { type: "title", title: result.title });
+						existing.sockets.add(ws);
 
 						db.update(terminalSessions)
 							.set({ lastAttachedAt: Date.now() })
 							.where(eq(terminalSessions.id, terminalId))
 							.run();
-						return;
-					}
 
-					existing.sockets.add(ws);
-
-					db.update(terminalSessions)
-						.set({ lastAttachedAt: Date.now() })
-						.where(eq(terminalSessions.id, terminalId))
-						.run();
-
-					sendMessage(ws, { type: "title", title: existing.title });
-					replayBuffer(existing, ws);
-					if (existing.exited) {
-						sendMessage(ws, {
-							type: "exit",
-							exitCode: existing.exitCode,
-							signal: existing.exitSignal,
+						sendMessage(ws, { type: "title", title: existing.title });
+						replayBuffer(existing, ws);
+						if (existing.exited) {
+							sendMessage(ws, {
+								type: "exit",
+								exitCode: existing.exitCode,
+								signal: existing.exitSignal,
+							});
+						}
+					} catch (error) {
+						reportHostServiceError("terminal websocket open failed", {
+							terminalId,
+							error,
 						});
+						sendMessage(ws, {
+							type: "error",
+							message: "Failed to open terminal session",
+						});
+						closeSocket(ws, 1011, "Failed to open terminal session");
 					}
 				},
 
 				onMessage: (event, ws) => {
-					const session = sessions.get(terminalId ?? "");
-					if (!session || !session.sockets.has(ws)) return;
-
-					let message: TerminalClientMessage;
 					try {
-						message = JSON.parse(String(event.data)) as TerminalClientMessage;
-					} catch {
+						const session = sessions.get(terminalId ?? "");
+						if (!session || !session.sockets.has(ws)) return;
+
+						let message: TerminalClientMessage;
+						try {
+							message = JSON.parse(String(event.data)) as TerminalClientMessage;
+						} catch {
+							sendMessage(ws, {
+								type: "error",
+								message: "Invalid terminal message payload",
+							});
+							return;
+						}
+
+						if (message.type === "dispose") {
+							disposeSession(terminalId ?? "", db);
+							return;
+						}
+
+						if (session.exited) return;
+
+						if (message.type === "input") {
+							session.pty.write(message.data);
+							return;
+						}
+
+						if (message.type === "resize") {
+							const cols = Math.max(20, Math.floor(message.cols));
+							const rows = Math.max(5, Math.floor(message.rows));
+							session.pty.resize(cols, rows);
+						}
+					} catch (error) {
+						reportHostServiceError("terminal websocket message failed", {
+							terminalId,
+							error,
+						});
 						sendMessage(ws, {
 							type: "error",
-							message: "Invalid terminal message payload",
+							message: "Terminal message failed",
 						});
-						return;
-					}
-
-					if (message.type === "dispose") {
-						disposeSession(terminalId ?? "", db);
-						return;
-					}
-
-					if (session.exited) return;
-
-					if (message.type === "input") {
-						session.pty.write(message.data);
-						return;
-					}
-
-					if (message.type === "resize") {
-						const cols = Math.max(20, Math.floor(message.cols));
-						const rows = Math.max(5, Math.floor(message.rows));
-						session.pty.resize(cols, rows);
 					}
 				},
 
 				onClose: (_event, ws) => {
-					const session = sessions.get(terminalId ?? "");
-					session?.sockets.delete(ws);
+					try {
+						const session = sessions.get(terminalId ?? "");
+						session?.sockets.delete(ws);
+					} catch (error) {
+						reportHostServiceError("terminal websocket close failed", {
+							terminalId,
+							error,
+						});
+					}
 				},
 
 				onError: (_event, ws) => {
-					const session = sessions.get(terminalId ?? "");
-					session?.sockets.delete(ws);
+					try {
+						const session = sessions.get(terminalId ?? "");
+						session?.sockets.delete(ws);
+					} catch (error) {
+						reportHostServiceError("terminal websocket error cleanup failed", {
+							terminalId,
+							error,
+						});
+					}
 				},
 			};
 		}),

--- a/packages/host-service/src/tunnel/connect.ts
+++ b/packages/host-service/src/tunnel/connect.ts
@@ -1,7 +1,10 @@
 import { getHostId, getHostName } from "@superset/shared/host-info";
 import { buildHostRoutingKey } from "@superset/shared/host-routing";
 import type { JwtApiAuthProvider } from "../providers/auth/JwtAuthProvider/JwtAuthProvider";
-import { runHostServiceBackgroundTask } from "../resilience";
+import {
+	reportHostServiceError,
+	runHostServiceBackgroundTask,
+} from "../resilience";
 import type { ApiClient } from "../types";
 import { TunnelClient } from "./tunnel-client";
 
@@ -37,7 +40,7 @@ export async function connectRelay(
 		);
 		return tunnel;
 	} catch (error) {
-		console.error("[host-service] failed to register/connect relay:", error);
+		reportHostServiceError("failed to register/connect relay", error);
 		return null;
 	}
 }

--- a/packages/host-service/src/tunnel/connect.ts
+++ b/packages/host-service/src/tunnel/connect.ts
@@ -1,6 +1,7 @@
 import { getHostId, getHostName } from "@superset/shared/host-info";
 import { buildHostRoutingKey } from "@superset/shared/host-routing";
 import type { JwtApiAuthProvider } from "../providers/auth/JwtAuthProvider/JwtAuthProvider";
+import { runHostServiceBackgroundTask } from "../resilience";
 import type { ApiClient } from "../types";
 import { TunnelClient } from "./tunnel-client";
 
@@ -31,7 +32,9 @@ export async function connectRelay(
 			localPort: options.localPort,
 			hostServiceSecret: options.hostServiceSecret,
 		});
-		void tunnel.connect();
+		runHostServiceBackgroundTask("relay tunnel connect failed", () =>
+			tunnel.connect(),
+		);
 		return tunnel;
 	} catch (error) {
 		console.error("[host-service] failed to register/connect relay:", error);

--- a/packages/host-service/src/tunnel/tunnel-client.ts
+++ b/packages/host-service/src/tunnel/tunnel-client.ts
@@ -1,3 +1,7 @@
+import {
+	reportHostServiceError,
+	runHostServiceBackgroundTask,
+} from "../resilience";
 import type {
 	TunnelHttpRequest,
 	TunnelRequest,
@@ -39,45 +43,52 @@ export class TunnelClient {
 	}
 
 	async connect(): Promise<void> {
-		if (this.closed) return;
+		try {
+			if (this.closed) return;
 
-		const token = await this.getAuthToken();
-		if (!token) {
-			console.warn("[host-service:tunnel] no auth token available, retrying");
-			this.scheduleReconnect();
-			return;
-		}
-
-		const url = new URL("/tunnel", this.relayUrl);
-		url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
-		url.searchParams.set("hostId", this.hostId);
-		url.searchParams.set("token", token);
-
-		const socket = new WebSocket(url.toString());
-		this.socket = socket;
-
-		socket.onopen = () => {
-			this.reconnectAttempts = 0;
-			console.log(
-				`[host-service:tunnel] connected to relay for host ${this.hostId}`,
-			);
-		};
-
-		socket.onmessage = (event) => {
-			void this.handleMessage(event.data);
-		};
-
-		socket.onclose = () => {
-			this.socket = null;
-			this.cleanupChannels();
-			if (!this.closed) {
+			const token = await this.getAuthToken();
+			if (!token) {
+				console.warn("[host-service:tunnel] no auth token available, retrying");
 				this.scheduleReconnect();
+				return;
 			}
-		};
 
-		socket.onerror = (event) => {
-			console.error("[host-service:tunnel] socket error:", event);
-		};
+			const url = new URL("/tunnel", this.relayUrl);
+			url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+			url.searchParams.set("hostId", this.hostId);
+			url.searchParams.set("token", token);
+
+			const socket = new WebSocket(url.toString());
+			this.socket = socket;
+
+			socket.onopen = () => {
+				this.reconnectAttempts = 0;
+				console.log(
+					`[host-service:tunnel] connected to relay for host ${this.hostId}`,
+				);
+			};
+
+			socket.onmessage = (event) => {
+				runHostServiceBackgroundTask("relay tunnel message failed", () =>
+					this.handleMessage(event.data),
+				);
+			};
+
+			socket.onclose = () => {
+				this.socket = null;
+				this.cleanupChannels();
+				if (!this.closed) {
+					this.scheduleReconnect();
+				}
+			};
+
+			socket.onerror = (event) => {
+				console.error("[host-service:tunnel] socket error:", event);
+			};
+		} catch (error) {
+			reportHostServiceError("relay tunnel connect failed", error);
+			this.scheduleReconnect();
+		}
 	}
 
 	close(): void {
@@ -91,14 +102,22 @@ export class TunnelClient {
 			this.socket?.readyState === WebSocket.CONNECTING ||
 			this.socket?.readyState === WebSocket.OPEN
 		) {
-			this.socket.close(1000, "Shutting down");
+			try {
+				this.socket.close(1000, "Shutting down");
+			} catch (error) {
+				reportHostServiceError("relay tunnel socket close failed", error);
+			}
 		}
 		this.socket = null;
 	}
 
 	private send(message: TunnelResponse): void {
 		if (this.socket?.readyState === WebSocket.OPEN) {
-			this.socket.send(JSON.stringify(message));
+			try {
+				this.socket.send(JSON.stringify(message));
+			} catch (error) {
+				reportHostServiceError("relay tunnel send failed", error);
+			}
 		}
 	}
 
@@ -170,43 +189,59 @@ export class TunnelClient {
 	}
 
 	private handleWsOpen(request: TunnelWsOpen): void {
-		const wsUrl = new URL(request.path, `ws://127.0.0.1:${this.localPort}`);
-		wsUrl.searchParams.set("token", this.hostServiceSecret);
-		if (request.query) {
-			const params = new URLSearchParams(request.query);
-			for (const [key, value] of params) {
-				if (key !== "token") {
-					wsUrl.searchParams.set(key, value);
+		try {
+			const wsUrl = new URL(request.path, `ws://127.0.0.1:${this.localPort}`);
+			wsUrl.searchParams.set("token", this.hostServiceSecret);
+			if (request.query) {
+				const params = new URLSearchParams(request.query);
+				for (const [key, value] of params) {
+					if (key !== "token") {
+						wsUrl.searchParams.set(key, value);
+					}
 				}
 			}
+
+			const localWs = new WebSocket(wsUrl.toString());
+
+			localWs.onmessage = (event) => {
+				this.send({
+					type: "ws:frame",
+					id: request.id,
+					data: String(event.data),
+				});
+			};
+
+			localWs.onclose = (event) => {
+				this.localChannels.delete(request.id);
+				this.send({ type: "ws:close", id: request.id, code: event.code });
+			};
+
+			localWs.onerror = (event) => {
+				// onclose always follows onerror; ws:close is sent from onclose
+				console.error(
+					`[host-service:tunnel] local WS error on ${request.path}`,
+					event,
+				);
+			};
+
+			this.localChannels.set(request.id, localWs);
+		} catch (error) {
+			reportHostServiceError("relay tunnel local websocket open failed", error);
+			this.send({ type: "ws:close", id: request.id, code: 1011 });
 		}
-
-		const localWs = new WebSocket(wsUrl.toString());
-
-		localWs.onmessage = (event) => {
-			this.send({ type: "ws:frame", id: request.id, data: String(event.data) });
-		};
-
-		localWs.onclose = (event) => {
-			this.localChannels.delete(request.id);
-			this.send({ type: "ws:close", id: request.id, code: event.code });
-		};
-
-		localWs.onerror = (event) => {
-			// onclose always follows onerror; ws:close is sent from onclose
-			console.error(
-				`[host-service:tunnel] local WS error on ${request.path}`,
-				event,
-			);
-		};
-
-		this.localChannels.set(request.id, localWs);
 	}
 
 	private handleWsFrame(message: TunnelWsFrame): void {
 		const localWs = this.localChannels.get(message.id);
 		if (localWs?.readyState === WebSocket.OPEN) {
-			localWs.send(message.data);
+			try {
+				localWs.send(message.data);
+			} catch (error) {
+				reportHostServiceError(
+					"relay tunnel local websocket send failed",
+					error,
+				);
+			}
 		}
 	}
 
@@ -214,13 +249,24 @@ export class TunnelClient {
 		const localWs = this.localChannels.get(message.id);
 		if (localWs) {
 			this.localChannels.delete(message.id);
-			localWs.close(message.code ?? 1000);
+			try {
+				localWs.close(message.code ?? 1000);
+			} catch (error) {
+				reportHostServiceError(
+					"relay tunnel local websocket close failed",
+					error,
+				);
+			}
 		}
 	}
 
 	private cleanupChannels(): void {
 		for (const ws of this.localChannels.values()) {
-			ws.close(1001, "Tunnel disconnected");
+			try {
+				ws.close(1001, "Tunnel disconnected");
+			} catch (error) {
+				reportHostServiceError("relay tunnel channel cleanup failed", error);
+			}
 		}
 		this.localChannels.clear();
 	}
@@ -240,7 +286,9 @@ export class TunnelClient {
 
 		this.reconnectTimer = setTimeout(() => {
 			this.reconnectTimer = null;
-			void this.connect();
+			runHostServiceBackgroundTask("relay tunnel reconnect failed", () =>
+				this.connect(),
+			);
 		}, delay);
 	}
 }


### PR DESCRIPTION
## Summary

Adds host-service resilience guards so process-level, startup, background-loop, websocket, terminal, and relay failures are logged and isolated instead of taking down the host service.

## Why

The host service owns long-lived desktop runtime state. A single escaped exception from a background watcher, tunnel callback, websocket send, terminal PTY callback, or startup helper could previously terminate the process or leave startup unrecovered.

## Changes

- Add shared host-service error reporting and background task guard helpers.
- Install process-level uncaught exception and unhandled rejection guards in both host-service entrypoints.
- Retry failed top-level startup instead of exiting with code 1.
- Guard app bootstrap, websocket auth/context creation, event bus, git watcher, PR runtime, chat runtime, filesystem prewarm, terminal callbacks, and relay tunnel flows.
- Preserve intentional SIGTERM/SIGINT shutdown behavior.

## Validation

- `bun run --cwd packages/host-service typecheck`
- `bun run --cwd apps/desktop typecheck`
- `bun test packages/host-service` (180 passing)
- `bunx @biomejs/biome@2.4.2 check packages/host-service/src apps/desktop/src/main/host-service/index.ts packages/host-service/package.json`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the host service running on errors with process guards, scoped error reporting, guarded background tasks, and atomic server startup with retry backoff so single failures no longer take it down.

- **Refactors**
  - Added `./server` with `startHostServiceServer`/`closeHostServiceServer`; entrypoints now use `runHostServiceMain` for guarded, retrying startup and atomic listen.
  - Expanded `./resilience`; added `app.onError` and guarded WebSocket auth; run relay connect and main-workspace sweep as background tasks.
  - Wrapped additional paths with try/catch and scoped logs across event bus, git watcher, terminal, and relay tunnel flows.

- **Bug Fixes**
  - Avoid half-starts: pre-listen server errors now reject and trigger backoff retry instead of exiting.
  - Return 500 on API errors; harden WS send/close and cleanup for terminal, event bus, and tunnel; keep relay reconnecting after failures.
  - Make watcher/listener and DB update cleanup safe; preserve SIGTERM/SIGINT shutdown behavior.

<sup>Written for commit 26c2aa6fe7269570e9675fbdcda5b77570b568b9. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3810?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized resilience utilities and managed background task runner.
  * Managed server startup with on-listen handling and automatic startup retry behavior.
  * New public controls for starting/stopping the host-service and process guards.

* **Bug Fixes**
  * Consistent error reporting across services (websockets, tunnels, terminal, git, filesystem, chat).
  * Safer shutdown/cleanup and hardened background task execution to prevent unhandled failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->