### PR TITLE
feat(cli): align automations + tasks commands with SDK and MCP-v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Logs
 logs
+!packages/cli/src/commands/automations/logs
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/packages/cli/src/commands/automations/create/command.ts
+++ b/packages/cli/src/commands/automations/create/command.ts
@@ -75,8 +75,8 @@ export default command({
 			throw new Error("Provide --prompt <text> or --prompt-file <path>");
 		}
 
-		if (!options.project) {
-			throw new Error("Provide --project (required)");
+		if (!options.project && !options.workspace) {
+			throw new Error("Provide --project or --workspace");
 		}
 
 		const agentConfig = options.agentConfigFile
@@ -88,7 +88,7 @@ export default command({
 			prompt,
 			agentConfig,
 			targetHostId: options.host ?? null,
-			v2ProjectId: options.project,
+			v2ProjectId: options.project ?? undefined,
 			v2WorkspaceId: options.workspace ?? null,
 			rrule: options.rrule,
 			dtstart: options.dtstart ? new Date(options.dtstart) : undefined,

--- a/packages/cli/src/commands/automations/create/command.ts
+++ b/packages/cli/src/commands/automations/create/command.ts
@@ -89,7 +89,7 @@ export default command({
 			agentConfig,
 			targetHostId: options.host ?? null,
 			v2ProjectId: options.project ?? undefined,
-			v2WorkspaceId: options.workspace ?? null,
+			v2WorkspaceId: options.workspace ?? undefined,
 			rrule: options.rrule,
 			dtstart: options.dtstart ? new Date(options.dtstart) : undefined,
 			timezone: options.timezone ?? DEFAULT_TIMEZONE,

--- a/packages/cli/src/commands/automations/logs/command.ts
+++ b/packages/cli/src/commands/automations/logs/command.ts
@@ -1,0 +1,41 @@
+import { number, positional, table } from "@superset/cli-framework";
+import { command } from "../../../lib/command";
+import { formatAutomationDate } from "../format";
+
+export default command({
+	description: "List recent runs of an automation",
+	args: [positional("id").required().desc("Automation id")],
+	options: {
+		limit: number()
+			.int()
+			.min(1)
+			.max(100)
+			.default(20)
+			.desc("Max runs to return (1-100)"),
+	},
+	run: async ({ ctx, args, options }) => {
+		const automationId = args.id as string;
+		return ctx.api.automation.listRuns.query({
+			automationId,
+			limit: options.limit,
+		});
+	},
+	display: (data) =>
+		table(
+			(data as Record<string, unknown>[]).map((row) => ({
+				id: row.id,
+				status: row.status,
+				scheduledFor: formatAutomationDate(
+					row.scheduledFor as Date | string | null | undefined,
+					null,
+				),
+				dispatchedAt: formatAutomationDate(
+					row.dispatchedAt as Date | string | null | undefined,
+					null,
+				),
+				host: row.hostId ?? "—",
+			})),
+			["id", "status", "scheduledFor", "dispatchedAt", "host"],
+			["RUN ID", "STATUS", "SCHEDULED", "DISPATCHED", "HOST"],
+		),
+});

--- a/packages/cli/src/commands/automations/update/command.ts
+++ b/packages/cli/src/commands/automations/update/command.ts
@@ -51,6 +51,9 @@ export default command({
 			"Path to a JSON file with a full ResolvedAgentConfig (overrides --agent)",
 		),
 		host: string().desc("New target host id"),
+		project: string().desc("New v2 project id"),
+		workspace: string().desc("New v2 workspace id"),
+		mcpScope: string().desc("Comma-separated MCP scope strings"),
 		enabled: boolean().desc("Enable or pause the automation"),
 	},
 	run: async ({ ctx, args, options }) => {
@@ -69,6 +72,14 @@ export default command({
 				? resolveDefaultAgentConfig(options.agent)
 				: undefined;
 
+		const mcpScope =
+			options.mcpScope !== undefined
+				? options.mcpScope
+						.split(",")
+						.map((s) => s.trim())
+						.filter(Boolean)
+				: undefined;
+
 		const result = await ctx.api.automation.update.mutate({
 			id,
 			name: options.name,
@@ -77,6 +88,13 @@ export default command({
 			dtstart: options.dtstart ? new Date(options.dtstart) : undefined,
 			agentConfig,
 			...(options.host !== undefined ? { targetHostId: options.host } : {}),
+			...(options.project !== undefined
+				? { v2ProjectId: options.project }
+				: {}),
+			...(options.workspace !== undefined
+				? { v2WorkspaceId: options.workspace }
+				: {}),
+			...(mcpScope !== undefined ? { mcpScope } : {}),
 		});
 
 		return {

--- a/packages/cli/src/commands/tasks/update/command.ts
+++ b/packages/cli/src/commands/tasks/update/command.ts
@@ -1,4 +1,5 @@
-import { CLIError, positional, string } from "@superset/cli-framework";
+import { CLIError, number, positional, string } from "@superset/cli-framework";
+import { isValid, parseISO } from "date-fns";
 import { command } from "../../../lib/command";
 
 export default command({
@@ -11,11 +12,35 @@ export default command({
 			.enum("urgent", "high", "medium", "low", "none")
 			.desc("Priority"),
 		assignee: string().desc("Assignee user ID"),
+		statusId: string().desc("Status ID"),
+		prUrl: string().desc("Linked PR URL"),
+		estimate: number().int().min(1).desc("Story-point estimate"),
+		dueDate: string().desc("Due date (ISO 8601)"),
+		labels: string().desc("Comma-separated labels"),
 	},
 	run: async ({ ctx, args, options }) => {
 		const idOrSlug = args.idOrSlug as string;
 		const task = await ctx.api.task.byIdOrSlug.query(idOrSlug);
 		if (!task) throw new CLIError(`Task not found: ${idOrSlug}`);
+
+		let dueDate: Date | undefined;
+		if (options.dueDate !== undefined) {
+			const parsed = parseISO(options.dueDate);
+			if (!isValid(parsed)) {
+				throw new CLIError(
+					`--due-date: invalid ISO 8601 date "${options.dueDate}"`,
+				);
+			}
+			dueDate = parsed;
+		}
+
+		const labels =
+			options.labels !== undefined
+				? options.labels
+						.split(",")
+						.map((label) => label.trim())
+						.filter(Boolean)
+				: undefined;
 
 		const result = await ctx.api.task.update.mutate({
 			id: task.id,
@@ -23,6 +48,11 @@ export default command({
 			description: options.description ?? undefined,
 			priority: options.priority ?? undefined,
 			assigneeId: options.assignee ?? undefined,
+			statusId: options.statusId ?? undefined,
+			prUrl: options.prUrl ?? undefined,
+			estimate: options.estimate ?? undefined,
+			dueDate,
+			labels,
 		});
 
 		return {


### PR DESCRIPTION
## Summary

Audited the CLI, SDK, and MCP-v2 surfaces for automations / tasks / workspaces / hosts / projects and brought the CLI back into sync with what the SDK and MCP-v2 already expose. Four real misalignments — all in CLI:

- **`superset automations logs <id>`** was missing. SDK already had `automations.logs()` and MCP-v2 already had `automations_logs`, both wrapping `automation.listRuns`. New command added at `packages/cli/src/commands/automations/logs/command.ts`. Required a `.gitignore` exception so the new `logs/` directory isn't swallowed by the generic `logs` rule at the top of the file.
- **`automations create`** required `--project` at runtime even though the API schema (and SDK / MCP-v2) accepts `v2ProjectId` OR `v2WorkspaceId`. Now accepts either; errors only when both are missing.
- **`automations update`** didn't expose `--project`, `--workspace`, or `--mcp-scope` even though the underlying `automation.update` schema accepts all three (and SDK / MCP-v2 already pass them through). Added the flags; partial-update semantics preserved (omitting a flag leaves the field unchanged).
- **`tasks update`** was missing `--status-id`, `--pr-url`, `--estimate`, `--due-date`, `--labels`. `tasks create` already had most of these, so the create/update flag surface was asymmetric. SDK and MCP-v2 expose the full set; CLI now does too.

Surfaces I checked and found already aligned: `tasks list/get/create/delete`, `automations list/get/delete/pause/resume/run/getPrompt/setPrompt`, `hosts list`, `projects list`, `workspaces list/create/delete`. The legacy `packages/mcp` (mounted at `/api/agent/[transport]`) is a separate older domain (devices/organizations/tasks) and out of scope; `packages/desktop-mcp` is a different domain entirely (DOM/browser control).

## Test plan

- [x] `bun run typecheck --filter=@superset/cli` clean
- [x] `bun run typecheck --filter=@superset/sdk --filter=@superset/mcp-v2` clean (no transitive breakage)
- [x] `bun run lint:fix` clean
- [ ] Run `superset automations logs <id>` against a real automation and confirm table output
- [ ] Run `superset automations create --workspace <ws>` (no --project) and confirm it succeeds
- [ ] Run `superset tasks update <slug> --status-id <id> --labels foo,bar --estimate 3` and confirm the patch applies

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the `superset` CLI with `@superset/sdk` and `@superset/mcp-v2` for automations and tasks. Adds automation run logs, completes update flags, and fixes create to accept workspace IDs.

- **New Features**
  - Add `superset automations logs <id>` to list recent runs (supports `--limit`).
  - `tasks update` now supports `--status-id`, `--pr-url`, `--estimate`, `--due-date` (ISO), and `--labels`.

- **Bug Fixes**
  - `automations create` now accepts `--project` or `--workspace` (either).
  - `automations update` exposes `--project`, `--workspace`, and `--mcp-scope`.
  - Use `undefined` (not `null`) for optional `v2ProjectId`/`v2WorkspaceId` on create to match schema expectations.

<sup>Written for commit 924c4453b0b5ba07766e343782f38a9b6674a8fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automation logs command to display recent automation runs with run ID, status, scheduled/dispatched times, and host.
  * Added task update options: status ID, PR URL, estimate, due date, and labels.

* **Enhancements**
  * Automation create command now accepts either --project or --workspace (requires at least one).
  * Automation update command now supports --project, --workspace, and --mcpScope options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->