### PR TITLE
revert: "fix(desktop): show local diff stats in v1 workspace hover card (#3881)"

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/CollapsedWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/CollapsedWorkspaceItem.tsx
@@ -33,7 +33,6 @@ interface CollapsedWorkspaceItemProps {
 	isActive: boolean;
 	isUnread: boolean;
 	workspaceStatus: ActivePaneStatus | null;
-	diffStats?: { additions: number; deletions: number } | null;
 	itemRef: RefObject<HTMLButtonElement | null>;
 	showDeleteDialog: boolean;
 	setShowDeleteDialog: (open: boolean) => void;
@@ -52,7 +51,6 @@ export function CollapsedWorkspaceItem({
 	isActive,
 	isUnread,
 	workspaceStatus,
-	diffStats,
 	itemRef,
 	showDeleteDialog,
 	setShowDeleteDialog,
@@ -172,7 +170,6 @@ export function CollapsedWorkspaceItem({
 					<WorkspaceHoverCardContent
 						workspaceId={id}
 						workspaceAlias={name}
-						diffStats={diffStats}
 						onEditBranchClick={setRenameBranchTarget}
 					/>
 				</HoverCardContent>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceContextMenu.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceContextMenu.tsx
@@ -47,7 +47,6 @@ interface WorkspaceContextMenuProps {
 	isUnread: boolean;
 	workspaceStatus: string | null | undefined;
 	sections: { id: string; name: string }[];
-	diffStats?: { additions: number; deletions: number } | null;
 	onRename: () => void;
 	onOpenInFinder: () => void;
 	onOpenInEditor: () => void;
@@ -67,7 +66,6 @@ export function WorkspaceContextMenu({
 	isUnread,
 	workspaceStatus,
 	sections,
-	diffStats,
 	onRename,
 	onOpenInFinder,
 	onOpenInEditor,
@@ -254,7 +252,6 @@ export function WorkspaceContextMenu({
 				<WorkspaceHoverCardContent
 					workspaceId={id}
 					workspaceAlias={name}
-					diffStats={diffStats}
 					onEditBranchClick={setRenameBranchTarget}
 				/>
 			</HoverCardContent>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/WorkspaceListItem.tsx
@@ -160,21 +160,6 @@ export function WorkspaceListItem({
 		enabled: hasHovered && !!worktreePath,
 		staleTime: GITHUB_STATUS_STALE_TIME,
 	});
-	const localDiffStats = useMemo(() => {
-		if (!localChanges) return null;
-		const allFiles =
-			localChanges.againstBase.length > 0
-				? localChanges.againstBase
-				: [
-						...localChanges.staged,
-						...localChanges.unstaged,
-						...localChanges.untracked,
-					];
-		const additions = allFiles.reduce((sum, f) => sum + (f.additions || 0), 0);
-		const deletions = allFiles.reduce((sum, f) => sum + (f.deletions || 0), 0);
-		if (additions === 0 && deletions === 0) return null;
-		return { additions, deletions };
-	}, [localChanges]);
 
 	const { data: aheadBehind, refetch: refetchAheadBehind } =
 		electronTrpc.workspaces.getAheadBehind.useQuery(
@@ -190,6 +175,22 @@ export function WorkspaceListItem({
 		workspaceBranch: branch,
 		workspaceId: id,
 	});
+
+	const localDiffStats = useMemo(() => {
+		if (!localChanges) return null;
+		const allFiles =
+			localChanges.againstBase.length > 0
+				? localChanges.againstBase
+				: [
+						...localChanges.staged,
+						...localChanges.unstaged,
+						...localChanges.untracked,
+					];
+		const additions = allFiles.reduce((sum, f) => sum + (f.additions || 0), 0);
+		const deletions = allFiles.reduce((sum, f) => sum + (f.deletions || 0), 0);
+		if (additions === 0 && deletions === 0) return null;
+		return { additions, deletions };
+	}, [localChanges]);
 
 	const handleClick = (e?: React.MouseEvent) => {
 		if (rename.isRenaming) return;
@@ -249,7 +250,11 @@ export function WorkspaceListItem({
 	};
 
 	const pr = githubStatus?.pr;
-	const diffStats = localDiffStats;
+	const diffStats =
+		localDiffStats ||
+		(pr && (pr.additions > 0 || pr.deletions > 0)
+			? { additions: pr.additions, deletions: pr.deletions }
+			: null);
 
 	const showBranchSubtitle = isBranchWorkspace || (!!name && name !== branch);
 
@@ -263,7 +268,6 @@ export function WorkspaceListItem({
 				isActive={isActive}
 				isUnread={isUnread}
 				workspaceStatus={workspaceStatus}
-				diffStats={diffStats}
 				itemRef={collapsedItemRef}
 				showDeleteDialog={showDeleteDialog}
 				setShowDeleteDialog={setShowDeleteDialog}
@@ -466,7 +470,6 @@ export function WorkspaceListItem({
 				isUnread={isUnread}
 				workspaceStatus={workspaceStatus}
 				sections={sections}
-				diffStats={diffStats}
 				onRename={rename.startRename}
 				onOpenInFinder={handleOpenInFinder}
 				onOpenInEditor={handleOpenInEditor}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/WorkspaceHoverCard.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/WorkspaceHoverCard.tsx
@@ -21,14 +21,12 @@ import { ReviewStatus } from "./components/ReviewStatus";
 interface WorkspaceHoverCardContentProps {
 	workspaceId: string;
 	workspaceAlias?: string;
-	diffStats?: { additions: number; deletions: number } | null;
 	onEditBranchClick?: (branchName: string) => void;
 }
 
 export function WorkspaceHoverCardContent({
 	workspaceId,
 	workspaceAlias,
-	diffStats,
 	onEditBranchClick,
 }: WorkspaceHoverCardContentProps) {
 	const { data: worktreeInfo } =
@@ -62,15 +60,6 @@ export function WorkspaceHoverCardContent({
 				Open Preview
 			</a>
 		</Button>
-	) : null;
-
-	const diffStatsBadge = diffStats ? (
-		<div className="flex items-center gap-1.5 text-xs font-mono shrink-0">
-			<span className="text-emerald-500">+{diffStats.additions}</span>
-			<span className="text-destructive-foreground">
-				-{diffStats.deletions}
-			</span>
-		</div>
 	) : null;
 
 	const needsRebase = worktreeInfo?.gitStatus?.needsRebase;
@@ -176,7 +165,12 @@ export function WorkspaceHoverCardContent({
 								/>
 							)}
 						</div>
-						{diffStatsBadge}
+						<div className="flex items-center gap-1.5 text-xs font-mono shrink-0">
+							<span className="text-emerald-500">+{pr.additions}</span>
+							<span className="text-destructive-foreground">
+								-{pr.deletions}
+							</span>
+						</div>
 					</div>
 
 					<p className="text-xs leading-relaxed line-clamp-2">{pr.title}</p>
@@ -214,17 +208,10 @@ export function WorkspaceHoverCardContent({
 				</div>
 			) : repoUrl ? (
 				<div className="pt-2 border-t border-border space-y-2">
-					<div className="flex items-center justify-between gap-2">
-						<div className="text-xs text-muted-foreground">
-							No PR for this branch
-						</div>
-						{diffStatsBadge}
+					<div className="text-xs text-muted-foreground">
+						No PR for this branch
 					</div>
 					{previewButton}
-				</div>
-			) : diffStatsBadge ? (
-				<div className="pt-2 border-t border-border flex items-center justify-end">
-					{diffStatsBadge}
 				</div>
 			) : null}
 		</div>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/WorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/WorkspaceRow.tsx
@@ -15,6 +15,7 @@ import {
 	LuRotateCw,
 } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import { useHoverGitHubStatus } from "renderer/lib/githubQueryPolicy";
 import { useWorkspaceDeleteHandler } from "renderer/react-query/workspaces/useWorkspaceDeleteHandler";
 import { STROKE_WIDTH } from "../../WorkspaceSidebar/constants";
 import { DeleteWorkspaceDialog } from "../../WorkspaceSidebar/WorkspaceListItem/components/DeleteWorkspaceDialog/DeleteWorkspaceDialog";
@@ -36,6 +37,12 @@ export function WorkspaceRow({
 	isOpening,
 }: WorkspaceRowProps) {
 	const isBranch = workspace.type === "branch";
+	const { githubStatus, onMouseEnter: onGithubMouseEnter } =
+		useHoverGitHubStatus({
+			workspaceId: workspace.workspaceId,
+			surface: "workspace-row",
+			isWorktree: workspace.type === "worktree",
+		});
 	const { showDeleteDialog, setShowDeleteDialog, handleDeleteClick } =
 		useWorkspaceDeleteHandler();
 	const openFileInEditor = electronTrpc.external.openFileInEditor.useMutation({
@@ -51,6 +58,9 @@ export function WorkspaceRow({
 			});
 		}
 	};
+
+	const pr = githubStatus?.pr;
+	const showDiffStats = pr && (pr.additions > 0 || pr.deletions > 0);
 
 	const timeText = workspace.isOpen
 		? `Opened ${getRelativeTime(workspace.lastOpenedAt)}`
@@ -69,6 +79,7 @@ export function WorkspaceRow({
 			type="button"
 			onClick={handleClick}
 			disabled={isOpening}
+			onMouseEnter={onGithubMouseEnter}
 			className={cn(
 				"flex items-center gap-3 w-full px-4 py-2 group text-left",
 				"hover:bg-background/50 transition-colors",
@@ -132,6 +143,14 @@ export function WorkspaceRow({
 					<span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-red-400 opacity-75" />
 					<span className="relative inline-flex size-2 rounded-full bg-red-500" />
 				</span>
+			)}
+
+			{/* Diff stats */}
+			{showDiffStats && (
+				<div className="flex items-center gap-1 text-[10px] font-mono shrink-0">
+					<span className="text-emerald-500">+{pr.additions}</span>
+					<span className="text-destructive-foreground">-{pr.deletions}</span>
+				</div>
 			)}
 
 			{/* Spacer */}


### PR DESCRIPTION
Reverts #3881 — that PR was applied to the v1 sidebar/hover card, but the actual flicker we were chasing is in the v2 dashboard sidebar. Backing it out so v2 can be addressed cleanly on its own.

## Test plan
- [ ] v1 workspace hover card LOC reverts to PR-snapshot values (`pr.additions` / `pr.deletions`).
- [ ] Workspace list view shows PR-based diff stats again.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the v1 hover card/local diff stats change and restores PR-based additions/deletions. This keeps v1 stable while we handle the v2 sidebar flicker separately.

- **Bug Fixes**
  - Hover card shows PR `additions`/`deletions`; local diff stats removed.
  - Removed `diffStats` prop from v1 sidebar components.
  - Workspace list view shows PR diff stats again; loads PR data via `useHoverGitHubStatus`.

<sup>Written for commit 5ed236f37758ae81f8b2a1fa4a24f09b652c9cf5. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3887?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace rows now display PR addition and deletion statistics inline when a PR exists.

* **Refactor**
  * Removed redundant diff statistics prop passing through hover cards and context menus.
  * PR statistics now sourced directly from loaded PR data instead of passed through component props.
  * Simplified "No PR for this branch" state UI presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->