### PR TITLE
fix(desktop): collapse v2 sidebar count + actions into one slot

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarProjectRow/DashboardSidebarProjectRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarProjectRow/DashboardSidebarProjectRow.tsx
@@ -96,31 +96,34 @@ export const DashboardSidebarProjectRow = forwardRef<
 					) : (
 						<span className="truncate">{projectName}</span>
 					)}
-					{!isRenaming && (
-						<span className="shrink-0 text-xs font-normal tabular-nums text-muted-foreground">
-							({totalWorkspaceCount})
-						</span>
-					)}
 				</div>
 
-				<Tooltip delayDuration={500}>
-					<TooltipTrigger asChild>
-						<button
-							type="button"
-							onClick={(event) => {
-								event.stopPropagation();
-								onNewWorkspace();
-							}}
-							onContextMenu={(event) => event.stopPropagation()}
-							className="p-1 rounded hover:bg-muted transition-colors shrink-0 ml-1"
-						>
-							<HiMiniPlus className="size-4 text-muted-foreground" />
-						</button>
-					</TooltipTrigger>
-					<TooltipContent side="bottom" sideOffset={4}>
-						New workspace
-					</TooltipContent>
-				</Tooltip>
+				{!isRenaming && (
+					<div className="relative ml-1 flex size-6 shrink-0 items-center justify-center">
+						<span className="text-[10px] font-normal tabular-nums text-muted-foreground transition-opacity group-hover:opacity-0 group-focus-within:opacity-0">
+							{totalWorkspaceCount}
+						</span>
+						<Tooltip delayDuration={500}>
+							<TooltipTrigger asChild>
+								<button
+									type="button"
+									onClick={(event) => {
+										event.stopPropagation();
+										onNewWorkspace();
+									}}
+									onContextMenu={(event) => event.stopPropagation()}
+									aria-label="New workspace"
+									className="absolute inset-0 flex items-center justify-center rounded opacity-0 transition-opacity hover:bg-muted group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+								>
+									<HiMiniPlus className="size-4 text-muted-foreground" />
+								</button>
+							</TooltipTrigger>
+							<TooltipContent side="bottom" sideOffset={4}>
+								New workspace
+							</TooltipContent>
+						</Tooltip>
+					</div>
+				)}
 			</div>
 		);
 	},

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarProjectRow/DashboardSidebarProjectRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarProjectRow/DashboardSidebarProjectRow.tsx
@@ -99,10 +99,7 @@ export const DashboardSidebarProjectRow = forwardRef<
 				</div>
 
 				{!isRenaming && (
-					<div className="relative ml-1 flex size-6 shrink-0 items-center justify-center">
-						<span className="text-[10px] font-normal tabular-nums text-muted-foreground transition-opacity group-hover:opacity-0 group-focus-within:opacity-0">
-							{totalWorkspaceCount}
-						</span>
+					<div className="ml-1 flex size-6 shrink-0 items-center justify-center">
 						<Tooltip delayDuration={500}>
 							<TooltipTrigger asChild>
 								<button
@@ -114,7 +111,7 @@ export const DashboardSidebarProjectRow = forwardRef<
 									onKeyDown={(event) => event.stopPropagation()}
 									onContextMenu={(event) => event.stopPropagation()}
 									aria-label="New workspace"
-									className="pointer-events-none absolute inset-0 flex items-center justify-center rounded opacity-0 transition-opacity hover:bg-muted group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+									className="hidden size-full items-center justify-center rounded transition-colors hover:bg-muted group-hover:flex group-focus-within:flex focus-visible:flex focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 								>
 									<HiMiniPlus className="size-4 text-muted-foreground" />
 								</button>
@@ -123,6 +120,9 @@ export const DashboardSidebarProjectRow = forwardRef<
 								New workspace
 							</TooltipContent>
 						</Tooltip>
+						<span className="text-[10px] font-normal tabular-nums text-muted-foreground group-hover:hidden group-focus-within:hidden">
+							{totalWorkspaceCount}
+						</span>
 					</div>
 				)}
 			</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarProjectRow/DashboardSidebarProjectRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarProjectRow/DashboardSidebarProjectRow.tsx
