### PR TITLE
feat(desktop): v2 workspaces list filters, project icons, PR hover

### DIFF
--- a/.superset/lib/setup/steps.sh
+++ b/.superset/lib/setup/steps.sh
@@ -492,7 +492,12 @@ step_write_env() {
 
   # Generate Caddyfile for HTTP/2 reverse proxy (avoids browser 6-connection limit with Electric SSE streams)
   # Caddy proxies to the local Wrangler worker, which handles auth and forwards upstream appropriately.
+  # auto_https disable_redirects keeps Caddy off port 80 — we only need HTTPS on the allocated port.
   cat > Caddyfile <<-CADDYEOF
+	{
+		auto_https disable_redirects
+	}
+
 	https://localhost:{\$CADDY_ELECTRIC_PORT} {
 		reverse_proxy localhost:{\$WRANGLER_PORT} {
 			flush_interval -1

--- a/apps/api/src/app/api/github/jobs/initial-sync/route.ts
+++ b/apps/api/src/app/api/github/jobs/initial-sync/route.ts
@@ -223,6 +223,7 @@ export async function POST(request: Request) {
 						checks,
 						mergedAt: pr.merged_at ? new Date(pr.merged_at) : null,
 						closedAt: pr.closed_at ? new Date(pr.closed_at) : null,
+						updatedAt: new Date(pr.updated_at),
 					})
 					.onConflictDoUpdate({
 						target: [
@@ -240,7 +241,7 @@ export async function POST(request: Request) {
 							mergedAt: pr.merged_at ? new Date(pr.merged_at) : null,
 							closedAt: pr.closed_at ? new Date(pr.closed_at) : null,
 							lastSyncedAt: new Date(),
-							updatedAt: new Date(),
+							updatedAt: new Date(pr.updated_at),
 						},
 					});
 			}

--- a/apps/api/src/app/api/github/sync/route.ts
+++ b/apps/api/src/app/api/github/sync/route.ts
@@ -191,6 +191,7 @@ export async function POST(request: Request) {
 						checks,
 						mergedAt: pr.merged_at ? new Date(pr.merged_at) : null,
 						closedAt: pr.closed_at ? new Date(pr.closed_at) : null,
+						updatedAt: new Date(pr.updated_at),
 					})
 					.onConflictDoUpdate({
 						target: [
@@ -208,7 +209,7 @@ export async function POST(request: Request) {
 							mergedAt: pr.merged_at ? new Date(pr.merged_at) : null,
 							closedAt: pr.closed_at ? new Date(pr.closed_at) : null,
 							lastSyncedAt: new Date(),
-							updatedAt: new Date(),
+							updatedAt: new Date(pr.updated_at),
 						},
 					});
 			}

