### PR TITLE
docs: correct Open Preset shortcut to Ctrl+1-9

### DIFF
--- a/apps/docs/content/docs/keyboard-shortcuts.mdx
+++ b/apps/docs/content/docs/keyboard-shortcuts.mdx
@@ -52,7 +52,7 @@ description: Customize hotkeys for common actions
 | Next Tab | ⌘⌥→ |
 | Previous Pane | ⌘⇧← |
 | Next Pane | ⌘⇧→ |
-| Open Preset 1-9 | ⌘⇧1-9 |
+| Open Preset 1-9 | ⌃1-9 |
 
 ## Window
 


### PR DESCRIPTION
## Description

The Keyboard Shortcuts page listed "Open Preset 1-9" as `⌘⇧1-9` (Cmd+Shift+1-9), but the actual default in `apps/desktop/src/renderer/hotkeys/registry.ts:480-524` is `ctrl+1` through `ctrl+9` on all platforms — a completely different chord. Updated to `⌃1-9` to match the registry, consistent with the Mac-symbol style used for every other shortcut on the page.

## Verified against

- `apps/desktop/src/renderer/hotkeys/registry.ts:480-524` — `key: { mac: "ctrl+1", windows: "ctrl+1", linux: "ctrl+1" }` for OPEN_PRESET_1 through OPEN_PRESET_9.
- `README.md:164` — `| Ctrl+1-9 | Open preset 1-9 |`.
- `apps/desktop/plans/20260411-v2-preset-parity.md:103` — "hotkeys Ctrl+1-9".

## Type of Change

- [x] Documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Terminal keyboard shortcut for opening presets from `⌘⇧1-9` to `⌃1-9`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->