### PR TITLE
feat(desktop): park v1 terminals on detach + re-enable WebGL

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-parking.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-parking.ts
@@ -1,0 +1,31 @@
+// Body-level hidden container that owns wrapper divs of terminals whose
+// React component is currently unmounted (e.g. workspace switch, tab hide).
+// Keeps xterm attached to the document so it survives provider remounts
+// without a detach/reattach flash — VSCode's setVisible(false) model. Looked
+// up by DOM id so it's HMR-safe (a module-level `let` would leak on re-eval).
+// `inert` removes the whole subtree from the tab order and the accessibility
+// tree, and also moves focus out of it — so a parked terminal's internal
+// <textarea> can't receive keystrokes meant for the active pane.
+//
+// Shared by v1 (v1-terminal-cache.ts) and v2 (terminal-runtime.ts) so the
+// two surfaces converge on a single DOM node and lifecycle.
+const PARKING_CONTAINER_ID = "terminal-parking";
+
+export function getTerminalParkingContainer(): HTMLDivElement {
+	const existing = document.getElementById(PARKING_CONTAINER_ID);
+	if (existing) return existing as HTMLDivElement;
+
+	const el = document.createElement("div");
+	el.id = PARKING_CONTAINER_ID;
+	el.setAttribute("inert", "");
+	el.setAttribute("aria-hidden", "true");
+	el.style.position = "fixed";
+	el.style.left = "-9999px";
+	el.style.top = "-9999px";
+	el.style.width = "100vw";
+	el.style.height = "100vh";
+	el.style.overflow = "hidden";
+	el.style.pointerEvents = "none";
+	document.body.appendChild(el);
+	return el;
+}

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -7,6 +7,7 @@ import { DEFAULT_TERMINAL_SCROLLBACK } from "shared/constants";
 import type { TerminalAppearance } from "./appearance";
 import { loadAddons } from "./terminal-addons";
 import { installTerminalKeyEventHandler } from "./terminal-key-event-handler";
+import { getTerminalParkingContainer } from "./terminal-parking";
 
 const SERIALIZE_SCROLLBACK = 1000;
 const STORAGE_KEY_PREFIX = "terminal-buffer:";
