### PR TITLE
fix(desktop): expand collapsed sections when cycling workspaces via keyboard

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarShortcuts/useDashboardSidebarShortcuts.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarShortcuts/useDashboardSidebarShortcuts.ts
@@ -2,8 +2,16 @@ import { useMatchRoute, useNavigate } from "@tanstack/react-router";
 import { useCallback, useMemo, useRef } from "react";
 import { useHotkey } from "renderer/hotkeys";
 import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
+import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import type { DashboardSidebarProject } from "../../types";
 import { getProjectChildrenWorkspaces } from "../../utils/projectChildren";
+
+interface WorkspaceLocation {
+	projectId: string;
+	projectIsCollapsed: boolean;
+	sectionId: string | null;
+	sectionIsCollapsed: boolean;
+}
 
 const MAX_SHORTCUT_COUNT = 9;
 
@@ -43,6 +51,8 @@ export function useDashboardSidebarShortcuts(
 	groups: DashboardSidebarProject[],
 ) {
 	const navigate = useNavigate();
+	const { toggleProjectCollapsed, toggleSectionCollapsed } =
+		useDashboardSidebarState();
 	const flattenedWorkspaces = useMemo(
 		() =>
 			groups
@@ -53,14 +63,55 @@ export function useDashboardSidebarShortcuts(
 	const workspaceShortcutLabels =
 		useStableWorkspaceShortcutLabels(flattenedWorkspaces);
 
+	const workspaceLocations = useMemo(() => {
+		const map = new Map<string, WorkspaceLocation>();
+		for (const project of groups) {
+			for (const child of project.children) {
+				if (child.type === "workspace") {
+					map.set(child.workspace.id, {
+						projectId: project.id,
+						projectIsCollapsed: project.isCollapsed,
+						sectionId: null,
+						sectionIsCollapsed: false,
+					});
+					continue;
+				}
+				for (const workspace of child.section.workspaces) {
+					map.set(workspace.id, {
+						projectId: project.id,
+						projectIsCollapsed: project.isCollapsed,
+						sectionId: child.section.id,
+						sectionIsCollapsed: child.section.isCollapsed,
+					});
+				}
+			}
+		}
+		return map;
+	}, [groups]);
+
+	const revealWorkspace = useCallback(
+		(workspaceId: string) => {
+			const location = workspaceLocations.get(workspaceId);
+			if (!location) return;
+			if (location.projectIsCollapsed) {
+				toggleProjectCollapsed(location.projectId);
+			}
+			if (location.sectionId && location.sectionIsCollapsed) {
+				toggleSectionCollapsed(location.sectionId);
+			}
+		},
+		[workspaceLocations, toggleProjectCollapsed, toggleSectionCollapsed],
+	);
+
 	const switchToWorkspace = useCallback(
 		(index: number) => {
 			const workspace = flattenedWorkspaces[index];
 			if (workspace) {
+				revealWorkspace(workspace.id);
 				navigateToV2Workspace(workspace.id, navigate);
 			}
 		},
-		[flattenedWorkspaces, navigate],
+		[flattenedWorkspaces, navigate, revealWorkspace],
 	);
 
 	useHotkey("JUMP_TO_WORKSPACE_1", () => switchToWorkspace(0));
@@ -88,7 +139,9 @@ export function useDashboardSidebarShortcuts(
 		);
 		if (index === -1) return;
 		const prevIndex = index <= 0 ? flattenedWorkspaces.length - 1 : index - 1;
-		navigateToV2Workspace(flattenedWorkspaces[prevIndex].id, navigate);
+		const target = flattenedWorkspaces[prevIndex];
+		revealWorkspace(target.id);
+		navigateToV2Workspace(target.id, navigate);
 	});
 
 	useHotkey("NEXT_WORKSPACE", () => {
@@ -98,7 +151,9 @@ export function useDashboardSidebarShortcuts(
 		);
 		if (index === -1) return;
 		const nextIndex = index >= flattenedWorkspaces.length - 1 ? 0 : index + 1;
-		navigateToV2Workspace(flattenedWorkspaces[nextIndex].id, navigate);
+		const target = flattenedWorkspaces[nextIndex];
+		revealWorkspace(target.id);
+		navigateToV2Workspace(target.id, navigate);
 	});
 
 	return workspaceShortcutLabels;


### PR DESCRIPTION
## Summary
- ⌘⌥↑/⌘⌥↓ (and the ⌘1..9 jumps) cycle through every workspace in the sidebar, but if the destination workspace lived inside a collapsed project or section the row stayed hidden — you'd land on a workspace you couldn't see.
- Build a workspaceId → { project, section, collapse state } map from the sidebar groups and toggle any collapsed parents open right before navigation.

## Test plan
- [ ] Collapse a section that contains the next workspace; press ⌘⌥↓ — section expands and the new workspace is highlighted.
- [ ] Collapse a project that contains the next workspace; press ⌘⌥↑/↓ — project expands and the new workspace is visible.
- [ ] ⌘1..⌘9 jumps to a workspace inside a collapsed project/section also expand the parents.
- [ ] Cycling between workspaces whose parents are already expanded doesn't re-toggle them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands collapsed projects/sections when navigating to a workspace via ⌘⌥↑/↓ or ⌘1..9 so the destination is always visible in the sidebar.

- **Bug Fixes**
  - Map each workspace to its parent project/section and collapse state from sidebar groups.
  - Toggle collapsed parents before navigating using `useDashboardSidebarState` (no re-toggle if already expanded).

<sup>Written for commit ff27e23aeb0223c1ebbb52b15f4669cab2cf4859. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3848?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard navigation in the dashboard sidebar. When navigating between workspaces using keyboard shortcuts, collapsed sections now automatically expand to reveal the destination workspace, eliminating the need for manual expansion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->