### PR TITLE
fix(host-service): route workspace.create through safeResolveWorktreePath

### DIFF
--- a/packages/host-service/src/trpc/router/workspace-creation/schemas.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/schemas.ts
@@ -103,10 +103,9 @@ export const adoptInputSchema = z.object({
 	baseBranch: z.string().optional(),
 	existingWorkspaceId: z.string().optional(),
 	// When provided, adopt the worktree at this explicit path instead
-	// of looking one up under <repoPath>/.worktrees/<branch>. Used by
-	// the v1→v2 migration to adopt worktrees at legacy paths (e.g.
-	// ~/.superset/worktrees/...) that aren't under the picker's
-	// Superset-managed prefix.
+	// of locating one by branch via `git worktree list`. Used by the
+	// v1→v2 migration when the renderer already knows the on-disk
+	// path and wants to skip the branch-based lookup.
 	worktreePath: z.string().optional(),
 });
 

--- a/packages/host-service/src/trpc/router/workspace/workspace.ts
+++ b/packages/host-service/src/trpc/router/workspace/workspace.ts
@@ -9,6 +9,7 @@ import { projects, workspaces } from "../../../db/schema";
 import { invalidateLabelCache } from "../../../ports/static-ports";
 import { protectedProcedure, router } from "../../index";
 import { ensureMainWorkspace } from "../project/utils/ensure-main-workspace";
+import { safeResolveWorktreePath } from "../workspace-creation/shared/worktree-paths";
 
 export const workspaceRouter = router({
 	get: protectedProcedure
@@ -80,11 +81,11 @@ export const workspaceRouter = router({
 
 			await ensureMainWorkspace(ctx, input.projectId, localProject.repoPath);
 
-			const worktreePath = join(
-				localProject.repoPath,
-				".worktrees",
+			const worktreePath = safeResolveWorktreePath(
+				localProject.id,
 				input.branch,
 			);
+			mkdirSync(dirname(worktreePath), { recursive: true });
 			const machineId = getHostId();
 			const hostName = getHostName();
 


### PR DESCRIPTION
## Summary
- The CLI's `workspace.create` was hard-coding `<repoPath>/.worktrees/<branch>` while the desktop's `workspaceCreation.create` resolved via `safeResolveWorktreePath()` to `~/.superset/worktrees/<projectId>/<branch>`. Same intent, two locations on disk depending on caller.
- Standardize on `safeResolveWorktreePath` so both routers funnel through the same helper.
- Fix a stale comment in `workspace-creation/schemas.ts` that had the locations reversed and misdescribed the `adopt` fallback (it's `git worktree list` by branch, not a fixed prefix).

## Why this matters
Discovered while auditing `~/.superset/host/<org>/host.db` rows: ~33 workspaces in one org's host.db pointed at `code/superset/.worktrees/...` instead of `~/.superset/worktrees/...`. Every one was created via the CLI. Desktop-created workspaces all landed in the standard location.

## Backward compat
Existing rows in `host.db.workspaces.worktree_path` keep their absolute paths, so already-created CLI worktrees continue to work. Only new creates relocate.

## Test plan
- [ ] `superset workspaces create --project <id> --name foo --branch foo` — verify the new worktree lands under `~/.superset/worktrees/<projectId>/foo`
- [ ] Existing CLI-created workspaces (those still under `<repoPath>/.worktrees/`) still open and operate
- [ ] Desktop create flow unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes CLI workspace creation to use the same worktree location as the desktop app. New worktrees now land under ~/.superset/worktrees/<projectId>/<branch>; existing ones continue to work.

- **Bug Fixes**
  - Route CLI `workspace.create` through safeResolveWorktreePath so both clients use ~/.superset/worktrees/<projectId>/<branch>.
  - Create the parent directory if missing before writing the worktree.
  - Fix comment in `workspace-creation/schemas.ts` to reflect branch-based lookup via `git worktree list`.
  - Backward compatible: existing absolute paths in host.db still work.

<sup>Written for commit b33357653558d1d25144e709d0102d03517457cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated inline documentation for the workspace adoption process to clarify branch-based lookup behavior.

* **Chores**
  * Improved internal workspace path resolution and directory management during workspace creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->