### PR TITLE
feat(desktop): default markdown files to preview view

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/MarkdownPreviewView/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/MarkdownPreviewView/index.ts
@@ -6,7 +6,7 @@ export const markdownPreviewView: FileView = {
 	id: "markdown-preview",
 	label: "Preview",
 	match: (filePath) => isMarkdownFile(filePath),
-	priority: "option",
+	priority: "default",
 	documentKind: "text",
 	Renderer: MarkdownPreviewView,
 };


### PR DESCRIPTION
## Summary
- Bump `markdownPreviewView` priority from `option` to `default` so markdown files open in the rendered preview by default instead of raw source.
- Per-pane `viewId` is already persisted, so anyone who toggles to raw stays on raw for that pane; only fresh pane opens are affected.

## Test plan
- [ ] Open a `.md` file from the v2 file tree → renders in preview by default
- [ ] Toggle to raw view → stays on raw across re-focus and tab switching for that pane
- [ ] Open a different `.md` file → also defaults to preview
- [ ] Non-markdown text files still open in CodeView

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Markdown files now open in the rendered Preview by default. We set the `markdownPreviewView` priority to `default`; per-pane view choice persists, so switching to Raw keeps Raw for that pane while new panes still default to Preview.

<sup>Written for commit e5d1b59c31d81f743794c0885231510ab294c6a3. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3860?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Markdown preview is now the default view when opening markdown files, streamlining file viewing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->