### PR TITLE
chore(host-service): bump version to 0.7.0 + raise min version

### DIFF
--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -51,8 +51,13 @@ import { HOOK_PROTOCOL_VERSION } from "./terminal/env";
  * line ~308) to SIGTERM old host-services on first launch and
  * respawn with the new bundle. One-time terminal-session loss for
  * users on upgrade — accepted per release-notes guidance.
+ *
+ * 0.7.0 — canonical `workspaces.create` flow + `settings.hostAgentConfigs`
+ * router (PR1, #3893). Older 0.6.x host-services don't expose either,
+ * so adopting one in place would break new-project creation and the
+ * agent-config settings UI. Force respawn on first launch.
  */
-const MIN_HOST_SERVICE_VERSION = "0.6.0";
+const MIN_HOST_SERVICE_VERSION = "0.7.0";
 
 export type HostServiceStatus = "starting" | "running" | "stopped";
 

--- a/packages/host-service/src/trpc/router/host/host.ts
+++ b/packages/host-service/src/trpc/router/host/host.ts
@@ -18,7 +18,11 @@ import { protectedProcedure, router } from "../../index";
 // them on upgrade and respawn with the new bundle. Adopting in
 // place would leave the new desktop talking to old code with no
 // `terminal.daemon.*` routes, breaking Settings → Manage daemon.
-const HOST_SERVICE_VERSION = "0.6.0";
+// 0.7.0: canonical `workspaces.create` flow + `settings.hostAgentConfigs`
+// router (PR1, #3893). 0.6.x host-services don't expose either, so
+// adopting one in place would break new-project creation and the
+// agent-config settings UI.
+const HOST_SERVICE_VERSION = "0.7.0";
 const ORGANIZATION_CACHE_TTL_MS = 60 * 60 * 1000;
 
 let cachedOrganization: {


### PR DESCRIPTION
## Summary
- Bumps `HOST_SERVICE_VERSION` and `MIN_HOST_SERVICE_VERSION` from 0.6.0 → 0.7.0.
- PR1 (#3893) added the canonical `workspaces.create` flow and `settings.hostAgentConfigs` router. 0.6.x host-services don't expose either, so adopting one in place would break v2 new-project creation and the agent-config settings UI.
- Forces the coordinator's `tryAdopt` to SIGTERM any pre-0.7.0 service on first launch and respawn with the new bundle. Same one-time disruption pattern as the prior 0.5 → 0.6 bump (#4006).

## Test plan
- [ ] Launch desktop with an adopted 0.6.x host-service; confirm it gets killed + respawned at 0.7.0.
- [ ] Verify v2 `workspaces.create` and `settings.hostAgentConfigs` work post-respawn.
- [ ] Fresh install (no prior service): host-service starts at 0.7.0, no respawn loop.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the host service to 0.7.0 and raises the minimum required version to 0.7.0. This enforces support for `workspaces.create` and `settings.hostAgentConfigs` and prevents broken v2 new-project creation and agent-config settings.

- **Migration**
  - On first launch with a 0.6.x service, the coordinator sends SIGTERM and respawns with the 0.7.0 bundle (one-time).
  - Fresh installs start at 0.7.0 with no respawn loop.

<sup>Written for commit fb3a36b182796f91a54507316a030ee2a336bb48. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum required host-service version to 0.7.0. Services running versions older than 0.7.0 will now be marked as incompatible and automatically removed from the system to maintain platform stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->