### PR TITLE
fix(desktop): wire electron-log to autoUpdater

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -172,6 +172,7 @@
 		"dnd-core": "^16.0.1",
 		"dotenv": "^17.3.1",
 		"drizzle-orm": "0.45.2",
+		"electron-log": "^5.4.3",
 		"electron-updater": "^6.8.3",
 		"execa": "^9.6.0",
 		"express": "^5.1.0",

--- a/apps/desktop/src/main/lib/auto-updater.ts
+++ b/apps/desktop/src/main/lib/auto-updater.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
 import { app, dialog } from "electron";
+import log from "electron-log/main";
 import { autoUpdater } from "electron-updater";
 import { env } from "main/env.main";
 import { setSkipQuitConfirmation } from "main/index";
@@ -241,6 +242,13 @@ export function setupAutoUpdater(): void {
 	if (env.NODE_ENV === "development" || !IS_AUTO_UPDATE_PLATFORM) {
 		return;
 	}
+
+	// Route electron-updater's internal logging to a file so we can diagnose
+	// silent install failures (Squirrel.Mac's ShipIt fails out-of-process and
+	// never surfaces an `error` event back to the lib). Logs land at
+	// ~/Library/Logs/Superset/main.log on macOS.
+	log.transports.file.level = "info";
+	autoUpdater.logger = log;
 
 	autoUpdater.autoDownload = true;
 	autoUpdater.autoInstallOnAppQuit = true;

--- a/apps/desktop/src/main/lib/auto-updater.ts
+++ b/apps/desktop/src/main/lib/auto-updater.ts
@@ -22,9 +22,9 @@ async function clearCachedUpdate(reason: string): Promise<void> {
 	if (!helper) return;
 	try {
 		await helper.clear();
-		console.info(`[auto-updater] Cleared cached update (${reason})`);
+		log.info(`[auto-updater] Cleared cached update (${reason})`);
 	} catch (error) {
-		console.error("[auto-updater] Failed to clear cached update:", error);
+		log.error("[auto-updater] Failed to clear cached update:", error);
 	}
 }
 
@@ -109,7 +109,7 @@ export function getUpdateStatus(): AutoUpdateStatusEvent {
 
 export function installUpdate(): void {
 	if (env.NODE_ENV === "development") {
-		console.info("[auto-updater] Install skipped in dev mode");
+		log.info("[auto-updater] Install skipped in dev mode");
 		emitStatus(AUTO_UPDATE_STATUS.IDLE);
 		return;
 	}
@@ -119,13 +119,13 @@ export function installUpdate(): void {
 	// parallel quitAndInstall calls once Squirrel fires — racing to swap
 	// the binary and leaving the app on the old version.
 	if (isInstalling) {
-		console.info(
+		log.info(
 			"[auto-updater] Install already in progress, ignoring duplicate request",
 		);
 		return;
 	}
 	if (currentStatus !== AUTO_UPDATE_STATUS.READY) {
-		console.warn(
+		log.warn(
 			`[auto-updater] Install ignored: update not ready (status=${currentStatus})`,
 		);
 		return;
@@ -148,11 +148,11 @@ export function checkForUpdates(): void {
 	emitStatus(AUTO_UPDATE_STATUS.CHECKING);
 	autoUpdater.checkForUpdates().catch((error) => {
 		if (isNetworkError(error)) {
-			console.info("[auto-updater] Network unavailable, will retry later");
+			log.info("[auto-updater] Network unavailable, will retry later");
 			emitStatus(AUTO_UPDATE_STATUS.IDLE);
 			return;
 		}
-		console.error("[auto-updater] Failed to check for updates:", error);
+		log.error("[auto-updater] Failed to check for updates:", error);
 		emitStatus(AUTO_UPDATE_STATUS.ERROR, undefined, error.message);
 	});
 }
@@ -196,7 +196,7 @@ export function checkForUpdatesInteractive(): void {
 		})
 		.catch((error) => {
 			if (isNetworkError(error)) {
-				console.info("[auto-updater] Network unavailable");
+				log.info("[auto-updater] Network unavailable");
 				emitStatus(AUTO_UPDATE_STATUS.IDLE);
 				dialog.showMessageBox({
 					type: "info",
@@ -206,7 +206,7 @@ export function checkForUpdatesInteractive(): void {
 				});
 				return;
 			}
-			console.error("[auto-updater] Failed to check for updates:", error);
+			log.error("[auto-updater] Failed to check for updates:", error);
 			emitStatus(AUTO_UPDATE_STATUS.ERROR, undefined, error.message);
 			dialog.showMessageBox({
 				type: "error",
@@ -244,8 +244,10 @@ export function setupAutoUpdater(): void {
 	}
 
 	// Squirrel.Mac install failures happen in ShipIt out-of-process and never
-	// reach the lib's `error` event, so route its logger to a file
-	// (~/Library/Logs/Superset/main.log) — our only post-mortem signal.
+	// reach the lib's `error` event, so route both the lib's internal logger
+	// and our own handler narration through electron-log. Both halves of the
+	// state machine end up interleaved in ~/Library/Logs/Superset/main.log —
+	// always use `log.{info,warn,error}` here, not `console.*`.
 	log.transports.file.level = "info";
 	autoUpdater.logger = log;
 
@@ -263,7 +265,7 @@ export function setupAutoUpdater(): void {
 		url: UPDATE_FEED_URL,
 	});
 
-	console.info(
+	log.info(
 		`[auto-updater] Initialized: version=${app.getVersion()}, channel=${IS_PRERELEASE ? "canary" : "stable"}, feedURL=${UPDATE_FEED_URL}`,
 	);
 
@@ -271,11 +273,11 @@ export function setupAutoUpdater(): void {
 		// Allow retry if Squirrel surfaces an error instead of actually quitting.
 		isInstalling = false;
 		if (isNetworkError(error)) {
-			console.info("[auto-updater] Network unavailable, will retry later");
+			log.info("[auto-updater] Network unavailable, will retry later");
 			emitStatus(AUTO_UPDATE_STATUS.IDLE);
 			return;
 		}
-		console.error(
+		log.error(
 			`[auto-updater] Error during update (currentVersion=${app.getVersion()}):`,
 			error?.message || error,
 		);
@@ -284,34 +286,34 @@ export function setupAutoUpdater(): void {
 	});
 
 	autoUpdater.on("checking-for-update", () => {
-		console.info(
+		log.info(
 			`[auto-updater] Checking for updates... (currentVersion=${app.getVersion()}, feedURL=${UPDATE_FEED_URL})`,
 		);
 		emitStatus(AUTO_UPDATE_STATUS.CHECKING);
 	});
 
 	autoUpdater.on("update-available", (info) => {
-		console.info(
+		log.info(
 			`[auto-updater] Update available: ${app.getVersion()} → ${info.version} (files: ${info.files?.map((f: { url: string }) => f.url).join(", ")})`,
 		);
 		emitStatus(AUTO_UPDATE_STATUS.DOWNLOADING, info.version);
 	});
 
 	autoUpdater.on("update-not-available", (info) => {
-		console.info(
+		log.info(
 			`[auto-updater] No updates available (currentVersion=${app.getVersion()}, latestVersion=${info.version})`,
 		);
 		emitStatus(AUTO_UPDATE_STATUS.IDLE);
 	});
 
 	autoUpdater.on("download-progress", (progress) => {
-		console.info(
+		log.info(
 			`[auto-updater] Download progress: ${progress.percent.toFixed(1)}% (${(progress.transferred / 1024 / 1024).toFixed(1)}MB / ${(progress.total / 1024 / 1024).toFixed(1)}MB)`,
 		);
 	});
 
 	autoUpdater.on("update-downloaded", (info) => {
-		console.info(
+		log.info(
 			`[auto-updater] Update downloaded: ${app.getVersion()} → ${info.version}. Ready to install.`,
 		);
 		emitStatus(AUTO_UPDATE_STATUS.READY, info.version);
@@ -327,7 +329,7 @@ export function setupAutoUpdater(): void {
 			.whenReady()
 			.then(() => checkForUpdates())
 			.catch((error) => {
-				console.error("[auto-updater] Failed to start update checks:", error);
+				log.error("[auto-updater] Failed to start update checks:", error);
 			});
 	}
 }

--- a/apps/desktop/src/main/lib/auto-updater.ts
+++ b/apps/desktop/src/main/lib/auto-updater.ts
@@ -243,10 +243,9 @@ export function setupAutoUpdater(): void {
 		return;
 	}
 
-	// Route electron-updater's internal logging to a file so we can diagnose
-	// silent install failures (Squirrel.Mac's ShipIt fails out-of-process and
-	// never surfaces an `error` event back to the lib). Logs land at
-	// ~/Library/Logs/Superset/main.log on macOS.
+	// Squirrel.Mac install failures happen in ShipIt out-of-process and never
+	// reach the lib's `error` event, so route its logger to a file
+	// (~/Library/Logs/Superset/main.log) — our only post-mortem signal.
 	log.transports.file.level = "info";
 	autoUpdater.logger = log;
 

--- a/bun.lock
+++ b/bun.lock
@@ -249,6 +249,7 @@
         "dnd-core": "^16.0.1",
         "dotenv": "^17.3.1",
         "drizzle-orm": "0.45.2",
+        "electron-log": "^5.4.3",
         "electron-updater": "^6.8.3",
         "execa": "^9.6.0",
         "express": "^5.1.0",
@@ -3853,6 +3854,8 @@
     "electron-builder": ["electron-builder@26.8.1", "", { "dependencies": { "app-builder-lib": "26.8.1", "builder-util": "26.8.1", "builder-util-runtime": "9.5.1", "chalk": "^4.1.2", "ci-info": "^4.2.0", "dmg-builder": "26.8.1", "fs-extra": "^10.1.0", "lazy-val": "^1.0.5", "simple-update-notifier": "2.0.0", "yargs": "^17.6.2" }, "bin": { "electron-builder": "cli.js", "install-app-deps": "install-app-deps.js" } }, "sha512-uWhx1r74NGpCagG0ULs/P9Nqv2nsoo+7eo4fLUOB8L8MdWltq9odW/uuLXMFCDGnPafknYLZgjNX0ZIFRzOQAw=="],
 
     "electron-builder-squirrel-windows": ["electron-builder-squirrel-windows@26.8.1", "", { "dependencies": { "app-builder-lib": "26.8.1", "builder-util": "26.8.1", "electron-winstaller": "5.4.0" } }, "sha512-o288fIdgPLHA76eDrFADHPoo7VyGkDCYbLV1GzndaMSAVBoZrGvM9m2IehdcVMzdAZJ2eV9bgyissQXHv5tGzA=="],
+
+    "electron-log": ["electron-log@5.4.3", "", {}, "sha512-sOUsM3LjZdugatazSQ/XTyNcw8dfvH1SYhXWiJyfYodAAKOZdHs0txPiLDXFzOZbhXgAgshQkshH2ccq0feyLQ=="],
 
     "electron-publish": ["electron-publish@26.8.1", "", { "dependencies": { "@types/fs-extra": "^9.0.11", "builder-util": "26.8.1", "builder-util-runtime": "9.5.1", "chalk": "^4.1.2", "form-data": "^4.0.5", "fs-extra": "^10.1.0", "lazy-val": "^1.0.5", "mime": "^2.5.2" } }, "sha512-q+jrSTIh/Cv4eGZa7oVR+grEJo/FoLMYBAnSL5GCtqwUpr1T+VgKB/dn1pnzxIxqD8S/jP1yilT9VrwCqINR4w=="],
 


### PR DESCRIPTION
## Summary

The auto-updater's default logger is `console` (`AppUpdater.ts:180`), which goes nowhere recoverable in a packaged main process. When a user hits the "READY toast re-appears every launch but the app never updates" loop, we have no signal to debug it — Squirrel.Mac's ShipIt fails out-of-process on macOS and never fires `error` back to electron-updater.

This wires `electron-log` as the autoUpdater's logger so its internal lines (manifest fetch, cache hit/miss, dispatch, native handoff) land at \`~/Library/Logs/Superset/main.log\`.

Mirrors the pattern in 1Code, opencode, and t3code — all three reference Electron apps in our workspace set a logger; Superset is the only one that doesn't.

## Test plan

- [x] \`bun run typecheck --filter=@superset/desktop\`
- [x] Existing \`auto-updater.test.ts\` (3 tests) still pass
- [ ] On a packaged build, trigger an update check and confirm \`~/Library/Logs/Superset/main.log\` contains \`electron-updater\` lines
- [ ] Ask one affected user (1.7.3 → can't update to 1.8.0) to send the log so we can diagnose the actual ShipIt failure

## Pulling logs from an affected user

> Hi! We have a fix coming for the update loop, but first we need a quick log from your end to see exactly what's failing.
>
> 1. Update to this build (the one with this PR) however you can — fresh install if needed.
> 2. Trigger the update check (it'll happen automatically, or use the "Check for Updates" menu item) and reproduce the loop once.
> 3. Open Finder, hit \`Cmd+Shift+G\`, paste \`~/Library/Logs/Superset/\`, hit Enter.
> 4. Send us \`main.log\` (zip it if it's large).
>
> Bonus, if you can find them — Squirrel writes its own logs to \`~/Library/Caches/com.superset.desktop.ShipIt/\` and \`~/Library/Logs/com.superset.desktop.ShipIt/\`. Anything in there would help too.

## Not in this PR

This is the diagnostics-only first step. Once we have a log from an affected user, we'll know whether the next fix is a stale-cache guard, a build/signing fix, or something else. No behavior change in this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired `electron-log` to `autoUpdater` and replaced handler `console.*` calls with `log.*` so both library and app-side update logs persist to `~/Library/Logs/Superset/main.log`. This improves diagnostics for the macOS update loop without changing behavior.

- **Refactors**
  - Switched all auto-updater module logging from `console` to `electron-log` so handler narration interleaves with `electron-updater` logs.

- **Dependencies**
  - Added `electron-log` (^5.4.3) and set it as the logger for `electron-updater` (file transport, level `info`).

<sup>Written for commit f2e461188034fe53e1ff0a0282e295eb3e03f5c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced auto-update diagnostics for better troubleshooting.
  * Added persistent file-based logging of update activity on the desktop app.
  * Replaced console-based updater messages with structured logger output to improve log quality and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->