--- a/apps/api/src/app/api/github/webhook/webhooks.ts
+++ b/apps/api/src/app/api/github/webhook/webhooks.ts
@@ -143,8 +143,10 @@ function upsertPullRequest(
 		changed_files?: number;
 		merged_at: string | null;
 		closed_at: string | null;
+		updated_at: string;
 	},
 ) {
+	const upstreamUpdatedAt = new Date(pr.updated_at);
 	return db
 		.insert(githubPullRequests)
 		.values({
@@ -167,6 +169,7 @@ function upsertPullRequest(
 			checksStatus: "none",
 			mergedAt: pr.merged_at ? new Date(pr.merged_at) : null,
 			closedAt: pr.closed_at ? new Date(pr.closed_at) : null,
+			updatedAt: upstreamUpdatedAt,
 		})
 		.onConflictDoUpdate({
 			target: [githubPullRequests.repositoryId, githubPullRequests.prNumber],
@@ -184,7 +187,7 @@ function upsertPullRequest(
 				mergedAt: pr.merged_at ? new Date(pr.merged_at) : null,
 				closedAt: pr.closed_at ? new Date(pr.closed_at) : null,
 				lastSyncedAt: new Date(),
-				updatedAt: new Date(),
+				updatedAt: upstreamUpdatedAt,
 			},
 		});
 }
@@ -290,7 +293,7 @@ webhooks.on(
 			.set({
 				reviewDecision,
 				lastSyncedAt: new Date(),
-				updatedAt: new Date(),
+				updatedAt: new Date(pr.updated_at),
 			})
 			.where(
 				and(
@@ -405,7 +408,6 @@ webhooks.on(
 					checks: currentChecks,
 					checksStatus,
 					lastSyncedAt: new Date(),
-					updatedAt: new Date(),
 				})
 				.where(eq(githubPullRequests.id, currentPr.id));
 		}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacePrHoverCardContent/V2WorkspacePrHoverCardContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacePrHoverCardContent/V2WorkspacePrHoverCardContent.tsx
@@ -1,23 +1,12 @@
 import { Button } from "@superset/ui/button";
-import { cn } from "@superset/ui/utils";
 import { formatDistanceToNow } from "date-fns";
-import { useState } from "react";
 import { FaGithub } from "react-icons/fa";
-import {
-	LuCheck,
-	LuChevronDown,
-	LuChevronRight,
-	LuGitBranch,
-	LuLoaderCircle,
-	LuMinus,
-	LuX,
-} from "react-icons/lu";
-import type {
-	V2WorkspacePrChecksStatus,
-	V2WorkspacePrReviewDecision,
-	V2WorkspacePrState,
-	V2WorkspacePrSummary,
-} from "renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces";
+import { LuGitBranch } from "react-icons/lu";
+import type { V2WorkspacePrSummary } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces";
+import { ChecksList } from "./components/ChecksList";
+import { ChecksSummary } from "./components/ChecksSummary";
+import { PrStateBadge } from "./components/PrStateBadge";
+import { ReviewStatusBadge } from "./components/ReviewStatusBadge";
 
 interface V2WorkspacePrHoverCardContentProps {
 	pr: V2WorkspacePrSummary;
@@ -28,6 +17,9 @@ export function V2WorkspacePrHoverCardContent({
 	pr,
 	branch,
 }: V2WorkspacePrHoverCardContentProps) {
+	const showChecks =
+		(pr.state === "open" || pr.state === "draft") && pr.checksStatus !== "none";
+
 	return (
 		<div className="space-y-3">
 			<div className="space-y-0.5">
@@ -65,8 +57,7 @@ export function V2WorkspacePrHoverCardContent({
 					Updated {formatDistanceToNow(pr.updatedAt, { addSuffix: true })}
 				</span>
 
-				{(pr.state === "open" || pr.state === "draft") &&
-				pr.checksStatus !== "none" ? (
+				{showChecks ? (
 					<div className="space-y-2 pt-1">
 						<div className="flex items-center gap-2 text-xs">
 							<ChecksSummary checks={pr.checks} status={pr.checksStatus} />
@@ -94,175 +85,4 @@ export function V2WorkspacePrHoverCardContent({
 			</div>
 		</div>
 	);
-}
-
-const STATE_BADGE_STYLES: Record<V2WorkspacePrState, string> = {
-	open: "bg-emerald-500/15 text-emerald-500",
-	draft: "bg-muted text-muted-foreground",
-	merged: "bg-violet-500/15 text-violet-500",
-	closed: "bg-destructive/15 text-destructive-foreground",
-};
-
-const STATE_BADGE_LABELS: Record<V2WorkspacePrState, string> = {
-	open: "Open",
-	draft: "Draft",
-	merged: "Merged",
-	closed: "Closed",
-};
-
-function PrStateBadge({ state }: { state: V2WorkspacePrState }) {
-	return (
-		<span
-			className={cn(
-				"shrink-0 rounded-md px-1.5 py-0.5 text-[10px] font-medium",
-				STATE_BADGE_STYLES[state],
-			)}
-		>
-			{STATE_BADGE_LABELS[state]}
-		</span>
-	);
-}
-
-const REVIEW_BADGE_STYLES: Record<V2WorkspacePrReviewDecision, string> = {
-	approved: "bg-emerald-500/15 text-emerald-500",
-	changes_requested: "bg-destructive/15 text-destructive-foreground",
-	pending: "bg-amber-500/15 text-amber-500",
-};
-
-const REVIEW_BADGE_LABELS: Record<V2WorkspacePrReviewDecision, string> = {
-	approved: "Approved",
-	changes_requested: "Changes requested",
-	pending: "Review pending",
-};
-
-function ReviewStatusBadge({
-	status,
-}: {
-	status: V2WorkspacePrReviewDecision;
-}) {
-	return (
-		<span
-			className={cn(
-				"max-w-[200px] shrink-0 truncate rounded-md px-1.5 py-0.5 text-[10px] font-medium",
-				REVIEW_BADGE_STYLES[status],
-			)}
-		>
-			{REVIEW_BADGE_LABELS[status]}
-		</span>
-	);
-}
-
-interface ChecksSummaryProps {
-	checks: V2WorkspacePrSummary["checks"];
-	status: V2WorkspacePrChecksStatus;
-}
-
-function ChecksSummary({ checks, status }: ChecksSummaryProps) {
-	if (status === "none") return null;
-
-	const passing = checks.filter((c) => c.status === "success").length;
-	const total = checks.filter(
-		(c) => c.status !== "skipped" && c.status !== "cancelled",
-	).length;
-
-	const config = {
-		success: { Icon: LuCheck, className: "text-emerald-500" },
-		failure: { Icon: LuX, className: "text-destructive-foreground" },
-		pending: { Icon: LuLoaderCircle, className: "text-amber-500" },
-	} as const;
-
-	const { Icon, className } = config[status];
-	const label = total > 0 ? `${passing}/${total} checks` : "Checks";
-
-	return (
-		<span className={cn("flex items-center gap-1", className)}>
-			<Icon className={cn("size-3", status === "pending" && "animate-spin")} />
-			<span>{label}</span>
-		</span>
-	);
-}
-
-interface ChecksListProps {
-	checks: V2WorkspacePrSummary["checks"];
-}
-
-function ChecksList({ checks }: ChecksListProps) {
-	const [expanded, setExpanded] = useState(false);
-
-	const relevant = checks.filter(
-		(c) => c.status !== "skipped" && c.status !== "cancelled",
-	);
-	if (relevant.length === 0) return null;
-
-	return (
-		<div className="text-xs">
-			<button
-				type="button"
-				onClick={() => setExpanded((prev) => !prev)}
-				className="flex items-center gap-1 text-muted-foreground transition-colors hover:text-foreground"
-			>
-				{expanded ? (
-					<LuChevronDown className="size-3" />
-				) : (
-					<LuChevronRight className="size-3" />
-				)}
-				<span>{expanded ? "Hide checks" : "Show checks"}</span>
-			</button>
-
-			{expanded ? (
-				<div className="mt-1.5 space-y-1 pl-1">
-					{relevant.map((check) => (
-						<CheckRow key={check.name} check={check} />
-					))}
-				</div>
-			) : null}
-		</div>
-	);
-}
-
-const CHECK_ROW_CONFIG: Record<
-	V2WorkspacePrSummary["checks"][number]["status"],
-	{ Icon: typeof LuCheck; className: string }
-> = {
-	success: { Icon: LuCheck, className: "text-emerald-500" },
-	failure: { Icon: LuX, className: "text-destructive-foreground" },
-	pending: { Icon: LuLoaderCircle, className: "text-amber-500" },
-	skipped: { Icon: LuMinus, className: "text-muted-foreground" },
-	cancelled: { Icon: LuMinus, className: "text-muted-foreground" },
-};
-
-function CheckRow({
-	check,
-}: {
-	check: V2WorkspacePrSummary["checks"][number];
-}) {
-	const { Icon, className } = CHECK_ROW_CONFIG[check.status];
-	const content = (
-		<span className="flex items-center gap-1.5 py-0.5">
-			<Icon
-				className={cn(
-					"size-3 shrink-0",
-					className,
-					check.status === "pending" && "animate-spin",
-				)}
-			/>
-			<span className="truncate">{check.name}</span>
-		</span>
-	);
-
-	if (check.url) {
-		return (
-			<a
-				href={check.url}
-				target="_blank"
-				rel="noopener noreferrer"
-				onClick={(event) => event.stopPropagation()}
-				className="block text-muted-foreground transition-colors hover:text-foreground"
-			>
-				{content}
-			</a>
-		);
-	}
-
-	return <div className="text-muted-foreground">{content}</div>;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacePrHoverCardContent/V2WorkspacePrHoverCardContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacePrHoverCardContent/V2WorkspacePrHoverCardContent.tsx
@@ -49,7 +49,7 @@ export function V2WorkspacePrHoverCardContent({
 							#{pr.prNumber}
 						</span>
 						<PrStateBadge state={pr.state} />
-						{pr.state === "open" ? (
+						{pr.state === "open" || pr.state === "draft" ? (
 							<ReviewStatusBadge status={pr.reviewDecision} />
 						) : null}
 					</div>
@@ -65,7 +65,8 @@ export function V2WorkspacePrHoverCardContent({
 					Updated {formatDistanceToNow(pr.updatedAt, { addSuffix: true })}
 				</span>
 
-				{pr.state === "open" && pr.checksStatus !== "none" ? (
+				{(pr.state === "open" || pr.state === "draft") &&
+				pr.checksStatus !== "none" ? (
 					<div className="space-y-2 pt-1">
 						<div className="flex items-center gap-2 text-xs">
 							<ChecksSummary checks={pr.checks} status={pr.checksStatus} />

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacePrHoverCardContent/V2WorkspacePrHoverCardContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacePrHoverCardContent/V2WorkspacePrHoverCardContent.tsx
@@ -1,0 +1,267 @@
+import { Button } from "@superset/ui/button";
+import { cn } from "@superset/ui/utils";
+import { formatDistanceToNow } from "date-fns";
+import { useState } from "react";
+import { FaGithub } from "react-icons/fa";
+import {
+	LuCheck,
+	LuChevronDown,
+	LuChevronRight,
+	LuGitBranch,
+	LuLoaderCircle,
+	LuMinus,
+	LuX,
+} from "react-icons/lu";
+import type {
+	V2WorkspacePrChecksStatus,
+	V2WorkspacePrReviewDecision,
+	V2WorkspacePrState,
+	V2WorkspacePrSummary,
+} from "renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces";
+
+interface V2WorkspacePrHoverCardContentProps {
+	pr: V2WorkspacePrSummary;
+	branch: string;
+}
+
+export function V2WorkspacePrHoverCardContent({
+	pr,
+	branch,
+}: V2WorkspacePrHoverCardContentProps) {
+	return (
+		<div className="space-y-3">
+			<div className="space-y-0.5">
+				<span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+					Branch
+				</span>
+				<div className="flex items-center gap-1.5 text-sm">
+					<LuGitBranch className="size-3 shrink-0 text-muted-foreground" />
+					<code className="block min-w-0 flex-1 break-all font-mono text-xs">
+						{branch}
+					</code>
+				</div>
+			</div>
+
+			<div className="space-y-2 border-t border-border pt-2">
+				<div className="flex items-center justify-between gap-2">
+					<div className="flex flex-wrap items-center gap-1.5">
+						<span className="text-xs font-medium text-muted-foreground">
+							#{pr.prNumber}
+						</span>
+						<PrStateBadge state={pr.state} />
+						{pr.state === "open" ? (
+							<ReviewStatusBadge status={pr.reviewDecision} />
+						) : null}
+					</div>
+					<div className="flex shrink-0 items-center gap-1.5 font-mono text-xs">
+						<span className="text-emerald-500">+{pr.additions}</span>
+						<span className="text-destructive-foreground">-{pr.deletions}</span>
+					</div>
+				</div>
+
+				<p className="line-clamp-2 text-xs leading-relaxed">{pr.title}</p>
+
+				<span className="block text-[10px] text-muted-foreground">
+					Updated {formatDistanceToNow(pr.updatedAt, { addSuffix: true })}
+				</span>
+
+				{pr.state === "open" && pr.checksStatus !== "none" ? (
+					<div className="space-y-2 pt-1">
+						<div className="flex items-center gap-2 text-xs">
+							<ChecksSummary checks={pr.checks} status={pr.checksStatus} />
+						</div>
+						{pr.checks.length > 0 ? <ChecksList checks={pr.checks} /> : null}
+					</div>
+				) : null}
+
+				<Button
+					variant="outline"
+					size="sm"
+					className="mt-1 h-7 w-full gap-1.5 text-xs"
+					asChild
+				>
+					<a
+						href={pr.url}
+						target="_blank"
+						rel="noopener noreferrer"
+						onClick={(event) => event.stopPropagation()}
+					>
+						<FaGithub className="size-3" />
+						View on GitHub
+					</a>
+				</Button>
+			</div>
+		</div>
+	);
+}
+
+const STATE_BADGE_STYLES: Record<V2WorkspacePrState, string> = {
+	open: "bg-emerald-500/15 text-emerald-500",
+	draft: "bg-muted text-muted-foreground",
+	merged: "bg-violet-500/15 text-violet-500",
+	closed: "bg-destructive/15 text-destructive-foreground",
+};
+
+const STATE_BADGE_LABELS: Record<V2WorkspacePrState, string> = {
+	open: "Open",
+	draft: "Draft",
+	merged: "Merged",
+	closed: "Closed",
+};
+
+function PrStateBadge({ state }: { state: V2WorkspacePrState }) {
+	return (
+		<span
+			className={cn(
+				"shrink-0 rounded-md px-1.5 py-0.5 text-[10px] font-medium",
+				STATE_BADGE_STYLES[state],
+			)}
+		>
+			{STATE_BADGE_LABELS[state]}
+		</span>
+	);
+}
+
+const REVIEW_BADGE_STYLES: Record<V2WorkspacePrReviewDecision, string> = {
+	approved: "bg-emerald-500/15 text-emerald-500",
+	changes_requested: "bg-destructive/15 text-destructive-foreground",
+	pending: "bg-amber-500/15 text-amber-500",
+};
+
+const REVIEW_BADGE_LABELS: Record<V2WorkspacePrReviewDecision, string> = {
+	approved: "Approved",
+	changes_requested: "Changes requested",
+	pending: "Review pending",
+};
+
+function ReviewStatusBadge({
+	status,
+}: {
+	status: V2WorkspacePrReviewDecision;
+}) {
+	return (
+		<span
+			className={cn(
+				"max-w-[200px] shrink-0 truncate rounded-md px-1.5 py-0.5 text-[10px] font-medium",
+				REVIEW_BADGE_STYLES[status],
+			)}
+		>
+			{REVIEW_BADGE_LABELS[status]}
+		</span>
+	);
+}
+
+interface ChecksSummaryProps {
+	checks: V2WorkspacePrSummary["checks"];
+	status: V2WorkspacePrChecksStatus;
+}
+
+function ChecksSummary({ checks, status }: ChecksSummaryProps) {
+	if (status === "none") return null;
+
+	const passing = checks.filter((c) => c.status === "success").length;
+	const total = checks.filter(
+		(c) => c.status !== "skipped" && c.status !== "cancelled",
+	).length;
+
+	const config = {
+		success: { Icon: LuCheck, className: "text-emerald-500" },
+		failure: { Icon: LuX, className: "text-destructive-foreground" },
+		pending: { Icon: LuLoaderCircle, className: "text-amber-500" },
+	} as const;
+
+	const { Icon, className } = config[status];
+	const label = total > 0 ? `${passing}/${total} checks` : "Checks";
+
+	return (
+		<span className={cn("flex items-center gap-1", className)}>
+			<Icon className={cn("size-3", status === "pending" && "animate-spin")} />
+			<span>{label}</span>
+		</span>
+	);
+}
+
+interface ChecksListProps {
+	checks: V2WorkspacePrSummary["checks"];
+}
+
+function ChecksList({ checks }: ChecksListProps) {
+	const [expanded, setExpanded] = useState(false);
+
+	const relevant = checks.filter(
+		(c) => c.status !== "skipped" && c.status !== "cancelled",
+	);
+	if (relevant.length === 0) return null;
+
+	return (
+		<div className="text-xs">
+			<button
+				type="button"
+				onClick={() => setExpanded((prev) => !prev)}
+				className="flex items-center gap-1 text-muted-foreground transition-colors hover:text-foreground"
+			>
+				{expanded ? (
+					<LuChevronDown className="size-3" />
+				) : (
+					<LuChevronRight className="size-3" />
+				)}
+				<span>{expanded ? "Hide checks" : "Show checks"}</span>
+			</button>
+
+			{expanded ? (
+				<div className="mt-1.5 space-y-1 pl-1">
+					{relevant.map((check) => (
+						<CheckRow key={check.name} check={check} />
+					))}
+				</div>
+			) : null}
+		</div>
+	);
+}
+
+const CHECK_ROW_CONFIG: Record<
+	V2WorkspacePrSummary["checks"][number]["status"],
+	{ Icon: typeof LuCheck; className: string }
+> = {
+	success: { Icon: LuCheck, className: "text-emerald-500" },
+	failure: { Icon: LuX, className: "text-destructive-foreground" },
+	pending: { Icon: LuLoaderCircle, className: "text-amber-500" },
+	skipped: { Icon: LuMinus, className: "text-muted-foreground" },
+	cancelled: { Icon: LuMinus, className: "text-muted-foreground" },
+};
+
+function CheckRow({
+	check,
+}: {
+	check: V2WorkspacePrSummary["checks"][number];
+}) {
+	const { Icon, className } = CHECK_ROW_CONFIG[check.status];
+	const content = (
+		<span className="flex items-center gap-1.5 py-0.5">
+			<Icon
+				className={cn(
+					"size-3 shrink-0",
+					className,
+					check.status === "pending" && "animate-spin",
+				)}
+			/>
+			<span className="truncate">{check.name}</span>
+		</span>
+	);
+
+	if (check.url) {
+		return (
+			<a
+				href={check.url}
+				target="_blank"
+				rel="noopener noreferrer"
+				onClick={(event) => event.stopPropagation()}
+				className="block text-muted-foreground transition-colors hover:text-foreground"
+			>
+				{content}
+			</a>
+		);
+	}
+
+	return <div className="text-muted-foreground">{content}</div>;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacePrHoverCardContent/components/ChecksList/ChecksList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacePrHoverCardContent/components/ChecksList/ChecksList.tsx
@@ -1,0 +1,42 @@
+import { useState } from "react";
+import { LuChevronDown, LuChevronRight } from "react-icons/lu";
+import type { V2WorkspacePrSummary } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces";
+import { CheckRow } from "./components/CheckRow";
+
+interface ChecksListProps {
+	checks: V2WorkspacePrSummary["checks"];
+}
+
+export function ChecksList({ checks }: ChecksListProps) {
+	const [expanded, setExpanded] = useState(false);
+
+	const relevant = checks.filter(
+		(c) => c.status !== "skipped" && c.status !== "cancelled",
+	);
+	if (relevant.length === 0) return null;
+
+	return (
+		<div className="text-xs">
+			<button
+				type="button"
+				onClick={() => setExpanded((prev) => !prev)}
+				className="flex items-center gap-1 text-muted-foreground transition-colors hover:text-foreground"
+			>
+				{expanded ? (
+					<LuChevronDown className="size-3" />
+				) : (
+					<LuChevronRight className="size-3" />
+				)}
+				<span>{expanded ? "Hide checks" : "Show checks"}</span>
+			</button>
+
+			{expanded ? (
+				<div className="mt-1.5 space-y-1 pl-1">
+					{relevant.map((check) => (
+						<CheckRow key={check.name} check={check} />
+					))}
+				</div>
+			) : null}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacePrHoverCardContent/components/ChecksList/components/CheckRow/CheckRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacePrHoverCardContent/components/ChecksList/components/CheckRow/CheckRow.tsx
@@ -1,0 +1,50 @@
+import { cn } from "@superset/ui/utils";
+import { LuCheck, LuLoaderCircle, LuMinus, LuX } from "react-icons/lu";
+import type { V2WorkspacePrSummary } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces";
+
+const CHECK_ROW_CONFIG: Record<
+	V2WorkspacePrSummary["checks"][number]["status"],
+	{ Icon: typeof LuCheck; className: string }
+> = {
+	success: { Icon: LuCheck, className: "text-emerald-500" },
+	failure: { Icon: LuX, className: "text-destructive-foreground" },
+	pending: { Icon: LuLoaderCircle, className: "text-amber-500" },
+	skipped: { Icon: LuMinus, className: "text-muted-foreground" },
+	cancelled: { Icon: LuMinus, className: "text-muted-foreground" },
+};
+
+interface CheckRowProps {
+	check: V2WorkspacePrSummary["checks"][number];
+}
+
+export function CheckRow({ check }: CheckRowProps) {
+	const { Icon, className } = CHECK_ROW_CONFIG[check.status];
+	const content = (
+		<span className="flex items-center gap-1.5 py-0.5">
+			<Icon
+				className={cn(
+					"size-3 shrink-0",
+					className,
+					check.status === "pending" && "animate-spin",
+				)}
+			/>
+			<span className="truncate">{check.name}</span>
+		</span>
+	);
+
+	if (check.url) {
+		return (
+			<a
+				href={check.url}
+				target="_blank"
+				rel="noopener noreferrer"
+				onClick={(event) => event.stopPropagation()}
+				className="block text-muted-foreground transition-colors hover:text-foreground"
+			>
+				{content}
+			</a>
+		);
+	}
+
+	return <div className="text-muted-foreground">{content}</div>;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacePrHoverCardContent/components/ChecksList/components/CheckRow/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacePrHoverCardContent/components/ChecksList/components/CheckRow/index.ts
@@ -1,0 +1,1 @@
+export { CheckRow } from "./CheckRow";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacePrHoverCardContent/components/ChecksList/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacePrHoverCardContent/components/ChecksList/index.ts
@@ -1,0 +1,1 @@
+export { ChecksList } from "./ChecksList";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacePrHoverCardContent/components/ChecksSummary/ChecksSummary.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacePrHoverCardContent/components/ChecksSummary/ChecksSummary.tsx
@@ -1,0 +1,36 @@
+import { cn } from "@superset/ui/utils";
+import { LuCheck, LuLoaderCircle, LuX } from "react-icons/lu";
+import type {
+	V2WorkspacePrChecksStatus,
+	V2WorkspacePrSummary,
+} from "renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces";
+
+interface ChecksSummaryProps {
+	checks: V2WorkspacePrSummary["checks"];
+	status: V2WorkspacePrChecksStatus;
+}
+
+export function ChecksSummary({ checks, status }: ChecksSummaryProps) {
+	if (status === "none") return null;
+
+	const passing = checks.filter((c) => c.status === "success").length;
+	const total = checks.filter(
+		(c) => c.status !== "skipped" && c.status !== "cancelled",
+	).length;
+
+	const config = {
+		success: { Icon: LuCheck, className: "text-emerald-500" },
+		failure: { Icon: LuX, className: "text-destructive-foreground" },
+		pending: { Icon: LuLoaderCircle, className: "text-amber-500" },
+	} as const;
+
+	const { Icon, className } = config[status];
+	const label = total > 0 ? `${passing}/${total} checks` : "Checks";
+
+	return (
+		<span className={cn("flex items-center gap-1", className)}>
+			<Icon className={cn("size-3", status === "pending" && "animate-spin")} />
+			<span>{label}</span>
+		</span>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacePrHoverCardContent/components/ChecksSummary/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacePrHoverCardContent/components/ChecksSummary/index.ts
@@ -1,0 +1,1 @@
+export { ChecksSummary } from "./ChecksSummary";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacePrHoverCardContent/components/PrStateBadge/PrStateBadge.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacePrHoverCardContent/components/PrStateBadge/PrStateBadge.tsx
@@ -1,0 +1,33 @@
+import { cn } from "@superset/ui/utils";
+import type { V2WorkspacePrState } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces";
+
+const STATE_BADGE_STYLES: Record<V2WorkspacePrState, string> = {
+	open: "bg-emerald-500/15 text-emerald-500",
+	draft: "bg-muted text-muted-foreground",
+	merged: "bg-violet-500/15 text-violet-500",
+	closed: "bg-destructive/15 text-destructive-foreground",
+};
+
+const STATE_BADGE_LABELS: Record<V2WorkspacePrState, string> = {
+	open: "Open",
+	draft: "Draft",
+	merged: "Merged",
+	closed: "Closed",
+};
+
+interface PrStateBadgeProps {
+	state: V2WorkspacePrState;
+}
+
+export function PrStateBadge({ state }: PrStateBadgeProps) {
+	return (
+		<span
+			className={cn(
+				"shrink-0 rounded-md px-1.5 py-0.5 text-[10px] font-medium",
+				STATE_BADGE_STYLES[state],
+			)}
+		>
+			{STATE_BADGE_LABELS[state]}
+		</span>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacePrHoverCardContent/components/PrStateBadge/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacePrHoverCardContent/components/PrStateBadge/index.ts
@@ -1,0 +1,1 @@
+export { PrStateBadge } from "./PrStateBadge";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacePrHoverCardContent/components/ReviewStatusBadge/ReviewStatusBadge.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacePrHoverCardContent/components/ReviewStatusBadge/ReviewStatusBadge.tsx
@@ -1,0 +1,31 @@
+import { cn } from "@superset/ui/utils";
+import type { V2WorkspacePrReviewDecision } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces";
+
+const REVIEW_BADGE_STYLES: Record<V2WorkspacePrReviewDecision, string> = {
+	approved: "bg-emerald-500/15 text-emerald-500",
+	changes_requested: "bg-destructive/15 text-destructive-foreground",
+	pending: "bg-amber-500/15 text-amber-500",
+};
+
+const REVIEW_BADGE_LABELS: Record<V2WorkspacePrReviewDecision, string> = {
+	approved: "Approved",
+	changes_requested: "Changes requested",
+	pending: "Review pending",
+};
+
+interface ReviewStatusBadgeProps {
+	status: V2WorkspacePrReviewDecision;
+}
+
+export function ReviewStatusBadge({ status }: ReviewStatusBadgeProps) {
+	return (
+		<span
+			className={cn(
+				"max-w-[200px] shrink-0 truncate rounded-md px-1.5 py-0.5 text-[10px] font-medium",
+				REVIEW_BADGE_STYLES[status],
+			)}
+		>
+			{REVIEW_BADGE_LABELS[status]}
+		</span>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacePrHoverCardContent/components/ReviewStatusBadge/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacePrHoverCardContent/components/ReviewStatusBadge/index.ts
@@ -1,0 +1,1 @@
+export { ReviewStatusBadge } from "./ReviewStatusBadge";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacePrHoverCardContent/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacePrHoverCardContent/index.ts
@@ -1,0 +1,1 @@
+export { V2WorkspacePrHoverCardContent } from "./V2WorkspacePrHoverCardContent";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspaceProjectIcon/V2WorkspaceProjectIcon.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspaceProjectIcon/V2WorkspaceProjectIcon.tsx
@@ -1,0 +1,65 @@
+import { cn } from "@superset/ui/utils";
+import { useState } from "react";
+
+interface V2WorkspaceProjectIconProps {
+	projectName: string;
+	githubOwner: string | null;
+	size?: "sm" | "md";
+	className?: string;
+}
+
+const SIZE_CLASSES: Record<
+	NonNullable<V2WorkspaceProjectIconProps["size"]>,
+	string
+> = {
+	sm: "size-5 text-[10px]",
+	md: "size-6 text-xs",
+};
+
+function githubAvatarUrl(owner: string): string {
+	return `https://github.com/${owner}.png?size=64`;
+}
+
+export function V2WorkspaceProjectIcon({
+	projectName,
+	githubOwner,
+	size = "md",
+	className,
+}: V2WorkspaceProjectIconProps) {
+	const [imageFailed, setImageFailed] = useState(false);
+	const dimensions = SIZE_CLASSES[size];
+	const showImage = githubOwner != null && !imageFailed;
+
+	if (showImage) {
+		return (
+			<div
+				className={cn(
+					"relative shrink-0 overflow-hidden rounded border border-border bg-muted",
+					dimensions,
+					className,
+				)}
+			>
+				<img
+					src={githubAvatarUrl(githubOwner)}
+					alt=""
+					aria-hidden
+					className="size-full object-cover"
+					onError={() => setImageFailed(true)}
+				/>
+			</div>
+		);
+	}
+
+	return (
+		<div
+			className={cn(
+				"flex shrink-0 items-center justify-center rounded border border-border bg-muted font-medium text-muted-foreground",
+				dimensions,
+				className,
+			)}
+			aria-hidden
+		>
+			{projectName.charAt(0).toUpperCase() || "?"}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspaceProjectIcon/V2WorkspaceProjectIcon.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspaceProjectIcon/V2WorkspaceProjectIcon.tsx
@@ -26,7 +26,8 @@ export function V2WorkspaceProjectIcon({
 	size = "md",
 	className,
 }: V2WorkspaceProjectIconProps) {
-	const [imageFailed, setImageFailed] = useState(false);
+	const [failedOwner, setFailedOwner] = useState<string | null>(null);
+	const imageFailed = githubOwner != null && failedOwner === githubOwner;
 	const dimensions = SIZE_CLASSES[size];
 	const showImage = githubOwner != null && !imageFailed;
 
@@ -44,7 +45,7 @@ export function V2WorkspaceProjectIcon({
 					alt=""
 					aria-hidden
 					className="size-full object-cover"
-					onError={() => setImageFailed(true)}
+					onError={() => setFailedOwner(githubOwner)}
 				/>
 			</div>
 		);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspaceProjectIcon/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspaceProjectIcon/index.ts
@@ -1,0 +1,1 @@
+export { V2WorkspaceProjectIcon } from "./V2WorkspaceProjectIcon";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesHeader/V2WorkspacesHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesHeader/V2WorkspacesHeader.tsx
@@ -14,7 +14,6 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@superset/ui/select";
-import { cn } from "@superset/ui/utils";
 import {
 	LuFolders,
 	LuLaptop,
@@ -35,6 +34,9 @@ import {
 	useV2WorkspacesFilterStore,
 } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore";
 import { V2WorkspaceProjectIcon } from "../V2WorkspaceProjectIcon";
+import { DeviceFilterTriggerLabel } from "./components/DeviceFilterTriggerLabel";
+import { DeviceOptionLabel } from "./components/DeviceOptionLabel";
+import { ProjectFilterTriggerLabel } from "./components/ProjectFilterTriggerLabel";
 
 interface V2WorkspacesHeaderProps {
 	counts: V2WorkspaceDeviceCounts;
@@ -105,21 +107,15 @@ export function V2WorkspacesHeader({
 			: undefined;
 	const selectedProjectLabel = selectedProjectFromOptions
 		? {
-				projectId: selectedProjectFromOptions.projectId,
 				projectName: selectedProjectFromOptions.projectName,
 				githubOwner: selectedProjectFromOptions.githubOwner,
 			}
 		: selectedProjectFallback
 			? {
-					projectId: projectFilter,
 					projectName: selectedProjectFallback.projectName,
 					githubOwner: selectedProjectFallback.githubOwner,
 				}
 			: undefined;
-	const totalProjectCount = projectOptions.reduce(
-		(total, project) => total + project.count,
-		0,
-	);
 
 	return (
 		<div className="border-b border-border">
@@ -166,9 +162,6 @@ export function V2WorkspacesHeader({
 										<LuFolders className="size-3.5" />
 										<span className="min-w-0 flex-1 truncate">
 											All projects
-										</span>
-										<span className="tabular-nums text-xs text-muted-foreground">
-											{totalProjectCount}
 										</span>
 									</span>
 								</SelectItem>
@@ -259,123 +252,5 @@ export function V2WorkspacesHeader({
 				</div>
 			</div>
 		</div>
-	);
-}
-
-interface ProjectFilterTriggerLabelProps {
-	projectFilter: string;
-	selectedProject:
-		| { projectName: string; githubOwner: string | null }
-		| undefined;
-}
-
-function ProjectFilterTriggerLabel({
-	projectFilter,
-	selectedProject,
-}: ProjectFilterTriggerLabelProps) {
-	if (projectFilter === PROJECT_FILTER_ALL) {
-		return (
-			<span className="flex items-center gap-2">
-				<LuFolders className="size-3.5" />
-				<span>All projects</span>
-			</span>
-		);
-	}
-	if (!selectedProject) {
-		return (
-			<span className="flex items-center gap-2">
-				<LuFolders className="size-3.5" />
-				<span className="text-muted-foreground">Unknown project</span>
-			</span>
-		);
-	}
-	return (
-		<span className="flex min-w-0 items-center gap-2">
-			<V2WorkspaceProjectIcon
-				projectName={selectedProject.projectName}
-				githubOwner={selectedProject.githubOwner}
-				size="sm"
-			/>
-			<span className="min-w-0 truncate">{selectedProject.projectName}</span>
-		</span>
-	);
-}
-
-interface DeviceFilterTriggerLabelProps {
-	deviceFilter: string;
-	selectedRemoteHost: { hostName: string; isOnline: boolean } | undefined;
-}
-
-function DeviceFilterTriggerLabel({
-	deviceFilter,
-	selectedRemoteHost,
-}: DeviceFilterTriggerLabelProps) {
-	if (deviceFilter === DEVICE_FILTER_ALL) {
-		return (
-			<span className="flex items-center gap-2">
-				<LuLayers className="size-3.5" />
-				<span>All devices</span>
-			</span>
-		);
-	}
-	if (deviceFilter === DEVICE_FILTER_THIS_DEVICE) {
-		return (
-			<span className="flex items-center gap-2">
-				<LuLaptop className="size-3.5" />
-				<span>This device</span>
-			</span>
-		);
-	}
-	return (
-		<span className="flex min-w-0 items-center gap-2">
-			<LuMonitor className="size-3.5" />
-			<span className="min-w-0 truncate">
-				{selectedRemoteHost?.hostName ?? "Unknown device"}
-			</span>
-			{selectedRemoteHost ? (
-				<span
-					aria-hidden
-					className={cn(
-						"inline-block size-1.5 shrink-0 rounded-full",
-						selectedRemoteHost.isOnline
-							? "bg-emerald-500"
-							: "bg-muted-foreground/40",
-					)}
-				/>
-			) : null}
-		</span>
-	);
-}
-
-interface DeviceOptionLabelProps {
-	icon: React.ReactNode;
-	label: string;
-	count: number;
-	isOnline?: boolean;
-}
-
-function DeviceOptionLabel({
-	icon,
-	label,
-	count,
-	isOnline,
-}: DeviceOptionLabelProps) {
-	return (
-		<span className="flex w-full min-w-0 items-center gap-2">
-			{icon}
-			<span className="min-w-0 flex-1 truncate">{label}</span>
-			{isOnline !== undefined ? (
-				<span
-					aria-hidden
-					className={cn(
-						"inline-block size-1.5 rounded-full",
-						isOnline ? "bg-emerald-500" : "bg-muted-foreground/40",
-					)}
-				/>
-			) : null}
-			<span className="tabular-nums text-xs text-muted-foreground">
-				{count}
-			</span>
-		</span>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesHeader/V2WorkspacesHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesHeader/V2WorkspacesHeader.tsx
@@ -1,38 +1,52 @@
 import {
 	InputGroup,
 	InputGroupAddon,
+	InputGroupButton,
 	InputGroupInput,
 } from "@superset/ui/input-group";
-import { ToggleGroup, ToggleGroupItem } from "@superset/ui/toggle-group";
 import {
-	LuCloud,
+	Select,
+	SelectContent,
+	SelectGroup,
+	SelectItem,
+	SelectLabel,
+	SelectSeparator,
+	SelectTrigger,
+	SelectValue,
+} from "@superset/ui/select";
+import { cn } from "@superset/ui/utils";
+import {
+	LuFolders,
 	LuLaptop,
 	LuLayers,
 	LuMonitor,
 	LuSearch,
+	LuX,
 } from "react-icons/lu";
-import type { V2WorkspaceDeviceCounts } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces";
+import type {
+	V2WorkspaceDeviceCounts,
+	V2WorkspaceHostOption,
+	V2WorkspaceProjectOption,
+} from "renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces";
 import {
+	DEVICE_FILTER_ALL,
+	DEVICE_FILTER_THIS_DEVICE,
+	PROJECT_FILTER_ALL,
 	useV2WorkspacesFilterStore,
-	type V2WorkspacesDeviceFilter,
 } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore";
+import { V2WorkspaceProjectIcon } from "../V2WorkspaceProjectIcon";
 
 interface V2WorkspacesHeaderProps {
 	counts: V2WorkspaceDeviceCounts;
+	hostOptions: V2WorkspaceHostOption[];
+	projectOptions: V2WorkspaceProjectOption[];
 }
 
-const DEVICE_FILTER_OPTIONS: Array<{
-	value: V2WorkspacesDeviceFilter;
-	label: string;
-	Icon: typeof LuLayers | null;
-}> = [
-	{ value: "all", label: "All", Icon: LuLayers },
-	{ value: "this-device", label: "This device", Icon: LuLaptop },
-	{ value: "other-devices", label: "Other devices", Icon: LuMonitor },
-	{ value: "cloud", label: "Cloud", Icon: LuCloud },
-];
-
-export function V2WorkspacesHeader({ counts }: V2WorkspacesHeaderProps) {
+export function V2WorkspacesHeader({
+	counts,
+	hostOptions,
+	projectOptions,
+}: V2WorkspacesHeaderProps) {
 	const searchQuery = useV2WorkspacesFilterStore((state) => state.searchQuery);
 	const setSearchQuery = useV2WorkspacesFilterStore(
 		(state) => state.setSearchQuery,
@@ -43,19 +57,24 @@ export function V2WorkspacesHeader({ counts }: V2WorkspacesHeaderProps) {
 	const setDeviceFilter = useV2WorkspacesFilterStore(
 		(state) => state.setDeviceFilter,
 	);
+	const projectFilter = useV2WorkspacesFilterStore(
+		(state) => state.projectFilter,
+	);
+	const setProjectFilter = useV2WorkspacesFilterStore(
+		(state) => state.setProjectFilter,
+	);
 
-	const countForFilter = (value: V2WorkspacesDeviceFilter): number => {
-		switch (value) {
-			case "all":
-				return counts.all;
-			case "this-device":
-				return counts.thisDevice;
-			case "other-devices":
-				return counts.otherDevices;
-			case "cloud":
-				return counts.cloud;
-		}
-	};
+	const remoteHosts = hostOptions.filter((host) => !host.isLocal);
+	const selectedRemoteHost = remoteHosts.find(
+		(host) => host.hostId === deviceFilter,
+	);
+	const selectedProject = projectOptions.find(
+		(project) => project.projectId === projectFilter,
+	);
+	const totalProjectCount = projectOptions.reduce(
+		(total, project) => total + project.count,
+		0,
+	);
 
 	return (
 		<div className="border-b border-border">
@@ -68,39 +87,240 @@ export function V2WorkspacesHeader({ counts }: V2WorkspacesHeaderProps) {
 							<LuSearch className="size-4" />
 						</InputGroupAddon>
 						<InputGroupInput
-							type="search"
+							type="text"
 							placeholder="Search workspaces…"
 							value={searchQuery}
 							onChange={(event) => setSearchQuery(event.target.value)}
 						/>
+						{searchQuery ? (
+							<InputGroupAddon align="inline-end">
+								<InputGroupButton
+									size="icon-xs"
+									aria-label="Clear search"
+									onClick={() => setSearchQuery("")}
+								>
+									<LuX />
+								</InputGroupButton>
+							</InputGroupAddon>
+						) : null}
 					</InputGroup>
 
-					<ToggleGroup
-						type="single"
-						variant="outline"
-						size="sm"
-						value={deviceFilter}
-						onValueChange={(value) => {
-							if (value) setDeviceFilter(value as V2WorkspacesDeviceFilter);
-						}}
-					>
-						{DEVICE_FILTER_OPTIONS.map(({ value, label, Icon }) => (
-							<ToggleGroupItem
-								key={value}
-								value={value}
-								aria-label={label}
-								className="gap-1.5"
-							>
-								{Icon ? <Icon className="size-3.5" /> : null}
-								<span>{label}</span>
-								<span className="tabular-nums text-muted-foreground">
-									{countForFilter(value)}
-								</span>
-							</ToggleGroupItem>
-						))}
-					</ToggleGroup>
+					<Select value={projectFilter} onValueChange={setProjectFilter}>
+						<SelectTrigger size="sm" className="min-w-[12rem]">
+							<SelectValue placeholder="Filter projects">
+								<ProjectFilterTriggerLabel
+									projectFilter={projectFilter}
+									selectedProject={selectedProject}
+								/>
+							</SelectValue>
+						</SelectTrigger>
+						<SelectContent align="end" className="min-w-[16rem]">
+							<SelectGroup>
+								<SelectItem value={PROJECT_FILTER_ALL}>
+									<span className="flex w-full min-w-0 items-center gap-2">
+										<LuFolders className="size-3.5" />
+										<span className="min-w-0 flex-1 truncate">
+											All projects
+										</span>
+										<span className="tabular-nums text-xs text-muted-foreground">
+											{totalProjectCount}
+										</span>
+									</span>
+								</SelectItem>
+							</SelectGroup>
+
+							{projectOptions.length > 0 ? (
+								<>
+									<SelectSeparator />
+									<SelectGroup>
+										<SelectLabel className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70">
+											Projects
+										</SelectLabel>
+										{projectOptions.map((project) => (
+											<SelectItem
+												key={project.projectId}
+												value={project.projectId}
+											>
+												<span className="flex w-full min-w-0 items-center gap-2">
+													<V2WorkspaceProjectIcon
+														projectName={project.projectName}
+														githubOwner={project.githubOwner}
+														size="sm"
+													/>
+													<span className="min-w-0 flex-1 truncate">
+														{project.projectName}
+													</span>
+													<span className="tabular-nums text-xs text-muted-foreground">
+														{project.count}
+													</span>
+												</span>
+											</SelectItem>
+										))}
+									</SelectGroup>
+								</>
+							) : null}
+						</SelectContent>
+					</Select>
+
+					<Select value={deviceFilter} onValueChange={setDeviceFilter}>
+						<SelectTrigger size="sm" className="min-w-[12rem]">
+							<SelectValue placeholder="Filter devices">
+								<DeviceFilterTriggerLabel
+									deviceFilter={deviceFilter}
+									selectedRemoteHost={selectedRemoteHost}
+								/>
+							</SelectValue>
+						</SelectTrigger>
+						<SelectContent align="end" className="min-w-[16rem]">
+							<SelectGroup>
+								<SelectItem value={DEVICE_FILTER_THIS_DEVICE}>
+									<DeviceOptionLabel
+										icon={<LuLaptop className="size-3.5" />}
+										label="This device"
+										count={counts.thisDevice}
+									/>
+								</SelectItem>
+								<SelectItem value={DEVICE_FILTER_ALL}>
+									<DeviceOptionLabel
+										icon={<LuLayers className="size-3.5" />}
+										label="All devices"
+										count={counts.all}
+									/>
+								</SelectItem>
+							</SelectGroup>
+
+							{remoteHosts.length > 0 ? (
+								<>
+									<SelectSeparator />
+									<SelectGroup>
+										<SelectLabel className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70">
+											Other devices
+										</SelectLabel>
+										{remoteHosts.map((host) => (
+											<SelectItem key={host.hostId} value={host.hostId}>
+												<DeviceOptionLabel
+													icon={<LuMonitor className="size-3.5" />}
+													label={host.hostName}
+													count={host.count}
+													isOnline={host.isOnline}
+												/>
+											</SelectItem>
+										))}
+									</SelectGroup>
+								</>
+							) : null}
+						</SelectContent>
+					</Select>
 				</div>
 			</div>
 		</div>
+	);
+}
+
+interface ProjectFilterTriggerLabelProps {
+	projectFilter: string;
+	selectedProject: V2WorkspaceProjectOption | undefined;
+}
+
+function ProjectFilterTriggerLabel({
+	projectFilter,
+	selectedProject,
+}: ProjectFilterTriggerLabelProps) {
+	if (projectFilter === PROJECT_FILTER_ALL || !selectedProject) {
+		return (
+			<span className="flex items-center gap-2">
+				<LuFolders className="size-3.5" />
+				<span>All projects</span>
+			</span>
+		);
+	}
+	return (
+		<span className="flex min-w-0 items-center gap-2">
+			<V2WorkspaceProjectIcon
+				projectName={selectedProject.projectName}
+				githubOwner={selectedProject.githubOwner}
+				size="sm"
+			/>
+			<span className="min-w-0 truncate">{selectedProject.projectName}</span>
+		</span>
+	);
+}
+
+interface DeviceFilterTriggerLabelProps {
+	deviceFilter: string;
+	selectedRemoteHost: V2WorkspaceHostOption | undefined;
+}
+
+function DeviceFilterTriggerLabel({
+	deviceFilter,
+	selectedRemoteHost,
+}: DeviceFilterTriggerLabelProps) {
+	if (deviceFilter === DEVICE_FILTER_ALL) {
+		return (
+			<span className="flex items-center gap-2">
+				<LuLayers className="size-3.5" />
+				<span>All devices</span>
+			</span>
+		);
+	}
+	if (deviceFilter === DEVICE_FILTER_THIS_DEVICE) {
+		return (
+			<span className="flex items-center gap-2">
+				<LuLaptop className="size-3.5" />
+				<span>This device</span>
+			</span>
+		);
+	}
+	return (
+		<span className="flex min-w-0 items-center gap-2">
+			<LuMonitor className="size-3.5" />
+			<span className="min-w-0 truncate">
+				{selectedRemoteHost?.hostName ?? "Unknown device"}
+			</span>
+			{selectedRemoteHost ? (
+				<span
+					aria-hidden
+					className={cn(
+						"inline-block size-1.5 shrink-0 rounded-full",
+						selectedRemoteHost.isOnline
+							? "bg-emerald-500"
+							: "bg-muted-foreground/40",
+					)}
+				/>
+			) : null}
+		</span>
+	);
+}
+
+interface DeviceOptionLabelProps {
+	icon: React.ReactNode;
+	label: string;
+	count: number;
+	isOnline?: boolean;
+}
+
+function DeviceOptionLabel({
+	icon,
+	label,
+	count,
+	isOnline,
+}: DeviceOptionLabelProps) {
+	return (
+		<span className="flex w-full min-w-0 items-center gap-2">
+			{icon}
+			<span className="min-w-0 flex-1 truncate">{label}</span>
+			{isOnline !== undefined ? (
+				<span
+					aria-hidden
+					className={cn(
+						"inline-block size-1.5 rounded-full",
+						isOnline ? "bg-emerald-500" : "bg-muted-foreground/40",
+					)}
+				/>
+			) : null}
+			<span className="tabular-nums text-xs text-muted-foreground">
+				{count}
+			</span>
+		</span>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesHeader/V2WorkspacesHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesHeader/V2WorkspacesHeader.tsx
@@ -40,12 +40,22 @@ interface V2WorkspacesHeaderProps {
 	counts: V2WorkspaceDeviceCounts;
 	hostOptions: V2WorkspaceHostOption[];
 	projectOptions: V2WorkspaceProjectOption[];
+	hostsById: Map<
+		string,
+		{ hostName: string; isOnline: boolean; isLocal: boolean }
+	>;
+	projectsById: Map<
+		string,
+		{ projectName: string; githubOwner: string | null }
+	>;
 }
 
 export function V2WorkspacesHeader({
 	counts,
 	hostOptions,
 	projectOptions,
+	hostsById,
+	projectsById,
 }: V2WorkspacesHeaderProps) {
 	const searchQuery = useV2WorkspacesFilterStore((state) => state.searchQuery);
 	const setSearchQuery = useV2WorkspacesFilterStore(
@@ -65,12 +75,47 @@ export function V2WorkspacesHeader({
 	);
 
 	const remoteHosts = hostOptions.filter((host) => !host.isLocal);
-	const selectedRemoteHost = remoteHosts.find(
+	const selectedRemoteHostFromOptions = remoteHosts.find(
 		(host) => host.hostId === deviceFilter,
 	);
-	const selectedProject = projectOptions.find(
+	const selectedHostFallback =
+		!selectedRemoteHostFromOptions &&
+		deviceFilter !== DEVICE_FILTER_ALL &&
+		deviceFilter !== DEVICE_FILTER_THIS_DEVICE
+			? hostsById.get(deviceFilter)
+			: undefined;
+	const selectedHostLabel = selectedRemoteHostFromOptions
+		? {
+				hostName: selectedRemoteHostFromOptions.hostName,
+				isOnline: selectedRemoteHostFromOptions.isOnline,
+			}
+		: selectedHostFallback
+			? {
+					hostName: selectedHostFallback.hostName,
+					isOnline: selectedHostFallback.isOnline,
+				}
+			: undefined;
+
+	const selectedProjectFromOptions = projectOptions.find(
 		(project) => project.projectId === projectFilter,
 	);
+	const selectedProjectFallback =
+		!selectedProjectFromOptions && projectFilter !== PROJECT_FILTER_ALL
+			? projectsById.get(projectFilter)
+			: undefined;
+	const selectedProjectLabel = selectedProjectFromOptions
+		? {
+				projectId: selectedProjectFromOptions.projectId,
+				projectName: selectedProjectFromOptions.projectName,
+				githubOwner: selectedProjectFromOptions.githubOwner,
+			}
+		: selectedProjectFallback
+			? {
+					projectId: projectFilter,
+					projectName: selectedProjectFallback.projectName,
+					githubOwner: selectedProjectFallback.githubOwner,
+				}
+			: undefined;
 	const totalProjectCount = projectOptions.reduce(
 		(total, project) => total + project.count,
 		0,
@@ -110,7 +155,7 @@ export function V2WorkspacesHeader({
 							<SelectValue placeholder="Filter projects">
 								<ProjectFilterTriggerLabel
 									projectFilter={projectFilter}
-									selectedProject={selectedProject}
+									selectedProject={selectedProjectLabel}
 								/>
 							</SelectValue>
 						</SelectTrigger>
@@ -167,7 +212,7 @@ export function V2WorkspacesHeader({
 							<SelectValue placeholder="Filter devices">
 								<DeviceFilterTriggerLabel
 									deviceFilter={deviceFilter}
-									selectedRemoteHost={selectedRemoteHost}
+									selectedRemoteHost={selectedHostLabel}
 								/>
 							</SelectValue>
 						</SelectTrigger>
@@ -219,18 +264,28 @@ export function V2WorkspacesHeader({
 
 interface ProjectFilterTriggerLabelProps {
 	projectFilter: string;
-	selectedProject: V2WorkspaceProjectOption | undefined;
+	selectedProject:
+		| { projectName: string; githubOwner: string | null }
+		| undefined;
 }
 
 function ProjectFilterTriggerLabel({
 	projectFilter,
 	selectedProject,
 }: ProjectFilterTriggerLabelProps) {
-	if (projectFilter === PROJECT_FILTER_ALL || !selectedProject) {
+	if (projectFilter === PROJECT_FILTER_ALL) {
 		return (
 			<span className="flex items-center gap-2">
 				<LuFolders className="size-3.5" />
 				<span>All projects</span>
+			</span>
+		);
+	}
+	if (!selectedProject) {
+		return (
+			<span className="flex items-center gap-2">
+				<LuFolders className="size-3.5" />
+				<span className="text-muted-foreground">Unknown project</span>
 			</span>
 		);
 	}
@@ -248,7 +303,7 @@ function ProjectFilterTriggerLabel({
 
 interface DeviceFilterTriggerLabelProps {
 	deviceFilter: string;
-	selectedRemoteHost: V2WorkspaceHostOption | undefined;
+	selectedRemoteHost: { hostName: string; isOnline: boolean } | undefined;
 }
 
 function DeviceFilterTriggerLabel({

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesHeader/components/DeviceFilterTriggerLabel/DeviceFilterTriggerLabel.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesHeader/components/DeviceFilterTriggerLabel/DeviceFilterTriggerLabel.tsx
@@ -1,0 +1,52 @@
+import { cn } from "@superset/ui/utils";
+import { LuLaptop, LuLayers, LuMonitor } from "react-icons/lu";
+import {
+	DEVICE_FILTER_ALL,
+	DEVICE_FILTER_THIS_DEVICE,
+} from "renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore";
+
+interface DeviceFilterTriggerLabelProps {
+	deviceFilter: string;
+	selectedRemoteHost: { hostName: string; isOnline: boolean } | undefined;
+}
+
+export function DeviceFilterTriggerLabel({
+	deviceFilter,
+	selectedRemoteHost,
+}: DeviceFilterTriggerLabelProps) {
+	if (deviceFilter === DEVICE_FILTER_ALL) {
+		return (
+			<span className="flex items-center gap-2">
+				<LuLayers className="size-3.5" />
+				<span>All devices</span>
+			</span>
+		);
+	}
+	if (deviceFilter === DEVICE_FILTER_THIS_DEVICE) {
+		return (
+			<span className="flex items-center gap-2">
+				<LuLaptop className="size-3.5" />
+				<span>This device</span>
+			</span>
+		);
+	}
+	return (
+		<span className="flex min-w-0 items-center gap-2">
+			<LuMonitor className="size-3.5" />
+			<span className="min-w-0 truncate">
+				{selectedRemoteHost?.hostName ?? "Unknown device"}
+			</span>
+			{selectedRemoteHost ? (
+				<span
+					aria-hidden
+					className={cn(
+						"inline-block size-1.5 shrink-0 rounded-full",
+						selectedRemoteHost.isOnline
+							? "bg-emerald-500"
+							: "bg-muted-foreground/40",
+					)}
+				/>
+			) : null}
+		</span>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesHeader/components/DeviceFilterTriggerLabel/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesHeader/components/DeviceFilterTriggerLabel/index.ts
@@ -1,0 +1,1 @@
+export { DeviceFilterTriggerLabel } from "./DeviceFilterTriggerLabel";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesHeader/components/DeviceOptionLabel/DeviceOptionLabel.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesHeader/components/DeviceOptionLabel/DeviceOptionLabel.tsx
@@ -1,0 +1,34 @@
+import { cn } from "@superset/ui/utils";
+
+interface DeviceOptionLabelProps {
+	icon: React.ReactNode;
+	label: string;
+	count: number;
+	isOnline?: boolean;
+}
+
+export function DeviceOptionLabel({
+	icon,
+	label,
+	count,
+	isOnline,
+}: DeviceOptionLabelProps) {
+	return (
+		<span className="flex w-full min-w-0 items-center gap-2">
+			{icon}
+			<span className="min-w-0 flex-1 truncate">{label}</span>
+			{isOnline !== undefined ? (
+				<span
+					aria-hidden
+					className={cn(
+						"inline-block size-1.5 rounded-full",
+						isOnline ? "bg-emerald-500" : "bg-muted-foreground/40",
+					)}
+				/>
+			) : null}
+			<span className="tabular-nums text-xs text-muted-foreground">
+				{count}
+			</span>
+		</span>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesHeader/components/DeviceOptionLabel/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesHeader/components/DeviceOptionLabel/index.ts
@@ -1,0 +1,1 @@
+export { DeviceOptionLabel } from "./DeviceOptionLabel";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesHeader/components/ProjectFilterTriggerLabel/ProjectFilterTriggerLabel.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesHeader/components/ProjectFilterTriggerLabel/ProjectFilterTriggerLabel.tsx
@@ -1,0 +1,42 @@
+import { LuFolders } from "react-icons/lu";
+import { V2WorkspaceProjectIcon } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspaceProjectIcon";
+import { PROJECT_FILTER_ALL } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore";
+
+interface ProjectFilterTriggerLabelProps {
+	projectFilter: string;
+	selectedProject:
+		| { projectName: string; githubOwner: string | null }
+		| undefined;
+}
+
+export function ProjectFilterTriggerLabel({
+	projectFilter,
+	selectedProject,
+}: ProjectFilterTriggerLabelProps) {
+	if (projectFilter === PROJECT_FILTER_ALL) {
+		return (
+			<span className="flex items-center gap-2">
+				<LuFolders className="size-3.5" />
+				<span>All projects</span>
+			</span>
+		);
+	}
+	if (!selectedProject) {
+		return (
+			<span className="flex items-center gap-2">
+				<LuFolders className="size-3.5" />
+				<span className="text-muted-foreground">Unknown project</span>
+			</span>
+		);
+	}
+	return (
+		<span className="flex min-w-0 items-center gap-2">
+			<V2WorkspaceProjectIcon
+				projectName={selectedProject.projectName}
+				githubOwner={selectedProject.githubOwner}
+				size="sm"
+			/>
+			<span className="min-w-0 truncate">{selectedProject.projectName}</span>
+		</span>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesHeader/components/ProjectFilterTriggerLabel/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesHeader/components/ProjectFilterTriggerLabel/index.ts
@@ -1,0 +1,1 @@
+export { ProjectFilterTriggerLabel } from "./ProjectFilterTriggerLabel";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/V2WorkspacesList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/V2WorkspacesList.tsx
@@ -17,9 +17,11 @@ import type {
 	V2WorkspaceHostType,
 } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces";
 import {
+	DEVICE_FILTER_THIS_DEVICE,
+	PROJECT_FILTER_ALL,
 	useV2WorkspacesFilterStore,
-	type V2WorkspacesDeviceFilter,
 } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore";
+import { V2WorkspaceProjectIcon } from "../V2WorkspaceProjectIcon";
 import { SortableHeader } from "./components/SortableHeader";
 import { V2WorkspaceRow } from "./components/V2WorkspaceRow";
 import { V2_WORKSPACES_ROW_GRID } from "./constants";
@@ -32,37 +34,13 @@ interface V2WorkspacesListProps {
 interface ProjectGroup {
 	projectId: string;
 	projectName: string;
+	githubOwner: string | null;
 	workspaces: AccessibleV2Workspace[];
 	latestCreatedAt: number;
 }
 
-function matchesDeviceFilter(
-	hostType: V2WorkspaceHostType,
-	deviceFilter: V2WorkspacesDeviceFilter,
-): boolean {
-	switch (deviceFilter) {
-		case "all":
-			return true;
-		case "this-device":
-			return hostType === "local-device";
-		case "other-devices":
-			return hostType === "remote-device";
-		case "cloud":
-			return hostType === "cloud";
-	}
-}
-
-// Host-type rank used as a tiebreaker when sorting by host — keeps local
-// device first, then remote devices, then cloud.
 function hostTypeRank(hostType: V2WorkspaceHostType): number {
-	switch (hostType) {
-		case "local-device":
-			return 0;
-		case "remote-device":
-			return 1;
-		case "cloud":
-			return 2;
-	}
+	return hostType === "local-device" ? 0 : 1;
 }
 
 function compareWorkspaces(
@@ -109,6 +87,7 @@ function groupByProject(
 			project = {
 				projectId: workspace.projectId,
 				projectName: workspace.projectName,
+				githubOwner: workspace.projectGithubOwner,
 				workspaces: [],
 				latestCreatedAt: 0,
 			};
@@ -152,6 +131,9 @@ export function V2WorkspacesList({ workspaces }: V2WorkspacesListProps) {
 	const deviceFilter = useV2WorkspacesFilterStore(
 		(state) => state.deviceFilter,
 	);
+	const projectFilter = useV2WorkspacesFilterStore(
+		(state) => state.projectFilter,
+	);
 	const resetFilters = useV2WorkspacesFilterStore((state) => state.reset);
 
 	const [sortField, setSortField] = useState<SortField>("created");
@@ -166,24 +148,25 @@ export function V2WorkspacesList({ workspaces }: V2WorkspacesListProps) {
 		}
 	};
 
-	const projectGroups = useMemo(() => {
-		const filtered = workspaces.filter((workspace) =>
-			matchesDeviceFilter(workspace.hostType, deviceFilter),
-		);
-		return groupByProject(filtered, sortField, sortDirection);
-	}, [workspaces, deviceFilter, sortField, sortDirection]);
+	const projectGroups = useMemo(
+		() => groupByProject(workspaces, sortField, sortDirection),
+		[workspaces, sortField, sortDirection],
+	);
 
 	const totalCount = projectGroups.reduce(
 		(total, project) => total + project.workspaces.length,
 		0,
 	);
-	const hasActiveFilters = searchQuery.trim() !== "" || deviceFilter !== "all";
+	const hasActiveFilters =
+		searchQuery.trim() !== "" ||
+		deviceFilter !== DEVICE_FILTER_THIS_DEVICE ||
+		projectFilter !== PROJECT_FILTER_ALL;
 
 	const columnHeader = (
 		<div
 			className={cn(
 				V2_WORKSPACES_ROW_GRID,
-				"sticky top-0 z-10 border-b border-border bg-background px-6 py-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/80",
+				"sticky top-0 z-10 h-8 border-b border-border bg-background px-6 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/80",
 			)}
 		>
 			<SortableHeader
@@ -275,7 +258,12 @@ export function V2WorkspacesList({ workspaces }: V2WorkspacesListProps) {
 
 				{projectGroups.map((project) => (
 					<div key={project.projectId} className="flex flex-col">
-						<div className="flex items-center gap-2 border-b border-border/60 bg-muted/30 px-6 py-1.5">
+						<div className="sticky top-8 z-[5] flex items-center gap-2 border-b border-border/60 bg-muted px-6 py-1.5">
+							<V2WorkspaceProjectIcon
+								projectName={project.projectName}
+								githubOwner={project.githubOwner}
+								size="sm"
+							/>
 							<h3
 								className="min-w-0 truncate text-xs font-semibold text-foreground/80"
 								title={project.projectName}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/V2WorkspacesList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/V2WorkspacesList.tsx
@@ -11,7 +11,12 @@ import { ScrollArea } from "@superset/ui/scroll-area";
 import { cn } from "@superset/ui/utils";
 import { useMatchRoute } from "@tanstack/react-router";
 import { useMemo, useState } from "react";
-import { LuLayers, LuSearchX } from "react-icons/lu";
+import {
+	LuChevronDown,
+	LuChevronRight,
+	LuLayers,
+	LuSearchX,
+} from "react-icons/lu";
 import type {
 	AccessibleV2Workspace,
 	V2WorkspaceHostType,
@@ -21,6 +26,7 @@ import {
 	PROJECT_FILTER_ALL,
 	useV2WorkspacesFilterStore,
 } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore";
+import { useV2ProjectLocalMetaStore } from "renderer/stores/v2-project-local-meta";
 import { V2WorkspaceProjectIcon } from "../V2WorkspaceProjectIcon";
 import { SortableHeader } from "./components/SortableHeader";
 import { V2WorkspaceRow } from "./components/V2WorkspaceRow";
@@ -257,35 +263,70 @@ export function V2WorkspacesList({ workspaces }: V2WorkspacesListProps) {
 				{columnHeader}
 
 				{projectGroups.map((project) => (
-					<div key={project.projectId} className="flex flex-col">
-						<div className="sticky top-8 z-[5] flex items-center gap-2 border-b border-border/60 bg-muted px-6 py-1.5">
-							<V2WorkspaceProjectIcon
-								projectName={project.projectName}
-								githubOwner={project.githubOwner}
-								size="sm"
-							/>
-							<h3
-								className="min-w-0 truncate text-xs font-semibold text-foreground/80"
-								title={project.projectName}
-							>
-								{project.projectName}
-							</h3>
-							<span className="shrink-0 text-xs tabular-nums text-muted-foreground/60">
-								{project.workspaces.length}
-							</span>
-						</div>
-						<ul className="flex flex-col">
-							{project.workspaces.map((workspace) => (
-								<V2WorkspaceRow
-									key={workspace.id}
-									workspace={workspace}
-									isCurrentRoute={workspace.id === currentWorkspaceId}
-								/>
-							))}
-						</ul>
-					</div>
+					<ProjectSection
+						key={project.projectId}
+						project={project}
+						currentWorkspaceId={currentWorkspaceId}
+					/>
 				))}
 			</div>
 		</ScrollArea>
+	);
+}
+
+interface ProjectSectionProps {
+	project: ProjectGroup;
+	currentWorkspaceId: string | null;
+}
+
+function ProjectSection({ project, currentWorkspaceId }: ProjectSectionProps) {
+	const isCollapsed = useV2ProjectLocalMetaStore(
+		(state) => state.projects[project.projectId]?.isCollapsed ?? false,
+	);
+	const toggleCollapsed = useV2ProjectLocalMetaStore(
+		(state) => state.toggleProjectCollapsed,
+	);
+	const Chevron = isCollapsed ? LuChevronRight : LuChevronDown;
+
+	return (
+		<div className="flex flex-col">
+			<button
+				type="button"
+				onClick={() => toggleCollapsed(project.projectId)}
+				aria-expanded={!isCollapsed}
+				aria-controls={`v2-workspaces-project-${project.projectId}`}
+				className="sticky top-8 z-[5] flex w-full items-center gap-2 border-b border-border/60 bg-muted px-6 py-1.5 text-left transition-colors hover:bg-muted/80"
+			>
+				<Chevron className="size-3 shrink-0 text-muted-foreground" />
+				<V2WorkspaceProjectIcon
+					projectName={project.projectName}
+					githubOwner={project.githubOwner}
+					size="sm"
+				/>
+				<h3
+					className="min-w-0 truncate text-xs font-semibold text-foreground/80"
+					title={project.projectName}
+				>
+					{project.projectName}
+				</h3>
+				<span className="shrink-0 text-xs tabular-nums text-muted-foreground/60">
+					{project.workspaces.length}
+				</span>
+			</button>
+			{isCollapsed ? null : (
+				<ul
+					id={`v2-workspaces-project-${project.projectId}`}
+					className="flex flex-col"
+				>
+					{project.workspaces.map((workspace) => (
+						<V2WorkspaceRow
+							key={workspace.id}
+							workspace={workspace}
+							isCurrentRoute={workspace.id === currentWorkspaceId}
+						/>
+					))}
+				</ul>
+			)}
+		</div>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/V2WorkspacesList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/V2WorkspacesList.tsx
@@ -280,12 +280,16 @@ interface ProjectSectionProps {
 }
 
 function ProjectSection({ project, currentWorkspaceId }: ProjectSectionProps) {
-	const isCollapsed = useV2ProjectLocalMetaStore(
+	const persistedCollapsed = useV2ProjectLocalMetaStore(
 		(state) => state.projects[project.projectId]?.isCollapsed ?? false,
 	);
 	const toggleCollapsed = useV2ProjectLocalMetaStore(
 		(state) => state.toggleProjectCollapsed,
 	);
+	const containsCurrent = project.workspaces.some(
+		(workspace) => workspace.id === currentWorkspaceId,
+	);
+	const isCollapsed = persistedCollapsed && !containsCurrent;
 	const Chevron = isCollapsed ? LuChevronRight : LuChevronDown;
 
 	return (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
@@ -1,10 +1,17 @@
 import { Button } from "@superset/ui/button";
+import {
+	HoverCard,
+	HoverCardContent,
+	HoverCardTrigger,
+} from "@superset/ui/hover-card";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
 import {
-	LuCloud,
+	LuCircleCheck,
+	LuCircleDashed,
+	LuCircleX,
 	LuGitBranch,
 	LuLaptop,
 	LuMinus,
@@ -13,11 +20,14 @@ import {
 } from "react-icons/lu";
 import { GATED_FEATURES, usePaywall } from "renderer/components/Paywall";
 import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
+import { V2WorkspacePrHoverCardContent } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacePrHoverCardContent";
 import type {
 	AccessibleV2Workspace,
 	V2WorkspaceHostType,
+	V2WorkspacePrSummary,
 } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
+import { PRIcon } from "renderer/screens/main/components/PRIcon/PRIcon";
 import { getRelativeTime } from "renderer/screens/main/components/WorkspacesListView/utils";
 import { V2_WORKSPACES_ROW_GRID } from "../../constants";
 
@@ -27,14 +37,7 @@ interface V2WorkspaceRowProps {
 }
 
 function hostIconFor(hostType: V2WorkspaceHostType) {
-	switch (hostType) {
-		case "cloud":
-			return LuCloud;
-		case "local-device":
-			return LuLaptop;
-		case "remote-device":
-			return LuMonitor;
-	}
+	return hostType === "local-device" ? LuLaptop : LuMonitor;
 }
 
 export function V2WorkspaceRow({
@@ -52,8 +55,6 @@ export function V2WorkspaceRow({
 
 	const HostIcon = hostIconFor(workspace.hostType);
 
-	// The local device is always reachable from here — ignore any stale
-	// isOnline flag on that row.
 	const treatAsOffline =
 		!workspace.hostIsOnline && workspace.hostType !== "local-device";
 
@@ -119,9 +120,6 @@ export function V2WorkspaceRow({
 
 	const handleRowKeyDown = useCallback(
 		(event: React.KeyboardEvent<HTMLDivElement>) => {
-			// Ignore keystrokes bubbling from focused descendants (e.g. the
-			// Add/Remove icon buttons) — `stopPropagation` on their click handlers
-			// doesn't catch keyboard events.
 			if (event.target !== event.currentTarget) return;
 			if (event.key === "Enter" || event.key === " ") {
 				event.preventDefault();
@@ -163,7 +161,7 @@ export function V2WorkspaceRow({
 				onKeyDown={handleRowKeyDown}
 				className={cn(
 					V2_WORKSPACES_ROW_GRID,
-					"group/row relative min-w-0 px-6 py-2 text-sm outline-none",
+					"group/row relative min-w-0 px-6 py-2.5 text-sm outline-none",
 					"cursor-pointer transition-colors",
 					"focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:ring-inset",
 					isCurrentRoute
@@ -213,13 +211,16 @@ export function V2WorkspaceRow({
 					)}
 				</div>
 
-				<span className="flex min-w-0 items-center">
+				<span className="flex min-w-0 items-center gap-2">
 					<span
 						className="min-w-0 truncate font-medium text-foreground"
 						title={workspace.name}
 					>
 						{workspace.name}
 					</span>
+					{workspace.pr ? (
+						<WorkspacePrPill pr={workspace.pr} branch={workspace.branch} />
+					) : null}
 				</span>
 
 				{treatAsOffline ? (
@@ -250,4 +251,52 @@ export function V2WorkspaceRow({
 			</div>
 		</li>
 	);
+}
+
+interface WorkspacePrPillProps {
+	pr: V2WorkspacePrSummary;
+	branch: string;
+}
+
+function WorkspacePrPill({ pr, branch }: WorkspacePrPillProps) {
+	return (
+		<HoverCard openDelay={200} closeDelay={120}>
+			<HoverCardTrigger asChild>
+				<a
+					href={pr.url}
+					target="_blank"
+					rel="noreferrer"
+					onClick={(event) => event.stopPropagation()}
+					className="inline-flex shrink-0 items-center gap-1 rounded-full border border-border/60 bg-muted/40 px-2 py-0.5 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+				>
+					<PRIcon state={pr.state} className="size-3" />
+					<span className="tabular-nums">#{pr.prNumber}</span>
+					<ChecksDot status={pr.checksStatus} />
+				</a>
+			</HoverCardTrigger>
+			<HoverCardContent
+				side="top"
+				align="start"
+				className="w-80 p-3"
+				onClick={(event) => event.stopPropagation()}
+			>
+				<V2WorkspacePrHoverCardContent pr={pr} branch={branch} />
+			</HoverCardContent>
+		</HoverCard>
+	);
+}
+
+interface ChecksDotProps {
+	status: V2WorkspacePrSummary["checksStatus"];
+}
+
+function ChecksDot({ status }: ChecksDotProps) {
+	if (status === "none") return null;
+	if (status === "pending") {
+		return <LuCircleDashed className="size-3 text-amber-500" />;
+	}
+	if (status === "success") {
+		return <LuCircleCheck className="size-3 text-emerald-500" />;
+	}
+	return <LuCircleX className="size-3 text-red-500" />;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces/index.ts
@@ -3,6 +3,12 @@ export {
 	type UseAccessibleV2WorkspacesResult,
 	useAccessibleV2Workspaces,
 	type V2WorkspaceDeviceCounts,
+	type V2WorkspaceHostOption,
 	type V2WorkspaceHostType,
+	type V2WorkspacePrChecksStatus,
 	type V2WorkspaceProjectGroup,
+	type V2WorkspaceProjectOption,
+	type V2WorkspacePrReviewDecision,
+	type V2WorkspacePrState,
+	type V2WorkspacePrSummary,
 } from "./useAccessibleV2Workspaces";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces/useAccessibleV2Workspaces.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces/useAccessibleV2Workspaces.ts
@@ -139,7 +139,7 @@ function matchesDeviceFilter(
 ): boolean {
 	if (deviceFilter === DEVICE_FILTER_ALL) return true;
 	if (deviceFilter === DEVICE_FILTER_THIS_DEVICE) {
-		return workspace.hostId === machineId;
+		return machineId == null || workspace.hostId === machineId;
 	}
 	return workspace.hostId === deviceFilter;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces/useAccessibleV2Workspaces.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces/useAccessibleV2Workspaces.ts
@@ -1,14 +1,48 @@
+import type { CheckItem } from "@superset/local-db";
 import { and, eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useMemo } from "react";
 import { env } from "renderer/env.renderer";
 import { authClient } from "renderer/lib/auth-client";
+import {
+	DEVICE_FILTER_ALL,
+	DEVICE_FILTER_THIS_DEVICE,
+	PROJECT_FILTER_ALL,
+	type V2WorkspacesDeviceFilter,
+	type V2WorkspacesProjectFilter,
+} from "renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { isSidebarWorkspaceVisible } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { MOCK_ORG_ID } from "shared/constants";
 
-export type V2WorkspaceHostType = "local-device" | "remote-device" | "cloud";
+export type V2WorkspaceHostType = "local-device" | "remote-device";
+
+export type V2WorkspacePrState = "open" | "merged" | "closed" | "draft";
+
+export type V2WorkspacePrReviewDecision =
+	| "approved"
+	| "changes_requested"
+	| "pending";
+
+export type V2WorkspacePrChecksStatus =
+	| "none"
+	| "pending"
+	| "success"
+	| "failure";
+
+export interface V2WorkspacePrSummary {
+	prNumber: number;
+	title: string;
+	url: string;
+	state: V2WorkspacePrState;
+	checksStatus: V2WorkspacePrChecksStatus;
+	reviewDecision: V2WorkspacePrReviewDecision;
+	checks: CheckItem[];
+	additions: number;
+	deletions: number;
+	updatedAt: Date;
+}
 
 export interface AccessibleV2Workspace {
 	id: string;
@@ -22,11 +56,14 @@ export interface AccessibleV2Workspace {
 	isCreatedByCurrentUser: boolean;
 	projectId: string;
 	projectName: string;
+	projectRepoId: string | null;
+	projectGithubOwner: string | null;
 	hostId: string;
 	hostName: string;
 	hostIsOnline: boolean;
 	hostType: V2WorkspaceHostType;
 	isInSidebar: boolean;
+	pr: V2WorkspacePrSummary | null;
 }
 
 export interface V2WorkspaceProjectGroup {
@@ -38,8 +75,21 @@ export interface V2WorkspaceProjectGroup {
 export interface V2WorkspaceDeviceCounts {
 	all: number;
 	thisDevice: number;
-	otherDevices: number;
-	cloud: number;
+}
+
+export interface V2WorkspaceHostOption {
+	hostId: string;
+	hostName: string;
+	isOnline: boolean;
+	isLocal: boolean;
+	count: number;
+}
+
+export interface V2WorkspaceProjectOption {
+	projectId: string;
+	projectName: string;
+	githubOwner: string | null;
+	count: number;
 }
 
 export interface UseAccessibleV2WorkspacesResult {
@@ -47,10 +97,14 @@ export interface UseAccessibleV2WorkspacesResult {
 	pinned: AccessibleV2Workspace[];
 	others: AccessibleV2Workspace[];
 	counts: V2WorkspaceDeviceCounts;
+	hostOptions: V2WorkspaceHostOption[];
+	projectOptions: V2WorkspaceProjectOption[];
 }
 
 interface UseAccessibleV2WorkspacesOptions {
 	searchQuery?: string;
+	deviceFilter?: V2WorkspacesDeviceFilter;
+	projectFilter?: V2WorkspacesProjectFilter;
 }
 
 function workspaceMatchesSearch(
@@ -64,14 +118,90 @@ function workspaceMatchesSearch(
 		workspace.projectName.toLowerCase().includes(query) ||
 		workspace.branch.toLowerCase().includes(query) ||
 		workspace.hostName.toLowerCase().includes(query) ||
-		(workspace.createdByName ?? "").toLowerCase().includes(query)
+		(workspace.createdByName ?? "").toLowerCase().includes(query) ||
+		(workspace.pr ? `#${workspace.pr.prNumber}`.includes(query) : false) ||
+		(workspace.pr?.title.toLowerCase().includes(query) ?? false)
 	);
+}
+
+function matchesDeviceFilter(
+	workspace: AccessibleV2Workspace,
+	deviceFilter: V2WorkspacesDeviceFilter,
+	machineId: string | null,
+): boolean {
+	if (deviceFilter === DEVICE_FILTER_ALL) return true;
+	if (deviceFilter === DEVICE_FILTER_THIS_DEVICE) {
+		return workspace.hostId === machineId;
+	}
+	return workspace.hostId === deviceFilter;
+}
+
+function matchesProjectFilter(
+	workspace: AccessibleV2Workspace,
+	projectFilter: V2WorkspacesProjectFilter,
+): boolean {
+	if (projectFilter === PROJECT_FILTER_ALL) return true;
+	return workspace.projectId === projectFilter;
+}
+
+function prStateFor(state: string, isDraft: boolean): V2WorkspacePrState {
+	if (isDraft) return "draft";
+	if (state === "merged") return "merged";
+	if (state === "closed") return "closed";
+	return "open";
+}
+
+function reviewDecisionFor(
+	raw: string | null | undefined,
+): V2WorkspacePrReviewDecision {
+	if (raw === "APPROVED") return "approved";
+	if (raw === "CHANGES_REQUESTED") return "changes_requested";
+	return "pending";
+}
+
+type RawCheckEntry = {
+	name: string;
+	status: string;
+	conclusion: string | null;
+	detailsUrl?: string;
+};
+
+function checkItemStatusFor(
+	rawStatus: string,
+	rawConclusion: string | null,
+): CheckItem["status"] {
+	if (rawStatus !== "completed") return "pending";
+	switch (rawConclusion) {
+		case "success":
+			return "success";
+		case "skipped":
+			return "skipped";
+		case "cancelled":
+			return "cancelled";
+		case "failure":
+		case "timed_out":
+		case "action_required":
+			return "failure";
+		default:
+			return "pending";
+	}
+}
+
+function mapChecks(rawChecks: RawCheckEntry[] | null | undefined): CheckItem[] {
+	if (!rawChecks) return [];
+	return rawChecks.map((entry) => ({
+		name: entry.name,
+		status: checkItemStatusFor(entry.status, entry.conclusion),
+		url: entry.detailsUrl,
+	}));
 }
 
 export function useAccessibleV2Workspaces(
 	options: UseAccessibleV2WorkspacesOptions = {},
 ): UseAccessibleV2WorkspacesResult {
 	const searchQuery = options.searchQuery ?? "";
+	const deviceFilter = options.deviceFilter ?? DEVICE_FILTER_ALL;
+	const projectFilter = options.projectFilter ?? PROJECT_FILTER_ALL;
 	const { data: session } = authClient.useSession();
 	const collections = useCollections();
 	const { machineId } = useLocalHostService();
@@ -106,6 +236,10 @@ export function useAccessibleV2Workspaces(
 					({ projects, sidebarProject }) =>
 						eq(sidebarProject.projectId, projects.id),
 				)
+				.leftJoin(
+					{ repos: collections.githubRepositories },
+					({ projects, repos }) => eq(projects.githubRepositoryId, repos.id),
+				)
 				.leftJoin({ creators: collections.users }, ({ workspaces, creators }) =>
 					eq(workspaces.createdByUserId, creators.id),
 				)
@@ -122,6 +256,7 @@ export function useAccessibleV2Workspaces(
 						projects,
 						sidebarState,
 						sidebarProject,
+						repos,
 						creators,
 					}) => ({
 						id: workspaces.id,
@@ -134,6 +269,8 @@ export function useAccessibleV2Workspaces(
 						createdByImage: creators?.image ?? null,
 						projectId: projects.id,
 						projectName: projects.name,
+						projectRepoId: projects.githubRepositoryId,
+						projectGithubOwner: repos?.owner ?? null,
 						hostId: workspaces.hostId,
 						hostName: hosts.name,
 						hostIsOnline: hosts.isOnline,
@@ -144,6 +281,71 @@ export function useAccessibleV2Workspaces(
 				),
 		[activeOrganizationId, collections, currentUserId],
 	);
+
+	const { data: prRows = [] } = useLiveQuery(
+		(q) =>
+			q
+				.from({ prs: collections.githubPullRequests })
+				.where(({ prs }) => eq(prs.organizationId, activeOrganizationId ?? ""))
+				.select(({ prs }) => ({
+					id: prs.id,
+					repositoryId: prs.repositoryId,
+					prNumber: prs.prNumber,
+					headBranch: prs.headBranch,
+					title: prs.title,
+					url: prs.url,
+					state: prs.state,
+					isDraft: prs.isDraft,
+					checksStatus: prs.checksStatus,
+					checks: prs.checks,
+					reviewDecision: prs.reviewDecision,
+					additions: prs.additions,
+					deletions: prs.deletions,
+					updatedAt: prs.updatedAt,
+					mergedAt: prs.mergedAt,
+				})),
+		[collections, activeOrganizationId],
+	);
+
+	const prsByRepoBranch = useMemo(() => {
+		const map = new Map<string, V2WorkspacePrSummary>();
+		const stateRank: Record<string, number> = {
+			open: 0,
+			draft: 1,
+			merged: 2,
+			closed: 3,
+		};
+		for (const row of prRows) {
+			const key = `${row.repositoryId}::${row.headBranch}`;
+			const candidate: V2WorkspacePrSummary = {
+				prNumber: row.prNumber,
+				title: row.title,
+				url: row.url,
+				state: prStateFor(row.state, row.isDraft),
+				checksStatus: (row.checksStatus as V2WorkspacePrChecksStatus) ?? "none",
+				reviewDecision: reviewDecisionFor(row.reviewDecision),
+				checks: mapChecks(row.checks as RawCheckEntry[] | null | undefined),
+				additions: row.additions,
+				deletions: row.deletions,
+				updatedAt: new Date(row.updatedAt),
+			};
+			const existing = map.get(key);
+			if (!existing) {
+				map.set(key, candidate);
+				continue;
+			}
+			const cmpState = stateRank[candidate.state] - stateRank[existing.state];
+			if (cmpState < 0) {
+				map.set(key, candidate);
+			} else if (
+				cmpState === 0 &&
+				candidate.updatedAt.getTime() > existing.updatedAt.getTime()
+			) {
+				map.set(key, candidate);
+			}
+		}
+		return map;
+	}, [prRows]);
 
 	const enriched = useMemo<AccessibleV2Workspace[]>(() => {
 		const deduped = new Map<string, AccessibleV2Workspace>();
@@ -158,6 +360,9 @@ export function useAccessibleV2Workspaces(
 			const isInSidebar =
 				isSidebarWorkspaceVisible({ isHidden: row.sidebarIsHidden }) &&
 				(row.sidebarWorkspaceId != null || isAutoVisibleMain);
+			const pr = row.projectRepoId
+				? (prsByRepoBranch.get(`${row.projectRepoId}::${row.branch}`) ?? null)
+				: null;
 
 			deduped.set(row.id, {
 				id: row.id,
@@ -172,17 +377,20 @@ export function useAccessibleV2Workspaces(
 					currentUserId != null && row.createdByUserId === currentUserId,
 				projectId: row.projectId,
 				projectName: row.projectName,
+				projectRepoId: row.projectRepoId,
+				projectGithubOwner: row.projectGithubOwner ?? null,
 				hostId: row.hostId,
 				hostName: row.hostName,
 				hostIsOnline: row.hostIsOnline,
 				hostType,
 				isInSidebar,
+				pr,
 			});
 		}
 		return Array.from(deduped.values()).sort(
 			(a, b) => b.createdAt.getTime() - a.createdAt.getTime(),
 		);
-	}, [rows, machineId, currentUserId]);
+	}, [rows, machineId, currentUserId, prsByRepoBranch]);
 
 	const searchFiltered = useMemo(
 		() =>
@@ -192,37 +400,91 @@ export function useAccessibleV2Workspaces(
 		[enriched, searchQuery],
 	);
 
+	const deviceFiltered = useMemo(
+		() =>
+			searchFiltered.filter((workspace) =>
+				matchesDeviceFilter(workspace, deviceFilter, machineId),
+			),
+		[searchFiltered, deviceFilter, machineId],
+	);
+
+	const fullyFiltered = useMemo(
+		() =>
+			deviceFiltered.filter((workspace) =>
+				matchesProjectFilter(workspace, projectFilter),
+			),
+		[deviceFiltered, projectFilter],
+	);
+
 	const pinned = useMemo(
-		() => searchFiltered.filter((workspace) => workspace.isInSidebar),
-		[searchFiltered],
+		() => fullyFiltered.filter((workspace) => workspace.isInSidebar),
+		[fullyFiltered],
 	);
 
 	const others = useMemo(
-		() => searchFiltered.filter((workspace) => !workspace.isInSidebar),
-		[searchFiltered],
+		() => fullyFiltered.filter((workspace) => !workspace.isInSidebar),
+		[fullyFiltered],
 	);
 
 	const counts = useMemo<V2WorkspaceDeviceCounts>(() => {
 		let thisDevice = 0;
-		let otherDevices = 0;
-		let cloud = 0;
 		for (const workspace of searchFiltered) {
-			if (workspace.hostType === "local-device") thisDevice += 1;
-			else if (workspace.hostType === "remote-device") otherDevices += 1;
-			else cloud += 1;
+			if (workspace.hostId === machineId) thisDevice += 1;
 		}
 		return {
 			all: searchFiltered.length,
 			thisDevice,
-			otherDevices,
-			cloud,
 		};
-	}, [searchFiltered]);
+	}, [searchFiltered, machineId]);
+
+	const hostOptions = useMemo<V2WorkspaceHostOption[]>(() => {
+		const byHost = new Map<string, V2WorkspaceHostOption>();
+		for (const workspace of searchFiltered) {
+			const existing = byHost.get(workspace.hostId);
+			if (existing) {
+				existing.count += 1;
+				continue;
+			}
+			byHost.set(workspace.hostId, {
+				hostId: workspace.hostId,
+				hostName: workspace.hostName,
+				isOnline: workspace.hostIsOnline,
+				isLocal: workspace.hostId === machineId,
+				count: 1,
+			});
+		}
+		return Array.from(byHost.values()).sort((a, b) => {
+			if (a.isLocal !== b.isLocal) return a.isLocal ? -1 : 1;
+			return a.hostName.localeCompare(b.hostName);
+		});
+	}, [searchFiltered, machineId]);
+
+	const projectOptions = useMemo<V2WorkspaceProjectOption[]>(() => {
+		const byProject = new Map<string, V2WorkspaceProjectOption>();
+		for (const workspace of deviceFiltered) {
+			const existing = byProject.get(workspace.projectId);
+			if (existing) {
+				existing.count += 1;
+				continue;
+			}
+			byProject.set(workspace.projectId, {
+				projectId: workspace.projectId,
+				projectName: workspace.projectName,
+				githubOwner: workspace.projectGithubOwner,
+				count: 1,
+			});
+		}
+		return Array.from(byProject.values()).sort((a, b) =>
+			a.projectName.localeCompare(b.projectName),
+		);
+	}, [deviceFiltered]);
 
 	return {
-		all: searchFiltered,
+		all: fullyFiltered,
 		pinned,
 		others,
 		counts,
+		hostOptions,
+		projectOptions,
 	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces/useAccessibleV2Workspaces.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces/useAccessibleV2Workspaces.ts
@@ -99,6 +99,14 @@ export interface UseAccessibleV2WorkspacesResult {
 	counts: V2WorkspaceDeviceCounts;
 	hostOptions: V2WorkspaceHostOption[];
 	projectOptions: V2WorkspaceProjectOption[];
+	hostsById: Map<
+		string,
+		{ hostName: string; isOnline: boolean; isLocal: boolean }
+	>;
+	projectsById: Map<
+		string,
+		{ projectName: string; githubOwner: string | null }
+	>;
 }
 
 interface UseAccessibleV2WorkspacesOptions {
@@ -144,9 +152,13 @@ function matchesProjectFilter(
 	return workspace.projectId === projectFilter;
 }
 
-function prStateFor(state: string, isDraft: boolean): V2WorkspacePrState {
+function prStateFor(
+	state: string,
+	isDraft: boolean,
+	mergedAt: Date | string | null,
+): V2WorkspacePrState {
+	if (mergedAt != null) return "merged";
 	if (isDraft) return "draft";
-	if (state === "merged") return "merged";
 	if (state === "closed") return "closed";
 	return "open";
 }
@@ -173,6 +185,7 @@ function checkItemStatusFor(
 	if (rawStatus !== "completed") return "pending";
 	switch (rawConclusion) {
 		case "success":
+		case "neutral":
 			return "success";
 		case "skipped":
 			return "skipped";
@@ -181,6 +194,8 @@ function checkItemStatusFor(
 		case "failure":
 		case "timed_out":
 		case "action_required":
+		case "stale":
+		case "startup_failure":
 			return "failure";
 		default:
 			return "pending";
@@ -321,7 +336,7 @@ export function useAccessibleV2Workspaces(
 				prNumber: row.prNumber,
 				title: row.title,
 				url: row.url,
-				state: prStateFor(row.state, row.isDraft),
+				state: prStateFor(row.state, row.isDraft, row.mergedAt),
 				checksStatus: (row.checksStatus as V2WorkspacePrChecksStatus) ?? "none",
 				reviewDecision: reviewDecisionFor(row.reviewDecision),
 				checks: mapChecks(row.checks as RawCheckEntry[] | null | undefined),
@@ -479,6 +494,37 @@ export function useAccessibleV2Workspaces(
 		);
 	}, [deviceFiltered]);
 
+	const hostsById = useMemo(() => {
+		const map = new Map<
+			string,
+			{ hostName: string; isOnline: boolean; isLocal: boolean }
+		>();
+		for (const workspace of enriched) {
+			if (map.has(workspace.hostId)) continue;
+			map.set(workspace.hostId, {
+				hostName: workspace.hostName,
+				isOnline: workspace.hostIsOnline,
+				isLocal: workspace.hostId === machineId,
+			});
+		}
+		return map;
+	}, [enriched, machineId]);
+
+	const projectsById = useMemo(() => {
+		const map = new Map<
+			string,
+			{ projectName: string; githubOwner: string | null }
+		>();
+		for (const workspace of enriched) {
+			if (map.has(workspace.projectId)) continue;
+			map.set(workspace.projectId, {
+				projectName: workspace.projectName,
+				githubOwner: workspace.projectGithubOwner,
+			});
+		}
+		return map;
+	}, [enriched]);
+
 	return {
 		all: fullyFiltered,
 		pinned,
@@ -486,5 +532,7 @@ export function useAccessibleV2Workspaces(
 		counts,
 		hostOptions,
 		projectOptions,
+		hostsById,
+		projectsById,
 	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/page.tsx
@@ -27,7 +27,7 @@ function V2WorkspacesPage() {
 		setSearchQuery("");
 	}, [setSearchQuery]);
 
-	const { all, counts, hostOptions, projectOptions } =
+	const { all, counts, hostOptions, projectOptions, hostsById, projectsById } =
 		useAccessibleV2Workspaces({
 			searchQuery,
 			deviceFilter,
@@ -40,6 +40,8 @@ function V2WorkspacesPage() {
 				counts={counts}
 				hostOptions={hostOptions}
 				projectOptions={projectOptions}
+				hostsById={hostsById}
+				projectsById={projectsById}
 			/>
 			<V2WorkspacesList workspaces={all} />
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/page.tsx
@@ -13,20 +13,34 @@ export const Route = createFileRoute(
 
 function V2WorkspacesPage() {
 	const searchQuery = useV2WorkspacesFilterStore((state) => state.searchQuery);
-	const resetFilters = useV2WorkspacesFilterStore((state) => state.reset);
+	const deviceFilter = useV2WorkspacesFilterStore(
+		(state) => state.deviceFilter,
+	);
+	const projectFilter = useV2WorkspacesFilterStore(
+		(state) => state.projectFilter,
+	);
+	const setSearchQuery = useV2WorkspacesFilterStore(
+		(state) => state.setSearchQuery,
+	);
 
-	// Start with a fresh view every time the discovery page mounts — otherwise
-	// the zustand singleton would carry over a stale search/device filter from a
-	// previous visit with no visible indication that a filter is active.
 	useEffect(() => {
-		resetFilters();
-	}, [resetFilters]);
+		setSearchQuery("");
+	}, [setSearchQuery]);
 
-	const { all, counts } = useAccessibleV2Workspaces({ searchQuery });
+	const { all, counts, hostOptions, projectOptions } =
+		useAccessibleV2Workspaces({
+			searchQuery,
+			deviceFilter,
+			projectFilter,
+		});
 
 	return (
 		<div className="flex h-full w-full flex-1 flex-col overflow-hidden">
-			<V2WorkspacesHeader counts={counts} />
+			<V2WorkspacesHeader
+				counts={counts}
+				hostOptions={hostOptions}
+				projectOptions={projectOptions}
+			/>
 			<V2WorkspacesList workspaces={all} />
 		</div>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore/index.ts
@@ -1,4 +1,8 @@
 export {
+	DEVICE_FILTER_ALL,
+	DEVICE_FILTER_THIS_DEVICE,
+	PROJECT_FILTER_ALL,
 	useV2WorkspacesFilterStore,
 	type V2WorkspacesDeviceFilter,
+	type V2WorkspacesProjectFilter,
 } from "./v2WorkspacesFilterStore";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore/v2WorkspacesFilterStore.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore/v2WorkspacesFilterStore.ts
@@ -1,25 +1,35 @@
 import { create } from "zustand";
 
-export type V2WorkspacesDeviceFilter =
-	| "all"
-	| "this-device"
-	| "other-devices"
-	| "cloud";
+export const DEVICE_FILTER_ALL = "all";
+export const DEVICE_FILTER_THIS_DEVICE = "this-device";
+export const PROJECT_FILTER_ALL = "all";
+
+export type V2WorkspacesDeviceFilter = string;
+export type V2WorkspacesProjectFilter = string;
 
 interface V2WorkspacesFilterState {
 	searchQuery: string;
 	deviceFilter: V2WorkspacesDeviceFilter;
+	projectFilter: V2WorkspacesProjectFilter;
 	setSearchQuery: (searchQuery: string) => void;
 	setDeviceFilter: (deviceFilter: V2WorkspacesDeviceFilter) => void;
+	setProjectFilter: (projectFilter: V2WorkspacesProjectFilter) => void;
 	reset: () => void;
 }
 
 export const useV2WorkspacesFilterStore = create<V2WorkspacesFilterState>()(
 	(set) => ({
 		searchQuery: "",
-		deviceFilter: "all",
+		deviceFilter: DEVICE_FILTER_THIS_DEVICE,
+		projectFilter: PROJECT_FILTER_ALL,
 		setSearchQuery: (searchQuery) => set({ searchQuery }),
 		setDeviceFilter: (deviceFilter) => set({ deviceFilter }),
-		reset: () => set({ searchQuery: "", deviceFilter: "all" }),
+		setProjectFilter: (projectFilter) => set({ projectFilter }),
+		reset: () =>
+			set({
+				searchQuery: "",
+				deviceFilter: DEVICE_FILTER_THIS_DEVICE,
+				projectFilter: PROJECT_FILTER_ALL,
+			}),
 	}),
 );

--- a/packages/db/src/schema/github.ts
+++ b/packages/db/src/schema/github.ts
@@ -168,8 +168,6 @@ export const githubPullRequests = pgTable(
 
 		// Record timestamps
 		createdAt: timestamp("created_at").notNull().defaultNow(),
-		// Mirrors GitHub's PR.updated_at — written explicitly by sync/webhook
-		// paths, not auto-stamped on row writes (use lastSyncedAt for that).
 		updatedAt: timestamp("updated_at").notNull().defaultNow(),
 	},
 	(table) => [

--- a/packages/db/src/schema/github.ts
+++ b/packages/db/src/schema/github.ts
@@ -168,10 +168,9 @@ export const githubPullRequests = pgTable(
 
 		// Record timestamps
 		createdAt: timestamp("created_at").notNull().defaultNow(),
-		updatedAt: timestamp("updated_at")
-			.notNull()
-			.defaultNow()
-			.$onUpdate(() => new Date()),
+		// Mirrors GitHub's PR.updated_at — written explicitly by sync/webhook
+		// paths, not auto-stamped on row writes (use lastSyncedAt for that).
+		updatedAt: timestamp("updated_at").notNull().defaultNow(),
 	},
 	(table) => [
 		unique("github_pull_requests_repo_pr_unique").on(

--- a/packages/trpc/src/router/task/task.test.ts
+++ b/packages/trpc/src/router/task/task.test.ts
@@ -10,6 +10,10 @@ const verifyOrgAdminMock = mock(async () => ({
 const verifyOrgMembershipMock = mock(async () => ({
 	membership: { role: "member" },
 }));
+const verifyOrgMembershipWithSubscriptionMock = mock(async () => ({
+	membership: { role: "member" },
+	subscription: null,
+}));
 
 let dbSelectResults: unknown[][] = [];
 let selectResults: unknown[][] = [];
@@ -166,6 +170,7 @@ mock.module("../../lib/integrations/sync", () => ({
 mock.module("../integration/utils", () => ({
 	verifyOrgAdmin: verifyOrgAdminMock,
 	verifyOrgMembership: verifyOrgMembershipMock,
+	verifyOrgMembershipWithSubscription: verifyOrgMembershipWithSubscriptionMock,
 }));
 
 const { createCallerFactory, createTRPCRouter } = await import("../../trpc");


### PR DESCRIPTION
## Summary

Reworks the v2 workspaces list view (`/v2-workspaces`) with real filters, real project icons, and a PR hover card matching the v1 detail layout. Plus two side fixes: a missing Caddy `auto_https` global block in the workspace setup script, and a long-standing semantics bug on `github_pull_requests.updatedAt`.

## What changed

**Filters (v2 workspaces list)**
- Device filter is now a `Select`, not a tab toggle. Defaults to **This device**. Drops the **Cloud** option (it was never populated — `hostType` only ever computes to `local-device`/`remote-device`). Each remote host gets its own entry with an online dot and a per-host count.
- New **project filter** `Select`. Defaults to All projects. Counts are computed pre-project-filter so the dropdown reflects what's actually reachable.
- Search input switches from `type="search"` to `type="text"` so we lose the native blue WebKit clear "x"; replaced with a design-system `InputGroupButton` + `LuX` (only when query is non-empty).

**Project sections**
- List groups workspaces by project under sticky section headers. Column header is `h-8` and project header is `top-8` so they sit flush — no 1px gap.
- New `V2WorkspaceProjectIcon` pulls the actual GitHub org avatar via `https://github.com/{owner}.png` (leftJoined from `v2Projects.githubRepositoryId` → `githubRepositories.owner`). Falls back to a first-letter tile on missing-owner or load error. Same icon used in the project filter dropdown.
- Row vertical padding bumped from `py-2` to `py-2.5` so rows sit comfortably with the icon-bearing section header.

**PR data on each row**
- Live-query joins `githubPullRequests` by `(repositoryId, headBranch)`. Picks the most recent PR per branch, preferring open → draft → merged → closed.
- Each row with a matching PR shows a small inline pill (PR state icon, `#NNN`, checks-status dot). Hovering opens a `HoverCard` with the same layout as v1's `WorkspaceHoverCardContent` PR section: `#N · state · review badge`, additions/deletions, title, "Updated X ago", checks summary + collapsible checks list, "View on GitHub". Presentational helpers (`PrStateBadge`, `ReviewStatusBadge`, `ChecksSummary`, `ChecksList`) are duplicated locally inside `V2WorkspacePrHoverCardContent` rather than imported from the v1 hover-card tree, per our v1↔v2 isolation policy.

**`github_pull_requests.updatedAt` now mirrors upstream**
- Drops Drizzle's `$onUpdate(() => new Date())` from the column. Previously, every sync upsert auto-stamped `updatedAt = now()`, so "Updated 3 minutes ago" really meant "last synced 3 minutes ago" — misleading next to a 6-month-old closed PR.
- Sync/initial-sync routes and the webhook `upsertPullRequest` helper now write `updatedAt: new Date(pr.updated_at)`. The `pull_request_review.submitted` handler does the same. The `check_run.*` handler no longer touches `updatedAt` since check runs don't bump GitHub's PR.updated_at.
- This is a **Drizzle schema-only change** — `$onUpdate` is a TS runtime hook, not a SQL trigger. The column SQL is unchanged (`timestamp NOT NULL DEFAULT now()`). drizzle-kit generate should be a no-op or produce only a snapshot update; please run it on a Neon branch and confirm before merging.

**Caddyfile setup**
- `.superset/lib/setup/steps.sh` heredoc now emits the global `{ auto_https disable_redirects }` block that's always been in `Caddyfile.example`. Without it, Caddy tries to bind port 80 for HTTP→HTTPS redirects on every `dev:caddy` start. `Caddyfile.example` itself is left alone since the README still uses it for the manual setup path.

## Test plan
- [ ] `bun dev` then visit `/v2-workspaces`: list defaults to "This device", switching to "All devices" or a remote host updates counts and rows
- [ ] Project filter dropdown shows real GH org avatars; selecting one filters rows
- [ ] Sticky column header + project section header sit flush as you scroll within a project
- [ ] Hover a PR pill: card matches v1's PR detail layout, "View on GitHub" opens the right URL
- [ ] Search clear `x` looks like the design system, only appears when query is non-empty
- [ ] Reset Caddy: with the new heredoc, `bun run dev:caddy` starts without trying to bind port 80
- [ ] Run `bunx drizzle-kit generate --name=github_pr_updatedat_drop_onupdate` on a Neon branch and verify the SQL migration is empty / snapshot-only
- [ ] Trigger a PR webhook (open/edit/close/review) and confirm `github_pull_requests.updatedAt` matches `pr.updated_at` from the payload, not the row write time

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworks the v2 workspaces list with real device/project filters, project icons, PR hover, and collapsible project sections that auto-expand for the active workspace. Also fixes PR timestamp/state mapping and updates the dev `Caddyfile` setup.

- **New Features**
  - Device filter is now a `Select` with “This device” by default; includes “All devices” and each remote host (online dot + per-host count). Removed “Cloud”.
  - Project filter with real GitHub org avatars; counts reflect reachable workspaces. Triggers keep labels even when the choice is filtered out. Rows are grouped by project under sticky, collapsible headers with the project icon; sections auto-expand for the active workspace.
  - Each row shows a PR pill (`#NNN` + checks dot); hover opens a card with state, review, additions/deletions, checks summary/list, and “View on GitHub”. Drafts also show review and checks.
  - Search matches workspace fields plus PR numbers and titles; custom clear button replaces the native WebKit “x”.

- **Bug Fixes**
  - `github_pull_requests.updatedAt` now mirrors GitHub’s `pr.updated_at` across sync/initial-sync/webhooks; schema-only change (no SQL). PR correctness: detect merged via `mergedAt`; map `check_run` conclusions (`neutral` → success, `stale`/`startup_failure` → failure) to avoid spinners.
  - Don’t blank the list while the device ID is unresolved; “This device” acts as a no-op until it’s known.
  - Setup script now emits the global `{ auto_https disable_redirects }` block in the generated `Caddyfile` to avoid binding port 80 during `dev:caddy`.
  - Fix `@superset/trpc` test by mocking `verifyOrgMembershipWithSubscription`.

<sup>Written for commit efb63692774b5fe215d40761557a60d9d2f7f3fe. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3852?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PR UI enhancements across workspaces: PR pills, richer hover cards (branch, state, review badge, checks summary/list, diffs) and "View on GitHub" button.
  * Project icons, new project/device dropdowns in header, and improved search (now matches PR numbers and titles).
  * Collapsible project sections and refined workspace list layout.

* **Bug Fixes**
  * Preserve GitHub PR updated_at from source so "Updated ..." timestamps reflect GitHub.
  * Check-run updates no longer overwrite PR update timestamps; filter defaults/clear/search behavior refined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->