@@ -109,7 +109,7 @@ export const DashboardSidebarProjectRow = forwardRef<
 									onKeyDown={(event) => event.stopPropagation()}
 									onContextMenu={(event) => event.stopPropagation()}
 									aria-label="New workspace"
-									className="hidden size-full items-center justify-center rounded transition-colors hover:bg-muted group-hover:flex group-focus-within:flex focus-visible:flex focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+									className="hidden size-full items-center justify-center rounded transition-colors hover:bg-muted group-hover:flex group-has-[:focus]:flex focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 								>
 									<HiMiniPlus className="size-4 text-muted-foreground" />
 								</button>
@@ -118,7 +118,7 @@ export const DashboardSidebarProjectRow = forwardRef<
 								New workspace
 							</TooltipContent>
 						</Tooltip>
-						<span className="text-[10px] font-normal tabular-nums text-muted-foreground group-hover:hidden group-focus-within:hidden">
+						<span className="text-[10px] font-normal tabular-nums text-muted-foreground group-hover:hidden group-has-[:focus]:hidden">
 							{totalWorkspaceCount}
 						</span>
 					</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarProjectRow/DashboardSidebarProjectRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarProjectRow/DashboardSidebarProjectRow.tsx
@@ -70,17 +70,15 @@ export const DashboardSidebarProjectRow = forwardRef<
 				{...props}
 			>
 				<div className="flex min-w-0 flex-1 items-center gap-2 py-0.5">
-					<div className="relative shrink-0 size-5 flex items-center justify-center">
-						<span className="group-hover:opacity-0 transition-opacity duration-150">
-							<ProjectThumbnail
-								projectName={projectName}
-								githubOwner={githubOwner}
-								className="size-4"
-							/>
-						</span>
+					<div className="flex size-5 shrink-0 items-center justify-center">
+						<ProjectThumbnail
+							projectName={projectName}
+							githubOwner={githubOwner}
+							className="size-4 group-hover:hidden"
+						/>
 						<HiChevronRight
 							className={cn(
-								"absolute inset-0 m-auto size-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-all duration-150",
+								"hidden size-4 text-muted-foreground transition-transform group-hover:block",
 								!isCollapsed && "rotate-90",
 							)}
 						/>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarProjectRow/DashboardSidebarProjectRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarProjectRow/DashboardSidebarProjectRow.tsx
@@ -111,9 +111,10 @@ export const DashboardSidebarProjectRow = forwardRef<
 										event.stopPropagation();
 										onNewWorkspace();
 									}}
+									onKeyDown={(event) => event.stopPropagation()}
 									onContextMenu={(event) => event.stopPropagation()}
 									aria-label="New workspace"
-									className="absolute inset-0 flex items-center justify-center rounded opacity-0 transition-opacity hover:bg-muted group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+									className="pointer-events-none absolute inset-0 flex items-center justify-center rounded opacity-0 transition-opacity hover:bg-muted group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 								>
 									<HiMiniPlus className="size-4 text-muted-foreground" />
 								</button>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
