### PR TITLE
chore(desktop): bump version to 1.7.3

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "@superset/desktop",
 	"productName": "Superset",
 	"description": "The last developer tool you'll ever need",
-	"version": "1.7.2",
+	"version": "1.7.3",
 	"main": "./dist/main/index.js",
 	"resources": "src/resources",
 	"repository": {


### PR DESCRIPTION
## Summary
- Bumps `@superset/desktop` from 1.7.2 to 1.7.3.

## Test plan
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated desktop application version to 1.7.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->