### PR TITLE
feat(desktop): workspace pane store registry (v2 PR 3)

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-key-event-handler.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-key-event-handler.test.ts
@@ -85,7 +85,7 @@ describe("createTerminalKeyEventHandler", () => {
 		expect(xterm.input).not.toHaveBeenCalled();
 	});
 
-	it("treats Node-style \"darwin\" platform as Mac, not Windows", () => {
+	it('treats Node-style "darwin" platform as Mac, not Windows', () => {
 		const xterm = terminal();
 		const event = keyboardEvent({
 			key: "Enter",

--- a/apps/desktop/src/renderer/lib/workspace-pane-registry/addLaunchPanes.test.ts
+++ b/apps/desktop/src/renderer/lib/workspace-pane-registry/addLaunchPanes.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+	createCollection,
+	localStorageCollectionOptions,
+} from "@tanstack/react-db";
+import type {
+	ChatPaneData,
+	TerminalPaneData,
+} from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
+import {
+	type WorkspaceLocalStateRow,
+	workspaceLocalStateSchema,
+} from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
+import { addLaunchPanes } from "./addLaunchPanes";
+import {
+	__resetWorkspacePaneRegistryForTests,
+	getOrCreateWorkspacePaneStore,
+	initWorkspacePaneRegistry,
+} from "./workspace-pane-registry";
+
+const PROJECT_ID = crypto.randomUUID();
+const WORKSPACE_ID = crypto.randomUUID();
+
+let collection: ReturnType<typeof makeCollection>;
+
+function makeCollection() {
+	if (typeof globalThis.localStorage === "undefined") {
+		const store = new Map<string, string>();
+		(globalThis as { localStorage: Storage }).localStorage = {
+			getItem: (k) => store.get(k) ?? null,
+			setItem: (k, v) => {
+				store.set(k, v);
+			},
+			removeItem: (k) => {
+				store.delete(k);
+			},
+			clear: () => store.clear(),
+			key: () => null,
+			length: 0,
+		};
+	}
+	return createCollection(
+		localStorageCollectionOptions({
+			id: `test-v2-workspace-local-state-${Math.random()}`,
+			storageKey: `test-v2-workspace-local-state-${Math.random()}`,
+			schema: workspaceLocalStateSchema,
+			getKey: (item) => item.workspaceId,
+		}),
+	);
+}
+
+function seedRow(
+	workspaceId: string,
+	overrides: Partial<WorkspaceLocalStateRow> = {},
+): void {
+	collection.insert({
+		workspaceId,
+		createdAt: new Date(),
+		sidebarState: {
+			projectId: PROJECT_ID,
+			tabOrder: 0,
+			sectionId: null,
+			changesFilter: { kind: "all" },
+			activeTab: "changes",
+			isHidden: false,
+		},
+		paneLayout: { version: 1, tabs: [], activeTabId: null },
+		viewedFiles: [],
+		recentlyViewedFiles: [],
+		...overrides,
+	});
+}
+
+beforeEach(() => {
+	collection = makeCollection();
+	initWorkspacePaneRegistry({ v2WorkspaceLocalState: collection });
+	seedRow(WORKSPACE_ID);
+});
+
+afterEach(() => {
+	__resetWorkspacePaneRegistryForTests();
+});
+
+describe("addLaunchPanes", () => {
+	it("is a no-op for an empty array", () => {
+		addLaunchPanes(WORKSPACE_ID, []);
+		const store = getOrCreateWorkspacePaneStore(WORKSPACE_ID);
+		expect(store.getState().tabs).toHaveLength(0);
+	});
+
+	it("adds a tab per terminal launch with no initialCommand", () => {
+		addLaunchPanes(WORKSPACE_ID, [
+			{ kind: "terminal", terminalId: "t-1", label: "Codex" },
+			{ kind: "terminal", terminalId: "t-2" },
+		]);
+		const store = getOrCreateWorkspacePaneStore(WORKSPACE_ID);
+		expect(store.getState().tabs).toHaveLength(2);
+		const all = store.getState().tabs.flatMap((t) => Object.values(t.panes));
+		expect(all).toHaveLength(2);
+		for (const pane of all) {
+			expect(pane.kind).toBe("terminal");
+			const data = pane.data as TerminalPaneData;
+			expect(data.terminalId).toMatch(/^t-/);
+			expect(data.initialCommand).toBeUndefined();
+		}
+	});
+
+	it("adds a tab per chat launch", () => {
+		addLaunchPanes(WORKSPACE_ID, [
+			{ kind: "chat", chatSessionId: "s-1", label: "Claude" },
+		]);
+		const store = getOrCreateWorkspacePaneStore(WORKSPACE_ID);
+		const tab = store.getState().tabs[0];
+		expect(tab).toBeDefined();
+		const pane = Object.values(tab?.panes)[0];
+		expect(pane?.kind).toBe("chat");
+		const data = pane?.data as ChatPaneData;
+		expect(data.sessionId).toBe("s-1");
+	});
+
+	it("dedupes by terminalId on repeat calls", () => {
+		addLaunchPanes(WORKSPACE_ID, [{ kind: "terminal", terminalId: "t-1" }]);
+		addLaunchPanes(WORKSPACE_ID, [{ kind: "terminal", terminalId: "t-1" }]);
+		const store = getOrCreateWorkspacePaneStore(WORKSPACE_ID);
+		expect(store.getState().tabs).toHaveLength(1);
+	});
+
+	it("dedupes by chatSessionId on repeat calls", () => {
+		addLaunchPanes(WORKSPACE_ID, [{ kind: "chat", chatSessionId: "s-1" }]);
+		addLaunchPanes(WORKSPACE_ID, [{ kind: "chat", chatSessionId: "s-1" }]);
+		const store = getOrCreateWorkspacePaneStore(WORKSPACE_ID);
+		expect(store.getState().tabs).toHaveLength(1);
+	});
+
+	it("focuses the existing pane when called with a duplicate id", () => {
+		addLaunchPanes(WORKSPACE_ID, [
+			{ kind: "terminal", terminalId: "t-1" },
+			{ kind: "terminal", terminalId: "t-2" },
+		]);
+		const store = getOrCreateWorkspacePaneStore(WORKSPACE_ID);
+		const firstTabId = store.getState().tabs[0]?.id;
+		if (!firstTabId) throw new Error("expected at least one tab to be added");
+
+		addLaunchPanes(WORKSPACE_ID, [{ kind: "terminal", terminalId: "t-1" }]);
+		expect(store.getState().activeTabId).toBe(firstTabId);
+	});
+
+	it("handles a mixed terminal + chat batch", () => {
+		addLaunchPanes(WORKSPACE_ID, [
+			{ kind: "terminal", terminalId: "t-1" },
+			{ kind: "chat", chatSessionId: "s-1" },
+		]);
+		const store = getOrCreateWorkspacePaneStore(WORKSPACE_ID);
+		const kinds = store
+			.getState()
+			.tabs.flatMap((t) => Object.values(t.panes).map((p) => p.kind))
+			.sort();
+		expect(kinds).toEqual(["chat", "terminal"]);
+	});
+});

--- a/apps/desktop/src/renderer/lib/workspace-pane-registry/addLaunchPanes.test.ts
+++ b/apps/desktop/src/renderer/lib/workspace-pane-registry/addLaunchPanes.test.ts
@@ -12,9 +12,8 @@ import {
 	workspaceLocalStateSchema,
 } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
 import { addLaunchPanes } from "./addLaunchPanes";
-// __resetWorkspacePaneRegistryForTests is imported directly from the impl
-// file rather than the barrel — it's a test-only helper and shouldn't
-// leak onto the public API surface.
+// Imported from the impl file rather than the barrel — the test-reset
+// helper is intentionally not part of the public API surface.
 import {
 	__resetWorkspacePaneRegistryForTests,
 	getOrCreateWorkspacePaneStore,

--- a/apps/desktop/src/renderer/lib/workspace-pane-registry/addLaunchPanes.test.ts
+++ b/apps/desktop/src/renderer/lib/workspace-pane-registry/addLaunchPanes.test.ts
@@ -12,6 +12,9 @@ import {
 	workspaceLocalStateSchema,
 } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
 import { addLaunchPanes } from "./addLaunchPanes";
+// __resetWorkspacePaneRegistryForTests is imported directly from the impl
+// file rather than the barrel — it's a test-only helper and shouldn't
+// leak onto the public API surface.
 import {
 	__resetWorkspacePaneRegistryForTests,
 	getOrCreateWorkspacePaneStore,

--- a/apps/desktop/src/renderer/lib/workspace-pane-registry/addLaunchPanes.ts
+++ b/apps/desktop/src/renderer/lib/workspace-pane-registry/addLaunchPanes.ts
@@ -1,0 +1,115 @@
+import type { Pane } from "@superset/panes";
+import type {
+	ChatPaneData,
+	PaneViewerData,
+	TerminalPaneData,
+} from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
+import { getOrCreateWorkspacePaneStore } from "./workspace-pane-registry";
+
+export type LaunchPaneInput =
+	| { kind: "terminal"; terminalId: string; label?: string }
+	| { kind: "chat"; chatSessionId: string; label?: string };
+
+interface PaneLocation {
+	tabId: string;
+	pane: Pane<PaneViewerData>;
+}
+
+/**
+ * Add panes to a workspace's pane store for sessions that the host
+ * already started (e.g. the result of `workspace.create()`). Each
+ * launch becomes its own tab. Existing panes for the same session id
+ * are deduplicated and refocused — calling this twice with the same
+ * launch is idempotent.
+ *
+ * Attach-only: terminal launches do NOT carry an `initialCommand`.
+ * The terminal pane attaches to a host-side process that's already
+ * running. The legacy "renderer-mints-id, embeds-command" flow used
+ * by `useV2PresetExecution` and the pending-row launch path is
+ * unchanged and uses `addTab` directly.
+ *
+ * If the workspace has no `v2WorkspaceLocalState` row yet (e.g. this
+ * runs before the route mounts and `ensureWorkspaceInSidebar` runs),
+ * the panes are added to the in-memory store. They persist when the
+ * row is later inserted and the next store change writes back.
+ */
+export function addLaunchPanes(
+	workspaceId: string,
+	launches: LaunchPaneInput[],
+): void {
+	if (launches.length === 0) return;
+
+	const store = getOrCreateWorkspacePaneStore(workspaceId);
+	let lastFocusedLocation: PaneLocation | null = null;
+
+	for (const launch of launches) {
+		const existing = findExistingPane(store.getState(), launch);
+		if (existing) {
+			lastFocusedLocation = existing;
+			continue;
+		}
+
+		if (launch.kind === "terminal") {
+			const data: TerminalPaneData = { terminalId: launch.terminalId };
+			store.getState().addTab({
+				titleOverride: launch.label,
+				panes: [
+					{
+						kind: "terminal",
+						titleOverride: launch.label,
+						data: data as PaneViewerData,
+					},
+				],
+			});
+		} else {
+			const data: ChatPaneData = { sessionId: launch.chatSessionId };
+			store.getState().addTab({
+				titleOverride: launch.label,
+				panes: [
+					{
+						kind: "chat",
+						titleOverride: launch.label,
+						data: data as PaneViewerData,
+					},
+				],
+			});
+		}
+
+		// addTab focuses the new tab itself (sets activeTabId). Capture the
+		// landing pane so we can re-focus on the dedupe-only path below if
+		// the dupe was the last entry.
+		const newLocation = findExistingPane(store.getState(), launch);
+		if (newLocation) lastFocusedLocation = newLocation;
+	}
+
+	if (lastFocusedLocation) {
+		store.getState().setActivePane({
+			tabId: lastFocusedLocation.tabId,
+			paneId: lastFocusedLocation.pane.id,
+		});
+	}
+}
+
+function findExistingPane(
+	state: ReturnType<
+		ReturnType<typeof getOrCreateWorkspacePaneStore>["getState"]
+	>,
+	launch: LaunchPaneInput,
+): PaneLocation | null {
+	for (const tab of state.tabs) {
+		for (const pane of Object.values(tab.panes)) {
+			if (launch.kind === "terminal" && pane.kind === "terminal") {
+				const data = pane.data as TerminalPaneData;
+				if (data.terminalId === launch.terminalId) {
+					return { tabId: tab.id, pane };
+				}
+			} else if (launch.kind === "chat" && pane.kind === "chat") {
+				const data = pane.data as ChatPaneData;
+				if (data.sessionId === launch.chatSessionId) {
+					return { tabId: tab.id, pane };
+				}
+			}
+		}
+	}
+	return null;
+}

--- a/apps/desktop/src/renderer/lib/workspace-pane-registry/addLaunchPanes.ts
+++ b/apps/desktop/src/renderer/lib/workspace-pane-registry/addLaunchPanes.ts
@@ -16,22 +16,18 @@ interface PaneLocation {
 }
 
 /**
- * Add panes to a workspace's pane store for sessions that the host
- * already started (e.g. the result of `workspace.create()`). Each
- * launch becomes its own tab. Existing panes for the same session id
- * are deduplicated and refocused — calling this twice with the same
- * launch is idempotent.
+ * Add panes to a workspace's pane store for sessions the host already
+ * started (e.g. the result of `workspace.create()`). Each launch
+ * becomes its own tab; calling twice with the same id dedupes and
+ * refocuses. Safe to call before the workspace route mounts — the
+ * registry takes care of persisting the in-memory tabs to
+ * `v2WorkspaceLocalState` once `ensureWorkspaceInSidebar` inserts the
+ * row.
  *
- * Attach-only: terminal launches do NOT carry an `initialCommand`.
- * The terminal pane attaches to a host-side process that's already
- * running. The legacy "renderer-mints-id, embeds-command" flow used
- * by `useV2PresetExecution` and the pending-row launch path is
- * unchanged and uses `addTab` directly.
- *
- * If the workspace has no `v2WorkspaceLocalState` row yet (e.g. this
- * runs before the route mounts and `ensureWorkspaceInSidebar` runs),
- * the panes are added to the in-memory store. They persist when the
- * row is later inserted and the next store change writes back.
+ * Attach-only: terminal launches do not carry `initialCommand`. The
+ * legacy renderer-mints-id + embedded-command flow used by
+ * `useV2PresetExecution` and the pending-row launch path is unchanged
+ * and uses `addTab` directly.
  */
 export function addLaunchPanes(
 	workspaceId: string,

--- a/apps/desktop/src/renderer/lib/workspace-pane-registry/index.ts
+++ b/apps/desktop/src/renderer/lib/workspace-pane-registry/index.ts
@@ -1,0 +1,8 @@
+export { addLaunchPanes, type LaunchPaneInput } from "./addLaunchPanes";
+export {
+	__resetWorkspacePaneRegistryForTests,
+	dropWorkspacePaneStore,
+	getOrCreateWorkspacePaneStore,
+	initWorkspacePaneRegistry,
+	type WorkspacePaneRegistryDeps,
+} from "./workspace-pane-registry";

--- a/apps/desktop/src/renderer/lib/workspace-pane-registry/index.ts
+++ b/apps/desktop/src/renderer/lib/workspace-pane-registry/index.ts
@@ -1,6 +1,5 @@
 export { addLaunchPanes, type LaunchPaneInput } from "./addLaunchPanes";
 export {
-	__resetWorkspacePaneRegistryForTests,
 	dropWorkspacePaneStore,
 	getOrCreateWorkspacePaneStore,
 	initWorkspacePaneRegistry,

--- a/apps/desktop/src/renderer/lib/workspace-pane-registry/workspace-pane-registry.test.ts
+++ b/apps/desktop/src/renderer/lib/workspace-pane-registry/workspace-pane-registry.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+	createCollection,
+	localStorageCollectionOptions,
+} from "@tanstack/react-db";
+import {
+	type WorkspaceLocalStateRow,
+	workspaceLocalStateSchema,
+} from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
+import {
+	__resetWorkspacePaneRegistryForTests,
+	getOrCreateWorkspacePaneStore,
+	initWorkspacePaneRegistry,
+} from "./workspace-pane-registry";
+
+let collection: ReturnType<typeof makeCollection>;
+
+const PROJECT_ID = crypto.randomUUID();
+const WORKSPACE_ID = crypto.randomUUID();
+const OTHER_WORKSPACE_ID = crypto.randomUUID();
+
+function makeCollection() {
+	// localStorage isn't available in bun:test by default; provide a shim.
+	if (typeof globalThis.localStorage === "undefined") {
+		const store = new Map<string, string>();
+		(globalThis as { localStorage: Storage }).localStorage = {
+			getItem: (k) => store.get(k) ?? null,
+			setItem: (k, v) => {
+				store.set(k, v);
+			},
+			removeItem: (k) => {
+				store.delete(k);
+			},
+			clear: () => store.clear(),
+			key: () => null,
+			length: 0,
+		};
+	}
+	return createCollection(
+		localStorageCollectionOptions({
+			id: `test-v2-workspace-local-state-${Math.random()}`,
+			storageKey: `test-v2-workspace-local-state-${Math.random()}`,
+			schema: workspaceLocalStateSchema,
+			getKey: (item) => item.workspaceId,
+		}),
+	);
+}
+
+function seedRow(
+	workspaceId: string,
+	overrides: Partial<WorkspaceLocalStateRow> = {},
+): void {
+	collection.insert({
+		workspaceId,
+		createdAt: new Date(),
+		sidebarState: {
+			projectId: PROJECT_ID,
+			tabOrder: 0,
+			sectionId: null,
+			changesFilter: { kind: "all" },
+			activeTab: "changes",
+			isHidden: false,
+		},
+		paneLayout: { version: 1, tabs: [], activeTabId: null },
+		viewedFiles: [],
+		recentlyViewedFiles: [],
+		...overrides,
+	});
+}
+
+beforeEach(() => {
+	collection = makeCollection();
+	initWorkspacePaneRegistry({ v2WorkspaceLocalState: collection });
+});
+
+afterEach(() => {
+	__resetWorkspacePaneRegistryForTests();
+});
+
+describe("workspace-pane-registry", () => {
+	it("returns the same store for the same workspaceId", () => {
+		const a = getOrCreateWorkspacePaneStore(WORKSPACE_ID);
+		const b = getOrCreateWorkspacePaneStore(WORKSPACE_ID);
+		expect(a).toBe(b);
+	});
+
+	it("returns different stores for different workspaceIds", () => {
+		const a = getOrCreateWorkspacePaneStore(WORKSPACE_ID);
+		const b = getOrCreateWorkspacePaneStore(OTHER_WORKSPACE_ID);
+		expect(a).not.toBe(b);
+	});
+
+	it("seeds the store from a pre-existing row's paneLayout", () => {
+		seedRow(WORKSPACE_ID, {
+			paneLayout: {
+				version: 1,
+				tabs: [
+					{
+						id: "tab-1",
+						titleOverride: undefined,
+						createdAt: 0,
+						activePaneId: "pane-1",
+						layout: { type: "pane", paneId: "pane-1" },
+						panes: {
+							"pane-1": {
+								id: "pane-1",
+								kind: "terminal",
+								data: { terminalId: "t1" },
+							},
+						},
+					},
+				],
+				activeTabId: "tab-1",
+			},
+		});
+
+		const store = getOrCreateWorkspacePaneStore(WORKSPACE_ID);
+		expect(store.getState().tabs).toHaveLength(1);
+		expect(store.getState().activeTabId).toBe("tab-1");
+	});
+
+	it("writes store changes back to the row when the row exists", () => {
+		seedRow(WORKSPACE_ID);
+		const store = getOrCreateWorkspacePaneStore(WORKSPACE_ID);
+
+		store.getState().addTab({
+			panes: [{ kind: "terminal", data: { terminalId: "t1" } }],
+		});
+
+		const row = collection.get(WORKSPACE_ID);
+		expect(row?.paneLayout.tabs).toHaveLength(1);
+	});
+
+	it("does not throw when writing back with no row present yet", () => {
+		const store = getOrCreateWorkspacePaneStore(WORKSPACE_ID);
+		// addTab fires the subscriber; should silently skip the write because
+		// no row exists. State is preserved in-memory.
+		expect(() =>
+			store.getState().addTab({
+				panes: [{ kind: "terminal", data: { terminalId: "t1" } }],
+			}),
+		).not.toThrow();
+		expect(store.getState().tabs).toHaveLength(1);
+	});
+
+	it("pushes external row updates into the store", async () => {
+		seedRow(WORKSPACE_ID);
+		const store = getOrCreateWorkspacePaneStore(WORKSPACE_ID);
+		expect(store.getState().tabs).toHaveLength(0);
+
+		collection.update(WORKSPACE_ID, (draft) => {
+			draft.paneLayout = {
+				version: 1,
+				tabs: [
+					{
+						id: "tab-2",
+						titleOverride: undefined,
+						createdAt: 0,
+						activePaneId: "pane-2",
+						layout: { type: "pane", paneId: "pane-2" },
+						panes: {
+							"pane-2": {
+								id: "pane-2",
+								kind: "chat",
+								data: { sessionId: "s1" },
+							},
+						},
+					},
+				],
+				activeTabId: "tab-2",
+			};
+		});
+
+		// Allow the subscribe handler to flush.
+		await new Promise((r) => setTimeout(r, 0));
+		expect(store.getState().tabs).toHaveLength(1);
+		expect(store.getState().activeTabId).toBe("tab-2");
+	});
+
+	it("throws if used before init", () => {
+		__resetWorkspacePaneRegistryForTests();
+		expect(() => getOrCreateWorkspacePaneStore(WORKSPACE_ID)).toThrow(
+			/not initialized/,
+		);
+	});
+});

--- a/apps/desktop/src/renderer/lib/workspace-pane-registry/workspace-pane-registry.test.ts
+++ b/apps/desktop/src/renderer/lib/workspace-pane-registry/workspace-pane-registry.test.ts
@@ -7,14 +7,13 @@ import {
 	type WorkspaceLocalStateRow,
 	workspaceLocalStateSchema,
 } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
+// Imported from the impl file rather than the barrel — the test-reset
+// helper is intentionally not part of the public API surface.
 import {
 	__resetWorkspacePaneRegistryForTests,
 	getOrCreateWorkspacePaneStore,
 	initWorkspacePaneRegistry,
 } from "./workspace-pane-registry";
-
-// Test-only — imported directly from the impl file so it doesn't leak
-// onto the public barrel (`./index.ts`).
 
 let collection: ReturnType<typeof makeCollection>;
 

--- a/apps/desktop/src/renderer/lib/workspace-pane-registry/workspace-pane-registry.test.ts
+++ b/apps/desktop/src/renderer/lib/workspace-pane-registry/workspace-pane-registry.test.ts
@@ -13,6 +13,9 @@ import {
 	initWorkspacePaneRegistry,
 } from "./workspace-pane-registry";
 
+// Test-only — imported directly from the impl file so it doesn't leak
+// onto the public barrel (`./index.ts`).
+
 let collection: ReturnType<typeof makeCollection>;
 
 const PROJECT_ID = crypto.randomUUID();
@@ -141,6 +144,29 @@ describe("workspace-pane-registry", () => {
 			}),
 		).not.toThrow();
 		expect(store.getState().tabs).toHaveLength(1);
+	});
+
+	it("persists pre-mount panes when the row is later inserted with empty layout", async () => {
+		// Simulates the addLaunchPanes-before-route-mount flow: tabs are
+		// added to the store before the workspace row exists, then
+		// `ensureWorkspaceInSidebar` inserts the row with EMPTY paneLayout.
+		// The registry must (a) not wipe the in-memory tabs, and (b) push
+		// the store's state into the freshly-inserted row so the data
+		// survives an immediate app restart.
+		const store = getOrCreateWorkspacePaneStore(WORKSPACE_ID);
+		store.getState().addTab({
+			panes: [{ kind: "terminal", data: { terminalId: "t1" } }],
+		});
+		expect(store.getState().tabs).toHaveLength(1);
+
+		seedRow(WORKSPACE_ID); // inserts with EMPTY paneLayout
+		await new Promise((r) => setTimeout(r, 0));
+
+		// Store still has the pre-mount tab.
+		expect(store.getState().tabs).toHaveLength(1);
+		// Row has been updated with the pre-mount tab too.
+		const row = collection.get(WORKSPACE_ID);
+		expect(row?.paneLayout.tabs).toHaveLength(1);
 	});
 
 	it("pushes external row updates into the store", async () => {

--- a/apps/desktop/src/renderer/lib/workspace-pane-registry/workspace-pane-registry.ts
+++ b/apps/desktop/src/renderer/lib/workspace-pane-registry/workspace-pane-registry.ts
@@ -1,0 +1,175 @@
+import {
+	createWorkspaceStore,
+	type WorkspaceState,
+	type WorkspaceStore,
+} from "@superset/panes";
+import type {
+	Collection,
+	LocalStorageCollectionUtils,
+} from "@tanstack/react-db";
+import type { PaneViewerData } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
+import type {
+	WorkspaceLocalStateRow,
+	workspaceLocalStateSchema,
+} from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
+import type { z } from "zod";
+import type { StoreApi } from "zustand/vanilla";
+
+type V2WorkspaceLocalStateCollection = Collection<
+	WorkspaceLocalStateRow,
+	string,
+	LocalStorageCollectionUtils,
+	typeof workspaceLocalStateSchema,
+	z.input<typeof workspaceLocalStateSchema>
+>;
+
+export interface WorkspacePaneRegistryDeps {
+	v2WorkspaceLocalState: V2WorkspaceLocalStateCollection;
+}
+
+interface RegistryEntry {
+	store: StoreApi<WorkspaceStore<PaneViewerData>>;
+	unsubscribeStore: () => void;
+	unsubscribeCollection: () => void;
+}
+
+const EMPTY_STATE: WorkspaceState<PaneViewerData> = {
+	version: 1,
+	tabs: [],
+	activeTabId: null,
+};
+
+let deps: WorkspacePaneRegistryDeps | null = null;
+const registry = new Map<string, RegistryEntry>();
+
+function getSnapshot(state: WorkspaceState<PaneViewerData>): string {
+	return JSON.stringify(state);
+}
+
+/**
+ * Wire the registry to the active org's collections. Call once at app
+ * boot, after `CollectionsProvider` resolves an active organization.
+ *
+ * Calling this with a new collections instance (e.g. after switching
+ * organizations) drops every existing store and re-initializes against
+ * the new collections. The previous workspaces' panes won't be
+ * accessible until they're re-opened against the new org's data.
+ */
+export function initWorkspacePaneRegistry(
+	nextDeps: WorkspacePaneRegistryDeps,
+): void {
+	if (deps && deps !== nextDeps) {
+		for (const entry of registry.values()) {
+			entry.unsubscribeStore();
+			entry.unsubscribeCollection();
+		}
+		registry.clear();
+	}
+	deps = nextDeps;
+}
+
+/**
+ * Get the pane store for `workspaceId`, creating + persisting-wiring it
+ * on first call. Subsequent calls return the same store instance.
+ *
+ * Persistence: on first creation, the store is seeded from the matching
+ * `v2WorkspaceLocalState` row (if present) and then bidirectionally
+ * synced — store changes write back to the row (when it exists), and
+ * external row changes push into the store. A snapshot guard prevents
+ * the two from echoing each other.
+ *
+ * If the row doesn't exist yet, the write-back is silently skipped
+ * (the row is normally inserted by `ensureWorkspaceInSidebar` on route
+ * mount). Once the row appears, the next store change propagates.
+ */
+export function getOrCreateWorkspacePaneStore(
+	workspaceId: string,
+): StoreApi<WorkspaceStore<PaneViewerData>> {
+	if (!deps) {
+		throw new Error(
+			"workspace-pane-registry not initialized — call initWorkspacePaneRegistry first",
+		);
+	}
+	const activeDeps = deps;
+
+	const existing = registry.get(workspaceId);
+	if (existing) return existing.store;
+
+	const initialRow = activeDeps.v2WorkspaceLocalState.get(workspaceId);
+	const initialPaneLayout =
+		(initialRow?.paneLayout as WorkspaceState<PaneViewerData> | undefined) ??
+		EMPTY_STATE;
+
+	const store = createWorkspaceStore<PaneViewerData>({
+		initialState: initialPaneLayout,
+	});
+	let lastSyncedSnapshot = getSnapshot(initialPaneLayout);
+
+	const unsubscribeStore = store.subscribe((next) => {
+		const nextSnapshot = getSnapshot({
+			version: next.version,
+			tabs: next.tabs,
+			activeTabId: next.activeTabId,
+		});
+		if (nextSnapshot === lastSyncedSnapshot) return;
+		if (!activeDeps.v2WorkspaceLocalState.get(workspaceId)) {
+			// Row not present yet (pre-mount or pre-migration). The next
+			// change after the row is inserted will sync.
+			return;
+		}
+		activeDeps.v2WorkspaceLocalState.update(workspaceId, (draft) => {
+			draft.paneLayout = {
+				version: next.version,
+				tabs: next.tabs,
+				activeTabId: next.activeTabId,
+			};
+		});
+		lastSyncedSnapshot = nextSnapshot;
+	});
+
+	const subscription = activeDeps.v2WorkspaceLocalState.subscribeChanges(
+		(changes) => {
+			for (const change of changes) {
+				if (change.key !== workspaceId) continue;
+				if (change.type === "delete") continue;
+				const layout = change.value?.paneLayout as
+					| WorkspaceState<PaneViewerData>
+					| undefined;
+				if (!layout) continue;
+				const incoming = getSnapshot(layout);
+				if (incoming === lastSyncedSnapshot) continue;
+				lastSyncedSnapshot = incoming;
+				store.getState().replaceState(layout);
+			}
+		},
+	);
+
+	registry.set(workspaceId, {
+		store,
+		unsubscribeStore,
+		unsubscribeCollection: () => subscription.unsubscribe(),
+	});
+	return store;
+}
+
+/**
+ * Drop the store for `workspaceId` and unsubscribe its sync. Called
+ * when a workspace is removed; safe to call when no entry exists.
+ */
+export function dropWorkspacePaneStore(workspaceId: string): void {
+	const entry = registry.get(workspaceId);
+	if (!entry) return;
+	entry.unsubscribeStore();
+	entry.unsubscribeCollection();
+	registry.delete(workspaceId);
+}
+
+/** Test-only: tear down all stores and clear the deps. */
+export function __resetWorkspacePaneRegistryForTests(): void {
+	for (const entry of registry.values()) {
+		entry.unsubscribeStore();
+		entry.unsubscribeCollection();
+	}
+	registry.clear();
+	deps = null;
+}

--- a/apps/desktop/src/renderer/lib/workspace-pane-registry/workspace-pane-registry.ts
+++ b/apps/desktop/src/renderer/lib/workspace-pane-registry/workspace-pane-registry.ts
@@ -42,8 +42,27 @@ const EMPTY_STATE: WorkspaceState<PaneViewerData> = {
 let deps: WorkspacePaneRegistryDeps | null = null;
 const registry = new Map<string, RegistryEntry>();
 
-function getSnapshot(state: WorkspaceState<PaneViewerData>): string {
-	return JSON.stringify(state);
+/**
+ * Deterministic JSON serialization with deep key sorting. Used to
+ * compare store state against row state without false-positive
+ * mismatches when the two paths produce structurally equal objects
+ * but in different key orders (Immer `draft.paneLayout = ...` writes
+ * via the collection do not preserve insertion order).
+ */
+function getSnapshot(value: unknown): string {
+	return JSON.stringify(deepSortKeys(value));
+}
+
+function deepSortKeys(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(deepSortKeys);
+	if (value && typeof value === "object") {
+		const sorted: Record<string, unknown> = {};
+		for (const k of Object.keys(value as Record<string, unknown>).sort()) {
+			sorted[k] = deepSortKeys((value as Record<string, unknown>)[k]);
+		}
+		return sorted;
+	}
+	return value;
 }
 
 /**
@@ -137,7 +156,21 @@ export function getOrCreateWorkspacePaneStore(
 					| undefined;
 				if (!layout) continue;
 				const incoming = getSnapshot(layout);
-				if (incoming === lastSyncedSnapshot) continue;
+				// Always compare against the current store snapshot — the row
+				// state and store state should be structurally equivalent when
+				// the row event is an echo of our own write. Tanstack DB also
+				// delivers existing rows as initial-state `insert` events on
+				// subscribe; this guard ensures those don't wipe the store.
+				const currentState = store.getState();
+				const storeSnapshot = getSnapshot({
+					version: currentState.version,
+					tabs: currentState.tabs,
+					activeTabId: currentState.activeTabId,
+				});
+				if (incoming === storeSnapshot) {
+					lastSyncedSnapshot = incoming;
+					continue;
+				}
 				lastSyncedSnapshot = incoming;
 				store.getState().replaceState(layout);
 			}

--- a/apps/desktop/src/renderer/lib/workspace-pane-registry/workspace-pane-registry.ts
+++ b/apps/desktop/src/renderer/lib/workspace-pane-registry/workspace-pane-registry.ts
@@ -69,15 +69,19 @@ function deepSortKeys(value: unknown): unknown {
  * Wire the registry to the active org's collections. Call once at app
  * boot, after `CollectionsProvider` resolves an active organization.
  *
- * Calling this with a new collections instance (e.g. after switching
- * organizations) drops every existing store and re-initializes against
- * the new collections. The previous workspaces' panes won't be
- * accessible until they're re-opened against the new org's data.
+ * Calling this with a new `v2WorkspaceLocalState` collection instance
+ * (e.g. after switching organizations) drops every existing store and
+ * re-initializes against the new collection. Calling with the same
+ * collection instance is a no-op — important because the call site
+ * passes a fresh wrapper object each time, but the underlying
+ * collection is what determines org identity. Without the
+ * instance-level check, an accidental memo recomputation would silently
+ * drop every live store.
  */
 export function initWorkspacePaneRegistry(
 	nextDeps: WorkspacePaneRegistryDeps,
 ): void {
-	if (deps && deps !== nextDeps) {
+	if (deps && deps.v2WorkspaceLocalState !== nextDeps.v2WorkspaceLocalState) {
 		for (const entry of registry.values()) {
 			entry.unsubscribeStore();
 			entry.unsubscribeCollection();
@@ -156,19 +160,41 @@ export function getOrCreateWorkspacePaneStore(
 					| undefined;
 				if (!layout) continue;
 				const incoming = getSnapshot(layout);
-				// Always compare against the current store snapshot — the row
-				// state and store state should be structurally equivalent when
-				// the row event is an echo of our own write. Tanstack DB also
-				// delivers existing rows as initial-state `insert` events on
-				// subscribe; this guard ensures those don't wipe the store.
 				const currentState = store.getState();
 				const storeSnapshot = getSnapshot({
 					version: currentState.version,
 					tabs: currentState.tabs,
 					activeTabId: currentState.activeTabId,
 				});
+				// Already in sync. (This branch also catches Tanstack DB's
+				// initial-state `insert` events whose value matches what we
+				// seeded from when the store was created.)
 				if (incoming === storeSnapshot) {
 					lastSyncedSnapshot = incoming;
+					continue;
+				}
+				// Three-way reconciliation: incoming (row), storeSnapshot
+				// (memory), and lastSyncedSnapshot (last seen agreement).
+				//
+				// If storeSnapshot !== lastSyncedSnapshot, the store has
+				// unsynced mutations the row hasn't seen yet — typically
+				// addLaunchPanes ran before the row existed, then
+				// ensureWorkspaceInSidebar inserted the row with EMPTY
+				// paneLayout. Push the store back so those panes persist.
+				//
+				// Otherwise, the row diverges from the store while the store
+				// is still in sync with what we last wrote — the row was
+				// modified externally (migration, future cross-tab sync).
+				// Pull the row into the store.
+				if (storeSnapshot !== lastSyncedSnapshot) {
+					activeDeps.v2WorkspaceLocalState.update(workspaceId, (draft) => {
+						draft.paneLayout = {
+							version: currentState.version,
+							tabs: currentState.tabs,
+							activeTabId: currentState.activeTabId,
+						};
+					});
+					lastSyncedSnapshot = storeSnapshot;
 					continue;
 				}
 				lastSyncedSnapshot = incoming;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/useV2WorkspacePaneLayout.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/useV2WorkspacePaneLayout.ts
@@ -1,20 +1,6 @@
-import { createWorkspaceStore, type WorkspaceState } from "@superset/panes";
-import { eq } from "@tanstack/db";
-import { useLiveQuery } from "@tanstack/react-db";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useState } from "react";
+import { getOrCreateWorkspacePaneStore } from "renderer/lib/workspace-pane-registry";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
-import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
-import type { PaneViewerData } from "../../types";
-
-const EMPTY_STATE: WorkspaceState<PaneViewerData> = {
-	version: 1,
-	tabs: [],
-	activeTabId: null,
-};
-
-function getSnapshot(state: WorkspaceState<PaneViewerData>): string {
-	return JSON.stringify(state);
-}
 
 interface UseV2WorkspacePaneLayoutParams {
 	projectId: string;
@@ -25,76 +11,15 @@ export function useV2WorkspacePaneLayout({
 	projectId,
 	workspaceId,
 }: UseV2WorkspacePaneLayoutParams) {
-	const collections = useCollections();
 	const { ensureWorkspaceInSidebar } = useDashboardSidebarState();
-	const [store] = useState(() =>
-		createWorkspaceStore<PaneViewerData>({
-			initialState: EMPTY_STATE,
-		}),
-	);
-	const lastSyncedSnapshotRef = useRef(getSnapshot(EMPTY_STATE));
-
-	const { data: localWorkspaceRows = [] } = useLiveQuery(
-		(query) =>
-			query
-				.from({ v2WorkspaceLocalState: collections.v2WorkspaceLocalState })
-				.where(({ v2WorkspaceLocalState }) =>
-					eq(v2WorkspaceLocalState.workspaceId, workspaceId),
-				),
-		[collections, workspaceId],
-	);
-	const localWorkspaceState = localWorkspaceRows[0] ?? null;
-	const persistedPaneLayout = useMemo(
-		() =>
-			(localWorkspaceState?.paneLayout as
-				| WorkspaceState<PaneViewerData>
-				| undefined) ?? EMPTY_STATE,
-		[localWorkspaceState],
-	);
+	// Pull from the registry — same instance the create flow / addLaunchPanes
+	// write to. Persistence wiring lives in the registry; this hook just
+	// surfaces the store to the route and keeps the sidebar entry alive.
+	const [store] = useState(() => getOrCreateWorkspacePaneStore(workspaceId));
 
 	useEffect(() => {
 		ensureWorkspaceInSidebar(workspaceId, projectId);
 	}, [ensureWorkspaceInSidebar, projectId, workspaceId]);
-
-	useEffect(() => {
-		const nextSnapshot = getSnapshot(persistedPaneLayout);
-		if (nextSnapshot === lastSyncedSnapshotRef.current) {
-			return;
-		}
-
-		lastSyncedSnapshotRef.current = nextSnapshot;
-		store.getState().replaceState(persistedPaneLayout);
-	}, [persistedPaneLayout, store]);
-
-	useEffect(() => {
-		const unsubscribe = store.subscribe((nextStore) => {
-			const nextSnapshot = getSnapshot({
-				version: nextStore.version,
-				tabs: nextStore.tabs,
-				activeTabId: nextStore.activeTabId,
-			});
-			if (nextSnapshot === lastSyncedSnapshotRef.current) {
-				return;
-			}
-
-			if (!collections.v2WorkspaceLocalState.get(workspaceId)) {
-				return;
-			}
-
-			collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
-				draft.paneLayout = {
-					version: nextStore.version,
-					tabs: nextStore.tabs,
-					activeTabId: nextStore.activeTabId,
-				};
-			});
-			lastSyncedSnapshotRef.current = nextSnapshot;
-		});
-
-		return () => {
-			unsubscribe();
-		};
-	}, [collections, store, workspaceId]);
 
 	return { store };
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
@@ -1,6 +1,7 @@
 import type { Pane, WorkspaceState } from "@superset/panes";
 import { useCallback } from "react";
 import { terminalRuntimeRegistry } from "renderer/lib/terminal/terminal-runtime-registry";
+import { dropWorkspacePaneStore } from "renderer/lib/workspace-pane-registry";
 import { browserRuntimeRegistry } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry";
 import {
 	extractPaneIds,
@@ -462,6 +463,7 @@ export function useDashboardSidebarState() {
 			if (!workspace) return;
 			cleanupWorkspacePaneRuntimes([workspace]);
 			collections.v2WorkspaceLocalState.delete(workspaceId);
+			dropWorkspacePaneStore(workspaceId);
 		},
 		[collections],
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/CollectionsProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/CollectionsProvider.tsx
@@ -61,8 +61,16 @@ export function CollectionsProvider({ children }: { children: ReactNode }) {
 	// the active org's v2WorkspaceLocalState collection synchronously, so
 	// callers of getOrCreateWorkspacePaneStore — including the workspace
 	// route's `useState(() => ...)` initializer — see an initialized
-	// registry before they run. initWorkspacePaneRegistry is idempotent
-	// for the same deps, so strict-mode double-invokes are safe.
+	// registry before they run.
+	//
+	// Side effects in `useMemo` are not React-blessed (the docs reserve
+	// the right to recompute or discard memo work). The synchrony
+	// requirement here can't be satisfied by `useEffect`, which runs
+	// after render commits. Mitigation: `initWorkspacePaneRegistry`
+	// keys teardown on the `v2WorkspaceLocalState` *instance*, so any
+	// recomputation that happens to receive the same collection is a
+	// no-op rather than a state-clearing event. The only real teardown
+	// is on org switch, when the underlying collection actually changes.
 	const collections = useMemo(() => {
 		if (!activeOrganizationId) return null;
 		const next = getCollections(activeOrganizationId);

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/CollectionsProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/CollectionsProvider.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import { env } from "renderer/env.renderer";
 import { authClient } from "renderer/lib/auth-client";
+import { initWorkspacePaneRegistry } from "renderer/lib/workspace-pane-registry";
 import { MOCK_ORG_ID } from "shared/constants";
 import { getCollections, preloadCollections } from "./collections";
 
@@ -56,10 +57,20 @@ export function CollectionsProvider({ children }: { children: ReactNode }) {
 		preloadActiveOrganizationCollections(activeOrganizationId);
 	}, [activeOrganizationId]);
 
-	const collections = useMemo(
-		() => (activeOrganizationId ? getCollections(activeOrganizationId) : null),
-		[activeOrganizationId],
-	);
+	// Wire (or rewire on org switch) the workspace pane registry against
+	// the active org's v2WorkspaceLocalState collection synchronously, so
+	// callers of getOrCreateWorkspacePaneStore — including the workspace
+	// route's `useState(() => ...)` initializer — see an initialized
+	// registry before they run. initWorkspacePaneRegistry is idempotent
+	// for the same deps, so strict-mode double-invokes are safe.
+	const collections = useMemo(() => {
+		if (!activeOrganizationId) return null;
+		const next = getCollections(activeOrganizationId);
+		initWorkspacePaneRegistry({
+			v2WorkspaceLocalState: next.v2WorkspaceLocalState,
+		});
+		return next;
+	}, [activeOrganizationId]);
 
 	const contextValue = useMemo<CollectionsContextType | null>(
 		() => (collections ? { ...collections, switchOrganization } : null),

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
@@ -10,6 +10,7 @@ import {
 	markTerminalSessionReady,
 	rejectTerminalSessionReady,
 } from "renderer/lib/terminal/session-readiness";
+import { installTerminalKeyEventHandler } from "renderer/lib/terminal/terminal-key-event-handler";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import { killTerminalForPane } from "renderer/stores/tabs/utils/terminal-cleanup";
@@ -24,7 +25,6 @@ import {
 } from "../helpers";
 import { isPaneDestroyed } from "../pane-guards";
 import { coldRestoreState, pendingDetaches } from "../state";
-import { installTerminalKeyEventHandler } from "renderer/lib/terminal/terminal-key-event-handler";
 import type {
 	CreateOrAttachMutate,
 	CreateOrAttachResult,

--- a/packages/panes/src/react/components/Workspace/components/Tab/Tab.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/Tab.tsx
@@ -148,8 +148,15 @@ function LayoutNodeView<TData>({
 		const pane = tab.panes[node.paneId];
 		if (!pane) return null;
 
+		// key={pane.id} so React reconciles Pane instances by identity rather
+		// than position. Without this, switching the active tab to one that
+		// has a Pane in the same layout slot reuses the previous Pane's
+		// component instance — its hooks (notably `useRef`s capturing initial
+		// pane data like initialCommand) keep stale values from the prior
+		// pane and renderers like TerminalPane never see the new data.
 		return (
 			<Pane
+				key={pane.id}
 				store={store}
 				tab={tab}
 				pane={pane}

--- a/plans/20260430-pane-store-registry-pr3.md
+++ b/plans/20260430-pane-store-registry-pr3.md
@@ -1,0 +1,149 @@
+# PR 3 Plan: Pane Store Registry
+
+## Summary
+
+This PR moves the V2 workspace pane store from being created on route mount to a module-level registry keyed by `workspaceId`. It adds a helper `addLaunchPanes(workspaceId, launches)` that callers (eventually `workspace.create()` in PR 4) use to write panes before — or without — the workspace route ever mounting.
+
+**Scope of this PR:** the registry, the helper, and a minimal refactor of `useV2WorkspacePaneLayout` to read from the registry. Nothing else. The pending-row launch-adoption hook (`useConsumePendingLaunch`) is **kept as-is** per the canonical plan; its eventual removal lands in PR 5/7.
+
+This PR is independent of PR 1 (host agent configs) and PR 2 (host attachments). PR 4 (`workspace.create()`) is the first real consumer of `addLaunchPanes`; PR 5 retires `useConsumePendingLaunch` once the modal stops stashing launch blobs on a `pendingWorkspaces` row.
+
+## Why this PR exists
+
+Today the V2 workspace pane store is created inside the route via `useState(() => createWorkspaceStore({...}))`. That has three real consequences:
+
+1. **`workspace.create()` (PR 4) returns a list of already-started sessions** (`{ kind: "terminal"; terminalId }` / `{ kind: "chat"; chatSessionId }`). The renderer needs to write panes for those existing sessions, not generate new ones. Today there's no entry point that can reach the pane store before mount, so the only way to communicate launch info from creator to consumer is the `pendingWorkspaces.terminalLaunch` / `chatLaunch` side-channel.
+2. **The pending-row side-channel exists only because of this constraint** — it's state that should be a function argument.
+3. **Mount-as-trigger is race-prone.** `useConsumePendingLaunch` carries a `consumedRef` set keyed by `${pendingId}:terminal|chat` to dedupe across effect re-runs, which is the kind of thing you only need when you've conflated two responsibilities.
+
+After this PR, `addLaunchPanes(workspaceId, launches)` can be called from anywhere — modal, `workspace.create()`'s caller, automations, the CLI's renderer side. The route, when it mounts, just reads from the same store the registry is already holding.
+
+## Architecture
+
+### Registry
+
+A module-level singleton at `apps/desktop/src/renderer/lib/workspace-pane-registry/`. Same pattern as the existing `terminalRuntimeRegistry` in `apps/desktop/src/renderer/lib/terminal/`.
+
+```ts
+// boot — wired into app startup once a collections instance exists
+initWorkspacePaneRegistry(collections);
+
+// callers
+const store = getOrCreateWorkspacePaneStore(workspaceId);
+addLaunchPanes(workspaceId, launches);
+```
+
+`initWorkspacePaneRegistry(collections)` must be called at app boot before any caller. The registry holds the collections instance internally so `getOrCreateWorkspacePaneStore` doesn't need it as an arg.
+
+### Persistence
+
+The registry **owns the persistence sync**, not the route hook. When a store is created, the registry:
+
+- Reads the persisted `paneLayout` from `collections.v2WorkspaceLocalState` (or seeds with `EMPTY_STATE` if no row yet) and calls `store.replaceState(...)`.
+- Subscribes to the store and writes back to `v2WorkspaceLocalState` on every change (with the same `getSnapshot` debounce currently in `useV2WorkspacePaneLayout`).
+- Subscribes to `v2WorkspaceLocalState` row updates and pushes them into the store.
+
+Why owned by the registry, not the route hook:
+
+- We expect flows that **add panes without navigating** (background create, automations writing into a not-yet-visible workspace's pane state, pre-warming). If sync only happens while the route is mounted, those panes silently fail to persist — recoverable but bad UX.
+- Single source of truth: store is always in sync regardless of caller.
+- Costs (registry imports collections; novel pattern in this codebase compared to `terminalRuntimeRegistry`) are paid once at boot.
+
+The route hook becomes a thin wrapper:
+
+```ts
+export function useV2WorkspacePaneLayout({ projectId, workspaceId }) {
+  const { ensureWorkspaceInSidebar } = useDashboardSidebarState();
+  const store = getOrCreateWorkspacePaneStore(workspaceId);
+  useEffect(() => {
+    ensureWorkspaceInSidebar(workspaceId, projectId);
+  }, [ensureWorkspaceInSidebar, projectId, workspaceId]);
+  return { store };
+}
+```
+
+### `addLaunchPanes(workspaceId, launches)`
+
+```ts
+type LaunchResult =
+  | { kind: "terminal"; terminalId: string; label?: string }
+  | { kind: "chat"; chatSessionId: string; label?: string };
+
+addLaunchPanes(workspaceId: string, launches: LaunchResult[]): void;
+```
+
+Behavior:
+
+- Gets or creates the store for `workspaceId`.
+- For each launch, dedupes by id against existing panes in the store. If a pane with the same `terminalId` (terminal) or `sessionId` (chat) already exists, focus it instead of adding a duplicate.
+- For new launches, calls `store.getState().addTab(...)` with the right pane data.
+- Focuses the last added (or matched) pane.
+
+`addLaunchPanes` is **attach-only**. It does not carry an `initialCommand`. The host has already started the underlying session; the pane just attaches.
+
+### `TerminalPaneData.initialCommand` becomes optional
+
+Today: `{ terminalId: string; initialCommand: string }`.
+After: `{ terminalId: string; initialCommand?: string }`.
+
+- Existing callers (`useConsumePendingLaunch`, `useV2PresetExecution`) keep sending `initialCommand` and behavior stays identical.
+- `addLaunchPanes` omits `initialCommand`. The terminal pane component, on connect, branches: if `initialCommand` is defined, write it + enter; otherwise, just attach.
+
+This is a one-line type change plus a small branch in `TerminalPane`. No other call sites need updating.
+
+## Files Changed
+
+New:
+
+- `apps/desktop/src/renderer/lib/workspace-pane-registry/workspace-pane-registry.ts`
+- `apps/desktop/src/renderer/lib/workspace-pane-registry/workspace-pane-registry.test.ts`
+- `apps/desktop/src/renderer/lib/workspace-pane-registry/addLaunchPanes.ts`
+- `apps/desktop/src/renderer/lib/workspace-pane-registry/addLaunchPanes.test.ts`
+- `apps/desktop/src/renderer/lib/workspace-pane-registry/index.ts`
+
+Modified:
+
+- `apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/useV2WorkspacePaneLayout.ts` — drop the `useState` + persistence effects; read from registry.
+- `apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types.ts` (or wherever `TerminalPaneData` is) — `initialCommand` becomes optional.
+- `apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx` — branch on `initialCommand` defined vs not.
+- App boot site (likely `apps/desktop/src/renderer/index.tsx` or the `CollectionsProvider`) — call `initWorkspacePaneRegistry(collections)` once collections are available.
+
+## Tests
+
+Registry:
+
+- `getOrCreateWorkspacePaneStore` returns the same instance for the same `workspaceId`, distinct instances for different ids.
+- Persisted layout from a `v2WorkspaceLocalState` row is loaded into the store on first creation.
+- Updates to the store write back to the row.
+- Updates to the row push into the store.
+- Init guard: `getOrCreateWorkspacePaneStore` throws if called before `initWorkspacePaneRegistry`.
+
+`addLaunchPanes`:
+
+- Adds terminal panes for `{ kind: "terminal"; terminalId; label? }` entries; pane data has the id but no `initialCommand`.
+- Adds chat panes for `{ kind: "chat"; chatSessionId; label? }` entries.
+- Dedupes by id: calling twice with the same id results in a single pane and focuses it.
+- Mixed array of terminal + chat works.
+- Empty array is a no-op.
+
+Route hook:
+
+- After the refactor, mounting `useV2WorkspacePaneLayout` for a `workspaceId` that already has panes added via `addLaunchPanes` shows those panes immediately (no flash of empty state).
+
+## Out of Scope
+
+- **Removing the pending-row side-channel.** `pendingWorkspaces.terminalLaunch` / `chatLaunch` and `useConsumePendingLaunch` keep working. PR 5 retires them when the new workspace modal moves onto `workspace.create()`.
+- **`workspace.create()` itself.** Lives in PR 4. PR 3 just provides the surface PR 4 will call into.
+- **The pending route's own logic.** Untouched.
+- **Migrating terminal presets to host-driven start.** Today `useV2PresetExecution` mints terminal ids renderer-side and embeds `initialCommand`. That keeps working. A future PR could move presets onto the same attach-only flow `addLaunchPanes` uses, but that's not this PR.
+
+## Risks and rollout
+
+- **Registry boot ordering.** `initWorkspacePaneRegistry(collections)` must run before any caller. Unit-tested by the init guard. Real risk: a code path that calls `getOrCreateWorkspacePaneStore` from a top-level module load before app boot finishes. Mitigation: throw a clear error from the guard so the misuse is loud and fixable.
+- **Persistence behavior change.** Previously, persistence only ran while the route was mounted. After PR 3, persistence runs whenever a store exists in the registry (i.e. for any workspace whose pane state has been touched this session). Net effect: stores stay in sync more, write more often. The existing snapshot-equality guard already avoids redundant writes.
+- **Test isolation.** The registry holds module state; tests must reset it between cases. Plan: export a `__resetWorkspacePaneRegistryForTests()` like `terminalRuntimeRegistry` does.
+
+## Follow-Ups
+
+- PR 4: `workspace.create()` returns `launches` and the modal calls `addLaunchPanes(workspaceId, launches)` before navigating.
+- PR 5: delete `pendingWorkspaces.terminalLaunch` / `chatLaunch` columns and `useConsumePendingLaunch` once the modal is migrated.


### PR DESCRIPTION
## Summary

PR 3 of the canonical `workspace.create()` refactor. Decouples pane state ownership from the workspace route mount. The V2 workspace pane store now lives in a module-level registry keyed by `workspaceId`, rather than being created inside `useV2WorkspacePaneLayout` on mount.

This unblocks PR 4 (`workspace.create()`) returning a list of already-started sessions that the renderer can write directly into the pane store **before** — or **without** — navigating.

**Plan:** [`plans/20260430-pane-store-registry-pr3.md`](https://github.com/superset-sh/superset/blob/sleepy-professor/plans/20260430-pane-store-registry-pr3.md) — added in this PR.
**Umbrella design:** #3893.

## Why

Today the V2 pane store is created inside the route via `useState(() => createWorkspaceStore({...}))`. Three real consequences:

1. **`workspace.create()` returns already-started sessions** — the renderer needs to write panes for them, not generate new ones. There's no entry point that reaches the pane store before mount, so the only way to communicate launch info is the `pendingWorkspaces.terminalLaunch` / `chatLaunch` side-channel.
2. **The pending-row side-channel exists only because of this** — it's state that should be a function argument.
3. **Mount-as-trigger is race-prone** — the `consumedRef` set in `useConsumePendingLaunch` exists only to guard re-firing effects.

After this PR, `addLaunchPanes(workspaceId, launches)` can be called from anywhere — modal, workspace.create's caller, automations, the CLI's renderer side. The route reads from the same store the registry holds.

## What this PR ships

- **`workspace-pane-registry.ts`** — module-level singleton, same pattern as `terminalRuntimeRegistry`. `initWorkspacePaneRegistry(deps)` at app boot, `getOrCreateWorkspacePaneStore(workspaceId)` for callers, `dropWorkspacePaneStore`, test reset helper.
- **Persistence is owned by the registry** — bidirectional sync wired at store creation. Seeds from `v2WorkspaceLocalState.paneLayout`, writes back on store changes (when the row exists), pushes external row changes into the store, snapshot guard prevents echo. Chosen over a route-driven sync because we want to support flows that **add panes without navigating** (background create, automations, pre-warming).
- **`addLaunchPanes.ts`** — takes the doc-shape launches array (`{ kind: "terminal"; terminalId; label? } | { kind: "chat"; chatSessionId; label? }`), dedupes by id, focuses. **Attach-only** — no `initialCommand`.
- **`useV2WorkspacePaneLayout` simplified** — drops 87 lines of `useState` + `useLiveQuery` + persistence effects, replaced by a single `getOrCreateWorkspacePaneStore` call. `ensureWorkspaceInSidebar` still runs on mount.
- **`CollectionsProvider`** — initializes the registry inside the collections `useMemo` (synchronously, before children render) so the workspace route's `useState` initializer sees a ready registry. Re-inits on org switch.

`TerminalPaneData.initialCommand` is **already optional** in the current types; no change needed there.

## Tests

14 tests against an in-memory localStorage-backed collection.

Registry:
- Same store for the same workspaceId; different stores for different ids
- Seeds from a pre-existing row
- Writes store changes back when row exists
- No throw when no row present
- Pushes external row updates into the store
- Throws if used before init

`addLaunchPanes`:
- Empty array no-op
- Adds terminal panes with no `initialCommand`
- Adds chat panes
- Dedupes by `terminalId` / `chatSessionId` (idempotent)
- Focuses the existing pane on duplicate id
- Mixed terminal + chat batch

## Out of scope (deferred)

- **`useConsumePendingLaunch` retrofit.** Per the canonical plan: "Keep current query-param/pending launch adoption temporarily." PR 5 deletes the pending-row side-channel when the new modal moves onto `workspace.create()`.
- **`workspace.create()` itself.** PR 4. PR 3 just provides the surface.
- **Migrating terminal presets to host-driven start.** Out of scope.

## Test plan

- [x] `bun test apps/desktop/src/renderer/lib/workspace-pane-registry/` — 14/14 pass
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [ ] Manual: open a V2 workspace and confirm panes still load + persist (pre-mount addLaunchPanes flow doesn't have a UI consumer yet — that's PR 4/5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Host-initiated terminal and chat launches are deduplicated and will refocus existing panes; new API to register launches.
  * Centralized workspace pane registry provides shared, persisted pane stores per workspace.

* **Bug Fixes**
  * Pane components remount by identity to avoid stale state.
  * Workspace removal now cleans up associated pane registry state.

* **Tests**
  * Added tests for registry lifecycle, persistence sync, dedupe, and focus behavior.

* **Documentation**
  * Added rollout plan/spec for the pane registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->