### PR TITLE
feat(desktop): tag PostHog events with v1/v2 surface

### DIFF
--- a/apps/desktop/src/renderer/components/PostHogSurfaceTagger/PostHogSurfaceTagger.tsx
+++ b/apps/desktop/src/renderer/components/PostHogSurfaceTagger/PostHogSurfaceTagger.tsx
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
+import { posthog } from "renderer/lib/posthog";
+import { useV2LocalOverrideStore } from "renderer/stores/v2-local-override";
+
+export function PostHogSurfaceTagger() {
+	const { isV2CloudEnabled, isRemoteV2Enabled } = useIsV2CloudEnabled();
+	const optInV2 = useV2LocalOverrideStore((s) => s.optInV2);
+
+	useEffect(() => {
+		const surface = isV2CloudEnabled ? "v2" : "v1";
+		const surface_source = !isRemoteV2Enabled
+			? "v2-flag-off"
+			: optInV2
+				? "opted-in"
+				: "opted-out";
+
+		posthog.register({ surface, surface_source });
+
+		posthog.people.set({ surface });
+		if (isV2CloudEnabled) {
+			posthog.people.set_once({
+				surface_first_v2_at: new Date().toISOString(),
+				surface_ever_v2: true,
+			});
+		}
+	}, [isV2CloudEnabled, isRemoteV2Enabled, optInV2]);
+
+	return null;
+}

--- a/apps/desktop/src/renderer/components/PostHogSurfaceTagger/index.ts
+++ b/apps/desktop/src/renderer/components/PostHogSurfaceTagger/index.ts
@@ -1,0 +1,1 @@
+export { PostHogSurfaceTagger } from "./PostHogSurfaceTagger";

--- a/apps/desktop/src/renderer/routes/-layout.tsx
+++ b/apps/desktop/src/renderer/routes/-layout.tsx
@@ -1,5 +1,6 @@
 import { Alerter } from "@superset/ui/atoms/Alert";
 import type { ReactNode } from "react";
+import { PostHogSurfaceTagger } from "renderer/components/PostHogSurfaceTagger";
 import { PostHogUserIdentifier } from "renderer/components/PostHogUserIdentifier";
 import { TelemetrySync } from "renderer/components/TelemetrySync";
 import { ThemedToaster } from "renderer/components/ThemedToaster";
