### PR TITLE
fix(cli): ship tokenizers linux-arm64-gnu binding in CLI tarball

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -799,6 +799,9 @@
         "drizzle-kit": "0.31.8",
         "typescript": "^5.9.3",
       },
+      "optionalDependencies": {
+        "@anush008/tokenizers-linux-arm64-gnu": "0.6.0",
+      },
     },
     "packages/local-db": {
       "name": "@superset/local-db",
@@ -896,7 +899,7 @@
     },
     "packages/sdk": {
       "name": "@superset/sdk",
-      "version": "0.0.1-alpha.0",
+      "version": "0.0.1-alpha.7",
       "devDependencies": {
         "@superset/typescript": "workspace:*",
         "bun-types": "^1.3.1",
@@ -1135,6 +1138,8 @@
     "@anush008/tokenizers": ["@anush008/tokenizers@0.0.0", "", { "optionalDependencies": { "@anush008/tokenizers-darwin-universal": "0.0.0", "@anush008/tokenizers-linux-x64-gnu": "0.0.0", "@anush008/tokenizers-win32-x64-msvc": "0.0.0" } }, "sha512-IQD9wkVReKAhsEAbDjh/0KrBGTEXelqZLpOBRDaIRvlzZ9sjmUP+gKbpvzyJnei2JHQiE8JAgj7YcNloINbGBw=="],
 
     "@anush008/tokenizers-darwin-universal": ["@anush008/tokenizers-darwin-universal@0.0.0", "", { "os": "darwin" }, "sha512-SACpWEooTjFX89dFKRVUhivMxxcZRtA3nJGVepdLyrwTkQ1TZQ8581B5JoXp0TcTMHfgnDaagifvVoBiFEdNCQ=="],
+
+    "@anush008/tokenizers-linux-arm64-gnu": ["@anush008/tokenizers-linux-arm64-gnu@0.6.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Go1ssG7AylDFpsDzLkh+nqXt1RcIGhL9pSpPH1nLF504lutxkCZcihESUt6vobtjnCONOAIwCWe1AVEoHui+9A=="],
 
     "@anush008/tokenizers-linux-x64-gnu": ["@anush008/tokenizers-linux-x64-gnu@0.0.0", "", { "os": "linux", "cpu": "x64" }, "sha512-TLjByOPWUEq51L3EJkS+slyH57HKJ7lAz/aBtEt7TIPq4QsE2owOPGovByOLIq1x5Wgh9b+a4q2JasrEFSDDhg=="],
 

--- a/packages/cli/scripts/build-dist.ts
+++ b/packages/cli/scripts/build-dist.ts
@@ -82,6 +82,7 @@ const TARGET_NATIVE_PACKAGES: Record<Target, string[]> = {
 	"linux-arm64": [
 		"@libsql/linux-arm64-gnu",
 		"@parcel/watcher-linux-arm64-glibc",
+		"@anush008/tokenizers-linux-arm64-gnu",
 	],
 };
 

--- a/packages/host-service/build.ts
+++ b/packages/host-service/build.ts
@@ -26,6 +26,7 @@ const result = await Bun.build({
 		"@anush008/tokenizers",
 		"@anush008/tokenizers-darwin-universal",
 		"@anush008/tokenizers-linux-x64-gnu",
+		"@anush008/tokenizers-linux-arm64-gnu",
 		"@anush008/tokenizers-win32-x64-msvc",
 	],
 });

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -83,5 +83,8 @@
 		"bun-types": "^1.3.1",
 		"drizzle-kit": "0.31.8",
 		"typescript": "^5.9.3"
+	},
+	"optionalDependencies": {
+		"@anush008/tokenizers-linux-arm64-gnu": "0.6.0"
 	}
 }


### PR DESCRIPTION
## Summary

