### PR TITLE
fix(desktop): derive v2 workspace locality from workspace.hostId, not joined v2Hosts

### DIFF
--- a/apps/desktop/src/renderer/hooks/host-service/useWorkspaceHostUrl/useWorkspaceHostUrl.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useWorkspaceHostUrl/useWorkspaceHostUrl.ts
@@ -14,27 +14,23 @@ export function useWorkspaceHostUrl(workspaceId: string | null): string | null {
 	const collections = useCollections();
 	const { machineId, activeHostUrl } = useLocalHostService();
 
-	const { data: workspaceWithHost = [] } = useLiveQuery(
+	const { data: workspaceRows = [] } = useLiveQuery(
 		(q) =>
 			q
 				.from({ workspaces: collections.v2Workspaces })
-				.leftJoin({ hosts: collections.v2Hosts }, ({ workspaces, hosts }) =>
-					eq(workspaces.hostId, hosts.machineId),
-				)
 				.where(({ workspaces }) => eq(workspaces.id, workspaceId ?? ""))
-				.select(({ workspaces, hosts }) => ({
+				.select(({ workspaces }) => ({
 					organizationId: workspaces.organizationId,
 					hostId: workspaces.hostId,
-					hostMachineId: hosts?.machineId ?? null,
 				})),
 		[collections, workspaceId],
 	);
 
-	const match = workspaceId ? (workspaceWithHost[0] ?? null) : null;
+	const match = workspaceId ? (workspaceRows[0] ?? null) : null;
 
 	return useMemo(() => {
 		if (!match) return null;
-		if (match.hostMachineId === machineId) return activeHostUrl;
+		if (match.hostId === machineId) return activeHostUrl;
 		const routingKey = buildHostRoutingKey(match.organizationId, match.hostId);
 		return `${env.RELAY_URL}/hosts/${routingKey}`;
 	}, [match, machineId, activeHostUrl]);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/hooks/useDashboardSidebarPortsData/useDashboardSidebarPortsData.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/hooks/useDashboardSidebarPortsData/useDashboardSidebarPortsData.test.ts
@@ -172,19 +172,16 @@ describe("deriveHostPortQueryTargets", () => {
 					id: "workspace-b",
 					name: "Workspace B",
 					hostId: "local-machine",
-					hostMachineId: "local-machine",
 				},
 				{
 					id: "workspace-a",
 					name: "Workspace A",
 					hostId: "local-machine",
-					hostMachineId: "local-machine",
 				},
 				{
 					id: "workspace-c",
 					name: "Workspace C",
 					hostId: "remote-machine",
-					hostMachineId: "remote-machine",
 				},
 			],
 		});
@@ -227,13 +224,11 @@ describe("deriveHostPortQueryTargets", () => {
 					id: "workspace-remote",
 					name: "Remote",
 					hostId: "remote-machine",
-					hostMachineId: "remote-machine",
 				},
 				{
 					id: "workspace-local",
 					name: "Local",
 					hostId: "local-machine",
-					hostMachineId: "local-machine",
 				},
 			],
 		});
@@ -284,19 +279,17 @@ describe("groupDashboardSidebarPorts", () => {
 					],
 				},
 			],
-			machineId: "machine-1",
+			machineId: "host-1",
 			workspaces: [
 				{
 					id: "workspace-b",
 					name: "Beta",
 					hostId: "host-1",
-					hostMachineId: "machine-1",
 				},
 				{
 					id: "workspace-a",
 					name: "Alpha",
 					hostId: "host-1",
-					hostMachineId: "machine-1",
 				},
 			],
 		});
@@ -336,7 +329,6 @@ describe("groupDashboardSidebarPorts", () => {
 					id: "workspace-1",
 					name: "Workspace",
 					hostId: "host-2",
-					hostMachineId: "machine-2",
 				},
 			],
 		});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/hooks/useDashboardSidebarPortsData/useDashboardSidebarPortsData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/hooks/useDashboardSidebarPortsData/useDashboardSidebarPortsData.ts
