### PR TITLE
[codex] Split terminal creation from websocket attach

### DIFF
--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -56,8 +56,12 @@ import { HOOK_PROTOCOL_VERSION } from "./terminal/env";
  * router (PR1, #3893). Older 0.6.x host-services don't expose either,
  * so adopting one in place would break new-project creation and the
  * agent-config settings UI. Force respawn on first launch.
+ *
+ * 0.8.0 — v2 terminal creation moved to `terminal.createSession`; the
+ * WebSocket route is attach-only by `terminalId`. Older host-services would
+ * reject the renderer's creation call and still expect socket-side startup.
  */
-const MIN_HOST_SERVICE_VERSION = "0.7.0";
+const MIN_HOST_SERVICE_VERSION = "0.8.0";
 
 export type HostServiceStatus = "starting" | "running" | "stopped";
 

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -166,20 +166,15 @@ class TerminalRuntimeRegistryImpl {
 
 	/**
 	 * Open (or re-use) the WebSocket transport for this terminal.
-	 * The WebSocket route can create the server session when the URL includes
-	 * workspaceId; initialCommand is sent as the first frame after open.
+	 * The server session must already exist; the WebSocket route only attaches
+	 * this xterm instance to the terminal id.
 	 *
 	 * Idempotent: no-op if already connected/connecting to the same URL.
 	 */
-	connect(
-		terminalId: string,
-		wsUrl: string,
-		instanceId = terminalId,
-		options: { initialCommand?: string } = {},
-	) {
+	connect(terminalId: string, wsUrl: string, instanceId = terminalId) {
 		const entry = this.getEntry(terminalId, instanceId);
 		if (!entry?.runtime) return;
-		connect(entry.transport, entry.runtime.terminal, wsUrl, options);
+		connect(entry.transport, entry.runtime.terminal, wsUrl);
 	}
 
 	/**
@@ -337,6 +332,14 @@ class TerminalRuntimeRegistryImpl {
 
 	getTerminal(terminalId: string, instanceId?: string) {
 		return this.getEntry(terminalId, instanceId)?.runtime?.terminal ?? null;
+	}
+
+	getDimensions(
+		terminalId: string,
+		instanceId?: string,
+	): { cols: number; rows: number } | null {
+		const terminal = this.getTerminal(terminalId, instanceId);
+		return terminal ? { cols: terminal.cols, rows: terminal.rows } : null;
 	}
 
 	getSearchAddon(terminalId: string, instanceId?: string): SearchAddon | null {

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Terminal as XTerm } from "@xterm/xterm";
+import { connect, createTransport } from "./terminal-ws-transport";
+
+type Listener = (event: {
+	data?: unknown;
+	code?: number;
+	reason?: string;
+}) => void;
+
+class MockWebSocket {
+	static readonly CONNECTING = 0;
+	static readonly OPEN = 1;
+	static readonly CLOSING = 2;
+	static readonly CLOSED = 3;
+
+	static instances: MockWebSocket[] = [];
+
+	readonly url: string;
+	readyState = MockWebSocket.CONNECTING;
+	binaryType: BinaryType = "blob";
+	sent: string[] = [];
+	private readonly listeners = new Map<string, Set<Listener>>();
+
+	constructor(url: string) {
+		this.url = url;
+		MockWebSocket.instances.push(this);
+	}
+
+	addEventListener(type: string, listener: Listener) {
+		let listeners = this.listeners.get(type);
+		if (!listeners) {
+			listeners = new Set();
+			this.listeners.set(type, listeners);
+		}
+		listeners.add(listener);
+	}
+
+	send(data: string) {
+		this.sent.push(data);
+	}
+
+	close() {
+		this.readyState = MockWebSocket.CLOSED;
+		this.dispatch("close", { code: 1000, reason: "" });
+	}
+
+	open() {
+		this.readyState = MockWebSocket.OPEN;
+		this.dispatch("open", {});
+	}
+
+	message(data: unknown) {
+		this.dispatch("message", { data });
+	}
+
+	private dispatch(type: string, event: Parameters<Listener>[0]) {
+		for (const listener of this.listeners.get(type) ?? []) {
+			listener(event);
+		}
+	}
+}
+
+const originalWebSocket = globalThis.WebSocket;
+
+function createMockTerminal(
+	cols = 101,
+	rows = 27,
+): XTerm & { emitData(data: string): void } {
+	let onDataListener: ((data: string) => void) | null = null;
+	return {
+		cols,
+		rows,
+		onData: (listener: (data: string) => void) => {
+			onDataListener = listener;
+			return { dispose() {} };
+		},
+		emitData(data: string) {
+			onDataListener?.(data);
+		},
+		write() {},
+		writeln() {},
+	} as unknown as XTerm & { emitData(data: string): void };
+}
+
+beforeEach(() => {
+	MockWebSocket.instances = [];
+	globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+});
+
+afterEach(() => {
+	globalThis.WebSocket = originalWebSocket;
+});
+
+describe("terminal-ws-transport", () => {
+	test("waits for server attach before sending resize or input", () => {
+		const transport = createTransport();
+		const terminal = createMockTerminal();
+
+		connect(transport, terminal, "ws://host/terminal/t1");
+
+		const socket = MockWebSocket.instances[0];
+		expect(socket).toBeDefined();
+		if (!socket) throw new Error("expected websocket instance");
+		const sentMessages = () =>
+			socket.sent.map((payload) => JSON.parse(payload) as unknown);
+
+		socket.open();
+		expect(transport.connectionState).toBe("connecting");
+		expect(sentMessages()).toEqual([]);
+
+		terminal.emitData("a");
+		expect(sentMessages()).toEqual([]);
+
+		socket.message(JSON.stringify({ type: "attached", terminalId: "t1" }));
+		expect(transport.connectionState).toBe("open");
+		expect(sentMessages()).toEqual([{ type: "resize", cols: 101, rows: 27 }]);
+
+		terminal.emitData("b");
+		expect(sentMessages()).toEqual([
+			{ type: "resize", cols: 101, rows: 27 },
+			{ type: "input", data: "b" },
+		]);
+	});
+});

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -17,6 +17,7 @@ export interface TerminalLogEntry {
 // partial sequences internally). Control messages (title/error/exit) stay
 // JSON.
 type TerminalServerMessage =
+	| { type: "attached"; terminalId: string }
 	| { type: "error"; message: string }
 	| { type: "exit"; exitCode: number; signal: number }
 	| { type: "title"; title: string | null };
@@ -197,7 +198,6 @@ export function connect(
 	transport: TerminalTransport,
 	terminal: XTerm,
 	wsUrl: string,
-	options: { initialCommand?: string } = {},
 ) {
 	// Idempotent: skip if already connected/connecting to the same endpoint.
 	const isActive =
@@ -228,16 +228,6 @@ export function connect(
 	socket.addEventListener("open", () => {
 		if (transport.socket !== socket) return;
 		transport._reconnectAttempt = 0;
-		setConnectionState(transport, "open");
-		sendResize(transport, terminal.cols, terminal.rows);
-		if (options.initialCommand) {
-			socket.send(
-				JSON.stringify({
-					type: "initialCommand",
-					data: options.initialCommand,
-				}),
-			);
-		}
 	});
 
 	socket.addEventListener("message", (event) => {
@@ -262,6 +252,12 @@ export function connect(
 
 		if (message.type === "title") {
 			setTerminalTitle(transport, message.title);
+			return;
+		}
+
+		if (message.type === "attached") {
+			setConnectionState(transport, "open");
+			sendResize(transport, terminal.cols, terminal.rows);
 			return;
 		}
 
@@ -310,6 +306,7 @@ export function connect(
 	transport.onDataDisposable?.dispose();
 	transport.onDataDisposable = terminal.onData((data) => {
 		if (socket.readyState !== WebSocket.OPEN) return;
+		if (transport.connectionState !== "open") return;
 		socket.send(JSON.stringify({ type: "input", data }));
 	});
 }
@@ -336,12 +333,14 @@ export function sendResize(
 ) {
 	if (!transport.socket || transport.socket.readyState !== WebSocket.OPEN)
 		return;
+	if (transport.connectionState !== "open") return;
 	transport.socket.send(JSON.stringify({ type: "resize", cols, rows }));
 }
 
 export function sendInput(transport: TerminalTransport, data: string) {
 	if (!transport.socket || transport.socket.readyState !== WebSocket.OPEN)
 		return;
+	if (transport.connectionState !== "open") return;
 	transport.socket.send(JSON.stringify({ type: "input", data }));
 }
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -167,14 +167,19 @@ export function TerminalPane({
 
 		void (async () => {
 			try {
-				await trpcClientRef.current.terminal.createSession.mutate({
-					terminalId,
-					workspaceId: workspaceIdRef.current,
-					themeType: initialThemeTypeRef.current,
-					initialCommand: pendingInitialCommand,
-					cols: dimensions?.cols,
-					rows: dimensions?.rows,
-				});
+				const { initialCommandAccepted } =
+					await trpcClientRef.current.terminal.createSession.mutate({
+						terminalId,
+						workspaceId: workspaceIdRef.current,
+						themeType: initialThemeTypeRef.current,
+						initialCommand: pendingInitialCommand,
+						cols: dimensions?.cols,
+						rows: dimensions?.rows,
+					});
+				if (cancelled) return;
+				if (pendingInitialCommand && initialCommandAccepted) {
+					markInitialCommandAccepted();
+				}
 			} catch (error) {
 				if (cancelled) return;
 				const message =
@@ -188,7 +193,6 @@ export function TerminalPane({
 			}
 
 			if (cancelled) return;
-			if (pendingInitialCommand) markInitialCommandAccepted();
 			terminalRuntimeRegistry.connect(
 				terminalId,
 				websocketUrlRef.current,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -1,6 +1,6 @@
 import type { RendererContext } from "@superset/panes";
 import { cn } from "@superset/ui/utils";
-import { workspaceTrpc } from "@superset/workspace-client";
+import { useWorkspaceClient, workspaceTrpc } from "@superset/workspace-client";
 import "@xterm/xterm/css/xterm.css";
 import {
 	useCallback,
@@ -63,6 +63,10 @@ export function TerminalPane({
 	const { hint, showHint } = useLinkClickHint();
 	const openInExternalEditor = useOpenInExternalEditor(workspaceId);
 	const paneData = ctx.pane.data as TerminalPaneData;
+	const paneDataRef = useRef(paneData);
+	paneDataRef.current = paneData;
+	const paneActionsRef = useRef(ctx.actions);
+	paneActionsRef.current = ctx.actions;
 	const { terminalId } = paneData;
 	const initialCommandRef = useRef(paneData.initialCommand);
 	const terminalInstanceId = ctx.pane.id;
@@ -80,17 +84,24 @@ export function TerminalPane({
 			activeThemeType: activeTheme?.type,
 		}),
 	);
+	const { trpcClient } = useWorkspaceClient();
+	const trpcClientRef = useRef(trpcClient);
+	trpcClientRef.current = trpcClient;
 
-	// Include workspaceId/themeType so the WebSocket route can create the
-	// session on open. Terminal attach should not wait behind workspace tRPC.
-	const websocketUrl = useWorkspaceWsUrl(`/terminal/${terminalId}`, {
-		workspaceId,
-		themeType: initialThemeTypeRef.current,
-	});
+	const websocketUrl = useWorkspaceWsUrl(`/terminal/${terminalId}`);
 	const websocketUrlRef = useRef(websocketUrl);
 	websocketUrlRef.current = websocketUrl;
 	const workspaceIdRef = useRef(workspaceId);
 	workspaceIdRef.current = workspaceId;
+	const markInitialCommandAccepted = useCallback(() => {
+		initialCommandRef.current = undefined;
+		const currentPaneData = paneDataRef.current;
+		if (currentPaneData.initialCommand === undefined) return;
+		paneActionsRef.current.updateData({
+			...currentPaneData,
+			initialCommand: undefined,
+		} as PaneViewerData);
+	}, []);
 
 	const workspaceTrpcUtils = workspaceTrpc.useUtils();
 	const invalidateTerminalSessionsRef = useRef(
@@ -127,15 +138,17 @@ export function TerminalPane({
 	//      is visible immediately, even on cold start. For a warm return
 	//      (workspace switch) this reparents the wrapper from the parking
 	//      container back into the live tree, preserving the buffer.
-	//   2. connect() opens the WebSocket immediately. The host-service terminal
-	//      route creates the session from the URL workspaceId if needed, avoiding
-	//      tRPC head-of-line blocking during workspace switches.
+	//   2. createSession() starts or adopts the server terminal using the
+	//      measured dimensions and optional initial command.
+	//   3. connect() attaches the WebSocket to that terminalId. The socket is
+	//      transport only; it does not carry creation-time intent.
 	// Deps narrowed to the terminal identity so provider key remount churn
-	// (workspaceId briefly flipping while pane data catches up) doesn't re-run
-	// this effect. workspaceId / websocketUrl are read through refs.
+	// (workspaceId/client briefly flipping while pane data catches up) doesn't
+	// re-run this effect. Mutable inputs are read through refs.
 	useEffect(() => {
 		const container = containerRef.current;
 		if (!container) return;
+		let cancelled = false;
 
 		terminalRuntimeRegistry.mount(
 			terminalId,
@@ -144,29 +157,50 @@ export function TerminalPane({
 			terminalInstanceId,
 		);
 
-		terminalRuntimeRegistry.connect(
+		const dimensions = terminalRuntimeRegistry.getDimensions(
 			terminalId,
-			websocketUrlRef.current,
 			terminalInstanceId,
-			{ initialCommand: initialCommandRef.current },
 		);
+		const pendingInitialCommand = initialCommandRef.current?.trim()
+			? initialCommandRef.current
+			: undefined;
+
+		void (async () => {
+			try {
+				await trpcClientRef.current.terminal.createSession.mutate({
+					terminalId,
+					workspaceId: workspaceIdRef.current,
+					themeType: initialThemeTypeRef.current,
+					initialCommand: pendingInitialCommand,
+					cols: dimensions?.cols,
+					rows: dimensions?.rows,
+				});
+			} catch (error) {
+				if (cancelled) return;
+				const message =
+					error instanceof Error
+						? error.message
+						: "Failed to create terminal session";
+				terminalRuntimeRegistry
+					.getTerminal(terminalId, terminalInstanceId)
+					?.writeln(`\r\n[terminal] ${message}`);
+				return;
+			}
+
+			if (cancelled) return;
+			if (pendingInitialCommand) markInitialCommandAccepted();
+			terminalRuntimeRegistry.connect(
+				terminalId,
+				websocketUrlRef.current,
+				terminalInstanceId,
+			);
+		})();
 
 		return () => {
+			cancelled = true;
 			terminalRuntimeRegistry.detach(terminalId, terminalInstanceId);
 		};
-	}, [terminalId, terminalInstanceId]);
-
-	useEffect(() => {
-		if (connectionState !== "open" || !initialCommandRef.current) return;
-
-		initialCommandRef.current = undefined;
-		if (paneData.initialCommand === undefined) return;
-
-		ctx.actions.updateData({
-			...paneData,
-			initialCommand: undefined,
-		} as PaneViewerData);
-	}, [connectionState, ctx.actions, paneData]);
+	}, [terminalId, terminalInstanceId, markInitialCommandAccepted]);
 
 	const lastInvalidatedOpenSessionRef = useRef<string | null>(null);
 	useEffect(() => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -167,19 +167,16 @@ export function TerminalPane({
 
 		void (async () => {
 			try {
-				const { initialCommandAccepted } =
-					await trpcClientRef.current.terminal.createSession.mutate({
-						terminalId,
-						workspaceId: workspaceIdRef.current,
-						themeType: initialThemeTypeRef.current,
-						initialCommand: pendingInitialCommand,
-						cols: dimensions?.cols,
-						rows: dimensions?.rows,
-					});
+				await trpcClientRef.current.terminal.createSession.mutate({
+					terminalId,
+					workspaceId: workspaceIdRef.current,
+					themeType: initialThemeTypeRef.current,
+					initialCommand: pendingInitialCommand,
+					cols: dimensions?.cols,
+					rows: dimensions?.rows,
+				});
 				if (cancelled) return;
-				if (pendingInitialCommand && initialCommandAccepted) {
-					markInitialCommandAccepted();
-				}
+				if (pendingInitialCommand) markInitialCommandAccepted();
 			} catch (error) {
 				if (cancelled) return;
 				const message =

--- a/packages/host-service/src/terminal/terminal.adoption.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.adoption.node-test.ts
@@ -24,7 +24,10 @@ import { Server } from "@superset/pty-daemon";
 import { eq } from "drizzle-orm";
 import { createDb, type HostDb } from "../db/index.ts";
 import { projects, workspaces } from "../db/schema.ts";
-import { disposeDaemonClient } from "./daemon-client-singleton.ts";
+import {
+	disposeDaemonClient,
+	getDaemonClient,
+} from "./daemon-client-singleton.ts";
 import { initTerminalBaseEnv } from "./env.ts";
 import {
 	__resetSessionsForTesting,
@@ -93,6 +96,29 @@ after(async () => {
 });
 
 describe("createTerminalSessionInternal — host-service restart adoption", () => {
+	test("fresh open uses requested initial dimensions", async () => {
+		const terminalId = `e2e-dims-${randomUUID().slice(0, 8)}`;
+		const result = await createTerminalSessionInternal({
+			terminalId,
+			workspaceId,
+			db,
+			listed: true,
+			cols: 101,
+			rows: 27,
+		});
+		assert.ok(!("error" in result));
+		if ("error" in result) return;
+
+		const daemon = await getDaemonClient();
+		const daemonSession = (await daemon.list()).find(
+			(s) => s.id === terminalId,
+		);
+		assert.equal(daemonSession?.cols, 101);
+		assert.equal(daemonSession?.rows, 27);
+
+		disposeSession(terminalId, db);
+	});
+
 	test("fresh open spawns a shell via the daemon", async () => {
 		const terminalId = `e2e-fresh-${randomUUID().slice(0, 8)}`;
 		const result = await createTerminalSessionInternal({

--- a/packages/host-service/src/terminal/terminal.adoption.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.adoption.node-test.ts
@@ -113,8 +113,12 @@ describe("createTerminalSessionInternal — host-service restart adoption", () =
 		const daemonSession = (await daemon.list()).find(
 			(s) => s.id === terminalId,
 		);
-		assert.equal(daemonSession?.cols, 101);
-		assert.equal(daemonSession?.rows, 27);
+		assert.ok(
+			daemonSession,
+			`expected terminalId "${terminalId}" in daemon.list()`,
+		);
+		assert.equal(daemonSession.cols, 101);
+		assert.equal(daemonSession.rows, 27);
 
 		disposeSession(terminalId, db);
 	});

--- a/packages/host-service/src/terminal/terminal.adoption.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.adoption.node-test.ts
@@ -23,7 +23,7 @@ import { fileURLToPath } from "node:url";
 import { Server } from "@superset/pty-daemon";
 import { eq } from "drizzle-orm";
 import { createDb, type HostDb } from "../db/index.ts";
-import { projects, workspaces } from "../db/schema.ts";
+import { projects, terminalSessions, workspaces } from "../db/schema.ts";
 import {
 	disposeDaemonClient,
 	getDaemonClient,
@@ -117,6 +117,66 @@ describe("createTerminalSessionInternal — host-service restart adoption", () =
 		assert.equal(daemonSession?.rows, 27);
 
 		disposeSession(terminalId, db);
+	});
+
+	test("existing session accepts a not-yet-queued initialCommand", async () => {
+		const terminalId = `e2e-late-initcmd-${randomUUID().slice(0, 8)}`;
+		const sentinelFile = path.join(TEST_HOME, `late-initcmd-${terminalId}`);
+
+		const first = await createTerminalSessionInternal({
+			terminalId,
+			workspaceId,
+			db,
+			listed: true,
+		});
+		assert.ok(!("error" in first));
+		if ("error" in first) return;
+		assert.equal(first.initialCommandQueued, false);
+
+		const second = await createTerminalSessionInternal({
+			terminalId,
+			workspaceId,
+			db,
+			listed: true,
+			initialCommand: `echo ok > ${sentinelFile}`,
+		});
+		assert.ok(!("error" in second));
+		if ("error" in second) return;
+		assert.equal(second.initialCommandQueued, true);
+		await waitFor(() => fs.existsSync(sentinelFile), 5000);
+
+		disposeSession(terminalId, db);
+	});
+
+	test("adoptOnly refuses to spawn when daemon does not own the session", async () => {
+		const terminalId = `e2e-adopt-only-${randomUUID().slice(0, 8)}`;
+		db.insert(terminalSessions)
+			.values({
+				id: terminalId,
+				originWorkspaceId: workspaceId,
+				status: "active",
+				createdAt: Date.now(),
+			})
+			.run();
+
+		const result = await createTerminalSessionInternal({
+			terminalId,
+			workspaceId,
+			db,
+			listed: true,
+			adoptOnly: true,
+		});
+		assert.ok("error" in result);
+
+		const daemon = await getDaemonClient();
+		const daemonSession = (await daemon.list()).find(
+			(s) => s.id === terminalId,
+		);
+		assert.equal(daemonSession, undefined);
+
+		db.delete(terminalSessions)
+			.where(eq(terminalSessions.id, terminalId))
+			.run();
 	});
 
 	test("fresh open spawns a shell via the daemon", async () => {

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -1007,7 +1007,15 @@ export function registerWorkspaceTerminalRoute({
 						}
 						if (ws.readyState !== SOCKET_OPEN) return;
 						attachSocketToSession(session, ws);
-					})();
+					})().catch((error) => {
+						console.error("[terminal] unexpected error during attach", error);
+						if (ws.readyState !== SOCKET_OPEN) return;
+						sendMessage(ws, {
+							type: "error",
+							message: "Internal terminal attach error",
+						});
+						ws.close(1011, "Internal terminal attach error");
+					});
 				},
 
 				onMessage: (event, ws) => {

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -142,7 +142,6 @@ function getHostAgentHookUrl(): string {
 
 type TerminalClientMessage =
 	| { type: "input"; data: string }
-	| { type: "initialCommand"; data: string }
 	| { type: "resize"; cols: number; rows: number }
 	| { type: "dispose" };
 
@@ -152,6 +151,7 @@ type TerminalClientMessage =
 // on attach) is a binary frame too; the renderer doesn't distinguish it
 // from live data.
 type TerminalServerMessage =
+	| { type: "attached"; terminalId: string }
 	| { type: "error"; message: string }
 	| { type: "exit"; exitCode: number; signal: number }
 	| { type: "title"; title: string | null };
@@ -160,6 +160,10 @@ const MAX_BUFFER_BYTES = 64 * 1024;
 const SOCKET_OPEN = 1;
 const SOCKET_CLOSING = 2;
 const SOCKET_CLOSED = 3;
+const DEFAULT_TERMINAL_COLS = 120;
+const DEFAULT_TERMINAL_ROWS = 32;
+const MIN_TERMINAL_COLS = 20;
+const MIN_TERMINAL_ROWS = 5;
 
 // `<ArrayBuffer>` narrowing matches hono/ws's WSContext.send signature.
 type TerminalSocket = {
@@ -383,6 +387,15 @@ function bufferOutput(session: TerminalSession, data: Uint8Array) {
 	}
 }
 
+function normalizeTerminalDimension(
+	value: number | null | undefined,
+	min: number,
+	fallback: number,
+): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+	return Math.max(min, Math.floor(value));
+}
+
 // All bytes we send here are ArrayBuffer-backed at runtime (node Buffers,
 // scanner outputs); the cast just narrows the type-system's loose default.
 function asArrayBufferBytes(bytes: Uint8Array): Uint8Array<ArrayBuffer> {
@@ -557,6 +570,8 @@ interface CreateTerminalSessionOptions {
 	initialCommand?: string;
 	/** Hidden sessions are process-internal and should not appear in user pickers. */
 	listed?: boolean;
+	cols?: number;
+	rows?: number;
 	/**
 	 * Replay the daemon's ring buffer on subscribe. Default true. Pass false
 	 * when the renderer's xterm already has the scrollback — replaying then
@@ -574,6 +589,8 @@ export async function createTerminalSessionInternal({
 	eventBus,
 	initialCommand,
 	listed = true,
+	cols: requestedCols,
+	rows: requestedRows,
 	replayOnAdoption = true,
 }: CreateTerminalSessionOptions): Promise<TerminalSession | { error: string }> {
 	const existing = sessions.get(terminalId);
@@ -600,6 +617,16 @@ export async function createTerminalSessionInternal({
 	}
 
 	const cwd = workspace.worktreePath;
+	const cols = normalizeTerminalDimension(
+		requestedCols,
+		MIN_TERMINAL_COLS,
+		DEFAULT_TERMINAL_COLS,
+	);
+	const rows = normalizeTerminalDimension(
+		requestedRows,
+		MIN_TERMINAL_ROWS,
+		DEFAULT_TERMINAL_ROWS,
+	);
 
 	// Use the preserved shell snapshot — never live process.env
 	const baseEnv = getTerminalBaseEnv();
@@ -634,8 +661,8 @@ export async function createTerminalSessionInternal({
 				shell,
 				argv: shellArgs,
 				cwd,
-				cols: 120,
-				rows: 32,
+				cols,
+				rows,
 				env: ptyEnv,
 			});
 		} catch (err) {
@@ -824,6 +851,9 @@ export function registerWorkspaceTerminalRoute({
 			terminalId: string;
 			workspaceId: string;
 			themeType?: string;
+			initialCommand?: string;
+			cols?: number;
+			rows?: number;
 		}>();
 
 		if (!body.terminalId || !body.workspaceId) {
@@ -836,6 +866,9 @@ export function registerWorkspaceTerminalRoute({
 			themeType: parseThemeType(body.themeType),
 			db,
 			eventBus,
+			initialCommand: body.initialCommand,
+			cols: body.cols,
+			rows: body.rows,
 		});
 
 		if ("error" in result) {
@@ -873,6 +906,69 @@ export function registerWorkspaceTerminalRoute({
 		"/terminal/:terminalId",
 		upgradeWebSocket((c) => {
 			const terminalId = c.req.param("terminalId") ?? "";
+			const attachSocketToSession = (
+				session: TerminalSession,
+				ws: TerminalSocket,
+			): boolean => {
+				if (session.sockets.has(ws)) return false;
+				session.sockets.add(ws);
+				sendMessage(ws, { type: "attached", terminalId });
+
+				db.update(terminalSessions)
+					.set({ lastAttachedAt: Date.now() })
+					.where(eq(terminalSessions.id, terminalId))
+					.run();
+
+				sendMessage(ws, { type: "title", title: session.title });
+				replayBuffer(session, ws);
+				if (session.exited) {
+					sendMessage(ws, {
+						type: "exit",
+						exitCode: session.exitCode,
+						signal: session.exitSignal,
+					});
+				}
+				return true;
+			};
+			const resolveSessionForAttach = async (): Promise<
+				TerminalSession | { error: string }
+			> => {
+				const existing = sessions.get(terminalId);
+				if (existing) return existing;
+
+				const record = db.query.terminalSessions
+					.findFirst({ where: eq(terminalSessions.id, terminalId) })
+					.sync();
+				if (!record) {
+					return {
+						error: `Terminal session "${terminalId}" not found; create it before connecting.`,
+					};
+				}
+				if (record.status === "disposed") {
+					return { error: `Terminal session "${terminalId}" is disposed.` };
+				}
+				if (record.status === "exited") {
+					return { error: `Terminal session "${terminalId}" has exited.` };
+				}
+				if (!record.originWorkspaceId) {
+					return {
+						error: `Terminal session "${terminalId}" is missing a workspace.`,
+					};
+				}
+
+				// Attach is by terminal id only. If host-service lost in-memory
+				// state during a restart, recover from the server-owned session row
+				// and let createTerminalSessionInternal adopt the daemon PTY when it
+				// still exists.
+				return createTerminalSessionInternal({
+					terminalId,
+					workspaceId: record.originWorkspaceId,
+					db,
+					eventBus,
+					// Renderer passes `?replay=0` on reconnect; see replayOnAdoption.
+					replayOnAdoption: c.req.query("replay") !== "0",
+				});
+			};
 
 			return {
 				onOpen: (_event, ws) => {
@@ -881,78 +977,19 @@ export function registerWorkspaceTerminalRoute({
 						return;
 					}
 
-					const existing = sessions.get(terminalId);
-					if (!existing) {
-						// V2 callers can create a session by opening the WebSocket with
-						// workspaceId; this keeps terminal attach out of tRPC request queues.
-						const workspaceId = c.req.query("workspaceId") ?? null;
-						if (!workspaceId) {
-							sendMessage(ws, {
-								type: "error",
-								message: `Terminal session "${terminalId}" not found; open with workspaceId or create it before connecting.`,
-							});
-							ws.close(1011, "Terminal session not found");
+					void (async () => {
+						const session = await resolveSessionForAttach();
+						if ("error" in session) {
+							sendMessage(ws, { type: "error", message: session.error });
+							ws.close(1011, session.error);
 							return;
 						}
-
-						const themeType = parseThemeType(c.req.query("themeType"));
-						// Renderer passes `?replay=0` on reconnect; see replayOnAdoption.
-						const replayOnAdoption = c.req.query("replay") !== "0";
-						// Daemon open is async; fire-and-forget while keeping the WS alive.
-						// On success: register the socket; on failure: surface and close.
-						void (async () => {
-							const result = await createTerminalSessionInternal({
-								terminalId,
-								workspaceId,
-								themeType,
-								db,
-								eventBus,
-								replayOnAdoption,
-							});
-
-							if ("error" in result) {
-								sendMessage(ws, { type: "error", message: result.error });
-								ws.close(1011, result.error);
-								return;
-							}
-
-							// WS may have closed during the daemon-open await; don't
-							// register a dead socket into the session's broadcast set.
-							if (ws.readyState !== SOCKET_OPEN) return;
-
-							result.sockets.add(ws);
-							sendMessage(ws, { type: "title", title: result.title });
-
-							db.update(terminalSessions)
-								.set({ lastAttachedAt: Date.now() })
-								.where(eq(terminalSessions.id, terminalId))
-								.run();
-						})();
-						return;
-					}
-
-					existing.sockets.add(ws);
-
-					db.update(terminalSessions)
-						.set({ lastAttachedAt: Date.now() })
-						.where(eq(terminalSessions.id, terminalId))
-						.run();
-
-					sendMessage(ws, { type: "title", title: existing.title });
-					replayBuffer(existing, ws);
-					if (existing.exited) {
-						sendMessage(ws, {
-							type: "exit",
-							exitCode: existing.exitCode,
-							signal: existing.exitSignal,
-						});
-					}
+						if (ws.readyState !== SOCKET_OPEN) return;
+						attachSocketToSession(session, ws);
+					})();
 				},
 
 				onMessage: (event, ws) => {
-					const session = sessions.get(terminalId ?? "");
-					if (!session || !session.sockets.has(ws)) return;
-
 					let message: TerminalClientMessage;
 					try {
 						message = JSON.parse(String(event.data)) as TerminalClientMessage;
@@ -963,6 +1000,9 @@ export function registerWorkspaceTerminalRoute({
 						});
 						return;
 					}
+
+					const session = sessions.get(terminalId ?? "");
+					if (!session || !session.sockets.has(ws)) return;
 
 					if (message.type === "dispose") {
 						disposeSession(terminalId ?? "", db);
@@ -976,14 +1016,17 @@ export function registerWorkspaceTerminalRoute({
 						return;
 					}
 
-					if (message.type === "initialCommand") {
-						queueInitialCommand(session, message.data);
-						return;
-					}
-
 					if (message.type === "resize") {
-						const cols = Math.max(20, Math.floor(message.cols));
-						const rows = Math.max(5, Math.floor(message.rows));
+						const cols = normalizeTerminalDimension(
+							message.cols,
+							MIN_TERMINAL_COLS,
+							DEFAULT_TERMINAL_COLS,
+						);
+						const rows = normalizeTerminalDimension(
+							message.rows,
+							MIN_TERMINAL_ROWS,
+							DEFAULT_TERMINAL_ROWS,
+						);
 						session.pty.resize(cols, rows);
 					}
 				},

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -470,8 +470,9 @@ function resolveShellReady(
 function queueInitialCommand(
 	session: TerminalSession,
 	initialCommand: string,
-): void {
-	if (session.initialCommandQueued) return;
+): boolean {
+	if (session.initialCommandQueued) return true;
+	if (session.exited) return false;
 	session.initialCommandQueued = true;
 	const cmd = initialCommand.endsWith("\n")
 		? initialCommand
@@ -481,6 +482,7 @@ function queueInitialCommand(
 			session.pty.write(cmd);
 		}
 	});
+	return true;
 }
 
 /**
@@ -572,6 +574,8 @@ interface CreateTerminalSessionOptions {
 	listed?: boolean;
 	cols?: number;
 	rows?: number;
+	/** Only recover an already-live daemon session; never spawn a new PTY. */
+	adoptOnly?: boolean;
 	/**
 	 * Replay the daemon's ring buffer on subscribe. Default true. Pass false
 	 * when the renderer's xterm already has the scrollback — replaying then
@@ -591,11 +595,13 @@ export async function createTerminalSessionInternal({
 	listed = true,
 	cols: requestedCols,
 	rows: requestedRows,
+	adoptOnly = false,
 	replayOnAdoption = true,
 }: CreateTerminalSessionOptions): Promise<TerminalSession | { error: string }> {
 	const existing = sessions.get(terminalId);
 	if (existing) {
 		if (listed) existing.listed = true;
+		if (initialCommand) queueInitialCommand(existing, initialCommand);
 		return existing;
 	}
 
@@ -656,6 +662,16 @@ export async function createTerminalSessionInternal({
 	let isAdopted = false;
 	try {
 		daemon = await getDaemonClient();
+		if (adoptOnly) {
+			const found = (await daemon.list()).find(
+				(s) => s.id === terminalId && s.alive,
+			);
+			if (!found) {
+				return {
+					error: `Terminal session "${terminalId}" is not active; create it before connecting.`,
+				};
+			}
+		}
 		try {
 			openResult = await daemon.open(terminalId, {
 				shell,
@@ -665,6 +681,14 @@ export async function createTerminalSessionInternal({
 				rows,
 				env: ptyEnv,
 			});
+			if (adoptOnly) {
+				await daemon.close(terminalId).catch(() => {
+					// best-effort cleanup for a lost race where open created a PTY
+				});
+				return {
+					error: `Terminal session "${terminalId}" is not active; create it before connecting.`,
+				};
+			}
 		} catch (err) {
 			// After host-service restart the daemon may already own this
 			// session. Adopt it instead of looping forever on "session already
@@ -965,6 +989,7 @@ export function registerWorkspaceTerminalRoute({
 					workspaceId: record.originWorkspaceId,
 					db,
 					eventBus,
+					adoptOnly: true,
 					// Renderer passes `?replay=0` on reconnect; see replayOnAdoption.
 					replayOnAdoption: c.req.query("replay") !== "0",
 				});

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -470,9 +470,8 @@ function resolveShellReady(
 function queueInitialCommand(
 	session: TerminalSession,
 	initialCommand: string,
-): boolean {
-	if (session.initialCommandQueued) return true;
-	if (session.exited) return false;
+): void {
+	if (session.initialCommandQueued || session.exited) return;
 	session.initialCommandQueued = true;
 	const cmd = initialCommand.endsWith("\n")
 		? initialCommand
@@ -482,7 +481,6 @@ function queueInitialCommand(
 			session.pty.write(cmd);
 		}
 	});
-	return true;
 }
 
 /**

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -669,42 +669,40 @@ export async function createTerminalSessionInternal({
 					error: `Terminal session "${terminalId}" is not active; create it before connecting.`,
 				};
 			}
-		}
-		try {
-			openResult = await daemon.open(terminalId, {
-				shell,
-				argv: shellArgs,
-				cwd,
-				cols,
-				rows,
-				env: ptyEnv,
-			});
-			if (adoptOnly) {
-				await daemon.close(terminalId).catch(() => {
-					// best-effort cleanup for a lost race where open created a PTY
+			openResult = { pid: found.pid };
+			isAdopted = true;
+			console.log(
+				`[terminal] adopted existing daemon session ${terminalId} pid=${found.pid}`,
+			);
+		} else {
+			try {
+				openResult = await daemon.open(terminalId, {
+					shell,
+					argv: shellArgs,
+					cwd,
+					cols,
+					rows,
+					env: ptyEnv,
 				});
-				return {
-					error: `Terminal session "${terminalId}" is not active; create it before connecting.`,
-				};
-			}
-		} catch (err) {
-			// After host-service restart the daemon may already own this
-			// session. Adopt it instead of looping forever on "session already
-			// exists". The daemon kept the buffer + the live shell; we just
-			// need to stitch up a TerminalSession record on this side and
-			// subscribe-with-replay below.
-			const msg = err instanceof Error ? err.message : String(err);
-			if (msg.includes("session already exists")) {
-				const list = await daemon.list();
-				const found = list.find((s) => s.id === terminalId && s.alive);
-				if (!found) throw err;
-				openResult = { pid: found.pid };
-				isAdopted = true;
-				console.log(
-					`[terminal] adopted existing daemon session ${terminalId} pid=${found.pid}`,
-				);
-			} else {
-				throw err;
+			} catch (err) {
+				// After host-service restart the daemon may already own this
+				// session. Adopt it instead of looping forever on "session already
+				// exists". The daemon kept the buffer + the live shell; we just
+				// need to stitch up a TerminalSession record on this side and
+				// subscribe-with-replay below.
+				const msg = err instanceof Error ? err.message : String(err);
+				if (msg.includes("session already exists")) {
+					const list = await daemon.list();
+					const found = list.find((s) => s.id === terminalId && s.alive);
+					if (!found) throw err;
+					openResult = { pid: found.pid };
+					isAdopted = true;
+					console.log(
+						`[terminal] adopted existing daemon session ${terminalId} pid=${found.pid}`,
+					);
+				} else {
+					throw err;
+				}
 			}
 		}
 	} catch (error) {

--- a/packages/host-service/src/trpc/router/host/host.ts
+++ b/packages/host-service/src/trpc/router/host/host.ts
@@ -22,7 +22,9 @@ import { protectedProcedure, router } from "../../index";
 // router (PR1, #3893). 0.6.x host-services don't expose either, so
 // adopting one in place would break new-project creation and the
 // agent-config settings UI.
-const HOST_SERVICE_VERSION = "0.7.0";
+// 0.8.0: terminal creation moved to `terminal.createSession`; WebSocket
+// `/terminal/:terminalId` is attach-only.
+const HOST_SERVICE_VERSION = "0.8.0";
 const ORGANIZATION_CACHE_TTL_MS = 60 * 60 * 1000;
 
 let cachedOrganization: {

--- a/packages/host-service/src/trpc/router/terminal/terminal.ts
+++ b/packages/host-service/src/trpc/router/terminal/terminal.ts
@@ -50,7 +50,9 @@ async function createTerminalSessionFromInput({
 	return {
 		terminalId: result.terminalId,
 		status: "active" as const,
-		initialCommandAccepted: Boolean(input.initialCommand),
+		initialCommandAccepted: Boolean(
+			input.initialCommand && result.initialCommandQueued,
+		),
 	};
 }
 

--- a/packages/host-service/src/trpc/router/terminal/terminal.ts
+++ b/packages/host-service/src/trpc/router/terminal/terminal.ts
@@ -17,8 +17,8 @@ const createSessionInputSchema = z.object({
 	terminalId: z.string().optional(),
 	initialCommand: z.string().trim().min(1).optional(),
 	themeType: z.string().optional(),
-	cols: z.number().optional(),
-	rows: z.number().optional(),
+	cols: z.number().int().positive().optional(),
+	rows: z.number().int().positive().optional(),
 });
 
 async function createTerminalSessionFromInput({

--- a/packages/host-service/src/trpc/router/terminal/terminal.ts
+++ b/packages/host-service/src/trpc/router/terminal/terminal.ts
@@ -50,9 +50,6 @@ async function createTerminalSessionFromInput({
 	return {
 		terminalId: result.terminalId,
 		status: "active" as const,
-		initialCommandAccepted: Boolean(
-			input.initialCommand && result.initialCommandQueued,
-		),
 	};
 }
 

--- a/packages/host-service/src/trpc/router/terminal/terminal.ts
+++ b/packages/host-service/src/trpc/router/terminal/terminal.ts
@@ -9,7 +9,50 @@ import {
 	listTerminalSessions,
 	parseThemeType,
 } from "../../../terminal/terminal";
+import type { HostServiceContext } from "../../../types";
 import { protectedProcedure, router } from "../../index";
+
+const createSessionInputSchema = z.object({
+	workspaceId: z.string(),
+	terminalId: z.string().optional(),
+	initialCommand: z.string().trim().min(1).optional(),
+	themeType: z.string().optional(),
+	cols: z.number().optional(),
+	rows: z.number().optional(),
+});
+
+async function createTerminalSessionFromInput({
+	ctx,
+	input,
+}: {
+	ctx: HostServiceContext;
+	input: z.infer<typeof createSessionInputSchema>;
+}) {
+	const terminalId = input.terminalId ?? crypto.randomUUID();
+	const result = await createTerminalSessionInternal({
+		terminalId,
+		workspaceId: input.workspaceId,
+		themeType: parseThemeType(input.themeType),
+		db: ctx.db,
+		eventBus: ctx.eventBus,
+		initialCommand: input.initialCommand,
+		cols: input.cols,
+		rows: input.rows,
+	});
+
+	if ("error" in result) {
+		throw new TRPCError({
+			code: "INTERNAL_SERVER_ERROR",
+			message: result.error,
+		});
+	}
+
+	return {
+		terminalId: result.terminalId,
+		status: "active" as const,
+		initialCommandAccepted: Boolean(input.initialCommand),
+	};
+}
 
 // Daemon control surface — sibling to the per-workspace terminal ops above.
 // Org-scoped (one daemon per host-service); org id comes from request ctx
@@ -48,35 +91,17 @@ const daemonRouter = router({
 });
 
 export const terminalRouter = router({
+	createSession: protectedProcedure
+		.input(createSessionInputSchema)
+		.mutation(createTerminalSessionFromInput),
+
 	launchSession: protectedProcedure
 		.input(
-			z.object({
-				workspaceId: z.string(),
-				terminalId: z.string().optional(),
-				initialCommand: z.string().min(1),
-				themeType: z.string().optional(),
+			createSessionInputSchema.extend({
+				initialCommand: z.string().trim().min(1),
 			}),
 		)
-		.mutation(async ({ ctx, input }) => {
-			const terminalId = input.terminalId ?? crypto.randomUUID();
-			const result = await createTerminalSessionInternal({
-				terminalId,
-				workspaceId: input.workspaceId,
-				themeType: parseThemeType(input.themeType),
-				db: ctx.db,
-				eventBus: ctx.eventBus,
-				initialCommand: input.initialCommand,
-			});
-
-			if ("error" in result) {
-				throw new TRPCError({
-					code: "INTERNAL_SERVER_ERROR",
-					message: result.error,
-				});
-			}
-
-			return { terminalId: result.terminalId, status: "active" as const };
-		}),
+		.mutation(createTerminalSessionFromInput),
 
 	listSessions: protectedProcedure
 		.input(


### PR DESCRIPTION
## Summary

- Add `terminal.createSession` as the server-owned creation path for v2 terminals.
- Pass measured terminal dimensions and optional initial command into PTY creation before WebSocket attach.
- Make `/terminal/:terminalId` attach-only, with host-service recovery/adoption from the persisted terminal session row.
- Gate renderer resize/input until the server sends an `attached` ack.
- Bump the host-service compatibility floor to `0.8.0` so stale services are not reused with the new protocol.

## Why

The old flow let the renderer open a terminal WebSocket and send sizing or initial-command intent during attach. On cold starts that could race ahead of server-side session creation, which made the PTY fall back to stale dimensions or occasionally swallow the initial command. Creation is now a distinct tRPC transaction, and the WebSocket only links an already-owned `terminalId` to the xterm transport.

## Validation

- `bun test apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts`
- `bun test packages/host-service/src/trpc/router/terminal/terminal.daemon.test.ts`
- `bun run typecheck`
- `bun run lint`

Note: `node --experimental-strip-types --test packages/host-service/src/terminal/terminal.adoption.node-test.ts` is still blocked in this local checkout by the existing `better-sqlite3` Node ABI mismatch: the installed module was compiled for `NODE_MODULE_VERSION 143`, while this Node requires `137`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split v2 terminal creation from WebSocket attach to remove PTY sizing and initial-command races and improve cold-start reliability. Sessions are created via tRPC with measured `cols`/`rows` and optional `initialCommand`, and the socket is attach-only with an `attached` ack before any resize or input.

- **Bug Fixes**
  - Added `terminal.createSession` to create/adopt sessions with measured `cols`/`rows`, optional `initialCommand`, and `themeType`; returns `{ terminalId, status }`.
  - WebSocket route `'/terminal/:terminalId'` is attach-only, sends `attached`, replays buffer, and errors if the session isn’t active; adopts from the DB with an `adoptOnly` path on restarts.
  - Renderer gates resize/input until `attached`; sends the first resize on attach and removes the socket-side initial-command path. `TerminalPane` calls `createSession` (using `getDimensions`) then `connect`, and clears the initial command after create.
  - Server normalizes terminal dimensions with sensible min/default bounds; added tests for attach gating, dimension passthrough, late initial-command queuing, and adopt-only refusal.

- **Migration**
  - Raise host-service compatibility floor to `0.8.0`.
  - Clients must call `terminal.createSession` before opening the WebSocket; the socket no longer creates sessions, accepts initial commands, or requires `workspaceId`/`themeType` in the URL.

<sup>Written for commit 6c4daff972f95529cf1c0004e54e3b5b067c6b97. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create terminal sessions via the workspace API (accepts initialCommand, cols/rows) and report active terminalId.
  * Runtime accessor to read current terminal dimensions.

* **Bug Fixes**
  * Terminal attach now waits for server "attached" before sending input/resize; an initial resize is sent on attach.
  * Initial command is queued/handled server-side (removed from socket protocol).
  * Sends/resizes gated on open connection; terminal sizing normalized with sane min/default bounds.

* **Tests**
  * Added transport tests validating attach sequencing, resize and input behavior.

* **Chores**
  * Minimum host-service version raised to 0.8.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->