### PR TITLE
feat(desktop): indent workspaces under projects in v2 sidebar

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -128,7 +128,7 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 				}}
 				onDoubleClick={onDoubleClick}
 				className={cn(
-					"relative flex w-full items-center pl-3 pr-2 text-left text-sm",
+					"relative flex w-full items-center pl-5 pr-2 text-left text-sm",
 					onClick &&
 						(isActive
 							? "cursor-pointer hover:bg-muted"


### PR DESCRIPTION
## Summary
- Adds left padding (`pl-3` → `pl-5`) to the v2 sidebar workspace row so workspaces visually nest under their parent project.

## Test plan
- [ ] Open the v2 desktop sidebar and confirm workspaces sit indented relative to the project header
- [ ] Confirm workspaces inside sections still look correct
- [ ] Confirm active/hover/drag styles still render correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Indents workspace rows under their parent project in the v2 desktop sidebar by increasing left padding from `pl-3` to `pl-5` for clearer hierarchy.

<sup>Written for commit 9983b4587b39185ffd772cf612cf557352ad6b69. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3835">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted left padding in the dashboard sidebar's workspace section for improved visual spacing and layout alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->