### PR TITLE
fix(terminal): restore xterm focus when closing find input

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -301,6 +301,20 @@ export const Terminal = memo(function Terminal({
 		onClear: handleClearHotkey,
 		xtermRef,
 	});
+
+	// Restore xterm focus after the search overlay closes. Doing this inline
+	// in onClose runs before React commits the input unmount, so the browser
+	// can land focus on document.body during the unmount and our focus call
+	// gets clobbered. A useEffect runs after commit, in a clean DOM state.
+	const wasSearchOpenRef = useRef(isSearchOpen);
+	useEffect(() => {
+		const justClosed = wasSearchOpenRef.current && !isSearchOpen;
+		wasSearchOpenRef.current = isSearchOpen;
+		if (justClosed && isFocused) {
+			xtermRef.current?.focus();
+		}
+	}, [isSearchOpen, isFocused]);
+
 	useEffect(() => {
 		if (!isRestoredMode) return;
 		handleStartShell();
@@ -455,12 +469,7 @@ export const Terminal = memo(function Terminal({
 			<TerminalSearch
 				searchAddon={searchAddonRef.current}
 				isOpen={isSearchOpen}
-				onClose={() => {
-					setIsSearchOpen(false);
-					// Restore focus to the terminal so keystrokes go to the shell
-					// instead of being swallowed by the body element.
-					xtermRef.current?.focus();
-				}}
+				onClose={() => setIsSearchOpen(false)}
 			/>
 			<ScrollToBottomButton terminal={xtermInstance} />
 			{exitStatus === "killed" &&

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -455,7 +455,12 @@ export const Terminal = memo(function Terminal({
 			<TerminalSearch
 				searchAddon={searchAddonRef.current}
 				isOpen={isSearchOpen}
-				onClose={() => setIsSearchOpen(false)}
+				onClose={() => {
+					setIsSearchOpen(false);
+					// Restore focus to the terminal so keystrokes go to the shell
+					// instead of being swallowed by the body element.
+					xtermRef.current?.focus();
+				}}
 			/>
 			<ScrollToBottomButton terminal={xtermInstance} />
 			{exitStatus === "killed" &&


### PR DESCRIPTION
## Summary

Closing the terminal find overlay (Esc, ⌘F toggle, or the close button) left focus on `document.body`, so keystrokes were swallowed until the user clicked back into the terminal. This refocuses xterm on close so typing resumes immediately.

## Reproduction (before fix)

1. Open a terminal pane.
2. Press ⌘F to open the find overlay.
3. Press Esc (or click the × button) to close it.
4. Type — keystrokes are dropped, no character appears in the shell.
5. Click into the terminal manually — typing resumes.

## After the fix

Step 4 above: keystrokes go to the shell immediately, no manual click needed.

## Change

One callsite in `Terminal.tsx`'s `<TerminalSearch onClose>` callback now also calls `xtermRef.current?.focus()` after `setIsSearchOpen(false)`. Same behavior as the existing `useEffect` that focuses xterm when `isFocused` flips true — extended to the search-close path that doesn't change `isFocused`.

## Test plan

- [x] ⌘F → Esc → type → text appears in shell.
- [x] ⌘F → click × button → type → text appears in shell.
- [x] ⌘F → ⌘F (toggle close) → type → text appears in shell.
- [x] No regression: opening find still focuses the input (existing behavior).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore focus to the `xterm` terminal when the find overlay closes, so typing resumes immediately without clicking. Focus is now restored in a `useEffect` that detects the overlay just closed (Esc, ⌘F toggle, or close button) and the terminal is focused, avoiding the inline `onClose` unmount race.

<sup>Written for commit 07f1fa86f8655510fa0d369439e3fd0547a3fbf0. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3855?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where keyboard input could be lost after closing the search overlay. The terminal now reliably regains focus when search closes, so keystrokes are delivered to the shell and command typing resumes without extra clicks or manual refocusing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->