### PR TITLE
feat(desktop): persist v2 diff-pane expand state, auto-expand clicked file

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
@@ -61,6 +61,10 @@ export function DiffPane({ context, workspaceId, onOpenFile }: DiffPaneProps) {
 		() => new Set(data.collapsedFiles ?? []),
 		[data.collapsedFiles],
 	);
+	const expandedSet = useMemo(
+		() => new Set(data.expandedFiles ?? []),
+		[data.expandedFiles],
+	);
 
 	// Stable callback via refs — identity does not churn as collapsedFiles
 	// updates, so memo'd children can skip re-renders on unrelated toggles.
@@ -77,6 +81,19 @@ export function DiffPane({ context, workspaceId, onOpenFile }: DiffPaneProps) {
 				? [...collapsed, path]
 				: collapsed.filter((p) => p !== path);
 			updateData({ ...current, collapsedFiles: next } as PaneViewerData);
+		},
+		[updateData],
+	);
+	const setExpanded = useCallback(
+		(path: string, value: boolean) => {
+			const current = dataRef.current;
+			const expanded = current.expandedFiles ?? [];
+			const has = expanded.includes(path);
+			if (value === has) return;
+			const next = value
+				? [...expanded, path]
+				: expanded.filter((p) => p !== path);
+			updateData({ ...current, expandedFiles: next } as PaneViewerData);
 		},
 		[updateData],
 	);
