### PR TITLE
fix(cli): retry + cache prebuild downloads in build-dist; add docker test

### DIFF
--- a/packages/cli/scripts/build-dist-linux-docker.sh
+++ b/packages/cli/scripts/build-dist-linux-docker.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Reproduce the GitHub Actions Linux CLI build inside a Docker container.
+# Mirrors `.github/workflows/build-cli.yml` so we can validate the full
+# install + build + smoke-test flow without cutting a release.
+#
+# Usage:
+#   packages/cli/scripts/build-dist-linux-docker.sh [linux-x64|linux-arm64]
+#
+# Outputs the tarball at packages/cli/dist/superset-<target>.tar.gz inside
+# the container's copy of the repo and runs the same require() smoke test
+# the CI workflow runs.
+set -euo pipefail
+
+TARGET="${1:-linux-x64}"
+case "$TARGET" in
+  linux-x64) PLATFORM="linux/amd64"; NODE_ARCH="x64" ;;
+  linux-arm64) PLATFORM="linux/arm64"; NODE_ARCH="arm64" ;;
+  *) echo "Usage: $0 [linux-x64|linux-arm64]" >&2; exit 1 ;;
+esac
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+BUN_VERSION="$(cat "$REPO_ROOT/.bun-version")"
+NODE_VERSION="22.22.2"
+
+echo "[docker-build] target=$TARGET platform=$PLATFORM bun=$BUN_VERSION node=$NODE_VERSION"
+echo "[docker-build] repo: $REPO_ROOT"
+
+# Mount the repo read-only and copy it into a writable workdir inside the
+# container so the host's darwin-arm64 node_modules don't bleed in. The
+# container does its own `bun install` against the lockfile.
+docker run --rm --platform "$PLATFORM" \
+  -v "$REPO_ROOT:/host:ro" \
+  -e TARGET="$TARGET" \
+  -e NODE_ARCH="$NODE_ARCH" \
+  -e NODE_VERSION="$NODE_VERSION" \
+  -e RELAY_URL="${RELAY_URL:-https://relay.superset.sh}" \
+  -e SUPERSET_API_URL="${SUPERSET_API_URL:-https://api.superset.sh}" \
+  -e SUPERSET_WEB_URL="${SUPERSET_WEB_URL:-https://app.superset.sh}" \
+  "oven/bun:${BUN_VERSION}" bash -euxc '
+    apt-get update -qq
+    apt-get install -y --no-install-recommends \
+      curl python3 make g++ ca-certificates xz-utils rsync >/dev/null
+
+    curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" \
+      | tar -xJ -C /usr/local --strip-components=1
+    node --version
+    bun --version
+
+    rsync -a --exclude=node_modules --exclude=dist --exclude=.next /host/ /work/
+    cd /work
+
+    # Mirrors `.github/workflows/build-cli.yml` Linux install step.
+    # Bun occasionally hits transient integrity-check failures on cold caches
+    # in Docker, retry once before giving up.
+    bun install --frozen --ignore-scripts || \
+      (rm -rf ~/.bun/install/cache && bun install --frozen --ignore-scripts)
+    PTY_DIR=$(ls -d node_modules/.bun/node-pty@*/node_modules/node-pty)
+    (cd "$PTY_DIR" && npx --yes node-gyp rebuild)
+    npm rebuild @parcel/watcher
+
+    cd packages/cli
+    bun run build:dist --target="$TARGET"
+
+    DIST="./dist/superset-${TARGET}"
+    "$DIST/bin/superset" --version
+    "$DIST/bin/superset" --help | head -5
+    "$DIST/lib/node" --version
+    NODE_PATH="$DIST/lib/node_modules" "$DIST/lib/node" -e "
+      for (const m of [\"better-sqlite3\", \"node-pty\", \"@parcel/watcher\", \"libsql\"]) {
+        require(m);
+        console.log(m, \"OK\");
+      }
+    "
+    echo "[docker-build] tarball: $(ls -la dist/superset-${TARGET}.tar.gz)"
+  '

--- a/packages/cli/scripts/build-dist.ts
+++ b/packages/cli/scripts/build-dist.ts
@@ -27,6 +27,7 @@ import {
 	readdirSync,
 	readFileSync,
 	realpathSync,
+	renameSync,
 	rmSync,
 	writeFileSync,
 } from "node:fs";
@@ -137,6 +138,35 @@ async function exec(cmd: string, args: string[], cwd?: string): Promise<void> {
 	});
 }
 
