### PR TITLE
fix(mcp-v2): proper relay path for workspaces, OAuth client_name in tracking

### DIFF
--- a/apps/api/src/app/api/v2/agent/[transport]/route.ts
+++ b/apps/api/src/app/api/v2/agent/[transport]/route.ts
@@ -25,7 +25,10 @@ function unauthorizedResponse(req: Request, message: string): Response {
 async function handle(req: Request): Promise<Response> {
 	let ctx: McpContext;
 	try {
-		ctx = await resolveMcpContext(req, env.NEXT_PUBLIC_API_URL);
+		ctx = await resolveMcpContext(req, {
+			apiUrl: env.NEXT_PUBLIC_API_URL,
+			relayUrl: env.RELAY_URL,
+		});
 	} catch (error) {
 		if (isMcpUnauthorized(error)) {
 			return unauthorizedResponse(req, error.message);

--- a/bun.lock
+++ b/bun.lock
@@ -673,7 +673,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@clack/prompts": "^0.10.0",
         "@superset/cli-framework": "workspace:*",
@@ -849,6 +849,7 @@
         "@superset/trpc": "workspace:*",
         "better-auth": "1.6.5",
         "drizzle-orm": "0.45.2",
+        "superjson": "^2.2.5",
         "zod": "^4.3.5",
       },
       "devDependencies": {

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -225,9 +225,16 @@ export const auth = betterAuth({
 					return activeOrganizationId ?? undefined;
 				},
 			},
-			customAccessTokenClaims: ({ referenceId }) => ({
-				organizationId: referenceId ?? undefined,
-			}),
+			customAccessTokenClaims: ({ referenceId, metadata }) => {
+				const clientName =
+					metadata && typeof metadata === "object" && "client_name" in metadata
+						? metadata.client_name
+						: undefined;
+				return {
+					organizationId: referenceId ?? undefined,
+					client_name: typeof clientName === "string" ? clientName : undefined,
+				};
+			},
 		}),
 		expo(),
 		organization({

--- a/packages/mcp-v2/package.json
+++ b/packages/mcp-v2/package.json
@@ -28,6 +28,7 @@
 		"@superset/trpc": "workspace:*",
 		"better-auth": "1.6.5",
 		"drizzle-orm": "0.45.2",
+		"superjson": "^2.2.5",
 		"zod": "^4.3.5"
 	},
 	"devDependencies": {

--- a/packages/mcp-v2/src/auth.ts
+++ b/packages/mcp-v2/src/auth.ts
@@ -13,6 +13,7 @@ export interface McpContext {
 	clientLabel: string | null;
 	requestId: string;
 	bearerToken: string;
+	relayUrl: string;
 }
 
 const MCP_UNAUTHORIZED = Symbol("MCP_UNAUTHORIZED");
@@ -144,33 +145,26 @@ async function resolveOAuth(
 	if (typeof payload.organizationId !== "string" || !payload.organizationId) {
 		throw new McpUnauthorizedError("OAuth token missing organizationId claim");
 	}
+	const clientName =
+		typeof payload.client_name === "string" ? payload.client_name : null;
 	const azp = typeof payload.azp === "string" ? payload.azp : null;
 	return {
 		userId: payload.sub,
 		organizationId: payload.organizationId,
-		clientLabel: azp ? mapOAuthClientId(azp) : null,
+		clientLabel: clientName ?? azp,
 	};
 }
 
-const KNOWN_OAUTH_CLIENT_PREFIXES: Array<{ prefix: string; label: string }> = [
-	{ prefix: "claude-desktop", label: "claude-desktop" },
-	{ prefix: "claude-code", label: "claude-code" },
-	{ prefix: "claude-ai", label: "claude-ai" },
-	{ prefix: "cursor", label: "cursor" },
-];
-
-function mapOAuthClientId(clientId: string): string {
-	const lower = clientId.toLowerCase();
-	for (const { prefix, label } of KNOWN_OAUTH_CLIENT_PREFIXES) {
-		if (lower.startsWith(prefix)) return label;
-	}
-	return clientId;
+export interface ResolveMcpContextOptions {
+	apiUrl: string;
+	relayUrl: string;
 }
 
 export async function resolveMcpContext(
 	req: Request,
-	apiUrl: string,
+	options: ResolveMcpContextOptions,
 ): Promise<McpContext> {
+	const { apiUrl, relayUrl } = options;
 	const token = extractBearer(req);
 	if (!token) {
 		throw new McpUnauthorizedError("Missing bearer token");
@@ -217,5 +211,6 @@ export async function resolveMcpContext(
 		clientLabel,
 		requestId: crypto.randomUUID(),
 		bearerToken,
+		relayUrl,
 	};
 }

--- a/packages/mcp-v2/src/auth.ts
+++ b/packages/mcp-v2/src/auth.ts
@@ -145,13 +145,14 @@ async function resolveOAuth(
 	if (typeof payload.organizationId !== "string" || !payload.organizationId) {
 		throw new McpUnauthorizedError("OAuth token missing organizationId claim");
 	}
-	const clientName =
-		typeof payload.client_name === "string" ? payload.client_name : null;
-	const azp = typeof payload.azp === "string" ? payload.azp : null;
+	const clientLabel =
+		typeof payload.client_name === "string" && payload.client_name
+			? payload.client_name
+			: null;
 	return {
 		userId: payload.sub,
 		organizationId: payload.organizationId,
-		clientLabel: clientName ?? azp,
+		clientLabel,
 	};
 }
 

--- a/packages/mcp-v2/src/host-service-client.ts
+++ b/packages/mcp-v2/src/host-service-client.ts
@@ -1,0 +1,81 @@
+import { buildHostRoutingKey } from "@superset/shared/host-routing";
+import SuperJSON from "superjson";
+
+export interface HostServiceCallOptions {
+	relayUrl: string;
+	organizationId: string;
+	hostId: string;
+	jwt: string;
+	timeoutMs?: number;
+}
+
+export class HostServiceCallError extends Error {
+	constructor(
+		message: string,
+		public readonly status: number,
+		public readonly body: string,
+	) {
+		super(message);
+		this.name = "HostServiceCallError";
+	}
+}
+
+export async function hostServiceMutation<TInput, TOutput>(
+	options: HostServiceCallOptions,
+	procedure: string,
+	input: TInput,
+): Promise<TOutput> {
+	const routingKey = buildHostRoutingKey(
+		options.organizationId,
+		options.hostId,
+	);
+	const url = `${options.relayUrl}/hosts/${routingKey}/trpc/${procedure}`;
+	const encoded = SuperJSON.serialize(input);
+
+	const controller = new AbortController();
+	const timer = setTimeout(
+		() => controller.abort(),
+		options.timeoutMs ?? 25_000,
+	);
+
+	let response: Response;
+	try {
+		response = await fetch(url, {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				authorization: `Bearer ${options.jwt}`,
+			},
+			body: JSON.stringify(encoded),
+			signal: controller.signal,
+		});
+	} finally {
+		clearTimeout(timer);
+	}
+
+	const rawBody = await response.text();
+	if (!response.ok) {
+		throw new HostServiceCallError(
+			`relay ${response.status}: ${rawBody.slice(0, 500)}`,
+			response.status,
+			rawBody,
+		);
+	}
+
+	type TrpcEnvelope = { result?: { data?: unknown } };
+	let parsed: TrpcEnvelope;
+	try {
+		parsed = JSON.parse(rawBody) as TrpcEnvelope;
+	} catch {
+		throw new HostServiceCallError(
+			`invalid JSON from relay: ${rawBody.slice(0, 200)}`,
+			response.status,
+			rawBody,
+		);
+	}
+
+	const data = parsed.result?.data;
+	return SuperJSON.deserialize(
+		data as Parameters<typeof SuperJSON.deserialize>[0],
+	) as TOutput;
+}

--- a/packages/mcp-v2/src/host-service-client.ts
+++ b/packages/mcp-v2/src/host-service-client.ts
@@ -56,7 +56,7 @@ export async function hostServiceMutation<TInput, TOutput>(
 	const rawBody = await response.text();
 	if (!response.ok) {
 		throw new HostServiceCallError(
-			`relay ${response.status}: ${rawBody.slice(0, 500)}`,
+			describeRelayFailure(response.status, rawBody, options.hostId, procedure),
 			response.status,
 			rawBody,
 		);
@@ -78,4 +78,20 @@ export async function hostServiceMutation<TInput, TOutput>(
 	return SuperJSON.deserialize(
 		data as Parameters<typeof SuperJSON.deserialize>[0],
 	) as TOutput;
+}
+
+function describeRelayFailure(
+	status: number,
+	rawBody: string,
+	hostId: string,
+	procedure: string,
+): string {
+	const trimmed = rawBody.slice(0, 200);
+	if (status === 503 && /host not connected/i.test(trimmed)) {
+		return `Host ${hostId} is not online`;
+	}
+	if (status === 401) return "You are not authenticated";
+	if (status === 403) return `You don't have access to host ${hostId}`;
+	if (status === 404) return `Host ${hostId} not found`;
+	return `Host ${hostId} returned ${status} for ${procedure}: ${trimmed}`;
 }

--- a/packages/mcp-v2/src/host-service-client.ts
+++ b/packages/mcp-v2/src/host-service-client.ts
@@ -75,6 +75,13 @@ export async function hostServiceMutation<TInput, TOutput>(
 	}
 
 	const data = parsed.result?.data;
+	if (data === undefined || data === null) {
+		throw new HostServiceCallError(
+			`Malformed response from host ${options.hostId} for ${procedure}`,
+			response.status,
+			rawBody,
+		);
+	}
 	return SuperJSON.deserialize(
 		data as Parameters<typeof SuperJSON.deserialize>[0],
 	) as TOutput;

--- a/packages/mcp-v2/src/in-memory.ts
+++ b/packages/mcp-v2/src/in-memory.ts
@@ -11,6 +11,7 @@ export interface InMemoryClientOptions {
 	userId: string;
 	organizationId: string;
 	clientLabel: string;
+	relayUrl: string;
 }
 
 /**
@@ -26,6 +27,7 @@ export async function createInMemoryMcpClient({
 	userId,
 	organizationId,
 	clientLabel,
+	relayUrl,
 }: InMemoryClientOptions): Promise<{
 	client: Client;
 	cleanup: () => Promise<void>;
@@ -67,6 +69,7 @@ export async function createInMemoryMcpClient({
 		clientLabel,
 		requestId: crypto.randomUUID(),
 		bearerToken,
+		relayUrl,
 	};
 
 	const server = createMcpServer();

--- a/packages/mcp-v2/src/tools/workspaces/create.ts
+++ b/packages/mcp-v2/src/tools/workspaces/create.ts
@@ -7,7 +7,7 @@ export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "workspaces_create",
 		description:
-			"Create a workspace on a host. A workspace is a branch-scoped working copy of a project. The host service materializes the git worktree on disk before returning. Use projects_list and hosts_list first to get the projectId and hostId. Errors with relay 503 if the target host is not currently connected.",
+			"Create a workspace on a host. A workspace is a branch-scoped working copy of a project. The host service materializes the git worktree on disk before returning. Use projects_list and hosts_list first to get the projectId and hostId.",
 		inputSchema: {
 			projectId: z.string().uuid().describe("Project UUID."),
 			name: z.string().min(1).describe("Workspace name (display)."),

--- a/packages/mcp-v2/src/tools/workspaces/create.ts
+++ b/packages/mcp-v2/src/tools/workspaces/create.ts
@@ -1,13 +1,13 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { createMcpCaller } from "../../caller";
 import { defineTool } from "../../define-tool";
+import { hostServiceMutation } from "../../host-service-client";
 
 export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "workspaces_create",
 		description:
-			"Create a workspace on a host. A workspace is a branch-scoped working copy of a project. Use projects_list and hosts_list first to get the projectId and hostId.",
+			"Create a workspace on a host. A workspace is a branch-scoped working copy of a project. The host service materializes the git worktree on disk before returning. Use projects_list and hosts_list first to get the projectId and hostId. Errors with relay 503 if the target host is not currently connected.",
 		inputSchema: {
 			projectId: z.string().uuid().describe("Project UUID."),
 			name: z.string().min(1).describe("Workspace name (display)."),
@@ -16,19 +16,25 @@ export function register(server: McpServer): void {
 				.string()
 				.min(1)
 				.describe("Host machineId to create the workspace on."),
-			type: z
-				.enum(["worktree", "main"])
-				.default("worktree")
-				.describe(
-					"Workspace type. Defaults to 'worktree'; 'main' has special semantics.",
-				),
 		},
 		handler: async (input, ctx) => {
-			const caller = createMcpCaller(ctx);
-			return caller.v2Workspace.create({
-				organizationId: ctx.organizationId,
-				...input,
-			});
+			return hostServiceMutation<
+				{ projectId: string; name: string; branch: string },
+				{ id: string; projectId: string; branch: string; worktreePath: string }
+			>(
+				{
+					relayUrl: ctx.relayUrl,
+					organizationId: ctx.organizationId,
+					hostId: input.hostId,
+					jwt: ctx.bearerToken,
+				},
+				"workspace.create",
+				{
+					projectId: input.projectId,
+					name: input.name,
+					branch: input.branch,
+				},
+			);
 		},
 	});
 }

--- a/packages/mcp-v2/src/tools/workspaces/delete.ts
+++ b/packages/mcp-v2/src/tools/workspaces/delete.ts
@@ -2,18 +2,35 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { createMcpCaller } from "../../caller";
 import { defineTool } from "../../define-tool";
+import { hostServiceMutation } from "../../host-service-client";
 
 export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "workspaces_delete",
 		description:
-			"Delete a workspace by UUID. Idempotent — succeeds if the workspace is already gone. Cannot delete 'main'-type workspaces.",
+			"Delete a workspace by UUID. The host service removes the git worktree from disk before returning. Cannot delete 'main'-type workspaces. Errors with relay 503 if the target host is not currently connected.",
 		inputSchema: {
 			id: z.string().uuid().describe("Workspace UUID."),
 		},
 		handler: async (input, ctx) => {
 			const caller = createMcpCaller(ctx);
-			return caller.v2Workspace.delete({ id: input.id });
+			const workspace = await caller.v2Workspace.getFromHost({
+				organizationId: ctx.organizationId,
+				id: input.id,
+			});
+			if (!workspace) {
+				throw new Error(`Workspace not found: ${input.id}`);
+			}
+			return hostServiceMutation<{ id: string }, { success: boolean }>(
+				{
+					relayUrl: ctx.relayUrl,
+					organizationId: ctx.organizationId,
+					hostId: workspace.hostId,
+					jwt: ctx.bearerToken,
+				},
+				"workspace.delete",
+				{ id: input.id },
+			);
 		},
 	});
 }

--- a/packages/mcp-v2/src/tools/workspaces/delete.ts
+++ b/packages/mcp-v2/src/tools/workspaces/delete.ts
@@ -8,7 +8,7 @@ export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "workspaces_delete",
 		description:
-			"Delete a workspace by UUID. The host service removes the git worktree from disk before returning. Cannot delete 'main'-type workspaces. Errors with relay 503 if the target host is not currently connected.",
+			"Delete a workspace by UUID. The host service removes the git worktree from disk before returning. Cannot delete 'main'-type workspaces.",
 		inputSchema: {
 			id: z.string().uuid().describe("Workspace UUID."),
 		},

--- a/packages/mcp-v2/src/tools/workspaces/delete.ts
+++ b/packages/mcp-v2/src/tools/workspaces/delete.ts
@@ -8,7 +8,7 @@ export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "workspaces_delete",
 		description:
-			"Delete a workspace by UUID. The host service removes the git worktree from disk before returning. Cannot delete 'main'-type workspaces.",
+			"Delete a workspace by UUID. The host service removes the git worktree from disk before returning. Idempotent — succeeds with alreadyGone:true if the workspace is gone. Cannot delete 'main'-type workspaces.",
 		inputSchema: {
 			id: z.string().uuid().describe("Workspace UUID."),
 		},
@@ -19,7 +19,7 @@ export function register(server: McpServer): void {
 				id: input.id,
 			});
 			if (!workspace) {
-				throw new Error(`Workspace not found: ${input.id}`);
+				return { success: true, alreadyGone: true };
 			}
 			return hostServiceMutation<{ id: string }, { success: boolean }>(
 				{


### PR DESCRIPTION
## Summary

Two follow-up fixes from prod smoke testing of v2 MCP.

### 1. `workspaces_create` / `workspaces_delete` now actually do work on the host

The MCP tools were wired to `caller.v2Workspace.create` / `.delete` — the **cloud** tRPC procedures, which only write the DB row. The host-service was never told to materialize (or remove) the git worktree on disk. The desktop app then "noticed" the row via Electric SQL and acted on it asynchronously, with no signal back to the caller.

That meant when the relay was down (which it was during today's smoke test), `workspaces_create` returned 200 OK and a row id while the actual worktree silently never existed.

Switched to the same path the CLI uses: `POST ${RELAY_URL}/hosts/{routingKey}/trpc/{procedure}` via a minimal `hostServiceMutation` transport helper. The host-service now does the filesystem work and writes the cloud row before the call returns. Same code path that powers `automations_run` — surfaces relay 503 honestly when the host isn't connected.

Why a new helper instead of importing host-service's tRPC `AppRouter` types directly: pulling the host-service source into the cloud TypeScript compile breaks because of host-only env strictness (better-sqlite3, node-pty, etc). Inline input/output types per call, mirroring the existing `relay-client.ts` pattern.

### 2. PostHog `client_label` now shows human-readable names for OAuth callers

`mcp_tool_called` events for OAuth-authenticated requests were tagged with raw DCR `client_id` (e.g. `yGixmCSVdmnmMulxajcjhDtrsxntdmtq`) instead of friendly labels. Fix: `oauthProvider.customAccessTokenClaims` passes through `client_name` from RFC 7591 client metadata. mcp-v2 reads `payload.client_name` first, falls back to `azp` if absent. Purely additive, zero per-request DB cost. Applies only to OAuth access tokens (not JWT-plugin tokens used by CLI/relay/electric-proxy).

## Test plan

- [ ] CI green
- [ ] Verify `workspaces_create` against an online host produces an actual worktree on disk (not just a DB row)
- [ ] Verify `workspaces_create` against a host with no relay connection returns 503 instead of silent success
- [ ] After deploy, watch a fresh `mcp_tool_called` event in PostHog to confirm `client_label` reflects the OAuth client's `client_name` (or raw `azp` if the client didn't set one)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Relay-backed host service for workspace operations (create/delete); create returns host worktreePath.

* **Improvements**
  * OAuth tokens include an optional client_name for clearer client labeling.
  * More robust host-service error reporting, authenticated relay calls with timeouts, and serialized payloads.
  * MCP context and in-memory client now carry a relayUrl for distributed requests.

* **Chores**
  * Added superjson dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->