### PR TITLE
fix: carry PTY output as bytes end-to-end (renderer + daemon wires)

### DIFF
--- a/apps/desktop/src/main/terminal-host/session.ts
+++ b/apps/desktop/src/main/terminal-host/session.ts
@@ -1051,14 +1051,17 @@ export class Session {
 			clearTimeout(this.shellReadyTimeoutId);
 			this.shellReadyTimeoutId = null;
 		}
-		// Flush held marker bytes — they weren't part of a full marker
+		// Flush held marker bytes — they weren't part of a full marker.
+		// heldBytes is `number[]` after the byte-scanner refactor; decode to a
+		// utf-8 string for v1's emulator/event surface, which is string-based.
 		if (this.scanState.heldBytes.length > 0) {
-			this.enqueueEmulatorWrite(this.scanState.heldBytes);
+			const flushed = Buffer.from(this.scanState.heldBytes).toString("utf8");
+			this.enqueueEmulatorWrite(flushed);
 			this.broadcastEvent("data", {
 				type: "data",
-				data: this.scanState.heldBytes,
+				data: flushed,
 			} satisfies TerminalDataEvent);
-			this.scanState.heldBytes = "";
+			this.scanState.heldBytes.length = 0;
 		}
 		this.scanState.matchPos = 0;
 	}

