### PR TITLE
fix(api): jwtProcedure accepts x-api-key sessions, not just Bearer

### DIFF
--- a/packages/trpc/src/trpc.ts
+++ b/packages/trpc/src/trpc.ts
@@ -72,34 +72,31 @@ export const protectedProcedure = t.procedure
 
 export const jwtProcedure = t.procedure.use(async ({ ctx, next }) => {
 	const authHeader = ctx.headers.get("authorization");
-	if (!authHeader?.startsWith("Bearer ")) {
-		throw new TRPCError({
-			code: "UNAUTHORIZED",
-			message: "Bearer token required",
-		});
-	}
+	const bearer = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
 
-	const token = authHeader.slice(7);
-
-	try {
-		const { payload } = await ctx.auth.api.verifyJWT({ body: { token } });
-		if (payload?.sub) {
-			const organizationIds = (payload.organizationIds as string[]) ?? [];
-			return next({
-				ctx: {
-					userId: payload.sub,
-					email: (payload.email as string) ?? "",
-					organizationIds,
-					activeOrganizationId: organizationIds[0] ?? null,
-				},
+	if (bearer) {
+		try {
+			const { payload } = await ctx.auth.api.verifyJWT({
+				body: { token: bearer },
 			});
+			if (payload?.sub) {
+				const organizationIds = (payload.organizationIds as string[]) ?? [];
+				return next({
+					ctx: {
+						userId: payload.sub,
+						email: (payload.email as string) ?? "",
+						organizationIds,
+						activeOrganizationId: organizationIds[0] ?? null,
+					},
+				});
+			}
+		} catch (error) {
+			// A live session is the legit fallback for an unverifiable token
+			// (expired/missing). A TRPCError from verifyJWT is an explicit
+			// rejection (revoked/forged) — surface it instead of laundering
+			// it into session auth.
+			if (error instanceof TRPCError) throw error;
 		}
-	} catch (error) {
-		// A live session is the legit fallback for an unverifiable token
-		// (expired/missing). A TRPCError from verifyJWT is an explicit
-		// rejection (revoked/forged) — surface it instead of laundering it
-		// into session auth.
-		if (error instanceof TRPCError) throw error;
 	}
 
 	if (ctx.session) {
@@ -124,7 +121,7 @@ export const jwtProcedure = t.procedure.use(async ({ ctx, next }) => {
 
 	throw new TRPCError({
 		code: "UNAUTHORIZED",
-		message: "Invalid bearer token",
+		message: "Not authenticated. Provide a bearer JWT, x-api-key, or session.",
 	});
 });
 


### PR DESCRIPTION
## Summary

`jwtProcedure` was rejecting any request without an `Authorization: Bearer …` header before reaching its session fallback. Better-auth's apiKey plugin (`enableSessionForAPIKeys: true`) populates `ctx.session` for `x-api-key` requests, so they're session-equivalent — but they couldn't reach that branch because the upfront throw fired first.

Concretely, the CLI's \`--api-key sk_live_…\` flag round-tripped through better-auth (returns 200 against \`protectedProcedure\` like \`user.me\`), but every \`jwtProcedure\`-gated procedure (\`host.list\`, \`v2-workspace.list\`, etc.) returned 401. \`superset hosts list\` and \`superset workspaces list\` were unusable with API keys.

This PR rewrites the procedure to accept any of:
1. A verifiable Bearer JWT (CLI OAuth flow)
2. A live \`ctx.session\` (web cookie OR x-api-key-derived session)

Bot-fix from #3889 preserved: TRPCError instances from \`verifyJWT\` (revoked/forged tokens) still re-throw rather than silently falling through.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` clean
- [ ] CLI with \`SUPERSET_API_KEY=sk_live_…\` succeeds on \`superset hosts list\`, \`superset workspaces list\`
- [ ] CLI with OAuth JWT still works (no regression)
- [ ] Desktop session-cookie path still works (no regression)
- [ ] Revoked JWT still surfaces UNAUTHORIZED instead of silently using session

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow `jwtProcedure` to authenticate with a Bearer JWT or any live session (cookie or `x-api-key`), fixing CLI API key flows that were returning 401. CLI commands like `superset hosts list` and `superset workspaces list` now work with `--api-key` or `SUPERSET_API_KEY`.

- **Bug Fixes**
  - Removed the Bearer-only guard; verify JWT if present, otherwise use `ctx.session` (includes `x-api-key` sessions from `better-auth`).
  - Preserved re-throw of `TRPCError` from `verifyJWT` for explicit JWT rejection.
  - Updated unauthorized message to list accepted auth methods.

<sup>Written for commit e19be156d58ea3edb962c5c499faa4d9a811ae3a. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3895?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved authentication flow to support multiple credential types: bearer JWT, x-api-key, or session authentication
  * Enhanced error messages to reflect all available authentication methods
  * Fixed authentication handling to allow graceful fallback between credential types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->