### PR TITLE
feat(desktop): sticky file headers in v2 diff pane

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
@@ -107,10 +107,7 @@ export function DiffPane({ context, workspaceId, onOpenFile }: DiffPaneProps) {
 	}
 
 	return (
-		<Virtualizer
-			className="h-full w-full overflow-auto"
-			contentClassName="space-y-2"
-		>
+		<Virtualizer className="h-full w-full overflow-auto">
 			<ScrollToFile path={data.path} />
 			{files.map((file) => (
 				<DiffFileEntry

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileEntry/DiffFileEntry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileEntry/DiffFileEntry.tsx
@@ -200,7 +200,7 @@ function DeferredDiffPlaceholder({
 		: `${(file.additions + file.deletions).toLocaleString()} changed lines`;
 
 	return (
-		<div className="flex flex-col overflow-hidden">
+		<div className="flex flex-col">
 			<DiffFileHeader
 				path={file.path}
 				status={file.status}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileHeader/DiffFileHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileHeader/DiffFileHeader.tsx
@@ -52,7 +52,7 @@ export function DiffFileHeader({
 	const name = lastSlash >= 0 ? path.slice(lastSlash + 1) : path;
 
 	return (
-		<div className="@container/diff-file-header flex min-w-0 flex-nowrap items-center gap-1 border-y border-border bg-muted/30 px-3 py-2">
+		<div className="@container/diff-file-header sticky top-0 z-10 flex min-w-0 flex-nowrap items-center gap-1 bg-card px-3 py-2">
 			<button
 				type="button"
 				onClick={onToggleCollapsed}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/WorkspaceDiff/WorkspaceDiff.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/WorkspaceDiff/WorkspaceDiff.tsx
@@ -119,7 +119,7 @@ export const WorkspaceDiff = memo(function WorkspaceDiff({
 	}, [source.kind, worktreePath, path]);
 
 	return (
-		<div className="flex flex-col overflow-hidden">
+		<div className="flex flex-col">
 			<DiffFileHeader
 				path={path}
 				status={status}


### PR DESCRIPTION
## Summary
- Pin each file's header to the top of the v2 diff pane while scrolling its hunks, so the filename and per-file actions (copy path, viewed, expand-unchanged, discard) stay reachable in long diffs.
- Stack file entries flush (drop the `space-y-2` between them) so headers replace each other cleanly as you scroll between files.
- Use the `bg-sidebar` token for the header surface — distinct from the `bg-secondary` selected-pane chrome and from the terminal-themed diff body, without introducing a custom color.

## Implementation notes
- `sticky top-0 z-10` on `DiffFileHeader`. Required dropping `overflow-hidden` from the per-file wrappers in `WorkspaceDiff` and `DeferredDiffPlaceholder` — `overflow-hidden` would have trapped sticky positioning to a non-scrolling ancestor.
- Background must be opaque (sticky overlays scrolling content). `bg-sidebar` is one step above `--background`, the mildest opaque token in the theme that's still distinct from the selected pane header.

## Test plan
- [ ] Open the v2 diff pane on a branch with a long single-file diff; scroll the body and verify the header stays pinned with all actions clickable.
- [ ] Open a multi-file diff; scroll across files and verify the next file's header replaces the previous one with no gap or visual jump.
- [ ] Toggle pane selection — confirm the file header (`bg-sidebar`) reads as distinct from the selected pane title (`bg-secondary`).
- [ ] Verify large-diff and deleted-file placeholders still render correctly with the sticky header.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make each file header sticky in the v2 diff pane so the filename and per-file actions stay visible while you scroll long diffs. Headers stack flush between files on an opaque `bg-card` surface with no borders.

- **New Features**
  - Set `DiffFileHeader` to `sticky top-0 z-10` on `bg-card`; removed header borders.
  - Removed `overflow-hidden` from per-file wrappers (`WorkspaceDiff`, `DeferredDiffPlaceholder`) so sticky anchors to the scroller.
  - Dropped `space-y-2` in the `Virtualizer` so headers hand off cleanly when scrolling across files.

<sup>Written for commit 0c8535e3b9ff4e12f359c35dc91c827b6e7f3792. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated diff pane layout and spacing for better visual organization.
  * Implemented sticky file headers for improved navigation while scrolling through diffs.
  * Refined overflow and spacing behavior throughout the diff view interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->