### PR TITLE
feat(billing): 14-day free trial for Pro

### DIFF
--- a/apps/api/scripts/clone-stripe-prod-to-test.ts
+++ b/apps/api/scripts/clone-stripe-prod-to-test.ts
@@ -1,0 +1,188 @@
+#!/usr/bin/env bun
+/**
+ * Creates the same Products + Prices we use in prod inside Stripe test mode,
+ * so local development uses identically-shaped data without touching prod.
+ *
+ * The prod plan structure is hardcoded in `PLANS` below — keep it in sync if
+ * prod prices change.
+ *
+ * Idempotent: skips test products/prices that already match by name + amount + interval.
+ *
+ * Reads `STRIPE_TEST_KEY` from the workspace `.env` at the repo root.
+ *
+ * Usage (from repo root):
+ *   bun apps/api/scripts/clone-stripe-prod-to-test.ts
+ *
+ * Output: prints the test-mode env vars to paste into your local `.env`.
+ */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { config } from "dotenv";
+import Stripe from "stripe";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+
+config({
+	path: path.resolve(scriptDir, "../../../.env"),
+	quiet: true,
+});
+
+interface PlanToClone {
+	productName: string;
+	productDescription?: string;
+	prices: Array<{
+		label: string;
+		envVar: string;
+		amount: number;
+		currency: string;
+		interval: "month" | "year";
+	}>;
+}
+
+const PLANS: PlanToClone[] = [
+	{
+		productName: "Pro",
+		productDescription:
+			"Per-seat pricing for teams. Includes mobile app, Linear integration, team collaboration, and priority support.",
+		prices: [
+			{
+				label: "Pro Monthly ($20/user/month)",
+				envVar: "STRIPE_PRO_MONTHLY_PRICE_ID",
+				amount: 2000,
+				currency: "usd",
+				interval: "month",
+			},
+			{
+				label: "Pro Yearly ($15/user/month, billed yearly)",
+				envVar: "STRIPE_PRO_YEARLY_PRICE_ID",
+				amount: 18000,
+				currency: "usd",
+				interval: "year",
+			},
+		],
+	},
+	{
+		productName: "Enterprise",
+		prices: [
+			{
+				label: "Enterprise Yearly (placeholder $0)",
+				envVar: "STRIPE_ENTERPRISE_YEARLY_PRICE_ID",
+				amount: 0,
+				currency: "usd",
+				interval: "year",
+			},
+		],
+	},
+];
+
+function assertKey(
+	value: string | undefined,
+	name: string,
+	prefix: string,
+): asserts value is string {
+	if (!value) {
+		console.error(`Missing env var: ${name}`);
+		process.exit(1);
+	}
+	if (!value.startsWith(prefix)) {
+		console.error(
+			`${name} must start with "${prefix}" — got "${value.slice(0, 8)}..."`,
+		);
+		process.exit(1);
+	}
+}
+
+const testKey = process.env.STRIPE_TEST_KEY;
+assertKey(testKey, "STRIPE_TEST_KEY", "sk_test_");
+
+const test = new Stripe(testKey);
+
+async function findOrCreateTestProduct(
+	plan: PlanToClone,
+): Promise<Stripe.Product> {
+	const existing = await test.products.list({ limit: 100 });
+	const match = existing.data.find(
+		(p) => p.name === plan.productName && p.active,
+	);
+	if (match) {
+		console.log(`  ✓ test product "${plan.productName}" exists: ${match.id}`);
+		return match;
+	}
+	const created = await test.products.create({
+		name: plan.productName,
+		description: plan.productDescription,
+	});
+	console.log(`  + created test product "${plan.productName}": ${created.id}`);
+	return created;
+}
+
+async function findOrCreateTestPrice(
+	productId: string,
+	amount: number,
+	currency: string,
+	interval: "month" | "year",
+): Promise<Stripe.Price> {
+	const existing = await test.prices.list({ product: productId, limit: 100 });
+	const match = existing.data.find(
+		(p) =>
+			p.unit_amount === amount &&
+			p.currency === currency &&
+			p.recurring?.interval === interval &&
+			p.active,
+	);
+	if (match) return match;
+	return test.prices.create({
+		product: productId,
+		unit_amount: amount,
+		currency,
+		recurring: { interval },
+	});
+}
+
+async function main() {
+	const testAccount = await test.accounts.retrieve();
+	console.log(
+		`Test account: ${testAccount.id} (${testAccount.settings?.dashboard?.display_name ?? "unknown"})`,
+	);
+	console.log();
+
+	const envLines: string[] = [];
+
+	for (const plan of PLANS) {
+		console.log(`Plan: ${plan.productName}`);
+		const testProduct = await findOrCreateTestProduct(plan);
+
+		for (const price of plan.prices) {
+			const testPrice = await findOrCreateTestPrice(
+				testProduct.id,
+				price.amount,
+				price.currency,
+				price.interval,
+			);
+			console.log(`  → ${price.label}: ${testPrice.id}`);
+			envLines.push(`${price.envVar}=${testPrice.id}`);
+		}
+		console.log();
+	}
+
+	console.log("─".repeat(60));
+	console.log("Add these to your local .env (test mode):");
+	console.log();
+	for (const line of envLines) console.log(line);
+	console.log();
+	console.log(
+		"Make sure STRIPE_SECRET_KEY in your .env matches STRIPE_TEST_KEY,",
+	);
+	console.log(
+		"then run `stripe listen --forward-to http://localhost:PORT/api/auth/stripe/webhook`",
+	);
+	console.log(
+		"and put the printed whsec_... in STRIPE_WEBHOOK_SECRET in your .env.",
+	);
+}
+
+main().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/apps/api/src/app/api/integrations/slack/events/process-assistant-message/process-assistant-message.ts
+++ b/apps/api/src/app/api/integrations/slack/events/process-assistant-message/process-assistant-message.ts
@@ -4,7 +4,8 @@ import {
 	subscriptions,
 	usersSlackUsers,
 } from "@superset/db/schema";
