### PR TITLE
feat(desktop): show Pro badge in account dropdown

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown/OrganizationDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown/OrganizationDropdown.tsx
@@ -1,5 +1,6 @@
 import { COMPANY } from "@superset/shared/constants";
 import { Avatar } from "@superset/ui/atoms/Avatar";
+import { Badge } from "@superset/ui/badge";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -27,6 +28,7 @@ import {
 } from "react-icons/hi2";
 import { IoBugOutline } from "react-icons/io5";
 import { LuKeyboard } from "react-icons/lu";
+import { useCurrentPlan } from "renderer/hooks/useCurrentPlan";
 import { useHotkeyDisplay } from "renderer/hotkeys";
 import { authClient } from "renderer/lib/auth-client";
 import { electronTrpc } from "renderer/lib/electron-trpc";
@@ -69,6 +71,18 @@ export function OrganizationDropdown({
 	const userName = session?.user?.name;
 	const displayName = activeOrganization?.name ?? userName ?? "Organization";
 
+	const currentPlan = useCurrentPlan();
+	const isPaid = currentPlan !== "free";
+	const planLabel = currentPlan.charAt(0).toUpperCase() + currentPlan.slice(1);
+	const planBadge = isPaid ? (
+		<Badge
+			variant="default"
+			className="px-1 py-0 text-[9px] leading-none uppercase tracking-wide h-3.5"
+		>
+			{planLabel}
+		</Badge>
+	) : null;
+
 	const triggerButton =
 		variant === "collapsed" ? (
 			<button
@@ -96,6 +110,7 @@ export function OrganizationDropdown({
 					className="rounded size-4 shrink-0"
 				/>
 				<span className="truncate">{displayName}</span>
+				{planBadge}
 				<HiChevronUpDown className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
 			</button>
 		) : (
@@ -113,6 +128,7 @@ export function OrganizationDropdown({
 				<span className="text-xs font-medium truncate max-w-32">
 					{displayName}
 				</span>
+				{planBadge}
 				<HiChevronUpDown className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
 			</button>
 		);

--- a/apps/web/src/app/(agents)/components/AgentsHeader/AgentsHeader.tsx
+++ b/apps/web/src/app/(agents)/components/AgentsHeader/AgentsHeader.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { authClient } from "@superset/auth/client";
+import { isPaidPlan } from "@superset/shared/billing";
 import { Avatar, AvatarFallback, AvatarImage } from "@superset/ui/avatar";
+import { Badge } from "@superset/ui/badge";
 import { Drawer, DrawerContent, DrawerTitle } from "@superset/ui/drawer";
 import {
 	DropdownMenu,
@@ -43,6 +45,13 @@ export function AgentsHeader() {
 	const { data: organizations } = useQuery(
 		trpc.user.myOrganizations.queryOptions(),
 	);
+
+	const { data: activePlan } = useQuery(trpc.billing.activePlan.queryOptions());
+
+	const isPro = isPaidPlan(activePlan?.plan);
+	const planLabel = activePlan?.plan
+		? activePlan.plan.charAt(0).toUpperCase() + activePlan.plan.slice(1)
+		: "Pro";
 
 	const user = session?.user;
 	const activeOrganizationId = session?.session?.activeOrganizationId;
@@ -191,7 +200,14 @@ export function AgentsHeader() {
 					<DrawerTitle className="sr-only">Account menu</DrawerTitle>
 					<div className="flex flex-col gap-1 p-3 pb-[max(1rem,env(safe-area-inset-bottom))]">
 						<div className="flex flex-col space-y-1 px-2 py-1.5">
-							<p className="text-sm font-medium">{user?.name}</p>
+							<div className="flex items-center gap-2">
+								<p className="text-sm font-medium">{user?.name}</p>
+								{isPro && (
+									<Badge variant="default" className="px-1.5 py-0 text-[10px]">
+										{planLabel}
+									</Badge>
+								)}
+							</div>
 							<p className="text-xs text-muted-foreground">{user?.email}</p>
 						</div>
 						<div className="my-1 h-px bg-border" />
@@ -251,7 +267,14 @@ export function AgentsHeader() {
 			<DropdownMenuContent align="end" className="min-w-56">
 				<DropdownMenuLabel>
 					<div className="flex flex-col space-y-1">
-						<p className="text-sm font-medium">{user?.name}</p>
+						<div className="flex items-center gap-2">
+							<p className="text-sm font-medium">{user?.name}</p>
+							{isPro && (
+								<Badge variant="default" className="px-1.5 py-0 text-[10px]">
+									{planLabel}
+								</Badge>
+							)}
+						</div>
 						<p className="text-xs text-muted-foreground">{user?.email}</p>
 					</div>
 				</DropdownMenuLabel>

--- a/apps/web/src/app/(agents)/components/AgentsHeader/AgentsHeader.tsx
+++ b/apps/web/src/app/(agents)/components/AgentsHeader/AgentsHeader.tsx
@@ -49,9 +49,10 @@ export function AgentsHeader() {
 	const { data: activePlan } = useQuery(trpc.billing.activePlan.queryOptions());
 
 	const isPro = isPaidPlan(activePlan?.plan);
-	const planLabel = activePlan?.plan
-		? activePlan.plan.charAt(0).toUpperCase() + activePlan.plan.slice(1)
-		: "Pro";
+	const planLabel =
+		isPro && activePlan?.plan
+			? activePlan.plan.charAt(0).toUpperCase() + activePlan.plan.slice(1)
+			: null;
 
 	const user = session?.user;
 	const activeOrganizationId = session?.session?.activeOrganizationId;

--- a/packages/trpc/src/router/billing/billing.ts
+++ b/packages/trpc/src/router/billing/billing.ts
@@ -1,8 +1,12 @@
 import { stripeClient } from "@superset/auth/stripe";
 import { db } from "@superset/db/client";
 import { members, subscriptions } from "@superset/db/schema";
+import {
+	ACTIVE_SUBSCRIPTION_STATUSES,
+	isActiveSubscriptionStatus,
+} from "@superset/shared/billing";
 import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
-import { and, eq } from "drizzle-orm";
+import { and, desc, eq, inArray } from "drizzle-orm";
 import type Stripe from "stripe";
 import { z } from "zod";
 import { env } from "../../env";
@@ -65,6 +69,25 @@ async function requireOwnerWithCustomer(ctx: {
 }
 
 export const billingRouter = {
+	activePlan: protectedProcedure.query(async ({ ctx }) => {
+		const activeOrgId = ctx.activeOrganizationId;
+		if (!activeOrgId) return { plan: "free" as const, status: null };
+
+		const subscription = await db.query.subscriptions.findFirst({
+			where: and(
+				eq(subscriptions.referenceId, activeOrgId),
+				inArray(subscriptions.status, ACTIVE_SUBSCRIPTION_STATUSES),
+			),
+			orderBy: desc(subscriptions.createdAt),
+		});
+
+		if (!subscription || !isActiveSubscriptionStatus(subscription.status)) {
+			return { plan: "free" as const, status: null };
+		}
+
+		return { plan: subscription.plan, status: subscription.status };
+	}),
+
 	invoices: protectedProcedure.query(async ({ ctx }) => {
 		const activeOrgId = ctx.activeOrganizationId;
 		if (!activeOrgId) {

--- a/packages/trpc/src/router/billing/billing.ts
+++ b/packages/trpc/src/router/billing/billing.ts
@@ -1,10 +1,7 @@
 import { stripeClient } from "@superset/auth/stripe";
 import { db } from "@superset/db/client";
 import { members, subscriptions } from "@superset/db/schema";
-import {
-	ACTIVE_SUBSCRIPTION_STATUSES,
-	isActiveSubscriptionStatus,
-} from "@superset/shared/billing";
+import { ACTIVE_SUBSCRIPTION_STATUSES } from "@superset/shared/billing";
 import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
 import { and, desc, eq, inArray } from "drizzle-orm";
 import type Stripe from "stripe";
@@ -81,7 +78,7 @@ export const billingRouter = {
 			orderBy: desc(subscriptions.createdAt),
 		});
 
-		if (!subscription || !isActiveSubscriptionStatus(subscription.status)) {
+		if (!subscription) {
 			return { plan: "free" as const, status: null };
 		}
 


### PR DESCRIPTION
## Summary
- Adds a `billing.activePlan` tRPC query that returns the active org's plan tier and subscription status (defaults to `free` when there's no active subscription).
- Renders a `Pro` / `Enterprise` badge next to the user's name in the `AgentsHeader` desktop dropdown and mobile drawer when the org is on a paid plan.
- Skipped the legacy `(dashboard-legacy)/Header.tsx` since the v1 dashboard is being sunset.

## Test plan
- [ ] Sign in as a user whose active org is on the `free` plan — no badge shows.
- [ ] Switch to an org on `pro` — `Pro` badge renders next to the name in both the desktop dropdown and the mobile drawer.
- [ ] Switch to an org on `enterprise` — badge label reads `Enterprise`.
- [ ] Subscription with non-active status (e.g. `canceled`) does not show a badge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a Pro/Enterprise badge when the active org has a paid plan in the web account menu (dropdown + mobile drawer) and the desktop Organization dropdown. Adds a `billing.activePlan` tRPC query to expose the active org’s plan and subscription status.

- **New Features**
  - `billing.activePlan` returns `{ plan, status }` for the active org; defaults to `free`/`null` and filters to active statuses via `@superset/shared/billing`.
  - Web (`AgentsHeader`): render a `Badge` next to the user’s name in the desktop dropdown and mobile drawer; label shows "Pro" or "Enterprise"; hidden for free or non-active subscriptions.
  - Desktop (`OrganizationDropdown`): render a `Badge` next to the org name in both trigger variants using `useCurrentPlan`.

- **Bug Fixes**
  - Avoid stale plan text by computing the label only when on a paid tier.
  - Remove a redundant status check in `billing.activePlan`.

<sup>Written for commit 3c17e8e3962d1904ff389da547866bb5b1f4c6f8. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3878?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Your active billing plan is now shown with a compact badge next to your account name and organization name in both mobile and desktop menus.
  * A human-readable plan label and status are consistently displayed across account and organization dropdowns, with the badge shown only for non-free (paid) plans.
  * The app reliably falls back to a free plan label when no active subscription is found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->