### PR TITLE
fix(docs): redirect docs root to /overview

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -29,12 +29,12 @@ const config = {
 		return [
 			{
 				source: "/",
-				destination: "/installation",
+				destination: "/overview",
 				permanent: false,
 			},
 			{
 				source: "/docs",
-				destination: "/installation",
+				destination: "/overview",
 				permanent: false,
 			},
 		];

--- a/apps/docs/src/app/sitemap.ts
+++ b/apps/docs/src/app/sitemap.ts
@@ -11,6 +11,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
 		url: `${baseUrl}${page.url}`,
 		lastModified: new Date(),
 		changeFrequency: "weekly" as const,
-		priority: page.url === "/installation" ? 1.0 : 0.8,
+		priority: page.url === "/overview" ? 1.0 : 0.8,
 	}));
 }


### PR DESCRIPTION
## Summary
- `docs.superset.sh/` was redirecting to `/installation`, but that page was removed when install+overview were merged in #3926, leaving the root URL pointing at a 404.
- Update the root and `/docs` redirects to point at `/overview` (the new landing page) and update the sitemap priority to match.

## Test plan
- [ ] Visit `https://docs.superset.sh/` on the deploy preview and confirm it lands on `/overview`
- [ ] Visit `https://docs.superset.sh/docs` and confirm it also lands on `/overview`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation site navigation to redirect the root path to the overview page.
  * Adjusted search and sitemap priorities to reflect the new documentation structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->