### PR TITLE
perf(desktop): unbatch host-service tRPC client

### DIFF
--- a/apps/desktop/src/renderer/lib/host-service-client.ts
+++ b/apps/desktop/src/renderer/lib/host-service-client.ts
@@ -1,5 +1,5 @@
 import type { AppRouter } from "@superset/host-service";
-import { createTRPCClient, httpBatchLink } from "@trpc/client";
+import { createTRPCClient, httpLink } from "@trpc/client";
 import superjson from "superjson";
 import { getHostServiceHeaders } from "./host-service-auth";
 
@@ -20,7 +20,7 @@ export function getHostServiceClientByUrl(hostUrl: string): HostServiceClient {
 
 	const client = createTRPCClient<AppRouter>({
 		links: [
-			httpBatchLink({
+			httpLink({
 				url: `${hostUrl}/trpc`,
 				transformer: superjson,
 				headers: () => getHostServiceHeaders(hostUrl),


### PR DESCRIPTION
Switch host-service-client from httpBatchLink to httpLink so calls to the local host service no longer wait on the slowest procedure in a batch.

## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `httpLink` for the desktop host-service tRPC client instead of `httpBatchLink` so local RPC calls resolve independently and no longer wait for the slowest request in a batch. This reduces latency for fast procedures and speeds up the UI.

<sup>Written for commit 31abdfb5aad169b040cdce21d0aef294f6cfe626. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3879?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal request handling for host service communication to improve performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->