### PR TITLE
chore(host-service): bump version to 0.6.0 + raise min version

### DIFF
--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -52,7 +52,7 @@ import { HOOK_PROTOCOL_VERSION } from "./terminal/env";
  * respawn with the new bundle. One-time terminal-session loss for
  * users on upgrade — accepted per release-notes guidance.
  */
-const MIN_HOST_SERVICE_VERSION = "0.5.0";
+const MIN_HOST_SERVICE_VERSION = "0.6.0";
 
 export type HostServiceStatus = "starting" | "running" | "stopped";
 

--- a/bun.lock
+++ b/bun.lock
@@ -111,7 +111,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.7.3",
+      "version": "1.8.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.43",
         "@ai-sdk/openai": "3.0.36",

--- a/packages/host-service/src/trpc/router/host/host.ts
+++ b/packages/host-service/src/trpc/router/host/host.ts
@@ -18,7 +18,7 @@ import { protectedProcedure, router } from "../../index";
 // them on upgrade and respawn with the new bundle. Adopting in
 // place would leave the new desktop talking to old code with no
 // `terminal.daemon.*` routes, breaking Settings → Manage daemon.
-const HOST_SERVICE_VERSION = "0.5.0";
+const HOST_SERVICE_VERSION = "0.6.0";
 const ORGANIZATION_CACHE_TTL_MS = 60 * 60 * 1000;
 
 let cachedOrganization: {


### PR DESCRIPTION
## Summary
- Bump `HOST_SERVICE_VERSION` (`packages/host-service/src/trpc/router/host/host.ts`) from `0.5.0` → `0.6.0`
- Bump `MIN_HOST_SERVICE_VERSION` (`apps/desktop/src/main/lib/host-service-coordinator.ts`) from `0.5.0` → `0.6.0`
- Sync `bun.lock` with `apps/desktop` 1.8.0

Min already matched latest, so both move together. The desktop coordinator will SIGTERM any adopted pre-0.6.0 host-service on first launch and respawn with the new bundle.

## Test plan
- [ ] CI green (lint, typecheck, tests)
- [ ] Manual: launch desktop against an adopted 0.5.0 host-service, confirm it respawns to 0.6.0

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the host service to 0.6.0 and raises the minimum required version to 0.6.0. On first launch, the desktop coordinator will stop any pre-0.6.0 host service and restart it with the new bundle to avoid API mismatches.

- **Dependencies**
  - Syncs `bun.lock` with `apps/desktop` 1.8.0.

<sup>Written for commit f93c4165448913a148b61c41aab6095bbe14698b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Host service version updated to 0.6.0. Services running on older versions are no longer supported and will be terminated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->