### PR TITLE
style(desktop): polish v2 diff pane header, file path, and unmodified-lines strip

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/StatusIndicator/StatusIndicator.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/StatusIndicator/StatusIndicator.tsx
@@ -26,8 +26,7 @@ const STATUS_COLORS: Record<FileStatus, string> = {
 	untracked: "text-green-700 dark:text-green-400",
 };
 
-function getStatusIcon(status: FileStatus): ReactNode {
-	const iconClass = "w-3 h-3";
+function getStatusIcon(status: FileStatus, iconClass: string): ReactNode {
 	switch (status) {
 		case "added":
 		case "untracked":
@@ -49,15 +48,17 @@ function getStatusIcon(status: FileStatus): ReactNode {
 export function StatusIndicator({
 	status,
 	className,
+	iconClassName = "w-3 h-3",
 }: {
 	status: string;
 	className?: string;
+	iconClassName?: string;
 }) {
 	return (
 		<span
 			className={`flex shrink-0 items-center ${STATUS_COLORS[status as FileStatus] ?? ""} ${className ?? ""}`}
 		>
-			{getStatusIcon(status as FileStatus)}
+			{getStatusIcon(status as FileStatus, iconClassName)}
 		</span>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
@@ -98,10 +98,10 @@ export function DiffPane({ context, workspaceId, onOpenFile }: DiffPaneProps) {
 		[updateData],
 	);
 
-	if (!isLoading && files.length === 0) {
+	if (files.length === 0) {
 		return (
 			<div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
-				No changes
+				{isLoading ? "Loading…" : "No changes"}
 			</div>
 		);
 	}
@@ -109,7 +109,7 @@ export function DiffPane({ context, workspaceId, onOpenFile }: DiffPaneProps) {
 	return (
 		<Virtualizer
 			className="h-full w-full overflow-auto"
-			contentClassName="space-y-2 px-2 py-2"
+			contentClassName="space-y-2"
 		>
 			<ScrollToFile path={data.path} />
 			{files.map((file) => (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileEntry/DiffFileEntry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileEntry/DiffFileEntry.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@superset/ui/button";
 import { toast } from "@superset/ui/sonner";
 import { memo, useCallback, useRef, useState } from "react";
 import type { ChangesetFile } from "../../../../../useChangeset";
@@ -199,7 +200,7 @@ function DeferredDiffPlaceholder({
 		: `${(file.additions + file.deletions).toLocaleString()} changed lines`;
 
 	return (
-		<div className="flex flex-col overflow-hidden rounded-md border border-border">
+		<div className="flex flex-col overflow-hidden">
 			<DiffFileHeader
 				path={file.path}
 				status={file.status}
@@ -222,13 +223,15 @@ function DeferredDiffPlaceholder({
 					{subtitle && (
 						<div className="text-xs text-muted-foreground">{subtitle}</div>
 					)}
-					<button
+					<Button
 						type="button"
+						size="xs"
+						variant="outline"
 						onClick={onShow}
-						className="mt-1 rounded border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground hover:bg-muted"
+						className="mt-1"
 					>
 						Show diff
-					</button>
+					</Button>
 				</div>
 			)}
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileHeader/DiffFileHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileHeader/DiffFileHeader.tsx
@@ -2,11 +2,13 @@ import { Checkbox } from "@superset/ui/checkbox";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { ChevronDown, ChevronRight, Eye, EyeOff } from "lucide-react";
 import { useId } from "react";
-import { LuCopy, LuUndo2 } from "react-icons/lu";
+import { LuCheck, LuCopy, LuUndo2 } from "react-icons/lu";
+import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import { StatusIndicator } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/StatusIndicator";
 import { CLICK_HINT_TOOLTIP } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/clickModifierLabels";
 import { getSidebarClickIntent } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/getSidebarClickIntent";
 import { FileIcon } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils";
+import { GIT_STAT_TEXT_CLASSES } from "../../utils/gitDecorationColors";
 
 interface DiffFileHeaderProps {
 	path: string;
@@ -21,7 +23,6 @@ interface DiffFileHeaderProps {
 	onToggleViewed: () => void;
 	onOpenFile?: (openInNewTab?: boolean) => void;
 	onOpenInExternalEditor?: () => void;
-	onCopyContents?: () => void;
 	onDiscard?: () => void;
 }
 
@@ -38,18 +39,25 @@ export function DiffFileHeader({
 	onToggleViewed,
 	onOpenFile,
 	onOpenInExternalEditor,
-	onCopyContents,
 	onDiscard,
 }: DiffFileHeaderProps) {
 	const viewedId = useId();
+	const { copyToClipboard, copied } = useCopyToClipboard();
+
+	// Split into directory + basename so the basename stays visible when the
+	// header is narrow — the directory truncates with ellipsis instead of
+	// hiding the filename behind it.
+	const lastSlash = path.lastIndexOf("/");
+	const dir = lastSlash >= 0 ? path.slice(0, lastSlash + 1) : "";
+	const name = lastSlash >= 0 ? path.slice(lastSlash + 1) : path;
 
 	return (
-		<div className="@container/diff-file-header flex min-w-0 flex-wrap items-center gap-1 px-2 py-1.5">
+		<div className="@container/diff-file-header flex min-w-0 flex-nowrap items-center gap-1 border-y border-border bg-muted/30 px-3 py-2">
 			<button
 				type="button"
 				onClick={onToggleCollapsed}
 				aria-label={collapsed ? "Expand file" : "Collapse file"}
-				className="shrink-0 rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground"
+				className="shrink-0 rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground"
 			>
 				{collapsed ? (
 					<ChevronRight className="size-3.5" />
@@ -57,8 +65,7 @@ export function DiffFileHeader({
 					<ChevronDown className="size-3.5" />
 				)}
 			</button>
-			<StatusIndicator status={status} />
-			<Tooltip delayDuration={300}>
+			<Tooltip>
 				<TooltipTrigger asChild>
 					<button
 						type="button"
@@ -72,11 +79,16 @@ export function DiffFileHeader({
 						}}
 						disabled={!onOpenFile && !onOpenInExternalEditor}
 						aria-label="Open in file viewer"
-						className="flex h-6 min-w-0 items-center gap-1.5 rounded border border-border px-1.5 py-0.5 text-left transition-colors hover:bg-accent disabled:pointer-events-none disabled:opacity-60"
+						className="flex h-6 min-w-0 flex-1 items-center gap-1.5 rounded px-1 text-left transition-colors hover:bg-accent disabled:pointer-events-none disabled:opacity-60"
 					>
 						<FileIcon fileName={path} className="size-3.5 shrink-0" />
-						<span className="min-w-0 truncate font-mono text-xs text-foreground">
-							{path}
+						<span className="flex min-w-0 items-baseline font-mono text-xs">
+							{dir && (
+								<span className="min-w-0 truncate text-muted-foreground">
+									{dir}
+								</span>
+							)}
+							<span className="shrink-0 text-foreground">{name}</span>
 						</span>
 					</button>
 				</TooltipTrigger>
@@ -84,17 +96,37 @@ export function DiffFileHeader({
 					{CLICK_HINT_TOOLTIP}
 				</TooltipContent>
 			</Tooltip>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<button
+						type="button"
+						onClick={() => void copyToClipboard(path)}
+						aria-label="Copy path"
+						className="shrink-0 rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground"
+					>
+						{copied ? (
+							<LuCheck className="size-3.5" />
+						) : (
+							<LuCopy className="size-3.5" />
+						)}
+					</button>
+				</TooltipTrigger>
+				<TooltipContent side="bottom" showArrow={false}>
+					{copied ? "Copied" : "Copy path"}
+				</TooltipContent>
+			</Tooltip>
 			<div className="ml-auto flex shrink-0 items-center gap-1.5">
+				<StatusIndicator status={status} iconClassName="size-3.5" />
 				{(additions > 0 || deletions > 0) && (
-					<span className="font-mono text-[10px] text-muted-foreground">
+					<span className="font-mono text-xs text-muted-foreground">
 						{additions > 0 && (
-							<span className="text-green-700 dark:text-green-400">
+							<span className={GIT_STAT_TEXT_CLASSES.addition}>
 								+{additions}
 							</span>
 						)}
 						{additions > 0 && deletions > 0 && " "}
 						{deletions > 0 && (
-							<span className="text-red-700 dark:text-red-500">
+							<span className={GIT_STAT_TEXT_CLASSES.deletion}>
 								-{deletions}
 							</span>
 						)}
@@ -110,7 +142,7 @@ export function DiffFileHeader({
 					/>
 					<label
 						htmlFor={viewedId}
-						className="hidden cursor-pointer select-none text-[10px] text-muted-foreground @min-[380px]/diff-file-header:inline"
+						className="hidden cursor-pointer select-none text-xs text-muted-foreground @min-[380px]/diff-file-header:inline"
 					>
 						Viewed
 					</label>
@@ -125,7 +157,7 @@ export function DiffFileHeader({
 							aria-label={
 								expandUnchanged ? "Hide unchanged regions" : "Show all lines"
 							}
-							className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-40"
+							className="rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-40"
 						>
 							{expandUnchanged ? (
 								<EyeOff className="size-3.5" />
@@ -143,27 +175,10 @@ export function DiffFileHeader({
 					<TooltipTrigger asChild>
 						<button
 							type="button"
-							onClick={onCopyContents}
-							disabled={!onCopyContents}
-							aria-label="Copy file contents"
-							className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-40"
-						>
-							<LuCopy className="size-3.5" />
-						</button>
-					</TooltipTrigger>
-					<TooltipContent side="bottom" showArrow={false}>
-						Copy file contents
-					</TooltipContent>
-				</Tooltip>
-
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<button
-							type="button"
 							onClick={onDiscard}
 							disabled={!onDiscard}
 							aria-label="Discard changes"
-							className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-destructive disabled:pointer-events-none disabled:opacity-40"
+							className="rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-destructive disabled:pointer-events-none disabled:opacity-40"
 						>
 							<LuUndo2 className="size-3.5" />
 						</button>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffPaneHeaderExtras/DiffPaneHeaderExtras.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffPaneHeaderExtras/DiffPaneHeaderExtras.tsx
@@ -1,0 +1,59 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { cn } from "@superset/ui/utils";
+import { SquareSplitHorizontal } from "lucide-react";
+import { TbScan } from "react-icons/tb";
+import { useSettings } from "renderer/stores/settings";
+
+export function DiffPaneHeaderExtras() {
+	const diffStyle = useSettings((s) => s.diffStyle);
+	const updateSetting = useSettings((s) => s.update);
+
+	const buttonClass = (active: boolean) =>
+		cn(
+			"flex size-5 items-center justify-center transition-colors",
+			active
+				? "bg-secondary text-foreground"
+				: "text-muted-foreground hover:text-foreground",
+		);
+
+	return (
+		<div className="flex items-center">
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<button
+						type="button"
+						onClick={() => updateSetting("diffStyle", "unified")}
+						aria-label="Unified view"
+						aria-pressed={diffStyle === "unified"}
+						className={buttonClass(diffStyle === "unified")}
+					>
+						<TbScan className="size-3.5" />
+					</button>
+				</TooltipTrigger>
+				<TooltipContent side="bottom" showArrow={false}>
+					Unified view
+				</TooltipContent>
+			</Tooltip>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<button
+						type="button"
+						onClick={() => updateSetting("diffStyle", "split")}
+						aria-label="Split view"
+						aria-pressed={diffStyle === "split"}
+						className={buttonClass(diffStyle === "split")}
+					>
+						<SquareSplitHorizontal className="size-3.5" />
+					</button>
+				</TooltipTrigger>
+				<TooltipContent side="bottom" showArrow={false}>
+					Split view
+				</TooltipContent>
+			</Tooltip>
+			<div
+				className="mx-1 h-3.5 w-px bg-muted-foreground/30"
+				aria-hidden="true"
+			/>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffPaneHeaderExtras/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffPaneHeaderExtras/index.ts
@@ -1,0 +1,1 @@
+export { DiffPaneHeaderExtras } from "./DiffPaneHeaderExtras";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/WorkspaceDiff/WorkspaceDiff.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/WorkspaceDiff/WorkspaceDiff.tsx
@@ -3,13 +3,12 @@ import { toast } from "@superset/ui/sonner";
 import { workspaceTrpc } from "@superset/workspace-client";
 import { useQuery } from "@tanstack/react-query";
 import { memo, useMemo } from "react";
-import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import {
 	getDiffsTheme,
 	getDiffViewerStyle,
 } from "renderer/screens/main/components/WorkspaceView/utils/code-theme";
-import { useResolvedTheme } from "renderer/stores/theme";
+import { useResolvedTheme, useTerminalTheme } from "renderer/stores/theme";
 import type { DiffFileSource } from "../../../../../useChangeset";
 import { DiffFileHeader } from "../DiffFileHeader";
 
@@ -49,6 +48,7 @@ export const WorkspaceDiff = memo(function WorkspaceDiff({
 	onOpenInExternalEditor,
 }: WorkspaceDiffProps) {
 	const activeTheme = useResolvedTheme();
+	const terminalTheme = useTerminalTheme();
 	const { data: fontSettings } = useQuery({
 		queryKey: ["electron", "settings", "getFontSettings"],
 		queryFn: () => electronTrpcClient.settings.getFontSettings.query(),
@@ -61,31 +61,18 @@ export const WorkspaceDiff = memo(function WorkspaceDiff({
 			: typeof fontSettings?.editorFontSize === "string"
 				? Number.parseFloat(fontSettings.editorFontSize)
 				: Number.NaN;
-	const baseThemeVars = getDiffViewerStyle(activeTheme, {
-		fontFamily: fontSettings?.editorFontFamily ?? undefined,
-		fontSize: Number.isFinite(parsedEditorFontSize)
-			? parsedEditorFontSize
-			: undefined,
-	});
-	// Match the file tree's git decoration colors (v2 WorkspaceFilesTreeItem)
-	// so addition/deletion/modified highlights read the same across the pane.
-	const gitDecorationColors =
-		activeTheme.type === "dark"
-			? {
-					addition: "var(--color-green-400)",
-					deletion: "var(--color-red-500)",
-					modified: "var(--color-yellow-400)",
-				}
-			: {
-					addition: "var(--color-green-700)",
-					deletion: "var(--color-red-700)",
-					modified: "var(--color-yellow-600)",
-				};
+	// Match the terminal pane's surface color so the diff body blends with
+	// the chrome. The actual override happens in unsafeCSS below — this just
+	// paints the wrapper before the diff mounts.
+	const surfaceBg = terminalTheme?.background ?? "var(--background)";
 	const themeVars = {
-		...baseThemeVars,
-		"--diffs-addition-color-override": gitDecorationColors.addition,
-		"--diffs-deletion-color-override": gitDecorationColors.deletion,
-		"--diffs-modified-color-override": gitDecorationColors.modified,
+		...getDiffViewerStyle(activeTheme, {
+			fontFamily: fontSettings?.editorFontFamily ?? undefined,
+			fontSize: Number.isFinite(parsedEditorFontSize)
+				? parsedEditorFontSize
+				: undefined,
+		}),
+		backgroundColor: surfaceBg,
 	};
 
 	const diffInput = useMemo(() => {
@@ -118,14 +105,6 @@ export const WorkspaceDiff = memo(function WorkspaceDiff({
 	});
 	const worktreePath = workspaceQuery.data?.worktreePath;
 
-	const { copyToClipboard } = useCopyToClipboard();
-	const newContents = diffQuery.data?.newFile.contents;
-	const handleCopyContents = useMemo(
-		() =>
-			newContents != null ? () => copyToClipboard(newContents) : undefined,
-		[newContents, copyToClipboard],
-	);
-
 	const handleDiscard = useMemo(() => {
 		if (source.kind !== "unstaged" || !worktreePath) return undefined;
 		return () => {
@@ -140,7 +119,7 @@ export const WorkspaceDiff = memo(function WorkspaceDiff({
 	}, [source.kind, worktreePath, path]);
 
 	return (
-		<div className="flex flex-col overflow-hidden rounded-md border border-border">
+		<div className="flex flex-col overflow-hidden">
 			<DiffFileHeader
 				path={path}
 				status={status}
@@ -154,7 +133,6 @@ export const WorkspaceDiff = memo(function WorkspaceDiff({
 				onToggleViewed={onToggleViewed}
 				onOpenFile={onOpenFile}
 				onOpenInExternalEditor={onOpenInExternalEditor}
-				onCopyContents={handleCopyContents}
 				onDiscard={handleDiscard}
 			/>
 			{diffQuery.data ? (
@@ -171,9 +149,26 @@ export const WorkspaceDiff = memo(function WorkspaceDiff({
 						theme: shikiTheme,
 						themeType: activeTheme.type,
 						unsafeCSS: `
-							* {
-								user-select: text;
-								-webkit-user-select: text;
+							* { user-select: text; -webkit-user-select: text; }
+							/* Pierre sets --diffs-light-bg/--diffs-dark-bg
+							 * inline on <pre data-diff> from the Shiki theme;
+							 * inline beats :host so we override at the pre. */
+							[data-diff] {
+								--diffs-light-bg: ${surfaceBg} !important;
+								--diffs-dark-bg: ${surfaceBg} !important;
+							}
+							/* Flatten the "N unmodified lines" strip flush to
+							 * the pane edges (kills wrapper/content/expand-
+							 * button rounding + inline gap on both
+							 * line-info and line-info-basic). */
+							[data-separator^='line-info'] [data-separator-wrapper],
+							[data-separator^='line-info'] [data-separator-content],
+							[data-separator^='line-info'] [data-expand-up],
+							[data-separator^='line-info'] [data-expand-down],
+							[data-separator^='line-info'] [data-expand-both] {
+								border-radius: 0 !important;
+								margin-inline: 0 !important;
+								padding-inline: 0 !important;
 							}
 						`,
 					}}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/utils/gitDecorationColors/gitDecorationColors.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/utils/gitDecorationColors/gitDecorationColors.ts
@@ -1,0 +1,5 @@
+export const GIT_STAT_TEXT_CLASSES = {
+	addition: "text-green-700 dark:text-green-400",
+	deletion: "text-red-700 dark:text-red-500",
+	modified: "text-yellow-600 dark:text-yellow-400",
+} as const;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/utils/gitDecorationColors/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/utils/gitDecorationColors/index.ts
@@ -1,0 +1,1 @@
+export { GIT_STAT_TEXT_CLASSES } from "./gitDecorationColors";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -5,7 +5,6 @@ import type {
 } from "@superset/panes";
 import { alert } from "@superset/ui/atoms/Alert";
 import { toast } from "@superset/ui/sonner";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { workspaceTrpc } from "@superset/workspace-client";
 import {
@@ -13,7 +12,6 @@ import {
 	GitCompareArrows,
 	Globe,
 	MessageSquare,
-	SquareSplitHorizontal,
 	TerminalSquare,
 } from "lucide-react";
 import { useMemo } from "react";
@@ -24,13 +22,11 @@ import {
 	LuEraser,
 	LuPower,
 } from "react-icons/lu";
-import { TbScan } from "react-icons/tb";
 import { useHotkeyDisplay } from "renderer/hotkeys";
 import { getBaseName } from "renderer/lib/pathBasename";
 import { consumeTerminalBackgroundIntent } from "renderer/lib/terminal/terminal-background-intents";
 import { terminalRuntimeRegistry } from "renderer/lib/terminal/terminal-runtime-registry";
 import { FileIcon } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils";
-import { useSettings } from "renderer/stores/settings";
 import { getV2NotificationSourcesForPane } from "renderer/stores/v2-notifications";
 import { V2NotificationStatusIndicator } from "../../components/V2NotificationStatusIndicator";
 import {
@@ -53,6 +49,7 @@ import { CommentPane } from "./components/CommentPane";
 import { CommentPaneHeaderExtras } from "./components/CommentPane/components/CommentPaneHeaderExtras";
 import { CommentPaneTitle } from "./components/CommentPane/components/CommentPaneTitle";
 import { DiffPane } from "./components/DiffPane";
+import { DiffPaneHeaderExtras } from "./components/DiffPane/components/DiffPaneHeaderExtras";
 import { FilePane } from "./components/FilePane";
 import { FilePaneHeaderExtras } from "./components/FilePane/components/FilePaneHeaderExtras";
 import { TerminalPane } from "./components/TerminalPane";
@@ -101,60 +98,6 @@ function FilePaneTabTitle({
 const MOD_KEY = navigator.platform.toLowerCase().includes("mac")
 	? "⌘"
 	: "Ctrl+";
-
-function DiffViewModeToggle() {
-	const diffStyle = useSettings((s) => s.diffStyle);
-	const updateSetting = useSettings((s) => s.update);
-
-	const buttonClass = (active: boolean) =>
-		cn(
-			"flex size-5 items-center justify-center transition-colors",
-			active
-				? "bg-secondary text-foreground"
-				: "text-muted-foreground hover:text-foreground",
-		);
-
-	return (
-		<div className="flex items-center">
-			<Tooltip>
-				<TooltipTrigger asChild>
-					<button
-						type="button"
-						onClick={() => updateSetting("diffStyle", "unified")}
-						aria-label="Unified view"
-						aria-pressed={diffStyle === "unified"}
-						className={buttonClass(diffStyle === "unified")}
-					>
-						<TbScan className="size-3.5" />
-					</button>
-				</TooltipTrigger>
-				<TooltipContent side="bottom" showArrow={false}>
-					Unified view
-				</TooltipContent>
-			</Tooltip>
-			<Tooltip>
-				<TooltipTrigger asChild>
-					<button
-						type="button"
-						onClick={() => updateSetting("diffStyle", "split")}
-						aria-label="Split view"
-						aria-pressed={diffStyle === "split"}
-						className={buttonClass(diffStyle === "split")}
-					>
-						<SquareSplitHorizontal className="size-3.5" />
-					</button>
-				</TooltipTrigger>
-				<TooltipContent side="bottom" showArrow={false}>
-					Split view
-				</TooltipContent>
-			</Tooltip>
-			<div
-				className="mx-1 h-3.5 w-px bg-muted-foreground/30"
-				aria-hidden="true"
-			/>
-		</div>
-	);
-}
 
 interface UsePaneRegistryOptions {
 	onOpenFile: (path: string, openInNewTab?: boolean) => void;
@@ -285,7 +228,7 @@ export function usePaneRegistry(
 						onOpenFile={onOpenFile}
 					/>
 				),
-				renderHeaderExtras: () => <DiffViewModeToggle />,
+				renderHeaderExtras: () => <DiffPaneHeaderExtras />,
 				contextMenuActions: (_ctx, defaults) =>
 					defaults.map((d) =>
 						d.key === "close-pane" ? { ...d, label: "Close Diff" } : d,


### PR DESCRIPTION
## Summary

- Each file header in the v2 Changes pane now matches the sidebar `ChangesHeader` chrome (`border-y` + `bg-muted/30`), with the `StatusIndicator` moved next to the +/- diff stats.
- Filename is split into directory + basename so the basename always stays visible — the directory truncates with `…` instead of hiding the file you actually care about.
- Added a **Copy path** button next to the filename and removed the Copy file contents button.
- Diff body now blends with the terminal pane surface (overrides pierre/diffs' inline `--diffs-light-bg` / `--diffs-dark-bg` on `[data-diff]`).
- Flattened the "N unmodified lines" expander flush to the pane edges (covers both `line-info` and `line-info-basic` separators, kills the wrapper / content / expand-button rounding and inline gaps).
- Extracted the inline `DiffViewModeToggle` from `usePaneRegistry.tsx` into a co-located `DiffPaneHeaderExtras` (matches the `FilePaneHeaderExtras` / `CommentPaneHeaderExtras` pattern); standardized icon-button padding (`p-0.5` → `p-1`); replaced the hand-rolled "Show diff" button with `<Button size=\"xs\" variant=\"outline\">`; loading state distinguishes \"Loading…\" from \"No changes\".

## Test plan

- [ ] Open a workspace, open the Changes diff pane — header bar reads as a single muted strip with top + bottom rules
- [ ] Resize the pane narrow with a deeply nested file open — the directory part truncates but the basename stays readable
- [ ] Click **Copy path** on a file header — clipboard gets the path; icon flips to a check + tooltip reads \"Copied\" briefly
- [ ] Confirm Copy file contents button is gone; Discard, Viewed, eye-toggle still work
- [ ] StatusIndicator (added/modified/deleted glyph) sits to the left of the +/- counters on the right
- [ ] Diff body background matches the terminal pane background (not pure black)
- [ ] Click an \"N unmodified lines\" expander on both split and unified views — strip is flush to both pane edges, no rounded corners
- [ ] Open a file with a deep path — header doesn't wrap to two rows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes the v2 Changes diff pane for clearer headers and consistent styling with the sidebar and terminal. Adds a Copy path action, better path display, and small UX tweaks for a smoother review experience.

- **New Features**
  - File headers match `ChangesHeader` (border-y + muted bg); status icon sits next to the +/- counters.
  - Paths split into dir + basename so the filename stays visible; added Copy path; removed Copy file contents.
  - Diff background matches the terminal surface; “N unmodified lines” strip is flush to pane edges.
  - Empty state shows “Loading…” while fetching, otherwise “No changes”.

- **Refactors**
  - Extracted `DiffPaneHeaderExtras` for the diff view toggle (replaces inline toggle).
  - Standardized icon-button padding and switched “Show diff” to `<Button size="xs" variant="outline">`.

<sup>Written for commit eb74dcecb305857f55f578f846c34e59acac6770. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3899?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Copy path" button to diff file headers for quick clipboard access
  * Introduced diff view mode toggle (unified/split) for customizable viewing

* **Bug Fixes**
  * Fixed diff header layout to ensure filenames remain visible in narrow widths

* **Refactor**
  * Migrated UI components to design system for improved visual consistency
  * Enhanced diff pane styling with terminal theming integration
  * Improved empty state messaging in diff view

<!-- end of auto-generated comment: release notes by coderabbit.ai -->