### PR TITLE
chore(desktop): remove spammy terminal_cold_restored PostHog event

### DIFF
--- a/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts
+++ b/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts
@@ -592,19 +592,11 @@ export class DaemonTerminalManager extends EventEmitter {
 			rawScrollbackBytes > MAX_SCROLLBACK_BYTES
 				? truncateUtf8ToLastBytes(rawScrollback, MAX_SCROLLBACK_BYTES)
 				: rawScrollback;
-		const scrollbackBytes = Buffer.byteLength(scrollback, "utf8");
-
 		this.coldRestoreInfo.set(paneId, {
 			scrollback,
 			previousCwd: metadata.cwd,
 			cols: metadata.cols || cols,
 			rows: metadata.rows || rows,
-		});
-
-		track("terminal_cold_restored", {
-			workspace_id: workspaceId,
-			pane_id: paneId,
-			scrollback_bytes: scrollbackBytes,
 		});
 
 		return {


### PR DESCRIPTION
## Summary
Same shape as the `terminal_warm_attached` removal in #1981 — `terminal_cold_restored` is a pure-lifecycle event fired by the main-process daemon manager every time a pane is recovered from scrollback after an unclean shutdown.

PostHog data (last 30 days, prod):
- **149k events** across 9.5k unique users
- **16 events / user** — fires once per recovered pane on every restore, so multi-pane workspaces multiply it
- Zero user-intent signal — the value (was a shutdown unclean? did recovery work?) is better captured in main-process logs

Drops one `track()` call in `daemon-manager.ts` and the `scrollbackBytes` local that only existed to feed it. The `track` import stays — `terminal_daemon_disconnected` still uses it.

## Test plan
- [ ] CI green
- [ ] Smoke: open a workspace, force-quit the desktop app, relaunch — terminal scrollback still restores (the `coldRestoreInfo` set + `wasRecovered: true` return path are unchanged; only the analytics call was removed)
- [ ] After merge, watch PostHog `terminal_cold_restored` event volume — should drain to zero as users update past this build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `terminal_cold_restored` PostHog event that fired on scrollback recovery to reduce noisy analytics. Scrollback restore behavior is unchanged.

- **Refactors**
  - Dropped `track("terminal_cold_restored", ...)` in `apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts`.
  - Removed `scrollbackBytes` local used only for that event; kept `track` import for `terminal_daemon_disconnected`.

<sup>Written for commit 1259e080be7d553724182451cb6e713a29e8968b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined terminal session restoration process for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->