### PR TITLE
release(cli): cut v0.2.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -674,7 +674,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@clack/prompts": "^0.10.0",
         "@superset/cli-framework": "workspace:*",

--- a/packages/cli/cli.config.ts
+++ b/packages/cli/cli.config.ts
@@ -1,6 +1,6 @@
 import { boolean, defineConfig, string } from "@superset/cli-framework";
 
-const VERSION = "0.2.1";
+const VERSION = "0.2.2";
 
 export default defineConfig({
 	name: "superset",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Summary

Patch release picking up #3960 — the linux-arm64 tarball was missing `@anush008/tokenizers-linux-arm64-gnu`, so `superset start` crashed on boot for ARM Linux hosts (Hetzner Ampere, AWS Graviton, Oracle Ampere, Raspberry Pi).

Push `cli-v0.2.2` after this lands to fire `release-cli.yml`.

## Test plan

- [ ] PR merges; CI green
- [ ] Push `cli-v0.2.2` tag → release-cli.yml builds the 3-target matrix
- [ ] Smoke test linux-arm64 tarball via `install.sh` on an ARM host

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cut `@superset/cli` v0.2.2 to fix a linux-arm64 startup crash. The linux-arm64 tarball now includes `@anush008/tokenizers-linux-arm64-gnu`, so `superset start` runs on ARM hosts (Hetzner Ampere, AWS Graviton, Oracle Ampere, Raspberry Pi).

<sup>Written for commit 160555183007d329e6755fc0400cb381acd6af2a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CLI to version 0.2.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->