### PR TITLE
feat(desktop): persistent v2 sidebar hover card

### DIFF
--- a/apps/desktop/src/renderer/globals.css
+++ b/apps/desktop/src/renderer/globals.css
@@ -295,15 +295,4 @@
 	.tiptap-chat-input p {
 		margin: 0;
 	}
-
-	/* Animate the sidebar hover card sliding between rows. Targets the
-	 * Radix popper wrapper (which carries the position transform) only after
-	 * it has been placed at its anchor (`data-…="ready"`), so the initial
-	 * measuring jump from translate(0, -200%) is not animated. */
-	[data-radix-popper-content-wrapper]:has(
-			> [data-dashboard-sidebar-hover-card="ready"]
-		) {
-		transition: transform 220ms cubic-bezier(0.32, 0.72, 0, 1);
-		will-change: transform;
-	}
 }

--- a/apps/desktop/src/renderer/globals.css
+++ b/apps/desktop/src/renderer/globals.css
@@ -295,4 +295,15 @@
 	.tiptap-chat-input p {
 		margin: 0;
 	}
+
+	/* Animate the sidebar hover card sliding between rows. Targets the
+	 * Radix popper wrapper (which carries the position transform) only after
+	 * it has been placed at its anchor (`data-…="ready"`), so the initial
+	 * measuring jump from translate(0, -200%) is not animated. */
+	[data-radix-popper-content-wrapper]:has(
+			> [data-dashboard-sidebar-hover-card="ready"]
+		) {
+		transition: transform 220ms cubic-bezier(0.32, 0.72, 0, 1);
+		will-change: transform;
+	}
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
@@ -22,11 +22,13 @@ import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { DashboardSidebarHeader } from "./components/DashboardSidebarHeader";
+import { DashboardSidebarHoverCardOverlay } from "./components/DashboardSidebarHoverCardOverlay";
 import { DashboardSidebarPortsList } from "./components/DashboardSidebarPortsList";
 import { DashboardSidebarProjectSection } from "./components/DashboardSidebarProjectSection";
 import { DashboardSidebarSectionRenameProvider } from "./components/DashboardSidebarSectionRenameContext";
 import { useDashboardSidebarData } from "./hooks/useDashboardSidebarData";
 import { useDashboardSidebarShortcuts } from "./hooks/useDashboardSidebarShortcuts";
