### PR TITLE
fix(sdk): redact x-api-key in debug-log header dumps

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/sdk",
-	"version": "0.0.1-alpha.6",
+	"version": "0.0.1-alpha.7",
 	"description": "TypeScript SDK for the Superset API",
 	"private": true,
 	"type": "module",

--- a/packages/sdk/src/internal/utils/log.ts
+++ b/packages/sdk/src/internal/utils/log.ts
@@ -112,6 +112,7 @@ export const formatRequestDetails = (details: {
 			).map(([name, value]) => [
 				name,
 				name.toLowerCase() === "api_key" ||
+				name.toLowerCase() === "x-api-key" ||
 				name.toLowerCase() === "authorization" ||
 				name.toLowerCase() === "cookie" ||
 				name.toLowerCase() === "set-cookie"

--- a/packages/sdk/src/version.ts
+++ b/packages/sdk/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.0.1-alpha.6";
+export const VERSION = "0.0.1-alpha.7";


### PR DESCRIPTION
## Summary

The Stainless template's request-detail log redactor masks `Authorization`, `Cookie`, `Set-Cookie`, and `api_key` (underscore — petstore's auth header). When we shipped \`@superset_sh/sdk\` we changed the auth scheme in \`client.ts:authHeaders\` to use \`x-api-key\` (dash) for \`sk_live_…\` keys, but didn't update the redaction list to match.

Net effect: any caller running with \`logLevel: 'debug'\` or \`SUPERSET_LOG=debug\` had their raw API key written into the debug logs alongside every request. Adding \`x-api-key\` to the redaction list patches it.

Bumps the SDK to \`0.0.1-alpha.7\`.

## Test plan

- [ ] Bun typecheck passes (it does locally)
- [ ] Sherif passes (it does locally)
- [ ] CI green
- [ ] Republish \`@superset_sh/sdk@0.0.1-alpha.7\` after merge

Caught by greptile + cubic + coderabbit on #3937, follow-up since that PR was already merged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts the `x-api-key` header in SDK debug request logs to prevent API key leakage when debug logging is enabled. Bumps `@superset/sdk` to `0.0.1-alpha.7`.

<sup>Written for commit caa3c0f1489a7dac29cee069d3c88cce4f38f1d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped SDK package version to 0.0.1-alpha.7, with updates reflected across package configuration and internal version constants

* **Bug Fixes**
  * Improved request logging security by implementing proper redaction of API key headers, ensuring they are masked consistently with other sensitive authentication headers to prevent credential exposure in request logs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->