### PR TITLE
feat(desktop): enable v2 by default in dev

### DIFF
--- a/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts
+++ b/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts
@@ -2,6 +2,8 @@ import { FEATURE_FLAGS } from "@superset/shared/constants";
 import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useV2LocalOverrideStore } from "renderer/stores/v2-local-override";
 
+const IS_DEV = process.env.NODE_ENV === "development";
+
 /**
  * Returns effective v2 state: remote PostHog flag AND local opt-in.
  * Also returns the raw remote flag so the toggle can be shown conditionally.
@@ -10,6 +12,13 @@ export function useIsV2CloudEnabled() {
 	const remoteV2Enabled =
 		useFeatureFlagEnabled(FEATURE_FLAGS.V2_CLOUD) ?? false;
 	const optInV2 = useV2LocalOverrideStore((s) => s.optInV2);
+
+	if (IS_DEV) {
+		return {
+			isV2CloudEnabled: true,
+			isRemoteV2Enabled: true,
+		};
+	}
 
 	return {
 		/** The effective value — use this wherever you previously checked the flag directly. */


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turn on v2 Cloud by default in development. In `NODE_ENV=development`, `useIsV2CloudEnabled` returns `isV2CloudEnabled: true` and `isRemoteV2Enabled: true`, bypassing the PostHog flag and local opt-in (no change in production).

<sup>Written for commit db1ff850696eaaabedb7279d3cd06440b759f48d. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3883?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added development environment override for v2 cloud feature testing, enabling developers to evaluate v2 cloud functionality during local development without relying on feature flag configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->