### PR TITLE
fix(desktop): show v2 sidebar PR badges for remote-host workspaces

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/derivePullRequestQueryTargets.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/derivePullRequestQueryTargets.ts
@@ -1,0 +1,104 @@
+import { buildHostRoutingKey } from "@superset/shared/host-routing";
+import type { DashboardSidebarWorkspaceHostType } from "../../types";
+
+export interface PullRequestQueryHostRow {
+	organizationId: string;
+	machineId: string;
+	isOnline: boolean;
+}
+
+export interface PullRequestQueryWorkspaceRow {
+	id: string;
+	hostId: string;
+}
+
+export interface PullRequestQueryTarget {
+	machineId: string;
+	hostType: DashboardSidebarWorkspaceHostType;
+	hostUrl: string;
+	workspaceIds: string[];
+}
+
+export function derivePullRequestQueryTargets({
+	activeHostUrl,
+	hosts,
+	machineId,
+	relayUrl,
+	workspaces,
+}: {
+	activeHostUrl: string | null;
+	hosts: PullRequestQueryHostRow[];
+	machineId: string | null;
+	relayUrl: string;
+	workspaces: PullRequestQueryWorkspaceRow[];
+}): PullRequestQueryTarget[] {
+	const workspaceIdsByHostId = new Map<string, string[]>();
+	for (const workspace of workspaces) {
+		const existing = workspaceIdsByHostId.get(workspace.hostId);
+		if (existing) {
+			existing.push(workspace.id);
+		} else {
+			workspaceIdsByHostId.set(workspace.hostId, [workspace.id]);
+		}
+	}
+	for (const workspaceIds of workspaceIdsByHostId.values()) {
+		workspaceIds.sort();
+	}
+
+	const targets = hosts.flatMap((host) => {
+		const workspaceIds = workspaceIdsByHostId.get(host.machineId);
+		if (!workspaceIds || workspaceIds.length === 0) return [];
+
+		const isLocal = host.machineId === machineId;
+		if (!isLocal && !host.isOnline) return [];
+
+		const hostUrl = isLocal
+			? activeHostUrl
+			: `${relayUrl}/hosts/${buildHostRoutingKey(host.organizationId, host.machineId)}`;
+		if (!hostUrl) return [];
+
+		return [
+			{
+				machineId: host.machineId,
+				hostType: isLocal
+					? ("local-device" as const)
+					: ("remote-device" as const),
+				hostUrl,
+				workspaceIds,
+			},
+		];
+	});
+
+	// If the local v2Hosts row hasn't synced via Electric yet, the loop above
+	// won't include it — synthesize a local target from machineId + activeHostUrl
+	// when there are local-host workspaces visible.
+	if (
+		machineId &&
+		activeHostUrl &&
+		!targets.some((target) => target.machineId === machineId)
+	) {
+		const localWorkspaceIds = workspaceIdsByHostId.get(machineId);
+		if (localWorkspaceIds && localWorkspaceIds.length > 0) {
+			targets.push({
+				machineId,
+				hostType: "local-device",
+				hostUrl: activeHostUrl,
+				workspaceIds: localWorkspaceIds,
+			});
+		}
+	}
+
+	return targets;
+}
+
+export function getDashboardSidebarPullRequestQueryKey(
+	target: PullRequestQueryTarget,
+) {
+	return [
+		"dashboard-sidebar",
+		"pull-requests",
+		target.machineId,
+		target.hostUrl,
+		target.workspaceIds,
+	] as const;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -1,39 +1,35 @@
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
-import { useQuery } from "@tanstack/react-query";
+import { useQueries, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo, useRef } from "react";
 import { env } from "renderer/env.renderer";
-import { authClient } from "renderer/lib/auth-client";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { getVisibleSidebarWorkspaces } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
-import { MOCK_ORG_ID } from "shared/constants";
 import type {
 	DashboardSidebarProject,
 	DashboardSidebarProjectChild,
 	DashboardSidebarSection,
 	DashboardSidebarWorkspace,
 } from "../../types";
+import {
+	derivePullRequestQueryTargets,
+	getDashboardSidebarPullRequestQueryKey,
+	type PullRequestQueryTarget,
+} from "./derivePullRequestQueryTargets";
 
 // Sits above every real workspace so the pending row lines up with the real one,
 // which is inserted via getPrependTabOrder.
 const PENDING_WORKSPACE_TAB_ORDER = Number.MIN_SAFE_INTEGER;
 const MAIN_WORKSPACE_TAB_ORDER = Number.MIN_SAFE_INTEGER;
 
-type LocalPullRequest = DashboardSidebarWorkspace["pullRequest"];
+type SidebarPullRequest = DashboardSidebarWorkspace["pullRequest"];
 type PullRequestWorkspaceRow = {
 	workspaceId: string;
-	pullRequest: LocalPullRequest;
+	pullRequest: SidebarPullRequest;
 };
-
-function haveSameStrings(left: string[], right: string[]): boolean {
-	return (
-		left.length === right.length &&
-		left.every((value, index) => value === right[index])
-	);
-}
 
 function haveSameProjects(
 	left: DashboardSidebarProject[],
@@ -63,26 +59,12 @@ function getDashboardSidebarProjectFingerprint(
 	return JSON.stringify(project);
 }
 
-function useStableStringArray(values: string[]): string[] {
-	const previousRef = useRef<string[] | null>(null);
-
-	return useMemo(() => {
-		const previous = previousRef.current;
-		if (previous && haveSameStrings(previous, values)) {
-			return previous;
-		}
-
-		previousRef.current = values;
-		return values;
-	}, [values]);
-}
-
-function useStableLocalPullRequestsByWorkspaceId(
+function useStablePullRequestsByWorkspaceId(
 	rows: PullRequestWorkspaceRow[] | undefined,
-): Map<string, LocalPullRequest> {
+): Map<string, SidebarPullRequest> {
 	const previousRef = useRef<{
 		fingerprint: string;
-		map: Map<string, LocalPullRequest>;
+		map: Map<string, SidebarPullRequest>;
 	} | null>(null);
 
 	return useMemo(() => {
@@ -144,10 +126,10 @@ function useStableDashboardSidebarProjects(
 }
 
 export function useDashboardSidebarData() {
-	const { data: session } = authClient.useSession();
 	const collections = useCollections();
 	const { machineId, activeHostUrl } = useLocalHostService();
 	const { toggleProjectCollapsed } = useDashboardSidebarState();
+	const queryClient = useQueryClient();
 
 	// Query pending workspaces from the local collection
 	const { data: pendingWorkspaces = [] } = useLiveQuery(
@@ -161,12 +143,16 @@ export function useDashboardSidebarData() {
 			})),
 		[collections],
 	);
-	const activeOrganizationId = env.SKIP_ENV_VALIDATION
-		? MOCK_ORG_ID
-		: (session?.session?.activeOrganizationId ?? null);
-	const activeHostClient = activeHostUrl
-		? getHostServiceClientByUrl(activeHostUrl)
-		: null;
+
+	const { data: hosts = [] } = useLiveQuery(
+		(q) =>
+			q.from({ hosts: collections.v2Hosts }).select(({ hosts }) => ({
+				organizationId: hosts.organizationId,
+				machineId: hosts.machineId,
+				isOnline: hosts.isOnline,
+			})),
+		[collections],
+	);
 
 	const { data: rawSidebarProjects = [] } = useLiveQuery(
 		(q) =>
@@ -310,47 +296,70 @@ export function useDashboardSidebarData() {
 		sidebarWorkspaces,
 	]);
 
-	const computedLocalWorkspaceIds = useMemo(
+	const pullRequestQueryTargets = useMemo<PullRequestQueryTarget[]>(
 		() =>
-			visibleSidebarWorkspaces
-				.filter((workspace) => workspace.hostId === machineId)
-				.map((workspace) => workspace.id)
-				.sort(),
-		[machineId, visibleSidebarWorkspaces],
+			derivePullRequestQueryTargets({
+				activeHostUrl,
+				hosts,
+				machineId,
+				relayUrl: env.RELAY_URL,
+				workspaces: visibleSidebarWorkspaces,
+			}),
+		[activeHostUrl, hosts, machineId, visibleSidebarWorkspaces],
 	);
-	const localWorkspaceIds = useStableStringArray(computedLocalWorkspaceIds);
 
-	const { data: pullRequestData, refetch: refetchPullRequests } = useQuery({
-		queryKey: [
-			"dashboard-sidebar",
-			"pull-requests",
-			activeOrganizationId,
-			localWorkspaceIds,
-		],
-		enabled: activeHostClient !== null && localWorkspaceIds.length > 0,
-		refetchInterval: 10_000,
-		queryFn: () =>
-			activeHostClient?.pullRequests.getByWorkspaces.query({
-				workspaceIds: localWorkspaceIds,
-			}) ?? Promise.resolve({ workspaces: [] }),
+	const pullRequestQueries = useQueries({
+		queries: pullRequestQueryTargets.map((target) => ({
+			queryKey: getDashboardSidebarPullRequestQueryKey(target),
+			refetchInterval: 10_000,
+			queryFn: async () => {
+				const client = getHostServiceClientByUrl(target.hostUrl);
+				return client.pullRequests.getByWorkspaces.query({
+					workspaceIds: target.workspaceIds,
+				});
+			},
+		})),
 	});
+
+	const pullRequestRows = useMemo<PullRequestWorkspaceRow[]>(() => {
+		const rows: PullRequestWorkspaceRow[] = [];
+		for (const query of pullRequestQueries) {
+			const data = query.data;
+			if (!data) continue;
+			for (const row of data.workspaces) {
+				rows.push({
+					workspaceId: row.workspaceId,
+					pullRequest: row.pullRequest,
+				});
+			}
+		}
+		return rows;
+	}, [pullRequestQueries]);
 
 	const refreshWorkspacePullRequest = useCallback(
 		async (workspaceId: string) => {
-			if (!activeHostClient || !localWorkspaceIds.includes(workspaceId)) {
-				return;
-			}
+			const workspace = visibleSidebarWorkspaces.find(
+				(candidate) => candidate.id === workspaceId,
+			);
+			if (!workspace) return;
+			const target = pullRequestQueryTargets.find(
+				(candidate) => candidate.machineId === workspace.hostId,
+			);
+			if (!target) return;
 
-			await activeHostClient.pullRequests.refreshByWorkspaces.mutate({
+			const client = getHostServiceClientByUrl(target.hostUrl);
+			await client.pullRequests.refreshByWorkspaces.mutate({
 				workspaceIds: [workspaceId],
 			});
-			await refetchPullRequests();
+			await queryClient.invalidateQueries({
+				queryKey: getDashboardSidebarPullRequestQueryKey(target),
+			});
 		},
-		[activeHostClient, localWorkspaceIds, refetchPullRequests],
+		[pullRequestQueryTargets, queryClient, visibleSidebarWorkspaces],
 	);
 
-	const localPullRequestsByWorkspaceId =
-		useStableLocalPullRequestsByWorkspaceId(pullRequestData?.workspaces);
+	const pullRequestsByWorkspaceId =
+		useStablePullRequestsByWorkspaceId(pullRequestRows);
 
 	const computedGroups = useMemo<DashboardSidebarProject[]>(() => {
 		const projectsById = new Map<
@@ -410,10 +419,7 @@ export function useDashboardSidebarData() {
 				accentColor: null,
 				name: workspace.name,
 				branch: workspace.branch,
-				pullRequest:
-					hostType === "local-device"
-						? (localPullRequestsByWorkspaceId.get(workspace.id) ?? null)
-						: null,
+				pullRequest: pullRequestsByWorkspaceId.get(workspace.id) ?? null,
 				repoUrl:
 					project.githubOwner && project.githubRepoName
 						? `https://github.com/${project.githubOwner}/${project.githubRepoName}`
@@ -523,7 +529,7 @@ export function useDashboardSidebarData() {
 		});
 	}, [
 		machineId,
-		localPullRequestsByWorkspaceId,
+		pullRequestsByWorkspaceId,
 		pendingWorkspaces,
 		sidebarProjects,
 		sidebarSections,
@@ -533,7 +539,6 @@ export function useDashboardSidebarData() {
 
 	return {
 		groups,
-		refetchPullRequests,
 		refreshWorkspacePullRequest,
 		toggleProjectCollapsed,
 	};


### PR DESCRIPTION
## Summary
- The v2 dashboard sidebar only rendered PR badges for workspaces on the local device. Remote-host workspaces silently got `pullRequest: null` even though the owning host's host-service was already polling GitHub for them.
- Root cause in `useDashboardSidebarData`: it filtered workspace IDs to `hostId === machineId`, queried only the loopback host-service via `activeHostUrl`, and then explicitly nulled `pullRequest` for `hostType === "remote-device"`.
- This change fans `pullRequests.getByWorkspaces` out across every online host using the same pattern `useDashboardSidebarPortsData` already uses for ports — loopback URL for local + relay URL (`${RELAY_URL}/hosts/${buildHostRoutingKey(orgId, machineId)}`) for each remote host. Auth (`getHostServiceHeaders`) and routing (relay → tunneled host-service) already handle this transport, so no backend changes are needed.
- New helper `derivePullRequestQueryTargets` is co-located with the hook and mirrors `deriveHostPortQueryTargets` (offline-remote skip + synthesize-local-when-v2Hosts-not-yet-synced fallback included). The manual refresh button now routes the `refreshByWorkspaces` mutation to the workspace's owning host URL and invalidates only that host's query.
- Why not piggyback on the Electric-synced `collections.githubPullRequests`: many users haven't installed the GitHub App on their org, so cloud-PR coverage would be partial. The host-service path works regardless of GitHub App install status.

## Test plan
- [ ] Two devices in the same org: open a PR for a workspace on device B; confirm device A's sidebar shows the PR badge + hover card within ~10s and the link opens the GitHub URL.
- [ ] Local regression: existing local workspaces still show PR badges as before.
- [ ] Quit device B's app, wait for the relay liveness window (~90s) to flip `v2Hosts.isOnline` to false, confirm device A stops issuing relay queries for that host.
- [ ] On a remote workspace's row, trigger the manual PR refresh — confirm the request hits the relay URL (not loopback) and the badge updates.
- [ ] Org with no GitHub App connected: confirm both local and remote PR badges still appear (proves we don't depend on the cloud `github_pull_requests` table).
- [ ] `bun run typecheck` and `bun run lint` clean (verified locally).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing PR badges in the v2 dashboard sidebar for remote-host workspaces by fetching PRs from every online host (local + relay) instead of only the local host-service. Remote workspaces now show the correct PR badge and hover card.

- **Bug Fixes**
  - Fanned out `pullRequests.getByWorkspaces` across all online hosts (loopback for local, relay per remote).
  - Added `derivePullRequestQueryTargets` with offline-remote skip and a local synth fallback; stable per-host query keys.
  - Switched to `useQueries` and merged per-host results into the sidebar.
  - Manual refresh now hits the workspace’s owning host and invalidates only that host’s query.
  - Removed logic that nulled PRs for `remote-device`; no dependency on cloud `collections.githubPullRequests`.

<sup>Written for commit 83f7ce1f2a96aa1be5b58a90e1157a7966b6093e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard sidebar now retrieves pull requests from all connected hosts and workspaces simultaneously, providing a unified view of all pull request activity.

* **Improvements**
  * Enhanced pull request handling for both local and remote hosts with consistent display behavior.
  * Optimized pull request refresh mechanism for improved performance across multiple workspace sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->