@@ -116,34 +117,6 @@ function clearPersistedDimensions(terminalId: string) {
 function hostIsVisible(container: HTMLDivElement | null): boolean {
 	if (!container) return false;
 	return container.clientWidth > 0 && container.clientHeight > 0;
-}
-
-// Body-level hidden container that owns wrapper divs of terminals whose
-// React component is currently unmounted (e.g. workspace switch). Keeps
-// xterm attached to the document so it survives provider remounts without
-// a detach/reattach flash — VSCode's setVisible(false) model. Looked up
-// by DOM id so it's HMR-safe (module-level `let` would leak on re-eval).
-// `inert` removes the whole subtree from the tab order and the accessibility
-// tree, and also moves focus out of it — so a parked terminal's internal
-// <textarea> can't receive keystrokes meant for the active pane.
-const PARKING_CONTAINER_ID = "v2-terminal-parking";
-function getParkingContainer(): HTMLDivElement {
-	const existing = document.getElementById(PARKING_CONTAINER_ID);
-	if (existing) return existing as HTMLDivElement;
-
-	const el = document.createElement("div");
-	el.id = PARKING_CONTAINER_ID;
-	el.setAttribute("inert", "");
-	el.setAttribute("aria-hidden", "true");
-	el.style.position = "fixed";
-	el.style.left = "-9999px";
-	el.style.top = "-9999px";
-	el.style.width = "100vw";
-	el.style.height = "100vh";
-	el.style.overflow = "hidden";
-	el.style.pointerEvents = "none";
-	document.body.appendChild(el);
-	return el;
 }
 
 function measureAndResize(runtime: TerminalRuntime): boolean {
@@ -299,8 +272,8 @@ export function detachFromContainer(runtime: TerminalRuntime) {
 	runtime.resizeObserver?.disconnect();
 	runtime.resizeObserver = null;
 	// Park instead of .remove() so xterm survives the React unmount —
-	// see getParkingContainer.
-	getParkingContainer().appendChild(runtime.wrapper);
+	// see getTerminalParkingContainer.
+	getTerminalParkingContainer().appendChild(runtime.wrapper);
 	runtime.container = null;
 }
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -5,6 +5,7 @@ import { ImageAddon } from "@xterm/addon-image";
 import { LigaturesAddon } from "@xterm/addon-ligatures";
 import { SearchAddon } from "@xterm/addon-search";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
+import { WebglAddon } from "@xterm/addon-webgl";
 import type { ITheme } from "@xterm/xterm";
 import { Terminal as XTerm } from "@xterm/xterm";
 import type { DetectedLink } from "renderer/lib/terminal/links";
@@ -55,6 +56,9 @@ export function getDefaultTerminalBg(): string {
 	return getDefaultTerminalTheme().background ?? "#151110";
 }
 
+// Once WebGL fails, skip it for all subsequent terminals (VS Code pattern).
+let suggestedRendererType: "webgl" | "dom" | undefined;
+
 export interface CreateTerminalOptions {
 	/**
 	 * Workspace id used for worktree lookup during path stat/resolution.
@@ -99,6 +103,9 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 	const unicode11Addon = new Unicode11Addon();
 	const imageAddon = new ImageAddon();
 
+	let disposed = false;
+	let webglAddon: WebglAddon | null = null;
+
 	// Open into a detached wrapper div — not the live container.
 	const wrapper = document.createElement("div");
 	wrapper.style.width = "100%";
@@ -116,6 +123,24 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 	} catch {
 		// Ligatures not supported by current font
 	}
+
+	// Defer WebGL to rAF to avoid racing xterm's post-open viewport sync.
+	const rafId = requestAnimationFrame(() => {
+		if (disposed || suggestedRendererType === "dom") return;
+
+		try {
+			webglAddon = new WebglAddon();
+			webglAddon.onContextLoss(() => {
+				webglAddon?.dispose();
+				webglAddon = null;
+				xterm.refresh(0, xterm.rows - 1);
+			});
+			xterm.loadAddon(webglAddon);
+		} catch {
+			suggestedRendererType = "dom";
+			webglAddon = null;
+		}
+	});
 
 	const cleanupQuerySuppression = suppressQueryResponses(xterm);
 
@@ -179,8 +204,14 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 		wrapper,
 		linkManager,
 		cleanup: () => {
+			disposed = true;
+			cancelAnimationFrame(rafId);
 			cleanupQuerySuppression();
 			linkManager.dispose();
+			try {
+				webglAddon?.dispose();
+			} catch {}
+			webglAddon = null;
 		},
 	};
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/v1-terminal-cache.ts
@@ -2,6 +2,7 @@ import type { Unsubscribable } from "@trpc/server/observable";
 import type { FitAddon } from "@xterm/addon-fit";
 import type { SearchAddon } from "@xterm/addon-search";
 import type { Terminal as XTerm } from "@xterm/xterm";
+import { getTerminalParkingContainer } from "renderer/lib/terminal/terminal-parking";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { DEBUG_TERMINAL } from "./config";
 import { type CreateTerminalOptions, createTerminalInWrapper } from "./helpers";
@@ -171,7 +172,9 @@ export function detachFromContainer(paneId: string): void {
 	entry.resizeObserver?.disconnect();
 	entry.resizeObserver = null;
 	entry.container = null;
-	entry.wrapper.remove();
+	// Park instead of .remove() so xterm survives the React unmount —
+	// see getTerminalParkingContainer.
+	getTerminalParkingContainer().appendChild(entry.wrapper);
 }
 
 // --- Appearance ---
@@ -333,6 +336,7 @@ export function dispose(paneId: string): void {
 	entry.resizeObserver?.disconnect();
 	entry.subscription?.unsubscribe();
 	entry.cleanupCreation();
+	entry.wrapper.remove();
 	entry.xterm.dispose();
 	cache.delete(paneId);
 }


### PR DESCRIPTION
## Summary
- v1's `detachFromContainer` was calling `wrapper.remove()`, fully detaching the xterm canvas from the document on every tab switch. Switch to v2's parking-container pattern so xterm stays in the document tree across React mount/unmount cycles.
- Lift the parking helper out of `terminal-runtime.ts` (v2) into a shared `lib/terminal/terminal-parking.ts`; v1 and v2 now use a single hidden body-level node (id `terminal-parking`).
- With parking in place, re-enable the WebGL renderer in v1 (reverting the workaround from #3924). Same pattern as v2's `terminal-addons.ts`: defer init to rAF, dispose + DOM fallback on `onContextLoss`, share `suggestedRendererType` so a failure stops retrying for the rest of the session.

## Why
v1 tabs hit silent xterm atlas corruption that #3924 dodged by dropping WebGL. The leading hypothesis was that repeated DOM detach/reattach was letting the GPU compositor drop texture backing without firing `onContextLoss`. Parking keeps the canvas in the document permanently, which removes that lifecycle event entirely. Bringing v1 in line with v2 also reduces divergence on a sunset surface.

## Test plan
- [ ] Open multiple v1 terminals, switch between them many times, scroll back through buffer — glyphs stay clean.
- [ ] Open a v1 terminal, run a long-running command, switch tabs while output streams, return — output is intact and not corrupted.
- [ ] Sleep/wake the laptop with a v1 terminal open, scroll buffer — check whether corruption reappears (this is the case parking does not address; if it shows up we'd want OS-resume `clearTextureAtlas` plumbing back).
- [ ] Force a context loss via DevTools (`canvas.getContext('webgl2').getExtension('WEBGL_lose_context').loseContext()`) — terminal should stay readable via DOM fallback.
- [ ] Existing v2 tests still pass — `bun test src/renderer/lib/terminal src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Park v1 terminals on detach so xterm stays mounted across tab switches and React unmounts. This fixes WebGL atlas corruption and allows re-enabling the WebGL renderer in v1 with a safe DOM fallback.

- **Bug Fixes**
  - Keep v1 terminal canvases attached using a hidden `terminal-parking` container to prevent GPU texture loss and flicker.
  - Re-enable `@xterm/addon-webgl` in v1: init deferred to rAF, dispose and fall back to DOM on context loss, and cache a session-level renderer suggestion to stop retries.

- **Refactors**
  - Move the parking helper to `apps/desktop/src/renderer/lib/terminal/terminal-parking.ts` and use it in both v1 and v2 via `getTerminalParkingContainer()`.

<sup>Written for commit 01d9013f2241ac93b83129f7af6987570a904461. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WebGL rendering support for terminal windows for improved graphics performance.

* **Improvements**
  * Enhanced terminal persistence across window navigation and component reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->