### PR TITLE
feat(desktop): v2 agents at startup + in v2 new workspace modal

### DIFF
--- a/.superset/lib/setup/steps.sh
+++ b/.superset/lib/setup/steps.sh
@@ -308,13 +308,23 @@ step_start_electric() {
 }
 
 # Ports we must avoid because the OS (or commonly-installed services) listen on
-# them. Bases whose [base, base+range) window contains any of these are skipped
-# during allocation.
+# them, OR because Node/Next.js refuses to bind them. Bases whose
+# [base, base+range) window contains any of these are skipped during allocation.
 #
 # - 5000, 7000: macOS Control Center / AirPlay Receiver (Sonoma+). Cannot be
 #   freed without disabling AirPlay Receiver in System Settings, so we just
 #   route around them.
-SUPERSET_RESERVED_PORTS="5000 7000"
+# - Node/Next.js "unsafe ports" in our [3000, ...) allocation range. Next.js
+#   refuses to start on these with errors like "Bad port: '5060' is reserved
+#   for sip" (see https://nextjs.org/docs/messages/reserved-port).
+#     3659  apple-sasl
+#     4045  lockd / npp
+#     5060  sip
+#     5061  sips
+#     6000  X11
+#     6566  sane-port
+#     6665-6669, 6697  IRC / IRC+TLS
+SUPERSET_RESERVED_PORTS="3659 4045 5000 5060 5061 6000 6566 6665 6666 6667 6668 6669 6697 7000"
 
 # Returns 0 if the [base, base+range) window contains no reserved port.
 port_base_is_safe() {

--- a/apps/desktop/src/renderer/components/AgentSelect/AgentSelect.tsx
+++ b/apps/desktop/src/renderer/components/AgentSelect/AgentSelect.tsx
@@ -14,12 +14,8 @@ import {
 
 const CONFIGURE_AGENTS_VALUE = "__configure_agents__";
 
-/**
- * Minimal agent shape consumed by `AgentSelect`. v1 callers pass
- * `ResolvedAgentConfig` (where `id` is the preset slug used for icons). v2
- * callers pass host-agent-config rows (where `id` is a UUID and `iconId` is
- * the preset slug to look up the icon).
- */
+// v1 callers' `id` doubles as the icon key. v2 ids are UUIDs, so v2 callers
+// pass `iconId: presetId` to keep the preset-keyed icon lookup working.
 export interface AgentSelectAgent {
 	id: string;
 	label: string;

--- a/apps/desktop/src/renderer/components/AgentSelect/AgentSelect.tsx
+++ b/apps/desktop/src/renderer/components/AgentSelect/AgentSelect.tsx
@@ -1,7 +1,3 @@
-import type {
-	AgentDefinitionId,
-	ResolvedAgentConfig,
-} from "@superset/shared/agent-settings";
 import {
 	Select,
 	SelectContent,
@@ -18,8 +14,20 @@ import {
 
 const CONFIGURE_AGENTS_VALUE = "__configure_agents__";
 
+/**
+ * Minimal agent shape consumed by `AgentSelect`. v1 callers pass
+ * `ResolvedAgentConfig` (where `id` is the preset slug used for icons). v2
+ * callers pass host-agent-config rows (where `id` is a UUID and `iconId` is
+ * the preset slug to look up the icon).
+ */
+export interface AgentSelectAgent {
+	id: string;
+	label: string;
+	iconId?: string;
+}
+
 interface AgentSelectProps<T extends string> {
-	agents: ResolvedAgentConfig[];
+	agents: AgentSelectAgent[];
 	value?: T;
 	placeholder: string;
 	onValueChange: (value: T) => void;
@@ -49,13 +57,10 @@ export function AgentSelect<T extends string>({
 }: AgentSelectProps<T>) {
 	const navigate = useNavigate();
 	const isDark = useIsDarkTheme();
-	const selectableIds = new Set<AgentDefinitionId>(
-		agents.map((agent) => agent.id),
-	);
+	const selectableIds = new Set<string>(agents.map((agent) => agent.id));
 	const selectedValue =
 		value != null &&
-		((allowNone && value === noneValue) ||
-			selectableIds.has(value as AgentDefinitionId))
+		((allowNone && value === noneValue) || selectableIds.has(value))
 			? value
 			: undefined;
 	const showSeparator = (allowNone || agents.length > 0) && !disabled;
@@ -84,7 +89,7 @@ export function AgentSelect<T extends string>({
 					<SelectItem value={noneValue}>{noneLabel}</SelectItem>
 				)}
 				{agents.map((agent) => {
-					const icon = getPresetIcon(agent.id, isDark);
+					const icon = getPresetIcon(agent.iconId ?? agent.id, isDark);
 					return (
 						<SelectItem key={agent.id} value={agent.id}>
 							<span className="flex items-center gap-2">

--- a/apps/desktop/src/renderer/hooks/useV2AgentConfigs/index.ts
+++ b/apps/desktop/src/renderer/hooks/useV2AgentConfigs/index.ts
@@ -1,0 +1,4 @@
+export {
+	useV2AgentConfigs,
+	V2_AGENT_CONFIGS_QUERY_KEY,
+} from "./useV2AgentConfigs";

--- a/apps/desktop/src/renderer/hooks/useV2AgentConfigs/useV2AgentConfigs.ts
+++ b/apps/desktop/src/renderer/hooks/useV2AgentConfigs/useV2AgentConfigs.ts
@@ -5,9 +5,7 @@ import { useLocalHostService } from "renderer/routes/_authenticated/providers/Lo
 
 export const V2_AGENT_CONFIGS_QUERY_KEY = ["host-agent-configs"] as const;
 
-/** Fetches v2 host-agent configs from the active host service. Shared so the
- * authenticated layout can prefetch on startup and the Settings page can read
- * the same cache without a second round-trip. */
+/** Shared between the startup prefetch and Settings → Agents so both share one cache entry. */
 export function useV2AgentConfigs() {
 	const { activeHostUrl } = useLocalHostService();
 

--- a/apps/desktop/src/renderer/hooks/useV2AgentConfigs/useV2AgentConfigs.ts
+++ b/apps/desktop/src/renderer/hooks/useV2AgentConfigs/useV2AgentConfigs.ts
@@ -18,5 +18,10 @@ export function useV2AgentConfigs() {
 				activeHostUrl,
 			).settings.agentConfigs.list.query();
 		},
+		// Configs only change via Settings → Agents mutations, which all
+		// invalidate this key explicitly. Otherwise the data is effectively
+		// static — Infinity keeps the startup prefetch warm across navigation
+		// instead of every consumer triggering a background refetch on mount.
+		staleTime: Number.POSITIVE_INFINITY,
 	});
 }

--- a/apps/desktop/src/renderer/hooks/useV2AgentConfigs/useV2AgentConfigs.ts
+++ b/apps/desktop/src/renderer/hooks/useV2AgentConfigs/useV2AgentConfigs.ts
@@ -1,27 +1,27 @@
 import type { HostAgentConfigDto } from "@superset/host-service/settings";
 import { useQuery } from "@tanstack/react-query";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
-import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 
 export const V2_AGENT_CONFIGS_QUERY_KEY = ["host-agent-configs"] as const;
 
-/** Shared between the startup prefetch and Settings → Agents so both share one cache entry. */
-export function useV2AgentConfigs() {
-	const { activeHostUrl } = useLocalHostService();
-
+/**
+ * Caller passes the host URL explicitly so this hook works for any host the
+ * user is targeting (local, remote-via-relay, or whatever the new-workspace
+ * modal has resolved). Cache is keyed on URL so distinct hosts don't share
+ * entries. Configs only change via Settings → Agents mutations that invalidate
+ * this key — `staleTime: Infinity` keeps the startup prefetch warm across
+ * navigation instead of every consumer refetching on mount.
+ */
+export function useV2AgentConfigs(hostUrl: string | null) {
 	return useQuery({
-		queryKey: [...V2_AGENT_CONFIGS_QUERY_KEY, activeHostUrl] as const,
-		enabled: !!activeHostUrl,
+		queryKey: [...V2_AGENT_CONFIGS_QUERY_KEY, hostUrl] as const,
+		enabled: !!hostUrl,
 		queryFn: () => {
-			if (!activeHostUrl) return [] as HostAgentConfigDto[];
+			if (!hostUrl) return [] as HostAgentConfigDto[];
 			return getHostServiceClientByUrl(
-				activeHostUrl,
+				hostUrl,
 			).settings.agentConfigs.list.query();
 		},
-		// Configs only change via Settings → Agents mutations, which all
-		// invalidate this key explicitly. Otherwise the data is effectively
-		// static — Infinity keeps the startup prefetch warm across navigation
-		// instead of every consumer triggering a background refetch on mount.
 		staleTime: Number.POSITIVE_INFINITY,
 	});
 }

--- a/apps/desktop/src/renderer/hooks/useV2AgentConfigs/useV2AgentConfigs.ts
+++ b/apps/desktop/src/renderer/hooks/useV2AgentConfigs/useV2AgentConfigs.ts
@@ -1,0 +1,24 @@
+import type { HostAgentConfigDto } from "@superset/host-service/settings";
+import { useQuery } from "@tanstack/react-query";
+import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+
+export const V2_AGENT_CONFIGS_QUERY_KEY = ["host-agent-configs"] as const;
+
+/** Fetches v2 host-agent configs from the active host service. Shared so the
+ * authenticated layout can prefetch on startup and the Settings page can read
+ * the same cache without a second round-trip. */
+export function useV2AgentConfigs() {
+	const { activeHostUrl } = useLocalHostService();
+
+	return useQuery({
+		queryKey: [...V2_AGENT_CONFIGS_QUERY_KEY, activeHostUrl] as const,
+		enabled: !!activeHostUrl,
+		queryFn: () => {
+			if (!activeHostUrl) return [] as HostAgentConfigDto[];
+			return getHostServiceClientByUrl(
+				activeHostUrl,
+			).settings.agentConfigs.list.query();
+		},
+	});
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/AgentHooks.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/AgentHooks.tsx
@@ -1,3 +1,4 @@
+import { useV2AgentConfigs } from "renderer/hooks/useV2AgentConfigs";
 import { useCommandWatcher } from "./hooks/useCommandWatcher";
 import { useDevicePresence } from "./hooks/useDevicePresence";
 
@@ -8,5 +9,8 @@ import { useDevicePresence } from "./hooks/useDevicePresence";
 export function AgentHooks() {
 	useDevicePresence();
 	useCommandWatcher();
+	// Prefill v2 agent configs at startup so the Settings page (and any other
+	// reader) sees them without a navigation-triggered fetch.
+	useV2AgentConfigs();
 	return null;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/AgentHooks.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/AgentHooks.tsx
@@ -9,8 +9,7 @@ import { useDevicePresence } from "./hooks/useDevicePresence";
 export function AgentHooks() {
 	useDevicePresence();
 	useCommandWatcher();
-	// Prefill v2 agent configs at startup so the Settings page (and any other
-	// reader) sees them without a navigation-triggered fetch.
+	// Warm v2 agent cache so Settings doesn't refetch on first navigation.
 	useV2AgentConfigs();
 	return null;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/AgentHooks.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/AgentHooks.tsx
@@ -1,4 +1,5 @@
 import { useV2AgentConfigs } from "renderer/hooks/useV2AgentConfigs";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { useCommandWatcher } from "./hooks/useCommandWatcher";
 import { useDevicePresence } from "./hooks/useDevicePresence";
 
@@ -7,9 +8,12 @@ import { useDevicePresence } from "./hooks/useDevicePresence";
  * useCommandWatcher uses useCollections which must be inside the provider.
  */
 export function AgentHooks() {
+	const { activeHostUrl } = useLocalHostService();
 	useDevicePresence();
 	useCommandWatcher();
-	// Warm v2 agent cache so Settings doesn't refetch on first navigation.
-	useV2AgentConfigs();
+	// Warm v2 agent cache for the local host so Settings doesn't refetch on
+	// first navigation. Remote-host caches populate lazily when the modal
+	// targets a different device.
+	useV2AgentConfigs(activeHostUrl);
 	return null;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -127,15 +127,37 @@ export function PromptGroup({
 		() => v2Agents.map((agent) => agent.id),
 		[v2Agents],
 	);
-	const defaultAgent = selectableAgentIds[0] ?? "none";
 	const { selectedAgent, setSelectedAgent } =
 		useAgentLaunchPreferences<WorkspaceCreateAgent>({
 			agentStorageKey: AGENT_STORAGE_KEY,
-			defaultAgent,
+			defaultAgent: "none",
 			fallbackAgent: "none",
 			validAgents: ["none", ...selectableAgentIds],
 			agentsReady: v2AgentConfigsQuery.isFetched,
 		});
+
+	// Promote the placeholder "none" → first configured agent once on initial
+	// fetch when the user has no stored preference. Without this, opening the
+	// modal before the startup prefetch resolves latches the picker on
+	// "No agent" — the corrective effect inside useAgentLaunchPreferences
+	// doesn't rescue it because "none" is always in validAgents.
+	const didInitialPromoteRef = useRef(false);
+	useEffect(() => {
+		if (didInitialPromoteRef.current) return;
+		if (!v2AgentConfigsQuery.isFetched) return;
+		didInitialPromoteRef.current = true;
+		if (selectedAgent !== "none") return;
+		if (typeof window !== "undefined") {
+			if (window.localStorage.getItem(AGENT_STORAGE_KEY)) return;
+		}
+		const first = selectableAgentIds[0];
+		if (first) setSelectedAgent(first);
+	}, [
+		v2AgentConfigsQuery.isFetched,
+		selectableAgentIds,
+		selectedAgent,
+		setSelectedAgent,
+	]);
 
 	const branchPreview = branchNameEdited
 		? sanitizeUserBranchName(branchName)

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -25,7 +25,7 @@ import { LinkedIssuePill } from "renderer/components/Chat/ChatInterface/componen
 import { IssueLinkCommand } from "renderer/components/Chat/ChatInterface/components/IssueLinkCommand";
 import { resolveHostUrl } from "renderer/hooks/host-service/useHostTargetUrl";
 import { useAgentLaunchPreferences } from "renderer/hooks/useAgentLaunchPreferences";
-import { useEnabledAgents } from "renderer/hooks/useEnabledAgents";
+import { useV2AgentConfigs } from "renderer/hooks/useV2AgentConfigs";
 import { PLATFORM } from "renderer/hotkeys";
 import { authClient } from "renderer/lib/auth-client";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
@@ -112,20 +112,31 @@ export function PromptGroup({
 		linkedPR,
 	} = draft;
 
-	// ── Agent presets ────────────────────────────────────────────────
-	const { agents: enabledAgentPresets, isFetched: agentsFetched } =
-		useEnabledAgents();
-	const selectableAgentIds = useMemo(
-		() => enabledAgentPresets.map((preset) => preset.id),
-		[enabledAgentPresets],
+	// ── Agent configs (v2 host_agent_configs) ───────────────────────
+	const v2AgentConfigsQuery = useV2AgentConfigs();
+	const v2Agents = useMemo(
+		() =>
+			(v2AgentConfigsQuery.data ?? []).map((config) => ({
+				id: config.id,
+				label: config.label,
+				iconId: config.presetId,
+			})),
+		[v2AgentConfigsQuery.data],
 	);
+	const selectableAgentIds = useMemo(
+		() => v2Agents.map((agent) => agent.id),
+		[v2Agents],
+	);
+	// Default to the first configured agent so users land in a launchable state
+	// without picking. Falls back to "none" if there are no configs yet.
+	const defaultAgent = selectableAgentIds[0] ?? "none";
 	const { selectedAgent, setSelectedAgent } =
 		useAgentLaunchPreferences<WorkspaceCreateAgent>({
 			agentStorageKey: AGENT_STORAGE_KEY,
-			defaultAgent: "claude",
+			defaultAgent,
 			fallbackAgent: "none",
 			validAgents: ["none", ...selectableAgentIds],
-			agentsReady: agentsFetched,
+			agentsReady: v2AgentConfigsQuery.isFetched,
 		});
 
 	const branchPreview = branchNameEdited
@@ -383,7 +394,7 @@ export function PromptGroup({
 				<PromptInputFooter>
 					<PromptInputTools className="gap-1.5">
 						<AgentSelect<WorkspaceCreateAgent>
-							agents={enabledAgentPresets}
+							agents={v2Agents}
 							value={selectedAgent}
 							placeholder="No agent"
 							onValueChange={setSelectedAgent}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -113,7 +113,23 @@ export function PromptGroup({
 	} = draft;
 
 	// ── Agent configs (v2 host_agent_configs) ───────────────────────
-	const v2AgentConfigsQuery = useV2AgentConfigs();
+	// Scoped to the launch host, not the local active host: agent UUIDs only
+	// exist on the host that owns them, so picking from the local list while
+	// submitting to a remote host would send a config id the target doesn't
+	// recognize.
+	const launchHostUrl = useMemo(() => {
+		const id = draft.hostId ?? machineId;
+		if (!id || !activeOrganizationId) return null;
+		return (
+			resolveHostUrl({
+				hostId: id,
+				machineId,
+				activeHostUrl,
+				organizationId: activeOrganizationId,
+			}) ?? null
+		);
+	}, [draft.hostId, machineId, activeHostUrl, activeOrganizationId]);
+	const v2AgentConfigsQuery = useV2AgentConfigs(launchHostUrl);
 	const v2Agents = useMemo(
 		() =>
 			(v2AgentConfigsQuery.data ?? []).map((config) => ({
@@ -136,20 +152,21 @@ export function PromptGroup({
 			agentsReady: v2AgentConfigsQuery.isFetched,
 		});
 
-	// Promote the placeholder "none" → first configured agent once on initial
-	// fetch when the user has no stored preference. Without this, opening the
-	// modal before the startup prefetch resolves latches the picker on
-	// "No agent" — the corrective effect inside useAgentLaunchPreferences
-	// doesn't rescue it because "none" is always in validAgents.
-	const didInitialPromoteRef = useRef(false);
+	// Promote the placeholder "none" → first configured agent whenever the
+	// current selection isn't a real agent and the user hasn't explicitly
+	// chosen "none". Fires on initial open (where useState init captured
+	// "none" before the query resolved) AND on host switch (where the
+	// previous host's UUID isn't valid here, so the corrective effect inside
+	// useAgentLaunchPreferences resets to "none"). The corrective effect
+	// can't rescue these on its own because "none" is always in validAgents.
 	useEffect(() => {
-		if (didInitialPromoteRef.current) return;
 		if (!v2AgentConfigsQuery.isFetched) return;
-		didInitialPromoteRef.current = true;
 		if (selectedAgent !== "none") return;
-		if (typeof window !== "undefined") {
-			if (window.localStorage.getItem(AGENT_STORAGE_KEY)) return;
-		}
+		const stored =
+			typeof window !== "undefined"
+				? window.localStorage.getItem(AGENT_STORAGE_KEY)
+				: null;
+		if (stored === "none") return;
 		const first = selectableAgentIds[0];
 		if (first) setSelectedAgent(first);
 	}, [

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -127,8 +127,6 @@ export function PromptGroup({
 		() => v2Agents.map((agent) => agent.id),
 		[v2Agents],
 	);
-	// Default to the first configured agent so users land in a launchable state
-	// without picking. Falls back to "none" if there are no configs yet.
 	const defaultAgent = selectableAgentIds[0] ?? "none";
 	const { selectedAgent, setSelectedAgent } =
 		useAgentLaunchPreferences<WorkspaceCreateAgent>({

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/types.ts
@@ -1,8 +1,10 @@
-import type { AgentDefinitionId } from "@superset/shared/agent-settings";
+// v2 agent ids are host_agent_configs UUIDs (resolved on the host by id, with
+// presetId fallback). Using `string` rather than the v1 AgentDefinitionId enum.
+export type WorkspaceCreateAgent = string;
 
-export type WorkspaceCreateAgent = AgentDefinitionId | "none";
-
-export const AGENT_STORAGE_KEY = "lastSelectedWorkspaceCreateAgent";
+// New key — old `lastSelectedWorkspaceCreateAgent` stored v1 preset slugs that
+// won't match v2 UUIDs. Bump it so persisted v1 state doesn't poison v2 picker.
+export const AGENT_STORAGE_KEY = "lastSelectedV2WorkspaceCreateAgent";
 
 export const PILL_BUTTON_CLASS =
 	"!h-[22px] min-h-0 rounded-md border-[0.5px] border-border bg-foreground/[0.04] shadow-none text-[11px]";

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/types.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/types.ts
@@ -1,9 +1,7 @@
-// v2 agent ids are host_agent_configs UUIDs (resolved on the host by id, with
-// presetId fallback). Using `string` rather than the v1 AgentDefinitionId enum.
+// v2 ids are runtime host_agent_configs UUIDs, not a static enum like v1.
 export type WorkspaceCreateAgent = string;
 
-// New key — old `lastSelectedWorkspaceCreateAgent` stored v1 preset slugs that
-// won't match v2 UUIDs. Bump it so persisted v1 state doesn't poison v2 picker.
+// New key — old one held v1 preset slugs that won't match v2 UUIDs.
 export const AGENT_STORAGE_KEY = "lastSelectedV2WorkspaceCreateAgent";
 
 export const PILL_BUTTON_CLASS =

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/V2AgentsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/V2AgentsSettings.tsx
@@ -20,7 +20,7 @@ export function V2AgentsSettings() {
 	const { activeHostUrl } = useLocalHostService();
 	const queryClient = useQueryClient();
 
-	const configsQuery = useV2AgentConfigs();
+	const configsQuery = useV2AgentConfigs(activeHostUrl);
 
 	const presetsQuery = useQuery({
 		queryKey: [...QUERY_KEY, "presets", activeHostUrl] as const,

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/V2AgentsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/agents/components/V2AgentsSettings/V2AgentsSettings.tsx
@@ -7,27 +7,20 @@ import { toast } from "@superset/ui/sonner";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Bot } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
+import {
+	V2_AGENT_CONFIGS_QUERY_KEY as QUERY_KEY,
+	useV2AgentConfigs,
+} from "renderer/hooks/useV2AgentConfigs";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { AgentDetail } from "./components/AgentDetail";
 import { AgentsSettingsSidebar } from "./components/AgentsSettingsSidebar";
 
-const QUERY_KEY = ["host-agent-configs"] as const;
-
 export function V2AgentsSettings() {
 	const { activeHostUrl } = useLocalHostService();
 	const queryClient = useQueryClient();
 
-	const configsQuery = useQuery({
-		queryKey: [...QUERY_KEY, activeHostUrl] as const,
-		enabled: !!activeHostUrl,
-		queryFn: () => {
-			if (!activeHostUrl) return [] as HostAgentConfigDto[];
-			return getHostServiceClientByUrl(
-				activeHostUrl,
-			).settings.agentConfigs.list.query();
-		},
-	});
+	const configsQuery = useV2AgentConfigs();
 
 	const presetsQuery = useQuery({
 		queryKey: [...QUERY_KEY, "presets", activeHostUrl] as const,


### PR DESCRIPTION
## Summary

- Prefill v2 `host_agent_configs` at app startup via a shared `useV2AgentConfigs` hook called from `AgentHooks`, so Settings → Agents loads instantly instead of fetching only on navigation.
- Switch the **v2 new workspace modal** off v1 `getAgentPresets` onto the same v2 host source. Custom labels and per-preset duplicates configured in Settings → Agents now appear in the agent picker, and the selected id is the host config's UUID (host already supports both UUID and presetId resolution, so wire format is unchanged).
- Generalize `AgentSelect` to accept a structural `{ id, label, iconId? }` so v2 callers can pass UUIDs while keeping the preset-keyed icon. v1 call sites (`NewWorkspaceModal`, `OpenInWorkspace`, `RunInWorkspacePopover`) keep working unchanged — `ResolvedAgentConfig` already satisfies the new prop shape.
- `WorkspaceCreateAgent` relaxes from `AgentDefinitionId | "none"` to `string`. The localStorage key is bumped to `lastSelectedV2WorkspaceCreateAgent` so persisted v1 slugs don't preselect a missing v2 entry on first open.
- **Bonus** (separate commit): extend `SUPERSET_RESERVED_PORTS` in the setup script to skip Node-unsafe ports (sip/sips/X11/IRC/lockd/sane-port/apple-sasl) during port-base allocation. Next.js refuses to bind these and a workspace that landed on base 5060 couldn't run web/api.

## Test plan

- [ ] Open app cold → Settings → Agents renders without a loading skeleton (cached from startup prefill).
- [ ] In v2 dashboard, open New Workspace → agent dropdown lists exactly what's in Settings → Agents (custom labels included).
- [ ] Add a second config for the same preset (e.g. two "Claude" rows with different labels) → both appear distinctly in the v2 modal picker.
- [ ] Pick an agent, type a prompt, submit → workspace launches with that agent (host resolves UUID → run config).
- [ ] First open after upgrade: old v1 persisted selection doesn't preselect a missing v2 entry; defaults to first configured agent.
- [ ] v1 surfaces unaffected: `NewWorkspaceModal`, task → `OpenInWorkspace`, `RunInWorkspacePopover` still show v1 enabled agents.
- [ ] Fresh worktree setup picks a port base that avoids 5060/5061 etc.; `bun dev` boots without "Bad port: reserved for sip" errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefill v2 host agent configs at app startup and use them in the v2 New Workspace modal, scoped to the launch host, so Agents opens instantly, the picker shows custom labels and duplicates, and first-open selects a real agent. Also skip Node/Next.js unsafe ports during setup to prevent bind errors.

- **New Features**
  - Added shared `useV2AgentConfigs` with `staleTime: Infinity` and startup prefetch in `AgentHooks`; cache is keyed by host URL so each host’s configs are isolated and Settings → Agents reads from a warm cache.
  - Switched the v2 New Workspace modal to the target host’s `host_agent_configs` (select by UUID). Kept preset icons via `iconId` and generalized `AgentSelect` to accept `{ id, label, iconId? }`. Bumped the localStorage key to avoid v1 slugs.

- **Bug Fixes**
  - New Workspace modal: prevent latching on “No agent” by promoting to the first configured agent when data loads or the launch host changes, unless the user explicitly chose “none”.
  - Setup: extended `SUPERSET_RESERVED_PORTS` to include Node/Next.js unsafe ports (e.g., 5060/5061, 6000, IRC ranges) so port-base allocation avoids them.

<sup>Written for commit 29856a38697d27c14322afa0aada76c66ba2ac74. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded port-safety checks to block additional OS and Node/Next.js reserved ports.

* **Improvements**
  * V2 agent configurations are prefetched earlier to speed up Settings and workspace flows.
  * Agent selection UI now uses v2 agent configs and updated preset icons.
  * New-workspace default agent remains "none" until v2 configs load; first configured agent may be promoted on initial fetch.
  * Persisted agent selection key updated to be v2-aware.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->