### PR TITLE
refactor(auth): unify bearer auth across CLI / SDK / MCP

### DIFF
--- a/apps/api/src/app/api/agent/[transport]/auth-flow.ts
+++ b/apps/api/src/app/api/agent/[transport]/auth-flow.ts
@@ -1,8 +1,8 @@
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { resolveBearerAuth } from "@superset/auth/resolve-bearer-auth";
 import type { createMcpServer } from "@superset/mcp";
 import type { McpContext } from "@superset/mcp/auth";
-import type { verifyAccessToken as verifyOAuthAccessToken } from "better-auth/oauth2";
 import { getOAuthProtectedResourceMetadataUrl } from "@/lib/oauth-metadata";
 
 interface SessionUser {
@@ -18,64 +18,14 @@ interface SessionResponse {
 	user: SessionUser;
 }
 
-interface VerifiedApiKey {
-	referenceId?: string | null;
-	metadata?: unknown;
-}
-
-interface VerifyApiKeyResponse {
-	valid: boolean;
-	key: VerifiedApiKey | null;
-}
-
 export interface McpRequestDeps {
-	apiUrl: string;
 	authApi: {
 		getSession(args: {
 			headers: Headers;
 		}): Promise<SessionResponse | null | undefined>;
-		verifyApiKey(args: {
-			body: { key: string };
-		}): Promise<VerifyApiKeyResponse>;
 	};
 	createServer: typeof createMcpServer;
 	createTransport: () => WebStandardStreamableHTTPServerTransport;
-	verifyAccessToken: typeof verifyOAuthAccessToken;
-}
-
-function getBearerToken(req: Request): string | undefined {
-	const authorization = req.headers.get("authorization");
-	const match = authorization?.match(/^Bearer\s+(.+)$/i);
-	return match?.[1];
-}
-
-export function isApiKeyBearerToken(token: string): boolean {
-	return token.startsWith("sk_live_");
-}
-
-function normalizeApiUrl(apiUrl: string): string {
-	return apiUrl.replace(/\/+$/, "");
-}
-
-function getSafeAuthErrorName(error: unknown): string {
-	if (error && typeof error === "object") {
-		const errorName = "name" in error ? error.name : undefined;
-		if (typeof errorName === "string" && errorName.length > 0) {
-			return errorName;
-		}
-
-		const errorCode = "code" in error ? error.code : undefined;
-		if (typeof errorCode === "string" && errorCode.length > 0) {
-			return errorCode;
-		}
-	}
-
-	return "AuthVerificationError";
-}
-
-function looksLikeJwt(token: string): boolean {
-	const parts = token.split(".");
-	return parts.length === 3 && parts.every(Boolean);
 }
 
 function buildSessionAuthInfo(session: SessionResponse): AuthInfo | undefined {
@@ -99,148 +49,41 @@ function buildSessionAuthInfo(session: SessionResponse): AuthInfo | undefined {
 	};
 }
 
-function parseApiKeyMetadata(
-	metadata: unknown,
-): Record<string, unknown> | null {
-	if (!metadata) {
-		return null;
-	}
-
-	if (typeof metadata === "string") {
-		try {
-			const parsed = JSON.parse(metadata);
-			return parsed && typeof parsed === "object"
-				? (parsed as Record<string, unknown>)
-				: null;
-		} catch (error) {
-			console.error("[mcp/auth] Failed to parse API key metadata:", error);
-			return null;
-		}
-	}
-
-	return typeof metadata === "object"
-		? (metadata as Record<string, unknown>)
-		: null;
-}
-
-function buildApiKeyAuthInfo(apiKey: VerifiedApiKey): AuthInfo | undefined {
-	const userId = apiKey.referenceId;
-
-	if (!userId) {
-		console.error("[mcp/auth] API key missing referenceId");
-		return undefined;
-	}
-
-	const metadata = parseApiKeyMetadata(apiKey.metadata);
-	const organizationId =
-		typeof metadata?.organizationId === "string"
-			? metadata.organizationId
-			: undefined;
-
-	if (!organizationId) {
-		console.error("[mcp/auth] API key missing organizationId in metadata");
-		return undefined;
-	}
-
-	return {
-		token: "api-key",
-		clientId: "api-key",
-		scopes: ["mcp:full"],
-		extra: {
-			mcpContext: {
-				userId,
-				organizationId,
-			} satisfies McpContext,
-		},
-	};
-}
-
-function buildOAuthAuthInfo(
-	bearerToken: string,
-	payload: Record<string, unknown>,
-): AuthInfo | undefined {
-	if (
-		typeof payload.sub !== "string" ||
-		typeof payload.organizationId !== "string"
-	) {
-		console.error(
-			"[mcp/auth] Access token missing sub or organizationId claim",
-		);
-		return undefined;
-	}
-
-	const scopes = Array.isArray(payload.scope)
-		? (payload.scope as string[])
-		: typeof payload.scope === "string"
-			? payload.scope.split(" ")
-			: [];
-
-	return {
-		token: bearerToken,
-		clientId: typeof payload.azp === "string" ? payload.azp : "mcp-client",
-		scopes,
-		extra: {
-			mcpContext: {
-				userId: payload.sub,
-				organizationId: payload.organizationId,
-			} satisfies McpContext,
-		},
-	};
-}
-
 export async function verifyToken(
 	req: Request,
 	deps: McpRequestDeps,
 ): Promise<AuthInfo | undefined> {
-	const bearerToken = getBearerToken(req);
-	const apiUrl = normalizeApiUrl(deps.apiUrl);
-	let oauthVerificationError: unknown;
+	let bearer: Awaited<ReturnType<typeof resolveBearerAuth>> = null;
+	try {
+		bearer = await resolveBearerAuth(req.headers);
+	} catch (error) {
+		console.error("[mcp/auth] Bearer auth rejected", {
+			message: error instanceof Error ? error.message : String(error),
+		});
+		return undefined;
+	}
 
-	if (bearerToken) {
-		if (isApiKeyBearerToken(bearerToken)) {
-			try {
-				const result = await deps.authApi.verifyApiKey({
-					body: { key: bearerToken },
-				});
-
-				if (result.valid && result.key) {
-					return buildApiKeyAuthInfo(result.key);
-				}
-			} catch (error) {
-				console.error("[mcp/auth] API key verification failed", {
-					errorName: getSafeAuthErrorName(error),
-				});
-			}
-
+	if (bearer) {
+		if (!bearer.activeOrganizationId) {
+			console.error("[mcp/auth] Bearer missing organizationId");
 			return undefined;
 		}
-
-		if (looksLikeJwt(bearerToken)) {
-			try {
-				const payload = (await deps.verifyAccessToken(bearerToken, {
-					jwksUrl: `${apiUrl}/api/auth/jwks`,
-					verifyOptions: {
-						issuer: apiUrl,
-						audience: [apiUrl, `${apiUrl}/`, `${apiUrl}/api/agent/mcp`],
-					},
-				})) as Record<string, unknown>;
-
-				return buildOAuthAuthInfo(bearerToken, payload);
-			} catch (error) {
-				oauthVerificationError = error;
-			}
-		}
+		return {
+			token: "bearer",
+			clientId: bearer.kind === "apiKey" ? "api-key" : "mcp-client",
+			scopes: bearer.scopes.length > 0 ? bearer.scopes : ["mcp:full"],
+			extra: {
+				mcpContext: {
+					userId: bearer.userId,
+					organizationId: bearer.activeOrganizationId,
+				} satisfies McpContext,
+			},
+		};
 	}
 
 	const session = await deps.authApi.getSession({ headers: req.headers });
 	if (session?.session) {
 		return buildSessionAuthInfo(session);
-	}
-
-	if (oauthVerificationError) {
-		console.error("[mcp/auth] Access token verification failed", {
-			errorName: getSafeAuthErrorName(oauthVerificationError),
-		});
 	}
 
 	return undefined;

--- a/apps/api/src/app/api/agent/[transport]/auth-flow.ts
+++ b/apps/api/src/app/api/agent/[transport]/auth-flow.ts
@@ -1,6 +1,10 @@
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
-import { resolveBearerAuth } from "@superset/auth/resolve-bearer-auth";
+import { MCP_AUDIENCES } from "@superset/auth/oauth-audiences";
+import {
+	BearerAuthError,
+	resolveBearerAuth,
+} from "@superset/auth/resolve-bearer-auth";
 import type { createMcpServer } from "@superset/mcp";
 import type { McpContext } from "@superset/mcp/auth";
 import { getOAuthProtectedResourceMetadataUrl } from "@/lib/oauth-metadata";
@@ -53,15 +57,9 @@ export async function verifyToken(
 	req: Request,
 	deps: McpRequestDeps,
 ): Promise<AuthInfo | undefined> {
-	let bearer: Awaited<ReturnType<typeof resolveBearerAuth>> = null;
-	try {
-		bearer = await resolveBearerAuth(req.headers);
-	} catch (error) {
-		console.error("[mcp/auth] Bearer auth rejected", {
-			message: error instanceof Error ? error.message : String(error),
-		});
-		return undefined;
-	}
+	const bearer = await resolveBearerAuth(req.headers, {
+		audiences: MCP_AUDIENCES,
+	});
 
 	if (bearer) {
 		if (!bearer.activeOrganizationId) {
@@ -100,11 +98,30 @@ export function unauthorizedResponse(req: Request): Response {
 	});
 }
 
+function forbiddenResponse(message: string): Response {
+	return new Response(message, { status: 403 });
+}
+
 export async function handleMcpRequest(
 	req: Request,
 	deps: McpRequestDeps,
 ): Promise<Response> {
-	const authInfo = await verifyToken(req, deps);
+	let authInfo: AuthInfo | undefined;
+	try {
+		authInfo = await verifyToken(req, deps);
+	} catch (error) {
+		if (error instanceof BearerAuthError) {
+			if (error.reason === "forbidden_org") {
+				return forbiddenResponse(error.message);
+			}
+			console.error("[mcp/auth] Bearer rejected", {
+				reason: error.reason,
+				message: error.message,
+			});
+			return unauthorizedResponse(req);
+		}
+		throw error;
+	}
 	if (!authInfo) {
 		return unauthorizedResponse(req);
 	}

--- a/apps/api/src/app/api/agent/[transport]/auth-flow.ts
+++ b/apps/api/src/app/api/agent/[transport]/auth-flow.ts
@@ -98,10 +98,6 @@ export function unauthorizedResponse(req: Request): Response {
 	});
 }
 
-function forbiddenResponse(message: string): Response {
-	return new Response(message, { status: 403 });
-}
-
 export async function handleMcpRequest(
 	req: Request,
 	deps: McpRequestDeps,
@@ -112,7 +108,7 @@ export async function handleMcpRequest(
 	} catch (error) {
 		if (error instanceof BearerAuthError) {
 			if (error.reason === "forbidden_org") {
-				return forbiddenResponse(error.message);
+				return new Response(error.message, { status: 403 });
 			}
 			console.error("[mcp/auth] Bearer rejected", {
 				reason: error.reason,

--- a/apps/api/src/app/api/agent/[transport]/route.ts
+++ b/apps/api/src/app/api/agent/[transport]/route.ts
@@ -1,16 +1,12 @@
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { auth } from "@superset/auth/server";
 import { createMcpServer } from "@superset/mcp";
-import { verifyAccessToken } from "better-auth/oauth2";
-import { env } from "@/env";
 import { handleMcpRequest, type McpRequestDeps } from "./auth-flow";
 
 const deps: McpRequestDeps = {
-	apiUrl: env.NEXT_PUBLIC_API_URL,
 	authApi: auth.api,
 	createServer: createMcpServer,
 	createTransport: () => new WebStandardStreamableHTTPServerTransport(),
-	verifyAccessToken,
 };
 
 async function handleRequest(req: Request): Promise<Response> {

--- a/apps/api/src/trpc/context.ts
+++ b/apps/api/src/trpc/context.ts
@@ -1,67 +1,5 @@
-import { auth, type Session } from "@superset/auth/server";
-import { db } from "@superset/db/client";
-import * as authSchema from "@superset/db/schema/auth";
+import { auth } from "@superset/auth/server";
 import { createTRPCContext } from "@superset/trpc";
-import { verifyAccessToken } from "better-auth/oauth2";
-import { eq } from "drizzle-orm";
-import { env } from "@/env";
-
-const apiUrl = env.NEXT_PUBLIC_API_URL.replace(/\/+$/, "");
-
-function looksLikeJwt(token: string): boolean {
-	const parts = token.split(".");
-	return parts.length === 3 && parts.every(Boolean);
-}
-
-async function sessionFromOAuthBearer(
-	headers: Headers,
-): Promise<Session | null> {
-	const authorization = headers.get("authorization");
-	const match = authorization?.match(/^Bearer\s+(.+)$/i);
-	const token = match?.[1];
-	if (!token || !looksLikeJwt(token)) return null;
-
-	let payload: Record<string, unknown>;
-	try {
-		payload = (await verifyAccessToken(token, {
-			jwksUrl: `${apiUrl}/api/auth/jwks`,
-			verifyOptions: {
-				issuer: apiUrl,
-				audience: [apiUrl, `${apiUrl}/`],
-			},
-		})) as Record<string, unknown>;
-	} catch {
-		return null;
-	}
-
-	const userId = typeof payload.sub === "string" ? payload.sub : null;
-	if (!userId) return null;
-
-	const user = await db.query.users.findFirst({
-		where: eq(authSchema.users.id, userId),
-	});
-	if (!user) return null;
-
-	const activeOrganizationId =
-		typeof payload.organizationId === "string" ? payload.organizationId : null;
-
-	const sessionId = typeof payload.sid === "string" ? payload.sid : userId;
-
-	return {
-		user,
-		session: {
-			id: sessionId,
-			userId,
-			activeOrganizationId,
-			expiresAt: new Date(((payload.exp as number) ?? 0) * 1000),
-			token: token,
-			ipAddress: null,
-			userAgent: null,
-			createdAt: new Date(((payload.iat as number) ?? 0) * 1000),
-			updatedAt: new Date(((payload.iat as number) ?? 0) * 1000),
-		},
-	} as unknown as Session;
-}
 
 export const createContext = async ({
 	req,
@@ -69,14 +7,9 @@ export const createContext = async ({
 	req: Request;
 	resHeaders: Headers;
 }) => {
-	let session = await auth.api.getSession({
+	const session = await auth.api.getSession({
 		headers: req.headers,
 	});
-
-	if (!session) {
-		session = await sessionFromOAuthBearer(req.headers);
-	}
-
 	return createTRPCContext({
 		session,
 		auth,

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -19,6 +19,10 @@
 		"./stripe": {
 			"types": "./src/stripe.ts",
 			"default": "./src/stripe.ts"
+		},
+		"./resolve-bearer-auth": {
+			"types": "./src/lib/resolve-bearer-auth.ts",
+			"default": "./src/lib/resolve-bearer-auth.ts"
 		}
 	},
 	"scripts": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -23,6 +23,10 @@
 		"./resolve-bearer-auth": {
 			"types": "./src/lib/resolve-bearer-auth.ts",
 			"default": "./src/lib/resolve-bearer-auth.ts"
+		},
+		"./oauth-audiences": {
+			"types": "./src/lib/oauth-audiences.ts",
+			"default": "./src/lib/oauth-audiences.ts"
 		}
 	},
 	"scripts": {

--- a/packages/auth/src/lib/oauth-audiences.ts
+++ b/packages/auth/src/lib/oauth-audiences.ts
@@ -1,0 +1,8 @@
+import { env } from "../env";
+
+export const VALID_OAUTH_AUDIENCES = [
+	env.NEXT_PUBLIC_API_URL,
+	`${env.NEXT_PUBLIC_API_URL}/`,
+	`${env.NEXT_PUBLIC_API_URL}/api/agent/mcp`,
+	`${env.NEXT_PUBLIC_API_URL}/api/v2/agent/mcp`,
+];

--- a/packages/auth/src/lib/oauth-audiences.ts
+++ b/packages/auth/src/lib/oauth-audiences.ts
@@ -1,8 +1,24 @@
 import { env } from "../env";
 
+const apiUrl = env.NEXT_PUBLIC_API_URL;
+
+/** Audiences accepted on general API (tRPC) routes. */
+export const TRPC_AUDIENCES = [apiUrl, `${apiUrl}/`];
+
+/** Audiences accepted on MCP routes (general API + MCP-specific paths). */
+export const MCP_AUDIENCES = [
+	apiUrl,
+	`${apiUrl}/`,
+	`${apiUrl}/api/agent/mcp`,
+	`${apiUrl}/api/v2/agent/mcp`,
+];
+
+/**
+ * The full set of resource indicators a client is allowed to request when
+ * exchanging an OAuth code for a token. Used by the OAuth provider config —
+ * NOT for verifying token audience at use time (use `TRPC_AUDIENCES` /
+ * `MCP_AUDIENCES` per resource server).
+ */
 export const VALID_OAUTH_AUDIENCES = [
-	env.NEXT_PUBLIC_API_URL,
-	`${env.NEXT_PUBLIC_API_URL}/`,
-	`${env.NEXT_PUBLIC_API_URL}/api/agent/mcp`,
-	`${env.NEXT_PUBLIC_API_URL}/api/v2/agent/mcp`,
+	...new Set([...TRPC_AUDIENCES, ...MCP_AUDIENCES]),
 ];

--- a/packages/auth/src/lib/oauth-audiences.ts
+++ b/packages/auth/src/lib/oauth-audiences.ts
@@ -5,20 +5,15 @@ const apiUrl = env.NEXT_PUBLIC_API_URL;
 /** Audiences accepted on general API (tRPC) routes. */
 export const TRPC_AUDIENCES = [apiUrl, `${apiUrl}/`];
 
-/** Audiences accepted on MCP routes (general API + MCP-specific paths). */
+/** Audiences accepted on MCP routes — tRPC's plus MCP-specific paths. */
 export const MCP_AUDIENCES = [
-	apiUrl,
-	`${apiUrl}/`,
+	...TRPC_AUDIENCES,
 	`${apiUrl}/api/agent/mcp`,
 	`${apiUrl}/api/v2/agent/mcp`,
 ];
 
 /**
- * The full set of resource indicators a client is allowed to request when
- * exchanging an OAuth code for a token. Used by the OAuth provider config —
- * NOT for verifying token audience at use time (use `TRPC_AUDIENCES` /
- * `MCP_AUDIENCES` per resource server).
+ * Resource indicators the OAuth provider is allowed to mint tokens for.
+ * Equals the MCP set since MCP accepts the broadest audience.
  */
-export const VALID_OAUTH_AUDIENCES = [
-	...new Set([...TRPC_AUDIENCES, ...MCP_AUDIENCES]),
-];
+export const VALID_OAUTH_AUDIENCES = MCP_AUDIENCES;

--- a/packages/auth/src/lib/resolve-bearer-auth.ts
+++ b/packages/auth/src/lib/resolve-bearer-auth.ts
@@ -2,7 +2,7 @@ import { db } from "@superset/db/client";
 import { members } from "@superset/db/schema";
 import { ORGANIZATION_HEADER } from "@superset/shared/constants";
 import { verifyAccessToken } from "better-auth/oauth2";
-import { and, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { env } from "../env";
 import { auth } from "../server";
 import { TRPC_AUDIENCES } from "./oauth-audiences";
@@ -36,11 +36,7 @@ export interface BearerAuthResult {
 }
 
 export interface ResolveBearerAuthOptions {
-	/**
-	 * Audiences accepted by this resource server. Tokens whose `aud` claim
-	 * doesn't intersect this list are rejected. Defaults to `TRPC_AUDIENCES`
-	 * (general API routes). Set to `MCP_AUDIENCES` for MCP routes.
-	 */
+	/** Defaults to {@link TRPC_AUDIENCES}. MCP routes pass `MCP_AUDIENCES`. */
 	audiences?: string[];
 }
 
@@ -57,19 +53,14 @@ function extractBearer(headers: Headers): {
 	apiKey?: string;
 	jwt?: string;
 } {
+	// x-api-key takes precedence; only honor it for our own prefix so an
+	// arbitrary header value can't be forwarded to verifyApiKey.
 	const xApiKey = headers.get("x-api-key")?.trim();
-	if (xApiKey) {
-		// Only accept x-api-key values that match our prefix. An arbitrary
-		// header value should not be forwarded to verifyApiKey.
-		if (isApiKey(xApiKey)) return { apiKey: xApiKey };
-		return {};
-	}
+	if (xApiKey) return isApiKey(xApiKey) ? { apiKey: xApiKey } : {};
 
-	const authHeader = headers.get("authorization");
-	const match = authHeader?.match(/^Bearer\s+(.+)$/i);
+	const match = headers.get("authorization")?.match(/^Bearer\s+(.+)$/i);
 	const token = match?.[1]?.trim();
 	if (!token) return {};
-
 	if (isApiKey(token)) return { apiKey: token };
 	if (looksLikeJwt(token)) return { jwt: token };
 	return {};
@@ -91,30 +82,6 @@ function parseApiKeyMetadata(metadata: unknown): Record<string, unknown> {
 		: {};
 }
 
-async function resolveOrgFromHeader(
-	headers: Headers,
-	userId: string,
-	fallback: string | null,
-): Promise<string | null> {
-	const requested = headers.get(ORGANIZATION_HEADER)?.trim() || null;
-	if (!requested || requested === fallback) return fallback;
-
-	const membership = await db.query.members.findFirst({
-		where: and(
-			eq(members.userId, userId),
-			eq(members.organizationId, requested),
-		),
-		columns: { id: true },
-	});
-	if (!membership) {
-		throw new BearerAuthError(
-			"forbidden_org",
-			`Not a member of organization ${requested}`,
-		);
-	}
-	return requested;
-}
-
 async function listOrganizationIds(userId: string): Promise<string[]> {
 	const rows = await db.query.members.findMany({
 		where: eq(members.userId, userId),
@@ -124,13 +91,32 @@ async function listOrganizationIds(userId: string): Promise<string[]> {
 }
 
 /**
+ * Pick the active org: header override (validated against membership) wins,
+ * otherwise the claim (from JWT / API-key metadata).
+ */
+function resolveActiveOrg(
+	headers: Headers,
+	organizationIds: string[],
+	claimed: string | null,
+): string | null {
+	const requested = headers.get(ORGANIZATION_HEADER)?.trim() || null;
+	if (!requested) return claimed;
+	if (!organizationIds.includes(requested)) {
+		throw new BearerAuthError(
+			"forbidden_org",
+			`Not a member of organization ${requested}`,
+		);
+	}
+	return requested;
+}
+
+/**
  * Validates an `Authorization: Bearer …` JWT or an `x-api-key` header.
  *
- * - Returns `null` when no bearer/api-key header is present (caller should
- *   fall back to other auth, e.g. cookie session).
- * - Throws `BearerAuthError` when a bearer IS present but invalid or
- *   forbidden — never silently falls through, so callers don't accidentally
- *   authenticate a stale-token request via cookie.
+ * Returns `null` only when no bearer is present — caller falls back to other
+ * auth (e.g. cookie session). Throws `BearerAuthError` when a bearer IS
+ * present but invalid or forbidden, so callers don't accidentally accept a
+ * stale-token request via cookie.
  */
 export async function resolveBearerAuth(
 	headers: Headers,
@@ -143,32 +129,28 @@ export async function resolveBearerAuth(
 		if (!result.valid || !result.key) {
 			throw new BearerAuthError("invalid_api_key", "API key invalid");
 		}
-
-		const userId = result.key.referenceId ?? null;
+		const userId = result.key.referenceId;
 		if (!userId) {
 			throw new BearerAuthError(
 				"invalid_api_key",
 				"API key has no associated user",
 			);
 		}
-
 		const metadata = parseApiKeyMetadata(result.key.metadata);
 		const claimedOrg =
 			typeof metadata.organizationId === "string"
 				? metadata.organizationId
 				: null;
-
-		const activeOrganizationId = await resolveOrgFromHeader(
-			headers,
-			userId,
-			claimedOrg,
-		);
-
+		const organizationIds = await listOrganizationIds(userId);
 		return {
 			kind: "apiKey",
 			userId,
-			activeOrganizationId,
-			organizationIds: await listOrganizationIds(userId),
+			activeOrganizationId: resolveActiveOrg(
+				headers,
+				organizationIds,
+				claimedOrg,
+			),
+			organizationIds,
 			scopes: [],
 		};
 	}
@@ -189,35 +171,30 @@ export async function resolveBearerAuth(
 				error instanceof Error ? error.message : "JWT verification failed",
 			);
 		}
-
 		const userId = typeof payload.sub === "string" ? payload.sub : null;
 		if (!userId) {
 			throw new BearerAuthError("invalid_token", "JWT missing sub claim");
 		}
-
 		const claimedOrg =
 			typeof payload.organizationId === "string"
 				? payload.organizationId
 				: null;
-
-		const activeOrganizationId = await resolveOrgFromHeader(
-			headers,
-			userId,
-			claimedOrg,
-		);
-
 		const scopes = Array.isArray(payload.scope)
 			? (payload.scope as string[])
 			: typeof payload.scope === "string"
 				? payload.scope.split(" ")
 				: [];
-
+		const organizationIds = await listOrganizationIds(userId);
 		return {
 			kind: "jwt",
 			userId,
 			email: typeof payload.email === "string" ? payload.email : undefined,
-			activeOrganizationId,
-			organizationIds: await listOrganizationIds(userId),
+			activeOrganizationId: resolveActiveOrg(
+				headers,
+				organizationIds,
+				claimedOrg,
+			),
+			organizationIds,
 			scopes,
 		};
 	}

--- a/packages/auth/src/lib/resolve-bearer-auth.ts
+++ b/packages/auth/src/lib/resolve-bearer-auth.ts
@@ -1,0 +1,172 @@
+import { db } from "@superset/db/client";
+import { members } from "@superset/db/schema";
+import { ORGANIZATION_HEADER } from "@superset/shared/constants";
+import { verifyAccessToken } from "better-auth/oauth2";
+import { and, eq } from "drizzle-orm";
+import { env } from "../env";
+import { auth } from "../server";
+import { VALID_OAUTH_AUDIENCES } from "./oauth-audiences";
+
+const apiUrl = env.NEXT_PUBLIC_API_URL.replace(/\/+$/, "");
+
+export type BearerAuthKind = "jwt" | "apiKey";
+
+export interface BearerAuthResult {
+	kind: BearerAuthKind;
+	userId: string;
+	email?: string;
+	activeOrganizationId: string | null;
+	organizationIds: string[];
+	scopes: string[];
+}
+
+function looksLikeJwt(token: string): boolean {
+	const parts = token.split(".");
+	return parts.length === 3 && parts.every(Boolean);
+}
+
+function isApiKey(token: string): boolean {
+	return token.startsWith("sk_live_");
+}
+
+function extractBearer(headers: Headers): {
+	apiKey?: string;
+	jwt?: string;
+} {
+	const apiKey = headers.get("x-api-key")?.trim();
+	if (apiKey) return { apiKey };
+
+	const authHeader = headers.get("authorization");
+	const match = authHeader?.match(/^Bearer\s+(.+)$/i);
+	const token = match?.[1]?.trim();
+	if (!token) return {};
+
+	if (isApiKey(token)) return { apiKey: token };
+	if (looksLikeJwt(token)) return { jwt: token };
+	return {};
+}
+
+function parseApiKeyMetadata(metadata: unknown): Record<string, unknown> {
+	if (typeof metadata === "string") {
+		try {
+			const parsed = JSON.parse(metadata);
+			return parsed && typeof parsed === "object"
+				? (parsed as Record<string, unknown>)
+				: {};
+		} catch {
+			return {};
+		}
+	}
+	return metadata && typeof metadata === "object"
+		? (metadata as Record<string, unknown>)
+		: {};
+}
+
+async function resolveOrgFromHeader(
+	headers: Headers,
+	userId: string,
+	fallback: string | null,
+): Promise<string | null> {
+	const requested = headers.get(ORGANIZATION_HEADER)?.trim() || null;
+	if (!requested || requested === fallback) return fallback;
+
+	const membership = await db.query.members.findFirst({
+		where: and(
+			eq(members.userId, userId),
+			eq(members.organizationId, requested),
+		),
+		columns: { id: true },
+	});
+	if (!membership) {
+		throw new Error(`Not a member of organization ${requested}`);
+	}
+	return requested;
+}
+
+async function listOrganizationIds(userId: string): Promise<string[]> {
+	const rows = await db.query.members.findMany({
+		where: eq(members.userId, userId),
+		columns: { organizationId: true },
+	});
+	return [...new Set(rows.map((r) => r.organizationId))];
+}
+
+export async function resolveBearerAuth(
+	headers: Headers,
+): Promise<BearerAuthResult | null> {
+	const { apiKey, jwt } = extractBearer(headers);
+
+	if (apiKey) {
+		const result = await auth.api.verifyApiKey({ body: { key: apiKey } });
+		if (!result.valid || !result.key) return null;
+
+		const userId = result.key.referenceId ?? null;
+		if (!userId) return null;
+
+		const metadata = parseApiKeyMetadata(result.key.metadata);
+		const claimedOrg =
+			typeof metadata.organizationId === "string"
+				? metadata.organizationId
+				: null;
+
+		const activeOrganizationId = await resolveOrgFromHeader(
+			headers,
+			userId,
+			claimedOrg,
+		);
+
+		return {
+			kind: "apiKey",
+			userId,
+			activeOrganizationId,
+			organizationIds: await listOrganizationIds(userId),
+			scopes: [],
+		};
+	}
+
+	if (jwt) {
+		let payload: Record<string, unknown>;
+		try {
+			payload = (await verifyAccessToken(jwt, {
+				jwksUrl: `${apiUrl}/api/auth/jwks`,
+				verifyOptions: {
+					issuer: apiUrl,
+					audience: VALID_OAUTH_AUDIENCES,
+				},
+			})) as Record<string, unknown>;
+		} catch {
+			return null;
+		}
+
+		const userId = typeof payload.sub === "string" ? payload.sub : null;
+		if (!userId) return null;
+
+		const claimedOrg =
+			typeof payload.organizationId === "string"
+				? payload.organizationId
+				: null;
+
+		const activeOrganizationId = await resolveOrgFromHeader(
+			headers,
+			userId,
+			claimedOrg,
+		);
+
+		const scopes = Array.isArray(payload.scope)
+			? (payload.scope as string[])
+			: typeof payload.scope === "string"
+				? payload.scope.split(" ")
+				: [];
+
+		return {
+			kind: "jwt",
+			userId,
+			email: typeof payload.email === "string" ? payload.email : undefined,
+			activeOrganizationId,
+			organizationIds: await listOrganizationIds(userId),
+			scopes,
+		};
+	}
+
+	return null;
+}

--- a/packages/auth/src/lib/resolve-bearer-auth.ts
+++ b/packages/auth/src/lib/resolve-bearer-auth.ts
@@ -7,7 +7,7 @@ import { env } from "../env";
 import { auth } from "../server";
 import { TRPC_AUDIENCES } from "./oauth-audiences";
 
-const apiUrl = env.NEXT_PUBLIC_API_URL.replace(/\/+$/, "");
+const apiUrl = env.NEXT_PUBLIC_API_URL;
 
 export type BearerAuthKind = "jwt" | "apiKey";
 
@@ -49,21 +49,26 @@ function isApiKey(token: string): boolean {
 	return token.startsWith("sk_live_");
 }
 
-function extractBearer(headers: Headers): {
-	apiKey?: string;
-	jwt?: string;
-} {
-	// x-api-key takes precedence; only honor it for our own prefix so an
-	// arbitrary header value can't be forwarded to verifyApiKey.
+type ExtractedBearer =
+	| { apiKey: string }
+	| { jwt: string }
+	| { malformed: "api_key" | "token" }
+	| { none: true };
+
+function extractBearer(headers: Headers): ExtractedBearer {
+	// x-api-key takes precedence. Only forward our own prefix to verifyApiKey;
+	// anything else with this header is malformed (rejected, not fallthrough).
 	const xApiKey = headers.get("x-api-key")?.trim();
-	if (xApiKey) return isApiKey(xApiKey) ? { apiKey: xApiKey } : {};
+	if (xApiKey) {
+		return isApiKey(xApiKey) ? { apiKey: xApiKey } : { malformed: "api_key" };
+	}
 
 	const match = headers.get("authorization")?.match(/^Bearer\s+(.+)$/i);
 	const token = match?.[1]?.trim();
-	if (!token) return {};
+	if (!token) return { none: true };
 	if (isApiKey(token)) return { apiKey: token };
 	if (looksLikeJwt(token)) return { jwt: token };
-	return {};
+	return { malformed: "token" };
 }
 
 function parseApiKeyMetadata(metadata: unknown): Record<string, unknown> {
@@ -122,7 +127,21 @@ export async function resolveBearerAuth(
 	headers: Headers,
 	options: ResolveBearerAuthOptions = {},
 ): Promise<BearerAuthResult | null> {
-	const { apiKey, jwt } = extractBearer(headers);
+	const extracted = extractBearer(headers);
+
+	if ("malformed" in extracted) {
+		throw new BearerAuthError(
+			extracted.malformed === "api_key" ? "invalid_api_key" : "invalid_token",
+			extracted.malformed === "api_key"
+				? "Malformed API key"
+				: "Malformed bearer token",
+		);
+	}
+
+	if ("none" in extracted) return null;
+
+	const apiKey = "apiKey" in extracted ? extracted.apiKey : undefined;
+	const jwt = "jwt" in extracted ? extracted.jwt : undefined;
 
 	if (apiKey) {
 		const result = await auth.api.verifyApiKey({ body: { key: apiKey } });

--- a/packages/auth/src/lib/resolve-bearer-auth.ts
+++ b/packages/auth/src/lib/resolve-bearer-auth.ts
@@ -5,11 +5,26 @@ import { verifyAccessToken } from "better-auth/oauth2";
 import { and, eq } from "drizzle-orm";
 import { env } from "../env";
 import { auth } from "../server";
-import { VALID_OAUTH_AUDIENCES } from "./oauth-audiences";
+import { TRPC_AUDIENCES } from "./oauth-audiences";
 
 const apiUrl = env.NEXT_PUBLIC_API_URL.replace(/\/+$/, "");
 
 export type BearerAuthKind = "jwt" | "apiKey";
+
+export type BearerAuthErrorReason =
+	| "invalid_token"
+	| "invalid_api_key"
+	| "forbidden_org";
+
+export class BearerAuthError extends Error {
+	constructor(
+		public readonly reason: BearerAuthErrorReason,
+		message: string,
+	) {
+		super(message);
+		this.name = "BearerAuthError";
+	}
+}
 
 export interface BearerAuthResult {
 	kind: BearerAuthKind;
@@ -18,6 +33,15 @@ export interface BearerAuthResult {
 	activeOrganizationId: string | null;
 	organizationIds: string[];
 	scopes: string[];
+}
+
+export interface ResolveBearerAuthOptions {
+	/**
+	 * Audiences accepted by this resource server. Tokens whose `aud` claim
+	 * doesn't intersect this list are rejected. Defaults to `TRPC_AUDIENCES`
+	 * (general API routes). Set to `MCP_AUDIENCES` for MCP routes.
+	 */
+	audiences?: string[];
 }
 
 function looksLikeJwt(token: string): boolean {
@@ -33,8 +57,13 @@ function extractBearer(headers: Headers): {
 	apiKey?: string;
 	jwt?: string;
 } {
-	const apiKey = headers.get("x-api-key")?.trim();
-	if (apiKey) return { apiKey };
+	const xApiKey = headers.get("x-api-key")?.trim();
+	if (xApiKey) {
+		// Only accept x-api-key values that match our prefix. An arbitrary
+		// header value should not be forwarded to verifyApiKey.
+		if (isApiKey(xApiKey)) return { apiKey: xApiKey };
+		return {};
+	}
 
 	const authHeader = headers.get("authorization");
 	const match = authHeader?.match(/^Bearer\s+(.+)$/i);
@@ -78,7 +107,10 @@ async function resolveOrgFromHeader(
 		columns: { id: true },
 	});
 	if (!membership) {
-		throw new Error(`Not a member of organization ${requested}`);
+		throw new BearerAuthError(
+			"forbidden_org",
+			`Not a member of organization ${requested}`,
+		);
 	}
 	return requested;
 }
@@ -91,17 +123,34 @@ async function listOrganizationIds(userId: string): Promise<string[]> {
 	return [...new Set(rows.map((r) => r.organizationId))];
 }
 
+/**
+ * Validates an `Authorization: Bearer …` JWT or an `x-api-key` header.
+ *
+ * - Returns `null` when no bearer/api-key header is present (caller should
+ *   fall back to other auth, e.g. cookie session).
+ * - Throws `BearerAuthError` when a bearer IS present but invalid or
+ *   forbidden — never silently falls through, so callers don't accidentally
+ *   authenticate a stale-token request via cookie.
+ */
 export async function resolveBearerAuth(
 	headers: Headers,
+	options: ResolveBearerAuthOptions = {},
 ): Promise<BearerAuthResult | null> {
 	const { apiKey, jwt } = extractBearer(headers);
 
 	if (apiKey) {
 		const result = await auth.api.verifyApiKey({ body: { key: apiKey } });
-		if (!result.valid || !result.key) return null;
+		if (!result.valid || !result.key) {
+			throw new BearerAuthError("invalid_api_key", "API key invalid");
+		}
 
 		const userId = result.key.referenceId ?? null;
-		if (!userId) return null;
+		if (!userId) {
+			throw new BearerAuthError(
+				"invalid_api_key",
+				"API key has no associated user",
+			);
+		}
 
 		const metadata = parseApiKeyMetadata(result.key.metadata);
 		const claimedOrg =
@@ -131,15 +180,20 @@ export async function resolveBearerAuth(
 				jwksUrl: `${apiUrl}/api/auth/jwks`,
 				verifyOptions: {
 					issuer: apiUrl,
-					audience: VALID_OAUTH_AUDIENCES,
+					audience: options.audiences ?? TRPC_AUDIENCES,
 				},
 			})) as Record<string, unknown>;
-		} catch {
-			return null;
+		} catch (error) {
+			throw new BearerAuthError(
+				"invalid_token",
+				error instanceof Error ? error.message : "JWT verification failed",
+			);
 		}
 
 		const userId = typeof payload.sub === "string" ? payload.sub : null;
-		if (!userId) return null;
+		if (!userId) {
+			throw new BearerAuthError("invalid_token", "JWT missing sub claim");
+		}
 
 		const claimedOrg =
 			typeof payload.organizationId === "string"

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -27,6 +27,7 @@ import type Stripe from "stripe";
 import { env } from "./env";
 import { acceptInvitationEndpoint } from "./lib/accept-invitation-endpoint";
 import { generateMagicTokenForInvite } from "./lib/generate-magic-token";
+import { VALID_OAUTH_AUDIENCES } from "./lib/oauth-audiences";
 import { invitationRateLimit } from "./lib/rate-limit";
 import { resend } from "./lib/resend";
 import {
@@ -202,12 +203,7 @@ export const auth = betterAuth({
 			consentPage: `${env.NEXT_PUBLIC_WEB_URL}/oauth/consent`,
 			allowDynamicClientRegistration: true,
 			allowUnauthenticatedClientRegistration: true,
-			validAudiences: [
-				env.NEXT_PUBLIC_API_URL,
-				`${env.NEXT_PUBLIC_API_URL}/`,
-				`${env.NEXT_PUBLIC_API_URL}/api/agent/mcp`,
-				`${env.NEXT_PUBLIC_API_URL}/api/v2/agent/mcp`,
-			],
+			validAudiences: VALID_OAUTH_AUDIENCES,
 			silenceWarnings: {
 				oauthAuthServerConfig: true,
 				openidConfig: true,

--- a/packages/trpc/src/router/automation/automation.ts
+++ b/packages/trpc/src/router/automation/automation.ts
@@ -21,7 +21,7 @@ import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
 import { and, desc, eq } from "drizzle-orm";
 import { z } from "zod";
 import { env } from "../../env";
-import { protectedProcedure } from "../../trpc";
+import { bearerProcedure, protectedProcedure } from "../../trpc";
 import {
 	requireActiveOrgMembership,
 	requireActiveOrgMembershipWithSubscription,
@@ -157,7 +157,7 @@ async function getAutomationForUser(
 
 export const automationRouter = {
 	/** List automations scoped to the caller's active organization. */
-	list: protectedProcedure.query(async ({ ctx }) => {
+	list: bearerProcedure.query(async ({ ctx }) => {
 		const organizationId = await requireActiveOrgMembership(ctx);
 
 		const rows = await db
@@ -173,12 +173,12 @@ export const automationRouter = {
 	}),
 
 	/** Get one automation. Use listRuns for run history. */
-	get: protectedProcedure
+	get: bearerProcedure
 		.input(z.object({ id: z.string().uuid() }))
 		.query(async ({ ctx, input }) => {
 			const organizationId = await requireActiveOrgMembership(ctx);
 			const automation = await getAutomationForUser(
-				ctx.session.user.id,
+				ctx.userId,
 				organizationId,
 				input.id,
 			);
@@ -188,7 +188,7 @@ export const automationRouter = {
 			};
 		}),
 
-	create: protectedProcedure
+	create: bearerProcedure
 		.input(createAutomationSchema)
 		.mutation(async ({ ctx, input }) => {
 			const { organizationId, subscription } =
@@ -196,11 +196,7 @@ export const automationRouter = {
 			requirePaidSubscription(subscription);
 
 			if (input.targetHostId) {
-				await verifyHostAccess(
-					ctx.session.user.id,
-					organizationId,
-					input.targetHostId,
-				);
+				await verifyHostAccess(ctx.userId, organizationId, input.targetHostId);
 			}
 
 			let v2ProjectId = input.v2ProjectId;
@@ -238,7 +234,7 @@ export const automationRouter = {
 				.insert(automations)
 				.values({
 					organizationId,
-					ownerUserId: ctx.session.user.id,
+					ownerUserId: ctx.userId,
 					name: input.name,
 					prompt: input.prompt,
 					agentConfig: input.agentConfig,
@@ -256,22 +252,18 @@ export const automationRouter = {
 			return { ...created, scheduleText: safeDescribeRrule(created) };
 		}),
 
-	update: protectedProcedure
+	update: bearerProcedure
 		.input(updateAutomationSchema)
 		.mutation(async ({ ctx, input }) => {
 			const organizationId = await requireActiveOrgMembership(ctx);
 			const existing = await getAutomationForUser(
-				ctx.session.user.id,
+				ctx.userId,
 				organizationId,
 				input.id,
 			);
 
 			if (input.targetHostId !== undefined && input.targetHostId !== null) {
-				await verifyHostAccess(
-					ctx.session.user.id,
-					organizationId,
-					input.targetHostId,
-				);
+				await verifyHostAccess(ctx.userId, organizationId, input.targetHostId);
 			}
 			if (input.v2WorkspaceId) {
 				await verifyWorkspaceInOrg(organizationId, input.v2WorkspaceId);
@@ -319,23 +311,23 @@ export const automationRouter = {
 			return { ...updated, scheduleText: safeDescribeRrule(updated) };
 		}),
 
-	getPrompt: protectedProcedure
+	getPrompt: bearerProcedure
 		.input(z.object({ id: z.string().uuid() }))
 		.query(async ({ ctx, input }) => {
 			const organizationId = await requireActiveOrgMembership(ctx);
 			const existing = await getAutomationForUser(
-				ctx.session.user.id,
+				ctx.userId,
 				organizationId,
 				input.id,
 			);
 			return { id: existing.id, prompt: existing.prompt };
 		}),
 
-	setPrompt: protectedProcedure
+	setPrompt: bearerProcedure
 		.input(setAutomationPromptSchema)
 		.mutation(async ({ ctx, input }) => {
 			const organizationId = await requireActiveOrgMembership(ctx);
-			await getAutomationForUser(ctx.session.user.id, organizationId, input.id);
+			await getAutomationForUser(ctx.userId, organizationId, input.id);
 
 			const [updated] = await dbWs
 				.update(automations)
@@ -346,18 +338,18 @@ export const automationRouter = {
 			return { ...updated, scheduleText: safeDescribeRrule(updated) };
 		}),
 
-	delete: protectedProcedure
+	delete: bearerProcedure
 		.input(z.object({ id: z.string().uuid() }))
 		.mutation(async ({ ctx, input }) => {
 			const organizationId = await requireActiveOrgMembership(ctx);
-			await getAutomationForUser(ctx.session.user.id, organizationId, input.id);
+			await getAutomationForUser(ctx.userId, organizationId, input.id);
 
 			await dbWs.delete(automations).where(eq(automations.id, input.id));
 
 			return { ok: true };
 		}),
 
-	setEnabled: protectedProcedure
+	setEnabled: bearerProcedure
 		.input(z.object({ id: z.string().uuid(), enabled: z.boolean() }))
 		.mutation(async ({ ctx, input }) => {
 			const { organizationId, subscription } =
@@ -366,7 +358,7 @@ export const automationRouter = {
 				requirePaidSubscription(subscription);
 			}
 			const existing = await getAutomationForUser(
-				ctx.session.user.id,
+				ctx.userId,
 				organizationId,
 				input.id,
 			);
@@ -394,14 +386,14 @@ export const automationRouter = {
 			return { ...updated, scheduleText: safeDescribeRrule(updated) };
 		}),
 
-	runNow: protectedProcedure
+	runNow: bearerProcedure
 		.input(z.object({ id: z.string().uuid() }))
 		.mutation(async ({ ctx, input }) => {
 			const { organizationId, subscription } =
 				await requireActiveOrgMembershipWithSubscription(ctx);
 			requirePaidSubscription(subscription);
 			const automation = await getAutomationForUser(
-				ctx.session.user.id,
+				ctx.userId,
 				organizationId,
 				input.id,
 			);
@@ -446,7 +438,7 @@ export const automationRouter = {
 		.query(async ({ ctx, input }) => {
 			const organizationId = await requireActiveOrgMembership(ctx);
 			await getAutomationForUser(
-				ctx.session.user.id,
+				ctx.userId,
 				organizationId,
 				input.automationId,
 			);

--- a/packages/trpc/src/router/host/host.ts
+++ b/packages/trpc/src/router/host/host.ts
@@ -15,10 +15,10 @@ import { parseHostRoutingKey } from "@superset/shared/host-routing";
 import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
 import { and, desc, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
-import { jwtProcedure, protectedProcedure } from "../../trpc";
+import { bearerProcedure, protectedProcedure } from "../../trpc";
 
 export const hostRouter = {
-	list: jwtProcedure
+	list: bearerProcedure
 		.input(z.object({ organizationId: z.string().uuid() }))
 		.query(async ({ ctx, input }) => {
 			if (!ctx.organizationIds.includes(input.organizationId)) {
@@ -58,7 +58,7 @@ export const hostRouter = {
 			}));
 		}),
 
-	ensure: jwtProcedure
+	ensure: bearerProcedure
 		.input(
 			z.object({
 				organizationId: z.string().uuid(),
@@ -166,7 +166,7 @@ export const hostRouter = {
 			return client;
 		}),
 
-	checkAccess: jwtProcedure
+	checkAccess: bearerProcedure
 		.input(z.object({ hostId: z.string().min(1) }))
 		.query(async ({ ctx, input }) => {
 			const parsed = parseHostRoutingKey(input.hostId);
@@ -206,7 +206,7 @@ export const hostRouter = {
 			return { allowed, paidPlan };
 		}),
 
-	setOnline: jwtProcedure
+	setOnline: bearerProcedure
 		.input(z.object({ hostId: z.string().min(1), isOnline: z.boolean() }))
 		.mutation(async ({ ctx, input }) => {
 			const parsed = parseHostRoutingKey(input.hostId);

--- a/packages/trpc/src/router/task/task.ts
+++ b/packages/trpc/src/router/task/task.ts
@@ -11,7 +11,7 @@ import { and, desc, eq, ilike, isNull } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { z } from "zod";
 import { syncTask } from "../../lib/integrations/sync";
-import { protectedProcedure, type TRPCContext } from "../../trpc";
+import { bearerProcedure, protectedProcedure } from "../../trpc";
 import { verifyOrgMembership } from "../integration/utils";
 import { requireActiveOrgMembership } from "../utils/active-org";
 import {
@@ -173,7 +173,7 @@ async function getScopedAssigneeId(
 }
 
 type CreateTaskContext = {
-	session: NonNullable<TRPCContext["session"]>;
+	userId: string;
 	activeOrganizationId: string | null;
 };
 
@@ -228,7 +228,7 @@ async function createTask(
 						statusId,
 						priority: input.priority ?? "none",
 						organizationId,
-						creatorId: ctx.session.user.id,
+						creatorId: ctx.userId,
 						assigneeId,
 						estimate: input.estimate ?? null,
 						dueDate: input.dueDate ?? null,
@@ -297,7 +297,7 @@ export const taskRouter = {
 			.orderBy(desc(tasks.createdAt));
 	}),
 
-	list: protectedProcedure
+	list: bearerProcedure
 		.input(taskListInputSchema)
 		.query(async ({ ctx, input }) => {
 			const organizationId = await requireActiveOrgMembership(ctx);
@@ -313,12 +313,12 @@ export const taskRouter = {
 			if (input?.priority) filters.push(eq(tasks.priority, input.priority));
 			if (input?.statusId) filters.push(eq(tasks.statusId, input.statusId));
 			if (input?.assigneeMe) {
-				filters.push(eq(tasks.assigneeId, ctx.session.user.id));
+				filters.push(eq(tasks.assigneeId, ctx.userId));
 			} else if (input?.assigneeId) {
 				filters.push(eq(tasks.assigneeId, input.assigneeId));
 			}
 			if (input?.creatorMe) {
-				filters.push(eq(tasks.creatorId, ctx.session.user.id));
+				filters.push(eq(tasks.creatorId, ctx.userId));
 			}
 			if (input?.search) {
 				filters.push(
@@ -354,7 +354,7 @@ export const taskRouter = {
 	byOrganization: protectedProcedure
 		.input(z.string().uuid())
 		.query(async ({ ctx, input }) => {
-			await verifyOrgMembership(ctx.session.user.id, input);
+			await verifyOrgMembership(ctx.userId, input);
 
 			return db
 				.select()
@@ -365,14 +365,14 @@ export const taskRouter = {
 
 	byId: protectedProcedure
 		.input(z.string().uuid())
-		.query(({ ctx, input }) => getTaskById(ctx.session.user.id, input)),
+		.query(({ ctx, input }) => getTaskById(ctx.userId, input)),
 
 	bySlug: protectedProcedure.input(z.string()).query(async ({ ctx, input }) => {
 		const organizationId = await requireActiveOrgMembership(ctx);
-		return getTaskBySlug(ctx.session.user.id, organizationId, input);
+		return getTaskBySlug(ctx.userId, organizationId, input);
 	}),
 
-	byIdOrSlug: protectedProcedure
+	byIdOrSlug: bearerProcedure
 		.input(z.string().min(1))
 		.query(async ({ ctx, input }) => {
 			const looksLikeUuid =
@@ -380,11 +380,11 @@ export const taskRouter = {
 					input,
 				);
 			if (looksLikeUuid) {
-				const task = await getTaskById(ctx.session.user.id, input);
+				const task = await getTaskById(ctx.userId, input);
 				if (task) return task;
 			}
 			const organizationId = await requireActiveOrgMembership(ctx);
-			return getTaskBySlug(ctx.session.user.id, organizationId, input);
+			return getTaskBySlug(ctx.userId, organizationId, input);
 		}),
 
 	/**
@@ -396,17 +396,17 @@ export const taskRouter = {
 		.input(createTaskSchema)
 		.mutation(({ ctx, input }) => createTask(ctx, input)),
 
-	create: protectedProcedure
+	create: bearerProcedure
 		.input(createTaskSchema)
 		.mutation(({ ctx, input }) => createTask(ctx, input)),
 
-	update: protectedProcedure
+	update: bearerProcedure
 		.input(updateTaskSchema)
 		.mutation(async ({ ctx, input }) => {
 			const { id, ...data } = input;
 
 			const result = await dbWs.transaction(async (tx) => {
-				const taskAccess = await getTaskAccess(tx, ctx.session.user.id, id);
+				const taskAccess = await getTaskAccess(tx, ctx.userId, id);
 
 				// Enforce assignee invariant: setting internal assignee clears external snapshot
 				const updateData: Record<string, unknown> = { ...data };
@@ -450,11 +450,11 @@ export const taskRouter = {
 			return result;
 		}),
 
-	delete: protectedProcedure
+	delete: bearerProcedure
 		.input(z.string().uuid())
 		.mutation(async ({ ctx, input }) => {
 			const result = await dbWs.transaction(async (tx) => {
-				await getTaskAccess(tx, ctx.session.user.id, input);
+				await getTaskAccess(tx, ctx.userId, input);
 
 				const [deleted] = await tx
 					.update(tasks)

--- a/packages/trpc/src/router/user/user.ts
+++ b/packages/trpc/src/router/user/user.ts
@@ -5,21 +5,29 @@ import { and, desc, eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { generateImagePathname, uploadImage } from "../../lib/upload";
-import { protectedProcedure } from "../../trpc";
+import { bearerProcedure, protectedProcedure } from "../../trpc";
 
 export const userRouter = {
-	me: protectedProcedure.query(({ ctx }) => ctx.session.user),
+	me: bearerProcedure.query(async ({ ctx }) => {
+		const user = await db.query.users.findFirst({
+			where: eq(users.id, ctx.userId),
+		});
+		if (!user) {
+			throw new TRPCError({ code: "NOT_FOUND", message: "User not found" });
+		}
+		return user;
+	}),
 
-	myOrganization: protectedProcedure.query(async ({ ctx }) => {
+	myOrganization: bearerProcedure.query(async ({ ctx }) => {
 		const activeOrganizationId = ctx.activeOrganizationId;
 
 		const membership = await db.query.members.findFirst({
 			where: activeOrganizationId
 				? and(
-						eq(members.userId, ctx.session.user.id),
+						eq(members.userId, ctx.userId),
 						eq(members.organizationId, activeOrganizationId),
 					)
-				: eq(members.userId, ctx.session.user.id),
+				: eq(members.userId, ctx.userId),
 			orderBy: desc(members.createdAt),
 			with: {
 				organization: true,
@@ -29,9 +37,9 @@ export const userRouter = {
 		return membership?.organization ?? null;
 	}),
 
-	myOrganizations: protectedProcedure.query(async ({ ctx }) => {
+	myOrganizations: bearerProcedure.query(async ({ ctx }) => {
 		const memberships = await db.query.members.findMany({
-			where: eq(members.userId, ctx.session.user.id),
+			where: eq(members.userId, ctx.userId),
 			orderBy: desc(members.createdAt),
 			with: {
 				organization: true,

--- a/packages/trpc/src/router/utils/active-org.ts
+++ b/packages/trpc/src/router/utils/active-org.ts
@@ -1,20 +1,17 @@
 import type { SelectSubscription } from "@superset/db/schema";
 import { TRPCError } from "@trpc/server";
-import type { TRPCContext } from "../../trpc";
 import {
 	verifyOrgMembership,
 	verifyOrgMembershipWithSubscription,
 } from "../integration/utils";
 
-type Session = NonNullable<TRPCContext["session"]>;
-
-type ProtectedContext = {
-	session: Session;
+type ActiveOrgContext = {
+	userId: string;
 	activeOrganizationId: string | null;
 };
 
 export function requireActiveOrgId(
-	ctx: ProtectedContext,
+	ctx: { activeOrganizationId: string | null },
 	message = "No active organization selected",
 ) {
 	const organizationId = ctx.activeOrganizationId;
@@ -30,11 +27,11 @@ export function requireActiveOrgId(
 }
 
 export async function requireActiveOrgMembership(
-	ctx: ProtectedContext,
+	ctx: ActiveOrgContext,
 	message?: string,
 ) {
 	const organizationId = requireActiveOrgId(ctx, message);
-	await verifyOrgMembership(ctx.session.user.id, organizationId);
+	await verifyOrgMembership(ctx.userId, organizationId);
 	return organizationId;
 }
 
@@ -44,7 +41,7 @@ export async function requireActiveOrgMembership(
  * is free vs. the basic call). Use when a procedure needs to gate on plan.
  */
 export async function requireActiveOrgMembershipWithSubscription(
-	ctx: ProtectedContext,
+	ctx: ActiveOrgContext,
 	message?: string,
 ): Promise<{
 	organizationId: string;
@@ -52,7 +49,7 @@ export async function requireActiveOrgMembershipWithSubscription(
 }> {
 	const organizationId = requireActiveOrgId(ctx, message);
 	const { subscription } = await verifyOrgMembershipWithSubscription(
-		ctx.session.user.id,
+		ctx.userId,
 		organizationId,
 	);
 	return { organizationId, subscription };

--- a/packages/trpc/src/trpc.ts
+++ b/packages/trpc/src/trpc.ts
@@ -1,3 +1,4 @@
+import { resolveBearerAuth } from "@superset/auth/resolve-bearer-auth";
 import type { auth, Session } from "@superset/auth/server";
 import { db } from "@superset/db/client";
 import { members } from "@superset/db/schema";
@@ -67,36 +68,33 @@ export const protectedProcedure = t.procedure
 			activeOrganizationId = headerOrgId;
 		}
 
-		return next({ ctx: { ...ctx, activeOrganizationId } });
+		return next({
+			ctx: { ...ctx, activeOrganizationId, userId: ctx.session.user.id },
+		});
 	});
 
-export const jwtProcedure = t.procedure.use(async ({ ctx, next }) => {
-	const authHeader = ctx.headers.get("authorization");
-	const bearer = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
+export const bearerProcedure = t.procedure.use(async ({ ctx, next }) => {
+	let bearerAuth: Awaited<ReturnType<typeof resolveBearerAuth>> = null;
+	try {
+		bearerAuth = await resolveBearerAuth(ctx.headers);
+	} catch (error) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: error instanceof Error ? error.message : "Bearer auth rejected",
+		});
+	}
 
-	if (bearer) {
-		try {
-			const { payload } = await ctx.auth.api.verifyJWT({
-				body: { token: bearer },
-			});
-			if (payload?.sub) {
-				const organizationIds = (payload.organizationIds as string[]) ?? [];
-				return next({
-					ctx: {
-						userId: payload.sub,
-						email: (payload.email as string) ?? "",
-						organizationIds,
-						activeOrganizationId: organizationIds[0] ?? null,
-					},
-				});
-			}
-		} catch (error) {
-			// A live session is the legit fallback for an unverifiable token
-			// (expired/missing). A TRPCError from verifyJWT is an explicit
-			// rejection (revoked/forged) — surface it instead of laundering
-			// it into session auth.
-			if (error instanceof TRPCError) throw error;
-		}
+	if (bearerAuth) {
+		return next({
+			ctx: {
+				userId: bearerAuth.userId,
+				email: bearerAuth.email ?? "",
+				organizationIds: bearerAuth.organizationIds,
+				activeOrganizationId: bearerAuth.activeOrganizationId,
+				authKind: bearerAuth.kind,
+				scopes: bearerAuth.scopes,
+			},
+		});
 	}
 
 	if (ctx.session) {
@@ -106,15 +104,29 @@ export const jwtProcedure = t.procedure.use(async ({ ctx, next }) => {
 			columns: { organizationId: true },
 		});
 		const organizationIds = memberRows.map((row) => row.organizationId);
+
+		const sessionOrgId = ctx.session.session.activeOrganizationId ?? null;
+		const headerOrgId = ctx.headers.get(ORGANIZATION_HEADER)?.trim() || null;
+
+		let activeOrganizationId = sessionOrgId ?? organizationIds[0] ?? null;
+		if (headerOrgId && headerOrgId !== sessionOrgId) {
+			if (!organizationIds.includes(headerOrgId)) {
+				throw new TRPCError({
+					code: "FORBIDDEN",
+					message: `Not a member of organization ${headerOrgId}`,
+				});
+			}
+			activeOrganizationId = headerOrgId;
+		}
+
 		return next({
 			ctx: {
 				userId,
 				email: ctx.session.user.email ?? "",
 				organizationIds,
-				activeOrganizationId:
-					ctx.session.session.activeOrganizationId ??
-					organizationIds[0] ??
-					null,
+				activeOrganizationId,
+				authKind: "session" as const,
+				scopes: [] as string[],
 			},
 		});
 	}
@@ -124,6 +136,11 @@ export const jwtProcedure = t.procedure.use(async ({ ctx, next }) => {
 		message: "Not authenticated. Provide a bearer JWT, x-api-key, or session.",
 	});
 });
+
+/**
+ * @deprecated Use {@link bearerProcedure}. Kept as an alias during migration.
+ */
+export const jwtProcedure = bearerProcedure;
 
 export const adminProcedure = protectedProcedure.use(async ({ ctx, next }) => {
 	if (!ctx.session.user.email.endsWith(COMPANY.EMAIL_DOMAIN)) {

--- a/packages/trpc/src/trpc.ts
+++ b/packages/trpc/src/trpc.ts
@@ -1,4 +1,7 @@
-import { resolveBearerAuth } from "@superset/auth/resolve-bearer-auth";
+import {
+	BearerAuthError,
+	resolveBearerAuth,
+} from "@superset/auth/resolve-bearer-auth";
 import type { auth, Session } from "@superset/auth/server";
 import { db } from "@superset/db/client";
 import { members } from "@superset/db/schema";
@@ -78,10 +81,13 @@ export const bearerProcedure = t.procedure.use(async ({ ctx, next }) => {
 	try {
 		bearerAuth = await resolveBearerAuth(ctx.headers);
 	} catch (error) {
-		throw new TRPCError({
-			code: "FORBIDDEN",
-			message: error instanceof Error ? error.message : "Bearer auth rejected",
-		});
+		if (error instanceof BearerAuthError) {
+			throw new TRPCError({
+				code: error.reason === "forbidden_org" ? "FORBIDDEN" : "UNAUTHORIZED",
+				message: error.message,
+			});
+		}
+		throw error;
 	}
 
 	if (bearerAuth) {


### PR DESCRIPTION
Stacked on #3965 — addresses the maintainability concerns raised during that PR's review (the synthetic Session cast in tRPC context).

## Summary

- Single source of truth: new \`resolveBearerAuth(headers)\` in \`@superset/auth\` validates JWT (via JWKS) or API key (\`sk_live_*\`), honors \`x-superset-organization-id\` header for per-call org override, returns \`{ userId, email, activeOrganizationId, organizationIds, scopes, kind }\`
- v1 MCP route, tRPC \`bearerProcedure\` (renamed from \`jwtProcedure\`), and \`auth.api.getSession\` cookie path all converge through the same resolver
- CLI / SDK-touched tRPC routers migrated from \`protectedProcedure\` to \`bearerProcedure\`. Web-only routers (admin, support, profile mutations) stay on \`protectedProcedure\` with the rich Session shape
- Synthetic-Session fallback in \`apps/api/src/trpc/context.ts\` deleted — back to the original 15-line shape
- \`VALID_OAUTH_AUDIENCES\` extracted to a shared constant — OAuth provider config and bearer resolver no longer keep parallel lists
- Latent bug fixed: mcp-v2's caller sets \`x-superset-organization-id\` but jwtProcedure didn't honor it. Now does.

## Files

**New**
- \`packages/auth/src/lib/resolve-bearer-auth.ts\` — the resolver
- \`packages/auth/src/lib/oauth-audiences.ts\` — shared audience constant

**Refactored**
- \`packages/trpc/src/trpc.ts\` — \`bearerProcedure\` calls \`resolveBearerAuth\`; \`protectedProcedure\` exposes \`ctx.userId\` for shared helpers
- \`packages/trpc/src/router/utils/active-org.ts\` — accepts \`{ userId, activeOrganizationId }\` (works for both procedure types)
- \`apps/api/src/app/api/agent/[transport]/auth-flow.ts\` — thin adapter around \`resolveBearerAuth\`; deletes duplicate JWT/API-key validation
- \`apps/api/src/app/api/agent/[transport]/route.ts\` — drops the now-unused \`apiUrl\`/\`verifyAccessToken\` deps
- \`apps/api/src/trpc/context.ts\` — back to a one-liner \`getSession\` call
- \`packages/auth/src/server.ts\` — uses the shared \`VALID_OAUTH_AUDIENCES\`

**Migrated procedures** (\`protectedProcedure\` → \`bearerProcedure\`)
- \`router/user/user.ts\`: \`me\`, \`myOrganization\`, \`myOrganizations\`
- \`router/task/task.ts\`: \`list\`, \`byIdOrSlug\`, \`create\`, \`update\`, \`delete\`
- \`router/automation/automation.ts\`: \`list\`, \`get\`, \`create\`, \`update\`, \`delete\`, \`getPrompt\`, \`setPrompt\`, \`setEnabled\`, \`runNow\`
- \`router/host/host.ts\`: rename \`jwtProcedure\` import → \`bearerProcedure\`

## Test plan

- [ ] \`bun run typecheck\` (27/27 packages green) ✓
- [ ] \`bun run lint\` ✓
- [ ] **Web cookie path**: load any tRPC dashboard page, confirm \`protectedProcedure\` routes still work
- [ ] **CLI bearer path**: \`superset auth login\` → \`auth whoami\` → migrated commands; verify \`--organization <slug>\` per-call override hits the right org and rejects non-member orgs with 403
- [ ] **SDK bearer path**: integration check with explicit \`organizationId\` per-call
- [ ] **v1 MCP path**: \`/api/agent/mcp\` with both API key and JWT — confirm no regressions
- [ ] \`grep verifyAccessToken\` shows usage only in \`resolve-bearer-auth.ts\` and \`mcp-v2/src/auth.ts\` (the latter is a follow-up)

## Out of scope

- mcp-v2's \`packages/mcp-v2/src/auth.ts\` still has its own \`verifyAccessToken\` call — separate parallel auth path, follow-up to migrate
- Refresh tokens (still pending; \`offline_access\` not requested)
- Migrating web-only \`protectedProcedure\` routes (no need; cookie session is fine)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies bearer auth across CLI, SDK, and MCP via a single resolver in `@superset/auth`, scopes token audiences per route, and removes the synthetic Session fallback while tightening invalid/malformed/forbidden handling.

- **Refactors**
  - Added `resolveBearerAuth(headers, { audiences })` in `@superset/auth` to validate JWT (JWKS) and `sk_live_*` API keys; returns user/org context and throws `BearerAuthError` on invalid/forbidden/malformed.
  - Introduced `TRPC_AUDIENCES` and `MCP_AUDIENCES`; tRPC defaults to TRPC audiences, MCP opts into MCP audiences; OAuth uses `VALID_OAUTH_AUDIENCES`.
  - Added `bearerProcedure` in `@superset/trpc` (keeps `jwtProcedure` as an alias); maps `BearerAuthError` to 401/403; v1 MCP route now calls the same resolver and returns 403 for forbidden org.
  - Removed the synthetic Session fallback from `apps/api/src/trpc/context.ts`; MCP auth-flow drops local JWT verification and `apiUrl`/`verifyAccessToken` deps.
  - Migrated CLI/SDK-touched tRPC routers to `bearerProcedure` and `ctx.userId`: `user.me`/`myOrganization`/`myOrganizations`, `task.list`/`byIdOrSlug`/`create`/`update`/`delete`, and all automation endpoints; host router switches to `bearerProcedure`.

- **Bug Fixes**
  - `x-superset-organization-id` is honored for bearer requests (JWT and API key) across MCP and SDK paths; forbidden org returns 403 with a clear message.
  - Malformed or invalid bearer credentials are rejected with 401 (e.g., non-JWT/non-API-key `Authorization` or non-`sk_live_*` `x-api-key`); no cookie-session fallback.
  - Audience checks are scoped correctly: MCP-scoped tokens cannot call general API routes; expired/invalid tokens return 401.

<sup>Written for commit f254f2a267583fd4024586309624276d4a62b844. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

