### PR TITLE
fix(desktop): preserve legacy agent hook notifications

### DIFF
--- a/apps/desktop/src/main/lib/agent-setup/notify-hook.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/notify-hook.test.ts
@@ -14,7 +14,7 @@ describe("getNotifyScriptContent", () => {
 			"SESSION_ID=" + "\u0024{RESOURCE_ID:-$HOOK_SESSION_ID}",
 		);
 		expect(script).toContain(
-			'PAYLOAD="{\\"json\\":{\\"terminalId\\":\\"$(json_escape "$SUPERSET_TERMINAL_ID")\\",\\"eventType\\":\\"$(json_escape "$EVENT_TYPE")\\"}}"',
+			'PAYLOAD="{\\"json\\":{\\"terminalId\\":\\"$(json_escape "$SUPERSET_TERMINAL_ID")\\",\\"workspaceId\\":\\"$(json_escape "$SUPERSET_WORKSPACE_ID")\\",\\"eventType\\":\\"$(json_escape "$EVENT_TYPE")\\"}}"',
 		);
 		expect(script).toContain('--data-urlencode "resourceId=$RESOURCE_ID"');
 		expect(script).toContain(
@@ -25,7 +25,7 @@ describe("getNotifyScriptContent", () => {
 		);
 	});
 
-	it("gives the v2 host-service hook enough time to avoid false fallback", () => {
+	it("keeps dispatching to the legacy hook after the v2 host-service hook when legacy ids exist", () => {
 		const script = readFileSync(
 			path.join(import.meta.dir, "templates", "notify-hook.template.sh"),
 			"utf-8",
@@ -33,6 +33,10 @@ describe("getNotifyScriptContent", () => {
 
 		expect(script).toContain(
 			'curl -sX POST "$SUPERSET_HOST_AGENT_HOOK_URL" \\\n    --connect-timeout 2 --max-time 5',
+		);
+		expect(script).not.toContain("2*) exit 0");
+		expect(script).toContain(
+			'if [ -n "$SUPERSET_HOST_AGENT_HOOK_URL" ] && [ -z "$SUPERSET_PANE_ID" ] && [ -z "$SUPERSET_TAB_ID" ]; then',
 		);
 	});
 

--- a/apps/desktop/src/main/lib/agent-setup/notify-hook.test.ts
+++ b/apps/desktop/src/main/lib/agent-setup/notify-hook.test.ts
@@ -25,19 +25,24 @@ describe("getNotifyScriptContent", () => {
 		);
 	});
 
-	it("keeps dispatching to the legacy hook after the v2 host-service hook when legacy ids exist", () => {
+	it("keeps the legacy hook after the v2 host-service hook", () => {
 		const script = readFileSync(
 			path.join(import.meta.dir, "templates", "notify-hook.template.sh"),
 			"utf-8",
 		);
 
-		expect(script).toContain(
-			'curl -sX POST "$SUPERSET_HOST_AGENT_HOOK_URL" \\\n    --connect-timeout 2 --max-time 5',
+		const hostServiceCurlIndex = script.indexOf(
+			'curl -sX POST "$SUPERSET_HOST_AGENT_HOOK_URL"',
 		);
-		expect(script).not.toContain("2*) exit 0");
-		expect(script).toContain(
-			'if [ -n "$SUPERSET_HOST_AGENT_HOOK_URL" ] && [ -z "$SUPERSET_PANE_ID" ] && [ -z "$SUPERSET_TAB_ID" ]; then',
+		const legacyCurlIndex = script.indexOf(
+			'curl -sG "http://127.0.0.1:' +
+				"$" +
+				'{SUPERSET_PORT:-{{DEFAULT_PORT}}}/hook/complete"',
 		);
+
+		expect(hostServiceCurlIndex).toBeGreaterThanOrEqual(0);
+		expect(legacyCurlIndex).toBeGreaterThanOrEqual(0);
+		expect(hostServiceCurlIndex).toBeLessThan(legacyCurlIndex);
 	});
 
 	it("keeps the legacy v1 fallback path when no host-service hook URL exists", () => {

--- a/apps/desktop/src/main/lib/agent-setup/templates/notify-hook.template.sh
+++ b/apps/desktop/src/main/lib/agent-setup/templates/notify-hook.template.sh
@@ -85,11 +85,10 @@ json_escape() {
 # v2: host-service tRPC endpoint. The renderer subscribes over the event
 # bus and plays the ringtone. Preferred when the URL is provided by
 # host-service's terminal env. Endpoint is unauthenticated — it only
-# broadcasts chimes, no auth header needed. Always captures the status
-# so we can fall back to v1 when host-service is unreachable or the
-# mutation returns non-2xx (restarts, crashes, transient errors).
+# broadcasts chimes, no auth header needed. We still continue to the legacy
+# desktop hook below so existing v1 listeners also receive lifecycle events.
 if [ -n "$SUPERSET_HOST_AGENT_HOOK_URL" ]; then
-  PAYLOAD="{\"json\":{\"terminalId\":\"$(json_escape "$SUPERSET_TERMINAL_ID")\",\"eventType\":\"$(json_escape "$EVENT_TYPE")\"}}"
+  PAYLOAD="{\"json\":{\"terminalId\":\"$(json_escape "$SUPERSET_TERMINAL_ID")\",\"workspaceId\":\"$(json_escape "$SUPERSET_WORKSPACE_ID")\",\"eventType\":\"$(json_escape "$EVENT_TYPE")\"}}"
 
   STATUS_CODE=$(curl -sX POST "$SUPERSET_HOST_AGENT_HOOK_URL" \
     --connect-timeout 2 --max-time 5 \
@@ -100,14 +99,17 @@ if [ -n "$SUPERSET_HOST_AGENT_HOOK_URL" ]; then
   if [ "$DEBUG_HOOKS_ENABLED" = "1" ]; then
     echo "[notify-hook] host-service dispatched status=$STATUS_CODE" >&2
   fi
-
-  case "$STATUS_CODE" in
-    2*) exit 0 ;;
-  esac
 fi
 
-# v1 fallback: electron localhost server. Used by v1 terminals and when
-# host-service is unreachable from the agent's shell.
+# Pure v2 terminals only have terminal/workspace ids, so host-service is the
+# notification path. Continue to the legacy desktop hook only when the shell
+# also has legacy pane/tab identity; otherwise v2 users would get duplicates.
+if [ -n "$SUPERSET_HOST_AGENT_HOOK_URL" ] && [ -z "$SUPERSET_PANE_ID" ] && [ -z "$SUPERSET_TAB_ID" ]; then
+  exit 0
+fi
+
+# v1/legacy: electron localhost server. Used by v1 terminals and by hybrid
+# environments that still expose legacy pane/tab identity.
 # Timeouts prevent blocking agent completion if notification server is unresponsive
 if [ "$DEBUG_HOOKS_ENABLED" = "1" ]; then
   STATUS_CODE=$(curl -sG "http://127.0.0.1:${SUPERSET_PORT:-{{DEFAULT_PORT}}}/hook/complete" \

--- a/packages/host-service/src/trpc/router/notifications/notifications.test.ts
+++ b/packages/host-service/src/trpc/router/notifications/notifications.test.ts
@@ -89,6 +89,26 @@ describe("notificationsRouter.hook", () => {
 		expect(unknownTerminal.broadcastAgentLifecycle).not.toHaveBeenCalled();
 	});
 
+	it("falls back to payload workspaceId when the terminal row is not visible yet", async () => {
+		const { ctx, broadcastAgentLifecycle, findFirst } = createContext(null);
+		const caller = notificationsRouter.createCaller(ctx);
+
+		const result = await caller.hook({
+			terminalId: "terminal-1",
+			workspaceId: "workspace-1",
+			eventType: "Stop",
+		});
+
+		expect(result).toEqual({ success: true, ignored: false });
+		expect(findFirst).toHaveBeenCalledTimes(1);
+		expect(broadcastAgentLifecycle).toHaveBeenCalledTimes(1);
+		expect(broadcastAgentLifecycle.mock.calls[0]?.[0]).toMatchObject({
+			workspaceId: "workspace-1",
+			eventType: "Stop",
+			terminalId: "terminal-1",
+		});
+	});
+
 	it("ignores unknown event types before looking up the terminal", async () => {
 		const { ctx, broadcastAgentLifecycle, findFirst } =
 			createContext("workspace-1");

--- a/packages/host-service/src/trpc/router/notifications/notifications.ts
+++ b/packages/host-service/src/trpc/router/notifications/notifications.ts
@@ -5,11 +5,14 @@ import { mapEventType } from "../../../events";
 import { publicProcedure, router } from "../../index";
 
 /**
- * v2 terminal hook payload. The shell hook sends only stable runtime identity;
- * host-service derives workspace identity from its terminal session table.
+ * v2 terminal hook payload. The shell hook sends stable runtime identity.
+ * Host-service prefers the terminal session table for workspace identity, but
+ * falls back to the terminal env's workspaceId so lifecycle events are not lost
+ * if a hook arrives while a new workspace/terminal is still settling.
  */
 const hookInput = z.object({
 	terminalId: z.string().optional(),
+	workspaceId: z.string().optional(),
 	eventType: z.string().optional(),
 });
 
@@ -44,12 +47,13 @@ export const notificationsRouter = router({
 				columns: { originWorkspaceId: true },
 			})
 			.sync();
-		if (!terminalSession?.originWorkspaceId) {
+		const workspaceId = terminalSession?.originWorkspaceId ?? input.workspaceId;
+		if (!workspaceId) {
 			return { success: true, ignored: true as const };
 		}
 
 		ctx.eventBus.broadcastAgentLifecycle({
-			workspaceId: terminalSession.originWorkspaceId,
+			workspaceId,
 			eventType,
 			terminalId: input.terminalId,
 			occurredAt: Date.now(),


### PR DESCRIPTION
## Description

  While the v2 workspace flow is still rolling out, some users may continue using the v1/legacy desktop flow. In that setup, agent lifecycle hooks should still reach the existing desktop hook listener so terminal status updates and completion signals continue to work.

  Previously, when `SUPERSET_HOST_AGENT_HOOK_URL` was present, the notify hook script returned after a successful host-service dispatch. That meant the legacy `/hook/complete` listener did not receive the same lifecycle event.

  This PR keeps the host-service notification path intact, but also preserves dispatch to the existing desktop hook listener.

  It also includes `workspaceId` in the host-service hook payload so lifecycle events are not dropped if the terminal session row is not visible yet.

  ## Related Issues

  N/A

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Documentation
  - [ ] Refactor
  - [ ] Other (please describe):

  ## Testing

  - `bun test apps/desktop/src/main/lib/agent-setup/notify-hook.test.ts packages/host-service/src/trpc/router/notifications/notifications.test.ts apps/desktop/src/
  renderer/routes/_authenticated/components/V2NotificationController/lib/statusTransitions.test.ts apps/desktop/src/renderer/routes/_authenticated/components/
  V2NotificationController/lib/resolveV2NotificationTarget.test.ts apps/desktop/src/renderer/stores/v2-notifications/store.test.ts`
  - `bun run lint`

  ## Screenshots (if applicable)

  N/A

  ## Additional Notes

  This appears to be a regression from `e07aef637` / #3675 (`feat(desktop): play v2 notification hooks client-side`), which added the v2 host-service hook path and exited early after a successful host-service dispatch. That prevented the existing desktop `/hook/complete` listener from receiving the same lifecycle event.

  The regression is present from `desktop-v1.6.0` onward.

  v2 is not yet comfortable for my workflow because worktree creation and PR number visibility are still being improved there, so I am currently using the v1 flow and hit this hook regression. Once this PR is merged, I would like to keep using v2 more and contribute follow-up improvements for the remaining rough edges I run into.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves legacy v1 desktop agent notifications alongside the v2 `host-service` hook so terminal status and completion keep working. Also includes `workspaceId` in the v2 payload and falls back to it to avoid dropped events when the terminal session isn’t loaded yet.

- **Bug Fixes**
  - Notify script always sends to v2 and also to the legacy `/hook/complete` when legacy pane/tab ids exist; for pure v2 terminals (no legacy ids), it skips the legacy call to prevent duplicates.
  - V2 `host-service` hook accepts `workspaceId` and falls back to it when the terminal session isn’t visible; broadcasts are no longer ignored.
  - Tests assert v2-before-legacy dispatch order and the `workspaceId` fallback.

<sup>Written for commit 5f843f7313df6363dbeb42ed63bba27dd784f50d. Summary will update on new commits. <a href="https://cubic.dev/pr/superset-sh/superset/pull/3904?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests covering notification behavior, ordering between v2 host-service and legacy hooks, and cases where terminal lookup yields no visible terminal.

* **Chores**
  * Notification payloads now include workspace identification and use a sourced fallback when needed.
  * Delivery flow refined to avoid duplicate v2-only notifications while preserving legacy hook delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->