@@ -2,7 +2,6 @@ import {
 	getEventBus,
 	type PortChangedPayload,
 } from "@superset/workspace-client";
-import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useQueries, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo } from "react";
@@ -52,14 +51,10 @@ export function useDashboardSidebarPortsData(): {
 		(q) =>
 			q
 				.from({ workspaces: collections.v2Workspaces })
-				.leftJoin({ hosts: collections.v2Hosts }, ({ workspaces, hosts }) =>
-					eq(workspaces.hostId, hosts.machineId),
-				)
-				.select(({ workspaces, hosts }) => ({
+				.select(({ workspaces }) => ({
 					id: workspaces.id,
 					name: workspaces.name,
 					hostId: workspaces.hostId,
-					hostMachineId: hosts?.machineId ?? null,
 				})),
 		[collections],
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/hooks/useDashboardSidebarPortsData/useDashboardSidebarPortsData.utils.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarPortsList/hooks/useDashboardSidebarPortsData/useDashboardSidebarPortsData.utils.ts
@@ -55,7 +55,6 @@ export interface DashboardSidebarWorkspaceRow {
 	id: string;
 	name: string;
 	hostId: string;
-	hostMachineId: string | null | undefined;
 }
 
 export function getHostPortsQueryKey(host: HostPortsQueryTarget) {
@@ -139,7 +138,7 @@ export function deriveHostPortQueryTargets({
 		workspaceIds.sort();
 	}
 
-	return hosts.flatMap((host) => {
+	const targets = hosts.flatMap((host) => {
 		const workspaceIds = workspaceIdsByHostId.get(host.machineId);
 		if (!workspaceIds || workspaceIds.length === 0) return [];
 
@@ -162,6 +161,28 @@ export function deriveHostPortQueryTargets({
 			},
 		];
 	});
+
+	// If the local v2Hosts row hasn't synced via Electric, the loop above won't
+	// include the local machine — which would hide its ports. Synthesize a
+	// local target from machineId + activeHostUrl whenever workspaces with
+	// hostId === machineId exist.
+	if (
+		machineId &&
+		activeHostUrl &&
+		!targets.some((target) => target.machineId === machineId)
+	) {
+		const localWorkspaceIds = workspaceIdsByHostId.get(machineId);
+		if (localWorkspaceIds && localWorkspaceIds.length > 0) {
+			targets.push({
+				machineId,
+				hostType: "local-device",
+				hostUrl: activeHostUrl,
+				workspaceIds: localWorkspaceIds,
+			});
+		}
+	}
+
+	return targets;
 }
 
 export function groupDashboardSidebarPorts({
@@ -180,11 +201,9 @@ export function groupDashboardSidebarPorts({
 				name: workspace.name,
 				hostId: workspace.hostId,
 				hostType:
-					workspace.hostMachineId == null
-						? ("cloud" as const)
-						: workspace.hostMachineId === machineId
-							? ("local-device" as const)
-							: ("remote-device" as const),
+					workspace.hostId === machineId
+						? ("local-device" as const)
+						: ("remote-device" as const),
 			},
 		]),
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -232,7 +232,7 @@ export function useDashboardSidebarData() {
 					({ sidebarWorkspaces, workspaces }) =>
 						eq(sidebarWorkspaces.workspaceId, workspaces.id),
 				)
-				.leftJoin({ hosts: collections.v2Hosts }, ({ workspaces, hosts }) =>
+				.innerJoin({ hosts: collections.v2Hosts }, ({ workspaces, hosts }) =>
 					eq(workspaces.hostId, hosts.machineId),
 				)
 				.orderBy(
@@ -243,9 +243,8 @@ export function useDashboardSidebarData() {
 					id: workspaces.id,
 					projectId: sidebarWorkspaces.sidebarState.projectId,
 					hostId: workspaces.hostId,
-					hostMachineId: hosts?.machineId ?? null,
 					type: workspaces.type,
-					hostIsOnline: hosts?.isOnline ?? null,
+					hostIsOnline: hosts.isOnline,
 					name: workspaces.name,
 					branch: workspaces.branch,
 					createdAt: workspaces.createdAt,
@@ -271,7 +270,7 @@ export function useDashboardSidebarData() {
 		(q) =>
 			q
 				.from({ workspaces: collections.v2Workspaces })
-				.leftJoin({ hosts: collections.v2Hosts }, ({ workspaces, hosts }) =>
+				.innerJoin({ hosts: collections.v2Hosts }, ({ workspaces, hosts }) =>
 					eq(workspaces.hostId, hosts.machineId),
 				)
 				.where(({ workspaces }) => eq(workspaces.type, "main"))
@@ -279,9 +278,8 @@ export function useDashboardSidebarData() {
 					id: workspaces.id,
 					projectId: workspaces.projectId,
 					hostId: workspaces.hostId,
-					hostMachineId: hosts?.machineId ?? null,
 					type: workspaces.type,
-					hostIsOnline: hosts?.isOnline ?? null,
+					hostIsOnline: hosts.isOnline,
 					name: workspaces.name,
 					branch: workspaces.branch,
 					createdAt: workspaces.createdAt,
@@ -299,8 +297,7 @@ export function useDashboardSidebarData() {
 		const autoLocalMainWorkspaces = localMainWorkspaces.filter(
 			(workspace) =>
 				!localStateWorkspaceIds.has(workspace.id) &&
-				workspace.hostMachineId != null &&
-				workspace.hostMachineId === machineId &&
+				workspace.hostId === machineId &&
 				sidebarProjectIds.has(workspace.projectId),
 		);
 
@@ -316,11 +313,7 @@ export function useDashboardSidebarData() {
 	const computedLocalWorkspaceIds = useMemo(
 		() =>
 			visibleSidebarWorkspaces
-				.filter(
-					(workspace) =>
-						workspace.hostMachineId != null &&
-						workspace.hostMachineId === machineId,
-				)
+				.filter((workspace) => workspace.hostId === machineId)
 				.map((workspace) => workspace.id)
 				.sort(),
 		[machineId, visibleSidebarWorkspaces],
@@ -404,11 +397,7 @@ export function useDashboardSidebarData() {
 			if (!project) continue;
 
 			const hostType: DashboardSidebarWorkspace["hostType"] =
-				workspace.hostMachineId == null
-					? "cloud"
-					: workspace.hostMachineId === machineId
-						? "local-device"
-						: "remote-device";
+				workspace.hostId === machineId ? "local-device" : "remote-device";
 
 			const sidebarWorkspace: DashboardSidebarWorkspace = {
 				id: workspace.id,
@@ -417,9 +406,7 @@ export function useDashboardSidebarData() {
 				hostType,
 				type: workspace.type,
 				hostIsOnline:
-					hostType === "remote-device"
-						? (workspace.hostIsOnline ?? null)
-						: null,
+					hostType === "remote-device" ? workspace.hostIsOnline : null,
 				accentColor: null,
 				name: workspace.name,
 				branch: workspace.branch,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/V2WorkspaceOpenInButton/V2WorkspaceOpenInButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/V2WorkspaceOpenInButton/V2WorkspaceOpenInButton.tsx
@@ -16,25 +16,21 @@ export function V2WorkspaceOpenInButton({
 	const collections = useCollections();
 	const { machineId, activeHostUrl } = useLocalHostService();
 
-	const { data: workspacesWithHost = [] } = useLiveQuery(
+	const { data: workspaces = [] } = useLiveQuery(
 		(q) =>
 			q
 				.from({ workspaces: collections.v2Workspaces })
-				.leftJoin({ hosts: collections.v2Hosts }, ({ workspaces, hosts }) =>
-					eq(workspaces.hostId, hosts.machineId),
-				)
 				.where(({ workspaces }) => eq(workspaces.id, workspaceId))
-				.select(({ workspaces, hosts }) => ({
+				.select(({ workspaces }) => ({
 					id: workspaces.id,
 					branch: workspaces.branch,
 					projectId: workspaces.projectId,
-					hostMachineId: hosts?.machineId ?? null,
+					hostId: workspaces.hostId,
 				})),
 		[collections, workspaceId],
 	);
-	const workspace = workspacesWithHost[0] ?? null;
-	const isLocalWorkspace =
-		Boolean(workspace) && workspace.hostMachineId === machineId;
+	const workspace = workspaces[0] ?? null;
+	const isLocalWorkspace = Boolean(workspace) && workspace.hostId === machineId;
 
 	const workspaceQuery = useQuery({
 		queryKey: ["v2-open-in-workspace", activeHostUrl, workspaceId],

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useOpenInExternalEditor/useOpenInExternalEditor.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useOpenInExternalEditor/useOpenInExternalEditor.ts
@@ -16,22 +16,19 @@ export interface OpenInExternalEditorOptions {
 export function useOpenInExternalEditor(workspaceId: string) {
 	const collections = useCollections();
 	const { machineId } = useLocalHostService();
-	const { data: workspacesWithHost = [] } = useLiveQuery(
+	const { data: workspaceRows = [] } = useLiveQuery(
 		(q) =>
 			q
 				.from({ workspaces: collections.v2Workspaces })
-				.leftJoin({ hosts: collections.v2Hosts }, ({ workspaces, hosts }) =>
-					eq(workspaces.hostId, hosts.machineId),
-				)
 				.where(({ workspaces }) => eq(workspaces.id, workspaceId))
-				.select(({ workspaces, hosts }) => ({
-					hostMachineId: hosts?.machineId ?? null,
+				.select(({ workspaces }) => ({
+					hostId: workspaces.hostId,
 					projectId: workspaces.projectId ?? null,
 				})),
 		[collections, workspaceId],
 	);
-	const workspaceHost = workspacesWithHost[0];
-	const projectId = workspaceHost?.projectId ?? undefined;
+	const workspaceRow = workspaceRows[0];
+	const projectId = workspaceRow?.projectId ?? undefined;
 
 	// Forward the v2 CMD+O choice as an explicit app override; the server
 	// can't look this up on its own (v2 projects aren't in the v1 localDb).
@@ -44,9 +41,7 @@ export function useOpenInExternalEditor(workspaceId: string) {
 
 	return useCallback(
 		(path: string, opts?: OpenInExternalEditorOptions) => {
-			// Treat unloaded host data as non-local to avoid firing the mutation
-			// against a potentially remote workspace before locality is confirmed.
-			if (workspaceHost?.hostMachineId !== machineId) {
+			if (workspaceRow?.hostId !== machineId) {
 				toast.error("Can't open remote workspace paths in an external editor");
 				return;
 			}
@@ -64,6 +59,6 @@ export function useOpenInExternalEditor(workspaceId: string) {
 					toast.error("Failed to open in external editor");
 				});
 		},
-		[workspaceHost, machineId, projectId, worktreePath, v2PreferredApp],
+		[workspaceRow, machineId, projectId, worktreePath, v2PreferredApp],
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/layout.tsx
@@ -31,27 +31,23 @@ function V2WorkspaceLayout() {
 	const { machineId, activeHostUrl } = useLocalHostService();
 	const { ensureWorkspaceInSidebar } = useDashboardSidebarState();
 
-	const { data: workspacesWithHost = [], isReady } = useLiveQuery(
+	const { data: workspaces = [], isReady } = useLiveQuery(
 		(q) =>
 			q
 				.from({ v2Workspaces: collections.v2Workspaces })
-				.leftJoin({ hosts: collections.v2Hosts }, ({ v2Workspaces, hosts }) =>
-					eq(v2Workspaces.hostId, hosts.machineId),
-				)
 				.where(({ v2Workspaces }) => eq(v2Workspaces.id, workspaceId ?? ""))
-				.select(({ v2Workspaces, hosts }) => ({
+				.select(({ v2Workspaces }) => ({
 					id: v2Workspaces.id,
 					organizationId: v2Workspaces.organizationId,
 					hostId: v2Workspaces.hostId,
-					hostMachineId: hosts?.machineId ?? null,
 					projectId: v2Workspaces.projectId,
 					branch: v2Workspaces.branch,
 				})),
 		[collections, workspaceId],
 	);
-	const workspace = workspacesWithHost[0] ?? null;
+	const workspace = workspaces[0] ?? null;
 
-	const isLocal = workspace?.hostMachineId === machineId;
+	const isLocal = workspace?.hostId === machineId;
 	const hostUrl = !workspace
 		? null
 		: isLocal

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces/useAccessibleV2Workspaces.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces/useAccessibleV2Workspaces.ts
@@ -24,7 +24,6 @@ export interface AccessibleV2Workspace {
 	projectName: string;
 	hostId: string;
 	hostName: string;
-	hostMachineId: string | null;
 	hostIsOnline: boolean;
 	hostType: V2WorkspaceHostType;
 	isInSidebar: boolean;
@@ -135,9 +134,8 @@ export function useAccessibleV2Workspaces(
 						createdByImage: creators?.image ?? null,
 						projectId: projects.id,
 						projectName: projects.name,
-						hostId: hosts.machineId,
+						hostId: workspaces.hostId,
 						hostName: hosts.name,
-						hostMachineId: hosts.machineId,
 						hostIsOnline: hosts.isOnline,
 						sidebarProjectId: sidebarProject?.projectId ?? null,
 						sidebarWorkspaceId: sidebarState?.workspaceId ?? null,
@@ -152,15 +150,10 @@ export function useAccessibleV2Workspaces(
 		for (const row of rows) {
 			if (deduped.has(row.id)) continue;
 			const hostType: V2WorkspaceHostType =
-				row.hostMachineId == null
-					? "cloud"
-					: row.hostMachineId === machineId
-						? "local-device"
-						: "remote-device";
+				row.hostId === machineId ? "local-device" : "remote-device";
 			const isAutoVisibleMain =
 				row.type === "main" &&
-				row.hostMachineId != null &&
-				row.hostMachineId === machineId &&
+				row.hostId === machineId &&
 				row.sidebarProjectId != null;
 			const isInSidebar =
 				isSidebarWorkspaceVisible({ isHidden: row.sidebarIsHidden }) &&
@@ -181,7 +174,6 @@ export function useAccessibleV2Workspaces(
 				projectName: row.projectName,
 				hostId: row.hostId,
 				hostName: row.hostName,
-				hostMachineId: row.hostMachineId,
 				hostIsOnline: row.hostIsOnline,
 				hostType,
 				isInSidebar,

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/DevicePicker/hooks/useWorkspaceHostOptions/useWorkspaceHostOptions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/DevicePicker/hooks/useWorkspaceHostOptions/useWorkspaceHostOptions.ts
@@ -70,9 +70,11 @@ export function useWorkspaceHostOptions(): UseWorkspaceHostOptionsResult {
 		[accessibleHosts, machineId],
 	);
 
+	// Always surface the local device, even if its v2Hosts row hasn't synced
+	// via Electric — the picker is useless without "this device" present.
 	return {
-		currentDeviceName: localHost?.name ?? null,
-		localHostId: localHost?.machineId ?? null,
+		currentDeviceName: localHost?.name ?? (machineId ? "This device" : null),
+		localHostId: localHost?.machineId ?? machineId,
 		activeHostUrl,
 		otherHosts,
 	};

--- a/apps/desktop/src/renderer/routes/_authenticated/components/GlobalTerminalLifecycle/hooks/useGlobalTerminalLifecycle/useGlobalTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/GlobalTerminalLifecycle/hooks/useGlobalTerminalLifecycle/useGlobalTerminalLifecycle.ts
@@ -1,6 +1,5 @@
 import type { WorkspaceState } from "@superset/panes";
 import { buildHostRoutingKey } from "@superset/shared/host-routing";
-import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useEffect, useMemo, useRef } from "react";
 import { env } from "renderer/env.renderer";
@@ -129,26 +128,22 @@ export function useGlobalTerminalLifecycle() {
 		[collections],
 	);
 
-	const { data: workspacesWithHosts = [] } = useLiveQuery(
+	const { data: workspaceRows = [] } = useLiveQuery(
 		(query) =>
 			query
 				.from({ v2Workspaces: collections.v2Workspaces })
-				.leftJoin({ hosts: collections.v2Hosts }, ({ v2Workspaces, hosts }) =>
-					eq(v2Workspaces.hostId, hosts.machineId),
-				)
-				.select(({ v2Workspaces, hosts }) => ({
+				.select(({ v2Workspaces }) => ({
 					workspaceId: v2Workspaces.id,
 					organizationId: v2Workspaces.organizationId,
 					hostId: v2Workspaces.hostId,
-					hostMachineId: hosts?.machineId ?? null,
 				})),
 		[collections],
 	);
 
 	const hostUrlByWorkspaceId = useMemo(() => {
 		const urls = new Map<string, string>();
-		for (const workspace of workspacesWithHosts) {
-			if (workspace.hostMachineId === machineId) {
+		for (const workspace of workspaceRows) {
+			if (workspace.hostId === machineId) {
 				if (activeHostUrl) {
 					urls.set(workspace.workspaceId, activeHostUrl);
 				}
@@ -163,7 +158,7 @@ export function useGlobalTerminalLifecycle() {
 			}
 		}
 		return urls;
-	}, [activeHostUrl, machineId, workspacesWithHosts]);
+	}, [activeHostUrl, machineId, workspaceRows]);
 	const hostUrlByWorkspaceIdRef = useRef(hostUrlByWorkspaceId);
 	hostUrlByWorkspaceIdRef.current = hostUrlByWorkspaceId;
 

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/V2NotificationController.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/V2NotificationController.tsx
@@ -1,6 +1,5 @@
 import type { WorkspaceState } from "@superset/panes";
 import { buildHostRoutingKey } from "@superset/shared/host-routing";
-import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useMemo } from "react";
 import { env } from "renderer/env.renderer";
@@ -16,7 +15,6 @@ interface WorkspaceHostRow {
 	workspaceId: string;
 	organizationId: string;
 	hostId: string;
-	hostMachineId: string | null | undefined;
 }
 
 interface HostNotificationSubscriberGroup {
@@ -40,16 +38,10 @@ export function V2NotificationController() {
 		(q) =>
 			q
 				.from({ v2Workspaces: collections.v2Workspaces })
-				.leftJoin(
-					{ v2Hosts: collections.v2Hosts },
-					({ v2Workspaces, v2Hosts }) =>
-						eq(v2Workspaces.hostId, v2Hosts.machineId),
-				)
-				.select(({ v2Workspaces, v2Hosts }) => ({
+				.select(({ v2Workspaces }) => ({
 					workspaceId: v2Workspaces.id,
 					organizationId: v2Workspaces.organizationId,
 					hostId: v2Workspaces.hostId,
-					hostMachineId: v2Hosts?.machineId ?? null,
 				})),
 		[collections],
 	);
@@ -113,7 +105,6 @@ function groupWorkspacesByHostUrl({
 		const hostUrl = getHostUrlForWorkspace({
 			organizationId: workspace.organizationId,
 			hostId: workspace.hostId,
-			hostMachineId: workspace.hostMachineId,
 			machineId,
 			activeHostUrl,
 		});
@@ -136,17 +127,15 @@ function groupWorkspacesByHostUrl({
 function getHostUrlForWorkspace({
 	organizationId,
 	hostId,
-	hostMachineId,
 	machineId,
 	activeHostUrl,
 }: {
 	organizationId: string;
 	hostId: string;
-	hostMachineId: string | null | undefined;
 	machineId: string | null;
 	activeHostUrl: string | null;
 }): string | null {
-	if (hostMachineId && machineId && hostMachineId === machineId) {
+	if (machineId && hostId === machineId) {
 		return activeHostUrl;
 	}
 	return `${env.RELAY_URL}/hosts/${buildHostRoutingKey(organizationId, hostId)}`;


### PR DESCRIPTION
## Summary
- Workspaces that loaded while Electric was still syncing `v2Hosts` were routed through the cloud relay instead of the local host service. The locality check in `v2-workspace/layout.tsx` (and 5 sibling sites) leftJoined `v2Workspaces → v2Hosts` and compared `joined.hostMachineId === machineId` — when Electric hadn't synced the host row, the joined value was `null`, the equality failed, and the entire `WorkspaceTrpcProvider` got pointed at `${RELAY_URL}/hosts/...`.
- `v2Workspaces.hostId` is `notNull` and FKs to `v2Hosts.machineId`, so the workspace already carries the value the join was producing. Switched locality to `workspace.hostId === machineId` everywhere. Routing-only paths drop the `v2Hosts` join entirely; metadata-display paths (sidebar / list) keep an `innerJoin` for host name + `isOnline`.
- Side-fixes for the same root cause: `useAccessibleV2Workspaces` now stays innerJoin (cleaner; rows briefly hide while Electric catches up but workspaces remain routable via direct URL); `DashboardSidebarPortsList` synthesizes a local-host port-query target so local ports show without a synced `v2Hosts` row; `DevicePicker` synthesizes "this device" so the picker never loses the local entry.

## Test plan
- [ ] `bun run lint:fix` — clean
- [ ] `bun run typecheck` — clean
- [ ] `bun test` (desktop) — 1870 pass
- [ ] Manually clear `v2Hosts` in tanstack-db inspector, navigate to `/v2-workspace/$workspaceId`, confirm `WorkspaceTrpcProvider` connects to `http://127.0.0.1:<port>` (not the relay) and the workspace loads
- [ ] DevicePicker: with `v2Hosts` cleared, "this device" still appears as default
- [ ] Sidebar ports: with `v2Hosts` cleared, local ports still render
- [ ] Don't regress remote routing: open a workspace whose `hostId` is a different machine; confirm it still routes via `${RELAY_URL}/hosts/<key>`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes v2 workspace routing by deriving locality from `v2Workspaces.hostId === machineId`, avoiding relay misrouting when `v2Hosts` hasn’t synced. Also keeps local ports and “this device” visible even if the local host row is missing.

- **Bug Fixes**
  - Route workspace TRPC, notifications, terminal, and “Open in” via local host when `hostId === machineId`; otherwise use the relay URL.
  - Prevent local ports from disappearing by synthesizing a local host target from `machineId` + `activeHostUrl`.
  - Ensure DevicePicker always shows “this device” using `machineId` when the local `v2Hosts` row is missing.

- **Refactors**
  - Removed `v2Hosts` leftJoin from routing-only queries; compare `hostId` directly.
  - Kept `innerJoin` to `v2Hosts` only where host metadata (name, `isOnline`) is displayed.
  - Simplified `hostType` derivation to `hostId === machineId ? "local-device" : "remote-device"`.

<sup>Written for commit 5e6513a181f32879d761af741c6c1552b697b927. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3837">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified workspace-to-host relationship handling across the application.
  * Streamlined local and remote device classification logic.
  * Optimized database queries for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->