### PR TITLE
fix(mcp-v2): clearer MCP error when target host hasn't enabled remote access

### DIFF
--- a/packages/mcp-v2/src/host-service-client.ts
+++ b/packages/mcp-v2/src/host-service-client.ts
@@ -95,7 +95,7 @@ function describeRelayFailure(
 ): string {
 	const trimmed = rawBody.slice(0, 200);
 	if (status === 503 && /host not connected/i.test(trimmed)) {
-		return `Host ${hostId} is not online`;
+		return `Host ${hostId} has not enabled remote access. Toggle "Allow remote workspaces to access this device" in Settings → Security on that machine.`;
 	}
 	if (status === 401) return "You are not authenticated";
 	if (status === 403) return `You don't have access to host ${hostId}`;


### PR DESCRIPTION
## Summary

Improves the error message MCP callers see when the cloud relay can't reach a user's host because the host hasn't enabled the remote-access tunnel.

## Root cause

Cloud MCP can only reach a user's host when the desktop's `exposeHostServiceViaRelay` setting is on (Pro plan + Settings → Security → "Allow remote workspaces to access this device"). That field defaults to `false`, so until a user explicitly toggles it on, the host-service never opens a tunnel to the relay.

When MCP hits an un-tunneled host, the relay returns `503 host not connected` and `describeRelayFailure` in `packages/mcp-v2/src/host-service-client.ts` previously rendered that as `Host {hostId} is not online`.

## Why the previous message was misleading

The host's heartbeat to the API can be perfectly healthy — the host process is running, the user is signed in, the device shows online in the UI. "Not online" implied the user's machine was off or the app was closed, sending people down the wrong debugging path. The actual fix is one toggle in Settings.

## Change

Single-line edit to the 503 + "host not connected" branch in `describeRelayFailure`. New string:

> Host {hostId} has not enabled remote access. Toggle "Allow remote workspaces to access this device" in Settings → Security on that machine.

`workspaces_create` / `workspaces_delete` tool descriptions are intentionally left untouched — the error itself now carries the guidance, and tool descriptions are token-cost-per-call.

## Predecessor

Follows #3918, which fixed the relay path for workspaces and OAuth `client_name` tracking.

## Test plan

- [ ] Trigger an MCP `workspaces_create` against a host with the remote-access toggle off; confirm the new error string is returned instead of "is not online"
- [ ] Confirm other branches (401/403/404/generic) are unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for remote connection failures with clearer, actionable guidance on enabling remote workspace access in system settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->