### PR TITLE
feat(desktop): let dev mode toggle between v1 and v2

### DIFF
--- a/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts
+++ b/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts
@@ -15,7 +15,7 @@ export function useIsV2CloudEnabled() {
 
 	if (IS_DEV) {
 		return {
-			isV2CloudEnabled: true,
+			isV2CloudEnabled: optInV2,
 			isRemoteV2Enabled: true,
 		};
 	}

--- a/apps/desktop/src/renderer/stores/v2-local-override.ts
+++ b/apps/desktop/src/renderer/stores/v2-local-override.ts
@@ -16,7 +16,7 @@ export const useV2LocalOverrideStore = create<V2LocalOverrideState>()(
 				optInV2: IS_DEV,
 				setOptInV2: (optInV2) => set({ optInV2 }),
 			}),
-			{ name: "v2-local-override-v3" },
+			{ name: "v2-local-override-v2" },
 		),
 		{ name: "V2LocalOverrideStore" },
 	),

--- a/apps/desktop/src/renderer/stores/v2-local-override.ts
+++ b/apps/desktop/src/renderer/stores/v2-local-override.ts
@@ -1,6 +1,8 @@
 import { create } from "zustand";
 import { devtools, persist } from "zustand/middleware";
 
+const IS_DEV = process.env.NODE_ENV === "development";
+
 interface V2LocalOverrideState {
 	/** When true, the user has opted into v2. v2 is gated behind both the remote flag and this opt-in. */
 	optInV2: boolean;
@@ -11,10 +13,10 @@ export const useV2LocalOverrideStore = create<V2LocalOverrideState>()(
 	devtools(
 		persist(
 			(set) => ({
-				optInV2: false,
+				optInV2: IS_DEV,
 				setOptInV2: (optInV2) => set({ optInV2 }),
 			}),
-			{ name: "v2-local-override-v2" },
+			{ name: "v2-local-override-v3" },
 		),
 		{ name: "V2LocalOverrideStore" },
 	),


### PR DESCRIPTION
## Summary
- Dev mode previously forced `isV2CloudEnabled = true`, making the Settings → Experimental toggle a no-op locally. There was no way to test v1 in dev.
- Respect the local `optInV2` value in dev too. `isRemoteV2Enabled` stays forced-on so the toggle remains visible/enabled.
- No copy or default changes; production behavior unaffected.

## Test plan
- [ ] In dev with `optInV2 = true` (toggle on) → lands on v2
- [ ] In dev with `optInV2 = false` (toggle off) → lands on v1
- [ ] Toggle visible in Settings → Experimental in dev (since `isRemoteV2Enabled` still true)
- [ ] Production unchanged: still requires both remote PostHog flag and `optInV2`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Development builds now respect the local opt-in setting for V2 Cloud availability rather than forcing it on.
  * V2 Cloud availability still requires both remote enablement and local opt-in in non-development environments.

* **Chores**
  * Local opt-in default set to enabled in development (disabled otherwise) and persisted storage key updated, causing prior saved overrides to be ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->