--- a/apps/desktop/src/main/terminal-host/session.ts
+++ b/apps/desktop/src/main/terminal-host/session.ts
@@ -360,18 +360,32 @@ export class Session {
 
 			case PtySubprocessIpcType.Data: {
 				if (payload.length === 0) break;
-				let data = payload.toString("utf8");
 
 				// Scan for OSC 133;A (shell ready) and strip from output.
+				// scanForShellReady operates on bytes — the OSC marker is pure
+				// ASCII, so byte-level matching is identical to char-level
+				// matching, and we avoid `payload.toString("utf8")` per chunk
+				// (which mangles multi-byte codepoints split across chunks).
+				let bytes: Uint8Array = payload;
 				if (this.shellReadyState === "pending") {
-					const result = scanForShellReady(this.scanState, data);
-					data = result.output;
+					const result = scanForShellReady(this.scanState, payload);
+					bytes = result.output;
 					if (result.matched) {
 						this.resolveShellReady("ready");
 					}
 				}
 
-				if (data.length === 0) break;
+				if (bytes.length === 0) break;
+				// v1's emulator + IPC consumers want a string. UTF-8 decode the
+				// stripped bytes here. Boundary mangling is still possible at
+				// chunk edges (v1 has no per-session StringDecoder), but v1 is
+				// sunset — the v2 daemon-backed path is the supported one and
+				// it's clean end-to-end.
+				const data = Buffer.from(
+					bytes.buffer,
+					bytes.byteOffset,
+					bytes.byteLength,
+				).toString("utf8");
 
 				this.enqueueEmulatorWrite(data);
 

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -11,11 +11,14 @@ export interface TerminalLogEntry {
 	message: string;
 }
 
+// PTY output bytes arrive as binary WebSocket frames and are fed straight
+// into xterm.write(Uint8Array) — no UTF-8 decoding hop, so multi-byte
+// codepoints that straddle a frame boundary stay intact (xterm.js buffers
+// partial sequences internally). Control messages (title/error/exit) stay
+// JSON.
 type TerminalServerMessage =
-	| { type: "data"; data: string }
 	| { type: "error"; message: string }
 	| { type: "exit"; exitCode: number; signal: number }
-	| { type: "replay"; data: string }
 	| { type: "title"; title: string | null };
 
 export interface TerminalTransport {
@@ -193,6 +196,10 @@ export function connect(
 	transport._exited = false;
 	setConnectionState(transport, "connecting");
 	const socket = new WebSocket(wsUrl);
+	// Receive PTY bytes as ArrayBuffer (the default would be Blob, which
+	// forces an async read); we want to feed bytes synchronously into
+	// xterm.write to keep render order strict.
+	socket.binaryType = "arraybuffer";
 	transport.socket = socket;
 
 	socket.addEventListener("open", () => {
@@ -212,16 +219,20 @@ export function connect(
 
 	socket.addEventListener("message", (event) => {
 		if (transport.socket !== socket) return;
+
+		// Binary frame = PTY output bytes (data + replay collapsed onto one
+		// channel; renderer treats them identically). Pipe straight into
+		// xterm without any decoding step.
+		if (event.data instanceof ArrayBuffer) {
+			terminal.write(new Uint8Array(event.data));
+			return;
+		}
+
 		let message: TerminalServerMessage;
 		try {
 			message = JSON.parse(String(event.data)) as TerminalServerMessage;
 		} catch {
 			terminal.writeln("\r\n[terminal] invalid server payload");
-			return;
-		}
-
-		if (message.type === "data" || message.type === "replay") {
-			terminal.write(message.data);
 			return;
 		}
 

--- a/packages/host-service/src/daemon/DaemonSupervisor.test.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.test.ts
@@ -73,8 +73,8 @@ async function startFakeDaemon(opts: FakeDaemonOptions): Promise<{
 		const decoder = new FrameDecoder();
 		sock.on("data", (chunk: Buffer) => {
 			decoder.push(chunk);
-			for (const raw of decoder.drain()) {
-				const msg = raw as ClientMessage;
+			for (const decoded of decoder.drain()) {
+				const msg = decoded.message as ClientMessage;
 				if (msg.type !== "hello") continue;
 				if (opts.silent) return;
 				if (opts.hangUpAfterHello) {

--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -658,8 +658,8 @@ export async function listDaemonSessions(
 		sock.on("data", (chunk: Buffer) => {
 			try {
 				decoder.push(chunk);
-				for (const raw of decoder.drain()) {
-					const msg = raw as ServerMessage;
+				for (const decoded of decoder.drain()) {
+					const msg = decoded.message as ServerMessage;
 					if (!helloAcked) {
 						if (msg.type !== "hello-ack") {
 							cleanup(null);
@@ -740,8 +740,8 @@ export async function probeDaemonVersion(
 		sock.on("data", (chunk: Buffer) => {
 			try {
 				decoder.push(chunk);
-				for (const raw of decoder.drain()) {
-					const msg = raw as ServerMessage;
+				for (const decoded of decoder.drain()) {
+					const msg = decoded.message as ServerMessage;
 					if (msg.type === "hello-ack") {
 						cleanup(msg.daemonVersion ?? null);
 						return;

--- a/packages/host-service/src/terminal/DaemonClient/DaemonClient.ts
+++ b/packages/host-service/src/terminal/DaemonClient/DaemonClient.ts
@@ -150,11 +150,9 @@ export class DaemonClient {
 
 	/** Fire-and-forget; bytes go straight to the PTY. */
 	input(id: string, data: Buffer): void {
-		this.send({
-			type: "input",
-			id,
-			data: data.toString("base64"),
-		});
+		// Bytes ride in the frame's binary tail (see ../../protocol/framing.ts).
+		// No base64 hop on either side.
+		this.send({ type: "input", id }, data);
 	}
 
 	/** Fire-and-forget; daemon validates dims. */
@@ -368,17 +366,17 @@ export class DaemonClient {
 		});
 	}
 
-	private send(msg: unknown): void {
+	private send(msg: unknown, payload?: Uint8Array): void {
 		const sock = this.socket;
 		if (!sock || sock.destroyed) {
 			throw new Error("DaemonClient: socket not connected");
 		}
-		sock.write(encodeFrame(msg));
+		sock.write(encodeFrame(msg, payload));
 	}
 
 	private onData(chunk: Buffer): void {
 		this.decoder.push(chunk);
-		let frames: unknown[];
+		let frames: ReturnType<FrameDecoder["drain"]>;
 		try {
 			frames = this.decoder.drain();
 		} catch (err) {
@@ -390,13 +388,21 @@ export class DaemonClient {
 			this.onClose(err as Error);
 			return;
 		}
-		for (const raw of frames) {
-			const msg = raw as ServerMessage;
+		for (const frame of frames) {
+			const msg = frame.message as ServerMessage;
 			// Route session-keyed events to subscriber callbacks.
 			if (msg.type === "output" && this.callbacks.has(msg.id)) {
-				const buf = Buffer.from(msg.data, "base64");
-				for (const cb of this.callbacks.get(msg.id)?.output ?? []) {
-					cb(buf);
+				if (frame.payload) {
+					// Hand the bytes to subscribers as a Buffer view; same shape
+					// they got pre-binary-tail when we base64-decoded into Buffer.
+					const buf = Buffer.from(
+						frame.payload.buffer,
+						frame.payload.byteOffset,
+						frame.payload.byteLength,
+					);
+					for (const cb of this.callbacks.get(msg.id)?.output ?? []) {
+						cb(buf);
+					}
 				}
 				continue;
 			}

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -1,15 +1,16 @@
 import { existsSync } from "node:fs";
+import { StringDecoder } from "node:string_decoder";
 import type { NodeWebSocket } from "@hono/node-ws";
 import {
-	createScanState,
+	createScanStateBytes,
 	SHELLS_WITH_READY_MARKER,
-	type ShellReadyScanState,
-	scanForShellReady,
+	type ShellReadyScanStateBytes,
+	scanForShellReadyBytes,
 } from "@superset/shared/shell-ready-scanner";
 import {
-	createTerminalTitleScanState,
-	scanForTerminalTitle,
-	type TerminalTitleScanState,
+	createTerminalTitleScanStateBytes,
+	scanForTerminalTitleBytes,
+	type TerminalTitleScanStateBytes,
 } from "@superset/shared/terminal-title-scanner";
 import { and, eq, ne } from "drizzle-orm";
 import type { Hono } from "hono";
@@ -82,11 +83,19 @@ function makeDaemonPty(
 				});
 		},
 		onData(cb) {
+			// StringDecoder buffers partial UTF-8 sequences across chunks.
+			// Without it `chunk.toString("utf8")` per chunk replaces the trailing
+			// 1–3 bytes of any codepoint that straddles a boundary with U+FFFD —
+			// the same bug we ripped out of the primary data path.
+			const decoder = new StringDecoder("utf8");
 			const unsub = daemon.subscribe(
 				sessionId,
 				{ replay: false },
 				{
-					onOutput: (chunk) => cb(chunk.toString("utf8")),
+					onOutput: (chunk) => {
+						const out = decoder.write(chunk);
+						if (out.length > 0) cb(out);
+					},
 					onExit: () => {},
 				},
 			);
@@ -137,11 +146,14 @@ type TerminalClientMessage =
 	| { type: "resize"; cols: number; rows: number }
 	| { type: "dispose" };
 
+// PTY output bytes travel as binary WebSocket frames — the renderer pipes
+// the ArrayBuffer straight into xterm.write(Uint8Array) without any UTF-8
+// decoding. Control messages stay JSON. Replay (the buffered prefix sent
+// on attach) is a binary frame too; the renderer doesn't distinguish it
+// from live data.
 type TerminalServerMessage =
-	| { type: "data"; data: string }
 	| { type: "error"; message: string }
 	| { type: "exit"; exitCode: number; signal: number }
-	| { type: "replay"; data: string }
 	| { type: "title"; title: string | null };
 
 const MAX_BUFFER_BYTES = 64 * 1024;
@@ -149,8 +161,11 @@ const SOCKET_OPEN = 1;
 const SOCKET_CLOSING = 2;
 const SOCKET_CLOSED = 3;
 
+// `Uint8Array<ArrayBuffer>` (not the looser `Uint8Array<ArrayBufferLike>`)
+// matches what hono/ws's WSContext.send accepts. Buffers from node and from
+// our scanners are all ArrayBuffer-backed, so this is the right narrowing.
 type TerminalSocket = {
-	send: (data: string) => void;
+	send: (data: string | Uint8Array<ArrayBuffer>) => void;
 	close: (code?: number, reason?: string) => void;
 	readyState: number;
 };
@@ -183,7 +198,12 @@ interface TerminalSession {
 	/** Unsubscribe from the daemon's output/exit stream when disposed. */
 	unsubscribeDaemon: (() => void) | null;
 	sockets: Set<TerminalSocket>;
-	buffer: string[];
+	/**
+	 * Buffered PTY output retained for replay on (re)attach. Bytes, not
+	 * strings — keeping this byte-aligned with the wire frees us from the
+	 * per-chunk UTF-8 decoding that used to mangle TUIs.
+	 */
+	buffer: Uint8Array[];
 	bufferBytes: number;
 	createdAt: number;
 	exited: boolean;
@@ -191,15 +211,24 @@ interface TerminalSession {
 	exitSignal: number;
 	listed: boolean;
 	title: string | null;
-	titleScanState: TerminalTitleScanState;
+	titleScanState: TerminalTitleScanStateBytes;
 
 	// Shell readiness (OSC 133)
 	shellReadyState: ShellReadyState;
 	shellReadyResolve: (() => void) | null;
 	shellReadyPromise: Promise<void>;
 	shellReadyTimeoutId: ReturnType<typeof setTimeout> | null;
-	scanState: ShellReadyScanState;
+	scanState: ShellReadyScanStateBytes;
 	initialCommandQueued: boolean;
+
+	/**
+	 * Side-channel UTF-8 decoder. portManager.checkOutputForHint takes a
+	 * string and does text-pattern matching for "Local: http://…" hints,
+	 * so we keep a per-session StringDecoder that buffers partial codepoints
+	 * across chunks — separate from the data path, never touching what we
+	 * actually broadcast to the renderer.
+	 */
+	portHintDecoder: StringDecoder;
 }
 
 /** PTY lifetime is independent of socket lifetime — sockets detach/reattach freely. */
@@ -346,25 +375,62 @@ function setSessionTitle(session: TerminalSession, title: string | null) {
 	broadcastMessage(session, { type: "title", title });
 }
 
-function bufferOutput(session: TerminalSession, data: string) {
+function bufferOutput(session: TerminalSession, data: Uint8Array) {
 	session.buffer.push(data);
-	session.bufferBytes += data.length;
+	session.bufferBytes += data.byteLength;
 
 	while (session.bufferBytes > MAX_BUFFER_BYTES && session.buffer.length > 1) {
 		const removed = session.buffer.shift();
-		if (removed) session.bufferBytes -= removed.length;
+		if (removed) session.bufferBytes -= removed.byteLength;
 	}
 }
 
-function replayBuffer(
-	session: TerminalSession,
-	socket: { send: (data: string) => void; readyState: number },
-) {
+// One cast lives here for `Uint8Array<ArrayBufferLike>` → `Uint8Array<ArrayBuffer>`,
+// the shape hono/ws's WSContext.send is typed against. Buffer (what node-pty
+// hands us) and our scanner outputs are always backed by ArrayBuffer; the
+// `<ArrayBufferLike>` looseness is purely a type-system artifact, not a
+// runtime concern. Concentrating the cast here keeps callers readable.
+function asArrayBufferBytes(bytes: Uint8Array): Uint8Array<ArrayBuffer> {
+	return bytes as Uint8Array<ArrayBuffer>;
+}
+
+function sendBytes(socket: TerminalSocket, bytes: Uint8Array) {
+	if (socket.readyState !== SOCKET_OPEN) return;
+	socket.send(asArrayBufferBytes(bytes));
+}
+
+function broadcastBytes(session: TerminalSession, bytes: Uint8Array): number {
+	let sent = 0;
+	const tight = asArrayBufferBytes(bytes);
+	for (const socket of session.sockets) {
+		if (socket.readyState !== SOCKET_OPEN) {
+			if (
+				socket.readyState === SOCKET_CLOSING ||
+				socket.readyState === SOCKET_CLOSED
+			) {
+				session.sockets.delete(socket);
+			}
+			continue;
+		}
+		socket.send(tight);
+		sent += 1;
+	}
+	return sent;
+}
+
+function replayBuffer(session: TerminalSession, socket: TerminalSocket) {
 	if (session.buffer.length === 0) return;
-	const combined = session.buffer.join("");
+	let total = 0;
+	for (const b of session.buffer) total += b.byteLength;
+	const combined = new Uint8Array(total);
+	let offset = 0;
+	for (const b of session.buffer) {
+		combined.set(b, offset);
+		offset += b.byteLength;
+	}
 	session.buffer.length = 0;
 	session.bufferBytes = 0;
-	sendMessage(socket, { type: "replay", data: combined });
+	sendBytes(socket, combined);
 }
 
 /**
@@ -383,8 +449,8 @@ function resolveShellReady(
 	}
 	// Flush held marker bytes — they weren't part of a full marker
 	if (session.scanState.heldBytes.length > 0) {
-		bufferOutput(session, session.scanState.heldBytes);
-		session.scanState.heldBytes = "";
+		bufferOutput(session, Uint8Array.from(session.scanState.heldBytes));
+		session.scanState.heldBytes.length = 0;
 	}
 	session.scanState.matchPos = 0;
 	if (session.shellReadyResolve) {
@@ -640,7 +706,7 @@ export async function createTerminalSessionInternal({
 		exitSignal: 0,
 		listed,
 		title: null,
-		titleScanState: createTerminalTitleScanState(),
+		titleScanState: createTerminalTitleScanStateBytes(),
 		shellReadyState: shellSupportsReady
 			? "pending"
 			: isAdopted
@@ -649,10 +715,11 @@ export async function createTerminalSessionInternal({
 		shellReadyResolve,
 		shellReadyPromise,
 		shellReadyTimeoutId: null,
-		scanState: createScanState(),
+		scanState: createScanStateBytes(),
 		// Adopted sessions have already run their initialCommand in the prior
 		// host-service lifetime — flag it as queued so we don't double-fire it.
 		initialCommandQueued: isAdopted,
+		portHintDecoder: new StringDecoder("utf8"),
 	};
 	sessions.set(terminalId, session);
 	portManager.upsertSession(terminalId, workspaceId, pty.pid);
@@ -673,30 +740,43 @@ export async function createTerminalSessionInternal({
 		{ replay: true },
 		{
 			onOutput(chunk) {
-				const rawData = chunk.toString("utf8");
-				const titleUpdates = scanForTerminalTitle(
+				// `chunk` is a Buffer (Uint8Array subclass). The whole data
+				// path stays on bytes from here to the renderer's xterm.write
+				// — the bug that motivated this rewrite was a per-chunk
+				// `chunk.toString("utf8")` that mangled multi-byte codepoints
+				// straddling chunk boundaries. Don't reintroduce it.
+				const titleUpdates = scanForTerminalTitleBytes(
 					session.titleScanState,
-					rawData,
+					chunk,
 				);
 				for (const title of titleUpdates.updates) {
 					setSessionTitle(session, title);
 				}
 
 				// Scan for OSC 133;A and strip it from output.
-				let data = rawData;
+				let bytes: Uint8Array = chunk;
 				if (session.shellReadyState === "pending") {
-					const result = scanForShellReady(session.scanState, rawData);
-					data = result.output;
+					const result = scanForShellReadyBytes(session.scanState, chunk);
+					bytes = result.output;
 					if (result.matched) {
 						resolveShellReady(session, "ready");
 					}
 				}
-				if (data.length === 0) return;
+				if (bytes.byteLength === 0) return;
 
-				portManager.checkOutputForHint(data);
+				// Side channel: portManager wants strings for URL/port hint
+				// regexes. The per-session StringDecoder buffers partial
+				// codepoints internally so this stays correct across chunk
+				// boundaries — and stays out of the data path.
+				const hintText = session.portHintDecoder.write(
+					bytes instanceof Buffer
+						? bytes
+						: Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength),
+				);
+				if (hintText.length > 0) portManager.checkOutputForHint(hintText);
 
-				if (broadcastMessage(session, { type: "data", data }) === 0) {
-					bufferOutput(session, data);
+				if (broadcastBytes(session, bytes) === 0) {
+					bufferOutput(session, bytes);
 				}
 			},
 			onExit({ code, signal }) {

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -2,15 +2,15 @@ import { existsSync } from "node:fs";
 import { StringDecoder } from "node:string_decoder";
 import type { NodeWebSocket } from "@hono/node-ws";
 import {
-	createScanStateBytes,
+	createScanState,
 	SHELLS_WITH_READY_MARKER,
-	type ShellReadyScanStateBytes,
-	scanForShellReadyBytes,
+	type ShellReadyScanState,
+	scanForShellReady,
 } from "@superset/shared/shell-ready-scanner";
 import {
-	createTerminalTitleScanStateBytes,
-	scanForTerminalTitleBytes,
-	type TerminalTitleScanStateBytes,
+	createTerminalTitleScanState,
+	scanForTerminalTitle,
+	type TerminalTitleScanState,
 } from "@superset/shared/terminal-title-scanner";
 import { and, eq, ne } from "drizzle-orm";
 import type { Hono } from "hono";
@@ -211,14 +211,14 @@ interface TerminalSession {
 	exitSignal: number;
 	listed: boolean;
 	title: string | null;
-	titleScanState: TerminalTitleScanStateBytes;
+	titleScanState: TerminalTitleScanState;
 
 	// Shell readiness (OSC 133)
 	shellReadyState: ShellReadyState;
 	shellReadyResolve: (() => void) | null;
 	shellReadyPromise: Promise<void>;
 	shellReadyTimeoutId: ReturnType<typeof setTimeout> | null;
-	scanState: ShellReadyScanStateBytes;
+	scanState: ShellReadyScanState;
 	initialCommandQueued: boolean;
 
 	/**
@@ -706,7 +706,7 @@ export async function createTerminalSessionInternal({
 		exitSignal: 0,
 		listed,
 		title: null,
-		titleScanState: createTerminalTitleScanStateBytes(),
+		titleScanState: createTerminalTitleScanState(),
 		shellReadyState: shellSupportsReady
 			? "pending"
 			: isAdopted
@@ -715,7 +715,7 @@ export async function createTerminalSessionInternal({
 		shellReadyResolve,
 		shellReadyPromise,
 		shellReadyTimeoutId: null,
-		scanState: createScanStateBytes(),
+		scanState: createScanState(),
 		// Adopted sessions have already run their initialCommand in the prior
 		// host-service lifetime — flag it as queued so we don't double-fire it.
 		initialCommandQueued: isAdopted,
@@ -745,7 +745,7 @@ export async function createTerminalSessionInternal({
 				// — the bug that motivated this rewrite was a per-chunk
 				// `chunk.toString("utf8")` that mangled multi-byte codepoints
 				// straddling chunk boundaries. Don't reintroduce it.
-				const titleUpdates = scanForTerminalTitleBytes(
+				const titleUpdates = scanForTerminalTitle(
 					session.titleScanState,
 					chunk,
 				);
@@ -756,7 +756,7 @@ export async function createTerminalSessionInternal({
 				// Scan for OSC 133;A and strip it from output.
 				let bytes: Uint8Array = chunk;
 				if (session.shellReadyState === "pending") {
-					const result = scanForShellReadyBytes(session.scanState, chunk);
+					const result = scanForShellReady(session.scanState, chunk);
 					bytes = result.output;
 					if (result.matched) {
 						resolveShellReady(session, "ready");

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -161,9 +161,7 @@ const SOCKET_OPEN = 1;
 const SOCKET_CLOSING = 2;
 const SOCKET_CLOSED = 3;
 
-// `Uint8Array<ArrayBuffer>` (not the looser `Uint8Array<ArrayBufferLike>`)
-// matches what hono/ws's WSContext.send accepts. Buffers from node and from
-// our scanners are all ArrayBuffer-backed, so this is the right narrowing.
+// `<ArrayBuffer>` narrowing matches hono/ws's WSContext.send signature.
 type TerminalSocket = {
 	send: (data: string | Uint8Array<ArrayBuffer>) => void;
 	close: (code?: number, reason?: string) => void;
@@ -385,11 +383,8 @@ function bufferOutput(session: TerminalSession, data: Uint8Array) {
 	}
 }
 
-// One cast lives here for `Uint8Array<ArrayBufferLike>` → `Uint8Array<ArrayBuffer>`,
-// the shape hono/ws's WSContext.send is typed against. Buffer (what node-pty
-// hands us) and our scanner outputs are always backed by ArrayBuffer; the
-// `<ArrayBufferLike>` looseness is purely a type-system artifact, not a
-// runtime concern. Concentrating the cast here keeps callers readable.
+// All bytes we send here are ArrayBuffer-backed at runtime (node Buffers,
+// scanner outputs); the cast just narrows the type-system's loose default.
 function asArrayBufferBytes(bytes: Uint8Array): Uint8Array<ArrayBuffer> {
 	return bytes as Uint8Array<ArrayBuffer>;
 }
@@ -740,11 +735,9 @@ export async function createTerminalSessionInternal({
 		{ replay: true },
 		{
 			onOutput(chunk) {
-				// `chunk` is a Buffer (Uint8Array subclass). The whole data
-				// path stays on bytes from here to the renderer's xterm.write
-				// — the bug that motivated this rewrite was a per-chunk
-				// `chunk.toString("utf8")` that mangled multi-byte codepoints
-				// straddling chunk boundaries. Don't reintroduce it.
+				// Bytes flow daemon → host → xterm without UTF-8 decoding;
+				// per-chunk `.toString("utf8")` here would mangle codepoints
+				// straddling chunk boundaries. (See no-encoding-hops.test.ts.)
 				const titleUpdates = scanForTerminalTitle(
 					session.titleScanState,
 					chunk,
@@ -753,7 +746,6 @@ export async function createTerminalSessionInternal({
 					setSessionTitle(session, title);
 				}
 
-				// Scan for OSC 133;A and strip it from output.
 				let bytes: Uint8Array = chunk;
 				if (session.shellReadyState === "pending") {
 					const result = scanForShellReady(session.scanState, chunk);
@@ -764,10 +756,10 @@ export async function createTerminalSessionInternal({
 				}
 				if (bytes.byteLength === 0) return;
 
-				// Side channel: portManager wants strings for URL/port hint
-				// regexes. The per-session StringDecoder buffers partial
-				// codepoints internally so this stays correct across chunk
-				// boundaries — and stays out of the data path.
+				// portManager.checkOutputForHint runs URL/port regexes on
+				// strings; the per-session StringDecoder buffers partial
+				// codepoints across chunks. This is a side branch — the
+				// transport above stays on bytes.
 				const hintText = session.portHintDecoder.write(
 					bytes instanceof Buffer
 						? bytes

--- a/packages/pty-daemon/src/Server/Server.ts
+++ b/packages/pty-daemon/src/Server/Server.ts
@@ -93,15 +93,15 @@ export class Server {
 			decoder: new FrameDecoder(),
 			negotiated: null,
 			subscriptions: new Set(),
-			send: (msg) => writeMessage(socket, msg),
+			send: (msg, payload) => writeMessage(socket, msg, payload),
 		};
 		this.conns.add(conn);
 
 		socket.on("data", (chunk) => {
 			try {
 				conn.decoder.push(chunk);
-				for (const raw of conn.decoder.drain()) {
-					this.dispatch(conn, raw as ClientMessage);
+				for (const frame of conn.decoder.drain()) {
+					this.dispatch(conn, frame.message as ClientMessage, frame.payload);
 				}
 			} catch (err) {
 				conn.send({
@@ -120,7 +120,11 @@ export class Server {
 		});
 	}
 
-	private dispatch(conn: ConnState, msg: ClientMessage): void {
+	private dispatch(
+		conn: ConnState,
+		msg: ClientMessage,
+		payload: Uint8Array | null,
+	): void {
 		// Handshake must come first.
 		if (conn.negotiated === null) {
 			if (msg.type !== "hello") {
@@ -162,7 +166,7 @@ export class Server {
 				return;
 			}
 			case "input": {
-				const reply = handleInput(ctx, msg);
+				const reply = handleInput(ctx, msg, payload);
 				if (reply) conn.send(reply);
 				return;
 			}
@@ -213,13 +217,9 @@ export class Server {
 	private wireSession(session: Session): void {
 		session.pty.onData((chunk) => {
 			this.store.appendOutput(session, chunk);
-			const out: ServerMessage = {
-				type: "output",
-				id: session.id,
-				data: chunk.toString("base64"),
-			};
+			const out: ServerMessage = { type: "output", id: session.id };
 			for (const c of this.conns) {
-				if (c.subscriptions.has(session.id)) c.send(out);
+				if (c.subscriptions.has(session.id)) c.send(out, chunk);
 			}
 		});
 		session.pty.onExit((info) => {
@@ -262,7 +262,11 @@ function pickProtocol(hello: HelloMessage): number | null {
 	return best;
 }
 
-function writeMessage(socket: net.Socket, msg: ServerMessage): void {
+function writeMessage(
+	socket: net.Socket,
+	msg: ServerMessage,
+	payload?: Uint8Array,
+): void {
 	if (socket.destroyed) return;
-	socket.write(encodeFrame(msg));
+	socket.write(encodeFrame(msg, payload));
 }

--- a/packages/pty-daemon/src/Server/Server.ts
+++ b/packages/pty-daemon/src/Server/Server.ts
@@ -26,6 +26,12 @@ export interface ServerOptions {
 	socketPath: string;
 	daemonVersion: string;
 	bufferCap?: number;
+	/**
+	 * Override for the PTY-spawn factory. Production leaves this unset;
+	 * `defaultSpawn` (real node-pty) is used. Tests inject a fake here so
+	 * they can drive sessions deterministically without a real shell.
+	 */
+	spawnPty?: HandlerCtx["spawnPty"];
 }
 
 interface ConnState extends Conn {
@@ -207,6 +213,7 @@ export class Server {
 		return {
 			store: this.store,
 			wireSession: (session) => this.wireSession(session),
+			spawnPty: this.opts.spawnPty,
 		};
 	}
 

--- a/packages/pty-daemon/src/handlers/handlers.test.ts
+++ b/packages/pty-daemon/src/handlers/handlers.test.ts
@@ -40,12 +40,17 @@ function makeFakePty(state: FakePtyState, meta: SpawnOptions["meta"]): Pty {
 	};
 }
 
-function makeConn(): Conn & { sent: ServerMessage[] } {
-	const sent: ServerMessage[] = [];
+interface SentFrame {
+	message: ServerMessage;
+	payload: Uint8Array | null;
+}
+
+function makeConn(): Conn & { sent: SentFrame[] } {
+	const sent: SentFrame[] = [];
 	return {
 		sent,
 		subscriptions: new Set(),
-		send: (m) => sent.push(m),
+		send: (m, payload) => sent.push({ message: m, payload: payload ?? null }),
 	};
 }
 
@@ -114,22 +119,22 @@ describe("handlers", () => {
 			id: "s0",
 			meta: { shell: "/bin/sh", argv: [], cols: 80, rows: 24 },
 		});
-		const result = handleInput(ctx, {
-			type: "input",
-			id: "s0",
-			data: Buffer.from("hello").toString("base64"),
-		});
+		const result = handleInput(
+			ctx,
+			{ type: "input", id: "s0" },
+			Buffer.from("hello"),
+		);
 		expect(result).toBeUndefined();
 		expect(states[0]?.written.map((b) => b.toString())).toEqual(["hello"]);
 	});
 
 	test("input on missing session returns error", () => {
 		const ctx = makeCtx();
-		const result = handleInput(ctx, {
-			type: "input",
-			id: "missing",
-			data: "",
-		});
+		const result = handleInput(
+			ctx,
+			{ type: "input", id: "missing" },
+			Buffer.alloc(0),
+		);
 		expect(result?.type).toBe("error");
 	});
 
@@ -183,10 +188,11 @@ describe("handlers", () => {
 		handleSubscribe(ctx, conn, { type: "subscribe", id: "s0", replay: true });
 		expect(conn.subscriptions.has("s0")).toBe(true);
 		expect(conn.sent).toHaveLength(1);
-		const m = conn.sent[0];
-		expect(m?.type).toBe("output");
-		if (m?.type === "output") {
-			expect(Buffer.from(m.data, "base64").toString()).toBe("prior bytes");
+		const frame = conn.sent[0];
+		expect(frame?.message.type).toBe("output");
+		expect(frame?.payload).toBeTruthy();
+		if (frame?.payload) {
+			expect(Buffer.from(frame.payload).toString()).toBe("prior bytes");
 		}
 	});
 

--- a/packages/pty-daemon/src/handlers/handlers.ts
+++ b/packages/pty-daemon/src/handlers/handlers.ts
@@ -87,12 +87,11 @@ export function handleInput(
 	if (session.exited)
 		return errorFor(msg.id, `session exited: ${msg.id}`, "EEXITED");
 	if (!payload || payload.byteLength === 0) {
-		// No-op: empty input. Don't bother the PTY or surface an error.
+		// Empty input is a no-op; surfacing an error would force callers
+		// to special-case zero-length writes for no real benefit.
 		return undefined;
 	}
 	try {
-		// Adapt to whatever the Pty implementation expects (node-pty / adopted).
-		// Buffer is a Uint8Array<ArrayBuffer>, which both sides accept.
 		session.pty.write(Buffer.from(payload));
 	} catch (err) {
 		return errorFor(msg.id, (err as Error).message, "EWRITE");

--- a/packages/pty-daemon/src/handlers/handlers.ts
+++ b/packages/pty-daemon/src/handlers/handlers.ts
@@ -20,10 +20,14 @@ import type { Session, SessionStore } from "../SessionStore/index.ts";
 /**
  * Per-connection state owned by the Server. Handlers receive a Conn ref to
  * read/write subscription membership and to send messages.
+ *
+ * `send` accepts an optional `payload` — the binary tail of the wire frame.
+ * Used for output/replay messages so PTY bytes don't have to detour through
+ * base64 inside the JSON header. (See ../protocol/framing.ts.)
  */
 export interface Conn {
 	subscriptions: Set<string>;
-	send(message: ServerMessage): void;
+	send(message: ServerMessage, payload?: Uint8Array): void;
 }
 
 /**
@@ -69,16 +73,27 @@ export function handleOpen(ctx: HandlerCtx, msg: OpenMessage): ServerMessage {
 	return reply;
 }
 
+/**
+ * `payload` is the input bytes the client wants written to the PTY. Pulled
+ * from the frame's binary tail by the Server before dispatching.
+ */
 export function handleInput(
 	ctx: HandlerCtx,
 	msg: InputMessage,
+	payload: Uint8Array | null,
 ): ServerMessage | undefined {
 	const session = ctx.store.get(msg.id);
 	if (!session) return errorFor(msg.id, `unknown session: ${msg.id}`, "ENOENT");
 	if (session.exited)
 		return errorFor(msg.id, `session exited: ${msg.id}`, "EEXITED");
+	if (!payload || payload.byteLength === 0) {
+		// No-op: empty input. Don't bother the PTY or surface an error.
+		return undefined;
+	}
 	try {
-		session.pty.write(Buffer.from(msg.data, "base64"));
+		// Adapt to whatever the Pty implementation expects (node-pty / adopted).
+		// Buffer is a Uint8Array<ArrayBuffer>, which both sides accept.
+		session.pty.write(Buffer.from(payload));
 	} catch (err) {
 		return errorFor(msg.id, (err as Error).message, "EWRITE");
 	}
@@ -121,9 +136,9 @@ export function handleList(ctx: HandlerCtx): ListReplyMessage {
 
 /**
  * Subscribe the connection to a session. If `replay` is true, immediately
- * send an `output` frame containing the buffered bytes before live streaming
- * begins. Live streaming is the Server's job once `subscriptions` includes
- * this session id.
+ * send an `output` frame whose binary tail is the buffered bytes — before
+ * live streaming begins. Live streaming is the Server's job once
+ * `subscriptions` includes this session id.
  */
 export function handleSubscribe(
 	ctx: HandlerCtx,
@@ -139,12 +154,8 @@ export function handleSubscribe(
 	if (msg.replay) {
 		const snap = ctx.store.snapshotBuffer(session);
 		if (snap.byteLength > 0) {
-			const out: OutputMessage = {
-				type: "output",
-				id: msg.id,
-				data: snap.toString("base64"),
-			};
-			conn.send(out);
+			const out: OutputMessage = { type: "output", id: msg.id };
+			conn.send(out, snap);
 		}
 	}
 }

--- a/packages/pty-daemon/src/protocol/framing.test.ts
+++ b/packages/pty-daemon/src/protocol/framing.test.ts
@@ -1,19 +1,22 @@
 import { describe, expect, test } from "bun:test";
 import { decodeFrame, encodeFrame, FrameDecoder } from "./framing.ts";
 
-describe("framing", () => {
-	test("round-trips a simple object", () => {
-		const msg = { type: "hello", protocols: [1] };
+describe("framing — JSON-only frames", () => {
+	test("round-trips a simple object with no payload", () => {
+		const msg = { type: "hello", protocols: [2] };
 		const frame = encodeFrame(msg);
-		expect(decodeFrame(frame)).toEqual(msg);
+		expect(decodeFrame(frame)).toEqual({ message: msg, payload: null });
 	});
 
 	test("round-trips through FrameDecoder", () => {
 		const a = { type: "open", id: "s0" };
-		const b = { type: "input", id: "s0", data: "aGk=" };
+		const b = { type: "close", id: "s0" };
 		const dec = new FrameDecoder();
 		dec.push(Buffer.concat([encodeFrame(a), encodeFrame(b)]));
-		expect(dec.drain()).toEqual([a, b]);
+		expect(dec.drain()).toEqual([
+			{ message: a, payload: null },
+			{ message: b, payload: null },
+		]);
 	});
 
 	test("FrameDecoder buffers across chunks", () => {
@@ -25,7 +28,7 @@ describe("framing", () => {
 		dec.push(full.subarray(2, 6));
 		expect(dec.drain()).toEqual([]);
 		dec.push(full.subarray(6));
-		expect(dec.drain()).toEqual([msg]);
+		expect(dec.drain()).toEqual([{ message: msg, payload: null }]);
 	});
 
 	test("FrameDecoder handles partial frame after a complete one", () => {
@@ -34,9 +37,9 @@ describe("framing", () => {
 		const buf = Buffer.concat([encodeFrame(a), encodeFrame(b)]);
 		const dec = new FrameDecoder();
 		dec.push(buf.subarray(0, encodeFrame(a).length + 3));
-		expect(dec.drain()).toEqual([a]);
+		expect(dec.drain()).toEqual([{ message: a, payload: null }]);
 		dec.push(buf.subarray(encodeFrame(a).length + 3));
-		expect(dec.drain()).toEqual([b]);
+		expect(dec.drain()).toEqual([{ message: b, payload: null }]);
 	});
 
 	test("rejects oversized frames", () => {
@@ -45,5 +48,79 @@ describe("framing", () => {
 		const dec = new FrameDecoder();
 		dec.push(bigHeader);
 		expect(() => dec.drain()).toThrow(/frame too large/);
+	});
+
+	test("rejects frames smaller than the inner header", () => {
+		// totalLen=2 is impossible — the inner jsonLen prefix alone is 4 bytes.
+		const tinyHeader = Buffer.alloc(4);
+		tinyHeader.writeUInt32BE(2, 0);
+		const dec = new FrameDecoder();
+		dec.push(tinyHeader);
+		expect(() => dec.drain()).toThrow(/frame too small/);
+	});
+
+	test("rejects jsonLen larger than the frame body", () => {
+		// totalLen = 6 (4 inner-len + 2 body), but jsonLen claims 99.
+		const malformed = Buffer.alloc(4 + 6);
+		malformed.writeUInt32BE(6, 0);
+		malformed.writeUInt32BE(99, 4);
+		const dec = new FrameDecoder();
+		dec.push(malformed);
+		expect(() => dec.drain()).toThrow(/jsonLen/);
+	});
+});
+
+describe("framing — frames with binary payload", () => {
+	test("round-trips a JSON header + arbitrary bytes", () => {
+		const msg = { type: "output", id: "s0" };
+		const payload = Uint8Array.from([0x00, 0xff, 0x80, 0x42]);
+		const frame = encodeFrame(msg, payload);
+		const decoded = decodeFrame(frame);
+		expect(decoded.message).toEqual(msg);
+		expect(decoded.payload).toEqual(payload);
+	});
+
+	test("payload survives chunk boundaries through FrameDecoder", () => {
+		const msg = { type: "output", id: "s0" };
+		// Include bytes that are problematic in JSON (0x00, high bytes).
+		const payload = Uint8Array.from([
+			0x00, 0xff, 0xc0, 0x80, 0x9d, 0xe2, 0x98, 0x83,
+		]);
+		const frame = encodeFrame(msg, payload);
+		const dec = new FrameDecoder();
+		// Split into three pieces, none aligned with internal boundaries.
+		dec.push(frame.subarray(0, 5));
+		dec.push(frame.subarray(5, 12));
+		dec.push(frame.subarray(12));
+		const drained = dec.drain();
+		expect(drained).toHaveLength(1);
+		expect(drained[0]?.message).toEqual(msg);
+		expect(drained[0]?.payload).toEqual(payload);
+	});
+
+	test("empty payload round-trips as null", () => {
+		// Passing an explicit empty Uint8Array should still decode as `null`
+		// (the wire layout makes payloadLen=0 and absent indistinguishable —
+		// we normalize on the receive side so callers don't have to branch).
+		const msg = { type: "output", id: "s0" };
+		const decoded = decodeFrame(encodeFrame(msg, new Uint8Array(0)));
+		expect(decoded.payload).toBeNull();
+	});
+
+	test("payload bytes are decoupled from the streaming buffer", () => {
+		// Regression check: the decoder must copy payload bytes out of its
+		// internal buffer; otherwise advancing past the frame could leave the
+		// caller's `payload` aliasing freed/reused memory.
+		const msg = { type: "input", id: "s0" };
+		const payload = Buffer.from("hello world");
+		const dec = new FrameDecoder();
+		dec.push(encodeFrame(msg, payload));
+		const [frame] = dec.drain();
+		// Push something else through; the decoder may reuse its internal buffer.
+		dec.push(encodeFrame({ type: "open", id: "s1" }));
+		dec.drain();
+		expect(Buffer.from(frame?.payload ?? new Uint8Array()).toString()).toBe(
+			"hello world",
+		);
 	});
 });

--- a/packages/pty-daemon/src/protocol/framing.ts
+++ b/packages/pty-daemon/src/protocol/framing.ts
@@ -1,21 +1,51 @@
 // Length-prefixed binary frames over a SOCK_STREAM socket.
 //
-// Wire: [u32 BE length][JSON UTF-8 payload of that length]
+// Wire layout:
+//
+//   [u32 BE totalLen] [u32 BE jsonLen] [json bytes (UTF-8)] [payload bytes]
+//                     └────── totalLen counts everything from here ──────┘
+//
+// `payloadLen = totalLen - 4 - jsonLen` (implicit). A frame with `jsonLen
+// === totalLen - 4` carries no payload — every control message looks
+// exactly like that.
+//
+// PTY input/output bytes ride in the payload tail rather than being
+// base64-stuffed inside the JSON. ~33% less wire for high-volume PTY
+// output, and zero encode/decode passes per chunk on either side.
 
 const HEADER_BYTES = 4;
+const INNER_JSON_LEN_BYTES = 4;
 const MAX_FRAME_BYTES = 8 * 1024 * 1024; // 8 MB hard cap; abort the connection above this.
 
-export function encodeFrame(message: unknown): Buffer {
+export interface DecodedFrame {
+	message: unknown;
+	/** Optional binary tail — `null` when the frame carries only JSON. */
+	payload: Uint8Array | null;
+}
+
+export function encodeFrame(message: unknown, payload?: Uint8Array): Buffer {
 	const json = JSON.stringify(message);
-	const payload = Buffer.from(json, "utf8");
-	const header = Buffer.alloc(HEADER_BYTES);
-	header.writeUInt32BE(payload.byteLength, 0);
-	return Buffer.concat([header, payload]);
+	const jsonBytes = Buffer.from(json, "utf8");
+	const payloadLen = payload?.byteLength ?? 0;
+	const totalLen = INNER_JSON_LEN_BYTES + jsonBytes.byteLength + payloadLen;
+
+	const out = Buffer.alloc(HEADER_BYTES + totalLen);
+	out.writeUInt32BE(totalLen, 0);
+	out.writeUInt32BE(jsonBytes.byteLength, HEADER_BYTES);
+	jsonBytes.copy(out, HEADER_BYTES + INNER_JSON_LEN_BYTES);
+	if (payload && payload.byteLength > 0) {
+		out.set(
+			payload,
+			HEADER_BYTES + INNER_JSON_LEN_BYTES + jsonBytes.byteLength,
+		);
+	}
+	return out;
 }
 
 /**
  * Streaming decoder. Feed bytes via `push`; iterate completed frames via `drain`.
- * Throws on oversized frames so a malformed peer can't exhaust memory.
+ * Throws on oversized or malformed frames so a misbehaving peer can't
+ * exhaust memory or trick the receiver into reading off the end.
  */
 export class FrameDecoder {
 	private buf: Buffer = Buffer.alloc(0);
@@ -24,17 +54,43 @@ export class FrameDecoder {
 		this.buf = this.buf.length === 0 ? chunk : Buffer.concat([this.buf, chunk]);
 	}
 
-	drain(): unknown[] {
-		const out: unknown[] = [];
+	drain(): DecodedFrame[] {
+		const out: DecodedFrame[] = [];
 		while (this.buf.length >= HEADER_BYTES) {
-			const len = this.buf.readUInt32BE(0);
-			if (len > MAX_FRAME_BYTES) {
-				throw new Error(`frame too large: ${len} bytes`);
+			const totalLen = this.buf.readUInt32BE(0);
+			if (totalLen > MAX_FRAME_BYTES) {
+				throw new Error(`frame too large: ${totalLen} bytes`);
 			}
-			if (this.buf.length < HEADER_BYTES + len) break;
-			const payload = this.buf.subarray(HEADER_BYTES, HEADER_BYTES + len);
-			out.push(JSON.parse(payload.toString("utf8")));
-			this.buf = this.buf.subarray(HEADER_BYTES + len);
+			if (totalLen < INNER_JSON_LEN_BYTES) {
+				throw new Error(`frame too small: ${totalLen} bytes (need ≥4)`);
+			}
+			if (this.buf.length < HEADER_BYTES + totalLen) break;
+
+			const jsonLen = this.buf.readUInt32BE(HEADER_BYTES);
+			if (jsonLen > totalLen - INNER_JSON_LEN_BYTES) {
+				throw new Error(
+					`frame jsonLen ${jsonLen} exceeds frame body ${totalLen - INNER_JSON_LEN_BYTES}`,
+				);
+			}
+
+			const jsonStart = HEADER_BYTES + INNER_JSON_LEN_BYTES;
+			const payloadStart = jsonStart + jsonLen;
+			const frameEnd = HEADER_BYTES + totalLen;
+
+			const message = JSON.parse(
+				this.buf.subarray(jsonStart, payloadStart).toString("utf8"),
+			);
+			let payload: Uint8Array | null = null;
+			if (payloadStart < frameEnd) {
+				// Copy the payload out of the streaming buffer so advancing
+				// past this frame can't strand the slice's underlying memory
+				// and so callers see a stable view they can hold onto.
+				const view = this.buf.subarray(payloadStart, frameEnd);
+				payload = new Uint8Array(view.length);
+				payload.set(view, 0);
+			}
+			out.push({ message, payload });
+			this.buf = this.buf.subarray(frameEnd);
 		}
 		return out;
 	}
@@ -44,13 +100,32 @@ export class FrameDecoder {
  * One-shot decode of a buffer that contains exactly one complete frame.
  * Used by tests; production reads use FrameDecoder.
  */
-export function decodeFrame(buf: Buffer): unknown {
-	if (buf.length < HEADER_BYTES) throw new Error("short frame");
-	const len = buf.readUInt32BE(0);
-	if (buf.length !== HEADER_BYTES + len) {
+export function decodeFrame(buf: Buffer): DecodedFrame {
+	if (buf.length < HEADER_BYTES + INNER_JSON_LEN_BYTES) {
+		throw new Error("short frame");
+	}
+	const totalLen = buf.readUInt32BE(0);
+	if (buf.length !== HEADER_BYTES + totalLen) {
 		throw new Error(
-			`frame length mismatch: header=${len} buf=${buf.length - HEADER_BYTES}`,
+			`frame length mismatch: header=${totalLen} buf=${buf.length - HEADER_BYTES}`,
 		);
 	}
-	return JSON.parse(buf.subarray(HEADER_BYTES).toString("utf8"));
+	const jsonLen = buf.readUInt32BE(HEADER_BYTES);
+	if (jsonLen > totalLen - INNER_JSON_LEN_BYTES) {
+		throw new Error(
+			`frame jsonLen ${jsonLen} exceeds frame body ${totalLen - INNER_JSON_LEN_BYTES}`,
+		);
+	}
+	const jsonStart = HEADER_BYTES + INNER_JSON_LEN_BYTES;
+	const payloadStart = jsonStart + jsonLen;
+	const message = JSON.parse(
+		buf.subarray(jsonStart, payloadStart).toString("utf8"),
+	);
+	let payload: Uint8Array | null = null;
+	if (payloadStart < buf.length) {
+		const view = buf.subarray(payloadStart);
+		payload = new Uint8Array(view.length);
+		payload.set(view, 0);
+	}
+	return { message, payload };
 }

--- a/packages/pty-daemon/src/protocol/messages.ts
+++ b/packages/pty-daemon/src/protocol/messages.ts
@@ -1,7 +1,9 @@
 // Message schemas for the pty-daemon Unix socket protocol.
 //
-// Wire format: 4-byte big-endian length prefix + UTF-8 JSON payload.
-// Binary data (PTY input/output) travels base64-encoded inside the JSON.
+// Wire format (v2): see ./framing.ts. Each frame carries a JSON header
+// and an optional binary payload tail. PTY input/output bytes ride in
+// the payload tail — they are NOT base64-encoded inside the JSON.
+//
 // See ../README.md and ../../../../apps/desktop/plans/20260429-pty-daemon-implementation.md
 
 export interface SessionMeta {
@@ -43,11 +45,13 @@ export interface OpenMessage {
 	meta: SessionMeta;
 }
 
+/**
+ * The bytes to write to the PTY ride in the frame's binary payload tail
+ * (see framing.ts). The message itself just identifies the target session.
+ */
 export interface InputMessage {
 	type: "input";
 	id: string;
-	/** base64-encoded bytes */
-	data: string;
 }
 
 export interface ResizeMessage {
@@ -87,11 +91,13 @@ export interface OpenOkMessage {
 	pid: number;
 }
 
+/**
+ * The PTY's output bytes ride in the frame's binary payload tail (see
+ * framing.ts). The message itself just identifies the source session.
+ */
 export interface OutputMessage {
 	type: "output";
 	id: string;
-	/** base64-encoded bytes */
-	data: string;
 }
 
 export interface ExitMessage {

--- a/packages/pty-daemon/src/protocol/messages.ts
+++ b/packages/pty-daemon/src/protocol/messages.ts
@@ -45,10 +45,7 @@ export interface OpenMessage {
 	meta: SessionMeta;
 }
 
-/**
- * The bytes to write to the PTY ride in the frame's binary payload tail
- * (see framing.ts). The message itself just identifies the target session.
- */
+/** Bytes ride in the frame's binary tail; this message just names the session. */
 export interface InputMessage {
 	type: "input";
 	id: string;
@@ -91,10 +88,7 @@ export interface OpenOkMessage {
 	pid: number;
 }
 
-/**
- * The PTY's output bytes ride in the frame's binary payload tail (see
- * framing.ts). The message itself just identifies the source session.
- */
+/** Bytes ride in the frame's binary tail; this message just names the session. */
 export interface OutputMessage {
 	type: "output";
 	id: string;

--- a/packages/pty-daemon/src/protocol/version.ts
+++ b/packages/pty-daemon/src/protocol/version.ts
@@ -1,4 +1,13 @@
-// Protocol versioning. Increment on breaking changes; add to SUPPORTED list
-// while we still need to interop with the previous major during rollouts.
-export const CURRENT_PROTOCOL_VERSION = 1 as const;
-export const SUPPORTED_PROTOCOL_VERSIONS: readonly number[] = [1];
+// Protocol versioning. Increment on breaking changes.
+//
+// v1: framing was [u32 len][JSON]; PTY input/output bytes were base64'd
+//     inside the JSON `data` field.
+// v2: framing is  [u32 totalLen][u32 jsonLen][JSON][optional payload bytes];
+//     OutputMessage and InputMessage drop their `data` field and carry
+//     bytes via the payload tail. (See framing.ts.)
+//
+// We don't keep v1 around. Phase 2 auto-update converges daemon to current
+// on host-service start, so the version-skew window is bounded; any
+// session lost to that one upgrade is recoverable.
+export const CURRENT_PROTOCOL_VERSION = 2 as const;
+export const SUPPORTED_PROTOCOL_VERSIONS: readonly number[] = [2];

--- a/packages/pty-daemon/src/protocol/wire-shape.test.ts
+++ b/packages/pty-daemon/src/protocol/wire-shape.test.ts
@@ -1,0 +1,88 @@
+// Wire-shape invariants. These trip the moment anyone re-introduces a
+// shape we explicitly removed in protocol v2. Cheap to run (no socket,
+// no shell), targeted at specific past-mistake patterns.
+
+import { describe, expect, test } from "bun:test";
+import { decodeFrame, encodeFrame } from "./framing.ts";
+
+const HEADER = 4;
+const INNER = 4;
+
+describe("v2 wire shape", () => {
+	test("output frames carry bytes in the binary tail, not the JSON header", () => {
+		// Pre-v2 shape was `{ type: "output", id, data: "<base64>" }`. If
+		// anyone reintroduces that, the JSON portion will contain "data".
+		// This test lays a tripwire: the JSON for an output frame must
+		// describe the message and nothing more.
+		const frame = encodeFrame(
+			{ type: "output", id: "s0" },
+			Buffer.from("hello"),
+		);
+
+		const totalLen = frame.readUInt32BE(0);
+		const jsonLen = frame.readUInt32BE(HEADER);
+		const json = frame
+			.subarray(HEADER + INNER, HEADER + INNER + jsonLen)
+			.toString("utf8");
+
+		expect(JSON.parse(json)).toEqual({ type: "output", id: "s0" });
+		expect(json).not.toContain("data");
+		// jsonLen strictly less than totalLen-INNER ⇒ a binary tail exists.
+		expect(jsonLen).toBeLessThan(totalLen - INNER);
+	});
+
+	test("input frames carry bytes in the binary tail, not the JSON header", () => {
+		// Same shape on the other direction. The motivating bug for v2 was
+		// output-side; input followed for symmetry, and reintroducing
+		// `data: data.toString("base64")` here would silently double-encode.
+		const frame = encodeFrame(
+			{ type: "input", id: "s0" },
+			Buffer.from([0xc0, 0x80, 0xff]),
+		);
+
+		const jsonLen = frame.readUInt32BE(HEADER);
+		const json = frame
+			.subarray(HEADER + INNER, HEADER + INNER + jsonLen)
+			.toString("utf8");
+
+		expect(JSON.parse(json)).toEqual({ type: "input", id: "s0" });
+		expect(json).not.toContain("data");
+	});
+
+	test("control frames have jsonLen === totalLen - 4 (no payload)", () => {
+		// Control messages must NOT accidentally pick up a binary tail —
+		// that would either confuse the receiver or mask a real bug where
+		// someone slips bytes through a JSON-only message type.
+		const cases = [
+			{ type: "hello-ack", protocol: 2, daemonVersion: "x" },
+			{ type: "open-ok", id: "s0", pid: 123 },
+			{ type: "closed", id: "s0" },
+			{ type: "exit", id: "s0", code: 0, signal: null },
+			{ type: "list-reply", sessions: [] },
+			{ type: "error", message: "x" },
+		];
+		for (const msg of cases) {
+			const frame = encodeFrame(msg);
+			const totalLen = frame.readUInt32BE(0);
+			const jsonLen = frame.readUInt32BE(HEADER);
+			expect(jsonLen).toBe(totalLen - INNER);
+			expect(decodeFrame(frame).payload).toBeNull();
+		}
+	});
+
+	test("payload bytes ARE the bytes — not base64, not anything else", () => {
+		// Round-trip a buffer of bytes whose base64 encoding is a recognizable
+		// distinct string ("aGVsbG8=" ← "hello"), then assert the wire frame
+		// contains the raw bytes ("hello") and NOT their base64 form.
+		const bytes = Buffer.from("hello");
+		const frame = encodeFrame({ type: "output", id: "s0" }, bytes);
+
+		const totalLen = frame.readUInt32BE(0);
+		const jsonLen = frame.readUInt32BE(HEADER);
+		const tail = frame.subarray(HEADER + INNER + jsonLen, HEADER + totalLen);
+		expect(tail).toEqual(bytes);
+		// Defensive: if someone reintroduces base64, the tail would be the
+		// 8-char "aGVsbG8=" instead of the 5-byte "hello".
+		expect(tail.toString("utf8")).not.toBe("aGVsbG8=");
+	});
+});

--- a/packages/pty-daemon/test/byte-fidelity.test.ts
+++ b/packages/pty-daemon/test/byte-fidelity.test.ts
@@ -1,0 +1,273 @@
+// Byte-fidelity canary for the daemon ↔ host wire.
+//
+// The motivating bug for protocol v2 was an encoding hop in the receive
+// path that mangled bytes at chunk boundaries. The structural unit tests
+// catch the obvious shape mistakes; this is the runtime canary that fails
+// the *moment* anyone reintroduces a hop, regardless of where:
+//
+//   - `chunk.toString("utf8")` per chunk (random bytes include sequences
+//     that aren't valid UTF-8 → U+FFFD replacement → hash mismatch)
+//   - base64-in-JSON for output bytes (would still byte-preserve, but the
+//     wire bytes go through JSON.parse + Buffer.from(.., "base64") instead
+//     of riding the binary tail; the structural shape tests catch that)
+//   - any silent split/truncate at any size threshold
+//
+// Runs under Node (`node --experimental-strip-types --test`).
+
+import { strict as assert } from "node:assert";
+import * as crypto from "node:crypto";
+import * as os from "node:os";
+import * as path from "node:path";
+import { after, before, test } from "node:test";
+import type {
+	Pty,
+	PtyOnData,
+	PtyOnExit,
+	SpawnOptions,
+} from "../src/Pty/index.ts";
+import { Server } from "../src/Server/index.ts";
+import { connectAndHello, payloadOf } from "./helpers/client.ts";
+
+const sockPath = path.join(os.tmpdir(), `pty-daemon-bytes-${process.pid}.sock`);
+
+/**
+ * A driveable fake PTY: the test calls `emit(bytes)` whenever it wants the
+ * "shell" to produce output. Lets us inject arbitrary byte sequences without
+ * a real shell or PTY's cooked-mode quirks (echo, line discipline, CRLF).
+ */
+interface DriveablePty extends Pty {
+	emit(bytes: Uint8Array): void;
+	finish(code: number): void;
+}
+
+let nextPid = 5000;
+let lastSpawned: DriveablePty | null = null;
+
+function makeDriveablePty(meta: SpawnOptions["meta"]): DriveablePty {
+	const onDataCbs: PtyOnData[] = [];
+	const onExitCbs: PtyOnExit[] = [];
+	const pid = nextPid++;
+	return {
+		pid,
+		meta,
+		write: () => {},
+		resize: () => {},
+		kill: () => {},
+		onData: (cb) => {
+			onDataCbs.push(cb);
+		},
+		onExit: (cb) => {
+			onExitCbs.push(cb);
+		},
+		emit: (bytes) => {
+			for (const cb of onDataCbs) cb(Buffer.from(bytes));
+		},
+		finish: (code) => {
+			for (const cb of onExitCbs) cb({ code, signal: null });
+		},
+	};
+}
+
+let server: Server;
+
+before(async () => {
+	server = new Server({
+		socketPath: sockPath,
+		daemonVersion: "0.0.0-bytes",
+		// Must be larger than any single replay payload in the tests below;
+		// otherwise the ring buffer trims prefix bytes and the hash diverges.
+		bufferCap: 256 * 1024,
+		spawnPty: ({ meta }) => {
+			const pty = makeDriveablePty(meta);
+			lastSpawned = pty;
+			return pty;
+		},
+	});
+	await server.listen();
+});
+
+after(async () => {
+	await server.close();
+});
+
+const META = {
+	shell: "/bin/sh",
+	argv: [] as string[],
+	cols: 80,
+	rows: 24,
+};
+
+/** Yield random byte chunks summing to `total` bytes, each at most `maxChunk`. */
+function* randomChunks(total: number, maxChunk: number): Generator<Buffer> {
+	let remaining = total;
+	while (remaining > 0) {
+		const size = Math.min(remaining, 1 + Math.floor(Math.random() * maxChunk));
+		yield crypto.randomBytes(size);
+		remaining -= size;
+	}
+}
+
+function sha256(...buffers: Uint8Array[]): string {
+	const h = crypto.createHash("sha256");
+	for (const b of buffers) h.update(b);
+	return h.digest("hex");
+}
+
+/**
+ * Subscribe sends no ack on success. To make sure the subscribe has been
+ * processed before we start injecting bytes, send a `list` and wait for
+ * its reply — the daemon dispatches in order, so list-reply implies the
+ * preceding subscribe is live.
+ */
+async function subscribeAndDrain(
+	c: Awaited<ReturnType<typeof connectAndHello>>,
+	id: string,
+	replay: boolean,
+): Promise<void> {
+	c.send({ type: "subscribe", id, replay });
+	c.send({ type: "list" });
+	await c.waitFor((m) => m.type === "list-reply", 1000);
+}
+
+async function waitForBytes(
+	c: Awaited<ReturnType<typeof connectAndHello>>,
+	id: string,
+	target: number,
+	ms: number,
+): Promise<void> {
+	const start = Date.now();
+	while (Date.now() - start < ms) {
+		let got = 0;
+		for (const m of c.messages) {
+			if (m.type === "output" && m.id === id) {
+				const p = payloadOf(m);
+				if (p) got += p.byteLength;
+			}
+		}
+		if (got >= target) return;
+		await new Promise((r) => setTimeout(r, 5));
+	}
+	throw new Error(`waitForBytes(${id}): only got <${target} bytes in ${ms}ms`);
+}
+
+function collectPayloads(
+	c: Awaited<ReturnType<typeof connectAndHello>>,
+	id: string,
+): Uint8Array[] {
+	const out: Uint8Array[] = [];
+	for (const m of c.messages) {
+		if (m.type === "output" && m.id === id) {
+			const p = payloadOf(m);
+			if (p) out.push(p);
+		}
+	}
+	return out;
+}
+
+test("live stream: random bytes survive daemon → host byte-perfect", async () => {
+	const c = await connectAndHello(sockPath);
+	const id = "fid-live";
+	c.send({ type: "open", id, meta: META });
+	await c.waitFor((m) => m.type === "open-ok" && m.id === id);
+	const spawned = lastSpawned;
+	assert.ok(spawned, "spawnPty hook must have fired");
+	await subscribeAndDrain(c, id, false);
+
+	// 64 KB of random bytes, varied chunk sizes that include 1-byte and 4 KB
+	// chunks so any per-chunk encoding bug has many opportunities to break.
+	const chunks = [...randomChunks(64 * 1024, 4096)];
+	for (const chunk of chunks) {
+		spawned.emit(chunk);
+	}
+	const sentHash = sha256(...chunks);
+	const sentLen = chunks.reduce((n, c) => n + c.byteLength, 0);
+
+	await waitForBytes(c, id, sentLen, 3000);
+
+	const received = collectPayloads(c, id);
+	const receivedLen = received.reduce((n, b) => n + b.byteLength, 0);
+	assert.equal(receivedLen, sentLen, "received total length must match sent");
+	assert.equal(
+		sha256(...received),
+		sentHash,
+		"received bytes must hash-match sent",
+	);
+
+	c.send({ type: "close", id });
+	await c.close();
+});
+
+test("replay: random bytes from ring buffer survive byte-perfect", async () => {
+	const c = await connectAndHello(sockPath);
+	const id = "fid-replay";
+	c.send({ type: "open", id, meta: META });
+	await c.waitFor((m) => m.type === "open-ok" && m.id === id);
+	const spawned = lastSpawned;
+	assert.ok(spawned, "spawnPty hook must have fired");
+
+	// Emit BEFORE subscribing so bytes accumulate in the daemon's ring buffer.
+	const chunks = [...randomChunks(32 * 1024, 2048)];
+	for (const chunk of chunks) {
+		spawned.emit(chunk);
+	}
+	const sentHash = sha256(...chunks);
+
+	// Subscribe with replay → one big concatenated output frame.
+	c.send({ type: "subscribe", id, replay: true });
+	const replayMsg = await c.waitFor(
+		(m) => m.type === "output" && m.id === id,
+		2000,
+	);
+	const replayBytes = payloadOf(replayMsg);
+	assert.ok(replayBytes, "replay frame must carry a binary payload");
+	assert.equal(
+		sha256(replayBytes),
+		sentHash,
+		"replayed bytes must hash-match what the store accumulated",
+	);
+
+	c.send({ type: "close", id });
+	await c.close();
+});
+
+test("non-UTF-8 byte sequences survive (the regression class)", async () => {
+	// The original bug ate bytes that weren't valid UTF-8 when split across
+	// chunks. Hand-craft a payload of explicitly-invalid sequences and split
+	// each one byte-by-byte to maximize the boundary-mangling surface.
+	const c = await connectAndHello(sockPath);
+	const id = "fid-non-utf8";
+	c.send({ type: "open", id, meta: META });
+	await c.waitFor((m) => m.type === "open-ok" && m.id === id);
+	const spawned = lastSpawned;
+	assert.ok(spawned, "spawnPty hook must have fired");
+	await subscribeAndDrain(c, id, false);
+
+	const sequences = [
+		Buffer.from([0xc0, 0x80]), // overlong null encoding
+		Buffer.from([0xff, 0xfe]), // BOM-like, invalid as utf-8 start
+		Buffer.from([0x80, 0x80, 0x80]), // lone continuation bytes
+		Buffer.from([0xed, 0xa0, 0x80]), // surrogate encoded as 3-byte (invalid)
+		Buffer.from("🙂", "utf8"), // valid 4-byte, split mid-codepoint below
+	];
+	for (const s of sequences) {
+		// Single-byte chunks: maximal boundary surface. Any per-chunk decode
+		// in the relay would replace these with U+FFFD and the hash diverges.
+		for (let i = 0; i < s.byteLength; i++) {
+			spawned.emit(s.subarray(i, i + 1));
+		}
+	}
+	const totalLen = sequences.reduce((n, s) => n + s.byteLength, 0);
+	const sentHash = sha256(...sequences);
+
+	await waitForBytes(c, id, totalLen, 2000);
+
+	const received = collectPayloads(c, id);
+	assert.equal(
+		sha256(...received),
+		sentHash,
+		"non-utf8 bytes must round-trip byte-perfect",
+	);
+
+	c.send({ type: "close", id });
+	await c.close();
+});

--- a/packages/pty-daemon/test/control-plane.test.ts
+++ b/packages/pty-daemon/test/control-plane.test.ts
@@ -13,7 +13,7 @@ import * as path from "node:path";
 import { after, before, describe, test } from "node:test";
 import { encodeFrame } from "../src/protocol/index.ts";
 import { Server } from "../src/Server/index.ts";
-import { connect, connectAndHello } from "./helpers/client.ts";
+import { connect, connectAndHello, payloadAsString } from "./helpers/client.ts";
 
 const sockPath = path.join(
 	os.tmpdir(),
@@ -67,15 +67,15 @@ describe("handshake", () => {
 
 	test("picks highest mutual when multiple offered", async () => {
 		const c = await connect(sockPath);
-		c.send({ type: "hello", protocols: [1, 99] });
+		c.send({ type: "hello", protocols: [2, 99] });
 		const ack = await c.waitFor((m) => m.type === "hello-ack");
-		if (ack.type === "hello-ack") assert.equal(ack.protocol, 1);
+		if (ack.type === "hello-ack") assert.equal(ack.protocol, 2);
 		await c.close();
 	});
 
 	test("rejects duplicate hello", async () => {
 		const c = await connectAndHello(sockPath);
-		c.send({ type: "hello", protocols: [1] });
+		c.send({ type: "hello", protocols: [2] });
 		const err = await c.waitFor((m) => m.type === "error", 1000);
 		if (err.type === "error") {
 			assert.match(err.message, /duplicate hello/);
@@ -115,7 +115,7 @@ describe("session lifecycle", () => {
 		const c = await connectAndHello(sockPath);
 		const missing = "missing-no-such";
 
-		c.send({ type: "input", id: missing, data: "" });
+		c.send({ type: "input", id: missing }, Buffer.alloc(0));
 		const e1 = await c.waitFor((m) => m.type === "error", 1000);
 		if (e1.type === "error") assert.equal(e1.code, "ENOENT");
 
@@ -209,16 +209,12 @@ describe("I/O patterns", () => {
 		c.send({ type: "subscribe", id, replay: false });
 
 		c.send({ type: "resize", id, cols: 120, rows: 40 });
-		c.send({
-			type: "input",
-			id,
-			data: Buffer.from("echo post-resize-marker\n").toString("base64"),
-		});
+		c.send({ type: "input", id }, Buffer.from("echo post-resize-marker\n"));
 		await c.waitFor(
 			(m) =>
 				m.type === "output" &&
 				m.id === id &&
-				Buffer.from(m.data, "base64").toString().includes("post-resize-marker"),
+				payloadAsString(m).includes("post-resize-marker"),
 			3000,
 		);
 
@@ -248,7 +244,7 @@ describe("I/O patterns", () => {
 			(m) =>
 				m.type === "output" &&
 				m.id === id &&
-				Buffer.from(m.data, "base64").toString().includes("BURST:200"),
+				payloadAsString(m).includes("BURST:200"),
 			5000,
 		);
 		await c.waitFor((m) => m.type === "exit" && m.id === id, 5000);
@@ -271,9 +267,7 @@ describe("I/O patterns", () => {
 		c.send({ type: "subscribe", id, replay: true });
 		await c.waitFor(
 			(m) =>
-				m.type === "output" &&
-				m.id === id &&
-				Buffer.from(m.data, "base64").toString().includes("🚀"),
+				m.type === "output" && m.id === id && payloadAsString(m).includes("🚀"),
 			3000,
 		);
 		await c.waitFor((m) => m.type === "exit" && m.id === id, 3000);
@@ -304,14 +298,14 @@ describe("multi-client fan-out", () => {
 				(m) =>
 					m.type === "output" &&
 					m.id === id &&
-					Buffer.from(m.data, "base64").toString().includes("fanout-marker"),
+					payloadAsString(m).includes("fanout-marker"),
 				3000,
 			),
 			b.waitFor(
 				(m) =>
 					m.type === "output" &&
 					m.id === id &&
-					Buffer.from(m.data, "base64").toString().includes("fanout-marker"),
+					payloadAsString(m).includes("fanout-marker"),
 				3000,
 			),
 		]);
@@ -335,22 +329,16 @@ describe("multi-client fan-out", () => {
 		b.send({ type: "subscribe", id, replay: false });
 
 		// First marker — both should see it.
-		a.send({
-			type: "input",
-			id,
-			data: Buffer.from("echo first-marker\n").toString("base64"),
-		});
+		a.send({ type: "input", id }, Buffer.from("echo first-marker\n"));
 		await Promise.all([
 			a.waitFor(
 				(m) =>
-					m.type === "output" &&
-					Buffer.from(m.data, "base64").toString().includes("first-marker"),
+					m.type === "output" && payloadAsString(m).includes("first-marker"),
 				3000,
 			),
 			b.waitFor(
 				(m) =>
-					m.type === "output" &&
-					Buffer.from(m.data, "base64").toString().includes("first-marker"),
+					m.type === "output" && payloadAsString(m).includes("first-marker"),
 				3000,
 			),
 		]);
@@ -365,23 +353,17 @@ describe("multi-client fan-out", () => {
 			500,
 		);
 
-		a.send({
-			type: "input",
-			id,
-			data: Buffer.from("echo second-marker\n").toString("base64"),
-		});
+		a.send({ type: "input", id }, Buffer.from("echo second-marker\n"));
 		await a.waitFor(
 			(m) =>
-				m.type === "output" &&
-				Buffer.from(m.data, "base64").toString().includes("second-marker"),
+				m.type === "output" && payloadAsString(m).includes("second-marker"),
 			3000,
 		);
 
 		const bMessages = await bAfterUnsub;
 		const sawSecondOnB = bMessages.some(
 			(m) =>
-				m.type === "output" &&
-				Buffer.from(m.data, "base64").toString().includes("second-marker"),
+				m.type === "output" && payloadAsString(m).includes("second-marker"),
 		);
 		assert.equal(sawSecondOnB, false);
 
@@ -407,15 +389,10 @@ describe("multi-client fan-out", () => {
 		// Force-close the dropper without unsubscribing.
 		dropper.socket.destroy();
 
-		owner.send({
-			type: "input",
-			id,
-			data: Buffer.from("echo survives-drop\n").toString("base64"),
-		});
+		owner.send({ type: "input", id }, Buffer.from("echo survives-drop\n"));
 		await observer.waitFor(
 			(m) =>
-				m.type === "output" &&
-				Buffer.from(m.data, "base64").toString().includes("survives-drop"),
+				m.type === "output" && payloadAsString(m).includes("survives-drop"),
 			3000,
 		);
 
@@ -450,7 +427,7 @@ describe("detach + reattach", () => {
 			(m) =>
 				m.type === "output" &&
 				m.id === id &&
-				Buffer.from(m.data, "base64").toString().includes("early-marker"),
+				payloadAsString(m).includes("early-marker"),
 			3000,
 		);
 
@@ -473,15 +450,10 @@ describe("detach + reattach", () => {
 		first.send({ type: "subscribe", id, replay: false });
 
 		// Generate some output via input.
-		owner.send({
-			type: "input",
-			id,
-			data: Buffer.from("echo before-reattach\n").toString("base64"),
-		});
+		owner.send({ type: "input", id }, Buffer.from("echo before-reattach\n"));
 		await first.waitFor(
 			(m) =>
-				m.type === "output" &&
-				Buffer.from(m.data, "base64").toString().includes("before-reattach"),
+				m.type === "output" && payloadAsString(m).includes("before-reattach"),
 			3000,
 		);
 
@@ -496,20 +468,16 @@ describe("detach + reattach", () => {
 			(m) =>
 				m.type === "output" &&
 				m.id === id &&
-				Buffer.from(m.data, "base64").toString().includes("before-reattach"),
+				payloadAsString(m).includes("before-reattach"),
 			2000,
 		);
 
-		owner.send({
-			type: "input",
-			id,
-			data: Buffer.from("echo after-reattach\n").toString("base64"),
-		});
+		owner.send({ type: "input", id }, Buffer.from("echo after-reattach\n"));
 		await second.waitFor(
 			(m) =>
 				m.type === "output" &&
 				m.id === id &&
-				Buffer.from(m.data, "base64").toString().includes("after-reattach"),
+				payloadAsString(m).includes("after-reattach"),
 			3000,
 		);
 
@@ -621,15 +589,10 @@ describe("cross-client continuity (host-service restart simulation)", () => {
 		await a.waitFor((m) => m.type === "open-ok" && m.id === id);
 
 		a.send({ type: "subscribe", id, replay: false });
-		a.send({
-			type: "input",
-			id,
-			data: Buffer.from("echo before-restart\n").toString("base64"),
-		});
+		a.send({ type: "input", id }, Buffer.from("echo before-restart\n"));
 		await a.waitFor(
 			(m) =>
-				m.type === "output" &&
-				Buffer.from(m.data, "base64").toString().includes("before-restart"),
+				m.type === "output" && payloadAsString(m).includes("before-restart"),
 			3000,
 		);
 
@@ -652,21 +615,17 @@ describe("cross-client continuity (host-service restart simulation)", () => {
 			(m) =>
 				m.type === "output" &&
 				m.id === id &&
-				Buffer.from(m.data, "base64").toString().includes("before-restart"),
+				payloadAsString(m).includes("before-restart"),
 			3000,
 		);
 
 		// New input from B reaches the (still-living) shell.
-		b.send({
-			type: "input",
-			id,
-			data: Buffer.from("echo after-restart\n").toString("base64"),
-		});
+		b.send({ type: "input", id }, Buffer.from("echo after-restart\n"));
 		await b.waitFor(
 			(m) =>
 				m.type === "output" &&
 				m.id === id &&
-				Buffer.from(m.data, "base64").toString().includes("after-restart"),
+				payloadAsString(m).includes("after-restart"),
 			3000,
 		);
 
@@ -762,15 +721,9 @@ describe("hostile input", () => {
 
 		// Owner is still functional.
 		owner.send({ type: "subscribe", id, replay: false });
-		owner.send({
-			type: "input",
-			id,
-			data: Buffer.from("echo still-alive\n").toString("base64"),
-		});
+		owner.send({ type: "input", id }, Buffer.from("echo still-alive\n"));
 		await owner.waitFor(
-			(m) =>
-				m.type === "output" &&
-				Buffer.from(m.data, "base64").toString().includes("still-alive"),
+			(m) => m.type === "output" && payloadAsString(m).includes("still-alive"),
 			3000,
 		);
 
@@ -809,11 +762,7 @@ describe("hostile input", () => {
 		await c.waitFor((m) => m.type === "exit" && m.id === id, 3000);
 		await new Promise((r) => setTimeout(r, 50));
 
-		c.send({
-			type: "input",
-			id,
-			data: Buffer.from("ignored").toString("base64"),
-		});
+		c.send({ type: "input", id }, Buffer.from("ignored"));
 		const err = await c.waitFor((m) => m.type === "error", 1000);
 		if (err.type === "error") assert.equal(err.code, "ENOENT");
 		await c.close();
@@ -865,7 +814,7 @@ describe("concurrency", () => {
 					m.type === "output" &&
 					!seen.has(m.id) &&
 					ids.includes(m.id) &&
-					Buffer.from(m.data, "base64").toString().includes("TICK:start"),
+					payloadAsString(m).includes("TICK:start"),
 				10_000,
 			);
 			if (m.type === "output") seen.add(m.id);
@@ -905,7 +854,7 @@ describe("concurrency", () => {
 					(m) =>
 						m.type === "output" &&
 						m.id === id &&
-						Buffer.from(m.data, "base64").toString().includes(`CONN:${i}`),
+						payloadAsString(m).includes(`CONN:${i}`),
 					5000,
 				);
 				c.send({ type: "close", id, signal: "SIGTERM" });
@@ -952,7 +901,7 @@ describe("server shutdown", () => {
 describe("framing on the wire", () => {
 	test("server tolerates split frames across multiple TCP chunks", async () => {
 		const c = await connect(sockPath);
-		const hello = encodeFrame({ type: "hello", protocols: [1] });
+		const hello = encodeFrame({ type: "hello", protocols: [2] });
 		// Send the hello in 3-byte chunks to force the decoder to buffer.
 		for (let i = 0; i < hello.length; i += 3) {
 			c.sendRaw(hello.subarray(i, Math.min(i + 3, hello.length)));

--- a/packages/pty-daemon/test/control-plane.test.ts
+++ b/packages/pty-daemon/test/control-plane.test.ts
@@ -13,7 +13,12 @@ import * as path from "node:path";
 import { after, before, describe, test } from "node:test";
 import { encodeFrame } from "../src/protocol/index.ts";
 import { Server } from "../src/Server/index.ts";
-import { connect, connectAndHello, payloadAsString } from "./helpers/client.ts";
+import {
+	accumulatedOutputAsString,
+	connect,
+	connectAndHello,
+	payloadAsString,
+} from "./helpers/client.ts";
 
 const sockPath = path.join(
 	os.tmpdir(),
@@ -265,9 +270,15 @@ describe("I/O patterns", () => {
 		});
 		await c.waitFor((m) => m.type === "open-ok" && m.id === id);
 		c.send({ type: "subscribe", id, replay: true });
+		// 🚀 is 4 bytes; if those bytes ever split across two `output` frames,
+		// per-frame `payloadAsString` would emit U+FFFD even though the wire
+		// is intact. Accumulate across all output frames and decode once so
+		// the test asserts the actual wire-level invariant we care about.
 		await c.waitFor(
 			(m) =>
-				m.type === "output" && m.id === id && payloadAsString(m).includes("🚀"),
+				m.type === "output" &&
+				m.id === id &&
+				accumulatedOutputAsString(c, id).includes("🚀"),
 			3000,
 		);
 		await c.waitFor((m) => m.type === "exit" && m.id === id, 3000);

--- a/packages/pty-daemon/test/helpers/client.ts
+++ b/packages/pty-daemon/test/helpers/client.ts
@@ -1,5 +1,5 @@
 // Reusable test client for pty-daemon integration tests.
-// Speaks the daemon's wire protocol over a Unix socket.
+// Speaks the daemon's wire protocol (v2) over a Unix socket.
 
 import * as net from "node:net";
 import {
@@ -8,10 +8,27 @@ import {
 	type ServerMessage,
 } from "../../src/protocol/index.ts";
 
+// Each decoded frame's binary tail (if any) is parked here, keyed by the
+// JSON message object. Tests that want output bytes use `payloadOf(m)`.
+// WeakMap so it cleans up if the message object is dropped.
+const payloads = new WeakMap<object, Uint8Array>();
+
+export function payloadOf(message: ServerMessage): Uint8Array | null {
+	return payloads.get(message as object) ?? null;
+}
+
+/** UTF-8 view of an output message's payload, for log/text assertions. */
+export function payloadAsString(message: ServerMessage): string {
+	const p = payloads.get(message as object);
+	if (!p) return "";
+	return Buffer.from(p).toString("utf8");
+}
+
 export interface DaemonClient {
 	socket: net.Socket;
 	messages: ServerMessage[];
-	send(m: unknown): void;
+	/** Send a control message; optional `payload` rides as the frame's binary tail. */
+	send(m: unknown, payload?: Uint8Array): void;
 	waitFor(
 		predicate: (m: ServerMessage) => boolean,
 		ms?: number,
@@ -45,8 +62,11 @@ export function connect(socketPath: string): Promise<DaemonClient> {
 		socket.on("data", (chunk) => {
 			try {
 				decoder.push(chunk);
-				for (const raw of decoder.drain()) {
-					const m = raw as ServerMessage;
+				for (const decoded of decoder.drain()) {
+					const m = decoded.message as ServerMessage;
+					if (decoded.payload) {
+						payloads.set(m as object, decoded.payload);
+					}
 					messages.push(m);
 					for (let i = waiters.length - 1; i >= 0; i--) {
 						const w = waiters[i];
@@ -58,7 +78,6 @@ export function connect(socketPath: string): Promise<DaemonClient> {
 					}
 				}
 			} catch (err) {
-				// Surface frame errors to any pending waiter.
 				for (const w of waiters) {
 					clearTimeout(w.timer);
 					w.reject(err as Error);
@@ -77,8 +96,8 @@ export function connect(socketPath: string): Promise<DaemonClient> {
 			resolve({
 				socket,
 				messages,
-				send(m) {
-					if (!socket.destroyed) socket.write(encodeFrame(m));
+				send(m, payload) {
+					if (!socket.destroyed) socket.write(encodeFrame(m, payload));
 				},
 				sendRaw(buf) {
 					if (!socket.destroyed) socket.write(buf);
@@ -108,7 +127,6 @@ export function connect(socketPath: string): Promise<DaemonClient> {
 						socket.on("data", onMsg);
 						setTimeout(() => {
 							socket.off("data", onMsg);
-							// Final sweep in case of late drains.
 							for (let i = collected.length; i < messages.length; i++) {
 								const m = messages[i];
 								if (m && predicate(m)) collected.push(m);
@@ -121,7 +139,6 @@ export function connect(socketPath: string): Promise<DaemonClient> {
 					return new Promise<void>((res) => {
 						if (socket.destroyed) return res();
 						socket.end(() => res());
-						// Fall back: if `end` doesn't fire close within 200ms, force.
 						setTimeout(() => {
 							if (!socket.destroyed) socket.destroy();
 							res();
@@ -140,12 +157,12 @@ export function connect(socketPath: string): Promise<DaemonClient> {
 	});
 }
 
-/** Convenience: connect and complete the v1 handshake. */
+/** Convenience: connect and complete the v2 handshake. */
 export async function connectAndHello(
 	socketPath: string,
 ): Promise<DaemonClient> {
 	const c = await connect(socketPath);
-	c.send({ type: "hello", protocols: [1] });
+	c.send({ type: "hello", protocols: [2] });
 	await c.waitFor((m) => m.type === "hello-ack");
 	return c;
 }

--- a/packages/pty-daemon/test/helpers/client.ts
+++ b/packages/pty-daemon/test/helpers/client.ts
@@ -17,11 +17,47 @@ export function payloadOf(message: ServerMessage): Uint8Array | null {
 	return payloads.get(message as object) ?? null;
 }
 
-/** UTF-8 view of an output message's payload, for log/text assertions. */
+/**
+ * UTF-8 view of an output message's payload, for log/text assertions.
+ *
+ * IMPORTANT: this decodes a SINGLE frame's payload — if a multi-byte
+ * codepoint straddles two daemon `output` frames, decoding each frame
+ * individually emits U+FFFD even though the bytes are intact on the wire.
+ * Safe for ASCII markers ("first-marker", "BURST:200", etc.) where the
+ * needle survives per-frame decoding by construction. For multi-byte
+ * markers (emoji, accented text), use {@link accumulatedOutputAsString}.
+ */
 export function payloadAsString(message: ServerMessage): string {
 	const p = payloads.get(message as object);
 	if (!p) return "";
 	return Buffer.from(p).toString("utf8");
+}
+
+/**
+ * Concatenate every output payload for `id` seen so far, then UTF-8 decode
+ * the whole thing once. Use this when the marker you're matching against
+ * is multi-byte and could theoretically split across daemon frames.
+ */
+export function accumulatedOutputAsString(
+	client: { messages: ServerMessage[] },
+	id: string,
+): string {
+	const parts: Uint8Array[] = [];
+	for (const m of client.messages) {
+		if (m.type !== "output" || m.id !== id) continue;
+		const p = payloads.get(m as object);
+		if (p) parts.push(p);
+	}
+	if (parts.length === 0) return "";
+	let total = 0;
+	for (const p of parts) total += p.byteLength;
+	const merged = new Uint8Array(total);
+	let offset = 0;
+	for (const p of parts) {
+		merged.set(p, offset);
+		offset += p.byteLength;
+	}
+	return Buffer.from(merged).toString("utf8");
 }
 
 export interface DaemonClient {

--- a/packages/pty-daemon/test/integration.test.ts
+++ b/packages/pty-daemon/test/integration.test.ts
@@ -8,7 +8,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { after, before, test } from "node:test";
 import { Server } from "../src/Server/index.ts";
-import { connect, connectAndHello } from "./helpers/client.ts";
+import { connect, connectAndHello, payloadAsString } from "./helpers/client.ts";
 
 const sockPath = path.join(os.tmpdir(), `pty-daemon-smoke-${process.pid}.sock`);
 let server: Server;
@@ -24,11 +24,11 @@ after(async () => {
 
 test("handshake: hello → hello-ack", async () => {
 	const c = await connect(sockPath);
-	c.send({ type: "hello", protocols: [1] });
+	c.send({ type: "hello", protocols: [2] });
 	const ack = await c.waitFor((m) => m.type === "hello-ack");
 	assert.equal(ack.type, "hello-ack");
 	if (ack.type === "hello-ack") {
-		assert.equal(ack.protocol, 1);
+		assert.equal(ack.protocol, 2);
 		assert.equal(ack.daemonVersion, "0.0.0-test");
 	}
 	await c.close();
@@ -53,7 +53,7 @@ test("open → subscribe → output → exit lifecycle", async () => {
 		(m) =>
 			m.type === "output" &&
 			m.id === "smoke-0" &&
-			Buffer.from(m.data, "base64").toString().includes("daemon-smoke"),
+			payloadAsString(m).includes("daemon-smoke"),
 		3000,
 	);
 	const exit = await c.waitFor(
@@ -73,16 +73,12 @@ test("input is forwarded and echoed via output", async () => {
 	});
 	await c.waitFor((m) => m.type === "open-ok");
 	c.send({ type: "subscribe", id: "smoke-1", replay: false });
-	c.send({
-		type: "input",
-		id: "smoke-1",
-		data: Buffer.from("echo abc-marker\n").toString("base64"),
-	});
+	c.send({ type: "input", id: "smoke-1" }, Buffer.from("echo abc-marker\n"));
 	await c.waitFor(
 		(m) =>
 			m.type === "output" &&
 			m.id === "smoke-1" &&
-			Buffer.from(m.data, "base64").toString().includes("abc-marker"),
+			payloadAsString(m).includes("abc-marker"),
 		3000,
 	);
 	c.send({ type: "close", id: "smoke-1", signal: "SIGTERM" });

--- a/packages/pty-daemon/test/no-encoding-hops.test.ts
+++ b/packages/pty-daemon/test/no-encoding-hops.test.ts
@@ -1,0 +1,103 @@
+// Source-level invariant: the data path in pty-daemon and host-service's
+// DaemonClient must NOT contain encoding hops.
+//
+// Pre-protocol-v2, PTY input/output bytes were base64'd into a JSON `data`
+// field. After v2, bytes ride in the frame's binary tail and there are
+// zero encode/decode passes per chunk. This test fails the moment anyone
+// reintroduces a hop in source — much earlier than runtime tests catch it.
+//
+// Why source-level (not bundle-level): bundlers minify/rename identifiers,
+// so grepping the bundle is fragile. The source files we want to guard are
+// short, stable, and centrally located.
+
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "../../..");
+
+/**
+ * Read a file relative to the repo root with comments stripped. We only
+ * care about real code: comments are allowed to *mention* forbidden patterns
+ * (e.g. "the old `chunk.toString("utf8")` was the bug"), they just can't
+ * actually call them.
+ */
+function read(relPath: string): string {
+	const abs = path.resolve(repoRoot, relPath);
+	if (!fs.existsSync(abs)) {
+		throw new Error(`expected file not found: ${relPath}`);
+	}
+	const raw = fs.readFileSync(abs, "utf8");
+	return stripComments(raw);
+}
+
+function stripComments(src: string): string {
+	// Block comments first (so `// inside /* */` doesn't escape the strip),
+	// then line comments. Naive — doesn't try to parse strings — but more
+	// than enough for our well-formatted source files.
+	return src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+}
+
+// Files in the daemon ↔ host wire data path. If any of these grow a base64
+// or per-chunk-utf8 hop, the canary fires.
+const DATA_PATH_FILES = [
+	"packages/pty-daemon/src/Server/Server.ts",
+	"packages/pty-daemon/src/handlers/handlers.ts",
+	"packages/pty-daemon/src/protocol/messages.ts",
+	"packages/pty-daemon/src/protocol/framing.ts",
+	"packages/host-service/src/terminal/DaemonClient/DaemonClient.ts",
+];
+
+describe("data path is base64-free", () => {
+	test.each(DATA_PATH_FILES)('%s: no toString("base64")', (rel) => {
+		const src = read(rel);
+		expect(src).not.toContain('toString("base64")');
+		expect(src).not.toContain("toString('base64')");
+	});
+
+	test.each(DATA_PATH_FILES)('%s: no Buffer.from(.., "base64")', (rel) => {
+		const src = read(rel);
+		// Catches the input-decode shape `Buffer.from(msg.data, "base64")`
+		// and any sibling `Buffer.from(<x>, "base64")` in the data path.
+		expect(src).not.toMatch(/Buffer\.from\([^)]*,\s*["']base64["']/);
+	});
+
+	test('OutputMessage and InputMessage do not declare a "data" field', () => {
+		// If anyone re-adds `data: string` to either message, base64 is
+		// the only way to fit binary into JSON — drop the temptation early.
+		const src = read("packages/pty-daemon/src/protocol/messages.ts");
+		const outputBlock = extractInterfaceBlock(src, "OutputMessage");
+		const inputBlock = extractInterfaceBlock(src, "InputMessage");
+		expect(outputBlock).not.toMatch(/^\s*data\s*:/m);
+		expect(inputBlock).not.toMatch(/^\s*data\s*:/m);
+	});
+});
+
+describe("output relay is StringDecoder-safe (host-service)", () => {
+	test('terminal.ts only uses Buffer.toString("utf8") in side-channel paths', () => {
+		// Per-chunk `chunk.toString("utf8")` was the renderer-side bug.
+		// terminal.ts is allowed to decode for side channels (port hint,
+		// teardown tail buffer), but those uses go through `StringDecoder`,
+		// not raw `.toString("utf8")`. If a fresh `.toString("utf8")` shows
+		// up here, it almost certainly mangles bytes at chunk boundaries.
+		const src = read("packages/host-service/src/terminal/terminal.ts");
+		// Allow only StringDecoder-mediated decoding; flag plain
+		// `chunk.toString("utf8")` / `data.toString("utf8")` shapes.
+		expect(src).not.toMatch(/chunk\.toString\(["']utf-?8["']\)/);
+		expect(src).not.toMatch(/data\.toString\(["']utf-?8["']\)/);
+		expect(src).toContain('new StringDecoder("utf8")');
+	});
+});
+
+/**
+ * Pull out the body of `interface Foo { ... }` so we can assert on its fields
+ * without false positives from neighboring interfaces in the same file.
+ */
+function extractInterfaceBlock(src: string, name: string): string {
+	const re = new RegExp(`interface\\s+${name}\\s*{([\\s\\S]*?)}`, "m");
+	const match = re.exec(src);
+	if (!match) throw new Error(`interface ${name} not found`);
+	return match[1] ?? "";
+}

--- a/packages/pty-daemon/test/signal-recovery.test.ts
+++ b/packages/pty-daemon/test/signal-recovery.test.ts
@@ -147,8 +147,8 @@ function connect(): Promise<Client> {
 
 		socket.on("data", (chunk) => {
 			decoder.push(chunk);
-			for (const raw of decoder.drain()) {
-				messages.push(raw as ServerMessage);
+			for (const decoded of decoder.drain()) {
+				messages.push(decoded.message as ServerMessage);
 			}
 		});
 

--- a/packages/shared/src/shell-ready-scanner.test.ts
+++ b/packages/shared/src/shell-ready-scanner.test.ts
@@ -1,37 +1,31 @@
 import { describe, expect, it } from "bun:test";
-import {
-	createScanStateBytes,
-	scanForShellReadyBytes,
-} from "./shell-ready-scanner";
+import { createScanState, scanForShellReady } from "./shell-ready-scanner";
 
 const enc = new TextEncoder();
 const dec = new TextDecoder();
 
 describe("shell-ready scanner (bytes)", () => {
 	it("strips the OSC 133;A marker from a single chunk", () => {
-		const state = createScanStateBytes();
-		const r = scanForShellReadyBytes(
-			state,
-			enc.encode("hello\x1b]133;A\x07$ "),
-		);
+		const state = createScanState();
+		const r = scanForShellReady(state, enc.encode("hello\x1b]133;A\x07$ "));
 		expect(r.matched).toBe(true);
 		expect(dec.decode(r.output)).toBe("hello$ ");
 	});
 
 	it("matches the marker spanning two chunks without dropping bytes", () => {
-		const state = createScanStateBytes();
-		const a = scanForShellReadyBytes(state, enc.encode("\x1b]133"));
+		const state = createScanState();
+		const a = scanForShellReady(state, enc.encode("\x1b]133"));
 		expect(a.matched).toBe(false);
 		expect(a.output.length).toBe(0);
-		const b = scanForShellReadyBytes(state, enc.encode(";A\x07"));
+		const b = scanForShellReady(state, enc.encode(";A\x07"));
 		expect(b.matched).toBe(true);
 		expect(b.output.length).toBe(0);
 	});
 
 	it("flushes held bytes that turned out not to be a marker", () => {
-		const state = createScanStateBytes();
+		const state = createScanState();
 		// Starts looking like the marker, then bails on the second char.
-		const r = scanForShellReadyBytes(state, enc.encode("\x1bX"));
+		const r = scanForShellReady(state, enc.encode("\x1bX"));
 		expect(r.matched).toBe(false);
 		expect(dec.decode(r.output)).toBe("\x1bX");
 	});
@@ -39,10 +33,10 @@ describe("shell-ready scanner (bytes)", () => {
 	it("passes UTF-8 bytes through verbatim — even split mid-codepoint", () => {
 		// The whole point of the byte scanner: no per-chunk utf-8 decoding,
 		// so a smiley split across chunks survives untouched.
-		const state = createScanStateBytes();
+		const state = createScanState();
 		const smiley = enc.encode("🙂"); // 4 bytes
-		const a = scanForShellReadyBytes(state, smiley.subarray(0, 2));
-		const b = scanForShellReadyBytes(state, smiley.subarray(2));
+		const a = scanForShellReady(state, smiley.subarray(0, 2));
+		const b = scanForShellReady(state, smiley.subarray(2));
 		const combined = new Uint8Array(a.output.length + b.output.length);
 		combined.set(a.output, 0);
 		combined.set(b.output, a.output.length);

--- a/packages/shared/src/shell-ready-scanner.test.ts
+++ b/packages/shared/src/shell-ready-scanner.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "bun:test";
+import {
+	createScanStateBytes,
+	scanForShellReadyBytes,
+} from "./shell-ready-scanner";
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+describe("shell-ready scanner (bytes)", () => {
+	it("strips the OSC 133;A marker from a single chunk", () => {
+		const state = createScanStateBytes();
+		const r = scanForShellReadyBytes(
+			state,
+			enc.encode("hello\x1b]133;A\x07$ "),
+		);
+		expect(r.matched).toBe(true);
+		expect(dec.decode(r.output)).toBe("hello$ ");
+	});
+
+	it("matches the marker spanning two chunks without dropping bytes", () => {
+		const state = createScanStateBytes();
+		const a = scanForShellReadyBytes(state, enc.encode("\x1b]133"));
+		expect(a.matched).toBe(false);
+		expect(a.output.length).toBe(0);
+		const b = scanForShellReadyBytes(state, enc.encode(";A\x07"));
+		expect(b.matched).toBe(true);
+		expect(b.output.length).toBe(0);
+	});
+
+	it("flushes held bytes that turned out not to be a marker", () => {
+		const state = createScanStateBytes();
+		// Starts looking like the marker, then bails on the second char.
+		const r = scanForShellReadyBytes(state, enc.encode("\x1bX"));
+		expect(r.matched).toBe(false);
+		expect(dec.decode(r.output)).toBe("\x1bX");
+	});
+
+	it("passes UTF-8 bytes through verbatim — even split mid-codepoint", () => {
+		// The whole point of the byte scanner: no per-chunk utf-8 decoding,
+		// so a smiley split across chunks survives untouched.
+		const state = createScanStateBytes();
+		const smiley = enc.encode("🙂"); // 4 bytes
+		const a = scanForShellReadyBytes(state, smiley.subarray(0, 2));
+		const b = scanForShellReadyBytes(state, smiley.subarray(2));
+		const combined = new Uint8Array(a.output.length + b.output.length);
+		combined.set(a.output, 0);
+		combined.set(b.output, a.output.length);
+		expect(dec.decode(combined)).toBe("🙂");
+	});
+});

--- a/packages/shared/src/shell-ready-scanner.ts
+++ b/packages/shared/src/shell-ready-scanner.ts
@@ -10,7 +10,6 @@
  * Vendored from WezTerm (MIT, Copyright 2018-Present Wez Furlong).
  */
 
-/** OSC 133;A as raw bytes. */
 const OSC_133_A_BYTES = Uint8Array.from(
 	[..."\x1b]133;A"].map((c) => c.charCodeAt(0)),
 );

--- a/packages/shared/src/shell-ready-scanner.ts
+++ b/packages/shared/src/shell-ready-scanner.ts
@@ -1,79 +1,58 @@
 /**
  * OSC 133 shell readiness scanner (FinalTerm semantic prompt standard).
  *
- * Pure scanning logic — no side effects. Callers handle their own readiness
- * resolution (promises, state machines, event broadcasts, etc.).
+ * Pure scanning logic, byte-oriented — no per-chunk UTF-8 decoding hop.
+ * The marker (`\x1b]133;A...\x07`) is pure ASCII, so byte-level matching
+ * is identical to char-level matching while letting callers keep PTY
+ * output as opaque bytes from the daemon all the way to xterm.js.
  *
  * Protocol ref: https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md
  * Vendored from WezTerm (MIT, Copyright 2018-Present Wez Furlong).
  */
 
-/** The OSC 133;A prefix that signals shell prompt start (= shell ready). */
-const OSC_133_A = "\x1b]133;A";
-
-/** Shells whose wrapper files inject OSC 133 markers. */
-export const SHELLS_WITH_READY_MARKER = new Set(["zsh", "bash", "fish"]);
-
-/**
- * Mutable state for the character-by-character scanner.
- * Callers should create one per terminal session via {@link createScanState}.
- */
-export interface ShellReadyScanState {
-	matchPos: number;
-	heldBytes: string;
-}
-
-export interface ShellReadyScanResult {
-	/** Output data with the marker stripped (if found). */
-	output: string;
-	/** Whether the full OSC 133;A marker was matched in this chunk. */
-	matched: boolean;
-}
-
-export function createScanState(): ShellReadyScanState {
-	return { matchPos: 0, heldBytes: "" };
-}
-
-// ---------- Byte-oriented variant (v2 PTY data path) ----------
-//
-// The string variant above runs `Buffer.toString("utf8")` per chunk before
-// scanning, which mangles any UTF-8 codepoint that straddles a chunk
-// boundary. v2 keeps PTY output as raw bytes from daemon → xterm.js;
-// `scanForShellReadyBytes` lets it stay that way. OSC 133;A is pure ASCII
-// (`\x1b]133;A...\x07`) so byte matching is identical to char matching.
-
-/** OSC 133;A as raw bytes — pure ASCII so 1:1 with the string form. */
+/** OSC 133;A as raw bytes. */
 const OSC_133_A_BYTES = Uint8Array.from(
 	[..."\x1b]133;A"].map((c) => c.charCodeAt(0)),
 );
 const BEL_BYTE = 0x07;
 
-export interface ShellReadyScanStateBytes {
+/** Shells whose wrapper files inject OSC 133 markers. */
+export const SHELLS_WITH_READY_MARKER = new Set(["zsh", "bash", "fish"]);
+
+/**
+ * Mutable state for the byte-by-byte scanner.
+ * Callers should create one per terminal session via {@link createScanState}.
+ */
+export interface ShellReadyScanState {
 	matchPos: number;
 	/** Bytes withheld from output while a match is in progress. */
 	heldBytes: number[];
 }
 
-export interface ShellReadyScanResultBytes {
+export interface ShellReadyScanResult {
 	// Tight ArrayBuffer-backed shape: matches Buffer and what
 	// hono/ws WSContext.send accepts, so callers don't need casts.
 	output: Uint8Array<ArrayBuffer>;
 	matched: boolean;
 }
 
-export function createScanStateBytes(): ShellReadyScanStateBytes {
+export function createScanState(): ShellReadyScanState {
 	return { matchPos: 0, heldBytes: [] };
 }
 
 /**
- * Byte-oriented scanner. Same state-machine as the string variant, but
- * never decodes UTF-8 — so it composes cleanly into a transport that
- * treats PTY data as opaque bytes from end to end.
+ * Scan a chunk of PTY output for the OSC 133;A (prompt start) marker.
+ *
+ * Matching bytes are held back from output. On full match (prefix + optional
+ * params + string terminator `\a`), they're discarded and `matched` is true.
+ * On mismatch, held bytes are flushed as regular terminal output.
+ *
+ * The scanner handles the marker spanning multiple data chunks.
  */
-export function scanForShellReadyBytes(
-	state: ShellReadyScanStateBytes,
+export function scanForShellReady(
+	state: ShellReadyScanState,
 	data: Uint8Array,
-): ShellReadyScanResultBytes {
+): ShellReadyScanResult {
 	const out: number[] = [];
 
 	for (let i = 0; i < data.length; i++) {
@@ -112,56 +91,4 @@ export function scanForShellReadyBytes(
 	}
 
 	return { output: Uint8Array.from(out), matched: false };
-}
-
-/**
- * Scan a chunk of PTY output for the OSC 133;A (prompt start) marker.
- *
- * Matching bytes are held back from output. On full match (prefix + optional
- * params + string terminator `\a`), they're discarded and `matched` is true.
- * On mismatch, held bytes are flushed as regular terminal output.
- *
- * The scanner handles the marker spanning multiple data chunks.
- */
-export function scanForShellReady(
-	state: ShellReadyScanState,
-	data: string,
-): ShellReadyScanResult {
-	let output = "";
-
-	for (let i = 0; i < data.length; i++) {
-		const ch = data[i] as string;
-		if (state.matchPos < OSC_133_A.length) {
-			// Still matching the "\x1b]133;A" prefix
-			if (ch === OSC_133_A[state.matchPos]) {
-				state.heldBytes += ch;
-				state.matchPos++;
-			} else {
-				// Mismatch — flush held bytes, then re-test current char as a
-				// fresh match start (e.g. stale ESC followed by real marker).
-				output += state.heldBytes;
-				state.heldBytes = "";
-				state.matchPos = 0;
-				if (ch === OSC_133_A[0]) {
-					state.heldBytes = ch;
-					state.matchPos = 1;
-				} else {
-					output += ch;
-				}
-			}
-		} else {
-			// Matched prefix — consume optional params until string terminator
-			if (ch === "\x07") {
-				// Full match — discard held bytes
-				const remaining = data.slice(i + 1);
-				state.heldBytes = "";
-				state.matchPos = 0;
-				return { output: output + remaining, matched: true };
-			}
-			// Consume optional params (e.g. ";cl=m;aid=123") before \a
-			state.heldBytes += ch;
-		}
-	}
-
-	return { output, matched: false };
 }

--- a/packages/shared/src/shell-ready-scanner.ts
+++ b/packages/shared/src/shell-ready-scanner.ts
@@ -34,6 +34,86 @@ export function createScanState(): ShellReadyScanState {
 	return { matchPos: 0, heldBytes: "" };
 }
 
+// ---------- Byte-oriented variant (v2 PTY data path) ----------
+//
+// The string variant above runs `Buffer.toString("utf8")` per chunk before
+// scanning, which mangles any UTF-8 codepoint that straddles a chunk
+// boundary. v2 keeps PTY output as raw bytes from daemon → xterm.js;
+// `scanForShellReadyBytes` lets it stay that way. OSC 133;A is pure ASCII
+// (`\x1b]133;A...\x07`) so byte matching is identical to char matching.
+
+/** OSC 133;A as raw bytes — pure ASCII so 1:1 with the string form. */
+const OSC_133_A_BYTES = Uint8Array.from(
+	[..."\x1b]133;A"].map((c) => c.charCodeAt(0)),
+);
+const BEL_BYTE = 0x07;
+
+export interface ShellReadyScanStateBytes {
+	matchPos: number;
+	/** Bytes withheld from output while a match is in progress. */
+	heldBytes: number[];
+}
+
+export interface ShellReadyScanResultBytes {
+	// Tight ArrayBuffer-backed shape: matches Buffer and what
+	// hono/ws WSContext.send accepts, so callers don't need casts.
+	output: Uint8Array<ArrayBuffer>;
+	matched: boolean;
+}
+
+export function createScanStateBytes(): ShellReadyScanStateBytes {
+	return { matchPos: 0, heldBytes: [] };
+}
+
+/**
+ * Byte-oriented scanner. Same state-machine as the string variant, but
+ * never decodes UTF-8 — so it composes cleanly into a transport that
+ * treats PTY data as opaque bytes from end to end.
+ */
+export function scanForShellReadyBytes(
+	state: ShellReadyScanStateBytes,
+	data: Uint8Array,
+): ShellReadyScanResultBytes {
+	const out: number[] = [];
+
+	for (let i = 0; i < data.length; i++) {
+		const b = data[i] as number;
+		if (state.matchPos < OSC_133_A_BYTES.length) {
+			if (b === OSC_133_A_BYTES[state.matchPos]) {
+				state.heldBytes.push(b);
+				state.matchPos++;
+			} else {
+				for (const h of state.heldBytes) out.push(h);
+				state.heldBytes.length = 0;
+				state.matchPos = 0;
+				if (b === OSC_133_A_BYTES[0]) {
+					state.heldBytes.push(b);
+					state.matchPos = 1;
+				} else {
+					out.push(b);
+				}
+			}
+		} else {
+			if (b === BEL_BYTE) {
+				state.heldBytes.length = 0;
+				state.matchPos = 0;
+				const remaining = data.subarray(i + 1);
+				const head = Uint8Array.from(out);
+				if (remaining.length === 0) {
+					return { output: head, matched: true };
+				}
+				const merged = new Uint8Array(head.length + remaining.length);
+				merged.set(head, 0);
+				merged.set(remaining, head.length);
+				return { output: merged, matched: true };
+			}
+			state.heldBytes.push(b);
+		}
+	}
+
+	return { output: Uint8Array.from(out), matched: false };
+}
+
 /**
  * Scan a chunk of PTY output for the OSC 133;A (prompt start) marker.
  *

--- a/packages/shared/src/terminal-title-scanner.test.ts
+++ b/packages/shared/src/terminal-title-scanner.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "bun:test";
 import {
 	createTerminalTitleScanState,
+	createTerminalTitleScanStateBytes,
 	normalizeTerminalTitle,
 	scanForTerminalTitle,
+	scanForTerminalTitleBytes,
 } from "./terminal-title-scanner";
+
+const enc = new TextEncoder();
 
 describe("terminal title scanner", () => {
 	it("handles OSC 0 and OSC 2 with BEL terminators", () => {
@@ -102,6 +106,37 @@ describe("terminal title scanner", () => {
 			scanForTerminalTitle(state, `\x1b]2;${"🙂".repeat(1024)}`).updates,
 		).toEqual([]);
 		expect(state.buffer).toBe("");
+	});
+});
+
+describe("terminal title scanner (bytes)", () => {
+	it("matches the string variant for the common cases", () => {
+		const state = createTerminalTitleScanStateBytes();
+		expect(
+			scanForTerminalTitleBytes(state, enc.encode("\x1b]0;Shell\x07")).updates,
+		).toEqual(["Shell"]);
+		expect(
+			scanForTerminalTitleBytes(state, enc.encode("\x1b]2;Editor\x1b\\"))
+				.updates,
+		).toEqual(["Editor"]);
+		expect(
+			scanForTerminalTitleBytes(state, enc.encode("\x1b]9;3;Agent\x07"))
+				.updates,
+		).toEqual(["Agent"]);
+	});
+
+	it("preserves multi-byte UTF-8 in titles when split across chunks", () => {
+		// Regression: the string variant calls Buffer.toString('utf8') per
+		// chunk and would mangle the smiley if its 4 bytes split across the
+		// wire. The byte variant decodes only the bounded payload slice so
+		// the codepoint round-trips intact.
+		const state = createTerminalTitleScanStateBytes();
+		const full = enc.encode("\x1b]0;Hi 🙂!\x07");
+		// Split mid-smiley (the 4-byte sequence is at bytes 6..10).
+		const a = full.subarray(0, 8);
+		const b = full.subarray(8);
+		expect(scanForTerminalTitleBytes(state, a).updates).toEqual([]);
+		expect(scanForTerminalTitleBytes(state, b).updates).toEqual(["Hi 🙂!"]);
 	});
 });
 

--- a/packages/shared/src/terminal-title-scanner.test.ts
+++ b/packages/shared/src/terminal-title-scanner.test.ts
@@ -1,142 +1,142 @@
 import { describe, expect, it } from "bun:test";
 import {
 	createTerminalTitleScanState,
-	createTerminalTitleScanStateBytes,
 	normalizeTerminalTitle,
 	scanForTerminalTitle,
-	scanForTerminalTitleBytes,
 } from "./terminal-title-scanner";
 
 const enc = new TextEncoder();
+// Latin-1 encoder: each char → its low byte. Used for fixtures that include
+// raw C1 control bytes (0x9D OSC / 0x9C ST) — TextEncoder would emit those
+// as their 2-byte UTF-8 forms, but PTYs send them as single bytes on the wire.
+const bin = (s: string) => new Uint8Array(Buffer.from(s, "binary"));
 
 describe("terminal title scanner", () => {
 	it("handles OSC 0 and OSC 2 with BEL terminators", () => {
 		const state = createTerminalTitleScanState();
 
-		expect(scanForTerminalTitle(state, "\x1b]0;Shell\x07").updates).toEqual([
-			"Shell",
-		]);
-		expect(scanForTerminalTitle(state, "\x1b]2;Editor\x07").updates).toEqual([
-			"Editor",
-		]);
+		expect(
+			scanForTerminalTitle(state, enc.encode("\x1b]0;Shell\x07")).updates,
+		).toEqual(["Shell"]);
+		expect(
+			scanForTerminalTitle(state, enc.encode("\x1b]2;Editor\x07")).updates,
+		).toEqual(["Editor"]);
 	});
 
 	it("handles ST terminators", () => {
 		const state = createTerminalTitleScanState();
 
 		expect(
-			scanForTerminalTitle(state, "\x1b]2;Workspace\x1b\\").updates,
+			scanForTerminalTitle(state, enc.encode("\x1b]2;Workspace\x1b\\")).updates,
 		).toEqual(["Workspace"]);
 	});
 
 	it("handles C1 ST terminators", () => {
 		const state = createTerminalTitleScanState();
 
-		expect(scanForTerminalTitle(state, "\x1b]2;Workspace\x9c").updates).toEqual(
-			["Workspace"],
-		);
-		expect(scanForTerminalTitle(state, "\x1b]2;Changed\x9c").updates).toEqual([
-			"Changed",
-		]);
+		expect(
+			scanForTerminalTitle(state, bin("\x1b]2;Workspace\x9c")).updates,
+		).toEqual(["Workspace"]);
+		expect(
+			scanForTerminalTitle(state, bin("\x1b]2;Changed\x9c")).updates,
+		).toEqual(["Changed"]);
 	});
 
 	it("handles C1 OSC introducers", () => {
 		const state = createTerminalTitleScanState();
 
-		expect(scanForTerminalTitle(state, "\x9d2;Workspace\x9c").updates).toEqual([
-			"Workspace",
-		]);
-		expect(scanForTerminalTitle(state, "\x9d9;3;Agent\x07").updates).toEqual([
-			"Agent",
-		]);
+		expect(
+			scanForTerminalTitle(state, bin("\x9d2;Workspace\x9c")).updates,
+		).toEqual(["Workspace"]);
+		expect(
+			scanForTerminalTitle(state, bin("\x9d9;3;Agent\x07")).updates,
+		).toEqual(["Agent"]);
 	});
 
 	it("handles fragmented OSC sequences", () => {
 		const state = createTerminalTitleScanState();
 
-		expect(scanForTerminalTitle(state, "\x1b]2;Work").updates).toEqual([]);
-		expect(scanForTerminalTitle(state, "space\x07").updates).toEqual([
-			"Workspace",
-		]);
+		expect(
+			scanForTerminalTitle(state, enc.encode("\x1b]2;Work")).updates,
+		).toEqual([]);
+		expect(
+			scanForTerminalTitle(state, enc.encode("space\x07")).updates,
+		).toEqual(["Workspace"]);
 	});
 
 	it("handles fragmented OSC introducers and ST terminators", () => {
 		const state = createTerminalTitleScanState();
 
-		expect(scanForTerminalTitle(state, "\x1b").updates).toEqual([]);
-		expect(scanForTerminalTitle(state, "]0;Split\x1b").updates).toEqual([]);
-		expect(scanForTerminalTitle(state, "\\").updates).toEqual(["Split"]);
+		expect(scanForTerminalTitle(state, enc.encode("\x1b")).updates).toEqual([]);
+		expect(
+			scanForTerminalTitle(state, enc.encode("]0;Split\x1b")).updates,
+		).toEqual([]);
+		expect(scanForTerminalTitle(state, enc.encode("\\")).updates).toEqual([
+			"Split",
+		]);
 	});
 
 	it("handles ConEmu tab title and reset sequences", () => {
 		const state = createTerminalTitleScanState();
 
-		expect(scanForTerminalTitle(state, "\x1b]9;3;Agent\x07").updates).toEqual([
-			"Agent",
-		]);
-		expect(scanForTerminalTitle(state, "\x1b]9;3;\x07").updates).toEqual([
-			null,
-		]);
+		expect(
+			scanForTerminalTitle(state, enc.encode("\x1b]9;3;Agent\x07")).updates,
+		).toEqual(["Agent"]);
+		expect(
+			scanForTerminalTitle(state, enc.encode("\x1b]9;3;\x07")).updates,
+		).toEqual([null]);
 	});
 
 	it("ignores malformed and unsupported payloads", () => {
 		const state = createTerminalTitleScanState();
 
-		expect(scanForTerminalTitle(state, "\x1b]9;3\x07").updates).toEqual([]);
-		expect(scanForTerminalTitle(state, "\x1b]9;3a\x07").updates).toEqual([]);
-		expect(scanForTerminalTitle(state, "\x1b]9;4;Nope\x07").updates).toEqual(
-			[],
-		);
-		expect(scanForTerminalTitle(state, "\x1b]1;Icon\x07").updates).toEqual([]);
+		expect(
+			scanForTerminalTitle(state, enc.encode("\x1b]9;3\x07")).updates,
+		).toEqual([]);
+		expect(
+			scanForTerminalTitle(state, enc.encode("\x1b]9;3a\x07")).updates,
+		).toEqual([]);
+		expect(
+			scanForTerminalTitle(state, enc.encode("\x1b]9;4;Nope\x07")).updates,
+		).toEqual([]);
+		expect(
+			scanForTerminalTitle(state, enc.encode("\x1b]1;Icon\x07")).updates,
+		).toEqual([]);
 	});
 
 	it("returns every title update in a chunk", () => {
 		const state = createTerminalTitleScanState();
 
 		expect(
-			scanForTerminalTitle(state, "\x1b]0;First\x07text\x1b]2;Second\x07")
-				.updates,
+			scanForTerminalTitle(
+				state,
+				enc.encode("\x1b]0;First\x07text\x1b]2;Second\x07"),
+			).updates,
 		).toEqual(["First", "Second"]);
 	});
 
-	it("drops oversized incomplete OSC payloads by UTF-8 byte length", () => {
+	it("drops oversized incomplete OSC payloads", () => {
 		const state = createTerminalTitleScanState();
 
 		expect(
-			scanForTerminalTitle(state, `\x1b]2;${"🙂".repeat(1024)}`).updates,
+			scanForTerminalTitle(state, enc.encode(`\x1b]2;${"🙂".repeat(1024)}`))
+				.updates,
 		).toEqual([]);
-		expect(state.buffer).toBe("");
-	});
-});
-
-describe("terminal title scanner (bytes)", () => {
-	it("matches the string variant for the common cases", () => {
-		const state = createTerminalTitleScanStateBytes();
-		expect(
-			scanForTerminalTitleBytes(state, enc.encode("\x1b]0;Shell\x07")).updates,
-		).toEqual(["Shell"]);
-		expect(
-			scanForTerminalTitleBytes(state, enc.encode("\x1b]2;Editor\x1b\\"))
-				.updates,
-		).toEqual(["Editor"]);
-		expect(
-			scanForTerminalTitleBytes(state, enc.encode("\x1b]9;3;Agent\x07"))
-				.updates,
-		).toEqual(["Agent"]);
+		expect(state.buffer.length).toBe(0);
 	});
 
 	it("preserves multi-byte UTF-8 in titles when split across chunks", () => {
-		// Regression: the string variant calls Buffer.toString('utf8') per
-		// chunk and would mangle the smiley if its 4 bytes split across the
-		// wire. The byte variant decodes only the bounded payload slice so
-		// the codepoint round-trips intact.
-		const state = createTerminalTitleScanStateBytes();
+		// Regression: pre-byte-rewrite, the upstream did Buffer.toString('utf8')
+		// per chunk and would mangle the smiley if its 4 bytes split across the
+		// wire. The byte scanner decodes only the bounded payload slice, so the
+		// codepoint round-trips intact.
+		const state = createTerminalTitleScanState();
 		const full = enc.encode("\x1b]0;Hi 🙂!\x07");
-		// Split mid-smiley (the 4-byte sequence is at bytes 6..10).
+		// Split mid-smiley.
 		const a = full.subarray(0, 8);
 		const b = full.subarray(8);
-		expect(scanForTerminalTitleBytes(state, a).updates).toEqual([]);
-		expect(scanForTerminalTitleBytes(state, b).updates).toEqual(["Hi 🙂!"]);
+		expect(scanForTerminalTitle(state, a).updates).toEqual([]);
+		expect(scanForTerminalTitle(state, b).updates).toEqual(["Hi 🙂!"]);
 	});
 });
 

--- a/packages/shared/src/terminal-title-scanner.ts
+++ b/packages/shared/src/terminal-title-scanner.ts
@@ -103,6 +103,133 @@ function parseTitlePayload(payload: string): string | null | undefined {
 	return normalizeTerminalTitle(value.slice(2));
 }
 
+// ---------- Byte-oriented variant (v2 PTY data path) ----------
+//
+// The string variant above forces a per-chunk `Buffer.toString("utf8")`
+// upstream, which loses partial codepoints at chunk boundaries. v2 carries
+// PTY data as bytes end-to-end. OSC framing is pure ASCII (ESC `]`, BEL,
+// ST), so the *framing* runs cheaply over bytes; only the title payload
+// itself needs to be decoded — and at that point we have a complete,
+// terminator-bounded slice, so the decode is lossless.
+
+const ESC_BYTE = 0x1b;
+const BACKSLASH_BYTE = 0x5c; // ESC + '\' = ST
+const RIGHT_BRACKET_BYTE = 0x5d; // ESC + ']' = OSC
+const C1_OSC_BYTE = 0x9d;
+const C1_ST_BYTE = 0x9c;
+const BEL_TITLE_BYTE = 0x07;
+
+const sharedTitleTextDecoder = /* @__PURE__ */ new TextDecoder("utf-8", {
+	fatal: false,
+});
+
+export interface TerminalTitleScanStateBytes {
+	/** Held bytes spanning a chunk boundary while an OSC sequence is mid-flight. */
+	buffer: Uint8Array;
+}
+
+export function createTerminalTitleScanStateBytes(): TerminalTitleScanStateBytes {
+	return { buffer: new Uint8Array(0) };
+}
+
+function findOscStartBytes(
+	input: Uint8Array,
+	from: number,
+): { index: number; length: number } | null {
+	for (let i = from; i < input.length; i++) {
+		const b = input[i];
+		if (b === C1_OSC_BYTE) return { index: i, length: 1 };
+		if (
+			b === ESC_BYTE &&
+			i + 1 < input.length &&
+			input[i + 1] === RIGHT_BRACKET_BYTE
+		) {
+			return { index: i, length: 2 };
+		}
+	}
+	return null;
+}
+
+function findOscTerminatorBytes(
+	input: Uint8Array,
+	from: number,
+): { index: number; length: number } | null {
+	for (let i = from; i < input.length; i++) {
+		const b = input[i];
+		if (b === BEL_TITLE_BYTE) return { index: i, length: 1 };
+		if (b === C1_ST_BYTE) return { index: i, length: 1 };
+		if (
+			b === ESC_BYTE &&
+			i + 1 < input.length &&
+			input[i + 1] === BACKSLASH_BYTE
+		) {
+			return { index: i, length: 2 };
+		}
+	}
+	return null;
+}
+
+function concatBytes(a: Uint8Array, b: Uint8Array): Uint8Array {
+	if (a.length === 0) return b;
+	if (b.length === 0) return a;
+	const out = new Uint8Array(a.length + b.length);
+	out.set(a, 0);
+	out.set(b, a.length);
+	return out;
+}
+
+/**
+ * Byte-oriented title scanner. Framing is matched on bytes; once a complete
+ * payload is bounded by its OSC start and terminator, the slice is decoded
+ * to a string for {@link normalizeTerminalTitle} (which needs codepoints
+ * to filter control characters and enforce a length cap).
+ */
+export function scanForTerminalTitleBytes(
+	state: TerminalTitleScanStateBytes,
+	chunk: Uint8Array,
+): TerminalTitleScanResult {
+	const input =
+		state.buffer.length === 0 ? chunk : concatBytes(state.buffer, chunk);
+	const updates: Array<string | null> = [];
+	let searchIndex = 0;
+
+	while (searchIndex < input.length) {
+		const oscStart = findOscStartBytes(input, searchIndex);
+		if (!oscStart) {
+			// Hold a trailing ESC so a `]` arriving in the next chunk still gets
+			// recognized as OSC start.
+			state.buffer =
+				input.length > 0 && input[input.length - 1] === ESC_BYTE
+					? input.subarray(input.length - 1)
+					: new Uint8Array(0);
+			return { updates };
+		}
+
+		const payloadStart = oscStart.index + oscStart.length;
+		const terminator = findOscTerminatorBytes(input, payloadStart);
+		if (!terminator) {
+			const sequence = input.subarray(oscStart.index);
+			state.buffer =
+				sequence.length <= MAX_OSC_SEQUENCE_BYTES
+					? sequence
+					: new Uint8Array(0);
+			return { updates };
+		}
+
+		const payloadBytes = input.subarray(payloadStart, terminator.index);
+		const payload = sharedTitleTextDecoder.decode(payloadBytes);
+		const title = parseTitlePayload(payload);
+		if (title !== undefined) {
+			updates.push(title);
+		}
+
+		searchIndex = terminator.index + terminator.length;
+	}
+
+	state.buffer = new Uint8Array(0);
+	return { updates };
+}
+
 /**
  * Scan PTY output for terminal title OSC sequences.
  *

--- a/packages/shared/src/terminal-title-scanner.ts
+++ b/packages/shared/src/terminal-title-scanner.ts
@@ -1,15 +1,29 @@
-const ESC = "\x1b";
-const OSC = `${ESC}]`;
-const C1_OSC = "\x9d";
-const BEL = "\x07";
-const ST = `${ESC}\\`;
-const C1_ST = "\x9c";
+// Byte-oriented terminal-title OSC scanner.
+//
+// PTY output flows through here as raw bytes from the daemon, so the
+// scanner runs over `Uint8Array` directly — no per-chunk UTF-8 decoding,
+// no boundary-mangling. OSC framing is pure ASCII (ESC `]`, BEL, ST), so
+// the framing pass is byte-cheap. Only the bounded title payload is
+// decoded to a string, and only at the moment {@link normalizeTerminalTitle}
+// needs codepoints to filter control characters and enforce a length cap.
 
 const MAX_OSC_SEQUENCE_BYTES = 4096;
 const MAX_TERMINAL_TITLE_LENGTH = 200;
 
+const ESC_BYTE = 0x1b;
+const BACKSLASH_BYTE = 0x5c; // ESC + '\' = ST
+const RIGHT_BRACKET_BYTE = 0x5d; // ESC + ']' = OSC
+const C1_OSC_BYTE = 0x9d;
+const C1_ST_BYTE = 0x9c;
+const BEL_BYTE = 0x07;
+
+const sharedTitleTextDecoder = /* @__PURE__ */ new TextDecoder("utf-8", {
+	fatal: false,
+});
+
 export interface TerminalTitleScanState {
-	buffer: string;
+	/** Held bytes spanning a chunk boundary while an OSC sequence is mid-flight. */
+	buffer: Uint8Array;
 }
 
 export interface TerminalTitleScanResult {
@@ -17,7 +31,7 @@ export interface TerminalTitleScanResult {
 }
 
 export function createTerminalTitleScanState(): TerminalTitleScanState {
-	return { buffer: "" };
+	return { buffer: new Uint8Array(0) };
 }
 
 export function normalizeTerminalTitle(title: string): string | null {
@@ -39,100 +53,7 @@ export function normalizeTerminalTitle(title: string): string | null {
 	return chars.slice(0, MAX_TERMINAL_TITLE_LENGTH).join("");
 }
 
-function getUtf8ByteLength(value: string): number {
-	let bytes = 0;
-	for (const char of value) {
-		const codePoint = char.codePointAt(0) ?? 0;
-		if (codePoint <= 0x7f) {
-			bytes += 1;
-		} else if (codePoint <= 0x7ff) {
-			bytes += 2;
-		} else if (codePoint <= 0xffff) {
-			bytes += 3;
-		} else {
-			bytes += 4;
-		}
-	}
-	return bytes;
-}
-
-function findOscTerminator(
-	input: string,
-	fromIndex: number,
-): { index: number; length: number } | null {
-	for (let i = fromIndex; i < input.length; i++) {
-		const ch = input[i];
-		if (ch === BEL) return { index: i, length: BEL.length };
-		if (ch === C1_ST) return { index: i, length: C1_ST.length };
-		if (ch === ESC && input.startsWith(ST, i)) {
-			return { index: i, length: ST.length };
-		}
-	}
-	return null;
-}
-
 function findOscStart(
-	input: string,
-	fromIndex: number,
-): { index: number; length: number } | null {
-	const escOscIndex = input.indexOf(OSC, fromIndex);
-	const c1OscIndex = input.indexOf(C1_OSC, fromIndex);
-
-	if (escOscIndex === -1 && c1OscIndex === -1) return null;
-	if (escOscIndex === -1) return { index: c1OscIndex, length: C1_OSC.length };
-	if (c1OscIndex === -1 || escOscIndex < c1OscIndex) {
-		return { index: escOscIndex, length: OSC.length };
-	}
-	return { index: c1OscIndex, length: C1_OSC.length };
-}
-
-function parseTitlePayload(payload: string): string | null | undefined {
-	const firstSeparator = payload.indexOf(";");
-	if (firstSeparator <= 0) return undefined;
-
-	const command = payload.slice(0, firstSeparator);
-	const value = payload.slice(firstSeparator + 1);
-
-	if (command === "0" || command === "2") {
-		return normalizeTerminalTitle(value);
-	}
-
-	if (command !== "9") return undefined;
-	if (value === "3;") return null;
-	if (!value.startsWith("3;")) return undefined;
-	return normalizeTerminalTitle(value.slice(2));
-}
-
-// ---------- Byte-oriented variant (v2 PTY data path) ----------
-//
-// The string variant above forces a per-chunk `Buffer.toString("utf8")`
-// upstream, which loses partial codepoints at chunk boundaries. v2 carries
-// PTY data as bytes end-to-end. OSC framing is pure ASCII (ESC `]`, BEL,
-// ST), so the *framing* runs cheaply over bytes; only the title payload
-// itself needs to be decoded — and at that point we have a complete,
-// terminator-bounded slice, so the decode is lossless.
-
-const ESC_BYTE = 0x1b;
-const BACKSLASH_BYTE = 0x5c; // ESC + '\' = ST
-const RIGHT_BRACKET_BYTE = 0x5d; // ESC + ']' = OSC
-const C1_OSC_BYTE = 0x9d;
-const C1_ST_BYTE = 0x9c;
-const BEL_TITLE_BYTE = 0x07;
-
-const sharedTitleTextDecoder = /* @__PURE__ */ new TextDecoder("utf-8", {
-	fatal: false,
-});
-
-export interface TerminalTitleScanStateBytes {
-	/** Held bytes spanning a chunk boundary while an OSC sequence is mid-flight. */
-	buffer: Uint8Array;
-}
-
-export function createTerminalTitleScanStateBytes(): TerminalTitleScanStateBytes {
-	return { buffer: new Uint8Array(0) };
-}
-
-function findOscStartBytes(
 	input: Uint8Array,
 	from: number,
 ): { index: number; length: number } | null {
@@ -150,13 +71,13 @@ function findOscStartBytes(
 	return null;
 }
 
-function findOscTerminatorBytes(
+function findOscTerminator(
 	input: Uint8Array,
 	from: number,
 ): { index: number; length: number } | null {
 	for (let i = from; i < input.length; i++) {
 		const b = input[i];
-		if (b === BEL_TITLE_BYTE) return { index: i, length: 1 };
+		if (b === BEL_BYTE) return { index: i, length: 1 };
 		if (b === C1_ST_BYTE) return { index: i, length: 1 };
 		if (
 			b === ESC_BYTE &&
@@ -178,14 +99,37 @@ function concatBytes(a: Uint8Array, b: Uint8Array): Uint8Array {
 	return out;
 }
 
+function parseTitlePayload(payload: string): string | null | undefined {
+	const firstSeparator = payload.indexOf(";");
+	if (firstSeparator <= 0) return undefined;
+
+	const command = payload.slice(0, firstSeparator);
+	const value = payload.slice(firstSeparator + 1);
+
+	if (command === "0" || command === "2") {
+		return normalizeTerminalTitle(value);
+	}
+
+	if (command !== "9") return undefined;
+	if (value === "3;") return null;
+	if (!value.startsWith("3;")) return undefined;
+	return normalizeTerminalTitle(value.slice(2));
+}
+
 /**
- * Byte-oriented title scanner. Framing is matched on bytes; once a complete
- * payload is bounded by its OSC start and terminator, the slice is decoded
- * to a string for {@link normalizeTerminalTitle} (which needs codepoints
- * to filter control characters and enforce a length cap).
+ * Scan PTY output for terminal title OSC sequences.
+ *
+ * Supported sequences:
+ * - OSC 0;<title> BEL/ST
+ * - OSC 2;<title> BEL/ST
+ * - OSC 9;3;<title> BEL/ST (ConEmu tab title)
+ * - OSC 9;3; BEL/ST reset
+ *
+ * OSC may be encoded as ESC ] or the single-byte C1 introducer.
+ * ST may be encoded as ESC \ or the single-byte C1 terminator.
  */
-export function scanForTerminalTitleBytes(
-	state: TerminalTitleScanStateBytes,
+export function scanForTerminalTitle(
+	state: TerminalTitleScanState,
 	chunk: Uint8Array,
 ): TerminalTitleScanResult {
 	const input =
@@ -194,7 +138,7 @@ export function scanForTerminalTitleBytes(
 	let searchIndex = 0;
 
 	while (searchIndex < input.length) {
-		const oscStart = findOscStartBytes(input, searchIndex);
+		const oscStart = findOscStart(input, searchIndex);
 		if (!oscStart) {
 			// Hold a trailing ESC so a `]` arriving in the next chunk still gets
 			// recognized as OSC start.
@@ -206,7 +150,7 @@ export function scanForTerminalTitleBytes(
 		}
 
 		const payloadStart = oscStart.index + oscStart.length;
-		const terminator = findOscTerminatorBytes(input, payloadStart);
+		const terminator = findOscTerminator(input, payloadStart);
 		if (!terminator) {
 			const sequence = input.subarray(oscStart.index);
 			state.buffer =
@@ -227,54 +171,5 @@ export function scanForTerminalTitleBytes(
 	}
 
 	state.buffer = new Uint8Array(0);
-	return { updates };
-}
-
-/**
- * Scan PTY output for terminal title OSC sequences.
- *
- * Supported sequences:
- * - OSC 0;<title> BEL/ST
- * - OSC 2;<title> BEL/ST
- * - OSC 9;3;<title> BEL/ST (ConEmu tab title)
- * - OSC 9;3; BEL/ST reset
- *
- * OSC may be encoded as ESC ] or the single-byte C1 introducer.
- * ST may be encoded as ESC \ or the single-byte C1 terminator.
- */
-export function scanForTerminalTitle(
-	state: TerminalTitleScanState,
-	chunk: string,
-): TerminalTitleScanResult {
-	const input = state.buffer ? state.buffer + chunk : chunk;
-	const updates: Array<string | null> = [];
-	let searchIndex = 0;
-
-	while (searchIndex < input.length) {
-		const oscStart = findOscStart(input, searchIndex);
-		if (!oscStart) {
-			state.buffer = input.endsWith(ESC) ? ESC : "";
-			return { updates };
-		}
-
-		const payloadStart = oscStart.index + oscStart.length;
-		const terminator = findOscTerminator(input, payloadStart);
-		if (!terminator) {
-			const sequence = input.slice(oscStart.index);
-			state.buffer =
-				getUtf8ByteLength(sequence) <= MAX_OSC_SEQUENCE_BYTES ? sequence : "";
-			return { updates };
-		}
-
-		const payload = input.slice(payloadStart, terminator.index);
-		const title = parseTitlePayload(payload);
-		if (title !== undefined) {
-			updates.push(title);
-		}
-
-		searchIndex = terminator.index + terminator.length;
-	}
-
-	state.buffer = "";
 	return { updates };
 }

--- a/packages/shared/src/terminal-title-scanner.ts
+++ b/packages/shared/src/terminal-title-scanner.ts
@@ -99,6 +99,17 @@ function concatBytes(a: Uint8Array, b: Uint8Array): Uint8Array {
 	return out;
 }
 
+// `subarray` returns a view into the original chunk's ArrayBuffer, which
+// would pin the entire (potentially multi-KB) chunk in memory just to hold
+// a few trailing bytes mid-OSC. Copy the slice into a fresh tiny buffer
+// before persisting in scanner state.
+function copySlice(input: Uint8Array, start: number, end?: number): Uint8Array {
+	const view = end === undefined ? input.subarray(start) : input.subarray(start, end);
+	const copy = new Uint8Array(view.length);
+	copy.set(view, 0);
+	return copy;
+}
+
 function parseTitlePayload(payload: string): string | null | undefined {
 	const firstSeparator = payload.indexOf(";");
 	if (firstSeparator <= 0) return undefined;
@@ -141,10 +152,11 @@ export function scanForTerminalTitle(
 		const oscStart = findOscStart(input, searchIndex);
 		if (!oscStart) {
 			// Hold a trailing ESC so a `]` arriving in the next chunk still gets
-			// recognized as OSC start.
+			// recognized as OSC start. Copy out the single byte rather than
+			// keeping a subarray view into the whole chunk.
 			state.buffer =
 				input.length > 0 && input[input.length - 1] === ESC_BYTE
-					? input.subarray(input.length - 1)
+					? copySlice(input, input.length - 1)
 					: new Uint8Array(0);
 			return { updates };
 		}
@@ -152,10 +164,12 @@ export function scanForTerminalTitle(
 		const payloadStart = oscStart.index + oscStart.length;
 		const terminator = findOscTerminator(input, payloadStart);
 		if (!terminator) {
-			const sequence = input.subarray(oscStart.index);
+			// Same memory-retention concern: copy the in-flight OSC slice out
+			// of the original chunk before persisting it in scanner state.
+			const sequenceLen = input.length - oscStart.index;
 			state.buffer =
-				sequence.length <= MAX_OSC_SEQUENCE_BYTES
-					? sequence
+				sequenceLen <= MAX_OSC_SEQUENCE_BYTES
+					? copySlice(input, oscStart.index)
 					: new Uint8Array(0);
 			return { updates };
 		}

--- a/packages/shared/src/terminal-title-scanner.ts
+++ b/packages/shared/src/terminal-title-scanner.ts
@@ -104,7 +104,8 @@ function concatBytes(a: Uint8Array, b: Uint8Array): Uint8Array {
 // a few trailing bytes mid-OSC. Copy the slice into a fresh tiny buffer
 // before persisting in scanner state.
 function copySlice(input: Uint8Array, start: number, end?: number): Uint8Array {
-	const view = end === undefined ? input.subarray(start) : input.subarray(start, end);
+	const view =
+		end === undefined ? input.subarray(start) : input.subarray(start, end);
 	const copy = new Uint8Array(view.length);
 	copy.set(view, 0);
 	return copy;
@@ -151,9 +152,8 @@ export function scanForTerminalTitle(
 	while (searchIndex < input.length) {
 		const oscStart = findOscStart(input, searchIndex);
 		if (!oscStart) {
-			// Hold a trailing ESC so a `]` arriving in the next chunk still gets
-			// recognized as OSC start. Copy out the single byte rather than
-			// keeping a subarray view into the whole chunk.
+			// Hold a trailing ESC so a `]` arriving in the next chunk still
+			// resolves to an OSC start.
 			state.buffer =
 				input.length > 0 && input[input.length - 1] === ESC_BYTE
 					? copySlice(input, input.length - 1)
@@ -164,8 +164,6 @@ export function scanForTerminalTitle(
 		const payloadStart = oscStart.index + oscStart.length;
 		const terminator = findOscTerminator(input, payloadStart);
 		if (!terminator) {
-			// Same memory-retention concern: copy the in-flight OSC slice out
-			// of the original chunk before persisting it in scanner state.
 			const sequenceLen = input.length - oscStart.index;
 			state.buffer =
 				sequenceLen <= MAX_OSC_SEQUENCE_BYTES


### PR DESCRIPTION
## Summary

Two architectural smells, same shape, both fixed:

1. **Host-service ↔ renderer wire** had `chunk.toString(\"utf8\")` per chunk on PTY output with no `StringDecoder`, mangling multi-byte codepoints at chunk boundaries. (TUIs with box-drawing/powerline glyphs/emoji glitched under load. Pure-ASCII output was unaffected, which is why nothing screamed during PR #3896 smoke.)
2. **Daemon ↔ host-service wire** base64'd PTY bytes into a JSON `data` field — wire-correct, but a 33% bandwidth tax + an encode/decode pass per chunk in each direction, paid for nothing.

After this PR, PTY bytes travel **kernel → daemon → wire → host-service → wire → xterm.js with zero decoding hops**. Control messages stay JSON.

```
┌─ daemon ─────────────────────────────────────────────────────┐
│ node-pty (encoding: null) → Buffer                           │
└────────────────────────┬─────────────────────────────────────┘
                         ▼ Unix socket, [u32 totalLen][u32 jsonLen][json][bytes]
┌─ host-service ──────────────────────────────────────────────┐
│ DaemonClient → Buffer  → byte-form OSC scanners            │
│              → broadcast as binary WebSocket frame          │
└────────────────────────┬─────────────────────────────────────┘
                         ▼ binary WS frame
┌─ renderer ──────────────────────────────────────────────────┐
│ binaryType=\"arraybuffer\" → terminal.write(new Uint8Array(…))│
└─────────────────────────────────────────────────────────────┘
```

## Commits, ordered for review

1. **`fix(host-service): carry PTY output as bytes end-to-end`** — host-service stops calling `chunk.toString(\"utf8\")` per chunk; bytes flow daemon → ws → xterm via binary WS frames. OSC scanners ride alongside (additive at this point).
2. **`refactor(shared): collapse OSC scanners onto a single byte-oriented impl`** — rip the string-form scanners now that nothing depends on them. v1's session.ts incidentally gets fixed for free. Net 354 deleted, 184 added.
3. **`fix(desktop,shared): address review feedback on byte-scanner refactor`** — addresses CodeRabbit (v1's resolveShellReady was still treating heldBytes as string after the type change) + cubic (`subarray()` retains the original chunk's ArrayBuffer; copy the bytes before persisting in scanner state).
4. **`feat(pty-daemon): carry PTY bytes as binary frame tail (protocol v2)`** — daemon↔host wire goes from `[u32 len][JSON-with-base64]` to `[u32 totalLen][u32 jsonLen][JSON][optional payload bytes]`. OutputMessage/InputMessage drop their `data` field; bytes ride in the binary tail.

## Protocol v2 — no backward compat

Daemon protocol bumps from v1 to v2. New host-service refuses to talk to old daemon (hello-mismatch → connection rejected → supervisor force-restarts the daemon → new bundle takes over). Phase 2 (PR #3971) is what makes this acceptable: auto-update converges daemon to current on host-service start, so the version-skew window is bounded to **the one upgrade in which this lands**. Sessions die during that window. After: every subsequent upgrade preserves sessions via Phase 2's fd-handoff.

This was a deliberate choice over maintaining a v1 fallback. Two implementations forever was the wrong tradeoff for a one-time migration cost.

## What's intentionally untouched

- **Input direction (renderer → daemon).** xterm's `onData` emits semantically complete UTF-8 strings (one keystroke/paste = one full sequence), so the per-chunk mangling that motivated this rewrite doesn't apply to input. We do still ride binary tail on the daemon↔host hop for input bytes — that's the v2 protocol — but the renderer→host hop stays JSON.

## Tests

- **`bun test`**: 685/685 across pty-daemon, host-service, shared
- **`node --test packages/pty-daemon/test/control-plane.test.ts`**: 31/31 through real Unix sockets — late subscribers, host-service restart adoption, hostile input, 20 concurrent sessions, partial-frame TCP chunking
- **`node --test packages/pty-daemon/test/integration.test.ts`**: 3/3 daemon-binary smoke tests
- **Workspace tsc**: clean across pty-daemon, host-service, shared, apps/desktop

## Test plan

- [ ] CI green (lint, typecheck, test)
- [ ] **Manual QA**: `bun dev`, open v2 terminal, run something Unicode-heavy under load — `lazygit`, `vim` w/ powerline, `btop`, or:
  ```
  printf '🙂%.0s' {1..10000}
  seq 1 1000 | xargs printf \"%s\\xe4\\xbd\\xa0\\xe5\\xa5\\xbd\\n\"
  ```
  Pre-PR symptom: U+FFFD smattered across the buffer + broken box-drawing under load. Post-PR: clean.
- [ ] Regression smoke: open + close terminals, host-service restart with adopted sessions, daemon binary upgrade (Phase 2) — sessions preserved.

## Out of scope

- v1 desktop main-process terminal-host has the same mangling regression at its remaining `payload.toString(\"utf8\")` site (after the scanner). Commit 2 fixes the scanner side as a side effect; the post-strip emulator/IPC string conversion still has chunk-boundary issues. v1 is sunset; we don't fix deeper.
- Cross-platform validation. Verified macOS arm64. Linux/x86_64 manual smoke is on the test plan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal output now streams as raw binary frames end-to-end (protocol v2) for exact replay and lower-latency delivery.
  * WebSocket transport accepts binary PTY frames directly for playback.

* **Bug Fixes**
  * Byte-oriented scanners prevent UTF‑8 corruption across chunk boundaries and reliably detect/strip shell‑ready markers and OSC titles, flushing partial bytes.
  * More consistent multi‑client replay/fan‑out with fewer dropped or mangled bytes.

* **Tests**
  * Added extensive byte‑level, framing, and integration tests to ensure byte‑perfect behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->