### PR TITLE
feat(desktop): add discard + stage/unstage controls to v2 changes tab

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/DiscardConfirmDialog/DiscardConfirmDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/DiscardConfirmDialog/DiscardConfirmDialog.tsx
@@ -1,0 +1,57 @@
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	EnterEnabledAlertDialogContent,
+} from "@superset/ui/alert-dialog";
+import { Button } from "@superset/ui/button";
+
+interface DiscardConfirmDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	title: string;
+	description: string;
+	confirmLabel?: string;
+	onConfirm: () => void;
+}
+
+export function DiscardConfirmDialog({
+	open,
+	onOpenChange,
+	title,
+	description,
+	confirmLabel = "Discard",
+	onConfirm,
+}: DiscardConfirmDialogProps) {
+	return (
+		<AlertDialog open={open} onOpenChange={onOpenChange}>
+			<EnterEnabledAlertDialogContent className="max-w-[360px] gap-0 p-0">
+				<AlertDialogHeader className="px-4 pt-4 pb-2">
+					<AlertDialogTitle className="font-medium">{title}</AlertDialogTitle>
+					<AlertDialogDescription>{description}</AlertDialogDescription>
+				</AlertDialogHeader>
+				<AlertDialogFooter className="flex-row justify-end gap-2 px-4 pt-2 pb-4">
+					<Button
+						variant="ghost"
+						size="sm"
+						className="h-7 px-3 text-xs"
+						onClick={() => onOpenChange(false)}
+					>
+						Cancel
+					</Button>
+					<AlertDialogAction
+						variant="destructive"
+						size="sm"
+						className="h-7 px-3 text-xs"
+						onClick={onConfirm}
+					>
+						{confirmLabel}
+					</AlertDialogAction>
+				</AlertDialogFooter>
+			</EnterEnabledAlertDialogContent>
+		</AlertDialog>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/DiscardConfirmDialog/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/DiscardConfirmDialog/index.ts
@@ -1,0 +1,1 @@
+export { DiscardConfirmDialog } from "./DiscardConfirmDialog";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/ChangesFileList.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/ChangesFileList.tsx
@@ -1,9 +1,11 @@
-import { memo } from "react";
-import type { ChangesetFile } from "../../../../../../hooks/useChangeset";
+import { memo, useMemo } from "react";
+import type { ChangesetFile } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset";
+import { ChangesSection } from "./components/ChangesSection";
 import { FileRow } from "./components/FileRow";
 
 interface ChangesFileListProps {
 	files: ChangesetFile[];
+	workspaceId: string;
 	isLoading?: boolean;
 	worktreePath?: string;
 	onSelectFile?: (path: string, openInNewTab?: boolean) => void;
@@ -11,14 +13,44 @@ interface ChangesFileListProps {
 	onOpenInEditor?: (path: string) => void;
 }
 
+type GroupKey = "unstaged" | "staged" | "against-base" | "commit";
+
+const GROUP_ORDER: GroupKey[] = [
+	"unstaged",
+	"staged",
+	"against-base",
+	"commit",
+];
+
+const GROUP_TITLES: Record<GroupKey, string> = {
+	unstaged: "Unstaged",
+	staged: "Staged",
+	"against-base": "Against base",
+	commit: "Committed",
+};
+
 export const ChangesFileList = memo(function ChangesFileList({
 	files,
+	workspaceId,
 	isLoading,
 	worktreePath,
 	onSelectFile,
 	onOpenFile,
 	onOpenInEditor,
 }: ChangesFileListProps) {
+	const grouped = useMemo(() => {
+		const groups: Record<GroupKey, ChangesetFile[]> = {
+			unstaged: [],
+			staged: [],
+			"against-base": [],
+			commit: [],
+		};
+		for (const file of files) {
+			groups[file.source.kind].push(file);
+		}
+		return groups;
+	}, [files]);
+
 	if (isLoading) {
 		return (
 			<div className="flex h-full items-center justify-center text-sm text-muted-foreground">
@@ -37,16 +69,35 @@ export const ChangesFileList = memo(function ChangesFileList({
 
 	return (
 		<div className="min-h-0 flex-1 overflow-y-auto">
-			{files.map((file) => (
-				<FileRow
-					key={`${file.source.kind}:${file.path}`}
-					file={file}
-					worktreePath={worktreePath}
-					onSelect={onSelectFile}
-					onOpenFile={onOpenFile}
-					onOpenInEditor={onOpenInEditor}
-				/>
-			))}
+			{GROUP_ORDER.map((key) => {
+				const groupFiles = grouped[key];
+				if (groupFiles.length === 0) return null;
+				const hasStagingActions = key === "unstaged" || key === "staged";
+				return (
+					<ChangesSection
+						key={key}
+						title={GROUP_TITLES[key]}
+						count={groupFiles.length}
+						stagingActions={
+							hasStagingActions
+								? { kind: key as "unstaged" | "staged", workspaceId }
+								: undefined
+						}
+					>
+						{groupFiles.map((file) => (
+							<FileRow
+								key={`${file.source.kind}:${file.path}`}
+								file={file}
+								workspaceId={workspaceId}
+								worktreePath={worktreePath}
+								onSelect={onSelectFile}
+								onOpenFile={onOpenFile}
+								onOpenInEditor={onOpenInEditor}
+							/>
+						))}
+					</ChangesSection>
+				);
+			})}
 		</div>
 	);
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesSection/ChangesSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesSection/ChangesSection.tsx
@@ -1,0 +1,179 @@
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "@superset/ui/collapsible";
+import { toast } from "@superset/ui/sonner";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { cn } from "@superset/ui/utils";
+import { workspaceTrpc } from "@superset/workspace-client";
+import { ChevronRight, Minus, Plus } from "lucide-react";
+import { type ReactNode, useState } from "react";
+import { LuUndo2 } from "react-icons/lu";
+import { DiscardConfirmDialog } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/DiscardConfirmDialog";
+
+type SectionKind = "unstaged" | "staged";
+
+interface ChangesSectionProps {
+	title: string;
+	count: number;
+	defaultOpen?: boolean;
+	stagingActions?: { kind: SectionKind; workspaceId: string };
+	children: ReactNode;
+}
+
+export function ChangesSection({
+	title,
+	count,
+	defaultOpen = true,
+	stagingActions,
+	children,
+}: ChangesSectionProps) {
+	const [open, setOpen] = useState(defaultOpen);
+	const [showConfirm, setShowConfirm] = useState(false);
+	const utils = workspaceTrpc.useUtils();
+
+	const invalidate = () => {
+		if (!stagingActions) return;
+		void utils.git.getStatus.invalidate({
+			workspaceId: stagingActions.workspaceId,
+		});
+		void utils.git.getDiff.invalidate({
+			workspaceId: stagingActions.workspaceId,
+		});
+	};
+
+	const discardAllUnstaged = workspaceTrpc.git.discardAllUnstaged.useMutation({
+		onSuccess: invalidate,
+		onError: (err) => {
+			toast.error("Couldn't discard unstaged changes", {
+				description: err.message,
+			});
+		},
+	});
+	const discardAllStaged = workspaceTrpc.git.discardAllStaged.useMutation({
+		onSuccess: invalidate,
+		onError: (err) => {
+			toast.error("Couldn't discard staged changes", {
+				description: err.message,
+			});
+		},
+	});
+	const stageAll = workspaceTrpc.git.stageAll.useMutation({
+		onSuccess: invalidate,
+		onError: (err) => {
+			toast.error("Couldn't stage changes", { description: err.message });
+		},
+	});
+	const unstageAll = workspaceTrpc.git.unstageAll.useMutation({
+		onSuccess: invalidate,
+		onError: (err) => {
+			toast.error("Couldn't unstage changes", { description: err.message });
+		},
+	});
+
+	if (count === 0) return null;
+
+	const runDiscardAll = () => {
+		if (!stagingActions) return;
+		const { kind, workspaceId } = stagingActions;
+		if (kind === "unstaged") {
+			discardAllUnstaged.mutate({ workspaceId });
+		} else {
+			discardAllStaged.mutate({ workspaceId });
+		}
+	};
+
+	const runStagingToggle = () => {
+		if (!stagingActions) return;
+		const { kind, workspaceId } = stagingActions;
+		if (kind === "unstaged") {
+			stageAll.mutate({ workspaceId });
+		} else {
+			unstageAll.mutate({ workspaceId });
+		}
+	};
+
+	const dialogCopy =
+		stagingActions?.kind === "unstaged"
+			? {
+					title: "Discard all unstaged changes?",
+					description:
+						"This will revert all unstaged modifications and delete untracked files. This cannot be undone.",
+				}
+			: {
+					title: "Discard all staged changes?",
+					description:
+						"This will unstage and revert all staged changes. Staged new files will be deleted. This cannot be undone.",
+				};
+
+	const isUnstaged = stagingActions?.kind === "unstaged";
+	const stagingToggleLabel = isUnstaged ? "Stage all" : "Unstage all";
+	const StagingToggleIcon = isUnstaged ? Plus : Minus;
+
+	return (
+		<Collapsible open={open} onOpenChange={setOpen}>
+			<div className="flex items-center">
+				<CollapsibleTrigger className="flex min-w-0 flex-1 items-center gap-1.5 px-2 py-1 text-left text-xs hover:bg-accent/30">
+					<ChevronRight
+						className={cn(
+							"size-3 shrink-0 text-muted-foreground transition-transform duration-150",
+							open && "rotate-90",
+						)}
+					/>
+					<span className="truncate font-medium">{title}</span>
+					<span className="shrink-0 text-[10px] text-muted-foreground">
+						{count}
+					</span>
+				</CollapsibleTrigger>
+				{stagingActions && (
+					<div className="flex shrink-0 items-center gap-0.5 pr-1.5">
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<button
+									type="button"
+									aria-label={`Discard all ${stagingActions.kind} changes`}
+									onClick={() => setShowConfirm(true)}
+									className="flex size-5 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-destructive"
+								>
+									<LuUndo2 className="size-3.5" />
+								</button>
+							</TooltipTrigger>
+							<TooltipContent side="bottom">
+								Discard all {stagingActions.kind}
+							</TooltipContent>
+						</Tooltip>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<button
+									type="button"
+									aria-label={stagingToggleLabel}
+									onClick={runStagingToggle}
+									className="flex size-5 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
+								>
+									<StagingToggleIcon className="size-3.5" />
+								</button>
+							</TooltipTrigger>
+							<TooltipContent side="bottom">
+								{stagingToggleLabel}
+							</TooltipContent>
+						</Tooltip>
+					</div>
+				)}
+			</div>
+			<CollapsibleContent>{children}</CollapsibleContent>
+			{stagingActions && (
+				<DiscardConfirmDialog
+					open={showConfirm}
+					onOpenChange={setShowConfirm}
+					title={dialogCopy.title}
+					description={dialogCopy.description}
+					onConfirm={() => {
+						setShowConfirm(false);
+						runDiscardAll();
+					}}
+				/>
+			)}
+		</Collapsible>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesSection/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesSection/index.ts
@@ -1,0 +1,1 @@
+export { ChangesSection } from "./ChangesSection";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
@@ -13,9 +13,13 @@ import {
 	DropdownMenuShortcut,
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
+import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { workspaceTrpc } from "@superset/workspace-client";
 import { ChevronDown } from "lucide-react";
-import { memo } from "react";
+import { memo, useState } from "react";
+import { LuUndo2 } from "react-icons/lu";
+import { DiscardConfirmDialog } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/DiscardConfirmDialog";
 import { StatusIndicator } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/StatusIndicator";
 import { PathActionsMenuItems } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/WorkspaceFilesTreeItem/components/PathActionsMenuItems";
 import type { ChangesetFile } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset";
@@ -39,6 +43,7 @@ function splitPath(path: string): { dir: string; basename: string } {
 
 interface FileRowProps {
 	file: ChangesetFile;
+	workspaceId: string;
 	worktreePath?: string;
 	onSelect?: (path: string, openInNewTab?: boolean) => void;
 	onOpenFile?: (absolutePath: string, openInNewTab?: boolean) => void;
@@ -47,6 +52,7 @@ interface FileRowProps {
 
 export const FileRow = memo(function FileRow({
 	file,
+	workspaceId,
 	worktreePath,
 	onSelect,
 	onOpenFile,
@@ -60,6 +66,23 @@ export const FileRow = memo(function FileRow({
 	const absolutePath = worktreePath
 		? toAbsoluteWorkspacePath(worktreePath, file.path)
 		: undefined;
+	const canDiscard = file.source.kind === "unstaged";
+	const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
+	const isDeleteAction = file.status === "untracked" || file.status === "added";
+	const utils = workspaceTrpc.useUtils();
+	const discardMutation = workspaceTrpc.git.discardChanges.useMutation({
+		onSuccess: () => {
+			void utils.git.getStatus.invalidate({ workspaceId });
+			void utils.git.getDiff.invalidate({ workspaceId });
+		},
+		onError: (err) => {
+			toast.error("Couldn't discard changes", { description: err.message });
+		},
+	});
+	const confirmDiscard = () => {
+		setShowDiscardConfirm(false);
+		discardMutation.mutate({ workspaceId, filePath: file.path });
+	};
 
 	const rowButton = (
 		<div className="group relative">
@@ -104,6 +127,24 @@ export const FileRow = memo(function FileRow({
 				</span>
 			</button>
 			<div className="pointer-events-none absolute inset-y-0 right-2 flex items-center gap-0.5 opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 has-[[data-state=open]]:pointer-events-auto has-[[data-state=open]]:opacity-100">
+				{canDiscard && (
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<button
+								type="button"
+								aria-label="Discard changes"
+								className="flex size-5 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-destructive"
+								onClick={(e) => {
+									e.stopPropagation();
+									setShowDiscardConfirm(true);
+								}}
+							>
+								<LuUndo2 className="size-3.5" />
+							</button>
+						</TooltipTrigger>
+						<TooltipContent side="top">Discard changes</TooltipContent>
+					</Tooltip>
+				)}
 				<DropdownMenu>
 					<DropdownMenuTrigger asChild>
 						<button
@@ -192,7 +233,34 @@ export const FileRow = memo(function FileRow({
 						/>
 					</>
 				)}
+				{canDiscard && (
+					<>
+						<ContextMenuSeparator />
+						<ContextMenuItem
+							onSelect={() => setShowDiscardConfirm(true)}
+							className="text-destructive focus:text-destructive"
+						>
+							{isDeleteAction ? "Delete" : "Discard changes"}
+						</ContextMenuItem>
+					</>
+				)}
 			</ContextMenuContent>
+			<DiscardConfirmDialog
+				open={showDiscardConfirm}
+				onOpenChange={setShowDiscardConfirm}
+				title={
+					isDeleteAction
+						? `Delete "${basename}"?`
+						: `Discard changes to "${basename}"?`
+				}
+				description={
+					isDeleteAction
+						? "This will permanently delete this file. This action cannot be undone."
+						: "This will revert all changes to this file. This action cannot be undone."
+				}
+				confirmLabel={isDeleteAction ? "Delete" : "Discard"}
+				onConfirm={confirmDiscard}
+			/>
 		</ContextMenu>
 	);
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesTabContent/ChangesTabContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesTabContent/ChangesTabContent.tsx
@@ -9,6 +9,7 @@ import { ChangesHeader } from "../ChangesHeader";
 type RouterOutputs = inferRouterOutputs<AppRouter>;
 
 interface ChangesTabContentProps {
+	workspaceId: string;
 	status: {
 		data: RouterOutputs["git"]["getStatus"] | undefined;
 		isLoading: boolean;
@@ -33,6 +34,7 @@ interface ChangesTabContentProps {
 }
 
 export const ChangesTabContent = memo(function ChangesTabContent({
+	workspaceId,
 	status,
 	commits,
 	branches,
@@ -91,6 +93,7 @@ export const ChangesTabContent = memo(function ChangesTabContent({
 			<div className="min-h-0 flex-1 overflow-y-auto">
 				<ChangesFileList
 					files={files}
+					workspaceId={workspaceId}
 					isLoading={isLoading}
 					worktreePath={worktreePath}
 					onSelectFile={onSelectFile}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
@@ -168,6 +168,7 @@ export function useChangesTab({
 
 	const content = (
 		<ChangesTabContent
+			workspaceId={workspaceId}
 			status={status}
 			commits={commits}
 			branches={branches}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileEntry/DiffFileEntry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileEntry/DiffFileEntry.tsx
@@ -1,6 +1,8 @@
 import { Button } from "@superset/ui/button";
 import { toast } from "@superset/ui/sonner";
-import { memo, useCallback, useRef, useState } from "react";
+import { workspaceTrpc } from "@superset/workspace-client";
+import { memo, useCallback, useMemo, useRef, useState } from "react";
+import { DiscardConfirmDialog } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/DiscardConfirmDialog";
 import type { ChangesetFile } from "../../../../../useChangeset";
 import { DiffFileHeader } from "../DiffFileHeader";
 import { WorkspaceDiff } from "../WorkspaceDiff";
@@ -104,6 +106,47 @@ export const DiffFileEntry = memo(function DiffFileEntry({
 		[],
 	);
 
+	const utils = workspaceTrpc.useUtils();
+	const discardMutation = workspaceTrpc.git.discardChanges.useMutation({
+		onSuccess: () => {
+			void utils.git.getStatus.invalidate({ workspaceId });
+			void utils.git.getDiff.invalidate({ workspaceId });
+		},
+		onError: (err) => {
+			toast.error("Couldn't discard changes", { description: err.message });
+		},
+	});
+	const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
+	const canDiscard = file.source.kind === "unstaged";
+	const requestDiscard = useMemo(() => {
+		if (!canDiscard) return undefined;
+		return () => setShowDiscardConfirm(true);
+	}, [canDiscard]);
+	const confirmDiscard = useCallback(() => {
+		setShowDiscardConfirm(false);
+		discardMutation.mutate({ workspaceId, filePath: file.path });
+	}, [discardMutation, workspaceId, file.path]);
+	const isDeleteAction = file.status === "untracked" || file.status === "added";
+	const basename = file.path.split("/").pop() ?? file.path;
+	const discardDialog = canDiscard ? (
+		<DiscardConfirmDialog
+			open={showDiscardConfirm}
+			onOpenChange={setShowDiscardConfirm}
+			title={
+				isDeleteAction
+					? `Delete "${basename}"?`
+					: `Discard changes to "${basename}"?`
+			}
+			description={
+				isDeleteAction
+					? "This will permanently delete this file. This action cannot be undone."
+					: "This will revert all changes to this file. This action cannot be undone."
+			}
+			confirmLabel={isDeleteAction ? "Delete" : "Discard"}
+			onConfirm={confirmDiscard}
+		/>
+	) : null;
+
 	if (reason && !showFullDiff) {
 		const placeholderHeight =
 			reason === "deleted"
@@ -127,7 +170,9 @@ export const DiffFileEntry = memo(function DiffFileEntry({
 					onToggleViewed={handleToggleViewed}
 					onOpenFile={handleOpenFile}
 					onOpenInExternalEditor={handleOpenInExternalEditor}
+					onDiscard={requestDiscard}
 				/>
+				{discardDialog}
 			</div>
 		);
 	}
@@ -159,8 +204,10 @@ export const DiffFileEntry = memo(function DiffFileEntry({
 					onToggleViewed={handleToggleViewed}
 					onOpenFile={handleOpenFile}
 					onOpenInExternalEditor={handleOpenInExternalEditor}
+					onDiscard={requestDiscard}
 				/>
 			) : null}
+			{discardDialog}
 		</div>
 	);
 });
@@ -175,6 +222,7 @@ interface DeferredDiffPlaceholderProps {
 	onToggleViewed: () => void;
 	onOpenFile?: (openInNewTab?: boolean) => void;
 	onOpenInExternalEditor?: () => void;
+	onDiscard?: () => void;
 }
 
 function DeferredDiffPlaceholder({
@@ -187,6 +235,7 @@ function DeferredDiffPlaceholder({
 	onToggleViewed,
 	onOpenFile,
 	onOpenInExternalEditor,
+	onDiscard,
 }: DeferredDiffPlaceholderProps) {
 	const isDeleted = reason === "deleted";
 	const fullHeight = isDeleted
@@ -213,6 +262,7 @@ function DeferredDiffPlaceholder({
 				onToggleViewed={onToggleViewed}
 				onOpenFile={onOpenFile}
 				onOpenInExternalEditor={onOpenInExternalEditor}
+				onDiscard={onDiscard}
 			/>
 			{!collapsed && (
 				<div

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileHeader/DiffFileHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffFileHeader/DiffFileHeader.tsx
@@ -52,7 +52,7 @@ export function DiffFileHeader({
 	const name = lastSlash >= 0 ? path.slice(lastSlash + 1) : path;
 
 	return (
-		<div className="@container/diff-file-header sticky top-0 z-10 flex min-w-0 flex-nowrap items-center gap-1 bg-card px-3 py-2">
+		<div className="group/diff-file-header @container/diff-file-header sticky top-0 z-10 flex min-w-0 flex-nowrap items-center gap-1 bg-card px-3 py-2">
 			<button
 				type="button"
 				onClick={onToggleCollapsed}
@@ -171,22 +171,23 @@ export function DiffFileHeader({
 					</TooltipContent>
 				</Tooltip>
 
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<button
-							type="button"
-							onClick={onDiscard}
-							disabled={!onDiscard}
-							aria-label="Discard changes"
-							className="rounded p-1 text-muted-foreground/60 transition-colors hover:bg-accent hover:text-destructive disabled:pointer-events-none disabled:opacity-40"
-						>
-							<LuUndo2 className="size-3.5" />
-						</button>
-					</TooltipTrigger>
-					<TooltipContent side="bottom" showArrow={false}>
-						Discard changes
-					</TooltipContent>
-				</Tooltip>
+				{onDiscard && (
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<button
+								type="button"
+								onClick={onDiscard}
+								aria-label="Discard changes"
+								className="rounded p-1 text-muted-foreground/60 opacity-0 transition-all hover:bg-accent hover:text-destructive group-hover/diff-file-header:opacity-100"
+							>
+								<LuUndo2 className="size-3.5" />
+							</button>
+						</TooltipTrigger>
+						<TooltipContent side="bottom" showArrow={false}>
+							Discard changes
+						</TooltipContent>
+					</Tooltip>
+				)}
 			</div>
 		</div>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/WorkspaceDiff/WorkspaceDiff.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/WorkspaceDiff/WorkspaceDiff.tsx
@@ -1,5 +1,4 @@
 import { MultiFileDiff } from "@pierre/diffs/react";
-import { toast } from "@superset/ui/sonner";
 import { workspaceTrpc } from "@superset/workspace-client";
 import { useQuery } from "@tanstack/react-query";
 import { memo, useMemo } from "react";
@@ -28,6 +27,7 @@ interface WorkspaceDiffProps {
 	onToggleViewed: () => void;
 	onOpenFile?: (openInNewTab?: boolean) => void;
 	onOpenInExternalEditor?: () => void;
+	onDiscard?: () => void;
 }
 
 export const WorkspaceDiff = memo(function WorkspaceDiff({
@@ -46,6 +46,7 @@ export const WorkspaceDiff = memo(function WorkspaceDiff({
 	onToggleViewed,
 	onOpenFile,
 	onOpenInExternalEditor,
+	onDiscard,
 }: WorkspaceDiffProps) {
 	const activeTheme = useResolvedTheme();
 	const terminalTheme = useTerminalTheme();
@@ -100,24 +101,6 @@ export const WorkspaceDiff = memo(function WorkspaceDiff({
 		staleTime: Number.POSITIVE_INFINITY,
 	});
 
-	const workspaceQuery = workspaceTrpc.workspace.get.useQuery({
-		id: workspaceId,
-	});
-	const worktreePath = workspaceQuery.data?.worktreePath;
-
-	const handleDiscard = useMemo(() => {
-		if (source.kind !== "unstaged" || !worktreePath) return undefined;
-		return () => {
-			electronTrpcClient.changes.discardChanges
-				.mutate({ worktreePath, filePath: path })
-				.catch((err) => {
-					toast.error("Couldn't discard changes", {
-						description: err instanceof Error ? err.message : String(err),
-					});
-				});
-		};
-	}, [source.kind, worktreePath, path]);
-
 	return (
 		<div className="flex flex-col">
 			<DiffFileHeader
@@ -133,7 +116,7 @@ export const WorkspaceDiff = memo(function WorkspaceDiff({
 				onToggleViewed={onToggleViewed}
 				onOpenFile={onOpenFile}
 				onOpenInExternalEditor={onOpenInExternalEditor}
-				onDiscard={handleDiscard}
+				onDiscard={onDiscard}
 			/>
 			{diffQuery.data ? (
 				<MultiFileDiff

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -424,22 +424,48 @@ export const gitRouter = router({
 			const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
 			const git = await ctx.git(worktreePath);
 			const status = await git.status();
-			// Files staged-as-added don't exist in HEAD — checkout would fail,
-			// so unstage and delete them instead.
-			const stagedAddedPaths = status.created;
-			// Files with staged changes that exist in HEAD (M/D/R/C/T). Scoped
-			// to staged paths only so unstaged-only files aren't touched.
-			const stagedTrackedPaths = status.files
-				.filter((f) => f.index !== " " && f.index !== "?" && f.index !== "A")
-				.map((f) => f.path);
-			if (stagedTrackedPaths.length > 0) {
-				await git.raw(["checkout", "HEAD", "--", ...stagedTrackedPaths]);
-			}
-			if (stagedAddedPaths.length > 0) {
-				await git.raw(["reset", "HEAD", "--", ...stagedAddedPaths]);
-				for (const filePath of stagedAddedPaths) {
-					await rm(join(worktreePath, filePath), { force: true });
+
+			// Files with a staged change (index entry differs from HEAD).
+			const stagedFiles = status.files.filter(
+				(f) => f.index !== " " && f.index !== "?",
+			);
+
+			const checkoutHeadPaths: string[] = [];
+			const resetPaths: string[] = [];
+			const deletePaths: string[] = [];
+
+			for (const f of stagedFiles) {
+				if (f.index === "A") {
+					// Staged-as-added: not in HEAD. Unstage + delete.
+					resetPaths.push(f.path);
+					deletePaths.push(f.path);
+				} else if (f.index === "R") {
+					// Staged rename: index has both delete-of-old and add-of-new.
+					// Unstage both ends, restore old from HEAD, delete new.
+					resetPaths.push(f.path);
+					deletePaths.push(f.path);
+					if (f.from) {
+						resetPaths.push(f.from);
+						checkoutHeadPaths.push(f.from);
+					}
+				} else if (f.index === "C") {
+					// Staged copy: source unchanged, dest is new in index.
+					resetPaths.push(f.path);
+					deletePaths.push(f.path);
+				} else {
+					// M, D, T: exists in HEAD; checkout reverts both index and WT.
+					checkoutHeadPaths.push(f.path);
 				}
+			}
+
+			if (resetPaths.length > 0) {
+				await git.raw(["reset", "HEAD", "--", ...resetPaths]);
+			}
+			if (checkoutHeadPaths.length > 0) {
+				await git.raw(["checkout", "HEAD", "--", ...checkoutHeadPaths]);
+			}
+			for (const filePath of deletePaths) {
+				await rm(join(worktreePath, filePath), { force: true });
 			}
 			return { success: true };
 		}),

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -1,4 +1,5 @@
-import { readFile } from "node:fs/promises";
+import { readFile, rm } from "node:fs/promises";
+import { isAbsolute, join, normalize, sep } from "node:path";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
@@ -33,6 +34,28 @@ import {
 	REVIEW_THREADS_QUERY,
 } from "./utils/graphql";
 import { resolveWorktreePath } from "./utils/resolve-worktree";
+
+function assertSafeRelativePath(filePath: string): void {
+	if (isAbsolute(filePath)) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: "Absolute paths are not allowed",
+		});
+	}
+	const normalized = normalize(filePath);
+	if (normalized.split(sep).includes("..")) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: "Path traversal is not allowed",
+		});
+	}
+	if (normalized === "" || normalized === ".") {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: "Cannot target worktree root",
+		});
+	}
+}
 
 export const gitRouter = router({
 	listBranches: queryProcedure
@@ -362,6 +385,69 @@ export const gitRouter = router({
 
 			await git.raw(["branch", "-m", input.oldName, input.newName]);
 			return { name: input.newName };
+		}),
+
+	discardChanges: protectedProcedure
+		.input(
+			z.object({
+				workspaceId: z.string(),
+				filePath: z.string(),
+			}),
+		)
+		.mutation(async ({ ctx, input }) => {
+			assertSafeRelativePath(input.filePath);
+			const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
+			const git = await ctx.git(worktreePath);
+			const status = await git.status();
+			const isUntracked = status.not_added.includes(input.filePath);
+			if (isUntracked) {
+				await rm(join(worktreePath, input.filePath), { force: true });
+			} else {
+				await git.raw(["checkout", "HEAD", "--", input.filePath]);
+			}
+			return { success: true };
+		}),
+
+	discardAllUnstaged: protectedProcedure
+		.input(z.object({ workspaceId: z.string() }))
+		.mutation(async ({ ctx, input }) => {
+			const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
+			const git = await ctx.git(worktreePath);
+			await git.raw(["checkout", "--", "."]);
+			await git.raw(["clean", "-fd"]);
+			return { success: true };
+		}),
+
+	discardAllStaged: protectedProcedure
+		.input(z.object({ workspaceId: z.string() }))
+		.mutation(async ({ ctx, input }) => {
+			const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
+			const git = await ctx.git(worktreePath);
+			const status = await git.status();
+			const stagedAddedPaths = status.created;
+			await git.raw(["reset", "HEAD", "--", "."]);
+			for (const filePath of stagedAddedPaths) {
+				await rm(join(worktreePath, filePath), { force: true });
+			}
+			return { success: true };
+		}),
+
+	stageAll: protectedProcedure
+		.input(z.object({ workspaceId: z.string() }))
+		.mutation(async ({ ctx, input }) => {
+			const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
+			const git = await ctx.git(worktreePath);
+			await git.raw(["add", "-A"]);
+			return { success: true };
+		}),
+
+	unstageAll: protectedProcedure
+		.input(z.object({ workspaceId: z.string() }))
+		.mutation(async ({ ctx, input }) => {
+			const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
+			const git = await ctx.git(worktreePath);
+			await git.raw(["reset", "HEAD"]);
+			return { success: true };
 		}),
 
 	getDiff: queryProcedure

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -424,8 +424,11 @@ export const gitRouter = router({
 			const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
 			const git = await ctx.git(worktreePath);
 			const status = await git.status();
+			// Capture before reset; afterwards these files become untracked
+			// and `git checkout` won't touch them.
 			const stagedAddedPaths = status.created;
 			await git.raw(["reset", "HEAD", "--", "."]);
+			await git.raw(["checkout", "--", "."]);
 			for (const filePath of stagedAddedPaths) {
 				await rm(join(worktreePath, filePath), { force: true });
 			}

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -424,13 +424,22 @@ export const gitRouter = router({
 			const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
 			const git = await ctx.git(worktreePath);
 			const status = await git.status();
-			// Capture before reset; afterwards these files become untracked
-			// and `git checkout` won't touch them.
+			// Files staged-as-added don't exist in HEAD — checkout would fail,
+			// so unstage and delete them instead.
 			const stagedAddedPaths = status.created;
-			await git.raw(["reset", "HEAD", "--", "."]);
-			await git.raw(["checkout", "--", "."]);
-			for (const filePath of stagedAddedPaths) {
-				await rm(join(worktreePath, filePath), { force: true });
+			// Files with staged changes that exist in HEAD (M/D/R/C/T). Scoped
+			// to staged paths only so unstaged-only files aren't touched.
+			const stagedTrackedPaths = status.files
+				.filter((f) => f.index !== " " && f.index !== "?" && f.index !== "A")
+				.map((f) => f.path);
+			if (stagedTrackedPaths.length > 0) {
+				await git.raw(["checkout", "HEAD", "--", ...stagedTrackedPaths]);
+			}
+			if (stagedAddedPaths.length > 0) {
+				await git.raw(["reset", "HEAD", "--", ...stagedAddedPaths]);
+				for (const filePath of stagedAddedPaths) {
+					await rm(join(worktreePath, filePath), { force: true });
+				}
 			}
 			return { success: true };
 		}),


### PR DESCRIPTION
## Summary

Brings v1's discard / staging affordances to the v2 workspace.

- **Per-file discard** on the diff viewer header (hover-revealed) and on sidebar file rows (hover overlay + right-click menu). All discards confirm via a shared `DiscardConfirmDialog` to prevent accidental loss.
- **Collapsible Staged / Unstaged section headers** above the file list, each with always-visible *Discard all* (with confirm) and a *Stage all* / *Unstage all* toggle. Against-base / committed groups render as section headers without staging actions.
- **New host-service git mutations** — `discardChanges`, `discardAllUnstaged`, `discardAllStaged`, `stageAll`, `unstageAll`. These belong on host-service (not the local Electron `changes` router) because v2 worktrees aren't registered in the local Electron DB that `assertRegisteredWorktree` checks. Each takes `workspaceId` and resolves through the host-service workspaces table; `discardChanges` validates `filePath` against absolute paths and `..` traversal.

## Test plan

- [ ] Modify a tracked file in a v2 workspace, hover the diff viewer file header, click the undo icon, confirm — change reverts and diff updates
- [ ] Same flow from the sidebar file row hover overlay
- [ ] Right-click a sidebar file row → "Discard changes" → confirm dialog reverts the file
- [ ] For an untracked file, the dialog says "Delete" and the file is removed
- [ ] On the Unstaged section header: click the plus icon → all files move to Staged; click the undo icon → confirm → working tree clean
- [ ] On the Staged section header: click the minus icon → all files move back to Unstaged; click the undo icon → confirm → staged changes wiped (staged-as-added files deleted)
- [ ] Sections only render when their group has files; collapsing the section hides its rows
- [ ] Errors surface as toasts (e.g., simulate by modifying a file outside the worktree)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds discard and stage/unstage controls to the v2 Changes tab to match v1. Improves “Discard all staged” to safely revert staged changes (including renames/copies) without touching unstaged edits.

- **New Features**
  - Per-file discard in the diff header and sidebar rows, gated by a shared `DiscardConfirmDialog`. Untracked or staged-as-added files are deleted.
  - Collapsible “Unstaged” and “Staged” sections with Discard all (with confirm) and Stage all/Unstage all. “Against base” and “Committed” show without staging actions.
  - Host-service git mutations: `discardChanges`, `discardAllUnstaged`, `discardAllStaged`, `stageAll`, `unstageAll`. Each takes `workspaceId`, validates paths, refreshes status/diff, and surfaces errors via toasts.

- **Bug Fixes**
  - `discardAllStaged` now reverts tracked files, deletes staged-as-added files, and correctly handles staged renames (`R`) and copies (`C`) by restoring sources and removing new paths. Checkout is scoped to staged paths to avoid losing unstaged-only changes.

<sup>Written for commit a7157861841f812b525099f0e0b0beb9701375ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-file discard/delete with a confirm dialog (customizable confirm label).
  * Bulk actions: discard all unstaged, discard all staged, stage all, unstage all.
  * Changes list grouped into collapsible sections by status with counts and staging controls.
  * Hover-revealed controls and placeholders/diff views now support discard actions from the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->