### PR TITLE
fix(cli-framework): --version prints just the version string

### DIFF
--- a/packages/cli-framework/src/runner.ts
+++ b/packages/cli-framework/src/runner.ts
@@ -223,7 +223,7 @@ async function execute(
 		commandPath.length === 0 &&
 		(args.includes("--version") || args.includes("-v"))
 	) {
-		console.log(`${name} v${version}`);
+		console.log(version);
 		return;
 	}
 


### PR DESCRIPTION
## Summary
- `superset --version` was printing `superset v0.2.0`. Switch to just `0.2.0` to match `bun --version`, `npm --version`, `pnpm --version`. The help banner (`superset --help`) still prefixes with the name — that's a header, different surface.

Single-line change in the runner's version short-circuit.

## Test plan
- [ ] Land this PR
- [ ] Tag a follow-up `cli-v0.2.1` (or roll into the next release) and run `superset --version` — expect `0.2.1` on its own line, no `superset v` prefix
- [ ] `superset --help` still shows the banner header `superset v0.2.1` as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the version flag (`--version`/`-v`) output to display only the version number instead of the CLI name with version prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->