### PR TITLE
fix(desktop): non-blocking inspect on v2 delete dialog

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/DashboardSidebarDeleteDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/DashboardSidebarDeleteDialog.tsx
@@ -55,11 +55,7 @@ export function DashboardSidebarDeleteDialog({
 	}
 
 	const hasWarnings = hasChanges || hasUnpushedCommits;
-	const confirmLabel = isCheckingStatus
-		? "Checking…"
-		: hasWarnings
-			? "Delete anyway"
-			: "Delete";
+	const confirmLabel = hasWarnings ? "Delete anyway" : "Delete";
 
 	return (
 		<DestroyConfirmPane

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/components/DestroyConfirmPane/DestroyConfirmPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/components/DestroyConfirmPane/DestroyConfirmPane.tsx
@@ -54,6 +54,11 @@ export function DestroyConfirmPane({
 						also be removed.
 					</AlertDialogDescription>
 				</AlertDialogHeader>
+				{isCheckingStatus && !hasWarnings && (
+					<div className="px-4 pb-2 text-xs text-muted-foreground">
+						Checking delete status…
+					</div>
+				)}
 				{hasWarnings && (
 					<div className="px-4 pb-2">
 						<div className="text-xs text-yellow-700 dark:text-yellow-400 bg-yellow-50 dark:bg-yellow-500/10 border border-yellow-200 dark:border-yellow-500/20 rounded-md px-2.5 py-1.5">
@@ -103,7 +108,7 @@ export function DestroyConfirmPane({
 						size="sm"
 						className="h-7 px-3 text-xs"
 						onClick={onConfirm}
-						disabled={isCheckingStatus || !canConfirm}
+						disabled={!canConfirm}
 					>
 						{confirmLabel}
 					</Button>


### PR DESCRIPTION
## Summary
- The Delete button on the v2 delete dialog was disabled while `workspaceCleanup.inspect` ran, making the dialog feel like it hung on slow inspects (the cloud `getFromHost` round-trip alone can be hundreds of ms).
- Inspect is purely informational — `destroy` re-runs the authoritative checks and silently force-retries on dirty-worktree `CONFLICT`s — so there's no correctness reason to gate the button on it.
- Drop \`isCheckingStatus\` from the Delete button's disabled state, and replace the "Checking…" confirm label with a muted "Checking delete status…" line in the dialog body, shown only while no warnings are available yet.

## Test plan
- [ ] Open the delete dialog for a workspace; confirm the Delete button is clickable immediately and the "Checking delete status…" hint shows briefly.
- [ ] Open the delete dialog for a dirty worktree; confirm the warning banner replaces the hint when inspect returns and clicking Delete still goes through (silent force-retry on CONFLICT).
- [ ] Open the delete dialog for a main workspace; confirm the blocking reason still disables Delete.
- [ ] Click Delete *before* inspect returns on a dirty worktree; confirm the destroy still completes (silent force-retry path).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the v2 delete dialog non-blocking by decoupling the Delete button from `workspaceCleanup.inspect`, so it’s clickable immediately. Status checks now render as a muted hint in the dialog body instead of replacing the button label.

- **Bug Fixes**
  - Removed `isCheckingStatus` from the Delete button’s disabled logic; only `canConfirm` gates the action.
  - Replaced the "Checking…" button label with a small "Checking delete status…" message shown until warnings appear; warnings still surface when inspect returns, and deletion re-checks and force-retries on dirty-worktree conflicts.

<sup>Written for commit 511bdb92cd1750ff6dd068065db462f9f25a8961. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved delete confirmation workflow: the confirm button is now enabled during status checks, allowing you to proceed with deletion immediately instead of being blocked while checks complete.
  * Updated status indicator messaging for clearer feedback during the deletion status check process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->