### PR TITLE
feat(desktop): image hover preview for v2 chat messages + fix lint

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ChatMessageList/components/AssistantMessage/AssistantMessage.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ChatMessageList/components/AssistantMessage/AssistantMessage.tsx
@@ -10,6 +10,7 @@ import { normalizeToolName } from "renderer/components/Chat/ChatInterface/utils/
 import type { UseChatDisplayReturn } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/hooks/useWorkspaceChatDisplay";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import { AttachmentChip } from "../AttachmentChip";
+import { ImageHoverPreview } from "../ImageHoverPreview";
 import { PendingPlanApprovalMessage } from "../PendingPlanApprovalMessage";
 
 type ChatMessage = NonNullable<UseChatDisplayReturn["messages"]>[number];
@@ -196,33 +197,47 @@ export function AssistantMessage({
 			}
 
 			if (part.type === "image" && "mimeType" in part && !rawPart.mediaType) {
+				const legacySrc = `data:${part.mimeType};base64,${part.data}`;
 				nodes.push(
-					<div key={`${message.id}-${partIndex}`} className="max-w-[85%]">
+					<ImageHoverPreview
+						key={`${message.id}-${partIndex}`}
+						src={legacySrc}
+						mediaType={part.mimeType}
+						triggerClassName="max-w-[85%]"
+					>
 						<ImagePart data={part.data} mimeType={part.mimeType} />
-					</div>,
+					</ImageHoverPreview>,
 				);
 				continue;
 			}
 
 			if (mediaType.startsWith("image/")) {
 				nodes.push(
-					<button
-						type="button"
+					<ImageHoverPreview
 						key={`${message.id}-${partIndex}`}
-						className="max-w-[85%] cursor-pointer"
-						aria-label={
-							rawPart.filename
-								? `View ${rawPart.filename}`
-								: "View generated image"
-						}
-						onClick={() => handleAttachmentClick(data, rawPart.filename)}
+						src={data}
+						filename={rawPart.filename}
+						mediaType={mediaType}
+						alt={rawPart.filename ?? "Generated"}
+						triggerClassName="max-w-[85%]"
 					>
-						<img
-							src={data}
-							alt={rawPart.filename ?? "Generated"}
-							className="max-h-48 rounded-lg object-contain"
-						/>
-					</button>,
+						<button
+							type="button"
+							className="cursor-pointer"
+							aria-label={
+								rawPart.filename
+									? `View ${rawPart.filename}`
+									: "View generated image"
+							}
+							onClick={() => handleAttachmentClick(data, rawPart.filename)}
+						>
+							<img
+								src={data}
+								alt={rawPart.filename ?? "Generated"}
+								className="max-h-48 rounded-lg object-contain"
+							/>
+						</button>
+					</ImageHoverPreview>,
 				);
 			} else {
 				nodes.push(

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ChatMessageList/components/ImageHoverPreview/ImageHoverPreview.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ChatMessageList/components/ImageHoverPreview/ImageHoverPreview.tsx
@@ -1,0 +1,62 @@
+import {
+	HoverCard,
+	HoverCardContent,
+	HoverCardTrigger,
+} from "@superset/ui/hover-card";
+import { cn } from "@superset/ui/utils";
+import type { ReactNode } from "react";
+
+interface ImageHoverPreviewProps {
+	src: string;
+	alt?: string;
+	filename?: string;
+	mediaType?: string;
+	triggerClassName?: string;
+	children: ReactNode;
+}
+
+export function ImageHoverPreview({
+	src,
+	alt,
+	filename,
+	mediaType,
+	triggerClassName,
+	children,
+}: ImageHoverPreviewProps) {
+	return (
+		<HoverCard openDelay={0} closeDelay={0}>
+			<HoverCardTrigger asChild>
+				<span className={cn("inline-flex max-w-full", triggerClassName)}>
+					{children}
+				</span>
+			</HoverCardTrigger>
+			<HoverCardContent align="start" className="w-auto p-2">
+				<div className="w-auto space-y-3">
+					<div className="relative flex max-h-96 w-96 items-center justify-center overflow-hidden rounded-md border">
+						<img
+							alt={alt ?? filename ?? "image preview"}
+							className="max-h-full max-w-full object-contain"
+							src={src}
+						/>
+					</div>
+					{(filename || mediaType) && (
+						<div className="flex items-center gap-2.5">
+							<div className="min-w-0 flex-1 space-y-1 px-0.5">
+								{filename && (
+									<h4 className="truncate font-semibold text-sm leading-none">
+										{filename}
+									</h4>
+								)}
+								{mediaType && (
+									<p className="truncate font-mono text-muted-foreground text-xs">
+										{mediaType}
+									</p>
+								)}
+							</div>
+						</div>
+					)}
+				</div>
+			</HoverCardContent>
+		</HoverCard>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ChatMessageList/components/ImageHoverPreview/ImageHoverPreview.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ChatMessageList/components/ImageHoverPreview/ImageHoverPreview.tsx
@@ -24,7 +24,7 @@ export function ImageHoverPreview({
 	children,
 }: ImageHoverPreviewProps) {
 	return (
-		<HoverCard openDelay={0} closeDelay={0}>
+		<HoverCard openDelay={200} closeDelay={50}>
 			<HoverCardTrigger asChild>
 				<span className={cn("inline-flex max-w-full", triggerClassName)}>
 					{children}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ChatMessageList/components/ImageHoverPreview/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ChatMessageList/components/ImageHoverPreview/index.ts
@@ -1,0 +1,1 @@
+export { ImageHoverPreview } from "./ImageHoverPreview";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ChatMessageList/components/UserMessage/components/UserMessageAttachments/UserMessageAttachments.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatPane/components/WorkspaceChatInterface/components/ChatMessageList/components/UserMessage/components/UserMessageAttachments/UserMessageAttachments.tsx
@@ -1,4 +1,5 @@
 import { AttachmentChip } from "../../../AttachmentChip";
+import { ImageHoverPreview } from "../../../ImageHoverPreview";
 import type { ChatMessage, ChatMessagePart } from "../../types";
 
 interface UserMessageAttachmentsProps {
@@ -32,14 +33,42 @@ export function UserMessageAttachments({
 				}
 
 				if (part.type === "image" && "mimeType" in part && !rawPart.mediaType) {
+					const legacySrc = `data:${part.mimeType};base64,${part.data}`;
 					return (
-						<div key={`${message.id}-${partIndex}`} className="max-w-[85%]">
+						<ImageHoverPreview
+							key={`${message.id}-${partIndex}`}
+							src={legacySrc}
+							mediaType={part.mimeType}
+							triggerClassName="max-w-[85%]"
+						>
 							<img
-								src={`data:${part.mimeType};base64,${part.data}`}
+								src={legacySrc}
 								alt="Attached"
 								className="max-h-48 rounded-lg object-contain"
 							/>
-						</div>
+						</ImageHoverPreview>
+					);
+				}
+
+				const chip = (
+					<AttachmentChip
+						data={data}
+						mediaType={mediaType}
+						filename={rawPart.filename}
+						onClick={() => onOpenAttachment(data, rawPart.filename)}
+					/>
+				);
+
+				if (mediaType.startsWith("image/")) {
+					return (
+						<ImageHoverPreview
+							key={`${message.id}-${partIndex}`}
+							src={data}
+							filename={rawPart.filename}
+							mediaType={mediaType}
+						>
+							{chip}
+						</ImageHoverPreview>
 					);
 				}
 

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/useMigrateV1DataToV2.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useMigrateV1DataToV2/useMigrateV1DataToV2.ts
@@ -30,7 +30,8 @@ function getLastRunAtKey(organizationId: string): string {
 }
 
 export const V1_MIGRATION_SUMMARY_EVENT = "v1-migration-summary-updated";
-export const V1_MIGRATION_LAST_RUN_AT_EVENT = "v1-migration-last-run-at-updated";
+export const V1_MIGRATION_LAST_RUN_AT_EVENT =
+	"v1-migration-last-run-at-updated";
 
 export function readLastMigrationRunAt(organizationId: string): number | null {
 	const raw = localStorage.getItem(getLastRunAtKey(organizationId));

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/V2AgentsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/V2AgentsSettings.tsx
@@ -130,8 +130,7 @@ export function V2AgentsSettings() {
 		if (!stillExists) setSelectedAgentId(configs[0].id);
 	}, [configs, selectedAgentId]);
 
-	const selectedAgent =
-		configs.find((c) => c.id === selectedAgentId) ?? null;
+	const selectedAgent = configs.find((c) => c.id === selectedAgentId) ?? null;
 
 	if (configsQuery.isError) {
 		return (

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/components/AgentDetail/AgentDetail.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/components/AgentDetail/AgentDetail.tsx
@@ -136,11 +136,7 @@ export function AgentDetail({
 		<div className="p-6 max-w-3xl w-full mx-auto">
 			<div className="mb-8 flex items-center gap-3">
 				{icon ? (
-					<img
-						src={icon}
-						alt=""
-						className="size-8 object-contain shrink-0"
-					/>
+					<img src={icon} alt="" className="size-8 object-contain shrink-0" />
 				) : null}
 				<div className="min-w-0 flex-1">
 					<h2 className="text-xl font-semibold truncate">{config.label}</h2>
@@ -180,8 +176,8 @@ export function AgentDetail({
 						label="Prompt-only args"
 						hint={
 							<>
-								Added only when launching with a prompt — e.g.{" "}
-								<code>--</code>, <code>--prompt</code>, <code>-i</code>.
+								Added only when launching with a prompt — e.g. <code>--</code>,{" "}
+								<code>--prompt</code>, <code>-i</code>.
 							</>
 						}
 						htmlFor={`prompt-args-${config.id}`}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsListSidebar/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/components/SettingsListSidebar/index.ts
@@ -1,5 +1,5 @@
 export {
-	settingsListItemClass,
-	SettingsListSidebar,
 	type SettingsListGroup,
+	SettingsListSidebar,
+	settingsListItemClass,
 } from "./SettingsListSidebar";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/experimental/components/ExperimentalSettings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/experimental/components/ExperimentalSettings/ExperimentalSettings.tsx
@@ -7,8 +7,8 @@ import { useEffect, useState } from "react";
 import { LuRefreshCw } from "react-icons/lu";
 import { env } from "renderer/env.renderer";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
-import { authClient } from "renderer/lib/auth-client";
 import { track } from "renderer/lib/analytics";
+import { authClient } from "renderer/lib/auth-client";
 import {
 	readLastMigrationRunAt,
 	useMigrateV1DataToV2,
@@ -74,8 +74,7 @@ export function ExperimentalSettings({
 								Try Superset v2
 							</Label>
 							<p className="text-xs text-muted-foreground">
-								Use the new workspace experience when early access is
-								available.
+								Use the new workspace experience when early access is available.
 							</p>
 							{!isRemoteV2Enabled && (
 								<p className="text-xs text-muted-foreground">
@@ -102,9 +101,9 @@ export function ExperimentalSettings({
 						<div className="min-w-0 flex-1 space-y-0.5">
 							<Label className="text-sm font-medium">v1 → v2 migration</Label>
 							<p className="text-xs text-muted-foreground">
-								Imports your local v1 projects and workspaces into the v2
-								cloud. Runs automatically on launch — use this to retry if
-								something was missed.
+								Imports your local v1 projects and workspaces into the v2 cloud.
+								Runs automatically on launch — use this to retry if something
+								was missed.
 							</p>
 							{!isV2CloudEnabled ? (
 								<p className="text-xs text-muted-foreground">
@@ -112,8 +111,8 @@ export function ExperimentalSettings({
 								</p>
 							) : lastRunAt !== null ? (
 								<p className="text-xs text-muted-foreground">
-									Last run{" "}
-									{formatDistanceToNow(lastRunAt, { addSuffix: true })}.
+									Last run {formatDistanceToNow(lastRunAt, { addSuffix: true })}
+									.
 								</p>
 							) : null}
 						</div>
@@ -161,10 +160,7 @@ function useLastMigrationRunAt(): number | null {
 		window.addEventListener(V1_MIGRATION_LAST_RUN_AT_EVENT, onUpdate);
 		// Re-render once a minute so "1 minute ago" advances to "2 minutes ago"
 		// without requiring a navigation.
-		const interval = window.setInterval(
-			() => forceTick((t) => t + 1),
-			60_000,
-		);
+		const interval = window.setInterval(() => forceTick((t) => t + 1), 60_000);
 		return () => {
 			window.removeEventListener(V1_MIGRATION_LAST_RUN_AT_EVENT, onUpdate);
 			window.clearInterval(interval);

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/components/HostsSettingsSidebar/HostsSettingsSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/components/HostsSettingsSidebar/HostsSettingsSidebar.tsx
@@ -9,8 +9,8 @@ import { useCollections } from "renderer/routes/_authenticated/providers/Collect
 import { MOCK_ORG_ID } from "shared/constants";
 import {
 	type SettingsListGroup,
-	settingsListItemClass,
 	SettingsListSidebar,
+	settingsListItemClass,
 } from "../../../components/SettingsListSidebar";
 
 interface HostRow {

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/projects/components/ProjectsSettingsSidebar/ProjectsSettingsSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/projects/components/ProjectsSettingsSidebar/ProjectsSettingsSidebar.tsx
@@ -10,8 +10,8 @@ import { useCollections } from "renderer/routes/_authenticated/providers/Collect
 import { MOCK_ORG_ID } from "shared/constants";
 import {
 	type SettingsListGroup,
-	settingsListItemClass,
 	SettingsListSidebar,
+	settingsListItemClass,
 } from "../../../components/SettingsListSidebar";
 
 interface ProjectRow {

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/components/PresetEditorDialog/PresetEditorDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/PresetsSection/components/PresetEditorDialog/PresetEditorDialog.tsx
@@ -1,7 +1,6 @@
 import type { ExecutionMode, TerminalPreset } from "@superset/local-db";
 import { Alert, AlertDescription } from "@superset/ui/alert";
 import { Button } from "@superset/ui/button";
-import { Switch } from "@superset/ui/switch";
 import {
 	Dialog,
 	DialogContent,
@@ -18,6 +17,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@superset/ui/select";
+import { Switch } from "@superset/ui/switch";
 import { Trash2 } from "lucide-react";
 import { useMemo } from "react";
 import { HiExclamationTriangle, HiOutlineFolderOpen } from "react-icons/hi2";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/V2SessionsSection/V2SessionsSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/terminal/components/TerminalSettings/components/V2SessionsSection/V2SessionsSection.tsx
@@ -266,31 +266,29 @@ function V2SessionsSectionInner() {
 								</tr>
 							</thead>
 							<tbody className="divide-y divide-border/40">
-									{sessions.map((s) => (
-										<tr key={s.id} className="hover:bg-muted/30">
-											<td className="px-2 py-2 font-mono">{s.id}</td>
-											<td className="px-2 py-2 text-right font-mono">
-												{s.pid || "—"}
-											</td>
-											<td className="px-2 py-2 text-right font-mono">
-												{s.cols}×{s.rows}
-											</td>
-											<td className="px-2 py-2">
-												<span
-													className={
-														s.alive
-															? "text-foreground"
-															: "text-muted-foreground"
-													}
-												>
-													{s.alive ? "Alive" : "Exited"}
-												</span>
-											</td>
-										</tr>
-									))}
-								</tbody>
-							</table>
-						</div>
+								{sessions.map((s) => (
+									<tr key={s.id} className="hover:bg-muted/30">
+										<td className="px-2 py-2 font-mono">{s.id}</td>
+										<td className="px-2 py-2 text-right font-mono">
+											{s.pid || "—"}
+										</td>
+										<td className="px-2 py-2 text-right font-mono">
+											{s.cols}×{s.rows}
+										</td>
+										<td className="px-2 py-2">
+											<span
+												className={
+													s.alive ? "text-foreground" : "text-muted-foreground"
+												}
+											>
+												{s.alive ? "Alive" : "Exited"}
+											</span>
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
 				) : null}
 			</div>
 


### PR DESCRIPTION
## Summary
- Adds the same big image preview-on-hover (HoverCard) that prompt-input attachment chips already have to image messages in v2 chat.
- Covers user-message image attachments (chips and legacy full-size) and assistant-message generated/attached images.
- Introduces a small shared `ImageHoverPreview` wrapper that internally renders a real DOM trigger (an `inline-flex` span), so non-ref-forwarding children like `AttachmentChip` work cleanly with `<HoverCardTrigger asChild>`.

## Test plan
- [ ] Hover an image attachment chip in a v2 user message — large preview popup opens with filename + media type.
- [ ] Hover an inline image in a v2 assistant message — large preview popup opens; clicking still opens the file viewer.
- [ ] Verify non-image attachments (PDF, text) still render as plain chips with no hover preview.
- [ ] Confirm layout in assistant messages still respects `max-w-[85%]`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds large image hover previews to v2 chat messages for both user attachments and assistant-generated images. Matches the prompt-input chip timing (200ms open, 50ms close); clicking still opens the file viewer.

- **New Features**
  - Introduced shared `ImageHoverPreview` using `@superset/ui/hover-card` and a real DOM trigger so non-ref-forwarding children like `AttachmentChip` work.
  - Enabled for assistant inline images and user attachments (including legacy base64); shows filename and media type; non-image attachments unchanged.

- **Refactors**
  - Applied Biome auto-fixes to resolve lint errors across settings and terminal code; no behavior changes.

<sup>Written for commit a6f758b3a27b0d7d00254915ecc0b8f994f63eac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Images in chat messages and attachments now use an image hover preview. Hovering shows an enlarged preview with filename and media type (when available) and preserves existing click/attachment behavior for non-image content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->