### PR TITLE
fix(desktop): wait for subscription sync before paywalling automations

### DIFF
--- a/apps/desktop/src/renderer/components/Paywall/usePaywall.ts
+++ b/apps/desktop/src/renderer/components/Paywall/usePaywall.ts
@@ -5,7 +5,7 @@ import { paywall } from "./Paywall";
 
 export function usePaywall() {
 	const { data: session } = authClient.useSession();
-	const userPlan = useCurrentPlan();
+	const { plan: userPlan, isReady } = useCurrentPlan();
 
 	function hasAccess(feature: GatedFeature): boolean {
 		void feature;
@@ -38,5 +38,6 @@ export function usePaywall() {
 		hasAccess,
 		gateFeature,
 		userPlan,
+		isReady,
 	};
 }

--- a/apps/desktop/src/renderer/hooks/useCurrentPlan.ts
+++ b/apps/desktop/src/renderer/hooks/useCurrentPlan.ts
@@ -38,22 +38,24 @@ export function resolveCurrentPlan({
 	return "free";
 }
 
-export function useCurrentPlan(): PlanTier {
+export function useCurrentPlan(): { plan: PlanTier; isReady: boolean } {
 	const { data: session } = authClient.useSession();
 	const collections = useCollections();
 
-	const { data: subscriptionsData } = useLiveQuery(
+	const { data: subscriptionsData = [], isReady } = useLiveQuery(
 		(q) => q.from({ subscriptions: collections.subscriptions }),
 		[collections],
 	);
 
-	const activeSubscription = subscriptionsData?.find((subscription) =>
+	const activeSubscription = subscriptionsData.find((subscription) =>
 		isActiveSubscriptionStatus(subscription.status),
 	);
 
-	return resolveCurrentPlan({
+	const plan = resolveCurrentPlan({
 		subscriptionPlan: activeSubscription?.plan,
 		sessionPlan: session?.session?.plan,
-		subscriptionsLoaded: subscriptionsData !== undefined,
+		subscriptionsLoaded: isReady,
 	});
+
+	return { plan, isReady };
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/layout.tsx
@@ -8,17 +8,17 @@ export const Route = createFileRoute("/_authenticated/_dashboard/automations")({
 
 function AutomationsLayout() {
 	const navigate = useNavigate();
-	const { hasAccess, gateFeature } = usePaywall();
+	const { hasAccess, gateFeature, isReady } = usePaywall();
 	const allowed = hasAccess(GATED_FEATURES.AUTOMATIONS);
 	const handledRef = useRef(false);
 
 	useEffect(() => {
-		if (allowed || handledRef.current) return;
+		if (!isReady || allowed || handledRef.current) return;
 		handledRef.current = true;
 		gateFeature(GATED_FEATURES.AUTOMATIONS, () => {});
 		navigate({ to: "/v2-workspaces", replace: true });
-	}, [allowed, gateFeature, navigate]);
+	}, [isReady, allowed, gateFeature, navigate]);
 
-	if (!allowed) return null;
+	if (!isReady || !allowed) return null;
 	return <Outlet />;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown/OrganizationDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown/OrganizationDropdown.tsx
@@ -71,7 +71,7 @@ export function OrganizationDropdown({
 	const userName = session?.user?.name;
 	const displayName = activeOrganization?.name ?? userName ?? "Organization";
 
-	const currentPlan = useCurrentPlan();
+	const { plan: currentPlan } = useCurrentPlan();
 	const isPaid = currentPlan !== "free";
 	const planLabel = currentPlan.charAt(0).toUpperCase() + currentPlan.slice(1);
 	const planBadge = isPaid ? (

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/members/components/MembersSettings/components/MemberActions/MemberActions.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/members/components/MembersSettings/components/MemberActions/MemberActions.tsx
@@ -39,7 +39,7 @@ export function MemberActions({
 }) {
 	const [isChangingRole, setIsChangingRole] = useState(false);
 	const { refetch: refetchSession } = authClient.useSession();
-	const plan = useCurrentPlan();
+	const { plan } = useCurrentPlan();
 	const navigate = useNavigate();
 
 	const availableRoles = getAvailableRoleChanges(


### PR DESCRIPTION
## Summary
- `useCurrentPlan` was treating an empty `subscriptions` live-query result as "loaded," so the automations layout's first-render redirect effect could fire `userPlan === "free"` for paid users while the collection was still syncing — bouncing them to `/v2-workspaces` before their plan resolved.
- Switched `useCurrentPlan` to return `{ plan, isReady }` driven by `useLiveQuery`'s `isReady`, surfaced `isReady` through `usePaywall`, and made `automations/layout.tsx` defer both the redirect effect and its render output until ready.
- Updated the two other `useCurrentPlan` callers (`OrganizationDropdown`, `MemberActions`) to destructure `plan` from the new return shape.

## Test plan
- [ ] Cold-load `/automations` as a pro user — no flash redirect to `/v2-workspaces`.
- [ ] Cold-load `/automations` as a free user — still redirects after subscriptions sync.
- [ ] Org dropdown still shows the correct plan badge (Pro/Enterprise/none).
- [ ] Member actions settings still gate on plan correctly.
- [ ] `bun run typecheck` and `bun run lint:fix` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined subscription and paywall state management logic to ensure consistent initialization tracking across application features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->