### PR TITLE
feat(desktop): focus-follows-mouse for v1 panes (opt-in)

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/BehaviorSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/BehaviorSettings.tsx
@@ -283,8 +283,8 @@ export function BehaviorSettings({ visibleItems }: BehaviorSettingsProps) {
 								Focus follows mouse
 							</Label>
 							<p className="text-xs text-muted-foreground">
-								When enabled, hovering over a pane briefly will focus it
-								without clicking. Useful with split layouts.
+								When enabled, hovering over a pane briefly will focus it without
+								clicking. Useful with split layouts.
 							</p>
 						</div>
 						<Switch

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/BehaviorSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/behavior/components/BehaviorSettings/BehaviorSettings.tsx
@@ -10,6 +10,10 @@ import {
 import { Switch } from "@superset/ui/switch";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
+	useFocusFollowsMouse,
+	useSetFocusFollowsMouse,
+} from "renderer/stores/pane-preferences";
+import {
 	isItemVisible,
 	SETTING_ITEM_ID,
 	type SettingItemId,
@@ -38,6 +42,10 @@ export function BehaviorSettings({ visibleItems }: BehaviorSettingsProps) {
 	);
 	const showOpenLinksInApp = isItemVisible(
 		SETTING_ITEM_ID.BEHAVIOR_OPEN_LINKS_IN_APP,
+		visibleItems,
+	);
+	const showFocusFollowsMouse = isItemVisible(
+		SETTING_ITEM_ID.BEHAVIOR_FOCUS_FOLLOWS_MOUSE,
 		visibleItems,
 	);
 
@@ -159,6 +167,9 @@ export function BehaviorSettings({ visibleItems }: BehaviorSettingsProps) {
 		},
 	);
 
+	const focusFollowsMouse = useFocusFollowsMouse();
+	const setFocusFollowsMouse = useSetFocusFollowsMouse();
+
 	return (
 		<div className="p-6 max-w-4xl w-full">
 			<div className="mb-8">
@@ -258,6 +269,28 @@ export function BehaviorSettings({ visibleItems }: BehaviorSettingsProps) {
 								setOpenLinksInApp.mutate({ enabled })
 							}
 							disabled={isOpenLinksInAppLoading || setOpenLinksInApp.isPending}
+						/>
+					</div>
+				)}
+
+				{showFocusFollowsMouse && (
+					<div className="flex items-center justify-between">
+						<div className="space-y-0.5">
+							<Label
+								htmlFor="focus-follows-mouse"
+								className="text-sm font-medium"
+							>
+								Focus follows mouse
+							</Label>
+							<p className="text-xs text-muted-foreground">
+								When enabled, hovering over a pane briefly will focus it
+								without clicking. Useful with split layouts.
+							</p>
+						</div>
+						<Switch
+							id="focus-follows-mouse"
+							checked={focusFollowsMouse}
+							onCheckedChange={setFocusFollowsMouse}
 						/>
 					</div>
 				)}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -26,6 +26,7 @@ export const SETTING_ITEM_ID = {
 	BEHAVIOR_FILE_OPEN_MODE: "behavior-file-open-mode",
 	BEHAVIOR_RESOURCE_MONITOR: "behavior-resource-monitor",
 	BEHAVIOR_OPEN_LINKS_IN_APP: "behavior-open-links-in-app",
+	BEHAVIOR_FOCUS_FOLLOWS_MOUSE: "behavior-focus-follows-mouse",
 
 	GIT_BRANCH_PREFIX: "git-branch-prefix",
 	GIT_DELETE_LOCAL_BRANCH: "git-delete-local-branch",
@@ -497,6 +498,24 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"chat",
 			"terminal",
 			"url",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.BEHAVIOR_FOCUS_FOLLOWS_MOUSE,
+		section: "behavior",
+		title: "Focus follows mouse",
+		description:
+			"When enabled, hovering over a pane briefly will focus it without clicking. Useful with split layouts.",
+		keywords: [
+			"focus",
+			"follows",
+			"mouse",
+			"hover",
+			"sloppy",
+			"panes",
+			"split",
+			"keyboard",
+			"x11",
 		],
 	},
 	{

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/FileViewerPane.tsx
@@ -150,6 +150,22 @@ export function FileViewerPane({
 
 	const filePath = fileViewer?.filePath ?? "";
 	const viewMode = fileViewer?.viewMode ?? "raw";
+
+	// Reactive focus: when this pane becomes the focused pane and we're showing
+	// the raw (CodeMirror) view, move keyboard focus into the editor. Markdown
+	// (TipTap) and diff views are read-ish — they don't take focus on click today
+	// either, so hover-focus matches existing behavior.
+	const isFirstFocusEffectRef = useRef(true);
+	useEffect(() => {
+		if (isFirstFocusEffectRef.current) {
+			isFirstFocusEffectRef.current = false;
+			return;
+		}
+		if (!isFocused) return;
+		if (viewMode !== "raw") return;
+		editorRef.current?.focus();
+	}, [isFocused, viewMode]);
+
 	const isPinned = fileViewer?.isPinned ?? false;
 	const diffCategory = fileViewer?.diffCategory;
 	const commitHash = fileViewer?.commitHash;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/BasePaneWindow.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/BasePaneWindow.tsx
@@ -3,14 +3,11 @@ import { useContext, useEffect, useRef } from "react";
 import type { MosaicBranch } from "react-mosaic-component";
 import { MosaicWindow, MosaicWindowContext } from "react-mosaic-component";
 import { useDragPaneStore } from "renderer/stores/drag-pane-store";
+import { useFocusFollowsMouse } from "renderer/stores/pane-preferences";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import type { SplitOrientation } from "../../hooks";
 import { useSplitOrientation } from "../../hooks";
-import { useFocusFollowsMouse } from "renderer/stores/pane-preferences";
-import {
-	createHoverFocusTimer,
-	type HoverFocusTimer,
-} from "./hoverFocusTimer";
+import { createHoverFocusTimer, type HoverFocusTimer } from "./hoverFocusTimer";
 import { useHoverFocusSuppression } from "./useHoverFocusSuppression";
 
 export interface PaneHandlers {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/BasePaneWindow.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/BasePaneWindow.tsx
@@ -1,11 +1,17 @@
 import { cn } from "@superset/ui/utils";
-import { useContext, useRef } from "react";
+import { useContext, useEffect, useRef } from "react";
 import type { MosaicBranch } from "react-mosaic-component";
 import { MosaicWindow, MosaicWindowContext } from "react-mosaic-component";
 import { useDragPaneStore } from "renderer/stores/drag-pane-store";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import type { SplitOrientation } from "../../hooks";
 import { useSplitOrientation } from "../../hooks";
+import { useFocusFollowsMouse } from "renderer/stores/pane-preferences";
+import {
+	createHoverFocusTimer,
+	type HoverFocusTimer,
+} from "./hoverFocusTimer";
+import { useHoverFocusSuppression } from "./useHoverFocusSuppression";
 
 export interface PaneHandlers {
 	onFocus: () => void;
@@ -13,6 +19,8 @@ export interface PaneHandlers {
 	onSplitPane: (e: React.MouseEvent) => void;
 	splitOrientation: SplitOrientation;
 }
+
+const FOCUS_FOLLOWS_MOUSE_DELAY_MS = 75;
 
 /**
  * Connects drag source for root panes (single pane in a tab).
@@ -64,6 +72,36 @@ export function BasePaneWindow({
 	const isResizing = useDragPaneStore((s) => s.isResizing);
 	const setDragging = useDragPaneStore((s) => s.setDragging);
 	const clearDragging = useDragPaneStore((s) => s.clearDragging);
+	const focusFollowsMouse = useFocusFollowsMouse();
+	const isSuppressed = useHoverFocusSuppression();
+	const timerRef = useRef<HoverFocusTimer | null>(null);
+
+	useEffect(() => {
+		if (!focusFollowsMouse) {
+			timerRef.current?.dispose();
+			timerRef.current = null;
+			return;
+		}
+		timerRef.current = createHoverFocusTimer({
+			delayMs: FOCUS_FOLLOWS_MOUSE_DELAY_MS,
+			onFire: () => {
+				// Defensive: if window lost focus between suppression check and
+				// fire (microtask race), bail.
+				if (!document.hasFocus()) return;
+				// Read action imperatively to avoid an extra store subscription
+				// for a value (the action) that is stable for the store's lifetime.
+				useTabsStore.getState().setFocusedPane(tabId, paneId);
+			},
+			// `isSuppressed` is required in deps for correctness if it ever
+			// becomes non-stable; today useHoverFocusSuppression returns a
+			// useCallback([])-stable reference so the dep is a no-op.
+			isSuppressed,
+		});
+		return () => {
+			timerRef.current?.dispose();
+			timerRef.current = null;
+		};
+	}, [focusFollowsMouse, isSuppressed, tabId, paneId]);
 
 	const handleFocus = () => {
 		setFocusedPane(tabId, paneId);
@@ -81,6 +119,15 @@ export function BasePaneWindow({
 
 		const { width, height } = container.getBoundingClientRect();
 		splitPaneAuto(tabId, paneId, { width, height }, path);
+	};
+
+	const handleMouseEnter = () => {
+		if (isActive) return;
+		timerRef.current?.enter();
+	};
+
+	const handleMouseLeave = () => {
+		timerRef.current?.leave();
 	};
 
 	const handlers: PaneHandlers = {
@@ -116,6 +163,8 @@ export function BasePaneWindow({
 				className={contentClassName}
 				style={isDragging || isResizing ? { pointerEvents: "none" } : undefined}
 				onClick={handleFocus}
+				onMouseEnter={handleMouseEnter}
+				onMouseLeave={handleMouseLeave}
 			>
 				{children}
 			</div>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/BasePaneWindow.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/BasePaneWindow.tsx
@@ -17,7 +17,11 @@ export interface PaneHandlers {
 	splitOrientation: SplitOrientation;
 }
 
-const FOCUS_FOLLOWS_MOUSE_DELAY_MS = 75;
+// 10ms: imperceptible to users (sub-frame at 60fps) but still allows
+// `isSuppressed` to be evaluated at fire time rather than at enter time —
+// so an overlay opening or a drag starting between enter and fire can still
+// cancel the focus shift.
+const FOCUS_FOLLOWS_MOUSE_DELAY_MS = 10;
 
 /**
  * Connects drag source for root panes (single pane in a tab).

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/hoverFocusTimer.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/hoverFocusTimer.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, mock } from "bun:test";
+import { createHoverFocusTimer } from "./hoverFocusTimer";
+
+const tick = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("createHoverFocusTimer", () => {
+	it("fires onFire after delayMs when enter() is called", async () => {
+		const onFire = mock(() => {});
+		const timer = createHoverFocusTimer({ delayMs: 30, onFire });
+		timer.enter();
+		expect(onFire).not.toHaveBeenCalled();
+		await tick(60);
+		expect(onFire).toHaveBeenCalledTimes(1);
+	});
+
+	it("leave() cancels a pending fire", async () => {
+		const onFire = mock(() => {});
+		const timer = createHoverFocusTimer({ delayMs: 30, onFire });
+		timer.enter();
+		timer.leave();
+		await tick(60);
+		expect(onFire).not.toHaveBeenCalled();
+	});
+
+	it("double enter() only schedules one fire", async () => {
+		const onFire = mock(() => {});
+		const timer = createHoverFocusTimer({ delayMs: 30, onFire });
+		timer.enter();
+		timer.enter();
+		await tick(60);
+		expect(onFire).toHaveBeenCalledTimes(1);
+	});
+
+	it("isSuppressed returning true at fire time skips onFire", async () => {
+		const onFire = mock(() => {});
+		const timer = createHoverFocusTimer({
+			delayMs: 30,
+			onFire,
+			isSuppressed: () => true,
+		});
+		timer.enter();
+		await tick(60);
+		expect(onFire).not.toHaveBeenCalled();
+	});
+
+	it("isSuppressed returning false at fire time still fires", async () => {
+		const onFire = mock(() => {});
+		const timer = createHoverFocusTimer({
+			delayMs: 30,
+			onFire,
+			isSuppressed: () => false,
+		});
+		timer.enter();
+		await tick(60);
+		expect(onFire).toHaveBeenCalledTimes(1);
+	});
+
+	it("dispose() cancels a pending fire", async () => {
+		const onFire = mock(() => {});
+		const timer = createHoverFocusTimer({ delayMs: 30, onFire });
+		timer.enter();
+		timer.dispose();
+		await tick(60);
+		expect(onFire).not.toHaveBeenCalled();
+	});
+
+	it("supports re-entering after a fire", async () => {
+		const onFire = mock(() => {});
+		const timer = createHoverFocusTimer({ delayMs: 20, onFire });
+		timer.enter();
+		await tick(40);
+		expect(onFire).toHaveBeenCalledTimes(1);
+		timer.enter();
+		await tick(40);
+		expect(onFire).toHaveBeenCalledTimes(2);
+	});
+
+	it("re-entering after a leave fires once", async () => {
+		const onFire = mock(() => {});
+		const timer = createHoverFocusTimer({ delayMs: 30, onFire });
+		timer.enter();
+		timer.leave();
+		timer.enter();
+		await tick(60);
+		expect(onFire).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/hoverFocusTimer.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/hoverFocusTimer.ts
@@ -1,0 +1,37 @@
+export interface HoverFocusTimerOptions {
+	delayMs: number;
+	onFire: () => void;
+	isSuppressed?: () => boolean;
+}
+
+export interface HoverFocusTimer {
+	enter: () => void;
+	leave: () => void;
+	dispose: () => void;
+}
+
+export function createHoverFocusTimer(
+	opts: HoverFocusTimerOptions,
+): HoverFocusTimer {
+	let timerId: ReturnType<typeof setTimeout> | null = null;
+
+	const clear = () => {
+		if (timerId !== null) {
+			clearTimeout(timerId);
+			timerId = null;
+		}
+	};
+
+	return {
+		enter() {
+			clear();
+			timerId = setTimeout(() => {
+				timerId = null;
+				if (opts.isSuppressed?.()) return;
+				opts.onFire();
+			}, opts.delayMs);
+		},
+		leave: clear,
+		dispose: clear,
+	};
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/useHoverFocusSuppression/computeHoverFocusSuppression.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/useHoverFocusSuppression/computeHoverFocusSuppression.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+import { computeHoverFocusSuppression } from "./computeHoverFocusSuppression";
+
+const baseline = {
+	isPointerDown: false,
+	isPaneDragging: false,
+	isResizing: false,
+	hasWindowFocus: true,
+	hasOpenOverlay: false,
+};
+
+describe("computeHoverFocusSuppression", () => {
+	it("returns false when no suppression cause is active", () => {
+		expect(computeHoverFocusSuppression(baseline)).toBe(false);
+	});
+
+	it("returns true when a pointer button is down", () => {
+		expect(
+			computeHoverFocusSuppression({ ...baseline, isPointerDown: true }),
+		).toBe(true);
+	});
+
+	it("returns true when a pane is being dragged", () => {
+		expect(
+			computeHoverFocusSuppression({ ...baseline, isPaneDragging: true }),
+		).toBe(true);
+	});
+
+	it("returns true when a split divider is being resized", () => {
+		expect(
+			computeHoverFocusSuppression({ ...baseline, isResizing: true }),
+		).toBe(true);
+	});
+
+	it("returns true when the app window does not have OS focus", () => {
+		expect(
+			computeHoverFocusSuppression({ ...baseline, hasWindowFocus: false }),
+		).toBe(true);
+	});
+
+	it("returns true when an overlay (Radix menu/dialog/tooltip) is open", () => {
+		expect(
+			computeHoverFocusSuppression({ ...baseline, hasOpenOverlay: true }),
+		).toBe(true);
+	});
+
+	it("returns true when multiple causes are active", () => {
+		expect(
+			computeHoverFocusSuppression({
+				isPointerDown: true,
+				isPaneDragging: true,
+				isResizing: true,
+				hasWindowFocus: false,
+				hasOpenOverlay: true,
+			}),
+		).toBe(true);
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/useHoverFocusSuppression/computeHoverFocusSuppression.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/useHoverFocusSuppression/computeHoverFocusSuppression.ts
@@ -1,0 +1,18 @@
+export interface HoverFocusSuppressionDeps {
+	isPointerDown: boolean;
+	isPaneDragging: boolean;
+	isResizing: boolean;
+	hasWindowFocus: boolean;
+	hasOpenOverlay: boolean;
+}
+
+export function computeHoverFocusSuppression(
+	deps: HoverFocusSuppressionDeps,
+): boolean {
+	if (deps.isPointerDown) return true;
+	if (deps.isPaneDragging) return true;
+	if (deps.isResizing) return true;
+	if (!deps.hasWindowFocus) return true;
+	if (deps.hasOpenOverlay) return true;
+	return false;
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/useHoverFocusSuppression/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/useHoverFocusSuppression/index.ts
@@ -1,0 +1,5 @@
+export { useHoverFocusSuppression } from "./useHoverFocusSuppression";
+export {
+	computeHoverFocusSuppression,
+	type HoverFocusSuppressionDeps,
+} from "./computeHoverFocusSuppression";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/useHoverFocusSuppression/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/useHoverFocusSuppression/index.ts
@@ -1,5 +1,5 @@
-export { useHoverFocusSuppression } from "./useHoverFocusSuppression";
 export {
 	computeHoverFocusSuppression,
 	type HoverFocusSuppressionDeps,
 } from "./computeHoverFocusSuppression";
+export { useHoverFocusSuppression } from "./useHoverFocusSuppression";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/useHoverFocusSuppression/useHoverFocusSuppression.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/useHoverFocusSuppression/useHoverFocusSuppression.ts
@@ -2,10 +2,14 @@ import { useCallback, useEffect, useRef } from "react";
 import { useDragPaneStore } from "renderer/stores/drag-pane-store";
 import { computeHoverFocusSuppression } from "./computeHoverFocusSuppression";
 
+// Tooltips (role="tooltip") are deliberately NOT in this selector. Tooltips
+// open in response to hover and have a fade-out delay; including them would
+// suppress hover-focus while the user is doing the very thing the feature
+// targets. Menus / dialogs / popovers are click-triggered and represent a
+// different user intent — those we DO suppress for.
 const RADIX_OPEN_OVERLAY_SELECTOR =
 	'[data-state="open"][role="menu"], ' +
 	'[data-state="open"][role="dialog"], ' +
-	'[data-state="open"][role="tooltip"], ' +
 	'[data-radix-popper-content-wrapper] [data-state="open"]';
 
 /**

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/useHoverFocusSuppression/useHoverFocusSuppression.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/BasePaneWindow/useHoverFocusSuppression/useHoverFocusSuppression.ts
@@ -1,0 +1,52 @@
+import { useCallback, useEffect, useRef } from "react";
+import { useDragPaneStore } from "renderer/stores/drag-pane-store";
+import { computeHoverFocusSuppression } from "./computeHoverFocusSuppression";
+
+const RADIX_OPEN_OVERLAY_SELECTOR =
+	'[data-state="open"][role="menu"], ' +
+	'[data-state="open"][role="dialog"], ' +
+	'[data-state="open"][role="tooltip"], ' +
+	'[data-radix-popper-content-wrapper] [data-state="open"]';
+
+/**
+ * Returns a stable callback that computes whether hover-focus should be
+ * suppressed at the moment of invocation. Sources:
+ *   - useDragPaneStore (read imperatively to avoid re-rendering on drag flips)
+ *   - document.hasFocus()
+ *   - document mousedown/mouseup listeners (for "mid-selection" detection)
+ *   - querySelector for an open Radix overlay
+ *
+ * Known limitation: a click that opens a native OS dialog and is released
+ * inside the native window won't deliver `mouseup` to our document. This
+ * leaves `isPointerDownRef` stuck at `true`, suppressing hover-focus until
+ * the user clicks back inside the app. Errs on the safe side.
+ */
+export function useHoverFocusSuppression(): () => boolean {
+	const isPointerDownRef = useRef(false);
+
+	useEffect(() => {
+		const onDown = (e: MouseEvent) => {
+			if (e.button === 0) isPointerDownRef.current = true;
+		};
+		const onUp = (e: MouseEvent) => {
+			if (e.button === 0) isPointerDownRef.current = false;
+		};
+		document.addEventListener("mousedown", onDown);
+		document.addEventListener("mouseup", onUp);
+		return () => {
+			document.removeEventListener("mousedown", onDown);
+			document.removeEventListener("mouseup", onUp);
+		};
+	}, []);
+
+	return useCallback((): boolean => {
+		const drag = useDragPaneStore.getState();
+		return computeHoverFocusSuppression({
+			isPointerDown: isPointerDownRef.current,
+			isPaneDragging: drag.draggingPaneId !== null,
+			isResizing: drag.isResizing,
+			hasWindowFocus: document.hasFocus(),
+			hasOpenOverlay: !!document.querySelector(RADIX_OPEN_OVERLAY_SELECTOR),
+		});
+	}, []);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -354,6 +354,20 @@ export const Terminal = memo(function Terminal({
 		defaultRestartCommandRef,
 	});
 
+	// Reactive focus: when this pane becomes the focused pane, re-focus xterm.
+	// useTerminalLifecycle already calls xterm.focus() at mount time, but only once;
+	// subsequent isFocused flips (e.g. from focus-follows-mouse hover) need this
+	// effect to deliver keyboard focus into the terminal.
+	const isFirstFocusEffectRef = useRef(true);
+	useEffect(() => {
+		if (isFirstFocusEffectRef.current) {
+			isFirstFocusEffectRef.current = false;
+			return;
+		}
+		if (!isFocused) return;
+		xtermInstance?.focus();
+	}, [isFocused, xtermInstance]);
+
 	// Stream event handler registration — the subscription itself lives in
 	// v1TerminalCache and stays alive across mount/unmount cycles so data
 	// keeps flowing to xterm even while the tab is hidden.

--- a/apps/desktop/src/renderer/stores/index.ts
+++ b/apps/desktop/src/renderer/stores/index.ts
@@ -1,5 +1,6 @@
 export * from "./chat-preferences";
 export * from "./markdown-preferences";
+export * from "./pane-preferences";
 export * from "./ports";
 export * from "./ringtone";
 export * from "./settings-state";

--- a/apps/desktop/src/renderer/stores/pane-preferences/index.ts
+++ b/apps/desktop/src/renderer/stores/pane-preferences/index.ts
@@ -1,0 +1,1 @@
+export * from "./store";

--- a/apps/desktop/src/renderer/stores/pane-preferences/store.test.ts
+++ b/apps/desktop/src/renderer/stores/pane-preferences/store.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { usePanePreferencesStore } from "./store";
+
+beforeEach(() => {
+	// Reset persisted localStorage entry so each test starts clean.
+	if (typeof localStorage !== "undefined") {
+		localStorage.removeItem("pane-preferences");
+	}
+	usePanePreferencesStore.setState({ focusFollowsMouse: false });
+});
+
+describe("pane-preferences store", () => {
+	it("defaults focusFollowsMouse to false", () => {
+		expect(usePanePreferencesStore.getState().focusFollowsMouse).toBe(false);
+	});
+
+	it("setFocusFollowsMouse(true) flips the value", () => {
+		usePanePreferencesStore.getState().setFocusFollowsMouse(true);
+		expect(usePanePreferencesStore.getState().focusFollowsMouse).toBe(true);
+	});
+
+	it("setFocusFollowsMouse(false) flips back", () => {
+		usePanePreferencesStore.getState().setFocusFollowsMouse(true);
+		usePanePreferencesStore.getState().setFocusFollowsMouse(false);
+		expect(usePanePreferencesStore.getState().focusFollowsMouse).toBe(false);
+	});
+});

--- a/apps/desktop/src/renderer/stores/pane-preferences/store.ts
+++ b/apps/desktop/src/renderer/stores/pane-preferences/store.ts
@@ -1,0 +1,28 @@
+import { create } from "zustand";
+import { devtools, persist } from "zustand/middleware";
+
+interface PanePreferencesState {
+	focusFollowsMouse: boolean;
+	setFocusFollowsMouse: (value: boolean) => void;
+}
+
+export const usePanePreferencesStore = create<PanePreferencesState>()(
+	devtools(
+		persist(
+			(set) => ({
+				focusFollowsMouse: false,
+				setFocusFollowsMouse: (value) => {
+					set({ focusFollowsMouse: value });
+				},
+			}),
+			{ name: "pane-preferences" },
+		),
+		{ name: "PanePreferencesStore" },
+	),
+);
+
+export const useFocusFollowsMouse = () =>
+	usePanePreferencesStore((state) => state.focusFollowsMouse);
+
+export const useSetFocusFollowsMouse = () =>
+	usePanePreferencesStore((state) => state.setFocusFollowsMouse);

--- a/apps/desktop/test-setup.ts
+++ b/apps/desktop/test-setup.ts
@@ -67,6 +67,30 @@ const mockHead = {
 	})),
 };
 
+// =============================================================================
+// localStorage mock (zustand-persist writes synchronously on every state
+// change; without this, any persist-using store throws ReferenceError)
+// =============================================================================
+
+const mockStorage = new Map<string, string>();
+// biome-ignore lint/suspicious/noExplicitAny: Test setup requires extending globalThis
+(globalThis as any).localStorage = {
+	getItem: (key: string) => mockStorage.get(key) ?? null,
+	setItem: (key: string, value: string) => {
+		mockStorage.set(key, value);
+	},
+	removeItem: (key: string) => {
+		mockStorage.delete(key);
+	},
+	clear: () => {
+		mockStorage.clear();
+	},
+	key: (index: number) => Array.from(mockStorage.keys())[index] ?? null,
+	get length() {
+		return mockStorage.size;
+	},
+};
+
 // Ensure window has addEventListener/removeEventListener for react-hotkeys-hook's IIFE
 if (typeof globalThis.window !== "undefined") {
 	const win = globalThis.window as Record<string, unknown>;


### PR DESCRIPTION
## Summary

Opt-in `Focus follows mouse` preference for v1 workspace panes. When enabled, hovering over a pane briefly (10ms) moves both the visual border and keyboard focus to that pane's primary input. Disabled by default; feature is invisible to users who don't enable it.

Settings → Behavior → "Focus follows mouse".

## Scope

- v1 workspace pane layout only (`screens/main/components/WorkspaceView/...`). v2 is a separate effort.
- Within the active tab only — never switches tabs.
- 10ms hover delay (started at 75ms per spec; tuned down after live testing — 75ms felt laggy without meaningful transit-protection benefit).
- Suppression: open Radix menus/dialogs/popovers, in-flight pane drags, divider resizes, window blur, and mid-text-selection (mouse button down). Radix tooltips are **not** in the suppression set — they fire on hover and including them would defeat the feature.
- Per-pane primary-input handling: ChatPane already worked via `useFocusPromptOnPane`. Terminal and FileViewer (raw view) gained reactive `useEffect`s because their existing `isFocused`-driven paths only fired `.focus()` at mount. Markdown / Diff / Browser / Comment panes get the visual highlight on hover but no keyboard pull (matches today's click semantics).

## Architecture

Three layers in the renderer process:

1. `pane-preferences` zustand-persist store — `focusFollowsMouse: boolean`, default `false`.
2. `useHoverFocusSuppression` hook composing `useDragPaneStore` + `document.hasFocus()` + Radix `[data-state="open"]` selector + a document-level mousedown/mouseup listener into a stable `() => boolean`.
3. A hover-timer (`createHoverFocusTimer`) wired into `BasePaneWindow.tsx`. On fire we call `setFocusedPane(tabId, paneId)` from the existing tabs store; the rest of v1's reactivity carries it through.

Two new reactive focus effects (Terminal, FileViewer) close the gap where the pre-existing wiring only fired at mount.

## Test plan

- [x] 18 new unit tests pass (3 store + 8 timer + 7 suppression-decision)
- [x] Manual QA on all 14 spec scenarios:
  - Toggle persists across app restart
  - Hover-focus between Code/Code, Terminal/Terminal, Terminal/Chat, Code/Chat
  - Markdown view stays visual-only
  - 3-way split: focus does not land on the middle pane
  - Suppressions: dropdown open, pane drag, divider resize, ⌘-Tab away, mid-selection drag
  - App startup: keyboard not yanked (first-render guard)
  - Toggle OFF: hover does nothing
- [x] `bun run typecheck` clean (apps/desktop)
- [x] `bun run lint:fix` clean

## Notes for reviewers

- Storage divergence from sibling Behavior toggles is intentional. The other Behavior toggles (telemetry, confirm-on-quit, etc.) round-trip via `electronTrpc.settings.*` because main process consumes them; `focusFollowsMouse` is purely renderer DOM behavior, so zustand-persist + localStorage is proportionate.
- Independent of the parallel v2 effort on the existing `feature/focus-follows-mouse` branch — no shared imports. If both land, naming will already align.
- 12 commits in the branch — kept TDD/atomic per task to make review easier; happy to squash if preferred.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt‑in “Focus follows mouse” for v1 workspace panes. When enabled, hovering a pane for ~10ms moves the visual border and keyboard focus to that pane’s primary input; off by default.

- **New Features**
  - Settings → Behavior → “Focus follows mouse” toggle (persisted).
  - v1 panes only, within the active tab; 10ms hover delay.
  - Suppressed while menus/dialogs/popovers are open, during pane drag or divider resize, when the window is unfocused, or while selecting text.
  - Terminal and File Viewer (raw) pull keyboard focus on hover; Markdown/Diff/Browser/Comment remain visual-only.
  - Implemented via renderer `pane-preferences` store and a hover timer in `BasePaneWindow`; includes unit tests.

<sup>Written for commit 7cf75097410deeaf9c420ff3144d780945844eab. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3832?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Focus follows mouse" setting in behavior preferences. When enabled, panes automatically receive keyboard focus on hover, streamlining navigation between panes without manual selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->