### PR TITLE
feat: add --name filter to automations list (CLI / SDK / MCP / tRPC)

### DIFF
--- a/packages/cli/src/commands/automations/list/command.ts
+++ b/packages/cli/src/commands/automations/list/command.ts
@@ -10,10 +10,9 @@ export default command({
 			.desc("Filter by name (case-insensitive substring match)"),
 	},
 	run: async ({ ctx, options }) => {
-		const rows = await ctx.api.automation.list.query();
-		if (!options.name) return rows;
-		const needle = options.name.toLowerCase();
-		return rows.filter((row) => row.name.toLowerCase().includes(needle));
+		return await ctx.api.automation.list.query(
+			options.name ? { name: options.name } : undefined,
+		);
 	},
 	display: (data) =>
 		table(

--- a/packages/cli/src/commands/automations/list/command.ts
+++ b/packages/cli/src/commands/automations/list/command.ts
@@ -1,11 +1,19 @@
-import { table } from "@superset/cli-framework";
+import { string, table } from "@superset/cli-framework";
 import { command } from "../../../lib/command";
 import { formatAutomationDate } from "../format";
 
 export default command({
 	description: "List automations in the organization",
-	run: async ({ ctx }) => {
-		return ctx.api.automation.list.query();
+	options: {
+		name: string()
+			.alias("n")
+			.desc("Filter by name (case-insensitive substring match)"),
+	},
+	run: async ({ ctx, options }) => {
+		const rows = await ctx.api.automation.list.query();
+		if (!options.name) return rows;
+		const needle = options.name.toLowerCase();
+		return rows.filter((row) => row.name.toLowerCase().includes(needle));
 	},
 	display: (data) =>
 		table(

--- a/packages/mcp-v2/src/tools/automations/list.ts
+++ b/packages/mcp-v2/src/tools/automations/list.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
 import { createMcpCaller } from "../../caller";
 import { defineTool } from "../../define-tool";
 
@@ -6,10 +7,21 @@ export function register(server: McpServer): void {
 	defineTool(server, {
 		name: "automations_list",
 		description:
-			"List automations (scheduled agent runs) the calling user owns in the active organization. Returns a summary shape — call automations_get_prompt to fetch the prompt for one automation, or automations_get for the rest of its config.",
-		handler: async (_input, ctx) => {
+			"List automations (scheduled agent runs) the calling user owns in the active organization. Returns a summary shape — call automations_get_prompt to fetch the prompt for one automation, or automations_get for the rest of its config. Pass `name` to filter rows by case-insensitive substring match on the automation name.",
+		inputSchema: {
+			name: z
+				.string()
+				.optional()
+				.describe(
+					"Filter rows by case-insensitive substring match on automation name.",
+				),
+		},
+		handler: async (input, ctx) => {
 			const caller = createMcpCaller(ctx);
-			return await caller.automation.list();
+			const rows = await caller.automation.list();
+			if (!input.name) return rows;
+			const needle = input.name.toLowerCase();
+			return rows.filter((row) => row.name.toLowerCase().includes(needle));
 		},
 	});
 }

--- a/packages/mcp-v2/src/tools/automations/list.ts
+++ b/packages/mcp-v2/src/tools/automations/list.ts
@@ -18,10 +18,9 @@ export function register(server: McpServer): void {
 		},
 		handler: async (input, ctx) => {
 			const caller = createMcpCaller(ctx);
-			const rows = await caller.automation.list();
-			if (!input.name) return rows;
-			const needle = input.name.toLowerCase();
-			return rows.filter((row) => row.name.toLowerCase().includes(needle));
+			return await caller.automation.list(
+				input.name ? { name: input.name } : undefined,
+			);
 		},
 	});
 }

--- a/packages/sdk/src/resources/automations.ts
+++ b/packages/sdk/src/resources/automations.ts
@@ -13,15 +13,10 @@ export class Automations extends APIResource {
 		params?: AutomationListParams,
 		options?: RequestOptions,
 	): APIPromise<AutomationListResponse> {
-		const promise = this._client.query<AutomationListResponse>(
+		return this._client.query<AutomationListResponse>(
 			"automation.list",
-			undefined,
+			params,
 			options,
-		);
-		if (!params?.name) return promise;
-		const needle = params.name.toLowerCase();
-		return promise._thenUnwrap((rows) =>
-			rows.filter((row) => row.name.toLowerCase().includes(needle)),
 		);
 	}
 

--- a/packages/sdk/src/resources/automations.ts
+++ b/packages/sdk/src/resources/automations.ts
@@ -9,11 +9,19 @@ export class Automations extends APIResource {
 	 *
 	 * Mirrors `superset automations list`.
 	 */
-	list(options?: RequestOptions): APIPromise<AutomationListResponse> {
-		return this._client.query<AutomationListResponse>(
+	list(
+		params?: AutomationListParams,
+		options?: RequestOptions,
+	): APIPromise<AutomationListResponse> {
+		const promise = this._client.query<AutomationListResponse>(
 			"automation.list",
 			undefined,
 			options,
+		);
+		if (!params?.name) return promise;
+		const needle = params.name.toLowerCase();
+		return promise._thenUnwrap((rows) =>
+			rows.filter((row) => row.name.toLowerCase().includes(needle)),
 		);
 	}
 
@@ -211,6 +219,11 @@ export interface Automation extends AutomationSummary {
 
 export type AutomationListResponse = Array<AutomationSummary>;
 
+export interface AutomationListParams {
+	/** Case-insensitive substring match on automation name. */
+	name?: string;
+}
+
 export interface AutomationCreateParams {
 	name: string;
 	prompt: string;
@@ -275,6 +288,7 @@ export declare namespace Automations {
 	export type {
 		Automation,
 		AutomationSummary,
+		AutomationListParams,
 		AutomationListResponse,
 		AutomationCreateParams,
 		AutomationUpdateParams,

--- a/packages/trpc/src/router/automation/automation.ts
+++ b/packages/trpc/src/router/automation/automation.ts
@@ -18,7 +18,7 @@ import {
 	parseRrule,
 } from "@superset/shared/rrule";
 import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
-import { and, desc, eq, getTableColumns } from "drizzle-orm";
+import { and, desc, eq, getTableColumns, ilike } from "drizzle-orm";
 import { z } from "zod";
 import { env } from "../../env";
 import { protectedProcedure } from "../../trpc";
@@ -34,6 +34,10 @@ import {
 	setAutomationPromptSchema,
 	updateAutomationSchema,
 } from "./schema";
+
+function escapeLikePattern(value: string): string {
+	return value.replace(/[\\%_]/g, (match) => `\\${match}`);
+}
 
 function requirePaidSubscription(subscription: SelectSubscription | null) {
 	if (
@@ -160,21 +164,41 @@ export const automationRouter = {
 	 * List automations scoped to the caller's active organization. The
 	 * `prompt` body is omitted — call `getPrompt` to fetch it for one row.
 	 */
-	list: protectedProcedure.query(async ({ ctx }) => {
-		const organizationId = await requireActiveOrgMembership(ctx);
+	list: protectedProcedure
+		.input(
+			z
+				.object({
+					name: z
+						.string()
+						.trim()
+						.min(1)
+						.optional()
+						.describe("Case-insensitive substring match on automation name."),
+				})
+				.optional(),
+		)
+		.query(async ({ ctx, input }) => {
+			const organizationId = await requireActiveOrgMembership(ctx);
 
-		const { prompt: _prompt, ...summaryCols } = getTableColumns(automations);
-		const rows = await db
-			.select(summaryCols)
-			.from(automations)
-			.where(eq(automations.organizationId, organizationId))
-			.orderBy(desc(automations.createdAt));
+			const { prompt: _prompt, ...summaryCols } = getTableColumns(automations);
+			const rows = await db
+				.select(summaryCols)
+				.from(automations)
+				.where(
+					and(
+						eq(automations.organizationId, organizationId),
+						input?.name
+							? ilike(automations.name, `%${escapeLikePattern(input.name)}%`)
+							: undefined,
+					),
+				)
+				.orderBy(desc(automations.createdAt));
 
-		return rows.map((row) => ({
-			...row,
-			scheduleText: safeDescribeRrule(row),
-		}));
-	}),
+			return rows.map((row) => ({
+				...row,
+				scheduleText: safeDescribeRrule(row),
+			}));
+		}),
 
 	/**
 	 * Get one automation's metadata. The `prompt` body is omitted (it can be


### PR DESCRIPTION
## Summary

Add `name?: string` filter to `automation.list` across every surface, applied at the DB layer via `ilike`:

- **CLI**: `superset automations list --name <substring>` (alias `-n`). Pairs with `--quiet` for ID-only output.
- **SDK**: `automations.list({ name })`
- **MCP v2**: `automations_list` tool now takes optional `name`
- **tRPC**: `automation.list` accepts an optional `{ name }` input and applies it as `ilike(automations.name, '%...%')` in the org-scoped query

## Why this instead of name-as-positional-arg

Task [60e7984c](https://app.superset.sh/tasks/superset-cli-accept-name-not-just-uuid-for-automat) originally proposed making each `automations <subcommand> <id>` positional accept a name. The catch: automation names aren't unique (the org has had two `Triage Linear` already). Resolution-on-positional bakes a fragile assumption into seven subcommands and forces an error-on-ambiguity fallback. A `list --name` filter respects the non-uniqueness directly and pairs cleanly with `--quiet` for scripting, which was the original irritation ("had to grep through ~50 entries of JSON").

## Why DB-side, not client-side

Initial implementation filtered client-side in each surface. That doesn't scale to teams with hundreds of automations — every list call would still ship the full set over the wire. Pushing the filter into the tRPC query keeps payloads small and lets each surface stay a thin pass-through.

## Verification

- `superset automations list --name "sales"` → narrows to the 3 Sales automations
- `superset automations list -n sales --quiet` → 3 UUIDs, one per line
- `superset automations list --name "no-such-thing"` → empty, exits 0 (grep-like)
- `superset automations list` → unchanged, returns all
- `superset automations list --help` → shows the new flag

## Follow-ups (not in this PR)

- Same `--name` filter on `projects list`, `workspaces list`, `tasks list` (tasks already has `--search`), `hosts list`.

## Test plan

- [x] Typecheck (`@superset/trpc`, `@superset/sdk`, `@superset/mcp-v2`, `@superset/cli`)
- [x] Lint clean
- [x] Manual smoke against live API (CLI)
- [ ] Reviewer eyeball on filter behavior + flag naming

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional name filter for automation listing; use --name / -n to show only automations whose names include the provided text (case-insensitive).

* **Bug Fixes**
  * Listing now supports server-side name filtering (with safe pattern handling) and SDK/CLI/tooling updated so filtered results are applied consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->