### PR TITLE
fix(desktop): meta+e splits along longer side in v2

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspaceHotkeys/useWorkspaceHotkeys.ts
@@ -1,5 +1,6 @@
 import {
 	type FocusDirection,
+	getPaneParentDirection,
 	getSpatialNeighborPaneId,
 	type PaneRegistry,
 	type WorkspaceStore,
@@ -200,10 +201,15 @@ export function useWorkspaceHotkeys({
 		const state = store.getState();
 		const active = state.getActivePane();
 		if (!active) return;
+		const tab = state.getActiveTab();
+		const parentDirection = tab
+			? getPaneParentDirection(tab.layout, active.pane.id)
+			: null;
+		const position = parentDirection === "horizontal" ? "bottom" : "right";
 		state.splitPane({
 			tabId: active.tabId,
 			paneId: active.pane.id,
-			position: "right",
+			position,
 			newPane: {
 				kind: "terminal",
 				data: { terminalId: crypto.randomUUID() } as TerminalPaneData,

--- a/packages/panes/src/core/store/utils/index.ts
+++ b/packages/panes/src/core/store/utils/index.ts
@@ -9,6 +9,7 @@ export {
 	getNodeAtPath,
 	getOtherBranch,
 	getPaneIdsInLayout,
+	getPaneParentDirection,
 	getSpatialNeighborPaneId,
 	positionToDirection,
 	removePaneFromLayout,

--- a/packages/panes/src/core/store/utils/utils.ts
+++ b/packages/panes/src/core/store/utils/utils.ts
@@ -211,6 +211,16 @@ function findEdgePaneId(
 	return findEdgePaneId(node[alignedBranch], dir, rest);
 }
 
+export function getPaneParentDirection(
+	root: LayoutNode,
+	paneId: string,
+): SplitDirection | null {
+	const path = findPanePath(root, paneId);
+	if (!path || path.length === 0) return null;
+	const parent = getNodeAtPath(root, path.slice(0, -1));
+	return parent && parent.type === "split" ? parent.direction : null;
+}
+
 export function getSpatialNeighborPaneId(
 	root: LayoutNode,
 	paneId: string,

--- a/packages/panes/src/index.ts
+++ b/packages/panes/src/index.ts
@@ -8,6 +8,7 @@ export { createWorkspaceStore } from "./core/store";
 export type { FocusDirection } from "./core/store/utils";
 export {
 	getActiveIdAfterRemoval,
+	getPaneParentDirection,
 	getSpatialNeighborPaneId,
 } from "./core/store/utils";
 export type {


### PR DESCRIPTION
## Summary
- v2 `SPLIT_AUTO` hotkey hardcoded `position: "right"`, so meta+e always created a vertical (side-by-side) split regardless of the active pane's parent direction
- Mirror the pane-header split button's logic (`useDefaultPaneActions`): if parent split is horizontal, split `bottom`; otherwise split `right`
- Add `getPaneParentDirection(layout, paneId)` helper to `@superset/panes` and use it in `useWorkspaceHotkeys`

## Test plan
- [ ] Open a v2 workspace
- [ ] meta+e on a pane with no siblings → splits to the right (default)
- [ ] meta+e on a pane inside a horizontal split → splits downward
- [ ] meta+e on a pane inside a vertical split → splits to the right
- [ ] Behavior matches clicking the split icon in the pane header

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the v2 SPLIT_AUTO hotkey so `meta+e` splits along the longer side, matching the pane-header split behavior. Horizontal parents split to bottom; otherwise split to right.

- **Bug Fixes**
  - Updated `useWorkspaceHotkeys` to compute parent direction and set split position accordingly.
  - Added and exported `getPaneParentDirection(layout, paneId)` in `@superset/panes` utils.

<sup>Written for commit c346835d7196e60f5d590764207a33ca46b3349d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced SPLIT_AUTO hotkey to intelligently determine split direction based on parent pane layout orientation, splitting downward for horizontal layouts and rightward for others.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->