@@ -89,11 +89,11 @@ export const DashboardSidebarSectionHeader = forwardRef<
 				</div>
 
 				{!isRenaming && (
-					<div className="relative ml-1 flex size-5 shrink-0 items-center justify-center">
+					<div className="ml-1 flex size-5 shrink-0 items-center justify-center">
 						{actions ? (
 							// biome-ignore lint/a11y/noStaticElementInteractions: Nested action controls handle their own semantics; this wrapper only isolates events from the header toggle.
 							<div
-								className="absolute inset-0 flex items-center justify-center"
+								className="peer hidden size-full items-center justify-center group-hover:flex group-focus-within:flex has-[[data-state=open]]:flex"
 								onClick={(event) => event.stopPropagation()}
 								onKeyDown={(event) => event.stopPropagation()}
 							>
@@ -102,8 +102,9 @@ export const DashboardSidebarSectionHeader = forwardRef<
 						) : null}
 						<span
 							className={cn(
-								"pointer-events-none relative text-[10px] font-normal tabular-nums text-muted-foreground transition-opacity",
-								actions && "group-hover:opacity-0 group-focus-within:opacity-0",
+								"text-[10px] font-normal tabular-nums text-muted-foreground",
+								actions &&
+									"group-hover:hidden group-focus-within:hidden peer-has-[[data-state=open]]:hidden",
 							)}
 						>
 							{section.workspaces.length}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
@@ -93,7 +93,7 @@ export const DashboardSidebarSectionHeader = forwardRef<
 						{actions ? (
 							// biome-ignore lint/a11y/noStaticElementInteractions: Nested action controls handle their own semantics; this wrapper only isolates events from the header toggle.
 							<div
-								className="peer hidden size-full items-center justify-center group-hover:flex group-focus-within:flex has-[[data-state=open]]:flex"
+								className="peer hidden size-full items-center justify-center group-hover:flex group-has-[:focus]:flex has-[[data-state=open]]:flex"
 								onClick={(event) => event.stopPropagation()}
 								onKeyDown={(event) => event.stopPropagation()}
 							>
@@ -104,7 +104,7 @@ export const DashboardSidebarSectionHeader = forwardRef<
 							className={cn(
 								"text-[10px] font-normal tabular-nums text-muted-foreground",
 								actions &&
-									"group-hover:hidden group-focus-within:hidden peer-has-[[data-state=open]]:hidden",
+									"group-hover:hidden group-has-[:focus]:hidden peer-has-[[data-state=open]]:hidden",
 							)}
 						>
 							{section.workspaces.length}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
@@ -58,7 +58,7 @@ export const DashboardSidebarSectionHeader = forwardRef<
 							}
 				}
 				className={cn(
-					"group flex min-h-8 w-full items-center pl-0.5 pr-2 py-1.5 text-[13px] font-medium",
+					"group flex min-h-8 w-full items-center pl-5 pr-2 py-1.5 text-[13px] font-medium",
 					"text-muted-foreground hover:bg-muted/50 transition-colors",
 					className,
 				)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
@@ -86,24 +86,25 @@ export const DashboardSidebarSectionHeader = forwardRef<
 					) : (
 						<span className="truncate">{section.name}</span>
 					)}
-
-					{!isRenaming && (
-						<span className="shrink-0 text-[10px] font-normal tabular-nums">
-							({section.workspaces.length})
-						</span>
-					)}
 				</div>
 
-				{!isRenaming && actions ? (
-					// biome-ignore lint/a11y/noStaticElementInteractions: Nested action controls handle their own semantics; this wrapper only isolates events from the header toggle.
-					<div
-						className="flex items-center"
-						onClick={(event) => event.stopPropagation()}
-						onKeyDown={(event) => event.stopPropagation()}
-					>
-						{actions}
+				{!isRenaming && (
+					<div className="relative ml-1 flex size-5 shrink-0 items-center justify-center">
+						<span className="text-[10px] font-normal tabular-nums transition-opacity group-hover:opacity-0 group-focus-within:opacity-0">
+							{section.workspaces.length}
+						</span>
+						{actions ? (
+							// biome-ignore lint/a11y/noStaticElementInteractions: Nested action controls handle their own semantics; this wrapper only isolates events from the header toggle.
+							<div
+								className="absolute inset-0 flex items-center justify-center"
+								onClick={(event) => event.stopPropagation()}
+								onKeyDown={(event) => event.stopPropagation()}
+							>
+								{actions}
+							</div>
+						) : null}
 					</div>
-				) : null}
+				)}
 			</div>
 		);
 	},

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
@@ -90,9 +90,6 @@ export const DashboardSidebarSectionHeader = forwardRef<
 
 				{!isRenaming && (
 					<div className="relative ml-1 flex size-5 shrink-0 items-center justify-center">
-						<span className="text-[10px] font-normal tabular-nums transition-opacity group-hover:opacity-0 group-focus-within:opacity-0">
-							{section.workspaces.length}
-						</span>
 						{actions ? (
 							// biome-ignore lint/a11y/noStaticElementInteractions: Nested action controls handle their own semantics; this wrapper only isolates events from the header toggle.
 							<div
@@ -103,6 +100,9 @@ export const DashboardSidebarSectionHeader = forwardRef<
 								{actions}
 							</div>
 						) : null}
+						<span className="pointer-events-none relative text-[10px] font-normal tabular-nums text-muted-foreground transition-opacity group-hover:opacity-0 group-focus-within:opacity-0">
+							{section.workspaces.length}
+						</span>
 					</div>
 				)}
 			</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
