### PR TITLE
release(cli): cut v0.2.5

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -677,7 +677,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
         "@clack/prompts": "^0.10.0",
         "@superset/cli-framework": "workspace:*",

--- a/packages/cli/cli.config.ts
+++ b/packages/cli/cli.config.ts
@@ -1,6 +1,6 @@
 import { boolean, defineConfig, string } from "@superset/cli-framework";
 
-const VERSION = "0.2.4";
+const VERSION = "0.2.5";
 
 export default defineConfig({
 	name: "superset",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "0.2.4",
+	"version": "0.2.5",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Summary
- Bumps `@superset/cli` to **v0.2.5** (`packages/cli/package.json`, `cli.config.ts`, `bun.lock`).
- Bundles the two cli-v0.2.4 regressions fixed in #4054:
  - **pty-daemon never bundled** — `build-dist.ts` only built `host-service.js`, host-service supervisor crashed at spawn with `script not found at /home/pty-daemon/...`.
  - **OAuth JWT 401 against relay** — `JwtApiAuthProvider` POSTed the OAuth access token to better-auth's `/api/auth/token`, which only accepts session tokens / api keys. The token is already a JWT signed by the relay's JWKS, so we now pass it through.

## Release plan
After this PR merges, push the `cli-v0.2.5` tag to fire `.github/workflows/release-cli.yml`.

## Test plan
- [ ] CI green on this PR
- [ ] After tag push, verify all three matrix targets land artifacts and the published release tarball contains both `lib/host-service.js` and `lib/pty-daemon.js`
- [ ] On a fresh machine: `superset auth login` → `superset start` should connect to the relay (no `Failed to mint JWT: 401`) and the supervisor should bootstrap (no `script not found` error)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `@superset/cli` v0.2.5 to fix two v0.2.4 regressions: the `pty-daemon` was not bundled, and OAuth logins failed with 401s when minting relay JWTs.

- **Bug Fixes**
  - Build and include `lib/pty-daemon.js` in the dist so the supervisor can spawn it (no more “script not found” on fresh installs).
  - Update `JwtApiAuthProvider` to pass through the OAuth access token (relay-signed JWT) instead of POSTing to `/api/auth/token`, preventing 401s during relay auth.

<sup>Written for commit 02808e58ffa794dad3e5ae56a7a045dd391ad2e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CLI version updated to 0.2.5

<!-- end of auto-generated comment: release notes by coderabbit.ai -->