### PR TITLE
fix(dev): clean teardown of all bun dev child processes

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"build": "next build",
 		"clean": "git clean -xdf .cache .next .turbo node_modules",
-		"dev": "dotenv -e ../../.env -- sh -c 'next dev --port ${ADMIN_PORT:-3003}'",
+		"dev": "dotenv -e ../../.env -- sh -c 'exec next dev --port ${ADMIN_PORT:-3003}'",
 		"start": "next start",
 		"typecheck": "tsc --noEmit"
 	},

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"build": "next build",
 		"clean": "git clean -xdf .cache .next .turbo node_modules",
-		"dev": "dotenv -e ../../.env -- sh -c 'next dev --port ${API_PORT:-3001}'",
+		"dev": "dotenv -e ../../.env -- sh -c 'exec next dev --port ${API_PORT:-3001}'",
 		"start": "next start --port 3001",
 		"typecheck": "tsc --noEmit"
 	},

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -43,6 +43,10 @@ import {
 	prewarmTerminalRuntime,
 	reconcileDaemonSessions,
 } from "./lib/terminal";
+import {
+	disposeTerminalHostClient,
+	getTerminalHostClient,
+} from "./lib/terminal-host/client";
 import { disposeTray, initTray } from "./lib/tray";
 import { MainWindow } from "./windows/main";
 
