### PR TITLE
style(panes): match v2 tab + add-button styling to v1

### DIFF
--- a/packages/panes/src/react/components/Workspace/components/TabBar/TabBar.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/TabBar.tsx
@@ -45,8 +45,8 @@ function AddTabButton<_TData>({
 }) {
 	const button = (
 		<Button
-			className="h-full w-full rounded-none border-0 bg-transparent px-0 text-muted-foreground shadow-none hover:bg-tertiary/20 hover:text-foreground"
-			size="sm"
+			className="size-7 rounded-md border border-border/60 bg-muted/30 px-1 text-muted-foreground shadow-none hover:bg-accent/60 hover:text-foreground"
+			size="icon"
 			type="button"
 			variant="ghost"
 		>
@@ -168,7 +168,7 @@ export function TabBar<TData>({
 				ref={setRootRef}
 				className="group/root-tabs flex h-10 min-w-0 shrink-0 items-stretch border-b border-border bg-background"
 			>
-				<div className="flex h-full w-10 shrink-0 items-stretch bg-background">
+				<div className="flex h-full w-10 shrink-0 items-center justify-center bg-background">
 					<AddTabButton renderAddTabMenu={renderAddTabMenu} />
 				</div>
 				<div className="flex min-w-0 flex-1 items-stretch" />
@@ -215,14 +215,14 @@ export function TabBar<TData>({
 						/>
 					)}
 					{!hasHorizontalOverflow && (
-						<div className="flex h-full w-10 shrink-0 items-stretch">
+						<div className="flex h-full w-10 shrink-0 items-center justify-center">
 							<AddTabButton renderAddTabMenu={renderAddTabMenu} />
 						</div>
 					)}
 				</div>
 			</OverflowFadeContainer>
 			{hasHorizontalOverflow && (
-				<div className="flex h-full w-10 shrink-0 items-stretch bg-background">
+				<div className="flex h-full w-10 shrink-0 items-center justify-center bg-background">
 					<AddTabButton renderAddTabMenu={renderAddTabMenu} />
 				</div>
 			)}

--- a/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
@@ -113,7 +113,7 @@ export function TabItem<TData>({
 					className={cn(
 						"group relative flex h-full w-full items-center border-r border-border transition-colors",
 						isActive
-							? "bg-muted text-foreground"
+							? "bg-border/30 text-foreground"
 							: "text-muted-foreground/70 hover:bg-tertiary/20 hover:text-muted-foreground",
 						isPaneOver && "bg-primary/5",
 						isDragging && "opacity-30",


### PR DESCRIPTION
## Summary
- Active tab uses `bg-border/30` (was `bg-muted`), matching the lighter v1 active state from `GroupItem`.
- Add-tab button is a 28px chip with a `border-border/60` outline and `bg-muted/30` fill, matching the compact v1 `AddTabButton`.
- The 40px add-button cells switched from `items-stretch` to `items-center justify-center` so the chip sits centered with breathing room instead of filling the cell.

## Test plan
- [ ] Open a v2 workspace; confirm the active tab background tone matches v1
- [ ] Confirm the add-tab (+) button renders as a small bordered chip, not a full-cell button
- [ ] Hover the add-tab button — `bg-accent/60` hover state, no layout shift
- [ ] Drag a tab/pane onto the tab bar; insert indicator, drop, and reorder still behave normally
- [ ] With many tabs (overflow), confirm the trailing add-button cell still centers the chip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the "add tab" button appearance and positioning within the tab bar, making it more compact and centered.
  * Refined the active tab visual styling for improved visual distinction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->