### PR TITLE
exploration: CF Workers + DO relay (do not merge)

### DIFF
--- a/apps/relay-cf/package.json
+++ b/apps/relay-cf/package.json
@@ -1,0 +1,25 @@
+{
+	"name": "@superset/relay-cf",
+	"version": "0.1.0",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "dotenv -e ../../.env -- sh -c 'wrangler dev --port ${WRANGLER_PORT:-8788}'",
+		"deploy": "wrangler deploy",
+		"typecheck": "tsc --noEmit --emitDeclarationOnly false"
+	},
+	"dependencies": {
+		"@superset/shared": "workspace:*",
+		"@superset/trpc": "workspace:*",
+		"@trpc/client": "^11.7.1",
+		"jose": "^6.1.3",
+		"lru-cache": "^11.2.7",
+		"superjson": "^2.2.5"
+	},
+	"devDependencies": {
+		"@cloudflare/workers-types": "^4.20250214.0",
+		"@superset/typescript": "workspace:*",
+		"typescript": "^5.9.3",
+		"wrangler": "^4.14.4"
+	}
+}

--- a/apps/relay-cf/src/access.ts
+++ b/apps/relay-cf/src/access.ts
@@ -1,0 +1,44 @@
+import { LRUCache } from "lru-cache";
+import { createApiClient } from "./api-client";
+
+const allowedCache = new LRUCache<string, true>({
+	max: 50_000,
+	ttl: 5 * 60 * 1000,
+});
+
+export async function checkHostAccess(
+	token: string,
+	hostId: string,
+	apiUrl: string,
+): Promise<boolean> {
+	const key = `${token}:${hostId}`;
+	if (allowedCache.has(key)) return true;
+
+	try {
+		const client = createApiClient(token, apiUrl);
+		const result = await client.host.checkAccess.query({ hostId });
+		if (result.allowed) {
+			allowedCache.set(key, true);
+		}
+		return result.allowed;
+	} catch {
+		return false;
+	}
+}
+
+export async function setHostOnline(
+	token: string,
+	hostId: string,
+	isOnline: boolean,
+	apiUrl: string,
+): Promise<void> {
+	try {
+		const client = createApiClient(token, apiUrl);
+		await client.host.setOnline.mutate({ hostId, isOnline });
+	} catch (error) {
+		console.error(
+			`[relay-cf] failed to set host ${hostId} online=${isOnline}:`,
+			error,
+		);
+	}
+}

--- a/apps/relay-cf/src/api-client.ts
+++ b/apps/relay-cf/src/api-client.ts
@@ -1,0 +1,15 @@
+import type { AppRouter } from "@superset/trpc";
+import { createTRPCClient, httpBatchLink } from "@trpc/client";
+import SuperJSON from "superjson";
+
+export function createApiClient(token: string, apiUrl: string) {
+	return createTRPCClient<AppRouter>({
+		links: [
+			httpBatchLink({
+				url: `${apiUrl}/api/trpc`,
+				transformer: SuperJSON,
+				headers: () => ({ Authorization: `Bearer ${token}` }),
+			}),
+		],
+	});
+}

--- a/apps/relay-cf/src/auth.ts
+++ b/apps/relay-cf/src/auth.ts
@@ -1,0 +1,42 @@
+import { createRemoteJWKSet, jwtVerify } from "jose";
+
+export interface AuthContext {
+	sub: string;
+	email: string;
+	organizationIds: string[];
+}
+
+let jwks: ReturnType<typeof createRemoteJWKSet> | null = null;
+
+function getJWKS(jwksUrl: string): ReturnType<typeof createRemoteJWKSet> {
+	if (!jwks) {
+		jwks = createRemoteJWKSet(new URL("/api/auth/jwks", jwksUrl));
+	}
+	return jwks;
+}
+
+export async function verifyJWT(
+	token: string,
+	jwksUrl: string,
+	issuer: string,
+): Promise<AuthContext | null> {
+	try {
+		const { payload } = await jwtVerify(token, getJWKS(jwksUrl), {
+			issuer,
+			audience: issuer,
+		});
+
+		const sub = payload.sub;
+		const email = payload.email as string | undefined;
+		const organizationIds = payload.organizationIds as string[] | undefined;
+
+		if (!sub || !organizationIds) {
+			return null;
+		}
+
+		return { sub, email: email ?? "", organizationIds };
+	} catch (error) {
+		console.error("[relay-cf] JWT verification failed:", error);
+		return null;
+	}
+}

