### PR TITLE
fix(host-service): dedupe PR refresh calls with repo-keyed cache

### DIFF
--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -6,6 +6,7 @@ import type { HostDb } from "../../db";
 import { projects, pullRequests, workspaces } from "../../db/schema";
 import type { GitFactory } from "../git";
 import { fetchRepositoryPullRequests } from "./utils/github-query";
+import type { GraphQLPullRequestNode } from "./utils/github-query/types";
 import {
 	type ChecksStatus,
 	coerceChecksStatus,
@@ -22,7 +23,11 @@ import {
 } from "./utils/pull-request-mappers";
 
 const BRANCH_SYNC_INTERVAL_MS = 30_000;
-const PROJECT_REFRESH_INTERVAL_MS = 10_000;
+const PROJECT_REFRESH_INTERVAL_MS = 20_000;
+// Multiple projects can target the same GitHub repo; collapse those into a
+// single GraphQL call within the polling window so we don't multiply traffic
+// by the number of projects.
+const REPO_PULL_REQUEST_CACHE_TTL_MS = 10_000;
 const UNBORN_HEAD_ERROR_PATTERNS = [
 	"ambiguous argument 'head'",
 	"unknown revision or path not in the working tree",
@@ -197,7 +202,10 @@ export class PullRequestRuntimeManager {
 	private branchSyncTimer: ReturnType<typeof setInterval> | null = null;
 	private projectRefreshTimer: ReturnType<typeof setInterval> | null = null;
 	private readonly inFlightProjects = new Map<string, Promise<void>>();
-	private readonly nextProjectRefreshAt = new Map<string, number>();
+	private readonly repoPullRequestCache = new Map<
+		string,
+		{ promise: Promise<GraphQLPullRequestNode[]>; fetchedAt: number }
+	>();
 
 	constructor(options: PullRequestRuntimeManagerOptions) {
 		this.db = options.db;
@@ -216,7 +224,7 @@ export class PullRequestRuntimeManager {
 		}, PROJECT_REFRESH_INTERVAL_MS);
 
 		void this.syncWorkspaceBranches();
-		void this.refreshEligibleProjects(true);
+		void this.refreshEligibleProjects();
 	}
 
 	stop() {
@@ -287,7 +295,7 @@ export class PullRequestRuntimeManager {
 
 		const projectIds = [...new Set(rows.map((row) => row.projectId))];
 		await Promise.all(
-			projectIds.map((projectId) => this.refreshProject(projectId, true)),
+			projectIds.map((projectId) => this.refreshProject(projectId)),
 		);
 	}
 
@@ -344,13 +352,11 @@ export class PullRequestRuntimeManager {
 		}
 
 		await Promise.all(
-			[...changedProjectIds].map((projectId) =>
-				this.refreshProject(projectId, true),
-			),
+			[...changedProjectIds].map((projectId) => this.refreshProject(projectId)),
 		);
 	}
 
-	private async refreshEligibleProjects(force = false): Promise<void> {
+	private async refreshEligibleProjects(): Promise<void> {
 		const rows = this.db
 			.select({
 				projectId: workspaces.projectId,
@@ -359,23 +365,14 @@ export class PullRequestRuntimeManager {
 			.all();
 		const projectIds = [...new Set(rows.map((row) => row.projectId))];
 		await Promise.all(
-			projectIds.map((projectId) => this.refreshProject(projectId, force)),
+			projectIds.map((projectId) => this.refreshProject(projectId)),
 		);
 	}
 
-	private async refreshProject(
-		projectId: string,
-		force = false,
-	): Promise<void> {
-		const now = Date.now();
+	private async refreshProject(projectId: string): Promise<void> {
 		const existing = this.inFlightProjects.get(projectId);
 		if (existing) {
 			await existing;
-			return;
-		}
-
-		const nextEligibleRefreshAt = this.nextProjectRefreshAt.get(projectId) ?? 0;
-		if (!force && nextEligibleRefreshAt > now) {
 			return;
 		}
 
@@ -391,10 +388,6 @@ export class PullRequestRuntimeManager {
 			})
 			.finally(() => {
 				this.inFlightProjects.delete(projectId);
-				this.nextProjectRefreshAt.set(
-					projectId,
-					Date.now() + PROJECT_REFRESH_INTERVAL_MS,
-				);
 			});
 
 		this.inFlightProjects.set(projectId, refreshPromise);
@@ -501,6 +494,37 @@ export class PullRequestRuntimeManager {
 		};
 	}
 
+	private async getCachedRepoPullRequests(
+		repo: NormalizedRepoIdentity,
+	): Promise<GraphQLPullRequestNode[]> {
+		const cacheKey = `${repo.owner.toLowerCase()}/${repo.name.toLowerCase()}`;
+		const cached = this.repoPullRequestCache.get(cacheKey);
+		if (
+			cached &&
+			Date.now() - cached.fetchedAt < REPO_PULL_REQUEST_CACHE_TTL_MS
+		) {
+			return cached.promise;
+		}
+
+		const fetchedAt = Date.now();
+		const promise = (async () => {
+			const octokit = await this.github();
+			return fetchRepositoryPullRequests(octokit, {
+				owner: repo.owner,
+				name: repo.name,
+			});
+		})();
+		// Evict on failure so the next caller retries instead of serving a
+		// poisoned cache entry for the rest of the TTL.
+		promise.catch(() => {
+			if (this.repoPullRequestCache.get(cacheKey)?.promise === promise) {
+				this.repoPullRequestCache.delete(cacheKey);
+			}
+		});
+		this.repoPullRequestCache.set(cacheKey, { promise, fetchedAt });
+		return promise;
+	}
+
 	private async fetchRepoPullRequests(
 		projectId: string,
 		repo: NormalizedRepoIdentity,
@@ -508,11 +532,7 @@ export class PullRequestRuntimeManager {
 	): Promise<Map<string, { id: string }>> {
 		if (wantedKeys.size === 0) return new Map();
 
-		const octokit = await this.github();
-		const nodes = await fetchRepositoryPullRequests(octokit, {
-			owner: repo.owner,
-			name: repo.name,
-		});
+		const nodes = await this.getCachedRepoPullRequests(repo);
 
 		const latestByKey = new Map<string, (typeof nodes)[number]>();
 

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -295,7 +295,9 @@ export class PullRequestRuntimeManager {
 
 		const projectIds = [...new Set(rows.map((row) => row.projectId))];
 		await Promise.all(
-			projectIds.map((projectId) => this.refreshProject(projectId)),
+			projectIds.map((projectId) =>
+				this.refreshProject(projectId, { bypassCache: true }),
+			),
 		);
 	}
 
@@ -352,7 +354,9 @@ export class PullRequestRuntimeManager {
 		}
 
 		await Promise.all(
-			[...changedProjectIds].map((projectId) => this.refreshProject(projectId)),
+			[...changedProjectIds].map((projectId) =>
+				this.refreshProject(projectId, { bypassCache: true }),
+			),
 		);
 	}
 
@@ -369,14 +373,17 @@ export class PullRequestRuntimeManager {
 		);
 	}
 
-	private async refreshProject(projectId: string): Promise<void> {
+	private async refreshProject(
+		projectId: string,
+		options: { bypassCache?: boolean } = {},
+	): Promise<void> {
 		const existing = this.inFlightProjects.get(projectId);
 		if (existing) {
 			await existing;
 			return;
 		}
 
-		const refreshPromise = this.performProjectRefresh(projectId)
+		const refreshPromise = this.performProjectRefresh(projectId, options)
 			.catch((error) => {
 				console.warn(
 					"[host-service:pull-request-runtime] Project refresh failed",
@@ -394,7 +401,10 @@ export class PullRequestRuntimeManager {
 		await refreshPromise;
 	}
 
-	private async performProjectRefresh(projectId: string): Promise<void> {
+	private async performProjectRefresh(
+		projectId: string,
+		options: { bypassCache?: boolean } = {},
+	): Promise<void> {
 		const repo = await this.getProjectRepository(projectId);
 		if (!repo) return;
 
@@ -419,6 +429,7 @@ export class PullRequestRuntimeManager {
 			projectId,
 			repo,
 			wantedKeys,
+			options,
 		);
 
 		for (const workspace of projectWorkspaces) {
@@ -496,14 +507,17 @@ export class PullRequestRuntimeManager {
 
 	private async getCachedRepoPullRequests(
 		repo: NormalizedRepoIdentity,
+		options: { bypassCache?: boolean } = {},
 	): Promise<GraphQLPullRequestNode[]> {
 		const cacheKey = `${repo.owner.toLowerCase()}/${repo.name.toLowerCase()}`;
-		const cached = this.repoPullRequestCache.get(cacheKey);
-		if (
-			cached &&
-			Date.now() - cached.fetchedAt < REPO_PULL_REQUEST_CACHE_TTL_MS
-		) {
-			return cached.promise;
+		if (!options.bypassCache) {
+			const cached = this.repoPullRequestCache.get(cacheKey);
+			if (
+				cached &&
+				Date.now() - cached.fetchedAt < REPO_PULL_REQUEST_CACHE_TTL_MS
+			) {
+				return cached.promise;
+			}
 		}
 
 		const fetchedAt = Date.now();
@@ -529,10 +543,11 @@ export class PullRequestRuntimeManager {
 		projectId: string,
 		repo: NormalizedRepoIdentity,
 		wantedKeys: Set<string>,
+		options: { bypassCache?: boolean } = {},
 	): Promise<Map<string, { id: string }>> {
 		if (wantedKeys.size === 0) return new Map();
 
-		const nodes = await this.getCachedRepoPullRequests(repo);
+		const nodes = await this.getCachedRepoPullRequests(repo, options);
 
 		const latestByKey = new Map<string, (typeof nodes)[number]>();
 

--- a/packages/host-service/src/trpc/router/workspace-creation/procedures/get-github-pull-request-content.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/procedures/get-github-pull-request-content.ts
@@ -7,40 +7,86 @@ import {
 import { resolveGithubRepo } from "../shared/project-helpers";
 import { execGh } from "../utils/exec-gh";
 
+type PullRequestContent = {
+	number: number;
+	title: string;
+	body: string;
+	url: string;
+	state: string;
+	branch: string;
+	baseBranch: string;
+	headRepositoryOwner: string | null;
+	isCrossRepository: boolean;
+	author: string | null;
+	isDraft: boolean;
+	createdAt: string | undefined;
+	updatedAt: string | undefined;
+};
+
+// Browsing the PR list re-opens the detail panel constantly; cache the
+// `gh pr view` response so we don't burn the user's GitHub token bucket on
+// repeat clicks. Concurrent callers share the same in-flight promise.
+const PULL_REQUEST_CONTENT_CACHE_TTL_MS = 30_000;
+const pullRequestContentCache = new Map<
+	string,
+	{ promise: Promise<PullRequestContent>; fetchedAt: number }
+>();
+
 export const getGitHubPullRequestContent = protectedProcedure
 	.input(githubPullRequestContentInputSchema)
 	.query(async ({ ctx, input }) => {
 		const repo = await resolveGithubRepo(ctx, input.projectId);
-		try {
-			const raw = await execGh([
-				"pr",
-				"view",
-				String(input.prNumber),
-				"--repo",
-				`${repo.owner}/${repo.name}`,
-				"--json",
-				"number,title,body,url,state,author,headRefName,baseRefName,headRepositoryOwner,isCrossRepository,isDraft,createdAt,updatedAt",
-			]);
-			const data = pullRequestContentSchema.parse(raw);
-			return {
-				number: data.number,
-				title: data.title,
-				body: data.body ?? "",
-				url: data.url,
-				state: data.state.toLowerCase(),
-				branch: data.headRefName,
-				baseBranch: data.baseRefName,
-				headRepositoryOwner: data.headRepositoryOwner?.login ?? null,
-				isCrossRepository: data.isCrossRepository,
-				author: data.author?.login ?? null,
-				isDraft: data.isDraft,
-				createdAt: data.createdAt,
-				updatedAt: data.updatedAt,
-			};
-		} catch (err) {
-			throw new TRPCError({
-				code: "INTERNAL_SERVER_ERROR",
-				message: `Failed to fetch PR #${input.prNumber}: ${err instanceof Error ? err.message : String(err)}`,
-			});
+		const cacheKey = `${repo.owner.toLowerCase()}/${repo.name.toLowerCase()}#${input.prNumber}`;
+		const cached = pullRequestContentCache.get(cacheKey);
+		if (
+			cached &&
+			Date.now() - cached.fetchedAt < PULL_REQUEST_CONTENT_CACHE_TTL_MS
+		) {
+			return cached.promise;
 		}
+
+		const fetchedAt = Date.now();
+		const promise = (async (): Promise<PullRequestContent> => {
+			try {
+				const raw = await execGh([
+					"pr",
+					"view",
+					String(input.prNumber),
+					"--repo",
+					`${repo.owner}/${repo.name}`,
+					"--json",
+					"number,title,body,url,state,author,headRefName,baseRefName,headRepositoryOwner,isCrossRepository,isDraft,createdAt,updatedAt",
+				]);
+				const data = pullRequestContentSchema.parse(raw);
+				return {
+					number: data.number,
+					title: data.title,
+					body: data.body ?? "",
+					url: data.url,
+					state: data.state.toLowerCase(),
+					branch: data.headRefName,
+					baseBranch: data.baseRefName,
+					headRepositoryOwner: data.headRepositoryOwner?.login ?? null,
+					isCrossRepository: data.isCrossRepository,
+					author: data.author?.login ?? null,
+					isDraft: data.isDraft,
+					createdAt: data.createdAt,
+					updatedAt: data.updatedAt,
+				};
+			} catch (err) {
+				throw new TRPCError({
+					code: "INTERNAL_SERVER_ERROR",
+					message: `Failed to fetch PR #${input.prNumber}: ${err instanceof Error ? err.message : String(err)}`,
+				});
+			}
+		})();
+		// Evict on failure so the next caller retries instead of replaying the
+		// same error for the rest of the TTL.
+		promise.catch(() => {
+			if (pullRequestContentCache.get(cacheKey)?.promise === promise) {
+				pullRequestContentCache.delete(cacheKey);
+			}
+		});
+		pullRequestContentCache.set(cacheKey, { promise, fetchedAt });
+		return promise;
 	});


### PR DESCRIPTION
Multiple projects targeting the same GitHub repo each fired their own GraphQL query every 10s, and force=true paths bypassed the per-project debounce entirely. Replace with a single repo-keyed response cache so N projects on the same repo collapse to 1 call, branch-sync/tRPC bursts share the in-flight promise, and the polling cadence drops to 20s.

## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates GitHub PR refresh calls in `host-service` with a repo-keyed cache and caches PR detail fetches to cut duplicate API/CLI calls across projects and views.

- **Bug Fixes**
  - Added repo-keyed PR list cache (10s TTL) and `gh pr view` detail cache (30s TTL); both share in-flight promises and evict on failure.
  - Explicit refreshes (branch sync and `refreshByWorkspaces`) bypass the repo cache to avoid stale reads; bypassed fetches still populate the cache while poll ticks keep deduping.
  - Increased project refresh interval to 20s; removed per-project debounce/force and rely on in-flight dedupe via a unified refresh path.

<sup>Written for commit d1c299c7b83537debc6d5710f47ca572ba0e6adf. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3884?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced redundant GitHub requests to lower network traffic
  * Added repository-level deduplication with a 10s TTL to speed repeated PR listings
  * Cached pull request content fetches to avoid repeated external CLI calls
  * Unified refresh behavior across startup and workspace/branch triggers
  * Increased project refresh interval from 10s to 20s
  * Failed cache entries are evicted so subsequent attempts retry promptly
<!-- end of auto-generated comment: release notes by coderabbit.ai -->