### PR TITLE
feat(desktop): persist Electric collections to SQLite for offline launch

### DIFF
--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -40,13 +40,3 @@ export const createMyRouter = () => {
   });
 };
 ```
-
-## TanStack DB persistence
-
-Synced collections in `src/renderer/.../CollectionsProvider/collections.ts` are persisted to SQLite at `~/.superset/tanstack-db.sqlite` via `@tanstack/electron-db-sqlite-persistence`. Local cache survives cold start so the app's core shell renders offline.
-
-- **Synced collections** use `createPersistedElectricCollection(electricCollectionOptions<T>(...))`. The helper wraps with `persistedCollectionOptions` + `schemaVersion: 1` + adds index defaults.
-- **Local-only collections** (sidebar layout, terminal presets, user preferences, etc.) stay on `localStorageCollectionOptions` via `createIndexedCollection(...)`. They were already offline-capable; migrating them to SQLite is a separate effort with data-migration risk (Date round-trip, base64 payloads, opaque deep objects).
-- **Schema evolution:** prefer additive Zod changes (`.optional().default(...)`) — no `schemaVersion` bump. Only bump `schemaVersion` for breaking changes (rename, type change, `getKey` change). Bumping a synced collection clears its local cache and triggers a fresh Electric pull (server is canonical, no data loss). Bumping a local-only collection throws unless paired with an explicit migration hook.
-- **Migration hooks** for future local-only schema changes: place under `routes/_authenticated/hooks/useMigrate*/`, mount from `CollectionsProvider`, follow the `useMigrateV1PresetsToV2` template (read old, transform, write new, set sentinel for idempotency).
-- **Data isolation:** each collection's id is org-scoped (e.g. `tasks-${organizationId}`), so SQLite tables don't collide across orgs. The DB file is machine-wide (matches `~/.superset/local.db`); not cleared on sign-out.

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -40,3 +40,13 @@ export const createMyRouter = () => {
   });
 };
 ```
+
+## TanStack DB persistence
+
+Synced collections in `src/renderer/.../CollectionsProvider/collections.ts` are persisted to SQLite at `~/.superset/tanstack-db.sqlite` via `@tanstack/electron-db-sqlite-persistence`. Local cache survives cold start so the app's core shell renders offline.
+
+- **Synced collections** use `createPersistedElectricCollection(electricCollectionOptions<T>(...))`. The helper wraps with `persistedCollectionOptions` + `schemaVersion: 1` + adds index defaults.
+- **Local-only collections** (sidebar layout, terminal presets, user preferences, etc.) stay on `localStorageCollectionOptions` via `createIndexedCollection(...)`. They were already offline-capable; migrating them to SQLite is a separate effort with data-migration risk (Date round-trip, base64 payloads, opaque deep objects).
+- **Schema evolution:** prefer additive Zod changes (`.optional().default(...)`) — no `schemaVersion` bump. Only bump `schemaVersion` for breaking changes (rename, type change, `getKey` change). Bumping a synced collection clears its local cache and triggers a fresh Electric pull (server is canonical, no data loss). Bumping a local-only collection throws unless paired with an explicit migration hook.
+- **Migration hooks** for future local-only schema changes: place under `routes/_authenticated/hooks/useMigrate*/`, mount from `CollectionsProvider`, follow the `useMigrateV1PresetsToV2` template (read old, transform, write new, set sentinel for idempotency).
+- **Data isolation:** each collection's id is org-scoped (e.g. `tasks-${organizationId}`), so SQLite tables don't collide across orgs. The DB file is machine-wide (matches `~/.superset/local.db`); not cleared on sign-out.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -98,6 +98,8 @@
 		"@t3-oss/env-core": "^0.13.8",
 		"@tanstack/db": "0.6.5",
 		"@tanstack/electric-db-collection": "0.3.3",
+		"@tanstack/electron-db-sqlite-persistence": "0.1.9",
+		"@tanstack/node-db-sqlite-persistence": "0.1.9",
 		"@tanstack/react-db": "0.1.83",
 		"@tanstack/react-query": "^5.90.19",
 		"@tanstack/react-router": "^1.147.3",

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -33,6 +33,10 @@ import { loadWebviewBrowserExtension } from "./lib/extensions";
 import { getHostServiceCoordinator } from "./lib/host-service-coordinator";
 import { localDb } from "./lib/local-db";
 import { requestLocalNetworkAccess } from "./lib/local-network-permission";
