### PR TITLE
fix(desktop): suppress duplicate terminal query response leak in v2 terminal

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -3,6 +3,7 @@ import type { ProgressAddon } from "@xterm/addon-progress";
 import type { SearchAddon } from "@xterm/addon-search";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import { Terminal as XTerm } from "@xterm/xterm";
+import { suppressQueryResponses } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/suppressQueryResponses";
 import { DEFAULT_TERMINAL_SCROLLBACK } from "shared/constants";
 import {
 	applyTerminalFontFamilyCssVariable,
@@ -214,6 +215,12 @@ export function createRuntime(
 
 	installTerminalKeyEventHandler(terminal);
 
+	// Suppress duplicate query responses (DA1, DA2, OSC 10/11/12 query reply, etc.)
+	// — daemon HeadlessEmulator owns canonical replies; without this, renderer xterm's
+	// auto-reply leaks back through the PTY and gets echoed at the next interactive
+	// prompt of any line-edited CLI. See suppressQueryResponses.ts.
+	const disposeQuerySuppression = suppressQueryResponses(terminal);
+
 	// Activate Unicode 11 widths (inside loadAddons) before restoring the buffer,
 	// else CJK/emoji/ZWJ widths get baked wrong into the replay. (#3572)
 	const addonsResult = loadAddons(terminal);
@@ -241,7 +248,10 @@ export function createRuntime(
 		_disposeResizeObserver: null,
 		lastCols: cols,
 		lastRows: rows,
-		_disposeAddons: addonsResult.dispose,
+		_disposeAddons: () => {
+			disposeQuerySuppression();
+			addonsResult.dispose();
+		},
 		_disposeImagePasteFallback: disposeImagePasteFallback,
 	};
 }

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -3,6 +3,7 @@ import type { ProgressAddon } from "@xterm/addon-progress";
 import type { SearchAddon } from "@xterm/addon-search";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import { Terminal as XTerm } from "@xterm/xterm";
+import { suppressQueryResponses } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/suppressQueryResponses";
 import { DEFAULT_TERMINAL_SCROLLBACK } from "shared/constants";
 import {
 	applyTerminalFontFamilyCssVariable,
@@ -213,6 +214,12 @@ export function createRuntime(
 
 	installTerminalKeyEventHandler(terminal);
 
+	// Suppress duplicate query responses (DA1, DA2, OSC 10/11/12 query reply, etc.)
+	// — daemon HeadlessEmulator owns canonical replies; without this, renderer xterm's
+	// auto-reply leaks back through the PTY and gets echoed at the next interactive
+	// prompt of any line-edited CLI. See suppressQueryResponses.ts.
+	const disposeQuerySuppression = suppressQueryResponses(terminal);
+
 	// Activate Unicode 11 widths (inside loadAddons) before restoring the buffer,
 	// else CJK/emoji/ZWJ widths get baked wrong into the replay. (#3572)
 	const addonsResult = loadAddons(terminal);
@@ -240,7 +247,10 @@ export function createRuntime(
 		_disposeResizeObserver: null,
 		lastCols: cols,
 		lastRows: rows,
-		_disposeAddons: addonsResult.dispose,
+		_disposeAddons: () => {
+			disposeQuerySuppression();
+			addonsResult.dispose();
+		},
 		_disposeImagePasteFallback: disposeImagePasteFallback,
 	};
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/suppressQueryResponses.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/suppressQueryResponses.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Verifies the renderer-side suppressors keep terminal queries from generating
+ * `onData` replies that would round-trip back to the PTY and echo as visible
+ * text at interactive prompts.
+ *
+ * Uses `@xterm/headless` (same parser as `@xterm/xterm`) because it runs under
+ * bun without a DOM.
+ */
+
+// xterm env polyfill comes from bunfig.toml `preload`.
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Terminal as XTerm } from "@xterm/xterm";
+
+import { suppressQueryResponses } from "./suppressQueryResponses";
+
+const { Terminal } = await import("@xterm/headless");
+
+const ESC = "\x1b";
+const CSI = `${ESC}[`;
+const OSC = `${ESC}]`;
+const BEL = "\x07";
+
+type Disposer = () => void;
+
+interface Harness {
+	terminal: InstanceType<typeof Terminal>;
+	cleanup: Disposer;
+	captured: string[];
+}
+
+function setup(): Harness {
+	const terminal = new Terminal({ cols: 80, rows: 24, allowProposedApi: true });
+	const captured: string[] = [];
+	terminal.onData((data) => captured.push(data));
+	// suppressQueryResponses takes `@xterm/xterm` Terminal but only touches
+	// `.parser`, which is shape-compatible with `@xterm/headless`.
+	const cleanup = suppressQueryResponses(terminal as unknown as XTerm);
+	return { terminal, cleanup, captured };
+}
+
+async function write(
+	terminal: InstanceType<typeof Terminal>,
+	data: string,
+): Promise<void> {
+	await new Promise<void>((resolve) => terminal.write(data, () => resolve()));
+}
+
+describe("suppressQueryResponses", () => {
+	let harness: Harness;
+
+	beforeEach(() => {
+		harness = setup();
+	});
+
+	afterEach(() => {
+		harness.cleanup();
+		harness.terminal.dispose();
+	});
+
+	describe("Device Attributes (DA)", () => {
+		test("suppresses DA1 query response (CSI c)", async () => {
+			await write(harness.terminal, `${CSI}c`);
+			expect(harness.captured).toEqual([]);
+		});
+
+		test("suppresses DA1 query response (CSI 0c)", async () => {
+			await write(harness.terminal, `${CSI}0c`);
+			expect(harness.captured).toEqual([]);
+		});
+
+		test("suppresses DA2 query response (CSI > c)", async () => {
+			await write(harness.terminal, `${CSI}>c`);
+			expect(harness.captured).toEqual([]);
+		});
+	});
+
+	describe("OSC color queries", () => {
+		test("suppresses OSC 10 fg color query", async () => {
+			await write(harness.terminal, `${OSC}10;?${BEL}`);
+			expect(harness.captured).toEqual([]);
+		});
+
+		test("suppresses OSC 11 bg color query", async () => {
+			await write(harness.terminal, `${OSC}11;?${BEL}`);
+			expect(harness.captured).toEqual([]);
+		});
+
+		test("suppresses OSC 12 cursor color query", async () => {
+			await write(harness.terminal, `${OSC}12;?${BEL}`);
+			expect(harness.captured).toEqual([]);
+		});
+
+		test("does NOT suppress OSC 11 set command", async () => {
+			// Set commands have a color spec payload, not '?'. Must still take
+			// effect so themes propagate.
+			await write(harness.terminal, `${OSC}11;rgb:00/00/00${BEL}`);
+			// Set commands themselves don't produce onData; we only assert the
+			// handler delegated to xterm's default (no replies, no errors).
+			expect(harness.captured).toEqual([]);
+		});
+	});
+
+	describe("response-only sequences", () => {
+		test("suppresses focus-in report (CSI I)", async () => {
+			await write(harness.terminal, `${CSI}I`);
+			expect(harness.captured).toEqual([]);
+		});
+
+		test("suppresses focus-out report (CSI O)", async () => {
+			await write(harness.terminal, `${CSI}O`);
+			expect(harness.captured).toEqual([]);
+		});
+
+		test("suppresses cursor position report response (CSI ; R)", async () => {
+			// Renderer should not re-emit a stray CPR response.
+			await write(harness.terminal, `${CSI}24;1R`);
+			expect(harness.captured).toEqual([]);
+		});
+
+		test("suppresses DECRPM mode report response (CSI ? Pm $ y)", async () => {
+			await write(harness.terminal, `${CSI}?2004;1$y`);
+			expect(harness.captured).toEqual([]);
+		});
+	});
+
+	describe("queries that must still be answered", () => {
+		test("DSR cursor position query (CSI 6n) still emits a CPR reply", async () => {
+			// We deliberately do NOT suppress DSR; only the daemon's headless
+			// emulator answers DA/OSC color but DSR is fine to answer from
+			// either side. This guards against accidentally widening the
+			// suppression to all CSI sequences.
+			await write(harness.terminal, `${CSI}6n`);
+			expect(harness.captured.length).toBeGreaterThan(0);
+			expect(harness.captured.join("")).toMatch(
+				new RegExp(`^${ESC}\\[\\d+;\\d+R$`),
+			);
+		});
+	});
+
+	describe("cleanup", () => {
+		test("disposing un-suppresses queries", async () => {
+			harness.cleanup();
+			await write(harness.terminal, `${CSI}c`);
+			// Default DA1 handler should now answer.
+			expect(harness.captured.join("")).toMatch(new RegExp(`^${ESC}\\[\\?\\d`));
+		});
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/suppressQueryResponses.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/suppressQueryResponses.ts
@@ -1,21 +1,33 @@
 import type { Terminal } from "@xterm/xterm";
 
 /**
- * Registers parser hooks to suppress terminal query responses from being displayed.
+ * Registers parser hooks to suppress terminal query responses from being
+ * generated or rendered by the renderer xterm.
  *
- * These handlers intercept specific response-only sequences that should not appear
- * as visible text. We only suppress sequences where the response has a DIFFERENT
- * format than the query, ensuring we don't break terminal functionality.
+ * In superset's split architecture the daemon owns a HeadlessEmulator that
+ * answers terminal queries (DA, DSR, OSC 10/11/12, etc.) and writes the
+ * response back into the PTY. That is the canonical reply.
  *
- * SAFE to suppress (response-only, query uses different format):
- * - CSI R: CPR response (query is CSI 6n)
- * - CSI I/O: Focus reports (no query, just mode enable)
- * - CSI $y: Mode report (query is CSI $p)
+ * The renderer xterm receives the same PTY output and would also auto-reply
+ * via `terminal.onData` -> WebSocket -> daemon `write()` -> PTY stdin. Once
+ * the shell-ready guard in `session.ts` releases (escape filter only fires
+ * during `pending`), those duplicate responses pass through and get echoed by
+ * the kernel PTY driver as visible text at the next interactive prompt
+ * (e.g. an interactive CLI's `Enter value:` prompt showing
+ * `^[[?62;4;9;22c^[]11;rgb:0c0c/0e0e/1414^[\\`).
  *
- * NOT suppressed (would break queries/commands):
- * - CSI c: DA query AND response both end in 'c'
- * - CSI t: Window query AND response both end in 't'
- * - OSC colors: Set command AND response have same format
+ * Two suppression strategies, picked per-sequence:
+ *
+ * 1. **Suppress at the query side** — register a handler matching the QUERY's
+ *    final byte and return `true`. Xterm's default handler is bypassed and no
+ *    `onData` reply is generated, so nothing reaches the PTY. Safe because
+ *    the headless emulator still answers. Used for DA1, DA2, OSC 10/11/12.
+ *
+ * 2. **Suppress at the response side** — register a handler matching the
+ *    RESPONSE's distinguishing bytes. Used when query and response share a
+ *    final byte but a different prefix/intermediate distinguishes them (CPR,
+ *    focus reports, mode reports). Prevents echoed responses from rendering
+ *    as visible text without affecting query interpretation.
  *
  * @param terminal - The xterm.js Terminal instance
  * @returns Cleanup function to dispose all registered handlers
@@ -24,25 +36,41 @@ export function suppressQueryResponses(terminal: Terminal): () => void {
 	const disposables: { dispose: () => void }[] = [];
 	const parser = terminal.parser;
 
-	// CSI sequences ending in 'R' - Cursor Position Report (SAFE)
-	// Query: ESC[6n (ends in 'n'), Response: ESC[24;1R (ends in 'R')
-	// Different final bytes, so suppressing 'R' only catches responses
+	// CSI Ps c — Primary Device Attributes (DA1) query.
+	// Query: `ESC[c` or `ESC[0c`. Response: `ESC[?62;...c` (handled by daemon's
+	// headless emulator). Suppressing the query stops the renderer from
+	// generating a duplicate response that would echo at the next prompt.
+	disposables.push(parser.registerCsiHandler({ final: "c" }, () => true));
+
+	// CSI > Ps c — Secondary Device Attributes (DA2) query. Same rationale.
+	disposables.push(
+		parser.registerCsiHandler({ prefix: ">", final: "c" }, () => true),
+	);
+
+	// CSI sequences ending in 'R' — Cursor Position Report (response only).
+	// Query is `ESC[6n` (final 'n'); response final byte 'R' is unique to the
+	// reply, so suppressing renders no visible text if a stray response echoes.
 	disposables.push(parser.registerCsiHandler({ final: "R" }, () => true));
 
-	// CSI sequences ending in 'I' - Focus In report (SAFE)
-	// No query - this is sent when terminal gains focus (mode 1004)
+	// CSI sequences ending in 'I' / 'O' — focus in/out reports (mode 1004).
+	// No matching query; emitted by the terminal on focus changes.
 	disposables.push(parser.registerCsiHandler({ final: "I" }, () => true));
-
-	// CSI sequences ending in 'O' - Focus Out report (SAFE)
-	// No query - this is sent when terminal loses focus (mode 1004)
 	disposables.push(parser.registerCsiHandler({ final: "O" }, () => true));
 
-	// CSI sequences ending in 'y' with '$' intermediate - Mode Reports (SAFE)
-	// Query: ESC[?Ps$p (ends in 'p'), Response: ESC[?Ps;Pm$y (ends in 'y')
-	// Different final bytes, so suppressing '$y' only catches responses
+	// CSI ? Ps ; Pm $ y — DECRPM mode report (response only).
+	// Query is `ESC[?Ps$p` (final 'p'); response final '$y' is unique.
 	disposables.push(
 		parser.registerCsiHandler({ intermediates: "$", final: "y" }, () => true),
 	);
+
+	// OSC 10/11/12 — fg/bg/cursor color queries vs. set commands.
+	// Query payload: `?` (e.g. `ESC]11;?BEL`). Set payload: a color spec
+	// (`#rrggbb`, `rgb:rr/gg/bb`, named color, etc.). Suppress only when the
+	// payload is a query so set commands continue to update theme colors.
+	const suppressColorQuery = (data: string): boolean => data.startsWith("?");
+	disposables.push(parser.registerOscHandler(10, suppressColorQuery));
+	disposables.push(parser.registerOscHandler(11, suppressColorQuery));
+	disposables.push(parser.registerOscHandler(12, suppressColorQuery));
 
 	return () => {
 		for (const disposable of disposables) {

--- a/docs/superpowers/specs/2026-06-08-vertex-small-model-design.md
+++ b/docs/superpowers/specs/2026-06-08-vertex-small-model-design.md
@@ -1,0 +1,133 @@
+# Vertex AI provider for `getSmallModel`
+
+**Date:** 2026-06-08
+**Status:** Approved (design)
+**Scope:** Minimal — engine only. No new settings UI, no new tRPC router.
+
+## Problem
+
+Desktop v2 workspaces fall back to random two-word branch names (e.g. `roan-modem`)
+instead of AI-generated names relevant to the task prompt. Root cause: workspace
+naming calls `getSmallModel()`
+(`packages/chat/src/server/shared/small-model/get-small-model.ts`), which resolves a
+small LLM from one of: `ANTHROPIC_API_KEY` env → mastracode Anthropic key → mastracode
+Anthropic OAuth → `OPENAI_API_KEY` env → mastracode OpenAI key. It returns `null` when
+none are present, logging `[get-small-model] no credentials found — naming will fall
+back`.
+
+Users on Google Vertex AI for Claude (`CLAUDE_CODE_USE_VERTEX=1`, ADC via
+`~/.config/gcloud/application_default_credentials.json`, no Anthropic API key) hit the
+`null` path every time. `getSmallModel` has no Vertex branch, and mastracode 0.18.1 has
+zero Vertex support. So naming can never succeed for these users today.
+
+## Goal
+
+Let `getSmallModel` produce a working small model from Google Vertex AI (Claude on
+Vertex) when the user is configured for Vertex, with no Anthropic/OpenAI key required.
+Fixes all five `getSmallModel` consumers at once (desktop `ai-name`, desktop
+`ai-branch-name`, host-service `ai-branch-name`, host-service `ai-workspace-names`, and
+any future caller) since they share the one function.
+
+## Non-goals
+
+- No settings-page UI for Vertex (configure via existing env / Advanced "Additional env
+  vars" field).
+- No Vertex support for the in-app chat agent (that runs through mastracode, which has no
+  Vertex provider — separate, larger effort).
+- No new persistence store or tRPC procedures.
+
+## Approach
+
+Approach A (minimal engine). Add a flag-gated Vertex resolver to `getSmallModel`,
+reusing the existing env-config persistence for configuration input.
+
+### Components
+
+**1. Dependency**
+
+Add `@ai-sdk/google-vertex` (pin `3.0.127`, already resolved transitively in `bun.lock`)
+to `packages/chat/package.json` dependencies. Run `bun install`.
+
+**2. `vertex-config.ts` — new file, co-located in `small-model/`**
+
+Exports `resolveVertexConfig(): { project: string; location: string } | null`.
+Returns the config object only when Vertex is fully enabled; returns `null` otherwise
+(flag off, or project missing). Single contract — no `enabled` field.
+
+- Reads `CLAUDE_CODE_USE_VERTEX`, `ANTHROPIC_VERTEX_PROJECT_ID`, `CLOUD_ML_REGION` from
+  `process.env`, falling back per-key to the persisted
+  `~/.superset/chat-anthropic-env.json` blob (parsed via the existing env-text parser)
+  when a key is absent from `process.env`.
+  - Rationale for the file fallback: the Advanced "Additional env vars" settings field
+    persists to that file, but the file is only applied to `process.env` on certain
+    runtime paths (e.g. `runtime/chat` `prepareRuntimeEnv`), **not** the
+    workspace-creation/naming path. Reading the file directly makes the existing settings
+    field actually drive naming regardless of process or timing.
+  - Path resolved the same way as the existing readers: `SUPERSET_HOME_DIR` (trimmed) or
+    `~/.superset`, then `chat-anthropic-env.json`.
+- Enabled when `CLAUDE_CODE_USE_VERTEX === "1"` and `project.length > 0`; only then is
+  the object returned. Otherwise `null`.
+- `location = CLOUD_ML_REGION ?? "global"`.
+
+**3. `get-small-model.ts` — edit**
+
+- New constant `VERTEX_SMALL_MODEL_ID = "claude-haiku-4-5@20251001"` (Vertex uses the
+  `@`-date model id form, vs the Anthropic API `-date` form).
+- New `resolveVertex()`:
+  - Call `resolveVertexConfig()`. If `null`, return `null`.
+  - Else `return createVertexAnthropic({ project, location })(VERTEX_SMALL_MODEL_ID)`.
+    ADC is auto-detected by `google-auth-library`; no API key passed.
+  - Wrap in try/catch: on any throw (bad ADC, network, init), `console.warn` and return
+    `null` so naming falls through to the existing resolvers instead of dying.
+- Precedence: call `resolveVertex()` **first** in `getSmallModel`, before
+  `resolveAnthropic()`. Because it only returns non-null when `CLAUDE_CODE_USE_VERTEX===1`
+  and a project is set, behavior with the flag unset is byte-for-byte identical to today.
+  Opt-in flag wins, matching claude-code semantics.
+
+### Data flow
+
+```
+getSmallModel()
+  → resolveVertex()            // flag-gated; null unless CLAUDE_CODE_USE_VERTEX=1 + project
+      → createVertexAnthropic({project, location})(VERTEX_SMALL_MODEL_ID)
+  → resolveAnthropic()         // apiKey | oauth  (unchanged)
+  → resolveOpenAIApiKey()      // unchanged
+  → null  + "no credentials found" warning  (unchanged)
+```
+
+### Error handling
+
+- `resolveVertex()` try/catch → warn + fall through (a misconfigured Vertex must not
+  break naming entirely).
+- Existing 5s caller timeout (`GENERATE_TIMEOUT_MS` in `ai-workspace-names.ts`) unchanged.
+- Keep the final `no credentials found — naming will fall back` warning.
+
+### Testing
+
+- `vertex-config.test.ts`:
+  - env value used when present.
+  - file-blob fallback used when env key absent (mock fs read of `chat-anthropic-env.json`).
+  - env overrides file when both present.
+  - `enabled=false` when `CLAUDE_CODE_USE_VERTEX !== "1"`.
+  - `enabled=false` when project missing even if flag set.
+  - `location` defaults to `"global"` when `CLOUD_ML_REGION` unset.
+- `get-small-model.test.ts`:
+  - returns a Vertex model when enabled (mock `createVertexAnthropic`).
+  - flag-off path unchanged (Vertex skipped, existing resolution order intact).
+
+## Risks / to verify during planning
+
+1. **Provider-version compatibility.** `@ai-sdk/google-vertex@3.0.127` bundles
+   `@ai-sdk/anthropic@2.0.74` / `@ai-sdk/provider@2.0.1`, while `packages/chat` uses
+   `@ai-sdk/anthropic@3.0.64`. Confirm the object returned by `createVertexAnthropic(...)`
+   satisfies the Mastra `LanguageModel` (provider V2 `LanguageModelV2`) interface the
+   small-model path expects. If incompatible, align versions or wrap the model.
+2. **ADC reachability.** Relies on
+   `~/.config/gcloud/application_default_credentials.json` being readable by whichever
+   process runs naming (host-service child for v2; Electron main for some desktop paths).
+   `HOME` is set in both, so default ADC discovery should work; verify.
+3. **Model availability.** Confirm `claude-haiku-4-5@20251001` is enabled in the target
+   Vertex project/region (`consolo-dev-vertex-wsky`, region `us`/`global`).
+4. **Config-source decision (recorded).** User chose env-only as the config source; the
+   file fallback is an additive robustness measure that keeps the existing settings field
+   functional for naming, not a new config surface.


### PR DESCRIPTION
**Links**
- Closes: #3499

## Summary
- Wire the existing `suppressQueryResponses` helper into v2 terminal runtime so it matches v1's behavior. Without this, every v2 terminal pane lets renderer xterm auto-reply to DA/OSC color queries and the duplicate reply round-trips back through the PTY.
- Strengthen the helper to suppress at the **query** side (not just response side) for sequences where query and response share a final byte (DA1, DA2, OSC 10/11/12). Response-side suppression alone cannot stop the leak for these.
- Add 13 unit tests using `@xterm/headless` covering each query class and the cleanup path.

## Why / Context
In Superset's split terminal architecture, the daemon hosts a `HeadlessEmulator` that owns the canonical reply to terminal queries (DA, DSR, OSC 10/11/12, etc.) and writes the response back into the PTY. The renderer xterm sees the same PTY output and would also auto-reply via `terminal.onData → WebSocket → daemon Session.write() → PTY stdin`.

`session.ts` filters renderer-originated escape replies, but only while `shellReadyState === "pending"`. Once the shell is ready, those duplicate responses pass through. The kernel PTY driver then echoes them as visible text at the next interactive prompt of any line-edited CLI — e.g. `spacectl profile login` shows:

```
Enter your tenant subdomain: ^[[?62;4;9;22c^[]11;rgb:0c0c/0e0e/1414^[\
```

Symptom: every interactive CLI in a Superset v2 terminal silently corrupts its first prompt with escape garbage. OMP's interactive bash tool consistently fails to parse prompts as a result. v1 terminals were unaffected because they already called this helper in `helpers.ts:150`; v2 terminals never got the same treatment.

## How It Works
Two suppression strategies, picked per-sequence based on whether the query and response share a final byte:

1. **Suppress at the query side** — register a parser handler matching the **query's** final byte and return `true`. xterm's default handler is bypassed, no `onData` reply is generated, nothing reaches the PTY. Used for **DA1 (`CSI c`), DA2 (`CSI > c`), OSC 10/11/12 color queries**. Safe because the daemon's headless emulator still answers.
2. **Suppress at the response side** — register a handler matching the response's distinguishing bytes. Used for sequences where the response has a unique final byte vs. the query: **CPR (`CSI R`), focus reports (`CSI I/O`), DECRPM (`CSI $y`)**.

OSC color handlers gate on payload prefix: only suppress when payload starts with `?` (query). Set commands (`OSC 11;rgb:...`) still take effect so themes propagate.

The wiring in `terminal-runtime.ts` calls `suppressQueryResponses(terminal)` right after attaching the key event handler, and folds the disposer into `_disposeAddons` so cleanup runs alongside the rest of the runtime teardown.

## Manual QA Checklist

### Terminal Features
- [x] `spacectl profile login` no longer corrupts its prompt; full interactive flow completes
- [x] Per-query repro shows zero reply bytes for DA1, DA2, OSC 10, OSC 11, OSC 12 individually
  ```
  bash -c 'stty -echo; printf "\e[c"; sleep 0.4; reply=""; while IFS= read -r -t 1 -n 1 ch; do reply+="$ch"; done; stty echo; echo "${#reply} bytes"'
  ```
- [x] Combined probe (`printf '\e[c\e[>c\e]10;?\a\e]11;?\a\e]12;?\a'; read -p`) — no `?62;4;9;22c` or `]11;rgb:...` text in prompt
- [x] DSR cursor position query (`CSI 6n`) still gets a CPR reply (regression guard — confirms suppression isn't over-broad)
- [x] OMP's interactive bash tool no longer trips on prompt parsing
- [x] Terminal pane closes/disposes cleanly (helper returns disposer, wired into `_disposeAddons`)

## Testing
- `bun run typecheck` (`@superset/desktop` — passes)
- `bunx biome check` on the 3 touched files (passes)
- `bun test apps/desktop/src/.../suppressQueryResponses.test.ts` — 13 pass
- Manual repro in dev electron with new dev `terminal-host` daemon

## Design Decisions
- **Why suppress at query side (not response side) for DA/OSC**: DA's query and response both end in `c`; OSC 10/11/12 query and set commands share the same OSC number. A response-side filter cannot distinguish them. Query-side suppression catches the input before xterm decides to reply, which is both simpler and removes the leak at its source.
- **Why keep response-side suppression for CPR/focus/DECRPM**: their response final bytes (`R`, `I`/`O`, `$y`) are distinct from any query, so response-side is unambiguous and avoids accidentally swallowing legitimate queries we don't own.
- **Why not suppress in the daemon's `Session.write()` filter**: that filter exists for the pre-shell window. Permanently filtering all renderer→PTY escape replies would break legitimate paste/typed escape input. Suppressing at the renderer parser level removes only the auto-replies we don't want, while keeping user input intact.

## Known Limitations
- Existing terminal pane runtimes created **before** the fix loaded keep their old, leak-prone runtime instance (the runtime registry caches per-pane state across HMR). Newly-opened panes after this PR ships pick up the fix automatically; users with a long-lived pane may need to close and reopen it once.

## Risks / Rollout
- **Risk:** Low. The helper is a renderer-only behavior change; it never touches the daemon, the PTY, or persistence. Worst-case rollback affects only what xterm does with 6 specific escape sequence classes.
- **Rollout:** Ship in next desktop release. No flag, no migration, no cross-package dependency.
- **Rollback:** Revert this commit. v2 terminals revert to leaking behavior; v1 terminals unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses duplicate terminal query replies in v2 by installing parser hooks and cleaning them up with the runtime, preventing prompt corruption and matching v1 behavior. Also adds a design spec for a Vertex AI provider in `getSmallModel` (docs only). Closes #3499.

- **Bug Fixes**
  - Wired `suppressQueryResponses` into the v2 runtime and dispose via `_disposeAddons`.
  - Suppress queries for DA1 (`CSI c`/`CSI 0c`), DA2 (`CSI > c`), and OSC 10/11/12 when payload starts with `?`; set commands still work.
  - Keep response-side suppression for CPR (`CSI R`), focus reports (`CSI I/O`), and DECRPM (`CSI ?…$y`); DSR (`CSI 6n`) still replies.
  - Added `@xterm/headless` tests covering suppression behavior and cleanup.

- **Migration**
  - Close and reopen existing terminal panes to pick up the fix.

<sup>Written for commit 0a5eb9a9d58ee4229c0aab3de1f732bb84247321. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/3894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded terminal suppression to cover additional terminal query responses (reducing duplicate/noisy escape output) while allowing legitimate settings to apply.
  * Ensured suppression is consistently cleaned up when the terminal runtime is disposed.

* **Tests**
  * Added tests exercising many escape-sequence queries, verifying suppression, expected non-suppressed replies, and disposal/resume behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->