### PR TITLE
fix(desktop): keep diff file header items left-aligned on wrap

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileHeader/DiffFileHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileHeader/DiffFileHeader.tsx
@@ -44,7 +44,7 @@ export function DiffFileHeader({
 	const viewedId = useId();
 
 	return (
-		<div className="@container/diff-file-header flex min-w-0 flex-wrap items-center justify-between gap-1 px-2 py-1.5">
+		<div className="@container/diff-file-header flex min-w-0 flex-wrap items-center gap-1 px-2 py-1.5">
 			<button
 				type="button"
 				onClick={onToggleCollapsed}


### PR DESCRIPTION
## Summary
- The v2 diff file header used `justify-between` with `flex-wrap`. When the action cluster (additions count, Viewed checkbox, eye/copy/discard buttons) wrapped to a second row at narrow widths, the remaining chevron, status indicator, and file badge spread out across the first row with large gaps between them.
- Removed `justify-between` so those items stay tight on the left; `ml-auto` on the action div still pushes it to the right when it wraps to row 2.

## Test plan
- [ ] Open a v2 workspace diff pane and shrink the pane horizontally until the action cluster wraps onto a second row — confirm the chevron, status icon, and file path badge stay grouped on the left of row 1 with no gap between them.
- [ ] At wider widths, confirm the header still lays out on a single row with the actions anchored to the right.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the diff file header layout so items stay left-aligned when the actions wrap on narrow widths, removing awkward gaps. Removes `justify-between` from the header container; `ml-auto` still pushes the action group right when space allows.

- **Bug Fixes**
  - Prevents chevron, status icon, and file badge from spreading across row 1 by removing `justify-between` on the flex container.
  - Preserves single-row layout at wider widths with actions anchored right.

<sup>Written for commit cc4bfa12f8c7673c0bbf660bc05ea9f0cb665d88. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3858?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined spacing and alignment in the diff file header component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->