### PR TITLE
fix(desktop): crash in sidebar FileRow when sidebarFileLinks pref is missing

### DIFF
--- a/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
+++ b/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
@@ -33,7 +33,11 @@ export function useV2UserPreferences(): V2UserPreferencesApi {
 		[collections],
 	);
 
-	const preferences = rows[0] ?? DEFAULT_V2_USER_PREFERENCES;
+	// Merge over defaults so rows persisted before a field was added (e.g.
+	// sidebarFileLinks) still resolve that field instead of returning undefined.
+	const preferences: V2UserPreferencesRow = rows[0]
+		? { ...DEFAULT_V2_USER_PREFERENCES, ...rows[0] }
+		: DEFAULT_V2_USER_PREFERENCES;
 
 	const upsertTierMap = useCallback(
 		(key: "fileLinks" | "urlLinks" | "sidebarFileLinks", next: LinkTierMap) => {

--- a/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
+++ b/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
@@ -33,30 +33,7 @@ export function useV2UserPreferences(): V2UserPreferencesApi {
 		[collections],
 	);
 
-	// Persisted rows come back from localStorage verbatim — Zod defaults only
-	// run on insert, not on read — so rows written before a field was added
-	// (e.g. sidebarFileLinks, or a tier added later inside a LinkTierMap) leave
-	// it undefined and crash downstream consumers like buildHint. Merge the
-	// stored row over the defaults at every level we have nested defaults for.
-	const stored = rows[0];
-	const preferences: V2UserPreferencesRow = stored
-		? {
-				...DEFAULT_V2_USER_PREFERENCES,
-				...stored,
-				fileLinks: {
-					...DEFAULT_V2_USER_PREFERENCES.fileLinks,
-					...stored.fileLinks,
-				},
-				urlLinks: {
-					...DEFAULT_V2_USER_PREFERENCES.urlLinks,
-					...stored.urlLinks,
-				},
-				sidebarFileLinks: {
-					...DEFAULT_V2_USER_PREFERENCES.sidebarFileLinks,
-					...stored.sidebarFileLinks,
-				},
-			}
-		: DEFAULT_V2_USER_PREFERENCES;
+	const preferences = rows[0] ?? DEFAULT_V2_USER_PREFERENCES;
 
 	const upsertTierMap = useCallback(
 		(key: "fileLinks" | "urlLinks" | "sidebarFileLinks", next: LinkTierMap) => {

--- a/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
+++ b/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
@@ -33,10 +33,29 @@ export function useV2UserPreferences(): V2UserPreferencesApi {
 		[collections],
 	);
 
-	// Merge over defaults so rows persisted before a field was added (e.g.
-	// sidebarFileLinks) still resolve that field instead of returning undefined.
-	const preferences: V2UserPreferencesRow = rows[0]
-		? { ...DEFAULT_V2_USER_PREFERENCES, ...rows[0] }
+	// Persisted rows come back from localStorage verbatim — Zod defaults only
+	// run on insert, not on read — so rows written before a field was added
+	// (e.g. sidebarFileLinks, or a tier added later inside a LinkTierMap) leave
+	// it undefined and crash downstream consumers like buildHint. Merge the
+	// stored row over the defaults at every level we have nested defaults for.
+	const stored = rows[0];
+	const preferences: V2UserPreferencesRow = stored
+		? {
+				...DEFAULT_V2_USER_PREFERENCES,
+				...stored,
+				fileLinks: {
+					...DEFAULT_V2_USER_PREFERENCES.fileLinks,
+					...stored.fileLinks,
+				},
+				urlLinks: {
+					...DEFAULT_V2_USER_PREFERENCES.urlLinks,
+					...stored.urlLinks,
+				},
+				sidebarFileLinks: {
+					...DEFAULT_V2_USER_PREFERENCES.sidebarFileLinks,
+					...stored.sidebarFileLinks,
+				},
+			}
 		: DEFAULT_V2_USER_PREFERENCES;
 
 	const upsertTierMap = useCallback(

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
@@ -47,6 +47,7 @@ import {
 	type DashboardSidebarSectionRow,
 	dashboardSidebarProjectSchema,
 	dashboardSidebarSectionSchema,
+	healV2UserPreferences,
 	type V2TerminalPresetRow,
 	type V2UserPreferencesRow,
 	v2TerminalPresetSchema,
@@ -54,6 +55,7 @@ import {
 	type WorkspaceLocalStateRow,
 	workspaceLocalStateSchema,
 } from "./dashboardSidebarLocal";
+import { withReadHeal } from "./withReadHeal";
 
 const columnMapper = snakeCamelMapper();
 
@@ -668,15 +670,20 @@ function createOrgCollections(organizationId: string): OrgCollections {
 	);
 
 	const v2UserPreferences = createCollection(
-		localStorageCollectionOptions({
-			id: `v2_user_preferences-${organizationId}`,
-			storageKey: `v2-user-preferences-${organizationId}`,
-			schema: v2UserPreferencesSchema,
-			// Cast widens the inferred literal "preferences" key to string so
-			// the collection slots into the shared OrgCollections.{...<TKey=string>}
-			// shape alongside the other v2 collections.
-			getKey: (item) => item.id as string,
-		}),
+		localStorageCollectionOptions(
+			withReadHeal(
+				{
+					id: `v2_user_preferences-${organizationId}`,
+					storageKey: `v2-user-preferences-${organizationId}`,
+					schema: v2UserPreferencesSchema,
+					// Cast widens the inferred literal "preferences" key to string so
+					// the collection slots into the shared OrgCollections.{...<TKey=string>}
+					// shape alongside the other v2 collections.
+					getKey: (item) => item.id as string,
+				},
+				healV2UserPreferences,
+			),
+		),
 	);
 
 	return {

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
@@ -48,6 +48,7 @@ import {
 	dashboardSidebarProjectSchema,
 	dashboardSidebarSectionSchema,
 	healV2UserPreferences,
+	healWorkspaceLocalState,
 	type V2TerminalPresetRow,
 	type V2UserPreferencesRow,
 	v2TerminalPresetSchema,
@@ -643,12 +644,17 @@ function createOrgCollections(organizationId: string): OrgCollections {
 	);
 
 	const v2WorkspaceLocalState = createIndexedCollection(
-		localStorageCollectionOptions({
-			id: `v2_workspace_local_state-${organizationId}`,
-			storageKey: `v2-workspace-local-state-${organizationId}`,
-			schema: workspaceLocalStateSchema,
-			getKey: (item) => item.workspaceId,
-		}),
+		localStorageCollectionOptions(
+			withReadHeal(
+				{
+					id: `v2_workspace_local_state-${organizationId}`,
+					storageKey: `v2-workspace-local-state-${organizationId}`,
+					schema: workspaceLocalStateSchema,
+					getKey: (item) => item.workspaceId,
+				},
+				healWorkspaceLocalState,
+			),
+		),
 	);
 
 	const v2SidebarSections = createIndexedCollection(

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/collections.ts
@@ -650,7 +650,9 @@ function createOrgCollections(organizationId: string): OrgCollections {
 					id: `v2_workspace_local_state-${organizationId}`,
 					storageKey: `v2-workspace-local-state-${organizationId}`,
 					schema: workspaceLocalStateSchema,
-					getKey: (item) => item.workspaceId,
+					// Explicit type so `withReadHeal`'s passthrough generic keeps the
+					// linkage between schema and getKey for downstream inference.
+					getKey: (item: WorkspaceLocalStateRow) => item.workspaceId,
 				},
 				healWorkspaceLocalState,
 			),
@@ -684,8 +686,9 @@ function createOrgCollections(organizationId: string): OrgCollections {
 					schema: v2UserPreferencesSchema,
 					// Cast widens the inferred literal "preferences" key to string so
 					// the collection slots into the shared OrgCollections.{...<TKey=string>}
-					// shape alongside the other v2 collections.
-					getKey: (item) => item.id as string,
+					// shape alongside the other v2 collections. Explicit `item` type so
+					// `withReadHeal`'s passthrough generic keeps schema/getKey linkage.
+					getKey: (item: V2UserPreferencesRow) => item.id as string,
 				},
 				healV2UserPreferences,
 			),

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.test.ts
@@ -84,7 +84,11 @@ describe("healWorkspaceLocalState", () => {
 		const healed = healWorkspaceLocalState(baseStored);
 		expect(healed.workspaceId).toBe(baseStored.workspaceId);
 		expect(healed.createdAt).toBe(baseStored.createdAt);
-		expect(healed.paneLayout).toBe(baseStored.paneLayout);
+		// Reference equality — bun's strict toBe types reject the narrow stub,
+		// so compare via Object.is on a widened lhs and assert the boolean.
+		expect(Object.is(healed.paneLayout as unknown, baseStored.paneLayout)).toBe(
+			true,
+		);
 		expect(healed.sidebarState.projectId).toBe(
 			baseStored.sidebarState.projectId,
 		);

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { DEFAULT_V2_USER_PREFERENCES, healV2UserPreferences } from "./schema";
+import {
+	DEFAULT_V2_USER_PREFERENCES,
+	healV2UserPreferences,
+	healWorkspaceLocalState,
+} from "./schema";
 
 describe("healV2UserPreferences", () => {
 	it("returns full defaults for empty/non-object input", () => {
@@ -56,5 +60,73 @@ describe("healV2UserPreferences", () => {
 		expect(healed.sidebarFileLinks.metaShift).toBe(
 			DEFAULT_V2_USER_PREFERENCES.sidebarFileLinks.metaShift,
 		);
+	});
+});
+
+describe("healWorkspaceLocalState", () => {
+	const baseStored = {
+		workspaceId: "11111111-1111-1111-1111-111111111111",
+		createdAt: new Date("2026-01-01T00:00:00.000Z"),
+		paneLayout: { panes: [], focusedPaneId: null },
+		sidebarState: {
+			projectId: "22222222-2222-2222-2222-222222222222",
+			tabOrder: 3,
+			sectionId: null,
+			changesFilter: { kind: "all" },
+			activeTab: "changes",
+			isHidden: false,
+		},
+		viewedFiles: ["a.ts"],
+		recentlyViewedFiles: [],
+	};
+
+	it("preserves identity fields and stored values verbatim", () => {
+		const healed = healWorkspaceLocalState(baseStored);
+		expect(healed.workspaceId).toBe(baseStored.workspaceId);
+		expect(healed.createdAt).toBe(baseStored.createdAt);
+		expect(healed.paneLayout).toBe(baseStored.paneLayout);
+		expect(healed.sidebarState.projectId).toBe(
+			baseStored.sidebarState.projectId,
+		);
+		expect(healed.sidebarState.tabOrder).toBe(3);
+		expect(healed.viewedFiles).toEqual(["a.ts"]);
+	});
+
+	it("fills missing top-level optional fields", () => {
+		const stored = {
+			...baseStored,
+			viewedFiles: undefined,
+			recentlyViewedFiles: undefined,
+		};
+		const healed = healWorkspaceLocalState(stored);
+		expect(healed.viewedFiles).toEqual([]);
+		expect(healed.recentlyViewedFiles).toEqual([]);
+	});
+
+	it("fills missing nested sidebarState fields while preserving projectId", () => {
+		// Hypothetical future shape: a sidebarState field was added after this
+		// row was written. Identity (projectId) survives; defaults fill in.
+		const stored = {
+			...baseStored,
+			sidebarState: { projectId: baseStored.sidebarState.projectId },
+		};
+		const healed = healWorkspaceLocalState(stored);
+		expect(healed.sidebarState.projectId).toBe(
+			baseStored.sidebarState.projectId,
+		);
+		expect(healed.sidebarState.tabOrder).toBe(0);
+		expect(healed.sidebarState.sectionId).toBeNull();
+		expect(healed.sidebarState.changesFilter).toEqual({ kind: "all" });
+		expect(healed.sidebarState.activeTab).toBe("changes");
+		expect(healed.sidebarState.isHidden).toBe(false);
+	});
+
+	it("does not throw on null/non-object input (parser must never throw)", () => {
+		// Heal must never throw — a throw would take down the entire collection
+		// load (loadFromStorage swallows the error and returns an empty Map).
+		expect(() => healWorkspaceLocalState(null)).not.toThrow();
+		expect(() => healWorkspaceLocalState(undefined)).not.toThrow();
+		expect(() => healWorkspaceLocalState("garbage")).not.toThrow();
+		expect(() => healWorkspaceLocalState(42)).not.toThrow();
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "bun:test";
+import { DEFAULT_V2_USER_PREFERENCES, healV2UserPreferences } from "./schema";
+
+describe("healV2UserPreferences", () => {
+	it("returns full defaults for empty/non-object input", () => {
+		expect(healV2UserPreferences({})).toEqual(DEFAULT_V2_USER_PREFERENCES);
+		expect(healV2UserPreferences(null)).toEqual(DEFAULT_V2_USER_PREFERENCES);
+		expect(healV2UserPreferences(undefined)).toEqual(
+			DEFAULT_V2_USER_PREFERENCES,
+		);
+	});
+
+	it("preserves stored top-level fields and fills missing ones", () => {
+		const stored = { rightSidebarOpen: false, rightSidebarWidth: 500 };
+		const healed = healV2UserPreferences(stored);
+		expect(healed.rightSidebarOpen).toBe(false);
+		expect(healed.rightSidebarWidth).toBe(500);
+		expect(healed.sidebarFileLinks).toEqual(
+			DEFAULT_V2_USER_PREFERENCES.sidebarFileLinks,
+		);
+		expect(healed.fileLinks).toEqual(DEFAULT_V2_USER_PREFERENCES.fileLinks);
+	});
+
+	it("reproduces the original crash shape: missing sidebarFileLinks entirely", () => {
+		// Shape of rows persisted before sidebarFileLinks was added in e8067e196.
+		const stored = {
+			id: "preferences",
+			fileLinks: { plain: null, shift: null, meta: "pane", metaShift: null },
+			urlLinks: { plain: null, shift: null, meta: "pane", metaShift: null },
+			rightSidebarOpen: true,
+			rightSidebarTab: "changes",
+			rightSidebarWidth: 340,
+			deleteLocalBranch: false,
+		};
+		const healed = healV2UserPreferences(stored);
+		expect(healed.sidebarFileLinks).toEqual(
+			DEFAULT_V2_USER_PREFERENCES.sidebarFileLinks,
+		);
+		// Every tier defined — the property buildHint reads.
+		expect(healed.sidebarFileLinks.shift).toBeDefined();
+	});
+
+	it("fills missing tiers inside an otherwise-present tier map", () => {
+		// Hypothetical future shape: sidebarFileLinks exists but a tier was added
+		// to the schema after this row was written.
+		const stored = {
+			sidebarFileLinks: { plain: "pane", meta: "external" },
+		};
+		const healed = healV2UserPreferences(stored);
+		expect(healed.sidebarFileLinks.plain).toBe("pane");
+		expect(healed.sidebarFileLinks.meta).toBe("external");
+		// Tiers absent from the stored row fall back to defaults.
+		expect(healed.sidebarFileLinks.shift).toBe(
+			DEFAULT_V2_USER_PREFERENCES.sidebarFileLinks.shift,
+		);
+		expect(healed.sidebarFileLinks.metaShift).toBe(
+			DEFAULT_V2_USER_PREFERENCES.sidebarFileLinks.metaShift,
+		);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -52,6 +52,26 @@ export const workspaceLocalStateSchema = z.object({
 		.default([]),
 });
 
+// Defaults for fields heal can synthesize. Identity fields (workspaceId,
+// createdAt, paneLayout, sidebarState.projectId) intentionally absent — they
+// must come from the stored row.
+const SIDEBAR_STATE_DEFAULTS = {
+	tabOrder: 0,
+	sectionId: null,
+	changesFilter: { kind: "all" },
+	activeTab: "changes",
+	isHidden: false,
+} as const;
+
+const WORKSPACE_LOCAL_STATE_OPTIONAL_DEFAULTS = {
+	viewedFiles: [] as string[],
+	recentlyViewedFiles: [] as Array<{
+		relativePath: string;
+		absolutePath: string;
+		lastAccessedAt: number;
+	}>,
+};
+
 export const dashboardSidebarSectionSchema = z.object({
 	sectionId: z.string().uuid(),
 	projectId: z.string().uuid(),
@@ -168,10 +188,37 @@ export const DEFAULT_V2_USER_PREFERENCES: V2UserPreferencesRow = {
 };
 
 /**
- * Heal a stored row against current defaults. Used by the localStorage
- * collection's read-time parser so rows persisted before a field was added
- * (top-level or nested in a LinkTierMap) don't surface as undefined to
- * consumers. Per-tier defaults vary by map, so we deep-merge each tier map
+ * Heal a stored workspaceLocalState row against current defaults. Identity
+ * fields (workspaceId, projectId, paneLayout, createdAt) pass through from
+ * the stored row — they have no synthesizable default. Optional fields with
+ * intrinsic defaults get filled at both the top level and inside sidebarState.
+ */
+export function healWorkspaceLocalState(raw: unknown): WorkspaceLocalStateRow {
+	const r = (
+		raw && typeof raw === "object" ? raw : {}
+	) as Partial<WorkspaceLocalStateRow>;
+	const sidebar = (
+		r.sidebarState && typeof r.sidebarState === "object" ? r.sidebarState : {}
+	) as Partial<WorkspaceLocalStateRow["sidebarState"]>;
+	return {
+		...r,
+		viewedFiles:
+			r.viewedFiles ?? WORKSPACE_LOCAL_STATE_OPTIONAL_DEFAULTS.viewedFiles,
+		recentlyViewedFiles:
+			r.recentlyViewedFiles ??
+			WORKSPACE_LOCAL_STATE_OPTIONAL_DEFAULTS.recentlyViewedFiles,
+		sidebarState: {
+			...SIDEBAR_STATE_DEFAULTS,
+			...sidebar,
+		} as WorkspaceLocalStateRow["sidebarState"],
+	} as WorkspaceLocalStateRow;
+}
+
+/**
+ * Heal a stored v2 user-preferences row against current defaults. Used by the
+ * localStorage collection's read-time parser so rows persisted before a field
+ * was added (top-level or nested in a LinkTierMap) don't surface as undefined
+ * to consumers. Per-tier defaults vary by map, so we deep-merge each tier map
  * against its own default rather than relying on a single Zod default.
  */
 export function healV2UserPreferences(raw: unknown): V2UserPreferencesRow {

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -166,3 +166,26 @@ export const DEFAULT_V2_USER_PREFERENCES: V2UserPreferencesRow = {
 	rightSidebarWidth: 340,
 	deleteLocalBranch: false,
 };
+
+/**
+ * Heal a stored row against current defaults. Used by the localStorage
+ * collection's read-time parser so rows persisted before a field was added
+ * (top-level or nested in a LinkTierMap) don't surface as undefined to
+ * consumers. Per-tier defaults vary by map, so we deep-merge each tier map
+ * against its own default rather than relying on a single Zod default.
+ */
+export function healV2UserPreferences(raw: unknown): V2UserPreferencesRow {
+	const r = (
+		raw && typeof raw === "object" ? raw : {}
+	) as Partial<V2UserPreferencesRow>;
+	return {
+		...DEFAULT_V2_USER_PREFERENCES,
+		...r,
+		fileLinks: { ...DEFAULT_V2_USER_PREFERENCES.fileLinks, ...r.fileLinks },
+		urlLinks: { ...DEFAULT_V2_USER_PREFERENCES.urlLinks, ...r.urlLinks },
+		sidebarFileLinks: {
+			...DEFAULT_V2_USER_PREFERENCES.sidebarFileLinks,
+			...r.sidebarFileLinks,
+		},
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/withReadHeal.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/withReadHeal.test.ts
@@ -8,7 +8,9 @@ import {
 	healV2UserPreferences,
 	healWorkspaceLocalState,
 	V2_USER_PREFERENCES_ID,
+	type V2UserPreferencesRow,
 	v2UserPreferencesSchema,
+	type WorkspaceLocalStateRow,
 	workspaceLocalStateSchema,
 } from "./dashboardSidebarLocal";
 import { withReadHeal } from "./withReadHeal";
@@ -37,14 +39,17 @@ const noopEvents = {
 describe("withReadHeal parser", () => {
 	it("heals each entry's data through the heal fn while preserving the envelope", () => {
 		const heal = (raw: unknown) => ({ ...(raw as object), healed: true });
-		const opts = withReadHeal({}, heal);
+		const opts = withReadHeal(
+			{} as { parser?: { parse: (s: string) => unknown } },
+			heal,
+		);
 		const raw = JSON.stringify({
 			"s:foo": { versionKey: "v1", data: { a: 1 } },
 			"s:bar": { versionKey: "v2", data: { b: 2 } },
 		});
 		const parsed = opts.parser?.parse(raw) as Record<
 			string,
-			{ versionKey: string; data: { healed: boolean } }
+			{ versionKey: string; data: Record<string, unknown> }
 		>;
 		expect(parsed["s:foo"]?.versionKey).toBe("v1");
 		expect(parsed["s:foo"]?.data).toEqual({ a: 1, healed: true });
@@ -55,7 +60,10 @@ describe("withReadHeal parser", () => {
 		const heal = () => {
 			throw new Error("should not be called for non-envelope values");
 		};
-		const opts = withReadHeal({}, heal);
+		const opts = withReadHeal(
+			{} as { parser?: { parse: (s: string) => unknown } },
+			heal,
+		);
 		const raw = JSON.stringify({ "s:foo": "string-not-an-envelope" });
 		const parsed = opts.parser?.parse(raw) as Record<string, unknown>;
 		expect(parsed["s:foo"]).toBe("string-not-an-envelope");
@@ -90,7 +98,7 @@ describe("withReadHeal end-to-end via real localStorageCollectionOptions", () =>
 						id: "test-prefs",
 						storageKey: "test-prefs",
 						schema: v2UserPreferencesSchema,
-						getKey: (item) => item.id as string,
+						getKey: (item: V2UserPreferencesRow) => item.id as string,
 						storage,
 						storageEventApi: noopEvents,
 					},
@@ -174,7 +182,7 @@ describe("withReadHeal end-to-end via real localStorageCollectionOptions", () =>
 						id: "test-wls",
 						storageKey: "test-wls",
 						schema: workspaceLocalStateSchema,
-						getKey: (item) => item.workspaceId,
+						getKey: (item: WorkspaceLocalStateRow) => item.workspaceId,
 						storage,
 						storageEventApi: noopEvents,
 					},

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/withReadHeal.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/withReadHeal.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "bun:test";
+import {
+	createCollection,
+	localStorageCollectionOptions,
+} from "@tanstack/react-db";
+import {
+	DEFAULT_V2_USER_PREFERENCES,
+	healV2UserPreferences,
+	V2_USER_PREFERENCES_ID,
+	v2UserPreferencesSchema,
+} from "./dashboardSidebarLocal";
+import { withReadHeal } from "./withReadHeal";
+
+function makeMapStorage() {
+	const map = new Map<string, string>();
+	return {
+		store: map,
+		api: {
+			getItem: (key: string) => map.get(key) ?? null,
+			setItem: (key: string, value: string) => {
+				map.set(key, value);
+			},
+			removeItem: (key: string) => {
+				map.delete(key);
+			},
+		},
+	};
+}
+
+const noopEvents = {
+	addEventListener: () => {},
+	removeEventListener: () => {},
+};
+
+describe("withReadHeal parser", () => {
+	it("heals each entry's data through the heal fn while preserving the envelope", () => {
+		const heal = (raw: unknown) => ({ ...(raw as object), healed: true });
+		const opts = withReadHeal({}, heal);
+		const raw = JSON.stringify({
+			"s:foo": { versionKey: "v1", data: { a: 1 } },
+			"s:bar": { versionKey: "v2", data: { b: 2 } },
+		});
+		const parsed = opts.parser?.parse(raw) as Record<
+			string,
+			{ versionKey: string; data: { healed: boolean } }
+		>;
+		expect(parsed["s:foo"]?.versionKey).toBe("v1");
+		expect(parsed["s:foo"]?.data).toEqual({ a: 1, healed: true });
+		expect(parsed["s:bar"]?.data).toEqual({ b: 2, healed: true });
+	});
+
+	it("passes non-envelope values through unchanged", () => {
+		const heal = () => {
+			throw new Error("should not be called for non-envelope values");
+		};
+		const opts = withReadHeal({}, heal);
+		const raw = JSON.stringify({ "s:foo": "string-not-an-envelope" });
+		const parsed = opts.parser?.parse(raw) as Record<string, unknown>;
+		expect(parsed["s:foo"]).toBe("string-not-an-envelope");
+	});
+});
+
+describe("withReadHeal end-to-end via real localStorageCollectionOptions", () => {
+	it("exposes healed rows when storage holds a pre-schema-add shape", async () => {
+		const { store, api: storage } = makeMapStorage();
+		// Pre-populate storage with the exact shape that crashed buildHint:
+		// a v2-user-preferences row missing `sidebarFileLinks`.
+		const stale = {
+			id: "preferences",
+			fileLinks: { plain: null, shift: null, meta: "pane", metaShift: null },
+			urlLinks: { plain: null, shift: null, meta: "pane", metaShift: null },
+			rightSidebarOpen: true,
+			rightSidebarTab: "changes",
+			rightSidebarWidth: 340,
+			deleteLocalBranch: false,
+		};
+		storage.setItem(
+			"test-prefs",
+			JSON.stringify({
+				"s:preferences": { versionKey: "v0", data: stale },
+			}),
+		);
+
+		const collection = createCollection(
+			localStorageCollectionOptions(
+				withReadHeal(
+					{
+						id: "test-prefs",
+						storageKey: "test-prefs",
+						schema: v2UserPreferencesSchema,
+						getKey: (item) => item.id as string,
+						storage,
+						storageEventApi: noopEvents,
+					},
+					healV2UserPreferences,
+				),
+			),
+		);
+		await collection.preload();
+
+		const row = collection.get(V2_USER_PREFERENCES_ID);
+		expect(row).toBeDefined();
+		expect(row?.sidebarFileLinks).toEqual(
+			DEFAULT_V2_USER_PREFERENCES.sidebarFileLinks,
+		);
+		// Storage isn't touched by reads — heal happens in-memory only. The
+		// write-back happens on the next mutation, not at read time.
+		expect(store.get("test-prefs")).toContain('"versionKey":"v0"');
+	});
+
+	it("returns stale shape unchanged when wrapper is NOT applied (regression guard)", async () => {
+		const { api: storage } = makeMapStorage();
+		const stale = {
+			id: "preferences",
+			fileLinks: { plain: null, shift: null, meta: "pane", metaShift: null },
+			urlLinks: { plain: null, shift: null, meta: "pane", metaShift: null },
+			rightSidebarOpen: true,
+			rightSidebarTab: "changes",
+			rightSidebarWidth: 340,
+			deleteLocalBranch: false,
+		};
+		storage.setItem(
+			"test-prefs-naked",
+			JSON.stringify({
+				"s:preferences": { versionKey: "v0", data: stale },
+			}),
+		);
+
+		const collection = createCollection(
+			localStorageCollectionOptions({
+				id: "test-prefs-naked",
+				storageKey: "test-prefs-naked",
+				schema: v2UserPreferencesSchema,
+				getKey: (item) => item.id as string,
+				storage,
+				storageEventApi: noopEvents,
+			}),
+		);
+		await collection.preload();
+
+		const row = collection.get(V2_USER_PREFERENCES_ID);
+		// Pins the underlying library behavior we're working around: without
+		// the heal wrapper the field is undefined, which is what crashed
+		// buildHint. If this ever starts returning a defined value the wrapper
+		// may no longer be needed.
+		expect(row?.sidebarFileLinks).toBeUndefined();
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/withReadHeal.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/withReadHeal.test.ts
@@ -6,8 +6,10 @@ import {
 import {
 	DEFAULT_V2_USER_PREFERENCES,
 	healV2UserPreferences,
+	healWorkspaceLocalState,
 	V2_USER_PREFERENCES_ID,
 	v2UserPreferencesSchema,
+	workspaceLocalStateSchema,
 } from "./dashboardSidebarLocal";
 import { withReadHeal } from "./withReadHeal";
 
@@ -144,5 +146,55 @@ describe("withReadHeal end-to-end via real localStorageCollectionOptions", () =>
 		// buildHint. If this ever starts returning a defined value the wrapper
 		// may no longer be needed.
 		expect(row?.sidebarFileLinks).toBeUndefined();
+	});
+
+	it("heals a workspaceLocalState row missing optional + nested fields", async () => {
+		const { api: storage } = makeMapStorage();
+		const workspaceId = "11111111-1111-1111-1111-111111111111";
+		const projectId = "22222222-2222-2222-2222-222222222222";
+		// Hypothetical pre-evolution shape: identity fields present, optional
+		// top-level + nested defaults absent.
+		const stale = {
+			workspaceId,
+			createdAt: "2026-01-01T00:00:00.000Z",
+			paneLayout: { panes: [], focusedPaneId: null },
+			sidebarState: { projectId },
+		};
+		storage.setItem(
+			"test-wls",
+			JSON.stringify({
+				[`s:${workspaceId}`]: { versionKey: "v0", data: stale },
+			}),
+		);
+
+		const collection = createCollection(
+			localStorageCollectionOptions(
+				withReadHeal(
+					{
+						id: "test-wls",
+						storageKey: "test-wls",
+						schema: workspaceLocalStateSchema,
+						getKey: (item) => item.workspaceId,
+						storage,
+						storageEventApi: noopEvents,
+					},
+					healWorkspaceLocalState,
+				),
+			),
+		);
+		await collection.preload();
+
+		const row = collection.get(workspaceId);
+		expect(row).toBeDefined();
+		// Identity fields preserved.
+		expect(row?.workspaceId).toBe(workspaceId);
+		expect(row?.sidebarState.projectId).toBe(projectId);
+		// Optional defaults filled.
+		expect(row?.viewedFiles).toEqual([]);
+		expect(row?.recentlyViewedFiles).toEqual([]);
+		// Nested sidebarState defaults filled.
+		expect(row?.sidebarState.activeTab).toBe("changes");
+		expect(row?.sidebarState.changesFilter).toEqual({ kind: "all" });
+		expect(row?.sidebarState.isHidden).toBe(false);
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/withReadHeal.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/withReadHeal.ts
@@ -1,0 +1,54 @@
+interface Parser {
+	parse: (raw: string) => unknown;
+	stringify: (value: unknown) => string;
+}
+
+/**
+ * `@tanstack/db`'s `localStorageCollectionOptions` only runs the configured
+ * schema on writes — reads return whatever shape was last persisted. So a row
+ * written before a field was added comes back with that field undefined and
+ * crashes downstream consumers.
+ *
+ * This wrapper installs a custom `parser` whose `.parse` runs each stored
+ * entry's `data` through `heal`, so collections expose a normalized shape
+ * regardless of when the row was first written. Writes are unaffected and
+ * naturally rewrite the healed shape to storage on the next mutation.
+ *
+ * The library expects parsed entries to have `{ versionKey, data }` — we
+ * preserve that envelope and only reshape `data`.
+ */
+export function withReadHeal<T>(
+	options: T,
+	heal: (raw: unknown) => unknown,
+): T {
+	const baseParser: Parser = (options as { parser?: Parser }).parser ?? JSON;
+	const healingParser: Parser = {
+		stringify: (value) => baseParser.stringify(value),
+		parse: (raw) => {
+			const parsed = baseParser.parse(raw);
+			if (
+				typeof parsed !== "object" ||
+				parsed === null ||
+				Array.isArray(parsed)
+			) {
+				return parsed;
+			}
+			const result: Record<string, unknown> = {};
+			for (const [key, value] of Object.entries(parsed)) {
+				if (
+					value &&
+					typeof value === "object" &&
+					"versionKey" in value &&
+					"data" in value
+				) {
+					const entry = value as { versionKey: unknown; data: unknown };
+					result[key] = { ...entry, data: heal(entry.data) };
+				} else {
+					result[key] = value;
+				}
+			}
+			return result;
+		},
+	};
+	return { ...options, parser: healingParser } as T;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/withReadHeal.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/withReadHeal.ts
@@ -1,7 +1,4 @@
-interface Parser {
-	parse: (raw: string) => unknown;
-	stringify: (value: unknown) => string;
-}
+import type { Parser } from "@tanstack/react-db";
 
 /**
  * `@tanstack/db`'s `localStorageCollectionOptions` only runs the configured


### PR DESCRIPTION
## Summary
- Older localStorage v2 user-preference rows predate `sidebarFileLinks`, so reading them back returned `undefined` for that key
- `useSidebarFilePolicy` -> `usePolicy` -> `buildHint` then crashed with `Cannot read properties of undefined (reading 'shift')` when rendering any sidebar `FileRow`
- Fix: shallow-merge `DEFAULT_V2_USER_PREFERENCES` over the persisted row so missing top-level fields fall back to defaults (also guards future schema additions)

## Test plan
- [ ] Reproduce: with a localStorage `v2-user-preferences-*` entry that lacks `sidebarFileLinks`, open a v2 workspace and confirm the sidebar no longer crashes
- [ ] Open Settings -> Links and confirm the sidebar file links section shows the default tier mapping
- [ ] Update a tier in Settings -> Links and confirm it persists across reloads

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a desktop sidebar crash in FileRow when older v2 preferences lack `sidebarFileLinks`. Adds read-time healing for localStorage rows so preferences and workspace local state expose safe defaults and avoid undefined chains.

- **Refactors**
  - Added `withReadHeal` to wrap `localStorageCollectionOptions` from `@tanstack/react-db`, healing each entry’s `data` during parse while preserving the `{versionKey, data}` envelope.
  - Applied to `v2_user_preferences` and `v2_workspace_local_state` via `healV2UserPreferences` (deep‑merge tier maps) and `healWorkspaceLocalState` (fill optional arrays, merge `sidebarState` defaults, preserve identity fields).
  - Type-safety and tests: use the library `Parser` type; annotate `getKey` param types at call sites; added unit tests for both heal functions and the wrapper, plus an end‑to‑end test with real `localStorageCollectionOptions` and a regression guard.

<sup>Written for commit d3b4a5767b8838b54f05f60e77cc63d8c7ae9cf8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preference and workspace persisted state now auto-repair missing or malformed fields on load, preventing undefined UI values (sidebar tiers/links, viewed/recent files, sidebar state).
* **New Features**
  * Read-time healing applied to local persisted collections so the app sees healed defaults without mutating stored JSON.
* **Tests**
  * Added unit and integration tests covering healing behavior and regression protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->