+import {
+	initTanstackDbPersistence,
+	shutdownTanstackDbPersistence,
+} from "./lib/persistence/persistence";
 import { ensureProjectIconsDir, getProjectIconPath } from "./lib/project-icons";
 import { initSentry } from "./lib/sentry";
 import {
@@ -207,6 +211,7 @@ app.on("before-quit", async (event) => {
 	isQuitting = true;
 	try {
 		getHostServiceCoordinator().releaseAll();
+		shutdownTanstackDbPersistence();
 		disposeTray();
 	} catch (error) {
 		console.error("[main] Cleanup during quit failed:", error);
@@ -345,6 +350,7 @@ if (!gotTheLock) {
 		setWorkspaceDockIcon();
 		initSentry();
 		await initAppState();
+		initTanstackDbPersistence();
 
 		await loadWebviewBrowserExtension();
 

--- a/apps/desktop/src/main/lib/persistence/persistence.ts
+++ b/apps/desktop/src/main/lib/persistence/persistence.ts
@@ -9,10 +9,11 @@ import {
 } from "../app-environment";
 
 let dispose: (() => void) | null = null;
+let database: Database.Database | null = null;
 
 export function initTanstackDbPersistence(): void {
 	ensureSupersetHomeDirExists();
-	const database = new Database(join(SUPERSET_HOME_DIR, "tanstack-db.sqlite"));
+	database = new Database(join(SUPERSET_HOME_DIR, "tanstack-db.sqlite"));
 	const persistence = createNodeSQLitePersistence({ database });
 	dispose = exposeElectronSQLitePersistence({ ipcMain, persistence });
 }
@@ -20,4 +21,6 @@ export function initTanstackDbPersistence(): void {
 export function shutdownTanstackDbPersistence(): void {
 	dispose?.();
 	dispose = null;
+	database?.close();
+	database = null;
 }

--- a/apps/desktop/src/main/lib/persistence/persistence.ts
+++ b/apps/desktop/src/main/lib/persistence/persistence.ts
@@ -1,0 +1,23 @@
+import { join } from "node:path";
+import { exposeElectronSQLitePersistence } from "@tanstack/electron-db-sqlite-persistence/main";
+import { createNodeSQLitePersistence } from "@tanstack/node-db-sqlite-persistence";
+import Database from "better-sqlite3";
+import { ipcMain } from "electron";
+import {
+	ensureSupersetHomeDirExists,
+	SUPERSET_HOME_DIR,
+} from "../app-environment";
+
+let dispose: (() => void) | null = null;
+
+export function initTanstackDbPersistence(): void {
+	ensureSupersetHomeDirExists();
+	const database = new Database(join(SUPERSET_HOME_DIR, "tanstack-db.sqlite"));
+	const persistence = createNodeSQLitePersistence({ database });
+	dispose = exposeElectronSQLitePersistence({ ipcMain, persistence });
+}
+
+export function shutdownTanstackDbPersistence(): void {
+	dispose?.();
+	dispose = null;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/TasksView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/TasksView.tsx
@@ -1,4 +1,3 @@
-import { Spinner } from "@superset/ui/spinner";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -78,7 +77,7 @@ export function TasksView({
 		storeSetSearch(searchQuery);
 	}, [searchQuery, storeSetSearch]);
 
-	const { data: integrations, isLoading: isCheckingLinear } = useLiveQuery(
+	const { data: integrations } = useLiveQuery(
 		(q) =>
 			q
 				.from({ integrationConnections: collections.integrationConnections })
@@ -134,7 +133,7 @@ export function TasksView({
 		});
 	};
 
-	const showLinearCTA = !isCheckingLinear && !isLinearConnected;
+	const showLinearCTA = integrations !== undefined && !isLinearConnected;
 
 	return (
 		<div className="flex-1 flex flex-col min-h-0 min-w-0 overflow-hidden">
@@ -153,11 +152,7 @@ export function TasksView({
 				/>
 			)}
 
-			{isCheckingLinear ? (
-				<div className="flex-1 flex items-center justify-center">
-					<Spinner className="size-5" />
-				</div>
-			) : showLinearCTA ? (
+			{showLinearCTA ? (
 				<LinearCTA />
 			) : viewMode === "board" ? (
 				<BoardContent

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/BoardContent/BoardContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/BoardContent/BoardContent.tsx
@@ -1,4 +1,3 @@
-import { Spinner } from "@superset/ui/spinner";
 import { HiCheckCircle } from "react-icons/hi2";
 import type { TaskWithStatus } from "../../hooks/useTasksData";
 import { useTasksData } from "../../hooks/useTasksData";
@@ -18,19 +17,11 @@ export function BoardContent({
 	assigneeFilter,
 	onTaskClick,
 }: BoardContentProps) {
-	const { data, allStatuses, isLoading } = useTasksData({
+	const { data, allStatuses } = useTasksData({
 		filterTab,
 		searchQuery,
 		assigneeFilter,
 	});
-
-	if (isLoading) {
-		return (
-			<div className="flex-1 flex items-center justify-center">
-				<Spinner className="size-5" />
-			</div>
-		);
-	}
 
 	if (data.length === 0) {
 		return (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TableContent/TableContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TableContent/TableContent.tsx
@@ -1,4 +1,3 @@
-import { Spinner } from "@superset/ui/spinner";
 import { useCallback, useEffect, useMemo } from "react";
 import { HiCheckCircle } from "react-icons/hi2";
 import type { TaskWithStatus } from "../../hooks/useTasksData";
@@ -25,7 +24,7 @@ export function TableContent({
 	onTaskClick,
 	onSelectionChange,
 }: TableContentProps) {
-	const { table, isLoading, slugColumnWidth, rowSelection, setRowSelection } =
+	const { table, slugColumnWidth, rowSelection, setRowSelection } =
 		useTasksTable({
 			filterTab,
 			searchQuery,
@@ -43,14 +42,6 @@ export function TableContent({
 	useEffect(() => {
 		onSelectionChange?.(selectedTasks, clearSelection);
 	}, [selectedTasks, clearSelection, onSelectionChange]);
-
-	if (isLoading) {
-		return (
-			<div className="flex-1 flex items-center justify-center">
-				<Spinner className="size-5" />
-			</div>
-		);
-	}
 
 	if (table.getRowModel().rows.length === 0) {
 		return (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/hooks/useTasksData/useTasksData.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/hooks/useTasksData/useTasksData.tsx
@@ -29,11 +29,10 @@ export function useTasksData({
 }: UseTasksDataParams): {
 	data: TaskWithStatus[];
 	allStatuses: SelectTaskStatus[];
-	isLoading: boolean;
 } {
 	const collections = useCollections();
 
-	const { data: allData, isLoading } = useLiveQuery(
+	const { data: allData } = useLiveQuery(
 		(q) =>
 			q
 				.from({ tasks: collections.tasks })
@@ -52,7 +51,7 @@ export function useTasksData({
 		[collections],
 	);
 
-	const { data: statusData, isLoading: isStatusesLoading } = useLiveQuery(
+	const { data: statusData } = useLiveQuery(
 		(q) =>
 			q
 				.from({ taskStatuses: collections.taskStatuses })
@@ -119,6 +118,5 @@ export function useTasksData({
 	return {
 		data: filteredData,
 		allStatuses,
-		isLoading: isLoading || isStatusesLoading,
 	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/hooks/useTasksTable/useTasksTable.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/hooks/useTasksTable/useTasksTable.tsx
@@ -71,7 +71,6 @@ export function useTasksTable({
 	assigneeFilter,
 }: UseTasksTableParams): {
 	table: Table<TaskWithStatus>;
-	isLoading: boolean;
 	slugColumnWidth: string;
 	rowSelection: RowSelectionState;
 	setRowSelection: (
@@ -87,7 +86,7 @@ export function useTasksTable({
 	const rowSelection = useRowSelectionStore((s) => s.rowSelection);
 	const setRowSelection = useRowSelectionStore((s) => s.setRowSelection);
 
-	const { data: allData, isLoading } = useLiveQuery(
+	const { data: allData } = useLiveQuery(
 		(q) =>
 			q
 				.from({ tasks: collections.tasks })
@@ -348,5 +347,5 @@ export function useTasksTable({
 		autoResetExpanded: false,
 	});
 
-	return { table, isLoading, slugColumnWidth, rowSelection, setRowSelection };
+	return { table, slugColumnWidth, rowSelection, setRowSelection };
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
@@ -24,6 +24,10 @@ import type {
 } from "@superset/db/schema";
 import type { AppRouter } from "@superset/trpc";
 import { electricCollectionOptions } from "@tanstack/electric-db-collection";
+import {
+	createElectronSQLitePersistence,
+	persistedCollectionOptions,
+} from "@tanstack/electron-db-sqlite-persistence";
 import type {
 	Collection,
 	LocalStorageCollectionUtils,
@@ -57,6 +61,10 @@ const columnMapper = snakeCamelMapper();
 
 const electricUrl = `${env.NEXT_PUBLIC_ELECTRIC_URL}/v1/shape`;
 
+const persistence = createElectronSQLitePersistence({
+	invoke: (channel, request) => window.ipcRenderer.invoke(channel, request),
+});
+
 const indexDefaults = {
 	autoIndex: "eager",
 	defaultIndexType: BasicIndex,
@@ -66,6 +74,21 @@ const createIndexedCollection = ((
 	config: Parameters<typeof createCollection>[0],
 ) =>
 	createCollection({ ...config, ...indexDefaults })) as typeof createCollection;
+
+type ElectricSyncConfig = ReturnType<typeof electricCollectionOptions>;
+const createPersistedElectricCollection = ((config: ElectricSyncConfig) => {
+	const persisted = persistedCollectionOptions({
+		...config,
+		persistence,
+		schemaVersion: 1,
+		// biome-ignore lint/suspicious/noExplicitAny: forces sync-wrapped overload
+	} as any);
+	return createCollection({
+		...persisted,
+		...indexDefaults,
+		// biome-ignore lint/suspicious/noExplicitAny: persisted utils widen generics
+	} as any);
+}) as unknown as typeof createCollection;
 
 const apiKeyDisplaySchema = z.object({
 	id: z.string(),
@@ -176,7 +199,7 @@ const electricHeaders = {
 	},
 };
 
-const organizationsCollection = createIndexedCollection(
+const organizationsCollection = createPersistedElectricCollection(
 	electricCollectionOptions<SelectOrganization>({
 		id: "organizations",
 		shapeOptions: {
@@ -190,7 +213,7 @@ const organizationsCollection = createIndexedCollection(
 );
 
 function createOrgCollections(organizationId: string): OrgCollections {
-	const tasks = createIndexedCollection(
+	const tasks = createPersistedElectricCollection(
 		electricCollectionOptions<SelectTask>({
 			id: `tasks-${organizationId}`,
 			shapeOptions: {
@@ -224,7 +247,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 		}),
 	);
 
-	const taskStatuses = createIndexedCollection(
+	const taskStatuses = createPersistedElectricCollection(
 		electricCollectionOptions<SelectTaskStatus>({
 			id: `task_statuses-${organizationId}`,
 			shapeOptions: {
@@ -240,7 +263,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 		}),
 	);
 
-	const projects = createIndexedCollection(
+	const projects = createPersistedElectricCollection(
 		electricCollectionOptions<SelectProject>({
 			id: `projects-${organizationId}`,
 			shapeOptions: {
@@ -256,7 +279,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 		}),
 	);
 
-	const v2Projects = createIndexedCollection(
+	const v2Projects = createPersistedElectricCollection(
 		electricCollectionOptions<SelectV2Project>({
 			id: `v2_projects-${organizationId}`,
 			shapeOptions: {
@@ -288,7 +311,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 		}),
 	);
 
-	const v2Hosts = createIndexedCollection(
+	const v2Hosts = createPersistedElectricCollection(
 		electricCollectionOptions<SelectV2Host>({
 			id: `v2_hosts-${organizationId}`,
 			shapeOptions: {
@@ -306,7 +329,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 		}),
 	);
 
-	const v2Clients = createIndexedCollection(
+	const v2Clients = createPersistedElectricCollection(
 		electricCollectionOptions<SelectV2Client>({
 			id: `v2_clients-${organizationId}`,
 			shapeOptions: {
@@ -324,7 +347,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 		}),
 	);
 
-	const v2UsersHosts = createIndexedCollection(
+	const v2UsersHosts = createPersistedElectricCollection(
 		electricCollectionOptions<SelectV2UsersHosts>({
 			id: `v2_users_hosts-${organizationId}`,
 			shapeOptions: {
@@ -369,7 +392,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 		}),
 	);
 
-	const v2Workspaces = createIndexedCollection(
+	const v2Workspaces = createPersistedElectricCollection(
 		electricCollectionOptions<SelectV2Workspace>({
 			id: `v2_workspaces-${organizationId}`,
 			shapeOptions: {
@@ -396,7 +419,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 		}),
 	);
 
-	const workspaces = createIndexedCollection(
+	const workspaces = createPersistedElectricCollection(
 		electricCollectionOptions<SelectWorkspace>({
 			id: `workspaces-${organizationId}`,
 			shapeOptions: {
@@ -412,7 +435,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 		}),
 	);
 
-	const members = createIndexedCollection(
+	const members = createPersistedElectricCollection(
 		electricCollectionOptions<SelectMember>({
 			id: `members-${organizationId}`,
 			shapeOptions: {
@@ -428,7 +451,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 		}),
 	);
 
-	const users = createIndexedCollection(
+	const users = createPersistedElectricCollection(
 		electricCollectionOptions<SelectUser>({
 			id: `users-${organizationId}`,
 			shapeOptions: {
@@ -444,7 +467,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 		}),
 	);
 
-	const invitations = createIndexedCollection(
+	const invitations = createPersistedElectricCollection(
 		electricCollectionOptions<SelectInvitation>({
 			id: `invitations-${organizationId}`,
 			shapeOptions: {
@@ -460,7 +483,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 		}),
 	);
 
-	const agentCommands = createIndexedCollection(
+	const agentCommands = createPersistedElectricCollection(
 		electricCollectionOptions<SelectAgentCommand>({
 			id: `agent_commands-${organizationId}`,
 			shapeOptions: {
@@ -484,7 +507,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 		}),
 	);
 
-	const integrationConnections = createIndexedCollection(
+	const integrationConnections = createPersistedElectricCollection(
 		electricCollectionOptions<IntegrationConnectionDisplay>({
 			id: `integration_connections-${organizationId}`,
 			shapeOptions: {
@@ -500,7 +523,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 		}),
 	);
 
-	const subscriptions = createIndexedCollection(
+	const subscriptions = createPersistedElectricCollection(
 		electricCollectionOptions<SelectSubscription>({
 			id: `subscriptions-${organizationId}`,
 			shapeOptions: {
@@ -516,7 +539,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 		}),
 	);
 
-	const apiKeys = createIndexedCollection(
+	const apiKeys = createPersistedElectricCollection(
 		electricCollectionOptions<ApiKeyDisplay>({
 			id: `apikeys-${organizationId}`,
 			shapeOptions: {
@@ -532,7 +555,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 		}),
 	);
 
-	const chatSessions = createIndexedCollection(
+	const chatSessions = createPersistedElectricCollection(
 		electricCollectionOptions<SelectChatSession>({
 			id: `chat_sessions-${organizationId}`,
 			shapeOptions: {
@@ -558,7 +581,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 		}),
 	);
 
-	const githubRepositories = createIndexedCollection(
+	const githubRepositories = createPersistedElectricCollection(
 		electricCollectionOptions<SelectGithubRepository>({
 			id: `github_repositories-${organizationId}`,
 			shapeOptions: {
@@ -574,7 +597,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 		}),
 	);
 
-	const githubPullRequests = createIndexedCollection(
+	const githubPullRequests = createPersistedElectricCollection(
 		electricCollectionOptions<SelectGithubPullRequest>({
 			id: `github_pull_requests-${organizationId}`,
 			shapeOptions: {
@@ -590,7 +613,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 		}),
 	);
 
-	const automations = createIndexedCollection(
+	const automations = createPersistedElectricCollection(
 		electricCollectionOptions<SelectAutomation>({
 			id: `automations-${organizationId}`,
 			shapeOptions: {
@@ -606,7 +629,7 @@ function createOrgCollections(organizationId: string): OrgCollections {
 		}),
 	);
 
-	const automationRuns = createIndexedCollection(
+	const automationRuns = createPersistedElectricCollection(
 		electricCollectionOptions<SelectAutomationRun>({
 			id: `automation_runs-${organizationId}`,
 			shapeOptions: {

--- a/bun.lock
+++ b/bun.lock
@@ -175,6 +175,8 @@
         "@t3-oss/env-core": "^0.13.8",
         "@tanstack/db": "0.6.5",
         "@tanstack/electric-db-collection": "0.3.3",
+        "@tanstack/electron-db-sqlite-persistence": "0.1.9",
+        "@tanstack/node-db-sqlite-persistence": "0.1.9",
         "@tanstack/react-db": "0.1.83",
         "@tanstack/react-query": "^5.90.19",
         "@tanstack/react-router": "^1.147.3",
@@ -2634,9 +2636,15 @@
 
     "@tanstack/db-ivm": ["@tanstack/db-ivm@0.1.18", "", { "dependencies": { "fractional-indexing": "^3.2.0", "sorted-btree": "^1.8.1" }, "peerDependencies": { "typescript": ">=4.7" } }, "sha512-+pZJiRKdoKRM5Epq9T7otD9ZJl82pRFauo7LKuJGrarjVKQ7r+QQlPe3kGdN9LEKSnuNGIWjX9OOY4M8kH4eLw=="],
 
+    "@tanstack/db-sqlite-persistence-core": ["@tanstack/db-sqlite-persistence-core@0.1.9", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@tanstack/db": "0.6.5" }, "peerDependencies": { "typescript": ">=4.7" } }, "sha512-Ju4HcBzaSXTaPJFMRWNjiyXRfCmom0AXBr/22sqLoQWY1TjFM/UTbSSTQgsrExkNuFDVFiV8EDpCt8WUBFiKcQ=="],
+
     "@tanstack/electric-db-collection": ["@tanstack/electric-db-collection@0.3.3", "", { "dependencies": { "@electric-sql/client": "^1.5.15", "@standard-schema/spec": "^1.1.0", "@tanstack/db": "0.6.5", "@tanstack/store": "^0.9.2", "debug": "^4.4.3" } }, "sha512-ywx5s6kv/ZNDszl2GwnlvZPlimEBAUREo9cEN9oCN7SyO36/5andaAKgjWQYXiXDc6FamjQfE6N6WuUFb0Zg0Q=="],
 
+    "@tanstack/electron-db-sqlite-persistence": ["@tanstack/electron-db-sqlite-persistence@0.1.9", "", { "dependencies": { "@tanstack/db-sqlite-persistence-core": "0.1.9" }, "peerDependencies": { "typescript": ">=4.7" } }, "sha512-QlH4pt0vhw9BZIdf6iyIioFoUy58vJoe5gXNIpXFEXY1uP4awKpTJ7ZrVTlBPPpaYvbcJxMxqjusoFCRVA5XQg=="],
+
     "@tanstack/history": ["@tanstack/history@1.161.6", "", {}, "sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg=="],
+
+    "@tanstack/node-db-sqlite-persistence": ["@tanstack/node-db-sqlite-persistence@0.1.9", "", { "dependencies": { "@tanstack/db-sqlite-persistence-core": "0.1.9", "better-sqlite3": "^12.6.2" }, "peerDependencies": { "typescript": ">=4.7" } }, "sha512-irgaRzZ6eMV4Ky7fIoiy823vPfGllnsJPI0oqdjWS4kD09juktR8JfS0Gqg9ONBbwLB2kLBrC3ei72Dzz92RKg=="],
 
     "@tanstack/pacer-lite": ["@tanstack/pacer-lite@0.2.1", "", {}, "sha512-3PouiFjR4B6x1c969/Pl4ZIJleof1M0n6fNX8NRiC9Sqv1g06CVDlEaXUR4212ycGFyfq4q+t8Gi37Xy+z34iQ=="],
 


### PR DESCRIPTION
## Summary

- Wraps all 21 Electric synced collections in `apps/desktop` with `@tanstack/electron-db-sqlite-persistence` so the local cache survives cold start. SQLite db lives at `~/.superset/tanstack-db.sqlite`, mirroring the existing `~/.superset/local.db` convention. The 6 local-only collections stay on `localStorageCollectionOptions` (already offline-capable; migrating them carries data-migration risk that's out of scope here).
- Drops `useLiveQuery`'s `isLoading` guards on the Tasks view. `isLoading` is `collection.status === "loading"`, which alpha 0.1.9 only flips to `ready` after Electric's first up-to-date handshake — so the page sat on a spinner forever offline even though cached rows were available. Now gated on data presence.

## How it works

Renderer constructs persistence via `createElectronSQLitePersistence({ invoke })` using the existing `window.ipcRenderer.invoke` preload bridge — no preload changes. Main process opens `better-sqlite3` (already a dep, already rebuilt for Electron via `electron-builder`) and registers IPC handlers in `whenReady` after `initAppState`, disposes them in `before-quit`. New helper `createPersistedElectricCollection` wraps `electricCollectionOptions` with `persistedCollectionOptions({ persistence, schemaVersion: 1 })` + index defaults; mechanically applied to all 21 sites.

Per-org isolation: collection ids are already org-scoped (`tasks-${organizationId}`), so SQLite tables don't collide across orgs. Per-user: matches existing `local.db` convention (machine-wide, not cleared on sign-out).

## Test plan

- [ ] Cold-start online (second launch): sidebar/workspace layout populate from SQLite immediately, before any network request resolves
- [ ] Cold-start offline (after one online launch to prime cache): launch with Electric off — sidebar renders projects, workspace clicks reach local host service, Tasks view renders cached rows or empty state instead of spinning
- [ ] Mutation round-trip: rename a workspace + create/update/delete a task; verify optimistic update persists across cold restart and Electric reconciles on reconnect
- [ ] Inspect `~/.superset/tanstack-db.sqlite` with `sqlite3` CLI; confirm 21 tables per active org
- [ ] Org-switching: tables stay isolated, no cross-org bleed
- [ ] No regression on the 6 untouched local-only collections (terminal presets, sidebar state, user prefs)
- [ ] Quit lifecycle clean — no SQLite lockfile / WAL stragglers in `~/.superset/`

## Follow-ups

- `OrganizationSettings.tsx` has the same `isLoading` pattern over `members` — settings-only, not on the offline-critical path, deferred
- Local-only collections → SQLite migration (data-preservation hooks for `v2TerminalPresets`, `v2WorkspaceLocalState`, etc.) is a separate, larger PR
- Alpha library (`@tanstack/*-db-sqlite-persistence@0.1.9` is "first alpha release of persistence") — pin exact versions, monitor releases

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist Electric-synced collections to SQLite so cached data survives cold start and the desktop app launches offline. Also removes Tasks view loading guards so cached data renders immediately instead of spinning.

- **New Features**
  - Wrapped all 21 Electric collections with `persistedCollectionOptions` (`schemaVersion: 1`) using `@tanstack/electron-db-sqlite-persistence`; data is stored at `~/.superset/tanstack-db.sqlite` with org-scoped tables.
  - Wired persistence in main via `@tanstack/node-db-sqlite-persistence` + `better-sqlite3`, exposed over existing IPC; lifecycle managed with `initTanstackDbPersistence`/`shutdownTanstackDbPersistence`.
  - Local-only collections remain on `localStorageCollectionOptions` (no migration in this PR).

- **Bug Fixes**
  - Removed `isLoading` guards in Tasks Board/Table and Linear check; views now render when `data` exists.
  - Close SQLite handle on app quit to prevent leftover WAL/lock files.

<sup>Written for commit 5f2646d00de2557dd32b449e20f36e335d8da5a8. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3841?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced local data persistence layer for improved reliability and offline support.

* **UI Improvements**
  * Refined Tasks view interface with streamlined loading experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->