### PR TITLE
fix(desktop): claim TERM_PROGRAM=kitty in v1 terminal

### DIFF
--- a/apps/desktop/src/main/lib/terminal/env.test.ts
+++ b/apps/desktop/src/main/lib/terminal/env.test.ts
@@ -658,9 +658,9 @@ describe("env", () => {
 		});
 
 		describe("terminal metadata", () => {
-			it("should set TERM_PROGRAM to Superset", () => {
+			it("should set TERM_PROGRAM to kitty", () => {
 				const result = buildTerminalEnv(baseParams);
-				expect(result.TERM_PROGRAM).toBe("Superset");
+				expect(result.TERM_PROGRAM).toBe("kitty");
 			});
 
 			it("should set COLORTERM to truecolor", () => {

--- a/apps/desktop/src/main/lib/terminal/env.ts
+++ b/apps/desktop/src/main/lib/terminal/env.ts
@@ -464,7 +464,7 @@ export function buildTerminalEnv(params: {
 	const terminalEnv: Record<string, string> = {
 		...baseEnv,
 		...shellEnv,
-		TERM_PROGRAM: "Superset",
+		TERM_PROGRAM: "kitty",
 		TERM_PROGRAM_VERSION: process.env.npm_package_version || "1.0.0",
 		COLORTERM: "truecolor",
 		COLORFGBG: colorFgBg,


### PR DESCRIPTION
Mirrors the host-service v2 path so chat TUIs (claude-code et al.) parse kitty CSI-u sequences from xterm.js. v1 already enables kittyKeyboard in the renderer; the env claim makes consumers honor it.

## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set TERM_PROGRAM to `kitty` in the desktop v1 terminal so TUIs correctly parse kitty CSI‑u keyboard sequences from `xterm.js`. Aligns v1 behavior with the host-service v2 path.

- **Bug Fixes**
  - Export `TERM_PROGRAM=kitty` in `buildTerminalEnv`.
  - Update test to expect `TERM_PROGRAM` as `kitty`.

<sup>Written for commit 0d0781ad59b5b103a5fb302f81b116030c9c4442. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3882?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal environment configuration to correctly identify the terminal program as "kitty" in spawned shell processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->