### PR TITLE
fix(host-service): clean up exited terminals on workspace delete

### DIFF
--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -11,7 +11,7 @@ import {
 	scanForTerminalTitle,
 	type TerminalTitleScanState,
 } from "@superset/shared/terminal-title-scanner";
-import { and, eq } from "drizzle-orm";
+import { and, eq, ne } from "drizzle-orm";
 import type { Hono } from "hono";
 import { type IPty, spawn } from "node-pty";
 import type { HostDb } from "../db";
@@ -318,7 +318,7 @@ export function disposeSessionsByWorkspaceId(
 		.where(
 			and(
 				eq(terminalSessions.originWorkspaceId, workspaceId),
-				eq(terminalSessions.status, "active"),
+				ne(terminalSessions.status, "disposed"),
 			),
 		)
 		.all();


### PR DESCRIPTION
## Summary
- `disposeSessionsByWorkspaceId` filtered DB rows by `status = "active"`, so any session whose row had drifted to `exited` (via `pty.onExit`) was skipped on workspace deletion
- The in-memory `sessions` Map entry stayed behind in those cases — slow leak per workspace delete
- Widened the filter to `status != "disposed"` so zombie rows are picked up too. `disposeSession` is already idempotent against a dead PTY (see comment at `terminal.ts:271`)

Terminals are intentionally persistent across most lifecycle events; this only changes behavior on the explicit workspace-delete path. Pane-deletion path is unaffected (it goes through `disposeSession` directly).

## Test plan
- [ ] Create a workspace with a terminal, kill the PTY out-of-band so its row becomes `exited`, then delete the workspace and confirm no `sessions` Map entry remains
- [ ] Normal workspace delete with a live terminal still kills the PTY
- [ ] Deleting a workspace with no terminals is a no-op

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clean up exited terminal sessions on workspace delete to prevent leftover in-memory `sessions` entries. `disposeSessionsByWorkspaceId` now disposes all rows where `status != 'disposed'` (using `ne` from `drizzle-orm`) instead of only `active`; pane deletion is unchanged.

<sup>Written for commit 9ab7de4004c2badadfc8dc966fb1678610c4a7c1. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3856?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal session disposal has been improved to comprehensively clean up all inactive terminal sessions within a workspace. Previously, only sessions marked as active were targeted for disposal; the system now properly disposes all sessions that are not already disposed, preventing orphaned resources and ensuring more efficient workspace management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->