### PR TITLE
fix(desktop): clear v2 sidebar run-status on terminal close + interrupt

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -38,6 +38,7 @@ import { resolveTerminalThemeType } from "renderer/stores/theme/utils";
 import { useLinkClickHint } from "./hooks/useLinkClickHint";
 import { type HoveredLink, useLinkHoverState } from "./hooks/useLinkHoverState";
 import { useTerminalAppearance } from "./hooks/useTerminalAppearance";
+import { useTerminalInterruptClear } from "./hooks/useTerminalInterruptClear";
 import { shellEscapePaths } from "./utils";
 
 interface TerminalPaneProps {
@@ -317,6 +318,13 @@ export function TerminalPane({
 		filePolicy,
 		urlPolicy,
 	]);
+
+	useTerminalInterruptClear({
+		terminalId,
+		terminalInstanceId,
+		workspaceId,
+		connectionState,
+	});
 
 	useHotkey(
 		"CLEAR_TERMINAL",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/hooks/useTerminalInterruptClear/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/hooks/useTerminalInterruptClear/index.ts
@@ -1,0 +1,1 @@
+export { useTerminalInterruptClear } from "./useTerminalInterruptClear";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/hooks/useTerminalInterruptClear/useTerminalInterruptClear.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/hooks/useTerminalInterruptClear/useTerminalInterruptClear.ts
@@ -1,0 +1,42 @@
+import { useEffect } from "react";
+import {
+	type ConnectionState,
+	terminalRuntimeRegistry,
+} from "renderer/lib/terminal/terminal-runtime-registry";
+import { clearV2TerminalRunStatus } from "renderer/stores/v2-notifications";
+
+interface UseTerminalInterruptClearOptions {
+	terminalId: string;
+	terminalInstanceId: string;
+	workspaceId: string;
+	connectionState: ConnectionState;
+}
+
+/**
+ * The host's `terminal:lifecycle` exit only fires when the pty dies. Ctrl+C
+ * kills the foreground agent process while the shell stays alive, and Claude
+ * Code's Stop hook doesn't fire on user interrupt — so without this hook,
+ * "working" / "permission" stays stuck in the sidebar.
+ */
+export function useTerminalInterruptClear({
+	terminalId,
+	terminalInstanceId,
+	workspaceId,
+	connectionState,
+}: UseTerminalInterruptClearOptions): void {
+	// biome-ignore lint/correctness/useExhaustiveDependencies: connectionState re-runs the effect on reconnect so we subscribe to the new xterm instance
+	useEffect(() => {
+		const terminal = terminalRuntimeRegistry.getTerminal(
+			terminalId,
+			terminalInstanceId,
+		);
+		if (!terminal) return;
+		const subscription = terminal.onKey(({ domEvent }) => {
+			const isInterrupt =
+				(domEvent.key === "c" && domEvent.ctrlKey) || domEvent.key === "Escape";
+			if (!isInterrupt) return;
+			clearV2TerminalRunStatus(terminalId, workspaceId);
+		});
+		return () => subscription.dispose();
+	}, [terminalId, terminalInstanceId, workspaceId, connectionState]);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -27,7 +27,10 @@ import { getBaseName } from "renderer/lib/pathBasename";
 import { consumeTerminalBackgroundIntent } from "renderer/lib/terminal/terminal-background-intents";
 import { terminalRuntimeRegistry } from "renderer/lib/terminal/terminal-runtime-registry";
 import { FileIcon } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/utils";
-import { getV2NotificationSourcesForPane } from "renderer/stores/v2-notifications";
+import {
+	clearV2TerminalRunStatus,
+	getV2NotificationSourcesForPane,
+} from "renderer/stores/v2-notifications";
 import { V2NotificationStatusIndicator } from "../../components/V2NotificationStatusIndicator";
 import {
 	getDocument,
@@ -243,6 +246,7 @@ export function usePaneRegistry(
 						terminalRuntimeRegistry.release(terminalId);
 						return;
 					}
+					clearV2TerminalRunStatus(terminalId, workspaceId);
 					terminalRuntimeRegistry.dispose(terminalId);
 					killTerminalSessionSilently({ terminalId, workspaceId });
 				},

--- a/apps/desktop/src/renderer/stores/v2-notifications/index.ts
+++ b/apps/desktop/src/renderer/stores/v2-notifications/index.ts
@@ -1,4 +1,5 @@
 export {
+	clearV2TerminalRunStatus,
 	getV2ChatNotificationSource,
 	getV2ManualNotificationSource,
 	getV2NotificationSourceKey,

--- a/apps/desktop/src/renderer/stores/v2-notifications/store.ts
+++ b/apps/desktop/src/renderer/stores/v2-notifications/store.ts
@@ -234,6 +234,22 @@ export function getV2NotificationSourcesForTab(
 	return [...sources.values()];
 }
 
+/**
+ * Used by close (races against host exit) and interrupt (pty stays alive,
+ * no host exit) — neither can rely on the `terminal:lifecycle` exit path.
+ */
+export function clearV2TerminalRunStatus(
+	terminalId: string,
+	workspaceId: string,
+): void {
+	useV2NotificationStore
+		.getState()
+		.clearSourceStatus(
+			getV2TerminalNotificationSource(terminalId),
+			workspaceId,
+		);
+}
+
 export function selectV2WorkspaceNotificationStatus(workspaceId: string) {
 	return (state: V2NotificationState) => {
 		function* statuses() {


### PR DESCRIPTION
## Summary

The v2 sidebar run-status indicator (working / permission) was getting stuck because the source was only cleared when the host emitted `terminal:lifecycle` exit — and that only fires when the pty itself dies.

Two paths left it stuck:

- **Close terminal** — `killTerminalSessionSilently` races against pane teardown; if the workspace unmounts before the host exit arrives, `HostNotificationSubscriber`'s `if (!workspace) return` drops the clear.
- **Ctrl+C / Esc** — kills the foreground agent process while the shell pty stays alive (no host exit), and Claude Code's Stop hook doesn't fire on user interrupt.

V1 had three duplicated clear paths to paper over this; v2 had none for interrupt. This PR adds a single helper used by both fix paths:

- `clearV2TerminalRunStatus(terminalId, workspaceId)` in the v2-notifications store — single source of truth, idempotent, no status-gating.
- Called optimistically from `onAfterClose` in `usePaneRegistry.tsx` (close path).
- New `useTerminalInterruptClear` hook subscribes to xterm `onKey` and calls the helper on Ctrl+C / Esc (interrupt path).

The hook is its own focused file — not entangled with command-buffer / line-edit / focus logic the way v1's `handleKeyPress` was.

## Test plan

- [ ] In a v2 workspace, run a long-running agent in a terminal, then close the pane → sidebar working/permission indicator clears immediately.
- [ ] Run a long-running agent, press Ctrl+C → indicator clears.
- [ ] Press Esc on a permission prompt → indicator clears.
- [ ] Send a terminal to background (Cmd+W or background intent) → indicator stays (agent is still running).
- [ ] Normal Stop lifecycle still transitions to `review` when not focused / `idle` when focused.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the v2 sidebar run-status getting stuck after terminal close or user interrupt by clearing the terminal’s notification source proactively. Ensures the indicator resets even when no `terminal:lifecycle` exit event fires.

- **Bug Fixes**
  - Added `clearV2TerminalRunStatus(terminalId, workspaceId)` in the `v2-notifications` store as the single clear path.
  - Call the helper from `usePaneRegistry` on pane close to avoid races with host exit.
  - Introduced `useTerminalInterruptClear` to clear on Ctrl+C or Esc via xterm `onKey` (resubscribes on reconnect).

<sup>Written for commit d94feca4d03b9b0312c9adc97c205e3072172463. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added terminal interrupt detection that monitors keyboard input and automatically clears terminal status when users press Ctrl+C or Escape within the terminal interface.

* **Improvements**
  * Enhanced terminal pane lifecycle management with improved state cleanup, ensuring terminal notifications and run status are properly cleared when terminal panes are closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->