-import { and, eq } from "drizzle-orm";
+import { ACTIVE_SUBSCRIPTION_STATUSES } from "@superset/shared/billing";
+import { and, eq, inArray } from "drizzle-orm";
 import { posthog } from "@/lib/analytics";
 import { generateConnectUrl } from "../utils/generate-connect-url";
 import {
@@ -89,7 +90,7 @@ export async function processAssistantMessage({
 		db.query.subscriptions.findFirst({
 			where: and(
 				eq(subscriptions.referenceId, connection.organizationId),
-				eq(subscriptions.status, "active"),
+				inArray(subscriptions.status, [...ACTIVE_SUBSCRIPTION_STATUSES]),
 			),
 			columns: { id: true },
 		}),

--- a/apps/api/src/app/api/integrations/slack/events/process-mention/process-mention.ts
+++ b/apps/api/src/app/api/integrations/slack/events/process-mention/process-mention.ts
@@ -4,7 +4,8 @@ import {
 	subscriptions,
 	usersSlackUsers,
 } from "@superset/db/schema";
-import { and, eq } from "drizzle-orm";
+import { ACTIVE_SUBSCRIPTION_STATUSES } from "@superset/shared/billing";
+import { and, eq, inArray } from "drizzle-orm";
 import { posthog } from "@/lib/analytics";
 import { generateConnectUrl } from "../utils/generate-connect-url";
 import {
@@ -88,7 +89,7 @@ export async function processSlackMention({
 		db.query.subscriptions.findFirst({
 			where: and(
 				eq(subscriptions.referenceId, connection.organizationId),
-				eq(subscriptions.status, "active"),
+				inArray(subscriptions.status, [...ACTIVE_SUBSCRIPTION_STATUSES]),
 			),
 			columns: { id: true },
 		}),

--- a/apps/desktop/src/renderer/components/Paywall/Paywall.tsx
+++ b/apps/desktop/src/renderer/components/Paywall/Paywall.tsx
@@ -7,6 +7,7 @@ import { FeaturePreview } from "./components/FeaturePreview";
 import { FeatureSidebar } from "./components/FeatureSidebar";
 import type { GatedFeature } from "./constants";
 import { FEATURE_ID_MAP, PRO_FEATURES } from "./constants";
+import { useHasTrialed } from "./useHasTrialed";
 
 type PaywallOptions = {
 	feature: GatedFeature;
@@ -17,6 +18,7 @@ let showPaywallFn: ((options: PaywallOptions) => void) | null = null;
 
 export const Paywall = () => {
 	const navigate = useNavigate();
+	const hasTrialed = useHasTrialed();
 	const [paywallOptions, setPaywallOptions] = useState<PaywallOptions | null>(
 		null,
 	);
@@ -139,7 +141,9 @@ export const Paywall = () => {
 					<Button variant="outline" onClick={() => handleOpenChange(false)}>
 						Cancel
 					</Button>
-					<Button onClick={handleUpgrade}>Get Superset Pro</Button>
+					<Button onClick={handleUpgrade}>
+						{hasTrialed ? "Get Superset Pro" : "Start 14-day free trial"}
+					</Button>
 				</div>
 			</DialogContent>
 		</Dialog>

--- a/apps/desktop/src/renderer/components/Paywall/useHasTrialed.ts
+++ b/apps/desktop/src/renderer/components/Paywall/useHasTrialed.ts
@@ -1,0 +1,11 @@
+import { useLiveQuery } from "@tanstack/react-db";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+
+export function useHasTrialed(): boolean {
+	const collections = useCollections();
+	const { data } = useLiveQuery(
+		(q) => q.from({ subscriptions: collections.subscriptions }),
+		[collections],
+	);
+	return Boolean(data?.some((s) => s.trialEnd != null));
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown/OrganizationDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown/OrganizationDropdown.tsx
@@ -14,6 +14,7 @@ import {
 } from "@superset/ui/dropdown-menu";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useNavigate } from "@tanstack/react-router";
+import { differenceInCalendarDays } from "date-fns";
 import { FaDiscord, FaGithub, FaXTwitter } from "react-icons/fa6";
 import { FiUsers } from "react-icons/fi";
 import {
@@ -54,6 +55,20 @@ export function OrganizationDropdown({
 	const activeOrganization = organizations?.find(
 		(o) => o.id === activeOrganizationId,
 	);
+
+	const { data: subscriptionsData } = useLiveQuery(
+		(q) => q.from({ subscriptions: collections.subscriptions }),
+		[collections],
+	);
+	const trialingSub = subscriptionsData?.find(
+		(s) => s.status === "trialing" && s.trialEnd != null,
+	);
+	const trialDaysLeft = trialingSub?.trialEnd
+		? Math.max(
+				0,
+				differenceInCalendarDays(new Date(trialingSub.trialEnd), new Date()),
+			)
+		: null;
 
 	const userEmail = session?.user?.email;
 
@@ -123,6 +138,21 @@ export function OrganizationDropdown({
 		<DropdownMenu>
 			<DropdownMenuTrigger asChild>{triggerButton}</DropdownMenuTrigger>
 			<DropdownMenuContent align={contentAlign} className="w-56">
+				{trialDaysLeft != null && (
+					<>
+						<DropdownMenuItem
+							onSelect={() => navigate({ to: "/settings/billing" })}
+							className="gap-2"
+						>
+							<span className="size-2 rounded-full bg-amber-500" />
+							<span>
+								Trial: {trialDaysLeft} {trialDaysLeft === 1 ? "day" : "days"}{" "}
+								left
+							</span>
+						</DropdownMenuItem>
+						<DropdownMenuSeparator />
+					</>
+				)}
 				{/* Organization */}
 				<DropdownMenuItem
 					onSelect={() => navigate({ to: "/settings/account" })}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/BillingOverview.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/BillingOverview.tsx
@@ -1,3 +1,4 @@
+import { isActiveSubscriptionStatus } from "@superset/shared/billing";
 import { Button } from "@superset/ui/button";
 import { toast } from "@superset/ui/sonner";
 import { useLiveQuery } from "@tanstack/react-db";
@@ -43,8 +44,11 @@ export function BillingOverview({ visibleItems }: BillingOverviewProps) {
 		(q) => q.from({ subscriptions: collections.subscriptions }),
 		[collections],
 	);
-	const subscriptionData = subscriptionsData?.find(
-		(s) => s.status === "active",
+	const subscriptionData = subscriptionsData?.find((s) =>
+		isActiveSubscriptionStatus(s.status),
+	);
+	const hasTrialed = Boolean(
+		subscriptionsData?.some((s) => s.trialEnd != null),
 	);
 
 	// Derive plan from subscription data (not session, which can be stale)
@@ -69,6 +73,7 @@ export function BillingOverview({ visibleItems }: BillingOverviewProps) {
 		if (!activeOrgId || memberCount === undefined) return;
 
 		setIsUpgrading(true);
+		const successFlag = hasTrialed ? "true" : "trial";
 		try {
 			await authClient.subscription.upgrade(
 				{
@@ -76,7 +81,7 @@ export function BillingOverview({ visibleItems }: BillingOverviewProps) {
 					referenceId: activeOrgId,
 					annual,
 					seats: memberCount,
-					successUrl: `${env.NEXT_PUBLIC_WEB_URL}/settings/billing?success=true`,
+					successUrl: `${env.NEXT_PUBLIC_WEB_URL}/settings/billing?success=${successFlag}`,
 					cancelUrl: env.NEXT_PUBLIC_WEB_URL,
 					disableRedirect: true,
 				},
@@ -166,11 +171,14 @@ export function BillingOverview({ visibleItems }: BillingOverviewProps) {
 							isRestoring={isRestoring}
 							cancelAt={subscriptionData?.cancelAt}
 							periodEnd={subscriptionData?.periodEnd}
+							subscriptionStatus={subscriptionData?.status}
+							trialEnd={subscriptionData?.trialEnd}
 						/>
 						{plan === "free" && (
 							<UpgradeCard
 								onUpgrade={() => handleUpgrade(false)}
 								isUpgrading={isUpgrading || memberCount === undefined}
+								hasTrialed={hasTrialed}
 							/>
 						)}
 					</>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/CurrentPlanCard/CurrentPlanCard.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/CurrentPlanCard/CurrentPlanCard.tsx
@@ -12,6 +12,8 @@ interface CurrentPlanCardProps {
 	isRestoring?: boolean;
 	cancelAt?: Date | null;
 	periodEnd?: Date | null;
+	subscriptionStatus?: string | null;
+	trialEnd?: Date | null;
 }
 
 export function CurrentPlanCard({
@@ -22,11 +24,14 @@ export function CurrentPlanCard({
 	isRestoring,
 	cancelAt,
 	periodEnd,
+	subscriptionStatus,
+	trialEnd,
 }: CurrentPlanCardProps) {
 	const plan = PLANS[currentPlan];
 	const isPaidPlan = currentPlan !== "free";
 	const isEnterprise = currentPlan === "enterprise";
 	const isCancelingAtPeriodEnd = isPaidPlan && !isEnterprise && !!cancelAt;
+	const isTrialing = subscriptionStatus === "trialing" && !!trialEnd;
 
 	return (
 		<Card className="gap-0 rounded-lg border-border/60 py-0 shadow-none">
@@ -35,7 +40,14 @@ export function CurrentPlanCard({
 					<div className="min-w-0 flex-1">
 						<div className="flex items-center gap-2 mb-1">
 							<span className="text-sm font-medium">{plan.name} plan</span>
-							{isCancelingAtPeriodEnd && cancelAt ? (
+							{isTrialing && trialEnd ? (
+								<Badge
+									variant="outline"
+									className="text-amber-600 border-amber-600/30"
+								>
+									Trialing
+								</Badge>
+							) : isCancelingAtPeriodEnd && cancelAt ? (
 								<Badge
 									variant="outline"
 									className="text-amber-600 border-amber-600/30"
@@ -47,13 +59,15 @@ export function CurrentPlanCard({
 							)}
 						</div>
 						<p className="text-xs text-muted-foreground">
-							{isCancelingAtPeriodEnd
-								? "Your plan will be downgraded to Free at the end of the billing period"
-								: isEnterprise
-									? "Managed by your organization admin"
-									: isPaidPlan && periodEnd
-										? `Renews ${format(new Date(periodEnd), "MMMM d, yyyy")}`
-										: plan.description}
+							{isTrialing && trialEnd
+								? `Trial ends ${format(new Date(trialEnd), "MMMM d, yyyy")} — your card will be charged then`
+								: isCancelingAtPeriodEnd
+									? "Your plan will be downgraded to Free at the end of the billing period"
+									: isEnterprise
+										? "Managed by your organization admin"
+										: isPaidPlan && periodEnd
+											? `Renews ${format(new Date(periodEnd), "MMMM d, yyyy")}`
+											: plan.description}
 						</p>
 					</div>
 					{isPaidPlan &&

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/UpgradeCard/UpgradeCard.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/components/UpgradeCard/UpgradeCard.tsx
@@ -7,21 +7,29 @@ import { PLANS } from "../../../../constants";
 interface UpgradeCardProps {
 	onUpgrade: () => void;
 	isUpgrading: boolean;
+	hasTrialed: boolean;
 }
 
-export function UpgradeCard({ onUpgrade, isUpgrading }: UpgradeCardProps) {
+export function UpgradeCard({
+	onUpgrade,
+	isUpgrading,
+	hasTrialed,
+}: UpgradeCardProps) {
 	const plan = PLANS.pro;
+	const ctaLabel = hasTrialed ? "Upgrade now" : "Start free trial";
+	const headline = hasTrialed
+		? `Upgrade to ${plan.name} plan`
+		: `Try ${plan.name} free for 14 days`;
 
 	return (
 		<Card className="gap-0 rounded-lg border-border/60 py-0 shadow-none">
 			<CardContent className="px-5 py-4">
 				<div className="flex flex-wrap items-center justify-between gap-4">
 					<div>
-						<div className="text-sm font-medium">
-							Upgrade to {plan.name} plan
-						</div>
+						<div className="text-sm font-medium">{headline}</div>
 						<p className="text-xs text-muted-foreground">
 							${plan.price?.monthly ? plan.price.monthly / 100 : 0} per user/mo
+							{hasTrialed ? "" : " after trial"}
 						</p>
 					</div>
 					<div className="flex items-center gap-3">
@@ -29,7 +37,7 @@ export function UpgradeCard({ onUpgrade, isUpgrading }: UpgradeCardProps) {
 							<Link to="/settings/billing/plans">View all plans</Link>
 						</Button>
 						<Button onClick={onUpgrade} size="sm" disabled={isUpgrading}>
-							{isUpgrading ? "Redirecting..." : "Upgrade now"}
+							{isUpgrading ? "Redirecting..." : ctaLabel}
 						</Button>
 					</div>
 				</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/plans/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/plans/page.tsx
@@ -1,3 +1,5 @@
+import { isActiveSubscriptionStatus } from "@superset/shared/billing";
+import { Badge } from "@superset/ui/badge";
 import { Button } from "@superset/ui/button";
 import { toast } from "@superset/ui/sonner";
 import { Switch } from "@superset/ui/switch";
@@ -49,7 +51,7 @@ type ComparisonValue = string | boolean | null;
 type ComparisonRow = {
 	label: string;
 	values: ComparisonValue[];
-	comingSoon?: boolean;
+	badge?: { label: string; variant: "default" | "secondary" };
 };
 
 type ComparisonSection = {
@@ -135,18 +137,22 @@ const COMPARISON_SECTIONS: ComparisonSection[] = [
 				values: [true, true, true],
 			},
 			{
-				label: "GitHub integration",
-				values: [true, true, true],
+				label: "Remote workspaces",
+				values: [null, true, true],
+				badge: { label: "Beta", variant: "default" },
 			},
 			{
-				label: "Cloud workspaces",
+				label: "Automations",
 				values: [null, true, true],
-				comingSoon: true,
 			},
 			{
 				label: "Mobile app",
 				values: [null, true, true],
-				comingSoon: true,
+				badge: { label: "Coming soon", variant: "secondary" },
+			},
+			{
+				label: "GitHub integration",
+				values: [true, true, true],
 			},
 			{
 				label: "Linear integration",
@@ -218,8 +224,11 @@ function PlansPage() {
 		(q) => q.from({ subscriptions: collections.subscriptions }),
 		[collections],
 	);
-	const subscriptionData = subscriptionsData?.find(
-		(s) => s.status === "active",
+	const subscriptionData = subscriptionsData?.find((s) =>
+		isActiveSubscriptionStatus(s.status),
+	);
+	const hasTrialed = Boolean(
+		subscriptionsData?.some((s) => s.trialEnd != null),
 	);
 
 	const currentPlan: PlanTier = (subscriptionData?.plan as PlanTier) ?? "free";
@@ -305,6 +314,7 @@ function PlansPage() {
 		}
 
 		setIsUpgrading(true);
+		const successFlag = hasTrialed ? "true" : "trial";
 		try {
 			await authClient.subscription.upgrade(
 				{
@@ -312,7 +322,7 @@ function PlansPage() {
 					referenceId: activeOrgId,
 					annual: isYearly,
 					seats: memberCount,
-					successUrl: `${env.NEXT_PUBLIC_WEB_URL}/settings/billing?success=true`,
+					successUrl: `${env.NEXT_PUBLIC_WEB_URL}/settings/billing?success=${successFlag}`,
 					cancelUrl: env.NEXT_PUBLIC_WEB_URL,
 					returnUrl: env.NEXT_PUBLIC_WEB_URL,
 					disableRedirect: true,
@@ -483,6 +493,17 @@ function PlansPage() {
 												variant: "outline" as const,
 											},
 										];
+									} else if (plan.id === "pro" && currentPlan === "free") {
+										const upgradeLabel = hasTrialed
+											? "Upgrade"
+											: "Start 14-day free trial";
+										planActions = [
+											{
+												label: upgradeLabel,
+												action: "upgrade" as const,
+												variant: "default" as const,
+											},
+										];
 									} else {
 										planActions = plan.actions;
 									}
@@ -531,6 +552,9 @@ function PlansPage() {
 										);
 									}
 
+									const showTrialDisclaimer =
+										plan.id === "pro" && currentPlan === "free" && !hasTrialed;
+
 									return (
 										<div key={plan.id} className="px-4 py-3">
 											<div className="flex flex-col gap-2">
@@ -553,6 +577,11 @@ function PlansPage() {
 														{action.label}
 													</Button>
 												))}
+												{showTrialDisclaimer && (
+													<p className="text-[11px] leading-snug text-muted-foreground">
+														We'll remind you 3 days before your trial ends.
+													</p>
+												)}
 											</div>
 										</div>
 									);
@@ -583,10 +612,13 @@ function PlansPage() {
 										<Fragment key={row.label}>
 											<div className="flex items-center gap-1.5 px-2 py-2.5 text-xs text-muted-foreground">
 												{row.label}
-												{row.comingSoon && (
-													<span className="text-[10px] text-muted-foreground/60">
-														(Coming Soon)
-													</span>
+												{row.badge && (
+													<Badge
+														variant={row.badge.variant}
+														className="px-1.5 py-0 text-[10px] font-medium"
+													>
+														{row.badge.label}
+													</Badge>
 												)}
 											</div>
 											{row.values.map((value, valueIndex) => (

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/members/components/MembersSettings/components/InviteMemberButton/InviteMemberButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/members/components/MembersSettings/components/InviteMemberButton/InviteMemberButton.tsx
@@ -4,9 +4,12 @@ import {
 } from "@superset/shared/auth";
 import { alert } from "@superset/ui/atoms/Alert";
 import { Button } from "@superset/ui/button";
+import { useLiveQuery } from "@tanstack/react-db";
+import { format } from "date-fns";
 import { useState } from "react";
 import { HiOutlinePlus } from "react-icons/hi2";
 import { GATED_FEATURES, usePaywall } from "renderer/components/Paywall";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { InviteMemberDialog } from "./components/InviteMemberDialog";
 
 interface InviteMemberButtonProps {
@@ -22,6 +25,15 @@ export function InviteMemberButton({
 }: InviteMemberButtonProps) {
 	const [open, setOpen] = useState(false);
 	const { gateFeature } = usePaywall();
+	const collections = useCollections();
+
+	const { data: subscriptionsData } = useLiveQuery(
+		(q) => q.from({ subscriptions: collections.subscriptions }),
+		[collections],
+	);
+	const trialingSub = subscriptionsData?.find(
+		(s) => s.status === "trialing" && s.trialEnd != null,
+	);
 
 	const invitableRoles = getInvitableRoles(currentUserRole);
 
@@ -32,10 +44,17 @@ export function InviteMemberButton({
 
 	const handleClick = () => {
 		gateFeature(GATED_FEATURES.INVITE_MEMBERS, () => {
+			const description =
+				trialingSub?.trialEnd != null
+					? `Adding members will increase your subscription cost after your trial ends on ${format(
+							new Date(trialingSub.trialEnd),
+							"MMMM d, yyyy",
+						)}.`
+					: "Adding members will increase your subscription cost, prorated to your billing cycle.";
+
 			alert({
 				title: "This will affect your billing",
-				description:
-					"Adding members will increase your subscription cost, prorated to your billing cycle.",
+				description,
 				actions: [
 					{ label: "Cancel", variant: "outline", onClick: () => {} },
 					{ label: "Continue", onClick: () => setOpen(true) },

--- a/apps/marketing/src/app/pricing/components/PricingHero/PricingHero.tsx
+++ b/apps/marketing/src/app/pricing/components/PricingHero/PricingHero.tsx
@@ -14,8 +14,9 @@ export function PricingHero() {
 					Simple pricing for every team
 				</h1>
 				<p className="text-muted-foreground mt-3 max-w-lg">
-					Start free. Upgrade when your team outgrows it. Enterprise plans for
-					organizations with advanced security and compliance needs.
+					Start free. Try Pro free for 14 days when your team outgrows it.
+					Enterprise plans for organizations with advanced security and
+					compliance needs.
 				</p>
 
 				<GridCross className="bottom-0 left-0" />

--- a/apps/marketing/src/app/pricing/constants.ts
+++ b/apps/marketing/src/app/pricing/constants.ts
@@ -49,7 +49,7 @@ export const PRICING_TIERS: PricingTier[] = [
 	{
 		id: "pro",
 		name: "Pro",
-		description: "For teams that need more power",
+		description: "For teams that need more power. 14-day free trial included.",
 		price: {
 			kind: "variable",
 			monthly: {
@@ -184,6 +184,11 @@ export const PRICING_FAQ_ITEMS: FAQItem[] = [
 		question: "How does Pro pricing work?",
 		answer:
 			"Pro is $20 per user/month billed monthly, or $15 per user/month billed yearly (a 25% discount). You're billed per active seat on your team.",
+	},
+	{
+		question: "Is there a free trial for Pro?",
+		answer:
+			"Yes — try Pro free for 14 days. You'll need a card to start the trial, and we'll only charge you when the trial ends. Cancel anytime from billing settings.",
 	},
 	{
 		question: "Can I switch plans or cancel anytime?",

--- a/apps/web/src/app/(dashboard-legacy)/settings/billing/page.tsx
+++ b/apps/web/src/app/(dashboard-legacy)/settings/billing/page.tsx
@@ -12,16 +12,20 @@ export default async function BillingPage({
 	searchParams: Promise<{ success?: string }>;
 }) {
 	const { success } = await searchParams;
-	const isSuccess = success === "true";
+	const isSuccess = success === "true" || success === "trial";
+	const isTrialStart = success === "trial";
 
 	if (isSuccess) {
 		return (
 			<div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
 				<HiCheckCircle className="h-12 w-12 text-green-500" />
-				<h1 className="text-2xl font-semibold">Payment Successful</h1>
+				<h1 className="text-2xl font-semibold">
+					{isTrialStart ? "Your free trial has started" : "Payment Successful"}
+				</h1>
 				<p className="text-muted-foreground">
-					Your subscription has been activated. You can now access all Pro
-					features.
+					{isTrialStart
+						? "You have 14 days of Pro access. We'll charge your card when the trial ends — cancel anytime in billing."
+						: "Your subscription has been activated. You can now access all Pro features."}
 				</p>
 			</div>
 		);

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -19,6 +19,10 @@
 		"./stripe": {
 			"types": "./src/stripe.ts",
 			"default": "./src/stripe.ts"
+		},
+		"./utils": {
+			"types": "./src/utils/index.ts",
+			"default": "./src/utils/index.ts"
 		}
 	},
 	"scripts": {

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -15,14 +15,16 @@ import { OrganizationInvitationEmail } from "@superset/email/emails/organization
 import { PaymentFailedEmail } from "@superset/email/emails/payment-failed";
 import { SubscriptionCancelledEmail } from "@superset/email/emails/subscription-cancelled";
 import { SubscriptionStartedEmail } from "@superset/email/emails/subscription-started";
+import { TrialEndingEmail } from "@superset/email/emails/trial-ending";
 import { canInvite, type OrganizationRole } from "@superset/shared/auth";
+import { ACTIVE_SUBSCRIPTION_STATUSES } from "@superset/shared/billing";
 import { getTrustedVercelPreviewOrigins } from "@superset/shared/vercel-preview-origins";
 import { Client } from "@upstash/qstash";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { bearer, customSession, organization } from "better-auth/plugins";
 import { jwt } from "better-auth/plugins/jwt";
-import { and, count, desc, eq, sql } from "drizzle-orm";
+import { and, count, desc, eq, inArray, sql } from "drizzle-orm";
 import type Stripe from "stripe";
 import { env } from "./env";
 import { acceptInvitationEndpoint } from "./lib/accept-invitation-endpoint";
@@ -34,7 +36,11 @@ import {
 	type SessionOrganizationContext,
 } from "./lib/resolve-session-organization-state";
 import { stripeClient } from "./stripe";
-import { formatPrice, getOrganizationOwners } from "./utils";
+import {
+	formatPrice,
+	getOrganizationOwners,
+	hasTrialedSubscription,
+} from "./utils";
 
 const qstash = new Client({ token: env.QSTASH_TOKEN });
 
@@ -348,7 +354,7 @@ export const auth = betterAuth({
 					const subscription = await db.query.subscriptions.findFirst({
 						where: and(
 							eq(subscriptions.referenceId, organization.id),
-							eq(subscriptions.status, "active"),
+							inArray(subscriptions.status, [...ACTIVE_SUBSCRIPTION_STATUSES]),
 						),
 					});
 
@@ -372,7 +378,7 @@ export const auth = betterAuth({
 					const subscription = await db.query.subscriptions.findFirst({
 						where: and(
 							eq(subscriptions.referenceId, organization.id),
-							eq(subscriptions.status, "active"),
+							inArray(subscriptions.status, [...ACTIVE_SUBSCRIPTION_STATUSES]),
 						),
 					});
 
@@ -487,7 +493,7 @@ export const auth = betterAuth({
 					const subscription = await db.query.subscriptions.findFirst({
 						where: and(
 							eq(subscriptions.referenceId, organization.id),
-							eq(subscriptions.status, "active"),
+							inArray(subscriptions.status, [...ACTIVE_SUBSCRIPTION_STATUSES]),
 						),
 					});
 
@@ -580,7 +586,7 @@ export const auth = betterAuth({
 				const subscription = await db.query.subscriptions.findFirst({
 					where: and(
 						eq(subscriptions.referenceId, activeOrganizationId),
-						eq(subscriptions.status, "active"),
+						inArray(subscriptions.status, [...ACTIVE_SUBSCRIPTION_STATUSES]),
 					),
 				});
 				plan = subscription?.plan ?? null;
@@ -634,7 +640,9 @@ export const auth = betterAuth({
 						const subscription = await db.query.subscriptions.findFirst({
 							where: and(
 								eq(subscriptions.referenceId, referenceId),
-								eq(subscriptions.status, "active"),
+								inArray(subscriptions.status, [
+									...ACTIVE_SUBSCRIPTION_STATUSES,
+								]),
 							),
 						});
 						if (subscription?.plan === "enterprise") return false;
@@ -666,6 +674,11 @@ export const auth = betterAuth({
 						),
 					});
 
+					const trialEligible =
+						plan.name === "pro" &&
+						org?.id != null &&
+						!(await hasTrialedSubscription(org.id));
+
 					return {
 						params: {
 							customer: org?.stripeCustomerId ?? undefined,
@@ -675,6 +688,9 @@ export const auth = betterAuth({
 								organizationId: org?.id ?? "",
 								initiatedByUserId: user.id,
 							},
+							...(trialEligible && {
+								subscription_data: { trial_period_days: 14 },
+							}),
 						},
 					};
 				},
@@ -917,6 +933,80 @@ export const auth = betterAuth({
 						} catch (error) {
 							console.error(
 								"[stripe/plan-changed] Failed to queue Slack notification:",
+								error,
+							);
+						}
+					}
+
+					if (event.type === "customer.subscription.trial_will_end") {
+						const stripeSubscription = event.data.object as Stripe.Subscription;
+
+						const customerId =
+							typeof stripeSubscription.customer === "string"
+								? stripeSubscription.customer
+								: stripeSubscription.customer.id;
+
+						const org = await db.query.organizations.findFirst({
+							where: eq(authSchema.organizations.stripeCustomerId, customerId),
+						});
+
+						if (!org?.stripeCustomerId) return;
+
+						const subscription = await db.query.subscriptions.findFirst({
+							where: eq(subscriptions.referenceId, org.id),
+						});
+
+						const trialEndUnix = stripeSubscription.trial_end;
+						if (!trialEndUnix) return;
+						const trialEndsAt = new Date(trialEndUnix * 1000);
+
+						const item = stripeSubscription.items.data[0];
+						const interval = item?.price?.recurring?.interval;
+						const billingInterval: "monthly" | "yearly" =
+							interval === "year" ? "yearly" : "monthly";
+						const pricePerSeat = item?.price?.unit_amount ?? 0;
+						const currency = item?.price?.currency ?? "usd";
+						const seatCount = item?.quantity ?? subscription?.seats ?? 1;
+						const amount = formatPrice(pricePerSeat * seatCount, currency);
+
+						const owners = await getOrganizationOwners(org.id);
+
+						const portalSession =
+							await stripeClient.billingPortal.sessions.create({
+								customer: org.stripeCustomerId,
+								return_url: env.NEXT_PUBLIC_WEB_URL,
+							});
+
+						await resend.batch.send(
+							owners.map((owner) => ({
+								from: "Superset <noreply@superset.sh>",
+								to: owner.email,
+								subject: `Your Superset trial ends in 3 days`,
+								react: TrialEndingEmail({
+									ownerName: owner.name,
+									organizationName: org.name,
+									planName: subscription?.plan ?? "Pro",
+									trialEndsAt,
+									amount,
+									billingInterval,
+									billingPortalUrl: portalSession.url,
+								}),
+							})),
+						);
+
+						try {
+							await qstash.publishJSON({
+								url: NOTIFY_SLACK_URL,
+								body: {
+									eventType: "trial_will_end",
+									stripeSubscriptionId: stripeSubscription.id,
+									trialEndsAt: trialEndUnix,
+								},
+								retries: 3,
+							});
+						} catch (error) {
+							console.error(
+								"[stripe/trial-will-end] Failed to queue Slack notification:",
 								error,
 							);
 						}

--- a/packages/auth/src/utils/billing.ts
+++ b/packages/auth/src/utils/billing.ts
@@ -1,7 +1,20 @@
 import { db } from "@superset/db/client";
-import { members } from "@superset/db/schema";
+import { members, subscriptions } from "@superset/db/schema";
 import * as authSchema from "@superset/db/schema/auth";
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNotNull } from "drizzle-orm";
+
+export async function hasTrialedSubscription(
+	organizationId: string,
+): Promise<boolean> {
+	const row = await db.query.subscriptions.findFirst({
+		where: and(
+			eq(subscriptions.referenceId, organizationId),
+			isNotNull(subscriptions.trialEnd),
+		),
+		columns: { id: true },
+	});
+	return row != null;
+}
 
 export async function getOrganizationOwners(organizationId: string) {
 	return db

--- a/packages/auth/src/utils/index.ts
+++ b/packages/auth/src/utils/index.ts
@@ -1,1 +1,5 @@
-export { formatPrice, getOrganizationOwners } from "./billing";
+export {
+	formatPrice,
+	getOrganizationOwners,
+	hasTrialedSubscription,
+} from "./billing";

--- a/packages/email/src/emails/trial-ending.tsx
+++ b/packages/email/src/emails/trial-ending.tsx
@@ -1,0 +1,88 @@
+import { Heading, Link, Section, Text } from "@react-email/components";
+import { Button, StandardLayout } from "../components";
+
+interface TrialEndingEmailProps {
+	ownerName?: string | null;
+	organizationName: string;
+	planName: string;
+	trialEndsAt: Date;
+	amount: string;
+	billingInterval: "monthly" | "yearly";
+	billingPortalUrl?: string;
+}
+
+export function TrialEndingEmail({
+	ownerName = "there",
+	organizationName = "Acme Inc",
+	planName = "Pro",
+	trialEndsAt = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000),
+	amount = "$10.00",
+	billingInterval = "monthly",
+	billingPortalUrl,
+}: TrialEndingEmailProps) {
+	const intervalText = billingInterval === "monthly" ? "month" : "year";
+	const formattedDate = trialEndsAt.toLocaleDateString("en-US", {
+		month: "long",
+		day: "numeric",
+		year: "numeric",
+	});
+
+	return (
+		<StandardLayout preview={`Your Superset ${planName} trial ends in 3 days`}>
+			<Heading className="text-lg font-normal leading-7 mb-8 text-foreground text-center">
+				Your trial ends in 3 days
+			</Heading>
+
+			<Text className="text-base leading-[26px] mb-4 text-foreground">
+				Hi {ownerName ?? "there"},
+			</Text>
+
+			<Text className="text-base leading-[26px] text-foreground mb-4">
+				Your <strong>Superset {planName}</strong> trial for{" "}
+				<strong>{organizationName}</strong> ends on{" "}
+				<strong>{formattedDate}</strong>. We'll automatically charge{" "}
+				<strong>
+					{amount}/{intervalText}
+				</strong>{" "}
+				to your card on file unless you cancel before then.
+			</Text>
+
+			<Section className="bg-[#f9fafb] rounded-lg p-4 mb-4">
+				<Text className="text-sm leading-5 text-foreground m-0">
+					<strong>Plan:</strong> {planName}
+				</Text>
+				<Text className="text-sm leading-5 text-foreground m-0">
+					<strong>Billing starts:</strong> {formattedDate}
+				</Text>
+				<Text className="text-sm leading-5 text-foreground m-0">
+					<strong>Amount:</strong> {amount}/{intervalText}
+				</Text>
+			</Section>
+
+			<Text className="text-base leading-[26px] text-foreground mb-4">
+				No action needed if you'd like to keep using Superset {planName} —
+				you'll be charged automatically and your team's access continues without
+				interruption.
+			</Text>
+
+			{billingPortalUrl && (
+				<Section className="mt-6 mb-6">
+					<Button href={billingPortalUrl}>Manage subscription</Button>
+				</Section>
+			)}
+
+			<Text className="text-xs leading-5 text-muted">
+				Questions?{" "}
+				<Link
+					href="mailto:support@superset.sh"
+					className="text-primary no-underline"
+				>
+					Reach out to our team
+				</Link>{" "}
+				— we're happy to help.
+			</Text>
+		</StandardLayout>
+	);
+}
+
+export default TrialEndingEmail;

--- a/packages/trpc/src/router/billing/billing.ts
+++ b/packages/trpc/src/router/billing/billing.ts
@@ -1,4 +1,5 @@
 import { stripeClient } from "@superset/auth/stripe";
+import { hasTrialedSubscription } from "@superset/auth/utils";
 import { db } from "@superset/db/client";
 import { members, subscriptions } from "@superset/db/schema";
 import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
@@ -65,6 +66,12 @@ async function requireOwnerWithCustomer(ctx: {
 }
 
 export const billingRouter = {
+	hasTrialed: protectedProcedure.query(async ({ ctx }) => {
+		const activeOrgId = ctx.activeOrganizationId;
+		if (!activeOrgId) return false;
+		return hasTrialedSubscription(activeOrgId);
+	}),
+
 	invoices: protectedProcedure.query(async ({ ctx }) => {
 		const activeOrgId = ctx.activeOrganizationId;
 		if (!activeOrgId) {


### PR DESCRIPTION
## Summary
- Enable Better Auth's Stripe `freeTrial` (14 days) on the Pro plan, with a one-time-per-org eligibility check so existing/returning subscribers don't get the trial again.
- Make trial-aware throughout: `beforeAddMember` / `afterAddMember` / `afterRemoveMember` and `customSession` plan resolution now treat `trialing` as paid alongside `active`.
- New trial-ending reminder email (`packages/email/src/emails/trial-ending.tsx`) plus copy updates across desktop billing, web billing, marketing pricing, paywall CTA ("Start 14-day free trial"), invite-member button, and Slack upsell.
- Desktop comparison table: rename Cloud → Remote workspaces, replace `(Coming Soon)` text with Beta/Coming-soon Badges, reorder, and add an Automations row (Pro/Enterprise).
- Dev tooling: `apps/api/scripts/clone-stripe-prod-to-test.ts` clones prod Products+Prices into Stripe test mode and prints the env vars to paste into `.env`. Reads `STRIPE_TEST_KEY` from env — no secrets in source.

## Test plan
- [ ] `bun run typecheck` and `bun run lint` clean (verified locally)
- [ ] Run `bun apps/api/scripts/clone-stripe-prod-to-test.ts` to seed test-mode prices
- [ ] `stripe listen --forward-to http://localhost:5741/api/auth/stripe/webhook`
- [ ] As a fresh org owner, click upgrade in desktop → Stripe checkout shows "14-day trial"
- [ ] After checkout, `subscriptions.status='trialing'` and `trial_end` is ~14d out; UI reflects Pro features
- [ ] Add a 2nd member during trial — `beforeAddMember` allows it (would have blocked under "active"-only filter)
- [ ] Trigger `customer.subscription.trial_will_end` → reminder email renders
- [ ] Cancel during trial → access ends at `trial_end`, no charge
- [ ] Re-subscribe same org → no second trial granted (eligibility check)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce a 14-day free trial for the Pro plan with a one-time-per-org eligibility check. Trialing orgs are treated as paid across auth, gating, Slack, and UI, and owners get a trial-ending reminder email.

- **New Features**
  - Billing/auth: Pro upgrades grant a 14-day trial when eligible; `trialing` is considered active for gating, seat sync, and session plan resolution. Adds `billing.hasTrialed` via `@superset/auth/utils` and TRPC (`billing.hasTrialed`).
  - Notifications: Sends `TrialEndingEmail` on `customer.subscription.trial_will_end` and queues a Slack notification.
  - UI: Trial-aware copy and states across desktop/web/marketing (paywall CTA, success page, plan badges). Org dropdown shows days left; Current Plan shows Trialing; invite-member alert explains pricing after trial; pricing table adds Automations, renames to “Remote workspaces,” and uses Beta/Coming soon badges.
  - Integrations: Slack checks use `ACTIVE_SUBSCRIPTION_STATUSES` so trialing orgs can use Slack features.
  - Dev tooling: Adds `apps/api/scripts/clone-stripe-prod-to-test.ts` to mirror prod Products/Prices in Stripe test mode and print `.env` price IDs.

- **Migration**
  - Set `STRIPE_TEST_KEY` in the repo root `.env` (test mode secret) and ensure `STRIPE_SECRET_KEY` matches it.
  - Run `bun apps/api/scripts/clone-stripe-prod-to-test.ts` to seed test prices and copy printed env vars.
  - Run `stripe listen --forward-to http://localhost:5741/api/auth/stripe/webhook` and set `STRIPE_WEBHOOK_SECRET`.

<sup>Written for commit eb8d66a96dfb2731b3334d8dee69af463eca9d1c. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3865?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced 14-day free trial for Pro plan with automatic billing after trial ends
  * Added trial countdown display in the organization menu
  * Updated pricing and billing pages with trial-eligible messaging and CTAs
  * Added trial-ending notification emails sent 3 days before trial expires

* **Documentation**
  * Updated pricing tier descriptions with 14-day free trial details and FAQ

<!-- end of auto-generated comment: release notes by coderabbit.ai -->