### PR TITLE
fix(ci): drop redundant better-sqlite3 rebuild in CLI Linux build

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -40,11 +40,18 @@ jobs:
           # against node-pty's compile-from-source path on Linux (node-pty
           # ships no Linux prebuilds). Skip scripts at install, then rebuild
           # native deps explicitly via npm/node-gyp.
+          #
+          # better-sqlite3 is intentionally NOT rebuilt here: build-dist.ts's
+          # fixNativeBinariesForNode() unconditionally downloads the matching
+          # Node-ABI prebuild from GitHub releases and overwrites the .node
+          # file. Running `npm rebuild better-sqlite3` here is redundant work
+          # and a CI flake source — its `prebuild-install || node-gyp rebuild`
+          # install script intermittently truncates the prebuild download or
+          # leaves partial state that breaks the gyp fallback on linux-x64.
           set -euo pipefail
           bun install --frozen --ignore-scripts
           PTY_DIR=$(ls -d node_modules/.bun/node-pty@*/node_modules/node-pty)
           (cd "$PTY_DIR" && npx --yes node-gyp rebuild)
-          npm rebuild better-sqlite3
           npm rebuild @parcel/watcher
 
       - name: Install dependencies (macOS)


### PR DESCRIPTION
## Why
The `cli-v0.2.4` release just bricked on `linux-x64` (run [25340826401](https://github.com/superset-sh/superset/actions/runs/25340826401)) at the `Install dependencies (Linux)` step:

```
npm error path .../node_modules/.bun/better-sqlite3@12.6.2/.../better-sqlite3
npm error command failed
npm error command sh -c prebuild-install || node-gyp rebuild --release
npm error prebuild-install warn install ENOENT: ...build/Release/better_sqlite3.node
npm error gyp: ...build/config.gypi not found while reading includes of binding.gyp
npm error gyp ERR! configure error
npm error gyp ERR! stack Error: `gyp` failed with exit code: 1
```

Same step has bricked before with a different mode each time:

| tag | mode |
|---|---|
| cli-v0.2.4 | `prebuild-install ENOENT` then gyp config.gypi missing |
| cli-v0.2.2 | `prebuild-install file too short` then gyp `EEXIST` on `python3` symlink |
| cli-v0.2.3 | succeeded |
| cli-v0.2.1 / 0.2.0 | succeeded |

`prebuild-install` is intermittently mis-extracting / failing the download, and when it falls through to `node-gyp rebuild --release` the leftover state breaks the gyp run.

## What changes
Remove `npm rebuild better-sqlite3` from the Linux install step. It was redundant: `packages/cli/scripts/build-dist.ts:282-297` (`fixNativeBinariesForNode`) **already** does

```ts
const bsqUrl =
  `https://github.com/WiseLibs/better-sqlite3/releases/download/` +
  `v${bsqVersion}/better-sqlite3-v${bsqVersion}-node-v${NODE_ABI}-${target}.tar.gz`;
...
rmSync(bsqDest, { recursive: true, force: true });
mkdirSync(bsqDest, { recursive: true });
cpSync(join(tmp, "build", "Release", "better_sqlite3.node"), join(bsqDest, "better_sqlite3.node"));
```

— it unconditionally fetches the Node-ABI prebuild from GitHub releases and overwrites `lib/node_modules/better-sqlite3/build/Release/better_sqlite3.node` in the dist. Whatever `npm rebuild` produced was just thrown away.

`node-pty` rebuild stays (no Linux prebuilds ship in the npm package — node-pty really is compiled from source). `@parcel/watcher` rebuild also stays for now (haven't seen it flake; out of scope).

## Test plan
- [ ] CI green on this PR (Linux build invoked via `build-cli.yml` from `ci.yml`)
- [ ] After merge, retry the CLI release — re-cut a release PR + push the tag, or temporarily run `release-cli.yml` via `workflow_dispatch` on `main` to verify all three matrix targets land artifacts
- [ ] Confirm the smoke-test `require('better-sqlite3')` still passes against the bundled Node — that's what proves `fixNativeBinariesForNode`'s GitHub fetch produced a usable binary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `npm rebuild better-sqlite3` from the CLI Linux build to stop flaky `linux-x64` failures. The dist step already fetches and overwrites the correct `better-sqlite3` prebuild via `fixNativeBinariesForNode()`.

- **Bug Fixes**
  - Dropped the redundant `better-sqlite3` rebuild that triggered intermittent `prebuild-install`/`node-gyp` errors.
  - Kept `node-pty` and `@parcel/watcher` rebuilds; `node-pty` requires source build on Linux and watcher remains unchanged.

<sup>Written for commit a71b7dcac3268d032749b3d60a69f1347467bcb6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Linux build process stability by optimizing dependency installation and native module compilation, reducing CI build failures on Linux systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->