### PR TITLE
fix(desktop): truncate diff file path and add copy-path action to fil…

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileHeader/DiffFileHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileHeader/DiffFileHeader.tsx
@@ -45,8 +45,8 @@ export function DiffFileHeader({
 	const { copyToClipboard, copied } = useCopyToClipboard();
 
 	// Split into directory + basename so the basename stays visible when the
-	// header is narrow — the directory truncates with ellipsis instead of
-	// hiding the filename behind it.
+	// header is narrow — the directory truncates with ellipsis first, and the
+	// basename truncates only as a fallback (very narrow pane or no directory).
 	const lastSlash = path.lastIndexOf("/");
 	const dir = lastSlash >= 0 ? path.slice(0, lastSlash + 1) : "";
 	const name = lastSlash >= 0 ? path.slice(lastSlash + 1) : path;
@@ -84,11 +84,11 @@ export function DiffFileHeader({
 						<FileIcon fileName={path} className="size-3.5 shrink-0" />
 						<span className="flex min-w-0 items-baseline font-mono text-xs">
 							{dir && (
-								<span className="min-w-0 truncate text-muted-foreground">
+								<span className="min-w-0 shrink-[1000] truncate text-muted-foreground">
 									{dir}
 								</span>
 							)}
-							<span className="shrink-0 text-foreground">{name}</span>
+							<span className="min-w-0 truncate text-foreground">{name}</span>
 						</span>
 					</button>
 				</TooltipTrigger>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/components/FilePaneHeaderExtras/FilePaneHeaderExtras.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/components/FilePaneHeaderExtras/FilePaneHeaderExtras.tsx
@@ -1,7 +1,9 @@
 import type { RendererContext } from "@superset/panes";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useCallback } from "react";
+import { LuCheck, LuCopy } from "react-icons/lu";
 import { TbExternalLink } from "react-icons/tb";
+import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import { useOpenInExternalEditor } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useOpenInExternalEditor";
 import { useSharedFileDocument } from "../../../../../../state/fileDocumentStore";
 import type { FilePaneData, PaneViewerData } from "../../../../../../types";
@@ -20,6 +22,7 @@ export function FilePaneHeaderExtras({
 	const data = context.pane.data as FilePaneData;
 	const { filePath } = data;
 	const openInExternalEditor = useOpenInExternalEditor(workspaceId);
+	const { copyToClipboard, copied } = useCopyToClipboard();
 
 	const document = useSharedFileDocument({
 		workspaceId,
@@ -54,6 +57,25 @@ export function FilePaneHeaderExtras({
 					onChange={handleChangeView}
 				/>
 			)}
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<button
+						type="button"
+						aria-label="Copy path"
+						onClick={() => void copyToClipboard(filePath)}
+						className="rounded p-1 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
+					>
+						{copied ? (
+							<LuCheck className="size-3.5" />
+						) : (
+							<LuCopy className="size-3.5" />
+						)}
+					</button>
+				</TooltipTrigger>
+				<TooltipContent side="bottom" showArrow={false}>
+					{copied ? "Copied" : "Copy path"}
+				</TooltipContent>
+			</Tooltip>
 			<Tooltip>
 				<TooltipTrigger asChild>
 					<button


### PR DESCRIPTION
…e pane

- DiffFileHeader: basename now also truncates as a fallback so root-level files (no directory prefix) no longer overlap the right-side actions. Directory still shrinks first via shrink-[1000].
- FilePaneHeaderExtras: add a Copy path button alongside Open in editor, matching the diff pane.

## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added copy-to-clipboard button for file paths with dynamic visual feedback indicating successful copy action

* **UI/UX Improvements**
  * Optimized text truncation in diff file header for narrow layouts, prioritizing directory path visibility over filename

<!-- end of auto-generated comment: release notes by coderabbit.ai -->