### PR TITLE
feat(terminal): toggle zoom for focused pane (Cmd+Shift+Enter)

### DIFF
--- a/apps/desktop/src/renderer/hotkeys/registry.ts
+++ b/apps/desktop/src/renderer/hotkeys/registry.ts
@@ -328,6 +328,12 @@ export const HOTKEYS_REGISTRY = {
 		label: "Clear Terminal",
 		category: "Terminal",
 	},
+	ZOOM_PANE: {
+		key: { mac: "meta+shift+enter", windows: "ctrl+shift+enter", linux: "ctrl+shift+enter" },
+		label: "Toggle Zoom Pane",
+		category: "Terminal",
+		description: "Toggle zoom for the focused terminal pane within its tab",
+	},
 	SCROLL_TO_BOTTOM: {
 		key: {
 			mac: "meta+shift+down",

--- a/apps/desktop/src/renderer/hotkeys/registry.ts
+++ b/apps/desktop/src/renderer/hotkeys/registry.ts
@@ -329,7 +329,11 @@ export const HOTKEYS_REGISTRY = {
 		category: "Terminal",
 	},
 	ZOOM_PANE: {
-		key: { mac: "meta+shift+enter", windows: "ctrl+shift+enter", linux: "ctrl+shift+enter" },
+		key: {
+			mac: "meta+shift+enter",
+			windows: "ctrl+shift+enter",
+			linux: "ctrl+shift+enter",
+		},
 		label: "Toggle Zoom Pane",
 		category: "Terminal",
 		description: "Toggle zoom for the focused terminal pane within its tab",

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/TabPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/TabPane.tsx
@@ -11,6 +11,7 @@ import { useTerminalCallbacksStore } from "renderer/stores/tabs/terminal-callbac
 import type { SplitPaneOptions, Tab } from "renderer/stores/tabs/types";
 import { TabContentContextMenu } from "../TabContentContextMenu";
 import { Terminal } from "../Terminal";
+import { ZoomIndicator } from "../Terminal/ZoomIndicator";
 import { BasePaneWindow, PaneTitle, PaneToolbarActions } from "./components";
 
 interface TabPaneProps {
@@ -63,6 +64,9 @@ export function TabPane({
 	const setPaneName = useTabsStore((s) => s.setPaneName);
 	const setPaneStatus = useTabsStore((s) => s.setPaneStatus);
 	const equalizePaneSplits = useTabsStore((s) => s.equalizePaneSplits);
+	const isZoomed = useTabsStore(
+		(s) => s.tabs.find((t) => t.id === tabId)?.zoom?.paneId === paneId,
+	);
 
 	const terminalContainerRef = useRef<HTMLDivElement>(null);
 	const getClearCallback = useTerminalCallbacksStore((s) => s.getClearCallback);
@@ -118,11 +122,13 @@ export function TabPane({
 							<StatusIndicator status={paneStatus} />
 						)}
 					</div>
+					{isZoomed && <ZoomIndicator />}
 					<PaneToolbarActions
 						splitOrientation={handlers.splitOrientation}
 						onSplitPane={handlers.onSplitPane}
 						onClosePane={handlers.onClosePane}
 						closeHotkeyId="CLOSE_TERMINAL"
+						hideSplit={isZoomed}
 					/>
 				</div>
 			)}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/PaneToolbarActions/PaneToolbarActions.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/PaneToolbarActions/PaneToolbarActions.tsx
@@ -12,6 +12,8 @@ interface PaneToolbarActionsProps {
 	leadingActions?: React.ReactNode;
 	/** Hotkey ID to display for the close action. Defaults to CLOSE_PANE. */
 	closeHotkeyId?: HotkeyId;
+	/** When true, hides the Split button (e.g. while a pane is zoomed). */
+	hideSplit?: boolean;
 }
 
 export function PaneToolbarActions({
@@ -20,6 +22,7 @@ export function PaneToolbarActions({
 	onClosePane,
 	leadingActions,
 	closeHotkeyId = "CLOSE_PANE",
+	hideSplit,
 }: PaneToolbarActionsProps) {
 	const splitIcon =
 		splitOrientation === "vertical" ? (
@@ -31,20 +34,22 @@ export function PaneToolbarActions({
 	return (
 		<div className="flex items-center gap-0.5">
 			{leadingActions}
-			<Tooltip>
-				<TooltipTrigger asChild>
-					<button
-						type="button"
-						onClick={onSplitPane}
-						className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
-					>
-						{splitIcon}
-					</button>
-				</TooltipTrigger>
-				<TooltipContent side="bottom" showArrow={false}>
-					<HotkeyLabel label="Split pane" id="SPLIT_AUTO" />
-				</TooltipContent>
-			</Tooltip>
+			{!hideSplit && (
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<button
+							type="button"
+							onClick={onSplitPane}
+							className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
+						>
+							{splitIcon}
+						</button>
+					</TooltipTrigger>
+					<TooltipContent side="bottom" showArrow={false}>
+						<HotkeyLabel label="Split pane" id="SPLIT_AUTO" />
+					</TooltipContent>
+				</Tooltip>
+			)}
 			<Tooltip>
 				<TooltipTrigger asChild>
 					<button

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -3,6 +3,7 @@ import type { SearchAddon } from "@xterm/addon-search";
 import type { Terminal as XTerm } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { useHotkey } from "renderer/hotkeys";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { sanitizeTerminalFontFamily } from "renderer/lib/terminal/appearance";
 import { buildTerminalCommand } from "renderer/lib/terminal/launch-command";
@@ -100,6 +101,7 @@ export const Terminal = memo(function Terminal({
 	const setFocusedPane = useTabsStore((s) => s.setFocusedPane);
 	const setPaneName = useTabsStore((s) => s.setPaneName);
 	const focusedPaneId = useTabsStore((s) => s.focusedPaneIds[tabId]);
+	const toggleZoomPane = useTabsStore((s) => s.toggleZoomPane);
 	const terminalTheme = useTerminalTheme();
 
 	// Terminal connection state and mutations
@@ -300,6 +302,9 @@ export const Terminal = memo(function Terminal({
 		isFocused,
 		onClear: handleClearHotkey,
 		xtermRef,
+	});
+	useHotkey("ZOOM_PANE", () => toggleZoomPane(tabId, paneId), {
+		enabled: isFocused,
 	});
 	useEffect(() => {
 		if (!isRestoredMode) return;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/ZoomIndicator/ZoomIndicator.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/ZoomIndicator/ZoomIndicator.tsx
@@ -1,0 +1,23 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { Maximize2 } from "lucide-react";
+import { useHotkeyDisplay } from "renderer/hotkeys";
+
+export function ZoomIndicator() {
+	const display = useHotkeyDisplay("ZOOM_PANE");
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<div
+					role="img"
+					aria-label="Pane zoomed"
+					className="flex items-center justify-center px-1 text-muted-foreground"
+				>
+					<Maximize2 className="h-3 w-3" />
+				</div>
+			</TooltipTrigger>
+			<TooltipContent side="bottom">
+				Zoomed — {display.text} to restore
+			</TooltipContent>
+		</Tooltip>
+	);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/ZoomIndicator/index.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/ZoomIndicator/index.ts
@@ -1,0 +1,1 @@
+export { ZoomIndicator } from "./ZoomIndicator";

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/terminalKeyboardHandler.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/terminalKeyboardHandler.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, mock } from "bun:test";
+import { createTerminalKeyboardHandler } from "./terminalKeyboardHandler";
+
+// In Bun's test runtime `navigator` is undefined, so registry.ts falls back to
+// "mac" (see registry.ts:16). Platform-specific bindings in these tests are
+// therefore mac bindings: ZOOM_PANE = meta+shift+enter.
+
+function makeKeyEvent(overrides: Partial<KeyboardEvent>): KeyboardEvent {
+	return {
+		key: "Enter",
+		code: "Enter",
+		type: "keydown",
+		metaKey: false,
+		ctrlKey: false,
+		altKey: false,
+		shiftKey: false,
+		isComposing: false,
+		keyCode: 0,
+		preventDefault: () => {},
+		getModifierState: () => false,
+		...overrides,
+	} as unknown as KeyboardEvent;
+}
+
+function makeXterm() {
+	return {
+		selectAll: mock(() => {}),
+		hasSelection: mock(() => false),
+	};
+}
+
+describe("terminalKeyboardHandler", () => {
+	describe("ZOOM_PANE chord (meta+shift+enter, mac binding)", () => {
+		it("returns false so the app-level hotkey bubbles to the document", () => {
+			const handler = createTerminalKeyboardHandler(makeXterm());
+			const event = makeKeyEvent({
+				key: "Enter",
+				code: "Enter",
+				metaKey: true,
+				shiftKey: true,
+			});
+			expect(handler(event)).toBe(false);
+		});
+
+		it("does NOT call onShiftEnter — meta+shift+enter is ZOOM_PANE, not line-continuation", () => {
+			const onShiftEnter = mock(() => {});
+			const handler = createTerminalKeyboardHandler(makeXterm(), {
+				onShiftEnter,
+			});
+			const event = makeKeyEvent({
+				key: "Enter",
+				code: "Enter",
+				metaKey: true,
+				shiftKey: true,
+			});
+			handler(event);
+			expect(onShiftEnter).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("plain Shift+Enter (line-continuation, no modifier)", () => {
+		it("calls onShiftEnter on keydown and returns false", () => {
+			const onShiftEnter = mock(() => {});
+			const handler = createTerminalKeyboardHandler(makeXterm(), {
+				onShiftEnter,
+			});
+			const event = makeKeyEvent({
+				key: "Enter",
+				code: "Enter",
+				type: "keydown",
+				shiftKey: true,
+			});
+			expect(handler(event)).toBe(false);
+			expect(onShiftEnter).toHaveBeenCalledTimes(1);
+		});
+
+		it("does NOT call onShiftEnter on keyup — only keydown triggers it", () => {
+			const onShiftEnter = mock(() => {});
+			const handler = createTerminalKeyboardHandler(makeXterm(), {
+				onShiftEnter,
+			});
+			const event = makeKeyEvent({
+				key: "Enter",
+				code: "Enter",
+				type: "keyup",
+				shiftKey: true,
+			});
+			handler(event);
+			expect(onShiftEnter).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("Ctrl+Shift+Enter (windows/linux ZOOM_PANE chord)", () => {
+		it("does not call onShiftEnter — ctrlKey guard in isShiftEnter blocks line-continuation", () => {
+			// In the test runtime navigator is undefined → PLATFORM defaults to "mac".
+			// On mac, ctrl+shift+enter is NOT a registered app hotkey (mac ZOOM_PANE
+			// is meta+shift+enter), so resolveHotkeyFromEvent returns null. The
+			// isShiftEnter guard then rejects it because ctrlKey is true — it falls
+			// through to xterm (returns true). The key regression assertion is that
+			// onShiftEnter is NOT called regardless of what xterm does with the key.
+			const onShiftEnter = mock(() => {});
+			const handler = createTerminalKeyboardHandler(makeXterm(), {
+				onShiftEnter,
+			});
+			const event = makeKeyEvent({
+				key: "Enter",
+				code: "Enter",
+				ctrlKey: true,
+				shiftKey: true,
+			});
+			handler(event);
+			expect(onShiftEnter).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/terminalKeyboardHandler.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/terminalKeyboardHandler.ts
@@ -13,22 +13,20 @@ export interface KeyboardHandlerOptions {
 }
 
 /**
- * Setup keyboard handling for xterm including:
- * - Shortcut forwarding: App hotkeys bubble to document where useAppHotkey listens
- * - Shift+Enter: Sends ESC+CR sequence (to avoid \ appearing in Claude Code while keeping line continuation behavior)
- *
- * Returns a cleanup function to remove the handler.
+ * Creates the keyboard handler function for xterm without attaching it.
+ * Exported for unit tests — prefer {@link setupKeyboardHandler} in production code.
+ * @internal exported only for tests
  */
-export function setupKeyboardHandler(
-	xterm: XTerm,
+export function createTerminalKeyboardHandler(
+	xterm: Pick<XTerm, "selectAll" | "hasSelection">,
 	options: KeyboardHandlerOptions = {},
-): () => void {
+): (event: KeyboardEvent) => boolean {
 	const platform =
 		typeof navigator !== "undefined" ? navigator.platform.toLowerCase() : "";
 	const isMac = platform.includes("mac");
 	const isWindows = platform.includes("win");
 
-	const handler = (event: KeyboardEvent): boolean => {
+	return (event: KeyboardEvent): boolean => {
 		// Match v2: registered app hotkeys must escape xterm before terminal
 		// translations or macOS Cmd bubbling can consume them.
 		if (resolveHotkeyFromEvent(event) !== null) return false;
@@ -81,7 +79,20 @@ export function setupKeyboardHandler(
 		// chords like ctrl+c/d/z/s/q.
 		return true;
 	};
+}
 
+/**
+ * Setup keyboard handling for xterm including:
+ * - Shortcut forwarding: App hotkeys bubble to document where useAppHotkey listens
+ * - Shift+Enter: Sends ESC+CR sequence (to avoid \ appearing in Claude Code while keeping line continuation behavior)
+ *
+ * Returns a cleanup function to remove the handler.
+ */
+export function setupKeyboardHandler(
+	xterm: XTerm,
+	options: KeyboardHandlerOptions = {},
+): () => void {
+	const handler = createTerminalKeyboardHandler(xterm, options);
 	xterm.attachCustomKeyEventHandler(handler);
 
 	return () => {

--- a/apps/desktop/src/renderer/stores/tabs/actions/zoom-pane.test.ts
+++ b/apps/desktop/src/renderer/stores/tabs/actions/zoom-pane.test.ts
@@ -214,10 +214,7 @@ describe("zoom + store actions (integration)", () => {
 	//    Its zoom-clearing behaviour is identical to case 2 — it delegates to
 	//    splitPaneVertical (or Horizontal), which calls clearZoomBeforeMutation.
 	//    No additional pure-function surface to test here beyond case 2.
-	it.todo(
-		"splitPaneAuto (wrapper) while zoomed inherits clearing transitively — covered by case 2 (same clearZoomBeforeMutation call path)",
-		() => {},
-	);
+	it.todo("splitPaneAuto (wrapper) while zoomed inherits clearing transitively — covered by case 2 (same clearZoomBeforeMutation call path)", () => {});
 
 	// 4. equalizePaneSplits calls updateTabLayout which calls
 	//    clearZoomBeforeMutation unconditionally. Verify that applying

--- a/apps/desktop/src/renderer/stores/tabs/actions/zoom-pane.test.ts
+++ b/apps/desktop/src/renderer/stores/tabs/actions/zoom-pane.test.ts
@@ -1,0 +1,105 @@
+import type { MosaicNode } from "react-mosaic-component";
+import { describe, expect, it } from "vitest";
+import type { Tab, TabsState } from "../types";
+import {
+	clearZoomBeforeMutation,
+	toggleZoomPane,
+	unzoomPane,
+	zoomPane,
+} from "./zoom-pane";
+
+const splitLayout: MosaicNode<string> = {
+	direction: "row",
+	first: "pane-a",
+	second: "pane-b",
+};
+
+function makeTab(overrides: Partial<Tab> = {}): Tab {
+	return {
+		id: "tab-1",
+		workspaceId: "ws-1",
+		name: "Tab 1",
+		layout: splitLayout,
+		...overrides,
+	} as Tab;
+}
+
+function makeState(tab: Tab): TabsState {
+	return {
+		tabs: [tab],
+	} as unknown as TabsState; // we only touch `tabs` in zoom-pane logic
+}
+
+describe("zoomPane", () => {
+	it("stashes layout, replaces with leaf, sets zoom.paneId", () => {
+		const next = zoomPane(makeState(makeTab()), "tab-1", "pane-a");
+		const t = next.tabs[0];
+		expect(t.layout).toBe("pane-a");
+		expect(t.zoom).toEqual({ savedLayout: splitLayout, paneId: "pane-a" });
+	});
+
+	it("is a no-op on already-zoomed tab", () => {
+		const zoomed = zoomPane(makeState(makeTab()), "tab-1", "pane-a");
+		const again = zoomPane(zoomed, "tab-1", "pane-a");
+		expect(again).toBe(zoomed);
+	});
+
+	it("is a no-op on a single-pane tab (no siblings to hide)", () => {
+		const single = makeState(makeTab({ layout: "pane-only" }));
+		const next = zoomPane(single, "tab-1", "pane-only");
+		expect(next).toBe(single);
+	});
+
+	it("is a no-op when tabId not found", () => {
+		const state = makeState(makeTab());
+		expect(zoomPane(state, "missing", "pane-a")).toBe(state);
+	});
+});
+
+describe("unzoomPane", () => {
+	it("restores savedLayout and clears zoom", () => {
+		const zoomed = zoomPane(makeState(makeTab()), "tab-1", "pane-a");
+		const restored = unzoomPane(zoomed, "tab-1");
+		const t = restored.tabs[0];
+		expect(t.layout).toEqual(splitLayout);
+		expect(t.zoom).toBeUndefined();
+	});
+
+	it("is a no-op on a non-zoomed tab", () => {
+		const state = makeState(makeTab());
+		expect(unzoomPane(state, "tab-1")).toBe(state);
+	});
+});
+
+describe("clearZoomBeforeMutation", () => {
+	it("restores savedLayout and clears zoom (same as unzoomPane)", () => {
+		const zoomed = zoomPane(makeState(makeTab()), "tab-1", "pane-a");
+		const cleared = clearZoomBeforeMutation(zoomed, "tab-1");
+		const t = cleared.tabs[0];
+		expect(t.layout).toEqual(splitLayout);
+		expect(t.zoom).toBeUndefined();
+	});
+
+	it("is a no-op when tab is not zoomed (idempotent)", () => {
+		const state = makeState(makeTab());
+		expect(clearZoomBeforeMutation(state, "tab-1")).toBe(state);
+	});
+});
+
+describe("toggleZoomPane", () => {
+	it("zoom→toggle→toggle is the identity on layout", () => {
+		const initial = makeState(makeTab());
+		const a = toggleZoomPane(initial, "tab-1", "pane-a");
+		const b = toggleZoomPane(a, "tab-1", "pane-a");
+		expect(b.tabs[0].layout).toEqual(splitLayout);
+		expect(b.tabs[0].zoom).toBeUndefined();
+	});
+
+	it("ignores paneId on the unzoom branch", () => {
+		const zoomed = zoomPane(makeState(makeTab()), "tab-1", "pane-a");
+		// Triggering toggle from a different paneId still un-zooms.
+		const restored = toggleZoomPane(zoomed, "tab-1", "pane-b");
+		expect(restored.tabs[0].layout).toEqual(splitLayout);
+		expect(restored.tabs[0].zoom).toBeUndefined();
+	});
+});

--- a/apps/desktop/src/renderer/stores/tabs/actions/zoom-pane.test.ts
+++ b/apps/desktop/src/renderer/stores/tabs/actions/zoom-pane.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "bun:test";
 import type { MosaicNode } from "react-mosaic-component";
-import { describe, expect, it } from "vitest";
 import type { Tab, TabsState } from "../types";
 import {
 	clearZoomBeforeMutation,
@@ -20,8 +20,9 @@ function makeTab(overrides: Partial<Tab> = {}): Tab {
 		workspaceId: "ws-1",
 		name: "Tab 1",
 		layout: splitLayout,
+		createdAt: 0,
 		...overrides,
-	} as Tab;
+	};
 }
 
 function makeState(tab: Tab): TabsState {

--- a/apps/desktop/src/renderer/stores/tabs/actions/zoom-pane.test.ts
+++ b/apps/desktop/src/renderer/stores/tabs/actions/zoom-pane.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "bun:test";
 import type { MosaicNode } from "react-mosaic-component";
-import type { Tab, TabsState } from "../types";
+import type { Pane, Tab, TabsState } from "../types";
+import { equalizeSplitPercentages, removePaneFromLayout } from "../utils";
+import { mergeTabIntoTab, movePaneToTab } from "./move-pane";
 import {
 	clearZoomBeforeMutation,
 	toggleZoomPane,
@@ -102,5 +104,335 @@ describe("toggleZoomPane", () => {
 		const restored = toggleZoomPane(zoomed, "tab-1", "pane-b");
 		expect(restored.tabs[0].layout).toEqual(splitLayout);
 		expect(restored.tabs[0].zoom).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests: zoom + layout-mutating actions
+//
+// All cases use the same pure-state approach as move-pane.test.ts. The live
+// store (useTabsStore) is intentionally NOT imported here — it depends on the
+// Electron IPC-backed persist middleware (trpcTabsStorage), posthog, and
+// editor-state stores that require a running Electron environment. The pure
+// action functions called by the store (clearZoomBeforeMutation,
+// removePaneFromLayout, mergeTabIntoTab, movePaneToTab, equalizeSplitPercentages)
+// are sufficient to verify that zoom is cleared correctly before every mutation.
+// ---------------------------------------------------------------------------
+
+const WS = "ws-1";
+
+function makeFullTab(id: string, layout: MosaicNode<string>): Tab {
+	return { id, workspaceId: WS, name: id, layout, createdAt: 0 };
+}
+
+function makePane(id: string, tabId: string): Pane {
+	return { id, tabId, type: "terminal", name: id };
+}
+
+function makeFullState(overrides: Partial<TabsState> = {}): TabsState {
+	return {
+		tabs: [],
+		panes: {},
+		activeTabIds: {},
+		focusedPaneIds: {},
+		tabHistoryStacks: {},
+		closedTabsStack: [],
+		...overrides,
+	};
+}
+
+describe("zoom + store actions (integration)", () => {
+	// 1. removePane(zoomedPaneId): clear zoom first, then remove the pane from
+	//    the restored layout. The sibling pane should become the new sole leaf.
+	it("removePane(zoomedPaneId) restores the tree without that pane", () => {
+		const layout: MosaicNode<string> = {
+			direction: "row",
+			first: "pane-a",
+			second: "pane-b",
+		};
+		const tab = makeFullTab("tab-1", layout);
+		const state = makeFullState({
+			tabs: [tab],
+			panes: {
+				"pane-a": makePane("pane-a", "tab-1"),
+				"pane-b": makePane("pane-b", "tab-1"),
+			},
+		});
+
+		// Zoom to pane-a (simulates user zooming)
+		const zoomed = zoomPane(state, "tab-1", "pane-a");
+		expect(zoomed.tabs[0].zoom).toBeDefined();
+
+		// The store's removePane calls clearZoomBeforeMutation first.
+		// Simulate that: clear zoom, then remove the pane.
+		const cleared = clearZoomBeforeMutation(zoomed, "tab-1");
+		expect(cleared.tabs[0].zoom).toBeUndefined();
+		expect(cleared.tabs[0].layout).toEqual(layout);
+
+		const newLayout = removePaneFromLayout(cleared.tabs[0].layout, "pane-a");
+		expect(newLayout).toBe("pane-b"); // sibling remains as sole leaf
+	});
+
+	// 2. splitPaneVertical (leaf) while zoomed: clear zoom then split.
+	//    After clearing zoom the tab layout is the restored tree; splitting
+	//    appends a new leaf to the right of it.
+	it("splitPaneVertical while zoomed clears zoom then splits", () => {
+		const layout: MosaicNode<string> = {
+			direction: "row",
+			first: "pane-a",
+			second: "pane-b",
+		};
+		const tab = makeFullTab("tab-1", layout);
+		const state = makeFullState({ tabs: [tab] });
+
+		const zoomed = zoomPane(state, "tab-1", "pane-a");
+		expect(zoomed.tabs[0].layout).toBe("pane-a"); // zoomed view
+
+		// Store's splitPaneVertical calls clearZoomBeforeMutation first.
+		const cleared = clearZoomBeforeMutation(zoomed, "tab-1");
+		expect(cleared.tabs[0].layout).toEqual(layout); // restored
+		expect(cleared.tabs[0].zoom).toBeUndefined();
+
+		// Then it appends the new pane to the right of the current layout.
+		const newPaneId = "pane-c";
+		const newLayout: MosaicNode<string> = {
+			direction: "row",
+			first: cleared.tabs[0].layout,
+			second: newPaneId,
+			splitPercentage: 50,
+		};
+		// Resulting layout contains all three panes; no zoom field.
+		expect(newLayout).toEqual({
+			direction: "row",
+			first: { direction: "row", first: "pane-a", second: "pane-b" },
+			second: "pane-c",
+			splitPercentage: 50,
+		});
+	});
+
+	// 3. splitPaneAuto is a thin dispatcher over splitPaneVertical/Horizontal.
+	//    Its zoom-clearing behaviour is identical to case 2 — it delegates to
+	//    splitPaneVertical (or Horizontal), which calls clearZoomBeforeMutation.
+	//    No additional pure-function surface to test here beyond case 2.
+	it.todo(
+		"splitPaneAuto (wrapper) while zoomed inherits clearing transitively — covered by case 2 (same clearZoomBeforeMutation call path)",
+	);
+
+	// 4. equalizePaneSplits calls updateTabLayout which calls
+	//    clearZoomBeforeMutation unconditionally. Verify that applying
+	//    equalizeSplitPercentages to a zoomed tab's restored layout gives the
+	//    correct split ratios.
+	it("equalizePaneSplits clears zoom via updateTabLayout", () => {
+		const threeWayLayout: MosaicNode<string> = {
+			direction: "row",
+			first: "pane-a",
+			second: {
+				direction: "row",
+				first: "pane-b",
+				second: "pane-c",
+				splitPercentage: 70, // deliberately uneven
+			},
+			splitPercentage: 30, // deliberately uneven
+		};
+		const tab = makeFullTab("tab-1", threeWayLayout);
+		const state = makeFullState({ tabs: [tab] });
+
+		const zoomed = zoomPane(state, "tab-1", "pane-a");
+
+		// equalizePaneSplits → updateTabLayout → clearZoomBeforeMutation first.
+		const cleared = clearZoomBeforeMutation(zoomed, "tab-1");
+		expect(cleared.tabs[0].zoom).toBeUndefined();
+
+		// Then equalizeSplitPercentages is applied to the restored layout.
+		const equalized = equalizeSplitPercentages(
+			cleared.tabs[0].layout as MosaicNode<string>,
+		);
+		// 1 leaf on left (pane-a), 2 leaves on right → 33.3% left
+		expect(
+			(equalized as { splitPercentage: number }).splitPercentage,
+		).toBeCloseTo((1 / 3) * 100, 5);
+	});
+
+	// 5. updateTabLayout direct call (mosaic onChange simulation) clears zoom.
+	//    The store's updateTabLayout calls clearZoomBeforeMutation
+	//    unconditionally before applying the new layout.
+	it("updateTabLayout (mosaic onChange simulation) clears zoom", () => {
+		const layout: MosaicNode<string> = {
+			direction: "row",
+			first: "pane-a",
+			second: "pane-b",
+		};
+		const tab = makeFullTab("tab-1", layout);
+		const state = makeFullState({ tabs: [tab] });
+
+		const zoomed = zoomPane(state, "tab-1", "pane-a");
+		expect(zoomed.tabs[0].zoom).toBeDefined();
+
+		// clearZoomBeforeMutation is the first call inside updateTabLayout.
+		const cleared = clearZoomBeforeMutation(zoomed, "tab-1");
+
+		// Then the incoming layout (e.g. a resize drag result) is applied.
+		const resizedLayout: MosaicNode<string> = {
+			direction: "row",
+			first: "pane-a",
+			second: "pane-b",
+			splitPercentage: 60,
+		};
+		const finalTabs = cleared.tabs.map((t) =>
+			t.id === "tab-1" ? { ...t, layout: resizedLayout } : t,
+		);
+
+		expect(finalTabs[0].zoom).toBeUndefined();
+		expect(finalTabs[0].layout).toEqual(resizedLayout);
+	});
+
+	// 6. mergeTabIntoTab clears zoom on the target tab.
+	//    The store calls clearZoomBeforeMutation(state, targetTabId) before
+	//    delegating to the pure mergeTabIntoTab function.
+	it("mergeTabIntoTab clears zoom on the target tab", () => {
+		const srcLayout: MosaicNode<string> = "pane-src";
+		const tgtLayout: MosaicNode<string> = {
+			direction: "row",
+			first: "pane-tgt-a",
+			second: "pane-tgt-b",
+		};
+
+		const srcTab = makeFullTab("tab-src", srcLayout);
+		const tgtTab = makeFullTab("tab-tgt", tgtLayout);
+		const state = makeFullState({
+			tabs: [srcTab, tgtTab],
+			panes: {
+				"pane-src": makePane("pane-src", "tab-src"),
+				"pane-tgt-a": makePane("pane-tgt-a", "tab-tgt"),
+				"pane-tgt-b": makePane("pane-tgt-b", "tab-tgt"),
+			},
+			activeTabIds: { [WS]: "tab-tgt" },
+			focusedPaneIds: { "tab-src": "pane-src", "tab-tgt": "pane-tgt-a" },
+			tabHistoryStacks: { [WS]: [] },
+		});
+
+		// Zoom the target tab on pane-tgt-a
+		const zoomed = zoomPane(state, "tab-tgt", "pane-tgt-a");
+		expect(zoomed.tabs.find((t) => t.id === "tab-tgt")?.zoom).toBeDefined();
+
+		// The store calls clearZoomBeforeMutation on targetTabId first.
+		const cleared = clearZoomBeforeMutation(zoomed, "tab-tgt");
+		expect(cleared.tabs.find((t) => t.id === "tab-tgt")?.zoom).toBeUndefined();
+		expect(cleared.tabs.find((t) => t.id === "tab-tgt")?.layout).toEqual(
+			tgtLayout,
+		);
+
+		// Then the pure merge is called on the cleared state.
+		const result = mergeTabIntoTab(cleared, "tab-src", "tab-tgt", [], "right");
+		expect(result).not.toBeNull();
+		if (!result) return;
+
+		expect(result.tabs).toHaveLength(1);
+		const merged = result.tabs.find((t) => t.id === "tab-tgt");
+		expect(merged?.zoom).toBeUndefined();
+		// Merged layout has src pane appended to the right of tgt layout.
+		expect(merged?.layout).toEqual({
+			direction: "row",
+			first: tgtLayout,
+			second: "pane-src",
+			splitPercentage: 50,
+		});
+	});
+
+	// 7. movePaneToTab clears zoom on both source and target tabs.
+	it("movePaneToTab clears zoom on both source and target", () => {
+		const srcLayout: MosaicNode<string> = {
+			direction: "row",
+			first: "pane-a",
+			second: "pane-b",
+		};
+		// Target also needs a multi-pane layout so zoomPane is not a no-op.
+		const tgtLayout: MosaicNode<string> = {
+			direction: "row",
+			first: "pane-c",
+			second: "pane-d",
+		};
+
+		const srcTab = makeFullTab("tab-src", srcLayout);
+		const tgtTab = makeFullTab("tab-tgt", tgtLayout);
+		const state = makeFullState({
+			tabs: [srcTab, tgtTab],
+			panes: {
+				"pane-a": makePane("pane-a", "tab-src"),
+				"pane-b": makePane("pane-b", "tab-src"),
+				"pane-c": makePane("pane-c", "tab-tgt"),
+				"pane-d": makePane("pane-d", "tab-tgt"),
+			},
+			activeTabIds: { [WS]: "tab-tgt" },
+			focusedPaneIds: { "tab-src": "pane-a", "tab-tgt": "pane-c" },
+			tabHistoryStacks: { [WS]: [] },
+		});
+
+		// Zoom pane-a in source and pane-c in target
+		let zoomed = zoomPane(state, "tab-src", "pane-a");
+		zoomed = zoomPane(zoomed, "tab-tgt", "pane-c");
+		expect(zoomed.tabs.find((t) => t.id === "tab-src")?.zoom).toBeDefined();
+		expect(zoomed.tabs.find((t) => t.id === "tab-tgt")?.zoom).toBeDefined();
+
+		// The store calls clearZoomBeforeMutation on both tabs before movePaneToTab.
+		let cleared = clearZoomBeforeMutation(zoomed, "tab-src");
+		cleared = clearZoomBeforeMutation(cleared, "tab-tgt");
+		expect(cleared.tabs.find((t) => t.id === "tab-src")?.zoom).toBeUndefined();
+		expect(cleared.tabs.find((t) => t.id === "tab-tgt")?.zoom).toBeUndefined();
+		expect(cleared.tabs.find((t) => t.id === "tab-src")?.layout).toEqual(
+			srcLayout,
+		);
+
+		// The pure movePaneToTab is called on the cleared state.
+		const result = movePaneToTab(cleared, "pane-b", "tab-tgt");
+		expect(result).not.toBeNull();
+		if (!result) return;
+
+		// Source tab still has pane-a; target tab gained pane-b.
+		const srcAfter = result.tabs.find((t) => t.id === "tab-src");
+		expect(srcAfter?.layout).toBe("pane-a");
+		const tgtAfter = result.tabs.find((t) => t.id === "tab-tgt");
+		// pane-b should appear in the target layout
+		const tgtLayoutStr = JSON.stringify(tgtAfter?.layout);
+		expect(tgtLayoutStr).toContain("pane-b");
+	});
+
+	// 8. Per-tab scope: zoom on tab A, switch tabs, return to A — still zoomed.
+	//    Zoom state is keyed per-tab in TabsState.tabs[n].zoom.
+	//    Switching the active tab does not clear other tabs' zoom state.
+	it("per-tab scope: zoom on tab A does not affect tab B", () => {
+		const layoutA: MosaicNode<string> = {
+			direction: "row",
+			first: "pane-a1",
+			second: "pane-a2",
+		};
+		const layoutB: MosaicNode<string> = {
+			direction: "row",
+			first: "pane-b1",
+			second: "pane-b2",
+		};
+		const tabA = makeFullTab("tab-a", layoutA);
+		const tabB = makeFullTab("tab-b", layoutB);
+		const state = makeFullState({ tabs: [tabA, tabB] });
+
+		// Zoom tab A
+		const zoomed = zoomPane(state, "tab-a", "pane-a1");
+
+		// Tab B is unaffected
+		const tabBAfter = zoomed.tabs.find((t) => t.id === "tab-b");
+		expect(tabBAfter?.zoom).toBeUndefined();
+		expect(tabBAfter?.layout).toEqual(layoutB);
+
+		// Tab A is zoomed
+		const tabAAfter = zoomed.tabs.find((t) => t.id === "tab-a");
+		expect(tabAAfter?.zoom).toBeDefined();
+		expect(tabAAfter?.layout).toBe("pane-a1");
+
+		// Clearing zoom on tab B (e.g. switching to it and performing a mutation)
+		// does NOT affect tab A's zoom.
+		const clearedB = clearZoomBeforeMutation(zoomed, "tab-b");
+		const tabAStill = clearedB.tabs.find((t) => t.id === "tab-a");
+		expect(tabAStill?.zoom).toBeDefined(); // A still zoomed
+		expect(tabAStill?.layout).toBe("pane-a1");
 	});
 });

--- a/apps/desktop/src/renderer/stores/tabs/actions/zoom-pane.test.ts
+++ b/apps/desktop/src/renderer/stores/tabs/actions/zoom-pane.test.ts
@@ -216,6 +216,7 @@ describe("zoom + store actions (integration)", () => {
 	//    No additional pure-function surface to test here beyond case 2.
 	it.todo(
 		"splitPaneAuto (wrapper) while zoomed inherits clearing transitively — covered by case 2 (same clearZoomBeforeMutation call path)",
+		() => {},
 	);
 
 	// 4. equalizePaneSplits calls updateTabLayout which calls

--- a/apps/desktop/src/renderer/stores/tabs/actions/zoom-pane.ts
+++ b/apps/desktop/src/renderer/stores/tabs/actions/zoom-pane.ts
@@ -1,0 +1,75 @@
+import type { TabsState } from "../types";
+
+/**
+ * Replace `tabs[tabId].layout` with the single leaf `paneId` and stash the
+ * original multi-leaf tree in `tabs[tabId].zoom.savedLayout`. No-op if the
+ * tab is already zoomed, the tab does not exist, or the tab has only one
+ * pane (a string-leaf layout — no siblings to hide).
+ */
+export function zoomPane(
+	state: TabsState,
+	tabId: string,
+	paneId: string,
+): TabsState {
+	const tab = state.tabs.find((t) => t.id === tabId);
+	if (!tab) return state;
+	if (tab.zoom !== undefined) return state;
+	if (typeof tab.layout === "string") return state;
+
+	return {
+		...state,
+		tabs: state.tabs.map((t) =>
+			t.id === tabId
+				? { ...t, layout: paneId, zoom: { savedLayout: t.layout, paneId } }
+				: t,
+		),
+	};
+}
+
+/**
+ * Restore `tabs[tabId].layout` from `zoom.savedLayout` and clear `zoom`.
+ * No-op if the tab is not zoomed or does not exist.
+ */
+export function unzoomPane(state: TabsState, tabId: string): TabsState {
+	const tab = state.tabs.find((t) => t.id === tabId);
+	if (!tab || tab.zoom === undefined) return state;
+	const savedLayout = tab.zoom.savedLayout;
+
+	return {
+		...state,
+		tabs: state.tabs.map((t) =>
+			t.id === tabId ? { ...t, layout: savedLayout, zoom: undefined } : t,
+		),
+	};
+}
+
+/**
+ * Idempotent: restore the saved layout if zoomed, otherwise no-op. Called as
+ * the unconditional first line of `updateTabLayout` and inlined at the start
+ * of every leaf layout-mutating action, so any write to `tabs[T].layout`
+ * automatically un-zooms before the mutation lands on the tree.
+ */
+export function clearZoomBeforeMutation(
+	state: TabsState,
+	tabId: string,
+): TabsState {
+	return unzoomPane(state, tabId);
+}
+
+/**
+ * Toggle: zoom if not zoomed, unzoom if zoomed. The `paneId` argument is
+ * intentionally only used on the zoom branch — when un-zooming, the saved
+ * layout is restored regardless of which pane the toggle was triggered from
+ * (only one pane can be zoomed per tab).
+ */
+export function toggleZoomPane(
+	state: TabsState,
+	tabId: string,
+	paneId: string,
+): TabsState {
+	const tab = state.tabs.find((t) => t.id === tabId);
+	if (!tab) return state;
+	return tab.zoom === undefined
+		? zoomPane(state, tabId, paneId)
+		: unzoomPane(state, tabId);
+}

--- a/apps/desktop/src/renderer/stores/tabs/persist-merge.test.ts
+++ b/apps/desktop/src/renderer/stores/tabs/persist-merge.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "bun:test";
+import type { MosaicNode } from "react-mosaic-component";
+import { applyZoomMergeRules } from "./persist-merge";
+import type { Tab, TabsState } from "./types";
+
+const splitLayout: MosaicNode<string> = {
+	direction: "row",
+	first: "pane-a",
+	second: "pane-b",
+};
+
+function makeTab(overrides: Partial<Tab> = {}): Tab {
+	return {
+		id: "tab-1",
+		workspaceId: "ws-1",
+		name: "Tab 1",
+		layout: splitLayout,
+		createdAt: 0,
+		...overrides,
+	};
+}
+
+function makeState(tabs: Tab[]): TabsState {
+	return { tabs } as unknown as TabsState;
+}
+
+describe("applyZoomMergeRules", () => {
+	it("on a tab quit while zoomed: restores layout from savedLayout, then clears zoom", () => {
+		const persisted = makeState([
+			makeTab({
+				layout: "pane-a",
+				zoom: { savedLayout: splitLayout, paneId: "pane-a" },
+			}),
+		]);
+		const merged = applyZoomMergeRules(persisted);
+		expect(merged.tabs[0].layout).toEqual(splitLayout);
+		expect(merged.tabs[0].zoom).toBeUndefined();
+	});
+
+	it("on a non-zoomed tab: returns state unchanged for that tab", () => {
+		const persisted = makeState([makeTab()]);
+		const merged = applyZoomMergeRules(persisted);
+		expect(merged.tabs[0].layout).toEqual(splitLayout);
+		expect(merged.tabs[0].zoom).toBeUndefined();
+	});
+
+	it("on a single-pane tab with no zoom: layout untouched (string leaf legitimate)", () => {
+		const persisted = makeState([makeTab({ layout: "pane-only" })]);
+		const merged = applyZoomMergeRules(persisted);
+		expect(merged.tabs[0].layout).toBe("pane-only");
+		expect(merged.tabs[0].zoom).toBeUndefined();
+	});
+
+	it("on pre-PR persisted state without a zoom field: harmless no-op", () => {
+		const tab = {
+			id: "tab-1",
+			workspaceId: "ws-1",
+			name: "Tab 1",
+			layout: splitLayout,
+			createdAt: 0,
+		};
+		const persisted = makeState([tab as unknown as Tab]);
+		const merged = applyZoomMergeRules(persisted);
+		expect(merged.tabs[0].layout).toEqual(splitLayout);
+		expect((merged.tabs[0] as Tab).zoom).toBeUndefined();
+	});
+
+	it("handles multiple tabs independently", () => {
+		const persisted = makeState([
+			makeTab({
+				id: "tab-1",
+				layout: "pane-a",
+				zoom: { savedLayout: splitLayout, paneId: "pane-a" },
+			}),
+			makeTab({ id: "tab-2", layout: splitLayout }),
+		]);
+		const merged = applyZoomMergeRules(persisted);
+		expect(merged.tabs[0].layout).toEqual(splitLayout);
+		expect(merged.tabs[0].zoom).toBeUndefined();
+		expect(merged.tabs[1].layout).toEqual(splitLayout);
+		expect(merged.tabs[1].zoom).toBeUndefined();
+	});
+});

--- a/apps/desktop/src/renderer/stores/tabs/persist-merge.ts
+++ b/apps/desktop/src/renderer/stores/tabs/persist-merge.ts
@@ -1,0 +1,35 @@
+import type { TabsState } from "./types";
+
+/**
+ * Apply zoom-related rules during persist rehydration. Two steps in this order:
+ *
+ *   1. Restore-if-zoomed: if `tab.zoom` is set AND `tab.layout === tab.zoom.paneId`
+ *      (the only legitimate way `layout` can equal `zoom.paneId` is if the tab
+ *      was zoomed at quit time, because `zoom.paneId` is set atomically with the
+ *      single-leaf overwrite of `layout` in `zoomPane`), write `tab.layout = tab.zoom.savedLayout`.
+ *
+ *   2. Then clear `zoom`: set `tab.zoom = undefined` on every tab.
+ *
+ * If the order were reversed, step 1 would always be a no-op (because `zoom`
+ * would already be undefined), and tabs that quit while zoomed would rehydrate
+ * with the single-leaf zoom tree as their permanent layout — exactly the bug
+ * we are preventing.
+ *
+ * Pre-PR persisted state without a `zoom` field is unaffected: step 1's
+ * `zoom !== undefined` check fails harmlessly; step 2 is a no-op (assigning
+ * `undefined` to an already-undefined field).
+ */
+export function applyZoomMergeRules(state: TabsState): TabsState {
+	return {
+		...state,
+		tabs: state.tabs.map((tab) => {
+			let layout = tab.layout;
+			// Step 1: restore-if-zoomed.
+			if (tab.zoom !== undefined && tab.layout === tab.zoom.paneId) {
+				layout = tab.zoom.savedLayout;
+			}
+			// Step 2: clear zoom.
+			return { ...tab, layout, zoom: undefined };
+		}),
+	};
+}

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -25,6 +25,7 @@ import {
 	unzoomPane as unzoomPaneAction,
 	zoomPane as zoomPaneAction,
 } from "./actions/zoom-pane";
+import { applyZoomMergeRules } from "./persist-merge";
 import type {
 	AddFileViewerPaneOptions,
 	AddTabWithMultiplePanesOptions,
@@ -2318,13 +2319,13 @@ export const useTabsStore = create<TabsStore>()(
 					return state;
 				},
 				merge: (persistedState, currentState) => {
-					const persisted = persistedState as TabsState;
+					const persistedRaw = persistedState as TabsState;
 					// Clear stale transient statuses on startup:
 					// - "working": Agent can't be working if app just restarted
 					// - "permission": Permission dialog is gone after restart
 					// Note: "review" is intentionally preserved so users see missed completions
-					if (persisted.panes) {
-						for (const pane of Object.values(persisted.panes)) {
+					if (persistedRaw.panes) {
+						for (const pane of Object.values(persistedRaw.panes)) {
 							if (pane.status === "working" || pane.status === "permission") {
 								pane.status = "idle";
 							}
@@ -2339,6 +2340,13 @@ export const useTabsStore = create<TabsStore>()(
 							}
 						}
 					}
+
+					// Apply zoom rehydrate rules: drop transient zoom and restore the
+					// pre-zoom layout for tabs that quit while zoomed. This must happen
+					// after the persistedRaw cast and before the assembled mergedState
+					// is used downstream (the zoom rules only touch `tabs`, so the
+					// pane-status mutations above don't conflict).
+					const persisted = applyZoomMergeRules(persistedRaw);
 
 					const mergedState = { ...currentState, ...persisted };
 

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -20,6 +20,7 @@ import {
 	movePaneToTab,
 } from "./actions/move-pane";
 import {
+	clearZoomBeforeMutation,
 	toggleZoomPane as toggleZoomPaneAction,
 	unzoomPane as unzoomPaneAction,
 	zoomPane as zoomPaneAction,
@@ -543,8 +544,10 @@ export const useTabsStore = create<TabsStore>()(
 				},
 
 				updateTabLayout: (tabId, layout) => {
-					const state = get();
-					const tab = state.tabs.find((t) => t.id === tabId);
+					// Unconditionally clear zoom: react-mosaic's <Mosaic onChange>
+					// calls this on every drag-resize, bypassing internal helpers.
+					const cleared = clearZoomBeforeMutation(get(), tabId);
+					const tab = cleared.tabs.find((t) => t.id === tabId);
 					if (!tab) return;
 
 					const newPaneIds = new Set(extractPaneIdsFromLayout(layout));
@@ -554,9 +557,9 @@ export const useTabsStore = create<TabsStore>()(
 						(id) => !newPaneIds.has(id),
 					);
 
-					const newPanes = { ...state.panes };
+					const newPanes = { ...cleared.panes };
 					for (const paneId of removedPaneIds) {
-						const pane = state.panes[paneId];
+						const pane = cleared.panes[paneId];
 						// Only delete panes that actually belong to this tab
 						// During drag operations, Mosaic may temporarily include foreign panes
 						// in layouts - we must not delete those when they're "removed"
@@ -569,20 +572,21 @@ export const useTabsStore = create<TabsStore>()(
 					}
 
 					// Update focused pane if it was removed
-					let newFocusedPaneIds = state.focusedPaneIds;
-					const currentFocusedPaneId = state.focusedPaneIds[tabId];
+					let newFocusedPaneIds = cleared.focusedPaneIds;
+					const currentFocusedPaneId = cleared.focusedPaneIds[tabId];
 					if (
 						currentFocusedPaneId &&
 						removedPaneIds.includes(currentFocusedPaneId)
 					) {
 						newFocusedPaneIds = {
-							...state.focusedPaneIds,
+							...cleared.focusedPaneIds,
 							[tabId]: getFirstPaneId(layout),
 						};
 					}
 
 					set({
-						tabs: state.tabs.map((t) =>
+						...cleared,
+						tabs: cleared.tabs.map((t) =>
 							t.id === tabId ? { ...t, layout } : t,
 						),
 						panes: newPanes,

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -20,7 +20,6 @@ import {
 	movePaneToTab,
 } from "./actions/move-pane";
 import {
-	clearZoomBeforeMutation,
 	toggleZoomPane as toggleZoomPaneAction,
 	unzoomPane as unzoomPaneAction,
 	zoomPane as zoomPaneAction,
@@ -593,8 +592,7 @@ export const useTabsStore = create<TabsStore>()(
 
 				zoomPane: (tabId, paneId) =>
 					set((state) => zoomPaneAction(state, tabId, paneId)),
-				unzoomPane: (tabId) =>
-					set((state) => unzoomPaneAction(state, tabId)),
+				unzoomPane: (tabId) => set((state) => unzoomPaneAction(state, tabId)),
 				toggleZoomPane: (tabId, paneId) =>
 					set((state) => toggleZoomPaneAction(state, tabId, paneId)),
 

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -1575,25 +1575,34 @@ export const useTabsStore = create<TabsStore>()(
 				},
 
 				movePaneToTab: (paneId, targetTabId) => {
-					const state = get();
-					const pane = state.panes[paneId];
+					const initial = get();
+					const pane = initial.panes[paneId];
+					if (!pane) return;
+					// Clear zoom on both source and target before computing the move,
+					// so the pure function operates on the un-zoomed layouts.
+					let state = clearZoomBeforeMutation(initial, pane.tabId);
+					if (pane.tabId !== targetTabId) {
+						state = clearZoomBeforeMutation(state, targetTabId);
+					}
 					const result = movePaneToTab(state, paneId, targetTabId);
 					if (!result) return;
 
-					set(withDerivedTabNames(result, [pane?.tabId, targetTabId]));
+					set(withDerivedTabNames(result, [pane.tabId, targetTabId]));
 				},
 
 				movePaneToNewTab: (paneId) => {
-					const state = get();
-					const pane = state.panes[paneId];
+					const initial = get();
+					const pane = initial.panes[paneId];
 					if (!pane) return "";
 
-					const sourceTab = state.tabs.find((t) => t.id === pane.tabId);
+					const sourceTab = initial.tabs.find((t) => t.id === pane.tabId);
 					if (!sourceTab) return "";
 
 					// Already in its own tab
-					if (isLastPaneInTab(state.panes, sourceTab.id)) return sourceTab.id;
+					if (isLastPaneInTab(initial.panes, sourceTab.id)) return sourceTab.id;
 
+					// Clear zoom on the source tab; the new tab can't be zoomed yet.
+					const state = clearZoomBeforeMutation(initial, sourceTab.id);
 					const moveResult = movePaneToNewTab(state, paneId);
 					if (!moveResult) return "";
 
@@ -1612,7 +1621,9 @@ export const useTabsStore = create<TabsStore>()(
 					destinationPath,
 					position,
 				) => {
-					const state = get();
+					// Clear zoom on the target tab — the source tab is being deleted by
+					// the merge, so its zoom (if any) goes with it.
+					const state = clearZoomBeforeMutation(get(), targetTabId);
 					const result = mergeTabIntoTab(
 						state,
 						sourceTabId,

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -1426,7 +1426,7 @@ export const useTabsStore = create<TabsStore>()(
 
 				// Split operations
 				splitPaneVertical: (tabId, sourcePaneId, path, options) => {
-					const state = get();
+					const state = clearZoomBeforeMutation(get(), tabId);
 					const tab = state.tabs.find((t) => t.id === tabId);
 					if (!tab) return;
 
@@ -1495,7 +1495,7 @@ export const useTabsStore = create<TabsStore>()(
 				},
 
 				splitPaneHorizontal: (tabId, sourcePaneId, path, options) => {
-					const state = get();
+					const state = clearZoomBeforeMutation(get(), tabId);
 					const tab = state.tabs.find((t) => t.id === tabId);
 					if (!tab) return;
 

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -19,6 +19,12 @@ import {
 	movePaneToNewTab,
 	movePaneToTab,
 } from "./actions/move-pane";
+import {
+	clearZoomBeforeMutation,
+	toggleZoomPane as toggleZoomPaneAction,
+	unzoomPane as unzoomPaneAction,
+	zoomPane as zoomPaneAction,
+} from "./actions/zoom-pane";
 import type {
 	AddFileViewerPaneOptions,
 	AddTabWithMultiplePanesOptions,
@@ -584,6 +590,13 @@ export const useTabsStore = create<TabsStore>()(
 						focusedPaneIds: newFocusedPaneIds,
 					});
 				},
+
+				zoomPane: (tabId, paneId) =>
+					set((state) => zoomPaneAction(state, tabId, paneId)),
+				unzoomPane: (tabId) =>
+					set((state) => unzoomPaneAction(state, tabId)),
+				toggleZoomPane: (tabId, paneId) =>
+					set((state) => toggleZoomPaneAction(state, tabId, paneId)),
 
 				equalizePaneSplits: (tabId) => {
 					const tab = get().tabs.find((t) => t.id === tabId);

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -1058,7 +1058,10 @@ export const useTabsStore = create<TabsStore>()(
 				},
 
 				removePane: (paneId) => {
-					const state = get();
+					const initial = get();
+					const tabId = initial.panes[paneId]?.tabId;
+					if (!tabId) return;
+					const state = clearZoomBeforeMutation(initial, tabId);
 					const pane = state.panes[paneId];
 					if (!pane) return;
 
@@ -1751,21 +1754,22 @@ export const useTabsStore = create<TabsStore>()(
 				},
 
 				openInBrowserPane: (workspaceId: string, url: string) => {
-					const state = get();
+					const initial = get();
 
 					// Find an existing browser pane in this workspace
 					const workspaceTabIds = new Set(
-						state.tabs
+						initial.tabs
 							.filter((t) => t.workspaceId === workspaceId)
 							.map((t) => t.id),
 					);
-					const existingPane = Object.values(state.panes).find(
+					const existingPane = Object.values(initial.panes).find(
 						(p) =>
 							p.type === "webview" && p.browser && workspaceTabIds.has(p.tabId),
 					);
 
 					if (existingPane?.browser) {
 						// Navigate existing pane and make its tab active
+						const state = clearZoomBeforeMutation(initial, existingPane.tabId);
 						const { history: prevHistory, historyIndex } = existingPane.browser;
 						const history = prevHistory.slice(0, historyIndex + 1);
 						history.push({
@@ -1815,18 +1819,24 @@ export const useTabsStore = create<TabsStore>()(
 						// No existing browser pane — add one to the active tab
 						const resolvedActiveTabId = resolveActiveTabIdForWorkspace({
 							workspaceId,
-							tabs: state.tabs,
-							activeTabIds: state.activeTabIds,
-							tabHistoryStacks: state.tabHistoryStacks,
+							tabs: initial.tabs,
+							activeTabIds: initial.activeTabIds,
+							tabHistoryStacks: initial.tabHistoryStacks,
 						});
-						const activeTab = resolvedActiveTabId
-							? state.tabs.find((t) => t.id === resolvedActiveTabId)
+						const resolvedActiveTab = resolvedActiveTabId
+							? initial.tabs.find((t) => t.id === resolvedActiveTabId)
 							: null;
 
-						if (!activeTab) {
+						if (!resolvedActiveTab) {
 							get().addBrowserTab(workspaceId, url);
 							return;
 						}
+
+						const state = clearZoomBeforeMutation(
+							initial,
+							resolvedActiveTab.id,
+						);
+						const activeTab = resolvedActiveTab;
 
 						const newPane = createBrowserPane(activeTab.id, {
 							url,
@@ -2042,7 +2052,7 @@ export const useTabsStore = create<TabsStore>()(
 				},
 
 				openDevToolsPane: (tabId, browserPaneId, path) => {
-					const state = get();
+					const state = clearZoomBeforeMutation(get(), tabId);
 					const tab = state.tabs.find((t) => t.id === tabId);
 					if (!tab) return null;
 

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -609,7 +609,7 @@ export const useTabsStore = create<TabsStore>()(
 
 				// Pane operations
 				addPane: (tabId, options?: CreatePaneOptions) => {
-					const state = get();
+					const state = clearZoomBeforeMutation(get(), tabId);
 					const tab = state.tabs.find((t) => t.id === tabId);
 					if (!tab) return "";
 
@@ -645,7 +645,7 @@ export const useTabsStore = create<TabsStore>()(
 					return newPane.id;
 				},
 				addChatPane: (tabId, options) => {
-					const state = get();
+					const state = clearZoomBeforeMutation(get(), tabId);
 					const tab = state.tabs.find((t) => t.id === tabId);
 					if (!tab) return "";
 
@@ -685,7 +685,7 @@ export const useTabsStore = create<TabsStore>()(
 					tabId: string,
 					options: AddTabWithMultiplePanesOptions,
 				) => {
-					const state = get();
+					const state = clearZoomBeforeMutation(get(), tabId);
 					const tab = state.tabs.find((t) => t.id === tabId);
 					if (!tab) return [];
 
@@ -743,13 +743,17 @@ export const useTabsStore = create<TabsStore>()(
 						};
 					}
 
-					const state = get();
+					const rawState = get();
 					const resolvedActiveTabId = resolveActiveTabIdForWorkspace({
 						workspaceId,
-						tabs: state.tabs,
-						activeTabIds: state.activeTabIds,
-						tabHistoryStacks: state.tabHistoryStacks,
+						tabs: rawState.tabs,
+						activeTabIds: rawState.activeTabIds,
+						tabHistoryStacks: rawState.tabHistoryStacks,
 					});
+					const state = clearZoomBeforeMutation(
+						rawState,
+						resolvedActiveTabId ?? "",
+					);
 					const activeTab = resolvedActiveTabId
 						? state.tabs.find((t) => t.id === resolvedActiveTabId)
 						: null;

--- a/apps/desktop/src/renderer/stores/tabs/types.ts
+++ b/apps/desktop/src/renderer/stores/tabs/types.ts
@@ -36,6 +36,15 @@ export interface ClosedTabEntry {
  */
 export interface Tab extends BaseTab {
 	layout: MosaicNode<string>; // Always defined, leaves are paneIds
+	/**
+	 * Transient zoom state. When set, the tab is rendering a single zoomed pane;
+	 * `layout` is overwritten with `paneId` and `savedLayout` holds the original
+	 * multi-leaf tree to restore on un-zoom. Stripped on persist rehydrate.
+	 */
+	zoom?: {
+		savedLayout: MosaicNode<string>;
+		paneId: string;
+	};
 }
 
 /**
@@ -126,6 +135,9 @@ export interface TabsStore extends TabsState {
 	) => void;
 	reorderTabById: (tabId: string, targetIndex: number) => void;
 	updateTabLayout: (tabId: string, layout: MosaicNode<string>) => void;
+	zoomPane: (tabId: string, paneId: string) => void;
+	unzoomPane: (tabId: string) => void;
+	toggleZoomPane: (tabId: string, paneId: string) => void;
 
 	// Pane operations
 	addPane: (tabId: string, options?: AddTabOptions) => string;


### PR DESCRIPTION
## Summary

Adds a hotkey that toggles a "zoom" mode for the focused terminal pane within its tab — equivalent to iTerm2's ⌘⇧↵ and Ghostty's split-zoom. While zoomed, sibling splits in the same tab are hidden; the tab fills with the single pane. Same hotkey toggles back. Zoom is per-tab, transient, and not persisted across restarts.

### Hotkey table

| Platform | Binding |
|---|---|
| macOS    | `⌘⇧↵` (`meta+shift+enter`) |
| Windows  | `Ctrl+Shift+Enter` |
| Linux    | `Ctrl+Shift+Enter` |

### Mechanism

Stash-and-swap on the per-tab `MosaicNode<string>` layout in `useTabsStore`. New optional `zoom: { savedLayout, paneId }` per tab. Every leaf action that writes `tabs[T].layout` inlines `clearZoomBeforeMutation(get(), tabId)` at its start, then issues a single atomic `set()` writing the cleared+mutated state. `updateTabLayout` itself also clears `zoom` unconditionally as its first line, because `react-mosaic-component`'s `<Mosaic onChange>` calls it directly on every drag-resize. Wrappers (`splitPaneAuto`, `equalizePaneSplits`) inherit protection transitively. The `persist` middleware's `merge` function strips transient `zoom` on rehydrate via a pure helper (`applyZoomMergeRules`).

### Out of scope

- Other pane types (Chat, Browser, FileViewer). The mechanism is pane-type-agnostic; extending to other pane types is a follow-up that registers the same hotkey from the other pane components.
- v2 workspace (uses a separate pane registry).
- Persistence of zoom state across restarts (transient by design).
- OS-level fullscreen (separate concept).

## Test plan

- [x] In a v1 workspace, ⌘⇧↵ zooms the focused terminal; ⌘⇧↵ again restores siblings.
- [x] While zoomed, OS window resize reflows xterm correctly.
- [x] While zoomed, ⌘W closes the terminal and restores siblings.
- [x] While zoomed, ⌘D and ⌘E split correctly against the restored tree.
- [x] Zoom on tab A, switch tabs, return to A — still zoomed (per-tab scope).
- [x] Quit app while zoomed, relaunch — tab opens with original split layout.
- [x] Plain Shift+Enter still triggers the existing line-continuation behavior in the terminal.

## Tests added

- `apps/desktop/src/renderer/stores/tabs/actions/zoom-pane.test.ts` — 10 unit tests for the pure transformers + 7 integration tests for zoom × layout-mutating action interactions.
- `apps/desktop/src/renderer/stores/tabs/persist-merge.test.ts` — 5 tests for the rehydrate rules.
- `apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/terminalKeyboardHandler.test.ts` — 5 tests covering ZOOM_PANE bubble-out, Shift+Enter line-continuation regression guard.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a hotkey to toggle zoom for the focused terminal pane (Cmd+Shift+Enter on macOS, Ctrl+Shift+Enter on Windows/Linux). This hides sibling splits within the tab, shows a small zoom badge, and restores the original layout when toggled off.

- **New Features**
  - Added `ZOOM_PANE` hotkey to toggle zoom on the focused terminal pane.
  - While zoomed: sibling panes are hidden, a `ZoomIndicator` is shown, and the Split button is hidden.
  - Introduced per-tab transient `zoom` state in the tabs store with `zoomPane`, `unzoomPane`, and `toggleZoomPane`.
  - All layout-changing actions clear zoom first; `updateTabLayout` also clears zoom for drag-resizes.
  - Persist merge restores the pre-zoom layout if the app quit while zoomed and removes transient `zoom`.

- **Refactors**
  - Extracted `createTerminalKeyboardHandler` for unit tests and kept `setupKeyboardHandler` for production.
  - Added tests for zoom state transformers, persistence merge rules, hotkey bubbling, and Shift+Enter behavior.

<sup>Written for commit 1431c20f62af29b4fb26fdd84e16197e108c1ba1. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3854?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pane zoom functionality with keyboard hotkey support to toggle zoom state for focused terminal panes.
  * Added visual indicator displaying when a terminal pane is zoomed.
  * Split toolbar actions are hidden while a pane is zoomed.

* **Tests**
  * Added comprehensive test coverage for zoom state management and keyboard handler behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->