### PR TITLE
fix(desktop): make NewProjectModal error text selectable

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/components/NewProjectModal/NewProjectModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/components/NewProjectModal/NewProjectModal.tsx
@@ -277,7 +277,9 @@ export function NewProjectModal({
 
 					{error && (
 						<div className="flex items-start gap-2 rounded-md border border-destructive/20 bg-destructive/10 px-3 py-2">
-							<span className="flex-1 text-xs text-destructive">{error}</span>
+							<span className="flex-1 text-xs text-destructive select-text">
+								{error}
+							</span>
 							<button
 								type="button"
 								onClick={() => setError(null)}


### PR DESCRIPTION
## Summary
- Global `user-select: none` on `body` prevented copying error messages from the New Project modal — the text users most need to share when reporting issues.
- Add `select-text` to the error span so the message can be selected and copied.

## Test plan
- [ ] Open New Project modal, trigger an error (e.g. invalid URL), select and copy the error text

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make error text in the New Project modal selectable so users can copy it. This overrides the global user-select: none that prevented copying error messages for bug reports.

<sup>Written for commit 4a451b76c247b5e9fe5452b68c906aad2a041d96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages are now selectable, allowing users to easily copy and share error text when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->