@@ -100,7 +100,12 @@ export const DashboardSidebarSectionHeader = forwardRef<
 								{actions}
 							</div>
 						) : null}
-						<span className="pointer-events-none relative text-[10px] font-normal tabular-nums text-muted-foreground transition-opacity group-hover:opacity-0 group-focus-within:opacity-0">
+						<span
+							className={cn(
+								"pointer-events-none relative text-[10px] font-normal tabular-nums text-muted-foreground transition-opacity",
+								actions && "group-hover:opacity-0 group-focus-within:opacity-0",
+							)}
+						>
 							{section.workspaces.length}
 						</span>
 					</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
@@ -58,7 +58,7 @@ export const DashboardSidebarSectionHeader = forwardRef<
 							}
 				}
 				className={cn(
-					"group flex min-h-8 w-full items-center pl-5 pr-2 py-1.5 text-[13px] font-medium",
+					"group flex min-h-8 w-full items-center pl-4 pr-2 py-1.5 text-[13px] font-medium",
 					"text-muted-foreground hover:bg-muted/50 transition-colors",
 					className,
 				)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
@@ -58,7 +58,7 @@ export const DashboardSidebarSectionHeader = forwardRef<
 							}
 				}
 				className={cn(
-					"group flex min-h-8 w-full items-center pl-3 pr-2 py-1.5 text-[13px] font-medium",
+					"group flex min-h-8 w-full items-center pl-5 pr-2 py-1.5 text-[13px] font-medium",
 					"text-muted-foreground hover:bg-muted/50 transition-colors",
 					className,
 				)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSection/components/DashboardSidebarSectionHeader/DashboardSidebarSectionHeader.tsx
@@ -58,13 +58,13 @@ export const DashboardSidebarSectionHeader = forwardRef<
 							}
 				}
 				className={cn(
-					"group flex min-h-8 w-full items-center pl-4 pr-2 py-1.5 text-[13px] font-medium",
+					"group flex min-h-8 w-full items-center pl-3 pr-2 py-1.5 text-[13px] font-medium",
 					"text-muted-foreground hover:bg-muted/50 transition-colors",
 					className,
 				)}
 				{...props}
 			>
