### PR TITLE
fix(cli): stage update bundle next to install root to avoid EXDEV

### DIFF
--- a/packages/cli/src/commands/update/command.ts
+++ b/packages/cli/src/commands/update/command.ts
@@ -9,7 +9,6 @@ import {
 	rmSync,
 	statSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
@@ -186,7 +185,12 @@ export default command({
 		}
 
 		const installRoot = resolveInstallRoot();
-		const tempDir = mkdtempSync(join(tmpdir(), "superset-update-"));
+		// Stage the new bundle as a sibling of installRoot so it's on the same
+		// filesystem — atomicReplace() uses renameSync, which fails with EXDEV
+		// across mounts (e.g. /tmp on a separate device from the install dir).
+		const tempDir = mkdtempSync(
+			join(dirname(installRoot), ".superset-update-"),
+		);
 
 		try {
 			await downloadAndExtract(tarballUrl(target, pinnedVersion), tempDir);


### PR DESCRIPTION
## Summary

- `superset update` failed on hosts where `/tmp` is on a different mount than the install directory, with `EXDEV: cross-device link not permitted, rename '/tmp/superset-update-XXXX' -> '<installRoot>'`.
- Root cause: `packages/cli/src/commands/update/command.ts` staged the new bundle in `os.tmpdir()` and then `atomicReplace()` did a single `renameSync(newRoot, installRoot)`. `rename(2)` returns EXDEV across filesystems, and the catch path just re-throws after rolling the backup back.
- Fix: stage the bundle as a sibling of `installRoot` (`mkdtemp` under `dirname(installRoot)`), so the rename is always intra-filesystem and stays truly atomic. No fallback copy path needed.

Repro on a host with `/tmp` on a separate device:

```
$ df /tmp /home/sprite/superset
Filesystem     1K-blocks     Used Available Use% Mounted on
/dev/vdb        20466256 16818284   2583012  87% /tmp
overlay        103069272  9889892  93162996  10% /
$ superset update
Error: EXDEV: cross-device link not permitted, rename '/tmp/superset-update-5EyRiG' -> '/home/sprite/superset'
```

After the fix, staging happens under `/home/sprite/.superset-update-XXXX` (same fs as `/home/sprite/superset`), and the rename succeeds.

The repo already knows this pattern — `apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts:733` has the comment "Rename the worktree to a sibling temp dir (same filesystem to avoid EXDEV)" — same fix applied here.

## Test plan

- [ ] On a host where `/tmp` and the install dir are on different filesystems, run `superset update` (or `superset update --force`) and confirm it succeeds end-to-end.
- [ ] On a host where they're on the same filesystem (the common case), confirm `superset update` still works — staging just moves from `/tmp` to `dirname(installRoot)`.
- [ ] With `SUPERSET_INSTALL_ROOT` overridden, confirm staging happens next to the override and the rename succeeds.
- [ ] On failure (e.g. corrupted tarball), confirm the existing rollback still restores `installRoot.bak` → `installRoot`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `superset update` failures on hosts where `/tmp` is on a different filesystem. The update now renames within the same filesystem to stay atomic and avoid `EXDEV`.

- **Bug Fixes**
  - Stage updates under `dirname(installRoot)` (e.g., `.superset-update-*`) instead of `os.tmpdir()`.
  - Keeps `renameSync` in `atomicReplace()` on the same filesystem to prevent `EXDEV`.
  - Respects `SUPERSET_INSTALL_ROOT` by staging next to the resolved install root.

<sup>Written for commit 2574cd1c020666431bcc2b0ced2649f07ace00ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed update command failures that occurred when temporary and installation directories were on separate filesystems or mounted volumes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->