### PR TITLE
fix(host-service): catch tunnel connect errors to prevent crash on DNS failure

### DIFF
--- a/packages/host-service/src/tunnel/tunnel-client.ts
+++ b/packages/host-service/src/tunnel/tunnel-client.ts
@@ -41,43 +41,52 @@ export class TunnelClient {
 	async connect(): Promise<void> {
 		if (this.closed) return;
 
-		const token = await this.getAuthToken();
-		if (!token) {
-			console.warn("[host-service:tunnel] no auth token available, retrying");
-			this.scheduleReconnect();
-			return;
-		}
-
-		const url = new URL("/tunnel", this.relayUrl);
-		url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
-		url.searchParams.set("hostId", this.hostId);
-		url.searchParams.set("token", token);
-
-		const socket = new WebSocket(url.toString());
-		this.socket = socket;
-
-		socket.onopen = () => {
-			this.reconnectAttempts = 0;
-			console.log(
-				`[host-service:tunnel] connected to relay for host ${this.hostId}`,
-			);
-		};
-
-		socket.onmessage = (event) => {
-			void this.handleMessage(event.data);
-		};
-
-		socket.onclose = () => {
-			this.socket = null;
-			this.cleanupChannels();
-			if (!this.closed) {
+		// An unhandled rejection here (e.g. DNS failure inside getAuthToken on
+		// wake from sleep) crashes host-service and orphans every PTY.
+		try {
+			const token = await this.getAuthToken();
+			if (!token) {
+				console.warn("[host-service:tunnel] no auth token available, retrying");
 				this.scheduleReconnect();
+				return;
 			}
-		};
 
-		socket.onerror = (event) => {
-			console.error("[host-service:tunnel] socket error:", event);
-		};
+			const url = new URL("/tunnel", this.relayUrl);
+			url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+			url.searchParams.set("hostId", this.hostId);
+			url.searchParams.set("token", token);
+
+			const socket = new WebSocket(url.toString());
+			this.socket = socket;
+
+			socket.onopen = () => {
+				this.reconnectAttempts = 0;
+				console.log(
+					`[host-service:tunnel] connected to relay for host ${this.hostId}`,
+				);
+			};
+
+			socket.onmessage = (event) => {
+				void this.handleMessage(event.data);
+			};
+
+			socket.onclose = () => {
+				this.socket = null;
+				this.cleanupChannels();
+				if (!this.closed) {
+					this.scheduleReconnect();
+				}
+			};
+
+			socket.onerror = (event) => {
+				console.error("[host-service:tunnel] socket error:", event);
+			};
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			console.error(`[host-service:tunnel] connect failed: ${message}`);
+			this.socket = null;
+			this.scheduleReconnect();
+		}
 	}
 
 	close(): void {


### PR DESCRIPTION
## Summary
- When the laptop wakes from sleep and DNS hasn't recovered, the tunnel's auto-reconnect path calls `JwtApiAuthProvider.getJwt()` which fetches `api.superset.sh`. The fetch throws `ENOTFOUND`, the rejection escapes via `void this.connect()` (`scheduleReconnect`'s `setTimeout`), and the host-service process crashes — orphaning every PTY.
- The coordinator respawns the host-service on a new port, but the renderer's terminal WebSockets are still pointed at the dead port → "WebSocket closed (1006). Reconnecting…" loop until max attempts → user reports "all terminals died overnight."
- Fix: wrap `TunnelClient.connect()`'s body in try/catch. Any throw (DNS failure, WebSocket constructor error, etc.) now routes through the same `scheduleReconnect()` path that handles normal socket-level errors.

## Evidence
Reproduced in `~/.superset/host/<org>/host-service.log`:
```
[host-service:tunnel] socket error: ErrorEvent { ... }
[host-service:tunnel] reconnecting in 1000ms (attempt 1)
node:internal/process/promises:394
    triggerUncaughtException(err, true /* fromPromise */);
[TypeError: fetch failed] {
  [cause]: Error: getaddrinfo ENOTFOUND api.superset.sh
}
Node.js v24.14.0
```
Followed immediately by a fresh `[host-service:db] Initialized` line — the coordinator-driven respawn that breaks the renderer's terminal sockets. No `[host-service] unhandledRejection — staying up` log was emitted, so the safety net in `safety.ts` didn't catch it (likely Node 24 default `--unhandled-rejections=throw` behavior on this path).

## Test plan
- [ ] Build host-service, kill network (`sudo ifconfig en0 down` or unplug Ethernet) while a terminal is open
- [ ] Confirm host-service stays up: `pgrep -fl host-service.js` shows the same pid before and after
- [ ] Confirm `host-service.log` shows `[host-service:tunnel] connect failed: ...` followed by `reconnecting in Nms (attempt N)` — no Node crash footer
- [ ] Restore network, confirm tunnel reconnects (`connected to relay for host ...`) and existing terminal WebSockets keep working
- [ ] Sanity: typecheck passes for `@superset/host-service` (verified locally)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent `@superset/host-service` from crashing on DNS/network failures during tunnel reconnect by catching connect errors and routing them through the backoff, so terminals survive sleep.

- **Bug Fixes**
  - Wrapped `TunnelClient.connect()` in try/catch; on any error (auth token fetch, WebSocket init), log `[host-service:tunnel] connect failed: ...`, clear the socket, and call `scheduleReconnect()`.
  - Avoids host-service process crashes that orphan PTYs and cause dead-port terminal reconnect loops.

<sup>Written for commit 4b16dabab23662c52f8011232eef36bd7411670e. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3861?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tunnel connection stability: all connection failures are now properly caught, logged, and trigger automatic reconnection attempts.
  * Ensures transient errors (including token or network issues) no longer leave the tunnel in a broken state, reducing downtime and improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->