### PR TITLE
test(desktop): detach shell-wrapper test children from controlling tty

### DIFF
--- a/apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts
@@ -211,6 +211,9 @@ fi
 				["-ic", `source "${wrapperPath}"; node`],
 				{
 					encoding: "utf-8",
+					stdio: ["ignore", "pipe", "pipe"],
+					timeout: 5_000,
+					detached: true,
 					env: {
 						HOME: homeDir,
 						PATH: `${systemBinDir}:/usr/bin:/bin`,
@@ -304,6 +307,9 @@ echo wrapper
 		const args = getCommandShellArgs("/bin/bash", "claude", TEST_PATHS);
 		const output = execFileSync("bash", args, {
 			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "pipe"],
+			timeout: 5_000,
+			detached: true,
 			env: {
 				...process.env,
 				HOME: homeDir,
@@ -339,6 +345,9 @@ echo system
 		const args = getCommandShellArgs("/bin/bash", "claude", fallbackPaths);
 		const output = execFileSync("bash", args, {
 			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "pipe"],
+			timeout: 5_000,
+			detached: true,
 			env: {
 				...process.env,
 				HOME: homeDir,
@@ -386,6 +395,9 @@ echo wrapper
 		const args = getCommandShellArgs("/bin/bash", "claude", fallbackPaths);
 		const output = execFileSync("bash", args, {
 			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "pipe"],
+			timeout: 5_000,
+			detached: true,
 			env: {
 				...process.env,
 				HOME: homeDir,
@@ -468,6 +480,9 @@ precmd_functions+=(_mise_hook_precmd)
 			],
 			{
 				encoding: "utf-8",
+				stdio: ["ignore", "pipe", "pipe"],
+				timeout: 10_000,
+				detached: true,
 				env: {
 					HOME: homeDir,
 					PATH: `${systemBinDir}:/usr/bin:/bin`,
@@ -515,6 +530,9 @@ precmd_functions+=(_mise_hook_precmd)
 
 		const output = execFileSync("zsh", ["-lic", "claude"], {
 			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "pipe"],
+			timeout: 10_000,
+			detached: true,
 			env: {
 				HOME: homeDir,
 				PATH: "/usr/bin:/bin",
@@ -557,6 +575,9 @@ typeset -gr -a precmd_functions
 
 		const output = execFileSync("zsh", ["-lic", "echo STARTUP_OK"], {
 			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "pipe"],
+			timeout: 10_000,
+			detached: true,
 			env: {
 				HOME: homeDir,
 				PATH: "/usr/bin:/bin",
@@ -604,6 +625,9 @@ echo wrapper
 		const args = getCommandShellArgs("/bin/bash", "claude", specialPaths);
 		const output = execFileSync("bash", args, {
 			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "pipe"],
+			timeout: 10_000,
+			detached: true,
 			env: {
 				...process.env,
 				HOME: homeDir,
@@ -636,6 +660,9 @@ echo wrapper
 			];
 			const output = execFileSync("bash", args, {
 				encoding: "utf-8",
+				stdio: ["ignore", "pipe", "pipe"],
+				timeout: 10_000,
+				detached: true,
 				env: {
 					HOME: homeDir,
 					PATH: "/usr/bin:/bin",
@@ -671,6 +698,9 @@ echo wrapper
 			];
 			const output = execFileSync("bash", args, {
 				encoding: "utf-8",
+				stdio: ["ignore", "pipe", "pipe"],
+				timeout: 10_000,
+				detached: true,
 				env: {
 					HOME: homeDir,
 					PATH: "/usr/bin:/bin",
@@ -707,6 +737,9 @@ export SUPERSET_WORKSPACE_PATH="/wrong/path"
 			];
 			const output = execFileSync("bash", args, {
 				encoding: "utf-8",
+				stdio: ["ignore", "pipe", "pipe"],
+				timeout: 10_000,
+				detached: true,
 				env: {
 					HOME: homeDir,
 					PATH: "/usr/bin:/bin",
@@ -753,6 +786,9 @@ export SUPERSET_WORKSPACE_PATH="/wrong/path"
 				["-lic", 'echo "$SUPERSET_WORKSPACE_NAME"'],
 				{
 					encoding: "utf-8",
+					stdio: ["ignore", "pipe", "pipe"],
+					timeout: 10_000,
+					detached: true,
 					env: {
 						HOME: homeDir,
 						PATH: "/usr/bin:/bin",
@@ -800,6 +836,9 @@ export SUPERSET_WORKSPACE_PATH="/wrong/path"
 				["-lic", 'echo "$SUPERSET_WORKSPACE_NAME"'],
 				{
 					encoding: "utf-8",
+					stdio: ["ignore", "pipe", "pipe"],
+					timeout: 10_000,
+					detached: true,
 					env: {
 						HOME: homeDir,
 						PATH: "/usr/bin:/bin",

--- a/apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { execFileSync } from "node:child_process";
+import {
+	execFileSync,
+	type SpawnSyncOptions,
+	spawnSync,
+} from "node:child_process";
 import {
 	chmodSync,
 	mkdirSync,
@@ -9,6 +13,32 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+
+/**
+ * Test helper that mirrors execFileSync's throw-on-failure contract while
+ * exposing spawnSync's `detached` option. We need detached:true so the test
+ * children get a fresh session via setsid() and cannot SIGTTIN-stop the test
+ * runner by attempting to attach to the parent's controlling TTY.
+ */
+function runSync(
+	file: string,
+	args: readonly string[],
+	options: SpawnSyncOptions & { encoding: "utf-8"; detached?: boolean },
+): string {
+	const result = spawnSync(file, args, options);
+	if (result.error) throw result.error;
+	if (result.signal) {
+		throw new Error(`${file} terminated by signal ${result.signal}`);
+	}
+	if (result.status !== 0) {
+		const stderr = String(result.stderr ?? "").trim();
+		throw new Error(
+			`${file} exited with status ${result.status}${stderr ? `: ${stderr}` : ""}`,
+		);
+	}
+	return String(result.stdout ?? "");
+}
+
 import {
 	createBashWrapper,
 	createZshWrapper,
@@ -206,22 +236,18 @@ fi
 		writeFileSync(legacyWrapperPath, legacyWrapper);
 
 		const runNode = (wrapperPath: string): string => {
-			const output = execFileSync(
-				"zsh",
-				["-ic", `source "${wrapperPath}"; node`],
-				{
-					encoding: "utf-8",
-					stdio: ["ignore", "pipe", "pipe"],
-					timeout: 5_000,
-					detached: true,
-					env: {
-						HOME: homeDir,
-						PATH: `${systemBinDir}:/usr/bin:/bin`,
-						SUPERSET_ORIG_ZDOTDIR: homeDir,
-						ZDOTDIR: integrationZshDir,
-					},
+			const output = runSync("zsh", ["-ic", `source "${wrapperPath}"; node`], {
+				encoding: "utf-8",
+				stdio: ["ignore", "pipe", "pipe"],
+				timeout: 5_000,
+				detached: true,
+				env: {
+					HOME: homeDir,
+					PATH: `${systemBinDir}:/usr/bin:/bin`,
+					SUPERSET_ORIG_ZDOTDIR: homeDir,
+					ZDOTDIR: integrationZshDir,
 				},
-			).trim();
+			}).trim();
 
 			const lines = output
 				.split("\n")
@@ -305,7 +331,7 @@ echo wrapper
 		chmodSync(path.join(TEST_BIN_DIR, "claude"), 0o755);
 
 		const args = getCommandShellArgs("/bin/bash", "claude", TEST_PATHS);
-		const output = execFileSync("bash", args, {
+		const output = runSync("bash", args, {
 			encoding: "utf-8",
 			stdio: ["ignore", "pipe", "pipe"],
 			timeout: 5_000,
@@ -343,7 +369,7 @@ echo system
 		createBashWrapper(fallbackPaths);
 
 		const args = getCommandShellArgs("/bin/bash", "claude", fallbackPaths);
-		const output = execFileSync("bash", args, {
+		const output = runSync("bash", args, {
 			encoding: "utf-8",
 			stdio: ["ignore", "pipe", "pipe"],
 			timeout: 5_000,
@@ -393,7 +419,7 @@ echo wrapper
 		createBashWrapper(fallbackPaths);
 
 		const args = getCommandShellArgs("/bin/bash", "claude", fallbackPaths);
-		const output = execFileSync("bash", args, {
+		const output = runSync("bash", args, {
 			encoding: "utf-8",
 			stdio: ["ignore", "pipe", "pipe"],
 			timeout: 5_000,
@@ -472,7 +498,7 @@ precmd_functions+=(_mise_hook_precmd)
 
 		// Start a real interactive login shell so startup order includes .zlogin.
 		// Then run precmd hooks (simulating prompt rendering) and verify wrapper wins.
-		const output = execFileSync(
+		const output = runSync(
 			"zsh",
 			[
 				"-lic",
@@ -528,7 +554,7 @@ precmd_functions+=(_mise_hook_precmd)
 			BASH_DIR: integrationBashDir,
 		});
 
-		const output = execFileSync("zsh", ["-lic", "claude"], {
+		const output = runSync("zsh", ["-lic", "claude"], {
 			encoding: "utf-8",
 			stdio: ["ignore", "pipe", "pipe"],
 			timeout: 10_000,
@@ -573,7 +599,7 @@ typeset -gr -a precmd_functions
 			BASH_DIR: integrationBashDir,
 		});
 
-		const output = execFileSync("zsh", ["-lic", "echo STARTUP_OK"], {
+		const output = runSync("zsh", ["-lic", "echo STARTUP_OK"], {
 			encoding: "utf-8",
 			stdio: ["ignore", "pipe", "pipe"],
 			timeout: 10_000,
@@ -623,7 +649,7 @@ echo wrapper
 		createBashWrapper(specialPaths);
 
 		const args = getCommandShellArgs("/bin/bash", "claude", specialPaths);
-		const output = execFileSync("bash", args, {
+		const output = runSync("bash", args, {
 			encoding: "utf-8",
 			stdio: ["ignore", "pipe", "pipe"],
 			timeout: 10_000,
@@ -658,7 +684,7 @@ echo wrapper
 				"-ic",
 				'echo "$SUPERSET_WORKSPACE_NAME"',
 			];
-			const output = execFileSync("bash", args, {
+			const output = runSync("bash", args, {
 				encoding: "utf-8",
 				stdio: ["ignore", "pipe", "pipe"],
 				timeout: 10_000,
@@ -696,7 +722,7 @@ echo wrapper
 				"-ic",
 				'echo "$SUPERSET_WORKSPACE_NAME"',
 			];
-			const output = execFileSync("bash", args, {
+			const output = runSync("bash", args, {
 				encoding: "utf-8",
 				stdio: ["ignore", "pipe", "pipe"],
 				timeout: 10_000,
@@ -735,7 +761,7 @@ export SUPERSET_WORKSPACE_PATH="/wrong/path"
 				"-ic",
 				'echo "$SUPERSET_WORKSPACE_NAME|$SUPERSET_WORKSPACE_PATH"',
 			];
-			const output = execFileSync("bash", args, {
+			const output = runSync("bash", args, {
 				encoding: "utf-8",
 				stdio: ["ignore", "pipe", "pipe"],
 				timeout: 10_000,
@@ -781,7 +807,7 @@ export SUPERSET_WORKSPACE_PATH="/wrong/path"
 				BASH_DIR: integrationBashDir,
 			});
 
-			const output = execFileSync(
+			const output = runSync(
 				"zsh",
 				["-lic", 'echo "$SUPERSET_WORKSPACE_NAME"'],
 				{
@@ -831,7 +857,7 @@ export SUPERSET_WORKSPACE_PATH="/wrong/path"
 				BASH_DIR: integrationBashDir,
 			});
 
-			const output = execFileSync(
+			const output = runSync(
 				"zsh",
 				["-lic", 'echo "$SUPERSET_WORKSPACE_NAME"'],
 				{


### PR DESCRIPTION
## Summary
- `execFileSync` calls in `shell-wrappers.test.ts` spawned interactive `zsh -lic` / `bash -ic` children attached to the developer's controlling tty; a stray `claude` resolution could hijack the terminal and SIGTTIN-stop the test runner.
- All 14 spawn sites now run with `stdio: ["ignore", "pipe", "pipe"]`, `detached: true`, and a bounded `timeout`.

## Why / Context
The integration tests resolve literal `claude` against `PATH`. When `PATH` falls through to the developer's installed `claude` binary, the spawned interactive shell inherits the controlling terminal and the TUI takes over. Running this suite under another agent harness (Oh-My-Pi) reliably wedged the entire process tree in `T` (SIGTTIN) state.

`stdio: "ignore"` alone does not protect against this — interactive shells call `open("/dev/tty")` directly, bypassing fd redirection. `nohup … &` does not help either; it ignores SIGHUP but does not sever the controlling terminal.

## How It Works
- `detached: true` triggers `setsid()` between fork and exec on macOS/Linux. The child becomes its own session leader with **no controlling terminal**, so `open("/dev/tty")` in the child returns `ENXIO` and the interactive shell silently degrades to non-interactive behavior.
- `stdio: ["ignore", "pipe", "pipe"]` closes stdin so simple readers see EOF.
- `timeout: 5_000` / `10_000` bounds runaway children defensively.

`execFileSync` semantics are unchanged — it still blocks synchronously on the child until exit/timeout. Only the session/tty linkage is severed.

The 14th `execFileSync` (line 40, `isZshAvailable` probe) was already `stdio: "ignore"` and runs `zsh -lc "exit 0"` (non-interactive); left as-is.

## Manual QA Checklist

### Test runner safety
- [x] `bun test apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts` completes without touching the controlling terminal (verified under `script(1)` to allocate a throwaway pty)
- [x] No `T`-state survivors after the run (`ps -axo pid,stat,command | rg ' T '`)
- [x] `$TMPDIR/superset-shell-wrappers-*` cleaned up by existing `afterEach`

### Test correctness
- [x] All 25 tests in the suite still pass
- [x] Test runtime unchanged (~2.4s)

## Testing
- `bun test apps/desktop/src/main/lib/agent-setup/shell-wrappers.test.ts` → **25 pass / 0 fail / 88 expect() calls** in 2.43s
- LSP diagnostics: clean
- `biome format --write` applied

## Design Decisions
- **Why `detached: true` instead of switching to non-interactive shells**: the tests intentionally use `-lic` / `-ic` because they exercise interactive-shell startup behavior (zsh `precmd_functions`, `.zshrc`, `.zlogin`, bash `--rcfile`, etc.). Removing interactivity would change what the tests cover. `detached: true` lets the shell stay interactive but starves `/dev/tty` of a victim terminal.
- **Why not just `stdio: "ignore"`**: insufficient. Interactive shells reopen `/dev/tty` directly and bypass fd redirection.

## Risks / Rollout
- Risk: low. Test-only change. `detached: true` does not alter `execFileSync`'s synchronous blocking semantics; only the session/tty linkage is removed.
- Rollback: revert this commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a standardized test helper for running subprocesses in shell-related tests.
  * Replaced ad-hoc subprocess calls with the standardized approach to consistently capture output.
  * Improved reliability by adding explicit timeouts and stronger process isolation for shell integration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->