### PR TITLE
feat(desktop): merge branch picker tabs into All + Worktree

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/CompareBaseBranchPicker/CompareBaseBranchPicker.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/CompareBaseBranchPicker/CompareBaseBranchPicker.tsx
@@ -140,8 +140,8 @@ export function CompareBaseBranchPicker({
 						className="p-2"
 					>
 						<TabsList className="grid w-full grid-cols-2 h-7 bg-transparent">
-							<TabsTrigger value="branch" className="text-[11px]">
-								Branch
+							<TabsTrigger value="all" className="text-[11px]">
+								All
 							</TabsTrigger>
 							<TabsTrigger value="worktree" className="text-[11px]">
 								Worktree
@@ -155,6 +155,7 @@ export function CompareBaseBranchPicker({
 							)}
 							{branches.map((branch) => {
 								const isRemoteOnly = branch.isRemote && !branch.isLocal;
+								const isWorktree = Boolean(branch.worktreePath);
 								return (
 									<CommandItem
 										key={branch.name}
@@ -186,6 +187,11 @@ export function CompareBaseBranchPicker({
 														remote
 													</span>
 												)}
+												{isWorktree && (
+													<span className="text-[10px] text-primary/80 bg-primary/10 px-1.5 py-0.5 rounded">
+														worktree
+													</span>
+												)}
 											</span>
 										</span>
 										<span className="flex items-center gap-2 shrink-0">
@@ -194,7 +200,7 @@ export function CompareBaseBranchPicker({
 													{formatRelativeTime(branch.lastCommitDate * 1000)}
 												</span>
 											)}
-											{branchFilter === "worktree" ? (
+											{isWorktree ? (
 												(() => {
 													// Authoritative check against the cloud-synced
 													// collection — a `server hasWorkspace:true` row

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/CompareBaseBranchPicker/CompareBaseBranchPicker.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/CompareBaseBranchPicker/CompareBaseBranchPicker.tsx
@@ -200,7 +200,32 @@ export function CompareBaseBranchPicker({
 													{formatRelativeTime(branch.lastCommitDate * 1000)}
 												</span>
 											)}
-											{branch.isCheckedOut ? (
+											{isWorktree ? (
+												(() => {
+													// Authoritative check against the cloud-synced
+													// collection — a `server hasWorkspace:true` row
+													// may be stale after a delete.
+													const hasWorkspace = hasWorkspaceForBranch(
+														branch.name,
+													);
+													return (
+														<button
+															type="button"
+															className="hidden group-hover:inline-flex group-focus-within:inline-flex items-center rounded-sm bg-primary/10 hover:bg-primary/20 px-2 py-0.5 text-[11px] text-primary font-medium"
+															onClick={(e) => {
+																e.stopPropagation();
+																if (hasWorkspace) {
+																	onOpenExisting(branch.name);
+																} else {
+																	onAdoptWorktree(branch.name);
+																}
+															}}
+														>
+															{hasWorkspace ? "Open" : "Create"}
+														</button>
+													);
+												})()
+											) : branch.isCheckedOut ? (
 												<Tooltip>
 													<TooltipTrigger asChild>
 														{/*
@@ -234,31 +259,6 @@ export function CompareBaseBranchPicker({
 													Check out
 												</button>
 											)}
-											{isWorktree &&
-												(() => {
-													// Authoritative check against the cloud-synced
-													// collection — a `server hasWorkspace:true` row
-													// may be stale after a delete.
-													const hasWorkspace = hasWorkspaceForBranch(
-														branch.name,
-													);
-													return (
-														<button
-															type="button"
-															className="hidden group-hover:inline-flex group-focus-within:inline-flex items-center rounded-sm bg-primary/10 hover:bg-primary/20 px-2 py-0.5 text-[11px] text-primary font-medium"
-															onClick={(e) => {
-																e.stopPropagation();
-																if (hasWorkspace) {
-																	onOpenExisting(branch.name);
-																} else {
-																	onAdoptWorktree(branch.name);
-																}
-															}}
-														>
-															{hasWorkspace ? "Open" : "Create"}
-														</button>
-													);
-												})()}
 											{effectiveCompareBaseBranch === branch.name && (
 												<HiCheck className="size-4 text-primary" />
 											)}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/CompareBaseBranchPicker/CompareBaseBranchPicker.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/CompareBaseBranchPicker/CompareBaseBranchPicker.tsx
@@ -200,32 +200,7 @@ export function CompareBaseBranchPicker({
 													{formatRelativeTime(branch.lastCommitDate * 1000)}
 												</span>
 											)}
-											{isWorktree ? (
-												(() => {
-													// Authoritative check against the cloud-synced
-													// collection — a `server hasWorkspace:true` row
-													// may be stale after a delete.
-													const hasWorkspace = hasWorkspaceForBranch(
-														branch.name,
-													);
-													return (
-														<button
-															type="button"
-															className="hidden group-hover:inline-flex group-focus-within:inline-flex items-center rounded-sm bg-primary/10 hover:bg-primary/20 px-2 py-0.5 text-[11px] text-primary font-medium"
-															onClick={(e) => {
-																e.stopPropagation();
-																if (hasWorkspace) {
-																	onOpenExisting(branch.name);
-																} else {
-																	onAdoptWorktree(branch.name);
-																}
-															}}
-														>
-															{hasWorkspace ? "Open" : "Create"}
-														</button>
-													);
-												})()
-											) : branch.isCheckedOut ? (
+											{branch.isCheckedOut ? (
 												<Tooltip>
 													<TooltipTrigger asChild>
 														{/*
@@ -259,6 +234,31 @@ export function CompareBaseBranchPicker({
 													Check out
 												</button>
 											)}
+											{isWorktree &&
+												(() => {
+													// Authoritative check against the cloud-synced
+													// collection — a `server hasWorkspace:true` row
+													// may be stale after a delete.
+													const hasWorkspace = hasWorkspaceForBranch(
+														branch.name,
+													);
+													return (
+														<button
+															type="button"
+															className="hidden group-hover:inline-flex group-focus-within:inline-flex items-center rounded-sm bg-primary/10 hover:bg-primary/20 px-2 py-0.5 text-[11px] text-primary font-medium"
+															onClick={(e) => {
+																e.stopPropagation();
+																if (hasWorkspace) {
+																	onOpenExisting(branch.name);
+																} else {
+																	onAdoptWorktree(branch.name);
+																}
+															}}
+														>
+															{hasWorkspace ? "Open" : "Create"}
+														</button>
+													);
+												})()}
 											{effectiveCompareBaseBranch === branch.name && (
 												<HiCheck className="size-4 text-primary" />
 											)}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useBranchPickerController/useBranchPickerController.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useBranchPickerController/useBranchPickerController.ts
@@ -55,7 +55,7 @@ export function useBranchPickerController(args: UseBranchPickerControllerArgs) {
 	// Branch list state — owned by the controller so the picker is purely
 	// presentational.
 	const [branchSearch, setBranchSearch] = useState("");
-	const [branchFilter, setBranchFilter] = useState<BranchFilter>("branch");
+	const [branchFilter, setBranchFilter] = useState<BranchFilter>("all");
 
 	const {
 		branches,

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/hooks/useBranchContext/useBranchContext.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/hooks/useBranchContext/useBranchContext.ts
@@ -26,7 +26,7 @@ export function useBranchContext(
 	projectId: string | null,
 	hostTarget: WorkspaceHostTarget,
 	query: string,
-	filter: BranchFilter = "branch",
+	filter: BranchFilter = "all",
 ) {
 	const hostUrl = useHostTargetUrl(hostTarget);
 

--- a/packages/host-service/src/trpc/router/workspace-creation/procedures/search-branches.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/procedures/search-branches.ts
@@ -125,10 +125,9 @@ export const searchBranches = protectedProcedure
 
 		if (input.filter === "worktree") {
 			branches = branches.filter((branch) => worktreeMap.has(branch.name));
-		} else {
-			// default "branch": any branch (local or remote) without a worktree
-			branches = branches.filter((branch) => !worktreeMap.has(branch.name));
 		}
+		// "all" (and undefined) — include every branch, worktree or not.
+		// The picker tags worktree rows so the user can still tell them apart.
 
 		if (input.query) {
 			const query = input.query.toLowerCase();

--- a/packages/host-service/src/trpc/router/workspace-creation/schemas.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/schemas.ts
@@ -23,7 +23,7 @@ export const searchBranchesInputSchema = z.object({
 	cursor: z.string().optional(),
 	limit: z.number().min(1).max(200).optional(),
 	refresh: z.boolean().optional(),
-	filter: z.enum(["branch", "worktree"]).optional(),
+	filter: z.enum(["all", "worktree"]).optional(),
 });
 
 export const generateBranchNameInputSchema = z.object({


### PR DESCRIPTION
## Summary
- Replace the v2 new-workspace branch picker's "Branch" tab with an "All" tab that lists every branch — worktree rows included — and tags them with a `worktree` badge so they're still distinguishable.
- "Worktree" tab kept as a focused view; the per-row action button (Check out vs Open/Create) now keys off the row's `worktreePath` instead of the active tab, so worktree rows in "All" still get adoption affordances.
- Server `searchBranches` filter enum becomes `"all" | "worktree"`; `"all"` (and undefined) returns every branch — the previous behavior of excluding worktree branches from the default tab is gone.

## Test plan
- [ ] Open New Workspace modal → branch picker defaults to "All" and lists worktree branches with a `worktree` tag alongside non-worktree branches.
- [ ] Hovering a non-worktree row in "All" shows "Check out"; hovering a worktree row shows "Open" (when a workspace row exists) or "Create" (orphan worktree).
- [ ] "Worktree" tab still narrows the list to worktree-backed branches only.
- [ ] `bun run typecheck` passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Merged the branch picker into two tabs: All and Worktree. All shows every branch and tags worktree rows; actions key off worktree state, and worktree rows show only Open/Create (no disabled Check out).

- **New Features**
  - Replaced “Branch” with “All” that lists all branches and adds a `worktree` badge.
  - Kept “Worktree” as a focused view; row actions now use `worktreePath` and show Open/Create on worktree rows.
  - Default filter is “all,” so the modal opens on All by default.

- **Migration**
  - `searchBranches` filter enum is now `"all" | "worktree"`; `"all"` (or undefined) returns all branches.
  - Update any callers using `"branch"` to use `"all"`.

<sup>Written for commit e8991956e23a80ab79b00a2075868bf0a4eecaa8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced the "Branch" tab with an "All" tab in the branch picker.
  * Worktree branches display a distinct "worktree" label and have tailored Open/Create actions.

* **Improvements**
  * Branch picker now defaults to showing all branches.
  * Branch search includes all branch types by default while still marking worktrees in results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->