### PR TITLE
refactor(desktop): polish NewProjectModal — toast errors, Label, spinner

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/components/NewProjectModal/NewProjectModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/components/NewProjectModal/NewProjectModal.tsx
@@ -277,7 +277,9 @@ export function NewProjectModal({
 
 					{error && (
 						<div className="flex items-start gap-2 rounded-md border border-destructive/20 bg-destructive/10 px-3 py-2">
-							<span className="flex-1 text-xs text-destructive">{error}</span>
+							<span className="flex-1 text-xs text-destructive select-text">
+								{error}
+							</span>
 							<button
 								type="button"
 								onClick={() => setError(null)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/components/NewProjectModal/NewProjectModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/components/NewProjectModal/NewProjectModal.tsx
@@ -171,15 +171,63 @@ export function NewProjectModal({
 
 	return (
 		<Dialog open={open} onOpenChange={handleOpenChange}>
-			<DialogContent className="max-w-xl">
-				<DialogHeader>
-					<DialogTitle>New project</DialogTitle>
+			<DialogContent className="gap-0 overflow-hidden rounded-xl p-0 shadow-2xl sm:max-w-md">
+				<DialogHeader className="px-5 pt-5 pb-4">
+					<DialogTitle className="text-base font-semibold">
+						New project
+					</DialogTitle>
 					<DialogDescription className="sr-only">
 						Create a new project by cloning a repository or local path.
 					</DialogDescription>
 				</DialogHeader>
 
-				<div className="flex flex-col gap-4">
+				<div className="flex flex-col gap-4 px-5 pb-5">
+					<div className="grid grid-cols-3 gap-2">
+						{OPTIONS.map((option) => {
+							const selected = mode === option.mode;
+							const isDisabled = option.disabled || working;
+							return (
+								<button
+									key={option.mode}
+									type="button"
+									disabled={isDisabled}
+									onClick={() => setMode(option.mode)}
+									className={cn(
+										"flex flex-col items-center gap-2 rounded-xl border px-3 py-4 text-center transition-all",
+										selected
+											? "border-primary/40 bg-primary/5 shadow-sm"
+											: "border-border/60 bg-background",
+										!isDisabled &&
+											!selected &&
+											"hover:border-border hover:bg-accent/40",
+										isDisabled && "cursor-not-allowed opacity-50",
+									)}
+								>
+									<option.icon
+										className={cn(
+											"size-5 transition-colors",
+											selected ? "text-primary" : "text-muted-foreground",
+										)}
+									/>
+									<div className="flex flex-col items-center gap-0.5 text-xs font-medium leading-tight">
+										<span
+											className={
+												selected ? "text-foreground" : "text-foreground/90"
+											}
+										>
+											{option.label}
+										</span>
+										{option.suffix && (
+											<span className="text-[11px] font-normal text-muted-foreground">
+												{option.suffix}
+											</span>
+										)}
+									</div>
+								</button>
+							);
+						})}
+					</div>
+
 					<div className="flex flex-col gap-1.5">
 						<Label
 							htmlFor="project-path"
@@ -209,44 +257,6 @@ export function NewProjectModal({
 						</div>
 					</div>
 
-					<div className="grid grid-cols-3 gap-2">
-						{OPTIONS.map((option) => {
-							const selected = mode === option.mode;
-							const isDisabled = option.disabled || working;
-							return (
-								<button
-									key={option.mode}
-									type="button"
-									disabled={isDisabled}
-									onClick={() => setMode(option.mode)}
-									className={cn(
-										"flex flex-col items-center gap-2 rounded-lg border px-3 py-4 text-center transition-colors",
-										selected
-											? "border-transparent bg-primary/5"
-											: "border-border/60",
-										!isDisabled && !selected && "hover:bg-accent/30",
-										isDisabled && "opacity-50 cursor-not-allowed",
-									)}
-								>
-									<option.icon
-										className={cn(
-											"size-5",
-											selected ? "text-primary" : "text-muted-foreground",
-										)}
-									/>
-									<div className="flex flex-col items-center gap-0.5 text-xs font-medium text-foreground leading-tight">
-										<span>{option.label}</span>
-										{option.suffix && (
-											<span className="text-[11px] font-normal text-muted-foreground">
-												{option.suffix}
-											</span>
-										)}
-									</div>
-								</button>
-							);
-						})}
-					</div>
-
 					{mode === "clone" && (
 						<div className="flex flex-col gap-1.5">
 							<Label
@@ -272,18 +282,20 @@ export function NewProjectModal({
 					)}
 				</div>
 
-				<DialogFooter>
+				<DialogFooter className="border-t border-border bg-muted/40 px-5 py-3 sm:gap-2">
 					<Button
 						type="button"
 						variant="outline"
 						onClick={() => handleOpenChange(false)}
 						disabled={working}
+						className="transition-transform duration-150 active:scale-[0.97]"
 					>
 						Cancel
 					</Button>
 					<Button
 						onClick={() => void createFromClone()}
 						disabled={working || mode !== "clone"}
+						className="transition-transform duration-150 active:scale-[0.97]"
 					>
 						{working ? (
 							<>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/components/NewProjectModal/NewProjectModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/components/NewProjectModal/NewProjectModal.tsx
@@ -8,6 +8,8 @@ import {
 	DialogTitle,
 } from "@superset/ui/dialog";
 import { Input } from "@superset/ui/input";
+import { Label } from "@superset/ui/label";
+import { toast } from "@superset/ui/sonner";
 import { cn } from "@superset/ui/utils";
 import { useEffect, useState } from "react";
 import {
@@ -15,7 +17,7 @@ import {
 	LuFolderPlus,
 	LuGitBranch,
 	LuLayoutTemplate,
-	LuX,
+	LuLoaderCircle,
 } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
@@ -86,7 +88,6 @@ export function NewProjectModal({
 	const [mode, setMode] = useState<NewProjectMode>("clone");
 	const [parentDir, setParentDir] = useState("");
 	const [url, setUrl] = useState("");
-	const [error, setError] = useState<string | null>(null);
 	const [working, setWorking] = useState(false);
 
 	useEffect(() => {
@@ -96,7 +97,6 @@ export function NewProjectModal({
 
 	const reset = () => {
 		setUrl("");
-		setError(null);
 		setWorking(false);
 	};
 
@@ -116,33 +116,32 @@ export function NewProjectModal({
 				setParentDir(result.path);
 			}
 		} catch (err) {
-			setError(err instanceof Error ? err.message : String(err));
+			toast.error(err instanceof Error ? err.message : String(err));
 		}
 	};
 
 	const createFromClone = async () => {
 		if (!activeHostUrl) {
-			setError("Host service not available");
+			toast.error("Host service not available");
 			return;
 		}
 		const trimmedUrl = url.trim();
 		const trimmedParent = parentDir.trim();
 		if (!trimmedUrl) {
-			setError("Please enter a repository URL");
+			toast.error("Please enter a repository URL");
 			return;
 		}
 		if (!trimmedParent) {
-			setError("Please select a project location");
+			toast.error("Please select a project location");
 			return;
 		}
 		const name = deriveProjectNameFromUrl(trimmedUrl);
 		if (!name) {
-			setError("Could not derive a project name from the URL or path");
+			toast.error("Could not derive a project name from the URL or path");
 			return;
 		}
 
 		setWorking(true);
-		setError(null);
 		try {
 			const client = getHostServiceClientByUrl(activeHostUrl);
 			const result = await client.project.create.mutate({
@@ -163,7 +162,7 @@ export function NewProjectModal({
 			const message = isLeakedSql
 				? "Could not create project. Please try a different name or check the logs."
 				: raw;
-			setError(message);
+			toast.error("Could not create project", { description: message });
 			onError?.(message);
 		} finally {
 			setWorking(false);
@@ -182,12 +181,12 @@ export function NewProjectModal({
 
 				<div className="flex flex-col gap-4">
 					<div className="flex flex-col gap-1.5">
-						<label
+						<Label
 							htmlFor="project-path"
 							className="text-xs font-medium text-muted-foreground"
 						>
 							Location
-						</label>
+						</Label>
 						<div className="flex gap-1.5">
 							<Input
 								id="project-path"
@@ -219,10 +218,7 @@ export function NewProjectModal({
 									key={option.mode}
 									type="button"
 									disabled={isDisabled}
-									onClick={() => {
-										setMode(option.mode);
-										setError(null);
-									}}
+									onClick={() => setMode(option.mode)}
 									className={cn(
 										"flex flex-col items-center gap-2 rounded-lg border px-3 py-4 text-center transition-colors",
 										selected
@@ -253,12 +249,12 @@ export function NewProjectModal({
 
 					{mode === "clone" && (
 						<div className="flex flex-col gap-1.5">
-							<label
+							<Label
 								htmlFor="clone-url"
 								className="text-xs font-medium text-muted-foreground"
 							>
 								Repository URL or path
-							</label>
+							</Label>
 							<Input
 								id="clone-url"
 								value={url}
@@ -272,22 +268,6 @@ export function NewProjectModal({
 								}}
 								autoFocus
 							/>
-						</div>
-					)}
-
-					{error && (
-						<div className="flex items-start gap-2 rounded-md border border-destructive/20 bg-destructive/10 px-3 py-2">
-							<span className="flex-1 text-xs text-destructive select-text">
-								{error}
-							</span>
-							<button
-								type="button"
-								onClick={() => setError(null)}
-								className="shrink-0 rounded p-0.5 text-destructive/70 hover:text-destructive transition-colors"
-								aria-label="Dismiss error"
-							>
-								<LuX className="size-3.5" />
-							</button>
 						</div>
 					)}
 				</div>
@@ -305,7 +285,14 @@ export function NewProjectModal({
 						onClick={() => void createFromClone()}
 						disabled={working || mode !== "clone"}
 					>
-						{working ? "Cloning…" : "Clone"}
+						{working ? (
+							<>
+								<LuLoaderCircle className="size-4 animate-spin" />
+								Cloning…
+							</>
+						) : (
+							"Clone"
+						)}
 					</Button>
 				</DialogFooter>
 			</DialogContent>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/components/NewProjectModal/NewProjectModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/components/NewProjectModal/NewProjectModal.tsx
@@ -10,15 +10,8 @@ import {
 import { Input } from "@superset/ui/input";
 import { Label } from "@superset/ui/label";
 import { toast } from "@superset/ui/sonner";
-import { cn } from "@superset/ui/utils";
 import { useEffect, useState } from "react";
-import {
-	LuFolderOpen,
-	LuFolderPlus,
-	LuGitBranch,
-	LuLayoutTemplate,
-	LuLoaderCircle,
-} from "react-icons/lu";
+import { LuFolderOpen, LuLoaderCircle } from "react-icons/lu";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import {
@@ -27,42 +20,12 @@ import {
 } from "renderer/react-query/projects";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 
-type NewProjectMode = "clone" | "empty" | "template";
-
 interface NewProjectModalProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	onSuccess?: (result: ProjectSetupResult) => void;
 	onError?: (message: string) => void;
 }
-
-const OPTIONS: {
-	mode: NewProjectMode;
-	label: string;
-	suffix?: string;
-	icon: typeof LuGitBranch;
-	disabled?: boolean;
-}[] = [
-	{
-		mode: "clone",
-		label: "Clone repository",
-		icon: LuGitBranch,
-	},
-	{
-		mode: "empty",
-		label: "Empty",
-		suffix: "(coming soon)",
-		icon: LuFolderPlus,
-		disabled: true,
-	},
-	{
-		mode: "template",
-		label: "Template",
-		suffix: "(coming soon)",
-		icon: LuLayoutTemplate,
-		disabled: true,
-	},
-];
 
 function deriveProjectNameFromUrl(url: string): string {
 	const trimmed = url
@@ -85,7 +48,6 @@ export function NewProjectModal({
 	const selectDirectory = electronTrpc.window.selectDirectory.useMutation();
 	const { data: homeDir } = electronTrpc.window.getHomeDir.useQuery();
 
-	const [mode, setMode] = useState<NewProjectMode>("clone");
 	const [parentDir, setParentDir] = useState("");
 	const [url, setUrl] = useState("");
 	const [working, setWorking] = useState(false);
@@ -173,51 +135,30 @@ export function NewProjectModal({
 		<Dialog open={open} onOpenChange={handleOpenChange}>
 			<DialogContent className="max-w-[420px]">
 				<DialogHeader>
-					<DialogTitle>New project</DialogTitle>
+					<DialogTitle>Clone a repository</DialogTitle>
 					<DialogDescription className="sr-only">
 						Create a new project by cloning a repository or local path.
 					</DialogDescription>
 				</DialogHeader>
 
 				<div className="flex flex-col gap-4">
-					<div className="grid grid-cols-3 gap-2">
-						{OPTIONS.map((option) => {
-							const selected = mode === option.mode;
-							const isDisabled = option.disabled || working;
-							return (
-								<button
-									key={option.mode}
-									type="button"
-									disabled={isDisabled}
-									onClick={() => setMode(option.mode)}
-									className={cn(
-										"flex flex-col items-center gap-2 rounded-lg border px-3 py-4 text-center transition-colors",
-										selected
-											? "border-primary/40 bg-primary/5"
-											: "border-border/60 bg-background",
-										!isDisabled &&
-											!selected &&
-											"hover:border-border hover:bg-accent/40",
-										isDisabled && "cursor-not-allowed opacity-50",
-									)}
-								>
-									<option.icon
-										className={cn(
-											"size-5",
-											selected ? "text-primary" : "text-muted-foreground",
-										)}
-									/>
-									<div className="flex flex-col items-center gap-0.5 text-xs font-medium leading-tight">
-										<span>{option.label}</span>
-										{option.suffix && (
-											<span className="text-[11px] font-normal text-muted-foreground">
-												{option.suffix}
-											</span>
-										)}
-									</div>
-								</button>
-							);
-						})}
+					<div className="flex flex-col gap-1.5">
+						<Label htmlFor="clone-url" className="text-xs">
+							Repository URL or path
+						</Label>
+						<Input
+							id="clone-url"
+							value={url}
+							onChange={(e) => setUrl(e.target.value)}
+							placeholder="https://github.com/owner/repo.git or /path/to/repo"
+							disabled={working}
+							onKeyDown={(e) => {
+								if (e.key === "Enter" && !working) {
+									void createFromClone();
+								}
+							}}
+							autoFocus
+						/>
 					</div>
 
 					<div className="flex flex-col gap-1.5">
@@ -245,27 +186,6 @@ export function NewProjectModal({
 							</Button>
 						</div>
 					</div>
-
-					{mode === "clone" && (
-						<div className="flex flex-col gap-1.5">
-							<Label htmlFor="clone-url" className="text-xs">
-								Repository URL or path
-							</Label>
-							<Input
-								id="clone-url"
-								value={url}
-								onChange={(e) => setUrl(e.target.value)}
-								placeholder="https://github.com/owner/repo.git or /path/to/repo"
-								disabled={working}
-								onKeyDown={(e) => {
-									if (e.key === "Enter" && !working) {
-										void createFromClone();
-									}
-								}}
-								autoFocus
-							/>
-						</div>
-					)}
 				</div>
 
 				<DialogFooter>
@@ -277,10 +197,7 @@ export function NewProjectModal({
 					>
 						Cancel
 					</Button>
-					<Button
-						onClick={() => void createFromClone()}
-						disabled={working || mode !== "clone"}
-					>
+					<Button onClick={() => void createFromClone()} disabled={working}>
 						{working ? (
 							<>
 								<LuLoaderCircle className="size-4 animate-spin" />

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/components/NewProjectModal/NewProjectModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/components/NewProjectModal/NewProjectModal.tsx
@@ -171,17 +171,15 @@ export function NewProjectModal({
 
 	return (
 		<Dialog open={open} onOpenChange={handleOpenChange}>
-			<DialogContent className="gap-0 overflow-hidden rounded-xl p-0 shadow-2xl sm:max-w-md">
-				<DialogHeader className="px-5 pt-5 pb-4">
-					<DialogTitle className="text-base font-semibold">
-						New project
-					</DialogTitle>
+			<DialogContent className="max-w-[420px]">
+				<DialogHeader>
+					<DialogTitle>New project</DialogTitle>
 					<DialogDescription className="sr-only">
 						Create a new project by cloning a repository or local path.
 					</DialogDescription>
 				</DialogHeader>
 
-				<div className="flex flex-col gap-4 px-5 pb-5">
+				<div className="flex flex-col gap-4">
 					<div className="grid grid-cols-3 gap-2">
 						{OPTIONS.map((option) => {
 							const selected = mode === option.mode;
@@ -193,9 +191,9 @@ export function NewProjectModal({
 									disabled={isDisabled}
 									onClick={() => setMode(option.mode)}
 									className={cn(
-										"flex flex-col items-center gap-2 rounded-xl border px-3 py-4 text-center transition-all",
+										"flex flex-col items-center gap-2 rounded-lg border px-3 py-4 text-center transition-colors",
 										selected
-											? "border-primary/40 bg-primary/5 shadow-sm"
+											? "border-primary/40 bg-primary/5"
 											: "border-border/60 bg-background",
 										!isDisabled &&
 											!selected &&
@@ -205,18 +203,12 @@ export function NewProjectModal({
 								>
 									<option.icon
 										className={cn(
-											"size-5 transition-colors",
+											"size-5",
 											selected ? "text-primary" : "text-muted-foreground",
 										)}
 									/>
 									<div className="flex flex-col items-center gap-0.5 text-xs font-medium leading-tight">
-										<span
-											className={
-												selected ? "text-foreground" : "text-foreground/90"
-											}
-										>
-											{option.label}
-										</span>
+										<span>{option.label}</span>
 										{option.suffix && (
 											<span className="text-[11px] font-normal text-muted-foreground">
 												{option.suffix}
@@ -229,10 +221,7 @@ export function NewProjectModal({
 					</div>
 
 					<div className="flex flex-col gap-1.5">
-						<Label
-							htmlFor="project-path"
-							className="text-xs font-medium text-muted-foreground"
-						>
+						<Label htmlFor="project-path" className="text-xs">
 							Location
 						</Label>
 						<div className="flex gap-1.5">
@@ -259,10 +248,7 @@ export function NewProjectModal({
 
 					{mode === "clone" && (
 						<div className="flex flex-col gap-1.5">
-							<Label
-								htmlFor="clone-url"
-								className="text-xs font-medium text-muted-foreground"
-							>
+							<Label htmlFor="clone-url" className="text-xs">
 								Repository URL or path
 							</Label>
 							<Input
@@ -282,20 +268,18 @@ export function NewProjectModal({
 					)}
 				</div>
 
-				<DialogFooter className="border-t border-border bg-muted/40 px-5 py-3 sm:gap-2">
+				<DialogFooter>
 					<Button
 						type="button"
-						variant="outline"
+						variant="ghost"
 						onClick={() => handleOpenChange(false)}
 						disabled={working}
-						className="transition-transform duration-150 active:scale-[0.97]"
 					>
 						Cancel
 					</Button>
 					<Button
 						onClick={() => void createFromClone()}
 						disabled={working || mode !== "clone"}
-						className="transition-transform duration-150 active:scale-[0.97]"
 					>
 						{working ? (
 							<>

--- a/bun.lock
+++ b/bun.lock
@@ -111,7 +111,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.43",
         "@ai-sdk/openai": "3.0.36",


### PR DESCRIPTION
## Summary
Following up on #4036, align the New Project modal with the rest of the desktop app (and 1Code-style conventions):

- Replace the inline destructive error block with `toast.error` from sonner. Toasts are selectable/copyable by default, match every other error surface in the app, and free up modal real estate.
- Use the shadcn `Label` component for the form labels.
- Add a spinning `LuLoaderCircle` to the Clone button while a clone is in flight.

## Test plan
- [ ] Open New Project modal and trigger each error path (no URL, bad URL, host service unavailable, server error) — verify toast surfaces and is selectable/copyable.
- [ ] Verify spinner appears in the Clone button during a real clone.
- [ ] Verify form labels still associate with their inputs (click the label, the input focuses).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the New Project modal for a simpler, consistent UX. Errors now use selectable toasts, the dialog matches desktop styles, and the clone form is shown by default.

- **Refactors**
  - Replaced inline error panel with `toast.error` from `@superset/ui/sonner` (selectable/copyable).
  - Switched form labels to `Label` from `@superset/ui/label`.
  - Added a spinning `LuLoaderCircle` to the Clone button while cloning.
  - Removed the mode selector; dialog title is now "Clone a repository" and the clone form is shown by default.
  - Matched desktop dialog conventions: narrower width (`max-w-[420px]`), default footer, ghost Cancel.

<sup>Written for commit c3a1e293472b61c893e8b48c72ccdd61a5b2b15f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Error notifications now appear as toast alerts for directory browse failures, validation errors, and clone/create issues, replacing inline banners.
  * Clone button shows a loading spinner with "Cloning..." while operations run.
  * Form fields use clearer label headings for improved usability; the UI is simplified to a single "Clone a repository" form.

* **Bug Fixes**
  * Stale inline error messages and mode-related disabling no longer occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->