### PR TITLE
release(cli): cut v0.2.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -111,7 +111,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.43",
         "@ai-sdk/openai": "3.0.36",
@@ -673,7 +673,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@clack/prompts": "^0.10.0",
         "@superset/cli-framework": "workspace:*",

--- a/packages/cli/cli.config.ts
+++ b/packages/cli/cli.config.ts
@@ -1,6 +1,6 @@
 import { boolean, defineConfig, string } from "@superset/cli-framework";
 
-const VERSION = "0.2.0";
+const VERSION = "0.2.1";
 
 export default defineConfig({
 	name: "superset",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Summary

Patch release. v0.2.0 linux-x64 tarballs crash on `superset start` because the bundled host-service couldn't find `tokenizers.linux-x64-gnu.node`. v0.2.1 picks up the fix plus the smoke-test polish + remote-access error message work landed since v0.2.0.

## What's new since v0.2.0

- #3921 fix(cli): ship onnxruntime-node + @anush008/tokenizers natives in linux-x64 tarball
- #3920 fix(cli): smoke-test polish pass — bugs, ergo, help text
- #3922 fix(mcp-v2): point users at remote-access toggle when relay tunnel is missing
- #3918 fix(mcp-v2): proper relay path for workspaces, OAuth client_name in tracking

## Release flow

1. Merge this PR (squash)
2. Push tag `cli-v0.2.1` to fire `release-cli.yml` — builds darwin-arm64 / linux-x64 / linux-arm64 tarballs in CI on real Linux runners and publishes them as a GitHub Release
3. `bump-homebrew.yml` updates the brew formula with the new SHAs
4. `install.sh` and `superset update` resolve to the new release

## Test plan

- [ ] CI green
- [ ] After merge + tag push, `release-cli.yml` succeeds and produces three tarballs
- [ ] On a fresh Linux host: `curl -fsSL https://superset.sh/cli/install.sh | bash` → `superset start` brings up the host service without crashing
- [ ] `superset update` from an existing v0.2.0 install resolves to v0.2.1 and replaces the install

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped CLI package version to 0.2.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->