### PR TITLE
fix(desktop): raise Chromium WebGL context cap to 256

### DIFF
--- a/apps/desktop/src/lib/electron-app/factories/app/setup.ts
+++ b/apps/desktop/src/lib/electron-app/factories/app/setup.ts
@@ -74,16 +74,12 @@ PLATFORM.IS_WINDOWS &&
 
 app.commandLine.appendSwitch("force-color-profile", "srgb");
 
-// Chromium's default active-WebGL-context cap is 16 per renderer process
-// (content/renderer/webgraphicscontext3d_provider_impl.cc). When exceeded,
-// Blink's ForciblyLoseOldestContext fires `webglcontextlost` on the oldest
-// xterm, producing the blank/garbled terminals reported in #3572, #3504,
-// #3527. Each pane's xterm holds one WebGL context, and the v2 parking model
-// keeps them alive across workspace switches — cumulative panes routinely
-// reach the low hundreds. VS Code's 32 covers their ~16-terminal budget but
-// is too low here; Tabby's 9000 is high enough to mask leaks. 256 sits in
-// the middle: 16× the default, covers low-hundreds of panes, and stays
-// bounded enough that a real leak still surfaces.
+// Each xterm pane holds one WebGL context. v2 parking keeps panes alive
+// across workspace switches, so cumulative contexts can reach the low
+// hundreds — past Chromium's default cap of 16, Blink force-evicts the
+// oldest context and the terminal blanks out. 256 covers the parking load
+// while staying bounded enough that a runaway leak still surfaces (Tabby
+// raises this to 9000, which masks leaks).
 app.commandLine.appendSwitch("max-active-webgl-contexts", "256");
 
 // Only expose CDP in development when a port is explicitly configured.

--- a/apps/desktop/src/lib/electron-app/factories/app/setup.ts
+++ b/apps/desktop/src/lib/electron-app/factories/app/setup.ts
@@ -74,6 +74,18 @@ PLATFORM.IS_WINDOWS &&
 
 app.commandLine.appendSwitch("force-color-profile", "srgb");
 
+// Chromium's default active-WebGL-context cap is 16 per renderer process
+// (content/renderer/webgraphicscontext3d_provider_impl.cc). When exceeded,
+// Blink's ForciblyLoseOldestContext fires `webglcontextlost` on the oldest
+// xterm, producing the blank/garbled terminals reported in #3572, #3504,
+// #3527. Each pane's xterm holds one WebGL context, and the v2 parking model
+// keeps them alive across workspace switches — cumulative panes routinely
+// reach the low hundreds. VS Code's 32 covers their ~16-terminal budget but
+// is too low here; Tabby's 9000 is high enough to mask leaks. 256 sits in
+// the middle: 16× the default, covers low-hundreds of panes, and stays
+// bounded enough that a real leak still surfaces.
+app.commandLine.appendSwitch("max-active-webgl-contexts", "256");
+
 // Only expose CDP in development when a port is explicitly configured.
 const cdpPort =
 	env.NODE_ENV === "development"


### PR DESCRIPTION
Chromium defaults `max-active-webgl-contexts` to 16 per renderer process. Each xterm holds one WebGL context, and the v2 parking model keeps panes alive across workspace switches, so cumulative panes routinely reach the low hundreds. Once over the cap, Blink forcibly fires `webglcontextlost` on the oldest pane, producing the blank/garbled terminals in #3572, #3504, #3527.

Raising to 256 covers low-hundreds of cumulative panes while staying bounded enough to surface a real leak. Does not address upstream xterm.js texture-atlas bugs (xtermjs/xterm.js#5849), which manifest as similar corruption but require a different fix.

## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise Chromium’s active WebGL context limit from 16 to 256 to stop terminals from blanking when many panes persist across workspace switches. Adds the `max-active-webgl-contexts` command-line switch so older contexts aren’t evicted under load.

<sup>Written for commit bc55d1788aab69c668a8f0d0249ac1a6a92beb4e. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3834">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced WebGL context handling to improve stability and performance when using terminal panes across multiple workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->