### PR TITLE
release(cli): cut v0.2.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -674,7 +674,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@clack/prompts": "^0.10.0",
         "@superset/cli-framework": "workspace:*",

--- a/packages/cli/cli.config.ts
+++ b/packages/cli/cli.config.ts
@@ -1,6 +1,6 @@
 import { boolean, defineConfig, string } from "@superset/cli-framework";
 
-const VERSION = "0.2.2";
+const VERSION = "0.2.3";
 
 export default defineConfig({
 	name: "superset",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "0.2.2",
+	"version": "0.2.3",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Summary
- Bumps `@superset/cli` 0.2.2 → 0.2.3 (`package.json`, `cli.config.ts`, `bun.lock`).
- Bundles the 5 feat(cli) commits since v0.2.2 — see commit body for the list.
- Push `cli-v0.2.3` after this lands to fire the release pipeline.

## Test plan
- [ ] CI green
- [ ] After merge: `git tag cli-v0.2.3 <merge-sha> && git push origin cli-v0.2.3`
- [ ] Verify release pipeline publishes the tarballs
- [ ] Smoke-test `superset --version` reports 0.2.3

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `@superset/cli` v0.2.3 to ship recent CLI features and bump version in `package.json`, `cli.config.ts`, and `bun.lock`.

- **New Features**
  - Align automations and tasks with SDK and MCP-v2.
  - Cross-device login via OAuth code + PKCE.
  - Split `automations prompt` into `prompt get` and `prompt set`.
  - Add `--name` filter to `automations list`.
  - Add `--assignee` filter to `tasks list`.

<sup>Written for commit 56619deb6da496b3893463f93d3b76a4b0b8c8a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CLI package version updated to 0.2.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->