### PR TITLE
feat(desktop): default v2 workspaces to all devices, sort by host then created

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/V2WorkspacesList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/V2WorkspacesList.tsx
@@ -22,7 +22,7 @@ import type {
 	V2WorkspaceHostType,
 } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces";
 import {
-	DEVICE_FILTER_THIS_DEVICE,
+	DEVICE_FILTER_ALL,
 	PROJECT_FILTER_ALL,
 	useV2WorkspacesFilterStore,
 } from "renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore";
@@ -142,8 +142,8 @@ export function V2WorkspacesList({ workspaces }: V2WorkspacesListProps) {
 	);
 	const resetFilters = useV2WorkspacesFilterStore((state) => state.reset);
 
-	const [sortField, setSortField] = useState<SortField>("created");
-	const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+	const [sortField, setSortField] = useState<SortField>("host");
+	const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
 
 	const handleSort = (field: SortField) => {
 		if (sortField === field) {
@@ -165,7 +165,7 @@ export function V2WorkspacesList({ workspaces }: V2WorkspacesListProps) {
 	);
 	const hasActiveFilters =
 		searchQuery.trim() !== "" ||
-		deviceFilter !== DEVICE_FILTER_THIS_DEVICE ||
+		deviceFilter !== DEVICE_FILTER_ALL ||
 		projectFilter !== PROJECT_FILTER_ALL;
 
 	const columnHeader = (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/components/V2WorkspaceRow/V2WorkspaceRow.tsx
@@ -8,6 +8,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
+import { CgLaptop } from "react-icons/cg";
 import {
 	LuCircleCheck,
 	LuCircleDashed,
@@ -212,6 +213,17 @@ export function V2WorkspaceRow({
 				</div>
 
 				<span className="flex min-w-0 items-center gap-2">
+					{isMainWorkspace ? (
+						<Tooltip delayDuration={300}>
+							<TooltipTrigger asChild>
+								<CgLaptop
+									className="size-3.5 shrink-0 text-muted-foreground"
+									aria-label="Main workspace"
+								/>
+							</TooltipTrigger>
+							<TooltipContent side="top">Main workspace</TooltipContent>
+						</Tooltip>
+					) : null}
 					<span
 						className="min-w-0 truncate font-medium text-foreground"
 						title={workspace.name}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore/v2WorkspacesFilterStore.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore/v2WorkspacesFilterStore.ts
@@ -20,7 +20,7 @@ interface V2WorkspacesFilterState {
 export const useV2WorkspacesFilterStore = create<V2WorkspacesFilterState>()(
 	(set) => ({
 		searchQuery: "",
-		deviceFilter: DEVICE_FILTER_THIS_DEVICE,
+		deviceFilter: DEVICE_FILTER_ALL,
 		projectFilter: PROJECT_FILTER_ALL,
 		setSearchQuery: (searchQuery) => set({ searchQuery }),
 		setDeviceFilter: (deviceFilter) => set({ deviceFilter }),
@@ -28,7 +28,7 @@ export const useV2WorkspacesFilterStore = create<V2WorkspacesFilterState>()(
 		reset: () =>
 			set({
 				searchQuery: "",
-				deviceFilter: DEVICE_FILTER_THIS_DEVICE,
+				deviceFilter: DEVICE_FILTER_ALL,
 				projectFilter: PROJECT_FILTER_ALL,
 			}),
 	}),

--- a/bun.lock
+++ b/bun.lock
@@ -111,7 +111,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.43",
         "@ai-sdk/openai": "3.0.36",


### PR DESCRIPTION
## Summary
- Default device filter is now **All devices** (was "This device") so cross-device workspaces are visible up-front
- Default sort is **host asc** (current device first, remote hosts after) with `createdAt desc` as the natural tiebreak from `compareWorkspaces`
- Main workspaces now show the same `CgLaptop` icon used in the sidebar next to their name, with a "Main workspace" tooltip

## Test plan
- [ ] Open v2 workspaces — list shows workspaces from all devices grouped by project, with local-device rows above remote rows within each project
- [ ] Within a host, rows are ordered newest createdAt first
- [ ] Main workspaces render with the laptop icon + tooltip; worktree workspaces do not
- [ ] Clicking the device filter still works; resetting filters returns to "All devices"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visual indicator icon to main workspaces in the workspace list, helping users identify them at a glance.

* **Updates**
  * Default workspace sorting changed from creation date to host for improved organization.
  * Device filter now defaults to displaying all devices instead of limiting to the current device.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->