### PR TITLE
fix(desktop): stable createdAt tiebreaker in v2 workspaces list sort

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/V2WorkspacesList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/components/V2WorkspacesList/V2WorkspacesList.tsx
@@ -74,10 +74,9 @@ function compareWorkspaces(
 			cmp = a.createdAt.getTime() - b.createdAt.getTime();
 			break;
 	}
-	if (cmp === 0) {
-		cmp = b.createdAt.getTime() - a.createdAt.getTime();
-	}
-	return direction === "asc" ? cmp : -cmp;
+	const directional = direction === "asc" ? cmp : -cmp;
+	if (directional !== 0) return directional;
+	return b.createdAt.getTime() - a.createdAt.getTime();
 }
 
 function groupByProject(


### PR DESCRIPTION
## Summary
- In the v2 workspaces list, the within-host createdAt tiebreaker was being inverted whenever the user toggled the host (device) sort direction, because the directional flip wrapped both the primary comparison and the tiebreaker.
- Apply the asc/desc flip to the primary-field comparison only, then always use newest-first `createdAt` as the final tiebreaker. After grouping by device, workspaces on the same device now sort by createdAt consistently regardless of direction.

## Test plan
- [ ] Open the v2 workspaces list with multiple workspaces on the same device
- [ ] Sort by Host asc — within each device, newest workspace appears first
- [ ] Toggle to Host desc — within each device, newest still appears first
- [ ] Sort by Name / Branch / In sidebar — ties also break newest-first
- [ ] Sort by Created — primary direction still works as before

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sorting in the v2 workspaces list by making `createdAt` a stable, newest-first tiebreaker. Within each device, the newest workspace stays first regardless of Host sort direction; Created sorting still respects asc/desc.

- **Bug Fixes**
  - Direction flip now applies only to the primary field.
  - Ties break by `createdAt` consistently across Host, Name, Branch, and Sidebar.

<sup>Written for commit d98e36baffd8cb590e158d4f343b790048cf55ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace list sorting logic to ensure consistent ordering when workspaces share the same primary sort criteria. Workspaces are now ordered by creation date as a secondary sort option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->