### PR TITLE
release(cli): cut v0.2.4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -677,7 +677,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
         "@clack/prompts": "^0.10.0",
         "@superset/cli-framework": "workspace:*",

--- a/packages/cli/cli.config.ts
+++ b/packages/cli/cli.config.ts
@@ -1,6 +1,6 @@
 import { boolean, defineConfig, string } from "@superset/cli-framework";
 
-const VERSION = "0.2.3";
+const VERSION = "0.2.4";
 
 export default defineConfig({
 	name: "superset",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "0.2.3",
+	"version": "0.2.4",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Summary
- Bumps `@superset/cli` to **v0.2.4** (`packages/cli/package.json`, `cli.config.ts`, `bun.lock`).
- Bundles the feat(cli) work merged since v0.2.3:
  - `agents run` command + variadic flag support (#3893)

## Release plan
After this PR merges, push the `cli-v0.2.4` tag to fire `.github/workflows/release-cli.yml`, which builds the 3-target matrix (`darwin-arm64`, `linux-x64`, `linux-arm64`) and publishes the draft GitHub release plus the rolling `cli-latest` pointer.

## Test plan
- [ ] CI green on this PR
- [ ] After merge + tag push, verify the Release CLI workflow run, draft release assets, and `cli-latest` pointer

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cut `@superset/cli` v0.2.4. Ships the new agents run command and variadic flag support since v0.2.3.

- **Migration**
  - After merge, push the `cli-v0.2.4` tag to trigger `.github/workflows/release-cli.yml`, build darwin-arm64/linux-x64/linux-arm64, publish the draft release, and update `cli-latest`.

<sup>Written for commit 1acfae274f950f8831063e6c5d4304877f8f5f10. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CLI version to 0.2.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->