### PR TITLE
feat(desktop): hover dropdown actions on changes sidebar rows

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -116,6 +116,7 @@ export function WorkspaceSidebar({
 		workspaceId,
 		gitStatus,
 		onSelectFile: onSelectDiffFile,
+		onOpenFile: onSelectFile,
 	});
 	const changesTab: SidebarTabDefinition = {
 		...changesTabDef,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/ChangesFileList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/ChangesFileList.tsx
@@ -7,6 +7,7 @@ interface ChangesFileListProps {
 	isLoading?: boolean;
 	worktreePath?: string;
 	onSelectFile?: (path: string, openInNewTab?: boolean) => void;
+	onOpenFile?: (absolutePath: string, openInNewTab?: boolean) => void;
 	onOpenInEditor?: (path: string) => void;
 }
 
@@ -15,6 +16,7 @@ export const ChangesFileList = memo(function ChangesFileList({
 	isLoading,
 	worktreePath,
 	onSelectFile,
+	onOpenFile,
 	onOpenInEditor,
 }: ChangesFileListProps) {
 	if (isLoading) {
@@ -41,6 +43,7 @@ export const ChangesFileList = memo(function ChangesFileList({
 					file={file}
 					worktreePath={worktreePath}
 					onSelect={onSelectFile}
+					onOpenFile={onOpenFile}
 					onOpenInEditor={onOpenInEditor}
 				/>
 			))}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
@@ -6,7 +6,15 @@ import {
 	ContextMenuShortcut,
 	ContextMenuTrigger,
 } from "@superset/ui/context-menu";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuShortcut,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { ChevronDown } from "lucide-react";
 import { memo } from "react";
 import { StatusIndicator } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/StatusIndicator";
 import { PathActionsMenuItems } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/PathActionsMenuItems";
@@ -33,6 +41,7 @@ interface FileRowProps {
 	file: ChangesetFile;
 	worktreePath?: string;
 	onSelect?: (path: string, openInNewTab?: boolean) => void;
+	onOpenFile?: (absolutePath: string, openInNewTab?: boolean) => void;
 	onOpenInEditor?: (path: string) => void;
 }
 
@@ -40,6 +49,7 @@ export const FileRow = memo(function FileRow({
 	file,
 	worktreePath,
 	onSelect,
+	onOpenFile,
 	onOpenInEditor,
 }: FileRowProps) {
 	const { dir, basename } = splitPath(file.path);
@@ -52,46 +62,90 @@ export const FileRow = memo(function FileRow({
 		: undefined;
 
 	const rowButton = (
-		<button
-			type="button"
-			className="flex w-full items-center gap-1.5 py-1 pr-3 pl-3 text-left text-xs hover:bg-accent/50"
-			onClick={(e) => {
-				const intent = getSidebarClickIntent(e);
-				if (intent === "openInEditor") {
-					onOpenInEditor?.(file.path);
-				} else {
-					onSelect?.(file.path, intent === "openInNewTab");
-				}
-			}}
-		>
-			<FileIcon fileName={basename} className="size-3.5 shrink-0" />
-			<span className="flex min-w-0 flex-1 items-baseline overflow-hidden">
-				{dir && <span className="truncate text-muted-foreground">{dir}</span>}
-				{oldBasename && (
-					<span className="truncate text-muted-foreground">
-						{oldBasename}
-						<span className="px-1">→</span>
+		<div className="group relative">
+			<button
+				type="button"
+				className="flex w-full items-center gap-1.5 py-1 pr-3 pl-3 text-left text-xs hover:bg-accent/50"
+				onClick={(e) => {
+					const intent = getSidebarClickIntent(e);
+					if (intent === "openInEditor") {
+						onOpenInEditor?.(file.path);
+					} else {
+						onSelect?.(file.path, intent === "openInNewTab");
+					}
+				}}
+			>
+				<FileIcon fileName={basename} className="size-3.5 shrink-0" />
+				<span className="flex min-w-0 flex-1 items-baseline overflow-hidden">
+					{dir && <span className="truncate text-muted-foreground">{dir}</span>}
+					{oldBasename && (
+						<span className="truncate text-muted-foreground">
+							{oldBasename}
+							<span className="px-1">→</span>
+						</span>
+					)}
+					<span className="min-w-[120px] truncate font-medium text-foreground">
+						{basename}
 					</span>
-				)}
-				<span className="min-w-[120px] truncate font-medium text-foreground">
-					{basename}
 				</span>
-			</span>
-			<span className="ml-auto flex shrink-0 items-center gap-1.5">
-				{(file.additions > 0 || file.deletions > 0) && (
-					<span className="text-[10px] text-muted-foreground">
-						{file.additions > 0 && (
-							<span className="text-green-400">+{file.additions}</span>
-						)}
-						{file.additions > 0 && file.deletions > 0 && " "}
-						{file.deletions > 0 && (
-							<span className="text-red-400">-{file.deletions}</span>
-						)}
-					</span>
-				)}
-				<StatusIndicator status={file.status} />
-			</span>
-		</button>
+				<span className="ml-auto flex shrink-0 items-center gap-1.5 group-hover:invisible">
+					{(file.additions > 0 || file.deletions > 0) && (
+						<span className="text-[10px] text-muted-foreground">
+							{file.additions > 0 && (
+								<span className="text-green-400">+{file.additions}</span>
+							)}
+							{file.additions > 0 && file.deletions > 0 && " "}
+							{file.deletions > 0 && (
+								<span className="text-red-400">-{file.deletions}</span>
+							)}
+						</span>
+					)}
+					<StatusIndicator status={file.status} />
+				</span>
+			</button>
+			<div className="pointer-events-none absolute inset-y-0 right-2 flex items-center gap-0.5 opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 has-[[data-state=open]]:pointer-events-auto has-[[data-state=open]]:opacity-100">
+				<DropdownMenu>
+					<DropdownMenuTrigger asChild>
+						<button
+							type="button"
+							aria-label="More actions"
+							className="flex size-5 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground"
+							onClick={(e) => e.stopPropagation()}
+						>
+							<ChevronDown className="size-3.5" />
+						</button>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent align="end" className="w-56">
+						<DropdownMenuItem onSelect={() => onSelect?.(file.path)}>
+							Open Diff
+						</DropdownMenuItem>
+						<DropdownMenuItem onSelect={() => onSelect?.(file.path, true)}>
+							Open Diff in New Tab
+							<DropdownMenuShortcut>{SHIFT_CLICK_LABEL}</DropdownMenuShortcut>
+						</DropdownMenuItem>
+						<DropdownMenuItem
+							onSelect={() => absolutePath && onOpenFile?.(absolutePath)}
+							disabled={!onOpenFile || !absolutePath}
+						>
+							Open File
+						</DropdownMenuItem>
+						<DropdownMenuItem
+							onSelect={() => absolutePath && onOpenFile?.(absolutePath, true)}
+							disabled={!onOpenFile || !absolutePath}
+						>
+							Open File in New Tab
+						</DropdownMenuItem>
+						<DropdownMenuItem
+							onSelect={() => onOpenInEditor?.(file.path)}
+							disabled={!onOpenInEditor}
+						>
+							Open in Editor
+							<DropdownMenuShortcut>{MOD_CLICK_LABEL}</DropdownMenuShortcut>
+						</DropdownMenuItem>
+					</DropdownMenuContent>
+				</DropdownMenu>
+			</div>
+		</div>
 	);
 
 	return (
@@ -109,6 +163,18 @@ export const FileRow = memo(function FileRow({
 				<ContextMenuItem onSelect={() => onSelect?.(file.path, true)}>
 					Open Diff in New Tab
 					<ContextMenuShortcut>{SHIFT_CLICK_LABEL}</ContextMenuShortcut>
+				</ContextMenuItem>
+				<ContextMenuItem
+					onSelect={() => absolutePath && onOpenFile?.(absolutePath)}
+					disabled={!onOpenFile || !absolutePath}
+				>
+					Open File
+				</ContextMenuItem>
+				<ContextMenuItem
+					onSelect={() => absolutePath && onOpenFile?.(absolutePath, true)}
+					disabled={!onOpenFile || !absolutePath}
+				>
+					Open File in New Tab
 				</ContextMenuItem>
 				<ContextMenuItem
 					onSelect={() => onOpenInEditor?.(file.path)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesTabContent/ChangesTabContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesTabContent/ChangesTabContent.tsx
@@ -24,6 +24,7 @@ interface ChangesTabContentProps {
 	totalDeletions: number;
 	worktreePath?: string;
 	onSelectFile?: (path: string, openInNewTab?: boolean) => void;
+	onOpenFile?: (absolutePath: string, openInNewTab?: boolean) => void;
 	onOpenInEditor?: (path: string) => void;
 	onFilterChange: (filter: ChangesFilter) => void;
 	onBaseBranchChange: (branchName: string) => void;
@@ -44,6 +45,7 @@ export const ChangesTabContent = memo(function ChangesTabContent({
 	totalDeletions,
 	worktreePath,
 	onSelectFile,
+	onOpenFile,
 	onOpenInEditor,
 	onFilterChange,
 	onBaseBranchChange,
@@ -92,6 +94,7 @@ export const ChangesTabContent = memo(function ChangesTabContent({
 					isLoading={isLoading}
 					worktreePath={worktreePath}
 					onSelectFile={onSelectFile}
+					onOpenFile={onOpenFile}
 					onOpenInEditor={onOpenInEditor}
 				/>
 			</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
@@ -21,12 +21,14 @@ interface UseChangesTabParams {
 	workspaceId: string;
 	gitStatus: ReturnType<typeof useGitStatus>;
 	onSelectFile?: (path: string, openInNewTab?: boolean) => void;
+	onOpenFile?: (absolutePath: string, openInNewTab?: boolean) => void;
 }
 
 export function useChangesTab({
 	workspaceId,
 	gitStatus: status,
 	onSelectFile,
+	onOpenFile,
 }: UseChangesTabParams): SidebarTabDefinition {
 	const collections = useCollections();
 	const utils = workspaceTrpc.useUtils();
@@ -178,6 +180,7 @@ export function useChangesTab({
 			totalDeletions={totalDeletions}
 			worktreePath={worktreePath}
 			onSelectFile={onSelectFile}
+			onOpenFile={onOpenFile}
 			onOpenInEditor={handleOpenInEditor}
 			onFilterChange={setFilter}
 			onBaseBranchChange={setBaseBranch}


### PR DESCRIPTION
## Summary
- Each file in the v2 changes sidebar now reveals a more-actions dropdown on hover (status badge / +/- counts hide while the action is showing)
- Dropdown mirrors the right-click context menu and adds new **Open File** / **Open File in New Tab** entries (routed through the same pane-opener the Files tab uses)
- Existing click-modifier shortcuts (⇧ click, ⌘ click) are shown next to the corresponding dropdown items so the dropdown and context menu stay in sync

## Test plan
- [ ] Hover a row in the Changes sidebar — the chevron button appears, stats hide
- [ ] Open the dropdown — five actions visible, ⇧ click and ⌘ click hints shown
- [ ] Open Diff / Open Diff in New Tab open the diff pane (matches plain click and ⇧ click)
- [ ] Open File / Open File in New Tab open the file (not the diff) in the same way the Files tab does
- [ ] Open in Editor launches the external editor (matches ⌘ click)
- [ ] Right-click context menu shows the same items
- [ ] Dropdown stays visible while open even if cursor leaves the row

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a hover “more actions” dropdown to each file row in the v2 Changes sidebar, with quick actions to open diffs, files, or the external editor. The dropdown mirrors the right‑click menu and adds new Open File options.

- **New Features**
  - Shows a chevron on hover; status badge and +/- counts hide while visible.
  - Actions: Open Diff, Open Diff in New Tab, Open File, Open File in New Tab, Open in Editor.
  - Displays shortcut hints for ⇧ click and ⌘ click.
  - Right‑click context menu matches the dropdown.
  - Wires `onOpenFile` through `useChangesTab` so file opens use the existing Files pane opener.

<sup>Written for commit dde72ca198ede6c289f5548a72aab9b38bdaf251. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3897?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now open changed files directly from the changes interface
  * Added "Open File in New Tab" option for quick access to changed files
  * New "More actions" dropdown menu appears on hover, providing quick access to file operations
  * Right-click context menu expanded with file opening options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->