--- a/apps/relay-cf/src/host-tunnel-do.ts
+++ b/apps/relay-cf/src/host-tunnel-do.ts
@@ -1,0 +1,403 @@
+import { setHostOnline } from "./access";
+import type {
+	Env,
+	TunnelHttpResponse,
+	TunnelRequest,
+	TunnelResponse,
+	TunnelWsClose,
+	TunnelWsFrame,
+} from "./types";
+
+interface HostAttachment {
+	type: "host";
+	hostId: string;
+	token: string;
+	generation: number;
+	stale?: boolean;
+}
+
+interface ClientAttachment {
+	type: "client";
+	channelId: string;
+}
+
+type Attachment = HostAttachment | ClientAttachment;
+
+interface PendingRequest {
+	resolve: (response: TunnelHttpResponse) => void;
+	reject: (error: Error) => void;
+	timer: ReturnType<typeof setTimeout>;
+}
+
+const REQUEST_TIMEOUT_MS = 30_000;
+const PING_INTERVAL_MS = 30_000;
+const PING_TIMEOUT_MISSED = 3;
+
+export class HostTunnel implements DurableObject {
+	private hostWs: WebSocket | null = null;
+	private hostGeneration = 0;
+	private pending = new Map<string, PendingRequest>();
+	private clientChannels = new Map<string, WebSocket>();
+	private missedPings = 0;
+	private pingTimer: ReturnType<typeof setInterval> | null = null;
+
+	constructor(
+		private readonly state: DurableObjectState,
+		private readonly env: Env,
+	) {
+		// Re-derive in-memory state on cold start. Pending HTTP requests cannot
+		// survive hibernation (they hold Promise resolvers), but persistent WS
+		// connections do, and we rebuild their indexes here.
+		for (const ws of this.state.getWebSockets()) {
+			const att = ws.deserializeAttachment() as Attachment | undefined;
+			if (!att) continue;
+			if (att.type === "host" && !att.stale) {
+				this.hostWs = ws;
+				this.hostGeneration = Math.max(this.hostGeneration, att.generation);
+			} else if (att.type === "client") {
+				this.clientChannels.set(att.channelId, ws);
+			}
+		}
+		if (this.hostWs) this.startPingTimer();
+	}
+
+	async fetch(request: Request): Promise<Response> {
+		const url = new URL(request.url);
+
+		if (url.pathname === "/tunnel") {
+			return this.registerHost(request, url);
+		}
+
+		const subpath = url.pathname.replace(/^\/hosts\/[^/]+/, "") || "/";
+		if (request.headers.get("Upgrade") === "websocket") {
+			return this.openClientWs(request, subpath, url.search);
+		}
+		return this.proxyHttp(request, subpath + url.search);
+	}
+
+	// ── Host registration ──────────────────────────────────────────────
+
+	private async registerHost(request: Request, url: URL): Promise<Response> {
+		if (request.headers.get("Upgrade") !== "websocket") {
+			return new Response("Expected WebSocket upgrade", { status: 426 });
+		}
+
+		const hostId = url.searchParams.get("hostId");
+		const token = extractToken(request);
+		if (!hostId || !token) {
+			return new Response("Missing hostId or token", { status: 400 });
+		}
+
+		// Last-write-wins: if a tunnel already exists, mark it stale and close
+		// it. The stale flag lets `webSocketClose` skip cleanup of the new
+		// tunnel's state when the old socket finishes closing.
+		if (this.hostWs) {
+			const oldAtt = this.hostWs.deserializeAttachment() as
+				| HostAttachment
+				| undefined;
+			if (oldAtt) {
+				this.hostWs.serializeAttachment({ ...oldAtt, stale: true });
+			}
+			try {
+				this.hostWs.close(1000, "replaced");
+			} catch {
+				// already closed
+			}
+		}
+
+		const pair = new WebSocketPair();
+		const client = pair[0];
+		const server = pair[1];
+
+		this.hostGeneration++;
+		const attachment: HostAttachment = {
+			type: "host",
+			hostId,
+			token,
+			generation: this.hostGeneration,
+		};
+
+		this.state.acceptWebSocket(server, ["host"]);
+		server.serializeAttachment(attachment);
+
+		this.hostWs = server;
+		this.missedPings = 0;
+		this.startPingTimer();
+		console.log(`[relay-cf] tunnel registered: ${hostId}`);
+
+		void setHostOnline(token, hostId, true, this.env.NEXT_PUBLIC_API_URL);
+
+		return new Response(null, {
+			status: 101,
+			webSocket: client,
+		} as ResponseInit);
+	}
+
+	// ── Client HTTP → host ────────────────────────────────────────────
+
+	private async proxyHttp(
+		request: Request,
+		pathWithQuery: string,
+	): Promise<Response> {
+		if (!this.hostWs) {
+			// Drain the request body so the runtime doesn't error trying to flush
+			// it after we've already sent the response.
+			if (request.body) await request.body.cancel().catch(() => {});
+			return new Response('{"error":"Host not connected"}', {
+				status: 503,
+				headers: { "Content-Type": "application/json" },
+			});
+		}
+
+		const id = crypto.randomUUID();
+		const reqHeaders: Record<string, string> = {};
+		request.headers.forEach((value, key) => {
+			if (key !== "host" && key !== "authorization") reqHeaders[key] = value;
+		});
+
+		const body = request.body
+			? await request.text().catch(() => "")
+			: undefined;
+
+		const responsePromise = new Promise<TunnelHttpResponse>(
+			(resolve, reject) => {
+				const timer = setTimeout(() => {
+					this.pending.delete(id);
+					reject(new Error("Tunnel request timed out"));
+				}, REQUEST_TIMEOUT_MS);
+				this.pending.set(id, { resolve, reject, timer });
+			},
+		);
+
+		this.sendToHost({
+			type: "http",
+			id,
+			method: request.method,
+			path: pathWithQuery,
+			headers: reqHeaders,
+			body,
+		});
+
+		try {
+			const response = await responsePromise;
+			return new Response(response.body ?? null, {
+				status: response.status,
+				headers: response.headers,
+			});
+		} catch (error) {
+			return new Response(
+				JSON.stringify({
+					error: error instanceof Error ? error.message : "Proxy error",
+				}),
+				{ status: 502, headers: { "Content-Type": "application/json" } },
+			);
+		}
+	}
+
+	// ── Client WS → host ──────────────────────────────────────────────
+
+	private openClientWs(
+		_request: Request,
+		subpath: string,
+		search: string,
+	): Response {
+		if (!this.hostWs) {
+			return new Response("Host not connected", { status: 503 });
+		}
+
+		const channelId = crypto.randomUUID();
+		const pair = new WebSocketPair();
+		const client = pair[0];
+		const server = pair[1];
+
+		const attachment: ClientAttachment = { type: "client", channelId };
+		this.state.acceptWebSocket(server, ["client"]);
+		server.serializeAttachment(attachment);
+		this.clientChannels.set(channelId, server);
+
+		const query = search.startsWith("?")
+			? search.slice(1)
+			: search || undefined;
+		this.sendToHost({
+			type: "ws:open",
+			id: channelId,
+			path: subpath,
+			query,
+		});
+
+		return new Response(null, {
+			status: 101,
+			webSocket: client,
+		} as ResponseInit);
+	}
+
+	// ── Hibernatable WS callbacks ──────────────────────────────────────
+
+	async webSocketMessage(
+		ws: WebSocket,
+		raw: string | ArrayBuffer,
+	): Promise<void> {
+		const att = ws.deserializeAttachment() as Attachment | undefined;
+		if (!att) return;
+
+		const text = typeof raw === "string" ? raw : new TextDecoder().decode(raw);
+
+		if (att.type === "host") {
+			if (att.stale) return;
+			let msg: TunnelResponse;
+			try {
+				msg = JSON.parse(text) as TunnelResponse;
+			} catch {
+				return;
+			}
+			this.handleHostMessage(msg);
+			return;
+		}
+
+		// Client WS frame → forward to host as ws:frame.
+		this.sendToHost({ type: "ws:frame", id: att.channelId, data: text });
+	}
+
+	async webSocketClose(
+		ws: WebSocket,
+		code: number,
+		_reason: string,
+		_wasClean: boolean,
+	): Promise<void> {
+		const att = ws.deserializeAttachment() as Attachment | undefined;
+		if (!att) return;
+
+		if (att.type === "host") {
+			if (att.stale) return;
+			// Host disconnected: tear down everything bound to it.
+			this.hostWs = null;
+			this.stopPingTimer();
+			for (const pending of this.pending.values()) {
+				clearTimeout(pending.timer);
+				pending.reject(new Error("Tunnel disconnected"));
+			}
+			this.pending.clear();
+			for (const channel of this.clientChannels.values()) {
+				try {
+					channel.close(1011, "tunnel disconnected");
+				} catch {
+					// already closed
+				}
+			}
+			this.clientChannels.clear();
+			if (att.token && att.hostId) {
+				void setHostOnline(
+					att.token,
+					att.hostId,
+					false,
+					this.env.NEXT_PUBLIC_API_URL,
+				);
+			}
+			return;
+		}
+
+		// Client channel closed: tell host.
+		if (this.clientChannels.get(att.channelId) === ws) {
+			this.clientChannels.delete(att.channelId);
+		}
+		this.sendToHost({ type: "ws:close", id: att.channelId, code });
+	}
+
+	async webSocketError(ws: WebSocket, _error: unknown): Promise<void> {
+		// onclose follows onerror; rely on the close handler to clean up.
+		const att = ws.deserializeAttachment() as Attachment | undefined;
+		if (att?.type === "client") {
+			try {
+				ws.close(1011, "client error");
+			} catch {
+				// already closed
+			}
+		}
+	}
+
+	// ── Internal message dispatch ──────────────────────────────────────
+
+	private handleHostMessage(msg: TunnelResponse): void {
+		switch (msg.type) {
+			case "pong":
+				this.missedPings = 0;
+				return;
+			case "http:response":
+				this.handleResponse(msg);
+				return;
+			case "ws:frame":
+				this.handleWsFrame(msg);
+				return;
+			case "ws:close":
+				this.handleWsCloseFromHost(msg);
+				return;
+		}
+	}
+
+	private handleResponse(msg: TunnelHttpResponse): void {
+		const pending = this.pending.get(msg.id);
+		if (!pending) return;
+		clearTimeout(pending.timer);
+		this.pending.delete(msg.id);
+		pending.resolve(msg);
+	}
+
+	private handleWsFrame(msg: TunnelWsFrame): void {
+		const channel = this.clientChannels.get(msg.id);
+		if (channel?.readyState === WebSocket.READY_STATE_OPEN) {
+			channel.send(msg.data);
+		}
+	}
+
+	private handleWsCloseFromHost(msg: TunnelWsClose): void {
+		const channel = this.clientChannels.get(msg.id);
+		if (channel) {
+			this.clientChannels.delete(msg.id);
+			try {
+				channel.close(msg.code ?? 1000);
+			} catch {
+				// already closed
+			}
+		}
+	}
+
+	private sendToHost(msg: TunnelRequest): void {
+		if (this.hostWs?.readyState === WebSocket.READY_STATE_OPEN) {
+			this.hostWs.send(JSON.stringify(msg));
+		}
+	}
+
+	// ── Server-side ping (matches the Fly relay's behavior) ────────────
+
+	private startPingTimer(): void {
+		this.stopPingTimer();
+		this.pingTimer = setInterval(() => {
+			if (!this.hostWs) {
+				this.stopPingTimer();
+				return;
+			}
+			this.missedPings++;
+			if (this.missedPings >= PING_TIMEOUT_MISSED) {
+				try {
+					this.hostWs.close(1000, "ping timeout");
+				} catch {}
+				return;
+			}
+			this.sendToHost({ type: "ping" });
+		}, PING_INTERVAL_MS);
+	}
+
+	private stopPingTimer(): void {
+		if (this.pingTimer) {
+			clearInterval(this.pingTimer);
+			this.pingTimer = null;
+		}
+	}
+}
+
+function extractToken(req: Request): string | null {
+	const header = req.headers.get("Authorization");
+	if (header?.startsWith("Bearer ")) return header.slice(7);
+	const url = new URL(req.url);
+	return url.searchParams.get("token");
+}

--- a/apps/relay-cf/src/host-tunnel-do.ts
+++ b/apps/relay-cf/src/host-tunnel-do.ts
@@ -21,7 +21,23 @@ interface ClientAttachment {
 	channelId: string;
 }
 
