### PR TITLE
style(desktop): refine v2 workspace not found state

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceNotFoundState/WorkspaceNotFoundState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceNotFoundState/WorkspaceNotFoundState.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@superset/ui/button";
 import { Link } from "@tanstack/react-router";
-import { FolderX } from "lucide-react";
+import { ArrowRight, FolderX } from "lucide-react";
 
 interface WorkspaceNotFoundStateProps {
 	workspaceId: string;
@@ -11,25 +11,36 @@ export function WorkspaceNotFoundState({
 }: WorkspaceNotFoundStateProps) {
 	return (
 		<div className="flex h-full w-full items-center justify-center p-6">
-			<div className="flex w-full max-w-md flex-col items-center rounded-xl border border-border bg-card px-6 py-8 text-center">
-				<div className="mb-4 rounded-full border border-border bg-muted/40 p-3 text-muted-foreground">
-					<FolderX className="size-5" />
+			<div className="flex w-full max-w-sm flex-col items-start gap-5">
+				<FolderX className="size-5 text-muted-foreground" strokeWidth={1.5} />
+				<div className="flex flex-col gap-1.5">
+					<h1 className="text-[15px] font-medium tracking-tight text-foreground">
+						Workspace not found
+					</h1>
+					<p className="text-[13px] leading-relaxed text-muted-foreground">
+						This workspace may have been removed, or you no longer have access
+						to it.
+					</p>
 				</div>
-				<h1 className="text-lg font-semibold tracking-tight">
-					Workspace not found
-				</h1>
-				<p className="mt-2 text-sm text-muted-foreground">
-					This workspace may have been removed or you may no longer have access
-					to it.
-				</p>
-				<p className="mt-1 text-xs text-muted-foreground/80">
-					ID: {workspaceId}
-				</p>
-				<div className="mt-6 flex items-center gap-2">
-					<Button asChild size="sm">
-						<Link to="/v2-workspaces">Browse workspaces</Link>
-					</Button>
+				<div className="flex w-full items-center gap-2 rounded-md border border-border/60 bg-muted/30 px-2.5 py-1.5">
+					<span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70">
+						ID
+					</span>
+					<code className="truncate font-mono text-[11px] text-muted-foreground">
+						{workspaceId}
+					</code>
 				</div>
+				<Button
+					asChild
+					size="sm"
+					variant="ghost"
+					className="-ml-2 h-7 gap-1.5 px-2 text-[13px] font-medium text-foreground hover:bg-muted/60"
+				>
+					<Link to="/v2-workspaces">
+						Browse workspaces
+						<ArrowRight className="size-3.5" strokeWidth={2} />
+					</Link>
+				</Button>
 			</div>
 		</div>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceNotFoundState/WorkspaceNotFoundState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceNotFoundState/WorkspaceNotFoundState.tsx
@@ -12,7 +12,11 @@ export function WorkspaceNotFoundState({
 	return (
 		<div className="flex h-full w-full items-center justify-center p-6">
 			<div className="flex w-full max-w-sm flex-col items-start gap-5">
-				<FolderX className="size-5 text-muted-foreground" strokeWidth={1.5} />
+				<FolderX
+					className="size-5 text-muted-foreground"
+					strokeWidth={1.5}
+					aria-hidden="true"
+				/>
 				<div className="flex flex-col gap-1.5">
 					<h1 className="text-[15px] font-medium tracking-tight text-foreground">
 						Workspace not found
@@ -26,7 +30,7 @@ export function WorkspaceNotFoundState({
 					<span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70">
 						ID
 					</span>
-					<code className="truncate font-mono text-[11px] text-muted-foreground">
+					<code className="min-w-0 truncate font-mono text-[11px] text-muted-foreground">
 						{workspaceId}
 					</code>
 				</div>
@@ -38,7 +42,11 @@ export function WorkspaceNotFoundState({
 				>
 					<Link to="/v2-workspaces">
 						Browse workspaces
-						<ArrowRight className="size-3.5" strokeWidth={2} />
+						<ArrowRight
+							className="size-3.5"
+							strokeWidth={2}
+							aria-hidden="true"
+						/>
 					</Link>
 				</Button>
 			</div>


### PR DESCRIPTION
## Summary
- Redesigns the v2 `WorkspaceNotFoundState` with Linear's minimal aesthetic — drops the bordered card for a borderless, left-aligned layout
- Replaces the icon-pill treatment with a bare thin-stroke icon, tightens type scale (15px medium title, 13px body), and renders the workspace ID as a monospaced chip with an `ID` label
- Swaps the solid primary CTA for a ghost button with a trailing arrow, optically aligned to the title

## Test plan
- [ ] Navigate to a non-existent v2 workspace URL and verify the new empty state renders correctly in light + dark themes
- [ ] Confirm "Browse workspaces" link routes to `/v2-workspaces`
- [ ] Verify long workspace IDs truncate gracefully in the ID chip

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restyled the v2 `WorkspaceNotFoundState` to a borderless, left-aligned layout that matches Linear’s minimal design. Uses a thin-stroke icon, tighter type (15px/13px), a monospaced ID chip, and a ghost “Browse workspaces” link with a trailing arrow to `/v2-workspaces`.

- **Bug Fixes**
  - Ensure long workspace IDs truncate inside the chip with `min-w-0`.
  - Hide decorative icons from screen readers by setting `aria-hidden` on `FolderX` and `ArrowRight`.

<sup>Written for commit 62757747a59becc52aa9bcc7364127de29b1f8dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined the workspace “not found” error state with a narrower, left-aligned column and updated typography for clearer hierarchy.
  * Improved the workspace ID display into a bordered, inline row with an uppercase label and monospaced, truncated code styling for readability.
  * Updated the “Browse workspaces” call-to-action to a ghost-styled button and added a right-arrow icon for clearer navigation affordance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->