-				<div className="grid h-5 w-5 shrink-0 cursor-grab items-center justify-center active:cursor-grabbing [&>*]:col-start-1 [&>*]:row-start-1">
+				<div className="mr-2 grid h-5 w-5 shrink-0 cursor-grab items-center justify-center active:cursor-grabbing [&>*]:col-start-1 [&>*]:row-start-1">
 					<HiChevronRight
 						className={cn(
 							"size-3 text-muted-foreground transition-[opacity,transform] duration-150 group-hover:opacity-0",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -222,6 +222,7 @@ export function DashboardSidebarWorkspaceItem({
 				shortcutLabel={shortcutLabel}
 				diffStats={isPending ? null : diffStats}
 				workspaceStatus={workspaceStatus}
+				isInSection={isInSection}
 				onClick={isPending ? handlePendingClick : handleClick}
 				onDoubleClick={isPending ? undefined : startRename}
 				onRemoveFromSidebarClick={handleRemoveFromSidebar}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/DashboardSidebarExpandedWorkspaceRow.tsx
@@ -40,6 +40,7 @@ interface DashboardSidebarExpandedWorkspaceRowProps
 	shortcutLabel?: string;
 	diffStats: DiffStats | null;
 	workspaceStatus?: ActivePaneStatus | null;
+	isInSection?: boolean;
 	onClick?: () => void;
 	onDoubleClick?: () => void;
 	onCloseWorkspaceClick: () => void;
@@ -62,6 +63,7 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 			shortcutLabel,
 			diffStats,
 			workspaceStatus = null,
+			isInSection = false,
 			onClick,
 			onDoubleClick,
 			onCloseWorkspaceClick,
@@ -128,7 +130,8 @@ export const DashboardSidebarExpandedWorkspaceRow = forwardRef<
 				}}
 				onDoubleClick={onDoubleClick}
 				className={cn(
-					"relative flex w-full items-center pl-5 pr-2 text-left text-sm",
+					"relative flex w-full items-center pr-2 text-left text-sm",
+					isInSection ? "pl-7" : "pl-5",
 					onClick &&
 						(isActive
 							? "cursor-pointer hover:bg-muted"


### PR DESCRIPTION
## Summary

Tightens the right edge of the v2 sidebar's project rows and section headers so the workspace count and the row's action button share one slot instead of competing for space.

- **Project row**: workspace count now lives where the "+" button sits. Count visible at rest; "+" overlays it on hover / focus-within. Count shrunk from `text-xs` to `text-[10px]` to match the section header. Parens dropped.
- **Section header**: same treatment with the section-actions ellipsis. Count visible at rest; ellipsis dropdown trigger overlays it on hover. Parens dropped.

Both swaps preserve the existing keyboard focus behavior — the action stays reachable via tab / focus-visible.

Builds on the v2 sidebar styling work in #3813 — credit to @saddlepaddle for the original pass; this PR is just polish on top.

## Test plan

- [ ] At rest, project rows show only `name … N` with no "+" visible
- [ ] Hovering a project row hides the count and shows the "+"; clicking creates a workspace
- [ ] Tabbing through reveals the "+" via `focus-visible` and `group-focus-within`
- [ ] Section headers behave the same way with the ellipsis dropdown
- [ ] Counts in both rows are the same size (`text-[10px]`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapses the v2 sidebar workspace count and actions into one end slot using a display swap, and tightens indents to clarify hierarchy. Keeps counts visible when rows are self-focused and keeps section actions visible while the menu is open; start icon swap now uses the same pattern.

- **Refactors**
  - Project row: count moves into the action slot (`text-[10px]`, no parens). “+” shows on hover or descendant focus via hidden/flex; has tooltip and `aria-label`; stops keydown bubbling. Start icon now swaps via display (thumbnail at rest, chevron on hover).
  - Section header: indent set to `pl-5` with `mr-2` between icon and title. Actions show on hover or descendant focus and stay visible when open via `has-[[data-state=open]]`; count hides only when actions are visible (no parens).
  - Workspaces: pass `isInSection`; grouped rows indent to `pl-7` (vs `pl-5` ungrouped) for clearer nesting.

<sup>Written for commit abc77005aa502e3ea6e7e16afb8544870245b1ab. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3842?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Workspace counts moved to a compact fixed container (no parentheses) with smooth opacity transitions; action controls overlay this area.
  * Row indentation adapts when a workspace appears inside a section for consistent alignment.

* **Accessibility**
  * “New workspace” button has an accessible label, visible focus styling, and appears on hover/focus to support keyboard and mouse users.
  * Interaction handling refined to prevent unintended header toggles during keyboard navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->