### PR TITLE
fix(cli): surface auth URL so headless logins can complete

### DIFF
--- a/packages/cli/src/commands/auth/login/command.ts
+++ b/packages/cli/src/commands/auth/login/command.ts
@@ -22,7 +22,14 @@ export default command({
 		spinner?.start("Waiting for browser authorization...");
 		if (!spinner) p.log.info("Waiting for browser authorization…");
 
-		const result = await login(opts.signal);
+		const result = await login({
+			signal: opts.signal,
+			onAuthUrl: (url) => {
+				p.log.info(
+					`If your browser doesn't open automatically, paste this URL:\n${url}`,
+				);
+			},
+		});
 
 		config.auth = {
 			accessToken: result.accessToken,

--- a/packages/cli/src/lib/auth.ts
+++ b/packages/cli/src/lib/auth.ts
@@ -131,7 +131,18 @@ export function getWebUrl(): string {
 	return env.SUPERSET_API_URL.replace("api.superset.sh", "app.superset.sh");
 }
 
-export async function login(signal: AbortSignal): Promise<LoginResult> {
+export interface LoginOptions {
+	signal: AbortSignal;
+	/**
+	 * Called once with the authorization URL just before the browser is
+	 * launched. Useful on headless hosts where `xdg-open` isn't available —
+	 * the caller can surface the URL so the user can paste it into a
+	 * browser on a different machine.
+	 */
+	onAuthUrl?: (url: string) => void;
+}
+
+export async function login(options: LoginOptions): Promise<LoginResult> {
 	const apiUrl = env.SUPERSET_API_URL;
 	const webUrl = getWebUrl();
 
@@ -143,13 +154,15 @@ export async function login(signal: AbortSignal): Promise<LoginResult> {
 	authorizeUrl.searchParams.set("redirect_uri", redirectUri);
 	authorizeUrl.searchParams.set("state", state);
 
-	await openBrowser(authorizeUrl.toString());
+	const url = authorizeUrl.toString();
+	options.onAuthUrl?.(url);
+	await openBrowser(url);
 
 	const code = await waitForCallback({
 		server,
 		port,
 		expectedState: state,
-		signal,
+		signal: options.signal,
 		timeoutMs: 5 * 60 * 1000,
 	});
 

--- a/packages/cli/src/lib/auth.ts
+++ b/packages/cli/src/lib/auth.ts
@@ -155,7 +155,13 @@ export async function login(options: LoginOptions): Promise<LoginResult> {
 	authorizeUrl.searchParams.set("state", state);
 
 	const url = authorizeUrl.toString();
-	options.onAuthUrl?.(url);
+	try {
+		options.onAuthUrl?.(url);
+	} catch (err) {
+		// Don't leak the bound loopback server if the callback throws.
+		server.close();
+		throw err;
+	}
 	await openBrowser(url);
 
 	const code = await waitForCallback({


### PR DESCRIPTION
## Summary

Closes #3949.

`superset auth login` hangs on headless Linux hosts because `openBrowser()` invokes `xdg-open` via fire-and-forget `exec()` — when `xdg-open` is missing the failure is silent and no URL is ever surfaced.

## Fix

- Add an optional `onAuthUrl(url)` callback to a new `LoginOptions` interface in `lib/auth.ts`.
- Refactor `login(signal)` → `login(options)`. Single internal caller updated.
- In the auth command, the callback prints the URL via `p.log.info(...)`. On TTY clack interleaves it with the running spinner; on non-TTY it's a clean info line.

Browser auto-launch is **unchanged** for GUI users — `openBrowser()` is still invoked after the URL is surfaced.

## Test plan

- [x] On macOS (TTY): browser still opens; URL also appears as a `p.log.info` line, interleaves cleanly with the spinner.
- [x] On Linux ARM64 headless (Hetzner Neoverse-N1, no `xdg-open`): URL is now printed. Combined with `ssh -L 51789:localhost:51789 <host>` the OAuth loopback callback completes through the tunnel and CLI logs in successfully.
- [ ] `bun run lint:fix && bun run typecheck` — couldn't run locally; relying on CI.

## Scope

- `packages/cli/src/lib/auth.ts` — new `LoginOptions`; `login()` signature refactor; URL hoisted to a const; `onAuthUrl` invoked before `openBrowser`.
- `packages/cli/src/commands/auth/login/command.ts` — pass options including the callback.

## Out of scope (potential follow-ups)

- `openBrowser()` still doesn't actually await `exec()` completion. Surfacing the URL eagerly sidesteps that for users; making `openBrowser` truly synchronous is a separate change.
- A `--no-browser` flag for purely scripted flows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Print the OAuth authorization URL during `superset auth login` so headless Linux hosts can complete login when no default browser is available. Auto-launch still works; this adds a visible URL fallback.

- **Bug Fixes**
  - Added `LoginOptions` with optional `onAuthUrl(url)` and refactored `login(signal)` to `login({ signal, ... })`.
  - The auth command logs the URL before launching the browser, allowing copy/paste on headless hosts.
  - If an `onAuthUrl` callback throws, close the loopback server to avoid port leaks and “All loopback ports in use” errors.

<sup>Written for commit e798930028a4c9f172574c862c3c5db27024392f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced authentication flow: the app now exposes a handler to surface the authorization URL and will print a fallback message with the URL during login if needed, improving visibility and reliability when completing sign-in from the browser.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->