### PR TITLE
feat(pricing): align desktop and marketing comparison tables

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/plans/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/plans/page.tsx
@@ -1,3 +1,4 @@
+import { Badge } from "@superset/ui/badge";
 import { Button } from "@superset/ui/button";
 import { toast } from "@superset/ui/sonner";
 import { Switch } from "@superset/ui/switch";
@@ -49,7 +50,7 @@ type ComparisonValue = string | boolean | null;
 type ComparisonRow = {
 	label: string;
 	values: ComparisonValue[];
-	comingSoon?: boolean;
+	badge?: { label: string; variant: "default" | "secondary" };
 };
 
 type ComparisonSection = {
@@ -135,18 +136,22 @@ const COMPARISON_SECTIONS: ComparisonSection[] = [
 				values: [true, true, true],
 			},
 			{
-				label: "GitHub integration",
-				values: [true, true, true],
+				label: "Remote workspaces",
+				values: [null, true, true],
+				badge: { label: "Beta", variant: "default" },
 			},
 			{
-				label: "Cloud workspaces",
+				label: "Automations",
 				values: [null, true, true],
-				comingSoon: true,
 			},
 			{
 				label: "Mobile app",
 				values: [null, true, true],
-				comingSoon: true,
+				badge: { label: "Coming soon", variant: "secondary" },
+			},
+			{
+				label: "GitHub integration",
+				values: [true, true, true],
 			},
 			{
 				label: "Linear integration",
@@ -583,10 +588,13 @@ function PlansPage() {
 										<Fragment key={row.label}>
 											<div className="flex items-center gap-1.5 px-2 py-2.5 text-xs text-muted-foreground">
 												{row.label}
-												{row.comingSoon && (
-													<span className="text-[10px] text-muted-foreground/60">
-														(Coming Soon)
-													</span>
+												{row.badge && (
+													<Badge
+														variant={row.badge.variant}
+														className="px-1.5 py-0 text-[10px] font-medium"
+													>
+														{row.badge.label}
+													</Badge>
 												)}
 											</div>
 											{row.values.map((value, valueIndex) => (

--- a/apps/marketing/src/app/pricing/components/ComparisonTable/ComparisonTable.tsx
+++ b/apps/marketing/src/app/pricing/components/ComparisonTable/ComparisonTable.tsx
@@ -88,7 +88,7 @@ function DesktopRow({ row }: { row: ComparisonRow }) {
 			<td className="py-4 pr-4 text-sm text-foreground">
 				<div className="flex items-center gap-2">
 					<span>{row.label}</span>
-					{row.comingSoon && <ComingSoonBadge />}
+					{row.badge && <RowBadge badge={row.badge} />}
 				</div>
 			</td>
 			{row.values.map((value, index) => (
@@ -143,7 +143,7 @@ function MobileTable() {
 								>
 									<div className="flex items-center gap-2 text-sm text-foreground">
 										<span>{row.label}</span>
-										{row.comingSoon && <ComingSoonBadge />}
+										{row.badge && <RowBadge badge={row.badge} />}
 									</div>
 									<div className="shrink-0 text-sm text-foreground">
 										<Cell value={row.values[selectedIndex] ?? null} />
@@ -173,14 +173,18 @@ function Cell({ value }: { value: ComparisonRow["values"][number] }) {
 	return <span>{value}</span>;
 }
 
-function ComingSoonBadge() {
+function RowBadge({ badge }: { badge: NonNullable<ComparisonRow["badge"]> }) {
+	const isPrimary = badge.variant === "default";
 	return (
 		<span
 			className={cn(
-				"rounded-sm bg-accent/40 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground",
+				"rounded-sm px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide",
+				isPrimary
+					? "bg-foreground text-background"
+					: "bg-accent/40 text-muted-foreground",
 			)}
 		>
-			Coming soon
+			{badge.label}
 		</span>
 	);
 }

--- a/apps/marketing/src/app/pricing/constants.ts
+++ b/apps/marketing/src/app/pricing/constants.ts
@@ -109,7 +109,7 @@ export interface ComparisonRow {
 		string | boolean | null,
 		string | boolean | null,
 	];
-	comingSoon?: boolean;
+	badge?: { label: string; variant: "default" | "secondary" };
 }
 
 export interface ComparisonSection {
@@ -134,22 +134,18 @@ export const COMPARISON_SECTIONS: ComparisonSection[] = [
 		rows: [
 			{ label: "Desktop app", values: [true, true, true] },
 			{ label: "Local workspaces", values: [true, true, true] },
-			{ label: "GitHub integration", values: [true, true, true] },
-			{
-				label: "CLI",
-				values: [true, true, true],
-				comingSoon: true,
-			},
 			{
 				label: "Remote workspaces",
 				values: [null, true, true],
-				comingSoon: true,
+				badge: { label: "Beta", variant: "default" },
 			},
+			{ label: "Automations", values: [null, true, true] },
 			{
-				label: "Mobile",
+				label: "Mobile app",
 				values: [null, true, true],
-				comingSoon: true,
+				badge: { label: "Coming soon", variant: "secondary" },
 			},
+			{ label: "GitHub integration", values: [true, true, true] },
 			{ label: "Linear integration", values: [null, true, true] },
 			{ label: "Slack integration", values: [null, true, true] },
 			{ label: "Team collaboration", values: [null, true, true] },


### PR DESCRIPTION
## Summary
Mirrors the same set of changes on the desktop billing comparison table and the marketing `/pricing` comparison table:

- Rename **Cloud workspaces → Remote workspaces**
- Replace the inline `(Coming Soon)` text with proper Badges:
  - Remote workspaces → **Beta** (primary)
  - Mobile app → **Coming soon** (secondary)
- Add an **Automations** row (Pro + Enterprise)
- Reorder Features so they read top-to-bottom by surface area: Desktop app → Local workspaces → Remote workspaces → Automations → Mobile app → GitHub → Linear → Slack → Team collaboration
- Drop the marketing-only "CLI" row (not on desktop, not actually shipping near-term)
- Marketing renderer: replaces the single-purpose `ComingSoonBadge` with a `RowBadge` that picks primary/secondary styling from the row's badge config

The two comparison tables now show the exact same feature list in the exact same order.

## Test plan
- [ ] `bun run typecheck` and `bun run lint` clean (verified locally)
- [ ] Open desktop Settings → Billing → Plans, confirm new order, Beta + Coming soon badges, Automations row
- [ ] Open marketing site `/pricing`, scroll to comparison table — desktop and mobile breakpoints both show new order, badges, Automations row
- [ ] Confirm CLI row no longer appears on marketing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the desktop Billing and marketing `/pricing` comparison tables so they show the same features in the same order, and replaces inline “Coming soon” text with clear badges.

- **New Features**
  - Renamed “Cloud workspaces” → “Remote workspaces”.
  - Added “Automations” row (Pro + Enterprise).
  - Swapped inline text for badges: Remote workspaces = Beta (primary); Mobile app = Coming soon (secondary).
  - Reordered features: Desktop app → Local workspaces → Remote workspaces → Automations → Mobile app → GitHub → Linear → Slack → Team collaboration.
  - Removed the marketing-only “CLI” row; marketing table now uses a reusable `RowBadge` with primary/secondary variants.

<sup>Written for commit 7320a0fe00772d687a0d34ceb1200e8a6d410d24. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3867?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced pricing comparison table with improved status badges displaying Beta and Coming Soon indicators with better visual distinction
  * Added Automations feature to pricing comparison across all plans

* **Style**
  * Improved visual presentation of feature status indicators throughout pricing tables for enhanced clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->