+/**
+ * curl wrapper that retries on network/HTTP flake (GitHub Releases 5xx,
+ * connection resets, etc). Writes atomically: download to a .partial
+ * sibling first, then rename — so a previous half-written file can't be
+ * mistaken for a cache hit on the next run. `--retry-all-errors` covers
+ * 5xx as well as transport errors; without it curl only retries a small
+ * subset by default.
+ */
+async function curlDownload(url: string, destPath: string): Promise<void> {
+	const partial = `${destPath}.partial`;
+	rmSync(partial, { force: true });
+	await exec("curl", [
+		"-fsSL",
+		"--retry",
+		"6",
+		"--retry-delay",
+		"2",
+		"--retry-all-errors",
+		"--connect-timeout",
+		"15",
+		"--max-time",
+		"180",
+		"-o",
+		partial,
+		url,
+	]);
+	renameSync(partial, destPath);
+}
+
 async function downloadAndExtractNode(
 	target: Target,
 	destDir: string,
@@ -150,7 +180,7 @@ async function downloadAndExtractNode(
 
 	if (!existsSync(archivePath)) {
 		console.log(`[build-dist] downloading ${nodeDownloadUrl(target)}`);
-		await exec("curl", ["-fsSL", "-o", archivePath, nodeDownloadUrl(target)]);
+		await curlDownload(nodeDownloadUrl(target), archivePath);
 	}
 
 	if (!existsSync(extractedPath)) {
@@ -282,13 +312,22 @@ async function fixNativeBinariesForNode(
 	const bsqUrl =
 		`https://github.com/WiseLibs/better-sqlite3/releases/download/` +
 		`v${bsqVersion}/better-sqlite3-v${bsqVersion}-node-v${NODE_ABI}-${target}.tar.gz`;
-	console.log(`[build-dist] fetching Node-ABI better-sqlite3: ${bsqUrl}`);
-	const tmp = join(homedir(), ".superset-build-cache", `bsq-${target}`);
+	const cacheDir = join(homedir(), ".superset-build-cache");
+	if (!existsSync(cacheDir)) mkdirSync(cacheDir, { recursive: true });
+	const cachedTarball = join(
+		cacheDir,
+		`better-sqlite3-v${bsqVersion}-node-v${NODE_ABI}-${target}.tar.gz`,
+	);
+	if (!existsSync(cachedTarball)) {
+		console.log(`[build-dist] fetching Node-ABI better-sqlite3: ${bsqUrl}`);
+		await curlDownload(bsqUrl, cachedTarball);
+	} else {
+		console.log(`[build-dist] using cached better-sqlite3: ${cachedTarball}`);
+	}
+	const tmp = join(cacheDir, `bsq-${target}`);
 	rmSync(tmp, { recursive: true, force: true });
 	mkdirSync(tmp, { recursive: true });
-	const tarball = join(tmp, "bsq.tar.gz");
-	await exec("curl", ["-fsSL", "-o", tarball, bsqUrl]);
-	await exec("tar", ["-xzf", tarball, "-C", tmp]);
+	await exec("tar", ["-xzf", cachedTarball, "-C", tmp]);
 	rmSync(bsqDest, { recursive: true, force: true });
 	mkdirSync(bsqDest, { recursive: true });
 	cpSync(


### PR DESCRIPTION
## Why
After landing #4049, `cli-v0.2.4` was re-tagged. Linux now passes ([run](https://github.com/superset-sh/superset/actions/runs/25341297736)) — but darwin-arm64 just failed inside `build-dist.ts`:

```
[build-dist] fetching Node-ABI better-sqlite3: https://github.com/WiseLibs/better-sqlite3/releases/download/v12.6.2/better-sqlite3-v12.6.2-node-v127-darwin-arm64.tar.gz
curl: (56) The requested URL returned error: 502
error: curl ... exited with 56
```

A single transient GitHub Releases 502 → full matrix is dead. Same single-shot curl was used for the Node download too, so this is a strictly weaker sibling of the same failure mode.

## What changes

### 1. Resilient prebuild downloads (`packages/cli/scripts/build-dist.ts`)
- Route all curl through `curlDownload(url, dest)` with:
  - `--retry 6 --retry-delay 2 --retry-all-errors` — `--retry-all-errors` is required for curl to retry on 5xx (default retry only covers transport errors).
  - `--connect-timeout 15 --max-time 180`
  - Atomic write: download to `${dest}.partial`, then `renameSync` — a half-finished file can't masquerade as a cache hit on the next run.
- Cache the better-sqlite3 prebuild on disk like the Node tarball already is, keyed by `version + ABI + target`. Re-running build-dist after a transient failure is now free.

### 2. Local Docker harness (`packages/cli/scripts/build-dist-linux-docker.sh`)
Reproduces the GH Actions Linux flow exactly (matches `.github/workflows/build-cli.yml`) inside the `oven/bun:<.bun-version>` image, for either `linux-x64` or `linux-arm64`. Runs the same `bun install --frozen --ignore-scripts → npm rebuild → build-dist → require()` smoke test the CI workflow runs.

Usage:
```bash
packages/cli/scripts/build-dist-linux-docker.sh linux-x64
packages/cli/scripts/build-dist-linux-docker.sh linux-arm64
```

We can now validate `build-cli.yml` / `build-dist.ts` changes locally without burning release tag pushes.

## Verification
- ✅ `bun run build:dist --target=darwin-arm64` runs locally end-to-end against the patched `build-dist.ts`; smoke test (`require('better-sqlite3')`, `node-pty`, `@parcel/watcher`, `libsql` from the bundled Node) all OK.
- ✅ Cache path verified — second run prints `[build-dist] using cached better-sqlite3: ...` instead of re-fetching.
- ✅ Typecheck + lint clean.
- 🟡 Docker harness was running for `linux-arm64` while writing this PR; will note the result in a follow-up comment.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, re-cut `cli-v0.2.4` (delete + re-push the tag at the new main HEAD) to verify all three matrix targets land artifacts and the draft release + `cli-latest` pointer are created
- [ ] Optional: `packages/cli/scripts/build-dist-linux-docker.sh linux-arm64` from a contributor's machine runs cleanly end-to-end

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `build-dist` downloads resilient with retries, timeouts, and atomic writes, and cache the `better-sqlite3` prebuild to prevent flaky 5xx failures. Add a Docker harness to reproduce the Linux CI build locally for `linux-x64` and `linux-arm64`.

- **Bug Fixes**
  - Route all downloads through `curlDownload()` with `--retry 6 --retry-delay 2 --retry-all-errors`, tight timeouts, and atomic `.partial` → rename writes.
  - Cache the `better-sqlite3` tarball by version/ABI/target in `~/.superset-build-cache`; applies the retry wrapper to Node and `better-sqlite3` downloads.

- **New Features**
  - Add `packages/cli/scripts/build-dist-linux-docker.sh` to mirror the GitHub Actions Linux flow in `oven/bun:<.bun-version>`.
  - Supports `linux-x64` and `linux-arm64`; runs install, rebuilds `node-pty` and `@parcel/watcher`, builds, and smoke-tests (`require('better-sqlite3')`, `node-pty`, `@parcel/watcher`, `libsql`).

<sup>Written for commit 2217de4e768ef192103a8a9da63c0a89dad9282f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Linux CLI build process with Docker support for reproducible builds across architectures
  * Enhanced build caching for native dependencies to accelerate compilation times
  * Added automatic retry mechanism for more reliable downloads during the build process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->