### PR TITLE
docs(cli): fix install URL on Getting Started page

### DIFF
--- a/apps/docs/content/docs/cli/getting-started.mdx
+++ b/apps/docs/content/docs/cli/getting-started.mdx
@@ -14,7 +14,7 @@ and the local host server from your terminal or from CI.
 ## Install
 
 ```bash
-curl -fsSL https://app.superset.sh/install.sh | sh
+curl -fsSL https://superset.sh/cli/install.sh | sh
 ```
 
 The script auto-detects your platform (macOS Apple Silicon or Linux x86_64) and installs the binary at `/usr/local/bin/superset`.


### PR DESCRIPTION
## Summary
- The CLI Getting Started page told users to run `curl -fsSL https://app.superset.sh/install.sh | sh`, but `app.superset.sh` is the authed web app — that path 307s to `/sign-in`, so curl (with `-L`) pipes the sign-in HTML into `sh` and the install silently breaks.
- The installer actually lives on the marketing site at `https://superset.sh/cli/install.sh` (matches the script's own usage hint and the Homebrew tap published alongside it).

## Test plan
- [x] `curl -fsSL https://superset.sh/cli/install.sh` returns 200 with `content-type: application/x-sh`
- [x] `curl -fsSL https://app.superset.sh/install.sh` 307s to `/sign-in?redirect=%2Finstall.sh` (the broken behavior)
- [ ] Verify `docs.superset.sh/cli/getting-started` renders the corrected URL after deploy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CLI Getting Started install command to point to the public installer at `https://superset.sh/cli/install.sh`. This avoids the auth redirect from `https://app.superset.sh/install.sh` that piped sign-in HTML into `sh` and broke installs.

<sup>Written for commit 83ee7a55dc9a7fc8296a5c94561579dc63b527cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI installer download URL in the getting-started guide to ensure users retrieve the correct installation script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->