### PR TITLE
fix(cli): bundle pty-daemon.js + pass OAuth JWT through to relay

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -72,6 +72,8 @@ jobs:
           "$DIST/bin/superset" --version
           "$DIST/bin/superset" --help
           "$DIST/lib/node" --version
+          test -f "$DIST/lib/host-service.js" || (echo "missing host-service.js" >&2; exit 1)
+          test -f "$DIST/lib/pty-daemon.js" || (echo "missing pty-daemon.js" >&2; exit 1)
           NODE_PATH="$DIST/lib/node_modules" "$DIST/lib/node" -e '
             for (const m of ["better-sqlite3", "node-pty", "@parcel/watcher", "libsql"]) {
               require(m);

--- a/packages/cli/scripts/build-dist-linux-docker.sh
+++ b/packages/cli/scripts/build-dist-linux-docker.sh
@@ -66,6 +66,8 @@ docker run --rm --platform "$PLATFORM" \
     "$DIST/bin/superset" --version
     "$DIST/bin/superset" --help | head -5
     "$DIST/lib/node" --version
+    test -f "$DIST/lib/host-service.js" || (echo "missing host-service.js" >&2; exit 1)
+    test -f "$DIST/lib/pty-daemon.js" || (echo "missing pty-daemon.js" >&2; exit 1)
     NODE_PATH="$DIST/lib/node_modules" "$DIST/lib/node" -e "
       for (const m of [\"better-sqlite3\", \"node-pty\", \"@parcel/watcher\", \"libsql\"]) {
         require(m);

--- a/packages/cli/scripts/build-dist.ts
+++ b/packages/cli/scripts/build-dist.ts
@@ -365,6 +365,12 @@ async function buildHostService(): Promise<string> {
 	return join(hostServiceDir, "dist", "host-service.js");
 }
 
+async function buildPtyDaemon(): Promise<string> {
+	const ptyDaemonDir = resolve(import.meta.dir, "../../pty-daemon");
+	await exec("bun", ["run", "build:daemon"], ptyDaemonDir);
+	return join(ptyDaemonDir, "dist", "pty-daemon.js");
+}
+
 function writeHostWrapper(binDir: string): void {
 	const wrapper = `#!/bin/sh
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -395,6 +401,14 @@ async function main(): Promise<void> {
 	console.log("[build-dist] building host-service bundle");
 	const hostServiceBundle = await buildHostService();
 	cpSync(hostServiceBundle, join(stagingRoot, "lib", "host-service.js"));
+
+	// pty-daemon ships side-by-side with host-service.js. The host-service
+	// resolves the script path via `resolveSupervisorScriptPath()` which
+	// looks for `pty-daemon.js` next to itself first; without this copy the
+	// supervisor falls back to the workspace path and bricks at spawn time.
+	console.log("[build-dist] building pty-daemon bundle");
+	const ptyDaemonBundle = await buildPtyDaemon();
+	cpSync(ptyDaemonBundle, join(stagingRoot, "lib", "pty-daemon.js"));
 
 	console.log("[build-dist] fetching Node.js");
 	await downloadAndExtractNode(target, join(stagingRoot, "lib"));

--- a/packages/host-service/src/providers/auth/JwtAuthProvider/JwtAuthProvider.ts
+++ b/packages/host-service/src/providers/auth/JwtAuthProvider/JwtAuthProvider.ts
@@ -3,6 +3,11 @@ import type { ApiAuthProvider } from "../types";
 const JWT_REFRESH_BUFFER_MS = 5 * 60 * 1000;
 const JWT_CACHE_DURATION_MS = 55 * 60 * 1000;
 
+function looksLikeJwt(token: string): boolean {
+	const parts = token.split(".");
+	return parts.length === 3 && parts.every(Boolean);
+}
+
 export class JwtApiAuthProvider implements ApiAuthProvider {
 	private readonly sessionToken: string;
 	private readonly apiUrl: string;
@@ -20,6 +25,16 @@ export class JwtApiAuthProvider implements ApiAuthProvider {
 	}
 
 	async getJwt(): Promise<string> {
+		// CLI OAuth code+PKCE login stores the OAuth access token directly,
+		// which is already a JWT signed by the same JWKS the relay verifies
+		// against and carries `organizationIds` via customAccessTokenClaims.
+		// Pass it through — no /api/auth/token exchange needed (and the
+		// better-auth jwt plugin endpoint doesn't accept OAuth tokens
+		// anyway, only sessions and api keys).
+		if (looksLikeJwt(this.sessionToken)) {
+			return this.sessionToken;
+		}
+
 		if (
 			this.cachedJwt &&
 			Date.now() < this.cachedJwtExpiresAt - JWT_REFRESH_BUFFER_MS
@@ -27,8 +42,13 @@ export class JwtApiAuthProvider implements ApiAuthProvider {
 			return this.cachedJwt;
 		}
 
+		// better-auth's apiKey plugin reads `sk_live_…` from x-api-key, not
+		// Authorization: Bearer; mirror what the CLI's tRPC client does in
+		// packages/cli/src/lib/api-client.ts.
 		const response = await fetch(`${this.apiUrl}/api/auth/token`, {
-			headers: { Authorization: `Bearer ${this.sessionToken}` },
+			headers: this.sessionToken.startsWith("sk_live_")
+				? { "x-api-key": this.sessionToken }
+				: { Authorization: `Bearer ${this.sessionToken}` },
 		});
 		if (!response.ok) {
 			throw new Error(`Failed to mint JWT: ${response.status}`);


### PR DESCRIPTION
## Why
Two bugs reported on `cli-v0.2.4` after install. Both reproduce on **linux-x64 and darwin-arm64** (universal regressions in the CLI host-service path):

```
[supervisor] bootstrap failed for org=…: Error:
  [pty-daemon:…] script not found at /home/pty-daemon/dist/pty-daemon.js
  — has the daemon binary been bundled?
```

```
[host-service] failed to register/connect relay:
  TRPCClientError2: Failed to mint JWT: 401
```

## Root causes
**#1 — pty-daemon never bundled.** `packages/cli/scripts/build-dist.ts` builds `host-service.js` but no equivalent step for `pty-daemon.js`. The host-service's `resolveSupervisorScriptPath()` (`packages/host-service/src/daemon/singleton.ts:22-47`) looks side-by-side first, falls through to the workspace path `../../../pty-daemon/dist/pty-daemon.js` resolved against `<install>/lib`, which on a user machine like `/home/avi/superset/lib` becomes the nonsense `/home/pty-daemon/dist/pty-daemon.js`. Confirmed with `tar -tzf superset-darwin-arm64.tar.gz | grep pty-daemon` against the released tarball — only `host-service.js` is present.

**#2 — OAuth access token rejected by `/api/auth/token`.** `superset auth login` does code+PKCE and stores `result.accessToken` (`packages/cli/src/commands/auth/login/command.ts:57`), which is an **OAuth access token issued by better-auth's `oauthProvider`**. `JwtApiAuthProvider.getJwt()` blindly POSTs it to better-auth's `/api/auth/token` (the JWT plugin endpoint), which only accepts session tokens / api keys — OAuth bearer tokens get 401.

But that exchange is unnecessary. The OAuth access token is *already a JWT*: signed by the same JWKS the relay verifies against (`apps/relay/src/auth.ts:13`), with `organizationIds` baked in via `customAccessTokenClaims` (`packages/auth/src/server.ts:228-251`). We can pass it straight through.

## What changes

### `packages/cli/scripts/build-dist.ts`
Add `buildPtyDaemon()` and copy the output next to `host-service.js`:

```ts
console.log("[build-dist] building pty-daemon bundle");
const ptyDaemonBundle = await buildPtyDaemon();
cpSync(ptyDaemonBundle, join(stagingRoot, "lib", "pty-daemon.js"));
```

### `packages/host-service/src/providers/auth/JwtAuthProvider/JwtAuthProvider.ts`
- If `sessionToken` is already a 3-segment JWT, return it as-is.
- For `sk_live_…` API keys, send as `x-api-key` (mirrors what the CLI's tRPC client already does in `packages/cli/src/lib/api-client.ts:24`). This was previously fixed on the unmerged `satya-patel/api-key-headless-cli` branch and never landed.
- Otherwise (session tokens) keep the old `Authorization: Bearer` exchange.

### Smoke-test guard rails
Both the GH Actions workflow (`.github/workflows/build-cli.yml`) and the local Docker harness (`packages/cli/scripts/build-dist-linux-docker.sh`) now `test -f` both `host-service.js` and `pty-daemon.js` after build. So pty-daemon ever going missing again will fail the build, not slip through.

## Verification
- ✅ `bun run build:dist --target=darwin-arm64` produces a tarball where `tar -tzf | grep pty-daemon` shows `./lib/pty-daemon.js` (29KB).
- ✅ `bash packages/cli/scripts/build-dist-linux-docker.sh linux-arm64` ran end-to-end inside the `oven/bun:1.3.11` container: bun install → npm rebuild → build-dist → smoke test all green, tarball produced (191MB), `pty-daemon.js` assertion passed, `require('better-sqlite3' | 'node-pty' | '@parcel/watcher' | 'libsql')` all OK against the bundled Node.
- ✅ Typecheck + lint clean on both packages.

JWT pass-through hasn't been live-tested against the relay since I can't easily replay the user's OAuth token on my machine — but the relay-side validation is `jwtVerify(token, jwks, { issuer, audience })` and the OAuth access token has `iss = NEXT_PUBLIC_API_URL`, `aud ⊇ NEXT_PUBLIC_API_URL`, and `organizationIds` claim, so it satisfies the relay's contract.

## Test plan
- [ ] CI green
- [ ] After merge, cut `cli-v0.2.5` (bump packages/cli/package.json + cli.config.ts + bun.lock; tag) — confirm the released tarball contains `lib/pty-daemon.js`
- [ ] On a fresh machine, `superset auth login` → `superset start` → host-service comes up, relay connects (no `Failed to mint JWT: 401`), pty-daemon spawns (no `script not found` error)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes supervisor startup and relay auth in the CLI by bundling `pty-daemon.js` and passing OAuth JWTs straight through to the relay.

- Bug Fixes
  - Build now compiles and ships `lib/pty-daemon.js` alongside `host-service.js`.
  - `JwtAuthProvider.getJwt()` returns 3-part JWTs as-is and sends `sk_live_…` keys via `x-api-key`; session tokens still use `Authorization: Bearer`.
  - CI and Docker smoke tests assert both files exist to prevent regressions.

<sup>Written for commit 136d5058069ced7bb95720c99f4bcbb53258c313. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * pty-daemon bundle now included in the CLI distribution
  * Improved JWT authentication to support both API key and bearer token methods

* **Chores**
  * Enhanced build process with validation checks to ensure all required artifacts are present

<!-- end of auto-generated comment: release notes by coderabbit.ai -->