### PR TITLE
[codex] warn before relay toggle restarts host service

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/security/components/SecuritySettings/SecuritySettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/security/components/SecuritySettings/SecuritySettings.tsx
@@ -46,6 +46,7 @@ export function SecuritySettings({ visibleItems }: SecuritySettingsProps) {
 		});
 
 	const [confirmOpen, setConfirmOpen] = useState(false);
+	const [confirmTargetEnabled, setConfirmTargetEnabled] = useState(false);
 
 	const runToggle = (enabled: boolean) => {
 		toast.promise(setExpose.mutateAsync({ enabled }), {
@@ -59,11 +60,8 @@ export function SecuritySettings({ visibleItems }: SecuritySettingsProps) {
 	};
 
 	const handleChange = (next: boolean) => {
-		if (next) {
-			setConfirmOpen(true);
-		} else {
-			runToggle(false);
-		}
+		setConfirmTargetEnabled(next);
+		setConfirmOpen(true);
 	};
 
 	return (
@@ -101,10 +99,12 @@ export function SecuritySettings({ visibleItems }: SecuritySettingsProps) {
 
 			<ExposeViaRelayConfirmDialog
 				open={confirmOpen}
+				targetEnabled={confirmTargetEnabled}
 				onOpenChange={setConfirmOpen}
 				onConfirm={() => {
+					const enabled = confirmTargetEnabled;
 					setConfirmOpen(false);
-					runToggle(true);
+					runToggle(enabled);
 				}}
 			/>
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/security/components/SecuritySettings/components/ExposeViaRelayConfirmDialog/ExposeViaRelayConfirmDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/security/components/SecuritySettings/components/ExposeViaRelayConfirmDialog/ExposeViaRelayConfirmDialog.tsx
@@ -41,38 +41,23 @@ export function ExposeViaRelayConfirmDialog({
 			<AlertDialogContent className="max-w-[480px]">
 				<AlertDialogHeader>
 					<AlertDialogTitle>
-						{targetEnabled
-							? "Expose this device to Superset Relay?"
-							: "Turn off Superset Relay access?"}
+						{targetEnabled ? "Enable Relay access?" : "Disable Relay access?"}
 					</AlertDialogTitle>
 					<AlertDialogDescription asChild>
 						<div className="space-y-3 text-sm text-muted-foreground">
 							<p>
-								Changing this setting restarts the host service. Any connected
-								workspace operations going through this host may briefly
-								disconnect.
+								This restarts the host service. Running terminals, file watches,
+								and other host-backed work may briefly disconnect.
 							</p>
 							{targetEnabled ? (
-								<>
-									<p>
-										Turning this on allows any remote device which you grant
-										access to — and anything that can compromise the Superset
-										Relay — to reach into this device to run commands. They will
-										be able to read and write files in your configured project
-										directories, run shell commands as you, and access any tools
-										the host service exposes.
-									</p>
-									<p>
-										Only enable this if you are okay with the risk that this
-										entails. Most users should leave this off.
-									</p>
-								</>
+								<p>
+									Remote workspaces you grant access to will be able to reach
+									this device through Superset Relay.
+								</p>
 							) : (
 								<p>
-									Turning this off prevents remote workspaces from reaching this
-									device through the Superset relay. Existing remote sessions
-									targeting this host may lose access until they reconnect
-									elsewhere or relay access is enabled again.
+									Remote workspaces will no longer be able to reach this device
+									through Superset Relay.
 								</p>
 							)}
 						</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/security/components/SecuritySettings/components/ExposeViaRelayConfirmDialog/ExposeViaRelayConfirmDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/security/components/SecuritySettings/components/ExposeViaRelayConfirmDialog/ExposeViaRelayConfirmDialog.tsx
@@ -15,12 +15,14 @@ const CONFIRM_PHRASE = "I understand";
 
 interface ExposeViaRelayConfirmDialogProps {
 	open: boolean;
+	targetEnabled: boolean;
 	onOpenChange: (open: boolean) => void;
 	onConfirm: () => void;
 }
 
 export function ExposeViaRelayConfirmDialog({
 	open,
+	targetEnabled,
 	onOpenChange,
 	onConfirm,
 }: ExposeViaRelayConfirmDialogProps) {
@@ -32,63 +34,83 @@ export function ExposeViaRelayConfirmDialog({
 		if (!open) setTyped("");
 	}, [open]);
 
-	const canConfirm = typed === CONFIRM_PHRASE;
+	const canConfirm = !targetEnabled || typed === CONFIRM_PHRASE;
 
 	return (
 		<AlertDialog open={open} onOpenChange={onOpenChange}>
 			<AlertDialogContent className="max-w-[480px]">
 				<AlertDialogHeader>
 					<AlertDialogTitle>
-						Expose this device to Superset Relay?
+						{targetEnabled
+							? "Expose this device to Superset Relay?"
+							: "Turn off Superset Relay access?"}
 					</AlertDialogTitle>
 					<AlertDialogDescription asChild>
 						<div className="space-y-3 text-sm text-muted-foreground">
 							<p>
-								Turning this on allows any remote device which you grant access
-								to — and anything that can compromise the Superset Relay — to
-								reach into this device to run commands. They will be able to
-								read and write files in your configured project directories, run
-								shell commands as you, and access any tools the host service
-								exposes.
+								Changing this setting restarts the host service. Any connected
+								workspace operations going through this host may briefly
+								disconnect.
 							</p>
-							<p>
-								Only enable this if you are okay with the risk that this
-								entails. Most users should leave this off.
-							</p>
+							{targetEnabled ? (
+								<>
+									<p>
+										Turning this on allows any remote device which you grant
+										access to — and anything that can compromise the Superset
+										Relay — to reach into this device to run commands. They will
+										be able to read and write files in your configured project
+										directories, run shell commands as you, and access any tools
+										the host service exposes.
+									</p>
+									<p>
+										Only enable this if you are okay with the risk that this
+										entails. Most users should leave this off.
+									</p>
+								</>
+							) : (
+								<p>
+									Turning this off prevents remote workspaces from reaching this
+									device through the Superset relay. Existing remote sessions
+									targeting this host may lose access until they reconnect
+									elsewhere or relay access is enabled again.
+								</p>
+							)}
 						</div>
 					</AlertDialogDescription>
 				</AlertDialogHeader>
 
-				<div className="space-y-2 pt-2">
-					<Label htmlFor="expose-relay-confirm" className="text-xs">
-						Type{" "}
-						<span className="font-mono font-medium text-foreground">
-							{CONFIRM_PHRASE}
-						</span>{" "}
-						to continue
-					</Label>
-					<Input
-						id="expose-relay-confirm"
-						autoFocus
-						value={typed}
-						onChange={(event) => setTyped(event.target.value)}
-						placeholder={CONFIRM_PHRASE}
-						autoComplete="off"
-						spellCheck={false}
-					/>
-				</div>
+				{targetEnabled && (
+					<div className="space-y-2 pt-2">
+						<Label htmlFor="expose-relay-confirm" className="text-xs">
+							Type{" "}
+							<span className="font-mono font-medium text-foreground">
+								{CONFIRM_PHRASE}
+							</span>{" "}
+							to continue
+						</Label>
+						<Input
+							id="expose-relay-confirm"
+							autoFocus
+							value={typed}
+							onChange={(event) => setTyped(event.target.value)}
+							placeholder={CONFIRM_PHRASE}
+							autoComplete="off"
+							spellCheck={false}
+						/>
+					</div>
+				)}
 
 				<AlertDialogFooter>
 					<Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
 						Cancel
 					</Button>
 					<Button
-						variant="destructive"
+						variant={targetEnabled ? "destructive" : "default"}
 						size="sm"
 						disabled={!canConfirm}
 						onClick={onConfirm}
 					>
-						Enable
+						{targetEnabled ? "Enable" : "Disable"}
 					</Button>
 				</AlertDialogFooter>
 			</AlertDialogContent>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/security/components/SecuritySettings/components/ExposeViaRelayConfirmDialog/ExposeViaRelayConfirmDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/security/components/SecuritySettings/components/ExposeViaRelayConfirmDialog/ExposeViaRelayConfirmDialog.tsx
@@ -46,8 +46,8 @@ export function ExposeViaRelayConfirmDialog({
 					<AlertDialogDescription asChild>
 						<div className="space-y-3 text-sm text-muted-foreground">
 							<p>
-								This restarts the host service. Running terminals, file watches,
-								and other host-backed work may briefly disconnect.
+								This restarts the host service and stops running terminals. File
+								watches and other host-backed work will be interrupted.
 							</p>
 							{targetEnabled ? (
 								<p>
@@ -90,12 +90,12 @@ export function ExposeViaRelayConfirmDialog({
 						Cancel
 					</Button>
 					<Button
-						variant={targetEnabled ? "destructive" : "default"}
+						variant="destructive"
 						size="sm"
 						disabled={!canConfirm}
 						onClick={onConfirm}
 					>
-						{targetEnabled ? "Enable" : "Disable"}
+						{targetEnabled ? "Enable and restart" : "Disable and restart"}
 					</Button>
 				</AlertDialogFooter>
 			</AlertDialogContent>


### PR DESCRIPTION
## Summary

Warn before changing the relay exposure setting in either direction, because the setting mutation restarts active host-service instances and stops running terminals.

## Changes

- Route both enable and disable switch actions through the relay confirmation dialog.
- Pass the intended target state into the dialog so the copy and action label match the direction.
- Use destructive confirmation actions for both directions, labeled `Enable and restart` or `Disable and restart`.
- Keep the stronger typed confirmation for enabling relay access.

## Impact

Users now see that changing Relay access restarts the host service, stops running terminals, and interrupts file watches or other host-backed work before the setting is applied.

## Validation

- `bunx @biomejs/biome@2.4.2 check --write --unsafe apps/desktop/src/renderer/routes/_authenticated/settings/security/components/SecuritySettings/SecuritySettings.tsx apps/desktop/src/renderer/routes/_authenticated/settings/security/components/SecuritySettings/components/ExposeViaRelayConfirmDialog/ExposeViaRelayConfirmDialog.tsx`
- `bun run --cwd apps/desktop typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a confirmation before enabling or disabling Superset Relay access, warning that the change restarts the host service, kills running terminals, and interrupts file watches and other host-backed work. Enabling still requires typing "I understand"; disabling only needs a simple confirm.

- **New Features**
  - Route both enable and disable through a single confirm dialog that knows the target state.
  - Action labels now read "Enable and restart" or "Disable and restart"; dialog copy trimmed to focus on the access change and restart.

<sup>Written for commit 635f1bcf87bc938823fa135440bea5eef50e7dad. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3845?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Confirmation dialog now appears for both enabling and disabling relay access to ensure deliberate changes.
* Enabling requires typing the confirmation phrase; disabling is simplified (no typed confirmation).
* Dialog titles, descriptions, and confirm button labels/appearance update to reflect whether you are enabling or disabling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->