### PR TITLE
fix(desktop): give v2 chat pane full width

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/SessionSelector/SessionSelector.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/SessionSelector/SessionSelector.tsx
@@ -116,7 +116,7 @@ export function SessionSelector({
 				<button
 					type="button"
 					title={currentTitle}
-					className="flex min-w-0 flex-1 items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+					className="flex w-full min-w-0 flex-1 items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
 				>
 					<HiMiniChevronDown className="size-3 shrink-0" />
 					<span className="min-w-0 flex-1 truncate text-left">

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/ChatPaneInterface.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/ChatPaneInterface.tsx
@@ -920,7 +920,7 @@ export function ChatPaneInterface({
 
 	return (
 		<PromptInputProvider initialInput={initialLaunchConfig?.draftInput}>
-			<div className="flex h-full flex-col bg-background">
+			<div className="flex h-full w-full flex-col bg-background">
 				<ChatMessageList
 					messages={visibleMessages}
 					isFocused={isFocused}


### PR DESCRIPTION
## Summary
- v2 `ChatPaneInterface` root sat inside `PaneContent`'s row-direction flex with no width directive, so it sized to its intrinsic content and the chat appeared smushed. Added `w-full` to match every other v2 pane (TerminalPane, FilePane, etc.).
- Restored `w-full` on the v2 `SessionSelector` trigger button — present in v1 but dropped in the port.

## Test plan
- [ ] Open a v2 workspace chat pane and confirm the message list, composer, and session selector fill the pane width
- [ ] Resize/split the pane and confirm content reflows instead of clipping

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the v2 chat pane width so the message list, composer, and session selector span the full pane. Prevents the smushed layout and clipping when panes are split or resized.

- **Bug Fixes**
  - Add `w-full` to the `ChatPaneInterface` root inside the row-direction flex.
  - Restore `w-full` on the `SessionSelector` trigger button.

<sup>Written for commit 5a9372fece1f8ecb5dc259d726c725154e9141d3. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3859?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved chat interface layout and width handling for better visual presentation and alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->