-type Attachment = HostAttachment | ClientAttachment;
+// Renderer-side WS for a dedicated terminal channel. Keyed by terminalId.
+interface TerminalRendererAttachment {
+	type: "terminal-renderer";
+	terminalId: string;
+}
+
+// Host-side outbound WS for a dedicated terminal channel. Keyed by terminalId.
+interface TerminalHostAttachment {
+	type: "terminal-host";
+	terminalId: string;
+}
+
+type Attachment =
+	| HostAttachment
+	| ClientAttachment
+	| TerminalRendererAttachment
+	| TerminalHostAttachment;
 
 interface PendingRequest {
 	resolve: (response: TunnelHttpResponse) => void;
@@ -32,12 +48,20 @@ interface PendingRequest {
 const REQUEST_TIMEOUT_MS = 30_000;
 const PING_INTERVAL_MS = 30_000;
 const PING_TIMEOUT_MISSED = 3;
+const TERMINAL_BUFFER_MAX_FRAMES = 256;
 
 export class HostTunnel implements DurableObject {
 	private hostWs: WebSocket | null = null;
 	private hostGeneration = 0;
 	private pending = new Map<string, PendingRequest>();
 	private clientChannels = new Map<string, WebSocket>();
+	// Dedicated terminal channels: keyed by terminalId, two WS each (one to
+	// the renderer, one outbound from the host) bridged 1:1.
+	private terminalRenderers = new Map<string, WebSocket>();
+	private terminalHosts = new Map<string, WebSocket>();
+	// Frames received from a renderer before its host counterpart connects.
+	// Drained on host connect, capped to TERMINAL_BUFFER_MAX_FRAMES.
+	private terminalRendererBuffers = new Map<string, (string | ArrayBuffer)[]>();
 	private missedPings = 0;
 	private pingTimer: ReturnType<typeof setInterval> | null = null;
 
@@ -56,6 +80,10 @@ export class HostTunnel implements DurableObject {
 				this.hostGeneration = Math.max(this.hostGeneration, att.generation);
 			} else if (att.type === "client") {
 				this.clientChannels.set(att.channelId, ws);
+			} else if (att.type === "terminal-renderer") {
+				this.terminalRenderers.set(att.terminalId, ws);
+			} else if (att.type === "terminal-host") {
+				this.terminalHosts.set(att.terminalId, ws);
 			}
 		}
 		if (this.hostWs) this.startPingTimer();
@@ -68,9 +96,24 @@ export class HostTunnel implements DurableObject {
 			return this.registerHost(request, url);
 		}
 
+		// Host-side dedicated terminal callback: /terminal/<hostId>/<terminalId>
+		const terminalCallback = url.pathname.match(/^\/terminal\/[^/]+\/([^/]+)$/);
+		if (terminalCallback?.[1]) {
+			return this.acceptTerminalHost(
+				request,
+				decodeURIComponent(terminalCallback[1]),
+			);
+		}
+
 		const subpath = url.pathname.replace(/^\/hosts\/[^/]+/, "") || "/";
+
 		if (request.headers.get("Upgrade") === "websocket") {
-			return this.openClientWs(request, subpath, url.search);
+			// Renderer-side terminal upgrade: /hosts/<hostId>/terminal/<terminalId>
+			const terminalRender = subpath.match(/^\/terminal\/(.+)$/);
+			if (terminalRender?.[1]) {
+				return this.openClientTerminal(terminalRender[1], subpath, url.search);
+			}
+			return this.openClientWs(subpath, url.search);
 		}
 		return this.proxyHttp(request, subpath + url.search);
 	}
@@ -194,13 +237,9 @@ export class HostTunnel implements DurableObject {
 		}
 	}
 
-	// ── Client WS → host ──────────────────────────────────────────────
+	// ── Renderer-side WS (multiplexed) ───────────────────────────────
 
-	private openClientWs(
-		_request: Request,
-		subpath: string,
-		search: string,
-	): Response {
+	private openClientWs(subpath: string, search: string): Response {
 		if (!this.hostWs) {
 			return new Response("Host not connected", { status: 503 });
 		}
@@ -231,6 +270,134 @@ export class HostTunnel implements DurableObject {
 		} as ResponseInit);
 	}
 
+	// ── Renderer-side WS (dedicated terminal channel) ─────────────────
+
+	private openClientTerminal(
+		terminalId: string,
+		path: string,
+		search: string,
+	): Response {
+		if (!this.hostWs) {
+			return new Response("Host not connected", { status: 503 });
+		}
+
+		const hostAtt = this.hostWs.deserializeAttachment() as
+			| HostAttachment
+			| undefined;
+		if (!hostAtt) {
+			return new Response("Host attachment missing", { status: 503 });
+		}
+
+		// Reconnecting renderer for an existing terminal: close the old
+		// renderer side and replace it. The old host outbound (if any) will
+		// be closed when its renderer counterpart goes away.
+		const existingRenderer = this.terminalRenderers.get(terminalId);
+		if (existingRenderer) {
+			try {
+				existingRenderer.close(1000, "renderer reconnect");
+			} catch {
+				// already closed
+			}
+			this.terminalRenderers.delete(terminalId);
+		}
+		// Same for the host side: a stale outbound from a prior session
+		// shouldn't sit around alongside a fresh renderer.
+		const existingHost = this.terminalHosts.get(terminalId);
+		if (existingHost) {
+			try {
+				existingHost.close(1000, "renderer reconnect");
+			} catch {
+				// already closed
+			}
+			this.terminalHosts.delete(terminalId);
+		}
+		this.terminalRendererBuffers.delete(terminalId);
+
+		const pair = new WebSocketPair();
+		const client = pair[0];
+		const server = pair[1];
+
+		const attachment: TerminalRendererAttachment = {
+			type: "terminal-renderer",
+			terminalId,
+		};
+		this.state.acceptWebSocket(server, ["terminal-renderer"]);
+		server.serializeAttachment(attachment);
+		this.terminalRenderers.set(terminalId, server);
+
+		const query = search.startsWith("?")
+			? search.slice(1)
+			: search || undefined;
+		this.sendToHost({
+			type: "ws:open:dedicated",
+			terminalId,
+			hostId: hostAtt.hostId,
+			path,
+			query,
+			token: hostAtt.token,
+		});
+
+		return new Response(null, {
+			status: 101,
+			webSocket: client,
+		} as ResponseInit);
+	}
+
+	// ── Host-side dedicated terminal callback ─────────────────────────
+
+	private acceptTerminalHost(request: Request, terminalId: string): Response {
+		if (request.headers.get("Upgrade") !== "websocket") {
+			return new Response("Expected WebSocket upgrade", { status: 426 });
+		}
+
+		const renderer = this.terminalRenderers.get(terminalId);
+		if (!renderer) {
+			// Renderer disconnected before host's callback arrived. Reject so
+			// the host doesn't keep an orphan WS open.
+			return new Response("No pending terminal channel", { status: 404 });
+		}
+
+		const existing = this.terminalHosts.get(terminalId);
+		if (existing) {
+			try {
+				existing.close(1000, "host replaced");
+			} catch {
+				// already closed
+			}
+			this.terminalHosts.delete(terminalId);
+		}
+
+		const pair = new WebSocketPair();
+		const client = pair[0];
+		const server = pair[1];
+
+		const attachment: TerminalHostAttachment = {
+			type: "terminal-host",
+			terminalId,
+		};
+		this.state.acceptWebSocket(server, ["terminal-host"]);
+		server.serializeAttachment(attachment);
+		this.terminalHosts.set(terminalId, server);
+
+		// Flush any frames the renderer sent before the host connected.
+		const buffered = this.terminalRendererBuffers.get(terminalId);
+		if (buffered) {
+			for (const frame of buffered) {
+				try {
+					server.send(frame);
+				} catch {
+					// host already closed
+				}
+			}
+			this.terminalRendererBuffers.delete(terminalId);
+		}
+
+		return new Response(null, {
+			status: 101,
+			webSocket: client,
+		} as ResponseInit);
+	}
+
 	// ── Hibernatable WS callbacks ──────────────────────────────────────
 
 	async webSocketMessage(
@@ -239,6 +406,38 @@ export class HostTunnel implements DurableObject {
 	): Promise<void> {
 		const att = ws.deserializeAttachment() as Attachment | undefined;
 		if (!att) return;
+
+		if (att.type === "terminal-renderer") {
+			const hostWs = this.terminalHosts.get(att.terminalId);
+			if (hostWs?.readyState === WebSocket.READY_STATE_OPEN) {
+				try {
+					hostWs.send(raw);
+				} catch {
+					// host channel torn down mid-send
+				}
+				return;
+			}
+			// Host hasn't connected yet (or has dropped) — buffer up to a cap.
+			let buf = this.terminalRendererBuffers.get(att.terminalId);
+			if (!buf) {
+				buf = [];
+				this.terminalRendererBuffers.set(att.terminalId, buf);
+			}
+			if (buf.length < TERMINAL_BUFFER_MAX_FRAMES) buf.push(raw);
+			return;
+		}
+
+		if (att.type === "terminal-host") {
+			const rendererWs = this.terminalRenderers.get(att.terminalId);
+			if (rendererWs?.readyState === WebSocket.READY_STATE_OPEN) {
+				try {
+					rendererWs.send(raw);
+				} catch {
+					// renderer torn down mid-send
+				}
+			}
+			return;
+		}
 
 		const text = typeof raw === "string" ? raw : new TextDecoder().decode(raw);
 
@@ -254,7 +453,7 @@ export class HostTunnel implements DurableObject {
 			return;
 		}
 
-		// Client WS frame → forward to host as ws:frame.
+		// Legacy multiplex: client WS frame → forward as ws:frame.
 		this.sendToHost({ type: "ws:frame", id: att.channelId, data: text });
 	}
 
@@ -285,6 +484,23 @@ export class HostTunnel implements DurableObject {
 				}
 			}
 			this.clientChannels.clear();
