### PR TITLE
feat(host-service): host agent configs (v2 PR 1, argv-array shape)

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/AgentsSettings/AgentsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/AgentsSettings/AgentsSettings.tsx
@@ -1,9 +1,11 @@
+import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
 	isItemVisible,
 	SETTING_ITEM_ID,
 	type SettingItemId,
 } from "../../../utils/settings-search";
+import { V2AgentsSettings } from "../V2AgentsSettings";
 import { AgentCard } from "./components/AgentCard";
 
 interface AgentsSettingsProps {
@@ -11,6 +13,14 @@ interface AgentsSettingsProps {
 }
 
 export function AgentsSettings({ visibleItems }: AgentsSettingsProps) {
+	const { isV2CloudEnabled } = useIsV2CloudEnabled();
+	if (isV2CloudEnabled) {
+		return <V2AgentsSettings />;
+	}
+	return <V1AgentsSettings visibleItems={visibleItems} />;
+}
+
+function V1AgentsSettings({ visibleItems }: AgentsSettingsProps) {
 	const { data: presets = [], isLoading } =
 		electronTrpc.settings.getAgentPresets.useQuery();
 

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/V2AgentsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/V2AgentsSettings.tsx
@@ -29,6 +29,10 @@ import { toast } from "@superset/ui/sonner";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Plus, RotateCcw } from "lucide-react";
 import { useMemo } from "react";
+import {
+	getPresetIcon,
+	useIsDarkTheme,
+} from "renderer/assets/app-icons/preset-icons";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { V2AgentCard } from "./components/V2AgentCard";
@@ -38,6 +42,7 @@ const QUERY_KEY = ["host-agent-configs"] as const;
 export function V2AgentsSettings() {
 	const { activeHostUrl } = useLocalHostService();
 	const queryClient = useQueryClient();
+	const isDark = useIsDarkTheme();
 
 	const configsQuery = useQuery({
 		queryKey: [...QUERY_KEY, activeHostUrl] as const,
@@ -177,14 +182,27 @@ export function V2AgentsSettings() {
 							</Button>
 						</DropdownMenuTrigger>
 						<DropdownMenuContent align="end">
-							{presets.map((preset) => (
-								<DropdownMenuItem
-									key={preset.presetId}
-									onSelect={() => addMutation.mutate(preset.presetId)}
-								>
-									{preset.label}
-								</DropdownMenuItem>
-							))}
+							{presets.map((preset) => {
+								const icon = getPresetIcon(preset.presetId, isDark);
+								return (
+									<DropdownMenuItem
+										key={preset.presetId}
+										onSelect={() => addMutation.mutate(preset.presetId)}
+										className="gap-2"
+									>
+										{icon ? (
+											<img
+												src={icon}
+												alt=""
+												className="size-4 object-contain shrink-0"
+											/>
+										) : (
+											<div className="size-4 rounded bg-muted shrink-0" />
+										)}
+										{preset.label}
+									</DropdownMenuItem>
+								);
+							})}
 						</DropdownMenuContent>
 					</DropdownMenu>
 				</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/V2AgentsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/V2AgentsSettings.tsx
@@ -1,0 +1,409 @@
+import type {
+	AgentPreset,
+	HostAgentConfigDto,
+	PromptTransport,
+} from "@superset/host-service/settings";
+import { Button } from "@superset/ui/button";
+import { Card, CardContent } from "@superset/ui/card";
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "@superset/ui/collapsible";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import { Input } from "@superset/ui/input";
+import { Label } from "@superset/ui/label";
+import { toast } from "@superset/ui/sonner";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ChevronDown, ChevronUp, Plus, RotateCcw, Trash2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import {
+	joinArgs,
+	joinCommandArgs,
+	parseArgs,
+	parseCommandString,
+} from "./utils/argv";
+
+const QUERY_KEY = ["host-agent-configs"] as const;
+
+export function V2AgentsSettings() {
+	const { activeHostUrl } = useLocalHostService();
+	const queryClient = useQueryClient();
+
+	const configsQuery = useQuery({
+		queryKey: [...QUERY_KEY, activeHostUrl] as const,
+		enabled: !!activeHostUrl,
+		queryFn: () => {
+			if (!activeHostUrl) return [] as HostAgentConfigDto[];
+			return getHostServiceClientByUrl(
+				activeHostUrl,
+			).settings.agentConfigs.list.query();
+		},
+	});
+
+	const presetsQuery = useQuery({
+		queryKey: [...QUERY_KEY, "presets", activeHostUrl] as const,
+		enabled: !!activeHostUrl,
+		queryFn: () => {
+			if (!activeHostUrl) return [] as AgentPreset[];
+			return getHostServiceClientByUrl(
+				activeHostUrl,
+			).settings.agentConfigs.listPresets.query();
+		},
+	});
+
+	const invalidate = () =>
+		queryClient.invalidateQueries({ queryKey: [...QUERY_KEY, activeHostUrl] });
+
+	const addMutation = useMutation({
+		mutationFn: (presetId: string) => {
+			if (!activeHostUrl) throw new Error("Host service is not available");
+			return getHostServiceClientByUrl(
+				activeHostUrl,
+			).settings.agentConfigs.add.mutate({
+				presetId,
+			});
+		},
+		onSuccess: () => invalidate(),
+		onError: (err) =>
+			toast.error(err instanceof Error ? err.message : "Failed to add agent"),
+	});
+
+	const reorderMutation = useMutation({
+		mutationFn: (ids: string[]) => {
+			if (!activeHostUrl) throw new Error("Host service is not available");
+			return getHostServiceClientByUrl(
+				activeHostUrl,
+			).settings.agentConfigs.reorder.mutate({ ids });
+		},
+		onSuccess: () => invalidate(),
+		onError: (err) =>
+			toast.error(err instanceof Error ? err.message : "Failed to reorder"),
+	});
+
+	const resetMutation = useMutation({
+		mutationFn: () => {
+			if (!activeHostUrl) throw new Error("Host service is not available");
+			return getHostServiceClientByUrl(
+				activeHostUrl,
+			).settings.agentConfigs.resetToDefaults.mutate();
+		},
+		onSuccess: () => invalidate(),
+		onError: (err) =>
+			toast.error(err instanceof Error ? err.message : "Failed to reset"),
+	});
+
+	const configs = configsQuery.data ?? [];
+	const presets = presetsQuery.data ?? [];
+
+	const moveAgent = (index: number, direction: -1 | 1) => {
+		const target = index + direction;
+		if (target < 0 || target >= configs.length) return;
+		const ids = configs.map((row) => row.id);
+		[ids[index], ids[target]] = [ids[target], ids[index]];
+		reorderMutation.mutate(ids);
+	};
+
+	return (
+		<div className="p-6 max-w-5xl w-full">
+			<div className="mb-8 flex items-start justify-between gap-4">
+				<div>
+					<h2 className="text-xl font-semibold">Agents</h2>
+					<p className="text-sm text-muted-foreground mt-1">
+						Configure terminal agents available on this host. Sent prompts are
+						appended to the launch argv (or piped via stdin).
+					</p>
+				</div>
+				<div className="flex items-center gap-2 shrink-0">
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild>
+							<Button variant="outline" size="sm">
+								<Plus className="size-4" /> Add agent
+							</Button>
+						</DropdownMenuTrigger>
+						<DropdownMenuContent align="end">
+							{presets.map((preset) => (
+								<DropdownMenuItem
+									key={preset.presetId}
+									onSelect={() => addMutation.mutate(preset.presetId)}
+								>
+									{preset.label}
+								</DropdownMenuItem>
+							))}
+						</DropdownMenuContent>
+					</DropdownMenu>
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={() => resetMutation.mutate()}
+						disabled={resetMutation.isPending}
+					>
+						<RotateCcw className="size-4" /> Reset to defaults
+					</Button>
+				</div>
+			</div>
+
+			{configsQuery.isLoading ? (
+				<p className="text-sm text-muted-foreground">
+					Loading agent settings...
+				</p>
+			) : configs.length === 0 ? (
+				<p className="text-sm text-muted-foreground">
+					No agents configured. Add one from the dropdown above.
+				</p>
+			) : (
+				<div className="space-y-3">
+					{configs.map((config, index) => (
+						<V2AgentCard
+							key={config.id}
+							config={config}
+							canMoveUp={index > 0}
+							canMoveDown={index < configs.length - 1}
+							onMoveUp={() => moveAgent(index, -1)}
+							onMoveDown={() => moveAgent(index, 1)}
+							onChanged={() => invalidate()}
+						/>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}
+
+interface V2AgentCardProps {
+	config: HostAgentConfigDto;
+	canMoveUp: boolean;
+	canMoveDown: boolean;
+	onMoveUp: () => void;
+	onMoveDown: () => void;
+	onChanged: () => void;
+}
+
+function V2AgentCard({
+	config,
+	canMoveUp,
+	canMoveDown,
+	onMoveUp,
+	onMoveDown,
+	onChanged,
+}: V2AgentCardProps) {
+	const { activeHostUrl } = useLocalHostService();
+	const [isOpen, setIsOpen] = useState(false);
+	const [label, setLabel] = useState(config.label);
+	const [commandText, setCommandText] = useState(
+		joinCommandArgs(config.command, config.args),
+	);
+	const [promptArgsText, setPromptArgsText] = useState(
+		joinArgs(config.promptArgs),
+	);
+	const [promptTransport, setPromptTransport] = useState<PromptTransport>(
+		config.promptTransport,
+	);
+
+	useEffect(() => {
+		setLabel(config.label);
+		setCommandText(joinCommandArgs(config.command, config.args));
+		setPromptArgsText(joinArgs(config.promptArgs));
+		setPromptTransport(config.promptTransport);
+	}, [
+		config.label,
+		config.command,
+		config.args,
+		config.promptArgs,
+		config.promptTransport,
+	]);
+
+	const updateMutation = useMutation({
+		mutationFn: (
+			patch: Parameters<
+				ReturnType<
+					typeof getHostServiceClientByUrl
+				>["settings"]["agentConfigs"]["update"]["mutate"]
+			>[0]["patch"],
+		) => {
+			if (!activeHostUrl) throw new Error("Host service is not available");
+			return getHostServiceClientByUrl(
+				activeHostUrl,
+			).settings.agentConfigs.update.mutate({
+				id: config.id,
+				patch,
+			});
+		},
+		onSuccess: () => onChanged(),
+		onError: (err) =>
+			toast.error(err instanceof Error ? err.message : "Failed to save"),
+	});
+
+	const removeMutation = useMutation({
+		mutationFn: () => {
+			if (!activeHostUrl) throw new Error("Host service is not available");
+			return getHostServiceClientByUrl(
+				activeHostUrl,
+			).settings.agentConfigs.remove.mutate({
+				id: config.id,
+			});
+		},
+		onSuccess: () => onChanged(),
+		onError: (err) =>
+			toast.error(err instanceof Error ? err.message : "Failed to remove"),
+	});
+
+	const handleLabelBlur = () => {
+		if (label !== config.label && label.trim().length > 0) {
+			updateMutation.mutate({ label });
+		}
+	};
+
+	const handleCommandBlur = () => {
+		const { command, args } = parseCommandString(commandText);
+		if (command.length === 0) {
+			toast.error("Command cannot be empty");
+			setCommandText(joinCommandArgs(config.command, config.args));
+			return;
+		}
+		const changed =
+			command !== config.command ||
+			args.length !== config.args.length ||
+			args.some((arg, i) => arg !== config.args[i]);
+		if (changed) updateMutation.mutate({ command, args });
+	};
+
+	const handlePromptArgsBlur = () => {
+		const args = parseArgs(promptArgsText);
+		const changed =
+			args.length !== config.promptArgs.length ||
+			args.some((arg, i) => arg !== config.promptArgs[i]);
+		if (changed) updateMutation.mutate({ promptArgs: args });
+	};
+
+	const handleTransportChange = (next: PromptTransport) => {
+		if (next === promptTransport) return;
+		setPromptTransport(next);
+		updateMutation.mutate({ promptTransport: next });
+	};
+
+	return (
+		<Card>
+			<Collapsible open={isOpen} onOpenChange={setIsOpen}>
+				<div className="flex items-center justify-between gap-3 px-4 py-3">
+					<CollapsibleTrigger asChild>
+						<button
+							type="button"
+							className="flex-1 flex items-center gap-3 text-left"
+						>
+							<span className="font-medium">{config.label}</span>
+							<span className="text-xs text-muted-foreground font-mono truncate">
+								{commandText}
+							</span>
+						</button>
+					</CollapsibleTrigger>
+					<div className="flex items-center gap-1 shrink-0">
+						<Button
+							variant="ghost"
+							size="icon"
+							disabled={!canMoveUp}
+							onClick={onMoveUp}
+						>
+							<ChevronUp className="size-4" />
+						</Button>
+						<Button
+							variant="ghost"
+							size="icon"
+							disabled={!canMoveDown}
+							onClick={onMoveDown}
+						>
+							<ChevronDown className="size-4" />
+						</Button>
+						<Button
+							variant="ghost"
+							size="icon"
+							onClick={() => removeMutation.mutate()}
+							disabled={removeMutation.isPending}
+						>
+							<Trash2 className="size-4" />
+						</Button>
+					</div>
+				</div>
+				<CollapsibleContent>
+					<CardContent className="grid gap-4 pt-2">
+						<div className="grid gap-1.5">
+							<Label htmlFor={`label-${config.id}`}>Label</Label>
+							<Input
+								id={`label-${config.id}`}
+								value={label}
+								onChange={(e) => setLabel(e.target.value)}
+								onBlur={handleLabelBlur}
+							/>
+						</div>
+						<div className="grid gap-1.5">
+							<Label htmlFor={`command-${config.id}`}>Command</Label>
+							<Input
+								id={`command-${config.id}`}
+								className="font-mono"
+								value={commandText}
+								onChange={(e) => setCommandText(e.target.value)}
+								onBlur={handleCommandBlur}
+								placeholder="claude --permission-mode acceptEdits"
+							/>
+							<p className="text-xs text-muted-foreground">
+								Argv used for promptless launches. The prompt is appended after
+								the prompt-only args.
+							</p>
+						</div>
+						<div className="grid gap-1.5">
+							<Label htmlFor={`prompt-args-${config.id}`}>
+								Prompt-only args
+							</Label>
+							<Input
+								id={`prompt-args-${config.id}`}
+								className="font-mono"
+								value={promptArgsText}
+								onChange={(e) => setPromptArgsText(e.target.value)}
+								onBlur={handlePromptArgsBlur}
+								placeholder="(empty)"
+							/>
+							<p className="text-xs text-muted-foreground">
+								Inserted only when launching with a prompt — e.g.{" "}
+								<code>--</code> for codex, <code>--prompt</code> for opencode,{" "}
+								<code>-i</code> for copilot.
+							</p>
+						</div>
+						<div className="grid gap-1.5">
+							<Label>Prompt transport</Label>
+							<div className="flex gap-2">
+								<Button
+									type="button"
+									size="sm"
+									variant={promptTransport === "argv" ? "default" : "outline"}
+									onClick={() => handleTransportChange("argv")}
+								>
+									argv
+								</Button>
+								<Button
+									type="button"
+									size="sm"
+									variant={promptTransport === "stdin" ? "default" : "outline"}
+									onClick={() => handleTransportChange("stdin")}
+								>
+									stdin
+								</Button>
+							</div>
+							<p className="text-xs text-muted-foreground">
+								<strong>argv</strong>: append the prompt as the last argv
+								element. <strong>stdin</strong>: pipe the prompt to the spawned
+								process's stdin.
+							</p>
+						</div>
+					</CardContent>
+				</CollapsibleContent>
+			</Collapsible>
+		</Card>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/V2AgentsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/V2AgentsSettings.tsx
@@ -1,35 +1,37 @@
+import {
+	closestCenter,
+	DndContext,
+	type DragEndEvent,
+	KeyboardSensor,
+	MouseSensor,
+	TouchSensor,
+	useSensor,
+	useSensors,
+} from "@dnd-kit/core";
+import {
+	arrayMove,
+	SortableContext,
+	sortableKeyboardCoordinates,
+	verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
 import type {
 	AgentPreset,
 	HostAgentConfigDto,
-	PromptTransport,
 } from "@superset/host-service/settings";
 import { Button } from "@superset/ui/button";
-import { Card, CardContent } from "@superset/ui/card";
-import {
-	Collapsible,
-	CollapsibleContent,
-	CollapsibleTrigger,
-} from "@superset/ui/collapsible";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
-import { Input } from "@superset/ui/input";
-import { Label } from "@superset/ui/label";
 import { toast } from "@superset/ui/sonner";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ChevronDown, ChevronUp, Plus, RotateCcw, Trash2 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { Plus, RotateCcw } from "lucide-react";
+import { useMemo } from "react";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
-import {
-	joinArgs,
-	joinCommandArgs,
-	parseArgs,
-	parseCommandString,
-} from "./utils/argv";
+import { V2AgentCard } from "./components/V2AgentCard";
 
 const QUERY_KEY = ["host-agent-configs"] as const;
 
@@ -67,9 +69,7 @@ export function V2AgentsSettings() {
 			if (!activeHostUrl) throw new Error("Host service is not available");
 			return getHostServiceClientByUrl(
 				activeHostUrl,
-			).settings.agentConfigs.add.mutate({
-				presetId,
-			});
+			).settings.agentConfigs.add.mutate({ presetId });
 		},
 		onSuccess: () => invalidate(),
 		onError: (err) =>
@@ -83,9 +83,33 @@ export function V2AgentsSettings() {
 				activeHostUrl,
 			).settings.agentConfigs.reorder.mutate({ ids });
 		},
-		onSuccess: () => invalidate(),
-		onError: (err) =>
-			toast.error(err instanceof Error ? err.message : "Failed to reorder"),
+		onMutate: async (ids) => {
+			await queryClient.cancelQueries({
+				queryKey: [...QUERY_KEY, activeHostUrl],
+			});
+			const previous = queryClient.getQueryData<HostAgentConfigDto[]>([
+				...QUERY_KEY,
+				activeHostUrl,
+			]);
+			if (previous) {
+				const byId = new Map(previous.map((row) => [row.id, row]));
+				const next = ids
+					.map((id, index) => {
+						const row = byId.get(id);
+						return row ? { ...row, order: index } : null;
+					})
+					.filter((row): row is HostAgentConfigDto => row !== null);
+				queryClient.setQueryData([...QUERY_KEY, activeHostUrl], next);
+			}
+			return { previous };
+		},
+		onError: (err, _ids, ctx) => {
+			if (ctx?.previous) {
+				queryClient.setQueryData([...QUERY_KEY, activeHostUrl], ctx.previous);
+			}
+			toast.error(err instanceof Error ? err.message : "Failed to reorder");
+		},
+		onSettled: () => invalidate(),
 	});
 
 	const resetMutation = useMutation({
@@ -100,15 +124,32 @@ export function V2AgentsSettings() {
 			toast.error(err instanceof Error ? err.message : "Failed to reset"),
 	});
 
+	const sensors = useSensors(
+		useSensor(MouseSensor, { activationConstraint: { distance: 4 } }),
+		useSensor(TouchSensor, {
+			activationConstraint: { delay: 150, tolerance: 5 },
+		}),
+		useSensor(KeyboardSensor, {
+			coordinateGetter: sortableKeyboardCoordinates,
+		}),
+	);
+
 	const configs = configsQuery.data ?? [];
 	const presets = presetsQuery.data ?? [];
+	const sortableIds = useMemo(() => configs.map((row) => row.id), [configs]);
+	const descriptionByPresetId = useMemo(
+		() =>
+			new Map(presets.map((preset) => [preset.presetId, preset.description])),
+		[presets],
+	);
 
-	const moveAgent = (index: number, direction: -1 | 1) => {
-		const target = index + direction;
-		if (target < 0 || target >= configs.length) return;
-		const ids = configs.map((row) => row.id);
-		[ids[index], ids[target]] = [ids[target], ids[index]];
-		reorderMutation.mutate(ids);
+	const handleDragEnd = (event: DragEndEvent) => {
+		const { active, over } = event;
+		if (!over || active.id === over.id) return;
+		const oldIndex = sortableIds.indexOf(String(active.id));
+		const newIndex = sortableIds.indexOf(String(over.id));
+		if (oldIndex < 0 || newIndex < 0) return;
+		reorderMutation.mutate(arrayMove(sortableIds, oldIndex, newIndex));
 	};
 
 	return (
@@ -117,14 +158,21 @@ export function V2AgentsSettings() {
 				<div>
 					<h2 className="text-xl font-semibold">Agents</h2>
 					<p className="text-sm text-muted-foreground mt-1">
-						Configure terminal agents available on this host. Sent prompts are
-						appended to the launch argv (or piped via stdin).
+						Configure terminal agents available on this host. Drag to reorder.
 					</p>
 				</div>
 				<div className="flex items-center gap-2 shrink-0">
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={() => resetMutation.mutate()}
+						disabled={resetMutation.isPending}
+					>
+						<RotateCcw className="size-4" /> Reset to defaults
+					</Button>
 					<DropdownMenu>
 						<DropdownMenuTrigger asChild>
-							<Button variant="outline" size="sm">
+							<Button size="sm">
 								<Plus className="size-4" /> Add agent
 							</Button>
 						</DropdownMenuTrigger>
@@ -139,14 +187,6 @@ export function V2AgentsSettings() {
 							))}
 						</DropdownMenuContent>
 					</DropdownMenu>
-					<Button
-						variant="ghost"
-						size="sm"
-						onClick={() => resetMutation.mutate()}
-						disabled={resetMutation.isPending}
-					>
-						<RotateCcw className="size-4" /> Reset to defaults
-					</Button>
 				</div>
 			</div>
 
@@ -156,254 +196,34 @@ export function V2AgentsSettings() {
 				</p>
 			) : configs.length === 0 ? (
 				<p className="text-sm text-muted-foreground">
-					No agents configured. Add one from the dropdown above.
+					No agents configured. Add one from the menu above.
 				</p>
 			) : (
-				<div className="space-y-3">
-					{configs.map((config, index) => (
-						<V2AgentCard
-							key={config.id}
-							config={config}
-							canMoveUp={index > 0}
-							canMoveDown={index < configs.length - 1}
-							onMoveUp={() => moveAgent(index, -1)}
-							onMoveDown={() => moveAgent(index, 1)}
-							onChanged={() => invalidate()}
-						/>
-					))}
-				</div>
+				<DndContext
+					sensors={sensors}
+					collisionDetection={closestCenter}
+					onDragEnd={handleDragEnd}
+				>
+					<SortableContext
+						items={sortableIds}
+						strategy={verticalListSortingStrategy}
+					>
+						<div className="space-y-3">
+							{configs.map((config) => (
+								<V2AgentCard
+									key={config.id}
+									config={config}
+									description={
+										descriptionByPresetId.get(config.presetId) ??
+										"Terminal agent launch configuration"
+									}
+									onChanged={invalidate}
+								/>
+							))}
+						</div>
+					</SortableContext>
+				</DndContext>
 			)}
 		</div>
-	);
-}
-
-interface V2AgentCardProps {
-	config: HostAgentConfigDto;
-	canMoveUp: boolean;
-	canMoveDown: boolean;
-	onMoveUp: () => void;
-	onMoveDown: () => void;
-	onChanged: () => void;
-}
-
-function V2AgentCard({
-	config,
-	canMoveUp,
-	canMoveDown,
-	onMoveUp,
-	onMoveDown,
-	onChanged,
-}: V2AgentCardProps) {
-	const { activeHostUrl } = useLocalHostService();
-	const [isOpen, setIsOpen] = useState(false);
-	const [label, setLabel] = useState(config.label);
-	const [commandText, setCommandText] = useState(
-		joinCommandArgs(config.command, config.args),
-	);
-	const [promptArgsText, setPromptArgsText] = useState(
-		joinArgs(config.promptArgs),
-	);
-	const [promptTransport, setPromptTransport] = useState<PromptTransport>(
-		config.promptTransport,
-	);
-
-	useEffect(() => {
-		setLabel(config.label);
-		setCommandText(joinCommandArgs(config.command, config.args));
-		setPromptArgsText(joinArgs(config.promptArgs));
-		setPromptTransport(config.promptTransport);
-	}, [
-		config.label,
-		config.command,
-		config.args,
-		config.promptArgs,
-		config.promptTransport,
-	]);
-
-	const updateMutation = useMutation({
-		mutationFn: (
-			patch: Parameters<
-				ReturnType<
-					typeof getHostServiceClientByUrl
-				>["settings"]["agentConfigs"]["update"]["mutate"]
-			>[0]["patch"],
-		) => {
-			if (!activeHostUrl) throw new Error("Host service is not available");
-			return getHostServiceClientByUrl(
-				activeHostUrl,
-			).settings.agentConfigs.update.mutate({
-				id: config.id,
-				patch,
-			});
-		},
-		onSuccess: () => onChanged(),
-		onError: (err) =>
-			toast.error(err instanceof Error ? err.message : "Failed to save"),
-	});
-
-	const removeMutation = useMutation({
-		mutationFn: () => {
-			if (!activeHostUrl) throw new Error("Host service is not available");
-			return getHostServiceClientByUrl(
-				activeHostUrl,
-			).settings.agentConfigs.remove.mutate({
-				id: config.id,
-			});
-		},
-		onSuccess: () => onChanged(),
-		onError: (err) =>
-			toast.error(err instanceof Error ? err.message : "Failed to remove"),
-	});
-
-	const handleLabelBlur = () => {
-		if (label !== config.label && label.trim().length > 0) {
-			updateMutation.mutate({ label });
-		}
-	};
-
-	const handleCommandBlur = () => {
-		const { command, args } = parseCommandString(commandText);
-		if (command.length === 0) {
-			toast.error("Command cannot be empty");
-			setCommandText(joinCommandArgs(config.command, config.args));
-			return;
-		}
-		const changed =
-			command !== config.command ||
-			args.length !== config.args.length ||
-			args.some((arg, i) => arg !== config.args[i]);
-		if (changed) updateMutation.mutate({ command, args });
-	};
-
-	const handlePromptArgsBlur = () => {
-		const args = parseArgs(promptArgsText);
-		const changed =
-			args.length !== config.promptArgs.length ||
-			args.some((arg, i) => arg !== config.promptArgs[i]);
-		if (changed) updateMutation.mutate({ promptArgs: args });
-	};
-
-	const handleTransportChange = (next: PromptTransport) => {
-		if (next === promptTransport) return;
-		setPromptTransport(next);
-		updateMutation.mutate({ promptTransport: next });
-	};
-
-	return (
-		<Card>
-			<Collapsible open={isOpen} onOpenChange={setIsOpen}>
-				<div className="flex items-center justify-between gap-3 px-4 py-3">
-					<CollapsibleTrigger asChild>
-						<button
-							type="button"
-							className="flex-1 flex items-center gap-3 text-left"
-						>
-							<span className="font-medium">{config.label}</span>
-							<span className="text-xs text-muted-foreground font-mono truncate">
-								{commandText}
-							</span>
-						</button>
-					</CollapsibleTrigger>
-					<div className="flex items-center gap-1 shrink-0">
-						<Button
-							variant="ghost"
-							size="icon"
-							disabled={!canMoveUp}
-							onClick={onMoveUp}
-						>
-							<ChevronUp className="size-4" />
-						</Button>
-						<Button
-							variant="ghost"
-							size="icon"
-							disabled={!canMoveDown}
-							onClick={onMoveDown}
-						>
-							<ChevronDown className="size-4" />
-						</Button>
-						<Button
-							variant="ghost"
-							size="icon"
-							onClick={() => removeMutation.mutate()}
-							disabled={removeMutation.isPending}
-						>
-							<Trash2 className="size-4" />
-						</Button>
-					</div>
-				</div>
-				<CollapsibleContent>
-					<CardContent className="grid gap-4 pt-2">
-						<div className="grid gap-1.5">
-							<Label htmlFor={`label-${config.id}`}>Label</Label>
-							<Input
-								id={`label-${config.id}`}
-								value={label}
-								onChange={(e) => setLabel(e.target.value)}
-								onBlur={handleLabelBlur}
-							/>
-						</div>
-						<div className="grid gap-1.5">
-							<Label htmlFor={`command-${config.id}`}>Command</Label>
-							<Input
-								id={`command-${config.id}`}
-								className="font-mono"
-								value={commandText}
-								onChange={(e) => setCommandText(e.target.value)}
-								onBlur={handleCommandBlur}
-								placeholder="claude --permission-mode acceptEdits"
-							/>
-							<p className="text-xs text-muted-foreground">
-								Argv used for promptless launches. The prompt is appended after
-								the prompt-only args.
-							</p>
-						</div>
-						<div className="grid gap-1.5">
-							<Label htmlFor={`prompt-args-${config.id}`}>
-								Prompt-only args
-							</Label>
-							<Input
-								id={`prompt-args-${config.id}`}
-								className="font-mono"
-								value={promptArgsText}
-								onChange={(e) => setPromptArgsText(e.target.value)}
-								onBlur={handlePromptArgsBlur}
-								placeholder="(empty)"
-							/>
-							<p className="text-xs text-muted-foreground">
-								Inserted only when launching with a prompt — e.g.{" "}
-								<code>--</code> for codex, <code>--prompt</code> for opencode,{" "}
-								<code>-i</code> for copilot.
-							</p>
-						</div>
-						<div className="grid gap-1.5">
-							<Label>Prompt transport</Label>
-							<div className="flex gap-2">
-								<Button
-									type="button"
-									size="sm"
-									variant={promptTransport === "argv" ? "default" : "outline"}
-									onClick={() => handleTransportChange("argv")}
-								>
-									argv
-								</Button>
-								<Button
-									type="button"
-									size="sm"
-									variant={promptTransport === "stdin" ? "default" : "outline"}
-									onClick={() => handleTransportChange("stdin")}
-								>
-									stdin
-								</Button>
-							</div>
-							<p className="text-xs text-muted-foreground">
-								<strong>argv</strong>: append the prompt as the last argv
-								element. <strong>stdin</strong>: pipe the prompt to the spawned
-								process's stdin.
-							</p>
-						</div>
-					</CardContent>
-				</CollapsibleContent>
-			</Collapsible>
-		</Card>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/V2AgentsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/V2AgentsSettings.tsx
@@ -212,6 +212,22 @@ export function V2AgentsSettings() {
 				<p className="text-sm text-muted-foreground">
 					Loading agent settings...
 				</p>
+			) : configsQuery.isError ? (
+				<div className="space-y-2">
+					<p className="text-sm text-destructive">
+						Couldn't load agent settings:{" "}
+						{configsQuery.error instanceof Error
+							? configsQuery.error.message
+							: "host service unavailable"}
+					</p>
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={() => configsQuery.refetch()}
+					>
+						Retry
+					</Button>
+				</div>
 			) : configs.length === 0 ? (
 				<p className="text-sm text-muted-foreground">
 					No agents configured. Add one from the menu above.

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/components/V2AgentCard/V2AgentCard.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/components/V2AgentCard/V2AgentCard.tsx
@@ -143,8 +143,12 @@ export function V2AgentCard({
 
 	const handleTransportChange = (next: PromptTransport) => {
 		if (next === promptTransport) return;
+		const prev = promptTransport;
 		setPromptTransport(next);
-		updateMutation.mutate({ promptTransport: next });
+		updateMutation.mutate(
+			{ promptTransport: next },
+			{ onError: () => setPromptTransport(prev) },
+		);
 	};
 
 	return (

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/components/V2AgentCard/V2AgentCard.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/components/V2AgentCard/V2AgentCard.tsx
@@ -1,0 +1,302 @@
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import type {
+	HostAgentConfigDto,
+	PromptTransport,
+} from "@superset/host-service/settings";
+import { Button } from "@superset/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardTitle,
+} from "@superset/ui/card";
+import { Collapsible, CollapsibleContent } from "@superset/ui/collapsible";
+import { Input } from "@superset/ui/input";
+import { Label } from "@superset/ui/label";
+import { toast } from "@superset/ui/sonner";
+import { cn } from "@superset/ui/utils";
+import { useMutation } from "@tanstack/react-query";
+import { ChevronDownIcon, Trash2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { LuGripVertical } from "react-icons/lu";
+import {
+	getPresetIcon,
+	useIsDarkTheme,
+} from "renderer/assets/app-icons/preset-icons";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import {
+	joinArgs,
+	joinCommandArgs,
+	parseArgs,
+	parseCommandString,
+} from "../../utils/argv";
+
+interface V2AgentCardProps {
+	config: HostAgentConfigDto;
+	description: string;
+	onChanged: () => void;
+}
+
+export function V2AgentCard({
+	config,
+	description,
+	onChanged,
+}: V2AgentCardProps) {
+	const { activeHostUrl } = useLocalHostService();
+	const isDark = useIsDarkTheme();
+	const icon = getPresetIcon(config.presetId, isDark);
+
+	const {
+		setNodeRef,
+		setActivatorNodeRef,
+		attributes,
+		listeners,
+		isDragging,
+		transform,
+		transition,
+	} = useSortable({ id: config.id });
+
+	const [isOpen, setIsOpen] = useState(false);
+	const [label, setLabel] = useState(config.label);
+	const [commandText, setCommandText] = useState(
+		joinCommandArgs(config.command, config.args),
+	);
+	const [promptArgsText, setPromptArgsText] = useState(
+		joinArgs(config.promptArgs),
+	);
+	const [promptTransport, setPromptTransport] = useState<PromptTransport>(
+		config.promptTransport,
+	);
+
+	useEffect(() => {
+		setLabel(config.label);
+		setCommandText(joinCommandArgs(config.command, config.args));
+		setPromptArgsText(joinArgs(config.promptArgs));
+		setPromptTransport(config.promptTransport);
+	}, [
+		config.label,
+		config.command,
+		config.args,
+		config.promptArgs,
+		config.promptTransport,
+	]);
+
+	const updateMutation = useMutation({
+		mutationFn: (
+			patch: Parameters<
+				ReturnType<
+					typeof getHostServiceClientByUrl
+				>["settings"]["agentConfigs"]["update"]["mutate"]
+			>[0]["patch"],
+		) => {
+			if (!activeHostUrl) throw new Error("Host service is not available");
+			return getHostServiceClientByUrl(
+				activeHostUrl,
+			).settings.agentConfigs.update.mutate({ id: config.id, patch });
+		},
+		onSuccess: () => onChanged(),
+		onError: (err) =>
+			toast.error(err instanceof Error ? err.message : "Failed to save"),
+	});
+
+	const removeMutation = useMutation({
+		mutationFn: () => {
+			if (!activeHostUrl) throw new Error("Host service is not available");
+			return getHostServiceClientByUrl(
+				activeHostUrl,
+			).settings.agentConfigs.remove.mutate({ id: config.id });
+		},
+		onSuccess: () => onChanged(),
+		onError: (err) =>
+			toast.error(err instanceof Error ? err.message : "Failed to remove"),
+	});
+
+	const handleLabelBlur = () => {
+		if (label !== config.label && label.trim().length > 0) {
+			updateMutation.mutate({ label });
+		}
+	};
+
+	const handleCommandBlur = () => {
+		const { command, args } = parseCommandString(commandText);
+		if (command.length === 0) {
+			toast.error("Command cannot be empty");
+			setCommandText(joinCommandArgs(config.command, config.args));
+			return;
+		}
+		const changed =
+			command !== config.command ||
+			args.length !== config.args.length ||
+			args.some((arg, i) => arg !== config.args[i]);
+		if (changed) updateMutation.mutate({ command, args });
+	};
+
+	const handlePromptArgsBlur = () => {
+		const args = parseArgs(promptArgsText);
+		const changed =
+			args.length !== config.promptArgs.length ||
+			args.some((arg, i) => arg !== config.promptArgs[i]);
+		if (changed) updateMutation.mutate({ promptArgs: args });
+	};
+
+	const handleTransportChange = (next: PromptTransport) => {
+		if (next === promptTransport) return;
+		setPromptTransport(next);
+		updateMutation.mutate({ promptTransport: next });
+	};
+
+	return (
+		<div
+			ref={setNodeRef}
+			style={{
+				transform: CSS.Translate.toString(transform),
+				transition,
+				opacity: isDragging ? 0.5 : undefined,
+			}}
+		>
+			<Card className="p-0">
+				<Collapsible open={isOpen} onOpenChange={setIsOpen}>
+					{/* biome-ignore lint/a11y/useSemanticElements: div needed to avoid invalid nested <button> elements */}
+					<div
+						role="button"
+						tabIndex={0}
+						aria-expanded={isOpen}
+						className="flex items-center gap-3 p-4 cursor-pointer transition-colors hover:bg-muted/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+						onClick={() => setIsOpen((open) => !open)}
+						onKeyDown={(event) => {
+							if (event.target !== event.currentTarget) return;
+							if (event.key === "Enter" || event.key === " ") {
+								event.preventDefault();
+								setIsOpen((open) => !open);
+							}
+						}}
+					>
+						<button
+							type="button"
+							ref={setActivatorNodeRef}
+							{...attributes}
+							{...listeners}
+							onClick={(event) => event.stopPropagation()}
+							className="shrink-0 flex items-center justify-center text-muted-foreground hover:text-foreground cursor-grab active:cursor-grabbing -ml-1 bg-transparent border-0 p-0"
+							aria-label="Drag to reorder"
+						>
+							<LuGripVertical className="size-4" />
+						</button>
+						{icon ? (
+							<img
+								src={icon}
+								alt=""
+								className="size-8 object-contain shrink-0"
+							/>
+						) : (
+							<div className="size-8 rounded-lg bg-muted shrink-0" />
+						)}
+						<div className="min-w-0 flex-1">
+							<CardTitle className="truncate">{config.label}</CardTitle>
+							<CardDescription className="mt-1 truncate">
+								{description}
+							</CardDescription>
+						</div>
+						<div className="flex shrink-0 items-center gap-1">
+							<Button
+								variant="ghost"
+								size="icon"
+								onClick={(event) => {
+									event.stopPropagation();
+									removeMutation.mutate();
+								}}
+								disabled={removeMutation.isPending}
+								aria-label={`Remove ${config.label}`}
+							>
+								<Trash2 className="size-4" />
+							</Button>
+							<ChevronDownIcon
+								aria-hidden="true"
+								className={cn(
+									"size-4 text-muted-foreground transition-transform duration-200",
+									isOpen && "rotate-180",
+								)}
+							/>
+						</div>
+					</div>
+					<CollapsibleContent>
+						<CardContent className="grid gap-4 pt-0 pb-4">
+							<div className="grid gap-1.5">
+								<Label htmlFor={`label-${config.id}`}>Label</Label>
+								<Input
+									id={`label-${config.id}`}
+									value={label}
+									onChange={(e) => setLabel(e.target.value)}
+									onBlur={handleLabelBlur}
+								/>
+							</div>
+							<div className="grid gap-1.5">
+								<Label htmlFor={`command-${config.id}`}>Command</Label>
+								<Input
+									id={`command-${config.id}`}
+									className="font-mono"
+									value={commandText}
+									onChange={(e) => setCommandText(e.target.value)}
+									onBlur={handleCommandBlur}
+									placeholder="claude --permission-mode acceptEdits"
+								/>
+								<p className="text-xs text-muted-foreground">
+									Argv used for promptless launches. The prompt is appended
+									after the prompt-only args.
+								</p>
+							</div>
+							<div className="grid gap-1.5">
+								<Label htmlFor={`prompt-args-${config.id}`}>
+									Prompt-only args
+								</Label>
+								<Input
+									id={`prompt-args-${config.id}`}
+									className="font-mono"
+									value={promptArgsText}
+									onChange={(e) => setPromptArgsText(e.target.value)}
+									onBlur={handlePromptArgsBlur}
+									placeholder="(empty)"
+								/>
+								<p className="text-xs text-muted-foreground">
+									Inserted only when launching with a prompt — e.g.{" "}
+									<code>--</code> for codex, <code>--prompt</code> for opencode,{" "}
+									<code>-i</code> for copilot.
+								</p>
+							</div>
+							<div className="grid gap-1.5">
+								<Label>Prompt transport</Label>
+								<div className="flex gap-2">
+									<Button
+										type="button"
+										size="sm"
+										variant={promptTransport === "argv" ? "default" : "outline"}
+										onClick={() => handleTransportChange("argv")}
+									>
+										argv
+									</Button>
+									<Button
+										type="button"
+										size="sm"
+										variant={
+											promptTransport === "stdin" ? "default" : "outline"
+										}
+										onClick={() => handleTransportChange("stdin")}
+									>
+										stdin
+									</Button>
+								</div>
+								<p className="text-xs text-muted-foreground">
+									<strong>argv</strong>: append the prompt as the last argv
+									element. <strong>stdin</strong>: pipe the prompt to the
+									spawned process's stdin.
+								</p>
+							</div>
+						</CardContent>
+					</CollapsibleContent>
+				</Collapsible>
+			</Card>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/components/V2AgentCard/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/components/V2AgentCard/index.ts
@@ -1,0 +1,1 @@
+export { V2AgentCard } from "./V2AgentCard";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/index.ts
@@ -1,0 +1,1 @@
+export { V2AgentsSettings } from "./V2AgentsSettings";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/utils/argv.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/utils/argv.test.ts
@@ -34,6 +34,23 @@ describe("joinCommandArgs", () => {
 		expect(joinCommandArgs("amp", [])).toBe("amp");
 	});
 
+	it("round-trips a command path with spaces", () => {
+		const command = "/opt/My Agent/bin/runner";
+		const args = ["--flag"];
+		const joined = joinCommandArgs(command, args);
+		const reparsed = parseCommandString(joined);
+		expect(reparsed.command).toBe(command);
+		expect(reparsed.args).toEqual(args);
+	});
+
+	it("round-trips an empty quoted arg", () => {
+		const args = ["--name", "", "--flag"];
+		const joined = joinCommandArgs("amp", args);
+		const reparsed = parseCommandString(joined);
+		expect(reparsed.command).toBe("amp");
+		expect(reparsed.args).toEqual(args);
+	});
+
 	it("round-trips quoted args through parse and join", () => {
 		const args = ["-c", "model_reasoning_effort=high"];
 		const joined = joinCommandArgs("codex", args);

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/utils/argv.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/utils/argv.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "bun:test";
+import {
+	joinArgs,
+	joinCommandArgs,
+	parseArgs,
+	parseCommandString,
+} from "./argv";
+
+describe("parseCommandString", () => {
+	it("splits a simple command and args", () => {
+		expect(parseCommandString("claude --permission-mode acceptEdits")).toEqual({
+			command: "claude",
+			args: ["--permission-mode", "acceptEdits"],
+		});
+	});
+
+	it("preserves quoted segments containing spaces", () => {
+		expect(
+			parseCommandString('codex -c "model_reasoning_effort=high"'),
+		).toEqual({
+			command: "codex",
+			args: ["-c", "model_reasoning_effort=high"],
+		});
+	});
+
+	it("returns empty command for empty input", () => {
+		expect(parseCommandString("")).toEqual({ command: "", args: [] });
+		expect(parseCommandString("   ")).toEqual({ command: "", args: [] });
+	});
+});
+
+describe("joinCommandArgs", () => {
+	it("returns command alone when args are empty", () => {
+		expect(joinCommandArgs("amp", [])).toBe("amp");
+	});
+
+	it("round-trips quoted args through parse and join", () => {
+		const args = ["-c", "model_reasoning_effort=high"];
+		const joined = joinCommandArgs("codex", args);
+		const reparsed = parseCommandString(joined);
+		expect(reparsed.command).toBe("codex");
+		expect(reparsed.args).toEqual(args);
+	});
+
+	it("round-trips claude default through parse and join", () => {
+		const original = "claude --permission-mode acceptEdits";
+		const { command, args } = parseCommandString(original);
+		expect(joinCommandArgs(command, args)).toBe(original);
+	});
+});
+
+describe("parseArgs / joinArgs", () => {
+	it("round-trips an empty list", () => {
+		expect(parseArgs("")).toEqual([]);
+		expect(joinArgs([])).toBe("");
+	});
+
+	it("round-trips simple flag args", () => {
+		expect(parseArgs("--")).toEqual(["--"]);
+		expect(parseArgs("-i")).toEqual(["-i"]);
+		expect(joinArgs(["--prompt"])).toBe("--prompt");
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/utils/argv.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/utils/argv.ts
@@ -2,29 +2,32 @@ import { parse, quote } from "shell-quote";
 
 /**
  * Format a command + argv array as an editable shell-style string.
- * Round-trips through `parseCommandString` for human-authored values.
+ * Round-trips through `parseCommandString` losslessly: the command
+ * and every argv element are quoted (when needed) so paths with
+ * spaces and explicit empty strings survive the round trip.
  */
 export function joinCommandArgs(command: string, args: string[]): string {
-	if (args.length === 0) return command;
-	return `${command} ${quote(args)}`;
+	const tokens = command.length === 0 ? args : [command, ...args];
+	if (tokens.length === 0) return "";
+	return quote(tokens);
 }
 
 /**
  * Parse a shell-style string into `command` (first token) and the rest as
  * `args`. Drops control operators (`|`, `>`, etc.) — this is a launch
- * spec, not a shell invocation.
+ * spec, not a shell invocation. Empty quoted args (`""`) and tokens with
+ * embedded spaces are preserved exactly.
  */
 export function parseCommandString(input: string): {
 	command: string;
 	args: string[];
 } {
-	const tokens = parse(input)
-		.filter((token): token is string => typeof token === "string")
-		.map((token) => token.trim())
-		.filter((token) => token.length > 0);
+	const tokens = parse(input).filter(
+		(token): token is string => typeof token === "string",
+	);
 	if (tokens.length === 0) return { command: "", args: [] };
 	const [command, ...args] = tokens;
-	return { command, args };
+	return { command: command ?? "", args };
 }
 
 /** Format a bare argv array (no leading executable). */
@@ -33,10 +36,12 @@ export function joinArgs(args: string[]): string {
 	return quote(args);
 }
 
-/** Parse a bare argv array (no leading executable). */
+/**
+ * Parse a bare argv array (no leading executable). Preserves empty
+ * quoted args; drops only shell control operators.
+ */
 export function parseArgs(input: string): string[] {
-	return parse(input)
-		.filter((token): token is string => typeof token === "string")
-		.map((token) => token.trim())
-		.filter((token) => token.length > 0);
+	return parse(input).filter(
+		(token): token is string => typeof token === "string",
+	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/utils/argv.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/utils/argv.ts
@@ -1,0 +1,42 @@
+import { parse, quote } from "shell-quote";
+
+/**
+ * Format a command + argv array as an editable shell-style string.
+ * Round-trips through `parseCommandString` for human-authored values.
+ */
+export function joinCommandArgs(command: string, args: string[]): string {
+	if (args.length === 0) return command;
+	return `${command} ${quote(args)}`;
+}
+
+/**
+ * Parse a shell-style string into `command` (first token) and the rest as
+ * `args`. Drops control operators (`|`, `>`, etc.) — this is a launch
+ * spec, not a shell invocation.
+ */
+export function parseCommandString(input: string): {
+	command: string;
+	args: string[];
+} {
+	const tokens = parse(input)
+		.filter((token): token is string => typeof token === "string")
+		.map((token) => token.trim())
+		.filter((token) => token.length > 0);
+	if (tokens.length === 0) return { command: "", args: [] };
+	const [command, ...args] = tokens;
+	return { command, args };
+}
+
+/** Format a bare argv array (no leading executable). */
+export function joinArgs(args: string[]): string {
+	if (args.length === 0) return "";
+	return quote(args);
+}
+
+/** Parse a bare argv array (no leading executable). */
+export function parseArgs(input: string): string[] {
+	return parse(input)
+		.filter((token): token is string => typeof token === "string")
+		.map((token) => token.trim())
+		.filter((token) => token.length > 0);
+}

--- a/packages/host-service/drizzle/0004_mean_blacklash.sql
+++ b/packages/host-service/drizzle/0004_mean_blacklash.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `host_agent_configs` (
+	`id` text PRIMARY KEY NOT NULL,
+	`preset_id` text NOT NULL,
+	`label` text NOT NULL,
+	`command` text NOT NULL,
+	`args_json` text DEFAULT '[]' NOT NULL,
+	`prompt_transport` text NOT NULL,
+	`prompt_args_json` text DEFAULT '[]' NOT NULL,
+	`env_json` text DEFAULT '{}' NOT NULL,
+	`display_order` integer NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `host_agent_configs_display_order_idx` ON `host_agent_configs` (`display_order`);

--- a/packages/host-service/drizzle/meta/0004_snapshot.json
+++ b/packages/host-service/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,591 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "db84ad81-bfc3-48e0-8393-7e8d004c7ffb",
+  "prevId": "d4171f78-422d-48d1-97c4-b803ed17fea9",
+  "tables": {
+    "host_agent_configs": {
+      "name": "host_agent_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_id": {
+          "name": "preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args_json": {
+          "name": "args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "prompt_transport": {
+          "name": "prompt_transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_args_json": {
+          "name": "prompt_args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "env_json": {
+          "name": "env_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "host_agent_configs_display_order_idx": {
+          "name": "host_agent_configs_display_order_idx",
+          "columns": [
+            "display_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_path": {
+          "name": "repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_provider": {
+          "name": "repo_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remote_name": {
+          "name": "remote_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_repo_path_idx": {
+          "name": "projects_repo_path_idx",
+          "columns": [
+            "repo_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pull_requests": {
+      "name": "pull_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_provider": {
+          "name": "repo_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "head_branch": {
+          "name": "head_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "review_decision": {
+          "name": "review_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checks_status": {
+          "name": "checks_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "checks_json": {
+          "name": "checks_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pull_requests_project_id_idx": {
+          "name": "pull_requests_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "pull_requests_repo_branch_idx": {
+          "name": "pull_requests_repo_branch_idx",
+          "columns": [
+            "repo_provider",
+            "repo_owner",
+            "repo_name",
+            "head_branch"
+          ],
+          "isUnique": false
+        },
+        "pull_requests_repo_pr_unique": {
+          "name": "pull_requests_repo_pr_unique",
+          "columns": [
+            "repo_provider",
+            "repo_owner",
+            "repo_name",
+            "pr_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "pull_requests_project_id_projects_id_fk": {
+          "name": "pull_requests_project_id_projects_id_fk",
+          "tableFrom": "pull_requests",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "terminal_sessions": {
+      "name": "terminal_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_workspace_id": {
+          "name": "origin_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_attached_at": {
+          "name": "last_attached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "terminal_sessions_origin_workspace_id_idx": {
+          "name": "terminal_sessions_origin_workspace_id_idx",
+          "columns": [
+            "origin_workspace_id"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_status_idx": {
+          "name": "terminal_sessions_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terminal_sessions_origin_workspace_id_workspaces_id_fk": {
+          "name": "terminal_sessions_origin_workspace_id_workspaces_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "origin_workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_owner": {
+          "name": "upstream_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_repo": {
+          "name": "upstream_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_branch": {
+          "name": "upstream_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_id": {
+          "name": "pull_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_project_id_idx": {
+          "name": "workspaces_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_upstream_ref_idx": {
+          "name": "workspaces_upstream_ref_idx",
+          "columns": [
+            "upstream_owner",
+            "upstream_repo",
+            "upstream_branch"
+          ],
+          "isUnique": false
+        },
+        "workspaces_pull_request_id_idx": {
+          "name": "workspaces_pull_request_id_idx",
+          "columns": [
+            "pull_request_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspaces_project_id_projects_id_fk": {
+          "name": "workspaces_project_id_projects_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_pull_request_id_pull_requests_id_fk": {
+          "name": "workspaces_pull_request_id_pull_requests_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "pull_requests",
+          "columnsFrom": [
+            "pull_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/host-service/drizzle/meta/_journal.json
+++ b/packages/host-service/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1776814372609,
       "tag": "0003_workspace_upstream_ref",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1777572778580,
+      "tag": "0004_mean_blacklash",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -31,6 +31,10 @@
 		"./terminal-env": {
 			"types": "./src/terminal/env.ts",
 			"default": "./src/terminal/env.ts"
+		},
+		"./settings": {
+			"types": "./src/trpc/router/settings/index.ts",
+			"default": "./src/trpc/router/settings/index.ts"
 		}
 	},
 	"scripts": {

--- a/packages/host-service/src/db/schema.ts
+++ b/packages/host-service/src/db/schema.ts
@@ -92,6 +92,30 @@ export const pullRequests = sqliteTable(
 	],
 );
 
+export const hostAgentConfigs = sqliteTable(
+	"host_agent_configs",
+	{
+		id: text().primaryKey(),
+		presetId: text("preset_id").notNull(),
+		label: text().notNull(),
+		command: text().notNull(),
+		argsJson: text("args_json").notNull().default("[]"),
+		promptTransport: text("prompt_transport").notNull(),
+		promptArgsJson: text("prompt_args_json").notNull().default("[]"),
+		envJson: text("env_json").notNull().default("{}"),
+		displayOrder: integer("display_order").notNull(),
+		createdAt: integer("created_at")
+			.notNull()
+			.$defaultFn(() => Date.now()),
+		updatedAt: integer("updated_at")
+			.notNull()
+			.$defaultFn(() => Date.now()),
+	},
+	(table) => [
+		index("host_agent_configs_display_order_idx").on(table.displayOrder),
+	],
+);
+
 export const workspaces = sqliteTable(
 	"workspaces",
 	{

--- a/packages/host-service/src/trpc/router/router.ts
+++ b/packages/host-service/src/trpc/router/router.ts
@@ -11,6 +11,7 @@ import { notificationsRouter } from "./notifications";
 import { portsRouter } from "./ports";
 import { projectRouter } from "./project";
 import { pullRequestsRouter } from "./pull-requests";
+import { settingsRouter } from "./settings";
 import { terminalRouter } from "./terminal";
 import { workspaceRouter } from "./workspace";
 import { workspaceCleanupRouter } from "./workspace-cleanup";
@@ -29,6 +30,7 @@ export const appRouter = router({
 	pullRequests: pullRequestsRouter,
 	project: projectRouter,
 	ports: portsRouter,
+	settings: settingsRouter,
 	terminal: terminalRouter,
 	workspace: workspaceRouter,
 	workspaceCleanup: workspaceCleanupRouter,

--- a/packages/host-service/src/trpc/router/settings/agent-configs.test.ts
+++ b/packages/host-service/src/trpc/router/settings/agent-configs.test.ts
@@ -1,31 +1,20 @@
 import { Database } from "bun:sqlite";
 import { describe, expect, it } from "bun:test";
+import { resolve } from "node:path";
 import { drizzle } from "drizzle-orm/bun-sqlite";
+import { migrate } from "drizzle-orm/bun-sqlite/migrator";
 import * as schema from "../../../db/schema";
 import type { HostServiceContext } from "../../../types";
 import { agentConfigsRouter } from "./agent-configs";
 import { AGENT_PRESETS } from "./agent-presets";
 
+const MIGRATIONS_FOLDER = resolve(import.meta.dir, "../../../../drizzle");
+
 function createTestDb() {
 	const sqlite = new Database(":memory:");
-	sqlite.run(`
-		CREATE TABLE host_agent_configs (
-			id TEXT PRIMARY KEY NOT NULL,
-			preset_id TEXT NOT NULL,
-			label TEXT NOT NULL,
-			command TEXT NOT NULL,
-			args_json TEXT NOT NULL DEFAULT '[]',
-			prompt_transport TEXT NOT NULL,
-			prompt_args_json TEXT NOT NULL DEFAULT '[]',
-			env_json TEXT NOT NULL DEFAULT '{}',
-			display_order INTEGER NOT NULL,
-			created_at INTEGER NOT NULL,
-			updated_at INTEGER NOT NULL
-		);
-		CREATE INDEX host_agent_configs_display_order_idx
-			ON host_agent_configs (display_order);
-	`);
-	return drizzle(sqlite, { schema });
+	const db = drizzle(sqlite, { schema });
+	migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
+	return db;
 }
 
 function createCaller() {

--- a/packages/host-service/src/trpc/router/settings/agent-configs.test.ts
+++ b/packages/host-service/src/trpc/router/settings/agent-configs.test.ts
@@ -174,6 +174,28 @@ describe("agentConfigsRouter", () => {
 				caller.update({ id: "does-not-exist", patch: { label: "x" } }),
 			).rejects.toThrow();
 		});
+
+		it("rejects whitespace-only label and command", async () => {
+			const caller = createCaller();
+			const first = await listFirst(caller);
+			await expect(
+				caller.update({ id: first.id, patch: { label: "   " } }),
+			).rejects.toThrow();
+			await expect(
+				caller.update({ id: first.id, patch: { command: "   " } }),
+			).rejects.toThrow();
+		});
+
+		it("trims label and command on save", async () => {
+			const caller = createCaller();
+			const first = await listFirst(caller);
+			const result = await caller.update({
+				id: first.id,
+				patch: { label: "  Trimmed  ", command: "  trimmed-cmd  " },
+			});
+			expect(result.label).toBe("Trimmed");
+			expect(result.command).toBe("trimmed-cmd");
+		});
 	});
 
 	describe("remove()", () => {
@@ -186,6 +208,14 @@ describe("agentConfigsRouter", () => {
 			expect(result.success).toBe(true);
 			const remaining = await caller.list();
 			expect(remaining.find((row) => row.id === first.id)).toBeUndefined();
+		});
+
+		it("throws NOT_FOUND for an unknown id", async () => {
+			const caller = createCaller();
+			await caller.list();
+			await expect(caller.remove({ id: "does-not-exist" })).rejects.toThrow(
+				/not found/i,
+			);
 		});
 	});
 

--- a/packages/host-service/src/trpc/router/settings/agent-configs.test.ts
+++ b/packages/host-service/src/trpc/router/settings/agent-configs.test.ts
@@ -1,0 +1,252 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, it } from "bun:test";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import * as schema from "../../../db/schema";
+import type { HostServiceContext } from "../../../types";
+import { agentConfigsRouter } from "./agent-configs";
+import { AGENT_PRESETS } from "./agent-presets";
+
+function createTestDb() {
+	const sqlite = new Database(":memory:");
+	sqlite.run(`
+		CREATE TABLE host_agent_configs (
+			id TEXT PRIMARY KEY NOT NULL,
+			preset_id TEXT NOT NULL,
+			label TEXT NOT NULL,
+			command TEXT NOT NULL,
+			args_json TEXT NOT NULL DEFAULT '[]',
+			prompt_transport TEXT NOT NULL,
+			prompt_args_json TEXT NOT NULL DEFAULT '[]',
+			env_json TEXT NOT NULL DEFAULT '{}',
+			display_order INTEGER NOT NULL,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		);
+		CREATE INDEX host_agent_configs_display_order_idx
+			ON host_agent_configs (display_order);
+	`);
+	return drizzle(sqlite, { schema });
+}
+
+function createCaller() {
+	const db = createTestDb();
+	const ctx = { db, isAuthenticated: true } as unknown as HostServiceContext;
+	return agentConfigsRouter.createCaller(ctx);
+}
+
+async function listFirst(
+	caller: ReturnType<typeof agentConfigsRouter.createCaller>,
+) {
+	const rows = await caller.list();
+	const first = rows[0];
+	if (!first) throw new Error("expected seeded rows but list was empty");
+	return first;
+}
+
+const DEFAULT_PRESET_IDS = ["claude", "amp", "codex", "gemini", "copilot"];
+
+describe("agentConfigsRouter", () => {
+	describe("list()", () => {
+		it("seeds bundled defaults on first call", async () => {
+			const caller = createCaller();
+
+			const result = await caller.list();
+
+			expect(result.map((row) => row.presetId)).toEqual(DEFAULT_PRESET_IDS);
+			expect(result.map((row) => row.order)).toEqual([0, 1, 2, 3, 4]);
+		});
+
+		it("does not seed Superset Chat", async () => {
+			const caller = createCaller();
+			const result = await caller.list();
+			expect(
+				result.find((row) => row.presetId === "superset-chat"),
+			).toBeUndefined();
+		});
+
+		it("returns existing rows on subsequent calls without re-seeding", async () => {
+			const caller = createCaller();
+			const first = await caller.list();
+			const second = await caller.list();
+			expect(second.map((row) => row.id)).toEqual(first.map((row) => row.id));
+		});
+
+		it("returns rows in displayOrder", async () => {
+			const caller = createCaller();
+			const seeded = await caller.list();
+			await caller.reorder({
+				ids: [...seeded.map((row) => row.id)].reverse(),
+			});
+
+			const reordered = await caller.list();
+			expect(reordered.map((row) => row.presetId)).toEqual(
+				[...DEFAULT_PRESET_IDS].reverse(),
+			);
+			expect(reordered.map((row) => row.order)).toEqual([0, 1, 2, 3, 4]);
+		});
+	});
+
+	describe("listPresets()", () => {
+		it("returns the full hardcoded preset catalog", async () => {
+			const caller = createCaller();
+			const presets = await caller.listPresets();
+			expect(presets.map((preset) => preset.presetId)).toEqual(
+				AGENT_PRESETS.map((preset) => preset.presetId),
+			);
+		});
+	});
+
+	describe("add()", () => {
+		it("copies preset fields and assigns a unique id and next order", async () => {
+			const caller = createCaller();
+			await caller.list();
+
+			const created = await caller.add({ presetId: "pi" });
+
+			expect(created.presetId).toBe("pi");
+			expect(created.command).toBe("pi");
+			expect(created.promptTransport).toBe("argv");
+			expect(created.order).toBe(5);
+			const all = await caller.list();
+			expect(all).toHaveLength(6);
+			expect(new Set(all.map((row) => row.id)).size).toBe(6);
+		});
+
+		it("allows duplicate presetId entries with distinct ids", async () => {
+			const caller = createCaller();
+			await caller.list();
+
+			const a = await caller.add({ presetId: "claude" });
+			const b = await caller.add({ presetId: "claude" });
+
+			expect(a.id).not.toBe(b.id);
+			const claudes = (await caller.list()).filter(
+				(row) => row.presetId === "claude",
+			);
+			expect(claudes).toHaveLength(3);
+		});
+
+		it("rejects unknown presetId", async () => {
+			const caller = createCaller();
+			await expect(
+				caller.add({ presetId: "nonexistent-preset" }),
+			).rejects.toThrow();
+		});
+	});
+
+	describe("update()", () => {
+		it("persists label, command, args, promptTransport, promptArgs, env", async () => {
+			const caller = createCaller();
+			const first = await listFirst(caller);
+
+			const updated = await caller.update({
+				id: first.id,
+				patch: {
+					label: "Custom Claude",
+					command: "claude-yolo",
+					args: ["--mode", "fast"],
+					promptTransport: "stdin",
+					promptArgs: ["-X"],
+					env: { ANTHROPIC_API_KEY: "test" },
+				},
+			});
+
+			expect(updated.label).toBe("Custom Claude");
+			expect(updated.command).toBe("claude-yolo");
+			expect(updated.args).toEqual(["--mode", "fast"]);
+			expect(updated.promptTransport).toBe("stdin");
+			expect(updated.promptArgs).toEqual(["-X"]);
+			expect(updated.env).toEqual({ ANTHROPIC_API_KEY: "test" });
+		});
+
+		it("rejects invalid promptTransport", async () => {
+			const caller = createCaller();
+			const first = await listFirst(caller);
+			await expect(
+				caller.update({
+					id: first.id,
+					// biome-ignore lint/suspicious/noExplicitAny: testing invalid input
+					patch: { promptTransport: "file" as any },
+				}),
+			).rejects.toThrow();
+		});
+
+		it("rejects an empty patch", async () => {
+			const caller = createCaller();
+			const first = await listFirst(caller);
+			await expect(
+				caller.update({ id: first.id, patch: {} }),
+			).rejects.toThrow();
+		});
+
+		it("rejects update for missing id", async () => {
+			const caller = createCaller();
+			await expect(
+				caller.update({ id: "does-not-exist", patch: { label: "x" } }),
+			).rejects.toThrow();
+		});
+	});
+
+	describe("remove()", () => {
+		it("deletes a config by id", async () => {
+			const caller = createCaller();
+			const first = await listFirst(caller);
+
+			const result = await caller.remove({ id: first.id });
+
+			expect(result.success).toBe(true);
+			const remaining = await caller.list();
+			expect(remaining.find((row) => row.id === first.id)).toBeUndefined();
+		});
+	});
+
+	describe("reorder()", () => {
+		it("persists the submitted id order", async () => {
+			const caller = createCaller();
+			const seeded = await caller.list();
+			const reversed = [...seeded.map((row) => row.id)].reverse();
+
+			const result = await caller.reorder({ ids: reversed });
+
+			expect(result.map((row) => row.id)).toEqual(reversed);
+			expect(result.map((row) => row.order)).toEqual([0, 1, 2, 3, 4]);
+		});
+
+		it("rejects when ids do not match existing configs", async () => {
+			const caller = createCaller();
+			const seeded = await caller.list();
+
+			await expect(
+				caller.reorder({
+					ids: [...seeded.slice(0, 2).map((row) => row.id)],
+				}),
+			).rejects.toThrow();
+		});
+
+		it("rejects duplicate ids", async () => {
+			const caller = createCaller();
+			const first = await listFirst(caller);
+			await expect(
+				caller.reorder({ ids: [first.id, first.id] }),
+			).rejects.toThrow();
+		});
+	});
+
+	describe("resetToDefaults()", () => {
+		it("replaces current configs with bundled defaults", async () => {
+			const caller = createCaller();
+			const seedFirst = await listFirst(caller);
+			await caller.update({
+				id: seedFirst.id,
+				patch: { label: "Renamed" },
+			});
+			await caller.add({ presetId: "pi" });
+
+			const result = await caller.resetToDefaults();
+
+			expect(result.map((row) => row.presetId)).toEqual(DEFAULT_PRESET_IDS);
+			expect(result.find((row) => row.label === "Renamed")).toBeUndefined();
+			expect(result.find((row) => row.presetId === "pi")).toBeUndefined();
+		});
+	});
+});

--- a/packages/host-service/src/trpc/router/settings/agent-configs.ts
+++ b/packages/host-service/src/trpc/router/settings/agent-configs.ts
@@ -1,0 +1,330 @@
+import { randomUUID } from "node:crypto";
+import { TRPCError } from "@trpc/server";
+import { asc, eq, inArray } from "drizzle-orm";
+import { z } from "zod";
+import type { HostDb } from "../../../db";
+import { hostAgentConfigs } from "../../../db/schema";
+import { protectedProcedure, router } from "../../index";
+import {
+	AGENT_PRESETS,
+	type AgentPreset,
+	getDefaultSeedPresets,
+	getPresetById,
+	type PromptTransport,
+} from "./agent-presets";
+
+const promptTransportSchema = z.enum(["argv", "stdin"]);
+
+const presetIdSchema = z
+	.string()
+	.refine((value) => getPresetById(value) !== undefined, {
+		message: "Unknown presetId",
+	});
+
+const argvSchema = z.array(z.string());
+const envSchema = z.record(z.string(), z.string());
+
+interface HostAgentConfigOutput {
+	id: string;
+	presetId: string;
+	label: string;
+	command: string;
+	args: string[];
+	promptTransport: PromptTransport;
+	promptArgs: string[];
+	env: Record<string, string>;
+	order: number;
+}
+
+interface HostAgentConfigRow {
+	id: string;
+	presetId: string;
+	label: string;
+	command: string;
+	argsJson: string;
+	promptTransport: string;
+	promptArgsJson: string;
+	envJson: string;
+	displayOrder: number;
+}
+
+function parseArgv(value: string): string[] {
+	const parsed: unknown = JSON.parse(value);
+	if (
+		!Array.isArray(parsed) ||
+		parsed.some((item) => typeof item !== "string")
+	) {
+		return [];
+	}
+	return parsed as string[];
+}
+
+function parseEnv(value: string): Record<string, string> {
+	const parsed: unknown = JSON.parse(value);
+	if (
+		parsed === null ||
+		typeof parsed !== "object" ||
+		Array.isArray(parsed) ||
+		Object.values(parsed).some((item) => typeof item !== "string")
+	) {
+		return {};
+	}
+	return parsed as Record<string, string>;
+}
+
+function toOutput(row: HostAgentConfigRow): HostAgentConfigOutput {
+	return {
+		id: row.id,
+		presetId: row.presetId,
+		label: row.label,
+		command: row.command,
+		args: parseArgv(row.argsJson),
+		promptTransport: row.promptTransport as PromptTransport,
+		promptArgs: parseArgv(row.promptArgsJson),
+		env: parseEnv(row.envJson),
+		order: row.displayOrder,
+	};
+}
+
+function rowFromPreset(
+	preset: AgentPreset,
+	displayOrder: number,
+): typeof hostAgentConfigs.$inferInsert {
+	return {
+		id: randomUUID(),
+		presetId: preset.presetId,
+		label: preset.label,
+		command: preset.command,
+		argsJson: JSON.stringify(preset.args),
+		promptTransport: preset.promptTransport,
+		promptArgsJson: JSON.stringify(preset.promptArgs),
+		envJson: JSON.stringify(preset.env),
+		displayOrder,
+	};
+}
+
+function listOrdered(db: HostDb): HostAgentConfigRow[] {
+	return db
+		.select()
+		.from(hostAgentConfigs)
+		.orderBy(asc(hostAgentConfigs.displayOrder))
+		.all();
+}
+
+function seedDefaultsIfEmpty(db: HostDb): HostAgentConfigRow[] {
+	const existing = listOrdered(db);
+	if (existing.length > 0) return existing;
+	const seeds = getDefaultSeedPresets().map((preset, index) =>
+		rowFromPreset(preset, index),
+	);
+	if (seeds.length === 0) return existing;
+	db.insert(hostAgentConfigs).values(seeds).run();
+	return listOrdered(db);
+}
+
+const updatePatchSchema = z
+	.object({
+		label: z.string().min(1).optional(),
+		command: z.string().min(1).optional(),
+		args: argvSchema.optional(),
+		promptTransport: promptTransportSchema.optional(),
+		promptArgs: argvSchema.optional(),
+		env: envSchema.optional(),
+	})
+	.refine(
+		(patch) =>
+			patch.label !== undefined ||
+			patch.command !== undefined ||
+			patch.args !== undefined ||
+			patch.promptTransport !== undefined ||
+			patch.promptArgs !== undefined ||
+			patch.env !== undefined,
+		{ message: "Patch must update at least one field" },
+	);
+
+export const agentConfigsRouter = router({
+	/**
+	 * List configured host agents in persisted order. Seeds bundled defaults
+	 * on first call when no configs exist.
+	 */
+	list: protectedProcedure.query(({ ctx }) => {
+		const rows = seedDefaultsIfEmpty(ctx.db);
+		return rows.map(toOutput);
+	}),
+
+	/**
+	 * Available add templates. Returns the hardcoded preset list — the UI
+	 * uses this to render the "add agent" picker.
+	 */
+	listPresets: protectedProcedure.query(() =>
+		AGENT_PRESETS.map((preset) => ({
+			...preset,
+			args: [...preset.args],
+			promptArgs: [...preset.promptArgs],
+			env: { ...preset.env },
+		})),
+	),
+
+	/**
+	 * Create a new host agent config from a hardcoded preset. Allows
+	 * duplicate `presetId` entries — each gets a fresh `id`.
+	 */
+	add: protectedProcedure
+		.input(z.object({ presetId: presetIdSchema }))
+		.mutation(({ ctx, input }) => {
+			const preset = getPresetById(input.presetId);
+			if (!preset) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `Unknown presetId: ${input.presetId}`,
+				});
+			}
+			const existing = listOrdered(ctx.db);
+			const nextOrder =
+				existing.length === 0
+					? 0
+					: Math.max(...existing.map((row) => row.displayOrder)) + 1;
+			const insert = rowFromPreset(preset, nextOrder);
+			ctx.db.insert(hostAgentConfigs).values(insert).run();
+			const created = ctx.db
+				.select()
+				.from(hostAgentConfigs)
+				.where(eq(hostAgentConfigs.id, insert.id))
+				.get();
+			if (!created) {
+				throw new TRPCError({
+					code: "INTERNAL_SERVER_ERROR",
+					message: "Failed to read back inserted host agent config",
+				});
+			}
+			return toOutput(created);
+		}),
+
+	/**
+	 * Update editable fields on an existing config. `presetId` and `order`
+	 * are not mutable.
+	 */
+	update: protectedProcedure
+		.input(
+			z.object({
+				id: z.string().min(1),
+				patch: updatePatchSchema,
+			}),
+		)
+		.mutation(({ ctx, input }) => {
+			const existing = ctx.db
+				.select()
+				.from(hostAgentConfigs)
+				.where(eq(hostAgentConfigs.id, input.id))
+				.get();
+			if (!existing) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: `Host agent config not found: ${input.id}`,
+				});
+			}
+			const update: Partial<typeof hostAgentConfigs.$inferInsert> = {
+				updatedAt: Date.now(),
+			};
+			if (input.patch.label !== undefined) update.label = input.patch.label;
+			if (input.patch.command !== undefined)
+				update.command = input.patch.command;
+			if (input.patch.args !== undefined)
+				update.argsJson = JSON.stringify(input.patch.args);
+			if (input.patch.promptTransport !== undefined)
+				update.promptTransport = input.patch.promptTransport;
+			if (input.patch.promptArgs !== undefined)
+				update.promptArgsJson = JSON.stringify(input.patch.promptArgs);
+			if (input.patch.env !== undefined)
+				update.envJson = JSON.stringify(input.patch.env);
+			ctx.db
+				.update(hostAgentConfigs)
+				.set(update)
+				.where(eq(hostAgentConfigs.id, input.id))
+				.run();
+			const updated = ctx.db
+				.select()
+				.from(hostAgentConfigs)
+				.where(eq(hostAgentConfigs.id, input.id))
+				.get();
+			if (!updated) {
+				throw new TRPCError({
+					code: "INTERNAL_SERVER_ERROR",
+					message: "Failed to read back updated host agent config",
+				});
+			}
+			return toOutput(updated);
+		}),
+
+	/** Delete a single host agent config by id. */
+	remove: protectedProcedure
+		.input(z.object({ id: z.string().min(1) }))
+		.mutation(({ ctx, input }) => {
+			ctx.db
+				.delete(hostAgentConfigs)
+				.where(eq(hostAgentConfigs.id, input.id))
+				.run();
+			return { success: true as const };
+		}),
+
+	/**
+	 * Persist a new ordering. The submitted ids must match the current
+	 * configured ids exactly — no additions, no removals, no duplicates.
+	 */
+	reorder: protectedProcedure
+		.input(z.object({ ids: z.array(z.string().min(1)).min(1) }))
+		.mutation(({ ctx, input }) => {
+			const existing = listOrdered(ctx.db);
+			const existingIds = new Set(existing.map((row) => row.id));
+			const inputIds = new Set(input.ids);
+			if (inputIds.size !== input.ids.length) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "Reorder ids must be unique",
+				});
+			}
+			if (
+				existingIds.size !== inputIds.size ||
+				input.ids.some((id) => !existingIds.has(id))
+			) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "Reorder ids must match existing configs exactly",
+				});
+			}
+			const now = Date.now();
+			input.ids.forEach((id, index) => {
+				ctx.db
+					.update(hostAgentConfigs)
+					.set({ displayOrder: index, updatedAt: now })
+					.where(eq(hostAgentConfigs.id, id))
+					.run();
+			});
+			return listOrdered(ctx.db).map(toOutput);
+		}),
+
+	/** Replace the current configs with the bundled defaults. */
+	resetToDefaults: protectedProcedure.mutation(({ ctx }) => {
+		const existing = listOrdered(ctx.db);
+		if (existing.length > 0) {
+			ctx.db
+				.delete(hostAgentConfigs)
+				.where(
+					inArray(
+						hostAgentConfigs.id,
+						existing.map((row) => row.id),
+					),
+				)
+				.run();
+		}
+		const seeds = getDefaultSeedPresets().map((preset, index) =>
+			rowFromPreset(preset, index),
+		);
+		if (seeds.length > 0) {
+			ctx.db.insert(hostAgentConfigs).values(seeds).run();
+		}
+		return listOrdered(ctx.db).map(toOutput);
+	}),
+});
+
+export type HostAgentConfigDto = HostAgentConfigOutput;

--- a/packages/host-service/src/trpc/router/settings/agent-configs.ts
+++ b/packages/host-service/src/trpc/router/settings/agent-configs.ts
@@ -49,7 +49,12 @@ interface HostAgentConfigRow {
 }
 
 function parseArgv(value: string): string[] {
-	const parsed: unknown = JSON.parse(value);
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(value);
+	} catch {
+		return [];
+	}
 	if (
 		!Array.isArray(parsed) ||
 		parsed.some((item) => typeof item !== "string")
@@ -60,7 +65,12 @@ function parseArgv(value: string): string[] {
 }
 
 function parseEnv(value: string): Record<string, string> {
-	const parsed: unknown = JSON.parse(value);
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(value);
+	} catch {
+		return {};
+	}
 	if (
 		parsed === null ||
 		typeof parsed !== "object" ||
@@ -124,8 +134,8 @@ function seedDefaultsIfEmpty(db: HostDb): HostAgentConfigRow[] {
 
 const updatePatchSchema = z
 	.object({
-		label: z.string().min(1).optional(),
-		command: z.string().min(1).optional(),
+		label: z.string().trim().min(1).optional(),
+		command: z.string().trim().min(1).optional(),
 		args: argvSchema.optional(),
 		promptTransport: promptTransportSchema.optional(),
 		promptArgs: argvSchema.optional(),
@@ -256,10 +266,21 @@ export const agentConfigsRouter = router({
 			return toOutput(updated);
 		}),
 
-	/** Delete a single host agent config by id. */
+	/** Delete a single host agent config by id. Throws NOT_FOUND if missing. */
 	remove: protectedProcedure
 		.input(z.object({ id: z.string().min(1) }))
 		.mutation(({ ctx, input }) => {
+			const existing = ctx.db
+				.select({ id: hostAgentConfigs.id })
+				.from(hostAgentConfigs)
+				.where(eq(hostAgentConfigs.id, input.id))
+				.get();
+			if (!existing) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: `Host agent config not found: ${input.id}`,
+				});
+			}
 			ctx.db
 				.delete(hostAgentConfigs)
 				.where(eq(hostAgentConfigs.id, input.id))
@@ -270,6 +291,8 @@ export const agentConfigsRouter = router({
 	/**
 	 * Persist a new ordering. The submitted ids must match the current
 	 * configured ids exactly — no additions, no removals, no duplicates.
+	 * All updates run in a single transaction so a crash mid-loop can't
+	 * leave displayOrder half-updated.
 	 */
 	reorder: protectedProcedure
 		.input(z.object({ ids: z.array(z.string().min(1)).min(1) }))
@@ -293,36 +316,45 @@ export const agentConfigsRouter = router({
 				});
 			}
 			const now = Date.now();
-			input.ids.forEach((id, index) => {
-				ctx.db
-					.update(hostAgentConfigs)
-					.set({ displayOrder: index, updatedAt: now })
-					.where(eq(hostAgentConfigs.id, id))
-					.run();
+			ctx.db.transaction((tx) => {
+				input.ids.forEach((id, index) => {
+					tx.update(hostAgentConfigs)
+						.set({ displayOrder: index, updatedAt: now })
+						.where(eq(hostAgentConfigs.id, id))
+						.run();
+				});
 			});
 			return listOrdered(ctx.db).map(toOutput);
 		}),
 
-	/** Replace the current configs with the bundled defaults. */
+	/**
+	 * Replace the current configs with the bundled defaults. Wrapped in a
+	 * transaction so a crash between delete and insert can't leave the
+	 * table empty.
+	 */
 	resetToDefaults: protectedProcedure.mutation(({ ctx }) => {
-		const existing = listOrdered(ctx.db);
-		if (existing.length > 0) {
-			ctx.db
-				.delete(hostAgentConfigs)
-				.where(
-					inArray(
-						hostAgentConfigs.id,
-						existing.map((row) => row.id),
-					),
-				)
-				.run();
-		}
-		const seeds = getDefaultSeedPresets().map((preset, index) =>
-			rowFromPreset(preset, index),
-		);
-		if (seeds.length > 0) {
-			ctx.db.insert(hostAgentConfigs).values(seeds).run();
-		}
+		ctx.db.transaction((tx) => {
+			const existing = tx
+				.select({ id: hostAgentConfigs.id })
+				.from(hostAgentConfigs)
+				.all();
+			if (existing.length > 0) {
+				tx.delete(hostAgentConfigs)
+					.where(
+						inArray(
+							hostAgentConfigs.id,
+							existing.map((row) => row.id),
+						),
+					)
+					.run();
+			}
+			const seeds = getDefaultSeedPresets().map((preset, index) =>
+				rowFromPreset(preset, index),
+			);
+			if (seeds.length > 0) {
+				tx.insert(hostAgentConfigs).values(seeds).run();
+			}
+		});
 		return listOrdered(ctx.db).map(toOutput);
 	}),
 });

--- a/packages/host-service/src/trpc/router/settings/agent-presets.ts
+++ b/packages/host-service/src/trpc/router/settings/agent-presets.ts
@@ -3,6 +3,7 @@ export type PromptTransport = "argv" | "stdin";
 export interface AgentPreset {
 	presetId: string;
 	label: string;
+	description: string;
 	command: string;
 	args: string[];
 	promptTransport: PromptTransport;
@@ -31,6 +32,8 @@ export const AGENT_PRESETS = [
 	{
 		presetId: "claude",
 		label: "Claude",
+		description:
+			"Anthropic's coding agent for reading code, editing files, and running terminal workflows.",
 		command: "claude",
 		args: ["--permission-mode", "acceptEdits"],
 		promptTransport: "argv",
@@ -40,6 +43,8 @@ export const AGENT_PRESETS = [
 	{
 		presetId: "amp",
 		label: "Amp",
+		description:
+			"Amp's coding agent for terminal-first coding, subagents, and task work.",
 		command: "amp",
 		args: [],
 		promptTransport: "stdin",
@@ -49,6 +54,8 @@ export const AGENT_PRESETS = [
 	{
 		presetId: "codex",
 		label: "Codex",
+		description:
+			"OpenAI's coding agent for reading, modifying, and running code across tasks.",
 		command: "codex",
 		args: [
 			"-c",
@@ -66,6 +73,8 @@ export const AGENT_PRESETS = [
 	{
 		presetId: "gemini",
 		label: "Gemini",
+		description:
+			"Google's open-source terminal agent for coding, problem-solving, and task work.",
 		command: "gemini",
 		args: ["--approval-mode=auto_edit"],
 		promptTransport: "argv",
@@ -75,6 +84,7 @@ export const AGENT_PRESETS = [
 	{
 		presetId: "opencode",
 		label: "OpenCode",
+		description: "Open-source coding agent for the terminal, IDE, and desktop.",
 		command: "opencode",
 		args: [],
 		promptTransport: "argv",
@@ -84,6 +94,8 @@ export const AGENT_PRESETS = [
 	{
 		presetId: "pi",
 		label: "Pi",
+		description:
+			"Minimal terminal coding harness for flexible coding workflows.",
 		command: "pi",
 		args: [],
 		promptTransport: "argv",
@@ -93,6 +105,8 @@ export const AGENT_PRESETS = [
 	{
 		presetId: "copilot",
 		label: "Copilot",
+		description:
+			"GitHub's coding agent for planning, editing, and building in your repo.",
 		command: "copilot",
 		args: ["--allow-tool=write"],
 		promptTransport: "argv",
@@ -102,6 +116,8 @@ export const AGENT_PRESETS = [
 	{
 		presetId: "cursor-agent",
 		label: "Cursor Agent",
+		description:
+			"Cursor's coding agent for editing, running, and debugging code in parallel.",
 		command: "cursor-agent",
 		args: [],
 		promptTransport: "argv",

--- a/packages/host-service/src/trpc/router/settings/agent-presets.ts
+++ b/packages/host-service/src/trpc/router/settings/agent-presets.ts
@@ -82,6 +82,17 @@ export const AGENT_PRESETS = [
 		env: {},
 	},
 	{
+		presetId: "mastracode",
+		label: "Mastracode",
+		description:
+			"Mastra's coding agent for building, debugging, and shipping code from the terminal.",
+		command: "mastracode",
+		args: [],
+		promptTransport: "argv",
+		promptArgs: ["--prompt"],
+		env: {},
+	},
+	{
 		presetId: "opencode",
 		label: "OpenCode",
 		description: "Open-source coding agent for the terminal, IDE, and desktop.",

--- a/packages/host-service/src/trpc/router/settings/agent-presets.ts
+++ b/packages/host-service/src/trpc/router/settings/agent-presets.ts
@@ -1,0 +1,141 @@
+export type PromptTransport = "argv" | "stdin";
+
+export interface AgentPreset {
+	presetId: string;
+	label: string;
+	command: string;
+	args: string[];
+	promptTransport: PromptTransport;
+	promptArgs: string[];
+	env: Record<string, string>;
+}
+
+/**
+ * Hardcoded terminal agent presets. Used as add templates and as the seed
+ * for first `list()` / `resetToDefaults()`.
+ *
+ * Launch resolution:
+ *   prompt
+ *     ? [command, ...args, ...promptArgs, ...(promptTransport === "argv" ? [prompt] : [])]
+ *     : [command, ...args]
+ *
+ * `promptArgs` is only included when launching with a prompt — codex's
+ * trailing `--`, opencode's `--prompt`, and copilot's `-i` therefore do
+ * not appear in promptless launches. Stdin transport pipes the prompt to
+ * the spawned process's stdin instead of pushing it to argv.
+ *
+ * Superset Chat is intentionally excluded — its model/provider config
+ * lives in chat settings, not in terminal-agent configs.
+ */
+export const AGENT_PRESETS = [
+	{
+		presetId: "claude",
+		label: "Claude",
+		command: "claude",
+		args: ["--permission-mode", "acceptEdits"],
+		promptTransport: "argv",
+		promptArgs: [],
+		env: {},
+	},
+	{
+		presetId: "amp",
+		label: "Amp",
+		command: "amp",
+		args: [],
+		promptTransport: "stdin",
+		promptArgs: [],
+		env: {},
+	},
+	{
+		presetId: "codex",
+		label: "Codex",
+		command: "codex",
+		args: [
+			"-c",
+			'model_reasoning_effort="high"',
+			"-c",
+			'model_reasoning_summary="detailed"',
+			"-c",
+			"model_supports_reasoning_summaries=true",
+			"--full-auto",
+		],
+		promptTransport: "argv",
+		promptArgs: ["--"],
+		env: {},
+	},
+	{
+		presetId: "gemini",
+		label: "Gemini",
+		command: "gemini",
+		args: ["--approval-mode=auto_edit"],
+		promptTransport: "argv",
+		promptArgs: [],
+		env: {},
+	},
+	{
+		presetId: "opencode",
+		label: "OpenCode",
+		command: "opencode",
+		args: [],
+		promptTransport: "argv",
+		promptArgs: ["--prompt"],
+		env: {},
+	},
+	{
+		presetId: "pi",
+		label: "Pi",
+		command: "pi",
+		args: [],
+		promptTransport: "argv",
+		promptArgs: [],
+		env: {},
+	},
+	{
+		presetId: "copilot",
+		label: "Copilot",
+		command: "copilot",
+		args: ["--allow-tool=write"],
+		promptTransport: "argv",
+		promptArgs: ["-i"],
+		env: {},
+	},
+	{
+		presetId: "cursor-agent",
+		label: "Cursor Agent",
+		command: "cursor-agent",
+		args: [],
+		promptTransport: "argv",
+		promptArgs: [],
+		env: {},
+	},
+] as const satisfies readonly AgentPreset[];
+
+const DEFAULT_PRESET_IDS = new Set([
+	"claude",
+	"amp",
+	"codex",
+	"gemini",
+	"copilot",
+]);
+
+export function getDefaultSeedPresets(): AgentPreset[] {
+	return AGENT_PRESETS.filter((preset) =>
+		DEFAULT_PRESET_IDS.has(preset.presetId),
+	).map((preset) => ({
+		...preset,
+		args: [...preset.args],
+		promptArgs: [...preset.promptArgs],
+		env: { ...preset.env },
+	}));
+}
+
+export function getPresetById(presetId: string): AgentPreset | undefined {
+	const preset = AGENT_PRESETS.find((item) => item.presetId === presetId);
+	if (!preset) return undefined;
+	return {
+		...preset,
+		args: [...preset.args],
+		promptArgs: [...preset.promptArgs],
+		env: { ...preset.env },
+	};
+}

--- a/packages/host-service/src/trpc/router/settings/index.ts
+++ b/packages/host-service/src/trpc/router/settings/index.ts
@@ -1,0 +1,9 @@
+import { router } from "../../index";
+import { agentConfigsRouter } from "./agent-configs";
+
+export const settingsRouter = router({
+	agentConfigs: agentConfigsRouter,
+});
+
+export type { HostAgentConfigDto } from "./agent-configs";
+export type { AgentPreset, PromptTransport } from "./agent-presets";


### PR DESCRIPTION
## Summary

PR 1 of the canonical `workspace.create()` refactor. Introduces the V2 host-runtime agent config model. Configs live in `host.db`, are edited through a new V2 Agents settings page, and are listed via a new `settings.agentConfigs.*` tRPC router.

V2 modal + launch dispatch are intentionally **not** migrated here; that lands later (PR 5).

Design doc: #3893.

## Backend

- New `host_agent_configs` table (argv-array shape: `command`, `args[]`, `promptTransport`, `promptArgs[]`, `env`) with migration `0004`. Storing argv directly avoids shell-quoting bugs and makes prompt injection a list push instead of string concatenation.
- Hardcoded `AgentPreset` catalog: claude, amp, codex, gemini, mastracode, opencode, pi, copilot, cursor-agent. Default seed = claude/amp/codex/gemini/copilot. Mastracode is available as an Add-template only (matches v1 `includeInDefaultTerminalPresets: false`).
- `settings.agentConfigs.{list, listPresets, add, update, remove, reorder, resetToDefaults}` with seeding on first list, duplicate-`presetId` support, reorder integrity validation, and zod-validated patches.
- 17 router tests run against an in-memory bun:sqlite DB seeded by the **real** drizzle migration chain (`0000…0004`), so any drift between schema and generated SQL fails every test.

## Renderer (desktop)

- Under `FEATURE_FLAGS.V2_CLOUD`, the Agents settings page renders a new `V2AgentsSettings` component that talks to the active host's `settings.agentConfigs.*`. Non-V2 keeps the legacy preset UI unchanged (clean if/else branch in `AgentsSettings.tsx`).
- UI matches v1's look: preset icon (`getPresetIcon`) + label + description + chevron per row.
- Drag-to-reorder via `@dnd-kit/sortable` (mouse 4px threshold, touch 150ms hold + 5px tolerance, keyboard sortable). Optimistic updates so the row settles immediately on drop and rolls back on error.
- Single shell-style command input parsed via `shell-quote` into `command` + `args` on save; separate prompt-only args input; argv/stdin transport toggle. Add (preset picker with icons), remove, reset-to-defaults wired through tRPC mutations + react-query invalidation.
- 8 argv-parsing/joining tests.

`AgentPreset` gains a `description` field returned by `listPresets()` — used by the row header and Add menu. Descriptions stay catalog-only; never stored on the user's instance row.

## Launch resolution (consumed by a later PR)

```
argv = prompt
  ? [command, ...args, ...promptArgs, ...(transport === "argv" ? [prompt] : [])]
  : [command, ...args]
```

Empty launches drop `promptArgs`, so codex (`--`), opencode (`--prompt`), and copilot (`-i`) don't carry their prompt-mode flags into promptless sessions.

## Out of scope (deliberately deferred)

- V1 customization migration into host configs — handled later by the existing v1-to-v2 migration flow.
- V2 modal / pending-page launch dispatch read from desktop presets — moves to host configs in PR 5.
- Per-agent prompt templates — kept centralized in `agent-prompt-template`.
- Team/builtin layering for `source` — V2 is host-scoped user data only.

## Test plan

- [x] `bun test packages/host-service/src/trpc/router/settings/` — 17 router tests pass against the real migration chain
- [x] `bun test apps/desktop/.../V2AgentsSettings/utils/` — 8 argv parsing tests pass
- [x] `bun run typecheck` — 26/26 packages clean
- [x] `bun run lint` — clean
- [x] `bun run build:host` — host-service prod bundle exits 0
- [x] Manual UI walkthrough on V2_CLOUD: first-load seeding, add (incl. duplicate presetId), edit (label/command/promptArgs/transport), drag-reorder, remove, reset-to-defaults — all persist correctly across reload, on-disk DB matches expected
- [ ] V1 regression: toggle V2_CLOUD off and confirm legacy `AgentCard` UI unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * V2 Agents settings UI with a presets catalog and host-scoped agent loading
  * Add, remove, and edit agent configurations (label, command, args, prompt transport)
  * Drag-and-drop reordering with persisted ordering
  * Reset agents to bundled default configurations

* **Tests & Data**
  * Added unit/integration tests and a database migration to support agent configs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->