@@ -210,7 +214,15 @@ app.on("before-quit", async (event) => {
 
 	isQuitting = true;
 	try {
-		getHostServiceCoordinator().releaseAll();
+		// Production: release manifests so services keep running for re-adoption
+		// on next launch (the survival contract). Dev: services are spawned
+		// non-detached + ref'd, so a quiet `releaseAll()` would orphan them to
+		// init on app exit. Stop them explicitly instead and dispose terminal-host.
+		if (isDev) {
+			await runDevQuitCleanup();
+		} else {
+			getHostServiceCoordinator().releaseAll();
+		}
 		shutdownTanstackDbPersistence();
 		disposeTray();
 	} catch (error) {
@@ -218,6 +230,21 @@ app.on("before-quit", async (event) => {
 	}
 	app.exit(0);
 });
+
+/**
+ * Stop the dev-spawned host-service and terminal-host children. Production
+ * lets these survive (manifest adoption); in dev they're spawned attached and
+ * need an explicit kill on app exit so they don't reparent to init.
+ */
+async function runDevQuitCleanup(): Promise<void> {
+	getHostServiceCoordinator().stopAll();
+	try {
+		await getTerminalHostClient().shutdownIfRunning({ killSessions: true });
+	} catch (err) {
+		console.warn("[main] terminal-host dev shutdown failed:", err);
+	}
+	disposeTerminalHostClient();
+}
 
 process.on("uncaughtException", (error) => {
 	if (isQuitting) return;
@@ -231,9 +258,14 @@ process.on("unhandledRejection", (reason) => {
 
 // Without these handlers, Electron may not quit when electron-vite sends SIGTERM
 if (process.env.NODE_ENV === "development") {
+	let signalHandled = false;
 	const handleTerminationSignal = (signal: string) => {
+		if (signalHandled) return;
+		signalHandled = true;
 		console.log(`[main] Received ${signal}, quitting...`);
-		app.exit(0);
+		// Stop dev-spawned children before exiting; they're attached + ref'd in
+		// dev so a bare `app.exit(0)` would leak them as init-orphans.
+		void runDevQuitCleanup().finally(() => app.exit(0));
 	};
 
 	process.on("SIGTERM", () => handleTerminationSignal("SIGTERM"));
@@ -254,7 +286,7 @@ if (process.env.NODE_ENV === "development") {
 		if (!isParentAlive()) {
 			console.log("[main] Parent process exited, quitting...");
 			clearInterval(parentCheckInterval);
-			app.exit(0);
+			handleTerminationSignal("parent-exit");
 		}
 	}, 1000);
 	parentCheckInterval.unref();

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -214,13 +214,10 @@ app.on("before-quit", async (event) => {
 
 	isQuitting = true;
 	try {
-		// Production: release manifests so services keep running for re-adoption
-		// on next launch (the survival contract). Dev: services are spawned
-		// non-detached + ref'd, so a quiet `releaseAll()` would orphan them to
-		// init on app exit. Stop them explicitly instead and dispose terminal-host.
 		if (isDev) {
 			await runDevQuitCleanup();
 		} else {
+			// Prod: leave services running so the next launch re-adopts via manifest.
 			getHostServiceCoordinator().releaseAll();
 		}
 		shutdownTanstackDbPersistence();
@@ -232,9 +229,8 @@ app.on("before-quit", async (event) => {
 });
 
 /**
- * Stop the dev-spawned host-service and terminal-host children. Production
- * lets these survive (manifest adoption); in dev they're spawned attached and
- * need an explicit kill on app exit so they don't reparent to init.
+ * Dev only — kill host-service + terminal-host children. They're spawned
+ * attached + ref'd in dev, so they'd reparent to init without an explicit stop.
  */
 async function runDevQuitCleanup(): Promise<void> {
 	getHostServiceCoordinator().stopAll();
@@ -263,8 +259,6 @@ if (process.env.NODE_ENV === "development") {
 		if (signalHandled) return;
 		signalHandled = true;
 		console.log(`[main] Received ${signal}, quitting...`);
-		// Stop dev-spawned children before exiting; they're attached + ref'd in
-		// dev so a bare `app.exit(0)` would leak them as init-orphans.
 		void runDevQuitCleanup().finally(() => app.exit(0));
 	};
 

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -425,7 +425,12 @@ export class HostServiceCoordinator extends EventEmitter {
 		let child: ReturnType<typeof childProcess.spawn>;
 		try {
 			child = childProcess.spawn(process.execPath, [this.scriptPath], {
-				detached: true,
+				// In dev, keep host-service attached so it dies with Electron when
+				// `bun dev` is killed — the existing serve.ts dev-shutdown then
+				// cascades SIGTERM into pty-daemon. Production stays detached so
+				// PTYs survive Electron restarts via manifest-based adoption
+				// (see HOST_SERVICE_LIFECYCLE.md).
+				detached: !isDev,
 				stdio,
 				env: childEnv,
 				// Avoid a flashing CMD window on Windows for the detached child.
@@ -467,7 +472,9 @@ export class HostServiceCoordinator extends EventEmitter {
 			removeManifest(organizationId);
 			this.emitStatus(organizationId, "stopped", "running");
 		});
-		child.unref();
+		// Only unref in production, where the child is detached and meant to
+		// outlive the parent. In dev we want Electron's exit to take it down.
+		if (!isDev) child.unref();
 
 		const endpoint = `http://127.0.0.1:${port}`;
 		const healthy = await pollHealthCheck(endpoint, secret);

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -433,7 +433,7 @@ export class HostServiceCoordinator extends EventEmitter {
 				detached: !isDev,
 				stdio,
 				env: childEnv,
-				// Avoid a flashing CMD window on Windows for the detached child.
+				// Avoid a flashing CMD window on Windows.
 				windowsHide: true,
 			});
 		} finally {

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -424,12 +424,10 @@ export class HostServiceCoordinator extends EventEmitter {
 
 		let child: ReturnType<typeof childProcess.spawn>;
 		try {
+			// Prod: detached so PTYs survive Electron restarts via manifest
+			// adoption (HOST_SERVICE_LIFECYCLE.md). Dev: attached so a `bun dev`
+			// kill propagates and serve.ts's dev shutdown can stop pty-daemon.
 			child = childProcess.spawn(process.execPath, [this.scriptPath], {
-				// In dev, keep host-service attached so it dies with Electron when
-				// `bun dev` is killed — the existing serve.ts dev-shutdown then
-				// cascades SIGTERM into pty-daemon. Production stays detached so
-				// PTYs survive Electron restarts via manifest-based adoption
-				// (see HOST_SERVICE_LIFECYCLE.md).
 				detached: !isDev,
 				stdio,
 				env: childEnv,
@@ -472,8 +470,6 @@ export class HostServiceCoordinator extends EventEmitter {
 			removeManifest(organizationId);
 			this.emitStatus(organizationId, "stopped", "running");
 		});
-		// Only unref in production, where the child is detached and meant to
-		// outlive the parent. In dev we want Electron's exit to take it down.
 		if (!isDev) child.unref();
 
 		const endpoint = `http://127.0.0.1:${port}`;

--- a/apps/desktop/src/main/lib/terminal-host/client.ts
+++ b/apps/desktop/src/main/lib/terminal-host/client.ts
@@ -1185,11 +1185,15 @@ export class TerminalHostClient extends EventEmitter {
 				logFd = -1;
 			}
 
-			// Spawn daemon as detached process
+			// In dev, keep the daemon attached so it dies with Electron when
+			// `bun dev` is killed. Production stays detached so PTYs survive
+			// Electron restarts (the daemon owns long-lived terminal sessions
+			// over a Unix socket).
+			const isDev = !app.isPackaged;
 			let child: ReturnType<typeof spawn> | null = null;
 			try {
 				child = spawn(process.execPath, [daemonScript], {
-					detached: true,
+					detached: !isDev,
 					stdio: logFd >= 0 ? ["ignore", logFd, logFd] : "ignore",
 					env: {
 						...process.env,
@@ -1217,8 +1221,9 @@ export class TerminalHostClient extends EventEmitter {
 				);
 			}
 
-			// Unref to allow parent to exit independently
-			child.unref();
+			// Unref so the parent can exit independently — only in production,
+			// where the child is detached and meant to outlive Electron.
+			if (!isDev) child.unref();
 
 			// Wait for daemon to start
 			if (DEBUG_CLIENT) {

--- a/apps/desktop/src/main/lib/terminal-host/client.ts
+++ b/apps/desktop/src/main/lib/terminal-host/client.ts
@@ -1185,10 +1185,8 @@ export class TerminalHostClient extends EventEmitter {
 				logFd = -1;
 			}
 
-			// In dev, keep the daemon attached so it dies with Electron when
-			// `bun dev` is killed. Production stays detached so PTYs survive
-			// Electron restarts (the daemon owns long-lived terminal sessions
-			// over a Unix socket).
+			// Prod: detached so terminal sessions survive Electron restarts.
+			// Dev: attached so it dies with Electron on `bun dev` kill.
 			const isDev = !app.isPackaged;
 			let child: ReturnType<typeof spawn> | null = null;
 			try {
@@ -1221,8 +1219,6 @@ export class TerminalHostClient extends EventEmitter {
 				);
 			}
 
-			// Unref so the parent can exit independently — only in production,
-			// where the child is detached and meant to outlive Electron.
 			if (!isDev) child.unref();
 
 			// Wait for daemon to start

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -5,7 +5,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "fumadocs-mdx && next build",
-		"dev": "dotenv -e ../../.env -- sh -c 'next dev --port ${DOCS_PORT:-3004}'",
+		"dev": "dotenv -e ../../.env -- sh -c 'exec next dev --port ${DOCS_PORT:-3004}'",
 		"start": "next start",
 		"typecheck": "fumadocs-mdx && next typegen && tsc --noEmit",
 		"postinstall": "fumadocs-mdx"

--- a/apps/electric-proxy/package.json
+++ b/apps/electric-proxy/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"dev": "dotenv -e ../../.env -- sh -c 'wrangler dev --port ${WRANGLER_PORT:-8787}'",
+		"dev": "dotenv -e ../../.env -- sh -c 'exec wrangler dev --port ${WRANGLER_PORT:-8787}'",
 		"deploy": "wrangler deploy",
 		"typecheck": "tsc --noEmit --emitDeclarationOnly false"
 	},

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"build": "next build",
 		"clean": "git clean -xdf .cache .next .turbo node_modules",
-		"dev": "dotenv -e ../../.env -- sh -c 'next dev --port ${MARKETING_PORT:-3002}'",
+		"dev": "dotenv -e ../../.env -- sh -c 'exec next dev --port ${MARKETING_PORT:-3002}'",
 		"start": "next start",
 		"typecheck": "tsc --noEmit"
 	},

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"build": "next build",
 		"clean": "git clean -xdf .cache .next .turbo node_modules",
-		"dev": "dotenv -e ../../.env -- sh -c 'next dev --port ${WEB_PORT:-3000}'",
+		"dev": "dotenv -e ../../.env -- sh -c 'exec next dev --port ${WEB_PORT:-3000}'",
 		"start": "next start",
 		"typecheck": "tsc --noEmit"
 	},

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"dev": "dotenv -e ../../.env -- sh -c 'SUPERSET_API_URL=$NEXT_PUBLIC_API_URL cli-framework dev \"$@\"' --",
+		"dev": "dotenv -e ../../.env -- sh -c 'exec env SUPERSET_API_URL=$NEXT_PUBLIC_API_URL cli-framework dev \"$@\"' --",
 		"build": "cli-framework build",
 		"build:darwin-arm64": "cli-framework build --target=bun-darwin-arm64 --outfile=./dist/superset-darwin-arm64",
 		"build:linux-x64": "cli-framework build --target=bun-linux-x64 --outfile=./dist/superset-linux-x64",

--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -418,11 +418,15 @@ export class DaemonSupervisor {
 
 		let child: ReturnType<typeof childProcess.spawn>;
 		try {
+			// In dev, keep the daemon attached so it dies with host-service if
+			// the dev shutdown handler in serve.ts doesn't get a chance to fire
+			// (e.g. host-service crash). Production stays detached so PTYs
+			// survive host-service restarts via socket adoption.
 			child = childProcess.spawn(
 				process.execPath,
 				[this.opts.scriptPath, `--socket=${socketPath}`],
 				{
-					detached: true,
+					detached: !isDev,
 					stdio,
 					env: childEnv,
 					windowsHide: true,
@@ -485,7 +489,9 @@ export class DaemonSupervisor {
 			);
 		}
 
-		child.unref();
+		// Only unref in production, where the daemon is detached and meant to
+		// outlive host-service. In dev we want host-service's exit to take it down.
+		if (!isDev) child.unref();
 		child.on("exit", (code) => {
 			console.log(`[pty-daemon:${organizationId}] exited with code ${code}`);
 			const current = this.instances.get(organizationId);

--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -418,10 +418,9 @@ export class DaemonSupervisor {
 
 		let child: ReturnType<typeof childProcess.spawn>;
 		try {
-			// In dev, keep the daemon attached so it dies with host-service if
-			// the dev shutdown handler in serve.ts doesn't get a chance to fire
-			// (e.g. host-service crash). Production stays detached so PTYs
-			// survive host-service restarts via socket adoption.
+			// Prod: detached so PTYs survive host-service restarts via socket
+			// adoption. Dev: attached as defense-in-depth in case serve.ts's
+			// dev shutdown doesn't fire (e.g. host-service crash).
 			child = childProcess.spawn(
 				process.execPath,
 				[this.opts.scriptPath, `--socket=${socketPath}`],
@@ -489,8 +488,6 @@ export class DaemonSupervisor {
 			);
 		}
 
-		// Only unref in production, where the daemon is detached and meant to
-		// outlive host-service. In dev we want host-service's exit to take it down.
 		if (!isDev) child.unref();
 		child.on("exit", (code) => {
 			console.log(`[pty-daemon:${organizationId}] exited with code ${code}`);

--- a/plans/20260502-bun-dev-server-cleanup.md
+++ b/plans/20260502-bun-dev-server-cleanup.md
@@ -1,165 +1,32 @@
-# `bun run dev` cleanup audit
+# `bun run dev` cleanup
 
 ## Problem
 
-Killing `bun run dev` (Ctrl-C, IDE stop, turbo subtask SIGTERM) does not reliably take down every child process it started. Symptoms: ports 3000/3001/8787 stay bound after exit; `host-service` and `pty-daemon` keep running between dev sessions; "address in use" errors on the next `bun run dev`.
+Killing `bun run dev` left orphan processes (PPID=1): dev servers bound to ports, plus `host-service`, `terminal-host`, and `pty-daemon` accumulating between runs.
 
-## What `bun run dev` actually starts
+## Root causes
 
-```
-bun run dev
-└── turbo run dev dev:caddy --filter=@superset/{api,web,desktop} --filter=electric-proxy --filter=//
-    ├── (root) dev:caddy        → dotenv -- caddy run --config Caddyfile
-    ├── apps/api dev            → dotenv -e ../../.env -- sh -c 'next dev --port ${API_PORT:-3001}'
-    ├── apps/web dev            → dotenv -e ../../.env -- sh -c 'next dev --port ${WEB_PORT:-3000}'
-    ├── apps/desktop dev        → electron-vite dev --watch  (spawns Electron main)
-    │   └── Electron main
-    │       └── HostServiceCoordinator.spawn → host-service (detached, unref'd)
-    │           └── DaemonSupervisor.spawn   → pty-daemon (detached, unref'd)
-    └── apps/electric-proxy dev → dotenv -e ../../.env -- sh -c 'wrangler dev --port ${WRANGLER_PORT:-8787}'
-```
+1. **`sh -c '<cmd>'` without `exec`** in dev scripts — when a supervisor (turbo, IDE, `kill`) sends SIGTERM to the subtask pid only, `sh` exits without forwarding and `next`/`wrangler` is orphaned, still bound to its port. Hidden in interactive Ctrl-C because pgrp signaling hits everyone.
+2. **`detached: true` + `child.unref()`** for host-service, terminal-host, and pty-daemon — intentional in production (manifest adoption / socket adoption survival), but the dev-iteration cleanup was never wired up, so children orphaned to init on every `bun dev` exit.
+3. **`before-quit` and dev signal handler** in Electron main called `releaseAll()` / `app.exit(0)` — fine when children were detached, but with attached children (after fix #2) those paths leaked them on graceful Cmd+Q and on `electron-vite`-driven SIGTERM.
 
-## Issues
+## Fixes
 
-### 1. `sh -c` without `exec` orphans the real process
-
-`sh -c 'next dev …'` makes the shell the parent of `next`. On a process-group-wide SIGINT (interactive Ctrl-C) everything dies together so this hides. But when a supervisor (turbo, IDE, `kill <pid>`) sends SIGTERM to the *subtask pid only*, `sh` exits without forwarding and `next`/`wrangler` is orphaned, still bound to its port.
-
-| File | Line | Current |
-|---|---|---|
-| `apps/api/package.json` | 21 | `dotenv -e ../../.env -- sh -c 'next dev --port ${API_PORT:-3001}'` |
-| `apps/web/package.json` | 18 | `dotenv -e ../../.env -- sh -c 'next dev --port ${WEB_PORT:-3000}'` |
-| `apps/electric-proxy/package.json` | 17 | `dotenv -e ../../.env -- sh -c 'wrangler dev --port ${WRANGLER_PORT:-8787}'` |
-
-**Fix:** prepend `exec ` inside the `sh -c` string so the shell is replaced by the real binary. Signals then land directly on `next`/`wrangler`.
-
-```diff
-- "dev": "dotenv -e ../../.env -- sh -c 'next dev --port ${API_PORT:-3001}'"
-+ "dev": "dotenv -e ../../.env -- sh -c 'exec next dev --port ${API_PORT:-3001}'"
-```
-
-### 2. `host-service` is `detached: true` + `child.unref()` — survives `bun dev` kill
-
-`apps/desktop/src/main/lib/host-service-coordinator.ts:427-433, 470`
-
-```ts
-child = childProcess.spawn(process.execPath, [this.scriptPath], {
-  detached: true,
-  stdio,
-  env: childEnv,
-  windowsHide: true,
-});
-…
-child.unref();
-```
-
-This is intentional for production — `apps/desktop/HOST_SERVICE_LIFECYCLE.md:39-62` describes manifest-based adoption so PTYs survive Electron restarts. The cost in dev: when `bun dev` is Ctrl-C'd, Electron dies without invoking any `stopAll()` path, and the detached host-service plus its detached pty-daemon stay alive.
-
-The existing mitigation (`82c337058 feat(host-service): kill stale daemon on dev-mode startup` + `MIN_HOST_SERVICE_VERSION` bumps in coordinator.ts:55) cleans up *on next launch*, not on shutdown. Between dev runs you accumulate stale `electron`-as-node host-service processes and stale daemons.
-
-The host-service itself has a dev-mode shutdown that kills the daemon (`packages/host-service/src/serve.ts:50-76`), but it only fires if host-service receives SIGINT/SIGTERM, which it doesn't on `bun dev` kill.
-
-**Fix options (pick one):**
-
-- **A. Don't detach in dev.** In `host-service-coordinator.ts:spawn`, branch on `app.isPackaged`:
-  ```ts
-  const isDev = !app.isPackaged;
-  child = childProcess.spawn(process.execPath, [this.scriptPath], {
-    detached: !isDev,
-    stdio,
-    env: childEnv,
-    windowsHide: true,
-  });
-  if (!isDev) child.unref();
-  ```
-  Pros: simplest, leverages the existing serve.ts dev-shutdown to cascade to the daemon.
-  Cons: host-service hot-reload (`enableDevReload`) still works since it explicitly `restartAll`s; nothing else relies on dev survival.
-
-- **B. Install a SIGTERM/SIGINT handler in Electron main** that calls `coordinator.stopAll()` before exiting. Requires that Electron's main process actually gets the signal — `electron-vite dev` propagates SIGTERM to Electron, so this should work, but verify.
-
-Option A is preferred — fewer moving parts and the existing detach/adopt path remains untouched in production.
-
-### 3. `pty-daemon` detached under host-service
-
-`packages/host-service/src/daemon/DaemonSupervisor.ts:425, 488`. Same `detached: true` + `unref()`. Already handled cleanly *if host-service receives SIGTERM* via `serve.ts:50-76`. Fixing #2 fixes this transitively — no separate work needed.
-
-### 4. `terminal-host` daemon (used by both v1 and v2)
-
-`apps/desktop/src/main/lib/terminal-host/client.ts:1188-1221`. Same `detached: true` + `child.unref()` pattern. `HOST_SERVICE_LIFECYCLE.md:64-66` describes this as the v1 path, but renderer callers under `routes/_authenticated/` (v2 settings, tasks `OpenInWorkspace`/`RunInWorkspacePopover`, `AgentHooks`) all hit the same `terminal.*` tRPC router → `getTerminalHostClient()`. So terminal-host is on the v2 codepath too — not v1-exclusive.
-
-**Fix:** same shape as host-service — `detached: !isDev` + `if (!isDev) child.unref()`, gated on `!app.isPackaged`.
-
-### 5. `dev:caddy` — likely fine
-
-`package.json:21` `dotenv -- caddy run --config Caddyfile` has no intermediate `sh -c`. `dotenv-cli@11` uses `cross-spawn` and forwards SIGINT/SIGTERM. No fix needed unless verification shows otherwise.
-
-## What's already good
-
-- `packages/pty-daemon/src/main.ts:60-79` — clean SIGINT/SIGTERM with re-entry guard and deterministic `process.exit(0)`.
-- `packages/host-service/src/serve.ts:50-76` — dev-only shutdown handler that calls `supervisor.stop(orgId)` before exit. Just needs to reliably *receive* the signal (issue #2).
-- `host-service-coordinator.ts:130-146` — `stop()` SIGTERMs the pid and removes the manifest. Solid; just isn't called on `bun dev` kill today.
-
-## Proposed change order
-
-1. **`exec` in the three `sh -c` dev scripts.** Lowest risk, fixes the most common "port already in use" symptom.
-2. **Don't detach host-service in dev** (option A above). Cascades the fix to pty-daemon via the existing serve.ts handler.
-3. Verify with:
-   ```sh
-   bun run dev &
-   BUN_DEV_PID=$!
-   sleep 20  # let everything start
-   kill $BUN_DEV_PID
-   sleep 3
-   lsof -iTCP -sTCP:LISTEN | grep -E '3000|3001|8787'
-   pgrep -lf 'host-service|pty-daemon|next dev|wrangler|electron'
-   ```
-   Both should be empty.
+| File | Change |
+|---|---|
+| `apps/{api,web,admin,docs,marketing,electric-proxy}/package.json` | `sh -c '<cmd>'` → `sh -c 'exec <cmd>'` |
+| `packages/cli/package.json` | `sh -c 'VAR=… cli-framework dev "$@"'` → `sh -c 'exec env VAR=… cli-framework dev "$@"'` |
+| `apps/desktop/src/main/lib/host-service-coordinator.ts` | `detached: !isDev` + `if (!isDev) child.unref()` (`isDev = !app.isPackaged`) |
+| `apps/desktop/src/main/lib/terminal-host/client.ts` | same |
+| `packages/host-service/src/daemon/DaemonSupervisor.ts` | same, gated on `NODE_ENV !== "production"` (defense-in-depth: covers host-service crash that bypasses serve.ts dev shutdown) |
+| `apps/desktop/src/main/index.ts` | dev branches in `before-quit` handler and signal handler now run `runDevQuitCleanup()` (`coordinator.stopAll()` + `terminal-host.shutdownIfRunning`) before exit |
 
 ## Prod safety
 
-Each fix is dev-only by construction:
+All daemon-spawn changes branch on `app.isPackaged` (or `NODE_ENV === "production"` for `DaemonSupervisor`). Packaged builds keep `detached: true` + `unref()` and the `releaseAll()` quit path unchanged, preserving manifest-based adoption and PTY survival across restarts (see `apps/desktop/HOST_SERVICE_LIFECYCLE.md`). The `exec` edits only touch `"dev"` scripts; cloud apps deploy via `next start` / `wrangler deploy`, which never run them.
 
-1. **`exec` in `sh -c`** — only edits `"dev"` scripts in `apps/{api,web,electric-proxy}/package.json`. Prod uses `next start` / `wrangler deploy`, which never go through these scripts. No production codepath touched.
-2. **`detached: !isDev` in host-service-coordinator** — gated on `!app.isPackaged`. Packaged production builds take the existing `detached: true` + `unref()` path unchanged, preserving manifest-based adoption and PTY survival across Electron restarts (`HOST_SERVICE_LIFECYCLE.md:39-62`).
-3. **pty-daemon** — no direct edit; behavior changes transitively only when host-service is non-detached, which is dev-only.
-4. **`detached: !isDev` in terminal-host client** — same `!app.isPackaged` gate. Packaged builds keep terminal-host detached so PTYs survive Electron restarts.
+## Verification
 
-Cloud apps (`apps/api`, `apps/web`) deploy via `next build` / `next start` — neither references the `dev` script. The desktop production bundle is built via `bun run build` → `electron-vite build` + `electron-builder`, which doesn't invoke `bun dev` either.
+`bun run dev` → wait for ports + 45s for Electron to mount and lazy-spawn host-service / terminal-host → SIGINT to pgrp → within 1s, every port (4980/4981/4985/4990/4993) is released and every spawned process from this worktree (turbo, electron-vite, Electron, host-service ×2, terminal-host, next dev ×2, wrangler, workerd, caddy, dotenv shells) is gone.
 
-## Verification (2026-05-02)
-
-Applied fixes:
-
-| # | File | Change |
-|---|---|---|
-| 1 | `apps/api/package.json:9` | `sh -c 'next dev …'` → `sh -c 'exec next dev …'` |
-| 1 | `apps/web/package.json:9` | same |
-| 1 | `apps/electric-proxy/package.json:7` | `sh -c 'wrangler dev …'` → `sh -c 'exec wrangler dev …'` |
-| 2 | `apps/desktop/src/main/lib/host-service-coordinator.ts:425-435, 470-477` | `detached: !isDev` + `if (!isDev) child.unref()` |
-| 4 | `apps/desktop/src/main/lib/terminal-host/client.ts:1188-1226` | `detached: !isDev` + `if (!isDev) child.unref()` |
-
-`apps/desktop` typecheck clean.
-
-Run / kill loop:
-
-```sh
-bun run dev > /tmp/bundev.log 2>&1 &
-# wait until web/api/wrangler ports listen, +15s settle
-kill -INT -<PGID>
-```
-
-Result within 1s of SIGINT — completely clean:
-- ports 4980 / 4981 / 4985 / 4990 / 4993 — *all* released
-- processes: every `dotenv`, `sh`, `next dev`, `wrangler`, `workerd`, `caddy`, `electron-vite`, `Electron` main + helpers, `turbo` from this worktree — gone
-
-Caveats — paths *not* exercised in this run:
-- **host-service** never spawned (no org logged in). Fix is symmetric to terminal-host, typecheck-clean, gated on `!app.isPackaged`.
-- **terminal-host** never spawned (lazy on first renderer terminal call; no UI interaction in headless test). Fix is the same shape as host-service.
-
-Both the host-service and terminal-host code changes are by-construction prod-neutral and follow standard Node child-process semantics: a non-detached, ref'd child receives the parent's death signal. Live UI verification with a logged-in org and a real terminal session is still the right next step.
-
-## Out of scope
-
-- Turbo `"ui": "tui"` signal handling (no concrete evidence of leaks here; revisit if #1+#2 don't fully resolve symptoms).
-- v1 `terminal-host` daemon cleanup (v1 sunset). Same fix applies if extended later.
-- Production manifest-adoption behavior — unchanged by any of the above.
+Graceful path tested separately: `kill -TERM <electron-pid>` (simulating Cmd+Q / electron-vite SIGTERM, not pgrp) cleanly stops host-service ×2 and terminal-host while the rest of `bun dev` keeps running, confirming the new dev quit cleanup fires on the non-pgrp path too.

--- a/plans/20260502-bun-dev-server-cleanup.md
+++ b/plans/20260502-bun-dev-server-cleanup.md
@@ -1,0 +1,165 @@
+# `bun run dev` cleanup audit
+
+## Problem
+
+Killing `bun run dev` (Ctrl-C, IDE stop, turbo subtask SIGTERM) does not reliably take down every child process it started. Symptoms: ports 3000/3001/8787 stay bound after exit; `host-service` and `pty-daemon` keep running between dev sessions; "address in use" errors on the next `bun run dev`.
+
+## What `bun run dev` actually starts
+
+```
+bun run dev
+└── turbo run dev dev:caddy --filter=@superset/{api,web,desktop} --filter=electric-proxy --filter=//
+    ├── (root) dev:caddy        → dotenv -- caddy run --config Caddyfile
+    ├── apps/api dev            → dotenv -e ../../.env -- sh -c 'next dev --port ${API_PORT:-3001}'
+    ├── apps/web dev            → dotenv -e ../../.env -- sh -c 'next dev --port ${WEB_PORT:-3000}'
+    ├── apps/desktop dev        → electron-vite dev --watch  (spawns Electron main)
+    │   └── Electron main
+    │       └── HostServiceCoordinator.spawn → host-service (detached, unref'd)
+    │           └── DaemonSupervisor.spawn   → pty-daemon (detached, unref'd)
+    └── apps/electric-proxy dev → dotenv -e ../../.env -- sh -c 'wrangler dev --port ${WRANGLER_PORT:-8787}'
+```
+
+## Issues
+
+### 1. `sh -c` without `exec` orphans the real process
+
+`sh -c 'next dev …'` makes the shell the parent of `next`. On a process-group-wide SIGINT (interactive Ctrl-C) everything dies together so this hides. But when a supervisor (turbo, IDE, `kill <pid>`) sends SIGTERM to the *subtask pid only*, `sh` exits without forwarding and `next`/`wrangler` is orphaned, still bound to its port.
+
+| File | Line | Current |
+|---|---|---|
+| `apps/api/package.json` | 21 | `dotenv -e ../../.env -- sh -c 'next dev --port ${API_PORT:-3001}'` |
+| `apps/web/package.json` | 18 | `dotenv -e ../../.env -- sh -c 'next dev --port ${WEB_PORT:-3000}'` |
+| `apps/electric-proxy/package.json` | 17 | `dotenv -e ../../.env -- sh -c 'wrangler dev --port ${WRANGLER_PORT:-8787}'` |
+
+**Fix:** prepend `exec ` inside the `sh -c` string so the shell is replaced by the real binary. Signals then land directly on `next`/`wrangler`.
+
+```diff
+- "dev": "dotenv -e ../../.env -- sh -c 'next dev --port ${API_PORT:-3001}'"
++ "dev": "dotenv -e ../../.env -- sh -c 'exec next dev --port ${API_PORT:-3001}'"
+```
+
+### 2. `host-service` is `detached: true` + `child.unref()` — survives `bun dev` kill
+
+`apps/desktop/src/main/lib/host-service-coordinator.ts:427-433, 470`
+
+```ts
+child = childProcess.spawn(process.execPath, [this.scriptPath], {
+  detached: true,
+  stdio,
+  env: childEnv,
+  windowsHide: true,
+});
+…
+child.unref();
+```
+
+This is intentional for production — `apps/desktop/HOST_SERVICE_LIFECYCLE.md:39-62` describes manifest-based adoption so PTYs survive Electron restarts. The cost in dev: when `bun dev` is Ctrl-C'd, Electron dies without invoking any `stopAll()` path, and the detached host-service plus its detached pty-daemon stay alive.
+
+The existing mitigation (`82c337058 feat(host-service): kill stale daemon on dev-mode startup` + `MIN_HOST_SERVICE_VERSION` bumps in coordinator.ts:55) cleans up *on next launch*, not on shutdown. Between dev runs you accumulate stale `electron`-as-node host-service processes and stale daemons.
+
+The host-service itself has a dev-mode shutdown that kills the daemon (`packages/host-service/src/serve.ts:50-76`), but it only fires if host-service receives SIGINT/SIGTERM, which it doesn't on `bun dev` kill.
+
+**Fix options (pick one):**
+
+- **A. Don't detach in dev.** In `host-service-coordinator.ts:spawn`, branch on `app.isPackaged`:
+  ```ts
+  const isDev = !app.isPackaged;
+  child = childProcess.spawn(process.execPath, [this.scriptPath], {
+    detached: !isDev,
+    stdio,
+    env: childEnv,
+    windowsHide: true,
+  });
+  if (!isDev) child.unref();
+  ```
+  Pros: simplest, leverages the existing serve.ts dev-shutdown to cascade to the daemon.
+  Cons: host-service hot-reload (`enableDevReload`) still works since it explicitly `restartAll`s; nothing else relies on dev survival.
+
+- **B. Install a SIGTERM/SIGINT handler in Electron main** that calls `coordinator.stopAll()` before exiting. Requires that Electron's main process actually gets the signal — `electron-vite dev` propagates SIGTERM to Electron, so this should work, but verify.
+
+Option A is preferred — fewer moving parts and the existing detach/adopt path remains untouched in production.
+
+### 3. `pty-daemon` detached under host-service
+
+`packages/host-service/src/daemon/DaemonSupervisor.ts:425, 488`. Same `detached: true` + `unref()`. Already handled cleanly *if host-service receives SIGTERM* via `serve.ts:50-76`. Fixing #2 fixes this transitively — no separate work needed.
+
+### 4. `terminal-host` daemon (used by both v1 and v2)
+
+`apps/desktop/src/main/lib/terminal-host/client.ts:1188-1221`. Same `detached: true` + `child.unref()` pattern. `HOST_SERVICE_LIFECYCLE.md:64-66` describes this as the v1 path, but renderer callers under `routes/_authenticated/` (v2 settings, tasks `OpenInWorkspace`/`RunInWorkspacePopover`, `AgentHooks`) all hit the same `terminal.*` tRPC router → `getTerminalHostClient()`. So terminal-host is on the v2 codepath too — not v1-exclusive.
+
+**Fix:** same shape as host-service — `detached: !isDev` + `if (!isDev) child.unref()`, gated on `!app.isPackaged`.
+
+### 5. `dev:caddy` — likely fine
+
+`package.json:21` `dotenv -- caddy run --config Caddyfile` has no intermediate `sh -c`. `dotenv-cli@11` uses `cross-spawn` and forwards SIGINT/SIGTERM. No fix needed unless verification shows otherwise.
+
+## What's already good
+
+- `packages/pty-daemon/src/main.ts:60-79` — clean SIGINT/SIGTERM with re-entry guard and deterministic `process.exit(0)`.
+- `packages/host-service/src/serve.ts:50-76` — dev-only shutdown handler that calls `supervisor.stop(orgId)` before exit. Just needs to reliably *receive* the signal (issue #2).
+- `host-service-coordinator.ts:130-146` — `stop()` SIGTERMs the pid and removes the manifest. Solid; just isn't called on `bun dev` kill today.
+
+## Proposed change order
+
+1. **`exec` in the three `sh -c` dev scripts.** Lowest risk, fixes the most common "port already in use" symptom.
+2. **Don't detach host-service in dev** (option A above). Cascades the fix to pty-daemon via the existing serve.ts handler.
+3. Verify with:
+   ```sh
+   bun run dev &
+   BUN_DEV_PID=$!
+   sleep 20  # let everything start
+   kill $BUN_DEV_PID
+   sleep 3
+   lsof -iTCP -sTCP:LISTEN | grep -E '3000|3001|8787'
+   pgrep -lf 'host-service|pty-daemon|next dev|wrangler|electron'
+   ```
+   Both should be empty.
+
+## Prod safety
+
+Each fix is dev-only by construction:
+
+1. **`exec` in `sh -c`** — only edits `"dev"` scripts in `apps/{api,web,electric-proxy}/package.json`. Prod uses `next start` / `wrangler deploy`, which never go through these scripts. No production codepath touched.
+2. **`detached: !isDev` in host-service-coordinator** — gated on `!app.isPackaged`. Packaged production builds take the existing `detached: true` + `unref()` path unchanged, preserving manifest-based adoption and PTY survival across Electron restarts (`HOST_SERVICE_LIFECYCLE.md:39-62`).
+3. **pty-daemon** — no direct edit; behavior changes transitively only when host-service is non-detached, which is dev-only.
+4. **`detached: !isDev` in terminal-host client** — same `!app.isPackaged` gate. Packaged builds keep terminal-host detached so PTYs survive Electron restarts.
+
+Cloud apps (`apps/api`, `apps/web`) deploy via `next build` / `next start` — neither references the `dev` script. The desktop production bundle is built via `bun run build` → `electron-vite build` + `electron-builder`, which doesn't invoke `bun dev` either.
+
+## Verification (2026-05-02)
+
+Applied fixes:
+
+| # | File | Change |
+|---|---|---|
+| 1 | `apps/api/package.json:9` | `sh -c 'next dev …'` → `sh -c 'exec next dev …'` |
+| 1 | `apps/web/package.json:9` | same |
+| 1 | `apps/electric-proxy/package.json:7` | `sh -c 'wrangler dev …'` → `sh -c 'exec wrangler dev …'` |
+| 2 | `apps/desktop/src/main/lib/host-service-coordinator.ts:425-435, 470-477` | `detached: !isDev` + `if (!isDev) child.unref()` |
+| 4 | `apps/desktop/src/main/lib/terminal-host/client.ts:1188-1226` | `detached: !isDev` + `if (!isDev) child.unref()` |
+
+`apps/desktop` typecheck clean.
+
+Run / kill loop:
+
+```sh
+bun run dev > /tmp/bundev.log 2>&1 &
+# wait until web/api/wrangler ports listen, +15s settle
+kill -INT -<PGID>
+```
+
+Result within 1s of SIGINT — completely clean:
+- ports 4980 / 4981 / 4985 / 4990 / 4993 — *all* released
+- processes: every `dotenv`, `sh`, `next dev`, `wrangler`, `workerd`, `caddy`, `electron-vite`, `Electron` main + helpers, `turbo` from this worktree — gone
+
+Caveats — paths *not* exercised in this run:
+- **host-service** never spawned (no org logged in). Fix is symmetric to terminal-host, typecheck-clean, gated on `!app.isPackaged`.
+- **terminal-host** never spawned (lazy on first renderer terminal call; no UI interaction in headless test). Fix is the same shape as host-service.
+
+Both the host-service and terminal-host code changes are by-construction prod-neutral and follow standard Node child-process semantics: a non-detached, ref'd child receives the parent's death signal. Live UI verification with a logged-in org and a real terminal session is still the right next step.
+
+## Out of scope
+
+- Turbo `"ui": "tui"` signal handling (no concrete evidence of leaks here; revisit if #1+#2 don't fully resolve symptoms).
+- v1 `terminal-host` daemon cleanup (v1 sunset). Same fix applies if extended later.
+- Production manifest-adoption behavior — unchanged by any of the above.


### PR DESCRIPTION
## Summary

After Ctrl-C'ing `bun run dev`, three categories of child processes were leaking and surviving as orphans (PPID=1):

- `next dev` (api, web) and `wrangler dev` (electric-proxy) — `sh -c '<cmd>'` doesn't `exec` the real binary, so on subtask SIGTERM the shell exits without forwarding the signal and the dev server is left bound to its port.
- `host-service` (`apps/desktop/src/main/lib/host-service-coordinator.ts`) — spawned `detached: true` + `child.unref()` unconditionally; on `bun dev` kill no `stopAll()` runs, so it reparents to init.
- `terminal-host` daemon (`apps/desktop/src/main/lib/terminal-host/client.ts`) — same pattern, same outcome. Used by both v1 and v2 codepaths (settings, tasks `OpenInWorkspace`/`RunInWorkspacePopover`, agent hooks).

## Changes

- `apps/{api,web,electric-proxy}/package.json` — prepend `exec ` inside the `sh -c` so signals land on `next`/`wrangler` directly.
- `apps/desktop/src/main/lib/host-service-coordinator.ts` — `detached: !isDev` + `if (!isDev) child.unref()`, gated on `!app.isPackaged`.
- `apps/desktop/src/main/lib/terminal-host/client.ts` — same shape.
- `plans/20260502-bun-dev-server-cleanup.md` — audit + verification notes.

## Prod safety

All changes are dev-only by construction:

- `exec` only edits `"dev"` scripts; prod uses `next start` / `wrangler deploy`.
- `detached` flips for both daemons are gated on `!app.isPackaged`. Packaged production builds keep `detached: true` + `unref()` exactly as before, preserving manifest-based adoption and PTY survival across Electron restarts (`apps/desktop/HOST_SERVICE_LIFECYCLE.md`).

## Verification

```sh
bun run dev > /tmp/bundev.log 2>&1 &
# wait for ports 4980/4981/4993 to listen, +45s to let Electron mount and lazy-spawn host-service/terminal-host
kill -INT -<PGID>
```

Result within 1s of SIGINT — completely clean:
- ports 4980 (web), 4981 (api), 4985 (vite), 4990 (caddy), 4992 (electron remote-debug), 4993 (workerd) — all released
- processes (turbo, electron-vite, Electron, host-service ×2, terminal-host, next dev ×2, wrangler, workerd, caddy, dotenv shells) — all gone
- no orphaned PPID=1 processes from this worktree

For comparison, sibling worktrees on older code in the same `ps` snapshot still had `host-service.js`, `terminal-host.js`, `pty-daemon.js` reparented to init — the exact leak this PR fixes.

`apps/desktop` typecheck clean.

## Test plan

- [ ] Reviewer: `bun run dev`, sign in to an org, open a v2 workspace + spawn a terminal, then Ctrl-C and confirm `pgrep -lf 'host-service|terminal-host|pty-daemon|next dev|wrangler|caddy'` is empty for your worktree.
- [ ] Verify packaged build (release-desktop canary) still adopts a previously-running host-service on launch (manifest-based adoption unchanged).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes leaking dev processes so stopping `bun run dev` or quitting Electron in dev cleanly shuts down all child servers and daemons, freeing ports with no orphans. Production behavior is unchanged.

- **Bug Fixes**
  - `apps/{api,web,electric-proxy,admin,docs,marketing}` and `packages/cli`: added `exec` inside `sh -c` for `next dev`/`wrangler dev`/`cli-framework dev` so signals reach the real process.
  - `apps/desktop`: spawn `host-service` and `terminal-host` with `detached: !isDev` and only `unref()` in production so they exit with Electron in dev.
  - `packages/host-service`: `DaemonSupervisor` now spawns the PTY daemon with `detached: !isDev` and only `unref()` in production, providing defense-in-depth for crash cases.
  - `apps/desktop/src/main/index.ts`: dev quit/SIGTERM/parent-exit runs cleanup to stop `host-service`, shut down `terminal-host` (kills sessions), dispose the client, then exit; adds a re-entry guard to avoid double handling.

- **Refactors**
  - Trimmed spawn-site comments across the coordinator, terminal-host client, and PTY supervisor to clarify prod vs. dev behavior.
  - `plans/20260502-bun-dev-server-cleanup.md`: tightened to reflect shipped state.

<sup>Written for commit 6d2de88580c21fab3077af1c208e326517aede50. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Dev servers and helper processes now terminate reliably on quit by keeping spawned processes attached in development and detached in production, and by launching dev servers via the shell so they replace the shell process for proper shutdown and port cleanup.
* **Documentation**
  * Added a verification-backed plan describing dev-server shutdown issues, root causes, and fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->