+import { DashboardSidebarHoverProvider } from "./providers/DashboardSidebarHoverProvider";
 import type { DashboardSidebarProject } from "./types";
 
 interface DashboardSidebarProps {
@@ -136,61 +138,65 @@ export function DashboardSidebar({
 
 	return (
 		<DashboardSidebarSectionRenameProvider>
-			<div className="flex h-full flex-col border-r border-border bg-muted/45 dark:bg-muted/35">
-				<DashboardSidebarHeader isCollapsed={isCollapsed} />
+			<DashboardSidebarHoverProvider>
+				<DashboardSidebarHoverCardOverlay>
+					<div className="flex h-full flex-col border-r border-border bg-muted/45 dark:bg-muted/35">
+						<DashboardSidebarHeader isCollapsed={isCollapsed} />
 
-				<div className="flex-1 overflow-y-auto hide-scrollbar">
-					<DndContext
-						sensors={sensors}
-						collisionDetection={closestCenter}
-						measuring={{
-							droppable: { strategy: MeasuringStrategy.Always },
-						}}
-						onDragStart={({ active }) => {
-							const project = groups.find((p) => p.id === active.id);
-							setActiveProject(project ?? null);
-						}}
-						onDragEnd={handleDragEnd}
-						onDragCancel={() => setActiveProject(null)}
-					>
-						<SortableContext
-							items={projectOrder}
-							strategy={verticalListSortingStrategy}
-						>
-							{orderedGroups.map((project) => (
-								<SortableProjectWrapper
-									key={project.id}
-									project={project}
-									isCollapsed={isCollapsed}
-									isDraggingProject={activeProject != null}
-									workspaceShortcutLabels={workspaceShortcutLabels}
-									onWorkspaceHover={refreshWorkspacePullRequest}
-									onToggleCollapse={toggleProjectCollapsed}
-								/>
-							))}
-						</SortableContext>
-
-						{createPortal(
-							<DragOverlay dropAnimation={null}>
-								{activeProject && (
-									<div className="bg-background shadow-lg border-b border-border">
-										<DashboardSidebarProjectSection
-											project={activeProject}
-											isSidebarCollapsed={isCollapsed}
-											isDraggingProject
+						<div className="flex-1 overflow-y-auto hide-scrollbar">
+							<DndContext
+								sensors={sensors}
+								collisionDetection={closestCenter}
+								measuring={{
+									droppable: { strategy: MeasuringStrategy.Always },
+								}}
+								onDragStart={({ active }) => {
+									const project = groups.find((p) => p.id === active.id);
+									setActiveProject(project ?? null);
+								}}
+								onDragEnd={handleDragEnd}
+								onDragCancel={() => setActiveProject(null)}
+							>
+								<SortableContext
+									items={projectOrder}
+									strategy={verticalListSortingStrategy}
+								>
+									{orderedGroups.map((project) => (
+										<SortableProjectWrapper
+											key={project.id}
+											project={project}
+											isCollapsed={isCollapsed}
+											isDraggingProject={activeProject != null}
 											workspaceShortcutLabels={workspaceShortcutLabels}
-											onWorkspaceHover={() => {}}
-											onToggleCollapse={() => {}}
+											onWorkspaceHover={refreshWorkspacePullRequest}
+											onToggleCollapse={toggleProjectCollapsed}
 										/>
-									</div>
+									))}
+								</SortableContext>
+
+								{createPortal(
+									<DragOverlay dropAnimation={null}>
+										{activeProject && (
+											<div className="bg-background shadow-lg border-b border-border">
+												<DashboardSidebarProjectSection
+													project={activeProject}
+													isSidebarCollapsed={isCollapsed}
+													isDraggingProject
+													workspaceShortcutLabels={workspaceShortcutLabels}
+													onWorkspaceHover={() => {}}
+													onToggleCollapse={() => {}}
+												/>
+											</div>
+										)}
+									</DragOverlay>,
+									document.body,
 								)}
-							</DragOverlay>,
-							document.body,
-						)}
-					</DndContext>
-				</div>
-				{!isCollapsed && <DashboardSidebarPortsList />}
-			</div>
+							</DndContext>
+						</div>
+						{!isCollapsed && <DashboardSidebarPortsList />}
+					</div>
+				</DashboardSidebarHoverCardOverlay>
+			</DashboardSidebarHoverProvider>
 		</DashboardSidebarSectionRenameProvider>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHoverCardOverlay/DashboardSidebarHoverCardOverlay.css
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHoverCardOverlay/DashboardSidebarHoverCardOverlay.css
@@ -1,0 +1,10 @@
+/* Animate the sidebar hover card sliding between rows. Targets the
+ * Radix popper wrapper (which carries the position transform) only after
+ * it has been placed at its anchor (`data-…="ready"`), so the initial
+ * measuring jump from translate(0, -200%) is not animated. */
+[data-radix-popper-content-wrapper]:has(
+		> [data-dashboard-sidebar-hover-card="ready"]
+	) {
+	transition: transform 220ms cubic-bezier(0.32, 0.72, 0, 1);
+	will-change: transform;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHoverCardOverlay/DashboardSidebarHoverCardOverlay.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHoverCardOverlay/DashboardSidebarHoverCardOverlay.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { useDiffStats } from "renderer/hooks/host-service/useDiffStats";
 import { useDashboardSidebarHover } from "../../providers/DashboardSidebarHoverProvider";
 import { DashboardSidebarWorkspaceHoverCardContent } from "../DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceHoverCardContent";
+import "./DashboardSidebarHoverCardOverlay.css";
 
 type Measurable = { getBoundingClientRect(): DOMRect };
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHoverCardOverlay/DashboardSidebarHoverCardOverlay.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHoverCardOverlay/DashboardSidebarHoverCardOverlay.tsx
@@ -1,0 +1,80 @@
+import { Popover, PopoverAnchor, PopoverContent } from "@superset/ui/popover";
+import type { RefObject } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useDiffStats } from "renderer/hooks/host-service/useDiffStats";
+import { useDashboardSidebarHover } from "../../providers/DashboardSidebarHoverProvider";
+import { DashboardSidebarWorkspaceHoverCardContent } from "../DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceHoverCardContent";
+
+type Measurable = { getBoundingClientRect(): DOMRect };
+
+export function DashboardSidebarHoverCardOverlay({
+	children,
+}: {
+	children: React.ReactNode;
+}) {
+	const {
+		hoveredId,
+		anchorElement,
+		payload,
+		contextMenuOpen,
+		cancelClose,
+		requestClose,
+		forceClose,
+	} = useDashboardSidebarHover();
+
+	const virtualRef = useRef<Measurable | null>(null);
+	virtualRef.current = anchorElement;
+
+	const open = hoveredId !== null && payload !== null && !contextMenuOpen;
+	const diffStats = useDiffStats(hoveredId ?? "");
+
+	// Suppress the transform transition until Radix has placed the popover at
+	// its real anchor — otherwise the initial jump from the off-screen measuring
+	// position (translate(0, -200%)) gets animated.
+	const [hasPositioned, setHasPositioned] = useState(false);
+	const frameRef = useRef<number | null>(null);
+	useEffect(() => {
+		if (!open) {
+			setHasPositioned(false);
+			return;
+		}
+		const first = requestAnimationFrame(() => {
+			frameRef.current = requestAnimationFrame(() => setHasPositioned(true));
+		});
+		frameRef.current = first;
+		return () => {
+			if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
+		};
+	}, [open]);
+
+	return (
+		<Popover
+			open={open}
+			onOpenChange={(nextOpen) => {
+				if (!nextOpen) forceClose();
+			}}
+		>
+			{children}
+			<PopoverAnchor virtualRef={virtualRef as RefObject<Measurable>} />
+			{payload && (
+				<PopoverContent
+					side="right"
+					align="start"
+					className="w-72"
+					data-dashboard-sidebar-hover-card={hasPositioned ? "ready" : ""}
+					onOpenAutoFocus={(event) => event.preventDefault()}
+					onPointerEnter={cancelClose}
+					onPointerLeave={() => {
+						if (hoveredId) requestClose(hoveredId);
+					}}
+				>
+					<DashboardSidebarWorkspaceHoverCardContent
+						workspace={payload.workspace}
+						diffStats={diffStats}
+						onEditBranchClick={payload.onEditBranchClick}
+					/>
+				</PopoverContent>
+			)}
+		</Popover>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHoverCardOverlay/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHoverCardOverlay/index.ts
@@ -1,0 +1,1 @@
+export { DashboardSidebarHoverCardOverlay } from "./DashboardSidebarHoverCardOverlay";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -1,16 +1,16 @@
 import { useNavigate } from "@tanstack/react-router";
-import { useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useDiffStats } from "renderer/hooks/host-service/useDiffStats";
 import { useOptimisticCollectionActions } from "renderer/routes/_authenticated/hooks/useOptimisticCollectionActions";
 import { useDeletingWorkspaces } from "renderer/routes/_authenticated/providers/DeletingWorkspacesProvider";
 import { RenameBranchDialog } from "renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components";
 import { useV2WorkspaceNotificationStatus } from "renderer/stores/v2-notifications";
+import { useDashboardSidebarHover } from "../../providers/DashboardSidebarHoverProvider";
 import type { DashboardSidebarWorkspace } from "../../types";
 import { DashboardSidebarDeleteDialog } from "../DashboardSidebarDeleteDialog";
 import { DashboardSidebarCollapsedWorkspaceButton } from "./components/DashboardSidebarCollapsedWorkspaceButton";
 import { DashboardSidebarExpandedWorkspaceRow } from "./components/DashboardSidebarExpandedWorkspaceRow";
 import { DashboardSidebarWorkspaceContextMenu } from "./components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu";
-import { DashboardSidebarWorkspaceHoverCardContent } from "./components/DashboardSidebarWorkspaceHoverCardContent";
 import { useDashboardSidebarWorkspaceItemActions } from "./hooks/useDashboardSidebarWorkspaceItemActions";
 
 interface DashboardSidebarWorkspaceItemProps {
@@ -89,9 +89,46 @@ export function DashboardSidebarWorkspaceItem({
 			}
 		: undefined;
 
+	const {
+		hoveredId: hoverHoveredId,
+		requestOpen: hoverRequestOpen,
+		requestClose: hoverRequestClose,
+		syncIfHovered: hoverSyncIfHovered,
+	} = useDashboardSidebarHover();
+	const rowRef = useRef<HTMLDivElement>(null);
+	const hoverEligible = !isPending;
+	const hoverPayload = useMemo(
+		() => ({ workspace, onEditBranchClick: setRenameBranchTarget }),
+		[workspace],
+	);
+
+	const handleMouseEnter = useCallback(() => {
+		if (!hoverEligible || !rowRef.current) return;
+		hoverRequestOpen(id, rowRef.current, hoverPayload);
+	}, [hoverEligible, hoverRequestOpen, id, hoverPayload]);
+	const handleMouseLeave = useCallback(() => {
+		if (!hoverEligible) return;
+		hoverRequestClose(id);
+	}, [hoverEligible, hoverRequestClose, id]);
+
+	const isHovered = hoverHoveredId === id;
+	useEffect(() => {
+		if (isHovered && hostType === "local-device") onHoverCardOpen?.();
+	}, [isHovered, hostType, onHoverCardOpen]);
+	useEffect(() => {
+		if (!isHovered) return;
+		hoverSyncIfHovered(id, hoverPayload);
+	}, [isHovered, hoverSyncIfHovered, id, hoverPayload]);
+
 	if (isCollapsed) {
 		const content = (
-			<div className="relative flex w-full justify-center">
+			// biome-ignore lint/a11y/noStaticElementInteractions: hover handlers drive a non-interactive popover, no new keyboard semantics
+			<div
+				ref={rowRef}
+				onMouseEnter={handleMouseEnter}
+				onMouseLeave={handleMouseLeave}
+				className="relative flex w-full justify-center"
+			>
 				{(accentColor || isActive) && (
 					<div
 						className="absolute inset-y-0 left-0 w-0.5"
@@ -126,16 +163,6 @@ export function DashboardSidebarWorkspaceItem({
 							projectId={projectId}
 							isInSection={isInSection}
 							isUnread={isUnread}
-							onHoverCardOpen={
-								hostType === "local-device" ? onHoverCardOpen : undefined
-							}
-							hoverCardContent={
-								<DashboardSidebarWorkspaceHoverCardContent
-									workspace={workspace}
-									diffStats={diffStats}
-									onEditBranchClick={setRenameBranchTarget}
-								/>
-							}
 							isLocalWorkspace={hostType === "local-device"}
 							onCreateSection={handleCreateSection}
 							onMoveToSection={(targetSectionId) =>
@@ -181,22 +208,29 @@ export function DashboardSidebarWorkspaceItem({
 	}
 
 	const expandedContent = (
-		<DashboardSidebarExpandedWorkspaceRow
-			workspace={workspace}
-			isActive={isActive}
-			isRenaming={isRenaming}
-			renameValue={renameValue}
-			shortcutLabel={shortcutLabel}
-			diffStats={isPending ? null : diffStats}
-			workspaceStatus={workspaceStatus}
-			onClick={isPending ? handlePendingClick : handleClick}
-			onDoubleClick={isPending ? undefined : startRename}
-			onRemoveFromSidebarClick={handleRemoveFromSidebar}
-			onCloseWorkspaceClick={() => setIsDeleteDialogOpen(true)}
-			onRenameValueChange={setRenameValue}
-			onSubmitRename={submitRename}
-			onCancelRename={cancelRename}
-		/>
+		// biome-ignore lint/a11y/noStaticElementInteractions: hover handlers drive a non-interactive popover, no new keyboard semantics
+		<div
+			ref={rowRef}
+			onMouseEnter={handleMouseEnter}
+			onMouseLeave={handleMouseLeave}
+		>
+			<DashboardSidebarExpandedWorkspaceRow
+				workspace={workspace}
+				isActive={isActive}
+				isRenaming={isRenaming}
+				renameValue={renameValue}
+				shortcutLabel={shortcutLabel}
+				diffStats={isPending ? null : diffStats}
+				workspaceStatus={workspaceStatus}
+				onClick={isPending ? handlePendingClick : handleClick}
+				onDoubleClick={isPending ? undefined : startRename}
+				onRemoveFromSidebarClick={handleRemoveFromSidebar}
+				onCloseWorkspaceClick={() => setIsDeleteDialogOpen(true)}
+				onRenameValueChange={setRenameValue}
+				onSubmitRename={submitRename}
+				onCancelRename={cancelRename}
+			/>
+		</div>
 	);
 
 	return (
@@ -209,16 +243,6 @@ export function DashboardSidebarWorkspaceItem({
 						projectId={projectId}
 						isInSection={isInSection}
 						isUnread={isUnread}
-						onHoverCardOpen={
-							hostType === "local-device" ? onHoverCardOpen : undefined
-						}
-						hoverCardContent={
-							<DashboardSidebarWorkspaceHoverCardContent
-								workspace={workspace}
-								diffStats={diffStats}
-								onEditBranchClick={setRenameBranchTarget}
-							/>
-						}
 						onCreateSection={handleCreateSection}
 						onMoveToSection={(targetSectionId) =>
 							moveWorkspaceToSection(id, projectId, targetSectionId)

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
@@ -8,14 +8,8 @@ import {
 	ContextMenuSubTrigger,
 	ContextMenuTrigger,
 } from "@superset/ui/context-menu";
-import {
-	HoverCard,
-	HoverCardContent,
-	HoverCardTrigger,
-} from "@superset/ui/hover-card";
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
-import { useState } from "react";
 import {
 	LuArrowRightLeft,
 	LuArrowUp,
@@ -30,14 +24,13 @@ import {
 	LuX,
 } from "react-icons/lu";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useDashboardSidebarHover } from "../../../../providers/DashboardSidebarHoverProvider";
 
 interface DashboardSidebarWorkspaceContextMenuProps {
-	hoverCardContent?: React.ReactNode;
 	projectId: string;
 	isInSection?: boolean;
 	isLocalWorkspace: boolean;
 	isUnread: boolean;
-	onHoverCardOpen?: () => void;
 	onCreateSection: () => void;
 	onMoveToSection: (sectionId: string | null) => void;
 	onOpenInFinder: () => void;
@@ -55,8 +48,6 @@ export function DashboardSidebarWorkspaceContextMenu({
 	isInSection,
 	isLocalWorkspace,
 	isUnread,
-	onHoverCardOpen,
-	hoverCardContent,
 	onCreateSection,
 	onMoveToSection,
 	onOpenInFinder,
@@ -69,7 +60,7 @@ export function DashboardSidebarWorkspaceContextMenu({
 	children,
 }: DashboardSidebarWorkspaceContextMenuProps) {
 	const collections = useCollections();
-	const [isContextMenuOpen, setIsContextMenuOpen] = useState(false);
+	const { setContextMenuOpen } = useDashboardSidebarHover();
 	const { data: sections = [] } = useLiveQuery(
 		(q) =>
 			q
@@ -86,129 +77,100 @@ export function DashboardSidebarWorkspaceContextMenu({
 		[collections, projectId],
 	);
 
-	const menuContent = (
-		<ContextMenuContent onCloseAutoFocus={(event) => event.preventDefault()}>
-			<ContextMenuItem onSelect={onRename}>
-				<LuPencil className="size-4 mr-2" />
-				Rename
-			</ContextMenuItem>
-			{isLocalWorkspace && (
-				<>
-					<ContextMenuSeparator />
-					<ContextMenuItem onSelect={onOpenInFinder}>
-						<LuFolderOpen className="size-4 mr-2" />
-						Open in Finder
-					</ContextMenuItem>
-					<ContextMenuItem onSelect={onCopyPath}>
-						<LuCopy className="size-4 mr-2" />
-						Copy Path
-					</ContextMenuItem>
-				</>
-			)}
-			{!isLocalWorkspace && <ContextMenuSeparator />}
-			<ContextMenuItem onSelect={onCopyBranchName}>
-				<LuGitBranch className="size-4 mr-2" />
-				Copy Branch Name
-			</ContextMenuItem>
-			<ContextMenuSeparator />
-			<ContextMenuItem onSelect={onToggleUnread}>
-				{isUnread ? (
+	return (
+		<ContextMenu onOpenChange={setContextMenuOpen}>
+			<ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+			<ContextMenuContent onCloseAutoFocus={(event) => event.preventDefault()}>
+				<ContextMenuItem onSelect={onRename}>
+					<LuPencil className="size-4 mr-2" />
+					Rename
+				</ContextMenuItem>
+				{isLocalWorkspace && (
 					<>
-						<LuEye className="size-4 mr-2" />
-						Mark as Read
-					</>
-				) : (
-					<>
-						<LuEyeOff className="size-4 mr-2" />
-						Mark as Unread
+						<ContextMenuSeparator />
+						<ContextMenuItem onSelect={onOpenInFinder}>
+							<LuFolderOpen className="size-4 mr-2" />
+							Open in Finder
+						</ContextMenuItem>
+						<ContextMenuItem onSelect={onCopyPath}>
+							<LuCopy className="size-4 mr-2" />
+							Copy Path
+						</ContextMenuItem>
 					</>
 				)}
-			</ContextMenuItem>
-			<ContextMenuSeparator />
-			<ContextMenuItem onSelect={onCreateSection}>
-				<LuFolderPlus className="size-4 mr-2" />
-				New group from workspace
-			</ContextMenuItem>
-			{(sections.length > 0 || isInSection) && <ContextMenuSeparator />}
-			{sections.length > 0 && (
-				<ContextMenuSub>
-					<ContextMenuSubTrigger>
-						<LuArrowRightLeft className="size-4 mr-2" />
-						Move to group
-					</ContextMenuSubTrigger>
-					<ContextMenuSubContent>
-						{sections.map((section) => (
-							<ContextMenuItem
-								key={section.id}
-								onSelect={() => onMoveToSection(section.id)}
-							>
-								{section.color && (
-									<span
-										className="size-2 shrink-0 rounded-full mr-2"
-										style={{ backgroundColor: section.color }}
-									/>
-								)}
-								{section.name}
-							</ContextMenuItem>
-						))}
-					</ContextMenuSubContent>
-				</ContextMenuSub>
-			)}
-			{isInSection && (
-				<ContextMenuItem onSelect={() => onMoveToSection(null)}>
-					<LuArrowUp className="size-4 mr-2" />
-					Ungroup
+				{!isLocalWorkspace && <ContextMenuSeparator />}
+				<ContextMenuItem onSelect={onCopyBranchName}>
+					<LuGitBranch className="size-4 mr-2" />
+					Copy Branch Name
 				</ContextMenuItem>
-			)}
-			<ContextMenuSeparator />
-			<ContextMenuItem
-				onSelect={onRemoveFromSidebar}
-				className="text-destructive focus:text-destructive"
-			>
-				<LuX className="size-4 mr-2 text-destructive" />
-				Remove from Sidebar
-			</ContextMenuItem>
-			{onDelete ? (
+				<ContextMenuSeparator />
+				<ContextMenuItem onSelect={onToggleUnread}>
+					{isUnread ? (
+						<>
+							<LuEye className="size-4 mr-2" />
+							Mark as Read
+						</>
+					) : (
+						<>
+							<LuEyeOff className="size-4 mr-2" />
+							Mark as Unread
+						</>
+					)}
+				</ContextMenuItem>
+				<ContextMenuSeparator />
+				<ContextMenuItem onSelect={onCreateSection}>
+					<LuFolderPlus className="size-4 mr-2" />
+					New group from workspace
+				</ContextMenuItem>
+				{(sections.length > 0 || isInSection) && <ContextMenuSeparator />}
+				{sections.length > 0 && (
+					<ContextMenuSub>
+						<ContextMenuSubTrigger>
+							<LuArrowRightLeft className="size-4 mr-2" />
+							Move to group
+						</ContextMenuSubTrigger>
+						<ContextMenuSubContent>
+							{sections.map((section) => (
+								<ContextMenuItem
+									key={section.id}
+									onSelect={() => onMoveToSection(section.id)}
+								>
+									{section.color && (
+										<span
+											className="size-2 shrink-0 rounded-full mr-2"
+											style={{ backgroundColor: section.color }}
+										/>
+									)}
+									{section.name}
+								</ContextMenuItem>
+							))}
+						</ContextMenuSubContent>
+					</ContextMenuSub>
+				)}
+				{isInSection && (
+					<ContextMenuItem onSelect={() => onMoveToSection(null)}>
+						<LuArrowUp className="size-4 mr-2" />
+						Ungroup
+					</ContextMenuItem>
+				)}
+				<ContextMenuSeparator />
 				<ContextMenuItem
-					onSelect={onDelete}
+					onSelect={onRemoveFromSidebar}
 					className="text-destructive focus:text-destructive"
 				>
-					<LuTrash2 className="size-4 mr-2 text-destructive" />
-					Delete
+					<LuX className="size-4 mr-2 text-destructive" />
+					Remove from Sidebar
 				</ContextMenuItem>
-			) : null}
-		</ContextMenuContent>
-	);
-
-	if (!hoverCardContent) {
-		return (
-			<ContextMenu>
-				<ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
-				{menuContent}
-			</ContextMenu>
-		);
-	}
-
-	return (
-		<HoverCard
-			open={isContextMenuOpen ? false : undefined}
-			openDelay={400}
-			closeDelay={100}
-			onOpenChange={(open) => {
-				if (open) {
-					onHoverCardOpen?.();
-				}
-			}}
-		>
-			<ContextMenu onOpenChange={setIsContextMenuOpen}>
-				<HoverCardTrigger asChild>
-					<ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
-				</HoverCardTrigger>
-				{menuContent}
-			</ContextMenu>
-			<HoverCardContent side="right" align="start" className="w-72">
-				{hoverCardContent}
-			</HoverCardContent>
-		</HoverCard>
+				{onDelete ? (
+					<ContextMenuItem
+						onSelect={onDelete}
+						className="text-destructive focus:text-destructive"
+					>
+						<LuTrash2 className="size-4 mr-2 text-destructive" />
+						Delete
+					</ContextMenuItem>
+				) : null}
+			</ContextMenuContent>
+		</ContextMenu>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarHoverProvider/DashboardSidebarHoverProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarHoverProvider/DashboardSidebarHoverProvider.tsx
@@ -1,0 +1,185 @@
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
+import type { DashboardSidebarWorkspace } from "../../types";
+
+const OPEN_DELAY_MS = 400;
+const CLOSE_DELAY_MS = 100;
+
+export interface DashboardSidebarHoverPayload {
+	workspace: DashboardSidebarWorkspace;
+	onEditBranchClick: (branchName: string) => void;
+}
+
+interface HoverState {
+	hoveredId: string | null;
+	anchorElement: HTMLElement | null;
+	payload: DashboardSidebarHoverPayload | null;
+}
+
+interface HoverContextValue {
+	hoveredId: string | null;
+	anchorElement: HTMLElement | null;
+	payload: DashboardSidebarHoverPayload | null;
+	contextMenuOpen: boolean;
+	requestOpen: (
+		id: string,
+		anchor: HTMLElement,
+		payload: DashboardSidebarHoverPayload,
+	) => void;
+	requestClose: (id: string) => void;
+	cancelClose: () => void;
+	forceClose: () => void;
+	setContextMenuOpen: (open: boolean) => void;
+	syncIfHovered: (id: string, payload: DashboardSidebarHoverPayload) => void;
+}
+
+const HoverContext = createContext<HoverContextValue | null>(null);
+
+export function DashboardSidebarHoverProvider({
+	children,
+}: {
+	children: React.ReactNode;
+}) {
+	const [state, setState] = useState<HoverState>({
+		hoveredId: null,
+		anchorElement: null,
+		payload: null,
+	});
+	const [contextMenuOpen, setContextMenuOpen] = useState(false);
+
+	const stateRef = useRef(state);
+	useEffect(() => {
+		stateRef.current = state;
+	}, [state]);
+
+	const openTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	const clearOpenTimer = useCallback(() => {
+		if (openTimerRef.current) {
+			clearTimeout(openTimerRef.current);
+			openTimerRef.current = null;
+		}
+	}, []);
+	const clearCloseTimer = useCallback(() => {
+		if (closeTimerRef.current) {
+			clearTimeout(closeTimerRef.current);
+			closeTimerRef.current = null;
+		}
+	}, []);
+
+	const requestOpen = useCallback<HoverContextValue["requestOpen"]>(
+		(id, anchor, payload) => {
+			clearCloseTimer();
+			if (stateRef.current.hoveredId !== null) {
+				clearOpenTimer();
+				setState({ hoveredId: id, anchorElement: anchor, payload });
+				return;
+			}
+			clearOpenTimer();
+			openTimerRef.current = setTimeout(() => {
+				setState({ hoveredId: id, anchorElement: anchor, payload });
+				openTimerRef.current = null;
+			}, OPEN_DELAY_MS);
+		},
+		[clearCloseTimer, clearOpenTimer],
+	);
+
+	const requestClose = useCallback<HoverContextValue["requestClose"]>(
+		(id) => {
+			if (openTimerRef.current && stateRef.current.hoveredId === null) {
+				// Pending open for this id — cancel it.
+				clearOpenTimer();
+				return;
+			}
+			if (stateRef.current.hoveredId !== id) return;
+			clearCloseTimer();
+			closeTimerRef.current = setTimeout(() => {
+				setState({ hoveredId: null, anchorElement: null, payload: null });
+				closeTimerRef.current = null;
+			}, CLOSE_DELAY_MS);
+		},
+		[clearCloseTimer, clearOpenTimer],
+	);
+
+	const cancelClose = useCallback(() => {
+		clearCloseTimer();
+	}, [clearCloseTimer]);
+
+	const forceClose = useCallback(() => {
+		clearOpenTimer();
+		clearCloseTimer();
+		setState({ hoveredId: null, anchorElement: null, payload: null });
+	}, [clearCloseTimer, clearOpenTimer]);
+
+	const syncIfHovered = useCallback<HoverContextValue["syncIfHovered"]>(
+		(id, payload) => {
+			setState((prev) => {
+				if (prev.hoveredId !== id) return prev;
+				if (
+					prev.payload?.workspace === payload.workspace &&
+					prev.payload.onEditBranchClick === payload.onEditBranchClick
+				) {
+					return prev;
+				}
+				return { ...prev, payload };
+			});
+		},
+		[],
+	);
+
+	useEffect(
+		() => () => {
+			clearOpenTimer();
+			clearCloseTimer();
+		},
+		[clearCloseTimer, clearOpenTimer],
+	);
+
+	const value = useMemo<HoverContextValue>(
+		() => ({
+			hoveredId: state.hoveredId,
+			anchorElement: state.anchorElement,
+			payload: state.payload,
+			contextMenuOpen,
+			requestOpen,
+			requestClose,
+			cancelClose,
+			forceClose,
+			setContextMenuOpen,
+			syncIfHovered,
+		}),
+		[
+			state.hoveredId,
+			state.anchorElement,
+			state.payload,
+			contextMenuOpen,
+			requestOpen,
+			requestClose,
+			cancelClose,
+			forceClose,
+			syncIfHovered,
+		],
+	);
+
+	return (
+		<HoverContext.Provider value={value}>{children}</HoverContext.Provider>
+	);
+}
+
+export function useDashboardSidebarHover() {
+	const ctx = useContext(HoverContext);
+	if (!ctx) {
+		throw new Error(
+			"useDashboardSidebarHover must be used inside DashboardSidebarHoverProvider",
+		);
+	}
+	return ctx;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarHoverProvider/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarHoverProvider/index.ts
@@ -1,0 +1,5 @@
+export {
+	type DashboardSidebarHoverPayload,
+	DashboardSidebarHoverProvider,
+	useDashboardSidebarHover,
+} from "./DashboardSidebarHoverProvider";

--- a/bun.lock
+++ b/bun.lock
@@ -110,7 +110,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.43",
         "@ai-sdk/openai": "3.0.36",


### PR DESCRIPTION
## Summary
- Replaces the per-row Radix HoverCard wrappers in the v2 dashboard sidebar with a single sidebar-level Popover. Moving between rows now slides the same panel and updates content in place, instead of unmounting and remounting (and re-paying the 400ms open delay).
- New `DashboardSidebarHoverProvider` owns the hover state (open/close timers, anchor element, payload, context-menu suppression). New `DashboardSidebarHoverCardOverlay` renders one `Popover` + `PopoverAnchor virtualRef` and reuses the existing `DashboardSidebarWorkspaceHoverCardContent`.
- A `data-positioned` flag suppresses the slide transition during the initial open so we don't animate from Radix's off-screen measuring transform.
- Cloud workspaces now show the hover card again; only the PR-refresh callback (`onHoverCardOpen`) is still gated to local-device hosts.

v1 sidebar (`WorkspaceHoverCard` under `screens/main/...`) is untouched — it's still the default path for users who haven't opted into v2.

## Test plan
- [ ] Toggle v2 cloud on, hover a workspace row, panel appears anchored to the right.
- [ ] Hover-drag across several neighboring rows: panel slides between rows with content swap, no flicker.
- [ ] Move cursor from row into the panel: stays open, "View on GitHub" / "Open Preview" / edit branch all clickable.
- [ ] Right-click a row: panel closes, context menu opens.
- [ ] Hover a cloud (non-local-device) workspace: hover card appears.
- [ ] Hover a pending workspace: hover card does not appear.
- [ ] Initial open doesn't animate; subsequent row transitions slide.
- [ ] Toggle v2 cloud off (v1 sidebar): hover card behavior unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the v2 dashboard sidebar use one persistent hover card that follows the hovered row and slides between items. This removes the per-row 400ms delay and flicker, and restores hover cards for cloud workspaces.

- New Features
  - Replace per-row `HoverCard` with a single sidebar-level `Popover` anchored via virtualRef that slides between rows.
  - Add `DashboardSidebarHoverProvider` to manage open/close timers, anchor element, payload, and context menu suppression; includes `syncIfHovered`.
  - Add `DashboardSidebarHoverCardOverlay` to render the shared `Popover` + `PopoverAnchor` and reuse existing `DashboardSidebarWorkspaceHoverCardContent`; `useDiffStats` lifted to the overlay.
  - Co-locate the transition CSS in `DashboardSidebarHoverCardOverlay.css` and gate the slide until positioned to avoid animating from the off-screen measuring transform; initial open does not animate.
  - Cloud workspaces show the hover card; only the PR-refresh callback remains gated to local-device hosts.
  - v1 sidebar path is unchanged.

<sup>Written for commit 39d49a4c91784fa2f3370b845819c6024f204fc5. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3813?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace hover cards now display when hovering over sidebar items, showing workspace information and quick actions with smooth animations.

* **Refactor**
  * Reorganized hover interaction management system in the sidebar for improved performance and maintainability.

* **Style**
  * Enhanced hover card animations with smooth transitions for a more polished visual experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->