### PR TITLE
fix(desktop): include user-created dot directories in file search

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/CommandPalette/hooks/useV2FileSearch/useV2FileSearch.ts
+++ b/apps/desktop/src/renderer/screens/main/components/CommandPalette/hooks/useV2FileSearch/useV2FileSearch.ts
@@ -13,6 +13,7 @@ export function useV2FileSearch(
 			workspaceId: workspaceId ?? "",
 			query: trimmedQuery,
 			limit: SEARCH_LIMIT,
+			includeHidden: true,
 		},
 		{
 			enabled: Boolean(workspaceId) && trimmedQuery.length > 0,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/hooks/useFileSearch/useFileSearch.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/hooks/useFileSearch/useFileSearch.ts
@@ -26,6 +26,7 @@ export function useFileSearch({
 				includePattern,
 				excludePattern,
 				limit,
+				includeHidden: true,
 			},
 			{
 				enabled: Boolean(workspaceId) && trimmedQuery.length > 0,

--- a/packages/workspace-fs/src/search.test.ts
+++ b/packages/workspace-fs/src/search.test.ts
@@ -241,4 +241,25 @@ describe("searchFiles", () => {
 		expect(paths).toContain(nestedPath);
 		expect(paths).toHaveLength(2);
 	});
+
+	it("finds files inside user-created dot directories when includeHidden is true", async () => {
+		// Regression test for issue #3752: dot-prefixed directories created by
+		// the user (e.g. `.test/`, `.scripts/`) were excluded from file search
+		// even when callers opted in via includeHidden.
+		const rootPath = await createTempRoot();
+		const dotDirFilePath = path.join(rootPath, ".test", "exists.md");
+
+		await fs.mkdir(path.dirname(dotDirFilePath), { recursive: true });
+		await fs.writeFile(dotDirFilePath, "# exists\n");
+
+		const results = await searchFiles({
+			rootPath,
+			query: "exists.md",
+			includeHidden: true,
+		});
+
+		expect(results.map((result) => result.absolutePath)).toContain(
+			dotDirFilePath,
+		);
+	});
 });


### PR DESCRIPTION
## Description

Cmd+P and the Files panel both call `filesystem.searchFiles` without passing `includeHidden`, which defaults to `false`. The hidden-file filter (`isHiddenRelativePath` in `packages/workspace-fs/src/search.ts:597`) treats any path segment starting with `.` as hidden, so user-created directories like `.test/`, `.config/`, `.scripts/` were silently dropped from search results.

This PR flips the two renderer hooks (`useFileSearch.ts`, `useV2FileSearch.ts`) to pass `includeHidden: true`. Tooling noise (`.git`, `.next`, `.turbo`, `node_modules`, `dist`, `build`, `coverage`) is already filtered by `DEFAULT_IGNORE_PATTERNS` in the same file, so the change does not leak `.git/HEAD` or build-cache files into the fuzzy finder. The only behavior change is that user dot-directories and `.env*` files become findable when explicitly searched, matching VS Code / Cursor / Sublime defaults.

## Related Issues

Closes #3752

## Type of Change

- [x] Bug fix

## Testing

- Added a regression test in `packages/workspace-fs/src/search.test.ts` covering the issue's repro (`.test/exists.md` searchable by `exists.md` when `includeHidden: true`).
- `bun test packages/workspace-fs/src/search.test.ts` → 8 pass, 0 fail.
- `bun run --filter=@superset/workspace-fs typecheck` → exit 0.
- `bun run --filter=@superset/desktop typecheck` → exit 0.
- `bunx @biomejs/biome@2.4.2 check` on the three changed files → clean.

## Alternative considered (Fix B)

A larger refactor would replace the blanket dot-prefix exclusion in `isHiddenRelativePath` with reliance on the existing `defaultIgnoreMatchers` ignore set, so the renderer wouldn't need to opt in. Trade-off: bigger diff, touches the search-index cache key (`includeHidden` is part of it), affects callers beyond the renderer (chat file mentions, automations, project file search). Fix A solves the user-reported bug with minimal blast radius; Fix B can come later as a separate cleanup. Happy to switch this PR to Fix B if maintainers prefer — see the discussion on the linked issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File search functionality now includes hidden files and folders in search results, providing more comprehensive coverage across your workspace.

* **Tests**
  * Added test coverage to verify hidden file discovery works correctly in the search functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->