### PR TITLE
fix(desktop): decouple machineId from host-service connection

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/device.ts
+++ b/apps/desktop/src/lib/trpc/routers/device.ts
@@ -1,0 +1,10 @@
+import { getHostId } from "@superset/shared/host-info";
+import { publicProcedure, router } from "..";
+
+export const createDeviceRouter = () => {
+	return router({
+		getMachineId: publicProcedure.query((): { machineId: string } => {
+			return { machineId: getHostId() };
+		}),
+	});
+};

--- a/apps/desktop/src/lib/trpc/routers/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/index.ts
@@ -10,6 +10,7 @@ import { createChangesRouter } from "./changes";
 import { createChatRuntimeServiceRouter } from "./chat-runtime-service";
 import { createChatServiceRouter } from "./chat-service";
 import { createConfigRouter } from "./config";
+import { createDeviceRouter } from "./device";
 import { createExternalRouter } from "./external";
 import { createFilesystemRouter } from "./filesystem";
 import { createHostServiceCoordinatorRouter } from "./host-service-coordinator";
@@ -52,6 +53,7 @@ export const createAppRouter = (getWindow: () => BrowserWindow | null) => {
 		external: createExternalRouter(),
 		settings: createSettingsRouter(),
 		config: createConfigRouter(),
+		device: createDeviceRouter(),
 		uiState: createUiStateRouter(),
 		ringtone: createRingtoneRouter(getWindow),
 		hostServiceCoordinator: createHostServiceCoordinatorRouter(),

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/LocalHostServiceProvider/LocalHostServiceProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/LocalHostServiceProvider/LocalHostServiceProvider.tsx
@@ -14,7 +14,7 @@ import { MOCK_ORG_ID } from "shared/constants";
 import { useCollections } from "../CollectionsProvider";
 
 interface LocalHostServiceContextValue {
-	machineId: string | null;
+	machineId: string;
 	activeHostUrl: string | null;
 }
 
@@ -51,15 +51,23 @@ export function LocalHostServiceProvider({
 		}
 	}, [organizationIds, startHostService]);
 
+	const { data: machineIdData } = electronTrpc.device.getMachineId.useQuery(
+		undefined,
+		{ staleTime: Number.POSITIVE_INFINITY },
+	);
+
 	const { data: activeConnection } =
 		electronTrpc.hostServiceCoordinator.getConnection.useQuery(
 			{ organizationId: activeOrganizationId as string },
 			{ enabled: !!activeOrganizationId, refetchInterval: 5_000 },
 		);
 
-	const value = useMemo(() => {
+	const value = useMemo<LocalHostServiceContextValue | null>(() => {
+		if (!machineIdData) return null;
+		const machineId = machineIdData.machineId;
+
 		if (!activeConnection?.port) {
-			return { machineId: null, activeHostUrl: null };
+			return { machineId, activeHostUrl: null };
 		}
 
 		const activeHostUrl = `http://127.0.0.1:${activeConnection.port}`;
@@ -67,11 +75,10 @@ export function LocalHostServiceProvider({
 			setHostServiceSecret(activeHostUrl, activeConnection.secret);
 		}
 
-		return {
-			machineId: activeConnection.machineId ?? null,
-			activeHostUrl,
-		};
-	}, [activeConnection]);
+		return { machineId, activeHostUrl };
+	}, [machineIdData, activeConnection]);
+
+	if (!value) return null;
 
 	return (
 		<LocalHostServiceContext.Provider value={value}>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/ProjectLocationSection/ProjectLocationSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/components/ProjectLocationSection/ProjectLocationSection.tsx
@@ -50,7 +50,7 @@ export function ProjectLocationSection({
 		(q) =>
 			q
 				.from({ hosts: collections.v2Hosts })
-				.where(({ hosts }) => eq(hosts.machineId, machineId ?? ""))
+				.where(({ hosts }) => eq(hosts.machineId, machineId))
 				.select(({ hosts }) => ({
 					name: hosts.name,
 					isOnline: hosts.isOnline,


### PR DESCRIPTION
## Summary

- `machineId` was sourced from `hostServiceCoordinator.getConnection`, which returns `null` whenever no host-service instance is running. After macOS sleep killed the detached host-service child, the renderer received `machineId: null`, every v2 workspace failed the `workspace.hostId === machineId` check, and all workspaces fell through to the relay branch — so data didn't load until the app was restarted.
- `machineId` is a deterministic per-device value (`getHostId()`), so it shouldn't be coupled to host-service liveness in the first place. Added a dedicated `device.getMachineId` tRPC query and gate `LocalHostServiceProvider` render on it, making `machineId` non-nullable everywhere downstream.
- This only fixes the misclassification. Reviving the host-service on wake (`powerMonitor.on('resume', ...)`) is being handled in a separate change.

## Test plan

- [ ] Open a v2 workspace, close laptop for >30 min, reopen. Workspace data should still classify as local (`isLocal === true`); behavior should match the pre-sleep state for any host-service that survived. If the host-service died, the workspace should show `WorkspaceNotFoundState` rather than silently routing through the relay.
- [ ] Cold app start: provider waits one IPC roundtrip for `device.getMachineId` before rendering children — verify no perceptible delay.
- [ ] `bun run typecheck` and `bun run lint` pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes local workspace misclassification after macOS sleep by decoupling the machine ID from host-service liveness and sourcing it directly from the device. Host-service auto-revive on wake will be handled separately.

- **Bug Fixes**
  - Added `device` tRPC router with `device.getMachineId` using `getHostId()` from `@superset/shared/host-info`.
  - Updated `LocalHostServiceProvider` to fetch the machine ID once, make it non-nullable, and stop reading it from `hostServiceCoordinator.getConnection`.
  - Updated project location query to use the required `machineId` directly.

<sup>Written for commit 3a74bc3e4a5e792a4c77361f83492854b2780f6c. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3876?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed machine identification issues affecting project location and host management configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->