+			for (const renderer of this.terminalRenderers.values()) {
+				try {
+					renderer.close(1011, "tunnel disconnected");
+				} catch {
+					// already closed
+				}
+			}
+			this.terminalRenderers.clear();
+			for (const hostSide of this.terminalHosts.values()) {
+				try {
+					hostSide.close(1011, "tunnel disconnected");
+				} catch {
+					// already closed
+				}
+			}
+			this.terminalHosts.clear();
+			this.terminalRendererBuffers.clear();
 			if (att.token && att.hostId) {
 				void setHostOnline(
 					att.token,
@@ -296,7 +512,40 @@ export class HostTunnel implements DurableObject {
 			return;
 		}
 
-		// Client channel closed: tell host.
+		if (att.type === "terminal-renderer") {
+			if (this.terminalRenderers.get(att.terminalId) === ws) {
+				this.terminalRenderers.delete(att.terminalId);
+			}
+			this.terminalRendererBuffers.delete(att.terminalId);
+			const hostSide = this.terminalHosts.get(att.terminalId);
+			if (hostSide) {
+				this.terminalHosts.delete(att.terminalId);
+				try {
+					hostSide.close(code, "renderer closed");
+				} catch {
+					// already closed
+				}
+			}
+			return;
+		}
+
+		if (att.type === "terminal-host") {
+			if (this.terminalHosts.get(att.terminalId) === ws) {
+				this.terminalHosts.delete(att.terminalId);
+			}
+			const renderer = this.terminalRenderers.get(att.terminalId);
+			if (renderer) {
+				this.terminalRenderers.delete(att.terminalId);
+				try {
+					renderer.close(code, "host closed");
+				} catch {
+					// already closed
+				}
+			}
+			return;
+		}
+
+		// Legacy multiplex client channel closed: tell host.
 		if (this.clientChannels.get(att.channelId) === ws) {
 			this.clientChannels.delete(att.channelId);
 		}
@@ -306,9 +555,13 @@ export class HostTunnel implements DurableObject {
 	async webSocketError(ws: WebSocket, _error: unknown): Promise<void> {
 		// onclose follows onerror; rely on the close handler to clean up.
 		const att = ws.deserializeAttachment() as Attachment | undefined;
-		if (att?.type === "client") {
+		if (
+			att?.type === "client" ||
+			att?.type === "terminal-renderer" ||
+			att?.type === "terminal-host"
+		) {
 			try {
-				ws.close(1011, "client error");
+				ws.close(1011, "channel error");
 			} catch {
 				// already closed
 			}

--- a/apps/relay-cf/src/types.ts
+++ b/apps/relay-cf/src/types.ts
@@ -1,0 +1,23 @@
+// Re-export the canonical wire-format types from @superset/shared so the
+// relay-cf and host-service share a single source of truth for the protocol.
+export type {
+	TunnelHttpRequest,
+	TunnelHttpResponse,
+	TunnelPing,
+	TunnelPong,
+	TunnelRequest,
+	TunnelResponse,
+	TunnelWsClose,
+	TunnelWsFrame,
+	TunnelWsOpen,
+} from "@superset/shared/tunnel-protocol";
+
+export interface Env {
+	NEXT_PUBLIC_API_URL: string;
+	// Optional: issuer/audience used for JWT verification. Falls back to
+	// NEXT_PUBLIC_API_URL when unset. Useful for local-tunnel deployments
+	// where JWKS lives behind a tunnel hostname but JWTs were signed by the
+	// local API with `iss=http://localhost:<port>`.
+	AUTH_ISSUER?: string;
+	HOST_TUNNEL: DurableObjectNamespace;
+}

--- a/apps/relay-cf/src/worker.ts
+++ b/apps/relay-cf/src/worker.ts
@@ -1,0 +1,141 @@
+import { checkHostAccess } from "./access";
+import { verifyJWT } from "./auth";
+import type { Env } from "./types";
+
+export { HostTunnel } from "./host-tunnel-do";
+
+function corsHeadersFor(request: Request): Record<string, string> {
+	const origin = request.headers.get("Origin") ?? "*";
+	const requestedHeaders =
+		request.headers.get("Access-Control-Request-Headers") ??
+		"Authorization, Content-Type";
+	return {
+		"Access-Control-Allow-Origin": origin,
+		"Access-Control-Allow-Methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+		"Access-Control-Allow-Headers": requestedHeaders,
+		"Access-Control-Expose-Headers": "*",
+		"Access-Control-Max-Age": "86400",
+		Vary: "Origin, Access-Control-Request-Headers",
+	};
+}
+
+function corsResponse(
+	request: Request,
+	status: number,
+	body: string,
+): Response {
+	return new Response(body, {
+		status,
+		headers: {
+			...corsHeadersFor(request),
+			"Content-Type": "application/json",
+		},
+	});
+}
+
+function withCors(request: Request, response: Response): Response {
+	const headers = new Headers(response.headers);
+	for (const [key, value] of Object.entries(corsHeadersFor(request))) {
+		headers.set(key, value);
+	}
+	return new Response(response.body, {
+		status: response.status,
+		statusText: response.statusText,
+		headers,
+		webSocket: (response as Response & { webSocket?: WebSocket }).webSocket,
+	} as ResponseInit);
+}
+
+// Map CF colo/continent → DO `locationHint`. The hint is best-effort; CF
+// picks the closest available region. Fallback to `wnam` since we expect
+// most early traffic from US-West.
+function pickLocationHint(
+	req: Request,
+): DurableObjectLocationHint | undefined {
+	const cf = (req as Request & { cf?: IncomingRequestCfProperties }).cf;
+	const continent = cf?.continent;
+	switch (continent) {
+		case "NA":
+			// Western vs Eastern split: heuristic on longitude when available.
+			return cf?.longitude && Number(cf.longitude) < -100 ? "wnam" : "enam";
+		case "EU":
+			return "weur";
+		case "AS":
+			return "apac";
+		case "OC":
+			return "oc";
+		case "SA":
+			return "sam";
+		case "AF":
+			return "afr";
+		default:
+			return "wnam";
+	}
+}
+
+function extractToken(req: Request): string | null {
+	const header = req.headers.get("Authorization");
+	if (header?.startsWith("Bearer ")) return header.slice(7);
+	const url = new URL(req.url);
+	return url.searchParams.get("token");
+}
+
+function extractHostId(url: URL): string | null {
+	if (url.pathname === "/tunnel") return url.searchParams.get("hostId");
+	const match = url.pathname.match(/^\/hosts\/([^/]+)/);
+	return match?.[1] ?? null;
+}
+
+export default {
+	async fetch(request: Request, env: Env): Promise<Response> {
+		if (request.method === "OPTIONS") {
+			return new Response(null, {
+				status: 204,
+				headers: corsHeadersFor(request),
+			});
+		}
+
+		const url = new URL(request.url);
+
+		if (url.pathname === "/health") {
+			return new Response(JSON.stringify({ ok: true }), {
+				status: 200,
+				headers: {
+					...corsHeadersFor(request),
+					"Content-Type": "application/json",
+				},
+			});
+		}
+
+		const token = extractToken(request);
+		if (!token) return corsResponse(request, 401, '{"error":"Unauthorized"}');
+
+		const auth = await verifyJWT(
+			token,
+			env.NEXT_PUBLIC_API_URL,
+			env.AUTH_ISSUER ?? env.NEXT_PUBLIC_API_URL,
+		);
+		if (!auth) return corsResponse(request, 401, '{"error":"Unauthorized"}');
+
+		const hostId = extractHostId(url);
+		if (!hostId)
+			return corsResponse(request, 400, '{"error":"Missing hostId"}');
+
+		const allowed = await checkHostAccess(
+			token,
+			hostId,
+			env.NEXT_PUBLIC_API_URL,
+		);
+		if (!allowed) return corsResponse(request, 403, '{"error":"Forbidden"}');
+
+		const id = env.HOST_TUNNEL.idFromName(hostId);
+		// `locationHint` is only consulted on first-create; existing DOs stay
+		// where they were initially placed. Setting it broadly so any new
+		// (hostId, region) combinations get placed close to the requester.
+		const stub = env.HOST_TUNNEL.get(id, {
+			locationHint: pickLocationHint(request),
+		});
+		const response = await stub.fetch(request);
+		return withCors(request, response);
+	},
+} satisfies ExportedHandler<Env>;

--- a/apps/relay-cf/src/worker.ts
+++ b/apps/relay-cf/src/worker.ts
@@ -49,9 +49,7 @@ function withCors(request: Request, response: Response): Response {
 // Map CF colo/continent → DO `locationHint`. The hint is best-effort; CF
 // picks the closest available region. Fallback to `wnam` since we expect
 // most early traffic from US-West.
-function pickLocationHint(
-	req: Request,
-): DurableObjectLocationHint | undefined {
+function pickLocationHint(req: Request): DurableObjectLocationHint | undefined {
 	const cf = (req as Request & { cf?: IncomingRequestCfProperties }).cf;
 	const continent = cf?.continent;
 	switch (continent) {
@@ -82,8 +80,14 @@ function extractToken(req: Request): string | null {
 
 function extractHostId(url: URL): string | null {
 	if (url.pathname === "/tunnel") return url.searchParams.get("hostId");
-	const match = url.pathname.match(/^\/hosts\/([^/]+)/);
-	return match?.[1] ?? null;
+	// `url.pathname` preserves percent-encoding; the renderer-side path is
+	// already in canonical form because the renderer doesn't encode it, but
+	// the host-side terminal callback uses encodeURIComponent on hostId
+	// (which contains a colon), so we must decode the captured segment.
+	const hostsMatch = url.pathname.match(/^\/hosts\/([^/]+)/);
+	if (hostsMatch?.[1]) return decodeURIComponent(hostsMatch[1]);
+	const terminalMatch = url.pathname.match(/^\/terminal\/([^/]+)\/[^/]+$/);
+	return terminalMatch?.[1] ? decodeURIComponent(terminalMatch[1]) : null;
 }
 
 export default {

--- a/apps/relay-cf/tsconfig.json
+++ b/apps/relay-cf/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"extends": "@superset/typescript/base.json",
+	"compilerOptions": {
+		"jsx": "react-jsx",
+		"types": ["@cloudflare/workers-types"],
+		"lib": ["ES2022", "ES2021.String"],
+		"moduleResolution": "Bundler",
+		"module": "ESNext",
+		"noEmit": true
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["node_modules"]
+}

--- a/apps/relay-cf/wrangler.jsonc
+++ b/apps/relay-cf/wrangler.jsonc
@@ -1,0 +1,27 @@
+{
+	"name": "superset-relay",
+	"main": "src/worker.ts",
+	"compatibility_date": "2025-01-01",
+	"compatibility_flags": ["nodejs_compat"],
+	"durable_objects": {
+		"bindings": [
+			{
+				"name": "HOST_TUNNEL",
+				"class_name": "HostTunnel"
+			}
+		]
+	},
+	"migrations": [
+		{
+			"tag": "v1",
+			"new_sqlite_classes": ["HostTunnel"]
+		}
+	],
+	"observability": {
+		"enabled": true,
+		"head_sampling_rate": 1,
+		"logs": {
+			"invocation_logs": true
+		}
+	}
+}

--- a/bun.lock
+++ b/bun.lock
@@ -558,6 +558,24 @@
         "typescript": "^5.9.3",
       },
     },
+    "apps/relay-cf": {
+      "name": "@superset/relay-cf",
+      "version": "0.1.0",
+      "dependencies": {
+        "@superset/shared": "workspace:*",
+        "@superset/trpc": "workspace:*",
+        "@trpc/client": "^11.7.1",
+        "jose": "^6.1.3",
+        "lru-cache": "^11.2.7",
+        "superjson": "^2.2.5",
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20250214.0",
+        "@superset/typescript": "workspace:*",
+        "typescript": "^5.9.3",
+        "wrangler": "^4.14.4",
+      },
+    },
     "apps/streams": {
       "name": "streams",
       "version": "0.0.0",
@@ -2574,6 +2592,8 @@
     "@superset/port-scanner": ["@superset/port-scanner@workspace:packages/port-scanner"],
 
     "@superset/relay": ["@superset/relay@workspace:apps/relay"],
+
+    "@superset/relay-cf": ["@superset/relay-cf@workspace:apps/relay-cf"],
 
     "@superset/shared": ["@superset/shared@workspace:packages/shared"],
 

--- a/packages/host-service/src/tunnel/tunnel-client.ts
+++ b/packages/host-service/src/tunnel/tunnel-client.ts
@@ -72,7 +72,11 @@ export class TunnelClient {
 
 			socket.onclose = () => {
 				this.socket = null;
-				this.cleanupChannels();
+				try {
+					this.cleanupChannels();
+				} catch (err) {
+					console.error("[host-service:tunnel] cleanupChannels threw:", err);
+				}
 				if (!this.closed) {
 					this.scheduleReconnect();
 				}
@@ -223,13 +227,22 @@ export class TunnelClient {
 		const localWs = this.localChannels.get(message.id);
 		if (localWs) {
 			this.localChannels.delete(message.id);
-			localWs.close(message.code ?? 1000);
+			try {
+				localWs.close(message.code ?? 1000);
+			} catch {
+				// invalid code from upstream; already closing
+			}
 		}
 	}
 
 	private cleanupChannels(): void {
 		for (const ws of this.localChannels.values()) {
-			ws.close(1001, "Tunnel disconnected");
+			// 1000 (Normal Closure) is the only standard code apps may emit per
+			// the WHATWG WebSocket spec; undici throws InvalidAccessError on
+			// reserved codes like 1001.
+			try {
+				ws.close(1000, "Tunnel disconnected");
+			} catch {}
 		}
 		this.localChannels.clear();
 	}

--- a/packages/host-service/src/tunnel/tunnel-client.ts
+++ b/packages/host-service/src/tunnel/tunnel-client.ts
@@ -5,10 +5,16 @@ import type {
 	TunnelWsClose,
 	TunnelWsFrame,
 	TunnelWsOpen,
+	TunnelWsOpenDedicated,
 } from "./types";
 
 const RECONNECT_BASE_MS = 1_000;
 const RECONNECT_MAX_MS = 30_000;
+
+interface DedicatedBridge {
+	relayWs: WebSocket;
+	localWs: WebSocket;
+}
 
 export interface TunnelClientOptions {
 	relayUrl: string;
@@ -26,6 +32,7 @@ export class TunnelClient {
 	private readonly hostServiceSecret: string;
 	private socket: WebSocket | null = null;
 	private localChannels = new Map<string, WebSocket>();
+	private dedicatedBridges = new Map<string, DedicatedBridge>();
 	private reconnectAttempts = 0;
 	private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 	private closed = false;
@@ -133,6 +140,9 @@ export class TunnelClient {
 			case "ws:open":
 				this.handleWsOpen(message);
 				break;
+			case "ws:open:dedicated":
+				this.handleWsOpenDedicated(message);
+				break;
 			case "ws:frame":
 				this.handleWsFrame(message);
 				break;
@@ -216,6 +226,84 @@ export class TunnelClient {
 		this.localChannels.set(request.id, localWs);
 	}
 
+	private handleWsOpenDedicated(request: TunnelWsOpenDedicated): void {
+		// Build the local pty URL the same way handleWsOpen does — same auth
+		// token and query passthrough rules.
+		const localUrl = new URL(request.path, `ws://127.0.0.1:${this.localPort}`);
+		localUrl.searchParams.set("token", this.hostServiceSecret);
+		if (request.query) {
+			const params = new URLSearchParams(request.query);
+			for (const [key, value] of params) {
+				if (key !== "token") {
+					localUrl.searchParams.set(key, value);
+				}
+			}
+		}
+
+		// Outbound callback to the relay's dedicated terminal endpoint. Frames
+		// are 1:1 between this WS and the local pty WS — no JSON wrapping.
+		const relayUrl = new URL(
+			`/terminal/${encodeURIComponent(request.hostId)}/${encodeURIComponent(request.terminalId)}`,
+			this.relayUrl,
+		);
+		relayUrl.protocol = relayUrl.protocol === "https:" ? "wss:" : "ws:";
+		relayUrl.searchParams.set("token", request.token);
+
+		const relayWs = new WebSocket(relayUrl.toString());
+		const localWs = new WebSocket(localUrl.toString());
+		this.dedicatedBridges.set(request.terminalId, { relayWs, localWs });
+
+		const closeBoth = (code: number, reason: string): void => {
+			this.dedicatedBridges.delete(request.terminalId);
+			try {
+				relayWs.close(1000, reason);
+			} catch {}
+			try {
+				localWs.close(1000, reason);
+			} catch {}
+			void code;
+		};
+
+		relayWs.onmessage = (event) => {
+			if (localWs.readyState === WebSocket.OPEN) {
+				try {
+					localWs.send(event.data as string | ArrayBuffer);
+				} catch {
+					// local side gone
+				}
+			}
+		};
+
+		localWs.onmessage = (event) => {
+			if (relayWs.readyState === WebSocket.OPEN) {
+				try {
+					relayWs.send(event.data as string | ArrayBuffer);
+				} catch {
+					// relay side gone
+				}
+			}
+		};
+
+		relayWs.onclose = (event) => {
+			closeBoth(event.code, "relay closed");
+		};
+		localWs.onclose = (event) => {
+			closeBoth(event.code, "local closed");
+		};
+		relayWs.onerror = (event) => {
+			console.error(
+				`[host-service:tunnel] dedicated relay WS error for terminal ${request.terminalId}:`,
+				event,
+			);
+		};
+		localWs.onerror = (event) => {
+			console.error(
+				`[host-service:tunnel] dedicated local WS error for terminal ${request.terminalId}:`,
+				event,
+			);
+		};
+	}
+
 	private handleWsFrame(message: TunnelWsFrame): void {
 		const localWs = this.localChannels.get(message.id);
 		if (localWs?.readyState === WebSocket.OPEN) {
@@ -245,6 +333,8 @@ export class TunnelClient {
 			} catch {}
 		}
 		this.localChannels.clear();
+		// Dedicated terminal bridges are independent of the control tunnel —
+		// they survive a control-WS reconnect. Don't tear them down here.
 	}
 
 	private scheduleReconnect(): void {

--- a/packages/host-service/src/tunnel/types.ts
+++ b/packages/host-service/src/tunnel/types.ts
@@ -8,4 +8,5 @@ export type {
 	TunnelWsClose,
 	TunnelWsFrame,
 	TunnelWsOpen,
+	TunnelWsOpenDedicated,
 } from "@superset/shared/tunnel-protocol";

--- a/packages/shared/src/tunnel-protocol.ts
+++ b/packages/shared/src/tunnel-protocol.ts
@@ -16,6 +16,23 @@ export interface TunnelWsOpen {
 	query?: string;
 }
 
+// Asks the host to open a *dedicated* outbound WebSocket back to the relay
+// for a single terminal session. Frames on that WS are not multiplexed —
+// the connection carries raw stdin/stdout for one terminal only.
+//
+// On receipt the host should:
+//   1. Open a local WebSocket to ws://localhost:<port><path>?<query>
+//   2. Open a callback WebSocket to wss://<relay>/terminal/<hostId>/<terminalId>?token=<tunnelToken>
+//   3. Bridge raw frames between (1) and (2) until either side closes
+export interface TunnelWsOpenDedicated {
+	type: "ws:open:dedicated";
+	terminalId: string;
+	hostId: string;
+	path: string;
+	query?: string;
+	token: string;
+}
+
 export interface TunnelWsFrame {
 	type: "ws:frame";
 	id: string;
@@ -35,6 +52,7 @@ export interface TunnelPing {
 export type TunnelRequest =
 	| TunnelHttpRequest
 	| TunnelWsOpen
+	| TunnelWsOpenDedicated
 	| TunnelWsFrame
 	| TunnelWsClose
 	| TunnelPing;

--- a/plans/20260428-relay-cf-rewrite.md
+++ b/plans/20260428-relay-cf-rewrite.md
@@ -1,0 +1,379 @@
+# Relay rewrite on Cloudflare Workers + Durable Objects
+
+## Context
+
+The current relay (`apps/relay`) is a Hono+WS service on Fly, single machine in `sjc`, in-memory tunnel directory (`Map<hostId, TunnelState>` at `apps/relay/src/tunnel.ts:30`). To scale globally on Fly we'd need to build a Redis-backed directory, fly-replay routing, a `_whoowns` WS pre-flight, region-aware fallback, SIGTERM drain, and reconciliation loops — all of which are coordination machinery around the fundamental thing: "one persistent owner per hostId, globally addressable."
+
+Cloudflare Durable Objects are exactly that primitive. Each hostId becomes one DO globally singleton; the Worker layer routes by name. The directory, the replay routing, the pre-flight, the boot cleanup, and the region sizing all collapse into the platform.
+
+The repo already runs one CF Worker (`apps/electric-proxy`, `apps/electric-proxy/wrangler.jsonc`, deployed on `wrangler ^4.14.4`) using the same JWKS-based JWT verification pattern. We have the operational muscle.
+
+User decisions captured during planning:
+- Rewrite on CF + DO rather than build out the Fly directory.
+- Keep streaming protocol changes in scope (Phase 3 from the old plan) — the wire format is changing either way.
+- Initial regions: implicit — Workers run at every CF PoP automatically; no region config to maintain.
+
+## Approach
+
+1. **New app `apps/relay-cf`** mirroring `apps/electric-proxy`'s shape: Worker entry + Durable Object class, deployed via `wrangler`.
+2. **Worker** = stateless edge handler. Verifies JWT, runs the `host.checkAccess` LRU check, looks up the DO by `idFromName(hostId)`, forwards via `stub.fetch(req)`. Same pattern as `apps/electric-proxy/src/index.ts`.
+3. **`HostTunnel` Durable Object** = one per hostId. Holds the host-side WS via the hibernatable WebSocket API (`state.acceptWebSocket`), multiplexes client HTTP/WS over it, calls `host.setOnline` via tRPC on register/unregister.
+4. **Chunked tunnel protocol** (replaces today's one-shot `http`/`http:response`): `http:start` + `http:chunk*` + `http:end` and matching response frames. Required for SSE, tRPC subscriptions, and any large body.
+5. **Cutover** by flipping `RELAY_URL` from `relay.superset.sh` (Fly) to `relay-cf.superset.sh` (CF). Single env-var change; A/B-able per-user via a PostHog flag during canary.
+
+## Files to create
+
+```
+apps/relay-cf/
+├── wrangler.jsonc                # DO bindings, routes, env, compatibility_date
+├── package.json                  # @cloudflare/workers-types, wrangler, jose, @upstash/redis (NOT NEEDED), @superset/trpc, @superset/shared, lru-cache, zod
+├── tsconfig.json                 # extends @superset/typescript, lib: webworker
+├── src/
+│   ├── worker.ts                 # entry: routes /tunnel, /hosts/:hostId/* to DO
+│   ├── auth.ts                   # COPY of apps/relay/src/auth.ts (already Workers-compatible)
+│   ├── access.ts                 # COPY of apps/relay/src/access.ts (lru-cache works in Workers)
+│   ├── api-client.ts             # COPY of apps/relay/src/api-client.ts (tRPC over fetch)
+│   ├── env.ts                    # Workers env binding schema (no @t3-oss/env-core; use zod against env arg)
+│   ├── host-tunnel-do.ts         # the HostTunnel Durable Object class
+│   ├── streaming.ts              # chunk frame helpers (encode/decode, base64)
+│   └── types.ts                  # wire format types (mirrored in host-service)
+```
+
+Three of those (`auth.ts`, `access.ts`, `api-client.ts`) are direct copies — same code already runs in `apps/electric-proxy`. Verified.
+
+## Files to modify
+
+### `packages/host-service/src/tunnel/tunnel-client.ts`
+- Streaming send: handle inbound `http:start`/`http:chunk`/`http:end` from relay, open `fetch` to local HTTP server with a streaming `ReadableStream` body.
+- Streaming receive: instead of today's `await response.text()`, pipe `response.body` chunks back as `http:response:chunk` frames.
+- Close-code handling at `packages/host-service/src/tunnel/tunnel-client.ts:70-76`: if `event.code === 4001`, skip backoff and reconnect on next tick.
+- Proactive ping every 15s; consider any 45s message-silence as dead and reconnect (today only relay pings, dead-server detection is up to ~90s).
+- Backwards-compat window: still accept legacy one-shot `http` from relay during transition.
+
+### `packages/host-service/src/tunnel/types.ts`
+- Add: `http:start`, `http:chunk`, `http:end`, `http:response:start`, `http:response:chunk`, `http:response:end`.
+- Keep legacy `http`/`http:response` for compat window; remove after host-client rollout settles.
+
+### `packages/cli/src/lib/env.ts:8`
+- Update default fallback after cutover, or leave pointing at the existing domain (we re-CNAME `relay.superset.sh` to the CF deployment when ready).
+
+### `packages/trpc/src/router/host/host.ts:142`
+- No changes needed — DO calls the existing `host.setOnline` mutation via tRPC over fetch with the host's JWT, same pattern the current Fly relay uses (`apps/relay/src/tunnel.ts:65`, `:85-86`).
+
+### Top-level `package.json` / `turbo.json`
+- Add `apps/relay-cf` to workspace globs (auto-discovered if `apps/*` is already a workspace pattern — likely yes).
+- Add a `deploy:relay-cf` task that runs `wrangler deploy` from the app directory.
+
+## Worker entry (sketch)
+
+```ts
+// apps/relay-cf/src/worker.ts
+import { verifyJWT } from "./auth";
+import { checkHostAccess } from "./access";
+
+export { HostTunnel } from "./host-tunnel-do";
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    const url = new URL(req.url);
+    if (url.pathname === "/health") return new Response("ok");
+
+    const token = extractToken(req);
+    if (!token) return new Response("Unauthorized", { status: 401 });
+    const auth = await verifyJWT(token, env.NEXT_PUBLIC_API_URL);
+    if (!auth) return new Response("Unauthorized", { status: 401 });
+
+    const hostId =
+      url.pathname === "/tunnel"
+        ? url.searchParams.get("hostId")
+        : url.pathname.match(/^\/hosts\/([^/]+)/)?.[1];
+    if (!hostId) return new Response("Missing hostId", { status: 400 });
+
+    const allowed = await checkHostAccess(token, hostId, env);
+    if (!allowed) return new Response("Forbidden", { status: 403 });
+
+    const stub = env.HOST_TUNNEL.get(env.HOST_TUNNEL.idFromName(hostId));
+    return stub.fetch(req);
+  },
+};
+```
+
+`extractToken` mirrors `apps/relay/src/index.ts:31-40` (Authorization header or `?token=` query param).
+
+## HostTunnel Durable Object (sketch)
+
+```ts
+// apps/relay-cf/src/host-tunnel-do.ts
+export class HostTunnel implements DurableObject {
+  private hostWs: WebSocket | null = null;
+  private pending = new Map<string, WritableStreamDefaultWriter<Uint8Array>>();
+  private pendingHead = new Map<string, (head: { status: number; headers: Record<string,string> }) => void>();
+  private clientChannels = new Map<string, WebSocket>();
+  private hostId: string | null = null;
+
+  constructor(private state: DurableObjectState, private env: Env) {
+    // re-attach hibernated host WS on wakeup
+    const [host] = this.state.getWebSockets("host");
+    if (host) {
+      this.hostWs = host;
+      this.hostId = host.deserializeAttachment()?.hostId ?? null;
+    }
+  }
+
+  async fetch(req: Request): Promise<Response> {
+    const url = new URL(req.url);
+    if (url.pathname === "/tunnel") return this.registerHost(req);
+
+    const subpath = url.pathname.replace(/^\/hosts\/[^/]+/, "") || "/";
+    if (req.headers.get("Upgrade") === "websocket")
+      return this.openClientWs(req, subpath);
+    return this.proxyHttp(req, subpath);
+  }
+
+  private async registerHost(req: Request): Promise<Response> {
+    const url = new URL(req.url);
+    const hostId = url.searchParams.get("hostId")!;
+    const token = extractToken(req)!;
+
+    if (this.hostWs) this.hostWs.close(1000, "replaced");  // last-write-wins
+
+    const pair = new WebSocketPair();
+    const [client, server] = [pair[0], pair[1]];
+    this.state.acceptWebSocket(server, ["host"]);
+    server.serializeAttachment({ hostId, token });
+    this.hostWs = server;
+    this.hostId = hostId;
+
+    // setOnline true via tRPC, fire-and-forget
+    void setHostOnline(this.env, token, hostId, true);
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  private async proxyHttp(req: Request, subpath: string): Promise<Response> {
+    if (!this.hostWs) return new Response("Host not connected", { status: 503 });
+
+    const id = crypto.randomUUID();
+    const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>();
+    this.pending.set(id, writable.getWriter());
+
+    const headPromise = new Promise<{ status: number; headers: Record<string,string> }>(
+      (r) => this.pendingHead.set(id, r)
+    );
+
+    this.send({ type: "http:start", id, method: req.method, path: subpath, headers: headersToObj(req.headers) });
+    if (req.body) {
+      const reader = req.body.getReader();
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        this.send({ type: "http:chunk", id, data: b64encode(value) });
+      }
+    }
+    this.send({ type: "http:end", id });
+
+    const { status, headers } = await headPromise;
+    return new Response(readable, { status, headers });
+  }
+
+  // hibernatable WS callbacks — Workers calls these even from a cold isolate
+  async webSocketMessage(ws: WebSocket, raw: string | ArrayBuffer): Promise<void> {
+    const msg = JSON.parse(typeof raw === "string" ? raw : new TextDecoder().decode(raw));
+    if (msg.type === "pong") return;
+    if (msg.type === "http:response:start") {
+      this.pendingHead.get(msg.id)?.({ status: msg.status, headers: msg.headers });
+      this.pendingHead.delete(msg.id);
+    }
+    if (msg.type === "http:response:chunk") {
+      await this.pending.get(msg.id)?.write(b64decode(msg.data));
+    }
+    if (msg.type === "http:response:end") {
+      await this.pending.get(msg.id)?.close();
+      this.pending.delete(msg.id);
+    }
+    if (msg.type === "ws:frame") {
+      this.clientChannels.get(msg.id)?.send(msg.data);
+    }
+    if (msg.type === "ws:close") {
+      const ch = this.clientChannels.get(msg.id);
+      if (ch) { this.clientChannels.delete(msg.id); ch.close(msg.code ?? 1000); }
+    }
+  }
+
+  async webSocketClose(ws: WebSocket, code: number, reason: string): Promise<void> {
+    if (ws === this.hostWs) {
+      this.hostWs = null;
+      // fail all pending, close all client channels, setOnline false
+      for (const w of this.pending.values()) await w.abort("tunnel closed");
+      this.pending.clear();
+      this.pendingHead.clear();
+      for (const ch of this.clientChannels.values()) ch.close(1011, "tunnel closed");
+      this.clientChannels.clear();
+      const att = ws.deserializeAttachment();
+      if (att) void setHostOnline(this.env, att.token, att.hostId, false);
+    } else {
+      // a client channel closed; tell the host
+      for (const [id, channel] of this.clientChannels) {
+        if (channel === ws) {
+          this.clientChannels.delete(id);
+          this.send({ type: "ws:close", id, code });
+          return;
+        }
+      }
+    }
+  }
+
+  private send(msg: unknown): void {
+    if (this.hostWs?.readyState === WebSocket.READY_STATE_OPEN)
+      this.hostWs.send(JSON.stringify(msg));
+  }
+}
+```
+
+`openClientWs` mirrors today's `apps/relay/src/index.ts:144-174` — accept the client WS, store in `clientChannels`, send `ws:open` to host, route inbound frames as `ws:frame`. Hibernatable accept on the client side too if we want zero-cost idle channels.
+
+## Wire format (chunked)
+
+Host-bound (DO → host):
+```
+{ type: "http:start",  id, method, path, headers }
+{ type: "http:chunk",  id, data: <base64> }
+{ type: "http:end",    id }
+{ type: "ws:open",     id, path, query? }
+{ type: "ws:frame",    id, data }
+{ type: "ws:close",    id, code? }
+{ type: "ping" }
+```
+
+Relay-bound (host → DO):
+```
+{ type: "http:response:start", id, status, headers }
+{ type: "http:response:chunk", id, data: <base64> }
+{ type: "http:response:end",   id }
+{ type: "ws:frame",            id, data }
+{ type: "ws:close",            id, code? }
+{ type: "pong" }
+```
+
+Compat: DO accepts legacy one-shot `http`/`http:response` during host-client rollout. Remove ~30 days after host-client min-version is deployed.
+
+## Auth flow on Workers
+
+Confirmed by exploration — all three auth pieces port directly:
+
+- `verifyJWT(token, apiUrl)` (`apps/relay/src/auth.ts:1-41`): jose `createRemoteJWKSet` against `${apiUrl}/api/auth/jwks`, local verify with `iss/aud=apiUrl`. Already runs in `apps/electric-proxy/src/auth.ts`. Module-level JWKS singleton survives within a Worker isolate; cold start re-fetches.
+- `checkHostAccess(token, hostId)` (`apps/relay/src/access.ts:1-26`): `lru-cache` (max 50k, TTL 5min, allow-only) wrapping `host.checkAccess` tRPC call. `lru-cache` is pure JS, runs fine in Workers. First request per cold isolate pays one tRPC round trip.
+- `host.setOnline` (`packages/trpc/src/router/host/host.ts:142-181`): JWT-protected mutation, single host write. DO calls it via tRPC over fetch with the host's stored JWT — same as `apps/relay/src/tunnel.ts:65,85-86` does today.
+
+Cold-isolate cost: one JWKS fetch + one `checkAccess` call. Both <50ms. Acceptable.
+
+## `wrangler.jsonc` (sketch)
+
+```jsonc
+{
+  "name": "superset-relay",
+  "main": "src/worker.ts",
+  "compatibility_date": "2026-01-01",
+  "compatibility_flags": ["nodejs_compat"],
+  "routes": [{ "pattern": "relay-cf.superset.sh/*", "zone_name": "superset.sh" }],
+  "durable_objects": {
+    "bindings": [{ "name": "HOST_TUNNEL", "class_name": "HostTunnel" }]
+  },
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["HostTunnel"] }],
+  "vars": {
+    "NEXT_PUBLIC_API_URL": "https://api.superset.sh"
+  }
+}
+```
+
+`new_sqlite_classes` (vs `new_classes`) gives us SQLite-backed DOs which are now the default — ~5× cheaper on storage and required for new DOs as of Cloudflare's 2025 pricing change.
+
+## Cutover plan
+
+Each step is independently revertible.
+
+1. **Build `apps/relay-cf` end-to-end**, deploy to `relay-cf.superset.sh`. No production traffic. Verify via direct curl + a hand-pointed dev desktop. ~1 week.
+2. **Land streaming protocol on host-service** (`packages/host-service/src/tunnel/*`). Ship in next desktop release. The current Fly relay continues to accept legacy one-shot frames; new host-clients still talk to it fine.
+3. **Internal canary**: add a `RELAY_URL_OVERRIDE` field on `users` (or a PostHog feature flag we read at host-service startup). Flip 5–10 internal users to `relay-cf.superset.sh`. Watch CF dashboard metrics + Sentry for one week.
+4. **Org-level canary**: extend the override to organization scope; bring up 2–3 friendly orgs.
+5. **Default flip**: change the default `RELAY_URL` in `packages/cli/src/lib/env.ts:8` and `apps/desktop` env defaults to point at the CF domain. Push a host-service release. Watch for one more week.
+6. **CNAME swap**: re-point `relay.superset.sh` DNS to the CF deployment so older host-service versions also migrate. Drop the override mechanism.
+7. **Decommission Fly**: `fly app destroy superset-relay`. Delete `apps/relay/`. Delete `apps/relay/plans/20260420-relay-hardening.md`.
+
+Rollback at any step: flip the override or DNS back. The Fly relay stays running until step 7.
+
+## Cost shape
+
+Sized for 1k concurrent hosts, ~100 client RPS aggregate (current ballpark scale):
+
+- Workers requests (Worker entry per client req + per host WS message round): ~780M/mo × $0.30/M ≈ **$234**
+- DO requests (Worker→DO sub-requests, similar order): ≈ **$234**
+- DO duration (hibernatable WS — only billed during active CPU): rough $10–50 depending on traffic shape
+- DO storage: ~$0
+- **Total ~$500/mo at projected steady load**
+
+Compare Fly: ~$108/mo idle baseline (3 regions × 1 machine) + traffic, ~$300–400/mo all-in at the same load.
+
+The key shape difference: **CF baseline is ~$0**; Fly baseline is fixed regardless of traffic. CF wins at <50% utilization; Fly wins at >80% steady-state. Cost is also unit-priced (per-request, per-CPU-ms) rather than capacity-priced (per-machine), which makes finance modeling easier.
+
+These are projections, not measurements — re-check on real traffic before scaling assumptions.
+
+## Classes of issues this rewrite eliminates
+
+| Today / Fly plan | After CF + DO |
+|---|---|
+| Upstash directory module + sweeper + heartbeat | Gone — DO singleton is the directory |
+| `fly-replay` middleware + `_whoowns` pre-flight | Gone — Worker→DO routing by name |
+| Last-write-wins register race (multi-machine) | Impossible — DO is single-writer per name |
+| Boot-time `is_online` cleanup | Gone — `webSocketClose` callback fires reliably |
+| Periodic reconciliation loop | Gone — same |
+| `[[regions]]` config + per-region machine sizing | Gone — runs at every PoP |
+| SIGTERM drain + 4001 dance for deploys | Simpler — `wrangler deploy` is atomic, no rolling fleet |
+| Replay-rate metric and sticky-LB tuning | Gone — there's no replay |
+
+What remains is the genuinely necessary work: streaming wire format, host-client reconnect/ping, and auth integration. Same in either world.
+
+## New risks introduced
+
+- **Workers CPU time** (50ms free / 30s paid per request or callback). Frame forwarding is microseconds; safe but it's a new constraint.
+- **DO memory ceiling** (128 MB). Streaming protocol keeps this bounded.
+- **WS frame size** (hard limit 1 MiB per Worker WebSocket message). Chunk size in our streaming protocol must stay <512 KB to be safe.
+- **Vendor lock-in.** DO is proprietary; lifting off CF later is a rewrite. Acceptable trade given the relay is an isolated service.
+- **Local dev** uses `wrangler dev` (Miniflare V8) instead of `bun run`. Different from rest of monorepo; precedent set by `apps/electric-proxy`.
+- **JWKS cold-start**: each new isolate fetches JWKS once. <50ms; doesn't matter in practice.
+
+## Out of scope (intentional)
+
+- `v2_machines` data-model refactor (Phase 6 from old plan).
+- Custom alerting rules — CF dashboard gives us metrics out of the box.
+- Migrating `apps/electric-proxy` or other Workers — independent.
+- Per-region DO `locationHint` tuning. Default migration heuristic is fine until telemetry shows a problem.
+
+## Critical files for implementation
+
+- `apps/electric-proxy/wrangler.jsonc` — copy as starting point for `wrangler.jsonc`
+- `apps/electric-proxy/src/auth.ts` — already-Workers-compatible JWT verify, copy
+- `apps/electric-proxy/package.json` — reference for Workers tooling versions
+- `apps/relay/src/auth.ts:1-41` — same code, already Workers-compatible
+- `apps/relay/src/access.ts:1-26` — same code, copy verbatim
+- `apps/relay/src/api-client.ts:1-16` — same code, copy verbatim
+- `apps/relay/src/index.ts:31-40` — `extractToken` helper, copy
+- `apps/relay/src/tunnel.ts` — reference for what state the DO needs to hold; rewrite, don't port
+- `packages/host-service/src/tunnel/tunnel-client.ts` — modify in place for streaming + 4001
+- `packages/host-service/src/tunnel/types.ts` — modify in place for new wire types
+- `packages/trpc/src/router/host/host.ts:142` — leave; DO calls existing `setOnline`
+- `packages/cli/src/lib/env.ts:8` — flip default `RELAY_URL` at cutover step
+
+## Verification
+
+End-to-end gates per phase:
+
+1. **Direct DO smoke**: deploy CF, point one dev desktop at `relay-cf.superset.sh`. Tunnel registers, web client opens a workspace, terminal works, all tRPC calls succeed.
+2. **Streaming**: open a chat tRPC subscription; verify chunks arrive incrementally (capture in browser devtools / `wrangler tail`). Trigger a 10 MB download via the tunnel; verify TTFB < 1s.
+3. **DO singleton**: force two host-service processes to claim the same `hostId`. First gets close 1000 "replaced"; second owns the tunnel. Web reconnects to the new owner without intervention.
+4. **Hibernation**: leave an idle tunnel for an hour. Verify `wrangler tail` shows ~zero events; CF dashboard shows DO duration billing near zero.
+5. **Code deploy**: `wrangler deploy` while tunnels are connected. Hosts see a brief WS close; reconnect within 2s on the new code; users don't notice.
+6. **Auth gates**: bad JWT → 401 from Worker, never hits DO (verify in `wrangler tail`). Org membership check failure → 403 from Worker.
+7. **Cross-region**: ask an EU teammate to run `RELAY_URL=https://relay-cf.superset.sh` against their desktop. Trigger requests from a US client. Confirm both legs are <100ms (visible in CF analytics).
+8. **Load**: `tunnel-client.ts` smoke script spinning 1000 synthetic hosts + 100 client RPS. Watch CF analytics for error rate, p95 latency, DO duration cost. Confirm projections.
+
+After step 8 passes for a week, proceed to default-flip + DNS cutover.


### PR DESCRIPTION
## Summary

Exploration of porting `apps/relay` to a Cloudflare Workers + Durable Objects implementation, with the goal of getting global routing for free instead of building out the in-region scale-out described in `apps/relay/plans/20260420-relay-hardening.md`.

**Outcome: parking this. Not merging.** See [plans/20260428-relay-cf-rewrite.md](./plans/20260428-relay-cf-rewrite.md) for the design and what we learned. Short version below.

## What's here

- `apps/relay-cf/` — Worker entry + `HostTunnel` Durable Object, wire-compatible with the existing `apps/relay` tunnel protocol (one-shot HTTP, multiplexed `ws:open` channels, ping/pong).
- New `ws:open:dedicated` protocol message that splits each terminal session onto its own WS pair, so HTTP fan-out can't head-of-line-block keystrokes on the host's control tunnel.
- `fix(host-service)`: WHATWG-compliant close code 1000 in `cleanupChannels` (undici throws `InvalidAccessError` on 1001). This is the only change worth landing on its own; will cherry-pick into a separate PR.
- Plan doc.

## Why we're parking it

CF + DO is a beautiful fit for the *coordination* problem (per-host singleton, global routing by name, hibernation). But for sustained sub-100ms WS frame routing — terminals — it's structurally less consistent than a Bun process on Fly:

- DO event-loop dispatch jitter: median single-digit ms, but a real long tail. CF tunes DOs for coordination workloads, not for high-frequency interactive frames.
- Hibernation wake cost on a cold isolate: <100ms when warm, sometimes >300ms after idle.
- Multi-tenant V8 contention on the DO machine.

Empirical: typing latency feels great most of the time but spikes to 500–700ms on a "came back from idle" pattern. Terminals need <100ms p99 to feel right; CF doesn't reliably hit that.

The dedicated-channel split fixed the HOL-blocking class of issues but doesn't address the platform's per-frame variance.

## What we'll do instead

Pick up `apps/relay/plans/20260420-relay-hardening.md` Phase 1: Upstash directory + `fly-replay` for in-region scale-out on the existing Fly relay. Same global-deploy story, no platform-induced variance on the data plane.

## What's worth keeping from this branch

- `fix(host-service): use close code 1000 in tunnel cleanup` — unrelated to CF, real bug under undici. Will land separately.
- The plan doc, as a record of the exploration.

The `apps/relay-cf` scaffold can sit here for future reference, or get deleted when this PR is closed.

## Test plan

- [x] Manual smoke against deployed CF Worker (`https://superset-relay.avi-6ac.workers.dev`)
- [x] HTTP forwarding works end-to-end via cloudflared tunnel
- [x] Terminals connect via dedicated `/terminal/<hostId>/<terminalId>` bridge
- [x] Sidebar HTTP fan-out no longer blocks terminal keystrokes
- [ ] Typing latency is consistently <100ms — **fails**, reason for parking