### PR TITLE
fix(desktop): only show v1 migration modal on first onboard

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1MigrationSummaryModal/V1MigrationSummaryModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1MigrationSummaryModal/V1MigrationSummaryModal.tsx
@@ -362,7 +362,7 @@ function ResultsPage({
 				</p>
 			</div>
 
-			<div className="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto px-5 py-4">
+			<div className="flex min-h-0 min-w-0 flex-1 flex-col gap-1 overflow-y-auto px-5 py-4">
 				<ExpandableSummaryRow
 					icon={LuFolder}
 					label="Projects"
@@ -529,7 +529,7 @@ function ExpandableSummaryRow({
 }: ExpandableSummaryRowProps) {
 	const clickable = onToggle !== undefined;
 	return (
-		<div className="flex flex-col">
+		<div className="flex min-w-0 flex-col">
 			<button
 				type="button"
 				disabled={!clickable}
@@ -603,7 +603,7 @@ function Entry({
 	detail,
 }: EntryProps) {
 	return (
-		<div className="flex items-center justify-between gap-3 py-1">
+		<div className="flex min-w-0 items-center justify-between gap-3 py-1">
 			<div className="flex min-w-0 flex-1 flex-col">
 				<span className="truncate text-xs font-medium text-foreground">
 					{primary}

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/useMigrateV1DataToV2.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/useMigrateV1DataToV2.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useSyncExternalStore } from "react";
 import { env } from "renderer/env.renderer";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { authClient } from "renderer/lib/auth-client";
@@ -21,6 +21,10 @@ function getSummaryKey(organizationId: string): string {
 	return `v1-migration-summary-${organizationId}`;
 }
 
+function getShownKey(organizationId: string): string {
+	return `v1-migration-modal-shown-${organizationId}`;
+}
+
 export const V1_MIGRATION_SUMMARY_EVENT = "v1-migration-summary-updated";
 
 function persistSummary(organizationId: string, summary: MigrationSummary) {
@@ -28,9 +32,33 @@ function persistSummary(organizationId: string, summary: MigrationSummary) {
 		getSummaryKey(organizationId),
 		JSON.stringify({ summary, createdAt: Date.now() }),
 	);
+	localStorage.setItem(getShownKey(organizationId), "1");
 	window.dispatchEvent(
 		new CustomEvent(V1_MIGRATION_SUMMARY_EVENT, { detail: { organizationId } }),
 	);
+}
+
+// Module-level singleton so every hook instance shares the same isRunning value.
+// Without this, the auto-run from the dashboard layout and the manual rerun
+// from settings each have their own isRunning ref, letting the user start a
+// concurrent migration from settings while the auto-run is still in flight.
+let activeMigrationCount = 0;
+const migrationRunningSubscribers = new Set<() => void>();
+
+function subscribeMigrationRunning(notify: () => void) {
+	migrationRunningSubscribers.add(notify);
+	return () => {
+		migrationRunningSubscribers.delete(notify);
+	};
+}
+
+function getMigrationRunningSnapshot() {
+	return activeMigrationCount > 0;
+}
+
+function setMigrationRunning(running: boolean) {
+	activeMigrationCount = Math.max(0, activeMigrationCount + (running ? 1 : -1));
+	for (const notify of migrationRunningSubscribers) notify();
 }
 
 /**
@@ -54,12 +82,15 @@ export function useMigrateV1DataToV2({
 	const { activeHostUrl } = useLocalHostService();
 	const { isV2CloudEnabled } = useIsV2CloudEnabled();
 	const collections = useCollections();
-	const [isRunning, setIsRunning] = useState(false);
+	const isRunning = useSyncExternalStore(
+		subscribeMigrationRunning,
+		getMigrationRunningSnapshot,
+		getMigrationRunningSnapshot,
+	);
 	const organizationId = env.SKIP_ENV_VALIDATION
 		? MOCK_ORG_ID
 		: (session?.session?.activeOrganizationId ?? null);
 	const attemptedRef = useRef<string | null>(null);
-	const isRunningRef = useRef(false);
 
 	const runMigration = useCallback(
 		async ({ manual }: { manual: boolean }): Promise<MigrationRunResult> => {
@@ -72,7 +103,7 @@ export function useMigrateV1DataToV2({
 			if (!activeHostUrl) {
 				return { completed: false, reason: "Host service is not ready" };
 			}
-			if (isRunningRef.current) {
+			if (activeMigrationCount > 0) {
 				return { completed: false, reason: "Migration is already running" };
 			}
 
@@ -95,8 +126,7 @@ export function useMigrateV1DataToV2({
 
 			attemptedRef.current = organizationId;
 			sessionStorage.setItem(attemptKey, "1");
-			isRunningRef.current = true;
-			setIsRunning(true);
+			setMigrationRunning(true);
 
 			try {
 				const hostService = getHostServiceClientByUrl(activeHostUrl);
@@ -118,7 +148,9 @@ export function useMigrateV1DataToV2({
 						summary.workspacesSkipped +
 						summary.workspacesErrored >
 					0;
-				if (manual || didAnything) {
+				const alreadyShown =
+					localStorage.getItem(getShownKey(organizationId)) === "1";
+				if (manual || (didAnything && !alreadyShown)) {
 					persistSummary(organizationId, summary);
 				}
 
@@ -135,8 +167,7 @@ export function useMigrateV1DataToV2({
 				const reason = err instanceof Error ? err.message : String(err);
 				return { completed: false, reason };
 			} finally {
-				isRunningRef.current = false;
-				setIsRunning(false);
+				setMigrationRunning(false);
 			}
 		},
 		[activeHostUrl, collections, isV2CloudEnabled, organizationId],


### PR DESCRIPTION
## Summary
- Stop the v1→v2 migration modal from reappearing on every refresh: track a per-org `v1-migration-modal-shown-${orgId}` flag in localStorage and gate auto-run persists on `manual || (didAnything && !alreadyShown)`. Manual reruns from `Settings → Experimental → Run again` still surface the modal.
- Fix long error messages overflowing the modal. The `truncate` chain was leaking because flex-item ancestors had no `min-w-0`, letting `white-space: nowrap` content force the row wider than the modal.
- Share `isRunning` across all `useMigrateV1DataToV2` callers (dashboard auto-run + settings rerun) via a module-level counter and `useSyncExternalStore`, and move the concurrency guard off the per-instance ref. Without this, the settings button was enabled while the dashboard auto-run was still in flight.

## Test plan
- [ ] First launch on v2: modal appears with welcome → results pages.
- [ ] Click Done, reload: modal stays closed.
- [ ] Reload again with a project that re-errors during reconciliation: modal still stays closed.
- [ ] Settings → Experimental → Run again: modal reopens with fresh results.
- [ ] Trigger a migration with a long error reason (e.g., a multi-hundred-char failed-query message): error row truncates with ellipsis instead of overflowing.
- [ ] While the dashboard auto-run is in flight, navigate to Settings → Experimental: "Run again" button is disabled, shows spinner.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop the v1→v2 migration modal from reopening on every relaunch by showing it only once per org after first onboard. Also fixes text overflow in the modal and blocks concurrent migrations so the settings button stays disabled during an auto-run.

- **Bug Fixes**
  - Track a per-org shown flag in `localStorage` (`v1-migration-modal-shown-${orgId}`) and only persist auto-run results on the first show; manual reruns always open the modal.
  - Add `min-w-0` to modal flex containers so long error messages truncate with ellipsis instead of overflowing.
  - Share `isRunning` across all `useMigrateV1DataToV2` instances via a module-level counter and `useSyncExternalStore`, preventing concurrent runs and keeping “Run again” disabled with a spinner during the dashboard auto-run.

<sup>Written for commit 2818981d75f4cbb38ce14ba7461911b21905725c. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3816?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text truncation and overflow display in migration summary components.
  * Improved migration summary logic to prevent redundant displays after initial viewing when no changes occurred.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->