- Ships `@anush008/tokenizers-linux-arm64-gnu` in the linux-arm64 CLI tarball so `superset start` no longer crashes with `Cannot find module '@anush008/tokenizers-linux-arm64-gnu'`. #3921 added the binding for linux-x64 but missed arm64.
- Pins the 0.6.0 binding directly on `@superset/host-service` as an `optionalDependency` (gated to `os: linux, cpu: arm64`), wires it through `build-dist.ts` and the host-service bundler externals.

## Why this shape

Three layers had to line up — the issue's diff alone wouldn't pass CI:

1. **Build pipeline** — `TARGET_NATIVE_PACKAGES["linux-arm64"]` and the host-service `Bun.build` externals didn't list the binding.
2. **`@anush008/tokenizers@0.0.0`** (pinned transitively via `fastembed → @anush008/tokenizers@^0.0.0`) lists no `linux-arm64-gnu` in `optionalDependencies`, so `bun install` couldn't resolve it from the parent.
3. **npm registry** — `@anush008/tokenizers-linux-arm64-gnu@0.0.0` was never published; only `0.5.0` and `0.6.0` exist.

Adding the `0.6.0` binding as a direct optional dep on host-service sidesteps (2) and (3): bun installs it on linux-arm64 CI runners and skips it everywhere else via `os`/`cpu` filtering. The `0.6.0` native binary is ABI-compatible with the `0.0.0` JS loader's `require('@anush008/tokenizers-linux-arm64-gnu')` path for the surface fastembed actually uses.

## Test plan

Verified end-to-end in a `linux/arm64` docker container (Apple Silicon → native arm64):

- [x] ABI compat: `0.6.0` binding loaded behind `0.0.0` JS loader resolves `Tokenizer.fromString` → `setTruncation` → `setPadding` → `new AddedToken(...)` → `addAddedTokens` → async `encode` → `getIds`/`getTokens` (the fastembed surface).
- [x] `bun install --frozen --ignore-scripts` resolves and installs `@anush008/tokenizers-linux-arm64-gnu@0.6.0`.
- [x] `bun run build:dist --target=linux-arm64` succeeds; tarball contains both `lib/node_modules/@anush008/tokenizers/index.js` and `lib/node_modules/@anush008/tokenizers-linux-arm64-gnu/tokenizers.linux-arm64-gnu.node`.
- [x] `NODE_PATH=$DIST/lib/node_modules $DIST/lib/node -e 'require("@anush008/tokenizers")'` loads cleanly.
- [x] `bin/superset --version` → `0.2.1`. `bin/superset-host` boots past the previous `MODULE_NOT_FOUND` and only fails on runtime env-var validation (`ORGANIZATION_ID`, `HOST_DB_PATH`) — unrelated.
- [x] `bun run lint` clean; `bun run typecheck` clean for `@superset/host-service` + `@superset/cli`.

## Notes

- darwin and linux-x64 unaffected: `optionalDependencies` skips on os/cpu mismatch and the bundler `external` list is platform-agnostic.
- `0.6.0` is the most recent published binding; the maintainer-side fix proposed in the issue (republish `0.0.0` with arm64 in opt-deps) is no longer needed.

Closes #3951.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ships `@anush008/tokenizers-linux-arm64-gnu` in the linux-arm64 CLI tarball to fix the `MODULE_NOT_FOUND` crash on `superset start`. Pins the `0.6.0` binding in `@superset/host-service` and updates the build to bundle it on arm64 Linux.

- **Bug Fixes**
  - Add `@anush008/tokenizers-linux-arm64-gnu@0.6.0` as an `optionalDependency` in `@superset/host-service` (os: linux, cpu: arm64).
  - Include the binding in `TARGET_NATIVE_PACKAGES["linux-arm64"]` and host-service bundler externals.
  - Tarball now ships the native `.node`; darwin and linux-x64 remain unaffected.

<sup>Written for commit 6dfde384bf5cd9787cdbbd40761f73af63c8ba1f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended support for Linux ARM64 systems by including required tokenizer packages and updating build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->