@@ -103,6 +120,8 @@ export function DiffPane({ context, workspaceId, onOpenFile }: DiffPaneProps) {
 					diffStyle={diffStyle}
 					collapsed={collapsedSet.has(file.path)}
 					onSetCollapsed={setCollapsed}
+					expanded={expandedSet.has(file.path)}
+					onSetExpanded={setExpanded}
 					viewed={viewedSet.has(file.path)}
 					onSetViewed={setViewed}
 					onOpenFile={onOpenFile}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileEntry/DiffFileEntry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileEntry/DiffFileEntry.tsx
@@ -33,6 +33,8 @@ interface DiffFileEntryProps {
 	diffStyle: "split" | "unified";
 	collapsed: boolean;
 	onSetCollapsed: (path: string, value: boolean) => void;
+	expanded: boolean;
+	onSetExpanded: (path: string, value: boolean) => void;
 	viewed: boolean;
 	onSetViewed: (path: string, next: boolean) => void;
 	onOpenFile: (path: string, openInNewTab?: boolean) => void;
@@ -45,6 +47,8 @@ export const DiffFileEntry = memo(function DiffFileEntry({
 	diffStyle,
 	collapsed,
 	onSetCollapsed,
+	expanded,
+	onSetExpanded,
 	viewed,
 	onSetViewed,
 	onOpenFile,
@@ -55,9 +59,9 @@ export const DiffFileEntry = memo(function DiffFileEntry({
 	const hasBeenNearRef = useRef(false);
 	if (isNear) hasBeenNearRef.current = true;
 
-	const [showFullDiff, setShowFullDiff] = useState(false);
 	const [expandUnchanged, setExpandUnchanged] = useState(false);
 	const reason = deferReason(file);
+	const showFullDiff = expanded;
 
 	const handleToggleCollapsed = useCallback(
 		() => onSetCollapsed(file.path, !collapsed),
@@ -90,7 +94,10 @@ export const DiffFileEntry = memo(function DiffFileEntry({
 		}
 		onOpenInExternalEditor(file.path);
 	}, [file.status, file.path, onOpenInExternalEditor, showDeletedFileToast]);
-	const handleShowFullDiff = useCallback(() => setShowFullDiff(true), []);
+	const handleShowFullDiff = useCallback(
+		() => onSetExpanded(file.path, true),
+		[onSetExpanded, file.path],
+	);
 	const handleToggleExpandUnchanged = useCallback(
 		() => setExpandUnchanged((prev) => !prev),
 		[],

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspacePaneOpeners/useWorkspacePaneOpeners.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspacePaneOpeners/useWorkspacePaneOpeners.ts
@@ -32,6 +32,7 @@ export function useWorkspacePaneOpeners({
 							data: {
 								path: filePath,
 								collapsedFiles: [],
+								expandedFiles: [filePath],
 							} as DiffPaneData,
 						},
 					],
@@ -42,11 +43,16 @@ export function useWorkspacePaneOpeners({
 				for (const pane of Object.values(tab.panes)) {
 					if (pane.kind !== "diff") continue;
 					const prev = pane.data as DiffPaneData;
+					const prevExpanded = prev.expandedFiles ?? [];
 					state.setPaneData({
 						paneId: pane.id,
 						data: {
 							...prev,
 							path: filePath,
+							collapsedFiles: prev.collapsedFiles.filter((p) => p !== filePath),
+							expandedFiles: prevExpanded.includes(filePath)
+								? prevExpanded
+								: [...prevExpanded, filePath],
 						} as PaneViewerData,
 					});
 					state.setActiveTab(tab.id);
@@ -60,6 +66,7 @@ export function useWorkspacePaneOpeners({
 					data: {
 						path: filePath,
 						collapsedFiles: [],
+						expandedFiles: [filePath],
 					} as DiffPaneData,
 				},
 			});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspacePaneOpeners/useWorkspacePaneOpeners.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspacePaneOpeners/useWorkspacePaneOpeners.ts
@@ -49,7 +49,9 @@ export function useWorkspacePaneOpeners({
 						data: {
 							...prev,
 							path: filePath,
-							collapsedFiles: prev.collapsedFiles.filter((p) => p !== filePath),
+							collapsedFiles: (prev.collapsedFiles ?? []).filter(
+								(p) => p !== filePath,
+							),
 							expandedFiles: prevExpanded.includes(filePath)
 								? prevExpanded
 								: [...prevExpanded, filePath],

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts
@@ -44,6 +44,7 @@ export interface DevtoolsPaneData {
 export interface DiffPaneData {
 	path: string;
 	collapsedFiles: string[];
+	expandedFiles?: string[];
 }
 
 export interface CommentPaneData {


### PR DESCRIPTION
## Summary
- Lift `showFullDiff` out of `DiffFileEntry` local state into a persisted `expandedFiles` array on `DiffPaneData`, synced through the existing `paneLayout` collection — "Show diff" decisions on large files now survive navigation and reload.
- Clicking a file from the v2 changes tab now adds its path to `expandedFiles` (and clears it from `collapsedFiles`), so a large file auto-renders its diff in the changes pane instead of showing the deferred placeholder.

## Test plan
- [ ] Open a workspace with a >250-line diff, click the file in the v2 changes tab → diff renders immediately (no "Show diff" placeholder).
- [ ] Click "Show diff" on another large file, switch tabs/panes and back → file remains expanded.
- [ ] Reload the workspace → previously expanded files are still expanded.
- [ ] Manual chevron collapse on a small file still toggles and persists as before.
- [ ] Open Diff in New Tab on a large file → new tab opens with that file already expanded.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persisted expanded state for large diffs in the v2 diff pane and auto-expand the clicked file from the changes tab. Large files now render immediately, and your expand choice survives navigation and reload; also fixes a crash with legacy panes.

- **New Features**
  - Store expand decisions in `DiffPaneData.expandedFiles` (persisted via `paneLayout`).
  - Clicking a file in the v2 changes tab adds it to `expandedFiles` and removes it from `collapsedFiles`; new tabs open with that file expanded.
  - Existing collapse/viewed toggles continue to work and persist as before.

- **Bug Fixes**
  - Guard `collapsedFiles` reads in the diff pane opener to handle legacy panes without this field and avoid undefined.filter errors.

<sup>Written for commit 7b7e19457abc632fe2688257588077694255ea9a. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3885?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized file expansion state for diff panes, enabling constant-time expansion checks.
  * "Show diff" now respects and updates the shared expansion state so UI stays in sync.
  * New persistence of expanded files: files open expanded when diffed and expansion is preserved across pane reuse and navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->