@@ -12,6 +13,7 @@ export function RootLayout({ children }: { children: ReactNode }) {
 		<PostHogProvider>
 			<ElectronTRPCProvider>
 				<PostHogUserIdentifier />
+				<PostHogSurfaceTagger />
 				<TelemetrySync />
 				<AuthProvider>
 					{children}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/experimental/components/ExperimentalSettings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/experimental/components/ExperimentalSettings/ExperimentalSettings.tsx
@@ -4,6 +4,7 @@ import { toast } from "@superset/ui/sonner";
 import { Switch } from "@superset/ui/switch";
 import { LuRefreshCw } from "react-icons/lu";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
+import { track } from "renderer/lib/analytics";
 import { useMigrateV1DataToV2 } from "renderer/routes/_authenticated/hooks/useMigrateV1DataToV2";
 import type { MigrationSummary } from "renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/migrate";
 import { useV2LocalOverrideStore } from "renderer/stores/v2-local-override";
@@ -74,7 +75,13 @@ export function ExperimentalSettings({
 						<Switch
 							id="superset-v2"
 							checked={isV2CloudEnabled}
-							onCheckedChange={(enabled) => setOptInV2(enabled)}
+							onCheckedChange={(enabled) => {
+								track("surface_toggled", {
+									from: isV2CloudEnabled ? "v2" : "v1",
+									to: enabled && isRemoteV2Enabled ? "v2" : "v1",
+								});
+								setOptInV2(enabled);
+							}}
 							disabled={!isRemoteV2Enabled}
 						/>
 					</div>

--- a/plans/20260427-posthog-v1-v2-dashboard.md
+++ b/plans/20260427-posthog-v1-v2-dashboard.md
@@ -1,0 +1,103 @@
+# PostHog v1 vs v2 usage dashboard (desktop)
+
+## Goal
+
+A PostHog dashboard that answers: how is the desktop migration from v1 to v2 going? Per-user, per-org, over time, and by feature. Scope is `apps/desktop` only — web/admin/mobile do not have a v1/v2 split.
+
+## The core problem
+
+PostHog has no idea which surface fired any event today. The v1/v2 decision lives in `apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts`:
+
+```
+isV2CloudEnabled = useFeatureFlagEnabled("v2-cloud") && useV2LocalOverrideStore.optInV2
+```
+
+Both gates are needed; neither is currently reflected on outgoing events. No super property, no user property, no event property. Every chart we want to build depends on filling that gap first.
+
+## Plan
+
+### 1. Tag every event with the surface — super property
+
+Register `surface` and `surface_source` as PostHog **super properties** so they auto-attach to every `capture()` without touching individual call sites.
+
+- `surface`: `"v1" | "v2"` — the effective state (matches `isV2CloudEnabled`)
+- `surface_source`: `"v2-flag-off" | "opted-out" | "opted-in"` — diagnostic. Lets us tell "user could be on v2 but chose not to" from "v2 flag isn't on for them yet"
+
+**Where:** new component `apps/desktop/src/renderer/components/PostHogSurfaceTagger/PostHogSurfaceTagger.tsx`, mounted next to `PostHogUserIdentifier` in the authenticated layout. It uses `useIsV2CloudEnabled` and re-registers super properties whenever the resolved state changes:
+
+```ts
+const { isV2CloudEnabled, isRemoteV2Enabled } = useIsV2CloudEnabled();
+const optInV2 = useV2LocalOverrideStore((s) => s.optInV2);
+
+useEffect(() => {
+  const surface = isV2CloudEnabled ? "v2" : "v1";
+  const source = !isRemoteV2Enabled
+    ? "v2-flag-off"
+    : optInV2
+      ? "opted-in"
+      : "opted-out";
+  posthog.register({ surface, surface_source: source });
+}, [isV2CloudEnabled, isRemoteV2Enabled, optInV2]);
+```
+
+Super properties persist across the session via localStorage (PostHog default). They re-evaluate on toggle, so a user who opts in mid-session immediately starts firing v2-tagged events.
+
+### 2. Mirror as a user property
+
+Persistent per-user dimensions for cohort building:
+
+- `surface` (latest)
+- `surface_first_v2_at` — set once, the first time `isV2CloudEnabled` becomes true
+- `surface_ever_v2` — boolean, sticky once true
+
+Done with `posthog.people.set()` / `posthog.people.set_once()` in the same effect as step 1. Enables PostHog cohorts: `v2-only`, `v1-only`, `ever-tried-v2`, `switched-back` (`surface_ever_v2 = true AND surface = v1`).
+
+### 3. Toggle event
+
+Capture `surface_toggled` whenever `setOptInV2` is called, with `{ from, to }`. Single event, fired from the toggle UI. This powers the switchback funnel without scraping super-property changes.
+
+Likely site: wherever `setOptInV2` is invoked in settings UI — grep `setOptInV2(` to confirm. Add `track("surface_toggled", { from, to })` adjacent to the store call.
+
+### 4. Event coverage audit (separate, blocking for some tiles)
+
+The exploration found that v1 has years of organic events while v2 routes (`/v2-workspace/...`) are newer. Before per-feature parity tiles work, audit the v2 surface to ensure parity for the events that already exist on v1:
+
+- workspace opened
+- pane opened (already has `panel_type`)
+- chat session created/opened/deleted
+- file opened from tool
+
+Rule: **one event name across both surfaces, segmented by the `surface` super property.** No `v2_chat_opened` vs `chat_opened`. If v2 has divergent event names today, rename to the v1 name.
+
+This audit produces a small follow-up PR; it isn't part of the wiring above.
+
+## Dashboard tiles (built in PostHog UI)
+
+All tiles filter to `app_name = "desktop"`.
+
+1. **Active users by surface** — DAU + WAU, stacked area, breakdown by `surface`. The headline number.
+2. **% of active users on v2** — single line, the migration north star. Trend over time.
+3. **Per-feature parity** — for each event in the audit list, events-per-active-user broken down by `surface`. Reveals features missing or slower on v2.
+4. **Switchback funnel** — `surface_toggled` from v1→v2 → any v2 event → `surface_toggled` v2→v1. Drop-off rate is the v2 regression signal.
+5. **Retention** — D1/D7/D30 retention curves, compared between `surface = v1` and `surface = v2` cohorts.
+6. **Surface source breakdown** — pie of `surface_source`. Tells us how much "v1" usage is "we haven't ramped the flag" vs "user opted out". Drives ramp decisions.
+
+## Cohorts to define once
+
+- `v2-only` — `surface = v2` in last 7d, no v1 events in last 7d
+- `v1-only` — inverse
+- `switched-back` — `surface_ever_v2 = true AND surface = v1` in last 7d
+- `never-tried-v2` — `surface_ever_v2 != true`
+
+## Rollout order
+
+1. PR 1: super property + user property + toggle event (steps 1–3). Low risk, no UI changes. Land first; data starts flowing.
+2. Wait ~7 days for backfill so dashboards have meaningful windows.
+3. PR 2: v2 event coverage audit + renames (step 4).
+4. Build dashboard tiles in PostHog UI (no code).
+
+## Out of scope
+
+- Backfilling historical events with `surface` — not possible, accept the cutover date as the dashboard start.
+- Web/admin/mobile instrumentation — no v1/v2 split there.
+- Org-level rollups (% of orgs on v2, etc.) — would need `posthog.group("organization", ...)`, deliberately out of scope here.


### PR DESCRIPTION
## Summary

- Foundation for a PostHog dashboard comparing v1 vs v2 desktop usage. Tags every event with a `surface` super property (`"v1"` / `"v2"`) plus `surface_source` (`"v2-flag-off"` / `"opted-in"` / `"opted-out"`), so we can slice any existing event by surface without touching individual `capture()` sites.
- Sets sticky user properties (`surface`, `surface_first_v2_at`, `surface_ever_v2`) for cohort building (e.g. "switched back to v1", "never tried v2").
- Emits a `surface_toggled` event from the experimental settings switch with `{ from, to }` for switchback funnels.

Plan with full context, dashboard tile design, and rollout sequencing in `plans/20260427-posthog-v1-v2-dashboard.md`. This PR is step 1 only — event coverage audit and the PostHog dashboard itself are follow-ups.

Total footprint: 1 new component (`PostHogSurfaceTagger`), 1 layout mount, 1 line in `ExperimentalSettings`. No behavior change for users.

## Test plan

- [ ] Build runs (`bun run typecheck` in `apps/desktop` passes locally).
- [ ] In dev, with PostHog enabled, captured events include `surface` and `surface_source` properties.
- [ ] Toggling the v2 switch in Experimental settings fires `surface_toggled` with correct `from`/`to`.
- [ ] First time `isV2CloudEnabled` resolves true, `surface_first_v2_at` is set on the user and `surface_ever_v2 = true`.
- [ ] Logging out (`posthog.reset()` in `PostHogUserIdentifier`) clears the identified state; super properties re-register on next session.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds automatic v1/v2 tagging to all desktop PostHog events so we can slice usage by surface and build a v1-vs-v2 dashboard without touching existing `capture()` calls. Also adds sticky user properties and a toggle event for cohorts and funnels.

- New Features
  - Added `PostHogSurfaceTagger` (mounted in the root layout) to register super properties `surface` ("v1"/"v2") and `surface_source` ("v2-flag-off"/"opted-in"/"opted-out"), and set person properties `surface`, `surface_first_v2_at` (set once), and `surface_ever_v2` (sticky).
  - Updated Experimental settings to emit `surface_toggled` with `{ from, to }` when the v2 switch changes.
  - No user-facing changes; existing instrumentation continues to work.

<sup>Written for commit 753aa41f148f82a472f746351a0564a8c4c76cfb. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3814?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced analytics instrumentation for feature tracking across versions
  * Added event capture for v2 feature toggle interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->